### PR TITLE
feat(memory): fold in-flight working state into session-start context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   is now reported as a clear failure rather than a vague "couldn't confirm."
   Setup and the full safety model: `docs/reference/proxmox-provisioning.md`.
 
+- **A fresh session now recalls what's already in flight.** When you start an
+  interactive session, its opening context now includes a terse snapshot of the
+  current working state — active autonomy tasks, live git worktrees, and
+  recently-touched plan files — so it can pick up in-progress threads instead of
+  starting cold. It's framed as the session's own recollection, not a report to
+  read back to you.
+
 ### Fixed
 
 - **Memory recall no longer surfaces Genesis's own internal noise.** Machine-generated

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -223,6 +223,7 @@ def main() -> None:
         # Replaces cognitive state — shows what Genesis knows, not system health.
         # Critical alerts only surface if genuinely user-blocking.
         _ek_file = Path.home() / ".genesis" / "essential_knowledge.md"
+        _ek_emitted = False
         if _ek_file.exists():
             try:
                 ek_content = _ek_file.read_text(encoding="utf-8").strip()
@@ -231,8 +232,29 @@ def main() -> None:
                         _emit("\n\n---\n\n")
                     _emit(ek_content)
                     first = False
+                    _ek_emitted = True
             except OSError:
                 pass  # Essential knowledge is advisory — silent failure is correct
+
+        # In-flight working state (advisory): active autonomy tasks, live
+        # worktrees, and recently-touched plan files — computed fresh here
+        # because they change far faster than the L1 essential-knowledge
+        # regeneration cadence. Folds directly UNDER Essential Knowledge with
+        # NO "---" divider so it reads as session context for recollection, not
+        # a standalone report to recite at the user. Foreground-only (this is
+        # the non-genesis-session branch). Writer: genesis.memory.open_loops.
+        try:
+            _inflight = _load_inflight_block()
+            if _inflight:
+                if _ek_emitted:
+                    _emit("\n\n" + _inflight)  # ride under EK, no divider
+                else:
+                    if not first:
+                        _emit("\n\n---\n\n")
+                    _emit(_inflight)
+                first = False
+        except Exception:
+            pass  # In-flight state is advisory — never block session start
 
         # Critical-only alert: surface genuinely user-blocking issues (DB down, etc.)
         _status_file = Path.home() / ".genesis" / "status.json"
@@ -576,6 +598,36 @@ async def _load_cognitive_state(last_session_data: dict | None = None) -> str | 
         return await cognitive_state.render(db, activity_tier=tier)
     finally:
         await db.close()
+
+
+def _load_inflight_block() -> str:
+    """Fresh in-flight working-state block for the foreground session context.
+
+    Opens its own short-timeout connection (mirroring the "2.6 Codebase L0"
+    block above — isolated, never touches the shared runtime connection) and
+    delegates assembly to genesis.memory.open_loops.build_inflight_block.
+    Fail-open: any error returns "" so session start is never blocked.
+    """
+    try:
+        import aiosqlite
+
+        db_path = Path.home() / "genesis" / "data" / "genesis.db"
+        if not db_path.exists():
+            return ""
+        repo_root = Path.home() / "genesis"
+        plans_dir = Path.home() / ".claude" / "plans"
+
+        async def _run() -> str:
+            from genesis.memory.open_loops import build_inflight_block
+            async with aiosqlite.connect(str(db_path), timeout=2) as db:
+                db.row_factory = aiosqlite.Row
+                return await build_inflight_block(
+                    db, repo_root=repo_root, plans_dir=plans_dir
+                )
+
+        return asyncio.run(_run())
+    except Exception:
+        return ""  # Advisory — never block session start
 
 
 if __name__ == "__main__":

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -245,13 +245,11 @@ def main() -> None:
         # the non-genesis-session branch). Writer: genesis.memory.open_loops.
         try:
             _inflight = _load_inflight_block()
+            for _chunk in _inflight_emission_chunks(
+                _inflight, ek_emitted=_ek_emitted, first=first
+            ):
+                _emit(_chunk)
             if _inflight:
-                if _ek_emitted:
-                    _emit("\n\n" + _inflight)  # ride under EK, no divider
-                else:
-                    if not first:
-                        _emit("\n\n---\n\n")
-                    _emit(_inflight)
                 first = False
         except Exception:
             pass  # In-flight state is advisory — never block session start
@@ -598,6 +596,28 @@ async def _load_cognitive_state(last_session_data: dict | None = None) -> str | 
         return await cognitive_state.render(db, activity_tier=tier)
     finally:
         await db.close()
+
+
+def _inflight_emission_chunks(
+    inflight: str, *, ek_emitted: bool, first: bool
+) -> list[str]:
+    """Emission chunks for the in-flight block (pure — drives the foreground branch).
+
+    Folds directly under Essential Knowledge with NO "---" divider when EK was
+    already emitted (so it reads as one continuous context block); otherwise it
+    stands alone, preceded by the standard divider only when it is not the first
+    block. Returns [] for an empty block (nothing to emit). Extracted so the
+    fold/divider logic is unit-testable without a full subprocess run.
+    """
+    if not inflight:
+        return []
+    if ek_emitted:
+        return ["\n\n" + inflight]  # fold under EK, no divider
+    chunks: list[str] = []
+    if not first:
+        chunks.append("\n\n---\n\n")
+    chunks.append(inflight)
+    return chunks
 
 
 def _load_inflight_block() -> str:

--- a/src/genesis/memory/open_loops.py
+++ b/src/genesis/memory/open_loops.py
@@ -67,6 +67,30 @@ def _safe_mtime(path: str) -> float:
         return 0.0
 
 
+def _worktree_activity(path: str) -> float:
+    """Best-effort recency for a linked worktree.
+
+    The worktree *directory* mtime alone is a poor activity signal — it only
+    changes when entries are added/removed directly in the worktree root, not
+    when files are edited/committed under ``src/``, ``tests/``, etc. Instead use
+    the newest mtime among the worktree's git metadata (``index``/``HEAD``/
+    ``ORIG_HEAD`` in its private gitdir, which update on checkout/commit/stage),
+    falling back to the directory mtime. A few cheap stats per worktree.
+    """
+    best = _safe_mtime(path)
+    try:
+        with open(os.path.join(path, ".git"), encoding="utf-8") as fh:
+            content = fh.read(4096).strip()
+    except OSError:
+        return best
+    # Linked worktree: .git is a file "gitdir: <abs path to private gitdir>".
+    if content.startswith("gitdir:"):
+        gitdir = content[len("gitdir:"):].strip()
+        for name in ("index", "HEAD", "ORIG_HEAD"):
+            best = max(best, _safe_mtime(os.path.join(gitdir, name)))
+    return best
+
+
 def _list_worktrees(repo_root: Path) -> list[dict]:
     """Parse ``git worktree list --porcelain`` into structured data.
 
@@ -133,9 +157,9 @@ async def _task_lines(db) -> list[str]:
 
 
 def _worktree_lines(repo_root: Path) -> list[str]:
-    """Live git worktrees (main tree excluded), most-recently-touched first."""
+    """Live git worktrees (main tree excluded), by recent git activity first."""
     wts = _list_worktrees(repo_root)
-    wts.sort(key=lambda w: _safe_mtime(w.get("path", "")), reverse=True)
+    wts.sort(key=lambda w: _worktree_activity(w.get("path", "")), reverse=True)
     lines: list[str] = []
     for w in wts[:_MAX_WORKTREES]:
         branch = w.get("branch") or Path(w.get("path", "")).name or "detached"

--- a/src/genesis/memory/open_loops.py
+++ b/src/genesis/memory/open_loops.py
@@ -1,0 +1,211 @@
+"""In-flight working-state block for session-start context.
+
+Builds a terse, mechanical snapshot of what is currently *in flight* — active
+autonomy tasks, live git worktrees, and recently-touched plan files — for a
+fresh foreground session to silently pick up. This is **situational awareness
+for the session itself, not a status report for the user**: the block leads
+with an explicit anti-dump directive because it folds directly under Essential
+Knowledge (which carries no such framing), and a fresh session must never open
+by reciting it.
+
+Computed fresh at session start (worktrees/plans change far faster than the L1
+Essential-Knowledge regeneration cadence, so a generator-side write would be
+stale-on-arrival). Every section is independently guarded; an empty snapshot
+returns "" so the caller emits nothing.
+
+Consumed by ``scripts/genesis_session_context.py`` (foreground branch only).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.db.crud.task_states import list_active
+
+logger = logging.getLogger(__name__)
+
+_MAX_TASKS = 5
+_MAX_WORKTREES = 8
+_MAX_PLANS = 3
+_MAX_CHARS = 2000
+_MAX_DESC = 80
+
+# Copied (not imported) from outreach.morning_report._relative_age: that module's
+# top-level imports pull in the content/routing chain (ContentDrafter, etc.),
+# which is the wrong cost + coupling for a latency-critical session-start hook.
+# This is a trivial stdlib-only pure helper; the duplication is deliberate.
+
+
+def _relative_age(iso_ts: str) -> str:
+    """Convert an ISO timestamp to a human-readable relative age string."""
+    if not iso_ts:
+        return "unknown age"
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+        delta = datetime.now(UTC) - ts
+        total_s = delta.total_seconds()
+        if total_s < 0:
+            return "just now"
+        if total_s < 3600:
+            return f"{int(total_s / 60)}m ago"
+        if total_s < 86400:
+            return f"{total_s / 3600:.0f}h ago"
+        return f"{total_s / 86400:.0f}d ago"
+    except (ValueError, TypeError):
+        return "unknown age"
+
+
+def _safe_mtime(path: str) -> float:
+    """File mtime, or 0.0 if the path is missing/unreadable."""
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return 0.0
+
+
+def _list_worktrees(repo_root: Path) -> list[dict]:
+    """Parse ``git worktree list --porcelain`` into structured data.
+
+    Returns list of dicts with keys: path, head, branch (branch absent for a
+    detached HEAD). Excludes the main worktree (the first porcelain entry).
+
+    Copied from ``scripts/worktree_lifecycle.py:_list_worktrees`` (scripts/ is
+    not an importable package) with the subprocess timeout tightened from 10s
+    to 2s for the session-start hook budget. Follow-up: extract a shared util
+    so this logic is not maintained in two places.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, cwd=str(repo_root), timeout=2,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+
+    worktrees: list[dict] = []
+    current: dict = {}
+    is_first = True
+
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            if current and "path" in current and not is_first:
+                worktrees.append(current)
+            current = {"path": line[len("worktree "):]}
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD "):]
+        elif line.startswith("branch "):
+            ref = line[len("branch "):]
+            current["branch"] = ref.removeprefix("refs/heads/")
+        elif line == "":
+            if current and "path" in current and not is_first:
+                worktrees.append(current)
+            is_first = False
+            current = {}
+
+    if current and "path" in current and not is_first:
+        worktrees.append(current)
+
+    return worktrees
+
+
+async def _task_lines(db) -> list[str]:
+    """Active (non-terminal) autonomy tasks, newest first, capped."""
+    rows = await list_active(db)
+    lines: list[str] = []
+    for r in rows[:_MAX_TASKS]:
+        tid = (r["task_id"] or "")[:8]
+        phase = r["current_phase"] or "?"
+        desc = (r["description"] or "").strip().replace("\n", " ")
+        if len(desc) > _MAX_DESC:
+            desc = desc[: _MAX_DESC - 3] + "..."
+        age = _relative_age(r["updated_at"] or "")
+        lines.append(f"- `{tid}` {phase} · {desc} ({age})")
+    extra = len(rows) - _MAX_TASKS
+    if extra > 0:
+        lines.append(f"- …(+{extra} more)")
+    return lines
+
+
+def _worktree_lines(repo_root: Path) -> list[str]:
+    """Live git worktrees (main tree excluded), most-recently-touched first."""
+    wts = _list_worktrees(repo_root)
+    wts.sort(key=lambda w: _safe_mtime(w.get("path", "")), reverse=True)
+    lines: list[str] = []
+    for w in wts[:_MAX_WORKTREES]:
+        branch = w.get("branch") or Path(w.get("path", "")).name or "detached"
+        head = (w.get("head") or "")[:8]
+        lines.append(f"- {branch} @ {head}")
+    extra = len(wts) - _MAX_WORKTREES
+    if extra > 0:
+        lines.append(f"- …(+{extra} more)")
+    return lines
+
+
+def _plan_lines(plans_dir: Path) -> list[str]:
+    """Recently-modified plan files, newest first, capped."""
+    if not plans_dir.exists():
+        return []
+    files = [p for p in plans_dir.glob("*.md") if p.is_file()]
+    files.sort(key=lambda p: _safe_mtime(str(p)), reverse=True)
+    lines: list[str] = []
+    for p in files[:_MAX_PLANS]:
+        age = _relative_age(datetime.fromtimestamp(_safe_mtime(str(p)), UTC).isoformat())
+        lines.append(f"- {p.name} ({age})")
+    return lines
+
+
+async def build_inflight_block(db, *, repo_root: Path, plans_dir: Path) -> str:
+    """Assemble the in-flight working-state block, or "" when nothing is in flight.
+
+    Each section is independently guarded (mirrors the morning-report assembler
+    discipline): one section failing never suppresses the others. The returned
+    string includes its own ``### In-flight state`` heading and anti-dump
+    directive, and carries NO leading ``---`` divider — the caller folds it
+    directly under Essential Knowledge.
+    """
+    try:
+        tasks = await _task_lines(db)
+    except Exception:
+        logger.debug("in-flight: active-tasks section failed", exc_info=True)
+        tasks = []
+    try:
+        worktrees = _worktree_lines(repo_root)
+    except Exception:
+        logger.debug("in-flight: worktrees section failed", exc_info=True)
+        worktrees = []
+    try:
+        plans = _plan_lines(plans_dir)
+    except Exception:
+        logger.debug("in-flight: plans section failed", exc_info=True)
+        plans = []
+
+    if not (tasks or worktrees or plans):
+        return ""
+
+    parts = [
+        "### In-flight state (for your recollection, not a report)",
+        "(you already have this context; the user knows what they're working "
+        "on. Reference only if relevant to what they raise; never open a "
+        "session by summarizing it.)",
+    ]
+    if tasks:
+        parts.append("\n**Active autonomy tasks:**\n" + "\n".join(tasks))
+    if worktrees:
+        parts.append("\n**Live worktrees:**\n" + "\n".join(worktrees))
+    if plans:
+        parts.append("\n**Recent plans:**\n" + "\n".join(plans))
+
+    block = "\n".join(parts)
+    if len(block) > _MAX_CHARS:
+        cut = block[:_MAX_CHARS]
+        nl = cut.rfind("\n")
+        if nl > 0:
+            cut = cut[:nl]
+        block = cut.rstrip() + "\n…(truncated)"
+    return block

--- a/tests/test_memory/test_open_loops.py
+++ b/tests/test_memory/test_open_loops.py
@@ -127,6 +127,31 @@ async def test_worktree_cap_and_overflow(empty_db, empty_dirs, monkeypatch):
     assert "(+4 more)" in block  # 12 - 8 cap
 
 
+async def test_worktrees_ordered_by_git_activity(empty_db, empty_dirs, tmp_path, monkeypatch):
+    import os
+
+    repo, plans = empty_dirs
+
+    def make_wt(name, index_mtime, branch):
+        # A fake linked worktree: .git file points at a private gitdir whose
+        # index mtime is the activity signal we sort on.
+        wt = tmp_path / name
+        wt.mkdir()
+        gitdir = tmp_path / "gd" / name
+        gitdir.mkdir(parents=True)
+        (gitdir / "index").write_text("x")
+        os.utime(gitdir / "index", (index_mtime, index_mtime))
+        (wt / ".git").write_text(f"gitdir: {gitdir}\n")
+        return {"path": str(wt), "head": "0" * 40, "branch": branch}
+
+    old = make_wt("oldwt", 1_000.0, "feat/old")
+    new = make_wt("newwt", 9_000_000_000.0, "feat/new")
+    # Return in old-first order so a working sort must reorder them.
+    monkeypatch.setattr(open_loops, "_list_worktrees", lambda root: [old, new])
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert block.index("feat/new") < block.index("feat/old")  # newer git activity first
+
+
 async def test_one_section_raises_others_still_render(empty_db, empty_dirs, monkeypatch):
     repo, plans = empty_dirs
     await _insert_task(empty_db, "task0001", "survivor task")

--- a/tests/test_memory/test_open_loops.py
+++ b/tests/test_memory/test_open_loops.py
@@ -1,0 +1,150 @@
+"""Tests for the in-flight working-state session-start block (open_loops)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import task_states
+from genesis.memory import open_loops
+from genesis.memory.open_loops import build_inflight_block
+
+
+async def _insert_task(db, task_id, description, phase="observing"):
+    # task_states has an intake-token trigger — go through the crud path, not
+    # a raw INSERT (see CLAUDE.md: never insert directly into task_states).
+    token = await task_states.create_intake_token(db)
+    await task_states.create(
+        db,
+        task_id=task_id,
+        description=description,
+        current_phase=phase,
+        intake_token=token,
+    )
+
+
+@pytest.fixture
+def empty_dirs(tmp_path):
+    """A non-git repo_root + empty plans_dir → worktree/plan sections empty."""
+    repo = tmp_path / "repo"
+    plans = tmp_path / "plans"
+    repo.mkdir()
+    plans.mkdir()
+    return repo, plans
+
+
+async def test_all_empty_returns_empty_string(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert block == ""
+
+
+async def test_block_has_directive_header_and_no_divider(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    await _insert_task(empty_db, "task0001", "Fix the widget")
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert block.startswith("### In-flight state (for your recollection, not a report)")
+    assert "never open a session by summarizing it" in block
+    # No markdown horizontal-rule divider — caller folds under Essential Knowledge.
+    assert "\n---" not in block
+    assert not block.startswith("---")
+
+
+async def test_active_tasks_render(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    await _insert_task(empty_db, "abcdef12", "Refactor the dispatcher", phase="planning")
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "Active autonomy tasks" in block
+    assert "abcdef12" in block
+    assert "planning" in block
+    assert "Refactor the dispatcher" in block
+
+
+async def test_terminal_tasks_excluded(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    await _insert_task(empty_db, "done0001", "Completed thing", phase="completed")
+    await _insert_task(empty_db, "live0001", "Live thing", phase="observing")
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "live0001" in block
+    assert "done0001" not in block
+
+
+async def test_task_cap_and_overflow(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    for i in range(7):
+        await _insert_task(empty_db, f"task{i:04d}", f"Task number {i}")
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert block.count("- `") == 5  # 5 task bullets; overflow marker has no backtick
+    assert "(+2 more)" in block
+
+
+async def test_long_description_truncated(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    await _insert_task(empty_db, "long0001", "x" * 200)
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "..." in block
+    for line in block.splitlines():
+        if line.startswith("- `"):  # a task bullet
+            assert len(line) < 140  # no runaway 200-char task line
+
+
+async def test_recent_plans_render(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    (plans / "my-plan.md").write_text("# plan")
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "Recent plans" in block
+    assert "my-plan.md" in block
+
+
+async def test_plan_cap(empty_db, empty_dirs):
+    repo, plans = empty_dirs
+    for i in range(5):
+        (plans / f"plan-{i}.md").write_text("x")
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    plan_section = block.split("**Recent plans:**")[1]
+    assert plan_section.count("- ") == 3
+
+
+async def test_worktrees_render_via_monkeypatch(empty_db, empty_dirs, monkeypatch):
+    repo, plans = empty_dirs
+    monkeypatch.setattr(open_loops, "_list_worktrees", lambda root: [
+        {"path": str(repo / "wt-a"), "head": "1234567890abcdef", "branch": "feat/foo"},
+        {"path": str(repo / "wt-b"), "head": "abcdef1234567890"},  # detached (no branch)
+    ])
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "Live worktrees" in block
+    assert "feat/foo @ 12345678" in block
+    assert "wt-b @ abcdef12" in block  # detached → path basename
+
+
+async def test_worktree_cap_and_overflow(empty_db, empty_dirs, monkeypatch):
+    repo, plans = empty_dirs
+    many = [
+        {"path": str(repo / f"wt{i}"), "head": f"{i:040d}", "branch": f"b{i}"}
+        for i in range(12)
+    ]
+    monkeypatch.setattr(open_loops, "_list_worktrees", lambda root: many)
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "(+4 more)" in block  # 12 - 8 cap
+
+
+async def test_one_section_raises_others_still_render(empty_db, empty_dirs, monkeypatch):
+    repo, plans = empty_dirs
+    await _insert_task(empty_db, "task0001", "survivor task")
+
+    def boom(root):
+        raise RuntimeError("worktree listing blew up")
+
+    monkeypatch.setattr(open_loops, "_worktree_lines", boom)
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert "survivor task" in block  # tasks survive the worktree failure
+    assert "Live worktrees" not in block
+
+
+async def test_truncation_hard_cap(empty_db, empty_dirs, monkeypatch):
+    repo, plans = empty_dirs
+    monkeypatch.setattr(
+        open_loops, "_plan_lines", lambda d: ["- " + "y" * 100 for _ in range(60)]
+    )
+    block = await build_inflight_block(empty_db, repo_root=repo, plans_dir=plans)
+    assert len(block) <= open_loops._MAX_CHARS + 20
+    assert "…(truncated)" in block

--- a/tests/test_scripts/test_session_context_inflight.py
+++ b/tests/test_scripts/test_session_context_inflight.py
@@ -1,0 +1,47 @@
+"""Tests for the in-flight block emission logic in the SessionStart hook.
+
+Guards the fold/divider wiring that the subprocess integration tests can't
+reach (they run with HOME=tmp_path, so the real genesis.db is absent and
+_load_inflight_block() short-circuits to "").
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "scripts" / "genesis_session_context.py"
+)
+_spec = importlib.util.spec_from_file_location("genesis_session_context", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+_chunks = _mod._inflight_emission_chunks
+
+_SENTINEL = "### In-flight state SENTINEL"
+
+
+def test_empty_block_emits_nothing():
+    assert _chunks("", ek_emitted=True, first=False) == []
+    assert _chunks("", ek_emitted=False, first=True) == []
+
+
+def test_folds_under_ek_with_no_divider():
+    out = _chunks(_SENTINEL, ek_emitted=True, first=False)
+    assert out == ["\n\n" + _SENTINEL]
+    # Critical: no horizontal-rule divider when riding under Essential Knowledge.
+    assert "---" not in "".join(out)
+
+
+def test_standalone_after_other_blocks_gets_divider():
+    # EK absent but something else already emitted → standard divider precedes it.
+    out = _chunks(_SENTINEL, ek_emitted=False, first=False)
+    assert out == ["\n\n---\n\n", _SENTINEL]
+
+
+def test_standalone_first_block_no_divider():
+    # EK absent and nothing emitted yet → block stands alone, no leading divider.
+    out = _chunks(_SENTINEL, ek_emitted=False, first=True)
+    assert out == [_SENTINEL]
+    assert "---" not in "".join(out)


### PR DESCRIPTION
## What

Adds an **in-flight working-state block** to the interactive session-start context: a terse, mechanical snapshot of what's currently in flight — active autonomy tasks, live git worktrees, and recently-touched plan files — folded directly under the Essential Knowledge block.

This is situational awareness **for the session itself, not a status report for the user**. A fresh session can silently pick up in-progress threads instead of starting cold. It leads with an explicit anti-dump directive and rides under Essential Knowledge with no divider, because a fresh session must never open by reciting it at the user.

Computed fresh at session start (worktrees/plans change far faster than the L1 Essential-Knowledge regeneration cadence, so a generator-side write would be stale-on-arrival).

## How

- **`src/genesis/memory/open_loops.py`** (new) — `async def build_inflight_block(db, *, repo_root, plans_dir)`. Each section (`_task_lines` via the sanctioned `task_states.list_active`, `_worktree_lines`, `_plan_lines`) is independently guarded; returns `""` when nothing is in flight; hard-caps at 2000 chars with per-section overflow markers.
- **`scripts/genesis_session_context.py`** — `_load_inflight_block()` (own 2s-timeout connection, fail-open, mirrors the existing Codebase-L0 pattern) + a pure `_inflight_emission_chunks()` that folds the block under Essential Knowledge with no `---` divider. Foreground-only (lives in the non-`GENESIS_CC_SESSION` branch).

**Design notes:**
- `_relative_age` and `_list_worktrees` are *copied* (not imported) — importing the morning-report module would pull its content/routing chain into a latency-critical hook, and `worktree_lifecycle.py` isn't an importable package. Both copies are cross-referenced by comment; a shared-util extraction is filed as a follow-up.
- Worktrees are sorted by newest git-metadata mtime (`index`/`HEAD`), not the worktree directory mtime (which misses edits under `src/`), so ordering reflects real activity.

## Testing

- 13 assembler tests (`tests/test_memory/test_open_loops.py`): caps, truncation, empty→`""`, terminal-task exclusion, section isolation, no-divider, directive header, git-activity ordering.
- 4 emission-wiring tests (`tests/test_scripts/test_session_context_inflight.py`): fold-under-EK / standalone-divider / first-block / empty.
- ruff clean.
- **E2E** against the live DB/worktrees/plans: foreground shows the block under Essential Knowledge (no divider); background (`GENESIS_CC_SESSION=1`) shows nothing; `build_inflight_block` runs in ~69ms (well under the session-start hook budget); overflow caps verified.

## Review

Code-reviewer pass: no blocking bugs (fail-open, foreground gating, CRUD path, resource handling all verified). Two findings fixed in this branch — extracted the pure emission helper for test coverage, and corrected the worktree ordering signal.

## Follow-ups

- Extract a single shared worktree-list helper (currently copied in two places).
- Clean up the Essential Knowledge generator's raw prompt-fragment "Active Work" section (separate subsystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
