### PR TITLE
feat(db): build_candidates ledger + task_states.source (build-lane groundwork)

### DIFF
--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -166,6 +166,7 @@ class TaskDispatcher:
             outputs=str(resolved_path),
             session_id=None,
             intake_token=intake_token,
+            source=source,
             created_at=now,
         )
 

--- a/src/genesis/db/crud/build_candidates.py
+++ b/src/genesis/db/crud/build_candidates.py
@@ -1,0 +1,189 @@
+"""CRUD for build_candidates — the capability-build lane's decision ledger.
+
+One row per (notepad item, verdict episode). The row carries the verdict and
+its reasoning, the pinned build spec, the greenlight approval reference, the
+user's actual decision (calibration ground truth), and the build outcome.
+
+Written only by the genesis-server process (BuildLane + executor delivery),
+so unlike the shadow stores there is no subprocess-writer table guard;
+migration 0047 / ``_tables.py`` are the schema authority.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+VERDICTS = ("build", "dont_build", "needs_discussion")
+USER_DECISIONS = ("approved", "rejected", "discussed")
+OUTCOMES = (
+    "pending", "submitted", "built", "pr_opened",
+    "scope_blocked", "build_failed", "abandoned",
+)
+
+
+async def create(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    item_key: str,
+    item_title: str,
+    source_file: str,
+    verdict: str,
+    batch_id: str | None = None,
+    eval_path: str | None = None,
+    verdict_reason: str | None = None,
+    confidence: str | None = None,
+    build_spec: str | None = None,
+    plan_path: str | None = None,
+    created_at: str | None = None,
+) -> str:
+    """Insert a new candidate row (outcome starts at 'pending').
+
+    Raises ``aiosqlite.IntegrityError`` if an OPEN candidate for the same
+    ``item_key`` already exists (partial unique index) — callers treat that
+    as "card already pending, do not re-ask".
+    """
+    await db.execute(
+        """INSERT INTO build_candidates
+           (id, item_key, item_title, source_file, batch_id, eval_path,
+            verdict, verdict_reason, confidence, build_spec, plan_path,
+            created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                   COALESCE(?, datetime('now')), COALESCE(?, datetime('now')))""",
+        (id, item_key, item_title, source_file, batch_id, eval_path,
+         verdict, verdict_reason, confidence, build_spec, plan_path,
+         created_at, created_at),
+    )
+    await db.commit()
+    return id
+
+
+async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates WHERE id = ?", (id,)
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_open_by_item_key(
+    db: aiosqlite.Connection, item_key: str
+) -> dict | None:
+    """Return the single OPEN (undecided) candidate for *item_key*, if any."""
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates "
+        "WHERE item_key = ? AND user_decision IS NULL",
+        (item_key,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_by_approval_request(
+    db: aiosqlite.Connection, approval_request_id: str
+) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates WHERE approval_request_id = ?",
+        (approval_request_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_by_task(db: aiosqlite.Connection, task_id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates WHERE task_id = ?", (task_id,)
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def list_open(db: aiosqlite.Connection) -> list[dict]:
+    """All undecided candidates, newest first."""
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates "
+        "WHERE user_decision IS NULL ORDER BY created_at DESC"
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def list_recent(
+    db: aiosqlite.Connection, *, limit: int = 50
+) -> list[dict]:
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates ORDER BY created_at DESC LIMIT ?",
+        (limit,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def record_user_decision(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    user_decision: str,
+    decided_at: str | None = None,
+) -> bool:
+    """Close a candidate with the user's decision (calibration ground truth)."""
+    if user_decision not in USER_DECISIONS:
+        raise ValueError(f"invalid user_decision: {user_decision!r}")
+    cursor = await db.execute(
+        """UPDATE build_candidates
+           SET user_decision = ?,
+               decided_at = COALESCE(?, datetime('now')),
+               updated_at = datetime('now')
+           WHERE id = ?""",
+        (user_decision, decided_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def update(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    plan_path: str | None = None,
+    approval_request_id: str | None = None,
+    task_id: str | None = None,
+    branch: str | None = None,
+    pr_url: str | None = None,
+    outcome: str | None = None,
+    scope_gate_result: str | None = None,
+) -> bool:
+    """Update lifecycle fields (None = leave unchanged)."""
+    if outcome is not None and outcome not in OUTCOMES:
+        raise ValueError(f"invalid outcome: {outcome!r}")
+    updates = []
+    params: list = []
+    if plan_path is not None:
+        updates.append("plan_path = ?")
+        params.append(plan_path)
+    if approval_request_id is not None:
+        updates.append("approval_request_id = ?")
+        params.append(approval_request_id)
+    if task_id is not None:
+        updates.append("task_id = ?")
+        params.append(task_id)
+    if branch is not None:
+        updates.append("branch = ?")
+        params.append(branch)
+    if pr_url is not None:
+        updates.append("pr_url = ?")
+        params.append(pr_url)
+    if outcome is not None:
+        updates.append("outcome = ?")
+        params.append(outcome)
+    if scope_gate_result is not None:
+        updates.append("scope_gate_result = ?")
+        params.append(scope_gate_result)
+    if not updates:
+        return False
+    updates.append("updated_at = datetime('now')")
+    params.append(id)
+    cursor = await db.execute(
+        f"UPDATE build_candidates SET {', '.join(updates)} WHERE id = ?",
+        tuple(params),
+    )
+    await db.commit()
+    return cursor.rowcount > 0

--- a/src/genesis/db/crud/build_candidates.py
+++ b/src/genesis/db/crud/build_candidates.py
@@ -59,6 +59,7 @@ async def create(
 
 
 async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
+    """Fetch one candidate row by primary key."""
     cursor = await db.execute(
         "SELECT * FROM build_candidates WHERE id = ?", (id,)
     )
@@ -82,6 +83,8 @@ async def get_open_by_item_key(
 async def get_by_approval_request(
     db: aiosqlite.Connection, approval_request_id: str
 ) -> dict | None:
+    """Fetch the candidate whose greenlight card is *approval_request_id*
+    (``approval_requests.id``) — the tap-resolution lookup."""
     cursor = await db.execute(
         "SELECT * FROM build_candidates WHERE approval_request_id = ?",
         (approval_request_id,),
@@ -91,6 +94,8 @@ async def get_by_approval_request(
 
 
 async def get_by_task(db: aiosqlite.Connection, task_id: str) -> dict | None:
+    """Fetch the candidate tied to a submitted executor task
+    (``task_states.task_id``) — the outcome-tracking lookup."""
     cursor = await db.execute(
         "SELECT * FROM build_candidates WHERE task_id = ?", (task_id,)
     )
@@ -110,6 +115,7 @@ async def list_open(db: aiosqlite.Connection) -> list[dict]:
 async def list_recent(
     db: aiosqlite.Connection, *, limit: int = 50
 ) -> list[dict]:
+    """Most recent candidates regardless of decision state, newest first."""
     cursor = await db.execute(
         "SELECT * FROM build_candidates ORDER BY created_at DESC LIMIT ?",
         (limit,),

--- a/src/genesis/db/crud/task_states.py
+++ b/src/genesis/db/crud/task_states.py
@@ -19,16 +19,17 @@ async def create(
     outputs: str | None = None,
     session_id: str | None = None,
     intake_token: str | None = None,
+    source: str = "user",
     created_at: str | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO task_states
            (task_id, description, current_phase, decisions, blockers,
-            outputs, session_id, intake_token, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
+            outputs, session_id, intake_token, source, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
                    COALESCE(?, datetime('now')))""",
         (task_id, description, current_phase, decisions, blockers,
-         outputs, session_id, intake_token, created_at, created_at),
+         outputs, session_id, intake_token, source, created_at, created_at),
     )
     await db.commit()
     return task_id

--- a/src/genesis/db/migrations/0047_build_candidates.py
+++ b/src/genesis/db/migrations/0047_build_candidates.py
@@ -1,0 +1,79 @@
+"""Add build_candidates — the autonomous capability-build lane's decision ledger.
+
+One row per (notepad item, verdict episode): Genesis's verdict on a dropped
+capability request (build / dont_build / needs_discussion) plus everything the
+lane needs downstream — the pinned build spec, the materialized plan path, the
+greenlight approval reference, the user's actual decision (calibration ground
+truth), and the build outcome (task, branch, PR, scope-gate result).
+
+Calibration is the point: every verdict row is scored against ``user_decision``
+so Stage-2 graduation (auto-submit per verdict class) is a USER call made on
+evidence, never an auto-promotion. ``dont_build`` items get a row and a report
+line, never a queue entry; ``needs_discussion`` items get BOTH a row and the
+normal follow-up.
+
+The partial unique index (one OPEN candidate per ``item_key``) is the rescan
+guard: re-evaluating an unchanged notepad can never spawn a second greenlight
+card for an item the user hasn't decided yet.
+
+Additive + idempotent; canonical DDL mirrored in ``db/schema/_tables.py`` for
+the fresh-DB path. Individual ``db.execute()`` calls (never ``executescript``).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS build_candidates (
+            id                  TEXT PRIMARY KEY,
+            item_key            TEXT NOT NULL,      -- sha256 of normalized primary URL/title (monitor normalization)
+            item_title          TEXT NOT NULL,
+            source_file         TEXT NOT NULL,      -- notepad the item was dropped in
+            batch_id            TEXT,               -- inbox batch that produced the verdict
+            eval_path           TEXT,               -- evaluation output document
+            verdict             TEXT NOT NULL CHECK (
+                verdict IN ('build', 'dont_build', 'needs_discussion')
+            ),
+            verdict_reason      TEXT,               -- articulable grounds (required for dont_build)
+            confidence          TEXT,               -- as emitted by the eval (low|medium|high)
+            build_spec          TEXT,               -- JSON: requirements/steps/success_criteria/risks/intended_paths
+            plan_path           TEXT,               -- materialized TASK_INTAKE-format plan
+            approval_request_id TEXT,               -- greenlight card (approval_requests.id)
+            user_decision       TEXT CHECK (
+                user_decision IN ('approved', 'rejected', 'discussed')
+            ),                                      -- NULL = still open (undecided)
+            decided_at          TEXT,
+            task_id             TEXT,               -- task_states row once submitted
+            branch              TEXT,
+            pr_url              TEXT,
+            outcome             TEXT NOT NULL DEFAULT 'pending' CHECK (
+                outcome IN ('pending', 'submitted', 'built', 'pr_opened',
+                            'scope_blocked', 'build_failed', 'abandoned')
+            ),
+            scope_gate_result   TEXT,               -- JSON verdict from the diff allowlist gate
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    # Rescan guard: at most ONE open (undecided) candidate per item.
+    await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_build_candidates_open_item "
+        "ON build_candidates(item_key) WHERE user_decision IS NULL"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_build_candidates_outcome "
+        "ON build_candidates(outcome)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_build_candidates_created "
+        "ON build_candidates(created_at)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS build_candidates")

--- a/src/genesis/db/migrations/0048_task_states_source.py
+++ b/src/genesis/db/migrations/0048_task_states_source.py
@@ -1,0 +1,35 @@
+"""Add ``task_states.source`` — who dispatched the task.
+
+The dispatcher has always ACCEPTED a ``source`` argument (``user`` for /task
+intake, internal names for observation dispatch) but never persisted it, so
+delivery had no way to branch on provenance. The build lane needs exactly
+that: ``source = 'build_lane'`` rows get the scope-gated diff check and the
+server-side draft-PR open at delivery; every other source keeps today's
+behavior byte-identical.
+
+``NOT NULL DEFAULT 'user'`` — every pre-existing row WAS a user submission
+(the only path that existed).
+
+Fresh/test DBs get the column from the canonical CREATE TABLE in
+``db/schema/_tables.py``; this numbered migration covers the existing-DB
+upgrade path. Idempotent: PRAGMA-guarded ADD COLUMN. No commit — the runner
+owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_states'"
+    )
+    if await cursor.fetchone():
+        col_cursor = await db.execute("PRAGMA table_info(task_states)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        if "source" not in cols:
+            await db.execute(
+                "ALTER TABLE task_states "
+                "ADD COLUMN source TEXT NOT NULL DEFAULT 'user'"
+            )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -749,8 +749,41 @@ TABLES = {
             outputs          TEXT,
             session_id       TEXT,
             intake_token     TEXT,
+            source           TEXT NOT NULL DEFAULT 'user',
             created_at       TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """,
+    "build_candidates": """
+        CREATE TABLE IF NOT EXISTS build_candidates (
+            id                  TEXT PRIMARY KEY,
+            item_key            TEXT NOT NULL,
+            item_title          TEXT NOT NULL,
+            source_file         TEXT NOT NULL,
+            batch_id            TEXT,
+            eval_path           TEXT,
+            verdict             TEXT NOT NULL CHECK (
+                verdict IN ('build', 'dont_build', 'needs_discussion')
+            ),
+            verdict_reason      TEXT,
+            confidence          TEXT,
+            build_spec          TEXT,
+            plan_path           TEXT,
+            approval_request_id TEXT,
+            user_decision       TEXT CHECK (
+                user_decision IN ('approved', 'rejected', 'discussed')
+            ),
+            decided_at          TEXT,
+            task_id             TEXT,
+            branch              TEXT,
+            pr_url              TEXT,
+            outcome             TEXT NOT NULL DEFAULT 'pending' CHECK (
+                outcome IN ('pending', 'submitted', 'built', 'pr_opened',
+                            'scope_blocked', 'build_failed', 'abandoned')
+            ),
+            scope_gate_result   TEXT,
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """,
     "intake_tokens": """
@@ -1694,6 +1727,12 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_task_states_phase ON task_states(current_phase)",
     # task steps (task executor)
     "CREATE INDEX IF NOT EXISTS idx_task_steps_status ON task_steps(status)",
+    # build candidates (capability-build lane) — partial unique index is the
+    # rescan guard: at most one OPEN (undecided) candidate per item_key
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_build_candidates_open_item "
+    "ON build_candidates(item_key) WHERE user_decision IS NULL",
+    "CREATE INDEX IF NOT EXISTS idx_build_candidates_outcome ON build_candidates(outcome)",
+    "CREATE INDEX IF NOT EXISTS idx_build_candidates_created ON build_candidates(created_at)",
     # cc_sessions: thread-aware lookup (Phase 9)
     "CREATE INDEX IF NOT EXISTS idx_cc_sess_user_ch_thread ON cc_sessions(user_id, channel, thread_id)",
     # telegram messages

--- a/tests/test_autonomy/test_crud.py
+++ b/tests/test_autonomy/test_crud.py
@@ -117,6 +117,16 @@ class TestTaskStates:
         row = await task_states.get_by_id(db, "task-1")
         assert row is not None
         assert row["current_phase"] == "planning"
+        assert row["source"] == "user"  # default provenance
+
+    async def test_create_persists_source(self, db):
+        token = await create_intake_token(db)
+        await task_states.create(
+            db, task_id="task-bl", description="build",
+            intake_token=token, source="build_lane",
+        )
+        row = await task_states.get_by_id(db, "task-bl")
+        assert row["source"] == "build_lane"
 
     async def test_update(self, db):
         token = await create_intake_token(db)

--- a/tests/test_autonomy/test_executor/test_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_dispatcher.py
@@ -125,6 +125,29 @@ class TestSubmit:
         assert task_id.startswith("t-")
         assert task_id in dispatcher._dispatched
         mock_create.assert_awaited_once()
+        assert mock_create.await_args.kwargs["source"] == "user"
+
+    async def test_submit_persists_internal_source(
+        self, dispatcher: TaskDispatcher, tmp_path: Path,
+    ) -> None:
+        """Non-user sources self-generate a token and are persisted verbatim —
+        the build lane depends on this to gate delivery on source."""
+        plan = tmp_path / "plan.md"
+        plan.write_text(VALID_PLAN)
+
+        with (
+            patch("genesis.autonomy.dispatcher._ALLOWED_PLAN_DIRS", [tmp_path]),
+            patch("genesis.db.crud.task_states.create", new_callable=AsyncMock) as mock_create,
+            patch("genesis.util.tasks.tracked_task"),
+            patch.object(
+                dispatcher, "_generate_intake_token",
+                new=AsyncMock(return_value="auto-tok"),
+            ),
+        ):
+            await dispatcher.submit(str(plan), "Build task", source="build_lane")
+
+        assert mock_create.await_args.kwargs["source"] == "build_lane"
+        assert mock_create.await_args.kwargs["intake_token"] == "auto-tok"
 
     async def test_submit_without_token_rejected(
         self, dispatcher: TaskDispatcher, tmp_path: Path,

--- a/tests/test_db/test_build_candidates.py
+++ b/tests/test_db/test_build_candidates.py
@@ -1,0 +1,132 @@
+"""Tests for build_candidates CRUD — the capability-build lane ledger."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import build_candidates
+
+
+async def _make(db, id="c1", item_key="k1", verdict="build", **kw):
+    return await build_candidates.create(
+        db,
+        id=id,
+        item_key=item_key,
+        item_title=kw.pop("item_title", "Test capability"),
+        source_file=kw.pop("source_file", "New Genesis Capabilities.md"),
+        verdict=verdict,
+        **kw,
+    )
+
+
+class TestCreateAndGet:
+    async def test_create_and_get(self, db):
+        await _make(
+            db,
+            batch_id="b1",
+            eval_path="/tmp/eval.md",
+            verdict_reason="clear fit",
+            confidence="high",
+            build_spec='{"requirements": ["r1"]}',
+        )
+        row = await build_candidates.get_by_id(db, "c1")
+        assert row is not None
+        assert row["item_key"] == "k1"
+        assert row["verdict"] == "build"
+        assert row["outcome"] == "pending"
+        assert row["user_decision"] is None
+        assert row["confidence"] == "high"
+
+    async def test_get_missing_returns_none(self, db):
+        assert await build_candidates.get_by_id(db, "nope") is None
+
+    async def test_open_duplicate_item_key_raises(self, db):
+        await _make(db, id="c1", item_key="k1")
+        with pytest.raises(aiosqlite.IntegrityError):
+            await _make(db, id="c2", item_key="k1")
+
+    async def test_get_open_by_item_key(self, db):
+        await _make(db, id="c1", item_key="k1")
+        row = await build_candidates.get_open_by_item_key(db, "k1")
+        assert row is not None and row["id"] == "c1"
+        assert await build_candidates.get_open_by_item_key(db, "k2") is None
+
+
+class TestDecisionLifecycle:
+    async def test_record_user_decision_closes_candidate(self, db):
+        await _make(db, id="c1", item_key="k1")
+        assert await build_candidates.record_user_decision(
+            db, "c1", user_decision="approved"
+        )
+        row = await build_candidates.get_by_id(db, "c1")
+        assert row["user_decision"] == "approved"
+        assert row["decided_at"] is not None
+        # No longer "open" — item can get a fresh candidate on re-drop.
+        assert await build_candidates.get_open_by_item_key(db, "k1") is None
+
+    async def test_invalid_decision_raises(self, db):
+        await _make(db, id="c1")
+        with pytest.raises(ValueError):
+            await build_candidates.record_user_decision(
+                db, "c1", user_decision="maybe"
+            )
+
+    async def test_decision_on_missing_row_returns_false(self, db):
+        assert not await build_candidates.record_user_decision(
+            db, "nope", user_decision="rejected"
+        )
+
+
+class TestLifecycleUpdate:
+    async def test_update_fields(self, db):
+        await _make(db, id="c1")
+        assert await build_candidates.update(
+            db,
+            "c1",
+            plan_path="/plans/p.md",
+            approval_request_id="ar-1",
+            task_id="t-abc",
+            branch="task/t-abc",
+            pr_url="https://example.invalid/pr/1",
+            outcome="pr_opened",
+            scope_gate_result='{"allowed": true}',
+        )
+        row = await build_candidates.get_by_id(db, "c1")
+        assert row["task_id"] == "t-abc"
+        assert row["outcome"] == "pr_opened"
+        assert row["approval_request_id"] == "ar-1"
+
+    async def test_invalid_outcome_raises(self, db):
+        await _make(db, id="c1")
+        with pytest.raises(ValueError):
+            await build_candidates.update(db, "c1", outcome="shipped")
+
+    async def test_no_fields_returns_false(self, db):
+        await _make(db, id="c1")
+        assert not await build_candidates.update(db, "c1")
+
+
+class TestQueries:
+    async def test_list_open_excludes_decided(self, db):
+        await _make(db, id="c1", item_key="k1")
+        await _make(db, id="c2", item_key="k2", verdict="dont_build")
+        await build_candidates.record_user_decision(
+            db, "c2", user_decision="rejected"
+        )
+        open_rows = await build_candidates.list_open(db)
+        assert [r["id"] for r in open_rows] == ["c1"]
+
+    async def test_list_recent_limit(self, db):
+        for i in range(3):
+            await _make(db, id=f"c{i}", item_key=f"k{i}")
+        rows = await build_candidates.list_recent(db, limit=2)
+        assert len(rows) == 2
+
+    async def test_get_by_approval_request_and_task(self, db):
+        await _make(db, id="c1")
+        await build_candidates.update(
+            db, "c1", approval_request_id="ar-9", task_id="t-9"
+        )
+        assert (await build_candidates.get_by_approval_request(db, "ar-9"))["id"] == "c1"
+        assert (await build_candidates.get_by_task(db, "t-9"))["id"] == "c1"

--- a/tests/test_db/test_migration_0047_build_candidates.py
+++ b/tests/test_db/test_migration_0047_build_candidates.py
@@ -1,0 +1,95 @@
+"""Migration 0047 — create build_candidates (capability-build lane ledger).
+
+Verifies table + index creation on an empty DB, idempotency (fresh DBs already
+have the table from _tables.py), the CHECK constraints, and the partial unique
+index (one OPEN candidate per item_key). Mirrors the 0044 new-table pattern.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+import aiosqlite
+import pytest
+
+M47 = importlib.import_module("genesis.db.migrations.0047_build_candidates")
+
+
+async def _tables(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+async def _indexes(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_creates_table_and_indexes(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M47.up(db)
+        assert "build_candidates" in await _tables(db)
+        idx = await _indexes(db)
+        assert "idx_build_candidates_open_item" in idx
+        assert "idx_build_candidates_outcome" in idx
+        assert "idx_build_candidates_created" in idx
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M47.up(db)
+        await M47.up(db)  # second run must NOT raise
+        assert "build_candidates" in await _tables(db)
+
+
+@pytest.mark.asyncio
+async def test_verdict_check_constraint(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M47.up(db)
+        with pytest.raises(sqlite3.IntegrityError):
+            await db.execute(
+                "INSERT INTO build_candidates "
+                "(id, item_key, item_title, source_file, verdict) "
+                "VALUES ('c1', 'k', 'title', 'n.md', 'maybe')"
+            )
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_open_candidate(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M47.up(db)
+        await db.execute(
+            "INSERT INTO build_candidates "
+            "(id, item_key, item_title, source_file, verdict) "
+            "VALUES ('c1', 'k', 'title', 'n.md', 'build')"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            await db.execute(
+                "INSERT INTO build_candidates "
+                "(id, item_key, item_title, source_file, verdict) "
+                "VALUES ('c2', 'k', 'title', 'n.md', 'build')"
+            )
+        await db.execute(
+            "UPDATE build_candidates SET user_decision = 'approved' WHERE id = 'c1'"
+        )
+        # Decided row no longer blocks a new open candidate.
+        await db.execute(
+            "INSERT INTO build_candidates "
+            "(id, item_key, item_title, source_file, verdict) "
+            "VALUES ('c3', 'k', 'title', 'n.md', 'build')"
+        )
+
+
+@pytest.mark.asyncio
+async def test_down_drops_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M47.up(db)
+        await M47.down(db)
+        assert "build_candidates" not in await _tables(db)

--- a/tests/test_db/test_migration_0048_task_states_source.py
+++ b/tests/test_db/test_migration_0048_task_states_source.py
@@ -1,0 +1,76 @@
+"""Migration 0048 — add task_states.source (dispatch provenance).
+
+Verifies the column is added to a pre-existing table with the 'user' default
+backfilled onto existing rows, the add is idempotent (fresh DBs already have
+it from _tables.py), and a missing table is a safe no-op. Mirrors 0046.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M48 = importlib.import_module("genesis.db.migrations.0048_task_states_source")
+
+# A minimal PRE-0048 task_states (no source) — the existing-DB upgrade path.
+_OLD_DDL = """
+    CREATE TABLE task_states (
+        task_id TEXT PRIMARY KEY, description TEXT NOT NULL,
+        current_phase TEXT NOT NULL DEFAULT 'planning', decisions TEXT,
+        blockers TEXT, outputs TEXT, session_id TEXT, intake_token TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+"""
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(task_states)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_adds_source_column_to_existing_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        assert "source" not in await _columns(db)
+        await M48.up(db)
+        assert "source" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_existing_rows_backfilled_as_user(tmp_path):
+    """Every pre-migration row was a /task user submission — the only path
+    that existed — so the DEFAULT backfill must label them 'user'."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await db.execute(
+            "INSERT INTO task_states (task_id, description) VALUES ('t-old', 'd')"
+        )
+        await M48.up(db)
+        cur = await db.execute(
+            "SELECT source FROM task_states WHERE task_id = 't-old'"
+        )
+        row = await cur.fetchone()
+        assert row[0] == "user"
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await M48.up(db)
+        await M48.up(db)  # second run must NOT raise "duplicate column"
+        assert "source" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_up_noop_when_table_absent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M48.up(db)  # no task_states table — must be a safe no-op
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='task_states'"
+        )
+        assert await cur.fetchone() is None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -60,6 +60,7 @@ EXPECTED_TABLES = [
     "pending_email_sends",  # WS-8 PR-C: email autonomy gate hold store
     "autonomous_email_sends",  # WS-8 PR-D: autonomous-send ledger (visibility + flag + rate-limit)
     "capability_shadow_events",  # WS5 Stage 2: Discord capability shadow-gate observations
+    "build_candidates",  # capability-build lane: verdicts + calibration + build outcomes
 ]
 
 
@@ -286,6 +287,70 @@ async def test_follow_ups_rejects_invalid_domain(db):
             "INSERT INTO follow_ups (id, source, content, strategy, created_at, domain) "
             "VALUES ('t', 's', 'c', 'ego_judgment', '2026-01-01T00:00:00', 'INVALID')"
         )
+
+
+async def test_build_candidates_rejects_invalid_verdict(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict) "
+            "VALUES ('t', 'k', 'title', 'notepad.md', 'INVALID')"
+        )
+
+
+async def test_build_candidates_rejects_invalid_outcome(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict, outcome) "
+            "VALUES ('t', 'k', 'title', 'notepad.md', 'build', 'INVALID')"
+        )
+
+
+async def test_build_candidates_rejects_invalid_user_decision(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO build_candidates "
+            "(id, item_key, item_title, source_file, verdict, user_decision) "
+            "VALUES ('t', 'k', 'title', 'notepad.md', 'build', 'INVALID')"
+        )
+
+
+async def test_build_candidates_one_open_per_item_key(db):
+    """Partial unique index: a second OPEN candidate for the same item_key is
+    rejected (rescan guard), but a DECIDED row plus a new open row coexist."""
+    await db.execute(
+        "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict) "
+        "VALUES ('c1', 'k1', 'title', 'notepad.md', 'build')"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict) "
+            "VALUES ('c2', 'k1', 'title', 'notepad.md', 'build')"
+        )
+    # Close c1 with a decision — a fresh open candidate is then allowed.
+    await db.execute(
+        "UPDATE build_candidates SET user_decision = 'rejected' WHERE id = 'c1'"
+    )
+    await db.execute(
+        "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict) "
+        "VALUES ('c3', 'k1', 'title', 'notepad.md', 'build')"
+    )
+
+
+async def test_task_states_source_defaults_to_user(db):
+    # Satisfy the enforce_intake_token trigger with a fresh, unconsumed token.
+    await db.execute(
+        "INSERT INTO intake_tokens (token, created_at, expires_at) "
+        "VALUES ('tok-src', datetime('now'), datetime('now', '+1 hour'))"
+    )
+    await db.execute(
+        "INSERT INTO task_states (task_id, description, intake_token) "
+        "VALUES ('t-x', 'd', 'tok-src')"
+    )
+    cursor = await db.execute(
+        "SELECT source FROM task_states WHERE task_id = 't-x'"
+    )
+    row = await cursor.fetchone()
+    assert row[0] == "user"
 
 
 # ─── NOT NULL constraints ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Groundwork PR-2 of the autonomous capability-build lane. Pure-additive DB changes; nothing consumes them yet (BuildLane lands separately).

- **Migration 0047 — `build_candidates`**: one row per (notepad item, verdict episode) — verdict (`build`/`dont_build`/`needs_discussion`) + reasoning + pinned `build_spec`, greenlight approval ref, the user's actual decision (`approved`/`rejected`/`discussed` — calibration ground truth), and build outcome (task/branch/PR/scope-gate result). **Partial unique index** `ON build_candidates(item_key) WHERE user_decision IS NULL` = rescan guard: re-evaluating an unchanged notepad can never spawn a second pending card.
- **Migration 0048 — `task_states.source`** (`TEXT NOT NULL DEFAULT 'user'`): the dispatcher always accepted `source` but never persisted it; delivery-side branching needs provenance. Existing rows backfill as `'user'` — the only path that ever existed.
- Canonical DDL mirrored in `db/schema/_tables.py` (fresh-DB path); new `crud/build_candidates.py`; `crud/task_states.create()` gains `source`; dispatcher passes it through.

## Testing

- 131 passed across `test_schema.py`, `test_migration_0047/0048`, `test_build_candidates.py`, `test_autonomy/test_crud.py`, `test_executor/test_dispatcher.py`, `test_migrations_runner.py`
- New tests: CHECK-constraint rejections, partial-unique-index semantics (open vs decided), migration idempotency + backfill, dispatcher `source` persistence
- `ruff check` clean on the full diff
- Inline code review: clean — migration/_tables DDL equivalence, placeholder counts, no-commit-in-migration, and all `task_states.create` call sites verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)