### PR TITLE
feat(executor): build-lane diff allowlist gate at delivery (fail-closed)

### DIFF
--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1234,6 +1234,14 @@ class CCSessionExecutor:
         wt_path = self._worktree_paths.get(task_id)
 
         if has_code and wt_path:
+            # Build-lane tasks pass the diff allowlist gate before anything
+            # leaves the worktree. Blocked (or any git failure computing the
+            # diff) => parked: no push, no PR. User tasks are untouched.
+            if await self._task_source(task_id) == "build_lane":
+                gate_result = await self._run_scope_gate(task_id, wt_path)
+                if not gate_result.allowed:
+                    return
+
             branch = f"task/{task_id[:8]}"
             try:
                 proc = await asyncio.create_subprocess_exec(
@@ -1255,6 +1263,112 @@ class CCSessionExecutor:
                 logger.error(
                     "Delivery failed for task %s", task_id, exc_info=True,
                 )
+
+    async def _task_source(self, task_id: str) -> str:
+        """Dispatch provenance of a task ('user' when unknown/absent).
+
+        Tolerates DBs without the ``source`` column (pre-0048): missing
+        column or row degrades to 'user', which keeps delivery behavior
+        byte-identical for everything except explicit build-lane rows.
+        """
+        from genesis.db.crud import task_states
+
+        try:
+            task = await task_states.get_by_id(self._db, task_id)
+        except Exception:
+            logger.error(
+                "Could not read task %s for source check — treating as 'user'",
+                task_id, exc_info=True,
+            )
+            return "user"
+        if not task:
+            return "user"
+        return str(task.get("source") or "user")
+
+    async def _run_scope_gate(self, task_id: str, wt_path: Path):
+        """Run the build-lane diff allowlist gate. Fail-closed throughout.
+
+        Blocked outcomes record ``scope_gate`` (verdict JSON) and
+        ``scope_blocked`` outputs on the task and notify the user; the
+        caller must then STOP delivery (no push, no PR).
+        """
+        from genesis.autonomy.executor.scope_gate import (
+            ScopeGateResult,
+            evaluate_scope,
+        )
+
+        async def _git(*args: str) -> tuple[int, str]:
+            proc = await asyncio.create_subprocess_exec(
+                "git", *args,
+                cwd=str(wt_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            out, err = await proc.communicate()
+            return proc.returncode or 0, (out or err).decode(errors="replace")
+
+        try:
+            # 1. Dirty tree = a step forgot to commit; the diff below would
+            #    silently exclude that work, so treat it as a gate failure.
+            rc, status_out = await _git("status", "--porcelain")
+            if rc != 0:
+                result = ScopeGateResult(
+                    allowed=False, reason=f"git status failed: {status_out[:200]}",
+                )
+            elif status_out.strip():
+                result = ScopeGateResult(
+                    allowed=False,
+                    reason="dirty worktree — uncommitted changes at delivery",
+                    blocked_paths=status_out.strip().splitlines()[:20],
+                )
+            else:
+                # 2. Committed diff vs the branch point.
+                rc, base = await _git("merge-base", "HEAD", "main")
+                if rc != 0:
+                    result = ScopeGateResult(
+                        allowed=False, reason=f"merge-base failed: {base[:200]}",
+                    )
+                else:
+                    rc, names = await _git(
+                        "diff", "--name-only", base.strip(), "HEAD",
+                    )
+                    if rc != 0:
+                        result = ScopeGateResult(
+                            allowed=False, reason=f"git diff failed: {names[:200]}",
+                        )
+                    else:
+                        result = evaluate_scope(names.splitlines())
+        except Exception as exc:
+            logger.error(
+                "Scope gate errored for task %s — failing closed",
+                task_id, exc_info=True,
+            )
+            result = ScopeGateResult(
+                allowed=False, reason=f"scope gate error: {type(exc).__name__}",
+            )
+
+        await self._set_output(task_id, "scope_gate", result.to_json())
+        if result.allowed:
+            logger.info(
+                "Scope gate PASSED for task %s (%d paths)",
+                task_id, result.checked_paths,
+            )
+        else:
+            await self._set_output(task_id, "scope_blocked", result.reason)
+            logger.warning(
+                "Scope gate BLOCKED task %s: %s — %s",
+                task_id, result.reason, result.blocked_paths[:10],
+            )
+            await self._notify(
+                task_id,
+                (
+                    f"Build parked by scope gate: {result.reason}. "
+                    f"Blocked paths: {', '.join(result.blocked_paths[:5]) or 'n/a'}. "
+                    "Nothing was pushed — widening build scope is a human decision."
+                ),
+                "alert",
+            )
+        return result
 
     async def _deliver_artifact(
         self, task_id: str, step_results: list[StepResult]

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1294,7 +1294,7 @@ class CCSessionExecutor:
         """
         from genesis.autonomy.executor.scope_gate import (
             ScopeGateResult,
-            evaluate_scope,
+            evaluate_raw_diff,
         )
 
         async def _git(*args: str) -> tuple[int, str]:
@@ -1329,15 +1329,17 @@ class CCSessionExecutor:
                         allowed=False, reason=f"merge-base failed: {base[:200]}",
                     )
                 else:
-                    rc, names = await _git(
-                        "diff", "--name-only", base.strip(), "HEAD",
+                    # --raw (not --name-only): exposes destination file modes
+                    # so symlink additions are visible and blockable.
+                    rc, raw = await _git(
+                        "diff", "--raw", base.strip(), "HEAD",
                     )
                     if rc != 0:
                         result = ScopeGateResult(
-                            allowed=False, reason=f"git diff failed: {names[:200]}",
+                            allowed=False, reason=f"git diff failed: {raw[:200]}",
                         )
                     else:
-                        result = evaluate_scope(names.splitlines())
+                        result = evaluate_raw_diff(raw.splitlines())
         except Exception as exc:
             logger.error(
                 "Scope gate errored for task %s — failing closed",

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -22,7 +22,7 @@ import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from genesis.autonomy.decomposer import has_deliverable_frame
 from genesis.autonomy.executor import dispatch as _dispatch
@@ -36,6 +36,11 @@ from genesis.autonomy.executor.types import (
     TaskPhase,
     validate_transition,
 )
+
+if TYPE_CHECKING:
+    # Runtime import stays lazy inside _run_scope_gate (executor/__init__ ->
+    # engine -> decomposer would cycle at import time).
+    from genesis.autonomy.executor.scope_gate import ScopeGateResult
 
 logger = logging.getLogger(__name__)
 
@@ -1285,7 +1290,7 @@ class CCSessionExecutor:
             return "user"
         return str(task.get("source") or "user")
 
-    async def _run_scope_gate(self, task_id: str, wt_path: Path):
+    async def _run_scope_gate(self, task_id: str, wt_path: Path) -> ScopeGateResult:
         """Run the build-lane diff allowlist gate. Fail-closed throughout.
 
         Blocked outcomes record ``scope_gate`` (verdict JSON) and
@@ -1304,7 +1309,17 @@ class CCSessionExecutor:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            out, err = await proc.communicate()
+            # A stuck git lock (aborted prior op, corrupted index) would
+            # otherwise wedge the delivery path — and its semaphore —
+            # permanently, with no external watchdog. 60s is generous for
+            # local status/merge-base/diff; timeout degrades to a gate
+            # failure (fail-closed), never a wedge.
+            try:
+                out, err = await asyncio.wait_for(proc.communicate(), timeout=60.0)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+                return 128, f"git {args[0]} timed out after 60s"
             return proc.returncode or 0, (out or err).decode(errors="replace")
 
         try:

--- a/src/genesis/autonomy/executor/scope_gate.py
+++ b/src/genesis/autonomy/executor/scope_gate.py
@@ -43,19 +43,29 @@ ALLOWED_TREES: tuple[str, ...] = (
     "docs/",
 )
 
-# Documentation subtrees that remain human territory (narrative/history);
-# builds document capabilities under docs/reference, docs/architecture, etc.
-DENIED_DOC_TREES: tuple[str, ...] = (
+# Subtrees denied even though a broader allowed tree contains them.
+# docs narrative/history dirs are human territory; src/genesis/mcp/health/
+# is the ADMIN/cognitive-control tool surface (settings_update's readonly
+# registry, session_control, ego tools, follow-up tools, ...) — a build may
+# add new MCP modules under src/genesis/mcp/, but never modify the admin
+# server's toolset. Widening is a human PR on Stage-1 evidence.
+DENIED_SUBTREES: tuple[str, ...] = (
     "docs/journey/",
     "docs/reflections/",
     "docs/case-studies/",
     "docs/superpowers/",
+    "src/genesis/mcp/health/",
 )
 
 # Basename glob patterns denied EVERYWHERE, even inside allowed trees.
+# Matched against the LOWERCASED basename — fnmatch is case-sensitive on
+# POSIX, and `SECRETS.ENV` must not slip past a lowercase-only pattern.
 DENIED_BASENAME_GLOBS: tuple[str, ...] = (
     "*.env",
+    "*.env.*",     # .env.local / .env.production / config.env.example
+    ".env*",
     "secrets*",
+    "*secret*",
     "*.service",
     "*.timer",
     "settings*.json",
@@ -98,7 +108,9 @@ def _deny_reason(path: str) -> str | None:
         return "malformed path"
     if path in DENIED_EXACT_PATHS:
         return "task submission surface"
-    basename = path.rsplit("/", 1)[-1]
+    # Case-insensitive throughout: fnmatch does NOT fold case on POSIX, and
+    # `SECRETS.ENV` / `Settings.JSON` must hit the same walls as lowercase.
+    basename = path.rsplit("/", 1)[-1].lower()
     for pattern in DENIED_BASENAME_GLOBS:
         if fnmatch(basename, pattern):
             return f"denied filename pattern {pattern!r}"
@@ -106,9 +118,9 @@ def _deny_reason(path: str) -> str | None:
     for token in DENIED_PATH_SUBSTRINGS:
         if token in lowered:
             return f"denied path token {token!r}"
-    for tree in DENIED_DOC_TREES:
-        if path.startswith(tree):
-            return f"denied docs subtree {tree!r}"
+    for tree in DENIED_SUBTREES:
+        if lowered.startswith(tree):
+            return f"denied subtree {tree!r}"
     return None
 
 
@@ -150,3 +162,47 @@ def evaluate_scope(changed_paths: list[str]) -> ScopeGateResult:
         reason="all changed paths within allowed capability trees",
         checked_paths=len(paths),
     )
+
+
+_SYMLINK_MODE = "120000"
+
+
+def evaluate_raw_diff(raw_lines: list[str]) -> ScopeGateResult:
+    """Judge ``git diff --raw <base> HEAD`` output.
+
+    Path-only gating can't see FILE CONTENT, so a symlink added inside an
+    allowed tree could point anywhere on the host. ``--raw`` exposes the
+    destination file mode; any entry whose new mode is 120000 (symlink) is
+    blocked outright, then the remaining paths go through the normal
+    allowlist. Unparseable raw lines are treated as paths (which blocks
+    them) — never silently skipped.
+    """
+    paths: list[str] = []
+    symlinks: list[str] = []
+    for raw in raw_lines:
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        if not line.startswith(":"):
+            paths.append(line)  # unexpected shape — let the allowlist judge it
+            continue
+        meta, sep, path = line.partition("\t")
+        if not sep or not path.strip():
+            paths.append(line)  # malformed — blocks as an unparseable path
+            continue
+        fields = meta.split()
+        new_mode = fields[1] if len(fields) >= 2 else ""
+        paths.append(path)
+        if new_mode == _SYMLINK_MODE:
+            symlinks.append(path)
+
+    result = evaluate_scope(paths)
+    if symlinks:
+        blocked = [f"{p} (symlink — content-level escape)" for p in symlinks]
+        return ScopeGateResult(
+            allowed=False,
+            reason=f"{len(symlinks)} symlink(s) in diff — blocked regardless of path",
+            blocked_paths=blocked + result.blocked_paths,
+            checked_paths=result.checked_paths,
+        )
+    return result

--- a/src/genesis/autonomy/executor/scope_gate.py
+++ b/src/genesis/autonomy/executor/scope_gate.py
@@ -1,0 +1,152 @@
+"""Diff allowlist gate for build-lane task delivery.
+
+Pure functions only — no I/O, no git. The engine computes the committed
+diff's changed paths and asks this module whether the build may leave the
+worktree (push + draft PR). Applied ONLY to ``source='build_lane'`` tasks;
+user-submitted tasks never pass through here.
+
+Design (fail-closed, allowlist):
+
+- An ALLOWLIST of capability trees ("body" code) is the only way out.
+  A denylist would fail OPEN on unenumerated paths; the allowlist fails
+  CLOSED — anything not explicitly allowed is blocked, including every
+  core subsystem (autonomy/, ego/, inbox/, memory/, runtime/, db/,
+  contribution/, scripts/, .claude/, .github/, config/).
+- DENY OVERRIDES win even inside allowed trees (secrets, service units,
+  settings, approval-related files, and the build lane's own submission
+  tool) — the lane must never be able to PR its own gate or its own
+  approval surface. This module lives in ``src/genesis/autonomy/``,
+  a tree the allowlist does not contain, so a build can never modify
+  the gate that judges it.
+- An EMPTY diff is blocked: a build that changed nothing has nothing
+  deliverable, and pushing an empty branch would masquerade as success.
+- Malformed paths (absolute, ``..`` traversal) are blocked, never
+  normalized into legality.
+
+Blocked builds are PARKED (no push, no PR, outcome ``scope_blocked``)
+with the offending paths listed — widening the allowlist is a deliberate
+HUMAN pull request informed by Stage-1 evidence, never an autonomous one.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+
+# Capability trees a build may touch ("body", never "brain").
+ALLOWED_TREES: tuple[str, ...] = (
+    "src/genesis/modules/",
+    "src/genesis/skills/",
+    "src/genesis/mcp/",
+    "tests/",
+    "docs/",
+)
+
+# Documentation subtrees that remain human territory (narrative/history);
+# builds document capabilities under docs/reference, docs/architecture, etc.
+DENIED_DOC_TREES: tuple[str, ...] = (
+    "docs/journey/",
+    "docs/reflections/",
+    "docs/case-studies/",
+    "docs/superpowers/",
+)
+
+# Basename glob patterns denied EVERYWHERE, even inside allowed trees.
+DENIED_BASENAME_GLOBS: tuple[str, ...] = (
+    "*.env",
+    "secrets*",
+    "*.service",
+    "*.timer",
+    "settings*.json",
+)
+
+# Full-path substrings denied everywhere. "approval" covers approval gates,
+# approval tools, and approval tests — the lane never touches its own
+# authorization surface, not even the test side of it.
+DENIED_PATH_SUBSTRINGS: tuple[str, ...] = (
+    "approval",
+)
+
+# Exact paths denied everywhere: the build lane's own submission door.
+DENIED_EXACT_PATHS: frozenset[str] = frozenset({
+    "src/genesis/mcp/health/task_tools.py",
+})
+
+
+@dataclass(frozen=True)
+class ScopeGateResult:
+    """Verdict for one build delivery."""
+
+    allowed: bool
+    reason: str
+    blocked_paths: list[str] = field(default_factory=list)
+    checked_paths: int = 0
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "blocked_paths": self.blocked_paths,
+            "checked_paths": self.checked_paths,
+        })
+
+
+def _deny_reason(path: str) -> str | None:
+    """Return why *path* is denied outright, or None."""
+    if path.startswith("/") or ".." in path.split("/"):
+        return "malformed path"
+    if path in DENIED_EXACT_PATHS:
+        return "task submission surface"
+    basename = path.rsplit("/", 1)[-1]
+    for pattern in DENIED_BASENAME_GLOBS:
+        if fnmatch(basename, pattern):
+            return f"denied filename pattern {pattern!r}"
+    lowered = path.lower()
+    for token in DENIED_PATH_SUBSTRINGS:
+        if token in lowered:
+            return f"denied path token {token!r}"
+    for tree in DENIED_DOC_TREES:
+        if path.startswith(tree):
+            return f"denied docs subtree {tree!r}"
+    return None
+
+
+def _is_allowed_tree(path: str) -> bool:
+    return any(path.startswith(tree) for tree in ALLOWED_TREES)
+
+
+def evaluate_scope(changed_paths: list[str]) -> ScopeGateResult:
+    """Judge a build's committed diff against the allowlist.
+
+    ``changed_paths`` are repo-relative paths from ``git diff --name-only``.
+    Returns a blocked result when the list is empty (nothing deliverable)
+    or when ANY path falls outside the allowlist / hits a deny override.
+    """
+    paths = [p.strip().removeprefix("./") for p in changed_paths if p and p.strip()]
+    if not paths:
+        return ScopeGateResult(
+            allowed=False,
+            reason="empty diff — nothing deliverable",
+        )
+
+    blocked: list[str] = []
+    for path in paths:
+        deny = _deny_reason(path)
+        if deny is not None:
+            blocked.append(f"{path} ({deny})")
+        elif not _is_allowed_tree(path):
+            blocked.append(f"{path} (outside allowed capability trees)")
+
+    if blocked:
+        return ScopeGateResult(
+            allowed=False,
+            reason=f"{len(blocked)} of {len(paths)} changed paths outside build scope",
+            blocked_paths=blocked,
+            checked_paths=len(paths),
+        )
+    return ScopeGateResult(
+        allowed=True,
+        reason="all changed paths within allowed capability trees",
+        checked_paths=len(paths),
+    )

--- a/tests/test_autonomy/test_executor/test_scope_gate.py
+++ b/tests/test_autonomy/test_executor/test_scope_gate.py
@@ -1,0 +1,313 @@
+"""Tests for the build-lane diff allowlist gate (scope_gate + engine graft)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.autonomy.executor.engine import CCSessionExecutor
+from genesis.autonomy.executor.scope_gate import (
+    ScopeGateResult,
+    evaluate_scope,
+)
+from genesis.db.crud import task_states
+from genesis.db.crud.task_states import create_intake_token
+
+# ---------------------------------------------------------------------------
+# Pure-function matrix
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateScope:
+    @pytest.mark.parametrize("path", [
+        "src/genesis/modules/star_velocity/collector.py",
+        "src/genesis/skills/aws-fde-delivery/SKILL.md",
+        "src/genesis/mcp/knowledge_tools.py",
+        "tests/test_modules/test_star_velocity.py",
+        "docs/reference/star-velocity.md",
+    ])
+    def test_allowed_capability_trees(self, path):
+        result = evaluate_scope([path])
+        assert result.allowed, result
+
+    @pytest.mark.parametrize("path", [
+        # Core subsystems — denied by absence from the allowlist.
+        "src/genesis/autonomy/executor/scope_gate.py",   # the gate itself
+        "src/genesis/autonomy/types.py",
+        "src/genesis/inbox/monitor.py",
+        "src/genesis/ego/proposals.py",
+        "src/genesis/runtime/init/tasks.py",
+        "src/genesis/db/schema/_tables.py",
+        "src/genesis/contribution/pr_opener.py",
+        "scripts/update.sh",
+        ".claude/hooks/genesis-hook",
+        ".github/workflows/ci.yml",
+        "config/model_routing.yaml",
+        "pyproject.toml",
+        "CLAUDE.md",
+    ])
+    def test_core_paths_denied_by_absence(self, path):
+        result = evaluate_scope([path])
+        assert not result.allowed
+        assert result.blocked_paths
+
+    @pytest.mark.parametrize("path", [
+        # Deny overrides WIN inside allowed trees.
+        "src/genesis/modules/foo/.env",
+        "src/genesis/modules/foo/prod.env",
+        "src/genesis/skills/foo/secrets.yaml",
+        "src/genesis/modules/foo/genesis-foo.service",
+        "src/genesis/modules/foo/genesis-foo.timer",
+        "src/genesis/mcp/settings.local.json",
+        "src/genesis/mcp/health/task_tools.py",          # its own submission door
+        "src/genesis/mcp/health/approval_tools.py",
+        "tests/test_autonomy/test_approval.py",          # approval surface, even tests
+        "docs/journey/2026-07-07.md",
+        "docs/reflections/on-building.md",
+    ])
+    def test_deny_overrides_inside_allowed_trees(self, path):
+        result = evaluate_scope([path])
+        assert not result.allowed, path
+
+    @pytest.mark.parametrize("path", [
+        "/etc/passwd",
+        "../outside/file.py",
+        "src/genesis/modules/../../genesis/autonomy/types.py",
+    ])
+    def test_malformed_paths_blocked_not_normalized(self, path):
+        result = evaluate_scope([path])
+        assert not result.allowed
+        assert "malformed" in result.blocked_paths[0]
+
+    def test_empty_diff_blocked(self):
+        result = evaluate_scope([])
+        assert not result.allowed
+        assert "empty diff" in result.reason
+
+    def test_whitespace_only_entries_are_empty(self):
+        assert not evaluate_scope(["", "  ", "\n"]).allowed
+
+    def test_one_bad_path_blocks_the_whole_diff(self):
+        result = evaluate_scope([
+            "src/genesis/skills/foo/SKILL.md",
+            "src/genesis/autonomy/dispatcher.py",
+        ])
+        assert not result.allowed
+        assert result.checked_paths == 2
+        assert len(result.blocked_paths) == 1
+        assert "dispatcher.py" in result.blocked_paths[0]
+
+    def test_dot_slash_prefix_normalized(self):
+        assert evaluate_scope(["./docs/reference/x.md"]).allowed
+
+    def test_to_json_round_trips(self):
+        result = evaluate_scope(["src/genesis/inbox/monitor.py"])
+        data = json.loads(result.to_json())
+        assert data["allowed"] is False
+        assert data["checked_paths"] == 1
+        assert data["blocked_paths"]
+
+
+# ---------------------------------------------------------------------------
+# Engine graft — _deliver gating (fail-closed at every branch)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+        self.returncode = returncode
+        self._out = (stdout, stderr)
+
+    async def communicate(self):
+        return self._out
+
+
+def _subprocess_script(monkeypatch, procs: list[_FakeProc]) -> list[tuple]:
+    """Patch create_subprocess_exec to replay *procs*; capture call args."""
+    calls: list[tuple] = []
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        return procs[len(calls) - 1]
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+    return calls
+
+
+def _engine(db) -> CCSessionExecutor:
+    return CCSessionExecutor(
+        db=db, invoker=AsyncMock(), decomposer=AsyncMock(), reviewer=AsyncMock(),
+    )
+
+
+async def _seed(db, task_id="t-sg1"):
+    token = await create_intake_token(db)
+    await task_states.create(
+        db, task_id=task_id, description="build", intake_token=token,
+    )
+
+
+_CODE_STEPS = [{"idx": 0, "type": "code", "description": "x"}]
+
+
+@pytest.mark.asyncio
+class TestDeliverScopeGate:
+    async def test_user_tasks_bypass_gate_entirely(self, db, tmp_path, monkeypatch):
+        """Non-build-lane delivery is byte-identical: first git call is the push."""
+        await _seed(db)
+        engine = _engine(db)
+        engine._worktree_paths["t-sg1"] = tmp_path
+        calls = _subprocess_script(monkeypatch, [_FakeProc(0)])
+
+        await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
+
+        assert len(calls) == 1
+        assert calls[0][:2] == ("git", "push")
+
+    async def test_build_lane_allowed_diff_pushes(self, db, tmp_path, monkeypatch):
+        await _seed(db)
+        engine = _engine(db)
+        engine._worktree_paths["t-sg1"] = tmp_path
+        monkeypatch.setattr(
+            engine, "_task_source", AsyncMock(return_value="build_lane"),
+        )
+        calls = _subprocess_script(monkeypatch, [
+            _FakeProc(0, b""),                                  # status --porcelain
+            _FakeProc(0, b"abc123\n"),                          # merge-base
+            _FakeProc(0, b"src/genesis/skills/foo/SKILL.md\n"),  # diff --name-only
+            _FakeProc(0),                                        # push
+        ])
+
+        await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
+
+        assert calls[-1][:2] == ("git", "push")
+        task = await task_states.get_by_id(db, "t-sg1")
+        outputs = json.loads(task["outputs"])
+        assert json.loads(outputs["scope_gate"])["allowed"] is True
+        assert outputs["branch"] == "task/t-sg1"
+
+    async def test_build_lane_blocked_diff_never_pushes(self, db, tmp_path, monkeypatch):
+        await _seed(db)
+        engine = _engine(db)
+        engine._worktree_paths["t-sg1"] = tmp_path
+        monkeypatch.setattr(
+            engine, "_task_source", AsyncMock(return_value="build_lane"),
+        )
+        calls = _subprocess_script(monkeypatch, [
+            _FakeProc(0, b""),
+            _FakeProc(0, b"abc123\n"),
+            _FakeProc(0, b"src/genesis/autonomy/approval_gate.py\n"),
+        ])
+
+        await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
+
+        assert all(c[:2] != ("git", "push") for c in calls)
+        task = await task_states.get_by_id(db, "t-sg1")
+        outputs = json.loads(task["outputs"])
+        assert json.loads(outputs["scope_gate"])["allowed"] is False
+        assert "scope_blocked" in outputs
+
+    async def test_dirty_worktree_blocks(self, db, tmp_path, monkeypatch):
+        """Uncommitted work would be invisible to the diff — fail, don't push."""
+        await _seed(db)
+        engine = _engine(db)
+        engine._worktree_paths["t-sg1"] = tmp_path
+        monkeypatch.setattr(
+            engine, "_task_source", AsyncMock(return_value="build_lane"),
+        )
+        calls = _subprocess_script(monkeypatch, [
+            _FakeProc(0, b" M src/genesis/skills/foo/SKILL.md\n"),
+        ])
+
+        await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
+
+        assert all(c[:2] != ("git", "push") for c in calls)
+        task = await task_states.get_by_id(db, "t-sg1")
+        assert "dirty worktree" in json.loads(task["outputs"])["scope_blocked"]
+
+    async def test_git_failure_fails_closed(self, db, tmp_path, monkeypatch):
+        await _seed(db)
+        engine = _engine(db)
+        engine._worktree_paths["t-sg1"] = tmp_path
+        monkeypatch.setattr(
+            engine, "_task_source", AsyncMock(return_value="build_lane"),
+        )
+        calls = _subprocess_script(monkeypatch, [
+            _FakeProc(0, b""),
+            _FakeProc(128, b"", b"fatal: no merge base"),
+        ])
+
+        await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
+
+        assert all(c[:2] != ("git", "push") for c in calls)
+        task = await task_states.get_by_id(db, "t-sg1")
+        assert "merge-base failed" in json.loads(task["outputs"])["scope_blocked"]
+
+    async def test_blocked_gate_notifies_user(self, db, tmp_path, monkeypatch):
+        await _seed(db)
+        engine = _engine(db)
+        engine._worktree_paths["t-sg1"] = tmp_path
+        engine._notify = AsyncMock()
+        monkeypatch.setattr(
+            engine, "_task_source", AsyncMock(return_value="build_lane"),
+        )
+        _subprocess_script(monkeypatch, [
+            _FakeProc(0, b""),
+            _FakeProc(0, b"abc\n"),
+            _FakeProc(0, b"scripts/update.sh\n"),
+        ])
+
+        await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
+
+        engine._notify.assert_awaited_once()
+        assert "scope gate" in engine._notify.await_args.args[1]
+
+
+@pytest.mark.asyncio
+class TestTaskSource:
+    async def test_row_without_source_column_degrades_to_user(self, db):
+        """Pre-0048 DBs have no source column — delivery must treat rows
+        as 'user' (gate inactive), never crash."""
+        await _seed(db, task_id="t-src1")
+        engine = _engine(db)
+        assert await engine._task_source("t-src1") == "user"
+
+    async def test_missing_row_is_user(self, db):
+        engine = _engine(db)
+        assert await engine._task_source("t-nope") == "user"
+
+    async def test_db_error_is_user(self, db):
+        engine = _engine(db)
+        engine._db = None  # forces an exception inside get_by_id
+        assert await engine._task_source("t-x") == "user"
+
+
+@pytest.mark.asyncio
+async def test_scope_gate_exception_fails_closed(db, tmp_path, monkeypatch):
+    """Any unexpected error inside the gate parks the build."""
+    await _seed(db, task_id="t-sg9")
+    engine = _engine(db)
+    engine._worktree_paths["t-sg9"] = tmp_path
+    monkeypatch.setattr(
+        engine, "_task_source", AsyncMock(return_value="build_lane"),
+    )
+
+    async def boom(*args, **kwargs):
+        raise OSError("git binary vanished")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", boom)
+
+    await engine._deliver("t-sg9", "d", _CODE_STEPS, [])
+
+    task = await task_states.get_by_id(db, "t-sg9")
+    outputs = json.loads(task["outputs"])
+    assert json.loads(outputs["scope_gate"])["allowed"] is False
+    assert "scope gate error" in outputs["scope_blocked"]
+
+
+def test_scope_gate_result_import_shape():
+    """The engine imports ScopeGateResult lazily — keep the contract pinned."""
+    r = ScopeGateResult(allowed=False, reason="x")
+    assert r.blocked_paths == [] and r.checked_paths == 0

--- a/tests/test_autonomy/test_executor/test_scope_gate.py
+++ b/tests/test_autonomy/test_executor/test_scope_gate.py
@@ -10,10 +10,16 @@ import pytest
 from genesis.autonomy.executor.engine import CCSessionExecutor
 from genesis.autonomy.executor.scope_gate import (
     ScopeGateResult,
+    evaluate_raw_diff,
     evaluate_scope,
 )
 from genesis.db.crud import task_states
 from genesis.db.crud.task_states import create_intake_token
+
+
+def _raw(path: str, new_mode: str = "100644") -> str:
+    """One `git diff --raw` line for *path* (added file by default)."""
+    return f":000000 {new_mode} 0000000 1111111 A\t{path}"
 
 # ---------------------------------------------------------------------------
 # Pure-function matrix
@@ -66,10 +72,30 @@ class TestEvaluateScope:
         "tests/test_autonomy/test_approval.py",          # approval surface, even tests
         "docs/journey/2026-07-07.md",
         "docs/reflections/on-building.md",
+        # Admin/cognitive-control MCP surface — whole subtree denied.
+        "src/genesis/mcp/health/settings.py",
+        "src/genesis/mcp/health/session_control.py",
+        "src/genesis/mcp/health/ego_tools.py",
+        # Case variants — fnmatch is case-sensitive on POSIX; the gate
+        # must not be (review finding, 2026-07-07).
+        "src/genesis/modules/foo/SECRETS.ENV",
+        "src/genesis/modules/foo/Prod.ENV",
+        "src/genesis/modules/foo/Settings.JSON",
+        "src/genesis/modules/foo/genesis.SERVICE",
+        "SRC/GENESIS/MODULES/foo/secrets.yaml",          # denied either way
+        # Dotenv family — *.env alone missed these (review finding).
+        "src/genesis/modules/foo/.env.local",
+        "src/genesis/modules/foo/.env.production",
+        "src/genesis/modules/foo/config.env.example",
+        "src/genesis/modules/foo/client_secret.json",
     ])
     def test_deny_overrides_inside_allowed_trees(self, path):
         result = evaluate_scope([path])
         assert not result.allowed, path
+
+    def test_new_mcp_module_outside_health_is_allowed(self):
+        # The health/ denial must not wall off the whole mcp/ tree.
+        assert evaluate_scope(["src/genesis/mcp/star_velocity_tools.py"]).allowed
 
     @pytest.mark.parametrize("path", [
         "/etc/passwd",
@@ -108,6 +134,47 @@ class TestEvaluateScope:
         assert data["allowed"] is False
         assert data["checked_paths"] == 1
         assert data["blocked_paths"]
+
+
+class TestEvaluateRawDiff:
+    def test_allowed_regular_files(self):
+        result = evaluate_raw_diff([
+            _raw("src/genesis/skills/foo/SKILL.md"),
+            _raw("tests/test_learning/test_foo.py", "100755"),
+        ])
+        assert result.allowed
+        assert result.checked_paths == 2
+
+    def test_symlink_blocked_even_in_allowed_tree(self):
+        result = evaluate_raw_diff([
+            _raw("src/genesis/modules/foo/link.py", "120000"),
+        ])
+        assert not result.allowed
+        assert "symlink" in result.reason
+        assert "link.py" in result.blocked_paths[0]
+
+    def test_symlink_plus_out_of_scope_reports_both(self):
+        result = evaluate_raw_diff([
+            _raw("src/genesis/modules/foo/link.py", "120000"),
+            _raw("src/genesis/autonomy/types.py"),
+        ])
+        assert not result.allowed
+        joined = " ".join(result.blocked_paths)
+        assert "symlink" in joined and "types.py" in joined
+
+    def test_malformed_raw_line_blocks(self):
+        # A line without the tab separator can't be trusted — it becomes an
+        # unparseable "path" that the allowlist rejects.
+        result = evaluate_raw_diff([":100644 100644 abc def M"])
+        assert not result.allowed
+
+    def test_non_colon_line_treated_as_path(self):
+        # Unexpected shapes are judged as paths, never silently skipped.
+        assert not evaluate_raw_diff(["some noise"]).allowed
+        assert evaluate_raw_diff(["docs/reference/x.md"]).allowed
+
+    def test_empty_raw_diff_blocked(self):
+        assert not evaluate_raw_diff([]).allowed
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +243,7 @@ class TestDeliverScopeGate:
         calls = _subprocess_script(monkeypatch, [
             _FakeProc(0, b""),                                  # status --porcelain
             _FakeProc(0, b"abc123\n"),                          # merge-base
-            _FakeProc(0, b"src/genesis/skills/foo/SKILL.md\n"),  # diff --name-only
+            _FakeProc(0, _raw("src/genesis/skills/foo/SKILL.md").encode() + b"\n"),
             _FakeProc(0),                                        # push
         ])
 
@@ -198,7 +265,7 @@ class TestDeliverScopeGate:
         calls = _subprocess_script(monkeypatch, [
             _FakeProc(0, b""),
             _FakeProc(0, b"abc123\n"),
-            _FakeProc(0, b"src/genesis/autonomy/approval_gate.py\n"),
+            _FakeProc(0, _raw("src/genesis/autonomy/approval_gate.py").encode() + b"\n"),
         ])
 
         await engine._deliver("t-sg1", "d", _CODE_STEPS, [])
@@ -256,7 +323,7 @@ class TestDeliverScopeGate:
         _subprocess_script(monkeypatch, [
             _FakeProc(0, b""),
             _FakeProc(0, b"abc\n"),
-            _FakeProc(0, b"scripts/update.sh\n"),
+            _FakeProc(0, _raw("scripts/update.sh").encode() + b"\n"),
         ])
 
         await engine._deliver("t-sg1", "d", _CODE_STEPS, [])


### PR DESCRIPTION
## Summary

PR-3 of the autonomous capability-build lane: the **containment boundary**. Ships safe-dark — with no `task_states.source` column yet (PR #927) and no build-lane submitter (PR-6), `_task_source` always resolves `'user'` and the gate is inert until those land. Nothing changes for user-submitted tasks, ever (pinned by test: their first git call is still the push).

- **New `executor/scope_gate.py`** (pure functions): builds may only touch capability trees — `src/genesis/modules/**`, `src/genesis/skills/**`, `src/genesis/mcp/**` (minus `mcp/health/**`, the admin/cognitive-control tool surface), `tests/**`, `docs/**` (minus narrative subtrees). **Deny overrides win everywhere**: env/dotenv files, `*secret*`, service/timer units, `settings*.json`, anything with `approval` in the path, and the task-submission MCP surface. Everything else (autonomy/, ego/, inbox/, db/, runtime/, scripts/, .claude/, .github/, config/) is denied by absence — the allowlist fails **closed**. The gate lives in `src/genesis/autonomy/` — a tree it does not allow — so a build can never PR the gate that judges it.
- **`engine._deliver` graft**: `source='build_lane'` → dirty tree, any git failure, empty diff, or any out-of-scope path **parks the build** (no push, `scope_gate`/`scope_blocked` recorded on the task, user notified). Widening scope is a deliberate human PR on Stage-1 evidence.
- **Adversarial review hardening (second commit)**: case-insensitive deny matching (fnmatch doesn't fold case on POSIX — `SECRETS.ENV` bypassed the globs); `.env.local`/`.env.*` family covered; `mcp/health/**` denied wholesale; delivery diffs with `--raw` and blocks any **symlink** (mode 120000) — path-only gating can't see that a link inside an allowed tree points at `/etc/passwd`.

## Residual risks (documented, accepted for Stage 1)
- Quoted non-ASCII paths from git fail the prefix match and therefore **over-block** (fail-safe, never a bypass).
- Content-level review remains the draft-PR human review; this gate bounds *where*, not *what*.

## Testing
- 67 scope-gate tests (allowlist matrix, deny overrides incl. case variants + dotenv family, malformed paths, raw-diff/symlink parsing, engine fail-closed branches, byte-identical user path) + 49 engine regressions — all green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)