### PR TITLE
fix(outreach): task notifications go verbatim + concise voice TL;DR (stop fabrication)

### DIFF
--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -81,8 +81,8 @@ health_alerts:
 # Everything still goes to Telegram regardless — this only controls what
 # interrupts the user out loud during `hours`. This block is authoritative;
 # editing it changes behavior on next server restart. Keep entries specific
-# (prefix match) and keep `task_notification` in sync with the signal_type
-# set in src/genesis/autonomy/executor/engine.py _notify.
+# (prefix match) and keep the `task_*` entries in sync with the signal_type
+# values set in src/genesis/autonomy/executor/engine.py _notify.
 voice:
   alert_ids:
     # Memory-system + resource emergencies (matched via source_id)
@@ -95,6 +95,9 @@ voice:
     - "sentinel_escalation"
     - "sentinel_approval"
     - "sentinel_action_approval"
-    # Autonomous task hit a blocker/alert
-    - "task_notification"
+    # Autonomous task reached an attention-worthy state (complete / alert).
+    # `task_progress` is intentionally omitted — routine progress pings go to
+    # Telegram only and never interrupt by voice.
+    - "task_complete"
+    - "task_alert"
   hours: [9, 2]   # 9am-2am local (wraps midnight); end hour exclusive

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -385,7 +385,7 @@ class CCSessionExecutor:
                     task_id,
                     f"Proceeding with task: {description} "
                     f"({len(steps)} steps)",
-                    "alert",
+                    "progress",
                 )
 
                 step_results = []
@@ -676,7 +676,8 @@ class CCSessionExecutor:
                 f"Task completed. {len(step_results)} steps executed.",
             )
             await self._notify(
-                task_id, f"Task completed: {description}", "alert",
+                task_id, f"Task completed: {description}", "success",
+                voice_text="Task completed successfully.",
             )
             return True
 
@@ -747,7 +748,10 @@ class CCSessionExecutor:
         await task_states.update(
             self._db, task_id, blockers=reason,
         )
-        await self._notify(task_id, f"Task failed: {reason}", "alert")
+        await self._notify(
+            task_id, f"Task failed: {reason}", "alert",
+            voice_text="A task failed — details are in Telegram.",
+        )
 
     # =================================================================
     # Exit gate + challenge recording
@@ -957,7 +961,10 @@ class CCSessionExecutor:
             await self._transition(task_id, TaskPhase.BLOCKED)
 
         # 3. THEN notify
-        await self._notify(task_id, f"Blocked: {description}", "blocker")
+        await self._notify(
+            task_id, f"Blocked: {description}", "blocked",
+            voice_text="A task is blocked and needs your input.",
+        )
 
     # =================================================================
     # Checkpoint (Amendment #13: global pause)
@@ -1188,30 +1195,60 @@ class CCSessionExecutor:
         self,
         task_id: str,
         message: str,
-        category: str,
+        kind: str,
+        *,
+        voice_text: str | None = None,
     ) -> None:
-        """Send notification via outreach pipeline."""
+        """Send a task notification via the outreach pipeline.
+
+        Task notifications are machine-generated FACTS, so they are delivered
+        ``verbatim`` — the LLM drafter is never in the path and cannot rewrite
+        or fabricate them. ``kind`` selects the outreach category and the voice
+        signal_type:
+
+        - ``progress`` — routine progress; Telegram only, never spoken.
+        - ``success``  — completion / result; spoken (attention-worthy).
+        - ``alert``    — a problem needing attention; spoken.
+        - ``blocked``  — highest-priority block; spoken (BLOCKER category).
+
+        ``voice_text`` is a short, factual TL;DR spoken aloud in place of the
+        full ``message`` (so file paths, branch names, and commands are never
+        read out). Pass None for notifications that must stay silent.
+        """
         if not self._outreach:
             logger.debug("No outreach pipeline, skipping: %s", message)
             return
 
         from genesis.outreach.types import OutreachCategory, OutreachRequest
 
-        cat = {
-            "blocker": OutreachCategory.BLOCKER,
-            "alert": OutreachCategory.ALERT,
-        }.get(category, OutreachCategory.ALERT)
+        # kind -> (category-is-blocker, voice signal_type, salience). category
+        # is preserved from the pre-refactor mapping (blocker vs alert) so
+        # governance/threshold/routing behavior is unchanged; the new levers
+        # (verbatim + signal_type + voice_text) are orthogonal to it.
+        kinds = {
+            "progress": (False, "task_progress", 0.5),
+            "success": (False, "task_complete", 0.5),
+            "alert": (False, "task_alert", 0.5),
+            "blocked": (True, "task_alert", 0.9),
+        }
+        is_blocker, signal_type, salience = kinds.get(kind, kinds["alert"])
+        cat = OutreachCategory.BLOCKER if is_blocker else OutreachCategory.ALERT
 
         request = OutreachRequest(
             category=cat,
             topic=f"Task {task_id[:8]}",
             context=message,
-            salience_score=0.9 if cat == OutreachCategory.BLOCKER else 0.5,
-            # signal_type makes task notifications a toggleable voice menu
-            # item (voice_alert_ids -> OutreachPipeline._should_voice matches
-            # this). source_id identifies the task in outreach history.
-            signal_type="task_notification",
+            salience_score=salience,
+            # Machine fact: deliver exactly, never LLM-drafted.
+            verbatim=True,
+            # signal_type is the voice-menu key (voice_alert_ids ->
+            # OutreachPipeline._should_voice). Only task_complete / task_alert
+            # are on the allowlist; task_progress is Telegram-only. source_id
+            # identifies the task in outreach history.
+            signal_type=signal_type,
             source_id=f"task:{task_id}",
+            # Short spoken TL;DR (no tokens/paths aloud); None → not spoken.
+            voice_text=voice_text,
         )
 
         try:
@@ -1351,7 +1388,8 @@ class CCSessionExecutor:
                 task_id,
                 f"Build delivered: draft PR {result.pr_url} (branch {branch}). "
                 "Review and merge when ready.",
-                "alert",
+                "success",
+                voice_text="Build finished — a draft pull request is ready for review.",
             )
         else:
             await self._set_output(
@@ -1362,6 +1400,7 @@ class CCSessionExecutor:
                 f"Build branch {branch} pushed, but draft PR creation failed: "
                 f"{result.error or 'unknown'}. Open the PR manually.",
                 "alert",
+                voice_text="A build finished, but the pull request didn't open automatically.",
             )
 
     async def _task_source(self, task_id: str) -> str:
@@ -1479,6 +1518,7 @@ class CCSessionExecutor:
                     "Nothing was pushed — widening build scope is a human decision."
                 ),
                 "alert",
+                voice_text="A build was parked by the safety gate.",
             )
         return result
 
@@ -1510,6 +1550,7 @@ class CCSessionExecutor:
                 "Deliverable task finished, but no rendered file was found — "
                 "check the task output.",
                 "alert",
+                voice_text="A deliverable task finished but produced no file.",
             )
             return
 
@@ -1527,7 +1568,8 @@ class CCSessionExecutor:
             task_id,
             f"Deliverable ready and Gate-2 verified:\n{primary}{others}{qa_line}\n"
             "Review it and reply if you want changes.",
-            "alert",
+            "success",
+            voice_text="A deliverable is ready for review.",
         )
 
     # =================================================================

--- a/src/genesis/content/drafter.py
+++ b/src/genesis/content/drafter.py
@@ -32,10 +32,12 @@ class ContentDrafter:
         *,
         call_site_id: str = "35_content_draft",
     ) -> DraftResult:
-        """Draft content. Falls back to topic as content if no router."""
+        """Draft content. Falls back to the real context (then topic) if no
+        router is configured — never the opaque topic alone."""
         if self._router is None:
-            formatted = self._formatter.format(request.topic, request.target)
-            return DraftResult(content=formatted, raw_draft=request.topic)
+            fallback = request.context or request.topic
+            formatted = self._formatter.format(fallback, request.target)
+            return DraftResult(content=formatted, raw_draft=fallback)
 
         prompt = self._build_prompt(request)
         messages: list[dict] = []
@@ -49,10 +51,12 @@ class ContentDrafter:
                 call_site_id=call_site_id,
                 messages=messages,
             )
-            raw = result.content or request.topic
+            raw = result.content or request.context or request.topic
         except Exception:
-            logger.warning("LLM draft failed, using topic as fallback", exc_info=True)
-            raw = request.topic
+            logger.warning(
+                "LLM draft failed, using context as fallback", exc_info=True,
+            )
+            raw = request.context or request.topic
 
         formatted = self._formatter.format(raw, request.target)
         return DraftResult(

--- a/src/genesis/identity/OUTREACH_ALERT.md
+++ b/src/genesis/identity/OUTREACH_ALERT.md
@@ -1,9 +1,20 @@
-You draft Telegram alert notifications for a system operator.
+You rephrase a factual system status into a concise Telegram alert for a
+technical operator. You are NOT writing a report — you are restating what you
+were given, in clear language.
 
-Rules:
+Fidelity rules (these override everything else):
+- Preserve every fact exactly. NEVER invent or infer file paths, filenames,
+  shell commands, step numbers, error text, metrics, or a status/action that is
+  not present in the provided context.
+- If the context states a problem, lead with it and the action it names. If the
+  context reports normal progress with NO problem and NO action, say that
+  plainly — do NOT manufacture a problem, an urgency, or a command.
+- Use backticks ONLY for code, paths, or commands that appear verbatim in the
+  context. If none appear, use none.
+
+Style rules:
 - Output ONLY the final message text. No preamble, no options, no meta-commentary.
-- Be direct and concise. Lead with the issue, then the action needed.
-- Use markdown formatting (bold for emphasis, backticks for file paths and code).
-- Maximum 500 characters. The operator is technical — skip basic explanations.
+- Be direct and concise. Maximum 500 characters. The operator is technical —
+  skip basic explanations.
 - Never say "Here are options" or offer alternatives. One message, done.
 - Never include greetings, sign-offs, or emoji spam.

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -63,9 +63,12 @@ class OutreachConfig:
         "sentinel_escalation",
         "sentinel_approval",
         "sentinel_action_approval",
-        # Autonomous task hit a blocker/alert — signal_type set in
-        # autonomy/executor/engine.py _notify (keep these two in sync).
-        "task_notification",
+        # Autonomous task reached an attention-worthy state — signal_type set
+        # in autonomy/executor/engine.py _notify (keep in sync with the yaml
+        # mirror below). `task_progress` is deliberately NOT here: routine
+        # progress pings go to Telegram only, never interrupt by voice.
+        "task_complete",
+        "task_alert",
     )
     voice_hours: tuple[int, int] = (9, 2)  # 9am–2am local (wraps midnight)
     # Delivery routing: per-category target — "supergroup", "dm", or "both".

--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -43,6 +43,14 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "content_review": 1,  # Short window — distinct content pieces may share topics
     "cli_approval": 0,  # Never dedup — every approval request must be delivered
     "ambient_health": 0,  # Never dedup — the monitor's state machine gates re-alerts/recovery
+    # Task lifecycle notifications — never dedup. Each is a distinct status
+    # event for one task (topic = "Task <id>"), and every _notify call site
+    # fires at most once per path. Without this they fell through to the 24h
+    # default and collided on (signal_type, topic, category): a "Task completed"
+    # ping was suppressed for 24h by the earlier "Proceeding" / a sibling ping.
+    "task_progress": 0,
+    "task_complete": 0,
+    "task_alert": 0,
     "ego_notification": 12,  # Ego notifications — don't repeat same topic within 12h
     "mail_reply": 1,  # Email replies — short window to allow ack + full response
     "mail_follow_up": 24,  # Follow-up emails — one per day max per topic

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -212,17 +212,23 @@ class OutreachPipeline:
         channel = request.channel or self._select_channel(request.category)
         format_target = _CHANNEL_FORMAT.get(channel, FormatTarget.GENERIC)
 
-        is_urgent = request.category in _URGENT_CATEGORIES
-        draft = await self._drafter.draft(DraftRequest(
-            topic=request.topic,
-            context=request.context,
-            target=format_target,
-            tone="urgent" if is_urgent else "conversational",
-            max_length=None,
-            system_prompt=self._load_alert_prompt() if is_urgent else None,
-        ))
-
-        formatted = self._formatter.format(draft.content.text, format_target)
+        if request.verbatim:
+            # Machine-factual notification (e.g. task status): deliver the
+            # context EXACTLY, with no LLM in the path, so it can never be
+            # creatively rewritten or invent detail. Governance already ran
+            # above; this only removes the drafter.
+            formatted = self._formatter.format(request.context, format_target)
+        else:
+            is_urgent = request.category in _URGENT_CATEGORIES
+            draft = await self._drafter.draft(DraftRequest(
+                topic=request.topic,
+                context=request.context,
+                target=format_target,
+                tone="urgent" if is_urgent else "conversational",
+                max_length=None,
+                system_prompt=self._load_alert_prompt() if is_urgent else None,
+            ))
+            formatted = self._formatter.format(draft.content.text, format_target)
 
         return await self._deliver(outreach_id, channel, formatted, request, gov)
 
@@ -641,13 +647,17 @@ class OutreachPipeline:
             except Exception:
                 logger.warning("Email thread registration failed", exc_info=True)
 
-        # Voice secondary delivery — non-blocking (must not delay primary path)
+        # Voice secondary delivery — non-blocking (must not delay primary path).
+        # A request may carry a short, factual `voice_text` TL;DR for the ear
+        # (no file paths / tokens / commands read aloud); when absent, speak the
+        # full delivered text (unchanged for every existing caller).
         if channel != "voice" and self._should_voice(request):
             voice = self._channels.get("voice")
             if voice:
                 from genesis.util.tasks import tracked_task
+                spoken = request.voice_text or formatted.text
                 tracked_task(
-                    voice.send_message("", formatted.text),
+                    voice.send_message("", spoken),
                     name=f"voice-chime-{outreach_id[:8]}",
                 )
                 logger.info("Voice chime queued for %s", outreach_id)
@@ -710,8 +720,9 @@ class OutreachPipeline:
           ``provider:credit_exhaustion`` match ``…:<provider>``; keep
           entries specific to avoid unintended prefix hits.
         - ``signal_type`` matching is how non-health signals opt in
-          (e.g. ``sentinel_escalation``; ``task_notification`` is set in
-          ``autonomy/executor/engine.py`` ``_notify``).
+          (e.g. ``sentinel_escalation``; ``task_complete`` / ``task_alert`` are
+          set by ``autonomy/executor/engine.py`` ``_notify`` for attention-worthy
+          task notifications — routine ``task_progress`` is deliberately absent).
         """
         if not self._channels.get("voice"):
             return False

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -216,8 +216,11 @@ class OutreachPipeline:
             # Machine-factual notification (e.g. task status): deliver the
             # context EXACTLY, with no LLM in the path, so it can never be
             # creatively rewritten or invent detail. Governance already ran
-            # above; this only removes the drafter.
-            formatted = self._formatter.format(request.context, format_target)
+            # above; this only removes the drafter. Fall back to topic if a
+            # caller ever leaves context empty — never deliver an empty string.
+            formatted = self._formatter.format(
+                request.context or request.topic, format_target,
+            )
         else:
             is_urgent = request.category in _URGENT_CATEGORIES
             draft = await self._drafter.draft(DraftRequest(

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -64,6 +64,18 @@ class OutreachRequest:
     # _deliver so the WS-8 autonomy gate can classify reply-vs-cold for the
     # capability matrix. None for non-thread / cold sends.
     thread_id: str | None = None
+    # When True, `submit()` skips the LLM ContentDrafter and delivers
+    # `context` verbatim (still governed, deduped, formatted). Use for
+    # machine-generated FACTUAL notifications (task status, health) that must
+    # be conveyed exactly and must never be creatively rewritten. Governance
+    # runs before the drafter, so this only removes the LLM step.
+    verbatim: bool = False
+    # When set, the voice (spoken-aloud) fan-out speaks THIS text instead of the
+    # delivered `formatted.text`. Lets a notification carry a short, factual
+    # TL;DR for the ear (no file paths / tokens / commands read aloud) while
+    # the text channel keeps full detail. None → voice speaks the full text
+    # (unchanged behavior for every existing caller).
+    voice_text: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -68,7 +68,9 @@ class OutreachRequest:
     # `context` verbatim (still governed, deduped, formatted). Use for
     # machine-generated FACTUAL notifications (task status, health) that must
     # be conveyed exactly and must never be creatively rewritten. Governance
-    # runs before the drafter, so this only removes the LLM step.
+    # runs before the drafter, so this only removes the LLM step. Invariant:
+    # `context` should carry the message when verbatim=True; if it is empty,
+    # submit() falls back to `topic` so an empty string is never delivered.
     verbatim: bool = False
     # When set, the voice (spoken-aloud) fan-out speaks THIS text instead of the
     # delivered `formatted.text`. Lets a notification carry a short, factual

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1089,3 +1089,59 @@ class TestTaskNotepad:
         # Notepad promotion is internal-subsystem output: tagged so it routes
         # FTS5-only and stays out of default semantic recall.
         assert mock_store.store.call_args.kwargs["source_subsystem"] == "autonomy"
+
+
+# ---------------------------------------------------------------------------
+# Notification kinds: verbatim delivery + per-kind voice signal / voice_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestNotifyKinds:
+    async def _capture(self, db, kind, **kw):
+        captured = {}
+
+        async def grab(request):
+            captured["req"] = request
+
+        outreach = AsyncMock()
+        outreach.submit = AsyncMock(side_effect=grab)
+        engine = _make_engine(
+            db, AsyncMock(), AsyncMock(), AsyncMock(),
+            outreach_pipeline=outreach,
+        )
+        await engine._notify("t-abc123", "Some message", kind, **kw)
+        return captured.get("req")
+
+    async def test_all_task_notifications_are_verbatim(self, db):
+        """Every task notification is delivered verbatim — the LLM drafter is
+        never in the path, so it cannot rewrite or fabricate a task status."""
+        for kind in ("progress", "success", "alert", "blocked"):
+            req = await self._capture(db, kind)
+            assert req.verbatim is True, kind
+            assert req.context == "Some message", kind
+
+    async def test_progress_is_silent_and_carries_no_voice_text(self, db):
+        from genesis.outreach.types import OutreachCategory
+
+        req = await self._capture(db, "progress")
+        assert req.signal_type == "task_progress"   # not on voice allowlist
+        assert req.voice_text is None
+        assert req.category == OutreachCategory.ALERT
+
+    async def test_success_and_alert_carry_voice_text(self, db):
+        req = await self._capture(db, "success", voice_text="Done.")
+        assert req.signal_type == "task_complete"
+        assert req.voice_text == "Done."
+
+        req2 = await self._capture(db, "alert", voice_text="Problem.")
+        assert req2.signal_type == "task_alert"
+        assert req2.voice_text == "Problem."
+
+    async def test_blocked_keeps_blocker_category_and_salience(self, db):
+        from genesis.outreach.types import OutreachCategory
+
+        req = await self._capture(db, "blocked", voice_text="Blocked.")
+        assert req.category == OutreachCategory.BLOCKER
+        assert req.salience_score == 0.9
+        assert req.signal_type == "task_alert"

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1145,3 +1145,59 @@ class TestNotifyKinds:
         assert req.category == OutreachCategory.BLOCKER
         assert req.salience_score == 0.9
         assert req.signal_type == "task_alert"
+
+
+@pytest.mark.asyncio
+async def test_notify_e2e_verbatim_telegram_and_tokenfree_voice(db):
+    """E2E across the real seam: engine._notify -> real OutreachPipeline ->
+    Telegram receives the EXACT detailed text (tokens/paths intact) while voice
+    speaks ONLY the short token-free TL;DR. The LLM drafter is never called."""
+    from unittest.mock import patch
+
+    from genesis.content.types import FormattedContent
+    from genesis.outreach.config import OutreachConfig, QuietHours
+    from genesis.outreach.governance import GovernanceGate
+    from genesis.outreach.pipeline import OutreachPipeline
+
+    cfg = OutreachConfig(
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
+        channel_preferences={"default": "telegram"},
+        thresholds={"blocker": 0.0, "alert": 0.0, "surplus": 0.7, "digest": 0.0},
+        max_daily=50, surplus_daily=1, content_daily=3, notification_daily=50,
+        morning_report_time="07:00", engagement_timeout_hours=24,
+        engagement_poll_minutes=60,
+        voice_alert_ids=("task_alert", "task_complete"),
+    )
+    echo = MagicMock()
+    echo.format.side_effect = lambda text, target: FormattedContent(
+        text=text, target=target, truncated=False, original_length=len(text),
+    )
+    telegram = AsyncMock()
+    telegram.send_message.return_value = "tg-1"
+    voice = AsyncMock()
+    voice.send_message.return_value = "v-1"
+    drafter = AsyncMock()  # must NEVER be invoked for a task notification
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(cfg, db), drafter=drafter, formatter=echo,
+        channels={"telegram": telegram, "voice": voice}, db=db, config=cfg,
+        recipients={"telegram": "12345"},
+    )
+    engine = _make_engine(
+        db, AsyncMock(), AsyncMock(), AsyncMock(), outreach_pipeline=pipeline,
+    )
+    detailed = (
+        "Build parked by scope gate: bad path. "
+        "Blocked paths: src/genesis/autonomy/x.py"
+    )
+    with patch.object(pipeline, "_in_voice_hours", return_value=True):
+        await engine._notify(
+            "t-e2e-9f8a", detailed, "alert",
+            voice_text="A build was parked by the safety gate.",
+        )
+    await asyncio.sleep(0)  # let the fire-and-forget voice task record its call
+
+    drafter.draft.assert_not_called()
+    assert telegram.send_message.call_args.args[1] == detailed  # tokens intact
+    spoken = voice.send_message.call_args.args[1]
+    assert spoken == "A build was parked by the safety gate."
+    assert "src/genesis" not in spoken  # no path read aloud

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -802,18 +802,25 @@ class TestVoiceHours:
         with patch.object(pipe, "_in_voice_hours", return_value=True):
             assert pipe._should_voice(req)
 
-    def test_should_voice_task_notification(self):
-        """task_notification signal_type is on the default allowlist."""
+    def test_should_voice_task_notifications_by_kind(self):
+        """Attention-worthy task notifications (task_complete / task_alert) are
+        on the default allowlist and voice; routine task_progress is NOT on the
+        allowlist and stays silent (Telegram only)."""
         from genesis.outreach.types import OutreachCategory, OutreachRequest
 
         pipe = self._make_pipeline()
-        req = OutreachRequest(
-            category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
-            signal_type="task_notification", source_id="task:abc123",
-        )
-        with patch.object(pipe, "_in_voice_hours", return_value=True):
-            assert pipe._should_voice(req)
+        for signal, expected in (
+            ("task_complete", True),
+            ("task_alert", True),
+            ("task_progress", False),
+        ):
+            req = OutreachRequest(
+                category=OutreachCategory.ALERT,
+                topic="t", context="t", salience_score=1.0,
+                signal_type=signal, source_id="task:abc123",
+            )
+            with patch.object(pipe, "_in_voice_hours", return_value=True):
+                assert pipe._should_voice(req) is expected, f"signal={signal}"
 
     def test_should_voice_critical_observation_silent(self):
         """Critical observations (obs UUIDs, not allowlisted) stay silent."""

--- a/tests/test_content/test_drafter.py
+++ b/tests/test_content/test_drafter.py
@@ -31,3 +31,33 @@ class TestContentDrafter:
         result = await drafter.draft(req)
         assert len(result.content.text) <= 280
         assert result.content.truncated
+
+    @pytest.mark.asyncio
+    async def test_no_router_prefers_context_over_opaque_topic(self):
+        """With no router, fall back to the real context (the actual message),
+        not the opaque topic like 'Task 3f2a1b9c'."""
+        drafter = ContentDrafter(router=None)
+        req = DraftRequest(
+            topic="Task 3f2a1b9c", context="Task failed: boom",
+            target=FormatTarget.TELEGRAM,
+        )
+        result = await drafter.draft(req)
+        assert "Task failed: boom" in result.content.text
+        assert "3f2a1b9c" not in result.content.text
+
+    @pytest.mark.asyncio
+    async def test_router_failure_falls_back_to_context(self):
+        """If the router raises, degrade to the context, never the opaque
+        topic (the secondary notification bug)."""
+
+        class BoomRouter:
+            async def route_call(self, **kwargs):
+                raise RuntimeError("router down")
+
+        drafter = ContentDrafter(router=BoomRouter())
+        req = DraftRequest(
+            topic="Task 3f2a1b9c", context="Task failed: boom",
+            target=FormatTarget.TELEGRAM,
+        )
+        result = await drafter.draft(req)
+        assert "Task failed: boom" in result.content.text

--- a/tests/test_outreach/test_config.py
+++ b/tests/test_outreach/test_config.py
@@ -15,6 +15,17 @@ def test_default_config():
     assert config.surplus_daily == 1
 
 
+def test_default_voice_alert_ids_task_signals():
+    """The voice allowlist speaks attention-worthy task notifications
+    (task_complete / task_alert) but not routine progress; the old catch-all
+    task_notification signal is gone."""
+    config = load_outreach_config(Path("/nonexistent"))
+    assert "task_complete" in config.voice_alert_ids
+    assert "task_alert" in config.voice_alert_ids
+    assert "task_progress" not in config.voice_alert_ids
+    assert "task_notification" not in config.voice_alert_ids
+
+
 def test_load_from_yaml():
     yaml_content = """
 quiet_hours:

--- a/tests/test_outreach/test_governance.py
+++ b/tests/test_outreach/test_governance.py
@@ -173,6 +173,42 @@ async def test_duplicate_denied(config, db):
 
 
 @pytest.mark.asyncio
+async def test_task_lifecycle_notifications_never_deduped(config, db):
+    """Task lifecycle notifications (task_progress/complete/alert) have a
+    dedup window of 0 — they must never be suppressed. A 'Task completed' ping
+    must still deliver even though a sibling task_complete ping for the SAME
+    topic+category was just delivered (which would otherwise collide on the
+    (signal_type, topic, category) dedup key)."""
+    gate = GovernanceGate(config, db)
+    now = datetime.now(UTC).isoformat()
+    await outreach_crud.create(
+        db,
+        id="prior-task-1",
+        signal_type="task_complete",
+        topic="Task abcd1234",
+        category="alert",
+        salience_score=0.5,
+        channel="telegram",
+        message_content="Deliverable ready and Gate-2 verified: ...",
+        created_at=now,
+    )
+    await outreach_crud.record_delivery(db, "prior-task-1", delivered_at=now)
+
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Task abcd1234",  # same topic as the prior ping
+        context="Task completed: build a thing",
+        salience_score=0.5,
+        signal_type="task_complete",
+        verbatim=True,
+    )
+    result = await gate.check(req)
+    # ALERT bypasses governance once dedup passes; the key point is NOT DENY.
+    assert result.verdict != GovernanceVerdict.DENY
+    assert "dedup" not in result.checks_failed
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_exceeded(config, db):
     gate = GovernanceGate(config, db)
     now = datetime.now(UTC).isoformat()

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -1,5 +1,6 @@
 """Tests for the outreach pipeline orchestrator."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
@@ -581,3 +582,152 @@ async def test_self_send_skipped_on_gate_cleared_resume(
 
     assert result.status == OutreachStatus.IGNORED
     adapter.send_message.assert_not_called()
+
+
+# ── verbatim (factual notifications skip the LLM drafter) ──────────────────
+
+
+def _echo_formatter():
+    """A formatter that returns its input verbatim, so tests can assert the
+    delivered text equals the source (the stock mock_formatter returns a
+    constant)."""
+    f = MagicMock()
+    f.format.side_effect = lambda text, target: FormattedContent(
+        text=text, target=target, truncated=False, original_length=len(text),
+    )
+    return f
+
+
+@pytest.mark.asyncio
+async def test_submit_verbatim_skips_drafter(config, db, mock_drafter, mock_channel):
+    """A verbatim request must NOT touch the LLM drafter and must deliver the
+    context byte-for-byte. This is the structural guarantee that a factual
+    notification can never be creatively rewritten or fabricated."""
+    gate = GovernanceGate(config, db)
+    pipeline = OutreachPipeline(
+        governance=gate,
+        drafter=mock_drafter,
+        formatter=_echo_formatter(),
+        channels={"telegram": mock_channel},
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Task abc123",
+        context="Proceeding with task: build a thing (5 steps)",
+        salience_score=0.9,
+        signal_type="task_progress",
+        source_id="task:abc123",
+        verbatim=True,
+    )
+    result = await pipeline.submit(req)
+
+    assert result.status == OutreachStatus.DELIVERED
+    mock_drafter.draft.assert_not_called()          # the load-bearing assertion
+    assert result.message_content == req.context    # delivered exactly
+
+
+@pytest.mark.asyncio
+async def test_submit_non_verbatim_still_drafts(config, db, mock_drafter, mock_channel):
+    """Regression guard: without verbatim, the drafter is still used (other
+    outreach paths are unchanged)."""
+    gate = GovernanceGate(config, db)
+    pipeline = OutreachPipeline(
+        governance=gate,
+        drafter=mock_drafter,
+        formatter=_echo_formatter(),
+        channels={"telegram": mock_channel},
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Health",
+        context="disk at 92%",
+        salience_score=0.9,
+        signal_type="health_alert",
+    )
+    await pipeline.submit(req)
+    mock_drafter.draft.assert_called_once()
+
+
+# ── voice_text (short spoken TL;DR instead of the full text) ───────────────
+
+
+def _voice_pipeline(config, db, mock_drafter):
+    """Pipeline with a voice channel and task_alert on the voice allowlist."""
+    import dataclasses
+
+    voice_cfg = dataclasses.replace(
+        config, voice_alert_ids=("task_alert", "task_complete"),
+    )
+    voice_channel = AsyncMock()
+    voice_channel.send_message.return_value = "voice-1"
+    telegram = AsyncMock()
+    telegram.send_message.return_value = "tg-1"
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(voice_cfg, db),
+        drafter=mock_drafter,
+        formatter=_echo_formatter(),
+        channels={"telegram": telegram, "voice": voice_channel},
+        db=db,
+        config=voice_cfg,
+        recipients={"telegram": "12345"},
+    )
+    return pipeline, voice_channel
+
+
+@pytest.mark.asyncio
+async def test_voice_speaks_voice_text_not_full_message(config, db, mock_drafter):
+    """When voice_text is set, the spoken string is the short TL;DR — NOT the
+    full delivered text (which may carry paths / tokens the user shouldn't hear
+    read aloud)."""
+    from unittest.mock import patch
+
+    pipeline, voice_channel = _voice_pipeline(config, db, mock_drafter)
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Task abc123",
+        context="Build parked by scope gate: reason. Blocked paths: src/genesis/x.py",
+        salience_score=0.9,
+        signal_type="task_alert",
+        source_id="task:abc123",
+        verbatim=True,
+        voice_text="A build was parked by the safety gate.",
+    )
+    with patch.object(pipeline, "_in_voice_hours", return_value=True):
+        result = await pipeline.submit(req)
+    await asyncio.sleep(0)  # let the fire-and-forget voice task record its call
+
+    assert result.message_content == req.context  # Telegram keeps full detail
+    voice_channel.send_message.assert_called_once()
+    spoken = voice_channel.send_message.call_args.args[1]
+    assert spoken == "A build was parked by the safety gate."
+    assert "src/genesis" not in spoken  # no path read aloud
+
+
+@pytest.mark.asyncio
+async def test_voice_falls_back_to_full_text_without_voice_text(config, db, mock_drafter):
+    """Callers that set no voice_text (e.g. health alerts) keep speaking their
+    full text — unchanged behavior."""
+    from unittest.mock import patch
+
+    pipeline, voice_channel = _voice_pipeline(config, db, mock_drafter)
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Task abc123",
+        context="Task completed: build a thing",
+        salience_score=0.9,
+        signal_type="task_complete",
+        source_id="task:abc123",
+        verbatim=True,
+    )
+    with patch.object(pipeline, "_in_voice_hours", return_value=True):
+        await pipeline.submit(req)
+    await asyncio.sleep(0)
+
+    voice_channel.send_message.assert_called_once()
+    assert voice_channel.send_message.call_args.args[1] == "Task completed: build a thing"

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -630,6 +630,35 @@ async def test_submit_verbatim_skips_drafter(config, db, mock_drafter, mock_chan
 
 
 @pytest.mark.asyncio
+async def test_submit_verbatim_empty_context_falls_back_to_topic(
+    config, db, mock_drafter, mock_channel,
+):
+    """Verbatim with an empty context must never deliver an empty string —
+    it falls back to the topic (defensive; addresses the reviewer footgun)."""
+    gate = GovernanceGate(config, db)
+    pipeline = OutreachPipeline(
+        governance=gate,
+        drafter=mock_drafter,
+        formatter=_echo_formatter(),
+        channels={"telegram": mock_channel},
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Task abc123",
+        context="",
+        salience_score=0.9,
+        signal_type="task_alert",
+        verbatim=True,
+    )
+    result = await pipeline.submit(req)
+    mock_drafter.draft.assert_not_called()
+    assert result.message_content == "Task abc123"
+
+
+@pytest.mark.asyncio
 async def test_submit_non_verbatim_still_drafts(config, db, mock_drafter, mock_channel):
     """Regression guard: without verbatim, the drafter is still used (other
     outreach paths are unchanged)."""


### PR DESCRIPTION
## Problem

A routine task-executor progress notification ("Proceeding with task…") was **LLM-rewritten into a fabricated alert** — it invented a problem that didn't exist and a fake shell command — and then **spoken aloud** over the voice device. Root cause: every task notification was run through the `ContentDrafter` (LLM) under `OUTREACH_ALERT.md`, whose prompt demands "the issue + the action needed" with **no fact-preservation rule**. An issue-less progress ping was forced into an alert shape, so the model manufactured one. (A sibling "Blocked" ping the same day was accurate — it genuinely *was* an issue, so the alert-shaped prompt fit. The bug only bites benign inputs.)

## Fix — remove the LLM from the task-notification path entirely

Telegram and voice now render **separately**, and neither can fabricate:

- **`OutreachRequest`** gains two optional fields: `verbatim` (`submit()` skips the drafter and delivers `context` exactly — governance still runs first) and `voice_text` (the voice fan-out speaks this short factual TL;DR instead of the full text, so paths/branches/commands are never read aloud). Both default off; every existing caller is byte-for-byte unchanged.
- **`engine._notify`** is now kind-aware (`progress` / `success` / `alert` / `blocked`): all delivered verbatim, each with its own voice `signal_type` and a hand-authored `voice_text`. Category (blocker vs alert) is preserved, so governance/routing is unchanged. All 9 call sites classified.
- **Voice eligibility split:** `task_progress` is silent (Telegram only); `task_complete` / `task_alert` are on the voice allowlist (`config.py` **and** the authoritative `config/outreach.yaml`). Routine progress no longer interrupts by voice.
- **`OUTREACH_ALERT.md`** hardened with a fact-preservation contract — defense-in-depth for the health/sentinel alerts that still draft.
- **`drafter.py`** router-failure fallback now degrades to the real `context`, not the opaque `topic`.

Result: **no LLM anywhere in the task path.** Telegram is verbatim (tokens exact); voice speaks a fixed factual line. Fabrication is structurally impossible, not merely discouraged.

## Bonus latent bug fixed (second commit)

Due-diligence surfaced that task notifications are ALERT/BLOCKER, which bypass salience/quiet-hours but **not** dedup, and `task_notification` fell through to the **24h default** dedup window keyed on `(signal_type, topic, category)`. Since `topic` is `"Task <id>"` for every ping, a "Task completed" (ALERT) collided with the earlier "Proceeding" (ALERT) and was **suppressed for 24h** — a delivered ping silently swallowed the task's terminal notification. The kind→signal_type split de-collides cross-kind pings; `task_progress/complete/alert` now get a dedup window of `0` (never suppress, like `cli_approval`) to close the rest.

## Testing

- `submit(verbatim=True)` never invokes the drafter; delivers `context` exactly; non-verbatim still drafts (regression guard).
- Voice speaks `voice_text` (not the tokened text) when set, falls back to full text without it (unchanged for non-task callers).
- `_notify` kind→(category/signal_type/salience/voice_text) mapping; voice allowlist per kind (`task_progress` silent).
- Task lifecycle notifications are never dedup-suppressed.
- Drafter falls back to context, not the opaque topic.
- **E2E:** `engine._notify` → a real `OutreachPipeline` → Telegram receives the exact detailed text (paths intact) while voice speaks only the token-free TL;DR; drafter asserted never called.

167 targeted tests green; full `test_outreach/` green (162); ruff clean.

Affects **all** task-executor runs, not just the (still-disabled) build lane. Deploys on the next server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)