### PR TITLE
fix(executor): downgrade shell-syntax deterministic commands at decompose time

### DIFF
--- a/src/genesis/autonomy/decomposer.py
+++ b/src/genesis/autonomy/decomposer.py
@@ -13,6 +13,7 @@ import contextlib
 import json
 import logging
 import re
+import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -67,6 +68,49 @@ _DELIVERABLE_STEP_DESC = (
     "authenticity_target / audience / acceptance, and its '## Requirements' + "
     "'## Success Criteria' for the substance to produce."
 )
+
+
+# Shell constructs an exec-only runner cannot execute. Operators/expansions
+# are substring-matched; builtins and env prefixes are matched on the first
+# token. Interpreter prefixes (bash/sh/python/...) are pulled from the
+# runner's own blocklist (lazy import — executor package imports back into
+# this module via engine.py, so a top-level import would cycle).
+_SHELL_OPERATORS: tuple[str, ...] = (
+    "&&", "||", ";", "|", ">", "<", "$(", "`", "\n",
+)
+_SHELL_BUILTINS: frozenset[str] = frozenset({
+    "source", ".", "cd", "export", "set", "unset", "alias", "eval", "exec",
+})
+
+
+def _shell_incompatible(command: str) -> str | None:
+    """Return why *command* cannot run under the exec-only deterministic
+    runner, or None if it can.
+
+    The runner uses ``create_subprocess_exec`` + ``shlex.split`` — no shell.
+    Shell operators, builtins (``source``), ``VAR=x`` env prefixes, and
+    interpreter invocations (which the runner blocks at execution time
+    anyway) all need a CC session instead.
+    """
+    from genesis.autonomy.executor.deterministic import _INTERPRETER_PREFIXES
+
+    for op in _SHELL_OPERATORS:
+        if op in command:
+            return f"shell operator {op!r}"
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return "unparseable quoting"
+    if not tokens:
+        return "empty command"
+    head = tokens[0]
+    if head in _SHELL_BUILTINS:
+        return f"shell builtin {head!r}"
+    if "=" in head:
+        return f"env-var prefix {head!r}"
+    if head.rsplit("/", 1)[-1] in _INTERPRETER_PREFIXES:
+        return f"interpreter {head!r} (blocked by the runner)"
+    return None
 
 
 def has_deliverable_frame(plan_content: str) -> bool:
@@ -311,6 +355,23 @@ class TaskDecomposer:
                     i, step_type,
                 )
                 step_type = "code"
+
+            # The deterministic runner is exec-only (create_subprocess_exec,
+            # no shell): shell operators, builtins, env prefixes, and
+            # interpreter invocations are guaranteed to fail at runtime and
+            # burn a recovery cycle (V0 canary: 'source venv && pytest' and
+            # 'git add X && git commit' both died instantly and were rerouted
+            # to paid CC sessions). Downgrade them to 'code' upfront.
+            if step_type in _DETERMINISTIC_TYPES and command:
+                reason = _shell_incompatible(str(command))
+                if reason is not None:
+                    logger.warning(
+                        "Step %d command needs a shell (%s) — the "
+                        "deterministic runner is exec-only; falling back "
+                        "to 'code': %r",
+                        i, reason, command,
+                    )
+                    step_type = "code"
 
             complexity = str(step.get("complexity", "medium")).lower()
             if complexity not in _VALID_COMPLEXITIES:

--- a/src/genesis/identity/TASK_DECOMPOSE.md
+++ b/src/genesis/identity/TASK_DECOMPOSE.md
@@ -59,6 +59,30 @@ no LLM reasoning.  Use ``code`` when the LLM needs to decide what to
 write or how to approach a problem.  Example: ``pytest tests/test_foo.py``
 is deterministic; "fix the failing test" is a code step.
 
+**Deterministic commands are EXEC-ONLY — there is no shell.** The runner
+executes ONE program with its arguments (``create_subprocess_exec``).
+Commands violating any of these are downgraded to ``code`` steps and lose
+their zero-cost execution:
+
+- NO shell operators: ``&&``, ``||``, ``;``, ``|``, ``>``, ``<``, ``$(...)``,
+  backticks.  One command per step — chain via separate steps with
+  ``dependencies`` instead of ``&&``.
+- NO shell builtins: ``source``, ``cd``, ``export``, ``eval``.  The venv is
+  already on PATH (``pytest``, ``ruff``, ``python`` resolve to it) — never
+  emit ``source .venv/bin/activate``.  The working directory is already set
+  by the executor — never emit ``cd``.
+- NO ``VAR=value`` env prefixes and NO interpreter invocations (``bash -c``,
+  ``python -c``, ...) — the runner blocks interpreters as an injection
+  guard.  If a step genuinely needs any of these, make it a ``code`` step.
+
+Right: ``{"type": "test", "command": "pytest tests/test_foo.py -v"}`` plus a
+separate ``{"type": "bash", "command": "ruff check src/"}`` step.
+Wrong: ``{"type": "test", "command": "source .venv/bin/activate && pytest tests/test_foo.py && ruff check src/"}``.
+
+For git commits, ``git add`` and ``git commit`` are TWO separate ``git``
+steps (``git add <specific files>`` then ``git commit -m "..."``), or fold
+the commit into the ``code`` step that produced the changes.
+
 ## Rules
 
 1. **Max 8 steps.** If the task needs more, consolidate related work.

--- a/src/genesis/identity/TASK_STEP.md
+++ b/src/genesis/identity/TASK_STEP.md
@@ -76,6 +76,12 @@ under the appropriate section heading (Learnings, Decisions, Issues).
 
 - **research**: Do not modify files. Read, search, fetch only.
 - **code**: Write clean, tested code. Run linting. Follow existing patterns.
+  If your working directory is a git worktree, COMMIT your changes before
+  finishing the step: `git add <the specific files you changed>` then
+  `git commit` with a conventional message (`feat:`/`fix:`/`test:`/...).
+  Never `git add .` or `-A`, never push, never open PRs — delivery pushes
+  the branch after all steps complete, and uncommitted work is invisible
+  to it.
 - **analysis**: Produce structured findings. Support conclusions with evidence.
 - **synthesis**: Combine prior results. Reference specific step outputs.
 - **verification**: Check against success criteria. Run tests if applicable.

--- a/tests/test_autonomy/test_decomposer.py
+++ b/tests/test_autonomy/test_decomposer.py
@@ -237,6 +237,55 @@ class TestDecompose:
         assert steps[0]["type"] == "code"
         assert "command" not in steps[0]
 
+    async def test_shell_syntax_commands_fall_back_to_code(self) -> None:
+        """Exec-only runner can't run shell constructs — downgrade upfront.
+
+        Exactly the V0-canary failure shapes: 'source venv && pytest' and
+        'git add X && git commit' died at runtime and burned CC recovery
+        cycles; validation now catches them at decompose time.
+        """
+        steps_json = json.dumps([
+            {"idx": 0, "type": "test", "description": "t",
+             "command": "source /home/u/.venv/bin/activate && pytest tests/x.py"},
+            {"idx": 1, "type": "git", "description": "g",
+             "command": 'git add a.py b.py && git commit -m "feat: x"'},
+            {"idx": 2, "type": "bash", "description": "b",
+             "command": "pytest tests/x.py | tail -5"},
+            {"idx": 3, "type": "bash", "description": "e",
+             "command": "FOO=bar pytest tests/x.py"},
+            {"idx": 4, "type": "bash", "description": "i",
+             "command": "python -c 'print(1)'"},
+            {"idx": 5, "type": "bash", "description": "cd",
+             "command": "cd /somewhere"},
+        ])
+        router = _make_router(steps_json)
+        d = TaskDecomposer(router=router)
+        steps = await d.decompose("plan", "Task")
+
+        for step in steps[:6]:
+            assert step["type"] == "code", step
+            assert "command" not in step, step
+
+    async def test_clean_exec_commands_stay_deterministic(self) -> None:
+        """Plain single-program commands are untouched by the shell check."""
+        steps_json = json.dumps([
+            {"idx": 0, "type": "test", "description": "t",
+             "command": "pytest tests/test_foo.py -v"},
+            {"idx": 1, "type": "bash", "description": "r",
+             "command": "ruff check src/"},
+            {"idx": 2, "type": "git", "description": "g",
+             "command": 'git commit -m "feat: wire A && B"'},
+        ])
+        router = _make_router(steps_json)
+        d = TaskDecomposer(router=router)
+        steps = await d.decompose("plan", "Task")
+
+        assert steps[0]["type"] == "test"
+        assert steps[1]["type"] == "bash"
+        # NOTE: '&&' inside a quoted commit message still trips the substring
+        # check — acceptable false positive (downgrades to code, never breaks).
+        assert steps[2]["type"] == "code"
+
     async def test_git_step_type_valid(self) -> None:
         """Git step type is accepted."""
         steps_json = json.dumps([


### PR DESCRIPTION
## Summary

First-contact fix from the V0 executor canary (task `t-21400a`, PR #928). The decomposer emitted `source …/activate && pytest …` and `git add … && git commit …` as deterministic steps, but the deterministic runner is **exec-only** (`create_subprocess_exec` + `shlex.split`, no shell — by design, as an injection guard). Both steps failed instantly (`Errno 2: 'source'`; git exit 129 on a literal `&&` argument) and the recovery layer rerouted them to paid CC sessions — correct outcome, wasteful path.

- `decomposer._validate_steps`: commands containing shell operators (`&& || ; | > < $( ` `), shell builtins (`source`, `cd`, `export`, …), `VAR=value` prefixes, or interpreter invocations now **downgrade to `code` steps at decompose time** (same pattern as the existing missing-command downgrade; interpreter set shared with the runner's blocklist via lazy import — top-level would cycle through `executor/__init__` → `engine` → `decomposer`).
- `TASK_DECOMPOSE.md`: documents the exec-only contract — one program per step, venv already on PATH (no `source`), cwd already set (no `cd`), chain via `dependencies` not `&&`.
- `TASK_STEP.md`: code-step constraint now requires committing changed files in-worktree (the executor never commits and delivery only pushes — uncommitted work is invisible; second V0 finding).

Known acceptable false positive: `&&` inside a quoted commit message downgrades to `code` (substring check) — safe direction, pinned by a test.

## Testing

- `pytest tests/test_autonomy/test_decomposer.py` — 35 passed (new: all six V0-shaped failure commands downgrade; clean single-program commands untouched)
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)