### PR TITLE
fix(channels): legacy Telegram approval fixes — shared vocabulary, scoped standalone resolution, human-scale waiter TTL

### DIFF
--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -17,14 +17,16 @@ from typing import Any
 from genesis.autonomy.cli_policy import load_autonomous_cli_policy
 from genesis.cc.types import CCInvocation
 
-logger = logging.getLogger(__name__)
+# Canonical vocabulary — shared with the Telegram bare-text path and the
+# ego proposal parser so the three surfaces can never drift again.
+from genesis.util.approval_words import (
+    APPROVE_TOKENS as _APPROVE_WORDS,
+)
+from genesis.util.approval_words import (
+    REJECT_TOKENS as _REJECT_WORDS,
+)
 
-_APPROVE_WORDS = frozenset({
-    "approve", "approved", "ok", "yes", "go", "lgtm",
-})
-_REJECT_WORDS = frozenset({
-    "reject", "rejected", "deny", "denied", "no", "nope",
-})
+logger = logging.getLogger(__name__)
 
 
 def _json_loads(raw: str | None) -> dict[str, Any]:

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -22,6 +22,7 @@ from genesis.channels.telegram._handler_helpers import (
 )
 from genesis.channels.telegram.transport.streaming import DraftStreamer, generate_draft_id
 from genesis.channels.telegram.transport.update_dedupe import message_key
+from genesis.util.approval_words import scoped_decision
 
 if TYPE_CHECKING:
     from genesis.channels.telegram._handler_context import HandlerContext
@@ -738,8 +739,6 @@ def _bare_decision(text: str) -> str | None:
     Approvals topic is a decision-scoped surface; never run this over
     general conversation.
     """
-    from genesis.util.approval_words import scoped_decision
-
     return scoped_decision(text)
 
 

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -726,28 +726,21 @@ async def _handle_media_inner(
             log.warning("Failed to clean up temp media file %s", file_path, exc_info=True)
 
 
-_BARE_APPROVE_WORDS = frozenset({"approve", "approved", "ok", "yes", "lgtm"})
-_BARE_REJECT_WORDS = frozenset({"reject", "rejected", "deny", "denied", "no"})
-
-
 def _bare_decision(text: str) -> str | None:
-    """Return 'approved'/'rejected' iff the entire message is a single
-    bare approve/reject word.  Rejects anything that's not an exact
-    single-token match so general conversation never triggers."""
-    stripped = (text or "").strip().lower()
-    if not stripped:
-        return None
-    # Allow optional trailing punctuation on a single token.
-    import re
+    """Return 'approved'/'rejected' for a message typed in the Approvals
+    topic (the caller enforces that scoping).
 
-    cleaned = re.sub(r"[^\w]", "", stripped) if " " not in stripped else stripped
-    if " " in cleaned:
-        return None
-    if cleaned in _BARE_APPROVE_WORDS:
-        return "approved"
-    if cleaned in _BARE_REJECT_WORDS:
-        return "rejected"
-    return None
+    Uses the CANONICAL shared vocabulary (genesis.util.approval_words) —
+    the same words a quote-reply resolves with — via two matchers:
+    exact standalone phrases ("sounds good", "go for it", a thumbs-up)
+    and leading-token decisions ("Ok sounds good, ship it" → approved,
+    matching the gate's own quote-reply semantics). Safe ONLY because the
+    Approvals topic is a decision-scoped surface; never run this over
+    general conversation.
+    """
+    from genesis.util.approval_words import scoped_decision
+
+    return scoped_decision(text)
 
 
 async def _try_bare_approval_resolution(
@@ -767,6 +760,13 @@ async def _try_bare_approval_resolution(
     topic, a bare 'approve' resolves the most recent pending request.
     """
     if ctx.autonomous_cli_gate is None:
+        return False
+    # Quote-replies NEVER take this path: the user pointed at a specific
+    # message, so the reply-specific resolution (which resolves the QUOTED
+    # request) must handle it. Without this guard, the widened matcher
+    # would intercept "Ok sounds good" quoted onto an OLDER approval and
+    # resolve the most recent one instead.
+    if getattr(msg, "reply_to_message", None) is not None:
         return False
     decision = _bare_decision(msg.text)
     if decision is None:
@@ -1287,9 +1287,24 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
             log.info("Outreach reply resolved for delivery %s", reply_to_id)
             return
 
-    # resolve_any_pending DISABLED — it conflates messages across chats/topics.
-    # A DM message resolved an alert-topic approval request. Use quote-reply
-    # or inline keyboard buttons instead. See plan: fluttering-humming-bentley.md
+    # Standalone (non-quote-reply) waiter resolution — SCOPED to the message's
+    # own chat+topic. The old unscoped resolve_any_pending stayed disabled for
+    # months because a DM once resolved an alert-topic approval; the scoped
+    # variant only matches a waiter whose prompt was DELIVERED to this exact
+    # chat+thread, so cross-chat conflation is structurally impossible. A
+    # waiter without recorded delivery context is never eligible.
+    if ctx.reply_waiter and msg.text:
+        thread_key = f"{msg.chat.id}:{getattr(msg, 'message_thread_id', None) or 'dm'}"
+        try:
+            if ctx.reply_waiter.resolve_scoped_pending(
+                msg.text, thread_key=thread_key,
+            ):
+                log.info(
+                    "Standalone message resolved scoped waiter in %s", thread_key,
+                )
+                return
+        except Exception:
+            log.warning("Scoped waiter resolution failed", exc_info=True)
 
     # Record implicit engagement: user is active after receiving outreach
     if ctx.engagement_tracker and ctx.db:
@@ -1487,11 +1502,12 @@ async def handle_callback_query(
             except Exception:
                 log.warning("Failed to edit message after callback resolution", exc_info=True)
         else:
-            # Waiter expired or already processed — still show user feedback
-            # so button presses aren't silently swallowed.
+            # Waiter expired or already processed — feedback must NOT read
+            # as if the decision was recorded ("Approved (expired)" implied
+            # exactly that). Say plainly that nothing happened.
             decision_label = "Approved" if action == "approve" else "Rejected"
             log.info(
-                "Callback for expired/processed waiter %s: %s (user %s)",
+                "Callback for expired/processed waiter %s: %s NOT recorded (user %s)",
                 key,
                 decision_label,
                 user.id,
@@ -1499,7 +1515,11 @@ async def handle_callback_query(
             try:
                 original = query.message.text_html or query.message.text or ""
                 await query.edit_message_text(
-                    text=f"{original}\n\n<b>{decision_label}</b> <i>(expired)</i>",
+                    text=(
+                        f"{original}\n\n<b>⏰ Prompt expired</b> — your "
+                        f"“{decision_label.lower()}” was <b>not</b> recorded. "
+                        "Genesis will re-ask if this still needs a decision."
+                    ),
                     parse_mode="HTML",
                 )
             except Exception:

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -16,6 +16,18 @@ from typing import TYPE_CHECKING
 
 from genesis.db.crud import ego as ego_crud
 from genesis.ego.types import ProposalStatus
+from genesis.util.approval_words import (
+    APPROVE_PHRASES as _SHARED_BARE_APPROVE,
+)
+from genesis.util.approval_words import (
+    APPROVE_TOKENS as _SHARED_APPROVE_TOKENS,
+)
+from genesis.util.approval_words import (
+    REJECT_PHRASES as _SHARED_BARE_REJECT,
+)
+from genesis.util.approval_words import (
+    REJECT_TOKENS as _SHARED_REJECT_TOKENS,
+)
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -746,32 +758,25 @@ class ProposalWorkflow:
 # Reply parser — converts user Telegram text into proposal decisions
 # ---------------------------------------------------------------------------
 
-_APPROVE_WORDS = {"approve", "approved", "yes", "accept", "go", "ok", "okay"}
-_REJECT_WORDS = {"reject", "rejected", "no", "deny", "denied", "skip", "nope"}
+# Token + phrase vocabulary is CANONICAL in genesis.util.approval_words
+# (imported at the top of this module) — shared with the CLI approval gate
+# and the Telegram bare-text path so the three decision surfaces can never
+# drift again. Only the cancel verbs are proposal-specific (grace-period
+# revoke has no equivalent elsewhere).
+_APPROVE_WORDS = _SHARED_APPROVE_TOKENS
+_REJECT_WORDS = _SHARED_REJECT_TOKENS
 _CANCEL_WORDS = {"cancel", "cancelled", "revoke", "revoked", "stop", "undo"}
 
-# Bare affirmative / negative — matches standalone short replies in
-# the ego_proposals topic.  Checked AFTER cross-batch and cancel
-# patterns, BEFORE the numbered regex.
-_BARE_APPROVE = frozenset({
-    # Short affirmatives — caught AFTER the explicit "X all" checks above,
-    # so entries like "approve all" belong there, not here.
-    "ok", "okay", "ok.", "okay.",
-    "yes", "yes.", "yep", "yep.", "yeah", "ya",
-    "sure", "sure.", "absolutely",
-    "go for it", "do it", "let's go", "lets go",
-    "proceed", "sounds good", "lgtm",
-    "approved", "approve", "accept",
-    "ship it", "send it",
-    "go", "alright", "aight",
-    "\U0001f44d", "\u2705",
+# Bare affirmative / negative — standalone short replies in the
+# ego_proposals topic. The shared phrase sets are punctuation-free (the
+# shared normalize() strips trailing punctuation before matching, but this
+# parser's caller only lowercases/strips), so the historical dotted
+# variants are added back locally for byte-compatible matching.
+_BARE_APPROVE = _SHARED_BARE_APPROVE | frozenset({
+    "ok.", "okay.", "yes.", "yep.", "sure.",
 })
-_BARE_REJECT = frozenset({
-    "no", "no.", "nope", "nah",
-    "reject", "rejected", "deny",
-    "skip", "pass",
-    "don't", "dont", "not now", "hold off",
-    "\U0001f44e", "\u274c",
+_BARE_REJECT = _SHARED_BARE_REJECT | frozenset({
+    "no.",
 })
 
 # Pattern: "1 approve" or "approve 1" or "1 yes" or "reject 2: reason"

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -334,9 +334,15 @@ async def outreach_send_and_wait(
     message: str,
     category: str = "blocker",
     channel: str = "telegram",
-    timeout_seconds: int = 300,
+    timeout_seconds: int = 1800,
 ) -> str:
-    """Send a message and wait for user reply. Returns JSON with reply or timeout."""
+    """Send a message and wait for user reply. Returns JSON with reply or timeout.
+
+    Default wait is 30 minutes (was 300s — the demonstrated "button pressed
+    after the waiter died" failure mode). Waiting on a human, not a machine;
+    pass a smaller timeout_seconds explicitly if the caller genuinely can't
+    block.
+    """
     if not _pipeline:
         return "Error: outreach pipeline not initialized"
     from genesis.outreach.types import OutreachCategory, OutreachRequest

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -21,7 +21,7 @@ from genesis.db.crud import outreach as outreach_crud
 from genesis.outreach.config import OutreachConfig
 from genesis.outreach.fresh_eyes import FreshEyesReview
 from genesis.outreach.governance import GovernanceGate
-from genesis.outreach.reply_waiter import ReplyWaiter
+from genesis.outreach.reply_waiter import DEFAULT_REPLY_TIMEOUT_S, ReplyWaiter
 from genesis.outreach.types import (
     GovernanceVerdict,
     OutreachCategory,
@@ -282,7 +282,7 @@ class OutreachPipeline:
         self,
         request: OutreachRequest,
         *,
-        timeout_s: float = 300.0,
+        timeout_s: float = DEFAULT_REPLY_TIMEOUT_S,
     ) -> tuple[OutreachResult, str | None]:
         """Submit outreach and wait for user reply. Returns (result, reply_text)."""
         if not self._reply_waiter:
@@ -294,17 +294,31 @@ class OutreachPipeline:
         if result.status != OutreachStatus.DELIVERED or not result.delivery_id:
             return result, None
 
+        self._attach_waiter_context(result, result.delivery_id)
         reply = await self._reply_waiter.wait_for_reply(
             result.delivery_id, timeout_s=timeout_s,
         )
         return result, reply
+
+    def _attach_waiter_context(self, result: OutreachResult, *keys: str) -> None:
+        """Record the delivered chat+topic on waiter *keys* so standalone
+        text in that same topic can resolve them (scoped, never cross-chat).
+        """
+        if not self._reply_waiter or not result.chat_id:
+            return
+        thread_key = f"{result.chat_id}:{result.thread_id if result.thread_id is not None else 'dm'}"
+        for key in keys:
+            try:
+                self._reply_waiter.set_context(key, thread_key)
+            except Exception:
+                logger.debug("set_context failed for %s", key, exc_info=True)
 
     async def submit_raw_and_wait(
         self,
         text: str,
         request: OutreachRequest,
         *,
-        timeout_s: float = 300.0,
+        timeout_s: float = DEFAULT_REPLY_TIMEOUT_S,
         reply_markup: object | None = None,
         waiter_key: str | None = None,
     ) -> tuple[OutreachResult, str | None]:
@@ -334,6 +348,7 @@ class OutreachPipeline:
         actual_key = waiter_key or result.delivery_id
         if waiter_key and result.delivery_id != waiter_key:
             self._reply_waiter.add_alias(result.delivery_id, waiter_key)
+        self._attach_waiter_context(result, actual_key, result.delivery_id)
 
         try:
             reply = await self._reply_waiter.wait_for_reply(
@@ -645,6 +660,8 @@ class OutreachPipeline:
             message_content=formatted.text,
             delivery_id=str(delivery_id),
             governance_result=gov,
+            chat_id=str(delivery_recipient) if channel == "telegram" else None,
+            thread_id=thread_id if channel == "telegram" else None,
         )
 
     async def deliver_approved(

--- a/src/genesis/outreach/reply_waiter.py
+++ b/src/genesis/outreach/reply_waiter.py
@@ -4,6 +4,13 @@ Maintains a registry of asyncio.Future objects keyed by delivery_id.
 When outreach sends a message and wants to wait for a user reply, it
 registers a waiter. When the Telegram handler detects a quote-reply
 to that message, it resolves the waiter with the reply text.
+
+Waiters may carry a *thread context* ("chat_id:thread_id" of the delivered
+message). That context is what makes standalone-text resolution safe:
+``resolve_scoped_pending`` only resolves a waiter when the user's message
+arrived in the SAME chat+topic the prompt was delivered to — the
+cross-chat conflation that got the old ``resolve_any_pending`` disabled
+(a DM once resolved an alert-topic approval) is structurally impossible.
 """
 
 from __future__ import annotations
@@ -13,12 +20,20 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Waiting on a HUMAN, not a machine: 300s was the demonstrated failure mode
+# (buttons tapped minutes later hit a vanished waiter — the "button TTL
+# stall"). Project timeout policy floor is 2 hours; a pending waiter holds
+# one future in a dict, nothing else.
+DEFAULT_REPLY_TIMEOUT_S = 7200.0
+
 
 class ReplyWaiter:
     """Registry for pending outreach reply futures."""
 
     def __init__(self) -> None:
         self._waiters: dict[str, asyncio.Future[str]] = {}
+        # delivery_id -> "chat_id:thread_id" of the delivered prompt.
+        self._contexts: dict[str, str] = {}
 
     def register(self, delivery_id: str) -> asyncio.Future[str]:
         """Register a waiter for a delivery_id. Returns the Future."""
@@ -28,9 +43,20 @@ class ReplyWaiter:
         logger.info("Registered reply waiter for delivery %s", delivery_id)
         return future
 
+    def set_context(self, delivery_id: str, thread_key: str) -> None:
+        """Attach the delivered message's "chat_id:thread_id" to a waiter.
+
+        Called by the pipeline after delivery, when the destination is
+        known. Waiters without a context are never eligible for
+        standalone-text resolution (quote-reply and buttons still work).
+        """
+        if delivery_id in self._waiters:
+            self._contexts[delivery_id] = thread_key
+
     def resolve(self, delivery_id: str, reply_text: str) -> bool:
         """Resolve a waiter with reply text. Returns True if waiter existed."""
         future = self._waiters.pop(delivery_id, None)
+        self._contexts.pop(delivery_id, None)
         if future is None or future.done():
             return False
         future.set_result(reply_text)
@@ -42,29 +68,66 @@ class ReplyWaiter:
 
         Used so that both a pre-generated UUID (in button callback_data) and
         the Telegram message_id (for quote-reply fallback) resolve the same
-        waiter.
+        waiter. The alias inherits the canonical context, if set.
         """
         future = self._waiters.get(canonical_id)
         if future is not None:
             self._waiters[alias_id] = future
+            context = self._contexts.get(canonical_id)
+            if context is not None:
+                self._contexts[alias_id] = context
 
     def remove(self, *keys: str) -> None:
         """Remove one or more keys from the registry without resolving."""
         for key in keys:
             self._waiters.pop(key, None)
+            self._contexts.pop(key, None)
 
     def cancel(self, delivery_id: str) -> None:
         """Cancel a pending waiter."""
         future = self._waiters.pop(delivery_id, None)
+        self._contexts.pop(delivery_id, None)
         if future and not future.done():
             future.cancel()
 
-    def resolve_any_pending(self, reply_text: str) -> bool:
-        """Resolve the most recent pending waiter with reply text.
+    def resolve_scoped_pending(self, reply_text: str, *, thread_key: str) -> bool:
+        """Resolve a pending waiter with a standalone (non-quote-reply)
+        message — but ONLY within the message's own chat+topic.
 
-        Used when a user sends a standalone message (not a quote-reply)
-        and there's exactly one pending waiter — no ambiguity about which
-        message they're responding to. Returns True if a waiter was resolved.
+        Eligible waiters are those whose recorded context equals
+        *thread_key*. Resolves only when exactly ONE distinct pending
+        future is eligible; zero or several (ambiguous) resolve nothing.
+        Contextless waiters are never eligible — guessing the destination
+        is exactly the bug that got the unscoped version disabled.
+        """
+        eligible: dict[asyncio.Future[str], str] = {}
+        for did, future in self._waiters.items():
+            if future.done():
+                continue
+            if self._contexts.get(did) != thread_key:
+                continue
+            eligible.setdefault(future, did)  # aliases share one future
+        if len(eligible) != 1:
+            return False
+        future, delivery_id = next(iter(eligible.items()))
+        self._pop_future(future)
+        future.set_result(reply_text)
+        logger.info(
+            "Resolved pending reply waiter %s via standalone message in %s",
+            delivery_id, thread_key,
+        )
+        return True
+
+    def _pop_future(self, future: asyncio.Future[str]) -> None:
+        """Drop every key (canonical + aliases) mapped to *future*."""
+        for key in [k for k, f in self._waiters.items() if f is future]:
+            self._waiters.pop(key, None)
+            self._contexts.pop(key, None)
+
+    def resolve_any_pending(self, reply_text: str) -> bool:
+        """UNSCOPED single-pending resolution — kept for API compatibility
+        only; it conflates messages across chats/topics (a DM once resolved
+        an alert-topic approval). Prefer ``resolve_scoped_pending``.
         """
         pending = [
             (did, f) for did, f in self._waiters.items() if not f.done()
@@ -72,7 +135,7 @@ class ReplyWaiter:
         if len(pending) != 1:
             return False  # Ambiguous or no waiters — don't resolve
         delivery_id, future = pending[0]
-        self._waiters.pop(delivery_id, None)
+        self._pop_future(future)
         future.set_result(reply_text)
         logger.info(
             "Resolved pending reply waiter %s via standalone message (no quote-reply)",
@@ -85,12 +148,12 @@ class ReplyWaiter:
         """Number of unresolved waiters.
 
         Note: when aliases exist, this may overcount (same future counted
-        twice). This is acceptable since resolve_any_pending is disabled.
+        twice); informational only.
         """
         return sum(1 for f in self._waiters.values() if not f.done())
 
     async def wait_for_reply(
-        self, delivery_id: str, *, timeout_s: float = 300.0,
+        self, delivery_id: str, *, timeout_s: float = DEFAULT_REPLY_TIMEOUT_S,
     ) -> str | None:
         """Wait for a reply to a specific delivery. Returns None on timeout."""
         future = self._waiters.get(delivery_id)
@@ -100,5 +163,6 @@ class ReplyWaiter:
             return await asyncio.wait_for(future, timeout=timeout_s)
         except TimeoutError:
             self._waiters.pop(delivery_id, None)
+            self._contexts.pop(delivery_id, None)
             logger.info("Reply waiter timed out for delivery %s", delivery_id)
             return None

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -83,6 +83,10 @@ class OutreachResult:
     delivery_id: str | None = None
     governance_result: GovernanceResult | None = None
     error: str | None = None
+    # Destination of the delivered message (Telegram): lets send-and-wait
+    # scope standalone-text resolution to the prompt's own chat+topic.
+    chat_id: str | None = None
+    thread_id: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/genesis/util/approval_words.py
+++ b/src/genesis/util/approval_words.py
@@ -1,0 +1,91 @@
+"""Canonical approve/reject vocabulary — the ONE place decision words live.
+
+Three subsystems parse human approval language: the autonomous CLI approval
+gate (quote-reply/voice text), the Telegram Approvals-topic bare-text path,
+and the ego proposal reply parser. They historically kept three separate,
+drifted word sets ("go" approved a quote-reply but not a bare message;
+"sounds good" worked for proposals only). All consumers now import from
+here; adding a word once adds it everywhere.
+
+Two matching modes, deliberately distinct:
+
+- TOKEN sets — single words, matched against a message's FIRST token
+  ("Ok sounds good, ship it" → approved). Only safe in contexts already
+  scoped to a decision (a quote-reply to an approval card, the Approvals
+  topic, a voice reply to a prompt) — never run this over general chat.
+- PHRASE sets — full-message matches for short standalone replies
+  ("go for it", "ship it", a thumbs-up emoji). Safe in decision-scoped
+  contexts; the whole (normalized) message must match.
+"""
+
+from __future__ import annotations
+
+import re
+
+APPROVE_TOKENS: frozenset[str] = frozenset({
+    "approve", "approved", "ok", "okay", "yes", "go", "lgtm", "accept",
+})
+REJECT_TOKENS: frozenset[str] = frozenset({
+    "reject", "rejected", "deny", "denied", "no", "nope", "skip",
+})
+
+APPROVE_PHRASES: frozenset[str] = frozenset({
+    "ok", "okay", "yes", "yep", "yeah", "ya", "sure", "absolutely",
+    "go for it", "do it", "let's go", "lets go", "go ahead",
+    "proceed", "sounds good", "lgtm", "looks good",
+    "approved", "approve", "accept",
+    "ship it", "send it",
+    "go", "alright", "aight",
+    "\U0001f44d", "✅",
+})
+REJECT_PHRASES: frozenset[str] = frozenset({
+    "no", "nope", "nah",
+    "reject", "rejected", "deny", "denied",
+    "skip", "pass",
+    "don't", "dont", "not now", "hold off",
+    "\U0001f44e", "❌",
+})
+
+_TRAILING_PUNCT_RE = re.compile(r"[\s.!,;:]+$")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, collapse whitespace, strip trailing punctuation."""
+    collapsed = " ".join((text or "").lower().split())
+    return _TRAILING_PUNCT_RE.sub("", collapsed)
+
+
+def phrase_decision(text: str) -> str | None:
+    """'approved'/'rejected' iff the ENTIRE normalized message is a known
+    standalone phrase. Conservative: anything longer returns None."""
+    cleaned = normalize(text)
+    if not cleaned:
+        return None
+    if cleaned in APPROVE_PHRASES:
+        return "approved"
+    if cleaned in REJECT_PHRASES:
+        return "rejected"
+    return None
+
+
+def leading_token_decision(text: str) -> str | None:
+    """'approved'/'rejected' from the FIRST token of the message.
+
+    "Ok sounds good, and rename the flag" → approved. Only for contexts
+    already scoped to a pending decision — the caller owns that scoping.
+    """
+    cleaned = normalize(text)
+    if not cleaned:
+        return None
+    first = cleaned.split()[0].strip(".,:;!—-")
+    if first in APPROVE_TOKENS:
+        return "approved"
+    if first in REJECT_TOKENS:
+        return "rejected"
+    return None
+
+
+def scoped_decision(text: str) -> str | None:
+    """Combined matcher for decision-scoped surfaces: exact phrase first
+    (catches multi-word standalone replies), then leading token."""
+    return phrase_decision(text) or leading_token_decision(text)

--- a/tests/test_channels/test_telegram_handlers_v2.py
+++ b/tests/test_channels/test_telegram_handlers_v2.py
@@ -478,6 +478,9 @@ def handlers_with_waiter(mock_loop, mock_adapter, dedupe):
     """Handlers with a mock reply_waiter injected."""
     waiter = MagicMock()
     waiter.resolve = MagicMock(return_value=True)
+    # Scoped standalone resolution defaults to "nothing pending here" so
+    # unrelated messages continue to normal CC flow.
+    waiter.resolve_scoped_pending = MagicMock(return_value=False)
     return make_handlers_v2(
         mock_loop,
         allowed_users={123},
@@ -519,6 +522,26 @@ async def test_outreach_reply_unresolved_continues_to_cc(handlers_with_waiter, m
 
     waiter.resolve.assert_called_once()
     mock_loop.handle_message_streaming.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_standalone_message_resolves_scoped_waiter(
+    handlers_with_waiter, mock_loop,
+):
+    """A NON-quote-reply message that resolves a chat+topic-scoped waiter is
+    consumed (no CC invocation) — the scoped replacement for the disabled
+    resolve_any_pending."""
+    handlers, waiter = handlers_with_waiter
+    waiter.resolve_scoped_pending = MagicMock(return_value=True)
+    update = _make_update(text="ok", message_id=201)
+    update.message.reply_to_message = None
+    ctx = _make_context()
+
+    await handlers["text"](update, ctx)
+
+    waiter.resolve_scoped_pending.assert_called_once()
+    assert waiter.resolve_scoped_pending.call_args.kwargs["thread_key"]
+    mock_loop.handle_message_streaming.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_callback_handler.py
+++ b/tests/test_outreach/test_callback_handler.py
@@ -242,9 +242,12 @@ async def test_cli_approve_unauthorized_user():
 # ---------------------------------------------------------------------------
 
 
-def test_bare_decision_exact_word_match_only():
-    """_bare_decision should only match single-token approve/reject
-    words — general conversation must not trigger."""
+def test_bare_decision_scoped_vocabulary():
+    """_bare_decision matches the shared decision vocabulary: standalone
+    phrases and LEADING-token decisions ("Ok sounds good" resolves — the
+    2026-07 'Ok did nothing' bug). Non-decision openers must never match:
+    this only runs inside the Approvals topic, but conversation there
+    still must not accidentally resolve."""
     from genesis.channels.telegram._handler_messages import _bare_decision
 
     assert _bare_decision("approve") == "approved"
@@ -259,13 +262,50 @@ def test_bare_decision_exact_word_match_only():
     assert _bare_decision("no") == "rejected"
     assert _bare_decision("denied") == "rejected"
 
-    # Not a bare word — must NOT match
+    # Leading-token decisions — the fix: quote-reply semantics now apply
+    # to bare text in the Approvals topic too.
+    assert _bare_decision("Ok sounds good") == "approved"
+    assert _bare_decision("approve this please") == "approved"
+    assert _bare_decision("yes, let's go") == "approved"
+    assert _bare_decision("no, hold off for now") == "rejected"
+
+    # Shared standalone phrases now work here too (parity with proposals).
+    assert _bare_decision("sounds good") == "approved"
+    assert _bare_decision("go for it") == "approved"
+    assert _bare_decision("ship it") == "approved"
+    assert _bare_decision("not now") == "rejected"
+
+    # Non-decision openers — must NOT match.
     assert _bare_decision("") is None
-    assert _bare_decision("approve this please") is None
     assert _bare_decision("please approve it") is None
     assert _bare_decision("I think we should approve") is None
-    assert _bare_decision("yes, let's go") is None
     assert _bare_decision("random text") is None
+    assert _bare_decision("what does this request do?") is None
+
     # Extra punctuation on a bare token still matches (user is informal)
     assert _bare_decision("approve!") == "approved"
     assert _bare_decision("reject.") == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_bare_approval_skips_quote_replies():
+    """A quote-reply must NEVER take the bare-text path: the user pointed
+    at a specific approval message, and the reply-specific resolution owns
+    it. Without the guard, the widened matcher would intercept 'Ok sounds
+    good' quoted onto an OLDER approval and resolve the most recent one."""
+    from genesis.channels.telegram._handler_messages import (
+        _try_bare_approval_resolution,
+    )
+
+    ctx = MagicMock()
+    ctx.autonomous_cli_gate = MagicMock()
+    ctx.autonomous_cli_gate.resolve_most_recent_pending = AsyncMock()
+    msg = MagicMock()
+    msg.text = "Ok sounds good"
+    msg.reply_to_message = MagicMock()  # it's a quote-reply
+    msg.message_thread_id = 42
+
+    consumed = await _try_bare_approval_resolution(ctx, msg, MagicMock())
+
+    assert consumed is False
+    ctx.autonomous_cli_gate.resolve_most_recent_pending.assert_not_awaited()

--- a/tests/test_outreach/test_reply_waiter.py
+++ b/tests/test_outreach/test_reply_waiter.py
@@ -79,3 +79,76 @@ async def test_wait_for_reply_success():
 async def test_cancel_nonexistent_is_safe():
     waiter = ReplyWaiter()
     waiter.cancel("does-not-exist")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Scoped standalone-text resolution (chat+topic bound)
+# ---------------------------------------------------------------------------
+
+
+async def test_scoped_resolution_matches_same_thread():
+    w = ReplyWaiter()
+    fut = w.register("d1")
+    w.set_context("d1", "123:45")
+    assert w.resolve_scoped_pending("ok", thread_key="123:45") is True
+    assert fut.result() == "ok"
+
+
+async def test_scoped_resolution_ignores_other_thread():
+    """The cross-chat conflation bug: a DM must never resolve a waiter
+    whose prompt was delivered to a forum topic."""
+    w = ReplyWaiter()
+    w.register("d1")
+    w.set_context("d1", "123:45")
+    assert w.resolve_scoped_pending("ok", thread_key="999:dm") is False
+    assert w.pending_count == 1
+
+
+async def test_scoped_resolution_skips_contextless_waiters():
+    w = ReplyWaiter()
+    w.register("d1")  # no context recorded
+    assert w.resolve_scoped_pending("ok", thread_key="123:45") is False
+
+
+async def test_scoped_resolution_ambiguous_does_nothing():
+    w = ReplyWaiter()
+    w.register("d1")
+    w.register("d2")
+    w.set_context("d1", "123:45")
+    w.set_context("d2", "123:45")
+    assert w.resolve_scoped_pending("ok", thread_key="123:45") is False
+    assert w.pending_count == 2
+
+
+async def test_scoped_resolution_alias_counts_once():
+    """A waiter with a callback-data alias is ONE waiter, not two —
+    aliasing must not make the single-pending check ambiguous."""
+    w = ReplyWaiter()
+    fut = w.register("uuid-key")
+    w.set_context("uuid-key", "123:45")
+    w.add_alias("msg-77", "uuid-key")
+    assert w.resolve_scoped_pending("go", thread_key="123:45") is True
+    assert fut.result() == "go"
+    # Both keys are gone — no stale entries.
+    assert w.pending_count == 0
+    assert w.resolve("msg-77", "late") is False
+
+
+async def test_alias_inherits_context():
+    w = ReplyWaiter()
+    w.register("uuid-key")
+    w.set_context("uuid-key", "123:45")
+    w.add_alias("msg-77", "uuid-key")
+    assert w._contexts.get("msg-77") == "123:45"
+
+
+async def test_context_cleared_on_resolve_and_cancel():
+    w = ReplyWaiter()
+    w.register("d1")
+    w.set_context("d1", "123:45")
+    w.resolve("d1", "ok")
+    assert "d1" not in w._contexts
+    w.register("d2")
+    w.set_context("d2", "123:45")
+    w.cancel("d2")
+    assert "d2" not in w._contexts

--- a/tests/test_util/test_approval_words.py
+++ b/tests/test_util/test_approval_words.py
@@ -1,0 +1,73 @@
+"""Tests for the canonical approve/reject vocabulary."""
+
+from __future__ import annotations
+
+from genesis.util.approval_words import (
+    APPROVE_PHRASES,
+    APPROVE_TOKENS,
+    REJECT_PHRASES,
+    REJECT_TOKENS,
+    leading_token_decision,
+    normalize,
+    phrase_decision,
+    scoped_decision,
+)
+
+
+class TestNormalize:
+    def test_lowercase_collapse_strip(self):
+        assert normalize("  Ok   Sounds  GOOD!! ") == "ok sounds good"
+
+    def test_empty(self):
+        assert normalize("") == ""
+        assert normalize(None) == ""
+
+
+class TestPhraseDecision:
+    def test_multiword_phrases(self):
+        assert phrase_decision("go for it") == "approved"
+        assert phrase_decision("Sounds good.") == "approved"
+        assert phrase_decision("not now") == "rejected"
+        assert phrase_decision("hold off") == "rejected"
+
+    def test_emoji(self):
+        assert phrase_decision("\U0001f44d") == "approved"
+        assert phrase_decision("❌") == "rejected"
+
+    def test_longer_message_is_none(self):
+        assert phrase_decision("sounds good but rename the flag") is None
+
+
+class TestLeadingTokenDecision:
+    def test_leading_approve(self):
+        assert leading_token_decision("Ok sounds good, ship it") == "approved"
+        assert leading_token_decision("approve — and rename the flag") == "approved"
+
+    def test_leading_reject(self):
+        assert leading_token_decision("No, this duplicates recon") == "rejected"
+
+    def test_non_decision_opener(self):
+        assert leading_token_decision("please approve it") is None
+        assert leading_token_decision("what does this do?") is None
+
+
+class TestScopedDecision:
+    def test_phrase_wins_over_token(self):
+        # "not now" has no decision leading token ("not" isn't one) but is
+        # a known phrase — scoped_decision must catch it.
+        assert scoped_decision("not now") == "rejected"
+
+    def test_falls_back_to_leading_token(self):
+        assert scoped_decision("yes, with the caveat noted") == "approved"
+
+
+def test_no_word_in_both_camps():
+    assert not (APPROVE_TOKENS & REJECT_TOKENS)
+    assert not (APPROVE_PHRASES & REJECT_PHRASES)
+
+
+def test_tokens_subset_expected_by_gate():
+    # The gate's historical words must all still be present — unification
+    # may only ADD vocabulary, never silently drop it.
+    assert {"approve", "approved", "ok", "yes", "go", "lgtm"} <= APPROVE_TOKENS
+    assert {"reject", "rejected", "deny", "denied", "no", "nope"} <= REJECT_TOKENS


### PR DESCRIPTION
## Summary

PR-9 of the build-lane campaign (user-approved scope): the three long-standing Telegram approval bugs share one root theme — three subsystems parsed decision words with three drifted vocabularies, and a machine-scale 300s timeout guarded a human-scale wait.

- **One canonical vocabulary** (`genesis/util/approval_words.py`, tokens + standalone phrases + emoji). The CLI approval gate, the Approvals-topic bare-text path, and the ego proposal parser all import from it — "go" and "sounds good" now work everywhere a quote-reply "ok" does. Strictly widened, never narrowed (pinned by test).
- **"Ok did nothing" fixed**: Approvals-topic bare text gains leading-token semantics ("Ok sounds good" resolves), matching the gate's own quote-reply behavior. Still hard-scoped to the Approvals topic; non-decision openers never match. Review hardening: **quote-replies never take the bare-text path** — without that guard, a quote-reply onto an OLDER approval would have resolved the most recent one instead.
- **Scoped standalone resolution**: `resolve_any_pending` stays retired. Its replacement `resolve_scoped_pending` resolves a waiter only when the message arrives in the exact chat+topic the prompt was **delivered** to (`OutreachResult` now carries `chat_id`/`thread_id`; the pipeline records the context on the waiter). The DM-resolves-alert-topic conflation that forced the original disable is structurally impossible; contextless waiters are never eligible; aliases count as one waiter; two eligible waiters = ambiguous = no resolution.
- **Button TTL stall fixed**: ReplyWaiter/pipeline default timeout 300s → 7200s (policy floor — waiting on a human), `outreach_send_and_wait` MCP default 300s → 1800s. Blast radius verified: every existing call site passes an explicit timeout, so the default change is inert today and only stops future stalls.
- **Honest expired-tap feedback**: "Approved *(expired)*" implied the decision was recorded; it now says plainly nothing was recorded and Genesis will re-ask.

## Testing
- 166 tests green across approval_words (new), reply_waiter (7 new scoped/alias/lifecycle tests), callback handler (incl. the quote-reply-shadowing guard), proposal parser, gate reply-decision, pipeline, MCP, and handler flow tests; `ruff` clean.
- Adversarial review: no blocking findings; its one sub-bar catch (quote-reply shadowing) fixed before push; timeout blast radius enumerated (all call sites explicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)