### PR TITLE
feat(attention): OMI off-prem wearable connector (buffers-only, sandboxed ingest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis can now listen in on your off-prem conversations through an OMI
+  wearable — with the same passive "is this worth paying attention to?" judgment
+  it already applies to the home mic.** A new opt-in receiver takes the OMI app's
+  real-time transcript webhook and feeds it into the attention engine's
+  passive-listening tier, so conversations away from home get the same treatment
+  as ambient audio at home. It's **buffers-only**: transcripts are stored for the
+  shadow "perk up?" pass, and the deeper judgment step (which sends household text
+  to the cloud) stays manual and asks first, exactly as today — nothing is sent
+  anywhere automatically. It runs as its own locked-down service reachable only
+  over your private Tailscale Funnel behind a secret URL token, and stays inactive
+  until you configure it. Setup: `config/omi_config.yaml.example` +
+  `OMI_INGEST_SECRET_TOKEN` in `secrets.env`.
+
 - **Genesis can now grow this VM's disk or RAM from the hypervisor — with your
   approval — to fix the one storage failure nothing else could.** When the
   container's storage pool has no room left to auto-expand into (the structural

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ systemctl --user list-units 'genesis-*' --all    # All units
 ```
 
 Other units: `genesis-bridge.service` (Telegram relay, on-demand),
+`genesis-omi-ingest.service` (off-prem OMI wearable transcript receiver,
+on-demand — installed but inactive until `~/.genesis/omi_config.yaml` +
+`OMI_INGEST_SECRET_TOKEN` are set),
 `genesis-tmp-watchgod.service` (/tmp protection), `genesis-watchdog.timer`
 (health check), `genesis-backup.timer` (6h encrypted backup via
 `scripts/backup.sh`), `genesis-disk-hygiene.timer` (daily worktree reaping, cache reclaim, `~/tmp`

--- a/config/omi_config.yaml.example
+++ b/config/omi_config.yaml.example
@@ -1,0 +1,33 @@
+# OMI ingest config — EXAMPLE. Copy to ~/.genesis/omi_config.yaml at deploy and edit.
+#
+# This file configures the genesis-omi-ingest service, which receives off-prem
+# wearable conversation transcripts from the OMI app's real-time webhook and buffers
+# them into the attention engine's passive-listening tier (same as home ambient).
+#
+# The SECRET path-token is NOT here — it lives in secrets.env as
+# OMI_INGEST_SECRET_TOKEN (see secrets.env.example). This file holds only
+# non-secret operational settings.
+#
+# The service reads this at startup; it exits 2 ("unconfigured", no restart-loop)
+# if this file is absent or `enabled: false`.
+
+# Master switch. false (or an absent file) = the service exits and stays inactive.
+enabled: true
+
+# Loopback port the Flask app binds (127.0.0.1). The Tailscale Funnel maps public
+# 443 -> localhost:<port>. 8799 is the verified-free default.
+port: 8799
+
+# Allowlist of OMI account uids permitted to POST (the `?uid=` query param, which
+# OMI also echoes as the body's session_id). A correct path-token but an
+# unallowlisted uid is rejected (403) — a misconfig SHOULD surface loudly.
+# Get your uid from the OMI app. Add each account that should feed this install.
+uid_allowlist:
+  - "REPLACE_WITH_YOUR_OMI_UID"
+
+# Re-anchor tolerance (seconds). OMI timestamps are conversation-relative and reset
+# at each new conversation; the receiver re-anchors a uid's clock when a batch's
+# predicted wall-clock drifts more than this from the actual receive time. 60s
+# absorbs normal in-conversation skew (incl. retries) while still catching a
+# conversation rollover (which jumps by >=~120s of silence).
+anchor_tolerance_s: 60

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -329,7 +329,7 @@ verified: 9037d45b 2026-07-07
   collectors). Tick → depth classification (MICRO/LIGHT/DEEP/STRATEGIC) →
   reflection dispatch. Also per-tick `_check_*` housekeeping: CC-slot RSS leak
   watch, subscription-cap detection, SQLite WAL hygiene, resilience-axis folds,
-  liveness heartbeat. It does NOT drive the ego cadence (ego has its own
+  liveness heartbeat, OMI-ingest unit liveness. It does NOT drive the ego cadence (ego has its own
   scheduler). Trap: PEP 562 lazy `__init__` — don't eager-import `loop.py`.
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
@@ -345,7 +345,12 @@ verified: 9037d45b 2026-07-07
   `sampler.py` (L1.5 judge) is the only LLM caller, outside the core.
   **Firewall: transcript text is never persisted** — only refs + derived
   features reach `attention_events`. Config is versioned DATA
-  (`~/.genesis/config/attention_config.json`).
+  (`~/.genesis/config/attention_config.json`). A separate **OMI off-prem
+  connector** (`omi_ingest.py` — a standalone sandboxed Flask receiver, NO
+  runtime import — plus pure `omi_normalize` and I/O `omi_state`/`omi_daydb`)
+  feeds wearable transcripts into the SAME shadow tier by writing byte-compatible
+  `omi_YYYYMMDD.db` snapshots the unchanged `SnapshotSource`/GC consume. It is
+  buffers-only (the L1.5 judge stays manual) and is NOT part of the pure core.
 
 ## 10. Learning & evaluation
 

--- a/scripts/systemd/genesis-omi-ingest.service.template
+++ b/scripts/systemd/genesis-omi-ingest.service.template
@@ -1,0 +1,41 @@
+[Unit]
+Description=Genesis OMI Ingest (off-prem wearable transcript receiver)
+After=network.target
+# Stop crash-looping: max 4 restarts in 120s, then give up until manual reset.
+# Must be in [Unit], not [Service] — systemd 255 ignores them in [Service].
+StartLimitBurst=4
+StartLimitIntervalSec=120
+
+[Service]
+Type=simple
+WorkingDirectory=__REPO_DIR__
+ExecStart=__VENV__/bin/python -m genesis.attention.omi_ingest
+Restart=on-failure
+RestartSec=10
+
+# Exit 200 = "another instance holds the lock" — don't restart for that.
+# Exit 2   = "unconfigured" (no omi_config.yaml / no token) — don't restart-loop;
+#            the unit stays inactive until the user finishes deploy setup.
+# See genesis.util.process_lock.EXIT_ALREADY_RUNNING.
+RestartPreventExitStatus=200 2
+
+# NOTE: deliberately NO `Environment=TMPDIR=...cc-tmp` — that is Claude Code's
+# watchgod-policed temp; a non-CC service must never point there.
+Environment=PATH=__VENV__/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=journal
+StandardError=journal
+
+# ── Least-privilege sandbox (this is the box's first public ingress) ──
+NoNewPrivileges=yes
+ProtectSystem=strict
+# Narrowed from %h: the receiver only ever writes state + day-dbs + heartbeat here.
+ReadWritePaths=%h/.genesis/attention
+# Kernel-enforced never-egress: Funnel traffic arrives via tailscaled on loopback,
+# and the service makes NO outbound connections (buffers-only). Turns "no egress"
+# from a code-review property into a cgroup guarantee. Verify effective at deploy
+# with `systemd-analyze security genesis-omi-ingest` (user-unit eBPF).
+IPAddressDeny=any
+IPAddressAllow=localhost
+
+[Install]
+WantedBy=default.target

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -284,3 +284,20 @@ GENESIS_BACKUP_NAS=
 GENESIS_BACKUP_NAS_USER=
 # Used by: smb backend — share password
 GENESIS_BACKUP_NAS_PASS=
+
+# ─── OMI ingest (off-prem wearable transcripts) ──────────────────────────
+# Used by: genesis-omi-ingest service (src/genesis/attention/omi_ingest.py).
+# The secret path-token that authenticates the OMI webhook. It becomes part of
+# the public Funnel URL: https://<node>.ts.net/omi/<TOKEN>/ingest?uid=<uid>
+# Generate a long random value: `openssl rand -hex 32`. Treat it like a password.
+# The rest of the config (enabled, port, uid_allowlist) lives in
+# ~/.genesis/omi_config.yaml, not here.
+OMI_INGEST_SECRET_TOKEN=
+# Optional — the PREVIOUS token, accepted during a rotation overlap so no speech
+# is lost mid-rotation. Rotation runbook:
+#   1. generate a new token; move the current OMI_INGEST_SECRET_TOKEN value here
+#      (into ...PREVIOUS) and set the new value as OMI_INGEST_SECRET_TOKEN;
+#   2. restart genesis-omi-ingest; update the OMI app's webhook URL to the new token;
+#   3. once traffic flows on the new token, blank OMI_INGEST_SECRET_TOKEN_PREVIOUS
+#      and restart again.
+OMI_INGEST_SECRET_TOKEN_PREVIOUS=

--- a/src/genesis/attention/omi_daydb.py
+++ b/src/genesis/attention/omi_daydb.py
@@ -1,0 +1,85 @@
+"""Per-UTC-day OMI snapshot-db writer.
+
+Writes normalized OMI utterances into ``omi_YYYYMMDD.db`` files under the SAME
+snapshots dir the reader/GC/runner are pinned to, using the EXACT 10-column
+``ambient_transcripts`` schema so a home ``SnapshotSource`` consumes them unchanged.
+The filename matches the GC regex ``^omi_\\d{8}\\.db$`` and its bare id
+(``omi_YYYYMMDD``) is what ``runner._snapshot_id_from_path`` yields and the dashboard
+reveal reconstructs.
+
+Connections are opened PER CALL, never held: a connection kept open past the
+day-rollover GC deletion would leave unlinked-open files + orphan ``-wal``/``-shm``.
+Writes are milliseconds at the legit ≤~1 req/s rate. The day-db is append-only —
+row-level dedup happens upstream in the ingest orchestrator via
+``omi_state.seen_segments`` (the schema has no segment_id column, by design, to stay
+byte-compatible with home snapshots).
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.attention.omi_normalize import NormalizedRow
+from genesis.attention.snapshot import _DEFAULT_DEST as SNAPSHOTS_DIR
+
+# Byte-compatible with a home ambient_*.db snapshot: same 10 columns, same order,
+# same types/defaults (verified against a live snapshot's PRAGMA table_info).
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS ambient_transcripts (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts            TEXT NOT NULL,
+    text          TEXT NOT NULL,
+    duration_s    REAL,
+    speaker_label TEXT,
+    provenance    TEXT NOT NULL DEFAULT 'ambient_overheard',
+    source        TEXT,
+    meta          TEXT,
+    is_user       INTEGER,
+    speaker_name  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_ambient_ts ON ambient_transcripts(ts);
+"""
+
+
+def snapshot_id_for(recv_ts: float) -> str:
+    """Bare snapshot id for a receive time: ``omi_YYYYMMDD`` (UTC day)."""
+    return "omi_" + datetime.fromtimestamp(recv_ts, UTC).strftime("%Y%m%d")
+
+
+def day_db_path(recv_ts: float, *, snapshots_dir=None) -> Path:
+    """Absolute path of the day-db file for ``recv_ts``."""
+    base = Path(snapshots_dir).expanduser() if snapshots_dir else Path(SNAPSHOTS_DIR).expanduser()
+    return base / f"{snapshot_id_for(recv_ts)}.db"
+
+
+def insert_rows(rows: list[NormalizedRow], *, recv_ts: float, snapshots_dir=None) -> int:
+    """Append normalized rows to the day-db for ``recv_ts``; return rows written.
+
+    A fresh connection is opened and closed here (never held across the GC
+    boundary). Empty input is a no-op — no file is created.
+    """
+    rows = list(rows)
+    if not rows:
+        return 0
+    path = day_db_path(recv_ts, snapshots_dir=snapshots_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.executescript(_SCHEMA)
+        conn.executemany(
+            "INSERT INTO ambient_transcripts "
+            "(ts, text, duration_s, speaker_label, provenance, source, meta, is_user, speaker_name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (r.ts, r.text, r.duration_s, r.speaker_label, r.provenance,
+                 r.source, r.meta, r.is_user, r.speaker_name)
+                for r in rows
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return len(rows)

--- a/src/genesis/attention/omi_ingest.py
+++ b/src/genesis/attention/omi_ingest.py
@@ -1,0 +1,286 @@
+"""Dedicated OMI ingest service — the ONLY publicly-exposed Genesis surface.
+
+A standalone single-route Flask app bound to ``127.0.0.1`` behind a Tailscale
+Funnel. It imports NO ``GenesisRuntime`` and NO attention engine — a leak or a
+compromise here cannot reach the rest of Genesis. It BUFFERS ONLY: normalized
+transcript rows land in per-UTC-day snapshot dbs; the L1.5 judge (the household-
+text cloud egress) stays manual and per-run user-gated, exactly as today.
+
+Error policy is shaped by OMI's failure budget: the webhook auto-disables after
+100 CUMULATIVE non-2xx responses (a counter that never resets). So POST-auth we
+NEVER return 429/5xx — overload/flood/internal-error all drop-with-``200``, because
+the data is lost either way and the webhook lifeline is the scarcer resource.
+Pre-auth 401/403 ARE returned (a genuinely misconfigured webhook SHOULD burn its
+budget and disable). A response body containing a ``message`` key push-notifies the
+user's phone, so no handler ever emits one.
+
+Concurrency: ``threaded=True`` (a slow request on a single thread would starve
+OMI's 2s-connect/30s-read deliveries into the permanent kill-switch). A single
+lock serializes the normalize→anchor→state→day-db critical section — also required
+for the anchor read-modify-write to be correct.
+"""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from flask import Flask, jsonify, request
+from werkzeug.exceptions import HTTPException
+
+from genesis.attention import omi_daydb
+from genesis.attention.omi_normalize import decide_anchor, normalize_segments, parse_payload
+from genesis.attention.omi_state import OmiState
+from genesis.env import genesis_home, secrets_path
+
+log = logging.getLogger("genesis.omi_ingest")
+
+_MAX_CONTENT_LENGTH = 256 * 1024  # 256 KB — a batch is a handful of short segments
+_CONFIG_PATH = Path("~/.genesis/omi_config.yaml").expanduser()
+_DEFAULT_PORT = 8799
+
+
+@dataclass(frozen=True)
+class OmiConfig:
+    enabled: bool
+    port: int
+    uid_allowlist: frozenset[str]
+    anchor_tolerance_s: float
+
+
+def load_omi_config(path: Path | None = None) -> OmiConfig | None:
+    """Load ``~/.genesis/omi_config.yaml``. ``None`` if absent or disabled.
+
+    Raises ``ValueError`` when present-and-enabled but malformed (empty allowlist),
+    so a config typo surfaces instead of silently accepting nothing.
+    """
+    cfg_path = path or _CONFIG_PATH
+    if not cfg_path.exists():
+        return None
+    import yaml
+
+    data = yaml.safe_load(cfg_path.read_text()) or {}
+    if not data.get("enabled", True):
+        return None
+    allowlist = frozenset(str(u) for u in (data.get("uid_allowlist") or []))
+    if not allowlist:
+        raise ValueError("omi_config.yaml is enabled but uid_allowlist is empty")
+    return OmiConfig(
+        enabled=True,
+        port=int(data.get("port", _DEFAULT_PORT)),
+        uid_allowlist=allowlist,
+        anchor_tolerance_s=float(data.get("anchor_tolerance_s", 60.0)),
+    )
+
+
+def load_tokens(secrets_file: Path | None = None) -> tuple[str, str]:
+    """Read ``(primary, previous)`` path tokens from secrets.env (bridge parser).
+
+    ``previous`` is ``""`` when unset. Dual tokens let a rotation overlap: a gap
+    would otherwise burn ~1 failure per 1-2s of speech and auto-disable OMI in
+    minutes.
+    """
+    path = str(secrets_file or secrets_path())
+    secrets: dict[str, str] = {}
+    if os.path.exists(path):
+        with open(path) as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                secrets[key.strip()] = value.strip().strip('"')
+    return (
+        secrets.get("OMI_INGEST_SECRET_TOKEN", ""),
+        secrets.get("OMI_INGEST_SECRET_TOKEN_PREVIOUS", ""),
+    )
+
+
+def _safe_end(seg: dict) -> float:
+    try:
+        return float(seg.get("end"))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def create_app(
+    *,
+    config: OmiConfig,
+    tokens: tuple[str, str],
+    state: OmiState,
+    write_rows=None,
+    now_fn=None,
+    heartbeat_path: Path | None = None,
+) -> Flask:
+    """Build the ingest app. Every dependency is injected so it unit-tests cleanly."""
+    primary, previous = tokens
+    now_fn = now_fn or time.time
+    if write_rows is None:
+        def write_rows(rows, recv_ts):  # default: write to the real day-db
+            return omi_daydb.insert_rows(rows, recv_ts=recv_ts)
+
+    # werkzeug's INFO access log would journal the secret path-token on every hit.
+    logging.getLogger("werkzeug").setLevel(logging.WARNING)
+
+    app = Flask(__name__)
+    app.config["MAX_CONTENT_LENGTH"] = _MAX_CONTENT_LENGTH
+
+    lock = threading.Lock()  # serializes the whole state + day-db critical section
+    hb = {
+        "started_at": now_fn(),
+        "last_recv_ts": None,
+        "accepted_total": 0,
+        "auth_failures": 0,
+        "internal_errors": 0,
+    }
+
+    def _write_heartbeat() -> None:
+        if heartbeat_path is None:
+            return
+        try:
+            heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+            heartbeat_path.write_text(json.dumps(hb))
+        except OSError:
+            log.warning("omi ingest: heartbeat write failed", exc_info=True)
+
+    def _token_ok(candidate: str) -> bool:
+        ok = hmac.compare_digest(candidate, primary)
+        if previous:
+            ok = hmac.compare_digest(candidate, previous) or ok
+        return ok
+
+    def _process(uid: str, data, idem_key: str | None) -> int:
+        """Under ``lock``: dedup → anchor → normalize → write. Returns rows written."""
+        recv_ts = now_fn()
+        hb["last_recv_ts"] = recv_ts
+        # 1. delivery-level dedup — a pure retry must not touch anchor/day-db.
+        if state.is_duplicate_delivery(idem_key, now=recv_ts):
+            _write_heartbeat()
+            return 0
+        session_id, segments = parse_payload(data)
+        if session_id and session_id != uid:
+            log.warning("omi ingest: body session_id != query uid (auth uses query uid)")
+        candidates = [s for s in segments if (s.get("text") or "").strip()]
+        if not candidates:
+            _write_heartbeat()
+            return 0
+        # 2. segment-uuid dedup BEFORE any anchor mutation.
+        seen = state.seen_segment_ids([s.get("id") for s in candidates], now=recv_ts)
+        unseen = [s for s in candidates if s.get("id") not in seen]
+        if not unseen:
+            _write_heartbeat()
+            return 0
+        # 3. anchor read-modify-write (max_end monotonic within a kept anchor).
+        batch_max_end = max(_safe_end(s) for s in unseen)
+        prev = state.get_anchor(uid)
+        prev_epoch0 = prev[0] if prev else None
+        epoch0 = decide_anchor(prev_epoch0, batch_max_end, recv_ts, config.anchor_tolerance_s)
+        if prev is None or epoch0 != prev_epoch0:
+            new_max_end = batch_max_end
+        else:
+            new_max_end = max(prev[1], batch_max_end)
+        state.set_anchor(uid, epoch0, new_max_end, now=recv_ts)
+        # 4. normalize + write + record.
+        rows = normalize_segments(unseen, uid=uid, epoch0=epoch0)
+        written = write_rows(rows, recv_ts)
+        state.record_segment_ids([r.segment_id for r in rows], now=recv_ts)
+        hb["accepted_total"] += written
+        _write_heartbeat()
+        return written
+
+    def _count_auth_failure() -> None:
+        with lock:
+            hb["auth_failures"] += 1
+            _write_heartbeat()
+
+    @app.post("/omi/<path_token>/ingest")
+    def ingest(path_token: str):
+        # Pre-auth: 401/403 returned freely (a real misconfig SHOULD disable OMI).
+        if not _token_ok(path_token):
+            log.warning("omi ingest: bad path token")
+            _count_auth_failure()
+            return jsonify({"error": "unauthorized"}), 401
+        uid = request.args.get("uid", "")
+        if uid not in config.uid_allowlist:
+            log.warning("omi ingest: uid not allowlisted")
+            _count_auth_failure()
+            return jsonify({"error": "forbidden"}), 403
+        # Post-auth: NEVER 5xx/429 — client errors 400/413 only; else drop-with-200.
+        try:
+            data = request.get_json(force=True, silent=True)
+            if data is None:
+                return jsonify({"error": "expected a json body"}), 400
+            idem_key = request.headers.get("Idempotency-Key")
+            with lock:
+                accepted = _process(uid, data, idem_key)
+            return jsonify({"accepted": accepted}), 200
+        except HTTPException:
+            # 400/413/405 — permanent client errors the policy allows; let the
+            # JSON error handlers render them (they never emit a `message` key).
+            raise
+        except Exception:
+            log.error("omi ingest: internal error (dropped, returning 200)", exc_info=True)
+            with lock:
+                hb["internal_errors"] += 1
+                _write_heartbeat()
+            return jsonify({"accepted": 0}), 200
+
+    # JSON error handlers — central enforcement of the no-``message``-key invariant.
+    @app.errorhandler(400)
+    def _400(_e):
+        return jsonify({"error": "bad request"}), 400
+
+    @app.errorhandler(404)
+    def _404(_e):
+        return jsonify({"error": "not found"}), 404
+
+    @app.errorhandler(405)
+    def _405(_e):
+        return jsonify({"error": "method not allowed"}), 405
+
+    @app.errorhandler(413)
+    def _413(_e):
+        return jsonify({"error": "payload too large"}), 413
+
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s"
+    )
+    logging.getLogger("werkzeug").setLevel(logging.WARNING)
+
+    config = load_omi_config()
+    if config is None:
+        log.error("OMI ingest not configured/enabled (~/.genesis/omi_config.yaml) — exiting")
+        sys.exit(2)
+    primary, previous = load_tokens()
+    if not primary:
+        log.error("OMI_INGEST_SECRET_TOKEN missing in secrets.env — exiting")
+        sys.exit(2)
+
+    attn_dir = genesis_home() / "attention"
+    state = OmiState(attn_dir / "omi_state.db")
+    app = create_app(
+        config=config,
+        tokens=(primary, previous),
+        state=state,
+        heartbeat_path=attn_dir / "omi_ingest_health.json",
+    )
+
+    from genesis.util.process_lock import ProcessLock
+
+    with ProcessLock("omi-ingest", pid_dir=attn_dir):
+        log.info("OMI ingest listening on 127.0.0.1:%d (buffers-only)", config.port)
+        app.run(host="127.0.0.1", port=config.port, threaded=True, use_reloader=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/attention/omi_ingest.py
+++ b/src/genesis/attention/omi_ingest.py
@@ -185,11 +185,14 @@ def create_app(
             new_max_end = batch_max_end
         else:
             new_max_end = max(prev[1], batch_max_end)
-        state.set_anchor(uid, epoch0, new_max_end, now=recv_ts)
-        # 4. normalize + write + record.
+        # 4. normalize + write + record, THEN persist the advanced anchor LAST. If
+        # the day-db write raises, the anchor must not have moved for data that never
+        # landed — the next batch re-anchors cleanly off the unchanged prior anchor.
+        # All advisory: worst case is ~2s ts jitter on one batch, never lost/dup speech.
         rows = normalize_segments(unseen, uid=uid, epoch0=epoch0)
         written = write_rows(rows, recv_ts)
         state.record_segment_ids([r.segment_id for r in rows], now=recv_ts)
+        state.set_anchor(uid, epoch0, new_max_end, now=recv_ts)
         hb["accepted_total"] += written
         _write_heartbeat()
         return written

--- a/src/genesis/attention/omi_normalize.py
+++ b/src/genesis/attention/omi_normalize.py
@@ -1,0 +1,144 @@
+"""Pure normalizer: OMI webhook transcript segments -> ``ambient_transcripts`` rows.
+
+No I/O, no genesis imports beyond stdlib — safe to unit-test in isolation and to
+reason about independently of the ingest service. The OMI wire format is traced
+from the BasedHardware/omi *sender* source (the public docs are wrong on several
+counts): the body is an object ``{"segments": [...], "session_id": "<uid>"}`` (a
+bare array is tolerated as a fallback), ``session_id`` is the ACCOUNT uid (stable
+forever, NOT per-conversation), and segment fields are snake_case (``speaker_id``,
+not ``speakerId``). Casing variants are tolerated defensively so a deployed-backend
+drift degrades to "still parses", never "drops real speech".
+
+The mapping deliberately emits NO ``meta.audio`` block: OMI is text-only, so the
+reader (``sources.row_to_utterance``) sets ``has_audio=False`` and the engine takes
+the text-only clarity path — no fabricated ``rms=0`` loudness penalty.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+_PROVENANCE = "omi_webhook"
+_SOURCE = "omi"
+
+
+@dataclass(frozen=True)
+class NormalizedRow:
+    """One ``ambient_transcripts`` row derived from an OMI segment.
+
+    ``segment_id`` is NOT a table column — it is the OMI segment uuid, carried
+    alongside for delivery-idempotent dedup (``seen_segments``). The remaining
+    fields map 1:1 onto ``ambient_transcripts`` (``id`` is autoincrement).
+    """
+
+    segment_id: str | None
+    ts: str
+    text: str
+    duration_s: float
+    speaker_label: str | None
+    provenance: str
+    source: str
+    meta: str
+    is_user: int | None
+    speaker_name: str | None
+
+
+def _first(seg: dict, *keys, default=None):
+    """Return the first present key's value — casing/naming tolerance."""
+    for k in keys:
+        if k in seg:
+            return seg[k]
+    return default
+
+
+def _as_float(v, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_payload(data) -> tuple[str | None, list[dict]]:
+    """Extract ``(session_id, segments)`` from an already-decoded JSON body.
+
+    Tolerates the real object shape and a bare-array fallback. ``session_id`` is
+    informational only (auth decides on the query ``uid``); a mismatch is logged
+    by the caller. Non-dict segment entries are dropped.
+    """
+    if isinstance(data, dict):
+        session_id = data.get("session_id")
+        raw_segs = data.get("segments") or []
+    elif isinstance(data, list):
+        session_id = None
+        raw_segs = data
+    else:
+        return None, []
+    segments = [s for s in raw_segs if isinstance(s, dict)]
+    return session_id, segments
+
+
+def normalize_segments(segments, *, uid: str, epoch0: float) -> list[NormalizedRow]:
+    """Map OMI segments -> ``NormalizedRow`` list using ``epoch0`` for timestamps.
+
+    ``epoch0`` is the per-uid anchor (see ``decide_anchor``): the wall-clock epoch
+    that OMI's conversation-relative ``start=0`` corresponds to. Empty/whitespace
+    segments are skipped; duration is clamped non-negative.
+    """
+    rows: list[NormalizedRow] = []
+    for seg in segments:
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        start = _as_float(seg.get("start"))
+        end = _as_float(seg.get("end"))
+        is_user_raw = _first(seg, "is_user", "isUser")
+        is_user = None if is_user_raw is None else int(bool(is_user_raw))
+        meta = {
+            "omi": {
+                "uid": uid,
+                "segment_id": seg.get("id"),
+                "speaker_id": _first(seg, "speaker_id", "speakerId"),
+                "person_id": _first(seg, "person_id", "personId"),
+                "stt_provider": _first(seg, "stt_provider", "sttProvider"),
+            },
+            "asr_feats": {"n_tokens": len(text.split())},
+        }
+        rows.append(
+            NormalizedRow(
+                segment_id=seg.get("id"),
+                ts=datetime.fromtimestamp(epoch0 + start, UTC).isoformat(),
+                text=text,
+                duration_s=max(0.0, end - start),
+                speaker_label=seg.get("speaker"),
+                provenance=_PROVENANCE,
+                source=_SOURCE,
+                meta=json.dumps(meta),
+                is_user=is_user,
+                speaker_name=None,
+            )
+        )
+    return rows
+
+
+def decide_anchor(
+    current_epoch0: float | None,
+    batch_max_end: float,
+    recv_ts: float,
+    tolerance: float,
+) -> float:
+    """Return the ``epoch0`` to use for a batch (pure; the state layer persists it).
+
+    Keep the existing anchor while this batch's predicted wall-clock
+    (``current_epoch0 + batch_max_end``) lands within ``tolerance`` of the actual
+    receive time. Otherwise — no anchor yet, or the prediction is off by more than
+    ``tolerance`` (a conversation rollover, a downtime gap, or device thrash) —
+    re-anchor so this batch's last utterance lands at ``recv_ts``. Self-correcting:
+    any re-anchor puts timestamps back at the wall-clock of speech.
+    """
+    if current_epoch0 is None:
+        return recv_ts - batch_max_end
+    predicted = current_epoch0 + batch_max_end
+    if abs(predicted - recv_ts) > tolerance:
+        return recv_ts - batch_max_end
+    return current_epoch0

--- a/src/genesis/attention/omi_state.py
+++ b/src/genesis/attention/omi_state.py
@@ -51,6 +51,10 @@ class OmiState:
                 segment_id TEXT PRIMARY KEY,
                 seen_at    REAL NOT NULL
             );
+            -- Anchor decision reads ONLY epoch0; max_end (monotonic within a kept
+            -- anchor, reset on re-anchor) and updated_at are DIAGNOSTIC — a record
+            -- of how far the current conversation got, not inputs to decide_anchor
+            -- (which uses each batch's own max-end). Kept for debugging the anchor.
             CREATE TABLE IF NOT EXISTS anchor (
                 uid        TEXT PRIMARY KEY,
                 epoch0     REAL NOT NULL,

--- a/src/genesis/attention/omi_state.py
+++ b/src/genesis/attention/omi_state.py
@@ -1,0 +1,132 @@
+"""Advisory state for the OMI ingest path: delivery/segment dedup + per-uid anchor.
+
+Lives at ``~/.genesis/attention/omi_state.db`` — deliberately OUTSIDE the
+``snapshots/`` tree (that dir holds only snapshot-shaped files the GC/reveal/runner
+scan). The store is ADVISORY: there is no cross-file atomicity with the day-dbs
+(SQLite can't provide it under WAL anyway), and losing it costs at most one
+duplicate row or ~2s of timestamp jitter on a single batch — both engine-tolerable.
+
+Three tables:
+  * ``idempotency_keys`` — OMI reuses an ``Idempotency-Key`` header across a batch's
+    retries; this is the dominant duplicate source. Short TTL (retries fire within
+    seconds).
+  * ``seen_segments`` — per-segment uuid dedup, a 7-day backstop for anything the
+    key layer misses.
+  * ``anchor`` — the per-uid ``(epoch0, max_end)`` reconstructed wall-clock anchor.
+
+All age logic is driven by a caller-supplied ``now`` so callers stay wall-clock
+independent (and testable). Access is serialized by the ingest service's single
+data-path lock, so one shared connection is safe.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+IDEMPOTENCY_TTL_S = 600  # 10 min — OMI reuses the key only across a batch's retries
+SEEN_SEGMENTS_TTL_S = 7 * 86400  # 7 days — segment-uuid dedup horizon
+
+DEFAULT_STATE_PATH = Path("~/.genesis/attention/omi_state.db").expanduser()
+
+
+class OmiState:
+    """SQLite-backed advisory dedup + anchor store. One connection, serialized use."""
+
+    def __init__(self, path: str | Path | None = None):
+        self.path = Path(path).expanduser() if path is not None else DEFAULT_STATE_PATH
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS idempotency_keys (
+                key     TEXT PRIMARY KEY,
+                seen_at REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS seen_segments (
+                segment_id TEXT PRIMARY KEY,
+                seen_at    REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS anchor (
+                uid        TEXT PRIMARY KEY,
+                epoch0     REAL NOT NULL,
+                max_end    REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            """
+        )
+        self._conn.commit()
+
+    # ── idempotency (delivery-level) dedup ─────────────────────────────────
+    def is_duplicate_delivery(self, key: str | None, *, now: float) -> bool:
+        """True if ``key`` was already seen (fresh). Records it on first sight.
+
+        A missing/empty key is never a duplicate (we cannot dedup it — bias to
+        insertion). Prunes expired keys on every call so the table stays bounded.
+        """
+        if not key:
+            return False
+        self._conn.execute(
+            "DELETE FROM idempotency_keys WHERE seen_at < ?", (now - IDEMPOTENCY_TTL_S,)
+        )
+        cur = self._conn.execute("SELECT 1 FROM idempotency_keys WHERE key=?", (key,))
+        if cur.fetchone() is not None:
+            self._conn.commit()
+            return True
+        self._conn.execute(
+            "INSERT OR REPLACE INTO idempotency_keys(key, seen_at) VALUES(?, ?)", (key, now)
+        )
+        self._conn.commit()
+        return False
+
+    # ── segment-uuid dedup ─────────────────────────────────────────────────
+    def seen_segment_ids(self, ids, *, now: float) -> set[str]:
+        """Return the subset of ``ids`` already recorded and still fresh (read-only).
+
+        ``None``/empty ids are ignored — a segment with no uuid can't be deduped, so
+        it is treated as unseen (inserted). Expired entries read as unseen.
+        """
+        wanted = [i for i in ids if i]
+        if not wanted:
+            return set()
+        placeholders = ",".join("?" for _ in wanted)
+        cur = self._conn.execute(
+            f"SELECT segment_id FROM seen_segments "  # noqa: S608 — placeholders only
+            f"WHERE segment_id IN ({placeholders}) AND seen_at > ?",
+            (*wanted, now - SEEN_SEGMENTS_TTL_S),
+        )
+        return {r[0] for r in cur.fetchall()}
+
+    def record_segment_ids(self, ids, *, now: float) -> None:
+        """Record segment uuids as seen (idempotent) and prune expired entries."""
+        wanted = [i for i in ids if i]
+        if wanted:
+            self._conn.executemany(
+                "INSERT OR REPLACE INTO seen_segments(segment_id, seen_at) VALUES(?, ?)",
+                [(i, now) for i in wanted],
+            )
+        self._conn.execute(
+            "DELETE FROM seen_segments WHERE seen_at < ?", (now - SEEN_SEGMENTS_TTL_S,)
+        )
+        self._conn.commit()
+
+    # ── per-uid anchor ─────────────────────────────────────────────────────
+    def get_anchor(self, uid: str) -> tuple[float, float] | None:
+        """Return ``(epoch0, max_end)`` for ``uid``, or ``None`` if unanchored."""
+        cur = self._conn.execute("SELECT epoch0, max_end FROM anchor WHERE uid=?", (uid,))
+        row = cur.fetchone()
+        return (row[0], row[1]) if row else None
+
+    def set_anchor(self, uid: str, epoch0: float, max_end: float, *, now: float) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO anchor(uid, epoch0, max_end, updated_at) VALUES(?, ?, ?, ?)",
+            (uid, epoch0, max_end, now),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -290,6 +290,102 @@ async def _check_cc_cap_detection(db) -> None:
         logger.debug("cc_cap detection failed — skipping this tick", exc_info=True)
 
 
+# OMI ingest liveness. Off-prem wearable transcripts stop SILENTLY if the
+# dedicated genesis-omi-ingest unit dies (the phone keeps POSTing to a dead
+# endpoint until OMI's own 100-failure budget disables the webhook, ~minutes).
+# Config-gated: only alerts once the user has an enabled ~/.genesis/omi_config.yaml,
+# so installs without OMI never fire. Same monotonic-since-boot caveat: None =
+# "never alerted", never 0.0.
+_OMI_ALERT_COOLDOWN_S = 3600  # one alert per hour max
+_last_omi_alert_at: float | None = None
+
+
+async def _systemd_unit_active(unit: str) -> bool | None:
+    """``systemctl --user is-active <unit>`` -> True / False / None.
+
+    True = "active"; False = a definitive not-active state (inactive/failed/…);
+    None = the probe itself could not run (systemctl missing, dbus hiccup, timeout)
+    so the caller must NOT guess. The 10s timeout guards a hung dbus call — a real
+    ``is-active`` returns in milliseconds — with no legitimate work to interrupt."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl", "--user", "is-active", unit,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+        return out.decode().strip() == "active"
+    except Exception:
+        return None
+
+
+async def _check_omi_ingest(db) -> None:
+    """Alert when OMI ingest is configured+enabled but its systemd unit is down.
+
+    Best-effort; never raises into the tick. NOTE (documented residual): an
+    OMI-side auto-disable is undetectable here — a healthy-but-idle service and a
+    disabled webhook look identical (no posts arrive), so this watches the UNIT's
+    liveness, not the transcript flow. A stale heartbeat alone can't distinguish
+    "unit down" from "user not wearing the device"."""
+    global _last_omi_alert_at
+    if db is None:
+        return
+    try:
+        from genesis.attention import omi_ingest
+
+        try:
+            config = omi_ingest.load_omi_config()
+        except Exception:
+            # A malformed config is a separate concern — do NOT read it as "down".
+            logger.debug("omi_ingest: config unreadable — skipping liveness check", exc_info=True)
+            return
+
+        async def _resolve(note: str) -> None:
+            global _last_omi_alert_at
+            resolved = await observations.resolve_by_source_and_type(
+                db, source="omi_ingest_monitor", type="infrastructure_alert",
+                resolved_at=datetime.now(UTC).isoformat(), resolution_notes=note,
+            )
+            if resolved:
+                _last_omi_alert_at = None
+
+        if config is None:
+            await _resolve("OMI ingest not configured/enabled")
+            return
+
+        active = await _systemd_unit_active("genesis-omi-ingest.service")
+        if active is True:
+            await _resolve("genesis-omi-ingest unit active")
+            return
+        if active is None:
+            return  # indeterminate — neither alert nor resolve
+
+        now = time.monotonic()
+        if _last_omi_alert_at is not None and now - _last_omi_alert_at < _OMI_ALERT_COOLDOWN_S:
+            return
+        _last_omi_alert_at = now  # set BEFORE the write so a failed create still suppresses
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="omi_ingest_monitor",
+            type="infrastructure_alert",
+            content=(
+                "OMI ingest is enabled (~/.genesis/omi_config.yaml) but the "
+                "genesis-omi-ingest unit is not active. Off-prem wearable transcripts "
+                "are being dropped until it restarts; OMI will auto-disable the webhook "
+                "once its own failure budget is spent."
+            ),
+            priority="high",
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=hashlib.sha256(b"omi_ingest_unit_down").hexdigest(),
+            skip_if_duplicate=True,
+        )
+        if created is None:
+            return  # an unresolved alert already exists — don't duplicate
+        logger.warning("OMI ingest unit down while enabled — alert raised")
+    except Exception:
+        logger.debug("omi_ingest check failed — skipping this tick", exc_info=True)
+
+
 # Micro ticks are silent by default (counted for cascade, no LLM call).
 # LLM fires only when these critical operational signals are active.
 _MICRO_CRITICAL_SIGNALS = frozenset({"software_error_spike", "critical_failure"})
@@ -927,6 +1023,11 @@ class AwarenessLoop:
             # completions (recorded by the invoker) and alerts on a run. Guarded
             # on db internally; a query failure no-ops (never breaks the tick).
             await _check_cc_cap_detection(self._db)
+
+            # OMI ingest liveness — alert if the off-prem transcript webhook's unit
+            # died while enabled (transcripts drop silently otherwise). Config-gated
+            # + best-effort; a no-op on installs without OMI configured.
+            await _check_omi_ingest(self._db)
 
             # SQLite WAL checkpoint — prevent unbounded WAL growth from
             # external scripts or concurrent writers. PASSIVE is non-blocking.

--- a/tests/test_attention/test_omi_daydb.py
+++ b/tests/test_attention/test_omi_daydb.py
@@ -1,0 +1,106 @@
+"""Tests for the OMI per-UTC-day snapshot-db writer.
+
+The day-db is byte-compatible with a home ``ambient_*.db`` snapshot — it contains
+ONLY the exact 10-column ``ambient_transcripts`` table — so the unchanged
+``SnapshotSource`` / ``run_shadow`` / reveal / GC machinery consumes it. Row-level
+dedup is NOT the day-db's job (the schema has no segment_id column); the ingest
+orchestrator filters via ``omi_state.seen_segments`` before calling ``insert_rows``.
+So the day-db is append-only and this file tests the schema, the filename/id
+contract with the GC + runner, and a real round-trip through the reader.
+"""
+import re
+import sqlite3
+from datetime import datetime
+
+from genesis.attention import omi_daydb, snapshot
+from genesis.attention.omi_normalize import normalize_segments
+from genesis.attention.sources import SnapshotSource
+
+_GC_RE = re.compile(r"^omi_\d{8}\.db$")
+
+
+def _epoch(iso: str) -> float:
+    return datetime.fromisoformat(iso).timestamp()
+
+
+def test_snapshot_id_and_filename_match_gc_regex():
+    recv = _epoch("2026-07-07T15:30:00+00:00")
+    assert omi_daydb.snapshot_id_for(recv) == "omi_20260707"
+    path = omi_daydb.day_db_path(recv, snapshots_dir="/tmp/x")
+    assert _GC_RE.match(path.name)  # exactly what scripts/attention_snapshot_gc.py wants
+
+
+def test_snapshot_id_is_utc_not_local():
+    # 23:59 UTC and 00:01 UTC next day fall on different UTC days regardless of TZ.
+    assert omi_daydb.snapshot_id_for(_epoch("2026-07-07T23:59:00+00:00")) == "omi_20260707"
+    assert omi_daydb.snapshot_id_for(_epoch("2026-07-08T00:01:00+00:00")) == "omi_20260708"
+
+
+def test_ensure_schema_exact_ten_columns(tmp_path):
+    recv = _epoch("2026-07-07T12:00:00+00:00")
+    rows = normalize_segments(
+        [{"id": "s1", "text": "hi there", "speaker": "SPEAKER_0", "start": 0.0, "end": 1.0}],
+        uid="u",
+        epoch0=recv,
+    )
+    omi_daydb.insert_rows(rows, recv_ts=recv, snapshots_dir=tmp_path)
+    db = tmp_path / "omi_20260707.db"
+    conn = sqlite3.connect(str(db))
+    cols = [(r[1], r[2], r[3], r[5]) for r in conn.execute("PRAGMA table_info(ambient_transcripts)")]
+    names = [c[0] for c in cols]
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    idx = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+    conn.close()
+    assert names == [
+        "id", "ts", "text", "duration_s", "speaker_label",
+        "provenance", "source", "meta", "is_user", "speaker_name",
+    ]
+    # id is the autoincrement PK; ts/text/provenance are NOT NULL
+    assert dict((c[0], c[3]) for c in cols)["id"] == 1  # pk
+    assert "idx_ambient_ts" in idx
+    # Only ambient_transcripts (+ sqlite_sequence from AUTOINCREMENT); no side tables.
+    assert tables == {"ambient_transcripts", "sqlite_sequence"}
+
+
+def test_roundtrip_through_snapshotsource(tmp_path):
+    recv = _epoch("2026-07-07T12:00:00+00:00")
+    segs = [
+        {"id": "s1", "text": "first utterance here", "speaker": "SPEAKER_0",
+         "is_user": True, "start": 1.0, "end": 3.0},
+        {"id": "s2", "text": "second one", "speaker": "SPEAKER_1",
+         "is_user": False, "start": 4.0, "end": 5.0},
+    ]
+    rows = normalize_segments(segs, uid="acct", epoch0=recv)
+    n = omi_daydb.insert_rows(rows, recv_ts=recv, snapshots_dir=tmp_path)
+    assert n == 2
+
+    src = SnapshotSource(tmp_path / "omi_20260707.db")
+    utts = list(src.iter_utterances())
+    assert [u.text for u in utts] == ["first utterance here", "second one"]  # ts order
+    assert all(u.source == "omi" for u in utts)
+    assert all(u.has_audio is False for u in utts)  # text-only clarity path
+    assert utts[0].n_tokens == 3  # "first utterance here"
+    assert utts[0].is_user == 1
+    assert utts[0].rms == 0.0  # no audio block -> rms unknown, not penalized
+
+
+def test_append_across_calls_same_day(tmp_path):
+    recv = _epoch("2026-07-07T12:00:00+00:00")
+    r1 = normalize_segments([{"id": "a", "text": "one", "start": 0.0, "end": 1.0}], uid="u", epoch0=recv)
+    r2 = normalize_segments([{"id": "b", "text": "two", "start": 2.0, "end": 3.0}], uid="u", epoch0=recv)
+    omi_daydb.insert_rows(r1, recv_ts=recv, snapshots_dir=tmp_path)
+    omi_daydb.insert_rows(r2, recv_ts=recv + 2, snapshots_dir=tmp_path)  # same UTC day
+    utts = list(SnapshotSource(tmp_path / "omi_20260707.db").iter_utterances())
+    assert [u.text for u in utts] == ["one", "two"]
+
+
+def test_insert_empty_rows_is_noop(tmp_path):
+    recv = _epoch("2026-07-07T12:00:00+00:00")
+    assert omi_daydb.insert_rows([], recv_ts=recv, snapshots_dir=tmp_path) == 0
+    assert not (tmp_path / "omi_20260707.db").exists()  # no file created for nothing
+
+
+def test_snapshots_dir_pinned_to_engine_default():
+    # No user-facing snapshots_dir knob: the write side is the SAME dir the
+    # reader / GC / runner are pinned to. This guards against drift.
+    assert omi_daydb.SNAPSHOTS_DIR == snapshot._DEFAULT_DEST

--- a/tests/test_attention/test_omi_ingest.py
+++ b/tests/test_attention/test_omi_ingest.py
@@ -1,0 +1,209 @@
+"""Tests for the dedicated OMI ingest Flask service (the only exposed surface).
+
+Driven through Flask's ``test_client`` with every dependency injected: a tmp state
+store, a controllable clock, and a capturing ``write_rows`` (no real disk / no
+engine). Asserts the auth matrix, the OMI-shaped error policy (NEVER 5xx/429
+post-auth; the response NEVER carries a ``message`` key — that would push-notify the
+user's phone), delivery + segment dedup, buffers-only, and the heartbeat.
+"""
+import json
+import logging
+
+import pytest
+
+from genesis.attention.omi_ingest import OmiConfig, create_app
+from genesis.attention.omi_state import OmiState
+
+TOKEN = "primary-secret-token"
+PREV = "previous-secret-token"
+UID = "acct-uid"
+
+
+class Clock:
+    def __init__(self, t=1_000_000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+def _seg(sid, text="hello there world", start=0.0, end=2.0, **kw):
+    return {"id": sid, "text": text, "speaker": "SPEAKER_0", "start": start, "end": end, **kw}
+
+
+@pytest.fixture()
+def ctx(tmp_path):
+    state = OmiState(tmp_path / "omi_state.db")
+    clock = Clock()
+    written = []
+
+    def write_rows(rows, recv_ts):
+        written.extend((recv_ts, r) for r in rows)
+        return len(rows)
+
+    cfg = OmiConfig(
+        enabled=True, port=8799, uid_allowlist=frozenset({UID}), anchor_tolerance_s=60.0
+    )
+    app = create_app(
+        config=cfg,
+        tokens=(TOKEN, PREV),
+        state=state,
+        write_rows=write_rows,
+        now_fn=clock,
+        heartbeat_path=tmp_path / "hb.json",
+    )
+    app.testing = True
+    yield type("Ctx", (), {
+        "client": app.test_client(), "state": state, "clock": clock,
+        "written": written, "hb": tmp_path / "hb.json",
+    })()
+    state.close()
+
+
+def _post(ctx, payload, *, token=TOKEN, uid=UID, idem=None, **kw):
+    headers = {"Idempotency-Key": idem} if idem else {}
+    return ctx.client.post(
+        f"/omi/{token}/ingest?uid={uid}", json=payload, headers=headers, **kw
+    )
+
+
+def _no_message(resp):
+    body = resp.get_json(silent=True)
+    assert body is None or "message" not in body, f"response carries a message key: {body}"
+
+
+# ── auth matrix ────────────────────────────────────────────────────────────
+def test_correct_token_accepts(ctx):
+    r = _post(ctx, {"segments": [_seg("s1")], "session_id": UID})
+    assert r.status_code == 200
+    assert r.get_json()["accepted"] == 1
+    _no_message(r)
+
+
+def test_previous_token_accepts(ctx):
+    r = _post(ctx, {"segments": [_seg("s1")]}, token=PREV)
+    assert r.status_code == 200
+    _no_message(r)
+
+
+def test_wrong_token_401(ctx):
+    r = _post(ctx, {"segments": [_seg("s1")]}, token="nope")
+    assert r.status_code == 401
+    _no_message(r)
+
+
+def test_uid_not_allowlisted_403(ctx):
+    r = _post(ctx, {"segments": [_seg("s1")]}, uid="stranger")
+    assert r.status_code == 403
+    _no_message(r)
+
+
+# ── body handling / error policy ───────────────────────────────────────────
+def test_non_json_body_400(ctx):
+    r = ctx.client.post(
+        f"/omi/{TOKEN}/ingest?uid={UID}", data="not json at all", content_type="text/plain"
+    )
+    assert r.status_code == 400
+    _no_message(r)
+
+
+def test_oversize_body_413(ctx):
+    big = b'{"segments": [' + b'0,' * 200_000 + b']}'  # > 256 KB
+    r = ctx.client.post(
+        f"/omi/{TOKEN}/ingest?uid={UID}", data=big, content_type="application/json"
+    )
+    assert r.status_code == 413
+    _no_message(r)
+
+
+def test_parseable_but_empty_is_accepted_zero(ctx):
+    for payload in ({}, {"segments": []}, {"foo": "bar"}, {"segments": [{"text": "  "}]}):
+        r = _post(ctx, payload)
+        assert r.status_code == 200
+        assert r.get_json()["accepted"] == 0
+
+
+def test_bare_array_payload_accepted(ctx):
+    r = _post(ctx, [_seg("s1"), _seg("s2", start=3.0, end=4.0)])
+    assert r.status_code == 200
+    assert r.get_json()["accepted"] == 2
+
+
+# ── dedup ──────────────────────────────────────────────────────────────────
+def test_idempotency_key_retry_untouched(ctx):
+    p = {"segments": [_seg("s1")], "session_id": UID}
+    r1 = _post(ctx, p, idem="delivery-1")
+    assert r1.get_json()["accepted"] == 1
+    anchor_after_first = ctx.state.get_anchor(UID)
+    r2 = _post(ctx, p, idem="delivery-1")  # same key -> pure retry
+    assert r2.get_json()["accepted"] == 0
+    assert ctx.state.get_anchor(UID) == anchor_after_first  # state untouched
+    assert len(ctx.written) == 1  # no second write
+
+
+def test_segment_uuid_dedup(ctx):
+    _post(ctx, {"segments": [_seg("s1")]}, idem="d1")
+    r = _post(ctx, {"segments": [_seg("s1"), _seg("s2", start=3.0, end=4.0)]}, idem="d2")
+    assert r.get_json()["accepted"] == 1  # s1 already seen, only s2 inserted
+
+
+# ── internal error → 200 (never spend OMI's 5xx failure budget) ────────────
+def test_internal_error_returns_200(tmp_path):
+    state = OmiState(tmp_path / "s.db")
+    cfg = OmiConfig(enabled=True, port=8799, uid_allowlist=frozenset({UID}), anchor_tolerance_s=60.0)
+
+    def boom(rows, recv_ts):
+        raise RuntimeError("disk exploded")
+
+    app = create_app(config=cfg, tokens=(TOKEN, ""), state=state, write_rows=boom,
+                     now_fn=Clock(), heartbeat_path=tmp_path / "hb.json")
+    app.testing = False  # let the route's own catch-all handle it, not the test reraise
+    r = app.test_client().post(f"/omi/{TOKEN}/ingest?uid={UID}", json={"segments": [_seg("s1")]})
+    assert r.status_code == 200
+    assert r.get_json()["accepted"] == 0
+    state.close()
+
+
+# ── buffers-only: the engine is never invoked from the ingest path ─────────
+def test_buffers_only_engine_never_called(ctx, monkeypatch):
+    import genesis.attention.engine as engine
+
+    called = []
+    monkeypatch.setattr(engine, "evaluate", lambda *a, **k: called.append(1), raising=False)
+    _post(ctx, {"segments": [_seg("s1")]})
+    assert called == []
+
+
+# ── anchoring through the service ──────────────────────────────────────────
+def test_reanchor_across_conversations(ctx):
+    # Conversation A at recv=1_000_000, ends ~2s in -> ts ~= recv.
+    ctx.clock.t = 1_000_000.0
+    _post(ctx, {"segments": [_seg("a1", start=0.0, end=2.0)]}, idem="a")
+    # Conversation B hours later; OMI's start/end reset to ~0 -> must re-anchor.
+    ctx.clock.t = 1_050_000.0
+    _post(ctx, {"segments": [_seg("b1", start=0.0, end=1.0)]}, idem="b")
+    # The second row's ts must reflect the NEW wall clock, not conversation A's.
+    _, row_b = ctx.written[-1]
+    from datetime import datetime
+    ts_epoch = datetime.fromisoformat(row_b.ts).timestamp()
+    assert abs(ts_epoch - 1_050_000.0) < 5  # anchored to recv, not ~1_000_000
+
+
+# ── heartbeat + log hygiene ────────────────────────────────────────────────
+def test_heartbeat_written(ctx):
+    _post(ctx, {"segments": [_seg("s1")]})
+    hb = json.loads(ctx.hb.read_text())
+    assert hb["accepted_total"] == 1
+    assert hb["last_recv_ts"] == ctx.clock.t
+    assert set(hb) >= {"started_at", "last_recv_ts", "accepted_total", "auth_failures", "internal_errors"}
+
+
+def test_auth_failure_counted(ctx):
+    _post(ctx, {"segments": [_seg("s1")]}, token="wrong")
+    hb = json.loads(ctx.hb.read_text())
+    assert hb["auth_failures"] == 1
+
+
+def test_werkzeug_logger_silenced(ctx):
+    # INFO access log would journal the secret path-token on every request.
+    assert logging.getLogger("werkzeug").level == logging.WARNING

--- a/tests/test_attention/test_omi_normalize.py
+++ b/tests/test_attention/test_omi_normalize.py
@@ -1,0 +1,171 @@
+"""Pure-function tests for the OMI transcript normalizer.
+
+Covers the three pure pieces of ``omi_normalize``:
+  * ``parse_payload`` — tolerate the real wire shape (object with ``segments`` +
+    ``session_id``) AND a bare-array fallback, both casings of ``speaker_id``.
+  * ``normalize_segments`` — map an OMI segment onto an ``ambient_transcripts``
+    row (byte-compatible with home snapshots), NEVER emitting a ``meta.audio``
+    block (that is what keeps OMI rows on PR-4's text-only clarity path).
+  * ``decide_anchor`` — the per-uid re-anchor rule that turns OMI's
+    conversation-relative ``start``/``end`` into wall-clock timestamps.
+
+All wall-clock independent: every timestamp is injected.
+"""
+import json
+
+import pytest
+
+from genesis.attention.omi_normalize import (
+    NormalizedRow,
+    decide_anchor,
+    normalize_segments,
+    parse_payload,
+)
+
+# A representative real segment (fields traced from the OMI sender source).
+_SEG = {
+    "id": "seg-uuid-1",
+    "text": "hello there world",
+    "speaker": "SPEAKER_0",
+    "speaker_id": 0,
+    "is_user": False,
+    "person_id": None,
+    "start": 2.0,
+    "end": 5.5,
+    "stt_provider": "deepgram",
+}
+
+
+# ── parse_payload ──────────────────────────────────────────────────────────
+def test_parse_payload_object_shape():
+    uid, segs = parse_payload({"segments": [_SEG], "session_id": "acct-uid"})
+    assert uid == "acct-uid"
+    assert segs == [_SEG]
+
+
+def test_parse_payload_bare_array_has_no_session_id():
+    uid, segs = parse_payload([_SEG, _SEG])
+    assert uid is None
+    assert len(segs) == 2
+
+
+def test_parse_payload_object_without_segments_is_empty():
+    uid, segs = parse_payload({"session_id": "acct-uid"})
+    assert uid == "acct-uid"
+    assert segs == []
+
+
+def test_parse_payload_non_container_is_empty():
+    assert parse_payload("garbage") == (None, [])
+    assert parse_payload(None) == (None, [])
+    assert parse_payload(42) == (None, [])
+
+
+def test_parse_payload_filters_non_dict_segments():
+    uid, segs = parse_payload({"segments": [_SEG, "junk", None, 7]})
+    assert segs == [_SEG]
+
+
+# ── normalize_segments ─────────────────────────────────────────────────────
+def test_normalize_basic_mapping():
+    rows = normalize_segments([_SEG], uid="acct-uid", epoch0=1000.0)
+    assert len(rows) == 1
+    row = rows[0]
+    assert isinstance(row, NormalizedRow)
+    assert row.segment_id == "seg-uuid-1"
+    assert row.text == "hello there world"
+    assert row.speaker_label == "SPEAKER_0"
+    assert row.duration_s == pytest.approx(3.5)  # 5.5 - 2.0
+    assert row.source == "omi"
+    assert row.provenance == "omi_webhook"
+    assert row.speaker_name is None
+    assert row.is_user == 0  # False -> 0
+
+
+def test_normalize_ts_is_epoch0_plus_start_utc_iso():
+    rows = normalize_segments([_SEG], uid="u", epoch0=1_000_000.0)
+    # epoch0 + start = 1_000_002.0; must render UTC ISO with +00:00 offset
+    assert rows[0].ts.endswith("+00:00")
+    from datetime import UTC, datetime
+
+    expected = datetime.fromtimestamp(1_000_002.0, UTC).isoformat()
+    assert rows[0].ts == expected
+
+
+def test_normalize_meta_has_omi_and_asr_feats_but_no_audio():
+    rows = normalize_segments([_SEG], uid="acct-uid", epoch0=0.0)
+    meta = json.loads(rows[0].meta)
+    assert "audio" not in meta  # critical: keeps has_audio=False text-only path
+    assert meta["omi"] == {
+        "uid": "acct-uid",
+        "segment_id": "seg-uuid-1",
+        "speaker_id": 0,
+        "person_id": None,
+        "stt_provider": "deepgram",
+    }
+    assert meta["asr_feats"]["n_tokens"] == 3  # "hello there world"
+
+
+def test_normalize_skips_empty_and_whitespace_text():
+    segs = [
+        {**_SEG, "id": "a", "text": ""},
+        {**_SEG, "id": "b", "text": "   "},
+        {**_SEG, "id": "c", "text": "real words"},
+    ]
+    rows = normalize_segments(segs, uid="u", epoch0=0.0)
+    assert [r.segment_id for r in rows] == ["c"]
+
+
+def test_normalize_clamps_negative_duration_to_zero():
+    seg = {**_SEG, "start": 5.0, "end": 2.0}  # end before start
+    rows = normalize_segments([seg], uid="u", epoch0=0.0)
+    assert rows[0].duration_s == 0.0
+
+
+def test_normalize_tolerates_camelcase_speaker_id():
+    seg = {k: v for k, v in _SEG.items() if k != "speaker_id"}
+    seg["speakerId"] = 4
+    rows = normalize_segments([seg], uid="u", epoch0=0.0)
+    meta = json.loads(rows[0].meta)
+    assert meta["omi"]["speaker_id"] == 4
+
+
+def test_normalize_missing_optional_fields_are_none():
+    seg = {"id": "x", "text": "hi", "start": 0.0, "end": 1.0}
+    rows = normalize_segments([seg], uid="u", epoch0=0.0)
+    row = rows[0]
+    assert row.speaker_label is None
+    assert row.is_user is None
+    meta = json.loads(row.meta)
+    assert meta["omi"]["speaker_id"] is None
+    assert meta["omi"]["person_id"] is None
+    assert meta["omi"]["stt_provider"] is None
+
+
+def test_normalize_is_user_true_maps_to_one():
+    rows = normalize_segments([{**_SEG, "is_user": True}], uid="u", epoch0=0.0)
+    assert rows[0].is_user == 1
+
+
+# ── decide_anchor ──────────────────────────────────────────────────────────
+def test_decide_anchor_no_state_anchors_to_recv_minus_end():
+    # First batch ever for this uid: epoch0 = recv_ts - batch_max_end
+    assert decide_anchor(None, batch_max_end=5.0, recv_ts=1000.0, tolerance=60.0) == 995.0
+
+
+def test_decide_anchor_in_window_keeps_existing_epoch0():
+    # epoch0=995 => predicted wall of this batch = 995 + 10 = 1005, recv=1006
+    # skew 1s < tolerance -> keep 995
+    assert decide_anchor(995.0, batch_max_end=10.0, recv_ts=1006.0, tolerance=60.0) == 995.0
+
+
+def test_decide_anchor_out_of_window_reanchors():
+    # Conversation rollover: start/end reset to ~0 while wall clock jumped hours.
+    # predicted = 995 + 2 = 997, recv = 9000 -> skew 8003 > tol -> re-anchor.
+    assert decide_anchor(995.0, batch_max_end=2.0, recv_ts=9000.0, tolerance=60.0) == 8998.0
+
+
+def test_decide_anchor_boundary_exactly_tolerance_keeps():
+    # skew == tolerance is NOT > tolerance -> keep (re-anchor only on strict exceed)
+    # predicted = 100 + 0 = 100, recv = 160, skew = 60 == tol -> keep 100
+    assert decide_anchor(100.0, batch_max_end=0.0, recv_ts=160.0, tolerance=60.0) == 100.0

--- a/tests/test_attention/test_omi_state.py
+++ b/tests/test_attention/test_omi_state.py
@@ -1,0 +1,91 @@
+"""Tests for the OMI advisory state store (dedup keys + per-uid anchor).
+
+The store is ADVISORY: losing it costs at most one duplicate row or ~2s of ts
+jitter, never real speech. All TTL/age logic is driven by an injected ``now`` so
+the tests never touch the wall clock.
+"""
+import pytest
+
+from genesis.attention.omi_state import (
+    IDEMPOTENCY_TTL_S,
+    SEEN_SEGMENTS_TTL_S,
+    OmiState,
+)
+
+
+@pytest.fixture()
+def state(tmp_path):
+    st = OmiState(tmp_path / "omi_state.db")
+    yield st
+    st.close()
+
+
+# ── idempotency (delivery-level) dedup ─────────────────────────────────────
+def test_idempotency_first_seen_is_not_duplicate_then_is(state):
+    assert state.is_duplicate_delivery("key-1", now=1000.0) is False
+    assert state.is_duplicate_delivery("key-1", now=1000.5) is True
+
+
+def test_idempotency_none_key_never_duplicate(state):
+    assert state.is_duplicate_delivery(None, now=1000.0) is False
+    assert state.is_duplicate_delivery(None, now=1001.0) is False
+
+
+def test_idempotency_key_expires_after_ttl(state):
+    state.is_duplicate_delivery("key-1", now=1000.0)
+    # Just past the TTL: the old key is pruned, so it reads as fresh again.
+    assert state.is_duplicate_delivery("key-1", now=1000.0 + IDEMPOTENCY_TTL_S + 1) is False
+
+
+# ── segment-uuid dedup ─────────────────────────────────────────────────────
+def test_seen_segment_ids_empty_initially(state):
+    assert state.seen_segment_ids(["a", "b"], now=1000.0) == set()
+
+
+def test_record_then_seen(state):
+    state.record_segment_ids(["a", "b"], now=1000.0)
+    assert state.seen_segment_ids(["a", "b", "c"], now=1000.5) == {"a", "b"}
+
+
+def test_record_is_idempotent(state):
+    state.record_segment_ids(["a"], now=1000.0)
+    state.record_segment_ids(["a"], now=1001.0)  # must not raise
+    assert state.seen_segment_ids(["a"], now=1001.0) == {"a"}
+
+
+def test_seen_ignores_none_ids(state):
+    state.record_segment_ids([None, "a"], now=1000.0)
+    assert state.seen_segment_ids([None, "a"], now=1000.0) == {"a"}
+
+
+def test_seen_segment_expires_after_ttl(state):
+    state.record_segment_ids(["a"], now=1000.0)
+    assert state.seen_segment_ids(["a"], now=1000.0 + SEEN_SEGMENTS_TTL_S + 1) == set()
+
+
+# ── per-uid anchor ─────────────────────────────────────────────────────────
+def test_anchor_unknown_uid_is_none(state):
+    assert state.get_anchor("nobody") is None
+
+
+def test_anchor_roundtrip(state):
+    state.set_anchor("uid-1", epoch0=995.0, max_end=10.0, now=1005.0)
+    assert state.get_anchor("uid-1") == (995.0, 10.0)
+
+
+def test_anchor_upsert_overwrites(state):
+    state.set_anchor("uid-1", epoch0=995.0, max_end=10.0, now=1005.0)
+    state.set_anchor("uid-1", epoch0=8998.0, max_end=2.0, now=9000.0)
+    assert state.get_anchor("uid-1") == (8998.0, 2.0)
+
+
+def test_advisory_loss_reanchors(tmp_path):
+    # Simulate state loss: a brand-new store on a fresh path has no anchor,
+    # so the next batch re-anchors sanely rather than crashing.
+    st1 = OmiState(tmp_path / "s.db")
+    st1.set_anchor("uid-1", epoch0=995.0, max_end=10.0, now=1005.0)
+    st1.close()
+    (tmp_path / "s.db").unlink()
+    st2 = OmiState(tmp_path / "s.db")
+    assert st2.get_anchor("uid-1") is None
+    st2.close()

--- a/tests/test_awareness/test_omi_ingest_check.py
+++ b/tests/test_awareness/test_omi_ingest_check.py
@@ -1,0 +1,111 @@
+"""Tests for _check_omi_ingest — the OMI ingest unit-liveness watcher.
+
+OMI transcripts stop SILENTLY if the ingest unit dies, so the awareness tick
+watches the unit. The check is config-gated (only alerts once the user has an
+enabled ~/.genesis/omi_config.yaml) and best-effort (never breaks the tick).
+Everything external — the config load and the systemctl probe — is injected.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.attention import omi_ingest
+from genesis.awareness import loop
+
+_DB = object()  # non-None sentinel; observations calls are mocked
+
+
+class _Cfg:  # truthy stand-in for an OmiConfig
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _mocks(monkeypatch):
+    monkeypatch.setattr(loop, "_last_omi_alert_at", None)
+    create = AsyncMock()
+    resolve = AsyncMock(return_value=0)
+    monkeypatch.setattr(loop.observations, "create", create)
+    monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
+    monkeypatch.setattr(omi_ingest, "load_omi_config", lambda: _Cfg())  # configured+enabled
+    active = AsyncMock(return_value=True)
+    monkeypatch.setattr(loop, "_systemd_unit_active", active)
+    return create, resolve, active
+
+
+@pytest.mark.asyncio
+async def test_enabled_but_unit_down_alerts(_mocks):
+    create, _, active = _mocks
+    active.return_value = False
+    await loop._check_omi_ingest(_DB)
+    create.assert_awaited_once()
+    kw = create.await_args.kwargs
+    assert kw["type"] == "infrastructure_alert"
+    assert kw["source"] == "omi_ingest_monitor"
+    assert kw["skip_if_duplicate"] is True
+    assert kw.get("content_hash")
+    assert "omi" in kw["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_enabled_and_active_resolves(_mocks):
+    create, resolve, _ = _mocks
+    await loop._check_omi_ingest(_DB)
+    create.assert_not_awaited()
+    resolve.assert_awaited_once()  # healthy → clear any stale alert
+
+
+@pytest.mark.asyncio
+async def test_not_configured_short_circuits(_mocks, monkeypatch):
+    create, _, active = _mocks
+    monkeypatch.setattr(omi_ingest, "load_omi_config", lambda: None)
+    await loop._check_omi_ingest(_DB)
+    create.assert_not_awaited()
+    active.assert_not_awaited()  # never probe systemctl if OMI isn't configured
+
+
+@pytest.mark.asyncio
+async def test_indeterminate_unit_state_no_alert_no_resolve(_mocks):
+    create, resolve, active = _mocks
+    active.return_value = None  # systemctl couldn't be determined → don't guess
+    await loop._check_omi_ingest(_DB)
+    create.assert_not_awaited()
+    resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_second_alert(_mocks):
+    create, _, active = _mocks
+    active.return_value = False
+    await loop._check_omi_ingest(_DB)
+    await loop._check_omi_ingest(_DB)
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_db_none_noop(_mocks):
+    create, _, active = _mocks
+    await loop._check_omi_ingest(None)
+    create.assert_not_awaited()
+    active.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_config_does_not_alert(_mocks, monkeypatch):
+    create, _, active = _mocks
+
+    def boom():
+        raise ValueError("bad yaml")
+
+    monkeypatch.setattr(omi_ingest, "load_omi_config", boom)
+    await loop._check_omi_ingest(_DB)
+    create.assert_not_awaited()  # malformed config is a separate concern, not "down"
+
+
+@pytest.mark.asyncio
+async def test_check_never_raises(_mocks):
+    create, _, active = _mocks
+    active.side_effect = RuntimeError("systemctl blew up")
+    await loop._check_omi_ingest(_DB)  # must not propagate into the tick
+    create.assert_not_awaited()


### PR DESCRIPTION
## PR-5: OMI off-prem wearable connector (attention Track 2)

Feeds OMI wearable conversation transcripts into the attention engine's passive-listening tier, so off-prem conversations get the same shadow "perk up?" judgment as home ambient. **Consume, don't rebuild** — OMI already does capture + STT; this consumes its real-time transcript webhook. Final piece of the approved attention-engine plan (PR-4 shipped the `has_audio`/`source` engine changes this builds on).

### What it does
The OMI app POSTs live transcripts to a dedicated single-route Flask receiver on `127.0.0.1:8799`, exposed publicly **only** via a Tailscale Funnel behind a secret URL path-token + uid allowlist. The receiver normalizes segments and writes them into per-UTC-day snapshot dbs (`omi_YYYYMMDD.db`) that the **existing, unchanged** `SnapshotSource` / offline runner / reveal / retention-GC machinery already consumes.

### Design highlights
- **Buffers-only.** Transcripts land in day-dbs for the shadow pass; the L1.5 judge (household-text cloud egress) stays manual + per-run user-gated. No auto-egress.
- **Standalone service** — no `GenesisRuntime`/engine import, so the exposed surface can't reach the rest of Genesis. Sandboxed systemd unit: narrowed `ReadWritePaths=%h/.genesis/attention`, `IPAddressDeny=any`+`IPAddressAllow=localhost` (kernel-enforced never-egress), no `TMPDIR` override.
- **OMI-shaped error policy.** OMI auto-disables the webhook after 100 cumulative non-2xx responses (counter never resets), so post-auth the service **never returns 429/5xx** — overload/internal-error drop-with-200. A response `message` key would push-notify the user's phone, so no handler emits one.
- **Per-uid anchor state machine.** OMI's `session_id` is the account uid (stable forever, not per-conversation) and `start`/`end` are conversation-relative, resetting each conversation. A tolerance-based re-anchor rule reconstructs wall-clock timestamps; dedup (delivery Idempotency-Key → segment uuid) runs before any anchor mutation, and the anchor is persisted only after the day-db write succeeds.
- **Byte-compatible day-dbs** — exactly the 10-column `ambient_transcripts` schema, no `meta.audio` block (keeps OMI rows on the text-only clarity path), filenames matching the GC regex `^omi_\d{8}\.db$`.
- **Awareness-tick watcher** wired in: alerts if the unit dies while configured+enabled (off-prem transcripts stop silently otherwise). Config-gated + best-effort.

### New modules
`attention/omi_normalize.py` (pure), `attention/omi_state.py` (advisory dedup + anchor), `attention/omi_daydb.py` (day-db writer), `attention/omi_ingest.py` (the service); `_check_omi_ingest` in `awareness/loop.py`; systemd template + `config/omi_config.yaml.example` + `secrets.env.example` additions.

### Verification
- 60 targeted unit tests (normalize/state/daydb/ingest/watcher); full attention (249) + awareness (149) suites green; ruff clean; subsystem-map guard clean.
- Reviewed by a focused code-review agent against six load-bearing constraints — no findings at ≥80 confidence; two sub-threshold observations addressed (anchor-persist ordering, `max_end` documented).
- **Live E2E through the real running service** (no `--l15`): auth matrix (401/403/400), delivery + segment dedup, re-anchor across conversations, day-db round-trip through `SnapshotSource` (`has_audio=False`/`source=omi`), offline runner persisting an event tagged `snapshot=omi_YYYYMMDD`/`source=omi`, **firewall verified** (no transcript text in genesis.db), GC dry-run recognizing `omi_*.db`, systemd unit parses clean.

### Deploy (all user-gated, after merge)
webhook.site ground-truth capture → install unit + `omi_config.yaml` + `OMI_INGEST_SECRET_TOKEN` → Tailscale Funnel 443→localhost:8799 → set OMI app webhook URL → user-gated `--l15` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
