### PR TITLE
feat(memory): measure proactive injection overlap per session (record-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   pass anchored to the voice-master audit. Previously these existed only as untracked files on the
   development install.
 
+- **Genesis now measures how often its automatic memory surfacing repeats itself within a session.**
+  Each prompt's surfaced memories are tracked per session, and the health snapshot's proactive-memory
+  section gains an `overlap_7d` rollup — the share of surfaced memories over the last 7 days that had
+  already been shown earlier in the same session. Measurement only: what gets surfaced is unchanged.
+  This data decides whether a planned improvement ships (skipping re-injection of memories already in
+  context to free slots for novel ones).
+
 - **Off-site backups now self-prune on a grandfather-father-son schedule instead of growing forever.**
   When you back up to an off-site target (NAS/SMB or a mounted path), each run now prunes old dated
   snapshots — keeping the last 7 daily, 4 weekly, and 6 monthly — so remote storage stays bounded. It

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -425,6 +425,70 @@ def _append_injection_log(session_id: str, record: dict) -> None:
         pass  # Never block
 
 
+def _ws_measure(
+    fused: list[dict],
+    session_id: str,
+    surfaced_proc_id: str | None,
+    now_iso: str,
+) -> dict:
+    """The whole working-set measurement step for one prompt.
+
+    Computes overlap vs the PRE-update working set, records this prompt's
+    injection, and appends the injection-log line. Contract: NEVER prints
+    (hook stdout is context injected into the conversation) and NEVER
+    raises — any internal failure returns the stats gathered so far with
+    safe defaults for the rest.
+    """
+    stats: dict = {
+        "injected_ids": [],
+        "repeat_count": 0,
+        "overlap_pct": None,
+        "working_set_size": None,
+        "zero_retrieved_injected": 0,
+        "procedure_repeat": False,
+    }
+    try:
+        stats["injected_ids"] = [r["memory_id"] for r in fused if r.get("memory_id")]
+        # Baseline for the PR2 serendipity boost: how often does today's
+        # ranking already surface never-retrieved episodic memories?
+        # FTS-only entries lack _retrieved_count → excluded (unknown ≠ 0).
+        stats["zero_retrieved_injected"] = sum(
+            1
+            for r in fused
+            if r.get("collection") != "knowledge_base"
+            and r.get("_retrieved_count", -1) == 0
+        )
+        if session_id and (stats["injected_ids"] or surfaced_proc_id):
+            ws = _load_working_set(session_id)
+            repeats, overlap_pct = _ws_overlap(ws, stats["injected_ids"])
+            stats["repeat_count"] = len(repeats)
+            stats["overlap_pct"] = overlap_pct
+            stats["procedure_repeat"] = bool(
+                surfaced_proc_id and surfaced_proc_id in ws.get("procedures", {})
+            )
+            _ws_record(
+                ws,
+                [(r["memory_id"], _ws_kind(r)) for r in fused if r.get("memory_id")],
+                surfaced_proc_id,
+                now_iso,
+            )
+            _save_working_set(session_id, ws)
+            stats["working_set_size"] = len(ws.get("entries", {}))
+            _append_injection_log(session_id, {
+                "ts": now_iso,
+                "turn": ws.get("turn", 0),
+                "injected": len(stats["injected_ids"]),
+                "repeats": stats["repeat_count"],
+                "overlap_pct": stats["overlap_pct"],
+                "ws_size": stats["working_set_size"],
+                "proc": bool(surfaced_proc_id),
+                "proc_repeat": stats["procedure_repeat"],
+            })
+    except Exception:
+        pass  # Measurement must never block the prompt
+    return stats
+
+
 def _is_garbage(content: str) -> bool:
     """Filter out content that should never surface as proactive memory."""
     # NOTE (PR2): we deliberately no longer drop content merely for containing
@@ -1591,50 +1655,7 @@ async def _run(prompt: str, session_id: str = "") -> None:
     # Overlap stats feed the PR2 novelty-gate decision. Runs after all
     # stdout is flushed — never touches injection output. Placed inside
     # the total_ms window so budget_exceeded watches its file I/O too.
-    injected_ids: list[str] = []
-    repeat_count = 0
-    overlap_pct: float | None = None
-    working_set_size: int | None = None
-    zero_retrieved_injected = 0
-    procedure_repeat = False
-    try:
-        injected_ids = [r["memory_id"] for r in fused if r.get("memory_id")]
-        # Baseline for the PR2 serendipity boost: how often does today's
-        # ranking already surface never-retrieved episodic memories?
-        # FTS-only entries lack _retrieved_count → excluded (unknown ≠ 0).
-        zero_retrieved_injected = sum(
-            1
-            for r in fused
-            if r.get("collection") != "knowledge_base"
-            and r.get("_retrieved_count", -1) == 0
-        )
-        if session_id and (injected_ids or _surfaced_proc_id):
-            ws = _load_working_set(session_id)
-            repeats, overlap_pct = _ws_overlap(ws, injected_ids)
-            repeat_count = len(repeats)
-            procedure_repeat = bool(
-                _surfaced_proc_id and _surfaced_proc_id in ws.get("procedures", {})
-            )
-            _ws_record(
-                ws,
-                [(r["memory_id"], _ws_kind(r)) for r in fused if r.get("memory_id")],
-                _surfaced_proc_id,
-                now_iso,
-            )
-            _save_working_set(session_id, ws)
-            working_set_size = len(ws.get("entries", {}))
-            _append_injection_log(session_id, {
-                "ts": now_iso,
-                "turn": ws.get("turn", 0),
-                "injected": len(injected_ids),
-                "repeats": repeat_count,
-                "overlap_pct": overlap_pct,
-                "ws_size": working_set_size,
-                "proc": bool(_surfaced_proc_id),
-                "proc_repeat": procedure_repeat,
-            })
-    except Exception:
-        pass  # Measurement must never block the prompt
+    ws_stats = _ws_measure(fused, session_id, _surfaced_proc_id, now_iso)
 
     total_ms = (time.monotonic() - start) * 1000
 
@@ -1652,12 +1673,12 @@ async def _run(prompt: str, session_id: str = "") -> None:
         total_latency_ms=total_ms,
         fts_only_fallback=fts_only_fallback,
         heartbeat_ms=heartbeat_ms,
-        injected_ids=injected_ids,
-        repeat_count=repeat_count,
-        overlap_pct=overlap_pct,
-        working_set_size=working_set_size,
-        zero_retrieved_injected=zero_retrieved_injected,
-        procedure_repeat=procedure_repeat,
+        injected_ids=ws_stats["injected_ids"],
+        repeat_count=ws_stats["repeat_count"],
+        overlap_pct=ws_stats["overlap_pct"],
+        working_set_size=ws_stats["working_set_size"],
+        zero_retrieved_injected=ws_stats["zero_retrieved_injected"],
+        procedure_repeat=ws_stats["procedure_repeat"],
     )
 
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -270,6 +270,161 @@ def _update_and_format_trail(
     return f"[Session trail] {prefix}{' → '.join(labels)}"
 
 
+# ---------------------------------------------------------------------------
+# Working set — per-session record of already-injected memories (H-1 PR1)
+# ---------------------------------------------------------------------------
+# Record-only measurement layer: tracks which memory/KB/code IDs this hook
+# has already injected into the session (surfaced_memories.json) and appends
+# per-prompt overlap stats to injection_log.jsonl. The 7-day rollup
+# (observability/snapshots/proactive_memory.py) is the data gate for the
+# PR2 novelty-gate decision. Nothing here may affect injection output.
+
+_WS_VERSION = 1
+_WS_FILENAME = "surfaced_memories.json"
+_WS_LOG_FILENAME = "injection_log.jsonl"
+_WS_MAX_ENTRIES = 300  # Evict oldest-surfaced beyond this (bounds file size)
+_WS_MAX_RESETS = 20  # resets[] is written by the PR2 reset path; capped here
+
+
+def _ws_path(session_id: str) -> Path | None:
+    """Path to the working-set file, or None for unusable session IDs.
+
+    Session IDs arrive via hook stdin — refuse anything that could
+    escape the sessions dir (mirrors _load_recent_files).
+    """
+    if not session_id or "/" in session_id or ".." in session_id:
+        return None
+    return _TRAIL_DIR / session_id / _WS_FILENAME
+
+
+def _empty_working_set(session_id: str) -> dict:
+    return {
+        "version": _WS_VERSION,
+        "session_id": session_id,
+        "turn": 0,
+        "entries": {},
+        "procedures": {},
+        "resets": [],
+    }
+
+
+def _load_working_set(session_id: str) -> dict:
+    """Load the session working set. Empty structure if missing/corrupt."""
+    path = _ws_path(session_id)
+    if path is None:
+        return _empty_working_set(session_id)
+    try:
+        if path.exists():
+            data = json.loads(path.read_text())
+            if (
+                isinstance(data, dict)
+                and isinstance(data.get("entries"), dict)
+                and isinstance(data.get("procedures"), dict)
+            ):
+                data.setdefault("version", _WS_VERSION)
+                data.setdefault("session_id", session_id)
+                data.setdefault("turn", 0)
+                data.setdefault("resets", [])
+                return data
+    except Exception:
+        pass
+    return _empty_working_set(session_id)
+
+
+def _save_working_set(session_id: str, ws: dict) -> None:
+    """Atomic write of the working set (mirrors _save_trail). Never raises."""
+    path = _ws_path(session_id)
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            os.write(fd, json.dumps(ws).encode())
+        finally:
+            os.close(fd)
+        os.replace(tmp, str(path))
+    except Exception:
+        pass  # Never block
+
+
+def _ws_kind(result: dict) -> str:
+    """Classify a fused result for working-set bookkeeping."""
+    if result.get("memory_id", "").startswith("code:"):
+        return "code"
+    if result.get("collection") == "knowledge_base":
+        return "kb"
+    return "memory"
+
+
+def _ws_overlap(ws: dict, injected_ids: list[str]) -> tuple[list[str], float]:
+    """Repeat IDs (already in the working set) + overlap percentage.
+
+    Must run on the PRE-update snapshot — call before _ws_record.
+    """
+    entries = ws.get("entries", {})
+    repeats = [mid for mid in injected_ids if mid in entries]
+    pct = round(100.0 * len(repeats) / len(injected_ids), 1) if injected_ids else 0.0
+    return repeats, pct
+
+
+def _ws_record(
+    ws: dict,
+    injected: list[tuple[str, str]],
+    proc_id: str | None,
+    now_iso: str,
+) -> None:
+    """Record injected (memory_id, kind) pairs + surfaced procedure in place."""
+    ws["turn"] = ws.get("turn", 0) + 1
+    turn = ws["turn"]
+    entries = ws.setdefault("entries", {})
+    for mid, kind in injected:
+        entry = entries.get(mid)
+        if entry is None:
+            entries[mid] = {
+                "first_ts": now_iso,
+                "last_ts": now_iso,
+                "count": 1,
+                "first_turn": turn,
+                "last_turn": turn,
+                "kind": kind,
+            }
+        else:
+            entry["last_ts"] = now_iso
+            entry["count"] = entry.get("count", 0) + 1
+            entry["last_turn"] = turn
+    if proc_id:
+        procedures = ws.setdefault("procedures", {})
+        proc = procedures.get(proc_id)
+        if proc is None:
+            procedures[proc_id] = {"last_ts": now_iso, "count": 1}
+        else:
+            proc["last_ts"] = now_iso
+            proc["count"] = proc.get("count", 0) + 1
+    # Bound file size: evict the oldest-surfaced entries beyond the cap
+    if len(entries) > _WS_MAX_ENTRIES:
+        by_age = sorted(entries.items(), key=lambda kv: kv[1].get("last_ts", ""))
+        for mid, _ in by_age[: len(entries) - _WS_MAX_ENTRIES]:
+            del entries[mid]
+    resets = ws.get("resets", [])
+    if len(resets) > _WS_MAX_RESETS:
+        ws["resets"] = resets[-_WS_MAX_RESETS:]
+
+
+def _append_injection_log(session_id: str, record: dict) -> None:
+    """Append one per-prompt overlap record. Best-effort, never raises."""
+    path = _ws_path(session_id)
+    if path is None:
+        return
+    try:
+        log_path = path.parent / _WS_LOG_FILENAME
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception:
+        pass  # Never block
+
+
 def _is_garbage(content: str) -> bool:
     """Filter out content that should never surface as proactive memory."""
     # NOTE (PR2): we deliberately no longer drop content merely for containing
@@ -1055,8 +1210,19 @@ def _record_detail(
     total_latency_ms: float,
     fts_only_fallback: bool,
     heartbeat_ms: float = 0.0,
+    injected_ids: list[str] | None = None,
+    repeat_count: int = 0,
+    overlap_pct: float | None = None,
+    working_set_size: int | None = None,
+    zero_retrieved_injected: int = 0,
+    procedure_repeat: bool = False,
 ) -> None:
-    """Atomic JSON write — latest invocation detail for health dashboard."""
+    """Atomic JSON write — latest invocation detail for health dashboard.
+
+    The working-set fields (H-1 PR1) describe this prompt's injection vs
+    the session's already-surfaced set; ``overlap_pct``/``working_set_size``
+    are None when no injection happened or no session ID was available.
+    """
     data = {
         "timestamp": datetime.now(UTC).isoformat(),
         "fts_results": fts_count,
@@ -1067,6 +1233,12 @@ def _record_detail(
         "fts_only_fallback": fts_only_fallback,
         "heartbeat_ms": round(heartbeat_ms, 1),
         "budget_exceeded": total_latency_ms > 2000,
+        "injected_ids": injected_ids or [],
+        "repeat_count": repeat_count,
+        "overlap_pct": overlap_pct,
+        "working_set_size": working_set_size,
+        "zero_retrieved_injected": zero_retrieved_injected,
+        "procedure_repeat": procedure_repeat,
     }
     try:
         _METRICS_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -1415,6 +1587,55 @@ async def _run(prompt: str, session_id: str = "") -> None:
     if fused:
         await _increment_retrieved(fused)
 
+    # ── Working-set measurement (H-1 PR1, record-only) ─────────────
+    # Overlap stats feed the PR2 novelty-gate decision. Runs after all
+    # stdout is flushed — never touches injection output. Placed inside
+    # the total_ms window so budget_exceeded watches its file I/O too.
+    injected_ids: list[str] = []
+    repeat_count = 0
+    overlap_pct: float | None = None
+    working_set_size: int | None = None
+    zero_retrieved_injected = 0
+    procedure_repeat = False
+    try:
+        injected_ids = [r["memory_id"] for r in fused if r.get("memory_id")]
+        # Baseline for the PR2 serendipity boost: how often does today's
+        # ranking already surface never-retrieved episodic memories?
+        # FTS-only entries lack _retrieved_count → excluded (unknown ≠ 0).
+        zero_retrieved_injected = sum(
+            1
+            for r in fused
+            if r.get("collection") != "knowledge_base"
+            and r.get("_retrieved_count", -1) == 0
+        )
+        if session_id and (injected_ids or _surfaced_proc_id):
+            ws = _load_working_set(session_id)
+            repeats, overlap_pct = _ws_overlap(ws, injected_ids)
+            repeat_count = len(repeats)
+            procedure_repeat = bool(
+                _surfaced_proc_id and _surfaced_proc_id in ws.get("procedures", {})
+            )
+            _ws_record(
+                ws,
+                [(r["memory_id"], _ws_kind(r)) for r in fused if r.get("memory_id")],
+                _surfaced_proc_id,
+                now_iso,
+            )
+            _save_working_set(session_id, ws)
+            working_set_size = len(ws.get("entries", {}))
+            _append_injection_log(session_id, {
+                "ts": now_iso,
+                "turn": ws.get("turn", 0),
+                "injected": len(injected_ids),
+                "repeats": repeat_count,
+                "overlap_pct": overlap_pct,
+                "ws_size": working_set_size,
+                "proc": bool(_surfaced_proc_id),
+                "proc_repeat": procedure_repeat,
+            })
+    except Exception:
+        pass  # Measurement must never block the prompt
+
     total_ms = (time.monotonic() - start) * 1000
 
     had_results = fused_count > 0
@@ -1431,6 +1652,12 @@ async def _run(prompt: str, session_id: str = "") -> None:
         total_latency_ms=total_ms,
         fts_only_fallback=fts_only_fallback,
         heartbeat_ms=heartbeat_ms,
+        injected_ids=injected_ids,
+        repeat_count=repeat_count,
+        overlap_pct=overlap_pct,
+        working_set_size=working_set_size,
+        zero_retrieved_injected=zero_retrieved_injected,
+        procedure_repeat=procedure_repeat,
     )
 
 

--- a/src/genesis/observability/snapshots/proactive_memory.py
+++ b/src/genesis/observability/snapshots/proactive_memory.py
@@ -47,7 +47,11 @@ def _overlap_7d(sessions_dir: Path | None = None, now: datetime | None = None) -
                 if log_path.stat().st_mtime < cutoff_epoch:
                     continue  # Whole file predates the window
                 counted_this_session = False
-                for line in log_path.read_text().splitlines():
+                # errors="replace": invalid bytes must cost only their own
+                # line (json.loads fails, line skipped), never the whole
+                # file or — via the outer catch — the remaining sessions.
+                text = log_path.read_text(encoding="utf-8", errors="replace")
+                for line in text.splitlines():
                     line = line.strip()
                     if not line:
                         continue

--- a/src/genesis/observability/snapshots/proactive_memory.py
+++ b/src/genesis/observability/snapshots/proactive_memory.py
@@ -2,11 +2,93 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+_METRICS_PATH = Path.home() / ".genesis" / "proactive_metrics.json"
+_SESSIONS_DIR = Path.home() / ".genesis" / "sessions"
+_WINDOW_DAYS = 7
+
+
+def _utcnow() -> datetime:
+    """Time seam — tests patch this instead of the wall clock."""
+    return datetime.now(UTC)
+
+
+def _overlap_7d(sessions_dir: Path | None = None, now: datetime | None = None) -> dict:
+    """Aggregate injection-overlap stats from per-session injection logs.
+
+    The proactive hook (scripts/proactive_memory_hook.py) appends one JSONL
+    record per prompt-with-injection to
+    ``~/.genesis/sessions/{sid}/injection_log.jsonl``. This 7-day rollup is
+    the data gate for the H-1 PR2 novelty-gated-injection decision: ship the
+    gate only if ``overlap_pct_7d`` shows meaningful repeat injection.
+    """
+    if sessions_dir is None:
+        sessions_dir = _SESSIONS_DIR
+    if now is None:
+        now = _utcnow()
+    cutoff = now - timedelta(days=_WINDOW_DAYS)
+    cutoff_epoch = cutoff.timestamp()
+
+    total_injected = 0
+    total_repeats = 0
+    prompts_with_injection = 0
+    prompts_with_repeat = 0
+    sessions = 0
+    try:
+        for log_path in sessions_dir.glob("*/injection_log.jsonl"):
+            try:
+                if log_path.stat().st_mtime < cutoff_epoch:
+                    continue  # Whole file predates the window
+                counted_this_session = False
+                for line in log_path.read_text().splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                        ts = datetime.fromisoformat(str(rec["ts"]))
+                        injected = int(rec.get("injected", 0))
+                        repeats = int(rec.get("repeats", 0))
+                    except (ValueError, KeyError, TypeError):
+                        continue  # Garbled line — skip, keep aggregating
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=UTC)
+                    if ts < cutoff or injected <= 0:
+                        continue
+                    total_injected += injected
+                    total_repeats += repeats
+                    prompts_with_injection += 1
+                    if repeats > 0:
+                        prompts_with_repeat += 1
+                    counted_this_session = True
+                if counted_this_session:
+                    sessions += 1
+            except OSError:
+                continue  # Unreadable file — skip
+    except Exception:
+        logger.debug("overlap_7d aggregation failed", exc_info=True)
+
+    overlap_pct = (
+        round(100.0 * total_repeats / total_injected, 1) if total_injected else 0.0
+    )
+    repeat_rate = (
+        round(prompts_with_repeat / prompts_with_injection, 3)
+        if prompts_with_injection
+        else 0.0
+    )
+    return {
+        "overlap_pct_7d": overlap_pct,
+        "prompts_with_injection_7d": prompts_with_injection,
+        "repeat_prompt_rate_7d": repeat_rate,
+        "sessions_7d": sessions,
+    }
 
 
 def proactive_memory_metrics() -> dict:
@@ -14,12 +96,17 @@ def proactive_memory_metrics() -> dict:
 
     Written by the UserPromptSubmit hook (scripts/proactive_memory_hook.py)
     on each invocation. Aggregated stats are in provider_activity under
-    the 'proactive_memory' provider key (via activity_log table).
+    the 'proactive_memory' provider key (via activity_log table). The
+    ``overlap_7d`` key carries the 7-day injection-overlap rollup.
     """
-    path = Path.home() / ".genesis" / "proactive_metrics.json"
+    data: dict = {}
     try:
-        if path.exists():
-            return json.loads(path.read_text())
+        if _METRICS_PATH.exists():
+            loaded = json.loads(_METRICS_PATH.read_text())
+            if isinstance(loaded, dict):
+                data = loaded
     except Exception:
         pass
-    return {}
+    with contextlib.suppress(Exception):
+        data["overlap_7d"] = _overlap_7d()
+    return data

--- a/tests/test_hooks/test_working_set.py
+++ b/tests/test_hooks/test_working_set.py
@@ -185,6 +185,73 @@ class TestInjectionLog:
         assert list(tmp_path.iterdir()) == []
 
 
+class TestWsMeasure:
+    """_ws_measure is the whole measurement step — it must NEVER print or
+    raise (the hook's stdout is context injected into the conversation)."""
+
+    _FUSED = [
+        {"memory_id": "a", "collection": "episodic_memory", "_retrieved_count": 0},
+        {"memory_id": "kb1", "collection": "knowledge_base", "_retrieved_count": 0},
+    ]
+
+    def test_happy_path_records_and_stays_silent(self, tmp_path: Path, capsys) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            stats = _mod._ws_measure(self._FUSED, "s1", "proc-1", _NOW)
+        assert capsys.readouterr().out == ""
+        assert stats["injected_ids"] == ["a", "kb1"]
+        assert stats["repeat_count"] == 0
+        assert stats["overlap_pct"] == 0.0
+        assert stats["working_set_size"] == 2
+        # KB entries never count toward the serendipity baseline
+        assert stats["zero_retrieved_injected"] == 1
+        assert stats["procedure_repeat"] is False
+        assert (tmp_path / "s1" / "surfaced_memories.json").exists()
+        assert (tmp_path / "s1" / "injection_log.jsonl").exists()
+
+    def test_repeat_detected_on_second_call(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            _mod._ws_measure(self._FUSED, "s1", "proc-1", _NOW)
+            stats = _mod._ws_measure(self._FUSED, "s1", "proc-1", _LATER)
+        assert stats["repeat_count"] == 2
+        assert stats["overlap_pct"] == 100.0
+        assert stats["procedure_repeat"] is True
+
+    def test_internal_failure_never_prints_or_raises(self, tmp_path: Path, capsys) -> None:
+        def _boom(session_id: str) -> dict:
+            raise RuntimeError("boom")
+
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path), \
+             patch.object(_mod, "_load_working_set", _boom):
+            stats = _mod._ws_measure(self._FUSED, "s1", None, _NOW)
+        assert capsys.readouterr().out == ""
+        # Pre-failure fields survive; ws-dependent fields keep safe defaults
+        assert stats["injected_ids"] == ["a", "kb1"]
+        assert stats["overlap_pct"] is None
+        assert stats["working_set_size"] is None
+
+    def test_save_failure_contained(self, tmp_path: Path, capsys) -> None:
+        def _boom_save(session_id: str, ws: dict) -> None:
+            raise OSError("disk full")
+
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path), \
+             patch.object(_mod, "_save_working_set", _boom_save):
+            _mod._ws_measure(self._FUSED, "s1", None, _NOW)
+        assert capsys.readouterr().out == ""
+
+    def test_no_session_id_skips_files(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            stats = _mod._ws_measure(self._FUSED, "", None, _NOW)
+        assert stats["injected_ids"] == ["a", "kb1"]
+        assert stats["working_set_size"] is None
+        assert list(tmp_path.iterdir()) == []
+
+    def test_nothing_injected_no_files(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            stats = _mod._ws_measure([], "s1", None, _NOW)
+        assert stats["injected_ids"] == []
+        assert list(tmp_path.iterdir()) == []
+
+
 class TestRecordDetailOverlapFields:
     def test_new_fields_present(self, tmp_path: Path) -> None:
         metrics_path = tmp_path / "proactive_metrics.json"

--- a/tests/test_hooks/test_working_set.py
+++ b/tests/test_hooks/test_working_set.py
@@ -1,0 +1,233 @@
+"""Tests for the per-session working set — H-1 PR1 injection-overlap measurement.
+
+The working set records which memory/KB/code IDs the proactive hook has
+already injected into a session (``~/.genesis/sessions/{sid}/surfaced_memories.json``)
+plus an append-only ``injection_log.jsonl`` used by the observability
+snapshot to compute 7-day overlap. PR1 is record-only: injection output
+must stay byte-identical.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# The hook script lives in scripts/, not a package — load it manually
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+_HOOK_PATH = _SCRIPTS_DIR / "proactive_memory_hook.py"
+
+_spec = importlib.util.spec_from_file_location("proactive_memory_hook_ws", _HOOK_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["proactive_memory_hook_ws"] = _mod
+_spec.loader.exec_module(_mod)
+
+_NOW = "2026-07-03T12:00:00+00:00"
+_LATER = "2026-07-03T13:00:00+00:00"
+
+
+def _empty_ws(session_id: str = "s1") -> dict:
+    return _mod._load_working_set(session_id)
+
+
+class TestWorkingSetIO:
+    def test_load_missing_returns_empty_structure(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            ws = _mod._load_working_set("nonexistent-session")
+        assert ws["version"] == _mod._WS_VERSION
+        assert ws["session_id"] == "nonexistent-session"
+        assert ws["turn"] == 0
+        assert ws["entries"] == {}
+        assert ws["procedures"] == {}
+        assert ws["resets"] == []
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            ws = _mod._load_working_set("s1")
+            _mod._ws_record(ws, [("mem-a", "memory"), ("kb-b", "kb")], "proc-1", _NOW)
+            _mod._save_working_set("s1", ws)
+            loaded = _mod._load_working_set("s1")
+        assert loaded["turn"] == 1
+        assert loaded["entries"]["mem-a"]["kind"] == "memory"
+        assert loaded["entries"]["kb-b"]["kind"] == "kb"
+        assert loaded["procedures"]["proc-1"]["count"] == 1
+
+    def test_corrupted_file_returns_empty(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "s1"
+        session_dir.mkdir(parents=True)
+        (session_dir / "surfaced_memories.json").write_text("{not json!!")
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            ws = _mod._load_working_set("s1")
+        assert ws["entries"] == {}
+        assert ws["turn"] == 0
+
+    def test_non_dict_payload_returns_empty(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "s1"
+        session_dir.mkdir(parents=True)
+        (session_dir / "surfaced_memories.json").write_text('["a", "list"]')
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            ws = _mod._load_working_set("s1")
+        assert ws["entries"] == {}
+
+    def test_path_traversal_session_id_is_noop(self, tmp_path: Path) -> None:
+        """Session IDs come from hook stdin — never build paths from ../ or /."""
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            assert _mod._ws_path("../evil") is None
+            assert _mod._ws_path("a/b") is None
+            assert _mod._ws_path("") is None
+            ws = _mod._load_working_set("../evil")
+            assert ws["entries"] == {}
+            # Save must be a silent no-op, not a crash or a file outside tmp
+            _mod._save_working_set("../evil", ws)
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestWsOverlap:
+    def test_overlap_math(self) -> None:
+        ws = _empty_ws()
+        _mod._ws_record(ws, [("a", "memory"), ("b", "memory")], None, _NOW)
+        repeats, pct = _mod._ws_overlap(ws, ["a", "c"])
+        assert repeats == ["a"]
+        assert pct == 50.0
+
+    def test_no_injected_ids_zero_pct(self) -> None:
+        ws = _empty_ws()
+        _mod._ws_record(ws, [("a", "memory")], None, _NOW)
+        repeats, pct = _mod._ws_overlap(ws, [])
+        assert repeats == []
+        assert pct == 0.0
+
+    def test_empty_working_set_zero_overlap(self) -> None:
+        repeats, pct = _mod._ws_overlap(_empty_ws(), ["a", "b"])
+        assert repeats == []
+        assert pct == 0.0
+
+    def test_all_repeats(self) -> None:
+        ws = _empty_ws()
+        _mod._ws_record(ws, [("a", "memory"), ("b", "kb")], None, _NOW)
+        repeats, pct = _mod._ws_overlap(ws, ["a", "b"])
+        assert sorted(repeats) == ["a", "b"]
+        assert pct == 100.0
+
+
+class TestWsRecord:
+    def test_upsert_bumps_counts_and_turns(self) -> None:
+        ws = _empty_ws()
+        _mod._ws_record(ws, [("a", "memory")], None, _NOW)
+        assert ws["turn"] == 1
+        entry = ws["entries"]["a"]
+        assert entry["count"] == 1
+        assert entry["first_turn"] == 1
+        assert entry["last_turn"] == 1
+        assert entry["first_ts"] == _NOW
+
+        _mod._ws_record(ws, [("a", "memory"), ("b", "code")], None, _LATER)
+        assert ws["turn"] == 2
+        entry = ws["entries"]["a"]
+        assert entry["count"] == 2
+        assert entry["first_turn"] == 1
+        assert entry["last_turn"] == 2
+        assert entry["first_ts"] == _NOW
+        assert entry["last_ts"] == _LATER
+        assert ws["entries"]["b"]["kind"] == "code"
+
+    def test_procedure_tracking(self) -> None:
+        ws = _empty_ws()
+        _mod._ws_record(ws, [], "proc-1", _NOW)
+        assert ws["procedures"]["proc-1"]["count"] == 1
+        _mod._ws_record(ws, [], "proc-1", _LATER)
+        assert ws["procedures"]["proc-1"]["count"] == 2
+        assert ws["procedures"]["proc-1"]["last_ts"] == _LATER
+
+    def test_eviction_keeps_newest_at_cap(self) -> None:
+        ws = _empty_ws()
+        # Fill to cap with increasing timestamps, oldest first
+        for i in range(_mod._WS_MAX_ENTRIES):
+            _mod._ws_record(
+                ws, [(f"m{i}", "memory")], None, f"2026-07-01T00:{i // 60:02d}:{i % 60:02d}+00:00",
+            )
+        assert len(ws["entries"]) == _mod._WS_MAX_ENTRIES
+        # One more evicts the oldest (m0), keeps the newest
+        _mod._ws_record(ws, [("overflow", "memory")], None, "2026-07-02T00:00:00+00:00")
+        assert len(ws["entries"]) == _mod._WS_MAX_ENTRIES
+        assert "overflow" in ws["entries"]
+        assert "m0" not in ws["entries"]
+        assert "m1" in ws["entries"]
+
+
+class TestWsKind:
+    def test_kind_classification(self) -> None:
+        assert _mod._ws_kind({"memory_id": "abc", "collection": "episodic_memory"}) == "memory"
+        assert _mod._ws_kind({"memory_id": "kbx", "collection": "knowledge_base"}) == "kb"
+        assert _mod._ws_kind({"memory_id": "code:src/mod.py:fn"}) == "code"
+
+
+class TestInjectionLog:
+    def test_appends_jsonl_lines(self, tmp_path: Path) -> None:
+        record1 = {"ts": _NOW, "turn": 1, "injected": 3, "repeats": 0,
+                   "overlap_pct": 0.0, "ws_size": 3}
+        record2 = {"ts": _LATER, "turn": 2, "injected": 2, "repeats": 1,
+                   "overlap_pct": 50.0, "ws_size": 4}
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            _mod._append_injection_log("s1", record1)
+            _mod._append_injection_log("s1", record2)
+        log_path = tmp_path / "s1" / "injection_log.jsonl"
+        lines = log_path.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["injected"] == 3
+        assert json.loads(lines[1])["repeats"] == 1
+
+    def test_bad_session_id_is_noop(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            _mod._append_injection_log("../evil", {"ts": _NOW})
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestRecordDetailOverlapFields:
+    def test_new_fields_present(self, tmp_path: Path) -> None:
+        metrics_path = tmp_path / "proactive_metrics.json"
+        with patch.object(_mod, "_METRICS_PATH", metrics_path):
+            _mod._record_detail(
+                fts_count=2,
+                vector_count=3,
+                fused_count=3,
+                embed_latency_ms=450.0,
+                total_latency_ms=800.0,
+                fts_only_fallback=False,
+                heartbeat_ms=5.0,
+                injected_ids=["a", "b", "c"],
+                repeat_count=1,
+                overlap_pct=33.3,
+                working_set_size=12,
+                zero_retrieved_injected=2,
+                procedure_repeat=True,
+            )
+        data = json.loads(metrics_path.read_text())
+        assert data["injected_ids"] == ["a", "b", "c"]
+        assert data["repeat_count"] == 1
+        assert data["overlap_pct"] == 33.3
+        assert data["working_set_size"] == 12
+        assert data["zero_retrieved_injected"] == 2
+        assert data["procedure_repeat"] is True
+
+    def test_defaults_when_no_injection(self, tmp_path: Path) -> None:
+        """Existing call shape (no new kwargs) still works — fields default."""
+        metrics_path = tmp_path / "proactive_metrics.json"
+        with patch.object(_mod, "_METRICS_PATH", metrics_path):
+            _mod._record_detail(
+                fts_count=0,
+                vector_count=0,
+                fused_count=0,
+                embed_latency_ms=None,
+                total_latency_ms=100.0,
+                fts_only_fallback=False,
+            )
+        data = json.loads(metrics_path.read_text())
+        assert data["injected_ids"] == []
+        assert data["repeat_count"] == 0
+        assert data["overlap_pct"] is None
+        assert data["working_set_size"] is None
+        assert data["zero_retrieved_injected"] == 0
+        assert data["procedure_repeat"] is False

--- a/tests/test_learning/test_proactive_hook_subprocess.py
+++ b/tests/test_learning/test_proactive_hook_subprocess.py
@@ -118,6 +118,11 @@ def test_procedure_surfacing_subprocess(seeded_db, tmp_path: Path):
     env = os.environ.copy()
     env["GENESIS_DB_PATH"] = str(db_path)
     env.pop("GENESIS_CC_SESSION", None)
+    # Isolate HOME so the hook's per-session state (intent trail, working
+    # set, injection log) and proactive_metrics.json land in tmp_path —
+    # NOT the real ~/.genesis. The injection log feeds the live 7-day
+    # overlap measurement; test runs must never pollute it.
+    env["HOME"] = str(tmp_path)
     # Qdrant URL — use the real one (needed for memory recall, but
     # we're testing procedure surfacing which uses SQLite only)
     env.setdefault("QDRANT_URL", "http://localhost:6333")
@@ -158,6 +163,14 @@ def test_procedure_surfacing_subprocess(seeded_db, tmp_path: Path):
             f"Expected task_type={_TASK_TYPE} or id prefix={proc_id[:8]}\n"
             f"Got: {stdout[:500]}"
         )
+
+    # H-1 PR1 wiring: the surfaced procedure must be recorded in the
+    # session working set + injection log — under the ISOLATED home.
+    session_dir = tmp_path / ".genesis" / "sessions" / "test-session-001"
+    ws = json.loads((session_dir / "surfaced_memories.json").read_text())
+    assert proc_id in ws["procedures"]
+    log_lines = (session_dir / "injection_log.jsonl").read_text().strip().split("\n")
+    assert json.loads(log_lines[0])["proc"] is True
 
 
 def test_genesis_cc_session_exits_immediately():

--- a/tests/test_learning/test_proactive_hook_subprocess.py
+++ b/tests/test_learning/test_proactive_hook_subprocess.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -123,6 +124,16 @@ def test_procedure_surfacing_subprocess(seeded_db, tmp_path: Path):
     # NOT the real ~/.genesis. The injection log feeds the live 7-day
     # overlap measurement; test runs must never pollute it.
     env["HOME"] = str(tmp_path)
+    # ...but install CONFIG must come along: the hook resolves the
+    # embedding backend (e.g. network.ollama_enabled) from
+    # ~/.genesis/config/genesis.yaml via HOME. Isolate mutable state,
+    # not the install's config, or the subprocess loses its only
+    # embedding backend on installs without cloud keys in the env.
+    real_config = Path.home() / ".genesis" / "config" / "genesis.yaml"
+    if real_config.exists():
+        iso_config_dir = tmp_path / ".genesis" / "config"
+        iso_config_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(real_config, iso_config_dir / "genesis.yaml")
     # Qdrant URL — use the real one (needed for memory recall, but
     # we're testing procedure surfacing which uses SQLite only)
     env.setdefault("QDRANT_URL", "http://localhost:6333")

--- a/tests/test_observability/test_proactive_snapshot_overlap.py
+++ b/tests/test_observability/test_proactive_snapshot_overlap.py
@@ -1,0 +1,122 @@
+"""Tests for the 7-day injection-overlap aggregation — H-1 PR1.
+
+``_overlap_7d`` globs ``~/.genesis/sessions/*/injection_log.jsonl`` (written
+by the proactive memory hook) and aggregates overlap stats into the
+``proactive_memory`` health section via ``proactive_memory_metrics``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from genesis.observability.snapshots import proactive_memory as pm
+
+_NOW = datetime(2026, 7, 3, 12, 0, 0, tzinfo=UTC)
+
+
+def _write_log(sessions_dir: Path, session_id: str, records: list[dict]) -> Path:
+    session_dir = sessions_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / "injection_log.jsonl"
+    with open(path, "a") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+    return path
+
+
+def _rec(ts: datetime, injected: int, repeats: int) -> dict:
+    return {
+        "ts": ts.isoformat(),
+        "turn": 1,
+        "injected": injected,
+        "repeats": repeats,
+        "overlap_pct": (100.0 * repeats / injected) if injected else 0.0,
+        "ws_size": injected,
+    }
+
+
+class TestOverlap7d:
+    def test_aggregates_across_sessions(self, tmp_path: Path) -> None:
+        recent = _NOW - timedelta(days=1)
+        _write_log(tmp_path, "s1", [_rec(recent, 3, 0), _rec(recent, 2, 1)])
+        _write_log(tmp_path, "s2", [_rec(recent, 5, 4)])
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        # totals: injected=10, repeats=5 → 50.0%
+        assert result["overlap_pct_7d"] == 50.0
+        assert result["prompts_with_injection_7d"] == 3
+        # 2 of 3 prompts had ≥1 repeat
+        assert result["repeat_prompt_rate_7d"] == round(2 / 3, 3)
+        assert result["sessions_7d"] == 2
+
+    def test_skips_lines_older_than_7d(self, tmp_path: Path) -> None:
+        old = _NOW - timedelta(days=10)
+        recent = _NOW - timedelta(days=2)
+        _write_log(tmp_path, "s1", [_rec(old, 100, 100), _rec(recent, 4, 1)])
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        assert result["overlap_pct_7d"] == 25.0
+        assert result["prompts_with_injection_7d"] == 1
+
+    def test_skips_stale_files_by_mtime(self, tmp_path: Path) -> None:
+        recent = _NOW - timedelta(days=1)
+        stale = _write_log(tmp_path, "s-old", [_rec(recent, 9, 9)])
+        # Backdate the file itself past the window — prefilter must skip it
+        old_epoch = (_NOW - timedelta(days=30)).timestamp()
+        os.utime(stale, (old_epoch, old_epoch))
+        _write_log(tmp_path, "s-new", [_rec(recent, 4, 1)])
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        assert result["prompts_with_injection_7d"] == 1
+        assert result["overlap_pct_7d"] == 25.0
+
+    def test_skips_garbled_lines(self, tmp_path: Path) -> None:
+        recent = _NOW - timedelta(days=1)
+        path = _write_log(tmp_path, "s1", [_rec(recent, 4, 2)])
+        with open(path, "a") as f:
+            f.write("{corrupt line\n")
+            f.write('{"ts": "not-a-timestamp", "injected": 5, "repeats": 5}\n')
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        assert result["prompts_with_injection_7d"] == 1
+        assert result["overlap_pct_7d"] == 50.0
+
+    def test_zero_injection_lines_excluded_from_prompt_count(self, tmp_path: Path) -> None:
+        recent = _NOW - timedelta(days=1)
+        _write_log(tmp_path, "s1", [_rec(recent, 0, 0), _rec(recent, 2, 0)])
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        assert result["prompts_with_injection_7d"] == 1
+        assert result["overlap_pct_7d"] == 0.0
+        assert result["repeat_prompt_rate_7d"] == 0.0
+
+    def test_empty_dir_returns_zeros(self, tmp_path: Path) -> None:
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        assert result["overlap_pct_7d"] == 0.0
+        assert result["prompts_with_injection_7d"] == 0
+        assert result["repeat_prompt_rate_7d"] == 0.0
+        assert result["sessions_7d"] == 0
+
+    def test_missing_dir_returns_zeros(self, tmp_path: Path) -> None:
+        result = pm._overlap_7d(sessions_dir=tmp_path / "nope", now=_NOW)
+        assert result["prompts_with_injection_7d"] == 0
+
+
+class TestMetricsIncludesOverlap:
+    def test_overlap_key_present(self, tmp_path: Path) -> None:
+        recent = _NOW - timedelta(days=1)
+        _write_log(tmp_path, "s1", [_rec(recent, 2, 1)])
+        metrics_path = tmp_path / "proactive_metrics.json"
+        metrics_path.write_text(json.dumps({"fused_results": 2}))
+        with patch.object(pm, "_SESSIONS_DIR", tmp_path), \
+             patch.object(pm, "_METRICS_PATH", metrics_path), \
+             patch.object(pm, "_utcnow", lambda: _NOW):
+            data = pm.proactive_memory_metrics()
+        assert data["fused_results"] == 2
+        assert data["overlap_7d"]["overlap_pct_7d"] == 50.0
+
+    def test_overlap_key_present_even_without_metrics_file(self, tmp_path: Path) -> None:
+        with patch.object(pm, "_SESSIONS_DIR", tmp_path), \
+             patch.object(pm, "_METRICS_PATH", tmp_path / "missing.json"), \
+             patch.object(pm, "_utcnow", lambda: _NOW):
+            data = pm.proactive_memory_metrics()
+        assert data["overlap_7d"]["prompts_with_injection_7d"] == 0

--- a/tests/test_observability/test_proactive_snapshot_overlap.py
+++ b/tests/test_observability/test_proactive_snapshot_overlap.py
@@ -89,6 +89,27 @@ class TestOverlap7d:
         assert result["overlap_pct_7d"] == 0.0
         assert result["repeat_prompt_rate_7d"] == 0.0
 
+    def test_invalid_utf8_does_not_abort_aggregation(self, tmp_path: Path) -> None:
+        """A log file with invalid UTF-8 bytes must not kill the whole rollup.
+
+        Pre-hardening, read_text() raised UnicodeDecodeError (a ValueError,
+        NOT caught by the per-file OSError guard) which escaped to the outer
+        catch and silently dropped every remaining session. Valid lines in
+        the corrupt file itself must still be salvaged.
+        """
+        recent = _NOW - timedelta(days=1)
+        bad_dir = tmp_path / "s-corrupt"
+        bad_dir.mkdir(parents=True)
+        with open(bad_dir / "injection_log.jsonl", "wb") as f:
+            f.write(b"\xff\xfe corrupt bytes\n")
+            f.write((json.dumps(_rec(recent, 2, 1)) + "\n").encode())
+        _write_log(tmp_path, "s-good", [_rec(recent, 4, 1)])
+        result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
+        # Both the salvaged line AND the other session must count
+        assert result["prompts_with_injection_7d"] == 2
+        assert result["sessions_7d"] == 2
+        assert result["overlap_pct_7d"] == round(100.0 * 2 / 6, 1)
+
     def test_empty_dir_returns_zeros(self, tmp_path: Path) -> None:
         result = pm._overlap_7d(sessions_dir=tmp_path, now=_NOW)
         assert result["overlap_pct_7d"] == 0.0


### PR DESCRIPTION
## Summary

**H-1 PR1** (WS-H memory track, Pillar 1) — record-only instrumentation of the L2 proactive-memory hook that measures how often per-prompt memory injection repeats itself within a session. This data gates PR2 (novelty-gated injection): PR2 ships only if `overlap_pct_7d` after 3-5 days shows meaningful repeat injection (threshold ~10%).

- **Working set** — `~/.genesis/sessions/{sid}/surfaced_memories.json` records every injected memory/KB/code ID per session (atomic tmp+replace writes mirroring the intent-trail pattern; 300-entry cap with oldest-`last_ts` eviction; path-traversal-guarded session IDs).
- **Injection log** — append-only `injection_log.jsonl` per session: one line per prompt-with-injection (`ts, turn, injected, repeats, overlap_pct, ws_size, proc, proc_repeat`).
- **Metrics detail** — `_record_detail` gains `injected_ids, repeat_count, overlap_pct, working_set_size, zero_retrieved_injected, procedure_repeat` (the last two baseline the PR2 serendipity boost).
- **Health rollup** — `_overlap_7d()` in `snapshots/proactive_memory.py` aggregates all session logs into `overlap_pct_7d / prompts_with_injection_7d / repeat_prompt_rate_7d / sessions_7d` under the health `proactive_memory` section (mtime-prefiltered, per-line garble tolerance incl. invalid UTF-8, tz-aware UTC throughout).
- **Measurement integrity fix** — the subprocess integration test ran the hook against the real `~/.genesis`, leaking session state (pre-existing) that would now have polluted the live overlap measurement. HOME is isolated to `tmp_path` with the install config mirrored in (state isolated, config not), plus wiring assertions.

## Hard invariant

**Injection output is byte-identical to main.** All measurement runs after the last stdout flush; the whole step is extracted into `_ws_measure()` with a never-prints/never-raises contract pinned by tests (monkeypatched failures + capsys). Verified live twice (initial + post-hardening): main hook vs this branch on identical stdin over a forced FTS-only path → `diff` clean.

## Verification

- TDD throughout: 33 new tests written first and watched fail (`tests/test_hooks/test_working_set.py`, `tests/test_observability/test_proactive_snapshot_overlap.py`), then green.
- Adjacent suites green (95 tests): intent trail, proactive hook invalid_at/keywords/provenance, subprocess integration, health data. Ruff clean.
- Live E2E against the real DB: first prompt records `injected=3, repeats=0`; same-topic second prompt in the same session → `repeats=3, overlap_pct=100`; health rollup aggregates real files. Synthetic verification sessions deleted afterward so the live measurement window starts at zero.
- Inline code review (adversarial, six invariants traced line-by-line): no findings ≥80% confidence; both sub-threshold hardening observations fixed in the second commit; third (pre-existing sessions-dir GC gap) tracked as follow-up `034e0331`.

## Risk / rollback

Record-only: ranking, truncation, formatting untouched. New I/O is small, capped, and exception-contained; `total_latency_ms`/`budget_exceeded` in the metrics file watch its cost. Regression markers: missing `injected_ids` in `~/.genesis/proactive_metrics.json` = wiring bug; `total_latency_ms` jump = I/O bug; any stdout diff = scope violation (must be zero). Rollback = revert; session files are inert data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)