### PR TITLE
fix(guardian): resolve btrfs backing LV via readlink+lsblk (live absorb fix)

### DIFF
--- a/src/genesis/guardian/provisioning/expand.py
+++ b/src/genesis/guardian/provisioning/expand.py
@@ -161,16 +161,29 @@ async def _rescan_and_pvresize(vg: str, run, _record) -> tuple[bool, str]:
 async def _btrfs_backing(mount: str, run) -> tuple[str | None, str | None]:
     """Resolve the (vg, lv) backing a mounted btrfs from its mountpath.
 
-    ``findmnt`` yields the dm device (``/dev/mapper/vg-lv``, possibly with a
-    ``[/subvol]`` suffix to strip); ``lvs <dev>`` resolves it to VG/LV names.
+    ``findmnt`` yields the backing device, but it can be a ``/dev/disk/by-uuid``
+    symlink or a bare ``/dev/dm-N`` (with a possible ``[/subvol]`` suffix) —
+    ``lvs`` accepts neither (a by-uuid path is "Invalid path for Logical Volume";
+    a ``/dev/dm-N`` is misread as a VG name). Canonicalize to the kernel device
+    (``readlink -f``), resolve its device-mapper name (``lsblk``), then
+    ``lvs /dev/mapper/<name>`` — which only succeeds for a real LVM LV, so a
+    non-LVM btrfs (e.g. on a bare partition) correctly returns (None, None).
     """
     rc, out, _ = await run("findmnt", "-no", "SOURCE", mount, timeout=10.0)
     if rc != 0 or not out.strip():
         return None, None
     dev = out.strip().splitlines()[0].split("[", 1)[0].strip()
+    # by-uuid symlink / dm path → canonical kernel device (/dev/dm-N).
+    rc, out, _ = await run("readlink", "-f", dev, timeout=10.0)
+    real = out.strip().splitlines()[0].strip() if rc == 0 and out.strip() else dev
+    # Kernel device → device-mapper name (e.g. ubuntu--vg-genesis--btrfs--lv).
+    rc, out, _ = await run("lsblk", "-ndo", "NAME", real, timeout=10.0)
+    if rc != 0 or not out.strip():
+        return None, None
+    dmname = out.strip().splitlines()[0].strip()
     rc, out, _ = await run(
-        "sudo", "-n", "lvs", "--noheadings", "-o", "vg_name,lv_name", dev,
-        timeout=15.0,
+        "sudo", "-n", "lvs", "--noheadings", "-o", "vg_name,lv_name",
+        f"/dev/mapper/{dmname}", timeout=15.0,
     )
     if rc != 0 or not out.strip():
         return None, None

--- a/tests/test_guardian/test_provisioning_expand.py
+++ b/tests/test_guardian/test_provisioning_expand.py
@@ -26,8 +26,10 @@ class FakeRun:
         self.incus_thinpool_name = "IncusThinPool"  # incus lvm.thinpool_name; "" = unset
         self.lvs_lv_name = "IncusThinPool"  # `lvs -o lv_name -S segtype=thin-pool <vg>`
         # btrfs-on-LVM knobs
-        self.findmnt_out = "/dev/mapper/vg0-genesis--btrfs--lv"
-        self.lvs_backing_out = "  vg0 genesis-btrfs-lv"  # `lvs -o vg_name,lv_name <dev>`
+        self.findmnt_out = "/dev/disk/by-uuid/11111111-2222-3333-4444-555555555555"  # by-uuid symlink
+        self.readlink_out = "/dev/dm-3"  # readlink -f <findmnt SOURCE> → kernel dev
+        self.lsblk_name = "vg0-genesis--btrfs--lv"  # lsblk -ndo NAME <real> → dm name
+        self.lvs_backing_out = "  vg0 genesis-btrfs-lv"  # `lvs -o vg_name,lv_name /dev/mapper/<name>`
         self.lvextend_rc = 0
         self.btrfs_resize_rc = 0
         # df --output=size --block-size=1 answers, consumed in order (before/after);
@@ -37,8 +39,12 @@ class FakeRun:
     async def __call__(self, *argv, timeout=60.0, stdin_data=None):
         self.calls.append((argv, stdin_data))
         a = list(argv)
+        if a[:1] == ["readlink"]:
+            return 0, self.readlink_out, ""
         if a[:1] == ["lsblk"]:
-            return 0, self.lsblk_out, ""
+            if "NAME" in a:  # btrfs backing: dm-name of the canonical device
+                return (0, self.lsblk_name, "") if self.lsblk_name else (1, "", "")
+            return 0, self.lsblk_out, ""  # PKNAME: thin-pool PV parent
         if a[:1] == ["findmnt"]:
             return (0, self.findmnt_out, "") if self.findmnt_out else (1, "", "not found")
         if a[:1] == ["df"]:
@@ -253,6 +259,36 @@ async def test_btrfs_happy_path_order_and_ok(_btrfs):
     assert "thinpool.profile" not in joined
     assert "lvchange" not in joined
     assert "100%FREE" not in joined
+
+
+async def test_btrfs_backing_resolves_via_readlink_and_mapper(_btrfs):
+    """Regression (live 2026-07-07): findmnt yields a /dev/disk/by-uuid symlink,
+    which lvs rejects ("Invalid path for Logical Volume"). The backing must be
+    resolved through readlink -f → lsblk NAME → lvs /dev/mapper/<name>, and the
+    lvs call must NOT receive the raw by-uuid path."""
+    fake = FakeRun()  # findmnt_out is a by-uuid symlink by default
+    res = await expand_storage(GuardianConfig(), run=fake, add_gib=1)
+    assert res["ok"] is True
+    assert res["vg"] == "vg0" and res["lv"] == "genesis-btrfs-lv"
+    # findmnt → readlink (canonicalize) happened, in order
+    assert fake.cmd_index("readlink") >= 0
+    assert fake.cmd_index("findmnt") < fake.cmd_index("readlink")
+    # the backing lvs targets /dev/mapper/<dmname>, never the by-uuid symlink
+    backing_lvs = next(
+        argv for argv, _ in fake.calls
+        if "lvs" in argv and "vg_name,lv_name" in argv
+    )
+    assert "/dev/mapper/vg0-genesis--btrfs--lv" in backing_lvs
+    assert not any("by-uuid" in tok for tok in backing_lvs)
+
+
+async def test_btrfs_unresolvable_dmname_refuses(_btrfs):
+    """If lsblk can't yield a dm-name (non-LVM btrfs), refuse cleanly."""
+    fake = FakeRun()
+    fake.lsblk_name = ""  # lsblk NAME returns nothing
+    res = await expand_storage(GuardianConfig(), run=fake, add_gib=1)
+    assert res["ok"] is False
+    assert "resolve" in res["error"].lower()
 
 
 async def test_btrfs_standalone_absorbs_vg_free(_btrfs):


### PR DESCRIPTION
## Summary

Fixes the btrfs-on-LVM absorb (from #944) failing at backing-LV resolution on a real host — found during the live +1 GiB grow E2E.

`_btrfs_backing` assumed `findmnt -no SOURCE <pool mount>` yields `/dev/mapper/vg-lv`. On a real btrfs-on-LVM host it returns a **`/dev/disk/by-uuid/<uuid>` symlink**, which `lvs` rejects (`Invalid path for Logical Volume`) → the absorb bailed with `vg: null, lv: null` and did nothing (the disk grew at the hypervisor but was never absorbed into the pool). A bare `/dev/dm-N` is no better — `lvs` misreads it as a VG name.

## Fix

Canonicalize the `findmnt` source, then resolve device→LV robustly:

```
findmnt -no SOURCE <mount>        # /dev/disk/by-uuid/<uuid>  (or /dev/mapper/…, /dev/dm-N)
→ readlink -f                     # /dev/dm-N  (canonical kernel device)
→ lsblk -ndo NAME                 # ubuntu--vg-genesis--btrfs--lv  (dm name)
→ lvs /dev/mapper/<name>          # ubuntu-vg  genesis-btrfs-lv
```

`lvs /dev/mapper/<name>` both resolves *and validates* it's a real LV, so a non-LVM btrfs (e.g. on a bare partition) still returns `(None, None)` → clean refuse. Verified live on the affected host: the chain yields `ubuntu-vg / genesis-btrfs-lv`.

## Testing

- Updated `FakeRun` to model the real chain (findmnt→readlink→lsblk NAME→lvs). Default `findmnt` output is now a `by-uuid` symlink (synthetic UUID).
- New `test_btrfs_backing_resolves_via_readlink_and_mapper` — the regression: asserts the backing `lvs` targets `/dev/mapper/<name>` and **never** the raw `by-uuid` path.
- New `test_btrfs_unresolvable_dmname_refuses` — non-LVM btrfs (no dm-name) refuses cleanly.
- Full `tests/test_guardian/test_provisioning_expand.py` green (20); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
