### PR TITLE
feat(inbox): BUILD verdict contract + parser fields (shadow, build-lane groundwork)

### DIFF
--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -228,6 +228,38 @@ all** — e.g., a note containing only the bracket itself with nothing
 else, which is pure meta-context and should be classified as
 **Acknowledged** (no response file) instead.
 
+### Capability-build directives (a Rule 1 sub-case)
+
+Some Genesis-directed brackets go further than classification: they express
+BUILD INTENT — e.g. "capabilities/tools I'd like Genesis to be able to use",
+"if it's in here, I believe we need it", "default to getting it done unless
+there's a technical reason we shouldn't", or close variants. When the bracket
+expresses build intent:
+
+1. Every item is Genesis-relevant per Rule 1, evaluated with the Genesis
+   framework as usual.
+2. Each item ADDITIONALLY receives a **build verdict** in its Recommendation
+   YAML (`verdict`, `verdict_reason`, and — for `verdict: build` — a
+   `build_spec`). See Step 5 for the exact format.
+3. The verdict carries a **strong prior toward `build`**: the user has
+   already declared they believe the capability is needed. You are NOT
+   running a second from-scratch evaluation of whether it's worthwhile.
+   `dont_build` is a VETO, and a veto requires articulable technical
+   grounds stated in `verdict_reason` — one of: Genesis already has this
+   capability (cite the component), it doesn't fit the architecture,
+   it is technically unsound, or it is brain-not-body scope (it modifies
+   Genesis's cognitive core — memory, reflection, triage, routing, ego —
+   which this lane never builds autonomously; the veto report tells the
+   user to raise it as an architecture conversation instead). Do NOT use
+   `needs_discussion` for brain-scope items — that verdict is for
+   genuinely unpinnable BODY builds, not for scope refusals.
+   "Not obviously valuable" is not a veto ground under a build directive.
+4. Use `needs_discussion` when you genuinely cannot pin the right shape —
+   an unmade design decision, missing access, or ambiguity about what the
+   user actually wants built. Say precisely what needs deciding.
+5. Emit the verdict fields ONLY under a build-intent bracket. Ordinary
+   Genesis notepads and unbracketed files never carry them.
+
 ### Classification Categories
 
 With Rule 1 resolved (or no bracket present), classification is judgment,
@@ -522,6 +554,48 @@ tool_momentum: high        # high | medium | low — growth/adoption trend
 tool_activity: high        # high | medium | low — maintenance/recency
 tool_maturity: medium      # high | medium | low — proven/stable/age
 ```
+
+For items under a **capability-build directive** (Step 2, "Capability-build
+directives"), use `action: BUILD` and extend the Genesis block with the
+verdict fields:
+
+```yaml
+action: BUILD              # capability-build items ONLY (never elsewhere)
+next_step: "One concrete sentence — what the build produces"
+effort: Small              # Trivial | Small | Medium | Large
+scope: V4                  # V4 | V5 | Future | Never
+confidence: high           # low | medium | high
+architecture_impact: extends
+verdict: build             # build | dont_build | needs_discussion
+verdict_reason: "Why this verdict — MANDATORY for dont_build (the veto grounds)"
+build_spec:                # REQUIRED for verdict: build — omit otherwise
+  requirements:            # specific, verifiable requirements
+    - "..."
+  steps:                   # executor-perspective steps, each typed
+    - type: code           # code | test | verification
+      description: "..."
+  success_criteria:        # testable by the executor in a headless container
+    - "..."
+  risks:                   # specific failure modes, not vague worries
+    - "..."
+  intended_paths:          # repo paths the build is expected to touch
+    - "src/genesis/skills/..."
+```
+
+**Capability-build rules:**
+- Strong prior toward `verdict: build` — the user pre-declared need by
+  dropping the item. `dont_build` is a veto and MUST argue articulable
+  technical grounds in `verdict_reason` (existing capability / architecture
+  misfit / technically unsound / brain-not-body scope).
+- `verdict: build` with an empty or missing `build_spec` (or any empty
+  required list inside it) is malformed — the build lane will park it as
+  needs_discussion. Fill every list or change the verdict.
+- `intended_paths` should stay within capability trees (modules, skills,
+  MCP tools, tests, docs). A build that needs core-subsystem changes is
+  `needs_discussion`, not `build`.
+- BUILD items never create follow-ups — the build lane owns their lifecycle.
+- `dont_build` and `needs_discussion` items still get the full evaluation
+  sections; the verdict fields ride on top, they don't replace analysis.
 
 For **User-relevant** items, use this YAML block:
 

--- a/src/genesis/inbox/recommendation.py
+++ b/src/genesis/inbox/recommendation.py
@@ -7,7 +7,14 @@ programmatically.
 
 Two vocabularies:
 - Genesis-relevant: ADOPT | ADAPT | WATCH | IGNORE
+  (+ BUILD, emitted only for capability-build notepad items — consumed by the
+  build lane, never by follow-up creation)
 - User-relevant:    adopt | explore | bookmark | potential_skip
+
+Capability-build extension: items evaluated under a capability-build bracket
+directive additionally carry ``verdict`` (build | dont_build | needs_discussion),
+``verdict_reason``, and a structured ``build_spec`` mapping. These parse into
+optional fields; evaluations without them are unchanged.
 """
 
 from __future__ import annotations
@@ -21,10 +28,22 @@ import yaml
 logger = logging.getLogger(__name__)
 
 # Actions that should NOT produce follow-ups.
+# BUILD is skipped by design: capability-build verdicts are consumed by the
+# build lane (greenlight card -> task executor), never queued as follow-ups.
 _SKIP_ACTIONS: frozenset[str] = frozenset({
     "ignore",
     "potential_skip",
     "potential skip",
+    "build",
+})
+
+# Valid values for the capability-build verdict field. An unrecognized value
+# parses as None (shadow-safe: bad LLM output degrades to "no verdict", it
+# never invents one).
+VALID_VERDICTS: frozenset[str] = frozenset({
+    "build",
+    "dont_build",
+    "needs_discussion",
 })
 
 # ---------------------------------------------------------------------------
@@ -51,6 +70,11 @@ class Recommendation:
     tool_momentum: str | None = None
     tool_activity: str | None = None
     tool_maturity: str | None = None
+    # Capability-build verdict (only for capability-notepad drops; the build
+    # lane consumes these — follow-up creation ignores them)
+    verdict: str | None = None
+    verdict_reason: str | None = None
+    build_spec: dict | None = None
     # Context
     item_title: str = ""
     classification: str = ""  # "genesis" or "user"
@@ -177,12 +201,37 @@ def parse_recommendations(evaluation_text: str) -> list[Recommendation]:
                 str(data["tool_maturity"]).strip()
                 if "tool_maturity" in data else None
             ),
+            verdict=_parse_verdict(data),
+            verdict_reason=(
+                str(data["verdict_reason"]).strip()
+                if data.get("verdict_reason") else None
+            ),
+            build_spec=(
+                data["build_spec"]
+                if isinstance(data.get("build_spec"), dict) else None
+            ),
             item_title=title,
             classification=classification,
         )
         results.append(rec)
 
     return results
+
+
+def _parse_verdict(data: dict) -> str | None:
+    """Normalize and validate the optional ``verdict`` field.
+
+    Unrecognized values degrade to None with a warning — a malformed verdict
+    must never masquerade as a real one downstream.
+    """
+    raw = data.get("verdict")
+    if not raw:
+        return None
+    verdict = str(raw).strip().lower().replace(" ", "_")
+    if verdict not in VALID_VERDICTS:
+        logger.warning("Unrecognized verdict value %r — treating as absent", raw)
+        return None
+    return verdict
 
 
 def _extract_item_title(section_text: str) -> str:

--- a/tests/test_inbox/test_recommendation.py
+++ b/tests/test_inbox/test_recommendation.py
@@ -322,6 +322,25 @@ verdict_reason: "No Proxmox cluster exists for Genesis to manage"
 ```
 """
 
+NEEDS_DISCUSSION_VERDICT = """\
+## 1. Hypothetical capability
+
+**Classification:** Genesis-relevant (capability-build directive)
+
+### Recommendation
+
+```yaml
+action: BUILD
+next_step: "Discuss shape before building"
+effort: Small
+scope: V4
+confidence: low
+architecture_impact: challenges
+verdict: needs_discussion
+verdict_reason: "Ambiguous interface - needs a design decision before the executor can proceed"
+```
+"""
+
 BAD_VERDICT_VALUE = """\
 ## 1. Something
 
@@ -400,6 +419,13 @@ class TestParseRecommendations:
         assert r.verdict_reason == "No Proxmox cluster exists for Genesis to manage"
         assert r.build_spec is None
         assert r.is_actionable is False
+
+    def test_needs_discussion_verdict_parses(self):
+        r = parse_recommendations(NEEDS_DISCUSSION_VERDICT)[0]
+        assert r.verdict == "needs_discussion"
+        assert r.verdict_reason is not None
+        assert r.build_spec is None
+        assert r.is_actionable is False  # BUILD is in _SKIP_ACTIONS
 
     def test_invalid_verdict_and_non_mapping_spec_degrade_to_none(self):
         # Shadow-safe: bad LLM output degrades to "no verdict", never invents one.

--- a/tests/test_inbox/test_recommendation.py
+++ b/tests/test_inbox/test_recommendation.py
@@ -266,6 +266,81 @@ confidence: low
 """
 
 
+BUILD_VERDICT = """\
+## 1. Warpchart — star-velocity tracker
+
+**Classification:** Genesis-relevant (capability-build directive)
+
+### Recommendation
+
+```yaml
+action: BUILD
+next_step: "Build a star-velocity module fed by gather_stars history"
+effort: Small
+scope: V4
+confidence: high
+architecture_impact: extends
+verdict: build
+verdict_reason: "Clear capability gap, fits module tree"
+build_spec:
+  requirements:
+    - "Compute +N/day velocity from existing star history"
+  steps:
+    - type: code
+      description: "Add velocity computation"
+    - type: verification
+      description: "Verify against recorded history"
+  success_criteria:
+    - "Velocity matches hand-computed value for fixture data"
+  risks:
+    - "Sparse history yields noisy velocity - require 3+ samples"
+  intended_paths:
+    - "src/genesis/modules/star_velocity/"
+```
+
+### Lens 1
+
+Analysis.
+"""
+
+DONT_BUILD_VERDICT = """\
+## 1. Proxmox VM provisioning MCP
+
+**Classification:** Genesis-relevant (capability-build directive)
+
+### Recommendation
+
+```yaml
+action: BUILD
+next_step: "Report the veto"
+effort: Trivial
+scope: Never
+confidence: high
+architecture_impact: irrelevant
+verdict: dont_build
+verdict_reason: "No Proxmox cluster exists for Genesis to manage"
+```
+"""
+
+BAD_VERDICT_VALUE = """\
+## 1. Something
+
+**Classification:** Genesis-relevant
+
+### Recommendation
+
+```yaml
+action: BUILD
+next_step: "n"
+effort: Small
+scope: V4
+confidence: low
+verdict: maybe_later
+build_spec: "not a mapping"
+```
+"""
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -300,6 +375,44 @@ class TestParseRecommendations:
         assert r.tool_momentum is None
         assert r.tool_activity is None
         assert r.tool_maturity is None
+
+    def test_build_verdict_parses_full_spec(self):
+        recs = parse_recommendations(BUILD_VERDICT)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.action == "BUILD"
+        assert r.verdict == "build"
+        assert r.verdict_reason == "Clear capability gap, fits module tree"
+        assert isinstance(r.build_spec, dict)
+        assert r.build_spec["requirements"] == [
+            "Compute +N/day velocity from existing star history"
+        ]
+        assert r.build_spec["steps"][0]["type"] == "code"
+        assert r.build_spec["intended_paths"] == [
+            "src/genesis/modules/star_velocity/"
+        ]
+        # BUILD never produces a follow-up — the build lane owns it.
+        assert r.is_actionable is False
+
+    def test_dont_build_verdict_without_spec(self):
+        r = parse_recommendations(DONT_BUILD_VERDICT)[0]
+        assert r.verdict == "dont_build"
+        assert r.verdict_reason == "No Proxmox cluster exists for Genesis to manage"
+        assert r.build_spec is None
+        assert r.is_actionable is False
+
+    def test_invalid_verdict_and_non_mapping_spec_degrade_to_none(self):
+        # Shadow-safe: bad LLM output degrades to "no verdict", never invents one.
+        r = parse_recommendations(BAD_VERDICT_VALUE)[0]
+        assert r.verdict is None
+        assert r.build_spec is None
+
+    def test_verdict_fields_default_none_for_ordinary_evals(self):
+        # Backward compatible: every pre-existing eval has no verdict fields.
+        r = parse_recommendations(GENESIS_SINGLE)[0]
+        assert r.verdict is None
+        assert r.verdict_reason is None
+        assert r.build_spec is None
 
     def test_user_single(self):
         recs = parse_recommendations(USER_SINGLE)


### PR DESCRIPTION
## Summary

Groundwork PR-5 of the autonomous capability-build lane — ships EARLY so live evaluations emit observable **shadow verdicts** before anything consumes them.

- **INBOX_EVALUATE.md**: new Rule-1 sub-case for capability-build bracket directives ("default to getting it done") + a Step 5 `action: BUILD` YAML block carrying `verdict` (`build`/`dont_build`/`needs_discussion`), `verdict_reason`, and a structured `build_spec` (requirements / typed steps / success criteria / risks / intended_paths). **Strong prior toward `build`** — the user pre-declared need by dropping the item; `dont_build` is a veto requiring articulable technical grounds (existing capability / architecture misfit / unsound / brain-not-body scope).
- **recommendation.py**: three optional parsed fields, shadow-safe — unrecognized verdicts and non-mapping build_specs degrade to `None`; `BUILD` joins `_SKIP_ACTIONS` so it can **never create a follow-up** (double-guarded: the monitor's `_ACTION_MAP` also has no `build` key).
- Zero behavior change for every existing evaluation (all new fields default `None`).

## Testing

- `pytest tests/test_inbox/test_recommendation.py` — 23 passed (new: full build_spec parse, dont_build without spec, degradation of invalid verdict/spec, backward-compat defaults, `is_actionable is False` for BUILD)
- `pytest tests/test_inbox/test_drop_dispatch.py` — 21 passed
- `ruff check` clean
- Inline review (extra scrutiny, prompt-file change): clean; one wording ambiguity it flagged (brain-not-body veto vs needs_discussion) fixed before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)