### PR TITLE
fix(autonomy): persist watchdog reclaim cooldown; mark dark verifiers as groundwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The watchdog's memory-reclaim cooldown now survives its own restarts, so it can't trigger an
+  I/O storm under sustained memory pressure.** When container memory runs high, the watchdog reclaims
+  a small, capped amount of page cache — throttled to at most once every 5 minutes to avoid an I/O
+  spiral. That throttle lived only in memory, but the watchdog runs as a fresh short-lived process on
+  each check, so it reset every run and never actually held. The cooldown is now persisted, so
+  repeated reclaims stay correctly spaced even across the watchdog's process boundary.
+
 - **Skill suggestions now actually fire — and nested skill packs show up in the catalog.** The
   prompt-time skill nudge scored matches against the length of your prompt, so on any wordy prompt a
   genuine match was diluted below the firing threshold and suggestions near-never appeared; a single

--- a/src/genesis/autonomy/trace_verification.py
+++ b/src/genesis/autonomy/trace_verification.py
@@ -107,6 +107,10 @@ def _verify_triage(payload: dict) -> TraceResult:
     )
 
 
+# GROUNDWORK(trace-verify): Built but not wired. Verifies stated_reason vs
+# actual_data for decisions, but nothing feeds it — execution_traces has 0 rows
+# and the trace-capture pipeline is a separate, parked workstream (audit 2026-07
+# §8). Wire this once decision traces are persisted. NOT dead code — do not remove.
 class TraceVerifier:
     """Programmatically verifies that stated reasons match actual data.
 

--- a/src/genesis/autonomy/verification.py
+++ b/src/genesis/autonomy/verification.py
@@ -21,6 +21,10 @@ class VerificationResult:
     warnings: list[str] = field(default_factory=list)
 
 
+# GROUNDWORK(task-verify): Constructed at runtime init (runtime/init/autonomy.py)
+# with a "code" validator, but .verify() is never called on any dispatch path —
+# the executor uses the LLM TaskReviewer.verify_deliverable instead. Kept as the
+# structural (non-LLM) gate to wire if a cheap pre-check is wanted. NOT dead code.
 class TaskVerifier:
     """Runs structural and custom checks on task completion artifacts."""
 

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -299,7 +299,7 @@ class WatchdogChecker:
     def _check_memory_pressure(self) -> None:
         """Proactive memory check — reclaim page cache if approaching limit.
 
-        Runs every watchdog cycle (60s). Uses anon+kernel memory (non-reclaimable)
+        Runs every watchdog cycle (300s). Uses anon+kernel memory (non-reclaimable)
         for threshold decisions. Total cgroup usage (memory.current) includes
         reclaimable page cache, which inflates the metric and causes false alarms.
         """
@@ -507,7 +507,31 @@ class WatchdogChecker:
         return Path("src") / Path(*parts).with_suffix(".py")
 
 
-_last_reclaim_time: float = 0.0
+# Reclaim-cooldown state is persisted to this sidecar rather than an in-process
+# global: the watchdog runs as a systemd *oneshot* (a fresh process every timer
+# fire), so a module global would reset to 0.0 each run and the cooldown would
+# never actually gate — letting reclaims fire back-to-back during memory pressure,
+# the exact I/O storm the cooldown exists to prevent (incident 2026-03-16).
+_RECLAIM_STATE_PATH = Path("~/.genesis/watchdog_reclaim.json").expanduser()
+
+
+def _load_last_reclaim() -> float:
+    """Epoch seconds of the last successful page-cache reclaim, persisted across
+    the watchdog's oneshot runs. Returns 0.0 when absent/unreadable (fail-open:
+    "never reclaimed" ⇒ a reclaim is allowed)."""
+    try:
+        return float(json.loads(_RECLAIM_STATE_PATH.read_text())["last_reclaim_at"])
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return 0.0
+
+
+def _save_last_reclaim(ts: float) -> None:
+    """Persist the last-reclaim time so the cooldown survives the next oneshot run."""
+    try:
+        _RECLAIM_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _RECLAIM_STATE_PATH.write_text(json.dumps({"last_reclaim_at": ts}))
+    except OSError:
+        logger.warning("Failed to persist reclaim cooldown to %s", _RECLAIM_STATE_PATH)
 
 
 def reclaim_page_cache(target_bytes: str = "128M") -> bool:
@@ -518,16 +542,20 @@ def reclaim_page_cache(target_bytes: str = "128M") -> bool:
     I/O-limited containers because evicted active pages are immediately
     re-faulted from disk, saturating the cgroup I/O budget and creating
     a death spiral (incident 2026-03-16).
-    """
-    global _last_reclaim_time
 
-    now = time.monotonic()
+    The 5-min cooldown is persisted (``_RECLAIM_STATE_PATH``) so it holds
+    across the watchdog's oneshot process boundary, not just within one run.
+    """
+    # Wall-clock time.time() (not monotonic): the value is persisted and compared
+    # across the oneshot's separate processes, where a monotonic reference resets.
+    now = time.time()
+    last_reclaim = _load_last_reclaim()
 
     # Cooldown: don't reclaim more than once per 5 minutes. Repeated
     # reclaims cause I/O storms in I/O-limited containers (incident 2026-03-16).
     _RECLAIM_COOLDOWN_S = 300.0
-    if now - _last_reclaim_time < _RECLAIM_COOLDOWN_S:
-        remaining = _RECLAIM_COOLDOWN_S - (now - _last_reclaim_time)
+    if now - last_reclaim < _RECLAIM_COOLDOWN_S:
+        remaining = _RECLAIM_COOLDOWN_S - (now - last_reclaim)
         logger.debug("Skipping reclaim — cooldown %.0fs remaining", remaining)
         return False
 
@@ -552,7 +580,7 @@ def reclaim_page_cache(target_bytes: str = "128M") -> bool:
 
     try:
         reclaim_path.write_text(target_bytes)
-        _last_reclaim_time = now
+        _save_last_reclaim(now)
         logger.info("Page cache reclaim succeeded (requested %s)", target_bytes)
         return True
     except OSError as exc:

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -553,10 +553,13 @@ def reclaim_page_cache(target_bytes: str = "128M") -> bool:
 
     # Cooldown: don't reclaim more than once per 5 minutes. Repeated
     # reclaims cause I/O storms in I/O-limited containers (incident 2026-03-16).
+    # The `0 <=` lower bound treats a *future* persisted timestamp (pre-NTP boot
+    # clock skew) or a backward clock jump as expired, so it self-heals in one
+    # cycle instead of wedging reclaim off until wall-clock catches up.
     _RECLAIM_COOLDOWN_S = 300.0
-    if now - last_reclaim < _RECLAIM_COOLDOWN_S:
-        remaining = _RECLAIM_COOLDOWN_S - (now - last_reclaim)
-        logger.debug("Skipping reclaim — cooldown %.0fs remaining", remaining)
+    elapsed = now - last_reclaim
+    if 0 <= elapsed < _RECLAIM_COOLDOWN_S:
+        logger.debug("Skipping reclaim — cooldown %.0fs remaining", _RECLAIM_COOLDOWN_S - elapsed)
         return False
 
     # Cap at 256M: small reclaims let the kernel LRU pick inactive pages

--- a/src/genesis/ego/integrity.py
+++ b/src/genesis/ego/integrity.py
@@ -51,6 +51,13 @@ def chained_hash(content_hash_val: str, previous_hash: str | None) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
+# GROUNDWORK(chain-verify): NOT wired — and cannot be naively wired. The ego/
+# approval chains form a single GLOBAL chain written by both egos concurrently
+# (crud/ego.py), so a TOCTOU fork (two records sharing one previous_hash) is
+# expected and is NOT tampering. This linear walk returns (False, idx) at the
+# first fork, so a periodic verify would false-alarm. Real tamper detection needs
+# a fork-tolerant check (verify each record's chain_hash independently). Kept for
+# that future check + as the fork/tamper reference. NOT dead code — do not remove.
 def verify_chain(records: list[dict]) -> tuple[bool, int]:
     """Walk records oldest-first and verify chain integrity.
 

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -35,6 +35,8 @@ async def init(rt: GenesisRuntime) -> None:
         rt._action_classifier = ActionClassifier()
         logger.info("Action classifier loaded")
 
+        # GROUNDWORK(task-verify): constructed + validator-registered here, but
+        # .verify() is never invoked on any live path yet (see verification.py).
         rt._task_verifier = TaskVerifier()
 
         from genesis.autonomy.verification import _code_task_validator

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -371,14 +371,12 @@ class TestYamlLoading:
 
 class TestPageCacheReclaim:
     @pytest.fixture(autouse=True)
-    def _reset_reclaim_cooldown(self):
-        """Reset the module-level cooldown so each test starts fresh."""
-        import time
-
+    def _reset_reclaim_cooldown(self, tmp_path: Path, monkeypatch):
+        """Point the persisted reclaim-cooldown sidecar at a fresh tmp file so
+        each test starts with no prior reclaim (cooldown expired) and never
+        touches the real ~/.genesis state."""
         import genesis.autonomy.watchdog as w
-        # Set to far in the past so cooldown check passes even on fresh CI runners
-        # where time.monotonic() may be small (recently booted).
-        w._last_reclaim_time = time.monotonic() - 600
+        monkeypatch.setattr(w, "_RECLAIM_STATE_PATH", tmp_path / "watchdog_reclaim.json")
 
     def test_reclaim_succeeds_when_path_exists(self, tmp_path: Path):
         reclaim_file = tmp_path / "memory.reclaim"
@@ -399,6 +397,42 @@ class TestPageCacheReclaim:
         with patch("genesis.autonomy.watchdog.Path") as mock_path:
             mock_path.return_value.exists.return_value = False
             assert reclaim_page_cache() is False
+
+    def test_reclaim_cooldown_persists_across_process_restart(self, tmp_path: Path):
+        """Regression for the dead module-global cooldown: the watchdog is a
+        systemd *oneshot* (fresh process each run), so the cooldown must be read
+        from the persisted sidecar, not in-memory state. A recent persisted
+        reclaim must block a new reclaim even with no in-process history."""
+        import genesis.autonomy.watchdog as w
+        # Seed a recent reclaim in the sidecar, as a prior oneshot run would have.
+        w._RECLAIM_STATE_PATH.write_text(json.dumps({"last_reclaim_at": time.time()}))
+
+        reclaim_file = tmp_path / "memory.reclaim"
+        reclaim_file.write_text("")  # exists + writable → would reclaim if cooldown ignored
+        with patch("genesis.autonomy.watchdog.Path", return_value=reclaim_file):
+            assert reclaim_page_cache("256M") is False  # in cooldown from the sidecar
+        assert reclaim_file.read_text() == ""  # and it did NOT write to the cgroup file
+
+    def test_reclaim_persists_timestamp_on_success(self, tmp_path: Path):
+        """A successful reclaim records its time to the sidecar so the NEXT
+        oneshot run sees the cooldown."""
+        import genesis.autonomy.watchdog as w
+        reclaim_file = tmp_path / "memory.reclaim"
+        reclaim_file.write_text("")
+        with patch("genesis.autonomy.watchdog.Path", return_value=reclaim_file):
+            assert reclaim_page_cache("128M") is True
+        saved = json.loads(w._RECLAIM_STATE_PATH.read_text())
+        assert abs(saved["last_reclaim_at"] - time.time()) < 5
+
+    def test_reclaim_corrupt_sidecar_fails_open(self, tmp_path: Path):
+        """A corrupt/unreadable sidecar is treated as 'never reclaimed' (reclaim
+        allowed) — it must never crash the watchdog."""
+        import genesis.autonomy.watchdog as w
+        w._RECLAIM_STATE_PATH.write_text("{not valid json")
+        reclaim_file = tmp_path / "memory.reclaim"
+        reclaim_file.write_text("")
+        with patch("genesis.autonomy.watchdog.Path", return_value=reclaim_file):
+            assert reclaim_page_cache("128M") is True
 
 
 class TestGetContainerMemory:

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -434,6 +434,21 @@ class TestPageCacheReclaim:
         with patch("genesis.autonomy.watchdog.Path", return_value=reclaim_file):
             assert reclaim_page_cache("128M") is True
 
+    def test_reclaim_not_wedged_by_future_timestamp(self, tmp_path: Path):
+        """A FUTURE persisted timestamp (pre-NTP boot clock skew / backward clock
+        jump) must NOT wedge reclaim off: negative elapsed is treated as expired
+        so the cooldown self-heals in one cycle rather than blocking for up to an
+        hour during real memory pressure."""
+        import genesis.autonomy.watchdog as w
+        w._RECLAIM_STATE_PATH.write_text(json.dumps({"last_reclaim_at": time.time() + 3600}))
+        reclaim_file = tmp_path / "memory.reclaim"
+        reclaim_file.write_text("")
+        with patch("genesis.autonomy.watchdog.Path", return_value=reclaim_file):
+            assert reclaim_page_cache("128M") is True  # not wedged
+        # and it re-persisted a sane now-based timestamp, healing the cooldown
+        saved = json.loads(w._RECLAIM_STATE_PATH.read_text())
+        assert saved["last_reclaim_at"] <= time.time() + 1
+
 
 class TestGetContainerMemory:
     def test_reads_cgroup_files(self, tmp_path: Path):


### PR DESCRIPTION
## Summary

Two small autonomy/watchdog correctness fixes.

### The watchdog's memory-reclaim cooldown now survives its own restarts

When container memory runs high, the watchdog reclaims a small, capped amount of page cache — throttled to at most once every 5 minutes to avoid an I/O spiral (the throttle exists because rapid repeated reclaims once caused an I/O death-spiral). That throttle lived only in memory, but the watchdog runs as a **systemd oneshot** — a fresh process on every timer fire — so the in-memory timestamp reset to zero each run and the cooldown never actually held. Under sustained memory pressure, reclaims could fire back-to-back.

The last-reclaim time is now persisted to a small sidecar file, using wall-clock time so it's comparable across the watchdog's separate processes. A future/backward-jumped timestamp (e.g. pre-NTP clock skew at boot) is treated as expired so the cooldown self-heals in one cycle rather than wedging reclaim off. Reads fail open (a missing or corrupt sidecar means "never reclaimed").

### Dark verifiers are marked as intentional groundwork, not dead code

Three verifier components have no runtime caller yet. Each is now tagged so it reads as deliberate future investment rather than dead code, with the reason it's parked:

- **TraceVerifier** — needs decision traces to be persisted first (a separate, parked pipeline).
- **TaskVerifier** — constructed at startup but its structural check isn't invoked on any path yet (the executor uses the LLM reviewer instead).
- **verify_chain** — cannot be wired as-is: the audit hash chain is a single chain written by two components concurrently, so expected concurrent-write forks would look like tampering to a linear walk. Real tamper detection needs a fork-tolerant check. The tag documents this so no one wires it naively.

Comment-only; no behavior change.

## Testing

- New tests cover the cross-process cooldown (persisted timestamp blocks a reclaim in a fresh process), timestamp-on-success, fail-open on a corrupt sidecar, and the future-timestamp self-heal.
- `tests/test_autonomy/test_watchdog.py` (51) and the verifier/integrity suites (61) pass; `ruff` clean.