### PR TITLE
feat(autonomy): BuildLane — activate the capability-build lane (PR-6, dark)

### DIFF
--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -124,6 +124,7 @@ class AutonomousCliApprovalGate:
         "autonomous_cli_fallback",
         "sentinel_dispatch",
         "sentinel_action",
+        "build_greenlight",
     })
 
     def __init__(
@@ -867,6 +868,35 @@ class AutonomousCliApprovalGate:
                 "",
                 f"Request ID: <code>{request_id}</code>",
             ]
+        elif action_type == "build_greenlight":
+            title = extra.get("title") or action_label
+            summary = extra.get("summary", "")
+            steps_count = extra.get("steps_count")
+            paths = extra.get("intended_paths") or []
+            plan_path = extra.get("plan_path", "")
+            lines = [
+                "<b>🔨 Build Greenlight</b>",
+                "",
+                "Genesis wants to autonomously build this capability and open "
+                "a <b>draft PR</b> (human review + merge always required):",
+                "",
+                f"<b>{title}</b>",
+            ]
+            if summary:
+                lines.append(summary)
+            scope_bits = []
+            if steps_count:
+                scope_bits.append(f"{steps_count} step(s)")
+            if paths:
+                shown = ", ".join(str(p) for p in paths[:4])
+                if len(paths) > 4:
+                    shown += f" (+{len(paths) - 4} more)"
+                scope_bits.append(f"touches {shown}")
+            if scope_bits:
+                lines.extend(["", f"<b>Scope:</b> {' · '.join(scope_bits)}"])
+            if plan_path:
+                lines.append(f"<b>Plan:</b> <code>{plan_path}</code>")
+            lines.append(f"Request ID: <code>{request_id}</code>")
         else:
             lines = [
                 "<b>Approval Needed</b>",

--- a/src/genesis/autonomy/build_lane.py
+++ b/src/genesis/autonomy/build_lane.py
@@ -30,7 +30,6 @@ import hashlib
 import json
 import logging
 import uuid
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -245,9 +244,12 @@ class BuildLane:
             return None
         intended_paths = _as_list(build_spec.get("intended_paths"))
 
-        date = datetime.now(UTC).strftime("%Y-%m-%d")
+        # Deterministic filename (no date): permanent item_key dedup means a
+        # key is materialized at most once, so the date added no uniqueness —
+        # only a crash-retry idempotency gap (the path is folded into the
+        # greenlight approval_key). The row's created_at carries the timestamp.
         _PLANS_DIR.mkdir(parents=True, exist_ok=True)
-        path = _PLANS_DIR / f"build-{item_key[:8]}-{date}.md"
+        path = _PLANS_DIR / f"build-{item_key[:8]}.md"
 
         lines: list[str] = [
             f"# Build: {title}",
@@ -364,8 +366,11 @@ class BuildLane:
                 logger.info("build_lane: candidate %s rejected", cand["id"])
 
     async def _reconcile_submitted(self) -> None:
-        for cand in await build_candidates.list_recent(self._db, limit=100):
-            if cand.get("outcome") != "submitted" or not cand.get("task_id"):
+        # Query submitted rows directly (indexed) — a recency-bounded scan
+        # would drop an in-flight candidate out of the window as unrelated
+        # calibration rows pile up, stranding it at 'submitted' forever.
+        for cand in await build_candidates.list_by_outcome(self._db, "submitted"):
+            if not cand.get("task_id"):
                 continue
             task = await task_states.get_by_id(self._db, cand["task_id"])
             if not task:

--- a/src/genesis/autonomy/build_lane.py
+++ b/src/genesis/autonomy/build_lane.py
@@ -1,0 +1,420 @@
+"""BuildLane — the autonomous capability-build lane's control service.
+
+Closes the Stage-1 loop that the rest of the V1 groundwork left dark:
+
+    inbox eval `build` verdict
+        -> materialize a dispatcher-ready plan (fail-closed)
+        -> record a build_candidate + send a one-tap greenlight card
+        -> (user taps) -> dispatcher.submit(source='build_lane')
+        -> existing executor delivery (scope gate + draft PR, NEVER a merge)
+        -> reconcile the candidate's outcome from task state
+
+Nothing builds without a tap; the greenlight card IS the approval gate for
+the whole build chain (mirroring the /task-submission = approval-for-steps
+precedent). ``dont_build`` / ``needs_discussion`` verdicts record a
+calibration row only — never a card, never a queued build.
+
+Dedup is permanent on ``item_key`` (title/URL, excluding next_step): a
+capability stays in the notepad after it is built and is re-evaluated on
+every rescan, so we skip any item that already has a candidate row. A
+genuine title/URL edit changes the key and legitimately re-proposes.
+
+The lane ships behind ``build_lane.enabled`` (default OFF). When disabled,
+``handle_eval`` / ``poll_pending`` are no-ops and the runtime never spawns
+the poll loop.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from genesis.db.crud import build_candidates, task_states
+from genesis.inbox.recommendation import parse_recommendations
+from genesis.inbox.scanner import extract_urls, normalize_url_line
+
+logger = logging.getLogger(__name__)
+
+_PLANS_DIR = Path.home() / ".genesis" / "plans"
+
+# Task phases that mean "delivery has run" — reconcile the candidate outcome.
+_TERMINAL_PHASES = frozenset({"completed", "failed", "cancelled"})
+
+
+class BuildLane:
+    """Consumes capability-build verdicts and drives them to draft PRs."""
+
+    def __init__(
+        self,
+        *,
+        db: aiosqlite.Connection,
+        dispatcher: Any,
+        approval_gate: Any,
+        enabled: bool,
+    ) -> None:
+        self._db = db
+        self._dispatcher = dispatcher
+        self._gate = approval_gate
+        self._enabled = bool(enabled)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    # -- keys -------------------------------------------------------------
+
+    @staticmethod
+    def item_key(title: str) -> str:
+        """Stable per-notepad-item key: sha256 of the tracking-normalized
+        primary URL, or the lowercased title when there is no URL.
+
+        Deliberately excludes ``next_step`` (which varies run-to-run) so the
+        same item maps to the same key across re-evaluations. A title/URL
+        edit changes the key — that is the intended re-proposal signal.
+        """
+        text = (title or "").strip()
+        urls = extract_urls(text)
+        primary = normalize_url_line(urls[0]) if urls else text.lower()
+        return hashlib.sha256(f"inbox_build|{primary}".encode()).hexdigest()
+
+    # -- eval intake ------------------------------------------------------
+
+    async def handle_eval(
+        self,
+        *,
+        evaluation_text: str,
+        batch_id: str,
+        item: Any,
+        response_path: Any = None,
+    ) -> int:
+        """Process an inbox evaluation for capability-build verdicts.
+
+        Returns the number of NEW candidate rows created (0 when disabled or
+        when every verdict item is already tracked). Never raises — the
+        caller wires this as a non-fatal hook.
+        """
+        if not self._enabled:
+            return 0
+
+        source_file = getattr(item, "file_path", "") or ""
+        eval_path = str(response_path) if response_path else None
+        created = 0
+
+        for rec in parse_recommendations(evaluation_text):
+            if rec.verdict is None:
+                continue
+            title = (rec.item_title or "").strip()
+            if not title:
+                logger.debug("build verdict with empty title — skipping")
+                continue
+            key = self.item_key(title)
+
+            # Permanent dedup: one candidate per item_key, any decision state.
+            if await build_candidates.get_any_by_item_key(self._db, key):
+                logger.debug("build item already tracked (%s) — skipping", title)
+                continue
+
+            try:
+                if rec.verdict == "build":
+                    made = await self._handle_build(
+                        rec=rec, key=key, title=title,
+                        source_file=source_file, batch_id=batch_id,
+                        eval_path=eval_path,
+                    )
+                else:  # dont_build | needs_discussion — calibration row only
+                    made = await self._record_calibration(
+                        rec=rec, key=key, title=title, verdict=rec.verdict,
+                        source_file=source_file, batch_id=batch_id,
+                        eval_path=eval_path,
+                    )
+                created += made
+            except aiosqlite.IntegrityError:
+                # Race: another writer inserted an open candidate for this
+                # key between the dedup check and the insert. Deduped.
+                logger.debug("build candidate race on %s — deduped", title)
+            except Exception:
+                logger.warning(
+                    "build_lane: failed to process verdict for %s (non-fatal)",
+                    title, exc_info=True,
+                )
+
+        return created
+
+    async def _handle_build(
+        self, *, rec: Any, key: str, title: str,
+        source_file: str, batch_id: str, eval_path: str | None,
+    ) -> int:
+        """Materialize a plan, send a greenlight card, record the candidate.
+
+        Card-first-then-row: because the greenlight ``extra_context`` is
+        reconstructable from row fields, ``ensure_approval`` is idempotent on
+        its stable approval_key, so a crash between card and row re-cards to
+        the same request on the next eval instead of stranding the item.
+        """
+        plan_path = self._materialize_plan(key, title, rec.build_spec)
+        if plan_path is None:
+            # Malformed/empty build_spec — fail closed to needs_discussion.
+            logger.info(
+                "build_spec unusable for %s — recording as needs_discussion", title,
+            )
+            return await self._record_calibration(
+                rec=rec, key=key, title=title, verdict="needs_discussion",
+                source_file=source_file, batch_id=batch_id, eval_path=eval_path,
+            )
+
+        extra = self._greenlight_extra(
+            title=title, build_spec=rec.build_spec, plan_path=plan_path,
+        )
+        _status, request_id, _reason = await self._gate.ensure_approval(
+            subsystem="build_lane",
+            policy_id="build_greenlight",
+            action_label=f"Build: {title[:60]} [{key[:8]}]",
+            invocation=None,
+            action_type="build_greenlight",
+            extra_context=extra,
+        )
+
+        await build_candidates.create(
+            self._db,
+            id=_new_id(),
+            item_key=key,
+            item_title=title,
+            source_file=source_file,
+            verdict="build",
+            batch_id=batch_id,
+            eval_path=eval_path,
+            verdict_reason=rec.verdict_reason,
+            confidence=rec.confidence,
+            build_spec=json.dumps(rec.build_spec),
+            plan_path=plan_path,
+            approval_request_id=request_id,
+        )
+        logger.info(
+            "build_lane: greenlight card sent for %s (candidate carded, req=%s)",
+            title, request_id,
+        )
+        return 1
+
+    async def _record_calibration(
+        self, *, rec: Any, key: str, title: str, verdict: str,
+        source_file: str, batch_id: str, eval_path: str | None,
+    ) -> int:
+        """Record a report-only calibration row (no card, no plan)."""
+        await build_candidates.create(
+            self._db,
+            id=_new_id(),
+            item_key=key,
+            item_title=title,
+            source_file=source_file,
+            verdict=verdict,
+            batch_id=batch_id,
+            eval_path=eval_path,
+            verdict_reason=rec.verdict_reason,
+            confidence=rec.confidence,
+            build_spec=json.dumps(rec.build_spec) if rec.build_spec else None,
+        )
+        logger.info("build_lane: recorded %s calibration row for %s", verdict, title)
+        return 1
+
+    # -- plan materialization --------------------------------------------
+
+    def _materialize_plan(
+        self, item_key: str, title: str, build_spec: Any,
+    ) -> str | None:
+        """Render a dispatcher-ready plan, or None if the spec is unusable.
+
+        Fail-closed: a missing spec or ANY empty required list returns None
+        so the caller downgrades to needs_discussion. The four exact section
+        headers required by ``dispatcher._validate_plan_content`` are emitted
+        verbatim as whole lines.
+        """
+        if not isinstance(build_spec, dict):
+            return None
+        requirements = _as_list(build_spec.get("requirements"))
+        steps = _as_list(build_spec.get("steps"))
+        success = _as_list(build_spec.get("success_criteria"))
+        risks = _as_list(build_spec.get("risks"))
+        if not (requirements and steps and success and risks):
+            return None
+        intended_paths = _as_list(build_spec.get("intended_paths"))
+
+        date = datetime.now(UTC).strftime("%Y-%m-%d")
+        _PLANS_DIR.mkdir(parents=True, exist_ok=True)
+        path = _PLANS_DIR / f"build-{item_key[:8]}-{date}.md"
+
+        lines: list[str] = [
+            f"# Build: {title}",
+            "",
+            "> Autonomous capability-build lane. Draft PR only — never a merge.",
+            "> Scope-gated to capability trees; out-of-tree writes are blocked.",
+            "",
+            "## Requirements",
+            "",
+        ]
+        lines += [f"- {r}" for r in requirements]
+        lines += ["", "## Steps", ""]
+        for i, step in enumerate(steps, 1):
+            if isinstance(step, dict):
+                stype = str(step.get("type", "code"))
+                desc = str(step.get("description", "")).strip() or "(no description)"
+            else:
+                stype, desc = "code", str(step)
+            lines.append(f"{i}. ({stype}) {desc}")
+        if intended_paths:
+            lines += ["", "Intended paths (scope-gated):"]
+            lines += [f"- {p}" for p in intended_paths]
+        lines += ["", "## Success Criteria", ""]
+        lines += [f"- {c}" for c in success]
+        lines += ["", "## Risks and Failure Modes", ""]
+        lines += [f"- {r}" for r in risks]
+        lines.append("")
+
+        path.write_text("\n".join(lines))
+        return str(path)
+
+    @staticmethod
+    def _greenlight_extra(
+        *, title: str, build_spec: Any, plan_path: str,
+    ) -> dict[str, Any]:
+        """Card context — deterministic from row-stored fields so the
+        approval_key stays stable across a card-then-row crash re-card."""
+        spec = build_spec if isinstance(build_spec, dict) else {}
+        steps = _as_list(spec.get("steps"))
+        paths = _as_list(spec.get("intended_paths"))
+        return {
+            "title": title,
+            "steps_count": len(steps),
+            "intended_paths": [str(p) for p in paths],
+            "plan_path": plan_path,
+        }
+
+    # -- greenlight resolution + outcome reconcile -----------------------
+
+    async def poll_pending(self) -> None:
+        """Resolve tapped greenlight cards and reconcile submitted builds.
+
+        Pass 1: open candidates with a greenlight card — approved -> consume
+        + submit; rejected -> record + abandon. Pass 2: submitted candidates
+        whose task has reached a terminal phase — reconcile the outcome from
+        task state (the engine writes task outputs, never build_candidates).
+        Never raises.
+        """
+        if not self._enabled:
+            return
+        try:
+            await self._resolve_cards()
+            await self._reconcile_submitted()
+        except Exception:
+            logger.warning("build_lane poll_pending failed (non-fatal)", exc_info=True)
+
+    async def _resolve_cards(self) -> None:
+        for cand in await build_candidates.list_open(self._db):
+            request_id = cand.get("approval_request_id")
+            if not request_id or cand.get("task_id"):
+                # Calibration rows (no card) or already-submitted — skip.
+                continue
+            req = await self._gate.get_request(request_id)
+            if not req:
+                continue
+            status = str(req.get("status") or "")
+            if status == "approved":
+                # Atomic single-consume — a lost race means another path
+                # already handled this tap; do not double-submit.
+                if not await self._gate.mark_consumed(request_id):
+                    continue
+                await build_candidates.record_user_decision(
+                    self._db, cand["id"], user_decision="approved",
+                )
+                try:
+                    task_id = await self._dispatcher.submit(
+                        cand["plan_path"],
+                        cand["item_title"],
+                        source="build_lane",
+                    )
+                except Exception:
+                    logger.error(
+                        "build_lane: dispatch failed for candidate %s",
+                        cand["id"], exc_info=True,
+                    )
+                    await build_candidates.update(
+                        self._db, cand["id"], outcome="build_failed",
+                    )
+                    continue
+                await build_candidates.update(
+                    self._db, cand["id"], task_id=task_id, outcome="submitted",
+                )
+                logger.info(
+                    "build_lane: candidate %s approved -> task %s dispatched",
+                    cand["id"], task_id,
+                )
+            elif status == "rejected":
+                await build_candidates.record_user_decision(
+                    self._db, cand["id"], user_decision="rejected",
+                )
+                await build_candidates.update(
+                    self._db, cand["id"], outcome="abandoned",
+                )
+                logger.info("build_lane: candidate %s rejected", cand["id"])
+
+    async def _reconcile_submitted(self) -> None:
+        for cand in await build_candidates.list_recent(self._db, limit=100):
+            if cand.get("outcome") != "submitted" or not cand.get("task_id"):
+                continue
+            task = await task_states.get_by_id(self._db, cand["task_id"])
+            if not task:
+                continue
+            phase = str(task.get("current_phase") or "")
+            if phase not in _TERMINAL_PHASES:
+                continue  # still running
+            outputs = _parse_outputs(task.get("outputs"))
+            branch = outputs.get("branch")
+            pr_url = outputs.get("pr_url")
+            scope_gate = outputs.get("scope_gate")
+            if outputs.get("scope_blocked"):
+                outcome = "scope_blocked"
+            elif pr_url:
+                outcome = "pr_opened"
+            elif branch:  # pushed but PR-open failed
+                outcome = "built"
+            else:
+                outcome = "build_failed"
+            await build_candidates.update(
+                self._db, cand["id"],
+                outcome=outcome,
+                branch=branch,
+                pr_url=pr_url,
+                scope_gate_result=scope_gate,
+            )
+            logger.info(
+                "build_lane: candidate %s reconciled -> %s", cand["id"], outcome,
+            )
+
+
+def _new_id() -> str:
+    return f"bc-{uuid.uuid4().hex[:12]}"
+
+
+def _as_list(value: Any) -> list:
+    """Coerce a build_spec field to a list of non-empty entries."""
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [v for v in value if v not in (None, "")]
+    return [value]
+
+
+def _parse_outputs(raw: Any) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -50,6 +50,7 @@ _DEFAULT_APPROVAL_TIMEOUTS: dict[str, int | None] = {
     "autonomous_cli_fallback": None,
     "sentinel_dispatch": None,
     "sentinel_action": None,
+    "build_greenlight": None,
     "irreversible": None,
 }
 

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -146,6 +146,15 @@ class CCSessionExecutor:
 
         description = task.get("description", "")
 
+        # Build-lane tasks upgrade their CODE/VERIFICATION steps to Opus
+        # (quality-over-cost for autonomous builds); every other source, and
+        # all non-code step types, stay on Sonnet. Resolved once per run from
+        # the already-loaded task row (no extra read).
+        model_override = None
+        if task.get("source") == "build_lane":
+            from genesis.cc.types import CCModel
+            model_override = CCModel.OPUS
+
         # Deliverable-frame tasks route delivery differently (hand the user the
         # rendered file, not a git branch). Keyed on plan_content so it survives
         # resume, where reconstructed step dicts have no `skills` key.
@@ -398,6 +407,7 @@ class CCSessionExecutor:
                 result = await self._step_dispatcher.execute_step(
                     task_id, step, step_results,
                     worktree_path=self._worktree_paths.get(task_id),
+                    model_override=model_override,
                 )
                 step_results.append(result)
 
@@ -445,6 +455,7 @@ class CCSessionExecutor:
                             task_id, step, step_results,
                             workaround=dd_context,
                             worktree_path=wt_path,
+                            model_override=model_override,
                         )
                         if dd_retry.status == "completed":
                             step_results[-1] = dd_retry
@@ -492,6 +503,7 @@ class CCSessionExecutor:
                                 task_id, step, step_results,
                                 workaround=suggested,
                                 worktree_path=wt_path,
+                                model_override=model_override,
                             )
                             if retry.status == "completed":
                                 step_results[-1] = retry
@@ -566,6 +578,7 @@ class CCSessionExecutor:
                     fixup_result = await self._step_dispatcher.execute_step(
                         task_id, fixup, step_results,
                         worktree_path=self._worktree_paths.get(task_id),
+                        model_override=model_override,
                     )
                     step_results.append(fixup_result)
                     deliverable = _dispatch.synthesize_deliverable(step_results)

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -439,6 +439,7 @@ class CCSessionExecutor:
                     recovered = await self._step_dispatcher.try_workaround(
                         task_id, step, result, step_results,
                         worktree_path=wt_path,
+                        model_override=model_override,
                     )
                     if recovered is not None:
                         step_results[-1] = recovered
@@ -477,6 +478,7 @@ class CCSessionExecutor:
                             task_id, step, result, step_results,
                             due_diligence_results=dd_context,
                             worktree_path=wt_path,
+                            model_override=model_override,
                         )
                     )
                     if researched is not None:

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -55,11 +55,15 @@ class StepDispatcher:
         *,
         workaround: str | None = None,
         worktree_path: Path | None = None,
+        model_override: Any = None,
     ) -> StepResult:
         """Execute and record a single step via CC session.
 
         Wraps ``dispatch_step`` with DB recording (started_at,
         status, result_json, cost, session_id, model_used).
+
+        ``model_override`` (a ``CCModel``) upgrades CODE/VERIFICATION steps
+        only — used by the build lane to run those steps on Opus.
         """
         from genesis.db.crud import task_steps
 
@@ -78,6 +82,7 @@ class StepDispatcher:
                 task_id, step, prior_results,
                 workaround=workaround,
                 worktree_path=worktree_path,
+                model_override=model_override,
             )
         except Exception as exc:
             duration = time.monotonic() - start
@@ -118,6 +123,7 @@ class StepDispatcher:
         *,
         workaround: str | None = None,
         worktree_path: Path | None = None,
+        model_override: Any = None,
     ) -> StepResult:
         """Dispatch step to a CC session or deterministic executor.
 
@@ -169,16 +175,23 @@ class StepDispatcher:
             working_dir = background_session_dir()
 
         # Effort: HIGH for code/verification, MEDIUM otherwise
-        effort = (
-            EffortLevel.HIGH
-            if step_type in (StepType.CODE, StepType.VERIFICATION)
-            else EffortLevel.MEDIUM
+        is_code_or_verify = step_type in (StepType.CODE, StepType.VERIFICATION)
+        effort = EffortLevel.HIGH if is_code_or_verify else EffortLevel.MEDIUM
+
+        # Model: SONNET by default; a build-lane task upgrades its CODE and
+        # VERIFICATION steps to the override model (Opus). Research/analysis/
+        # synthesis stay on SONNET regardless — quality-over-cost applies to
+        # the steps that write and check code.
+        model = (
+            model_override
+            if (model_override is not None and is_code_or_verify)
+            else CCModel.SONNET
         )
 
         invocation = CCInvocation(
             prompt=prompt,
             expect_output=True,  # silent-cap detection (step needs a result)
-            model=CCModel.SONNET,
+            model=model,
             effort=effort,
             timeout_s=step_type.default_timeout_s,
             skip_permissions=True,

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -344,6 +344,7 @@ class StepDispatcher:
         step_results: list[StepResult],
         *,
         worktree_path: Path | None = None,
+        model_override: Any = None,
     ) -> StepResult | None:
         """Attempt workaround for a failed step. Returns new result or None."""
         if not self._workaround:
@@ -363,11 +364,12 @@ class StepDispatcher:
         if wa_result is None or not wa_result.found or not wa_result.approach:
             return None
 
-        # Retry with workaround context
+        # Retry with workaround context (preserve any build-lane model upgrade)
         retry = await self.execute_step(
             task_id, step, step_results,
             workaround=wa_result.approach,
             worktree_path=worktree_path,
+            model_override=model_override,
         )
         return retry if retry.status == "completed" else None
 
@@ -400,6 +402,7 @@ class StepDispatcher:
         due_diligence_results: str | None = None,
         *,
         worktree_path: Path | None = None,
+        model_override: Any = None,
     ) -> tuple[StepResult | None, ResearchResult | None]:
         """Dispatch research session. Returns (retry_result, research_result).
 
@@ -424,11 +427,12 @@ class StepDispatcher:
         if research_result is None or not research_result.found:
             return None, research_result
 
-        # Retry with research-derived approach
+        # Retry with research-derived approach (preserve build-lane model upgrade)
         retry = await self.execute_step(
             task_id, step, step_results,
             workaround=research_result.approach,
             worktree_path=worktree_path,
+            model_override=model_override,
         )
         if retry.status == "completed":
             return retry, research_result

--- a/src/genesis/db/crud/build_candidates.py
+++ b/src/genesis/db/crud/build_candidates.py
@@ -150,6 +150,26 @@ async def list_recent(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def list_by_outcome(
+    db: aiosqlite.Connection, outcome: str
+) -> list[dict]:
+    """All candidates in a given *outcome*, oldest first.
+
+    Uses ``idx_build_candidates_outcome``. Unlike a recency-bounded scan,
+    this never drops an in-flight candidate out of the window as unrelated
+    calibration rows accumulate — the reconcile loop must see EVERY
+    ``submitted`` row until its task reaches a terminal phase.
+    """
+    if outcome not in OUTCOMES:
+        raise ValueError(f"invalid outcome: {outcome!r}")
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates WHERE outcome = ? "
+        "ORDER BY created_at ASC",
+        (outcome,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
 async def record_user_decision(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/db/crud/build_candidates.py
+++ b/src/genesis/db/crud/build_candidates.py
@@ -35,9 +35,15 @@ async def create(
     confidence: str | None = None,
     build_spec: str | None = None,
     plan_path: str | None = None,
+    approval_request_id: str | None = None,
     created_at: str | None = None,
 ) -> str:
     """Insert a new candidate row (outcome starts at 'pending').
+
+    ``approval_request_id`` is set at insert time for ``build`` candidates
+    (the greenlight card is sent first, then the row records its request id)
+    so a crash between card and row simply re-cards idempotently on the next
+    eval rather than stranding a carded-but-unrecorded item.
 
     Raises ``aiosqlite.IntegrityError`` if an OPEN candidate for the same
     ``item_key`` already exists (partial unique index) — callers treat that
@@ -47,12 +53,12 @@ async def create(
         """INSERT INTO build_candidates
            (id, item_key, item_title, source_file, batch_id, eval_path,
             verdict, verdict_reason, confidence, build_spec, plan_path,
-            created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            approval_request_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                    COALESCE(?, datetime('now')), COALESCE(?, datetime('now')))""",
         (id, item_key, item_title, source_file, batch_id, eval_path,
          verdict, verdict_reason, confidence, build_spec, plan_path,
-         created_at, created_at),
+         approval_request_id, created_at, created_at),
     )
     await db.commit()
     return id
@@ -74,6 +80,27 @@ async def get_open_by_item_key(
     cursor = await db.execute(
         "SELECT * FROM build_candidates "
         "WHERE item_key = ? AND user_decision IS NULL",
+        (item_key,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_any_by_item_key(
+    db: aiosqlite.Connection, item_key: str
+) -> dict | None:
+    """Return the most recent candidate for *item_key*, ANY decision state.
+
+    The partial unique index only guards OPEN (undecided) rows, so it does
+    not stop a *decided* item from being re-inserted. A capability-notepad
+    item stays in the file after it is built and is re-evaluated on every
+    rescan — this is the permanent dedup axis that prevents re-carding an
+    already-adjudicated item. A genuine title/URL edit changes the item_key
+    and legitimately produces a fresh candidate.
+    """
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates "
+        "WHERE item_key = ? ORDER BY created_at DESC LIMIT 1",
         (item_key,),
     )
     row = await cursor.fetchone()

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -283,6 +283,26 @@ def ollama_enabled() -> bool:
     return False
 
 
+def build_lane_enabled() -> bool:
+    """Check if the autonomous capability-build lane is active.
+
+    Defaults to False — the lane ships dark. When enabled, a ``build``
+    verdict on a capability-notepad drop produces a one-tap greenlight
+    card whose approval dispatches an autonomous build to a draft PR
+    (never a merge). Set GENESIS_BUILD_LANE_ENABLED=true in secrets.env
+    or build_lane.enabled in ~/.genesis/config/genesis.yaml. A flag flip
+    requires a server restart to take effect (the poll loop is only
+    spawned when enabled).
+    """
+    env_val = os.environ.get("GENESIS_BUILD_LANE_ENABLED")
+    if env_val is not None:
+        return env_val.strip().lower() not in {"0", "false", "no", "off"}
+    local_val = _local_config().get("build_lane", {}).get("enabled")
+    if local_val is not None:
+        return bool(local_val)
+    return False
+
+
 def user_timezone() -> str:
     """User's local timezone (IANA format).
 

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -202,6 +202,11 @@ class InboxMonitor:
         self._check_lock = asyncio.Lock()
         self._triage_pipeline = triage_pipeline
         self._autonomous_dispatcher = None
+        self._build_lane = None
+
+    def set_build_lane(self, build_lane: object) -> None:
+        """Wire the capability-build lane (late-bound after autonomy+tasks init)."""
+        self._build_lane = build_lane
 
     @property
     def config(self) -> InboxConfig:
@@ -1495,6 +1500,23 @@ class InboxMonitor:
                     "Follow-up creation from inbox eval failed (non-fatal)",
                     exc_info=True,
                 )
+
+            # Capability-build lane (non-fatal, no-op unless enabled + wired):
+            # consumes `build` verdicts into greenlight cards. Independent of
+            # follow-up creation — BUILD verdicts never become follow-ups.
+            if self._build_lane is not None:
+                try:
+                    await self._build_lane.handle_eval(
+                        evaluation_text=output_text,
+                        batch_id=batch_id,
+                        item=item,
+                        response_path=response_path,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Build-lane eval handling failed (non-fatal)",
+                        exc_info=True,
+                    )
 
         # URL-fetch give-up -> mark failed (retry); do NOT baseline these lines.
         if _has_url_failures(output_text, item.content):

--- a/src/genesis/runtime/_capabilities.py
+++ b/src/genesis/runtime/_capabilities.py
@@ -54,7 +54,7 @@ _CAPABILITY_DESCRIPTIONS: dict[str, str] = {
     "modules": "Capability module registry — domain-specific add-on modules (prediction markets, crypto ops)",
     "pipeline": "Pipeline orchestrator — signal collection, triage, and module dispatch cycles",
     "memory_extraction": "Periodic cross-session memory extraction — entities, decisions, relationships from conversation transcripts",
-    "tasks": "Task executor — autonomous multi-step task execution with adversarial review, pause/resume/cancel",
+    "tasks": "Task executor — autonomous multi-step task execution with adversarial review, pause/resume/cancel; hosts the capability-build lane (inbox build verdicts → greenlight card → scope-gated draft PR)",
     "guardian": "External host VM guardian — container health monitoring, diagnosis, and recovery",
     "guardian_monitoring": "Guardian bidirectional monitoring — detects stale Guardian heartbeat and auto-restarts via SSH",
     "sentinel": "Container-side guardian — autonomous CC call site for infrastructure diagnosis and remediation, counterpart to external Guardian",

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -234,6 +234,8 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._task_executor: object | None = None
         self._task_dispatcher: object | None = None
         self._task_dispatch_poll: asyncio.Task | None = None
+        self._build_lane: object | None = None
+        self._build_lane_poll: asyncio.Task | None = None
         self._direct_session_runner: object | None = None
         self._direct_session_poll: asyncio.Task | None = None
         self._ego_session: object | None = None  # User ego (primary)

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -131,6 +131,65 @@ async def init(rt: GenesisRuntime) -> None:
             _dispatch_poll_loop(), name="task-dispatch-poll",
         )
 
+        # Capability-build lane: consumes inbox `build` verdicts into one-tap
+        # greenlight cards and drives approved builds to draft PRs via the
+        # dispatcher. Ships dark (build_lane.enabled default OFF). Always
+        # constructed so the monitor hook is a clean no-op when disabled; the
+        # poll loop is spawned ONLY when enabled (no idle churn while dark).
+        try:
+            from genesis.autonomy.build_lane import BuildLane
+            from genesis.env import build_lane_enabled
+
+            gate = getattr(rt, "_autonomous_cli_approval_gate", None)
+            bl_enabled = build_lane_enabled()
+            if bl_enabled and gate is None:
+                logger.warning(
+                    "build_lane.enabled=true but the approval gate is "
+                    "unavailable — lane forced OFF (greenlight cards require "
+                    "the gate)",
+                )
+                bl_enabled = False
+
+            build_lane = BuildLane(
+                db=rt._db,
+                dispatcher=dispatcher,
+                approval_gate=gate,
+                enabled=bl_enabled,
+            )
+            rt._build_lane = build_lane
+
+            # Late-wire the monitor hook (inbox init ran before tasks init).
+            if rt._inbox_monitor is not None and hasattr(
+                rt._inbox_monitor, "set_build_lane",
+            ):
+                rt._inbox_monitor.set_build_lane(build_lane)
+
+            if bl_enabled:
+                async def _build_lane_poll_loop() -> None:
+                    while True:
+                        try:
+                            await asyncio.sleep(90)
+                            await build_lane.poll_pending()
+                            rt.record_job_success("build_lane_poll")
+                        except asyncio.CancelledError:
+                            break
+                        except Exception as exc:
+                            rt.record_job_failure("build_lane_poll", str(exc))
+                            logger.error(
+                                "Build-lane polling failed", exc_info=True,
+                            )
+
+                rt._build_lane_poll = tracked_task(
+                    _build_lane_poll_loop(), name="build-lane-poll",
+                )
+                logger.info("Capability-build lane ENABLED (poll loop active)")
+            else:
+                logger.info("Capability-build lane constructed (dark — disabled)")
+        except ImportError:
+            logger.warning("Build lane modules not available")
+        except Exception:
+            logger.exception("Failed to initialize build lane")
+
         logger.info("Task executor subsystem initialized")
 
     except ImportError:

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -12,6 +12,66 @@ if TYPE_CHECKING:
 logger = logging.getLogger("genesis.runtime")
 
 
+def _wire_build_lane(rt: GenesisRuntime, dispatcher: object) -> None:
+    """Construct the capability-build lane and wire it into the runtime.
+
+    Consumes inbox ``build`` verdicts into one-tap greenlight cards and drives
+    approved builds to draft PRs via *dispatcher*. Always constructs the lane
+    (so the inbox monitor hook is a clean no-op when disabled); the poll loop
+    is spawned ONLY when the flag is enabled (no idle churn while dark). The
+    lane is forced OFF if the approval gate is unavailable — greenlight cards
+    require it. Must be called from within a running event loop (schedules the
+    poll loop via ``tracked_task``).
+
+    Extracted from :func:`init` so the wiring is unit-testable without the full
+    task-executor bootstrap.
+    """
+    from genesis.autonomy.build_lane import BuildLane
+    from genesis.env import build_lane_enabled
+    from genesis.util.tasks import tracked_task
+
+    gate = getattr(rt, "_autonomous_cli_approval_gate", None)
+    enabled = build_lane_enabled()
+    if enabled and gate is None:
+        logger.warning(
+            "build_lane.enabled=true but the approval gate is unavailable — "
+            "lane forced OFF (greenlight cards require the gate)",
+        )
+        enabled = False
+
+    build_lane = BuildLane(
+        db=rt._db, dispatcher=dispatcher, approval_gate=gate, enabled=enabled,
+    )
+    rt._build_lane = build_lane
+
+    # Late-wire the monitor hook (inbox init ran before tasks init).
+    if rt._inbox_monitor is not None and hasattr(
+        rt._inbox_monitor, "set_build_lane",
+    ):
+        rt._inbox_monitor.set_build_lane(build_lane)
+
+    if not enabled:
+        logger.info("Capability-build lane constructed (dark — disabled)")
+        return
+
+    async def _build_lane_poll_loop() -> None:
+        while True:
+            try:
+                await asyncio.sleep(90)
+                await build_lane.poll_pending()
+                rt.record_job_success("build_lane_poll")
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                rt.record_job_failure("build_lane_poll", str(exc))
+                logger.error("Build-lane polling failed", exc_info=True)
+
+    rt._build_lane_poll = tracked_task(
+        _build_lane_poll_loop(), name="build-lane-poll",
+    )
+    logger.info("Capability-build lane ENABLED (poll loop active)")
+
+
 async def init(rt: GenesisRuntime) -> None:
     """Initialize task executor: decomposer, reviewer, executor, dispatcher.
 
@@ -131,60 +191,9 @@ async def init(rt: GenesisRuntime) -> None:
             _dispatch_poll_loop(), name="task-dispatch-poll",
         )
 
-        # Capability-build lane: consumes inbox `build` verdicts into one-tap
-        # greenlight cards and drives approved builds to draft PRs via the
-        # dispatcher. Ships dark (build_lane.enabled default OFF). Always
-        # constructed so the monitor hook is a clean no-op when disabled; the
-        # poll loop is spawned ONLY when enabled (no idle churn while dark).
+        # Capability-build lane (dark by default; see _wire_build_lane).
         try:
-            from genesis.autonomy.build_lane import BuildLane
-            from genesis.env import build_lane_enabled
-
-            gate = getattr(rt, "_autonomous_cli_approval_gate", None)
-            bl_enabled = build_lane_enabled()
-            if bl_enabled and gate is None:
-                logger.warning(
-                    "build_lane.enabled=true but the approval gate is "
-                    "unavailable — lane forced OFF (greenlight cards require "
-                    "the gate)",
-                )
-                bl_enabled = False
-
-            build_lane = BuildLane(
-                db=rt._db,
-                dispatcher=dispatcher,
-                approval_gate=gate,
-                enabled=bl_enabled,
-            )
-            rt._build_lane = build_lane
-
-            # Late-wire the monitor hook (inbox init ran before tasks init).
-            if rt._inbox_monitor is not None and hasattr(
-                rt._inbox_monitor, "set_build_lane",
-            ):
-                rt._inbox_monitor.set_build_lane(build_lane)
-
-            if bl_enabled:
-                async def _build_lane_poll_loop() -> None:
-                    while True:
-                        try:
-                            await asyncio.sleep(90)
-                            await build_lane.poll_pending()
-                            rt.record_job_success("build_lane_poll")
-                        except asyncio.CancelledError:
-                            break
-                        except Exception as exc:
-                            rt.record_job_failure("build_lane_poll", str(exc))
-                            logger.error(
-                                "Build-lane polling failed", exc_info=True,
-                            )
-
-                rt._build_lane_poll = tracked_task(
-                    _build_lane_poll_loop(), name="build-lane-poll",
-                )
-                logger.info("Capability-build lane ENABLED (poll loop active)")
-            else:
-                logger.info("Capability-build lane constructed (dark — disabled)")
+            _wire_build_lane(rt, dispatcher)
         except ImportError:
             logger.warning("Build lane modules not available")
         except Exception:

--- a/tests/test_autonomy/test_approval.py
+++ b/tests/test_autonomy/test_approval.py
@@ -172,6 +172,37 @@ def _voice_gate(mgr):
     return AutonomousCliApprovalGate(runtime=MagicMock(), approval_manager=mgr)
 
 
+def test_build_greenlight_is_voice_gated():
+    from genesis.autonomy.approval_gate import AutonomousCliApprovalGate
+
+    assert "build_greenlight" in AutonomousCliApprovalGate._VOICE_GATED_TYPES
+
+
+def test_format_message_build_greenlight_card():
+    from genesis.autonomy.approval_gate import AutonomousCliApprovalGate
+
+    msg = AutonomousCliApprovalGate._format_message(
+        request_id="req-1",
+        action_label="Build: Widget Skill [abc12345]",
+        invocation=None,
+        api_error=None,
+        action_type="build_greenlight",
+        extra_context={
+            "title": "Widget Skill",
+            "steps_count": 3,
+            "intended_paths": ["src/genesis/skills/widget/"],
+            "plan_path": "/home/u/.genesis/plans/build-abc12345-2026-07-07.md",
+        },
+    )
+    assert "Build Greenlight" in msg
+    assert "Widget Skill" in msg
+    assert "draft PR" in msg
+    assert "3 step(s)" in msg
+    assert "src/genesis/skills/widget/" in msg
+    # Must NOT fall through to the misleading generic CLI-fallback copy.
+    assert "autonomous Claude Code fallback" not in msg
+
+
 @pytest.mark.asyncio
 async def test_resolve_pending_voice_single(db):
     mgr = ApprovalManager(db=db)

--- a/tests/test_autonomy/test_build_lane.py
+++ b/tests/test_autonomy/test_build_lane.py
@@ -1,0 +1,479 @@
+"""Tests for BuildLane — the capability-build lane control service.
+
+Uses the real ``db`` fixture (full schema) and the real recommendation
+parser + dispatcher plan validator, faking only the two runtime
+collaborators (approval gate, task dispatcher).
+"""
+
+from __future__ import annotations
+
+import json
+
+from genesis.autonomy.build_lane import BuildLane
+from genesis.autonomy.dispatcher import _validate_plan_content
+from genesis.db.crud import build_candidates, task_states
+
+# --------------------------------------------------------------------------
+# Fakes + helpers
+# --------------------------------------------------------------------------
+
+
+class FakeGate:
+    """Records ensure_approval calls; drives get_request/mark_consumed."""
+
+    def __init__(self):
+        self.ensure_calls = []
+        self._status = {}  # request_id -> status
+        self._consumed = set()
+        self._counter = 0
+
+    async def ensure_approval(self, **kwargs):
+        self._counter += 1
+        request_id = f"req-{self._counter}"
+        self.ensure_calls.append(kwargs)
+        self._status[request_id] = "pending"
+        return ("pending", request_id, "approval pending")
+
+    def set_status(self, request_id, status):
+        self._status[request_id] = status
+
+    async def get_request(self, request_id):
+        if request_id not in self._status:
+            return None
+        return {"id": request_id, "status": self._status[request_id]}
+
+    async def mark_consumed(self, request_id):
+        if request_id in self._consumed:
+            return False
+        self._consumed.add(request_id)
+        return True
+
+
+class FakeDispatcher:
+    def __init__(self, *, fail=False):
+        self.calls = []
+        self._fail = fail
+        self._counter = 0
+
+    async def submit(self, plan_path, description, *, source="user"):
+        self.calls.append((plan_path, description, source))
+        if self._fail:
+            raise RuntimeError("boom")
+        self._counter += 1
+        return f"t-{self._counter:012d}"
+
+
+class FakeItem:
+    def __init__(self, file_path="New Genesis Capabilities.md"):
+        self.file_path = file_path
+
+
+_GOOD_SPEC = {
+    "requirements": ["Add a widget", "Wire the widget"],
+    "steps": [
+        {"type": "code", "description": "Write widget.py"},
+        {"type": "test", "description": "Add widget test"},
+        {"type": "verification", "description": "Run the test"},
+    ],
+    "success_criteria": ["widget test passes"],
+    "risks": ["widget conflicts with gadget"],
+    "intended_paths": ["src/genesis/skills/widget/"],
+}
+
+
+def _eval_text(title, verdict, *, build_spec=None, next_step="Produce a widget"):
+    """Build a single-item evaluation with a build verdict block."""
+    lines = [
+        f"## 1. {title}",
+        "",
+        "### Recommendation",
+        "",
+        "```yaml",
+        "action: BUILD",
+        f'next_step: "{next_step}"',
+        "effort: Small",
+        "scope: V4",
+        "confidence: high",
+        "architecture_impact: extends",
+        f"verdict: {verdict}",
+        'verdict_reason: "clear fit"',
+    ]
+    if build_spec is not None:
+        # Inline JSON flow mapping is valid YAML as build_spec's value.
+        lines.append(f"build_spec: {json.dumps(build_spec)}")
+    lines += ["```", ""]
+    return "\n".join(lines)
+
+
+def _lane(db, gate=None, dispatcher=None, *, enabled=True):
+    return BuildLane(
+        db=db,
+        dispatcher=dispatcher or FakeDispatcher(),
+        approval_gate=gate or FakeGate(),
+        enabled=enabled,
+    )
+
+
+# --------------------------------------------------------------------------
+# item_key
+# --------------------------------------------------------------------------
+
+
+class TestItemKey:
+    def test_same_title_same_key(self):
+        assert BuildLane.item_key("My Skill") == BuildLane.item_key("My Skill")
+
+    def test_case_and_whitespace_normalized(self):
+        assert BuildLane.item_key("  My Skill ") == BuildLane.item_key("my skill")
+
+    def test_edited_title_new_key(self):
+        assert BuildLane.item_key("My Skill") != BuildLane.item_key("My Other Skill")
+
+    def test_url_titles_dedupe_on_normalized_url(self):
+        a = BuildLane.item_key("Cool tool https://example.com/x?utm_source=z")
+        b = BuildLane.item_key("Cool tool https://example.com/x")
+        assert a == b
+
+
+# --------------------------------------------------------------------------
+# handle_eval routing
+# --------------------------------------------------------------------------
+
+
+class TestHandleEvalBuild:
+    async def test_build_creates_candidate_card_and_plan(self, db, monkeypatch, tmp_path):
+        monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+
+        n = await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=_GOOD_SPEC),
+            batch_id="batch-123",
+            item=FakeItem(),
+            response_path="/tmp/eval.md",
+        )
+        assert n == 1
+
+        key = BuildLane.item_key("Widget Skill")
+        row = await build_candidates.get_open_by_item_key(db, key)
+        assert row is not None
+        assert row["verdict"] == "build"
+        assert row["approval_request_id"] == "req-1"
+        assert row["batch_id"] == "batch-123"
+        assert row["plan_path"] and tmp_path.as_posix() in row["plan_path"]
+
+        # Card sent via the gate with build_greenlight semantics.
+        assert len(gate.ensure_calls) == 1
+        call = gate.ensure_calls[0]
+        assert call["action_type"] == "build_greenlight"
+        assert call["invocation"] is None
+        assert call["subsystem"] == "build_lane"
+        extra = call["extra_context"]
+        assert extra["title"] == "Widget Skill"
+        assert extra["steps_count"] == 3
+        assert extra["intended_paths"] == ["src/genesis/skills/widget/"]
+
+        # Materialized plan is dispatcher-valid.
+        from pathlib import Path
+        _validate_plan_content(Path(row["plan_path"]))
+
+    async def test_permanent_dedup_across_reevals(self, db, monkeypatch, tmp_path):
+        monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+
+        first = await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=_GOOD_SPEC),
+            batch_id="b1", item=FakeItem(),
+        )
+        # Re-eval same title, different next_step — must NOT re-card.
+        second = await lane.handle_eval(
+            evaluation_text=_eval_text(
+                "Widget Skill", "build", build_spec=_GOOD_SPEC,
+                next_step="A slightly different sentence",
+            ),
+            batch_id="b2", item=FakeItem(),
+        )
+        assert first == 1
+        assert second == 0
+        assert len(gate.ensure_calls) == 1
+
+    async def test_decided_item_not_recarded(self, db, monkeypatch, tmp_path):
+        """After a candidate is decided, a later eval must not re-card it."""
+        monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+        await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=_GOOD_SPEC),
+            batch_id="b1", item=FakeItem(),
+        )
+        key = BuildLane.item_key("Widget Skill")
+        row = await build_candidates.get_open_by_item_key(db, key)
+        await build_candidates.record_user_decision(db, row["id"], user_decision="approved")
+
+        # Same item re-evaluated after the build was approved — no new card/row.
+        n = await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=_GOOD_SPEC),
+            batch_id="b2", item=FakeItem(),
+        )
+        assert n == 0
+        assert len(gate.ensure_calls) == 1
+
+    async def test_malformed_spec_downgrades_to_needs_discussion(self, db, monkeypatch, tmp_path):
+        monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+        bad_spec = dict(_GOOD_SPEC, steps=[])  # empty required list
+        await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=bad_spec),
+            batch_id="b1", item=FakeItem(),
+        )
+        key = BuildLane.item_key("Widget Skill")
+        row = await build_candidates.get_any_by_item_key(db, key)
+        assert row["verdict"] == "needs_discussion"
+        assert row["plan_path"] is None
+        assert row["approval_request_id"] is None
+        assert gate.ensure_calls == []  # no card for a downgrade
+
+    async def test_missing_spec_on_build_downgrades(self, db, monkeypatch, tmp_path):
+        monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+        await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=None),
+            batch_id="b1", item=FakeItem(),
+        )
+        key = BuildLane.item_key("Widget Skill")
+        row = await build_candidates.get_any_by_item_key(db, key)
+        assert row["verdict"] == "needs_discussion"
+        assert gate.ensure_calls == []
+
+
+class TestHandleEvalOtherVerdicts:
+    async def test_dont_build_records_row_no_card(self, db):
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+        await lane.handle_eval(
+            evaluation_text=_eval_text("Bad Idea", "dont_build"),
+            batch_id="b1", item=FakeItem(),
+        )
+        key = BuildLane.item_key("Bad Idea")
+        row = await build_candidates.get_any_by_item_key(db, key)
+        assert row["verdict"] == "dont_build"
+        assert row["plan_path"] is None
+        assert gate.ensure_calls == []
+
+    async def test_needs_discussion_records_row_no_card(self, db):
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+        await lane.handle_eval(
+            evaluation_text=_eval_text("Fuzzy Idea", "needs_discussion"),
+            batch_id="b1", item=FakeItem(),
+        )
+        key = BuildLane.item_key("Fuzzy Idea")
+        row = await build_candidates.get_any_by_item_key(db, key)
+        assert row["verdict"] == "needs_discussion"
+        assert gate.ensure_calls == []
+
+    async def test_no_verdict_ignored(self, db):
+        gate = FakeGate()
+        lane = _lane(db, gate=gate)
+        # Ordinary (non-build) recommendation: no verdict field.
+        text = (
+            "## 1. Some Article\n\n### Recommendation\n\n"
+            "```yaml\naction: ADOPT\nnext_step: read it\nscope: V4\n```\n"
+        )
+        n = await lane.handle_eval(evaluation_text=text, batch_id="b1", item=FakeItem())
+        assert n == 0
+        assert gate.ensure_calls == []
+
+
+class TestDisabled:
+    async def test_handle_eval_noop_when_disabled(self, db):
+        gate = FakeGate()
+        lane = _lane(db, gate=gate, enabled=False)
+        n = await lane.handle_eval(
+            evaluation_text=_eval_text("Widget Skill", "build", build_spec=_GOOD_SPEC),
+            batch_id="b1", item=FakeItem(),
+        )
+        assert n == 0
+        assert gate.ensure_calls == []
+        assert await build_candidates.list_recent(db) == []
+
+    async def test_poll_noop_when_disabled(self, db):
+        lane = _lane(db, enabled=False)
+        await lane.poll_pending()  # must not raise
+
+
+# --------------------------------------------------------------------------
+# _materialize_plan
+# --------------------------------------------------------------------------
+
+
+class TestMaterializePlan:
+    def test_valid_spec_has_exact_sections(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+        lane = BuildLane(db=None, dispatcher=None, approval_gate=None, enabled=True)
+        path = lane._materialize_plan("abcdef1234", "Widget Skill", _GOOD_SPEC)
+        assert path is not None
+        text = (tmp_path / __import__("os").path.basename(path)).read_text()
+        for header in ("## Requirements", "## Steps",
+                       "## Success Criteria", "## Risks and Failure Modes"):
+            assert f"\n{header}\n" in text
+        assert "(code) Write widget.py" in text
+        assert "(verification) Run the test" in text
+
+    def test_missing_required_list_returns_none(self):
+        lane = BuildLane(db=None, dispatcher=None, approval_gate=None, enabled=True)
+        assert lane._materialize_plan("k", "T", dict(_GOOD_SPEC, risks=[])) is None
+        assert lane._materialize_plan("k", "T", None) is None
+        assert lane._materialize_plan("k", "T", {}) is None
+
+
+# --------------------------------------------------------------------------
+# poll_pending — card resolution
+# --------------------------------------------------------------------------
+
+
+async def _card(db, monkeypatch, tmp_path, gate, dispatcher):
+    """Create a carded build candidate; return its row id + request id."""
+    monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path)
+    lane = BuildLane(db=db, dispatcher=dispatcher, approval_gate=gate, enabled=True)
+    await lane.handle_eval(
+        evaluation_text=_eval_text("Widget Skill", "build", build_spec=_GOOD_SPEC),
+        batch_id="b1", item=FakeItem(),
+    )
+    key = BuildLane.item_key("Widget Skill")
+    row = await build_candidates.get_open_by_item_key(db, key)
+    return lane, row["id"], row["approval_request_id"]
+
+
+class TestPollCardResolution:
+    async def test_approved_submits_and_marks(self, db, monkeypatch, tmp_path):
+        gate, disp = FakeGate(), FakeDispatcher()
+        lane, cid, rid = await _card(db, monkeypatch, tmp_path, gate, disp)
+        gate.set_status(rid, "approved")
+        await lane.poll_pending()
+
+        assert len(disp.calls) == 1
+        _plan, _desc, source = disp.calls[0]
+        assert source == "build_lane"
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["user_decision"] == "approved"
+        assert row["outcome"] == "submitted"
+        assert row["task_id"] is not None
+
+    async def test_double_tap_no_double_submit(self, db, monkeypatch, tmp_path):
+        gate, disp = FakeGate(), FakeDispatcher()
+        lane, cid, rid = await _card(db, monkeypatch, tmp_path, gate, disp)
+        gate.set_status(rid, "approved")
+        await lane.poll_pending()
+        # Second poll: candidate is decided (not open) AND mark_consumed=False.
+        await lane.poll_pending()
+        assert len(disp.calls) == 1
+
+    async def test_rejected_abandons_no_submit(self, db, monkeypatch, tmp_path):
+        gate, disp = FakeGate(), FakeDispatcher()
+        lane, cid, rid = await _card(db, monkeypatch, tmp_path, gate, disp)
+        gate.set_status(rid, "rejected")
+        await lane.poll_pending()
+        assert disp.calls == []
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["user_decision"] == "rejected"
+        assert row["outcome"] == "abandoned"
+
+    async def test_pending_card_waits(self, db, monkeypatch, tmp_path):
+        gate, disp = FakeGate(), FakeDispatcher()
+        lane, cid, rid = await _card(db, monkeypatch, tmp_path, gate, disp)
+        await lane.poll_pending()  # still pending
+        assert disp.calls == []
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["user_decision"] is None
+        assert row["outcome"] == "pending"
+
+    async def test_dispatch_failure_marks_build_failed(self, db, monkeypatch, tmp_path):
+        gate, disp = FakeGate(), FakeDispatcher(fail=True)
+        lane, cid, rid = await _card(db, monkeypatch, tmp_path, gate, disp)
+        gate.set_status(rid, "approved")
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "build_failed"
+
+    async def test_calibration_row_skipped_by_poll(self, db, monkeypatch, tmp_path):
+        # dont_build row has no approval_request_id — poll must skip it cleanly.
+        gate, disp = FakeGate(), FakeDispatcher()
+        lane = BuildLane(db=db, dispatcher=disp, approval_gate=gate, enabled=True)
+        await lane.handle_eval(
+            evaluation_text=_eval_text("Bad Idea", "dont_build"),
+            batch_id="b1", item=FakeItem(),
+        )
+        await lane.poll_pending()  # must not raise / submit
+        assert disp.calls == []
+
+
+# --------------------------------------------------------------------------
+# poll_pending — outcome reconciliation
+# --------------------------------------------------------------------------
+
+
+async def _submitted_candidate(db, monkeypatch, tmp_path):
+    gate, disp = FakeGate(), FakeDispatcher()
+    lane, cid, rid = await _card(db, monkeypatch, tmp_path, gate, disp)
+    gate.set_status(rid, "approved")
+    await lane.poll_pending()
+    row = await build_candidates.get_by_id(db, cid)
+    return lane, cid, row["task_id"]
+
+
+async def _set_task(db, task_id, *, phase, outputs=None):
+    # The fake dispatcher creates no task_states row — stand one up here.
+    # task_states enforces a valid intake token via a DB trigger.
+    token = await task_states.create_intake_token(db)
+    await task_states.create(
+        db, task_id=task_id, description="build",
+        current_phase=phase, source="build_lane", intake_token=token,
+        outputs=json.dumps(outputs) if outputs is not None else None,
+    )
+
+
+class TestReconcile:
+    async def test_pr_opened(self, db, monkeypatch, tmp_path):
+        lane, cid, tid = await _submitted_candidate(db, monkeypatch, tmp_path)
+        await _set_task(db, tid, phase="completed",
+                        outputs={"branch": "task/abc", "pr_url": "https://x/pr/1"})
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "pr_opened"
+        assert row["pr_url"] == "https://x/pr/1"
+        assert row["branch"] == "task/abc"
+
+    async def test_scope_blocked(self, db, monkeypatch, tmp_path):
+        lane, cid, tid = await _submitted_candidate(db, monkeypatch, tmp_path)
+        await _set_task(db, tid, phase="completed",
+                        outputs={"scope_blocked": "touched src/genesis/autonomy/x",
+                                 "scope_gate": '{"allowed": false}'})
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "scope_blocked"
+
+    async def test_built_when_pushed_but_no_pr(self, db, monkeypatch, tmp_path):
+        lane, cid, tid = await _submitted_candidate(db, monkeypatch, tmp_path)
+        await _set_task(db, tid, phase="completed",
+                        outputs={"branch": "task/abc", "pr_error": "gh boom"})
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "built"
+
+    async def test_failed_phase(self, db, monkeypatch, tmp_path):
+        lane, cid, tid = await _submitted_candidate(db, monkeypatch, tmp_path)
+        await _set_task(db, tid, phase="failed", outputs={})
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "build_failed"
+
+    async def test_still_running_stays_submitted(self, db, monkeypatch, tmp_path):
+        lane, cid, tid = await _submitted_candidate(db, monkeypatch, tmp_path)
+        await _set_task(db, tid, phase="executing", outputs={"branch": "task/abc"})
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "submitted"

--- a/tests/test_autonomy/test_build_lane.py
+++ b/tests/test_autonomy/test_build_lane.py
@@ -477,3 +477,19 @@ class TestReconcile:
         await lane.poll_pending()
         row = await build_candidates.get_by_id(db, cid)
         assert row["outcome"] == "submitted"
+
+    async def test_reconcile_survives_calibration_flood(self, db, monkeypatch, tmp_path):
+        """A submitted candidate must reconcile even when >100 newer calibration
+        rows exist — the reconcile query is outcome-filtered, not recency-bounded."""
+        lane, cid, tid = await _submitted_candidate(db, monkeypatch, tmp_path)
+        # Flood with 120 unrelated dont_build calibration rows created AFTER it.
+        for i in range(120):
+            await build_candidates.create(
+                db, id=f"flood-{i}", item_key=f"flood-key-{i}",
+                item_title=f"noise {i}", source_file="x.md", verdict="dont_build",
+            )
+        await _set_task(db, tid, phase="completed",
+                        outputs={"branch": "task/abc", "pr_url": "https://x/pr/9"})
+        await lane.poll_pending()
+        row = await build_candidates.get_by_id(db, cid)
+        assert row["outcome"] == "pr_opened"

--- a/tests/test_autonomy/test_classification.py
+++ b/tests/test_autonomy/test_classification.py
@@ -89,6 +89,11 @@ class TestGetTimeout:
         c = self._make_classifier()
         assert c.get_timeout("sentinel_dispatch") is None
 
+    def test_build_greenlight_timeout_none(self) -> None:
+        # Greenlight cards wait indefinitely for a human tap.
+        c = self._make_classifier()
+        assert c.get_timeout("build_greenlight") is None
+
     def test_sentinel_action_timeout(self) -> None:
         c = self._make_classifier()
         assert c.get_timeout("sentinel_action") is None

--- a/tests/test_autonomy/test_executor/test_step_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_step_dispatcher.py
@@ -252,3 +252,43 @@ class TestNoAutonomousDispatcher:
 
         assert result.status == "failed"
         assert "session crashed" in result.result
+
+
+@pytest.mark.asyncio
+class TestModelOverride:
+    """model_override upgrades CODE/VERIFICATION steps only."""
+
+    def _invoker(self):
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(return_value=MagicMock(
+            is_error=False,
+            text='{"status": "completed", "result": "done"}',
+            cost_usd=0.01, session_id="s", model_used="opus",
+        ))
+        return invoker
+
+    async def _model_used(self, step_type, model_override):
+        invoker = self._invoker()
+        sd = StepDispatcher(db=AsyncMock(), invoker=invoker, autonomous_dispatcher=None)
+        await sd.dispatch_step(
+            "t-1", _make_step(step_type=step_type), [],
+            model_override=model_override,
+        )
+        return invoker.run.call_args[0][0].model
+
+    async def test_code_step_uses_override(self) -> None:
+        from genesis.cc.types import CCModel
+        assert await self._model_used("code", CCModel.OPUS) == CCModel.OPUS
+
+    async def test_verification_step_uses_override(self) -> None:
+        from genesis.cc.types import CCModel
+        assert await self._model_used("verification", CCModel.OPUS) == CCModel.OPUS
+
+    async def test_research_step_ignores_override(self) -> None:
+        from genesis.cc.types import CCModel
+        # Non-code steps stay on Sonnet even under a build-lane override.
+        assert await self._model_used("research", CCModel.OPUS) == CCModel.SONNET
+
+    async def test_code_step_defaults_sonnet_without_override(self) -> None:
+        from genesis.cc.types import CCModel
+        assert await self._model_used("code", None) == CCModel.SONNET

--- a/tests/test_autonomy/test_executor/test_step_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_step_dispatcher.py
@@ -292,3 +292,46 @@ class TestModelOverride:
     async def test_code_step_defaults_sonnet_without_override(self) -> None:
         from genesis.cc.types import CCModel
         assert await self._model_used("code", None) == CCModel.SONNET
+
+    async def test_try_workaround_preserves_override(self, monkeypatch) -> None:
+        from genesis.cc.types import CCModel
+        monkeypatch.setattr(
+            "genesis.db.crud.task_steps.update_step", AsyncMock(),
+        )
+        invoker = self._invoker()
+        workaround = AsyncMock()
+        workaround.search = AsyncMock(return_value=MagicMock(
+            found=True, approach="do it differently",
+        ))
+        sd = StepDispatcher(
+            db=AsyncMock(), invoker=invoker,
+            autonomous_dispatcher=None, workaround_searcher=workaround,
+        )
+        await sd.try_workaround(
+            "t-1", _make_step(step_type="code"),
+            MagicMock(result="failed"), [],
+            model_override=CCModel.OPUS,
+        )
+        # The recovery retry must NOT silently drop to Sonnet.
+        assert invoker.run.call_args[0][0].model == CCModel.OPUS
+
+    async def test_try_research_preserves_override(self, monkeypatch) -> None:
+        from genesis.cc.types import CCModel
+        monkeypatch.setattr(
+            "genesis.db.crud.task_steps.update_step", AsyncMock(),
+        )
+        invoker = self._invoker()
+        research = AsyncMock()
+        research.research = AsyncMock(return_value=MagicMock(
+            found=True, approach="research-derived approach",
+        ))
+        sd = StepDispatcher(
+            db=AsyncMock(), invoker=invoker,
+            autonomous_dispatcher=None, research_searcher=research,
+        )
+        await sd.try_research(
+            "t-1", _make_step(step_type="verification"),
+            MagicMock(result="failed"), [],
+            model_override=CCModel.OPUS,
+        )
+        assert invoker.run.call_args[0][0].model == CCModel.OPUS

--- a/tests/test_db/test_build_candidates.py
+++ b/tests/test_db/test_build_candidates.py
@@ -130,3 +130,20 @@ class TestQueries:
         )
         assert (await build_candidates.get_by_approval_request(db, "ar-9"))["id"] == "c1"
         assert (await build_candidates.get_by_task(db, "t-9"))["id"] == "c1"
+
+    async def test_create_persists_approval_request_id(self, db):
+        await _make(db, id="c1", approval_request_id="ar-42")
+        row = await build_candidates.get_by_id(db, "c1")
+        assert row["approval_request_id"] == "ar-42"
+
+    async def test_get_any_by_item_key_finds_decided(self, db):
+        # Permanent dedup: a DECIDED row (not "open") is still found by
+        # get_any_by_item_key so a rescan never re-cards a built item.
+        await _make(db, id="c1", item_key="k1")
+        await build_candidates.record_user_decision(
+            db, "c1", user_decision="approved"
+        )
+        assert await build_candidates.get_open_by_item_key(db, "k1") is None
+        found = await build_candidates.get_any_by_item_key(db, "k1")
+        assert found is not None and found["id"] == "c1"
+        assert await build_candidates.get_any_by_item_key(db, "nope") is None

--- a/tests/test_db/test_build_candidates.py
+++ b/tests/test_db/test_build_candidates.py
@@ -123,6 +123,20 @@ class TestQueries:
         rows = await build_candidates.list_recent(db, limit=2)
         assert len(rows) == 2
 
+    async def test_list_by_outcome(self, db):
+        await _make(db, id="c1", item_key="k1")  # outcome defaults to 'pending'
+        await _make(db, id="c2", item_key="k2")
+        await build_candidates.update(db, "c2", outcome="submitted")
+        await _make(db, id="c3", item_key="k3")
+        await build_candidates.update(db, "c3", outcome="submitted")
+        submitted = await build_candidates.list_by_outcome(db, "submitted")
+        assert {r["id"] for r in submitted} == {"c2", "c3"}
+        assert [r["id"] for r in submitted] == ["c2", "c3"]  # oldest first
+
+    async def test_list_by_outcome_rejects_bad_value(self, db):
+        with pytest.raises(ValueError):
+            await build_candidates.list_by_outcome(db, "shipped")
+
     async def test_get_by_approval_request_and_task(self, db):
         await _make(db, id="c1")
         await build_candidates.update(

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -971,3 +971,67 @@ async def test_folded_file_reevaluates_only_unprocessed_delta(
     assert "https://example.com/a3" in prompts
     assert "https://example.com/b0" in prompts
     assert "https://example.com/a0" not in prompts, "re-evaluated processed URL"
+
+
+# ── Build-lane hook end-to-end (real monitor -> handle_eval -> greenlight) ──
+
+
+def _build_eval_text() -> str:
+    """An evaluation whose single item carries a `build` verdict + build_spec."""
+    import json as _json
+    spec = {
+        "requirements": ["Add widget"],
+        "steps": [{"type": "code", "description": "write widget.py"}],
+        "success_criteria": ["widget imports"],
+        "risks": ["none material"],
+        "intended_paths": ["src/genesis/skills/widget/"],
+    }
+    return (
+        "# Inbox Evaluation\n\n"
+        "## 1. Widget Skill\n\n"
+        "### Recommendation\n\n"
+        "```yaml\n"
+        "action: BUILD\n"
+        'next_step: "Build the widget skill"\n'
+        "scope: V4\n"
+        "confidence: high\n"
+        "verdict: build\n"
+        'verdict_reason: "clear fit"\n'
+        f"build_spec: {_json.dumps(spec)}\n"
+        "```\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_verdict_flows_through_monitor_to_greenlight(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, monkeypatch,
+):
+    """A `build` verdict in a real eval batch must reach BuildLane.handle_eval
+    via the monitor hook and produce a carded build_candidate — the wiring the
+    unit tests can't prove (they call handle_eval directly)."""
+    from unittest.mock import AsyncMock
+
+    from genesis.autonomy.build_lane import BuildLane
+    from genesis.db.crud import build_candidates
+
+    monkeypatch.setattr("genesis.autonomy.build_lane._PLANS_DIR", tmp_path / "plans")
+
+    gate = AsyncMock()
+    gate.ensure_approval = AsyncMock(return_value=("pending", "req-1", "pending"))
+    dispatcher = AsyncMock()
+    lane = BuildLane(db=db, dispatcher=dispatcher, approval_gate=gate, enabled=True)
+
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=1)
+    mon.set_build_lane(lane)
+    mock_invoker.run.return_value = _ok(text=_build_eval_text())
+
+    (inbox_dir / "Capabilities.md").write_text("https://example.com/widget")
+    await mon.check_once()
+
+    key = BuildLane.item_key("Widget Skill")
+    row = await build_candidates.get_open_by_item_key(db, key)
+    assert row is not None, "build verdict did not reach the lane via the monitor hook"
+    assert row["verdict"] == "build"
+    assert row["approval_request_id"] == "req-1"
+    gate.ensure_approval.assert_awaited_once()
+    assert gate.ensure_approval.await_args.kwargs["action_type"] == "build_greenlight"

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -124,6 +124,17 @@ async def test_empty_folder(monitor):
     assert result.errors == []
 
 
+def test_build_lane_defaults_none(monitor):
+    # Hook is inert until the build lane is late-wired.
+    assert monitor._build_lane is None
+
+
+def test_set_build_lane_wires_hook(monitor):
+    sentinel = object()
+    monitor.set_build_lane(sentinel)
+    assert monitor._build_lane is sentinel
+
+
 @pytest.mark.asyncio
 async def test_new_files_dispatched(monitor, inbox_dir, mock_invoker):
     (inbox_dir / "links.md").write_text("https://example.com")

--- a/tests/test_runtime/test_build_lane_wiring.py
+++ b/tests/test_runtime/test_build_lane_wiring.py
@@ -1,0 +1,91 @@
+"""Wiring for the capability-build lane at task-executor init.
+
+`_wire_build_lane` must: always construct the lane (so the inbox monitor hook
+is a clean no-op when disabled), late-wire the monitor, spawn the poll loop
+ONLY when enabled, and force the lane OFF when the approval gate is missing.
+These lock the "if the system restarts now, will this work?" wiring in place
+without the full task-executor bootstrap.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from genesis.autonomy.build_lane import BuildLane
+from genesis.runtime.init.tasks import _wire_build_lane
+
+
+class _FakeMonitor:
+    def __init__(self):
+        self._build_lane = None
+
+    def set_build_lane(self, bl):
+        self._build_lane = bl
+
+
+# Module-level singleton so the default isn't a call in the signature (B008).
+_PRESENT_GATE = object()
+
+
+def _fake_rt(*, gate=_PRESENT_GATE, monitor=None):
+    return SimpleNamespace(
+        _db=object(),
+        _autonomous_cli_approval_gate=gate,
+        _inbox_monitor=monitor if monitor is not None else _FakeMonitor(),
+        _build_lane=None,
+        _build_lane_poll=None,
+        record_job_success=lambda *a, **k: None,
+        record_job_failure=lambda *a, **k: None,
+    )
+
+
+def _set_flag(monkeypatch, value: bool):
+    monkeypatch.setattr("genesis.env.build_lane_enabled", lambda: value)
+
+
+class TestWireBuildLane:
+    async def test_enabled_constructs_wires_and_spawns_poll(self, monkeypatch):
+        _set_flag(monkeypatch, True)
+        rt = _fake_rt()
+        _wire_build_lane(rt, dispatcher=object())
+        try:
+            assert isinstance(rt._build_lane, BuildLane)
+            assert rt._build_lane.enabled is True
+            # Monitor hook wired to the SAME instance.
+            assert rt._inbox_monitor._build_lane is rt._build_lane
+            # Poll loop spawned.
+            assert rt._build_lane_poll is not None
+        finally:
+            if rt._build_lane_poll is not None:
+                rt._build_lane_poll.cancel()
+
+    async def test_disabled_constructs_wires_but_no_poll(self, monkeypatch):
+        _set_flag(monkeypatch, False)
+        rt = _fake_rt()
+        _wire_build_lane(rt, dispatcher=object())
+        assert isinstance(rt._build_lane, BuildLane)
+        assert rt._build_lane.enabled is False
+        # Hook still wired (so a later flag-flip+restart works); no-op while dark.
+        assert rt._inbox_monitor._build_lane is rt._build_lane
+        # No idle poll loop while dark.
+        assert rt._build_lane_poll is None
+
+    async def test_enabled_but_no_gate_forced_off(self, monkeypatch):
+        _set_flag(monkeypatch, True)
+        rt = _fake_rt(gate=None)
+        _wire_build_lane(rt, dispatcher=object())
+        assert rt._build_lane.enabled is False  # cards need the gate
+        assert rt._build_lane_poll is None
+
+    async def test_missing_monitor_does_not_crash(self, monkeypatch):
+        _set_flag(monkeypatch, False)
+        rt = _fake_rt()
+        rt._inbox_monitor = None
+        _wire_build_lane(rt, dispatcher=object())  # must not raise
+        assert isinstance(rt._build_lane, BuildLane)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Closes the Stage-1 loop the V1 groundwork (PRs #926–#933, #937) left dark. An inbox capability-build evaluation that emits a `build` verdict now:

1. materializes a dispatcher-ready plan (fail-closed on a malformed `build_spec`),
2. records a `build_candidates` calibration row,
3. sends a one-tap **greenlight card**,
4. on the tap, dispatches an autonomous task that builds in a worktree and opens a **draft PR — never a merge**,
5. reconciles the candidate's outcome from task state.

`dont_build` / `needs_discussion` verdicts record a calibration row only — no card, no queued build.

**Ships dark:** gated behind `build_lane.enabled` (default OFF; env override `GENESIS_BUILD_LANE_ENABLED`). Constructed always so the monitor hook is a clean no-op; the poll loop is spawned only when enabled. Activation is a deliberate flag-flip + restart, after a canary run.

## Design notes

- **Permanent item_key dedup** (`get_any_by_item_key`): a capability stays in the notepad after it's built and is re-evaluated every rescan. The partial-unique index only guards *open* rows, so dedup is enforced at the app layer — one candidate per item_key until a genuine title/URL edit re-proposes.
- **Card-first-then-row** with a deterministic plan filename (`build-<key8>.md`): the greenlight `extra_context` is reconstructable from row fields, so `ensure_approval` is idempotent — a crash between card and row re-cards to the same request instead of stranding or double-carding the item.
- **Opus for build CODE/VERIFICATION steps** via a threaded per-task `model_override`; every other source and step type stays on Sonnet.
- Outcome reconciliation reads `task_states` outputs (the engine writes no candidate rows); `_deliver` is untouched.

## Safety

- No merge call anywhere in the path — draft PRs only.
- The scope gate (shipped in #932) denies the lane's own gate/approval/submission surface, secrets, service units, and symlinks — a build cannot widen its own scope.
- The autonomous approval gate is untouched; the greenlight tap is the single root approval for the build chain.

## Verification

- New `tests/test_autonomy/test_build_lane.py` — item_key stability, verdict routing, fail-closed materialization, poll approve/reject/double-tap/dispatch-fail, outcome-reconcile matrix incl. a calibration-flood regression.
- Wiring test (`test_build_lane_wiring`) — construct + hook + flag-gated poll loop at init.
- Real-monitor data-flow E2E (`test_drop_dispatch::test_build_verdict_flows_through_monitor_to_greenlight`) — a `build` verdict flows through `check_once()` to a carded candidate.
- Targeted additions across CRUD, approval gate, classification, step dispatcher, monitor. 829-test affected regression green, ruff clean.

## Review fixes applied

An independent review flagged 2 HIGH + 1 note, all addressed in this branch: reconcile starvation (recency-scan → indexed `list_by_outcome`), `model_override` dropped by the two recovery re-dispatch paths (now threaded through all six dispatch sites), and a midnight-crash double-card gap (deterministic filename).

## Follow-up

PR-8 (reporting + calibration surfacing) and the live canary activation (flag ON + restart + `[canary]` drop) come next, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)