### PR TITLE
feat(memory): entity-layer substrate — entities, mentions, bi-temporal links (E2)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -64,6 +64,15 @@ Easy-to-forget mechanisms:
   (`learning/procedural/matcher.py find_relevant`), not hybrid retrieval.
 - External-world recall results are provenance-wrapped (`wrap_external_recall`)
   — first-party memory vs knowledge-base is a load-bearing distinction.
+- **Entity layer (WS-H Pillar 2)** — typed entity nodes with identity:
+  `entities`/`entity_mentions`/`entity_links` tables (migration 0051),
+  `db/crud/entities.py` (recursive-CTE traversal, bi-temporal edge validity,
+  EXTRACTED/INFERRED/AMBIGUOUS provenance), `memory/entity_registry.py`
+  (string→ID resolution tiering; fuzzy matches queue `entity_adjudication`),
+  `memory/entity_seed.py` (curated spine incl. the repo-split rule).
+  Distinct from `memory/entity_resolution.py`, which is near-duplicate
+  memory-PAIR dedup. Bitemporal timestamps are canonicalized at the write
+  gate (`db/timeutil.canonical_iso`, migration 0050).
 
 **Consolidation (dream cycle)** — `memory/dream_cycle.py` (~1480 LOC):
 weekly clustering (Sun 4am) persists a value-ranked worklist to

--- a/scripts/apply_entity_seed.py
+++ b/scripts/apply_entity_seed.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Apply the curated entity-layer seed to the live DB (idempotent).
+
+Usage:
+    python scripts/apply_entity_seed.py [--db PATH]
+
+Prints counts and the OMI→repo-split spine as a spot-check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+async def main() -> None:
+    import aiosqlite
+
+    from genesis import env as genesis_env
+    from genesis.db.crud import entities as entities_crud
+    from genesis.memory.entity_seed import apply_seed
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", default=None)
+    args = parser.parse_args()
+    db_path = args.db or str(genesis_env.genesis_db_path())
+
+    db = await aiosqlite.connect(db_path)
+    try:
+        counts = await apply_seed(db)
+        print(f"seed applied to {db_path}: {counts}")
+
+        omi = await entities_crud.get_by_norm_name(db, norm_name="omi")
+        if omi:
+            reached = await entities_crud.connected_entities(db, [omi["entity_id"]])
+            names = {}
+            for eid, info in reached.items():
+                row = await entities_crud.get_entity(db, eid)
+                names[row["name"] if row else eid] = (
+                    f"depth={info['depth']} via={info['via_link_type']}"
+                )
+            print(f"spine check — reachable from OMI: {names}")
+            mention_rows = await entities_crud.memories_mentioning(db, list(reached))
+            print(f"mentions on reached entities: {mention_rows}")
+    finally:
+        await db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/genesis/db/crud/entities.py
+++ b/src/genesis/db/crud/entities.py
@@ -1,0 +1,387 @@
+"""CRUD for the entity layer — entities, entity_mentions, entity_links.
+
+WS-H Pillar 2 substrate (Graphiti blueprint): typed entity nodes,
+memory↔entity mentions, and bi-temporal entity↔entity relations with
+provenance tags. Traversal is a plain recursive CTE — entity tables are
+10²–10⁴ rows, so there is deliberately NO NetworkX cache here (that
+machinery exists for the 160K-edge memory_links graph).
+
+Naming note: this is NOT ``memory/entity_resolution.py`` (near-duplicate
+memory-pair dedup) — these are entity NODES with identity.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.timeutil import canonical_iso
+
+# Provenance weights used by traversal path-confidence (mirrored by the
+# session-awareness entity lane; keep in sync deliberately, not by import,
+# so the read lane stays dependency-light).
+PROVENANCE_WEIGHTS = {"EXTRACTED": 1.0, "INFERRED": 0.8, "AMBIGUOUS": 0.5}
+
+_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+_MAX_LINK_TYPE_LEN = 40
+
+
+def slugify_link_type(raw: str) -> str:
+    """Lowercase-snake a (possibly LLM-emitted) relation name.
+
+    Open vocabulary by design — the extraction prompt *suggests* a
+    vocabulary but any sane slug is accepted; a dream-cycle report
+    surfaces sprawl for humans.
+    """
+    slug = _SLUG_RE.sub("_", raw.strip().lower()).strip("_")
+    return slug[:_MAX_LINK_TYPE_LEN] or "related_to"
+
+
+async def create_entity(
+    db: aiosqlite.Connection,
+    *,
+    name: str,
+    norm_name: str,
+    entity_type: str,
+    summary: str | None = None,
+    source: str = "extracted",
+    _commit: bool = True,
+) -> str:
+    """Insert an entity. Returns entity_id (existing id on norm collision)."""
+    now = datetime.now(UTC).isoformat()
+    entity_id = str(uuid.uuid4())
+    cursor = await db.execute(
+        "INSERT OR IGNORE INTO entities "
+        "(entity_id, name, norm_name, entity_type, summary, source, "
+        "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (entity_id, name, norm_name, entity_type, summary, source, now, now),
+    )
+    if cursor.rowcount == 0:  # UNIQUE(norm_name, entity_type) collision
+        row = await get_by_norm_name(db, norm_name=norm_name, entity_type=entity_type)
+        entity_id = row["entity_id"]
+    if _commit:
+        await db.commit()
+    return entity_id
+
+
+async def get_by_norm_name(
+    db: aiosqlite.Connection,
+    *,
+    norm_name: str,
+    entity_type: str | None = None,
+) -> dict | None:
+    """Exact norm_name lookup, optionally type-filtered. Follows merges."""
+    if entity_type is not None:
+        rows = await db.execute_fetchall(
+            "SELECT * FROM entities WHERE norm_name = ? AND entity_type = ?",
+            (norm_name, entity_type),
+        )
+    else:
+        rows = await db.execute_fetchall(
+            "SELECT * FROM entities WHERE norm_name = ?", (norm_name,),
+        )
+    if not rows:
+        return None
+    entity = _row_to_dict(db, rows[0])
+    if entity["status"] == "merged" and entity["merged_into"]:
+        survivor = await get_entity(db, entity["merged_into"])
+        return survivor or entity
+    return entity
+
+
+async def get_entity(db: aiosqlite.Connection, entity_id: str) -> dict | None:
+    rows = await db.execute_fetchall(
+        "SELECT * FROM entities WHERE entity_id = ?", (entity_id,),
+    )
+    return _row_to_dict(db, rows[0]) if rows else None
+
+
+async def list_norm_names(
+    db: aiosqlite.Connection,
+    *,
+    entity_types: list[str] | None = None,
+) -> list[tuple[str, str, str]]:
+    """(norm_name, entity_id, entity_type) for active entities.
+
+    Feeds the registry's fuzzy tier; entity counts are small enough to
+    scan in-process.
+    """
+    if entity_types:
+        ph = ",".join("?" * len(entity_types))
+        rows = await db.execute_fetchall(
+            f"SELECT norm_name, entity_id, entity_type FROM entities "  # noqa: S608
+            f"WHERE status = 'active' AND entity_type IN ({ph})",
+            entity_types,
+        )
+    else:
+        rows = await db.execute_fetchall(
+            "SELECT norm_name, entity_id, entity_type FROM entities "
+            "WHERE status = 'active'",
+        )
+    return [(r[0], r[1], r[2]) for r in rows]
+
+
+async def upsert_mention(
+    db: aiosqlite.Connection,
+    *,
+    memory_id: str,
+    entity_id: str,
+    provenance: str,
+    confidence: float = 0.7,
+    source: str | None = None,
+    _commit: bool = True,
+) -> None:
+    """Record memory↔entity mention. Existing rows keep the STRONGER claim."""
+    await db.execute(
+        "INSERT INTO entity_mentions "
+        "(memory_id, entity_id, provenance, confidence, source, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT(memory_id, entity_id) DO UPDATE SET "
+        "provenance = excluded.provenance, confidence = excluded.confidence, "
+        "source = excluded.source "
+        "WHERE excluded.confidence > entity_mentions.confidence",
+        (
+            memory_id, entity_id, provenance, confidence, source,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    if _commit:
+        await db.commit()
+
+
+async def upsert_link(
+    db: aiosqlite.Connection,
+    *,
+    source_id: str,
+    target_id: str,
+    link_type: str,
+    provenance: str,
+    confidence: float = 0.7,
+    evidence_memory_id: str | None = None,
+    valid_at: str | None = None,
+    _commit: bool = True,
+) -> None:
+    """Record a typed entity relation. Bi-temporal columns canonicalized."""
+    await db.execute(
+        "INSERT INTO entity_links "
+        "(source_id, target_id, link_type, provenance, confidence, "
+        "evidence_memory_id, valid_at, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT(source_id, target_id, link_type) DO UPDATE SET "
+        "provenance = excluded.provenance, confidence = excluded.confidence, "
+        "evidence_memory_id = excluded.evidence_memory_id "
+        "WHERE excluded.confidence > entity_links.confidence",
+        (
+            source_id, target_id, slugify_link_type(link_type), provenance,
+            confidence, evidence_memory_id, canonical_iso(valid_at),
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    if _commit:
+        await db.commit()
+
+
+async def invalidate_links_for_entity(
+    db: aiosqlite.Connection,
+    *,
+    entity_id: str,
+    invalid_at: str,
+    invalidated_by: str,
+    _commit: bool = True,
+) -> int:
+    """Close the validity interval on all live links touching an entity."""
+    canonical = canonical_iso(invalid_at)
+    if canonical is None:
+        raise ValueError(f"unparseable invalid_at {invalid_at!r}")
+    cursor = await db.execute(
+        "UPDATE entity_links SET invalid_at = ?, invalidated_by = ? "
+        "WHERE (source_id = ? OR target_id = ?) AND invalid_at IS NULL",
+        (canonical, invalidated_by, entity_id, entity_id),
+    )
+    if _commit:
+        await db.commit()
+    return cursor.rowcount
+
+
+async def connected_entities(
+    db: aiosqlite.Connection,
+    entity_ids: list[str],
+    *,
+    max_depth: int = 2,
+    as_of: str | None = None,
+) -> dict[str, dict]:
+    """Entities reachable within *max_depth* undirected valid hops.
+
+    Returns ``{entity_id: {depth, path_confidence, via_link_type}}`` for
+    reached entities (seeds excluded), keeping the strongest path per
+    entity. Edge validity: ``valid_at <= as_of`` (NULL = always) and
+    ``invalid_at`` NULL or ``> as_of``. Path confidence multiplies edge
+    ``confidence × provenance_weight`` per hop.
+    """
+    if not entity_ids:
+        return {}
+    as_of = canonical_iso(as_of) or datetime.now(UTC).isoformat()
+    seeds = set(entity_ids)
+    frontier: dict[str, float] = {eid: 1.0 for eid in seeds}
+    reached: dict[str, dict] = {}
+    for depth in range(1, max_depth + 1):
+        if not frontier:
+            break
+        ph = ",".join("?" * len(frontier))
+        ids = list(frontier)
+        rows = await db.execute_fetchall(
+            f"SELECT source_id, target_id, link_type, provenance, confidence "  # noqa: S608
+            f"FROM entity_links "
+            f"WHERE (source_id IN ({ph}) OR target_id IN ({ph})) "
+            f"AND (valid_at IS NULL OR valid_at <= ?) "
+            f"AND (invalid_at IS NULL OR invalid_at > ?)",
+            ids + ids + [as_of, as_of],
+        )
+        next_frontier: dict[str, float] = {}
+        for source_id, target_id, link_type, provenance, confidence in rows:
+            for here, there in ((source_id, target_id), (target_id, source_id)):
+                if here not in frontier or there in seeds:
+                    continue
+                path_conf = (
+                    frontier[here]
+                    * confidence
+                    * PROVENANCE_WEIGHTS.get(provenance, 0.5)
+                )
+                prior = reached.get(there)
+                if prior is None or path_conf > prior["path_confidence"]:
+                    reached[there] = {
+                        "depth": depth,
+                        "path_confidence": path_conf,
+                        "via_link_type": link_type,
+                    }
+                    next_frontier[there] = max(
+                        next_frontier.get(there, 0.0), path_conf
+                    )
+        frontier = next_frontier
+    return reached
+
+
+async def memories_mentioning(
+    db: aiosqlite.Connection,
+    entity_ids: list[str],
+    *,
+    limit_per_entity: int = 20,
+) -> list[dict]:
+    """Mention rows for *entity_ids*, strongest first per entity."""
+    if not entity_ids:
+        return []
+    out: list[dict] = []
+    for entity_id in entity_ids:
+        rows = await db.execute_fetchall(
+            "SELECT memory_id, entity_id, provenance, confidence, source "
+            "FROM entity_mentions WHERE entity_id = ? "
+            "ORDER BY confidence DESC LIMIT ?",
+            (entity_id, limit_per_entity),
+        )
+        out.extend(
+            {
+                "memory_id": r[0],
+                "entity_id": r[1],
+                "provenance": r[2],
+                "confidence": r[3],
+                "source": r[4],
+            }
+            for r in rows
+        )
+    return out
+
+
+async def merge_entity(
+    db: aiosqlite.Connection,
+    *,
+    loser_id: str,
+    survivor_id: str,
+    _commit: bool = True,
+) -> None:
+    """Adjudicated merge: rewrite loser's mentions/links to the survivor."""
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        "INSERT OR IGNORE INTO entity_mentions "
+        "(memory_id, entity_id, provenance, confidence, source, created_at) "
+        "SELECT memory_id, ?, provenance, confidence, source, created_at "
+        "FROM entity_mentions WHERE entity_id = ?",
+        (survivor_id, loser_id),
+    )
+    await db.execute(
+        "DELETE FROM entity_mentions WHERE entity_id = ?", (loser_id,),
+    )
+    for src_col, dst_col in (("source_id", "target_id"), ("target_id", "source_id")):
+        await db.execute(
+            f"INSERT OR IGNORE INTO entity_links "  # noqa: S608
+            f"({src_col}, {dst_col}, link_type, provenance, confidence, "
+            f"evidence_memory_id, valid_at, invalid_at, invalidated_by, created_at) "
+            f"SELECT ?, {dst_col}, link_type, provenance, confidence, "
+            f"evidence_memory_id, valid_at, invalid_at, invalidated_by, created_at "
+            f"FROM entity_links WHERE {src_col} = ?",
+            (survivor_id, loser_id),
+        )
+        await db.execute(
+            f"DELETE FROM entity_links WHERE {src_col} = ?",  # noqa: S608
+            (loser_id,),
+        )
+    await db.execute(
+        "UPDATE entities SET status = 'merged', merged_into = ?, updated_at = ? "
+        "WHERE entity_id = ?",
+        (survivor_id, now, loser_id),
+    )
+    if _commit:
+        await db.commit()
+
+
+async def enqueue_adjudication(
+    db: aiosqlite.Connection,
+    *,
+    entity_id: str,
+    similar_entity_id: str,
+    _commit: bool = True,
+) -> None:
+    """Queue a fuzzy-match pair for LLM adjudication (entity_maintenance job).
+
+    Inline INSERT rather than ``deferred_work.create`` — that helper
+    commits unconditionally, which would break callers batching under
+    ``_commit=False`` (extraction transaction discipline).
+    """
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        """INSERT INTO deferred_work_queue
+           (id, work_type, priority, payload_json, deferred_at,
+            deferred_reason, created_at)
+           VALUES (?, 'entity_adjudication', 60, ?, ?, ?, ?)""",
+        (
+            str(uuid.uuid4()),
+            json.dumps(
+                {"entity_id": entity_id, "similar_entity_id": similar_entity_id}
+            ),
+            now,
+            "fuzzy norm_name match at entity creation",
+            now,
+        ),
+    )
+    if _commit:
+        await db.commit()
+
+
+def _row_to_dict(db: aiosqlite.Connection, row) -> dict:
+    if isinstance(row, aiosqlite.Row) or hasattr(row, "keys"):
+        return dict(row)
+    return {
+        "entity_id": row[0],
+        "name": row[1],
+        "norm_name": row[2],
+        "entity_type": row[3],
+        "summary": row[4],
+        "source": row[5],
+        "status": row[6],
+        "merged_into": row[7],
+        "created_at": row[8],
+        "updated_at": row[9],
+    }

--- a/src/genesis/db/migrations/0051_entity_layer.py
+++ b/src/genesis/db/migrations/0051_entity_layer.py
@@ -1,0 +1,32 @@
+"""Entity layer substrate — entities, entity_mentions, entity_links.
+
+WS-H Pillar 2 (Graphiti blueprint on the SQLite+Qdrant substrate):
+typed entity nodes, memory↔entity mentions with provenance tags
+(EXTRACTED/INFERRED/AMBIGUOUS), and bi-temporal entity↔entity relations
+with an open link_type vocabulary (LLM-first; deliberately NOT the
+memory_links CHECK registry). Canonical DDL lives in
+``db/schema/_tables.py``; this migration brings existing DBs to the
+same shape. Additive + idempotent.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_ENTITY_TABLES = ("entities", "entity_mentions", "entity_links")
+_ENTITY_INDEX_PREFIXES = ("idx_entities_", "idx_entity_")
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    from genesis.db.schema._tables import INDEXES, TABLES
+
+    for name in _ENTITY_TABLES:
+        await db.execute(TABLES[name])
+    for ddl in INDEXES:
+        if any(prefix in ddl for prefix in _ENTITY_INDEX_PREFIXES):
+            await db.execute(ddl)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    for name in reversed(_ENTITY_TABLES):
+        await db.execute(f"DROP TABLE IF EXISTS {name}")  # noqa: S608

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1566,6 +1566,62 @@ TABLES = {
             created_at      TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """,
+    # Entity layer (WS-H Pillar 2, Graphiti blueprint on SQLite+Qdrant).
+    # NOTE: distinct from memory-pair dedup ("entity resolution" in
+    # memory/entity_resolution.py) — these are typed entity NODES.
+    "entities": """
+        CREATE TABLE IF NOT EXISTS entities (
+            entity_id   TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            norm_name   TEXT NOT NULL,
+            entity_type TEXT NOT NULL CHECK (entity_type IN (
+                'code_file','code_symbol','pr','commit',
+                'product','device','repo','subsystem','person','org','concept'
+            )),
+            summary     TEXT,
+            source      TEXT NOT NULL DEFAULT 'extracted',
+            status      TEXT NOT NULL DEFAULT 'active'
+                            CHECK (status IN ('active','merged','gone')),
+            merged_into TEXT,
+            created_at  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL,
+            UNIQUE (norm_name, entity_type)
+        )
+    """,
+    "entity_mentions": """
+        CREATE TABLE IF NOT EXISTS entity_mentions (
+            memory_id  TEXT NOT NULL,
+            entity_id  TEXT NOT NULL,
+            provenance TEXT NOT NULL CHECK (
+                provenance IN ('EXTRACTED','INFERRED','AMBIGUOUS')
+            ),
+            confidence REAL NOT NULL DEFAULT 0.7,
+            source     TEXT,
+            created_at TEXT NOT NULL,
+            -- No validity columns: "M mentions E" is an event-time fact;
+            -- memory-level validity lives in memory_metadata.
+            PRIMARY KEY (memory_id, entity_id)
+        )
+    """,
+    "entity_links": """
+        CREATE TABLE IF NOT EXISTS entity_links (
+            source_id          TEXT NOT NULL,
+            target_id          TEXT NOT NULL,
+            -- Free-form slug by design (LLM-first open vocabulary);
+            -- deliberately NOT the memory_links CHECK registry.
+            link_type          TEXT NOT NULL,
+            provenance         TEXT NOT NULL CHECK (
+                provenance IN ('EXTRACTED','INFERRED','AMBIGUOUS')
+            ),
+            confidence         REAL NOT NULL DEFAULT 0.7,
+            evidence_memory_id TEXT,
+            valid_at           TEXT,
+            invalid_at         TEXT,
+            invalidated_by     TEXT,
+            created_at         TEXT NOT NULL,
+            PRIMARY KEY (source_id, target_id, link_type)
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -1685,6 +1741,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_deferred_work_status ON deferred_work_queue(status)",
     "CREATE INDEX IF NOT EXISTS idx_deferred_work_priority ON deferred_work_queue(priority)",
     "CREATE INDEX IF NOT EXISTS idx_deferred_work_type ON deferred_work_queue(work_type)",
+    "CREATE INDEX IF NOT EXISTS idx_entities_norm ON entities(norm_name)",
+    "CREATE INDEX IF NOT EXISTS idx_entity_mentions_entity ON entity_mentions(entity_id)",
+    "CREATE INDEX IF NOT EXISTS idx_entity_links_target ON entity_links(target_id)",
     # pending embeddings
     "CREATE INDEX IF NOT EXISTS idx_pending_embeddings_status ON pending_embeddings(status)",
     "CREATE INDEX IF NOT EXISTS idx_pending_embeddings_memory ON pending_embeddings(memory_id)",

--- a/src/genesis/memory/entity_registry.py
+++ b/src/genesis/memory/entity_registry.py
@@ -1,0 +1,124 @@
+"""Entity registry — string → entity-ID resolution with write-time tiering.
+
+WS-H Pillar 2. Resolution never calls an LLM inline; ambiguity is
+recorded (AMBIGUOUS provenance) and queued for dream-window adjudication
+on the ``deferred_work_queue`` (``entity_adjudication`` rows, drained by
+the entity_maintenance job).
+
+Tiers:
+1. Mechanical anchors (code_file/code_symbol/pr/commit) — norm_name is
+   the literal identifier; exact match or create. Zero ambiguity.
+2. Named exact — ``normalize_content(name).lower()`` match on
+   (norm_name, entity_type); cross-type reuse inside the concept cluster.
+3. Named fuzzy (difflib ≥ 0.85 against same-cluster norm_names) —
+   create anyway, tag AMBIGUOUS, enqueue adjudication.
+4. Else create, EXTRACTED.
+
+Distinct from ``memory/entity_resolution.py`` (near-duplicate memory-pair
+dedup) — that module contributes only ``normalize_content`` alias
+rewriting here.
+"""
+
+from __future__ import annotations
+
+import difflib
+
+import aiosqlite
+
+from genesis.db.crud import entities as entities_crud
+from genesis.memory.entity_resolution import load_aliases, normalize_content
+
+MECHANICAL_TYPES = frozenset({"code_file", "code_symbol", "pr", "commit"})
+
+# Named types that may share identity across type labels (the LLM may
+# call OMI a "product" in one extraction and a "device" in another).
+_CONCEPT_CLUSTER = frozenset({"product", "device", "concept", "subsystem", "repo"})
+
+FUZZY_THRESHOLD = 0.85
+
+
+def norm(name: str, aliases: dict[str, str] | None = None) -> str:
+    """Canonical lowercase form — MUST match the session-awareness
+    ledger's keyword normalization (both route through
+    ``normalize_content``) so ledger keys equal norm_names."""
+    if aliases is None:
+        aliases = load_aliases()
+    return normalize_content(name.strip(), aliases).strip().lower()
+
+
+async def resolve_entity(
+    db: aiosqlite.Connection,
+    *,
+    name: str,
+    entity_type: str,
+    source: str = "extracted",
+    aliases: dict[str, str] | None = None,
+    _commit: bool = True,
+) -> tuple[str, str]:
+    """Resolve *name* to an entity id, creating if needed.
+
+    Returns ``(entity_id, provenance)`` where provenance is EXTRACTED
+    for confident identity and AMBIGUOUS when a fuzzy near-match was
+    detected (adjudication queued).
+    """
+    norm_name = norm(name, aliases)
+    if not norm_name:
+        raise ValueError(f"unresolvable empty entity name {name!r}")
+
+    # Tier 1 — mechanical: exact identity by construction.
+    if entity_type in MECHANICAL_TYPES:
+        entity_id = await entities_crud.create_entity(
+            db, name=name, norm_name=norm_name, entity_type=entity_type,
+            source=source, _commit=_commit,
+        )
+        return entity_id, "EXTRACTED"
+
+    # Tier 2 — named exact (same type, then concept-cluster cross-type).
+    existing = await entities_crud.get_by_norm_name(
+        db, norm_name=norm_name, entity_type=entity_type,
+    )
+    if existing is None and entity_type in _CONCEPT_CLUSTER:
+        any_type = await entities_crud.get_by_norm_name(db, norm_name=norm_name)
+        if any_type is not None and any_type["entity_type"] in _CONCEPT_CLUSTER:
+            existing = any_type
+    if existing is not None:
+        return existing["entity_id"], "EXTRACTED"
+
+    # Tier 3 — fuzzy against the cluster (or same type for person/org).
+    cluster = (
+        list(_CONCEPT_CLUSTER)
+        if entity_type in _CONCEPT_CLUSTER
+        else [entity_type]
+    )
+    candidates = await entities_crud.list_norm_names(db, entity_types=cluster)
+    near = _closest(norm_name, candidates)
+    entity_id = await entities_crud.create_entity(
+        db, name=name, norm_name=norm_name, entity_type=entity_type,
+        source=source, _commit=False,
+    )
+    if near is not None:
+        await entities_crud.enqueue_adjudication(
+            db, entity_id=entity_id, similar_entity_id=near, _commit=False,
+        )
+        if _commit:
+            await db.commit()
+        return entity_id, "AMBIGUOUS"
+
+    # Tier 4 — genuinely new.
+    if _commit:
+        await db.commit()
+    return entity_id, "EXTRACTED"
+
+
+def _closest(
+    norm_name: str, candidates: list[tuple[str, str, str]]
+) -> str | None:
+    """entity_id of the nearest same-cluster norm_name above threshold."""
+    best_id, best_ratio = None, FUZZY_THRESHOLD
+    for cand_norm, cand_id, _cand_type in candidates:
+        if cand_norm == norm_name:
+            continue
+        ratio = difflib.SequenceMatcher(None, norm_name, cand_norm).ratio()
+        if ratio >= best_ratio:
+            best_id, best_ratio = cand_id, ratio
+    return best_id

--- a/src/genesis/memory/entity_resolution.py
+++ b/src/genesis/memory/entity_resolution.py
@@ -7,6 +7,11 @@ Three capabilities:
 4. **Audit logging** — every resolution action logged for post-hoc review
 
 Used by the dream cycle entity resolution phase and the store pipeline.
+
+NAMING NOTE: "entity" here means a near-duplicate MEMORY PAIR, not a
+typed entity node — those live in the entity layer (``entity_registry``
+/ ``db/crud/entities.py``, WS-H Pillar 2), which uses only
+``normalize_content`` from this module.
 """
 
 from __future__ import annotations

--- a/src/genesis/memory/entity_seed.py
+++ b/src/genesis/memory/entity_seed.py
@@ -1,0 +1,112 @@
+"""Curated entity-layer seed — high-recall entities + the repo-split spine.
+
+Idempotent: entities land via INSERT OR IGNORE on (norm_name, type);
+relations/mentions upsert keeping the stronger claim. Run via
+``scripts/apply_entity_seed.py`` (also safe to re-run after edits).
+
+The seed is deliberately SMALL (~20): identity anchors the acceptance
+test and the FTS backfill need. Everything else accrues organically via
+extraction (forward-only, per the approved hybrid backfill).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from genesis.db.crud import entities as entities_crud
+from genesis.memory.entity_registry import norm
+
+SEED_SOURCE = "seed"
+SEED_CONFIDENCE = 0.95
+
+# (name, entity_type, summary)
+SEED_ENTITIES: list[tuple[str, str, str]] = [
+    ("OMI", "device", "Wearable always-on AI mic (omi.me); evaluated, not adopted"),
+    ("HAOS Voice PE", "device", "Home Assistant Voice Preview Edition — the invested edge device"),
+    ("voice-edge-device", "concept", "Category: voice/edge hardware endpoints (wearables, smart speakers)"),
+    ("GENesis-Voice", "repo", "Public repo for voice/edge-device software (firmware, esphome, bridges)"),
+    ("GENesis-AGI", "repo", "Public primary repo — the Genesis cognitive core"),
+    ("genesis-backups", "repo", "Private encrypted backups repo"),
+    ("genesis-voice-repo-split", "concept", "Decision: voice/edge work lives in GENesis-Voice, not GENesis-AGI"),
+    ("Genesis", "product", "The autonomous AI agent system itself"),
+    ("Claude Code", "product", "Anthropic CLI agent — Genesis's cognitive substrate"),
+    ("Qdrant", "product", "Vector store backing semantic memory"),
+    ("SQLite", "product", "Primary structured store (genesis.db)"),
+    ("Ollama", "product", "Optional local model server"),
+    ("Telegram", "product", "Primary outreach/approval channel"),
+    ("Discord", "product", "Campaign/community channel"),
+    ("Home Assistant", "product", "Smart-home platform hosting the voice pipeline"),
+    ("ESPHome", "product", "Firmware toolchain for the Voice PE device"),
+    ("Tailscale", "product", "Overlay network between Genesis nodes"),
+    ("memory system", "subsystem", "Genesis memory: SQLite+Qdrant, 4-layer recall"),
+    ("session awareness", "subsystem", "Ambient session-theme layer (WS-C): EMA, drift trigger, arbiter"),
+    ("guardian", "subsystem", "Host-VM watchdog deployed via update.sh"),
+    ("dashboard", "subsystem", "Flask web UI on the host proxy"),
+]
+
+# (source_name, link_type, target_name, valid_at)
+SEED_RELATIONS: list[tuple[str, str, str, str | None]] = [
+    ("OMI", "is_a", "voice-edge-device", None),
+    ("HAOS Voice PE", "is_a", "voice-edge-device", None),
+    # The OMI-incident spine: category → the repo-split decision.
+    ("voice-edge-device", "constrained_by", "genesis-voice-repo-split", "2026-06-14"),
+    ("genesis-voice-repo-split", "governs", "GENesis-Voice", "2026-06-14"),
+    ("HAOS Voice PE", "depends_on", "ESPHome", None),
+    ("HAOS Voice PE", "depends_on", "Home Assistant", None),
+    ("session awareness", "part_of", "memory system", None),
+    ("memory system", "part_of", "Genesis", None),
+    ("Genesis", "depends_on", "Claude Code", None),
+    ("memory system", "depends_on", "Qdrant", None),
+    ("memory system", "depends_on", "SQLite", None),
+]
+
+# (entity_name, memory_id) — hand-anchored mentions; the FTS backfill
+# (E3) adds the organic ones.
+SEED_MENTIONS: list[tuple[str, str]] = [
+    # The GENesis-Voice repo-split decision memory (OMI-incident target).
+    ("genesis-voice-repo-split", "9d36f039-3126-4721-8c71-027df1a94e2a"),
+]
+
+
+async def apply_seed(db: aiosqlite.Connection) -> dict:
+    """Apply the full seed. Returns counts. Idempotent."""
+    aliases = None  # load once inside norm() per call is fine at this scale
+    ids: dict[str, str] = {}
+    for name, entity_type, summary in SEED_ENTITIES:
+        entity_id = await entities_crud.create_entity(
+            db,
+            name=name,
+            norm_name=norm(name, aliases),
+            entity_type=entity_type,
+            summary=summary,
+            source=SEED_SOURCE,
+            _commit=False,
+        )
+        ids[name] = entity_id
+    for source_name, link_type, target_name, valid_at in SEED_RELATIONS:
+        await entities_crud.upsert_link(
+            db,
+            source_id=ids[source_name],
+            target_id=ids[target_name],
+            link_type=link_type,
+            provenance="EXTRACTED",
+            confidence=SEED_CONFIDENCE,
+            valid_at=valid_at,
+            _commit=False,
+        )
+    for entity_name, memory_id in SEED_MENTIONS:
+        await entities_crud.upsert_mention(
+            db,
+            memory_id=memory_id,
+            entity_id=ids[entity_name],
+            provenance="EXTRACTED",
+            confidence=SEED_CONFIDENCE,
+            source=SEED_SOURCE,
+            _commit=False,
+        )
+    await db.commit()
+    return {
+        "entities": len(SEED_ENTITIES),
+        "relations": len(SEED_RELATIONS),
+        "mentions": len(SEED_MENTIONS),
+    }

--- a/tests/test_db/test_migration_0051_entity_layer.py
+++ b/tests/test_db/test_migration_0051_entity_layer.py
@@ -1,0 +1,64 @@
+"""Migration 0051 — entity layer tables (entities/mentions/links)."""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M51 = importlib.import_module("genesis.db.migrations.0051_entity_layer")
+
+_TABLES = ("entities", "entity_mentions", "entity_links")
+
+
+async def _tables(db: aiosqlite.Connection) -> set[str]:
+    rows = await db.execute_fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    return {r[0] for r in rows}
+
+
+async def _indexes(db: aiosqlite.Connection) -> set[str]:
+    rows = await db.execute_fetchall(
+        "SELECT name FROM sqlite_master WHERE type='index'"
+    )
+    return {r[0] for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_up_creates_tables_and_indexes():
+    db = await aiosqlite.connect(":memory:")
+    try:
+        await M51.up(db)
+        tables = await _tables(db)
+        assert all(t in tables for t in _TABLES)
+        indexes = await _indexes(db)
+        assert "idx_entities_norm" in indexes
+        assert "idx_entity_mentions_entity" in indexes
+        assert "idx_entity_links_target" in indexes
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_up_idempotent():
+    db = await aiosqlite.connect(":memory:")
+    try:
+        await M51.up(db)
+        await M51.up(db)  # must not raise
+        tables = await _tables(db)
+        assert all(t in tables for t in _TABLES)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_down_drops():
+    db = await aiosqlite.connect(":memory:")
+    try:
+        await M51.up(db)
+        await M51.down(db)
+        assert not (await _tables(db)) & set(_TABLES)
+    finally:
+        await db.close()

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -30,6 +30,9 @@ EXPECTED_TABLES = [
     "message_queue",
     "cc_sessions",
     "memory_links",
+    "entities",
+    "entity_mentions",
+    "entity_links",
     "inbox_items",
     "deferred_work_queue",
     "pending_embeddings",
@@ -111,6 +114,7 @@ async def test_no_unexpected_tables(db):
         "ego_calibration_snapshots",  # measure-only ego calibration
         "otel_spans",  # tracing/spans backbone
         "cognitive_file_modifications",  # cognitive self-mod rollback ledger
+        "entities", "entity_mentions", "entity_links",  # entity layer (WS-H P2)
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_memory/test_entity_layer.py
+++ b/tests/test_memory/test_entity_layer.py
@@ -1,0 +1,228 @@
+"""Entity layer substrate (E2): crud, registry tiering, seed spine.
+
+The acceptance-critical invariant: OMI →is_a→ voice-edge-device
+→constrained_by→ genesis-voice-repo-split, whose mention row anchors the
+GENesis-Voice repo-split memory — reachable in ≤2 undirected valid hops.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from genesis.db.crud import entities as entities_crud
+from genesis.db.schema._tables import TABLES
+from genesis.memory import entity_registry
+from genesis.memory.entity_seed import SEED_MENTIONS, apply_seed
+
+
+@pytest_asyncio.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    for table in ("entities", "entity_mentions", "entity_links",
+                  "deferred_work_queue"):
+        await conn.execute(TABLES[table])
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+# Registry resolution never hits the alias YAML in tests.
+_NO_ALIASES: dict[str, str] = {}
+
+
+async def _mk(db, name, entity_type="concept", **kw):
+    return await entities_crud.create_entity(
+        db, name=name, norm_name=name.lower(), entity_type=entity_type, **kw
+    )
+
+
+class TestCrud:
+    @pytest.mark.asyncio
+    async def test_create_collision_returns_existing(self, db):
+        first = await _mk(db, "Qdrant", "product")
+        second = await _mk(db, "Qdrant", "product")
+        assert first == second
+
+    @pytest.mark.asyncio
+    async def test_mention_upsert_keeps_stronger(self, db):
+        eid = await _mk(db, "Qdrant", "product")
+        await entities_crud.upsert_mention(
+            db, memory_id="m1", entity_id=eid, provenance="EXTRACTED",
+            confidence=0.9,
+        )
+        await entities_crud.upsert_mention(
+            db, memory_id="m1", entity_id=eid, provenance="INFERRED",
+            confidence=0.4,
+        )
+        rows = await entities_crud.memories_mentioning(db, [eid])
+        assert rows[0]["confidence"] == 0.9
+        assert rows[0]["provenance"] == "EXTRACTED"
+
+    @pytest.mark.asyncio
+    async def test_link_type_slugified(self, db):
+        a = await _mk(db, "a")
+        b = await _mk(db, "b")
+        await entities_crud.upsert_link(
+            db, source_id=a, target_id=b, link_type="Is A!",
+            provenance="EXTRACTED",
+        )
+        rows = await db.execute_fetchall(
+            "SELECT link_type FROM entity_links"
+        )
+        assert rows[0][0] == "is_a"
+
+    @pytest.mark.asyncio
+    async def test_connected_entities_two_hops_undirected(self, db):
+        omi = await _mk(db, "omi", "device")
+        cat = await _mk(db, "voice-edge-device")
+        rule = await _mk(db, "repo-split")
+        await entities_crud.upsert_link(
+            db, source_id=omi, target_id=cat, link_type="is_a",
+            provenance="EXTRACTED", confidence=0.95,
+        )
+        await entities_crud.upsert_link(
+            db, source_id=cat, target_id=rule, link_type="constrained_by",
+            provenance="EXTRACTED", confidence=0.95,
+        )
+        reached = await entities_crud.connected_entities(db, [omi])
+        assert reached[cat]["depth"] == 1
+        assert reached[rule]["depth"] == 2
+        assert reached[rule]["via_link_type"] == "constrained_by"
+        # sibling via undirected hop through the category
+        pe = await _mk(db, "haos voice pe", "device")
+        await entities_crud.upsert_link(
+            db, source_id=pe, target_id=cat, link_type="is_a",
+            provenance="EXTRACTED",
+        )
+        reached = await entities_crud.connected_entities(db, [omi])
+        assert pe in reached  # OMI → category → sibling device
+
+    @pytest.mark.asyncio
+    async def test_connected_entities_validity_filter(self, db):
+        a = await _mk(db, "a")
+        b = await _mk(db, "b")
+        await entities_crud.upsert_link(
+            db, source_id=a, target_id=b, link_type="related_to",
+            provenance="EXTRACTED",
+        )
+        n = await entities_crud.invalidate_links_for_entity(
+            db, entity_id=b, invalid_at="2026-01-01T00:00:00+00:00",
+            invalidated_by="test",
+        )
+        assert n == 1
+        reached = await entities_crud.connected_entities(db, [a])
+        assert reached == {}
+        # as_of BEFORE the invalidation still sees the edge
+        reached = await entities_crud.connected_entities(
+            db, [a], as_of="2025-12-01T00:00:00+00:00",
+        )
+        assert b in reached
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_provenance_weakens_path(self, db):
+        a = await _mk(db, "a")
+        b = await _mk(db, "b")
+        await entities_crud.upsert_link(
+            db, source_id=a, target_id=b, link_type="related_to",
+            provenance="AMBIGUOUS", confidence=1.0,
+        )
+        reached = await entities_crud.connected_entities(db, [a])
+        assert reached[b]["path_confidence"] == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_merge_rewrites_mentions_and_links(self, db):
+        loser = await _mk(db, "qdrantdb", "product")
+        survivor = await _mk(db, "qdrant", "product")
+        other = await _mk(db, "genesis", "product")
+        await entities_crud.upsert_mention(
+            db, memory_id="m1", entity_id=loser, provenance="EXTRACTED",
+        )
+        await entities_crud.upsert_link(
+            db, source_id=loser, target_id=other, link_type="part_of",
+            provenance="EXTRACTED",
+        )
+        await entities_crud.merge_entity(db, loser_id=loser, survivor_id=survivor)
+        rows = await entities_crud.memories_mentioning(db, [survivor])
+        assert rows and rows[0]["memory_id"] == "m1"
+        reached = await entities_crud.connected_entities(db, [survivor])
+        assert other in reached
+        # norm lookup on the loser follows the merge to the survivor
+        resolved = await entities_crud.get_by_norm_name(
+            db, norm_name="qdrantdb", entity_type="product",
+        )
+        assert resolved["entity_id"] == survivor
+
+
+class TestRegistry:
+    @pytest.mark.asyncio
+    async def test_mechanical_exact_identity(self, db):
+        eid1, prov = await entity_registry.resolve_entity(
+            db, name="src/genesis/memory/store.py", entity_type="code_file",
+            aliases=_NO_ALIASES,
+        )
+        eid2, _ = await entity_registry.resolve_entity(
+            db, name="src/genesis/memory/store.py", entity_type="code_file",
+            aliases=_NO_ALIASES,
+        )
+        assert eid1 == eid2
+        assert prov == "EXTRACTED"
+
+    @pytest.mark.asyncio
+    async def test_named_cross_cluster_reuse(self, db):
+        eid1, _ = await entity_registry.resolve_entity(
+            db, name="OMI", entity_type="product", aliases=_NO_ALIASES,
+        )
+        eid2, prov = await entity_registry.resolve_entity(
+            db, name="omi", entity_type="device", aliases=_NO_ALIASES,
+        )
+        assert eid1 == eid2
+        assert prov == "EXTRACTED"
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_creates_ambiguous_and_enqueues(self, db):
+        await entity_registry.resolve_entity(
+            db, name="GENesis-Voice", entity_type="repo", aliases=_NO_ALIASES,
+        )
+        eid, prov = await entity_registry.resolve_entity(
+            db, name="GENesis-Voices", entity_type="repo", aliases=_NO_ALIASES,
+        )
+        assert prov == "AMBIGUOUS"
+        rows = await db.execute_fetchall(
+            "SELECT work_type, payload_json FROM deferred_work_queue"
+        )
+        assert rows and rows[0][0] == "entity_adjudication"
+        assert eid in rows[0][1]
+
+    @pytest.mark.asyncio
+    async def test_distinct_name_is_extracted(self, db):
+        _, prov = await entity_registry.resolve_entity(
+            db, name="Tailscale", entity_type="product", aliases=_NO_ALIASES,
+        )
+        assert prov == "EXTRACTED"
+
+
+class TestSeed:
+    @pytest.mark.asyncio
+    async def test_seed_idempotent_and_spine_reachable(self, db):
+        counts1 = await apply_seed(db)
+        counts2 = await apply_seed(db)
+        assert counts1 == counts2
+        n = (await db.execute_fetchall("SELECT COUNT(*) FROM entities"))[0][0]
+        assert n == counts1["entities"]
+
+        omi = await entities_crud.get_by_norm_name(db, norm_name="omi")
+        assert omi is not None
+        reached = await entities_crud.connected_entities(db, [omi["entity_id"]])
+        depths = {}
+        for eid, info in reached.items():
+            row = await entities_crud.get_entity(db, eid)
+            depths[row["norm_name"]] = info["depth"]
+        assert depths.get("voice-edge-device") == 1
+        assert depths.get("genesis-voice-repo-split") == 2
+
+        mentions = await entities_crud.memories_mentioning(db, list(reached))
+        target = SEED_MENTIONS[0][1]
+        assert any(m["memory_id"] == target for m in mentions)


### PR DESCRIPTION
## Summary
Second PR of the entity-layer lane (WS-H Pillar 2, Graphiti blueprint on the existing SQLite+Qdrant substrate — no new server). Adds typed entity nodes with identity, memory↔entity mentions, and bi-temporal entity↔entity relations. Wired by E3 (extraction + backfill) and read by E4 (session-awareness entity lane, shadow-first).

### Data model (migration 0051 + DDL twins)
- **`entities`** — typed nodes (`code_file/code_symbol/pr/commit` mechanical anchors + `product/device/repo/subsystem/person/org/concept` named), `UNIQUE(norm_name, entity_type)`, merge lifecycle (`active/merged/gone`).
- **`entity_mentions`** — memory↔entity with provenance tags (`EXTRACTED/INFERRED/AMBIGUOUS`); no validity columns (a mention is an event-time fact; memory validity stays in `memory_metadata`).
- **`entity_links`** — entity↔entity, bi-temporal `valid_at/invalid_at` (canonicalized via #982's write gate), provenance + confidence, `evidence_memory_id`. **Open `link_type` vocabulary** (slugified) — deliberately NOT the 5-place `memory_links` CHECK registry; a maintenance report will surface vocab sprawl.

### Code
- `db/crud/entities.py` — upserts keep the stronger claim; **undirected ≤2-hop traversal** with validity filtering and provenance-weighted path confidence (plain queries; no NetworkX cache at 10²–10⁴ rows); adjudicated merge (mentions/links rewritten to survivor, norm lookups follow the merge); fuzzy matches enqueue `entity_adjudication` on `deferred_work_queue`.
- `memory/entity_registry.py` — write-time resolution tiering: mechanical anchors exact by construction → named exact (concept-cluster cross-type reuse) → fuzzy ≥0.85 creates AMBIGUOUS + queues adjudication → new. **Never an inline LLM call.**
- `memory/entity_seed.py` + `scripts/apply_entity_seed.py` — ~20 curated entities + relations incl. the repo-split spine; idempotent; the apply script prints a reachability spot-check.
- `entity_resolution.py` docstring disambiguation (that module = memory-PAIR dedup, not entity nodes); subsystem map updated.

### Design invariant
Session-ledger keywords equal `norm_name`s by construction (both normalize through `entity_resolution.normalize_content`) — the E4 read lane resolves ledger keys with one indexed exact lookup, which is also the noise filter (unresolvable STT filler words drop out).

## Testing
- 15 new tests: crud (collision, stronger-claim upserts, slugify, 2-hop undirected traversal incl. sibling-via-category, validity/as-of filtering, provenance weighting, merge), registry tiers, seed idempotence + spine reachability (category depth 1, rule depth 2, target memory mention present)
- Schema guard, migration-runner lifecycle, subsystem-map guard all green; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)