### PR TITLE
feat(memory): ambient worker + 3-lane ranking + spawn + slots (WS-C PR2)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -352,13 +352,20 @@ verified: 8dac642c 2026-07-09
   **Firewall: transcript text is never persisted** — only refs + derived
   features reach `attention_events`. Config is versioned DATA
   (`~/.genesis/config/attention_config.json`).
-- **session_awareness/**: WS-C ambient session-theme layer — SHADOW,
-  record-only (PR1). The proactive memory hook folds each genuine user
-  prompt's embedding into a per-session EMA + entity ledger and records
-  drift-trigger fires in `~/.genesis/sessions/<id>/session_theme.json`;
-  the detached retrieval worker/arbiter lanes (PR2+) act on fires. Pure
-  functions, no clocks (callers pass time), zero DB writes, fail-open at
-  the hook boundary. Kill switch: `GENESIS_SESSION_AWARENESS_DISABLED=1`.
+- **session_awareness/**: WS-C ambient session-theme layer — SHADOW.
+  The proactive memory hook folds each genuine user prompt's embedding
+  into a per-session EMA + entity ledger
+  (`~/.genesis/sessions/<id>/session_theme.json`); on a drift-trigger
+  fire it spawns the detached worker (2-slot flock semaphore), which
+  retrieves+ranks candidates over three lanes — vector, decisions
+  (`tags~decision`, the OMI-incident class), entity-keyword drift — all
+  Qdrant lanes EXACT search (filtered HNSW without payload indexes
+  drops valid results; found 2026-07-09). Verdicts →
+  `ambient_verdict.json`, tuning → size-capped shadow log. **Zero
+  DB/Qdrant writes — never bumps retrieved_count** (protects
+  MEM-005/H-1 baselines). Fail-open at the hook boundary. Kill switch:
+  `GENESIS_SESSION_AWARENESS_DISABLED=1`. Arbiter (PR3) + replay gate
+  (PR4) pending.
 
 ## 10. Learning & evaluation
 

--- a/scripts/ambient_awareness_worker.py
+++ b/scripts/ambient_awareness_worker.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Entry point for the detached ambient worker (WS-C PR2).
+
+Spawned by the proactive memory hook on a drift-trigger fire:
+
+    python scripts/ambient_awareness_worker.py --session-id <id> --no-arbiter
+
+Exit code is always 0 unless argument parsing fails — outcomes
+(including errors) are recorded in the session's ambient_verdict.json
+and the shadow log, because nothing is attached to read a detached
+process's exit status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument(
+        "--no-arbiter",
+        action="store_true",
+        help="Skip the arbiter stage (PR2 shadow mode; arbiter lands in PR3)",
+    )
+    args = parser.parse_args()
+
+    from genesis.session_awareness.worker import run_worker
+
+    asyncio.run(run_worker(args.session_id, no_arbiter=args.no_arbiter))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -20,10 +20,12 @@ Reads hook input from stdin as JSON:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import importlib
 import json
 import os
 import sqlite3
+import subprocess
 import sys
 import tempfile
 import time
@@ -1681,13 +1683,13 @@ async def _run(prompt: str, session_id: str = "") -> None:
         procedure_repeat=ws_stats["procedure_repeat"],
     )
 
-    # ── Ambient session-awareness fold (WS-C PR1, record-only) ─────
+    # ── Ambient session-awareness fold (WS-C) ──────────────────────
     # Folds the prompt embedding (already computed above) into a
-    # session-theme EMA and records drift-trigger fires in the
-    # session's session_theme.json. No spawn (PR2), no output. Runs
-    # after all stdout AND all existing metrics so it can never affect
-    # either; placed outside the total_ms window on purpose — new work
-    # must not skew the H-1 latency baselines.
+    # session-theme EMA; on a drift-trigger fire, spawns the detached
+    # ambient worker (shadow mode: retrieve+rank only, no injection).
+    # No output. Runs after all stdout AND all existing metrics so it
+    # can never affect either; placed outside the total_ms window on
+    # purpose — new work must not skew the H-1 latency baselines.
     _ambient_fold(vector, session_id, prompt, recent_files)
 
 
@@ -1724,15 +1726,50 @@ def _ambient_fold(
             return
         from genesis.session_awareness import hook_fold
 
-        hook_fold(
+        result = hook_fold(
             session_id=session_id,
             vector=vector,
             prompt_keywords=_extract_keywords(prompt),
             file_keywords=_keywords_from_files(recent_files) if recent_files else [],
             pivoted=_turn_pivoted(session_id),
         )
+        if result and result.get("fired"):
+            _spawn_ambient_worker(session_id)
     except Exception:
         pass  # Ambient layer must never affect the hook
+
+
+def _spawn_ambient_worker(session_id: str) -> None:
+    """Detached worker spawn (WS-C PR2) — the genesis_session_end idiom.
+
+    start_new_session=True: the worker outlives this hook process.
+    stdout is discarded; stderr goes to a shared error log (the worker
+    records outcomes in ambient_verdict.json / shadow_log.jsonl, so
+    stderr only matters for crashes-before-logging). --no-arbiter until
+    PR3 lands the judgment stage.
+    """
+    try:
+        script = Path(__file__).resolve().parent / "ambient_awareness_worker.py"
+        err_dir = Path.home() / ".genesis" / "session_awareness"
+        err_dir.mkdir(parents=True, exist_ok=True)
+        with (
+            (err_dir / "worker_err.log").open("ab") as log_fh,
+            contextlib.suppress(OSError),
+        ):
+            subprocess.Popen(
+                    [
+                        sys.executable,
+                        str(script),
+                        "--session-id",
+                        session_id,
+                        "--no-arbiter",
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=log_fh,
+                    start_new_session=True,
+                )
+    except Exception:
+        pass  # Spawn failure must never affect the hook
 
 
 def main() -> None:

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -86,6 +86,8 @@ def search(
     exclude_subsystems: list[str] | None = None,
     include_only_subsystems: list[str] | None = None,
     include_deprecated: bool = False,
+    tags_any: list[str] | None = None,
+    exact: bool = False,
 ) -> list[dict]:
     """Search by vector similarity with optional payload filters.
 
@@ -93,6 +95,12 @@ def search(
     the ``source_subsystem`` payload key. Excludes use ``must_not`` —
     points missing the key (legacy data without the tag) are preserved.
     Includes use ``must`` — only points whose key matches are returned.
+
+    ``tags_any`` matches points whose ``tags`` array contains any of the
+    given values. ``exact=True`` forces brute-force scoring instead of
+    HNSW — use for offline/latency-tolerant lanes: filtered HNSW without
+    payload indexes measurably drops valid results (found 2026-07-09;
+    ~90-220ms exact at ~49K points).
     """
     from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
 
@@ -142,15 +150,25 @@ def search(
                 match=MatchAny(any=list(exclude_subsystems)),
             )
         )
+    if tags_any:
+        conditions.append(
+            FieldCondition(key="tags", match=MatchAny(any=list(tags_any)))
+        )
     query_filter = Filter(
         must=conditions or None,
         must_not=must_not_conditions or None,
     )
+    search_params = None
+    if exact:
+        from qdrant_client.models import SearchParams
+
+        search_params = SearchParams(exact=True)
     results = client.query_points(
         collection_name=collection,
         query=query_vector,
         limit=limit,
         query_filter=query_filter,
+        search_params=search_params,
     )
     return [
         {"id": str(hit.id), "score": hit.score, "payload": hit.payload}

--- a/src/genesis/session_awareness/ranking.py
+++ b/src/genesis/session_awareness/ranking.py
@@ -1,0 +1,197 @@
+"""Candidate retrieval + ranking for the ambient worker.
+
+Three lanes, unioned (all Qdrant lanes use **exact search** — this is
+an offline worker, and filtered HNSW without payload indexes measurably
+drops valid results; found 2026-07-09 hunting the OMI kill-criterion
+memory):
+
+- **Vector lane** — the theme EMA straight into Qdrant
+  (``qdrant_ops.search``; deprecated points filtered by default).
+- **Decisions lane** — the EMA against ``tags~decision`` memories only.
+  This is the OMI-incident class: decisions/facts drown under walls of
+  near-duplicate operational memories on the same topic (measured: the
+  repo-split fact sat past rank 200 unfiltered, rank 12 in this lane).
+- **Drift lane** — the entity ledger's top keywords as a query string
+  through ``drift_recall`` (it has no vector entry point; it re-embeds
+  internally and only READS retrieval bookkeeping).
+
+Bitemporal parity with the main retrieval path via
+``_expired_candidate_ids``. Rank mirrors the graph-boost shape from
+``HybridRetriever._apply_graph_boost``:
+
+    (1 + 0.05·log1p(inbound_links)) × confidence × CLASS_WEIGHT × cosine
+
+The final candidate set is stratified: top-N overall by score, but at
+least ``DECISION_RESERVED`` decision-lane candidates are always included
+when available — otherwise the operational wall crowds out exactly the
+memories this layer exists to surface.
+
+**This lane writes NOTHING** — no retrieved_count bump, ever, even after
+a live flip. Retrieval baselines (MEM-005 / H-1) must stay clean.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from .accumulator import cosine
+
+if TYPE_CHECKING:
+    import aiosqlite
+    from qdrant_client import QdrantClient
+
+    from genesis.memory.embeddings import EmbeddingProvider
+
+VECTOR_LANE_LIMIT = 24
+DECISION_LANE_LIMIT = 15
+DRIFT_LANE_LIMIT = 10
+TOP_N = 8
+DECISION_RESERVED = 2  # decision-lane floor in the final candidate set
+BACKLINK_COEF = 0.05  # mirrors retrieval._BACKLINK_BOOST_COEF
+DEFAULT_CONFIDENCE = 0.5
+PREVIEW_CHARS = 200
+
+
+def _preview(content: str) -> str:
+    return content[:PREVIEW_CHARS]
+
+
+async def rank_candidates(
+    *,
+    ema: list[float],
+    entity_query: str,
+    db: aiosqlite.Connection,
+    qdrant_client: QdrantClient,
+    embedding_provider: EmbeddingProvider,
+    top_n: int = TOP_N,
+) -> list[dict]:
+    """Gather both lanes, filter expired, rank, return the top *top_n*.
+
+    Each candidate: memory_id, score, cosine, confidence, memory_class,
+    inbound_links, lanes, preview.
+    """
+    from genesis.db.crud.memory_links import batch_link_counts
+    from genesis.memory.classification import CLASS_WEIGHTS
+    from genesis.memory.drift import drift_recall
+    from genesis.memory.retrieval import _expired_candidate_ids
+    from genesis.qdrant import collections as qdrant_ops
+
+    # ── Vector + decisions lanes (both exact) ────────────────────────
+    by_id: dict[str, dict] = {}
+    for lane, limit, tags in (
+        ("vector", VECTOR_LANE_LIMIT, None),
+        ("decision", DECISION_LANE_LIMIT, ["decision"]),
+    ):
+        for hit in qdrant_ops.search(
+            qdrant_client,
+            collection="episodic_memory",
+            query_vector=ema,
+            limit=limit,
+            tags_any=tags,
+            exact=True,
+        ):
+            mid = str(hit["id"])
+            if mid in by_id:
+                by_id[mid]["lanes"].append(lane)
+                continue
+            payload = hit.get("payload") or {}
+            by_id[mid] = {
+                "memory_id": mid,
+                "cosine": float(hit.get("score", 0.0)),  # cosine metric: score IS cos
+                "confidence": payload.get("confidence"),
+                "memory_class": payload.get("memory_class"),
+                "preview": _preview(payload.get("content", "")),
+                "lanes": [lane],
+            }
+
+    # ── Drift lane ───────────────────────────────────────────────────
+    if entity_query.strip():
+        for r in await drift_recall(
+            entity_query,
+            db=db,
+            qdrant_client=qdrant_client,
+            embedding_provider=embedding_provider,
+            source="episodic",
+            limit=DRIFT_LANE_LIMIT,
+        ):
+            if r.memory_id in by_id:
+                by_id[r.memory_id]["lanes"].append("drift")
+                continue
+            payload = r.payload or {}
+            by_id[r.memory_id] = {
+                "memory_id": r.memory_id,
+                "cosine": None,  # backfilled below from the stored vector
+                "confidence": payload.get("confidence"),
+                "memory_class": payload.get("memory_class"),
+                "preview": _preview(r.content),
+                "lanes": ["drift"],
+            }
+
+    if not by_id:
+        return []
+
+    # Drift-only candidates need their stored vector for cosine-vs-EMA.
+    missing = [mid for mid, c in by_id.items() if c["cosine"] is None]
+    if missing:
+        try:
+            points = qdrant_client.retrieve(
+                collection_name="episodic_memory",
+                ids=missing,
+                with_payload=False,
+                with_vectors=True,
+            )
+            for p in points:
+                vec = p.vector if isinstance(p.vector, list) else None
+                if vec:
+                    by_id[str(p.id)]["cosine"] = cosine(ema, vec)
+        except Exception:
+            pass  # cosine stays None → scored at 0 below, not dropped info
+        for mid in missing:
+            if by_id[mid]["cosine"] is None:
+                by_id[mid]["cosine"] = 0.0
+
+    # ── Bitemporal parity ────────────────────────────────────────────
+    expired = await _expired_candidate_ids(db, set(by_id))
+    for mid in expired:
+        by_id.pop(mid, None)
+    if not by_id:
+        return []
+
+    # ── Rank ─────────────────────────────────────────────────────────
+    link_counts = await batch_link_counts(db, list(by_id))
+    for mid, cand in by_id.items():
+        inbound = link_counts.get(mid, (0, 0))[1]
+        conf_raw = cand.get("confidence")
+        confidence = conf_raw if isinstance(conf_raw, int | float) else DEFAULT_CONFIDENCE
+        class_w = CLASS_WEIGHTS.get(cand.get("memory_class") or "", 1.0)
+        cand["inbound_links"] = inbound
+        cand["confidence"] = confidence
+        cand["score"] = (
+            (1.0 + BACKLINK_COEF * math.log1p(inbound))
+            * confidence
+            * class_w
+            * max(cand["cosine"] or 0.0, 0.0)
+        )
+
+    ranked = sorted(by_id.values(), key=lambda c: c["score"], reverse=True)
+    picked = ranked[:top_n]
+
+    # Stratified floor: guarantee decision-lane representation. Without
+    # it the operational near-duplicate wall crowds out exactly the
+    # class of memory this layer exists to surface (the OMI incident).
+    decision_in = sum(1 for c in picked if "decision" in c["lanes"])
+    if decision_in < DECISION_RESERVED:
+        extras = [
+            c for c in ranked[top_n:] if "decision" in c["lanes"]
+        ][: DECISION_RESERVED - decision_in]
+        if extras:
+            keep = [c for c in picked if "decision" not in c["lanes"]]
+            picked = (
+                [c for c in picked if "decision" in c["lanes"]]
+                + keep[: top_n - decision_in - len(extras)]
+                + extras
+            )
+            picked.sort(key=lambda c: c["score"], reverse=True)
+
+    return picked

--- a/src/genesis/session_awareness/slots.py
+++ b/src/genesis/session_awareness/slots.py
@@ -1,0 +1,75 @@
+"""Two-slot flock semaphore for ambient workers.
+
+Same primitive as ``genesis.util.process_lock.ProcessLock`` (flock
+LOCK_EX|LOCK_NB, auto-release on process death — no stale-lock problem)
+generalized to N slots and returning failure instead of ``sys.exit``:
+the worker is fire-and-forget, so "slots busy" is a recorded outcome,
+not a process error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import os
+from pathlib import Path
+
+SLOT_COUNT = 2
+ACQUIRE_TIMEOUT_S = 15.0  # a fire's context goes stale fast; don't queue
+_POLL_S = 0.5
+
+
+def default_lock_dir() -> Path:
+    return Path.home() / ".genesis" / "session_awareness" / "locks"
+
+
+class SlotHandle:
+    """A held slot. Release explicitly or let process death release it."""
+
+    def __init__(self, index: int, fd: int):
+        self.index = index
+        self._fd: int | None = fd
+
+    def release(self) -> None:
+        if self._fd is not None:
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._fd = None
+
+
+def try_acquire_slot(lock_dir: Path | None = None) -> SlotHandle | None:
+    """Try each slot once; None if all are held."""
+    lock_dir = lock_dir or default_lock_dir()
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(SLOT_COUNT):
+        fd = os.open(str(lock_dir / f"slot-{i}.lock"), os.O_CREAT | os.O_RDWR)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            continue
+        os.ftruncate(fd, 0)
+        os.write(fd, str(os.getpid()).encode())
+        return SlotHandle(i, fd)
+    return None
+
+
+async def acquire_slot(
+    lock_dir: Path | None = None,
+    timeout_s: float | None = None,
+) -> SlotHandle | None:
+    """Poll for a slot up to *timeout_s* (default ACQUIRE_TIMEOUT_S,
+    resolved at call time so tests can shrink it); None on timeout."""
+    if timeout_s is None:
+        timeout_s = ACQUIRE_TIMEOUT_S
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while True:
+        handle = try_acquire_slot(lock_dir)
+        if handle is not None:
+            return handle
+        if asyncio.get_event_loop().time() >= deadline:
+            return None
+        await asyncio.sleep(_POLL_S)

--- a/src/genesis/session_awareness/worker.py
+++ b/src/genesis/session_awareness/worker.py
@@ -1,0 +1,140 @@
+"""Detached ambient worker: retrieve + rank on a drift-trigger fire.
+
+Spawned by the proactive hook (``start_new_session=True``) when a
+session theme settles. Opens its OWN read-only DB connection, Qdrant
+client, and embedding provider — it must never touch server state.
+Writes exactly two places, both under ``~/.genesis``:
+
+- ``sessions/<id>/ambient_verdict.json`` — the latest outcome (atomic)
+- ``session_awareness/shadow_log.jsonl`` — append-only tuning record
+  (size-capped; skips are counted in the verdict, never silent)
+
+PR2 runs ``--no-arbiter`` only; PR3 adds the arbiter judgment stage.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .accumulator import top_entities
+from .ranking import rank_candidates
+from .slots import acquire_slot
+from .statefiles import load_state
+from .trigger import stability
+
+SHADOW_LOG_MAX_BYTES = 50 * 1024 * 1024  # cap, counted when hit
+ENTITY_QUERY_TERMS = 8
+VERDICT_FILENAME = "ambient_verdict.json"
+
+
+def _state_root() -> Path:
+    return Path.home() / ".genesis" / "session_awareness"
+
+
+def _sessions_root() -> Path:
+    return Path.home() / ".genesis" / "sessions"
+
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        os.write(fd, json.dumps(data).encode())
+    finally:
+        os.close(fd)
+    os.replace(tmp, str(path))
+
+
+def _append_shadow_log(record: dict, state_root: Path) -> bool:
+    """Append to shadow_log.jsonl. False (and no write) once capped."""
+    log_path = state_root / "shadow_log.jsonl"
+    try:
+        if log_path.exists() and log_path.stat().st_size >= SHADOW_LOG_MAX_BYTES:
+            return False
+        state_root.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a") as fh:
+            fh.write(json.dumps(record) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+async def run_worker(
+    session_id: str,
+    *,
+    no_arbiter: bool = False,
+    sessions_root: Path | None = None,
+    state_root: Path | None = None,
+    db_path: Path | None = None,
+    qdrant_url: str | None = None,
+) -> dict:
+    """One retrieval pass for *session_id*. Returns the verdict it wrote."""
+    sessions_root = sessions_root or _sessions_root()
+    state_root = state_root or _state_root()
+    now_iso = datetime.now(UTC).isoformat()
+    verdict_path = sessions_root / session_id / VERDICT_FILENAME
+
+    def finish(verdict: dict) -> dict:
+        verdict.setdefault("session_id", session_id)
+        verdict.setdefault("generated_at", now_iso)
+        _atomic_write_json(verdict_path, verdict)
+        logged = _append_shadow_log(verdict, state_root)
+        if not logged:
+            verdict["shadow_log_skipped"] = True
+            _atomic_write_json(verdict_path, verdict)
+        return verdict
+
+    state = load_state(session_id, base=sessions_root)
+    if not state.get("ema"):
+        return finish({"status": "no_theme"})
+
+    slot = await acquire_slot(state_root / "locks")
+    if slot is None:
+        return finish({"status": "slots_busy"})
+
+    try:
+        import aiosqlite
+        from qdrant_client import QdrantClient
+
+        from genesis import env as genesis_env
+        from genesis.memory.embeddings import EmbeddingProvider
+
+        resolved_db = db_path or genesis_env.genesis_db_path()
+        url = qdrant_url or genesis_env.qdrant_url()
+
+        db = await aiosqlite.connect(
+            f"file:{resolved_db}?mode=ro", uri=True,
+        )
+        try:
+            qdrant = QdrantClient(url=url, timeout=10)
+            provider = EmbeddingProvider()
+            entity_query = " ".join(top_entities(state, ENTITY_QUERY_TERMS))
+            candidates = await rank_candidates(
+                ema=state["ema"],
+                entity_query=entity_query,
+                db=db,
+                qdrant_client=qdrant,
+                embedding_provider=provider,
+            )
+        finally:
+            await db.close()
+
+        return finish({
+            "status": "no_arbiter" if no_arbiter else "ranked",
+            "theme": {
+                "ema_turns": state.get("ema_turns", 0),
+                "stability": stability(state.get("ring", [])),
+                "fired_count": state.get("fired_count", 0),
+                "outlier_skips": state.get("outlier_skips", 0),
+            },
+            "entity_query": entity_query,
+            "candidates": candidates,
+        })
+    except Exception as exc:  # recorded, never raised — detached process
+        return finish({"status": "error", "error": f"{type(exc).__name__}: {exc}"})
+    finally:
+        slot.release()

--- a/tests/test_session_awareness/test_ranking.py
+++ b/tests/test_session_awareness/test_ranking.py
@@ -1,0 +1,270 @@
+"""Ranking unit tests — mocked lanes, real formula, zero-write proof."""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.session_awareness.ranking import (
+    BACKLINK_COEF,
+    DEFAULT_CONFIDENCE,
+    TOP_N,
+    rank_candidates,
+)
+
+DIM = 8
+EMA = [1.0] + [0.0] * (DIM - 1)
+
+
+def _vec(cos_target: float) -> list[float]:
+    """A unit vector at the given cosine to EMA (axis 0)."""
+    return [cos_target, math.sqrt(max(0.0, 1 - cos_target**2))] + [0.0] * (DIM - 2)
+
+
+def _hit(mid: str, score: float, *, confidence=0.8, mclass="fact", content="c"):
+    return {
+        "id": mid,
+        "score": score,
+        "payload": {
+            "confidence": confidence,
+            "memory_class": mclass,
+            "content": content,
+        },
+    }
+
+
+def _rr(mid: str, *, confidence=0.6, mclass="rule"):
+    r = MagicMock()
+    r.memory_id = mid
+    r.content = f"drift {mid}"
+    r.payload = {"confidence": confidence, "memory_class": mclass}
+    return r
+
+
+def _db():
+    return MagicMock()  # only passed through to patched helpers
+
+
+@pytest.mark.asyncio
+async def test_formula_and_ordering():
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=[])
+    with (
+        patch("genesis.qdrant.collections.search", side_effect=[[
+            _hit("high", 0.9, confidence=1.0, mclass="rule"),
+            _hit("mid", 0.9, confidence=0.5, mclass="fact"),
+            _hit("low", 0.2, confidence=1.0, mclass="reference"),
+        ], []]),
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={"high": (5, 3), "mid": (0, 0)}),
+        ),
+    ):
+        ranked = await rank_candidates(
+            ema=EMA, entity_query="q", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    by_id = {c["memory_id"]: c for c in ranked}
+    # high: (1 + 0.05*log1p(3)) * 1.0 * 1.3 * 0.9
+    expected_high = (1 + BACKLINK_COEF * math.log1p(3)) * 1.0 * 1.3 * 0.9
+    assert abs(by_id["high"]["score"] - expected_high) < 1e-9
+    # mid: 1.0 * 0.5 * 1.0 * 0.9
+    assert abs(by_id["mid"]["score"] - 0.45) < 1e-9
+    assert [c["memory_id"] for c in ranked][:2] == ["high", "mid"]
+
+
+@pytest.mark.asyncio
+async def test_drift_lane_union_and_cosine_backfill():
+    qdrant = MagicMock()
+    drift_vec = _vec(0.7)
+    point = MagicMock()
+    point.id = "drift-only"
+    point.vector = drift_vec
+    qdrant.retrieve = MagicMock(return_value=[point])
+    with (
+        patch("genesis.qdrant.collections.search", side_effect=[[
+            _hit("both-lanes", 0.8),
+        ], []]),
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[
+            _rr("both-lanes"),
+            _rr("drift-only", confidence=1.0, mclass="fact"),
+        ])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        ranked = await rank_candidates(
+            ema=EMA, entity_query="genesis voice", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    by_id = {c["memory_id"]: c for c in ranked}
+    assert by_id["both-lanes"]["lanes"] == ["vector", "drift"]
+    # both-lanes keeps the VECTOR lane's payload (first lane wins)
+    assert by_id["both-lanes"]["confidence"] == 0.8
+    assert by_id["drift-only"]["lanes"] == ["drift"]
+    assert abs(by_id["drift-only"]["cosine"] - 0.7) < 1e-6
+    assert abs(by_id["drift-only"]["score"] - 1.0 * 1.0 * 0.7) < 1e-6
+    # retrieve was called only for the drift-only candidate
+    _, kwargs = qdrant.retrieve.call_args
+    assert kwargs["ids"] == ["drift-only"]
+    assert kwargs["with_vectors"] is True
+
+
+@pytest.mark.asyncio
+async def test_expired_candidates_dropped_and_empty_query_skips_drift():
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=[])
+    drift_mock = AsyncMock(return_value=[])
+    with (
+        patch("genesis.qdrant.collections.search", side_effect=[[
+            _hit("keep", 0.9), _hit("expired", 0.95),
+        ], []]),
+        patch("genesis.memory.drift.drift_recall", new=drift_mock),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value={"expired"}),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        ranked = await rank_candidates(
+            ema=EMA, entity_query="   ", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    assert [c["memory_id"] for c in ranked] == ["keep"]
+    drift_mock.assert_not_awaited()  # blank entity query → no drift lane
+
+
+@pytest.mark.asyncio
+async def test_missing_confidence_defaults_and_top_n_cap():
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=[])
+    hits = [
+        _hit(f"m{i}", 0.9 - i * 0.01, confidence=None, mclass=None)
+        for i in range(TOP_N + 4)
+    ]
+    with (
+        patch("genesis.qdrant.collections.search", side_effect=[hits, []]),
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        ranked = await rank_candidates(
+            ema=EMA, entity_query="q", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    assert len(ranked) == TOP_N
+    assert ranked[0]["confidence"] == DEFAULT_CONFIDENCE
+    assert abs(ranked[0]["score"] - DEFAULT_CONFIDENCE * 0.9) < 1e-9
+
+
+@pytest.mark.asyncio
+async def test_zero_writes_no_unexpected_client_calls():
+    """The lane is read-only: search + retrieve are the ONLY qdrant calls,
+    and nothing on the client that mutates (upsert/set_payload/update) runs."""
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=[])
+    with (
+        patch("genesis.qdrant.collections.search", side_effect=[[_hit("a", 0.9)], []]),
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        await rank_candidates(
+            ema=EMA, entity_query="q", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    for name in ("upsert", "set_payload", "overwrite_payload", "delete", "update_vectors"):
+        assert not getattr(qdrant, name).called
+
+
+@pytest.mark.asyncio
+async def test_decision_lane_stratified_floor():
+    """A low-scoring decision-lane candidate must survive the operational
+    wall — the final set reserves slots for the decision class."""
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=[])
+    ops_wall = [_hit(f"ops{i}", 0.9 - i * 0.001, confidence=1.0) for i in range(12)]
+    decision = [_hit("the-decision", 0.73, confidence=0.9, mclass="fact")]
+    with (
+        patch(
+            "genesis.qdrant.collections.search",
+            side_effect=[ops_wall, decision],
+        ) as search_mock,
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        ranked = await rank_candidates(
+            ema=EMA, entity_query="q", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    assert len(ranked) == TOP_N
+    by_id = {c["memory_id"]: c for c in ranked}
+    assert "the-decision" in by_id  # would be rank 13 by raw score
+    assert by_id["the-decision"]["lanes"] == ["decision"]
+    # Both lanes were exact, and only the decision lane was tag-filtered
+    kw0 = search_mock.call_args_list[0].kwargs
+    kw1 = search_mock.call_args_list[1].kwargs
+    assert kw0["exact"] is True and kw0["tags_any"] is None
+    assert kw1["exact"] is True and kw1["tags_any"] == ["decision"]
+
+
+@pytest.mark.asyncio
+async def test_decision_lane_dedup_with_vector_lane():
+    """A candidate in both Qdrant lanes appears once, tagged with both."""
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=[])
+    with (
+        patch(
+            "genesis.qdrant.collections.search",
+            side_effect=[[_hit("dual", 0.85)], [_hit("dual", 0.85)]],
+        ),
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        ranked = await rank_candidates(
+            ema=EMA, entity_query="q", db=_db(),
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+        )
+    assert len(ranked) == 1
+    assert ranked[0]["lanes"] == ["vector", "decision"]

--- a/tests/test_session_awareness/test_slots.py
+++ b/tests/test_session_awareness/test_slots.py
@@ -1,0 +1,47 @@
+"""Slot-semaphore tests — flock contention within one process.
+
+flock locks attach to the open file description, so separate os.open()
+calls in the same process genuinely contend — no subprocesses needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.session_awareness.slots import (
+    SLOT_COUNT,
+    acquire_slot,
+    try_acquire_slot,
+)
+
+
+def test_two_slots_then_busy(tmp_path):
+    a = try_acquire_slot(tmp_path)
+    b = try_acquire_slot(tmp_path)
+    assert a is not None and b is not None
+    assert {a.index, b.index} == set(range(SLOT_COUNT))
+    assert try_acquire_slot(tmp_path) is None
+    a.release()
+    c = try_acquire_slot(tmp_path)
+    assert c is not None and c.index == a.index
+    b.release()
+    c.release()
+
+
+def test_release_idempotent(tmp_path):
+    a = try_acquire_slot(tmp_path)
+    a.release()
+    a.release()  # second release is a no-op, not an error
+
+
+@pytest.mark.asyncio
+async def test_acquire_slot_times_out_fast(tmp_path):
+    held = [try_acquire_slot(tmp_path) for _ in range(SLOT_COUNT)]
+    assert all(held)
+    got = await acquire_slot(tmp_path, timeout_s=0.1)
+    assert got is None
+    for h in held:
+        h.release()
+    got = await acquire_slot(tmp_path, timeout_s=0.1)
+    assert got is not None
+    got.release()

--- a/tests/test_session_awareness/test_worker.py
+++ b/tests/test_session_awareness/test_worker.py
@@ -1,0 +1,149 @@
+"""Worker tests — verdict plumbing in-process, entry script as subprocess."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.session_awareness import worker as worker_mod
+from genesis.session_awareness.slots import try_acquire_slot
+from genesis.session_awareness.statefiles import empty_state, save_state
+from genesis.session_awareness.worker import run_worker
+
+REPO_DIR = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_DIR / "scripts" / "ambient_awareness_worker.py"
+
+DIM = 8
+SID = "worker-test-1"
+
+
+def _seed_theme(sessions_root: Path, *, ema=None) -> None:
+    s = empty_state(SID)
+    s["ema"] = ema or [1.0] + [0.0] * (DIM - 1)
+    s["ema_turns"] = 4
+    s["ring"] = [s["ema"]] * 3
+    s["entities"] = {"genesis": 2.0, "voice": 1.1, "faint": 0.06}
+    s["updated_at"] = "2026-07-09T12:00:00+00:00"
+    save_state(SID, s, base=sessions_root)
+
+
+def _tmp_db(tmp_path: Path) -> Path:
+    db = tmp_path / "g.db"
+    sqlite3.connect(str(db)).close()
+    return db
+
+
+def _verdict(sessions_root: Path) -> dict:
+    return json.loads((sessions_root / SID / "ambient_verdict.json").read_text())
+
+
+@pytest.mark.asyncio
+async def test_no_theme_verdict(tmp_path):
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    result = await run_worker(SID, sessions_root=sessions, state_root=state)
+    assert result["status"] == "no_theme"
+    assert _verdict(sessions)["status"] == "no_theme"
+    log_lines = (state / "shadow_log.jsonl").read_text().splitlines()
+    assert json.loads(log_lines[0])["session_id"] == SID
+
+
+@pytest.mark.asyncio
+async def test_ranked_verdict_and_entity_query(tmp_path):
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    _seed_theme(sessions)
+    fake = [{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}]
+    with patch.object(
+        worker_mod, "rank_candidates", new=AsyncMock(return_value=fake),
+    ) as rc:
+        result = await run_worker(
+            SID,
+            no_arbiter=True,
+            sessions_root=sessions,
+            state_root=state,
+            db_path=_tmp_db(tmp_path),
+            qdrant_url="http://127.0.0.1:1",
+        )
+    assert result["status"] == "no_arbiter"
+    assert result["candidates"] == fake
+    assert result["theme"]["ema_turns"] == 4
+    assert result["theme"]["stability"] == 1.0
+    # Entity query = top-weight ledger entries, best first
+    assert result["entity_query"].split()[:2] == ["genesis", "voice"]
+    kwargs = rc.call_args.kwargs
+    assert kwargs["ema"] == [1.0] + [0.0] * (DIM - 1)
+    v = _verdict(sessions)
+    assert v["candidates"] == fake
+
+
+@pytest.mark.asyncio
+async def test_slots_busy_fail_closed(tmp_path, monkeypatch):
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    _seed_theme(sessions)
+    monkeypatch.setattr(
+        "genesis.session_awareness.slots.ACQUIRE_TIMEOUT_S", 0.1,
+    )
+    held = [try_acquire_slot(state / "locks") for _ in range(2)]
+    assert all(held)
+    result = await run_worker(SID, sessions_root=sessions, state_root=state)
+    assert result["status"] == "slots_busy"
+    for h in held:
+        h.release()
+
+
+@pytest.mark.asyncio
+async def test_error_recorded_and_slot_released(tmp_path):
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    _seed_theme(sessions)
+    with patch.object(
+        worker_mod, "rank_candidates",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await run_worker(
+            SID, sessions_root=sessions, state_root=state,
+            db_path=_tmp_db(tmp_path), qdrant_url="http://127.0.0.1:1",
+        )
+    assert result["status"] == "error"
+    assert "boom" in result["error"]
+    # Slot must be free again after the failure
+    a, b = try_acquire_slot(state / "locks"), try_acquire_slot(state / "locks")
+    assert a is not None and b is not None
+    a.release()
+    b.release()
+
+
+@pytest.mark.asyncio
+async def test_shadow_log_cap_is_counted_not_silent(tmp_path, monkeypatch):
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    state.mkdir(parents=True)
+    (state / "shadow_log.jsonl").write_text('{"old": true}\n')
+    monkeypatch.setattr(worker_mod, "SHADOW_LOG_MAX_BYTES", 5)
+    result = await run_worker(SID, sessions_root=sessions, state_root=state)
+    assert result["status"] == "no_theme"
+    assert result["shadow_log_skipped"] is True
+    assert _verdict(sessions)["shadow_log_skipped"] is True
+    # Log untouched past the cap
+    assert (state / "shadow_log.jsonl").read_text() == '{"old": true}\n'
+
+
+def test_entry_script_subprocess(tmp_path):
+    """The spawned form end-to-end: argparse → asyncio → verdict file."""
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--session-id", SID, "--no-arbiter"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+        cwd=str(REPO_DIR),
+    )
+    assert proc.returncode == 0, proc.stderr
+    verdict_path = tmp_path / ".genesis" / "sessions" / SID / "ambient_verdict.json"
+    assert json.loads(verdict_path.read_text())["status"] == "no_theme"


### PR DESCRIPTION
## What

Second stage of the ambient session-awareness layer: on a drift-trigger fire, the hook spawns a **detached worker** (\`start_new_session=True\`, the genesis_session_end idiom) that retrieves and ranks candidate memories — SHADOW only: verdicts recorded, nothing injected.

**Three candidate lanes, all exact-search** (filtered HNSW without payload indexes measurably drops valid results — found hunting the OMI kill-criterion memory; production-wide fix in #975):
- **Vector**: theme EMA → Qdrant (deprecated filtered).
- **Decisions**: EMA against \`tags~decision\` only — the OMI-incident class. Measured: the repo-split fact sat past rank 200 unfiltered behind a wall of near-duplicate operational memories, rank 12 in this lane; E2E it entered the final candidate set at rank 8.
- **Drift**: entity-ledger top keywords through \`drift_recall\` (read-only path).

Rank = \`(1 + 0.05·log1p(inbound)) × confidence × CLASS_WEIGHT × cosine\` (mirrors the retrieval graph-boost shape) + bitemporal parity via \`_expired_candidate_ids\`. Stratified floor keeps ≥2 decision-lane candidates in the final 8 — otherwise the operational wall crowds out exactly what this layer exists to surface.

**Zero writes**: no retrieved_count bump, ever — MEM-005/H-1 baselines stay clean (asserted by test and verified E2E with before/after payload snapshots).

Infra: 2-slot flock semaphore (auto-release on death, 15s fail-closed acquire → recorded \`slots_busy\`), atomic \`ambient_verdict.json\`, size-capped \`shadow_log.jsonl\` (cap counted, never silent). \`qdrant_ops.search\` gains additive \`tags_any\`/\`exact\` params (default behavior byte-identical).

## Verification

- 16 new tests (ranking formula/lanes/stratified-floor/zero-write, slots contention/timeout, worker verdict paths incl. error + cap, subprocess entry E2E).
- Live E2E vs real stores: kill-criterion memory in candidates at rank 8; target \`retrieved_count\` unchanged before/after; two held slots → third worker records \`slots_busy\`.
- Worker cold start measured ~3.3s — detached, session never waits.

PR3 (arbiter) and PR4 (replay harness + verdict) follow on this branch chain.