### PR TITLE
docs: document GENesis-Voice repo across always-on docs

### DIFF
--- a/.claude/docs/your-genesis.md
+++ b/.claude/docs/your-genesis.md
@@ -7,7 +7,17 @@ organized as:
 
 Where Genesis development happens. Everyone clones this. PRs go here.
 Bugs get filed as issues here. This is the single source of truth for
-the codebase.
+the **cognitive core** codebase — voice and edge-device software lives in a
+separate repo (see below).
+
+## The voice / edge repo — `GENesis-Voice`
+
+Voice and edge-device software lives in its own repo, `GENesis-Voice`: OMI and
+Voice PE firmware, esphome device configs, the S2S / ambient audio bridges, and
+edge deployment. `GENesis-AGI` keeps only its **internal** channel code — the
+voice API route and channel adapters that run inside the core runtime. Rule of
+thumb: if a change is about flashing a device, an esphome config, or an
+edge/satellite bridge, it belongs in `GENesis-Voice`, not here.
 
 ## Your fork (private) — automatic
 
@@ -50,6 +60,7 @@ disk failure.
 |------|-------|-----|
 | Your customizations to code | Your fork, as git commits | Versioned, diffable, contributable upstream when desired |
 | Your memory / DB / secrets | Your backup repo, encrypted | Changes constantly; separating keeps code history clean |
+| Voice / edge-device software | The `GENesis-Voice` repo | Firmware, esphome, bridges, edge deploy — separate from the cognitive core |
 | Nothing | The public repo, from you directly | Public repo is shared; contribute via fork + PR |
 
 ## The contribution flow (decentralized bug fixing)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,10 @@ Genesis to research, summarize, write content, or do non-Genesis tasks).
 ## Your Genesis
 
 Your Genesis install is one operational system: the public `GENesis-AGI`
-codebase, your private fork for customizations, and your private
+codebase (the cognitive core), the public `GENesis-Voice` repo for
+voice/edge-device software (OMI + Voice PE firmware, esphome configs, S2S/
+ambient audio bridges, edge deploy — `GENesis-AGI` keeps only its internal
+channel code), your private fork for customizations, and your private
 `genesis-backups` repo for encrypted data. Full model:
 `.claude/docs/your-genesis.md`.
 

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -221,7 +221,7 @@ Every surface a human (or host process) talks to Genesis through.
 ```yaml subsystem-map
 entry: channels-interfaces
 modules: [channels, dashboard, mcp, hosting, browser, mail]
-verified: 9037d45b 2026-07-07
+verified: 8235a607 2026-07-08
 ```
 
 - **channels/**: adapter framework. Telegram (`bridge.py` =
@@ -229,7 +229,10 @@ verified: 9037d45b 2026-07-07
   OUTBOUND-only — inbound voice arrives via `dashboard/routes/voice_api.py`;
   uses `media_player.play_media`, never `assist_satellite.announce` which
   reopens the mic); Discord webhook; email SMTP. All env-gated. "OpenClaw" here
-  is only the MIT origin of the Telegram transport code.
+  is only the MIT origin of the Telegram transport code. Device/edge-side voice
+  software (firmware, esphome, S2S/ambient bridges, edge deploy) lives in the
+  separate `GENesis-Voice` repo — `channels/voice/` here is only the in-runtime
+  channel.
 - **dashboard/**: Flask blueprint at `/genesis` (~45 route modules);
   `_async_route` bridges sync Flask onto the runtime event loop; heartbeat
   thread detects degraded-but-alive Flask; web terminal.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -762,6 +762,7 @@ section is safe to hand-edit; install scripts preserve it.
 - **Working Repo**: (set by installer)
 - **Backups Repo**: (set by installer)
 - **Public Distribution**: (set by installer)
+- **Voice/Edge Repo**: (set by installer)
 <!-- end:github-config -->
 
 ## Personal Notes

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -1041,6 +1041,7 @@ section is safe to hand-edit; install scripts preserve it.
 - **Working Repo**: (set by installer)
 - **Backups Repo**: (set by installer)
 - **Public Distribution**: (set by installer)
+- **Voice/Edge Repo**: (set by installer)
 <!-- end:github-config -->
 
 ## Personal Notes

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1017,6 +1017,7 @@ section is safe to hand-edit; install scripts preserve it.
 - **Working Repo**: (set by installer)
 - **Backups Repo**: (set by installer)
 - **Public Distribution**: (set by installer)
+- **Voice/Edge Repo**: (set by installer)
 <!-- end:github-config -->
 
 ## Personal Notes


### PR DESCRIPTION
## What

Makes four always-on docs correct about the **GENesis-Voice** repo, so future sessions know voice/edge-device software lives in a separate repo — not in GENesis-AGI (the cognitive core). This is the documentation half of the OMI wrong-repo incident remediation (the deterministic backstop is the repo-routing guard, PR #961).

## Why

A prior session built edge-device software into GENesis-AGI, blind to the GENesis-Voice repo. Several always-on docs described GENesis-AGI as the "single source of truth," which is wrong for voice/edge work and actively contributed to the mis-routing. These edits scope that claim to the cognitive core and add an explicit "voice/edge → GENesis-Voice" pointer.

## Changes

- **`.claude/docs/your-genesis.md`** — scope "single source of truth" to the cognitive core; add a voice/edge repo section + table row.
- **`CLAUDE.md`** — "Your Genesis" paragraph now names the GENesis-Voice repo and what it holds vs. what GENesis-AGI keeps (internal channel code only).
- **`docs/architecture/CURRENT.md`** — voice-channel bullet clarifies device/edge software lives in GENesis-Voice; `verified:` stamp bumped to `8235a607 2026-07-08`.
- **`scripts/{bootstrap,host-setup,update}.sh`** — seed the install-config `Voice/Edge Repo` placeholder line so `~/.claude/CLAUDE.md` gets it on setup/update.

Docs-only. `check_subsystem_map.py` green; `bash -n` clean on the three scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)