### PR TITLE
refactor(surplus): job_guard decorator + swallow-safe record helpers

### DIFF
--- a/src/genesis/surplus/jobs/_guard.py
+++ b/src/genesis/surplus/jobs/_guard.py
@@ -1,0 +1,79 @@
+"""Shared job-health guard for surplus job bodies.
+
+Two layers, used by different job shapes:
+
+- :func:`job_guard` — full decorator for the uniform enqueue-gate jobs
+  (``gates.py``): swallow-all try/except with ``logger.exception`` +
+  job-health recording. Jobs with pause checks, event emissions, or
+  not-wired guards do NOT use the decorator — that per-job variance stays
+  in their bodies by design (see the 2026-07-07 refactor decision: a
+  fully-parametrized decorator merely relocates variance into arg
+  cocktails).
+- :func:`record_success` / :func:`record_failure` — swallow-safe
+  job-health recording helpers for every other job body, replacing the
+  hand-rolled ``try: GenesisRuntime.instance().record_job_* except: pass``
+  blocks without touching the surrounding control flow.
+
+The ``genesis.runtime`` import is function-scope and resolved at call
+time — this is both the import-cycle breaker and the tests' patch seam
+(``patch("genesis.runtime.GenesisRuntime")``); do not hoist it.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any
+
+#: Sentinel a decorated job body returns to signal "intentionally did
+#: nothing" — the guard then records neither success nor failure, so
+#: disabled-by-config paths stay invisible to job_health exactly as their
+#: pre-decorator early ``return`` did.
+SKIP: Any = object()
+
+
+def record_success(job_id: str) -> None:
+    """Record a job-health success; never raises (health tracking must not
+    break the job that is being tracked)."""
+    try:
+        from genesis.runtime import GenesisRuntime
+        GenesisRuntime.instance().record_job_success(job_id)
+    except Exception:
+        pass
+
+
+def record_failure(job_id: str, error: str) -> None:
+    """Record a job-health failure; never raises."""
+    try:
+        from genesis.runtime import GenesisRuntime
+        GenesisRuntime.instance().record_job_failure(job_id, error)
+    except Exception:
+        pass
+
+
+def job_guard(job_id: str, fail_log: str):
+    """Wrap an async job body in the uniform surplus job protocol.
+
+    On normal return: record success (unless the body returned
+    :data:`SKIP`) and propagate the body's return value. On exception:
+    ``logger.exception(fail_log)`` under the body's own module logger
+    (log-parity with the pre-decorator inline blocks), record the
+    failure, and swallow — APScheduler job callables must not raise.
+    """
+    def deco(fn):
+        logger = logging.getLogger(fn.__module__)
+
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                result = await fn(*args, **kwargs)
+                if result is SKIP:
+                    return None
+                record_success(job_id)
+                return result
+            except Exception as exc:
+                logger.exception(fail_log)
+                record_failure(job_id, str(exc))
+                return None
+        return wrapper
+    return deco

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -1,11 +1,14 @@
 """Enqueue-gate jobs — cooldown-gated surplus task enqueues.
 
-Bodies extracted verbatim from ``SurplusScheduler``; the scheduler keeps every
-original method name as a thin delegate. Function-scope imports are
-intentional — they are both the tests' patch-target seam and the import-cycle
-breaker; do not hoist them to module top. Bodies call back through the
-scheduler instance (``sched._recently_completed`` / ``sched.schedule_pipeline``)
-so instance-level patching in tests keeps working.
+Bodies extracted from ``SurplusScheduler``; the scheduler keeps every original
+method name as a thin delegate. The nine uniform gate jobs carry their
+try/except + job-health protocol via ``@job_guard`` (see ``_guard.py``);
+``brainstorm_check`` keeps its pause check and failure event in the body.
+Function-scope imports are intentional — they are both the tests'
+patch-target seam and the import-cycle breaker; do not hoist them to module
+top. Bodies call back through the scheduler instance
+(``sched._recently_completed`` / ``sched.schedule_pipeline``) so
+instance-level patching in tests keeps working.
 """
 
 from __future__ import annotations

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -17,7 +17,12 @@ from typing import TYPE_CHECKING
 
 from genesis.db.crud import surplus as surplus_crud
 from genesis.observability.types import Severity, Subsystem
-from genesis.surplus.jobs._guard import SKIP, job_guard
+from genesis.surplus.jobs._guard import (
+    SKIP,
+    job_guard,
+    record_failure,
+    record_success,
+)
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -39,18 +44,10 @@ async def brainstorm_check(sched: SchedulerContext) -> None:
         return
     try:
         await sched._brainstorm_runner.schedule_daily_brainstorms()
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("surplus_brainstorm")
-        except Exception:
-            pass
+        record_success("surplus_brainstorm")
     except Exception as exc:
         logger.exception("Brainstorm check failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("surplus_brainstorm", str(exc))
-        except Exception:
-            pass
+        record_failure("surplus_brainstorm", str(exc))
         if sched._event_bus:
             await sched._event_bus.emit(
                 Subsystem.SURPLUS, Severity.ERROR,

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -10,7 +10,6 @@ so instance-level patching in tests keeps working.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -18,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from genesis.db.crud import surplus as surplus_crud
 from genesis.observability.types import Severity, Subsystem
+from genesis.surplus.jobs._guard import SKIP, job_guard
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -80,138 +80,81 @@ async def recently_completed(
         return False
 
 
+@job_guard("schedule_code_audit", "Code audit scheduling failed")
 async def schedule_code_audit(sched: SchedulerContext) -> None:
     """Enqueue a code audit task if none pending/running."""
     if not sched._enable_code_audits:
-        return
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+        # Disabled-by-config: record neither success nor failure, exactly
+        # as the pre-guard early return did (the job_health row is
+        # stale-by-design while audits are off).
+        return SKIP
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.CODE_AUDIT)
-        if active == 0 and not await sched._recently_completed(
-            TaskType.CODE_AUDIT, sched._code_audit_hours,
-        ):
-            await sched._queue.enqueue(
-                TaskType.CODE_AUDIT, ComputeTier.FREE_API, 0.5, "competence"
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_code_audit")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("Code audit scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_code_audit", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.CODE_AUDIT)
+    if active == 0 and not await sched._recently_completed(
+        TaskType.CODE_AUDIT, sched._code_audit_hours,
+    ):
+        await sched._queue.enqueue(
+            TaskType.CODE_AUDIT, ComputeTier.FREE_API, 0.5, "competence"
+        )
 
 
+@job_guard("schedule_code_index", "Code index scheduling failed")
 async def schedule_code_index(sched: SchedulerContext) -> None:
     """Enqueue a code index task if none pending/running."""
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.CODE_INDEX)
-        if active == 0 and not await sched._recently_completed(
-            TaskType.CODE_INDEX, sched._code_index_hours,
-        ):
-            await sched._queue.enqueue(
-                TaskType.CODE_INDEX, ComputeTier.FREE_API, 0.6, "competence"
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_code_index")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("Code index scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_code_index", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.CODE_INDEX)
+    if active == 0 and not await sched._recently_completed(
+        TaskType.CODE_INDEX, sched._code_index_hours,
+    ):
+        await sched._queue.enqueue(
+            TaskType.CODE_INDEX, ComputeTier.FREE_API, 0.6, "competence"
+        )
 
 
+@job_guard("schedule_j9_eval_batch", "J9 eval batch scheduling failed")
 async def schedule_j9_eval_batch(sched: SchedulerContext) -> None:
     """Enqueue a J9 eval batch task if none pending/running."""
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.J9_EVAL_BATCH)
-        if active == 0 and not await sched._recently_completed(
-            TaskType.J9_EVAL_BATCH, sched._j9_eval_batch_hours,
-        ):
-            await sched._queue.enqueue(
-                TaskType.J9_EVAL_BATCH, ComputeTier.FREE_API, 0.3, "competence"
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_j9_eval_batch")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("J9 eval batch scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_j9_eval_batch", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.J9_EVAL_BATCH)
+    if active == 0 and not await sched._recently_completed(
+        TaskType.J9_EVAL_BATCH, sched._j9_eval_batch_hours,
+    ):
+        await sched._queue.enqueue(
+            TaskType.J9_EVAL_BATCH, ComputeTier.FREE_API, 0.3, "competence"
+        )
 
 
+@job_guard("schedule_fresh_session_test", "Fresh session test scheduling failed")
 async def schedule_fresh_session_test(sched: SchedulerContext) -> None:
     """Enqueue a FRESH_SESSION_TEST task if none pending/running."""
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.FRESH_SESSION_TEST)
-        if active == 0:
-            await sched._queue.enqueue(
-                TaskType.FRESH_SESSION_TEST, ComputeTier.FREE_API, 0.2, "competence"
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_fresh_session_test")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("Fresh session test scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_fresh_session_test", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.FRESH_SESSION_TEST)
+    if active == 0:
+        await sched._queue.enqueue(
+            TaskType.FRESH_SESSION_TEST, ComputeTier.FREE_API, 0.2, "competence"
+        )
 
 
+@job_guard("schedule_model_eval", "Model eval scheduling failed")
 async def schedule_model_eval(sched: SchedulerContext) -> None:
     """Enqueue a MODEL_EVAL task if none pending/running."""
-    try:
-        import json
+    import json
 
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.MODEL_EVAL)
-        if active == 0 and not await sched._recently_completed(
-            TaskType.MODEL_EVAL, sched._model_eval_hours,
-        ):
-            payload = json.dumps({"model_id": "groq-free"})
-            await sched._queue.enqueue(
-                TaskType.MODEL_EVAL, ComputeTier.FREE_API, 0.4, "competence",
-                payload=payload,
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_model_eval")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("Model eval scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_model_eval", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.MODEL_EVAL)
+    if active == 0 and not await sched._recently_completed(
+        TaskType.MODEL_EVAL, sched._model_eval_hours,
+    ):
+        payload = json.dumps({"model_id": "groq-free"})
+        await sched._queue.enqueue(
+            TaskType.MODEL_EVAL, ComputeTier.FREE_API, 0.4, "competence",
+            payload=payload,
+        )
 
 
 async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
@@ -271,44 +214,35 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
         logger.warning("GC: transcript archival failed", exc_info=True)
 
 
+@job_guard("schedule_maintenance", "Maintenance scheduling failed")
 async def schedule_maintenance(sched: SchedulerContext) -> None:
     """Enqueue mechanical infrastructure maintenance tasks if none active."""
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        # Mechanical tasks only — no LLM needed, run every maintenance_hours
-        maintenance_tasks = [
-            (TaskType.DISK_CLEANUP, 0.4, "preservation"),
-            (TaskType.BACKUP_VERIFICATION, 0.7, "preservation"),
-            (TaskType.DEAD_LETTER_REPLAY, 0.5, "cooperation"),
-            (TaskType.DB_MAINTENANCE, 0.3, "competence"),
-        ]
-        for task_type, priority, drive in maintenance_tasks:
-            active = await sched._queue.active_by_type(task_type)
-            if active == 0 and not await sched._recently_completed(
-                task_type, sched._maintenance_hours,
-            ):
-                await sched._queue.enqueue(
-                    task_type, ComputeTier.FREE_API, priority, drive,
-                )
+    # Mechanical tasks only — no LLM needed, run every maintenance_hours
+    maintenance_tasks = [
+        (TaskType.DISK_CLEANUP, 0.4, "preservation"),
+        (TaskType.BACKUP_VERIFICATION, 0.7, "preservation"),
+        (TaskType.DEAD_LETTER_REPLAY, 0.5, "cooperation"),
+        (TaskType.DB_MAINTENANCE, 0.3, "competence"),
+    ]
+    for task_type, priority, drive in maintenance_tasks:
+        active = await sched._queue.active_by_type(task_type)
+        if active == 0 and not await sched._recently_completed(
+            task_type, sched._maintenance_hours,
+        ):
+            await sched._queue.enqueue(
+                task_type, ComputeTier.FREE_API, priority, drive,
+            )
 
-        # ── GC operations ──────────────────────────────────────────
-        from genesis.runtime import GenesisRuntime
-        rt = GenesisRuntime.instance()
-        if rt.db is not None:
-            await _run_maintenance_gc(rt.db)
-
-        with contextlib.suppress(Exception):
-            GenesisRuntime.instance().record_job_success("schedule_maintenance")
-    except Exception as exc:
-        logger.exception("Maintenance scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_maintenance", str(exc))
-        except Exception:
-            pass
+    # ── GC operations ──────────────────────────────────────────
+    from genesis.runtime import GenesisRuntime
+    rt = GenesisRuntime.instance()
+    if rt.db is not None:
+        await _run_maintenance_gc(rt.db)
 
 
+@job_guard("schedule_analytical", "Analytical scheduling failed")
 async def schedule_analytical(sched: SchedulerContext) -> None:
     """Enqueue LLM-based analytical tasks if none active.
 
@@ -316,84 +250,47 @@ async def schedule_analytical(sched: SchedulerContext) -> None:
     because their inputs change slowly and their free-tier model output
     needs time to be consumed by deep reflection.
     """
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        analytical_tasks = [
-            (TaskType.GAP_CLUSTERING, 0.4, "competence"),
-            # anticipatory_research returns as a pipeline — see pipelines.py.
-        ]
-        for task_type, priority, drive in analytical_tasks:
-            active = await sched._queue.active_by_type(task_type)
-            if active == 0 and not await sched._recently_completed(
-                task_type, sched._analytical_hours,
-            ):
-                await sched._queue.enqueue(
-                    task_type, ComputeTier.FREE_API, priority, drive,
-                )
-        # prompt_effectiveness runs as a 3-step pipeline.
-        await sched.schedule_pipeline("prompt_effectiveness")
-        await sched.schedule_pipeline("anticipatory_research")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_analytical")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("Analytical scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_analytical", str(exc))
-        except Exception:
-            pass
+    analytical_tasks = [
+        (TaskType.GAP_CLUSTERING, 0.4, "competence"),
+        # anticipatory_research returns as a pipeline — see pipelines.py.
+    ]
+    for task_type, priority, drive in analytical_tasks:
+        active = await sched._queue.active_by_type(task_type)
+        if active == 0 and not await sched._recently_completed(
+            task_type, sched._analytical_hours,
+        ):
+            await sched._queue.enqueue(
+                task_type, ComputeTier.FREE_API, priority, drive,
+            )
+    # prompt_effectiveness runs as a 3-step pipeline.
+    await sched.schedule_pipeline("prompt_effectiveness")
+    await sched.schedule_pipeline("anticipatory_research")
 
 
+@job_guard("schedule_wing_audit", "Wing audit scheduling failed")
 async def schedule_wing_audit(sched: SchedulerContext) -> None:
     """Enqueue a wing audit task if none pending/running."""
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.WING_AUDIT)
-        if active == 0:
-            await sched._queue.enqueue(
-                TaskType.WING_AUDIT, ComputeTier.FREE_API, 0.4, "competence"
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_wing_audit")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("Wing audit scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_wing_audit", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.WING_AUDIT)
+    if active == 0:
+        await sched._queue.enqueue(
+            TaskType.WING_AUDIT, ComputeTier.FREE_API, 0.4, "competence"
+        )
 
 
+@job_guard("schedule_cc_memory_staleness", "CC memory staleness scheduling failed")
 async def schedule_cc_memory_staleness(sched: SchedulerContext) -> None:
     """Enqueue a CC memory staleness scan if none pending/running."""
-    try:
-        from genesis.surplus.types import ComputeTier, TaskType
+    from genesis.surplus.types import ComputeTier, TaskType
 
-        active = await sched._queue.active_by_type(TaskType.CC_MEMORY_STALENESS)
-        if active == 0:
-            await sched._queue.enqueue(
-                TaskType.CC_MEMORY_STALENESS, ComputeTier.FREE_API, 0.3, "competence"
-            )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("schedule_cc_memory_staleness")
-        except Exception:
-            pass
-    except Exception as exc:
-        logger.exception("CC memory staleness scheduling failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("schedule_cc_memory_staleness", str(exc))
-        except Exception:
-            pass
+    active = await sched._queue.active_by_type(TaskType.CC_MEMORY_STALENESS)
+    if active == 0:
+        await sched._queue.enqueue(
+            TaskType.CC_MEMORY_STALENESS, ComputeTier.FREE_API, 0.3, "competence"
+        )
 
 
 async def schedule_pipeline(sched: SchedulerContext, pipeline_name: str) -> str | None:

--- a/src/genesis/surplus/jobs/gitnexus.py
+++ b/src/genesis/surplus/jobs/gitnexus.py
@@ -15,6 +15,8 @@ import logging
 import re
 from pathlib import Path
 
+from genesis.surplus.jobs._guard import record_failure, record_success
+
 logger = logging.getLogger(__name__)
 
 
@@ -170,14 +172,10 @@ async def run_gitnexus_strip() -> None:
     intentionally keeps the block (read by cross-tool agents). Idempotent no-op
     when the block is absent.
     """
-    from genesis.runtime import GenesisRuntime
-
     try:
         if _strip_gitnexus_block(Path.home() / "genesis" / "CLAUDE.md"):
             logger.info("Stripped GitNexus block from CLAUDE.md (kept in AGENTS.md)")
-        with contextlib.suppress(Exception):
-            GenesisRuntime.instance().record_job_success("gitnexus_strip")
+        record_success("gitnexus_strip")
     except Exception as exc:
         logger.warning("GitNexus strip failed", exc_info=True)
-        with contextlib.suppress(Exception):
-            GenesisRuntime.instance().record_job_failure("gitnexus_strip", str(exc))
+        record_failure("gitnexus_strip", str(exc))

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from genesis.observability.types import Severity, Subsystem
+from genesis.surplus.jobs._guard import record_failure, record_success
 
 if TYPE_CHECKING:
     from genesis.surplus.jobs.context import SchedulerContext
@@ -33,11 +34,7 @@ async def dispatch_follow_ups(sched: SchedulerContext) -> None:
         pass
     try:
         summary = await sched._follow_up_dispatcher.run_cycle()
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("follow_up_dispatch")
-        except Exception:
-            pass
+        record_success("follow_up_dispatch")
         if summary.get("failures_detected", 0) > 0:
             logger.warning(
                 "Follow-up dispatch detected %d failure(s)",
@@ -45,21 +42,13 @@ async def dispatch_follow_ups(sched: SchedulerContext) -> None:
             )
     except Exception as exc:
         logger.exception("Follow-up dispatch failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("follow_up_dispatch", str(exc))
-        except Exception:
-            pass
+        record_failure("follow_up_dispatch", str(exc))
 
 
 async def run_recon_gather(sched: SchedulerContext) -> None:
     """Check watchlist projects for new GitHub releases and star counts."""
     if sched._recon_gatherer is None:
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("recon_gather", "gatherer not wired")
-        except Exception:
-            pass
+        record_failure("recon_gather", "gatherer not wired")
         return
     try:
         result = await sched._recon_gatherer.gather_releases()
@@ -82,11 +71,7 @@ async def run_recon_gather(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.DEBUG,
                 "heartbeat", "recon_gather completed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("recon_gather")
-        except Exception:
-            pass
+        record_success("recon_gather")
     except Exception as exc:
         logger.exception("Recon gather failed")
         if sched._event_bus:
@@ -95,23 +80,13 @@ async def run_recon_gather(sched: SchedulerContext) -> None:
                 "recon_gather.failed",
                 "Recon gather failed with exception",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("recon_gather", str(exc))
-        except Exception:
-            pass
+        record_failure("recon_gather", str(exc))
 
 
 async def run_model_intelligence(sched: SchedulerContext) -> None:
     """Run model intelligence scan (weekly)."""
     if sched._model_intelligence_job is None:
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure(
-                "model_intelligence", "job not wired",
-            )
-        except Exception:
-            pass
+        record_failure("model_intelligence", "job not wired")
         return
     try:
         result = await sched._model_intelligence_job.run()
@@ -122,11 +97,7 @@ async def run_model_intelligence(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.DEBUG,
                 "heartbeat", "model_intelligence completed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("model_intelligence")
-        except Exception:
-            pass
+        record_success("model_intelligence")
     except Exception as exc:
         logger.exception("Model intelligence scan failed")
         if sched._event_bus:
@@ -135,23 +106,13 @@ async def run_model_intelligence(sched: SchedulerContext) -> None:
                 "model_intelligence.failed",
                 "Model intelligence scan failed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("model_intelligence", str(exc))
-        except Exception:
-            pass
+        record_failure("model_intelligence", str(exc))
 
 
 async def run_skill_security_scan(sched: SchedulerContext) -> None:
     """Run the weekly skill-security scan (SkillSpector → recon findings)."""
     if sched._skill_security_scan_job is None:
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure(
-                "skill_security_scan", "job not wired",
-            )
-        except Exception:
-            pass
+        record_failure("skill_security_scan", "job not wired")
         return
     try:
         result = await sched._skill_security_scan_job.run()
@@ -162,11 +123,7 @@ async def run_skill_security_scan(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.DEBUG,
                 "heartbeat", "skill_security_scan completed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("skill_security_scan")
-        except Exception:
-            pass
+        record_success("skill_security_scan")
     except Exception as exc:
         logger.exception("Skill-security scan failed")
         if sched._event_bus:
@@ -175,11 +132,7 @@ async def run_skill_security_scan(sched: SchedulerContext) -> None:
                 "skill_security_scan.failed",
                 "Skill-security scan failed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("skill_security_scan", str(exc))
-        except Exception:
-            pass
+        record_failure("skill_security_scan", str(exc))
 
 
 async def run_github_discovery(sched: SchedulerContext) -> None:
@@ -192,13 +145,7 @@ async def run_github_discovery(sched: SchedulerContext) -> None:
     except Exception:
         pass
     if sched._github_discovery_job is None:
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure(
-                "github_discovery", "job not wired",
-            )
-        except Exception:
-            pass
+        record_failure("github_discovery", "job not wired")
         return
     try:
         result = await sched._github_discovery_job.run()
@@ -209,11 +156,7 @@ async def run_github_discovery(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.DEBUG,
                 "heartbeat", "github_discovery completed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("github_discovery")
-        except Exception:
-            pass
+        record_success("github_discovery")
     except Exception as exc:
         logger.exception("GitHub Discovery failed")
         if sched._event_bus:
@@ -222,11 +165,7 @@ async def run_github_discovery(sched: SchedulerContext) -> None:
                 "github_discovery.failed",
                 "GitHub Discovery failed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("github_discovery", str(exc))
-        except Exception:
-            pass
+        record_failure("github_discovery", str(exc))
 
 
 async def run_models_md_synthesis(sched: SchedulerContext) -> None:
@@ -244,13 +183,7 @@ async def run_models_md_synthesis(sched: SchedulerContext) -> None:
     except Exception:
         pass
     if sched._models_md_synthesis_job is None:
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure(
-                "models_md_synthesis", "job not wired",
-            )
-        except Exception:
-            pass
+        record_failure("models_md_synthesis", "job not wired")
         return
     try:
         result = await sched._models_md_synthesis_job.run()
@@ -268,11 +201,7 @@ async def run_models_md_synthesis(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.DEBUG,
                 "heartbeat", "models_md_synthesis dispatched",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("models_md_synthesis")
-        except Exception:
-            pass
+        record_success("models_md_synthesis")
     except Exception as exc:
         logger.exception("Models.md synthesis failed")
         if sched._event_bus:
@@ -281,11 +210,7 @@ async def run_models_md_synthesis(sched: SchedulerContext) -> None:
                 "models_md_synthesis.failed",
                 "Models.md synthesis failed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("models_md_synthesis", str(exc))
-        except Exception:
-            pass
+        record_failure("models_md_synthesis", str(exc))
 
 
 async def run_db_integrity_check(sched: SchedulerContext) -> None:
@@ -310,18 +235,10 @@ async def run_db_integrity_check(sched: SchedulerContext) -> None:
         else:
             logger.error("DB integrity check FAILED: %s", status[:500])
             await sched._alarm_db_integrity(status)
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("db_integrity_check")
-        except Exception:
-            pass
+        record_success("db_integrity_check")
     except Exception as exc:
         logger.exception("DB integrity check job failed")
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("db_integrity_check", str(exc))
-        except Exception:
-            pass
+        record_failure("db_integrity_check", str(exc))
 
 
 async def alarm_db_integrity(sched: SchedulerContext, detail: str) -> None:
@@ -368,13 +285,7 @@ async def run_memory_extraction(sched: SchedulerContext) -> None:
         logger.warning("Pause check failed — skipping extraction as precaution", exc_info=True)
         return
     if sched._extraction_store is None or sched._extraction_router is None:
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure(
-                "memory_extraction", "extraction deps not wired",
-            )
-        except Exception:
-            pass
+        record_failure("memory_extraction", "extraction deps not wired")
         return
     try:
         from genesis.memory.extraction_job import run_extraction_cycle
@@ -398,11 +309,7 @@ async def run_memory_extraction(sched: SchedulerContext) -> None:
                 Subsystem.SURPLUS, Severity.DEBUG,
                 "heartbeat", "memory_extraction completed",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_success("memory_extraction")
-        except Exception:
-            pass
+        record_success("memory_extraction")
     except Exception as exc:
         logger.exception("Memory extraction failed")
         if sched._event_bus:
@@ -411,8 +318,4 @@ async def run_memory_extraction(sched: SchedulerContext) -> None:
                 "memory_extraction.failed",
                 "Memory extraction failed with exception",
             )
-        try:
-            from genesis.runtime import GenesisRuntime
-            GenesisRuntime.instance().record_job_failure("memory_extraction", str(exc))
-        except Exception:
-            pass
+        record_failure("memory_extraction", str(exc))

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -1,9 +1,12 @@
 """Direct-run jobs — scheduled work delegating to wired components.
 
-Bodies extracted verbatim from ``SurplusScheduler``; the scheduler keeps every
-original method name as a thin delegate. Function-scope imports are
-intentional — they are both the tests' patch-target seam and the import-cycle
-breaker; do not hoist them to module top.
+Bodies extracted from ``SurplusScheduler``; the scheduler keeps every
+original method name as a thin delegate. Job-health recording goes through
+the swallow-safe ``_guard`` helpers; each job's pause check, not-wired
+guard, and event emissions stay in its body (they vary per job — see
+``_guard.py``). Function-scope imports are intentional — they are both the
+tests' patch-target seam and the import-cycle breaker; do not hoist them to
+module top.
 """
 
 from __future__ import annotations

--- a/tests/test_surplus/test_job_guard.py
+++ b/tests/test_surplus/test_job_guard.py
@@ -1,0 +1,151 @@
+"""Tests for the shared surplus job guard (genesis.surplus.jobs._guard).
+
+Locks the uniform job protocol the decorator encodes: success recording,
+exception swallowing with log-parity, the SKIP sentinel for
+disabled-by-config paths, and the swallow-safety of the record helpers.
+Job-health SQL persistence is owned by tests/test_runtime/test_job_health.py;
+dispatch-level failure observation by test_dispatch.py — not re-covered here.
+"""
+
+import inspect
+import logging
+from unittest.mock import MagicMock, patch
+
+from genesis.surplus.jobs._guard import (
+    SKIP,
+    job_guard,
+    record_failure,
+    record_success,
+)
+
+
+def _mock_runtime():
+    """Patch genesis.runtime.GenesisRuntime; returns (patcher, mock_rt)."""
+    patcher = patch("genesis.runtime.GenesisRuntime")
+    mock_cls = patcher.start()
+    mock_rt = MagicMock()
+    mock_cls.instance.return_value = mock_rt
+    return patcher, mock_rt
+
+
+# ── decorator: the uniform protocol ─────────────────────────────────
+
+async def test_success_records_once_and_propagates_return():
+    sentinel = object()
+
+    @job_guard("some_job", "Some job failed")
+    async def body():
+        return sentinel
+
+    patcher, mock_rt = _mock_runtime()
+    try:
+        result = await body()
+    finally:
+        patcher.stop()
+
+    assert result is sentinel
+    mock_rt.record_job_success.assert_called_once_with("some_job")
+    mock_rt.record_job_failure.assert_not_called()
+
+
+async def test_exception_swallowed_logged_and_recorded(caplog):
+    @job_guard("some_job", "Some job failed")
+    async def body():
+        raise RuntimeError("boom")
+
+    patcher, mock_rt = _mock_runtime()
+    try:
+        with caplog.at_level(logging.ERROR):
+            result = await body()  # must NOT raise
+    finally:
+        patcher.stop()
+
+    assert result is None
+    mock_rt.record_job_failure.assert_called_once_with("some_job", "boom")
+    mock_rt.record_job_success.assert_not_called()
+    # Log-parity: logger.exception(fail_log) under the body's module logger.
+    err = [r for r in caplog.records if r.message == "Some job failed"]
+    assert len(err) == 1
+    assert err[0].name == body.__module__
+    assert err[0].exc_info is not None
+
+
+async def test_skip_sentinel_records_nothing():
+    @job_guard("some_job", "Some job failed")
+    async def body():
+        return SKIP
+
+    patcher, mock_rt = _mock_runtime()
+    try:
+        result = await body()
+    finally:
+        patcher.stop()
+
+    assert result is None
+    mock_rt.record_job_success.assert_not_called()
+    mock_rt.record_job_failure.assert_not_called()
+
+
+async def test_decorated_fn_is_still_a_coroutine_function():
+    # test_jobs_extraction.py's contract: module job fns must satisfy
+    # inspect.iscoroutinefunction after decoration.
+    @job_guard("some_job", "Some job failed")
+    async def body():
+        return None
+
+    assert inspect.iscoroutinefunction(body)
+    assert body.__name__ == "body"
+
+
+# ── record helpers: swallow-safety ──────────────────────────────────
+
+def test_record_helpers_call_through():
+    patcher, mock_rt = _mock_runtime()
+    try:
+        record_success("job_a")
+        record_failure("job_b", "bad")
+    finally:
+        patcher.stop()
+
+    mock_rt.record_job_success.assert_called_once_with("job_a")
+    mock_rt.record_job_failure.assert_called_once_with("job_b", "bad")
+
+
+def test_record_helpers_swallow_recorder_exceptions():
+    patcher, mock_rt = _mock_runtime()
+    try:
+        mock_rt.record_job_success.side_effect = RuntimeError("db gone")
+        mock_rt.record_job_failure.side_effect = RuntimeError("db gone")
+        record_success("job_a")  # must not raise
+        record_failure("job_b", "bad")  # must not raise
+    finally:
+        patcher.stop()
+
+
+def test_record_helpers_swallow_instance_lookup_failure():
+    with patch("genesis.runtime.GenesisRuntime") as mock_cls:
+        mock_cls.instance.side_effect = RuntimeError("no runtime")
+        record_success("job_a")  # must not raise
+        record_failure("job_b", "bad")  # must not raise
+
+
+# ── integration: the one disabled-by-config path in gates.py ────────
+
+async def test_schedule_code_audit_disabled_records_nothing():
+    # The _enable_code_audits early-out predates the decorator and never
+    # recorded job health (its job_health row is stale-by-design while
+    # audits are off). SKIP must preserve that exactly.
+    import types
+
+    from genesis.surplus.jobs import gates
+
+    sched = types.SimpleNamespace(_enable_code_audits=False)
+
+    patcher, mock_rt = _mock_runtime()
+    try:
+        await gates.schedule_code_audit(sched)
+    finally:
+        patcher.stop()
+
+    mock_rt.record_job_success.assert_not_called()
+    mock_rt.record_job_failure.assert_not_called()


### PR DESCRIPTION
## Summary

Final deferred item from the 2026-07-07 oversize-file campaign (Part B follow-through). The 23 surplus job bodies span 6 distinct guard protocols; this PR DRYs exactly the part that is genuinely uniform and leaves every per-job variance in place.

- **New `src/genesis/surplus/jobs/_guard.py`**: `job_guard(job_id, fail_log)` decorator encoding the uniform enqueue-gate protocol (record success / log + record failure / swallow — APScheduler jobs must not raise), a `SKIP` sentinel for disabled-by-config paths, and swallow-safe `record_success` / `record_failure` helpers. Function-scope `genesis.runtime` import preserved as the test patch seam and import-cycle breaker.
- **9 uniform gate jobs decorated** (gates.py): bodies become bare work.
- **10 non-uniform jobs get helper substitution only**: the nested `try/GenesisRuntime/except: pass` record blocks collapse to one-line helpers; pause checks, event emissions, not-wired guards, and all logging untouched.
- **4 job bodies untouched**: the dream pair (bespoke `record_job_start` + owner-checked finally + truncation), `run_gitnexus_reindex` (multi-exit record protocol), `_dispatch_loop` (mid-loop heartbeats). **`scheduler.py` has a zero diff.**

A fully-parametrized decorator was considered and rejected: it would relocate per-job variance into decorator arg cocktails instead of removing it.

## Per-job before/after

| Job | Treatment | Behavior delta |
|---|---|---|
| schedule_code_audit | @job_guard | none — disabled-by-config early return becomes `return SKIP` (records nothing, exactly as before; locked by new integration test) |
| schedule_code_index, schedule_j9_eval_batch, schedule_fresh_session_test, schedule_model_eval, schedule_analytical, schedule_wing_audit, schedule_cc_memory_staleness | @job_guard | none — job-id, fail-log message, logger name (`fn.__module__`), swallow semantics byte-identical |
| schedule_maintenance | @job_guard | none — `contextlib.suppress` success idiom absorbed by the helper (semantically identical) |
| brainstorm_check | helpers | none — pause fail-CLOSED + `brainstorm.failed` event untouched; failure-record-before-emit order preserved |
| dispatch_follow_ups | helpers | none — success-record-before-failures-warning order preserved |
| run_recon_gather, run_model_intelligence, run_skill_security_scan, run_github_discovery, run_models_md_synthesis, run_memory_extraction | helpers | none — not-wired guards, heartbeat/`*.failed` events, pause semantics untouched |
| run_db_integrity_check | helpers | none — success still recorded after an integrity alarm (job ran; the alarm is the signal) |
| run_gitnexus_strip | helpers | negligible — the record helper now also swallows a (practically impossible) `genesis.runtime` import failure that previously would have propagated before the strip work; aligns with every other job's semantics |
| run_dream_cycle, run_dream_synthesis_drain, run_gitnexus_reindex, _dispatch_loop | untouched | — |

## Tests

- New `tests/test_surplus/test_job_guard.py` (8 tests): success/failure/SKIP protocol, log-parity (module logger + exc_info), `iscoroutinefunction` contract for the extraction tests, helper swallow-safety (recorder raising, `instance()` lookup failing), and an integration lock on the real `schedule_code_audit` disabled path (previously locked by no test).
- `tests/test_surplus/` + `tests/test_pipeline/test_pause_guard.py` + `tests/test_runtime/test_job_health.py`: 300 passed.

## Verification

- Frozen constraints checked: scheduler.py diff empty, GROUNDWORK count unchanged (3), no module-top `genesis.runtime` imports under surplus/, job-id strings byte-identical (they key job_health rows + the MCP tool).
- Post-merge E2E planned: restart gate, job-id set diff, decorated gate job recording within ~1h (gates fire at :28 past the hour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)