### PR TITLE
refactor(memory): decompose HybridRetriever.recall into stage methods

### DIFF
--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -12,7 +12,12 @@ from genesis.db.crud import memory as memory_crud
 from genesis.db.crud import memory_links, observations
 from genesis.memory.activation import compute_activation
 from genesis.memory.embeddings import EmbeddingProvider, EmbeddingUnavailableError
-from genesis.memory.intent import classify_intent, expand_query, rank_by_intent
+from genesis.memory.intent import (
+    QueryIntent,
+    classify_intent,
+    expand_query,
+    rank_by_intent,
+)
 from genesis.memory.reranker import VoyageReranker
 from genesis.memory.types import RetrievalResult
 from genesis.observability.call_site_recorder import record_last_run
@@ -280,6 +285,201 @@ def _apply_diversity_penalty(
 
     # Return candidates that still have positive scores
     return [mid for mid in candidates if fused.get(mid, 0.0) > 0.0]
+
+
+def _build_intent_ranked(
+    intent: QueryIntent,
+    all_ids: set[str],
+    qdrant_by_id: dict[str, dict],
+    fts_by_id: dict[str, dict],
+) -> list[str]:
+    """Build the intent-biased ranked list for RRF (empty for GENERAL — no bias)."""
+    intent_ranked: list[str] = []
+    if intent.category != "GENERAL":
+        candidate_meta: dict[str, dict] = {}
+        for mid in all_ids:
+            qhit = qdrant_by_id.get(mid)
+            fhit = fts_by_id.get(mid)
+            if qhit:
+                p = qhit.get("payload", {})
+                candidate_meta[mid] = {
+                    "source": p.get("source", ""),
+                    "tags": p.get("tags") or [],
+                    "content": p.get("content", ""),
+                }
+            elif fhit:
+                candidate_meta[mid] = {
+                    "source": fhit.get("source_type", ""),
+                    "tags": [],
+                    "content": fhit.get("content", ""),
+                }
+        intent_ranked = rank_by_intent(intent, candidate_meta)
+    return intent_ranked
+
+
+def _filter_scope_fts_only(
+    candidates: list[str],
+    qdrant_by_id: dict[str, dict],
+    fts_by_id: dict[str, dict],
+    *,
+    wing: str | None,
+    room: str | None,
+    life_domain: str | None,
+) -> list[str]:
+    """Filter FTS5-only candidates by wing/room/life_domain (Qdrant results
+    are already filtered at query time; this catches FTS5-only candidates
+    that don't match the requested filters). No-op when no filter is set.
+    """
+    if wing or room or life_domain:
+        filtered: list[str] = []
+        for mid in candidates:
+            qhit = qdrant_by_id.get(mid)
+            if qhit:
+                # Qdrant already filtered — guaranteed match
+                filtered.append(mid)
+            elif life_domain and not wing and not room:
+                # FTS5-only + life_domain filter: check the tag string
+                fhit = fts_by_id.get(mid)
+                if fhit:
+                    tags_str = fhit.get("tags", "")
+                    if f"life_domain:{life_domain}" in tags_str:
+                        filtered.append(mid)
+            else:
+                # FTS5-only candidate with wing/room filter — no
+                # wing/room data in FTS5, exclude since we can't
+                # verify membership.
+                pass
+        candidates = filtered
+    return candidates
+
+
+def _assemble_results(
+    *,
+    top: list[str],
+    qdrant_by_id: dict[str, dict],
+    fts_by_id: dict[str, dict],
+    fused: dict[str, float],
+    activation_by_id: dict[str, float],
+    vector_ranked_dedup: list[str],
+    seen: set[str],
+    fts_ranked: list[str],
+    embedding_available: bool,
+    intent: QueryIntent,
+) -> list[RetrievalResult]:
+    """Build RetrievalResult objects for the top-ranked candidates.
+
+    Vector/FTS ranks are recomputed positionally against the stage-6 ranked
+    lists (``vector_ranked_dedup``/``seen``/``fts_ranked``) — that reach-back
+    is deliberate and explicit in the parameters.
+    """
+    results: list[RetrievalResult] = []
+    for mid in top:
+        qdrant_hit = qdrant_by_id.get(mid)
+        fts_hit = fts_by_id.get(mid)
+
+        # Determine content and metadata. ``_collection`` is the
+        # authoritative first-party/external discriminator (audit D12):
+        # the Qdrant collection on a vector hit (set at recall time, ~L367),
+        # or the FTS row's collection tag for an FTS5-only hit.
+        if qdrant_hit:
+            payload = qdrant_hit.get("payload", {})
+            content = payload.get("content", "")
+            src = payload.get("source", "")
+            mem_type = payload.get("memory_type", "")
+            _collection = qdrant_hit.get("_collection", "episodic_memory")
+        elif fts_hit:
+            content = fts_hit.get("content", "")
+            src = fts_hit.get("source_type", "")
+            mem_type = fts_hit.get("collection", "")
+            payload = fts_hit
+            _collection = fts_hit.get("collection", "episodic_memory")
+        else:
+            continue
+
+        # Determine ranks
+        if embedding_available:
+            v_rank = (
+                vector_ranked_dedup.index(mid) + 1
+                if mid in seen and mid in set(vector_ranked_dedup)
+                else None
+            )
+        else:
+            v_rank = None
+        f_rank = (
+            fts_ranked.index(mid) + 1
+            if mid in set(fts_ranked)
+            else None
+        )
+
+        # Extract provenance from Qdrant payload if available
+        _p = payload if qdrant_hit else {}
+        _line_range = _p.get("source_line_range")
+        results.append(
+            RetrievalResult(
+                memory_id=mid,
+                content=content,
+                source=src,
+                memory_type=mem_type,
+                score=fused[mid],
+                vector_rank=v_rank,
+                fts_rank=f_rank,
+                activation_score=activation_by_id.get(mid, 0.0),
+                payload=_p,
+                source_session_id=_p.get("source_session_id"),
+                transcript_path=_p.get("transcript_path"),
+                source_line_range=tuple(_line_range) if _line_range else None,
+                source_pipeline=_p.get("source_pipeline"),
+                memory_class=_p.get("memory_class", "fact"),
+                query_intent=intent.category,
+                intent_confidence=intent.confidence,
+                collection=_collection,
+            ),
+        )
+    return results
+
+
+def _entrenchment_metrics(
+    results: list[RetrievalResult],
+    _scores: list[float],
+    retrieved_count_by_id: dict[str, int],
+    created_at_by_id: dict[str, str],
+    now_str: str,
+) -> tuple[float | None, float | None, float | None]:
+    """MEM-005: entrenchment signal — does retrieval frequency predict final
+    ranking? A positive corr(retrieved_count, score) means the activation
+    loop is rewarding mere frequency in the ranking. Monitor-only (D7:
+    instrument, do NOT re-rank); a sustained strong-positive trend over
+    time flags entrenchment of stale-but-popular memories. Defensive — it
+    reads external payload data and must never break recall.
+
+    Returns ``(entrenchment_corr, mean_retrieved_count, mean_age_days)``.
+    """
+    _entrenchment = _mean_retrieved = _mean_age_days = None
+    try:
+        _ret_counts = [
+            float(retrieved_count_by_id.get(r.memory_id, 0)) for r in results
+        ]
+        if _ret_counts:
+            _entrenchment = _spearman_rank_corr(_ret_counts, _scores)
+            _mean_retrieved = round(sum(_ret_counts) / len(_ret_counts), 2)
+            _now_dt = datetime.fromisoformat(now_str.replace("Z", "+00:00"))
+            _ages: list[float] = []
+            for r in results:
+                _ca = created_at_by_id.get(r.memory_id)
+                if not _ca:
+                    continue
+                try:
+                    _ages.append(
+                        (_now_dt - datetime.fromisoformat(
+                            _ca.replace("Z", "+00:00"))).total_seconds() / 86400.0
+                    )
+                except (ValueError, AttributeError):
+                    continue
+            if _ages:
+                _mean_age_days = round(sum(_ages) / len(_ages), 1)
+    except Exception:
+        logger.debug("MEM-005 entrenchment metric failed", exc_info=True)
+    return _entrenchment, _mean_retrieved, _mean_age_days
 
 
 async def _expired_candidate_ids(
@@ -576,26 +776,9 @@ class HybridRetriever:
         activation_ranked = sorted(all_ids, key=lambda m: activation_by_id[m], reverse=True)
 
         # 6b. Build intent-biased ranked list (empty for GENERAL — no bias)
-        intent_ranked: list[str] = []
-        if intent.category != "GENERAL":
-            candidate_meta: dict[str, dict] = {}
-            for mid in all_ids:
-                qhit = qdrant_by_id.get(mid)
-                fhit = fts_by_id.get(mid)
-                if qhit:
-                    p = qhit.get("payload", {})
-                    candidate_meta[mid] = {
-                        "source": p.get("source", ""),
-                        "tags": p.get("tags") or [],
-                        "content": p.get("content", ""),
-                    }
-                elif fhit:
-                    candidate_meta[mid] = {
-                        "source": fhit.get("source_type", ""),
-                        "tags": [],
-                        "content": fhit.get("content", ""),
-                    }
-            intent_ranked = rank_by_intent(intent, candidate_meta)
+        intent_ranked = _build_intent_ranked(
+            intent, all_ids, qdrant_by_id, fts_by_id,
+        )
 
         # 7. Fusion: RRF if we have vector results, otherwise FTS5 + activation only
         if embedding_available:
@@ -698,29 +881,11 @@ class HybridRetriever:
         # 9. Sort by fused score descending
         candidates.sort(key=lambda m: fused[m], reverse=True)
 
-        # 9b. Filter FTS5-only candidates by wing/room/life_domain (Qdrant
-        #     results are already filtered at query time; this catches
-        #     FTS5-only candidates that don't match the requested filters).
-        if wing or room or life_domain:
-            filtered: list[str] = []
-            for mid in candidates:
-                qhit = qdrant_by_id.get(mid)
-                if qhit:
-                    # Qdrant already filtered — guaranteed match
-                    filtered.append(mid)
-                elif life_domain and not wing and not room:
-                    # FTS5-only + life_domain filter: check the tag string
-                    fhit = fts_by_id.get(mid)
-                    if fhit:
-                        tags_str = fhit.get("tags", "")
-                        if f"life_domain:{life_domain}" in tags_str:
-                            filtered.append(mid)
-                else:
-                    # FTS5-only candidate with wing/room filter — no
-                    # wing/room data in FTS5, exclude since we can't
-                    # verify membership.
-                    pass
-            candidates = filtered
+        # 9b. Filter FTS5-only candidates by wing/room/life_domain
+        candidates = _filter_scope_fts_only(
+            candidates, qdrant_by_id, fts_by_id,
+            wing=wing, room=room, life_domain=life_domain,
+        )
 
         # 10. Take top limit
         top = candidates[:limit]
@@ -792,69 +957,18 @@ class HybridRetriever:
                 )
 
         # 12. Build RetrievalResult objects
-        results: list[RetrievalResult] = []
-        for mid in top:
-            qdrant_hit = qdrant_by_id.get(mid)
-            fts_hit = fts_by_id.get(mid)
-
-            # Determine content and metadata. ``_collection`` is the
-            # authoritative first-party/external discriminator (audit D12):
-            # the Qdrant collection on a vector hit (set at recall time, ~L367),
-            # or the FTS row's collection tag for an FTS5-only hit.
-            if qdrant_hit:
-                payload = qdrant_hit.get("payload", {})
-                content = payload.get("content", "")
-                src = payload.get("source", "")
-                mem_type = payload.get("memory_type", "")
-                _collection = qdrant_hit.get("_collection", "episodic_memory")
-            elif fts_hit:
-                content = fts_hit.get("content", "")
-                src = fts_hit.get("source_type", "")
-                mem_type = fts_hit.get("collection", "")
-                payload = fts_hit
-                _collection = fts_hit.get("collection", "episodic_memory")
-            else:
-                continue
-
-            # Determine ranks
-            if embedding_available:
-                v_rank = (
-                    vector_ranked_dedup.index(mid) + 1
-                    if mid in seen and mid in set(vector_ranked_dedup)
-                    else None
-                )
-            else:
-                v_rank = None
-            f_rank = (
-                fts_ranked.index(mid) + 1
-                if mid in set(fts_ranked)
-                else None
-            )
-
-            # Extract provenance from Qdrant payload if available
-            _p = payload if qdrant_hit else {}
-            _line_range = _p.get("source_line_range")
-            results.append(
-                RetrievalResult(
-                    memory_id=mid,
-                    content=content,
-                    source=src,
-                    memory_type=mem_type,
-                    score=fused[mid],
-                    vector_rank=v_rank,
-                    fts_rank=f_rank,
-                    activation_score=activation_by_id.get(mid, 0.0),
-                    payload=_p,
-                    source_session_id=_p.get("source_session_id"),
-                    transcript_path=_p.get("transcript_path"),
-                    source_line_range=tuple(_line_range) if _line_range else None,
-                    source_pipeline=_p.get("source_pipeline"),
-                    memory_class=_p.get("memory_class", "fact"),
-                    query_intent=intent.category,
-                    intent_confidence=intent.confidence,
-                    collection=_collection,
-                ),
-            )
+        results = _assemble_results(
+            top=top,
+            qdrant_by_id=qdrant_by_id,
+            fts_by_id=fts_by_id,
+            fused=fused,
+            activation_by_id=activation_by_id,
+            vector_ranked_dedup=vector_ranked_dedup,
+            seen=seen,
+            fts_ranked=fts_ranked,
+            embedding_available=embedding_available,
+            intent=intent,
+        )
 
         # J-9 eval: log recall event for memory retrieval quality measurement
         from genesis.eval.j9_hooks import (
@@ -863,37 +977,10 @@ class HybridRetriever:
         )
 
         _scores = [r.score for r in results]
-        # MEM-005: entrenchment signal — does retrieval frequency predict final
-        # ranking? A positive corr(retrieved_count, score) means the activation
-        # loop is rewarding mere frequency in the ranking. Monitor-only (D7:
-        # instrument, do NOT re-rank); a sustained strong-positive trend over
-        # time flags entrenchment of stale-but-popular memories. Defensive — it
-        # reads external payload data and must never break recall.
-        _entrenchment = _mean_retrieved = _mean_age_days = None
-        try:
-            _ret_counts = [
-                float(retrieved_count_by_id.get(r.memory_id, 0)) for r in results
-            ]
-            if _ret_counts:
-                _entrenchment = _spearman_rank_corr(_ret_counts, _scores)
-                _mean_retrieved = round(sum(_ret_counts) / len(_ret_counts), 2)
-                _now_dt = datetime.fromisoformat(now_str.replace("Z", "+00:00"))
-                _ages: list[float] = []
-                for r in results:
-                    _ca = created_at_by_id.get(r.memory_id)
-                    if not _ca:
-                        continue
-                    try:
-                        _ages.append(
-                            (_now_dt - datetime.fromisoformat(
-                                _ca.replace("Z", "+00:00"))).total_seconds() / 86400.0
-                        )
-                    except (ValueError, AttributeError):
-                        continue
-                if _ages:
-                    _mean_age_days = round(sum(_ages) / len(_ages), 1)
-        except Exception:
-            logger.debug("MEM-005 entrenchment metric failed", exc_info=True)
+        # MEM-005: entrenchment signal (monitor-only) — see _entrenchment_metrics.
+        _entrenchment, _mean_retrieved, _mean_age_days = _entrenchment_metrics(
+            results, _scores, retrieved_count_by_id, created_at_by_id, now_str,
+        )
 
         recall_event_id = await emit_recall_fired(
             self._db,

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -686,79 +686,20 @@ class HybridRetriever:
             ranked_lists.append(event_memory_ids)
         fused = _rrf_fuse(ranked_lists)
 
-        # 7.5 Cross-encoder reranking (optional, off by default)
-        #
-        # Voyage scores live in a different range (0.0–1.0) than RRF scores
-        # (~0.01–0.05). To keep the score space uniform for graph boost and
-        # final sort, we replace the entire fused dict with positional scores
-        # derived from the reranker's ordering. Candidates the reranker
-        # didn't score are dropped — if they lacked content or fell below
-        # top_k, they weren't strong enough to keep.
-        if rerank and self._reranker and self._reranker.enabled and fused:
-            rerank_candidates = sorted(
-                fused, key=fused.get, reverse=True,  # type: ignore[arg-type]
-            )[:limit * 3]
-            rerank_docs: list[dict[str, str]] = []
-            for mid in rerank_candidates:
-                content = ""
-                qhit = qdrant_by_id.get(mid)
-                if qhit:
-                    content = qhit.get("payload", {}).get("content", "")
-                elif mid in fts_by_id:
-                    content = fts_by_id[mid].get("content", "")
-                if content:
-                    rerank_docs.append({"id": mid, "text": content})
-            if rerank_docs:
-                reranked = await self._reranker.rerank(
-                    query, rerank_docs, top_k=limit * 2,
-                )
-                if reranked:
-                    # Rebuild fused with only reranked candidates, using
-                    # positional scores so graph boost floor-gating works.
-                    fused = {
-                        item["id"]: 1.0 / (1 + rank)
-                        for rank, item in enumerate(reranked)
-                    }
+        # 7.5 Cross-encoder reranking (optional, off by default) — the ONLY
+        # post-fusion point where ``fused`` is reassigned rather than mutated.
+        fused = await self._maybe_rerank(
+            query=query,
+            fused=fused,
+            qdrant_by_id=qdrant_by_id,
+            fts_by_id=fts_by_id,
+            limit=limit,
+            rerank=rerank,
+        )
 
-        # 7b. Graph boost: backlink + adjacency (floor-gated)
-        graph_boost_applied = False
-        if fused:
-            top_fused = max(fused.values())
-            floor_score = top_fused * _FLOOR_RATIO
-
-            # 7b-i. Backlink boost: reward memories referenced by many others
-            for mid in fused:
-                if fused[mid] < floor_score:
-                    continue  # floor-gated: skip weak candidates
-                inbound = inbound_by_id.get(mid, 0)
-                if inbound > 0:
-                    fused[mid] *= 1 + _BACKLINK_BOOST_COEF * math.log(1 + inbound)
-                    graph_boost_applied = True
-
-            # 7b-ii. Adjacency boost: reward cluster coherence in top-K
-            # Recompute floor after backlink boost — the top score may
-            # have changed, and the adjacency gate should use the new top.
-            floor_score = max(fused.values()) * _FLOOR_RATIO
-            boosted_ranked = sorted(fused, key=fused.get, reverse=True)  # type: ignore[arg-type]
-            top_k = boosted_ranked[:_ADJACENCY_TOP_K]
-            if len(top_k) >= 3:
-                try:
-                    edges = await memory_links.inter_candidate_links(
-                        self._db, top_k,
-                    )
-                    intra_inbound: dict[str, int] = {}
-                    for src, tgt in edges:
-                        if src != tgt:
-                            intra_inbound[tgt] = intra_inbound.get(tgt, 0) + 1
-                    for mid, count in intra_inbound.items():
-                        if count >= _ADJACENCY_MIN_INLINKS and fused[mid] >= floor_score:
-                            fused[mid] *= _ADJACENCY_BOOST
-                            graph_boost_applied = True
-                except Exception:
-                    logger.warning(
-                        "Adjacency boost query failed, skipping",
-                        exc_info=True,
-                    )
+        # 7b. Graph boost: backlink + adjacency (floor-gated); mutates
+        # ``fused`` in place.
+        graph_boost_applied = await self._apply_graph_boost(fused, inbound_by_id)
 
         # 8. Filter by min_activation
         candidates = [
@@ -785,71 +726,9 @@ class HybridRetriever:
         # 10. Take top limit
         top = candidates[:limit]
 
-        # 11. Increment retrieved_count + stamp last_retrieved_at
-        for mid in top:
-            qdrant_hit = qdrant_by_id.get(mid)
-            if qdrant_hit:
-                coll = qdrant_hit.get("_collection", "episodic_memory")
-                old_count = qdrant_hit.get("payload", {}).get("retrieved_count", 0)
-                try:
-                    qdrant_ops.update_payload(
-                        self._qdrant,
-                        collection=coll,
-                        point_id=mid,
-                        payload={
-                            "retrieved_count": old_count + 1,
-                            "last_retrieved_at": now_str,
-                        },
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to update retrieved_count for %s in %s",
-                        mid, coll, exc_info=True,
-                    )
-
-        # 11b. Sync observation retrieved_count in SQLite
-        #       Extract obs:<uuid> tags from Qdrant payloads to find linked observations
-        obs_ids: list[str] = []
-        for mid in top:
-            qdrant_hit = qdrant_by_id.get(mid)
-            if qdrant_hit:
-                tags = qdrant_hit.get("payload", {}).get("tags") or []
-                for tag in tags:
-                    if tag.startswith("obs:"):
-                        obs_ids.append(tag[4:])
-        if obs_ids:
-            try:
-                await observations.increment_retrieved_batch(self._db, obs_ids)
-            except Exception:
-                logger.warning(
-                    "Failed to sync observation retrieved_count for %d obs",
-                    len(obs_ids), exc_info=True,
-                )
-
-        # 11c. Sync knowledge_units retrieved_count in SQLite
-        #       Match via qdrant_id (Qdrant point ID == knowledge_units.qdrant_id)
-        ku_qdrant_ids: list[str] = []
-        for mid in top:
-            qdrant_hit = qdrant_by_id.get(mid)
-            if qdrant_hit:
-                if qdrant_hit.get("_collection") == "knowledge_base":
-                    ku_qdrant_ids.append(mid)
-            else:
-                # FTS5-only hit — check collection tag
-                fts_hit = fts_by_id.get(mid)
-                if fts_hit and fts_hit.get("collection") == "knowledge_base":
-                    ku_qdrant_ids.append(mid)
-        if ku_qdrant_ids:
-            try:
-                from genesis.db.crud import knowledge as knowledge_crud
-                await knowledge_crud.increment_retrieved_batch(
-                    self._db, ku_qdrant_ids,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to sync knowledge retrieved_count for %d units",
-                    len(ku_qdrant_ids), exc_info=True,
-                )
+        # 11/11b/11c. Retrieval write-backs (Qdrant counts, observation +
+        # knowledge_units sync) — each individually swallowed.
+        await self._record_retrievals(top, qdrant_by_id, fts_by_id, now_str)
 
         # 12. Build RetrievalResult objects
         results = _assemble_results(
@@ -1161,3 +1040,181 @@ class HybridRetriever:
             retrieved_count_by_id[mid] = retrieved_count
             created_at_by_id[mid] = created_at
         return activation_by_id, inbound_by_id, retrieved_count_by_id, created_at_by_id
+
+    # --- recall() stage helpers (mutators / side effects) ---
+
+    async def _maybe_rerank(
+        self,
+        *,
+        query: str,
+        fused: dict[str, float],
+        qdrant_by_id: dict[str, dict],
+        fts_by_id: dict[str, dict],
+        limit: int,
+        rerank: bool,
+    ) -> dict[str, float]:
+        """Stage 7.5: cross-encoder reranking (optional, off by default).
+
+        Voyage scores live in a different range (0.0–1.0) than RRF scores
+        (~0.01–0.05). To keep the score space uniform for graph boost and
+        final sort, we replace the entire fused dict with positional scores
+        derived from the reranker's ordering. Candidates the reranker
+        didn't score are dropped — if they lacked content or fell below
+        top_k, they weren't strong enough to keep.
+
+        Returns the SAME ``fused`` object when reranking is skipped, or a
+        replacement positional-score dict when it ran.
+        """
+        if rerank and self._reranker and self._reranker.enabled and fused:
+            rerank_candidates = sorted(
+                fused, key=fused.get, reverse=True,  # type: ignore[arg-type]
+            )[:limit * 3]
+            rerank_docs: list[dict[str, str]] = []
+            for mid in rerank_candidates:
+                content = ""
+                qhit = qdrant_by_id.get(mid)
+                if qhit:
+                    content = qhit.get("payload", {}).get("content", "")
+                elif mid in fts_by_id:
+                    content = fts_by_id[mid].get("content", "")
+                if content:
+                    rerank_docs.append({"id": mid, "text": content})
+            if rerank_docs:
+                reranked = await self._reranker.rerank(
+                    query, rerank_docs, top_k=limit * 2,
+                )
+                if reranked:
+                    # Rebuild fused with only reranked candidates, using
+                    # positional scores so graph boost floor-gating works.
+                    fused = {
+                        item["id"]: 1.0 / (1 + rank)
+                        for rank, item in enumerate(reranked)
+                    }
+        return fused
+
+    async def _apply_graph_boost(
+        self,
+        fused: dict[str, float],
+        inbound_by_id: dict[str, int],
+    ) -> bool:
+        """Stage 7b: graph boost — backlink + adjacency (floor-gated).
+
+        **Mutates ``fused`` in place** (multiplicative boosts); never
+        rebinds it. Returns whether any boost was applied.
+        """
+        graph_boost_applied = False
+        if fused:
+            top_fused = max(fused.values())
+            floor_score = top_fused * _FLOOR_RATIO
+
+            # 7b-i. Backlink boost: reward memories referenced by many others
+            for mid in fused:
+                if fused[mid] < floor_score:
+                    continue  # floor-gated: skip weak candidates
+                inbound = inbound_by_id.get(mid, 0)
+                if inbound > 0:
+                    fused[mid] *= 1 + _BACKLINK_BOOST_COEF * math.log(1 + inbound)
+                    graph_boost_applied = True
+
+            # 7b-ii. Adjacency boost: reward cluster coherence in top-K
+            # Recompute floor after backlink boost — the top score may
+            # have changed, and the adjacency gate should use the new top.
+            floor_score = max(fused.values()) * _FLOOR_RATIO
+            boosted_ranked = sorted(fused, key=fused.get, reverse=True)  # type: ignore[arg-type]
+            top_k = boosted_ranked[:_ADJACENCY_TOP_K]
+            if len(top_k) >= 3:
+                try:
+                    edges = await memory_links.inter_candidate_links(
+                        self._db, top_k,
+                    )
+                    intra_inbound: dict[str, int] = {}
+                    for src, tgt in edges:
+                        if src != tgt:
+                            intra_inbound[tgt] = intra_inbound.get(tgt, 0) + 1
+                    for mid, count in intra_inbound.items():
+                        if count >= _ADJACENCY_MIN_INLINKS and fused[mid] >= floor_score:
+                            fused[mid] *= _ADJACENCY_BOOST
+                            graph_boost_applied = True
+                except Exception:
+                    logger.warning(
+                        "Adjacency boost query failed, skipping",
+                        exc_info=True,
+                    )
+        return graph_boost_applied
+
+    async def _record_retrievals(
+        self,
+        top: list[str],
+        qdrant_by_id: dict[str, dict],
+        fts_by_id: dict[str, dict],
+        now_str: str,
+    ) -> None:
+        """Stages 11/11b/11c: retrieval write-backs for the returned
+        candidates. Every write is individually swallowed — a failed
+        write-back must never block returning results.
+        """
+        # 11. Increment retrieved_count + stamp last_retrieved_at
+        for mid in top:
+            qdrant_hit = qdrant_by_id.get(mid)
+            if qdrant_hit:
+                coll = qdrant_hit.get("_collection", "episodic_memory")
+                old_count = qdrant_hit.get("payload", {}).get("retrieved_count", 0)
+                try:
+                    qdrant_ops.update_payload(
+                        self._qdrant,
+                        collection=coll,
+                        point_id=mid,
+                        payload={
+                            "retrieved_count": old_count + 1,
+                            "last_retrieved_at": now_str,
+                        },
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to update retrieved_count for %s in %s",
+                        mid, coll, exc_info=True,
+                    )
+
+        # 11b. Sync observation retrieved_count in SQLite
+        #       Extract obs:<uuid> tags from Qdrant payloads to find linked observations
+        obs_ids: list[str] = []
+        for mid in top:
+            qdrant_hit = qdrant_by_id.get(mid)
+            if qdrant_hit:
+                tags = qdrant_hit.get("payload", {}).get("tags") or []
+                for tag in tags:
+                    if tag.startswith("obs:"):
+                        obs_ids.append(tag[4:])
+        if obs_ids:
+            try:
+                await observations.increment_retrieved_batch(self._db, obs_ids)
+            except Exception:
+                logger.warning(
+                    "Failed to sync observation retrieved_count for %d obs",
+                    len(obs_ids), exc_info=True,
+                )
+
+        # 11c. Sync knowledge_units retrieved_count in SQLite
+        #       Match via qdrant_id (Qdrant point ID == knowledge_units.qdrant_id)
+        ku_qdrant_ids: list[str] = []
+        for mid in top:
+            qdrant_hit = qdrant_by_id.get(mid)
+            if qdrant_hit:
+                if qdrant_hit.get("_collection") == "knowledge_base":
+                    ku_qdrant_ids.append(mid)
+            else:
+                # FTS5-only hit — check collection tag
+                fts_hit = fts_by_id.get(mid)
+                if fts_hit and fts_hit.get("collection") == "knowledge_base":
+                    ku_qdrant_ids.append(mid)
+        if ku_qdrant_ids:
+            try:
+                from genesis.db.crud import knowledge as knowledge_crud
+                await knowledge_crud.increment_retrieved_batch(
+                    self._db, ku_qdrant_ids,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to sync knowledge retrieved_count for %d units",
+                    len(ku_qdrant_ids), exc_info=True,
+                )

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -593,101 +593,45 @@ class HybridRetriever:
         candidate_limit = limit * 3
 
         # 1. Embed query (with fallback to FTS5-only)
-        embedding_available = True
-        vector = None
-        try:
-            vector = await self._embeddings.embed(query)
-            await record_last_run(
-                self._db, "21b_query_embedding",
-                provider="embedding", model_id="cloud-primary",
-                response_text=f"Query embed: {query[:60]}",
-            )
-        except EmbeddingUnavailableError:
-            embedding_available = False
-            logger.warning("Embedding unavailable, falling back to FTS5-only retrieval")
+        vector, embedding_available = await self._embed_query(query)
 
         # 2. Qdrant vector search across collections (skip if no embedding)
         qdrant_results: list[dict] = []
         qdrant_by_id: dict[str, dict] = {}
         if embedding_available and vector is not None:
-            for coll in collections:
-                with track_operation(self._embeddings.tracker, "qdrant.search"):
-                    hits = qdrant_ops.search(
-                        self._qdrant,
-                        collection=coll,
-                        query_vector=vector,
-                        limit=candidate_limit,
-                        wing=wing,
-                        room=room,
-                        life_domain=life_domain,
-                        project_type=project_type,
-                        exclude_subsystems=exclude_subsystems,
-                        include_only_subsystems=include_only_subsystems,
-                        include_deprecated=include_deprecated,
-                    )
-                for hit in hits:
-                    hit["_collection"] = coll
-                qdrant_results.extend(hits)
-
-            qdrant_results.sort(key=lambda h: h["score"], reverse=True)
-
-            for hit in qdrant_results:
-                mid = hit["id"]
-                if mid not in qdrant_by_id:
-                    qdrant_by_id[mid] = hit
+            qdrant_results, qdrant_by_id = await self._gather_vector_candidates(
+                vector=vector,
+                collections=collections,
+                candidate_limit=candidate_limit,
+                wing=wing,
+                room=room,
+                life_domain=life_domain,
+                project_type=project_type,
+                exclude_subsystems=exclude_subsystems,
+                include_only_subsystems=include_only_subsystems,
+                include_deprecated=include_deprecated,
+            )
 
         # 2b. Event-calendar search (temporal queries)
-        # (Intent classified at the top of recall(); reused below for
-        # RRF bias in step 7 and for the temporal-marker check here.)
-        event_memory_ids: list[str] = []
-        if intent.category == "WHEN" or _has_temporal_markers(query):
-            try:
-                from genesis.memory.temporal import parse_temporal_reference
-                time_range = parse_temporal_reference(query)
-                if time_range:
-                    from genesis.db.crud import memory_events
-                    event_memory_ids = await memory_events.get_memory_ids_in_range(
-                        self._db, time_range[0], time_range[1],
-                        limit=candidate_limit,
-                    )
-            except Exception:
-                logger.warning("Event-calendar search failed", exc_info=True)
+        event_memory_ids = await self._gather_event_candidates(
+            query, intent, candidate_limit,
+        )
 
         # 2c. Expand query via tag co-occurrence (opt-in, expensive index rebuild)
-        fts_query = query
-        if expand_query_terms:
-            try:
-                fts_query = await expand_query(
-                    query, self._qdrant, collections, max_expansions=5,
-                )
-            except Exception:
-                logger.warning("Query expansion failed, using original", exc_info=True)
+        fts_query = await self._expand_fts_query(
+            query, collections, expand_query_terms=expand_query_terms,
+        )
 
         # 3. FTS5 text search (using expanded query)
-        # FTS5 respects the caller's source choice — searching the wrong
-        # pool here is how knowledge_base entries flood episodic recall
-        # results purely by candidate volume. When source="both" we pass
-        # None so FTS5 sees every row; for a single-collection source we
-        # filter at the SQL level so the candidate set matches Qdrant's
-        # filtered search and RRF fuses comparable lists.
-        fts_is_boolean = fts_query != query  # expansion produced boolean syntax
-        fts_collection = collections[0] if len(collections) == 1 else None
-        fts_results = await memory_crud.search_ranked(
-            self._db,
-            query=fts_query,
-            collection=fts_collection,
-            limit=candidate_limit,
-            boolean=fts_is_boolean,
+        fts_results, fts_by_id = await self._gather_fts_candidates(
+            query=query,
+            fts_query=fts_query,
+            collections=collections,
+            candidate_limit=candidate_limit,
             exclude_subsystems=exclude_subsystems,
             include_only_subsystems=include_only_subsystems,
             include_deprecated=include_deprecated,
         )
-
-        fts_by_id: dict[str, dict] = {}
-        for row in fts_results:
-            mid = row["memory_id"]
-            if mid not in fts_by_id:
-                fts_by_id[mid] = row
 
         # 4. Union of all candidate memory_ids
         all_ids = set(qdrant_by_id) | set(fts_by_id) | set(event_memory_ids)
@@ -695,70 +639,21 @@ class HybridRetriever:
             return []
 
         # 4b. Phase 1.5e: drop candidates past their bitemporal invalid_at.
-        # FTS5 already filtered (search_ranked has SQL WHERE on invalid_at);
-        # Qdrant and the event calendar don't see invalid_at, so a batched
-        # lookup here catches their candidates before we waste activation/
-        # link computation on expired rows.
-        # Wrapped in try/except: a DB failure here should degrade to
-        # "no expiry filter applied" rather than crash the entire recall.
-        try:
-            expired = await _expired_candidate_ids(self._db, all_ids)
-        except Exception:
-            logger.warning(
-                "invalid_at filter failed, returning unfiltered candidates",
-                exc_info=True,
-            )
-            expired = set()
-        if expired:
-            all_ids -= expired
-            for mid in expired:
-                qdrant_by_id.pop(mid, None)
-                fts_by_id.pop(mid, None)
-            event_memory_ids = [m for m in event_memory_ids if m not in expired]
-            if not all_ids:
-                return []
+        all_ids, event_memory_ids = await self._filter_expired_candidates(
+            all_ids, qdrant_by_id, fts_by_id, event_memory_ids,
+        )
+        if not all_ids:
+            return []
 
-        # 5. Batch-fetch link counts for all candidates (replaces N+1 per-ID loop)
         now_str = datetime.now(UTC).isoformat()
-        link_counts = await memory_links.batch_link_counts(self._db, list(all_ids))
 
-        # 5b. Compute activation scores using batched link data
-        activation_by_id: dict[str, float] = {}
-        inbound_by_id: dict[str, int] = {}  # saved for graph boost in step 7b
-        # MEM-005: capture retrieval frequency + age per id to measure (not act
-        # on) whether the activation loop entrenches frequently-retrieved memories.
-        retrieved_count_by_id: dict[str, int] = {}
-        created_at_by_id: dict[str, str] = {}
-        for mid in all_ids:
-            total_links, inbound_links = link_counts.get(mid, (0, 0))
-            inbound_by_id[mid] = inbound_links
-
-            qdrant_hit = qdrant_by_id.get(mid)
-            if qdrant_hit:
-                payload = qdrant_hit.get("payload", {})
-                confidence = payload.get("confidence", 0.5)
-                created_at = payload.get("created_at", now_str)
-                retrieved_count = payload.get("retrieved_count", 0)
-            else:
-                confidence = 0.5
-                created_at = now_str
-                retrieved_count = 0
-
-            mem_class = payload.get("memory_class", "fact") if qdrant_hit else "fact"
-            act = compute_activation(
-                confidence=confidence,
-                created_at=created_at,
-                retrieved_count=retrieved_count,
-                link_count=total_links,
-                source=payload.get("source", "") if qdrant_hit else "",
-                tags=payload.get("tags") or [] if qdrant_hit else [],
-                now=now_str,
-                memory_class=mem_class,
-                last_retrieved_at=payload.get("last_retrieved_at") if qdrant_hit else None,
-            )
-            activation_by_id[mid] = act.final_score
-            retrieved_count_by_id[mid] = retrieved_count
-            created_at_by_id[mid] = created_at
+        # 5/5b. Batch-fetch link counts + compute activation scores
+        (
+            activation_by_id,
+            inbound_by_id,
+            retrieved_count_by_id,
+            created_at_by_id,
+        ) = await self._compute_activations(all_ids, qdrant_by_id, now_str)
 
         # 6. Build ranked lists for RRF (or FTS5-only if no embedding)
         vector_ranked_dedup: list[str] = []
@@ -1024,3 +919,245 @@ class HybridRetriever:
         )
 
         return results
+
+    # --- recall() stage helpers (read-only gathers/computes) ---
+    # Bodies are verbatim moves out of recall(); the orchestration order,
+    # guards, and early returns live in recall() itself.
+
+    async def _embed_query(
+        self, query: str,
+    ) -> tuple[list[float] | None, bool]:
+        """Stage 1: embed the query, degrading to FTS5-only on failure.
+
+        Returns ``(vector, embedding_available)``.
+        """
+        embedding_available = True
+        vector = None
+        try:
+            vector = await self._embeddings.embed(query)
+            await record_last_run(
+                self._db, "21b_query_embedding",
+                provider="embedding", model_id="cloud-primary",
+                response_text=f"Query embed: {query[:60]}",
+            )
+        except EmbeddingUnavailableError:
+            embedding_available = False
+            logger.warning("Embedding unavailable, falling back to FTS5-only retrieval")
+        return vector, embedding_available
+
+    async def _gather_vector_candidates(
+        self,
+        *,
+        vector: list[float],
+        collections: list[str],
+        candidate_limit: int,
+        wing: str | None,
+        room: str | None,
+        life_domain: str | None,
+        project_type: str | None,
+        exclude_subsystems: list[str] | None,
+        include_only_subsystems: list[str] | None,
+        include_deprecated: bool,
+    ) -> tuple[list[dict], dict[str, dict]]:
+        """Stage 2: Qdrant vector search across collections.
+
+        Returns ``(qdrant_results, qdrant_by_id)`` — the score-sorted hit
+        list and a first-hit-wins dedup map.
+        """
+        qdrant_results: list[dict] = []
+        qdrant_by_id: dict[str, dict] = {}
+        for coll in collections:
+            with track_operation(self._embeddings.tracker, "qdrant.search"):
+                hits = qdrant_ops.search(
+                    self._qdrant,
+                    collection=coll,
+                    query_vector=vector,
+                    limit=candidate_limit,
+                    wing=wing,
+                    room=room,
+                    life_domain=life_domain,
+                    project_type=project_type,
+                    exclude_subsystems=exclude_subsystems,
+                    include_only_subsystems=include_only_subsystems,
+                    include_deprecated=include_deprecated,
+                )
+            for hit in hits:
+                hit["_collection"] = coll
+            qdrant_results.extend(hits)
+
+        qdrant_results.sort(key=lambda h: h["score"], reverse=True)
+
+        for hit in qdrant_results:
+            mid = hit["id"]
+            if mid not in qdrant_by_id:
+                qdrant_by_id[mid] = hit
+        return qdrant_results, qdrant_by_id
+
+    async def _gather_event_candidates(
+        self, query: str, intent: QueryIntent, candidate_limit: int,
+    ) -> list[str]:
+        """Stage 2b: event-calendar search for temporal queries.
+
+        (Intent classified at the top of recall(); reused downstream for
+        RRF bias in step 7 and for the temporal-marker check here.)
+        """
+        event_memory_ids: list[str] = []
+        if intent.category == "WHEN" or _has_temporal_markers(query):
+            try:
+                from genesis.memory.temporal import parse_temporal_reference
+                time_range = parse_temporal_reference(query)
+                if time_range:
+                    from genesis.db.crud import memory_events
+                    event_memory_ids = await memory_events.get_memory_ids_in_range(
+                        self._db, time_range[0], time_range[1],
+                        limit=candidate_limit,
+                    )
+            except Exception:
+                logger.warning("Event-calendar search failed", exc_info=True)
+        return event_memory_ids
+
+    async def _expand_fts_query(
+        self, query: str, collections: list[str], *, expand_query_terms: bool,
+    ) -> str:
+        """Stage 2c: expand the FTS query via tag co-occurrence (degrades to
+        the original query on failure)."""
+        fts_query = query
+        if expand_query_terms:
+            try:
+                fts_query = await expand_query(
+                    query, self._qdrant, collections, max_expansions=5,
+                )
+            except Exception:
+                logger.warning("Query expansion failed, using original", exc_info=True)
+        return fts_query
+
+    async def _gather_fts_candidates(
+        self,
+        *,
+        query: str,
+        fts_query: str,
+        collections: list[str],
+        candidate_limit: int,
+        exclude_subsystems: list[str] | None,
+        include_only_subsystems: list[str] | None,
+        include_deprecated: bool,
+    ) -> tuple[list[dict], dict[str, dict]]:
+        """Stage 3: FTS5 text search using the expanded query.
+
+        FTS5 respects the caller's source choice — searching the wrong
+        pool here is how knowledge_base entries flood episodic recall
+        results purely by candidate volume. When source="both" we pass
+        None so FTS5 sees every row; for a single-collection source we
+        filter at the SQL level so the candidate set matches Qdrant's
+        filtered search and RRF fuses comparable lists.
+
+        Returns ``(fts_results, fts_by_id)``.
+        """
+        fts_is_boolean = fts_query != query  # expansion produced boolean syntax
+        fts_collection = collections[0] if len(collections) == 1 else None
+        fts_results = await memory_crud.search_ranked(
+            self._db,
+            query=fts_query,
+            collection=fts_collection,
+            limit=candidate_limit,
+            boolean=fts_is_boolean,
+            exclude_subsystems=exclude_subsystems,
+            include_only_subsystems=include_only_subsystems,
+            include_deprecated=include_deprecated,
+        )
+
+        fts_by_id: dict[str, dict] = {}
+        for row in fts_results:
+            mid = row["memory_id"]
+            if mid not in fts_by_id:
+                fts_by_id[mid] = row
+        return fts_results, fts_by_id
+
+    async def _filter_expired_candidates(
+        self,
+        all_ids: set[str],
+        qdrant_by_id: dict[str, dict],
+        fts_by_id: dict[str, dict],
+        event_memory_ids: list[str],
+    ) -> tuple[set[str], list[str]]:
+        """Stage 4b (Phase 1.5e): drop candidates past their bitemporal
+        invalid_at.
+
+        FTS5 already filtered (search_ranked has SQL WHERE on invalid_at);
+        Qdrant and the event calendar don't see invalid_at, so a batched
+        lookup here catches their candidates before we waste activation/
+        link computation on expired rows.
+        Wrapped in try/except: a DB failure here should degrade to
+        "no expiry filter applied" rather than crash the entire recall.
+
+        **Mutates ``qdrant_by_id``/``fts_by_id`` in place** (pops expired
+        ids); returns the shrunk ``(all_ids, event_memory_ids)``.
+        """
+        try:
+            expired = await _expired_candidate_ids(self._db, all_ids)
+        except Exception:
+            logger.warning(
+                "invalid_at filter failed, returning unfiltered candidates",
+                exc_info=True,
+            )
+            expired = set()
+        if expired:
+            all_ids -= expired
+            for mid in expired:
+                qdrant_by_id.pop(mid, None)
+                fts_by_id.pop(mid, None)
+            event_memory_ids = [m for m in event_memory_ids if m not in expired]
+        return all_ids, event_memory_ids
+
+    async def _compute_activations(
+        self,
+        all_ids: set[str],
+        qdrant_by_id: dict[str, dict],
+        now_str: str,
+    ) -> tuple[dict[str, float], dict[str, int], dict[str, int], dict[str, str]]:
+        """Stages 5/5b: batch-fetch link counts (replaces N+1 per-ID loop)
+        and compute activation scores using the batched link data.
+
+        Returns ``(activation_by_id, inbound_by_id, retrieved_count_by_id,
+        created_at_by_id)`` — inbound counts feed graph boost in step 7b;
+        the MEM-005 maps capture retrieval frequency + age per id to measure
+        (not act on) whether the activation loop entrenches frequently-
+        retrieved memories.
+        """
+        link_counts = await memory_links.batch_link_counts(self._db, list(all_ids))
+
+        activation_by_id: dict[str, float] = {}
+        inbound_by_id: dict[str, int] = {}  # saved for graph boost in step 7b
+        retrieved_count_by_id: dict[str, int] = {}
+        created_at_by_id: dict[str, str] = {}
+        for mid in all_ids:
+            total_links, inbound_links = link_counts.get(mid, (0, 0))
+            inbound_by_id[mid] = inbound_links
+
+            qdrant_hit = qdrant_by_id.get(mid)
+            if qdrant_hit:
+                payload = qdrant_hit.get("payload", {})
+                confidence = payload.get("confidence", 0.5)
+                created_at = payload.get("created_at", now_str)
+                retrieved_count = payload.get("retrieved_count", 0)
+            else:
+                confidence = 0.5
+                created_at = now_str
+                retrieved_count = 0
+
+            mem_class = payload.get("memory_class", "fact") if qdrant_hit else "fact"
+            act = compute_activation(
+                confidence=confidence,
+                created_at=created_at,
+                retrieved_count=retrieved_count,
+                link_count=total_links,
+                source=payload.get("source", "") if qdrant_hit else "",
+                tags=payload.get("tags") or [] if qdrant_hit else [],
+                now=now_str,
+                memory_class=mem_class,
+                last_retrieved_at=payload.get("last_retrieved_at") if qdrant_hit else None,
+            )
+            activation_by_id[mid] = act.final_score
+            retrieved_count_by_id[mid] = retrieved_count
+            created_at_by_id[mid] = created_at
+        return activation_by_id, inbound_by_id, retrieved_count_by_id, created_at_by_id

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -782,3 +782,157 @@ class TestSpearmanRankCorr:
 
         v = _spearman_rank_corr([1, 5, 2, 8, 3], [2, 1, 4, 3, 9])
         assert -1.0 <= v <= 1.0
+
+
+# --- Characterization tests: degradation paths + reranker contract ---
+# Written BEFORE the recall() stage decomposition to pin current behavior.
+# Each failure-path test asserts the failing dependency was actually called,
+# so a refactor that silently skips the stage fails the test.
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_survives_event_calendar_failure(
+    mock_qdrant, mock_crud, mock_links, _mock_expand,
+):
+    """A raising event-calendar range query degrades to a warning, not a crash."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95)]
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-1", -5.0)])
+    _setup_link_mocks(mock_links)
+
+    with (
+        patch(
+            "genesis.memory.temporal.parse_temporal_reference",
+            return_value=("2026-07-01T00:00:00+00:00", "2026-07-02T00:00:00+00:00"),
+        ),
+        patch(
+            "genesis.db.crud.memory_events.get_memory_ids_in_range",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("event calendar down"),
+        ) as mock_events,
+    ):
+        results = await retriever.recall("when did that happen yesterday", limit=5)
+
+    mock_events.assert_called_once()
+    assert [r.memory_id for r in results] == ["mem-1"]
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock)
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_expansion_failure_uses_original_query(
+    mock_qdrant, mock_crud, mock_links, mock_expand,
+):
+    """expand_query raising falls back to the ORIGINAL query, boolean=False."""
+    retriever, _, _, _ = _build_retriever()
+    mock_expand.side_effect = RuntimeError("tag index rebuild failed")
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95)]
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-1", -5.0)])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall("original query text", limit=5)
+
+    mock_expand.assert_called_once()
+    kwargs = mock_crud.search_ranked.call_args.kwargs
+    assert kwargs["query"] == "original query text"
+    assert kwargs["boolean"] is False
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_expiry_filter_failure_returns_unfiltered(
+    mock_qdrant, mock_crud, mock_links, _mock_expand,
+):
+    """A raising invalid_at lookup degrades to 'no expiry filter applied'."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("mem-1", 0.95),
+        _make_qdrant_hit("mem-2", 0.80),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    _setup_link_mocks(mock_links)
+
+    with patch(
+        "genesis.memory.retrieval._expired_candidate_ids",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db locked"),
+    ) as mock_expired:
+        results = await retriever.recall("test query", limit=5)
+
+    mock_expired.assert_called_once()
+    assert {r.memory_id for r in results} == {"mem-1", "mem-2"}
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_update_payload_failure_still_returns_results(
+    mock_qdrant, mock_crud, mock_links, _mock_expand,
+):
+    """A raising retrieved_count write-back never blocks returning results."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95)]
+    mock_qdrant.update_payload.side_effect = RuntimeError("qdrant write failed")
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-1", -5.0)])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall("test query", limit=5)
+
+    mock_qdrant.update_payload.assert_called_once()
+    assert [r.memory_id for r in results] == ["mem-1"]
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_reranker_replaces_fused_with_positional_scores(
+    mock_qdrant, mock_crud, mock_links, _mock_expand,
+):
+    """Reranker path: fused is REPLACED with 1/(1+rank) positional scores and
+    candidates the reranker didn't score are dropped entirely."""
+    embed_provider = MagicMock()
+    embed_provider.embed = AsyncMock(return_value=[0.1] * 1024)
+    reranker = MagicMock()
+    reranker.enabled = True
+    # Reranker inverts the RRF ordering and omits mem-3.
+    reranker.rerank = AsyncMock(return_value=[{"id": "mem-2"}, {"id": "mem-1"}])
+    retriever = HybridRetriever(
+        embedding_provider=embed_provider,
+        qdrant_client=MagicMock(),
+        db=MagicMock(spec_set=["execute", "commit"]),
+        reranker=reranker,
+    )
+
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("mem-1", 0.95),
+        _make_qdrant_hit("mem-2", 0.80),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-3", -5.0)])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall("test query", limit=5, rerank=True)
+
+    reranker.rerank.assert_called_once()
+    call_args = reranker.rerank.call_args
+    assert call_args.args[0] == "test query"
+    assert {d["id"] for d in call_args.args[1]} == {"mem-1", "mem-2", "mem-3"}
+    assert call_args.kwargs["top_k"] == 10  # limit * 2
+
+    # Positional scores from the reranker's ordering; mem-3 dropped.
+    assert [r.memory_id for r in results] == ["mem-2", "mem-1"]
+    assert results[0].score == pytest.approx(1.0)   # 1/(1+0)
+    assert results[1].score == pytest.approx(0.5)   # 1/(1+1)


### PR DESCRIPTION
## What

Decomposes the 609-line `HybridRetriever.recall` — the largest god-function in the codebase per the 2026-07-07 oversize-file audit (follow-up Tier-1) — into 13 named stage units with **strictly zero behavior change**. `recall()` is now a ~200-line orchestrator whose call syntax documents the mutation semantics; every extracted body is a verbatim move.

## Structure (4 commits)

1. **Characterization tests first** — 5 new tests pinning degradation paths (event-calendar failure, expansion failure, expiry-filter failure, write-back failure) + the previously-untested reranker contract (fused replaced with `1/(1+rank)` positional scores, unscored candidates dropped). Green against the unmodified code before any motion.
2. **4 module-level pure functions** — `_build_intent_ranked` (6b), `_filter_scope_fts_only` (9b), `_assemble_results` (12; the positional-rank reach-back into stage 6's lists is now explicit params), `_entrenchment_metrics` (MEM-005).
3. **7 read-only gather/compute methods** — `_embed_query` (1), `_gather_vector_candidates` (2; embedding-available guard + fallback inits stay in `recall()`), `_gather_event_candidates` (2b), `_expand_fts_query` (2c), `_gather_fts_candidates` (3), `_filter_expired_candidates` (4b; mutates by-id dicts in place, documented), `_compute_activations` (5/5b).
4. **3 mutator/side-effect methods** — `_maybe_rerank` (7.5; **the only post-fusion reassignment of `fused`**), `_apply_graph_boost` (7b; in-place), `_record_retrievals` (11/11b/11c).

**Deliberately NOT extracted:** the J-9 telemetry tail (`emit_recall_fired`/`emit_recall_diagnostics`/`event_id_sink`) stays inline — extracting it trades a visible single-emit contract (MEM-003) for a 17-param method. Both early `return []`s, the guard structure, and `now_str`'s single derivation stay in `recall()` verbatim.

## Frozen contracts (verified by enumeration)

- Public `recall()` signature + `RetrievalResult` — all production call sites untouched.
- Module globals `_SOURCE_TO_COLLECTIONS` / `_resolve_subsystem_filter` / `_expired_candidate_ids` (drift.py imports), `_KNOWN_SUBSYSTEMS` (CI drift-guard), `_rrf_fuse` / `_spearman_rank_corr` (test imports) — unchanged.
- Instance attrs `_embeddings` / `_reranker` / `_qdrant` / `_db` — unchanged (the reranker shutdown reads `_reranker` via string `getattr`, invisible to rename tooling).
- Extracted methods keep calling module-level `qdrant_ops`/`memory_crud`/`memory_links`/`expand_query`/`observations` — all 116 existing test patch seams survive by construction.
- Function-scope imports (temporal, memory_events, knowledge_crud, j9_hooks) travel with their stages or stay in `recall()` — cycle-breakers preserved.

## Verification (zero behavior change, proven 3 ways)

1. **Moved-code audit**: `git diff --color-moved=dimmed-zebra --color-moved-ws=allow-indentation-change` per commit and cumulative — across the whole branch, the only removed code lines not detected as verbatim moves are the import reformat and one analyzed early-return hoist (equivalent: the candidate set only shrinks and was non-empty at stage 4).
2. **Tests**: 44 targeted retrieval tests + full `tests/test_memory` (712 passed) at every commit; ruff clean.
3. **Record/replay equivalence harness**: captured every read-boundary result (Qdrant search, FTS, link counts, event calendar, expiry, expansion) from live production data, then replayed identical inputs through old and new trees — 12 cases spanning WHY/WHEN/WHAT/GENERAL × source overrides × wing/subsystem filters × rerank on/off × min-activation, 103 results. Outputs **byte-identical** (sha256-equal), including all scores at 9 dp, emit kwargs, and write-back call sequences. (Harness pins PYTHONHASHSEED: RRF tie-ordering via set iteration is hash-seed-dependent — pre-existing behavior, identical in both trees.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)