### PR TITLE
feat(dashboard): P3 nav/layout — wrap tabs, clear footer, Comms, icon a11y

### DIFF
--- a/src/genesis/dashboard/templates/partials/chrome/header.html
+++ b/src/genesis/dashboard/templates/partials/chrome/header.html
@@ -11,7 +11,7 @@
 
     <!-- Error banner -->
     <div class="error-banner" x-show="$store.genesisDashboard.error" x-transition>
-      <span class="material-symbols-outlined">warning</span>
+      <span class="material-symbols-outlined" aria-hidden="true">warning</span>
       <span x-text="$store.genesisDashboard.error"></span>
     </div>
 
@@ -34,7 +34,7 @@
 
     <!-- Header -->
     <h1>
-      <span class="material-symbols-outlined">neurology</span>
+      <span class="material-symbols-outlined" aria-hidden="true">neurology</span>
       Genesis Dashboard
       <span style="margin-left: auto; display: flex; gap: 0.5rem; align-items: center;">
         <button @click="$store.genesisDashboard.restartBridge()"
@@ -48,7 +48,7 @@
                   x-text="$store.genesisDashboard._restartingHF ? 'Restarting...' : 'Restart ' + ($store.genesisDashboard.health.services.host_framework.name || 'Host')"></button>
         </template>
         <a href="#" @click.prevent="$store.genesisDashboard.navigateTo('chat')" class="back-link">
-          <span class="material-symbols-outlined" style="font-size:1rem">terminal</span>
+          <span class="material-symbols-outlined" style="font-size:1rem" aria-hidden="true">terminal</span>
           Terminal
         </a>
         <template x-if="$store.genesisDashboard.authEnabled">
@@ -66,7 +66,7 @@
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'overview' }"
               @click="location.hash = 'overview'">Overview</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'chat' }"
-              @click="location.hash = 'chat'">Chat</button>
+              @click="location.hash = 'chat'">Comms</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'work' }"
               @click="location.hash = 'work'">Work</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'follow-ups' }"

--- a/src/genesis/dashboard/webui/css/dashboard.css
+++ b/src/genesis/dashboard/webui/css/dashboard.css
@@ -141,7 +141,8 @@
       max-width: 1400px;
       width: 100%;
       margin: 0 auto;
-      padding: 1.5rem;
+      /* bottom padding clears the fixed 36px kill-switch footer (chrome/footer.html) */
+      padding: 1.5rem 1.5rem 56px;
       color: var(--color-text);
       font-family: var(--font-family);
     }
@@ -352,7 +353,8 @@
     }
     .genesis-tabs {
       display: flex;
-      gap: 0;
+      flex-wrap: wrap;
+      gap: 0.15rem 0;
       margin-bottom: 1.25rem;
       border-bottom: 1px solid var(--color-border);
     }


### PR DESCRIPTION
## What

Dashboard roadmap **P3 (Navigation & layout)** — pure template/CSS, no JS/route/hash changes. Four fixes, all grounded against a live 1280×720 measurement.

- **Tab bar overflow (core):** `.genesis-tabs` gets `flex-wrap: wrap` + a small row-gap so the 15 tabs wrap to a second row instead of clipping. Previously the flat `nowrap` bar overflowed its container and caused a **page-wide horizontal scroll**, with "Backup & Updates" clipped off the right edge at ≤1280px.
- **Pause-footer overlap:** `.genesis-dashboard` bottom padding `24px → 56px` to clear the fixed **36px** kill-switch footer that was overlapping the last card (Container card on Overview).
- **"Chat" → "Comms" label:** that tab is the comms hub (terminal + approvals + proposals + outreach). **Label text only** — the hash key `chat` is unchanged (it's referenced in 8+ call sites), so deep links and routing are untouched.
- **Icon a11y leak:** `aria-hidden="true"` on the decorative `material-symbols` icons in the chrome header, so ligature text (`neurology`/`terminal`/`warning`) no longer leaks into accessible names.

## Verification (live, at 1280×720)

Rules injected into the running dashboard and re-measured (nothing booted from the worktree):

| | before → after |
|---|---|
| page horizontal scroll | bodyScrollW 1318 → **1265** (= clientW) — gone |
| tab-bar clip | scrollW 1294 → **1217** (= clientW); wraps, "Backup & Updates" visible |
| footer clearance | padding-bottom 24px → **56px** (footer top y=684) |
| heading accessible name | "neurology Genesis Dashboard…" → **"Genesis Dashboard Restart Server Terminal"** |
| nav button | "Chat" → **"Comms"** |

No test asserts on the changed strings and nothing parses `header.html`/`dashboard.css`, so there's no unit coverage for these static assets — verified live instead. Definitive re-check at 1280 **and** 1024px will follow post-deploy.

## Scope

- The 07-06 audit's "dead left rail (~230px)" was **verified not-a-bug** and dropped — it's the `max-width:1400px; margin:0 auto` container's symmetric centering at >1400px viewports, not a defect.
- No guardian/host paths touched → no Host-Deploy Gate. Deploy is code-only (`systemctl --user restart genesis-server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)