### PR TITLE
fix(guardian): storage-expand targets the real thin-pool LV (autoextend now actually arms)

### DIFF
--- a/src/genesis/guardian/pool.py
+++ b/src/genesis/guardian/pool.py
@@ -166,7 +166,9 @@ async def _lvm_source(pool_name: str) -> str | None:
             source = s.split(":", 1)[1].strip()
     if driver != "lvm" or not source:
         return None
-    # source is the VG name; the thin pool LV is conventionally the pool name.
+    # ``source`` is the VG name. NOTE: the backing thin-pool LV name is NOT
+    # necessarily the incus pool name (default layout: pool "default" / LV
+    # "IncusThinPool") — resolve it via lvm.thinpool_name, not by assumption.
     return source
 
 

--- a/src/genesis/guardian/provisioning/expand.py
+++ b/src/genesis/guardian/provisioning/expand.py
@@ -81,6 +81,37 @@ async def _seg_monitored(vg: str, thinpool: str, run) -> bool:
     return rc == 0 and "monitored" in out.lower() and "not monitored" not in out.lower()
 
 
+async def _resolve_thinpool_lv(pool_name: str, vg: str, run) -> str:
+    """Resolve the thin-pool LV name backing an incus LVM pool.
+
+    The incus pool name and its backing thin-pool LV are NOT the same in the
+    default incus LVM layout: the pool is ``default`` but its LV is
+    ``IncusThinPool``. Assuming ``thinpool == pool_name`` made the autoextend
+    profile + monitoring target a nonexistent ``vg/<pool_name>`` LV. Resolve it
+    honestly, most-authoritative first:
+
+    1. incus's own ``lvm.thinpool_name`` config (exactly which LV incus uses),
+    2. the single thin-pool LV present in the VG (``lvs -S segtype=thin-pool``),
+    3. last resort: the pool name (correct only where the naming happens to
+       coincide) — never worse than the old behaviour.
+    """
+    rc, out, _ = await run(
+        "incus", "storage", "get", pool_name, "lvm.thinpool_name", timeout=10.0,
+    )
+    name = out.strip() if rc == 0 else ""
+    if name:
+        return name
+    rc, out, _ = await run(
+        "sudo", "-n", "lvs", "--noheadings", "-o", "lv_name",
+        "-S", "segtype=thin-pool", vg, timeout=15.0,
+    )
+    if rc == 0:
+        names = [ln.strip() for ln in out.splitlines() if ln.strip()]
+        if len(names) == 1:  # unambiguous → use it
+            return names[0]
+    return pool_name
+
+
 async def expand_storage(config: GuardianConfig, *, run=None) -> dict:
     """Absorb a grown disk into the thin pool. Returns a JSON-able result dict."""
     run = run or run_subprocess
@@ -100,7 +131,7 @@ async def expand_storage(config: GuardianConfig, *, run=None) -> dict:
             "ok": False, "steps": steps,
             "error": f"pool {pool_name} is not LVM-thin — nothing to expand",
         }
-    thinpool = pool_name  # thin-pool LV is conventionally the incus pool name
+    thinpool = await _resolve_thinpool_lv(pool_name, vg, run)
 
     # 1. Discover PVs in the VG.
     rc, out, err = await _run(

--- a/tests/test_guardian/test_provisioning_expand.py
+++ b/tests/test_guardian/test_provisioning_expand.py
@@ -7,7 +7,11 @@ import pytest
 
 import genesis.guardian.provisioning.expand as expand_mod
 from genesis.guardian.config import GuardianConfig
-from genesis.guardian.provisioning.expand import _assert_no_full_extend, expand_storage
+from genesis.guardian.provisioning.expand import (
+    _assert_no_full_extend,
+    _resolve_thinpool_lv,
+    expand_storage,
+)
 
 
 class FakeRun:
@@ -18,19 +22,26 @@ class FakeRun:
         self.pvresize_rc = 0
         self.vg_free = "34359738368"  # 32 GiB
         self.seg_monitor = "monitored"
+        # thin-pool LV name resolution knobs
+        self.incus_thinpool_name = "IncusThinPool"  # incus lvm.thinpool_name; "" = unset
+        self.lvs_lv_name = "IncusThinPool"  # `lvs -o lv_name -S segtype=thin-pool <vg>`
 
     async def __call__(self, *argv, timeout=60.0, stdin_data=None):
         self.calls.append((argv, stdin_data))
         a = list(argv)
         if a[:1] == ["lsblk"]:
             return 0, self.lsblk_out, ""
+        if a[:2] == ["incus", "storage"] and "lvm.thinpool_name" in a:
+            return 0, self.incus_thinpool_name, ""
         if "pvs" in a:
             return 0, self.pvs_out, ""
         if "pvresize" in a:
             return self.pvresize_rc, "", ("" if self.pvresize_rc == 0 else "device busy")
         if "vgs" in a:
             return 0, self.vg_free, ""
-        if "lvs" in a:
+        if "lvs" in a and "lv_name" in a:  # thin-pool name resolution
+            return 0, self.lvs_lv_name, ""
+        if "lvs" in a:  # seg_monitor check
             return 0, self.seg_monitor, ""
         if "tee" in a or "lvchange" in a:
             return 0, "", ""
@@ -64,6 +75,50 @@ async def test_happy_path_order_and_ok(_lvm):
     # pvs before pvresize before the autoextend profile write.
     assert fake.cmd_index("pvs") < fake.cmd_index("pvresize")
     assert fake.cmd_index("pvresize") < fake.cmd_index("thinpool.profile")
+
+
+async def test_profile_targets_real_thinpool_lv_not_pool_name(_lvm):
+    """Regression: the pool is 'default' but the LV is 'IncusThinPool' — the
+    autoextend profile + monitoring must target vg0/IncusThinPool, NOT vg0/default
+    (the bug that left autoextend unarmed after a real grow)."""
+    fake = FakeRun()  # incus_thinpool_name = "IncusThinPool"
+    res = await expand_storage(GuardianConfig(), run=fake)
+    assert res["thinpool"] == "IncusThinPool"
+    lvchange = [argv for argv, _ in fake.calls if "lvchange" in argv]
+    assert lvchange, "expected lvchange calls"
+    for argv in lvchange:
+        assert "vg0/IncusThinPool" in argv
+        assert "vg0/default" not in argv
+
+
+async def test_thinpool_falls_back_to_lvs_when_incus_silent(_lvm):
+    """No incus lvm.thinpool_name → resolve via the single thin-pool LV in the VG."""
+    fake = FakeRun()
+    fake.incus_thinpool_name = ""  # incus key unset
+    fake.lvs_lv_name = "IncusThinPool"
+    res = await expand_storage(GuardianConfig(), run=fake)
+    assert res["thinpool"] == "IncusThinPool"
+
+
+async def test_thinpool_last_resort_is_pool_name(_lvm):
+    """Both sources silent → fall back to the pool name (never worse than old)."""
+    fake = FakeRun()
+    fake.incus_thinpool_name = ""
+    fake.lvs_lv_name = ""  # no single unambiguous LV
+    res = await expand_storage(GuardianConfig(), run=fake)
+    assert res["thinpool"] == "default"
+
+
+async def test_resolve_thinpool_ambiguous_multiple_pools_falls_back():
+    """Two thin pools in the VG is ambiguous → don't guess; fall back to pool_name."""
+    async def _run(*argv, timeout=60.0, stdin_data=None):
+        if list(argv)[:2] == ["incus", "storage"]:
+            return 0, "", ""  # incus silent
+        if "lvs" in argv:
+            return 0, "poolA\n  poolB", ""  # two thin pools
+        return 0, "", ""
+
+    assert await _resolve_thinpool_lv("default", "vg0", _run) == "default"
 
 
 async def test_never_issues_100pct_free(_lvm):


### PR DESCRIPTION
## What

Found during the first real disk grow that reached the storage-expand autoextend steps. `expand.py` assumed the thin-pool **LV** name equals the incus **pool** name (`thinpool = pool_name`). In the **default incus LVM layout** the pool is named `default` but its backing LV is `IncusThinPool` — so the two `lvchange` steps (attach autoextend profile, enable dmeventd monitoring) ran against `vg0/default`, a nonexistent LV, and failed:

```
"apply metadataprofile", ok=false, "Failed to find logical volume \"vg0/default\""
"enable monitoring",     ok=false, "Failed to find logical volume \"vg0/default\""
```

The grow still corrected `vg_free` (pvresize worked), but **autoextend was left unarmed** — the profile was never attached to the pool, so the pool would never auto-grow into the new free space. That silently defeats the point of the grow.

## Fix

`_resolve_thinpool_lv(pool_name, vg, run)` resolves the LV name honestly, most-authoritative first:
1. incus's own `lvm.thinpool_name` config (exactly which LV incus uses),
2. the single `lvs -S segtype=thin-pool <vg>` LV in the VG,
3. last resort: the pool name (correct only where the names coincide — never worse than the old behavior).

Also fixes the misleading `pool.py` `_lvm_source` comment that seeded the wrong assumption.

## Impact

This affects **every** incus-LVM install using the default layout (pool `default` / LV `IncusThinPool`), not just one machine — anyone who runs an approval-gated grow would get a corrected `vg_free` but a still-unarmed pool.

## Verified live

On the affected host: `lvchange --metadataprofile genesis-thinpool vg0/IncusThinPool` attaches correctly → `LProfile=genesis-thinpool`, `monitored`, `vg_free=32G`. This PR makes the code produce that outcome automatically on the next grow.

## Tests

`tests/test_guardian/test_provisioning_expand.py` — all three resolution branches, the ambiguous-multiple-pools fallback, and a regression asserting the profile/monitoring target `vg0/IncusThinPool`, never `vg0/default`. 11 file / 137 provision+pool-slice tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)