### PR TITLE
fix(autonomy): atomic dispatch claim + refuse-taxonomy (F2 duplicate execution)

### DIFF
--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -44,6 +44,15 @@ _TERMINAL_PHASES = frozenset({
     TaskPhase.CANCELLED.value,
 })
 
+# Non-resumable tail phases: a task that crashed here cannot be safely re-run
+# from scratch (execute() refuses them), so crash recovery leaves them for
+# review instead of spawning a guaranteed-refusal dispatch.
+_NON_RESUMABLE_TAIL = frozenset({
+    TaskPhase.SYNTHESIZING.value,
+    TaskPhase.DELIVERING.value,
+    TaskPhase.RETROSPECTIVE.value,
+})
+
 
 def _validate_plan_path(path_str: str) -> Path:
     """Validate that a plan path is under allowed directories.
@@ -276,6 +285,12 @@ class TaskDispatcher:
             if phase != TaskPhase.BLOCKED.value:
                 continue
 
+            # Bug B guard: if this task is already executing in-process, don't
+            # stack another dispatch. Without this a blocked+approved task
+            # re-fires every cycle until execute() consumes the approval.
+            if task_id in self._executor._active_tasks:
+                continue
+
             # Check if there's an approved-but-unconsumed approval for this task
             try:
                 cursor = await self._db.execute(
@@ -439,6 +454,18 @@ class TaskDispatcher:
                     logger.info("Found blocked task %s, re-notifying", task_id)
                     self._dispatched.add(task_id)
                     recovered += 1
+                continue
+
+            # Non-resumable tail phase (crashed mid synth/deliver/retro):
+            # execute() would refuse a fresh re-run, so leave it for review
+            # instead of spawning a guaranteed-refusal dispatch.
+            if phase in _NON_RESUMABLE_TAIL:
+                logger.info(
+                    "Found task %s stuck in tail phase %s, leaving for review",
+                    task_id, phase,
+                )
+                self._dispatched.add(task_id)
+                recovered += 1
                 continue
 
             # Re-dispatch executing/reviewing/planning/etc tasks

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -101,6 +101,11 @@ class TaskDispatcher:
         self._event_bus = event_bus
         self._exec_semaphore = exec_semaphore
         self._dispatched: set[str] = set()  # in-memory dedup guard
+        # Tasks with a live _guarded_execute. Added before the semaphore
+        # acquire, so it also covers a dispatch still QUEUED on the semaphore —
+        # the window where the executor's _active_tasks is not yet set. Path 1b
+        # checks this to avoid re-firing a blocked+approved task every cycle.
+        self._dispatch_inflight: set[str] = set()
 
     async def _guarded_execute(self, task_id: str) -> bool:
         """Execute a task, serialized through the semaphore if present.
@@ -111,17 +116,21 @@ class TaskDispatcher:
         via ``_semaphore_released`` that it already released, so we
         must NOT release again here.
         """
-        if self._exec_semaphore is None:
-            return await self._executor.execute(task_id)
-        await self._exec_semaphore.acquire()
+        self._dispatch_inflight.add(task_id)
         try:
-            return await self._executor.execute(task_id)
+            if self._exec_semaphore is None:
+                return await self._executor.execute(task_id)
+            await self._exec_semaphore.acquire()
+            try:
+                return await self._executor.execute(task_id)
+            finally:
+                # Only release if engine didn't already release during pause
+                if task_id not in self._executor._semaphore_released:
+                    self._exec_semaphore.release()
+                else:
+                    self._executor._semaphore_released.discard(task_id)
         finally:
-            # Only release if engine didn't already release during pause
-            if task_id not in self._executor._semaphore_released:
-                self._exec_semaphore.release()
-            else:
-                self._executor._semaphore_released.discard(task_id)
+            self._dispatch_inflight.discard(task_id)
 
     async def submit(
         self,
@@ -285,10 +294,12 @@ class TaskDispatcher:
             if phase != TaskPhase.BLOCKED.value:
                 continue
 
-            # Bug B guard: if this task is already executing in-process, don't
-            # stack another dispatch. Without this a blocked+approved task
-            # re-fires every cycle until execute() consumes the approval.
-            if task_id in self._executor._active_tasks:
+            # Bug B guard: skip if this task already has a live dispatch — this
+            # covers both a running execute() and a dispatch still queued on the
+            # semaphore (the window where _active_tasks is not yet set). Without
+            # it, a blocked+approved task re-fires every 120s cycle until the
+            # approval is consumed.
+            if task_id in self._dispatch_inflight:
                 continue
 
             # Check if there's an approved-but-unconsumed approval for this task

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -121,35 +121,25 @@ class CCSessionExecutor:
             logger.error("Task %s not found in DB", task_id)
             return False
 
-        # --- Dispatch claim + refuse-taxonomy (WS-C / F2) ------------------
-        # Decide fresh-vs-resume-vs-refuse BEFORE any side-effecting work, so a
-        # duplicate or stale dispatch returns without re-running the task.
+        # --- Refuse non-restartable phases up front (WS-C / F2) -----------
+        # A duplicate or stale dispatch that lands on a task which already ran
+        # (completed), is past a safe restart point (synthesizing/delivering/
+        # retrospective), is a transient claim (dispatching), or is terminal
+        # must never re-run it. Refuse before any work. The atomic claim and
+        # the resume-vs-restart decision happen AFTER the plan read below, so a
+        # task that fails its plan read is never claimed into 'dispatching'.
         db_phase_str = task.get("current_phase", "pending")
         _RESUMABLE_PHASES = {"executing", "verifying", "blocked"}
-        if db_phase_str == TaskPhase.PENDING.value:
-            # Atomically flip pending -> dispatching. Losing the claim means
-            # another dispatch already took it: refuse with no side effects.
-            if not await task_states.claim_for_dispatch(self._db, task_id):
-                logger.info(
-                    "Task %s: lost dispatch claim (already claimed/advanced), "
-                    "skipping", task_id,
-                )
-                await self._emit_claim_lost(task_id, db_phase_str)
-                return False
-            resuming = False
-            self._active_tasks[task_id] = TaskPhase.DISPATCHING
-        elif db_phase_str in _RESUMABLE_PHASES:
-            resuming = True
-            self._active_tasks[task_id] = TaskPhase(db_phase_str)
-            logger.info(
-                "Task %s: resuming from %s phase (skipping observe/review/plan)",
-                task_id, db_phase_str,
-            )
-        else:
-            # Terminal, transient 'dispatching', or a non-resumable tail phase
-            # (synthesizing/delivering/retrospective). Never re-run — refuse.
+        # Pre-execution phases (no code run / nothing delivered yet) plus a
+        # paused task recovered at startup: safe to re-run fresh, never refuse.
+        _RESTARTABLE_PHASES = {"observing", "reviewing", "planning", "paused"}
+        if (
+            db_phase_str != TaskPhase.PENDING.value
+            and db_phase_str not in _RESUMABLE_PHASES
+            and db_phase_str not in _RESTARTABLE_PHASES
+        ):
             logger.warning(
-                "Task %s: refusing execute() in non-dispatchable phase %s",
+                "Task %s: refusing execute() in non-restartable phase %s",
                 task_id, db_phase_str,
             )
             await self._emit_claim_lost(task_id, db_phase_str)
@@ -193,6 +183,35 @@ class CCSessionExecutor:
         # rendered file, not a git branch). Keyed on plan_content so it survives
         # resume, where reconstructed step dicts have no `skills` key.
         is_deliverable = has_deliverable_frame(plan_content)
+
+        # --- Claim / resume / restart (WS-C / F2) -------------------------
+        # Done after the plan read so a task that fails its plan read is never
+        # claimed into the transient 'dispatching' phase (just marked failed).
+        if db_phase_str == TaskPhase.PENDING.value:
+            # Atomically flip pending -> dispatching. Losing the claim means
+            # another dispatch already took it: refuse with no side effects.
+            if not await task_states.claim_for_dispatch(self._db, task_id):
+                logger.info(
+                    "Task %s: lost dispatch claim (already claimed/advanced), "
+                    "skipping", task_id,
+                )
+                await self._emit_claim_lost(task_id, db_phase_str)
+                return False
+            resuming = False
+            self._active_tasks[task_id] = TaskPhase.DISPATCHING
+        elif db_phase_str in _RESUMABLE_PHASES:
+            resuming = True
+            self._active_tasks[task_id] = TaskPhase(db_phase_str)
+            logger.info(
+                "Task %s: resuming from %s phase (skipping observe/review/plan)",
+                task_id, db_phase_str,
+            )
+        else:
+            # Restartable pre-execution phase (observing/reviewing/planning) or
+            # a paused task recovered at startup: re-run fresh from PENDING (a
+            # paused task re-pauses at the first checkpoint via _paused_tasks).
+            resuming = False
+            self._active_tasks[task_id] = TaskPhase.PENDING
 
         cancel_event = asyncio.Event()
         self._cancel_events[task_id] = cancel_event

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -129,10 +129,14 @@ class CCSessionExecutor:
         # the resume-vs-restart decision happen AFTER the plan read below, so a
         # task that fails its plan read is never claimed into 'dispatching'.
         db_phase_str = task.get("current_phase", "pending")
-        _RESUMABLE_PHASES = {"executing", "verifying", "blocked"}
-        # Pre-execution phases (no code run / nothing delivered yet) plus a
-        # paused task recovered at startup: safe to re-run fresh, never refuse.
-        _RESTARTABLE_PHASES = {"observing", "reviewing", "planning", "paused"}
+        # 'paused' resumes from persisted steps: PAUSED is only ever reached
+        # mid-EXECUTING (after >=1 step ran), so re-running it fresh would
+        # silently redo completed steps and re-spend cost. Resume + re-pause at
+        # the first checkpoint via _paused_tasks instead.
+        _RESUMABLE_PHASES = {"executing", "verifying", "blocked", "paused"}
+        # Pre-execution phases only (nothing decomposed / no code run yet):
+        # safe to re-run fresh, never refuse.
+        _RESTARTABLE_PHASES = {"observing", "reviewing", "planning"}
         if (
             db_phase_str != TaskPhase.PENDING.value
             and db_phase_str not in _RESUMABLE_PHASES
@@ -207,9 +211,8 @@ class CCSessionExecutor:
                 task_id, db_phase_str,
             )
         else:
-            # Restartable pre-execution phase (observing/reviewing/planning) or
-            # a paused task recovered at startup: re-run fresh from PENDING (a
-            # paused task re-pauses at the first checkpoint via _paused_tasks).
+            # Restartable pre-execution phase (observing/reviewing/planning):
+            # crashed before anything was decomposed/run, so re-run fresh.
             resuming = False
             self._active_tasks[task_id] = TaskPhase.PENDING
 

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -121,6 +121,40 @@ class CCSessionExecutor:
             logger.error("Task %s not found in DB", task_id)
             return False
 
+        # --- Dispatch claim + refuse-taxonomy (WS-C / F2) ------------------
+        # Decide fresh-vs-resume-vs-refuse BEFORE any side-effecting work, so a
+        # duplicate or stale dispatch returns without re-running the task.
+        db_phase_str = task.get("current_phase", "pending")
+        _RESUMABLE_PHASES = {"executing", "verifying", "blocked"}
+        if db_phase_str == TaskPhase.PENDING.value:
+            # Atomically flip pending -> dispatching. Losing the claim means
+            # another dispatch already took it: refuse with no side effects.
+            if not await task_states.claim_for_dispatch(self._db, task_id):
+                logger.info(
+                    "Task %s: lost dispatch claim (already claimed/advanced), "
+                    "skipping", task_id,
+                )
+                await self._emit_claim_lost(task_id, db_phase_str)
+                return False
+            resuming = False
+            self._active_tasks[task_id] = TaskPhase.DISPATCHING
+        elif db_phase_str in _RESUMABLE_PHASES:
+            resuming = True
+            self._active_tasks[task_id] = TaskPhase(db_phase_str)
+            logger.info(
+                "Task %s: resuming from %s phase (skipping observe/review/plan)",
+                task_id, db_phase_str,
+            )
+        else:
+            # Terminal, transient 'dispatching', or a non-resumable tail phase
+            # (synthesizing/delivering/retrospective). Never re-run — refuse.
+            logger.warning(
+                "Task %s: refusing execute() in non-dispatchable phase %s",
+                task_id, db_phase_str,
+            )
+            await self._emit_claim_lost(task_id, db_phase_str)
+            return False
+
         # Resolve plan path from outputs (may be plain string or JSON)
         raw_outputs = task.get("outputs") or ""
         plan_path = raw_outputs
@@ -159,21 +193,6 @@ class CCSessionExecutor:
         # rendered file, not a git branch). Keyed on plan_content so it survives
         # resume, where reconstructed step dicts have no `skills` key.
         is_deliverable = has_deliverable_frame(plan_content)
-
-        # Determine recovery phase from DB
-        db_phase_str = task.get("current_phase", "pending")
-        _RESUMABLE_PHASES = {"executing", "verifying", "blocked"}
-        resuming = db_phase_str in _RESUMABLE_PHASES
-
-        # Register task at current phase (recovery) or PENDING (fresh)
-        if resuming:
-            self._active_tasks[task_id] = TaskPhase(db_phase_str)
-            logger.info(
-                "Task %s: resuming from %s phase (skipping observe/review/plan)",
-                task_id, db_phase_str,
-            )
-        else:
-            self._active_tasks[task_id] = TaskPhase.PENDING
 
         cancel_event = asyncio.Event()
         self._cancel_events[task_id] = cancel_event
@@ -709,6 +728,22 @@ class CCSessionExecutor:
     # State machine (Amendment #10)
     # =================================================================
 
+    async def _emit_claim_lost(self, task_id: str, phase: str) -> None:
+        """Emit an observability event when a dispatch is refused (lost claim
+        or non-dispatchable phase). Should be rare; a spike signals races."""
+        if not self._event_bus:
+            return
+        from genesis.observability.types import Severity, Subsystem
+        with contextlib.suppress(Exception):
+            await self._event_bus.emit(
+                Subsystem.AUTONOMY,
+                Severity.INFO,
+                "task.dispatch_claim_lost",
+                f"Task {task_id[:8]}: dispatch refused in phase {phase}",
+                task_id=task_id,
+                phase=phase,
+            )
+
     async def _transition(self, task_id: str, to_phase: TaskPhase) -> None:
         """Validate and apply a state transition. Emits event."""
         from genesis.db.crud import task_states
@@ -719,6 +754,7 @@ class CCSessionExecutor:
         self._active_tasks[task_id] = to_phase
         await task_states.update(
             self._db, task_id, current_phase=to_phase.value,
+            updated_at=datetime.now(UTC).isoformat(),
         )
 
         if self._event_bus:

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -583,6 +583,14 @@ class CCSessionExecutor:
                     )
                     return False
 
+            # A task paused right at the exec->verify boundary (all steps already
+            # completed) has an empty remaining_steps loop, so the per-step
+            # _checkpoint never ran. Honor a pending pause here so a paused task
+            # recovered after its last step stays paused instead of delivering
+            # without an explicit resume.
+            if not await self._honor_pause(task_id, cancel_event):
+                return False
+
             # --- VERIFYING (review loop, Amendment #4) ---
             deliverable = _dispatch.synthesize_deliverable(step_results)
 
@@ -1028,6 +1036,54 @@ class CCSessionExecutor:
     # Checkpoint (Amendment #13: global pause)
     # =================================================================
 
+    async def _honor_pause(
+        self, task_id: str, cancel: asyncio.Event | None,
+    ) -> bool:
+        """If a global or per-task pause is active, transition to PAUSED,
+        release the exec semaphore, and wait for resume (or cancel).
+
+        Returns ``False`` if the task was cancelled while paused, ``True``
+        otherwise (including when no pause is active — a no-op). Callers must
+        ``return False`` on a False result. Shared by the per-step checkpoint
+        and the pre-verify gate, so a task paused with no remaining steps still
+        stays paused across a restart instead of delivering without a resume.
+        """
+        should_pause = (
+            (self._runtime and getattr(self._runtime, "paused", False))
+            or task_id in self._paused_tasks
+        )
+        if not should_pause:
+            return True
+
+        await self._transition(task_id, TaskPhase.PAUSED)
+
+        # Release execution semaphore so another task can run
+        if self._exec_semaphore:
+            self._exec_semaphore.release()
+            self._semaphore_released.add(task_id)
+
+        pause_event = asyncio.Event()
+        self._pause_events[task_id] = pause_event
+
+        # Wait for resume OR cancel
+        while not pause_event.is_set():
+            if cancel and cancel.is_set():
+                with contextlib.suppress(InvalidTransitionError):
+                    await self._transition(task_id, TaskPhase.CANCELLED)
+                # semaphore_released stays set — dispatcher skips release
+                # in _guarded_execute finally block
+                return False
+            await asyncio.sleep(0.1)
+
+        # Reacquire semaphore before resuming
+        if self._exec_semaphore:
+            await self._exec_semaphore.acquire()
+            self._semaphore_released.discard(task_id)
+
+        self._paused_tasks.discard(task_id)
+        await self._transition(task_id, TaskPhase.EXECUTING)
+        return True
+
     async def _checkpoint(
         self,
         task_id: str,
@@ -1045,38 +1101,8 @@ class CCSessionExecutor:
             return False
 
         # Amendment #13: global pause check + per-task pause
-        should_pause = (
-            (self._runtime and getattr(self._runtime, "paused", False))
-            or task_id in self._paused_tasks
-        )
-        if should_pause:
-            await self._transition(task_id, TaskPhase.PAUSED)
-
-            # Release execution semaphore so another task can run
-            if self._exec_semaphore:
-                self._exec_semaphore.release()
-                self._semaphore_released.add(task_id)
-
-            pause_event = asyncio.Event()
-            self._pause_events[task_id] = pause_event
-
-            # Wait for resume OR cancel
-            while not pause_event.is_set():
-                if cancel and cancel.is_set():
-                    with contextlib.suppress(InvalidTransitionError):
-                        await self._transition(task_id, TaskPhase.CANCELLED)
-                    # semaphore_released stays set — dispatcher will
-                    # skip release in _guarded_execute finally block
-                    return False
-                await asyncio.sleep(0.1)
-
-            # Reacquire semaphore before resuming
-            if self._exec_semaphore:
-                await self._exec_semaphore.acquire()
-                self._semaphore_released.discard(task_id)
-
-            self._paused_tasks.discard(task_id)
-            await self._transition(task_id, TaskPhase.EXECUTING)
+        if not await self._honor_pause(task_id, cancel):
+            return False
 
         # Emit progress event
         if self._event_bus:

--- a/src/genesis/autonomy/executor/types.py
+++ b/src/genesis/autonomy/executor/types.py
@@ -19,6 +19,7 @@ class TaskPhase(StrEnum):
     """Lifecycle phases for a background task."""
 
     PENDING = "pending"
+    DISPATCHING = "dispatching"  # transient: atomically claimed, not yet started
     OBSERVING = "observing"
     REVIEWING = "reviewing"
     PLANNING = "planning"
@@ -39,7 +40,18 @@ class TaskPhase(StrEnum):
 # ---------------------------------------------------------------------------
 
 VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
-    TaskPhase.PENDING: {TaskPhase.OBSERVING, TaskPhase.FAILED, TaskPhase.CANCELLED},
+    TaskPhase.PENDING: {
+        TaskPhase.DISPATCHING,  # won the atomic dispatch claim
+        TaskPhase.OBSERVING,  # pre-planning-blocker re-run resets to PENDING then observes
+        TaskPhase.FAILED,
+        TaskPhase.CANCELLED,
+    },
+    TaskPhase.DISPATCHING: {
+        TaskPhase.OBSERVING,  # claim won -> first real phase
+        TaskPhase.PENDING,  # reaper reset of a stale claim
+        TaskPhase.FAILED,
+        TaskPhase.CANCELLED,
+    },
     TaskPhase.OBSERVING: {
         TaskPhase.REVIEWING,  # annotation-only, always proceeds
         TaskPhase.FAILED,

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -977,7 +977,7 @@
         },
         phaseColor(phase) {
           const colors = {
-            pending: '#616161', observing: '#78909c', reviewing: '#7e57c2',
+            pending: '#616161', dispatching: '#546e7a', observing: '#78909c', reviewing: '#7e57c2',
             planning: '#9e9e9e', executing: '#2196F3', verifying: '#ab47bc',
             synthesizing: '#26a69a', delivering: '#66bb6a', completed: '#66bb6a',
             failed: '#ef9a9a', cancelled: '#9e9e9e', blocked: '#ffa726', paused: '#ffa726',

--- a/src/genesis/db/crud/task_states.py
+++ b/src/genesis/db/crud/task_states.py
@@ -93,6 +93,55 @@ async def update(
     return cursor.rowcount > 0
 
 
+async def claim_for_dispatch(db: aiosqlite.Connection, task_id: str) -> bool:
+    """Atomically claim a PENDING task for dispatch (at-most-once).
+
+    Transitions ``current_phase`` from ``pending`` to ``dispatching`` in one
+    guarded UPDATE, but ONLY for a row still in ``pending``. Returns True iff
+    this call won the claim (``rowcount == 1``). A row already claimed
+    (``dispatching``), running, or terminal does not match and returns False,
+    so the caller must refuse it — this is the dedup gate that stops two
+    overlapping dispatches from both executing the same task.
+
+    Stamps ``updated_at`` (ISO) so :func:`recover_stale_dispatching` can reap a
+    claim stranded by a crash between the claim and the first real phase.
+    """
+    now = datetime.now(UTC).isoformat()
+    cursor = await db.execute(
+        """UPDATE task_states
+           SET current_phase = 'dispatching', updated_at = ?
+           WHERE task_id = ? AND current_phase = 'pending'""",
+        (now, task_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def recover_stale_dispatching(
+    db: aiosqlite.Connection, max_age_s: int = 120,
+) -> int:
+    """Reset ``dispatching`` claims older than ``max_age_s`` back to ``pending``.
+
+    A task sits in ``dispatching`` only between the atomic claim and the first
+    real phase transition. If the executor crashes in that window the row would
+    stay stuck (and be refused on the next pickup), so this reaper — run at
+    startup and on the dispatch poll — returns it to ``pending`` for a clean
+    re-dispatch. Mirrors ``direct_session_queue.recover_stale_claims``. All
+    ``dispatching`` rows carry an ISO ``updated_at`` (written by
+    :func:`claim_for_dispatch`), so the ``<`` compare is well-ordered.
+    """
+    cutoff_iso = (datetime.now(UTC) - timedelta(seconds=max_age_s)).isoformat()
+    now = datetime.now(UTC).isoformat()
+    cursor = await db.execute(
+        """UPDATE task_states
+           SET current_phase = 'pending', updated_at = ?
+           WHERE current_phase = 'dispatching' AND updated_at < ?""",
+        (now, cutoff_iso),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def delete(db: aiosqlite.Connection, task_id: str) -> bool:
     cursor = await db.execute(
         "DELETE FROM task_states WHERE task_id = ?", (task_id,)

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -163,8 +163,8 @@ async def init(rt: GenesisRuntime) -> None:
             logger.warning("Task MCP tools not available")
 
         # Crash recovery
+        from genesis.db.crud import task_states as _task_states
         try:
-            from genesis.db.crud import task_states as _task_states
             # Reset stale 'dispatching' claims (a crash between the atomic claim
             # and the first phase) BEFORE recover_incomplete, so they return to
             # pending and re-dispatch cleanly instead of being refused.
@@ -178,7 +178,6 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Task crash recovery failed", exc_info=True)
 
         # Background polling loop for observation-based dispatch
-        from genesis.db.crud import task_states as _task_states_poll
         from genesis.util.tasks import tracked_task
 
         async def _dispatch_poll_loop() -> None:
@@ -188,7 +187,7 @@ async def init(rt: GenesisRuntime) -> None:
                     # Reap stale 'dispatching' claims each cycle (own job key so
                     # a reaper failure is visible separately from the dispatch).
                     try:
-                        reaped = await _task_states_poll.recover_stale_dispatching(
+                        reaped = await _task_states.recover_stale_dispatching(
                             rt._db,
                         )
                         if reaped:

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -164,6 +164,13 @@ async def init(rt: GenesisRuntime) -> None:
 
         # Crash recovery
         try:
+            from genesis.db.crud import task_states as _task_states
+            # Reset stale 'dispatching' claims (a crash between the atomic claim
+            # and the first phase) BEFORE recover_incomplete, so they return to
+            # pending and re-dispatch cleanly instead of being refused.
+            reaped = await _task_states.recover_stale_dispatching(rt._db)
+            if reaped:
+                logger.info("Reset %d stale dispatching claims", reaped)
             recovered = await dispatcher.recover_incomplete()
             if recovered:
                 logger.info("Recovered %d incomplete tasks", recovered)
@@ -171,12 +178,25 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Task crash recovery failed", exc_info=True)
 
         # Background polling loop for observation-based dispatch
+        from genesis.db.crud import task_states as _task_states_poll
         from genesis.util.tasks import tracked_task
 
         async def _dispatch_poll_loop() -> None:
             while True:
                 try:
                     await asyncio.sleep(120)  # 2-minute interval
+                    # Reap stale 'dispatching' claims each cycle (own job key so
+                    # a reaper failure is visible separately from the dispatch).
+                    try:
+                        reaped = await _task_states_poll.recover_stale_dispatching(
+                            rt._db,
+                        )
+                        if reaped:
+                            logger.info("Reaped %d stale dispatching claims", reaped)
+                        rt.record_job_success("task_dispatch_reaper")
+                    except Exception as exc:
+                        rt.record_job_failure("task_dispatch_reaper", str(exc))
+                        logger.error("Dispatch reaper failed", exc_info=True)
                     count = await dispatcher.dispatch_cycle()
                     if count:
                         logger.info("Dispatch cycle: %d tasks dispatched", count)

--- a/tests/test_autonomy/test_executor/test_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_dispatcher.py
@@ -320,3 +320,43 @@ class TestRecoverIncomplete:
             count = await dispatcher.recover_incomplete()
 
         assert count == 0
+
+
+@pytest.mark.asyncio
+class TestWSCDispatchGuards:
+    """WS-C: Bug B in-flight guard (Path 1b) + non-resumable tail-phase skip."""
+
+    async def test_path1b_skips_task_already_executing(
+        self, dispatcher: TaskDispatcher, mock_executor: AsyncMock,
+    ) -> None:
+        """A blocked+approved task already live in the executor is NOT re-fired
+        (without the guard it re-dispatches every 120s cycle)."""
+        mock_executor._active_tasks = {"t-blk": "blocked"}
+        with (
+            patch("genesis.db.crud.task_states.list_active", new_callable=AsyncMock,
+                  return_value=[{"task_id": "t-blk", "current_phase": "blocked"}]),
+            patch("genesis.db.crud.observations.query", new_callable=AsyncMock,
+                  return_value=[]),
+            patch("genesis.util.tasks.tracked_task") as mock_tt,
+        ):
+            count = await dispatcher.dispatch_cycle()
+
+        assert count == 0
+        mock_tt.assert_not_called()
+
+    async def test_recover_skips_tail_phase(
+        self, dispatcher: TaskDispatcher, mock_executor: AsyncMock,
+    ) -> None:
+        """A task crashed mid-synthesizing is left for review, not re-dispatched
+        into a guaranteed refusal."""
+        mock_executor._active_tasks = {}
+        with (
+            patch("genesis.db.crud.task_states.list_active", new_callable=AsyncMock,
+                  return_value=[{"task_id": "t-synth", "current_phase": "synthesizing"}]),
+            patch("genesis.util.tasks.tracked_task") as mock_tt,
+        ):
+            count = await dispatcher.recover_incomplete()
+
+        assert count == 1  # counted as known/recovered
+        assert "t-synth" in dispatcher._dispatched
+        mock_tt.assert_not_called()  # but NOT re-dispatched

--- a/tests/test_autonomy/test_executor/test_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_dispatcher.py
@@ -329,9 +329,11 @@ class TestWSCDispatchGuards:
     async def test_path1b_skips_task_already_executing(
         self, dispatcher: TaskDispatcher, mock_executor: AsyncMock,
     ) -> None:
-        """A blocked+approved task already live in the executor is NOT re-fired
+        """A blocked+approved task with a live dispatch is NOT re-fired
         (without the guard it re-dispatches every 120s cycle)."""
-        mock_executor._active_tasks = {"t-blk": "blocked"}
+        # Simulate a dispatch already in flight (running OR queued on the
+        # semaphore — the window where _active_tasks is not yet set).
+        dispatcher._dispatch_inflight.add("t-blk")
         with (
             patch("genesis.db.crud.task_states.list_active", new_callable=AsyncMock,
                   return_value=[{"task_id": "t-blk", "current_phase": "blocked"}]),

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1331,21 +1331,75 @@ class TestDispatchClaim:
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "dispatching"
 
-    async def test_restartable_paused_phase_is_not_refused(
+    async def test_paused_task_resumes_without_redoing_completed_work(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
         mock_subprocess,
     ):
-        """A paused task recovered at startup re-runs fresh, not refused
-        (regression: refusing would orphan it forever — reaper only resets
-        'dispatching', never 'paused')."""
+        """A paused task recovered at startup RESUMES from persisted steps — it
+        is neither refused (would orphan it: the reaper only resets
+        'dispatching', never 'paused') nor re-run fresh (would redo completed
+        steps + re-spend cost). Proven by decompose/review NOT being called."""
         await _seed_task(db, plan_path=plan_file, phase="paused")
-        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        await task_steps.create_step(
+            db, task_id="t-001", step_idx=0, step_type="research",
+            description="Research",
+        )
+        await db.execute(
+            """UPDATE task_steps SET status = 'completed',
+               result_json = '{"result": "done", "artifacts": []}'
+               WHERE task_id = ? AND step_idx = ?""",
+            ("t-001", 0),
+        )
+        await db.commit()
 
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
         result = await engine.execute("t-001")
 
-        # _paused_tasks is empty in this unit, so it runs fresh to completion.
         assert result is True
-        mock_decomposer.decompose.assert_called()
+        mock_decomposer.decompose.assert_not_called()  # no re-plan
+        mock_reviewer.review_plan.assert_not_called()  # no re-review
+
+    async def test_paused_task_repauses_on_resume(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """A paused task with _paused_tasks pre-set (as recover_incomplete does)
+        resumes and re-pauses at the first checkpoint rather than wedging or
+        re-planning."""
+        await _seed_task(db, plan_path=plan_file, phase="paused")
+        # Two steps; step 0 is then marked completed, step 1 stays pending so
+        # resume executes it and the checkpoint honors the pre-set pause flag.
+        for idx in (0, 1):
+            await task_steps.create_step(
+                db, task_id="t-001", step_idx=idx, step_type="research",
+                description=f"Step {idx}",
+            )
+        await db.execute(
+            """UPDATE task_steps SET status='completed',
+               result_json='{"result": "done", "artifacts": []}'
+               WHERE task_id='t-001' AND step_idx=0""",
+        )
+        await db.commit()
+
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        engine._paused_tasks.add("t-001")  # as recover_incomplete pre-sets
+
+        # execute() parks in the checkpoint pause-wait loop, so run it as a task.
+        task = asyncio.create_task(engine.execute("t-001"))
+        await asyncio.sleep(0.3)
+
+        # Resumed from persisted steps (not re-planned) and re-paused at the
+        # first checkpoint — it did not wedge or re-decompose.
+        assert engine._active_tasks.get("t-001") == TaskPhase.PAUSED
+        mock_decomposer.decompose.assert_not_called()
+
+        # Clear the pause flag and release the wait loop; it runs to completion.
+        engine._paused_tasks.discard("t-001")
+        pause_event = engine._pause_events.get("t-001")
+        assert pause_event is not None
+        pause_event.set()
+        result = await asyncio.wait_for(task, timeout=5.0)
+        assert result is True
 
     async def test_restartable_planning_phase_reruns_fresh(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1457,3 +1457,39 @@ class TestDispatchClaim:
         assert dispatcher._dispatch_inflight == set()  # guard cleaned up
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "completed"
+
+    async def test_paused_at_verify_boundary_stays_paused(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """A task paused after its LAST step completed (empty remaining_steps)
+        must stay paused on recovery — not verify/deliver without an explicit
+        resume. Codex P2: the per-step checkpoint never runs when the loop is
+        empty, so a pre-verify pause gate is required."""
+        await _seed_task(db, plan_path=plan_file, phase="paused")
+        await task_steps.create_step(
+            db, task_id="t-001", step_idx=0, step_type="research",
+            description="Step 0",
+        )
+        await db.execute(
+            """UPDATE task_steps SET status='completed',
+               result_json='{"result": "done", "artifacts": []}'
+               WHERE task_id='t-001' AND step_idx=0""",
+        )
+        await db.commit()
+
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        engine._paused_tasks.add("t-001")
+
+        task = asyncio.create_task(engine.execute("t-001"))
+        await asyncio.sleep(0.3)
+
+        # Paused at the verify boundary — did NOT verify/deliver.
+        assert engine._active_tasks.get("t-001") == TaskPhase.PAUSED
+        mock_reviewer.verify_deliverable.assert_not_called()
+
+        # Explicit resume -> completes.
+        engine._paused_tasks.discard("t-001")
+        engine._pause_events["t-001"].set()
+        assert await asyncio.wait_for(task, timeout=5.0) is True
+        mock_reviewer.verify_deliverable.assert_called()

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1201,3 +1201,132 @@ async def test_notify_e2e_verbatim_telegram_and_tokenfree_voice(db):
     spoken = voice.send_message.call_args.args[1]
     assert spoken == "A build was parked by the safety gate."
     assert "src/genesis" not in spoken  # no path read aloud
+
+
+# ---------------------------------------------------------------------------
+# WS-C: atomic dispatch claim + refuse-taxonomy (F2 — duplicate execution)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDispatchClaim:
+    """Atomic PENDING claim + explicit refuse-taxonomy in execute().
+
+    Proves the F2 fix: a task may only be run once. Overlapping dispatches
+    lose the atomic claim, and a task already in a terminal / tail /
+    transient phase is refused instead of silently re-run from scratch.
+    """
+
+    async def test_completed_task_is_refused_not_rerun(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """A 'completed' task must be refused, never re-run fresh (the harm)."""
+        await _seed_task(db, plan_path=plan_file, phase="completed")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        assert result is False
+        mock_decomposer.decompose.assert_not_called()
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "completed"
+
+    async def test_tail_phase_task_is_refused(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """A task stuck in a non-resumable tail phase (synthesizing) is refused."""
+        await _seed_task(db, plan_path=plan_file, phase="synthesizing")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        assert result is False
+        mock_decomposer.decompose.assert_not_called()
+
+    async def test_dispatching_phase_is_refused(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """The transient 'dispatching' claim phase is refused by execute()
+        (only the reaper resets it to pending)."""
+        await _seed_task(db, plan_path=plan_file, phase="dispatching")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        assert result is False
+        mock_decomposer.decompose.assert_not_called()
+
+    async def test_concurrent_execute_runs_once(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Two overlapping execute() calls for one pending task → exactly one runs."""
+        await _seed_task(db, plan_path=plan_file, phase="pending")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        results = await asyncio.gather(
+            engine.execute("t-001"), engine.execute("t-001"),
+        )
+
+        assert sum(1 for r in results if r is True) == 1
+        assert mock_decomposer.decompose.call_count == 1
+
+    async def test_claim_for_dispatch_is_atomic(self, db):
+        """First claim wins (pending -> dispatching); a second claim loses."""
+        await _seed_task(db, phase="pending")
+
+        won_first = await task_states.claim_for_dispatch(db, "t-001")
+        won_second = await task_states.claim_for_dispatch(db, "t-001")
+
+        assert won_first is True
+        assert won_second is False
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "dispatching"
+
+    async def test_claim_for_dispatch_stamps_updated_at(self, db):
+        """A winning claim refreshes updated_at (reaper staleness relies on it)."""
+        await _seed_task(db, phase="pending")
+        await task_states.update(
+            db, "t-001", updated_at="2020-01-01T00:00:00+00:00",
+        )
+
+        assert await task_states.claim_for_dispatch(db, "t-001") is True
+
+        after = (await task_states.get_by_id(db, "t-001"))["updated_at"]
+        assert after != "2020-01-01T00:00:00+00:00"
+
+    async def test_claim_for_dispatch_rejects_non_pending(self, db):
+        """Only a 'pending' row is claimable; a 'blocked' row is not."""
+        await _seed_task(db, phase="blocked")
+        assert await task_states.claim_for_dispatch(db, "t-001") is False
+
+    async def test_recover_stale_dispatching_resets_old(self, db):
+        """A 'dispatching' row older than max_age is reset to pending."""
+        await _seed_task(db, phase="pending")
+        await task_states.update(
+            db, "t-001", current_phase="dispatching",
+            updated_at="2020-01-01T00:00:00+00:00",
+        )
+
+        n = await task_states.recover_stale_dispatching(db, max_age_s=120)
+
+        assert n == 1
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "pending"
+
+    async def test_recover_stale_dispatching_spares_fresh(self, db):
+        """A freshly-claimed 'dispatching' row is NOT reaped."""
+        await _seed_task(db, phase="pending")
+        fresh = datetime.now(UTC).isoformat()
+        await task_states.update(
+            db, "t-001", current_phase="dispatching", updated_at=fresh,
+        )
+
+        n = await task_states.recover_stale_dispatching(db, max_age_s=120)
+
+        assert n == 0
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "dispatching"

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1330,3 +1330,49 @@ class TestDispatchClaim:
         assert n == 0
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "dispatching"
+
+    async def test_restartable_paused_phase_is_not_refused(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """A paused task recovered at startup re-runs fresh, not refused
+        (regression: refusing would orphan it forever — reaper only resets
+        'dispatching', never 'paused')."""
+        await _seed_task(db, plan_path=plan_file, phase="paused")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        # _paused_tasks is empty in this unit, so it runs fresh to completion.
+        assert result is True
+        mock_decomposer.decompose.assert_called()
+
+    async def test_restartable_planning_phase_reruns_fresh(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """A task crashed mid-planning re-runs fresh (pre-execution phase, no
+        committed side effects), rather than being refused."""
+        await _seed_task(db, plan_path=plan_file, phase="planning")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        assert result is True
+        mock_decomposer.decompose.assert_called()
+
+    async def test_pending_with_unreadable_plan_is_failed_not_claimed(
+        self, db, mock_invoker, mock_decomposer, mock_reviewer,
+    ):
+        """A pending task with an unreadable plan is marked failed, and the plan
+        read (which fails) happens before the claim — so the row is never left
+        stuck in the transient 'dispatching' phase."""
+        await _seed_task(db, plan_path="/nonexistent/plan.md", phase="pending")
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        assert result is False
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "failed"  # not stuck in 'dispatching'
+        assert "t-001" not in engine.get_active_tasks()  # terminal, not surfaced

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1430,3 +1430,30 @@ class TestDispatchClaim:
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "failed"  # not stuck in 'dispatching'
         assert "t-001" not in engine.get_active_tasks()  # terminal, not surfaced
+
+    async def test_e2e_guarded_execute_real_chain_single_run(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """End-to-end integration: two overlapping dispatches of one pending
+        task through the REAL TaskDispatcher._guarded_execute + REAL executor +
+        REAL Semaphore + REAL atomic claim run the task exactly once, and the
+        _dispatch_inflight guard cleans up. Only the LLM calls are mocked."""
+        from genesis.autonomy.dispatcher import TaskDispatcher
+
+        await _seed_task(db, plan_path=plan_file, phase="pending")
+        executor = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        dispatcher = TaskDispatcher(
+            db=db, executor=executor, exec_semaphore=asyncio.Semaphore(1),
+        )
+
+        results = await asyncio.gather(
+            dispatcher._guarded_execute("t-001"),
+            dispatcher._guarded_execute("t-001"),
+        )
+
+        assert sum(1 for r in results if r is True) == 1  # exactly one ran
+        assert mock_decomposer.decompose.call_count == 1  # no duplicate work
+        assert dispatcher._dispatch_inflight == set()  # guard cleaned up
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "completed"

--- a/tests/test_autonomy/test_executor/test_types.py
+++ b/tests/test_autonomy/test_executor/test_types.py
@@ -118,3 +118,18 @@ class TestExecutionTrace:
         assert t.total_cost_usd == 0.0
         assert t.step_results == []
         assert t.retrospective_id is None
+
+
+class TestDispatchingPhase:
+    """WS-C: the transient DISPATCHING claim phase and its transitions."""
+
+    def test_pending_can_transition_to_dispatching(self) -> None:
+        assert TaskPhase.DISPATCHING in VALID_TRANSITIONS[TaskPhase.PENDING]
+
+    def test_dispatching_transitions_to_observing_and_pending(self) -> None:
+        # OBSERVING = won claim proceeds; PENDING = reaper reset
+        assert TaskPhase.OBSERVING in VALID_TRANSITIONS[TaskPhase.DISPATCHING]
+        assert TaskPhase.PENDING in VALID_TRANSITIONS[TaskPhase.DISPATCHING]
+
+    def test_dispatching_is_not_terminal(self) -> None:
+        assert VALID_TRANSITIONS[TaskPhase.DISPATCHING] != set()


### PR DESCRIPTION
## Summary

Fixes **F2 (duplicate task execution)** from the 2026-07-02 audit. The autonomy dispatcher could execute a task more than once. Two root causes plus the real harm:

- **Bug A — no atomic claim.** Path 1 spawned `execute()` guarded only by an in-memory `_dispatched` set; `execute()` read `current_phase` once and `_transition` wrote it back unconditionally, so two overlapping dispatches could both run.
- **Bug B — Path 1b re-fired every 120s.** A blocked task with an approved, unconsumed approval was re-dispatched on every poll with no effective in-flight guard.
- **The harm — completed-refresh hole.** `execute()`'s phase branch treated any non-resumable phase (completed / synthesizing / delivering / retrospective) as a fresh run, so a stacked re-dispatch that landed after the first finished re-ran the whole task — re-pushing branches, re-notifying.

## The fix

- **`TaskPhase.DISPATCHING`** transient phase + transitions (`PENDING→DISPATCHING→OBSERVING`; `DISPATCHING→PENDING` for reaper reset).
- **`task_states.claim_for_dispatch()`** — one guarded `UPDATE … WHERE current_phase='pending'`, stamps `updated_at`, returns True only for the winner.
- **`execute()` phase taxonomy** (decided up front, claim after the plan read): `pending`→atomic claim; RESUMABLE {executing, verifying, blocked, **paused**}→resume from persisted steps; RESTARTABLE {observing, reviewing, planning}→safe fresh re-run; everything else (completed / tail phases / dispatching / terminal)→refuse with `task.dispatch_claim_lost`.
- **`_transition()` now stamps `updated_at`** (it never did) — the reaper relies on it and it also fixes `list_active`/dashboard recency ordering.
- **`recover_stale_dispatching()` reaper** resets claims stranded by a crash; wired at startup (before `recover_incomplete`) and on the dispatch poll with its own `task_dispatch_reaper` job-health key.
- **Dispatcher `_dispatch_inflight` guard** — populated before the semaphore acquire, so Path 1b also covers a dispatch still *queued* on the single-worker semaphore (the window where `_active_tasks` isn't set yet). `recover_incomplete` leaves crashed tail-phase tasks for review instead of a guaranteed-refusal dispatch.
- **Dashboard** color for the transient `dispatching` phase.

No DB migration (`current_phase` is `TEXT`, no CHECK).

## Verification (repro-test-first)

- 18 targeted WS-C tests (claim atomicity, one-execution under overlap, completed/tail/dispatching refusal, restartable-phase fresh re-run, **paused resume without redoing completed work + re-pause on resume**, reaper reset/spare, Path 1b queued-window guard, transitions).
- **E2E integration test**: real `TaskDispatcher._guarded_execute` + real executor + real `Semaphore` + real claim — two overlapping dispatches run the task exactly once.
- Full `test_autonomy/` suite green (**1020 passed**); executor dir 418; ruff clean.

## Review history

Two Claude inline review rounds each caught real defects, both fixed with regression tests: (1) the initial refuse-taxonomy wrongly orphaned `paused`/`observing`/`reviewing`/`planning` recovery — narrowed to a restartable set; (2) the Path 1b guard's semaphore blind spot — closed with `_dispatch_inflight`; (3) paused tasks were re-run fresh (silently redoing completed steps + re-spending cost) — now resumed. Commits are kept separate for that history.

Live-core change → single execution and the reaper reset are verified pre-merge; a live-server E2E (submit a queued task, observe single execution + dashboard `dispatching`) will run post-deploy.