### PR TITLE
feat(guardian): credential resilience — passphrase escrow + backup coverage (G.2+G.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   starting cold. It's framed as the session's own recollection, not a report to
   read back to you.
 
+### Added
+
+- **Backups now cover the credentials and wiring you'd need to actually rebuild —
+  and the backup passphrase is escrowed so a lost secrets file can't lock you out
+  of your own backup.** The encrypted backup set now includes your SSH keys, the
+  GitHub and Claude Code credentials, and the host/network wiring config (the
+  difference between "restore" and "reprovision from scratch"). Separately, the
+  backup passphrase — which previously lived *only* inside the very secrets file
+  the backup encrypts with it — is now escrowed to the host outside the container,
+  so a secrets-file loss no longer leaves the encrypted backup undecryptable.
+  Restore reads the escrowed passphrase automatically and stages recovered
+  credentials to a review directory rather than overwriting live ones.
+
 ### Fixed
 
 - **The Guardian's recovery brain no longer goes dark when its work directory is

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -327,6 +327,47 @@ else
     log "WARNING: secrets file not found at $SECRETS_FILE"
 fi
 
+# --- 8. Critical credential & wiring files (encrypted, Tier 1) ---
+# Small, high-value files whose loss means "reprovision from scratch" instead of
+# "restore": SSH keys (incl. the guardian control-plane key), the gh + Claude
+# Code credentials, and the host/network wiring config. Each is GPG-encrypted;
+# missing files are skipped (non-fatal). Refuses plaintext without a passphrase.
+log "Backing up critical credential & wiring files (encrypted)..."
+mkdir -p creds
+_CREDS_COUNT=0
+if $_ENCRYPT_READY; then
+    # Whole ~/.ssh (keys, config, known_hosts) — regular files only.
+    if [ -d "$HOME/.ssh" ]; then
+        mkdir -p creds/ssh
+        while IFS= read -r -d '' _f; do
+            _base="$(basename "$_f")"
+            if encrypt_file "$_f" "creds/ssh/${_base}.gpg"; then
+                _CREDS_COUNT=$(( _CREDS_COUNT + 1 ))
+            else
+                log "WARNING: failed to encrypt ssh/${_base}"
+            fi
+        done < <(find "$HOME/.ssh" -maxdepth 1 -type f -print0)
+    fi
+    # Named single files → creds/<flatname>.gpg
+    for _spec in \
+        "$HOME/.config/gh/hosts.yml:gh_hosts.yml" \
+        "$HOME/.claude/.credentials.json:claude_credentials.json" \
+        "$HOME/.claude.json:claude.json" \
+        "$HOME/.genesis/guardian_remote.yaml:guardian_remote.yaml" \
+        "$HOME/.genesis/config/genesis.yaml:genesis.yaml"; do
+        _srcf="${_spec%%:*}"; _dstn="${_spec##*:}"
+        [ -f "$_srcf" ] || continue
+        if encrypt_file "$_srcf" "creds/${_dstn}.gpg"; then
+            _CREDS_COUNT=$(( _CREDS_COUNT + 1 ))
+        else
+            log "WARNING: failed to encrypt ${_dstn}"
+        fi
+    done
+    log "Creds: $_CREDS_COUNT files (encrypted)"
+else
+    log "WARNING: GENESIS_BACKUP_PASSPHRASE not set — skipping creds backup (refusing plaintext)"
+fi
+
 # --- Tier 2: upload large files to the off-site backend (pluggable) ---
 # Destination is selectable (none/local/smb) via GENESIS_BACKUP_TIER2_BACKEND —
 # the public repo prescribes no provider. The dated snapshot tree

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -490,6 +490,24 @@ else
         fi
     fi
 
+    # Upload creds (encrypted credential + wiring files) so the COMPLETE snapshot
+    # genuinely includes them — a no-git fresh box pulls them from here (restore
+    # §8). One level of nesting: creds/*.gpg + creds/ssh/*.gpg; a failed upload of
+    # a present file flips _T2_OK, same contract as the payloads above.
+    if [ -d creds ]; then
+        backend_mkdir "${_T2_DIR}/creds"
+        [ -d creds/ssh ] && backend_mkdir "${_T2_DIR}/creds/ssh"
+        while IFS= read -r -d '' f; do
+            rel="${f#creds/}"
+            if backend_put "$f" "${_T2_DIR}/creds/${rel}"; then
+                log "  off-site: uploaded creds/${rel}"
+            else
+                log "WARNING: off-site upload failed for creds/${rel}"
+                _T2_OK=false
+            fi
+        done < <(find creds -type f -name '*.gpg' -print0 2>/dev/null)
+    fi
+
     # Mark the snapshot COMPLETE only when every upload succeeded, so restore never
     # picks a half-uploaded snapshot (it selects the latest COMPLETE one). If the
     # marker itself fails to upload, the snapshot is unusable for restore — treat

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -323,6 +323,20 @@ _pull_from_offsite() {
             warn "off-site: failed to pull secrets.env.gpg from snapshot $latest — secrets will not be restored"
         fi
     fi
+    # creds — Tier-1 git normally carries these; a no-git box needs them from the
+    # snapshot too (restore §8 reads $BACKUP_DIR/creds). backend_list is
+    # single-level, so iterate creds/ and creds/ssh/ separately; the .gpg filter
+    # drops the `ssh` subdir entry so it is not mis-fetched as a flat file.
+    for _sub in creds creds/ssh; do
+        while read -r fname; do
+            mkdir -p "$BACKUP_DIR/$_sub"
+            if backend_get "$snap/$_sub/$fname" "$BACKUP_DIR/$_sub/$fname"; then
+                log "  off-site: pulled $_sub/$fname"
+            else
+                warn "off-site: failed to pull $_sub/$fname from snapshot $latest"
+            fi
+        done < <(backend_list "$snap/$_sub" 2>/dev/null | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u)
+    done
 }
 _pull_from_offsite
 
@@ -619,6 +633,13 @@ CREDS_SRC_DIR="$BACKUP_DIR/creds"
 if [ -d "$CREDS_SRC_DIR" ]; then
     CREDS_STAGE="${GENESIS_CREDS_STAGE:-$HOME/.genesis/restore-creds}"
     _CREDS_STAGED=0
+    # Private-by-creation: make the stage dir 0700 and set umask 077 BEFORE any
+    # plaintext is written, so decrypted SSH keys / credentials are never briefly
+    # world-readable on a multi-user host (no window between write and chmod).
+    if ! $DRY_RUN; then
+        mkdir -p "$CREDS_STAGE" && chmod 0700 "$CREDS_STAGE"
+    fi
+    _prev_umask="$(umask)"; umask 077
     while IFS= read -r -d '' _gpg; do
         _rel="${_gpg#"$CREDS_SRC_DIR"/}"       # e.g. ssh/id_ed25519.gpg
         _out="$CREDS_STAGE/${_rel%.gpg}"        # strip trailing .gpg
@@ -634,8 +655,8 @@ if [ -d "$CREDS_SRC_DIR" ]; then
             warn "Creds: decrypt failed for $_rel"
         fi
     done < <(find "$CREDS_SRC_DIR" -type f -name '*.gpg' -print0)
+    umask "$_prev_umask"
     if ! $DRY_RUN; then
-        chmod 0700 "$CREDS_STAGE" 2>/dev/null || true
         log "Creds: $_CREDS_STAGED file(s) decrypted → $CREDS_STAGE (staged, NOT auto-placed)"
         log "      Move into place manually (ssh/ → ~/.ssh/, gh_hosts.yml → ~/.config/gh/hosts.yml, etc.)."
     fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -127,6 +127,28 @@ _quiesce_genesis_server() {
 
 _BACKUP_PASSPHRASE="${GENESIS_BACKUP_PASSPHRASE:-}"
 
+# Circular-trap fallback: if the passphrase is not in the environment (e.g.
+# secrets.env was lost — the exact disaster this backup exists for), read it
+# from the host-side escrow the credential bridge writes. Without this, an
+# encrypted backup of a lost secrets.env would be undecryptable.
+if [ -z "$_BACKUP_PASSPHRASE" ]; then
+    for _escrow in \
+        "${GENESIS_PASSPHRASE_ESCROW:-}" \
+        "$HOME/.genesis/shared/guardian/backup_passphrase.env" \
+        "$HOME/.local/state/genesis-guardian/shared/guardian/backup_passphrase.env"; do
+        [ -n "$_escrow" ] && [ -f "$_escrow" ] || continue
+        # Bridge writes exactly `GENESIS_BACKUP_PASSPHRASE=<value>` (no quotes);
+        # tolerate an optional `export ` prefix. Do NOT strip quotes — the
+        # passphrase may legitimately contain them.
+        _escrowed="$(sed -n 's/^\(export \)\{0,1\}GENESIS_BACKUP_PASSPHRASE=//p' "$_escrow" | head -n1)"
+        if [ -n "$_escrowed" ]; then
+            _BACKUP_PASSPHRASE="$_escrowed"
+            log "Using escrowed backup passphrase from $_escrow (env passphrase absent)"
+            break
+        fi
+    done
+fi
+
 # decrypt_file <src.gpg> <dst>
 decrypt_file() {
     local src="$1" dst="$2"
@@ -585,6 +607,40 @@ if [ -f "$SECRETS_SRC" ]; then
     fi
 else
     log "Secrets: no backup payload at $SECRETS_SRC"
+fi
+
+# ── 8. Critical credential & wiring files → staging (non-destructive) ─
+# Decrypted to a staging dir, never auto-placed: clobbering a live ~/.ssh key or
+# credential file mid-restore is dangerous. On a fresh rebuild, move them into
+# place from the staging dir (paths logged below). These live in the Tier-1 git
+# clone, so no off-site pull is needed.
+log "--- Credential & wiring files ---"
+CREDS_SRC_DIR="$BACKUP_DIR/creds"
+if [ -d "$CREDS_SRC_DIR" ]; then
+    CREDS_STAGE="${GENESIS_CREDS_STAGE:-$HOME/.genesis/restore-creds}"
+    _CREDS_STAGED=0
+    while IFS= read -r -d '' _gpg; do
+        _rel="${_gpg#"$CREDS_SRC_DIR"/}"       # e.g. ssh/id_ed25519.gpg
+        _out="$CREDS_STAGE/${_rel%.gpg}"        # strip trailing .gpg
+        if $DRY_RUN; then
+            log "Creds: would decrypt → $_out"
+            continue
+        fi
+        mkdir -p "$(dirname "$_out")"
+        if decrypt_file "$_gpg" "$_out"; then
+            chmod 0600 "$_out"
+            _CREDS_STAGED=$(( _CREDS_STAGED + 1 ))
+        else
+            warn "Creds: decrypt failed for $_rel"
+        fi
+    done < <(find "$CREDS_SRC_DIR" -type f -name '*.gpg' -print0)
+    if ! $DRY_RUN; then
+        chmod 0700 "$CREDS_STAGE" 2>/dev/null || true
+        log "Creds: $_CREDS_STAGED file(s) decrypted → $CREDS_STAGE (staged, NOT auto-placed)"
+        log "      Move into place manually (ssh/ → ~/.ssh/, gh_hosts.yml → ~/.config/gh/hosts.yml, etc.)."
+    fi
+else
+    log "Creds: no backup payload at $CREDS_SRC_DIR"
 fi
 
 # ── Done ─────────────────────────────────────────────────────────────

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -22,8 +22,10 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "load_backup_passphrase",
     "load_provisioning_credentials",
     "load_telegram_credentials",
+    "propagate_backup_passphrase",
     "propagate_guardian_credentials",
     "propagate_provisioning_credentials",
     "propagate_telegram_credentials",
@@ -43,6 +45,18 @@ _PROVISIONING_FILENAME = "proxmox_creds.env"
 _KEY_MAP_PROVISIONING = {
     "PROXMOX_AUDIT_TOKEN": "PROXMOX_AUDIT_TOKEN",
     "PROXMOX_PROVISION_TOKEN": "PROXMOX_PROVISION_TOKEN",
+}
+
+# Backup-passphrase escrow. GENESIS_BACKUP_PASSPHRASE lives ONLY inside
+# secrets.env, which the backup encrypts WITH it — so a secrets.env loss makes
+# the encrypted backup undecryptable (a circular trap). Escrowing the passphrase
+# to the host-side shared mount (outside the container's blast radius) breaks the
+# circle: a rebuilt/fresh container can decrypt the backup from the host copy.
+# The passphrase is as sensitive as everything it decrypts; the escrow file is
+# 0600 on the host mount (same trust level as the telegram/proxmox tokens here).
+_PASSPHRASE_FILENAME = "backup_passphrase.env"
+_KEY_MAP_PASSPHRASE = {
+    "GENESIS_BACKUP_PASSPHRASE": "GENESIS_BACKUP_PASSPHRASE",
 }
 
 # Keys to extract from container secrets.env
@@ -168,17 +182,75 @@ def load_provisioning_credentials(
         return {}
 
 
+def propagate_backup_passphrase(
+    shared_dir: Path | None = None,
+    secrets_path: Path | None = None,
+) -> Path | None:
+    """Escrow GENESIS_BACKUP_PASSPHRASE → host shared mount (host reads on restore).
+
+    Breaks the circular trap where the only copy of the passphrase lives inside
+    the very secrets.env the backup encrypts with it. Returns the path written,
+    or None if the passphrase is absent.
+    """
+    src = secrets_path or _CONTAINER_SECRETS
+    out_dir = (shared_dir or _CONTAINER_SHARED_DIR) / _CREDS_SUBDIR
+
+    source_secrets = _read_dotenv(src)
+    if not source_secrets:
+        logger.debug("No secrets file for passphrase escrow — skipping")
+        return None
+
+    creds: dict[str, str] = {}
+    for src_key, dst_key in _KEY_MAP_PASSPHRASE.items():
+        value = source_secrets.get(src_key, "")
+        if value:
+            creds[dst_key] = value
+
+    if not creds.get("GENESIS_BACKUP_PASSPHRASE"):
+        logger.debug("No GENESIS_BACKUP_PASSPHRASE present — skipping escrow")
+        return None
+
+    out_path = _write_creds_atomic(out_dir, _PASSPHRASE_FILENAME, creds)
+    logger.debug("Backup passphrase escrowed to %s", out_path)
+    return out_path
+
+
+def load_backup_passphrase(
+    state_dir: str = "~/.local/state/genesis-guardian",
+) -> dict[str, str]:
+    """Read the escrowed backup passphrase from the shared mount (host side).
+
+    Returns {} when absent/unreadable — the caller falls back to secrets.env or
+    refuses to decrypt.
+    """
+    creds_path = (
+        Path(state_dir).expanduser() / "shared" / _CREDS_SUBDIR / _PASSPHRASE_FILENAME
+    )
+    if not creds_path.exists():
+        logger.debug("Escrowed backup passphrase not found at %s", creds_path)
+        return {}
+    try:
+        return _read_dotenv(creds_path)
+    except OSError as exc:
+        logger.warning("Failed to read escrowed backup passphrase: %s", exc)
+        return {}
+
+
 def propagate_guardian_credentials(
     shared_dir: Path | None = None,
     secrets_path: Path | None = None,
 ) -> list[Path]:
-    """Combined container-side bridge: telegram + provisioning, each guarded.
+    """Combined container-side bridge: telegram + provisioning + passphrase escrow.
 
     Wired to the awareness-loop tick (called zero-arg). A failure in one leg
     never blocks the other, and never raises into the loop.
     """
     written: list[Path] = []
-    for fn in (propagate_telegram_credentials, propagate_provisioning_credentials):
+    for fn in (
+        propagate_telegram_credentials,
+        propagate_provisioning_credentials,
+        propagate_backup_passphrase,
+    ):
         try:
             path = fn(shared_dir=shared_dir, secrets_path=secrets_path)
         except Exception as exc:  # noqa: BLE001 — must never break the tick

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -54,6 +54,12 @@ _KEY_MAP_PROVISIONING = {
 # circle: a rebuilt/fresh container can decrypt the backup from the host copy.
 # The passphrase is as sensitive as everything it decrypts; the escrow file is
 # 0600 on the host mount (same trust level as the telegram/proxmox tokens here).
+# NOTE: backup.sh obtains the passphrase by `source`-ing secrets.env (full shell
+# parsing) while this escrow reads it via _read_dotenv (strip one quote layer).
+# For a passphrase containing unescaped shell metacharacters (``$``, backticks,
+# backslashes, unbalanced quotes) the two can diverge, so the escrowed value
+# would not match what encrypted the backup. The generated passphrase is a plain
+# token; keep any hand-set one shell-safe (alphanumeric / base64) to stay sound.
 _PASSPHRASE_FILENAME = "backup_passphrase.env"
 _KEY_MAP_PASSPHRASE = {
     "GENESIS_BACKUP_PASSPHRASE": "GENESIS_BACKUP_PASSPHRASE",

--- a/tests/test_guardian/test_credential_bridge.py
+++ b/tests/test_guardian/test_credential_bridge.py
@@ -317,3 +317,53 @@ class TestCombinedBridge:
             shared_dir=tmp_path / "shared", secrets_path=tmp_path / "nope.env",
         )
         assert written == []
+
+
+class TestBackupPassphraseEscrow:
+    """GENESIS_BACKUP_PASSPHRASE escrow — breaks the circular backup trap."""
+
+    def test_escrows_only_the_passphrase(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import (
+            load_backup_passphrase,
+            propagate_backup_passphrase,
+        )
+        secrets = tmp_path / "container" / "secrets.env"
+        secrets.parent.mkdir(parents=True)
+        secrets.write_text(
+            "ANTHROPIC_API_KEY=should-not-appear\n"
+            "GENESIS_BACKUP_PASSPHRASE=s3cret-pass-phrase\n"
+            "TELEGRAM_BOT_TOKEN=should-not-appear\n"
+        )
+        shared = tmp_path / "state" / "shared"
+        out = propagate_backup_passphrase(shared_dir=shared, secrets_path=secrets)
+        assert out is not None
+        assert out.name == "backup_passphrase.env"
+        assert stat.S_IMODE(os.stat(out).st_mode) == 0o600
+        result = load_backup_passphrase(str(tmp_path / "state"))
+        assert result == {"GENESIS_BACKUP_PASSPHRASE": "s3cret-pass-phrase"}
+
+    def test_absent_passphrase_skips(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import propagate_backup_passphrase
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text("TELEGRAM_BOT_TOKEN=bot\n")
+        assert propagate_backup_passphrase(
+            shared_dir=tmp_path / "shared", secrets_path=secrets,
+        ) is None
+
+    def test_load_missing_returns_empty(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import load_backup_passphrase
+        assert load_backup_passphrase(str(tmp_path / "nope")) == {}
+
+    def test_combined_bridge_includes_passphrase(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import propagate_guardian_credentials
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text(
+            "TELEGRAM_BOT_TOKEN=bot\nTELEGRAM_FORUM_CHAT_ID=chat\n"
+            "PROXMOX_AUDIT_TOKEN=audit\n"
+            "GENESIS_BACKUP_PASSPHRASE=pp\n"
+        )
+        written = propagate_guardian_credentials(
+            shared_dir=tmp_path / "state" / "shared", secrets_path=secrets,
+        )
+        names = sorted(p.name for p in written)
+        assert names == ["backup_passphrase.env", "proxmox_creds.env", "telegram_creds.env"]


### PR DESCRIPTION
## Why

Two latent disaster-recovery gaps in the backup system:

1. **Circular passphrase trap.** `GENESIS_BACKUP_PASSPHRASE` lived *only* inside the `secrets.env` that the backup encrypts *with* it. A secrets.env loss (the exact zeroing/corruption class that has bitten this environment) → all auth gone **and** the encrypted backup undecryptable. The safety net had no anchor.
2. **Backup coverage stopped at secrets.env.** SSH keys (incl. the guardian control-plane key), gh/Claude credentials, and host/network wiring config weren't backed up — the difference between "restore" and "reprovision from scratch."

## What

**G.2 — break the circular trap (escrow):** `credential_bridge.py` gains `propagate_backup_passphrase`, which escrows the passphrase to the host-side shared mount (`0600`, outside the container's blast radius, alongside the existing telegram/proxmox token escrow the awareness tick already writes). `restore.sh` falls back to the escrowed passphrase when the env/secrets copy is gone. **The escrow lives outside every backup source, so it never re-enters the encrypted set** — the circle stays broken.

**G.3 — expand coverage:** `backup.sh` now also GPG-encrypts (Tier-1 + Tier-2) `~/.ssh/*`, gh `hosts.yml`, Claude `.credentials.json`/`.claude.json`, and `guardian_remote.yaml`/`genesis.yaml`. Missing files are skipped; plaintext is refused without a passphrase. `restore.sh` decrypts them to a **staging dir** (never auto-clobbering live keys), private-by-creation (`umask 077` + `0700`).

## Safety review (this is credential code)

A focused security review verified the critical invariant: **the plaintext escrow is never included in any backup source** (traced every backup.sh path vs `~/.genesis/shared/`), all `creds/*.gpg` are committed encrypted only, and the passphrase is only ever passed via `--passphrase-fd 0` (never argv). Three findings raised and fixed: the restore-staging perms window (`umask 077` before decrypt), a passphrase parser-divergence note (keep hand-set passphrases shell-safe), and Tier-2 creds coverage (so the "COMPLETE snapshot" contract stays true for a git-less restore).

## Tests / verification

- `tests/test_guardian/test_credential_bridge.py`: escrow propagate/load, absent-passphrase skip, combined-bridge 3-leg fanout (27 file tests green; ruff clean; `bash -n` on both scripts).
- Functional-verified: the escrowed passphrase gpg-decrypts the backup (parse handles `=`/space/unicode); creds restore stages with correct `ssh/` nesting and `0600`/`0700` perms.
- Full backup→restore E2E will run live after merge+deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)