### PR TITLE
fix(guardian): report a failed Proxmox resize as a failure (poll the PVE task)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   Genesis itself is down in the outage, the host-side guardian can do it as part
   of recovery. It is **off by default**, every change is approval-gated and
   rate-capped, grows are one-attempt/never-auto-retried, and only two
-  read/write-split Proxmox tokens are ever stored. Setup and the full safety
-  model: `docs/reference/proxmox-provisioning.md`.
+  read/write-split Proxmox tokens are ever stored. A grow that Proxmox accepts
+  but then fails to carry out in the background (e.g. a storage-permission gap)
+  is now reported as a clear failure rather than a vague "couldn't confirm."
+  Setup and the full safety model: `docs/reference/proxmox-provisioning.md`.
 
 - **Ambient bridge memory-leak regression alert.** If the edge bridge's RSS ever climbs past the
   healthy plateau again (total > 1000 MB or diarization child > 450 MB), ambient health flips to

--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -114,6 +114,11 @@ provisioning:
   node_memory_margin_mib: 8192  # required node-RAM headroom (keys on available)
   max_actions_per_week: 2     # rate cap (counts EXECUTED mutations)
   require_recent_backup: true # refuse a grow without a recent backup
+  # NOTE: the Proxmox backup-age query is not yet implemented
+  # (newest_backup_age_days() returns None → treated as unknown → REFUSE). So
+  # leaving this `true` refuses EVERY grow. Set false to enable grows until the
+  # backup-age check lands (a grow is additive/grow-only). See
+  # docs/reference/proxmox-provisioning.md.
   backup_max_age_days: 14
   approval_timeout_s: 1800    # bounded wait for APPROVE/DENY
   min_repropose_hours: 24     # damper on autonomous pool-crit re-proposals

--- a/docs/reference/proxmox-provisioning.md
+++ b/docs/reference/proxmox-provisioning.md
@@ -51,14 +51,18 @@ getUpdates gate lives only in the guardian's Genesis-DOWN path.
 
 ## Host setup (generalized — substitute your own values)
 
-Replace `<NODE>` (PVE node name), `<VMID>` (this container's VM id), and choose
-your own token secrets. Run on the PVE host:
+Replace `<NODE>` (PVE node name), `<VMID>` (this container's VM id), `<STORAGE>`
+(the storage the VM's disks live on, e.g. `local-lvm`), and choose your own token
+secrets. Run on the PVE host:
 
 ```sh
 # 1. A dedicated user + two roles (least privilege)
 pveum user add genesis@pve
 pveum role add GenesisAudit    -privs "Sys.Audit Datastore.Audit VM.Audit"
-pveum role add GenesisProvision -privs "VM.Config.Disk VM.Config.Memory"
+# A disk grow ALLOCATES space on the datastore → Datastore.AllocateSpace is
+# REQUIRED alongside VM.Config.Disk (without it the resize task 403s in the
+# worker even though the PUT returns 200 — see "The ACL gotcha" below).
+pveum role add GenesisProvision -privs "VM.Config.Disk VM.Config.Memory Datastore.AllocateSpace"
 
 # 2. Audit role at / (read the node/storage/VM config)
 pveum acl modify /                 -user genesis@pve -role GenesisAudit
@@ -66,7 +70,10 @@ pveum acl modify /                 -user genesis@pve -role GenesisAudit
 # 3. Provision role scoped to THIS VM only
 pveum acl modify /vms/<VMID>       -user genesis@pve -role GenesisProvision
 
-# 4. Two privilege-separated tokens (privsep=1). Save the printed secrets.
+# 4. Provision role ALSO on the storage (disk grow allocates space there)
+pveum acl modify /storage/<STORAGE> -user genesis@pve -role GenesisProvision
+
+# 5. Two privilege-separated tokens (privsep=1). Save the printed secrets.
 pveum user token add genesis@pve ro       --privsep 1
 pveum user token add genesis@pve provision --privsep 1
 ```
@@ -85,6 +92,31 @@ pveum acl modify /vms/<VMID> -token 'genesis@pve!ro'        -role GenesisAudit
 pveum acl modify /vms/<VMID> -token 'genesis@pve!provision' -role GenesisProvision
 ```
 
+The **same replacement rule bites again at the storage path**, in *both*
+directions:
+
+- The **provision token** needs `Datastore.AllocateSpace` at
+  `/storage/<STORAGE>` (the role privilege from step 1 only takes effect where
+  the ACL is granted). Without it, the resize PUT returns 200 but the async
+  worker task fails `403 Permission check failed (/storage/<STORAGE>,
+  Datastore.AllocateSpace)`.
+- The moment you add ANY ACL at `/storage/<STORAGE>`, that path stops
+  inheriting the `GenesisAudit` you granted at `/` — so the **audit token's
+  storage read silently breaks** (avail flips to 0 / access denied) until you
+  RE-grant `GenesisAudit` there too. Grant all three:
+
+```sh
+pveum acl modify /storage/<STORAGE> -token 'genesis@pve!provision' -role GenesisProvision
+pveum acl modify /storage/<STORAGE> -user  genesis@pve             -role GenesisAudit
+pveum acl modify /storage/<STORAGE> -token 'genesis@pve!ro'        -role GenesisAudit
+```
+
+Verify the provision token actually carries the privilege at the storage path:
+
+```sh
+pveum user token permissions genesis@pve provision /storage/<STORAGE> | grep -i AllocateSpace
+```
+
 ### Validate (audit reads succeed, writes 403)
 
 ```sh
@@ -92,8 +124,11 @@ AUD='PVEAPIToken=genesis@pve!ro=<AUDIT_SECRET>'
 PRV='PVEAPIToken=genesis@pve!provision=<PROVISION_SECRET>'
 H=https://<PVE_HOST>:8006/api2/json
 
-curl -sk -H "Authorization: $AUD" "$H/nodes/<NODE>/status"            | jq .data.memory
+curl -sk -H "Authorization: $AUD" "$H/nodes/<NODE>/status"             | jq .data.memory
 curl -sk -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" | jq '{cores,memory,scsi1}'
+# Storage read MUST still return a non-zero avail after the /storage ACLs above
+# (proves the GenesisAudit re-grant at /storage/<STORAGE> worked).
+curl -sk -H "Authorization: $AUD" "$H/nodes/<NODE>/storage"           | jq '.data[] | select(.storage=="<STORAGE>") | .avail'
 # Negative: the audit token must be REFUSED a write (expect 403)
 curl -sk -X PUT -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" -d 'memory=99999'
 ```
@@ -101,6 +136,14 @@ curl -sk -X PUT -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" -d
 > RAM headroom keys on `/nodes/<NODE>/status` → **`.memory.available`**, not
 > `.memory.free`. On a busy host `free` is near-zero (Linux uses RAM as cache);
 > gating on it would spuriously refuse every grow.
+
+> **A resize is asynchronous.** `PUT .../qemu/<VMID>/resize` returns HTTP 200
+> with a `UPID:` task string in `data`; the real work runs as a background task
+> that can FAIL *after* the 200 (the missing-`Datastore.AllocateSpace` case
+> above surfaces exactly this way). The adapter therefore polls
+> `/nodes/<NODE>/tasks/<UPID>/status` until `status=stopped` and only reports
+> success on `exitstatus=OK` — a failed task is reported as a failure, never as
+> an unverified "slow" success.
 
 ## Wiring on this install
 
@@ -135,6 +178,12 @@ curl -sk -X PUT -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" -d
   `<state_dir>/provisioning/ledger.json`; the gate refuses once
   `max_actions_per_week` is reached. Autonomous pool-crit re-proposals are
   damped by `min_repropose_hours` (`proposal_state.json`).
+- **`require_recent_backup`:** the backup-age check is not yet implemented for
+  Proxmox (`newest_backup_age_days()` returns `None`), and the gate treats an
+  unknown age as a refusal. So **setting `require_recent_backup: true` today
+  refuses every grow.** Leave it `false` until the backup-age query lands; a
+  grow is additive/grow-only and the container keeps a ≤24h healthy incus
+  snapshot lifeline, so a corrupting rollback risk from the grow itself is nil.
 
 ## `verify_tls: false`
 

--- a/src/genesis/guardian/provisioning/proxmox.py
+++ b/src/genesis/guardian/provisioning/proxmox.py
@@ -157,15 +157,19 @@ class ProxmoxAdapter(ProvisioningAdapter):
 
         Never raises. On poll timeout or a persistent read failure we return
         ``(False, <reason>)`` so the caller treats the mutation as UNVERIFIED
-        (and never auto-retries) rather than as a silent success. The ~120s
-        bound (poll count × interval) is a raw external poll with no other
-        watchdog: a resize completes in seconds, so it only guards a
-        pathologically slow/hung task worker or status endpoint from blocking
-        the (already bounded) provisioning flow.
+        (and never auto-retries) rather than as a silent success. The ~``timeout``
+        bound is a raw external poll with no other watchdog: a resize completes
+        in seconds, so it only guards a pathologically slow/hung task worker or
+        status endpoint from blocking the (already bounded) provisioning flow.
+        Bounded two ways — a wall-clock deadline (honours the bound even when a
+        connected-but-hung endpoint makes each read block up to the per-request
+        timeout) AND a poll-count cap (deterministic when reads return fast).
         """
         cfg = self._config
         encoded = urllib.parse.quote(upid, safe="")
         path = f"/nodes/{cfg.node}/tasks/{encoded}/status"
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
         max_polls = max(1, int(timeout / interval))
         last_err = "task did not reach 'stopped'"
         for _ in range(max_polls):
@@ -177,6 +181,8 @@ class ProxmoxAdapter(ProvisioningAdapter):
                 # still running — keep polling
             else:
                 last_err = err or f"task status read failed: {st}"
+            if loop.time() >= deadline:
+                break
             await asyncio.sleep(interval)
         return False, f"task poll timed out after ~{timeout:.0f}s ({last_err})"
 

--- a/src/genesis/guardian/provisioning/proxmox.py
+++ b/src/genesis/guardian/provisioning/proxmox.py
@@ -143,6 +143,43 @@ class ProxmoxAdapter(ProvisioningAdapter):
             None, self._request_sync, method, path, params, token,
         )
 
+    async def _await_task(
+        self, upid: str, timeout: float = 120.0, interval: float = 2.0,
+    ) -> tuple[bool, str]:
+        """Poll a PVE task UPID to completion. Returns (ok, exitstatus).
+
+        A resize (and many PVE mutations) return HTTP 200 with a ``UPID:`` task
+        string in ``data``; the actual work runs as a background worker that can
+        FAIL *after* the 200 (e.g. a Datastore.AllocateSpace permission error
+        surfaces only in the worker). We poll
+        ``GET /nodes/N/tasks/{upid}/status`` (audit token — it has Sys.Audit)
+        until ``status == "stopped"``, then map ``exitstatus == "OK"`` → ok.
+
+        Never raises. On poll timeout or a persistent read failure we return
+        ``(False, <reason>)`` so the caller treats the mutation as UNVERIFIED
+        (and never auto-retries) rather than as a silent success. The ~120s
+        bound (poll count × interval) is a raw external poll with no other
+        watchdog: a resize completes in seconds, so it only guards a
+        pathologically slow/hung task worker or status endpoint from blocking
+        the (already bounded) provisioning flow.
+        """
+        cfg = self._config
+        encoded = urllib.parse.quote(upid, safe="")
+        path = f"/nodes/{cfg.node}/tasks/{encoded}/status"
+        max_polls = max(1, int(timeout / interval))
+        last_err = "task did not reach 'stopped'"
+        for _ in range(max_polls):
+            st, data, err = await self._request("GET", path, token=self._audit)
+            if st == 200 and isinstance(data, dict):
+                if data.get("status") == "stopped":
+                    exitstatus = str(data.get("exitstatus") or "").strip()
+                    return exitstatus == "OK", exitstatus or "no exitstatus reported"
+                # still running — keep polling
+            else:
+                last_err = err or f"task status read failed: {st}"
+            await asyncio.sleep(interval)
+        return False, f"task poll timed out after ~{timeout:.0f}s ({last_err})"
+
     # ── parsing helpers ──────────────────────────────────────────────────
     @staticmethod
     def _disk_entries(cfg: dict[str, Any]) -> dict[str, int]:
@@ -255,7 +292,7 @@ class ProxmoxAdapter(ProvisioningAdapter):
             )
         expected = before + add_gib * _GIB
         # The one mutating PUT — provision token.
-        stp, _data, ep = await self._request(
+        stp, put_data, ep = await self._request(
             "PUT", f"/nodes/{cfg.node}/qemu/{cfg.vmid}/resize",
             params={"disk": disk, "size": f"+{add_gib}G"}, token=self._provision,
         )
@@ -265,6 +302,19 @@ class ProxmoxAdapter(ProvisioningAdapter):
                 before=_human(before), target_bytes=expected,
                 error=f"resize PUT failed: {ep or stp}",
             )
+        # The resize runs as an async PVE task: the 200 above only means
+        # "accepted". When data is a UPID string, await the task so a resize
+        # that FAILS in the worker (e.g. a storage permission error) is
+        # reported as a failure — not misread as a slow-but-pending success by
+        # the config re-read below.
+        if isinstance(put_data, str) and put_data.startswith("UPID:"):
+            task_ok, exitstatus = await self._await_task(put_data)
+            if not task_ok:
+                return ProvisionResult(
+                    ok=False, action=action, requested=requested,
+                    before=_human(before), target_bytes=expected, verified=False,
+                    error=f"resize task failed: {exitstatus}",
+                )
         # Verify by re-read ONLY — never re-issue the PUT.
         after: int | None = None
         for _ in range(3):
@@ -315,7 +365,7 @@ class ProxmoxAdapter(ProvisioningAdapter):
                 before=f"{current}MiB",
                 error=f"grow-only: requested {new_mib} <= current {current} MiB",
             )
-        stp, _data, ep = await self._request(
+        stp, put_data, ep = await self._request(
             "PUT", f"/nodes/{cfg.node}/qemu/{cfg.vmid}/config",
             params={"memory": new_mib}, token=self._provision,
         )
@@ -325,6 +375,16 @@ class ProxmoxAdapter(ProvisioningAdapter):
                 before=f"{current}MiB",
                 error=f"config PUT failed: {ep or stp}",
             )
+        # A config PUT is normally synchronous (data=null), but await defensively
+        # if PVE ever returns a task UPID so a failed worker isn't misread as ok.
+        if isinstance(put_data, str) and put_data.startswith("UPID:"):
+            task_ok, exitstatus = await self._await_task(put_data)
+            if not task_ok:
+                return ProvisionResult(
+                    ok=False, action=action, requested=requested,
+                    before=f"{current}MiB", verified=False,
+                    error=f"config task failed: {exitstatus}",
+                )
         # Confirm the config accepted the new value; the running VM needs a
         # reboot to actually use it (hotplug is off on this install → default
         # requires_reboot True unless /pending proves it took effect live).

--- a/tests/test_guardian/test_provisioning_proxmox.py
+++ b/tests/test_guardian/test_provisioning_proxmox.py
@@ -8,6 +8,7 @@ that records (method, path, params, token) so we can assert token discipline
 from __future__ import annotations
 
 import re
+import urllib.parse
 
 import pytest
 
@@ -63,11 +64,25 @@ class FakePVE:
         self.put_config_status = 200
         self.apply_writes = True  # False → PUT returns 200 but config unchanged
         self.transport_dead = False  # True → every call is a -1 transport error
+        # Async-task (UPID) knobs — default None keeps the old synchronous shape.
+        self.resize_upid = None  # str → resize PUT returns this UPID in `data`
+        self.task_exitstatus = "OK"  # exitstatus once the task reports 'stopped'
+        self.task_running_polls = 0  # 'running' responses before 'stopped'
+        self.task_never_stops = False  # True → always 'running' (poll timeout)
+        self.task_status_code = 200  # non-200 → task-status read failure
+        self._task_polls = 0
 
     def __call__(self, method, path, params=None, token=""):
         self.calls.append((method, path, params, token))
         if self.transport_dead:
             return -1, None, "connection refused"
+        if method == "GET" and "/tasks/" in path and path.endswith("/status"):
+            if self.task_status_code != 200:
+                return self.task_status_code, None, f"HTTP {self.task_status_code}: nope"
+            self._task_polls += 1
+            if self.task_never_stops or self._task_polls <= self.task_running_polls:
+                return 200, {"status": "running"}, ""
+            return 200, {"status": "stopped", "exitstatus": self.task_exitstatus}, ""
         if method == "GET" and path.endswith("/status"):
             return 200, self.status, ""
         if method == "GET" and path.endswith("/storage"):
@@ -86,7 +101,7 @@ class FakePVE:
                 m = re.search(r"size=(\d+)G", cur)
                 new = int(m.group(1)) + add
                 self.config[disk] = re.sub(r"size=\d+G", f"size={new}G", cur)
-            return 200, None, ""
+            return 200, self.resize_upid, ""
         if method == "PUT" and path.endswith("/config"):
             if self.put_config_status != 200:
                 return self.put_config_status, None, f"HTTP {self.put_config_status}: denied"
@@ -201,7 +216,79 @@ async def test_grow_disk_403_structured_failure():
     assert res.ok is False and "403" in res.error
 
 
+# ── grow disk: async task (UPID) polling ─────────────────────────────────
+_UPID = "UPID:proxmox:001234AB:0056789A:66AABBCC:resize:100:root@pam:"
+
+
+async def test_grow_disk_awaits_task_ok_then_verifies():
+    """Resize returns a UPID; task runs then stops OK → verified grow."""
+    fake = FakePVE()
+    fake.resize_upid = _UPID
+    fake.task_running_polls = 2  # two 'running' polls, then 'stopped'/OK
+    res = await _adapter(fake).grow_vm_disk("scsi1", 32)
+    assert res.ok is True and res.verified is True
+    assert res.after == "64.0G"
+    # exactly one mutating PUT despite the multi-poll wait
+    assert len([c for c in fake.calls if c[0] == "PUT"]) == 1
+    # the task-status GET url-encodes the UPID's colons (%3A)
+    task_gets = [p for (m, p, _pa, _t) in fake.calls if m == "GET" and "/tasks/" in p]
+    assert task_gets, "expected a task-status poll"
+    assert "%3A" in task_gets[0]
+    assert urllib.parse.quote(_UPID, safe="") in task_gets[0]
+    # task status polled with the audit token
+    assert all(t == "AUDIT" for (m, p, _pa, t) in fake.calls if "/tasks/" in p)
+
+
+async def test_grow_disk_task_failed_reports_exitstatus_one_put():
+    """Resize PUT 200 but the worker task FAILS → ok=False, exitstatus surfaced,
+    exactly one PUT, and no confusion with a slow/unverified success."""
+    fake = FakePVE()
+    fake.resize_upid = _UPID
+    fake.apply_writes = False  # a failed resize does not change the disk
+    fake.task_exitstatus = "403 Permission check failed (/storage/local-lvm, Datastore.AllocateSpace)"
+    res = await _adapter(fake).grow_vm_disk("scsi1", 32)
+    assert res.ok is False and res.verified is False
+    assert "resize task failed" in res.error
+    assert "Datastore.AllocateSpace" in res.error  # the real exitstatus surfaced
+    assert res.target_bytes == 64 * _GIB  # diagnostic target preserved
+    assert len([c for c in fake.calls if c[0] == "PUT"]) == 1
+    # early return on task failure → no config re-read after the task poll
+    task_idx = max(i for i, c in enumerate(fake.calls) if "/tasks/" in c[1])
+    assert not [c for c in fake.calls[task_idx + 1 :] if c[1].endswith("/config")]
+
+
+async def test_grow_disk_task_poll_timeout_unverified():
+    """Task never reaches 'stopped' → bounded poll gives up, unverified, one PUT."""
+    fake = FakePVE()
+    fake.resize_upid = _UPID
+    fake.task_never_stops = True
+    res = await _adapter(fake).grow_vm_disk("scsi1", 32)
+    assert res.ok is False and res.verified is False
+    assert "timed out" in res.error
+    assert len([c for c in fake.calls if c[0] == "PUT"]) == 1
+
+
+async def test_await_task_status_read_failure_unverified():
+    """Persistent non-200 on the status endpoint → unverified, surfaced reason."""
+    fake = FakePVE()
+    fake.resize_upid = _UPID
+    fake.task_status_code = 500
+    res = await _adapter(fake).grow_vm_disk("scsi1", 32)
+    assert res.ok is False and res.verified is False
+    assert "timed out" in res.error and "500" in res.error
+
+
 # ── grow memory ──────────────────────────────────────────────────────────
+async def test_grow_memory_no_task_poll_when_synchronous():
+    """Config PUT returns data=null (synchronous) → no /tasks/ poll, still verifies."""
+    fake = FakePVE()
+    fake.pending = [{"key": "memory", "value": "21500", "pending": "24576"}]
+    res = await _adapter(fake).grow_vm_memory(24576)
+    assert res.ok is True and res.verified is True
+    assert not [c for c in fake.calls if "/tasks/" in c[1]]
+
+
+
 async def test_grow_memory_grow_only_guard_no_put():
     fake = FakePVE()
     res = await _adapter(fake).grow_vm_memory(21500)  # == current


### PR DESCRIPTION
## What

A Proxmox VE disk/RAM resize is **asynchronous**: `PUT .../qemu/<vmid>/resize` returns HTTP 200 with a `UPID:` task string in `data`, and the real work runs as a background worker that can **fail after the 200** (a missing `Datastore.AllocateSpace` on the storage surfaces exactly this way). The adapter ignored the UPID and only re-read the VM config, so a **failed** resize task and a merely **slow** one both looked identical — an "unverified" grow with no diagnostic.

This adds `ProxmoxAdapter._await_task(upid)`: poll `GET /nodes/<node>/tasks/<upid>/status` (audit token — it has `Sys.Audit`) until `status == "stopped"`, mapping `exitstatus == "OK"` → success. Wired into `grow_vm_disk` (after the resize PUT 200) and defensively into `grow_vm_memory`. On a non-OK task it returns `ok=False` / `verified=False` with the **real exitstatus** in the error; on OK it keeps the existing verify-by-re-read.

## Safety contract (preserved)

- **Never-raise** — `_await_task` only issues reads and is null-safe on every field.
- **Exactly one mutating PUT** — the poll never re-issues the resize; every failure/timeout path returns a typed failure.
- **Bounded** — a wall-clock deadline (honors the ~120s bound even when a connected-but-hung status endpoint makes each read block up to the per-request timeout) plus a poll-count cap (deterministic when reads return fast).
- Reads use the audit token; the mutation stays provision-token only.

## Docs

Corrects `docs/reference/proxmox-provisioning.md` pveum setup to match what the live failure proved:
- `GenesisProvision` needs `Datastore.AllocateSpace` (a disk grow allocates storage), granted at `/storage/<STORAGE>` for the provision token.
- `GenesisAudit` must be **re-granted** at `/storage/<STORAGE>` — a specific-path ACL *replaces* the propagated one, silently breaking the storage read the moment you touch that path.
- Documents the async-resize task behavior and that `require_recent_backup: true` currently refuses every grow (the Proxmox backup-age query is a stub returning `None`; follow-up filed).

## Design note (conscious choice, not a gap)

`exitstatus == "OK"` treats a rare `"WARNINGS: N"` task completion as non-OK. This is the *safe* direction (reports unverified, never auto-retries; a resize doesn't emit warnings), and #920's anti-stack guard self-corrects an unverified-but-landed grow on the next cycle. Kept strict deliberately rather than masking a potential partial failure.

## Tests

`tests/test_guardian/test_provisioning_proxmox.py` — fake task-status transport: running→stopped-OK (verified), stopped-non-OK 403 (exitstatus surfaced, one PUT, no re-read), UPID url-encoding (`%3A`), poll timeout, persistent non-200, and memory-PUT-no-UPID falls through. 21 file / 106 provision-slice tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)