### PR TITLE
Backup scheduling via systemd timer + honest health readouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ reflection) → Services (routing, memory, outreach, autonomy, surplus) → Data
 - **Qdrant**: `localhost:6333` (systemd service)
 - **GitHub**: configured in `~/.genesis/config/genesis.yaml` (`github.user` / `github.public_repo`)
 - **Database**: `~/genesis/data/genesis.db` (NOT `~/genesis/genesis.db`)
-- **Backups**: encrypted 6h cron via `scripts/backup.sh` → your private
+- **Backups**: encrypted, every 6h via `genesis-backup.timer` (systemd user
+  unit; enable deliberately after configuring) running `scripts/backup.sh` → your private
   `genesis-backups` repo (SQLite, Qdrant, memory, transcripts, config,
   secrets). Restore via `scripts/restore.sh` or `python -m genesis restore`.
 - **Env scrub**: `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` is NOT used — Genesis
@@ -53,7 +54,8 @@ systemctl --user list-units 'genesis-*' --all    # All units
 
 Other units: `genesis-bridge.service` (Telegram relay, on-demand),
 `genesis-tmp-watchgod.service` (/tmp protection), `genesis-watchdog.timer`
-(health check), `genesis-disk-hygiene.timer` (daily worktree reaping, cache reclaim, `~/tmp`
+(health check), `genesis-backup.timer` (6h encrypted backup via
+`scripts/backup.sh`), `genesis-disk-hygiene.timer` (daily worktree reaping, cache reclaim, `~/tmp`
 prune, and label-aware attention-snapshot GC; see `scripts/disk_hygiene.sh`). MCP servers are CC child processes
 (not systemd) — code changes take effect on next CC session start.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Without these, Genesis uses cloud embedding APIs. With them: private, faster, fr
 
 Your Genesis install is one operational system: the public `GENesis-AGI` codebase, your private fork for customizations, and your private encrypted backups repo. See [`.claude/docs/your-genesis.md`](.claude/docs/your-genesis.md) for the full model.
 
-- **Backup** — runs every 6h via cron. SQLite, Qdrant snapshots, memory, transcripts, secrets—GPG-encrypted before push.
+- **Backup** — runs every 6h via a systemd user timer (enable it once configured — see [SETUP.md](SETUP.md)). SQLite, Qdrant snapshots, memory, transcripts, secrets—GPG-encrypted before push.
 - **Restore** — `git clone <your-fork>` → `scripts/bootstrap.sh` → `scripts/restore.sh`. Back in minutes.
 - **Contribute** — a distributed bug fixing pipeline automatically detects eligible fixes, pushes them to GitHub for inspection, and opens upstream PRs.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -102,7 +102,8 @@ Populates the voice exemplar library with samples of your writing style.
 
 ## Backups
 
-Backups run every 6 hours via cron and split into two tiers:
+Backups run every 6 hours via the `genesis-backup.timer` systemd user unit
+and split into two tiers:
 
 - **Tier 1** (git → GitHub): Memory files, configs, secrets (~1MB). Automatic.
 - **Tier 2** (smbclient → NAS/remote): Qdrant snapshots, SQL dumps (~200MB+). Opt-in.
@@ -119,6 +120,18 @@ GENESIS_BACKUP_NAS_PASS=password
 ```
 
 Requires `smbclient` (`sudo apt-get install smbclient`).
+
+Bootstrap installs the timer's unit files but does **not** enable them —
+scheduling a backup that silently leaves your database local-only would give a
+false sense of safety. Once `GENESIS_BACKUP_REPO` and
+`GENESIS_BACKUP_PASSPHRASE` are set (and Tier 2, if you want off-site copies of
+the large payloads), enable it deliberately and verify one run:
+
+```bash
+systemctl --user enable --now genesis-backup.timer
+systemctl --user start genesis-backup.service   # fire one run now
+cat ~/.genesis/backup_status.json               # expect "success":true
+```
 
 ## Verify Installation
 

--- a/docs/architecture/genesis-v3-survivable-architecture.md
+++ b/docs/architecture/genesis-v3-survivable-architecture.md
@@ -484,7 +484,7 @@ what's NOT in this list.
 |---|---|---|---|---|
 | Qdrant data deletion | Tests without delete guard | Production data lost | Delete guard + backup verify | 2026-03-16 |
 | Backup failure | Passphrase not set, push failure | No recovery point | Backup log monitoring | Ongoing (secrets) |
-| Cron job failure | Path error, permission issue | Backups/inbox sync stop | Cron output monitoring | Not yet hit |
+| Scheduler job failure | Path error, permission issue | Backups (genesis-backup.timer) / inbox sync (cron) stop | Timer + cron output monitoring | Not yet hit |
 
 ### What's NOT in this list (prompt for forecast LLM)
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Genesis automated backup — runs every 6h via cron.
+# Genesis automated backup — runs every 6h via the genesis-backup.timer
+# systemd user unit. Unit files are installed by bootstrap.sh; enabling is a
+# deliberate step once backup is configured (see SETUP.md "Backups"):
+#   systemctl --user enable --now genesis-backup.timer
 # Writes your Genesis state to <your-gh-user>/genesis-backups.
 # All PII-bearing payloads are GPG-encrypted with GENESIS_BACKUP_PASSPHRASE.
 #
@@ -89,7 +92,7 @@ _send_telegram() {
 
 # Large intermediate files (the multi-hundred-MB SQLite .dump) must NOT land in the
 # inherited TMPDIR: for a CC-launched run that is ~/.genesis/cc-tmp (the watchgod-policed
-# "oxygen" folder — filling it kills CC sessions); for the 6h cron it is /tmp (tmpfs/RAM).
+# "oxygen" folder — filling it kills CC sessions); for the 6h timer unit it is /tmp (tmpfs/RAM).
 # Route them to a dedicated on-disk dir, per the tmp_filesystem_limit procedure ("use ~/tmp
 # for large temporary files"). We do NOT export TMPDIR — only the big files move; everything
 # else (and Claude Code) keeps its normal TMPDIR.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -684,11 +684,14 @@ if [ -f "$GENESIS_ROOT/secrets.env" ]; then
     fi
 fi
 
-# NOTE: Backups are NOT auto-enabled here. Backup is a deliberate setup step
-# (both tiers + passphrase + a verify run) handled in the onboarding skill —
-# auto-installing a 6h cron on bootstrap just because GENESIS_BACKUP_REPO is set
-# gives a false sense of safety (large data is local-only until Tier 2/NAS is
-# configured) and isn't a switch to flip for every new user.
+# NOTE: Backups are NOT auto-enabled here. The genesis-backup.{service,timer}
+# unit FILES are installed by the template-sync loop above, but the timer is
+# left disabled: backup is a deliberate setup step (both tiers + passphrase +
+# a verify run — see SETUP.md "Backups") handled in the onboarding skill.
+# Auto-enabling a 6h schedule on bootstrap just because GENESIS_BACKUP_REPO is
+# set gives a false sense of safety (large data is local-only until Tier 2/NAS
+# is configured) and isn't a switch to flip for every new user. Enable with:
+#   systemctl --user enable --now genesis-backup.timer
 
 # --- VNC stack (collaborative browser mode) ---
 echo "--- Setting up VNC stack ---"

--- a/scripts/systemd/genesis-backup.service.template
+++ b/scripts/systemd/genesis-backup.service.template
@@ -1,0 +1,24 @@
+[Unit]
+Description=Genesis Backup — Tier-1 encrypted push (+ Tier-2 off-site when configured)
+After=genesis-server.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=__REPO_DIR__
+ExecStart=/bin/bash __REPO_DIR__/scripts/backup.sh
+# A large install's SQLite dump + GPG + Qdrant snapshots + Tier-2 upload over
+# LAN can run well past the 90s default TimeoutStartSec, which would SIGTERM a
+# healthy backup mid-encryption. Project floor (timeout policy): 2h.
+TimeoutStartSec=7200
+# git push authenticates via ~/.gitconfig's `gh auth git-credential` helper
+# (/usr/bin/gh, hosts.yml-backed) — no shell env or GH_TOKEN needed. sqlite3,
+# gpg, curl, smbclient all live in the system paths below.
+Environment=PATH=__VENV__/bin:/usr/local/bin:/usr/bin:/bin
+# NOTE: no TMPDIR override. backup.sh routes its large intermediates to ~/tmp
+# itself (GENESIS_BIG_TMP); pointing TMPDIR at the watchgod-policed cc-tmp
+# would risk killing CC sessions on a big dump.
+StandardOutput=journal
+StandardError=journal
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=%h

--- a/scripts/systemd/genesis-backup.service.template
+++ b/scripts/systemd/genesis-backup.service.template
@@ -20,5 +20,11 @@ Environment=PATH=__VENV__/bin:/usr/local/bin:/usr/bin:/bin
 StandardOutput=journal
 StandardError=journal
 NoNewPrivileges=yes
-ProtectSystem=strict
-ReadWritePaths=%h
+# No ProtectSystem=strict / ReadWritePaths sandbox here (unlike the watchdog and
+# disk-hygiene units, which only touch $HOME). backup.sh orchestrates external
+# tools that write OUTSIDE $HOME: gpg drives gpg-agent over its socket in
+# /run/user/%U, and the Tier-2 COMPLETE marker uses a bare `mktemp` in /tmp —
+# both are read-only under ProtectSystem=strict, so a hardened unit would fail
+# Tier-1 encryption (non-deterministically, depending on whether gpg-agent is
+# already alive) and the Tier-2 marker outright. The sandbox also delivers
+# little for an unprivileged user unit that cannot write system paths regardless.

--- a/scripts/systemd/genesis-backup.timer.template
+++ b/scripts/systemd/genesis-backup.timer.template
@@ -1,0 +1,13 @@
+[Unit]
+Description=Genesis Backup — every 6h
+
+[Timer]
+# :10 offset avoids the :00 cron reapers; Persistent catches up a missed
+# window after downtime. systemd skips a fire while the service is still
+# running, so overlapping backups can't stack.
+OnCalendar=00/6:10
+Persistent=true
+AccuracySec=5min
+
+[Install]
+WantedBy=timers.target

--- a/src/genesis/mcp/health/ego_calibration.py
+++ b/src/genesis/mcp/health/ego_calibration.py
@@ -31,8 +31,12 @@ async def _impl_ego_calibration_status(domain: str = "ego") -> dict:
         return {
             "status": "no_data",
             "message": (
-                f"No calibration snapshots yet for domain={domain!r}. Computed at "
-                f"09:00/21:00 once the Outcome Bus has ground-truth (T1) rows."
+                f"No calibration snapshots yet for domain={domain!r}. Computed "
+                f"at 09:00/21:00 once the Outcome Bus has {domain}-sourced "
+                f"ground-truth rows (calibration_pairs requires "
+                f"source={domain!r} with stated confidence; T1 volume from "
+                f"other sources doesn't count). Expected while that source's "
+                f"proposal loop has no resolved, confidence-stated outcomes."
             ),
         }
 

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -64,49 +64,47 @@ def _annotate_staleness(jobs: dict) -> dict:
 
 
 # Module-level so tests can monkeypatch the location.
-_CAPABILITIES_FILE = Path.home() / ".genesis" / "capabilities.json"
+_MANIFEST_FILE = Path.home() / ".genesis" / "bootstrap_manifest.json"
 
 
-def _manifest_from_capabilities_file() -> dict | None:
-    """Reconstruct the bootstrap manifest from ``~/.genesis/capabilities.json``.
+def _read_persisted_manifest() -> dict | None:
+    """Read the manifest genesis-server persisted at its last bootstrap.
 
-    MCP servers run as separate processes from genesis-server, so the
-    in-process runtime singleton never bootstraps here. The server persists
-    a manifest-derived capabilities file at the tail of its own bootstrap
-    (``runtime/_capabilities.py``) — map its statuses back to manifest form.
-    Returns None when the file is missing or unreadable.
+    MCP servers run in a separate CC-child process that never bootstraps the
+    runtime, so the in-process singleton has no manifest. genesis-server writes
+    the verbatim manifest to ``~/.genesis/bootstrap_manifest.json`` at the tail
+    of its own bootstrap (``runtime/_capabilities.py``); read it directly — no
+    reverse mapping, exact fidelity. Returns None when the file is missing or
+    unreadable so the caller can report an honest empty result.
+
+    This is last-known state, NOT a liveness signal: the file survives a server
+    crash, so it never asserts the server is currently up. ``bootstrapped`` is
+    reported False (this process did not bootstrap); the populated manifest is
+    labelled ``source='persisted_manifest'`` with ``persisted_at`` and a pointer
+    to ``subsystem_heartbeats`` for current liveness.
     """
-    if not _CAPABILITIES_FILE.exists():
-        return None
     try:
-        caps = json.loads(_CAPABILITIES_FILE.read_text())
-        persisted_at = datetime.fromtimestamp(
-            _CAPABILITIES_FILE.stat().st_mtime, tz=UTC
-        ).isoformat()
+        raw = json.loads(_MANIFEST_FILE.read_text())
+    except FileNotFoundError:
+        return None
     except (json.JSONDecodeError, OSError) as exc:
-        logger.error("Failed to read %s: %s", _CAPABILITIES_FILE, exc)
+        logger.error("Failed to read %s: %s", _MANIFEST_FILE, exc)
         return None
 
-    manifest: dict[str, str] = {}
-    for name, info in caps.items():
-        if name.startswith("module:"):
-            continue  # module-registry entries, not bootstrap init steps
-        status = info.get("status", "unknown")
-        if status == "active":
-            manifest[name] = "ok"
-        elif status == "failed":
-            manifest[name] = f"failed: {info.get('error', 'unknown')}"
-        else:
-            manifest[name] = status  # degraded / disabled / unknown
+    manifest = raw.get("manifest") if isinstance(raw, dict) else None
+    if not isinstance(manifest, dict):
+        logger.error("Malformed bootstrap manifest file: %s", _MANIFEST_FILE)
+        return None
+
     return {
-        "bootstrapped": True,
+        "bootstrapped": False,  # THIS process didn't bootstrap; liveness ≠ file
         "manifest": manifest,
-        "source": "capabilities_file",
-        "persisted_at": persisted_at,
+        "source": "persisted_manifest",
+        "persisted_at": raw.get("persisted_at"),
         "note": (
-            "Out-of-process read: reconstructed from ~/.genesis/"
-            "capabilities.json, persisted by genesis-server at its last "
-            "bootstrap. Check subsystem_heartbeats for current liveness."
+            "Last-known manifest persisted by genesis-server at its last "
+            "bootstrap (this MCP process does not bootstrap the runtime). "
+            "Does NOT indicate current liveness — check subsystem_heartbeats."
         ),
     }
 
@@ -124,8 +122,8 @@ async def _impl_bootstrap_manifest() -> dict:
             }
         # Not bootstrapped in THIS process — the normal case for MCP
         # servers (CC child processes, separate from genesis-server).
-        # Fall back to the manifest the server persisted at bootstrap.
-        persisted = _manifest_from_capabilities_file()
+        # Serve the manifest genesis-server persisted at its bootstrap.
+        persisted = _read_persisted_manifest()
         if persisted is not None:
             return persisted
         return {

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -62,23 +63,83 @@ def _annotate_staleness(jobs: dict) -> dict:
     return annotated
 
 
+# Module-level so tests can monkeypatch the location.
+_CAPABILITIES_FILE = Path.home() / ".genesis" / "capabilities.json"
+
+
+def _manifest_from_capabilities_file() -> dict | None:
+    """Reconstruct the bootstrap manifest from ``~/.genesis/capabilities.json``.
+
+    MCP servers run as separate processes from genesis-server, so the
+    in-process runtime singleton never bootstraps here. The server persists
+    a manifest-derived capabilities file at the tail of its own bootstrap
+    (``runtime/_capabilities.py``) — map its statuses back to manifest form.
+    Returns None when the file is missing or unreadable.
+    """
+    if not _CAPABILITIES_FILE.exists():
+        return None
+    try:
+        caps = json.loads(_CAPABILITIES_FILE.read_text())
+        persisted_at = datetime.fromtimestamp(
+            _CAPABILITIES_FILE.stat().st_mtime, tz=UTC
+        ).isoformat()
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error("Failed to read %s: %s", _CAPABILITIES_FILE, exc)
+        return None
+
+    manifest: dict[str, str] = {}
+    for name, info in caps.items():
+        if name.startswith("module:"):
+            continue  # module-registry entries, not bootstrap init steps
+        status = info.get("status", "unknown")
+        if status == "active":
+            manifest[name] = "ok"
+        elif status == "failed":
+            manifest[name] = f"failed: {info.get('error', 'unknown')}"
+        else:
+            manifest[name] = status  # degraded / disabled / unknown
+    return {
+        "bootstrapped": True,
+        "manifest": manifest,
+        "source": "capabilities_file",
+        "persisted_at": persisted_at,
+        "note": (
+            "Out-of-process read: reconstructed from ~/.genesis/"
+            "capabilities.json, persisted by genesis-server at its last "
+            "bootstrap. Check subsystem_heartbeats for current liveness."
+        ),
+    }
+
+
 async def _impl_bootstrap_manifest() -> dict:
     try:
         from genesis.runtime import GenesisRuntime
 
         rt = GenesisRuntime.instance()
+        if rt.is_bootstrapped:
+            return {
+                "bootstrapped": True,
+                "manifest": rt.bootstrap_manifest,
+                "source": "runtime",
+            }
+        # Not bootstrapped in THIS process — the normal case for MCP
+        # servers (CC child processes, separate from genesis-server).
+        # Fall back to the manifest the server persisted at bootstrap.
+        persisted = _manifest_from_capabilities_file()
+        if persisted is not None:
+            return persisted
         return {
-            "bootstrapped": rt.is_bootstrapped,
-            "manifest": rt.bootstrap_manifest,
+            "bootstrapped": False,
+            "manifest": {},
+            "source": "runtime",
         }
     except (ImportError, AttributeError, RuntimeError):
         # Narrow catch: runtime module genuinely unimportable, singleton
         # __init__ failed, or runtime attribute access failure. In the
-        # common "standalone mode" path the runtime IS importable and
-        # the happy path returns {"bootstrapped": False, "manifest": {}}
-        # via the real singleton — this except branch only fires on a
-        # real bug, which is why it logs at ERROR. A broader catch
-        # would hide those bugs.
+        # common "standalone mode" path the runtime IS importable and the
+        # happy path answers from the persisted capabilities file — this
+        # except branch only fires on a real bug, which is why it logs at
+        # ERROR. A broader catch would hide those bugs.
         logger.error(
             "bootstrap_manifest fallback fired — runtime unreachable",
             exc_info=True,

--- a/src/genesis/mcp/health/self_improvement_status.py
+++ b/src/genesis/mcp/health/self_improvement_status.py
@@ -59,7 +59,11 @@ async def _impl_self_improvement_status() -> dict:
             "status": "no_data",
             "message": (
                 "No ego calibration snapshot yet — computed at 09:00/21:00 once "
-                "the Outcome Bus has ground-truth (T1) rows."
+                "the Outcome Bus has ego-sourced ground-truth rows "
+                "(calibration_pairs requires source='ego' with stated "
+                "confidence; T1 volume from other sources doesn't count). "
+                "Expected while the ego-proposal loop has no resolved "
+                "proposals — not a pipeline fault."
             ),
         }
     else:

--- a/src/genesis/runtime/_capabilities.py
+++ b/src/genesis/runtime/_capabilities.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -140,3 +141,45 @@ def write_capabilities_file(runtime: GenesisRuntime) -> None:
         logger.info("Capabilities file written: %d entries", len(capabilities))
     except OSError:
         logger.error("Failed to write capabilities file", exc_info=True)
+
+    _write_bootstrap_manifest_file(runtime)
+
+
+def _write_bootstrap_manifest_file(runtime: GenesisRuntime) -> None:
+    """Persist the raw bootstrap manifest to ``~/.genesis/bootstrap_manifest.json``.
+
+    ``capabilities.json`` above is a lossy human-facing projection (manifest
+    string → status/description triple). This sibling file preserves the
+    verbatim ``runtime._bootstrap_manifest`` so out-of-process readers (the
+    ``bootstrap_manifest`` MCP tool, which runs in a separate CC-child process
+    that never bootstraps the runtime) get exact fidelity with no reverse
+    mapping. Best-effort: a write failure here must not fail bootstrap.
+
+    In ``readonly`` bootstrap mode we do NOT overwrite the primary runtime's
+    file — a readonly probe's manifest would clobber the real one.
+    """
+    if getattr(runtime, "_bootstrap_mode", "") == "readonly":
+        return
+
+    manifest_file = Path.home() / ".genesis" / "bootstrap_manifest.json"
+    payload = {
+        "bootstrapped": True,
+        "manifest": dict(runtime._bootstrap_manifest),
+        "persisted_at": datetime.now(UTC).isoformat(),
+    }
+    try:
+        manifest_file.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=manifest_file.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(payload, f, indent=2)
+            os.replace(tmp_path, manifest_file)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+        logger.info(
+            "Bootstrap manifest persisted: %d entries", len(payload["manifest"])
+        )
+    except OSError:
+        logger.error("Failed to write bootstrap manifest file", exc_info=True)

--- a/src/genesis/skills/onboarding/SKILL.md
+++ b/src/genesis/skills/onboarding/SKILL.md
@@ -222,12 +222,14 @@ are, not asking for keys. Let the user choose their comfort level.
    `~/.genesis/backup_status.json` shows `"success": true` (and
    `"tier2_status": "ok"` if a NAS was configured).
 
-9. **Install the 6h backup cron — only after the verify run passed.** Add it if
-   absent (`crontab -l 2>/dev/null | grep -q 'backup\.sh'`):
-   `0 */6 * * * $HOME/genesis/scripts/backup.sh >> $HOME/genesis/logs/backup.log 2>&1`
-   (`mkdir -p $HOME/genesis/logs` first). This is done HERE, deliberately —
-   never auto-installed at bootstrap — so backups are an opt-in, verified setup,
-   not a switch flipped for every install.
+9. **Enable the 6h backup timer — only after the verify run passed.**
+   `systemctl --user enable --now genesis-backup.timer` (the unit files are
+   installed by bootstrap but left disabled). Confirm with
+   `systemctl --user list-timers genesis-backup.timer`. This is done HERE,
+   deliberately — never auto-enabled at bootstrap — so backups are an opt-in,
+   verified setup, not a switch flipped for every install. (Do NOT also add a
+   crontab entry — the timer is the single scheduler; two would double every
+   backup.)
 
 ---
 

--- a/tests/test_mcp/test_standalone_health.py
+++ b/tests/test_mcp/test_standalone_health.py
@@ -137,6 +137,55 @@ class TestStandaloneBootstrapAndJobHealth:
         # Should return a dict (either real data or graceful unavailable)
         assert isinstance(result, dict)
 
+    async def test_bootstrap_manifest_falls_back_to_capabilities_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Out-of-process (MCP) reads answer from the persisted capabilities file."""
+        from genesis.mcp.health import manifest as manifest_mod
+
+        cap_file = tmp_path / "capabilities.json"
+        cap_file.write_text(json.dumps({
+            "db": {"status": "active", "description": "SQLite"},
+            "outreach": {"status": "degraded", "description": "Outreach"},
+            "voice": {"status": "failed", "description": "Voice", "error": "no api key"},
+            "module:crypto_ops": {"status": "active", "description": "module"},
+        }))
+        monkeypatch.setattr(manifest_mod, "_CAPABILITIES_FILE", cap_file)
+
+        result = manifest_mod._manifest_from_capabilities_file()
+        assert result is not None
+        assert result["bootstrapped"] is True
+        assert result["source"] == "capabilities_file"
+        assert result["manifest"] == {
+            "db": "ok",
+            "outreach": "degraded",
+            "voice": "failed: no api key",
+        }
+        assert "module:crypto_ops" not in result["manifest"]
+        assert result["persisted_at"]  # ISO timestamp present
+
+    async def test_bootstrap_manifest_missing_file_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No capabilities file → fallback declines (caller reports empty manifest)."""
+        from genesis.mcp.health import manifest as manifest_mod
+
+        monkeypatch.setattr(
+            manifest_mod, "_CAPABILITIES_FILE", tmp_path / "nope.json"
+        )
+        assert manifest_mod._manifest_from_capabilities_file() is None
+
+    async def test_bootstrap_manifest_corrupt_file_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unparseable capabilities file → fallback declines instead of raising."""
+        from genesis.mcp.health import manifest as manifest_mod
+
+        cap_file = tmp_path / "capabilities.json"
+        cap_file.write_text("{not json")
+        monkeypatch.setattr(manifest_mod, "_CAPABILITIES_FILE", cap_file)
+        assert manifest_mod._manifest_from_capabilities_file() is None
+
     async def test_job_health_does_not_crash(self) -> None:
         """job_health should never crash, even without a running runtime."""
         from genesis.mcp.health_mcp import _impl_job_health

--- a/tests/test_mcp/test_standalone_health.py
+++ b/tests/test_mcp/test_standalone_health.py
@@ -137,54 +137,67 @@ class TestStandaloneBootstrapAndJobHealth:
         # Should return a dict (either real data or graceful unavailable)
         assert isinstance(result, dict)
 
-    async def test_bootstrap_manifest_falls_back_to_capabilities_file(
+    async def test_bootstrap_manifest_reads_persisted_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Out-of-process (MCP) reads answer from the persisted capabilities file."""
+        """Out-of-process (MCP) reads the manifest genesis-server persisted verbatim."""
         from genesis.mcp.health import manifest as manifest_mod
 
-        cap_file = tmp_path / "capabilities.json"
-        cap_file.write_text(json.dumps({
-            "db": {"status": "active", "description": "SQLite"},
-            "outreach": {"status": "degraded", "description": "Outreach"},
-            "voice": {"status": "failed", "description": "Voice", "error": "no api key"},
-            "module:crypto_ops": {"status": "active", "description": "module"},
+        mf = tmp_path / "bootstrap_manifest.json"
+        mf.write_text(json.dumps({
+            "bootstrapped": True,
+            "manifest": {"db": "ok", "outreach": "degraded: no token",
+                         "voice": "failed: no api key"},
+            "persisted_at": "2026-07-06T01:00:00+00:00",
         }))
-        monkeypatch.setattr(manifest_mod, "_CAPABILITIES_FILE", cap_file)
+        monkeypatch.setattr(manifest_mod, "_MANIFEST_FILE", mf)
 
-        result = manifest_mod._manifest_from_capabilities_file()
+        result = manifest_mod._read_persisted_manifest()
         assert result is not None
-        assert result["bootstrapped"] is True
-        assert result["source"] == "capabilities_file"
+        # Liveness is NOT asserted from a persisted file — this process
+        # did not bootstrap, so bootstrapped is False even with data present.
+        assert result["bootstrapped"] is False
+        assert result["source"] == "persisted_manifest"
+        # Exact fidelity — "degraded: reason" survives (no lossy round-trip).
         assert result["manifest"] == {
             "db": "ok",
-            "outreach": "degraded",
+            "outreach": "degraded: no token",
             "voice": "failed: no api key",
         }
-        assert "module:crypto_ops" not in result["manifest"]
-        assert result["persisted_at"]  # ISO timestamp present
+        assert result["persisted_at"] == "2026-07-06T01:00:00+00:00"
 
     async def test_bootstrap_manifest_missing_file_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No capabilities file → fallback declines (caller reports empty manifest)."""
+        """No persisted file → reader declines (caller reports empty manifest)."""
         from genesis.mcp.health import manifest as manifest_mod
 
         monkeypatch.setattr(
-            manifest_mod, "_CAPABILITIES_FILE", tmp_path / "nope.json"
+            manifest_mod, "_MANIFEST_FILE", tmp_path / "nope.json"
         )
-        assert manifest_mod._manifest_from_capabilities_file() is None
+        assert manifest_mod._read_persisted_manifest() is None
 
     async def test_bootstrap_manifest_corrupt_file_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Unparseable capabilities file → fallback declines instead of raising."""
+        """Unparseable file → reader declines instead of raising."""
         from genesis.mcp.health import manifest as manifest_mod
 
-        cap_file = tmp_path / "capabilities.json"
-        cap_file.write_text("{not json")
-        monkeypatch.setattr(manifest_mod, "_CAPABILITIES_FILE", cap_file)
-        assert manifest_mod._manifest_from_capabilities_file() is None
+        mf = tmp_path / "bootstrap_manifest.json"
+        mf.write_text("{not json")
+        monkeypatch.setattr(manifest_mod, "_MANIFEST_FILE", mf)
+        assert manifest_mod._read_persisted_manifest() is None
+
+    async def test_bootstrap_manifest_non_dict_manifest_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed manifest value doesn't collapse the whole tool (corr. #3)."""
+        from genesis.mcp.health import manifest as manifest_mod
+
+        mf = tmp_path / "bootstrap_manifest.json"
+        mf.write_text(json.dumps({"bootstrapped": True, "manifest": "oops"}))
+        monkeypatch.setattr(manifest_mod, "_MANIFEST_FILE", mf)
+        assert manifest_mod._read_persisted_manifest() is None
 
     async def test_job_health_does_not_crash(self) -> None:
         """job_health should never crash, even without a running runtime."""

--- a/tests/test_runtime/test_bootstrap_partial.py
+++ b/tests/test_runtime/test_bootstrap_partial.py
@@ -1,7 +1,10 @@
 """Tests for partial bootstrap behavior."""
+import json
+
 import pytest
 
 from genesis.runtime import GenesisRuntime
+from genesis.runtime._capabilities import _write_bootstrap_manifest_file
 
 
 @pytest.mark.asyncio
@@ -30,6 +33,32 @@ async def test_bootstrap_all_critical_ok():
     )
     rt._bootstrapped = critical_ok
     assert rt.is_bootstrapped
+
+
+def test_write_bootstrap_manifest_file_round_trips(tmp_path, monkeypatch):
+    """The persisted manifest is verbatim — the MCP reader gets exact fidelity."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    rt = GenesisRuntime.__new__(GenesisRuntime)
+    rt._bootstrap_mode = "full"
+    rt._bootstrap_manifest = {
+        "db": "ok", "outreach": "degraded: no token", "voice": "failed: no key",
+    }
+    _write_bootstrap_manifest_file(rt)
+
+    written = json.loads((tmp_path / ".genesis" / "bootstrap_manifest.json").read_text())
+    assert written["bootstrapped"] is True
+    assert written["manifest"] == rt._bootstrap_manifest  # no lossy mapping
+    assert written["persisted_at"]
+
+
+def test_write_bootstrap_manifest_file_skips_readonly(tmp_path, monkeypatch):
+    """A readonly probe must not clobber the primary runtime's manifest file."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    rt = GenesisRuntime.__new__(GenesisRuntime)
+    rt._bootstrap_mode = "readonly"
+    rt._bootstrap_manifest = {"db": "ok"}
+    _write_bootstrap_manifest_file(rt)
+    assert not (tmp_path / ".genesis" / "bootstrap_manifest.json").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

The backup script and docs claimed backups ran "every 6h via cron," but no installer ever created that schedule — an install could silently have **no scheduled backups at all**. This wires real scheduling, and fixes three health-readout papercuts found alongside it.

## What changed

**Backup scheduling**
- New `genesis-backup.{service,timer}` systemd user units (6h cadence, `Persistent=true`). Bootstrap installs the unit *files* via its existing template-sync loop but leaves the timer **disabled** — enabling stays a deliberate, verified opt-in (a schedule that quietly leaves your DB local-only is worse than none). Enable with `systemctl --user enable --now genesis-backup.timer`.
- The backup unit intentionally does **not** use `ProtectSystem=strict`/`ReadWritePaths` (unlike the watchdog/disk-hygiene units, which only touch `$HOME`): `backup.sh` drives `gpg-agent` over its socket in `/run/user` and writes a Tier-2 marker via `mktemp` in `/tmp`, both read-only under `strict`.
- Docs (`SETUP.md`, `README.md`, `CLAUDE.md`, `backup.sh` header, onboarding skill) updated from the stale "cron" framing to the timer, with the explicit enable step. The onboarding skill previously installed a 6h **crontab** entry — removed, so it can't double every backup alongside the timer.

**Health readouts**
- `bootstrap_manifest` MCP tool returned `{bootstrapped:false, manifest:{}}` whenever called out-of-process (i.e. always, from the CC-child MCP server). It now reads the manifest genesis-server persists verbatim to `~/.genesis/bootstrap_manifest.json` at bootstrap — exact fidelity, and reported as `source:persisted_manifest` with `bootstrapped:false` so a persisted file can never masquerade as current liveness (use `subsystem_heartbeats` for that).
- Ego-calibration `no_data` message now states its real precondition (ego-sourced ground-truth rows are required) instead of implying the Outcome Bus lacks tier-1 volume. Fixed in both places the message lived.

## Tests
New unit tests for the persisted-manifest writer/reader (round-trip fidelity, readonly-skip, missing/corrupt/malformed-file handling). `78 passed` across affected files, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)