### PR TITLE
Prevent two same-hostname machines from pruning each other's NAS backups

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -121,6 +121,15 @@ GENESIS_BACKUP_NAS_PASS=password
 
 Requires `smbclient` (`sudo apt-get install smbclient`).
 
+Off-site snapshots are written under `<share>/Genesis/<host>/`, where `<host>`
+defaults to the machine's hostname. **If you back up two machines that share a
+hostname to the same NAS, give each a distinct label** or their retention prunes
+will delete each other's snapshots:
+```
+GENESIS_BACKUP_NAS_HOST=this-machine-label
+```
+(`restore.sh` reads the same variable to find the source snapshot dir.)
+
 Bootstrap installs the timer's unit files but does **not** enable them —
 scheduling a backup that silently leaves your database local-only would give a
 false sense of safety. Once `GENESIS_BACKUP_REPO` and

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -20,6 +20,12 @@
 #   GENESIS_DIR                — Genesis repo root (default: ~/genesis)
 #   QDRANT_URL                 — Qdrant server URL (default: http://localhost:6333)
 #   SECRETS_PATH               — Path to secrets.env (default: $GENESIS_DIR/secrets.env)
+#   GENESIS_BACKUP_NAS_HOST    — Tier-2 off-site host dir label under Genesis/
+#                                (default: $(hostname)). SET THIS to a distinct
+#                                value when two machines share a hostname and back
+#                                up to the same NAS, or their GFS prunes delete
+#                                each other's snapshots. Read symmetrically by
+#                                restore.sh to locate the source snapshot dir.
 set -euo pipefail
 
 # Pluggable Tier-2 (off-site) backend interface — selects none/local/smb at runtime
@@ -343,7 +349,13 @@ elif ! backend_available; then
         _T2_STATUS="not_configured"
     fi
 else
-    _T2_HOST_DIR="Genesis/$(hostname)"
+    # Off-site host dir. Defaults to $(hostname), but an explicit
+    # GENESIS_BACKUP_NAS_HOST override is REQUIRED when two machines share a
+    # hostname AND a Tier-2 target: the GFS prune below deletes stale COMPLETE
+    # snapshots under _T2_HOST_DIR, so two same-hostname machines writing to one
+    # NAS would prune each other's history. Symmetric with restore.sh, which
+    # already reads GENESIS_BACKUP_NAS_HOST to locate the source snapshot dir.
+    _T2_HOST_DIR="Genesis/${GENESIS_BACKUP_NAS_HOST:-$(hostname)}"
     # Per-run DATED snapshot dir — a consistent point-in-time copy that restore.sh
     # selects the latest COMPLETE of (and GFS retention prunes).
     _T2_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"


### PR DESCRIPTION
## Why

Tier-2 off-site backups are written under `<share>/Genesis/<host>/`, where `<host>` was hardcoded to `$(hostname)`. When two machines share a hostname and back up to the same NAS, they write into the **same** `Genesis/<hostname>/` directory — and because each backup run's GFS retention prune deletes stale COMPLETE snapshots under that dir, the two machines would eventually **prune each other's backup history**. (Hit live: a second install with hostname `genesis` began writing into another `genesis` machine's snapshot tree.)

## What changed

- `backup.sh` write path now honors an explicit `GENESIS_BACKUP_NAS_HOST` override, defaulting to `$(hostname)`. `restore.sh` **already** reads this same variable to locate the source snapshot dir, so read and write are now symmetric — set it once and both agree.
- Documented the multi-machine case in the `backup.sh` header and `SETUP.md`.

No behavior change for single-machine installs (default stays `$(hostname)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)