### PR TITLE
fix(guardian+inbox): gateway-staleness reference + modified-path storm guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The Guardian no longer false-alarms that the host gateway is "stale" after a
+  healthy update — and can no longer roll it back.** A guardian redeploy advances
+  the host's deployed code without moving its install-dir git checkout, so the
+  staleness check (which compared against that lagging checkout) fired a spurious
+  "gateway stale" alert after every clean update, and its self-heal could copy the
+  *older* checked-out gateway over the current one. The check now measures against
+  the commit that was actually deployed, so a healthy update stays quiet while a
+  genuinely frozen gateway is still detected and repaired.
+
 - **Memory recall no longer surfaces Genesis's own internal noise.** Machine-generated
   decisional output — background reflections, autonomy task retrospectives, and ego-dispatch
   records — was leaking into normal recall because several writers didn't mark themselves as

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -476,11 +476,12 @@ class GuardianWatchdog:
         except Exception:
             return None
 
-    async def _expected_gateway_sha(self, code_version: str) -> str | None:
-        """sha256 of the gateway script at the host's install-dir commit.
+    async def _expected_gateway_sha(self, commit_ref: str) -> str | None:
+        """sha256 of the gateway script at the given commit ref.
 
-        Returns None if the container's git can't resolve that commit (e.g. the
-        host is ahead of the container) — the caller then skips, never
+        Callers pass the host's ``deployed_commit`` (what the last redeploy
+        shipped). Returns None if the container's git can't resolve that commit
+        (e.g. the host is ahead of the container) — the caller then skips, never
         false-alarms. Split out so tests can stub the expected value.
         """
         import asyncio
@@ -489,7 +490,7 @@ class GuardianWatchdog:
         show = await asyncio.to_thread(
             subprocess.run,
             ["git", "-C", str(Path.home() / "genesis"),
-             "show", f"{code_version}:scripts/guardian-gateway.sh"],
+             "show", f"{commit_ref}:scripts/guardian-gateway.sh"],
             capture_output=True, timeout=5,
         )
         if show.returncode != 0 or not show.stdout:
@@ -499,22 +500,31 @@ class GuardianWatchdog:
     async def _check_gateway_staleness(self, version_info: dict) -> None:
         """Detect (and self-heal) a stale DEPLOYED gateway script.
 
-        The `update` self-update can fail while the git pull succeeds, leaving
-        ``~/.local/bin/guardian-gateway.sh`` frozen while the install dir
-        advances — the bug that froze the host gateway ~2 months. We compare the
+        A guardian redeploy can fail to swap ``~/.local/bin/guardian-gateway.sh``
+        (the atomic self-``cp``) while still advancing the install dir and
+        recording the new ``deployed_commit`` — leaving the deployed gateway
+        frozen (the bug that froze the host gateway ~2 months). We compare the
         host's reported ``gateway_sha`` against the sha of the gateway script at
-        the host's install-dir commit. On a confirmed mismatch we attempt ONE
+        the host's ``deployed_commit`` — the authoritative record of what the
+        last redeploy shipped. We deliberately do NOT key off ``code_version``
+        (the install-dir git HEAD): the tar-based redeploy never runs ``git`` in
+        the install dir, so HEAD systematically LAGS the deployed gateway, and
+        keying off it inverts the check (false-alarm on every healthy redeploy,
+        and the self-heal would then ``cp`` the STALE install-dir gateway back).
+        This matches the sibling ``_check_code_drift_inner``, which also measures
+        against ``deployed_commit``. On a confirmed mismatch we attempt ONE
         guarded ``sync-gateway`` self-heal per episode, then escalate if still
         unresolved. Best-effort (invoked under _check_code_drift's suppress).
         """
         host_gw_sha = version_info.get("gateway_sha", "unknown")
-        host_code_ver = version_info.get("code_version", "unknown")
+        host_deploy_commit = version_info.get("deployed_commit", "unknown")
         if not isinstance(host_gw_sha, str) or host_gw_sha in ("", "unknown"):
             return  # host gateway predates gateway_sha, or unreadable
-        if not isinstance(host_code_ver, str) or host_code_ver in ("", "unknown"):
-            return
+        if not isinstance(host_deploy_commit, str) or \
+                host_deploy_commit in ("", "unknown"):
+            return  # host hasn't recorded a deploy yet — skip, never false-alarm
 
-        expected = await self._expected_gateway_sha(host_code_ver)
+        expected = await self._expected_gateway_sha(host_deploy_commit)
         if expected is None:
             return  # can't determine expected sha — don't false-alarm
 
@@ -538,7 +548,7 @@ class GuardianWatchdog:
             logger.warning(
                 "Guardian deployed gateway stale (deployed=%s expected=%s @ %s) "
                 "— auto-running sync-gateway",
-                host_gw_sha[:12], expected[:12], host_code_ver,
+                host_gw_sha[:12], expected[:12], host_deploy_commit,
             )
             try:
                 res = await self._remote.sync_gateway()
@@ -552,7 +562,7 @@ class GuardianWatchdog:
                     Subsystem.GUARDIAN, Severity.WARNING,
                     "guardian.gateway_resync",
                     f"Deployed gateway was stale (sha {host_gw_sha[:12]} vs "
-                    f"{expected[:12]} @ {host_code_ver}); auto sync-gateway "
+                    f"{expected[:12]} @ {host_deploy_commit}); auto sync-gateway "
                     f"ok={ok}. Re-verifying next tick.",
                 )
             return
@@ -564,7 +574,7 @@ class GuardianWatchdog:
             logger.error(
                 "Guardian deployed gateway STILL stale after auto sync-gateway "
                 "(deployed=%s expected=%s @ %s)",
-                host_gw_sha[:12], expected[:12], host_code_ver,
+                host_gw_sha[:12], expected[:12], host_deploy_commit,
             )
             if self._event_bus:
                 from genesis.observability.types import Severity, Subsystem
@@ -573,14 +583,14 @@ class GuardianWatchdog:
                     "guardian.gateway_stale",
                     f"Deployed gateway still stale after auto-resync (sha "
                     f"{host_gw_sha[:12]} vs expected {expected[:12]} @ "
-                    f"{host_code_ver}). Manual check needed.",
+                    f"{host_deploy_commit}). Manual check needed.",
                 )
             await self._alert_user(
                 topic="Guardian gateway stale",
                 context=(
                     f"Guardian deployed gateway is STILL stale after auto-resync "
                     f"(sha {host_gw_sha[:12]} vs expected {expected[:12]} @ "
-                    f"{host_code_ver}). Manual intervention needed."
+                    f"{host_deploy_commit}). Manual intervention needed."
                 ),
                 source_id="guardian:gateway_stale",
             )

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -884,6 +884,29 @@ class InboxMonitor:
                     created_at=now_iso,
                 )
                 continue
+            # Storm guard: a file whose evaluations keep failing on dead URLs
+            # must not re-queue a drop every scan. Mirror the new-file and retry
+            # paths (which already gate here) — the modified path was the one
+            # site missing it. Instead of dropping, write a completing row to
+            # ADVANCE the known hash (stopping re-detection), exactly like the
+            # empty-delta branch above.
+            url_fail_count = await inbox_items.count_url_failures(
+                self._db, str(f), since_hours=48,
+            )
+            if url_fail_count >= self._config.max_retries:
+                logger.warning(
+                    "Retry storm: %s has %d URL failures in 48h, "
+                    "skipping modification", f, url_fail_count,
+                )
+                await inbox_items.create(
+                    self._db,
+                    id=item_id,
+                    file_path=str(f),
+                    content_hash=h,
+                    status="completed",
+                    created_at=now_iso,
+                )
+                continue
             # Genuinely new content -> segment the delta into per-batch rows.
             await self._queue_drop(
                 str(f), eval_content, h, now_iso, pending_items,

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -268,7 +268,7 @@ class TestGatewayStaleness:
     async def test_match_no_action(self):
         wd, r, eb, outreach = _gw_watchdog()
         await wd._check_gateway_staleness(
-            {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"})
+            {"gateway_sha": _EXPECTED_GW_SHA, "deployed_commit": "abc1234"})
         r.sync_gateway.assert_not_called()
         eb.emit.assert_not_called()
         assert wd._gateway_drift_count == 0
@@ -278,7 +278,7 @@ class TestGatewayStaleness:
         """Host gateway too old to report gateway_sha → never alarm."""
         wd, r, _, _ = _gw_watchdog()
         await wd._check_gateway_staleness(
-            {"gateway_sha": "unknown", "code_version": "abc1234"})
+            {"gateway_sha": "unknown", "deployed_commit": "abc1234"})
         r.sync_gateway.assert_not_called()
         assert wd._gateway_drift_count == 0
 
@@ -288,14 +288,14 @@ class TestGatewayStaleness:
         wd, r, _, _ = _gw_watchdog()
         wd._expected_gateway_sha = AsyncMock(return_value=None)
         await wd._check_gateway_staleness(
-            {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"})
+            {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "abc1234"})
         r.sync_gateway.assert_not_called()
         assert wd._gateway_drift_count == 0
 
     @pytest.mark.asyncio
     async def test_stale_below_threshold_no_resync(self):
         wd, r, _, _ = _gw_watchdog()
-        vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        vi = {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "abc1234"}
         for _ in range(_THRESHOLD - 1):
             await wd._check_gateway_staleness(vi)
         r.sync_gateway.assert_not_called()
@@ -304,7 +304,7 @@ class TestGatewayStaleness:
     @pytest.mark.asyncio
     async def test_threshold_triggers_single_resync(self):
         wd, r, eb, outreach = _gw_watchdog()
-        vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        vi = {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "abc1234"}
         for _ in range(_THRESHOLD):
             await wd._check_gateway_staleness(vi)
         r.sync_gateway.assert_called_once()
@@ -314,7 +314,7 @@ class TestGatewayStaleness:
     @pytest.mark.asyncio
     async def test_still_stale_after_resync_escalates_once(self):
         wd, r, eb, outreach = _gw_watchdog()
-        vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        vi = {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "abc1234"}
         for _ in range(_THRESHOLD):
             await wd._check_gateway_staleness(vi)   # → one resync
         await wd._check_gateway_staleness(vi)        # still stale → escalate
@@ -329,13 +329,13 @@ class TestGatewayStaleness:
     @pytest.mark.asyncio
     async def test_resolved_after_resync_resets_state(self):
         wd, r, _, _ = _gw_watchdog()
-        vi_stale = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        vi_stale = {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "abc1234"}
         for _ in range(_THRESHOLD):
             await wd._check_gateway_staleness(vi_stale)
         r.sync_gateway.assert_called_once()
         # Next tick: sync worked → deployed sha now matches expected.
         await wd._check_gateway_staleness(
-            {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"})
+            {"gateway_sha": _EXPECTED_GW_SHA, "deployed_commit": "abc1234"})
         assert wd._gateway_drift_count == 0
         assert wd._gateway_resync_attempted is False
         assert wd._gateway_escalated is False
@@ -345,8 +345,8 @@ class TestGatewayStaleness:
         """After a resolved episode, a fresh staleness episode must self-heal
         again (the most safety-critical transition — no 'quiet forever')."""
         wd, r, _, _ = _gw_watchdog()
-        vi_stale = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
-        vi_ok = {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"}
+        vi_stale = {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "abc1234"}
+        vi_ok = {"gateway_sha": _EXPECTED_GW_SHA, "deployed_commit": "abc1234"}
         for _ in range(_THRESHOLD):
             await wd._check_gateway_staleness(vi_stale)   # episode 1 → resync
         await wd._check_gateway_staleness(vi_ok)           # resolved → reset
@@ -354,6 +354,33 @@ class TestGatewayStaleness:
         for _ in range(_THRESHOLD):
             await wd._check_gateway_staleness(vi_stale)   # episode 2 → re-armed
         assert r.sync_gateway.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_uses_deployed_commit_not_code_version(self):
+        """The staleness check keys the expected sha off ``deployed_commit`` (the
+        authoritative deploy record), NOT ``code_version`` (the install-dir git
+        HEAD, which the tar-based guardian redeploy leaves stale). A healthy
+        redeploy must NOT false-alarm just because the install-dir HEAD lags."""
+        wd, r, eb, _ = _gw_watchdog()
+        await wd._check_gateway_staleness({
+            "gateway_sha": _EXPECTED_GW_SHA,
+            "deployed_commit": "deadbee",
+            "code_version": "0ldc0de",  # stale/lagging — must be IGNORED
+        })
+        wd._expected_gateway_sha.assert_awaited_once_with("deadbee")
+        r.sync_gateway.assert_not_called()
+        eb.emit.assert_not_called()
+        assert wd._gateway_drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_deployed_commit_skips(self):
+        """Host hasn't recorded a deployed_commit yet → skip, never false-alarm
+        (mirrors the unknown-gateway_sha skip)."""
+        wd, r, _, _ = _gw_watchdog()
+        await wd._check_gateway_staleness(
+            {"gateway_sha": _STALE_GW_SHA, "deployed_commit": "unknown"})
+        r.sync_gateway.assert_not_called()
+        assert wd._gateway_drift_count == 0
 
 
 class TestExpectedGatewaySha:

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -270,6 +270,85 @@ async def test_retry_respects_url_failure_storm_guard(
 
 
 @pytest.mark.asyncio
+async def test_modified_path_respects_url_failure_storm_guard(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A file detected as MODIFIED (genuinely-new content) that persistently
+    fails URL fetches (>= max_retries partial_url_failure in 48h) must NOT be
+    re-dropped every scan — the modified path needs the same storm guard the
+    new-file and retry paths already have. Instead of dropping, it writes a
+    completing row to advance the known hash (stopping re-detection)."""
+    from genesis.inbox.scanner import compute_hash
+
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    max_r = mon._config.max_retries
+    fp = inbox_dir / "Genesis.md"
+    fp.write_text(_urls(3))
+    new_h = compute_hash(fp)
+    recent = datetime.now(UTC).isoformat()  # count_url_failures windows on REAL now
+    # >= max_retries partial_url_failures pin the file as a storm. retry_count at
+    # the cap makes them NON-retriable (so the file is NOT a retry candidate) yet
+    # still counted by count_url_failures — and get_all_known keeps them (failed
+    # at cap) at an OLD hash, so the NEW disk content is detected as MODIFIED.
+    for i in range(max_r):
+        await inbox_items.create(
+            db, id=f"puf{i}", file_path=str(fp), content_hash="oldhash",
+            status="pending", created_at=recent,
+        )
+        await inbox_items.update_status(
+            db, f"puf{i}", status="failed",
+            error_message="partial_url_failure", retry_count=max_r,
+        )
+
+    r = await mon.check_once()
+
+    assert r.items_modified == 1, "file must be detected as modified, not retry"
+    assert r.items_retried == 0, "rows at the retry cap are not retry candidates"
+    assert r.batches_dispatched == 0, "storm guard must NOT dispatch a modified drop"
+    assert mock_invoker.run.call_count == 0
+    # The guard advanced the known hash via a completing row (stops re-detection).
+    completed_new = await (await db.execute(
+        "SELECT id FROM inbox_items WHERE file_path=? AND status='completed' "
+        "AND content_hash=?", (str(fp), new_h))).fetchall()
+    assert len(completed_new) == 1, "a completing row at the new hash must be written"
+    # No drop was queued.
+    pending = await (await db.execute(
+        "SELECT id FROM inbox_items WHERE file_path=? AND status IN "
+        "('pending','processing')", (str(fp),))).fetchall()
+    assert pending == [], "storm guard must not leave a pending/processing drop"
+
+
+@pytest.mark.asyncio
+async def test_modified_under_cap_still_queues(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """The modified-path storm guard is BOUNDED: an under-cap URL-failure count
+    (< max_retries) must NOT suppress a genuine modification — it still drops
+    and dispatches. Guards against the >= comparison over-suppressing."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    max_r = mon._config.max_retries
+    fp = inbox_dir / "Genesis.md"
+    fp.write_text(_urls(3))
+    recent = datetime.now(UTC).isoformat()
+    # One under-cap failure (non-retriable at the cap so the file is modified,
+    # not a retry candidate); count 1 < max_retries -> guard must NOT fire.
+    await inbox_items.create(
+        db, id="puf0", file_path=str(fp), content_hash="oldhash",
+        status="pending", created_at=recent,
+    )
+    await inbox_items.update_status(
+        db, "puf0", status="failed",
+        error_message="partial_url_failure", retry_count=max_r,
+    )
+
+    r = await mon.check_once()
+
+    assert r.items_modified == 1
+    assert r.batches_dispatched >= 1, "an under-cap modification must still drop"
+    assert mock_invoker.run.call_count >= 1
+
+
+@pytest.mark.asyncio
 async def test_retry_candidate_vanished_file_is_abandoned(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):


### PR DESCRIPTION
Two small, independent container-side fixes (take effect on next `genesis-server` restart; no host deploy required — `watchdog.py` is container-side per `guardian/DEPLOYMENT.md`).

## 1. Guardian gateway-staleness inversion (`guardian/watchdog.py`)

`_check_gateway_staleness` computed its expected gateway sha from `code_version` (the install-dir's `git rev-parse HEAD`). The guardian `redeploy` action tar-extracts new code and records a new `deployed_commit` **without ever running git** in the install dir, so that HEAD systematically lags what was deployed. Result: after every healthy redeploy the check fired a spurious "gateway stale" alert, and its `sync-gateway` self-heal (which copies the install-dir gateway) could roll the deployed gateway **back** to the older one.

Fix: key the expected sha off `deployed_commit` (the authoritative record of what the last redeploy shipped) — matching the sibling `_check_code_drift_inner`, which already measures against `deployed_commit`. A fully-successful redeploy now matches and stays quiet; a genuinely frozen gateway (deployed_commit advanced but the atomic gateway `cp` failed) still mismatches, fires, and self-heals from the tar-updated install-dir file. Verified against `scripts/guardian-gateway.sh` and by running the check unstubbed against the real container git.

## 2. Inbox modified-path storm guard (`inbox/monitor.py`)

`_phase_create_records` has three `_queue_drop` sites — new, modified, retry. The new-file and retry paths both gate on `count_url_failures(f) >= max_retries`; the modified path did not, so a file repeatedly edited with genuinely-new content whose evaluations keep failing on dead URLs would re-queue a drop every scan. Added the same guard to the modified path, placed after the shared supersede and below the empty-delta branch, writing a completing row (advancing the known hash, stopping re-detection) — mirroring the new-file/retry shape. Closes a 2-of-3 consistency gap (defense-in-depth).

## Tests
- `TestGatewayStaleness`: existing cases switched to `deployed_commit` + `test_uses_deployed_commit_not_code_version`, `test_unknown_deployed_commit_skips`.
- `test_modified_path_respects_url_failure_storm_guard`, `test_modified_under_cap_still_queues`.
- 899 guardian+inbox tests pass; ruff clean. Empirical RED confirmed for both fixes (each fix's test fails without the fix). Code-reviewed clean (no P1/P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)