### PR TITLE
fix(guardian): read non-LVM pool used% from df, not a bogus incus flag

### DIFF
--- a/src/genesis/guardian/pool.py
+++ b/src/genesis/guardian/pool.py
@@ -15,7 +15,6 @@ Design:
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -203,30 +202,46 @@ async def _lvm_source(pool_name: str) -> str | None:
     return source
 
 
+async def _pool_used_pct_via_df(mount: str) -> float | None:
+    """Filesystem used% of a pool mount via ``df`` (statvfs).
+
+    The tiering signal for non-LVM pools, where there is no thin-pool
+    data%/metadata%. Returns None on any error (missing mount, unparsable
+    output, zero size) so a probe failure is never a false alarm.
+    """
+    rc, out, _ = await _run_subprocess(
+        "df", "-B1", "--output=used,size", mount, timeout=10.0,
+    )
+    if rc != 0:
+        return None
+    lines = out.strip().splitlines()
+    if len(lines) < 2:  # header + at least one data row
+        return None
+    try:
+        used, size = (int(x) for x in lines[-1].split()[:2])
+    except (ValueError, IndexError):
+        return None
+    if size <= 0:
+        return None
+    return 100.0 * used / size
+
+
 async def measure_storage_pool(config: GuardianConfig) -> StoragePoolStatus:
     """Measure the host storage pool. Defensive: failure → detected=False."""
     pool_name = await _detect_pool_name(config)
     if not pool_name:
         return StoragePoolStatus(detected=False, detail="pool name undetected")
 
-    # Backend-agnostic used% via incus storage info (best-effort).
     pool_used_pct: float | None = None
-    rc, out, _ = await _run_subprocess(
-        "incus", "storage", "info", pool_name, "--format", "json", timeout=10.0,
-    )
-    if rc == 0:
-        try:
-            info = json.loads(out)
-            space = info.get("space") or info.get("resources", {}).get("space", {})
-            used, total = space.get("used"), space.get("total")
-            if isinstance(used, (int, float)) and total:
-                pool_used_pct = 100.0 * used / total
-        except (json.JSONDecodeError, TypeError, AttributeError, ZeroDivisionError):
-            pass
 
     vg = await _lvm_source(pool_name)
     if not vg:
-        # Non-LVM backend — pool_used_pct (if any) is the only signal.
+        # Non-LVM backend (btrfs/dir): the pool mount's filesystem used% is the
+        # only tiering signal (there is no thin-pool data%/metadata%). incus
+        # storage info exposes no machine-readable space for an uncapped
+        # btrfs-on-LV pool, so read the mount directly — the same source
+        # snapshots.py uses for this pool.
+        pool_used_pct = await _pool_used_pct_via_df(pool_mount_path(pool_name))
         return StoragePoolStatus(
             detected=pool_used_pct is not None,
             pool_used_pct=pool_used_pct,

--- a/tests/test_guardian/test_pool.py
+++ b/tests/test_guardian/test_pool.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
+from genesis.guardian import pool as pool_mod
 from genesis.guardian.config import StoragePoolConfig
 from genesis.guardian.pool import (
     TIER_CRIT,
@@ -12,6 +15,7 @@ from genesis.guardian.pool import (
     TIER_WARN,
     StoragePoolStatus,
     decide_alert,
+    measure_storage_pool,
     parse_lvs_data_metadata,
     worst_tier,
 )
@@ -56,8 +60,8 @@ class TestWorstTier:
         assert worst_tier(_btrfs(93.0), self.cfg) == TIER_CRIT
 
     def test_pool_used_ignored_when_lvm_percents_present(self):
-        # LVM-thin: data%/metadata% stay the sole authority — incus's used%
-        # is also populated there and must NOT change long-standing behavior.
+        # LVM-thin: data%/metadata% stay the sole authority. Even if a used%
+        # were present, it must NOT change long-standing behavior.
         s = StoragePoolStatus(
             detected=True, data_pct=50.0, metadata_pct=40.0, pool_used_pct=95.0,
         )
@@ -118,3 +122,102 @@ class TestDecideAlert:
     def test_sustained_with_no_prior_time_alerts(self):
         # Defensive: missing last_alert_at shouldn't suppress a live problem.
         assert decide_alert(TIER_WARN, TIER_WARN, None, self.now, 6.0).should_alert
+
+
+def _df(used: int, size: int) -> str:
+    # `df -B1 --output=used,size` form: header row + one data row.
+    return f"       Used    1B-blocks\n{used} {size}\n"
+
+
+class TestPoolUsedViaDf:
+    """The non-LVM used% signal. `incus storage info` has no machine-readable
+    space for an uncapped btrfs-on-LV pool (its `--format json` flag doesn't
+    even exist), so the mount is read via df."""
+
+    @pytest.mark.asyncio
+    async def test_computes_used_pct(self, monkeypatch):
+        async def _run(*a, **k):
+            return 0, _df(48_318_382_080, 322_122_547_200), ""
+
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+        pct = await pool_mod._pool_used_pct_via_df("/mnt/pool")
+        assert pct == pytest.approx(15.0, abs=0.1)
+
+    @pytest.mark.asyncio
+    async def test_rc_nonzero_is_none(self, monkeypatch):
+        async def _run(*a, **k):
+            return 1, "", "df: no such file or directory"
+
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+        assert await pool_mod._pool_used_pct_via_df("/nope") is None
+
+    @pytest.mark.asyncio
+    async def test_single_line_output_is_none(self, monkeypatch):
+        async def _run(*a, **k):
+            return 0, "only a header\n", ""
+
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+        assert await pool_mod._pool_used_pct_via_df("/mnt/pool") is None
+
+    @pytest.mark.asyncio
+    async def test_nonnumeric_row_is_none(self, monkeypatch):
+        async def _run(*a, **k):
+            return 0, "Used 1B-blocks\nfoo bar\n", ""
+
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+        assert await pool_mod._pool_used_pct_via_df("/mnt/pool") is None
+
+    @pytest.mark.asyncio
+    async def test_zero_size_is_none(self, monkeypatch):
+        # Never divide by zero — a 0-size mount yields no signal, not a crash.
+        async def _run(*a, **k):
+            return 0, _df(0, 0), ""
+
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+        assert await pool_mod._pool_used_pct_via_df("/mnt/pool") is None
+
+
+class TestMeasureNonLvmPool:
+    """End-to-end of the non-LVM branch of measure_storage_pool: a btrfs pool
+    must surface a real pool_used_pct (from df) so worst_tier can tier it."""
+
+    @pytest.mark.asyncio
+    async def test_btrfs_pool_populates_used_pct(self, monkeypatch):
+        async def _detect(_config):
+            return "genesis-btrfs"
+
+        async def _lvm(_name):
+            return None  # non-LVM backend
+
+        async def _run(*a, **k):
+            return 0, _df(48_318_382_080, 322_122_547_200), ""
+
+        monkeypatch.setattr(pool_mod, "_detect_pool_name", _detect)
+        monkeypatch.setattr(pool_mod, "_lvm_source", _lvm)
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+
+        status = await measure_storage_pool(object())
+        assert status.detected is True
+        assert status.data_pct is None and status.metadata_pct is None
+        assert status.pool_used_pct == pytest.approx(15.0, abs=0.1)
+        # The whole point: a measured btrfs pool now tiers.
+        assert worst_tier(status, StoragePoolConfig()) == TIER_OK
+
+    @pytest.mark.asyncio
+    async def test_btrfs_df_failure_is_not_detected(self, monkeypatch):
+        async def _detect(_config):
+            return "genesis-btrfs"
+
+        async def _lvm(_name):
+            return None
+
+        async def _run(*a, **k):
+            return 1, "", "df failed"
+
+        monkeypatch.setattr(pool_mod, "_detect_pool_name", _detect)
+        monkeypatch.setattr(pool_mod, "_lvm_source", _lvm)
+        monkeypatch.setattr(pool_mod, "_run_subprocess", _run)
+
+        status = await measure_storage_pool(object())
+        assert status.detected is False
+        assert status.pool_used_pct is None


### PR DESCRIPTION
## Summary

Fixes a latent bug in the Guardian's storage-pool measurement, surfaced while validating #944 (btrfs-on-LVM support) on real hardware.

`measure_storage_pool` derived the backend-agnostic `pool_used_pct` from `incus storage info <pool> --format json` — but **`--format` is not a valid flag for `incus storage info`**. The call therefore always errored (`Error: unknown flag: --format`), and `pool_used_pct` was **perpetually `None`**.

This went unnoticed because LVM-thin pools tier on `data%`/`metadata%` (from `lvs`); `pool_used_pct` is only the *sole* tiering signal for **non-LVM (btrfs/dir) pools** — which never ran this path before #944. On a btrfs pool the effect was that `worst_tier` stayed permanently `unknown`: **no early warning as the pool fills toward a read-only-rootfs outage** (the exact failure the storage tiers exist to pre-empt).

## Fix

- Derive `pool_used_pct` from `df -B1 --output=used,size <mount>` on the pool mount — the same source `snapshots.py` already uses for this pool — via a new defensive `_pool_used_pct_via_df` helper. Every failure path (rc≠0, short/garbage output, zero size) returns `None`, never raises.
- Scope it to the **non-LVM branch only**. The LVM-thin path is unchanged: `pool_used_pct` stays `None` there (unused — `data%`/`metadata%` remain authoritative), byte-for-byte identical to prior behavior.
- Remove the now-unused broken incus call and the `import json` it needed.

## Validation

- **Live on the btrfs-on-LVM host:** the old call returns `Error: unknown flag: --format`; `df` on the pool mount reports ~16% used. After deploy, `disk-status` should report `detected: true`, `pool_used_pct ≈ 16`, `tier: ok` (previously `detected: false`, `tier: unknown`).
- New tests (`tests/test_guardian/test_pool.py`): `_pool_used_pct_via_df` success + every failure path (rc≠0, single-line, non-numeric, zero-size), and the `measure_storage_pool` non-LVM branch end-to-end (populates used% → tiers) plus df-failure → `detected: false`.
- Full `tests/test_guardian/` green (615 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
