### PR TITLE
fix(executor): stop text-only reviewer from vetoing on file existence

### DIFF
--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -674,9 +674,34 @@ class TaskReviewer:
             else "Try hard to find flaws, gaps, edge cases, and "
                  "potential failures. Be thorough and skeptical."
         )
+        # This reviewer is TEXT-ONLY (routed to an API model with no tools):
+        # it sees only the reported deliverable below and has no filesystem,
+        # shell, or tool access. A separate tool-capable verifier independently
+        # confirms that files exist, tests pass, and URLs are live. Without
+        # this scoping the model fabricates existence failures — e.g. blocking
+        # a task because worktree-built files are "not in the main tree".
+        scope = (
+            "## Your access is limited — read this first\n"
+            "You are a TEXT-ONLY reviewer with NO filesystem, shell, or tool "
+            "access. You see only the reported deliverable below. A separate "
+            "tool-capable verifier independently checks reality (that files "
+            "exist, tests actually pass, URLs are live).\n"
+            "- Assume the reported deliverable is factually accurate for this "
+            "review. Do NOT fail it because you personally cannot confirm an "
+            "artifact exists or that a step ran.\n"
+            "- Do NOT judge WHERE artifacts live. Code is built in an isolated "
+            "git worktree and delivered afterward; files being absent from the "
+            "main tree / working tree is EXPECTED and is never a defect.\n"
+            "- Judge only what the text supports: does the described work, if "
+            "accurately reported, satisfy the requirements? Is the approach "
+            "sound, complete, and internally correct? Flag genuine design, "
+            "completeness, or correctness gaps — never unverifiable existence "
+            "or execution claims.\n\n"
+        )
         return (
             f"You are {role}. Evaluate whether the deliverable "
             "meets the requirements.\n\n"
+            f"{scope}"
             "## Requirements\n"
             f"{requirements}\n\n"
             "## Deliverable\n"

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -624,3 +624,48 @@ class TestPreMortem:
 
         assert result is not None
         assert result.confidence == 75
+
+
+# ---------------------------------------------------------------------------
+# Fresh-eyes (text-only) reviewer scoping — must not judge file existence
+# ---------------------------------------------------------------------------
+
+
+class TestFreshEyesPromptScoping:
+    """The text-only fresh-eyes reviewer has no filesystem access, so its
+    prompt must forbid existence/location/execution judgments (which caused
+    false 'artifacts not in main tree' failures on worktree-built code)."""
+
+    def test_text_only_prompt_disclaims_fs_access(self) -> None:
+        from genesis.autonomy.executor.review import (
+            _CALL_SITE_EXECUTOR_REVIEW,
+            TaskReviewer,
+        )
+
+        prompt = TaskReviewer._build_verify_prompt(
+            _CALL_SITE_EXECUTOR_REVIEW,
+            deliverable="Created src/genesis/skills/dad_joke/__init__.py in the worktree.",
+            requirements="A dad_joke skill exists with a test.",
+        )
+        low = prompt.lower()
+        # Must disclose no-fs access and forbid existence/location vetoes.
+        assert "text-only" in low
+        assert "no filesystem" in low
+        assert "worktree" in low
+        assert "main tree" in low
+        # Must tell it not to fail on unverifiable existence.
+        assert "do not fail" in low or "never" in low
+        # Still carries the deliverable + requirements.
+        assert "dad_joke" in prompt
+        assert "## Requirements" in prompt
+
+    def test_tool_capable_prompt_still_uses_tools(self) -> None:
+        # The tool-capable verifier is unchanged — it SHOULD check reality.
+        from genesis.autonomy.executor.review import TaskReviewer
+
+        prompt = TaskReviewer._build_active_verify_prompt(
+            deliverable="Made a file.", requirements="A file exists.",
+        )
+        low = prompt.lower()
+        assert "read the file" in low
+        assert "run the tests" in low


### PR DESCRIPTION
## Problem

The executor verify phase (`review.py::review_deliverable`) runs two reviewers:

- **Adversarial** (`_verify_via_invoker`) — a tool-capable CC session that runs **in the task worktree**, so it can READ files and RUN tests.
- **Fresh-eyes** (`_llm_review`) — a **pure text router/API call with NO filesystem, shell, or tool access**; it only sees the reported deliverable text.

`_build_verify_prompt` never disclosed that the fresh-eyes model has no tools, so the model made — and *failed on* — file-existence claims it cannot verify. `_assess_feedback` fails the task if **either** reviewer returns `verdict: fail`, so the blind reviewer's hallucinated veto overrode the tool-capable reviewer's PASS.

**Surfaced by the 2026-07-07 build-lane canary:** a trivial `dad_joke` skill built, committed (`b0c4ac80`), and passed its tests in the worktree — the adversarial reviewer PASSED — but the fresh-eyes reviewer failed it with *"artifacts don't exist in the main tree"* (worktree-built code is legitimately absent from the main tree until delivery), blocking the task before it could open its draft PR.

## Fix

Scope the text-only prompt to what it can actually judge:

- Disclose it is a **text-only reviewer with no filesystem/tool access**; a separate tool-capable verifier checks reality.
- **Assume the reported deliverable is accurate** — do not fail because existence can't be personally confirmed.
- **Do not judge where artifacts live** — worktree-built code being absent from the main tree is *expected*, never a defect.
- Flag only genuine **design / completeness / correctness** gaps.

The tool-capable adversarial prompt (`_build_active_verify_prompt`) is unchanged — it still actively READs files and RUNs tests.

## Tests

Prompt-scoping assertions for both the text-only prompt (discloses no-fs, forbids existence/location vetoes, still carries requirements+deliverable) and the tool-capable prompt (still instructs to use tools). Full `test_review.py` suite green (44).

## Scope

Pure prompt change to one text-only reviewer; no behavior change to the tool-capable verifier or the programmatic gate. This is an executor review fix, independent of the build lane (PR-6) that surfaced it. A separate follow-up (`e8ff8a5f`) tracks the unrelated outreach notification-hallucination bug the same canary exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)