### PR TITLE
fix(update): host-VM sync silently dead — restore guardian redeploy + host pin healing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **`update.sh` was silently skipping the host-VM sync (guardian redeploy + host Node/Claude Code
+  pin healing).** A recent refactor re-indented the two inline Python snippets that read
+  `guardian_remote.yaml`; the resulting parse error was suppressed, the host address resolved
+  empty, and the entire host-side block quietly skipped on every update — guardian code stopped
+  reaching the host and host pin drift went unhealed, while update history still reported the host
+  as healthy. The snippets are now single-line (immune to the indentation class), an unusable
+  guardian config now prints a loud warning and is recorded as a degraded subsystem, and a
+  repo-wide test guards against any shell script reintroducing the indented-snippet shape.
+
 - **Stale duplicate copies of Claude Code are now detected and removed automatically.** If your
   machine ever accumulated a second Claude Code install (an old nvm-tree copy, a native-installer
   leftover, or an install in a directory only interactive shells can see), it could silently shadow

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -146,16 +146,14 @@ _sync_deploy_targets() {
     # ── Update Guardian on host VM (if configured) ──────────
     GUARDIAN_CONFIG="$HOME/.genesis/guardian_remote.yaml"
     if [ -f "$GUARDIAN_CONFIG" ]; then
-        HOST_IP=$("$VENV_DIR/bin/python" -c "
-    import yaml, pathlib
-    cfg = yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text())
-    print(cfg.get('host_ip', ''))
-    " 2>/dev/null || true)
-        HOST_USER=$("$VENV_DIR/bin/python" -c "
-    import yaml, pathlib
-    cfg = yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text())
-    print(cfg.get('host_user', 'ubuntu'))
-    " 2>/dev/null || echo "ubuntu")
+        # Single-line python -c on purpose: a multi-line body picks up the
+        # shell's indentation, which is a top-level IndentationError — the
+        # 2>/dev/null then silently empties HOST_IP and the ENTIRE host sync
+        # (guardian redeploy + Node/CC pin healing) skips on every run.
+        # That exact regression shipped once when this block was re-indented
+        # into a function; test_update_host_sync.py guards the class.
+        HOST_IP=$("$VENV_DIR/bin/python" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_ip', ''))" 2>/dev/null || true)
+        HOST_USER=$("$VENV_DIR/bin/python" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_user', 'ubuntu'))" 2>/dev/null || echo "ubuntu")
         SSH_KEY="$HOME/.ssh/genesis_guardian_ed25519"
 
         if [ -n "$HOST_IP" ] && [ -f "$SSH_KEY" ]; then
@@ -281,6 +279,12 @@ _sync_deploy_targets() {
                 fi
             fi
             echo ""
+        else
+            # guardian_remote.yaml exists but is unusable — never skip silently:
+            # a skipped sync here means guardian redeploy AND host pin healing
+            # are dead, which is exactly the drift this function exists to heal.
+            echo "  WARNING: guardian_remote.yaml present but host_ip unparseable or SSH key missing — host sync SKIPPED"
+            HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_config_unreadable"
         fi
     fi
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -846,6 +846,13 @@ if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
     # pins): a pin bump pulled MANUALLY before this run, or an earlier failed
     # sync, must not leave drift in place just because the merge was a no-op.
     _sync_deploy_targets
+    # Persist any host-side degradation the drift healing just found — this
+    # path exits before the success-path recording, so without this the flag
+    # would only ever reach stdout on no-op runs.
+    if [ -n "$HOST_CC_DEGRADED" ]; then
+        echo "  NOTE: recording degraded subsystem: $HOST_CC_DEGRADED"
+        _record_update_history "success" "" "$HOST_CC_DEGRADED"
+    fi
     echo ""
     echo "  Nothing to do."
     exit 0

--- a/tests/test_scripts/test_update_host_sync.py
+++ b/tests/test_scripts/test_update_host_sync.py
@@ -1,0 +1,128 @@
+"""Host-sync config parsing in scripts/update.sh (`_sync_deploy_targets`).
+
+PR #898 extracted the deploy-target sync into a function and re-indented the
+inline ``python -c`` snippets that parse ``guardian_remote.yaml``. Indented
+top-level Python is an IndentationError; the ``2>/dev/null || true`` swallowed
+it, ``HOST_IP`` resolved empty, and the ENTIRE host block — guardian redeploy
+plus host Node/CC pin healing — silently skipped on every update run, with
+``HOST_CC_DEGRADED`` never set (update_history reported the host healthy).
+
+These tests extract the snippets and the function from the REAL update.sh and
+execute them, so the logic under test is the shipped script, not a copy. A
+class-level guardrail scans every shell script for the indented-multiline
+``python -c`` shape so the regression cannot be reintroduced elsewhere.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+UPDATE_SH = SCRIPTS_DIR / "update.sh"
+
+SAMPLE_YAML = 'host_ip: "192.0.2.7"\nhost_user: "opuser"\n'
+
+
+def _extract_snippet(var: str) -> str:
+    """Pull the python -c payload off the HOST_IP=/HOST_USER= line."""
+    for line in UPDATE_SH.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f'{var}=$(') and '-c "' in stripped:
+            m = re.search(r'-c "(.+)" 2>/dev/null', stripped)
+            assert m, f"could not extract -c payload from {var} line: {stripped}"
+            return m.group(1)
+    pytest.fail(f"no single-line {var}= python -c assignment found in update.sh")
+
+
+def _run_snippet(var: str, config_path: Path) -> subprocess.CompletedProcess:
+    code = _extract_snippet(var).replace("$GUARDIAN_CONFIG", str(config_path))
+    return subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+
+
+def test_host_ip_snippet_parses_and_reads_config(tmp_path):
+    """The exact shipped snippet must be valid Python and yield host_ip.
+
+    With the pre-fix indented body this fails with IndentationError.
+    """
+    cfg = tmp_path / "guardian_remote.yaml"
+    cfg.write_text(SAMPLE_YAML)
+    result = _run_snippet("HOST_IP", cfg)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "192.0.2.7"
+
+
+def test_host_user_snippet_parses_and_defaults(tmp_path):
+    cfg = tmp_path / "guardian_remote.yaml"
+    cfg.write_text(SAMPLE_YAML)
+    result = _run_snippet("HOST_USER", cfg)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "opuser"
+
+    cfg.write_text('host_ip: "192.0.2.7"\n')
+    result = _run_snippet("HOST_USER", cfg)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ubuntu"
+
+
+def test_no_indented_multiline_python_bodies_in_shell_scripts():
+    """Class guardrail: a multi-line ``python -c "`` whose body's first line is
+    indented is a top-level IndentationError waiting behind 2>/dev/null.
+
+    Unindented multi-line bodies (first line at column 0) are fine and exist
+    legitimately (e.g. the network-identity block in update.sh).
+    """
+    violations = []
+    for script in sorted(SCRIPTS_DIR.rglob("*.sh")):
+        text = script.read_text()
+        for m in re.finditer(r'-c "\n[ \t]+', text):
+            line_no = text[: m.start()].count("\n") + 1
+            violations.append(f"{script.relative_to(REPO_ROOT)}:{line_no}")
+    assert not violations, (
+        "indented multi-line python -c body (silent IndentationError under "
+        f"2>/dev/null): {violations} — inline the snippet on one line or "
+        "start its body at column 0"
+    )
+
+
+def _extract_sync_function() -> str:
+    text = UPDATE_SH.read_text()
+    start = text.index("_sync_deploy_targets() {")
+    end = text.index("\n}", start) + 2
+    return text[start:end]
+
+
+def test_unusable_guardian_config_warns_and_marks_degraded(tmp_path):
+    """Config present but unusable (here: SSH key absent) must be LOUD:
+    warning on stdout + guardian_config_unreadable in HOST_CC_DEGRADED,
+    never a silent skip."""
+    home = tmp_path / "home"
+    (home / ".genesis").mkdir(parents=True)
+    (home / ".genesis" / "guardian_remote.yaml").write_text(SAMPLE_YAML)
+
+    venv = tmp_path / "venv" / "bin"
+    venv.mkdir(parents=True)
+    (venv / "python").symlink_to(sys.executable)
+
+    script_dir = tmp_path / "scripts"  # no lib/cc_version.sh → CC sync skips
+    script_dir.mkdir()
+
+    harness = (
+        f"HOME={home}\nVENV_DIR={tmp_path / 'venv'}\nSCRIPT_DIR={script_dir}\n"
+        f"GENESIS_ROOT={tmp_path}\n"
+        + _extract_sync_function()
+        + '\n_sync_deploy_targets\necho "DEGRADED=$HOST_CC_DEGRADED"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr
+    assert "host sync SKIPPED" in result.stdout
+    assert "DEGRADED=guardian_config_unreadable" in result.stdout


### PR DESCRIPTION
## Problem

The refactor that extracted the deploy-target sync into `_sync_deploy_targets()` re-indented the two inline `python -c` snippets that parse `guardian_remote.yaml`. Indented top-level Python raises `IndentationError`; the `2>/dev/null || true` suppressed it, `HOST_IP` resolved empty, and the **entire host-VM block — guardian code redeploy plus host Node/Claude Code pin healing — silently skipped on every `update.sh` run** since that refactor. `HOST_CC_DEGRADED` was never set, so update history kept reporting the host as healthy while drift healing was dead.

Observed live: a gateway-touching release never reached the deployed gateway through `update.sh`. (The run that pulled the refactor itself still synced correctly, because bash keeps executing the pre-pull script from the old inode — which masked the regression once.)

## Fix

- **Single-line both snippets** — immune to the indentation class entirely.
- **Loud failure instead of silent skip**: when `guardian_remote.yaml` exists but `host_ip` is unparseable or the SSH key is missing, print a warning and record `guardian_config_unreadable` as a degraded subsystem.
- **No-op runs persist the flag too**: the "Already up to date" path ran the sync but exited before any update-history recording, so degradation found there only ever reached stdout (pre-existing gap, surfaced in review).

## Tests

`tests/test_scripts/test_update_host_sync.py` extracts and executes the *shipped* snippets and function from the real `update.sh` (no copies):
- both snippets parse and read a config correctly (fails with `IndentationError` pre-fix),
- `host_user` defaulting,
- unusable-config path warns and marks degraded (hermetic sandbox, no network),
- repo-wide guardrail failing any shell script that reintroduces an indented multi-line `python -c` body (legitimate column-0 multi-line bodies pass).

All four tests fail against the pre-fix script and pass with the fix. A live run of the fixed function against a real install verified the host probe, Node/CC pin checks, and container sync all execute again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)