### PR TITLE
feat(memory): dream-cycle weekly-cluster / daily-drain split (shadow)

### DIFF
--- a/src/genesis/db/crud/deferred_work.py
+++ b/src/genesis/db/crud/deferred_work.py
@@ -32,6 +32,35 @@ async def create(
     return id
 
 
+async def delete_by_work_type(
+    db: aiosqlite.Connection,
+    *,
+    work_type: str,
+    exclude_status: str | None = "processing",
+) -> int:
+    """Delete all rows for a work_type, optionally preserving one status.
+
+    Used to supersede an ephemeral batch worklist (e.g. dream-cycle re-clustering
+    replaces last week's synthesis worklist and its completed/discarded residue).
+    ``exclude_status`` defaults to ``'processing'`` so an in-flight drain item is
+    never yanked out from under the worker. Returns the count deleted. This is an
+    explicit synchronous supersede — NOT a staleness policy — so it never races
+    the recovery ``expire_by_policy`` cadence (which only touches refresh/discard).
+    """
+    if exclude_status is not None:
+        cursor = await db.execute(
+            "DELETE FROM deferred_work_queue WHERE work_type = ? AND status != ?",
+            (work_type, exclude_status),
+        )
+    else:
+        cursor = await db.execute(
+            "DELETE FROM deferred_work_queue WHERE work_type = ?",
+            (work_type,),
+        )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
+
+
 async def query_pending(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -911,6 +911,11 @@ async def _synthesize_clusters(
     into a saturated chain. Genuine quality blocks reset the streak and never
     trip the breaker.
     """
+    # Deliberate re-sort: the worklist was value-ranked at enqueue, but
+    # rehydration can shrink clusters (members deprecated since Sunday) — the
+    # POST-rehydration size is the fresher value signal, so attempt order may
+    # diverge from queue order for shrunk clusters. PR2's per-item lifecycle
+    # supersedes this batch call.
     all_clusters.sort(key=len, reverse=True)
     merged = 0
     breaker = _CapacityBreaker(_CAPACITY_ABORT_THRESHOLD)

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -183,19 +183,17 @@ async def run(
     report dict with cluster counts, worklist-enqueue count, and any errors.
     """
     run_id = str(uuid.uuid4())
+    # Synthesis-outcome keys (clusters_merged, memories_deprecated, breaker
+    # state, …) live in run_synthesis_drain's report now — the weekly report
+    # carries only clustering + worklist facts, so a permanent "0 merged" here
+    # can't masquerade as a synthesis result.
     report: dict[str, Any] = {
         "run_id": run_id,
         "dry_run": dry_run,
         "threshold": similarity_threshold,
         "clusters_found": 0,
-        "clusters_merged": 0,
-        "clusters_skipped_large": 0,
-        "memories_deprecated": 0,
-        "adversarial_blocked": 0,
-        "shrink_gate_blocked": 0,
-        "rollback_flagged": False,
-        "aborted_capacity": False,
         "worklist_enqueued": 0,
+        "oversize_flagged": 0,
         "errors": [],
     }
 
@@ -283,9 +281,11 @@ async def run(
     # gated on the drain side. Supersedes last week's worklist (a fresh full
     # re-cluster is authoritative).
     try:
-        report["worklist_enqueued"] = await _persist_worklist(
+        worklist = await _persist_worklist(
             db, all_clusters, weekly_run_id=run_id, cap=WORKLIST_CAP,
         )
+        report["worklist_enqueued"] = worklist["enqueued"]
+        report["oversize_flagged"] = worklist["oversize_flagged"]
     except Exception as exc:
         report["errors"].append({"phase": "worklist_persist", "error": str(exc)})
         logger.warning(
@@ -310,24 +310,20 @@ async def run(
         logger.warning("Dream phase link_repair failed: %s", exc, exc_info=True)
 
     # Phase 6 — Entity resolution (dedup + contradiction detection).
-    # Skip when synthesis aborted on capacity: entity resolution is LLM-heavy
-    # and would just hammer the same saturated providers (Phases 5/7/8 are
-    # non-LLM SQL/graph work and run regardless).
-    if report["aborted_capacity"]:
-        logger.info(
-            "Dream cycle %s: skipping entity resolution — synthesis aborted on capacity",
-            run_id[:8],
-        )
-    else:
-        try:
-            from genesis.memory.dream_entity_scan import run_entity_resolution
+    # The old "skip when synthesis aborted on capacity" guard is gone: synthesis
+    # moved to run_synthesis_drain, so run() has no capacity signal to read.
+    # Equivalent protection (provider probe or an internal breaker) lands with
+    # the live flip (T2-D PR2 / FM-8); until then entity resolution is bounded
+    # by its own MAX_ENTITY_CHECKS_PER_RUN cap and gated by dry_run.
+    try:
+        from genesis.memory.dream_entity_scan import run_entity_resolution
 
-            report["entity_resolution"] = await run_entity_resolution(
-                **phase_kwargs, buckets=buckets,
-            )
-        except Exception as exc:
-            report["errors"].append({"phase": "entity_resolution", "error": str(exc)})
-            logger.warning("Dream phase entity_resolution failed: %s", exc, exc_info=True)
+        report["entity_resolution"] = await run_entity_resolution(
+            **phase_kwargs, buckets=buckets,
+        )
+    except Exception as exc:
+        report["errors"].append({"phase": "entity_resolution", "error": str(exc)})
+        logger.warning("Dream phase entity_resolution failed: %s", exc, exc_info=True)
 
     # Phase 7 — Orphan detection
     try:
@@ -355,8 +351,14 @@ async def run(
 
 def _rank_and_cap_clusters(
     clusters: list[list[dict]], *, cap: int,
+    max_cluster_size: int = MAX_CLUSTER_SIZE,
 ) -> list[list[dict]]:
-    """Rank clusters by VALUE (size desc = dedup payoff) and keep the top ``cap``.
+    """Rank MERGEABLE clusters by VALUE (size desc = dedup payoff), top ``cap``.
+
+    Clusters over ``max_cluster_size`` are excluded up front — synthesis skips
+    them (manual-review territory), so enqueueing them would put unmergeable
+    items at the TOP of a size-ranked worklist, wasting drain budget every week
+    and making shadow "would merge" reports unfaithful to live behavior (FM-1).
 
     Size is the v1 value signal (matches the existing synthesis sort). The daily
     drain works this list top-down within its budget, so the highest-value merges
@@ -364,7 +366,8 @@ def _rank_and_cap_clusters(
     (A similarity tiebreak is a deferred enhancement — the union edge-scores are
     computed during clustering but not currently retained past ``_cluster_bucket``.)
     """
-    return sorted(clusters, key=len, reverse=True)[:cap]
+    mergeable = [c for c in clusters if len(c) <= max_cluster_size]
+    return sorted(mergeable, key=len, reverse=True)[:cap]
 
 
 async def _persist_worklist(
@@ -373,8 +376,10 @@ async def _persist_worklist(
     *,
     weekly_run_id: str,
     cap: int = WORKLIST_CAP,
-) -> int:
-    """Persist the top-value clusters as the daily-drain worklist. Returns count.
+) -> dict[str, int]:
+    """Persist the top-value clusters as the daily-drain worklist.
+
+    Returns ``{"enqueued": n, "oversize_flagged": n, "superseded": n}``.
 
     Supersedes any prior ``dream_synthesis_slice`` rows (a fresh full re-cluster
     is authoritative) via an explicit synchronous supersede — NOT a staleness
@@ -382,11 +387,21 @@ async def _persist_worklist(
     under a single priority so the FIFO-within-priority drain order == value order.
     Stores only member ids + (wing, room) + weekly_run_id; the drain re-fetches
     live payloads (rehydrate), so a stale snapshot can't merge deprecated members.
+    Oversize clusters (> MAX_CLUSTER_SIZE) are never enqueued — flagged for
+    manual review here instead (FM-1).
     """
     from genesis.resilience.deferred_work import DRAIN, MEMORY_OPS, DeferredWorkQueue
 
     queue = DeferredWorkQueue(db)
     superseded = await queue.supersede(WORKLIST_WORK_TYPE)
+    oversize = [c for c in clusters if len(c) > MAX_CLUSTER_SIZE]
+    for cluster in oversize:
+        logger.info(
+            "Dream cycle %s: cluster of %d in %s/%s exceeds MAX_CLUSTER_SIZE — "
+            "flagged for manual review, not enqueued",
+            weekly_run_id[:8], len(cluster),
+            cluster[0].get("wing", "?"), cluster[0].get("room", "?"),
+        )
     ranked = _rank_and_cap_clusters(clusters, cap=cap)
 
     enqueued = 0
@@ -407,16 +422,21 @@ async def _persist_worklist(
             enqueued += 1
 
     logger.info(
-        "Dream cycle %s: worklist superseded %d prior, enqueued %d/%d clusters",
-        weekly_run_id[:8], superseded, enqueued, len(ranked),
+        "Dream cycle %s: worklist superseded %d prior, enqueued %d/%d clusters, "
+        "%d oversize flagged",
+        weekly_run_id[:8], superseded, enqueued, len(ranked), len(oversize),
     )
-    return enqueued
+    return {
+        "enqueued": enqueued,
+        "oversize_flagged": len(oversize),
+        "superseded": superseded,
+    }
 
 
 def _rehydrate_cluster(
     qdrant: QdrantClient, member_ids: list[str], wing: str, room: str,
 ) -> list[dict]:
-    """Re-fetch a persisted cluster's live members from Qdrant.
+    """Re-fetch a persisted cluster's live members from Qdrant (one batch call).
 
     A worklist slice stores only ids; by drain time members may have been
     deprecated (by an earlier slice or entity resolution). Fetch current payloads,
@@ -424,18 +444,25 @@ def _rehydrate_cluster(
     ``_synthesize_and_deprecate`` consumes. The caller skips a cluster with < 2
     live members (nothing left to consolidate). Union-find components are disjoint,
     so a member belongs to exactly one cluster — no cross-cluster double-merge.
-    """
-    from genesis.qdrant.collections import get_point
 
+    Synchronous (call via ``asyncio.to_thread``). Deliberately does NOT swallow
+    Qdrant errors: a genuinely-deleted point is simply absent from the batch
+    result, while an unreachable Qdrant RAISES — the drain must not mistake an
+    infrastructure outage for "members gone" and mass-discard the worklist (FM-2).
+    """
+    points = qdrant.retrieve(
+        collection_name=COLLECTION,
+        ids=member_ids,
+        with_payload=True,
+        with_vectors=False,
+    )
     live: list[dict] = []
-    for mid in member_ids:
-        point = get_point(qdrant, collection=COLLECTION, point_id=mid)
-        if point is None:
-            continue
-        if point["payload"].get("deprecated") is True:
+    for point in points:
+        payload = point.payload or {}
+        if payload.get("deprecated") is True:
             continue
         live.append({
-            "id": point["id"], "payload": point["payload"],
+            "id": str(point.id), "payload": payload,
             "wing": wing, "room": room,
         })
     return live
@@ -461,7 +488,12 @@ async def run_synthesis_drain(
 
     Items attempted this slice are marked completed regardless of per-cluster
     outcome — unmerged/blocked/aborted clusters simply re-surface in next week's
-    re-cluster (the design is value-ranked, not exhaustive).
+    re-cluster (the design is value-ranked, not exhaustive). Exception: on an
+    infrastructure failure (Qdrant unreachable) the drain aborts WITHOUT
+    consuming items — a preflight ping guards the start, and a mid-drain
+    rehydrate error resets the in-flight item to pending (FM-2). A stale slice
+    (<2 live members) is completed as a no-op, not discarded — discard implies
+    failure on the dashboard errors view (FM-5).
     """
     from genesis.resilience.deferred_work import DeferredWorkQueue
 
@@ -472,8 +504,22 @@ async def run_synthesis_drain(
         "clusters_merged": 0, "clusters_skipped_large": 0,
         "memories_deprecated": 0, "adversarial_blocked": 0,
         "shrink_gate_blocked": 0, "rollback_flagged": False,
-        "aborted_capacity": False, "errors": [],
+        "aborted_capacity": False, "aborted_infra": False, "errors": [],
     }
+
+    # Preflight: don't consume the worklist when Qdrant is unreachable — a dead
+    # Qdrant makes every member look "gone" and would mass-discard the week's
+    # top-value slices as stale (FM-2).
+    try:
+        await asyncio.to_thread(qdrant.get_collection, COLLECTION)
+    except Exception as exc:
+        report["aborted_infra"] = True
+        report["errors"].append({"phase": "preflight", "error": str(exc)})
+        logger.warning(
+            "Dream drain %s: Qdrant preflight failed — aborting without "
+            "consuming worklist: %s", run_id[:8], exc,
+        )
+        return report
 
     queue = DeferredWorkQueue(db)
     pending: list[tuple[dict, list[dict]]] = []
@@ -481,23 +527,46 @@ async def run_synthesis_drain(
         item = await queue.next_pending(work_type=WORKLIST_WORK_TYPE)
         if item is None:
             break
-        await queue.mark_processing(item["id"])
+        if not await queue.mark_processing(item["id"]):
+            # Row deleted between fetch and claim (weekly supersede racing this
+            # drain — near-impossible by schedule, cheap to guard: FM-10).
+            continue
         try:
             payload = json.loads(item["payload_json"])
-            cluster = _rehydrate_cluster(
+        except Exception as exc:
+            await queue.mark_discarded(item["id"], f"corrupt payload: {exc}")
+            report["errors"].append({"phase": "payload", "error": str(exc)})
+            continue
+        try:
+            cluster = await asyncio.to_thread(
+                _rehydrate_cluster,
                 qdrant,
                 payload.get("member_ids", []),
                 payload.get("wing", "general"),
                 payload.get("room", "uncategorized"),
             )
         except Exception as exc:
-            await queue.mark_discarded(item["id"], f"rehydrate error: {exc}")
+            # Infrastructure error mid-drain (Qdrant died after preflight):
+            # put the item back and stop — never discard on infra failure.
+            await queue.reset_to_pending(item["id"])
+            report["aborted_infra"] = True
             report["errors"].append({"phase": "rehydrate", "error": str(exc)})
-            continue
+            logger.warning(
+                "Dream drain %s: rehydrate infra error — item reset to "
+                "pending, aborting drain: %s", run_id[:8], exc,
+            )
+            break
         report["drained"] += 1
         if len(cluster) < 2:
-            await queue.mark_discarded(item["id"], "stale: <2 live members")
+            # Normal lifecycle outcome (members deprecated since Sunday), not a
+            # failure — completed, so it doesn't surface on the dashboard
+            # errors view via query_failed (FM-5).
+            await queue.mark_completed(item["id"])
             report["stale_skipped"] += 1
+            logger.info(
+                "Dream drain %s: slice stale (<2 live members) — completed as "
+                "no-op", run_id[:8],
+            )
             continue
         pending.append((item, cluster))
 

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -1,21 +1,32 @@
 """Dream cycle — retroactive episodic memory consolidation.
 
-Sweeps the episodic_memory Qdrant collection on a schedule, identifies
-clusters of semantically near-duplicate memories, synthesizes each
-cluster into a single canonical memory via LLM, and soft-deletes the
-originals.  Analogy: the brain consolidates episodic memories during
-sleep.
+Sweeps the episodic_memory Qdrant collection, identifies clusters of
+semantically near-duplicate memories, synthesizes each into a single canonical
+memory via LLM, and soft-deletes the originals.  Analogy: the brain consolidates
+episodic memories during sleep.
+
+**Two cadences (weekly-cluster / daily-drain split):**
+- ``run()`` — WEEKLY. Does the expensive full-collection scan + clustering (the
+  ~3h cost) and the additive link/centrality layer, then persists a value-ranked
+  worklist of the top clusters (``_persist_worklist``). It no longer synthesizes.
+- ``run_synthesis_drain()`` — DAILY. Merges a bounded, value-ranked *slice* of
+  that worklist (``DAILY_SYNTHESIS_BUDGET`` clusters/day), so provider load is
+  spread across days instead of a single weekly spike. The low-value tail is
+  dropped and re-ranked by the next weekly re-cluster (value-ranked, not
+  exhaustive).
 
 **Key design decisions:**
 - Episodic only — knowledge_base excluded (low volume, upsert handles dedup)
 - No time-based confidence decay — evidence-based changes only
 - deprecated supplements invalid_at (independent dimensions)
-- Dry-run mode is the default until manually reviewed
-- Max 100 cluster merges per run (configurable)
-- Clusters > 10 memories flagged for manual review, not auto-merged
-- Capacity breaker: the synthesis sweep aborts after N consecutive provider
-  exhaustions and defers the rest, so a run during a provider outage fails
-  fast instead of grinding every cluster (bounds attempts, not just successes)
+- Merges are OFF by default (env ``GENESIS_DREAM_CYCLE_LIVE``); the additive
+  link/centrality layer in ``run()`` runs regardless of merge mode (it is
+  cheap non-destructive maintenance, not gated by dry-run)
+- ``DAILY_SYNTHESIS_BUDGET`` cluster merges per daily drain slice
+- Clusters > ``MAX_CLUSTER_SIZE`` flagged for manual review, not auto-merged
+- Capacity breaker: the synthesis loop aborts after N consecutive provider
+  exhaustions, so a run during a provider outage fails fast instead of grinding
+  every cluster (bounds attempts, not just successes)
 
 Spec: docs/superpowers/specs/2026-05-14-dream-cycle-design.md
 """
@@ -47,7 +58,6 @@ logger = logging.getLogger(__name__)
 
 SIMILARITY_THRESHOLD: float = 0.87
 MAX_CLUSTER_SIZE: int = 10
-MAX_MERGES_PER_RUN: int = 100
 MAX_BUCKET_SIZE: int = 500
 MIN_AVAILABLE_MB: int = 256
 _YIELD_EVERY: int = 50  # yield to event loop every N search calls
@@ -59,6 +69,19 @@ COLLECTION: str = "episodic_memory"
 # the loop bounded successes, not attempts, so a degraded run attempted ~782
 # clusters). Genuine quality blocks reset the streak.
 _CAPACITY_ABORT_THRESHOLD: int = 5
+
+# ── Weekly-cluster / daily-drain split ─────────────────────────────────────
+# Destructive synthesis is no longer done in one weekly pass. The weekly run
+# persists a value-ranked worklist; a daily drain job merges a bounded top-value
+# slice, spreading provider load across days (see run_synthesis_drain).
+WORKLIST_WORK_TYPE: str = "dream_synthesis_slice"
+# Max clusters merged per daily drain (→ ~2 LLM calls each). Absolute cap so one
+# slice can't exhaust providers at once — complements the reactive capacity
+# breaker (a % would scale the budget UP on backlog-heavy weeks, the worst time).
+DAILY_SYNTHESIS_BUDGET: int = 100
+# Max top-value clusters the weekly pass persists. Kept under the deferred-work
+# overflow alarm (resilience queue_overflow_threshold=1000) with headroom.
+WORKLIST_CAP: int = 500
 
 
 class ProvidersExhaustedError(Exception):
@@ -149,13 +172,15 @@ async def run(
     store: MemoryStore,
     dry_run: bool = True,
     similarity_threshold: float = SIMILARITY_THRESHOLD,
-    max_merges: int = MAX_MERGES_PER_RUN,
-    max_cluster_size: int = MAX_CLUSTER_SIZE,
 ) -> dict[str, Any]:
-    """Execute one dream cycle run.
+    """Execute one WEEKLY dream cycle pass.
 
-    Returns a report dict with cluster counts, merge stats, and any
-    errors encountered.
+    Scans + clusters the episodic collection, runs the additive link/centrality
+    layer, and persists a value-ranked synthesis worklist for the daily drain.
+    Destructive synthesis/deprecate is NOT done here — it moved to
+    ``run_synthesis_drain`` (bounded daily slices). ``dry_run`` still gates the
+    Sprint-2 destructive phases (link repair, entity resolution). Returns a
+    report dict with cluster counts, worklist-enqueue count, and any errors.
     """
     run_id = str(uuid.uuid4())
     report: dict[str, Any] = {
@@ -170,6 +195,7 @@ async def run(
         "shrink_gate_blocked": 0,
         "rollback_flagged": False,
         "aborted_capacity": False,
+        "worklist_enqueued": 0,
         "errors": [],
     }
 
@@ -250,18 +276,21 @@ async def run(
         logger.warning("Cross-wing scan failed", exc_info=True)
         report["cross_wing_findings"] = []
 
-    # Phase 3+4 — Synthesize and deprecate (live mode only)
-    if not dry_run:
-        await _synthesize_clusters(
-            all_clusters,
-            run_id=run_id,
-            qdrant=qdrant,
-            db=db,
-            router=router,
-            store=store,
-            max_merges=max_merges,
-            max_cluster_size=max_cluster_size,
-            report=report,
+    # Phase 3 — Persist the value-ranked synthesis worklist for the daily drain.
+    # Destructive synthesis/deprecate moved OUT of this weekly pass into
+    # run_synthesis_drain (bounded daily slices). This enqueue runs in ALL modes:
+    # clustering + worklist maintenance IS the weekly job; the merge decision is
+    # gated on the drain side. Supersedes last week's worklist (a fresh full
+    # re-cluster is authoritative).
+    try:
+        report["worklist_enqueued"] = await _persist_worklist(
+            db, all_clusters, weekly_run_id=run_id, cap=WORKLIST_CAP,
+        )
+    except Exception as exc:
+        report["errors"].append({"phase": "worklist_persist", "error": str(exc)})
+        logger.warning(
+            "Dream cycle %s: worklist persist failed: %s",
+            run_id[:8], exc, exc_info=True,
         )
 
     # ── Sprint 2 phases (each handles dry_run internally) ──────────────
@@ -318,6 +347,184 @@ async def run(
         report["errors"].append({"phase": "centrality", "error": str(exc)})
         logger.warning("Dream phase centrality failed: %s", exc, exc_info=True)
 
+    return report
+
+
+# ── Worklist persistence + daily synthesis drain ───────────────────────────
+
+
+def _rank_and_cap_clusters(
+    clusters: list[list[dict]], *, cap: int,
+) -> list[list[dict]]:
+    """Rank clusters by VALUE (size desc = dedup payoff) and keep the top ``cap``.
+
+    Size is the v1 value signal (matches the existing synthesis sort). The daily
+    drain works this list top-down within its budget, so the highest-value merges
+    happen first; the low-value tail is dropped and re-ranked next weekly cycle.
+    (A similarity tiebreak is a deferred enhancement — the union edge-scores are
+    computed during clustering but not currently retained past ``_cluster_bucket``.)
+    """
+    return sorted(clusters, key=len, reverse=True)[:cap]
+
+
+async def _persist_worklist(
+    db: aiosqlite.Connection,
+    clusters: list[list[dict]],
+    *,
+    weekly_run_id: str,
+    cap: int = WORKLIST_CAP,
+) -> int:
+    """Persist the top-value clusters as the daily-drain worklist. Returns count.
+
+    Supersedes any prior ``dream_synthesis_slice`` rows (a fresh full re-cluster
+    is authoritative) via an explicit synchronous supersede — NOT a staleness
+    policy, so it never races the recovery expiry cadence. Enqueues in value order
+    under a single priority so the FIFO-within-priority drain order == value order.
+    Stores only member ids + (wing, room) + weekly_run_id; the drain re-fetches
+    live payloads (rehydrate), so a stale snapshot can't merge deprecated members.
+    """
+    from genesis.resilience.deferred_work import DRAIN, MEMORY_OPS, DeferredWorkQueue
+
+    queue = DeferredWorkQueue(db)
+    superseded = await queue.supersede(WORKLIST_WORK_TYPE)
+    ranked = _rank_and_cap_clusters(clusters, cap=cap)
+
+    enqueued = 0
+    for cluster in ranked:
+        payload = json.dumps({
+            "member_ids": [item["id"] for item in cluster],
+            "wing": cluster[0].get("wing", "general"),
+            "room": cluster[0].get("room", "uncategorized"),
+            "weekly_run_id": weekly_run_id,
+            "value_score": len(cluster),
+        })
+        item_id = await queue.enqueue(
+            WORKLIST_WORK_TYPE, None, MEMORY_OPS, payload,
+            "dream_cycle weekly synthesis worklist",
+            staleness_policy=DRAIN,
+        )
+        if item_id is not None:
+            enqueued += 1
+
+    logger.info(
+        "Dream cycle %s: worklist superseded %d prior, enqueued %d/%d clusters",
+        weekly_run_id[:8], superseded, enqueued, len(ranked),
+    )
+    return enqueued
+
+
+def _rehydrate_cluster(
+    qdrant: QdrantClient, member_ids: list[str], wing: str, room: str,
+) -> list[dict]:
+    """Re-fetch a persisted cluster's live members from Qdrant.
+
+    A worklist slice stores only ids; by drain time members may have been
+    deprecated (by an earlier slice or entity resolution). Fetch current payloads,
+    drop deprecated members, and return survivors in the shape
+    ``_synthesize_and_deprecate`` consumes. The caller skips a cluster with < 2
+    live members (nothing left to consolidate). Union-find components are disjoint,
+    so a member belongs to exactly one cluster — no cross-cluster double-merge.
+    """
+    from genesis.qdrant.collections import get_point
+
+    live: list[dict] = []
+    for mid in member_ids:
+        point = get_point(qdrant, collection=COLLECTION, point_id=mid)
+        if point is None:
+            continue
+        if point["payload"].get("deprecated") is True:
+            continue
+        live.append({
+            "id": point["id"], "payload": point["payload"],
+            "wing": wing, "room": room,
+        })
+    return live
+
+
+async def run_synthesis_drain(
+    *,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
+    router: Router,
+    store: MemoryStore,
+    budget: int = DAILY_SYNTHESIS_BUDGET,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Drain a bounded, value-ranked slice of the synthesis worklist (runs DAILY).
+
+    Pulls up to ``budget`` clusters (highest-value first — the weekly pass enqueued
+    them in value order), rehydrates each against live Qdrant, then:
+      * SHADOW (``dry_run``) — exercises the full queue + rehydration lifecycle but
+        performs NO LLM calls and NO memory mutations (reports what it WOULD merge).
+      * LIVE — synthesizes+deprecates via the same capacity-breaker loop as the old
+        weekly path (``_synthesize_clusters`` with ``max_merges=budget``).
+
+    Items attempted this slice are marked completed regardless of per-cluster
+    outcome — unmerged/blocked/aborted clusters simply re-surface in next week's
+    re-cluster (the design is value-ranked, not exhaustive).
+    """
+    from genesis.resilience.deferred_work import DeferredWorkQueue
+
+    run_id = str(uuid.uuid4())
+    report: dict[str, Any] = {
+        "run_id": run_id, "dry_run": dry_run,
+        "drained": 0, "stale_skipped": 0, "would_merge": 0,
+        "clusters_merged": 0, "clusters_skipped_large": 0,
+        "memories_deprecated": 0, "adversarial_blocked": 0,
+        "shrink_gate_blocked": 0, "rollback_flagged": False,
+        "aborted_capacity": False, "errors": [],
+    }
+
+    queue = DeferredWorkQueue(db)
+    pending: list[tuple[dict, list[dict]]] = []
+    for _ in range(budget):
+        item = await queue.next_pending(work_type=WORKLIST_WORK_TYPE)
+        if item is None:
+            break
+        await queue.mark_processing(item["id"])
+        try:
+            payload = json.loads(item["payload_json"])
+            cluster = _rehydrate_cluster(
+                qdrant,
+                payload.get("member_ids", []),
+                payload.get("wing", "general"),
+                payload.get("room", "uncategorized"),
+            )
+        except Exception as exc:
+            await queue.mark_discarded(item["id"], f"rehydrate error: {exc}")
+            report["errors"].append({"phase": "rehydrate", "error": str(exc)})
+            continue
+        report["drained"] += 1
+        if len(cluster) < 2:
+            await queue.mark_discarded(item["id"], "stale: <2 live members")
+            report["stale_skipped"] += 1
+            continue
+        pending.append((item, cluster))
+
+    if dry_run:
+        for item, cluster in pending:
+            report["would_merge"] += 1
+            logger.info(
+                "Dream drain %s SHADOW: would merge cluster of %d (%s/%s)",
+                run_id[:8], len(cluster),
+                cluster[0].get("wing", "?"), cluster[0].get("room", "?"),
+            )
+            await queue.mark_completed(item["id"])
+    elif pending:
+        await _synthesize_clusters(
+            [c for _, c in pending],
+            run_id=run_id, qdrant=qdrant, db=db, router=router, store=store,
+            max_merges=budget, max_cluster_size=MAX_CLUSTER_SIZE, report=report,
+        )
+        for item, _ in pending:
+            await queue.mark_completed(item["id"])
+
+    logger.info(
+        "Dream drain %s (%s): drained=%d stale=%d would_merge=%d merged=%d deprecated=%d",
+        run_id[:8], "SHADOW" if dry_run else "LIVE",
+        report["drained"], report["stale_skipped"], report["would_merge"],
+        report["clusters_merged"], report["memories_deprecated"],
+    )
     return report
 
 

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -491,9 +491,9 @@ _CALL_SITE_META: dict[str, dict] = {
         "status_reason": "V4_PLACEHOLDER",
     },
     "dream_cycle_synthesis": {
-        "description": "Dream cycle cluster-merge synthesis. Consolidates near-duplicate episodic memories into canonical records. Weekly Sunday 4am via CronTrigger.",
+        "description": "Dream cycle cluster-merge synthesis. Consolidates near-duplicate episodic memories into canonical records. Fires from the DAILY synthesis drain (dream_synthesis_drain, 8am) in live mode — the weekly Sunday 4am job only clusters and persists the worklist. Drain is SHADOW (no LLM calls) until the T2-D PR2 live flip.",
         "category": "consolidation",
-        "frequency": "Weekly batch (Sunday 4am, max 100 clusters/run)",
+        "frequency": "Daily drain slices (8am, max 100 clusters/day; live-gated)",
         "model_tier": "slm",
         "wired": True,
     },
@@ -508,7 +508,7 @@ _CALL_SITE_META: dict[str, dict] = {
     "dream_cycle_synthesis_challenge": {
         "description": "Adversarial challenge of dream cycle synthesis output. Different provider from synthesis (Kimi challenges DeepSeek) to ensure model independence. Blocks deprecation when information loss detected.",
         "category": "consolidation",
-        "frequency": "Weekly batch (Sunday 4am, one per cluster synthesized)",
+        "frequency": "Daily drain slices (8am, one per cluster synthesized; live-gated)",
         "model_tier": "slm",
         "wired": True,
         "see_also": ["dream_cycle_synthesis"],

--- a/src/genesis/resilience/deferred_work.py
+++ b/src/genesis/resilience/deferred_work.py
@@ -151,6 +151,18 @@ class DeferredWorkQueue:
         """Count pending items, optionally filtered by work_type."""
         return await crud.count_pending(self._db, work_type=work_type)
 
+    async def supersede(self, work_type: str) -> int:
+        """Delete all non-in-flight rows for a work_type (supersede a batch).
+
+        Removes pending/completed/discarded/expired rows for ``work_type`` but
+        leaves any ``processing`` item alone. For ephemeral batch worklists that
+        a fresh producer run fully replaces (e.g. the weekly dream-cycle synthesis
+        worklist). Returns the count removed.
+        """
+        return await crud.delete_by_work_type(
+            self._db, work_type=work_type, exclude_status="processing",
+        )
+
     async def drain_by_priority(self, limit: int = 10) -> list[dict]:
         """Return up to `limit` pending items ordered by priority."""
         return await crud.drain_by_priority(self._db, limit=limit)

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -393,12 +393,24 @@ class SurplusScheduler:
                 max_instances=1,
                 misfire_grace_time=3600,
             )
-        # Dream cycle: weekly Sunday 4am — episodic memory consolidation
+        # Dream cycle: weekly Sunday 4am — clustering + worklist persist
         from apscheduler.triggers.cron import CronTrigger
         self._scheduler.add_job(
             self.run_dream_cycle,
             CronTrigger(day_of_week="sun", hour=4, timezone=user_timezone()),
             id="dream_cycle",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+        # Dream synthesis drain: daily 8am — merges a bounded, value-ranked
+        # slice of the weekly worklist (SHADOW until the user-gated live flip),
+        # spreading synthesis load across the week instead of a Sunday spike.
+        # 8am leaves ~4h after the weekly scan starts; if the weekly is still
+        # running, the drain skips via the heavy_workload guard.
+        self._scheduler.add_job(
+            self.run_dream_synthesis_drain,
+            CronTrigger(hour=8, timezone=user_timezone()),
+            id="dream_synthesis_drain",
             max_instances=1,
             misfire_grace_time=3600,
         )
@@ -1356,10 +1368,14 @@ class SurplusScheduler:
                 pass
 
     async def run_dream_cycle(self) -> None:
-        """Run weekly episodic memory consolidation (dream cycle).
+        """Run the WEEKLY dream-cycle clustering pass (Sunday 4am).
 
-        Dry-run by default — set ``dream_cycle_live`` in Genesis config
-        to enable live merges after reviewing a dry-run report.
+        Scans + clusters episodic memory, runs the additive link/centrality
+        layer, and persists the value-ranked synthesis worklist that
+        ``run_dream_synthesis_drain`` consumes daily. Destructive phases
+        (entity resolution, link repair) are dry-run by default — set the
+        ``GENESIS_DREAM_CYCLE_LIVE=1`` environment variable (there is NO
+        config-file key for this) after reviewing dry-run reports.
         """
         try:
             from genesis.runtime import GenesisRuntime
@@ -1423,10 +1439,12 @@ class SurplusScheduler:
                     source="dream_cycle",
                     type="dream_cycle_report",
                     content=(
-                        f"Dream cycle {'DRY RUN' if dry_run else 'LIVE'}: "
+                        f"Dream cycle {'DRY RUN' if dry_run else 'LIVE'} "
+                        f"(weekly clustering): "
                         f"{report.get('clusters_found', 0)} clusters found, "
-                        f"{report.get('clusters_merged', 0)} merged, "
-                        f"{report.get('memories_deprecated', 0)} deprecated, "
+                        f"{report.get('worklist_enqueued', 0)} enqueued for "
+                        f"daily drain, "
+                        f"{report.get('oversize_flagged', 0)} oversize flagged, "
                         f"{len(report.get('errors', []))} errors"
                     ),
                     priority="low",
@@ -1452,14 +1470,124 @@ class SurplusScheduler:
                     rec_err, exc,
                 )
         finally:
-            # Always clear heavy workload flag, even on failure.
+            # Always clear heavy workload flag, even on failure — but ONLY if
+            # this job set it: an early return above fires before the flag is
+            # set, and an unconditional clear would clobber a flag held by the
+            # daily synthesis drain (the two dream jobs share the flag).
             # Use the captured `rt` reference from the try block above —
             # re-looking up GenesisRuntime.instance() here introduces a
             # second failure mode during shutdown races.  If `rt` is
             # unbound (import/lookup failed), NameError is caught below.
             try:
-                rt._heavy_workload = None
-                rt._heavy_workload_since = None
+                if rt._heavy_workload == "dream_cycle":
+                    rt._heavy_workload = None
+                    rt._heavy_workload_since = None
+            except Exception:
+                pass
+
+    async def run_dream_synthesis_drain(self) -> None:
+        """Drain a bounded, value-ranked slice of the dream-cycle synthesis
+        worklist (DAILY 8am — the weekly clustering job persists the worklist).
+
+        SHADOW mode: exercises the full queue + rehydration lifecycle but makes
+        no LLM calls and no memory mutations, reporting what it WOULD merge.
+        The live flip (honoring ``GENESIS_DREAM_CYCLE_LIVE``) is a separate,
+        user-gated change (T2-D PR2).
+        """
+        try:
+            from genesis.runtime import GenesisRuntime
+            rt = GenesisRuntime.instance()
+            if rt.paused:
+                logger.debug("Dream synthesis drain skipped (Genesis paused)")
+                return
+            if rt.heavy_workload:
+                # Weekly clustering (or another batch job) still running —
+                # don't overlap; today's slice re-surfaces tomorrow.
+                logger.info(
+                    "Dream synthesis drain skipped — heavy workload active (%s)",
+                    rt.heavy_workload,
+                )
+                return
+        except Exception:
+            logger.warning(
+                "Pause check failed — skipping dream synthesis drain",
+                exc_info=True,
+            )
+            return
+
+        with contextlib.suppress(Exception):
+            GenesisRuntime.instance().record_job_start("dream_synthesis_drain")
+
+        try:
+            from genesis.memory import dream_cycle
+
+            store = rt.memory_store
+            if rt.db is None or store is None or rt.router is None:
+                logger.warning(
+                    "Dream synthesis drain skipped — missing runtime dependencies"
+                )
+                return
+            qdrant = store.qdrant_client
+            if qdrant is None:
+                logger.warning(
+                    "Dream synthesis drain skipped — MemoryStore has no Qdrant client"
+                )
+                return
+
+            rt._heavy_workload = "dream_synthesis_drain"
+            rt._heavy_workload_since = datetime.now(UTC)
+
+            # SHADOW hardwired: the live flip is a separate user-gated change.
+            report = await dream_cycle.run_synthesis_drain(
+                qdrant=qdrant, db=rt.db, router=rt.router, store=store,
+                dry_run=True,
+            )
+
+            try:
+                import uuid as _uuid  # noqa: PLC0415
+
+                from genesis.db.crud import observations as obs_crud
+                await obs_crud.create(
+                    rt.db,
+                    id=str(_uuid.uuid4()),
+                    source="dream_cycle",
+                    type="dream_synthesis_drain_report",
+                    content=(
+                        f"Dream synthesis drain "
+                        f"{'SHADOW' if report.get('dry_run') else 'LIVE'}: "
+                        f"{report.get('drained', 0)} drained, "
+                        f"{report.get('would_merge', 0)} would merge, "
+                        f"{report.get('stale_skipped', 0)} stale, "
+                        f"{len(report.get('errors', []))} errors"
+                    ),
+                    priority="low",
+                    created_at=datetime.now(UTC).isoformat(),
+                )
+            except Exception:
+                pass
+
+            logger.info("Dream synthesis drain complete: %s", report)
+            with contextlib.suppress(Exception):
+                GenesisRuntime.instance().record_job_success("dream_synthesis_drain")
+        except Exception as exc:
+            logger.exception("Dream synthesis drain failed: %s", exc)
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure(
+                    "dream_synthesis_drain", str(exc)[:500],
+                )
+            except Exception as rec_err:
+                logger.error(
+                    "Failed to record dream_synthesis_drain failure: %s "
+                    "(original error: %s)",
+                    rec_err, exc,
+                )
+        finally:
+            # Clear only if this job set the flag (see run_dream_cycle note).
+            try:
+                if rt._heavy_workload == "dream_synthesis_drain":
+                    rt._heavy_workload = None
+                    rt._heavy_workload_since = None
             except Exception:
                 pass
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -1508,19 +1508,9 @@ class SurplusScheduler:
                     rt.heavy_workload,
                 )
                 return
-        except Exception:
-            logger.warning(
-                "Pause check failed — skipping dream synthesis drain",
-                exc_info=True,
-            )
-            return
-
-        with contextlib.suppress(Exception):
-            GenesisRuntime.instance().record_job_start("dream_synthesis_drain")
-
-        try:
-            from genesis.memory import dream_cycle
-
+            # Dependency checks BEFORE record_job_start — a skip on a
+            # misconfigured deploy must not leave the job perpetually
+            # "started" in job_health (masks real stuck-job detection).
             store = rt.memory_store
             if rt.db is None or store is None or rt.router is None:
                 logger.warning(
@@ -1533,6 +1523,18 @@ class SurplusScheduler:
                     "Dream synthesis drain skipped — MemoryStore has no Qdrant client"
                 )
                 return
+        except Exception:
+            logger.warning(
+                "Pause check failed — skipping dream synthesis drain",
+                exc_info=True,
+            )
+            return
+
+        with contextlib.suppress(Exception):
+            GenesisRuntime.instance().record_job_start("dream_synthesis_drain")
+
+        try:
+            from genesis.memory import dream_cycle
 
             rt._heavy_workload = "dream_synthesis_drain"
             rt._heavy_workload_since = datetime.now(UTC)

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,15 +12,20 @@ from genesis.memory.dream_cycle import (
     _CAPACITY_ABORT_THRESHOLD,
     MAX_BUCKET_SIZE,
     MAX_CLUSTER_SIZE,
+    WORKLIST_WORK_TYPE,
     _build_synthesis_prompt,
     _CapacityBreaker,
     _parse_synthesis_response,
+    _persist_worklist,
+    _rank_and_cap_clusters,
     _read_mem_available_mb,
     _size_distribution,
     _synthesize_clusters,
     _UnionFind,
     run,
+    run_synthesis_drain,
 )
+from genesis.resilience.deferred_work import DeferredWorkQueue
 
 
 def _fake_cluster(n: int = 2, wing: str = "memory", room: str = "store"):
@@ -249,7 +255,7 @@ class TestSizeDistribution:
 class TestDryRun:
     @pytest.mark.asyncio
     async def test_dry_run_returns_report_without_changes(self):
-        """Dry run computes clusters but doesn't write anything."""
+        """Dry run clusters + persists the worklist but stores no memories."""
         mock_qdrant = MagicMock()
         mock_db = AsyncMock()
         mock_router = AsyncMock()
@@ -257,7 +263,12 @@ class TestDryRun:
 
         with patch(_SCROLL) as mock_scroll, \
              patch(_SEARCH) as mock_search, \
-             patch(_BATCH_VEC) as mock_vec:
+             patch(_BATCH_VEC) as mock_vec, \
+             patch(
+                 "genesis.memory.dream_cycle._persist_worklist",
+                 new_callable=AsyncMock,
+                 return_value={"enqueued": 1, "oversize_flagged": 0, "superseded": 0},
+             ) as mock_persist:
             mock_scroll.return_value = (
                 [
                     {"id": "p1", "payload": {"wing": "memory", "room": "store", "content": "fact A", "confidence": 0.9}},
@@ -280,7 +291,13 @@ class TestDryRun:
 
         assert report["dry_run"] is True
         assert report["clusters_found"] >= 1
-        assert report["clusters_merged"] == 0
+        # Worklist maintenance runs in ALL modes — clustering + enqueue IS the
+        # weekly job; the merge decision is gated on the drain side.
+        mock_persist.assert_awaited_once()
+        assert report["worklist_enqueued"] == 1
+        # Synthesis-outcome keys moved to the drain report — a permanent
+        # "0 merged" here must not masquerade as a synthesis result.
+        assert "clusters_merged" not in report
         # Consolidation must not write any new memories in dry_run
         mock_store.store.assert_not_called()
         # Note: Sprint 2 phases (link repair, entity resolution, etc.) may
@@ -288,105 +305,277 @@ class TestDryRun:
         # The key assertion is that no synthesized memories were stored.
 
 
-class TestLiveRun:
+class TestSynthesizeClustersSkipsLarge:
     @pytest.mark.asyncio
-    async def test_live_run_synthesizes_and_deprecates(self):
-        """Live run calls LLM, stores synthesis, deprecates originals."""
-        mock_qdrant = MagicMock()
-        mock_db = AsyncMock()
-        mock_db.execute = AsyncMock()
-        mock_db.commit = AsyncMock()
-        mock_router = AsyncMock()
-        mock_store = AsyncMock()
-        mock_store.store = AsyncMock(return_value="new-synth-id")
-        mock_store.linker = None
+    async def test_oversize_cluster_skipped_no_llm(self):
+        """Defense-in-depth: even if an oversize cluster reaches synthesis
+        (worklist excludes them at enqueue), it is skipped without LLM calls."""
+        router = AsyncMock()
+        report = _fresh_report()
+        await _synthesize_clusters(
+            [_fake_cluster(MAX_CLUSTER_SIZE + 2)],
+            run_id="t", qdrant=MagicMock(), db=AsyncMock(),
+            router=router, store=AsyncMock(),
+            max_merges=100, max_cluster_size=MAX_CLUSTER_SIZE, report=report,
+        )
+        assert report["clusters_skipped_large"] == 1
+        assert report["clusters_merged"] == 0
+        router.route_call.assert_not_called()
 
-        synthesis_json = json.dumps({
-            "content": "Merged fact A+B",
-            "tags": ["test"],
-            "confidence": 0.9,
-            "memory_class": "fact",
-            "wing": "memory",
-            "room": "store",
-            "synthesis_notes": "combined",
-        })
-        adversarial_json = json.dumps({"verdict": "PASS"})
-        mock_router.route_call = AsyncMock(
-            side_effect=[
-                MagicMock(success=True, content=synthesis_json),
-                MagicMock(success=True, content=adversarial_json),
-            ],
+
+# ── Worklist persistence (weekly → queue) ───────────────────────────────
+
+
+def _clusters_of_sizes(*sizes: int):
+    return [_fake_cluster(n, room=f"r{i}") for i, n in enumerate(sizes)]
+
+
+class TestWorklist:
+    @pytest.mark.asyncio
+    async def test_enqueues_value_ordered_and_supersedes(self, db):
+        """Slices drain biggest-first; a fresh weekly run replaces the old list."""
+        queue = DeferredWorkQueue(db)
+        result = await _persist_worklist(
+            db, _clusters_of_sizes(2, 5, 3), weekly_run_id="week-1",
+        )
+        assert result == {"enqueued": 3, "oversize_flagged": 0, "superseded": 0}
+        assert await queue.count_pending(work_type=WORKLIST_WORK_TYPE) == 3
+
+        # FIFO-within-priority == enqueue order == size desc
+        first = await queue.next_pending(work_type=WORKLIST_WORK_TYPE)
+        payload = json.loads(first["payload_json"])
+        assert len(payload["member_ids"]) == 5
+        assert payload["weekly_run_id"] == "week-1"
+        assert payload["value_score"] == 5
+
+        # A fresh weekly re-cluster is authoritative: old rows deleted
+        result2 = await _persist_worklist(
+            db, _clusters_of_sizes(4), weekly_run_id="week-2",
+        )
+        assert result2["superseded"] == 3
+        assert await queue.count_pending(work_type=WORKLIST_WORK_TYPE) == 1
+        only = await queue.next_pending(work_type=WORKLIST_WORK_TYPE)
+        assert json.loads(only["payload_json"])["weekly_run_id"] == "week-2"
+
+    @pytest.mark.asyncio
+    async def test_top_k_cap(self, db):
+        """Only the top-K by value are persisted; the tail is dropped."""
+        queue = DeferredWorkQueue(db)
+        result = await _persist_worklist(
+            db, _clusters_of_sizes(2, 6, 3, 5, 4), weekly_run_id="w", cap=3,
+        )
+        assert result["enqueued"] == 3
+        sizes = []
+        for _ in range(3):
+            item = await queue.next_pending(work_type=WORKLIST_WORK_TYPE)
+            sizes.append(json.loads(item["payload_json"])["value_score"])
+            await queue.mark_completed(item["id"])
+        assert sizes == [6, 5, 4]
+
+    @pytest.mark.asyncio
+    async def test_oversize_excluded_and_flagged(self, db):
+        """Clusters > MAX_CLUSTER_SIZE never enter the worklist (FM-1) — they
+        would rank FIRST (size desc) yet be unmergeable, wasting drain budget
+        weekly and making shadow reports unfaithful to live behavior."""
+        queue = DeferredWorkQueue(db)
+        clusters = [_fake_cluster(MAX_CLUSTER_SIZE + 3), _fake_cluster(3)]
+        result = await _persist_worklist(db, clusters, weekly_run_id="w")
+        assert result["enqueued"] == 1
+        assert result["oversize_flagged"] == 1
+        item = await queue.next_pending(work_type=WORKLIST_WORK_TYPE)
+        assert len(json.loads(item["payload_json"])["member_ids"]) == 3
+
+    def test_rank_and_cap_excludes_oversize(self):
+        ranked = _rank_and_cap_clusters(
+            _clusters_of_sizes(12, 4, 2), cap=10, max_cluster_size=10,
+        )
+        assert [len(c) for c in ranked] == [4, 2]
+
+
+# ── Daily synthesis drain ────────────────────────────────────────────────
+
+
+def _drain_qdrant(points_by_id: dict[str, dict]):
+    """Qdrant mock for the drain: healthy preflight + batch retrieve that
+    returns only the ids present in ``points_by_id`` (Qdrant semantics)."""
+    q = MagicMock()
+
+    def _retrieve(*, collection_name, ids, with_payload, with_vectors):
+        return [
+            SimpleNamespace(id=i, payload=points_by_id[i])
+            for i in ids if i in points_by_id
+        ]
+
+    q.retrieve = MagicMock(side_effect=_retrieve)
+    return q
+
+
+def _live_points(cluster) -> dict[str, dict]:
+    return {item["id"]: dict(item["payload"]) for item in cluster}
+
+
+class TestSynthesisDrain:
+    @pytest.mark.asyncio
+    async def test_shadow_reports_would_merge_without_mutation(self, db):
+        """SHADOW exercises the full queue lifecycle: no LLM, no writes."""
+        clusters = _clusters_of_sizes(3, 2)
+        await _persist_worklist(db, clusters, weekly_run_id="w")
+        points = {**_live_points(clusters[0]), **_live_points(clusters[1])}
+        router = AsyncMock()
+        store = AsyncMock()
+
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(points), db=db, router=router, store=store,
+            budget=10, dry_run=True,
         )
 
-        with patch(_SCROLL) as mock_scroll, \
-             patch(_SEARCH) as mock_search, \
-             patch(_BATCH_VEC) as mock_vec, \
-             patch(_UPDATE) as mock_update:
-            mock_scroll.return_value = (
-                [
-                    {"id": "p1", "payload": {"wing": "memory", "room": "store", "content": "fact A", "confidence": 0.9}},
-                    {"id": "p2", "payload": {"wing": "memory", "room": "store", "content": "fact A v2", "confidence": 0.8}},
-                ],
-                None,
-            )
-            mock_search.return_value = [
-                {"id": "p2", "score": 0.92, "payload": {}},
-            ]
-            mock_vec.return_value = {"p1": [0.1] * 768, "p2": [0.1] * 768}
+        assert report["dry_run"] is True
+        assert report["drained"] == 2
+        assert report["would_merge"] == 2
+        assert report["clusters_merged"] == 0
+        router.route_call.assert_not_called()
+        store.store.assert_not_called()
+        queue = DeferredWorkQueue(db)
+        assert await queue.count_pending(work_type=WORKLIST_WORK_TYPE) == 0
 
-            report = await run(
-                qdrant=mock_qdrant,
-                db=mock_db,
-                router=mock_router,
-                store=mock_store,
-                dry_run=False,
+    @pytest.mark.asyncio
+    async def test_drain_honors_budget(self, db):
+        """At most ``budget`` slices are consumed per drain."""
+        clusters = _clusters_of_sizes(2, 2, 2, 2, 2)
+        await _persist_worklist(db, clusters, weekly_run_id="w")
+        points: dict[str, dict] = {}
+        for c in clusters:
+            points.update(_live_points(c))
+
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(points), db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=2, dry_run=True,
+        )
+
+        assert report["drained"] == 2
+        queue = DeferredWorkQueue(db)
+        assert await queue.count_pending(work_type=WORKLIST_WORK_TYPE) == 3
+
+    @pytest.mark.asyncio
+    async def test_stale_slice_completed_not_discarded(self, db):
+        """<2 live members = normal lifecycle no-op: completed, NOT discarded —
+        discarded rows surface as failures on the dashboard errors view (FM-5)."""
+        cluster = _fake_cluster(2)
+        await _persist_worklist(db, [cluster], weekly_run_id="w")
+        points = _live_points(cluster)
+        points[cluster[0]["id"]]["deprecated"] = True  # one member deprecated
+
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(points), db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+
+        assert report["stale_skipped"] == 1
+        assert report["would_merge"] == 0
+        cursor = await db.execute(
+            "SELECT status FROM deferred_work_queue WHERE work_type = ?",
+            (WORKLIST_WORK_TYPE,),
+        )
+        rows = await cursor.fetchall()
+        assert [r["status"] for r in rows] == ["completed"]
+
+    @pytest.mark.asyncio
+    async def test_qdrant_preflight_abort_consumes_nothing(self, db):
+        """Qdrant down at drain start: abort without touching the worklist —
+        an outage must not mass-discard the week's top-value slices (FM-2)."""
+        await _persist_worklist(db, _clusters_of_sizes(2), weekly_run_id="w")
+        qdrant = MagicMock()
+        qdrant.get_collection = MagicMock(side_effect=ConnectionError("down"))
+
+        report = await run_synthesis_drain(
+            qdrant=qdrant, db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+
+        assert report["aborted_infra"] is True
+        assert report["drained"] == 0
+        queue = DeferredWorkQueue(db)
+        assert await queue.count_pending(work_type=WORKLIST_WORK_TYPE) == 1
+
+    @pytest.mark.asyncio
+    async def test_mid_drain_infra_error_resets_item(self, db):
+        """Qdrant dies after preflight: in-flight item goes back to pending
+        and the drain aborts — never discard on infrastructure failure (FM-2)."""
+        await _persist_worklist(db, _clusters_of_sizes(2), weekly_run_id="w")
+        qdrant = MagicMock()
+        qdrant.retrieve = MagicMock(side_effect=ConnectionError("died mid-drain"))
+
+        report = await run_synthesis_drain(
+            qdrant=qdrant, db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+
+        assert report["aborted_infra"] is True
+        assert report["drained"] == 0
+        queue = DeferredWorkQueue(db)
+        assert await queue.count_pending(work_type=WORKLIST_WORK_TYPE) == 1
+
+    @pytest.mark.asyncio
+    async def test_superseded_item_skipped(self, db):
+        """mark_processing returning False (row deleted by a racing weekly
+        supersede) skips the item instead of processing a ghost (FM-10)."""
+        cluster = _fake_cluster(2)
+        await _persist_worklist(db, [cluster], weekly_run_id="w")
+
+        with patch.object(
+            DeferredWorkQueue, "mark_processing",
+            new_callable=AsyncMock, return_value=False,
+        ):
+            report = await run_synthesis_drain(
+                qdrant=_drain_qdrant(_live_points(cluster)), db=db,
+                router=AsyncMock(), store=AsyncMock(), budget=3, dry_run=True,
+            )
+
+        assert report["drained"] == 0
+        assert report["would_merge"] == 0
+
+    @pytest.mark.asyncio
+    async def test_live_drain_synthesizes_and_deprecates(self, db):
+        """LIVE drain: rehydrates, calls LLM, stores synthesis, deprecates
+        originals, and completes the queue item (the old weekly live path,
+        now driven from the drain)."""
+        cluster = _fake_cluster(2)
+        await _persist_worklist(db, [cluster], weekly_run_id="w")
+
+        store = AsyncMock()
+        store.store = AsyncMock(return_value="new-synth-id")
+        store.linker = None
+        synthesis_json = json.dumps({
+            "content": "Merged fact 0 and fact 1 into one canonical record",
+            "tags": ["test"], "confidence": 0.9, "memory_class": "fact",
+            "wing": "memory", "room": "store", "synthesis_notes": "combined",
+        })
+        adversarial_json = json.dumps({"verdict": "PASS"})
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=[
+            MagicMock(success=True, content=synthesis_json),
+            MagicMock(success=True, content=adversarial_json),
+        ])
+
+        with patch(_UPDATE) as mock_update:
+            report = await run_synthesis_drain(
+                qdrant=_drain_qdrant(_live_points(cluster)), db=db,
+                router=router, store=store, budget=10, dry_run=False,
             )
 
         assert report["dry_run"] is False
-        assert report["clusters_merged"] >= 1
-        assert report["memories_deprecated"] >= 2
-        mock_store.store.assert_called_once()
-        assert mock_store.store.call_args[1]["source_pipeline"] == "dream_cycle"
-        # 1 for synthesized_from + 2 for deprecated originals
+        assert report["clusters_merged"] == 1
+        assert report["memories_deprecated"] == 2
+        store.store.assert_called_once()
+        assert store.store.call_args[1]["source_pipeline"] == "dream_cycle"
+        # 1 synthesized_from + 2 deprecated originals
         assert mock_update.call_count >= 3
-
-    @pytest.mark.asyncio
-    async def test_skips_large_clusters(self):
-        """Clusters > MAX_CLUSTER_SIZE are skipped."""
-        mock_qdrant = MagicMock()
-        mock_db = AsyncMock()
-        mock_router = AsyncMock()
-        mock_store = AsyncMock()
-        mock_store.linker = None
-
-        large_cluster_points = [
-            {"id": f"p{i}", "payload": {"wing": "memory", "room": "store", "content": f"fact {i}", "confidence": 0.5}}
-            for i in range(MAX_CLUSTER_SIZE + 5)
-        ]
-
-        with patch(_SCROLL) as mock_scroll, \
-             patch(_SEARCH) as mock_search, \
-             patch(_BATCH_VEC) as mock_vec:
-            mock_scroll.return_value = (large_cluster_points, None)
-            mock_search.side_effect = lambda *a, **kw: [
-                {"id": p["id"], "score": 0.95, "payload": {}}
-                for p in large_cluster_points
-            ]
-            mock_vec.return_value = {
-                p["id"]: [0.1] * 768 for p in large_cluster_points
-            }
-
-            report = await run(
-                qdrant=mock_qdrant,
-                db=mock_db,
-                router=mock_router,
-                store=mock_store,
-                dry_run=False,
-            )
-
-        assert report["clusters_skipped_large"] >= 1
-        assert report["clusters_merged"] == 0
-        mock_store.store.assert_not_called()
+        cursor = await db.execute(
+            "SELECT status FROM deferred_work_queue WHERE work_type = ?",
+            (WORKLIST_WORK_TYPE,),
+        )
+        rows = await cursor.fetchall()
+        assert [r["status"] for r in rows] == ["completed"]
 
 
 # ── Rollback ─────────────────────────────────────────────────────────────

--- a/tests/test_resilience/test_deferred_work.py
+++ b/tests/test_resilience/test_deferred_work.py
@@ -10,6 +10,7 @@ from genesis.resilience.deferred_work import (
     DISCARD,
     DRAIN,
     FOREGROUND,
+    MEMORY_OPS,
     MORNING_REPORT,
     REFLECTION,
     REFRESH,
@@ -181,3 +182,35 @@ class TestCountPending:
         await queue.enqueue("b", None, SURPLUS, '{}', "reason")
         assert await queue.count_pending(work_type="a") == 2
         assert await queue.count_pending(work_type="b") == 1
+
+
+class TestSupersede:
+    @pytest.mark.asyncio
+    async def test_deletes_batch_but_preserves_processing(self, queue):
+        """supersede removes a work_type's pending/completed residue but never
+        yanks an in-flight (processing) item out from under its worker."""
+        a = await queue.enqueue("dream_synthesis_slice", None, MEMORY_OPS, "{}", "weekly")
+        b = await queue.enqueue("dream_synthesis_slice", None, MEMORY_OPS, "{}", "weekly")
+        c = await queue.enqueue("dream_synthesis_slice", None, MEMORY_OPS, "{}", "weekly")
+        await queue.enqueue("reflection", None, REFLECTION, "{}", "cloud_down")
+        await queue.mark_completed(a)
+        await queue.mark_processing(b)
+
+        removed = await queue.supersede("dream_synthesis_slice")
+
+        # completed a + pending c removed; processing b preserved
+        assert removed == 2
+        assert await queue.count_pending("dream_synthesis_slice") == 0
+        cursor = await queue._db.execute(
+            "SELECT id, status FROM deferred_work_queue WHERE work_type = ?",
+            ("dream_synthesis_slice",),
+        )
+        rows = await cursor.fetchall()
+        assert [(r["id"], r["status"]) for r in rows] == [(b, "processing")]
+        assert c not in [r["id"] for r in rows]
+        # other work_types untouched
+        assert await queue.count_pending("reflection") == 1
+
+    @pytest.mark.asyncio
+    async def test_supersede_empty_returns_zero(self, queue):
+        assert await queue.supersede("dream_synthesis_slice") == 0

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -468,3 +468,125 @@ async def test_start_registers_db_integrity_check(db):
         await sched.start()
     assert sched._scheduler.get_job("db_integrity_check") is not None
     await sched.stop()
+
+
+# ── run_dream_synthesis_drain wrapper ──────────────────────────────────────
+
+
+def _fake_runtime(db):
+    """Runtime stand-in for the drain wrapper: healthy deps, no flags set."""
+    from unittest.mock import MagicMock
+    rt = MagicMock()
+    rt.paused = False
+    rt.heavy_workload = None  # MagicMock auto-attrs are truthy — must be explicit
+    rt._heavy_workload = None
+    rt._heavy_workload_since = None
+    rt.db = db
+    rt.router = AsyncMock()
+    rt.memory_store = MagicMock()
+    rt.memory_store.qdrant_client = MagicMock()
+    return rt
+
+
+_DRAIN_REPORT = {
+    "run_id": "t", "dry_run": True, "drained": 2, "would_merge": 2,
+    "stale_skipped": 0, "errors": [],
+}
+_RT_CLS = "genesis.runtime.GenesisRuntime"
+_DRAIN_FN = "genesis.memory.dream_cycle.run_synthesis_drain"
+
+
+async def test_drain_wrapper_happy_path_shadow(db):
+    """Wrapper drives the drain in SHADOW, records job health, writes the
+    observation, and clears its own heavy_workload flag."""
+    sched, _ = _make_scheduler(db)
+    rt = _fake_runtime(db)
+    with patch(_RT_CLS) as rt_cls, \
+         patch(_DRAIN_FN, new_callable=AsyncMock, return_value=dict(_DRAIN_REPORT)) as drain:
+        rt_cls.instance.return_value = rt
+        await sched.run_dream_synthesis_drain()
+
+    drain.assert_awaited_once()
+    assert drain.call_args.kwargs["dry_run"] is True  # SHADOW hardwired in PR1
+    rt.record_job_start.assert_called_once_with("dream_synthesis_drain")
+    rt.record_job_success.assert_called_once_with("dream_synthesis_drain")
+    rt.record_job_failure.assert_not_called()
+    assert rt._heavy_workload is None  # cleared by the owner-guarded finally
+    cur = await db.execute(
+        "SELECT content FROM observations WHERE type = 'dream_synthesis_drain_report'"
+    )
+    rows = await cur.fetchall()
+    assert len(rows) == 1
+    assert "SHADOW" in rows[0]["content"]
+    assert "2 would merge" in rows[0]["content"]
+
+
+async def test_drain_wrapper_paused_skips(db):
+    sched, _ = _make_scheduler(db)
+    rt = _fake_runtime(db)
+    rt.paused = True
+    with patch(_RT_CLS) as rt_cls, \
+         patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
+        rt_cls.instance.return_value = rt
+        await sched.run_dream_synthesis_drain()
+    drain.assert_not_awaited()
+    rt.record_job_start.assert_not_called()
+
+
+async def test_drain_wrapper_heavy_workload_skips(db):
+    """Weekly clustering still running -> the drain defers to tomorrow (F6)."""
+    sched, _ = _make_scheduler(db)
+    rt = _fake_runtime(db)
+    rt.heavy_workload = "dream_cycle"
+    rt._heavy_workload = "dream_cycle"
+    with patch(_RT_CLS) as rt_cls, \
+         patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
+        rt_cls.instance.return_value = rt
+        await sched.run_dream_synthesis_drain()
+    drain.assert_not_awaited()
+    rt.record_job_start.assert_not_called()
+    # the skip path must not touch the other job's flag
+    assert rt._heavy_workload == "dream_cycle"
+
+
+async def test_drain_wrapper_missing_deps_skip_before_job_start(db):
+    """Dependency checks precede record_job_start — a misconfigured deploy
+    must not leave the job perpetually 'started' in job_health."""
+    sched, _ = _make_scheduler(db)
+    rt = _fake_runtime(db)
+    rt.db = None
+    with patch(_RT_CLS) as rt_cls, \
+         patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
+        rt_cls.instance.return_value = rt
+        await sched.run_dream_synthesis_drain()
+    drain.assert_not_awaited()
+    rt.record_job_start.assert_not_called()
+
+
+async def test_drain_wrapper_failure_records_and_clears_flag(db):
+    sched, _ = _make_scheduler(db)
+    rt = _fake_runtime(db)
+    with patch(_RT_CLS) as rt_cls, \
+         patch(_DRAIN_FN, new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+        rt_cls.instance.return_value = rt
+        await sched.run_dream_synthesis_drain()
+    rt.record_job_failure.assert_called_once()
+    assert rt.record_job_failure.call_args.args[0] == "dream_synthesis_drain"
+    assert rt._heavy_workload is None
+
+
+async def test_drain_wrapper_finally_is_owner_guarded(db):
+    """If another job's flag replaced ours mid-run, the finally must NOT
+    clear it — the two dream jobs share rt._heavy_workload."""
+    sched, _ = _make_scheduler(db)
+    rt = _fake_runtime(db)
+
+    async def _drain_then_flag_stolen(**kw):
+        rt._heavy_workload = "dream_cycle"  # weekly job took the flag
+        return dict(_DRAIN_REPORT)
+
+    with patch(_RT_CLS) as rt_cls, \
+         patch(_DRAIN_FN, new_callable=AsyncMock, side_effect=_drain_then_flag_stolen):
+        rt_cls.instance.return_value = rt
+        await sched.run_dream_synthesis_drain()
+    assert rt._heavy_workload == "dream_cycle"  # not clobbered


### PR DESCRIPTION
## What

T2-D PR1: splits the dream cycle's two workloads onto their own cadences, SHADOW-first.

- **Weekly `run()` (Sunday 4am)** keeps the expensive full-collection scan + clustering + the additive link/centrality layer, and now persists a **value-ranked worklist** (size-DESC, top-500, oversize `>MAX_CLUSTER_SIZE` excluded and flagged for manual review) into the existing `deferred_work_queue` (`work_type="dream_synthesis_slice"`, `DRAIN` policy — the recovery expiry cadence never touches it). A fresh weekly run supersedes the prior list via a new `supersede`/`delete_by_work_type` queue primitive that preserves in-flight `processing` rows. No migration.
- **New daily drain (8am)** `run_dream_synthesis_drain` merges a bounded, value-ranked slice (`DAILY_SYNTHESIS_BUDGET=100` clusters/day) — spreading synthesis load across the week instead of a single ~1560-call Sunday spike, and deferring on bad days. **SHADOW hardwired in this PR**: full queue + rehydration lifecycle, zero LLM calls, zero memory/Qdrant mutations, reports what it *would* merge. The live flip (honoring `GENESIS_DREAM_CYCLE_LIVE`) is a separate, gated PR2.

## Why

Consolidation has been dry-run since 6-21; the backlog grows ~7-10%/week (1058 clusters at 6-28). The blocker to re-enabling was the weekly all-at-once spike (the 6-14 provider-outage grind: 838 clusters → 1 merge, 556 errors). Value-ranked + budget-bounded means the highest-value merges happen first and a slice can't exhaust providers; the low-value tail is dropped and re-ranked by the next weekly re-cluster.

## Hardening (from a pre-build failure-mode review)

- Oversize clusters excluded at enqueue — size-DESC ranking would otherwise put unmergeable clusters at the TOP of the worklist, wasting budget weekly and making shadow reports unfaithful to live behavior.
- Qdrant preflight + mid-drain infra reset — an outage can no longer mass-discard the week's top slices as "stale"; the drain aborts without consuming items.
- Rehydration is one batch `retrieve` per cluster, run via `asyncio.to_thread` (no event-loop blocking), and raises on infra errors instead of swallowing them.
- Stale slices (<2 live members) complete as no-ops instead of discarding — discarded rows surface as failures on the dashboard errors view.
- `mark_processing` return checked (supersede race guard); heavy_workload flag clears are owner-guarded (two jobs now share it); dead `aborted_capacity` branch removed from `run()` (capacity signal moved to the drain; equivalent entity-resolution protection is a PR2 item).
- Docstring drift fixed: the merge gate is the `GENESIS_DREAM_CYCLE_LIVE` env var — there is no config-file key. Weekly observation now reports `worklist_enqueued`/`oversize_flagged` instead of a permanently-zero merged count.

## Verification

- 86 targeted tests green (`tests/test_memory/test_dream_cycle.py`, `tests/test_resilience/test_deferred_work.py`, `tests/test_surplus/test_scheduler.py`) + routing-config guards.
- **E2E shadow against a consistent copy of the production DB + the real Qdrant instance**: 600 clusters → 500 enqueued (unfiltered pending stays ≤ the 1000 overflow threshold); supersede purged all 500; value-ordered drain; stale slice completed-not-discarded; before/after fingerprints of `memory_metadata` and Qdrant payloads identical; router/store stubs that raise on any call never fired; empty-worklist drain is a clean no-op.
- Code-reviewer pass: no blocking findings; both should-fixes applied.

## Expected shadow behavior (for the watch window)

Weekly obs: "N clusters found, K enqueued for daily drain". Daily obs: "N drained, M would merge". The worklist empties by ~day 5 (500 cap / 100 budget) — `drained=0` late-week is normal, not a failure. No `dream_synthesis_slice` rows should appear on the dashboard errors view.

No CHANGELOG entry: no user-visible effect until the PR2 live flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)