### PR TITLE
fix(mcp): hard memory cap on codebase-memory-mcp — contain upstream leak

### DIFF
--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -70,6 +70,12 @@ symbol/reference/impact questions.
 **codebase-memory-mcp** — Tree-sitter code graph, SQLite index (~48MB for
 Genesis). Supports 66 languages. 3D visualization at `localhost:9749`.
 Indexed (reindex on local commit); if stale, run `index_repository`.
+Runs under a hard 2G memory cap (`.claude/mcp/run-codebase-memory` wraps it in
+a systemd scope) because upstream v0.8.1 leaks memory without bound on query
+operations (DeusData/codebase-memory-mcp#581). If its tools suddenly error
+mid-session, the instance likely hit the cap and was killed — run `/mcp` to
+reconnect a fresh one; Serena/GitNexus/Grep are unaffected. Cap override:
+`CODEBASE_MEMORY_MCP_MEMORY_MAX` (e.g. `4G`).
 
 **GitNexus** — LadybugDB graph (v1.6.8). Snapshot-based: correct only when the
 index matches the working tree. Its reindex fires on local commit, **not** on

--- a/.claude/mcp/run-codebase-memory
+++ b/.claude/mcp/run-codebase-memory
@@ -28,10 +28,14 @@ fi
 
 # Preferred: cgroup cap via a transient scope. Probe first — exec has no
 # fallback once taken, and systemd-run needs a reachable user manager (absent
-# in some CI/containers). MemorySwapMax=0 keeps a future swap enablement from
-# letting the leak thrash swap instead of being killed.
+# in some CI/containers). The probe sets the SAME properties as the real
+# invocation so a property the manager rejects fails at probe time, not after
+# exec. MemorySwapMax=0 keeps a future swap enablement from letting the leak
+# thrash swap instead of being killed.
 if command -v systemd-run >/dev/null 2>&1 \
-    && systemd-run --user --scope --quiet -p "MemoryMax=${MEM_MAX}" -- /bin/true >/dev/null 2>&1; then
+    && systemd-run --user --scope --quiet \
+        -p "MemoryMax=${MEM_MAX}" -p "MemorySwapMax=0" \
+        -- /bin/true >/dev/null 2>&1; then
     exec systemd-run --user --scope --quiet \
         --description="codebase-memory-mcp (MemoryMax=${MEM_MAX})" \
         -p "MemoryMax=${MEM_MAX}" -p "MemorySwapMax=0" \
@@ -40,14 +44,16 @@ fi
 
 # Fallback: no usable user manager — bound the address space instead. Coarser
 # than a cgroup cap (allocation failure instead of a clean kill), but still a
-# hard ceiling. Only G/M suffixes are converted; anything else runs uncapped
-# with a warning rather than mis-capping.
-case "$MEM_MAX" in
-    *G) _kb=$(( ${MEM_MAX%G} * 1024 * 1024 )) ;;
-    *M) _kb=$(( ${MEM_MAX%M} * 1024 )) ;;
-    *)  _kb="" ;;
-esac
-if [[ -n "$_kb" ]]; then
+# hard ceiling. Accepts systemd-style <int>[.<frac>]G/M (case-insensitive),
+# truncating any fraction; anything else runs uncapped with a warning rather
+# than mis-capping (never let a malformed value become a bash arithmetic
+# error on the MCP stderr).
+if [[ "$MEM_MAX" =~ ^([0-9]+)(\.[0-9]+)?([GgMm])$ ]]; then
+    _int="${BASH_REMATCH[1]}"
+    case "${BASH_REMATCH[3]}" in
+        G|g) _kb=$(( _int * 1024 * 1024 )) ;;
+        *)   _kb=$(( _int * 1024 )) ;;
+    esac
     ulimit -v "$_kb" 2>/dev/null \
         || printf 'run-codebase-memory: WARNING: could not apply ulimit -v %s\n' "$_kb" >&2
 else

--- a/.claude/mcp/run-codebase-memory
+++ b/.claude/mcp/run-codebase-memory
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
-# Launcher for codebase-memory-mcp MCP server.
-# Resolves the binary installed by the codebase-memory-mcp install script.
+# Launcher for codebase-memory-mcp MCP server, with a hard memory cap.
+#
+# WHY THE CAP: upstream v0.8.1 (latest as of 2026-07-05) has a known unbounded
+# memory leak on query/read operations — DeusData/codebase-memory-mcp#581,
+# acknowledged by the maintainer, no fix shipped. Long-lived CC sessions grow
+# an instance from ~10MB to multiple GB over hours/days; several concurrent
+# sessions can exhaust a container's (or host's) RAM. Until upstream ships a
+# fix, every instance runs inside a transient systemd scope with MemoryMax:
+# the kernel kills it at the cap and the CC session degrades gracefully
+# (other code-intel tools keep working; `/mcp` reconnects a fresh instance).
+#
+# --scope keeps the server a direct child of this launcher's replacement
+# (systemd-run), so MCP stdio passes through untouched — only the cgroup
+# membership changes.
 #
 # Install the tool first:
 #   curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui
 
-BINARY="${HOME}/.local/bin/codebase-memory-mcp"
+BINARY="${CODEBASE_MEMORY_MCP_BIN:-${HOME}/.local/bin/codebase-memory-mcp}"
+MEM_MAX="${CODEBASE_MEMORY_MCP_MEMORY_MAX:-2G}"
 
 if [[ ! -x "$BINARY" ]]; then
     printf 'codebase-memory-mcp not installed.\n' >&2
@@ -13,4 +26,31 @@ if [[ ! -x "$BINARY" ]]; then
     exit 1
 fi
 
+# Preferred: cgroup cap via a transient scope. Probe first — exec has no
+# fallback once taken, and systemd-run needs a reachable user manager (absent
+# in some CI/containers). MemorySwapMax=0 keeps a future swap enablement from
+# letting the leak thrash swap instead of being killed.
+if command -v systemd-run >/dev/null 2>&1 \
+    && systemd-run --user --scope --quiet -p "MemoryMax=${MEM_MAX}" -- /bin/true >/dev/null 2>&1; then
+    exec systemd-run --user --scope --quiet \
+        --description="codebase-memory-mcp (MemoryMax=${MEM_MAX})" \
+        -p "MemoryMax=${MEM_MAX}" -p "MemorySwapMax=0" \
+        -- "$BINARY" "$@"
+fi
+
+# Fallback: no usable user manager — bound the address space instead. Coarser
+# than a cgroup cap (allocation failure instead of a clean kill), but still a
+# hard ceiling. Only G/M suffixes are converted; anything else runs uncapped
+# with a warning rather than mis-capping.
+case "$MEM_MAX" in
+    *G) _kb=$(( ${MEM_MAX%G} * 1024 * 1024 )) ;;
+    *M) _kb=$(( ${MEM_MAX%M} * 1024 )) ;;
+    *)  _kb="" ;;
+esac
+if [[ -n "$_kb" ]]; then
+    ulimit -v "$_kb" 2>/dev/null \
+        || printf 'run-codebase-memory: WARNING: could not apply ulimit -v %s\n' "$_kb" >&2
+else
+    printf 'run-codebase-memory: WARNING: unparseable CODEBASE_MEMORY_MCP_MEMORY_MAX=%s — running uncapped\n' "$MEM_MAX" >&2
+fi
 exec "$BINARY" "$@"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **The codebase-memory code-intelligence server can no longer eat all your RAM.** The third-party
+  `codebase-memory-mcp` binary has a known upstream memory leak (grows without bound over hours of
+  use — several gigabytes per Claude Code session, enough to freeze the whole container when a few
+  sessions run at once). Every instance now starts inside a hard 2 GB memory cap: when the leak hits
+  the cap, only that server is killed and the session keeps working (reconnect it with `/mcp`).
+  Existing installs pick the cap up automatically on their next update — the setup script now also
+  detects and re-points a stale registration that would have bypassed the capped launcher. Override
+  with `CODEBASE_MEMORY_MCP_MEMORY_MAX` if your machine has RAM to spare.
+
 ### Security
 
 - **The contribution sanitizer now blocks Tailscale addresses before they can reach the public

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -512,54 +512,10 @@ echo
 
 # --- MCP Server Registration (Code Intelligence) ---
 echo "--- Registering code intelligence MCP servers ---"
-_register_mcp() {
-    local name="$1" scope="$2"
-    shift 2
-    local cmd_args=("$@")
-    if ! command -v claude &>/dev/null; then
-        echo "  WARNING: 'claude' CLI not found — skipping $name registration"
-        return 0
-    fi
-    if [ "$scope" = "user" ]; then
-        # User scope: read ~/.claude.json directly. `claude mcp list` merges
-        # scopes, so a same-named project-scope entry can mask a STALE
-        # user-scope command and freeze it behind "already registered" (real
-        # case: codebase-memory-mcp stayed pointed at the bare binary,
-        # bypassing the memory-cap launcher below). Compare the registered
-        # command and re-register on drift.
-        local registered
-        registered="$(python3 - "$name" <<'PYEOF' 2>/dev/null
-import json, os, sys
-try:
-    cfg = json.load(open(os.path.expanduser("~/.claude.json")))
-    print(cfg.get("mcpServers", {}).get(sys.argv[1], {}).get("command", ""))
-except Exception:
-    print("")
-PYEOF
-)"
-        # Compare basenames, not full strings: `claude mcp add` may store the
-        # RESOLVED absolute path for a command registered by bare name (e.g.
-        # "gitnexus" → "~/.local/bin/gitnexus"), which is not drift. A wrapper
-        # swap genuinely changes the basename (codebase-memory-mcp →
-        # run-codebase-memory), which is.
-        if [ -n "$registered" ] && [ "$(basename "$registered")" = "$(basename "${cmd_args[0]}")" ]; then
-            echo "  $name: already registered"
-            return 0
-        fi
-        if [ -n "$registered" ]; then
-            echo "  $name: registered command drifted ($registered) — re-registering"
-            claude mcp remove "$name" -s "$scope" 2>/dev/null || true
-        fi
-    else
-        if claude mcp list 2>/dev/null | grep -q "^$name:"; then
-            echo "  $name: already registered"
-            return 0
-        fi
-    fi
-    claude mcp add "$name" -s "$scope" -- "${cmd_args[@]}" 2>/dev/null \
-        && echo "  $name: registered ($scope)" \
-        || echo "  WARNING: Failed to register $name"
-}
+# _register_mcp lives in scripts/lib/mcp_register.sh — shared with install.sh
+# so fresh installs and updates register (and drift-heal) identically.
+# shellcheck source=lib/mcp_register.sh
+. "$SCRIPT_DIR/lib/mcp_register.sh"
 
 if command -v gitnexus &>/dev/null; then
     _register_mcp "gitnexus" "user" "gitnexus" "mcp"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -516,24 +516,60 @@ _register_mcp() {
     local name="$1" scope="$2"
     shift 2
     local cmd_args=("$@")
-    if command -v claude &>/dev/null; then
+    if ! command -v claude &>/dev/null; then
+        echo "  WARNING: 'claude' CLI not found — skipping $name registration"
+        return 0
+    fi
+    if [ "$scope" = "user" ]; then
+        # User scope: read ~/.claude.json directly. `claude mcp list` merges
+        # scopes, so a same-named project-scope entry can mask a STALE
+        # user-scope command and freeze it behind "already registered" (real
+        # case: codebase-memory-mcp stayed pointed at the bare binary,
+        # bypassing the memory-cap launcher below). Compare the registered
+        # command and re-register on drift.
+        local registered
+        registered="$(python3 - "$name" <<'PYEOF' 2>/dev/null
+import json, os, sys
+try:
+    cfg = json.load(open(os.path.expanduser("~/.claude.json")))
+    print(cfg.get("mcpServers", {}).get(sys.argv[1], {}).get("command", ""))
+except Exception:
+    print("")
+PYEOF
+)"
+        # Compare basenames, not full strings: `claude mcp add` may store the
+        # RESOLVED absolute path for a command registered by bare name (e.g.
+        # "gitnexus" → "~/.local/bin/gitnexus"), which is not drift. A wrapper
+        # swap genuinely changes the basename (codebase-memory-mcp →
+        # run-codebase-memory), which is.
+        if [ -n "$registered" ] && [ "$(basename "$registered")" = "$(basename "${cmd_args[0]}")" ]; then
+            echo "  $name: already registered"
+            return 0
+        fi
+        if [ -n "$registered" ]; then
+            echo "  $name: registered command drifted ($registered) — re-registering"
+            claude mcp remove "$name" -s "$scope" 2>/dev/null || true
+        fi
+    else
         if claude mcp list 2>/dev/null | grep -q "^$name:"; then
             echo "  $name: already registered"
             return 0
         fi
-        claude mcp add "$name" -s "$scope" -- "${cmd_args[@]}" 2>/dev/null \
-            && echo "  $name: registered ($scope)" \
-            || echo "  WARNING: Failed to register $name"
-    else
-        echo "  WARNING: 'claude' CLI not found — skipping $name registration"
     fi
+    claude mcp add "$name" -s "$scope" -- "${cmd_args[@]}" 2>/dev/null \
+        && echo "  $name: registered ($scope)" \
+        || echo "  WARNING: Failed to register $name"
 }
 
 if command -v gitnexus &>/dev/null; then
     _register_mcp "gitnexus" "user" "gitnexus" "mcp"
 fi
 if command -v codebase-memory-mcp &>/dev/null; then
-    _register_mcp "codebase-memory-mcp" "user" "codebase-memory-mcp"
+    # Registered via the repo launcher (NOT the bare binary): the launcher
+    # wraps the server in a systemd scope with MemoryMax to contain upstream's
+    # unbounded leak (DeusData/codebase-memory-mcp#581). See
+    # .claude/mcp/run-codebase-memory for the full rationale.
+    _register_mcp "codebase-memory-mcp" "user" "$GENESIS_ROOT/.claude/mcp/run-codebase-memory"
 fi
 if command -v serena &>/dev/null; then
     _register_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$GENESIS_ROOT"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -887,22 +887,19 @@ fi
 
 # Register code intelligence tools as MCP servers
 if command -v claude &>/dev/null; then
-    _register_ci_mcp() {
-        local name="$1" scope="$2"; shift 2
-        if ! claude mcp list 2>/dev/null | grep -q "^$name:"; then
-            claude mcp add "$name" -s "$scope" -- "$@" 2>/dev/null \
-                && echo "    + MCP: $name registered ($scope)" || true
-        fi
-    }
+    # Shared with bootstrap.sh: registers AND drift-heals user-scope entries
+    # (a re-run installer must re-point a stale registration, not skip it).
+    # shellcheck source=lib/mcp_register.sh
+    . "$SCRIPT_DIR/lib/mcp_register.sh"
     command -v gitnexus &>/dev/null && \
-        _register_ci_mcp "gitnexus" "user" "gitnexus" "mcp"
+        _register_mcp "gitnexus" "user" "gitnexus" "mcp"
     # Via the repo launcher (NOT the bare binary): wraps the server in a
     # systemd scope with MemoryMax=2G to contain upstream's unbounded memory
     # leak (DeusData/codebase-memory-mcp#581). Rationale in the launcher.
     command -v codebase-memory-mcp &>/dev/null && \
-        _register_ci_mcp "codebase-memory-mcp" "user" "$REPO_DIR/.claude/mcp/run-codebase-memory"
+        _register_mcp "codebase-memory-mcp" "user" "$REPO_DIR/.claude/mcp/run-codebase-memory"
     command -v serena &>/dev/null && \
-        _register_ci_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$REPO_DIR"
+        _register_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$REPO_DIR"
 fi
 
 # Trigger initial code intelligence indexing (background)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -896,8 +896,11 @@ if command -v claude &>/dev/null; then
     }
     command -v gitnexus &>/dev/null && \
         _register_ci_mcp "gitnexus" "user" "gitnexus" "mcp"
+    # Via the repo launcher (NOT the bare binary): wraps the server in a
+    # systemd scope with MemoryMax=2G to contain upstream's unbounded memory
+    # leak (DeusData/codebase-memory-mcp#581). Rationale in the launcher.
     command -v codebase-memory-mcp &>/dev/null && \
-        _register_ci_mcp "codebase-memory-mcp" "user" "codebase-memory-mcp"
+        _register_ci_mcp "codebase-memory-mcp" "user" "$REPO_DIR/.claude/mcp/run-codebase-memory"
     command -v serena &>/dev/null && \
         _register_ci_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$REPO_DIR"
 fi

--- a/scripts/lib/mcp_register.sh
+++ b/scripts/lib/mcp_register.sh
@@ -1,0 +1,94 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# _register_mcp — register a code-intelligence MCP server with Claude Code,
+# healing DRIFTED user-scope registrations. Single source of truth, sourced by
+# scripts/install.sh (fresh install) and scripts/bootstrap.sh (every update via
+# update.sh), so both paths register identically and existing installs heal.
+#
+# Why drift-healing exists: `claude mcp list` merges scopes, so a same-named
+# project-scope entry can mask a STALE user-scope command behind "already
+# registered" (real case: codebase-memory-mcp stayed pointed at the bare
+# binary, bypassing the memory-cap launcher). User scope is therefore checked
+# against ~/.claude.json directly and re-registered on mismatch.
+#
+# Usage: _register_mcp <name> <scope> <command> [args...]
+
+_register_mcp() {
+    local name="$1" scope="$2"
+    shift 2
+    local cmd_args=("$@")
+    if ! command -v claude &>/dev/null; then
+        echo "  WARNING: 'claude' CLI not found — skipping $name registration"
+        return 0
+    fi
+    if [ "$scope" = "user" ]; then
+        local registered
+        registered="$(python3 - "$name" <<'PYEOF' 2>/dev/null
+import json, os, sys
+try:
+    cfg = json.load(open(os.path.expanduser("~/.claude.json")))
+    print(cfg.get("mcpServers", {}).get(sys.argv[1], {}).get("command", ""))
+except Exception:
+    print("")
+PYEOF
+)"
+        # Match rule: an ABSOLUTE intended command must match exactly (a stale
+        # path with the right basename — e.g. a reaped worktree's launcher —
+        # is drift and must heal). A BARE intended name matches any stored
+        # resolution with that basename (`claude mcp add gitnexus` may store
+        # "~/.local/bin/gitnexus", which is not drift).
+        local intended="${cmd_args[0]}" matched=false
+        if [ -n "$registered" ]; then
+            case "$intended" in
+                /*) [ "$registered" = "$intended" ] && matched=true ;;
+                *)  [ "$(basename "$registered")" = "$intended" ] && matched=true ;;
+            esac
+        fi
+        if [ "$matched" = true ]; then
+            echo "  $name: already registered"
+            _warn_local_scope_shadow "$name" "$intended"
+            return 0
+        fi
+        if [ -n "$registered" ]; then
+            echo "  $name: registered command drifted ($registered) — re-registering"
+            claude mcp remove "$name" -s "$scope" 2>/dev/null || true
+        fi
+    else
+        if claude mcp list 2>/dev/null | grep -q "^$name:"; then
+            echo "  $name: already registered"
+            return 0
+        fi
+    fi
+    claude mcp add "$name" -s "$scope" -- "${cmd_args[@]}" 2>/dev/null \
+        && echo "  $name: registered ($scope)" \
+        || echo "  WARNING: Failed to register $name"
+    [ "$scope" = "user" ] && _warn_local_scope_shadow "$name" "${cmd_args[0]}"
+    return 0
+}
+
+# Local-scope (per-project) entries take PRECEDENCE over user scope, so a
+# stale local entry silently shadows a healed user registration. Never
+# auto-remove a user's local config — surface it loudly instead.
+_warn_local_scope_shadow() {
+    local name="$1" intended="$2" shadows
+    shadows="$(python3 - "$name" "$intended" <<'PYEOF' 2>/dev/null
+import json, os, sys
+try:
+    cfg = json.load(open(os.path.expanduser("~/.claude.json")))
+    for proj, p in cfg.get("projects", {}).items():
+        cmd = p.get("mcpServers", {}).get(sys.argv[1], {}).get("command", "")
+        if cmd and cmd != sys.argv[2]:
+            print(f"{proj} -> {cmd}")
+except Exception:
+    pass
+PYEOF
+)"
+    if [ -n "$shadows" ]; then
+        echo "  WARNING: $name has LOCAL-scope registrations that shadow the user-scope one:"
+        while IFS= read -r line; do
+            echo "    $line"
+        done <<< "$shadows"
+        echo "    Remove with: claude mcp remove $name -s local (run inside that project)"
+    fi
+}

--- a/tests/test_scripts/test_run_codebase_memory_launcher.py
+++ b/tests/test_scripts/test_run_codebase_memory_launcher.py
@@ -14,7 +14,6 @@ One real-cgroup smoke test runs only where ``systemd-run --user`` works.
 from __future__ import annotations
 
 import os
-import re
 import stat
 import subprocess
 from pathlib import Path
@@ -23,7 +22,7 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _LAUNCHER = _REPO_ROOT / ".claude" / "mcp" / "run-codebase-memory"
-_BOOTSTRAP = _REPO_ROOT / "scripts" / "bootstrap.sh"
+_REGISTER_LIB = _REPO_ROOT / "scripts" / "lib" / "mcp_register.sh"
 
 _SYSTEM_PATH = "/usr/bin:/bin"  # real python3/bash/coreutils for harnesses
 
@@ -128,10 +127,50 @@ def test_args_passthrough_scope_path(tmp_path):
     assert "ARGS:cli impact" in blog.read_text()
 
 
+def _minimal_path(tmp_path: Path) -> Path:
+    """A PATH dir with ONLY bash + env (genuinely no systemd-run).
+
+    ``/usr/bin:/bin`` contains the real systemd-run on most Linux hosts, so
+    using it would exercise the probe-fail path, not the absent-binary path.
+    """
+    d = tmp_path / "minbin"
+    d.mkdir(exist_ok=True)
+    for tool in ("bash", "env", "sh"):
+        src = Path("/usr/bin") / tool
+        if not src.exists():
+            src = Path("/bin") / tool
+        (d / tool).symlink_to(src)
+    return d
+
+
 def test_fallback_when_systemd_run_absent(tmp_path):
-    # No systemd-run on PATH at all → ulimit fallback (2G = 2097152 KB).
-    res, blog = _run_launcher(tmp_path, fakebin=None)
+    # command -v systemd-run itself fails → ulimit fallback (2G = 2097152 KB).
+    minbin = _minimal_path(tmp_path)
+    binary, blog = _fake_binary(tmp_path)
+    res = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env={"PATH": str(minbin), "HOME": str(tmp_path),
+             "CODEBASE_MEMORY_MCP_BIN": str(binary)},
+        capture_output=True, text=True, timeout=30,
+    )
     assert res.returncode == 0, res.stderr
+    assert "ULIMIT_V:2097152" in blog.read_text()
+
+
+def test_fallback_fractional_gig_truncates_cleanly(tmp_path):
+    # 2.5G is valid for systemd but the rlimit fallback truncates to 2G —
+    # and must NOT spray a bash arithmetic error on stderr.
+    minbin = _minimal_path(tmp_path)
+    binary, blog = _fake_binary(tmp_path)
+    res = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env={"PATH": str(minbin), "HOME": str(tmp_path),
+             "CODEBASE_MEMORY_MCP_BIN": str(binary),
+             "CODEBASE_MEMORY_MCP_MEMORY_MAX": "2.5G"},
+        capture_output=True, text=True, timeout=30,
+    )
+    assert res.returncode == 0, res.stderr
+    assert "arithmetic" not in res.stderr
     assert "ULIMIT_V:2097152" in blog.read_text()
 
 
@@ -188,14 +227,7 @@ def test_real_scope_applies_memory_max(tmp_path):
     assert res.stdout.strip() == str(2 * 1024**3)  # MemoryMax=2G
 
 
-# ── bootstrap _register_mcp drift-healing (extracted from the real script) ─
-
-
-def _extract_register_mcp() -> str:
-    text = _BOOTSTRAP.read_text(encoding="utf-8")
-    m = re.search(r"^_register_mcp\(\) \{$.*?^\}$", text, re.M | re.S)
-    assert m, "_register_mcp() not found in bootstrap.sh"
-    return m.group(0)
+# ── _register_mcp drift-healing (sources the REAL shared lib) ─────────────
 
 
 def _run_register(tmp_path: Path, args: list[str], claude_json: dict | None,
@@ -219,7 +251,7 @@ def _run_register(tmp_path: Path, args: list[str], claude_json: dict | None,
     harness = tmp_path / "harness.sh"
     quoted = " ".join(f"'{a}'" for a in args)
     harness.write_text(
-        "#!/usr/bin/env bash\n" + _extract_register_mcp() + f"\n_register_mcp {quoted}\n",
+        f'#!/usr/bin/env bash\n. "{_REGISTER_LIB}"\n_register_mcp {quoted}\n',
         encoding="utf-8",
     )
     res = subprocess.run(
@@ -256,6 +288,41 @@ def test_register_user_scope_drift_reregisters(tmp_path):
     assert "mcp remove codebase-memory-mcp -s user" in calls
     assert "mcp add codebase-memory-mcp -s user -- /repo/.claude/mcp/run-codebase-memory" in calls
     assert calls.index("mcp remove") < calls.index("mcp add")
+
+
+def test_register_user_scope_absolute_path_drift_reregisters(tmp_path):
+    # Same basename, different absolute path (e.g. a launcher registered from
+    # a since-reaped worktree) IS drift for an absolute intended command.
+    stale = "/repo/.claude/worktrees/old/.claude/mcp/run-codebase-memory"
+    cfg = {"mcpServers": {"codebase-memory-mcp": {"command": stale}}}
+    res, clog = _run_register(
+        tmp_path,
+        ["codebase-memory-mcp", "user", "/repo/.claude/mcp/run-codebase-memory"], cfg,
+    )
+    assert res.returncode == 0
+    calls = clog.read_text()
+    assert "mcp remove codebase-memory-mcp -s user" in calls
+    assert "mcp add codebase-memory-mcp -s user -- /repo/.claude/mcp/run-codebase-memory" in calls
+
+
+def test_register_warns_on_local_scope_shadow(tmp_path):
+    # A local-scope (per-project) entry takes precedence over user scope and
+    # must be surfaced, never silently shadowed. It is warned, not removed.
+    cfg = {
+        "mcpServers": {"codebase-memory-mcp":
+                       {"command": "/repo/.claude/mcp/run-codebase-memory"}},
+        "projects": {"/some/project": {"mcpServers": {
+            "codebase-memory-mcp": {"command": "/old/bare-binary"}}}},
+    }
+    res, clog = _run_register(
+        tmp_path,
+        ["codebase-memory-mcp", "user", "/repo/.claude/mcp/run-codebase-memory"], cfg,
+    )
+    assert res.returncode == 0
+    assert "already registered" in res.stdout
+    assert "LOCAL-scope" in res.stdout
+    assert "/old/bare-binary" in res.stdout
+    assert "mcp remove" not in (clog.read_text() if clog.exists() else "")
 
 
 def test_register_project_scope_existing_is_noop(tmp_path):

--- a/tests/test_scripts/test_run_codebase_memory_launcher.py
+++ b/tests/test_scripts/test_run_codebase_memory_launcher.py
@@ -1,0 +1,268 @@
+"""Memory-cap launcher for codebase-memory-mcp (.claude/mcp/run-codebase-memory).
+
+Upstream v0.8.1 leaks memory without bound on query operations
+(DeusData/codebase-memory-mcp#581), so the launcher wraps the server in a
+transient systemd scope with MemoryMax, falling back to an address-space
+rlimit where no user manager is reachable.
+
+These tests are binary- and environment-independent: the server binary and
+``systemd-run`` are both faked via PATH/env injection, so they run in CI
+runners with no systemd user manager and no codebase-memory-mcp install.
+One real-cgroup smoke test runs only where ``systemd-run --user`` works.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LAUNCHER = _REPO_ROOT / ".claude" / "mcp" / "run-codebase-memory"
+_BOOTSTRAP = _REPO_ROOT / "scripts" / "bootstrap.sh"
+
+_SYSTEM_PATH = "/usr/bin:/bin"  # real python3/bash/coreutils for harnesses
+
+
+def _write_exec(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _fake_binary(tmp_path: Path) -> tuple[Path, Path]:
+    """A stand-in server binary that records its args and its ulimit -v."""
+    log = tmp_path / "binary.log"
+    binary = _write_exec(
+        tmp_path / "fake-cbm",
+        "#!/usr/bin/env bash\n"
+        f'echo "ARGS:$*" >> "{log}"\n'
+        f'echo "ULIMIT_V:$(ulimit -v)" >> "{log}"\n',
+    )
+    return binary, log
+
+
+def _fake_systemd_run(tmp_path: Path, *, probe_ok: bool = True) -> tuple[Path, Path]:
+    """A fake systemd-run: logs argv, then execs the wrapped command.
+
+    The launcher probes with ``-- /bin/true`` before committing; ``probe_ok``
+    controls whether that probe (and everything else) succeeds.
+    """
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir(exist_ok=True)
+    log = tmp_path / "systemd-run.log"
+    if probe_ok:
+        body = (
+            "#!/usr/bin/env bash\n"
+            f'echo "$*" >> "{log}"\n'
+            "# exec everything after the -- separator\n"
+            'while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done\n'
+            "shift\n"
+            'exec "$@"\n'
+        )
+    else:
+        body = f'#!/usr/bin/env bash\necho "$*" >> "{log}"\nexit 1\n'
+    _write_exec(fakebin / "systemd-run", body)
+    return fakebin, log
+
+
+def _run_launcher(tmp_path, *args, fakebin=None, env_extra=None):
+    binary, blog = _fake_binary(tmp_path)
+    path = f"{fakebin}:{_SYSTEM_PATH}" if fakebin else _SYSTEM_PATH
+    env = {
+        "PATH": path,
+        "HOME": str(tmp_path),
+        "CODEBASE_MEMORY_MCP_BIN": str(binary),
+        **(env_extra or {}),
+    }
+    res = subprocess.run(
+        ["bash", str(_LAUNCHER), *args],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+    return res, blog
+
+
+# ── launcher behavior (fully faked, CI-safe) ──────────────────────────────
+
+
+def test_missing_binary_errors(tmp_path):
+    res = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env={"PATH": _SYSTEM_PATH, "HOME": str(tmp_path),
+             "CODEBASE_MEMORY_MCP_BIN": str(tmp_path / "nope")},
+        capture_output=True, text=True, timeout=30,
+    )
+    assert res.returncode == 1
+    assert "not installed" in res.stderr
+
+
+def test_scope_path_passes_memorymax(tmp_path):
+    fakebin, slog = _fake_systemd_run(tmp_path, probe_ok=True)
+    res, blog = _run_launcher(tmp_path, fakebin=fakebin)
+    assert res.returncode == 0, res.stderr
+    calls = slog.read_text()
+    assert "MemoryMax=2G" in calls
+    assert "MemorySwapMax=0" in calls
+    assert "--scope" in calls
+    assert "ARGS:" in blog.read_text()  # the server actually ran
+
+
+def test_mem_max_env_override(tmp_path):
+    fakebin, slog = _fake_systemd_run(tmp_path, probe_ok=True)
+    res, _ = _run_launcher(
+        tmp_path, fakebin=fakebin,
+        env_extra={"CODEBASE_MEMORY_MCP_MEMORY_MAX": "512M"},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "MemoryMax=512M" in slog.read_text()
+
+
+def test_args_passthrough_scope_path(tmp_path):
+    fakebin, _ = _fake_systemd_run(tmp_path, probe_ok=True)
+    res, blog = _run_launcher(tmp_path, "cli", "impact", fakebin=fakebin)
+    assert res.returncode == 0, res.stderr
+    assert "ARGS:cli impact" in blog.read_text()
+
+
+def test_fallback_when_systemd_run_absent(tmp_path):
+    # No systemd-run on PATH at all → ulimit fallback (2G = 2097152 KB).
+    res, blog = _run_launcher(tmp_path, fakebin=None)
+    assert res.returncode == 0, res.stderr
+    assert "ULIMIT_V:2097152" in blog.read_text()
+
+
+def test_fallback_when_probe_fails(tmp_path):
+    fakebin, slog = _fake_systemd_run(tmp_path, probe_ok=False)
+    res, blog = _run_launcher(tmp_path, "cli", fakebin=fakebin)
+    assert res.returncode == 0, res.stderr
+    # probe was attempted, then the binary ran under ulimit instead
+    assert slog.read_text().count("\n") == 1
+    out = blog.read_text()
+    assert "ULIMIT_V:2097152" in out
+    assert "ARGS:cli" in out
+
+
+def test_unparseable_memmax_warns_and_runs_uncapped(tmp_path):
+    res, blog = _run_launcher(
+        tmp_path, fakebin=None,
+        env_extra={"CODEBASE_MEMORY_MCP_MEMORY_MAX": "lots"},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "running uncapped" in res.stderr
+    assert "ULIMIT_V:unlimited" in blog.read_text()
+
+
+# ── real-cgroup smoke (local only; skipped where no user manager) ─────────
+
+
+def _user_scope_works() -> bool:
+    try:
+        return subprocess.run(
+            ["systemd-run", "--user", "--scope", "--quiet", "--", "/bin/true"],
+            capture_output=True, timeout=15,
+        ).returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+@pytest.mark.skipif(not _user_scope_works(), reason="no usable systemd user manager")
+def test_real_scope_applies_memory_max(tmp_path):
+    probe = _write_exec(
+        tmp_path / "cgprobe",
+        "#!/usr/bin/env bash\n"
+        'cg="$(sed -n \'s/^0:://p\' /proc/self/cgroup)"\n'
+        'cat "/sys/fs/cgroup${cg}/memory.max"\n',
+    )
+    env = {"PATH": os.environ["PATH"], "HOME": os.environ["HOME"],
+           "XDG_RUNTIME_DIR": os.environ.get("XDG_RUNTIME_DIR", ""),
+           "DBUS_SESSION_BUS_ADDRESS": os.environ.get("DBUS_SESSION_BUS_ADDRESS", ""),
+           "CODEBASE_MEMORY_MCP_BIN": str(probe)}
+    res = subprocess.run(
+        ["bash", str(_LAUNCHER)], env=env, capture_output=True, text=True, timeout=30,
+    )
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == str(2 * 1024**3)  # MemoryMax=2G
+
+
+# ── bootstrap _register_mcp drift-healing (extracted from the real script) ─
+
+
+def _extract_register_mcp() -> str:
+    text = _BOOTSTRAP.read_text(encoding="utf-8")
+    m = re.search(r"^_register_mcp\(\) \{$.*?^\}$", text, re.M | re.S)
+    assert m, "_register_mcp() not found in bootstrap.sh"
+    return m.group(0)
+
+
+def _run_register(tmp_path: Path, args: list[str], claude_json: dict | None,
+                  mcp_list: str = "") -> tuple[subprocess.CompletedProcess, Path]:
+    import json
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir(exist_ok=True)
+    clog = tmp_path / "claude.log"
+    _write_exec(
+        fakebin / "claude",
+        "#!/usr/bin/env bash\n"
+        f'echo "$*" >> "{clog}"\n'
+        f'if [ "$1 $2" = "mcp list" ]; then cat "{tmp_path}/mcp_list.txt" 2>/dev/null; fi\n'
+        "exit 0\n",
+    )
+    (tmp_path / "mcp_list.txt").write_text(mcp_list, encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    if claude_json is not None:
+        (home / ".claude.json").write_text(json.dumps(claude_json), encoding="utf-8")
+    harness = tmp_path / "harness.sh"
+    quoted = " ".join(f"'{a}'" for a in args)
+    harness.write_text(
+        "#!/usr/bin/env bash\n" + _extract_register_mcp() + f"\n_register_mcp {quoted}\n",
+        encoding="utf-8",
+    )
+    res = subprocess.run(
+        ["bash", str(harness)],
+        env={"PATH": f"{fakebin}:{_SYSTEM_PATH}", "HOME": str(home)},
+        capture_output=True, text=True, timeout=30,
+    )
+    return res, clog
+
+
+def test_register_user_scope_fresh_adds(tmp_path):
+    res, clog = _run_register(tmp_path, ["srv", "user", "/opt/launcher"], {"mcpServers": {}})
+    assert res.returncode == 0
+    assert "mcp add srv -s user -- /opt/launcher" in clog.read_text()
+
+
+def test_register_user_scope_same_basename_is_noop(tmp_path):
+    # Registered by bare name, stored resolved — same basename is NOT drift.
+    cfg = {"mcpServers": {"gitnexus": {"command": "/home/x/.local/bin/gitnexus"}}}
+    res, clog = _run_register(tmp_path, ["gitnexus", "user", "gitnexus", "mcp"], cfg)
+    assert res.returncode == 0
+    assert "already registered" in res.stdout
+    assert not clog.exists() or "mcp add" not in clog.read_text()
+
+
+def test_register_user_scope_drift_reregisters(tmp_path):
+    cfg = {"mcpServers": {"codebase-memory-mcp":
+                          {"command": "/home/x/.local/bin/codebase-memory-mcp"}}}
+    res, clog = _run_register(
+        tmp_path, ["codebase-memory-mcp", "user", "/repo/.claude/mcp/run-codebase-memory"], cfg,
+    )
+    assert res.returncode == 0
+    calls = clog.read_text()
+    assert "mcp remove codebase-memory-mcp -s user" in calls
+    assert "mcp add codebase-memory-mcp -s user -- /repo/.claude/mcp/run-codebase-memory" in calls
+    assert calls.index("mcp remove") < calls.index("mcp add")
+
+
+def test_register_project_scope_existing_is_noop(tmp_path):
+    res, clog = _run_register(
+        tmp_path, ["serena", "project", "serena", "start-mcp-server"],
+        None, mcp_list="serena: serena start-mcp-server\n",
+    )
+    assert res.returncode == 0
+    assert "already registered" in res.stdout
+    assert "mcp add" not in clog.read_text()


### PR DESCRIPTION
## Problem

The third-party `codebase-memory-mcp` binary (v0.8.1, latest) has a known unbounded memory leak on query operations — [DeusData/codebase-memory-mcp#581](https://github.com/DeusData/codebase-memory-mcp/issues/581), acknowledged upstream, no fix shipped. Each Claude Code session spawns its own instance; long-lived sessions grow from ~10MB to multiple GB, and a few concurrent sessions can exhaust all available RAM and freeze the machine.

## Fix

**Launcher (`.claude/mcp/run-codebase-memory`)** — every instance now starts inside a transient systemd scope with `MemoryMax` (default 2G, override via `CODEBASE_MEMORY_MCP_MEMORY_MAX`; `MemorySwapMax=0`). `--scope` keeps the server a direct child, so MCP stdio passes through untouched. The kernel kills the process at the cap; the session degrades gracefully (other code-intel tools unaffected) and `/mcp` reconnects a fresh instance. Probe-first with an address-space rlimit fallback where no user manager is reachable — the probe sets the same properties as the real invocation, and malformed size values degrade to a warned uncapped run, never a bash error.

**Registration drift-healing (`scripts/lib/mcp_register.sh`, shared by `install.sh` + `bootstrap.sh`)** — a stale user-scope registration pointing at the bare binary would silently bypass the capped launcher forever: `claude mcp list` merges scopes, so a same-named project entry masked it behind "already registered". User-scope registrations are now checked against `~/.claude.json` directly and re-registered on drift. Absolute intended commands compare exact (a right-basename-wrong-path launcher, e.g. from a removed worktree, is drift and heals); bare names match any stored resolution. Local-scope entries that would shadow the healed registration are loudly warned, never auto-removed. Existing installs heal on their next update run.

## Tests

15 in `tests/test_scripts/test_run_codebase_memory_launcher.py`, CI-safe via faked `systemd-run`/binary (no systemd or codebase-memory install needed): scope-path property passing, env override, arg passthrough, genuinely-absent-binary fallback (minimal PATH), probe-failure fallback, fractional/garbage size values, plus a real-cgroup smoke test (asserts `memory.max` = 2G through the actual launcher; skipped where no user manager). Registration matrix sources the real shared lib: fresh add, bare-name resolution no-op, basename drift, absolute-path drift, local-scope shadow warning, project-scope no-op.

## Verification

- Cap enforcement proven live: an over-cap allocation inside the scope is SIGKILLed (rc=137); `memory.max` reads 2147483648 through the launcher.
- `systemd-run --user --scope` verified working from a Claude-Code-spawned process context.
- Sessions whose MCP dies keep working (observed live) — reconnect with `/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)