### PR TITLE
feat(observability): RSS-threshold leak-regression alert for the ambient bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Ambient bridge memory-leak regression alert.** If the edge bridge's RSS ever climbs past the
+  healthy plateau again (total > 1000 MB or diarization child > 450 MB), ambient health flips to
+  degraded and you get a one-time Telegram alert naming the breach — no nagging, and normal
+  workload bursts never trigger it. Requires an ambient edge reporting the `rss_*` health keys.
+
 - **The voice dashboard's Bridge tab is now a full cockpit.** Instead of a bare status line, it
   shows the ambient edge bridge's complete live health, grouped for scanning: memory leak-watch
   (parent / diarization-child / total RSS, ORT-arena state, pool recycles), capture activity

--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -34,6 +34,15 @@ _DEFAULT_KEY = "~/.ssh/id_ed25519"
 _HEARTBEAT_STALE_S = 300.0
 _SSH_TIMEOUT_S = 10.0
 
+# RSS ceilings for the leak-class regression watch. Calibrated from the
+# post-arena-off soak (closed 2026-07-06, 4.6 days): total plateau ~470 MB with
+# activity bursts to ~780; diar child flat ~170 with window excursions to ~280.
+# Ceilings sit ~2x the worst observed burst so workload breathing never fires
+# them — only a real regression of the leak class does (pre-fix pathology was
+# 1.67 GB total / 840+ MB child).
+_RSS_TOTAL_ALERT_MB = 1000.0
+_RSS_DIAR_CHILD_ALERT_MB = 450.0
+
 
 @dataclass(frozen=True)
 class AmbientRemoteConfig:
@@ -186,6 +195,23 @@ def evaluate_ambient_health(
         reasons.append("diarization worker not alive")
         if status == "ok":
             status = "degraded"
+
+    # Leak-class regression watch: RSS beyond the trusted post-arena-off
+    # plateau ceiling. Null/absent keys are normal (lazy diar-pool spawn,
+    # older edge builds) — never a breach. Only upgrades ok -> degraded;
+    # a dead bridge stays "down" (but the reason is still appended).
+    for key, ceiling, label in (
+        ("rss_total_mb", _RSS_TOTAL_ALERT_MB, "total"),
+        ("rss_diar_child_mb", _RSS_DIAR_CHILD_ALERT_MB, "diar child"),
+    ):
+        value = data.get(key)
+        if isinstance(value, (int, float)) and value > ceiling:
+            reasons.append(
+                f"{label} RSS {value:.0f} MB exceeds the {ceiling:.0f} MB "
+                "plateau ceiling — possible leak regression",
+            )
+            if status == "ok":
+                status = "degraded"
 
     if status == "ok":
         reasons.append("healthy")

--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -141,6 +141,12 @@ async def read_edge_health(cfg: AmbientRemoteConfig) -> dict | None:
 class AmbientVerdict:
     status: str  # "ok" | "degraded" | "down" | "unknown"
     reasons: list[str]
+    # Stable, value-free keys for the reasons ("bridge-dead" | "diar-worker" |
+    # "rss-total" | "rss-diar-child" | "unreachable"). Consumers need these to
+    # detect a NEW fault appearing while already degraded — reason strings
+    # embed live numbers and the bare status can't distinguish causes, so a
+    # status-edge alert gate would silently swallow a second, independent fault.
+    causes: tuple[str, ...] = ()
 
 
 def _parse_ts(value: object) -> datetime | None:
@@ -173,15 +179,19 @@ def evaluate_ambient_health(
     not a fault to alert on.
     """
     if data is None:
-        return AmbientVerdict("unknown", ["edge health unreachable / unreadable"])
+        return AmbientVerdict(
+            "unknown", ["edge health unreachable / unreadable"], ("unreachable",),
+        )
 
     now = now or datetime.now(UTC)
     reasons: list[str] = []
+    causes: list[str] = []
     status = "ok"
 
     ts = _parse_ts(data.get("ts"))
     if ts is None:
         reasons.append("health file has no/invalid heartbeat ts")
+        causes.append("bridge-dead")
         status = "down"
     else:
         age = (now - ts).total_seconds()
@@ -189,10 +199,12 @@ def evaluate_ambient_health(
             reasons.append(
                 f"heartbeat stale ({age:.0f}s > {_HEARTBEAT_STALE_S:.0f}s) — bridge dead/hung",
             )
+            causes.append("bridge-dead")
             status = "down"
 
     if data.get("diar_enabled") and not data.get("diar_worker_alive", False):
         reasons.append("diarization worker not alive")
+        causes.append("diar-worker")
         if status == "ok":
             status = "degraded"
 
@@ -200,9 +212,9 @@ def evaluate_ambient_health(
     # plateau ceiling. Null/absent keys are normal (lazy diar-pool spawn,
     # older edge builds) — never a breach. Only upgrades ok -> degraded;
     # a dead bridge stays "down" (but the reason is still appended).
-    for key, ceiling, label in (
-        ("rss_total_mb", _RSS_TOTAL_ALERT_MB, "total"),
-        ("rss_diar_child_mb", _RSS_DIAR_CHILD_ALERT_MB, "diar child"),
+    for key, ceiling, label, cause in (
+        ("rss_total_mb", _RSS_TOTAL_ALERT_MB, "total", "rss-total"),
+        ("rss_diar_child_mb", _RSS_DIAR_CHILD_ALERT_MB, "diar child", "rss-diar-child"),
     ):
         value = data.get(key)
         if isinstance(value, (int, float)) and value > ceiling:
@@ -210,12 +222,13 @@ def evaluate_ambient_health(
                 f"{label} RSS {value:.0f} MB exceeds the {ceiling:.0f} MB "
                 "plateau ceiling — possible leak regression",
             )
+            causes.append(cause)
             if status == "ok":
                 status = "degraded"
 
     if status == "ok":
         reasons.append("healthy")
-    return AmbientVerdict(status, reasons)
+    return AmbientVerdict(status, reasons, tuple(causes))
 
 
 async def bridge_snapshot(*, now: datetime | None = None) -> dict:
@@ -252,6 +265,7 @@ async def bridge_snapshot(*, now: datetime | None = None) -> dict:
         "reachable": data is not None,
         "verdict": verdict.status,
         "reasons": verdict.reasons,
+        "causes": list(verdict.causes),
         "latency_ms": latency_ms,
     }
     if data is not None:

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -63,6 +63,11 @@ class OutreachScheduler:
         self._cached_critical_obs_at: float = 0.0  # monotonic time of cache
         # Ambient-capture health — last-known status (alert only on a state change).
         self._ambient_health_status: str = "ok"
+        # Cause keys already alerted on (from AmbientVerdict.causes). A bare
+        # status-edge gate would swallow a NEW independent fault that appears
+        # while the bridge is already degraded/down (e.g. an RSS regression
+        # during a diar-worker outage) — track causes so new ones re-alert.
+        self._ambient_health_causes: set[str] = set()
 
     @property
     def is_running(self) -> bool:
@@ -490,13 +495,15 @@ class OutreachScheduler:
             await self._record_job_result("critical_observations", error=str(exc))
 
     async def _ambient_health_job(self) -> None:
-        """Alert when the edge ambient-capture bridge goes dark.
+        """Alert when the edge ambient-capture bridge goes dark or regresses.
 
         SSH-reads the edge health file, evaluates it, and alerts the user
-        (Telegram) on a transition into a bad state, with a recovery note when it
-        comes back. No-op if ~/.genesis/ambient_remote.yaml is not configured.
-        Runs even when paused (observability, not a dispatch). A single "unknown"
-        (transient SSH failure) does not flip the alert state.
+        (Telegram) on a transition into a bad state OR when a new independent
+        fault cause appears while already bad (see ``AmbientVerdict.causes``),
+        with a recovery note when it comes back. No-op if
+        ~/.genesis/ambient_remote.yaml is not configured. Runs even when paused
+        (observability, not a dispatch). A single "unknown" (transient SSH
+        failure) does not flip the alert state.
         """
         try:
             from genesis.observability.ambient_health import (
@@ -525,13 +532,17 @@ class OutreachScheduler:
             prev = self._ambient_health_status
 
             if verdict.status in ("down", "degraded"):
-                # Alert ONCE on entering a bad state — no nagging, no periodic re-alert.
-                if prev not in ("down", "degraded"):
+                # Alert ONCE on entering a bad state — no nagging on the same
+                # persisting cause — but DO re-alert when a NEW independent
+                # fault appears while already bad (cause keys are value-free,
+                # so a changing RSS number never counts as "new").
+                new_causes = set(verdict.causes) - self._ambient_health_causes
+                if prev not in ("down", "degraded") or new_causes:
                     emoji = "\U0001f534" if verdict.status == "down" else "\U0001f7e1"
                     text = (
                         f"{emoji} Ambient capture {verdict.status.upper()}\n"
                         + "\n".join(f"• {r}" for r in verdict.reasons)
-                        + "\n\n(ambient bridge process down/hung — check/restart ambient-bridge.service)"
+                        + f"\n\n{self._ambient_remedy_hint(verdict.causes)}"
                     )
                     envelope = OutreachRequest(
                         category=OutreachCategory.BLOCKER,
@@ -544,6 +555,7 @@ class OutreachScheduler:
                     result = await self._pipeline.submit_raw(text, envelope)
                     logger.info("Ambient health alert (%s): %s", verdict.status, result.status.value)
                 self._ambient_health_status = verdict.status
+                self._ambient_health_causes = set(verdict.causes)
             elif verdict.status == "ok":
                 if prev in ("down", "degraded"):
                     text = "\U0001f7e2 Ambient capture recovered (healthy)."
@@ -558,12 +570,31 @@ class OutreachScheduler:
                     await self._pipeline.submit_raw(text, envelope)
                     logger.info("Ambient health recovered")
                 self._ambient_health_status = "ok"
+                self._ambient_health_causes = set()
             # status == "unknown": transient — leave _ambient_health_status as-is
 
             await self._record_job_result("ambient_health")
         except Exception as exc:
             logger.exception("Ambient health monitor job failed")
             await self._record_job_result("ambient_health", error=str(exc))
+
+    @staticmethod
+    def _ambient_remedy_hint(causes: tuple[str, ...]) -> str:
+        """Cause-aware remediation line for the ambient alert (worst cause wins).
+
+        "degraded" is a multi-cause bucket (dead diar worker, RSS regression) —
+        a fixed "process down/hung" suffix misdiagnoses a live-but-leaking bridge.
+        """
+        if "bridge-dead" in causes:
+            return "(ambient bridge process down/hung — check/restart ambient-bridge.service)"
+        if "diar-worker" in causes:
+            return "(diarization worker crashed — a bridge restart respawns it: systemctl --user restart ambient-bridge)"
+        if "rss-total" in causes or "rss-diar-child" in causes:
+            return (
+                "(RSS past the healthy plateau — possible leak regression; a bridge "
+                "restart reclaims memory, but investigate before the VM feels it)"
+            )
+        return "(check the bridge: journalctl --user -u ambient-bridge)"
 
     async def _calibration_job(self) -> None:
         """Reconcile predictions and recompute calibration curves."""

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -211,3 +211,52 @@ def test_bridge_snapshot_verdict_logic_reused_not_reimplemented(monkeypatch):
     assert out["reachable"] is True
     assert out["verdict"] == "down"
     assert any("stale" in r for r in out["reasons"])
+
+
+# --- RSS-threshold alert: leak-class regression watch on the health snapshot ---
+# Thresholds sit ~2x the worst observed post-arena-off burst (soak closed
+# 2026-07-06: total plateau ~470 MB / bursts ~780; child flat ~170 / bursts ~280)
+# so workload breathing never fires them, only a real regression does.
+
+
+def test_rss_total_over_ceiling_is_degraded():
+    verdict = evaluate_ambient_health(_snapshot(rss_total_mb=1200.0), now=NOW)
+    assert verdict.status == "degraded"
+    assert any("RSS" in r and "1200" in r for r in verdict.reasons)
+
+
+def test_rss_child_over_ceiling_is_degraded():
+    verdict = evaluate_ambient_health(_snapshot(rss_diar_child_mb=600.0), now=NOW)
+    assert verdict.status == "degraded"
+    assert any("diar child" in r for r in verdict.reasons)
+
+
+def test_rss_at_plateau_is_ok():
+    verdict = evaluate_ambient_health(
+        _snapshot(rss_total_mb=470.0, rss_diar_child_mb=170.0, rss_parent_mb=300.0),
+        now=NOW,
+    )
+    assert verdict.status == "ok"
+
+
+def test_rss_keys_absent_or_null_do_not_trigger():
+    # Lazy pool spawn → child key is null until the first diar window; absent
+    # keys (older edge) must also be a no-op. Null/absent != breach.
+    assert evaluate_ambient_health(_snapshot(rss_diar_child_mb=None), now=NOW).status == "ok"
+    assert evaluate_ambient_health(_snapshot(), now=NOW).status == "ok"
+
+
+def test_rss_non_numeric_is_ignored():
+    verdict = evaluate_ambient_health(_snapshot(rss_total_mb="lots"), now=NOW)
+    assert verdict.status == "ok"
+
+
+def test_rss_breach_does_not_mask_down():
+    # A dead bridge (stale heartbeat) stays "down" even when RSS also breaches;
+    # the RSS reason is still appended for the operator.
+    stale = (NOW - timedelta(minutes=10)).isoformat()
+    verdict = evaluate_ambient_health(
+        _snapshot(ts=stale, rss_total_mb=1200.0), now=NOW,
+    )
+    assert verdict.status == "down"
+    assert any("RSS" in r for r in verdict.reasons)

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -260,3 +260,32 @@ def test_rss_breach_does_not_mask_down():
     )
     assert verdict.status == "down"
     assert any("RSS" in r for r in verdict.reasons)
+
+
+def test_causes_are_stable_machine_keys():
+    # Consumers (the outreach alert state machine) need value-free keys to
+    # detect a NEW fault while already degraded — reason strings embed live
+    # numbers, and the bare status can't distinguish causes.
+    assert evaluate_ambient_health(_snapshot(), now=NOW).causes == ()
+    assert evaluate_ambient_health(None, now=NOW).causes == ("unreachable",)
+    stale = (NOW - timedelta(minutes=10)).isoformat()
+    assert evaluate_ambient_health(_snapshot(ts=stale), now=NOW).causes == ("bridge-dead",)
+    assert evaluate_ambient_health(
+        _snapshot(diar_worker_alive=False), now=NOW,
+    ).causes == ("diar-worker",)
+    verdict = evaluate_ambient_health(
+        _snapshot(rss_total_mb=1200.0, rss_diar_child_mb=600.0), now=NOW,
+    )
+    assert verdict.causes == ("rss-total", "rss-diar-child")
+
+
+def test_bridge_snapshot_carries_causes(monkeypatch):
+    monkeypatch.setattr(ambient_health, "load_ambient_remote_config", _cfg)
+    snap = _snapshot(rss_total_mb=1200.0)
+
+    async def _data(cfg):
+        return snap
+
+    monkeypatch.setattr(ambient_health, "read_edge_health", _data)
+    out = asyncio.run(ambient_health.bridge_snapshot(now=NOW))
+    assert out["causes"] == ["rss-total"]

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -333,3 +333,95 @@ async def test_drain_ages_out_naive_timestamp_row(config, db):
 
     pipeline.submit.assert_not_called()
     assert await _remaining(db) == []
+
+
+# ── ambient health alert gating (cause-aware state machine) ─────────────────
+# governance dedups ambient_health with window=0 ("the monitor's state machine
+# gates re-alerts") — so THIS state machine is the only thing standing between
+# the user and a silently-swallowed second fault.
+
+
+def _ambient_snapshot(**overrides):
+    from datetime import UTC, datetime
+
+    base = {
+        "ts": datetime.now(UTC).isoformat(),
+        "active_connections": 1,
+        "diar_enabled": True,
+        "diar_worker_alive": True,
+    }
+    base.update(overrides)
+    return base
+
+
+async def _ambient_tick(scheduler, snapshot):
+    with (
+        patch(
+            "genesis.observability.ambient_health.load_ambient_remote_config",
+            return_value=object(),
+        ),
+        patch(
+            "genesis.observability.ambient_health.read_edge_health",
+            AsyncMock(return_value=snapshot),
+        ),
+    ):
+        await scheduler._ambient_health_job()
+
+
+def _make_scheduler(config, db):
+    return OutreachScheduler(AsyncMock(), AsyncMock(), AsyncMock(), config, db)
+
+
+@pytest.mark.asyncio
+async def test_ambient_new_cause_realerts_while_already_degraded(config, db):
+    scheduler = _make_scheduler(config, db)
+
+    # Tick 1: diar worker dead -> degraded, alert fires.
+    await _ambient_tick(scheduler, _ambient_snapshot(diar_worker_alive=False))
+    assert scheduler._pipeline.submit_raw.call_count == 1
+
+    # Tick 2: diar recovered, but an INDEPENDENT fault (RSS regression)
+    # appeared while still degraded — a bare status-edge gate would swallow
+    # it and the user would never hear about the leak.
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1200.0))
+    assert scheduler._pipeline.submit_raw.call_count == 2
+    assert "RSS" in scheduler._pipeline.submit_raw.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_ambient_same_cause_does_not_nag(config, db):
+    scheduler = _make_scheduler(config, db)
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1200.0))
+    # Same cause next tick, different live value — must NOT re-alert.
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1300.0))
+    assert scheduler._pipeline.submit_raw.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ambient_down_then_new_degraded_cause_alerts(config, db):
+    from datetime import UTC, datetime, timedelta
+
+    scheduler = _make_scheduler(config, db)
+    stale = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    await _ambient_tick(scheduler, _ambient_snapshot(ts=stale))  # down, alert 1
+    # Heartbeat recovers but lands straight on an RSS breach: new cause, alert 2.
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1200.0))
+    assert scheduler._pipeline.submit_raw.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ambient_recovery_then_rebreach_realerts(config, db):
+    scheduler = _make_scheduler(config, db)
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1200.0))  # alert 1
+    await _ambient_tick(scheduler, _ambient_snapshot())  # recovery notice (2)
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1200.0))  # alert 3
+    assert scheduler._pipeline.submit_raw.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_ambient_rss_alert_text_names_leak_not_down(config, db):
+    scheduler = _make_scheduler(config, db)
+    await _ambient_tick(scheduler, _ambient_snapshot(rss_total_mb=1200.0))
+    text = scheduler._pipeline.submit_raw.call_args[0][0]
+    assert "down/hung" not in text  # the bridge is alive — don't misdiagnose
+    assert "RSS" in text


### PR DESCRIPTION
## What

Closes the loop on the ambient-bridge memory-leak saga: now that the arena-off soak has **passed** (4.6 days: child RSS flat ~170 MB, parent slope ≈ 0, total plateau ~470 MB vs the old 1.67 GB pathology), `evaluate_ambient_health` gains a leak-class regression watch:

- **degraded** when `rss_total_mb` > 1000 MB or `rss_diar_child_mb` > 450 MB — ceilings ~2× the worst burst observed in the soak, so workload breathing can never fire them.
- Null/absent `rss_*` keys (lazy diar-pool spawn, older edge builds) are never a breach.
- A dead bridge stays **down**; the RSS reason is still appended for the operator.
- Flows to the existing transition-gated Telegram alert (one alert on entering the bad state, no nagging), the infrastructure card, and the voice Bridge tab's verdict chip (#913).

## Verification

- TDD RED→GREEN: 6 new tests (both ceilings, plateau-ok, null/absent no-op, non-numeric ignored, down-not-masked). Blast radius 57/57 (`test_ambient_health` + `test_health`), ruff clean.
- Downstream trace: `OutreachScheduler._ambient_health_job` alert is transition-gated and includes verdict reasons verbatim.
- Threshold calibration data: 4.6-day soak via the edge `rss_*` health keys (GENesis-Voice #27/#29).

Closes follow-up `6c11696b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)