### PR TITLE
fix(sentinel): scope alarms to what the Sentinel can remediate; fix approval-wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **The Sentinel (Genesis's internal emergency responder) now only wakes for problems it can
+  actually fix.** Previously any CRITICAL health alert woke it — including things it has no way to
+  remediate, like backups failing to reach a remote repo, a provider running out of credits, or an
+  external API outage. Those now stay visible on the dashboard and still notify you directly (backup
+  failures were added to the immediate-notification list), but they no longer trigger an automated
+  diagnostic session that can only conclude "nothing I can do." Each alert is matched against the
+  remediation tools available on your install, so e.g. a Guardian alarm only wakes the Sentinel where
+  a Guardian is actually configured. Installs that intentionally don't run backups no longer see a
+  false "backup failed" critical alert at all.
+
+- **A rejected Sentinel approval can no longer freeze the Sentinel.** If you rejected (or let
+  expire) a Sentinel dispatch approval while the underlying alarm stayed active, the Sentinel parked
+  itself waiting forever and silently ignored every new alarm. It now applies your decision on the
+  next check: a rejection suppresses that alarm pattern for 24h and returns the Sentinel to healthy,
+  ready for the next real emergency. Sentinel state changes also now appear in the event log under
+  their own "sentinel" subsystem, so a parked or wedged state is visible instead of silent.
+
 - **The dashboard loads faster and shows consistent status/time formats.** The web UI's
   scripts and styles moved out of the page into cacheable files, so after your first visit
   only data — not the whole 700KB page — is re-fetched. Overview health chips now use one

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -621,6 +621,18 @@ class AutonomousCliApprovalGate:
             subsystem=subsystem, policy_id=policy_id,
         )
 
+    async def get_request(self, request_id: str) -> dict[str, Any] | None:
+        """Fetch one approval request row by id, or None if it doesn't exist.
+
+        Used by the sentinel resume mechanism to converge a parked dispatch
+        on the row's OBSERVED status (approved/rejected/expired/cancelled)
+        instead of only scanning for approvals — a rejection that is never
+        delivered leaves the Sentinel parked forever.
+        """
+        from genesis.db.crud import approval_requests as ar_crud
+
+        return await ar_crud.get_by_id(self._approval_manager._db, request_id)
+
     async def mark_consumed(self, request_id: str) -> bool:
         """Mark an approved request as consumed (action dispatched).
 

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1364,10 +1364,19 @@ class AwarenessLoop:
                 )
 
     async def _resume_approved_sentinel_dispatches(self) -> None:
-        """Resume sentinel dispatches whose approvals were granted.
+        """Converge a parked sentinel dispatch on its approval's REAL status.
 
-        Mirrors _resume_approved_reflections: checks for approved-but-
-        unconsumed sentinel approvals and resumes the dispatcher.
+        State-keyed: when the sentinel is AWAITING_*, look up the exact
+        pending request row and apply whatever actually happened to it —
+        approved → resume, rejected → apply the rejection (24h pattern
+        suppression + HEALTHY), expired/cancelled/missing → clear the park.
+        The previous implementation only scanned for approved rows, so a
+        rejection was never delivered and the sentinel stayed parked forever
+        (Gate 2 blocks all other dispatches while parked — this blinded the
+        Sentinel for 26 days in June/July 2026).
+
+        The legacy approved-row scan is kept as a fallback for the
+        inconsistent case where the state lost its pending_request_id.
         """
         if self._sentinel is None:
             return
@@ -1384,6 +1393,18 @@ class AwarenessLoop:
         if state.state not in (_SS.AWAITING_DISPATCH_APPROVAL, _SS.AWAITING_ACTION_APPROVAL):
             return
 
+        if state.pending_request_id:
+            try:
+                await self._sentinel.converge_pending_approval()
+            except Exception:
+                logger.error(
+                    "Failed to converge sentinel on pending approval",
+                    exc_info=True,
+                )
+            return
+
+        # Inconsistent: AWAITING with no pending id recorded. Fall back to
+        # the legacy scan for an approved-but-unconsumed sentinel row.
         for policy_id in ("sentinel_dispatch", "sentinel_action"):
             try:
                 approved = await gate.find_recently_approved(

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1366,24 +1366,22 @@ class AwarenessLoop:
     async def _resume_approved_sentinel_dispatches(self) -> None:
         """Converge a parked sentinel dispatch on its approval's REAL status.
 
-        State-keyed: when the sentinel is AWAITING_*, look up the exact
-        pending request row and apply whatever actually happened to it —
-        approved → resume, rejected → apply the rejection (24h pattern
-        suppression + HEALTHY), expired/cancelled/missing → clear the park.
-        The previous implementation only scanned for approved rows, so a
-        rejection was never delivered and the sentinel stayed parked forever
-        (Gate 2 blocks all other dispatches while parked — this blinded the
-        Sentinel for 26 days in June/July 2026).
-
-        The legacy approved-row scan is kept as a fallback for the
-        inconsistent case where the state lost its pending_request_id.
+        State-keyed: when the sentinel is AWAITING_*, the dispatcher looks
+        up the exact pending request row and applies whatever actually
+        happened to it — approved → resume, rejected → apply the rejection
+        (24h pattern suppression + HEALTHY), expired/cancelled/missing →
+        clear the park, no-pending-id-recorded → clear the inconsistent
+        park. The previous implementation only scanned for approved rows,
+        so a rejection was never delivered and the sentinel stayed parked
+        forever (Gate 2 blocks all other dispatches while parked — this
+        blinded the Sentinel for 26 days in June/July 2026). The old
+        approved-row scan fallback was removed outright: for a park with no
+        recorded pending id it consumed an approval whose id could never
+        match, eating the user's decision while staying parked.
         """
         if self._sentinel is None:
             return
-
-        # Access the approval gate via the sentinel dispatcher
-        gate = getattr(self._sentinel, "_approval_gate", None)
-        if gate is None:
+        if getattr(self._sentinel, "_approval_gate", None) is None:
             return
 
         from genesis.sentinel.state import SentinelState as _SS
@@ -1393,43 +1391,13 @@ class AwarenessLoop:
         if state.state not in (_SS.AWAITING_DISPATCH_APPROVAL, _SS.AWAITING_ACTION_APPROVAL):
             return
 
-        if state.pending_request_id:
-            try:
-                await self._sentinel.converge_pending_approval()
-            except Exception:
-                logger.error(
-                    "Failed to converge sentinel on pending approval",
-                    exc_info=True,
-                )
-            return
-
-        # Inconsistent: AWAITING with no pending id recorded. Fall back to
-        # the legacy scan for an approved-but-unconsumed sentinel row.
-        for policy_id in ("sentinel_dispatch", "sentinel_action"):
-            try:
-                approved = await gate.find_recently_approved(
-                    subsystem="sentinel",
-                    policy_id=policy_id,
-                )
-                if not approved:
-                    continue
-
-                # Atomic consume — prevents double-dispatch
-                consumed = await gate.mark_consumed(approved["id"])
-                if not consumed:
-                    continue
-
-                logger.info(
-                    "Resuming sentinel %s from approved request %s",
-                    policy_id, approved["id"][:8],
-                )
-                await self._sentinel.resume_from_approval(
-                    approved["id"], "approved",
-                )
-            except Exception:
-                logger.error(
-                    "Failed to resume sentinel %s", policy_id, exc_info=True,
-                )
+        try:
+            await self._sentinel.converge_pending_approval()
+        except Exception:
+            logger.error(
+                "Failed to converge sentinel on pending approval",
+                exc_info=True,
+            )
 
     async def _retry_deferred_reflection(self, current_tick: TickResult) -> None:
         """Retry ONE deferred reflection per tick using current tick's fresh data.

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -129,18 +129,30 @@ async def _impl_health_errors(
 
 
 def _backups_enabled() -> bool:
-    """Whether backups are configured on this install (GENESIS_BACKUP_REPO).
+    """Whether backups are configured on this install.
 
-    Checks the process environment first (genesis-server load_dotenv()s all
-    of secrets.env at startup), then falls back to reading secrets.env
-    directly — the standalone MCP health server only imports an allowlist
-    of vars (scripts/genesis_mcp_server.py _MCP_VARS), so the env alone
-    would wrongly report "disabled" there even on a fully configured
-    install. Fails OPEN (enabled) on read errors: never hide a real backup
-    failure because we couldn't determine the configuration.
+    Three "enabled" signals, any of which suffices:
+
+    1. ``GENESIS_BACKUP_REPO`` in the process environment (genesis-server
+       load_dotenv()s all of secrets.env at startup).
+    2. The var in secrets.env itself — the standalone MCP health server
+       only imports an allowlist of vars (scripts/genesis_mcp_server.py
+       _MCP_VARS), so the env alone would wrongly report "disabled" there
+       even on a fully configured install.
+    3. An existing backup clone at backup.sh's BACKUP_DIR — backup.sh only
+       needs the repo var for the FIRST clone (restore.sh --from <url>, or
+       a transient shell var, creates the clone without persisting the
+       var), and runs indefinitely off the clone's remote afterwards.
+
+    Fails OPEN (enabled) on read errors: never hide a real backup failure
+    because we couldn't determine the configuration.
     """
     val = os.environ.get("GENESIS_BACKUP_REPO", "").strip()
     if val and val not in ("None", "NA"):
+        return True
+    from pathlib import Path as _Path
+
+    if (_Path.home() / "backups" / "genesis-backups" / ".git").is_dir():
         return True
     try:
         from genesis.env import secrets_path

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import UTC, datetime
 
 from genesis.mcp.health import mcp  # noqa: E402
@@ -125,6 +126,37 @@ async def _impl_health_errors(
         return list(grouped.values())
 
     return errors
+
+
+def _backups_enabled() -> bool:
+    """Whether backups are configured on this install (GENESIS_BACKUP_REPO).
+
+    Checks the process environment first (genesis-server load_dotenv()s all
+    of secrets.env at startup), then falls back to reading secrets.env
+    directly — the standalone MCP health server only imports an allowlist
+    of vars (scripts/genesis_mcp_server.py _MCP_VARS), so the env alone
+    would wrongly report "disabled" there even on a fully configured
+    install. Fails OPEN (enabled) on read errors: never hide a real backup
+    failure because we couldn't determine the configuration.
+    """
+    val = os.environ.get("GENESIS_BACKUP_REPO", "").strip()
+    if val and val not in ("None", "NA"):
+        return True
+    try:
+        from genesis.env import secrets_path
+
+        path = secrets_path()
+        if not path.is_file():
+            return False
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("GENESIS_BACKUP_REPO="):
+                v = line.split("=", 1)[1].strip().strip('"').strip("'")
+                return bool(v) and v not in ("None", "NA")
+        return False
+    except Exception:
+        logger.warning("Could not determine backup configuration", exc_info=True)
+        return True
 
 
 async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
@@ -618,10 +650,20 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             logger.error("Genesis update alert check failed", exc_info=True)
 
     # ── Backup health ───────────────────────────────────────────────
+    # Gated on backups being ENABLED on this install: GENESIS_BACKUP_REPO is
+    # the same signal backup.sh itself requires. On an install where backups
+    # are intentionally disabled (another machine owns the offsite backups),
+    # a stale/failed local status file is a dishonest CRITICAL — same class
+    # as the call_site:* source-gating above. Where backups ARE enabled,
+    # real failures still alert (user-facing: dashboard + the outreach
+    # immediate-escalation whitelist — backup targets are external, so this
+    # never wakes the Sentinel; see sentinel/remediation_map.py).
     from pathlib import Path
 
     backup_status_file = Path.home() / ".genesis" / "backup_status.json"
-    if backup_status_file.is_file():
+    if not _backups_enabled():
+        pass
+    elif backup_status_file.is_file():
         try:
             backup_data = json.loads(backup_status_file.read_text())
             if not backup_data.get("success", False):

--- a/src/genesis/observability/types.py
+++ b/src/genesis/observability/types.py
@@ -34,6 +34,7 @@ class Subsystem(StrEnum):
     MAIL = "mail"
     OBSERVABILITY = "observability"
     GUARDIAN = "guardian"
+    SENTINEL = "sentinel"
 
 
 class ProbeStatus(StrEnum):

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -40,6 +40,11 @@ class OutreachConfig:
         "provider:credit_exhaustion",  # Prefix — matches any provider
         "awareness:tick_overdue",
         "service:health_data_uninitialized",
+        # Backups are outside Sentinel scope (external target — see
+        # sentinel/remediation_map.py), so this whitelist is the push
+        # channel for real backup failures on installs where backups
+        # are enabled. Prefix — matches backup:last_failed / backup:overdue.
+        "backup:",
     )
     # Voice proactive chiming — the spoken-aloud allowlist. This IS the menu:
     # a request is spoken only if its signal_type or a source_id part matches
@@ -93,6 +98,7 @@ _DEFAULTS = OutreachConfig(
         "provider:credit_exhaustion",  # Prefix — matches any provider
         "awareness:tick_overdue",
         "service:health_data_uninitialized",
+        "backup:",  # Prefix — push channel now that backups are out of Sentinel scope
     ),
     delivery_routing={"default": "supergroup"},
 )

--- a/src/genesis/sentinel/classifier.py
+++ b/src/genesis/sentinel/classifier.py
@@ -1,8 +1,20 @@
 """Fire alarm classifier — maps health alerts to Sentinel response tiers.
 
-Tier 1: Defense mechanism failures (guards are down) → CC immediately
-Tier 2: Cascading / compounding failures → reflexes first, then CC
-Tier 3: Persistent unresolved conditions → reflexes only unless exhausted
+The Sentinel is Genesis's emergency responder — the firefighter. It is woken
+only for fires it can actually put out: short-term emergencies, inside the
+container, with a real remediation path. Classification is two-stage:
+
+1. **Scope** (can we act?): an alert becomes a fire alarm only if it maps to
+   an available remediation tool (see ``sentinel/remediation_map.py``).
+   Unmapped or unavailable → never a FireAlarm, regardless of severity —
+   the alert stays fully visible to the user/ego via the dashboard, health
+   digest, and outreach escalation; it just doesn't wake the firefighter.
+   Fail-closed. (Direct escalations via ``escalate_direct`` bypass this —
+   the caller has already exercised judgment.)
+2. **Tier** (how urgent?): unchanged semantics for alerts that pass scope —
+   Tier 1: Defense mechanism failures (guards are down) → CC immediately
+   Tier 2: Cascading / compounding failures → reflexes first, then CC
+   Tier 3: Persistent unresolved conditions → reflexes only unless exhausted
 
 The classifier consumes health_alerts from the health MCP and categorizes
 them by severity and pattern.
@@ -12,6 +24,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+
+from genesis.sentinel.remediation_map import is_remediable
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +38,9 @@ _TIER1_PATTERNS = {
     # is genuinely unavailable, a diagnostic CC session cannot run — waking
     # the tool to fix the tool it's missing is a self-defeating loop, and
     # each failed dispatch burns a per-pattern backoff slot for nothing.
-    # Emission severity for cc:quota_exhausted is WARNING (see
-    # mcp/health/errors.py), which routes to Tier 3 via the default path
-    # — the alert stays visible in the dashboard and health_alerts MCP,
-    # but Sentinel doesn't wake. See Part 9c in
-    # .claude/plans/fluttering-humming-bentley.md for the incident.
+    # (They are also unmapped in capabilities.py, so the scope stage drops
+    # them before tiering is ever considered — same rationale, enforced by
+    # the same mechanism as every other non-remediable alert.)
     # Guardian is the host-side safety net. If its heartbeat stops updating,
     # the container has lost its external eyes on itself. This must wake
     # the Sentinel immediately regardless of other conditions.
@@ -38,15 +50,21 @@ _TIER1_PATTERNS = {
     "awareness:tick_overdue",
 }
 
-# Alert IDs for cascading/compounding failures (Tier 2)
+# Alert IDs for cascading/compounding failures (Tier 2).
+# Only ids the health emitter actually produces belong here — the historic
+# entries (memory:critical, disk:critical, embedding:unreachable,
+# qdrant:unreachable, qdrant:collections_missing) matched no emitter id and
+# only "worked" through the CRITICAL blanket rule below; they were removed
+# when capability scoping landed. service:watchdog_failing is real and is
+# listed so its WARNING-severity emission still tiers at 2.
 _TIER2_PATTERNS = {
-    "memory:critical",
-    "disk:critical",
-    "embedding:unreachable",
-    "qdrant:unreachable",
-    "qdrant:collections_missing",
     "service:watchdog_failing",
 }
+
+# Non-remediable CRITICALs are dropped at every awareness tick — log each
+# dropped id once per process so the scope decision is visible in the
+# journal without spamming it.
+_LOGGED_DROPPED_IDS: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -63,15 +81,25 @@ class FireAlarm:
         return self.tier == 1
 
 
-def classify_alerts(alerts: list[dict]) -> list[FireAlarm]:
+def classify_alerts(
+    alerts: list[dict],
+    scope: frozenset[str],
+) -> list[FireAlarm]:
     """Classify health alerts into fire alarm tiers.
 
     Args:
         alerts: List of alert dicts from health_alerts MCP (each has
                 id, severity, message).
+        scope: Available remediation tool ids — callers pass
+               ``remediation_map.available_tools()`` (the dispatcher does)
+               or an explicit frozenset (tests). Deliberately a REQUIRED
+               argument: a default that auto-detects would let a forgotten
+               call site silently pick a polarity.
 
     Returns:
         Fire alarms sorted by tier (worst first). Empty list if no alarms.
+        Alerts with no available remediation tool are never included —
+        the Sentinel is only woken for what it can act on.
     """
     alarms: list[FireAlarm] = []
 
@@ -80,23 +108,33 @@ def classify_alerts(alerts: list[dict]) -> list[FireAlarm]:
         severity = alert.get("severity", "").upper()
         message = alert.get("message", "")
 
-        # Tier 1: Defense mechanism failures
+        # Stage 1 — scope: no remediation tool, no fire alarm.
+        if not is_remediable(alert_id, scope):
+            if severity == "CRITICAL" and alert_id not in _LOGGED_DROPPED_IDS:
+                _LOGGED_DROPPED_IDS.add(alert_id)
+                logger.info(
+                    "Sentinel scope: CRITICAL alert %r has no available "
+                    "remediation tool — not a fire alarm (stays visible "
+                    "on user-facing surfaces)",
+                    alert_id,
+                )
+            continue
+
+        # Stage 2 — tier. Tier 1: Defense mechanism failures.
         if alert_id in _TIER1_PATTERNS:
             alarms.append(FireAlarm(tier=1, alert_id=alert_id, severity=severity, message=message))
             continue
 
-        # Tier 2: Critical infrastructure — known cascading patterns OR any
-        # CRITICAL severity from a trusted emitter. Severity is the contract:
+        # Tier 2: known cascading patterns OR any CRITICAL severity from a
+        # trusted emitter. For in-scope alerts, severity is the contract:
         # if mcp/health/errors.py emits something at CRITICAL, it MEANS
-        # critical, and Sentinel should wake for it. Don't silence the
-        # listener — fix dishonest emitters at the source instead.
-        #
-        # The call_site:* false-CRITICAL spam was fixed by source-gating in
-        # mcp/health/errors.py (skip status=="disabled" + skip wired==False),
-        # NOT by removing this blanket rule. Removing it silently dropped 8
-        # legitimate infrastructure CRITICAL alerts (memory, disk, tmpfs,
-        # qdrant, embeddings, awareness tick overdue, etc.) — see the
-        # regression test test_all_emitted_critical_ids_classify below.
+        # critical, and Sentinel should wake for it. Dishonest emitters get
+        # fixed at the source (e.g. the call_site:* source-gating and the
+        # disabled-backup gate in mcp/health/errors.py), and non-remediable
+        # alerts are excluded by the scope stage above — never by silencing
+        # legitimate in-scope CRITICALs here. The regression test
+        # test_all_emitted_critical_ids_classify pins every emitted CRITICAL
+        # to its expected disposition.
         if alert_id in _TIER2_PATTERNS or severity == "CRITICAL":
             alarms.append(FireAlarm(tier=2, alert_id=alert_id, severity=severity, message=message))
             continue

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -946,7 +946,30 @@ class SentinelDispatcher:
 
         pending_id = self._state.pending_request_id
         if not pending_id:
-            return  # Inconsistent park — the awareness loop's legacy scan covers it.
+            # Inconsistent park: AWAITING with no pending request recorded
+            # (e.g. a partial state-file write). Nothing can ever resolve
+            # this — resume paths are id-matched — so clear it. The old
+            # "legacy scan" fallback for this case was worse than nothing:
+            # it consumed a matching approved row whose id could never
+            # match the empty pending id, eating the approval AND staying
+            # parked.
+            async with self._lock:
+                if self._state.state in (
+                    SentinelState.AWAITING_DISPATCH_APPROVAL,
+                    SentinelState.AWAITING_ACTION_APPROVAL,
+                ) and not self._state.pending_request_id:
+                    self._state.clear_pending()
+                    self._state.transition(
+                        SentinelState.HEALTHY,
+                        reason="awaiting approval with no pending request — inconsistent park cleared",
+                    )
+                    save_state(self._state)
+            await self._emit_event(
+                "WARNING", "sentinel.approval_cleared",
+                "Sentinel was awaiting approval with no pending request "
+                "recorded — inconsistent park cleared, back to HEALTHY",
+            )
+            return
 
         row = await self._approval_gate.get_request(pending_id)
         status = str(row.get("status") or "pending") if row else "missing"

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from genesis.sentinel.classifier import FireAlarm, classify_alerts, worst_tier
 from genesis.sentinel.context import assemble_diagnostic_context
+from genesis.sentinel.remediation_map import available_tools
 from genesis.sentinel.shared import append_log, write_last_run, write_state_for_guardian
 from genesis.sentinel.state import (
     SentinelState,
@@ -300,7 +301,7 @@ class SentinelDispatcher:
             logger.warning("Re-verification failed — proceeding with dispatch", exc_info=True)
             return True  # Fail-open
 
-        current_alarms = classify_alerts(alerts or [])
+        current_alarms = classify_alerts(alerts or [], available_tools())
         current_ids = {a.alert_id for a in current_alarms}
         overlap = original_ids & current_ids
 
@@ -316,6 +317,26 @@ class SentinelDispatcher:
             len(original_ids), current_ids or "none",
         )
         return False
+
+    async def _emit_event(self, severity_name: str, event_type: str, message: str) -> None:
+        """Emit a sentinel event to the bus (no-op without a bus, never raises).
+
+        Sentinel state transitions were historically invisible in the events
+        table (only dispatch/completion emitted, and under the guardian
+        subsystem) — which is how a 26-day approval wedge went unnoticed.
+        Every user-relevant transition now emits under Subsystem.SENTINEL.
+        """
+        if self._event_bus is None:
+            return
+        try:
+            from genesis.observability.types import Severity, Subsystem
+
+            await self._event_bus.emit(
+                Subsystem.SENTINEL, getattr(Severity, severity_name),
+                event_type, message,
+            )
+        except Exception:
+            logger.error("Failed to emit sentinel event %s", event_type, exc_info=True)
 
     async def _gated_dispatch(self, request: SentinelRequest) -> SentinelResult:
         """Gate checks and dispatch, protected by asyncio.Lock."""
@@ -423,6 +444,11 @@ class SentinelDispatcher:
                     )
                     save_state(self._state)
                     append_log({"event": "dispatch_approval_pending", "request_id": request_id})
+                    await self._emit_event(
+                        "INFO", "sentinel.approval_pending",
+                        f"Sentinel dispatch parked awaiting approval "
+                        f"({pattern}): {request.trigger_reason[:120]}",
+                    )
                     return SentinelResult(
                         dispatched=False,
                         reason=f"Dispatch approval pending: {reason}",
@@ -435,6 +461,11 @@ class SentinelDispatcher:
                     self._state.transition(SentinelState.HEALTHY, reason="dispatch rejected via approval gate")
                     save_state(self._state)
                     append_log({"event": "dispatch_rejected", "request_id": request_id})
+                    await self._emit_event(
+                        "INFO", "sentinel.dispatch_rejected",
+                        f"Sentinel dispatch rejected by user ({pattern}) — "
+                        f"pattern suppressed 24h",
+                    )
                     return SentinelResult(
                         dispatched=False,
                         reason="User rejected Sentinel dispatch",
@@ -505,13 +536,10 @@ class SentinelDispatcher:
         })
 
         # Emit event
-        if self._event_bus:
-            from genesis.observability.types import Severity, Subsystem
-            await self._event_bus.emit(
-                Subsystem.GUARDIAN, Severity.INFO,
-                "sentinel.dispatched",
-                f"Sentinel dispatched: {request.trigger_source} — {request.trigger_reason}",
-            )
+        await self._emit_event(
+            "INFO", "sentinel.dispatched",
+            f"Sentinel dispatched: {request.trigger_source} — {request.trigger_reason}",
+        )
 
         # Transition to REMEDIATING and dispatch CC
         self._state.transition(SentinelState.REMEDIATING, reason="dispatching CC session")
@@ -748,15 +776,12 @@ class SentinelDispatcher:
                 logger.error("Failed to create sentinel observation", exc_info=True)
 
         # Emit completion event
-        if self._event_bus:
-            from genesis.observability.types import Severity, Subsystem
-            severity = Severity.INFO if result.resolved else Severity.WARNING
-            await self._event_bus.emit(
-                Subsystem.GUARDIAN, severity,
-                "sentinel.completed",
-                f"Sentinel {'resolved' if result.resolved else 'escalated'}: "
-                f"{result.diagnosis[:100] if result.diagnosis else 'no diagnosis'}",
-            )
+        await self._emit_event(
+            "INFO" if result.resolved else "WARNING",
+            "sentinel.completed",
+            f"Sentinel {'resolved' if result.resolved else 'escalated'}: "
+            f"{result.diagnosis[:100] if result.diagnosis else 'no diagnosis'}",
+        )
 
         return result
 
@@ -893,13 +918,81 @@ class SentinelDispatcher:
 
         return None
 
+    async def converge_pending_approval(self) -> None:
+        """Converge a parked dispatch on its approval row's OBSERVED status.
+
+        Called from the awareness loop each tick while the sentinel is
+        AWAITING_*. Looks up the exact pending request row and applies
+        whatever actually happened to it: approved → consume + resume;
+        rejected → apply the rejection (24h pattern suppression + HEALTHY);
+        expired/cancelled/missing → clear the park. A previous
+        implementation only scanned for approved rows, so a rejection was
+        never delivered and the sentinel stayed parked forever — Gate 2
+        blocks all other dispatches while parked, which blinded the
+        Sentinel for 26 days in June/July 2026.
+
+        State mutations all route through lock-protected, id-re-checking
+        methods (``resume_from_approval`` / ``handle_approval_resolution``),
+        so concurrent ticks race safely: the loser finds the pending id
+        already cleared and no-ops.
+        """
+        if self._approval_gate is None:
+            return
+        if self._state.state not in (
+            SentinelState.AWAITING_DISPATCH_APPROVAL,
+            SentinelState.AWAITING_ACTION_APPROVAL,
+        ):
+            return
+
+        pending_id = self._state.pending_request_id
+        if not pending_id:
+            return  # Inconsistent park — the awareness loop's legacy scan covers it.
+
+        row = await self._approval_gate.get_request(pending_id)
+        status = str(row.get("status") or "pending") if row else "missing"
+
+        if status == "pending":
+            return  # Legitimately parked — the user hasn't decided yet.
+
+        if status == "approved":
+            # Atomic consume — prevents double-dispatch across ticks.
+            if await self._approval_gate.mark_consumed(pending_id):
+                logger.info("Resuming sentinel from approved request %s", pending_id[:8])
+                await self.resume_from_approval(pending_id, "approved")
+            else:
+                # Approved but already consumed while we're still parked — a
+                # prior resume died mid-flight. Don't re-run (can't tell
+                # whether the CC session already executed); clear the stale
+                # park. If the alarm is real it re-fires next tick into a
+                # fresh backoff-gated cycle.
+                logger.warning(
+                    "Sentinel pending approval %s already consumed — clearing stale park",
+                    pending_id[:8],
+                )
+                await self.handle_approval_resolution(pending_id, "cancelled")
+            return
+
+        logger.info(
+            "Sentinel pending approval %s is %s — converging", pending_id[:8], status,
+        )
+        await self.handle_approval_resolution(
+            pending_id,
+            status if status in ("rejected", "cancelled", "expired") else "missing",
+        )
+
     async def handle_approval_resolution(
         self, request_id: str, status: str,
     ) -> SentinelResult | None:
-        """Handle a rejected or cancelled approval.
+        """Converge a parked dispatch on its approval row's observed status.
 
-        Called by the awareness loop or alarm-clearing cancellation.
-        Lock-protected to prevent races with check_fire_alarms.
+        Called by the awareness loop (state-keyed convergence) or the
+        alarm-clearing cancellation. ``rejected`` suppresses the pattern for
+        24h; ``cancelled``/``expired``/``missing`` just clear the park. All
+        paths return to HEALTHY — a resolved (or vanished) approval must
+        never leave the Sentinel parked: a rejected-but-still-active alarm
+        wedged it for 26 days (2026-06-08 → 2026-07-04) because rejections
+        were never delivered here and Gate 2 blocks every other dispatch
+        while parked. Lock-protected to prevent races with check_fire_alarms.
         """
         async with self._lock:
             if self._state.pending_request_id != request_id:
@@ -916,14 +1009,29 @@ class SentinelDispatcher:
                 self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} rejected by user")
                 save_state(self._state)
                 append_log({"event": f"{policy_id}_rejected", "request_id": request_id})
+                await self._emit_event(
+                    "INFO", "sentinel.approval_rejected",
+                    f"Sentinel {policy_id} rejection applied ({pattern}) — "
+                    f"pattern suppressed 24h, back to HEALTHY",
+                )
                 return SentinelResult(dispatched=False, reason=f"{policy_id} rejected")
 
-            if status == "cancelled":
+            if status in ("cancelled", "expired", "missing"):
                 self._state.clear_pending()
-                self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} cancelled (alarm cleared)")
+                self._state.transition(
+                    SentinelState.HEALTHY,
+                    reason=f"{policy_id} approval {status} — park cleared",
+                )
                 save_state(self._state)
-                append_log({"event": f"{policy_id}_cancelled", "request_id": request_id})
-                return SentinelResult(dispatched=False, reason=f"{policy_id} cancelled: alarm cleared")
+                append_log({"event": f"{policy_id}_{status}", "request_id": request_id})
+                await self._emit_event(
+                    "INFO", "sentinel.approval_cleared",
+                    f"Sentinel {policy_id} approval {status} ({pattern}) — "
+                    f"park cleared, back to HEALTHY",
+                )
+                return SentinelResult(
+                    dispatched=False, reason=f"{policy_id} {status}: park cleared",
+                )
 
         return None
 
@@ -1461,7 +1569,7 @@ class SentinelDispatcher:
         self._state.record_heartbeat()
         save_state(self._state)
 
-        alarms = classify_alerts(alerts or [])
+        alarms = classify_alerts(alerts or [], available_tools())
         current_ids = {a.alert_id for a in alarms}
 
         # Update the ring buffer with this tick's alarm ids (always — even
@@ -1504,6 +1612,11 @@ class SentinelDispatcher:
                     self._state.clear_pending()
                     self._state.transition(SentinelState.HEALTHY, reason="pending alarms cleared while awaiting approval")
                     save_state(self._state)
+                await self._emit_event(
+                    "INFO", "sentinel.approval_cleared",
+                    f"Pending alarms {sorted(pending_ids)} cleared while "
+                    f"awaiting approval — park cancelled, back to HEALTHY",
+                )
                 return None
 
         if not alarms:

--- a/src/genesis/sentinel/prompts/SENTINEL.md
+++ b/src/genesis/sentinel/prompts/SENTINEL.md
@@ -44,12 +44,18 @@ You handle infrastructure problems INSIDE the container:
 - Configuration issues (auth, routing, settings)
 - Stuck processes and deadlocks
 - Database connectivity
-- Provider circuit breaker recovery
 
 You do NOT handle:
 - Host VM issues (that's the Guardian's domain)
 - Network issues between container and host (you can detect but not fix)
-- External API outages (circuit breakers handle these automatically)
+- External API outages and provider call sites (circuit breakers + user
+  notification handle these; you cannot fix a third-party service)
+- Backups, provider billing/credits, or anything whose target lives
+  outside the container (escalate-notify surfaces cover these)
+
+Mechanically enforced: an alert only wakes you if it maps to an available
+remediation tool (`sentinel/remediation_map.py`). Direct escalations from
+the Guardian watchdog bypass that map — the caller exercised judgment.
 
 ## Available Tools
 

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -1,0 +1,250 @@
+"""Remediation map — which alerts the Sentinel can actually act on.
+
+The Sentinel is Genesis's emergency responder: it exists for short-term
+emergencies that threaten the continuous operation of the container, and it
+is woken ONLY for conditions it has a real remediation path for. Anything it
+cannot act on — remote backup targets, provider billing/quota, third-party
+API outages — is not a fire alarm: those stay fully visible to the user and
+the ego through the dashboard, health digest, and outreach escalation, but
+they never wake the firefighter.
+
+Naming note: this is deliberately NOT called "capabilities" — in Genesis that
+word means the autonomy grant matrix (``autonomy/capabilities.py``,
+``runtime/_capabilities.py``, ``~/.genesis/capabilities.json``). This module
+describes *infrastructure reach of this install*, a different axis entirely.
+
+Three pieces:
+
+- ``TOOLS`` — each :class:`RemediationTool` names something the Sentinel can
+  do, with a detector answering "is this available on THIS install right
+  now?". Detectors are cheap filesystem checks (they run once per awareness
+  tick) and answer "can we act on it", never "is it healthy" — a tool must
+  not vanish exactly when it is needed.
+- ``REMEDIATION_MAP`` / ``REMEDIATION_PREFIX_MAP`` — alert id (or id prefix)
+  → the set of tools, ANY of which makes the alert remediable.
+- ``UNMAPPED_BY_DESIGN`` — alert ids/prefixes deliberately left unmapped,
+  each with the reason. The coverage test in
+  ``tests/test_sentinel/test_classifier.py`` extracts every alert id the
+  health emitter can produce and requires it to appear in the map or here —
+  so a new CRITICAL emitter cannot silently bypass the Sentinel, and a
+  deliberate exclusion is always an explicit, reviewed decision.
+
+An alert id in neither table is **fail-closed**: it never becomes a fire
+alarm, regardless of severity (and the coverage test fails until it is
+placed). Direct escalations (``SentinelDispatcher.escalate_direct``, used by
+the Guardian watchdog and remediation-registry exhaustion) bypass this map
+by design — the caller has already exercised judgment.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RemediationTool:
+    """One thing the Sentinel can do, with an availability detector."""
+
+    id: str
+    description: str
+    detector: Callable[[], bool]
+
+
+def _always() -> bool:
+    return True
+
+
+def _qdrant_local_unit_present() -> bool:
+    """Local qdrant systemd unit exists → Sentinel can restart it.
+
+    This is "can we act on qdrant", NOT "is qdrant up" — during a qdrant
+    outage the unit file is still there, which is exactly when the tool
+    matters. Installs vary on unit scope (this one uses a user unit), so
+    check both user and system locations.
+    """
+    candidates = (
+        Path.home() / ".config/systemd/user/qdrant.service",
+        Path("/etc/systemd/system/qdrant.service"),
+        Path("/usr/lib/systemd/system/qdrant.service"),
+        Path("/lib/systemd/system/qdrant.service"),
+    )
+    return any(p.exists() for p in candidates)
+
+
+def _guardian_configured() -> bool:
+    """Guardian remote config exists → Sentinel can restart it over SSH."""
+    return (Path.home() / ".genesis" / "guardian_remote.yaml").exists()
+
+
+def _host_resource_alloc() -> bool:
+    """Host-level resource allocation (grow disk/RAM from the hypervisor).
+
+    No tool is wired for this yet — this is the integration slot for a
+    future Proxmox/AWS/host MCP. When one lands, its detector goes here and
+    ``infra:disk_low`` / ``infra:container_memory_high`` proposals gain the
+    host-allocation option (with capacity numbers and user approval).
+    """
+    return False
+
+
+TOOLS: tuple[RemediationTool, ...] = (
+    RemediationTool(
+        "container.services",
+        "Inspect and restart systemd user services inside the container",
+        _always,
+    ),
+    RemediationTool(
+        "container.disk_reclaim",
+        "Reclaim container disk (prune caches, worktrees, temp files)",
+        _always,
+    ),
+    RemediationTool(
+        "container.process_control",
+        "Find and stop runaway processes inside the container",
+        _always,
+    ),
+    RemediationTool(
+        "container.db_local",
+        "Inspect and repair local SQLite state (queues, stuck rows)",
+        _always,
+    ),
+    RemediationTool(
+        "qdrant.local",
+        "Restart the local Qdrant systemd service",
+        _qdrant_local_unit_present,
+    ),
+    RemediationTool(
+        "guardian.ssh_restart",
+        "Restart the host-side Guardian over SSH (guardian-gateway)",
+        _guardian_configured,
+    ),
+    RemediationTool(
+        "host.resource_alloc",
+        "Allocate additional disk/RAM from the host (future Proxmox/AWS MCP)",
+        _host_resource_alloc,
+    ),
+)
+
+
+# Alert id → tools, ANY of which makes the alert remediable.
+# Exact ids first; dynamic-suffix families live in the prefix map below.
+REMEDIATION_MAP: dict[str, frozenset[str]] = {
+    "service:genesis_down": frozenset({"container.services"}),
+    "service:watchdog_blind": frozenset({"container.services"}),
+    "service:watchdog_failing": frozenset({"container.services"}),
+    "service:health_data_uninitialized": frozenset({"container.services"}),
+    "awareness:tick_overdue": frozenset({"container.services"}),
+    "guardian:heartbeat_stale": frozenset({"guardian.ssh_restart"}),
+    "infra:disk_low": frozenset({"container.disk_reclaim", "host.resource_alloc"}),
+    "infra:container_memory_high": frozenset(
+        {"container.process_control", "host.resource_alloc"}
+    ),
+    "infra:qdrant_collections_missing": frozenset({"qdrant.local"}),
+    "provider:qdrant_unreachable": frozenset({"qdrant.local"}),
+    "genesis:update_failed": frozenset({"container.services"}),
+}
+
+# Alert id PREFIX → tools, for families with dynamic suffixes.
+REMEDIATION_PREFIX_MAP: dict[str, frozenset[str]] = {
+    # Genesis's own scheduler jobs silently failing — internal, restartable.
+    "job_stale:": frozenset({"container.services"}),
+    # Quarantined scheduler jobs — internal state, repairable.
+    "job:quarantined:": frozenset({"container.services", "container.db_local"}),
+    # Queue depth / dead letters — local SQLite state.
+    "queue:": frozenset({"container.db_local"}),
+}
+
+# Alert ids/prefixes (a trailing ":" marks a prefix) deliberately excluded
+# from Sentinel scope, with the reason. These stay user-visible: the alerts
+# still appear on the dashboard and health digest, and the ids below are on
+# the outreach immediate-escalation whitelist (outreach/config.py) so real
+# failures still ping the user — they just never wake the firefighter.
+UNMAPPED_BY_DESIGN: dict[str, str] = {
+    "backup:": (
+        "Backup targets are external (remote git repo / S3 / NAS) — both "
+        "the target and the credentials live outside the container. "
+        "Escalate-notify only."
+    ),
+    "provider:credit_exhaustion:": (
+        "Provider billing. Refilling credits is a user action, and a "
+        "financial one (no-unsanctioned-transactions rule). Same reasoning "
+        "as the long-standing cc:quota_exhausted exclusion."
+    ),
+    "provider:embedding_failing": (
+        "The embedding provider is a remote API — a third-party outage is "
+        "not remediable from inside the container."
+    ),
+    "cc:budget": (
+        "The Sentinel's only response tool IS a CC session; waking it for "
+        "CC budget/quota problems is self-defeating (see classifier note)."
+    ),
+    "cc:quota_exhausted": (
+        "Self-defeating loop — see cc:budget / classifier Tier-1 note."
+    ),
+    "infra:ollama_model_mismatch": (
+        "Ollama is optional and typically runs on a separate machine — "
+        "model pulls there are not the container's to make."
+    ),
+    "backup:tier2_unconfigured": (
+        "Backup configuration guidance, not an emergency (WARNING-level; "
+        "also covered by the backup: prefix rule above)."
+    ),
+    "genesis:update_available": (
+        "INFO-level notice; updating is a user/steward decision."
+    ),
+    "call_site:": (
+        "Provider call sites going down is dominated by external API "
+        "outages the Sentinel cannot fix (user decision 2026-07-04: an API "
+        "site being down is for the user/ego to know about, not the "
+        "firefighter). In-container circuit-breaker resets can return as a "
+        "dedicated tool later if the stuck-breaker case proves real."
+    ),
+}
+
+
+def available_tools() -> frozenset[str]:
+    """Evaluate every detector and return the available tool ids.
+
+    Called once per fire-alarm check (~5 min awareness tick) — detectors
+    are cheap filesystem checks, so no caching is needed. A detector that
+    raises is treated as unavailable (fail-closed) and logged.
+    """
+    available: set[str] = set()
+    for tool in TOOLS:
+        try:
+            if tool.detector():
+                available.add(tool.id)
+        except Exception:
+            logger.warning(
+                "Remediation tool detector %s raised — treating as unavailable",
+                tool.id, exc_info=True,
+            )
+    return frozenset(available)
+
+
+def required_tools(alert_id: str) -> frozenset[str] | None:
+    """The tool set mapped for this alert id, or None if unmapped."""
+    exact = REMEDIATION_MAP.get(alert_id)
+    if exact is not None:
+        return exact
+    for prefix, tools in REMEDIATION_PREFIX_MAP.items():
+        if alert_id.startswith(prefix):
+            return tools
+    return None
+
+
+def is_remediable(alert_id: str, scope: frozenset[str]) -> bool:
+    """True iff the alert maps to at least one AVAILABLE tool.
+
+    Unmapped → False (fail-closed): an alert nobody has declared a
+    remediation path for must not wake the Sentinel, no matter how loud.
+    """
+    required = required_tools(alert_id)
+    if required is None:
+        return False
+    return bool(required & scope)

--- a/tests/test_mcp/test_health_mcp.py
+++ b/tests/test_mcp/test_health_mcp.py
@@ -702,3 +702,19 @@ class TestBackupsEnabledHelper:
         secrets.write_text("GENESIS_BACKUP_REPO=\n")
         monkeypatch.setattr("genesis.env.secrets_path", lambda: secrets)
         assert _backups_enabled() is False
+
+    def test_existing_clone_counts_as_enabled(self, monkeypatch, tmp_path):
+        """backup.sh only needs GENESIS_BACKUP_REPO for the FIRST clone —
+        an existing clone (e.g. created by restore.sh --from <url>) keeps
+        backing up off the clone's remote with the var never persisted.
+        Such an install must still alert on failures.
+        """
+        from pathlib import Path
+
+        from genesis.mcp.health.errors import _backups_enabled
+
+        fake_home = tmp_path / "fakehome"
+        (fake_home / "backups" / "genesis-backups" / ".git").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        assert _backups_enabled() is True

--- a/tests/test_mcp/test_health_mcp.py
+++ b/tests/test_mcp/test_health_mcp.py
@@ -583,3 +583,122 @@ async def test_session_set_effort_empty_session_id():
     result = await _impl_session_set_effort("  ", "high")
     assert "error" in result
     assert "required" in result["error"].lower()
+
+
+class TestBackupAlertGate:
+    """Backup alerts are gated on backups being ENABLED on this install
+    (GENESIS_BACKUP_REPO). A failed/stale status file on an install where
+    backups are intentionally disabled is a dishonest CRITICAL — it wedged
+    the Sentinel for 26 days via a rejected approval that could never be
+    re-resolved. Where backups ARE enabled, real failures still alert.
+    """
+
+    def _svc(self):
+        svc = AsyncMock()
+        svc.snapshot.return_value = {
+            "call_sites": {},
+            "cc_sessions": {"background": {}},
+            "infrastructure": {},
+            "queues": {},
+            "awareness": {},
+        }
+        return svc
+
+    def _fake_home(self, tmp_path, status: dict | None):
+        import json as _json
+
+        fake_home = tmp_path / "fakehome"
+        (fake_home / ".genesis").mkdir(parents=True)
+        if status is not None:
+            (fake_home / ".genesis" / "backup_status.json").write_text(
+                _json.dumps(status),
+            )
+        return fake_home
+
+    async def _alerts(self, monkeypatch, tmp_path, *, status, enabled):
+        from pathlib import Path
+
+        fake_home = self._fake_home(tmp_path, status)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        monkeypatch.setattr(
+            "genesis.mcp.health.errors._backups_enabled", lambda: enabled,
+        )
+        old_service = health_mcp_mod._service
+        old_history = health_mcp_mod._alert_history.copy()
+        try:
+            health_mcp_mod._service = self._svc()
+            health_mcp_mod._alert_history = {}
+            return await _impl_health_alerts()
+        finally:
+            health_mcp_mod._service = old_service
+            health_mcp_mod._alert_history = old_history
+
+    async def test_disabled_install_emits_no_backup_alerts(self, monkeypatch, tmp_path):
+        alerts = await self._alerts(
+            monkeypatch, tmp_path,
+            status={"timestamp": "2026-07-02T18:38:34Z", "success": False,
+                    "failure_reason": "Cannot clone backup repo without GENESIS_BACKUP_REPO"},
+            enabled=False,
+        )
+        assert not [a for a in alerts if a["id"].startswith("backup:")]
+
+    async def test_disabled_install_no_not_configured_nag(self, monkeypatch, tmp_path):
+        alerts = await self._alerts(monkeypatch, tmp_path, status=None, enabled=False)
+        assert not [a for a in alerts if a["id"].startswith("backup:")]
+
+    async def test_enabled_install_failed_backup_still_alerts(self, monkeypatch, tmp_path):
+        alerts = await self._alerts(
+            monkeypatch, tmp_path,
+            status={"timestamp": "2026-07-02T18:38:34Z", "success": False,
+                    "failure_reason": "push failed"},
+            enabled=True,
+        )
+        failed = [a for a in alerts if a["id"] == "backup:last_failed"]
+        assert len(failed) == 1
+        assert failed[0]["severity"] == "CRITICAL"
+
+    async def test_enabled_install_missing_status_still_nags(self, monkeypatch, tmp_path):
+        alerts = await self._alerts(monkeypatch, tmp_path, status=None, enabled=True)
+        assert [a for a in alerts if a["id"] == "backup:not_configured"]
+
+
+class TestBackupsEnabledHelper:
+    """_backups_enabled: env first (server process), secrets.env file as
+    fallback (the standalone MCP server only imports an allowlist of vars,
+    so the env alone under-reports there)."""
+
+    def test_env_var_set(self, monkeypatch):
+        from genesis.mcp.health.errors import _backups_enabled
+
+        monkeypatch.setenv("GENESIS_BACKUP_REPO", "https://example.com/o/backups.git")
+        assert _backups_enabled() is True
+
+    def test_unset_everywhere(self, monkeypatch, tmp_path):
+        from genesis.mcp.health.errors import _backups_enabled
+
+        monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        monkeypatch.setattr(
+            "genesis.env.secrets_path", lambda: tmp_path / "secrets.env",
+        )
+        assert _backups_enabled() is False
+
+    def test_secrets_file_fallback(self, monkeypatch, tmp_path):
+        from genesis.mcp.health.errors import _backups_enabled
+
+        monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text(
+            "API_KEY_DEEPINFRA=abc\n"
+            'GENESIS_BACKUP_REPO="https://example.com/o/backups.git"\n'
+        )
+        monkeypatch.setattr("genesis.env.secrets_path", lambda: secrets)
+        assert _backups_enabled() is True
+
+    def test_secrets_file_empty_value(self, monkeypatch, tmp_path):
+        from genesis.mcp.health.errors import _backups_enabled
+
+        monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text("GENESIS_BACKUP_REPO=\n")
+        monkeypatch.setattr("genesis.env.secrets_path", lambda: secrets)
+        assert _backups_enabled() is False

--- a/tests/test_sentinel/test_classifier.py
+++ b/tests/test_sentinel/test_classifier.py
@@ -1,19 +1,48 @@
-"""Tests for genesis.sentinel.classifier — fire alarm tier classification."""
+"""Tests for genesis.sentinel.classifier — scope gate + fire alarm tiers.
+
+Classification is two-stage (see classifier docstring): scope (is the alert
+remediable with an available tool?) then tier. These tests pin BOTH stages:
+the boundary test enumerates every alert id the health emitter can produce
+and requires an explicit disposition (mapped or unmapped-by-design), so a
+new CRITICAL emitter can neither silently bypass the Sentinel nor silently
+wake it.
+"""
 
 from __future__ import annotations
 
-from genesis.sentinel.classifier import FireAlarm, classify_alerts, worst_tier
+import re
+from pathlib import Path
+
+from genesis.sentinel.classifier import (
+    _TIER1_PATTERNS,
+    FireAlarm,
+    classify_alerts,
+    worst_tier,
+)
+from genesis.sentinel.remediation_map import (
+    REMEDIATION_MAP,
+    REMEDIATION_PREFIX_MAP,
+    TOOLS,
+    UNMAPPED_BY_DESIGN,
+    available_tools,
+    is_remediable,
+    required_tools,
+)
+
+# Every tool available — makes remediability deterministic in tier tests so
+# the only variable is the map, not this machine's install shape.
+FULL_SCOPE = frozenset(t.id for t in TOOLS)
 
 
 class TestClassifyAlerts:
     def test_empty_alerts(self):
-        assert classify_alerts([]) == []
+        assert classify_alerts([], FULL_SCOPE) == []
 
     def test_tier1_defense_failure(self):
         alerts = [
             {"id": "service:watchdog_blind", "severity": "WARNING", "message": "Watchdog inactive"},
         ]
-        alarms = classify_alerts(alerts)
+        alarms = classify_alerts(alerts, FULL_SCOPE)
         assert len(alarms) == 1
         assert alarms[0].tier == 1
         assert alarms[0].is_defense_failure
@@ -29,145 +58,265 @@ class TestClassifyAlerts:
                 "message": "Guardian heartbeat not updating (stale 600s)",
             },
         ]
-        alarms = classify_alerts(alerts)
+        alarms = classify_alerts(alerts, FULL_SCOPE)
         assert len(alarms) == 1
         assert alarms[0].tier == 1
         assert alarms[0].is_defense_failure
 
     def test_tier2_critical_infrastructure(self):
         alerts = [
-            {"id": "memory:critical", "severity": "CRITICAL", "message": "Memory >90%"},
+            {"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "Memory >90%"},
         ]
-        alarms = classify_alerts(alerts)
+        alarms = classify_alerts(alerts, FULL_SCOPE)
         assert len(alarms) == 1
         assert alarms[0].tier == 2
 
-    def test_tier2_generic_critical(self):
-        """Any CRITICAL severity gets promoted to Tier 2 by the blanket rule.
-
-        Severity is the contract: emitters that mark something CRITICAL mean
-        it. The classifier trusts them and wakes Sentinel. Fixing dishonest
-        emitters happens at the source (gate at health_alerts), not by
-        silencing the listener.
+    def test_unmapped_critical_is_fail_closed(self):
+        """An alert id with NO remediation mapping never classifies, even at
+        CRITICAL. This inverts the old blanket rule ("any CRITICAL wakes the
+        Sentinel"): the Sentinel is an emergency responder and is only woken
+        for fires it can actually put out. Severity is still the contract
+        for URGENCY of in-scope alerts; scope is the contract for WHETHER it
+        is the Sentinel's fire at all. Fail-closed is safe because the
+        boundary test below forces every emitted id to take an explicit
+        disposition — nothing can be unmapped by accident.
         """
         alerts = [
             {"id": "unknown:thing", "severity": "CRITICAL", "message": "Something critical"},
         ]
-        alarms = classify_alerts(alerts)
-        assert len(alarms) == 1
-        assert alarms[0].tier == 2  # Any CRITICAL is at least Tier 2
+        assert classify_alerts(alerts, FULL_SCOPE) == []
 
-    def test_all_emitted_critical_ids_classify(self):
-        """Regression: every CRITICAL alert id emitted by _impl_health_alerts
-        MUST classify to Tier 1 or Tier 2.
-
-        This is the trip-wire for emission/classification drift. If a new
-        CRITICAL alert is added to mcp/health/errors.py without updating
-        _TIER1_PATTERNS or _TIER2_PATTERNS (or being explicitly suppressed
-        at the source), this test fails immediately.
-
-        Source IDs verified against src/genesis/mcp/health/errors.py
-        on 2026-04-09. When adding/removing CRITICAL alert sources, update
-        both files together and add the new id to this list.
+    def test_scope_relative_guardian(self):
+        """The same alert classifies or not depending on available tools —
+        an install without a Guardian configured has no SSH-restart path,
+        so a stale-guardian alarm cannot wake a Sentinel that can't act.
         """
-        emitted_critical_ids = [
-            "service:genesis_down",                # Tier 1
-            # cc:quota_exhausted removed from this list in Part 9 — it
-            # is now emitted at WARNING severity (mcp/health/errors.py)
-            # and deliberately not in _TIER1_PATTERNS (see classifier.py
-            # rationale). It routes to Tier 3 via the WARNING fall-through.
-            "guardian:heartbeat_stale",             # Tier 1 (Part 8)
-            "awareness:tick_overdue",               # Tier 1 (explicit — defense mechanism)
-            "infra:disk_low",                       # Tier 2 (via blanket)
-            "infra:container_memory_high",          # Tier 2 (via blanket)
-            "infra:qdrant_collections_missing",     # Tier 2 (via blanket)
-            "provider:embedding_failing",           # Tier 2 (via blanket)
-            "provider:qdrant_unreachable",          # Tier 2 (via blanket)
-            "genesis:update_failed",                # Tier 2 (via blanket)
+        alerts = [
+            {"id": "guardian:heartbeat_stale", "severity": "CRITICAL", "message": "stale"},
         ]
-        for alert_id in emitted_critical_ids:
-            alarms = classify_alerts([
-                {"id": alert_id, "severity": "CRITICAL", "message": f"test {alert_id}"},
-            ])
-            assert len(alarms) == 1, (
-                f"{alert_id} did not classify — would be silently dropped. "
-                f"Add to _TIER1_PATTERNS or _TIER2_PATTERNS, OR document why "
-                f"it should be suppressed at the emitter in errors.py."
-            )
-            assert alarms[0].tier in (1, 2), (
-                f"{alert_id} classified as Tier {alarms[0].tier}, expected 1 or 2"
-            )
+        without = FULL_SCOPE - {"guardian.ssh_restart"}
+        assert classify_alerts(alerts, without) == []
+        assert len(classify_alerts(alerts, FULL_SCOPE)) == 1
 
     def test_cc_quota_exhausted_not_tier1(self):
-        """Part 9c: cc:quota_exhausted must NOT be in Tier 1.
+        """cc:quota_exhausted must NOT be in Tier 1.
 
         The Sentinel's only response tool is dispatching a CC session.
         If CC is unavailable, the diagnostic CC session cannot run —
-        waking Sentinel for CC failures is self-defeating. The alert
-        is downgraded to WARNING at the emitter and routes to Tier 3.
+        waking Sentinel for CC failures is self-defeating.
         """
-        from genesis.sentinel.classifier import _TIER1_PATTERNS
-
         assert "cc:quota_exhausted" not in _TIER1_PATTERNS
         assert "cc:unavailable" not in _TIER1_PATTERNS
 
-    def test_cc_quota_exhausted_warning_is_tier3(self):
-        """With emission severity downgraded to WARNING, cc:quota_exhausted
-        routes to Tier 3 via the default WARNING fall-through.
+    def test_cc_quota_exhausted_never_classifies(self):
+        """cc:* alerts are unmapped-by-design (self-defeating loop), so they
+        no longer classify at any severity — previously the WARNING routed
+        to inert Tier 3; now the scope stage drops it entirely. The alert
+        itself stays visible (dashboard + outreach whitelist).
         """
-        alerts = [
-            {
-                "id": "cc:quota_exhausted",
-                "severity": "WARNING",
-                "message": "CC rate limited — contingency mode active",
-            },
-        ]
-        alarms = classify_alerts(alerts)
-        assert len(alarms) == 1
-        assert alarms[0].tier == 3
+        for severity in ("WARNING", "CRITICAL"):
+            alerts = [
+                {"id": "cc:quota_exhausted", "severity": severity, "message": "rate limited"},
+            ]
+            assert classify_alerts(alerts, FULL_SCOPE) == []
 
     def test_tier3_warning(self):
         alerts = [
-            {"id": "some:warning", "severity": "WARNING", "message": "Something warned"},
+            {"id": "queue:deferred_work", "severity": "WARNING", "message": "Queue deep"},
         ]
-        alarms = classify_alerts(alerts)
+        alarms = classify_alerts(alerts, FULL_SCOPE)
         assert len(alarms) == 1
         assert alarms[0].tier == 3
 
     def test_mixed_tiers_sorted(self):
         alerts = [
-            {"id": "some:warning", "severity": "WARNING", "message": "Minor"},
+            {"id": "queue:deferred_work", "severity": "WARNING", "message": "Minor"},
             {"id": "service:watchdog_blind", "severity": "WARNING", "message": "Watchdog"},
-            {"id": "memory:critical", "severity": "CRITICAL", "message": "Memory"},
+            {"id": "infra:disk_low", "severity": "CRITICAL", "message": "Disk"},
         ]
-        alarms = classify_alerts(alerts)
+        alarms = classify_alerts(alerts, FULL_SCOPE)
         assert len(alarms) == 3
         # Sorted by tier (worst first)
         assert alarms[0].tier == 1
         assert alarms[1].tier == 2
         assert alarms[2].tier == 3
 
-    def test_call_site_down_is_tier3(self):
-        """Call site DOWN alerts emit WARNING (not CRITICAL) because the
-        Sentinel has no remediation path for provider circuit breakers.
-        WARNING routes to Tier 3 (reflexes only, Sentinel stays asleep).
+    def test_call_site_alerts_never_classify(self):
+        """Provider call sites going down is dominated by external API
+        outages the Sentinel cannot fix — unmapped by design (user decision
+        2026-07-04). Any severity.
         """
-        alerts = [
-            {
-                "id": "call_site:33_skill_refiner",
-                "severity": "WARNING",
-                "message": "Call site 33_skill_refiner is DOWN (all providers exhausted)",
-            },
-        ]
-        alarms = classify_alerts(alerts)
-        assert len(alarms) == 1
-        assert alarms[0].tier == 3
+        for severity in ("WARNING", "CRITICAL"):
+            alerts = [
+                {
+                    "id": "call_site:33_skill_refiner",
+                    "severity": severity,
+                    "message": "Call site 33_skill_refiner is DOWN (all providers exhausted)",
+                },
+            ]
+            assert classify_alerts(alerts, FULL_SCOPE) == []
 
     def test_info_severity_ignored(self):
         alerts = [
-            {"id": "resolved:thing", "severity": "INFO", "message": "All good"},
+            {"id": "genesis:update_failed", "severity": "INFO", "message": "All good"},
         ]
-        assert classify_alerts(alerts) == []
+        assert classify_alerts(alerts, FULL_SCOPE) == []
+
+
+# The ratified scope boundary (user decision 2026-07-04). IN = internal,
+# remediable, wakes the Sentinel at CRITICAL. OUT = external / not
+# remediable, never wakes it at any severity.
+RATIFIED_IN = [
+    "service:genesis_down",
+    "service:health_data_uninitialized",
+    "guardian:heartbeat_stale",
+    "awareness:tick_overdue",
+    "infra:disk_low",
+    "infra:container_memory_high",
+    "infra:qdrant_collections_missing",
+    "provider:qdrant_unreachable",  # LOCAL qdrant — restartable
+    "genesis:update_failed",
+]
+RATIFIED_OUT = [
+    "backup:last_failed",
+    "backup:overdue",
+    "backup:not_configured",
+    "provider:credit_exhaustion:deepinfra",
+    "provider:embedding_failing",
+    "cc:budget",
+    "cc:quota_exhausted",
+    "infra:ollama_model_mismatch",
+    "call_site:5_deep_reflection",
+]
+
+
+class TestScopeBoundary:
+    def test_ratified_in_classify_at_critical(self):
+        for alert_id in RATIFIED_IN:
+            alarms = classify_alerts(
+                [{"id": alert_id, "severity": "CRITICAL", "message": f"test {alert_id}"}],
+                FULL_SCOPE,
+            )
+            assert len(alarms) == 1, (
+                f"{alert_id} did not classify — an internal CRITICAL would be "
+                f"silently dropped. Map it in sentinel/remediation_map.py."
+            )
+            assert alarms[0].tier in (1, 2), (
+                f"{alert_id} classified as Tier {alarms[0].tier}, expected 1 or 2"
+            )
+
+    def test_ratified_out_never_classify(self):
+        for alert_id in RATIFIED_OUT:
+            alarms = classify_alerts(
+                [{"id": alert_id, "severity": "CRITICAL", "message": f"test {alert_id}"}],
+                FULL_SCOPE,
+            )
+            assert alarms == [], (
+                f"{alert_id} classified as a fire alarm — it is outside "
+                f"Sentinel scope by user decision (2026-07-04). If this is "
+                f"intentional, update RATIFIED_OUT with the new decision."
+            )
+
+    def test_tier1_patterns_all_mapped(self):
+        """Every Tier-1 (defense failure) id must have a remediation
+        mapping, or Tier-1 wake dies silently at the scope stage.
+        """
+        for alert_id in _TIER1_PATTERNS:
+            assert required_tools(alert_id) is not None, (
+                f"Tier-1 pattern {alert_id} has no remediation mapping — "
+                f"defense-failure wake would be silently dropped"
+            )
+
+
+def _emitted_id_shapes() -> set[str]:
+    """Every alert id shape the health emitter can produce, extracted
+    mechanically from the source. Dynamic-suffix f-string ids are
+    normalized to their prefix (text before the first ``{``).
+    """
+    import genesis.mcp.health.errors as errors_mod
+
+    src = Path(errors_mod.__file__).read_text()
+    raw = set(re.findall(r'(?:alert_id = |"id": )f?"([^"]+)"', src))
+    shapes = set()
+    for rid in raw:
+        shapes.add(rid.split("{", 1)[0] if "{" in rid else rid)
+    return shapes
+
+
+class TestEmitterCoverage:
+    """Cross-cutting coverage guardrail (same pattern as
+    test_recall_inject_coverage): every alert id the emitter can produce
+    must take an EXPLICIT disposition — mapped in the remediation map, or
+    listed in UNMAPPED_BY_DESIGN with a reason. A new emitter that does
+    neither fails here, so scope drift is impossible in either direction.
+    """
+
+    @staticmethod
+    def _placed(shape: str) -> bool:
+        if shape in REMEDIATION_MAP or shape in UNMAPPED_BY_DESIGN:
+            return True
+        for prefix in REMEDIATION_PREFIX_MAP:
+            if shape.startswith(prefix) or prefix.startswith(shape):
+                return True
+        for key in UNMAPPED_BY_DESIGN:
+            if key.endswith(":") and (shape.startswith(key) or key.startswith(shape)):
+                return True
+        return False
+
+    def test_every_emitted_id_has_explicit_disposition(self):
+        shapes = _emitted_id_shapes()
+        assert shapes, "extraction found no alert ids — regex drifted from errors.py style"
+        unplaced = sorted(s for s in shapes if not self._placed(s))
+        assert not unplaced, (
+            f"Alert ids with no explicit Sentinel disposition: {unplaced}. "
+            f"Add each to REMEDIATION_MAP/REMEDIATION_PREFIX_MAP (wakes the "
+            f"Sentinel) or UNMAPPED_BY_DESIGN with a reason (never wakes it) "
+            f"in sentinel/remediation_map.py."
+        )
+
+    def test_extraction_sees_known_ids(self):
+        """Canary for the regex itself — if errors.py changes its emission
+        style, extraction must fail loudly, not return a shrunken set.
+        """
+        shapes = _emitted_id_shapes()
+        for known in ("backup:last_failed", "service:genesis_down", "call_site:",
+                      "provider:credit_exhaustion:", "service:health_data_uninitialized"):
+            assert known in shapes, f"extraction lost {known} — update the regex"
+
+
+class TestRemediationMap:
+    def test_available_tools_returns_frozenset(self):
+        tools = available_tools()
+        assert isinstance(tools, frozenset)
+        # The always-available container tools must be present everywhere.
+        assert {"container.services", "container.disk_reclaim",
+                "container.process_control", "container.db_local"} <= tools
+
+    def test_detector_failure_is_unavailable(self, monkeypatch):
+        """A raising detector means the tool is treated as unavailable
+        (fail-closed), not a crash of the classification path.
+        """
+        import genesis.sentinel.remediation_map as rm
+
+        def _boom() -> bool:
+            raise RuntimeError("detector exploded")
+
+        broken = tuple(
+            rm.RemediationTool(t.id, t.description, _boom)
+            if t.id == "qdrant.local" else t
+            for t in rm.TOOLS
+        )
+        monkeypatch.setattr(rm, "TOOLS", broken)
+        assert "qdrant.local" not in rm.available_tools()
+
+    def test_is_remediable_requires_available_tool(self):
+        assert is_remediable("infra:disk_low", frozenset({"container.disk_reclaim"}))
+        assert not is_remediable("infra:disk_low", frozenset({"container.db_local"}))
+        assert not is_remediable("not:mapped", FULL_SCOPE)
+
+    def test_unmapped_by_design_reasons_are_substantive(self):
+        for key, reason in UNMAPPED_BY_DESIGN.items():
+            assert len(reason) > 30, f"UNMAPPED_BY_DESIGN[{key!r}] needs a real reason"
 
 
 class TestWorstTier:

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -227,9 +227,9 @@ class TestExtractPattern:
         req = SentinelRequest(
             trigger_source="fire_alarm",
             trigger_reason="Tier 2: Memory >90%",
-            alarms=[FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")],
+            alarms=[FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")],
         )
-        assert _extract_pattern(req) == "memory:critical"
+        assert _extract_pattern(req) == "infra:container_memory_high"
 
     def test_direct_escalation_uses_trigger_source(self):
         req = SentinelRequest(
@@ -245,7 +245,7 @@ class TestExtractPattern:
             trigger_reason="multi",
             alarms=[
                 FireAlarm(tier=1, alert_id="service:watchdog_blind", severity="WARNING", message="a"),
-                FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="b"),
+                FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="b"),
             ],
         )
         assert _extract_pattern(req) == "service:watchdog_blind"
@@ -254,55 +254,55 @@ class TestExtractPattern:
 class TestBackoffReady:
     def test_first_attempt_immediate(self):
         d = _make_dispatcher()
-        ready, _ = d._backoff_ready("memory:critical")
+        ready, _ = d._backoff_ready("infra:container_memory_high")
         assert ready is True
 
     def test_second_attempt_blocked_until_15min(self):
         d = _make_dispatcher()
         # Simulate one prior attempt, just now
-        d._pattern_attempts["memory:critical"] = [time.monotonic()]
-        ready, reason = d._backoff_ready("memory:critical")
+        d._pattern_attempts["infra:container_memory_high"] = [time.monotonic()]
+        ready, reason = d._backoff_ready("infra:container_memory_high")
         assert ready is False
         assert "backoff" in reason.lower()
 
     def test_second_attempt_ready_after_15min(self):
         d = _make_dispatcher()
         # Simulate one prior attempt >15 min ago
-        d._pattern_attempts["memory:critical"] = [time.monotonic() - (16 * 60)]
-        ready, _ = d._backoff_ready("memory:critical")
+        d._pattern_attempts["infra:container_memory_high"] = [time.monotonic() - (16 * 60)]
+        ready, _ = d._backoff_ready("infra:container_memory_high")
         assert ready is True
 
     def test_third_attempt_needs_45min(self):
         d = _make_dispatcher()
         now = time.monotonic()
         # Two prior attempts; last was 30 min ago (< 45 min required)
-        d._pattern_attempts["memory:critical"] = [now - 3600, now - (30 * 60)]
-        ready, _ = d._backoff_ready("memory:critical")
+        d._pattern_attempts["infra:container_memory_high"] = [now - 3600, now - (30 * 60)]
+        ready, _ = d._backoff_ready("infra:container_memory_high")
         assert ready is False
 
         # Bump the last attempt to 50 min ago — should clear
-        d._pattern_attempts["memory:critical"] = [now - 7200, now - (50 * 60)]
-        ready, _ = d._backoff_ready("memory:critical")
+        d._pattern_attempts["infra:container_memory_high"] = [now - 7200, now - (50 * 60)]
+        ready, _ = d._backoff_ready("infra:container_memory_high")
         assert ready is True
 
     def test_fourth_attempt_needs_2h(self):
         d = _make_dispatcher()
         now = time.monotonic()
         # Three prior attempts, last was 1h ago (< 2h)
-        d._pattern_attempts["memory:critical"] = [
+        d._pattern_attempts["infra:container_memory_high"] = [
             now - 7200, now - 5400, now - 3600,
         ]
-        ready, _ = d._backoff_ready("memory:critical")
+        ready, _ = d._backoff_ready("infra:container_memory_high")
         assert ready is False
 
     def test_fifth_attempt_hits_escalation(self):
         """4 prior attempts → the 5th attempt = escalation threshold."""
         d = _make_dispatcher()
         now = time.monotonic()
-        d._pattern_attempts["memory:critical"] = [
+        d._pattern_attempts["infra:container_memory_high"] = [
             now - 10000, now - 8000, now - 6000, now - 3000,
         ]
-        ready, reason = d._backoff_ready("memory:critical")
+        ready, reason = d._backoff_ready("infra:container_memory_high")
         # _backoff_ready returns ready=True at the threshold — the dispatcher
         # distinguishes escalation from normal dispatch separately.
         assert ready is True
@@ -310,14 +310,14 @@ class TestBackoffReady:
 
     def test_escalated_pattern_always_blocked(self):
         d = _make_dispatcher()
-        d._escalated_patterns["memory:critical"] = "2026-04-09T23:00:00+00:00"
-        ready, reason = d._backoff_ready("memory:critical")
+        d._escalated_patterns["infra:container_memory_high"] = "2026-04-09T23:00:00+00:00"
+        ready, reason = d._backoff_ready("infra:container_memory_high")
         assert ready is False
         assert "escalated" in reason.lower()
 
     def test_different_patterns_have_independent_backoff(self):
         d = _make_dispatcher()
-        d._pattern_attempts["memory:critical"] = [time.monotonic()]
+        d._pattern_attempts["infra:container_memory_high"] = [time.monotonic()]
         # Other pattern should still be ready
         ready, _ = d._backoff_ready("infra:disk_low")
         assert ready is True
@@ -345,9 +345,9 @@ class TestPatternResetOnResolve:
         d._state.started_at = "2020-01-01T00:00:00+00:00"
         # Pre-seed one old attempt (past 15-min wait) so the next attempt
         # is ready — and then verify the whole counter gets wiped on resolve.
-        d._pattern_attempts["memory:critical"] = [time.monotonic() - (20 * 60)]
+        d._pattern_attempts["infra:container_memory_high"] = [time.monotonic() - (20 * 60)]
 
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.write_last_run"), \
              patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
@@ -362,7 +362,7 @@ class TestPatternResetOnResolve:
         assert result.dispatched
         assert result.resolved
         # Pattern cleared after resolution
-        assert "memory:critical" not in d._pattern_attempts
+        assert "infra:container_memory_high" not in d._pattern_attempts
 
     @pytest.mark.asyncio
     async def test_unresolved_dispatch_keeps_pattern(self):
@@ -374,7 +374,7 @@ class TestPatternResetOnResolve:
         mock_output.text = '{"diagnosis": "cannot fix", "actions_taken": [], "resolved": false}'
         d._invoker.run = AsyncMock(return_value=mock_output)
 
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.write_last_run"), \
              patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
@@ -387,8 +387,8 @@ class TestPatternResetOnResolve:
             ))
 
         # Pattern is recorded so next attempt hits backoff
-        assert "memory:critical" in d._pattern_attempts
-        assert len(d._pattern_attempts["memory:critical"]) == 1
+        assert "infra:container_memory_high" in d._pattern_attempts
+        assert len(d._pattern_attempts["infra:container_memory_high"]) == 1
 
 
 class TestResolvedCooldown:
@@ -399,7 +399,7 @@ class TestResolvedCooldown:
         """After a pattern resolves, the same pattern is blocked by cooldown."""
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
 
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.write_last_run"), \
@@ -414,7 +414,7 @@ class TestResolvedCooldown:
         assert r1.dispatched and r1.resolved
 
         # Cooldown recorded
-        assert "memory:critical" in d._resolved_cooldowns
+        assert "infra:container_memory_high" in d._resolved_cooldowns
 
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.write_last_run"), \
@@ -435,20 +435,20 @@ class TestResolvedCooldown:
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
         # Simulate a cooldown that already expired
-        d._resolved_cooldowns["memory:critical"] = time.monotonic() - (_RESOLVED_COOLDOWN_S + 1)
+        d._resolved_cooldowns["infra:container_memory_high"] = time.monotonic() - (_RESOLVED_COOLDOWN_S + 1)
 
-        ready, reason = d._backoff_ready("memory:critical")
+        ready, reason = d._backoff_ready("infra:container_memory_high")
         assert ready
         # Expired cooldown should be cleaned up
-        assert "memory:critical" not in d._resolved_cooldowns
+        assert "infra:container_memory_high" not in d._resolved_cooldowns
 
     @pytest.mark.asyncio
     async def test_cooldown_independent_per_pattern(self):
         """Cooldown on one pattern doesn't block a different pattern."""
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
-        # memory:critical is in cooldown
-        d._resolved_cooldowns["memory:critical"] = time.monotonic()
+        # infra:container_memory_high is in cooldown
+        d._resolved_cooldowns["infra:container_memory_high"] = time.monotonic()
 
         # Different pattern should be unaffected
         ready, reason = d._backoff_ready("disk:critical")
@@ -465,11 +465,11 @@ class TestEscalation:
         d._state.started_at = "2020-01-01T00:00:00+00:00"
         # Pre-seed 4 prior attempts (escalation = 5th)
         now = time.monotonic()
-        d._pattern_attempts["memory:critical"] = [
+        d._pattern_attempts["infra:container_memory_high"] = [
             now - 20000, now - 16000, now - 10000, now - 5000,
         ]
 
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.append_log"):
             result = await d.dispatch(SentinelRequest(
@@ -484,7 +484,7 @@ class TestEscalation:
         # Outreach was posted
         assert outreach.submit_raw.await_count == 1
         # Pattern is now marked escalated
-        assert "memory:critical" in d._escalated_patterns
+        assert "infra:container_memory_high" in d._escalated_patterns
         # Invoker was NOT called (no CC session spun up)
         d._invoker.run.assert_not_called()
 
@@ -498,11 +498,11 @@ class TestEscalation:
         d = _make_dispatcher(outreach_pipeline=outreach)
         d._state.started_at = "2020-01-01T00:00:00+00:00"
         now = time.monotonic()
-        d._pattern_attempts["memory:critical"] = [
+        d._pattern_attempts["infra:container_memory_high"] = [
             now - 20000, now - 16000, now - 10000, now - 5000,
         ]
 
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.append_log"):
             await d.dispatch(SentinelRequest(
@@ -520,7 +520,7 @@ class TestEscalation:
         assert "dispatch attempts" in message_body
         assert "4 dispatch attempts" in message_body  # 4 prior + current = 5th triggers
         # Pattern identifier is visible to user
-        assert "memory:critical" in message_body
+        assert "infra:container_memory_high" in message_body
 
     @pytest.mark.asyncio
     async def test_escalation_marks_pattern_even_without_outreach(self):
@@ -531,11 +531,11 @@ class TestEscalation:
         d = _make_dispatcher(outreach_pipeline=None)
         d._state.started_at = "2020-01-01T00:00:00+00:00"
         now = time.monotonic()
-        d._pattern_attempts["memory:critical"] = [
+        d._pattern_attempts["infra:container_memory_high"] = [
             now - 20000, now - 16000, now - 10000, now - 5000,
         ]
 
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.append_log"):
             result = await d.dispatch(SentinelRequest(
@@ -547,15 +547,15 @@ class TestEscalation:
 
         assert not result.dispatched
         # Still marked escalated even though no outreach pipeline
-        assert "memory:critical" in d._escalated_patterns
+        assert "infra:container_memory_high" in d._escalated_patterns
 
     @pytest.mark.asyncio
     async def test_escalated_pattern_blocks_subsequent_attempts(self):
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
-        d._escalated_patterns["memory:critical"] = "2026-04-09T23:00:00+00:00"
+        d._escalated_patterns["infra:container_memory_high"] = "2026-04-09T23:00:00+00:00"
 
-        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+        alarm = FireAlarm(tier=2, alert_id="infra:container_memory_high", severity="CRITICAL", message="mem")
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.append_log"):
             result = await d.dispatch(SentinelRequest(
@@ -579,7 +579,7 @@ class TestRingBufferDebounce:
         d._state.started_at = "2020-01-01T00:00:00+00:00"
 
         with patch("genesis.mcp.health_mcp._impl_health_alerts", new=AsyncMock(return_value=[
-            {"id": "memory:critical", "severity": "CRITICAL", "message": "mem"},
+            {"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "mem"},
         ])):
             result = await d.check_fire_alarms()
 
@@ -593,7 +593,7 @@ class TestRingBufferDebounce:
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
 
-        alerts = [{"id": "memory:critical", "severity": "CRITICAL", "message": "mem"}]
+        alerts = [{"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "mem"}]
         with patch("genesis.mcp.health_mcp._impl_health_alerts", new=AsyncMock(return_value=alerts)), \
              patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.write_last_run"), \
@@ -612,7 +612,7 @@ class TestRingBufferDebounce:
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
 
-        alerts_on = [{"id": "memory:critical", "severity": "CRITICAL", "message": "mem"}]
+        alerts_on = [{"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "mem"}]
         alerts_off: list = []
 
         async def _alerts_side_effect(*args, **kwargs):
@@ -638,7 +638,7 @@ class TestRingBufferDebounce:
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
 
-        alerts_on = [{"id": "memory:critical", "severity": "CRITICAL", "message": "mem"}]
+        alerts_on = [{"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "mem"}]
         alerts_off: list = []
 
         async def _alerts_side_effect(*args, **kwargs):
@@ -662,8 +662,8 @@ class TestRejectionWindow:
         """Pattern with active rejection window returns not-ready."""
         d = _make_dispatcher()
         expiry = (datetime.now(UTC) + timedelta(hours=23)).isoformat()
-        d._state.rejected_patterns["memory:critical"] = expiry
-        ready, reason = d._backoff_ready("memory:critical")
+        d._state.rejected_patterns["infra:container_memory_high"] = expiry
+        ready, reason = d._backoff_ready("infra:container_memory_high")
         assert ready is False
         assert "rejected" in reason.lower()
 
@@ -671,19 +671,19 @@ class TestRejectionWindow:
         """Pattern with expired rejection window is allowed and entry cleaned."""
         d = _make_dispatcher()
         expiry = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-        d._state.rejected_patterns["memory:critical"] = expiry
+        d._state.rejected_patterns["infra:container_memory_high"] = expiry
 
         with patch("genesis.sentinel.dispatcher.save_state"):
-            ready, _ = d._backoff_ready("memory:critical")
+            ready, _ = d._backoff_ready("infra:container_memory_high")
 
         assert ready is True
-        assert "memory:critical" not in d._state.rejected_patterns
+        assert "infra:container_memory_high" not in d._state.rejected_patterns
 
     def test_rejection_independent_per_pattern(self):
         """Rejecting one pattern doesn't block another."""
         d = _make_dispatcher()
         expiry = (datetime.now(UTC) + timedelta(hours=23)).isoformat()
-        d._state.rejected_patterns["memory:critical"] = expiry
+        d._state.rejected_patterns["infra:container_memory_high"] = expiry
         ready, _ = d._backoff_ready("infra:disk_low")
         assert ready is True
 
@@ -692,14 +692,14 @@ class TestRejectionWindow:
         d = _make_dispatcher()
         d._state.started_at = "2020-01-01T00:00:00+00:00"
         expiry = (datetime.now(UTC) + timedelta(hours=20)).isoformat()
-        d._state.rejected_patterns["memory:critical"] = expiry
+        d._state.rejected_patterns["infra:container_memory_high"] = expiry
 
         # Simulate resolve by directly calling the logic from _finalize_dispatch
-        pattern = "memory:critical"
+        pattern = "infra:container_memory_high"
         if pattern in d._state.rejected_patterns:
             del d._state.rejected_patterns[pattern]
 
-        assert "memory:critical" not in d._state.rejected_patterns
+        assert "infra:container_memory_high" not in d._state.rejected_patterns
 
     @pytest.mark.asyncio
     async def test_handle_approval_resolution_rejected(self):
@@ -708,7 +708,7 @@ class TestRejectionWindow:
         d._state.current_state = "awaiting_dispatch_approval"
         d._state.pending_request_id = "req-123"
         d._state.pending_policy_id = "sentinel_dispatch"
-        d._state.pending_pattern = "memory:critical"
+        d._state.pending_pattern = "infra:container_memory_high"
 
         with patch("genesis.sentinel.dispatcher.save_state"), \
              patch("genesis.sentinel.dispatcher.append_log"):
@@ -716,9 +716,9 @@ class TestRejectionWindow:
 
         assert result is not None
         assert result.dispatched is False
-        assert "memory:critical" in d._state.rejected_patterns
+        assert "infra:container_memory_high" in d._state.rejected_patterns
         # Verify the expiry is ~24h from now
-        expiry = datetime.fromisoformat(d._state.rejected_patterns["memory:critical"])
+        expiry = datetime.fromisoformat(d._state.rejected_patterns["infra:container_memory_high"])
         diff = expiry - datetime.now(UTC)
         assert timedelta(hours=23) < diff < timedelta(hours=25)
         # State transitioned to HEALTHY
@@ -730,14 +730,14 @@ class TestRejectionWindow:
 
         state = SentinelStateData()
         expiry = (datetime.now(UTC) + timedelta(hours=12)).isoformat()
-        state.rejected_patterns["memory:critical"] = expiry
+        state.rejected_patterns["infra:container_memory_high"] = expiry
 
         state_file = tmp_path / "sentinel_state.json"
         save_state(state, path=state_file)
         loaded = load_state(path=state_file)
 
-        assert "memory:critical" in loaded.rejected_patterns
-        assert loaded.rejected_patterns["memory:critical"] == expiry
+        assert "infra:container_memory_high" in loaded.rejected_patterns
+        assert loaded.rejected_patterns["infra:container_memory_high"] == expiry
 
 
 # ---------------------------------------------------------------------------
@@ -858,3 +858,105 @@ class TestSentinelActionStalenessGuard:
             result = await d.resume_from_approval("req-wrong-id", "approved")
 
         assert result is None
+
+
+class TestConvergePendingApproval:
+    """State-keyed convergence: a parked dispatch must follow whatever
+    actually happened to its approval row. The approved-only resume scan
+    left a REJECTED row undelivered for 26 days (June–July 2026) while
+    Gate 2 blocked every other dispatch — these tests pin every branch.
+    """
+
+    def _parked(self, gate):
+        d = _make_dispatcher(approval_gate=gate)
+        d._state.transition(
+            SentinelState.AWAITING_DISPATCH_APPROVAL, reason="test park",
+        )
+        d._state.pending_request_id = "req-123"
+        d._state.pending_policy_id = "sentinel_dispatch"
+        d._state.pending_pattern = "backup:last_failed"
+        d._state.pending_request_json = (
+            '{"trigger_source": "fire_alarm", "trigger_reason": "t",'
+            ' "tier": 2, "alarms": [], "context": {}}'
+        )
+        return d
+
+    @pytest.mark.asyncio
+    async def test_rejected_row_converges_healthy_and_suppresses(self):
+        gate = AsyncMock()
+        gate.get_request = AsyncMock(return_value={"id": "req-123", "status": "rejected"})
+        d = self._parked(gate)
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            await d.converge_pending_approval()
+
+        assert d._state.state == SentinelState.HEALTHY
+        assert d._state.pending_request_id == ""
+        assert "backup:last_failed" in d._state.rejected_patterns
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("row", [None, {"id": "req-123", "status": "expired"},
+                                     {"id": "req-123", "status": "cancelled"}])
+    async def test_gone_row_clears_park(self, row):
+        gate = AsyncMock()
+        gate.get_request = AsyncMock(return_value=row)
+        d = self._parked(gate)
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            await d.converge_pending_approval()
+
+        assert d._state.state == SentinelState.HEALTHY
+        assert d._state.pending_request_id == ""
+        # No rejection happened — the pattern must NOT be suppressed.
+        assert "backup:last_failed" not in d._state.rejected_patterns
+
+    @pytest.mark.asyncio
+    async def test_pending_row_stays_parked(self):
+        gate = AsyncMock()
+        gate.get_request = AsyncMock(return_value={"id": "req-123", "status": "pending"})
+        d = self._parked(gate)
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            await d.converge_pending_approval()
+
+        assert d._state.state == SentinelState.AWAITING_DISPATCH_APPROVAL
+        assert d._state.pending_request_id == "req-123"
+
+    @pytest.mark.asyncio
+    async def test_approved_unconsumed_resumes(self):
+        gate = AsyncMock()
+        gate.get_request = AsyncMock(return_value={"id": "req-123", "status": "approved"})
+        gate.mark_consumed = AsyncMock(return_value=True)
+        d = self._parked(gate)
+        d.resume_from_approval = AsyncMock(return_value=None)
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            await d.converge_pending_approval()
+
+        gate.mark_consumed.assert_awaited_once_with("req-123")
+        d.resume_from_approval.assert_awaited_once_with("req-123", "approved")
+
+    @pytest.mark.asyncio
+    async def test_approved_already_consumed_clears_stale_park(self):
+        gate = AsyncMock()
+        gate.get_request = AsyncMock(return_value={"id": "req-123", "status": "approved"})
+        gate.mark_consumed = AsyncMock(return_value=False)
+        d = self._parked(gate)
+        d.resume_from_approval = AsyncMock(return_value=None)
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            await d.converge_pending_approval()
+
+        d.resume_from_approval.assert_not_awaited()
+        assert d._state.state == SentinelState.HEALTHY
+        assert d._state.pending_request_id == ""
+
+    @pytest.mark.asyncio
+    async def test_not_parked_is_noop(self):
+        gate = AsyncMock()
+        d = _make_dispatcher(approval_gate=gate)
+
+        await d.converge_pending_approval()
+
+        gate.get_request.assert_not_awaited()
+        assert d._state.state == SentinelState.HEALTHY

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -960,3 +960,25 @@ class TestConvergePendingApproval:
 
         gate.get_request.assert_not_awaited()
         assert d._state.state == SentinelState.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_awaiting_with_no_pending_id_clears_park(self):
+        """AWAITING with an empty pending_request_id (partial state write)
+        can never be resolved by id-matched resume paths — converge must
+        clear it. The removed legacy scan made this WORSE: it consumed an
+        approved row whose id could never match the empty pending id,
+        eating the approval while staying parked.
+        """
+        gate = AsyncMock()
+        d = _make_dispatcher(approval_gate=gate)
+        d._state.transition(
+            SentinelState.AWAITING_DISPATCH_APPROVAL, reason="test park",
+        )
+        d._state.pending_request_id = ""
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            await d.converge_pending_approval()
+
+        gate.get_request.assert_not_awaited()
+        gate.mark_consumed.assert_not_awaited()
+        assert d._state.state == SentinelState.HEALTHY


### PR DESCRIPTION
## Summary

- The Sentinel (Genesis's internal emergency responder) now only wakes for alerts it has an actual remediation path for. A new remediation map pairs each health-alert id with the tools available on the install (restart a local service, reclaim disk, restart the local Qdrant, SSH-restart the Guardian, etc.); alerts outside that scope — backups to a remote target, provider billing/credit exhaustion, external API/provider outages — no longer trigger an automated diagnostic session, at any severity. Those alerts stay fully visible on the dashboard, and backup failures were added to the immediate-notification list so real failures still reach you directly.
- Fixes a 26-day approval wedge: if a Sentinel dispatch approval was rejected (or expired/cancelled) while the underlying alarm stayed active, the Sentinel parked itself waiting forever and silently blocked every subsequent alarm. It now converges on the approval's real outcome every check — a rejection now actually applies (24h suppression, back to healthy) instead of being ignored.
- Sentinel state transitions now emit events under a dedicated subsystem, so a parked or wedged state is visible in the event log instead of silent.
- Backup alerts are also gated on backups actually being configured on the install (env var, secrets file, or an existing backup clone) — a stale failure from a never-configured backup no longer raises a false critical alert.

## Test plan

- [x] `pytest tests/test_sentinel/ tests/test_mcp/test_health_mcp.py tests/test_health_mcp.py tests/test_awareness/ tests/test_autonomy/test_approval.py tests/test_outreach/test_config.py` — all passing (452 targeted tests)
- [x] `ruff check` clean on all touched files
- [x] Mechanical coverage test: every alert id producible by the health emitter has an explicit in/out-of-scope disposition
- [x] Code review (architect pre-review + inline review) — all findings resolved with regression tests
- [ ] Post-merge live verification: confirm the standing backup-alarm wedge on this install self-clears within one awareness tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)