### PR TITLE
fix(dashboard): merge duplicate resolveApproval store keys

### DIFF
--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -2692,7 +2692,7 @@
           }
         },
 
-        async resolveApproval(requestId, decision) {
+        async resolveApproval(requestId, decision, outreachMsgId = null) {
           const current = this.approvalActions[requestId] || {};
           this.approvalActions = {
             ...this.approvalActions,
@@ -2711,6 +2711,25 @@
                 [requestId]: { saving: false, error: null },
               };
               this.finishFetch("approvals");
+              // Post-resolve follow-ups must not flip the error state — the
+              // approval itself already resolved successfully.
+              try {
+                if (outreachMsgId) {
+                  const outcome = decision === "approved" ? "useful" : "not_useful";
+                  await fetchApi(`/api/genesis/outreach/${encodeURIComponent(outreachMsgId)}/engage`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ outcome, response: decision === "approved" ? "approve" : "deny" }),
+                  });
+                }
+                await Promise.all([
+                  this.fetchOutreachMessages(),
+                  this.fetchApprovals(),
+                  this.fetchComms(),
+                ]);
+              } catch (e) {
+                console.error("post-resolve refresh failed", e);
+              }
             } else {
               const error = await this.readApiError(resp, "Approval update failed");
               this.approvalActions = {
@@ -3835,28 +3854,6 @@
             if (a.description && msg.topic && a.description.includes(msg.topic.slice(0, 30))) return a;
           }
           return null;
-        },
-
-        async resolveApproval(approvalId, decision, outreachMsgId) {
-          try {
-            await fetchApi("/api/genesis/approvals/" + approvalId + "/resolve", {
-              method: "POST", headers: {"Content-Type": "application/json"},
-              body: JSON.stringify({decision})
-            });
-            if (outreachMsgId) {
-              const outcome = decision === 'approved' ? 'useful' : 'not_useful';
-              await fetchApi("/api/genesis/outreach/" + outreachMsgId + "/engage", {
-                method: "POST", headers: {"Content-Type": "application/json"},
-                body: JSON.stringify({outcome, response: decision === 'approved' ? 'approve' : 'deny'})
-              });
-            }
-            // Refresh all approval-related stores for immediate UI update
-            await Promise.all([
-              this.fetchOutreachMessages(),
-              this.fetchApprovals(),
-              this.fetchComms(),
-            ]);
-          } catch (e) { console.error("resolve failed", e); }
         },
 
         async approveAllPending() {

--- a/tests/test_dashboard/test_webui_js_integrity.py
+++ b/tests/test_dashboard/test_webui_js_integrity.py
@@ -1,0 +1,68 @@
+"""Structural integrity checks for the dashboard webui JS.
+
+dashboard.js defines one large Alpine store as a single object literal. In a
+JS object literal a duplicated key is legal and the *second* definition
+silently wins — which is how the two ``resolveApproval`` implementations
+coexisted with one shadowing the other. These tests parse the store literal
+by its stable indentation convention (members at exactly 8 spaces) and
+assert every member name is unique.
+"""
+
+import re
+from pathlib import Path
+
+DASHBOARD_JS = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "genesis"
+    / "dashboard"
+    / "webui"
+    / "js"
+    / "dashboard.js"
+)
+
+STORE_OPEN = 'Alpine.store("genesisDashboard", {'
+STORE_CLOSE = re.compile(r"^      \}\);")
+MEMBER = re.compile(r"^        (?:async )?([A-Za-z_$][\w$]*)\s*[:(]")
+
+# If the file shrinks below this, the indentation convention the parser
+# relies on has probably changed and the scan has gone blind — fail loudly
+# instead of passing on an empty member list.
+MIN_EXPECTED_MEMBERS = 300
+
+
+def _store_member_names() -> list[str]:
+    lines = DASHBOARD_JS.read_text().splitlines()
+    names: list[str] = []
+    in_store = False
+    for line in lines:
+        if not in_store:
+            if STORE_OPEN in line:
+                in_store = True
+            continue
+        if STORE_CLOSE.match(line):
+            break
+        m = MEMBER.match(line)
+        if m:
+            names.append(m.group(1))
+    return names
+
+
+def test_store_literal_found_and_parsed():
+    names = _store_member_names()
+    assert len(names) >= MIN_EXPECTED_MEMBERS, (
+        f"Only {len(names)} store members detected — the store literal or its "
+        "8-space member indentation convention has changed; update this test's "
+        "parser so duplicate-key detection keeps working."
+    )
+
+
+def test_store_member_names_are_unique():
+    names = _store_member_names()
+    seen: set[str] = set()
+    dupes = sorted({n for n in names if n in seen or seen.add(n)})
+    assert not dupes, (
+        f"Duplicate keys in the genesisDashboard store literal: {dupes}. "
+        "In a JS object literal the second definition silently shadows the "
+        "first — merge the implementations instead."
+    )


### PR DESCRIPTION
## Problem

`dashboard.js` defines `resolveApproval` twice inside the same Alpine store object literal. In a JS object literal the second key silently wins, so the first implementation — the one carrying the `approvalActions` saving/error state machine, the optimistic `approvals` filter, and `readApiError` handling — was dead code. The chat-tab approval buttons therefore resolved approvals with no saving state and no error reporting.

## Fix

One merged implementation at the original (first) location, signature `(requestId, decision, outreachMsgId = null)`:

- Saving/error state machine, optimistic filter, and `readApiError` path kept from the first variant.
- The second variant's optional outreach engage POST (3-arg call site) and outreach/approvals/comms refresh folded in after a successful resolve.
- Post-resolve refresh failures are logged only — they no longer paint an error onto an approval that already resolved.
- Second definition deleted. No template changes: both existing 2-arg and 3-arg call sites work with the merged signature.

## Prevention

New `tests/test_dashboard/test_webui_js_integrity.py` parses the store literal and asserts member-name uniqueness (plus a member-count floor so the parser failing to match fails loudly instead of passing on an empty list). Verified RED on the pre-fix file (detects exactly this duplicate) and GREEN after.

## Verification

- Guard test: RED pre-fix / GREEN post-fix
- `node --check` parses the fixed file
- `tests/test_dashboard/test_api.py`: 29/29 pass
- Inline code review: no findings (call sites, fetchApi semantics, and test heuristic independently verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)