### PR TITLE
fix(scripts): single source for the CLAUDE.md network-identity block

### DIFF
--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -991,20 +991,13 @@ fi
 # instructions, not tracked in the repo). Idempotent via sentinel blocks.
 echo ""
 echo "  Writing network identity into ~/.claude/CLAUDE.md..."
-# Build the network block on the host side where all variables are available
-_NET_LINES="## Network Identity"
-_NET_LINES="${_NET_LINES}
-"
-_NET_LINES="${_NET_LINES}
-- **Container IP**: ${CONTAINER_IPV4}"
-[ -n "$CONTAINER_IPV6" ] && _NET_LINES="${_NET_LINES} (v6: ${CONTAINER_IPV6})"
-_NET_LINES="${_NET_LINES}
-- **Host VM IP**: ${HOST_IPV4}"
-[ -n "$HOST_IPV6" ] && _NET_LINES="${_NET_LINES} (v6: ${HOST_IPV6})"
-[ -n "$TS_IPV4" ] && _NET_LINES="${_NET_LINES}
-- **Tailscale**: ${TS_IPV4}"
-_NET_LINES="${_NET_LINES}
-- **Dashboard**: http://${HOST_IPV4:-localhost}:5000 (via proxy device)"
+# Build the network block on the host side where all variables are
+# available, using the shared builder so the format can't drift from
+# update.sh's in-container refresh (which rewrites this block every run).
+# shellcheck source=lib/claude_md_blocks.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/claude_md_blocks.sh"
+_NET_LINES="$(build_network_identity_block \
+    "$CONTAINER_IPV4" "$CONTAINER_IPV6" "$HOST_IPV4" "$HOST_IPV6" "$TS_IPV4")"
 
 # Write into container via incus exec, piping the block through stdin.
 # Target: ~/.claude/CLAUDE.md (user-level, not tracked in repo).

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -854,10 +854,19 @@ LAN_IPV6=$(ip -6 addr show scope global 2>/dev/null | grep -oP 'inet6 \K[^ /]+' 
 HOST_IPV4="${TS_IPV4:-$LAN_IPV4}"
 HOST_IPV6="${TS_IPV6:-$LAN_IPV6}"
 
-# Container IPs
-CONTAINER_IPV4=$(incus exec "$CONTAINER_NAME" -- hostname -I 2>/dev/null | awk '{print $1}' || echo "")
-CONTAINER_IPV6=$(incus exec "$CONTAINER_NAME" -- ip -6 addr show scope global 2>/dev/null \
-    | grep -oP 'inet6 \K[^ /]+' | head -1 || echo "")
+# Container IPs — exclude tailscale interfaces, same rule as
+# detect_container_lan_ip/_ipv6 in scripts/lib/claude_md_blocks.sh (the
+# detection runs INSIDE the container via incus, where the host-side
+# sourced lib isn't available, so the rule is inlined; keep in sync).
+# hostname -I fallback preserved: it picks the tailscale0 address first
+# when present, but an address beats no address.
+CONTAINER_IPV4=$(incus exec "$CONTAINER_NAME" -- sh -c \
+    "ip -4 -o addr show scope global 2>/dev/null | awk '\$2 !~ /^tailscale/ {print \$4}' | cut -d/ -f1 | head -1" \
+    2>/dev/null || echo "")
+[ -z "$CONTAINER_IPV4" ] && CONTAINER_IPV4=$(incus exec "$CONTAINER_NAME" -- hostname -I 2>/dev/null | awk '{print $1}' || echo "")
+CONTAINER_IPV6=$(incus exec "$CONTAINER_NAME" -- sh -c \
+    "ip -6 -o addr show scope global 2>/dev/null | awk '\$2 !~ /^tailscale/ {print \$4}' | cut -d/ -f1 | head -1" \
+    2>/dev/null || echo "")
 
 # Build dashboard URL for final report
 DASHBOARD_URL=""

--- a/scripts/lib/claude_md_blocks.sh
+++ b/scripts/lib/claude_md_blocks.sh
@@ -1,0 +1,77 @@
+# Genesis — user-level CLAUDE.md sentinel-block helpers.
+# Sourced by update.sh (in-container) and host-setup.sh (host-side); not
+# executable on its own. Single source of truth for the network-identity
+# block: the two writers previously drifted (update.sh dropped the
+# Tailscale line and its `hostname -I | awk '{print $1}'` detection picked
+# the tailscale0 address as the "Container IP" on Tailscale installs).
+
+# detect_container_lan_ip — first global IPv4 that is NOT on a tailscale
+# interface; falls back to the old hostname -I behavior if none found.
+detect_container_lan_ip() {
+    local lan_ip
+    lan_ip=$(ip -4 -o addr show scope global 2>/dev/null \
+        | awk '$2 !~ /^tailscale/ {print $4}' | cut -d/ -f1 | head -1)
+    if [ -z "$lan_ip" ]; then
+        lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    fi
+    printf '%s' "$lan_ip"
+}
+
+# detect_container_lan_ipv6 — first global IPv6 NOT on a tailscale
+# interface (Tailscale's fd7a::/48 ULA shows up as scope global too).
+detect_container_lan_ipv6() {
+    ip -6 -o addr show scope global 2>/dev/null \
+        | awk '$2 !~ /^tailscale/ {print $4}' | cut -d/ -f1 | head -1
+    return 0
+}
+
+# detect_tailscale_ip — Tailscale IPv4 if the daemon or interface is
+# present; prints nothing (rc 0) when Tailscale is absent. Tailscale is
+# the default-but-optional overlay, so absence is a normal configuration.
+detect_tailscale_ip() {
+    local ts=""
+    if command -v tailscale >/dev/null 2>&1; then
+        ts=$(tailscale ip -4 2>/dev/null | head -1 || true)
+    fi
+    if [ -z "$ts" ]; then
+        ts=$(ip -4 -o addr show dev tailscale0 2>/dev/null \
+            | awk '{print $4}' | cut -d/ -f1 | head -1 || true)
+    fi
+    [ -n "$ts" ] && printf '%s\n' "$ts"
+    return 0
+}
+
+# build_network_identity_block <container_ip> <container_ipv6> <host_ip> <host_ipv6> <tailscale_ip>
+# Prints the canonical block CONTENT (heading + bullets) to stdout, without
+# sentinel markers. Empty arguments drop their line/suffix (Tailscale, v6),
+# except the required IPs which fall back to "localhost". Callers detect
+# values in their own environment (update.sh in-container, host-setup.sh
+# host-side) and pass them in — the FORMAT lives only here.
+build_network_identity_block() {
+    local c_ip="$1" c_ipv6="$2" host_ip="$3" host_ipv6="$4" ts_ip="$5"
+    echo "## Network Identity"
+    echo ""
+    printf -- "- **Container IP**: %s" "${c_ip:-localhost}"
+    [ -n "$c_ipv6" ] && printf " (v6: %s)" "$c_ipv6"
+    echo ""
+    printf -- "- **Host VM IP**: %s" "${host_ip:-localhost}"
+    [ -n "$host_ipv6" ] && printf " (v6: %s)" "$host_ipv6"
+    echo ""
+    [ -n "$ts_ip" ] && printf -- "- **Tailscale**: %s\n" "$ts_ip"
+    printf -- "- **Dashboard**: http://%s:5000 (via proxy device)\n" "${host_ip:-localhost}"
+}
+
+# write_sentinel_block <file> <name>
+# Replaces the <!-- begin:name --> .. <!-- end:name --> block in <file>
+# with stdin wrapped in fresh markers. Appends at EOF, matching the
+# long-standing writer behavior (block position in the file is not
+# preserved; readers key on the markers, not the position).
+write_sentinel_block() {
+    local file="$1" name="$2"
+    sed -i "/<!-- begin:${name} -->/,/<!-- end:${name} -->/d" "$file"
+    {
+        echo "<!-- begin:${name} -->"
+        cat
+        echo "<!-- end:${name} -->"
+    } >> "$file"
+}

--- a/scripts/lib/claude_md_blocks.sh
+++ b/scripts/lib/claude_md_blocks.sh
@@ -10,9 +10,9 @@
 detect_container_lan_ip() {
     local lan_ip
     lan_ip=$(ip -4 -o addr show scope global 2>/dev/null \
-        | awk '$2 !~ /^tailscale/ {print $4}' | cut -d/ -f1 | head -1)
+        | awk '$2 !~ /^tailscale/ {print $4}' | cut -d/ -f1 | head -1 || true)
     if [ -z "$lan_ip" ]; then
-        lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+        lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
     fi
     printf '%s' "$lan_ip"
 }
@@ -21,7 +21,7 @@ detect_container_lan_ip() {
 # interface (Tailscale's fd7a::/48 ULA shows up as scope global too).
 detect_container_lan_ipv6() {
     ip -6 -o addr show scope global 2>/dev/null \
-        | awk '$2 !~ /^tailscale/ {print $4}' | cut -d/ -f1 | head -1
+        | awk '$2 !~ /^tailscale/ {print $4}' | cut -d/ -f1 | head -1 || true
     return 0
 }
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1026,8 +1026,14 @@ reminders here.)
 UCLSEED
 fi
 echo "--- Refreshing Network Identity in ~/.claude/CLAUDE.md ---"
-_c_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
-_c_ipv6=$(ip -6 addr show scope global 2>/dev/null | grep -oP 'inet6 \K[^ /]+' | head -1 || true)
+# Block format + detection helpers are shared with host-setup.sh via the
+# lib — the two writers previously drifted (Tailscale line lost, container
+# IP mis-detected as the tailscale0 address).
+# shellcheck source=lib/claude_md_blocks.sh
+. "$SCRIPT_DIR/lib/claude_md_blocks.sh"
+_c_ip=$(detect_container_lan_ip)
+_c_ipv6=$(detect_container_lan_ipv6)
+_ts_ip=$(detect_tailscale_ip)
 _host_ip=$("$VENV_DIR/bin/python" -c "
 import yaml, pathlib
 p = pathlib.Path.home() / '.genesis' / 'guardian_remote.yaml'
@@ -1037,18 +1043,8 @@ if p.exists():
 " 2>/dev/null || true)
 [ -z "$_host_ip" ] && _host_ip=$(ip route | grep default | awk '{print $3}' || true)
 
-sed -i '/<!-- begin:network-identity -->/,/<!-- end:network-identity -->/d' "$_user_claude"
-{
-    echo "<!-- begin:network-identity -->"
-    echo "## Network Identity"
-    echo ""
-    printf -- "- **Container IP**: %s" "${_c_ip:-localhost}"
-    [ -n "$_c_ipv6" ] && printf " (v6: %s)" "$_c_ipv6"
-    echo ""
-    printf -- "- **Host VM IP**: %s\n" "${_host_ip:-localhost}"
-    printf -- "- **Dashboard**: http://%s:5000 (via proxy device)\n" "${_host_ip:-localhost}"
-    echo "<!-- end:network-identity -->"
-} >> "$_user_claude"
+build_network_identity_block "$_c_ip" "$_c_ipv6" "$_host_ip" "" "$_ts_ip" \
+    | write_sentinel_block "$_user_claude" "network-identity"
 echo "  Network identity updated in ~/.claude/CLAUDE.md"
 echo ""
 


### PR DESCRIPTION
## Problem

`update.sh` and `host-setup.sh` each carried their own writer for the network-identity sentinel block in the user-level CLAUDE.md, and they drifted:

- `update.sh` (which rewrites the block on **every** update) dropped the Tailscale line entirely.
- Its container-IP detection (`hostname -I | awk '{print $1}'`) reports the Tailscale CGNAT address as the "Container IP" on installs where the tailscale interface sorts first — observed live.
- Its IPv6 detection has the same flaw (Tailscale's ULA is scope global).

Net effect: one run of host-setup writes a correct block; the next update.sh run silently degrades it.

## Fix

New `scripts/lib/claude_md_blocks.sh` — single source of truth:

- `build_network_identity_block` — one canonical builder (container v4/v6, host v4/v6, optional Tailscale line, dashboard URL). Tailscale absent → line omitted, everything else intact (it is default-but-optional across installs).
- `detect_container_lan_ip` / `detect_container_lan_ipv6` — first global address **not** on a tailscale interface, with fallback to the old behavior.
- `detect_tailscale_ip` — CLI first, interface fallback, empty + rc 0 when absent.
- `write_sentinel_block` — the shared sed-delete + append.

`update.sh` sources it in-container. `host-setup.sh` sources it from its host-side checkout and keeps piping the built block into the container via incus — same mechanism, shared content.

## Verification

- `bash -n` on all three scripts.
- Builder run standalone in-container: container IP is now the bridge address (not CGNAT), Tailscale line present, no-tailscale variant degrades cleanly.
- `write_sentinel_block` idempotent on a scratch file (two runs → one marker pair), user-editable sections preserved.
- Full e2e via the post-merge `scripts/update.sh` run (host-deploy gate applies to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)