### PR TITLE
fix(cc): enforce one canonical Claude Code copy — shadow scan + pin-verified selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Stale duplicate copies of Claude Code are now detected and removed automatically.** If your
+  machine ever accumulated a second Claude Code install (an old nvm-tree copy, a native-installer
+  leftover, or an install in a directory only interactive shells can see), it could silently shadow
+  the version Genesis pins — you'd see a months-old Claude Code in your terminal while Genesis
+  believed everything was current, or updates would pointlessly reinstall on every run. The
+  install/update scripts now enforce a single canonical copy: provable duplicates are removed (with
+  clear logging), ambiguous files are only warned about, and shell aliases that shadow the real
+  binary are flagged. Set `CC_SHADOW_SCAN=0` if you deliberately run multiple copies.
+
 - **The codebase-memory code-intelligence server can no longer eat all your RAM.** The third-party
   `codebase-memory-mcp` binary has a known upstream memory leak (grows without bound over hours of
   use — several gigabytes per Claude Code session, enough to freeze the whole container when a few

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -71,13 +71,20 @@ user-prefix copy invisible to non-interactive shells, which made the updater
 
 `cc_shadow_scan` (in `scripts/lib/cc_version.sh`, run by install/bootstrap/
 update/host-setup; mirrored compactly in the gateway's `update-cc` op for the
-host) enforces the policy: the canonical copy is what `command -v claude`
-resolves (all automation runs that one); every other copy on a known surface
-(nvm trees, `~/.claude/local`, `~/.local/bin`, native version blobs, stale npm
-prefixes) is removed — but only when provably a claude-code install; anything
-ambiguous is warned about and left alone, as are `alias claude=` lines in rc
-files (detected, never edited). The gateway variant is user-dir-only (it never
-sudo-removes). Deliberate multi-copy setups: `CC_SHADOW_SCAN=0` opts out.
+host) enforces the policy. The canonical copy is **pin-verified**: the first
+copy (PATH resolution, then `CC_PROBE_DIRS`) that actually reports
+`CC_VERSION` — never a bare `command -v`, because an interactive PATH can put
+a stale copy first, and crowning that one would delete the good copy.
+**Fail-safe: if no copy at the pin exists anywhere, nothing is removed.**
+Every other copy on a known surface (nvm trees, `~/.claude/local`,
+`~/.local/bin`, native version blobs, stale npm prefixes) is removed — but
+only when provably a claude-code install; the canonical's own package dir is
+never removed (a stale second link into it loses only the link), a
+native-install canonical keeps its versions dir, and anything ambiguous is
+warned about and left alone, as are `alias claude=` lines in rc files
+(detected, never edited). The gateway variant is user-dir-only (it never
+sudo-removes) and runs only after its post-install verify proves the pin.
+Deliberate multi-copy setups: `CC_SHADOW_SCAN=0` opts out.
 
 `cc_ensure_local` also probes known prefixes (`CC_PROBE_DIRS`) before declaring
 CC "not installed", so a PATH-blind install is aligned in place instead of

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -59,6 +59,30 @@ host (or container) can be rolled back to an older known-good version the same w
 (`update-cc <older>`) if a release regresses — exactly what the 2.1.90→2.1.87
 rollback needed.
 
+### One-canonical-copy policy (`cc_shadow_scan`)
+
+The pin machinery only manages ONE copy of Claude Code per machine. Any second
+copy drifts silently and eventually shadows the pinned one in some PATH context
+— four real incidents in one week (2026-07): an nvm-tree copy that won
+interactive PATH and showed a months-old version; a native-installer symlink in
+`~/.local/bin` doing the same; ~490MB of leftover native version blobs; and a
+user-prefix copy invisible to non-interactive shells, which made the updater
+"reinstall" CC on every run AND silently skipped MCP registration.
+
+`cc_shadow_scan` (in `scripts/lib/cc_version.sh`, run by install/bootstrap/
+update/host-setup; mirrored compactly in the gateway's `update-cc` op for the
+host) enforces the policy: the canonical copy is what `command -v claude`
+resolves (all automation runs that one); every other copy on a known surface
+(nvm trees, `~/.claude/local`, `~/.local/bin`, native version blobs, stale npm
+prefixes) is removed — but only when provably a claude-code install; anything
+ambiguous is warned about and left alone, as are `alias claude=` lines in rc
+files (detected, never edited). The gateway variant is user-dir-only (it never
+sudo-removes). Deliberate multi-copy setups: `CC_SHADOW_SCAN=0` opts out.
+
+`cc_ensure_local` also probes known prefixes (`CC_PROBE_DIRS`) before declaring
+CC "not installed", so a PATH-blind install is aligned in place instead of
+reinstalled forever.
+
 ---
 
 ## Integration Surface — Genesis Components That Use CC

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -281,6 +281,7 @@ if [ -f "$_cc_env" ]; then
     # shellcheck source=/dev/null
     source "$_cc_env"
     cc_ensure_local || true
+    cc_shadow_scan || true
 fi
 
 # bubblewrap (sandbox for codex exec — optional)

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -390,15 +390,30 @@ PYEOF
             echo '{"ok": false, "action": "update-cc", "error": "npm install failed"}' >&2
             exit 1
         fi
+        # Verify: the in-use claude must now report exactly the requested version.
+        INSTALLED="$(claude --version 2>/dev/null || echo unknown)"
+        INSTALLED_VER="$(printf '%s' "$INSTALLED" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)"
+        if [ "$INSTALLED_VER" != "$VERSION" ]; then
+            printf '{"ok": false, "action": "update-cc", "error": "version mismatch after install", "requested": "%s", "installed": "%s"}\n' "$VERSION" "$INSTALLED" >&2
+            exit 1
+        fi
         # One-canonical-copy sweep — compact mirror of cc_shadow_scan in
         # scripts/lib/cc_version.sh (this script must stay hermetic; it is the
-        # path that manages host CC when the install dir may be broken). Every
-        # host shadow incident to date was a USER-dir copy (nvm tree, native
-        # installer symlink + version blobs), so this sweep is user-dir-only —
-        # the gateway never sudo-removes files. Silent on stdout (consumers
-        # parse the JSON line below); count reported in the JSON.
+        # path that manages host CC when the install dir may be broken).
+        # Runs ONLY after the verify above proved the resolved claude is at
+        # the requested pin — the fail-safe: no proven-good copy, no removal.
+        # Every host shadow incident to date was a USER-dir copy (nvm tree,
+        # native installer symlink + version blobs), so this sweep is
+        # user-dir-only — the gateway never sudo-removes files. Silent on
+        # stdout (consumers parse the JSON line below); count in the JSON.
         SHADOWS_REMOVED=0
         CANON="$(readlink -f "$(command -v claude 2>/dev/null)" 2>/dev/null || true)"
+        CANON_PKG=""
+        case "$CANON" in
+            */@anthropic-ai/claude-code/*)
+                CANON_PKG="$(readlink -f "${CANON%%/@anthropic-ai/claude-code/*}/@anthropic-ai/claude-code" 2>/dev/null || true)"
+                ;;
+        esac
         if [ -n "$CANON" ] && [ "${CC_SHADOW_SCAN:-1}" != "0" ]; then
             for SHADOW in "$HOME"/.nvm/versions/node/*/bin/claude \
                           "$HOME/.local/bin/claude" \
@@ -413,7 +428,13 @@ PYEOF
                         PKG="${PKG%%/@anthropic-ai/claude-code*}/@anthropic-ai/claude-code"
                         rm -f "$SHADOW"
                         case "$PKG" in
-                            */@anthropic-ai/claude-code) [ -d "$PKG" ] && rm -rf "$PKG" ;;
+                            */@anthropic-ai/claude-code)
+                                # Never rm the CANONICAL's package via a stale
+                                # second link into it — the link alone goes.
+                                if [ -d "$PKG" ] && [ "$(readlink -f "$PKG" 2>/dev/null)" != "$CANON_PKG" ]; then
+                                    rm -rf "$PKG"
+                                fi
+                                ;;
                         esac
                         SHADOWS_REMOVED=$((SHADOWS_REMOVED + 1))
                         ;;
@@ -423,20 +444,18 @@ PYEOF
                         ;;
                 esac
             done
-            if [ -d "$HOME/.local/share/claude/versions" ]; then
-                rm -rf "$HOME/.local/share/claude/versions"
-                SHADOWS_REMOVED=$((SHADOWS_REMOVED + 1))
-            fi
+            # Native version blobs — unless the canonical IS a native install.
+            case "$CANON" in
+                "$HOME/.local/share/claude/"*) : ;;
+                *)
+                    if [ -d "$HOME/.local/share/claude/versions" ]; then
+                        rm -rf "$HOME/.local/share/claude/versions"
+                        SHADOWS_REMOVED=$((SHADOWS_REMOVED + 1))
+                    fi
+                    ;;
+            esac
         fi
-        # Verify: the in-use claude must now report exactly the requested version.
-        INSTALLED="$(claude --version 2>/dev/null || echo unknown)"
-        INSTALLED_VER="$(printf '%s' "$INSTALLED" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)"
-        if [ "$INSTALLED_VER" = "$VERSION" ]; then
-            printf '{"ok": true, "action": "update-cc", "version": "%s", "installed": "%s", "shadows_removed": %s}\n' "$VERSION" "$INSTALLED" "$SHADOWS_REMOVED"
-        else
-            printf '{"ok": false, "action": "update-cc", "error": "version mismatch after install", "requested": "%s", "installed": "%s"}\n' "$VERSION" "$INSTALLED" >&2
-            exit 1
-        fi
+        printf '{"ok": true, "action": "update-cc", "version": "%s", "installed": "%s", "shadows_removed": %s}\n' "$VERSION" "$INSTALLED" "$SHADOWS_REMOVED"
         ;;
     update-node\ *)
         # Controlled Node.js major upgrade on the host (WS-16).

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -390,11 +390,49 @@ PYEOF
             echo '{"ok": false, "action": "update-cc", "error": "npm install failed"}' >&2
             exit 1
         fi
+        # One-canonical-copy sweep — compact mirror of cc_shadow_scan in
+        # scripts/lib/cc_version.sh (this script must stay hermetic; it is the
+        # path that manages host CC when the install dir may be broken). Every
+        # host shadow incident to date was a USER-dir copy (nvm tree, native
+        # installer symlink + version blobs), so this sweep is user-dir-only —
+        # the gateway never sudo-removes files. Silent on stdout (consumers
+        # parse the JSON line below); count reported in the JSON.
+        SHADOWS_REMOVED=0
+        CANON="$(readlink -f "$(command -v claude 2>/dev/null)" 2>/dev/null || true)"
+        if [ -n "$CANON" ] && [ "${CC_SHADOW_SCAN:-1}" != "0" ]; then
+            for SHADOW in "$HOME"/.nvm/versions/node/*/bin/claude \
+                          "$HOME/.local/bin/claude" \
+                          "$HOME/.claude/local/claude" \
+                          "$HOME/.npm-global/bin/claude"; do
+                { [ -e "$SHADOW" ] || [ -L "$SHADOW" ]; } || continue
+                [ "$(readlink -f "$SHADOW" 2>/dev/null)" = "$CANON" ] && continue
+                T="$(readlink "$SHADOW" 2>/dev/null || true)"
+                case "$T" in
+                    *@anthropic-ai/claude-code*)
+                        PKG="$(cd "$(dirname "$SHADOW")" 2>/dev/null && cd "$(dirname "$T")" 2>/dev/null && pwd || true)"
+                        PKG="${PKG%%/@anthropic-ai/claude-code*}/@anthropic-ai/claude-code"
+                        rm -f "$SHADOW"
+                        case "$PKG" in
+                            */@anthropic-ai/claude-code) [ -d "$PKG" ] && rm -rf "$PKG" ;;
+                        esac
+                        SHADOWS_REMOVED=$((SHADOWS_REMOVED + 1))
+                        ;;
+                    */.local/share/claude/*)
+                        rm -f "$SHADOW"
+                        SHADOWS_REMOVED=$((SHADOWS_REMOVED + 1))
+                        ;;
+                esac
+            done
+            if [ -d "$HOME/.local/share/claude/versions" ]; then
+                rm -rf "$HOME/.local/share/claude/versions"
+                SHADOWS_REMOVED=$((SHADOWS_REMOVED + 1))
+            fi
+        fi
         # Verify: the in-use claude must now report exactly the requested version.
         INSTALLED="$(claude --version 2>/dev/null || echo unknown)"
         INSTALLED_VER="$(printf '%s' "$INSTALLED" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)"
         if [ "$INSTALLED_VER" = "$VERSION" ]; then
-            printf '{"ok": true, "action": "update-cc", "version": "%s", "installed": "%s"}\n' "$VERSION" "$INSTALLED"
+            printf '{"ok": true, "action": "update-cc", "version": "%s", "installed": "%s", "shadows_removed": %s}\n' "$VERSION" "$INSTALLED" "$SHADOWS_REMOVED"
         else
             printf '{"ok": false, "action": "update-cc", "error": "version mismatch after install", "requested": "%s", "installed": "%s"}\n' "$VERSION" "$INSTALLED" >&2
             exit 1

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -1192,6 +1192,12 @@ else
     echo "  . Claude Code already on host ($(claude --version 2>/dev/null))"
 fi
 
+# Enforce the one-canonical-copy policy: remove shadow CC copies (nvm trees,
+# native-installer artifacts, stale prefixes) that drift silently because
+# update-cc only manages the canonical copy. See cc_shadow_scan in
+# scripts/lib/cc_version.sh (sourced above). CC_SHADOW_SCAN=0 opts out.
+cc_shadow_scan || true
+
 # Suppress CC auto-updater via user-level ~/.claude/settings.json on the host.
 # The repo's .claude/settings.json doesn't apply when CC runs outside the project
 # directory, and CC's auto-updater silently bumps the version in that context.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1174,6 +1174,7 @@ if ! cc_ensure_local; then
     echo "    Install manually: npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
     SETUP_WARNINGS=1
 fi
+cc_shadow_scan || true
 
 # Genesis wrapper — lets users type 'genesis' from anywhere inside the container
 # to launch Claude Code in the right directory with all hooks/MCP active.

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -28,6 +28,12 @@ CC_VERSION="${CC_VERSION:-2.1.201}"
 # host VM via the guardian-gateway `update-node` op — mirroring `update-cc`.
 NODE_MAJOR="${NODE_MAJOR:-22}"
 
+# Known CC install prefixes (bin dirs), probed when `command -v claude` fails —
+# a PATH-blind install (user npm prefix whose PATH export only fires in
+# interactive shells) must be treated as installed, not reinstalled forever.
+# Colon-separated; overridable for tests and exotic layouts.
+CC_PROBE_DIRS="${CC_PROBE_DIRS:-/usr/local/bin:/usr/bin:$HOME/.npm-global/bin}"
+
 
 # cc_ensure_local — install or align the LOCAL Claude Code CLI to $CC_VERSION.
 #
@@ -62,10 +68,29 @@ cc_ensure_local() {
         return 0
     fi
 
-    local existing current prefix
+    local existing current prefix p
     existing="$(command -v claude 2>/dev/null || true)"
+    if [ -z "$existing" ]; then
+        # PATH-blind check before declaring absence: a user-prefix install
+        # (~/.npm-global with its PATH export in .bashrc AFTER the interactive
+        # early-exit) is invisible to every non-interactive shell — which made
+        # this function reinstall CC on EVERY update run on one machine while
+        # a perfectly good copy sat one directory away.
+        local _oldIFS="$IFS"
+        IFS=':'
+        for p in $CC_PROBE_DIRS; do
+            if [ -x "$p/claude" ]; then
+                existing="$p/claude"
+                echo "  cc_ensure_local: claude found at $existing but NOT on this shell's PATH — treating as installed (fix the PATH wiring, or move the install to a system prefix)" >&2
+                break
+            fi
+        done
+        IFS="$_oldIFS"
+    fi
     if [ -n "$existing" ]; then
-        current="$(claude --version 2>/dev/null | awk '{print $1}')"
+        # Version via the resolved binary, not a PATH lookup — $existing may
+        # have come from the PATH-blind prefix probe above.
+        current="$("$existing" --version 2>/dev/null | awk '{print $1}')"
         if [ "$current" = "$pin" ]; then
             echo "  Claude Code already at pin ($pin)"
             return 0
@@ -122,4 +147,121 @@ cc_ensure_local() {
     fi
     echo "  WARNING: cc_ensure_local: install ran but 'claude --version' is ${installed:-unknown} (expected $pin) — possible npm-prefix/PATH mismatch" >&2
     return 1
+}
+
+
+# cc_shadow_scan — enforce the ONE-canonical-copy policy for Claude Code.
+#
+# Four real incidents motivated this (2026-07): an nvm-tree copy that shadowed
+# the pinned CC in interactive shells only (user saw a months-old version); a
+# native-installer symlink in ~/.local/bin doing the same; leftover native
+# version blobs (~490MB dead weight); and a user-prefix copy invisible to
+# non-interactive shells. Shadow copies drift silently because update-cc /
+# cc_ensure_local only manage the canonical copy.
+#
+# Canonical = what `command -v claude` resolves in THIS (non-interactive)
+# shell — i.e. the copy all automation actually runs — falling back to the
+# known-prefix probe order used by cc_ensure_local. Every OTHER copy on a
+# known surface is removed, with loud logging. Removal is gated on the
+# artifact being PROVABLY a claude-code install (npm package dir or a symlink
+# into one, or the native-installer layout); anything unprovable is warned
+# about and left alone.
+#
+# Opt-out for deliberate multi-copy setups: CC_SHADOW_SCAN=0.
+# Non-fatal by design; call as `cc_shadow_scan || true`.
+cc_shadow_scan() {
+    if [ "${CC_SHADOW_SCAN:-1}" = "0" ]; then
+        echo "  cc_shadow_scan: disabled (CC_SHADOW_SCAN=0)"
+        return 0
+    fi
+
+    local canonical="" canon_real="" p
+    canonical="$(command -v claude 2>/dev/null || true)"
+    if [ -z "$canonical" ]; then
+        local _oldIFS="$IFS"
+        IFS=':'
+        for p in $CC_PROBE_DIRS; do
+            [ -x "$p/claude" ] && canonical="$p/claude" && break
+        done
+        IFS="$_oldIFS"
+    fi
+    if [ -z "$canonical" ]; then
+        echo "  cc_shadow_scan: no canonical claude found — skipping (nothing to protect)" >&2
+        return 0
+    fi
+    canon_real="$(readlink -f "$canonical" 2>/dev/null || echo "$canonical")"
+
+    # Native-installer version blobs: shadows by definition under the npm-only
+    # canon (docs/reference/cc-compatibility.md), and BIG (~250MB each).
+    if [ -d "$HOME/.local/share/claude/versions" ]; then
+        echo "  cc_shadow_scan: removing native-installer version blobs ($HOME/.local/share/claude/versions)"
+        rm -rf "$HOME/.local/share/claude/versions"
+    fi
+
+    local candidate real target
+    for candidate in \
+        "$HOME"/.nvm/versions/node/*/bin/claude \
+        "$HOME/.claude/local/claude" \
+        "$HOME/.local/bin/claude" \
+        "$HOME/.npm-global/bin/claude" \
+        /usr/local/bin/claude \
+        /usr/bin/claude; do
+        [ -e "$candidate" ] || [ -L "$candidate" ] || continue
+        real="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
+        # The canonical copy itself (or a same-file alias like /bin vs /usr/bin
+        # under usrmerge) is never touched.
+        [ "$real" = "$canon_real" ] && continue
+        _cc_remove_shadow "$candidate"
+    done
+
+    # Aliases/functions can shadow every file-level fix — detect, never edit
+    # a user's rc files.
+    local rc hits
+    for rc in "$HOME/.bashrc" "$HOME/.bash_aliases" "$HOME/.zshrc" "$HOME/.profile"; do
+        [ -f "$rc" ] || continue
+        hits="$(grep -nE '^[[:space:]]*alias claude=' "$rc" 2>/dev/null || true)"
+        [ -n "$hits" ] && echo "  WARNING: cc_shadow_scan: 'claude' alias in $rc shadows the canonical copy — remove it manually: $hits" >&2
+    done
+    return 0
+}
+
+# _cc_remove_shadow <path> — remove one shadow copy, ONLY if provably a
+# claude-code install. System-prefix removals need passwordless sudo; user
+# paths are removed directly. Unprovable artifacts are warned and kept.
+_cc_remove_shadow() {
+    local candidate="$1" target pkg_dir=""
+    target="$(readlink "$candidate" 2>/dev/null || true)"
+
+    if [[ "$target" == *"@anthropic-ai/claude-code"* ]]; then
+        # npm-style symlink → the package dir it points into (resolve relative
+        # to the symlink's own directory).
+        pkg_dir="$(cd "$(dirname "$candidate")" 2>/dev/null && cd "$(dirname "$target")" 2>/dev/null && pwd)"
+        pkg_dir="${pkg_dir%%/@anthropic-ai/claude-code*}/@anthropic-ai/claude-code"
+        [[ "$pkg_dir" == *"@anthropic-ai/claude-code" && -d "$pkg_dir" ]] || pkg_dir=""
+    elif [[ "$target" == *"/.local/share/claude/"* || "$candidate" == "$HOME/.claude/local/claude" ]]; then
+        # Native-installer symlink (target dir handled by the blob sweep) or
+        # the migrate-installer launcher — the launcher/link itself goes.
+        pkg_dir=""
+    else
+        echo "  WARNING: cc_shadow_scan: $candidate is not provably a claude-code install — left in place (remove manually if it is one)" >&2
+        return 1
+    fi
+
+    local -a rm_link=(rm -f "$candidate")
+    local -a rm_pkg=()
+    [ -n "$pkg_dir" ] && rm_pkg=(rm -rf "$pkg_dir")
+    case "$candidate" in
+        /usr/*|/opt/*)
+            if ! sudo -n true 2>/dev/null; then
+                echo "  WARNING: cc_shadow_scan: shadow at $candidate needs sudo to remove — skipped" >&2
+                return 1
+            fi
+            rm_link=(sudo -n "${rm_link[@]}")
+            [ -n "$pkg_dir" ] && rm_pkg=(sudo -n "${rm_pkg[@]}")
+            ;;
+    esac
+    echo "  cc_shadow_scan: removing shadow copy $candidate${pkg_dir:+ (+ $pkg_dir)}"
+    "${rm_link[@]}"
+    [ -n "$pkg_dir" ] && "${rm_pkg[@]}"
+    return 0
 }

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -159,13 +159,20 @@ cc_ensure_local() {
 # non-interactive shells. Shadow copies drift silently because update-cc /
 # cc_ensure_local only manage the canonical copy.
 #
-# Canonical = what `command -v claude` resolves in THIS (non-interactive)
-# shell — i.e. the copy all automation actually runs — falling back to the
-# known-prefix probe order used by cc_ensure_local. Every OTHER copy on a
-# known surface is removed, with loud logging. Removal is gated on the
-# artifact being PROVABLY a claude-code install (npm package dir or a symlink
-# into one, or the native-installer layout); anything unprovable is warned
-# about and left alone.
+# Canonical = a copy that REPORTS THE PIN ($CC_VERSION): first the PATH
+# resolution if it's at the pin, else the first at-pin copy in CC_PROBE_DIRS.
+# Version-verified selection is the core safety property — `command -v` alone
+# follows the INVOKING shell's PATH, and an interactive PATH can put a stale
+# copy first (the exact incident class this scan exists to fix), which would
+# otherwise crown the stale copy canonical and sudo-remove the good one.
+# FAIL-SAFE: if NO copy at the pin exists anywhere, nothing is removed —
+# a scan that cannot prove a good copy exists has no business deleting.
+#
+# Every OTHER copy on a known surface is removed, with loud logging. Removal
+# is gated on the artifact being PROVABLY a claude-code install (npm package
+# dir or a symlink into one, or the native-installer layout); anything
+# unprovable is warned about and left alone. The canonical's own package dir
+# and (for a native canonical) the native versions dir are never touched.
 #
 # Opt-out for deliberate multi-copy setups: CC_SHADOW_SCAN=0.
 # Non-fatal by design; call as `cc_shadow_scan || true`.
@@ -174,31 +181,61 @@ cc_shadow_scan() {
         echo "  cc_shadow_scan: disabled (CC_SHADOW_SCAN=0)"
         return 0
     fi
-
-    local canonical="" canon_real="" p
-    canonical="$(command -v claude 2>/dev/null || true)"
-    if [ -z "$canonical" ]; then
-        local _oldIFS="$IFS"
-        IFS=':'
-        for p in $CC_PROBE_DIRS; do
-            [ -x "$p/claude" ] && canonical="$p/claude" && break
-        done
-        IFS="$_oldIFS"
+    local pin="${CC_VERSION:-}"
+    if [ -z "$pin" ]; then
+        echo "  cc_shadow_scan: CC_VERSION unset — skipping (cannot verify a canonical)" >&2
+        return 0
     fi
+
+    local canonical="" canon_real="" canon_pkg="" p v
+    local -a _candidates=()
+    p="$(command -v claude 2>/dev/null || true)"
+    [ -n "$p" ] && _candidates+=("$p")
+    local _oldIFS="$IFS"
+    IFS=':'
+    for p in $CC_PROBE_DIRS; do
+        _candidates+=("$p/claude")
+    done
+    IFS="$_oldIFS"
+    for p in "${_candidates[@]}"; do
+        [ -x "$p" ] || continue
+        v="$("$p" --version 2>/dev/null | awk '{print $1}')"
+        if [ "$v" = "$pin" ]; then
+            canonical="$p"
+            break
+        fi
+    done
     if [ -z "$canonical" ]; then
-        echo "  cc_shadow_scan: no canonical claude found — skipping (nothing to protect)" >&2
+        echo "  cc_shadow_scan: no claude at the pin ($pin) found — REFUSING to remove anything (align with cc_ensure_local / update-cc first)" >&2
         return 0
     fi
     canon_real="$(readlink -f "$canonical" 2>/dev/null || echo "$canonical")"
+    # The canonical's own npm package dir — never removed, even when a STALE
+    # extra symlink points into it (that link alone goes; nuking the package
+    # would destroy the canonical).
+    case "$canon_real" in
+        */@anthropic-ai/claude-code/*)
+            canon_pkg="$(readlink -f "${canon_real%%/@anthropic-ai/claude-code/*}/@anthropic-ai/claude-code" 2>/dev/null || true)"
+            ;;
+    esac
 
     # Native-installer version blobs: shadows by definition under the npm-only
-    # canon (docs/reference/cc-compatibility.md), and BIG (~250MB each).
+    # canon (docs/reference/cc-compatibility.md), and BIG (~250MB each) —
+    # UNLESS the canonical itself is a native install (then they ARE the
+    # canonical's payload; leave them and let the operator migrate to npm).
     if [ -d "$HOME/.local/share/claude/versions" ]; then
-        echo "  cc_shadow_scan: removing native-installer version blobs ($HOME/.local/share/claude/versions)"
-        rm -rf "$HOME/.local/share/claude/versions"
+        case "$canon_real" in
+            "$HOME/.local/share/claude/"*)
+                echo "  cc_shadow_scan: canonical is a native install — keeping $HOME/.local/share/claude/versions (consider migrating to the npm install path)" >&2
+                ;;
+            *)
+                echo "  cc_shadow_scan: removing native-installer version blobs ($HOME/.local/share/claude/versions)"
+                rm -rf "$HOME/.local/share/claude/versions"
+                ;;
+        esac
     fi
 
-    local candidate real target
+    local candidate real
     for candidate in \
         "$HOME"/.nvm/versions/node/*/bin/claude \
         "$HOME/.claude/local/claude" \
@@ -211,7 +248,7 @@ cc_shadow_scan() {
         # The canonical copy itself (or a same-file alias like /bin vs /usr/bin
         # under usrmerge) is never touched.
         [ "$real" = "$canon_real" ] && continue
-        _cc_remove_shadow "$candidate"
+        _cc_remove_shadow "$candidate" "$canon_pkg"
     done
 
     # Aliases/functions can shadow every file-level fix — detect, never edit
@@ -225,11 +262,13 @@ cc_shadow_scan() {
     return 0
 }
 
-# _cc_remove_shadow <path> — remove one shadow copy, ONLY if provably a
-# claude-code install. System-prefix removals need passwordless sudo; user
-# paths are removed directly. Unprovable artifacts are warned and kept.
+# _cc_remove_shadow <path> <canon_pkg> — remove one shadow copy, ONLY if
+# provably a claude-code install. System-prefix removals need passwordless
+# sudo; user paths are removed directly. Unprovable artifacts are warned and
+# kept. A package dir equal to <canon_pkg> (the canonical's own package) is
+# never removed — only the stale link into it.
 _cc_remove_shadow() {
-    local candidate="$1" target pkg_dir=""
+    local candidate="$1" canon_pkg="${2:-}" target pkg_dir=""
     target="$(readlink "$candidate" 2>/dev/null || true)"
 
     if [[ "$target" == *"@anthropic-ai/claude-code"* ]]; then
@@ -238,13 +277,27 @@ _cc_remove_shadow() {
         pkg_dir="$(cd "$(dirname "$candidate")" 2>/dev/null && cd "$(dirname "$target")" 2>/dev/null && pwd)"
         pkg_dir="${pkg_dir%%/@anthropic-ai/claude-code*}/@anthropic-ai/claude-code"
         [[ "$pkg_dir" == *"@anthropic-ai/claude-code" && -d "$pkg_dir" ]] || pkg_dir=""
-    elif [[ "$target" == *"/.local/share/claude/"* || "$candidate" == "$HOME/.claude/local/claude" ]]; then
-        # Native-installer symlink (target dir handled by the blob sweep) or
-        # the migrate-installer launcher — the launcher/link itself goes.
+    elif [[ "$candidate" == "$HOME/.claude/local/claude" ]]; then
+        # migrate-installer layout: the launcher plus its own npm subtree
+        # (~/.claude/local/node_modules/...) — remove both, not just the
+        # launcher (the package tree is hundreds of MB of dead weight).
+        pkg_dir="$HOME/.claude/local/node_modules/@anthropic-ai/claude-code"
+        [ -d "$pkg_dir" ] || pkg_dir=""
+    elif [[ "$target" == *"/.local/share/claude/"* ]]; then
+        # Native-installer symlink — the blob dir is handled (and guarded)
+        # by the sweep in cc_shadow_scan; only the link goes here.
         pkg_dir=""
     else
         echo "  WARNING: cc_shadow_scan: $candidate is not provably a claude-code install — left in place (remove manually if it is one)" >&2
         return 1
+    fi
+
+    # Never rm -rf the canonical's own package — a stale SECOND link into it
+    # (e.g. an old entry-file path) loses only the link.
+    if [ -n "$pkg_dir" ] && [ -n "$canon_pkg" ] \
+        && [ "$(readlink -f "$pkg_dir" 2>/dev/null)" = "$canon_pkg" ]; then
+        echo "  cc_shadow_scan: $candidate is a stale link into the CANONICAL package — removing the link only"
+        pkg_dir=""
     fi
 
     local -a rm_link=(rm -f "$candidate")

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -298,6 +298,7 @@ _sync_deploy_targets() {
         # shellcheck source=/dev/null
         source "$_cc_env"
         cc_ensure_local || true
+        cc_shadow_scan || true
     else
         echo "  WARNING: $_cc_env missing — skipping container CC sync"
     fi

--- a/tests/test_scripts/test_cc_shadow_scan.py
+++ b/tests/test_scripts/test_cc_shadow_scan.py
@@ -69,6 +69,7 @@ def _run(tmp_path: Path, script: str, *, extra_env: dict | None = None,
     harness.write_text(f'#!/usr/bin/env bash\n. "{_LIB}"\n{script}\n', encoding="utf-8")
     env = {"PATH": ":".join(path_dirs), "HOME": str(home),
            "CC_PROBE_DIRS": str(tmp_path / "probe-nowhere"),
+           "CC_VERSION": "2.1.201",
            **(extra_env or {})}
     return subprocess.run(["bash", str(harness)], env=env,
                           capture_output=True, text=True, timeout=30)
@@ -133,16 +134,97 @@ def test_canonical_on_a_scanned_surface_is_kept(tmp_path):
 def test_system_path_shadow_skipped_without_sudo(tmp_path):
     # PATH has no sudo → a /usr/* candidate must be warned about, never rm'd.
     # (Also the safety net that keeps THIS test suite from touching the real
-    # /usr/local/bin/claude on dev machines.)
+    # /usr/local/bin/claude on dev machines.) Snapshot BEFORE the scan so a
+    # gate regression that deletes a real system copy fails loudly on dev
+    # boxes; on CI (no /usr/*/claude) only the exit-0 half is meaningful.
+    before = {p: (Path(p).exists() or Path(p).is_symlink())
+              for p in ("/usr/local/bin/claude", "/usr/bin/claude")}
     canon = _canonical(tmp_path)
     res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
     assert res.returncode == 0, res.stderr
-    # Real system copies (if any on this machine) still present.
-    for sys_path in ("/usr/local/bin/claude", "/usr/bin/claude"):
-        p = Path(sys_path)
-        existed_before = p.exists() or p.is_symlink()
-        if existed_before:
-            assert p.exists() or p.is_symlink()
+    for p, existed in before.items():
+        if existed:
+            assert Path(p).exists() or Path(p).is_symlink(), \
+                f"scan removed real system copy {p} despite no-sudo PATH"
+            assert "needs sudo to remove — skipped" in res.stderr
+
+
+def test_stale_path_first_copy_is_not_crowned_canonical(tmp_path):
+    # THE inverted-incident case: a STALE copy wins the invoking shell's PATH
+    # while the pinned copy sits in a probe dir. Canonical selection is
+    # pin-verified, so the stale PATH-first copy must be removed and the
+    # pinned copy kept — never the other way around.
+    home = tmp_path / "home"
+    stale = _plant_npm_tree(home / ".nvm" / "versions" / "node" / "v24.15.0",
+                            version="2.1.150")
+    pinned = _canonical(tmp_path)  # prints the pin
+    res = _run(
+        tmp_path, "cc_shadow_scan",
+        canonical=stale,  # stale dir goes FIRST on PATH
+        extra_env={"CC_PROBE_DIRS": str(pinned.parent)},
+    )
+    assert res.returncode == 0, res.stderr
+    assert pinned.exists()
+    assert not stale.exists()
+    assert "removing shadow copy" in res.stdout
+
+
+def test_no_pinned_copy_refuses_all_removal(tmp_path):
+    # Fail-safe: ONLY stale copies exist (nothing at the pin) → refuse to
+    # remove anything at all.
+    home = tmp_path / "home"
+    stale = _plant_npm_tree(home / ".nvm" / "versions" / "node" / "v24.15.0",
+                            version="2.1.150")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=stale)
+    assert res.returncode == 0, res.stderr
+    assert stale.exists()
+    assert "REFUSING to remove anything" in res.stderr
+
+
+def test_native_canonical_is_protected(tmp_path):
+    # Canonical IS a native install (~/.local/bin/claude → versions blob at
+    # the pin): the blob sweep must keep the versions dir AND the link.
+    home = tmp_path / "home"
+    blob = _write_exec(home / ".local" / "share" / "claude" / "versions" / "2.1.201",
+                       '#!/usr/bin/env bash\necho "2.1.201 (Claude Code)"\n')
+    link = home / ".local" / "bin" / "claude"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(blob)
+    res = _run(tmp_path, "cc_shadow_scan", canonical=link)
+    assert res.returncode == 0, res.stderr
+    assert blob.exists() and link.exists()
+    assert "keeping" in res.stderr
+
+
+def test_stale_link_into_canonical_package_loses_link_only(tmp_path):
+    # A leftover second symlink pointing at a DIFFERENT entry file of the
+    # CANONICAL package must lose only the link — never the package.
+    home = tmp_path / "home"
+    canon_link = _plant_npm_tree(home / ".npm-global", version="2.1.201")
+    pkg = home / ".npm-global" / "lib" / "node_modules" / "@anthropic-ai" / "claude-code"
+    (pkg / "cli.js").write_text("// old entry\n", encoding="utf-8")
+    stale_link = home / ".local" / "bin" / "claude"
+    stale_link.parent.mkdir(parents=True)
+    stale_link.symlink_to(pkg / "cli.js")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon_link)
+    assert res.returncode == 0, res.stderr
+    assert not stale_link.exists() and not stale_link.is_symlink()
+    assert canon_link.exists() and pkg.is_dir()
+    assert "CANONICAL package — removing the link only" in res.stdout
+
+
+def test_migrate_installer_removes_launcher_and_package(tmp_path):
+    canon = _canonical(tmp_path)
+    home = tmp_path / "home"
+    launcher = _write_exec(home / ".claude" / "local" / "claude",
+                           "#!/usr/bin/env bash\n")
+    pkg = home / ".claude" / "local" / "node_modules" / "@anthropic-ai" / "claude-code"
+    pkg.mkdir(parents=True)
+    (pkg / "package.json").write_text("{}", encoding="utf-8")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
+    assert res.returncode == 0, res.stderr
+    assert not launcher.exists()
+    assert not pkg.exists()
 
 
 def test_opt_out_env(tmp_path):
@@ -166,13 +248,10 @@ def test_alias_warning(tmp_path):
     assert "alias" in res.stderr and ".bashrc" in res.stderr
 
 
-def test_no_canonical_is_a_noop(tmp_path):
-    home = tmp_path / "home"
-    link = _plant_npm_tree(home / ".nvm" / "versions" / "node" / "v24.15.0")
-    res = _run(tmp_path, "cc_shadow_scan")  # no canonical anywhere
+def test_no_claude_anywhere_is_a_noop(tmp_path):
+    res = _run(tmp_path, "cc_shadow_scan")  # no claude at all
     assert res.returncode == 0, res.stderr
-    assert link.exists()
-    assert "no canonical claude found" in res.stderr
+    assert "REFUSING to remove anything" in res.stderr
 
 
 # ── gateway mirror parity ─────────────────────────────────────────────────
@@ -199,31 +278,26 @@ def test_gateway_compact_scan_covers_same_user_surfaces():
 
 def test_ensure_local_finds_path_blind_install_at_pin(tmp_path):
     # claude NOT on PATH, but present at a probe dir AND at the pin →
-    # "already at pin", no npm invocation (npm absent from PATH would fail).
+    # "already at pin", no npm install attempted (the fake npm logs any call).
     blind = _write_exec(tmp_path / "blind" / "claude",
                         '#!/usr/bin/env bash\necho "2.1.201 (Claude Code)"\n')
-    fake_npm = _write_exec(tmp_path / "minbin-extra" / "npm",
-                           f'#!/usr/bin/env bash\necho npm-called >> "{tmp_path}/npm.log"\n')
-    res = _run(
-        tmp_path, "CC_VERSION=2.1.201 cc_ensure_local",
-        extra_env={"CC_PROBE_DIRS": str(blind.parent),
-                   "CC_VERSION": "2.1.201"},
-    )
-    # npm gate fires first; give it npm via PATH by re-running with npm dir.
-    if "npm not found" in res.stderr:
-        home = tmp_path / "home"
-        minbin = tmp_path / "minbin"
-        env = {"PATH": f"{fake_npm.parent}:{minbin}", "HOME": str(home),
-               "CC_PROBE_DIRS": str(blind.parent), "CC_VERSION": "2.1.201"}
-        harness = tmp_path / "harness.sh"
-        harness.write_text(f'#!/usr/bin/env bash\n. "{_LIB}"\ncc_ensure_local\n',
-                           encoding="utf-8")
-        res = subprocess.run(["bash", str(harness)], env=env,
-                             capture_output=True, text=True, timeout=30)
+    fake_npm = _write_exec(tmp_path / "npmbin" / "npm",
+                           f'#!/usr/bin/env bash\necho "$*" >> "{tmp_path}/npm.log"\n')
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    minbin = _minimal_bin(tmp_path)
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f'#!/usr/bin/env bash\n. "{_LIB}"\ncc_ensure_local\n',
+                       encoding="utf-8")
+    env = {"PATH": f"{fake_npm.parent}:{minbin}", "HOME": str(home),
+           "CC_PROBE_DIRS": str(blind.parent), "CC_VERSION": "2.1.201"}
+    res = subprocess.run(["bash", str(harness)], env=env,
+                         capture_output=True, text=True, timeout=30)
     assert res.returncode == 0, res.stderr
     assert "already at pin" in res.stdout
     assert "NOT on this shell's PATH" in res.stderr
-    assert not (tmp_path / "npm.log").exists()  # no reinstall attempted
+    log = tmp_path / "npm.log"
+    assert not log.exists() or "install" not in log.read_text()
 
 
 def test_ensure_local_absent_everywhere_still_installs(tmp_path):

--- a/tests/test_scripts/test_cc_shadow_scan.py
+++ b/tests/test_scripts/test_cc_shadow_scan.py
@@ -1,0 +1,251 @@
+"""CC single-copy enforcement (cc_shadow_scan / cc_ensure_local PATH-blind fix).
+
+Four real shadow-copy incidents motivated scripts/lib/cc_version.sh's
+``cc_shadow_scan``: an nvm-tree copy shadowing the pin in interactive shells,
+a native-installer symlink in ~/.local/bin, leftover native version blobs,
+and a user-prefix copy invisible to non-interactive shells (which also made
+``cc_ensure_local`` reinstall CC on every update run).
+
+Harness: sources the REAL lib with a fake $HOME, a minimal PATH (no sudo —
+which is also the safety these tests assert for system-path candidates), and
+``CC_PROBE_DIRS`` pointed at fake dirs so nothing depends on the machine's
+actual Claude Code install.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LIB = _REPO_ROOT / "scripts" / "lib" / "cc_version.sh"
+
+_TOOLS = ("bash", "sh", "env", "readlink", "rm", "grep", "dirname", "awk",
+          "cat", "mkdir", "ln", "chmod", "timeout")
+
+
+def _minimal_bin(tmp_path: Path) -> Path:
+    """PATH dir with core tools but deliberately NO sudo and NO npm."""
+    d = tmp_path / "minbin"
+    d.mkdir(exist_ok=True)
+    for tool in _TOOLS:
+        for src_dir in ("/usr/bin", "/bin"):
+            src = Path(src_dir) / tool
+            if src.exists():
+                (d / tool).symlink_to(src)
+                break
+    return d
+
+
+def _write_exec(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _plant_npm_tree(prefix: Path, version: str = "2.1.150") -> Path:
+    """An npm-style CC install: bin/claude → ../lib/node_modules/.../claude.exe."""
+    pkg = prefix / "lib" / "node_modules" / "@anthropic-ai" / "claude-code"
+    _write_exec(pkg / "bin" / "claude.exe",
+                f'#!/usr/bin/env bash\necho "{version} (Claude Code)"\n')
+    bin_link = prefix / "bin" / "claude"
+    bin_link.parent.mkdir(parents=True, exist_ok=True)
+    bin_link.symlink_to("../lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe")
+    return bin_link
+
+
+def _run(tmp_path: Path, script: str, *, extra_env: dict | None = None,
+         canonical: Path | None = None) -> subprocess.CompletedProcess:
+    """Source the real lib in a fake HOME and run `script`."""
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    minbin = _minimal_bin(tmp_path)
+    path_dirs = [str(minbin)]
+    if canonical is not None:
+        path_dirs.insert(0, str(canonical.parent))
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f'#!/usr/bin/env bash\n. "{_LIB}"\n{script}\n', encoding="utf-8")
+    env = {"PATH": ":".join(path_dirs), "HOME": str(home),
+           "CC_PROBE_DIRS": str(tmp_path / "probe-nowhere"),
+           **(extra_env or {})}
+    return subprocess.run(["bash", str(harness)], env=env,
+                          capture_output=True, text=True, timeout=30)
+
+
+def _canonical(tmp_path: Path, version: str = "2.1.201") -> Path:
+    return _write_exec(tmp_path / "canon" / "claude",
+                       f'#!/usr/bin/env bash\necho "{version} (Claude Code)"\n')
+
+
+# ── cc_shadow_scan ────────────────────────────────────────────────────────
+
+
+def test_nvm_shadow_removed_with_package_dir(tmp_path):
+    canon = _canonical(tmp_path)
+    home = tmp_path / "home"
+    nvm_prefix = home / ".nvm" / "versions" / "node" / "v24.15.0"
+    link = _plant_npm_tree(nvm_prefix)
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
+    assert res.returncode == 0, res.stderr
+    assert not link.exists()
+    assert not (nvm_prefix / "lib" / "node_modules" / "@anthropic-ai" / "claude-code").exists()
+    assert "removing shadow copy" in res.stdout
+    assert canon.exists()
+
+
+def test_native_installer_artifacts_removed(tmp_path):
+    canon = _canonical(tmp_path)
+    home = tmp_path / "home"
+    blob_dir = home / ".local" / "share" / "claude" / "versions"
+    _write_exec(blob_dir / "2.1.170", "#!/usr/bin/env bash\n")
+    native_link = home / ".local" / "bin" / "claude"
+    native_link.parent.mkdir(parents=True)
+    native_link.symlink_to(home / ".local" / "share" / "claude" / "versions" / "2.1.170")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
+    assert res.returncode == 0, res.stderr
+    assert not blob_dir.exists()
+    assert not native_link.exists() and not native_link.is_symlink()
+
+
+def test_unprovable_artifact_kept_and_warned(tmp_path):
+    canon = _canonical(tmp_path)
+    home = tmp_path / "home"
+    impostor = _write_exec(home / ".npm-global" / "bin" / "claude",
+                           "#!/usr/bin/env bash\necho not-claude\n")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
+    assert res.returncode == 0, res.stderr
+    assert impostor.exists()
+    assert "not provably a claude-code install" in res.stderr
+
+
+def test_canonical_on_a_scanned_surface_is_kept(tmp_path):
+    # Canonical living AT a candidate path (~/.npm-global/bin) must survive.
+    home = tmp_path / "home"
+    link = _plant_npm_tree(home / ".npm-global", version="2.1.201")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=link)
+    assert res.returncode == 0, res.stderr
+    assert link.exists()
+    assert "removing shadow copy" not in res.stdout
+
+
+def test_system_path_shadow_skipped_without_sudo(tmp_path):
+    # PATH has no sudo → a /usr/* candidate must be warned about, never rm'd.
+    # (Also the safety net that keeps THIS test suite from touching the real
+    # /usr/local/bin/claude on dev machines.)
+    canon = _canonical(tmp_path)
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
+    assert res.returncode == 0, res.stderr
+    # Real system copies (if any on this machine) still present.
+    for sys_path in ("/usr/local/bin/claude", "/usr/bin/claude"):
+        p = Path(sys_path)
+        existed_before = p.exists() or p.is_symlink()
+        if existed_before:
+            assert p.exists() or p.is_symlink()
+
+
+def test_opt_out_env(tmp_path):
+    canon = _canonical(tmp_path)
+    home = tmp_path / "home"
+    link = _plant_npm_tree(home / ".nvm" / "versions" / "node" / "v24.15.0")
+    res = _run(tmp_path, "cc_shadow_scan", extra_env={"CC_SHADOW_SCAN": "0"},
+               canonical=canon)
+    assert res.returncode == 0, res.stderr
+    assert link.exists()
+    assert "disabled" in res.stdout
+
+
+def test_alias_warning(tmp_path):
+    canon = _canonical(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    (home / ".bashrc").write_text("alias claude='~/somewhere/claude'\n", encoding="utf-8")
+    res = _run(tmp_path, "cc_shadow_scan", canonical=canon)
+    assert res.returncode == 0, res.stderr
+    assert "alias" in res.stderr and ".bashrc" in res.stderr
+
+
+def test_no_canonical_is_a_noop(tmp_path):
+    home = tmp_path / "home"
+    link = _plant_npm_tree(home / ".nvm" / "versions" / "node" / "v24.15.0")
+    res = _run(tmp_path, "cc_shadow_scan")  # no canonical anywhere
+    assert res.returncode == 0, res.stderr
+    assert link.exists()
+    assert "no canonical claude found" in res.stderr
+
+
+# ── gateway mirror parity ─────────────────────────────────────────────────
+
+
+def test_gateway_compact_scan_covers_same_user_surfaces():
+    """guardian-gateway.sh's hermetic update-cc sweep must keep covering the
+    same USER-dir shadow surfaces as cc_shadow_scan (it deliberately excludes
+    system paths — the gateway never sudo-removes). A surface added to the lib
+    but not the gateway would silently re-open host-side drift."""
+    gateway = (_REPO_ROOT / "scripts" / "guardian-gateway.sh").read_text(encoding="utf-8")
+    for surface in (
+        '.nvm/versions/node/*/bin/claude',
+        '.local/bin/claude',
+        '.claude/local/claude',
+        '.npm-global/bin/claude',
+        '.local/share/claude/versions',
+    ):
+        assert surface in gateway, f"gateway update-cc sweep missing surface: {surface}"
+
+
+# ── cc_ensure_local PATH-blind probe ──────────────────────────────────────
+
+
+def test_ensure_local_finds_path_blind_install_at_pin(tmp_path):
+    # claude NOT on PATH, but present at a probe dir AND at the pin →
+    # "already at pin", no npm invocation (npm absent from PATH would fail).
+    blind = _write_exec(tmp_path / "blind" / "claude",
+                        '#!/usr/bin/env bash\necho "2.1.201 (Claude Code)"\n')
+    fake_npm = _write_exec(tmp_path / "minbin-extra" / "npm",
+                           f'#!/usr/bin/env bash\necho npm-called >> "{tmp_path}/npm.log"\n')
+    res = _run(
+        tmp_path, "CC_VERSION=2.1.201 cc_ensure_local",
+        extra_env={"CC_PROBE_DIRS": str(blind.parent),
+                   "CC_VERSION": "2.1.201"},
+    )
+    # npm gate fires first; give it npm via PATH by re-running with npm dir.
+    if "npm not found" in res.stderr:
+        home = tmp_path / "home"
+        minbin = tmp_path / "minbin"
+        env = {"PATH": f"{fake_npm.parent}:{minbin}", "HOME": str(home),
+               "CC_PROBE_DIRS": str(blind.parent), "CC_VERSION": "2.1.201"}
+        harness = tmp_path / "harness.sh"
+        harness.write_text(f'#!/usr/bin/env bash\n. "{_LIB}"\ncc_ensure_local\n',
+                           encoding="utf-8")
+        res = subprocess.run(["bash", str(harness)], env=env,
+                             capture_output=True, text=True, timeout=30)
+    assert res.returncode == 0, res.stderr
+    assert "already at pin" in res.stdout
+    assert "NOT on this shell's PATH" in res.stderr
+    assert not (tmp_path / "npm.log").exists()  # no reinstall attempted
+
+
+def test_ensure_local_absent_everywhere_still_installs(tmp_path):
+    # No claude on PATH or probe dirs → falls through to the install branch
+    # (fake npm records the call and pretends success; verify then fails
+    # non-fatally, which is fine — the assertion is the install ATTEMPT).
+    # Prefix must be USER-writable — a system prefix would route through the
+    # sudo guard (and this PATH has no sudo, by design).
+    fake_npm = _write_exec(tmp_path / "npmbin" / "npm",
+                           "#!/usr/bin/env bash\n"
+                           f'echo "$*" >> "{tmp_path}/npm.log"\n'
+                           f'if [ "$1" = "config" ]; then echo "{tmp_path}/home/.npm-global"; fi\n')
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    minbin = _minimal_bin(tmp_path)
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f'#!/usr/bin/env bash\n. "{_LIB}"\ncc_ensure_local\n',
+                       encoding="utf-8")
+    env = {"PATH": f"{fake_npm.parent}:{minbin}", "HOME": str(home),
+           "CC_PROBE_DIRS": str(tmp_path / "nowhere"), "CC_VERSION": "2.1.201"}
+    res = subprocess.run(["bash", str(harness)], env=env,
+                         capture_output=True, text=True, timeout=30)
+    assert "not installed — installing pinned" in res.stdout
+    log = (tmp_path / "npm.log").read_text()
+    assert "install -g" in log and "@anthropic-ai/claude-code@2.1.201" in log


### PR DESCRIPTION
## Problem

Four real shadow-copy incidents in one week: an nvm-tree Claude Code (2.1.150) silently winning interactive-shell PATH over the pinned 2.1.201 install; a native-installer symlink doing the same earlier; ~490MB of leftover native version blobs; and a user-prefix install invisible to non-interactive shells, which made `cc_ensure_local` reinstall CC on every single update run and silently skipped MCP registration ('claude CLI not found'). The pin machinery (`update-cc`, `cc_ensure_local`) only manages ONE copy — every other copy on the machine drifts silently until it shadows the real one somewhere.

## Fix

**`cc_shadow_scan`** (new, in `scripts/lib/cc_version.sh`; compact mirror in `guardian-gateway.sh`'s `update-cc` op for the host) enforces a single canonical copy. Canonical selection is **pin-verified**: the first candidate (PATH resolution, then `CC_PROBE_DIRS`) that actually reports `$CC_VERSION` — never a bare `command -v`, because an interactive shell's PATH can put a stale copy first, which would otherwise crown the stale copy 'canonical' and delete the good one. **Hard fail-safe: if no copy anywhere is at the pin, nothing is removed.**

Every other copy on a known surface (nvm trees, `~/.claude/local`, `~/.local/bin`, native version blobs, stale npm prefixes) is removed — but only when provably a claude-code install (npm symlink into the package, or native-installer layout); anything ambiguous is warned about and left alone, as are shadowing `alias claude=` lines in rc files (detected, never edited). The canonical's own package directory is never removed, even by a stale second link pointing into it. System-path (`/usr/*`) removals require passwordless sudo or are skipped with a warning; the gateway variant is user-dir-only (never sudo-removes) and runs only after its post-install verify proves the pin.

`cc_ensure_local` also now probes `CC_PROBE_DIRS` before declaring CC absent, so a PATH-blind install is aligned in place instead of reinstalled every run.

## Review round (self-caught before merge)

A code-review agent, verifying the destructive-path logic, **empirically confirmed two ways the first version of this scan could destroy the canonical install it exists to protect** (and briefly deleted this container's own CC while proving it — restored immediately, zero session impact since Linux keeps executing a deleted inode). Both are fixed in the second commit: canonical selection is now pin-verified with the fail-safe described above (was: bare `command -v`, which could crown a stale copy and remove the real one), and the blob sweep / package removal both check against the canonical's own resolved path first (was: unconditional).

## Tests

16 in `tests/test_scripts/test_cc_shadow_scan.py`, sourcing the real lib in a fake $HOME with a sudo-free minimal PATH: removal/keep matrix for every surface, canonical-on-a-scanned-surface survival, no-sudo system-path guard (with a pre-run snapshot so a regression fails loudly on dev boxes), opt-out, alias warning, no-claude-anywhere no-op, gateway surface-parity guard, PATH-blind at-pin no-reinstall — plus the review round's new cases: stale-PATH-first is correctly treated as the shadow (not the canonical), no-pin-anywhere refuses all removal, native canonical is protected, stale link into the canonical package loses only the link, migrate-installer package cleanup.

## E2E verification (live, this container)

- Ran `cc_shadow_scan` for real: no-op (nothing to remove), canonical (`/usr/local/bin/claude` @ 2.1.201) correctly identified.
- **Sabotage test**: recreated the exact 2.1.150 nvm-shadow incident (stale copy first on PATH) in an isolated $HOME — the scan correctly identified the stale copy as the shadow (despite winning PATH) and removed it, while the real system CC stayed untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)