### PR TITLE
feat(guardian): configure-provisioning gateway verb (state-dir override)

### DIFF
--- a/docs/reference/proxmox-provisioning.md
+++ b/docs/reference/proxmox-provisioning.md
@@ -172,9 +172,18 @@ curl -sk -X PUT -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" -d
 2. **Credential bridge** — the awareness tick propagates just those two keys to
    `<state_dir>/shared/guardian/proxmox_creds.env` (0600) for the host guardian
    to read. Host/node/vmid are non-secret config, not bridged.
-3. **guardian.yaml** — fill the `provisioning:` block (`enabled: true`,
-   `api_host`, `node`, `vmid`, `verify_tls`). See the commented template in
-   `config/guardian.yaml`.
+3. **provisioning config** — land the `provisioning` fields (`enabled: true`,
+   `api_host`, `node`, `vmid`, `target_disk`, `storage`, `verify_tls`,
+   `require_recent_backup`). Preferred: the audited, repeatable gateway verb
+   ```
+   configure-provisioning enabled=true api_host=<PVE> node=<node> vmid=<id> \
+       target_disk=scsi1 storage=local-lvm verify_tls=false require_recent_backup=false
+   ```
+   which writes a `provisioning.local.yaml` **override in the guardian state_dir**
+   (outside the git checkout, so `update.sh` redeploys never clobber it) that the
+   config loader merges over `guardian.yaml`. `GUARDIAN_PROVISIONING_ENABLED=0`
+   still force-disables it. (Alternatively, edit the `provisioning:` block in
+   `guardian.yaml` directly — see the commented template in `config/guardian.yaml`.)
 4. **guardian_remote.yaml** (container) — add `provisioning: true` so the
    sentinel offers the `host.resource_alloc` remediation for disk/RAM alarms.
 

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -22,6 +22,8 @@
 #   provision-grow-memory <MiB>      — EXECUTE a pre-approved VM memory grow
 #   storage-expand            — absorb an already-grown disk into the storage
 #                     pool (LVM-thin: pvresize; btrfs-on-LVM: + lvextend/resize)
+#   configure-provisioning <k=v ...> — land host provisioning config as a
+#                     state-dir override (survives redeploys; no secrets)
 #   reharden-key    — rewrite the guardian authorized_keys line to the canonical
 #                     hardened options with a self-proving from= (dead-man's-
 #                     switch restores the previous file unless a fresh
@@ -646,6 +648,36 @@ PYEOF
         PYTHONPATH="$INSTALL_DIR/src" \
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
             timeout 600 "$VENV_PY" -m genesis.guardian --storage-expand
+        ;;
+    configure-provisioning\ *)
+        # Land/refresh host provisioning config as a state-dir override
+        # (provisioning.local.yaml — survives redeploys, never edits the tracked
+        # guardian.yaml). key=value args only; strict charset guards the untrusted
+        # SSH_ORIGINAL_COMMAND (no shell metacharacters). NO secrets here — the two
+        # Proxmox tokens cross the credential bridge, not this verb.
+        ARGS="${SSH_ORIGINAL_COMMAND#configure-provisioning }"
+        # Require EVERY token to be key=value — a bare flag-shaped token (e.g.
+        # "--storage-expand") would otherwise word-split into argv and hijack
+        # main()'s `if "--x" in sys.argv` dispatch to a different guardian verb.
+        # key = lowercase field name; value = [-A-Za-z0-9_.] (covers IPs,
+        # local-lvm, scsiN, true/false, ints). No leading "-" token can match.
+        PROV_KV_RE='^[a-z_][a-z0-9_]*=[-A-Za-z0-9_.]*( [a-z_][a-z0-9_]*=[-A-Za-z0-9_.]*)*$'
+        if [[ ! "$ARGS" =~ $PROV_KV_RE ]]; then
+            echo '{"ok": false, "action": "configure-provisioning", "error": "invalid args (expected key=value tokens; key [a-z_], value [-A-Za-z0-9_.])"}' >&2
+            exit 1
+        fi
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "configure-provisioning", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        # ARGS is charset-validated above; intentional word-split into argv tokens.
+        # shellcheck disable=SC2086
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+        GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
+            timeout 30 "$VENV_PY" -m genesis.guardian --configure-provisioning $ARGS
         ;;
     sync-gateway)
         # Recovery: redeploy the gateway script from the (already-pulled) install

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -59,6 +59,9 @@ def main() -> None:
     if "--storage-expand" in sys.argv:
         sys.exit(asyncio.run(_storage_expand()))
 
+    if "--configure-provisioning" in sys.argv:
+        sys.exit(_configure_provisioning(sys.argv))
+
     asyncio.run(run_check())
 
 
@@ -182,6 +185,44 @@ def _args_after(argv: list[str], flag: str, n: int) -> list[str] | None:
         return None
     tail = argv[i + 1 : i + 1 + n]
     return tail if len(tail) == n else None
+
+
+def _configure_provisioning(argv: list[str]) -> int:
+    """Land/refresh the host provisioning config as a state-dir override.
+
+    Takes ``key=value`` args (only ProvisioningConfig fields). Writes
+    ``<state_dir>/provisioning.local.yaml`` — outside the git checkout, so it
+    survives guardian redeploys — then re-loads to confirm it parses and echoes
+    the merged result. No secrets here (the Proxmox tokens cross the bridge).
+    """
+    from genesis.guardian.config import load_config, write_provisioning_override
+
+    i = argv.index("--configure-provisioning")
+    kvs = argv[i + 1:]
+    if not kvs:
+        return _emit({"ok": False, "action": "configure-provisioning",
+                      "error": "usage: --configure-provisioning key=value [key=value ...]"})
+    params: dict[str, str] = {}
+    for tok in kvs:
+        if "=" not in tok:
+            return _emit({"ok": False, "action": "configure-provisioning",
+                          "error": f"bad arg {tok!r} (expected key=value)"})
+        k, _, v = tok.partition("=")
+        params[k.strip()] = v.strip()
+
+    try:
+        config = load_config()
+        dest = write_provisioning_override(config.state_dir, params)
+    except (ValueError, OSError) as exc:
+        return _emit({"ok": False, "action": "configure-provisioning", "error": str(exc)})
+
+    p = load_config().provisioning  # re-read to reflect the merged result
+    return _emit({"ok": True, "action": "configure-provisioning", "path": str(dest),
+                  "provisioning": {"enabled": p.enabled, "api_host": p.api_host,
+                                   "api_port": p.api_port, "node": p.node, "vmid": p.vmid,
+                                   "target_disk": p.target_disk, "storage": p.storage,
+                                   "verify_tls": p.verify_tls,
+                                   "require_recent_backup": p.require_recent_backup}})
 
 
 async def _provision_status() -> int:

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -380,6 +380,89 @@ def _build_sub(cls: type, raw: dict, key: str) -> object:
     return cls(**{k: v for k, v in section.items() if k in valid_fields})
 
 
+# Provisioning override lives in the guardian STATE dir (not the git checkout),
+# so `configure-provisioning` can land host-specific provisioning config that
+# survives `update.sh` guardian redeploys without editing (or skip-worktree-ing)
+# the tracked guardian.yaml.
+_PROVISIONING_OVERRIDE_FILE = "provisioning.local.yaml"
+
+
+def _coerce_provisioning_value(default: object, value: object) -> object:
+    """Coerce a raw override value to the ProvisioningConfig field's type.
+
+    bool is checked before int (bool is an int subclass). Accepts real YAML
+    types (already correct) or strings (from the ``key=value`` CLI path).
+    """
+    if isinstance(default, bool):
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in ("1", "true", "yes", "on")
+    if isinstance(default, int):
+        return int(value)
+    return str(value)
+
+
+def write_provisioning_override(state_dir: str, params: dict) -> Path:
+    """Write/replace the provisioning override file; return its path.
+
+    Only keys valid on ProvisioningConfig are accepted — an unknown key raises
+    ValueError so a typo can't silently no-op. No secrets belong here (the two
+    Proxmox tokens cross the credential bridge, never this file).
+    """
+    defaults = {f.name: f.default for f in dataclasses.fields(ProvisioningConfig)}
+    coerced: dict = {}
+    for k, v in params.items():
+        if k not in defaults:
+            raise ValueError(f"unknown provisioning field: {k!r}")
+        coerced[k] = _coerce_provisioning_value(defaults[k], v)
+    state_path = Path(state_dir).expanduser()
+    state_path.mkdir(parents=True, exist_ok=True)
+    dest = state_path / _PROVISIONING_OVERRIDE_FILE
+    # Atomic write: a mid-write kill must never leave a truncated override
+    # (it would be ignored and fall back to defaults, but a clean swap is free).
+    tmp = dest.with_suffix(".tmp")
+    with open(tmp, "w") as f:
+        yaml.safe_dump({"provisioning": coerced}, f, default_flow_style=False, sort_keys=True)
+    os.replace(tmp, dest)
+    return dest
+
+
+def _apply_provisioning_override(config: GuardianConfig) -> None:
+    """Merge the state-dir provisioning override onto the loaded config.
+
+    An absent or unreadable file is a silent no-op — a broken override must
+    never crash a guardian check cycle. Only fields valid on ProvisioningConfig
+    are applied; env overrides (incl. the GUARDIAN_PROVISIONING_ENABLED kill
+    switch) run AFTER this, so they always win.
+    """
+    override = config.state_path / _PROVISIONING_OVERRIDE_FILE
+    try:
+        if not override.exists():
+            return
+        with open(override) as f:
+            raw = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Ignoring unreadable provisioning override %s: %s", override, exc)
+        return
+    section = raw.get("provisioning") if isinstance(raw, dict) and "provisioning" in raw else raw
+    if not isinstance(section, dict):
+        return
+    valid = {f.name for f in dataclasses.fields(ProvisioningConfig)}
+    applied = False
+    for k, v in section.items():
+        if k in valid:
+            setattr(config.provisioning, k, v)
+            applied = True
+    if applied:
+        logger.info("Applied provisioning override from %s", override)
+
+
+def _finalize(config: GuardianConfig) -> GuardianConfig:
+    """Apply the provisioning override then env overrides (env wins)."""
+    _apply_provisioning_override(config)
+    return _env_override(config)
+
+
 def load_config(path: Path | None = None) -> GuardianConfig:
     """Load Guardian config from YAML with env var overrides.
 
@@ -389,7 +472,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
 
     if not config_path.exists():
         logger.info("Guardian config not found at %s, using defaults", config_path)
-        return _env_override(GuardianConfig())
+        return _finalize(GuardianConfig())
 
     with open(config_path) as f:
         raw = yaml.safe_load(f) or {}
@@ -416,7 +499,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         provisioning=_build_sub(ProvisioningConfig, raw, "provisioning"),
     )
 
-    return _env_override(config)
+    return _finalize(config)
 
 
 def load_secrets(path: Path | None = None) -> dict[str, str]:

--- a/tests/test_guardian/test_config_provisioning_override.py
+++ b/tests/test_guardian/test_config_provisioning_override.py
@@ -1,0 +1,101 @@
+"""Tests for the state-dir provisioning override (configure-provisioning verb).
+
+The override lets `configure-provisioning` land host-specific provisioning config
+in the guardian state_dir — outside the git checkout — so it survives guardian
+redeploys without editing the tracked guardian.yaml.
+"""
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from genesis.guardian.config import (
+    ProvisioningConfig,
+    load_config,
+    write_provisioning_override,
+)
+
+
+def _guardian_yaml(tmp_path, state_dir):
+    p = tmp_path / "guardian.yaml"
+    p.write_text(f'container_name: genesis\nstate_dir: "{state_dir}"\n')
+    return p
+
+
+def test_write_and_merge_roundtrip(tmp_path):
+    state = tmp_path / "state"
+    cfg_path = _guardian_yaml(tmp_path, state)
+    dest = write_provisioning_override(str(state), {
+        "enabled": "true", "api_host": "10.0.0.5", "api_port": "8006",
+        "node": "proxmox", "vmid": "500", "target_disk": "scsi1",
+        "storage": "local-lvm", "verify_tls": "false",
+        "require_recent_backup": "false",
+    })
+    assert dest.exists()
+    written = yaml.safe_load(dest.read_text())["provisioning"]
+    assert written["enabled"] is True          # str -> bool coercion
+    assert written["vmid"] == 500              # str -> int coercion
+    assert written["verify_tls"] is False
+    assert written["api_host"] == "10.0.0.5"
+
+    cfg = load_config(cfg_path)
+    assert cfg.provisioning.enabled is True
+    assert cfg.provisioning.vmid == 500
+    assert cfg.provisioning.target_disk == "scsi1"
+    assert cfg.provisioning.verify_tls is False
+    assert cfg.provisioning.require_recent_backup is False
+
+
+def test_absent_override_is_noop(tmp_path):
+    cfg_path = _guardian_yaml(tmp_path, tmp_path / "state")
+    cfg = load_config(cfg_path)
+    assert cfg.provisioning == ProvisioningConfig()  # defaults, disabled
+
+
+def test_unknown_field_raises(tmp_path):
+    with pytest.raises(ValueError, match="unknown provisioning field"):
+        write_provisioning_override(str(tmp_path / "s"), {"bogus": "x"})
+
+
+def test_partial_override_merges_onto_defaults(tmp_path):
+    state = tmp_path / "state"
+    cfg_path = _guardian_yaml(tmp_path, state)
+    write_provisioning_override(str(state), {"enabled": "true", "vmid": "300"})
+    cfg = load_config(cfg_path)
+    assert cfg.provisioning.enabled is True
+    assert cfg.provisioning.vmid == 300
+    # untouched fields keep their defaults
+    assert cfg.provisioning.api_port == 8006
+    assert cfg.provisioning.target_disk == "scsi1"
+
+
+def test_env_kill_switch_wins_over_override(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    cfg_path = _guardian_yaml(tmp_path, state)
+    write_provisioning_override(str(state), {"enabled": "true"})
+    monkeypatch.setenv("GUARDIAN_PROVISIONING_ENABLED", "0")
+    cfg = load_config(cfg_path)
+    assert cfg.provisioning.enabled is False  # env override runs last and wins
+
+
+def test_unreadable_override_is_silent(tmp_path):
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "provisioning.local.yaml").write_text(":::not: valid: yaml:::\n  - [")
+    cfg_path = _guardian_yaml(tmp_path, state)
+    cfg = load_config(cfg_path)  # must not raise
+    assert cfg.provisioning.enabled is False  # fell back to defaults
+
+
+def test_native_yaml_types_accepted(tmp_path):
+    """The loader must also accept an override written with real YAML types
+    (not just the CLI's key=value strings)."""
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "provisioning.local.yaml").write_text(
+        yaml.safe_dump({"provisioning": {"enabled": True, "vmid": 42}})
+    )
+    cfg_path = _guardian_yaml(tmp_path, state)
+    cfg = load_config(cfg_path)
+    assert cfg.provisioning.enabled is True
+    assert cfg.provisioning.vmid == 42


### PR DESCRIPTION
## Summary

Adds a `configure-provisioning` guardian gateway verb so activating the Guardian's approval-gated Proxmox provisioning (#920) on an install no longer requires hand-editing the host `guardian.yaml`.

The host `guardian.yaml` is git-tracked (not skip-worktree) and installer-generated, so a raw edit risks being clobbered by a future checkout and leaves an un-landed host divergence. Instead:

- **Gateway verb** `configure-provisioning key=value ...` → `python -m genesis.guardian --configure-provisioning ...` writes a `provisioning.local.yaml` **override into the guardian state dir** — outside the git checkout, so `update.sh` redeploys never touch it.
- **Config loader** merges the override onto the `provisioning` sub-config in `load_config` (via `_finalize`) *before* env overrides, so `GUARDIAN_PROVISIONING_ENABLED` still wins as the kill switch.
- Only `ProvisioningConfig` fields are accepted (unknown key → error); values are type-coerced from the `key=value` strings. **No secrets** here — the two Proxmox tokens cross the credential bridge, never this verb.

## Security

`SSH_ORIGINAL_COMMAND` is untrusted. The verb requires **every token to be strictly `key=value`-shaped** (`^[a-z_][a-z0-9_]*=[-A-Za-z0-9_.]*( ...)*$`). Without that, a bare flag-shaped token (e.g. `--storage-expand`, `--provision-grow-disk scsi1 5`) would word-split into `argv` and hijack `main()`'s `if "--x" in sys.argv` dispatch to a *different* guardian verb (an argument-injection footgun; not a privilege escalation, since a key-holder can call those verbs directly). Verified: valid `key=value` passes; `--test`, `--storage-expand`, `--provision-grow-disk scsi1 5`, `; rm -rf /`, `$(whoami)` all rejected. The override write is atomic (temp + `os.replace`).

## Testing

- `tests/test_guardian/test_config_provisioning_override.py` (7): write+merge roundtrip, partial merge onto defaults, unknown-field rejection, env-kill-switch precedence, unreadable-override resilience (never raises in the health-check hot path), native-YAML-type acceptance.
- Full `tests/test_guardian/` green (629); ruff + shellcheck + `bash -n` clean; CLI + gateway-regex smoke-tested live.

Reviewed adversarially (found + fixed the injection vector above); config-loader ordering, exception-safety, coercion, and unknown-key handling all verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
