### PR TITLE
fix(dashboard): event-log severity select shows the active filter on load

### DIFF
--- a/src/genesis/dashboard/templates/genesis_logs.html
+++ b/src/genesis/dashboard/templates/genesis_logs.html
@@ -230,15 +230,6 @@
                   "perception", "learning", "inbox", "reflection", "providers", "web", "outreach", "dashboard"];
         },
 
-        get severityOptions() {
-          return [
-            { value: "debug", label: "DEBUG+" },
-            { value: "info", label: "INFO+" },
-            { value: "warning", label: "WARN+" },
-            { value: "error", label: "ERROR+" },
-            { value: "critical", label: "CRIT" },
-          ];
-        },
       });
     });
   </script>
@@ -578,10 +569,15 @@
 
     <!-- Filter bar -->
     <div class="filter-bar">
+      <!-- Static options: x-model applies its initial value ("info") before
+           x-for renders options, which left the select DISPLAYING the first
+           option (DEBUG+) while actually filtering INFO+. -->
       <select x-model="$store.genesisLogs.filters.severities" @change="$store.genesisLogs.applyFilters()">
-        <template x-for="opt in $store.genesisLogs.severityOptions" :key="opt.value">
-          <option :value="opt.value" x-text="opt.label"></option>
-        </template>
+        <option value="debug">DEBUG+</option>
+        <option value="info">INFO+</option>
+        <option value="warning">WARN+</option>
+        <option value="error">ERROR+</option>
+        <option value="critical">CRIT</option>
       </select>
 
       <select x-model="$store.genesisLogs.filters.subsystem" @change="$store.genesisLogs.applyFilters()">


### PR DESCRIPTION
Follow-up to #981. The Event Log's severity `<select>` displayed **DEBUG+** while the page was actually filtering **INFO+**: Alpine applies `x-model`'s initial value before the `x-for`-rendered options exist, so the select fell back to showing its first option. The old `debug` default coincidentally matched the first option, which is why this was invisible until #981 changed the default.

The option list is a hardcoded five-entry set, so render the `<option>` tags statically (letting `x-model` sync correctly on init) and drop the now-unused `severityOptions` getter. Caught by post-deploy live verification: store said `info` and the feed was heartbeat-free, but the combobox showed DEBUG+ selected.

One file, template-only. `tests/test_dashboard/test_logs_api.py` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)