### PR TITLE
feat(sentinel): inject live remediation inventory + charter clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   a Guardian is actually configured. Installs that intentionally don't run backups no longer see a
   false "backup failed" critical alert at all.
 
+- **When the Sentinel does wake, it now launches knowing exactly what it can act on.** Its diagnostic
+  session is handed the live list of remediation tools available on your install and told which one
+  applies to each firing alarm, so its proposed fixes stay grounded in what's actually possible here
+  — and it escalates with its diagnosis instead of inventing a command when nothing available can fix
+  the problem. It also launches with a short orientation to your system's shape and pointers to the
+  architecture docs it can consult.
+
 - **A rejected Sentinel approval can no longer freeze the Sentinel.** If you rejected (or let
   expire) a Sentinel dispatch approval while the underlying alarm stayed active, the Sentinel parked
   itself waiting forever and silently ignored every new alarm. It now applies your decision on the

--- a/src/genesis/sentinel/context.py
+++ b/src/genesis/sentinel/context.py
@@ -12,6 +12,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from genesis.sentinel.remediation_map import (
+    TOOLS,
+    available_tools,
+    required_tools,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -22,29 +28,72 @@ async def assemble_diagnostic_context(
     trigger_reason: str,
     health_snapshot: dict | None = None,
     remediation_history: list[dict] | None = None,
+    scope: frozenset[str] | None = None,
     db=None,
 ) -> str:
     """Build a diagnostic context string for the Sentinel CC session.
 
     Includes:
-    - Fire alarm details (what triggered the Sentinel)
+    - Fire alarm details (what triggered the Sentinel) + why each woke it
+    - The live remediation-tool inventory available on THIS install
     - Current health alerts
     - Recent remediation outcomes
     - Infrastructure health snapshot
     - Recent observations (if DB available)
+
+    ``scope`` is the set of remediation-tool ids available right now (from
+    :func:`available_tools`). The dispatcher computes it once per dispatch and
+    threads it in; when omitted it is evaluated here so the function stays
+    self-contained for tests and other callers.
     """
     sections: list[str] = []
     now = datetime.now(UTC).isoformat()
 
+    # Live remediation inventory — evaluated once, reused for the per-alarm
+    # rationale (below) and the tool-inventory section.
+    tool_scope = scope if scope is not None else available_tools()
+
     # 1. Trigger context
     sections.append(f"## Trigger\n\nSource: {trigger_source}\nReason: {trigger_reason}\nTime: {now}")
 
-    # 2. Fire alarms
+    # 2. Fire alarms — each line names the remediation path that made it wake
+    #    the Sentinel ("why you were woken"). Direct escalations bypass the
+    #    map, so an alarm may have no mapped tools; that is fine.
     if alarms:
         alarm_lines = []
         for a in alarms:
-            alarm_lines.append(f"- **Tier {a.tier}** [{a.alert_id}] {a.severity}: {a.message}")
+            line = f"- **Tier {a.tier}** [{a.alert_id}] {a.severity}: {a.message}"
+            req = required_tools(a.alert_id)
+            if req:
+                actionable = sorted(req & tool_scope)
+                if actionable:
+                    line += f"\n  ↳ you can act on this with: {', '.join(actionable)}"
+                else:
+                    line += (
+                        f"\n  ↳ mapped remediation ({', '.join(sorted(req))}) is "
+                        "not available on this install — escalate with your diagnosis"
+                    )
+            alarm_lines.append(line)
         sections.append("## Active Fire Alarms\n\n" + "\n".join(alarm_lines))
+
+    # 2b. Available remediation tools — what the Sentinel can actually do on
+    #     THIS install right now. Proposed actions must be achievable with
+    #     these; anything else is an escalation, not a fix.
+    if tool_scope:
+        tool_lines = [
+            f"- **{tool.id}** — {tool.description}"
+            for tool in TOOLS
+            if tool.id in tool_scope
+        ]
+        if tool_lines:
+            sections.append(
+                "## Available Remediation Tools\n\n"
+                "These are the remediation capabilities available on THIS install "
+                "right now. Your `proposed_actions` must be achievable with these; "
+                "if the fix needs something not listed here, say so in "
+                "`recommendation` and escalate rather than inventing a command.\n\n"
+                + "\n".join(tool_lines)
+            )
 
     # 3. Health snapshot
     if health_snapshot:

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -41,6 +41,53 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _build_operational_brief() -> str:
+    """A short launch-context brief appended to the Sentinel's system prompt.
+
+    Gives the firefighter (a) a compact orientation to what Genesis actually is
+    at the infrastructure level and (b) absolute paths to architecture docs it
+    can ``Read`` at runtime for depth. Deliberately NOT the genesis-development
+    skill — that skill is about writing PRs (worktrees, commit gates), which is
+    irrelevant to an emergency responder and would bloat every dispatch.
+
+    Doc paths are resolved from this file's location so they are correct for
+    whatever install the code runs in; only files that actually exist are
+    listed, so a trimmed install degrades to just the orientation.
+    """
+    from pathlib import Path
+
+    orientation = (
+        "## Operational Orientation\n\n"
+        "Genesis is a single autonomous cognitive system running inside this "
+        "container: a Python server process (systemd user unit `genesis-server`) "
+        "fronting a SQLite/WAL database (`~/genesis/data/genesis.db`), a local "
+        "Qdrant vector store, and an event/health observability layer. You are "
+        "its container-internal immune responder. You run *inside* the server "
+        "process, so you never restart your own host — you propose exact commands "
+        "and the dispatcher executes them after approval."
+    )
+
+    try:
+        arch = Path(__file__).resolve().parents[3] / "docs" / "architecture"
+        candidates = (
+            "genesis-v3-self-healing-design.md",
+            "genesis-v3-resilience-architecture.md",
+            "genesis-v3-vision.md",
+        )
+        present = [arch / name for name in candidates if (arch / name).is_file()]
+        if present:
+            pointer_lines = "\n".join(f"- {p}" for p in present)
+            orientation += (
+                "\n\nFor deeper architecture context, `Read` any of these at "
+                "runtime when a diagnosis needs it:\n" + pointer_lines
+            )
+    except Exception:
+        logger.debug("Could not resolve architecture doc pointers", exc_info=True)
+
+    return orientation
+
+
 # Per-pattern exponential backoff. Index = prior attempt count, value = seconds
 # to wait since the last attempt before trying again. Attempt 0 is immediate.
 # After the last entry is consumed, the pattern escalates to the user instead
@@ -1153,6 +1200,7 @@ class SentinelDispatcher:
             trigger_source=request.trigger_source,
             trigger_reason=request.trigger_reason,
             health_snapshot=health_snapshot,
+            scope=available_tools(),
             db=self._db,
         )
 
@@ -1165,6 +1213,16 @@ class SentinelDispatcher:
                 "You are the Sentinel — Genesis's internal health guardian. "
                 "Diagnose the problem and fix it. Use outreach_send_and_wait "
                 "to get approval before taking any action."
+            )
+
+        # Append the operational brief (orientation + architecture doc pointers)
+        # so the firefighter launches knowing what Genesis is and where to read
+        # more. Purpose-written and compact — NOT the dev-workflow skill.
+        try:
+            system_prompt = f"{system_prompt}\n\n{_build_operational_brief()}"
+        except Exception:
+            logger.warning(
+                "Failed to append operational brief to Sentinel prompt", exc_info=True
             )
 
         full_prompt = f"{context_str}\n\n---\n\nDiagnose and fix the above issues."

--- a/src/genesis/sentinel/prompts/SENTINEL.md
+++ b/src/genesis/sentinel/prompts/SENTINEL.md
@@ -7,10 +7,17 @@ and operational.
 
 ## Prime Directive: First, Do No Harm
 
-You are operating on a live system. Your role is to DIAGNOSE and PROPOSE fixes.
-The dispatcher that invoked you handles user approval and execution. You do NOT
-execute fixes yourself — you investigate, diagnose, and output a structured
-proposal.
+You are operating on a live system. Your job is to drive the problem to a
+RESOLVED state — not merely to describe it. You diagnose the root cause and
+output concrete, exact, verifiable `proposed_actions`. Those actions are
+executed by the dispatcher after user approval, so your proposal **is** the
+fix: make it complete and correct, not a vague suggestion or a hand-off ticket.
+
+You do NOT run the commands yourself. You live inside the very server process
+you are protecting (see Hard Constraints) — self-executing a restart or a bad
+command would take down your own host. So the division is: **you own the fix
+end-to-end (diagnose → propose the exact commands → verify it will work); the
+dispatcher pulls the trigger** once the user approves.
 
 ## How to Think
 
@@ -36,28 +43,42 @@ with evidence, you're not done.
 **Check logs FIRST, not code.** `journalctl` is your primary diagnostic tool.
 Read the actual error messages before theorizing about what might be wrong.
 
-## Your Scope
+## Your Scope — Three-Way Disposition
 
-You handle infrastructure problems INSIDE the container:
-- Service health (Qdrant, bridge, watchdog timer)
-- Memory pressure and resource management
-- Configuration issues (auth, routing, settings)
-- Stuck processes and deadlocks
-- Database connectivity
+You are the firefighter for container-internal emergencies. Every alarm falls
+into one of three dispositions:
 
-You do NOT handle:
-- Host VM issues (that's the Guardian's domain)
-- Network issues between container and host (you can detect but not fix)
-- External API outages and provider call sites (circuit breakers + user
-  notification handle these; you cannot fix a third-party service)
-- Backups, provider billing/credits, or anything whose target lives
-  outside the container (escalate-notify surfaces cover these)
+1. **Act** — the problem is inside the container and a remediation tool exists
+   for it (restart a service, reclaim disk, stop a runaway process, repair local
+   SQLite state, restart local Qdrant). Diagnose → propose the exact command(s)
+   → dispatcher gets approval and executes → verify. This is your core job.
+
+2. **Escalate with numbers** — a tool exists but the action crosses the
+   container boundary or grants resources (e.g. a future host-resource tool that
+   grows disk/RAM from the hypervisor). Gather the facts FIRST — what's
+   available, what's safe to take, the impact on neighbors — and put them in the
+   proposal: "30 GB free on the host; proposing +10 GB." Never a context-free ask.
+
+3. **Not your problem** — nothing you have can fix it: remote backup targets,
+   provider billing/credits, third-party API outages, host-VM issues (the
+   Guardian's domain), container↔host network. You are NOT woken for these; they
+   stay visible to the user and the ego via the dashboard, health digest, and
+   outreach. Do not invent a remediation for something outside the container.
+
+The live inventory of tools available on THIS install — and which tool maps to
+each firing alarm — is injected into your diagnostic context at dispatch time
+under "Available Remediation Tools" and on each fire-alarm line. Trust that
+injected inventory over any static list; propose only actions it can achieve.
 
 Mechanically enforced: an alert only wakes you if it maps to an available
 remediation tool (`sentinel/remediation_map.py`). Direct escalations from
 the Guardian watchdog bypass that map — the caller exercised judgment.
 
 ## Available Tools
+
+These are the MCP/CLI tools your CC session can call — for **diagnosis**. They
+are distinct from your *remediation* inventory (the infrastructure you can act
+on), which is injected per dispatch under "Available Remediation Tools".
 
 - **MCP health tools**: `health_status`, `health_alerts`, `health_errors`,
   `subsystem_heartbeats`, `job_health` — use these to query live system state
@@ -116,7 +137,11 @@ missing the root cause.
 
 ## Failure Inventory
 
-Common infrastructure failures and their fixes:
+Concrete command exemplars for the **Act** disposition — these are the
+container-internal cases the remediation map (`sentinel/remediation_map.py`)
+scopes you to. Use them as the grounded starting point (the Grounding Rules
+below require proposed commands to come from here or be verified to exist), but
+always confirm against the live system and the injected tool inventory first.
 
 | Condition | Diagnosis | Fix |
 |-----------|-----------|-----|

--- a/tests/test_sentinel/test_context.py
+++ b/tests/test_sentinel/test_context.py
@@ -1,7 +1,86 @@
 
 
 
+from types import SimpleNamespace
+
 import pytest
+
+
+def _alarm(alert_id, *, tier=1, severity="critical", message="test"):
+    return SimpleNamespace(tier=tier, alert_id=alert_id, severity=severity, message=message)
+
+
+@pytest.mark.asyncio
+async def test_available_remediation_tools_section_renders_from_scope():
+    """The tool-inventory section lists the tools in the passed scope, with
+    their descriptions, so the Sentinel knows what it can actually do."""
+    from genesis.sentinel.context import assemble_diagnostic_context
+
+    scope = frozenset({"container.services", "container.disk_reclaim"})
+    result = await assemble_diagnostic_context(
+        alarms=[],
+        trigger_source="test",
+        trigger_reason="test",
+        scope=scope,
+    )
+    assert "## Available Remediation Tools" in result
+    # descriptions come straight from remediation_map.TOOLS
+    assert "restart systemd user services" in result
+    assert "Reclaim container disk" in result
+    # a tool NOT in scope must not appear
+    assert "Restart the local Qdrant" not in result
+
+
+@pytest.mark.asyncio
+async def test_alarm_line_shows_actionable_remediation():
+    """A firing alarm whose mapped tool is available shows the 'you can act on
+    this with' rationale naming that tool — the 'why you were woken' link."""
+    from genesis.sentinel.context import assemble_diagnostic_context
+
+    # infra:disk_low → {container.disk_reclaim, host.resource_alloc}
+    result = await assemble_diagnostic_context(
+        alarms=[_alarm("infra:disk_low")],
+        trigger_source="fire_alarm",
+        trigger_reason="disk",
+        scope=frozenset({"container.disk_reclaim"}),
+    )
+    assert "[infra:disk_low]" in result
+    assert "you can act on this with: container.disk_reclaim" in result
+
+
+@pytest.mark.asyncio
+async def test_alarm_line_flags_unavailable_remediation():
+    """A mapped alarm whose tool is NOT available on this install tells the
+    Sentinel to escalate rather than invent a fix."""
+    from genesis.sentinel.context import assemble_diagnostic_context
+
+    # provider:qdrant_unreachable → {qdrant.local}, which we omit from scope
+    result = await assemble_diagnostic_context(
+        alarms=[_alarm("provider:qdrant_unreachable")],
+        trigger_source="fire_alarm",
+        trigger_reason="qdrant",
+        scope=frozenset({"container.services"}),
+    )
+    assert "is not available on this install" in result
+    assert "escalate" in result
+
+
+@pytest.mark.asyncio
+async def test_scope_none_defaults_to_live_available_tools(monkeypatch):
+    """When scope is omitted, the function evaluates available_tools() itself so
+    it stays self-contained for callers/tests that don't thread scope in."""
+    from genesis.sentinel import context as context_mod
+
+    monkeypatch.setattr(
+        context_mod, "available_tools", lambda: frozenset({"container.services"})
+    )
+    result = await context_mod.assemble_diagnostic_context(
+        alarms=[],
+        trigger_source="test",
+        trigger_reason="test",
+    )
+    assert "## Available Remediation Tools" in result
+    assert "restart systemd user services" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -982,3 +982,50 @@ class TestConvergePendingApproval:
         gate.get_request.assert_not_awaited()
         gate.mark_consumed.assert_not_awaited()
         assert d._state.state == SentinelState.HEALTHY
+
+
+class TestOperationalBrief:
+    def test_brief_has_orientation_and_doc_pointers(self):
+        from genesis.sentinel.dispatcher import _build_operational_brief
+
+        brief = _build_operational_brief()
+        assert "Operational Orientation" in brief
+        assert "immune responder" in brief
+        # architecture doc pointers resolve to real files in this checkout
+        assert "genesis-v3-self-healing-design.md" in brief
+
+    def test_brief_degrades_gracefully_without_docs(self, monkeypatch):
+        """If the docs tree can't be resolved, the brief still returns the
+        orientation (no crash, no pointer lines)."""
+        from genesis.sentinel.dispatcher import _build_operational_brief
+
+        def boom(self):
+            raise OSError("no filesystem")
+
+        monkeypatch.setattr("pathlib.Path.is_file", boom)
+        brief = _build_operational_brief()
+        assert "Operational Orientation" in brief
+        assert "genesis-v3-self-healing-design.md" not in brief
+
+    @pytest.mark.asyncio
+    async def test_dispatch_appends_brief_to_system_prompt(self):
+        """The dispatched CC session's system prompt = SENTINEL.md charter +
+        the operational brief (appended, not replacing)."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+
+        with patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.write_last_run"), \
+             patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            await d.dispatch(SentinelRequest(
+                trigger_source="test", trigger_reason="test",
+            ))
+
+        assert d._invoker.run.await_count == 1
+        invocation = d._invoker.run.await_args.args[0]
+        # brief appended
+        assert "Operational Orientation" in invocation.system_prompt
+        # SENTINEL.md charter still present (append, not replace)
+        assert "Three-Way Disposition" in invocation.system_prompt
+        assert invocation.append_system_prompt is True


### PR DESCRIPTION
## What

Follow-on to #896 (capability-relative alarm scoping). #896 made the Sentinel wake only for alarms it *can* remediate; this PR makes it launch **knowing what it can do and why it was woken**, and sharpens its charter.

### Changes
- **`context.py` — live inventory + "why woken":** each fire-alarm line now names the remediation path that made it wake the Sentinel (`↳ you can act on this with: container.disk_reclaim`), and a new **Available Remediation Tools** section lists the tools actually available on this install (from `remediation_map.TOOLS`). The dispatcher threads the live `available_tools()` scope in once per dispatch. When a mapped tool isn't available locally, the alarm line says so and tells the Sentinel to escalate rather than invent a command.
- **`SENTINEL.md` — charter:** Prime Directive reframed — the Sentinel **owns driving the problem to resolved** (its `proposed_actions` *are* the fix the dispatcher executes on approval, not a hand-off ticket), while keeping the safety split that it never self-executes inside its own host process. Scope rewritten as the explicit **three-way disposition** (Act / Escalate-with-numbers / Not-your-problem). Failure Inventory reconciled with the remediation map and framed as the grounded **Act**-case exemplars.
- **`dispatcher.py` — launch context:** a short, purpose-written **operational brief** (system orientation + absolute pointers to `docs/architecture/*.md` it can `Read` at runtime) is appended to the system prompt. Deliberately **not** the genesis-development skill (that's dev-workflow, ~3.4k tokens, wrong for a firefighter).

## Testing
- `tests/test_sentinel/` — 110 pass. New tests cover: the tools-inventory section renders from scope; the per-alarm actionable/unavailable rationale; `scope=None` falls back to live `available_tools()`; the operational brief has orientation + doc pointers and degrades gracefully when docs are unresolvable; the dispatch appends the brief to the SENTINEL.md charter (`append_system_prompt=True`).
- **E2E (data-flow):** assembled the exact prompt a real dispatch builds using this install's live detectors — 6 real tools resolved (`container.*`, `guardian.ssh_restart`, `qdrant.local`; `host.resource_alloc` correctly absent), charter+brief present in the system prompt, inventory + rationale present in the context.

## Risk
Additive and guarded: new `scope=` kwarg preserves old behavior for other callers; brief-append and doc-resolution are both try/except-wrapped so a dispatch can't break on them. Import DAG stays acyclic (`remediation_map` is stdlib-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)