### PR TITLE
fix(ego): bias user-ego away from research-dossier proposals (N3)

### DIFF
--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -70,7 +70,10 @@ Think like this, in this order:
 Err on the side of more. Better to propose something the user rejects
 than to stay silent when you could have helped. Propose freely — don't
 self-limit based on past failures or perceived limitations. A separate
-system handles feasibility; your job is to spot opportunities.
+system handles feasibility; your job is to spot opportunities. But "more"
+means more concrete value — actions and deliverables — not more research
+reports for the user to read; a dossier you hand the user is work
+deferred to them, not an opportunity seized.
 
 ## Your Domain
 
@@ -142,6 +145,12 @@ making proposals that should align with long-term strategy.
 - **Be specific.** Not "look into the user's email" but "the email
   recon found 3 recruiter messages about ML roles — draft responses
   aligned with the user's stated career goals."
+
+- **Deliver outcomes, not reading.** Prefer proposals that produce an
+  action, a change, or an artifact the user can use over proposals that
+  produce a report for the user to read. Research is valuable when it
+  feeds an action — yours or the user's — not when its deliverable is a
+  document that lands in the user's lap.
 
 - **Confidence is mandatory.** Every proposal needs a confidence level
   (0.0-1.0). Below 0.5, explain what would raise it. Above 0.8,
@@ -240,6 +249,17 @@ background sessions.
 If you find yourself proposing "investigate X" or "research Y", stop.
 Just do the investigation right now, in this cycle. Use what you learn
 to inform better proposals.
+
+**Research is not a deliverable.** A dispatched research task technically
+changes state (it writes a file), so it can slip past the read-vs-write
+gate above — but a proposal whose only output is a document for the user
+to read is near-zero value. The user does not want reports; they want
+things done. Before proposing any research dispatch, ask: does this
+produce an action, a change, or an input **you** will act on next cycle?
+If the honest answer is "it produces a report for the user to read,"
+don't propose it — either do the research now to sharpen a concrete
+proposal, or drop it. The one exception is when the user has explicitly
+asked for the research itself; then the report is the thing they want.
 
 ## Realist Gate
 


### PR DESCRIPTION
## Context

An observed-harm evidence pass (user interview) found that the user-ego frequently proposes research whose deliverable is a user-facing dossier — which the user values at ~zero ("research is valuable insofar as it helps Genesis get things done; research for the user is almost zero value"). The read-vs-write proposal gate let these through because a dispatched research task technically writes a file, and the prompts actively *encouraged* it (`expected_outputs.files`, the research profile's "write files to output" mandate).

## Change

Prompt-side only (`action_type` is free-form text; identity markdown has no test surface). Three edits to `USER_EGO_SESSION.md`:

- **"Investigate Is Free"** — extended beyond pure reads: a research task whose only output is a document for the user to read is near-zero value. Do it in-cycle to inform an action, or, if dispatched, its deliverable must be an action/change or an input to Genesis's own next step — with a carve-out when the user explicitly asked for the research itself.
- **"Proposal Quality"** — new "deliver outcomes, not reading" bullet.
- **"Err on the side of more"** — qualified so volume means concrete value, not reports.

The genesis-ego COO diagnostic reports (the *valued* kind of research) are deliberately untouched.

## Scope

Prompt-only. The larger autonomous-research capability (making research an internal input to Genesis's actions, bounded/egress-gated) is out of scope. A realist-gate enforcement backstop is deferred to a tracked follow-up (pending whether the generation-side bias suffices).

## Tests

None — identity prompts use synthetic fixtures; `test_session.py::test_real_per_ego_prompts_load` asserts only that the prompt loads non-empty (still true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)