### PR TITLE
feat(hooks): repo_routing_guard — catch wrong-repo git add/commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -167,6 +167,16 @@
                 "hooks": [
                     {
                         "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/repo_routing_guard.py",
+                        "timeout": 2000
+                    }
+                ]
+            },
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/concurrent_test_guard.py",
                         "timeout": 3000
                     }

--- a/config/repo_topology.yaml
+++ b/config/repo_topology.yaml
@@ -47,3 +47,12 @@ settings:
   max_content_files: 20   # cap on NEW files whose content is read
   max_content_bytes: 4096 # bytes read per file for content markers
   git_timeout_seconds: 2  # per git subprocess call
+  # Content markers scan CODE, not prose/tests/the ruleset itself. Without this,
+  # this file (which names the markers verbatim) and the guard's tests would
+  # self-block on a fresh add. Path/glob STRONG checks still apply everywhere.
+  content_scan_exclude:
+    - "*.md"
+    - "**/*.md"
+    - "docs/**"
+    - "tests/**"
+    - "**/repo_topology.yaml"

--- a/config/repo_topology.yaml
+++ b/config/repo_topology.yaml
@@ -1,0 +1,49 @@
+# repo_topology.yaml — declares which code belongs to which repo so the
+# repo_routing_guard PreToolUse hook can catch "wrong-repo" git add/commit
+# (e.g. building edge-device firmware into the AGI codebase — the OMI incident,
+# 2026-07). This is the in-repo TEMPLATE / fallback.
+#
+# Resolution order (first found wins):
+#   1. $REPO_TOPOLOGY_PATH               (tests / explicit override)
+#   2. ~/.genesis/config/repo_topology.yaml  (user override)
+#   3. this file (config/repo_topology.yaml) (in-repo fallback)
+#
+# The guard identifies the CURRENT repo by its `origin` remote URL, then flags
+# staged/added files whose path or (for new files) content matches ANOTHER
+# repo's signature. STRONG match -> block (exit 2). WEAK match -> advisory only.
+version: 1
+
+repos:
+  GENesis-AGI:
+    remotes:
+      - WingedGuardian/GENesis-AGI
+    # Paths legitimately internal to AGI — silence WEAK markers here. (AGI keeps
+    # internal channel code; "voice"/"wyoming" are deliberately NOT markers.)
+    # Does NOT silence STRONG markers: a foreign component name (s2s_bridge,
+    # firmware, ...) landing under these paths is still the wrong-repo mistake.
+    allow_paths:
+      - dashboard/routes/voice_api.py
+      - src/genesis/channels/voice/
+      - src/genesis/attention/
+
+  GENesis-Voice:
+    remotes:
+      - WingedGuardian/GENesis-Voice
+    # STRONG — a match BLOCKS the commit. Path segments use exact segment
+    # equality (a path part == the marker), not substring, to avoid catching
+    # e.g. "device_registry".
+    strong_path_segments: [firmware, esphome, s2s_bridge, ambient_bridge, omi]
+    strong_path_globs:
+      - "config/voice-pe/**"
+      - "**/flash_*.sh"
+    # Content markers checked only in NEW files (added/untracked).
+    strong_content_markers: ["esphome:", "ESP32", "esp-idf", "platformio"]
+    # WEAK — advisory only (additionalContext), never blocks. Silenced by the
+    # current repo's allow_paths.
+    weak_path_segments: [voice-pe, voice_pe, satellite, edge]
+
+settings:
+  max_files: 200          # cap on files inspected per invocation
+  max_content_files: 20   # cap on NEW files whose content is read
+  max_content_bytes: 4096 # bytes read per file for content markers
+  git_timeout_seconds: 2  # per git subprocess call

--- a/scripts/hooks/repo_routing_guard.py
+++ b/scripts/hooks/repo_routing_guard.py
@@ -25,6 +25,11 @@ Known limits (accepted, documented):
 - ``git commit --amend`` sees only the staged delta, not the files already in
   the commit being amended.
 - Topology is matched by ``origin`` remote; a repo with no origin is not guarded.
+- Exotic command shapes degrade in the FAIL-SAFE direction (broader scan, never
+  a missed detection): a pathspec/message token literally equal to ``git``/``cd``
+  truncates arg collection, and space-separated global flags (``git --git-dir P
+  commit``) are not value-skipped like ``-C``/``-c``. Agent-issued commands here
+  use ``git -C`` / ``cd && git``, both handled and tested.
 """
 
 from __future__ import annotations
@@ -71,53 +76,64 @@ def _load_topology() -> dict | None:
         return None
 
 
-def _segments(cmd: str) -> list[str]:
-    """Split a compound command on top-level && and ; into trimmed segments."""
-    return [s.strip() for s in re.split(r"&&|;", cmd) if s.strip()]
+_SHELL_OPS = {"&&", "||", ";", "|", "&"}
 
 
-def _parse_git_invocation(cmd: str) -> tuple[str | None, list[str], str]:
-    """Find the git add|commit segment; return (subcommand, args, effective_dir).
+def _parse_git_invocations(cmd: str) -> list[tuple[str, list[str], str]]:
+    """Return every git add|commit in the command as (subcommand, args, dir).
 
-    Tracks a leading ``cd <dir>`` and ``git -C <dir>`` to infer the directory the
-    git command actually runs in. Best-effort — falls back to cwd. subcommand is
-    None if there is no add/commit.
+    Tokenizes the WHOLE command once with shlex (quote-aware, so a ``;`` inside a
+    ``-m`` message is not a separator, and newlines collapse to whitespace), then
+    walks the token stream: shell operators separate commands, ``cd <dir>`` and
+    ``git -C <dir>`` update the effective directory, and EVERY add/commit is
+    collected (not just the first). Best-effort — an unparseable command yields [].
     """
+    try:
+        toks = shlex.split(cmd)
+    except ValueError:
+        return []
+    out: list[tuple[str, list[str], str]] = []
     cur_dir = os.getcwd()
-    for seg in _segments(cmd):
-        try:
-            toks = shlex.split(seg)
-        except ValueError:
+    i, n = 0, len(toks)
+    while i < n:
+        t = toks[i]
+        if t in _SHELL_OPS:
+            i += 1
             continue
-        if not toks:
-            continue
-        if toks[0] == "cd" and len(toks) >= 2:
-            d = os.path.expanduser(toks[1])
+        if t == "cd" and i + 1 < n and toks[i + 1] not in _SHELL_OPS:
+            d = os.path.expanduser(toks[i + 1])
             cur_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
+            i += 2
             continue
-        if "git" not in toks:
-            continue
-        rest = toks[toks.index("git") + 1:]
-        git_dir = cur_dir
-        i = 0
-        while i < len(rest):
-            t = rest[i]
-            if t == "-C" and i + 1 < len(rest):
-                d = os.path.expanduser(rest[i + 1])
-                git_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
-                i += 2
-                continue
-            if t == "-c" and i + 1 < len(rest):
-                i += 2
-                continue
-            if t.startswith("-"):
+        if t == "git":
+            i += 1
+            git_dir = cur_dir
+            while i < n:
+                if toks[i] == "-C" and i + 1 < n:
+                    d = os.path.expanduser(toks[i + 1])
+                    git_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
+                    i += 2
+                    continue
+                if toks[i] == "-c" and i + 1 < n:
+                    i += 2
+                    continue
+                if toks[i].startswith("-"):
+                    i += 1
+                    continue
+                break
+            sub = toks[i] if i < n else None
+            if sub is not None:
                 i += 1
-                continue
-            break
-        sub = rest[i] if i < len(rest) else None
-        if sub in ("add", "commit"):
-            return sub, rest[i + 1:], git_dir
-    return None, [], cur_dir
+            # Collect this git command's args until the next command boundary.
+            args: list[str] = []
+            while i < n and toks[i] not in _SHELL_OPS and toks[i] not in ("git", "cd"):
+                args.append(toks[i])
+                i += 1
+            if sub in ("add", "commit"):
+                out.append((sub, args, git_dir))
+            continue
+        i += 1
+    return out
 
 
 def _git(git_dir: str, args: list[str], timeout: int) -> str:
@@ -157,7 +173,11 @@ def _porcelain_files(
         if len(line) < 4:
             continue
         xy, path = line[:2], line[3:]
-        if " -> " in path:  # rename
+        # Deletions can never INTRODUCE wrong-repo content — skip so that
+        # removing a foreign file (the incident cleanup) is never blocked.
+        if "D" in xy:
+            continue
+        if " -> " in path:  # rename — classify the destination path
             path = path.split(" -> ", 1)[1]
         path = path.strip().strip('"')
         if not path:
@@ -178,16 +198,19 @@ def _commit_files(
         if len(parts) < 2:
             continue
         status, path = parts[0], parts[-1].strip().strip('"')
+        if status.startswith("D"):  # deletion — cannot introduce foreign content
+            continue
         files.add(path)
         if status.startswith("A"):
             new.add(path)
-    # `commit -a` / `-am` also stages tracked modifications
+    # `commit -a` / `-am` also stages tracked modifications (never new files).
     if any(a in ("-a", "--all") or (a.startswith("-") and not a.startswith("--") and "a" in a)
            for a in args):
-        for line in _git(git_dir, ["diff", "HEAD", "--name-only"], timeout).splitlines():
-            p = line.strip().strip('"')
-            if p:
-                files.add(p)
+        for line in _git(git_dir, ["diff", "HEAD", "--name-status"], timeout).splitlines():
+            parts = line.split("\t")
+            if len(parts) < 2 or parts[0].startswith("D"):
+                continue
+            files.add(parts[-1].strip().strip('"'))
     return files, new
 
 
@@ -236,6 +259,15 @@ def _has_content_marker(git_dir: str, path: str, markers: list[str], max_bytes: 
     return any(m in blob for m in markers)
 
 
+_DEFAULT_CONTENT_EXCLUDE = [
+    "*.md", "**/*.md", "docs/**", "tests/**", "**/repo_topology.yaml",
+]
+
+
+def _path_excluded(path: str, globs: list[str]) -> bool:
+    return any(_glob_match(path, g) for g in globs)
+
+
 def _classify(
     files: set[str], new_files: set[str], git_dir: str,
     cur_allow: list[str], foreign: dict[str, dict], settings: dict,
@@ -244,6 +276,10 @@ def _classify(
     max_files = int(settings.get("max_files", 200))
     max_content = int(settings.get("max_content_files", 20))
     max_bytes = int(settings.get("max_content_bytes", 4096))
+    # Content markers scan CODE, not prose/tests/the ruleset itself — otherwise
+    # this guard's own topology + test files (which name the markers verbatim)
+    # would self-block on a fresh add (e.g. the public-repo distribution).
+    content_exclude = settings.get("content_scan_exclude") or _DEFAULT_CONTENT_EXCLUDE
     strong: list[tuple[str, str]] = []
     weak: list[tuple[str, str]] = []
     reads = 0
@@ -255,6 +291,7 @@ def _classify(
                 matched_strong = True
                 break
             if (path in new_files and reads < max_content
+                    and not _path_excluded(path, content_exclude)
                     and _has_content_marker(
                         git_dir, path, sig.get("strong_content_markers", []) or [], max_bytes)):
                 reads += 1
@@ -288,8 +325,8 @@ def main() -> int:
             print("NOTE: repo-routing-guard override acknowledged by session.", file=sys.stderr)
             return 0
 
-        sub, args, git_dir = _parse_git_invocation(cmd)
-        if sub is None:
+        invocations = _parse_git_invocations(cmd)
+        if not invocations:
             return 0
 
         topo = _load_topology()
@@ -299,37 +336,48 @@ def main() -> int:
         settings = topo.get("settings", {}) or {}
         timeout = int(settings.get("git_timeout_seconds", 2))
 
-        origin = _normalize_remote(
-            _git(git_dir, ["config", "--get", "remote.origin.url"], timeout).strip())
-        if not origin:
-            return 0
-        cur_key = next(
-            (k for k, v in repos.items()
-             if origin in {_normalize_remote(r) for r in (v.get("remotes") or [])}),
-            None,
-        )
-        if cur_key is None:
-            return 0  # unknown repo — don't guard
+        # Accumulate hits across EVERY git add/commit in the command (chained
+        # commands each get classified against their own effective repo).
+        strong: list[tuple[str, str]] = []
+        weak: list[tuple[str, str]] = []
+        cur_key = None
+        for sub, args, git_dir in invocations:
+            origin = _normalize_remote(
+                _git(git_dir, ["config", "--get", "remote.origin.url"], timeout).strip())
+            if not origin:
+                continue
+            key = next(
+                (k for k, v in repos.items()
+                 if origin in {_normalize_remote(r) for r in (v.get("remotes") or [])}),
+                None,
+            )
+            if key is None:
+                continue  # unknown repo — don't guard this invocation
+            foreign = {
+                k: v for k, v in repos.items()
+                if k != key and (
+                    v.get("strong_path_segments") or v.get("strong_path_globs")
+                    or v.get("strong_content_markers") or v.get("weak_path_segments"))
+            }
+            if not foreign:
+                continue
+            if sub == "commit":
+                files, new_files = _commit_files(git_dir, args, timeout)
+            else:
+                files, new_files = _add_files(git_dir, args, timeout)
+            if not files:
+                continue
+            cur_allow = repos.get(key, {}).get("allow_paths", []) or []
+            s, w = _classify(files, new_files, git_dir, cur_allow, foreign, settings)
+            strong.extend(s)
+            weak.extend(w)
+            cur_key = key
 
-        # Foreign = every OTHER repo that declares a signature.
-        foreign = {
-            k: v for k, v in repos.items()
-            if k != cur_key and (
-                v.get("strong_path_segments") or v.get("strong_path_globs")
-                or v.get("strong_content_markers") or v.get("weak_path_segments"))
-        }
-        if not foreign:
-            return 0
-
-        if sub == "commit":
-            files, new_files = _commit_files(git_dir, args, timeout)
-        else:
-            files, new_files = _add_files(git_dir, args, timeout)
-        if not files:
-            return 0
-
-        cur_allow = repos.get(cur_key, {}).get("allow_paths", []) or []
-        strong, weak = _classify(files, new_files, git_dir, cur_allow, foreign, settings)
+        # A file staged then committed in one command is hit twice — dedup,
+        # preserving order, and drop weak hits already flagged as strong.
+        strong = list(dict.fromkeys(strong))
+        strong_paths = {p for p, _ in strong}
+        weak = [h for h in dict.fromkeys(weak) if h[0] not in strong_paths]
 
         if strong:
             belongs = sorted({name for _, name in strong})

--- a/scripts/hooks/repo_routing_guard.py
+++ b/scripts/hooks/repo_routing_guard.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: catch wrong-repo ``git add`` / ``git commit``.
+
+The OMI incident (2026-07): a session built edge-device software (esphome /
+firmware / s2s_bridge) into the AGI codebase, blind to the separate
+GENesis-Voice repo. This hook is the deterministic backstop — it identifies the
+CURRENT repo by its ``origin`` remote, then flags staged/added files whose path
+(or, for new files, content) belongs to a DIFFERENT repo per
+``repo_topology.yaml``.
+
+Contract (matches the other Genesis PreToolUse hooks):
+- Input via ``CLAUDE_TOOL_INPUT`` env (JSON with a ``command`` field).
+- STRONG match -> BLOCK: message to stderr, exit 2.
+- WEAK match  -> ADVISORY: ``hookSpecificOutput.additionalContext`` on stdout, exit 0.
+- No match / not a git add|commit / anything unexpected -> exit 0 (fail-open).
+- Override: append ``# repo-routing-override`` to the command to bypass.
+
+Fail-open is load-bearing: this hook must NEVER block a legitimate commit. Every
+failure path returns 0. The WS-C ambient-awareness layer is the upstream net;
+this guard is a precise, deterministic backstop, not a wall.
+
+Known limits (accepted, documented):
+- ``bash -c "..."`` nesting or multi-``cd`` chains can defeat cwd inference; the
+  guard fails open in those cases (the ambient lane is the net).
+- ``git commit --amend`` sees only the staged delta, not the files already in
+  the commit being amended.
+- Topology is matched by ``origin`` remote; a repo with no origin is not guarded.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+_OVERRIDE_RE = re.compile(r"#\s*repo-routing-override\b")
+
+
+def _load_topology() -> dict | None:
+    """Load repo topology from the first available source. None on any failure."""
+    candidates = []
+    env_path = os.environ.get("REPO_TOPOLOGY_PATH")
+    if env_path:
+        candidates.append(Path(env_path))
+    candidates.append(Path.home() / ".genesis" / "config" / "repo_topology.yaml")
+    # In-repo fallback: this file lives at <root>/scripts/hooks/, config at <root>/config/.
+    candidates.append(Path(__file__).resolve().parents[2] / "config" / "repo_topology.yaml")
+
+    path = next((p for p in candidates if p.is_file()), None)
+    if path is None:
+        return None
+    try:
+        import yaml
+    except ImportError:
+        # Visible degradation, not silent — the guard is off without a parser.
+        print(
+            "NOTE: repo_routing_guard disabled — PyYAML unavailable in hook runtime.",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def _segments(cmd: str) -> list[str]:
+    """Split a compound command on top-level && and ; into trimmed segments."""
+    return [s.strip() for s in re.split(r"&&|;", cmd) if s.strip()]
+
+
+def _parse_git_invocation(cmd: str) -> tuple[str | None, list[str], str]:
+    """Find the git add|commit segment; return (subcommand, args, effective_dir).
+
+    Tracks a leading ``cd <dir>`` and ``git -C <dir>`` to infer the directory the
+    git command actually runs in. Best-effort — falls back to cwd. subcommand is
+    None if there is no add/commit.
+    """
+    cur_dir = os.getcwd()
+    for seg in _segments(cmd):
+        try:
+            toks = shlex.split(seg)
+        except ValueError:
+            continue
+        if not toks:
+            continue
+        if toks[0] == "cd" and len(toks) >= 2:
+            d = os.path.expanduser(toks[1])
+            cur_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
+            continue
+        if "git" not in toks:
+            continue
+        rest = toks[toks.index("git") + 1:]
+        git_dir = cur_dir
+        i = 0
+        while i < len(rest):
+            t = rest[i]
+            if t == "-C" and i + 1 < len(rest):
+                d = os.path.expanduser(rest[i + 1])
+                git_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
+                i += 2
+                continue
+            if t == "-c" and i + 1 < len(rest):
+                i += 2
+                continue
+            if t.startswith("-"):
+                i += 1
+                continue
+            break
+        sub = rest[i] if i < len(rest) else None
+        if sub in ("add", "commit"):
+            return sub, rest[i + 1:], git_dir
+    return None, [], cur_dir
+
+
+def _git(git_dir: str, args: list[str], timeout: int) -> str:
+    r = subprocess.run(
+        ["git", "-C", git_dir, *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    return r.stdout if r.returncode == 0 else ""
+
+
+def _normalize_remote(url: str | None) -> str | None:
+    """Normalize a remote to ``owner/name`` (lowercased).
+
+    Handles full URLs and the bare ``owner/name`` form used in the topology:
+      git@github.com:Owner/Name.git | https://github.com/Owner/Name | Owner/Name
+    """
+    if not url:
+        return None
+    s = re.sub(r"\.git$", "", url.strip().rstrip("/"))
+    parts = [p for p in re.split(r"[/:]", s) if p]
+    return "/".join(parts[-2:]).lower() if len(parts) >= 2 else None
+
+
+def _porcelain_files(
+    git_dir: str, pathspecs: list[str], timeout: int,
+) -> tuple[set[str], set[str]]:
+    """(all_files, new_files) that a status/add would touch, via git porcelain."""
+    # --untracked-files=all expands fully-untracked directories into individual
+    # file paths (porcelain otherwise collapses them to "dir/"), which we need
+    # for per-file classification and content-marker reads.
+    args = ["status", "--porcelain", "--untracked-files=all"]
+    if pathspecs:
+        args += ["--", *pathspecs]
+    out = _git(git_dir, args, timeout)
+    files, new = set(), set()
+    for line in out.splitlines():
+        if len(line) < 4:
+            continue
+        xy, path = line[:2], line[3:]
+        if " -> " in path:  # rename
+            path = path.split(" -> ", 1)[1]
+        path = path.strip().strip('"')
+        if not path:
+            continue
+        files.add(path)
+        if xy.strip() in ("A", "??") or xy[0] == "A":
+            new.add(path)
+    return files, new
+
+
+def _commit_files(
+    git_dir: str, args: list[str], timeout: int,
+) -> tuple[set[str], set[str]]:
+    """(all_files, new_files) a commit would include."""
+    files, new = set(), set()
+    for line in _git(git_dir, ["diff", "--cached", "--name-status"], timeout).splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status, path = parts[0], parts[-1].strip().strip('"')
+        files.add(path)
+        if status.startswith("A"):
+            new.add(path)
+    # `commit -a` / `-am` also stages tracked modifications
+    if any(a in ("-a", "--all") or (a.startswith("-") and not a.startswith("--") and "a" in a)
+           for a in args):
+        for line in _git(git_dir, ["diff", "HEAD", "--name-only"], timeout).splitlines():
+            p = line.strip().strip('"')
+            if p:
+                files.add(p)
+    return files, new
+
+
+def _add_files(
+    git_dir: str, args: list[str], timeout: int,
+) -> tuple[set[str], set[str]]:
+    pathspecs = [a for a in args if not a.startswith("-")]
+    broad = (not pathspecs) or any(p in (".", ":/", "-A", "--all") for p in pathspecs)
+    return _porcelain_files(git_dir, [] if broad else pathspecs, timeout)
+
+
+def _path_segments(path: str) -> set[str]:
+    return set(path.replace("\\", "/").split("/"))
+
+
+def _glob_match(path: str, glob: str) -> bool:
+    base = os.path.basename(path)
+    tail = glob.rsplit("/", 1)[-1]
+    return (
+        fnmatch.fnmatch(path, glob)
+        or fnmatch.fnmatch(path, glob.replace("**/", "*"))
+        or ("**/" in glob and fnmatch.fnmatch(base, tail))
+    )
+
+
+def _matches_strong_path(path: str, sig: dict) -> bool:
+    if _path_segments(path) & set(sig.get("strong_path_segments", []) or []):
+        return True
+    return any(_glob_match(path, g) for g in (sig.get("strong_path_globs", []) or []))
+
+
+def _is_allowed(path: str, allow_paths: list[str]) -> bool:
+    for a in allow_paths or []:
+        a = a.rstrip("/")
+        if path == a or path.startswith(a + "/"):
+            return True
+    return False
+
+
+def _has_content_marker(git_dir: str, path: str, markers: list[str], max_bytes: int) -> bool:
+    try:
+        with open(os.path.join(git_dir, path), "rb") as f:
+            blob = f.read(max_bytes).decode("utf-8", "ignore")
+    except OSError:
+        return False
+    return any(m in blob for m in markers)
+
+
+def _classify(
+    files: set[str], new_files: set[str], git_dir: str,
+    cur_allow: list[str], foreign: dict[str, dict], settings: dict,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return (strong_hits, weak_hits) as lists of (path, foreign_repo_name)."""
+    max_files = int(settings.get("max_files", 200))
+    max_content = int(settings.get("max_content_files", 20))
+    max_bytes = int(settings.get("max_content_bytes", 4096))
+    strong: list[tuple[str, str]] = []
+    weak: list[tuple[str, str]] = []
+    reads = 0
+    for path in sorted(files)[:max_files]:
+        matched_strong = False
+        for name, sig in foreign.items():
+            if _matches_strong_path(path, sig):
+                strong.append((path, name))
+                matched_strong = True
+                break
+            if (path in new_files and reads < max_content
+                    and _has_content_marker(
+                        git_dir, path, sig.get("strong_content_markers", []) or [], max_bytes)):
+                reads += 1
+                strong.append((path, name))
+                matched_strong = True
+                break
+        if matched_strong:
+            continue
+        if _is_allowed(path, cur_allow):
+            continue  # allow_paths silence WEAK markers
+        for name, sig in foreign.items():
+            if _path_segments(path) & set(sig.get("weak_path_segments", []) or []):
+                weak.append((path, name))
+                break
+    return strong, weak
+
+
+def main() -> int:
+    try:
+        raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
+        if not raw:
+            return 0
+        cmd = (json.loads(raw) or {}).get("command", "")
+        # Cheap pre-filter: skip clearly non-git commands. Do NOT match "git add"
+        # as a substring — `git -C <dir> add` splits it. _parse_git_invocation
+        # is the accurate check (returns None for non add/commit).
+        if not cmd or "git" not in cmd:
+            return 0
+
+        if _OVERRIDE_RE.search(cmd):
+            print("NOTE: repo-routing-guard override acknowledged by session.", file=sys.stderr)
+            return 0
+
+        sub, args, git_dir = _parse_git_invocation(cmd)
+        if sub is None:
+            return 0
+
+        topo = _load_topology()
+        if not topo or not isinstance(topo.get("repos"), dict):
+            return 0
+        repos = topo["repos"]
+        settings = topo.get("settings", {}) or {}
+        timeout = int(settings.get("git_timeout_seconds", 2))
+
+        origin = _normalize_remote(
+            _git(git_dir, ["config", "--get", "remote.origin.url"], timeout).strip())
+        if not origin:
+            return 0
+        cur_key = next(
+            (k for k, v in repos.items()
+             if origin in {_normalize_remote(r) for r in (v.get("remotes") or [])}),
+            None,
+        )
+        if cur_key is None:
+            return 0  # unknown repo — don't guard
+
+        # Foreign = every OTHER repo that declares a signature.
+        foreign = {
+            k: v for k, v in repos.items()
+            if k != cur_key and (
+                v.get("strong_path_segments") or v.get("strong_path_globs")
+                or v.get("strong_content_markers") or v.get("weak_path_segments"))
+        }
+        if not foreign:
+            return 0
+
+        if sub == "commit":
+            files, new_files = _commit_files(git_dir, args, timeout)
+        else:
+            files, new_files = _add_files(git_dir, args, timeout)
+        if not files:
+            return 0
+
+        cur_allow = repos.get(cur_key, {}).get("allow_paths", []) or []
+        strong, weak = _classify(files, new_files, git_dir, cur_allow, foreign, settings)
+
+        if strong:
+            belongs = sorted({name for _, name in strong})
+            shown = [p for p, _ in strong][:8]
+            print(
+                f"BLOCKED: wrong-repo commit. These files belong to "
+                f"{', '.join(belongs)}, not {cur_key}:",
+                file=sys.stderr,
+            )
+            for p in shown:
+                print(f"  - {p}", file=sys.stderr)
+            if len(strong) > len(shown):
+                print(f"  … and {len(strong) - len(shown)} more", file=sys.stderr)
+            print(
+                f"Commit this in the {belongs[0]} repo, or append "
+                f"'# repo-routing-override' to proceed if this is intentional.",
+                file=sys.stderr,
+            )
+            return 2
+
+        if weak:
+            belongs = sorted({name for _, name in weak})
+            shown = ", ".join(p for p, _ in weak[:5])
+            print(json.dumps({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": (
+                        f"NOTE: {len(weak)} file(s) look voice/edge-related "
+                        f"({shown}) and may belong to {', '.join(belongs)} rather "
+                        f"than {cur_key}. Proceed if this is legitimately internal "
+                        f"channel code; otherwise commit it in the right repo."
+                    ),
+                }
+            }))
+            return 0
+
+    except Exception:
+        return 0  # fail-open — never block legitimate work
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/repo_routing_guard.py
+++ b/scripts/hooks/repo_routing_guard.py
@@ -30,6 +30,11 @@ Known limits (accepted, documented):
   truncates arg collection, and space-separated global flags (``git --git-dir P
   commit``) are not value-skipped like ``-C``/``-c``. Agent-issued commands here
   use ``git -C`` / ``cd && git``, both handled and tested.
+
+Runtime requirement: PyYAML. It is always present in the Genesis venv (this hook
+runs via ``genesis-hook``, which invokes that venv's python). If ``yaml`` is
+unavailable the guard prints a visible NOTE to stderr and fails open (disables
+itself) rather than crashing.
 """
 
 from __future__ import annotations
@@ -310,6 +315,7 @@ def _classify(
 
 
 def main() -> int:
+    """Entry point: parse hook input, classify staged files, block or advise."""
     try:
         raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
         if not raw:

--- a/tests/test_hooks/test_repo_routing_guard.py
+++ b/tests/test_hooks/test_repo_routing_guard.py
@@ -1,0 +1,257 @@
+"""Tests for repo_routing_guard.py — wrong-repo git add/commit backstop.
+
+Exit codes: 0 = allowed (silent or advisory), 2 = blocked. Advisory emits
+hookSpecificOutput.additionalContext on stdout with exit 0.
+
+The guard must NEVER block legitimate work — fail-open is exercised explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_TOPOLOGY = textwrap.dedent("""\
+    version: 1
+    repos:
+      GENesis-AGI:
+        remotes: [WingedGuardian/GENesis-AGI]
+        allow_paths:
+          - dashboard/routes/voice_api.py
+          - src/genesis/channels/voice/
+          - src/genesis/attention/
+      GENesis-Voice:
+        remotes: [WingedGuardian/GENesis-Voice]
+        strong_path_segments: [firmware, esphome, s2s_bridge, ambient_bridge, omi]
+        strong_path_globs: ["config/voice-pe/**", "**/flash_*.sh"]
+        strong_content_markers: ["esphome:", "ESP32", "esp-idf", "platformio"]
+        weak_path_segments: [voice-pe, voice_pe, satellite, edge]
+    settings:
+      max_files: 200
+      max_content_files: 20
+      max_content_bytes: 4096
+      git_timeout_seconds: 5
+""")
+
+
+def _guard_script() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        s = ancestor / "scripts" / "hooks" / "repo_routing_guard.py"
+        if s.exists():
+            return s
+    raise FileNotFoundError("repo_routing_guard.py not found")
+
+
+@pytest.fixture(scope="module")
+def topology(tmp_path_factory) -> str:
+    p = tmp_path_factory.mktemp("topo") / "repo_topology.yaml"
+    p.write_text(_TOPOLOGY)
+    return str(p)
+
+
+def _make_repo(path: Path, origin: str) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "remote", "add", "origin", origin], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t.io"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    return path
+
+
+def _write(repo: Path, rel: str, content: str = "x\n") -> None:
+    f = repo / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(content)
+
+
+def _run(cmd: str, cwd: Path, topology: str | None) -> subprocess.CompletedProcess:
+    env = {**os.environ, "CLAUDE_TOOL_INPUT": json.dumps({"command": cmd})}
+    if topology is not None:
+        env["REPO_TOPOLOGY_PATH"] = topology
+    else:
+        env.pop("REPO_TOPOLOGY_PATH", None)
+    return subprocess.run(
+        [sys.executable, str(_guard_script())],
+        env=env, cwd=str(cwd), capture_output=True, text=True, timeout=20,
+    )
+
+
+AGI = "https://github.com/WingedGuardian/GENesis-AGI.git"
+
+
+@pytest.fixture
+def agi_repo(tmp_path) -> Path:
+    return _make_repo(tmp_path / "agi", AGI)
+
+
+# ── STRONG → block ──────────────────────────────────────────────────────
+
+def test_firmware_add_blocks(agi_repo, topology):
+    _write(agi_repo, "firmware/boot.py")
+    r = _run("git add firmware/boot.py", agi_repo, topology)
+    assert r.returncode == 2
+    assert "GENesis-Voice" in r.stderr and "firmware/boot.py" in r.stderr
+
+
+def test_staged_firmware_commit_blocks(agi_repo, topology):
+    _write(agi_repo, "esphome/device.yaml", "esphome:\n  name: x\n")
+    subprocess.run(["git", "-C", str(agi_repo), "add", "esphome/device.yaml"], check=True)
+    r = _run("git commit -m 'add device'", agi_repo, topology)
+    assert r.returncode == 2
+    assert "GENesis-Voice" in r.stderr
+
+
+def test_add_dot_porcelain_blocks(agi_repo, topology):
+    _write(agi_repo, "s2s_bridge/app.py")
+    _write(agi_repo, "README.md")
+    r = _run("git add .", agi_repo, topology)
+    assert r.returncode == 2
+    assert "s2s_bridge/app.py" in r.stderr
+
+
+def test_glob_flash_script_blocks(agi_repo, topology):
+    _write(agi_repo, "scripts/flash_device.sh", "#!/bin/sh\n")
+    r = _run("git add scripts/flash_device.sh", agi_repo, topology)
+    assert r.returncode == 2
+
+
+def test_content_marker_new_file_blocks(agi_repo, topology):
+    # Path has no marker segment, but content does (ESP32) — new file only.
+    _write(agi_repo, "src/genesis/hardware/driver.py", "# ESP32 pin config\n")
+    r = _run("git add src/genesis/hardware/driver.py", agi_repo, topology)
+    assert r.returncode == 2
+
+
+def test_worktree_dash_C_blocks(agi_repo, topology, tmp_path):
+    # Run the guard from an unrelated cwd; target the repo via `git -C`.
+    _write(agi_repo, "omi/connector.py")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    r = _run(f"git -C {agi_repo} add omi/connector.py", elsewhere, topology)
+    assert r.returncode == 2
+
+
+def test_cd_prefix_blocks(agi_repo, topology, tmp_path):
+    _write(agi_repo, "ambient_bridge/x.py")
+    elsewhere = tmp_path / "elsewhere2"
+    elsewhere.mkdir()
+    r = _run(f"cd {agi_repo} && git add ambient_bridge/x.py", elsewhere, topology)
+    assert r.returncode == 2
+
+
+# ── WEAK → advisory (exit 0, additionalContext) ─────────────────────────
+
+def test_weak_marker_advises(agi_repo, topology):
+    _write(agi_repo, "docs/satellite/notes.md")
+    r = _run("git add docs/satellite/notes.md", agi_repo, topology)
+    assert r.returncode == 0
+    ctx = json.loads(r.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "GENesis-Voice" in ctx and "satellite" in ctx
+
+
+# ── allow_paths silence WEAK, clean files silent ────────────────────────
+
+def test_allow_path_voice_api_silent(agi_repo, topology):
+    _write(agi_repo, "dashboard/routes/voice_api.py")
+    r = _run("git add dashboard/routes/voice_api.py", agi_repo, topology)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_allow_path_channels_voice_silences_weak(agi_repo, topology):
+    # 'edge' is a weak marker, but channels/voice/ is allow-listed.
+    _write(agi_repo, "src/genesis/channels/voice/edge_client.py")
+    r = _run("git add src/genesis/channels/voice/edge_client.py", agi_repo, topology)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_clean_agi_file_silent(agi_repo, topology):
+    _write(agi_repo, "src/genesis/memory/retrieval.py")
+    r = _run("git add src/genesis/memory/retrieval.py", agi_repo, topology)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_strong_still_fires_under_allow_path(agi_repo, topology):
+    # channels/voice/ is allow-listed but s2s_bridge is a STRONG marker: the
+    # wrong-repo component name still blocks (this IS the incident shape).
+    _write(agi_repo, "src/genesis/channels/voice/s2s_bridge/app.py")
+    r = _run("git add src/genesis/channels/voice/s2s_bridge/app.py", agi_repo, topology)
+    assert r.returncode == 2
+
+
+# ── override ────────────────────────────────────────────────────────────
+
+def test_override_bypasses(agi_repo, topology):
+    _write(agi_repo, "firmware/boot.py")
+    r = _run("git add firmware/boot.py  # repo-routing-override", agi_repo, topology)
+    assert r.returncode == 0
+    assert "override acknowledged" in r.stderr
+
+
+# ── fail-open cases (all exit 0) ────────────────────────────────────────
+
+def test_non_git_command_passes(agi_repo, topology):
+    assert _run("ls -la", agi_repo, topology).returncode == 0
+
+
+def test_non_add_commit_git_passes(agi_repo, topology):
+    _write(agi_repo, "firmware/boot.py")
+    assert _run("git status", agi_repo, topology).returncode == 0
+
+
+def test_empty_topology_fails_open(agi_repo, tmp_path):
+    # A topology with no repos declared must not guard (fail-open).
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("version: 1\nrepos: {}\n")
+    _write(agi_repo, "firmware/boot.py")
+    r = _run("git add firmware/boot.py", agi_repo, str(empty))
+    assert r.returncode == 0
+
+
+def test_missing_topology_falls_back_to_in_repo(agi_repo, tmp_path):
+    # A bad REPO_TOPOLOGY_PATH falls back to the in-repo config, which still
+    # guards — the guard is never silently disabled by a stale env var.
+    _write(agi_repo, "firmware/boot.py")
+    r = _run("git add firmware/boot.py", agi_repo, str(tmp_path / "nope.yaml"))
+    assert r.returncode == 2
+
+
+def test_malformed_tool_input_fails_open(agi_repo, topology):
+    env = {**os.environ, "CLAUDE_TOOL_INPUT": "{not json",
+           "REPO_TOPOLOGY_PATH": topology}
+    r = subprocess.run([sys.executable, str(_guard_script())], env=env,
+                       cwd=str(agi_repo), capture_output=True, text=True, timeout=20)
+    assert r.returncode == 0
+
+
+def test_unknown_repo_fails_open(tmp_path, topology):
+    other = _make_repo(tmp_path / "other", "https://github.com/someone/unrelated.git")
+    _write(other, "firmware/boot.py")
+    r = _run("git add firmware/boot.py", other, topology)
+    assert r.returncode == 0
+
+
+def test_no_remote_fails_open(tmp_path, topology):
+    repo = tmp_path / "noremote"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _write(repo, "firmware/boot.py")
+    r = _run("git add firmware/boot.py", repo, topology)
+    assert r.returncode == 0
+
+
+def test_empty_tool_input_passes(agi_repo, topology):
+    env = {**os.environ, "REPO_TOPOLOGY_PATH": topology}
+    env.pop("CLAUDE_TOOL_INPUT", None)
+    r = subprocess.run([sys.executable, str(_guard_script())], env=env,
+                       cwd=str(agi_repo), capture_output=True, text=True, timeout=20)
+    assert r.returncode == 0

--- a/tests/test_hooks/test_repo_routing_guard.py
+++ b/tests/test_hooks/test_repo_routing_guard.py
@@ -60,8 +60,8 @@ def _make_repo(path: Path, origin: str) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True)
     subprocess.run(["git", "-C", str(path), "remote", "add", "origin", origin], check=True)
-    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t.io"], check=True)
-    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "test"], check=True)
     return path
 
 

--- a/tests/test_hooks/test_repo_routing_guard.py
+++ b/tests/test_hooks/test_repo_routing_guard.py
@@ -188,6 +188,84 @@ def test_strong_still_fires_under_allow_path(agi_repo, topology):
     assert r.returncode == 2
 
 
+# ── compound-command parsing (review findings 1-3) ──────────────────────
+
+def test_semicolon_in_commit_message_still_detects(agi_repo, topology):
+    # A ';' inside the -m message must NOT be treated as a command separator.
+    _write(agi_repo, "esphome/device.yaml", "esphome:\n")
+    subprocess.run(["git", "-C", str(agi_repo), "add", "esphome/device.yaml"], check=True)
+    r = _run('git commit -m "add esphome device; then wire it in"', agi_repo, topology)
+    assert r.returncode == 2
+
+
+def test_chained_adds_second_is_checked(agi_repo, topology):
+    _write(agi_repo, "README.md")
+    _write(agi_repo, "firmware/boot.py")
+    r = _run("git add README.md && git add firmware/boot.py", agi_repo, topology)
+    assert r.returncode == 2
+    assert "firmware/boot.py" in r.stderr
+
+
+def test_add_then_commit_all_chained(agi_repo, topology):
+    # `git add safe && git commit -am` — the commit stage must still be checked.
+    _write(agi_repo, "firmware/boot.py")
+    subprocess.run(["git", "-C", str(agi_repo), "add", "firmware/boot.py"], check=True)
+    _write(agi_repo, "notes.txt")
+    r = _run("git add notes.txt && git commit -m done", agi_repo, topology)
+    assert r.returncode == 2
+
+
+def test_newline_separated_cd_then_git(agi_repo, topology, tmp_path):
+    _write(agi_repo, "firmware/boot.py")
+    elsewhere = tmp_path / "nl"
+    elsewhere.mkdir()
+    r = _run(f"cd {agi_repo}\ngit add firmware/boot.py", elsewhere, topology)
+    assert r.returncode == 2
+
+
+# ── content-marker false positives (review finding 4) ───────────────────
+
+def test_ruleset_config_not_content_blocked(agi_repo, topology):
+    # A file literally named repo_topology.yaml (contains markers as data) must
+    # not self-block on content scan.
+    _write(agi_repo, "config/repo_topology.yaml",
+           'strong_content_markers: ["ESP32", "esphome:", "platformio"]\n')
+    r = _run("git add config/repo_topology.yaml", agi_repo, topology)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+
+def test_test_file_with_markers_not_content_blocked(agi_repo, topology):
+    _write(agi_repo, "tests/test_x.py", "# fixture mentions ESP32 and platformio\n")
+    r = _run("git add tests/test_x.py", agi_repo, topology)
+    assert r.returncode == 0
+
+
+def test_doc_with_markers_not_content_blocked(agi_repo, topology):
+    _write(agi_repo, "docs/hardware.md", "The ESP32 runs esphome: firmware.\n")
+    r = _run("git add docs/hardware.md", agi_repo, topology)
+    assert r.returncode == 0
+
+
+def test_code_file_with_markers_still_blocks(agi_repo, topology):
+    # Control: real code (not prose/tests/config) with a content marker still blocks.
+    _write(agi_repo, "src/genesis/hw/driver.py", "# ESP32 pinout\n")
+    r = _run("git add src/genesis/hw/driver.py", agi_repo, topology)
+    assert r.returncode == 2
+
+
+# ── deletions are never blocked (review finding 5) ──────────────────────
+
+def test_deleting_foreign_file_not_blocked(agi_repo, topology):
+    # Removing wrong-repo content (the incident cleanup) must never be blocked.
+    _write(agi_repo, "firmware/boot.py")
+    subprocess.run(["git", "-C", str(agi_repo), "add", "firmware/boot.py"], check=True)
+    subprocess.run(["git", "-C", str(agi_repo), "commit", "-q", "-m", "seed"], check=True)
+    subprocess.run(["git", "-C", str(agi_repo), "rm", "-q", "firmware/boot.py"], check=True)
+    r = _run("git commit -m 'remove firmware'", agi_repo, topology)
+    assert r.returncode == 0
+
+
 # ── override ────────────────────────────────────────────────────────────
 
 def test_override_bypasses(agi_repo, topology):


### PR DESCRIPTION
## Problem

The OMI incident (2026-07): a session built edge-device software (esphome / firmware / s2s_bridge) into the AGI codebase, blind to the separate GENesis-Voice repo. Nothing deterministic caught it.

## What this adds

A `PreToolUse(Bash)` hook (`scripts/hooks/repo_routing_guard.py`) that, on `git add` / `git commit`, identifies the current repo by its `origin` remote via `config/repo_topology.yaml`, then classifies staged/added files against **other** repos' signatures:

- **STRONG** match (foreign path segment, glob, or a content marker in a *new* file) → **block** (exit 2) with the target repo named + an override hint.
- **WEAK** match → advisory (`additionalContext`, exit 0).
- `allow_paths` silence WEAK for legitimately-internal paths (e.g. `channels/voice/`); STRONG still fires (a foreign component name landing under an allow-path is still the mistake).

Robust to `git -C <dir>`, `cd X && git …`, chained commands (`a && b`), newline-separated commands, quoted `-m` messages, and `git add .`/dirs/globs (files resolved via `git status --porcelain --untracked-files=all`). Deletions are never blocked (removing wrong-repo content is the *fix*). Content markers scan code only, not prose/tests/the ruleset (`content_scan_exclude`). **Fail-open everywhere** — the guard can never block a legitimate commit; override with `# repo-routing-override`.

Topology resolution: `$REPO_TOPOLOGY_PATH` → `~/.genesis/config/repo_topology.yaml` → in-repo `config/repo_topology.yaml` (template/fallback). Wired in `.claude/settings.json` after `git_push_guard` (timeout 2000).

## Verification

- **30 tests** (`tests/test_hooks/test_repo_routing_guard.py`): STRONG/WEAK/allow/override/worktree-`-C`/`cd`/porcelain, chained + newline + semicolon-in-message parsing, content-marker false-positive guards, deletion cleanup, and 6 fail-open paths. All pass, ruff clean.
- E2E verified through the real `genesis-hook` wrapper (firmware add → block; deletion cleanup → allow; chained add → block).
- Two independent adversarial review passes: the first found 5 real bugs (now fixed with tests); the re-review of the fix delta was clean.