### PR TITLE
feat(autonomy): add AUTONOMOUS_BUILD action domain (min level 2, high-risk)

### DIFF
--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -288,6 +288,10 @@ ACTION_TYPE_DOMAIN_MAP: dict[str, ActionDomain] = {
     "payment": ActionDomain.FINANCIAL,
     "code_change": ActionDomain.SELF_MODIFY,
     "refactor": ActionDomain.SELF_MODIFY,
+    # Build-lane capability builds land on a scope-gated branch as a draft PR
+    # (never merged autonomously) — gated at level 2, not hard-blocked like
+    # SELF_MODIFY, which changes running code/config in place.
+    "autonomous_build": ActionDomain.AUTONOMOUS_BUILD,
     # Evo promotion rewrites Genesis's own deep-reflection prompt — a change to
     # its cognition. SELF_MODIFY is hard-blocked from background dispatch
     # (ACTION_DOMAIN_MIN_LEVEL = None), so an approved promotion can never be

--- a/src/genesis/autonomy/proposal_gate.py
+++ b/src/genesis/autonomy/proposal_gate.py
@@ -186,6 +186,7 @@ HIGH_RISK_DOMAINS: frozenset[ActionDomain] = frozenset({
     ActionDomain.REPRESENT_USER,
     ActionDomain.FINANCIAL,
     ActionDomain.SELF_MODIFY,
+    ActionDomain.AUTONOMOUS_BUILD,
 })
 
 

--- a/src/genesis/autonomy/types.py
+++ b/src/genesis/autonomy/types.py
@@ -98,6 +98,10 @@ class ActionDomain(StrEnum):
     REPRESENT_USER = "represent_user"      # Acts in user's name to external parties
     FINANCIAL = "financial"                # Involves money
     SELF_MODIFY = "self_modify"            # Changes Genesis's own code/config/identity
+    AUTONOMOUS_BUILD = "autonomous_build"  # Builds capability code on a branch only
+                                           # (scope-gated diff, draft PR, human merge).
+                                           # Distinct from SELF_MODIFY, which changes
+                                           # running code/config/identity in place.
 
 
 # Minimum autonomy level required per domain (background context).
@@ -111,6 +115,7 @@ ACTION_DOMAIN_MIN_LEVEL: dict[ActionDomain, int | None] = {
     ActionDomain.REPRESENT_USER: 3,
     ActionDomain.FINANCIAL: 4,
     ActionDomain.SELF_MODIFY: None,         # Blocked from background (V5 deferred)
+    ActionDomain.AUTONOMOUS_BUILD: 2,       # Branch-only builds; delivery cannot merge
 }
 
 

--- a/tests/test_autonomy/test_classification.py
+++ b/tests/test_autonomy/test_classification.py
@@ -184,5 +184,22 @@ class TestClassifyDomain:
     def test_existing_code_change_self_modify(self) -> None:
         assert classify_domain("code_change") is ActionDomain.SELF_MODIFY
 
+    def test_autonomous_build_maps_to_autonomous_build(self) -> None:
+        """Build-lane dispatches classify as AUTONOMOUS_BUILD (min level 2,
+        high-risk under a degraded gate) — NOT SELF_MODIFY (hard-blocked) and
+        NOT the EXTERNAL_READ fallback (always allowed)."""
+        assert (
+            classify_domain("autonomous_build")
+            is ActionDomain.AUTONOMOUS_BUILD
+        )
+
+    def test_self_modify_still_hard_blocked(self) -> None:
+        """Adding AUTONOMOUS_BUILD must not soften SELF_MODIFY: its minimum
+        level stays None (blocked from background dispatch entirely)."""
+        from genesis.autonomy.types import ACTION_DOMAIN_MIN_LEVEL
+
+        assert ACTION_DOMAIN_MIN_LEVEL[ActionDomain.SELF_MODIFY] is None
+        assert ACTION_DOMAIN_MIN_LEVEL[ActionDomain.AUTONOMOUS_BUILD] == 2
+
     def test_unknown_action_type_falls_to_external_read(self) -> None:
         assert classify_domain("totally_unknown_xyz") is ActionDomain.EXTERNAL_READ

--- a/tests/test_autonomy/test_proposal_gate_sentinel.py
+++ b/tests/test_autonomy/test_proposal_gate_sentinel.py
@@ -25,6 +25,7 @@ _HIGH_RISK_ACTION_TYPES = [
     "purchase", "payment",                 # FINANCIAL
     "code_change", "refactor",             # SELF_MODIFY
     "cognitive_variant_promotion",         # SELF_MODIFY
+    "autonomous_build",                    # AUTONOMOUS_BUILD
 ]
 _BENIGN_ACTION_TYPES = [
     "investigate", "research", "analyze",  # EXTERNAL_READ
@@ -40,8 +41,24 @@ def test_high_risk_domains_is_the_external_and_self_modify_set():
         ActionDomain.REPRESENT_USER,
         ActionDomain.FINANCIAL,
         ActionDomain.SELF_MODIFY,
+        ActionDomain.AUTONOMOUS_BUILD,
     }
     assert set(HIGH_RISK_DOMAINS) == expected
+
+
+def test_high_risk_matches_min_level_contract():
+    """HIGH_RISK_DOMAINS must be exactly the domains whose
+    ACTION_DOMAIN_MIN_LEVEL is >= 2 or None (the KEEP IN SYNC rule stated
+    at its definition). A new ActionDomain that raises the bar but is not
+    added to HIGH_RISK_DOMAINS would be ALLOWED under a degraded gate."""
+    from genesis.autonomy.types import ACTION_DOMAIN_MIN_LEVEL
+
+    derived = {
+        domain
+        for domain, level in ACTION_DOMAIN_MIN_LEVEL.items()
+        if level is None or level >= 2
+    }
+    assert set(HIGH_RISK_DOMAINS) == derived
 
 
 @pytest.mark.parametrize("domain", sorted(HIGH_RISK_DOMAINS, key=str))


### PR DESCRIPTION
## Summary

Groundwork PR-1 of the autonomous capability-build lane (see plan: staged-autonomy build lane, Stage 1).

- New `ActionDomain.AUTONOMOUS_BUILD` (`"autonomous_build"`): capability builds that land on a scope-gated branch as a **draft PR, never merged autonomously**.
- `ACTION_DOMAIN_MIN_LEVEL[AUTONOMOUS_BUILD] = 2` — same bar as `EXTERNAL_WRITE`.
- Registered in `HIGH_RISK_DOMAINS` per its KEEP IN SYNC contract, so a degraded dispatch gate fails **closed** for build dispatches.
- `ACTION_TYPE_DOMAIN_MAP["autonomous_build"]` mapping for classification.
- **`SELF_MODIFY` is byte-identical** — still `None` (hard-blocked from background); a new test pins this.

## New guard test

`test_high_risk_matches_min_level_contract` derives the high-risk set from `ACTION_DOMAIN_MIN_LEVEL` (`level is None or level >= 2`) and asserts equality with `HIGH_RISK_DOMAINS` — future domains can no longer silently bypass the degraded-gate fail-closed path.

## Testing

- `pytest tests/test_autonomy/test_proposal_gate_sentinel.py tests/test_autonomy/test_classification.py tests/test_autonomy/test_proposal_gate.py` — 81 passed
- `pytest tests/test_autonomy/test_dispatch_gate.py` — 6 passed
- `ruff check` clean on the full diff
- Inline code review: clean (additive-only confirmed; no exhaustive `ActionDomain` consumers elsewhere in `src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)