### PR TITLE
fix(mcp): resolve short id: handles in memory_expand instead of silent []

### DIFF
--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -339,6 +339,26 @@ async def get_metadata(
     }
 
 
+async def match_id_prefix(
+    db: aiosqlite.Connection,
+    prefix: str,
+    *,
+    limit: int = 2,
+) -> list[str]:
+    """Memory IDs starting with *prefix* (e.g. an 8-char ``id:`` handle).
+
+    ``limit=2`` lets callers distinguish unique from ambiguous without
+    counting every match. Parameterized LIKE; callers are expected to
+    pre-validate the prefix shape (hex/dash).
+    """
+    rows = await db.execute_fetchall(
+        "SELECT memory_id FROM memory_metadata"
+        " WHERE memory_id LIKE ? || '%' LIMIT ?",
+        (prefix, limit),
+    )
+    return [str(r[0]) for r in rows]
+
+
 async def delete_metadata(db: aiosqlite.Connection, *, memory_id: str) -> bool:
     """Delete a memory_metadata row. Returns True if deleted."""
     cursor = await db.execute(

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import asdict
 from datetime import UTC, datetime
 
@@ -402,6 +403,49 @@ async def memory_recall(
     return enriched
 
 
+_UUID_LEN = 36
+# Hex (with optional dashes) 4–35 chars — a partial memory UUID. Anything
+# else (full UUIDs, non-hex ids) bypasses prefix resolution untouched.
+_ID_PREFIX_RE = re.compile(r"^[0-9a-f][0-9a-f-]{3,34}$")
+
+
+async def _resolve_id_prefixes(
+    db, memory_ids: list[str],
+) -> tuple[list[str], list[str]]:
+    """Resolve short hex handles to full memory UUIDs via memory_metadata.
+
+    The proactive memory hook surfaces memories as ``id:<8-char-prefix>``
+    handles and documents memory_expand as the expansion path, so those
+    handles must resolve here. Unknown prefixes pass through unchanged (they
+    surface in ``not_found``); ambiguous prefixes are never guessed; DB
+    errors fail open (identical behavior to no resolver).
+
+    Returns ``(resolved_ids, ambiguous_handles)``.
+    """
+    resolved: list[str] = []
+    ambiguous: list[str] = []
+    for raw in memory_ids:
+        mid = raw.strip().lower().removeprefix("id:")
+        if len(mid) >= _UUID_LEN or not _ID_PREFIX_RE.match(mid):
+            resolved.append(mid)
+            continue
+        try:
+            from genesis.db.crud.memory import match_id_prefix
+
+            matches = await match_id_prefix(db, mid, limit=2)
+        except Exception:
+            logger.debug("prefix resolution failed for %r", raw, exc_info=True)
+            resolved.append(mid)
+            continue
+        if len(matches) == 1:
+            resolved.append(matches[0])
+        elif matches:
+            ambiguous.append(raw)
+        else:
+            resolved.append(mid)
+    return resolved, ambiguous
+
+
 @mcp.tool()
 async def memory_expand(
     memory_ids: list[str],
@@ -409,11 +453,17 @@ async def memory_expand(
     """Fetch full content + graph neighbors for specific memory IDs.
 
     Use after a compact memory_recall to selectively expand interesting results.
-    Returns full RetrievalResult data with graph enrichment for each ID found.
+    Accepts full UUIDs or the proactive hook's short handles (``id:xxxxxxxx``
+    or bare 8-char hex prefixes). Returns full RetrievalResult data with graph
+    enrichment for each ID found; unresolved or ambiguous handles are reported
+    in a trailing ``{"not_found": [...], "ambiguous": [...]}`` entry instead
+    of being silently dropped.
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._qdrant is not None and memory_mod._db is not None
+
+    memory_ids, ambiguous = await _resolve_id_prefixes(memory_mod._db, memory_ids)
 
     # Batch retrieve from all collections (episodic_memory + knowledge_base).
     # Track which collection each point came from — it's the authoritative
@@ -435,7 +485,10 @@ async def memory_expand(
             logger.warning("Qdrant retrieve from %s failed", coll, exc_info=True)
 
     if not points:
-        return []
+        trailer: dict = {"not_found": memory_ids}
+        if ambiguous:
+            trailer["ambiguous"] = ambiguous
+        return [trailer]
 
     found_ids = {str(p.id) for p in points}
     not_found = [mid for mid in memory_ids if mid not in found_ids]
@@ -508,8 +561,11 @@ async def memory_expand(
 
         results.append(d)
 
-    if not_found:
-        results.append({"not_found": not_found})
+    if not_found or ambiguous:
+        trailer = {"not_found": not_found}
+        if ambiguous:
+            trailer["ambiguous"] = ambiguous
+        results.append(trailer)
 
     return results
 

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -506,3 +506,126 @@ async def test_memory_recall_full_path_labels_post_crag(mock_deps, tools, monkey
     assert by_id["ep1"]["provenance"] == "first-party memory"
     assert by_id["kb_aug"]["collection"] == "knowledge_base"
     assert by_id["kb_aug"]["provenance"].startswith("external-world knowledge")
+
+
+# ─── PR0: prefix-handle resolution (proactive-hook `id:xxxxxxxx` contract) ───
+
+_FULL_ID = "9d36f039-3126-4721-8c71-027df1a94e2a"
+
+
+def _db_resolving(rows_by_prefix):
+    """MagicMock db whose execute_fetchall answers prefix lookups."""
+    db = MagicMock()
+
+    async def _fetchall(sql, params=None):
+        return rows_by_prefix.get(params[0], []) if params else []
+
+    db.execute_fetchall = MagicMock(side_effect=_fetchall)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_resolves_prefix_handle(mock_deps, tools):
+    """An 8-char hex handle (the proactive hook's `id:xxxxxxxx` format) must
+    resolve to the full UUID via memory_metadata before hitting Qdrant."""
+    from types import SimpleNamespace
+
+    _init_with_mocks(mock_deps)
+    memory_mcp._db = _db_resolving({"9d36f039": [(_FULL_ID,)]})
+
+    seen_ids = []
+
+    def _retrieve(collection_name, ids, with_payload):
+        seen_ids.append(list(ids))
+        if collection_name == "episodic_memory":
+            return [SimpleNamespace(id=_FULL_ID, payload={"content": "fact"})]
+        return []
+
+    memory_mcp._qdrant.retrieve = MagicMock(side_effect=_retrieve)
+
+    results = await tools["memory_expand"].fn(memory_ids=["9d36f039"])
+    by_id = {r["memory_id"]: r for r in results if "memory_id" in r}
+    assert _FULL_ID in by_id
+    assert all(_FULL_ID in ids for ids in seen_ids)
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_strips_id_colon_and_case(mock_deps, tools):
+    """A verbatim pasted `id:9D36F039` handle still resolves."""
+    from types import SimpleNamespace
+
+    _init_with_mocks(mock_deps)
+    memory_mcp._db = _db_resolving({"9d36f039": [(_FULL_ID,)]})
+    memory_mcp._qdrant.retrieve = MagicMock(
+        side_effect=lambda collection_name, ids, with_payload: (
+            [SimpleNamespace(id=_FULL_ID, payload={"content": "fact"})]
+            if collection_name == "episodic_memory" and _FULL_ID in ids else []
+        )
+    )
+
+    results = await tools["memory_expand"].fn(memory_ids=["ID:9D36F039"])
+    assert any(r.get("memory_id") == _FULL_ID for r in results)
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_ambiguous_prefix_reported(mock_deps, tools):
+    """An ambiguous prefix must not guess — it is reported, never resolved."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._db = _db_resolving(
+        {"abcd1234": [("abcd1234-aaaa",), ("abcd1234-bbbb",)]}
+    )
+    memory_mcp._qdrant.retrieve = MagicMock(return_value=[])
+
+    results = await tools["memory_expand"].fn(memory_ids=["abcd1234"])
+    assert results == [{"not_found": [], "ambiguous": ["abcd1234"]}]
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_empty_result_reports_not_found(mock_deps, tools):
+    """When nothing resolves, the tool must say so — never a silent []."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._db = _db_resolving({})
+    memory_mcp._qdrant.retrieve = MagicMock(return_value=[])
+
+    results = await tools["memory_expand"].fn(memory_ids=[_FULL_ID])
+    assert results == [{"not_found": [_FULL_ID]}]
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_non_hex_short_ids_skip_resolution(mock_deps, tools):
+    """Short non-hex IDs (e.g. test fixtures like 'ep1') bypass the prefix
+    lookup entirely — no DB call, passed through to Qdrant unchanged."""
+    from types import SimpleNamespace
+
+    _init_with_mocks(mock_deps)
+    db = MagicMock()
+    db.execute_fetchall = MagicMock()
+    memory_mcp._db = db
+    memory_mcp._qdrant.retrieve = MagicMock(
+        side_effect=lambda collection_name, ids, with_payload: (
+            [SimpleNamespace(id="ep1", payload={"content": "x"})]
+            if collection_name == "episodic_memory" else []
+        )
+    )
+
+    results = await tools["memory_expand"].fn(memory_ids=["ep1"])
+    assert any(r.get("memory_id") == "ep1" for r in results)
+    db.execute_fetchall.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_db_error_fails_open(mock_deps, tools):
+    """A broken prefix lookup must not take the tool down — the raw handle
+    passes through and surfaces in not_found."""
+    _init_with_mocks(mock_deps)
+    db = MagicMock()
+
+    async def _boom(sql, params=None):
+        raise RuntimeError("db down")
+
+    db.execute_fetchall = MagicMock(side_effect=_boom)
+    memory_mcp._db = db
+    memory_mcp._qdrant.retrieve = MagicMock(return_value=[])
+
+    results = await tools["memory_expand"].fn(memory_ids=["9d36f039"])
+    assert results == [{"not_found": ["9d36f039"]}]


### PR DESCRIPTION
## Problem

The proactive memory hook surfaces memories as \`id:<8-char>\` handles, and the documented contract (CLAUDE.md L2 layer) tells sessions to pass those handles to \`memory_expand\`. But the tool passed IDs raw to Qdrant \`retrieve\` — which requires full-UUID point IDs — so every handle-based expand silently returned \`[]\`, with no diagnostic. Found live while verifying an unrelated plan's target memory.

Second defect in the same path: when *nothing* resolved, the early-return skipped the \`not_found\` trailer entirely — the silent-empty case gave callers no signal anything went wrong.

## Fix

- \`_resolve_id_prefixes\`: strips an optional \`id:\` prefix (case-insensitive), and resolves hex-ish handles (4–35 hex/dash chars) against \`memory_metadata\` via a parameterized \`LIKE\` (LIMIT 2). Unique match → full UUID. Ambiguous → reported, never guessed. Unknown → passes through into \`not_found\`. DB errors fail open (identical to pre-fix behavior).
- Non-hex short IDs (e.g. literal test IDs) bypass resolution entirely — no DB call.
- Empty results now return \`[{"not_found": [...], "ambiguous": [...]}]\` instead of a bare \`[]\`.
- Zero writes introduced; the resolver is a single SELECT.

## Verification

- 6 new tests (prefix resolve, \`ID:\` case variant, ambiguous, silent-empty, non-hex bypass, DB-error fail-open); 27/27 in the file, plus the two other memory_expand-touching test files green (12/12).
- E2E against live stores: 8-char handle → full UUID → real Qdrant point retrieved; a real colliding 4-char prefix correctly reported ambiguous.
- No non-test Python callers pattern-match the old \`[]\` shape (searched; the consumers are LLM sessions via MCP).

## Notes

MCP servers load code at CC session start — the fix takes effect for new sessions after merge; verified post-merge by expanding a handle in a fresh session.