### PR TITLE
fix(qdrant): payload indexes for filtered search recall

### DIFF
--- a/scripts/apply_qdrant_payload_indexes.py
+++ b/scripts/apply_qdrant_payload_indexes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""One-off: create payload indexes on the live Qdrant collections.
+
+The server creates them at next init via ensure_collections(); this
+script applies them immediately (online, non-destructive — Qdrant
+builds payload indexes without blocking reads/writes) and prints the
+resulting payload schema per collection.
+
+Usage:
+    python scripts/apply_qdrant_payload_indexes.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def main() -> None:
+    from genesis.qdrant.collections import (
+        COLLECTIONS,
+        ensure_payload_indexes,
+        get_client,
+    )
+
+    client = get_client()
+    ensure_payload_indexes(client)
+    for name in COLLECTIONS:
+        info = client.get_collection(name)
+        schema = {
+            field: str(meta.data_type)
+            for field, meta in (info.payload_schema or {}).items()
+        }
+        print(f"{name}: {json.dumps(schema, indent=2, sort_keys=True)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -31,8 +31,29 @@ def get_client(url: str | None = None) -> QdrantClient:
     return QdrantClient(url=url)
 
 
+# Payload fields used in search filters. Without payload indexes,
+# filtered HNSW search measurably DROPS valid results (verified
+# 2026-07-09: exact-vs-approx same-query comparisons on episodic_memory
+# at ~49K points returned different result sets) — and every production
+# search is filtered (the unconditional `deprecated` must_not). Indexed
+# fields make filtered HNSW use the filterable index instead of
+# guessing.
+INDEXED_PAYLOAD_FIELDS: dict[str, str] = {
+    "deprecated": "bool",
+    "tags": "keyword",
+    "wing": "keyword",
+    "room": "keyword",
+    "life_domain": "keyword",
+    "project_type": "keyword",
+    "source_subsystem": "keyword",
+    "source_type": "keyword",
+    "source_pipeline": "keyword",
+    "memory_class": "keyword",
+}
+
+
 def ensure_collections(client: QdrantClient) -> None:
-    """Create all Genesis collections if they don't exist."""
+    """Create all Genesis collections and their payload indexes."""
     existing = {c.name for c in client.get_collections().collections}
     for name in COLLECTIONS:
         if name not in existing:
@@ -40,6 +61,35 @@ def ensure_collections(client: QdrantClient) -> None:
                 collection_name=name,
                 vectors_config=VectorParams(size=VECTOR_DIM, distance=Distance.COSINE),
             )
+    ensure_payload_indexes(client)
+
+
+def ensure_payload_indexes(client: QdrantClient) -> None:
+    """Idempotently create payload indexes on all Genesis collections.
+
+    Runs at server init (via ensure_collections). Creating an index that
+    already exists is a no-op server-side; each field is still wrapped
+    so one failure can't block init or the remaining fields.
+    """
+    from qdrant_client.models import PayloadSchemaType
+
+    schema_types = {
+        "bool": PayloadSchemaType.BOOL,
+        "keyword": PayloadSchemaType.KEYWORD,
+    }
+    for collection in COLLECTIONS:
+        for field, kind in INDEXED_PAYLOAD_FIELDS.items():
+            try:
+                client.create_payload_index(
+                    collection_name=collection,
+                    field_name=field,
+                    field_schema=schema_types[kind],
+                )
+            except Exception:
+                logger.warning(
+                    "payload index %s.%s not created", collection, field,
+                    exc_info=True,
+                )
 
 
 def upsert_point(

--- a/tests/test_qdrant/test_collections.py
+++ b/tests/test_qdrant/test_collections.py
@@ -198,3 +198,57 @@ def test_ensure_collections(qdrant):
     assert "knowledge_base" in existing
     # NOTE: Do NOT delete production collections here. ensure_collections is
     # idempotent — leaving them is safe. Deleting them nukes production data.
+
+
+class TestPayloadIndexes:
+    """ensure_payload_indexes: coverage + idempotency (mock client —
+    creation against the real instance is the apply script's job)."""
+
+    def test_creates_every_field_on_every_collection(self):
+        from unittest.mock import MagicMock
+
+        from genesis.qdrant.collections import (
+            COLLECTIONS,
+            INDEXED_PAYLOAD_FIELDS,
+            ensure_payload_indexes,
+        )
+
+        client = MagicMock()
+        ensure_payload_indexes(client)
+        calls = client.create_payload_index.call_args_list
+        assert len(calls) == len(COLLECTIONS) * len(INDEXED_PAYLOAD_FIELDS)
+        seen = {
+            (c.kwargs["collection_name"], c.kwargs["field_name"]) for c in calls
+        }
+        for coll in COLLECTIONS:
+            for field in INDEXED_PAYLOAD_FIELDS:
+                assert (coll, field) in seen
+
+    def test_one_failure_does_not_block_the_rest(self):
+        from unittest.mock import MagicMock
+
+        from genesis.qdrant.collections import (
+            COLLECTIONS,
+            INDEXED_PAYLOAD_FIELDS,
+            ensure_payload_indexes,
+        )
+
+        client = MagicMock()
+        client.create_payload_index.side_effect = [RuntimeError("boom")] + [
+            None
+        ] * (len(COLLECTIONS) * len(INDEXED_PAYLOAD_FIELDS) - 1)
+        ensure_payload_indexes(client)  # must not raise
+        assert client.create_payload_index.call_count == (
+            len(COLLECTIONS) * len(INDEXED_PAYLOAD_FIELDS)
+        )
+
+    def test_ensure_collections_wires_indexes(self):
+        from unittest.mock import MagicMock, patch
+
+        from genesis.qdrant import collections as mod
+
+        client = MagicMock()
+        client.get_collections.return_value.collections = []
+        with patch.object(mod, "ensure_payload_indexes") as epi:
+            mod.ensure_collections(client)
+        epi.assert_called_once_with(client)


### PR DESCRIPTION
## Problem (found 2026-07-09, during WS-C ambient-layer E2E)

\`episodic_memory\` (48.7K points) has **zero payload indexes**, and every production vector search is filtered — at minimum the unconditional \`deprecated\` must_not. Filtered HNSW without payload indexes measurably **drops valid results**: exact-vs-approximate comparisons of the same query+filter returned different result sets (an internally inconsistent store — a point scoring 0.734 was absent from a filtered top-100 whose floor was far below that). Production recall quality has been silently degraded across the board.

## Fix

- \`ensure_payload_indexes()\`: idempotent bool/keyword index creation for every filter-used payload field (\`deprecated\`, \`tags\`, \`wing\`, \`room\`, \`life_domain\`, \`project_type\`, \`source_subsystem\`, \`source_type\`, \`source_pipeline\`, \`memory_class\`) on both collections, wired into \`ensure_collections()\` so server init keeps them in place. Per-field try/except: one failure can't block init.
- \`scripts/apply_qdrant_payload_indexes.py\`: one-off online apply (non-destructive; Qdrant builds payload indexes without blocking reads/writes) + resulting schema report — for applying without waiting for a server restart.

## Verification

- 3 new tests: full field×collection coverage, one-failure-doesn't-block, ensure_collections wiring. 13/13 in the file.
- The apply step runs only on explicit approval; before/after recall comparison on the same probe queries will be posted after applying.