### PR TITLE
fix(cc): truthful terminal states for crashed/cancelled sessions (T2-B reconcile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   included knowledge sources could only surface knowledge via vector
   similarity — exact-phrase and keyword matches on ingested docs were
   silently dropped. It now searches every requested collection.
+
+- **Background sessions that crash or get cancelled no longer show up as
+  "completed."** A session interrupted mid-run used to sit "active" until a
+  cleanup job quietly relabeled it completed — so the dashboard and
+  Genesis's own success metrics counted crashes as wins. Cancelled sessions
+  are now recorded as failed on the spot, orphaned ones are marked expired
+  (outcome unknown) at boot and every 6 hours, and only genuinely finished
+  sessions read as completed.
 - **Asking Genesis to grow a disk or wait on your reply now works from a Claude
   Code session, not only from inside the running server.** The two tools that
   block on your Telegram reply (`provision_grow`, `outreach_send_and_wait`) need

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -102,9 +102,11 @@ verified: e01e0c49 2026-07-09
   + a boot-time kick) routes through `SessionManager.cleanup_stale` —
   stale non-foreground 'active' rows → `expired` (outcome unknown),
   end-hooks fired. Known interruptions record `failed`: `_run_session` has
-  an explicit `CancelledError` handler (T2-B 2026-07-09; the old crud
-  `reap_stale`, which relabeled orphans 'completed', is deleted). J-9
-  counts only `completed` as success.
+  an explicit `CancelledError` handler, and `GenesisRuntime.shutdown()`
+  cancel-and-awaits the runner's in-flight tasks (`DirectSessionRunner
+  .shutdown`, 10s grace) BEFORE closing the DB so that handler can persist
+  (T2-B 2026-07-09; the old crud `reap_stale`, which relabeled orphans
+  'completed', is deleted). J-9 counts only `completed` as success.
 - **Perimeter-session hardening:** `_NO_WEB_TOOLS` / `_NO_OUTREACH_EXTRAS`
   blocklists strip risky tools from perimeter profiles — a security edge, not
   configuration convenience.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -105,7 +105,7 @@ verified: e01e0c49 2026-07-09
   an explicit `CancelledError` handler, and `GenesisRuntime.shutdown()`
   cancel-and-awaits the runner's in-flight tasks (`DirectSessionRunner
   .shutdown`, 10s grace) BEFORE closing the DB so that handler can persist
-  (T2-B 2026-07-09; the old crud `reap_stale`, which relabeled orphans
+  (2026-07-09; the old crud `reap_stale`, which relabeled orphans
   'completed', is deleted). J-9 counts only `completed` as success.
 - **Perimeter-session hardening:** `_NO_WEB_TOOLS` / `_NO_OUTREACH_EXTRAS`
   blocklists strip risky tools from perimeter profiles — a security edge, not

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -87,7 +87,7 @@ any task bigger than an LLM call.
 ```yaml subsystem-map
 entry: execution-cc
 modules: [cc]
-verified: 9037d45b 2026-07-07
+verified: e01e0c49 2026-07-09
 ```
 
 - `cc/direct_session.py` + `cc/conversation.py` (both >1000 LOC; split
@@ -97,9 +97,14 @@ verified: 9037d45b 2026-07-07
 - **Spawn autonomy circuit breaker** (direct_session.py ~:600-635):
   `bayesian_posterior < 0.15 and total_corrections > 3` blocks non-foreground
   dispatch — flagged for review as a visible lever (Design Principle 3).
-- Recovery: `recover_stale_claims` on boot; `reap_stale` runs as the
-  `session_reaper` job on the **learning** scheduler (CronTrigger every 6h).
-  `SessionManager.cleanup_stale` is built but UNWIRED.
+- Recovery: `recover_stale_claims` on boot (queue claims); the
+  `session_reaper` job on the **learning** scheduler (CronTrigger every 6h
+  + a boot-time kick) routes through `SessionManager.cleanup_stale` —
+  stale non-foreground 'active' rows → `expired` (outcome unknown),
+  end-hooks fired. Known interruptions record `failed`: `_run_session` has
+  an explicit `CancelledError` handler (T2-B 2026-07-09; the old crud
+  `reap_stale`, which relabeled orphans 'completed', is deleted). J-9
+  counts only `completed` as success.
 - **Perimeter-session hardening:** `_NO_WEB_TOOLS` / `_NO_OUTREACH_EXTRAS`
   blocklists strip risky tools from perimeter profiles — a security edge, not
   configuration convenience.

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -282,8 +282,9 @@ class ConversationLoop:
             # session's sticky peer session (failover returns early, never here).
             await self._maybe_clear_fallback(session)
 
-            # Activity timestamp — non-critical, but reap_stale() uses it so
-            # persistent failures deserve monitoring (WARNING, not debug).
+            # Activity timestamp — non-critical, but the stale-session reaper
+            # (SessionManager.cleanup_stale) keys on it so persistent
+            # failures deserve monitoring (WARNING, not debug).
             try:
                 await self._session_mgr.update_activity(session["id"])
             except Exception:
@@ -583,8 +584,9 @@ class ConversationLoop:
             # session's sticky peer session (failover returns early, never here).
             await self._maybe_clear_fallback(session)
 
-            # Activity timestamp — non-critical, but reap_stale() uses it so
-            # persistent failures deserve monitoring (WARNING, not debug).
+            # Activity timestamp — non-critical, but the stale-session reaper
+            # (SessionManager.cleanup_stale) keys on it so persistent
+            # failures deserve monitoring (WARNING, not debug).
             try:
                 await self._session_mgr.update_activity(session["id"])
             except Exception:

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -818,7 +818,7 @@ class DirectSessionRunner:
             return result
 
         except asyncio.CancelledError:
-            # T2-B: CancelledError is a BaseException — the Exception handler
+            # CancelledError is a BaseException — the Exception handler
             # below never sees it, so a cancelled session used to linger
             # 'active' until the stale reaper swept it. A cancel (runtime
             # shutdown via self.shutdown(), task.cancel) is a KNOWN
@@ -838,7 +838,7 @@ class DirectSessionRunner:
             try:
                 await self._store_result(session_id, request, cancel_result)
                 # Feed the outcome back to an ego proposal, matching the
-                # generic failure path below (review P3).
+                # generic failure path below.
                 await self._record_proposal_outcome(request, cancel_result)
                 await self._session_manager.fail(
                     session_id, reason="cancelled",

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -665,6 +665,30 @@ class DirectSessionRunner:
     def active_count(self) -> int:
         return len(self._active)
 
+    async def shutdown(self, *, grace_s: float = 10.0) -> int:
+        """Cancel in-flight session tasks and await their handlers.
+
+        Called by ``GenesisRuntime.shutdown()`` BEFORE the DB closes so the
+        CancelledError handler in ``_run_session`` can persist a terminal
+        'failed' status. Without this, a ``systemctl restart`` tears the
+        event loop down only after the DB is closed — the handler's writes
+        no-op and the rows linger 'active' until the stale reaper.
+
+        ``grace_s`` bounds the wait because shutdown runs under systemd's
+        TimeoutStopSec (~90s) hard deadline: an unbounded wait on a wedged
+        CC child would push the whole unit into SIGKILL, losing every later
+        cleanup step (including the DB close itself). 10s is ample for the
+        handler's few DB writes.
+
+        Returns the number of tasks that were still in flight.
+        """
+        tasks = [t for t in self._active.values() if not t.done()]
+        for t in tasks:
+            t.cancel()
+        if tasks:
+            await asyncio.wait(tasks, timeout=grace_s)
+        return len(tasks)
+
     @staticmethod
     def _summarize_tools(tools_called: list[dict]) -> dict[str, int]:
         """Aggregate tool calls into {name: count} dict."""
@@ -796,24 +820,26 @@ class DirectSessionRunner:
         except asyncio.CancelledError:
             # T2-B: CancelledError is a BaseException — the Exception handler
             # below never sees it, so a cancelled session used to linger
-            # 'active' until the stale reaper swept it. A cancel (shutdown,
-            # task.cancel) is a KNOWN interruption: record it as failed.
-            # Best-effort — cancellation was already delivered at the await
-            # point above, so these writes normally complete; a second cancel
-            # or a closed DB just propagates after the log.
+            # 'active' until the stale reaper swept it. A cancel (runtime
+            # shutdown via self.shutdown(), task.cancel) is a KNOWN
+            # interruption: record it as failed. Best-effort — cancellation
+            # was already delivered at the await point above, so these writes
+            # normally complete; a closed DB is caught and logged, while a
+            # genuinely re-delivered second cancel propagates immediately
+            # (skipping the log — same terminal task state either way).
             elapsed = time.monotonic() - start
+            cancel_result = DirectSessionResult(
+                session_id=session_id,
+                success=False,
+                error="CancelledError: session cancelled",
+                duration_s=round(elapsed, 1),
+                tools_called=telemetry,
+            )
             try:
-                await self._store_result(
-                    session_id,
-                    request,
-                    DirectSessionResult(
-                        session_id=session_id,
-                        success=False,
-                        error="CancelledError: session cancelled",
-                        duration_s=round(elapsed, 1),
-                        tools_called=telemetry,
-                    ),
-                )
+                await self._store_result(session_id, request, cancel_result)
+                # Feed the outcome back to an ego proposal, matching the
+                # generic failure path below (review P3).
+                await self._record_proposal_outcome(request, cancel_result)
                 await self._session_manager.fail(
                     session_id, reason="cancelled",
                 )

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -793,6 +793,41 @@ class DirectSessionRunner:
             )
             return result
 
+        except asyncio.CancelledError:
+            # T2-B: CancelledError is a BaseException — the Exception handler
+            # below never sees it, so a cancelled session used to linger
+            # 'active' until the stale reaper swept it. A cancel (shutdown,
+            # task.cancel) is a KNOWN interruption: record it as failed.
+            # Best-effort — cancellation was already delivered at the await
+            # point above, so these writes normally complete; a second cancel
+            # or a closed DB just propagates after the log.
+            elapsed = time.monotonic() - start
+            try:
+                await self._store_result(
+                    session_id,
+                    request,
+                    DirectSessionResult(
+                        session_id=session_id,
+                        success=False,
+                        error="CancelledError: session cancelled",
+                        duration_s=round(elapsed, 1),
+                        tools_called=telemetry,
+                    ),
+                )
+                await self._session_manager.fail(
+                    session_id, reason="cancelled",
+                )
+            except Exception:
+                logger.error(
+                    "Failed to record session %s cancellation",
+                    session_id[:8], exc_info=True,
+                )
+            logger.warning(
+                "Direct session %s cancelled after %.1fs",
+                session_id[:8], elapsed,
+            )
+            raise
+
         except Exception as exc:
             elapsed = time.monotonic() - start
             error_result = DirectSessionResult(

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -841,6 +841,27 @@ class CCInvoker:
                 os.killpg(pgid, signal.SIGKILL)
             except (ProcessLookupError, PermissionError, ValueError, TypeError):
                 proc.kill()
+        except asyncio.CancelledError:
+            # Task cancellation (runtime shutdown cancelling an in-flight
+            # session) must not leak the CC child: without this handler the
+            # finally below only unregistered the proc, leaving the subprocess
+            # running — spending tokens and editing files — after the session
+            # row was already finalized. Same guarded group-kill as the
+            # timeout path; the non-streaming run() already kills in its
+            # finally for exactly this case.
+            logger.warning(
+                "CC streaming cancelled (PID %s) — killing subprocess",
+                proc.pid,
+            )
+            try:
+                pgid = os.getpgid(proc.pid)
+                if pgid <= 1:
+                    raise ValueError(f"Refusing killpg with pgid={pgid}")
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, ValueError, TypeError):
+                with contextlib.suppress(ProcessLookupError, OSError):
+                    proc.kill()
+            raise
         finally:
             self._unregister_proc(reg_key)
 

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -131,26 +131,10 @@ async def query_stale(
     return [dict(r) for r in await cursor.fetchall()]
 
 
-async def reap_stale(
-    db: aiosqlite.Connection,
-    *,
-    older_than: str,
-) -> int:
-    """Mark stale active sessions as completed. Returns count reaped.
-
-    Foreground sessions are excluded — they should never be auto-expired
-    (the user might resume).  This matches the policy in
-    ``SessionManager.cleanup_stale()``.
-    """
-    cursor = await db.execute(
-        """UPDATE cc_sessions SET status = 'completed'
-           WHERE status = 'active'
-             AND session_type != 'foreground'
-             AND last_activity_at < ?""",
-        (older_than,),
-    )
-    await db.commit()
-    return cursor.rowcount
+# T2-B: reap_stale (bulk UPDATE → 'completed') was deleted. It relabeled
+# crashed/orphaned sessions as successes; the session reaper now routes
+# through ``SessionManager.cleanup_stale()`` (policy-aware, → 'expired',
+# fires end-hooks). See runtime/init/learning.py::_reap_stale_sessions.
 
 
 async def set_pid(db: aiosqlite.Connection, id: str, pid: int) -> bool:

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -131,7 +131,7 @@ async def query_stale(
     return [dict(r) for r in await cursor.fetchall()]
 
 
-# T2-B: reap_stale (bulk UPDATE → 'completed') was deleted. It relabeled
+# reap_stale (bulk UPDATE → 'completed') was deleted. It relabeled
 # crashed/orphaned sessions as successes; the session reaper now routes
 # through ``SessionManager.cleanup_stale()`` (policy-aware, → 'expired',
 # fires end-hooks). See runtime/init/learning.py::_reap_stale_sessions.

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -459,6 +459,24 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             except Exception:
                 logger.warning("Failed to expire cognitive state entries", exc_info=True)
 
+        # Boot-time stale-session sweep — 'active' rows orphaned by a crashed
+        # process shouldn't wait up to ~6h for the session_reaper cron.
+        # Deliberately HERE, after ALL init steps: session end-hooks (e.g. the
+        # ego dispatch-outcome tracker, registered in ego init) must exist
+        # before orphans are expired, and ego init runs after learning init
+        # (where the job itself is registered).
+        if self._learning_scheduler is not None:
+            try:
+                _reaper_job = self._learning_scheduler.get_job("session_reaper")
+                if _reaper_job is not None:
+                    from genesis.util.tasks import tracked_task
+
+                    tracked_task(
+                        _reaper_job.func(), name="initial_session_reap",
+                    )
+            except Exception:
+                logger.warning("Boot session-reap kick failed", exc_info=True)
+
         self._wire_job_retry_registry()
 
         critical_ok = all(
@@ -503,8 +521,8 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
 
         # Cancel-and-await in-flight direct sessions while the DB is still
         # open, so _run_session's CancelledError handler can persist a
-        # terminal 'failed' status (T2-B review P2 — without this the rows
-        # linger 'active' across every systemctl restart).
+        # terminal 'failed' status (without this the rows linger 'active'
+        # across every systemctl restart).
         if self._direct_session_runner is not None:
             try:
                 stopped = await self._direct_session_runner.shutdown()

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -501,6 +501,20 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
                 await self._status_writer_task
             logger.info("Stopped status writer loop")
 
+        # Cancel-and-await in-flight direct sessions while the DB is still
+        # open, so _run_session's CancelledError handler can persist a
+        # terminal 'failed' status (T2-B review P2 — without this the rows
+        # linger 'active' across every systemctl restart).
+        if self._direct_session_runner is not None:
+            try:
+                stopped = await self._direct_session_runner.shutdown()
+                if stopped:
+                    logger.info(
+                        "Cancelled %d in-flight direct sessions", stopped,
+                    )
+            except Exception:
+                logger.exception("Failed to stop direct-session runner")
+
         for name, component in [
             ("user_ego_cadence", self._ego_cadence_manager),
             ("genesis_ego_cadence", self._genesis_ego_cadence_manager),

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -719,15 +719,25 @@ async def init(rt: GenesisRuntime) -> None:
             if rt._db is None:
                 return
             try:
-                from genesis.db.crud.cc_sessions import reap_stale
-                from genesis.db.crud.session_heartbeats import cleanup_stale
+                from genesis.db.crud.session_heartbeats import (
+                    cleanup_stale as cleanup_stale_heartbeats,
+                )
 
-                cutoff = (datetime.now(UTC) - timedelta(hours=6)).isoformat()
-                reaped = await reap_stale(rt._db, older_than=cutoff)
-                cleaned = await cleanup_stale(rt._db)
+                # T2-B: policy-aware sweep via SessionManager — stale
+                # non-foreground 'active' rows → 'expired' (outcome UNKNOWN:
+                # the process is gone; it may have crashed or been killed),
+                # with session end-hooks fired. Replaces the old crud
+                # reap_stale, which relabeled these rows 'completed' and made
+                # crashes read as successes in J-9's success rates.
+                reaped = 0
+                if rt._session_manager is not None:
+                    reaped = await rt._session_manager.cleanup_stale(
+                        max_idle_minutes=360,
+                    )
+                cleaned = await cleanup_stale_heartbeats(rt._db)
                 rt.record_job_success("session_reaper")
                 if reaped:
-                    logger.info("Session reaper: marked %d stale sessions as completed", reaped)
+                    logger.info("Session reaper: expired %d stale sessions", reaped)
                 if cleaned:
                     logger.info("Session reaper: cleaned %d stale heartbeats", cleaned)
             except Exception as exc:
@@ -741,6 +751,11 @@ async def init(rt: GenesisRuntime) -> None:
             max_instances=1,
             misfire_grace_time=3600,
         )
+        # T2-B: boot-time sweep — 'active' rows orphaned by a crashed process
+        # shouldn't wait up to ~6h for the next cron tick. Init order runs
+        # cc_relay (which sets rt._session_manager) before learning, so the
+        # manager exists here; the None-guard above covers degraded init.
+        _tt(_reap_stale_sessions(), name="initial_session_reap")
 
         async def _refresh_capability_map() -> None:
             if rt._db is None:

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -723,7 +723,7 @@ async def init(rt: GenesisRuntime) -> None:
                     cleanup_stale as cleanup_stale_heartbeats,
                 )
 
-                # T2-B: policy-aware sweep via SessionManager — stale
+                # Policy-aware sweep via SessionManager — stale
                 # non-foreground 'active' rows → 'expired' (outcome UNKNOWN:
                 # the process is gone; it may have crashed or been killed),
                 # with session end-hooks fired. Replaces the old crud
@@ -751,11 +751,11 @@ async def init(rt: GenesisRuntime) -> None:
             max_instances=1,
             misfire_grace_time=3600,
         )
-        # T2-B: boot-time sweep — 'active' rows orphaned by a crashed process
-        # shouldn't wait up to ~6h for the next cron tick. Init order runs
-        # cc_relay (which sets rt._session_manager) before learning, so the
-        # manager exists here; the None-guard above covers degraded init.
-        _tt(_reap_stale_sessions(), name="initial_session_reap")
+        # The boot-time sweep kick for this job lives at the END of
+        # GenesisRuntime.bootstrap() (not here) — session end-hooks (e.g. the
+        # ego's dispatch-outcome tracker) register during LATER init steps,
+        # and a sweep fired from learning init would expire orphaned rows
+        # before those hooks exist.
 
         async def _refresh_capability_map() -> None:
             if rt._db is None:

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -286,3 +286,42 @@ async def test_run_session_isolates_and_cleans_sandbox(db, tmp_path, monkeypatch
     assert "bg-cc-sessions" in captured["path"]
     # finally cleanup removed the whole per-session tree
     assert not _bg_session_root(sess["id"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_run_session_cancelled_marks_failed(db):
+    """T2-B: a cancelled session must not linger 'active'.
+
+    CancelledError is a BaseException, so the ``except Exception`` failure
+    path never saw it — the row stayed 'active' until the stale reaper
+    swept it (historically relabeling it 'completed', i.e. a crash
+    masquerading as success in J-9's success rates).
+    """
+    from types import SimpleNamespace
+
+    from genesis.cc.types import CCInvocation, CCModel, EffortLevel, SessionType
+
+    sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+    invoker = AsyncMock()
+    # Cancellation delivered at the await point inside _run_session's try
+    invoker.run_streaming = AsyncMock(side_effect=asyncio.CancelledError())
+    runner = DirectSessionRunner(
+        invoker=invoker,
+        session_manager=sm,
+        config_builder=AsyncMock(),
+        runtime=SimpleNamespace(_db=db),
+    )
+    runner._build_invocation = lambda _req, _sid: CCInvocation(prompt="x")
+    sess = await sm.create_background(
+        session_type=SessionType.BACKGROUND_TASK,
+        model=CCModel.SONNET,
+        effort=EffortLevel.MEDIUM,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._run_session(DirectSessionRequest(prompt="t"), sess["id"])
+
+    row = await cc_sessions.get_by_id(db, sess["id"])
+    assert row["status"] == "failed", (
+        f"cancelled session left status={row['status']!r} — must be terminal"
+    )

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -325,3 +325,81 @@ async def test_run_session_cancelled_marks_failed(db):
     assert row["status"] == "failed", (
         f"cancelled session left status={row['status']!r} — must be terminal"
     )
+
+
+@pytest.mark.asyncio
+async def test_runner_shutdown_cancels_and_persists_failed(db):
+    """Review P2: runtime shutdown must cancel-and-await in-flight session
+    tasks BEFORE the DB closes, so the CancelledError handler can persist a
+    terminal status. Without this, `systemctl restart` tears the loop down
+    after the DB is gone and rows stay 'active'."""
+    from types import SimpleNamespace
+
+    from genesis.cc.types import CCInvocation, CCModel, EffortLevel, SessionType
+
+    sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+    invoker = AsyncMock()
+
+    async def _blocks_forever(inv, on_event=None):
+        await asyncio.Event().wait()  # never set — a wedged CC child
+
+    invoker.run_streaming = _blocks_forever
+    runner = DirectSessionRunner(
+        invoker=invoker,
+        session_manager=sm,
+        config_builder=AsyncMock(),
+        runtime=SimpleNamespace(_db=db),
+    )
+    runner._build_invocation = lambda _req, _sid: CCInvocation(prompt="x")
+    sess = await sm.create_background(
+        session_type=SessionType.BACKGROUND_TASK,
+        model=CCModel.SONNET,
+        effort=EffortLevel.MEDIUM,
+    )
+    task = asyncio.create_task(
+        runner._run_session(DirectSessionRequest(prompt="t"), sess["id"]),
+    )
+    runner._active[sess["id"]] = task
+    await asyncio.sleep(0.05)  # let the task enter run_streaming
+
+    stopped = await runner.shutdown()
+
+    assert stopped == 1
+    assert task.done()
+    row = await cc_sessions.get_by_id(db, sess["id"])
+    assert row["status"] == "failed", (
+        f"in-flight session left status={row['status']!r} after shutdown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_session_cancelled_records_proposal_outcome(db):
+    """Review P3: the CancelledError path must feed the outcome back to an
+    ego proposal, matching the generic failure path."""
+    from types import SimpleNamespace
+
+    from genesis.cc.types import CCInvocation, CCModel, EffortLevel, SessionType
+
+    sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+    invoker = AsyncMock()
+    invoker.run_streaming = AsyncMock(side_effect=asyncio.CancelledError())
+    runner = DirectSessionRunner(
+        invoker=invoker,
+        session_manager=sm,
+        config_builder=AsyncMock(),
+        runtime=SimpleNamespace(_db=db),
+    )
+    runner._build_invocation = lambda _req, _sid: CCInvocation(prompt="x")
+    runner._record_proposal_outcome = AsyncMock()
+    sess = await sm.create_background(
+        session_type=SessionType.BACKGROUND_TASK,
+        model=CCModel.SONNET,
+        effort=EffortLevel.MEDIUM,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._run_session(DirectSessionRequest(prompt="t"), sess["id"])
+
+    runner._record_proposal_outcome.assert_awaited_once()
+    result = runner._record_proposal_outcome.await_args.args[1]
+    assert result.success is False

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -1422,3 +1422,41 @@ class TestEffortClamping:
         with caplog.at_level(logging.WARNING, logger="genesis.cc.invoker"):
             invoker._build_args(inv)
         assert not any("clamping" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_cancelled_kills_subprocess(invoker):
+    """Cancellation mid-stream must terminate the CC child.
+
+    The streaming loop's CancelledError path previously only unregistered
+    the proc — the child kept running (spending tokens, editing files)
+    after the session row was finalized. Mirrors the guarded-killpg
+    pattern the TimeoutError path already uses.
+    """
+    mock_proc = AsyncMock()
+    mock_proc.pid = 99999  # real int — killpg(1) would signal EVERYTHING
+    mock_proc.returncode = None
+    mock_proc.kill = MagicMock()
+    mock_proc.terminate = MagicMock()
+    stdin = MagicMock()
+    stdin.drain = AsyncMock()
+    mock_proc.stdin = stdin
+
+    class _CancelledStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            # Simulate task.cancel() delivered at the stdout await point
+            raise asyncio.CancelledError
+
+    mock_proc.stdout = _CancelledStream()
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+         pytest.raises(asyncio.CancelledError):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+
+    # getpgid(99999) raises ProcessLookupError -> falls back to proc.kill()
+    assert mock_proc.kill.called, (
+        "cancelled streaming run must kill the CC subprocess"
+    )

--- a/tests/test_cc/test_session_manager.py
+++ b/tests/test_cc/test_session_manager.py
@@ -160,3 +160,57 @@ async def test_cleanup_stale(db, manager):
     assert bg_row["status"] == "expired"
     fg_row = await cc_sessions.get_by_id(db, "stale-fg")
     assert fg_row["status"] == "active"  # Foreground never auto-expired
+
+
+async def test_cleanup_stale_fires_end_hooks(db, manager):
+    """T2-B: the reaper path must fire session end-hooks for swept rows —
+    the old crud reap_stale bypassed SessionManager and never did."""
+    await cc_sessions.create(
+        db,
+        id="stale-hook",
+        session_type="background_task",
+        model="sonnet",
+        effort="medium",
+        status="active",
+        user_id="u1",
+        channel="telegram",
+        started_at="2026-03-07T06:00:00",
+        last_activity_at="2026-03-07T06:00:00",
+        source_tag="direct_session",
+    )
+    fired: list[str] = []
+
+    async def _hook(session_id: str) -> None:
+        fired.append(session_id)
+
+    manager.add_on_end(_hook)
+    count = await manager.cleanup_stale(max_idle_minutes=60)
+    assert count == 1
+    assert fired == ["stale-hook"]
+    row = await cc_sessions.get_by_id(db, "stale-hook")
+    assert row["status"] == "expired"
+
+
+async def test_cleanup_stale_respects_cutoff(db, manager):
+    """A recently-active background session is NOT swept (6h cron passes
+    max_idle_minutes=360; recent activity must survive)."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
+    await cc_sessions.create(
+        db,
+        id="fresh-bg",
+        session_type="background_task",
+        model="sonnet",
+        effort="medium",
+        status="active",
+        user_id="u1",
+        channel="telegram",
+        started_at=now,
+        last_activity_at=now,
+        source_tag="direct_session",
+    )
+    count = await manager.cleanup_stale(max_idle_minutes=360)
+    assert count == 0
+    row = await cc_sessions.get_by_id(db, "fresh-bg")
+    assert row["status"] == "active"

--- a/tests/test_db/test_cc_sessions.py
+++ b/tests/test_db/test_cc_sessions.py
@@ -146,30 +146,10 @@ async def test_query_stale_excludes_foreground(db, sess_fields):
     assert len(rows) == 0
 
 
-async def test_reap_stale_excludes_foreground(db, sess_fields):
-    """reap_stale must never mark foreground sessions as completed."""
-    await cc_sessions.create(
-        db,
-        **{**sess_fields, "session_type": "foreground",
-           "last_activity_at": "2026-03-07T06:00:00"},
-    )
-    reaped = await cc_sessions.reap_stale(db, older_than="2026-03-07T07:00:00")
-    assert reaped == 0
-    row = await cc_sessions.get_by_id(db, "sess-1")
-    assert row["status"] == "active"  # Still active, not reaped
-
-
-async def test_reap_stale_expires_background(db, sess_fields):
-    """reap_stale should expire stale background sessions."""
-    await cc_sessions.create(
-        db,
-        **{**sess_fields, "session_type": "background_task",
-           "last_activity_at": "2026-03-07T06:00:00"},
-    )
-    reaped = await cc_sessions.reap_stale(db, older_than="2026-03-07T07:00:00")
-    assert reaped == 1
-    row = await cc_sessions.get_by_id(db, "sess-1")
-    assert row["status"] == "completed"
+# T2-B: the reap_stale crud tests were removed with the function itself —
+# the stale-sweep policy (foreground preserved, background → 'expired',
+# end-hooks fired) is covered at the SessionManager.cleanup_stale level in
+# tests/test_cc/test_session_manager.py.
 
 
 async def test_delete(db, sess_fields):

--- a/tests/test_db/test_cc_sessions.py
+++ b/tests/test_db/test_cc_sessions.py
@@ -146,7 +146,7 @@ async def test_query_stale_excludes_foreground(db, sess_fields):
     assert len(rows) == 0
 
 
-# T2-B: the reap_stale crud tests were removed with the function itself —
+# The reap_stale crud tests were removed with the function itself —
 # the stale-sweep policy (foreground preserved, background → 'expired',
 # end-hooks fired) is covered at the SessionManager.cleanup_stale level in
 # tests/test_cc/test_session_manager.py.

--- a/tests/test_runtime/test_runtime_shutdown.py
+++ b/tests/test_runtime/test_runtime_shutdown.py
@@ -181,3 +181,36 @@ async def test_ashutdown_clears_instance_even_when_shutdown_raises(
     await GenesisRuntime.ashutdown()
 
     assert GenesisRuntime._instance is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stops_direct_session_runner_before_db_close() -> None:
+    """Review P2 ordering guard: the direct-session runner's in-flight tasks
+    are cancelled-and-awaited while the DB connection is still OPEN — that's
+    the whole point (the CancelledError handler persists terminal status).
+    The fake runner proves it by using the DB inside its shutdown()."""
+    GenesisRuntime.reset()
+    rt = GenesisRuntime.instance()
+    rt._db = await aiosqlite.connect(":memory:")
+    rt._bootstrapped = True
+
+    db_was_usable: list[bool] = []
+
+    class _FakeRunner:
+        async def shutdown(self) -> int:
+            try:
+                async with rt._db.execute("SELECT 1") as cursor:
+                    db_was_usable.append((await cursor.fetchone()) == (1,))
+            except Exception:
+                db_was_usable.append(False)
+            return 0
+
+    rt._direct_session_runner = _FakeRunner()
+    try:
+        await GenesisRuntime.ashutdown()
+    finally:
+        GenesisRuntime.reset()
+
+    assert db_was_usable == [True], (
+        "runner.shutdown() must run BEFORE the DB closes"
+    )


### PR DESCRIPTION
## Summary

Crashed or cancelled background sessions read as SUCCESSES: they lingered `active` until the 6h `session_reaper` cron bulk-relabeled them `completed` — and J-9 counts only `status='completed'` as success (session_success_pct and the cognitive-loop rate). Full reconcile of the three overlapping defects:

- **CancelledError handler** in `DirectSessionRunner._run_session` — `CancelledError` is a `BaseException`, so the existing `except Exception` failure path never saw it. Cancels now record `failed` (reason=cancelled), feed the outcome back to ego proposals (matching the generic failure path), and re-raise.
- **Reaper reconcile** — the `session_reaper` job now routes through `SessionManager.cleanup_stale` (same 6h cutoff, verified bit-for-bit equivalent): policy-aware sweep of stale non-foreground `active` rows → `expired` (outcome UNKNOWN — the process is gone; `failed` would over-claim exactly like `completed` over-claimed), foreground never swept, session end-hooks fired. This wires the previously caller-less `cleanup_stale` and deletes the misleading crud `reap_stale`.
- **Boot-time sweep** — orphans from a crashed process no longer wait up to ~6h: an immediate `tracked_task` kick runs the reaper at startup (init order verified: cc_relay sets `rt._session_manager` before learning init).
- **Review P2 (fixed in-PR)** — nothing ever cancelled in-flight session tasks during runtime shutdown; asyncio's teardown delivered CancelledError only AFTER the DB closed, so the handler's writes no-oped on the most common trigger (`systemctl restart`). `GenesisRuntime.shutdown()` now cancel-and-awaits the runner's tasks (`DirectSessionRunner.shutdown()`, 10s grace — bounded because shutdown runs under systemd's TimeoutStopSec hard deadline) BEFORE closing the DB, with an ordering test proving the DB is still open when it runs.

## Verification

- TDD with empirical RED for every behavior change (cancel→failed; end-hooks on sweep; cutoff respected; shutdown persistence ×3).
- 53 tests green (direct_session, session_manager, cc_sessions crud, runtime shutdown); ruff clean; subsystem-map guard clean.
- Independent code review verified the risky assumptions with evidence: the boot sweep cannot catch a legitimately-running session (systemd cgroup kill covers CC children; max session timeout 1h vs 6h cutoff; background runs never update `last_activity_at`), and no `cc_sessions.status` consumer breaks on `completed`→`expired` (J-9, capability aggregator, dashboard — which already has an "Expired" filter — and the extraction job's source-tag allowlist all enumerated).

## Notes

- Regression markers: journal shows `initial_session_reap` at boot and `Cancelled N in-flight direct sessions` on restarts with sessions in flight; no `active` rows older than 6h; success metrics may dip slightly as crashes stop counting as wins (that's the fix working).
- CHANGELOG (user-visible entry) + `docs/architecture/CURRENT.md` execution-cc entry refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)