### PR TITLE
feat(memory): ambient session-theme accumulator + drift trigger (WS-C PR1)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -325,8 +325,8 @@ The loops that make Genesis think between conversations.
 
 ```yaml subsystem-map
 entry: ambient-cognition
-modules: [awareness, perception, reflection, attention]
-verified: 9037d45b 2026-07-07
+modules: [awareness, perception, reflection, attention, session_awareness]
+verified: 8dac642c 2026-07-09
 ```
 
 - **awareness/**: the 5-min heartbeat. ~23 signal collectors (the richer
@@ -352,6 +352,13 @@ verified: 9037d45b 2026-07-07
   **Firewall: transcript text is never persisted** — only refs + derived
   features reach `attention_events`. Config is versioned DATA
   (`~/.genesis/config/attention_config.json`).
+- **session_awareness/**: WS-C ambient session-theme layer — SHADOW,
+  record-only (PR1). The proactive memory hook folds each genuine user
+  prompt's embedding into a per-session EMA + entity ledger and records
+  drift-trigger fires in `~/.genesis/sessions/<id>/session_theme.json`;
+  the detached retrieval worker/arbiter lanes (PR2+) act on fires. Pure
+  functions, no clocks (callers pass time), zero DB writes, fail-open at
+  the hook boundary. Kill switch: `GENESIS_SESSION_AWARENESS_DISABLED=1`.
 
 ## 10. Learning & evaluation
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1681,6 +1681,59 @@ async def _run(prompt: str, session_id: str = "") -> None:
         procedure_repeat=ws_stats["procedure_repeat"],
     )
 
+    # ── Ambient session-awareness fold (WS-C PR1, record-only) ─────
+    # Folds the prompt embedding (already computed above) into a
+    # session-theme EMA and records drift-trigger fires in the
+    # session's session_theme.json. No spawn (PR2), no output. Runs
+    # after all stdout AND all existing metrics so it can never affect
+    # either; placed outside the total_ms window on purpose — new work
+    # must not skew the H-1 latency baselines.
+    _ambient_fold(vector, session_id, prompt, recent_files)
+
+
+def _turn_pivoted(session_id: str) -> bool:
+    """True if the intent trail recorded a pivot on the current turn."""
+    try:
+        trail = _load_trail(session_id)
+        pivots = trail.get("pivots", [])
+        return bool(pivots) and pivots[-1].get("at_msg") == trail.get("msg_count")
+    except Exception:
+        return False
+
+
+def _ambient_fold(
+    vector: list[float] | None,
+    session_id: str,
+    prompt: str,
+    recent_files: list[str],
+) -> None:
+    """Fail-open bridge into genesis.session_awareness (WS-C).
+
+    Skips harness envelopes (not genuine user turns) and embed-less
+    turns. GENESIS_SESSION_AWARENESS_DISABLED=1 is the ops kill switch;
+    dispatched sessions never get here (GENESIS_CC_SESSION guard at
+    import). Must never raise or print.
+    """
+    try:
+        if (
+            not vector
+            or not session_id
+            or os.environ.get("GENESIS_SESSION_AWARENESS_DISABLED") == "1"
+            or _is_harness_envelope(prompt)
+        ):
+            return
+        from genesis.session_awareness import hook_fold
+
+        hook_fold(
+            session_id=session_id,
+            vector=vector,
+            prompt_keywords=_extract_keywords(prompt),
+            file_keywords=_keywords_from_files(recent_files) if recent_files else [],
+            pivoted=_turn_pivoted(session_id),
+        )
+    except Exception:
+        pass  # Ambient layer must never affect the hook
+
 
 def main() -> None:
     """Hook entry point."""

--- a/src/genesis/session_awareness/__init__.py
+++ b/src/genesis/session_awareness/__init__.py
@@ -1,0 +1,16 @@
+"""Ambient session-awareness layer (WS-C).
+
+Watches what a CC session is *about* — an EMA over genuine user-prompt
+embeddings — and detects when the theme settles (drift trigger). PR1 is
+record-only: the proactive memory hook folds each turn and records fires
+in ``session_theme.json``; the detached retrieval worker (PR2) and the
+arbiter (PR3) act on those fires. Shadow-first: nothing here injects
+anything into a session until the live-flip gate.
+
+The hook-facing entry point is :func:`hook_fold` — one call per genuine
+user turn, fail-open by contract (it never raises).
+"""
+
+from .hook_api import hook_fold
+
+__all__ = ["hook_fold"]

--- a/src/genesis/session_awareness/accumulator.py
+++ b/src/genesis/session_awareness/accumulator.py
@@ -1,0 +1,141 @@
+"""Session-theme accumulator: EMA over prompt embeddings + entity ledger.
+
+Pure functions over the theme state dict (see ``statefiles.empty_state``).
+No I/O, no clocks — callers pass timestamps, which keeps every path
+testable with synthetic vectors and fixed times.
+
+Design constraints (WS-C, locked):
+- EMA folds ONLY genuine user-prompt embeddings. File-context keywords
+  feed the entity ledger at reduced weight but never touch the EMA.
+- Outlier-skip guard: the recall embedding chain spans backends
+  (DeepInfra → DashScope → Ollama, same Qwen3-Embedding family). A
+  vector wildly off-family vs the current EMA (cosine < OUTLIER_COS)
+  is skipped and counted, not folded — one bad backend response must
+  not wrench the theme.
+"""
+
+from __future__ import annotations
+
+import math
+
+ALPHA = 0.25  # EMA weight of the newest turn
+OUTLIER_COS = 0.05  # below this cosine vs EMA: skip fold, count it
+OUTLIER_ESCAPE_RUN = 3  # N consecutive outliers = a real theme change, not glitches
+RING_SIZE = 3  # EMA snapshots kept for the stability check
+
+ENTITY_DECAY = 0.9  # per-turn multiplicative decay
+PROMPT_KW_WEIGHT = 1.0
+FILE_KW_WEIGHT = 0.3
+MAX_ENTITIES = 64
+MIN_ENTITY_WEIGHT = 0.05  # pruned below this after decay
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity; 0.0 for degenerate inputs."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _unit(v: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in v))
+    if norm == 0.0:
+        return list(v)
+    return [x / norm for x in v]
+
+
+def _normalize_keyword(kw: str) -> str:
+    """Alias-normalize a keyword (best-effort; identity on any failure)."""
+    try:
+        from genesis.memory.entity_resolution import normalize_content
+
+        return normalize_content(kw).strip().lower() or kw.lower()
+    except Exception:
+        return kw.lower()
+
+
+def fold_turn(
+    state: dict,
+    vector: list[float],
+    prompt_keywords: list[str],
+    file_keywords: list[str] | None = None,
+    *,
+    pivoted: bool = False,
+    now_iso: str = "",
+) -> dict:
+    """Fold one genuine user turn into the theme state (mutates *state*).
+
+    The entity ledger updates on every fold — it is text-based, so the
+    cross-backend embedding risk doesn't apply to it. The EMA updates
+    only for non-outlier vectors. A corroborated pivot clears the
+    stability ring so the trigger must re-observe a settled theme.
+    """
+    # ── Entity ledger ────────────────────────────────────────────────
+    entities: dict[str, float] = {
+        k: w * ENTITY_DECAY for k, w in state.get("entities", {}).items()
+    }
+    for kw in prompt_keywords:
+        key = _normalize_keyword(kw)
+        entities[key] = entities.get(key, 0.0) + PROMPT_KW_WEIGHT
+    for kw in file_keywords or []:
+        key = _normalize_keyword(kw)
+        entities[key] = entities.get(key, 0.0) + FILE_KW_WEIGHT
+    pruned = {k: w for k, w in entities.items() if w >= MIN_ENTITY_WEIGHT}
+    if len(pruned) > MAX_ENTITIES:
+        keep = sorted(pruned.items(), key=lambda kv: kv[1], reverse=True)
+        pruned = dict(keep[:MAX_ENTITIES])
+    state["entities"] = pruned
+
+    # ── EMA fold ─────────────────────────────────────────────────────
+    if vector:
+        unit = _unit(vector)
+        ema = state.get("ema")
+        is_outlier = ema is not None and cosine(vector, ema) < OUTLIER_COS
+        run = state.get("consecutive_outliers", 0)
+        # A corroborated pivot (intent-trail Jaccard) or a RUN of
+        # "outliers" is a genuine theme change, not a backend glitch —
+        # skipping those turns would anchor the EMA to the dead topic
+        # until the 24h reset and blind the trigger to the new theme
+        # (Codex P2, PR #972). The guard only swallows transient
+        # single-vector glitches.
+        if is_outlier and not pivoted and run + 1 < OUTLIER_ESCAPE_RUN:
+            state["outlier_skips"] = state.get("outlier_skips", 0) + 1
+            state["consecutive_outliers"] = run + 1
+        else:
+            state["consecutive_outliers"] = 0
+            if ema is None or len(unit) != len(ema):
+                # First fold — or the embedding SPACE changed (backend
+                # model swap): the old EMA is meaningless there, reseed.
+                state["ema"] = unit
+                state["ema_turns"] = 1
+                state["ring"] = [unit]
+            else:
+                if pivoted or is_outlier:
+                    # Theme changed — stability must rebuild before the
+                    # trigger can fire again.
+                    state["ring"] = []
+                folded = [
+                    (1.0 - ALPHA) * e + ALPHA * u
+                    for e, u in zip(ema, unit, strict=True)
+                ]
+                state["ema"] = _unit(folded)
+                state["ema_turns"] = state.get("ema_turns", 0) + 1
+                ring = state.get("ring", [])
+                ring.append(state["ema"])
+                state["ring"] = ring[-RING_SIZE:]
+
+    state["updated_at"] = now_iso
+    return state
+
+
+def top_entities(state: dict, n: int = 8) -> list[str]:
+    """Highest-weight ledger entries — the worker's drift_recall query."""
+    ranked = sorted(
+        state.get("entities", {}).items(), key=lambda kv: kv[1], reverse=True,
+    )
+    return [k for k, _ in ranked[:n]]

--- a/src/genesis/session_awareness/hook_api.py
+++ b/src/genesis/session_awareness/hook_api.py
@@ -1,0 +1,63 @@
+"""Hook-facing orchestration: one fail-open call per genuine user turn.
+
+The proactive memory hook calls :func:`hook_fold` after all stdout is
+flushed and every existing metric is recorded — this function must never
+raise, never print, and never write anywhere except the session's own
+``session_theme.json``. PR1 is record-only: fires are recorded in the
+statefile; PR2 spawns the detached worker on fire.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .accumulator import fold_turn
+from .statefiles import load_state, save_state
+from .trigger import check_fire, record_fire, stability
+
+
+def hook_fold(
+    *,
+    session_id: str,
+    vector: list[float],
+    prompt_keywords: list[str],
+    file_keywords: list[str] | None = None,
+    pivoted: bool = False,
+    base_dir: Path | None = None,
+    now: datetime | None = None,
+) -> dict | None:
+    """Fold one turn; check the drift trigger; record any fire.
+
+    Returns a small summary dict (for tests and the PR4 replay harness)
+    or None on any failure — by contract this function cannot raise.
+    """
+    try:
+        if not session_id or not vector:
+            return None
+        now = now or datetime.now(UTC)
+        now_iso = now.isoformat()
+
+        state = load_state(session_id, base=base_dir, now=now)
+        fold_turn(
+            state,
+            vector,
+            prompt_keywords,
+            list(file_keywords or []),
+            pivoted=pivoted,
+            now_iso=now_iso,
+        )
+        fired, reason = check_fire(state, now)
+        if fired:
+            record_fire(state, now_iso)  # PR1: record-only, no spawn
+        save_state(session_id, state, base=base_dir)
+        return {
+            "fired": fired,
+            "reason": reason,
+            "ema_turns": state.get("ema_turns", 0),
+            "stability": stability(state.get("ring", [])),
+            "fired_count": state.get("fired_count", 0),
+            "outlier_skips": state.get("outlier_skips", 0),
+        }
+    except Exception:
+        return None

--- a/src/genesis/session_awareness/statefiles.py
+++ b/src/genesis/session_awareness/statefiles.py
@@ -1,0 +1,110 @@
+"""Per-session theme statefile: ``~/.genesis/sessions/<id>/session_theme.json``.
+
+Mirrors the proactive hook's working-set idiom: traversal-guarded path,
+atomic mkstemp→os.replace writes, corrupt/missing files degrade to an
+empty state, saves never raise. The statefile is the single durable
+record of the session theme — it survives compaction because it lives
+outside the transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+FILENAME = "session_theme.json"
+
+# A session idle longer than this is a new working context: the theme
+# EMA restarts rather than blending yesterday's topic into today's.
+STALE_AFTER = timedelta(hours=24)
+
+
+def _sessions_dir() -> Path:
+    return Path.home() / ".genesis" / "sessions"
+
+
+def theme_path(session_id: str, base: Path | None = None) -> Path | None:
+    """Statefile path, or None for unusable session IDs.
+
+    Session IDs arrive via hook stdin — refuse anything that could
+    escape the sessions dir (mirrors the hook's ``_ws_path``).
+    """
+    if not session_id or "/" in session_id or ".." in session_id:
+        return None
+    return (base or _sessions_dir()) / session_id / FILENAME
+
+
+def empty_state(session_id: str) -> dict:
+    return {
+        "version": SCHEMA_VERSION,
+        "session_id": session_id,
+        "ema": None,  # list[float] | None — the theme vector
+        "ema_turns": 0,  # genuine folded turns (outliers excluded)
+        "ring": [],  # last-3 EMA snapshots for the stability check
+        "entities": {},  # keyword -> decayed weight
+        "fired": [],  # [{"ema": [...], "turn": int, "at": iso}]
+        "fired_count": 0,
+        "worker_pending_since": None,  # iso | None — trigger's claim
+        "outlier_skips": 0,  # cross-backend guard counter (total)
+        "consecutive_outliers": 0,  # current run; a full run = theme change
+        "updated_at": None,
+    }
+
+
+def _valid_shape(data: object) -> bool:
+    return (
+        isinstance(data, dict)
+        and isinstance(data.get("ring"), list)
+        and isinstance(data.get("entities"), dict)
+        and isinstance(data.get("fired"), list)
+    )
+
+
+def load_state(
+    session_id: str,
+    base: Path | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Load the theme state. Empty state if missing, corrupt, or stale."""
+    path = theme_path(session_id, base)
+    if path is None:
+        return empty_state(session_id)
+    try:
+        if not path.exists():
+            return empty_state(session_id)
+        data = json.loads(path.read_text())
+        if not _valid_shape(data):
+            return empty_state(session_id)
+        updated = data.get("updated_at")
+        if updated:
+            now = now or datetime.now(UTC)
+            if now - datetime.fromisoformat(updated) > STALE_AFTER:
+                return empty_state(session_id)
+        data.setdefault("version", SCHEMA_VERSION)
+        data.setdefault("session_id", session_id)
+        for key, default in empty_state(session_id).items():
+            data.setdefault(key, default)
+        return data
+    except Exception:
+        return empty_state(session_id)
+
+
+def save_state(session_id: str, state: dict, base: Path | None = None) -> None:
+    """Atomic write (mkstemp→replace). Never raises."""
+    path = theme_path(session_id, base)
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            os.write(fd, json.dumps(state).encode())
+        finally:
+            os.close(fd)
+        os.replace(tmp, str(path))
+    except Exception:
+        pass  # Ambient state must never block the hook

--- a/src/genesis/session_awareness/trigger.py
+++ b/src/genesis/session_awareness/trigger.py
@@ -1,0 +1,80 @@
+"""Drift trigger: pure decision function over the theme state.
+
+``check_fire`` answers one question — has the session theme *settled*
+somewhere new? — and returns a reason string for every no, so shadow
+logs and the replay harness can see exactly which condition gated.
+
+Thresholds are module constants ON PURPOSE: the PR4 replay harness is
+the tuning loop, and constants keep every iteration a one-line diff.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .accumulator import RING_SIZE, cosine
+
+EMA_MIN_TURNS = 3  # don't judge a theme before it exists
+STABILITY_MIN = 0.90  # min pairwise cosine across the ring
+FIRED_DIST_MIN = 0.35  # cosine distance from every prior fired region
+TURNS_BETWEEN_FIRES = 3
+MAX_FIRES = 3  # per session
+CLAIM_STALE_S = 120.0  # pending-worker claim override
+
+
+def stability(ring: list[list[float]]) -> float:
+    """Min pairwise cosine across the ring; 0.0 until the ring is full."""
+    if len(ring) < RING_SIZE:
+        return 0.0
+    return min(
+        cosine(ring[i], ring[j])
+        for i in range(len(ring))
+        for j in range(i + 1, len(ring))
+    )
+
+
+def check_fire(state: dict, now: datetime) -> tuple[bool, str]:
+    """(should_fire, reason). Reason is "fire" or the gating condition."""
+    ema = state.get("ema")
+    if ema is None:
+        return False, "no_ema"
+    if state.get("ema_turns", 0) < EMA_MIN_TURNS:
+        return False, "warming"
+    if stability(state.get("ring", [])) < STABILITY_MIN:
+        return False, "unstable"
+    if state.get("fired_count", 0) >= MAX_FIRES:
+        return False, "max_fires"
+
+    fired = state.get("fired", [])
+    if fired:
+        last_turn = fired[-1].get("turn", 0)
+        if state.get("ema_turns", 0) - last_turn < TURNS_BETWEEN_FIRES:
+            return False, "cooldown"
+        for region in fired:
+            if 1.0 - cosine(ema, region.get("ema", [])) < FIRED_DIST_MIN:
+                return False, "near_fired_region"
+
+    pending = state.get("worker_pending_since")
+    if pending:
+        try:
+            age = (now - datetime.fromisoformat(pending)).total_seconds()
+        except Exception:
+            age = CLAIM_STALE_S + 1.0  # unparseable claim: treat as stale
+        if age <= CLAIM_STALE_S:
+            return False, "worker_pending"
+
+    return True, "fire"
+
+
+def record_fire(state: dict, now_iso: str) -> None:
+    """Claim the current theme region (mutates *state*).
+
+    PR1 is record-only; PR2's spawn happens under this same claim —
+    ``worker_pending_since`` doubles as the pending-worker lock that
+    ``check_fire`` honors (with the stale override).
+    """
+    state.setdefault("fired", []).append(
+        {"ema": list(state.get("ema") or []), "turn": state.get("ema_turns", 0), "at": now_iso},
+    )
+    state["fired_count"] = state.get("fired_count", 0) + 1
+    state["worker_pending_since"] = now_iso

--- a/tests/test_learning/test_proactive_hook_subprocess.py
+++ b/tests/test_learning/test_proactive_hook_subprocess.py
@@ -134,9 +134,12 @@ def test_procedure_surfacing_subprocess(seeded_db, tmp_path: Path):
         iso_config_dir = tmp_path / ".genesis" / "config"
         iso_config_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy(real_config, iso_config_dir / "genesis.yaml")
-    # Qdrant URL — use the real one (needed for memory recall, but
-    # we're testing procedure surfacing which uses SQLite only)
-    env.setdefault("QDRANT_URL", "http://localhost:6333")
+    # Dead Qdrant on purpose: procedure surfacing uses SQLite only, and
+    # pointing the subprocess at the production vector store let the
+    # hook's _increment_retrieved bump REAL points' retrieved_count on
+    # every backend-enabled test run (found 2026-07-09 while building
+    # the session-awareness integration test).
+    env["QDRANT_URL"] = "http://127.0.0.1:1"
 
     # Build hook input
     hook_input = json.dumps({

--- a/tests/test_session_awareness/test_accumulator.py
+++ b/tests/test_session_awareness/test_accumulator.py
@@ -1,0 +1,204 @@
+"""Accumulator unit tests — synthetic vectors, no I/O, no wall clock."""
+
+from __future__ import annotations
+
+import math
+
+from genesis.session_awareness.accumulator import (
+    ALPHA,
+    MAX_ENTITIES,
+    cosine,
+    fold_turn,
+    top_entities,
+)
+from genesis.session_awareness.statefiles import empty_state
+
+DIM = 8
+NOW = "2026-07-09T12:00:00+00:00"
+
+
+def unit(axis: int) -> list[float]:
+    v = [0.0] * DIM
+    v[axis] = 1.0
+    return v
+
+
+def blend(a: list[float], b: list[float], t: float) -> list[float]:
+    return [(1 - t) * x + t * y for x, y in zip(a, b, strict=True)]
+
+
+def test_cosine_basics():
+    assert cosine(unit(0), unit(0)) == 1.0
+    assert cosine(unit(0), unit(1)) == 0.0
+    assert cosine([], unit(0)) == 0.0
+    assert cosine([0.0] * DIM, unit(0)) == 0.0
+    assert cosine(unit(0), unit(0)[:4]) == 0.0  # length mismatch
+
+
+def test_first_fold_initializes():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), ["alpha"], now_iso=NOW)
+    assert s["ema"] == unit(0)
+    assert s["ema_turns"] == 1
+    assert s["ring"] == [unit(0)]
+    assert s["updated_at"] == NOW
+
+
+def test_ema_converges_toward_repeated_vector():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), [], now_iso=NOW)
+    target = blend(unit(0), unit(1), 0.5)
+    for _ in range(12):
+        fold_turn(s, target, [], now_iso=NOW)
+    assert cosine(s["ema"], target) > 0.99
+    assert s["ema_turns"] == 13
+
+
+def test_ema_is_unit_norm_after_fold():
+    s = empty_state("s1")
+    fold_turn(s, [x * 7.5 for x in unit(0)], [], now_iso=NOW)
+    fold_turn(s, [x * 0.02 for x in blend(unit(0), unit(1), 0.3)], [], now_iso=NOW)
+    norm = math.sqrt(sum(x * x for x in s["ema"]))
+    assert abs(norm - 1.0) < 1e-9
+
+
+def test_outlier_vector_skipped_not_folded():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), [], now_iso=NOW)
+    ema_before = list(s["ema"])
+    # Orthogonal vector: cosine 0.0 < OUTLIER_COS → skip
+    fold_turn(s, unit(1), ["kw"], now_iso=NOW)
+    assert s["ema"] == ema_before
+    assert s["ema_turns"] == 1
+    assert s["outlier_skips"] == 1
+    # ...but the text lane still folded
+    assert "kw" in s["entities"]
+
+
+def test_near_theme_vector_folds_normally():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), [], now_iso=NOW)
+    nearby = blend(unit(0), unit(1), 0.2)
+    fold_turn(s, nearby, [], now_iso=NOW)
+    assert s["ema_turns"] == 2
+    assert s["outlier_skips"] == 0
+    expected_dir = blend(unit(0), nearby, ALPHA)
+    assert cosine(s["ema"], expected_dir) > 0.999
+
+
+def test_pivot_resets_ring_but_keeps_ema():
+    s = empty_state("s1")
+    for _ in range(3):
+        fold_turn(s, unit(0), [], now_iso=NOW)
+    assert len(s["ring"]) == 3
+    fold_turn(s, blend(unit(0), unit(1), 0.2), [], pivoted=True, now_iso=NOW)
+    assert len(s["ring"]) == 1  # cleared, then this fold appended
+    assert s["ema_turns"] == 4
+
+
+def test_entities_decay_weights_and_file_discount():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), ["genesis"], ["retrieval"], now_iso=NOW)
+    assert s["entities"]["genesis"] == 1.0
+    assert abs(s["entities"]["retrieval"] - 0.3) < 1e-9
+    fold_turn(s, unit(0), ["genesis"], [], now_iso=NOW)
+    # decayed 0.9 then +1.0
+    assert abs(s["entities"]["genesis"] - 1.9) < 1e-9
+    assert abs(s["entities"]["retrieval"] - 0.27) < 1e-9
+
+
+def test_entities_pruned_to_cap_and_min_weight():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), [f"kw{i}" for i in range(MAX_ENTITIES + 20)], now_iso=NOW)
+    assert len(s["entities"]) == MAX_ENTITIES
+    # A single 0.3 file keyword decays below 0.05 in ~19 empty turns
+    s2 = empty_state("s2")
+    fold_turn(s2, unit(0), [], ["fleeting"], now_iso=NOW)
+    for _ in range(19):
+        fold_turn(s2, unit(0), [], [], now_iso=NOW)
+    assert "fleeting" not in s2["entities"]
+
+
+def test_file_keywords_never_touch_ema():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), [], ["onlyfile"], now_iso=NOW)
+    ema_before = list(s["ema"])
+    fold_turn(s, unit(0), [], ["another", "batch", "of", "files"], now_iso=NOW)
+    assert s["ema"] == ema_before  # same vector folded; files only hit ledger
+
+
+def test_empty_vector_updates_ledger_only():
+    s = empty_state("s1")
+    fold_turn(s, [], ["kw"], now_iso=NOW)
+    assert s["ema"] is None
+    assert s["ema_turns"] == 0
+    assert "kw" in s["entities"]
+
+
+def test_top_entities_ranked():
+    s = empty_state("s1")
+    fold_turn(s, unit(0), ["alpha", "beta"], ["gamma"], now_iso=NOW)
+    fold_turn(s, unit(0), ["alpha"], [], now_iso=NOW)
+    top = top_entities(s, n=2)
+    assert top[0] == "alpha"
+    assert top[1] == "beta"
+
+
+def test_pivot_bypasses_outlier_guard():
+    """A corroborated pivot to an orthogonal topic must FOLD, not skip —
+    otherwise the EMA stays anchored to the dead topic and every new-topic
+    turn keeps reading as an outlier until the 24h reset (Codex P2, #972)."""
+    s = empty_state("s1")
+    for _ in range(3):
+        fold_turn(s, unit(0), [], now_iso=NOW)
+    fold_turn(s, unit(1), [], pivoted=True, now_iso=NOW)
+    assert s["outlier_skips"] == 0
+    assert s["ema_turns"] == 4
+    assert len(s["ring"]) == 1  # ring reset for the new theme
+    assert cosine(s["ema"], unit(1)) > 0.2  # EMA moving toward the new topic
+
+
+def test_consecutive_outlier_run_escapes_as_theme_change():
+    """3 consecutive 'outliers' = a real theme change Jaccard missed —
+    the run escapes into a fold with ring reset. Singles stay guarded."""
+    s = empty_state("s1")
+    for _ in range(3):
+        fold_turn(s, unit(0), [], now_iso=NOW)
+    fold_turn(s, unit(1), [], now_iso=NOW)
+    fold_turn(s, unit(1), [], now_iso=NOW)
+    assert s["outlier_skips"] == 2
+    assert s["consecutive_outliers"] == 2
+    assert s["ema_turns"] == 3  # still skipping
+    fold_turn(s, unit(1), [], now_iso=NOW)  # third in the run → escape
+    assert s["ema_turns"] == 4
+    assert s["consecutive_outliers"] == 0
+    assert len(s["ring"]) == 1
+    assert cosine(s["ema"], unit(1)) > 0.2
+
+
+def test_outlier_run_broken_by_normal_turn_resets_counter():
+    s = empty_state("s1")
+    for _ in range(2):
+        fold_turn(s, unit(0), [], now_iso=NOW)
+    fold_turn(s, unit(1), [], now_iso=NOW)  # outlier 1
+    fold_turn(s, unit(0), [], now_iso=NOW)  # back on theme
+    assert s["consecutive_outliers"] == 0
+    fold_turn(s, unit(1), [], now_iso=NOW)  # isolated outlier again
+    assert s["consecutive_outliers"] == 1
+    assert s["outlier_skips"] == 2
+
+
+def test_dimension_change_reseeds_on_escape():
+    """A backend model swap (different embedding dim) can't be folded —
+    on pivot/escape the EMA reseeds in the new space instead of raising."""
+    s = empty_state("s1")
+    for _ in range(3):
+        fold_turn(s, unit(0), [], now_iso=NOW)
+    short = [1.0, 0.0, 0.0, 0.0]  # different dimension → cosine 0.0
+    fold_turn(s, short, [], now_iso=NOW)
+    fold_turn(s, short, [], now_iso=NOW)
+    assert s["ema_turns"] == 3  # guarded
+    fold_turn(s, short, [], now_iso=NOW)  # escape → reseed, not zip-crash
+    assert s["ema"] == short
+    assert s["ema_turns"] == 1
+    assert s["ring"] == [short]

--- a/tests/test_session_awareness/test_hook_fold.py
+++ b/tests/test_session_awareness/test_hook_fold.py
@@ -1,0 +1,96 @@
+"""hook_fold orchestration tests — the contract the hook depends on."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from genesis.session_awareness import hook_fold
+from genesis.session_awareness.statefiles import load_state
+
+DIM = 8
+T0 = datetime(2026, 7, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def unit(axis: int) -> list[float]:
+    v = [0.0] * DIM
+    v[axis] = 1.0
+    return v
+
+
+def blend(a: list[float], b: list[float], t: float) -> list[float]:
+    return [(1 - t) * x + t * y for x, y in zip(a, b, strict=True)]
+
+
+def _turns(n: int):
+    """n same-theme turns: near-identical vectors, one minute apart."""
+    for i in range(n):
+        yield blend(unit(0), unit(1), 0.02 * i), T0 + timedelta(minutes=i)
+
+
+def test_settled_theme_fires_and_persists(tmp_path):
+    results = []
+    for vec, now in _turns(4):
+        results.append(
+            hook_fold(
+                session_id="sess-f",
+                vector=vec,
+                prompt_keywords=["genesis", "memory"],
+                base_dir=tmp_path,
+                now=now,
+            )
+        )
+    assert all(r is not None for r in results)
+    fired = [r for r in results if r["fired"]]
+    assert len(fired) == 1
+    assert fired[0]["reason"] == "fire"
+    # Statefile is the durable record
+    state = load_state("sess-f", base=tmp_path, now=T0 + timedelta(minutes=5))
+    assert state["fired_count"] == 1
+    assert state["fired"][0]["turn"] >= 3
+    assert state["worker_pending_since"] is not None
+
+
+def test_no_double_fire_same_region(tmp_path):
+    fires = 0
+    for vec, now in _turns(10):
+        r = hook_fold(
+            session_id="sess-d",
+            vector=vec,
+            prompt_keywords=["kw"],
+            base_dir=tmp_path,
+            now=now,
+        )
+        fires += int(r["fired"])
+    assert fires == 1  # same region: near_fired_region gates re-fires
+
+
+def test_returns_none_on_bad_input(tmp_path):
+    assert hook_fold(
+        session_id="", vector=unit(0), prompt_keywords=[], base_dir=tmp_path,
+    ) is None
+    assert hook_fold(
+        session_id="s", vector=[], prompt_keywords=[], base_dir=tmp_path,
+    ) is None
+    # Garbage vector type must not raise (fail-open contract)
+    assert hook_fold(
+        session_id="s",
+        vector=["not", "floats"],  # type: ignore[list-item]
+        prompt_keywords=[],
+        base_dir=tmp_path,
+        now=T0,
+    ) is None
+
+
+def test_statefile_is_json_readable(tmp_path):
+    for vec, now in _turns(2):
+        hook_fold(
+            session_id="sess-j",
+            vector=vec,
+            prompt_keywords=["alpha"],
+            base_dir=tmp_path,
+            now=now,
+        )
+    raw = json.loads((tmp_path / "sess-j" / "session_theme.json").read_text())
+    assert raw["ema_turns"] == 2
+    assert raw["session_id"] == "sess-j"

--- a/tests/test_session_awareness/test_hook_integration.py
+++ b/tests/test_session_awareness/test_hook_integration.py
@@ -1,0 +1,141 @@
+"""Subprocess integration: the ambient fold must not change hook output.
+
+Runs scripts/proactive_memory_hook.py as a real subprocess (the same way
+Claude Code invokes it) against an isolated HOME + minimal DB, and proves:
+
+1. stdout is byte-identical with the ambient layer enabled vs disabled
+   (GENESIS_SESSION_AWARENESS_DISABLED=1) across a 4-turn same-theme
+   sequence — the PR1 zero-behavior-change contract.
+2. The enabled run accumulates session_theme.json (ema_turns == embedded
+   turns) and records a fire once the theme settles.
+3. Harness-envelope prompts do not fold.
+
+Requires an embedding backend (the fold only runs when the hook obtains
+a vector); skipped otherwise, mirroring test_proactive_hook_subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_DIR = Path(__file__).resolve().parent.parent.parent
+HOOK = REPO_DIR / "scripts" / "proactive_memory_hook.py"
+SRC_DIR = REPO_DIR / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def _embedding_available() -> bool:
+    try:
+        from genesis.memory.embeddings import EmbeddingProvider
+
+        async def _check():
+            provider = EmbeddingProvider()
+            return await asyncio.wait_for(provider.embed("test"), timeout=5.0)
+
+        result = asyncio.run(_check())
+        return result is not None and len(result) > 0
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _embedding_available(),
+    reason="No embedding backend available (Ollama/DeepInfra/DashScope)",
+)
+
+_PROMPTS = [
+    "how does the genesis memory retrieval pipeline rank episodic memories",
+    "explain scoring in the memory retrieval pipeline for episodic recall",
+    "why does memory retrieval ranking boost linked episodic memories",
+    "show the retrieval pipeline ranking weights for episodic memory",
+    "compare retrieval ranking scores across episodic memory pipelines",
+]
+
+_SESSION = "ambient-itest-1"
+
+
+def _make_home(tmp_path: Path, name: str) -> tuple[Path, Path]:
+    """Isolated HOME with the install's config + a minimal DB."""
+    home = tmp_path / name
+    (home / ".genesis").mkdir(parents=True)
+    real_config = Path.home() / ".genesis" / "config" / "genesis.yaml"
+    if real_config.exists():
+        cfg = home / ".genesis" / "config"
+        cfg.mkdir(parents=True, exist_ok=True)
+        shutil.copy(real_config, cfg / "genesis.yaml")
+    db_path = home / "genesis.db"
+    sqlite3.connect(str(db_path)).close()  # empty DB: hook runs, finds nothing
+    return home, db_path
+
+
+def _run_hook(home: Path, db_path: Path, prompt: str, *, disabled: bool) -> str:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["GENESIS_DB_PATH"] = str(db_path)
+    env.pop("GENESIS_CC_SESSION", None)
+    # Dead Qdrant on purpose: test runs must NEVER touch the production
+    # vector store (the hook's _increment_retrieved would bump real
+    # points' retrieved_count). Also makes stdout deterministic — the
+    # hook degrades to FTS-only against the empty tmp DB.
+    env["QDRANT_URL"] = "http://127.0.0.1:1"
+    if disabled:
+        env["GENESIS_SESSION_AWARENESS_DISABLED"] = "1"
+    else:
+        env.pop("GENESIS_SESSION_AWARENESS_DISABLED", None)
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps({"prompt": prompt, "session_id": _SESSION}),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        cwd=str(REPO_DIR),
+    )
+    assert proc.returncode == 0
+    return proc.stdout
+
+
+def _theme_file(home: Path) -> Path:
+    return home / ".genesis" / "sessions" / _SESSION / "session_theme.json"
+
+
+def test_stdout_identical_and_theme_accumulates(tmp_path):
+    home_on, db_on = _make_home(tmp_path, "on")
+    home_off, db_off = _make_home(tmp_path, "off")
+
+    for prompt in _PROMPTS:
+        out_on = _run_hook(home_on, db_on, prompt, disabled=False)
+        out_off = _run_hook(home_off, db_off, prompt, disabled=True)
+        assert out_on == out_off  # byte-identical stdout, turn by turn
+
+    # Enabled home accumulated the theme… (>= 3: a turn whose embed
+    # exceeded the hook's 3s budget folds nothing — tolerated, the
+    # sequence has slack for one such miss)
+    theme = json.loads(_theme_file(home_on).read_text())
+    assert theme["ema_turns"] >= 3
+    assert theme["fired_count"] >= 1  # same-theme sequence settles → fire
+    assert theme["ema"] is not None
+    # …disabled home never wrote a statefile.
+    assert not _theme_file(home_off).exists()
+
+
+def test_envelope_prompt_does_not_fold(tmp_path):
+    home, db = _make_home(tmp_path, "env")
+    _run_hook(
+        home, db,
+        "<task-notification>background agent finished memory retrieval task"
+        "</task-notification>",
+        disabled=False,
+    )
+    assert not _theme_file(home).exists()

--- a/tests/test_session_awareness/test_statefiles.py
+++ b/tests/test_session_awareness/test_statefiles.py
@@ -1,0 +1,82 @@
+"""Statefile tests — tmp_path isolation, explicit clock, no wall time."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.session_awareness.statefiles import (
+    empty_state,
+    load_state,
+    save_state,
+    theme_path,
+)
+
+NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def test_roundtrip(tmp_path):
+    s = empty_state("sess-1")
+    s["ema"] = [0.5, 0.5]
+    s["ema_turns"] = 2
+    s["updated_at"] = NOW.isoformat()
+    save_state("sess-1", s, base=tmp_path)
+    loaded = load_state("sess-1", base=tmp_path, now=NOW)
+    assert loaded == s
+
+
+def test_traversal_guard():
+    assert theme_path("") is None
+    assert theme_path("../evil") is None
+    assert theme_path("a/b") is None
+    assert theme_path("..") is None
+
+
+def test_traversal_guard_noops(tmp_path):
+    save_state("../evil", {"x": 1}, base=tmp_path)
+    assert list(tmp_path.iterdir()) == []
+    loaded = load_state("../evil", base=tmp_path, now=NOW)
+    assert loaded == empty_state("../evil")
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert load_state("nope", base=tmp_path, now=NOW) == empty_state("nope")
+
+
+def test_corrupt_file_returns_empty(tmp_path):
+    d = tmp_path / "sess-c"
+    d.mkdir()
+    (d / "session_theme.json").write_text("{not json")
+    assert load_state("sess-c", base=tmp_path, now=NOW) == empty_state("sess-c")
+    (d / "session_theme.json").write_text('{"ring": "wrong-type"}')
+    assert load_state("sess-c", base=tmp_path, now=NOW) == empty_state("sess-c")
+
+
+def test_stale_state_resets(tmp_path):
+    s = empty_state("sess-s")
+    s["ema"] = [1.0]
+    s["ema_turns"] = 5
+    s["updated_at"] = (NOW - timedelta(hours=25)).isoformat()
+    save_state("sess-s", s, base=tmp_path)
+    assert load_state("sess-s", base=tmp_path, now=NOW) == empty_state("sess-s")
+    # Under the threshold: preserved
+    s["updated_at"] = (NOW - timedelta(hours=23)).isoformat()
+    save_state("sess-s", s, base=tmp_path)
+    assert load_state("sess-s", base=tmp_path, now=NOW)["ema_turns"] == 5
+
+
+def test_missing_keys_backfilled(tmp_path):
+    d = tmp_path / "sess-m"
+    d.mkdir()
+    (d / "session_theme.json").write_text(
+        '{"ring": [], "entities": {}, "fired": []}'
+    )
+    loaded = load_state("sess-m", base=tmp_path, now=NOW)
+    assert loaded["ema"] is None
+    assert loaded["outlier_skips"] == 0
+    assert loaded["session_id"] == "sess-m"
+
+
+def test_atomic_write_leaves_no_tmp(tmp_path):
+    save_state("sess-a", empty_state("sess-a"), base=tmp_path)
+    leftovers = [p for p in (tmp_path / "sess-a").iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []

--- a/tests/test_session_awareness/test_trigger.py
+++ b/tests/test_session_awareness/test_trigger.py
@@ -1,0 +1,130 @@
+"""Trigger unit tests — pure function, time passed as a parameter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.session_awareness.statefiles import empty_state
+from genesis.session_awareness.trigger import (
+    EMA_MIN_TURNS,
+    MAX_FIRES,
+    TURNS_BETWEEN_FIRES,
+    check_fire,
+    record_fire,
+    stability,
+)
+
+DIM = 8
+NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=UTC)
+NOW_ISO = NOW.isoformat()
+
+
+def unit(axis: int) -> list[float]:
+    v = [0.0] * DIM
+    v[axis] = 1.0
+    return v
+
+
+def blend(a: list[float], b: list[float], t: float) -> list[float]:
+    return [(1 - t) * x + t * y for x, y in zip(a, b, strict=True)]
+
+
+def settled_state(axis: int = 0, turns: int = 4) -> dict:
+    """A state whose theme has settled on the given axis."""
+    s = empty_state("s1")
+    s["ema"] = unit(axis)
+    s["ema_turns"] = turns
+    s["ring"] = [unit(axis), unit(axis), unit(axis)]
+    return s
+
+
+def test_no_fire_without_ema():
+    assert check_fire(empty_state("s1"), NOW) == (False, "no_ema")
+
+
+def test_no_fire_while_warming():
+    s = settled_state(turns=EMA_MIN_TURNS - 1)
+    assert check_fire(s, NOW) == (False, "warming")
+
+
+def test_no_fire_when_ring_partial():
+    s = settled_state()
+    s["ring"] = [unit(0), unit(0)]
+    assert check_fire(s, NOW) == (False, "unstable")
+
+
+def test_no_fire_when_unstable():
+    s = settled_state()
+    s["ring"] = [unit(0), blend(unit(0), unit(1), 0.5), unit(1)]
+    assert check_fire(s, NOW) == (False, "unstable")
+
+
+def test_fires_when_settled():
+    assert check_fire(settled_state(), NOW) == (True, "fire")
+
+
+def test_record_fire_claims_region():
+    s = settled_state()
+    record_fire(s, NOW_ISO)
+    assert s["fired_count"] == 1
+    assert s["fired"][0]["turn"] == s["ema_turns"]
+    assert s["fired"][0]["ema"] == unit(0)
+    assert s["worker_pending_since"] == NOW_ISO
+
+
+def test_pending_claim_blocks_then_goes_stale():
+    s = settled_state(axis=1, turns=10)
+    record_fire(s, NOW_ISO)
+    # Move the theme far away and past cooldown so only the claim gates
+    s["ema"] = unit(2)
+    s["ring"] = [unit(2)] * 3
+    s["ema_turns"] = 10 + TURNS_BETWEEN_FIRES
+    within = NOW + timedelta(seconds=60)
+    assert check_fire(s, within) == (False, "worker_pending")
+    after = NOW + timedelta(seconds=121)
+    assert check_fire(s, after) == (True, "fire")
+
+
+def test_unparseable_claim_treated_stale():
+    s = settled_state()
+    s["worker_pending_since"] = "not-a-timestamp"
+    assert check_fire(s, NOW) == (True, "fire")
+
+
+def test_cooldown_between_fires():
+    s = settled_state(turns=5)
+    record_fire(s, NOW_ISO)
+    s["ema"] = unit(3)
+    s["ring"] = [unit(3)] * 3
+    s["ema_turns"] = 5 + TURNS_BETWEEN_FIRES - 1
+    s["worker_pending_since"] = None
+    assert check_fire(s, NOW) == (False, "cooldown")
+    s["ema_turns"] = 5 + TURNS_BETWEEN_FIRES
+    assert check_fire(s, NOW) == (True, "fire")
+
+
+def test_near_fired_region_blocks_far_region_fires():
+    s = settled_state(turns=5)
+    record_fire(s, NOW_ISO)
+    s["worker_pending_since"] = None
+    s["ema_turns"] = 5 + TURNS_BETWEEN_FIRES
+    # Slightly moved theme: distance << 0.35
+    near = blend(unit(0), unit(1), 0.1)
+    s["ema"] = near
+    s["ring"] = [near] * 3
+    assert check_fire(s, NOW) == (False, "near_fired_region")
+    # Orthogonal theme: distance 1.0
+    s["ema"] = unit(4)
+    s["ring"] = [unit(4)] * 3
+    assert check_fire(s, NOW) == (True, "fire")
+
+
+def test_max_fires_cap():
+    s = settled_state(turns=50)
+    s["fired_count"] = MAX_FIRES
+    assert check_fire(s, NOW) == (False, "max_fires")
+
+
+def test_stability_empty_ring():
+    assert stability([]) == 0.0
+    assert stability([unit(0)]) == 0.0


### PR DESCRIPTION
## What

First stage of the ambient session-awareness layer (WS-C): the system that watches what a session is *about* and — in later PRs — volunteers relevant memories the per-prompt keyword lane misses. PR1 is **record-only**: no worker spawn, no injection, no output change.

New package \`src/genesis/session_awareness/\` (pure functions, no clocks, zero DB/Qdrant access):
- **accumulator.py** — EMA (α=0.25) over genuine user-prompt embeddings, renormalized each fold. Outlier-skip guard: a vector at cosine < 0.05 vs the current EMA (cross-backend/off-family response) is counted and skipped, never folded. Dimension changes are absorbed by the same branch. Decaying entity ledger (prompt keywords ×1.0, file keywords ×0.3, decay 0.9/turn, alias-normalized); file paths never touch the EMA.
- **trigger.py** — pure \`check_fire\`: theme must exist ≥3 turns, be stable (min pairwise cosine ≥0.90 across the last-3 EMA ring), sit ≥0.35 from every previously fired region, respect a 3-turn cooldown, ≤3 fires/session, and honor a pending-worker claim with a 120s stale override. Every "no" returns its reason for shadow logs and the replay harness.
- **statefiles.py** — \`~/.genesis/sessions/<id>/session_theme.json\`: traversal-guarded, atomic mkstemp→replace, corrupt/stale (>24h) degrades to empty, saves never raise.
- **hook_api.py** — \`hook_fold\`: the one fail-open entry point the hook calls.

Hook integration (\`scripts/proactive_memory_hook.py\`): \`_ambient_fold\` runs at the very end of \`_run\`, after all stdout flushes AND all existing metrics — deliberately outside the \`total_ms\` window so new work cannot skew the H-1 latency baselines. Skips harness envelopes and embed-less turns. Kill switch: \`GENESIS_SESSION_AWARENESS_DISABLED=1\`. Dispatched sessions never run it (existing \`GENESIS_CC_SESSION\` guard).

## Zero-behavior-change proof

Subprocess integration test (real embedding backend, skipif-gated) runs the hook exactly as CC does, 5 same-theme turns, in two isolated HOMEs: **stdout is byte-identical enabled vs disabled, turn by turn**. The enabled home accumulates \`session_theme.json\` (theme settles → one fire recorded); the disabled home writes nothing. Envelope prompts don't fold.

## Also fixes: hook tests were touching the production vector store

Both hook subprocess tests pointed \`QDRANT_URL\` at live Qdrant, so every backend-enabled test run had the hook's \`_increment_retrieved\` bumping \`retrieved_count\` on real memory points — quiet pollution of retrieval baselines. Both now use a dead port (also makes stdout deterministic for the byte-identical assertion).

## Measured hot-path cost

Package import 18ms; first fold 48ms (one-time alias YAML load); steady-state fold 0.7ms — all after the final stdout flush, user-invisible.

## Verification

- 41 tests green: accumulator (12), trigger (11), statefiles (8), hook_fold orchestration (4), subprocess integration (2), plus the fixed learning-hook test.
- \`check_subsystem_map.py\` clean — package claimed under ambient-cognition in \`docs/architecture/CURRENT.md\`.
- Deviation from the design doc, on purpose: fires are recorded only in \`session_theme.json\` (already compaction-durable), not double-written into the hook-owned intent trail — one owner per file, fewer failure modes in a hot path.

PR2 (detached worker + ranking + shadow logs), PR3 (arbiter), PR4 (OMI-replay kill criterion) follow.