### PR TITLE
feat(outreach): capability-build lane reporting + calibration (PR-8)

### DIFF
--- a/src/genesis/db/crud/build_candidates.py
+++ b/src/genesis/db/crud/build_candidates.py
@@ -170,6 +170,42 @@ async def list_by_outcome(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def list_by_verdict(
+    db: aiosqlite.Connection, verdict: str, *, limit: int = 50
+) -> list[dict]:
+    """All candidates with a given *verdict*, newest first.
+
+    Used by the report's "wouldn't-build" section (verdict='dont_build') —
+    ``list_by_outcome`` can't serve this because dont_build rows never leave
+    ``outcome='pending'`` (they are closed via ``user_decision``, not outcome).
+    """
+    if verdict not in VERDICTS:
+        raise ValueError(f"invalid verdict: {verdict!r}")
+    cursor = await db.execute(
+        "SELECT * FROM build_candidates WHERE verdict = ? "
+        "ORDER BY created_at DESC LIMIT ?",
+        (verdict, limit),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def verdict_decision_counts(db: aiosqlite.Connection) -> list[dict]:
+    """Calibration aggregate: count of candidates grouped by (verdict,
+    user_decision). ``user_decision`` is NULL for still-open candidates.
+
+    Returns rows like ``{"verdict": "build", "user_decision": "approved",
+    "count": 3}`` — the raw material for the report's per-verdict agreement
+    lines (how often the user's decision matched Genesis's verdict).
+    """
+    cursor = await db.execute(
+        "SELECT verdict, user_decision, COUNT(*) AS count "
+        "FROM build_candidates "
+        "GROUP BY verdict, user_decision "
+        "ORDER BY verdict, user_decision"
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
 async def record_user_decision(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -134,7 +134,9 @@ Use these sections in order. Skip any that are empty/normal:
 3. **Overnight** — brainstorm highlights, background findings worth
    noting. Only include genuinely useful insights.
 4. **System Health** — one line if normal. Detail only if something broke.
-5. **Open Items** — pending items requiring user input (inbox, approvals)
+5. **Open Items** — pending items requiring user input (inbox, approvals, and
+   any open capability-build draft PRs awaiting your review/merge — name the
+   PR and its CI state)
 6. **Next Steps & Blockers** — the few highest-leverage actions for today and
    anything blocking progress. Each bullet is one concrete item drawn from the
    data above: a blocked/failed follow-up, a pending approval, or an observation

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -58,6 +58,7 @@ def init_health_mcp(
 
 
 from genesis.mcp.health import browser as _browser  # noqa: E402
+from genesis.mcp.health import build_lane_status as _build_lane_status  # noqa: E402, F401
 from genesis.mcp.health import campaign_tools as _campaign_tools  # noqa: E402, F401
 from genesis.mcp.health import codebase as _codebase  # noqa: E402
 from genesis.mcp.health import cognitive_ledger_tools as _cognitive_ledger_tools  # noqa: E402, F401

--- a/src/genesis/mcp/health/build_lane_status.py
+++ b/src/genesis/mcp/health/build_lane_status.py
@@ -1,0 +1,96 @@
+"""build_lane_status MCP tool — the autonomous capability-build lane surface.
+
+One read-only view of what the lane has done: draft build PRs awaiting review,
+the items Genesis declined to build (with reasons), greenlight cards still
+awaiting a tap, and the verdict-vs-decision calibration record.
+
+Read-only. Reuses existing CRUD; no new schema; does NOT change behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+async def _impl_build_lane_status() -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+    from genesis.db.crud import build_candidates as bc
+    from genesis.env import build_lane_enabled
+
+    open_prs = await bc.list_by_outcome(db, "pr_opened")
+    dont_build = await bc.list_by_verdict(db, "dont_build", limit=25)
+    counts = await bc.verdict_decision_counts(db)
+    # Open (undecided) build verdicts with a card out = pending greenlights.
+    # list_open also returns undecided dont_build/needs_discussion rows, which
+    # are NOT awaiting a tap, so filter to carded build rows.
+    open_undecided = await bc.list_open(db)
+    pending_greenlights = [
+        r for r in open_undecided
+        if r.get("verdict") == "build" and r.get("approval_request_id")
+    ]
+
+    return {
+        "status": "ok",
+        "enabled": build_lane_enabled(),
+        "open_prs": [
+            {
+                "title": r.get("item_title"),
+                "pr_url": r.get("pr_url"),
+                "branch": r.get("branch"),
+                "created_at": r.get("created_at"),
+            }
+            for r in open_prs
+        ],
+        "wouldnt_build": [
+            {
+                "title": r.get("item_title"),
+                "reason": r.get("verdict_reason"),
+                "created_at": r.get("created_at"),
+            }
+            for r in dont_build
+        ],
+        "pending_greenlights": [
+            {"title": r.get("item_title"), "created_at": r.get("created_at")}
+            for r in pending_greenlights
+        ],
+        "calibration": [
+            {
+                "verdict": r.get("verdict"),
+                "user_decision": r.get("user_decision"),
+                "count": r.get("count"),
+            }
+            for r in counts
+        ],
+        "note": (
+            "Autonomous capability-build lane. open_prs = built, a draft PR is "
+            "awaiting your review/merge; wouldnt_build = declined verdicts "
+            "(reported, never queued); pending_greenlights = carded, awaiting "
+            "your tap; calibration = verdict vs your actual decision "
+            "(user_decision NULL = still open; dont_build is never carded, so "
+            "its rows are uncontested, not agreed). Read-only — does NOT change "
+            "behaviour. `enabled` reflects the build_lane.enabled flag."
+        ),
+    }
+
+
+@mcp.tool()
+async def build_lane_status() -> dict:
+    """What has the autonomous capability-build lane done — and how well do its
+    verdicts track your decisions?
+
+    Draft build PRs awaiting review/merge, the items Genesis declined to build
+    (with reasons), greenlight cards still awaiting a tap, and the
+    verdict-vs-decision calibration record. Read-only; does NOT change
+    behaviour.
+    """
+    return await _impl_build_lane_status()

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -56,6 +56,97 @@ _STALE_OBS_SECONDS = 3 * 86400
 _STALE_PRIORITY_DEMOTION = {"critical": "high", "high": "medium", "medium": "medium"}
 
 
+# ── Capability-build lane report helpers ──────────────────────────────────
+
+_BUILD_PR_CI_TIMEOUT_S = 20  # per-PR gh call; PRs are checked concurrently
+_MAX_BUILD_PR_CHECKS = 10    # cap concurrent gh calls (rate-limit safety)
+
+
+async def _pr_ci_status(pr_url: str) -> str | None:
+    """One-shot CI rollup for a draft build PR via
+    ``gh pr view <url> --json statusCheckRollup``. Returns a compact word
+    ('passing'/'failing'/'pending'/'no checks'), or None on error/timeout.
+
+    Uses the shared ``run_gh`` helper, which kills+reaps the child process on
+    timeout (the process-kill sequence is easy to get subtly wrong, so it is
+    not re-implemented here).
+    """
+    import json
+
+    from genesis.recon.gh_cli import run_gh
+
+    if not pr_url:
+        return None
+    raw = await run_gh(
+        "gh", "pr", "view", pr_url, "--json", "statusCheckRollup",
+        timeout=_BUILD_PR_CI_TIMEOUT_S,
+    )
+    if not raw:
+        return None
+    try:
+        checks = json.loads(raw).get("statusCheckRollup") or []
+    except (ValueError, TypeError):
+        return None
+    return _summarize_ci_rollup(checks)
+
+
+def _summarize_ci_rollup(checks: list) -> str:
+    """Collapse a heterogeneous statusCheckRollup (CheckRun + StatusContext)
+    into one word: failing > pending > passing."""
+    if not checks:
+        return "no checks"
+    _FAIL = {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED",
+             "STARTUP_FAILURE", "ERROR"}
+    _OK = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+    saw_fail = saw_pending = False
+    for c in checks:
+        conclusion = (c.get("conclusion") or "").upper()
+        state = (c.get("state") or "").upper()  # StatusContext form
+        if conclusion in _FAIL or state in {"FAILURE", "ERROR"}:
+            saw_fail = True
+        elif conclusion in _OK or state == "SUCCESS":
+            continue
+        else:
+            # COMPLETED-without-conclusion, QUEUED, IN_PROGRESS, PENDING, ...
+            saw_pending = True
+    if saw_fail:
+        return "failing"
+    if saw_pending:
+        return "pending"
+    return "passing"
+
+
+def _format_build_calibration(counts: list[dict]) -> list[str]:
+    """Per-verdict agreement lines from verdict×user_decision counts.
+    dont_build is reported as 'uncontested' (never carded), never as agreement.
+    """
+    agg: dict[str, dict[str, int]] = {}
+    for row in counts:
+        verdict = row.get("verdict") or "?"
+        decision = row.get("user_decision") or "pending"
+        agg.setdefault(verdict, {})[decision] = row.get("count", 0)
+    lines: list[str] = []
+    if "build" in agg:
+        b = agg["build"]
+        approved = b.get("approved", 0)
+        rejected = b.get("rejected", 0)
+        pending = b.get("pending", 0)
+        decided = approved + rejected
+        rate = f"{approved}/{decided} approved" if decided else "none decided yet"
+        extra = f", {pending} pending your tap" if pending else ""
+        lines.append(f"- build verdicts: {rate}{extra}")
+    if "dont_build" in agg:
+        total = sum(agg["dont_build"].values())
+        lines.append(
+            f"- dont_build verdicts: {total} "
+            "(uncontested — reported, never carded)"
+        )
+    if "needs_discussion" in agg:
+        total = sum(agg["needs_discussion"].values())
+        lines.append(f"- needs_discussion verdicts: {total}")
+    return lines
+
+
 class MorningReportGenerator:
     """Synthesizes system state into a daily morning report."""
 
@@ -188,6 +279,15 @@ class MorningReportGenerator:
                 sections.append(f"## Inbox Follow-ups (Ego-resolved)\n{inbox_resolved}")
         except Exception:
             logger.warning("Morning report: inbox resolved digest unavailable", exc_info=True)
+
+        # 5c. Capability-build lane (open draft build PRs + calibration)
+        try:
+            build_lane = await self._get_build_lane_section()
+            if build_lane:
+                sections.append(f"## Capability Build Lane\n{build_lane}")
+        except Exception:
+            logger.warning("Morning report: build lane section unavailable", exc_info=True)
+            await self._emit_warning("build_lane", "Capability build lane section unavailable")
 
         # 6. Outreach summary (just total count, no self-analysis)
         try:
@@ -404,6 +504,64 @@ class MorningReportGenerator:
             score = g.get("score")
             score_txt = f" ({score:.0f})" if isinstance(score, (int, float)) else ""
             lines.append(f"- {sub}: {grade}{score_txt}")
+        return "\n".join(lines)
+
+    async def _get_build_lane_section(self) -> str | None:
+        """Capability-build lane readout: open draft build PRs (+ one-shot CI),
+        the wouldn't-build reasons, and per-verdict calibration vs the user's
+        actual decisions. Returns None when the lane has no candidates yet
+        (cold start) so the section is skipped entirely."""
+        import asyncio
+
+        from genesis.db.crud import build_candidates as bc
+
+        open_prs = await bc.list_by_outcome(self._db, "pr_opened")
+        dont_build = await bc.list_by_verdict(self._db, "dont_build", limit=10)
+        counts = await bc.verdict_decision_counts(self._db)
+
+        if not open_prs and not dont_build and not counts:
+            return None
+
+        lines: list[str] = [
+            "Autonomous capability-build lane. State facts only. 'Uncontested' "
+            "means an item was never carded for a decision, NOT that the user "
+            "agreed. Surface open build PRs under Open Items / Next Steps.",
+        ]
+
+        if open_prs:
+            checked = open_prs[:_MAX_BUILD_PR_CHECKS]
+            ci_states = await asyncio.gather(
+                *[_pr_ci_status(r.get("pr_url") or "") for r in checked]
+            )
+            lines.append("")
+            lines.append("Open build PRs (draft, awaiting your review/merge):")
+            for row, ci in zip(checked, ci_states, strict=True):
+                title = row.get("item_title") or "(untitled)"
+                pr_url = row.get("pr_url") or "(no url)"
+                ci_txt = f" — CI {ci}" if ci else ""
+                lines.append(f"- {title}: {pr_url}{ci_txt}")
+            if len(open_prs) > _MAX_BUILD_PR_CHECKS:
+                lines.append(
+                    f"- (+{len(open_prs) - _MAX_BUILD_PR_CHECKS} more open build "
+                    "PRs; CI not checked)"
+                )
+
+        if dont_build:
+            lines.append("")
+            lines.append(
+                "Wouldn't-build (Genesis declined; reported, never queued):"
+            )
+            for row in dont_build:
+                title = row.get("item_title") or "(untitled)"
+                reason = row.get("verdict_reason") or "no reason recorded"
+                lines.append(f"- {title}: {reason}")
+
+        calibration = _format_build_calibration(counts)
+        if calibration:
+            lines.append("")
+            lines.append("Calibration (Genesis verdict vs your decision):")
+            lines.extend(calibration)
+
         return "\n".join(lines)
 
     async def _get_pending_items(self) -> str:

--- a/tests/test_db/test_build_candidates.py
+++ b/tests/test_db/test_build_candidates.py
@@ -137,6 +137,35 @@ class TestQueries:
         with pytest.raises(ValueError):
             await build_candidates.list_by_outcome(db, "shipped")
 
+    async def test_list_by_verdict(self, db):
+        await _make(db, id="c1", item_key="k1", verdict="build")
+        await _make(db, id="c2", item_key="k2", verdict="dont_build",
+                    verdict_reason="duplicates existing capability")
+        await _make(db, id="c3", item_key="k3", verdict="dont_build",
+                    verdict_reason="brain-not-body scope")
+        rows = await build_candidates.list_by_verdict(db, "dont_build")
+        assert {r["id"] for r in rows} == {"c2", "c3"}
+        assert all(r["verdict"] == "dont_build" for r in rows)
+
+    async def test_list_by_verdict_limit_and_bad_value(self, db):
+        for i in range(3):
+            await _make(db, id=f"c{i}", item_key=f"k{i}", verdict="build")
+        assert len(await build_candidates.list_by_verdict(db, "build", limit=2)) == 2
+        with pytest.raises(ValueError):
+            await build_candidates.list_by_verdict(db, "ship_it")
+
+    async def test_verdict_decision_counts(self, db):
+        # build: 1 approved, 1 open; dont_build: 1 (never decided)
+        await _make(db, id="c1", item_key="k1", verdict="build")
+        await build_candidates.record_user_decision(db, "c1", user_decision="approved")
+        await _make(db, id="c2", item_key="k2", verdict="build")  # open
+        await _make(db, id="c3", item_key="k3", verdict="dont_build")
+        counts = await build_candidates.verdict_decision_counts(db)
+        as_set = {(r["verdict"], r["user_decision"], r["count"]) for r in counts}
+        assert ("build", "approved", 1) in as_set
+        assert ("build", None, 1) in as_set
+        assert ("dont_build", None, 1) in as_set
+
     async def test_get_by_approval_request_and_task(self, db):
         await _make(db, id="c1")
         await build_candidates.update(

--- a/tests/test_mcp/test_build_lane_status.py
+++ b/tests/test_mcp/test_build_lane_status.py
@@ -1,0 +1,66 @@
+"""Tests for the build_lane_status MCP tool (read-only lane surface)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import build_candidates as bc
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _run(db):
+    svc = MagicMock()
+    svc._db = db
+    with patch("genesis.mcp.health_mcp._service", svc):
+        from genesis.mcp.health.build_lane_status import _impl_build_lane_status
+        return await _impl_build_lane_status()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_without_db():
+    svc = MagicMock()
+    svc._db = None
+    with patch("genesis.mcp.health_mcp._service", svc):
+        from genesis.mcp.health.build_lane_status import _impl_build_lane_status
+        result = await _impl_build_lane_status()
+    assert result["status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_reports_prs_declines_greenlights_and_calibration(db):
+    # An open (built) draft PR the user approved.
+    await bc.create(db, id="c1", item_key="k1", item_title="Dad-joke skill",
+                    source_file="f.md", verdict="build")
+    await bc.update(db, "c1", outcome="pr_opened",
+                    pr_url="https://github.com/o/r/pull/42", branch="task/c1")
+    await bc.record_user_decision(db, "c1", user_decision="approved")
+    # A decline (reported, never queued).
+    await bc.create(db, id="c2", item_key="k2", item_title="Rewrite the kernel",
+                    source_file="f.md", verdict="dont_build",
+                    verdict_reason="brain-not-body scope")
+    # A carded build still awaiting a tap.
+    await bc.create(db, id="c3", item_key="k3", item_title="OMI connector",
+                    source_file="f.md", verdict="build",
+                    approval_request_id="ar-9")
+
+    result = await _run(db)
+    assert result["status"] == "ok"
+    assert "enabled" in result
+    assert result["open_prs"][0]["pr_url"] == "https://github.com/o/r/pull/42"
+    assert result["wouldnt_build"][0]["reason"] == "brain-not-body scope"
+    assert [g["title"] for g in result["pending_greenlights"]] == ["OMI connector"]
+    pairs = {(r["verdict"], r["user_decision"]) for r in result["calibration"]}
+    assert ("build", "approved") in pairs
+    assert ("dont_build", None) in pairs

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -7,6 +7,7 @@ import pytest
 
 from genesis.content.types import DraftResult, FormatTarget, FormattedContent
 from genesis.db.schema import create_all_tables
+from genesis.outreach import morning_report as _mr_mod
 from genesis.outreach.morning_report import MorningReportGenerator
 from genesis.outreach.types import OutreachCategory
 
@@ -363,3 +364,83 @@ async def test_eval_quality_section_appears_in_assembled_context(db, mock_health
 
     assert "## Cognitive Subsystem Grades" in context
     assert "memory: B (82)" in context
+
+
+# ── Capability-build lane section ─────────────────────────────────────────
+
+
+def test_summarize_ci_rollup():
+    assert _mr_mod._summarize_ci_rollup([]) == "no checks"
+    assert _mr_mod._summarize_ci_rollup(
+        [{"conclusion": "SUCCESS"}, {"state": "SUCCESS"}]) == "passing"
+    assert _mr_mod._summarize_ci_rollup(
+        [{"conclusion": "SUCCESS"}, {"status": "IN_PROGRESS"}]) == "pending"
+    assert _mr_mod._summarize_ci_rollup(
+        [{"conclusion": "SUCCESS"}, {"conclusion": "FAILURE"}]) == "failing"
+
+
+def test_format_build_calibration():
+    counts = [
+        {"verdict": "build", "user_decision": "approved", "count": 2},
+        {"verdict": "build", "user_decision": None, "count": 1},
+        {"verdict": "dont_build", "user_decision": None, "count": 3},
+    ]
+    joined = "\n".join(_mr_mod._format_build_calibration(counts))
+    assert "build verdicts: 2/2 approved, 1 pending" in joined
+    assert "dont_build verdicts: 3 (uncontested" in joined
+
+
+@pytest.mark.asyncio
+async def test_build_lane_section_none_when_empty(db, mock_health, mock_drafter):
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    assert await gen._get_build_lane_section() is None
+
+
+@pytest.mark.asyncio
+async def test_build_lane_section_renders(db, mock_health, mock_drafter, monkeypatch):
+    from genesis.db.crud import build_candidates as bc
+
+    await bc.create(db, id="c1", item_key="k1", item_title="Dad-joke skill",
+                    source_file="New Genesis Capabilities.md", verdict="build")
+    await bc.update(db, "c1", outcome="pr_opened",
+                    pr_url="https://github.com/o/r/pull/42", branch="task/c1")
+    await bc.record_user_decision(db, "c1", user_decision="approved")
+    await bc.create(db, id="c2", item_key="k2", item_title="Rewrite the kernel",
+                    source_file="New Genesis Capabilities.md",
+                    verdict="dont_build", verdict_reason="brain-not-body scope")
+
+    async def fake_ci(url):
+        return "passing"
+
+    monkeypatch.setattr(_mr_mod, "_pr_ci_status", fake_ci)
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    section = await gen._get_build_lane_section()
+    assert section is not None
+    assert "https://github.com/o/r/pull/42" in section
+    assert "CI passing" in section
+    assert "brain-not-body scope" in section
+    assert "Calibration" in section
+
+
+@pytest.mark.asyncio
+async def test_pr_ci_status_parses_run_gh(monkeypatch):
+    import genesis.recon.gh_cli as gh_cli
+
+    async def fake_run_gh(*args, timeout=None):
+        return '{"statusCheckRollup": [{"conclusion": "SUCCESS"}]}'
+
+    monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
+    assert await _mr_mod._pr_ci_status("https://x/pull/1") == "passing"
+
+
+@pytest.mark.asyncio
+async def test_pr_ci_status_none_on_empty_or_no_url(monkeypatch):
+    import genesis.recon.gh_cli as gh_cli
+
+    async def fake_run_gh(*args, timeout=None):
+        return ""  # run_gh collapses failure/timeout to ""
+
+    monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
+    assert await _mr_mod._pr_ci_status("https://x/pull/1") is None
+    assert await _mr_mod._pr_ci_status("") is None


### PR DESCRIPTION
## What

The last planned piece of the autonomous capability-build lane: two **read-only** surfaces over the `build_candidates` ledger so you can see what the lane is doing and how well its verdicts track your decisions. No new schema; everything reuses existing seams.

### Morning-report section
`_get_build_lane_section()` (wired into `_assemble_context`, isolated in its own try/except):
- **Open build PRs** — draft PRs awaiting review/merge (`list_by_outcome("pr_opened")`), each with a one-shot CI rollup (`gh pr view --json statusCheckRollup`, checked concurrently, capped at 10).
- **Wouldn't-build** — the items Genesis declined, with reasons (`list_by_verdict("dont_build")`).
- **Calibration** — per-verdict agreement between Genesis's verdict and your actual decision. `dont_build` is reported as "uncontested — never carded", never as agreement.

`MORNING_REPORT.md`'s Open Items now names open build PRs + CI state.

### MCP tool
`build_lane_status` (read-only): open PRs, wouldn't-build reasons, pending greenlights (carded, awaiting a tap), and raw calibration counts. Reflects the `build_lane.enabled` flag.

### New CRUD
- `list_by_verdict` — `dont_build` rows never leave `outcome='pending'`, so `list_by_outcome` can't serve them.
- `verdict_decision_counts` — the calibration aggregate (GROUP BY verdict, user_decision).

## Notes
- CI status uses the shared `recon.gh_cli.run_gh` helper (kills+reaps the child on timeout) rather than a hand-rolled subprocess — per review.
- The CI-rollup summarizer buckets unknown/in-progress states as "pending", never "passing" (no false-green).

## Testing
CRUD queries; CI-rollup summarizer + calibration formatter (pure); `_pr_ci_status` parse path (run_gh mocked); morning-report section (renders + None-when-empty, CI mocked); MCP tool (structure + unavailable-without-db). MCP registration verified live. 46 targeted tests green; ruff clean.

The lane remains **disabled by default** — this only surfaces its data; it changes no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)