### PR TITLE
feat(eval): WS-1 A2 — first-class metric series (precision@3, approvals, goals, noise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Three new honesty-first metric series on the dashboard's compounding
+  panel, plus retrieval precision@3.** The weekly eval now tracks how your
+  approval gates actually get resolved (by you vs. auto-expired vs.
+  fail-closed cancels — unknown resolver values are surfaced, never silently
+  bucketed), goal completion (reports "no data yet" instead of a fake 0%
+  until goals actually close), and a noise/passivity view (stale follow-ups,
+  empty ego cycles, rejected-proposal clusters). Memory retrieval gains a
+  precision@3 series alongside precision@5, with judge changes marked as
+  series breaks. Trend arrows are now honest too: the arrow shows which way a
+  metric moved, while its color shows whether that's an improvement — a
+  rising noise metric no longer glows green.
+
 - **Genesis can now grow this VM's disk or RAM from the hypervisor — with your
   approval — to fix the one storage failure nothing else could.** When the
   container's storage pool has no room left to auto-expand into (the structural

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -360,7 +360,7 @@ Self-improvement loops and the instrumentation that keeps them honest.
 ```yaml subsystem-map
 entry: learning-evaluation
 modules: [learning, eval, experimentation, feedback, calibration]
-verified: 9037d45b 2026-07-07
+verified: b2fde2bb 2026-07-09
 ```
 
 - **learning/** is the de-facto cron host: `rt._learning_scheduler` registers
@@ -375,7 +375,15 @@ verified: 9037d45b 2026-07-07
   "cannot break production" contract — hooks must never raise) + weekly Sunday
   aggregation (hard 7-day window) + an on-demand batch judge as a surplus
   task. The model gauntlet is weekly but OFF by default (paid inference) and
-  NEVER auto-mutates the roster.
+  NEVER auto-mutates the roster. Nine snapshot dimensions: the original five
+  (memory/system/ego/cognitive/procedure) + cognitive_drift + three
+  snapshot-only WS-1 A2 series (approvals gate-throughput, goals scaffold,
+  noise/passivity). `run_weekly_aggregation` swallows per-dimension failures
+  silently — the registration test in `tests/test_eval/test_j9_eval.py` is
+  the guard; keep it in sync when adding a dimension. Resolver-origin
+  classification for the approvals series is canonical in
+  `db/crud/approval_requests.py classify_resolver` (free-text convention —
+  a new `resolved_by` writer must extend the prefix tuples + drift test).
 - **experimentation/**: Crucible A/B + Evo fan-out — on-demand via MCP tools
   only; **recommend-only is the safety invariant** (no autonomous promotion,
   no live-cognition writes; Bonferroni + held-out re-validation).

--- a/src/genesis/dashboard/routes/eval.py
+++ b/src/genesis/dashboard/routes/eval.py
@@ -10,7 +10,10 @@ from genesis.dashboard._blueprint import _async_route, blueprint
 
 logger = logging.getLogger(__name__)
 
-_DIMENSIONS = ("memory", "system", "ego", "cognitive", "procedure")
+_DIMENSIONS = (
+    "memory", "system", "ego", "cognitive", "procedure",
+    "approvals", "goals", "noise",
+)
 
 # Which metric to extract as the "headline" value per dimension
 _HEADLINE_METRIC = {
@@ -19,7 +22,38 @@ _HEADLINE_METRIC = {
     "ego": "approval_rate",
     "cognitive": "delta",
     "procedure": "success_rate",
+    "approvals": "user_resolved_rate",
+    "goals": "completion_rate",
+    "noise": "empty_ego_cycle_pct",
 }
+
+# Valence of a RISING headline value per dimension: True = improving,
+# False = degrading, None = direction-ambiguous. Drives trend_good (the
+# display color) while `trend` stays the factual direction of the value —
+# a rising noise metric must never render as improvement.
+_HIGHER_IS_BETTER = {
+    "memory": True,
+    "system": True,
+    "ego": True,
+    "cognitive": True,
+    "procedure": True,
+    # more human touch on approval gates = more oversight, not better/worse
+    "approvals": None,
+    "goals": True,
+    "noise": False,
+}
+
+
+def _trend_good(dim: str, trend: str) -> bool | None:
+    """Map a factual trend direction to a valence for the given dimension.
+
+    Returns None (neutral display) when the dimension's valence is ambiguous
+    or the trend is flat/insufficient.
+    """
+    higher_is_better = _HIGHER_IS_BETTER.get(dim, True)
+    if higher_is_better is None or trend not in ("up", "down"):
+        return None
+    return (trend == "up") == higher_is_better
 
 
 @blueprint.route("/api/genesis/metrics/compounding")
@@ -79,6 +113,7 @@ async def metrics_compounding():
             )
         else:
             data["trend"] = "insufficient_data"
+        data["trend_good"] = _trend_good(_dim, data["trend"])
 
     return jsonify({"dimensions": dimensions})
 

--- a/src/genesis/dashboard/templates/partials/tabs/internals.html
+++ b/src/genesis/dashboard/templates/partials/tabs/internals.html
@@ -472,15 +472,18 @@
                 <div style="display: flex; align-items: baseline; gap: 0.4rem;">
                   <span style="font-size: 1.1rem; font-weight: 700;"
                         x-text="data.current_value !== null ? (data.headline_metric === 'delta' ? (data.current_value >= 0 ? '+' : '') : '') + (data.current_value * 100).toFixed(1) + '%' : '—'"></span>
+                  <!-- Arrow = factual direction of the value; COLOR = valence
+                       (trend_good from the API: green improving, red degrading,
+                       gray neutral) \u2014 a rising noise metric must not render green. -->
                   <span style="font-size: 0.7rem;"
-                        :style="data.trend === 'up' ? 'color: #4caf50' : data.trend === 'down' ? 'color: #d9534f' : 'color: #888'"
+                        :style="data.trend_good === true ? 'color: #4caf50' : data.trend_good === false ? 'color: #d9534f' : 'color: #888'"
                         x-text="data.trend === 'up' ? '\u2191' : data.trend === 'down' ? '\u2193' : data.trend === 'flat' ? '\u2192' : '\u2026'"></span>
                 </div>
                 <!-- Sparkline: CSS bar chart (min-max normalized per series) -->
                 <div style="display: flex; align-items: flex-end; gap: 1px; height: 24px; margin-top: 0.3rem;">
                   <template x-for="(pt, i) in data.series" :key="i">
                     <div :style="(() => {
-                      const color = data.trend === 'up' ? 'rgba(76,175,80,0.5)' : data.trend === 'down' ? 'rgba(217,83,79,0.5)' : 'rgba(136,136,136,0.4)';
+                      const color = data.trend_good === true ? 'rgba(76,175,80,0.5)' : data.trend_good === false ? 'rgba(217,83,79,0.5)' : 'rgba(136,136,136,0.4)';
                       if (pt.value === null) return `flex:1; background:${color}; border-radius:1px; height:2px;`;
                       const vals = data.series.filter(p => p.value !== null).map(p => p.value);
                       const mn = Math.min(...vals), mx = Math.max(...vals);

--- a/src/genesis/db/crud/approval_requests.py
+++ b/src/genesis/db/crud/approval_requests.py
@@ -4,6 +4,58 @@ from __future__ import annotations
 
 import aiosqlite
 
+# ── Resolver-origin classification ───────────────────────────────────────────
+# ``resolved_by`` is free text written by convention, not constraint. This is
+# the ONE canonical mapping from resolved_by values to a resolver class —
+# consumers (J-9 approvals metrics, dashboards) must use it rather than
+# re-deriving prefixes. When adding a new resolved_by writer, extend the
+# prefix tuples AND tests/test_db/test_approval_resolver_classes.py (which
+# pins every known writer literal and the live-DB value inventory).
+#
+# Known writers as of 2026-07-09:
+#   human:  telegram:batch:/button:/bare_text: (channels/telegram/
+#           _handler_messages.py), <channel>:reply (autonomy/approval_gate.py),
+#           dashboard / dashboard:batch (dashboard/routes/state.py),
+#           voice:s2s (channels/voice/genesis_bridge.py),
+#           manual:* (operator sessions), "user" (autonomy/approval.py default)
+#   system: "system" (approval.py cancel()), timeout_auto_expire
+#           (approval_gate.py), alarm_cleared (sentinel/dispatcher.py),
+#           cleanup:* (housekeeping jobs)
+#   blank/None → system: bulk expiry (expire_timed_out below) never writes
+#           resolved_by — no human acted on those rows.
+HUMAN_RESOLVER_PREFIXES: tuple[str, ...] = (
+    "telegram:",
+    "dashboard",
+    "voice:",
+    "manual:",
+    "user",
+)
+SYSTEM_RESOLVER_PREFIXES: tuple[str, ...] = (
+    "system",
+    "timeout_auto_expire",
+    "cleanup:",
+    "alarm_cleared",
+)
+
+
+def classify_resolver(resolved_by: str | None) -> str:
+    """Classify a ``resolved_by`` value as ``human`` | ``system`` | ``unknown``.
+
+    Unmatched non-blank values return ``unknown`` — never guessed: the live DB
+    carries values with no in-tree writer (one-off manual DB fixes such as
+    ``manual_stale_cleanup``), and misclassifying a novel human channel as
+    system would silently deflate the human-resolution metrics. Consumers
+    surface unknowns rather than bucketing them.
+    """
+    if resolved_by is None or not resolved_by.strip():
+        return "system"
+    value = resolved_by.strip()
+    if value.startswith(HUMAN_RESOLVER_PREFIXES):
+        return "human"
+    if value.startswith(SYSTEM_RESOLVER_PREFIXES):
+        return "system"
+    return "unknown"
+
 
 async def create(
     db: aiosqlite.Connection,

--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -23,6 +23,14 @@ import json
 
 import aiosqlite
 
+# Canonical staleness cutoff: a discovered item still un-actuated after this
+# long is counted as a leak ("work goes here to die"). Shared by the
+# loop_closure_status MCP tool and the J-9 noise dimension — callers derive
+# their ISO ``stale_before`` cutoff from it (the query layer itself stays
+# deterministic; no wall-clock in here). 14d mirrors the morning report's
+# follow-up staleness rule.
+STALE_DAYS = 14
+
 # Session statuses where a skill's outcome is DETERMINABLE at all (so a
 # success-rate is computable) — the full terminal set, not just failures.
 # 'active'/'checkpointed'/'expired' are not terminal-for-outcome. NB:

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -648,9 +648,13 @@ async def _compute_approvals(
     )
     resolved = [dict(r) for r in await cursor.fetchall()]
 
+    # datetime() here too: production always passes ISO-T created_at, but the
+    # CRUD's COALESCE(?, datetime('now')) fallback writes space-format — a
+    # future caller omitting created_at must not dodge the window.
     cursor = await db.execute(
         "SELECT COUNT(*) FROM approval_requests "
-        "WHERE created_at >= ? AND created_at < ?",
+        "WHERE datetime(created_at) >= datetime(?) "
+        "AND datetime(created_at) < datetime(?)",
         (since, until),
     )
     total_created = (await cursor.fetchone())[0]

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -4,12 +4,15 @@ Runs on a weekly CronTrigger. Reads eval_events and existing DB tables
 to compute metrics for each dimension, stores results in eval_snapshots.
 
 Dimensions:
-1. Memory retrieval quality (precision@5, hit rate, MRR, usage rate)
+1. Memory retrieval quality (precision@5, precision@3, hit rate, MRR, usage rate)
 2. System improvement composite (session success, ego acceptance, etc.)
 3. Ego proposal quality (approval rate, confidence calibration)
 4. Cognitive loop value (recall vs no-recall session comparison)
 5. Procedural learning effectiveness (invocation rate, success rate)
 6. Cognitive drift (Phase 7, dark): dissent-rate + proposal-diversity
+7. Approvals (WS-1 A2): approval-gate resolution throughput
+8. Goals (WS-1 A2, scaffold): user_goals status ratios + completion rate
+9. Noise/passivity (WS-1 A2): loop-closure leaks + empty-ego-cycle rate
 """
 
 from __future__ import annotations
@@ -84,7 +87,7 @@ async def _compute_cognitive_drift(
 
 
 async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
-    """Compute and store weekly snapshots for all 5 eval dimensions + drift.
+    """Compute and store weekly snapshots for all eval dimensions.
 
     Returns dict of {dimension: metrics} for logging/inspection.
     """
@@ -101,6 +104,9 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
         ("cognitive", _compute_cognitive_loop),
         ("procedure", _compute_procedural_effectiveness),
         ("cognitive_drift", _compute_cognitive_drift),
+        ("approvals", _compute_approvals),
+        ("goals", _compute_goal_completion),
+        ("noise", _compute_noise_passivity),
     ]:
         try:
             metrics, sample_count = await fn(db, period_start, period_end)
@@ -247,7 +253,9 @@ async def _compute_memory_quality(
     relevance_events = _dedupe_by_pair(relevance_events)
 
     if not relevance_events:
-        return {"precision_at_5": None, "hit_rate": None, "mrr": None,
+        return {"precision_at_5": None, "precision_at_3": None,
+                "precision_at_3_recalls": 0, "judge_prompt_versions": [],
+                "hit_rate": None, "mrr": None,
                 "usage_rate": None, "total_recalls": 0, **entrenchment}, 0
 
     # Group by recall_event_id
@@ -260,6 +268,7 @@ async def _compute_memory_quality(
 
     # Compute per-recall metrics
     precisions = []
+    precisions_at_3 = []
     mrrs = []
     hits = 0
     total_recalls = len(by_recall)
@@ -270,8 +279,23 @@ async def _compute_memory_quality(
         # timestamp-DESC order, so list order is NOT the rank — without this sort
         # MRR is meaningless. Pre-fix historical events lack a rank → sort last.
         memories.sort(key=lambda m: m.get("rank", 1 << 30))
+        # Defensive top-5 cap: j9_batch judges memory_ids[:5], so post-dedup
+        # this is a no-op on well-formed data — but a malformed emitter must
+        # not inflate the "@5" denominator beyond 5.
+        memories = memories[:5]
         relevant_count = sum(1 for m in memories if m.get("relevance", 0) >= 0.5)
+        # Precision among judged (top-k of what was judged), NOT a hard-k
+        # denominator — preserves the historical precision_at_5 series.
         precisions.append(relevant_count / max(len(memories), 1))
+
+        # precision@3: only meaningful when every judged memory carries a real
+        # rank — for unranked pre-fix events the [:3] slice would be arbitrary.
+        # Denominator = min(3, judged); recalls skipped here are visible via
+        # precision_at_3_recalls vs total_recalls.
+        if all("rank" in m for m in memories):
+            top3 = memories[:3]
+            relevant_top3 = sum(1 for m in top3 if m.get("relevance", 0) >= 0.5)
+            precisions_at_3.append(relevant_top3 / max(len(top3), 1))
 
         # MRR: rank of first relevant result
         found_relevant = False
@@ -293,8 +317,22 @@ async def _compute_memory_quality(
     total_used = sum(1 for ev in used_events if ev.get("metrics", {}).get("used"))
     total_usage_checked = len(used_events)
 
+    # Judge-prompt versions seen in-window: a change here is a series break
+    # (precision@k is judge-rated; a reworded judge prompt shifts the series
+    # without any retrieval change). Pre-versioning events → "unversioned".
+    judge_prompt_versions = sorted({
+        (ev.get("metrics", {}) or {}).get("judge_prompt_version") or "unversioned"
+        for ev in relevance_events
+    })
+
     metrics = {
         "precision_at_5": round(sum(precisions) / len(precisions), 4) if precisions else None,
+        "precision_at_3": round(sum(precisions_at_3) / len(precisions_at_3), 4)
+        if precisions_at_3 else None,
+        # Coverage: recalls that qualified for the @3 metric (fully ranked)
+        # vs total_recalls — thin coverage must be visible, not hidden.
+        "precision_at_3_recalls": len(precisions_at_3),
+        "judge_prompt_versions": judge_prompt_versions,
         "hit_rate": round(hits / total_recalls, 4) if total_recalls else None,
         "mrr": round(sum(mrrs) / len(mrrs), 4) if mrrs else None,
         "usage_rate": round(total_used / total_usage_checked, 4) if total_usage_checked else None,
@@ -565,6 +603,260 @@ async def _compute_procedural_effectiveness(
         "confidence_calibration": calibration,
     }
     return metrics, invocation_count + outcome_total
+
+
+# ── Dimension 7: Approval-Gate Throughput (WS-1 A2) ──────────────────────────
+
+# The self-approval churn class: background sessions requesting CLI fallback
+# via the fail-closed gate (autonomy/approval_gate.py). 86% of all rows at
+# time of writing — excluded views are reported alongside, never alone.
+_CHURN_ACTION_TYPE = "autonomous_cli_fallback"
+
+
+async def _compute_approvals(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Approval-request resolution metrics over ``approval_requests``.
+
+    Measures GATE THROUGHPUT — how designed approval gates get resolved and
+    by whom — NOT corrective intervention: genuinely corrective user action
+    (mid-course correction via chat) never lands in this table, so no single
+    "intervention rate" headline is derived from it.
+
+    Honesty notes baked into the shape:
+    - resolver classes come from the ONE canonical ``classify_resolver``
+      (db/crud/approval_requests.py); unmatched values surface as
+      ``unknown_resolver_*`` keys so free-text drift is visible in the series.
+    - ``system_cancelled`` conflates never-delivered approval cards with
+      delivered-but-unanswered ones — there is no delivery-receipt column, so
+      no "user ignored rate" is synthesized.
+    - ``resolved_at`` carries two formats (space-separated from SQLite
+      ``datetime('now')`` bulk expiry; ISO-T+00:00 from Python isoformat) —
+      both UTC; ``datetime()`` normalizes them for windowing.
+
+    Snapshot-only dimension (writes no eval_events).
+    """
+    from genesis.db.crud.approval_requests import classify_resolver
+
+    cursor = await db.execute(
+        """SELECT action_type, status, resolved_by
+           FROM approval_requests
+           WHERE resolved_at IS NOT NULL
+             AND datetime(resolved_at) >= datetime(?)
+             AND datetime(resolved_at) < datetime(?)""",
+        (since, until),
+    )
+    resolved = [dict(r) for r in await cursor.fetchall()]
+
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM approval_requests "
+        "WHERE created_at >= ? AND created_at < ?",
+        (since, until),
+    )
+    total_created = (await cursor.fetchone())[0]
+
+    # Point-in-time gauge, not windowed: what is open right now.
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM approval_requests WHERE status = 'pending'"
+    )
+    pending_open = (await cursor.fetchone())[0]
+
+    total_resolved = len(resolved)
+    classified = [(r, classify_resolver(r["resolved_by"])) for r in resolved]
+    user_resolved = sum(1 for _r, c in classified if c == "human")
+    auto_resolved = sum(1 for _r, c in classified if c == "system")
+    unknown_rows = [r for r, c in classified if c == "unknown"]
+
+    churn_total = sum(
+        1 for r in resolved if r["action_type"] == _CHURN_ACTION_TYPE
+    )
+    non_churn_total = total_resolved - churn_total
+    user_non_churn = sum(
+        1 for r, c in classified
+        if c == "human" and r["action_type"] != _CHURN_ACTION_TYPE
+    )
+
+    metrics = {
+        "total_created": total_created,
+        "total_resolved": total_resolved,
+        "churn_total": churn_total,
+        "churn_excluded_total": non_churn_total,
+        "user_resolved": user_resolved,
+        "user_resolved_rate": round(user_resolved / total_resolved, 4)
+        if total_resolved else None,
+        "user_resolved_rate_excl_churn": round(user_non_churn / non_churn_total, 4)
+        if non_churn_total else None,
+        "auto_resolved": auto_resolved,
+        "auto_expired": sum(1 for r in resolved if r["status"] == "expired"),
+        "system_cancelled": sum(
+            1 for r, c in classified
+            if r["status"] == "cancelled" and c == "system"
+        ),
+        "rejection_count": sum(1 for r in resolved if r["status"] == "rejected"),
+        # M12 scaffold: a human-resolved rejection = an explicit user denial.
+        # Zero observed instances to date — derivation is unvalidated against
+        # real deny data until a first real rejection occurs.
+        "user_denied_count": sum(
+            1 for r, c in classified
+            if r["status"] == "rejected" and c == "human"
+        ),
+        "unknown_resolver_count": len(unknown_rows),
+        "unknown_resolver_values": sorted(
+            {r["resolved_by"] for r in unknown_rows if r["resolved_by"]}
+        )[:10],
+        "pending_open": pending_open,
+    }
+    return metrics, total_resolved
+
+
+# ── Dimension 8: Goal Completion (WS-1 A2, scaffold) ─────────────────────────
+
+
+async def _compute_goal_completion(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """``user_goals`` status ratios + completion rate.
+
+    SCAFFOLD: zero terminal goals exist to date, so ``completion_rate`` is
+    None (never 0.0 on 0/0). Rate = achieved / (achieved + abandoned);
+    achieved and abandoned are always reported separately — a lone ratio
+    would invite abandoning stale goals to juice it. Ex-ante success
+    criteria (a ``success_criteria`` column + population wiring) are
+    deliberately deferred; until then any non-null rate is unvalidated.
+
+    Snapshot-only dimension (writes no eval_events).
+    """
+    cursor = await db.execute(
+        "SELECT status, COUNT(*) FROM user_goals GROUP BY status"
+    )
+    by_status = {r[0]: r[1] for r in await cursor.fetchall()}
+    total_goals = sum(by_status.values())
+    achieved = by_status.get("achieved", 0)
+    abandoned = by_status.get("abandoned", 0)
+    terminal = achieved + abandoned
+
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM user_goals "
+        "WHERE achieved_at >= ? AND achieved_at < ?",
+        (since, until),
+    )
+    achieved_in_period = (await cursor.fetchone())[0]
+
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM user_goals "
+        "WHERE status = 'abandoned' AND updated_at >= ? AND updated_at < ?",
+        (since, until),
+    )
+    abandoned_in_period = (await cursor.fetchone())[0]
+
+    metrics = {
+        "total_goals": total_goals,
+        "by_status": {
+            s: by_status.get(s, 0)
+            for s in ("active", "paused", "achieved", "abandoned")
+        },
+        "terminal_count": terminal,
+        "achieved_count": achieved,
+        "abandoned_count": abandoned,
+        "completion_rate": round(achieved / terminal, 4) if terminal else None,
+        "achieved_in_period": achieved_in_period,
+        "abandoned_in_period": abandoned_in_period,
+    }
+    if terminal == 0:
+        metrics["note"] = "scaffold: no terminal goals yet — rate uncomputable"
+    return metrics, total_goals
+
+
+# ── Dimension 9: Noise / Passivity v1 (WS-1 A2) ──────────────────────────────
+
+# Mirrors _STALE_DAYS in mcp/health/loop_closure_status.py — a follow-up /
+# proposal still pending past this cutoff counts as a leak.
+_NOISE_STALE_DAYS = 14
+
+
+async def _compute_noise_passivity(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Noise/passivity v1: loop-closure leaks + windowed ego-cycle activity.
+
+    Two kinds of numbers, deliberately distinct:
+    - Funnel gauges (``stale_followups`` …) reuse db/crud/loop_closure.py and
+      are ALL-TIME LEVELS (stocks) snapshotted weekly — the *series* shows
+      drift, but week-over-week deltas are NOT flows.
+    - Windowed counts (``ego_cycles`` …) are true per-period flows.
+      ``empty_ego_cycle_pct`` has an opportunity denominator (cycles run in
+      the window) — an empty cycle on a quiet week isn't passivity, which is
+      why the denominator is cycles, not wall-clock.
+
+    Raw buckets only — no composite "suppression score": realist ``reject``
+    verdicts have zero observed rows, so any composite would be dominated by
+    unvalidated components.
+
+    Snapshot-only dimension (writes no eval_events).
+    """
+    from genesis.db.crud import loop_closure
+
+    stale_before = (
+        datetime.fromisoformat(until) - timedelta(days=_NOISE_STALE_DAYS)
+    ).isoformat()
+    fu = await loop_closure.followup_funnel(db, stale_before=stale_before)
+    obs = await loop_closure.observation_funnel(db, stale_before=stale_before)
+    prop = await loop_closure.proposal_funnel(db, stale_before=stale_before)
+
+    cursor = await db.execute(
+        "SELECT COUNT(*), COALESCE(SUM(num_proposals = 0), 0) "
+        "FROM ego_cycle_outcomes WHERE created_at >= ? AND created_at < ?",
+        (since, until),
+    )
+    row = await cursor.fetchone()
+    ego_cycles, empty_ego_cycles = row[0], row[1]
+
+    cursor = await db.execute(
+        "SELECT status, COUNT(*) FROM ego_proposals "
+        "WHERE created_at >= ? AND created_at < ? GROUP BY status",
+        (since, until),
+    )
+    status_counts = {r[0]: r[1] for r in await cursor.fetchall()}
+    proposals_in_period = sum(status_counts.values())
+
+    cursor = await db.execute(
+        "SELECT action_type, COUNT(*) FROM ego_proposals "
+        "WHERE created_at >= ? AND created_at < ? AND status = 'rejected' "
+        "GROUP BY action_type",
+        (since, until),
+    )
+    rejected_by_action_type = {r[0]: r[1] for r in await cursor.fetchall()}
+
+    cursor = await db.execute(
+        "SELECT realist_verdict, COUNT(*) FROM ego_proposals "
+        "WHERE created_at >= ? AND created_at < ? "
+        "AND realist_verdict IS NOT NULL GROUP BY realist_verdict",
+        (since, until),
+    )
+    verdicts = {r[0]: r[1] for r in await cursor.fetchall()}
+
+    metrics = {
+        # Gauges (all-time stocks, see docstring)
+        "stale_followups": fu["leak_pending_stale"],
+        "followups_pending": fu["by_status"].get("pending", 0),
+        "observations_stale_unactuated": obs["leak_stale_unactuated"],
+        "proposals_pending_stale": prop["leak_pending_stale"],
+        "stale_cutoff_days": _NOISE_STALE_DAYS,
+        # Windowed flows
+        "ego_cycles": ego_cycles,
+        "empty_ego_cycles": empty_ego_cycles,
+        "empty_ego_cycle_pct": round(empty_ego_cycles / ego_cycles, 4)
+        if ego_cycles else None,
+        "proposals_in_period": proposals_in_period,
+        "rejected_count": status_counts.get("rejected", 0),
+        "withdrawn_count": status_counts.get("withdrawn", 0),
+        "tabled_count": status_counts.get("tabled", 0),
+        "rejected_by_action_type": rejected_by_action_type,
+        "realist_amend": verdicts.get("amend", 0),
+        "realist_reject": verdicts.get("reject", 0),
+        "realist_quality_hold": verdicts.get("quality_hold", 0),
+    }
+    return metrics, ego_cycles + proposals_in_period
 
 
 # ── Composite Trends ─────────────────────────────────────────────────────────

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -746,13 +746,11 @@ async def _compute_goal_completion(
     )
     achieved_in_period = (await cursor.fetchone())[0]
 
-    cursor = await db.execute(
-        "SELECT COUNT(*) FROM user_goals "
-        "WHERE status = 'abandoned' AND updated_at >= ? AND updated_at < ?",
-        (since, until),
-    )
-    abandoned_in_period = (await cursor.fetchone())[0]
-
+    # No abandoned_in_period: user_goals has no abandonment timestamp
+    # (mark_abandoned only touches updated_at, which ANY later edit also
+    # refreshes) — a windowed count would double-report edited-after-abandon
+    # goals. The all-time abandoned_count stock (weekly deltas in the series)
+    # carries the flow signal honestly.
     metrics = {
         "total_goals": total_goals,
         "by_status": {
@@ -764,7 +762,6 @@ async def _compute_goal_completion(
         "abandoned_count": abandoned,
         "completion_rate": round(achieved / terminal, 4) if terminal else None,
         "achieved_in_period": achieved_in_period,
-        "abandoned_in_period": abandoned_in_period,
     }
     if terminal == 0:
         metrics["note"] = "scaffold: no terminal goals yet — rate uncomputable"
@@ -772,10 +769,6 @@ async def _compute_goal_completion(
 
 
 # ── Dimension 9: Noise / Passivity v1 (WS-1 A2) ──────────────────────────────
-
-# Mirrors _STALE_DAYS in mcp/health/loop_closure_status.py — a follow-up /
-# proposal still pending past this cutoff counts as a leak.
-_NOISE_STALE_DAYS = 14
 
 
 async def _compute_noise_passivity(
@@ -801,7 +794,7 @@ async def _compute_noise_passivity(
     from genesis.db.crud import loop_closure
 
     stale_before = (
-        datetime.fromisoformat(until) - timedelta(days=_NOISE_STALE_DAYS)
+        datetime.fromisoformat(until) - timedelta(days=loop_closure.STALE_DAYS)
     ).isoformat()
     fu = await loop_closure.followup_funnel(db, stale_before=stale_before)
     obs = await loop_closure.observation_funnel(db, stale_before=stale_before)
@@ -816,16 +809,29 @@ async def _compute_noise_passivity(
     ego_cycles, empty_ego_cycles = row[0], row[1]
 
     cursor = await db.execute(
-        "SELECT status, COUNT(*) FROM ego_proposals "
-        "WHERE created_at >= ? AND created_at < ? GROUP BY status",
+        "SELECT COUNT(*) FROM ego_proposals "
+        "WHERE created_at >= ? AND created_at < ?",
         (since, until),
     )
-    status_counts = {r[0]: r[1] for r in await cursor.fetchall()}
-    proposals_in_period = sum(status_counts.values())
+    proposals_in_period = (await cursor.fetchone())[0]
+
+    # Decision buckets window on resolved_at (set by the reject/table/withdraw
+    # CRUD transitions), NOT created_at — a proposal created before the window
+    # but decided inside it IS this week's decision; created_at windowing
+    # would undercount decisions on boundary-straddling proposals.
+    cursor = await db.execute(
+        "SELECT status, COUNT(*) FROM ego_proposals "
+        "WHERE resolved_at IS NOT NULL "
+        "AND resolved_at >= ? AND resolved_at < ? "
+        "AND status IN ('rejected', 'withdrawn', 'tabled') GROUP BY status",
+        (since, until),
+    )
+    decision_counts = {r[0]: r[1] for r in await cursor.fetchall()}
 
     cursor = await db.execute(
         "SELECT action_type, COUNT(*) FROM ego_proposals "
-        "WHERE created_at >= ? AND created_at < ? AND status = 'rejected' "
+        "WHERE resolved_at IS NOT NULL "
+        "AND resolved_at >= ? AND resolved_at < ? AND status = 'rejected' "
         "GROUP BY action_type",
         (since, until),
     )
@@ -845,16 +851,17 @@ async def _compute_noise_passivity(
         "followups_pending": fu["by_status"].get("pending", 0),
         "observations_stale_unactuated": obs["leak_stale_unactuated"],
         "proposals_pending_stale": prop["leak_pending_stale"],
-        "stale_cutoff_days": _NOISE_STALE_DAYS,
+        "stale_cutoff_days": loop_closure.STALE_DAYS,
         # Windowed flows
         "ego_cycles": ego_cycles,
         "empty_ego_cycles": empty_ego_cycles,
         "empty_ego_cycle_pct": round(empty_ego_cycles / ego_cycles, 4)
         if ego_cycles else None,
         "proposals_in_period": proposals_in_period,
-        "rejected_count": status_counts.get("rejected", 0),
-        "withdrawn_count": status_counts.get("withdrawn", 0),
-        "tabled_count": status_counts.get("tabled", 0),
+        # Decisions RESOLVED in window (not created-in-window cohort)
+        "rejected_count": decision_counts.get("rejected", 0),
+        "withdrawn_count": decision_counts.get("withdrawn", 0),
+        "tabled_count": decision_counts.get("tabled", 0),
         "rejected_by_action_type": rejected_by_action_type,
         "realist_amend": verdicts.get("amend", 0),
         "realist_reject": verdicts.get("reject", 0),

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -63,6 +63,13 @@ def _text_overlap(memory_text: str, reference_text: str, min_phrases: int = 2) -
     return matches >= min_phrases
 
 
+# Version of the relevance-judge prompt below, stamped into every
+# recall_relevance event so the aggregator can mark a judge change as a
+# series break (precision@k is judge-rated — a reworded prompt shifts the
+# series without any retrieval change). BUMP THIS whenever _RELEVANCE_PROMPT
+# changes materially. Events predating this stamp read as "unversioned".
+_RELEVANCE_PROMPT_VERSION = "1"
+
 _RELEVANCE_PROMPT = """\
 You are judging whether a recalled memory is relevant to a query.
 
@@ -182,6 +189,7 @@ class J9EvalBatchExecutor:
                             "relevance": relevance,
                             "judge_rationale": rationale,
                             "judge_model": model_used,
+                            "judge_prompt_version": _RELEVANCE_PROMPT_VERSION,
                         },
                     )
                     scored += 1

--- a/src/genesis/mcp/health/j9_eval.py
+++ b/src/genesis/mcp/health/j9_eval.py
@@ -27,9 +27,11 @@ async def _impl_j9_eval_status() -> dict:
     for dim in dimensions:
         event_counts[dim] = await j9_eval.count_events(db, dimension=dim)
 
-    # Get latest snapshot per dimension
+    # Get latest snapshot per dimension. approvals/goals/noise are
+    # snapshot-only dimensions (no eval_events), so they appear here but
+    # not in event_counts above.
     latest_snapshots: dict[str, dict | None] = {}
-    for dim in [*dimensions, "composite"]:
+    for dim in [*dimensions, "composite", "approvals", "goals", "noise"]:
         snap = await j9_eval.get_latest_snapshot(db, dimension=dim)
         if snap:
             latest_snapshots[dim] = {

--- a/src/genesis/mcp/health/loop_closure_status.py
+++ b/src/genesis/mcp/health/loop_closure_status.py
@@ -21,14 +21,11 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 
+# Canonical staleness cutoff lives beside the funnel queries it governs.
+from genesis.db.crud.loop_closure import STALE_DAYS as _STALE_DAYS
 from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
-
-# A discovered item still un-actuated after this long is counted as a leak
-# (the "work goes here to die" signal). 14d mirrors the morning report's
-# follow-up staleness rule.
-_STALE_DAYS = 14
 
 
 async def _impl_loop_closure_status() -> dict:

--- a/tests/test_dashboard/test_eval_routes.py
+++ b/tests/test_dashboard/test_eval_routes.py
@@ -1,0 +1,58 @@
+"""Coverage/valence guards for the compounding-metrics dashboard route.
+
+The route's dimension tuple, headline map, and valence map are hand-
+maintained — these tests keep them in lockstep with each other and with the
+aggregator's registered dimensions, and pin the trend_good semantics (arrow
+color = valence, never raw direction: a rising noise metric must not render
+as improvement).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.dashboard.routes.eval import (
+    _DIMENSIONS,
+    _HEADLINE_METRIC,
+    _HIGHER_IS_BETTER,
+    _trend_good,
+)
+
+
+def test_headline_metric_covers_every_dimension():
+    missing = set(_DIMENSIONS) - _HEADLINE_METRIC.keys()
+    assert not missing, f"dimensions without a headline metric: {missing}"
+
+
+def test_valence_map_covers_every_dimension():
+    missing = set(_DIMENSIONS) - _HIGHER_IS_BETTER.keys()
+    assert not missing, f"dimensions without a valence entry: {missing}"
+
+
+def test_dimensions_match_aggregator_registration():
+    """Every snapshot dimension the weekly aggregator writes (except the
+    derived 'composite'/'cognitive_drift' internals) must be displayed."""
+    for dim in ("memory", "system", "ego", "cognitive", "procedure",
+                "approvals", "goals", "noise"):
+        assert dim in _DIMENSIONS, f"aggregator dimension not displayed: {dim}"
+
+
+@pytest.mark.parametrize(
+    ("dim", "trend", "expected"),
+    [
+        # higher-is-better: up = improving, down = degrading
+        ("memory", "up", True),
+        ("memory", "down", False),
+        # lower-is-better (noise): up = degrading, down = improving
+        ("noise", "up", False),
+        ("noise", "down", True),
+        # valence-ambiguous (approvals): always neutral
+        ("approvals", "up", None),
+        ("approvals", "down", None),
+        # non-directional trends: always neutral
+        ("memory", "flat", None),
+        ("noise", "insufficient_data", None),
+    ],
+)
+def test_trend_good_valence(dim, trend, expected):
+    assert _trend_good(dim, trend) is expected

--- a/tests/test_db/test_approval_resolver_classes.py
+++ b/tests/test_db/test_approval_resolver_classes.py
@@ -1,0 +1,83 @@
+"""Drift guard for the free-text ``resolved_by`` → resolver-class convention.
+
+``approval_requests.resolved_by`` has no CHECK constraint — its values are a
+convention spread across several writers. ``classify_resolver`` is the ONE
+canonical mapping (J-9 ``approvals`` metrics depend on it); this test pins
+every known writer literal and the full live-DB value inventory so the
+convention can't drift silently.
+
+**When you add a new ``resolved_by`` writer anywhere in the codebase, add its
+literal here** (and, if it's a new class prefix, to the prefix tuples in
+``genesis/db/crud/approval_requests.py``). A novel value that matches neither
+prefix list classifies as ``unknown`` — visible in the weekly ``approvals``
+snapshot as ``unknown_resolver_count``, never silently bucketed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud.approval_requests import (
+    HUMAN_RESOLVER_PREFIXES,
+    SYSTEM_RESOLVER_PREFIXES,
+    classify_resolver,
+)
+
+# Every in-tree writer literal, with its source location, plus the values
+# observed in the live DB as of 2026-07-09 that have no in-tree writer
+# (one-off manual DB fixes) — those must classify as ``unknown``.
+_CASES = [
+    # ── human: Telegram handlers (channels/telegram/_handler_messages.py) ──
+    ("telegram:batch:12345", "human"),
+    ("telegram:button:12345", "human"),
+    ("telegram:bare_text:12345", "human"),
+    # human: approval-channel reply (autonomy/approval_gate.py ~:347)
+    ("telegram:reply", "human"),
+    # human: dashboard (dashboard/routes/state.py :88/:106)
+    ("dashboard", "human"),
+    ("dashboard:batch", "human"),
+    # human: voice (channels/voice/genesis_bridge.py ~:248)
+    ("voice:s2s", "human"),
+    # human: operator sessions
+    ("manual:cc_session", "human"),
+    ("manual:genesis_session", "human"),
+    # human: ApprovalManager.resolve() default (autonomy/approval.py ~:95)
+    ("user", "human"),
+    # ── system: fail-closed cancel (autonomy/approval.py ~:121) ──
+    ("system", "system"),
+    # system: gate timeout (autonomy/approval_gate.py ~:110)
+    ("timeout_auto_expire", "system"),
+    # system: sentinel alarm clear (sentinel/dispatcher.py ~:1767)
+    ("alarm_cleared", "system"),
+    # system: housekeeping jobs
+    ("cleanup:self-send-spam", "system"),
+    ("cleanup:orphaned-pre-fix-approval", "system"),
+    # ── blank: bulk expiry (crud expire_timed_out never writes resolved_by) ──
+    (None, "system"),
+    ("", "system"),
+    ("   ", "system"),
+    # ── unknown: live values with NO in-tree writer — never guessed ──
+    ("manual_clear_fallow_recovery", "unknown"),
+    ("manual_stale_cleanup", "unknown"),
+    # unknown: a hypothetical future channel nobody registered
+    ("app:button:99", "unknown"),
+]
+
+
+@pytest.mark.parametrize(("resolved_by", "expected"), _CASES)
+def test_classify_resolver(resolved_by, expected):
+    assert classify_resolver(resolved_by) == expected
+
+
+def test_manual_colon_vs_manual_underscore_distinction():
+    """``manual:`` (operator session) is human; ``manual_*`` (one-off DB fix
+    scripts with no in-tree writer) is unknown — the colon is load-bearing."""
+    assert classify_resolver("manual:cc_session") == "human"
+    assert classify_resolver("manual_stale_cleanup") == "unknown"
+
+
+def test_prefix_lists_do_not_overlap():
+    """No value can match both a human and a system prefix."""
+    for h in HUMAN_RESOLVER_PREFIXES:
+        for s in SYSTEM_RESOLVER_PREFIXES:
+            assert not h.startswith(s) and not s.startswith(h), (h, s)

--- a/tests/test_eval/test_j9_batch.py
+++ b/tests/test_eval/test_j9_batch.py
@@ -149,3 +149,26 @@ async def test_deadline_defers_remaining(db, monkeypatch):
     assert "PARTIAL" in result.content
     assert router.calls == 0  # everything deferred to next run
     assert len(await _relevance_pairs(db)) == 0
+
+
+async def test_stored_events_carry_rank_and_judge_prompt_version(db):
+    """Each stored recall_relevance event must carry the retrieval rank AND
+    the judge-prompt version stamp — the aggregator's series-break marker
+    (judge_prompt_versions) reads this exact key; without it every event
+    reports as 'unversioned' and a judge change becomes invisible."""
+    from genesis.eval.j9_batch import _RELEVANCE_PROMPT_VERSION
+
+    eid = await _seed_recall(db, query="q", memory_ids=["m1", "m2"])
+    ex = J9EvalBatchExecutor(db=db, router=_FakeRouter())
+    result = await ex.execute(_task())
+    assert result.success
+
+    events = await j9_eval.get_events(
+        db, dimension="memory", event_type="recall_relevance", limit=10,
+    )
+    assert len(events) == 2
+    by_mid = {e["metrics"]["memory_id"]: e["metrics"] for e in events}
+    assert by_mid["m1"]["recall_event_id"] == eid
+    assert {by_mid["m1"]["rank"], by_mid["m2"]["rank"]} == {1, 2}
+    for m in by_mid.values():
+        assert m["judge_prompt_version"] == _RELEVANCE_PROMPT_VERSION

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -936,7 +936,9 @@ async def test_compute_goal_completion_rate(db):
     assert metrics["abandoned_count"] == 1
     assert metrics["completion_rate"] == 0.5
     assert metrics["achieved_in_period"] == 1
-    assert metrics["abandoned_in_period"] == 1
+    # No abandoned_in_period: no abandonment timestamp exists (updated_at is
+    # refreshed by ANY edit) — the stock abandoned_count carries the signal.
+    assert "abandoned_in_period" not in metrics
     assert "note" not in metrics
 
 
@@ -963,14 +965,17 @@ async def test_compute_noise_passivity(db):
         "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
         "VALUES ('o1','s','generic','c','medium',?,0,0,0)", (old,),
     )
-    # ego proposals: rejected + withdrawn + stale-pending, one realist amend
+    # ego proposals: rejected + withdrawn (decision buckets window on
+    # resolved_at, which the reject/table/withdraw transitions set) +
+    # stale-pending, one realist amend
     await db.execute(
-        "INSERT INTO ego_proposals (id, action_type, content, status, created_at, realist_verdict) "
-        "VALUES ('p1','investigate','c','rejected',?, 'amend')", (old,),
+        "INSERT INTO ego_proposals "
+        "(id, action_type, content, status, created_at, resolved_at, realist_verdict) "
+        "VALUES ('p1','investigate','c','rejected',?,?,'amend')", (old, old),
     )
     await db.execute(
-        "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
-        "VALUES ('p2','outreach','c','withdrawn',?)", (old,),
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at, resolved_at) "
+        "VALUES ('p2','outreach','c','withdrawn',?,?)", (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
@@ -1037,3 +1042,50 @@ async def test_run_weekly_aggregation_writes_new_dimensions(db):
     memory_snap = await j9_eval.get_latest_snapshot(db, dimension="memory")
     assert "precision_at_3" in memory_snap["metrics"]
     assert "judge_prompt_versions" in memory_snap["metrics"]
+
+
+async def test_noise_decision_buckets_window_on_resolved_at(db):
+    """A proposal created BEFORE the window but decided INSIDE it is this
+    week's decision — created_at windowing would undercount boundary-
+    straddling proposals (Codex P2 on PR #966)."""
+    from genesis.eval.j9_aggregator import _compute_noise_passivity
+
+    # created long before the window, rejected inside it
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at, resolved_at) "
+        "VALUES ('pb1','investigate','c','rejected',"
+        "'1999-01-01T00:00:00+00:00','2050-06-01T00:00:00+00:00')",
+    )
+    # created AND resolved before the window — must NOT count
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at, resolved_at) "
+        "VALUES ('pb2','outreach','c','withdrawn',"
+        "'1999-01-01T00:00:00+00:00','1999-06-01T00:00:00+00:00')",
+    )
+    await db.commit()
+
+    metrics, _ = await _compute_noise_passivity(
+        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+    )
+    assert metrics["rejected_count"] == 1       # pb1: decided in window
+    assert metrics["withdrawn_count"] == 0      # pb2: decided before window
+    assert metrics["proposals_in_period"] == 0  # neither was CREATED in window
+    assert metrics["rejected_by_action_type"] == {"investigate": 1}
+
+
+async def test_j9_eval_status_reports_new_snapshot_dimensions(db, monkeypatch):
+    """The MCP health endpoint must surface the three snapshot-only dims
+    (they have no eval_events, so only the snapshot loop shows them)."""
+    from types import SimpleNamespace
+
+    import genesis.mcp.health_mcp as health_mcp_mod
+    from genesis.eval.j9_aggregator import run_weekly_aggregation
+    from genesis.mcp.health.j9_eval import _impl_j9_eval_status
+
+    await run_weekly_aggregation(db)
+    monkeypatch.setattr(health_mcp_mod, "_service", SimpleNamespace(_db=db))
+
+    res = await _impl_j9_eval_status()
+    for dim in ("approvals", "goals", "noise"):
+        assert dim in res["latest_snapshots"], f"missing {dim}"
+        assert res["latest_snapshots"][dim] is not None

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -694,3 +694,346 @@ async def test_insert_run_persists_metadata_json_per_result(db):
     }
     assert rows["c1"] == detail  # judge result → JSON dual-write
     assert rows["c2"] is None  # non-judge result → NULL (not the plain string)
+
+
+# ── WS-1 A2: precision@3 + top-5 truncation ─────────────────────────────────
+
+
+async def test_memory_quality_precision_at_3(db):
+    """p@3 counts relevance in the top-3 by rank; p@5 stays precision-among-
+    judged. Ranks 1-5 with relevance (1,0,1,0,1): p@5 = 3/5, p@3 = 2/3."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    for rank, rel in enumerate((1.0, 0.0, 1.0, 0.0, 1.0), 1):
+        await j9_eval.insert_event(
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
+                     "relevance": rel, "rank": rank},
+        )
+
+    metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
+    assert metrics["precision_at_5"] == 0.6
+    assert metrics["precision_at_3"] == pytest.approx(2 / 3, abs=1e-3)
+    assert metrics["precision_at_3_recalls"] == 1
+
+
+async def test_memory_quality_precision_at_3_fewer_than_three(db):
+    """With fewer than 3 judged memories the p@3 denominator is the judged
+    count (min(3, judged)), not a hard 3."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    for rank, rel in ((1, 1.0), (2, 0.0)):
+        await j9_eval.insert_event(
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
+                     "relevance": rel, "rank": rank},
+        )
+
+    metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
+    assert metrics["precision_at_3"] == 0.5
+
+
+async def test_memory_quality_truncates_to_top5(db):
+    """A malformed emitter judging >5 memories per recall must not inflate the
+    @5 denominator: rank-6 (the only relevant one) is cut, p@5 = 0/5."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    for rank in range(1, 6):
+        await j9_eval.insert_event(
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
+                     "relevance": 0.0, "rank": rank},
+        )
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m6",
+                 "relevance": 1.0, "rank": 6},
+    )
+
+    metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
+    assert metrics["precision_at_5"] == 0.0
+    assert metrics["hit_rate"] == 0.0  # the relevant memory was beyond top-5
+
+
+async def test_precision_at_3_skips_unranked_recalls(db):
+    """Pre-fix events without rank sort arbitrarily — an unranked recall is
+    excluded from p@3 (None when no recall qualifies) while p@5 still computes."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    for i, rel in enumerate((1.0, 0.0, 1.0, 0.0), 1):
+        await j9_eval.insert_event(
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{i}", "relevance": rel},
+        )
+
+    metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
+    assert metrics["precision_at_5"] == 0.5
+    assert metrics["precision_at_3"] is None
+    assert metrics["precision_at_3_recalls"] == 0
+
+
+async def test_memory_quality_reports_judge_prompt_versions(db):
+    """The set of judge-prompt versions seen in-window is reported so a judge
+    change reads as a series break; version-less events show as 'unversioned'."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 1.0,
+                 "rank": 1, "judge_prompt_version": "1"},
+    )
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0,
+                 "rank": 1},
+    )
+
+    metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
+    assert metrics["judge_prompt_versions"] == ["1", "unversioned"]
+
+
+# ── WS-1 A2: approvals dimension ─────────────────────────────────────────────
+
+
+async def _approval(db, aid, *, action_type="other", status=None,
+                    resolved_at=None, resolved_by=None):
+    from genesis.db.crud import approval_requests as ar
+
+    await ar.create(
+        db, id=aid, action_type=action_type, action_class="reversible",
+        description="d",
+    )
+    if status is not None:
+        assert await ar.resolve(
+            db, aid, status=status, resolved_at=resolved_at,
+            resolved_by=resolved_by,
+        )
+
+
+async def test_compute_approvals_buckets(db):
+    """Every bucket of the approvals dimension, incl. the M12 scaffold
+    (human-resolved rejection → user_denied_count) and unknown surfacing."""
+    from genesis.eval.j9_aggregator import _compute_approvals
+
+    ts = "2026-06-05T12:00:00+00:00"
+    # churn class: one human approve, one fail-closed system cancel
+    await _approval(db, "a1", action_type="autonomous_cli_fallback",
+                    status="approved", resolved_at=ts,
+                    resolved_by="telegram:button:1")
+    await _approval(db, "a2", action_type="autonomous_cli_fallback",
+                    status="cancelled", resolved_at=ts, resolved_by="system")
+    # non-churn: explicit human denial (M12), timeout expiry, unknown resolver
+    await _approval(db, "a3", status="rejected", resolved_at=ts,
+                    resolved_by="telegram:bare_text:1")
+    await _approval(db, "a4", status="expired", resolved_at=ts,
+                    resolved_by="timeout_auto_expire")
+    await _approval(db, "a5", status="approved", resolved_at=ts,
+                    resolved_by="manual_stale_cleanup")
+    # still pending — resolved-population excludes it; pending_open gauge sees it
+    await _approval(db, "a6")
+
+    metrics, sample = await _compute_approvals(
+        db, since="2000-01-01", until="2100-01-01",
+    )
+    assert sample == 5
+    assert metrics["total_created"] == 6
+    assert metrics["total_resolved"] == 5
+    assert metrics["churn_total"] == 2
+    assert metrics["churn_excluded_total"] == 3
+    assert metrics["user_resolved"] == 2          # a1 + a3
+    assert metrics["user_resolved_rate"] == 0.4
+    assert metrics["user_resolved_rate_excl_churn"] == pytest.approx(1 / 3, abs=1e-3)
+    assert metrics["auto_resolved"] == 2          # a2 + a4
+    assert metrics["auto_expired"] == 1
+    assert metrics["system_cancelled"] == 1
+    assert metrics["rejection_count"] == 1
+    assert metrics["user_denied_count"] == 1      # M12: human reject
+    assert metrics["unknown_resolver_count"] == 1
+    assert metrics["unknown_resolver_values"] == ["manual_stale_cleanup"]
+    assert metrics["pending_open"] == 1
+
+
+async def test_compute_approvals_empty_window_is_null(db):
+    """No resolved rows → rates are None, never 0.0."""
+    from genesis.eval.j9_aggregator import _compute_approvals
+
+    metrics, sample = await _compute_approvals(
+        db, since="2000-01-01", until="2100-01-01",
+    )
+    assert sample == 0
+    assert metrics["user_resolved_rate"] is None
+    assert metrics["user_resolved_rate_excl_churn"] is None
+
+
+async def test_compute_approvals_mixed_resolved_at_formats(db):
+    """resolved_at carries space-separated (SQLite datetime('now')) AND
+    ISO-T (+00:00) formats. Lexicographically ' ' < 'T', so a space-format
+    timestamp AFTER an ISO-T window bound would leak in — datetime()
+    normalization must window both formats correctly."""
+    from genesis.eval.j9_aggregator import _compute_approvals
+
+    # in-window, one of each format
+    await _approval(db, "b1", status="approved",
+                    resolved_at="2026-06-05 12:00:00",
+                    resolved_by="telegram:button:1")
+    await _approval(db, "b2", status="approved",
+                    resolved_at="2026-06-06T12:00:00+00:00",
+                    resolved_by="dashboard")
+    # space-format AFTER the until bound — lexicographic compare against
+    # '2026-06-30T00:00:00+00:00' would wrongly include it (' ' < 'T')
+    await _approval(db, "b3", status="approved",
+                    resolved_at="2026-06-30 12:00:00",
+                    resolved_by="dashboard")
+
+    metrics, _ = await _compute_approvals(
+        db, since="2026-06-01T00:00:00+00:00", until="2026-06-30T00:00:00+00:00",
+    )
+    assert metrics["total_resolved"] == 2  # b3 excluded
+    assert metrics["user_resolved"] == 2
+
+
+# ── WS-1 A2: goals dimension ─────────────────────────────────────────────────
+
+
+async def test_compute_goal_completion_zero_terminal_is_null(db):
+    """0 terminal goals → completion_rate is None (never 0.0 on 0/0), with the
+    scaffold note present."""
+    from genesis.db.crud import user_goals
+    from genesis.eval.j9_aggregator import _compute_goal_completion
+
+    await user_goals.create(db, title="g1", category="project")
+    await user_goals.create(db, title="g2", category="learning")
+
+    metrics, sample = await _compute_goal_completion(
+        db, since="2000-01-01", until="2100-01-01",
+    )
+    assert sample == 2
+    assert metrics["total_goals"] == 2
+    assert metrics["terminal_count"] == 0
+    assert metrics["completion_rate"] is None
+    assert "note" in metrics
+
+
+async def test_compute_goal_completion_rate(db):
+    """achieved / terminal with achieved and abandoned reported separately."""
+    from genesis.db.crud import user_goals
+    from genesis.eval.j9_aggregator import _compute_goal_completion
+
+    g1 = await user_goals.create(db, title="g1", category="project")
+    g2 = await user_goals.create(db, title="g2", category="project")
+    await user_goals.create(db, title="g3", category="project")
+    await user_goals.mark_achieved(db, g1)
+    await user_goals.mark_abandoned(db, g2)
+
+    metrics, _ = await _compute_goal_completion(
+        db, since="2000-01-01", until="2100-01-01",
+    )
+    assert metrics["by_status"] == {
+        "active": 1, "paused": 0, "achieved": 1, "abandoned": 1,
+    }
+    assert metrics["terminal_count"] == 2
+    assert metrics["achieved_count"] == 1
+    assert metrics["abandoned_count"] == 1
+    assert metrics["completion_rate"] == 0.5
+    assert metrics["achieved_in_period"] == 1
+    assert metrics["abandoned_in_period"] == 1
+    assert "note" not in metrics
+
+
+# ── WS-1 A2: noise/passivity dimension ───────────────────────────────────────
+
+
+async def test_compute_noise_passivity(db):
+    """Funnel gauges + windowed ego-cycle/proposal flows, raw buckets only."""
+    from genesis.eval.j9_aggregator import _compute_noise_passivity
+
+    old = "2020-01-01T00:00:00+00:00"
+    # follow-ups: one stale-pending (leak), one completed
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
+        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)", (old,),
+    )
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
+        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)", (old,),
+    )
+    # observation: unresolved, un-actuated, old → stale leak
+    await db.execute(
+        "INSERT INTO observations "
+        "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
+        "VALUES ('o1','s','generic','c','medium',?,0,0,0)", (old,),
+    )
+    # ego proposals: rejected + withdrawn + stale-pending, one realist amend
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at, realist_verdict) "
+        "VALUES ('p1','investigate','c','rejected',?, 'amend')", (old,),
+    )
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
+        "VALUES ('p2','outreach','c','withdrawn',?)", (old,),
+    )
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
+        "VALUES ('p3','maintenance','c','pending',?)", (old,),
+    )
+    # ego cycles: 2 empty, 1 productive
+    for cid, n in (("c1", 0), ("c2", 0), ("c3", 2)):
+        await db.execute(
+            "INSERT INTO ego_cycle_outcomes (cycle_id, focus_type, num_proposals, created_at) "
+            "VALUES (?, 'signal', ?, ?)", (cid, n, old),
+        )
+    await db.commit()
+
+    metrics, sample = await _compute_noise_passivity(
+        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+    )
+    assert metrics["stale_followups"] == 1
+    assert metrics["followups_pending"] == 1
+    assert metrics["observations_stale_unactuated"] == 1
+    assert metrics["proposals_pending_stale"] == 1
+    assert metrics["ego_cycles"] == 3
+    assert metrics["empty_ego_cycles"] == 2
+    assert metrics["empty_ego_cycle_pct"] == pytest.approx(2 / 3, abs=1e-3)
+    assert metrics["proposals_in_period"] == 3
+    assert metrics["rejected_count"] == 1
+    assert metrics["withdrawn_count"] == 1
+    assert metrics["rejected_by_action_type"] == {"investigate": 1}
+    assert metrics["realist_amend"] == 1
+    assert metrics["realist_reject"] == 0
+    assert sample == 6  # 3 cycles + 3 proposals
+
+
+async def test_compute_noise_passivity_zero_cycles_is_null(db):
+    """No ego cycles in window → empty_ego_cycle_pct is None, not 0.0."""
+    from genesis.eval.j9_aggregator import _compute_noise_passivity
+
+    metrics, _ = await _compute_noise_passivity(
+        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+    )
+    assert metrics["empty_ego_cycle_pct"] is None
+
+
+# ── WS-1 A2: registration / E2E guard ────────────────────────────────────────
+
+
+async def test_run_weekly_aggregation_writes_new_dimensions(db):
+    """run_weekly_aggregation swallows per-dimension exceptions (a broken
+    compute fn fails SILENTLY in production) — so this asserts every
+    registered dimension actually produced a snapshot on a fresh DB, and that
+    the memory snapshot carries the new precision_at_3 keys."""
+    from genesis.eval.j9_aggregator import run_weekly_aggregation
+
+    results = await run_weekly_aggregation(db)
+
+    expected = {"memory", "system", "ego", "cognitive", "procedure",
+                "cognitive_drift", "approvals", "goals", "noise"}
+    missing = expected - results.keys()
+    assert not missing, f"dimensions failed silently: {missing}"
+
+    for dim in ("approvals", "goals", "noise"):
+        snap = await j9_eval.get_latest_snapshot(db, dimension=dim)
+        assert snap is not None, f"no snapshot written for {dim}"
+
+    memory_snap = await j9_eval.get_latest_snapshot(db, dimension="memory")
+    assert "precision_at_3" in memory_snap["metrics"]
+    assert "judge_prompt_versions" in memory_snap["metrics"]


### PR DESCRIPTION
## What

Adds honesty-first metric series to the J-9 weekly eval pipeline (WS-1 A2 of the gap-closure campaign). **Zero schema migrations** — all snapshot-only.

### Memory dimension (extended)
- **`precision_at_3`**: top-3 of the rank-sorted judged memories per recall; only recalls where every judged memory carries a real `rank` qualify (unranked pre-fix events would make the slice arbitrary); denominator `min(3, judged)`; coverage visible via `precision_at_3_recalls`.
- **Defensive top-5 truncation**: j9_batch judges `memory_ids[:5]`, so this is a no-op on well-formed data, but a malformed emitter can no longer inflate the `@5` denominator. `precision_at_5` semantics unchanged (historical series preserved).
- **`judge_prompt_versions`**: the relevance judge is a raw prompt (not a registry rubric) — the prompt is now versioned, stamped into every event, and the versions seen in-window are reported so a judge change reads as a series break instead of silent drift.

### New snapshot dimensions
- **`approvals`** — gate-throughput buckets over `approval_requests`. Deliberately NOT labeled "intervention rate": this table measures how designed approval gates get resolved, not corrective intervention. Resolver classes come from ONE canonical `classify_resolver` (new, in `db/crud/approval_requests.py`); unknown `resolved_by` values surface as `unknown_resolver_*` keys, never silently bucketed. `datetime()` windowing handles the mixed space-format/ISO-T timestamps (both UTC). Includes the M12 scaffold `user_denied_count` (zero live instances to date — documented as unvalidated).
- **`goals`** — `user_goals` status ratios. `completion_rate` is **null on 0/0** (all 8 live goals are active — never a fake 0%), achieved/abandoned always reported separately. Ex-ante `success_criteria` deliberately deferred (needs writer/consumer plumbing — tracked as a follow-up).
- **`noise`** — loop-closure leak gauges (documented as all-time stocks, not flows) + windowed empty-ego-cycle % (opportunity denominator = cycles run) + rejected/withdrawn/tabled proposal buckets + realist-verdict counts. Raw buckets only, no composite score.

### Dashboard honesty fix
Trend arrows previously colored "up" green for every dimension — a rising noise metric would render as improvement. The arrow glyph stays factual (direction of the value); its **color** is now driven by a per-dimension valence map (`noise` lower-is-better; `approvals` direction-ambiguous → neutral gray).

## Guards
- Registration test: `run_weekly_aggregation` swallows per-dimension failures silently, so a test asserts every registered dimension produces a snapshot on a fresh DB.
- Resolver drift test: pins every in-tree `resolved_by` writer literal + the live value inventory; new writers must extend it.
- Headline/valence map coverage tests keep the dashboard in lockstep with the aggregator.

## Verification
- 285 targeted tests pass (`tests/test_eval/`, resolver classes, dashboard route maps, loop-closure, schema); ruff clean on the full diff.
- **E2E against a copy of the live production DB**: all dimensions produced with no silent failures; `precision_at_3` 0.7193 vs `precision_at_5` 0.7149 on 57 fully-ranked recalls; goals correctly null; approvals buckets internally consistent.
- Subsystem-map guard clean; CHANGELOG + `docs/architecture/CURRENT.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)