### PR TITLE
fix(observability): edit-failure sensor blind to failures — register PostToolUseFailure

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -372,6 +372,18 @@
                     }
                 ]
             }
+        ],
+        "PostToolUseFailure": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook edit_failure_sensor.py",
+                        "timeout": 500
+                    }
+                ]
+            }
         ]
     },
     "worktree": {

--- a/scripts/edit_failure_sensor.py
+++ b/scripts/edit_failure_sensor.py
@@ -1,27 +1,44 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: track Edit/Write success and failure rates.
+"""PostToolUse + PostToolUseFailure hook: track Edit/Write success and failure rates.
 
 Records every Edit and Write tool call outcome to the tool_call_outcomes
 table, enabling measurement of edit failure rates and identification of
 patterns in failed edits (file size, match complexity, etc.).
 
-Fires on Edit|Write completions. Reads stdin JSON per the PostToolUse
-contract (includes tool_result/tool_output).
+Registered for BOTH events (see .claude/settings.json):
+- PostToolUse fires only on SUCCESSFUL tool calls — it never sees a failed
+  Edit, so on this event the row is a success record (the marker scan below
+  is a belt-and-braces guard for soft-error text in nominally-successful
+  output).
+- PostToolUseFailure fires when the tool call FAILS (e.g. "old_string not
+  found") and carries the error in ``tool_error``. This is the only path
+  that can produce success=0 rows; without it the sensor is blind to
+  failures (observed: 12,737 rows / 0 failures over 7 weeks before this
+  event was registered).
 
-Zero tokens — pure shell/DB operation.
+Reads stdin JSON per the hook contract; ``hook_event_name`` distinguishes
+the two events. Zero tokens — pure shell/DB operation.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-_DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+# GENESIS_DB_PATH override exists for tests/verification only; production
+# hooks rely on the default. Keep this script stdlib-only (no genesis imports).
+_DB_PATH = Path(
+    os.environ.get("GENESIS_DB_PATH", "")
+    or Path.home() / "genesis" / "data" / "genesis.db"
+)
 
-# Markers in tool_output that indicate an Edit failure
+# Markers in tool_output that indicate an Edit failure surfaced in a
+# nominally-successful call (defensive; hard failures arrive via
+# PostToolUseFailure instead).
 _FAILURE_MARKERS = [
     "old_string not found",
     "not unique in the file",
@@ -42,6 +59,23 @@ def main() -> None:
         return
 
 
+def _extract_error(data: dict) -> str:
+    """Best-effort error text from a PostToolUseFailure payload.
+
+    ``tool_error`` is the documented key; the fallbacks tolerate payload
+    drift across Claude Code versions rather than silently recording an
+    empty snippet.
+    """
+    for key in ("tool_error", "error", "tool_output", "tool_response"):
+        value = data.get(key)
+        if value:
+            return str(value)
+    code = data.get("tool_error_code")
+    if code is not None:
+        return f"tool failed (error code {code}, no error text)"
+    return "tool failed (no error text in payload)"
+
+
 def _process(data: dict) -> None:
     tool_name = data.get("tool_name", "")
     if tool_name not in ("Edit", "Write"):
@@ -49,23 +83,25 @@ def _process(data: dict) -> None:
 
     session_id = data.get("session_id", "")
     tool_input = data.get("tool_input") or {}
-    tool_output = data.get("tool_output", "") or ""
 
     if not isinstance(tool_input, dict):
         return
 
     file_path = tool_input.get("file_path", "")
 
-    # Determine success/failure from tool_output
-    success = 1
-    error_snippet = None
-
-    output_lower = tool_output.lower()
-    for marker in _FAILURE_MARKERS:
-        if marker.lower() in output_lower:
-            success = 0
-            error_snippet = tool_output[:200]
-            break
+    if data.get("hook_event_name") == "PostToolUseFailure":
+        success = 0
+        error_snippet = _extract_error(data)[:200]
+    else:
+        tool_output = data.get("tool_output", "") or ""
+        success = 1
+        error_snippet = None
+        output_lower = str(tool_output).lower()
+        for marker in _FAILURE_MARKERS:
+            if marker.lower() in output_lower:
+                success = 0
+                error_snippet = str(tool_output)[:200]
+                break
 
     if not _DB_PATH.exists():
         return

--- a/tests/test_scripts/test_edit_failure_sensor.py
+++ b/tests/test_scripts/test_edit_failure_sensor.py
@@ -1,0 +1,207 @@
+"""Tests for scripts/edit_failure_sensor.py — the Edit/Write outcome sensor.
+
+The sensor was blind to failures for its first 7 weeks (12,737 rows, 0
+failures) because it was registered only for PostToolUse, which fires solely
+on successful tool calls. These tests pin the failure path (PostToolUseFailure)
+and the success path against a real temp SQLite DB.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "edit_failure_sensor.py"
+
+_SCHEMA = """
+CREATE TABLE tool_call_outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    tool_name TEXT NOT NULL,
+    file_path TEXT,
+    success INTEGER NOT NULL,
+    error_snippet TEXT,
+    timestamp TEXT NOT NULL
+);
+"""
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("edit_failure_sensor", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def sensor_db(tmp_path):
+    db_path = tmp_path / "genesis.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _rows(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT tool_name, file_path, success, error_snippet FROM tool_call_outcomes"
+        )
+        return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def _run_process(monkeypatch, db_path, payload):
+    module = _load_module()
+    monkeypatch.setattr(module, "_DB_PATH", db_path)
+    module._process(payload)
+
+
+class TestFailurePath:
+    def test_post_tool_use_failure_records_failure(self, monkeypatch, sensor_db):
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "tool_name": "Edit",
+                "session_id": "s1",
+                "tool_input": {"file_path": "/tmp/x.py"},
+                "tool_error": "String to replace not found in file (old_string not found)",
+                "tool_error_code": 1,
+            },
+        )
+        rows = _rows(sensor_db)
+        assert rows == [
+            ("Edit", "/tmp/x.py", 0, "String to replace not found in file (old_string not found)")
+        ]
+
+    def test_failure_without_error_text_still_records(self, monkeypatch, sensor_db):
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "tool_name": "Write",
+                "tool_input": {"file_path": "/tmp/y.py"},
+            },
+        )
+        rows = _rows(sensor_db)
+        assert rows[0][2] == 0
+        assert "no error text" in rows[0][3]
+
+    def test_error_snippet_capped_at_200(self, monkeypatch, sensor_db):
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/tmp/z.py"},
+                "tool_error": "x" * 500,
+            },
+        )
+        assert len(_rows(sensor_db)[0][3]) == 200
+
+    def test_non_edit_write_failure_ignored(self, monkeypatch, sensor_db):
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "tool_name": "Bash",
+                "tool_input": {"command": "false"},
+                "tool_error": "exit 1",
+            },
+        )
+        assert _rows(sensor_db) == []
+
+
+class TestSuccessPath:
+    def test_post_tool_use_records_success(self, monkeypatch, sensor_db):
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Edit",
+                "session_id": "s2",
+                "tool_input": {"file_path": "/tmp/a.py"},
+                "tool_output": "The file /tmp/a.py has been updated.",
+            },
+        )
+        assert _rows(sensor_db) == [("Edit", "/tmp/a.py", 1, None)]
+
+    def test_soft_error_marker_in_success_output_records_failure(
+        self, monkeypatch, sensor_db
+    ):
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/tmp/b.py"},
+                "tool_output": "Error: old_string not found",
+            },
+        )
+        assert _rows(sensor_db)[0][2] == 0
+
+    def test_missing_event_name_defaults_to_success_path(self, monkeypatch, sensor_db):
+        # Older payloads without hook_event_name must keep working.
+        _run_process(
+            monkeypatch,
+            sensor_db,
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": "/tmp/c.py"},
+                "tool_output": "ok",
+            },
+        )
+        assert _rows(sensor_db)[0][2] == 1
+
+
+class TestSubprocessEndToEnd:
+    def test_stdin_pipe_failure_event(self, sensor_db):
+        """Drive the real script as CC does: JSON on stdin, env-pointed DB."""
+        payload = json.dumps(
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "tool_name": "Edit",
+                "session_id": "e2e",
+                "tool_input": {"file_path": "/tmp/e2e.py"},
+                "tool_error": "old_string not found",
+            }
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={"GENESIS_DB_PATH": str(sensor_db), "PATH": "/usr/bin:/bin"},
+        )
+        assert result.returncode == 0
+        assert _rows(sensor_db) == [("Edit", "/tmp/e2e.py", 0, "old_string not found")]
+
+    def test_malformed_stdin_never_raises(self, sensor_db):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input="{not json",
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={"GENESIS_DB_PATH": str(sensor_db), "PATH": "/usr/bin:/bin"},
+        )
+        assert result.returncode == 0
+        assert _rows(sensor_db) == []


### PR DESCRIPTION
## Problem

`tool_call_outcomes` has 12,737 rows and **zero recorded failures** since the sensor shipped (May 17). The sensor was built specifically to measure Edit/Write failure rates — it has been blind since birth.

## Root cause

The sensor was registered only for **PostToolUse**, which per the Claude Code hooks contract fires **only on successful tool calls**. A failed Edit ("old_string not found" etc.) never reaches the hook at all; the failure-marker scan inside the script was unreachable in practice. Failures arrive via the separate **PostToolUseFailure** event (supported by the installed CC 2.1.201 — verified against current hooks docs and the installed binary), which was never registered.

## Fix

- Register `PostToolUseFailure` (matcher `Edit|Write`) → same sensor script.
- Script branches on `hook_event_name`: failure events write `success=0` with the error from `tool_error` (defensive key fallbacks, 200-char snippet cap). Success path unchanged, marker scan kept as a soft-error guard.
- `GENESIS_DB_PATH` env override added for tests only (script stays stdlib-only).

## Tests

9 new tests in `tests/test_scripts/test_edit_failure_sensor.py`: failure/success paths, missing-error-text fallback, snippet cap, non-Edit/Write filtering, malformed stdin, plus a subprocess E2E piping JSON through the real script into a temp DB.

## Verification & regression marker

Hooks load at session start, so the new registration cannot be live-fired from the authoring session. Regression marker: **the first failed Edit in a post-merge CC session must produce a success=0 row**; if the table is still 100% success after a week, the registration is not firing.

Found by the WS-0 observed-harm evidence pass (instrumentation meta-finding M2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)