### PR TITLE
fix(guardian): fall back to a writable work_dir so a misconfigured cc.work_dir can't blind the recovery brain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The Guardian's recovery brain no longer goes dark when its work directory is
+  misconfigured.** On some installs the Guardian's configured CC work dir points
+  at a path it can't create (e.g. a root-owned dir on an install that predates
+  the setup script) — which used to make its intelligent diagnosis fail mid-
+  incident and silently drop it to alert-only. It now falls back to a writable
+  state dir so the self-healing path keeps working.
+
 - **Asking Genesis to grow a disk or wait on your reply now works from a Claude
   Code session, not only from inside the running server.** The two tools that
   block on your Telegram reply (`provision_grow`, `outreach_send_and_wait`) need

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -57,6 +57,35 @@ def _host_mem_available_gib() -> float | None:
     return None
 
 
+_WORK_DIR_FALLBACK = "~/.local/state/genesis-guardian/cc-sessions"
+
+
+def _ensure_work_dir(configured: Path, fallback: Path | None = None) -> Path:
+    """Create the CC diagnosis work dir, returning the dir actually usable.
+
+    A vintage or misconfigured install may point ``cc.work_dir`` at a path this
+    process can't create (e.g. ``/var/lib/guardian-snapshots`` owned by root on
+    an install that predates the installer's mkdir/chown). A bare
+    ``work_dir.mkdir`` there raises mid-tick and drops the guardian to
+    alert-only — exactly the failure seen live during a freeze. Fall back to a
+    user-writable state dir so the diagnosis brain still runs.
+
+    If the fallback itself can't be created, the OSError propagates — with no
+    writable work dir anywhere, alert-only is the honest degradation.
+    """
+    fallback = fallback or Path(_WORK_DIR_FALLBACK).expanduser()
+    try:
+        configured.mkdir(parents=True, exist_ok=True)
+        return configured
+    except OSError as exc:
+        logger.warning(
+            "guardian cc.work_dir %s not creatable (%s) — falling back to %s",
+            configured, exc, fallback,
+        )
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+
+
 class CCDiagnosisError(Exception):
     """CC diagnosis failed with a specific, capturable reason."""
 
@@ -378,8 +407,7 @@ class DiagnosisEngine:
             diagnostic, signal_summary, container_name, briefing_context,
         )
         cc_path = str(Path(self._config.cc.path).expanduser())
-        work_dir = Path(self._config.cc.work_dir).expanduser()
-        work_dir.mkdir(parents=True, exist_ok=True)
+        work_dir = _ensure_work_dir(Path(self._config.cc.work_dir).expanduser())
 
         # Pre-flight: check disk space before launching CC.
         # CC diagnosis generates significant I/O against the genesis pool.

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -16,6 +16,7 @@ from genesis.guardian.config import GuardianConfig
 from genesis.guardian.diagnosis import (
     DiagnosisEngine,
     RecoveryAction,
+    _ensure_work_dir,
 )
 
 
@@ -289,3 +290,31 @@ def test_prompt_includes_essential_knowledge(tmp_path, monkeypatch):
     prompt = _build_diagnosis_prompt(snap, "test signal", "genesis")
     assert "Essential Knowledge" in prompt
     assert "approval gate fix" in prompt
+
+
+# ── _ensure_work_dir — guardian brain survives an uncreatable work_dir ──────
+def test_ensure_work_dir_uses_configured_when_creatable(tmp_path):
+    configured = tmp_path / "guardian-snapshots" / "cc-sessions"
+    got = _ensure_work_dir(configured, fallback=tmp_path / "fb")
+    assert got == configured and configured.is_dir()
+
+
+def test_ensure_work_dir_falls_back_when_configured_uncreatable(tmp_path):
+    # A file where a parent dir is expected → mkdir(parents=True) raises OSError
+    # (NotADirectoryError). Mirrors a root-owned/misconfigured cc.work_dir.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file, not a dir")
+    configured = blocker / "cc-sessions"
+    fallback = tmp_path / "state" / "cc-sessions"
+    got = _ensure_work_dir(configured, fallback=fallback)
+    assert got == fallback and fallback.is_dir()
+    assert not configured.exists()  # configured was never created
+
+
+def test_ensure_work_dir_propagates_when_fallback_also_uncreatable(tmp_path):
+    # No writable dir anywhere → OSError propagates (alert-only is the honest
+    # degradation; we must NOT silently return an unusable path).
+    blocker = tmp_path / "blocker"
+    blocker.write_text("file")
+    with pytest.raises(OSError):
+        _ensure_work_dir(blocker / "wd", fallback=blocker / "fb")


### PR DESCRIPTION
## What

`diagnosis.py` created the CC diagnosis work dir with a bare
`work_dir.mkdir(parents=True, exist_ok=True)` on the configured `cc.work_dir`.
On a vintage or misconfigured install that path can be **uncreatable** — e.g. a
root-owned `/var/lib/guardian-snapshots` on an install predating the setup
script's mkdir/chown. The mkdir then raised mid-tick and dropped the Guardian to
**alert-only** instead of running its intelligent diagnosis — the exact failure
observed live during a freeze (Guardian could detect + alert but not self-heal).

## Fix

Extract `_ensure_work_dir(configured, fallback)`:
1. try to create the configured dir → use it;
2. on `OSError`, log and fall back to `~/.local/state/genesis-guardian/cc-sessions`
   (always writable by the guardian user) → use that;
3. if the fallback is *also* uncreatable, the `OSError` propagates — with no
   writable work dir anywhere, alert-only is the honest degradation (we never
   silently return an unusable path).

## Scope note

This is the last genuinely-unbuilt sliver of the planned "F-detect" workstream.
The larger F-detect pieces (deploy/build **drift detection**, guardian-down
heartbeat recovery) already shipped via container-side `guardian/watchdog.py`
(+ #940), so this PR deliberately builds only the remaining gap rather than
duplicating that.

## Tests

`tests/test_guardian/test_diagnosis.py` — configured-dir-used, fallback-on-
uncreatable (verifies the configured path is never created and the fallback is),
and propagate-when-fallback-also-uncreatable. 25 file tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)