### PR TITLE
feat(attention): text-only clarity (has_audio) + device provenance (source) on attention events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Attention events now record which device they came from, and the Judgment tab can filter by it.**
+  Every "perk-up" event the passive-listening engine emits now carries the source device (the home
+  edge connection, or `omi` once the wearable connector lands), and the dashboard's Judgment review
+  gains a device dropdown plus a per-event source pill — so you can review one device's moments in
+  isolation. The engine also stops penalizing text-only sources: an utterance with no audio capture
+  (no loudness to measure) is scored on its text signals instead of being docked 25% clarity or
+  dropped as near-silence junk, which is what OMI wearable transcripts will need.
+
 - **The Sentinel now learns which infrastructure fixes would be safe to run itself — observe-only.**
   Every fix the Sentinel proposes still requires your approval, exactly as before. What's new: each
   proposed action is additionally classified as "would run autonomously" (reversible, programmatic,

--- a/src/genesis/attention/clarity.py
+++ b/src/genesis/attention/clarity.py
@@ -41,23 +41,34 @@ def _clamp01(x: float) -> float:
     return 0.0 if x < 0.0 else (1.0 if x > 1.0 else x)
 
 
-def is_blip(rms: float, duration_s: float, n_tokens: int) -> bool:
+def is_blip(rms: float, duration_s: float, n_tokens: int, *, has_audio: bool = True) -> bool:
     """True for a near-silence throwaway (the ASR emitting a word or two from almost
     no audio): ``rms`` below the near-silence floor AND sparse (sub-second OR <=2
     tokens). Conservative physics gate — flags ~1.8% of the live corpus, the
-    unambiguous junk tail only. Needs no accuracy/relevance judgement, just loudness."""
+    unambiguous junk tail only. Needs no accuracy/relevance judgement, just loudness.
+
+    ``has_audio=False`` (a text-only source, e.g. OMI — no rms to judge): the physics
+    gate is inapplicable, so only a token-less row is junk."""
+    if not has_audio:
+        return n_tokens <= 0
     return rms < RMS_FLOOR and (duration_s < 1.0 or n_tokens <= 2)
 
 
 def capture_clarity(
-    rms: float, duration_s: float, frac_lt_1: float, n_tokens: int,
+    rms: float, duration_s: float, frac_lt_1: float, n_tokens: int, *, has_audio: bool = True,
 ) -> float:
     """Heuristic 0..1 capture-clarity score — equal-weight mean of four bounded
     sub-scores (ASR confidence ``1-frac_lt_1``, loudness, length, token-richness).
     Near-silence blips land near 0; loud/long/confident passages near 1. Edge-portable
-    plain arithmetic; NaN-safe (corrupt meta -> conservative low clarity)."""
+    plain arithmetic; NaN-safe (corrupt meta -> conservative low clarity).
+
+    ``has_audio=False`` (a text-only source, e.g. OMI): loudness is unknowable, not
+    quiet — drop that sub-score and average the three text-derived ones instead of
+    pinning every text-only utterance to a 25% clarity penalty."""
     confidence = 1.0 - _clamp01(frac_lt_1)
-    loudness = _clamp01((rms - RMS_FLOOR) / (RMS_REF - RMS_FLOOR))
     length = _clamp01(duration_s / DUR_REF)
     richness = _clamp01(n_tokens / NTOK_REF)
+    if not has_audio:
+        return (confidence + length + richness) / 3.0
+    loudness = _clamp01((rms - RMS_FLOOR) / (RMS_REF - RMS_FLOOR))
     return (confidence + loudness + length + richness) / 4.0

--- a/src/genesis/attention/consumers.py
+++ b/src/genesis/attention/consumers.py
@@ -78,7 +78,7 @@ class ShadowStoreConsumer:
             triggers, json.dumps(list(ev.suppressors)), window_ref, ev.mode_state,
             ev.clarity, json.dumps(ev.l15_verdict) if ev.l15_verdict is not None else None,
             None,  # acceptance_signal — back-filled at review (PR2)
-            self.snapshot_id, self.config_version, self._created_at,
+            self.snapshot_id, self.config_version, self._created_at, ev.source,
         )
 
     async def flush(self) -> int:

--- a/src/genesis/attention/engine.py
+++ b/src/genesis/attention/engine.py
@@ -41,10 +41,12 @@ def evaluate(
 ) -> tuple[EngineState, AttentionEvent | None]:
     """One fold step. Mutates ``state`` in place and returns ``(state, event | None)``."""
     sm = config.state_modifiers
-    clarity = capture_clarity(utt.rms, utt.duration_s, utt.frac_lt_1, utt.n_tokens)
+    clarity = capture_clarity(
+        utt.rms, utt.duration_s, utt.frac_lt_1, utt.n_tokens, has_audio=utt.has_audio,
+    )
 
     # near-silence junk: ignore entirely (never pollutes windows or timing).
-    if is_blip(utt.rms, utt.duration_s, utt.n_tokens):
+    if is_blip(utt.rms, utt.duration_s, utt.n_tokens, has_audio=utt.has_audio):
         return state, None
 
     # ── sessionize (gap-based, a pure fold over ts) ──

--- a/src/genesis/attention/engine.py
+++ b/src/genesis/attention/engine.py
@@ -121,5 +121,6 @@ def evaluate(
         ts=utt.ts,
         mode_state=utt.mode_state,
         clarity=round(clarity, 4),
+        source=utt.source,
     )
     return state, event

--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -98,7 +98,7 @@ async def run_shadow(
     for utt in src.iter_utterances():
         total += 1
         utt_by_id[utt.id] = utt
-        if is_blip(utt.rms, utt.duration_s, utt.n_tokens):
+        if is_blip(utt.rms, utt.duration_s, utt.n_tokens, has_audio=utt.has_audio):
             continue
         evaluated += 1
         state, ev = evaluate(utt, state, config)

--- a/src/genesis/attention/sources.py
+++ b/src/genesis/attention/sources.py
@@ -76,6 +76,9 @@ def row_to_utterance(row: dict) -> AmbientUtterance | None:
         rms=float(audio.get("rms") or 0.0),
         mode_state="unknown",  # ambient_transcripts carries no interaction-plane state
         source=row.get("source") or "",
+        # no audio block (OMI / absent-or-corrupt meta) -> text-only clarity path:
+        # loudness is unknowable, not quiet — don't fabricate an rms=0 penalty.
+        has_audio=bool(audio),
     )
 
 

--- a/src/genesis/attention/types.py
+++ b/src/genesis/attention/types.py
@@ -85,6 +85,7 @@ class AttentionEvent:
     mode_state: str
     clarity: float                 # capture_clarity of the triggering utterance
     l15_verdict: dict | None = None  # {real, perk} from L1.5 — always None in v1 (stub)
+    source: str = ""               # device provenance of the trigger utterance (e.g. omi / edge id)
 
 
 @dataclass

--- a/src/genesis/attention/types.py
+++ b/src/genesis/attention/types.py
@@ -45,6 +45,7 @@ class AmbientUtterance:
     rms: float
     mode_state: str = "unknown"  # edge: space-separated active modes ("listen_active s2s_active global_mute"); "unknown" offline. Suppressors test `<mode> in mode_state.split()`.
     source: str = ""            # connection/device id
+    has_audio: bool = True      # False = text-only source (OMI): no capture physics (rms) to judge
 
 
 @dataclass(frozen=True)

--- a/src/genesis/dashboard/routes/attention.py
+++ b/src/genesis/dashboard/routes/attention.py
@@ -66,6 +66,7 @@ def _event_summary(row: dict) -> dict:
         "snapshot_id": row.get("snapshot_id"),
         "config_version": row.get("config_version"),
         "created_at": row.get("created_at"),
+        "source": row.get("source"),
     }
 
 
@@ -87,13 +88,15 @@ async def attention_list():
     is_user = request.args.get("is_user", "").lower() == "true"
     unlabeled = request.args.get("unlabeled", "").lower() == "true"
     config_version = request.args.get("config_version") or None
+    source = request.args.get("source") or None
     limit = max(1, min(request.args.get("limit", 200, type=int), 500))
     offset = max(0, request.args.get("offset", 0, type=int))
 
     try:
         rows = await attention_crud.list_events(
             rt.db, activation=activation, trigger=trigger, is_user=is_user,
-            unlabeled=unlabeled, config_version=config_version, limit=limit, offset=offset,
+            unlabeled=unlabeled, config_version=config_version, source=source,
+            limit=limit, offset=offset,
         )
         events = [_event_summary(r) for r in rows]
         return jsonify({"events": events, "count": len(events)})
@@ -127,6 +130,7 @@ async def attention_stats():
             "by_trigger": await attention_crud.trigger_stats(rt.db, config_version),
             "by_suppressor": await attention_crud.suppressor_stats(rt.db, config_version),
             "config_versions": await attention_crud.config_versions(rt.db),
+            "sources": await attention_crud.sources(rt.db),
         })
     except Exception:
         logger.exception("Attention stats failed")

--- a/src/genesis/dashboard/templates/genesis_voice.html
+++ b/src/genesis/dashboard/templates/genesis_voice.html
@@ -26,7 +26,7 @@
         //    keys to read on first load (before any fetch returns) ──
         attentionEvents: [],
         attentionStats: null,
-        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true, config_version: "" },
+        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true, config_version: "", source: "" },
         _attentionVersionDefaulted: false,   // one-time guard: default the filter to newest version once
         _attentionEventsGen: 0,   // request generation — discard a stale events response superseded by a newer fetch
         attentionRevealed: {},   // {event_id: [window rows] | "unavailable"}
@@ -99,6 +99,7 @@
           if (f.is_user) p.set("is_user", "true");
           if (f.unlabeled) p.set("unlabeled", "true");
           if (f.config_version) p.set("config_version", f.config_version);
+          if (f.source) p.set("source", f.source);
           return p.toString();
         },
         async fetchAttentionEvents() {
@@ -369,6 +370,14 @@
             <option :value="v" x-text="v"></option>
           </template>
         </select>
+        <!-- source: device provenance filter (omi vs home edge); list-only, dropdown fed by stats.sources -->
+        <select x-model="$store.genesisVoice.attentionFilters.source" @change="$store.genesisVoice.fetchAttentionEvents()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All devices</option>
+          <template x-for="s in ($store.genesisVoice.attentionStats?.sources || [])" :key="s">
+            <option :value="s" x-text="s"></option>
+          </template>
+        </select>
         <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
           <input type="checkbox" x-model="$store.genesisVoice.attentionFilters.is_user" @change="$store.genesisVoice.fetchAttentionEvents()"> is_user
         </label>
@@ -392,6 +401,7 @@
                       x-text="ev.activation"></span>
                 <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="'score ' + (typeof ev.score === 'number' ? ev.score.toFixed(2) : ev.score)"></span>
                 <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="(ev.ts||'').substring(0,19).replace('T',' ')"></span>
+                <span x-show="ev.source" style="font-size:.6rem; padding:1px 6px; border-radius:3px; color:var(--color-text-secondary); border:1px solid var(--color-border);" x-text="ev.source"></span>
                 <template x-for="t in (ev.triggers_fired||[])" :key="t.name">
                   <span style="font-size:.6rem; padding:1px 5px; border-radius:3px; background:var(--color-panel);" x-text="t.name"></span>
                 </template>

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -20,7 +20,7 @@ import aiosqlite
 COLUMNS = (
     "id", "ts", "session_id", "activation", "score", "triggers_fired", "suppressors",
     "window_ref", "mode_state", "clarity", "l15_verdict", "acceptance_signal",
-    "snapshot_id", "config_version", "created_at",
+    "snapshot_id", "config_version", "created_at", "source",
 )
 
 # On a re-run over the same snapshot+config the row id collides. Refresh the derived
@@ -75,6 +75,7 @@ async def list_events(
     unlabeled: bool = False,
     session_id: str | None = None,
     config_version: str | None = None,
+    source: str | None = None,
     limit: int = 200,
     offset: int = 0,
 ) -> list[dict]:
@@ -84,7 +85,8 @@ async def list_events(
     ``name`` (via ``json_each``, not ``LIKE``). ``is_user=True`` additionally requires the
     ``is_user`` trigger — i.e. the *trigger utterance* (window end) had ``is_user=1``.
     ``unlabeled=True`` restricts to ``acceptance_signal IS NULL`` (the review queue).
-    ``config_version`` scopes to one shadow-run config (the calibration A/B filter — PR3c-1)."""
+    ``config_version`` scopes to one shadow-run config (the calibration A/B filter — PR3c-1).
+    ``source`` scopes to one device (exact match — the Judgment tab's device filter)."""
     where: list[str] = []
     params: list = []
     if activation is not None:
@@ -96,6 +98,9 @@ async def list_events(
     if session_id is not None:
         where.append("session_id = ?")
         params.append(session_id)
+    if source is not None:
+        where.append("source = ?")
+        params.append(source)
     if unlabeled:
         where.append("acceptance_signal IS NULL")
     # Exact name match on a triggers_fired[] element. EXISTS composes for AND without a
@@ -243,6 +248,16 @@ async def config_versions(db: aiosqlite.Connection) -> list[str]:
         "WHERE config_version IS NOT NULL ORDER BY config_version"
     )
     return [r["config_version"] for r in await cursor.fetchall()]
+
+
+async def sources(db: aiosqlite.Connection) -> list[str]:
+    """Every distinct non-empty ``source`` present (UNFILTERED — populates the Judgment
+    tab's device-filter dropdown, mirroring ``config_versions``)."""
+    cursor = await db.execute(
+        "SELECT DISTINCT source FROM attention_events "
+        "WHERE source IS NOT NULL AND source != '' ORDER BY source"
+    )
+    return [r["source"] for r in await cursor.fetchall()]
 
 
 # ── calibration tooling (PR3c-1) ──────────────────────────────────────────────────

--- a/src/genesis/db/migrations/0046_attention_events_source.py
+++ b/src/genesis/db/migrations/0046_attention_events_source.py
@@ -1,0 +1,27 @@
+"""Add ``attention_events.source`` — device provenance of the trigger utterance.
+
+The engine now threads ``AmbientUtterance.source`` onto every ``AttentionEvent``
+(``omi`` for the wearable connector, the edge connection id for home ambient), so the
+shadow store can tell which device a perk came from and the Judgment tab can filter
+by it. A machine-derived column: it rides the normal label-preserving upsert (in
+``crud.attention.COLUMNS``), unlike the human-input ``acceptance_note``.
+
+Fresh/test DBs get it from the canonical CREATE TABLE in ``db/schema/_tables.py``;
+this numbered migration covers the existing-DB upgrade path. Idempotent:
+PRAGMA-guarded ADD COLUMN. No commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='attention_events'"
+    )
+    if await cursor.fetchone():
+        col_cursor = await db.execute("PRAGMA table_info(attention_events)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        if "source" not in cols:
+            await db.execute("ALTER TABLE attention_events ADD COLUMN source TEXT")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -56,7 +56,8 @@ TABLES = {
             acceptance_note   TEXT,                        -- reviewer's optional one-line WHY (PR3d); their reasoning, not the judge's
             snapshot_id       TEXT,
             config_version    TEXT,
-            created_at        TEXT NOT NULL
+            created_at        TEXT NOT NULL,
+            source            TEXT                         -- device provenance of the trigger utterance (e.g. omi / edge id)
             -- SHADOW/OFFLINE-ONLY firewall table: attention DECISIONS + REFERENCES only,
             -- NEVER ambient transcript text (that lives+dies in ambient.db on the edge).
             -- Not read by any cognition job (dream/ego/memory-synthesis).

--- a/tests/test_attention/test_calibrate.py
+++ b/tests/test_attention/test_calibrate.py
@@ -261,7 +261,7 @@ def _row_tuple(id_, config_version, *, activation="soft", score=0.65, clarity=0.
                              "ts_start": 0.0, "ts_end": 1.0})
     ts = "2026-07-01T00:00:00+00:00"
     return (id_, ts, "s1", activation, score, triggers_json, json.dumps([]), window_ref,
-            "unknown", clarity, None, signal, "s", config_version, ts)
+            "unknown", clarity, None, signal, "s", config_version, ts, "")
 
 
 async def _seed(path, rows):

--- a/tests/test_attention/test_clarity.py
+++ b/tests/test_attention/test_clarity.py
@@ -1,6 +1,8 @@
 """capture-clarity pure-function tests (runtime copy of the garble_features math)."""
 import math
 
+import pytest
+
 from genesis.attention.clarity import capture_clarity, frac_below, is_blip
 
 
@@ -34,3 +36,35 @@ def test_is_blip():
     assert is_blip(rms=0.01, duration_s=0.4, n_tokens=1) is True     # near-silence + short
     assert is_blip(rms=0.01, duration_s=5.0, n_tokens=20) is False   # quiet but long + rich
     assert is_blip(rms=0.2, duration_s=0.2, n_tokens=1) is False     # loud -> not a blip
+
+
+# ── has_audio=False: the text-only path (OMI — no capture physics to judge) ─────────
+
+
+def test_capture_clarity_no_audio_is_three_term_mean():
+    # loudness dropped: mean of (confidence, length, richness) only.
+    # confidence=1.0, length=2.0/4.0, richness=4/8 -> (1.0 + 0.5 + 0.5) / 3
+    v = capture_clarity(rms=0.0, duration_s=2.0, frac_lt_1=0.0, n_tokens=4, has_audio=False)
+    assert v == pytest.approx(2.0 / 3.0)
+
+
+def test_capture_clarity_no_audio_ignores_rms():
+    a = capture_clarity(rms=0.0, duration_s=2.0, frac_lt_1=0.1, n_tokens=4, has_audio=False)
+    b = capture_clarity(rms=0.9, duration_s=2.0, frac_lt_1=0.1, n_tokens=4, has_audio=False)
+    assert a == b
+
+
+def test_capture_clarity_default_reproduces_four_term_mean():
+    # regression pin: the default (audio) path must stay byte-identical to the
+    # pre-has_audio math (also guards the mirrored edge-vendored copy's behaviour).
+    conf, loud = 1.0 - 0.2, (0.095 - 0.02) / (0.17 - 0.02)
+    length, rich = 2.0 / 4.0, 4 / 8.0
+    expected = (conf + loud + length + rich) / 4.0
+    assert capture_clarity(rms=0.095, duration_s=2.0, frac_lt_1=0.2, n_tokens=4) == pytest.approx(expected)
+
+
+def test_is_blip_no_audio_only_empty_text():
+    # no physics to judge: any tokens at all -> never a blip...
+    assert is_blip(rms=0.0, duration_s=0.2, n_tokens=1, has_audio=False) is False
+    # ...but a token-less row is still junk.
+    assert is_blip(rms=0.0, duration_s=0.2, n_tokens=0, has_audio=False) is True

--- a/tests/test_attention/test_consumers.py
+++ b/tests/test_attention/test_consumers.py
@@ -86,6 +86,24 @@ async def test_firewall_no_transcript_text_persisted(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_persist_writes_source_column(tmp_path):
+    # device provenance round-trips: utterance.source -> event.source -> the source column
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    evs = _run_events([_utt(1, 100.0, "what do you think about it?", source="omi")], cfg)
+    assert evs
+    c = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+    for ev in evs:
+        c.add(ev)
+    await c.flush()
+    conn = sqlite3.connect(db)
+    vals = [r[0] for r in conn.execute("SELECT source FROM attention_events")]
+    conn.close()
+    assert vals and all(v == "omi" for v in vals)
+
+
+@pytest.mark.asyncio
 async def test_idempotent_reflush_same_snapshot_and_config(tmp_path):
     db = tmp_path / "g.db"
     _make_db(db)

--- a/tests/test_attention/test_differ.py
+++ b/tests/test_attention/test_differ.py
@@ -206,7 +206,7 @@ def _full_row(id_, config_version, *, utt_ids=(1, 2, 3), activation="soft",
     return (
         id_, "2026-07-01T00:00:00+00:00", "s1", activation, 0.6, triggers_json,
         json.dumps([]), window_ref, "unknown", 0.9, None, None, "s", config_version,
-        "2026-07-01T00:00:00+00:00",
+        "2026-07-01T00:00:00+00:00", "",
     )
 
 

--- a/tests/test_attention/test_engine.py
+++ b/tests/test_attention/test_engine.py
@@ -25,12 +25,13 @@ def make_config(**over) -> AttentionConfig:
 
 
 def make_utt(id, ts, text="", *, is_user=None, speaker_total=None, rms=0.2,
-             duration_s=5.0, frac_lt_1=0.0, n_tokens=20, mode_state="unknown") -> AmbientUtterance:
+             duration_s=5.0, frac_lt_1=0.0, n_tokens=20, mode_state="unknown",
+             has_audio=True) -> AmbientUtterance:
     # defaults = clean / high-clarity so tests isolate the trigger + threshold logic.
     return AmbientUtterance(
         id=id, ts=ts, text=text, duration_s=duration_s, is_user=is_user,
         speaker_total=speaker_total, n_tokens=n_tokens, frac_lt_1=frac_lt_1, rms=rms,
-        mode_state=mode_state, source="test",
+        mode_state=mode_state, source="test", has_audio=has_audio,
     )
 
 
@@ -103,6 +104,18 @@ def test_blip_ignored_and_not_windowed():
     state, ev = evaluate(make_utt(1, 100.0, "hey genesis", rms=0.01, duration_s=0.3, n_tokens=1), state, cfg)
     assert ev is None                 # blip short-circuits even with an alias
     assert len(state.window) == 0     # never added to the window
+
+
+def test_text_only_short_utterance_not_blipped():
+    # a text-only (has_audio=False) source has no rms — a short utt must be EVALUATED,
+    # not dropped as a near-silence physics blip (rms=0 + duration<1 blips audio rows).
+    cfg = make_config()
+    state = EngineState()
+    utt = make_utt(1, 100.0, "hey genesis look at this", rms=0.0, duration_s=0.5,
+                   n_tokens=5, has_audio=False)
+    state, ev = evaluate(utt, state, cfg)
+    assert ev is not None and ev.activation == Activation.HARD
+    assert len(state.window) == 1
 
 
 def test_new_session_on_gap_clears_window():

--- a/tests/test_attention/test_engine.py
+++ b/tests/test_attention/test_engine.py
@@ -152,6 +152,12 @@ def test_cooldown_raises_threshold():
     assert e3 is not None and e3.activation == Activation.SOFT  # 40s > cooldown -> fires again
 
 
+def test_event_carries_source_of_trigger_utterance():
+    # device provenance must reach the event (else the store can't tell OMI from home edge)
+    ev = run([make_utt(7, 100.0, "hey genesis check this")], make_config())[0]
+    assert ev.source == "test"   # make_utt's source, threaded onto the event
+
+
 def test_event_carries_refs_not_text():
     ev = run([make_utt(7, 100.0, "hey genesis secret plan")], make_config())[0]
     # AttentionEvent must expose no raw transcript — window_ref is ids + ts only.

--- a/tests/test_attention/test_runner.py
+++ b/tests/test_attention/test_runner.py
@@ -56,6 +56,19 @@ def test_load_runner_config_falls_back_to_builtin(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_shadow_text_only_short_utt_not_blipped(tmp_path):
+    # the runner pre-filters physics blips; a text-only row (no meta.audio -> has_audio=False)
+    # must pass through even when short (rms=0 + duration<1 would blip an audio row).
+    snap = tmp_path / "ambient.db"
+    meta = json.dumps({"asr_feats": {"ys_log_probs": [-0.1] * 5, "n_tokens": 5}})  # no audio block
+    _make_ambient(snap, [(1, "2026-06-30T12:00:00+00:00", "hey genesis quick one", 0.5, "w1:1/1", meta, 1)])
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    report = await run_shadow(snap, cfg, snapshot_id="t", sample_n=5)
+    assert report.evaluated == 1     # NOT dropped by the physics blip pre-filter
+    assert report.events == 1        # wake alias -> HARD
+
+
+@pytest.mark.asyncio
 async def test_run_shadow_over_snapshot(tmp_path):
     snap = tmp_path / "ambient.db"
     _make_ambient(snap, [

--- a/tests/test_attention/test_sources.py
+++ b/tests/test_attention/test_sources.py
@@ -51,6 +51,23 @@ def test_row_corrupt_meta_tolerated():
     assert u is not None and u.n_tokens == 0 and u.rms == 0.0
 
 
+def test_row_with_audio_meta_has_audio_true():
+    assert row_to_utterance(_row()).has_audio is True
+
+
+def test_row_without_audio_block_is_text_only():
+    # a text-only source (OMI) carries asr-ish feats but NO audio block
+    meta = json.dumps({"asr_feats": {"ys_log_probs": [], "n_tokens": 3}})
+    assert row_to_utterance(_row(meta=meta)).has_audio is False
+
+
+def test_row_missing_or_corrupt_meta_treated_text_only():
+    # no physics available -> text-only path (don't fabricate a loudness-0 penalty
+    # or blip-drop a row whose capture stats are simply absent/corrupt)
+    assert row_to_utterance(_row(meta=None)).has_audio is False
+    assert row_to_utterance(_row(meta="{not valid json")).has_audio is False
+
+
 def test_speaker_total_parse():
     assert _speaker_total("w500:2/5") == 5
     assert _speaker_total("w1:1/1") == 1

--- a/tests/test_dashboard/test_attention_api.py
+++ b/tests/test_dashboard/test_attention_api.py
@@ -62,6 +62,7 @@ def _evrow(**over):
         "snapshot_id": "20260701T013412Z",
         "config_version": "0.1.0-default",
         "created_at": "2026-07-01T00:00:04+00:00",
+        "source": "ambient-edge",
     }
     row.update(over)
     return row
@@ -109,6 +110,7 @@ def test_stats_aggregates(client):
         patch("genesis.db.crud.attention.trigger_stats", new=AsyncMock(return_value={"multi_speaker": 2})),
         patch("genesis.db.crud.attention.suppressor_stats", new=AsyncMock(return_value={})),
         patch("genesis.db.crud.attention.config_versions", new=AsyncMock(return_value=["0.1.0-default"])),
+        patch("genesis.db.crud.attention.sources", new=AsyncMock(return_value=[])),
     ):
         MockRT.instance.return_value = _mock_rt()
         resp = client.get("/api/genesis/attention/stats")
@@ -146,6 +148,7 @@ def test_stats_scopes_aggregates_but_lists_all_versions(client):
         patch("genesis.db.crud.attention.suppressor_stats", new=AsyncMock(return_value={})),
         patch("genesis.db.crud.attention.config_versions",
               new=AsyncMock(return_value=["0.1.0-default", "0.2.0-taxonomy"])),
+        patch("genesis.db.crud.attention.sources", new=AsyncMock(return_value=[])),
     ):
         MockRT.instance.return_value = _mock_rt()
         resp = client.get("/api/genesis/attention/stats?config_version=0.1.0-default")
@@ -154,6 +157,39 @@ def test_stats_scopes_aggregates_but_lists_all_versions(client):
     assert data["config_versions"] == ["0.1.0-default", "0.2.0-taxonomy"]  # UNFILTERED
     args, _ = act.call_args
     assert args[1] == "0.1.0-default"                                      # aggregate scoped
+
+
+# ── source (device provenance) filter — PR-4 ───────────────────────────────
+
+def test_list_threads_source_and_summary_includes_it(client):
+    le = AsyncMock(return_value=[_evrow(source="omi")])
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.list_events", new=le),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/list?source=omi")
+    assert resp.status_code == 200
+    assert resp.get_json()["events"][0]["source"] == "omi"   # surfaced in the summary
+    _, kwargs = le.call_args
+    assert kwargs["source"] == "omi"                          # threaded to the crud call
+
+
+def test_stats_includes_sources_dropdown(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.label_counts",
+              new=AsyncMock(return_value={"total": 0, "labeled": 0, "unlabeled": 0, "by_signal": {}})),
+        patch("genesis.db.crud.attention.activation_stats", new=AsyncMock(return_value={})),
+        patch("genesis.db.crud.attention.trigger_stats", new=AsyncMock(return_value={})),
+        patch("genesis.db.crud.attention.suppressor_stats", new=AsyncMock(return_value={})),
+        patch("genesis.db.crud.attention.config_versions", new=AsyncMock(return_value=[])),
+        patch("genesis.db.crud.attention.sources", new=AsyncMock(return_value=["ambient-edge", "omi"])),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/stats")
+    assert resp.status_code == 200
+    assert resp.get_json()["sources"] == ["ambient-edge", "omi"]  # device-filter dropdown, UNFILTERED
 
 
 # ── reveal-text ───────────────────────────────────────────────────────────

--- a/tests/test_db/test_crud_attention.py
+++ b/tests/test_db/test_crud_attention.py
@@ -32,6 +32,7 @@ def _row(
     snapshot_id="20260701T013412Z",
     utt_ids=(1, 2, 3),
     config_version="0.1.0-default",
+    source="",
 ):
     """A full attention_events tuple in COLUMNS order."""
     triggers_json = json.dumps([{"name": nm, "kind": k, "contribution": c} for nm, k, c in triggers])
@@ -42,7 +43,7 @@ def _row(
     return (
         f"id-{n}", ts, session_id, activation, score, triggers_json,
         json.dumps(list(suppressors)), window_ref, "unknown", 0.9, None,
-        acceptance, snapshot_id, config_version, "2026-07-01T00:00:00+00:00",
+        acceptance, snapshot_id, config_version, "2026-07-01T00:00:00+00:00", source,
     )
 
 
@@ -200,6 +201,29 @@ async def test_config_versions_is_distinct_sorted_unfiltered(tmp_path):
         _row(3, config_version="0.2.0-taxonomy"),
     ])
     assert await crud.config_versions(db) == ["0.1.0-default", "0.2.0-taxonomy"]
+    await db.close()
+
+
+# ── device provenance: source filter + sources dropdown (PR-4) ─────────────────────
+
+@pytest.mark.asyncio
+async def test_list_events_filters_by_source(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1, source="omi"), _row(2, source="ambient-edge")])
+    assert [e["id"] for e in await crud.list_events(db, source="omi")] == ["id-1"]
+    got = await crud.list_events(db)                        # no filter -> both
+    assert {e["source"] for e in got} == {"omi", "ambient-edge"}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sources_is_distinct_sorted_nonempty(tmp_path):
+    # mirrors config_versions(): populates the device-filter dropdown; blank/NULL excluded
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, source="omi"), _row(2, source="omi"), _row(3, source="ambient-edge"), _row(4),
+    ])
+    assert await crud.sources(db) == ["ambient-edge", "omi"]
     await db.close()
 
 

--- a/tests/test_db/test_migration_0046_attention_events_source.py
+++ b/tests/test_db/test_migration_0046_attention_events_source.py
@@ -1,0 +1,58 @@
+"""Migration 0046 — add attention_events.source (device provenance, e.g. omi / edge id).
+
+Verifies the column is added to a pre-existing table, the add is idempotent (fresh DBs
+already have it from _tables.py), and a missing table is a safe no-op. Mirrors 0045.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M46 = importlib.import_module("genesis.db.migrations.0046_attention_events_source")
+
+# A minimal PRE-0046 attention_events (no source) — the existing-DB upgrade path.
+_OLD_DDL = """
+    CREATE TABLE attention_events (
+        id TEXT PRIMARY KEY, ts TEXT NOT NULL, session_id TEXT NOT NULL,
+        activation TEXT NOT NULL, score REAL NOT NULL, triggers_fired TEXT NOT NULL DEFAULT '[]',
+        suppressors TEXT NOT NULL DEFAULT '[]', window_ref TEXT NOT NULL, mode_state TEXT,
+        clarity REAL, l15_verdict TEXT, acceptance_signal TEXT, acceptance_note TEXT,
+        snapshot_id TEXT, config_version TEXT, created_at TEXT NOT NULL
+    )
+"""
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(attention_events)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_adds_source_column_to_existing_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        assert "source" not in await _columns(db)
+        await M46.up(db)
+        assert "source" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await M46.up(db)
+        await M46.up(db)  # second run must NOT raise "duplicate column"
+        assert "source" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_up_noop_when_table_absent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M46.up(db)  # no attention_events table — must be a safe no-op
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='attention_events'"
+        )
+        assert await cur.fetchone() is None


### PR DESCRIPTION
## Summary

PR-4 of the omnipresence track — the two pure-core attention-engine changes the OMI wearable connector (PR-5) builds on. Both are additive with defaults that keep every existing code path byte-identical.

### 1. Text-only clarity path (`has_audio`)

A text-only source (OMI transcripts) has no `rms` — today that pins `capture_clarity`'s loudness sub-score to 0 (a permanent −25% penalty) and makes `is_blip` drop short utterances as near-silence junk.

- `AmbientUtterance.has_audio: bool = True` (appended last), decided in ONE place: `row_to_utterance` sets `has_audio=bool(meta.audio)`. Verified against both live snapshots (5,423 rows each): zero rows lack `meta.audio`, so every existing home row keeps the audio path.
- `capture_clarity(has_audio=False)` averages the three text sub-scores (confidence/length/richness); `is_blip(has_audio=False)` treats only a token-less row as junk. Keyword-only args, default `True`; the audio path is regression-pinned to the exact 4-term math.
- Threaded at the 3 call sites (`engine.py` clarity + blip, `runner.py` pre-filter). The edge-vendored `garble_features.py` copy is deliberately untouched (backward-compatible default).

### 2. Device provenance (`source` on events)

`AmbientUtterance.source` was dropped at the event boundary — the store couldn't tell which device a perk came from.

- `AttentionEvent.source: str = ""` (appended last), populated from the trigger utterance in `evaluate()`.
- Persisted via `crud.attention.COLUMNS` + `ShadowStoreConsumer._to_row` (order-match preserved; machine-derived column, rides the label-preserving upsert — labeled rows stay frozen).
- **Migration 0046** (`attention_events.source`, PRAGMA-guarded idempotent ADD COLUMN, mirrors 0045) + the canonical DDL in `_tables.py`.
- Dashboard: `list_events` gains an exact-match `source` filter; a new `sources()` aggregate (mirrors `config_versions()`) feeds a device dropdown on the Judgment tab; each event row shows a source pill.

## Tests

TDD throughout (RED verified before each implementation). New coverage: 3-term clarity math + rms-invariance + 4-term regression pin; text-only blip rule; `row_to_utterance` discriminator (incl. corrupt/absent meta → text-only, fail-safe); engine/runner pass-through of short text-only utterances; `evaluate` sets `source`; consumer persists it; crud filter + `sources()`; migration 0046 idempotency/no-op; dashboard list threading + stats `sources`. All three COLUMNS-order test tuple builders updated. 274 passed across the affected surface (attention, crud, migrations runner, stripped-db schema, dashboard API).

## Verification still to run (post-review)

E2E over a live snapshot with `--persist`: confirm `source` lands on `attention_events`, the device filter scopes correctly, existing events reproduce identical clarity, and no transcript text reaches genesis.db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)