### PR TITLE
fix(scripts): worktree guard for bootstrap.sh editable install

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -394,8 +394,17 @@ if [[ ! -d "$VENV_DIR" ]] || [[ ! -x "$VENV_DIR/bin/python" ]] || [[ ! -x "$VENV
     "$PYTHON_BIN" -m venv "$VENV_DIR"
 fi
 echo "  Syncing dependencies..."
-"$VENV_DIR/bin/pip" install -e "$GENESIS_ROOT" --quiet 2>&1 | tail -1 || true
-if ! "$VENV_DIR/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/dev/null; then
+# Worktree guard + editable install + import verification — shared with
+# install.sh so the guard can't drift between the two entry points.
+# shellcheck source=lib/venv_setup.sh
+. "$SCRIPT_DIR/lib/venv_setup.sh"
+_ei_rc=0
+editable_install_guarded "$GENESIS_ROOT" "$VENV_DIR" || _ei_rc=$?
+if [ "$_ei_rc" -eq 1 ]; then
+    # Blocked: bootstrap from a worktree would poison the system-wide
+    # editable install — abort instead of continuing half-configured.
+    exit 1
+elif [ "$_ei_rc" -ne 0 ]; then
     echo "  FAIL: pip install completed but Genesis is not importable."
     echo "  Re-run: $VENV_DIR/bin/pip install -e $GENESIS_ROOT --verbose"
     exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -781,24 +781,26 @@ fi
 echo "  [6/$TOTAL_STEPS] Installing Genesis package..."
 
 if [ -d "$VENV_PATH" ]; then
-    # Guard: refuse editable install from inside a worktree.
-    # Canonical detection: --git-common-dir differs from --git-dir in worktrees.
-    _git_common="$(git rev-parse --git-common-dir 2>/dev/null)"
-    _git_dir="$(git rev-parse --git-dir 2>/dev/null)"
-    if [ -n "$_git_common" ] && [ -n "$_git_dir" ] && [ "$_git_common" != "$_git_dir" ]; then
-        echo "    BLOCKED: pip install -e from a worktree redirects ALL system imports."
-        echo "    Use PYTHONPATH=$REPO_DIR/src instead, or run from the main checkout."
-    else
-        "$VENV_PATH/bin/pip" install -e "$REPO_DIR" --quiet 2>&1 | tail -1 || true
-        # Validate pip actually installed Genesis (|| true above masks pip failures)
-        if "$VENV_PATH/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/dev/null; then
+    # Worktree guard + editable install + import verification — shared with
+    # bootstrap.sh so the guard can't drift between the two entry points.
+    # shellcheck source=lib/venv_setup.sh
+    . "$SCRIPT_DIR/lib/venv_setup.sh"
+    _ei_rc=0
+    editable_install_guarded "$REPO_DIR" "$VENV_PATH" || _ei_rc=$?
+    case $_ei_rc in
+        0)
             echo "    + Genesis installed in editable mode"
-        else
+            ;;
+        1)
+            # Blocked (worktree) — guard already printed the reason; the
+            # install continues, matching the previous inline behavior.
+            ;;
+        *)
             echo "    FAIL  pip install completed but Genesis is not importable."
             echo "    Re-run with verbose output: $VENV_PATH/bin/pip install -e $REPO_DIR --verbose"
             SETUP_WARNINGS=1
-        fi
-    fi
+            ;;
+    esac
 else
     echo "    WARNING: venv not found at $VENV_PATH — skipping pip install"
 fi

--- a/scripts/lib/venv_setup.sh
+++ b/scripts/lib/venv_setup.sh
@@ -1,0 +1,38 @@
+# Genesis — shared venv/package-install helpers.
+# Sourced by install.sh and bootstrap.sh; not executable on its own.
+
+# editable_install_guarded <repo_dir> <venv_path>
+#
+# Installs the Genesis package into <venv_path> in editable mode, refusing
+# to run when <repo_dir> is a linked git worktree: an editable install is
+# system-wide state, so pointing it at a worktree redirects EVERY Genesis
+# process (server, bridge, watchdog) to load the worktree's code. This
+# caused an I/O death spiral and repeated crashes on 2026-03-16.
+#
+# Return codes (callers decide severity):
+#   0 — installed and import-verified
+#   1 — blocked: <repo_dir> is a git worktree (message already printed)
+#   2 — pip ran but the package is not importable
+editable_install_guarded() {
+    local repo_dir="$1"
+    local venv_path="$2"
+
+    # Canonical worktree detection: --git-common-dir differs from --git-dir
+    # in a linked worktree. Checked against repo_dir explicitly (git -C), not
+    # the caller's cwd — the installer may be invoked from anywhere.
+    local git_common git_dir
+    git_common="$(git -C "$repo_dir" rev-parse --git-common-dir 2>/dev/null)"
+    git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)"
+    if [ -n "$git_common" ] && [ -n "$git_dir" ] && [ "$git_common" != "$git_dir" ]; then
+        echo "    BLOCKED: pip install -e from a worktree redirects ALL system imports."
+        echo "    Use PYTHONPATH=$repo_dir/src instead, or run from the main checkout."
+        return 1
+    fi
+
+    "$venv_path/bin/pip" install -e "$repo_dir" --quiet 2>&1 | tail -1 || true
+    # Validate pip actually installed Genesis (|| true above masks pip failures)
+    if "$venv_path/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/dev/null; then
+        return 0
+    fi
+    return 2
+}


### PR DESCRIPTION
## Problem

`bootstrap.sh` ran `pip install -e` with **no worktree guard**, while `install.sh` carried its own inline guard for the identical operation. An editable install is system-wide state — pointing it at a git worktree redirects every Genesis process (server, bridge, watchdog) to the worktree's code, which previously caused an I/O death spiral and repeated crashes. Direct `bootstrap.sh` invocation from a worktree was unprotected (update.sh refuses worktrees by path only, and only on its own entry path).

## Fix

Root cause is duplication, so the guard + install + import verification move to a single implementation:

- New `scripts/lib/venv_setup.sh` → `editable_install_guarded <repo_dir> <venv_path>` (rc 0 = installed+verified, 1 = blocked worktree, 2 = not importable).
- The guard now checks the **target repo dir** explicitly (`git -C`) instead of the caller's cwd — the old install.sh guard silently checked whatever directory the installer was run from.
- Both entry points source it; caller semantics preserved: install.sh warns + `SETUP_WARNINGS=1` on import failure (continues on a blocked worktree, as before); bootstrap.sh exits 1 on either.

## Verification

- `bash -n` on all three scripts.
- Functional test in a scratch git repo with a fake pip: worktree run → rc 1, pip **never invoked**; main-checkout run → pip invoked with correct args, rc 0; failed import verification → rc 2.
- Independent code review confirmed the `set -euo pipefail` interactions (`|| rc=$?` capture, pipefail inside the lib), sourcing order in both scripts, and that no other `pip install -e` call site was missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)