### PR TITLE
docs(architecture): canonical subsystem map (CURRENT.md) + CI drift guard + skill

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -236,8 +236,9 @@ stack**, and a negative from a positive search is not evidence of absence:
 A 2026-06-30 competitive audit wrongly claimed Genesis lacked CRAG,
 scope-before-rank, and a live reranker — all three had already shipped. Full
 protocol: procedure `codebase_audit` / CC memory `audit-enumerate-not-spotcheck`.
-For "does Genesis already have X", consult the capability map
-(`references/codebase-map.md`) FIRST.
+For "does Genesis already have X", consult the subsystem map
+(`docs/architecture/CURRENT.md`, via the `subsystem-map` skill) FIRST;
+`references/codebase-map.md` stays the package-level structural companion.
 
 ## Adaptive Review Protocol
 
@@ -346,6 +347,7 @@ references on every trigger.
 
 | When you need... | Read... |
 |---|---|
+| Subsystem purpose/maturity/do-not-touch (judgment layer) | `docs/architecture/CURRENT.md` |
 | Codebase structure, package map, gotchas, debugging | `references/codebase-map.md` |
 | Package/module/symbol navigation (progressive drill) | `codebase_navigate` MCP tool (L0→L1→L2) |
 | venv, DB paths, Qdrant, Ollama, network, commands | `references/environment.md` |
@@ -360,6 +362,9 @@ references on every trigger.
 **Freshness rule:** On first read of `codebase-map.md` in a session,
 verify structural claims against current code. If a package status or
 gotcha has changed, flag to user before acting on stale assumptions.
+`docs/architecture/CURRENT.md` carries per-entry `verified:` stamps
+enforced by `scripts/check_subsystem_map.py` (CI `subsystem-map-check`) —
+after changing a subsystem's capabilities, update its entry and stamp.
 
 ## Public Repo & Release Workflow
 

--- a/.claude/skills/genesis-development/references/codebase-map.md
+++ b/.claude/skills/genesis-development/references/codebase-map.md
@@ -3,6 +3,11 @@
 Quick reference for how Genesis is structurally organized, where to find
 things, and what trips developers up repeatedly.
 
+> For the judgment layer — what each subsystem is FOR, its easy-to-forget
+> mechanisms, maturity, and do-not-touch edges — read
+> `docs/architecture/CURRENT.md` (stamped + CI-enforced via
+> `scripts/check_subsystem_map.py`). This file stays package-level.
+
 ## Package Map (`src/genesis/`)
 
 | Package | Purpose | Status |

--- a/.claude/skills/subsystem-map/SKILL.md
+++ b/.claude/skills/subsystem-map/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: subsystem-map
+description: >
+  This skill should be used before answering "does Genesis have X", "does
+  Genesis lack X", auditing Genesis capabilities, comparing Genesis to an
+  external system, or reviewing/summarizing the architecture. It routes to
+  the canonical judgment-layer subsystem map so audits start from the map,
+  not from a cold grep. Also fires after changing a subsystem's
+  capabilities, to keep the map current.
+keywords: [capability, capabilities, subsystem, map, audit, architecture, lacks, missing, compare, competitive]
+---
+
+## The Rule
+
+**Read `docs/architecture/CURRENT.md` FIRST** — before any grep, agent
+dispatch, or claim about what Genesis has or lacks. It is the canonical
+judgment-layer map: what each subsystem is FOR, its easy-to-forget
+mechanisms, maturity (live / shadow / dark), and do-not-touch edges.
+
+A claim of absence ("Genesis lacks X", "Genesis should add X") made
+without consulting the map first is a protocol violation — the 2026-06-30
+audit produced 6/7 wrong infrastructure claims exactly this way.
+
+## Workflow
+
+1. **Locate the entry.** Find the subsystem entry (or entries) covering the
+   capability in question. Entries claim modules in fenced
+   `yaml subsystem-map` blocks — the union covers every top-level package
+   in `src/genesis`, so "no entry mentions it" means you're using the wrong
+   concept name, not that it doesn't exist.
+2. **Trust but verify.** The map is judgment-layer, not ground truth. Check
+   each entry's `verified: <sha> <date>` stamp; if its modules have moved
+   since, re-verify the specific claim against the live tree before relying
+   on it.
+3. **Then enumerate.** For absence/existence conclusions, follow the audit
+   protocol (procedure `codebase_audit` / dev-skill "Auditing Existing
+   Capabilities"): enumerate the subsystem's module inventory, trace the
+   call graph both directions, grep by concept with synonyms, and verify
+   against RUNTIME state (env gates, logs) — the map tells you where to
+   look, not what to conclude.
+
+## Write-Back Duty
+
+After you **change** a subsystem's capabilities (new mechanism, new gate,
+wiring flip, removal) or **re-verify** an entry during an audit:
+
+- Update the owning entry's prose and its `modules:` block if the package
+  set changed.
+- Bump the entry's `verified:` stamp to the current short sha + date.
+
+CI enforces the module partition (`scripts/check_subsystem_map.py`): a new
+top-level package that no entry claims fails the build; stale stamps warn.
+
+## Naming Trap
+
+`capability_map` (DB table) and `ego/capability_aggregator.py` are the
+ego's per-domain self-confidence model — completely unrelated to this map.
+Never conflate them; everything here is "subsystem map".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,4 @@
 - [ ] `ruff check .` passes
 - [ ] `pytest -v` passes
 - [ ] Tested end-to-end (describe how)
+- [ ] `docs/architecture/CURRENT.md` updated (entry prose + `verified:` stamp) if subsystem capabilities changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,26 @@ jobs:
       - name: External-I/O egress guard
         run: python scripts/check_external_io.py
 
+  subsystem-map-check:
+    # Judgment-layer map guard: docs/architecture/CURRENT.md must claim every
+    # top-level src/genesis module (an unmapped or vanished module = the map
+    # lies to audits → error). Stale 'verified:' stamps only warn. The stamp
+    # check counts commits since each entry's stamp, so this job alone checks
+    # out full history (fetch-depth: 0); the checker degrades gracefully on
+    # shallow clones. See scripts/check_subsystem_map.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install checker dependency
+        run: pip install pyyaml
+      - name: Subsystem-map drift guard
+        run: python scripts/check_subsystem_map.py
+
   cc-node-lockstep:
     # Enforce the CC↔Node pin lockstep: NODE_MAJOR in scripts/lib/cc_version.sh
     # must satisfy the pinned Claude Code's engines.node floor. Prevents the

--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,10 @@ src/genesis/cc/profile_overlay.py
 
 # Docs are private by default — opt-in for public.
 # Only directories listed with ! are tracked.
-docs/
+# NOTE: must be docs/* (not docs/) — excluding the parent dir itself makes
+# the ! re-inclusions below dead (git never descends into an excluded dir),
+# which silently forced `git add -f` for every new file in the opt-in dirs.
+docs/*
 !docs/architecture/
 !docs/decisions/
 !docs/case-studies/

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1,0 +1,509 @@
+# Genesis — Current Architecture (the Subsystem Map)
+
+This is the **canonical judgment-layer map** of Genesis: what each subsystem is
+FOR, the mechanisms auditors keep forgetting exist, what is LIVE vs shadow vs
+dark, and the do-not-touch edges. It answers "does Genesis have X?" — consult
+it FIRST (via the `subsystem-map` skill) before any capability claim, audit, or
+competitive comparison. The package-level structural companion is
+`.claude/skills/genesis-development/references/codebase-map.md`; the
+philosophical "why" is `docs/architecture/genesis-v3-vision.md`.
+
+**How this file stays honest.** Every entry claims its top-level
+`src/genesis` modules in a fenced `yaml subsystem-map` block and carries a
+`verified: <short-sha> <date>` stamp. CI (`subsystem-map-check`, backed by
+`scripts/check_subsystem_map.py`) fails the build if a module is unmapped,
+claimed twice, or vanished; stale stamps only warn. After changing a
+subsystem's capabilities, update its entry and bump its stamp (PR-template
+checkbox).
+
+**Naming trap.** The `capability_map` DB table and `ego/capability_aggregator.py`
+are the ego's per-domain *self-confidence model* — completely unrelated to this
+document. Everything here is "subsystem map".
+
+Maturity vocabulary: **LIVE** = wired into the runtime path and running;
+**shadow** = running but observe/log-only; **dark** = built, no live caller
+(usually `# GROUNDWORK(id)` — intentional, never delete as dead code);
+**gated** = present but off until an env var / config / user grant enables it.
+
+---
+
+## 1. Memory — retrieval, consolidation, vector store
+
+Persistent hybrid memory: FTS5 + Qdrant episodic/knowledge retrieval on the
+read side, extraction and dream-cycle consolidation on the write/maintenance
+side.
+
+```yaml subsystem-map
+entry: memory
+modules: [memory, qdrant]
+verified: 9037d45b 2026-07-07
+```
+
+**Retrieval is TIERED — the hottest auto-fired paths carry the thinnest
+stack.** Deep path: `memory/retrieval.py` `HybridRetriever.recall` (bitemporal
+`invalid_at` filter, entrenchment, activation/decay, graph boost, diversity
+penalty). Easy-to-forget mechanisms:
+
+- **CRAG** lives in the MCP-wrapper only (`memory/corrective.py`
+  `maybe_correct_recall`; `top_score >= 0.75` skips grading) — not in
+  `retrieval.py`.
+- **VoyageReranker** (`memory/reranker.py`, rerank-2.5) exists and is
+  API_KEY_VOYAGE-gated; the `rerank=` param is off by default at the retriever
+  and applied by callers.
+- **`drift_recall`** (`memory/drift.py`) is the degraded-mode fallback; its
+  FTS drilldown is hardcoded to `episodic_memory` (known MEM-006).
+- The proactive per-prompt path is `scripts/proactive_memory_hook.py` — an
+  **independent reimplementation** (own FTS5→Qdrant→RRF pipeline), not a
+  `HybridRetriever` caller. The `memory_proactive` MCP tool is registered but
+  has zero internal callers — the hook is the live path.
+- `procedure_recall` deliberately uses Jaccard tag-overlap
+  (`learning/procedural/matcher.py find_relevant`), not hybrid retrieval.
+- External-world recall results are provenance-wrapped (`wrap_external_recall`)
+  — first-party memory vs knowledge-base is a load-bearing distinction.
+
+**Consolidation (dream cycle)** — `memory/dream_cycle.py` (~1480 LOC):
+weekly clustering (Sun 4am) persists a value-ranked worklist to
+`deferred_work_queue` (`work_type="dream_synthesis_slice"`); a daily drain
+(8am) processes a budgeted top-value slice. Destructive merges are gated on
+`GENESIS_DREAM_CYCLE_LIVE` (env var, NOT a config key) and the drain is
+**shadow-hardwired** (`dry_run=True`) — the live flip is a separate user-gated
+change (#892). `_CapacityBreaker` aborts on consecutive provider exhaustion.
+`_cross_wing_scan` writes `memory_links` even under dry_run — intentional
+additive layer, not a leak.
+
+**Do not touch:** the drain's shadow hardwiring; the dry_run-independent link
+write. **Trap:** with no embedding provider registered, memory silently
+degrades to FTS5-only (see routing-providers entry).
+
+## 2. Execution — CC sessions (DirectSession)
+
+Spawning, tracking, and recovering Claude Code sessions — Genesis's hands for
+any task bigger than an LLM call.
+
+```yaml subsystem-map
+entry: execution-cc
+modules: [cc]
+verified: 9037d45b 2026-07-07
+```
+
+- `cc/direct_session.py` + `cc/conversation.py` (both >1000 LOC; split
+  candidates). Profile machinery: `PROFILES`, `_PROFILE_ADDENDA`,
+  `_PROFILE_SKILLS`, `_PROFILE_TO_MCP` (direct_session.py) +
+  `session_config._MCP_PROFILES` (profile → MCP-server allowlist).
+- **Spawn autonomy circuit breaker** (direct_session.py ~:600-635):
+  `bayesian_posterior < 0.15 and total_corrections > 3` blocks non-foreground
+  dispatch — flagged for review as a visible lever (Design Principle 3).
+- Recovery: `recover_stale_claims` on boot; `reap_stale` runs as the
+  `session_reaper` job on the **learning** scheduler (CronTrigger every 6h).
+  `SessionManager.cleanup_stale` is built but UNWIRED.
+- **Perimeter-session hardening:** `_NO_WEB_TOOLS` / `_NO_OUTREACH_EXTRAS`
+  blocklists strip risky tools from perimeter profiles — a security edge, not
+  configuration convenience.
+- `cc/context_injector.py` (memory→session injection) lives HERE, not in
+  memory. GROUNDWORK: `reflection_bridge/_bridge.py` (v4-executor),
+  `session_config.py` (hook-inheritance).
+
+## 3. Autonomy & egress gating
+
+Every autonomous action on the outside world funnels through deterministic
+in-code gates. Owner-facing delivery (Telegram/voice/email-to-owner) is NEVER
+gated — that contract is one-directional.
+
+```yaml subsystem-map
+entry: autonomy-egress
+modules: [autonomy, outreach, distribution, content, campaigns]
+verified: 9037d45b 2026-07-07
+```
+
+- **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
+  converge there. `EmailAutonomyGate` (`autonomy/email_gate.py`, WS-8
+  capability cells) sits below the LLM tool layer, unbypassable: HOLD writes
+  the `approval_requests` row FIRST, then `pending_email_sends`; the
+  `email_gate_watcher` job (every 5 min, learning scheduler) drains approved
+  sends.
+- **Discord is shadow-gated** (`autonomy/shadow_gate.py`): three doors —
+  `pipeline._deliver`, `outreach_poll` webhook, discord-bot `send_reply` —
+  observe-only into `capability_shadow`, best-effort so it can NEVER break the
+  real send. Enforcement (hold-for-approval) is the designed next stage. CI
+  backstop: `scripts/check_external_io.py` fails on new ungated egress
+  endpoints.
+- **`content/egress.py gate()` is LIVE** in the pipeline: anti-slop scrub +
+  PII scan for EXTERNAL channels and `content`-category drafts only. Never
+  applied to owner channels — don't add them.
+- `_NEVER_DISPATCH_ACTION_TYPES` lives in `ego/session.py`, not here.
+- **`DistributionManager` is not dead code** — instantiated by
+  `modules/content_pipeline`, but its autonomous publish path is
+  GROUNDWORK(autonomous-distribution) dark; the live Medium path is the
+  `content-publish` CC skill (browser automation).
+- **campaigns/** ships infrastructure only — a hard public/private contract:
+  campaign names/prompts/targets are USER DATA (DB + private backups), never
+  tracked source; zero shipped defaults. `CampaignRunner` cron-ticks
+  programmatic prechecks then dispatches DirectSessions; a 120s reaper
+  reconciles finished sessions.
+- GROUNDWORK across the entry: cross-vendor-review, per-step-verify,
+  trace-verify, task-verify (built, dark), outreach-voice,
+  autonomous-distribution.
+
+## 4. Scheduling & background work
+
+Genesis's system jobs, surplus-compute usage, and deferred-work accountability.
+Note: the *learning* package hosts the other big scheduler (see entry 10).
+
+```yaml subsystem-map
+entry: scheduling-background
+modules: [surplus, scheduler, follow_ups]
+verified: 9037d45b 2026-07-07
+```
+
+- `surplus/scheduler.py` (~2170 LOC) is the system-job hub (dream cycle, recon,
+  pipeline cycles, maintenance, code index/audit, model evals…).
+  `dispatch_once()` is **idle-gated** — surplus tasks only run when idle;
+  follow-up dispatch is deliberately NOT idle-gated.
+- **Durability model:** no persistent jobstore — jobs are re-registered at
+  every boot + CronTrigger + `misfire_grace_time`, backed by three durable DB
+  queues (`surplus_tasks`, `dead_letter`, `deferred_work_queue`).
+  **IntervalTrigger resets on restart** — anything >1h must be a CronTrigger
+  (documented bug class).
+- **`surplus/intake.py`** (intelligence intake: atomize → score → route)
+  auto-ingests curated sources into the knowledge base with NO manifest gate —
+  an INTENTIONAL bypass of the conversational confirm-first path; don't "fix"
+  it.
+- **`scheduler/` (top-level package) is the UserJobScheduler** — user-authored
+  cron jobs (via MCP) that dispatch background DirectSessions. Distinct from
+  `surplus/scheduler.py`.
+- `follow_ups/` = accountability ledger + dispatcher (every 5 min) that turns
+  follow-ups into surplus tasks; retention sweep on the learning scheduler.
+- GROUNDWORK: v4-parallel-dispatch, v4-surplus-tasks, v4-rate-tracking.
+
+## 5. Information intake & research
+
+Everything that pulls outside information IN: knowledge ingestion, the inbox
+drop folder, web search/fetch, recon jobs, and the research pipeline.
+
+```yaml subsystem-map
+entry: intake-research
+modules: [knowledge, inbox, research, recon, web, pipeline]
+verified: 9037d45b 2026-07-07
+```
+
+- **knowledge/**: orchestrator + manifest + tree index. Content-hash gate
+  (`has_unchanged_source`) makes re-ingest of changed sources re-distill;
+  `remove_unit` tombstones a source when its last unit is deleted (invariant:
+  only that method may tombstone). The conversational path
+  (`knowledge_ingest_source` MCP) requires explicit user confirmation —
+  contrast the intake bypass in entry 4.
+- **inbox/**: file-drop monitor with approval-gated dispatch; phase order
+  resume → detect → create → dispatch; `approval_key_stable=True` (ONE
+  site-level approval key). The refresh path folds parked files into the
+  batch so approvals fire once (#914). Coherence + URL-failure heuristics gate
+  dispatch.
+- **recon/**: scheduled intelligence jobs (release watch, model intelligence
+  Sun 8am, models.md synthesis Sun 10am, GitHub discovery, skill-security scan
+  via external NVIDIA SkillSpector). Emits findings for triage
+  (`recon_findings`/`recon_triage`) — intelligence-only, never auto-acts.
+- **web/**: stateless search (SearXNG primary, Brave fallback) + httpx fetch
+  (50k-char cap), sanitizer-wrapped; consumed via importers (MCP web tools,
+  research, recon, pipeline), not runtime init.
+- **research/**: `ResearchOrchestrator` over the provider registry — read-only
+  capability, no egress gate needed.
+- **pipeline/**: tiered research collection → triage → elevation feeding
+  capability modules (crypto/prediction); pause-guarded. It is research
+  plumbing, NOT the cognitive pipeline.
+- GROUNDWORK: vision-ocr (image processor).
+
+## 6. Channels & interfaces
+
+Every surface a human (or host process) talks to Genesis through.
+
+```yaml subsystem-map
+entry: channels-interfaces
+modules: [channels, dashboard, mcp, hosting, browser, mail]
+verified: 9037d45b 2026-07-07
+```
+
+- **channels/**: adapter framework. Telegram (`bridge.py` =
+  `genesis-bridge.service`, boots a full headless runtime); voice (HA,
+  OUTBOUND-only — inbound voice arrives via `dashboard/routes/voice_api.py`;
+  uses `media_player.play_media`, never `assist_satellite.announce` which
+  reopens the mic); Discord webhook; email SMTP. All env-gated. "OpenClaw" here
+  is only the MIT origin of the Telegram transport code.
+- **dashboard/**: Flask blueprint at `/genesis` (~45 route modules);
+  `_async_route` bridges sync Flask onto the runtime event loop; heartbeat
+  thread detects degraded-but-alive Flask; web terminal.
+- **mcp/**: 5 Genesis MCP servers (health, memory, outreach, recon,
+  discord-bot) + external codebase-memory; profile→server allowlist lives in
+  `cc/session_config._MCP_PROFILES`. `genesis-health` is the big one (~35 tool
+  modules). `standalone_health.py` serves from `~/.genesis/status.json` when no
+  live runtime (stale-but-functional).
+- **hosting/**: the OUTER layer that calls the runtime. `standalone.py` is the
+  default (`python -m genesis serve`; also hosts the OpenClaw
+  `/v1/chat/completions` endpoint); Agent Zero adapter optional.
+- **browser/**: profile/state layer only (persistent
+  `~/.genesis/browser-profile`, `BrowserLayer` enum, pgrep patterns as the
+  single source of process detection). The automation TOOLS live in
+  `mcp/health/browser.py`.
+- **mail/**: Gmail IMAP recon (weekly two-layer monitor: cheap-LLM briefs →
+  CC judge, sanitizer-wrapped) + reply poller (4h) + `ReplyHandler` dispatching
+  restricted `mail`-profile sessions. Sending is NOT here — all sends go
+  through the outreach gate (entry 3). Trap: never default a recipient to the
+  agent's own address (self-send loop).
+- GROUNDWORK: unified-bridge, outreach-pipeline (channels/base.py),
+  guardian-dialogue (dashboard health route).
+
+## 7. Ego & self-model
+
+The two autonomous decision-making egos and the identity documents that shape
+them.
+
+```yaml subsystem-map
+entry: ego-self-model
+modules: [ego, identity, deliberation]
+verified: 9037d45b 2026-07-07
+```
+
+- **Two egos, both LIVE**: user ego (CEO, Opus, MCP profile `user_reflection`)
+  and Genesis ego (COO, Sonnet, profile `reflection`), sharing `EgoSession`
+  (~108K). `EgoCadenceManager`: adaptive proactive cycles, morning-report cron,
+  30-min mechanical sweep, goal-staleness scans. Review cadence + budget
+  controls before adding call sites.
+- **`capability_aggregator.py` → `capability_map` table** = per-domain
+  self-confidence from up to 6 sources (inverse-confidence weighted; the
+  Outcome-Bus feed is flag-gated OFF). This is the naming-trap twin of this
+  document — unrelated to the subsystem map.
+- Proposal pipeline (`proposals.py`): batch WHAT/WHY/HOW digests to Telegram,
+  content firewall via `validate_batch()`, 6h digest rate-limit GROUNDWORK;
+  `_NEVER_DISPATCH_ACTION_TYPES` blocklist lives in `session.py`. Dispatches
+  record `follow_ups` rows for accountability. `integrity.py` chain-verify is
+  GROUNDWORK, explicitly NOT wired.
+- **identity/**: SOUL/USER/VOICE/STEERING CAPS-markdown + `IdentityLoader`
+  (wired via perception). `cc/session_config` reads SOUL+VOICE directly, not
+  via the loader. **USER.md auto-synthesis is PERMANENTLY DISABLED** — the
+  evolver writes system-owned `USER_KNOWLEDGE.md` instead, ledger-tracked.
+- **deliberation/**: `deliberate()` multi-model panel with explicit dissent —
+  reachable ONLY via the `deliberate` MCP tool, recursion-blocked,
+  never-raises. On-demand, not a default judgment path.
+
+## 8. Guardian & sentinel — infrastructure self-healing
+
+Two complementary watchdogs: the host-VM Guardian (outside the container blast
+radius) and the container-side Sentinel (CC-driven diagnosis/repair).
+
+```yaml subsystem-map
+entry: guardian-sentinel
+modules: [guardian, sentinel]
+verified: 9037d45b 2026-07-07
+```
+
+- **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
+  systemd timer; `check.py` runs 5 parallel probes → 6-state machine → act;
+  Proxmox disk/RAM provisioning verbs) and container side (`watchdog.py`
+  monitors the host Guardian every awareness tick, incl. git-SHA code-drift
+  detection). Config `~/.genesis/guardian_remote.yaml`; missing → silently
+  disabled.
+- **Merged ≠ deployed**: guardian code reaches the host ONLY via
+  `scripts/update.sh` / `guardian-gateway.sh` (the host-deploy gate in the dev
+  skill). Known wart: the watchdog's stale-alert wording inverts when the
+  deployed script is NEWER than the host checkout.
+- Provisioning verbs are EXECUTE-ONLY — approval is the CALLER's
+  responsibility (container obtains it via Telegram before invoking).
+- **sentinel/** is LIVE-wired but **shadow-only autonomy**: config mode
+  `"live"` is NOT implemented (dispatcher warns + downgrades); every proposed
+  action requires human approval. `InfrastructureMonitor` (call site 37, free
+  models) observes each awareness tick and wakes the dispatcher; state persists
+  to `~/.genesis/sentinel_state.json`.
+- GROUNDWORK: guardian-cgroup, guardian-bidirectional, sentinel-live-autonomy.
+
+## 9. Ambient cognition — heartbeat, reflection, attention
+
+The loops that make Genesis think between conversations.
+
+```yaml subsystem-map
+entry: ambient-cognition
+modules: [awareness, perception, reflection, attention]
+verified: 9037d45b 2026-07-07
+```
+
+- **awareness/**: the 5-min heartbeat. ~23 signal collectors (the richer
+  `learning/signals/*` set REPLACES the bootstrap placeholders in
+  `signals.py` — those stubs are GROUNDWORK(signal-bootstrap), not the live
+  collectors). Tick → depth classification (MICRO/LIGHT/DEEP/STRATEGIC) →
+  reflection dispatch. Also per-tick `_check_*` housekeeping: CC-slot RSS leak
+  watch, subscription-cap detection, SQLite WAL hygiene, resilience-axis folds,
+  liveness heartbeat. It does NOT drive the ego cadence (ego has its own
+  scheduler). Trap: PEP 562 lazy `__init__` — don't eager-import `loop.py`.
+- **perception/**: the real-time reflection engine — MICRO (and LIGHT without
+  a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
+  reflection bridge. GROUNDWORK: user-model-synthesis, pre-execution-gate
+  (template exists, gate not live).
+- **reflection/**: the deep/scheduled path (self-assessment, quality
+  calibration, learning-stability). **Cadence trap:** jobs FIRE DAILY but an
+  idempotency gate holds each to ≤1 SUCCESS per week — a failed day retries
+  tomorrow, not next week.
+- **attention/**: Track-1 ambient attention — SHADOW, not in runtime init;
+  runs via offline CLI over pulled snapshots. The 6-module core is pure and
+  edge-portable (no wall clock, no I/O, no genesis deps — test-enforced);
+  `sampler.py` (L1.5 judge) is the only LLM caller, outside the core.
+  **Firewall: transcript text is never persisted** — only refs + derived
+  features reach `attention_events`. Config is versioned DATA
+  (`~/.genesis/config/attention_config.json`).
+
+## 10. Learning & evaluation
+
+Self-improvement loops and the instrumentation that keeps them honest.
+
+```yaml subsystem-map
+entry: learning-evaluation
+modules: [learning, eval, experimentation, feedback, calibration]
+verified: 9037d45b 2026-07-07
+```
+
+- **learning/** is the de-facto cron host: `rt._learning_scheduler` registers
+  ~20+ jobs well beyond learning (recovery orchestrator, reapers, email-gate
+  drain, retention sweeps, plus the eval/feedback jobs below). CronTrigger
+  discipline is load-bearing here. Loops that actually run: triage pipeline,
+  procedural extraction (extract → judge → promote hourly, novelty +
+  contradiction gates), weekly skill evolution, daily triage calibration.
+  `tool_discovery.py` static maps are deprecated (GROUNDWORK
+  provider-migration) — use ProviderRegistry.
+- **eval/**: J9 = fire-and-forget emit hooks on live cognitive paths (the
+  "cannot break production" contract — hooks must never raise) + weekly Sunday
+  aggregation (hard 7-day window) + an on-demand batch judge as a surplus
+  task. The model gauntlet is weekly but OFF by default (paid inference) and
+  NEVER auto-mutates the roster.
+- **experimentation/**: Crucible A/B + Evo fan-out — on-demand via MCP tools
+  only; **recommend-only is the safety invariant** (no autonomous promotion,
+  no live-cognition writes; Bonferroni + held-out re-validation).
+- **feedback/**: the Outcome Bus (`outcome_events`) — **write-path LIVE
+  (harvest 8:45/20:45), read-path DARK** (nothing consumes the ledger yet).
+  Tier taxonomy is load-bearing: Tier-1 ground truth outranks user approval.
+  `record_outcome` must never raise. Deliberately "observation, not
+  reinforcement" — don't rename toward RL.
+- **calibration/**: Bayesian prediction-calibration primitives, currently
+  wired via outreach (engagement reconciliation). **Four distinct
+  "calibration" surfaces exist** (this package, `learning/triage/calibration`,
+  `feedback/calibration` ego-ECE, `eval/calibration` golden-set loader) —
+  don't conflate.
+
+## 11. Routing & providers
+
+How every LLM call picks a provider, and the registry for non-LLM tools.
+
+```yaml subsystem-map
+entry: routing-providers
+modules: [routing, providers]
+verified: 9037d45b 2026-07-07
+```
+
+- **routing/**: `config/model_routing.yaml` defines ~54 numbered call sites,
+  each a free-first → paid-last chain; `never_pays` sites are filtered to
+  free-only. Per-provider circuit breaker (3 failures, exponential backoff
+  capped 30 min — 4h for QUOTA_EXHAUSTED; 429 = backpressure, NOT a breaker
+  failure; state persisted cross-process to
+  `~/.genesis/circuit_breaker_state.json`). Degradation levels are
+  hand-curated: L2 sheds nice-to-haves; **L3 keeps ONLY micro-reflection,
+  embeddings, tagging** — changing those sets changes what survives an outage.
+  Some call sites alias another site's chain — don't assume 1:1.
+- **providers/**: the `ToolProvider` registry for NON-LLM tools (search,
+  embeddings, STT/TTS, crawl, probes). Adapters register GATED ON ENV KEYS —
+  silent non-registration is by design (absence ≠ bug). LLM breaker/health
+  logic lives in routing, not here. No embedding provider registered → memory
+  silently degrades to FTS5-only.
+- GROUNDWORK: gpt-oss-120b provider defined but unwired into any chain.
+
+## 12. Platform & data
+
+The load-bearing floor: database, runtime bootstrap, resilience, observability,
+config resolution, and hygiene utilities.
+
+```yaml subsystem-map
+entry: platform-data
+modules: [db, runtime, resilience, observability, security, codebase,
+          restore, util, env.py, _config_overlay.py]
+verified: 9037d45b 2026-07-07
+```
+
+- **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
+  without it interleaved commits pin `in_transaction` until restart). Two
+  schema paths coexist: base DDL (~113 CREATE TABLE; docs still say "60+")
+  plus versioned migrations 0001..0046 run ONCE at startup before any other
+  init step touches data; a failed migration ABORTS bootstrap. Migration
+  atomicity is hand-rolled (BEGIN IMMEDIATE + a proxy that blocks stray
+  commits/DDL autocommit) with a post-commit reconcile and SQLITE_LOCKED
+  retry (2026-06-25 incident guard). No TABLES-vs-sqlite_master parity test
+  exists.
+- **runtime/**: sequential bootstrap (secrets → db → … → sentinel, ~27 steps);
+  each step records ok/degraded/failed in the manifest — only db aborts.
+  `~/.genesis/capabilities.json` + `bootstrap_manifest.json` are projected at
+  bootstrap tail; readonly probes must never clobber the primary's state.
+  New capabilities need `_CAPABILITY_DESCRIPTIONS` registration. Autonomy init
+  installs a fail-closed `DenyHighRiskSentinel` FIRST so ctor failures degrade
+  to blocking. GROUNDWORK: task-verify (constructed, `.verify()` never called
+  — dark), web-dd.
+- **resilience/**: RecoveryOrchestrator on a 30-min interval (3 confirmation
+  probes before draining); `DeferredWorkQueue` priorities + staleness policies;
+  dead-letter replay. The `dream_synthesis_slice` worklist is deliberately
+  excluded from the backlog alarm (drift-guard test pins it).
+- **observability/**: event bus dispatches inline AND logs every event;
+  persist-queue overflow drops events but emits a rate-limited "dropped"
+  meta-event (WS-17). Two health layers (async probes vs systemd shell-out);
+  `/health` is a dashboard route, not an MCP tool; `job_health` state machine
+  is runtime-owned.
+- **security/**: prompt-injection defense + outbound scanning — sanitizer is
+  LOG-ONLY for internal sources (perimeter EMAIL/INBOX can block);
+  `output_scanner` = deterministic outbound secrets/IP scan; `skill_scan`
+  shells to external NVIDIA SkillSpector. NOT auth or secrets storage (that's
+  `runtime/init/secrets.py` + `env.py`).
+- **codebase/**: AST indexer (surplus task, set-difference deletes with
+  CASCADE) behind the `codebase_navigate` MCP tool.
+- **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h
+  encrypted `scripts/backup.sh` timer).
+- **util/**: `atomic_write_text`, `tracked_task` (logs swallowed exceptions),
+  `process_lock` (the reason bare `python -m genesis serve` blocks systemd),
+  tmp discipline (`~/tmp` for large temp — never override TMPDIR).
+- **env.py**: 3-tier resolution (env var → `~/.genesis/config/genesis.yaml` →
+  default). **`update_in_progress()` is load-bearing**: the watchdog defers
+  restarts during deploys (mid-deploy revival deadlocks bootstrap); fails open
+  to "no deploy". `secrets_path()` is repo-relative unless SECRETS_PATH set.
+- **_config_overlay.py**: `.local.yaml` deep-merge (user config dir first;
+  dicts merge, lists REPLACE wholesale); dependency-free by design to stay
+  import-cycle-safe.
+
+## 13. Modules, skills & self-extension
+
+The pluggable edges: capability modules, the skill library, and the pipeline
+for contributing code upstream.
+
+```yaml subsystem-map
+entry: modules-skills
+modules: [modules, skills, contribution, bookmark, workflows]
+verified: 9037d45b 2026-07-07
+```
+
+- **modules/**: capability modules are "hands, not brain" — a module may
+  observe Genesis but never participates in cognition, and MUST NOT set
+  `source_subsystem` on memory writes (test-enforced). Two-phase load
+  (config/modules/*.yaml + auto-discovery; YAML wins), enabled-state persisted
+  in DB. Shipped: content-pipeline (enabled, ALL auto-features OFF),
+  crypto-ops, prediction-markets. GROUNDWORK: autonomous-distribution.
+- **skills/**: skills are directories with SKILL.md — registration is catalog
+  generation (`scripts/generate_skill_catalog.py` scans `.claude/skills/`,
+  `src/genesis/skills/`, `~/.genesis/skill-library/` →
+  `~/.genesis/skill_catalog.json`, self-heals hourly), consumed by the
+  injection hook and by autonomous-session resources. Skill refinement is a
+  tracked cognitive-file modification (`learning/skills/applicator.py`).
+  Voice-master exemplars are on the contribution FORBIDDEN list.
+- **contribution/**: `python -m genesis contribute <sha>` — sanitize-then-PR
+  upstream, pseudonymous. `sanitize.scan_diff()` is FAIL-CLOSED (8 scanners;
+  any finding stops). Its forbidden-globs floor duplicates
+  `config/protected_paths.yaml` — keep in sync.
+- **bookmark/**: two-tier session bookmarks stored as episodic memories +
+  a lookup table; enrichment runs on surplus compute.
+- **workflows/**: YAML DAG executor — GROUNDWORK(workflow-engine), built with
+  NO runtime caller. Not live; do not treat as a capability.
+
+---
+
+*Maintenance: run `python scripts/check_subsystem_map.py` from the repo root;
+CI runs it on every PR. Entry stamps mark the commit each entry was last
+verified against — bump them when you re-verify, not when you merely edit
+prose.*

--- a/scripts/check_subsystem_map.py
+++ b/scripts/check_subsystem_map.py
@@ -60,6 +60,8 @@ _SKIP_TOP_LEVEL = {"__init__.py", "__main__.py"}
 
 @dataclass
 class Entry:
+    """Parsed representation of one ``yaml subsystem-map`` block in CURRENT.md."""
+
     name: str
     modules: list[str]
     verified_sha: str
@@ -68,10 +70,12 @@ class Entry:
 
 @dataclass
 class Coverage:
-    unmapped: set[str] = field(default_factory=set)
-    vanished: set[str] = field(default_factory=set)
-    duplicates: set[str] = field(default_factory=set)
-    unused_allowlist: set[str] = field(default_factory=set)
+    """Result of diffing claimed modules against the live src/genesis tree."""
+
+    unmapped: set[str] = field(default_factory=set)  # live, claimed by no entry
+    vanished: set[str] = field(default_factory=set)  # claimed, gone from disk
+    duplicates: set[str] = field(default_factory=set)  # claimed by 2+ entries
+    unused_allowlist: set[str] = field(default_factory=set)  # allowlisted, no longer needed
 
 
 def parse_map(text: str) -> tuple[list[Entry], list[str]]:
@@ -132,6 +136,11 @@ def live_modules(src_root: Path) -> set[str]:
 def check_coverage(
     entries: list[Entry], live: set[str], allowlist: dict[str, str]
 ) -> Coverage:
+    """Diff claimed vs live modules both directions.
+
+    An allowlist entry is "unused" when its module is no longer a live-but-
+    unclaimed straggler (it vanished from disk, or an entry now claims it).
+    """
     cov = Coverage()
     claimed: set[str] = set()
     for entry in entries:

--- a/scripts/check_subsystem_map.py
+++ b/scripts/check_subsystem_map.py
@@ -115,12 +115,16 @@ def parse_map(text: str) -> tuple[list[Entry], list[str]]:
 
 
 def live_modules(src_root: Path) -> set[str]:
-    """Top-level packages (dirs with __init__.py) + loose .py modules."""
+    """Top-level dirs (packaged or not — e.g. skills/ has no __init__.py) + loose .py modules."""
     live: set[str] = set()
     for child in src_root.iterdir():
-        is_package = child.is_dir() and (child / "__init__.py").is_file()
+        is_subsystem_dir = (
+            child.is_dir()
+            and child.name != "__pycache__"
+            and not child.name.startswith(".")
+        )
         is_loose_module = child.suffix == ".py" and child.name not in _SKIP_TOP_LEVEL
-        if is_package or is_loose_module:
+        if is_subsystem_dir or is_loose_module:
             live.add(child.name)
     return live
 

--- a/scripts/check_subsystem_map.py
+++ b/scripts/check_subsystem_map.py
@@ -151,7 +151,9 @@ def _git(args: list[str]) -> str | None:
         proc = subprocess.run(
             ["git", *args], capture_output=True, text=True, timeout=60, check=False,
         )
-    except OSError:
+    except (OSError, subprocess.SubprocessError):
+        # incl. TimeoutExpired — staleness is warning-only; a hung git call
+        # must degrade to a skip, never crash the guard into a hard failure
         return None
     if proc.returncode != 0:
         return None

--- a/scripts/check_subsystem_map.py
+++ b/scripts/check_subsystem_map.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Subsystem-map drift guard — docs/architecture/CURRENT.md must track src/genesis.
+
+CURRENT.md is the canonical judgment-layer subsystem map (what each subsystem
+is FOR, its easy-to-forget mechanisms, its do-not-touch edges). Audits and
+capability comparisons consult it FIRST — so a map that silently drifts from
+the tree is worse than no map. This guard is the CI backstop:
+
+  * Every top-level package / loose module under ``src/genesis`` must be
+    claimed by exactly ONE entry's fenced ``yaml subsystem-map`` block (or
+    carry a reasoned ALLOWLIST entry) → a NEW package that nobody mapped is
+    a hard ``::error::`` (exit 1).
+  * A claimed module that no longer exists on disk means the map lies →
+    hard ``::error::`` (exit 1).
+  * An entry whose modules have accumulated more than STALE_COMMIT_THRESHOLD
+    commits since its ``verified: <sha> <date>`` stamp gets a ``::warning::``
+    only (exit 0) — staleness nudges, it never blocks.
+
+The staleness check needs real history: on a shallow clone (or when the
+stamped sha is absent locally) it degrades gracefully — it says so and skips,
+it does not guess. The CI job for this script therefore checks out with
+``fetch-depth: 0`` (see .github/workflows/ci.yml, subsystem-map-check).
+
+Map block format (one per entry in CURRENT.md; the info-string tag is what
+distinguishes map blocks from ordinary yaml examples):
+
+    ```yaml subsystem-map
+    entry: memory
+    modules: [memory, qdrant]
+    verified: 9037d45b 2026-07-07
+    ```
+
+Usage:  python scripts/check_subsystem_map.py   (exit 0 = clean, 1 = drift)
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+MAP_PATH = Path("docs/architecture/CURRENT.md")
+SRC_ROOT = Path("src/genesis")
+
+# Top-level modules deliberately NOT mapped. Every entry MUST carry a reason;
+# prefer assigning a module to a map entry over growing this list.
+ALLOWLIST: dict[str, str] = {}
+
+# Commits touching an entry's modules since its stamp before we nudge.
+STALE_COMMIT_THRESHOLD = 20
+
+_BLOCK_RE = re.compile(r"^```yaml[ \t]+subsystem-map[ \t]*\n(.*?)^```", re.M | re.S)
+_VERIFIED_RE = re.compile(r"^(?P<sha>[0-9a-f]{7,40})\s+(?P<date>\d{4}-\d{2}-\d{2})$")
+_SKIP_TOP_LEVEL = {"__init__.py", "__main__.py"}
+
+
+@dataclass
+class Entry:
+    name: str
+    modules: list[str]
+    verified_sha: str
+    verified_date: str
+
+
+@dataclass
+class Coverage:
+    unmapped: set[str] = field(default_factory=set)
+    vanished: set[str] = field(default_factory=set)
+    duplicates: set[str] = field(default_factory=set)
+    unused_allowlist: set[str] = field(default_factory=set)
+
+
+def parse_map(text: str) -> tuple[list[Entry], list[str]]:
+    """Parse every ``yaml subsystem-map`` fenced block → (entries, errors)."""
+    entries: list[Entry] = []
+    errors: list[str] = []
+    for i, match in enumerate(_BLOCK_RE.finditer(text), start=1):
+        raw = match.group(1)
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            errors.append(f"block #{i}: invalid yaml ({exc})".replace("\n", " "))
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"block #{i}: expected a mapping, got {type(data).__name__}")
+            continue
+        name = data.get("entry")
+        modules = data.get("modules")
+        verified = data.get("verified")
+        if not name or not isinstance(name, str):
+            errors.append(f"block #{i}: missing 'entry' name")
+            continue
+        if not modules or not isinstance(modules, list):
+            errors.append(f"block '{name}': missing or empty 'modules' list")
+            continue
+        stamp = _VERIFIED_RE.match(str(verified).strip()) if verified else None
+        if stamp is None:
+            errors.append(
+                f"block '{name}': 'verified' must be '<short-sha> <YYYY-MM-DD>', got {verified!r}"
+            )
+            continue
+        entries.append(
+            Entry(
+                name=name,
+                modules=[str(m) for m in modules],
+                verified_sha=stamp.group("sha"),
+                verified_date=stamp.group("date"),
+            )
+        )
+    return entries, errors
+
+
+def live_modules(src_root: Path) -> set[str]:
+    """Top-level packages (dirs with __init__.py) + loose .py modules."""
+    live: set[str] = set()
+    for child in src_root.iterdir():
+        is_package = child.is_dir() and (child / "__init__.py").is_file()
+        is_loose_module = child.suffix == ".py" and child.name not in _SKIP_TOP_LEVEL
+        if is_package or is_loose_module:
+            live.add(child.name)
+    return live
+
+
+def check_coverage(
+    entries: list[Entry], live: set[str], allowlist: dict[str, str]
+) -> Coverage:
+    cov = Coverage()
+    claimed: set[str] = set()
+    for entry in entries:
+        for mod in entry.modules:
+            if mod in claimed:
+                cov.duplicates.add(mod)
+            claimed.add(mod)
+    cov.unmapped = live - claimed - set(allowlist)
+    cov.vanished = claimed - live
+    cov.unused_allowlist = set(allowlist) - (live - claimed)
+    return cov
+
+
+def _git(args: list[str]) -> str | None:
+    """Run git, return stripped stdout, or None on any failure."""
+    try:
+        proc = subprocess.run(
+            ["git", *args], capture_output=True, text=True, timeout=60, check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def check_staleness(entries: list[Entry], threshold: int) -> list[str] | None:
+    """Per-entry commits-since-stamp warnings; None = history unavailable (skip)."""
+    if _git(["rev-parse", "--is-shallow-repository"]) != "false":
+        return None
+    warnings: list[str] = []
+    for entry in entries:
+        if _git(["cat-file", "-e", f"{entry.verified_sha}^{{commit}}"]) is None:
+            return None  # stamped sha not in local history — can't count honestly
+        paths = [f"src/genesis/{m}" for m in entry.modules]
+        count_out = _git(["rev-list", "--count", f"{entry.verified_sha}..HEAD", "--", *paths])
+        if count_out is None:
+            return None
+        if int(count_out) > threshold:
+            warnings.append(
+                f"entry '{entry.name}': {count_out} commits touched its modules since "
+                f"verified stamp {entry.verified_sha} ({entry.verified_date}) — "
+                f"re-verify the entry and bump its stamp"
+            )
+    return warnings
+
+
+def main() -> int:
+    if not MAP_PATH.is_file():
+        print(f"::error::subsystem-map guard: {MAP_PATH} not found (run from repo root)")
+        return 1
+    if not SRC_ROOT.is_dir():
+        print(f"::error::subsystem-map guard: scan root {SRC_ROOT} not found")
+        return 1
+
+    entries, errors = parse_map(MAP_PATH.read_text(encoding="utf-8"))
+    cov = check_coverage(entries, live_modules(SRC_ROOT), ALLOWLIST)
+
+    for err in errors:
+        print(f"::error::{MAP_PATH}: {err}")
+    for mod in sorted(cov.unmapped):
+        print(
+            f"::error::src/genesis/{mod} is not claimed by any {MAP_PATH} entry. "
+            f"Add it to the right entry's modules block (or a reasoned ALLOWLIST entry)."
+        )
+    for mod in sorted(cov.vanished):
+        print(
+            f"::error::{MAP_PATH} claims src/genesis/{mod}, which no longer exists — "
+            f"the map lies; update the owning entry."
+        )
+    for mod in sorted(cov.duplicates):
+        print(f"::error::{MAP_PATH}: module '{mod}' is claimed by more than one entry.")
+
+    for mod in sorted(cov.unused_allowlist):
+        print(f"::warning::subsystem-map ALLOWLIST entry '{mod}' no longer needed — remove it.")
+
+    stale = check_staleness(entries, STALE_COMMIT_THRESHOLD)
+    if stale is None:
+        print(
+            "subsystem-map guard: staleness check SKIPPED (shallow or incomplete git "
+            "history — CI needs fetch-depth: 0)"
+        )
+    else:
+        for warning in stale:
+            print(f"::warning::{warning}")
+
+    if errors or cov.unmapped or cov.vanished or cov.duplicates:
+        return 1
+    print(
+        f"Subsystem-map guard: CLEAN ({len(entries)} entries cover "
+        f"{len(live_modules(SRC_ROOT))} top-level modules)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scripts/test_check_subsystem_map.py
+++ b/tests/test_scripts/test_check_subsystem_map.py
@@ -116,6 +116,16 @@ def test_live_modules_lists_packages_and_loose_modules(tmp_path):
     assert csm.live_modules(src) == {"memory", "db", "env.py"}
 
 
+def test_live_modules_includes_non_package_dirs(tmp_path):
+    # src/genesis/skills has no __init__.py (SKILL.md tree) but is still a
+    # top-level subsystem directory the map must claim.
+    src = _write_src(tmp_path, ["memory"], [])
+    (src / "skills").mkdir()
+    (src / "skills" / "SKILL.md").write_text("")
+    (src / ".hidden").mkdir()
+    assert csm.live_modules(src) == {"memory", "skills"}
+
+
 # --- coverage diff ---
 
 

--- a/tests/test_scripts/test_check_subsystem_map.py
+++ b/tests/test_scripts/test_check_subsystem_map.py
@@ -172,7 +172,30 @@ def test_unused_allowlist_entry_is_a_warning(tmp_path):
     assert problems.unused_allowlist == {"long_gone"}
 
 
+def test_parse_map_multiline_flow_list():
+    text = (
+        "```yaml subsystem-map\n"
+        "entry: platform\n"
+        "modules: [db, util,\n"
+        "          env.py]\n"
+        "verified: 9037d45b 2026-07-07\n"
+        "```\n"
+    )
+    entries, errors = csm.parse_map(text)
+    assert errors == []
+    assert entries[0].modules == ["db", "util", "env.py"]
+
+
 # --- staleness (git stubbed; warning-only by contract) ---
+
+
+def test_git_returns_none_on_timeout(monkeypatch):
+    # _git must never raise — a hung git call degrades to a staleness skip.
+    def hang(*args, **kwargs):
+        raise csm.subprocess.TimeoutExpired(cmd="git", timeout=60)
+
+    monkeypatch.setattr(csm.subprocess, "run", hang)
+    assert csm._git(["rev-parse", "--is-shallow-repository"]) is None
 
 
 def test_staleness_warns_past_threshold(monkeypatch):

--- a/tests/test_scripts/test_check_subsystem_map.py
+++ b/tests/test_scripts/test_check_subsystem_map.py
@@ -1,0 +1,264 @@
+"""Subsystem-map drift guard (scripts/check_subsystem_map.py).
+
+The guard parses the fenced ``yaml subsystem-map`` blocks in
+docs/architecture/CURRENT.md and diffs the claimed module set against the live
+top-level contents of src/genesis, both directions. Tests use synthetic maps
+and source trees under tmp_path; the git-based staleness check is exercised
+through a stubbed git runner so no test depends on real history or wall clock.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "check_subsystem_map", _REPO_ROOT / "scripts" / "check_subsystem_map.py",
+)
+csm = importlib.util.module_from_spec(_spec)
+sys.modules["check_subsystem_map"] = csm  # @dataclass resolves cls.__module__ here
+_spec.loader.exec_module(csm)
+
+
+MAP_TWO_ENTRIES = """# Genesis — Current Architecture
+
+## Memory
+
+```yaml subsystem-map
+entry: memory
+modules: [memory, qdrant]
+verified: 9037d45b 2026-07-07
+```
+
+## Platform
+
+Some prose between blocks.
+
+```yaml subsystem-map
+entry: platform
+modules:
+  - db
+  - util
+  - env.py
+verified: 9037d45b 2026-07-07
+```
+
+```yaml
+not_a_map_block: this yaml block has no subsystem-map tag and is ignored
+```
+"""
+
+
+def _write_src(tmp_path: Path, packages: list[str], loose: list[str]) -> Path:
+    src = tmp_path / "src" / "genesis"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("")
+    (src / "__main__.py").write_text("")
+    for pkg in packages:
+        d = src / pkg
+        d.mkdir()
+        (d / "__init__.py").write_text("")
+    for mod in loose:
+        (src / mod).write_text("")
+    return src
+
+
+# --- parse_map ---
+
+
+def test_parse_map_reads_tagged_blocks_only():
+    entries, errors = csm.parse_map(MAP_TWO_ENTRIES)
+    assert errors == []
+    assert [e.name for e in entries] == ["memory", "platform"]
+    assert entries[0].modules == ["memory", "qdrant"]
+    assert entries[1].modules == ["db", "util", "env.py"]
+    assert entries[0].verified_sha == "9037d45b"
+    assert entries[0].verified_date == "2026-07-07"
+
+
+def test_parse_map_flags_malformed_yaml():
+    text = "```yaml subsystem-map\nentry: [unclosed\n```\n"
+    entries, errors = csm.parse_map(text)
+    assert entries == []
+    assert len(errors) == 1
+
+
+def test_parse_map_flags_missing_or_malformed_verified():
+    missing = "```yaml subsystem-map\nentry: a\nmodules: [x]\n```\n"
+    _, errors = csm.parse_map(missing)
+    assert len(errors) == 1
+
+    bad_stamp = (
+        "```yaml subsystem-map\nentry: a\nmodules: [x]\nverified: sometime in june\n```\n"
+    )
+    _, errors = csm.parse_map(bad_stamp)
+    assert len(errors) == 1
+
+
+def test_parse_map_flags_missing_entry_name_and_empty_modules():
+    no_name = "```yaml subsystem-map\nmodules: [x]\nverified: abc1234 2026-07-07\n```\n"
+    _, errors = csm.parse_map(no_name)
+    assert len(errors) == 1
+
+    no_modules = "```yaml subsystem-map\nentry: a\nverified: abc1234 2026-07-07\n```\n"
+    _, errors = csm.parse_map(no_modules)
+    assert len(errors) == 1
+
+
+# --- live_modules ---
+
+
+def test_live_modules_lists_packages_and_loose_modules(tmp_path):
+    src = _write_src(tmp_path, ["memory", "db"], ["env.py"])
+    (src / "__pycache__").mkdir()
+    assert csm.live_modules(src) == {"memory", "db", "env.py"}
+
+
+# --- coverage diff ---
+
+
+def test_unmapped_module_is_an_error(tmp_path):
+    src = _write_src(tmp_path, ["memory", "qdrant", "db", "util", "rogue_new_pkg"], ["env.py"])
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+    problems = csm.check_coverage(entries, csm.live_modules(src), allowlist={})
+    assert problems.unmapped == {"rogue_new_pkg"}
+    assert problems.vanished == set()
+
+
+def test_allowlist_suppresses_unmapped(tmp_path):
+    src = _write_src(tmp_path, ["memory", "qdrant", "db", "util", "rogue_new_pkg"], ["env.py"])
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+    problems = csm.check_coverage(
+        entries, csm.live_modules(src), allowlist={"rogue_new_pkg": "why it is fine"},
+    )
+    assert problems.unmapped == set()
+
+
+def test_vanished_claimed_module_is_an_error(tmp_path):
+    src = _write_src(tmp_path, ["memory", "db", "util"], ["env.py"])  # no qdrant
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+    problems = csm.check_coverage(entries, csm.live_modules(src), allowlist={})
+    assert problems.vanished == {"qdrant"}
+
+
+def test_module_claimed_twice_is_an_error(tmp_path):
+    text = MAP_TWO_ENTRIES.replace("modules: [memory, qdrant]", "modules: [memory, qdrant, db]")
+    src = _write_src(tmp_path, ["memory", "qdrant", "db", "util"], ["env.py"])
+    entries, errors = csm.parse_map(text)
+    assert errors == []
+    problems = csm.check_coverage(entries, csm.live_modules(src), allowlist={})
+    assert problems.duplicates == {"db"}
+
+
+def test_unused_allowlist_entry_is_a_warning(tmp_path):
+    src = _write_src(tmp_path, ["memory", "qdrant", "db", "util"], ["env.py"])
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+    problems = csm.check_coverage(
+        entries, csm.live_modules(src), allowlist={"long_gone": "stale reason"},
+    )
+    assert problems.unmapped == set()
+    assert problems.unused_allowlist == {"long_gone"}
+
+
+# --- staleness (git stubbed; warning-only by contract) ---
+
+
+def test_staleness_warns_past_threshold(monkeypatch):
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+
+    def fake_git(args: list[str]) -> str | None:
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        if args[0] == "cat-file":
+            return ""
+        if args[0] == "rev-list":
+            return "999"
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(csm, "_git", fake_git)
+    warnings = csm.check_staleness(entries, threshold=20)
+    assert len(warnings) == 2
+    assert "memory" in warnings[0]
+
+
+def test_staleness_quiet_under_threshold(monkeypatch):
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+
+    def fake_git(args: list[str]) -> str | None:
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        if args[0] == "cat-file":
+            return ""
+        if args[0] == "rev-list":
+            return "3"
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(csm, "_git", fake_git)
+    assert csm.check_staleness(entries, threshold=20) == []
+
+
+def test_staleness_degrades_on_shallow_history(monkeypatch):
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+
+    def fake_git(args: list[str]) -> str | None:
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "true"
+        raise AssertionError("must not inspect history on a shallow clone")
+
+    monkeypatch.setattr(csm, "_git", fake_git)
+    assert csm.check_staleness(entries, threshold=20) is None
+
+
+def test_staleness_degrades_on_unknown_sha(monkeypatch):
+    entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
+
+    def fake_git(args: list[str]) -> str | None:
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        if args[0] == "cat-file":
+            return None  # sha not present locally
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(csm, "_git", fake_git)
+    assert csm.check_staleness(entries, threshold=20) is None
+
+
+# --- main (integration over a synthetic repo) ---
+
+
+def _run_main(tmp_path, monkeypatch, packages: list[str], map_text: str) -> int:
+    src = _write_src(tmp_path, packages, ["env.py"])
+    map_path = tmp_path / "docs" / "architecture" / "CURRENT.md"
+    map_path.parent.mkdir(parents=True)
+    map_path.write_text(map_text)
+    monkeypatch.setattr(csm, "MAP_PATH", map_path)
+    monkeypatch.setattr(csm, "SRC_ROOT", src)
+    monkeypatch.setattr(csm, "_git", lambda args: None)  # no git → staleness skipped
+    return csm.main()
+
+
+def test_main_clean_map_exits_zero(tmp_path, monkeypatch, capsys):
+    rc = _run_main(tmp_path, monkeypatch, ["memory", "qdrant", "db", "util"], MAP_TWO_ENTRIES)
+    assert rc == 0
+    assert "CLEAN" in capsys.readouterr().out
+
+
+def test_main_unmapped_module_exits_one_with_error_annotation(tmp_path, monkeypatch, capsys):
+    rc = _run_main(
+        tmp_path, monkeypatch, ["memory", "qdrant", "db", "util", "rogue_new_pkg"],
+        MAP_TWO_ENTRIES,
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "rogue_new_pkg" in out
+
+
+def test_main_missing_map_file_exits_one(tmp_path, monkeypatch, capsys):
+    src = _write_src(tmp_path, ["memory"], [])
+    monkeypatch.setattr(csm, "MAP_PATH", tmp_path / "nope.md")
+    monkeypatch.setattr(csm, "SRC_ROOT", src)
+    assert csm.main() == 1
+    assert "::error::" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Builds the subsystem-map front-door that the audit protocol (#822) left open: a canonical judgment-layer map at `docs/architecture/CURRENT.md` (what each subsystem is FOR, easy-to-forget mechanisms, live/shadow/dark maturity, do-not-touch edges), a CI guard that keeps it honest, and a thin skill that routes capability questions to it. The `genesis-architect` agent's existing `CURRENT.md` reference (previously dangling) now resolves.

## Changes

- **`docs/architecture/CURRENT.md`** — 13 entries covering all 54 top-level `src/genesis` modules exactly once (deep entries for core subsystems, grouped entries for platform/edges); every entry carries a fenced `yaml subsystem-map` modules block and a `verified: <sha> <date>` stamp. Facts verified against the live tree at authoring time.
- **`scripts/check_subsystem_map.py`** + 20 tests — parses the map blocks and diffs claimed vs live top-level modules both directions: unmapped / vanished / duplicate = error (with reasoned in-script allowlist); stale stamps = warning only; degrades gracefully on shallow git history; `_git` never raises (incl. TimeoutExpired).
- **CI job `subsystem-map-check`** — mirrors the external-io guard stanza; checks out with `fetch-depth: 0` (this job only) for the stamp check.
- **`.claude/skills/subsystem-map/SKILL.md`** — thin router: consult the map FIRST on any "does Genesis have X" / audit / comparison; write back entry + stamp after subsystem changes. Auto-registers via the skill catalog.
- **PR template** — checkbox for map updates on capability changes.
- **Wiring** — genesis-development skill + codebase-map.md cross-pointers.
- **`.gitignore` fix** — `docs/` → `docs/*`: the opt-in `!docs/<dir>/` negations from #499 were dead (git never descends into an excluded parent dir), silently forcing `git add -f` for every new public doc. Per-file re-ignores and private docs dirs verified unaffected.

## Testing

- [x] `ruff check .` passes (changed files)
- [x] Targeted tests pass (20/20 `tests/test_scripts/test_check_subsystem_map.py`)
- [x] Tested end-to-end: checker exit 0 on the real map (13 entries / 54 modules); planted fake module → exit 1 (mutation proof); staleness check runs against real history; skill-catalog parser dry-run extracts the new skill correctly
- [x] `docs/architecture/CURRENT.md` updated (entry prose + `verified:` stamp) if subsystem capabilities changed — this PR creates it

Code review: inline reviewer pass completed; its one P2 finding (uncaught `TimeoutExpired`) is fixed with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)