### PR TITLE
fix(memory): faceting parity on embedding recovery + real created_at for FTS-only rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Memories recovered after an embedding outage keep their wing/room/life_domain
+  filters, and keyword-only results are no longer ranked as artificially fresh.**
+  When the embedding provider was down, memories were stored keyword-only and
+  re-embedded on recovery — but the rebuilt vector dropped its wing/room/life_domain
+  tags, so it silently vanished from any domain-scoped ("wing=…") recall. Recovery
+  now restores those fields. Separately, keyword-only memories were being scored as
+  if created just now (maximum freshness), letting old notes outrank genuinely recent
+  ones; they now use their real creation time.
+
 - **Protected-path guarding now covers the real systemd unit sources.** The
   critical-path rules protected a stale copy of the watchdog unit under
   `config/` while leaving `scripts/systemd/*.template` — the files installs

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -355,6 +355,63 @@ async def get_metadata(
     }
 
 
+async def get_taxonomy(
+    db: aiosqlite.Connection,
+    memory_id: str,
+) -> dict[str, str | None] | None:
+    """Return ``{"wing", "room"}`` for a memory_id, or None if no row.
+
+    The embedding-recovery worker uses this to restore the faceting
+    fields onto the reconstructed Qdrant payload (see
+    ``resilience/embedding_recovery``) so a recovered point is not
+    silently dropped from ``wing=``/``room=`` filtered recall. Only
+    ``wing`` and ``room`` are metadata columns; ``life_domain`` is
+    recovered from the ``life_domain:`` tag and ``project_type`` is not
+    persisted on this path.
+    """
+    rows = await db.execute_fetchall(
+        "SELECT wing, room FROM memory_metadata WHERE memory_id = ?",
+        (memory_id,),
+    )
+    row = rows[0] if rows else None
+    if not row:
+        return None
+    return {"wing": row[0], "room": row[1]}
+
+
+async def batch_created_at(
+    db: aiosqlite.Connection,
+    memory_ids: list[str],
+) -> dict[str, str]:
+    """Batch-fetch ``created_at`` from memory_metadata for *memory_ids*.
+
+    Mirrors ``memory_links.batch_link_counts``: one chunked IN-clause
+    query instead of N lookups. ``HybridRetriever._compute_activations``
+    uses it to give FTS-only rows (no Qdrant hit) their real creation
+    time instead of the ``now_str`` fallback — that fallback yields an
+    unearned ``recency = exp(0) = 1.0`` and a phantom age of 0 in the
+    MEM-005 entrenchment metric. Ids with no metadata row are omitted;
+    the caller falls back to ``now_str`` for those.
+    """
+    if not memory_ids:
+        return {}
+
+    _CHUNK = 900  # single-column query, stays under SQLite's 999 limit
+    out: dict[str, str] = {}
+    for offset in range(0, len(memory_ids), _CHUNK):
+        chunk = memory_ids[offset : offset + _CHUNK]
+        ph = ",".join("?" * len(chunk))
+        rows = await db.execute_fetchall(
+            f"SELECT memory_id, created_at FROM memory_metadata"
+            f" WHERE memory_id IN ({ph})",
+            chunk,
+        )
+        for row in rows:
+            if row[1]:
+                out[row[0]] = row[1]
+    return out
+
+
 async def match_id_prefix(
     db: aiosqlite.Connection,
     prefix: str,

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -1023,6 +1023,18 @@ class HybridRetriever:
         """
         link_counts = await memory_links.batch_link_counts(self._db, list(all_ids))
 
+        # FTS-only rows (no Qdrant hit) otherwise fall back to now_str for
+        # created_at, giving them an unearned recency = exp(0) = 1.0 and a
+        # phantom age of 0 in the MEM-005 entrenchment metric. Fetch their
+        # real created_at from memory_metadata (NOT NULL there); legacy FTS
+        # ghosts with no metadata row keep the now_str fallback below.
+        fts_only_ids = [mid for mid in all_ids if mid not in qdrant_by_id]
+        meta_created_at = (
+            await memory_crud.batch_created_at(self._db, fts_only_ids)
+            if fts_only_ids
+            else {}
+        )
+
         activation_by_id: dict[str, float] = {}
         inbound_by_id: dict[str, int] = {}  # saved for graph boost in step 7b
         retrieved_count_by_id: dict[str, int] = {}
@@ -1039,7 +1051,7 @@ class HybridRetriever:
                 retrieved_count = payload.get("retrieved_count", 0)
             else:
                 confidence = 0.5
-                created_at = now_str
+                created_at = meta_created_at.get(mid, now_str)
                 retrieved_count = 0
 
             mem_class = payload.get("memory_class", "fact") if qdrant_hit else "fact"

--- a/src/genesis/resilience/embedding_recovery.py
+++ b/src/genesis/resilience/embedding_recovery.py
@@ -7,6 +7,7 @@ import logging
 
 import aiosqlite
 
+from genesis.db.crud import memory as memory_crud
 from genesis.db.crud import pending_embeddings as crud
 
 logger = logging.getLogger(__name__)
@@ -59,8 +60,25 @@ class EmbeddingRecoveryWorker:
                 tag_list = [t.strip() for t in raw_tags.split(",") if t.strip()] if raw_tags else []
                 collection = item.get("collection", "episodic_memory")
 
+                # Restore faceting fields so the recovered point survives
+                # wing=/room=/life_domain= filtered recall — Qdrant `must`
+                # filters exclude a point that LACKS the key, so a payload
+                # missing these silently drops out of scoped recall (the
+                # normal write path sets all of them, see memory/store.py).
+                # wing/room live in memory_metadata (written by create_metadata
+                # in the same store() that enqueued this pending row, so the
+                # row is present at drain time); life_domain is not a metadata
+                # column — recover it from the `life_domain:` tag store.py
+                # appends. project_type is not persisted on this path (absent
+                # from metadata, pending_embeddings, and tags) → stays unset.
+                taxo = await memory_crud.get_taxonomy(self._db, item["memory_id"])
+                life_domain = next(
+                    (t.split(":", 1)[1] for t in tag_list
+                     if t.startswith("life_domain:")),
+                    None,
+                )
+
                 payload = {
-                    "memory_id": item["memory_id"],
                     "memory_type": item["memory_type"],
                     "content": item["content"],
                     "source": item.get("source") or "embedding_recovery",
@@ -71,6 +89,13 @@ class EmbeddingRecoveryWorker:
                     "retrieved_count": 0,
                     "scope": "external" if collection == "knowledge_base" else "user",
                 }
+                if taxo:
+                    if taxo.get("wing"):
+                        payload["wing"] = taxo["wing"]
+                    if taxo.get("room"):
+                        payload["room"] = taxo["room"]
+                if life_domain:
+                    payload["life_domain"] = life_domain
                 # Restore provenance fields if queued with them
                 for prov_key in (
                     "source_session_id", "transcript_path",

--- a/tests/test_db/test_memory.py
+++ b/tests/test_db/test_memory.py
@@ -69,3 +69,36 @@ async def test_search_ranked_with_collection(db):
     )
     results = await memory.search_ranked(db, query="ranked", collection="special")
     assert all(r["collection"] == "special" for r in results)
+
+
+async def test_get_taxonomy(db):
+    await memory.create_metadata(
+        db, memory_id="tx1", created_at="2020-01-01T00:00:00+00:00",
+        wing="infrastructure", room="watchdog",
+    )
+    assert await memory.get_taxonomy(db, "tx1") == {
+        "wing": "infrastructure", "room": "watchdog",
+    }
+    # room is optional — a wing-only row still resolves
+    await memory.create_metadata(
+        db, memory_id="tx2", created_at="2020-01-01T00:00:00+00:00", wing="memory",
+    )
+    assert await memory.get_taxonomy(db, "tx2") == {"wing": "memory", "room": None}
+    assert await memory.get_taxonomy(db, "missing") is None
+
+
+async def test_batch_created_at(db):
+    await memory.create_metadata(
+        db, memory_id="c1", created_at="2020-01-01T00:00:00+00:00",
+    )
+    await memory.create_metadata(
+        db, memory_id="c2", created_at="2021-02-02T00:00:00+00:00",
+    )
+    got = await memory.batch_created_at(db, ["c1", "c2", "missing"])
+    assert got == {
+        "c1": "2020-01-01T00:00:00+00:00",
+        "c2": "2021-02-02T00:00:00+00:00",
+    }
+    # missing ids are simply omitted; empty input short-circuits
+    assert "missing" not in got
+    assert await memory.batch_created_at(db, []) == {}

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -109,6 +109,7 @@ async def test_recall_returns_results(mock_qdrant, mock_crud, mock_links, _mock_
         _make_fts_row("mem-1", -5.0),
         _make_fts_row("mem-3", -3.0),
     ])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
     _setup_link_mocks(mock_links, link_count=2)
 
     results = await retriever.recall("test query", limit=10)
@@ -209,6 +210,7 @@ async def test_recall_threads_collection_fts_only(mock_qdrant, mock_crud, mock_l
     mock_crud.search_ranked = AsyncMock(return_value=[
         {**_make_fts_row("mem-kb", -5.0), "collection": "knowledge_base"},
     ])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
     _setup_link_mocks(mock_links)
 
     results = await retriever.recall(
@@ -685,6 +687,7 @@ async def test_recall_graph_boost_floor_gating(mock_qdrant, mock_crud, mock_link
         _make_fts_row("s3", -6.0),
         _make_fts_row("weak", -1.0),
     ])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
 
     # weak has massive inbound links — but should be floor-gated
     mock_links.batch_link_counts = AsyncMock(return_value={
@@ -922,6 +925,7 @@ async def test_recall_reranker_replaces_fused_with_positional_scores(
         _make_qdrant_hit("mem-2", 0.80),
     ]
     mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-3", -5.0)])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
     _setup_link_mocks(mock_links)
 
     results = await retriever.recall("test query", limit=5, rerank=True)
@@ -1016,3 +1020,46 @@ async def test_no_penalty_retrieval_score_equals_score(
     assert len(results) == 2
     for r in results:
         assert r.score == pytest.approx(r.retrieval_score)
+
+
+# --- D4: FTS-only rows must not get phantom now_str freshness ---
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+async def test_compute_activations_fts_only_uses_metadata_created_at(
+    mock_crud, mock_links,
+):
+    """D4: an FTS-only row (no Qdrant hit) takes its real created_at from
+    memory_metadata via batch_created_at, not the now_str phantom that
+    yields recency = exp(0) = 1.0 (and a phantom age of 0 in MEM-005)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    old = "2020-01-01T00:00:00+00:00"
+    mock_crud.batch_created_at = AsyncMock(return_value={"fts-1": old})
+
+    now_str = datetime.now(UTC).isoformat()
+    _act, _inb, _rc, created_at_by_id = await retriever._compute_activations(
+        {"fts-1"}, {}, now_str,  # empty qdrant_by_id → fts-1 is FTS-only
+    )
+    assert created_at_by_id["fts-1"] == old  # real date, NOT now_str
+    mock_crud.batch_created_at.assert_awaited_once_with(retriever._db, ["fts-1"])
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+async def test_compute_activations_fts_ghost_falls_back_to_now(
+    mock_crud, mock_links,
+):
+    """A legacy FTS ghost with no metadata row keeps the now_str fallback."""
+    retriever, _, _, _ = _build_retriever()
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    mock_crud.batch_created_at = AsyncMock(return_value={})  # no metadata row
+
+    now_str = datetime.now(UTC).isoformat()
+    _a, _i, _r, created_at_by_id = await retriever._compute_activations(
+        {"ghost"}, {}, now_str,
+    )
+    assert created_at_by_id["ghost"] == now_str

--- a/tests/test_memory/test_retrieval_fallback.py
+++ b/tests/test_memory/test_retrieval_fallback.py
@@ -50,6 +50,7 @@ async def test_recall_fts_only_on_embedding_failure(mock_qdrant, mock_crud, mock
         _make_fts_row("mem-1", -5.0),
         _make_fts_row("mem-2", -3.0),
     ])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
     mock_links.count_links = AsyncMock(return_value=0)
     mock_links.batch_link_counts = AsyncMock(return_value={})
     mock_links.inter_candidate_links = AsyncMock(return_value=[])
@@ -76,6 +77,7 @@ async def test_recall_fts_only_vector_rank_is_none(mock_qdrant, mock_crud, mock_
     mock_crud.search_ranked = AsyncMock(return_value=[
         _make_fts_row("mem-1", -5.0),
     ])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
     mock_links.count_links = AsyncMock(return_value=0)
     mock_links.batch_link_counts = AsyncMock(return_value={})
     mock_links.inter_candidate_links = AsyncMock(return_value=[])

--- a/tests/test_resilience/test_embedding_recovery.py
+++ b/tests/test_resilience/test_embedding_recovery.py
@@ -79,6 +79,54 @@ class TestDrainPending:
         assert len(pending) == 0  # None pending (one embedded, one failed)
 
     @pytest.mark.asyncio
+    async def test_recovery_restores_faceting_fields(self, db, worker):
+        """D3: a recovered point carries wing/room (from memory_metadata) and
+        life_domain (from the ``life_domain:`` tag) so it survives faceted
+        (wing=/room=/life_domain=) recall — a payload missing these keys is
+        silently excluded by Qdrant ``must`` filters.
+        """
+        from genesis.db.crud import memory as memory_crud
+
+        w, _, qdrant = worker
+        # create_metadata runs in the same store() that enqueues the pending
+        # row, so wing/room are guaranteed present at drain time.
+        await memory_crud.create_metadata(
+            db, memory_id="mem-facet", created_at="2026-03-11T12:00:00",
+            wing="infrastructure", room="watchdog",
+        )
+        await crud.create(
+            db, id="pe-facet", memory_id="mem-facet", content="facet item",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+            tags="wing:infrastructure,life_domain:health,tag1",
+        )
+
+        assert await w.drain_pending() == 1
+        payload = qdrant.upsert.call_args.kwargs["points"][0].payload
+        assert payload["wing"] == "infrastructure"
+        assert payload["room"] == "watchdog"
+        assert payload["life_domain"] == "health"
+        # project_type is not recoverable on this path — must stay absent
+        assert "project_type" not in payload
+        # the stray memory_id key is dropped to match the normal write path
+        assert "memory_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_recovery_without_metadata_omits_facets(self, db, worker):
+        """A pending row whose metadata row is somehow absent (legacy) must
+        still drain — faceting fields are simply omitted, no crash."""
+        w, _, qdrant = worker
+        await crud.create(
+            db, id="pe-nofacet", memory_id="mem-nofacet", content="no facet",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2026-03-11T12:00:00", tags="tag1",
+        )
+        assert await w.drain_pending() == 1
+        payload = qdrant.upsert.call_args.kwargs["points"][0].payload
+        assert "wing" not in payload
+        assert "life_domain" not in payload
+
+    @pytest.mark.asyncio
     async def test_count_pending(self, db, worker):
         w, _, _ = worker
         await crud.create(


### PR DESCRIPTION
## What

Two related memory-retrieval correctness fixes (one concern: `memory_metadata` parity).

### D3 — recovered memories keep their faceting filters
`EmbeddingRecoveryWorker.drain_pending` rebuilt the Qdrant payload of a memory that was stored FTS5-only during an embedding outage, but **dropped its `wing`/`room`/`life_domain`** — so the re-embedded point was silently excluded from every faceted (`wing=`/`room=`/`life_domain=`) recall, because Qdrant `must` filters exclude points that lack the key.

Recovery now restores them:
- **wing/room** ← `memory_metadata` (written by `create_metadata` in the same `store()` that enqueued the pending row, so it's present at drain time)
- **life_domain** ← the `life_domain:` tag `store.py` appends (not a metadata column)
- **project_type** stays absent — it is never persisted on this path (metadata/pending/tags); documented + follow-up filed, not a regression this introduces

Also drops a stray `memory_id` payload key the normal write path never sets.

### D4 — keyword-only results are no longer ranked as artificially fresh
`_compute_activations` gave FTS-only rows (no Qdrant hit) `created_at = now_str`, yielding `recency = exp(0) = 1.0` (max freshness) and a phantom age of 0 in the MEM-005 entrenchment metric. It now batch-fetches their real `created_at` from `memory_metadata` (NOT NULL there); legacy FTS ghosts with no metadata row keep the `now_str` fallback. Guarded to skip the async call when there are no FTS-only rows.

## How
- New crud helpers `memory.get_taxonomy` + `memory.batch_created_at` (mirror `memory_links.batch_link_counts`).

## Tests / verification
- 63/63 targeted tests green; RED-proven (both fixes fail without the change).
- Independent code review: clean, no correctness findings.
- **Live E2E vs real Qdrant** (scratch collection): the recovered point carried wing/room/life_domain and a `wing=` filter surfaced it, while a keyless control point was excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)