### PR TITLE
fix(memory): canonicalize bitemporal timestamps at the write gate + data repair (E1)

### DIFF
--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -10,6 +10,8 @@ import re
 
 import aiosqlite
 
+from genesis.db.timeutil import canonical_iso
+
 
 def _prepare_fts5(query: str, *, boolean: bool = False) -> str | None:
     """Prepare a query string for FTS5 MATCH.
@@ -263,15 +265,22 @@ async def create_metadata(
     triage, reflection) so foreground recall can default-filter them.
     NULL = user-sourced.
     """
-    resolved_valid_at = valid_at or created_at
+    # Bitemporal columns are raw TEXT-compared everywhere — canonicalize
+    # at the write gate. Unparseable valid_at (LLM temporal strings like
+    # "Friday" or date ranges) falls back to created_at; unparseable
+    # invalid_at is dropped (NULL = valid forever) rather than stored as
+    # a string that breaks the always-on filter.
+    resolved_valid_at = (
+        canonical_iso(valid_at) or canonical_iso(created_at) or created_at
+    )
     await db.execute(
         "INSERT OR IGNORE INTO memory_metadata "
         "(memory_id, created_at, collection, confidence, embedding_status, "
         "memory_class, wing, room, valid_at, invalid_at, source_subsystem) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (memory_id, created_at, collection, confidence, embedding_status,
-         memory_class, wing, room, resolved_valid_at, invalid_at,
-         source_subsystem),
+         memory_class, wing, room, resolved_valid_at,
+         canonical_iso(invalid_at), source_subsystem),
     )
     await db.commit()
     return memory_id
@@ -284,11 +293,18 @@ async def invalidate_memory(
 ) -> bool:
     """Mark a memory as no longer valid (bi-temporal invalidation).
 
-    Returns True if the memory was found and updated.
+    Returns True if the memory was found and updated. Raises
+    ``ValueError`` on an unparseable timestamp — an explicit
+    invalidation with a garbage cutoff is a programming error, and a
+    non-canonical string would silently break the always-on TEXT
+    comparison in ``search_ranked``.
     """
+    canonical = canonical_iso(invalid_at)
+    if canonical is None:
+        raise ValueError(f"invalidate_memory: unparseable invalid_at {invalid_at!r}")
     cursor = await db.execute(
         "UPDATE memory_metadata SET invalid_at = ? WHERE memory_id = ?",
-        (invalid_at, memory_id),
+        (canonical, memory_id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0050_canonicalize_bitemporal_ts.py
+++ b/src/genesis/db/migrations/0050_canonicalize_bitemporal_ts.py
@@ -1,0 +1,78 @@
+"""Canonicalize memory_metadata.valid_at / invalid_at to sortable form.
+
+Every bitemporal read is a raw SQLite TEXT comparison against
+``datetime.now(UTC).isoformat()``, so non-canonical rows compare
+incorrectly: ``Z`` sorts after ``+``, a space separator sorts before
+``T``, naive timestamps sort before their aware twins, and non-UTC
+offsets order by offset string instead of instant. Live census
+(2026-07-09): valid_at — 2,632 Z-suffix, 67 naive-T, 11 non-UTC
+offsets, 10 space/other (LLM temporal strings incl. ranges and words);
+invalid_at — 55 space-format. Date-only valid_at (5,488) is canonical
+by design ("valid from that date") and untouched.
+
+Rules, applied via ``genesis.db.timeutil.canonical_iso`` plus two
+data-repair cases for LLM temporal strings:
+- parseable → canonical UTC ISO (``...T...+00:00``)
+- range ("A/B", "A to B") → start date, date-only form
+- month ("YYYY-MM") → first of month, date-only form
+- unparseable ("Friday", free text) → NULL (honest "unknown onset";
+  the always-on filter treats NULL invalid_at as still-valid, and
+  valid_at is not filtered on today)
+
+Data-only migration: no DDL, idempotent (canonical rows are no-ops on
+re-run). Closes follow-up b80d00c7.
+"""
+
+from __future__ import annotations
+
+import re
+
+import aiosqlite
+
+from genesis.db.timeutil import canonical_iso
+
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+_RANGE_SPLIT_RE = re.compile(r"\s+to\s+|/")
+
+
+def _repair(value: str) -> str | None:
+    """Canonical form for one legacy value, or None if unsalvageable."""
+    canonical = canonical_iso(value)
+    if canonical is not None:
+        return canonical
+    text = value.strip()
+    if _MONTH_RE.match(text):
+        return f"{text}-01"
+    start = _RANGE_SPLIT_RE.split(text)[0].strip()
+    if _DATE_ONLY_RE.match(start):
+        return start
+    return None
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_metadata'"
+    )
+    if not await cursor.fetchone():
+        return
+    for column in ("valid_at", "invalid_at"):
+        rows = await db.execute_fetchall(
+            f"SELECT memory_id, {column} FROM memory_metadata "  # noqa: S608
+            f"WHERE {column} IS NOT NULL"
+        )
+        for memory_id, value in rows:
+            if _DATE_ONLY_RE.match(value) or (
+                "T" in value and value.endswith("+00:00")
+            ):
+                continue  # already canonical
+            await db.execute(
+                f"UPDATE memory_metadata SET {column} = ? "  # noqa: S608
+                f"WHERE memory_id = ?",
+                (_repair(value), memory_id),
+            )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    # Lossy-forward data repair; original strings are not preserved.
+    return

--- a/src/genesis/db/timeutil.py
+++ b/src/genesis/db/timeutil.py
@@ -1,0 +1,46 @@
+"""Canonical bitemporal timestamp handling for SQLite storage.
+
+Every bitemporal comparison in Genesis is a raw SQLite TEXT comparison
+(``invalid_at > ?`` against ``datetime.now(UTC).isoformat()``), so the
+stored format IS the correctness contract. Canonical forms:
+
+- Full timestamps: ``YYYY-MM-DDTHH:MM:SS[.ffffff]+00:00`` (UTC offset,
+  never ``Z``, never naive, never space-separated — all three sort
+  incorrectly against the canonical form in TEXT comparisons).
+- Date-only ``YYYY-MM-DD`` (valid_at only): canonical by design —
+  "valid from that date"; prefix-compares correctly against full ISO
+  cutoffs. See the WS-H design (2026-07-03).
+
+``canonical_iso`` is the single write-path gate; migration 0050
+retrofits the legacy rows.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def canonical_iso(ts: str | None) -> str | None:
+    """Normalize a timestamp string to canonical storage form.
+
+    Returns the canonical string, the input unchanged for date-only
+    values, or ``None`` for empty/unparseable input (callers decide the
+    fallback — ``create_metadata`` falls back to ``created_at`` for
+    ``valid_at``; ``invalidate_memory`` refuses to write garbage).
+    """
+    if not ts or not isinstance(ts, str):
+        return None
+    ts = ts.strip()
+    if _DATE_ONLY_RE.match(ts):
+        return ts
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        # All Genesis writers stamp UTC; naive values are UTC by contract.
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).isoformat()

--- a/tests/test_db/test_migration_0050_bitemporal_canon.py
+++ b/tests/test_db/test_migration_0050_bitemporal_canon.py
@@ -1,0 +1,128 @@
+"""Migration 0050 — bitemporal timestamp canonicalization data repair.
+
+Seeds one row per live format class (2026-07-09 census) and verifies:
+canonical + date-only untouched, Z/naive/space/offset canonicalized,
+ranges → start date, month → first-of-month, free text → NULL, and
+idempotence on re-run. Missing table is a safe no-op (bare-DB runner
+lifecycle). Mirrors 0049's structure.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M50 = importlib.import_module(
+    "genesis.db.migrations.0050_canonicalize_bitemporal_ts"
+)
+
+_DDL = """
+    CREATE TABLE memory_metadata (
+        memory_id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        valid_at TEXT,
+        invalid_at TEXT
+    )
+"""
+
+_SEED = [
+    # (memory_id, valid_at, invalid_at)
+    ("m-canon", "2026-07-09T12:00:00+00:00", "2026-07-09T13:00:00+00:00"),
+    ("m-micro", "2026-07-09T12:00:00.123456+00:00", None),
+    ("m-date", "2026-06-14", None),
+    ("m-z", "2026-05-03T17:30:26Z", None),
+    ("m-naive", "2026-05-03T17:30:26", None),
+    ("m-space", "2026-04-03 13:30:54", "2026-04-03 13:30:54"),
+    ("m-offset", "2026-05-11T17:00:00-04:00", None),
+    ("m-month", "2026-04", None),
+    ("m-range-slash", "2026-03-18/2026-03-28", None),
+    ("m-range-to", "2026-05-13 to 2026-05-18", None),
+    ("m-garbage", "Friday", None),
+    ("m-null", None, None),
+]
+
+_EXPECTED_VALID = {
+    "m-canon": "2026-07-09T12:00:00+00:00",
+    "m-micro": "2026-07-09T12:00:00.123456+00:00",
+    "m-date": "2026-06-14",
+    "m-z": "2026-05-03T17:30:26+00:00",
+    "m-naive": "2026-05-03T17:30:26+00:00",
+    "m-space": "2026-04-03T13:30:54+00:00",
+    "m-offset": "2026-05-11T21:00:00+00:00",
+    "m-month": "2026-04-01",
+    "m-range-slash": "2026-03-18",
+    "m-range-to": "2026-05-13",
+    "m-garbage": None,
+    "m-null": None,
+}
+
+
+async def _seeded_db() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    await db.execute(_DDL)
+    for memory_id, valid_at, invalid_at in _SEED:
+        await db.execute(
+            "INSERT INTO memory_metadata "
+            "(memory_id, created_at, valid_at, invalid_at) VALUES (?, ?, ?, ?)",
+            (memory_id, "2026-07-09T00:00:00+00:00", valid_at, invalid_at),
+        )
+    return db
+
+
+async def _column(db: aiosqlite.Connection, column: str) -> dict[str, str | None]:
+    rows = await db.execute_fetchall(
+        f"SELECT memory_id, {column} FROM memory_metadata"  # noqa: S608
+    )
+    return dict(rows)
+
+
+@pytest.mark.asyncio
+async def test_up_canonicalizes_every_format_class():
+    db = await _seeded_db()
+    try:
+        await M50.up(db)
+        assert await _column(db, "valid_at") == _EXPECTED_VALID
+        invalid = await _column(db, "invalid_at")
+        assert invalid["m-canon"] == "2026-07-09T13:00:00+00:00"
+        assert invalid["m-space"] == "2026-04-03T13:30:54+00:00"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent():
+    db = await _seeded_db()
+    try:
+        await M50.up(db)
+        first = await _column(db, "valid_at")
+        await M50.up(db)
+        assert await _column(db, "valid_at") == first
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_up_missing_table_is_noop():
+    db = await aiosqlite.connect(":memory:")
+    try:
+        await M50.up(db)  # must not raise
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sort_contract_after_repair():
+    """Post-repair, the always-on filter's TEXT comparison is correct."""
+    db = await _seeded_db()
+    try:
+        await M50.up(db)
+        rows = await db.execute_fetchall(
+            "SELECT memory_id FROM memory_metadata "
+            "WHERE invalid_at IS NOT NULL AND invalid_at <= ?",
+            ("2026-04-03T13:30:54+00:00",),
+        )
+        assert {r[0] for r in rows} == {"m-space"}
+    finally:
+        await db.close()

--- a/tests/test_db/test_timeutil.py
+++ b/tests/test_db/test_timeutil.py
@@ -1,0 +1,79 @@
+"""canonical_iso — the single write-path gate for bitemporal timestamps.
+
+Format matrix mirrors the live-DB census (2026-07-09): canonical iso_tz,
+Z-suffix (2,632 rows), naive-T (67), space-separated (55+5), non-UTC
+offsets (11), date-only (5,488 — canonical, untouched), plus the
+unparseable LLM temporal strings ("Friday", ranges, month-only).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.timeutil import canonical_iso
+
+
+def test_none_and_empty():
+    assert canonical_iso(None) is None
+    assert canonical_iso("") is None
+    assert canonical_iso("   ") is None
+
+
+def test_canonical_passthrough():
+    assert (
+        canonical_iso("2026-07-09T12:00:00+00:00") == "2026-07-09T12:00:00+00:00"
+    )
+
+
+def test_canonical_microseconds_preserved():
+    ts = "2026-07-09T12:00:00.123456+00:00"
+    assert canonical_iso(ts) == ts
+
+
+def test_z_suffix_becomes_utc_offset():
+    assert canonical_iso("2026-05-03T17:30:26Z") == "2026-05-03T17:30:26+00:00"
+
+
+def test_naive_t_assumed_utc():
+    assert canonical_iso("2026-05-03T17:30:26") == "2026-05-03T17:30:26+00:00"
+
+
+def test_naive_minute_precision_padded():
+    assert canonical_iso("2026-05-20T22:41") == "2026-05-20T22:41:00+00:00"
+
+
+def test_space_separator_canonicalized():
+    assert canonical_iso("2026-04-03 13:30:54") == "2026-04-03T13:30:54+00:00"
+
+
+def test_non_utc_offset_converted_to_utc():
+    assert (
+        canonical_iso("2026-05-11T17:00:00-04:00") == "2026-05-11T21:00:00+00:00"
+    )
+
+
+def test_date_only_is_canonical_untouched():
+    assert canonical_iso("2026-06-14") == "2026-06-14"
+
+
+@pytest.mark.parametrize(
+    "garbage",
+    [
+        "Friday",
+        "July 3",
+        "commit dfce0319 (PR #58)",
+        "2026-04",
+        "2026-03-18/2026-03-28",
+        "2026-05-13 to 2026-05-18",
+    ],
+)
+def test_unparseable_returns_none(garbage):
+    assert canonical_iso(garbage) is None
+
+
+def test_sort_order_contract():
+    """The point of it all: canonical strings TEXT-compare correctly."""
+    earlier = canonical_iso("2026-05-03T17:30:26Z")
+    later = canonical_iso("2026-05-03 17:30:27")
+    assert earlier is not None and later is not None
+    assert earlier < later

--- a/tests/test_memory/test_bitemporal.py
+++ b/tests/test_memory/test_bitemporal.py
@@ -93,7 +93,8 @@ class TestCreateMetadata:
             ("m1",),
         )
         row = await cursor.fetchone()
-        assert row["valid_at"] == "2026-05-08T12:00:00Z"
+        # Fallback to created_at is canonicalized at the write gate (E1).
+        assert row["valid_at"] == "2026-05-08T12:00:00+00:00"
         assert row["invalid_at"] is None
 
     @pytest.mark.asyncio
@@ -146,10 +147,71 @@ class TestInvalidateMemory:
             ("m1",),
         )
         row = await cursor.fetchone()
-        assert row["invalid_at"] == "2026-05-08T15:00:00Z"
+        # Z-suffix canonicalized at the write gate (E1) — Z sorts after
+        # '+' in the always-on TEXT comparison.
+        assert row["invalid_at"] == "2026-05-08T15:00:00+00:00"
 
     @pytest.mark.asyncio
     async def test_invalidate_nonexistent_returns_false(self, meta_db):
         from genesis.db.crud.memory import invalidate_memory
         result = await invalidate_memory(meta_db, "nonexistent", "2026-05-08")
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_invalidate_garbage_timestamp_raises(self, meta_db):
+        from genesis.db.crud.memory import create_metadata, invalidate_memory
+        await create_metadata(
+            meta_db, memory_id="m1", created_at="2026-05-08T12:00:00+00:00",
+        )
+        with pytest.raises(ValueError, match="unparseable"):
+            await invalidate_memory(meta_db, "m1", "next Friday")
+
+
+class TestWriteGateCanonicalization:
+    """E1 write gate: non-canonical inputs never reach the table."""
+
+    @pytest.mark.asyncio
+    async def test_garbage_valid_at_falls_back_to_created_at(self, meta_db):
+        from genesis.db.crud.memory import create_metadata
+        await create_metadata(
+            meta_db,
+            memory_id="g1",
+            created_at="2026-05-08T12:00:00+00:00",
+            valid_at="Friday",  # LLM temporal string
+        )
+        cursor = await meta_db.execute(
+            "SELECT valid_at FROM memory_metadata WHERE memory_id = ?", ("g1",),
+        )
+        row = await cursor.fetchone()
+        assert row["valid_at"] == "2026-05-08T12:00:00+00:00"
+
+    @pytest.mark.asyncio
+    async def test_garbage_invalid_at_dropped_to_null(self, meta_db):
+        from genesis.db.crud.memory import create_metadata
+        await create_metadata(
+            meta_db,
+            memory_id="g2",
+            created_at="2026-05-08T12:00:00+00:00",
+            invalid_at="soon",
+        )
+        cursor = await meta_db.execute(
+            "SELECT invalid_at FROM memory_metadata WHERE memory_id = ?",
+            ("g2",),
+        )
+        row = await cursor.fetchone()
+        assert row["invalid_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_naive_valid_at_canonicalized(self, meta_db):
+        from genesis.db.crud.memory import create_metadata
+        await create_metadata(
+            meta_db,
+            memory_id="g3",
+            created_at="2026-05-08T12:00:00+00:00",
+            valid_at="2026-05-03T17:30:26",
+        )
+        cursor = await meta_db.execute(
+            "SELECT valid_at FROM memory_metadata WHERE memory_id = ?", ("g3",),
+        )
+        row = await cursor.fetchone()
+        assert row["valid_at"] == "2026-05-03T17:30:26+00:00"


### PR DESCRIPTION
## Summary
First PR of the entity-layer lane (WS-H Pillar 2 pull-forward). Every bitemporal read in Genesis is a raw SQLite TEXT comparison against `datetime.now(UTC).isoformat()`, so the stored format IS the correctness contract. This PR makes the format canonical at the write gate and repairs legacy rows. Closes follow-up `b80d00c7`.

### Live census (2026-07-09) — worse than the follow-up recorded
| format | valid_at | invalid_at | hazard |
|---|---|---|---|
| canonical `...T...+00:00` | 43,344 | 1,128 | — |
| `Z` suffix | **2,632** (follow-up said 1) | 0 | `Z` sorts after `+` |
| naive `T` (no tz) | 67 | 0 | naive sorts before aware |
| space-separated | 5 | 55 | space sorts before `T` |
| non-UTC offset | 11 | 0 | orders by offset string |
| date-only | 5,488 (canonical by design) | 0 | — |
| LLM temporal strings (ranges, "Friday", "2026-04") | 10 | 0 | unorderable |

Origin of the garbage: `extraction.py` passes the LLM's raw `temporal` string straight into `valid_at`.

### Changes
- **`genesis/db/timeutil.py`** — `canonical_iso()`: parseable → canonical UTC ISO; date-only passthrough (canonical per the WS-H design: "valid from that date", prefix-compares correctly); unparseable → None.
- **`db/crud/memory.py`** — `create_metadata` canonicalizes both columns (garbage `valid_at` falls back to `created_at`; garbage `invalid_at` drops to NULL rather than storing a string that breaks the always-on filter). `invalidate_memory` refuses garbage with `ValueError` (zero production callers today; the entity lane's anchor-revision job will be the first).
- **Migration `0050`** — data-only, idempotent repair: ranges → start date, `YYYY-MM` → first-of-month, free text → NULL. Applies at next server startup.

### Blast radius (enumerated)
`create_metadata`: one production caller (`store.py:324`). `invalidate_memory`: zero callers. All live writers already emit canonical values — this gate stops the extraction temporal path and protects the entity layer's edge-validity columns from inheriting the hazard.

## Testing
- 66 passed: `test_db/test_timeutil.py` (16, full format matrix), `test_db/test_migration_0050_bitemporal_canon.py` (4, incl. idempotence + post-repair sort contract), `test_memory/test_bitemporal.py` (extended: write-gate cases), migration-runner lifecycle
- ruff clean on the full diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)