### PR TITLE
fix(metrics): un-blind outreach engagement grading (WS-1 A1)

### DIFF
--- a/src/genesis/calibration/reconciler.py
+++ b/src/genesis/calibration/reconciler.py
@@ -7,6 +7,7 @@ import logging
 import aiosqlite
 
 from genesis.db.crud import predictions as pred_crud
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
 
 logger = logging.getLogger(__name__)
 
@@ -40,10 +41,11 @@ class PredictionReconciler:
                 continue
             if outcome == "ambivalent":
                 continue  # neutral implicit-activity signal — not gradeable
-            # Positive engagement set (mirrors feedback.harvest._OUTREACH_MAP).
-            # Was `outcome == "engaged"`, a value never written to the column,
-            # so every outreach prediction was graded incorrect unconditionally.
-            correct = outcome in ("useful", "acted_on", "acknowledged")
+            # Was `outcome == "engaged"` alone. 'engaged' IS written (dashboard
+            # /engage endpoint) but a real reply writes 'useful' — so every
+            # reply-engaged prediction was graded incorrect. Use the canonical
+            # positive set so no real engagement value is missed.
+            correct = outcome in POSITIVE_ENGAGEMENT_OUTCOMES
             await pred_crud.record_outcome(
                 self._db, pred["id"], outcome=outcome, correct=correct,
             )

--- a/src/genesis/calibration/reconciler.py
+++ b/src/genesis/calibration/reconciler.py
@@ -23,7 +23,7 @@ class PredictionReconciler:
         for pred in unmatched:
             action_id = pred["action_id"]
             cursor = await self._db.execute(
-                "SELECT engagement_outcome FROM outreach_history "
+                "SELECT engagement_outcome, engagement_signal FROM outreach_history "
                 "WHERE id = ? AND engagement_outcome IS NOT NULL",
                 (action_id,),
             )
@@ -31,7 +31,19 @@ class PredictionReconciler:
             if not row:
                 continue
             outcome = row[0] if isinstance(row, tuple) else row["engagement_outcome"]
-            correct = outcome == "engaged"
+            signal = row[1] if isinstance(row, tuple) else row["engagement_signal"]
+            # No-reply (the 24h timeout) is not a graded outcome: silence is
+            # unresolved, not a wrong prediction (WS-0: "ignored" != no value).
+            # An explicit dismissal via the outreach_engagement tool carries a
+            # non-'timeout' signal and is still graded below.
+            if outcome == "ignored" and signal == "timeout":
+                continue
+            if outcome == "ambivalent":
+                continue  # neutral implicit-activity signal — not gradeable
+            # Positive engagement set (mirrors feedback.harvest._OUTREACH_MAP).
+            # Was `outcome == "engaged"`, a value never written to the column,
+            # so every outreach prediction was graded incorrect unconditionally.
+            correct = outcome in ("useful", "acted_on", "acknowledged")
             await pred_crud.record_outcome(
                 self._db, pred["id"], outcome=outcome, correct=correct,
             )

--- a/src/genesis/db/crud/outreach.py
+++ b/src/genesis/db/crud/outreach.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import aiosqlite
 
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
+
+# SQL IN-list of positive engagement values (trusted constants, safe to inline).
+_POSITIVE_IN = ", ".join(f"'{o}'" for o in sorted(POSITIVE_ENGAGEMENT_OUTCOMES))
+
 
 async def create(
     db: aiosqlite.Connection,
@@ -154,9 +159,9 @@ async def get_engagement_stats(db: aiosqlite.Connection, *, days: int = 7) -> di
     Returns: {total, engaged, ignored, ambivalent, pending}
     """
     cursor = await db.execute(
-        """SELECT
+        f"""SELECT
             COUNT(*) AS total,
-            SUM(CASE WHEN engagement_outcome = 'useful' THEN 1 ELSE 0 END) AS engaged,
+            SUM(CASE WHEN engagement_outcome IN ({_POSITIVE_IN}) THEN 1 ELSE 0 END) AS engaged,
             SUM(CASE WHEN engagement_outcome = 'ignored' THEN 1 ELSE 0 END) AS ignored,
             SUM(CASE WHEN engagement_outcome = 'ambivalent' THEN 1 ELSE 0 END) AS ambivalent,
             SUM(CASE WHEN engagement_outcome IS NULL THEN 1 ELSE 0 END) AS pending

--- a/src/genesis/db/crud/outreach.py
+++ b/src/genesis/db/crud/outreach.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import aiosqlite
 
-from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
-
-# SQL IN-list of positive engagement values (trusted constants, safe to inline).
-_POSITIVE_IN = ", ".join(f"'{o}'" for o in sorted(POSITIVE_ENGAGEMENT_OUTCOMES))
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_SQL_IN as _POSITIVE_IN
 
 
 async def create(

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -280,7 +280,7 @@ class OutcomeHarvester:
     async def _harvest_outreach(self, cutoff: str | None) -> int:
         """outreach_history → outreach_reply (T2) / outreach_implicit (T3)."""
         sql = (
-            "SELECT id, engagement_outcome, user_response, category, "
+            "SELECT id, engagement_outcome, engagement_signal, user_response, category, "
             "       prediction_error, delivered_at, created_at "
             "FROM outreach_history "
             "WHERE engagement_outcome IS NOT NULL AND trim(engagement_outcome) != ''"
@@ -297,7 +297,14 @@ class OutcomeHarvester:
         inserted = 0
         for raw in rows:
             r = dict(zip(cols, raw, strict=False))
-            mapping = _OUTREACH_MAP.get((r["engagement_outcome"] or "").strip())
+            outcome = (r["engagement_outcome"] or "").strip()
+            # No-reply (24h timeout) carries no value signal — silence is not a
+            # negative (WS-0: "ignored" != no value). An explicit dismissal via
+            # the outreach_engagement tool has a non-'timeout' signal and still
+            # maps through _OUTREACH_MAP below.
+            if outcome == "ignored" and (r.get("engagement_signal") or "").strip() == "timeout":
+                continue
+            mapping = _OUTREACH_MAP.get(outcome)
             if mapping is None:
                 continue  # empty / unknown engagement value — no real signal
             signal_type, polarity, value = mapping

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -74,8 +74,12 @@ _SUFFIX_MAP = (
 # signals) — a pre-existing outreach schema/data drift, tracked separately. We map
 # what actually exists; explicit > implicit-negative defaulting (which would
 # mislabel acted_on/acknowledged and the empty-string rows).
+# Positive keys must stay in sync with genesis.outreach.types
+# .POSITIVE_ENGAGEMENT_OUTCOMES ('engaged' is written by the dashboard /engage
+# endpoint and was previously dropped here, losing that positive signal).
 _OUTREACH_MAP: dict[str, tuple[str, str, float | None]] = {
     "useful":       ("outreach_reply", "positive", 1.0),
+    "engaged":      ("outreach_reply", "positive", 1.0),
     "acted_on":     ("outreach_reply", "positive", 1.0),
     "acknowledged": ("outreach_reply", "positive", 0.5),
     "not_useful":   ("outreach_reply", "negative", 0.0),

--- a/src/genesis/learning/signals/outreach_engagement.py
+++ b/src/genesis/learning/signals/outreach_engagement.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import aiosqlite
 
 from genesis.awareness.types import SignalReading
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
 
 
 class OutreachEngagementCollector:
@@ -35,10 +36,10 @@ class OutreachEngagementCollector:
                 baseline_note=note,
             )
         total = sum(r[1] for r in rows)
-        # Positive engagement set (mirrors feedback.harvest._OUTREACH_MAP). Was
-        # `r[0] == "engaged"`, a value never written to engagement_outcome, so
-        # this ratio was always 0.0 regardless of real engagement.
-        engaged = sum(r[1] for r in rows if r[0] in ("useful", "acted_on", "acknowledged"))
+        # Was `r[0] == "engaged"` alone, so a real reply ('useful') never counted
+        # and this ratio was ~0.0 regardless of true engagement. Use the canonical
+        # positive set (see genesis.outreach.types).
+        engaged = sum(r[1] for r in rows if r[0] in POSITIVE_ENGAGEMENT_OUTCOMES)
         value = engaged / total if total > 0 else 0.0
         return SignalReading(
             name=self.signal_name,

--- a/src/genesis/learning/signals/outreach_engagement.py
+++ b/src/genesis/learning/signals/outreach_engagement.py
@@ -35,7 +35,10 @@ class OutreachEngagementCollector:
                 baseline_note=note,
             )
         total = sum(r[1] for r in rows)
-        engaged = sum(r[1] for r in rows if r[0] == "engaged")
+        # Positive engagement set (mirrors feedback.harvest._OUTREACH_MAP). Was
+        # `r[0] == "engaged"`, a value never written to engagement_outcome, so
+        # this ratio was always 0.0 regardless of real engagement.
+        engaged = sum(r[1] for r in rows if r[0] in ("useful", "acted_on", "acknowledged"))
         value = engaged / total if total > 0 else 0.0
         return SignalReading(
             name=self.signal_name,

--- a/src/genesis/observability/snapshots/outreach.py
+++ b/src/genesis/observability/snapshots/outreach.py
@@ -5,16 +5,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_SQL_IN as _POSITIVE_IN
 
 if TYPE_CHECKING:
     import aiosqlite
 
 logger = logging.getLogger(__name__)
-
-# SQL IN-list of positive engagement values, sorted for deterministic queries.
-# Values are trusted module constants (no user input) — safe to inline.
-_POSITIVE_IN = ", ".join(f"'{o}'" for o in sorted(POSITIVE_ENGAGEMENT_OUTCOMES))
 
 
 async def outreach_stats(db: aiosqlite.Connection | None) -> dict:

--- a/src/genesis/observability/snapshots/outreach.py
+++ b/src/genesis/observability/snapshots/outreach.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
+
 if TYPE_CHECKING:
     import aiosqlite
 
 logger = logging.getLogger(__name__)
+
+# SQL IN-list of positive engagement values, sorted for deterministic queries.
+# Values are trusted module constants (no user input) — safe to inline.
+_POSITIVE_IN = ", ".join(f"'{o}'" for o in sorted(POSITIVE_ENGAGEMENT_OUTCOMES))
 
 
 async def outreach_stats(db: aiosqlite.Connection | None) -> dict:
@@ -17,11 +23,11 @@ async def outreach_stats(db: aiosqlite.Connection | None) -> dict:
 
     try:
         cursor = await db.execute(
-            """SELECT
+            f"""SELECT
                 COUNT(*) as total,
                 COUNT(delivered_at) as delivered,
                 SUM(CASE WHEN engagement_signal = 'user_reply' THEN 1 ELSE 0 END) as responded,
-                SUM(CASE WHEN engagement_outcome IN ('useful', 'engaged') THEN 1 ELSE 0 END) as engaged
+                SUM(CASE WHEN engagement_outcome IN ({_POSITIVE_IN}) THEN 1 ELSE 0 END) as engaged
             FROM outreach_history
             WHERE created_at >= datetime('now', '-7 days')
               AND category != 'digest'"""

--- a/src/genesis/outreach/api.py
+++ b/src/genesis/outreach/api.py
@@ -7,6 +7,8 @@ from functools import wraps
 
 from flask import Blueprint, jsonify, request
 
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
+
 logger = logging.getLogger(__name__)
 
 outreach_api = Blueprint("outreach_api", __name__, url_prefix="/api/genesis/outreach")
@@ -68,11 +70,14 @@ async def get_engagement():
     rows = await cursor.fetchall()
     summary = {r[0]: r[1] for r in rows}
     total = sum(summary.values())
+    # Count every positive engagement value, not just the literal 'engaged'
+    # (see genesis.outreach.types.POSITIVE_ENGAGEMENT_OUTCOMES).
+    engaged = sum(summary.get(k, 0) for k in POSITIVE_ENGAGEMENT_OUTCOMES)
     return jsonify({
         "period": "7d",
         "total": total,
         "breakdown": summary,
-        "engagement_rate": summary.get("engaged", 0) / total if total else 0,
+        "engagement_rate": engaged / total if total else 0,
     })
 
 

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -53,6 +53,13 @@ POSITIVE_ENGAGEMENT_OUTCOMES: frozenset[str] = frozenset(
     {"useful", "engaged", "acted_on", "acknowledged"}
 )
 
+# SQL IN-list rendering of the positive set, sorted for deterministic queries.
+# Values are trusted module constants (no user input) — safe to inline into a
+# query string. Every SQL consumer references this instead of re-deriving it.
+POSITIVE_ENGAGEMENT_SQL_IN: str = ", ".join(
+    f"'{o}'" for o in sorted(POSITIVE_ENGAGEMENT_OUTCOMES)
+)
+
 
 class GovernanceVerdict(StrEnum):
     ALLOW = "allow"

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -39,6 +39,21 @@ class OutreachStatus(StrEnum):
     HELD = "held"
 
 
+# Canonical set of engagement_outcome values that count as genuine POSITIVE
+# engagement, for grading and metrics. Writers drifted this vocabulary over time:
+# a reply writes 'useful', the dashboard /engage endpoint writes 'engaged', and
+# behavioural signals write 'acted_on'/'acknowledged'. Every consumer that scores
+# "did the user engage" MUST reference this ONE set — hardcoding it per-consumer is
+# exactly what caused the drift (the reconciler and the awareness collector
+# compared only 'engaged' and so mis-graded every real reply; harvest omitted
+# 'engaged'; the dashboard snapshot omitted acted_on/acknowledged). This is
+# deliberately NOT the inverse of the outreach spam-throttle, which counts
+# 'ignored' (a 24h no-reply) and is governed separately.
+POSITIVE_ENGAGEMENT_OUTCOMES: frozenset[str] = frozenset(
+    {"useful", "engaged", "acted_on", "acknowledged"}
+)
+
+
 class GovernanceVerdict(StrEnum):
     ALLOW = "allow"
     DENY = "deny"

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -62,18 +62,18 @@ async def _add_proposal(
 
 
 async def _add_outreach(
-    db, *, oid, engagement_outcome, user_response=None, category="notification",
-    prediction_error=None, delivered_at=None,
+    db, *, oid, engagement_outcome, engagement_signal=None, user_response=None,
+    category="notification", prediction_error=None, delivered_at=None,
 ):
     delivered_at = delivered_at or _recent(hours=1)
     await db.execute(
         "INSERT INTO outreach_history "
         "(id, signal_type, topic, category, salience_score, channel, "
-        " message_content, engagement_outcome, user_response, prediction_error, "
-        " delivered_at, created_at) "
-        "VALUES (?, 'sig', 'topic', ?, 0.5, 'telegram', 'msg', ?, ?, ?, ?, ?)",
-        (oid, category, engagement_outcome, user_response, prediction_error,
-         delivered_at, _recent(hours=2)),
+        " message_content, engagement_outcome, engagement_signal, user_response, "
+        " prediction_error, delivered_at, created_at) "
+        "VALUES (?, 'sig', 'topic', ?, 0.5, 'telegram', 'msg', ?, ?, ?, ?, ?, ?)",
+        (oid, category, engagement_outcome, engagement_signal, user_response,
+         prediction_error, delivered_at, _recent(hours=2)),
     )
     await db.commit()
 
@@ -242,6 +242,28 @@ class TestHarvestOutreach:
         await _add_outreach(db, oid="real", engagement_outcome="useful")
         await OutcomeHarvester(db).run_backfill()
         assert await oe.count(db) == 1  # only the real one
+
+    @pytest.mark.asyncio
+    async def test_noreply_timeout_is_skipped(self, db):
+        # A 24h no-reply (outcome='ignored', signal='timeout') carries no value
+        # signal — silence is not a negative (WS-0). It must NOT harvest a row.
+        await _add_outreach(
+            db, oid="nr", engagement_outcome="ignored", engagement_signal="timeout",
+        )
+        await _add_outreach(db, oid="real", engagement_outcome="useful")
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count(db) == 1  # only the useful one
+
+    @pytest.mark.asyncio
+    async def test_explicit_ignored_nontimeout_stays_negative(self, db):
+        # An explicit dismissal (non-'timeout' signal) is still a real negative.
+        await _add_outreach(
+            db, oid="dis", engagement_outcome="ignored", engagement_signal="user_dismiss",
+        )
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "outreach_implicit"
+        assert row["polarity"] == "negative"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -221,6 +221,7 @@ class TestHarvestOutreach:
         "outcome, exp_type, exp_polarity",
         [
             ("useful", "outreach_reply", "positive"),
+            ("engaged", "outreach_reply", "positive"),        # dashboard /engage writer
             ("acted_on", "outreach_reply", "positive"),       # was mislabeled negative
             ("acknowledged", "outreach_reply", "positive"),   # was mislabeled negative
             ("not_useful", "outreach_reply", "negative"),

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -10,12 +10,14 @@ import pytest
 from genesis.db.crud import ego as ego_crud
 from genesis.db.crud import outcome_events as oe
 from genesis.feedback.harvest import (
+    _OUTREACH_MAP,
     BACKFILL_MARKER,
     BACKFILL_VERSION,
     OutcomeHarvester,
     _marker_version,
     _parse_execution_suffix,
 )
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
 
 
 @pytest.fixture
@@ -527,3 +529,16 @@ class TestIdempotencyAndScheduling:
         # ...but backfill (all history) captures it.
         await OutcomeHarvester(db).run_backfill()
         assert await oe.count(db) == 1
+
+
+def test_outreach_map_covers_all_positive_outcomes():
+    """Forcing function: every positive engagement outcome must have an
+    _OUTREACH_MAP entry, or harvest silently drops it (mapping is None →
+    continue). This is the exact drift that caused the original bug — if a
+    value is added to POSITIVE_ENGAGEMENT_OUTCOMES without a matching harvest
+    mapping, this test fails instead of the signal vanishing in production."""
+    missing = POSITIVE_ENGAGEMENT_OUTCOMES - _OUTREACH_MAP.keys()
+    assert not missing, (
+        f"POSITIVE_ENGAGEMENT_OUTCOMES {sorted(missing)} have no _OUTREACH_MAP "
+        f"entry and would be silently dropped from harvest."
+    )

--- a/tests/test_calibration/test_reconciler.py
+++ b/tests/test_calibration/test_reconciler.py
@@ -157,6 +157,32 @@ async def test_reconcile_outreach_acted_on_is_correct(db):
 
 
 @pytest.mark.asyncio
+async def test_reconcile_outreach_ambivalent_is_skipped(db):
+    """An 'ambivalent' outcome (neutral implicit-activity signal) is not
+    gradeable — the reconciler skips it, leaving the prediction unmatched
+    rather than scoring it either way."""
+    now = datetime.now(UTC).isoformat()
+    await pred_crud.log_prediction(
+        db, id="pred-amb", action_id="outreach-amb",
+        prediction="user will engage", confidence=0.7,
+        confidence_bucket="0.7-0.8", domain="outreach", reasoning="t",
+    )
+    await outreach_crud.create(
+        db, id="outreach-amb", signal_type="surplus", topic="Amb",
+        category="surplus", salience_score=0.7, channel="telegram",
+        message_content="Hi", created_at=now,
+    )
+    await outreach_crud.record_delivery(db, "outreach-amb", delivered_at=now)
+    await outreach_crud.record_engagement(db, "outreach-amb", engagement_outcome="ambivalent", engagement_signal="implicit_activity")
+
+    count = await PredictionReconciler(db).reconcile_outreach()
+    assert count == 0  # ambivalent skipped, not graded
+
+    row = await pred_crud.get_by_id(db, "pred-amb")
+    assert row["outcome"] is None  # left unmatched
+
+
+@pytest.mark.asyncio
 async def test_reconcile_skips_already_matched(db):
     await pred_crud.log_prediction(
         db, id="pred-3", action_id="outreach-ghi",

--- a/tests/test_calibration/test_reconciler.py
+++ b/tests/test_calibration/test_reconciler.py
@@ -16,6 +16,12 @@ async def db():
     conn = await aiosqlite.connect(":memory:")
     conn.row_factory = aiosqlite.Row
     await create_all_tables(conn)
+    # The engagement_outcome CHECK is a no-op in practice (NULL in its IN-list
+    # defeats enforcement), and prod carries drifted values ('engaged',
+    # 'acted_on', 'acknowledged'). Match tests/feedback/test_harvest.py and
+    # disable check enforcement so the fixture reproduces real data regardless
+    # of whether the CHECK is ever repaired.
+    await conn.execute("PRAGMA ignore_check_constraints = ON")
     yield conn
     await conn.close()
 
@@ -100,6 +106,31 @@ async def test_reconcile_outreach_explicit_ignored_is_incorrect(db):
     row = await pred_crud.get_by_id(db, "pred-x")
     assert row["outcome"] == "ignored"
     assert row["correct"] == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_outreach_engaged_dashboard_is_correct(db):
+    """The dashboard /engage endpoint writes engagement_outcome='engaged' — a
+    real positive that must grade correct (the original code only ever matched
+    'engaged', which is precisely why replies were mis-graded)."""
+    now = datetime.now(UTC).isoformat()
+    await pred_crud.log_prediction(
+        db, id="pred-e", action_id="outreach-e",
+        prediction="user will engage", confidence=0.8,
+        confidence_bucket="0.8-0.9", domain="outreach", reasoning="t",
+    )
+    await outreach_crud.create(
+        db, id="outreach-e", signal_type="surplus", topic="E",
+        category="surplus", salience_score=0.8, channel="telegram",
+        message_content="Hi", created_at=now,
+    )
+    await outreach_crud.record_delivery(db, "outreach-e", delivered_at=now)
+    await outreach_crud.record_engagement(db, "outreach-e", engagement_outcome="engaged", engagement_signal="dashboard")
+
+    count = await PredictionReconciler(db).reconcile_outreach()
+    assert count == 1
+    row = await pred_crud.get_by_id(db, "pred-e")
+    assert row["correct"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_calibration/test_reconciler.py
+++ b/tests/test_calibration/test_reconciler.py
@@ -21,7 +21,10 @@ async def db():
 
 
 @pytest.mark.asyncio
-async def test_reconcile_outreach_engaged(db):
+async def test_reconcile_outreach_useful_is_correct(db):
+    """A genuine reply ('useful') is a correct engagement prediction. Was
+    asserted against 'engaged' — a value never written to the column — so every
+    outreach prediction was graded incorrect regardless of the real outcome."""
     now = datetime.now(UTC).isoformat()
     await pred_crud.log_prediction(
         db, id="pred-1", action_id="outreach-abc",
@@ -35,19 +38,22 @@ async def test_reconcile_outreach_engaged(db):
         message_content="Hello", created_at=now,
     )
     await outreach_crud.record_delivery(db, "outreach-abc", delivered_at=now)
-    await outreach_crud.record_engagement(db, "outreach-abc", engagement_outcome="engaged", engagement_signal="reply")
+    await outreach_crud.record_engagement(db, "outreach-abc", engagement_outcome="useful", engagement_signal="user_reply")
 
     reconciler = PredictionReconciler(db)
     count = await reconciler.reconcile_outreach()
     assert count == 1
 
     row = await pred_crud.get_by_id(db, "pred-1")
-    assert row["outcome"] == "engaged"
+    assert row["outcome"] == "useful"
     assert row["correct"] == 1
 
 
 @pytest.mark.asyncio
-async def test_reconcile_outreach_ignored(db):
+async def test_reconcile_outreach_noreply_is_skipped(db):
+    """A 24h no-reply (outcome='ignored', signal='timeout') is unresolved, not a
+    wrong prediction — the reconciler must skip it, not grade it incorrect
+    (WS-0: 'ignored' != no value)."""
     now = datetime.now(UTC).isoformat()
     await pred_crud.log_prediction(
         db, id="pred-2", action_id="outreach-def",
@@ -65,11 +71,58 @@ async def test_reconcile_outreach_ignored(db):
 
     reconciler = PredictionReconciler(db)
     count = await reconciler.reconcile_outreach()
-    assert count == 1
+    assert count == 0  # no-reply skipped, not graded
 
     row = await pred_crud.get_by_id(db, "pred-2")
+    assert row["outcome"] is None  # left unmatched, not scored incorrect
+
+
+@pytest.mark.asyncio
+async def test_reconcile_outreach_explicit_ignored_is_incorrect(db):
+    """An explicit dismissal (outcome='ignored' with a non-'timeout' signal, e.g.
+    via the outreach_engagement tool) IS a real negative and gets graded."""
+    now = datetime.now(UTC).isoformat()
+    await pred_crud.log_prediction(
+        db, id="pred-x", action_id="outreach-x",
+        prediction="user will engage", confidence=0.6,
+        confidence_bucket="0.6-0.7", domain="outreach", reasoning="t",
+    )
+    await outreach_crud.create(
+        db, id="outreach-x", signal_type="surplus", topic="X",
+        category="surplus", salience_score=0.6, channel="telegram",
+        message_content="Hi", created_at=now,
+    )
+    await outreach_crud.record_delivery(db, "outreach-x", delivered_at=now)
+    await outreach_crud.record_engagement(db, "outreach-x", engagement_outcome="ignored", engagement_signal="user_dismiss")
+
+    count = await PredictionReconciler(db).reconcile_outreach()
+    assert count == 1
+    row = await pred_crud.get_by_id(db, "pred-x")
     assert row["outcome"] == "ignored"
     assert row["correct"] == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_outreach_acted_on_is_correct(db):
+    """The positive set includes behavioural signals beyond 'useful'."""
+    now = datetime.now(UTC).isoformat()
+    await pred_crud.log_prediction(
+        db, id="pred-a", action_id="outreach-a",
+        prediction="user will engage", confidence=0.8,
+        confidence_bucket="0.8-0.9", domain="outreach", reasoning="t",
+    )
+    await outreach_crud.create(
+        db, id="outreach-a", signal_type="surplus", topic="A",
+        category="surplus", salience_score=0.8, channel="telegram",
+        message_content="Hi", created_at=now,
+    )
+    await outreach_crud.record_delivery(db, "outreach-a", delivered_at=now)
+    await outreach_crud.record_engagement(db, "outreach-a", engagement_outcome="acted_on", engagement_signal="behavioural")
+
+    count = await PredictionReconciler(db).reconcile_outreach()
+    assert count == 1
+    row = await pred_crud.get_by_id(db, "pred-a")
+    assert row["correct"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_engagement_collector.py
+++ b/tests/test_outreach/test_engagement_collector.py
@@ -15,6 +15,10 @@ async def db():
     conn = await aiosqlite.connect(":memory:")
     conn.row_factory = aiosqlite.Row
     await create_all_tables(conn)
+    # engagement_outcome CHECK is a no-op and prod carries drifted values
+    # ('acted_on', 'acknowledged'); disable check enforcement for parity with
+    # real data (see tests/feedback/test_harvest.py).
+    await conn.execute("PRAGMA ignore_check_constraints = ON")
     yield conn
     await conn.close()
 
@@ -48,9 +52,10 @@ async def test_all_engaged_returns_high(db):
 
 @pytest.mark.asyncio
 async def test_positive_set_includes_behavioural(db):
-    """useful / acted_on / acknowledged all count as engaged (harvest's set)."""
+    """useful / engaged / acted_on / acknowledged all count as engaged
+    (the canonical POSITIVE_ENGAGEMENT_OUTCOMES set)."""
     now = datetime.now(UTC).isoformat()
-    for i, outcome in enumerate(["useful", "acted_on", "acknowledged"]):
+    for i, outcome in enumerate(["useful", "engaged", "acted_on", "acknowledged"]):
         await outreach_crud.create(
             db, id=f"p-{i}", signal_type="surplus", topic=f"P{i}",
             category="surplus", salience_score=0.8, channel="telegram",

--- a/tests/test_outreach/test_engagement_collector.py
+++ b/tests/test_outreach/test_engagement_collector.py
@@ -37,10 +37,29 @@ async def test_all_engaged_returns_high(db):
             message_content="Hi", created_at=now,
         )
         await outreach_crud.record_delivery(db, f"e-{i}", delivered_at=now)
-        await outreach_crud.record_engagement(db, f"e-{i}", engagement_outcome="engaged", engagement_signal="reply")
+        # 'useful' is the value a real reply writes — was 'engaged', a value
+        # never written, so this ratio used to be 0.0 no matter what.
+        await outreach_crud.record_engagement(db, f"e-{i}", engagement_outcome="useful", engagement_signal="user_reply")
 
     collector = OutreachEngagementCollector(db)
     reading = await collector.collect()
+    assert reading.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_positive_set_includes_behavioural(db):
+    """useful / acted_on / acknowledged all count as engaged (harvest's set)."""
+    now = datetime.now(UTC).isoformat()
+    for i, outcome in enumerate(["useful", "acted_on", "acknowledged"]):
+        await outreach_crud.create(
+            db, id=f"p-{i}", signal_type="surplus", topic=f"P{i}",
+            category="surplus", salience_score=0.8, channel="telegram",
+            message_content="Hi", created_at=now,
+        )
+        await outreach_crud.record_delivery(db, f"p-{i}", delivered_at=now)
+        await outreach_crud.record_engagement(db, f"p-{i}", engagement_outcome=outcome, engagement_signal="s")
+
+    reading = await OutreachEngagementCollector(db).collect()
     assert reading.value == 1.0
 
 
@@ -54,7 +73,7 @@ async def test_mixed_engagement(db):
             message_content="Hi", created_at=now,
         )
         await outreach_crud.record_delivery(db, f"eng-{i}", delivered_at=now)
-        await outreach_crud.record_engagement(db, f"eng-{i}", engagement_outcome="engaged", engagement_signal="reply")
+        await outreach_crud.record_engagement(db, f"eng-{i}", engagement_outcome="useful", engagement_signal="user_reply")
     for i in range(2):
         await outreach_crud.create(
             db, id=f"ign-{i}", signal_type="surplus", topic=f"I{i}",


### PR DESCRIPTION
## What

Un-blinds outreach **engagement** measurement (WS-1 "A1" — the Bench foundation). Two bug classes, one canonical fix, no schema migration, outreach throttle deliberately untouched.

### Bug 1 — always-false grading (dead/incomplete positive set)
Consumers compared `engagement_outcome == "engaged"` or `IN ('useful','engaged')`, but the real positive vocabulary is `{useful, engaged, acted_on, acknowledged}` (a reply writes `useful`; the dashboard `/engage` endpoint writes `engaged`; behavioural signals write `acted_on`/`acknowledged`). Result: real replies were graded incorrect and engagement ratios undercounted.

The vocabulary had drifted across **six** independent consumers, each with its own incomplete copy. Rather than patch them individually (which is what let the drift happen), this defines one canonical set — `genesis.outreach.types.POSITIVE_ENGAGEMENT_OUTCOMES` — and routes every consumer through it:

- `calibration/reconciler.py` (prediction grading)
- `learning/signals/outreach_engagement.py` (awareness signal ratio)
- `feedback/harvest.py` (`_OUTREACH_MAP` omitted `engaged`)
- `observability/snapshots/outreach.py` (dashboard tile: missed `acted_on`/`acknowledged`)
- `db/crud/outreach.py` `get_engagement_stats` (morning report: `useful` only)
- `outreach/api.py` `/engagement` (rate: literal `engaged` only)

### Bug 2 — no-reply conflated with negative (WS-0 finding)
A 24h timeout writes `outcome='ignored', signal='timeout'` — the sole source of `ignored`. It was harvested as a **negative** learning signal and graded as a wrong prediction. The learning pipeline (harvest + reconciler) now treats no-reply (`ignored` + `timeout`) as **unknown** — skipped, not scored negative. An explicit dismissal via the `outreach_engagement` tool carries a non-`timeout` signal and is still a real negative.

The outreach spam-throttle (`governance.py`, counts `ignored`) is **not** changed — it keeps backing off on silence as outreach hygiene; only the *learning* interpretation changes.

## Why it matters (verified E2E on a copy of the live DB)
- **663 false-negative outreach signals** were sitting in the learning bus (no-reply treated as "user rejected"). Re-harvesting with the fix: **0 negative** (was 663), 196 neutral, 18 positive.
- `get_engagement_stats` engaged count: **18** (full positive set) vs the old `useful`-only **10**.

## Scope / deferrals
- **M12 (user-denied approvals)** → A2, where the intervention-rate metric consumes it (`rejected` already exists; `resolved_by` is free text — no schema change needed).
- **No-reply predictions accumulate unmatched** (reviewer finding #3): not a correctness regression — the calibration reader filters `outcome IS NOT NULL`, so they're correctly *excluded*, not mis-graded. A "resolved-as-unknown" state belongs with A2's calibration-reader rework.
- **The `engagement_outcome` CHECK is a no-op** (a `NULL` inside its `IN`-list defeats enforcement — verified). Tracked as a separate follow-up (needs a vocabulary decision + drifted-row reconciliation + table rebuild).

## Tests
Rewrote the tests that encoded the bug (they asserted the never-a-reply `engaged` vocabulary), added dashboard-`engaged` grading, no-reply-skip, explicit-dismissal-stays-negative, and full-positive-set coverage. Fixtures set `PRAGMA ignore_check_constraints=ON` for parity with the existing `test_harvest.py`. Targeted suites green locally.

Note: `test_health_mcp.py::TestBackupsEnabledHelper::{test_unset_everywhere,test_secrets_file_empty_value}` fail **identically on untouched `main`** in this environment (they detect a real local backup clone) — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
