### PR TITLE
feat(memory): shadow-project novelty gate (H-1 PR2a, measurement-only)

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1014,6 +1014,12 @@ def _rrf_fusion(
     (curated ~0.95 competes at rank 2+; recon ~0.65 rarely surfaces). Max 1 KB
     slot prevents KB from flooding out episodic context.
     Code index results get a 0.5x weight (supplementary, not primary).
+
+    ``suppress_ids`` and ``shadow`` drive the H-1 PR2a novelty-gate MEASUREMENT
+    only — they never affect the returned results. When ``shadow`` is a dict, the
+    projected gate (suppress ``suppress_ids`` + serendipity boost) is computed on
+    copies and written into it fail-open; when ``shadow`` is None (all existing
+    callers) nothing extra runs.
     """
     scores: dict[str, float] = {}
     content_map: dict[str, dict] = {}
@@ -1100,7 +1106,14 @@ def _rrf_fusion(
     if shadow is not None:
         # Shadow projection must never affect the real injection path.
         with contextlib.suppress(Exception):
-            shadow.update(_shadow_gate(scores, content_map, suppress_ids))
+            # Vector rows carry the true _retrieved_count; content_map may hold
+            # the FTS duplicate (which lacks it), so pass an authoritative map.
+            rc_map = {
+                r["memory_id"]: r["_retrieved_count"]
+                for r in vector_results
+                if r.get("memory_id") and "_retrieved_count" in r
+            }
+            shadow.update(_shadow_gate(scores, content_map, suppress_ids, rc_map))
 
     return results
 
@@ -1109,6 +1122,7 @@ def _shadow_gate(
     scores: dict[str, float],
     content_map: dict[str, dict],
     suppress_ids: frozenset[str],
+    retrieved_counts: dict[str, int] | None = None,
 ) -> dict:
     """Project the PR2b novelty gate's injection set (H-1 PR2a, measurement-only).
 
@@ -1121,15 +1135,17 @@ def _shadow_gate(
     (Intentional near-duplicate of the loop above: keeping it separate is what
     guarantees the measured path stays byte-identical during the shadow window.)
     """
+    # A memory hit by both FTS and vector keeps its FTS row in content_map (no
+    # _retrieved_count); retrieved_counts carries the vector payload's value so a
+    # never-surfaced duplicate hit is still recognized as serendipity-eligible.
+    retrieved_counts = retrieved_counts or {}
     boosted = dict(scores)
     serendipity_boosted = 0
     for mid, entry in content_map.items():
         if mid not in boosted:
             continue
-        if (
-            entry.get("_retrieved_count", -1) == 0
-            and entry.get("collection") != "knowledge_base"
-        ):
+        rc = retrieved_counts.get(mid, entry.get("_retrieved_count", -1))
+        if rc == 0 and entry.get("collection") != "knowledge_base":
             boosted[mid] *= _SERENDIPITY_BOOST
             serendipity_boosted += 1
     ranked = sorted(boosted.items(), key=lambda x: x[1], reverse=True)

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -20,6 +20,7 @@ Reads hook input from stdin as JSON:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import importlib
 import json
 import os
@@ -539,6 +540,8 @@ def _is_garbage(content: str) -> bool:
     # boundary markers, but it also silently lost legitimate hits. `_format_results`
     # now strips any leaked markers and re-labels external-world hits (`KB·…`),
     # so surfacing-clean is safe. Do not re-add this drop as "protective".
+    if content is None:
+        return True  # NULL-content row (FTS content is nullable): filter, never crash
     stripped = content.lstrip()
     if stripped.startswith("{") and any(
         k in stripped[:100] for k in ('"drift_detected"', '"tags"', '"type":', '"operation"')
@@ -1091,9 +1094,13 @@ def _rrf_fusion(
 
     # H-1 PR2a (measurement-only): project what the novelty gate WOULD inject,
     # without touching `results`. Skipped entirely when shadow is None (every
-    # existing caller), so the injected output is byte-identical.
+    # existing caller). Wrapped fail-open: this runs inline BEFORE the caller
+    # prints `results`, so a shadow-projection failure must never suppress the
+    # real injection — the measurement is strictly subordinate to the output.
     if shadow is not None:
-        shadow.update(_shadow_gate(scores, content_map, suppress_ids))
+        # Shadow projection must never affect the real injection path.
+        with contextlib.suppress(Exception):
+            shadow.update(_shadow_gate(scores, content_map, suppress_ids))
 
     return results
 
@@ -1129,7 +1136,7 @@ def _shadow_gate(
 
     suppressed = 0
     kb_count = 0
-    projected: list[str] = []
+    selected: list[dict] = []
     for i, (mid, score) in enumerate(ranked[:_MAX_RESULTS * 4]):
         if mid not in content_map:
             continue
@@ -1143,11 +1150,19 @@ def _shadow_gate(
             kb_count += 1
             if kb_count > _MAX_KB_SLOTS:
                 continue
-        if _is_garbage(entry.get("content", "")):
-            continue
-        projected.append(mid)
-        if len(projected) >= _MAX_RESULTS:
+        selected.append(entry)
+        if len(selected) >= _MAX_RESULTS:
             break
+    # Mirror the real path exactly (see _run: `fused = [r for r in fused if not
+    # _is_garbage(...)]`): drop garbage from the SELECTED set with NO backfill,
+    # so projected vs actual differs ONLY by suppression + serendipity boost —
+    # the two mechanisms PR2a exists to measure. (The widened *4 scan above is
+    # for skipping suppressed IDs, not for backfilling garbage.)
+    projected = [
+        e.get("memory_id", "")
+        for e in selected
+        if not _is_garbage(e.get("content", ""))
+    ]
     return {
         "projected_ids": projected,
         "projected_injected": len(projected),

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -67,6 +67,19 @@ _MAX_RESULTS = 3
 _MIN_PROMPT_WORDS = 1  # Stop words already filter greetings to 0 keywords
 _METRICS_PATH = Path.home() / ".genesis" / "proactive_metrics.json"
 
+# Rank-2+ RRF floor and single-KB-slot cap for result selection. Module-level
+# so the H-1 PR2a shadow projection (_shadow_gate) shares the exact same values
+# as the real selection loop in _rrf_fusion.
+_MIN_RRF_SCORE_RANK2 = 0.015
+_MAX_KB_SLOTS = 1  # Prevent KB from flooding out episodic context
+
+# H-1 PR2a novelty-gate shadow: serendipity boost applied (in projection only)
+# to never-surfaced episodic memories, and the kill-switch flag that neutralizes
+# the suppression set without a deploy. PR2a is measurement-only — these affect
+# the shadow projection, never the injected output.
+_SERENDIPITY_BOOST = 1.3
+_WS_GATE_DISABLED_FLAG = Path.home() / ".genesis" / "ws_gate_disabled"
+
 # Common English stop words to filter from search queries
 _STOP_WORDS = frozenset({
     "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
@@ -425,11 +438,31 @@ def _append_injection_log(session_id: str, record: dict) -> None:
         pass  # Never block
 
 
+def _compute_suppress_ids(session_id: str) -> frozenset[str]:
+    """IDs already surfaced this session — the PR2b suppression set.
+
+    Empty when there's no session, or when the kill-switch flag
+    (``~/.genesis/ws_gate_disabled``) exists — a hot disable without a deploy.
+    In PR2a this feeds the shadow projection only; the real injection is
+    unaffected regardless.
+    """
+    if not session_id:
+        return frozenset()
+    try:
+        if _WS_GATE_DISABLED_FLAG.exists():
+            return frozenset()
+    except OSError:
+        pass
+    ws = _load_working_set(session_id)
+    return frozenset(ws.get("entries", {}).keys())
+
+
 def _ws_measure(
     fused: list[dict],
     session_id: str,
     surfaced_proc_id: str | None,
     now_iso: str,
+    shadow: dict | None = None,
 ) -> dict:
     """The whole working-set measurement step for one prompt.
 
@@ -438,6 +471,11 @@ def _ws_measure(
     (hook stdout is context injected into the conversation) and NEVER
     raises — any internal failure returns the stats gathered so far with
     safe defaults for the rest.
+
+    ``shadow`` (H-1 PR2a) is the ``_shadow_gate`` projection for this prompt;
+    when non-empty its ``projected_injected``/``suppressed``/``serendipity_boosted``
+    fields are merged into the injection-log record and returned stats. It never
+    changes the injected output — this step already runs after stdout is flushed.
     """
     stats: dict = {
         "injected_ids": [],
@@ -474,7 +512,7 @@ def _ws_measure(
             )
             _save_working_set(session_id, ws)
             stats["working_set_size"] = len(ws.get("entries", {}))
-            _append_injection_log(session_id, {
+            record = {
                 "ts": now_iso,
                 "turn": ws.get("turn", 0),
                 "injected": len(stats["injected_ids"]),
@@ -483,7 +521,12 @@ def _ws_measure(
                 "ws_size": stats["working_set_size"],
                 "proc": bool(surfaced_proc_id),
                 "proc_repeat": stats["procedure_repeat"],
-            })
+            }
+            if shadow:
+                for key in ("projected_injected", "suppressed", "serendipity_boosted"):
+                    record[key] = shadow.get(key)
+                    stats[key] = shadow.get(key)
+            _append_injection_log(session_id, record)
     except Exception:
         pass  # Measurement must never block the prompt
     return stats
@@ -957,6 +1000,8 @@ def _rrf_fusion(
     code_results: list[dict] | None = None,
     knowledge_results: list[dict] | None = None,
     k: int = 60,
+    suppress_ids: frozenset[str] = frozenset(),
+    shadow: dict | None = None,
 ) -> list[dict]:
     """Reciprocal Rank Fusion of FTS5, vector, wing-filtered, knowledge, and code results.
 
@@ -1024,12 +1069,10 @@ def _rrf_fusion(
     ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
 
     # Dynamic count: rank 0 always surfaces; rank 1-2 only if they meet
-    # a minimum RRF score threshold.  At k=60, single-source rank 0 scores
-    # ~0.016 so 0.015 filters code-index-only results (0.5x weight = 0.008)
-    # and very weak multi-source hits.  Tune upward to ~0.025 if rank 2-3
-    # results are still noisy in practice.
-    _MIN_RRF_SCORE_RANK2 = 0.015
-    _MAX_KB_SLOTS = 1  # Prevent KB from flooding out episodic context
+    # a minimum RRF score threshold (_MIN_RRF_SCORE_RANK2, module-level).  At
+    # k=60, single-source rank 0 scores ~0.016 so 0.015 filters code-index-only
+    # results (0.5x weight = 0.008) and very weak multi-source hits.  Tune
+    # upward to ~0.025 if rank 2-3 results are still noisy in practice.
     kb_count = 0
     results = []
     for i, (mid, score) in enumerate(ranked[:_MAX_RESULTS * 2]):  # scan extra to handle KB slot skips
@@ -1045,7 +1088,72 @@ def _rrf_fusion(
         results.append(entry)
         if len(results) >= _MAX_RESULTS:
             break
+
+    # H-1 PR2a (measurement-only): project what the novelty gate WOULD inject,
+    # without touching `results`. Skipped entirely when shadow is None (every
+    # existing caller), so the injected output is byte-identical.
+    if shadow is not None:
+        shadow.update(_shadow_gate(scores, content_map, suppress_ids))
+
     return results
+
+
+def _shadow_gate(
+    scores: dict[str, float],
+    content_map: dict[str, dict],
+    suppress_ids: frozenset[str],
+) -> dict:
+    """Project the PR2b novelty gate's injection set (H-1 PR2a, measurement-only).
+
+    Mirrors the real selection loop in ``_rrf_fusion`` but on COPIES: applies the
+    serendipity boost to never-surfaced episodic memories (``_retrieved_count==0``,
+    non-KB), then skips already-surfaced ``suppress_ids`` over a widened scan.
+    Never mutates its inputs — the real injection path above is untouched. PR2b
+    folds this logic into the real loop; here it only feeds measurement.
+
+    (Intentional near-duplicate of the loop above: keeping it separate is what
+    guarantees the measured path stays byte-identical during the shadow window.)
+    """
+    boosted = dict(scores)
+    serendipity_boosted = 0
+    for mid, entry in content_map.items():
+        if mid not in boosted:
+            continue
+        if (
+            entry.get("_retrieved_count", -1) == 0
+            and entry.get("collection") != "knowledge_base"
+        ):
+            boosted[mid] *= _SERENDIPITY_BOOST
+            serendipity_boosted += 1
+    ranked = sorted(boosted.items(), key=lambda x: x[1], reverse=True)
+
+    suppressed = 0
+    kb_count = 0
+    projected: list[str] = []
+    for i, (mid, score) in enumerate(ranked[:_MAX_RESULTS * 4]):
+        if mid not in content_map:
+            continue
+        if i > 0 and score < _MIN_RRF_SCORE_RANK2:
+            break
+        if mid in suppress_ids:
+            suppressed += 1
+            continue
+        entry = content_map[mid]
+        if entry.get("collection") == "knowledge_base":
+            kb_count += 1
+            if kb_count > _MAX_KB_SLOTS:
+                continue
+        if _is_garbage(entry.get("content", "")):
+            continue
+        projected.append(mid)
+        if len(projected) >= _MAX_RESULTS:
+            break
+    return {
+        "projected_ids": projected,
+        "projected_injected": len(projected),
+        "suppressed": suppressed,
+        "serendipity_boosted": serendipity_boosted,
+    }
 
 
 def _format_age(iso_str: str) -> str:
@@ -1280,12 +1388,17 @@ def _record_detail(
     working_set_size: int | None = None,
     zero_retrieved_injected: int = 0,
     procedure_repeat: bool = False,
+    projected_injected: int | None = None,
+    suppressed: int = 0,
+    serendipity_boosted: int = 0,
 ) -> None:
     """Atomic JSON write — latest invocation detail for health dashboard.
 
     The working-set fields (H-1 PR1) describe this prompt's injection vs
     the session's already-surfaced set; ``overlap_pct``/``working_set_size``
-    are None when no injection happened or no session ID was available.
+    are None when no injection happened or no session ID was available. The
+    shadow fields (H-1 PR2a) are the novelty-gate projection for this prompt —
+    ``projected_injected`` is None when no shadow ran.
     """
     data = {
         "timestamp": datetime.now(UTC).isoformat(),
@@ -1303,6 +1416,9 @@ def _record_detail(
         "working_set_size": working_set_size,
         "zero_retrieved_injected": zero_retrieved_injected,
         "procedure_repeat": procedure_repeat,
+        "projected_injected": projected_injected,
+        "suppressed": suppressed,
+        "serendipity_boosted": serendipity_boosted,
     }
     try:
         _METRICS_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -1577,12 +1693,19 @@ async def _run(prompt: str, session_id: str = "") -> None:
     # Fuse results (with wing boost, code index, and knowledge base)
     fused: list[dict] = []
     fused_count = 0
+    # H-1 PR2a: shadow-project the novelty gate. suppress_ids feeds the shadow
+    # projection ONLY — the real selection loop ignores it, so injected output
+    # is unchanged. _shadow accumulates the projection for the injection log.
+    _suppress_ids = _compute_suppress_ids(session_id)
+    _shadow: dict = {}
     if fts_results or vector_results or wing_results or code_results or knowledge_results:
         fused = _rrf_fusion(
             fts_results, vector_results,
             wing_results=wing_results,
             code_results=code_results or None,
             knowledge_results=knowledge_results or None,
+            suppress_ids=_suppress_ids,
+            shadow=_shadow,
         )
         fused = [r for r in fused if not _is_garbage(r.get("content", ""))]
         fused_count = len(fused)
@@ -1651,11 +1774,12 @@ async def _run(prompt: str, session_id: str = "") -> None:
     if fused:
         await _increment_retrieved(fused)
 
-    # ── Working-set measurement (H-1 PR1, record-only) ─────────────
-    # Overlap stats feed the PR2 novelty-gate decision. Runs after all
-    # stdout is flushed — never touches injection output. Placed inside
-    # the total_ms window so budget_exceeded watches its file I/O too.
-    ws_stats = _ws_measure(fused, session_id, _surfaced_proc_id, now_iso)
+    # ── Working-set measurement (H-1 PR1 record-only + PR2a shadow) ─
+    # Overlap stats + the shadow novelty-gate projection feed the PR2b
+    # enforcement decision. Runs after all stdout is flushed — never touches
+    # injection output. Inside the total_ms window so budget_exceeded watches
+    # its file I/O too.
+    ws_stats = _ws_measure(fused, session_id, _surfaced_proc_id, now_iso, shadow=_shadow)
 
     total_ms = (time.monotonic() - start) * 1000
 
@@ -1679,6 +1803,9 @@ async def _run(prompt: str, session_id: str = "") -> None:
         working_set_size=ws_stats["working_set_size"],
         zero_retrieved_injected=ws_stats["zero_retrieved_injected"],
         procedure_repeat=ws_stats["procedure_repeat"],
+        projected_injected=ws_stats.get("projected_injected"),
+        suppressed=ws_stats.get("suppressed", 0),
+        serendipity_boosted=ws_stats.get("serendipity_boosted", 0),
     )
 
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1106,13 +1106,16 @@ def _rrf_fusion(
     if shadow is not None:
         # Shadow projection must never affect the real injection path.
         with contextlib.suppress(Exception):
-            # Vector rows carry the true _retrieved_count; content_map may hold
-            # the FTS duplicate (which lacks it), so pass an authoritative map.
-            rc_map = {
-                r["memory_id"]: r["_retrieved_count"]
-                for r in vector_results
-                if r.get("memory_id") and "_retrieved_count" in r
-            }
+            # content_map may hold a duplicate's FTS row (no _retrieved_count).
+            # Build an authoritative count map from EVERY Qdrant-backed source
+            # that carries the payload (vector + wing-filtered + KB + code), so a
+            # never-surfaced hit is recognized regardless of which search found it.
+            rc_map: dict[str, int] = {}
+            for _src in (vector_results, wing_results, knowledge_results, code_results):
+                for r in _src or []:
+                    mid = r.get("memory_id")
+                    if mid and "_retrieved_count" in r:
+                        rc_map[mid] = r["_retrieved_count"]
             shadow.update(_shadow_gate(scores, content_map, suppress_ids, rc_map))
 
     return results

--- a/tests/test_hooks/test_shadow_gate.py
+++ b/tests/test_hooks/test_shadow_gate.py
@@ -114,6 +114,21 @@ class TestShadowGateSerendipity:
             _mod._rrf_fusion(fts, vector, shadow=shadow)
         assert shadow["serendipity_boosted"] >= 1
 
+    def test_serendipity_uses_wing_retrieved_count(self) -> None:
+        # m1 found by FTS + the wing-filtered Qdrant search (retrieved_count=0) but
+        # NOT the unfiltered vector top-N. The authoritative count map must include
+        # wing rows too, else wing-scoped prompts lose the serendipity signal (Codex P2).
+        fts = [
+            {"memory_id": "m1", "content": "alpha", "collection": "episodic"},
+            {"memory_id": "m2", "content": "beta", "collection": "episodic"},
+        ]
+        wing = [{"memory_id": "m1", "content": "alpha", "collection": "episodic",
+                 "_retrieved_count": 0}]
+        shadow: dict = {}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            _mod._rrf_fusion(fts, [], wing_results=wing, shadow=shadow)
+        assert shadow["serendipity_boosted"] >= 1
+
     def test_unknown_retrieved_count_not_boosted(self) -> None:
         scores = {"a": 0.020, "b": 0.016}
         cmap = {"a": _cm("a", retrieved=5), "b": _cm("b", retrieved=-1)}  # FTS-only, unknown

--- a/tests/test_hooks/test_shadow_gate.py
+++ b/tests/test_hooks/test_shadow_gate.py
@@ -166,6 +166,46 @@ class TestOutputInvariance:
         assert ids.count("k1") <= 1  # single KB slot honored
 
 
+class TestShadowFailOpen:
+    """A shadow-projection failure must NEVER suppress the real injection."""
+
+    def test_shadow_exception_does_not_break_real_results(self) -> None:
+        fts = [
+            {"memory_id": "m1", "content": "alpha", "collection": "episodic"},
+            {"memory_id": "m2", "content": "beta", "collection": "episodic"},
+        ]
+        vector = [{"memory_id": "m1", "content": "alpha", "collection": "episodic",
+                   "_retrieved_count": 3}]
+        base = _mod._rrf_fusion(fts, vector, shadow=None)
+        # _shadow_gate calls _is_garbage; make it explode.
+        def boom(_c):
+            raise RuntimeError("shadow blew up")
+        with patch.object(_mod, "_is_garbage", boom):
+            got = _mod._rrf_fusion(fts, vector, suppress_ids=frozenset(), shadow={})
+        assert [r["memory_id"] for r in got] == [r["memory_id"] for r in base]
+
+    def test_shadow_garbage_matches_real_no_backfill(self) -> None:
+        # A garbage item in the real top-3 → real path drops it with NO backfill
+        # (injected count falls below 3). The shadow must do the same, so the
+        # projected delta is attributable only to suppression/boost.
+        scores = {"g": 0.030, "b": 0.020, "c": 0.018, "d": 0.017}
+        cmap = {"g": _cm("g", content="JUNK"), "b": _cm("b"), "c": _cm("c"), "d": _cm("d")}
+        with patch.object(_mod, "_is_garbage", lambda x: x == "JUNK"):
+            out = _mod._shadow_gate(scores, cmap, frozenset())
+        assert out["projected_ids"] == ["b", "c"]  # g dropped, NO backfill of d
+        assert "d" not in out["projected_ids"]
+        assert out["projected_injected"] == 2
+
+
+class TestIsGarbageNoneSafe:
+    def test_none_content_is_filtered_not_crash(self) -> None:
+        assert _mod._is_garbage(None) is True  # was AttributeError
+
+    def test_empty_string_behavior_preserved(self) -> None:
+        assert _mod._is_garbage("") is False
+        assert _mod._is_garbage("a normal memory") is False
+
+
 class TestComputeSuppressIds:
     def test_returns_working_set_entry_ids(self, tmp_path: Path) -> None:
         sid = "sess-a"

--- a/tests/test_hooks/test_shadow_gate.py
+++ b/tests/test_hooks/test_shadow_gate.py
@@ -1,0 +1,228 @@
+"""Tests for the H-1 PR2a shadow novelty-gate projection (measurement-only).
+
+PR2a simulates what the PR2b novelty gate (suppress already-surfaced IDs +
+serendipity-boost never-surfaced memories) WOULD inject, and logs actual-vs-
+projected per prompt — while the real injection output stays byte-identical.
+
+The critical property is output-neutrality: ``_rrf_fusion(..., shadow={})`` must
+return exactly what ``shadow=None`` returns. These tests also characterize the
+(previously untested) real selection loop so PR2b's enforcement can't drift it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# The hook lives in scripts/, not a package — load it manually (mirrors
+# test_working_set.py). Unique module name to avoid sys.modules clashes.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+_HOOK_PATH = _SCRIPTS_DIR / "proactive_memory_hook.py"
+_spec = importlib.util.spec_from_file_location("proactive_memory_hook_shadow", _HOOK_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["proactive_memory_hook_shadow"] = _mod
+_spec.loader.exec_module(_mod)
+
+_NOW = "2026-07-09T12:00:00+00:00"
+
+
+def _cm(mid: str, *, score_src="episodic", retrieved=5, content="real memory content") -> dict:
+    """A content_map entry."""
+    return {
+        "memory_id": mid,
+        "content": content,
+        "collection": score_src,
+        "_retrieved_count": retrieved,
+    }
+
+
+class TestShadowGateSuppression:
+    def test_suppresses_repeat_and_promotes_novel(self) -> None:
+        scores = {"a": 0.030, "b": 0.020, "c": 0.018, "d": 0.017}
+        cmap = {m: _cm(m) for m in scores}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset({"a"}))
+        # 'a' suppressed → the below-top novel 'd' is promoted into the freed slot
+        assert out["projected_ids"] == ["b", "c", "d"]
+        assert "a" not in out["projected_ids"]
+        assert out["suppressed"] == 1
+        assert out["serendipity_boosted"] == 0
+
+    def test_all_repeat_no_novel_projects_empty(self) -> None:
+        scores = {"a": 0.030, "b": 0.020}
+        cmap = {m: _cm(m) for m in scores}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset({"a", "b"}))
+        assert out["projected_ids"] == []
+        assert out["projected_injected"] == 0
+        assert out["suppressed"] == 2
+
+    def test_all_top_repeat_but_novel_below_is_found(self) -> None:
+        scores = {"a": 0.030, "b": 0.020, "c": 0.018}
+        cmap = {m: _cm(m) for m in scores}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset({"a", "b"}))
+        assert out["projected_ids"] == ["c"]
+        assert out["suppressed"] == 2
+
+    def test_widened_scan_reaches_novel_beyond_real_bound(self) -> None:
+        # 6 suppressed above-floor candidates (fill the real _MAX_RESULTS*2 scan),
+        # then 3 novel ones only a *4 scan reaches.
+        supp = {f"s{i}": 0.030 - i * 0.001 for i in range(6)}
+        novel = {"g": 0.024, "h": 0.023, "i": 0.022}
+        scores = {**supp, **novel}
+        cmap = {m: _cm(m) for m in scores}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset(supp))
+        assert out["projected_ids"] == ["g", "h", "i"]
+        assert out["suppressed"] == 6
+
+
+class TestShadowGateSerendipity:
+    def test_zero_retrieved_episodic_is_boosted_and_reorders(self) -> None:
+        scores = {"a": 0.020, "b": 0.016}
+        cmap = {"a": _cm("a", retrieved=5), "b": _cm("b", retrieved=0)}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset())
+        # b (0.016*1.3=0.0208) now outranks a (0.020)
+        assert out["projected_ids"][0] == "b"
+        assert out["serendipity_boosted"] == 1
+
+    def test_knowledge_base_zero_retrieved_not_boosted(self) -> None:
+        scores = {"a": 0.020, "b": 0.016}
+        cmap = {"a": _cm("a", retrieved=5), "b": _cm("b", score_src="knowledge_base", retrieved=0)}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset())
+        assert out["serendipity_boosted"] == 0
+        assert out["projected_ids"][0] == "a"  # order unchanged
+
+    def test_unknown_retrieved_count_not_boosted(self) -> None:
+        scores = {"a": 0.020, "b": 0.016}
+        cmap = {"a": _cm("a", retrieved=5), "b": _cm("b", retrieved=-1)}  # FTS-only, unknown
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset())
+        assert out["serendipity_boosted"] == 0
+        assert out["projected_ids"][0] == "a"
+
+    def test_boost_promotes_near_floor_but_not_far_below(self) -> None:
+        floor = _mod._MIN_RRF_SCORE_RANK2  # 0.015
+        near = floor / 1.3 + 0.0005   # boosted crosses floor
+        far = 0.004                   # boosted (×1.3) still far below floor
+        scores = {"a": 0.030, "near": near, "far": far}
+        cmap = {
+            "a": _cm("a", retrieved=5),
+            "near": _cm("near", retrieved=0),
+            "far": _cm("far", retrieved=0),
+        }
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            out = _mod._shadow_gate(scores, cmap, frozenset())
+        assert "near" in out["projected_ids"]
+        assert "far" not in out["projected_ids"]
+
+
+class TestOutputInvariance:
+    """The real _rrf_fusion return must be identical with shadow on or off."""
+
+    def _inputs(self):
+        # Two FTS + one vector hit that also appears in FTS (score stacks),
+        # plus a KB hit — exercises floor + the single-KB-slot rule.
+        fts = [
+            {"memory_id": "m1", "content": "alpha", "collection": "episodic"},
+            {"memory_id": "m2", "content": "beta", "collection": "episodic"},
+        ]
+        vector = [
+            {"memory_id": "m1", "content": "alpha", "collection": "episodic",
+             "_retrieved_count": 3},
+        ]
+        knowledge = [
+            {"memory_id": "k1", "content": "kb-fact", "collection": "knowledge_base",
+             "confidence": 0.95, "_retrieved_count": 0},
+        ]
+        return fts, vector, knowledge
+
+    def test_shadow_does_not_change_returned_results(self) -> None:
+        fts, vector, knowledge = self._inputs()
+        base = _mod._rrf_fusion(fts, vector, knowledge_results=knowledge, shadow=None)
+        shadow: dict = {}
+        withshadow = _mod._rrf_fusion(
+            fts, vector, knowledge_results=knowledge,
+            suppress_ids=frozenset({"m1"}), shadow=shadow,
+        )
+        assert [r["memory_id"] for r in withshadow] == [r["memory_id"] for r in base]
+        assert withshadow == base  # full dict equality — nothing mutated
+        # shadow populated (m1 suppressed → projection differs from actual)
+        assert "projected_ids" in shadow
+        assert "m1" not in shadow["projected_ids"]
+
+    def test_real_selection_characterization(self) -> None:
+        # Pin the real top-N so PR2b enforcement can't silently change it.
+        fts, vector, knowledge = self._inputs()
+        base = _mod._rrf_fusion(fts, vector, knowledge_results=knowledge, shadow=None)
+        ids = [r["memory_id"] for r in base]
+        assert ids[0] == "m1"  # stacked FTS+vector score wins
+        assert "m2" in ids
+        assert ids.count("k1") <= 1  # single KB slot honored
+
+
+class TestComputeSuppressIds:
+    def test_returns_working_set_entry_ids(self, tmp_path: Path) -> None:
+        sid = "sess-a"
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            ws = _mod._load_working_set(sid)
+            _mod._ws_record(ws, [("m1", "memory"), ("m2", "memory")], None, _NOW)
+            _mod._save_working_set(sid, ws)
+            with patch.object(_mod, "_WS_GATE_DISABLED_FLAG", tmp_path / "nope"):
+                supp = _mod._compute_suppress_ids(sid)
+        assert supp == frozenset({"m1", "m2"})
+
+    def test_kill_switch_flag_disables_suppression(self, tmp_path: Path) -> None:
+        sid = "sess-b"
+        flag = tmp_path / "ws_gate_disabled"
+        flag.write_text("")
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            ws = _mod._load_working_set(sid)
+            _mod._ws_record(ws, [("m1", "memory")], None, _NOW)
+            _mod._save_working_set(sid, ws)
+            with patch.object(_mod, "_WS_GATE_DISABLED_FLAG", flag):
+                supp = _mod._compute_suppress_ids(sid)
+        assert supp == frozenset()
+
+    def test_no_session_id_returns_empty(self, tmp_path: Path) -> None:
+        with patch.object(_mod, "_WS_GATE_DISABLED_FLAG", tmp_path / "nope"):
+            assert _mod._compute_suppress_ids("") == frozenset()
+
+
+class TestWsMeasureShadowFields:
+    def test_shadow_fields_merged_into_log_and_stats(self, tmp_path: Path) -> None:
+        import json
+
+        fused = [{"memory_id": "m1", "collection": "episodic"}]
+        shadow = {
+            "projected_ids": ["m9"],
+            "projected_injected": 1,
+            "suppressed": 1,
+            "serendipity_boosted": 0,
+        }
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            stats = _mod._ws_measure(fused, "s1", None, _NOW, shadow=shadow)
+            log = (tmp_path / "s1" / _mod._WS_LOG_FILENAME).read_text().strip().splitlines()
+        rec = json.loads(log[-1])
+        assert rec["projected_injected"] == 1
+        assert rec["suppressed"] == 1
+        assert rec["serendipity_boosted"] == 0
+        assert stats["projected_injected"] == 1
+        assert stats["suppressed"] == 1
+
+    def test_shadow_none_keeps_pr1_behavior(self, tmp_path: Path) -> None:
+        import json
+
+        fused = [{"memory_id": "m1", "collection": "episodic"}]
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path):
+            stats = _mod._ws_measure(fused, "s1", None, _NOW)  # no shadow arg
+            log = (tmp_path / "s1" / _mod._WS_LOG_FILENAME).read_text().strip().splitlines()
+        rec = json.loads(log[-1])
+        assert "projected_injected" not in rec  # PR1 log schema untouched
+        assert "injected" in rec
+        assert stats.get("projected_injected") is None or "projected_injected" not in stats

--- a/tests/test_hooks/test_shadow_gate.py
+++ b/tests/test_hooks/test_shadow_gate.py
@@ -98,6 +98,22 @@ class TestShadowGateSerendipity:
         assert out["serendipity_boosted"] == 0
         assert out["projected_ids"][0] == "a"  # order unchanged
 
+    def test_duplicate_hit_uses_vector_retrieved_count(self) -> None:
+        # m1 is returned by BOTH FTS and vector; _rrf_fusion keeps the FTS row
+        # (no _retrieved_count) in content_map. The shadow must still see the
+        # vector payload's retrieved_count==0 and count it as serendipity-eligible
+        # (Codex P2 — otherwise duplicate strong hits are never boosted).
+        fts = [
+            {"memory_id": "m1", "content": "alpha", "collection": "episodic"},
+            {"memory_id": "m2", "content": "beta", "collection": "episodic"},
+        ]
+        vector = [{"memory_id": "m1", "content": "alpha", "collection": "episodic",
+                   "_retrieved_count": 0}]
+        shadow: dict = {}
+        with patch.object(_mod, "_is_garbage", lambda c: False):
+            _mod._rrf_fusion(fts, vector, shadow=shadow)
+        assert shadow["serendipity_boosted"] >= 1
+
     def test_unknown_retrieved_count_not_boosted(self) -> None:
         scores = {"a": 0.020, "b": 0.016}
         cmap = {"a": _cm("a", retrieved=5), "b": _cm("b", retrieved=-1)}  # FTS-only, unknown


### PR DESCRIPTION
## What

H-1 PR2a — **measurement-only**. Simulates what a future novelty gate *would* inject (suppress memory IDs the session has already been shown + serendipity-boost never-surfaced ones) and logs actual-vs-projected per prompt. **Injected output is byte-identical to today** — this ships no behavior change, only the data needed to decide whether to enforce the gate.

Prior PR measured that ~26% of proactively-injected memories are re-injections of something the session already saw. This PR answers the follow-on question the logs can't: on the prompts where *every* top hit is a repeat, would the gate surface useful deeper context, or go empty? Two days of this shadow data drives that go/no-go.

## How

- New `_shadow_gate()` projects the gate on **copies** of the RRF scores; `_rrf_fusion` gains two defaulted params (`suppress_ids`, `shadow`) and calls the projection **fail-open** (`contextlib.suppress`) — skipped entirely when `shadow is None`, so every existing caller is unchanged.
- The projection mirrors the real selection loop exactly (floor, single-KB-slot, select-then-drop-garbage with **no backfill**) so the projected-vs-actual delta is attributable only to suppression/boost.
- `_compute_suppress_ids()` reads the working set with a kill-switch flag (`~/.genesis/ws_gate_disabled`).
- Projection fields flow into `injection_log.jsonl` + the proactive-metrics snapshot.
- Hardened a pre-existing `_is_garbage(None)` crash on nullable FTS content.

## Testing

- 20 unit tests incl. an **output-invariance** check (`shadow={}` returns identical results to `shadow=None`) and a **fail-open** check (a projection exception never suppresses real output).
- 531 hook/trail/snapshot regression tests green; ruff clean.
- **E2E on the live hook** (verified before and after review fixes): real injected set byte-stable; shadow logged; an all-repeat prompt projects 3 novel replacements (`suppressed=3, projected_injected=3`).

## Notes

- **No CHANGELOG entry** — measurement-only, zero user-visible effect (per the "no internal changes in CHANGELOG" convention).
- Follow-on **PR2b** flips enforcement on, tuned by this window's data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
