### PR TITLE
feat(guardian): self-heal the host SSH key — reharden-key verb + autonomous reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now re-hardens its own host SSH key automatically — no human on the host required.** The
+  Guardian's control key (the one the container uses to manage the host) is supposed to carry `no-pty`
+  and a source-IP `from=` restriction, but before this those were applied only at install time, so an
+  install set up before the hardening — or one whose container address changed — kept a weaker key
+  until someone re-ran the installer by hand. The watchdog now checks the key's hardening every cycle
+  and, when it has drifted, calls a new `reharden-key` gateway operation that rewrites the key to the
+  hardened form and proves the rewrite still works before committing to it (a built-in 120-second
+  dead-man's-switch restores the previous key otherwise, so it can never lock Genesis out of its own
+  host). A moved-but-stable source address heals on its own; a flapping address is left alone and
+  reported instead of chased. For the rare manual case, `install_guardian.sh --reharden-key-only`
+  re-hardens the key without a full re-install.
+
 - **The Guardian now maintains a rolling "healthy" snapshot of the container — the restore point its
   snapshot-rollback recovery always needed.** Once a day, while every health check passes, the Guardian
   takes a `-healthy` container snapshot and deletes the previous one (exactly one exists, never more

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -625,7 +625,12 @@ PYEOF
         OLD_N=$(grep -c '' "$AK") || OLD_N=0
         NEW_N=$(grep -c '' "$AK_TMP") || NEW_N=0
         if [ "$OLD_N" -ne "$NEW_N" ]; then
+            # Aborting WITHOUT writing → the file is unchanged, so disarm the
+            # switch we armed above (keep "armed iff we wrote" symmetry). The
+            # restore would be a harmless self-copy either way, but leaving a
+            # pending timer around is untidy.
             rm -f "$AK_TMP"
+            systemctl --user stop genesis-authkey-restore.timer 2>/dev/null || true
             printf '{"ok": false, "action": "reharden-key", "error": "line-count invariant violated (%s -> %s); file untouched"}\n' "$OLD_N" "$NEW_N" >&2
             exit 1
         fi

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -16,6 +16,10 @@
 #   test-approval   — E2E test the keyword-reply approval gate (no recovery)
 #   disk-status     — read-only storage-pool + snapshot JSON (Genesis's window
 #                     into host capacity: lvs data%/metadata%, VG free, snapshots)
+#   reharden-key    — rewrite the guardian authorized_keys line to the canonical
+#                     hardened options with a self-proving from= (dead-man's-
+#                     switch restores the previous file unless a fresh
+#                     connection confirms the rewrite works)
 #   ping            — liveness check
 #
 # SSH authorized_keys entry (replace CONTAINER_IP with the container's
@@ -99,8 +103,46 @@ PYEOF
         # code can be current while ~/.local/bin/guardian-gateway.sh lags).
         GW_SHA=$(sha256sum "$HOME/.local/bin/guardian-gateway.sh" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
         [ -n "$GW_SHA" ] || GW_SHA="unknown"
-        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "gateway_sha": "%s"}\n' \
-            "$CC_VER" "$NODE_VER" "$CODE_VER" "$CODE_DATE" "$DEPLOYED" "$GW_SHA"
+        # --- authorized_keys hardening indicators (consumed by the container's
+        # _check_authkey_hardening reconciler; healed via `reharden-key`).
+        # Least disclosure: booleans + sha256 hashes only — never the raw key
+        # blob, the stored from= literal, or the observed source address.
+        AK_NO_PTY=false; AK_HAS_FROM=false; AK_FROM_MATCHES=false
+        AK_OPTS_HASH=""; AK_SRC_HASH=""
+        AK_SRC=$(printf '%s' "${SSH_CONNECTION:-}" | awk '{print $1}')
+        if [ -n "$AK_SRC" ]; then
+            AK_SRC_HASH=$(printf '%s' "$AK_SRC" | sha256sum | cut -d' ' -f1)
+        fi
+        AK_LINE=$(grep -F "genesis-guardian-control" "$HOME/.ssh/authorized_keys" 2>/dev/null | head -1 || true)
+        if [ -n "$AK_LINE" ]; then
+            # Options = the line minus the keytype/blob/comment tail. The
+            # keytype anchor is robust against options containing spaces.
+            AK_KEYPART=$(printf '%s\n' "$AK_LINE" | grep -oE '(ssh|ecdsa|sk)-[A-Za-z0-9@.-]+ [A-Za-z0-9+/=]+( .*)?$' || true)
+            AK_OPTS="${AK_LINE%"$AK_KEYPART"}"
+            AK_OPTS="${AK_OPTS% }"
+            case ",$AK_OPTS," in *,no-pty,*) AK_NO_PTY=true;; esac
+            if [ -n "$AK_OPTS" ]; then
+                AK_OPTS_HASH=$(printf '%s' "$AK_OPTS" | tr ',' '\n' | sort | sha256sum | cut -d' ' -f1)
+            fi
+            AK_FROM=$(printf '%s\n' "$AK_OPTS" | grep -oE 'from="[^"]*"' | head -1 | sed 's/^from="//;s/"$//' || true)
+            if [ -n "$AK_FROM" ]; then
+                AK_HAS_FROM=true
+                if [ -n "$AK_SRC" ]; then
+                    # sshd-style match: comma-separated fnmatch patterns.
+                    # Negated (!) patterns are skipped — never report an
+                    # operator's manual negation as a mismatch to "fix".
+                    IFS=',' read -ra _AK_PATS <<< "$AK_FROM"
+                    for _pat in "${_AK_PATS[@]}"; do
+                        case "$_pat" in "!"*) continue;; esac
+                        # shellcheck disable=SC2254  # glob match is the point (sshd fnmatch semantics)
+                        case "$AK_SRC" in $_pat) AK_FROM_MATCHES=true; break;; esac
+                    done
+                fi
+            fi
+        fi
+        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "gateway_sha": "%s", "authkey_no_pty": %s, "authkey_has_from": %s, "authkey_from_matches": %s, "authkey_observed_src_hash": "%s", "authkey_opts_hash": "%s"}\n' \
+            "$CC_VER" "$NODE_VER" "$CODE_VER" "$CODE_DATE" "$DEPLOYED" "$GW_SHA" \
+            "$AK_NO_PTY" "$AK_HAS_FROM" "$AK_FROM_MATCHES" "$AK_SRC_HASH" "$AK_OPTS_HASH"
         ;;
     update)
         INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
@@ -492,6 +534,104 @@ PYEOF
             echo '{"ok": false, "action": "sync-gateway", "error": "failed to deploy gateway"}' >&2
             exit 1
         fi
+        ;;
+    reharden-key)
+        # Rewrite the guardian authorized_keys line to the canonical hardened
+        # options, deriving from= from THIS connection's source address —
+        # self-proving: sshd authenticated this very connection from that
+        # address, and the container always re-dials the same host_ip, so the
+        # next connection presents the same source. Zero input is taken from
+        # the caller; key material comes from the FILE, options are hardcoded.
+        #
+        # Un-brickable by construction: the previous file is snapshotted and a
+        # systemd dead-man's-switch restores it after 120s unless a fresh
+        # connection arrives to cancel it. Any arrival at this verb
+        # authenticated against the CURRENT file is living proof the file
+        # works — so the container's second call doubles as the confirm.
+        AK="$HOME/.ssh/authorized_keys"
+        AK_BAK="$AK.guardian-bak"
+        AK_MARKER="genesis-guardian-control"
+        # Canonical hardened options. Deliberately duplicated from
+        # install_guardian.sh Step 11 (this script must stay hermetic — it is
+        # the recovery path when the install dir is broken); byte-identity is
+        # enforced by tests/test_guardian/test_gateway_reharden.py
+        # (TestOptionsDivergenceGuardrail).
+        GUARD_BASE_OPTS="command=\"$HOME/.local/bin/guardian-gateway.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty"
+
+        # A connection reaching this verb proves the current file works →
+        # cancel any pending restore (the confirm path after a rewrite).
+        systemctl --user stop genesis-authkey-restore.timer 2>/dev/null || true
+        systemctl --user stop genesis-authkey-restore.service 2>/dev/null || true
+
+        COUNT=$(grep -cF "$AK_MARKER" "$AK" 2>/dev/null) || COUNT=0
+        if [ "$COUNT" -ne 1 ]; then
+            # 0 = nothing safe to rewrite; >1 = ambiguous/tampered. Refuse —
+            # a human must resolve this, the reconciler will escalate.
+            printf '{"ok": false, "action": "reharden-key", "error": "expected exactly 1 guardian line, found %s"}\n' "$COUNT" >&2
+            exit 1
+        fi
+        AK_LINE=$(grep -F "$AK_MARKER" "$AK")
+        # keytype anchor tolerates options containing spaces; blob + comment
+        # are preserved exactly as stored.
+        KEYPART=$(printf '%s\n' "$AK_LINE" | grep -oE '(ssh|ecdsa|sk)-[A-Za-z0-9@.-]+ [A-Za-z0-9+/=]+( .*)?$' || true)
+        BLOB=$(printf '%s\n' "$KEYPART" | awk '{print $2}')
+        if [ -z "$KEYPART" ] || [ -z "$BLOB" ]; then
+            echo '{"ok": false, "action": "reharden-key", "error": "cannot parse guardian key line"}' >&2
+            exit 1
+        fi
+        SRC=$(printf '%s' "${SSH_CONNECTION:-}" | awk '{print $1}')
+        HAS_FROM=false
+        if [ -n "$SRC" ]; then
+            NEW_LINE="from=\"${SRC}\",${GUARD_BASE_OPTS} ${KEYPART}"
+            HAS_FROM=true
+        else
+            # Never guess a source. Hardened-without-from matches the
+            # installer's fallback and cannot lock the container out.
+            NEW_LINE="${GUARD_BASE_OPTS} ${KEYPART}"
+        fi
+        if [ "$NEW_LINE" = "$AK_LINE" ]; then
+            printf '{"ok": true, "action": "reharden-key", "changed": false, "has_from": %s}\n' "$HAS_FROM"
+            exit 0
+        fi
+        # Validate the rebuilt line parses as an authorized_keys entry BEFORE
+        # touching the real file. mktemp beside the target (tiny file; also
+        # keeps everything on one filesystem).
+        CHECK_TMP=$(mktemp "$AK.check.XXXXXX")
+        printf '%s\n' "$NEW_LINE" > "$CHECK_TMP"
+        if ! ssh-keygen -l -f "$CHECK_TMP" >/dev/null 2>&1; then
+            rm -f "$CHECK_TMP"
+            echo '{"ok": false, "action": "reharden-key", "error": "rebuilt line failed ssh-keygen validation"}' >&2
+            exit 1
+        fi
+        rm -f "$CHECK_TMP"
+        # Snapshot + arm the dead-man's-switch BEFORE any write. No armed
+        # switch → no safety net → refuse to modify the file at all. The
+        # fixed unit name doubles as a concurrency lock (a second concurrent
+        # reharden's systemd-run fails while one is pending).
+        cp "$AK" "$AK_BAK"
+        if ! systemd-run --user --collect --on-active=120 \
+                --unit=genesis-authkey-restore \
+                /bin/cp "$AK_BAK" "$AK" >/dev/null 2>&1; then
+            rm -f "$AK_BAK"
+            echo '{"ok": false, "action": "reharden-key", "error": "cannot arm restore switch (systemd-run failed); refusing to modify authorized_keys"}' >&2
+            exit 1
+        fi
+        AK_TMP=$(mktemp "$AK.XXXXXX")
+        # Drop the guardian line by its blob (unique key material — immune to
+        # option/comment drift), keep every other line untouched, append the
+        # rebuilt line.
+        grep -vF "$BLOB" "$AK" > "$AK_TMP" || true
+        printf '%s\n' "$NEW_LINE" >> "$AK_TMP"
+        OLD_N=$(grep -c '' "$AK") || OLD_N=0
+        NEW_N=$(grep -c '' "$AK_TMP") || NEW_N=0
+        if [ "$OLD_N" -ne "$NEW_N" ]; then
+            rm -f "$AK_TMP"
+            printf '{"ok": false, "action": "reharden-key", "error": "line-count invariant violated (%s -> %s); file untouched"}\n' "$OLD_N" "$NEW_N" >&2
+            exit 1
+        fi
+        chmod 600 "$AK_TMP"
+        mv "$AK_TMP" "$AK"
+        printf '{"ok": true, "action": "reharden-key", "changed": true, "has_from": %s}\n' "$HAS_FROM"
         ;;
     ping)
         echo '{"ok": true, "action": "ping"}'

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -20,6 +20,11 @@
 # Options:
 #   --container-name NAME  Container name (default: auto-detect or "genesis")
 #   --non-interactive      Skip prompts
+#   --reharden-key-only    Only (re)install the hardened guardian SSH key, then
+#                          exit. Out-of-band Tier-3 recovery for an existing
+#                          install whose live key predates the current hardening
+#                          (the container's reharden-key gateway verb is the
+#                          normal, Genesis-driven path — this is the manual one).
 #   -h, --help             Show this help
 #
 # This script is idempotent — safe to run multiple times.
@@ -30,6 +35,7 @@ set -euo pipefail
 
 CONTAINER_NAME=""
 NON_INTERACTIVE=0
+REHARDEN_KEY_ONLY=0
 INSTALL_DIR="$HOME/.local/share/genesis-guardian"
 STATE_DIR="$HOME/.local/state/genesis-guardian"
 SYSTEMD_DIR="$HOME/.config/systemd/user"
@@ -41,6 +47,7 @@ while [ $# -gt 0 ]; do
         --container-name) [ $# -ge 2 ] || { echo "ERROR: $1 requires a value"; exit 1; }; CONTAINER_NAME="$2"; shift ;;
         --repo-url)       echo "WARN: --repo-url is deprecated (code is copied from local repo)"; shift ;;
         --non-interactive) NON_INTERACTIVE=1 ;;
+        --reharden-key-only) REHARDEN_KEY_ONLY=1 ;;
         -h|--help)
             sed -n '2,/^$/{ s/^# \?//; p }' "$0"
             exit 0
@@ -49,6 +56,155 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+# ── Reusable functions ───────────────────────────────────────────────
+
+# Derive TS_IP: the host address the container uses for approval URLs and as
+# the target for the guardian key's from= derivation. Prefers Tailscale, falls
+# back to the host's default-route source IP. Sets the global TS_IP.
+derive_ts_ip() {
+    if command -v tailscale &>/dev/null; then
+        TS_IP=$(tailscale ip -4 2>/dev/null || echo "")
+        if [ -n "$TS_IP" ]; then
+            echo "  OK    Tailscale: $TS_IP (will use for approval URLs)"
+        else
+            echo "  WARN  Tailscale running but no IPv4"
+        fi
+    fi
+    if [ -z "${TS_IP:-}" ]; then
+        TS_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | grep -oP 'src \K\S+' || echo "")
+        if [ -n "$TS_IP" ]; then
+            echo "  OK    Host LAN IP: $TS_IP (will use for approval URLs)"
+        else
+            echo "  WARN  Could not detect host IP — set approval.bind_host manually"
+        fi
+    fi
+}
+
+# Generate the container's guardian keypair (if absent) and install a
+# command-restricted, hardened authorized_keys entry on this host, then verify
+# the container→host link and self-heal a wrong from= by dropping it. Idempotent
+# by key material. Requires CONTAINER_NAME, CONTAINER_USER, TS_IP set.
+setup_bidirectional_ssh() {
+    local GUARDIAN_KEY="/home/${CONTAINER_USER}/.ssh/genesis_guardian_ed25519"
+
+    # Generate dedicated keypair in container (if not already present)
+    if incus exec "$CONTAINER_NAME" -- test -f "$GUARDIAN_KEY" 2>/dev/null; then
+        echo "  Guardian SSH key already exists in container"
+    else
+        incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
+            "ssh-keygen -t ed25519 -f $GUARDIAN_KEY -N '' -C 'genesis-guardian-control'" 2>/dev/null
+        echo "  Generated guardian SSH keypair in container"
+    fi
+
+    # Pull public key from container
+    local PUBKEY
+    PUBKEY=$(incus exec "$CONTAINER_NAME" -- cat "${GUARDIAN_KEY}.pub" 2>/dev/null || echo "")
+    if [ -z "$PUBKEY" ]; then
+        echo "  WARNING: Could not read guardian public key — bidirectional monitoring disabled"
+        return 0
+    fi
+
+    # Install command-restricted authorized_keys entry (idempotent by key material)
+    local PUBKEY_BLOB GUARD_FROM_IP GUARD_BASE_OPTS
+    PUBKEY_BLOB=$(echo "$PUBKEY" | awk '{print $2}')
+    GUARD_FROM_IP=""
+    GUARD_BASE_OPTS="command=\"$HOME/.local/bin/guardian-gateway.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty"
+    # Treat the key as installed only if it is present AND hardened (no-pty is
+    # the marker for this installer version's options). A key present without
+    # no-pty is an older, under-hardened entry — re-install to upgrade it.
+    if grep -F "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null | grep -q 'no-pty'; then
+        echo "  Authorized key already installed and hardened"
+    else
+        # Remove any existing control entry (stale key OR older un-hardened one)
+        if grep -q "genesis-guardian-control" "$HOME/.ssh/authorized_keys" 2>/dev/null; then
+            sed -i '/genesis-guardian-control/d' "$HOME/.ssh/authorized_keys"
+            echo "  Removed prior guardian key entry (re-installing hardened)"
+        fi
+        mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
+        # Harden beyond the ForceCommand:
+        #   no-pty  — the gateway is a non-interactive JSON contract, never a shell.
+        #   from="" — bind the key to the container's source IP so a stolen key
+        #             can't be used from any other LAN host. Derive that IP from
+        #             the container's ACTUAL egress route to the host, NOT
+        #             `incus list -c4` (which can return the tailscale address the
+        #             host never sees). If it can't be derived, install without
+        #             from= (no-pty still applies) rather than guess and risk a
+        #             lockout; a wrong from= is caught + rolled back by the
+        #             connectivity test below.
+        GUARD_FROM_IP=$(incus exec "$CONTAINER_NAME" -- ip -4 route get "${TS_IP:-}" 2>/dev/null | grep -oP 'src \K\S+' | head -1 || true)
+        if [ -n "$GUARD_FROM_IP" ]; then
+            echo "from=\"${GUARD_FROM_IP}\",${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
+        else
+            echo "  NOTE: could not derive container source IP — installing without from= (no-pty still applied)"
+            echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
+        fi
+        chmod 600 "$HOME/.ssh/authorized_keys"
+        echo "  Installed hardened command-restricted SSH key for Genesis→Guardian control"
+    fi
+
+    # Write connection config into container for Genesis to read
+    local HOST_USER HOST_IP
+    HOST_USER="$(whoami)"
+    HOST_IP="${TS_IP:-}"
+    incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
+        "mkdir -p ~/.genesis && cat > ~/.genesis/guardian_remote.yaml" <<REMOTECONF
+# Auto-generated by install_guardian.sh — $(date -Is)
+# Genesis reads this to SSH to the host for Guardian management.
+host_ip: "${HOST_IP}"
+host_user: "${HOST_USER}"
+ssh_key: "~/.ssh/genesis_guardian_ed25519"
+REMOTECONF
+    echo "  Wrote guardian_remote.yaml into container"
+
+    # Verify SSH connectivity: container → host
+    echo "  Testing SSH connectivity (container → host)..."
+    _guardian_ssh_test() {
+        incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
+            "ssh -i ${GUARDIAN_KEY} -o StrictHostKeyChecking=no -o ConnectTimeout=5 ${HOST_USER}@${HOST_IP} ping 2>&1" || echo "FAILED"
+    }
+    local SSH_TEST
+    SSH_TEST=$(_guardian_ssh_test)
+    if echo "$SSH_TEST" | grep -q '"ok": true'; then
+        echo "  SSH bidirectional link verified${GUARD_FROM_IP:+ (source-restricted to ${GUARD_FROM_IP})}"
+    elif grep -F "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null | grep -q 'from='; then
+        # The guardian key carries a from= restriction and the link is down — the
+        # restriction likely doesn't match the source IP the host observes (wrong
+        # derivation, or the container's address changed since the key was
+        # written). A wrong from= silently locks Guardian out, so drop it (keeping
+        # no-pty + the other options) and re-test. Keyed on the PRESENCE of from=
+        # (not on whether we wrote it this run), so a stale from= also self-heals
+        # on a plain re-run. Remove by key material (grep -vF on the blob), not
+        # the comment, so it works regardless of the key's comment field.
+        echo "  SSH test failed while a from= restriction is set on the guardian key — dropping from= (keeping no-pty) and retrying..."
+        local _ak="$HOME/.ssh/authorized_keys" _tmp="$HOME/.ssh/authorized_keys.tmp.$$"
+        grep -vF "$PUBKEY_BLOB" "$_ak" > "$_tmp" 2>/dev/null || true
+        echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$_tmp"
+        mv "$_tmp" "$_ak"
+        chmod 600 "$_ak"
+        SSH_TEST=$(_guardian_ssh_test)
+        if echo "$SSH_TEST" | grep -q '"ok": true'; then
+            echo "  SSH link verified WITHOUT from= — the source-IP restriction did not match what the host observes."
+            echo "  Guardian works; the LAN key-theft restriction is NOT enforced. To enable it, add"
+            echo "  from=\"<container's host-facing source IP>\" to the guardian key in ~/.ssh/authorized_keys."
+        else
+            echo ""
+            echo "  WARNING: SSH test still failing after dropping from=. Guardian bidirectional monitoring may not work."
+            echo "  Error: $SSH_TEST"
+            echo "  To fix manually, add this to ~/.ssh/authorized_keys on the host:"
+            echo "    ${GUARD_BASE_OPTS} ${PUBKEY}"
+            echo ""
+        fi
+    else
+        echo ""
+        echo "  WARNING: SSH test failed. Guardian bidirectional monitoring may not work."
+        echo "  Error: $SSH_TEST"
+        echo ""
+        echo "  To fix manually, add this to ~/.ssh/authorized_keys on the host:"
+        echo "    ${GUARD_BASE_OPTS} ${PUBKEY}"
+        echo ""
+    fi
+}
 
 # ── Auto-detect container ─────────────────────────────────────────────
 
@@ -80,6 +236,27 @@ if [ -z "$CONTAINER_IP" ]; then
     echo "ERROR: Cannot detect IP for container '$CONTAINER_NAME'"
     echo "  Is the container running? Try: incus start $CONTAINER_NAME"
     exit 1
+fi
+
+# ── Out-of-band key re-harden (Tier-3 recovery) ──────────────────────
+# Only (re)install the hardened guardian SSH key on an existing install, then
+# exit — skips prerequisites, venv, systemd, mounts. The container's
+# reharden-key gateway verb is the normal Genesis-driven path; this is the
+# manual fallback when that channel is unavailable.
+if [ "$REHARDEN_KEY_ONLY" -eq 1 ]; then
+    echo ""
+    echo "  Re-hardening guardian SSH key only (container: $CONTAINER_NAME)"
+    echo ""
+    derive_ts_ip
+    if [ ! -f "$HOME/.local/bin/guardian-gateway.sh" ]; then
+        echo "  ERROR: guardian gateway not installed at ~/.local/bin/guardian-gateway.sh"
+        echo "  Run the full installer first: bash install_guardian.sh"
+        exit 1
+    fi
+    setup_bidirectional_ssh
+    echo ""
+    echo "  Guardian SSH key re-harden complete."
+    exit 0
 fi
 
 # Auto-detect health API port (default 5000)
@@ -129,25 +306,8 @@ fi
 echo "  OK    incus: $(incus version 2>/dev/null || echo 'available')"
 echo "  OK    Container '$CONTAINER_NAME': $CONTAINER_IP"
 
-# Tailscale (optional, preferred for approval URLs)
-if command -v tailscale &>/dev/null; then
-    TS_IP=$(tailscale ip -4 2>/dev/null || echo "")
-    if [ -n "$TS_IP" ]; then
-        echo "  OK    Tailscale: $TS_IP (will use for approval URLs)"
-    else
-        echo "  WARN  Tailscale running but no IPv4"
-    fi
-fi
-
-# Fallback: use host LAN IP if no Tailscale
-if [ -z "${TS_IP:-}" ]; then
-    TS_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | grep -oP 'src \K\S+' || echo "")
-    if [ -n "$TS_IP" ]; then
-        echo "  OK    Host LAN IP: $TS_IP (will use for approval URLs)"
-    else
-        echo "  WARN  Could not detect host IP — set approval.bind_host manually"
-    fi
-fi
+# Sets the global TS_IP (host address the container reaches + approval URLs).
+derive_ts_ip
 
 # Claude CLI (optional)
 CLAUDE_PATH=$(command -v claude 2>/dev/null)
@@ -520,119 +680,7 @@ echo "  Installed guardian-gateway.sh"
 echo ""
 echo "[11/14] Setting up bidirectional SSH..."
 
-GUARDIAN_KEY="/home/${CONTAINER_USER}/.ssh/genesis_guardian_ed25519"
-
-# Generate dedicated keypair in container (if not already present)
-if incus exec "$CONTAINER_NAME" -- test -f "$GUARDIAN_KEY" 2>/dev/null; then
-    echo "  Guardian SSH key already exists in container"
-else
-    incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
-        "ssh-keygen -t ed25519 -f $GUARDIAN_KEY -N '' -C 'genesis-guardian-control'" 2>/dev/null
-    echo "  Generated guardian SSH keypair in container"
-fi
-
-# Pull public key from container
-PUBKEY=$(incus exec "$CONTAINER_NAME" -- cat "${GUARDIAN_KEY}.pub" 2>/dev/null || echo "")
-if [ -z "$PUBKEY" ]; then
-    echo "  WARNING: Could not read guardian public key — bidirectional monitoring disabled"
-else
-    # Install command-restricted authorized_keys entry (idempotent by key material)
-    PUBKEY_BLOB=$(echo "$PUBKEY" | awk '{print $2}')
-    GUARD_FROM_IP=""
-    GUARD_BASE_OPTS="command=\"$HOME/.local/bin/guardian-gateway.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty"
-    # Treat the key as installed only if it is present AND hardened (no-pty is
-    # the marker for this installer version's options). A key present without
-    # no-pty is an older, under-hardened entry — re-install to upgrade it.
-    if grep -F "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null | grep -q 'no-pty'; then
-        echo "  Authorized key already installed and hardened"
-    else
-        # Remove any existing control entry (stale key OR older un-hardened one)
-        if grep -q "genesis-guardian-control" "$HOME/.ssh/authorized_keys" 2>/dev/null; then
-            sed -i '/genesis-guardian-control/d' "$HOME/.ssh/authorized_keys"
-            echo "  Removed prior guardian key entry (re-installing hardened)"
-        fi
-        mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
-        # Harden beyond the ForceCommand:
-        #   no-pty  — the gateway is a non-interactive JSON contract, never a shell.
-        #   from="" — bind the key to the container's source IP so a stolen key
-        #             can't be used from any other LAN host. Derive that IP from
-        #             the container's ACTUAL egress route to the host, NOT
-        #             `incus list -c4` (which can return the tailscale address the
-        #             host never sees). If it can't be derived, install without
-        #             from= (no-pty still applies) rather than guess and risk a
-        #             lockout; a wrong from= is caught + rolled back by the
-        #             connectivity test below.
-        GUARD_FROM_IP=$(incus exec "$CONTAINER_NAME" -- ip -4 route get "${TS_IP:-}" 2>/dev/null | grep -oP 'src \K\S+' | head -1 || true)
-        if [ -n "$GUARD_FROM_IP" ]; then
-            echo "from=\"${GUARD_FROM_IP}\",${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
-        else
-            echo "  NOTE: could not derive container source IP — installing without from= (no-pty still applied)"
-            echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
-        fi
-        chmod 600 "$HOME/.ssh/authorized_keys"
-        echo "  Installed hardened command-restricted SSH key for Genesis→Guardian control"
-    fi
-
-    # Write connection config into container for Genesis to read
-    HOST_USER="$(whoami)"
-    HOST_IP="${TS_IP:-}"
-    incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
-        "mkdir -p ~/.genesis && cat > ~/.genesis/guardian_remote.yaml" <<REMOTECONF
-# Auto-generated by install_guardian.sh — $(date -Is)
-# Genesis reads this to SSH to the host for Guardian management.
-host_ip: "${HOST_IP}"
-host_user: "${HOST_USER}"
-ssh_key: "~/.ssh/genesis_guardian_ed25519"
-REMOTECONF
-    echo "  Wrote guardian_remote.yaml into container"
-
-    # Verify SSH connectivity: container → host
-    echo "  Testing SSH connectivity (container → host)..."
-    _guardian_ssh_test() {
-        incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
-            "ssh -i ${GUARDIAN_KEY} -o StrictHostKeyChecking=no -o ConnectTimeout=5 ${HOST_USER}@${HOST_IP} ping 2>&1" || echo "FAILED"
-    }
-    SSH_TEST=$(_guardian_ssh_test)
-    if echo "$SSH_TEST" | grep -q '"ok": true'; then
-        echo "  SSH bidirectional link verified${GUARD_FROM_IP:+ (source-restricted to ${GUARD_FROM_IP})}"
-    elif grep -F "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null | grep -q 'from='; then
-        # The guardian key carries a from= restriction and the link is down — the
-        # restriction likely doesn't match the source IP the host observes (wrong
-        # derivation, or the container's address changed since the key was
-        # written). A wrong from= silently locks Guardian out, so drop it (keeping
-        # no-pty + the other options) and re-test. Keyed on the PRESENCE of from=
-        # (not on whether we wrote it this run), so a stale from= also self-heals
-        # on a plain re-run. Remove by key material (grep -vF on the blob), not
-        # the comment, so it works regardless of the key's comment field.
-        echo "  SSH test failed while a from= restriction is set on the guardian key — dropping from= (keeping no-pty) and retrying..."
-        _ak="$HOME/.ssh/authorized_keys"; _tmp="${_ak}.tmp.$$"
-        grep -vF "$PUBKEY_BLOB" "$_ak" > "$_tmp" 2>/dev/null || true
-        echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$_tmp"
-        mv "$_tmp" "$_ak"
-        chmod 600 "$_ak"
-        SSH_TEST=$(_guardian_ssh_test)
-        if echo "$SSH_TEST" | grep -q '"ok": true'; then
-            echo "  SSH link verified WITHOUT from= — the source-IP restriction did not match what the host observes."
-            echo "  Guardian works; the LAN key-theft restriction is NOT enforced. To enable it, add"
-            echo "  from=\"<container's host-facing source IP>\" to the guardian key in ~/.ssh/authorized_keys."
-        else
-            echo ""
-            echo "  WARNING: SSH test still failing after dropping from=. Guardian bidirectional monitoring may not work."
-            echo "  Error: $SSH_TEST"
-            echo "  To fix manually, add this to ~/.ssh/authorized_keys on the host:"
-            echo "    ${GUARD_BASE_OPTS} ${PUBKEY}"
-            echo ""
-        fi
-    else
-        echo ""
-        echo "  WARNING: SSH test failed. Guardian bidirectional monitoring may not work."
-        echo "  Error: $SSH_TEST"
-        echo ""
-        echo "  To fix manually, add this to ~/.ssh/authorized_keys on the host:"
-        echo "    ${GUARD_BASE_OPTS} ${PUBKEY}"
-        echo ""
-    fi
-fi
+setup_bidirectional_ssh
 
 # ── Step 12: Configure shared filesystem mounts ─────────────────────
 # Incus disk devices give Genesis and Guardian a shared data plane.

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -9,7 +9,8 @@ tried to run arbitrary commands, the host would reject them. OpenSSH
 enforces this restriction, not our code.
 
 Gateway allowlist: restart-timer, pause, resume, status, reset-state, version,
-update, sync-gateway, redeploy, update-cc, test-approval, ping.
+update, sync-gateway, redeploy, update-cc, update-node, test-approval,
+disk-status, reharden-key, ping.
 """
 
 from __future__ import annotations
@@ -56,6 +57,14 @@ class GuardianRemote:
             "-o", "StrictHostKeyChecking=accept-new",
             "-o", f"ConnectTimeout={int(self._timeout)}",
             "-o", "BatchMode=yes",
+        ]
+        # Pin the address family for a v4 literal or a hostname so a dual-stack
+        # resolution can't flip which source address the host's sshd sees — the
+        # address the guardian key's from= is matched against. A v6 literal
+        # (contains ':') is left alone: forcing inet would break the connection.
+        if ":" not in self._host_ip:
+            cmd += ["-o", "AddressFamily=inet"]
+        cmd += [
             f"{self._host_user}@{self._host_ip}",
             command,
         ]
@@ -174,3 +183,49 @@ class GuardianRemote:
                 return {"ok": True, "raw": output[:200]}
         logger.error("Guardian sync-gateway failed: %s", output[:200])
         return {"ok": False, "error": output[:200]}
+
+    async def reharden_key(self) -> dict:
+        """Re-harden the guardian authorized_keys line on the host.
+
+        The verb rewrites the key line to the canonical hardened options with a
+        self-proving ``from=`` and arms a 120s dead-man's-switch that restores
+        the previous file unless a fresh connection confirms the rewrite works.
+        When the line actually changed we make that confirming connection HERE:
+        a second call over a brand-new SSH process. Its success proves the
+        rewritten key still authenticates AND cancels the pending restore
+        (a no-op idempotent second reharden). If the confirm fails, we do NOT
+        claim success — the host's switch will restore the known-good file, and
+        we surface ``restore_pending`` so the next reconciler tick (5 min, well
+        past the 120s window) observes the outcome rather than a wedge.
+
+        Unlike sync-gateway, a non-JSON response is treated as failure: we must
+        not guess whether the key file changed.
+        """
+        ok, output = await self._ssh_command("reharden-key")
+        if not ok:
+            logger.error("Guardian reharden-key failed: %s", output[:200])
+            return {"ok": False, "error": output[:200]}
+        try:
+            result = json.loads(output)
+        except json.JSONDecodeError:
+            logger.warning("Guardian reharden-key returned non-JSON: %s", output[:200])
+            return {"ok": False, "error": "non-JSON response", "raw": output[:200]}
+
+        if not result.get("changed"):
+            return result  # idempotent no-op — nothing to confirm
+
+        # The line changed: prove it works with a fresh connection. This second
+        # call is idempotent (changed:false) and cancels the restore switch.
+        confirm_ok, confirm_out = await self._ssh_command("reharden-key")
+        if confirm_ok:
+            result["confirmed"] = True
+            logger.info("Guardian reharden-key confirmed via fresh connection")
+        else:
+            result["ok"] = False
+            result["confirmed"] = False
+            result["restore_pending"] = True
+            logger.error(
+                "Guardian reharden-key confirm FAILED (%s) — host dead-man's-"
+                "switch will restore the previous key", confirm_out[:200],
+            )
+        return result

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -678,8 +678,8 @@ class GuardianWatchdog:
         if not self._authkey_reharden_attempted:
             self._authkey_reharden_attempted = True
             logger.warning(
-                "Guardian authkey from= stably moved (%s consecutive ticks) — reharden-key",
-                self._authkey_drift_count,
+                "Guardian authkey from= stably moved (drift streak hit threshold) "
+                "— reharden-key",
             )
             await self._run_reharden(reason="from= no longer matches container source")
             return

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -69,6 +69,14 @@ class GuardianWatchdog:
         self._gateway_drift_count: int = 0
         self._gateway_resync_attempted: bool = False
         self._gateway_escalated: bool = False
+        # authorized_keys hardening reconciler: heal a guardian key line that
+        # lost no-pty/from= (regression) or whose from= no longer matches the
+        # container's source (a stable move heals; a flapping source escalates).
+        self._authkey_drift_count: int = 0
+        self._authkey_reharden_attempted: bool = False
+        self._authkey_escalated: bool = False
+        self._authkey_flap_escalated: bool = False
+        self._authkey_last_src_hash: str | None = None
 
     async def _alert_user(self, *, topic: str, context: str, source_id: str) -> None:
         """Deliver a user-facing (Telegram) alert about a Guardian degradation.
@@ -330,6 +338,11 @@ class GuardianWatchdog:
         with contextlib.suppress(Exception):
             await self._check_gateway_staleness(version_info)
 
+        # Authorized_keys hardening reconciler reuses the same version() payload.
+        # Own suppress so a failure here can't skip code-drift logic below.
+        with contextlib.suppress(Exception):
+            await self._check_authkey_hardening(version_info)
+
         host_hash = version_info.get("deployed_commit", "unknown")
 
         if not isinstance(host_hash, str) or host_hash == "unknown":
@@ -571,3 +584,169 @@ class GuardianWatchdog:
                 ),
                 source_id="guardian:gateway_stale",
             )
+
+    def _reset_authkey_state(self) -> None:
+        self._authkey_drift_count = 0
+        self._authkey_reharden_attempted = False
+        self._authkey_escalated = False
+        self._authkey_flap_escalated = False
+        self._authkey_last_src_hash = None
+
+    async def _check_authkey_hardening(self, version_info: dict) -> None:
+        """Detect (and self-heal) an under-hardened guardian authorized_keys line.
+
+        The host's ``version`` reports whether its guardian key line still
+        carries ``no-pty`` + ``from=`` and whether the stored ``from=`` matches
+        the source of THIS connection (plus a hash of that source). Two trigger
+        classes, deliberately treated differently because the reconciler runs
+        live from merge:
+
+        * **Regression** — ``no-pty`` stripped, or ``from=`` missing while a
+          source is observable. These states do not oscillate, so heal on the
+          first tick (one guarded ``reharden-key`` per episode), then escalate
+          if still bad.
+        * **Source mismatch** — ``from=`` present but no longer matching. A
+          rewrite chases the source, so only heal a CONFIRMED STABLE move:
+          ``DRIFT_ALERT_THRESHOLD`` consecutive ticks with the SAME observed
+          source hash. A source that differs between ticks is a flap — never
+          reharden it (that would churn the key file forever); escalate once.
+          The guard is non-sticky: a source that later stabilizes reaches the
+          streak and heals, so no episode can wedge until a process restart.
+
+        Best-effort (invoked under _check_code_drift's suppress). Least
+        disclosure: the host sends booleans + hashes, never the raw address.
+        """
+        no_pty = version_info.get("authkey_no_pty")
+        has_from = version_info.get("authkey_has_from")
+        from_matches = version_info.get("authkey_from_matches")
+        src_hash = version_info.get("authkey_observed_src_hash")
+        # Old gateway without the authkey_* fields → nothing to reconcile.
+        if no_pty is None or has_from is None:
+            return
+        src_available = isinstance(src_hash, str) and src_hash != ""
+
+        # A reharden can only add from= when a source is observable; treat a
+        # missing from= as a healable regression ONLY when we have a source.
+        regression = (no_pty is False) or (has_from is False and src_available)
+        # A pure source-mismatch (opts otherwise fine): from= present, no longer
+        # matching. Needs a stable-move streak, never healed on a flap.
+        mismatch = (not regression) and has_from is True and from_matches is False
+
+        if not regression and not mismatch:
+            # Fully hardened + matching (or unfixable no-src state) → resolved.
+            if self._authkey_drift_count > 0 or self._authkey_last_src_hash:
+                logger.info("Guardian authkey hardening resolved")
+            self._reset_authkey_state()
+            return
+
+        if regression:
+            await self._heal_authkey_regression(no_pty, has_from)
+            return
+
+        # --- source mismatch: require a stable streak, guard against flaps ---
+        if not src_available:
+            return  # can't form a streak on an unobservable source
+        if self._authkey_last_src_hash is None:
+            self._authkey_last_src_hash = src_hash
+            self._authkey_drift_count = 1
+        elif src_hash == self._authkey_last_src_hash:
+            self._authkey_drift_count += 1
+        else:
+            # Source moved again mid-episode → flapping. Never chase it.
+            self._authkey_last_src_hash = src_hash
+            self._authkey_drift_count = 1
+            await self._escalate_authkey_flap()
+            return
+
+        if self._authkey_drift_count < self.DRIFT_ALERT_THRESHOLD:
+            return
+        await self._heal_authkey_mismatch()
+
+    async def _heal_authkey_regression(self, no_pty, has_from) -> None:
+        detail = "no-pty missing" if no_pty is False else "from= missing"
+        if not self._authkey_reharden_attempted:
+            self._authkey_reharden_attempted = True
+            logger.warning("Guardian authkey under-hardened (%s) — reharden-key", detail)
+            await self._run_reharden(reason=detail)
+            return
+        await self._escalate_authkey(
+            f"Guardian authorized_keys STILL under-hardened ({detail}) after "
+            f"auto reharden-key. Manual check needed.",
+        )
+
+    async def _heal_authkey_mismatch(self) -> None:
+        if not self._authkey_reharden_attempted:
+            self._authkey_reharden_attempted = True
+            logger.warning(
+                "Guardian authkey from= stably moved (%s consecutive ticks) — reharden-key",
+                self._authkey_drift_count,
+            )
+            await self._run_reharden(reason="from= no longer matches container source")
+            return
+        await self._escalate_authkey(
+            "Guardian authorized_keys from= STILL mismatched after auto "
+            "reharden-key. Manual check needed.",
+        )
+
+    async def _run_reharden(self, *, reason: str) -> None:
+        """Run one guarded reharden-key and notify (a reharden means the
+        container's host-facing source changed — the operator should know)."""
+        try:
+            res = await self._remote.reharden_key()
+        except Exception:
+            logger.exception("reharden-key self-heal raised")
+            res = {"ok": False}
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.WARNING,
+                "guardian.authkey_reharden",
+                f"Guardian authorized_keys re-hardened ({reason}); "
+                f"ok={res.get('ok')} changed={res.get('changed')}. "
+                f"Re-verifying next tick.",
+            )
+        await self._alert_user(
+            topic="Guardian key re-hardened",
+            context=(
+                f"Guardian re-hardened its host SSH key ({reason}). "
+                f"ok={res.get('ok')} changed={res.get('changed')} "
+                f"confirmed={res.get('confirmed')}."
+            ),
+            source_id="guardian:authkey_rehardened",
+        )
+
+    async def _escalate_authkey(self, message: str) -> None:
+        if self._authkey_escalated:
+            return
+        self._authkey_escalated = True
+        logger.error(message)
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.ERROR, "guardian.authkey_drift", message)
+        await self._alert_user(
+            topic="Guardian key hardening failed",
+            context=message,
+            source_id="guardian:authkey_drift",
+        )
+
+    async def _escalate_authkey_flap(self) -> None:
+        if self._authkey_flap_escalated:
+            return
+        self._authkey_flap_escalated = True
+        message = (
+            "Guardian authorized_keys from= no longer matches and the "
+            "container's source address is FLAPPING (differs between checks). "
+            "Refusing to rewrite the key on a moving target — set a stable "
+            "address or a subnet from= manually."
+        )
+        logger.error(message)
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.ERROR, "guardian.authkey_flap", message)
+        await self._alert_user(
+            topic="Guardian key source flapping",
+            context=message,
+            source_id="guardian:authkey_flap",
+        )

--- a/tests/test_guardian/test_gateway_reharden.py
+++ b/tests/test_guardian/test_gateway_reharden.py
@@ -154,7 +154,7 @@ class TestRehardenKeyVerb:
         _run(sandbox, "reharden-key")
         _run(sandbox, "reharden-key")  # confirm call
         calls = _calls(sandbox)
-        assert "systemctl stop genesis-authkey-restore.timer" in calls
+        assert "stop genesis-authkey-restore.timer" in calls
 
     def test_empty_ssh_connection_falls_back_to_no_from(self, sandbox):
         res = _run(sandbox, "reharden-key", ssh_connection=None)

--- a/tests/test_guardian/test_gateway_reharden.py
+++ b/tests/test_guardian/test_gateway_reharden.py
@@ -1,0 +1,258 @@
+"""Tests for the guardian-gateway.sh `reharden-key` verb + `version` authkey fields.
+
+These run the REAL gateway script in a sandboxed $HOME (never the live
+~/.ssh/authorized_keys), with `systemctl`/`systemd-run` replaced by PATH
+shims that record their invocations. The dead-man's-switch and the
+authorized_keys rewrite invariants are the security-critical surface here,
+so they get direct coverage rather than mock-only tests.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATEWAY = REPO_ROOT / "scripts" / "guardian-gateway.sh"
+INSTALLER = REPO_ROOT / "scripts" / "install_guardian.sh"
+
+_needs_tools = pytest.mark.skipif(
+    shutil.which("ssh-keygen") is None or shutil.which("bash") is None,
+    reason="requires bash + ssh-keygen",
+)
+
+# The source address sshd would report for the test connection.
+TEST_SRC = "10.0.0.42"
+TEST_SSH_CONNECTION = f"{TEST_SRC} 51234 10.0.0.1 22"
+
+
+def _gen_pubkey(tmp_path: Path, name: str, comment: str) -> str:
+    """Generate a real ed25519 keypair; return the public-key line."""
+    key = tmp_path / name
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-f", str(key), "-N", "", "-C", comment],
+        check=True, capture_output=True,
+    )
+    return (tmp_path / f"{name}.pub").read_text().strip()
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    """Sandboxed HOME with an authorized_keys containing a PRE-#882 guardian
+    line (ForceCommand + forwarding blocks, NO no-pty, NO from=) between two
+    unrelated keys — mirroring the observed live host state."""
+    home = tmp_path / "home"
+    (home / ".ssh").mkdir(parents=True)
+    (home / ".local" / "bin").mkdir(parents=True)
+
+    other1 = _gen_pubkey(tmp_path, "other1", "user@laptop")
+    guardian = _gen_pubkey(tmp_path, "guardian", "genesis-guardian-control")
+    other2 = _gen_pubkey(tmp_path, "other2", "admin@desktop")
+
+    old_opts = (
+        'command="/home/olduser/.local/bin/guardian-gateway.sh",'
+        "no-port-forwarding,no-X11-forwarding,no-agent-forwarding"
+    )
+    ak = home / ".ssh" / "authorized_keys"
+    ak.write_text(f"{other1}\n{old_opts} {guardian}\n{other2}\n")
+    ak.chmod(0o600)
+
+    # PATH shims: record calls, succeed.
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    calls = tmp_path / "calls.log"
+    for tool in ("systemctl", "systemd-run"):
+        shim = fakebin / tool
+        shim.write_text(f'#!/bin/sh\necho "{tool} $@" >> "{calls}"\nexit 0\n')
+        shim.chmod(0o755)
+
+    return {"home": home, "ak": ak, "fakebin": fakebin, "calls": calls,
+            "guardian_pub": guardian, "others": (other1, other2)}
+
+
+def _run(sandbox: dict, verb: str, ssh_connection: str | None = TEST_SSH_CONNECTION,
+         ) -> subprocess.CompletedProcess:
+    env = {
+        "HOME": str(sandbox["home"]),
+        "PATH": f"{sandbox['fakebin']}:/usr/bin:/bin",
+        "SSH_ORIGINAL_COMMAND": verb,
+    }
+    if ssh_connection is not None:
+        env["SSH_CONNECTION"] = ssh_connection
+    return subprocess.run(
+        ["bash", str(GATEWAY)], env=env, capture_output=True, text=True, timeout=60,
+    )
+
+
+def _guardian_lines(sandbox: dict) -> list[str]:
+    return [line for line in sandbox["ak"].read_text().splitlines()
+            if "genesis-guardian-control" in line]
+
+
+def _calls(sandbox: dict) -> str:
+    return sandbox["calls"].read_text() if sandbox["calls"].exists() else ""
+
+
+@_needs_tools
+class TestRehardenKeyVerb:
+    def test_hardens_unhardened_line_with_self_proving_from(self, sandbox):
+        res = _run(sandbox, "reharden-key")
+        assert res.returncode == 0, res.stderr
+        payload = json.loads(res.stdout)
+        assert payload["ok"] is True
+        assert payload["changed"] is True
+        assert payload["has_from"] is True
+
+        lines = _guardian_lines(sandbox)
+        assert len(lines) == 1
+        line = lines[0]
+        assert f'from="{TEST_SRC}"' in line
+        assert "no-pty" in line
+        assert "no-port-forwarding" in line
+        assert "no-agent-forwarding" in line
+        # command= is rebuilt against THIS home, never taken from input
+        assert f'command="{sandbox["home"]}/.local/bin/guardian-gateway.sh"' in line
+        # key material preserved exactly
+        assert sandbox["guardian_pub"].split()[1] in line
+
+    def test_other_lines_untouched_and_count_preserved(self, sandbox):
+        before = sandbox["ak"].read_text().splitlines()
+        res = _run(sandbox, "reharden-key")
+        assert res.returncode == 0
+        after = sandbox["ak"].read_text().splitlines()
+        assert len(after) == len(before) == 3
+        other1, other2 = sandbox["others"]
+        assert other1 in after
+        assert other2 in after
+
+    def test_idempotent_second_call_reports_unchanged(self, sandbox):
+        assert _run(sandbox, "reharden-key").returncode == 0
+        content_after_first = sandbox["ak"].read_text()
+        res2 = _run(sandbox, "reharden-key")
+        assert res2.returncode == 0
+        payload = json.loads(res2.stdout)
+        assert payload["ok"] is True
+        assert payload["changed"] is False
+        assert sandbox["ak"].read_text() == content_after_first
+
+    def test_arms_dead_mans_switch_before_write(self, sandbox):
+        _run(sandbox, "reharden-key")
+        calls = _calls(sandbox)
+        assert "systemd-run" in calls
+        assert "--on-active=120" in calls
+        # snapshot exists for the restore to copy back
+        assert (sandbox["ak"].parent / "authorized_keys.guardian-bak").exists()
+
+    def test_call_cancels_pending_restore(self, sandbox):
+        """Any reharden-key arrival authenticated against the CURRENT file —
+        living proof it works — so it disarms a pending restore (the confirm
+        path for the container's second call)."""
+        _run(sandbox, "reharden-key")
+        _run(sandbox, "reharden-key")  # confirm call
+        calls = _calls(sandbox)
+        assert "systemctl stop genesis-authkey-restore.timer" in calls
+
+    def test_empty_ssh_connection_falls_back_to_no_from(self, sandbox):
+        res = _run(sandbox, "reharden-key", ssh_connection=None)
+        assert res.returncode == 0, res.stderr
+        payload = json.loads(res.stdout)
+        assert payload["ok"] is True
+        assert payload["has_from"] is False
+        line = _guardian_lines(sandbox)[0]
+        assert "from=" not in line
+        assert "no-pty" in line  # still hardened
+
+    def test_refuses_when_no_guardian_line(self, sandbox):
+        content = "\n".join(sandbox["others"]) + "\n"
+        sandbox["ak"].write_text(content)
+        res = _run(sandbox, "reharden-key")
+        assert res.returncode != 0
+        assert sandbox["ak"].read_text() == content  # untouched
+
+    def test_refuses_when_multiple_guardian_lines(self, sandbox):
+        content = sandbox["ak"].read_text()
+        dup = content + f"{sandbox['guardian_pub']}\n"
+        sandbox["ak"].write_text(dup)
+        res = _run(sandbox, "reharden-key")
+        assert res.returncode != 0
+        assert sandbox["ak"].read_text() == dup  # untouched
+
+    def test_refuses_to_write_when_switch_cannot_arm(self, sandbox):
+        """No dead-man's-switch → no write. A failed systemd-run must abort
+        BEFORE authorized_keys is modified."""
+        shim = sandbox["fakebin"] / "systemd-run"
+        shim.write_text("#!/bin/sh\nexit 1\n")
+        shim.chmod(0o755)
+        before = sandbox["ak"].read_text()
+        res = _run(sandbox, "reharden-key")
+        assert res.returncode != 0
+        assert sandbox["ak"].read_text() == before
+
+
+@_needs_tools
+class TestVersionAuthkeyFields:
+    def test_reports_unhardened_state(self, sandbox):
+        res = _run(sandbox, "version")
+        assert res.returncode == 0, res.stderr
+        payload = json.loads(res.stdout)
+        assert payload["authkey_no_pty"] is False
+        assert payload["authkey_has_from"] is False
+
+    def test_reports_hardened_state_with_matching_source(self, sandbox):
+        assert _run(sandbox, "reharden-key").returncode == 0
+        res = _run(sandbox, "version")
+        payload = json.loads(res.stdout)
+        assert payload["authkey_no_pty"] is True
+        assert payload["authkey_has_from"] is True
+        assert payload["authkey_from_matches"] is True
+        assert len(payload["authkey_observed_src_hash"]) == 64
+        assert len(payload["authkey_opts_hash"]) == 64
+        # least disclosure: no raw address in the payload
+        assert TEST_SRC not in res.stdout
+
+    def test_from_mismatch_detected_when_source_moves(self, sandbox):
+        assert _run(sandbox, "reharden-key").returncode == 0
+        moved = "10.0.0.99 51234 10.0.0.1 22"
+        res = _run(sandbox, "version", ssh_connection=moved)
+        payload = json.loads(res.stdout)
+        assert payload["authkey_has_from"] is True
+        assert payload["authkey_from_matches"] is False
+
+    def test_glob_from_pattern_matches(self, sandbox):
+        """An operator-set subnet glob (sshd fnmatch semantics) must read as
+        matching — the reconciler must never fight a manual subnet from=."""
+        assert _run(sandbox, "reharden-key").returncode == 0
+        sandbox["ak"].write_text(
+            sandbox["ak"].read_text().replace(
+                f'from="{TEST_SRC}"', 'from="10.0.0.*"',
+            ),
+        )
+        res = _run(sandbox, "version")
+        payload = json.loads(res.stdout)
+        assert payload["authkey_from_matches"] is True
+
+    def test_empty_src_reports_empty_hash(self, sandbox):
+        res = _run(sandbox, "version", ssh_connection=None)
+        payload = json.loads(res.stdout)
+        assert payload["authkey_observed_src_hash"] == ""
+
+
+class TestOptionsDivergenceGuardrail:
+    """The canonical hardened-options string is deliberately duplicated in
+    guardian-gateway.sh (hermetic — must work when the install dir is broken)
+    and install_guardian.sh. That duplication is safe ONLY while this test
+    forces the two literals to stay byte-identical."""
+
+    def _extract(self, path: Path) -> str:
+        import re
+        text = path.read_text()
+        m = re.search(r'GUARD_BASE_OPTS="([^\n]*)"', text)
+        assert m, f"GUARD_BASE_OPTS not found in {path.name}"
+        return m.group(1)
+
+    def test_gateway_and_installer_opts_identical(self):
+        assert self._extract(GATEWAY) == self._extract(INSTALLER)

--- a/tests/test_guardian/test_remote.py
+++ b/tests/test_guardian/test_remote.py
@@ -155,3 +155,102 @@ class TestSyncGateway:
             result = await remote.sync_gateway()
         assert result["ok"] is False
         assert "error" in result
+
+
+class TestRehardenKey:
+    """Verb call + confirm flow: a changed key must be proven by a SECOND
+    fresh SSH connection (which doubles as the dead-man's-switch cancel)."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_needs_no_confirm(self, remote):
+        with patch.object(
+            remote, "_ssh_command",
+            return_value=(True, '{"ok": true, "changed": false}'),
+        ) as ssh:
+            result = await remote.reharden_key()
+        assert result["ok"] is True
+        assert result["changed"] is False
+        ssh.assert_awaited_once()  # idempotent no-op → no second connection
+
+    @pytest.mark.asyncio
+    async def test_changed_confirms_with_second_connection(self, remote):
+        with patch.object(
+            remote, "_ssh_command",
+            side_effect=[
+                (True, '{"ok": true, "changed": true, "has_from": true}'),
+                (True, '{"ok": true, "changed": false}'),
+            ],
+        ) as ssh:
+            result = await remote.reharden_key()
+        assert ssh.await_count == 2
+        assert result["ok"] is True
+        assert result["changed"] is True
+        assert result["confirmed"] is True
+
+    @pytest.mark.asyncio
+    async def test_confirm_failure_reports_restore_pending(self, remote):
+        """Second connection failing means the rewritten line may not work —
+        the host's dead-man's-switch will restore it; surface that instead
+        of claiming success."""
+        with patch.object(
+            remote, "_ssh_command",
+            side_effect=[
+                (True, '{"ok": true, "changed": true, "has_from": true}'),
+                (False, "timeout"),
+            ],
+        ):
+            result = await remote.reharden_key()
+        assert result["ok"] is False
+        assert result["changed"] is True
+        assert result["confirmed"] is False
+        assert result["restore_pending"] is True
+
+    @pytest.mark.asyncio
+    async def test_ssh_failure(self, remote):
+        with patch.object(remote, "_ssh_command", return_value=(False, "timeout")):
+            result = await remote.reharden_key()
+        assert result["ok"] is False
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_non_json_response_is_failure(self, remote):
+        """Unlike sync-gateway, an unparseable reharden response is NOT a
+        success — we can't know whether the key file changed."""
+        with patch.object(remote, "_ssh_command", return_value=(True, "not json")):
+            result = await remote.reharden_key()
+        assert result["ok"] is False
+
+
+class TestAddressFamilyPin:
+    """_ssh_command must pin AddressFamily=inet for v4/hostname targets so a
+    dual-stack resolution can't flip the source address sshd sees (which
+    from= matches against). A v6-literal host_ip must NOT get the pin."""
+
+    async def _spawn_args(self, remote_obj) -> list[str]:
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (b'{"ok": true}', b"")
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc,
+        ) as spawn:
+            await remote_obj._ssh_command("status")
+        return [str(a) for a in spawn.call_args.args]
+
+    @pytest.mark.asyncio
+    async def test_v4_literal_gets_pin(self, remote):
+        args = await self._spawn_args(remote)
+        assert "AddressFamily=inet" in args
+
+    @pytest.mark.asyncio
+    async def test_hostname_gets_pin(self):
+        r = GuardianRemote(host_ip="guardian.example.internal", host_user="u",
+                           key_path="/tmp/test_key")
+        args = await self._spawn_args(r)
+        assert "AddressFamily=inet" in args
+
+    @pytest.mark.asyncio
+    async def test_v6_literal_skips_pin(self):
+        r = GuardianRemote(host_ip="fd00::1", host_user="u",
+                           key_path="/tmp/test_key")
+        args = await self._spawn_args(r)
+        assert "AddressFamily=inet" not in args

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -730,3 +730,177 @@ class TestAlertUser:
         outreach.submit_raw.side_effect = Exception("telegram down")
         wd = GuardianWatchdog(AsyncMock(), event_bus=None, outreach_pipeline=outreach)
         await wd._alert_user(topic="t", context="c", source_id="guardian:x")  # swallowed
+
+
+# --- Authorized-keys hardening reconciler -----------------------------------
+
+# sha256 hexdigests of the host-observed SSH source (values arbitrary).
+_SRC_A = "c" * 64
+_SRC_B = "d" * 64
+_SRC_C = "e" * 64
+
+
+def _authkey_vi(*, no_pty=True, has_from=True, from_matches=True,
+                src_hash=_SRC_A) -> dict:
+    """version() payload carrying the authkey_* hardening indicators."""
+    return {
+        "gateway_sha": _EXPECTED_GW_SHA,
+        "code_version": "abc1234",
+        "authkey_no_pty": no_pty,
+        "authkey_has_from": has_from,
+        "authkey_from_matches": from_matches,
+        "authkey_observed_src_hash": src_hash,
+        "authkey_opts_hash": "f" * 64,
+    }
+
+
+def _ak_watchdog():
+    wd, r, eb, outreach = _gw_watchdog()
+    r.reharden_key = AsyncMock(
+        return_value={"ok": True, "changed": True, "confirmed": True})
+    return wd, r, eb, outreach
+
+
+def _alert_ids(outreach) -> list[str]:
+    return [c.args[1].source_id for c in outreach.submit_raw.call_args_list]
+
+
+class TestAuthkeyHardening:
+    """Self-heal reconciler for the host guardian authorized_keys line.
+
+    Two trigger classes: a hardening REGRESSION (no-pty stripped, or from=
+    missing while the source is derivable) heals immediately — those states
+    don't oscillate. A from= MISMATCH heals only after a stable streak (same
+    observed-source hash for DRIFT_ALERT_THRESHOLD consecutive ticks); a
+    source that changes between ticks is a flap and must NEVER be chased —
+    escalate instead. The flap guard is non-sticky: a source that later
+    stabilizes reaches the streak and heals.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_skips(self):
+        """Old gateway without authkey_* fields → never act, never alarm."""
+        wd, r, eb, outreach = _ak_watchdog()
+        await wd._check_authkey_hardening(
+            {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"})
+        r.reharden_key.assert_not_called()
+        outreach.submit_raw.assert_not_called()
+        assert wd._authkey_drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_healthy_resets_state(self):
+        wd, r, _, _ = _ak_watchdog()
+        wd._authkey_drift_count = 2
+        wd._authkey_reharden_attempted = True
+        wd._authkey_escalated = True
+        wd._authkey_flap_escalated = True
+        wd._authkey_last_src_hash = _SRC_B
+        await wd._check_authkey_hardening(_authkey_vi())
+        r.reharden_key.assert_not_called()
+        assert wd._authkey_drift_count == 0
+        assert wd._authkey_reharden_attempted is False
+        assert wd._authkey_escalated is False
+        assert wd._authkey_flap_escalated is False
+        assert wd._authkey_last_src_hash is None
+
+    @pytest.mark.asyncio
+    async def test_no_pty_regression_heals_immediately(self):
+        """A stripped no-pty is a non-oscillating regression → heal on the
+        FIRST tick, and tell the operator a reharden happened."""
+        wd, r, eb, outreach = _ak_watchdog()
+        await wd._check_authkey_hardening(_authkey_vi(no_pty=False))
+        r.reharden_key.assert_awaited_once()
+        assert any("authkey" in e for e in _emitted_events(eb))
+        assert "guardian:authkey_rehardened" in _alert_ids(outreach)
+
+    @pytest.mark.asyncio
+    async def test_regression_heals_once_then_escalates_once(self):
+        wd, r, _, outreach = _ak_watchdog()
+        vi = _authkey_vi(no_pty=False)
+        for _ in range(4):
+            await wd._check_authkey_hardening(vi)
+        r.reharden_key.assert_awaited_once()  # one heal per episode
+        drift_alerts = [s for s in _alert_ids(outreach)
+                        if s == "guardian:authkey_drift"]
+        assert len(drift_alerts) == 1  # escalated exactly once
+
+    @pytest.mark.asyncio
+    async def test_missing_from_with_src_heals(self):
+        wd, r, _, _ = _ak_watchdog()
+        await wd._check_authkey_hardening(
+            _authkey_vi(has_from=False, from_matches=False))
+        r.reharden_key.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_from_without_src_never_heals(self):
+        """No observable source → a reharden could not add from= anyway;
+        do nothing rather than churn (fail-safe)."""
+        wd, r, _, outreach = _ak_watchdog()
+        vi = _authkey_vi(has_from=False, from_matches=False, src_hash="")
+        for _ in range(_THRESHOLD + 1):
+            await wd._check_authkey_hardening(vi)
+        r.reharden_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_from_mismatch_heals_only_at_stable_streak(self):
+        """A moved-but-stable source heals exactly once, and only after
+        DRIFT_ALERT_THRESHOLD consecutive ticks with the SAME source hash."""
+        wd, r, _, _ = _ak_watchdog()
+        vi = _authkey_vi(from_matches=False, src_hash=_SRC_B)
+        for _ in range(_THRESHOLD - 1):
+            await wd._check_authkey_hardening(vi)
+        r.reharden_key.assert_not_called()
+        await wd._check_authkey_hardening(vi)  # threshold tick
+        r.reharden_key.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_from_mismatch_empty_src_never_heals(self):
+        """Mismatch reported but the source is unobservable → no streak can
+        form; never reharden on it."""
+        wd, r, _, _ = _ak_watchdog()
+        vi = _authkey_vi(from_matches=False, src_hash="")
+        for _ in range(_THRESHOLD + 1):
+            await wd._check_authkey_hardening(vi)
+        r.reharden_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flap_never_heals_escalates_once(self):
+        """Source hash differing between mismatch ticks = flapping network —
+        rewriting from= each tick would churn the key file forever. Never
+        heal; escalate exactly once with the real remedy."""
+        wd, r, _, outreach = _ak_watchdog()
+        for h in (_SRC_A, _SRC_B, _SRC_C, _SRC_A, _SRC_B):
+            await wd._check_authkey_hardening(
+                _authkey_vi(from_matches=False, src_hash=h))
+        r.reharden_key.assert_not_called()
+        flap_alerts = [s for s in _alert_ids(outreach)
+                       if s == "guardian:authkey_flap"]
+        assert len(flap_alerts) == 1
+
+    @pytest.mark.asyncio
+    async def test_flap_then_stable_source_recovers(self):
+        """The flap guard is NON-STICKY: once the source stabilizes for a
+        full streak, the reconciler heals — no wedged state needing a
+        restart."""
+        wd, r, _, _ = _ak_watchdog()
+        await wd._check_authkey_hardening(
+            _authkey_vi(from_matches=False, src_hash=_SRC_A))
+        for _ in range(_THRESHOLD):  # stabilizes on B
+            await wd._check_authkey_hardening(
+                _authkey_vi(from_matches=False, src_hash=_SRC_B))
+        r.reharden_key.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resolved_resets_and_rearms(self):
+        """After a healed episode resolves, a NEW episode must self-heal
+        again (no 'quiet forever')."""
+        wd, r, _, _ = _ak_watchdog()
+        for _ in range(_THRESHOLD):  # episode 1: stable move → heal
+            await wd._check_authkey_hardening(
+                _authkey_vi(from_matches=False, src_hash=_SRC_B))
+        assert r.reharden_key.await_count == 1
+        await wd._check_authkey_hardening(_authkey_vi())  # resolved → reset
+        for _ in range(_THRESHOLD):  # episode 2 → re-armed
+            await wd._check_authkey_hardening(
+                _authkey_vi(from_matches=False, src_hash=_SRC_C))
+        assert r.reharden_key.await_count == 2


### PR DESCRIPTION
## What

Genesis now re-hardens its own host Guardian SSH key automatically — no human on the host required. This is Phase 1 of the Guardian self-maintenance initiative (escalation-inversion: Genesis acts via its own control plane; the human is the last resort).

The Guardian's control key should carry `no-pty` + a source-IP `from=` restriction, but before this those were applied **only at install time** — so an install set up before the hardening (or one whose container address changed) kept a weaker key until someone re-ran the installer by hand.

## Changes

- **`reharden-key` gateway verb** (`guardian-gateway.sh`) — zero-input; rewrites the guardian `authorized_keys` line to the canonical hardened options with a **self-proving `from=`** derived from the connection's own `$SSH_CONNECTION` source (the container always re-dials the same host, so the next connection presents the same source). Key material is read from the file; options are hardcoded. **Un-brickable:** snapshot + a 120s systemd dead-man's-switch restores the previous file unless a fresh connection confirms the rewrite works; `ssh-keygen` validates the rebuilt line before an atomic `mv`; exactly-one-guardian-line and line-count invariants guard the write.
- **`version` verb** now reports `authkey_no_pty`, `authkey_has_from`, `authkey_from_matches`, `authkey_opts_hash`, and `authkey_observed_src_hash` — **booleans + sha256 hashes only**, never the raw key blob, the `from=` literal, or the source address.
- **`_check_authkey_hardening` reconciler** (`watchdog.py`) — runs each watchdog tick beside the gateway-staleness check. A hardening **regression** (no-pty stripped, or from= missing with an observable source) heals on the first tick; a **from= mismatch** heals only after a confirmed **stable-source streak** (same observed-source hash for `DRIFT_ALERT_THRESHOLD` consecutive ticks); a **flapping** source is never chased — escalated once — and the guard is non-sticky so a later-stable source self-recovers.
- **`GuardianRemote.reharden_key()`** — when the line changed, confirms with a second fresh connection (proves the rewrite still authenticates **and** cancels the host dead-man's-switch); a failed confirm reports `restore_pending` rather than false success. Plus an `AddressFamily=inet` pin for v4/hostname targets so a dual-stack resolution can't flip the source the host's `from=` matches (skipped for v6 literals).
- **`install_guardian.sh --reharden-key-only`** — Step 11 factored into `setup_bidirectional_ssh()` + `derive_ts_ip()` (behavior-identical normal path); the flag re-hardens the key without a full re-install, as the manual out-of-band fallback.
- **Divergence guardrail test** — asserts the canonical `GUARD_BASE_OPTS` is byte-identical between `guardian-gateway.sh` and `install_guardian.sh` (the duplication is deliberate — the gateway must stay hermetic — so it's mechanically enforced).

## Security posture (SSH trust boundary)

The verb is **theft-neutral** (to reach it a caller's source must already satisfy the current `from=`, or `from=` is absent = a pre-existing weakness this closes), **strictly less powerful** than the existing `sudo`-running `update`/`update-cc`/`update-node` verbs, takes **zero caller input**, and is **fail-safe on every path** — no armed switch → no write; every error leaves the file untouched or the switch restores it. It can only make the key *more* restrictive.

## Tests

TDD RED→GREEN. 34 new tests (483 guardian tests total, all passing):
- `test_gateway_reharden.py` runs the **real** gateway script as subprocess E2E with real ed25519 keys + real file rewrites (self-proving from=, other-lines-untouched, idempotency, dead-man's-switch arm/cancel, refuses on 0/>1 guardian lines, refuses when the switch can't arm, no-from fallback) + version authkey fields + the divergence guardrail.
- `test_watchdog.py::TestAuthkeyHardening` — the full reconciler state machine (regression heal-once-then-escalate, stable-move heal at the streak, flap never-heals-escalates-once, flap-then-stable recovery, resolved reset + re-arm).
- `test_remote.py` — the confirm flow + AddressFamily pin.

ruff + shellcheck clean; private-data scan clean (fixtures use synthetic `10.0.0.42`).

## Deploy (Genesis-driven, no manual host access)

On merge, the container's `update` gateway verb self-installs the new gateway on its next call, and the reconciler heals the live (pre-hardening) key automatically — the initiative's thesis proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
