### PR TITLE
fix(memory): recover procedure extractions lost to provider exhaustion + storm alert (N1)

### DIFF
--- a/src/genesis/db/crud/dead_letter.py
+++ b/src/genesis/db/crud/dead_letter.py
@@ -174,3 +174,47 @@ async def query_recent(
     db.row_factory = aiosqlite.Row
     cursor = await db.execute(sql, params)
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def count_recent(
+    db: aiosqlite.Connection,
+    *,
+    since: str,
+    exclude_prefix: str | None = None,
+) -> int:
+    """Count dead-letter rows enqueued at/after ``since`` (any status).
+
+    ``exclude_prefix`` drops operation_types starting with it — the rate-based
+    provider-exhaustion storm detector passes ``chain_exhausted:judge`` so a
+    self-healing 1h-TTL judge burst (worthless-late, drains itself) never counts
+    toward the storm trigger. Backed by ``idx_dead_letter_created``.
+    """
+    sql = "SELECT COUNT(*) FROM dead_letter WHERE created_at >= ?"
+    params: list = [since]
+    if exclude_prefix:
+        sql += " AND operation_type NOT LIKE ?"
+        params.append(exclude_prefix + "%")
+    cursor = await db.execute(sql, params)
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
+async def recent_optype_counts(
+    db: aiosqlite.Connection,
+    *,
+    since: str,
+    exclude_prefix: str | None = None,
+) -> list[tuple[str, int]]:
+    """Per-operation_type counts of dead-letters enqueued at/after ``since``.
+
+    Feeds the storm alert's breakdown line (``light-reflection ×N``). Ordered by
+    count descending. ``exclude_prefix`` behaves as in :func:`count_recent`.
+    """
+    sql = "SELECT operation_type, COUNT(*) AS c FROM dead_letter WHERE created_at >= ?"
+    params: list = [since]
+    if exclude_prefix:
+        sql += " AND operation_type NOT LIKE ?"
+        params.append(exclude_prefix + "%")
+    sql += " GROUP BY operation_type ORDER BY c DESC"
+    cursor = await db.execute(sql, params)
+    return [(str(r[0]), int(r[1])) for r in await cursor.fetchall()]

--- a/src/genesis/db/migrations/0049_dead_letter_created_index.py
+++ b/src/genesis/db/migrations/0049_dead_letter_created_index.py
@@ -1,0 +1,31 @@
+"""Add idx_dead_letter_created — index dead_letter(created_at).
+
+Backs the rate-based provider-exhaustion storm detector
+(``dead_letter.count_recent`` over a rolling window), which runs on every
+awareness tick. The dead_letter table is not pruned on a schedule, so it grows
+unbounded over months; without this index the storm counter degrades into a
+full-table scan. Additive + idempotent; canonical DDL mirrored in
+``db/schema/_tables.py`` for the fresh-DB path.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Guard for the base table: fresh/test DBs get the index from the canonical
+    # DDL in db/schema/_tables.py, and the runner's lifecycle tests apply
+    # migrations to a bare DB where dead_letter does not yet exist.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='dead_letter'"
+    )
+    if await cursor.fetchone():
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dead_letter_created "
+            "ON dead_letter(created_at)"
+        )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP INDEX IF EXISTS idx_dead_letter_created")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1653,6 +1653,7 @@ INDEXES = [
     # dead letter
     "CREATE INDEX IF NOT EXISTS idx_dead_letter_status ON dead_letter(status)",
     "CREATE INDEX IF NOT EXISTS idx_dead_letter_provider ON dead_letter(target_provider)",
+    "CREATE INDEX IF NOT EXISTS idx_dead_letter_created ON dead_letter(created_at)",
     # cognitive state
     "CREATE INDEX IF NOT EXISTS idx_cognitive_state_section ON cognitive_state(section)",
     # message queue

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -31,6 +31,18 @@ logger = logging.getLogger(__name__)
 
 _CALL_SITE = "38_procedure_extraction"
 
+
+class ProcedureBuilderUnavailable(Exception):
+    """The builder LLM call could not complete (provider chain exhausted or the
+    transport raised) — as opposed to succeeding with zero procedures.
+
+    Raised by ``_call_and_parse_list`` so the caller can distinguish a *transient*
+    failure worth re-attempting later (the source session is re-queued for a
+    procedure rebuild) from a genuine "no procedures here". A persistently
+    unparseable response is NOT this — that is a deterministic model-quality issue
+    and still returns ``[]`` (retrying it forever is waste).
+    """
+
 # Outer guard for the whole-session builder (extraction_job caller). NOT a single
 # call: the builder makes up to ~15 sequential LLM calls (1 build + 1 retry, then
 # per stored procedure a scoping check + a cross-type dedup check). Realistic
@@ -322,18 +334,24 @@ async def _call_and_parse_list(router: object, prompt: str) -> list[dict]:
             result = await router.route_call(
                 call_site_id=_CALL_SITE,
                 messages=[{"role": "user", "content": prompt}],
+                # This builder path owns its own durable retry (the extraction
+                # job re-queues the source session on failure), so do NOT also
+                # dead-letter — the DLQ replay only re-issues the transport and
+                # discards the parsed procedures, doubling the LLM cost and
+                # inflating the queue for zero recovery.
+                suppress_dead_letter=True,
             )
-        except Exception:
+        except Exception as exc:
             logger.warning(
                 "Judge LLM call failed for multi-procedure (attempt %d)", attempt,
                 exc_info=True,
             )
-            return []
+            raise ProcedureBuilderUnavailable(str(exc)) from exc
         if not result.success:
             logger.warning(
                 "Judge LLM call unsuccessful (attempt %d): %s", attempt, result.error,
             )
-            return []
+            raise ProcedureBuilderUnavailable(result.error or "call unsuccessful")
         parsed = _parse_judge_response_list(result.content)
         if parsed is not None:
             return parsed
@@ -359,6 +377,11 @@ async def judge_multi_procedure(
     uncapped execution record used for grounding. Each built procedure is grounded
     (warning-only — never dropped), scoping-gated, novelty-checked, and stored.
     Returns the list of stored procedure IDs (capped at ``max_new`` when given).
+
+    Raises ``ProcedureBuilderUnavailable`` when the builder LLM call cannot
+    complete (provider chain exhausted / transport error) so the caller can
+    re-queue the source session for a later rebuild. A successful call that
+    yields no procedures returns ``[]`` (nothing to rebuild).
     """
     from genesis.learning.procedural.grounding import grounding_score
     from genesis.learning.procedural.struggle_detector import format_spine_for_judge

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -13,6 +13,7 @@ Extraction scope:
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,6 +22,7 @@ from typing import TYPE_CHECKING
 import aiosqlite
 
 from genesis.env import cc_project_dir
+from genesis.learning.procedural.judge import ProcedureBuilderUnavailable
 from genesis.memory.extraction import (
     RETRY_PROMPT,
     ExtractionResult,
@@ -48,6 +50,17 @@ _EXTRACTABLE_SOURCE_TAGS = {"foreground", "inbox"}
 
 # Transcript directory
 _TRANSCRIPT_DIR = Path.home() / ".claude" / "projects" / cc_project_dir()
+
+# Durable rebuild queue for procedure builds that died on provider exhaustion.
+# The extraction watermark advances BEFORE the whole-session procedure builder
+# runs, so once a build fails the session is never revisited by the normal cycle
+# (``if not messages: continue``) and the procedure is lost for good. On failure
+# the session is re-queued here and a later cycle rebuilds it from the full
+# transcript. Capped so a persistently-failing session (e.g. a rotated
+# transcript) can't retry forever — exhaustion is surfaced as an observation,
+# never silently dropped.
+_PROCEDURE_REBUILD_WORK = "procedure_rebuild"
+_MAX_PROCEDURE_REBUILD_ATTEMPTS = 8
 
 
 async def _check_claim_duplicate(
@@ -141,6 +154,27 @@ async def run_extraction_cycle(
     }
     # Collect newly stored memories for cross-session connection discovery
     _newly_stored: list[tuple[str, str, str]] = []
+
+    # Rebuild procedures whose build previously died on provider exhaustion.
+    # Their sessions' watermarks have advanced, so the loop below will skip them
+    # (``if not messages: continue``) — this drain is the only path that recovers
+    # them. Skipped for the history-mining / filtered invocations, which don't
+    # own production extraction state.
+    if (
+        not reference_only_mode
+        and start_line_override is None
+        and session_filter is None
+    ):
+        try:
+            await _drain_procedure_rebuilds(
+                db=db,
+                router=router,
+                transcript_dir=transcript_dir,
+                summary=summary,
+                max_procedures_per_session=max_procedures_per_session,
+            )
+        except Exception:
+            logger.error("Procedure rebuild drain failed", exc_info=True)
 
     # Find sessions with unextracted content (includes filesystem discovery)
     sessions = await _find_extractable_sessions(db, transcript_dir=transcript_dir)
@@ -487,16 +521,23 @@ async def run_extraction_cycle(
                         session_id, struggle_score, len(session_candidates),
                         len(stored_ids),
                     )
-            except TimeoutError:
-                # The build was cancelled mid-flight; discard any half-written
-                # store so a partial transaction can't block the shared connection.
-                # (Completed per-procedure stores already auto-committed.)
+            except (ProcedureBuilderUnavailable, TimeoutError) as exc:
+                # Transient: the provider chain was exhausted, or the build was
+                # cancelled mid-flight (timeout). Roll back any half-written store
+                # (completed per-procedure stores already auto-committed), then
+                # re-queue the session for a later rebuild — the watermark has
+                # already advanced past its lines above, so without this the
+                # session is never revisited and the procedure is lost.
                 with contextlib.suppress(Exception):
                     await db.rollback()
                 logger.warning(
-                    "Procedure builder timed out for session %s", session_id,
+                    "Procedure builder unavailable for session %s (%s) — "
+                    "re-queuing for rebuild", session_id, type(exc).__name__,
                 )
+                await _enqueue_procedure_rebuild(db, session_id, cc_session_id)
             except Exception:
+                # Deterministic failure (parse/logic) — NOT re-queued; retrying
+                # would burn every attempt identically.
                 with contextlib.suppress(Exception):
                     await db.rollback()
                 logger.warning(
@@ -522,6 +563,174 @@ async def run_extraction_cycle(
             logger.warning("Connection pass failed", exc_info=True)
 
     return summary
+
+
+async def _enqueue_procedure_rebuild(
+    db: aiosqlite.Connection, session_id: str, cc_session_id: str,
+) -> None:
+    """Re-queue a session whose procedure build died on provider exhaustion.
+
+    Durable (deferred_work_queue): a later extraction cycle drains it and rebuilds
+    the procedures from the full transcript. Best-effort — a failure to enqueue
+    must not break the extraction cycle. Rebuild idempotency is guaranteed by the
+    novelty/dedup gate in ``store_procedure_checked``.
+    """
+    from genesis.resilience.deferred_work import (
+        DRAIN,
+        MEMORY_OPS,
+        DeferredWorkQueue,
+    )
+
+    try:
+        queue = DeferredWorkQueue(db)
+        await queue.enqueue(
+            work_type=_PROCEDURE_REBUILD_WORK,
+            call_site_id="38_procedure_extraction",
+            priority=MEMORY_OPS,
+            payload=json.dumps(
+                {"session_id": session_id, "cc_session_id": cc_session_id}
+            ),
+            reason="procedure builder provider-exhausted; watermark already advanced",
+            staleness_policy=DRAIN,
+        )
+    except Exception:
+        logger.error(
+            "Failed to enqueue procedure rebuild for session %s",
+            session_id, exc_info=True,
+        )
+
+
+async def _drain_procedure_rebuilds(
+    *,
+    db: aiosqlite.Connection,
+    router: Router,
+    transcript_dir: Path,
+    summary: dict,
+    max_procedures_per_session: int,
+) -> None:
+    """Rebuild procedures for sessions whose build previously died.
+
+    Per queued item: rebuild spine+haystack from the full transcript and re-run
+    the whole-session builder. Success → mark completed (even with zero
+    procedures — the provider was available, nothing to rebuild). Still
+    provider-exhausted → reset to pending (retry next cycle). Transcript gone or
+    attempts exhausted → discard, surfacing an observation so the genuine loss is
+    visible, never silent.
+    """
+    import asyncio
+
+    from genesis.db.crud import deferred_work as dw_crud
+    from genesis.learning.procedural.judge import (
+        JUDGE_TIMEOUT_SECS,
+        judge_multi_procedure,
+    )
+    from genesis.learning.procedural.struggle_detector import (
+        build_spine_and_haystack,
+        score_struggle,
+    )
+    from genesis.resilience.deferred_work import DeferredWorkQueue
+
+    queue = DeferredWorkQueue(db)
+    items = await dw_crud.query_pending(
+        db, work_type=_PROCEDURE_REBUILD_WORK, limit=20,
+    )
+    for item in items:
+        item_id = item["id"]
+        attempts = item.get("attempts", 0)
+
+        if attempts >= _MAX_PROCEDURE_REBUILD_ATTEMPTS:
+            await _exhaust_procedure_rebuild(db, queue, item)
+            continue
+
+        try:
+            payload = json.loads(item.get("payload_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            await queue.mark_discarded(item_id, "unparseable payload")
+            continue
+
+        cc_session_id = payload.get("cc_session_id") or payload.get("session_id")
+        transcript_path = (
+            _find_transcript(transcript_dir, cc_session_id) if cc_session_id else None
+        )
+        if not transcript_path:
+            # Transcript rotated/gone — nothing to rebuild from.
+            await queue.mark_discarded(item_id, "transcript not found")
+            continue
+
+        await queue.mark_processing(item_id)  # increments attempts
+        try:
+            spine, haystack = build_spine_and_haystack(transcript_path)
+            score = score_struggle(spine)
+            stored_ids = await asyncio.wait_for(
+                judge_multi_procedure(
+                    db, spine, haystack, score, router,
+                    source_session_id=cc_session_id,
+                    max_new=max_procedures_per_session,
+                ),
+                timeout=JUDGE_TIMEOUT_SECS,
+            )
+            await queue.mark_completed(item_id)
+            summary["procedures_rebuilt"] = (
+                summary.get("procedures_rebuilt", 0) + len(stored_ids)
+            )
+            if stored_ids:
+                logger.info(
+                    "Rebuilt %d procedure(s) for session %s (attempt %d)",
+                    len(stored_ids), cc_session_id, attempts + 1,
+                )
+        except (ProcedureBuilderUnavailable, TimeoutError):
+            # Providers still down — keep it pending for a later cycle.
+            with contextlib.suppress(Exception):
+                await db.rollback()
+            await queue.reset_to_pending(item_id)
+        except Exception:
+            # Deterministic failure (bad transcript / parse) — don't loop forever.
+            with contextlib.suppress(Exception):
+                await db.rollback()
+            logger.warning(
+                "Procedure rebuild failed permanently for session %s",
+                cc_session_id, exc_info=True,
+            )
+            await queue.mark_discarded(item_id, "rebuild raised non-retryable error")
+
+
+async def _exhaust_procedure_rebuild(db: aiosqlite.Connection, queue, item: dict) -> None:
+    """Give up on a rebuild after the attempt cap and record the loss honestly."""
+    import uuid
+
+    from genesis.db.crud import observations as obs_crud
+
+    item_id = item["id"]
+    try:
+        payload = json.loads(item.get("payload_json", "{}"))
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    cc_session_id = payload.get("cc_session_id") or payload.get("session_id") or "?"
+
+    await queue.mark_discarded(
+        item_id,
+        f"procedure rebuild exhausted {_MAX_PROCEDURE_REBUILD_ATTEMPTS} attempts",
+    )
+    with contextlib.suppress(Exception):
+        await obs_crud.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="procedure_rebuild",
+            type="procedure_extraction_lost",
+            content=(
+                f"Procedure extraction permanently lost for session {cc_session_id}: "
+                f"the builder stayed provider-exhausted across "
+                f"{_MAX_PROCEDURE_REBUILD_ATTEMPTS} rebuild attempts. A reusable "
+                f"playbook that should have been learned was not."
+            ),
+            priority="medium",
+            created_at=datetime.now(UTC).isoformat(),
+            skip_if_duplicate=True,
+        )
+    logger.warning(
+        "Procedure rebuild EXHAUSTED for session %s after %d attempts",
+        cc_session_id, _MAX_PROCEDURE_REBUILD_ATTEMPTS,
+    )
 
 
 async def _find_extractable_sessions(

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -523,13 +523,15 @@ async def run_extraction_cycle(
                     )
             except (ProcedureBuilderUnavailable, TimeoutError) as exc:
                 # Transient: the provider chain was exhausted, or the build was
-                # cancelled mid-flight (timeout). Roll back any half-written store
-                # (completed per-procedure stores already auto-committed), then
-                # re-queue the session for a later rebuild — the watermark has
-                # already advanced past its lines above, so without this the
-                # session is never revisited and the procedure is lost.
-                with contextlib.suppress(Exception):
-                    await db.rollback()
+                # cancelled mid-flight (timeout). Re-queue the session for a later
+                # rebuild — the watermark has already advanced past its lines
+                # above, so without this the session is never revisited and the
+                # procedure is lost. Do NOT db.rollback(): this ``db`` is the
+                # shared SerializedConnection and a rollback discards EVERY
+                # coroutine's pending write, not just ours (see connection.py).
+                # There is nothing of ours to undo anyway — procedure stores
+                # self-commit and the deferred memory_events was committed by the
+                # watermark update above.
                 logger.warning(
                     "Procedure builder unavailable for session %s (%s) — "
                     "re-queuing for rebuild", session_id, type(exc).__name__,
@@ -537,9 +539,8 @@ async def run_extraction_cycle(
                 await _enqueue_procedure_rebuild(db, session_id, cc_session_id)
             except Exception:
                 # Deterministic failure (parse/logic) — NOT re-queued; retrying
-                # would burn every attempt identically.
-                with contextlib.suppress(Exception):
-                    await db.rollback()
+                # would burn every attempt identically. No rollback (shared
+                # connection — see above).
                 logger.warning(
                     "Procedure builder failed for session %s",
                     session_id, exc_info=True,
@@ -679,14 +680,13 @@ async def _drain_procedure_rebuilds(
                     len(stored_ids), cc_session_id, attempts + 1,
                 )
         except (ProcedureBuilderUnavailable, TimeoutError):
-            # Providers still down — keep it pending for a later cycle.
-            with contextlib.suppress(Exception):
-                await db.rollback()
+            # Providers still down — keep it pending for a later cycle. No
+            # db.rollback(): shared SerializedConnection (a rollback would discard
+            # other coroutines' pending writes); procedure stores self-commit so
+            # there is nothing of ours to undo.
             await queue.reset_to_pending(item_id)
         except Exception:
             # Deterministic failure (bad transcript / parse) — don't loop forever.
-            with contextlib.suppress(Exception):
-                await db.rollback()
             logger.warning(
                 "Procedure rebuild failed permanently for session %s",
                 cc_session_id, exc_info=True,

--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -27,6 +27,23 @@ _last_dead_letter_alert_at: float = 0.0
 # cooldown; a band change is an escalation-worthy transition that bypasses it.
 _last_dead_letter_band: str = ""
 
+# Rate-based provider-exhaustion STORM alert. The accumulation alert above is
+# depth-based (get_stuck_count) and only counts an item once it ages past its
+# TTL — so a short-intense storm that self-heals or expires inside the TTL
+# window is invisible to it (the observed Apr/Jun storm shape). This catches the
+# storm at ENQUEUE RATE: N non-judge dead-letters within a rolling window.
+# chain_exhausted:judge (1h self-heal TTL, worthless-late) is excluded so a
+# judge burst never pages. Calibrated against real storms: normal operation
+# stays <40 non-judge enqueues per 15 min, every observed storm exceeded 45.
+# Distinct source so it never collides with the accumulation alert's dedup /
+# resolve. Safety-net for provider outages (e.g. a future Groq model EOL).
+_DLQ_STORM_WINDOW_S = 900
+_DLQ_STORM_THRESHOLD = 40
+_DLQ_STORM_COOLDOWN_S = 3600
+_DLQ_STORM_JUDGE_PREFIX = "chain_exhausted:judge"
+_last_dlq_storm_alert_at: float = 0.0
+_last_dlq_storm_band: str = ""
+
 
 def _dlq_band(count: int) -> str:
     """Bucket the dead-letter count into a stable band.
@@ -145,6 +162,114 @@ async def _resolve_dead_letter_alerts(db: aiosqlite.Connection | None, count: in
         logger.debug("Failed to resolve dead letter alert observations", exc_info=True)
 
 
+async def _alert_dead_letter_storm(
+    db: aiosqlite.Connection | None,
+    count: int,
+    breakdown: list[tuple[str, int]],
+) -> None:
+    """Create a critical observation when dead-letters enqueue at STORM rate.
+
+    Rate-based early warning, distinct from the depth-based accumulation alert:
+    fires on ``count`` non-judge dead-letters within the rolling window. Uses a
+    distinct ``source="dead_letter_storm"`` AND hash prefix so it never collides
+    with the accumulation alert's ``skip_if_duplicate`` dedup or its
+    ``resolve_by_source_and_type`` recovery. Same band + cooldown +
+    skip_if_duplicate throttle as the accumulation alert, so one storm surfaces
+    one alert (a band change bypasses the cooldown as an escalation).
+    """
+    global _last_dlq_storm_alert_at, _last_dlq_storm_band
+
+    now = time.monotonic()
+    band = _dlq_band(count)
+    if (
+        now - _last_dlq_storm_alert_at < _DLQ_STORM_COOLDOWN_S
+        and band == _last_dlq_storm_band
+    ):
+        return  # Cooldown active for the same band
+
+    if db is None:
+        return
+
+    try:
+        import uuid
+
+        from genesis.db.crud import observations as obs_crud
+
+        top = ", ".join(
+            f"{op.removeprefix('chain_exhausted:')} ×{c}"
+            for op, c in breakdown[:5]
+        )
+        window_min = _DLQ_STORM_WINDOW_S // 60
+        content_hash = hashlib.sha256(
+            f"dead_letter_storm:{band}".encode()
+        ).hexdigest()
+        created = await obs_crud.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="dead_letter_storm",
+            type="infrastructure_alert",
+            content=(
+                f"Provider-exhaustion STORM: {count} internal-cognition "
+                f"operations dead-lettered in the last {window_min}m (self-"
+                f"healing judge calls excluded). Genesis's background thinking "
+                f"is failing to run — check provider health and circuit-"
+                f"breaker state. Top: {top or 'n/a'}."
+            ),
+            priority="critical",
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        if created is None:
+            return  # An unresolved storm alert for this band already exists.
+        _last_dlq_storm_alert_at = now
+        _last_dlq_storm_band = band
+        logger.warning(
+            "Dead letter STORM alert: %d non-judge ops in %ds "
+            "(critical observation created)",
+            count, _DLQ_STORM_WINDOW_S,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to create dead letter storm alert observation", exc_info=True
+        )
+
+
+async def _resolve_dead_letter_storm(db: aiosqlite.Connection | None) -> None:
+    """Resolve outstanding storm alerts once the enqueue rate returns to normal.
+
+    Mirror of _resolve_dead_letter_alerts for the distinct storm source. Kept
+    unconditional (no in-memory guard) so it survives restart; the UPDATE is a
+    cheap no-op when nothing matches.
+    """
+    global _last_dlq_storm_alert_at, _last_dlq_storm_band
+
+    if db is None:
+        return
+
+    try:
+        from genesis.db.crud import observations as obs_crud
+
+        resolved = await obs_crud.resolve_by_source_and_type(
+            db,
+            source="dead_letter_storm",
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="auto-resolved: dead-letter enqueue rate back to normal",
+        )
+        if resolved:
+            _last_dlq_storm_alert_at = 0.0
+            _last_dlq_storm_band = ""
+            logger.info(
+                "Auto-resolved %d dead-letter storm alert observation(s) on rate drop",
+                resolved,
+            )
+    except Exception:
+        logger.debug(
+            "Failed to resolve dead letter storm alert observations", exc_info=True
+        )
+
+
 async def queues(
     db: aiosqlite.Connection | None,
     deferred_queue: DeferredWorkQueue | None,
@@ -190,6 +315,27 @@ async def queues(
                 await _alert_dead_letter_accumulation(db, stuck)
             else:
                 await _resolve_dead_letter_alerts(db, stuck)
+
+            # Rate-based storm early-warning (independent of depth). Catches a
+            # short-intense provider-exhaustion burst that the depth alert above
+            # misses because items self-heal / expire before aging past their
+            # TTL. Judge (self-healing) is excluded from the trigger count.
+            if db is not None:
+                from genesis.db.crud import dead_letter as _dl_crud
+
+                since = (
+                    datetime.now(UTC) - timedelta(seconds=_DLQ_STORM_WINDOW_S)
+                ).isoformat()
+                recent = await _dl_crud.count_recent(
+                    db, since=since, exclude_prefix=_DLQ_STORM_JUDGE_PREFIX,
+                )
+                if recent >= _DLQ_STORM_THRESHOLD:
+                    breakdown = await _dl_crud.recent_optype_counts(
+                        db, since=since, exclude_prefix=_DLQ_STORM_JUDGE_PREFIX,
+                    )
+                    await _alert_dead_letter_storm(db, recent, breakdown)
+                else:
+                    await _resolve_dead_letter_storm(db)
         except Exception:
             errors.append("dead_letters: query failed")
             logger.error("Failed to query dead letter queue", exc_info=True)

--- a/tests/test_db/test_dead_letter.py
+++ b/tests/test_db/test_dead_letter.py
@@ -104,3 +104,35 @@ async def test_duplicate_id_raises(db):
     await dead_letter.create(db, id="dldup", **_COMMON)
     with pytest.raises(sqlite3.IntegrityError):
         await dead_letter.create(db, id="dldup", **_COMMON)
+
+
+async def _seed(db, id, op_type, created_at):
+    await dead_letter.create(
+        db, id=id, operation_type=op_type, payload="{}",
+        target_provider="all", failure_reason="All providers exhausted",
+        created_at=created_at,
+    )
+
+
+async def test_count_recent_window_and_exclude_prefix(db):
+    await _seed(db, "r1", "chain_exhausted:4_light_reflection", "2026-03-01T12:00:00")
+    await _seed(db, "r2", "chain_exhausted:4_light_reflection", "2026-03-01T12:05:00")
+    await _seed(db, "r3", "chain_exhausted:judge", "2026-03-01T12:06:00")
+    await _seed(db, "old", "chain_exhausted:3_micro_reflection", "2026-03-01T11:00:00")
+
+    since = "2026-03-01T11:50:00"
+    # All recent (3 in-window; the 11:00 one excluded by the since cutoff).
+    assert await dead_letter.count_recent(db, since=since) == 3
+    # Judge excluded → the two light-reflection rows only.
+    assert await dead_letter.count_recent(
+        db, since=since, exclude_prefix="chain_exhausted:judge",
+    ) == 2
+
+
+async def test_recent_optype_counts_grouped(db):
+    await _seed(db, "a1", "chain_exhausted:4_light_reflection", "2026-03-01T12:00:00")
+    await _seed(db, "a2", "chain_exhausted:4_light_reflection", "2026-03-01T12:01:00")
+    await _seed(db, "a3", "chain_exhausted:38_procedure_extraction", "2026-03-01T12:02:00")
+    rows = await dead_letter.recent_optype_counts(db, since="2026-03-01T11:00:00")
+    assert rows[0] == ("chain_exhausted:4_light_reflection", 2)
+    assert ("chain_exhausted:38_procedure_extraction", 1) in rows

--- a/tests/test_db/test_migration_0049_dead_letter_created_index.py
+++ b/tests/test_db/test_migration_0049_dead_letter_created_index.py
@@ -1,0 +1,62 @@
+"""Migration 0049 — add idx_dead_letter_created.
+
+Verifies the index is created on a pre-existing dead_letter table (the
+existing-DB upgrade path), the add is idempotent, and a missing table is a
+safe no-op (the runner's lifecycle tests apply migrations to a bare DB).
+Mirrors 0048.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M49 = importlib.import_module(
+    "genesis.db.migrations.0049_dead_letter_created_index"
+)
+
+_DDL = """
+    CREATE TABLE dead_letter (
+        id TEXT PRIMARY KEY, operation_type TEXT NOT NULL, payload TEXT NOT NULL,
+        target_provider TEXT NOT NULL, failure_reason TEXT NOT NULL,
+        created_at TEXT NOT NULL, retry_count INTEGER DEFAULT 0,
+        last_retry_at TEXT, status TEXT DEFAULT 'pending'
+    )
+"""
+
+
+async def _indexes(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='dead_letter'"
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_adds_index_to_existing_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_DDL)
+        assert "idx_dead_letter_created" not in await _indexes(db)
+        await M49.up(db)
+        assert "idx_dead_letter_created" in await _indexes(db)
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_DDL)
+        await M49.up(db)
+        await M49.up(db)  # second run must not raise
+        assert "idx_dead_letter_created" in await _indexes(db)
+
+
+@pytest.mark.asyncio
+async def test_up_noop_when_table_absent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M49.up(db)  # no dead_letter table — safe no-op
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='dead_letter'"
+        )
+        assert await cur.fetchone() is None

--- a/tests/test_learning/test_judge_multi.py
+++ b/tests/test_learning/test_judge_multi.py
@@ -76,6 +76,39 @@ async def test_builder_empty_response_returns_empty(db):
 
 
 @pytest.mark.asyncio
+async def test_builder_raises_on_provider_exhaustion(db):
+    """A failed builder call (providers exhausted) RAISES so the caller can
+    re-queue — distinct from a successful call that yields zero procedures."""
+    from genesis.learning.procedural.judge import ProcedureBuilderUnavailable
+
+    router = _router_seq(_Result(success=False, error="All providers exhausted"))
+    with pytest.raises(ProcedureBuilderUnavailable):
+        await judge_multi_procedure(db, _SPINE, "", 0.5, router)
+
+
+@pytest.mark.asyncio
+async def test_builder_raises_on_call_exception(db):
+    """A transport exception is also a rebuild-worthy failure, not a []-return."""
+    from genesis.learning.procedural.judge import ProcedureBuilderUnavailable
+
+    router = MagicMock()
+    router.route_call = AsyncMock(side_effect=RuntimeError("router down"))
+    with pytest.raises(ProcedureBuilderUnavailable):
+        await judge_multi_procedure(db, _SPINE, "", 0.5, router)
+
+
+@pytest.mark.asyncio
+async def test_builder_suppresses_dead_letter(db):
+    """The builder owns its own durable retry (the rebuild queue), so it must NOT
+    also dead-letter — that would re-issue the transport, discard the parsed
+    procedures, and double the cost for zero recovery."""
+    router = _router_seq(_Result(content=_builder_json([])))
+    await judge_multi_procedure(db, _SPINE, "", 0.5, router)
+    _, kwargs = router.route_call.call_args
+    assert kwargs.get("suppress_dead_letter") is True
+
+
+@pytest.mark.asyncio
 async def test_builder_stores_real_procedure_and_records_grounding(db):
     router = _router_seq(
         _Result(content=_builder_json([_proc()])),  # builder

--- a/tests/test_memory/test_procedure_rebuild.py
+++ b/tests/test_memory/test_procedure_rebuild.py
@@ -98,6 +98,19 @@ async def test_drain_still_exhausted_stays_pending(mdb, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_drain_never_rolls_back_shared_connection(mdb, monkeypatch):
+    """Regression: the drain must never call rollback() — ``db`` is the shared
+    SerializedConnection, so a rollback would discard other concurrent jobs'
+    pending writes, not just ours."""
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    _stub_builder(monkeypatch, result=jm.ProcedureBuilderUnavailable("down"))
+    rollback_spy = AsyncMock()
+    monkeypatch.setattr(mdb, "rollback", rollback_spy)
+    await _drain(mdb)
+    rollback_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_drain_transcript_gone_discards(mdb, monkeypatch):
     await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
     monkeypatch.setattr(ej, "_find_transcript", lambda d, s: None)

--- a/tests/test_memory/test_procedure_rebuild.py
+++ b/tests/test_memory/test_procedure_rebuild.py
@@ -1,0 +1,147 @@
+"""Tests for the procedure-rebuild recovery path (N1 cognition-loss leak fix).
+
+When the whole-session procedure builder dies on provider exhaustion, the
+extraction watermark has already advanced past the session's lines, so the
+normal cycle never revisits it. These tests cover the durable rebuild queue that
+recovers it: enqueue-on-failure, drain-and-complete, retry-while-exhausted,
+discard-on-missing-transcript, and attempt-cap exhaustion (with a visible
+observation so the loss is never silent).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+import genesis.learning.procedural.judge as jm
+import genesis.learning.procedural.struggle_detector as sd
+from genesis.db.crud import deferred_work as dw_crud
+from genesis.db.schema import create_all_tables
+from genesis.memory import extraction_job as ej
+
+
+@pytest.fixture
+async def mdb():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _pending(db):
+    return await dw_crud.query_pending(db, work_type="procedure_rebuild", limit=50)
+
+
+def _stub_builder(monkeypatch, *, result):
+    """Point the drain's builder imports at fakes. ``result`` is a return value
+    (list of ids) or an exception instance to raise."""
+    monkeypatch.setattr(ej, "_find_transcript", lambda d, s: Path("/fake/cc1.jsonl"))
+    monkeypatch.setattr(sd, "build_spine_and_haystack", lambda p: ([{"turn": 1}], "hay"))
+    monkeypatch.setattr(sd, "score_struggle", lambda spine: 0.5)
+    if isinstance(result, Exception):
+        monkeypatch.setattr(jm, "judge_multi_procedure", AsyncMock(side_effect=result))
+    else:
+        monkeypatch.setattr(jm, "judge_multi_procedure", AsyncMock(return_value=result))
+
+
+async def _drain(mdb):
+    await ej._drain_procedure_rebuilds(
+        db=mdb, router=MagicMock(), transcript_dir=Path("/fake"),
+        summary={}, max_procedures_per_session=7,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enqueue_creates_pending_item(mdb):
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    items = await _pending(mdb)
+    assert len(items) == 1
+    assert json.loads(items[0]["payload_json"])["cc_session_id"] == "cc1"
+
+
+@pytest.mark.asyncio
+async def test_drain_success_completes_and_counts(mdb, monkeypatch):
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    _stub_builder(monkeypatch, result=["proc-1", "proc-2"])
+    summary: dict = {}
+    await ej._drain_procedure_rebuilds(
+        db=mdb, router=MagicMock(), transcript_dir=Path("/fake"),
+        summary=summary, max_procedures_per_session=7,
+    )
+    assert summary["procedures_rebuilt"] == 2
+    assert await _pending(mdb) == []  # completed → no longer pending
+
+
+@pytest.mark.asyncio
+async def test_drain_completes_even_with_zero_procedures(mdb, monkeypatch):
+    """A successful rebuild that finds nothing still COMPLETES (provider was up,
+    nothing to recover) — it must not linger and retry forever."""
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    _stub_builder(monkeypatch, result=[])
+    await _drain(mdb)
+    assert await _pending(mdb) == []
+
+
+@pytest.mark.asyncio
+async def test_drain_still_exhausted_stays_pending(mdb, monkeypatch):
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    _stub_builder(monkeypatch, result=jm.ProcedureBuilderUnavailable("still down"))
+    await _drain(mdb)
+    items = await _pending(mdb)
+    assert len(items) == 1           # kept for a later cycle
+    assert items[0]["attempts"] == 1  # one attempt consumed
+
+
+@pytest.mark.asyncio
+async def test_drain_transcript_gone_discards(mdb, monkeypatch):
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    monkeypatch.setattr(ej, "_find_transcript", lambda d, s: None)
+    await _drain(mdb)
+    assert await _pending(mdb) == []  # discarded — nothing to rebuild from
+
+
+@pytest.mark.asyncio
+async def test_drain_attempts_exhausted_discards_and_observes(mdb, monkeypatch):
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    items = await _pending(mdb)
+    await mdb.execute(
+        "UPDATE deferred_work_queue SET attempts = ? WHERE id = ?",
+        (ej._MAX_PROCEDURE_REBUILD_ATTEMPTS, items[0]["id"]),
+    )
+    await mdb.commit()
+    await _drain(mdb)
+    assert await _pending(mdb) == []  # given up
+    rows = await mdb.execute_fetchall(
+        "SELECT COUNT(*) FROM observations WHERE type='procedure_extraction_lost'"
+    )
+    assert rows[0][0] == 1  # the loss is surfaced, not silent
+
+
+@pytest.mark.asyncio
+async def test_reference_only_mode_skips_drain(mdb, monkeypatch):
+    """History-mining / reference-only cycles must not touch the rebuild queue."""
+    await ej._enqueue_procedure_rebuild(mdb, "s1", "cc1")
+    monkeypatch.setattr(ej, "_find_extractable_sessions", AsyncMock(return_value=[]))
+    spy = AsyncMock()
+    monkeypatch.setattr(ej, "_drain_procedure_rebuilds", spy)
+    await ej.run_extraction_cycle(
+        db=mdb, store=MagicMock(), router=MagicMock(), reference_only_mode=True,
+    )
+    spy.assert_not_called()
+    assert len(await _pending(mdb)) == 1  # untouched
+
+
+@pytest.mark.asyncio
+async def test_normal_mode_runs_drain(mdb, monkeypatch):
+    monkeypatch.setattr(ej, "_find_extractable_sessions", AsyncMock(return_value=[]))
+    spy = AsyncMock()
+    monkeypatch.setattr(ej, "_drain_procedure_rebuilds", spy)
+    await ej.run_extraction_cycle(
+        db=mdb, store=MagicMock(), router=MagicMock(), reference_only_mode=False,
+    )
+    spy.assert_called_once()

--- a/tests/test_observability/test_queues_dead_letter.py
+++ b/tests/test_observability/test_queues_dead_letter.py
@@ -35,9 +35,13 @@ def _reset_cooldown():
     # so each exercises the intended path, not leftover state.
     q._last_dead_letter_alert_at = 0.0
     q._last_dead_letter_band = ""
+    q._last_dlq_storm_alert_at = 0.0
+    q._last_dlq_storm_band = ""
     yield
     q._last_dead_letter_alert_at = 0.0
     q._last_dead_letter_band = ""
+    q._last_dlq_storm_alert_at = 0.0
+    q._last_dlq_storm_band = ""
 
 
 async def _unresolved_infra(db) -> int:
@@ -157,3 +161,102 @@ async def test_queues_high_pending_low_stuck_does_not_alert(db):
     result = await q.queues(db, None, _DLQ(200, stuck=0), None)
     assert await _unresolved_infra(db) == 0        # no cry-wolf
     assert result["dead_letters"] == 200           # raw total stays honest
+
+
+# ── Rate-based storm alert ───────────────────────────────────────────────────
+
+from datetime import UTC, datetime, timedelta  # noqa: E402
+
+
+async def _seed_dead_letters(db, n: int, op_type: str, *, minutes_ago: int = 1) -> None:
+    """Insert ``n`` dead_letter rows created ``minutes_ago`` in the past."""
+    created = (datetime.now(UTC) - timedelta(minutes=minutes_ago)).isoformat()
+    for i in range(n):
+        await db.execute(
+            "INSERT INTO dead_letter (id, operation_type, payload, target_provider, "
+            "failure_reason, created_at, status) VALUES (?,?,?,?,?,?, 'pending')",
+            (f"{op_type}:{minutes_ago}:{i}", op_type, "{}", "all",
+             "All providers exhausted", created),
+        )
+    await db.commit()
+
+
+async def _unresolved_storm(db) -> int:
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM observations WHERE source='dead_letter_storm' "
+        "AND type='infrastructure_alert' AND resolved=0"
+    )
+    return rows[0][0]
+
+
+@pytest.mark.asyncio
+async def test_storm_alerts_on_nonjudge_rate(db):
+    """A rate spike of non-judge dead-letters in the window pages once."""
+    await _seed_dead_letters(db, 45, "chain_exhausted:4_light_reflection")
+    await q.queues(db, None, _DLQ(0, stuck=0), None)  # depth path silent
+    assert await _unresolved_storm(db) == 1
+
+
+@pytest.mark.asyncio
+async def test_storm_excludes_judge_burst(db):
+    """A self-healing judge burst must NOT trip the storm alert (worthless-late)."""
+    await _seed_dead_letters(db, 200, "chain_exhausted:judge")
+    await q.queues(db, None, _DLQ(0, stuck=0), None)
+    assert await _unresolved_storm(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_storm_below_threshold_no_alert(db):
+    """Normal trickle (< threshold non-judge) does not page."""
+    await _seed_dead_letters(db, 30, "chain_exhausted:3_micro_reflection")
+    await q.queues(db, None, _DLQ(0, stuck=0), None)
+    assert await _unresolved_storm(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_storm_ignores_aged_rows(db):
+    """Rows older than the window don't count — only the *rate* matters."""
+    await _seed_dead_letters(db, 60, "chain_exhausted:dream_cycle_synthesis",
+                             minutes_ago=30)  # outside the 15m window
+    await q.queues(db, None, _DLQ(0, stuck=0), None)
+    assert await _unresolved_storm(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_storm_resolves_when_rate_drops(db):
+    """After a storm alerts, a subsequent tick with the rate back to normal
+    auto-resolves it (mirrors the accumulation resolve-on-drain)."""
+    await _seed_dead_letters(db, 50, "chain_exhausted:4_light_reflection")
+    await q.queues(db, None, _DLQ(0, stuck=0), None)
+    assert await _unresolved_storm(db) == 1
+    # Age the rows out of the window, then tick again.
+    await db.execute(
+        "UPDATE dead_letter SET created_at = ?",
+        ((datetime.now(UTC) - timedelta(hours=2)).isoformat(),),
+    )
+    await db.commit()
+    await q.queues(db, None, _DLQ(0, stuck=0), None)
+    assert await _unresolved_storm(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_storm_no_duplicate_rapid_same_band(db):
+    """Four rapid same-band storm alerts (the observed 4-in-30s dup bug) produce
+    exactly one unresolved row — band + cooldown + skip_if_duplicate hold."""
+    breakdown = [("chain_exhausted:4_light_reflection", 60)]
+    for _ in range(4):
+        await q._alert_dead_letter_storm(db, 60, breakdown)  # cooldown NOT reset
+    assert await _unresolved_storm(db) == 1
+
+
+@pytest.mark.asyncio
+async def test_storm_distinct_from_accumulation_alert(db):
+    """Storm and accumulation alerts use distinct sources: both can coexist, and
+    resolving one must not clobber the other."""
+    await q._alert_dead_letter_accumulation(db, 200)   # source=dead_letter_monitor
+    await q._alert_dead_letter_storm(db, 60, [("chain_exhausted:4_light_reflection", 60)])
+    assert await _unresolved_infra(db) == 1            # accumulation
+    assert await _unresolved_storm(db) == 1            # storm
+    await q._resolve_dead_letter_alerts(db, 0)         # resolve accumulation only
+    assert await _unresolved_infra(db) == 0
+    assert await _unresolved_storm(db) == 1            # storm untouched


### PR DESCRIPTION
## Context

An observed-harm evidence pass over production found that provider-exhaustion storms silently dropped internal-cognition work via the dead-letter queue. Two distinct gaps, both addressed here.

### 1. Procedure extractions permanently lost (the learning leak)

The whole-session procedure builder (`38_procedure_extraction`) runs **after** the extraction watermark advances, and `_call_and_parse_list` swallowed provider-exhaustion as an empty list. So when the builder hit "All providers exhausted": the failure was invisible, the watermark had already moved, and the next cycle skipped the session (`if not messages: continue`). The procedure — a reusable playbook — was lost for good (~174 dead-lettered over two months).

**Fix:** the builder now raises `ProcedureBuilderUnavailable` on call failure (distinct from a genuine no-procedures `[]`) and passes `suppress_dead_letter=True` (it owns its own retry; the DLQ replay only re-issued the transport and discarded the parsed procedures). On that failure the session is re-queued on the existing `deferred_work_queue` (`work_type=procedure_rebuild`); a drain pass at the top of each extraction cycle rebuilds from the full transcript. Idempotent via the `store_procedure_checked` novelty gate. Capped at 8 attempts; exhaustion or a rotated transcript discards and surfaces a `procedure_extraction_lost` observation, so the loss is visible, never silent. Reuses the `outreach_delivery` recovery pattern — no new schema.

### 2. Short-intense storms produced no alert (safety-net)

The existing DLQ alert is depth-based (`get_stuck_count`) and only counts an item once it ages past its TTL, so a short storm that self-heals or expires inside the TTL window fired no signal. Add a **rate-based** early warning: `_alert_dead_letter_storm` counts non-judge dead-letters enqueued in a rolling 15m window and pages once per storm.

- `count_recent` / `recent_optype_counts` CRUD + `idx_dead_letter_created` (migration 0049)
- distinct `source=dead_letter_storm` + hash prefix so it never collides with the accumulation alert's dedup/resolve; same band + cooldown + skip_if_duplicate throttle
- `chain_exhausted:judge` excluded (1h self-heal TTL, worthless-late)
- threshold 40/15m calibrated on the real storm timeline (normal <40 non-judge/15m, every observed storm >45)
- rides the existing critical-observations → notification channel

Safety-net for provider outages (e.g. a future model EOL). The depth alert is kept for sustained multi-hour backlogs.

## Tests

- storm alert: fires on rate, throttled same-band, resolves on drain, **judge burst excluded**, aged rows ignored, no-dup-rapid-fire, distinct-from-accumulation
- CRUD `count_recent` / `recent_optype_counts` (window + exclude-prefix); migration 0049 (upgrade + idempotent + no-op)
- builder raises on exhaustion / transport error and suppresses dead-letter
- rebuild: enqueue → drain-completes → counts; still-exhausted stays pending; transcript-gone discards; attempt-cap exhausts + observes; reference-only skips drain

## Follow-up

The single-extraction path (`extractor.py` via the retrospective-triage pipeline) shares the `38_procedure_extraction` call site and may have a sibling skip-on-failure. Tracked separately — it is a different pipeline with its own trigger semantics and was not traced end-to-end here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)