### PR TITLE
fix(guardian): wire the healthy-snapshot lifeline + recover stopped containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The Guardian now maintains a rolling "healthy" snapshot of the container — the restore point its
+  snapshot-rollback recovery always needed.** Once a day, while every health check passes, the Guardian
+  takes a `-healthy` container snapshot and deletes the previous one (exactly one exists, never more
+  than a day old, so copy-on-write growth can't quietly fill the storage pool the way stale snapshots
+  once did). Snapshot rollback — the one recovery action that works even with the network down — now
+  has a real target; before this, nothing ever created a healthy snapshot, so rollback could never
+  succeed. Kill switch: `snapshots.healthy_enabled: false` in `guardian.yaml`.
+
+- **The Genesis container now comes back on its own after a host reboot — including an unclean one.**
+  `host-setup.sh` sets incus `boot.autostart` on the container (applied to existing installs on
+  re-run, not just fresh ones). Previously an unclean host reboot could leave the container stopped
+  indefinitely, taking Genesis and its network access down until someone noticed.
+
 - **Three session skills now ship with the repo: `/shelve`, `/unshelve`, and `genesis-voice`.** `/shelve`
   bookmarks the current session with tags and a context note; `/unshelve` finds bookmarked sessions later by
   keyword and gives you the resume command. `genesis-voice` is the style guide Genesis applies when it writes
@@ -176,6 +189,27 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   spiral. That throttle lived only in memory, but the watchdog runs as a fresh short-lived process on
   each check, so it reset every run and never actually held. The cooldown is now persisted, so
   repeated reclaims stay correctly spaced even across the watchdog's process boundary.
+
+- **The Guardian's snapshot safety gate now measures real LVM thin-pool allocation instead of the
+  host root filesystem.** On LVM-backed storage, the free-space check behind "is it safe to take a
+  snapshot" ran `df` against a path that lives on the host's root disk — so it could happily approve
+  snapshots while the actual thin pool was nearly full (the same blindness behind the pool-exhaustion
+  outage). The gate now reads the pool's own data/metadata usage and refuses at the configured high
+  tiers; non-LVM backends keep the existing byte-headroom check, where `df` is correct.
+
+- **The Guardian can now recover a container that is fully stopped.** Its container-restart recovery
+  action used `incus restart`, which errors out on a stopped instance — exactly the state an unclean
+  host reboot leaves behind. On restart failure it now falls back to `incus start`.
+
+- **Taking a pre-recovery snapshot can no longer evict the healthy rollback snapshot.** The
+  make-room-before-create step deleted the oldest snapshots purely by count, and at the default
+  retention that meant deleting the healthy restore point right before the risky recovery action that
+  might need it. The latest healthy snapshot is now exempt, mirroring the existing prune exemption.
+
+- **Snapshot rollback now recovers when the storage driver refuses to restore a non-latest
+  snapshot.** ZFS (documented) won't restore past newer snapshots; if the restore fails and newer
+  guardian-created snapshots exist, they are deleted (they capture the already-broken state) and the
+  restore is retried once.
 
 - **Skill suggestions now actually fire — and nested skill packs show up in the catalog.** The
   prompt-time skill nudge scored matches against the length of your prompt, so on any wordy prompt a

--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -50,9 +50,16 @@ briefing:
   max_age_s: 600
 
 snapshots:
-  retention: 1
+  # Non-healthy snapshots kept by delete-before-create (the latest healthy is
+  # exempt and rotated separately): 2 = healthy lifeline + newest pre-recovery.
+  retention: 2
   prefix: "guardian-"
   take_pre_recovery: false
+  # Daily 'healthy' snapshot while state is HEALTHY — the offline
+  # SNAPSHOT_ROLLBACK lifeline (rotated: exactly one, <=1 day old, so CoW
+  # divergence never accumulates). Requires pool headroom (refused at the
+  # storage_pool high tiers). Set false to disable.
+  healthy_enabled: true
   max_pool_usage_pct: 80
   # Age-prune backstop: delete guardian-* snapshots older than this many days,
   # except the newest and the latest healthy (the rollback lifeline). Catches

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -543,6 +543,15 @@ if ! incus info "$CONTAINER_NAME" &>/dev/null; then
     echo "  + Container ready"
 fi
 
+# Always come back after a host reboot — including an UNCLEAN one, where
+# incus's "restore last state" behavior can leave the container stopped
+# (2026-07-04 outage: unclean host reboot → container stayed down, taking
+# Genesis and its network node with it). Applied outside the creation block
+# so re-running host-setup on an existing install enforces it too.
+incus config set "$CONTAINER_NAME" boot.autostart true
+incus config set "$CONTAINER_NAME" boot.autostart.delay 5
+echo "  + boot.autostart enabled (container survives host reboots)"
+
 # ── Split-disk: ensure container home has adequate space ─────────────────────
 # If /home is on a separate larger disk but the Incus pool was initialized on
 # root (common when Incus was pre-installed before host-setup.sh ran, e.g. on

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -211,7 +211,14 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # a guardian stuck in confirmed_dead/recovering for weeks must still
         # enforce expiry + prune stale snapshots (the incident: prune only ran
         # in HEALTHY, so it never fired while the pool silently filled).
-        await _maintain_snapshots(config, snapshots)
+        # is_healthy reflects THIS tick's post-cycle state: the daily healthy
+        # snapshot (offline rollback lifeline) is only taken when HEALTHY.
+        await _maintain_snapshots(
+            config,
+            snapshots,
+            is_healthy=sm.current_state == GuardianState.HEALTHY,
+            snapshot_size_history=sm.state.snapshot_size_history,
+        )
         # Storage-pool monitoring runs every cycle regardless of state — a
         # filling thin pool is the exact silent failure that caused the outage.
         await _check_storage_pool_and_alert(config, dispatcher)
@@ -329,14 +336,22 @@ async def _handle_healthy(
 async def _maintain_snapshots(
     config: GuardianConfig,
     snapshots: SnapshotManager,
+    is_healthy: bool = False,
+    snapshot_size_history: list[int] | None = None,
 ) -> None:
-    """Enforce snapshot expiry policy and prune, on a daily cadence.
+    """Enforce snapshot expiry, prune, and take the daily healthy snapshot.
 
     Runs after every check cycle regardless of guardian state, but the actual
     work (an ``incus config set`` + a list/delete pass) is throttled to once
     per 24h via a marker — the first tick has no marker so both fire
     immediately on deploy, then daily. `snapshots.expiry` is a persistent incus
     setting, so re-asserting it daily is ample and avoids a per-tick subprocess.
+
+    The healthy snapshot (``is_healthy`` must reflect THIS tick's state — never
+    snapshot a broken container as "healthy") is the offline SNAPSHOT_ROLLBACK
+    lifeline: before this wiring, ``mark_healthy`` had no callers, so rollback
+    could never find a target. Taken after prune so the pool is at its
+    cleanest; rotation inside ``mark_healthy`` keeps exactly one.
     """
     prune_marker = config.state_path / ".last_prune"
     should_run = True
@@ -364,6 +379,19 @@ async def _maintain_snapshots(
             logger.info("Pruned %d old snapshots", pruned)
     except Exception:
         logger.warning("Snapshot prune failed", exc_info=True)
+
+    if is_healthy and config.snapshots.healthy_enabled:
+        try:
+            name = await snapshots.mark_healthy(snapshot_size_history)
+            if name:
+                logger.info("Healthy snapshot refreshed: %s", name)
+            else:
+                logger.warning(
+                    "Healthy snapshot NOT taken (pool gate or create failure) "
+                    "— offline rollback lifeline not refreshed this cycle",
+                )
+        except Exception:
+            logger.warning("Healthy snapshot take failed", exc_info=True)
 
     prune_marker.parent.mkdir(parents=True, exist_ok=True)
     prune_marker.write_text(datetime.now(UTC).isoformat())

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -104,9 +104,19 @@ class BriefingConfig:
 class SnapshotConfig:
     """Incus snapshot management settings."""
 
-    retention: int = 1
+    # Non-healthy snapshots kept by take()'s delete-before-create (the latest
+    # healthy snapshot is exempt there and rotated by mark_healthy instead).
+    # 2 so the healthy lifeline and the newest pre-recovery snapshot coexist.
+    retention: int = 2
     prefix: str = "guardian-"
     take_pre_recovery: bool = True  # Take snapshot before recovery action
+    # Daily 'healthy' snapshot while the guardian state is HEALTHY — produces
+    # the offline SNAPSHOT_ROLLBACK lifeline (without it, rollback has no
+    # target and always fails). Rotated on each take: exactly one healthy
+    # snapshot, ≤1 maintenance interval old, so CoW divergence never
+    # accumulates. Set false to stop taking (existing healthy snapshots then
+    # age out via max_age_days / expiry).
+    healthy_enabled: bool = True
     max_pool_usage_pct: float = 80.0  # Fallback threshold if headroom check unavailable
     min_headroom_gb: float = 5.0  # Minimum free space floor for headroom check
     # Age-based prune: delete guardian-* snapshots older than this many days,

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -318,22 +318,59 @@ class RecoveryEngine:
         return svc_ok, f"Code reverted, {svc_detail}"
 
     async def _restart_container(self, container: str) -> tuple[bool, str]:
-        """Restart the entire container."""
+        """Restart the entire container (or start it, if stopped).
+
+        `incus restart` FAILS on a stopped instance — the 2026-07-04 outage
+        (unclean host reboot left the container stopped) made this recovery
+        action a guaranteed no-op exactly when it was needed. On restart
+        failure, fall back to `incus start`: if the container was merely
+        stopped, start brings it back; if it was running (restart failed for
+        another reason), start fails too and the original error is reported.
+        """
         rc, stdout, stderr = await _run_subprocess(
             "incus", "restart", container, "--timeout", "30",
             timeout=60.0,
         )
-        if rc != 0:
-            return False, f"incus restart failed: {stderr}"
-        return True, "Container restarted"
+        if rc == 0:
+            return True, "Container restarted"
+
+        start_rc, _, start_err = await _run_subprocess(
+            "incus", "start", container,
+            timeout=60.0,
+        )
+        if start_rc == 0:
+            return True, "Container started (was stopped — restart cannot start a stopped instance)"
+        return False, f"incus restart failed: {stderr}"
 
     async def _snapshot_rollback(self) -> tuple[bool, str]:
-        """Rollback to the last healthy snapshot."""
+        """Rollback to the last healthy snapshot.
+
+        If the restore fails and NEWER guardian snapshots exist, delete them
+        and retry once: some storage drivers (documented: ZFS) refuse to
+        restore a non-latest snapshot. The newer snapshots are guardian-made
+        captures of the already-broken state (e.g. pre-recovery) — the healthy
+        restore is last-resort, so sacrificing them is the right trade.
+        """
         healthy = await self._snapshots.get_latest_healthy()
         if not healthy:
             return False, "No healthy snapshot available for rollback"
 
         ok = await self._snapshots.restore(healthy)
+        if not ok:
+            # Names are timestamped and sort newest-first; anything sorting
+            # above the healthy name is newer.
+            newer = [
+                n for n in await self._snapshots.list_snapshots() if n > healthy
+            ]
+            if newer:
+                logger.warning(
+                    "Restore of %s failed with newer snapshots present — "
+                    "deleting %s and retrying once",
+                    healthy, ", ".join(newer),
+                )
+                for name in newer:
+                    await self._snapshots.delete(name)
+                ok = await self._snapshots.restore(healthy)
         if not ok:
             return False, f"Failed to restore snapshot {healthy}"
         return True, f"Restored snapshot {healthy}"

--- a/src/genesis/guardian/snapshots.py
+++ b/src/genesis/guardian/snapshots.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime, timedelta
 
 from genesis.guardian._subprocess import run_subprocess as _run_subprocess
 from genesis.guardian.config import GuardianConfig
+from genesis.guardian.pool import measure_storage_pool
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,10 @@ class SnapshotManager:
         """Check if it's safe to take a snapshot using headroom-based gating.
 
         Strategy:
+        - LVM-thin pool detected: gate on REAL pool allocation (lvs data% /
+          metadata%) at the storage-pool `high` tiers. The df paths below
+          measure the host rootfs on LVM backends — the exact blindness behind
+          the thin-pool-exhaustion incident — so lvs is authoritative here.
         - With snapshot size history: require free > max(min_headroom_gb, 2x avg
           of last 3 snapshot sizes). Adapts to actual snapshot sizes.
         - Without history: require at least 10% of pool free (safe default for
@@ -124,6 +129,31 @@ class SnapshotManager:
         - If pool detection fails entirely: fall back to percentage threshold
           (max_pool_usage_pct) for robustness.
         """
+        try:
+            pool_status = await measure_storage_pool(self._config)
+        except Exception:
+            logger.warning("Pool measurement failed — using df fallback", exc_info=True)
+            pool_status = None
+        if pool_status is not None and pool_status.detected and (
+            pool_status.data_pct is not None or pool_status.metadata_pct is not None
+        ):
+            tiers = self._config.storage_pool
+            data = pool_status.data_pct
+            meta = pool_status.metadata_pct
+            if data is not None and data >= tiers.data_high_pct:
+                logger.error(
+                    "Pool data %.1f%% >= %.0f%% high tier — refusing snapshot",
+                    data, tiers.data_high_pct,
+                )
+                return False
+            if meta is not None and meta >= tiers.metadata_high_pct:
+                logger.error(
+                    "Pool metadata %.1f%% >= %.0f%% high tier — refusing snapshot",
+                    meta, tiers.metadata_high_pct,
+                )
+                return False
+            return True
+
         pool_info = await self._get_pool_free_bytes()
         if pool_info is None:
             # Can't get byte-level info — fall back to percentage check
@@ -185,18 +215,22 @@ class SnapshotManager:
         if not await self.safe_to_snapshot(snapshot_size_history):
             return None
 
-        # Delete-before-create: remove excess snapshots to stay within retention
+        # Delete-before-create: remove excess snapshots to stay within
+        # retention — but NEVER evict the latest healthy snapshot (the offline
+        # snapshot-rollback lifeline). prune() has the same exemption; without
+        # it here, a pre-recovery take at retention=1 would delete the healthy
+        # snapshot right before the risky action that might need it. Rotation
+        # of superseded healthy snapshots is mark_healthy()'s job (after a
+        # successful create — no zero-lifeline window).
         existing = await self.list_snapshots()
-        if existing and len(existing) >= self._retention:
-            for old_name in existing[self._retention - 1:]:
-                rc, _, stderr = await _run_subprocess(
-                    "incus", "snapshot", "delete", self._container, old_name,
-                    timeout=60.0,
-                )
-                if rc == 0:
+        latest_healthy = next(
+            (n for n in existing if n.endswith("-healthy")), None,
+        )
+        candidates = [n for n in existing if n != latest_healthy]
+        if candidates and len(candidates) >= self._retention:
+            for old_name in candidates[self._retention - 1:]:
+                if await self.delete(old_name):
                     logger.info("Deleted snapshot before create: %s", old_name)
-                else:
-                    logger.warning("Failed to delete snapshot %s: %s", old_name, stderr)
 
         ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
         name = f"{self._prefix}{ts}"
@@ -233,6 +267,17 @@ class SnapshotManager:
                     )
 
         return name
+
+    async def delete(self, name: str) -> bool:
+        """Delete a snapshot by name. Returns True on success."""
+        rc, _, stderr = await _run_subprocess(
+            "incus", "snapshot", "delete", self._container, name,
+            timeout=60.0,
+        )
+        if rc != 0:
+            logger.warning("Failed to delete snapshot %s: %s", name, stderr)
+            return False
+        return True
 
     async def restore(self, name: str) -> bool:
         """Restore a snapshot. Returns True on success."""
@@ -360,10 +405,25 @@ class SnapshotManager:
     async def mark_healthy(
         self, snapshot_size_history: list[int] | None = None,
     ) -> str | None:
-        """Take a snapshot labeled 'healthy'."""
-        return await self.take(
+        """Take a 'healthy' snapshot, then rotate superseded healthy ones.
+
+        Create-then-delete ordering: the new lifeline must exist before the
+        old one goes, so a failed create leaves the previous healthy snapshot
+        intact and there is never a zero-lifeline window. Rotation keeps
+        exactly one healthy snapshot → CoW divergence stays bounded to one
+        maintenance interval (the incident was 2 months of divergence).
+        """
+        name = await self.take(
             label="healthy", snapshot_size_history=snapshot_size_history,
         )
+        if name is None:
+            return None
+
+        for old_name in await self.list_snapshots():
+            is_superseded = old_name.endswith("-healthy") and old_name != name
+            if is_superseded and await self.delete(old_name):
+                logger.info("Rotated superseded healthy snapshot: %s", old_name)
+        return name
 
     async def get_latest_healthy(self) -> str | None:
         """Get the name of the most recent 'healthy' snapshot."""

--- a/src/genesis/guardian/snapshots.py
+++ b/src/genesis/guardian/snapshots.py
@@ -18,6 +18,12 @@ from genesis.guardian.pool import measure_storage_pool
 
 logger = logging.getLogger(__name__)
 
+# Label suffix marking the offline snapshot-rollback lifeline. take(label=
+# _HEALTHY_LABEL) produces names ending in this suffix; prune()/take()
+# eviction exempt the latest one and mark_healthy() rotates the rest.
+_HEALTHY_LABEL = "healthy"
+_HEALTHY_SUFFIX = f"-{_HEALTHY_LABEL}"
+
 
 def _parse_created_at(raw: object) -> datetime | None:
     """Parse an incus snapshot `created_at` into an aware UTC datetime.
@@ -224,7 +230,7 @@ class SnapshotManager:
         # successful create — no zero-lifeline window).
         existing = await self.list_snapshots()
         latest_healthy = next(
-            (n for n in existing if n.endswith("-healthy")), None,
+            (n for n in existing if n.endswith(_HEALTHY_SUFFIX)), None,
         )
         candidates = [n for n in existing if n != latest_healthy]
         if candidates and len(candidates) >= self._retention:
@@ -269,10 +275,15 @@ class SnapshotManager:
         return name
 
     async def delete(self, name: str) -> bool:
-        """Delete a snapshot by name. Returns True on success."""
+        """Delete a snapshot by name. Returns True on success.
+
+        120s timeout: deleting a long-lived LVM-thin snapshot with heavy CoW
+        divergence involves real kernel metadata work (the incident snapshots
+        were months old) — 60s can genuinely be exceeded.
+        """
         rc, _, stderr = await _run_subprocess(
             "incus", "snapshot", "delete", self._container, name,
-            timeout=60.0,
+            timeout=120.0,
         )
         if rc != 0:
             logger.warning("Failed to delete snapshot %s: %s", name, stderr)
@@ -344,7 +355,7 @@ class SnapshotManager:
             return 0
 
         names = [name for name, _ in meta]
-        healthy = [n for n in names if n.endswith("-healthy")]
+        healthy = [n for n in names if n.endswith(_HEALTHY_SUFFIX)]
         latest_healthy = healthy[0] if healthy else None
 
         # Retention rule: keep newest N + latest healthy.
@@ -366,15 +377,9 @@ class SnapshotManager:
 
         deleted = 0
         for name in sorted(to_delete):
-            rc, _, stderr = await _run_subprocess(
-                "incus", "snapshot", "delete", self._container, name,
-                timeout=120.0,
-            )
-            if rc == 0:
+            if await self.delete(name):
                 logger.info("Pruned snapshot: %s", name)
                 deleted += 1
-            else:
-                logger.warning("Failed to prune snapshot %s: %s", name, stderr)
 
         return deleted
 
@@ -414,13 +419,13 @@ class SnapshotManager:
         maintenance interval (the incident was 2 months of divergence).
         """
         name = await self.take(
-            label="healthy", snapshot_size_history=snapshot_size_history,
+            label=_HEALTHY_LABEL, snapshot_size_history=snapshot_size_history,
         )
         if name is None:
             return None
 
         for old_name in await self.list_snapshots():
-            is_superseded = old_name.endswith("-healthy") and old_name != name
+            is_superseded = old_name.endswith(_HEALTHY_SUFFIX) and old_name != name
             if is_superseded and await self.delete(old_name):
                 logger.info("Rotated superseded healthy snapshot: %s", old_name)
         return name
@@ -429,6 +434,6 @@ class SnapshotManager:
         """Get the name of the most recent 'healthy' snapshot."""
         snapshots = await self.list_snapshots()
         for name in snapshots:
-            if name.endswith("-healthy"):
+            if name.endswith(_HEALTHY_SUFFIX):
                 return name
         return None

--- a/tests/test_guardian/test_check.py
+++ b/tests/test_guardian/test_check.py
@@ -948,3 +948,70 @@ class TestTwoGateApproval:
 
         recovery_engine.execute.assert_not_called()
         assert sm.state.down_alert_sent is False
+
+
+class TestHealthySnapshotWiring:
+    """_maintain_snapshots must produce the offline lifeline: a daily healthy
+    snapshot, taken ONLY when the guardian state is HEALTHY this tick.
+
+    Before this wiring, mark_healthy() had zero callers — SNAPSHOT_ROLLBACK
+    could never succeed because nothing ever created a healthy snapshot.
+    """
+
+    def _snapshots_mock(self) -> MagicMock:
+        snapshots = MagicMock()
+        snapshots.prune = AsyncMock(return_value=0)
+        snapshots.enforce_expiry_policy = AsyncMock(return_value=True)
+        snapshots.mark_healthy = AsyncMock(
+            return_value="guardian-20260703-000000-healthy",
+        )
+        return snapshots
+
+    @pytest.mark.asyncio
+    async def test_takes_healthy_snapshot_when_healthy(
+        self, config: GuardianConfig,
+    ) -> None:
+        snapshots = self._snapshots_mock()
+        await _maintain_snapshots(config, snapshots, is_healthy=True)
+        snapshots.mark_healthy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_healthy_snapshot_when_not_healthy(
+        self, config: GuardianConfig,
+    ) -> None:
+        """NEVER snapshot a broken container as 'healthy'."""
+        snapshots = self._snapshots_mock()
+        await _maintain_snapshots(config, snapshots, is_healthy=False)
+        snapshots.mark_healthy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_healthy_snapshot_when_disabled(
+        self, config: GuardianConfig,
+    ) -> None:
+        config.snapshots.healthy_enabled = False
+        snapshots = self._snapshots_mock()
+        await _maintain_snapshots(config, snapshots, is_healthy=True)
+        snapshots.mark_healthy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_healthy_snapshot_respects_daily_marker(
+        self, config: GuardianConfig,
+    ) -> None:
+        from datetime import UTC, datetime
+        marker = config.state_path / ".last_prune"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(datetime.now(UTC).isoformat())
+
+        snapshots = self._snapshots_mock()
+        await _maintain_snapshots(config, snapshots, is_healthy=True)
+        snapshots.mark_healthy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mark_healthy_failure_does_not_stop_marker(
+        self, config: GuardianConfig,
+    ) -> None:
+        """A failing healthy-take must not wedge the daily cadence."""
+        snapshots = self._snapshots_mock()
+        snapshots.mark_healthy = AsyncMock(side_effect=RuntimeError("incus down"))
+        await _maintain_snapshots(config, snapshots, is_healthy=True)
+        assert (config.state_path / ".last_prune").exists()

--- a/tests/test_guardian/test_config.py
+++ b/tests/test_guardian/test_config.py
@@ -68,9 +68,11 @@ class TestGuardianConfigDefaults:
 
     def test_snapshot_defaults(self) -> None:
         cfg = GuardianConfig()
-        assert cfg.snapshots.retention == 1
+        # 2 = the healthy lifeline + the newest pre-recovery coexist.
+        assert cfg.snapshots.retention == 2
         assert cfg.snapshots.prefix == "guardian-"
         assert cfg.snapshots.take_pre_recovery is True
+        assert cfg.snapshots.healthy_enabled is True
         assert cfg.snapshots.max_pool_usage_pct == 80.0
 
 

--- a/tests/test_guardian/test_recovery.py
+++ b/tests/test_guardian/test_recovery.py
@@ -244,3 +244,94 @@ class TestRecoveryRevertCode:
             result = await engine.execute(_diagnosis(RecoveryAction.REVERT_CODE))
         assert result.success is True
         assert "reverted" in result.detail.lower()
+
+
+class TestRestartContainerStopped:
+    """`incus restart` fails on a STOPPED instance (2026-07-04 outage: unclean
+    host reboot left the container stopped and the guardian's designed
+    recovery action was a guaranteed no-op). Fall back to `incus start`."""
+
+    @pytest.mark.asyncio
+    async def test_start_fallback_when_stopped(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        calls: list[tuple] = []
+
+        async def mock(*args, **kwargs):
+            calls.append(args)
+            if args[:2] == ("incus", "restart"):
+                return (1, "", "Error: The instance is not running")
+            if args[:2] == ("incus", "start"):
+                return (0, "", "")
+            return (0, "", "")
+
+        with patch("genesis.guardian.recovery._run_subprocess", mock):
+            ok, detail = await engine._restart_container("genesis")
+        assert ok is True
+        assert "start" in detail.lower()
+        assert calls[-1][:3] == ("incus", "start", "genesis")
+
+    @pytest.mark.asyncio
+    async def test_reports_restart_error_when_start_also_fails(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        async def mock(*args, **kwargs):
+            if args[:2] == ("incus", "restart"):
+                return (1, "", "restart boom")
+            if args[:2] == ("incus", "start"):
+                return (1, "", "already running")
+            return (0, "", "")
+
+        with patch("genesis.guardian.recovery._run_subprocess", mock):
+            ok, detail = await engine._restart_container("genesis")
+        assert ok is False
+        assert "restart boom" in detail
+
+
+class TestSnapshotRollbackRetry:
+    """Restore can fail when newer snapshots exist (documented ZFS behavior;
+    driver-agnostic hardening): delete newer guardian-* snapshots, retry once."""
+
+    def _engine_with(self, config, sm, dispatcher, snapshots) -> RecoveryEngine:
+        return RecoveryEngine(config, sm, snapshots, dispatcher)
+
+    @pytest.mark.asyncio
+    async def test_retry_after_deleting_newer(
+        self, config: GuardianConfig, sm, dispatcher,
+    ) -> None:
+        from unittest.mock import MagicMock
+        snapshots = MagicMock()
+        healthy = "guardian-20260701-000000-healthy"
+        snapshots.get_latest_healthy = AsyncMock(return_value=healthy)
+        snapshots.restore = AsyncMock(side_effect=[False, True])
+        snapshots.list_snapshots = AsyncMock(return_value=[
+            "guardian-20260702-000000-pre-recovery",  # newer than healthy
+            healthy,
+        ])
+        snapshots.delete = AsyncMock(return_value=True)
+
+        engine = self._engine_with(config, sm, dispatcher, snapshots)
+        ok, detail = await engine._snapshot_rollback()
+        assert ok is True
+        snapshots.delete.assert_called_once_with(
+            "guardian-20260702-000000-pre-recovery",
+        )
+        assert snapshots.restore.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_nothing_newer(
+        self, config: GuardianConfig, sm, dispatcher,
+    ) -> None:
+        from unittest.mock import MagicMock
+        snapshots = MagicMock()
+        healthy = "guardian-20260701-000000-healthy"
+        snapshots.get_latest_healthy = AsyncMock(return_value=healthy)
+        snapshots.restore = AsyncMock(return_value=False)
+        snapshots.list_snapshots = AsyncMock(return_value=[healthy])
+        snapshots.delete = AsyncMock(return_value=True)
+
+        engine = self._engine_with(config, sm, dispatcher, snapshots)
+        ok, _ = await engine._snapshot_rollback()
+        assert ok is False
+        snapshots.delete.assert_not_called()
+        assert snapshots.restore.call_count == 1

--- a/tests/test_guardian/test_snapshots.py
+++ b/tests/test_guardian/test_snapshots.py
@@ -160,8 +160,10 @@ class TestSnapshotPrune:
         assert deleted == 0
 
     @pytest.mark.asyncio
-    async def test_prune_over_retention(self, manager: SnapshotManager) -> None:
-        """Should prune oldest snapshots past retention (1)."""
+    async def test_prune_over_retention(self, config: GuardianConfig) -> None:
+        """Should prune oldest snapshots past retention."""
+        config.snapshots.retention = 1
+        manager = SnapshotManager(config)
         snapshots = _meta([(f"guardian-{i}", float(3 - i)) for i in range(3, 0, -1)])
         with (
             patch.object(manager, "_list_snapshots_with_meta", return_value=snapshots),
@@ -442,3 +444,216 @@ class TestGetLatestHealthy:
         ):
             name = await manager.get_latest_healthy()
         assert name is None
+
+
+def _pool_status(detected: bool = True, data=None, meta=None):
+    from genesis.guardian.pool import StoragePoolStatus
+    return StoragePoolStatus(detected=detected, data_pct=data, metadata_pct=meta)
+
+
+class TestLvmPoolGating:
+    """safe_to_snapshot must gate on REAL thin-pool allocation when LVM.
+
+    The df-on-mountpath fallback measures the host rootfs on LVM backends
+    (the original-incident blindness), so when measure_storage_pool detects
+    the pool, its data%/metadata% are authoritative.
+    """
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_data_at_high_tier(
+        self, manager: SnapshotManager,
+    ) -> None:
+        with patch(
+            "genesis.guardian.snapshots.measure_storage_pool",
+            return_value=_pool_status(data=86.0, meta=10.0),
+        ):
+            assert await manager.safe_to_snapshot() is False
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_metadata_at_high_tier(
+        self, manager: SnapshotManager,
+    ) -> None:
+        # Metadata exhaustion is nastier than data — gate at its (lower) tier.
+        with patch(
+            "genesis.guardian.snapshots.measure_storage_pool",
+            return_value=_pool_status(data=40.0, meta=71.0),
+        ):
+            assert await manager.safe_to_snapshot() is False
+
+    @pytest.mark.asyncio
+    async def test_allows_below_tiers(self, manager: SnapshotManager) -> None:
+        with patch(
+            "genesis.guardian.snapshots.measure_storage_pool",
+            return_value=_pool_status(data=55.0, meta=29.0),
+        ):
+            assert await manager.safe_to_snapshot() is True
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_df_when_pool_undetected(
+        self, manager: SnapshotManager,
+    ) -> None:
+        """Non-LVM/undetectable pool → existing df byte-headroom logic."""
+        async def df_mock(*args, **kwargs):
+            cmd = args[0] if args else ""
+            if cmd == "incus":
+                return (0, "genesis-pool\n", "")
+            if cmd == "df":
+                # size, avail (bytes): 100G total, 50G free — plenty
+                return (0, "1B-blocks Avail\n107374182400 53687091200\n", "")
+            return (0, "", "")
+        with (
+            patch(
+                "genesis.guardian.snapshots.measure_storage_pool",
+                return_value=_pool_status(detected=False),
+            ),
+            patch("genesis.guardian.snapshots._run_subprocess", df_mock),
+        ):
+            assert await manager.safe_to_snapshot() is True
+
+
+def _take_env_mock(existing_json: str, deletes: list, creates: list):
+    """Subprocess mock for take(): list/delete/create capture."""
+    async def mock(*args, **kwargs):
+        cmd = args[0] if args else ""
+        if cmd == "incus" and args[1] == "config":
+            return (0, "genesis-pool\n", "")
+        if cmd == "df":
+            return (0, "1B-blocks Avail\n107374182400 53687091200\n", "")
+        if cmd == "incus" and args[1] == "snapshot" and args[2] == "list":
+            return (0, existing_json, "")
+        if cmd == "incus" and args[1] == "snapshot" and args[2] == "delete":
+            deletes.append(args[4])
+            return (0, "", "")
+        if cmd == "incus" and args[1] == "snapshot" and args[2] == "create":
+            creates.append(args[4])
+            return (0, "", "")
+        return (0, "", "")
+    return mock
+
+
+class TestTakeHealthyExemption:
+    """take()'s delete-before-create must never evict the healthy lifeline.
+
+    prune() got the latest-healthy exemption; take()'s parallel eviction path
+    was missed — at retention=1 a pre-recovery take would delete the healthy
+    snapshot RIGHT BEFORE the risky action that might need it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pre_recovery_take_does_not_evict_healthy(
+        self, config: GuardianConfig,
+    ) -> None:
+        config.snapshots.retention = 1
+        manager = SnapshotManager(config)
+        existing = json.dumps([
+            {"name": "guardian-20260702-000000-pre-recovery",
+             "created_at": "2026-07-02T00:00:00Z"},
+            {"name": "guardian-20260701-000000-healthy",
+             "created_at": "2026-07-01T00:00:00Z"},
+        ])
+        deletes: list = []
+        creates: list = []
+        with (
+            patch(
+                "genesis.guardian.snapshots.measure_storage_pool",
+                return_value=_pool_status(data=50.0, meta=20.0),
+            ),
+            patch(
+                "genesis.guardian.snapshots._run_subprocess",
+                _take_env_mock(existing, deletes, creates),
+            ),
+        ):
+            name = await manager.take(label="pre-recovery")
+        assert name is not None
+        assert "guardian-20260701-000000-healthy" not in deletes
+        # The older non-healthy IS evicted to hold retention.
+        assert "guardian-20260702-000000-pre-recovery" in deletes
+
+
+class TestMarkHealthyRotation:
+    """mark_healthy: create the NEW healthy first, then delete superseded
+    healthy snapshots — no zero-lifeline window, create-failure keeps the old."""
+
+    @pytest.mark.asyncio
+    async def test_rotation_deletes_only_superseded_healthy(
+        self, config: GuardianConfig,
+    ) -> None:
+        config.snapshots.retention = 2
+        manager = SnapshotManager(config)
+        existing = json.dumps([
+            {"name": "guardian-20260702-000000-pre-recovery",
+             "created_at": "2026-07-02T00:00:00Z"},
+            {"name": "guardian-20260701-000000-healthy",
+             "created_at": "2026-07-01T00:00:00Z"},
+        ])
+        deletes: list = []
+        creates: list = []
+        with (
+            patch(
+                "genesis.guardian.snapshots.measure_storage_pool",
+                return_value=_pool_status(data=50.0, meta=20.0),
+            ),
+            patch(
+                "genesis.guardian.snapshots._run_subprocess",
+                _take_env_mock(existing, deletes, creates),
+            ),
+        ):
+            name = await manager.mark_healthy()
+        assert name is not None and name.endswith("-healthy")
+        assert "guardian-20260701-000000-healthy" in deletes
+        assert "guardian-20260702-000000-pre-recovery" not in deletes
+
+    @pytest.mark.asyncio
+    async def test_create_failure_keeps_old_healthy(
+        self, config: GuardianConfig,
+    ) -> None:
+        manager = SnapshotManager(config)
+        existing = json.dumps([
+            {"name": "guardian-20260701-000000-healthy",
+             "created_at": "2026-07-01T00:00:00Z"},
+        ])
+        deletes: list = []
+
+        async def failing_create(*args, **kwargs):
+            cmd = args[0] if args else ""
+            if cmd == "incus" and args[1] == "config":
+                return (0, "genesis-pool\n", "")
+            if cmd == "df":
+                return (0, "1B-blocks Avail\n107374182400 53687091200\n", "")
+            if cmd == "incus" and args[1] == "snapshot" and args[2] == "list":
+                return (0, existing, "")
+            if cmd == "incus" and args[1] == "snapshot" and args[2] == "delete":
+                deletes.append(args[4])
+                return (0, "", "")
+            if cmd == "incus" and args[1] == "snapshot" and args[2] == "create":
+                return (1, "", "boom")
+            return (0, "", "")
+
+        with (
+            patch(
+                "genesis.guardian.snapshots.measure_storage_pool",
+                return_value=_pool_status(data=50.0, meta=20.0),
+            ),
+            patch("genesis.guardian.snapshots._run_subprocess", failing_create),
+        ):
+            name = await manager.mark_healthy()
+        assert name is None
+        assert deletes == []  # old lifeline untouched
+
+
+class TestDelete:
+
+    @pytest.mark.asyncio
+    async def test_delete_success(self, manager: SnapshotManager) -> None:
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess", _mock_subprocess(0),
+        ):
+            assert await manager.delete("guardian-20260701-000000") is True
+
+    @pytest.mark.asyncio
+    async def test_delete_failure(self, manager: SnapshotManager) -> None:
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess",
+            _mock_subprocess(1, "", "nope"),
+        ):
+            assert await manager.delete("guardian-20260701-000000") is False


### PR DESCRIPTION
## What

Four structural gaps in the Guardian's offline recovery layer, found by tracing recent outages back through the code:

1. **The healthy-snapshot lifeline was never created.** `mark_healthy()` had zero callers, so `SNAPSHOT_ROLLBACK` — the only recovery action that works with the network down — could never find a target and always failed. The Guardian now takes a daily `-healthy` snapshot while all health checks pass, rotated create-then-delete so exactly one exists (CoW divergence bounded to one day; kill switch `snapshots.healthy_enabled`).

2. **The snapshot safety gate measured the wrong filesystem on LVM.** `safe_to_snapshot` ran `df` against a mountpath that lives on the host rootfs, blind to real thin-pool allocation. It now gates on `lvs` data%/metadata% at the storage-pool high tiers (reusing `pool.py`'s measurement); non-LVM backends keep the df byte-headroom logic, where df is correct.

3. **`take()`'s delete-before-create could evict the lifeline.** Eviction was purely count-based, so at default retention a pre-recovery snapshot would delete the healthy restore point right before the risky action that might need it. The latest healthy snapshot is now exempt (mirroring `prune()`'s exemption); retention default 1→2 so the lifeline and the newest pre-recovery coexist.

4. **A stopped container was unrecoverable.** `incus restart` errors on a stopped instance — exactly what an unclean host reboot leaves behind. `RESTART_CONTAINER` now falls back to `incus start`, and `host-setup.sh` sets `boot.autostart` on the container (idempotently, so re-running it upgrades existing installs).

Also: snapshot rollback deletes newer guardian-created snapshots and retries once when the storage driver refuses non-latest restores (documented ZFS behavior), and the snapshot-delete path is unified in one `delete()` helper with a 120s timeout (deleting a long-diverged thin snapshot does real kernel metadata work).

## Testing

- TDD: 15 new tests across `test_snapshots.py`, `test_check.py`, `test_recovery.py` (LVM-tier gating + df fallback, eviction exemption, rotation ordering incl. create-failure, healthy-only-when-HEALTHY wiring, daily-marker throttle, start-fallback, rollback retry)
- Full guardian suite: 449 passed; ruff clean

## Notes

- The healthy snapshot is only taken when the Guardian's state machine reports HEALTHY *this tick* — a broken container is never labeled healthy.
- A failed healthy-take logs loudly but does not block the daily maintenance marker (no retry storms against a failing incus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)