### PR TITLE
fix(dashboard): infra-card failed-first ordering, drop raw cc_slots row, emit probe transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The dashboard's Infrastructure card is clearer at a glance: failed probes sort to the top, and a
+  stray raw row is gone.** Probes now order worst-first (down/error, then degraded, then healthy) so
+  problems surface at the top of the card instead of wherever they happened to fall in insertion
+  order. The "Claude Code Sessions" data no longer also leaks out as a raw, unlabeled `cc_slots` row
+  — it appears only in its dedicated section. And when an infrastructure probe crosses the
+  healthy↔unhealthy line (e.g. Qdrant goes down, then recovers), that transition is now recorded in
+  the Activity feed — with startup-grace and flap dampening so a restart blip or a rapidly-bouncing
+  probe won't spam it.
+
 - **The watchdog's memory-reclaim cooldown now survives its own restarts, so it can't trigger an
   I/O storm under sustained memory pressure.** When container memory runs high, the watchdog reclaims
   a small, capped amount of page cache — throttled to at most once every 5 minutes to avoid an I/O

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -31,8 +31,8 @@
             </div>
             <div class="health-card-value">
               <template x-if="$store.genesisDashboard.health.infrastructure">
-                <template x-for="(probe, name) in $store.genesisDashboard.health.infrastructure" :key="name">
-                  <div x-show="!['container_memory', 'disk', 'cpu'].includes(name)"
+                <template x-for="(probe, name) in $store.genesisDashboard.sortedInfrastructure" :key="name">
+                  <div x-show="!['container_memory', 'disk', 'cpu', 'cc_slots'].includes(name)"
                        style="margin-bottom: 0.2rem; cursor: default;"
                        :title="probe.error
                          ? $store.genesisDashboard.infraLabel(name) + ': ERROR — ' + probe.error

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3432,8 +3432,31 @@
         // Display label for infrastructure probe keys: the internal dict key stays
         // canonical (e.g. "ambient"); only the surfaced name is user-facing. The
         // ambient-capture edge bridge is shown as "Voice Bridge" on the card.
+        // Infrastructure probes ordered failed-first so operators see problems at
+        // the top of the card. Severity is derived from probeStatusColor so the
+        // sort order always matches the status dots the user sees (RED > YELLOW >
+        // GRAY > GREEN). Rebuilds an object rather than an array: infra keys are
+        // non-integer strings, so insertion order is preserved and the existing
+        // `(probe, name) in ...` template iterates in sorted order unchanged.
+        get sortedInfrastructure() {
+          const infra = this.health.infrastructure;
+          if (!infra || typeof infra !== "object") return infra;
+          const rankOf = (probe) => (
+            { "#d9534f": 3, "#f0ad4e": 2, "#888": 1, "#666": 1 }[this.probeStatusColor(probe)] ?? 0
+          );
+          // Array.prototype.sort is stable in modern engines → within-rank order
+          // stays as the backend emitted it.
+          const sorted = Object.entries(infra).sort((a, b) => rankOf(b[1]) - rankOf(a[1]));
+          const out = {};
+          for (const [name, probe] of sorted) out[name] = probe;
+          return out;
+        },
+
         infraLabel(name) {
-          const labels = { ambient: "Voice Bridge" };
+          // cc_slots renders in its own dedicated "Claude Code Sessions" section
+          // (it's an array, not a probe) and is excluded from the probe grid; the
+          // label here is defensive in case infraLabel is ever called for it.
+          const labels = { ambient: "Voice Bridge", cc_slots: "Claude Code Sessions" };
           return labels[name] || name;
         },
 

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -27,11 +27,27 @@ if TYPE_CHECKING:
     from genesis.surplus.scheduler import SurplusScheduler
 
 from genesis.env import cc_project_dir
+from genesis.observability.probe_transitions import ProbeTransition, ProbeTransitionTracker
+from genesis.observability.types import Severity, Subsystem
 
 logger = logging.getLogger(__name__)
 
 # Backward-compat constant still imported by reflection/context code.
 CC_JSONL_DIR = str(Path.home() / ".claude" / "projects" / cc_project_dir())
+
+# Infra probes carrying a stable string ``status`` field worth tracking for
+# healthy<->unhealthy transitions. Deliberately EXCLUDES: cpu (utilization noise
+# — a flip at 95% would spam the feed), disk (no ``status`` on success), cc_tmp
+# (tier-nested, no top-level status), cc_slots (a list), and the conditional
+# ambient/ollama probes. Excluded on purpose, not silently dropped.
+_TRACKED_PROBES: tuple[str, ...] = (
+    "genesis.db",
+    "qdrant",
+    "guardian",
+    "qdrant_collections",
+    "scheduler",
+    "container_memory",
+)
 
 
 def _or_error(result: object) -> object:
@@ -90,6 +106,12 @@ class HealthDataService:
         self._activity_tracker = activity_tracker
         self._provider_health = provider_health_checker
         self._event_bus = event_bus
+        # One tracker per service instance. This service is a singleton in the
+        # server process (constructed only in runtime/init/health_data.py), so the
+        # tracker sees every snapshot and is the sole emitter of probe transitions.
+        # It detects healthy<->unhealthy boundary crossings; it NEVER touches
+        # routing state (that is resilience.state's job, kept strictly separate).
+        self._probe_tracker = ProbeTransitionTracker()
         # Single-flight: concurrent snapshot() callers coalesce onto one compute.
         self._inflight: asyncio.Task | None = None
 
@@ -214,6 +236,13 @@ class HealthDataService:
             r_services, r_conversation, r_proactive,
         ) = results
 
+        # Surface infra probe healthy<->unhealthy transitions to the activity
+        # feed. Best-effort: a bad emit must never poison the shared snapshot.
+        try:
+            await self._emit_probe_transitions(r_infrastructure)
+        except Exception:
+            logger.debug("Probe-transition emit pass failed", exc_info=True)
+
         return {
             "timestamp": now,
             "call_sites": r_call_sites,
@@ -236,6 +265,68 @@ class HealthDataService:
             "eval_staleness": r_eval_staleness,
             "vcr": r_vcr,
         }
+
+    async def _emit_probe_transitions(self, infra: object) -> None:
+        """Drive the probe-transition tracker from the freshly-built infra dict,
+        emitting one activity event per healthy<->unhealthy crossing.
+
+        Storm guard: if the whole infrastructure section failed (not a dict, or a
+        top-level ``status == "error"`` injected by ``_or_error``), skip the cycle
+        entirely — otherwise every tracked probe would read "down" at once and
+        flood the feed with a false N-probe outage on one transient snapshot error.
+        """
+        if self._event_bus is None:
+            return
+        if not isinstance(infra, dict) or infra.get("status") == "error":
+            return
+        for probe_id in _TRACKED_PROBES:
+            entry = infra.get(probe_id)
+            if not isinstance(entry, dict):
+                continue
+            status = entry.get("status")
+            if not status:
+                continue
+            try:
+                transition = self._probe_tracker.observe(probe_id, status)
+            except Exception:
+                logger.debug("Probe-transition observe failed for %s", probe_id, exc_info=True)
+                continue
+            if transition is not None:
+                await self._emit_transition_event(transition)
+
+    async def _emit_transition_event(self, t: ProbeTransition) -> None:
+        """Emit a single ``probe_transition`` activity event (best-effort).
+
+        Recovery (→ healthy) is INFO; a hard down/error is ERROR; a softer
+        unhealthy state (e.g. degraded) is WARNING.
+        """
+        if t.new_class == "healthy":
+            severity = Severity.INFO
+        elif t.new_status in ("down", "error"):
+            severity = Severity.ERROR
+        else:
+            severity = Severity.WARNING
+        message = f"{t.probe_id}: {t.old_status} → {t.new_status}"
+        if t.flapping:
+            message += " (flapping)"
+        try:
+            # "from" is a keyword — details MUST be passed via dict-unpack.
+            await self._event_bus.emit(
+                Subsystem.HEALTH,
+                severity,
+                "probe_transition",
+                message,
+                **{
+                    "probe": t.probe_id,
+                    "from": t.old_status,
+                    "to": t.new_status,
+                    "from_class": t.old_class,
+                    "to_class": t.new_class,
+                    "flapping": t.flapping,
+                },
+            )
+        except Exception:
+            logger.debug("Probe-transition emit failed for %s", t.probe_id, exc_info=True)
 
     async def _vcr_snapshot(self) -> dict:
         """Verified Completion Rate for ego proposals."""

--- a/src/genesis/observability/probe_transitions.py
+++ b/src/genesis/observability/probe_transitions.py
@@ -1,0 +1,127 @@
+"""Probe-transition tracking — signal when an infra probe crosses the
+healthy<->unhealthy boundary, with flapping protection and a startup grace.
+
+Deliberately SEPARATE from ``resilience.state.ResilienceStateMachine``: that
+class manages the 5 typed degradation axes that DRIVE ROUTING. Probe transitions
+are raw observability and must never influence routing decisions, so they live
+here, isolated by construction. Probes are binary (healthy/unhealthy via
+``status_class``), so the 4-level axis flap machinery is reimplemented lean
+rather than reused.
+
+The tracker is pure/stateful and does NOT emit events itself — the caller
+(``HealthDataService.build``) decides how to surface a returned transition. This
+keeps the tracker trivially testable and free of an event-bus dependency.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+from genesis.observability.types import status_class
+
+# If a probe crosses the healthy<->unhealthy boundary more than _FLAP_THRESHOLD
+# times within _FLAP_WINDOW, subsequent crossings are flagged flapping (still
+# returned, but the caller can dampen them). Mirrors the resilience flap window.
+_FLAP_WINDOW = timedelta(minutes=15)
+_FLAP_THRESHOLD = 3
+
+# Grace period after construction (server start) during which transitions update
+# internal state but are NOT returned — avoids the restart transient where DB /
+# Qdrant probes read down for a few seconds before services settle.
+_DEFAULT_WARMUP = timedelta(seconds=90)
+
+
+@dataclass(frozen=True)
+class ProbeTransition:
+    """A single healthy<->unhealthy crossing for one probe."""
+
+    probe_id: str
+    old_class: str        # "healthy" | "unhealthy"
+    new_class: str        # "healthy" | "unhealthy"
+    old_status: str       # raw status, e.g. "healthy"
+    new_status: str       # raw status, e.g. "down"
+    timestamp: str        # ISO datetime
+    flapping: bool = False
+
+
+@dataclass
+class _ProbeState:
+    last_class: str
+    last_status: str
+    crossings: deque = field(default_factory=lambda: deque(maxlen=8))
+
+
+class ProbeTransitionTracker:
+    """Tracks per-probe health class and reports boundary crossings.
+
+    Not thread/async-safe by itself, but `observe` is synchronous (no awaits),
+    and its sole live caller runs it inside a single-flight `snapshot()` build,
+    so no lock is needed there.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        warmup: timedelta = _DEFAULT_WARMUP,
+    ) -> None:
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._warmup = warmup
+        self._started_at = self._clock()
+        self._probes: dict[str, _ProbeState] = {}
+
+    def observe(self, probe_id: str, status: str) -> ProbeTransition | None:
+        """Feed a probe's current raw status; return a transition iff its
+        healthy<->unhealthy CLASS changed, else None.
+
+        - First real observation of a probe seeds state and returns None (no
+          spurious transition at boot).
+        - Rank-1 "no signal" states (unknown/unavailable → class None) are
+          ignored entirely: they don't seed, don't cross, don't reset — the
+          probe keeps its last known class, so healthy→unknown→healthy is silent.
+        - During the warmup grace, state is updated but nothing is returned.
+        """
+        new_class = status_class(status)
+        if new_class is None:
+            return None  # no-signal state — ignore
+
+        prev = self._probes.get(probe_id)
+        if prev is None:
+            self._probes[probe_id] = _ProbeState(last_class=new_class, last_status=status)
+            return None
+
+        if new_class == prev.last_class:
+            prev.last_status = status  # keep raw status fresh for the next record
+            return None
+
+        # Class crossing.
+        now = self._clock()
+        old_class = prev.last_class
+        old_status = prev.last_status
+
+        # Flap accounting within the sliding window.
+        cutoff = now - _FLAP_WINDOW
+        while prev.crossings and prev.crossings[0] < cutoff:
+            prev.crossings.popleft()
+        prev.crossings.append(now)
+        flapping = len(prev.crossings) > _FLAP_THRESHOLD
+
+        prev.last_class = new_class
+        prev.last_status = status
+
+        # Warmup: state is now updated, but suppress the emit itself.
+        if now < self._started_at + self._warmup:
+            return None
+
+        return ProbeTransition(
+            probe_id=probe_id,
+            old_class=old_class,
+            new_class=new_class,
+            old_status=old_status,
+            new_status=status,
+            timestamp=now.isoformat(),
+            flapping=flapping,
+        )

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -19,7 +19,7 @@ from genesis.observability.health import (
     probe_scheduler,
     probe_wal,
 )
-from genesis.observability.types import ProbeStatus
+from genesis.observability.types import STATUS_RANK, ProbeStatus
 from genesis.routing.types import DegradationLevel, RoutingConfig
 
 if TYPE_CHECKING:
@@ -114,13 +114,9 @@ def _read_psi(path: str) -> dict:
         return {}
 
 
-# Health-status ranking (higher = worse) for composing multiple signals.
-_STATUS_RANK = {"healthy": 0, "unknown": 1, "unavailable": 1, "degraded": 2, "down": 3, "error": 3}
-
-
 def _worse_status(a: str, b: str) -> str:
     """Return the worse (higher-ranked) of two health statuses."""
-    return a if _STATUS_RANK.get(a, 0) >= _STATUS_RANK.get(b, 0) else b
+    return a if STATUS_RANK.get(a, 0) >= STATUS_RANK.get(b, 0) else b
 
 
 # Container memory PSI thresholds (full.avg60 %). Sustained memory stall is REAL

--- a/src/genesis/observability/types.py
+++ b/src/genesis/observability/types.py
@@ -43,6 +43,32 @@ class ProbeStatus(StrEnum):
     DOWN = "down"
 
 
+# Health-status ranking (higher = worse) for composing multiple signals and for
+# classifying probe transitions. Shared so snapshot code and the probe-transition
+# tracker rank identically. Unknown/unavailable rank 1 = "no signal", distinct
+# from healthy(0) and from degraded/down(2/3).
+STATUS_RANK: dict[str, int] = {
+    "healthy": 0,
+    "unknown": 1,
+    "unavailable": 1,
+    "degraded": 2,
+    "down": 3,
+    "error": 3,
+}
+
+
+def status_class(status: str) -> str | None:
+    """Collapse a raw probe status to a coarse health class for transition
+    detection: "healthy" (rank 0), "unhealthy" (rank >= 2), or None for
+    rank-1 "no signal" states (unknown/unavailable) which must NOT count as a
+    crossing — a probe flickering healthy->unknown->healthy should emit nothing.
+    """
+    rank = STATUS_RANK.get(status)
+    if rank is None or rank == 1:
+        return None
+    return "healthy" if rank == 0 else "unhealthy"
+
+
 @dataclass(frozen=True)
 class GenesisEvent:
     """A single observability event emitted by a Genesis subsystem."""

--- a/src/genesis/resilience/state.py
+++ b/src/genesis/resilience/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -83,7 +84,10 @@ class ResilienceState:
     cc: CCStatus = CCStatus.NORMAL
     tmp_pressure: TmpPressureStatus = TmpPressureStatus.NORMAL
     timestamp: str = ""
-    transitions: list[StateTransition] = field(default_factory=list)
+    # Bounded append-only observability log (never read by routing). Capped so a
+    # long-lived server can't grow it without limit; flap detection uses a
+    # separate per-axis window (`_FlapState.transition_times`), not this deque.
+    transitions: deque[StateTransition] = field(default_factory=lambda: deque(maxlen=200))
 
     def to_legacy_degradation_level(self) -> DegradationLevel:
         """Map composite state to single DegradationLevel for backward compat."""

--- a/tests/test_observability/test_health_data_probe_emit.py
+++ b/tests/test_observability/test_health_data_probe_emit.py
@@ -1,0 +1,126 @@
+"""Integration: HealthDataService drives the probe-transition tracker and emits
+one activity event per healthy<->unhealthy crossing, with a whole-infra storm
+guard and emit-failure isolation."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.observability.health_data import HealthDataService
+from genesis.observability.probe_transitions import ProbeTransitionTracker
+
+
+def _bus() -> AsyncMock:
+    bus = AsyncMock()
+    bus.emit = AsyncMock()
+    return bus
+
+
+def _svc(bus) -> HealthDataService:
+    """Service with a zero-warmup tracker so crossings emit immediately in tests
+    (production uses the 90s startup grace to swallow the restart transient)."""
+    svc = HealthDataService(event_bus=bus)
+    svc._probe_tracker = ProbeTransitionTracker(warmup=timedelta(0))
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_healthy_to_down_emits_one_event():
+    bus = _bus()
+    svc = _svc(bus)
+    # First pass seeds (no emit); second pass crosses to unhealthy → one emit.
+    await svc._emit_probe_transitions({"genesis.db": {"status": "healthy"}})
+    assert bus.emit.await_count == 0
+    await svc._emit_probe_transitions({"genesis.db": {"status": "down"}})
+    assert bus.emit.await_count == 1
+    args, kwargs = bus.emit.await_args
+    # subsystem, severity, event_type, message positional; details as kwargs.
+    assert args[2] == "probe_transition"
+    assert kwargs["probe"] == "genesis.db"
+    assert kwargs["from"] == "healthy"
+    assert kwargs["to"] == "down"
+
+
+@pytest.mark.asyncio
+async def test_no_bus_is_noop():
+    svc = HealthDataService(event_bus=None)
+    # Must not raise despite no bus.
+    await svc._emit_probe_transitions({"genesis.db": {"status": "healthy"}})
+    await svc._emit_probe_transitions({"genesis.db": {"status": "down"}})
+
+
+@pytest.mark.asyncio
+async def test_whole_infra_error_is_storm_guarded():
+    """A transient snapshot error (_or_error injects top-level status=error) must
+    NOT be read as every probe going down at once."""
+    bus = _bus()
+    svc = _svc(bus)
+    # Seed everyone healthy.
+    await svc._emit_probe_transitions(
+        {p: {"status": "healthy"} for p in ("genesis.db", "qdrant", "guardian")}
+    )
+    assert bus.emit.await_count == 0
+    # Whole-section failure → skip entirely, no N-probe false outage.
+    await svc._emit_probe_transitions({"status": "error", "error": "boom"})
+    assert bus.emit.await_count == 0
+    # And the skip did not corrupt state: a real recovery reading is still healthy
+    # (no spurious down→healthy), so the next genuine down still emits exactly one.
+    await svc._emit_probe_transitions({"genesis.db": {"status": "down"}})
+    assert bus.emit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_non_dict_infra_is_ignored():
+    bus = _bus()
+    svc = _svc(bus)
+    await svc._emit_probe_transitions(["not", "a", "dict"])
+    await svc._emit_probe_transitions(None)
+    assert bus.emit.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_untracked_probe_never_emits():
+    """cpu/disk/cc_slots are deliberately outside _TRACKED_PROBES."""
+    bus = _bus()
+    svc = _svc(bus)
+    await svc._emit_probe_transitions({"cpu": {"status": "healthy"}})
+    await svc._emit_probe_transitions({"cpu": {"status": "down"}})
+    assert bus.emit.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_or_falsy_status_skipped():
+    bus = _bus()
+    svc = _svc(bus)
+    # disk has no status field on success; entry without status must be skipped.
+    await svc._emit_probe_transitions({"genesis.db": {"latency_ms": 1.2}})
+    await svc._emit_probe_transitions({"genesis.db": {"status": ""}})
+    assert bus.emit.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_failure_does_not_propagate():
+    """A raising event bus must never poison the snapshot pass."""
+    bus = _bus()
+    bus.emit = AsyncMock(side_effect=RuntimeError("bus down"))
+    svc = _svc(bus)
+    await svc._emit_probe_transitions({"qdrant": {"status": "healthy"}})
+    # Crossing triggers an emit that raises — must be swallowed.
+    await svc._emit_probe_transitions({"qdrant": {"status": "error"}})
+    assert bus.emit.await_count == 1  # attempted once, exception swallowed
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_info_and_hard_down_is_error():
+    from genesis.observability.types import Severity
+
+    bus = _bus()
+    svc = _svc(bus)
+    await svc._emit_probe_transitions({"qdrant": {"status": "healthy"}})
+    await svc._emit_probe_transitions({"qdrant": {"status": "down"}})
+    assert bus.emit.await_args.args[1] == Severity.ERROR
+    await svc._emit_probe_transitions({"qdrant": {"status": "healthy"}})
+    assert bus.emit.await_args.args[1] == Severity.INFO

--- a/tests/test_observability/test_probe_transitions.py
+++ b/tests/test_observability/test_probe_transitions.py
@@ -1,0 +1,136 @@
+"""Tests for ProbeTransitionTracker — boundary crossings + flap + warmup."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.observability.probe_transitions import ProbeTransitionTracker
+
+
+class _Clock:
+    """Controllable clock; advance() moves virtual time forward."""
+
+    def __init__(self, start: datetime) -> None:
+        self._now = start
+
+    def __call__(self) -> datetime:
+        return self._now
+
+    def advance(self, **kw) -> None:
+        self._now = self._now + timedelta(**kw)
+
+
+def _tracker(clock, *, warmup_s: int = 0) -> ProbeTransitionTracker:
+    # warmup 0 by default so tests exercise emits immediately unless stated
+    return ProbeTransitionTracker(clock=clock, warmup=timedelta(seconds=warmup_s))
+
+
+def test_first_observation_seeds_no_emit():
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    assert t.observe("genesis.db", "healthy") is None
+
+
+def test_healthy_to_down_emits_one_transition():
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    t.observe("genesis.db", "healthy")
+    clk.advance(minutes=5)
+    tr = t.observe("genesis.db", "down")
+    assert tr is not None
+    assert tr.probe_id == "genesis.db"
+    assert tr.old_class == "healthy" and tr.new_class == "unhealthy"
+    assert tr.old_status == "healthy" and tr.new_status == "down"
+    assert tr.flapping is False
+
+
+def test_recovery_emits_transition():
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    t.observe("qdrant", "healthy")
+    clk.advance(minutes=5)
+    t.observe("qdrant", "error")
+    clk.advance(minutes=5)
+    tr = t.observe("qdrant", "healthy")
+    assert tr is not None
+    assert tr.old_class == "unhealthy" and tr.new_class == "healthy"
+
+
+def test_same_class_no_emit():
+    """degraded and down are both 'unhealthy' — no crossing between them."""
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    t.observe("guardian", "healthy")
+    clk.advance(minutes=1)
+    assert t.observe("guardian", "degraded") is not None  # healthy->unhealthy
+    clk.advance(minutes=1)
+    assert t.observe("guardian", "down") is None  # unhealthy->unhealthy, no cross
+
+
+def test_unknown_is_noop_not_a_crossing():
+    """A healthy->unknown->healthy flicker must emit nothing (no-signal state)."""
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    t.observe("scheduler", "healthy")
+    clk.advance(minutes=1)
+    assert t.observe("scheduler", "unknown") is None  # ignored, class unchanged
+    clk.advance(minutes=1)
+    assert t.observe("scheduler", "healthy") is None  # still healthy, no crossing
+
+
+def test_unavailable_does_not_seed():
+    """First-ever observation of a no-signal status must not seed; a later real
+    status is then the seed (no bogus transition)."""
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    assert t.observe("qdrant_collections", "unavailable") is None
+    clk.advance(minutes=1)
+    # first real status seeds, still no emit
+    assert t.observe("qdrant_collections", "healthy") is None
+    clk.advance(minutes=1)
+    assert t.observe("qdrant_collections", "down") is not None
+
+
+def test_flapping_flagged_after_threshold():
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    t.observe("cc_tmp", "healthy")  # seed
+    flags = []
+    # 6 crossings within 15 min: healthy<->down repeatedly
+    for i in range(6):
+        clk.advance(minutes=1)
+        status = "down" if i % 2 == 0 else "healthy"
+        tr = t.observe("cc_tmp", status)
+        assert tr is not None
+        flags.append(tr.flapping)
+    # threshold is 3 crossings in-window; the 4th+ crossing is flagged
+    assert flags[:3] == [False, False, False]
+    assert all(flags[3:])
+
+
+def test_flap_window_resets_after_quiet_period():
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = _tracker(clk)
+    t.observe("container_memory", "healthy")
+    for i in range(4):
+        clk.advance(minutes=1)
+        t.observe("container_memory", "down" if i % 2 == 0 else "healthy")
+    # long quiet gap flushes the window
+    clk.advance(minutes=30)
+    tr = t.observe("container_memory", "down")
+    assert tr is not None
+    assert tr.flapping is False
+
+
+def test_warmup_suppresses_emit_but_tracks_state():
+    clk = _Clock(datetime(2026, 1, 1, tzinfo=UTC))
+    t = ProbeTransitionTracker(clock=clk, warmup=timedelta(seconds=90))
+    t.observe("genesis.db", "healthy")  # seed at t0
+    clk.advance(seconds=30)
+    # crossing inside warmup: state updates, but no emit
+    assert t.observe("genesis.db", "down") is None
+    clk.advance(seconds=120)  # now past warmup
+    # class is already 'unhealthy' from the suppressed crossing; recovery emits
+    tr = t.observe("genesis.db", "healthy")
+    assert tr is not None
+    assert tr.old_class == "unhealthy" and tr.new_class == "healthy"


### PR DESCRIPTION
## What & why

Three user-facing Infrastructure-card bugs on the dashboard overview:

- **B1 — raw `cc_slots` row leak.** `cc_slots` is an array with its own dedicated "Claude Code Sessions" section (#881), but the probe grid's exclusion filter omitted it, so it also rendered as a raw unlabeled `cc_slots` row. Added to the grid `x-show` exclusion + a defensive `infraLabel` entry.

- **B2 — failed-probe-first ordering.** Probes rendered in dict-insertion order, burying a down probe below healthy ones. New `sortedInfrastructure` getter orders worst-first (down/error → degraded → unknown → healthy), deriving severity from `probeStatusColor` so the order always matches the status dots the operator sees. Stable within-rank (backend order preserved); rebuilds an object (infra keys are non-integer strings → insertion order preserved) so the existing template body is untouched.

- **B3 — probe-transition events.** New `observability/probe_transitions.py` `ProbeTransitionTracker` detects healthy↔unhealthy boundary crossings and `HealthDataService` emits a `probe_transition` event to the activity feed per crossing. Isolated by construction from `resilience.state` (the routing-driving state machine) — probe transitions are pure observability and never influence routing. Includes a 90s startup grace (swallow the restart transient) and a 15min/3-crossing flap window (dampen a bouncing probe). Single emitter: `HealthDataService` is a singleton in the server process; the standalone health MCP calls `infrastructure()` directly and never emits.

- **Drive-by:** bounded the previously-unbounded append-only `ResilienceState.transitions` log to `deque(maxlen=200)`. It has zero routing readers; flap detection uses a separate per-axis window, so the bound is behaviorally inert.

## Verification

- `ruff` clean; `node --check` on dashboard.js clean.
- Targeted tests green (81 passed): new `test_probe_transitions.py` (9) + `test_health_data_probe_emit.py` (8, incl. storm-guard/emit-failure isolation/severity), plus existing `test_types`, `test_health_psi_cpu`, `test_service_status`, `test_resilience/test_state`.
- B2 sort + object-order assumption verified in Node.
- Wiring confirmed: `runtime/init/health_data.py` passes the live `event_bus`, so emits fire in production.
- Frontend browser E2E and B3 activity-feed E2E run post-deploy (dashboard is served from the installed package, not a worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)