### PR TITLE
fix(update): reconcile guardian redeploy against host deployed_commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   guardian config now prints a loud warning and is recorded as a degraded subsystem, and a
   repo-wide test guards against any shell script reintroducing the indented-snippet shape.
 
-- **Stale duplicate copies of Claude Code are now detected and removed automatically.** If your
+- **The host Guardian no longer gets stranded on an old commit.** `update.sh` decided whether to
+  redeploy the Guardian by looking only at what the *current* update pulled in — so on a run that
+  pulled nothing, a host that was already behind stayed behind indefinitely (and it could fall
+  behind whenever it had last been deployed from a commit that was later rebased away). The
+  redeploy now compares the host's actually-deployed commit against the current code and reconciles
+  the difference: it redeploys when Guardian-relevant code differs, converges a host on an
+  unrecognized/orphaned commit back onto current, and only falls back to the old behavior when the
+  host can't be reached — so a lagging host heals itself on the next update instead of drifting. If your
   machine ever accumulated a second Claude Code install (an old nvm-tree copy, a native-installer
   leftover, or an install in a directory only interactive shells can see), it could silently shadow
   the version Genesis pins — you'd see a months-old Claude Code in your terminal while Genesis

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -130,6 +130,39 @@ fi
 # Untracked files (^??) are excluded — merge/reset never touches them.
 # git reset --hard in _do_rollback would silently discard uncommitted work.
 #
+# Pure redeploy-decision helper (facts in → reason string out; no git/ssh) so
+# the guardian-redeploy matrix is unit-testable. Emits a non-empty reason to
+# stdout when the host guardian must be redeployed, empty when it is in sync.
+#   $1 reachable          "1" if the gateway `version` op returned (host state readable)
+#   $2 recognized         "1" if the host's deployed_commit resolves to a local commit
+#   $3 host_commit        host's reported deployed_commit (message only)
+#   $4 head_commit        local HEAD short-sha (message only)
+#   $5 host_paths_differ  "1" if guardian paths differ host_commit..HEAD (meaningful iff recognized)
+#   $6 pull_paths_differ  "1" if guardian paths differ OLD_COMMIT..HEAD (legacy pull-delta fallback)
+_guardian_redeploy_reason() {
+    local reachable="$1" recognized="$2" host_commit="$3" head_commit="$4"
+    local host_paths_differ="$5" pull_paths_differ="$6"
+    if [ "$reachable" != "1" ]; then
+        # Host state unreadable — fall back to the legacy "did this run's pull
+        # touch guardian paths" trigger (best effort; the redeploy SSH will
+        # itself fail-soft if the host is genuinely down).
+        if [ "$pull_paths_differ" = "1" ]; then
+            echo "gateway unreachable — pull-delta: guardian paths changed this run"
+        fi
+        return 0
+    fi
+    if [ "$recognized" != "1" ]; then
+        # deployed_commit is unknown/empty or a since-rebased/GC'd orphan we
+        # cannot diff against — converge unconditionally onto HEAD.
+        echo "host deployed_commit '${host_commit:-unknown}' unrecognized — reconciling to $head_commit"
+        return 0
+    fi
+    if [ "$host_paths_differ" = "1" ]; then
+        echo "host $host_commit vs HEAD $head_commit — guardian code drift"
+    fi
+    return 0
+}
+
 # ── Deploy-target sync: guardian redeploy + host Node/CC + container CC ──
 # Extracted into a function so it runs on BOTH paths: the normal post-update
 # path AND the "Already up to date" path. Drift healing (pin alignment on the
@@ -161,8 +194,48 @@ _sync_deploy_targets() {
             GUARDIAN_PATHS="src/genesis/guardian src/genesis/util src/genesis/env.py src/genesis/observability src/genesis/db config/guardian-claude.md pyproject.toml scripts/install_guardian.sh scripts/guardian-gateway.sh"
             DEPLOY_HASH=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 
+            # ── Read host state ONCE: deployed_commit + node/cc versions ──
+            # A single `version` gateway call feeds BOTH the redeploy decision
+            # (deployed_commit) and the Node/CC pin sync further below. Fetched
+            # up front so the redeploy trigger keys on the host's ACTUAL deployed
+            # commit (observable state), NOT on whether THIS run's git pull
+            # happened to touch guardian paths. The old pull-delta gate
+            # ("$OLD_COMMIT"→HEAD) silently skipped the redeploy whenever the host
+            # was last deployed from a since-rebased local HEAD (a no-op run has
+            # OLD_COMMIT == HEAD), stranding it on an orphan commit indefinitely.
+            HOST_VER_RAW="$(ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 \
+                "${HOST_USER}@${HOST_IP}" version 2>/dev/null || true)"
+            HOST_DEPLOYED_COMMIT="$(printf '%s' "$HOST_VER_RAW" \
+                | sed -n 's/.*"deployed_commit": "\([^"]*\)".*/\1/p' || true)"
+
+            # Compute redeploy-decision facts (no side effects) and let the pure
+            # _guardian_redeploy_reason helper resolve the reason string.
+            if [ -n "$HOST_VER_RAW" ]; then _gv_reachable=1; else _gv_reachable=0; fi
+            # recognized = deployed_commit resolves to a real local commit (so we
+            # can diff it). Empty / "unknown" / orphaned-or-GC'd shas → 0.
+            if [ -n "$HOST_DEPLOYED_COMMIT" ] && [ "$HOST_DEPLOYED_COMMIT" != "unknown" ] \
+               && git -C "$GENESIS_ROOT" cat-file -e "${HOST_DEPLOYED_COMMIT}^{commit}" 2>/dev/null; then
+                _gv_recognized=1
+            else
+                _gv_recognized=0
+            fi
+            # host-state drift: guardian content differs between what the host
+            # actually runs and HEAD (only meaningful when recognized).
+            _gv_host_differ=0
+            if [ "$_gv_recognized" = 1 ] \
+               && ! git -C "$GENESIS_ROOT" diff --quiet "$HOST_DEPLOYED_COMMIT" HEAD -- $GUARDIAN_PATHS 2>/dev/null; then
+                _gv_host_differ=1
+            fi
+            # legacy pull-delta (only used as the unreachable-host fallback).
+            _gv_pull_differ=0
             if ! git -C "$GENESIS_ROOT" diff --quiet "$OLD_COMMIT" HEAD -- $GUARDIAN_PATHS 2>/dev/null; then
-                echo "--- Guardian-relevant paths changed — redeploying to host ---"
+                _gv_pull_differ=1
+            fi
+            _gv_reason="$(_guardian_redeploy_reason "$_gv_reachable" "$_gv_recognized" \
+                "$HOST_DEPLOYED_COMMIT" "$DEPLOY_HASH" "$_gv_host_differ" "$_gv_pull_differ")"
+
+            if [ -n "$_gv_reason" ]; then
+                echo "--- Guardian redeploy needed ($_gv_reason) — redeploying to host ---"
                 # Try push-based redeploy (new gateway verb)
                 # Archive excludes config/guardian.yaml (host-specific, generated by installer)
                 ARCHIVE_CMD=(git -C "$GENESIS_ROOT" archive HEAD -- src/ scripts/ pyproject.toml config/guardian-claude.md)
@@ -191,7 +264,7 @@ _sync_deploy_targets() {
                     fi
                 fi
             else
-                echo "--- No Guardian-relevant changes — skipping host redeploy ---"
+                echo "--- Guardian in sync (host ${HOST_DEPLOYED_COMMIT:-unknown} @ HEAD $DEPLOY_HASH) — skipping host redeploy ---"
             fi
 
             # ── Sync host Node.js + Claude Code to the pinned versions (WS-16) ──
@@ -214,10 +287,8 @@ _sync_deploy_targets() {
                 echo "  WARNING: $_cc_env missing — skipping host Node/CC sync"
             fi
 
-            # One `version` call yields both node_version and cc_version.
-            HOST_VER_RAW="$(ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 \
-                "${HOST_USER}@${HOST_IP}" version 2>/dev/null || true)"
-
+            # HOST_VER_RAW was fetched up front (feeds the redeploy decision too);
+            # parse node/cc from that same single `version` response here.
             if [ -z "$HOST_VER_RAW" ]; then
                 # Genuinely could not reach/parse the gateway — DISTINCT from "CC
                 # absent" (the conflation the old message got wrong).

--- a/tests/test_scripts/test_update_host_sync.py
+++ b/tests/test_scripts/test_update_host_sync.py
@@ -16,6 +16,7 @@ class-level guardrail scans every shell script for the indented-multiline
 from __future__ import annotations
 
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -126,3 +127,99 @@ def test_unusable_guardian_config_warns_and_marks_degraded(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "host sync SKIPPED" in result.stdout
     assert "DEGRADED=guardian_config_unreadable" in result.stdout
+
+
+# ── Guardian redeploy reconciliation (PR-D) ─────────────────────────────────
+# The redeploy trigger keys on the host's ACTUAL deployed_commit (observable
+# state), not on whether THIS run's git pull touched guardian paths. The old
+# pull-delta gate (OLD_COMMIT→HEAD) silently skipped the redeploy whenever the
+# host was last deployed from a since-rebased local HEAD, stranding it on an
+# orphan commit. These tests run the shipped pure decision helper directly.
+
+
+def _extract_reason_function() -> str:
+    text = UPDATE_SH.read_text()
+    start = text.index("_guardian_redeploy_reason() {")
+    end = text.index("\n}", start) + 2
+    return text[start:end]
+
+
+def _run_reason(*args: str) -> subprocess.CompletedProcess:
+    """Source the REAL _guardian_redeploy_reason from update.sh and invoke it.
+
+    Runs under ``set -euo pipefail`` so a set -e / unbound-var regression in the
+    helper surfaces as a non-zero exit, not a silently-empty reason.
+
+    Arg order: reachable recognized host_commit head_commit host_differ pull_differ
+    """
+    harness = (
+        "set -euo pipefail\n"
+        + _extract_reason_function()
+        + "\n_guardian_redeploy_reason "
+        + " ".join(shlex.quote(a) for a in args)
+        + "\n"
+    )
+    return subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True, timeout=30
+    )
+
+
+def test_reason_in_sync_is_empty():
+    """Reachable host, recognized commit, no guardian-path drift → no redeploy
+    (and specifically NOT triggered by an unrelated pull-delta)."""
+    r = _run_reason("1", "1", "abc1234", "def5678", "0", "1")
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == "", r.stdout
+
+
+def test_reason_host_drift_redeploys():
+    r = _run_reason("1", "1", "abc1234", "def5678", "1", "0")
+    assert r.returncode == 0, r.stderr
+    assert "drift" in r.stdout
+    assert "abc1234" in r.stdout and "def5678" in r.stdout
+
+
+def test_reason_unrecognized_commit_redeploys():
+    """Orphaned / GC'd deployed_commit we cannot diff → reconcile unconditionally."""
+    r = _run_reason("1", "0", "0ffaced", "def5678", "0", "0")
+    assert r.returncode == 0, r.stderr
+    assert "unrecognized" in r.stdout
+    assert "def5678" in r.stdout
+
+
+def test_reason_unknown_deployed_commit_redeploys():
+    """Host never deployed / gateway returned "unknown" → reconcile."""
+    r = _run_reason("1", "0", "unknown", "def5678", "0", "0")
+    assert r.returncode == 0, r.stderr
+    assert "unrecognized" in r.stdout
+
+
+def test_reason_unreachable_falls_back_to_pull_delta():
+    """Cannot read host state; legacy pull-delta says guardian paths changed."""
+    r = _run_reason("0", "0", "", "def5678", "0", "1")
+    assert r.returncode == 0, r.stderr
+    assert "pull-delta" in r.stdout
+
+
+def test_reason_unreachable_no_pull_delta_skips():
+    """Cannot read host state and nothing changed this run → skip (legacy)."""
+    r = _run_reason("0", "0", "", "def5678", "0", "0")
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == ""
+
+
+def test_redeploy_gate_reconciles_against_host_deployed_commit():
+    """Structural regression guard: the redeploy trigger must content-diff
+    guardian paths against the host's reported deployed_commit and drive the
+    decision through _guardian_redeploy_reason — never revert to the old
+    pull-delta-only gate (OLD_COMMIT→HEAD) that stranded hosts on orphans."""
+    fn = _extract_sync_function()
+    assert 'diff --quiet "$HOST_DEPLOYED_COMMIT" HEAD -- $GUARDIAN_PATHS' in fn, (
+        "redeploy decision must content-diff against the host's deployed_commit"
+    )
+    assert "_guardian_redeploy_reason" in fn, (
+        "redeploy decision must route through the pure reason helper"
+    )
+    assert 'if [ -n "$_gv_reason" ]; then' in fn, (
+        "redeploy must be gated on the helper's reason, not a raw pull-delta diff"
+    )


### PR DESCRIPTION
## Problem

`update.sh` `_sync_deploy_targets()` decided whether to redeploy the host Guardian by diffing guardian paths across `\$OLD_COMMIT`→HEAD — i.e. *what this run's git-pull brought in*. On a no-op update run `OLD_COMMIT == HEAD`, so that delta is empty and the redeploy is skipped. Any host last deployed from a **since-rebased local HEAD** (which becomes an orphan commit) therefore stays stranded on that stale commit indefinitely — the gate never notices the host is behind.

Observed live: the host guardian sat on orphan `35d3e83b` while #909's guardian-path changes went undeployed across multiple `update.sh` runs.

## Fix

Key the redeploy decision on the host's **actual** `deployed_commit` (observable state), not the pull delta:

- Hoist the existing gateway `version` SSH call to the top of the host block and parse `HOST_DEPLOYED_COMMIT` from its JSON (no extra round-trip).
- A pure `_guardian_redeploy_reason()` helper (facts in → reason string out; no git/ssh) decides:
  - **recognized commit + guardian-path content differs** → redeploy ("guardian code drift")
  - **unknown / orphaned / GC'd commit** (can't diff) → redeploy unconditionally to converge onto HEAD
  - **host unreachable** → fall back to the legacy pull-delta trigger (best effort)
  - otherwise → in sync, skip
- Extracted as a pure function so the decision matrix is unit-testable; a structural guard test blocks any silent revert to the pull-delta-only gate.

The Node/CC pin-sync block is unchanged — it now consumes the already-fetched `HOST_VER_RAW`.

## Verification

- `shellcheck` + `bash -n`: clean (SC2086 on `\$GUARDIAN_PATHS` is the intended path word-splitting, matching the existing gate).
- Unit tests: 11/11 (7 new — full decision matrix run under `set -euo pipefail`, plus the structural revert-guard).
- **Integration against real git objects** (no-op run, `OLD_COMMIT==HEAD`): orphan `35d3e83b` → redeploy; HEAD → skip (idempotent); `unknown` → redeploy; unrecognized sha → redeploy.
- Adversarial review: clean, no correctness/safety defects.

## Deploy note

Touches `scripts/update.sh` (Host-Deploy Gate path). After merge, `scripts/update.sh` is run to redeploy — it self-validates by reconciling the live host off orphan `35d3e83b` onto current HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)