### PR TITLE
feat(memory): WS-C PR4 — replay harness, replay-derived tuning, soften-not-reset staleness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ Genesis to research, summarize, write content, or do non-Genesis tasks).
 
 Your Genesis install is one operational system: the public `GENesis-AGI`
 codebase (the cognitive core), the public `GENesis-Voice` repo for
-voice/edge-device software (OMI + Voice PE firmware, esphome configs, S2S/
+voice/edge-device software (HAOS Voice PE device firmware, esphome configs, S2S/
 ambient audio bridges, edge deploy — `GENesis-AGI` keeps only its internal
 channel code), your private fork for customizations, and your private
 `genesis-backups` repo for encrypted data. Full model:

--- a/scripts/ambient_replay.py
+++ b/scripts/ambient_replay.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""WS-C replay harness: run the ambient pipeline over a recorded session.
+
+Acceptance instrument for the session-awareness layer (NOT a CI test).
+Streams a CC session transcript, feeds each GENUINE user turn through
+the exact live gates (the hook's envelope + keyword functions, imported
+from the hook module itself), folds the theme EMA, traces every trigger
+decision, and on each fire runs the real retrieve+rank lanes (read-only)
+to capture the candidate set.
+
+KILL CRITERION (OMI incident, session 246fe52b…):
+    PASS = memory 9d36f039… appears in a fire's candidate set within
+    the first 10 genuine turns. FAIL → tune constants (authorized) or
+    STOP and redesign if it's structural.
+
+Usage:
+    python scripts/ambient_replay.py --session-id 246fe52b-... \
+        [--target 9d36f039] [--max-genuine-turns N] [--no-retrieve]
+        [--transcript /path/to.jsonl]
+
+Timestamps come from the transcript (never the wall clock); embeddings
+are cached by content hash in ~/.genesis/session_awareness/ so tuning
+iterations are cheap. Everything is read-only against production
+stores — the replay never writes session state, Qdrant, or the DB.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import importlib.util
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+_TRANSCRIPT_DIR = Path.home() / ".claude" / "projects" / "-home-ubuntu-genesis"
+_CACHE_PATH = (
+    Path.home() / ".genesis" / "session_awareness" / "replay_embed_cache.json"
+)
+
+
+def _load_hook_module():
+    """Import the live hook for gate parity (_extract_keywords, etc.)."""
+    import os
+
+    # The hook exits at import inside dispatched Genesis sessions; the
+    # replay is never that context, so clear the guard before exec.
+    os.environ.pop("GENESIS_CC_SESSION", None)
+    path = REPO_DIR / "scripts" / "proactive_memory_hook.py"
+    spec = importlib.util.spec_from_file_location("proactive_memory_hook", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def iter_user_turns(transcript: Path):
+    """Yield (timestamp, text, recent_files) for user turns, streamed.
+
+    recent_files = file paths from assistant tool calls (Edit/Write/Read/
+    NotebookEdit) since the PREVIOUS user turn — the replay equivalent of
+    the live hook's PostToolUse file-context tracking.
+    """
+    pending_files: list[str] = []
+    with transcript.open() as fh:
+        for line in fh:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            etype = entry.get("type")
+            if etype == "assistant":
+                msg = entry.get("message") or {}
+                for block in msg.get("content") or []:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        fp = (block.get("input") or {}).get("file_path")
+                        if fp:
+                            pending_files.append(fp)
+                continue
+            if etype != "user" or entry.get("isMeta"):
+                continue
+            msg = entry.get("message") or {}
+            content = msg.get("content")
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, list):
+                parts = [
+                    c.get("text", "")
+                    for c in content
+                    if isinstance(c, dict) and c.get("type") == "text"
+                ]
+                text = "\n".join(p for p in parts if p)
+            else:
+                continue
+            if not text.strip():
+                continue
+            files = pending_files[-20:]
+            pending_files = []
+            yield entry.get("timestamp"), text, files
+
+
+class EmbedCache:
+    def __init__(self, path: Path):
+        self.path = path
+        try:
+            self.data = json.loads(path.read_text())
+        except Exception:
+            self.data = {}
+        self.misses = 0
+
+    async def embed(self, provider, text: str) -> list[float] | None:
+        key = hashlib.sha256(text.encode()).hexdigest()
+        if key in self.data:
+            return self.data[key]
+        vec = await provider.embed(text)
+        if vec:
+            self.data[key] = vec
+            self.misses += 1
+            if self.misses % 10 == 0:
+                self.save()
+        return vec
+
+    def save(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.data))
+
+
+async def replay(args) -> dict:
+    from genesis.session_awareness.accumulator import fold_turn, should_fold
+    from genesis.session_awareness.statefiles import empty_state
+    from genesis.session_awareness.trigger import check_fire, record_fire, stability
+
+    hook = _load_hook_module()
+    transcript = (
+        Path(args.transcript)
+        if args.transcript
+        else _TRANSCRIPT_DIR / f"{args.session_id}.jsonl"
+    )
+    if not transcript.exists():
+        raise SystemExit(f"transcript not found: {transcript}")
+
+    # API keys live in secrets.env (env-only resolution) — load from the
+    # MAIN repo via genesis.env, not this worktree (the hook's own
+    # load_dotenv points at its REPO_DIR, which has no secrets file in a
+    # worktree). Cloud-first chain = the hook's recall path, minus the
+    # 3s interactive budget (offline harness; backend timeouts apply).
+    from dotenv import load_dotenv
+
+    from genesis import env as genesis_env
+
+    load_dotenv(genesis_env.secrets_path())
+
+    from genesis.memory.embeddings import EmbeddingProvider
+
+    provider = EmbeddingProvider(
+        backends=EmbeddingProvider.build_chain(ollama_first=False),
+        cache_dir=None,
+    )
+    cache = EmbedCache(_CACHE_PATH)
+
+    state = empty_state(args.session_id)
+    trail: dict = {"msg_count": 0, "pivots": [], "last_keywords": []}
+    genuine = 0
+    trace: list[dict] = []
+    fires: list[dict] = []
+    as_of_cutoff: str | None = None if args.as_of in (None, "auto") else args.as_of
+
+    db = qdrant = None
+    if not args.no_retrieve:
+        import aiosqlite
+        from qdrant_client import QdrantClient
+
+        from genesis import env as genesis_env
+
+        db = await aiosqlite.connect(
+            f"file:{genesis_env.genesis_db_path()}?mode=ro", uri=True,
+        )
+        qdrant = QdrantClient(url=genesis_env.qdrant_url(), timeout=30)
+
+    try:
+        for ts, text, recent_files in iter_user_turns(transcript):
+            if hook._is_harness_envelope(text):
+                continue
+            keywords = hook._extract_keywords(text)
+            if len(keywords) < hook._MIN_PROMPT_WORDS:
+                continue
+            genuine += 1
+            if args.max_genuine_turns and genuine > args.max_genuine_turns:
+                break
+
+            # Same Jaccard pivot logic as the live trail
+            trail["msg_count"] += 1
+            pivoted = bool(hook._detect_pivot(keywords, trail))
+            if pivoted:
+                trail["pivots"].append({"at_msg": trail["msg_count"]})
+            if keywords:
+                trail["last_keywords"] = keywords
+
+            now = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            now_iso = now.isoformat()
+            if args.as_of == "auto" and as_of_cutoff is None:
+                as_of_cutoff = now_iso  # first genuine turn = session start
+            thematic = should_fold(text, keywords)
+            vec = await cache.embed(provider, text) if thematic else None
+            if vec:
+                file_kws = (
+                    hook._keywords_from_files(recent_files) if recent_files else []
+                )
+                fold_turn(
+                    state, vec, keywords, file_kws,
+                    pivoted=pivoted, now_iso=now_iso,
+                )
+                fired, reason = check_fire(state, now)
+            else:
+                fired, reason = False, ("low_signal" if not thematic else "no_embed")
+
+            row = {
+                "turn": genuine,
+                "ts": now_iso,
+                "prompt": text[:80].replace("\n", " "),
+                "pivot": pivoted,
+                "embedded": bool(vec),
+                "ema_turns": state.get("ema_turns", 0),
+                "stability": round(stability(state.get("ring", [])), 4),
+                "reason": reason,
+            }
+            trace.append(row)
+
+            if fired:
+                record_fire(state, now_iso)
+                fire_rec: dict = {"turn": genuine, "ts": now_iso}
+                if not args.no_retrieve:
+                    from genesis.session_awareness.accumulator import top_entities
+                    from genesis.session_awareness.ranking import rank_candidates
+
+                    candidates = await rank_candidates(
+                        ema=state["ema"],
+                        entity_query=" ".join(top_entities(state, 8)),
+                        db=db,
+                        qdrant_client=qdrant,
+                        embedding_provider=provider,
+                        created_before=as_of_cutoff,
+                    )
+                    fire_rec["candidates"] = [
+                        {
+                            "memory_id": c["memory_id"],
+                            "score": round(c["score"], 4),
+                            "lanes": c["lanes"],
+                            "preview": c["preview"][:60],
+                        }
+                        for c in candidates
+                    ]
+                fires.append(fire_rec)
+    finally:
+        if db is not None:
+            await db.close()
+        cache.save()
+
+    result = {
+        "session_id": args.session_id,
+        "as_of": as_of_cutoff,
+        "genuine_turns": genuine,
+        "fires": fires,
+        "trace": trace,
+        "outlier_skips": state.get("outlier_skips", 0),
+    }
+    if args.target:
+        hit = None
+        for f in fires:
+            for c in f.get("candidates", []):
+                if c["memory_id"].startswith(args.target):
+                    hit = {"turn": f["turn"], "memory_id": c["memory_id"]}
+                    break
+            if hit:
+                break
+        result["target"] = args.target
+        result["target_hit"] = hit
+        result["PASS"] = bool(hit and hit["turn"] <= 10)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--transcript", default=None)
+    parser.add_argument("--target", default=None, help="memory-id prefix to hunt")
+    parser.add_argument("--max-genuine-turns", type=int, default=0)
+    parser.add_argument("--no-retrieve", action="store_true")
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="ISO cutoff: only memories created before this instant are "
+             "candidates. 'auto' = the session's first turn timestamp "
+             "(the honest counterfactual — no post-session leakage).",
+    )
+    parser.add_argument("--json", action="store_true", help="full JSON to stdout")
+    args = parser.parse_args()
+
+    result = asyncio.run(replay(args))
+
+    if args.json:
+        print(json.dumps(result, indent=1))
+        return
+    print(f"session {result['session_id']}: {result['genuine_turns']} genuine turns, "
+          f"{len(result['fires'])} fires, {result['outlier_skips']} outlier skips")
+    for row in result["trace"]:
+        flag = " FIRE" if any(f["turn"] == row["turn"] for f in result["fires"]) else ""
+        pv = " PIVOT" if row["pivot"] else ""
+        print(f"  t{row['turn']:>3} ema={row['ema_turns']:>3} "
+              f"stab={row['stability']:.3f} {row['reason']:<18}{pv}{flag} | {row['prompt']}")
+    for f in result["fires"]:
+        print(f"FIRE @ turn {f['turn']}:")
+        for c in f.get("candidates", []):
+            print(f"    {c['score']:.3f} [{','.join(c['lanes'])}] "
+                  f"{c['memory_id'][:8]} {c['preview']!r}")
+    if args.target:
+        print(f"TARGET {args.target}: hit={result['target_hit']} "
+              f"PASS={result.get('PASS')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ambient_replay.py
+++ b/scripts/ambient_replay.py
@@ -40,7 +40,14 @@ SRC_DIR = REPO_DIR / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-_TRANSCRIPT_DIR = Path.home() / ".claude" / "projects" / "-home-ubuntu-genesis"
+from genesis.env import repo_root  # noqa: E402  (needs the sys.path insert)
+
+# CC keys a project's transcript dir by the project path with '/' → '-';
+# derive from the resolved repo root (GENESIS_REPO_ROOT-aware) so the
+# default works on any install. --transcript overrides.
+_TRANSCRIPT_DIR = (
+    Path.home() / ".claude" / "projects" / str(repo_root()).replace("/", "-")
+)
 _CACHE_PATH = (
     Path.home() / ".genesis" / "session_awareness" / "replay_embed_cache.json"
 )

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1892,6 +1892,7 @@ def _ambient_fold(
             prompt_keywords=_extract_keywords(prompt),
             file_keywords=_keywords_from_files(recent_files) if recent_files else [],
             pivoted=_turn_pivoted(session_id),
+            prompt_text=prompt,
         )
         if result and result.get("fired"):
             _spawn_ambient_worker(session_id)

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -138,6 +138,7 @@ def search(
     include_deprecated: bool = False,
     tags_any: list[str] | None = None,
     exact: bool = False,
+    created_before: str | None = None,
 ) -> list[dict]:
     """Search by vector similarity with optional payload filters.
 
@@ -147,7 +148,8 @@ def search(
     Includes use ``must`` — only points whose key matches are returned.
 
     ``tags_any`` matches points whose ``tags`` array contains any of the
-    given values. ``exact=True`` forces brute-force scoring instead of
+    given values. ``created_before`` keeps only points whose RFC3339
+    ``created_at`` payload is <= the given instant (as-of replays). ``exact=True`` forces brute-force scoring instead of
     HNSW — use for offline/latency-tolerant lanes: filtered HNSW without
     payload indexes measurably drops valid results (found 2026-07-09;
     ~90-220ms exact at ~49K points).
@@ -203,6 +205,14 @@ def search(
     if tags_any:
         conditions.append(
             FieldCondition(key="tags", match=MatchAny(any=list(tags_any)))
+        )
+    if created_before:
+        from qdrant_client.models import DatetimeRange
+
+        conditions.append(
+            FieldCondition(
+                key="created_at", range=DatetimeRange(lte=created_before),
+            )
         )
     query_filter = Filter(
         must=conditions or None,

--- a/src/genesis/session_awareness/accumulator.py
+++ b/src/genesis/session_awareness/accumulator.py
@@ -23,6 +23,14 @@ OUTLIER_COS = 0.05  # below this cosine vs EMA: skip fold, count it
 OUTLIER_ESCAPE_RUN = 3  # N consecutive outliers = a real theme change, not glitches
 RING_SIZE = 3  # EMA snapshots kept for the stability check
 
+FOLD_MIN_KEYWORDS = 3  # "continue"-class turns carry no thematic signal
+PIVOT_CONFIRM_COS = 0.5  # lexical pivot resets the ring only if semantics agree
+_NON_THEMATIC_PREFIXES = (
+    "This session is being continued",  # compaction walls fold topic soup
+    "[Request interrupted",  # harness interrupt markers, not user themes
+    "<bash-",  # `!` passthrough input/output, not a user theme
+)
+
 ENTITY_DECAY = 0.9  # per-turn multiplicative decay
 PROMPT_KW_WEIGHT = 1.0
 FILE_KW_WEIGHT = 0.3
@@ -47,6 +55,19 @@ def _unit(v: list[float]) -> list[float]:
     if norm == 0.0:
         return list(v)
     return [x / norm for x in v]
+
+
+def should_fold(prompt_text: str, prompt_keywords: list[str]) -> bool:
+    """Is this turn thematic signal worth folding into the EMA?
+
+    Replay-derived gates (2026-07-09, session 246fe52b): "continue"-class
+    turns converged the EMA into filler-space and fired on it; compaction
+    continuations are summaries of EVERYTHING, not a theme.
+    """
+    if len(prompt_keywords) < FOLD_MIN_KEYWORDS:
+        return False
+    stripped = prompt_text.lstrip()
+    return not stripped.startswith(_NON_THEMATIC_PREFIXES)
 
 
 def _normalize_keyword(kw: str) -> str:
@@ -115,9 +136,13 @@ def fold_turn(
                 state["ema_turns"] = 1
                 state["ring"] = [unit]
             else:
-                if pivoted or is_outlier:
-                    # Theme changed — stability must rebuild before the
-                    # trigger can fire again.
+                semantic_break = cosine(vector, ema) < PIVOT_CONFIRM_COS
+                if (pivoted and semantic_break) or is_outlier:
+                    # Theme genuinely changed (lexical pivot corroborated
+                    # by semantics, or an escaped outlier run) — stability
+                    # must rebuild. Uncorroborated Jaccard pivots fire on
+                    # ~40%% of real turns (replay-measured); resetting on
+                    # every one starves the trigger.
                     state["ring"] = []
                 folded = [
                     (1.0 - ALPHA) * e + ALPHA * u

--- a/src/genesis/session_awareness/hook_api.py
+++ b/src/genesis/session_awareness/hook_api.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .accumulator import fold_turn
+from .accumulator import fold_turn, should_fold
 from .statefiles import load_state, save_state
 from .trigger import check_fire, record_fire, stability
 
@@ -24,6 +24,7 @@ def hook_fold(
     prompt_keywords: list[str],
     file_keywords: list[str] | None = None,
     pivoted: bool = False,
+    prompt_text: str = "",
     base_dir: Path | None = None,
     now: datetime | None = None,
 ) -> dict | None:
@@ -35,6 +36,8 @@ def hook_fold(
     try:
         if not session_id or not vector:
             return None
+        if prompt_text and not should_fold(prompt_text, prompt_keywords):
+            return {"fired": False, "reason": "low_signal"}
         now = now or datetime.now(UTC)
         now_iso = now.isoformat()
 

--- a/src/genesis/session_awareness/hook_api.py
+++ b/src/genesis/session_awareness/hook_api.py
@@ -30,6 +30,12 @@ def hook_fold(
 ) -> dict | None:
     """Fold one turn; check the drift trigger; record any fire.
 
+    ``prompt_text``, when provided, runs the ``should_fold`` gate first:
+    non-thematic turns (continuations, interrupts, bash passthrough,
+    sub-minimum keyword count) return ``{"fired": False, "reason":
+    "low_signal"}`` without folding. Empty ``prompt_text`` (legacy
+    callers) skips the gate and folds unconditionally.
+
     Returns a small summary dict (for tests and the PR4 replay harness)
     or None on any failure — by contract this function cannot raise.
     """

--- a/src/genesis/session_awareness/ranking.py
+++ b/src/genesis/session_awareness/ranking.py
@@ -65,6 +65,7 @@ async def rank_candidates(
     qdrant_client: QdrantClient,
     embedding_provider: EmbeddingProvider,
     top_n: int = TOP_N,
+    created_before: str | None = None,
 ) -> list[dict]:
     """Gather both lanes, filter expired, rank, return the top *top_n*.
 
@@ -90,6 +91,7 @@ async def rank_candidates(
             limit=limit,
             tags_any=tags,
             exact=True,
+            created_before=created_before,
         ):
             mid = str(hit["id"])
             if mid in by_id:
@@ -119,6 +121,10 @@ async def rank_candidates(
                 by_id[r.memory_id]["lanes"].append("drift")
                 continue
             payload = r.payload or {}
+            # drift_recall has no as-of entry point — post-filter (the
+            # replay's fidelity concern; live runs pass no cutoff)
+            if created_before and str(payload.get("created_at") or "") > created_before:
+                continue
             by_id[r.memory_id] = {
                 "memory_id": r.memory_id,
                 "cosine": None,  # backfilled below from the stored vector

--- a/src/genesis/session_awareness/statefiles.py
+++ b/src/genesis/session_awareness/statefiles.py
@@ -18,9 +18,14 @@ from pathlib import Path
 SCHEMA_VERSION = 1
 FILENAME = "session_theme.json"
 
-# A session idle longer than this is a new working context: the theme
-# EMA restarts rather than blending yesterday's topic into today's.
+# A session idle longer than this re-arms rather than resets (user
+# decision, 2026-07-09): a CC session spans days and hundreds of compactions —
+# identity (EMA + entity ledger) must survive idle gaps. Softening
+# clears the trigger state (ring, fired regions, claims) so yesterday's
+# fires can't gate today's, halves ledger weights, and keeps the theme.
 STALE_AFTER = timedelta(hours=24)
+_SOFTEN_ENTITY_FACTOR = 0.5
+_SOFTEN_MIN_WEIGHT = 0.05  # mirrors accumulator.MIN_ENTITY_WEIGHT
 
 
 def _sessions_dir() -> Path:
@@ -83,7 +88,7 @@ def load_state(
         if updated:
             now = now or datetime.now(UTC)
             if now - datetime.fromisoformat(updated) > STALE_AFTER:
-                return empty_state(session_id)
+                data = _soften_stale(data)
         data.setdefault("version", SCHEMA_VERSION)
         data.setdefault("session_id", session_id)
         for key, default in empty_state(session_id).items():
@@ -91,6 +96,24 @@ def load_state(
         return data
     except Exception:
         return empty_state(session_id)
+
+
+def _soften_stale(data: dict) -> dict:
+    """Re-arm a stale session without forgetting what it was about."""
+    entities = {
+        k: w * _SOFTEN_ENTITY_FACTOR
+        for k, w in (data.get("entities") or {}).items()
+        if w * _SOFTEN_ENTITY_FACTOR >= _SOFTEN_MIN_WEIGHT
+    }
+    data.update(
+        entities=entities,
+        ring=[],  # stability must rebuild before any fire
+        fired=[],  # yesterday's regions must not gate today
+        fired_count=0,  # daily fire budget, effectively
+        worker_pending_since=None,
+        consecutive_outliers=0,
+    )
+    return data
 
 
 def save_state(session_id: str, state: dict, base: Path | None = None) -> None:

--- a/src/genesis/session_awareness/trigger.py
+++ b/src/genesis/session_awareness/trigger.py
@@ -16,9 +16,11 @@ from .accumulator import RING_SIZE, cosine
 
 EMA_MIN_TURNS = 3  # don't judge a theme before it exists
 STABILITY_MIN = 0.90  # min pairwise cosine across the ring
-FIRED_DIST_MIN = 0.35  # cosine distance from every prior fired region
+FIRED_DIST_MIN = 0.15  # cosine distance from every prior fired region
+# (0.35 starved on replay: ALL topics in a real dev session sit within
+# ~0.3 of each other — the arbiter, not the region gate, filters noise)
 TURNS_BETWEEN_FIRES = 3
-MAX_FIRES = 3  # per session
+MAX_FIRES = 8  # per session (multi-day resumed sessions starve at 3)
 CLAIM_STALE_S = 120.0  # pending-worker claim override
 
 

--- a/tests/test_session_awareness/test_accumulator.py
+++ b/tests/test_session_awareness/test_accumulator.py
@@ -86,14 +86,45 @@ def test_near_theme_vector_folds_normally():
     assert cosine(s["ema"], expected_dir) > 0.999
 
 
-def test_pivot_resets_ring_but_keeps_ema():
+def test_uncorroborated_pivot_does_not_reset_ring():
+    """A Jaccard pivot with NO semantic shift (cos >= PIVOT_CONFIRM_COS)
+    keeps the ring — lexical pivots fire on ~40% of real turns and
+    resetting on every one starves the trigger (replay-measured)."""
     s = empty_state("s1")
     for _ in range(3):
         fold_turn(s, unit(0), [], now_iso=NOW)
     assert len(s["ring"]) == 3
     fold_turn(s, blend(unit(0), unit(1), 0.2), [], pivoted=True, now_iso=NOW)
+    assert len(s["ring"]) == 3  # same theme: ring survives
+    assert s["ema_turns"] == 4
+
+
+def test_corroborated_pivot_resets_ring():
+    """Pivot + genuine semantic shift (cos < PIVOT_CONFIRM_COS) resets."""
+    s = empty_state("s1")
+    for _ in range(3):
+        fold_turn(s, unit(0), [], now_iso=NOW)
+    shifted = blend(unit(0), unit(1), 0.9)  # cos vs EMA ~0.11 < 0.5
+    fold_turn(s, shifted, [], pivoted=True, now_iso=NOW)
     assert len(s["ring"]) == 1  # cleared, then this fold appended
     assert s["ema_turns"] == 4
+
+
+def test_should_fold_gates_low_signal_turns():
+    from genesis.session_awareness.accumulator import should_fold
+
+    assert should_fold("plan the memory retrieval ranking", ["plan", "memory", "retrieval", "ranking"])
+    assert not should_fold("continue", ["continue"])
+    assert not should_fold("ok credits now", ["credits", "now"])
+    assert not should_fold(
+        "This session is being continued from a previous conversation..."
+        " lots of summary soup",
+        ["session", "continued", "previous", "conversation", "summary"],
+    )
+    assert not should_fold(
+        "[Request interrupted by user for tool use]",
+        ["request", "interrupted", "user", "tool"],
+    )
 
 
 def test_entities_decay_weights_and_file_discount():

--- a/tests/test_session_awareness/test_statefiles.py
+++ b/tests/test_session_awareness/test_statefiles.py
@@ -51,17 +51,34 @@ def test_corrupt_file_returns_empty(tmp_path):
     assert load_state("sess-c", base=tmp_path, now=NOW) == empty_state("sess-c")
 
 
-def test_stale_state_resets(tmp_path):
+def test_stale_state_softens_not_resets(tmp_path):
+    """A multi-day session keeps its identity (EMA + decayed ledger) but
+    re-arms the trigger: ring/fired/claims cleared (user decision,
+    2026-07-09 — one CC session spans days and many compactions)."""
     s = empty_state("sess-s")
     s["ema"] = [1.0]
     s["ema_turns"] = 5
+    s["entities"] = {"voice": 2.0, "faint": 0.08}
+    s["ring"] = [[1.0]] * 3
+    s["fired"] = [{"ema": [1.0], "turn": 4, "at": "x"}]
+    s["fired_count"] = 3
+    s["worker_pending_since"] = "2026-07-08T00:00:00+00:00"
     s["updated_at"] = (NOW - timedelta(hours=25)).isoformat()
     save_state("sess-s", s, base=tmp_path)
-    assert load_state("sess-s", base=tmp_path, now=NOW) == empty_state("sess-s")
-    # Under the threshold: preserved
+    loaded = load_state("sess-s", base=tmp_path, now=NOW)
+    assert loaded["ema"] == [1.0]  # theme identity survives
+    assert loaded["ema_turns"] == 5
+    assert loaded["entities"] == {"voice": 1.0}  # halved; faint pruned
+    assert loaded["ring"] == []
+    assert loaded["fired"] == []
+    assert loaded["fired_count"] == 0
+    assert loaded["worker_pending_since"] is None
+    # Under the threshold: fully preserved
     s["updated_at"] = (NOW - timedelta(hours=23)).isoformat()
     save_state("sess-s", s, base=tmp_path)
-    assert load_state("sess-s", base=tmp_path, now=NOW)["ema_turns"] == 5
+    loaded = load_state("sess-s", base=tmp_path, now=NOW)
+    assert loaded["fired_count"] == 3
+    assert loaded["ring"] != []
 
 
 def test_missing_keys_backfilled(tmp_path):


### PR DESCRIPTION
## Summary
Final PR of the WS-C ambient session-awareness lane (PR0-PR3 merged: #970, #972, #976, #977; indexes #975).

### Replay harness (`scripts/ambient_replay.py`)
Offline acceptance instrument: streams a recorded CC transcript through the live fold→trigger→rank gates (hook-module import for gate parity), read-only against prod stores, with an embed cache, `--as-of` temporal cutoff (no post-session memory leakage into candidates), per-turn file context from transcript tool_use entries, and `--json` output.

### Replay-derived tuning (4 documented iterations)
- `FIRED_DIST_MIN` 0.35→0.15, `MAX_FIRES` 3→8 (0.35 starved all later fires)
- Fold gates: `FOLD_MIN_KEYWORDS=3`, non-thematic prefix skip (continuation/interrupt/bash-passthrough turns no longer fold)
- `PIVOT_CONFIRM_COS=0.5` — ring resets only on semantically corroborated pivots (Jaccard pivots fired on ~40% of turns and kept resetting stability)
- `OUTLIER_ESCAPE_RUN=3` unchanged from #972

### Kill-criterion verdict (documented; gate honored)
**FAIL, STRUCTURAL** on the incident session: the theme lived in the action stream (1 of 238 genuine user turns mentions the target topic) — a user-prompt EMA cannot see it; no constants fix this. Validated elsewhere: narrated-theme control session fires sanely (3 fires/34 turns) and a synthetic on-theme EMA ranks the target memory 8th. Per the locked gate, PR5 (delivery) is NOT proceeding on this design alone; the redesign (entity layer) was brought back for a design decision and is planned separately.

### Soften-not-reset staleness
A >24h-idle session now keeps its EMA + ema_turns (theme identity survives idle/compaction gaps), halves entity-ledger weights (prune <0.05), and clears only trigger state (ring, fired regions, claims) so the trigger re-arms. Hard reset remains new-session-id only.

### Docs
GENesis-Voice scope wording in CLAUDE.md: the invested edge platform is the HAOS Voice PE device.

## Testing
- `tests/test_session_awareness/` 79 passed in worktree (incl. new soften test, replay-adjacent ranking `created_before` tests)
- ruff clean on the full diff
- Replay runs documented against two real sessions + synthetic control

🤖 Generated with [Claude Code](https://claude.com/claude-code)