### PR TITLE
fix(memory): reconcile embedding_status when purging subsystem vectors

### DIFF
--- a/scripts/cleanup_subsystem_qdrant.py
+++ b/scripts/cleanup_subsystem_qdrant.py
@@ -212,6 +212,40 @@ async def main(apply: bool = False) -> None:
                     len(orphan_ids),
                 )
 
+        # --- Step 2c: reconcile embedding_status on purged rows ------------
+        # Steps 2/2b delete the Qdrant vector but leave the metadata row's
+        # embedding_status untouched — so a subsystem row that was 'embedded'
+        # now claims a vector that no longer exists. That lie has a real
+        # consequence: mark_superseded (store.py) reads
+        # ``embedding_status != 'fts5_only'`` to decide whether to update the
+        # Qdrant payload, and would issue a doomed update_payload on the
+        # deleted point. Every source_subsystem-tagged row is FTS5-only by
+        # invariant (store.py forces it on subsystem writes), and post-purge
+        # none of them has a vector, so normalise them all to 'fts5_only'.
+        # Idempotent (gated on != 'fts5_only'); matches the forward-write path.
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM memory_metadata "
+            "WHERE source_subsystem IS NOT NULL "
+            "AND embedding_status IS NOT 'fts5_only'"
+        )
+        stale_status = (await cursor.fetchone())[0]
+        if apply:
+            await db.execute(
+                "UPDATE memory_metadata SET embedding_status = 'fts5_only' "
+                "WHERE source_subsystem IS NOT NULL "
+                "AND embedding_status IS NOT 'fts5_only'"
+            )
+            await db.commit()
+            logger.info(
+                "embedding_status reconcile: set %d subsystem row(s) to "
+                "'fts5_only'", stale_status,
+            )
+        else:
+            logger.info(
+                "DRY-RUN: would set embedding_status='fts5_only' on %d "
+                "subsystem row(s)", stale_status,
+            )
+
         # --- Step 3: invalid_at backfill via obs:<uuid> tag JOIN -----------
         # Find subsystem rows that still have NULL invalid_at, parse the
         # obs:<uuid> tag from memory_fts.tags, JOIN observations.expires_at,

--- a/tests/test_scripts/test_cleanup_subsystem_qdrant.py
+++ b/tests/test_scripts/test_cleanup_subsystem_qdrant.py
@@ -57,17 +57,31 @@ def _make_db(path: pathlib.Path) -> None:
     conn = sqlite3.connect(path)
     conn.execute(
         "CREATE TABLE memory_metadata (memory_id TEXT PRIMARY KEY, "
-        "source_subsystem TEXT, collection TEXT, invalid_at TEXT)"
+        "source_subsystem TEXT, collection TEXT, invalid_at TEXT, "
+        "embedding_status TEXT)"
     )
     conn.execute("CREATE TABLE memory_fts (memory_id TEXT, tags TEXT)")
     conn.execute("CREATE TABLE observations (id TEXT PRIMARY KEY, expires_at TEXT)")
-    # One tagged row (matched) -> Step 2 deletes its point.
+    # One tagged row (matched) -> Step 2 deletes its point. Its
+    # embedding_status is the stale 'embedded' the purge must reconcile to
+    # 'fts5_only' (Step 2c).
     conn.execute(
-        "INSERT INTO memory_metadata VALUES ('refl-1', 'reflection', "
-        "'episodic_memory', NULL)"
+        "INSERT INTO memory_metadata "
+        "(memory_id, source_subsystem, collection, invalid_at, embedding_status) "
+        "VALUES ('refl-1', 'reflection', 'episodic_memory', NULL, 'embedded')"
     )
     conn.commit()
     conn.close()
+
+
+def _embedding_status(path: pathlib.Path, memory_id: str) -> str | None:
+    conn = sqlite3.connect(path)
+    row = conn.execute(
+        "SELECT embedding_status FROM memory_metadata WHERE memory_id = ?",
+        (memory_id,),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
 
 
 @pytest.fixture
@@ -103,6 +117,34 @@ def test_dry_run_deletes_nothing(scenario):
     assert stub.deleted == []
 
 
+def test_apply_reconciles_stale_embedding_status(tmp_path, monkeypatch):
+    """The purge deletes the Qdrant vector, so a subsystem row that was
+    'embedded' must be reconciled to 'fts5_only' (Step 2c) — otherwise the
+    field lies about vector presence and mark_superseded would issue a doomed
+    update_payload on the deleted point."""
+    db = tmp_path / "genesis.db"
+    _make_db(db)  # refl-1 tagged 'reflection', embedding_status='embedded'
+    stub = _StubQdrant([_Point("refl-1", "reflection")])
+    module = _load_script()
+    import genesis.env as genv
+
+    monkeypatch.setattr(genv, "genesis_db_path", lambda: db)
+    monkeypatch.setattr(genv, "qdrant_url", lambda: "http://stub")
+    monkeypatch.setattr("qdrant_client.QdrantClient", lambda **_kw: stub)
+
+    # Dry-run: status untouched.
+    asyncio.run(module.main(apply=False))
+    assert _embedding_status(db, "refl-1") == "embedded"
+
+    # Apply: reconciled to fts5_only.
+    asyncio.run(module.main(apply=True))
+    assert _embedding_status(db, "refl-1") == "fts5_only"
+
+    # Idempotent: second apply leaves it fts5_only.
+    asyncio.run(module.main(apply=True))
+    assert _embedding_status(db, "refl-1") == "fts5_only"
+
+
 def test_orphan_sweep_runs_with_no_tagged_rows(tmp_path, monkeypatch):
     """Regression: the sweep must run even when memory_metadata has no tagged
     rows (pure-orphan install), i.e. the early return must not skip Step 2b."""
@@ -110,7 +152,8 @@ def test_orphan_sweep_runs_with_no_tagged_rows(tmp_path, monkeypatch):
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE memory_metadata (memory_id TEXT PRIMARY KEY, "
-        "source_subsystem TEXT, collection TEXT, invalid_at TEXT)"
+        "source_subsystem TEXT, collection TEXT, invalid_at TEXT, "
+        "embedding_status TEXT)"
     )
     conn.execute("CREATE TABLE memory_fts (memory_id TEXT, tags TEXT)")
     conn.execute("CREATE TABLE observations (id TEXT PRIMARY KEY, expires_at TEXT)")


### PR DESCRIPTION
## What

Follow-up correctness fix to `scripts/cleanup_subsystem_qdrant.py` (from #918).

The cleanup script deletes the Qdrant vector for `source_subsystem`-tagged memories but left `memory_metadata.embedding_status='embedded'` on those rows — so the field claimed a vector that no longer existed.

This is not purely cosmetic: `MemoryStore._mark_superseded` reads `embedding_status != 'fts5_only'` to decide whether to update the Qdrant payload, and would issue a doomed `update_payload` on the already-deleted point if such a memory were later superseded (e.g. by dream-cycle consolidation).

## Change

- **Step 2c** in the cleanup script: after the purge, normalise every `source_subsystem`-tagged row to `embedding_status='fts5_only'` — the same invariant the forward-write path already enforces in `store.py`. NULL-safe (`IS NOT`), idempotent, `--apply`-gated, dry-run reports the count.
- New reconcile test (dry-run leaves status, apply sets `fts5_only`, second apply idempotent); extended the two stub schemas with the `embedding_status` column.

Targeted test file passes (4/4); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
