### PR TITLE
docs(modules): narrow module memory-write contract to match reality

### DIFF
--- a/src/genesis/modules/base.py
+++ b/src/genesis/modules/base.py
@@ -18,13 +18,18 @@ class CapabilityModule(Protocol):
     The unifying property is "hands, not brain" — modules can be plugged in
     and unplugged without affecting Genesis identity, reflection, or learning.
     A module may *observe* Genesis's state, but it does not *think with* it:
-    no memory writes, no reflection contribution, no ego role. Components that
-    participate in Genesis's cognitive operations belong elsewhere (memory,
-    reflection, ego, sentinel) — not in modules. In particular, a module is
-    NEVER a Genesis *subsystem*: module code must never set a
-    ``source_subsystem`` on a memory write (that tag is reserved for internal
-    subsystems and excludes the write from recall). This is enforced
-    mechanically by ``tests/test_memory/test_store_subsystem_coverage.py``.
+    no reflection contribution, no ego role, and no read-then-write cognitive
+    loop with memory. The one sanctioned memory surface is the *observation
+    writer* (``learning/observation_writer.py``): a module may emit
+    observations to core memory through it — e.g. ``generalization.py``
+    promoting a generalizable lesson — but it never calls the memory store
+    directly as a cognitive participant. Components that participate in
+    Genesis's cognitive operations belong elsewhere (memory, reflection, ego,
+    sentinel) — not in modules. In particular, a module is NEVER a Genesis
+    *subsystem*: module code must never set a ``source_subsystem`` on a
+    memory write (that tag is reserved for internal subsystems and excludes
+    the write from recall). This is enforced mechanically by
+    ``tests/test_memory/test_store_subsystem_coverage.py``.
 
     ## Implementing a Native Module
 

--- a/src/genesis/modules/generalization.py
+++ b/src/genesis/modules/generalization.py
@@ -95,6 +95,10 @@ class GeneralizationFilter:
     ) -> str | None:
         """Write a generalizable lesson to Genesis core memory.
 
+        This is the sanctioned module→core bridge: modules emit observations
+        through the observation writer, never via the memory store directly
+        (see the module contract in ``modules/base.py``).
+
         Promoted observations get:
         - source: "module:<name>" (traceable provenance)
         - category: "generalizable_lesson"


### PR DESCRIPTION
## What

`modules/base.py` states the module contract as "no memory writes" (absolute) — but `modules/generalization.py` has always promoted generalizable lessons to core memory through the observation writer. The contradiction is prose-only: the enforced invariant is narrower and already CI-checked.

## Change

- **`modules/base.py`** — replace the absolute "no memory writes" clause with the accurate contract: modules may emit observations to core memory via the observation writer (`learning/observation_writer.py`), the one sanctioned module→core bridge, but never call the memory store directly, never set `source_subsystem`, never contribute to reflection/ego, never form a read-then-write cognitive loop.
- **`modules/generalization.py`** — one-paragraph docstring note naming `promote_to_core` as that sanctioned bridge, cross-referencing the contract.

Docs-only; no behavior change. The mechanical enforcement (`tests/test_memory/test_store_subsystem_coverage.py`) is untouched and still green — verified no module anywhere calls `.store()` directly (the observation writer is the only memory surface under `modules/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)