### PR TITLE
fix: awareness-tick health-signal correctness (deferred-work alarm, sentinel lock, qdrant self-heal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A false "deferred work backlog" health warning no longer fires every few minutes.** The
+  weekly memory dream-cycle parks a large synthesis worklist that drains a little each day by
+  design; the health check was counting that scheduled batch against the "postponed due to
+  degradation" queue alarm, so it tripped a WARNING on every awareness tick. The alarm now
+  watches only genuine recovery backlog (a stalled worklist still surfaces after a full drain
+  cycle), and the dashboard shows the batch worklist separately from recovery work.
+
+- **Automatic Qdrant restart works again.** The self-heal action that restarts a downed Qdrant
+  targeted the wrong systemd manager and failed with "Access denied," leaving the vector store
+  without automatic recovery. It now restarts the correct user-scoped service.
+
+- **The emergency responder can't stall its own monitoring anymore.** If a Sentinel remediation
+  session was running when a health tick fired, the tick could block behind it long enough to
+  trip the very "monitoring is overdue" alarm the Sentinel exists to prevent. The tick now skips
+  cleanly when a remediation is already in flight.
+
 - **`update.sh` was silently skipping the host-VM sync (guardian redeploy + host Node/Claude Code
   pin healing).** A recent refactor re-indented the two inline Python snippets that read
   `guardian_remote.yaml`; the resulting parse error was suppressed, the host address resolved

--- a/src/genesis/autonomy/remediation.py
+++ b/src/genesis/autonomy/remediation.py
@@ -378,7 +378,11 @@ DEFAULT_REMEDIATIONS: list[RemediationAction] = [
         name="qdrant_restart",
         probe_name="qdrant",
         condition="Qdrant health probe returns DOWN",
-        command=["systemctl", "restart", "qdrant"],
+        # Qdrant is a systemd USER unit (~/.config/systemd/user/qdrant.service);
+        # without --user this targets the system manager and fails with
+        # "Access denied" (rc=4), leaving qdrant self-heal non-functional.
+        # Mirrors awareness_restart below.
+        command=["systemctl", "--user", "restart", "qdrant"],
         governance_level=2,
         reversible=True,
         cooldown_s=300,

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -176,13 +176,18 @@
                           :style="($store.genesisDashboard.health.queues.dead_letters || 0) > 0 ? 'color: #d9534f; font-weight: 700' : 'color: #4caf50'"></span>
                   </div>
                   <div style="font-size: 0.82rem; cursor: default;"
-                       title="Tasks postponed due to service degradation">
+                       title="Tasks postponed due to service degradation (recovery backlog only — scheduled batch worklists are counted separately)">
                     Deferred Pending:
-                    <span x-text="$store.genesisDashboard.health.queues.deferred_work ?? 0"
-                          :style="($store.genesisDashboard.health.queues.deferred_work || 0) > 0 ? 'color: #f0ad4e; font-weight: 700' : 'color: #4caf50'"></span>
-                    <template x-if="$store.genesisDashboard.health.queues.deferred_oldest_age_seconds > 0">
+                    <span x-text="$store.genesisDashboard.health.queues.deferred_recovery ?? 0"
+                          :style="($store.genesisDashboard.health.queues.deferred_recovery || 0) > 0 ? 'color: #f0ad4e; font-weight: 700' : 'color: #4caf50'"></span>
+                    <template x-if="($store.genesisDashboard.health.queues.deferred_recovery || 0) > 0 && $store.genesisDashboard.health.queues.deferred_oldest_age_seconds > 0">
                       <span style="font-size: 0.68rem; color: var(--color-text-secondary);"
                             x-text="'(oldest: ' + (() => { const s = $store.genesisDashboard.health.queues.deferred_oldest_age_seconds; return s > 3600 ? Math.round(s/3600) + 'h' : Math.round(s/60) + 'm'; })() + ')'"></span>
+                    </template>
+                    <template x-if="($store.genesisDashboard.health.queues.deferred_worklist || 0) > 0">
+                      <span style="font-size: 0.68rem; color: var(--color-text-secondary);"
+                            :title="'Dream-synthesis worklist — drains on a daily cadence, not stuck'"
+                            x-text="'(+' + $store.genesisDashboard.health.queues.deferred_worklist + ' worklist)'"></span>
                     </template>
                   </div>
                   <template x-if="($store.genesisDashboard.health.queues.deferred_processing || 0) > 0">

--- a/src/genesis/db/crud/deferred_work.py
+++ b/src/genesis/db/crud/deferred_work.py
@@ -124,6 +124,57 @@ async def count_pending(
     return int(row[0])
 
 
+async def count_pending_in(
+    db: aiosqlite.Connection,
+    *,
+    work_types: frozenset[str],
+) -> int:
+    """Count pending items whose work_type is in ``work_types`` (empty → 0)."""
+    if not work_types:
+        return 0
+    placeholders = ",".join("?" * len(work_types))
+    cursor = await db.execute(
+        f"SELECT COUNT(*) FROM deferred_work_queue "
+        f"WHERE status = 'pending' AND work_type IN ({placeholders})",
+        list(work_types),
+    )
+    row = await cursor.fetchone()
+    return int(row[0])
+
+
+async def count_recovery_pending(
+    db: aiosqlite.Connection,
+    *,
+    batch_work_types: frozenset[str],
+    stale_cutoff_iso: str,
+) -> int:
+    """Count pending items that should trip the recovery-backlog depth alarm.
+
+    Genuine resilience-recovery deferred work always counts. Batch worklist
+    items (e.g. the dream-synthesis worklist, which legitimately parks hundreds
+    of slices and drains over a cadence) are EXCLUDED — unless they have been
+    pending past a full drain cycle (``deferred_at < stale_cutoff_iso``), which
+    means the drain has actually stalled and the backlog is real again.
+
+    With no batch types the count is simply all pending (identical to
+    ``count_pending``), so callers can pass an empty set to opt out.
+    """
+    if not batch_work_types:
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM deferred_work_queue WHERE status = 'pending'"
+        )
+        row = await cursor.fetchone()
+        return int(row[0])
+    placeholders = ",".join("?" * len(batch_work_types))
+    cursor = await db.execute(
+        f"SELECT COUNT(*) FROM deferred_work_queue WHERE status = 'pending' "
+        f"AND (work_type NOT IN ({placeholders}) OR deferred_at < ?)",
+        [*batch_work_types, stale_cutoff_iso],
+    )
+    row = await cursor.fetchone()
+    return int(row[0])
+
+
 async def drain_by_priority(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -236,8 +236,17 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     queues = snap.get("queues", {})
     # Only check fields that represent actual queue depths — exclude
     # cumulative counters (embedded_total), timestamps, error messages, etc.
+    #
+    # NOTE: we alarm on `deferred_recovery` (genuine recovery backlog), NOT the
+    # raw `deferred_work` total. The raw total includes scheduled batch worklists
+    # (dream synthesis, ~500 slices draining over a week) that legitimately sit
+    # hundreds-deep by design — alerting on the raw total fired `queue:deferred_work`
+    # WARNING on every awareness tick. `deferred_recovery` folds a stalled worklist
+    # back in (see resilience/deferred_work.py:STALE_WORKLIST_DAYS), so a genuinely
+    # broken drain still surfaces. `deferred_work`/`deferred_worklist` stay in the
+    # snapshot for honest display but are not depth-alarmed here.
     _QUEUE_DEPTH_FIELDS = {
-        "pending_embeddings", "dead_letters", "deferred_work",
+        "pending_embeddings", "dead_letters", "deferred_recovery",
         "deferred_processing", "deferred_stuck", "failed_embeddings",
         "discarded_count",
     }

--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -154,14 +154,25 @@ async def queues(
     errors: list[str] = []
 
     deferred = None
+    # Recovery-backlog subset (what the depth alarm should watch) vs the raw
+    # total (honest display). Batch worklists like the dream-synthesis slice
+    # legitimately park hundreds of pending items and drain on a cadence — they
+    # inflate the raw total but are NOT stuck recovery work, so alerting on the
+    # raw total cries wolf on every tick. Mirror the dead_letter raw-vs-stuck
+    # split below.
+    deferred_recovery = None
+    deferred_worklist = 0
     if deferred_queue:
         try:
             deferred = await deferred_queue.count_pending()
+            deferred_recovery = await deferred_queue.count_recovery_pending()
+            deferred_worklist = await deferred_queue.count_worklist_pending()
         except Exception:
             errors.append("deferred_work: query failed")
             logger.error("Failed to query deferred work queue", exc_info=True)
     else:
         deferred = 0
+        deferred_recovery = 0
 
     dead = None
     if dead_letter:
@@ -329,6 +340,13 @@ async def queues(
 
     result = {
         "deferred_work": deferred,
+        # Alarm-eligible subset: genuine recovery backlog, excluding scheduled
+        # batch worklists unless they've stalled past a full drain cycle. This
+        # is what errors.py:_QUEUE_DEPTH_FIELDS thresholds on (not the raw total).
+        "deferred_recovery": deferred_recovery,
+        # Batch worklist depth (dream synthesis etc.) — display only, never
+        # summed into the depth alarm.
+        "deferred_worklist": deferred_worklist,
         "deferred_oldest_age_seconds": deferred_oldest_s,
         "deferred_processing": deferred_processing,
         "deferred_stuck": deferred_stuck,

--- a/src/genesis/resilience/deferred_work.py
+++ b/src/genesis/resilience/deferred_work.py
@@ -31,6 +31,26 @@ REFRESH = "refresh"
 DISCARD = "discard"
 TTL = "ttl"
 
+# ── Batch-worklist work types ────────────────────────────────────────────────
+#
+# Work types that are *scheduled bulk worklists*, not resilience-recovery work.
+# The dream-cycle synthesis worklist (``dream_synthesis_slice``) enqueues ~500
+# value-ranked slices weekly and drains a bounded budget PER DAY — so hundreds
+# sit pending for days by design. That must NOT trip the ``queue:deferred_work``
+# recovery-backlog depth alarm (which exists to catch genuinely-stuck recovery
+# work), or the Sentinel fires a Tier-3 alarm on every awareness tick.
+#
+# Kept here (low-level) rather than in ``memory/dream_cycle`` so the observability
+# snapshot can import it without a memory→observability dependency inversion.
+# A drift-guard test pins this against ``dream_cycle.WORKLIST_WORK_TYPE``.
+BATCH_WORK_TYPES: frozenset[str] = frozenset({"dream_synthesis_slice"})
+
+# A batch worklist item pending longer than this is treated as genuinely stalled
+# (the daily drain has broken) and folded BACK into the recovery-backlog count so
+# it re-trips the depth alarm. One full weekly drain cycle (~5 days at 100/day for
+# a 500-slice worklist) plus slack.
+STALE_WORKLIST_DAYS: int = 8
+
 
 class DeferredWorkQueue:
     """Queue for work items deferred due to degraded resilience state."""
@@ -150,6 +170,32 @@ class DeferredWorkQueue:
     async def count_pending(self, work_type: str | None = None) -> int:
         """Count pending items, optionally filtered by work_type."""
         return await crud.count_pending(self._db, work_type=work_type)
+
+    async def count_worklist_pending(self) -> int:
+        """Count pending batch-worklist items (dream synthesis etc.).
+
+        The honest total of scheduled bulk work parked in the queue — exposed for
+        display, deliberately NOT summed into the recovery-backlog depth alarm.
+        """
+        return await crud.count_pending_in(self._db, work_types=BATCH_WORK_TYPES)
+
+    async def count_recovery_pending(
+        self, stale_worklist_days: int = STALE_WORKLIST_DAYS
+    ) -> int:
+        """Count pending items that should trip the recovery-backlog depth alarm.
+
+        Genuine resilience-recovery work always counts; batch worklist items are
+        excluded unless they've been pending past ``stale_worklist_days`` (drain
+        stalled → real backlog). See ``BATCH_WORK_TYPES``.
+        """
+        from datetime import timedelta
+
+        cutoff = (self._clock() - timedelta(days=stale_worklist_days)).isoformat()
+        return await crud.count_recovery_pending(
+            self._db,
+            batch_work_types=BATCH_WORK_TYPES,
+            stale_cutoff_iso=cutoff,
+        )
 
     async def supersede(self, work_type: str) -> int:
         """Delete all non-in-flight rows for a work_type (supersede a batch).

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -1716,6 +1716,27 @@ class SentinelDispatcher:
         # if empty, an empty set is data that confirms absence).
         self._recent_alarm_sets.append(current_ids)
 
+        # Lock-starvation guard. dispatch() and resume_from_approval() hold
+        # self._lock for the whole of an ACTIVE CC remediation (up to timeout_s,
+        # default 3600s). Because check_fire_alarms is awaited inline in the
+        # awareness tick, blocking on that lock below — both the approval-cancel
+        # branch (async with self._lock) and the dispatch() tail acquire it —
+        # would stall the tick and can self-inflict awareness:tick_overdue, which
+        # is itself a Tier-1 alarm. If a remediation is already in flight there is
+        # nothing useful to do this tick, so bail fast: the heartbeat is already
+        # stamped (staleness accounting intact) and these alarm ids are already in
+        # the ring buffer (debounce intact), so they are reconsidered next tick.
+        # The lock is RELEASED while merely parked awaiting approval (dispatch
+        # returns on a pending gate), so the approval-cancel path below is never
+        # starved by this guard.
+        if self._lock.locked():
+            logger.debug(
+                "Sentinel busy (remediation in flight) — skipping this tick's "
+                "fire-alarm dispatch; alarms retained in the ring buffer for "
+                "the next tick"
+            )
+            return None
+
         # If the specific alarm(s) that triggered this dispatch have cleared
         # while we're waiting for approval, cancel the pending approval and
         # go back to HEALTHY.  We check the *pending* alarm IDs specifically

--- a/tests/test_autonomy/test_remediation.py
+++ b/tests/test_autonomy/test_remediation.py
@@ -79,6 +79,30 @@ def _l4_action() -> RemediationAction:
 # Registration
 # ---------------------------------------------------------------------------
 
+class TestDefaultCommandScoping:
+    """Guardrail: systemctl unit restarts must target the user manager.
+
+    Genesis services (qdrant, genesis-bridge) are systemd USER units; a bare
+    `systemctl restart X` hits the system manager and fails rc=4 Access denied,
+    silently disabling self-heal. Regression pin so a new action can't drop
+    --user. (Non-systemctl commands like the disk_reclaim python script, which
+    legitimately uses a --system flag of its own, are out of scope.)
+    """
+
+    def test_qdrant_restart_uses_user_manager(self):
+        qdrant = [a for a in DEFAULT_REMEDIATIONS if a.name == "qdrant_restart"][0]
+        assert qdrant.command == ["systemctl", "--user", "restart", "qdrant"]
+
+    def test_all_systemctl_restarts_are_user_scoped(self):
+        for action in DEFAULT_REMEDIATIONS:
+            cmd = action.command
+            if cmd and cmd[0] == "systemctl":
+                assert "--user" in cmd, (
+                    f"{action.name}: systemctl command {cmd} missing --user — "
+                    f"will fail against the system manager (Access denied)"
+                )
+
+
 class TestRegistration:
     def test_register_action(self):
         reg = RemediationRegistry()

--- a/tests/test_health_mcp.py
+++ b/tests/test_health_mcp.py
@@ -184,15 +184,31 @@ class TestHealthAlerts:
 
     @pytest.mark.asyncio
     async def test_high_queue_depth_generates_warning(self):
+        # The depth alarm watches `deferred_recovery` (genuine recovery backlog),
+        # not the raw `deferred_work` total — the latter includes scheduled batch
+        # worklists that legitimately sit hundreds-deep by design.
         svc = _mock_service({
             "call_sites": {},
-            "queues": {"deferred_work": 150},
+            "queues": {"deferred_recovery": 150},
             "cc_sessions": {},
         })
         health_mcp.init_health_mcp(svc)
         result = await _impl_health_alerts()
         warnings = [a for a in result if a["severity"] == "WARNING"]
-        assert any("deferred_work" in w["message"] for w in warnings)
+        assert any("deferred_recovery" in w["message"] for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_raw_deferred_work_total_does_not_alarm(self):
+        # Regression: a large raw deferred_work total (batch worklist parked) must
+        # NOT trip the depth alarm on its own — that was the every-tick false WARNING.
+        svc = _mock_service({
+            "call_sites": {},
+            "queues": {"deferred_work": 400, "deferred_recovery": 0, "deferred_worklist": 400},
+            "cc_sessions": {},
+        })
+        health_mcp.init_health_mcp(svc)
+        result = await _impl_health_alerts()
+        assert not any(a.get("id") == "queue:deferred_work" for a in result)
 
     @pytest.mark.asyncio
     async def test_cc_throttled_generates_warning(self):

--- a/tests/test_observability/test_deferred_work_segmentation.py
+++ b/tests/test_observability/test_deferred_work_segmentation.py
@@ -1,0 +1,188 @@
+"""Deferred-work alarm segmentation.
+
+The `deferred_work_queue` table backs BOTH genuine resilience-recovery work AND
+the scheduled dream-synthesis worklist (~500 slices enqueued weekly, drained a
+bounded budget/day). Counting the raw total against the `>100` depth alarm fired
+`queue:deferred_work` WARNING on every awareness tick. These tests pin the
+split: the alarm watches the recovery-only subset, batch worklists are excluded
+until they stall past a full drain cycle, and the raw total stays honest for
+display.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import deferred_work as crud
+from genesis.db.schema import create_all_tables
+from genesis.resilience.deferred_work import (
+    BATCH_WORK_TYPES,
+    DRAIN,
+    MEMORY_OPS,
+    REFLECTION,
+    STALE_WORKLIST_DAYS,
+    DeferredWorkQueue,
+)
+
+WORKLIST_TYPE = "dream_synthesis_slice"
+_NOW = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _queue(db) -> DeferredWorkQueue:
+    return DeferredWorkQueue(db, clock=lambda: _NOW)
+
+
+async def _seed_recovery(db, n: int) -> None:
+    q = _queue(db)
+    for _ in range(n):
+        await q.enqueue("reflection", None, REFLECTION, "{}", "degraded", DRAIN)
+
+
+async def _seed_worklist(db, n: int, *, age_days: float = 0.0) -> None:
+    """Seed batch worklist rows with a controllable deferred_at age."""
+    deferred_at = (_NOW - timedelta(days=age_days)).isoformat()
+    for i in range(n):
+        await crud.create(
+            db,
+            id=f"wl-{age_days}-{i}",
+            work_type=WORKLIST_TYPE,
+            priority=MEMORY_OPS,
+            payload_json="{}",
+            deferred_at=deferred_at,
+            deferred_reason="dream_cycle weekly synthesis worklist",
+            created_at=deferred_at,
+            staleness_policy=DRAIN,
+        )
+
+
+class TestQueueCounts:
+    @pytest.mark.asyncio
+    async def test_recovery_excludes_fresh_worklist(self, db):
+        await _seed_recovery(db, 3)
+        await _seed_worklist(db, 5, age_days=0.0)
+
+        q = _queue(db)
+        assert await q.count_pending() == 8          # raw total, honest
+        assert await q.count_worklist_pending() == 5  # batch subset
+        assert await q.count_recovery_pending() == 3  # alarm-eligible subset
+
+    @pytest.mark.asyncio
+    async def test_stale_worklist_folds_into_recovery(self, db):
+        # A worklist that has sat past a full drain cycle means the drain broke —
+        # it should re-count as recovery backlog so the alarm surfaces it.
+        await _seed_recovery(db, 2)
+        await _seed_worklist(db, 4, age_days=STALE_WORKLIST_DAYS + 1)
+
+        q = _queue(db)
+        assert await q.count_worklist_pending() == 4
+        # 2 recovery + 4 stale worklist folded back in
+        assert await q.count_recovery_pending() == 6
+
+    @pytest.mark.asyncio
+    async def test_fresh_and_stale_worklist_mix(self, db):
+        await _seed_worklist(db, 3, age_days=1.0)                    # fresh, excluded
+        await _seed_worklist(db, 2, age_days=STALE_WORKLIST_DAYS + 2)  # stale, folded
+
+        q = _queue(db)
+        assert await q.count_worklist_pending() == 5   # all batch, display
+        assert await q.count_recovery_pending() == 2   # only the stale ones
+
+
+class TestSnapshotSplit:
+    @pytest.mark.asyncio
+    async def test_queues_snapshot_exposes_split(self, db):
+        import importlib
+
+        # The snapshots package re-exports the ``queues`` FUNCTION, which shadows
+        # the submodule on attribute access — import the module object explicitly.
+        qmod = importlib.import_module("genesis.observability.snapshots.queues")
+
+        await _seed_recovery(db, 2)
+        await _seed_worklist(db, 6, age_days=0.0)
+
+        # Pass the fixed-clock queue so the stale-worklist cutoff is deterministic
+        # (fresh age-0 worklist is excluded from recovery regardless of wall clock).
+        result = await qmod.queues(db, _queue(db), None)
+
+        assert result["deferred_work"] == 8       # raw total
+        assert result["deferred_worklist"] == 6   # batch, display-only
+        assert result["deferred_recovery"] == 2   # alarm-eligible
+
+    @pytest.mark.asyncio
+    async def test_queues_snapshot_no_queue_is_zero(self, db):
+        import importlib
+
+        # The snapshots package re-exports the ``queues`` FUNCTION, which shadows
+        # the submodule on attribute access — import the module object explicitly.
+        qmod = importlib.import_module("genesis.observability.snapshots.queues")
+
+        result = await qmod.queues(db, None, None)
+        assert result["deferred_work"] == 0
+        assert result["deferred_recovery"] == 0
+        assert result["deferred_worklist"] == 0
+
+
+class TestDriftGuard:
+    def test_batch_work_types_matches_dream_cycle(self):
+        # If dream_cycle renames its worklist work_type, the exclusion silently
+        # stops matching and the alarm regresses — pin them together.
+        from genesis.memory.dream_cycle import WORKLIST_WORK_TYPE
+
+        assert WORKLIST_WORK_TYPE in BATCH_WORK_TYPES
+
+
+class TestAlarmSwap:
+    """errors.py must threshold on `deferred_recovery`, never the raw
+    `deferred_work` total."""
+
+    async def _alerts_for_queues(self, monkeypatch, queues_dict: dict) -> list[dict]:
+        import genesis.mcp.health.errors as errors_mod
+        import genesis.mcp.health_mcp as health_mcp_mod
+
+        snap = {
+            "call_sites": {},
+            "services": {},
+            "queues": queues_dict,
+            "cc_sessions": {},
+            "infrastructure": {},
+            "scheduler": {},
+        }
+        service = AsyncMock()
+        service.snapshot = AsyncMock(return_value=snap)
+        monkeypatch.setattr(health_mcp_mod, "_service", service)
+        monkeypatch.setattr(health_mcp_mod, "_activity_tracker", None)
+        monkeypatch.setattr(health_mcp_mod, "_job_retry_registry", None)
+        monkeypatch.setattr(health_mcp_mod, "_alert_history", {})
+        return await errors_mod._impl_health_alerts(active_only=True)
+
+    @pytest.mark.asyncio
+    async def test_raw_total_does_not_alarm(self, monkeypatch):
+        # 400 raw / 5 recovery: the old behavior fired; the new behavior stays silent.
+        alerts = await self._alerts_for_queues(
+            monkeypatch, {"deferred_work": 400, "deferred_recovery": 5, "deferred_worklist": 395}
+        )
+        ids = {a["id"] for a in alerts}
+        assert "queue:deferred_work" not in ids
+        assert "queue:deferred_recovery" not in ids  # 5 <= 100
+
+    @pytest.mark.asyncio
+    async def test_recovery_backlog_alarms(self, monkeypatch):
+        alerts = await self._alerts_for_queues(
+            monkeypatch, {"deferred_work": 400, "deferred_recovery": 150, "deferred_worklist": 250}
+        )
+        ids = {a["id"] for a in alerts}
+        assert "queue:deferred_recovery" in ids  # 150 > 100
+        assert "queue:deferred_work" not in ids  # raw total never alarms

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -570,6 +570,55 @@ class TestEscalation:
         d._invoker.run.assert_not_called()
 
 
+class TestLockStarvationGuard:
+    """check_fire_alarms must not block on self._lock while an active CC
+    remediation holds it — that stalls the awareness tick and can self-inflict
+    awareness:tick_overdue (Tier 1). It bails fast, but only AFTER stamping the
+    heartbeat and recording the ring buffer (staleness + debounce accounting).
+    """
+
+    @pytest.mark.asyncio
+    async def test_busy_lock_skips_dispatch_but_keeps_accounting(self):
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        alerts = [{"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "mem"}]
+
+        await d._lock.acquire()  # simulate an in-flight remediation holding the lock
+        try:
+            with patch("genesis.mcp.health_mcp._impl_health_alerts", new=AsyncMock(return_value=alerts)), \
+                 patch("genesis.sentinel.dispatcher.save_state"):
+                # Two consecutive confirmed ticks would normally dispatch on the
+                # second — while the lock is held, neither does (and neither blocks).
+                r1 = await d.check_fire_alarms()
+                r2 = await d.check_fire_alarms()
+        finally:
+            d._lock.release()
+
+        assert r1 is None and r2 is None
+        # Guard sits AFTER heartbeat + ring-buffer append, so accounting persisted.
+        assert len(d._recent_alarm_sets) == 2
+        d._invoker.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_free_lock_dispatches_normally(self):
+        """Control: identical alarm scenario with the lock free confirms and
+        dispatches on the second tick — proving the guard is what suppresses it."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        alerts = [{"id": "infra:container_memory_high", "severity": "CRITICAL", "message": "mem"}]
+
+        with patch("genesis.mcp.health_mcp._impl_health_alerts", new=AsyncMock(return_value=alerts)), \
+             patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.write_last_run"), \
+             patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            r1 = await d.check_fire_alarms()
+            r2 = await d.check_fire_alarms()
+
+        assert r1 is None
+        assert r2 is not None and r2.dispatched
+
+
 class TestRingBufferDebounce:
     """2-of-3 debouncing: single-tick flaps are filtered out."""
 


### PR DESCRIPTION
## Summary

Three related fixes to health signals driven off the awareness tick, all found while E2E-verifying the probe-transition work.

### 1. Segment the dream-synthesis worklist out of the deferred-work depth alarm
The `deferred_work_queue` table backs **both** genuine resilience-recovery work and the dream-cycle synthesis worklist (work_type `dream_synthesis_slice`), which enqueues ~500 slices weekly and drains a bounded budget/day **by design**. The `queue:deferred_work` depth alarm (`>100`) counted the raw total, so the parked worklist tripped a WARNING on **every awareness tick** — a chronic Tier-3 fire-alarm classification (`{3:1}`).

- New crud counts (`count_pending_in`, `count_recovery_pending`) + queue wrappers; `BATCH_WORK_TYPES` + `STALE_WORKLIST_DAYS=8` constants in `resilience/deferred_work.py`.
- `snapshots/queues.py` emits `deferred_recovery` (alarm-eligible: non-batch **or** batch aged past a full drain cycle) and `deferred_worklist` (display); raw `deferred_work` stays for honest display.
- `errors.py` `_QUEUE_DEPTH_FIELDS` alarms on `deferred_recovery` instead of the raw total. A genuinely stalled worklist still surfaces (folds back after `STALE_WORKLIST_DAYS`).
- Dashboard shows recovery and worklist separately.
- Mirrors the existing dead_letter raw-vs-stuck split in the same module.

### 2. Sentinel lock fast-fail
`dispatch()`/`resume_from_approval()` hold `self._lock` through an active CC remediation (up to `timeout_s`, 3600s). `check_fire_alarms` is awaited inline in the awareness tick and blocks on that lock — so a long remediation can stall ticks and self-inflict `awareness:tick_overdue`, itself a Tier-1 alarm. Guard: bail if the lock is held, **after** stamping the heartbeat + ring buffer (staleness/debounce accounting intact). The lock is released while merely parked awaiting approval, so the approval-cancel path is never starved. Closes the F7 lock-starvation follow-up from the capability-scoping PR.

### 3. Qdrant self-heal `--user`
`qdrant_restart` ran `systemctl restart qdrant` (no `--user`) → system manager → **rc=4 Access denied** live; qdrant is a user unit. Now `systemctl --user restart qdrant`, matching the `awareness_restart` sibling, plus a guardrail test pinning every systemctl restart in `DEFAULT_REMEDIATIONS` to user scope.

## Testing
- New `tests/test_observability/test_deferred_work_segmentation.py` (queue counts, stale-fold, snapshot split, drift guard vs `dream_cycle.WORKLIST_WORK_TYPE`, errors.py alarm swap).
- New lock-guard tests in `test_dispatcher.py`; guardrail tests in `test_remediation.py`; updated `test_health_mcp.py`.
- Broad targeted sweep across observability/sentinel/autonomy/resilience/health: **274 passed**.

## Review
Lean architect review: 1 blocking issue (stale `test_health_mcp.py` assertion) found + fixed; SQL precedence, lock semantics, and snapshot/alert-id consumers independently verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)