### PR TITLE
fix(memory): retrieval correctness — drift FTS source parity + raw scores for J-9 (MEM-006, mem-007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   incident and silently drop it to alert-only. It now falls back to a writable
   state dir so the self-healing path keeps working.
 
+- **Knowledge-base results no longer go missing from DRIFT memory recall's
+  keyword arm.** The wing-scoped keyword (FTS) search inside the DRIFT
+  fallback pipeline only ever looked at episodic memories, so a recall that
+  included knowledge sources could only surface knowledge via vector
+  similarity — exact-phrase and keyword matches on ingested docs were
+  silently dropped. It now searches every requested collection.
 - **Asking Genesis to grow a disk or wait on your reply now works from a Claude
   Code session, not only from inside the running server.** The two tools that
   block on your Telegram reply (`provision_grow`, `outreach_send_and_wait`) need

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -44,7 +44,7 @@ stack.** Deep path: `memory/retrieval.py` `HybridRetriever.recall` (bitemporal
 `invalid_at` filter, entrenchment, activation/decay, graph boost, diversity
 penalty). The diversity penalty only shapes ORDERING —
 `RetrievalResult.retrieval_score` carries the pre-penalty score and is what
-J-9 quality logging reads (mem-007; the MCP MEM-003 enrichment reads it too).
+J-9 quality logging reads (the MCP MEM-003 enrichment reads it too).
 Easy-to-forget mechanisms:
 
 - **CRAG** lives in the MCP-wrapper only (`memory/corrective.py`
@@ -54,8 +54,8 @@ Easy-to-forget mechanisms:
   API_KEY_VOYAGE-gated; the `rerank=` param is off by default at the retriever
   and applied by callers.
 - **`drift_recall`** (`memory/drift.py`) is the degraded-mode fallback; its
-  FTS drilldown searches every collection in `source_collections`
-  (MEM-006 fixed 2026-07-09; was hardcoded to `episodic_memory`).
+  FTS drilldown searches every collection in `source_collections`,
+  rank-merged across collections.
 - The proactive per-prompt path is `scripts/proactive_memory_hook.py` — an
   **independent reimplementation** (own FTS5→Qdrant→RRF pipeline), not a
   `HybridRetriever` caller. The `memory_proactive` MCP tool is registered but

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -36,13 +36,16 @@ side.
 ```yaml subsystem-map
 entry: memory
 modules: [memory, qdrant]
-verified: 9037d45b 2026-07-07
+verified: d3d48d94 2026-07-09
 ```
 
 **Retrieval is TIERED — the hottest auto-fired paths carry the thinnest
 stack.** Deep path: `memory/retrieval.py` `HybridRetriever.recall` (bitemporal
 `invalid_at` filter, entrenchment, activation/decay, graph boost, diversity
-penalty). Easy-to-forget mechanisms:
+penalty). The diversity penalty only shapes ORDERING —
+`RetrievalResult.retrieval_score` carries the pre-penalty score and is what
+J-9 quality logging reads (mem-007; the MCP MEM-003 enrichment reads it too).
+Easy-to-forget mechanisms:
 
 - **CRAG** lives in the MCP-wrapper only (`memory/corrective.py`
   `maybe_correct_recall`; `top_score >= 0.75` skips grading) — not in
@@ -51,7 +54,8 @@ penalty). Easy-to-forget mechanisms:
   API_KEY_VOYAGE-gated; the `rerank=` param is off by default at the retriever
   and applied by callers.
 - **`drift_recall`** (`memory/drift.py`) is the degraded-mode fallback; its
-  FTS drilldown is hardcoded to `episodic_memory` (known MEM-006).
+  FTS drilldown searches every collection in `source_collections`
+  (MEM-006 fixed 2026-07-09; was hardcoded to `episodic_memory`).
 - The proactive per-prompt path is `scripts/proactive_memory_hook.py` — an
   **independent reimplementation** (own FTS5→Qdrant→RRF pipeline), not a
   `HybridRetriever` caller. The `memory_proactive` MCP tool is registered but

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -278,9 +278,14 @@ async def memory_recall(
         recall_event_sink[0] if recall_event_sink else None
     )
     try:
-        _top_scores = [r.score for r in results[:5]]
+        # mem-007: J-9 quality metrics use the PRE-diversity-penalty score
+        # (retrieval_score); ``score`` is the final ordering value with the
+        # echo-cluster penalty applied — logging it understates penalized
+        # results. Fall back to ``score`` for paths that don't populate
+        # retrieval_score (0.0 == unset; real fused scores are always > 0).
+        _top_scores = [r.retrieval_score or r.score for r in results[:5]]
         _memory_ids = [r.memory_id for r in results[:10]]
-        _all_scores = [r.score for r in results]
+        _all_scores = [r.retrieval_score or r.score for r in results]
         _mean_score = (
             round(sum(_all_scores) / len(_all_scores), 4) if _all_scores else None
         )

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -278,7 +278,7 @@ async def memory_recall(
         recall_event_sink[0] if recall_event_sink else None
     )
     try:
-        # mem-007: J-9 quality metrics use the PRE-diversity-penalty score
+        # J-9 quality metrics use the PRE-diversity-penalty score
         # (retrieval_score); ``score`` is the final ordering value with the
         # echo-cluster penalty applied — logging it understates penalized
         # results. Fall back to ``score`` for paths that don't populate

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -48,7 +48,7 @@ def _apply_authority_boost(merged: list[dict]) -> list[dict]:
                 boost = multiplier
                 break
         item["score"] = item.get("score", 0.0) * boost
-        # mem-007: the authority boost is a legitimate quality signal (like
+        # The authority boost is a legitimate quality signal (like
         # graph boost), so the pre-diversity-penalty score carries it too —
         # only the echo-dedup penalty is excluded from J-9 quality metrics.
         if "retrieval_score" in item:
@@ -114,7 +114,7 @@ async def knowledge_recall(
             "source": r.source,
             "source_doc": r.source,
             "score": r.score,
-            # mem-007: pre-diversity-penalty score, for J-9 metrics only —
+            # Pre-diversity-penalty score, for J-9 metrics only —
             # ordering/floor stay on the penalized ``score``. Fallback for
             # paths that don't populate it (0.0 == unset).
             "retrieval_score": r.retrieval_score or r.score,
@@ -137,7 +137,7 @@ async def knowledge_recall(
                 "domain": fts_row.get("domain", ""),
                 "project_type": fts_row.get("project_type", ""),
                 "score": fts_score,
-                # mem-007: synthetic FTS score never saw the diversity
+                # The synthetic FTS score never saw the diversity
                 # penalty — raw == final.
                 "retrieval_score": fts_score,
                 "origin": "fts",
@@ -163,7 +163,7 @@ async def knowledge_recall(
         recall_event_sink[0] if recall_event_sink else None
     )
     try:
-        # mem-007: J-9 metrics read the pre-diversity-penalty score
+        # J-9 metrics read the pre-diversity-penalty score
         # (authority boost included); ordering/floor above used ``score``.
         _top_scores = [
             r.get("retrieval_score") or r.get("score", 0.0) for r in final[:5]

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -48,6 +48,11 @@ def _apply_authority_boost(merged: list[dict]) -> list[dict]:
                 boost = multiplier
                 break
         item["score"] = item.get("score", 0.0) * boost
+        # mem-007: the authority boost is a legitimate quality signal (like
+        # graph boost), so the pre-diversity-penalty score carries it too —
+        # only the echo-dedup penalty is excluded from J-9 quality metrics.
+        if "retrieval_score" in item:
+            item["retrieval_score"] = item["retrieval_score"] * boost
     merged.sort(key=lambda x: x.get("score", 0.0), reverse=True)
     return merged
 
@@ -109,6 +114,10 @@ async def knowledge_recall(
             "source": r.source,
             "source_doc": r.source,
             "score": r.score,
+            # mem-007: pre-diversity-penalty score, for J-9 metrics only —
+            # ordering/floor stay on the penalized ``score``. Fallback for
+            # paths that don't populate it (0.0 == unset).
+            "retrieval_score": r.retrieval_score or r.score,
             "origin": "vector",
             "source_pipeline": r.source_pipeline,
         })
@@ -128,6 +137,9 @@ async def knowledge_recall(
                 "domain": fts_row.get("domain", ""),
                 "project_type": fts_row.get("project_type", ""),
                 "score": fts_score,
+                # mem-007: synthetic FTS score never saw the diversity
+                # penalty — raw == final.
+                "retrieval_score": fts_score,
                 "origin": "fts",
                 "source_pipeline": fts_row.get("source_pipeline"),
             })
@@ -151,7 +163,11 @@ async def knowledge_recall(
         recall_event_sink[0] if recall_event_sink else None
     )
     try:
-        _top_scores = [r.get("score", 0.0) for r in final[:5]]
+        # mem-007: J-9 metrics read the pre-diversity-penalty score
+        # (authority boost included); ordering/floor above used ``score``.
+        _top_scores = [
+            r.get("retrieval_score") or r.get("score", 0.0) for r in final[:5]
+        ]
         _memory_ids = [r.get("unit_id", "") for r in final[:10]]
         if recall_event_id is not None:
             from genesis.eval.j9_hooks import update_recall_metrics

--- a/src/genesis/memory/drift.py
+++ b/src/genesis/memory/drift.py
@@ -190,30 +190,39 @@ async def _local_drilldown(
     # Scoped FTS5 search (room filter via tag match if available)
     fts_query = query
     if wing:
-        # MEM-006: mirror the vector arm below — search each source
-        # collection's FTS rows. Hardcoding ``episodic_memory`` here made
-        # knowledge recall vector-only in the wing-scoped phase (knowledge
-        # rows ARE FTS-indexed under collection='knowledge_base').
-        fts_ids: list[str] = []
+        # Mirror the vector arm below — search each source collection's FTS
+        # rows (hardcoding ``episodic_memory`` here made knowledge recall
+        # vector-only in the wing-scoped phase; knowledge rows ARE
+        # FTS-indexed under collection='knowledge_base'). Merge across
+        # collections by FTS rank — bm25, lower = more relevant, and ranks
+        # are comparable because every collection lives in the same
+        # ``memory_fts`` table under the same query. Appending
+        # per-collection pages instead would rank every hit of the first
+        # collection above the second's regardless of relevance, and this
+        # order matters: ``local_ids`` feeds RRF as a ranked list.
+        fts_rows: list[dict] = []
         for collection in source_collections:
-            fts_results = await memory_crud.search_ranked(
+            fts_rows.extend(await memory_crud.search_ranked(
                 db, query=fts_query, collection=collection, limit=local_limit,
                 exclude_subsystems=exclude_subsystems,
                 include_only_subsystems=include_only_subsystems,
-            )
-            fts_ids.extend(r["memory_id"] for r in fts_results)
-        # Preserve rank order, drop cross-collection duplicates
-        fts_ids = list(dict.fromkeys(fts_ids))
+            ))
+        fts_rows.sort(key=lambda r: r["rank"])
+        # Rank order preserved; drop cross-collection duplicates
+        fts_ids = list(dict.fromkeys(r["memory_id"] for r in fts_rows))
         # Filter results by wing in post-processing (FTS5 doesn't support wing filter)
         if fts_ids:
-            # Verify wing membership
+            # Verify wing membership. Filter as a SET and keep the ranked
+            # order — the IN-clause SELECT returns rows in table-scan
+            # order, which would rescramble the rank merge above.
             placeholders = ",".join("?" * len(fts_ids))
             wing_query = f"""
                 SELECT memory_id FROM memory_metadata
                 WHERE memory_id IN ({placeholders}) AND wing = ?
             """
             async with db.execute(wing_query, [*fts_ids, wing]) as cursor:
-                fts_ids = [row[0] async for row in cursor]
+                wing_members = {row[0] async for row in cursor}
+            fts_ids = [mid for mid in fts_ids if mid in wing_members]
         local_ids.extend(fts_ids)
 
     # Scoped vector search with wing filter
@@ -415,7 +424,7 @@ async def drift_recall(
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,
                 collection=row.get("collection", "episodic_memory"),
-                # mem-007: DRIFT applies no diversity penalty — raw == final.
+                # DRIFT applies no diversity penalty — raw == final.
                 retrieval_score=fused_scores[mid],
             )
         )

--- a/src/genesis/memory/drift.py
+++ b/src/genesis/memory/drift.py
@@ -190,24 +190,30 @@ async def _local_drilldown(
     # Scoped FTS5 search (room filter via tag match if available)
     fts_query = query
     if wing:
-        # FTS5 can filter by tags field which contains wing info
-        fts_results = await memory_crud.search_ranked(
-            db, query=fts_query, collection="episodic_memory", limit=local_limit,
-            exclude_subsystems=exclude_subsystems,
-            include_only_subsystems=include_only_subsystems,
-        )
+        # MEM-006: mirror the vector arm below — search each source
+        # collection's FTS rows. Hardcoding ``episodic_memory`` here made
+        # knowledge recall vector-only in the wing-scoped phase (knowledge
+        # rows ARE FTS-indexed under collection='knowledge_base').
+        fts_ids: list[str] = []
+        for collection in source_collections:
+            fts_results = await memory_crud.search_ranked(
+                db, query=fts_query, collection=collection, limit=local_limit,
+                exclude_subsystems=exclude_subsystems,
+                include_only_subsystems=include_only_subsystems,
+            )
+            fts_ids.extend(r["memory_id"] for r in fts_results)
+        # Preserve rank order, drop cross-collection duplicates
+        fts_ids = list(dict.fromkeys(fts_ids))
         # Filter results by wing in post-processing (FTS5 doesn't support wing filter)
-        fts_ids = [r["memory_id"] for r in fts_results]
-        if wing:
+        if fts_ids:
             # Verify wing membership
             placeholders = ",".join("?" * len(fts_ids))
-            if fts_ids:
-                wing_query = f"""
-                    SELECT memory_id FROM memory_metadata
-                    WHERE memory_id IN ({placeholders}) AND wing = ?
-                """
-                async with db.execute(wing_query, [*fts_ids, wing]) as cursor:
-                    fts_ids = [row[0] async for row in cursor]
+            wing_query = f"""
+                SELECT memory_id FROM memory_metadata
+                WHERE memory_id IN ({placeholders}) AND wing = ?
+            """
+            async with db.execute(wing_query, [*fts_ids, wing]) as cursor:
+                fts_ids = [row[0] async for row in cursor]
         local_ids.extend(fts_ids)
 
     # Scoped vector search with wing filter

--- a/src/genesis/memory/drift.py
+++ b/src/genesis/memory/drift.py
@@ -415,6 +415,8 @@ async def drift_recall(
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,
                 collection=row.get("collection", "episodic_memory"),
+                # mem-007: DRIFT applies no diversity penalty — raw == final.
+                retrieval_score=fused_scores[mid],
             )
         )
 

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -374,7 +374,7 @@ def _assemble_results(
     is deliberate and explicit in the parameters.
 
     ``fused`` carries the final (diversity-penalized) ordering scores;
-    ``raw_fused`` is the pre-penalty snapshot (mem-007) so J-9 logging can
+    ``raw_fused`` is the pre-penalty snapshot so J-9 logging can
     read genuine retrieval quality via ``RetrievalResult.retrieval_score``.
     """
     results: list[RetrievalResult] = []
@@ -438,7 +438,7 @@ def _assemble_results(
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,
                 collection=_collection,
-                # mem-007: pre-penalty score; falls back to the final score
+                # Pre-penalty score; falls back to the final score
                 # for ids that predate the snapshot (defensive — every id in
                 # ``top`` is in the snapshot today).
                 retrieval_score=raw_fused.get(mid, fused[mid]),
@@ -719,7 +719,7 @@ class HybridRetriever:
         # If multiple candidates have near-identical content (Jaccard ≥ 0.80),
         # penalize lower-ranked echoes to prevent sycophantic memory clusters
         # from dominating retrieval results.
-        # mem-007: snapshot the pre-penalty scores first — the penalty mutates
+        # Snapshot the pre-penalty scores first — the penalty mutates
         # ``fused`` in place, and J-9 must log retrieval QUALITY, not the
         # halved dedup artifact. ``fused`` (penalized) still drives ordering.
         raw_fused = dict(fused)
@@ -764,7 +764,7 @@ class HybridRetriever:
             emit_recall_fired,
         )
 
-        # mem-007: J-9 logs the PRE-diversity-penalty scores. ``score`` is an
+        # J-9 logs the PRE-diversity-penalty scores. ``score`` is an
         # ordering value (echo penalty applied); logging it understated the
         # quality of penalized results in top_scores/mean_score/score_spread
         # and skewed the entrenchment correlation.

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -359,6 +359,7 @@ def _assemble_results(
     qdrant_by_id: dict[str, dict],
     fts_by_id: dict[str, dict],
     fused: dict[str, float],
+    raw_fused: dict[str, float],
     activation_by_id: dict[str, float],
     vector_ranked_dedup: list[str],
     seen: set[str],
@@ -371,6 +372,10 @@ def _assemble_results(
     Vector/FTS ranks are recomputed positionally against the stage-6 ranked
     lists (``vector_ranked_dedup``/``seen``/``fts_ranked``) — that reach-back
     is deliberate and explicit in the parameters.
+
+    ``fused`` carries the final (diversity-penalized) ordering scores;
+    ``raw_fused`` is the pre-penalty snapshot (mem-007) so J-9 logging can
+    read genuine retrieval quality via ``RetrievalResult.retrieval_score``.
     """
     results: list[RetrievalResult] = []
     for mid in top:
@@ -433,6 +438,10 @@ def _assemble_results(
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,
                 collection=_collection,
+                # mem-007: pre-penalty score; falls back to the final score
+                # for ids that predate the snapshot (defensive — every id in
+                # ``top`` is in the snapshot today).
+                retrieval_score=raw_fused.get(mid, fused[mid]),
             ),
         )
     return results
@@ -710,6 +719,10 @@ class HybridRetriever:
         # If multiple candidates have near-identical content (Jaccard ≥ 0.80),
         # penalize lower-ranked echoes to prevent sycophantic memory clusters
         # from dominating retrieval results.
+        # mem-007: snapshot the pre-penalty scores first — the penalty mutates
+        # ``fused`` in place, and J-9 must log retrieval QUALITY, not the
+        # halved dedup artifact. ``fused`` (penalized) still drives ordering.
+        raw_fused = dict(fused)
         candidates = _apply_diversity_penalty(
             candidates, fused, qdrant_by_id, fts_by_id,
         )
@@ -736,6 +749,7 @@ class HybridRetriever:
             qdrant_by_id=qdrant_by_id,
             fts_by_id=fts_by_id,
             fused=fused,
+            raw_fused=raw_fused,
             activation_by_id=activation_by_id,
             vector_ranked_dedup=vector_ranked_dedup,
             seen=seen,
@@ -750,7 +764,11 @@ class HybridRetriever:
             emit_recall_fired,
         )
 
-        _scores = [r.score for r in results]
+        # mem-007: J-9 logs the PRE-diversity-penalty scores. ``score`` is an
+        # ordering value (echo penalty applied); logging it understated the
+        # quality of penalized results in top_scores/mean_score/score_spread
+        # and skewed the entrenchment correlation.
+        _scores = [r.retrieval_score for r in results]
         # MEM-005: entrenchment signal (monitor-only) — see _entrenchment_metrics.
         _entrenchment, _mean_retrieved, _mean_age_days = _entrenchment_metrics(
             results, _scores, retrieved_count_by_id, created_at_by_id, now_str,
@@ -760,7 +778,7 @@ class HybridRetriever:
             self._db,
             query=query,
             result_count=len(results),
-            top_scores=[r.score for r in results[:5]],
+            top_scores=[r.retrieval_score for r in results[:5]],
             memory_ids=[r.memory_id for r in results[:10]],
             latency_ms=(time.monotonic() - _t0) * 1000,
             source=source,

--- a/src/genesis/memory/types.py
+++ b/src/genesis/memory/types.py
@@ -52,9 +52,17 @@ class RetrievalResult:
     # retrieved from. ``knowledge_base`` == external-world knowledge; anything
     # else == first-party memory. Authoritative (always known at retrieval),
     # unlike the per-item ``source`` string. Defaults first-party so an unset
-    # value is never mislabeled external. Kept LAST for positional-construction
-    # safety. Use ``genesis.memory.provenance`` to turn it into a label.
+    # value is never mislabeled external. Defaulted fields are appended (never
+    # inserted) for positional-construction safety. Use
+    # ``genesis.memory.provenance`` to turn it into a label.
     collection: str = "episodic_memory"
+    # mem-007: the pre-diversity-penalty fused score (post-rerank, post-graph-
+    # boost). ``score`` is the FINAL ordering score — the echo-cluster penalty
+    # is applied to it so near-duplicate results rank lower. J-9 quality
+    # logging reads THIS field instead, so a dedup artifact (score * 0.5)
+    # never masquerades as retrieval quality. 0.0 == not populated (paths
+    # other than HybridRetriever.recall don't compute it).
+    retrieval_score: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/src/genesis/memory/types.py
+++ b/src/genesis/memory/types.py
@@ -56,7 +56,7 @@ class RetrievalResult:
     # inserted) for positional-construction safety. Use
     # ``genesis.memory.provenance`` to turn it into a label.
     collection: str = "episodic_memory"
-    # mem-007: the pre-diversity-penalty fused score (post-rerank, post-graph-
+    # The pre-diversity-penalty fused score (post-rerank, post-graph-
     # boost). ``score`` is the FINAL ordering score — the echo-cluster penalty
     # is applied to it so near-duplicate results rank lower. J-9 quality
     # logging reads THIS field instead, so a dedup artifact (score * 0.5)

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1434,3 +1434,60 @@ async def test_memory_recall_drift_mode_emits_exactly_one_recall_fired(db):
         assert events[0]["metrics"]["pipeline_used"] == "drift"
     finally:
         mod._store, mod._db, mod._retriever, mod._qdrant = old
+
+
+async def test_memory_recall_mcp_enrichment_uses_raw_scores(db):
+    """mem-007 (MCP layer): the MEM-003 in-place enrichment realigns the
+    retriever's recall_fired event with the final result set — it must
+    re-derive top_scores/mean_score from ``retrieval_score`` (pre-diversity-
+    penalty), NOT ``score``, or it clobbers the retriever's raw values with
+    the halved dedup artifact."""
+    import genesis.mcp.memory_mcp as mod
+    from genesis.db.crud import j9_eval
+    from genesis.eval.j9_hooks import emit_recall_fired
+    from genesis.memory.types import RetrievalResult
+
+    def _penalized(mid: str, score: float, raw: float):
+        return RetrievalResult(
+            memory_id=mid, content=f"c-{mid}", source="test",
+            memory_type="episodic", score=score, vector_rank=1, fts_rank=1,
+            activation_score=0.3, payload={}, source_pipeline="hybrid",
+            collection="episodic_memory", retrieval_score=raw,
+        )
+
+    # winner unpenalized (raw == final); echo halved (raw 1.0 → final 0.5)
+    results = [_penalized("win", 1.0, 1.0), _penalized("echo", 0.5, 1.0)]
+
+    async def fake_recall(*_a, event_id_sink=None, **_k):
+        eid = await emit_recall_fired(
+            db, query="q", result_count=len(results),
+            top_scores=[r.retrieval_score for r in results],
+            memory_ids=[r.memory_id for r in results],
+            latency_ms=1.0, source="both",
+        )
+        if event_id_sink is not None and eid is not None:
+            event_id_sink.append(eid)
+        return list(results)
+
+    mock_retriever = AsyncMock()
+    mock_retriever.recall = fake_recall
+    mock_retriever._embeddings = MagicMock()
+
+    old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+    try:
+        mod._store = MagicMock()
+        mod._db = db
+        mod._retriever = mock_retriever
+        mod._qdrant = MagicMock()
+        tools = await _get_tools()
+        await tools["memory_recall"].fn(
+            query="q", source="both", limit=10, compact=True,
+        )
+        events = await j9_eval.get_events(db, event_type="recall_fired")
+        assert len(events) == 1
+        m = events[0]["metrics"]
+        # Raw scores survive the MCP realignment: both 1.0, not [1.0, 0.5]
+        assert m["top_scores"] == pytest.approx([1.0, 1.0])
+        assert m["mean_score"] == pytest.approx(1.0)
+    finally:
+        mod._store, mod._db, mod._retriever, mod._qdrant = old

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1436,6 +1436,7 @@ async def test_memory_recall_drift_mode_emits_exactly_one_recall_fired(db):
         mod._store, mod._db, mod._retriever, mod._qdrant = old
 
 
+@pytest.mark.asyncio
 async def test_memory_recall_mcp_enrichment_uses_raw_scores(db):
     """mem-007 (MCP layer): the MEM-003 in-place enrichment realigns the
     retriever's recall_fired event with the final result set — it must
@@ -1489,5 +1490,82 @@ async def test_memory_recall_mcp_enrichment_uses_raw_scores(db):
         # Raw scores survive the MCP realignment: both 1.0, not [1.0, 0.5]
         assert m["top_scores"] == pytest.approx([1.0, 1.0])
         assert m["mean_score"] == pytest.approx(1.0)
+    finally:
+        mod._store, mod._db, mod._retriever, mod._qdrant = old
+
+
+def test_apply_authority_boost_propagates_to_retrieval_score():
+    """The authority boost is a quality signal and must scale BOTH the
+    ordering score and the raw (pre-diversity-penalty) score by the same
+    factor — and must not require the raw key to be present."""
+    from genesis.mcp.memory.knowledge import _apply_authority_boost
+
+    boosted = _apply_authority_boost([
+        {"unit_id": "a", "score": 0.6, "retrieval_score": 0.8,
+         "source_pipeline": "curated"},          # 1.5x tier
+        {"unit_id": "b", "score": 0.6, "source_pipeline": "curated"},
+    ])
+    by_id = {r["unit_id"]: r for r in boosted}
+    assert by_id["a"]["score"] == pytest.approx(0.9)
+    assert by_id["a"]["retrieval_score"] == pytest.approx(1.2)
+    assert by_id["b"]["score"] == pytest.approx(0.9)
+    assert "retrieval_score" not in by_id["b"]  # guarded, no KeyError
+
+
+async def test_knowledge_recall_enrichment_uses_raw_scores(db):
+    """knowledge_recall's J-9 enrichment must log pre-diversity-penalty
+    scores (with the authority boost applied), not the halved dedup
+    artifact carried by ``score``."""
+    import genesis.mcp.memory_mcp as mod
+    from genesis.db.crud import j9_eval
+    from genesis.eval.j9_hooks import emit_recall_fired
+    from genesis.memory.types import RetrievalResult
+
+    def _kb(mid: str, score: float, raw: float):
+        return RetrievalResult(
+            memory_id=mid, content=f"c-{mid}", source="test",
+            memory_type="knowledge", score=score, vector_rank=1,
+            fts_rank=None, activation_score=0.3, payload={},
+            source_pipeline="curated",  # 1.5x authority tier
+            collection="knowledge_base", retrieval_score=raw,
+        )
+
+    # echo penalized for ordering (0.6 -> 0.3) but raw stays 0.6;
+    # after the 1.5x curated boost: scores [0.9, 0.45], raws [0.9, 0.9]
+    results = [_kb("kb-win", 0.6, 0.6), _kb("kb-echo", 0.3, 0.6)]
+
+    async def fake_recall(*_a, event_id_sink=None, **_k):
+        eid = await emit_recall_fired(
+            db, query="q", result_count=len(results),
+            top_scores=[r.retrieval_score for r in results],
+            memory_ids=[r.memory_id for r in results],
+            latency_ms=1.0, source="knowledge",
+        )
+        if event_id_sink is not None and eid is not None:
+            event_id_sink.append(eid)
+        return list(results)
+
+    mock_retriever = AsyncMock()
+    mock_retriever.recall = fake_recall
+
+    old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+    try:
+        mod._store = MagicMock()
+        mod._db = db
+        mod._retriever = mock_retriever
+        mod._qdrant = MagicMock()
+        tools = await _get_tools()
+        out = await tools["knowledge_recall"].fn(
+            query="q", limit=5, corrective=False,
+        )
+        # Ordering/return still keyed on the penalized+boosted score
+        assert [r["unit_id"] for r in out] == ["kb-win", "kb-echo"]
+        events = await j9_eval.get_events(db, event_type="recall_fired")
+        assert len(events) == 1  # enriched in place, no second emit
+        m = events[0]["metrics"]
+        assert m["top_scores"] == pytest.approx([0.9, 0.9]), (
+            "J-9 must see boosted RAW scores, not the penalized ordering "
+            f"values — got {m['top_scores']}"
+        )
     finally:
         mod._store, mod._db, mod._retriever, mod._qdrant = old

--- a/tests/test_memory/test_drift.py
+++ b/tests/test_memory/test_drift.py
@@ -362,3 +362,48 @@ class TestLocalDrilldownCollections:
 
         assert seen_collections == ["episodic_memory"]
         assert ids == ["ep1"]
+
+    @pytest.mark.asyncio
+    async def test_fts_drilldown_merges_by_rank_across_collections(self):
+        """A knowledge hit with a BETTER FTS rank must precede weaker
+        episodic hits in the returned order (Codex P2): local_ids feeds RRF
+        as a ranked list, so naive per-collection appending would rank every
+        hit of the first collection above the second's regardless of
+        relevance. Ranks are comparable — same memory_fts table, same query.
+        """
+        # Wing filter passes all three (single shared cursor is fine — the
+        # filter must also PRESERVE the rank-merged order, not rescramble it)
+        db = self._db_with_wing_rows([("ep1",), ("ep2",), ("kb1",)])
+        rows_by_collection = {
+            "episodic_memory": [
+                {"memory_id": "ep1", "content": "e1", "rank": -5.0},
+                {"memory_id": "ep2", "content": "e2", "rank": -3.0},
+            ],
+            # kb1 outranks both episodic hits (more negative = better)
+            "knowledge_base": [
+                {"memory_id": "kb1", "content": "k1", "rank": -9.0},
+            ],
+        }
+
+        async def fake_search_ranked(db_, *, query, limit,
+                                     collection=None, **kw):
+            return rows_by_collection[collection]
+
+        with patch(
+            "genesis.memory.drift.memory_crud.search_ranked",
+            new=AsyncMock(side_effect=fake_search_ranked),
+        ):
+            ids = await _local_drilldown(
+                "test query",
+                db=db,
+                qdrant_client=MagicMock(),
+                embedding_provider=self._failing_embeddings(),
+                source_collections=["episodic_memory", "knowledge_base"],
+                wing="memory",
+                room=None,
+                global_ids=[],
+            )
+
+        assert ids == ["kb1", "ep1", "ep2"], (
+            f"expected rank-merged order [kb1, ep1, ep2], got {ids!r}"
+        )

--- a/tests/test_memory/test_drift.py
+++ b/tests/test_memory/test_drift.py
@@ -10,6 +10,7 @@ from genesis.memory.drift import (
     _coalesce,
     _global_primer,
     _identify_clusters,
+    _local_drilldown,
     _rrf_fuse,
     drift_recall,
 )
@@ -256,3 +257,108 @@ class TestDriftRecallDefaultSource:
         assert call_kwargs["source_collections"] == ["episodic_memory"], (
             f"Expected ['episodic_memory'], got {call_kwargs['source_collections']!r}"
         )
+
+
+class TestLocalDrilldownCollections:
+    """MEM-006: the scoped FTS drill-down must honor source_collections.
+
+    The vector arm already loops over ``source_collections``; the FTS arm
+    hardcoded ``episodic_memory``, making knowledge recall vector-only in
+    the wing-scoped phase.
+    """
+
+    @staticmethod
+    def _wing_cursor(rows):
+        """Async context-manager cursor for the wing post-filter query."""
+
+        class _Cursor:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def __aiter__(self):
+                async def gen():
+                    for r in rows:
+                        yield r
+
+                return gen()
+
+        return _Cursor()
+
+    def _db_with_wing_rows(self, rows):
+        db = MagicMock()
+        db.execute = MagicMock(return_value=self._wing_cursor(rows))
+        return db
+
+    @staticmethod
+    def _failing_embeddings():
+        embeddings = AsyncMock()
+        embeddings.embed = AsyncMock(side_effect=Exception("no embeddings"))
+        return embeddings
+
+    @pytest.mark.asyncio
+    async def test_fts_drilldown_searches_all_source_collections(self):
+        """With source='both'-style collections, FTS must hit each one."""
+        # Both ids pass the wing post-filter
+        db = self._db_with_wing_rows([("ep1",), ("kb1",)])
+        seen_collections: list[str | None] = []
+
+        async def fake_search_ranked(db_, *, query, limit,
+                                     collection=None, **kw):
+            seen_collections.append(collection)
+            if collection == "knowledge_base":
+                return [{"memory_id": "kb1", "content": "kb", "rank": -1.0}]
+            return [{"memory_id": "ep1", "content": "ep", "rank": -2.0}]
+
+        with patch(
+            "genesis.memory.drift.memory_crud.search_ranked",
+            new=AsyncMock(side_effect=fake_search_ranked),
+        ):
+            ids = await _local_drilldown(
+                "test query",
+                db=db,
+                qdrant_client=MagicMock(),
+                embedding_provider=self._failing_embeddings(),
+                source_collections=["episodic_memory", "knowledge_base"],
+                wing="memory",
+                room=None,
+                global_ids=[],
+            )
+
+        assert seen_collections == ["episodic_memory", "knowledge_base"], (
+            f"FTS drill-down searched {seen_collections!r}, expected one "
+            "search per source collection"
+        )
+        assert "kb1" in ids, "knowledge_base FTS hit must survive the drill-down"
+        assert "ep1" in ids
+
+    @pytest.mark.asyncio
+    async def test_fts_drilldown_episodic_only_unchanged(self):
+        """Default episodic source still searches exactly one collection."""
+        db = self._db_with_wing_rows([("ep1",)])
+        seen_collections: list[str | None] = []
+
+        async def fake_search_ranked(db_, *, query, limit,
+                                     collection=None, **kw):
+            seen_collections.append(collection)
+            return [{"memory_id": "ep1", "content": "ep", "rank": -2.0}]
+
+        with patch(
+            "genesis.memory.drift.memory_crud.search_ranked",
+            new=AsyncMock(side_effect=fake_search_ranked),
+        ):
+            ids = await _local_drilldown(
+                "test query",
+                db=db,
+                qdrant_client=MagicMock(),
+                embedding_provider=self._failing_embeddings(),
+                source_collections=["episodic_memory"],
+                wing="memory",
+                room=None,
+                global_ids=[],
+            )
+
+        assert seen_collections == ["episodic_memory"]
+        assert ids == ["ep1"]

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -936,3 +936,83 @@ async def test_recall_reranker_replaces_fused_with_positional_scores(
     assert [r.memory_id for r in results] == ["mem-2", "mem-1"]
     assert results[0].score == pytest.approx(1.0)   # 1/(1+0)
     assert results[1].score == pytest.approx(0.5)   # 1/(1+1)
+
+
+# --- mem-007: diversity penalty must not contaminate J9-logged scores ---
+
+
+def _make_echo_hit(mid: str, score: float, content: str) -> dict:
+    hit = _make_qdrant_hit(mid, score)
+    hit["payload"]["content"] = content
+    return hit
+
+
+@pytest.mark.asyncio
+@patch("genesis.eval.j9_hooks.emit_recall_fired", new_callable=AsyncMock, return_value=None)
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_diversity_penalty_preserves_raw_score_for_j9(
+    mock_qdrant, mock_crud, mock_links, _expand, mock_emit,
+):
+    """An echo-penalized result keeps its pre-penalty score in
+    ``retrieval_score``, and the J-9 recall event logs THAT — not the
+    halved dedup artifact. ``score`` (final ordering) stays penalized."""
+    retriever, _, _, _ = _build_retriever()
+
+    echo = "alpha beta gamma delta epsilon zeta identical content"
+    mock_qdrant.search.return_value = [
+        _make_echo_hit("echo-hi", 0.95, echo),
+        _make_echo_hit("echo-lo", 0.90, echo),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall("test", limit=5)
+
+    by_id = {r.memory_id: r for r in results}
+    assert {"echo-hi", "echo-lo"} <= set(by_id), (
+        "both echo-cluster members should survive (2 <= max_per_cluster)"
+    )
+    hi, lo = by_id["echo-hi"], by_id["echo-lo"]
+
+    # The winner is unpenalized: final == raw
+    assert hi.score == pytest.approx(hi.retrieval_score)
+    # The echo is halved for ORDERING, but its raw score is preserved
+    assert lo.score == pytest.approx(lo.retrieval_score * 0.5), (
+        f"echo final score {lo.score} should be raw {lo.retrieval_score} * 0.5"
+    )
+    assert lo.retrieval_score > lo.score > 0.0
+
+    # J-9 logging reads the RAW scores, not the penalized ones
+    emit_kwargs = mock_emit.call_args.kwargs
+    assert emit_kwargs["top_scores"] == pytest.approx(
+        [r.retrieval_score for r in results[:5]]
+    ), "J-9 top_scores must be pre-penalty retrieval scores"
+    expected_mean = sum(r.retrieval_score for r in results) / len(results)
+    assert emit_kwargs["mean_score"] == pytest.approx(expected_mean)
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_no_penalty_retrieval_score_equals_score(
+    mock_qdrant, mock_crud, mock_links, _expand,
+):
+    """With no echo clusters, retrieval_score == score for every result."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = [
+        _make_echo_hit("m1", 0.95, "completely unique first content"),
+        _make_echo_hit("m2", 0.90, "utterly different second thing"),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall("test", limit=5)
+    assert len(results) == 2
+    for r in results:
+        assert r.score == pytest.approx(r.retrieval_score)


### PR DESCRIPTION
## Summary

Two isolated memory-retrieval correctness fixes (Tier-2 carry-overs), plus the review-found P1 that made the second one stick end-to-end.

- **MEM-006** — `drift_recall`'s wing-scoped FTS drill-down hardcoded `collection="episodic_memory"` while the sibling vector arm loops `source_collections`. Knowledge-base rows ARE FTS-indexed (`store.py` upserts with the resolved collection), so `source="knowledge"/"both"` recall could never surface knowledge lexically in the scoped phase. Now mirrors the vector arm: one `search_ranked` per collection, order-preserving dedup, wing post-filter unchanged.
- **mem-007** — `_apply_diversity_penalty` mutates `fused` in place (echoes ×0.5, evictions =0.0) and `RetrievalResult.score` fed J-9's `emit_recall_fired` — logging a dedup artifact as retrieval quality (top_scores / mean_score / score_spread / entrenchment corr). New `RetrievalResult.retrieval_score` snapshots the pre-penalty (post-rerank, post-graph-boost) score; J-9 reads it. `score` stays penalized — it drives the returned ordering, which SHOULD demote near-duplicates. Unblocks a trustworthy mem-005 graph-boost A/B baseline.
- **Review P1 (fixed in-PR)** — the MCP MEM-003 enrichment (`memory_recall`/`knowledge_recall`) re-derived top_scores/mean_score from `.score` and `update_event_metrics` overwrites keys — clobbering the raw values on the primary production paths. The enrichment now reads `retrieval_score` (fallback to `score` for paths that don't populate it), `knowledge_recall` carries it through the merge with the authority boost applied (a legitimate quality signal, unlike the echo penalty), and the DRIFT path populates it (no penalty there — raw == final).

## Verification

- TDD with empirical RED for all three changes (each test confirmed failing against the unfixed code).
- 126 tests green across the affected surface (drift, retrieval, types, reranker, MCP memory, recall instrumentation, runtime retriever); ruff clean; subsystem-map guard clean.
- Two independent code reviews: initial review surfaced the P1; focused re-review of the P1 fix came back clean on all five checks (fallback safety, additive-key consumers, boost mutation, test pinning, FTS parity).
- Pre-existing (NOT this PR): 6 `*_requires_init` tests in `tests/test_mcp/test_memory_mcp.py` fail under one specific multi-file local batch on main too — cross-file pollution, tracked as follow-up 05034405.

## Notes

- `knowledge_recall` result dicts gain an additive `retrieval_score` key (all consumers duck-type; verified).
- CHANGELOG (user-visible MEM-006 entry) + `docs/architecture/CURRENT.md` memory entry refreshed (stamp `d3d48d94 2026-07-09`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)