### PR TITLE
fix(outreach): close message-queue findings once a morning report delivers them

### DIFF
--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -163,6 +163,7 @@ class MorningReportGenerator:
         self._drafter = drafter
         self._event_bus = event_bus
         self._pending_surface_ids: list[str] = []
+        self._pending_mq_ids: list[str] = []
 
     async def generate(self) -> OutreachRequest:
         context = await self._assemble_context()
@@ -193,23 +194,42 @@ class MorningReportGenerator:
         )
 
     async def confirm_delivery(self) -> None:
-        """Mark observations as surfaced after successful delivery.
+        """Mark surfaced items as consumed after successful delivery.
 
         Called by the scheduler after the pipeline confirms delivery.
-        Observations collected during generate() are only marked surfaced
-        here — if delivery fails, they re-appear in the next report.
+        Items collected during generate() are only closed here — if
+        delivery fails, they re-appear in the next report.
 
-        Only calls mark_surfaced — retrieved/influenced tracking is
-        handled by _get_activity_summary to avoid double-counting.
+        Observations: only calls mark_surfaced — retrieved/influenced
+        tracking is handled by _get_activity_summary to avoid
+        double-counting.
+
+        Message-queue rows rendered into the report are marked responded;
+        nothing else ever closes them (the 7-day expiry job is the only
+        other exit, which conflates "seen in a delivered report" with
+        "never seen at all").
         """
-        ids = self._pending_surface_ids
-        if not ids:
-            return
-        from genesis.db.crud.observations import mark_surfaced
-
         now = datetime.now(UTC).isoformat()
-        await mark_surfaced(self._db, ids, now)
-        self._pending_surface_ids = []
+
+        ids = self._pending_surface_ids
+        if ids:
+            from genesis.db.crud.observations import mark_surfaced
+
+            await mark_surfaced(self._db, ids, now)
+            self._pending_surface_ids = []
+
+        mq_ids = self._pending_mq_ids
+        if mq_ids:
+            from genesis.db.crud import message_queue as mq_crud
+
+            for mq_id in mq_ids:
+                await mq_crud.set_response(
+                    self._db,
+                    mq_id,
+                    response="surfaced_in_morning_report",
+                    responded_at=now,
+                )
+            self._pending_mq_ids = []
 
     @staticmethod
     def _load_system_prompt() -> str | None:
@@ -571,8 +591,12 @@ class MorningReportGenerator:
 
         lines: list[str] = []
 
-        # Message queue items
+        # Message queue items. Rendered rows are collected so
+        # confirm_delivery() can close them — without that they re-list
+        # every morning until the 7-day expiry job silently drops them
+        # (observed: 158 expired / 0 ever responded over 4 months).
         mq_rows = await mq_crud.query_pending(self._db)
+        self._pending_mq_ids = []
         for r in mq_rows:
             content = r.get("content", "")
             if "Untitled" in content:
@@ -583,6 +607,12 @@ class MorningReportGenerator:
                 f"from={r.get('source') or '?'}, "
                 f"created={r.get('created_at', '?')}: {content[:200]}"
             )
+            # Only fire-and-forget findings are closed on delivery.
+            # question/decision/error rows belong to the checkpoint flow
+            # (CheckpointManager.deliver_response) — closing them here
+            # would swallow a background session's pending question.
+            if r.get("id") and r.get("message_type") == "finding":
+                self._pending_mq_ids.append(r["id"])
 
         # Pending ego proposals (user needs to approve/reject on dashboard)
         try:

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -595,8 +595,9 @@ class MorningReportGenerator:
         # confirm_delivery() can close them — without that they re-list
         # every morning until the 7-day expiry job silently drops them
         # (observed: 158 expired / 0 ever responded over 4 months).
-        mq_rows = await mq_crud.query_pending(self._db)
         self._pending_mq_ids = []
+        mq_rows = await mq_crud.query_pending(self._db)
+        rendered_mq_ids: list[str] = []
         for r in mq_rows:
             content = r.get("content", "")
             if "Untitled" in content:
@@ -612,7 +613,8 @@ class MorningReportGenerator:
             # (CheckpointManager.deliver_response) — closing them here
             # would swallow a background session's pending question.
             if r.get("id") and r.get("message_type") == "finding":
-                self._pending_mq_ids.append(r["id"])
+                rendered_mq_ids.append(r["id"])
+        self._pending_mq_ids = rendered_mq_ids
 
         # Pending ego proposals (user needs to approve/reject on dashboard)
         try:

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -444,3 +444,96 @@ async def test_pr_ci_status_none_on_empty_or_no_url(monkeypatch):
     monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
     assert await _mr_mod._pr_ci_status("https://x/pull/1") is None
     assert await _mr_mod._pr_ci_status("") is None
+
+
+# --- message_queue finding closure (confirm_delivery) ---
+
+
+async def _insert_finding(db, id_: str, content: str = "inbox batch finding"):
+    from genesis.db.crud import message_queue as mq_crud
+
+    await mq_crud.create(
+        db, id=id_, source="cc_background", target="cc_foreground",
+        message_type="finding", content=content,
+        created_at="2026-03-12T06:00:00+00:00", priority="low",
+    )
+
+
+async def _mq_row(db, id_: str):
+    cursor = await db.execute(
+        "SELECT response, responded_at FROM message_queue WHERE id = ?", (id_,)
+    )
+    return dict(await cursor.fetchone())
+
+
+@pytest.mark.asyncio
+async def test_mq_finding_closed_after_confirm_delivery(db, mock_health, mock_drafter):
+    await _insert_finding(db, "f1")
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    await gen.confirm_delivery()
+
+    row = await _mq_row(db, "f1")
+    assert row["response"] == "surfaced_in_morning_report"
+    assert row["responded_at"] is not None
+    assert gen._pending_mq_ids == []
+
+
+@pytest.mark.asyncio
+async def test_mq_finding_stays_pending_when_delivery_unconfirmed(
+    db, mock_health, mock_drafter
+):
+    # Delivery failed → confirm_delivery never called → finding re-appears
+    # in the next report instead of being silently closed.
+    await _insert_finding(db, "f2")
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+
+    row = await _mq_row(db, "f2")
+    assert row["responded_at"] is None
+    assert gen._pending_mq_ids == ["f2"]
+
+
+@pytest.mark.asyncio
+async def test_untitled_mq_rows_not_rendered_and_not_closed(
+    db, mock_health, mock_drafter
+):
+    # "Untitled" rows are filtered from the report, so closing them would
+    # mark items responded that were never shown.
+    await _insert_finding(db, "f3", content="Untitled batch artifact")
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    await gen.confirm_delivery()
+
+    row = await _mq_row(db, "f3")
+    assert row["responded_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_mq_ids_replaced_not_accumulated_across_generates(
+    db, mock_health, mock_drafter
+):
+    await _insert_finding(db, "f4")
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    await gen.generate()  # retry after failed delivery must not duplicate
+    assert gen._pending_mq_ids == ["f4"]
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_question_rows_never_closed(db, mock_health, mock_drafter):
+    # question/decision/error rows are the checkpoint flow's to answer
+    # (CheckpointManager.deliver_response); the report must not close them.
+    from genesis.db.crud import message_queue as mq_crud
+
+    await mq_crud.create(
+        db, id="q1", source="cc_background", target="user",
+        message_type="question", content="Need a decision on X",
+        created_at="2026-03-12T06:00:00+00:00",
+    )
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    await gen.confirm_delivery()
+
+    row = await _mq_row(db, "q1")
+    assert row["responded_at"] is None


### PR DESCRIPTION
## Problem

Inbox-monitor findings (`cc_background` → `cc_foreground` in `message_queue`) render into the morning report's pending section, but **nothing can ever close them** — they re-list every morning until the 7-day expiry job silently drops them at 2:30am. Observed over 4 months: **158 expired, 0 ever marked responded**. `expired` conflates "surfaced in a delivered report" with "never seen at all," and every report re-lists stale findings (repeat-listing noise).

## Fix

Extends the existing `confirm_delivery()` idiom (same one observations use via `mark_surfaced`):

- `_get_pending_items` collects the ids of **rendered** finding rows (list replaced per `generate()`, matching the `_pending_surface_ids` pattern — no accumulation across failed-delivery retries).
- `confirm_delivery()` (called by the scheduler only after confirmed delivery) marks them `responded` with `surfaced_in_morning_report`. Failed delivery → they re-appear next report, exactly like observations.

## Deliberately NOT closed

- **question/decision/error rows** — they belong to the checkpoint flow (`CheckpointManager.deliver_response`); closing them would swallow a background session's pending question. Scoped by `message_type == 'finding'`, with a test pinning it.
- **"Untitled"-filtered rows** — never shown, so never closed (7-day expiry remains their exit).

## Tests

5 new tests against the real in-memory schema: closed-after-confirm, stays-pending-without-confirm, Untitled not closed, no id accumulation across generates, checkpoint questions untouched. Full file: 29 passed.

## Regression marker

Finding-type rows expiring with `responded_at IS NULL` should drop to ~zero within a week of deploy; if they don't, the scheduler's confirm path isn't reaching `confirm_delivery()`.

Found by the WS-0 observed-harm evidence pass (instrumentation meta-finding M11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)