### PR TITLE
fix(inbox): fold parked files into the refresh batch (30-min approval nag)

### DIFF
--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -682,7 +682,15 @@ class InboxMonitor:
                     exc_info=True,
                 )
 
-            # Invalidate inbox_items parked on the cancelled approval.
+            # Invalidate inbox_items parked on the cancelled approval and
+            # fold their files into THIS refresh. Invalidated rows are
+            # excluded from get_all_known and from retry by design ("fresh
+            # rows with fresh approvals"), so a parked file that is not
+            # re-dispatched here re-surfaces as phantom-new next scan and
+            # cancels the fresh approval in turn — two parked files then
+            # leapfrog forever: a cancel + a new request (a Telegram
+            # message) every scan with no disk change.
+            parked_paths: list[str] = []
             try:
                 awaiting = await inbox_items.get_awaiting_approval(self._db)
                 for row in awaiting:
@@ -699,11 +707,25 @@ class InboxMonitor:
                             ),
                             processed_at=self._clock().isoformat(),
                         )
+                        parked_paths.append(str(row["file_path"]))
             except Exception:
                 logger.warning(
                     "Failed to invalidate parked inbox items for %s",
                     pending_id,
                     exc_info=True,
+                )
+
+            detected = {str(p) for p in new_files}
+            detected |= {str(p) for p in modified_files}
+            folded = [
+                Path(fp) for fp in dict.fromkeys(parked_paths)
+                if fp not in detected and Path(fp).exists()
+            ]
+            if folded:
+                modified_files = [*modified_files, *folded]
+                logger.info(
+                    "Folded %d parked file(s) into the refresh batch: %s",
+                    len(folded), ", ".join(p.name for p in folded),
                 )
 
             return new_files, modified_files

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -783,8 +783,13 @@ async def test_refresh_folds_parked_files_no_oscillation(
 async def test_refresh_does_not_resurrect_deleted_parked_file(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):
-    """A parked file deleted from disk must NOT be folded back into the
-    refresh batch, and must not oscillate afterwards."""
+    """End-to-end: a parked file deleted from disk stays out of the refresh
+    batch and does not oscillate afterwards.
+
+    (In the full check_once flow the resume phase's vanished-file check
+    invalidates the row before the fold runs — the fold's own exists() guard
+    is isolated in test_fold_skips_parked_path_missing_from_disk.)
+    """
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
     disp, gate = _stateful_dispatcher(mon._clock)
     mon._autonomous_dispatcher = disp
@@ -805,6 +810,45 @@ async def test_refresh_does_not_resurrect_deleted_parked_file(
     parked = await inbox_items.get_awaiting_approval(db)
     assert {p["file_path"] for p in parked} == {str(file_b)}
     assert gate.request_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fold_skips_parked_path_missing_from_disk(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """Isolates the fold's exists() guard in _phase_detect_changes: a parked
+    row whose file is gone by the time the refresh folds (deleted mid-cycle,
+    after the resume phase's own vanished-file check already ran) must be
+    invalidated but NOT folded into the refresh batch."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    disp, gate = _stateful_dispatcher(mon._clock)
+    mon._autonomous_dispatcher = disp
+    gate.pending_id = "req-1"
+    gate.created_at = mon._clock().isoformat()
+
+    ghost = inbox_dir / "Ghost.md"  # parked row exists; file never on disk
+    await inbox_items.create(
+        db, id="row-g", file_path=str(ghost), content_hash="h",
+        status="processing", created_at="2026-06-30T11:00:00+00:00",
+        drop_id="DG", batch_items="https://example.com/g0",
+    )
+    await inbox_items.update_status(
+        db, "row-g", status="processing",
+        error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-1",
+    )
+    live = inbox_dir / "Live.md"
+    live.write_text("https://example.com/n0")  # triggers the refresh
+
+    new_files, modified_files = await mon._phase_detect_changes(
+        inbox_dir, resumed_paths=set(),
+    )
+
+    returned = {str(p) for p in [*new_files, *modified_files]}
+    assert str(live) in returned
+    assert str(ghost) not in returned, "vanished parked file was folded"
+    row = await inbox_items.get_by_id(db, "row-g")
+    assert row["status"] == "failed"  # still invalidated, just not re-dispatched
+    assert gate.cancel_calls == ["req-1"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -663,3 +663,188 @@ async def test_follow_up_dedup_key_persisted(db, inbox_dir, mock_invoker, mock_s
     assert len(row) == 1
     assert row[0]["dedup_key"]  # non-null
     assert await follow_ups.exists_by_dedup_key(db, row[0]["dedup_key"]) is True
+
+
+# ── Refresh folds parked files into one batch (oscillator regression) ────
+
+
+class _StatefulGate:
+    """Model the REAL gate contract for the inbox site (stable approval key):
+    at most ONE pending request per site; route() while pending parks on the
+    existing request; cancel() clears it; the next route() after a cancel
+    creates a fresh request id (in production: a fresh Telegram message).
+    """
+
+    def __init__(self, clock):
+        self._clock = clock
+        self.pending_id: str | None = None
+        self.created_at: str = ""
+        self.approved: set[str] = set()
+        self.request_count = 0
+        self.cancel_calls: list[str] = []
+
+    async def route(self, request):
+        if self.pending_id is None:
+            self.request_count += 1
+            self.pending_id = f"req-{self.request_count}"
+            self.created_at = self._clock().isoformat()
+        return AutonomousDispatchDecision(
+            mode="blocked", reason="approval requested",
+            approval_request_id=self.pending_id,
+        )
+
+    async def find_site_pending(self, *, subsystem, policy_id):
+        if self.pending_id is None:
+            return None
+        return {"id": self.pending_id, "created_at": self.created_at}
+
+    async def cancel(self, request_id):
+        self.cancel_calls.append(request_id)
+        if request_id == self.pending_id:
+            self.pending_id = None
+        return True
+
+    def approve(self):
+        assert self.pending_id is not None
+        self.approved.add(self.pending_id)
+        self.pending_id = None
+
+    async def get_by_id(self, request_id):
+        if request_id == self.pending_id:
+            return {"status": "pending"}
+        if request_id in self.approved:
+            return {"status": "approved"}
+        return {"status": "cancelled"}
+
+
+def _stateful_dispatcher(clock):
+    gate = _StatefulGate(clock)
+    d = SimpleNamespace()
+    d.route = gate.route
+    d.approval_gate = SimpleNamespace(
+        find_site_pending=gate.find_site_pending,
+        approval_manager=SimpleNamespace(
+            get_by_id=gate.get_by_id, cancel=gate.cancel,
+        ),
+        mark_consumed=AsyncMock(return_value=True),
+    )
+    return d, gate
+
+
+@pytest.mark.asyncio
+async def test_refresh_folds_parked_files_no_oscillation(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """Two files parked on one approval + one file edited → the refresh must
+    cancel ONCE and re-park BOTH files on the fresh request.
+
+    Without folding the parked files into the refresh batch, the
+    not-refreshed file's rows are invalidated but never re-dispatched, so it
+    re-surfaces as phantom-"new" next scan and the two files leapfrog:
+    cancel + recreate every scan (a Telegram message each time) with NO disk
+    change — the 30-minute approval nag.
+    """
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    disp, gate = _stateful_dispatcher(mon._clock)
+    mon._autonomous_dispatcher = disp
+    file_a = inbox_dir / "Genesis.md"
+    file_b = inbox_dir / "Capabilities.md"
+    file_a.write_text(_urls(2))
+    file_b.write_text("https://example.com/b0\nhttps://example.com/b1")
+
+    # Scan 1: both drops park on the single site-stable request.
+    await mon.check_once()
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert {p["file_path"] for p in parked} == {str(file_a), str(file_b)}
+    assert gate.request_count == 1
+
+    # The user edits B while the approval is pending.
+    file_b.write_text("https://example.com/b9")
+
+    # Scan 2: ONE cancel, and the refreshed request covers BOTH files.
+    await mon.check_once()
+    assert gate.cancel_calls == ["req-1"]
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert {p["file_path"] for p in parked} == {str(file_a), str(file_b)}, (
+        "parked files must fold into the refresh batch"
+    )
+    assert gate.request_count == 2
+
+    # Scans 3-4, disk unchanged: detection stays quiet — no cancel, no new
+    # request, no dispatch. (Unfixed: A and B alternate forever.)
+    await mon.check_once()
+    await mon.check_once()
+    assert gate.cancel_calls == ["req-1"], "approval churned on unchanged disk"
+    assert gate.request_count == 2
+    assert mock_invoker.run.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_resurrect_deleted_parked_file(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A parked file deleted from disk must NOT be folded back into the
+    refresh batch, and must not oscillate afterwards."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    disp, gate = _stateful_dispatcher(mon._clock)
+    mon._autonomous_dispatcher = disp
+    file_a = inbox_dir / "Genesis.md"
+    file_b = inbox_dir / "Capabilities.md"
+    file_a.write_text(_urls(2))
+    file_b.write_text("https://example.com/b0")
+
+    await mon.check_once()  # both park on req-1
+    file_a.unlink()
+    file_b.write_text("https://example.com/b9")
+
+    await mon.check_once()  # refresh: only B re-parks
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert {p["file_path"] for p in parked} == {str(file_b)}
+
+    await mon.check_once()  # deleted file stays gone; no churn
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert {p["file_path"] for p in parked} == {str(file_b)}
+    assert gate.request_count == 2
+
+
+@pytest.mark.asyncio
+async def test_folded_file_reevaluates_only_unprocessed_delta(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A folded parked file must go through the same delta batching as any
+    modified file: URLs already evaluated in a prior approved run are NOT
+    re-evaluated when the file is folded into a refresh batch."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    disp, gate = _stateful_dispatcher(mon._clock)
+    mon._autonomous_dispatcher = disp
+    file_a = inbox_dir / "Genesis.md"
+    file_a.write_text(_urls(2))  # a0, a1
+
+    await mon.check_once()          # A parks on req-1
+    gate.approve()
+    await mon.check_once()          # resume: a0/a1 evaluated (baseline)
+    assert mock_invoker.run.call_count == 1
+
+    # User appends 2 new URLs -> parks on req-2 (delta batch only).
+    file_a.write_text(_urls(4))     # a0..a3
+    await mon.check_once()
+    assert gate.request_count == 2
+
+    # A second file arrives while req-2 is pending -> refresh folds A.
+    file_b = inbox_dir / "Capabilities.md"
+    file_b.write_text("https://example.com/b0")
+    await mon.check_once()
+    assert gate.cancel_calls == ["req-2"]
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert {p["file_path"] for p in parked} == {str(file_a), str(file_b)}
+
+    # Approve the merged request: only the delta + the new file are evaluated.
+    gate.approve()
+    await mon.check_once()
+    prompts = " ".join(
+        c.args[0].prompt for c in mock_invoker.run.call_args_list[1:]
+    )
+    assert "https://example.com/a2" in prompts
+    assert "https://example.com/a3" in prompts
+    assert "https://example.com/b0" in prompts
+    assert "https://example.com/a0" not in prompts, "re-evaluated processed URL"


### PR DESCRIPTION
## Problem

Inbox approvals nagged via Telegram every 30 minutes (38 system-cancelled approval requests on 2026-07-06 alone; same storm pattern Jun 28-29). Mechanism, verified live: two files parked on one pending approval; the refresh path in `_phase_detect_changes` cancels the approval and invalidates ALL rows parked on it, but re-dispatches only the newly-detected file. The other file's invalidated rows are excluded from `get_all_known` by design, so it re-surfaces as phantom-new on the next scan, cancels the fresh approval in turn, and the two files leapfrog forever — a new approval request (= new Telegram message) every scan with no disk change.

No notification-policy change caused this: fire-once + 24h re-ask is intact; the churn creates genuinely-new approvals. Latent since the #323 refresh path; the crud docstrings' design intent ("fresh rows with fresh approvals" via re-detection) is what the leapfrog exploits — re-detection lands one scan too late.

## Fix

The refresh's invalidation loop now collects the file paths of the rows it invalidates and folds them (deduped against detected files, still-existing files only) into the returned `modified_files`, so ONE merged batch covers parked + new in the same cycle. Folded files flow through the identical modified-file machinery (including #810 URL-delta batching) they would have taken via re-detection one scan later — the fix changes when, not how.

## Tests

- Oscillator repro: two files parked on one approval, one edited → ONE cancel, merged re-park of BOTH files, and quiet scans (no cancel, no new request) on unchanged disk. Fails on unfixed code at the merged re-park assertion.
- Folded file with a prior completed baseline re-evaluates ONLY the unprocessed URL delta (never re-evals baselined URLs).
- Deleted parked file: end-to-end non-resurrection, plus an isolated test of the fold's `exists()` guard (mutation-verified: removing the guard fails the test).
- Stateful gate mock models the real stable-approval-key contract (one pending per site; cancel clears; next route mints a fresh id).

Review: inline code review clean, no blocking findings. One reviewer observation on record: the pre-existing `modified_files` loop in `_phase_create_records` lacks the `count_url_failures` retry-storm guard that the `new_files`/`retry_files` loops have; no realistic exploit path found (parked rows are pre-dispatch; URL-failure history is post-dispatch), so intentionally not changed here.

## Verification plan (post-deploy)

With files parked on a pending approval: first scan after new content → one refresh message covering the merged batch; subsequent unchanged-disk scans → journal shows "Inbox detection skipped — approval pending, no new files", no cancel, no new `approval_requests` rows. Regression markers: no "cancelling stale approval to refresh" on unchanged-disk scans; inbox-eval approval creations ≤1/day absent real drops; superseded rows stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)