### PR TITLE
feat(ci): enforce CC↔Node pin lockstep at PR time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,22 @@ jobs:
       - name: External-I/O egress guard
         run: python scripts/check_external_io.py
 
+  cc-node-lockstep:
+    # Enforce the CC↔Node pin lockstep: NODE_MAJOR in scripts/lib/cc_version.sh
+    # must satisfy the pinned Claude Code's engines.node floor. Prevents the
+    # "bumped CC past a Node floor, forgot NODE_MAJOR" mistake that left a host
+    # unable to run `claude -p`. Fails closed on a real mismatch / typo'd pin;
+    # fails open (warn) on a transient npm-registry error. See
+    # scripts/check_cc_node_lockstep.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: CC↔Node pin-lockstep guard
+        run: python scripts/check_cc_node_lockstep.py
+
   test:
     runs-on: ubuntu-latest
     # CI is blocking — local full-suite runs are banned. See procedure

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -33,7 +33,11 @@ Code" below).
 
 One pin, both machines, no drift:
 
-1. Edit `CC_VERSION` in `scripts/lib/cc_version.sh` (one line).
+1. Edit `CC_VERSION` in `scripts/lib/cc_version.sh` (one line). If the new CC
+   version raises its `engines.node` floor, bump `NODE_MAJOR` in the same file
+   in lockstep — the `cc-node-lockstep` CI job (`scripts/check_cc_node_lockstep.py`)
+   fails the PR if `NODE_MAJOR` is below the pinned CC's required Node major, so
+   this can't be forgotten (it fails open on a transient npm-registry error).
 2. Merge to `main`.
 3. Run `scripts/update.sh`. It updates the container, redeploys the Guardian
    (carrying the new gateway script), then queries the host's CC version and —

--- a/scripts/check_cc_node_lockstep.py
+++ b/scripts/check_cc_node_lockstep.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""CC↔Node pin-lockstep guard — fail a PR that bumps Claude Code past the Node
+floor its ``engines.node`` requires without also bumping ``NODE_MAJOR``.
+
+Why this exists (a real incident, 2026-07-04): a host VM sat on Node 20 while
+its pinned Claude Code required Node >=22, so ``claude -p`` — the Guardian's
+recovery brain — could not start. ``scripts/update.sh`` now HEALS deployed
+drift, but nothing stopped the *authoring-time* mistake: the "bump NODE_MAJOR
+in lockstep" instruction in ``scripts/lib/cc_version.sh`` was only a comment.
+This turns that comment into a mechanical CI gate.
+
+The single source of truth for both pins is ``scripts/lib/cc_version.sh``
+(``CC_VERSION`` + ``NODE_MAJOR``). This script reads them, fetches the pinned
+CC version's ``engines.node`` from the npm registry, and asserts
+``NODE_MAJOR >= <required floor major>``.
+
+Error policy (deliberate):
+  * FAIL CLOSED (exit 1) on a real, definitive problem: NODE_MAJOR below the
+    floor; a pin file that cannot be parsed; or an HTTP 404 for the pinned CC
+    version (a version that does not exist in the registry is a typo'd pin,
+    not a network blip — catching it here is free).
+  * FAIL OPEN (warn + exit 0) on anything that is plausibly transient or
+    merely unrecognized: connection/timeout/5xx errors (one retry first), or
+    an ``engines.node`` comparator shape this parser does not understand. A
+    flaky npm registry must never wall off every PR, and an unparseable-but-
+    present spec should not hard-block on a parser gap — it degrades to a
+    no-op gate, never a false failure.
+
+Usage:  python scripts/check_cc_node_lockstep.py [--pin-file PATH]
+        exit 0 = lockstep OK (or fail-open condition), 1 = violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_PIN_FILE = _REPO_ROOT / "scripts" / "lib" / "cc_version.sh"
+
+_REGISTRY_URL = "https://registry.npmjs.org/@anthropic-ai/claude-code/{version}"
+_HTTP_TIMEOUT = 15  # seconds — a single registry GET; generous for a slow runner.
+_RETRIES = 1  # one retry on a transient network error before failing open.
+
+# Matches `CC_VERSION="${CC_VERSION:-2.1.201}"` / `NODE_MAJOR="${NODE_MAJOR:-22}"`.
+# Captures the default value after `:-`. Tolerant of surrounding quoting/spacing.
+_PIN_RE = {
+    "CC_VERSION": re.compile(r'CC_VERSION="?\$\{CC_VERSION:-([0-9]+\.[0-9]+\.[0-9]+)\}"?'),
+    "NODE_MAJOR": re.compile(r'NODE_MAJOR="?\$\{NODE_MAJOR:-([0-9]+)\}"?'),
+}
+
+
+class LockstepViolation(Exception):
+    """A definitive lockstep failure — the caller should exit non-zero."""
+
+
+class FailOpen(Exception):
+    """A transient / unrecognized condition — warn and exit zero."""
+
+
+def parse_pins(pin_file: Path) -> tuple[str, int]:
+    """Extract (CC_VERSION, NODE_MAJOR) defaults from cc_version.sh.
+
+    A pin file we cannot parse is a real error (fail closed) — the pins are
+    the contract this gate enforces; if they are unreadable the gate is blind.
+    """
+    try:
+        text = pin_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LockstepViolation(f"cannot read pin file {pin_file}: {exc}") from exc
+
+    cc_match = _PIN_RE["CC_VERSION"].search(text)
+    node_match = _PIN_RE["NODE_MAJOR"].search(text)
+    if not cc_match or not node_match:
+        missing = []
+        if not cc_match:
+            missing.append("CC_VERSION")
+        if not node_match:
+            missing.append("NODE_MAJOR")
+        raise LockstepViolation(
+            f"could not parse {', '.join(missing)} default(s) from {pin_file} "
+            "(expected `VAR=\"${VAR:-value}\"` form)"
+        )
+    return cc_match.group(1), int(node_match.group(1))
+
+
+def fetch_engines_node(cc_version: str, *, opener=urllib.request.urlopen) -> str:
+    """Return the ``engines.node`` string for a pinned CC version from npm.
+
+    ``opener`` is injectable so tests never touch the network. Raises
+    ``LockstepViolation`` on HTTP 404 (nonexistent version = typo'd pin);
+    ``FailOpen`` on transient network errors (after one retry) or a missing
+    engines.node field.
+    """
+    url = _REGISTRY_URL.format(version=cc_version)
+    last_exc: Exception | None = None
+    for attempt in range(_RETRIES + 1):
+        try:
+            with opener(url, timeout=_HTTP_TIMEOUT) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+            break
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                raise LockstepViolation(
+                    f"Claude Code {cc_version} not found in the npm registry "
+                    "(HTTP 404) — is the pin a typo?"
+                ) from exc
+            # 5xx and other HTTP errors are treated as transient.
+            last_exc = exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_exc = exc
+        if attempt < _RETRIES:
+            time.sleep(1)
+    else:
+        raise FailOpen(
+            f"npm registry unreachable for {cc_version} after "
+            f"{_RETRIES + 1} attempt(s): {last_exc}"
+        )
+
+    engines = payload.get("engines") or {}
+    node_spec = engines.get("node")
+    if not node_spec:
+        raise FailOpen(
+            f"Claude Code {cc_version} declares no engines.node — "
+            "cannot verify the Node floor (treating as non-blocking)"
+        )
+    return str(node_spec)
+
+
+def required_node_major(node_spec: str) -> int:
+    """Extract the minimum required Node MAJOR from an ``engines.node`` spec.
+
+    Handles the comparator shapes npm packages actually use: ``>=22.0.0``,
+    ``>=22``, ``^22.1.0``, ``~22``, ``22.x``, and ranges like ``>=20 <23``
+    (the lower bound governs the floor). An unrecognized shape fails OPEN
+    (a parser gap must not hard-block a real, valid spec).
+    """
+    # Lower-bound comparators that establish a floor.
+    floor_re = re.compile(r"(?:>=|\^|~|=)?\s*v?(\d+)(?:\.\d+|\.x|\.\*)?")
+    # A bare ">N" (strictly greater) floor means major N+1 at minimum only if
+    # it's ">Nmajor.max" — too rare to model; treat ">" like ">=" conservatively
+    # (lower floor = more lenient = fail-open-leaning, never a false failure).
+    for token in node_spec.replace(",", " ").split():
+        # Skip pure upper-bound comparators so a range's lower bound wins.
+        if token.startswith("<"):
+            continue
+        m = floor_re.match(token)
+        if m:
+            return int(m.group(1))
+    raise FailOpen(f"unrecognized engines.node spec {node_spec!r} — cannot derive floor")
+
+
+def check(pin_file: Path, *, opener=urllib.request.urlopen) -> str:
+    """Run the lockstep check. Returns a success message or raises.
+
+    Raises ``LockstepViolation`` (fail closed) or ``FailOpen`` (warn + pass).
+    """
+    cc_version, node_major = parse_pins(pin_file)
+    node_spec = fetch_engines_node(cc_version, opener=opener)
+    floor = required_node_major(node_spec)
+    if node_major < floor:
+        raise LockstepViolation(
+            f"NODE_MAJOR={node_major} is BELOW the floor required by "
+            f"Claude Code {cc_version} (engines.node={node_spec!r} → needs "
+            f"Node major >= {floor}). Bump NODE_MAJOR in scripts/lib/cc_version.sh "
+            "in lockstep with the CC pin."
+        )
+    return (
+        f"CC↔Node lockstep OK: Claude Code {cc_version} needs Node >= {floor} "
+        f"(engines.node={node_spec!r}); NODE_MAJOR={node_major}."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CC↔Node pin-lockstep CI guard.")
+    parser.add_argument(
+        "--pin-file",
+        type=Path,
+        default=_DEFAULT_PIN_FILE,
+        help="Path to cc_version.sh (default: scripts/lib/cc_version.sh).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        message = check(args.pin_file)
+    except LockstepViolation as exc:
+        print(f"CC↔Node lockstep FAILED: {exc}", file=sys.stderr)
+        return 1
+    except FailOpen as exc:
+        print(f"CC↔Node lockstep SKIPPED (non-blocking): {exc}", file=sys.stderr)
+        return 0
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scripts/test_cc_node_lockstep.py
+++ b/tests/test_scripts/test_cc_node_lockstep.py
@@ -1,0 +1,194 @@
+"""CC↔Node pin-lockstep CI guard (scripts/check_cc_node_lockstep.py).
+
+Enforces that ``NODE_MAJOR`` in ``scripts/lib/cc_version.sh`` satisfies the
+Node floor declared by the pinned Claude Code's ``engines.node``. All network
+access is injected (a fake ``opener``), so these run fully offline and
+deterministically. One real-file smoke test parses the live cc_version.sh
+without touching the network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_cc_node_lockstep.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_cc_node_lockstep", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+
+# ── Fake registry opener ──────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _opener_ok(engines_node: str | None):
+    """An opener returning a valid registry payload with the given engines.node."""
+    engines = {"node": engines_node} if engines_node is not None else {}
+
+    def _open(url, timeout=None):
+        return _FakeResp(json.dumps({"engines": engines}).encode())
+
+    return _open
+
+
+def _opener_raising(exc: Exception):
+    def _open(url, timeout=None):
+        raise exc
+
+    return _open
+
+
+def _write_pins(tmp_path: Path, cc: str, node: str) -> Path:
+    p = tmp_path / "cc_version.sh"
+    p.write_text(
+        f'CC_VERSION="${{CC_VERSION:-{cc}}}"\n'
+        f'NODE_MAJOR="${{NODE_MAJOR:-{node}}}"\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+# ── parse_pins ────────────────────────────────────────────────────────────
+
+
+def test_parse_pins_reads_defaults(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+    assert mod.parse_pins(pin) == ("2.1.201", 22)
+
+
+def test_parse_pins_unparseable_fails_closed(tmp_path):
+    pin = tmp_path / "cc_version.sh"
+    pin.write_text("# no pins here\n", encoding="utf-8")
+    with pytest.raises(mod.LockstepViolation):
+        mod.parse_pins(pin)
+
+
+def test_real_pin_file_parses(tmp_path):
+    """Smoke: the live cc_version.sh parses (no network)."""
+    real = _REPO_ROOT / "scripts" / "lib" / "cc_version.sh"
+    cc, node = mod.parse_pins(real)
+    assert cc.count(".") == 2 and node >= 1
+
+
+# ── required_node_major (comparator parser) ───────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [
+        (">=22.0.0", 22),
+        (">=22", 22),
+        ("^22.1.0", 22),
+        ("~22", 22),
+        ("22.x", 22),
+        ("=18.0.0", 18),
+        (">=20 <23", 20),   # range: lower bound governs
+        (">=20.0.0 <23.0.0", 20),
+    ],
+)
+def test_required_node_major_shapes(spec, expected):
+    assert mod.required_node_major(spec) == expected
+
+
+def test_required_node_major_unrecognized_fails_open():
+    with pytest.raises(mod.FailOpen):
+        mod.required_node_major("garbage-not-a-version")
+
+
+# ── check() end-to-end (injected opener) ──────────────────────────────────
+
+
+def test_lockstep_ok(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+    msg = mod.check(pin, opener=_opener_ok(">=22.0.0"))
+    assert "lockstep OK" in msg
+
+
+def test_node_below_floor_fails_closed(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.201", "20")
+    with pytest.raises(mod.LockstepViolation) as ei:
+        mod.check(pin, opener=_opener_ok(">=22.0.0"))
+    assert "BELOW the floor" in str(ei.value)
+
+
+def test_http_404_fails_closed(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.999", "22")
+    err = urllib.error.HTTPError("url", 404, "Not Found", {}, io.BytesIO(b""))
+    with pytest.raises(mod.LockstepViolation) as ei:
+        mod.check(pin, opener=_opener_raising(err))
+    assert "404" in str(ei.value)
+
+
+def test_http_500_fails_open(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+    err = urllib.error.HTTPError("url", 503, "Service Unavailable", {}, io.BytesIO(b""))
+    with pytest.raises(mod.FailOpen):
+        mod.check(pin, opener=_opener_raising(err))
+
+
+def test_network_error_fails_open(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+    with pytest.raises(mod.FailOpen):
+        mod.check(pin, opener=_opener_raising(urllib.error.URLError("dns fail")))
+
+
+def test_missing_engines_node_fails_open(tmp_path):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+    with pytest.raises(mod.FailOpen):
+        mod.check(pin, opener=_opener_ok(None))
+
+
+# ── main() exit codes ─────────────────────────────────────────────────────
+
+
+def test_main_violation_exit_1(tmp_path, monkeypatch, capsys):
+    pin = _write_pins(tmp_path, "2.1.201", "20")
+    monkeypatch.setattr(mod, "fetch_engines_node", lambda v, **k: ">=22.0.0")
+    assert mod.main(["--pin-file", str(pin)]) == 1
+    assert "FAILED" in capsys.readouterr().err
+
+
+def test_main_fail_open_exit_0(tmp_path, monkeypatch, capsys):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+
+    def _raise(v, **k):
+        raise mod.FailOpen("registry down")
+
+    monkeypatch.setattr(mod, "fetch_engines_node", _raise)
+    assert mod.main(["--pin-file", str(pin)]) == 0
+    assert "SKIPPED" in capsys.readouterr().err
+
+
+def test_main_ok_exit_0(tmp_path, monkeypatch, capsys):
+    pin = _write_pins(tmp_path, "2.1.201", "22")
+    monkeypatch.setattr(mod, "fetch_engines_node", lambda v, **k: ">=22.0.0")
+    assert mod.main(["--pin-file", str(pin)]) == 0
+    assert "lockstep OK" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Makes it mechanically impossible to bump the Claude Code pin past its Node floor without also bumping `NODE_MAJOR`. A host VM recently ran Node 20 while its pinned CC required Node >=22, so `claude -p` — the Guardian's recovery brain — could not start. `update.sh` already *heals* deployed drift; this closes the remaining **authoring-time** gap, where the "bump NODE_MAJOR in lockstep" instruction was only a comment in `scripts/lib/cc_version.sh`.

## What it does

`scripts/check_cc_node_lockstep.py` reads `CC_VERSION` + `NODE_MAJOR` from the pin file, fetches the pinned CC version's `engines.node` from the npm registry (stdlib `urllib`, no dependencies), and asserts `NODE_MAJOR` satisfies the required Node major. Wired as a new `cc-node-lockstep` CI job mirroring `external-io-check`.

**Error policy (deliberate):**
- **Fail closed** (block the PR): `NODE_MAJOR` below the floor; an unparseable pin file; or an **HTTP 404** for the pinned CC version (a version that doesn't exist is a typo'd pin, not weather).
- **Fail open** (warn + pass): transient network errors (one retry first) or an `engines.node` comparator shape the parser doesn't recognize. A flaky npm registry must never wall off every PR, and a parser gap must never false-fail a valid spec.

## Test plan

- [x] 21 offline tests (`tests/test_scripts/test_cc_node_lockstep.py`) via an injected registry opener: lockstep pass, below-floor fail, 404 fail-closed, 5xx/URLError fail-open, missing/exotic `engines.node` fail-open, comparator-shape parser units, real-file parse smoke
- [x] Live: passes at the current `22 >= 22` lockstep; fails closed (exit 1) under a sabotaged `NODE_MAJOR=20`
- [x] `ruff` clean; `ci.yml` YAML validated
- [ ] CI (the new job runs against this PR — proves the wiring E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)