### PR TITLE
feat(dashboard): voice Bridge tab cockpit — full live edge health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **The voice dashboard's Bridge tab is now a full cockpit.** Instead of a bare status line, it
+  shows the ambient edge bridge's complete live health, grouped for scanning: memory leak-watch
+  (parent / diarization-child / total RSS, ORT-arena state, pool recycles), capture activity
+  (utterances, rows per hour, last-utterance age), diarization worker state, connection
+  stability (connects, dark events, gap durations), and speaker-ID status — read on demand from
+  the edge via the new `GET /api/genesis/voice/bridge` endpoint. Any new health field the edge
+  starts reporting surfaces automatically under "Other."
+
+- **Voice dashboard Device tab: live Voice PE hardware vitals.** Temperature, WiFi signal,
+  uptime, reset reason, free heap, loop time, and voice-pipeline status, polled from Home
+  Assistant on demand (`GET /api/genesis/voice/device`; set `HA_VOICE_PE_PREFIX`). *(Shipped
+  earlier in #876; the changelog entry was missed at the time.)*
+
 ### Fixed
 
 - **A false "deferred work backlog" health warning no longer fires every few minutes.** The

--- a/src/genesis/dashboard/routes/voice.py
+++ b/src/genesis/dashboard/routes/voice.py
@@ -7,10 +7,10 @@ visibility. Voice is an OPTIONAL add-on: on a stock clone with no
 non-voice installs never see voice surfaces.
 
 The page's sub-tabs (Judgment / Bridge / STT / S2S / Device) are all in the served
-template. The Bridge tab reuses the existing ``/api/genesis/health``
-``infrastructure.ambient`` block; the Device tab reads live Voice PE hardware vitals
-from Home Assistant via ``GET /api/genesis/voice/device`` (below) — the one
-voice-specific endpoint here, on-demand so it never burdens the health snapshot.
+template. The Bridge tab reads the full edge health payload on demand via
+``GET /api/genesis/voice/bridge`` (below); the Device tab reads live Voice PE
+hardware vitals from Home Assistant via ``GET /api/genesis/voice/device`` (below).
+Both are on-demand so they never burden the cached health snapshot.
 """
 from __future__ import annotations
 
@@ -55,6 +55,22 @@ def voice_enabled():
     """Whether the optional voice add-on is configured — drives nav-link visibility.
     Non-sensitive boolean; open like the rest of the ``/api`` surface."""
     return jsonify({"enabled": _voice_configured()})
+
+
+@blueprint.route("/api/genesis/voice/bridge")
+@_async_route(timeout=20.0)
+async def voice_bridge():
+    """Full ambient edge-bridge health for the Bridge tab, SSH-read on demand.
+
+    Returns ``bridge_snapshot()`` verbatim: verdict + reasons + the complete
+    ``ambient_health.json`` payload under ``health``. Always HTTP 200 with
+    ``configured``/``reachable`` flags so the tab degrades gracefully — never a
+    5xx the frontend would treat as a server fault. Timeout 20s: strictly a
+    backstop above the SSH read's own ~15s internal bound (ConnectTimeout 10s +
+    communicate wait), so the inner path always resolves first."""
+    from genesis.observability.ambient_health import bridge_snapshot
+
+    return jsonify(await bridge_snapshot())
 
 
 @blueprint.route("/api/genesis/voice/device")

--- a/src/genesis/dashboard/templates/genesis_voice.html
+++ b/src/genesis/dashboard/templates/genesis_voice.html
@@ -550,6 +550,7 @@
                   <div class="bridge-row"><span>Longest gap</span><span x-text="gv._num(h.conn_longest_gap_s, ' s')"></span></div>
                   <div class="bridge-row"><span>Last device link</span><span :title="h.last_connection_ts || ''" x-text="gv._age(h.last_connection_ts)"></span></div>
                   <div class="bridge-row" x-show="h.conn_dark_for_s != null"><span>Dark for</span><span style="color:var(--color-warning-text);" x-text="gv._num(h.conn_dark_for_s, ' s')"></span></div>
+                  <div class="bridge-row" x-show="h.conn_dark_since != null"><span>Dark since</span><span style="color:var(--color-warning-text);" :title="h.conn_dark_since || ''" x-text="gv._age(h.conn_dark_since)"></span></div>
                 </div>
                 <div>
                   <div class="bridge-group-title">Speaker ID</div>

--- a/src/genesis/dashboard/templates/genesis_voice.html
+++ b/src/genesis/dashboard/templates/genesis_voice.html
@@ -16,6 +16,7 @@
 
   <script type="module">
     import { fetchApi } from "/js/api.js";
+    import { fmtAge, chipState, chipClass, chipGlyph } from "/js/ui-utils.js";
 
     document.addEventListener("alpine:init", () => {
       Alpine.store("genesisVoice", {
@@ -33,32 +34,38 @@
         attentionLabeling: {},   // {event_id: true} while a label POST is in flight
         attentionNotes: {},      // {event_id: draft note text} — the reviewer's WHY, sent with the label
 
-        // ── Bridge (ambient edge) — reuses /api/genesis/health infrastructure.ambient ──
-        bridge: null,
+        // ── Bridge (ambient edge) — full health snapshot via /api/genesis/voice/bridge ──
+        bridge: null,          // {configured, reachable, verdict, reasons, latency_ms, health?}
         bridgeError: null,
         bridgeLoading: true,
         async fetchBridge() {
           this.bridgeLoading = true;
           try {
-            const resp = await fetchApi("/api/genesis/health");
+            const resp = await fetchApi("/api/genesis/voice/bridge");
             if (resp && resp.ok) {
-              const data = await resp.json();
-              this.bridge = (data.infrastructure || {}).ambient || null;
-              this.bridgeError = this.bridge ? null : "no ambient bridge in the health snapshot (edge not reporting)";
-            } else { this.bridgeError = `health fetch failed (${resp ? resp.status : "network error"})`; }
-          } catch (e) { this.bridgeError = String(e); }
+              const d = await resp.json();
+              if (d && d.configured === false) { this.bridge = null; this.bridgeError = d.reason || "no ambient edge configured"; }
+              // unreachable/misconfigured stay renderable: the verdict chip + reasons tell the story
+              else { this.bridge = d; this.bridgeError = null; }
+            } else { this.bridge = null; this.bridgeError = `bridge fetch failed (${resp ? resp.status : "network error"})`; }
+          } catch (e) { this.bridge = null; this.bridgeError = String(e); }
           finally { this.bridgeLoading = false; }
         },
-        _bridgeColor(status) {
-          const s = (status || "").toLowerCase();
-          if (s === "healthy" || s === "ok") return "var(--color-primary)";
-          if (s === "degraded") return "var(--color-warning-text)";
-          if (s === "down" || s === "error") return "#ef4444";
-          return "var(--color-text-secondary)";
-        },
+        bridgeHealth() { return (this.bridge && this.bridge.health) || {}; },
+        // shared ui-utils wrappers — Alpine template expressions can't reach module imports
+        _age(ts) { return fmtAge(ts); },
+        _chip(verdict) { return chipClass(chipState(verdict)); },
+        _chipGlyph(verdict) { return chipGlyph(chipState(verdict)); },
+        _yn(v) { return v === true ? "yes" : v === false ? "no" : (v ?? "—"); },
+        _num(v, unit) { return (v === null || v === undefined) ? "—" : `${v}${unit || ""}`; },
+        // keys the panel renders explicitly; anything else the edge adds shows under "Other"
+        _bridgeShown: ["ts","mode","active_connections","last_connection_ts","utterances_total",
+          "rows_last_hour","total_rows","last_ts","diar_enabled","diar_worker_alive","diar_queue_depth",
+          "diar_windows_dropped","diar_pool_recycles","ort_arena_off","rss_parent_mb","rss_diar_child_mb",
+          "rss_total_mb","conn_total_connects","conn_total_disconnects","conn_dark_events","conn_last_gap_s",
+          "conn_longest_gap_s","conn_dark_since","conn_dark_for_s","speaker_id_enabled","enrolling"],
         bridgeExtras() {
-          const b = this.bridge || {};
-          return Object.entries(b).filter(([k]) => !["status","latency_ms","message"].includes(k));
+          return Object.entries(this.bridgeHealth()).filter(([k]) => !this._bridgeShown.includes(k));
         },
 
         // ── Device (Voice PE hardware vitals via Home Assistant) ──
@@ -227,6 +234,9 @@
     .voice-tabs button { background:transparent; border:none; color:var(--color-text-secondary); padding:.5rem 1rem; cursor:pointer; border-bottom:2px solid transparent; font-size:.9rem; }
     .voice-tabs button.active { color:var(--color-text); border-bottom-color:var(--color-primary); font-weight:600; }
     .voice-stat { flex:1; min-width:120px; background:var(--color-background); border-radius:6px; padding:.75rem; text-align:center; }
+    .bridge-group-title { font-size:.72rem; text-transform:uppercase; letter-spacing:.06em; color:var(--color-text-secondary); margin-bottom:.4rem; font-weight:600; }
+    .bridge-row { display:flex; gap:.5rem; font-size:.8rem; margin-bottom:.25rem; }
+    .bridge-row span:first-child { min-width:140px; color:var(--color-text-secondary); flex-shrink:0; }
   </style>
 </head>
 
@@ -471,28 +481,88 @@
       <div class="panel-header"><span class="material-symbols-outlined">sensors</span> Ambient Bridge</div>
       <div style="padding:1rem;">
         <div style="color:var(--color-text-secondary); font-size:.85em; margin-bottom:1rem;">
-          Live health of the edge ambient-capture bridge (from the <code>infrastructure.ambient</code> probe). An absent bridge is not a fault.
+          Live health of the edge ambient-capture bridge, read on demand from the edge's <code>ambient_health.json</code>. An absent device is not a fault.
         </div>
         <template x-if="$store.genesisVoice.bridgeLoading && !$store.genesisVoice.bridge">
-          <p style="color:var(--color-text-secondary);">Loading bridge status…</p>
+          <p style="color:var(--color-text-secondary);">Loading bridge health…</p>
         </template>
         <template x-if="$store.genesisVoice.bridge">
-          <div>
+          <div x-data="{ get gv() { return $store.genesisVoice; }, get b() { return $store.genesisVoice.bridge || {}; }, get h() { return $store.genesisVoice.bridgeHealth(); } }">
+            <!-- verdict chip + reasons -->
+            <div style="display:flex; gap:.75rem; align-items:center; flex-wrap:wrap; margin-bottom:1rem;">
+              <span :class="gv._chip(b.verdict)"><span x-text="gv._chipGlyph(b.verdict)"></span> <span style="text-transform:uppercase;" x-text="b.verdict || 'unknown'"></span></span>
+              <span style="font-size:.8rem; color:var(--color-text-secondary);" x-text="(b.reasons || []).join('; ')"></span>
+            </div>
+            <!-- headline stat cards -->
             <div style="display:flex; gap:1rem; flex-wrap:wrap; margin-bottom:1rem;">
               <div class="voice-stat">
-                <div style="font-size:1.3rem; font-weight:700; text-transform:uppercase;" :style="`color:${$store.genesisVoice._bridgeColor($store.genesisVoice.bridge.status)}`" x-text="$store.genesisVoice.bridge.status || 'unknown'"></div>
-                <div style="font-size:.75rem; color:var(--color-text-secondary);">Status</div>
+                <div style="font-size:1.3rem; font-weight:700; text-transform:uppercase;" x-text="h.mode || '—'"></div>
+                <div style="font-size:.75rem; color:var(--color-text-secondary);">Mode</div>
               </div>
-              <div class="voice-stat" x-show="$store.genesisVoice.bridge.latency_ms != null">
-                <div style="font-size:1.3rem; font-weight:700;" x-text="Math.round($store.genesisVoice.bridge.latency_ms) + ' ms'"></div>
+              <div class="voice-stat">
+                <div style="font-size:1.3rem; font-weight:700;" :style="`color:${(h.active_connections || 0) > 0 ? 'var(--color-primary)' : 'var(--color-text-secondary)'}`" x-text="(h.active_connections || 0) > 0 ? 'connected' : 'no device'"></div>
+                <div style="font-size:.75rem; color:var(--color-text-secondary);">Device</div>
+              </div>
+              <div class="voice-stat">
+                <div style="font-size:1.3rem; font-weight:700;" :title="h.ts || ''" x-text="gv._age(h.ts)"></div>
+                <div style="font-size:.75rem; color:var(--color-text-secondary);">Heartbeat</div>
+              </div>
+              <div class="voice-stat" x-show="h.rss_total_mb != null">
+                <div style="font-size:1.3rem; font-weight:700;" x-text="gv._num(h.rss_total_mb, ' MB')"></div>
+                <div style="font-size:.75rem; color:var(--color-text-secondary);">Total RSS</div>
+              </div>
+              <div class="voice-stat" x-show="b.latency_ms != null">
+                <div style="font-size:1.3rem; font-weight:700;" x-text="Math.round(b.latency_ms) + ' ms'"></div>
                 <div style="font-size:.75rem; color:var(--color-text-secondary);">Probe latency</div>
               </div>
             </div>
-            <div x-show="$store.genesisVoice.bridge.message" style="color:var(--color-text-secondary); margin-bottom:1rem;" x-text="$store.genesisVoice.bridge.message"></div>
-            <template x-if="$store.genesisVoice.bridgeExtras().length">
-              <div style="display:flex; flex-direction:column; gap:.25rem; font-size:.8rem;">
-                <template x-for="[k,v] in $store.genesisVoice.bridgeExtras()" :key="k">
-                  <div style="display:flex; gap:.5rem;"><span style="min-width:160px; color:var(--color-text-secondary);" x-text="k"></span><span x-text="typeof v === 'object' ? JSON.stringify(v) : v"></span></div>
+            <!-- detail groups (only when the edge payload came back) -->
+            <template x-if="b.health">
+              <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); gap:1.25rem;">
+                <div>
+                  <div class="bridge-group-title">Memory (leak watch)</div>
+                  <div class="bridge-row"><span>Parent RSS</span><span x-text="gv._num(h.rss_parent_mb, ' MB')"></span></div>
+                  <div class="bridge-row"><span>Diar child RSS</span><span x-text="gv._num(h.rss_diar_child_mb, ' MB')"></span></div>
+                  <div class="bridge-row"><span>Total RSS</span><span x-text="gv._num(h.rss_total_mb, ' MB')"></span></div>
+                  <div class="bridge-row"><span>ORT arena off</span><span x-text="gv._yn(h.ort_arena_off)"></span></div>
+                  <div class="bridge-row"><span>Pool recycles</span><span x-text="gv._num(h.diar_pool_recycles)"></span></div>
+                </div>
+                <div>
+                  <div class="bridge-group-title">Capture</div>
+                  <div class="bridge-row"><span>Utterances total</span><span x-text="gv._num(h.utterances_total)"></span></div>
+                  <div class="bridge-row"><span>Rows last hour</span><span x-text="gv._num(h.rows_last_hour)"></span></div>
+                  <div class="bridge-row"><span>Total rows</span><span x-text="gv._num(h.total_rows)"></span></div>
+                  <div class="bridge-row"><span>Last utterance</span><span :title="h.last_ts || ''" x-text="gv._age(h.last_ts)"></span></div>
+                </div>
+                <div>
+                  <div class="bridge-group-title">Diarization</div>
+                  <div class="bridge-row"><span>Enabled</span><span x-text="gv._yn(h.diar_enabled)"></span></div>
+                  <div class="bridge-row"><span>Worker alive</span><span x-text="gv._yn(h.diar_worker_alive)"></span></div>
+                  <div class="bridge-row"><span>Queue depth</span><span x-text="gv._num(h.diar_queue_depth)"></span></div>
+                  <div class="bridge-row"><span>Windows dropped</span><span x-text="gv._num(h.diar_windows_dropped)"></span></div>
+                </div>
+                <div>
+                  <div class="bridge-group-title">Connection stability</div>
+                  <div class="bridge-row"><span>Connects</span><span x-text="gv._num(h.conn_total_connects)"></span></div>
+                  <div class="bridge-row"><span>Disconnects</span><span x-text="gv._num(h.conn_total_disconnects)"></span></div>
+                  <div class="bridge-row"><span>Dark events</span><span x-text="gv._num(h.conn_dark_events)"></span></div>
+                  <div class="bridge-row"><span>Last gap</span><span x-text="gv._num(h.conn_last_gap_s, ' s')"></span></div>
+                  <div class="bridge-row"><span>Longest gap</span><span x-text="gv._num(h.conn_longest_gap_s, ' s')"></span></div>
+                  <div class="bridge-row"><span>Last device link</span><span :title="h.last_connection_ts || ''" x-text="gv._age(h.last_connection_ts)"></span></div>
+                  <div class="bridge-row" x-show="h.conn_dark_for_s != null"><span>Dark for</span><span style="color:var(--color-warning-text);" x-text="gv._num(h.conn_dark_for_s, ' s')"></span></div>
+                </div>
+                <div>
+                  <div class="bridge-group-title">Speaker ID</div>
+                  <div class="bridge-row"><span>Enabled</span><span x-text="gv._yn(h.speaker_id_enabled)"></span></div>
+                  <div class="bridge-row"><span>Enrolling</span><span x-text="h.enrolling || '—'"></span></div>
+                </div>
+                <template x-if="gv.bridgeExtras().length">
+                  <div>
+                    <div class="bridge-group-title">Other</div>
+                    <template x-for="[k,v] in gv.bridgeExtras()" :key="k">
+                      <div class="bridge-row"><span x-text="k"></span><span x-text="typeof v === 'object' ? JSON.stringify(v) : String(v)"></span></div>
+                    </template>
+                  </div>
                 </template>
               </div>
             </template>

--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -4,7 +4,10 @@ The ambient bridge runs on a separate edge VM and writes ``ambient_health.json``
 every 60s. This module SSH-reads that file (connection in
 ``~/.genesis/ambient_remote.yaml``, mirroring ``guardian_remote.yaml``) and turns
 a snapshot into an alert verdict. ``OutreachScheduler._ambient_health_job`` runs
-the read + evaluate on a cadence and alerts the user on a bad-state transition.
+the read + evaluate on a cadence and alerts the user on a bad-state transition;
+``probe_ambient_health`` surfaces the verdict in the infrastructure snapshot; and
+``bridge_snapshot`` serves the dashboard voice Bridge tab the full health payload
+on demand (``GET /api/genesis/voice/bridge``).
 
 No config file -> the monitor is a silent no-op, so installs without an ambient
 edge are unaffected. The edge host/IP lives ONLY in the install-local config,
@@ -15,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -186,3 +190,44 @@ def evaluate_ambient_health(
     if status == "ok":
         reasons.append("healthy")
     return AmbientVerdict(status, reasons)
+
+
+async def bridge_snapshot(*, now: datetime | None = None) -> dict:
+    """One-call data contract for the dashboard voice Bridge tab.
+
+    Composes the module's own pieces — config load, SSH read, verdict — and
+    returns the FULL edge health payload under a ``health`` sub-key (no
+    filtering, so future edge keys surface without a Genesis-side change).
+    Deliberately separate from ``probe_ambient_health``: that shared
+    infrastructure card carries only the verdict and sits behind snapshot +
+    SSH-TTL caches; the cockpit tab wants the whole payload, fresh, on demand.
+
+    Never raises. ``now`` is a test seam for verdict staleness (defaults to
+    real time in :func:`evaluate_ambient_health`).
+    """
+    try:
+        cfg = load_ambient_remote_config()
+    except AmbientRemoteConfigError as exc:
+        return {
+            "configured": True,
+            "reachable": False,
+            "verdict": "misconfigured",
+            "reasons": [str(exc)],
+        }
+    if cfg is None:
+        return {"configured": False, "reason": "no ambient edge configured"}
+
+    start = time.monotonic()
+    data = await read_edge_health(cfg)  # None on any failure, never raises
+    latency_ms = round((time.monotonic() - start) * 1000, 2)
+    verdict = evaluate_ambient_health(data, now=now)
+    out = {
+        "configured": True,
+        "reachable": data is not None,
+        "verdict": verdict.status,
+        "reasons": verdict.reasons,
+        "latency_ms": latency_ms,
+    }
+    if data is not None:
+        out["health"] = data
+    return out

--- a/tests/test_dashboard/test_voice_api.py
+++ b/tests/test_dashboard/test_voice_api.py
@@ -63,3 +63,29 @@ def test_page_served_when_configured(client):
         resp = client.get("/genesis/voice")
     assert resp.status_code == 200
     assert b"Genesis Voice" in resp.data  # the served template
+
+
+# ── /api/genesis/voice/bridge (wiring: route registered, snapshot passthrough) ──
+
+def test_bridge_route_returns_snapshot_verbatim(client):
+    snap = {
+        "configured": True, "reachable": True, "verdict": "ok",
+        "reasons": ["healthy"], "latency_ms": 12.3,
+        "health": {"ts": "2026-06-18T12:00:00+00:00", "rss_total_mb": 438.0},
+    }
+    with patch(
+        "genesis.observability.ambient_health.bridge_snapshot", return_value=snap,
+    ):
+        resp = client.get("/api/genesis/voice/bridge")
+    assert resp.status_code == 200
+    assert resp.get_json() == snap
+
+
+def test_bridge_route_not_configured_is_200(client):
+    snap = {"configured": False, "reason": "no ambient edge configured"}
+    with patch(
+        "genesis.observability.ambient_health.bridge_snapshot", return_value=snap,
+    ):
+        resp = client.get("/api/genesis/voice/bridge")
+    assert resp.status_code == 200
+    assert resp.get_json()["configured"] is False

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -1,8 +1,10 @@
-"""Unit tests for the pure ambient-health evaluator.
+"""Unit tests for the pure ambient-health evaluator + the bridge snapshot.
 
-Covers the alert-decision logic (the testable core); the SSH read + scheduler
-wiring are verified on-device (they need the edge + a running scheduler).
+Covers the alert-decision logic (the testable core) and ``bridge_snapshot``'s
+composition/contract; the SSH read + scheduler wiring are verified on-device
+(they need the edge + a running scheduler).
 """
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -130,3 +132,82 @@ def test_load_unparseable_raises(tmp_path, monkeypatch):
     _point_config_at(tmp_path, monkeypatch, "host_ip: [1, 2\n")
     with pytest.raises(AmbientRemoteConfigError):
         load_ambient_remote_config()
+
+
+# --- bridge_snapshot: the voice Bridge tab's one-call data contract ---
+# Composes load_ambient_remote_config + read_edge_health + evaluate_ambient_health;
+# must NEVER raise (the dashboard route serializes whatever comes back).
+
+
+def _cfg() -> AmbientRemoteConfig:
+    return AmbientRemoteConfig(host_ip="192.0.2.9", host_user="edge")
+
+
+def test_bridge_snapshot_not_configured(monkeypatch):
+    monkeypatch.setattr(ambient_health, "load_ambient_remote_config", lambda: None)
+    out = asyncio.run(ambient_health.bridge_snapshot())
+    assert out == {"configured": False, "reason": "no ambient edge configured"}
+
+
+def test_bridge_snapshot_misconfigured(monkeypatch):
+    # Present-but-broken config must surface VISIBLY (not raise, not look absent).
+    def _raise():
+        raise AmbientRemoteConfigError("enabled but missing host_ip/host_user")
+
+    monkeypatch.setattr(ambient_health, "load_ambient_remote_config", _raise)
+    out = asyncio.run(ambient_health.bridge_snapshot())
+    assert out["configured"] is True
+    assert out["reachable"] is False
+    assert out["verdict"] == "misconfigured"
+    assert any("host_ip" in r for r in out["reasons"])
+    assert "health" not in out
+
+
+def test_bridge_snapshot_unreachable_edge(monkeypatch):
+    monkeypatch.setattr(ambient_health, "load_ambient_remote_config", _cfg)
+
+    async def _none(cfg):
+        return None
+
+    monkeypatch.setattr(ambient_health, "read_edge_health", _none)
+    out = asyncio.run(ambient_health.bridge_snapshot(now=NOW))
+    assert out["configured"] is True
+    assert out["reachable"] is False
+    assert out["verdict"] == "unknown"
+    assert isinstance(out["latency_ms"], float)
+    assert "health" not in out
+
+
+def test_bridge_snapshot_happy_passthrough(monkeypatch):
+    monkeypatch.setattr(ambient_health, "load_ambient_remote_config", _cfg)
+    snap = _snapshot(rss_total_mb=438.0, ort_arena_off=True)
+
+    async def _data(cfg):
+        return snap
+
+    monkeypatch.setattr(ambient_health, "read_edge_health", _data)
+    out = asyncio.run(ambient_health.bridge_snapshot(now=NOW))
+    assert out["configured"] is True
+    assert out["reachable"] is True
+    assert out["verdict"] == "ok"
+    assert out["reasons"] == ["healthy"]
+    # Full passthrough under a "health" sub-key — no filtering, so future edge
+    # keys surface without a Genesis-side change.
+    assert out["health"]["rss_total_mb"] == 438.0
+    assert isinstance(out["latency_ms"], float)
+
+
+def test_bridge_snapshot_verdict_logic_reused_not_reimplemented(monkeypatch):
+    # A stale heartbeat must flow through evaluate_ambient_health as "down":
+    # the SSH read WORKED (reachable=True) — it's the bridge process that's dead.
+    monkeypatch.setattr(ambient_health, "load_ambient_remote_config", _cfg)
+    stale = _snapshot(ts=(NOW - timedelta(minutes=10)).isoformat())
+
+    async def _data(cfg):
+        return stale
+
+    monkeypatch.setattr(ambient_health, "read_edge_health", _data)
+    out = asyncio.run(ambient_health.bridge_snapshot(now=NOW))
+    assert out["reachable"] is True
+    assert out["verdict"] == "down"
+    assert any("stale" in r for r in out["reasons"])


### PR DESCRIPTION
## What

The voice dashboard's **Bridge tab** becomes a full cockpit. Previously it showed only status/latency/verdict — the rich edge health payload never reached the frontend (`probe_ambient_health` forwards only the verdict into the shared infrastructure snapshot).

- **`bridge_snapshot()`** (`observability/ambient_health.py`): composes the module's existing config-load / SSH-read / verdict pieces into one never-raising call; full `ambient_health.json` passthrough under a `health` sub-key so future edge keys surface without a Genesis-side change. TDD, 5 tests.
- **`GET /api/genesis/voice/bridge`** (`dashboard/routes/voice.py`): thin on-demand `_async_route` wrapper — deliberately NOT widening the shared infrastructure probe (avoids leaking ~25 keys into the generic health cards, and skips its two cache layers, wrong for a live cockpit). 20s timeout is strictly a backstop above the SSH read's ~15s internal bound. 2 wiring tests.
- **Bridge panel** (`genesis_voice.html`): verdict as a shared status chip + ages via `fmtAge` (reusing #893's `ui-utils.js` — its docstring names this page as an intended consumer), grouped sections: memory leak-watch (RSS parent/child/total, ORT-arena state, pool recycles), capture, diarization, connection stability, speaker ID, plus a forward-compat "Other" k/v for unknown health keys.
- CHANGELOG: this + the previously-missed #876 Device-tab entry.

## Verification

- TDD RED→GREEN; blast-radius sweep 58/58 (`test_ambient_health` + `test_voice_api` + `test_health`), ruff clean.
- **Full-stack browser E2E pre-PR** via a throwaway local server running this branch: panel renders live edge data end-to-end (chip styled, ages humanized, all groups populated, "Other" catches un-rendered keys); "not configured" degradation verified visually.
- Code review: 1 finding (`conn_dark_since` listed as shown but rendered nowhere) — fixed in `7f1ed78a`.
- Private-data scan of the full diff: clean (test fixtures use RFC 5737 TEST-NET only; edge host/user stay in install-local config).

## Notes

- The voice page's horizontal overflow at narrow viewports is **pre-existing** (reproduces on the untouched Device tab) — left for the Dashboard P1 restyle workstream.
- Deploy note: needs a genesis-server restart (new Python route); the template half is served from disk per-request, so FF + restart should happen together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)