### PR TITLE
feat(audit): AI-code failure-mode taxonomy for auditor + dev guidance

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -133,6 +133,22 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   fires. Use `CronTrigger` for anything longer than a few hours.
   Bit us with `user_model_evolution` (48h interval, daily restarts).
 
+### Iterative-Refinement Discipline
+
+AI refinement cycles degrade code they were asked to "improve" — validation
+gets stripped, types relaxed, function scope widened. Published measurements
+show vague improvement prompts degrade security fastest across iterations.
+Three binding rules:
+
+1. **Iterate with scoped, explicit prompts** ("fix the race in X by
+   serializing on Y"), never "improve/clean up/make robust".
+2. **Be security-explicit when touching validation, auth, or boundaries** —
+   state what must not be weakened.
+3. **Diff each refinement for what it REMOVED** (constraints, guards, type
+   enforcement), not just what it added.
+
+Full failure-mode taxonomy + ordered audit passes: `references/ai-code-audit.md`.
+
 ### Anti-Rationalization
 
 These are excuses sessions use to skip discipline. If you catch yourself
@@ -305,6 +321,7 @@ references on every trigger.
 | V3 state, build order, GROUNDWORK, architecture docs | `references/architecture.md` |
 | Phase 6 contribution pipeline, sanitizer | `references/contribution.md` |
 | Pending work, active incidents, subsystem status | `references/build-state.md` |
+| Auditing/deep-reviewing AI-generated code (failure taxonomy, audit passes) | `references/ai-code-audit.md` |
 | Which code tool to use (CBM vs Serena vs GitNexus vs Grep) | `.claude/docs/code-intelligence.md` |
 
 **Freshness rule:** On first read of `codebase-map.md` in a session,

--- a/.claude/skills/genesis-development/references/ai-code-audit.md
+++ b/.claude/skills/genesis-development/references/ai-code-audit.md
@@ -1,0 +1,72 @@
+# Auditing AI-Generated Code
+
+Distilled from published research on AI-generated codebases (2026-07 knowledge
+ingest, domain `engineering.ai-code-audit`; original source in the KB). Use
+when auditing or deep-reviewing code that was produced through iterative LLM
+sessions — which includes Genesis itself. The idle-time surplus auditor
+carries a compact version of the taxonomy in
+`src/genesis/identity/CODE_AUDITOR.md`; this reference adds the ordered audit
+passes for interactive deep audits.
+
+## Why iteration makes it worse, not better
+
+The counterintuitive core finding: security and structure degrade across
+AI refinement cycles. Vague "improve this" prompts degrade fastest —
+each cycle tends to strip validation, relax types, and widen function scope.
+Consequences for how WE work:
+
+- **Iterate with scoped, explicit prompts.** "Fix the race in
+  `mark_completed` by serializing on the queue lock" — never "improve this
+  file" or "make this more robust".
+- **Be security-explicit when touching validation/auth/boundaries.** State
+  what must NOT be weakened, or the refinement will weaken it.
+- **Diff every refinement against what it replaced** for removed
+  constraints, dropped guards, and widened signatures — that is where the
+  regressions live, not in what was added.
+
+## Failure-mode taxonomy (what to hunt)
+
+Structural: excessive narrating comments substituting for clarity; features
+bolted on with zero refactoring (monolith growth as context fills);
+phantom guards for impossible conditions; near-duplicate functions far apart
+(context loss); cosmetic abstractions (single-implementation interfaces that
+relocate complexity instead of hiding it); pattern abandonment in
+later-generated modules; mid-file naming-convention drift.
+
+Async/state: un-awaited or unhandled promises; catch-log-return-nothing error
+handling (caller proceeds on a missing value); orphan state (written
+conditionally, read unconditionally; no teardown for listeners/timers;
+mutation after cancel); concurrent writes to shared state with no
+lock/serialization; polling loops without cancellation.
+
+Error handling: reveals too much (stack traces / paths / schema in
+responses) or handles too little (one generic message for every failure);
+missing boundary validation — the single most common flaw class in
+LLM-generated code.
+
+Tests: high count, low depth — happy path asserted N ways; empty
+collections, nulls, and zeros never probed.
+
+## Ordered audit passes (deep audits)
+
+**Pass 0 — inventory.** Map modules: exports, imports, callers. Flag modules
+importing from 5+ sources (god module) and modules with 10+ consumers
+(highest-priority audit targets). Estimate AI-generation density (commit
+history shape, comment style) to calibrate suspicion.
+
+**Pass 1 — structure.** Orphan modules (zero live callers — tested-but-dead
+code counts); orphan state declarations; pattern-consistency sweep (which
+modules deviate from the established architecture, and are they the
+later-added ones?); abstraction audit (would deleting this interface change
+any behavior?); dead-path detection (unreachable branches, unconsumed
+returns).
+
+**Pass 2 — async/state.** Inventory every await/task/callback: does each
+have a failure path? Trace every catch: does it rethrow, return a typed
+fallback, or notify — or does it swallow? Map shared-state writers: what
+serializes them? Verify every registration has a teardown. Trace
+collection-processing code against empty/null/single-item inputs.
+
+Genesis-specific overlays for these passes: `tracked_task()` for background
+tasks, the observability rules in `references/observability.md`, and the
+enumerate-don't-spot-check protocol in the skill body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   Assistant on demand (`GET /api/genesis/voice/device`; set `HA_VOICE_PE_PREFIX`). *(Shipped
   earlier in #876; the changelog entry was missed at the time.)*
 
+### Changed
+
+- **The idle-time code auditor now hunts the failure modes AI-generated code actually has.** Its
+  briefing gained a research-backed taxonomy — swallowed async errors, orphan state without
+  teardown, race surfaces, phantom guards, near-duplicate helpers, cosmetic abstractions, pattern
+  abandonment, and constraints quietly removed during refinement cycles — so audit findings target
+  the defect classes iterative LLM development is known to produce instead of only generic lint
+  categories. Development guidance gained the matching discipline: iterate with scoped explicit
+  prompts (never "improve this"), and diff refinements for what they *removed*.
+
 ### Fixed
 
 - **A false "deferred work backlog" health warning no longer fires every few minutes.** The

--- a/src/genesis/identity/CODE_AUDITOR.md
+++ b/src/genesis/identity/CODE_AUDITOR.md
@@ -10,6 +10,33 @@ Focus areas:
 - Security: command injection, path traversal, unvalidated input at boundaries
 - Observability gaps: missing logging, silent failures, untracked tasks
 
+## AI-Generated-Code Failure Modes (hunt these specifically)
+
+This codebase is built iteratively with LLMs, so audit for the defect classes
+that iterative AI development is known to produce:
+
+- **Swallowed async errors**: an except block that logs and returns None (or
+  nothing) so the caller proceeds on a missing value with no failure signal.
+- **Orphan state**: state written on some paths but read without guards on
+  others; listeners/timers/subscriptions registered with no teardown;
+  callbacks that mutate state after cancellation.
+- **Race surface**: two async paths writing shared state (file, table row,
+  in-memory dict) with no lock or serialization; polling loops without
+  cancellation; non-atomic read-modify-write on shared files.
+- **Phantom guards**: checks for conditions that cannot occur, unreachable
+  else branches, speculative parameters nothing passes — noise that
+  masquerades as safety.
+- **Near-duplicate helpers**: the same logic implemented twice far apart in
+  a file or package (context loss during generation) — flag the pair.
+- **Cosmetic abstraction**: an interface/base class with one implementation
+  that adds no isolation; removing it would change nothing.
+- **Pattern abandonment**: a convention established early (repository
+  pattern, error wrapper, naming scheme) silently dropped in later-added
+  modules — usually marks the seam where context decayed.
+- **Iteration scars**: constraints, validation, or type enforcement that an
+  earlier version had and a later "improvement" quietly removed. When you
+  can see history, compare — refinement cycles are where safety erodes.
+
 Output format: JSON array of findings, each with:
 - file: path relative to project root
 - line: approximate line number


### PR DESCRIPTION
## Summary

Folds the AI-generated-code audit research (ingested to the KB under `engineering.ai-code-audit`) into the two surfaces that act on it:

- **`CODE_AUDITOR.md`** (idle-time surplus auditor briefing): a new hunting section for the defect classes iterative LLM development is documented to produce — swallowed async errors (catch-log-return-nothing), orphan state without teardown, race surfaces, phantom guards, near-duplicate helpers from context loss, cosmetic single-implementation abstractions, pattern abandonment at context-decay seams, and constraints quietly removed across refinement cycles. The JSON output contract is unchanged (and pairs with the bare-array intake handling shipped in #886).
- **genesis-development skill**: new `references/ai-code-audit.md` — the distilled taxonomy plus ordered deep-audit passes (inventory → structure → async/state) — added to the reference router, and a short inline **iterative-refinement discipline** rule: iterate with scoped explicit prompts (never "improve this"), be security-explicit when touching validation/auth, and diff each refinement for what it *removed*.

Companion change made outside the repo: the user-level code-voice skill gained the same tells for reviewer-facing code.

## Testing
- Prompt/docs only — no runtime code paths. Auditor output contract unchanged (pinned by existing `tests/test_surplus/test_code_audit.py` parsing tests, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)