### PR TITLE
feat(guardian): credential-file integrity detection + auto-restore (G.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now detects and repairs corrupted credential files on its own.**
+  If a critical credential or wiring file (`secrets.env`, your Claude Code and
+  GitHub credentials, SSH keys, `guardian_remote.yaml`, `genesis.yaml`) gets
+  zeroed, truncated, or otherwise corrupted — the exact kind of damage a storage
+  outage can cause mid-write — Genesis notices on its next cycle, restores the
+  file from your encrypted backup with the corrupt copy set aside for
+  inspection, and alerts you (telling you to rotate anything that may have
+  changed since the backup). It only ever acts on *proven* corruption, never on
+  a file that is simply different, and it validates the decrypted backup before
+  touching the original, so a bad backup can never make things worse. The
+  host-side guardian is the backstop: it watches the same files and steps in to
+  restore them if Genesis is too degraded to heal itself. Restores are
+  rate-capped, and installs without backups configured still get the detection
+  and alert. Requires the backup passphrase escrow shipped in the previous
+  release. (Backup-failure alerts also reach Telegram now — they were being
+  silently dropped on installs using the shipped `outreach.yaml`.)
+
 - **Three new honesty-first metric series on the dashboard's compounding
   panel, plus retrieval precision@3.** The weekly eval now tracks how your
   approval gates actually get resolved (by you vs. auto-expired vs.

--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -90,6 +90,22 @@ storage_pool:
   pool_used_crit_pct: 92
   realert_hours: 6
 
+# Credential-file integrity backstop (G.1). The container self-heals corrupt
+# credential files first (its awareness tick); the guardian validates the same
+# files via read-only `incus exec`, WARNs on first sight, and STEPS IN (restores
+# inside the container) only if the corruption survives grace_minutes — covering
+# the window a degraded/dead server's awareness loop can't. Machine specifics
+# stay empty (real container home + default backup path).
+cred_integrity:
+  enabled: true
+  grace_minutes: 30        # container self-heal window before the guardian steps in
+  realert_hours: 6
+  max_restores_per_day: 3  # per-target guardian step-in cap
+  check_timeout_s: 30
+  restore_timeout_s: 60
+  # backup_dir: ""         # container-side backup path; empty = module default
+  # container_home: ""     # empty = container's real home; set only for E2E
+
 recovery:
   verification_delay_s: 30
   max_escalations: 3

--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -74,6 +74,11 @@ health_alerts:
     - "provider:embedding_failing"
     - "provider:qdrant_unreachable"
     - "awareness:tick_overdue"
+    # Prefixes. This list REPLACES the code default when present, so anything the
+    # default escalates must be repeated here. backup: was missing (backup-failure
+    # alerts were silently non-escalating); creds: is new for G.1.
+    - "backup:"
+    - "creds:"
 
 # Voice proactive chiming — the spoken-aloud allowlist (THE menu).
 # A request is spoken through the Voice PE only if its signal_type or a

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -712,6 +712,7 @@ class AwarenessLoop:
         self._remediation_registry = None
         self._sentinel = None
         self._credential_bridge_fn = None
+        self._cred_integrity_fn = None
         self._autonomous_cli_policy_export_fn = None
         self._briefing_writer_fn = None
         self._findings_ingest_fn = None
@@ -1056,6 +1057,14 @@ class AwarenessLoop:
                     self._credential_bridge_fn()
                 except Exception:
                     logger.error("Credential bridge write failed", exc_info=True)
+
+            # Credential-file integrity: detect corruption + self-heal from backup
+            # (first responder; the host guardian steps in only if this doesn't).
+            if self._cred_integrity_fn:
+                try:
+                    self._cred_integrity_fn()
+                except Exception:
+                    logger.error("Credential integrity self-heal failed", exc_info=True)
 
             if self._autonomous_cli_policy_export_fn:
                 try:
@@ -1618,6 +1627,10 @@ class AwarenessLoop:
     def set_credential_bridge(self, fn) -> None:
         """Inject credential bridge for Telegram credential propagation."""
         self._credential_bridge_fn = fn
+
+    def set_cred_integrity_fn(self, fn) -> None:
+        """Inject the credential-file integrity check + self-heal (per tick)."""
+        self._cred_integrity_fn = fn
 
     def set_autonomous_cli_policy_exporter(self, fn) -> None:
         """Inject shared-mount exporter for effective autonomous CLI policy."""

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -325,6 +325,10 @@ async def run_check(config: GuardianConfig | None = None) -> None:
             config, dispatcher,
             genesis_down=(sm.current_state == GuardianState.CONFIRMED_DEAD),
         )
+        # Credential-file integrity backstop. The container self-heals first; the
+        # guardian WARNs on first sight and steps in only after the grace window —
+        # covering the window a degraded/dead server's awareness loop can't.
+        await _check_credential_integrity_and_alert(config, dispatcher)
     finally:
         # Always save state, even on error
         sm.save_state(state_path)
@@ -498,6 +502,20 @@ _POOL_TIER_SEVERITY = {
     "high": AlertSeverity.WARNING,
     "crit": AlertSeverity.CRITICAL,
 }
+
+
+async def _check_credential_integrity_and_alert(
+    config: GuardianConfig, dispatcher: AlertDispatcher,
+) -> None:
+    """Guardian-side credential-integrity backstop (delegates to cred_watch).
+
+    Never raises into the tick — a check exec failure is 'no signal', not an
+    alert (container-down is the state machine's job)."""
+    try:
+        from genesis.guardian.cred_watch import check_credential_integrity_and_alert
+        await check_credential_integrity_and_alert(config, dispatcher)
+    except Exception:
+        logger.warning("credential-integrity watch failed", exc_info=True)
 
 
 async def _check_storage_pool_and_alert(

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -171,6 +171,29 @@ class StoragePoolConfig:
 
 
 @dataclass
+class CredIntegrityConfig:
+    """Guardian-side credential-file integrity watch (G.1 escalation ladder).
+
+    The container's own awareness tick is the FIRST responder (detect + self-heal
+    from the encrypted backup). The guardian is the backstop: it validates the
+    same files via read-only ``incus exec`` each tick, WARNs on first sight
+    (deferring to the container's self-heal), and only STEPS IN — executing the
+    restore inside the container — if the corruption survives ``grace_minutes``.
+    This exists for the exact window the container can't cover itself: a
+    degraded/dead genesis-server whose awareness loop isn't ticking.
+    """
+
+    enabled: bool = True
+    grace_minutes: int = 30          # container self-heal window before guardian steps in
+    realert_hours: float = 6.0       # re-alert cadence while corruption persists
+    max_restores_per_day: int = 3    # per-target guardian step-in cap
+    check_timeout_s: int = 30
+    restore_timeout_s: int = 60
+    backup_dir: str = ""             # container-side backup path; "" = module default
+    container_home: str = ""         # "" = the container's real home; set only for E2E
+
+
+@dataclass
 class ProvisioningConfig:
     """Hypervisor provisioning (rung 5 of the escalation ladder).
 
@@ -240,6 +263,7 @@ class GuardianConfig:
     snapshots: SnapshotConfig = field(default_factory=SnapshotConfig)
     recovery: RecoveryConfig = field(default_factory=RecoveryConfig)
     storage_pool: StoragePoolConfig = field(default_factory=StoragePoolConfig)
+    cred_integrity: CredIntegrityConfig = field(default_factory=CredIntegrityConfig)
     provisioning: ProvisioningConfig = field(default_factory=ProvisioningConfig)
 
     @property
@@ -496,6 +520,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         snapshots=_build_sub(SnapshotConfig, raw, "snapshots"),
         recovery=_build_sub(RecoveryConfig, raw, "recovery"),
         storage_pool=_build_sub(StoragePoolConfig, raw, "storage_pool"),
+        cred_integrity=_build_sub(CredIntegrityConfig, raw, "cred_integrity"),
         provisioning=_build_sub(ProvisioningConfig, raw, "provisioning"),
     )
 

--- a/src/genesis/guardian/cred_integrity.py
+++ b/src/genesis/guardian/cred_integrity.py
@@ -396,8 +396,10 @@ def _default_home() -> Path:
     return Path(os.environ.get("HOME") or os.path.expanduser("~"))
 
 
-def _default_backup_dir() -> Path:
-    return _default_home() / "backups" / "genesis-backups"
+def _default_backup_dir(home: Path) -> Path:
+    # Derive from the RESOLVED home (respects --home), not $HOME — otherwise a
+    # --home sandbox / container_home override leaks to the real backup clone.
+    return home / "backups" / "genesis-backups"
 
 
 def _targets_by_name() -> dict[str, CredTarget]:
@@ -422,7 +424,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     home = Path(args.home).expanduser() if args.home else _default_home()
     backup_dir = (
-        Path(args.backup_dir).expanduser() if args.backup_dir else _default_backup_dir()
+        Path(args.backup_dir).expanduser() if args.backup_dir
+        else _default_backup_dir(home)
     )
     backup_arg = backup_dir if backup_dir.exists() else None
 

--- a/src/genesis/guardian/cred_integrity.py
+++ b/src/genesis/guardian/cred_integrity.py
@@ -1,0 +1,455 @@
+"""Credential-file integrity validation + restore — BOTH SIDES, standalone.
+
+CONTRACT: stdlib + PyYAML only. **ZERO ``genesis.*`` imports.** The host
+guardian pipes THIS FILE'S SOURCE into the container's *system* python3
+(``incus exec ... -- su - ubuntu -c "python3 - check --json"``, stdin = this
+source), so the module must run with no package context and survive a broken
+``.venv``. A subprocess parity test (``test_cred_integrity.py``) re-runs the
+module in pipe mode and fails the build if any ``genesis.*`` import creeps in.
+
+Two entry points, one implementation both sides share:
+
+- **check** (read-only): validate each target credential file; return only a
+  JSON verdict. No secret bytes ever cross the container boundary.
+- **restore** (mutating, container-only): decrypt the last-known-good copy from
+  the Tier-1 backup clone, validate the *decrypted* bytes with the same
+  validator BEFORE touching the original, move the corrupt original aside, then
+  atomically place the restored file. The passphrase is resolved locally
+  (env → validated secrets.env → host escrow) so the guardian process — which
+  only pipes the command — never handles it.
+
+Trigger policy (locked): restore fires STRICTLY on observed corruption
+(missing-with-backup / empty / NUL-zeroed / unparseable / missing structural
+key). A valid-but-different file is never touched — this is what protects a
+mid-refresh ``.credentials.json`` or an install that legitimately omits an
+optional key from a destructive restore.
+
+Sibling: ``credential_bridge.py`` owns the passphrase *escrow* write; this
+module is its *reader* on the restore path. Keep the two dotenv parsers in
+sync (both strip one quote layer; see the quoting caveat in credential_bridge).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+try:
+    import yaml  # PyYAML — present in the venv and in the container's system python3
+    _YAML_OK = True
+except ImportError:  # pragma: no cover - degradation path
+    _YAML_OK = False
+
+# ── Target inventory ────────────────────────────────────────────────────────
+# Paths are HOME-relative; backup_rel is relative to the Tier-1 backup clone
+# (~/backups/genesis-backups). Names/paths MUST match scripts/backup.sh §8 so a
+# corrupt file always has a decryptable last-known-good copy.
+
+
+@dataclass(frozen=True)
+class CredTarget:
+    name: str                 # stable id, e.g. "secrets_env"
+    path: str                 # HOME-relative, e.g. "genesis/secrets.env"
+    backup_rel: str           # inside the backup clone, e.g. "secrets/secrets.env.gpg"
+    kind: str                 # "dotenv" | "json" | "yaml" | "ssh_key"
+    required_keys: tuple[str, ...] = ()
+    min_keys: int = 0         # dotenv only — a truncation/zeroing guard
+    file_mode: int = 0o600
+
+
+# secrets.env deliberately carries NO required_keys: requiring a specific key
+# (e.g. ANTHROPIC_API_KEY) would false-positive a *destructive* restore on an
+# install that legitimately omits it, violating the strict-corruption rule. The
+# structural signals (empty / NUL-zeroed — the outage signature — / <min_keys)
+# catch the real threat without that risk. .credentials.json keeps its one
+# stable structural key (claudeAiOauth) — CC always writes it.
+DEFAULT_TARGETS: tuple[CredTarget, ...] = (
+    CredTarget("secrets_env", "genesis/secrets.env", "secrets/secrets.env.gpg",
+               "dotenv", min_keys=5),
+    CredTarget("claude_credentials", ".claude/.credentials.json",
+               "creds/claude_credentials.json.gpg", "json",
+               required_keys=("claudeAiOauth",)),
+    CredTarget("claude_json", ".claude.json", "creds/claude.json.gpg", "json"),
+    CredTarget("gh_hosts", ".config/gh/hosts.yml", "creds/gh_hosts.yml.gpg", "yaml"),
+    CredTarget("guardian_remote", ".genesis/guardian_remote.yaml",
+               "creds/guardian_remote.yaml.gpg", "yaml"),
+    CredTarget("genesis_yaml", ".genesis/config/genesis.yaml",
+               "creds/genesis.yaml.gpg", "yaml"),
+    CredTarget("ssh_guardian_key", ".ssh/genesis_guardian_ed25519",
+               "creds/ssh/genesis_guardian_ed25519.gpg", "ssh_key", file_mode=0o600),
+    CredTarget("ssh_id_ed25519", ".ssh/id_ed25519",
+               "creds/ssh/id_ed25519.gpg", "ssh_key", file_mode=0o600),
+)
+
+# Statuses that mean "corrupt and safe to restore from backup". "unreadable"
+# is deliberately excluded — a permission/IO error is ambiguous, not proven
+# corruption, so it alerts but never triggers a destructive overwrite.
+RESTORABLE_STATUSES = frozenset(
+    {"missing", "empty", "nul_bytes", "parse_error", "missing_keys"}
+)
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    ok: bool
+    status: str   # ok|absent|missing|empty|nul_bytes|parse_error|missing_keys|unreadable
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    ok: bool
+    action: str   # restored|skipped_no_backup|skipped_no_passphrase|backup_invalid|
+                  # decrypt_failed|restore_verify_failed|error
+    aside_path: str | None = None
+    backup_mtime: str | None = None
+    detail: str = ""
+
+
+# ── Pure validation ─────────────────────────────────────────────────────────
+
+
+def _parse_dotenv(text: str) -> dict[str, str]:
+    """Minimal key=value parser (mirrors credential_bridge._read_dotenv)."""
+    result: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if key.startswith("export "):
+            key = key[7:].strip()
+        if key:
+            result[key] = value.strip().strip("'\"")
+    return result
+
+
+def validate_bytes(
+    kind: str,
+    data: bytes,
+    required_keys: tuple[str, ...] = (),
+    min_keys: int = 0,
+) -> ValidationResult:
+    """Validate raw file bytes. Pure — the single implementation both sides use."""
+    if not data or not data.strip():
+        return ValidationResult(False, "empty", "file is empty")
+    if b"\x00" in data:
+        return ValidationResult(False, "nul_bytes", "contains NUL bytes (zeroed write)")
+
+    if kind == "ssh_key":
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            return ValidationResult(False, "parse_error", "not valid UTF-8")
+        first = next((ln for ln in text.splitlines() if ln.strip()), "")
+        if first.startswith("-----BEGIN ") and "PRIVATE KEY" in first:
+            return ValidationResult(True, "ok")
+        return ValidationResult(False, "parse_error", "missing OpenSSH private-key header")
+
+    if kind == "dotenv":
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            return ValidationResult(False, "parse_error", "not valid UTF-8")
+        parsed = _parse_dotenv(text)
+        if len(parsed) < max(min_keys, 1):
+            return ValidationResult(
+                False, "parse_error", f"only {len(parsed)} keys (min {min_keys})"
+            )
+        missing = [k for k in required_keys if not parsed.get(k)]
+        if missing:
+            return ValidationResult(False, "missing_keys", f"missing {','.join(missing)}")
+        return ValidationResult(True, "ok")
+
+    if kind == "json":
+        try:
+            obj = json.loads(data)
+        except (ValueError, UnicodeDecodeError) as exc:
+            return ValidationResult(False, "parse_error", f"invalid JSON: {exc}")
+        if not isinstance(obj, dict) or not obj:
+            return ValidationResult(False, "parse_error", "not a non-empty JSON object")
+        missing = [k for k in required_keys if k not in obj]
+        if missing:
+            return ValidationResult(False, "missing_keys", f"missing {','.join(missing)}")
+        return ValidationResult(True, "ok")
+
+    if kind == "yaml":
+        if not _YAML_OK:
+            # Degraded: without PyYAML we can only confirm non-empty/no-NUL (done
+            # above). Report ok so a missing library never triggers a false restore.
+            return ValidationResult(True, "ok", "yaml_unavailable")
+        try:
+            obj = yaml.safe_load(data)
+        except yaml.YAMLError as exc:
+            return ValidationResult(False, "parse_error", f"invalid YAML: {exc}")
+        if not isinstance(obj, dict) or not obj:
+            return ValidationResult(False, "parse_error", "not a non-empty YAML mapping")
+        return ValidationResult(True, "ok")
+
+    return ValidationResult(False, "parse_error", f"unknown kind {kind!r}")
+
+
+def validate_file(
+    target: CredTarget, home: Path, backup_dir: Path | None
+) -> ValidationResult:
+    """Validate one target on disk. Missing disambiguates on backup presence:
+    missing + backup exists → corruption ("missing"); missing + no backup →
+    never provisioned ("absent", healthy — the clean degradation for installs
+    without backups or without an optional file like genesis.yaml)."""
+    path = home / target.path
+    if not path.exists():
+        has_backup = backup_dir is not None and (backup_dir / target.backup_rel).exists()
+        if has_backup:
+            return ValidationResult(False, "missing", f"{path} absent but backup exists")
+        return ValidationResult(True, "absent", f"{path} never provisioned")
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return ValidationResult(False, "unreadable", f"read failed: {exc}")
+    return validate_bytes(target.kind, data, target.required_keys, target.min_keys)
+
+
+def check_all(
+    targets: tuple[CredTarget, ...] | None,
+    home: Path,
+    backup_dir: Path | None,
+) -> dict[str, ValidationResult]:
+    tgts = targets if targets is not None else DEFAULT_TARGETS
+    return {t.name: validate_file(t, home, backup_dir) for t in tgts}
+
+
+# ── Restore (container-only side effects) ───────────────────────────────────
+
+
+class _DecryptError(Exception):
+    pass
+
+
+def _gpg_decrypt(src: Path, passphrase: str) -> bytes:
+    """Symmetric-decrypt a backup .gpg to bytes. Matches scripts/restore.sh:
+    ``gpg --batch --yes --passphrase-fd 0 -d <src>`` (passphrase on stdin)."""
+    try:
+        proc = subprocess.run(
+            ["gpg", "--batch", "--yes", "--quiet", "--passphrase-fd", "0", "-d", str(src)],
+            input=passphrase.encode("utf-8"),
+            capture_output=True,
+            timeout=60,
+        )
+    except FileNotFoundError as exc:
+        raise _DecryptError("gpg not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise _DecryptError("gpg decrypt timed out") from exc
+    if proc.returncode != 0:
+        # stderr carries no passphrase; trim to keep logs bounded.
+        raise _DecryptError(
+            proc.stderr.decode("utf-8", "replace").strip()[:200] or "gpg failed"
+        )
+    return proc.stdout
+
+
+def restore_file(
+    target: CredTarget, *, home: Path, backup_dir: Path, passphrase: str
+) -> RestoreResult:
+    """Restore one target from its encrypted backup. Order is the safety
+    property: decrypt → validate decrypted → (only then) move original aside →
+    atomic place → re-validate. A bad backup never destroys a present original."""
+    src = backup_dir / target.backup_rel
+    if not src.exists():
+        return RestoreResult(False, "skipped_no_backup", detail=f"no backup at {src}")
+
+    try:
+        data = _gpg_decrypt(src, passphrase)
+    except _DecryptError as exc:
+        return RestoreResult(False, "decrypt_failed", detail=str(exc))
+
+    decrypted = validate_bytes(target.kind, data, target.required_keys, target.min_keys)
+    if not decrypted.ok:
+        return RestoreResult(
+            False, "backup_invalid",
+            detail=f"decrypted backup {decrypted.status}: {decrypted.detail}",
+        )
+
+    target_path = home / target.path
+    try:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if target.kind == "ssh_key":
+            os.chmod(target_path.parent, 0o700)
+
+        tmp = target_path.with_name(f".{target_path.name}.restore-tmp-{os.getpid()}")
+        fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
+        os.chmod(tmp, target.file_mode)
+
+        aside: Path | None = None
+        if target_path.exists():
+            stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+            aside = target_path.with_name(f"{target_path.name}.corrupt-{stamp}")
+            os.replace(target_path, aside)
+            with contextlib.suppress(OSError):
+                os.chmod(aside, 0o600)  # the corrupt original is still sensitive
+
+        os.replace(tmp, target_path)
+    except OSError as exc:
+        return RestoreResult(False, "error", detail=f"placement failed: {exc}")
+
+    placed = validate_file(target, home, backup_dir)
+    mtime = datetime.fromtimestamp(src.stat().st_mtime, UTC).isoformat()
+    if not placed.ok:
+        return RestoreResult(
+            False, "restore_verify_failed",
+            aside_path=str(aside) if aside else None,
+            backup_mtime=mtime, detail=f"placed file {placed.status}",
+        )
+    return RestoreResult(
+        True, "restored",
+        aside_path=str(aside) if aside else None,
+        backup_mtime=mtime, detail=f"restored from backup dated {mtime}",
+    )
+
+
+# ── Passphrase resolution (container-side) ──────────────────────────────────
+
+
+def resolve_passphrase(home: Path) -> str | None:
+    """env → validated secrets.env → host escrow. The escrow is the exit for the
+    circular case (secrets.env itself corrupt → its passphrase is unusable)."""
+    env_pass = os.environ.get("GENESIS_BACKUP_PASSPHRASE", "").strip()
+    if env_pass:
+        return env_pass
+
+    secrets = home / "genesis/secrets.env"
+    if secrets.exists():
+        try:
+            raw = secrets.read_bytes()
+        except OSError:
+            raw = b""
+        # Only trust secrets.env for the passphrase if it is NOT itself corrupt.
+        if validate_bytes("dotenv", raw, min_keys=1).ok:
+            val = _parse_dotenv(raw.decode("utf-8", "replace")).get(
+                "GENESIS_BACKUP_PASSPHRASE", ""
+            ).strip()
+            if val:
+                return val
+
+    escrow = home / ".genesis/shared/guardian/backup_passphrase.env"
+    if escrow.exists():
+        try:
+            val = _parse_dotenv(escrow.read_text()).get(
+                "GENESIS_BACKUP_PASSPHRASE", ""
+            ).strip()
+            if val:
+                return val
+        except OSError:
+            pass
+    return None
+
+
+# ── Rate-cap helper (shared policy primitive) ───────────────────────────────
+
+
+def allowed_restore(attempt_isotimes: list[str], now: datetime, max_per_day: int) -> bool:
+    """True if fewer than max_per_day restore attempts fall in the last 24h."""
+    if max_per_day <= 0:
+        return False
+    cutoff = now.timestamp() - 86400
+    recent = 0
+    for iso in attempt_isotimes:
+        try:
+            if datetime.fromisoformat(iso).timestamp() >= cutoff:
+                recent += 1
+        except ValueError:
+            continue
+    return recent < max_per_day
+
+
+# ── CLI (works as `python -m ...` and as `python3 - <args>` pipe) ───────────
+
+
+def _default_home() -> Path:
+    return Path(os.environ.get("HOME") or os.path.expanduser("~"))
+
+
+def _default_backup_dir() -> Path:
+    return _default_home() / "backups" / "genesis-backups"
+
+
+def _targets_by_name() -> dict[str, CredTarget]:
+    return {t.name: t for t in DEFAULT_TARGETS}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="cred_integrity", add_help=True)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_check = sub.add_parser("check")
+    p_check.add_argument("--json", action="store_true")
+    p_check.add_argument("--home", default=None)
+    p_check.add_argument("--backup-dir", default=None)
+
+    p_restore = sub.add_parser("restore")
+    p_restore.add_argument("--target", required=True)
+    p_restore.add_argument("--json", action="store_true")
+    p_restore.add_argument("--home", default=None)
+    p_restore.add_argument("--backup-dir", default=None)
+
+    args = parser.parse_args(argv)
+    home = Path(args.home).expanduser() if args.home else _default_home()
+    backup_dir = (
+        Path(args.backup_dir).expanduser() if args.backup_dir else _default_backup_dir()
+    )
+    backup_arg = backup_dir if backup_dir.exists() else None
+
+    if args.cmd == "check":
+        results = check_all(None, home, backup_arg)
+        payload = {
+            "version": 1,
+            "results": {
+                name: {
+                    "ok": r.ok,
+                    "status": r.status,
+                    "detail": r.detail,
+                    "path": str(home / _targets_by_name()[name].path),
+                    "backup_exists": backup_arg is not None
+                    and (backup_dir / _targets_by_name()[name].backup_rel).exists(),
+                }
+                for name, r in results.items()
+            },
+        }
+        print(json.dumps(payload))
+        return 0
+
+    # restore
+    target = _targets_by_name().get(args.target)
+    if target is None:
+        print(json.dumps({"ok": False, "action": "error", "detail": "unknown target"}))
+        return 0
+    if backup_arg is None:
+        print(json.dumps({"ok": False, "action": "skipped_no_backup",
+                          "detail": "no backup dir"}))
+        return 0
+    passphrase = resolve_passphrase(home)
+    if not passphrase:
+        print(json.dumps({"ok": False, "action": "skipped_no_passphrase",
+                          "detail": "no passphrase in env/secrets/escrow"}))
+        return 0
+    result = restore_file(target, home=home, backup_dir=backup_dir, passphrase=passphrase)
+    print(json.dumps({
+        "ok": result.ok, "action": result.action, "aside_path": result.aside_path,
+        "backup_mtime": result.backup_mtime, "detail": result.detail,
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesis/guardian/cred_integrity.py
+++ b/src/genesis/guardian/cred_integrity.py
@@ -38,8 +38,14 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
+
+# This module is piped into the container's *system* python3, whose version is
+# unknown (an install may leave python3 at 3.10 while provisioning 3.12
+# elsewhere). Stay portable to 3.9+: use timezone.utc, not datetime.UTC (3.11+).
+# (UP017 would "modernize" this to datetime.UTC — exactly what breaks 3.10.)
+_UTC = timezone.utc  # noqa: UP017
 
 try:
     import yaml  # PyYAML — present in the venv and in the container's system python3
@@ -302,7 +308,7 @@ def restore_file(
         os.chmod(tmp, target.file_mode)
 
         if target_path.exists():
-            stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+            stamp = datetime.now(_UTC).strftime("%Y%m%dT%H%M%SZ")
             aside = target_path.with_name(f"{target_path.name}.corrupt-{stamp}")
             os.replace(target_path, aside)
             with contextlib.suppress(OSError):
@@ -320,7 +326,7 @@ def restore_file(
         )
 
     placed = validate_file(target, home, backup_dir)
-    mtime = datetime.fromtimestamp(src.stat().st_mtime, UTC).isoformat()
+    mtime = datetime.fromtimestamp(src.stat().st_mtime, _UTC).isoformat()
     if not placed.ok:
         return RestoreResult(
             False, "restore_verify_failed",

--- a/src/genesis/guardian/cred_integrity.py
+++ b/src/genesis/guardian/cred_integrity.py
@@ -64,15 +64,17 @@ class CredTarget:
     file_mode: int = 0o600
 
 
-# secrets.env deliberately carries NO required_keys: requiring a specific key
-# (e.g. ANTHROPIC_API_KEY) would false-positive a *destructive* restore on an
-# install that legitimately omits it, violating the strict-corruption rule. The
-# structural signals (empty / NUL-zeroed — the outage signature — / <min_keys)
-# catch the real threat without that risk. .credentials.json keeps its one
-# stable structural key (claudeAiOauth) — CC always writes it.
+# secrets.env deliberately carries NO required_keys and min_keys=1: requiring a
+# specific key (e.g. ANTHROPIC_API_KEY) or a key-count floor would false-positive
+# a *destructive* restore on an install that legitimately omits a key or ships a
+# small secrets.env, violating the strict-corruption rule. min_keys=1 means only
+# a file that parses to ZERO valid keys (garbage / all-comments) is corrupt; the
+# real outage signatures (empty, NUL-zeroed) are caught by the pre-checks above.
+# .credentials.json keeps its one stable structural key (claudeAiOauth) — CC
+# always writes it, and missing_keys is debounced 2 ticks before any restore.
 DEFAULT_TARGETS: tuple[CredTarget, ...] = (
     CredTarget("secrets_env", "genesis/secrets.env", "secrets/secrets.env.gpg",
-               "dotenv", min_keys=5),
+               "dotenv", min_keys=1),
     CredTarget("claude_credentials", ".claude/.credentials.json",
                "creds/claude_credentials.json.gpg", "json",
                required_keys=("claudeAiOauth",)),
@@ -233,6 +235,13 @@ class _DecryptError(Exception):
     pass
 
 
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte — os.write may short-write; a truncated secret is unsafe."""
+    view = memoryview(data)
+    while view:
+        view = view[os.write(fd, view):]
+
+
 def _gpg_decrypt(src: Path, passphrase: str) -> bytes:
     """Symmetric-decrypt a backup .gpg to bytes. Matches scripts/restore.sh:
     ``gpg --batch --yes --passphrase-fd 0 -d <src>`` (passphrase on stdin)."""
@@ -278,20 +287,20 @@ def restore_file(
         )
 
     target_path = home / target.path
+    tmp = target_path.with_name(f".{target_path.name}.restore-tmp-{os.getpid()}")
+    aside: Path | None = None
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         if target.kind == "ssh_key":
             os.chmod(target_path.parent, 0o700)
 
-        tmp = target_path.with_name(f".{target_path.name}.restore-tmp-{os.getpid()}")
         fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         try:
-            os.write(fd, data)
+            _write_all(fd, data)
         finally:
             os.close(fd)
         os.chmod(tmp, target.file_mode)
 
-        aside: Path | None = None
         if target_path.exists():
             stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
             aside = target_path.with_name(f"{target_path.name}.corrupt-{stamp}")
@@ -301,7 +310,14 @@ def restore_file(
 
         os.replace(tmp, target_path)
     except OSError as exc:
-        return RestoreResult(False, "error", detail=f"placement failed: {exc}")
+        # Never leave a plaintext temp of the decrypted secret behind.
+        with contextlib.suppress(OSError):
+            if tmp.exists():
+                tmp.unlink()
+        return RestoreResult(
+            False, "error", aside_path=str(aside) if aside else None,
+            detail=f"placement failed: {exc}",
+        )
 
     placed = validate_file(target, home, backup_dir)
     mtime = datetime.fromtimestamp(src.stat().st_mtime, UTC).isoformat()

--- a/src/genesis/guardian/cred_selfheal.py
+++ b/src/genesis/guardian/cred_selfheal.py
@@ -1,0 +1,235 @@
+"""Container-side credential self-heal — runs on the awareness tick + at startup.
+
+Wraps the standalone validator (``cred_integrity``) with the container's policy:
+detect corruption, restore from the encrypted backup, and write a status file
+that the health-alert path (``mcp/health/errors.py``) surfaces to Telegram.
+
+This is the FIRST responder in the G.1 escalation ladder — the host guardian
+only steps in if the container fails to self-heal within its grace window.
+
+Debounce policy (protects a legitimate writer caught mid-rewrite, e.g. Claude
+Code rewriting ~/.claude.json):
+- ``empty`` / ``nul_bytes`` / ``missing`` — the outage signature; restore now.
+- ``parse_error`` / ``missing_keys`` — restore only if still corrupt next tick
+  (2-tick confirmation). At startup there is no live writer, so restore now.
+- ``unreadable`` — ambiguous (permission/IO), alert-only, never a destructive
+  restore.
+
+Restores are rate-capped per target (``max_restores_per_day``) so a bad backup
+copy can't drive a restore loop; the cap then alerts instead.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.guardian.cred_integrity import (
+    DEFAULT_TARGETS,
+    RESTORABLE_STATUSES,
+    allowed_restore,
+    check_all,
+    resolve_passphrase,
+    restore_file,
+)
+
+logger = logging.getLogger(__name__)
+
+_STATUS_VERSION = 1
+_IMMEDIATE_STATUSES = frozenset({"empty", "nul_bytes", "missing"})
+_RESTORED_TTL_S = 86400  # keep a "restored" status visible for 24h (alert dedup window)
+_MAX_EVENTS = 20
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _load_status(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_status(path: Path, payload: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".cred_status.")
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(payload, fh)
+            os.replace(tmp, path)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+    except OSError:
+        logger.warning("failed to write cred integrity status", exc_info=True)
+
+
+def check_and_selfheal(
+    *,
+    home: Path | None = None,
+    backup_dir: Path | None = None,
+    status_path: Path | None = None,
+    max_restores_per_day: int = 3,
+    startup: bool = False,
+    targets=None,
+) -> dict:
+    """Validate all credential targets; restore corrupt ones from backup.
+
+    Returns the status dict (also persisted to ``status_path``). Never raises —
+    the awareness loop invokes this zero-arg and must not be broken by it.
+    """
+    home = home or Path.home()
+    if backup_dir is None:
+        candidate = home / "backups" / "genesis-backups"
+        backup_dir = candidate if candidate.exists() else None
+    status_path = status_path or (home / ".genesis" / "cred_integrity_status.json")
+    tgts = targets if targets is not None else DEFAULT_TARGETS
+    by_name = {t.name: t for t in tgts}
+
+    prior = _load_status(status_path).get("targets", {})
+    now = _now()
+    now_iso = now.isoformat()
+    out_targets: dict[str, dict] = {}
+    events: list[str] = []
+
+    try:
+        results = check_all(tgts, home, backup_dir)
+    except Exception:  # noqa: BLE001 — must never break the tick
+        logger.warning("cred integrity check failed", exc_info=True)
+        return _load_status(status_path)
+
+    for name, vr in results.items():
+        target = by_name[name]
+        prev = prior.get(name, {})
+        attempts: list[str] = list(prev.get("restore_attempts", []))
+
+        # Healthy (ok / absent): keep a recent "restored" visible for its TTL so
+        # the CRITICAL creds:restored alert fires, then collapse to ok.
+        if vr.ok:
+            if prev.get("status") == "restored":
+                last = prev.get("last_event_at")
+                if last and (now - _isoparse(last)).total_seconds() < _RESTORED_TTL_S:
+                    out_targets[name] = {**prev}  # preserve the restored record
+                    continue
+            out_targets[name] = {"status": "ok", "detail": vr.detail}
+            continue
+
+        # Corrupt. first_seen persists across ticks until it resolves.
+        first_seen = prev.get("first_seen", now_iso)
+
+        # Unreadable → alert-only, never restore.
+        if vr.status not in RESTORABLE_STATUSES:
+            out_targets[name] = {
+                "status": "corrupt", "detail": f"{vr.status}: {vr.detail}",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: {vr.status} (alert-only)")
+            continue
+
+        immediate = startup or vr.status in _IMMEDIATE_STATUSES
+        confirmed = prev.get("status") == "corrupt_pending"
+
+        if not immediate and not confirmed:
+            # First sighting of an ambiguous corruption — wait one tick.
+            out_targets[name] = {
+                "status": "corrupt_pending", "detail": f"{vr.status}: {vr.detail}",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: {vr.status} (pending 2-tick confirm)")
+            continue
+
+        # Restore. Rate-cap first.
+        if not allowed_restore(attempts, now, max_restores_per_day):
+            out_targets[name] = {
+                "status": "restore_failed",
+                "detail": f"{vr.status}; rate cap reached ({max_restores_per_day}/day)",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: restore rate-capped")
+            continue
+
+        if backup_dir is None:
+            out_targets[name] = {
+                "status": "corrupt", "detail": f"{vr.status}; no backup configured",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: {vr.status} (no backup to restore from)")
+            continue
+
+        passphrase = resolve_passphrase(home)
+        if not passphrase:
+            out_targets[name] = {
+                "status": "restore_failed",
+                "detail": f"{vr.status}; no passphrase (env/secrets/escrow)",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: no passphrase to decrypt backup")
+            continue
+
+        attempts.append(now_iso)
+        try:
+            rr = restore_file(
+                target, home=home, backup_dir=backup_dir, passphrase=passphrase
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("restore_file raised for %s", name, exc_info=True)
+            out_targets[name] = {
+                "status": "restore_failed", "detail": f"restore error: {exc}",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: restore raised {exc}")
+            continue
+
+        if rr.ok:
+            logger.warning(
+                "cred self-heal: RESTORED %s from backup (%s)", name, rr.backup_mtime
+            )
+            out_targets[name] = {
+                "status": "restored", "detail": rr.detail,
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+                "aside_path": rr.aside_path, "backup_mtime": rr.backup_mtime,
+            }
+            events.append(f"{name}: restored from backup dated {rr.backup_mtime}")
+        else:
+            logger.error("cred self-heal: restore FAILED for %s (%s)", name, rr.action)
+            out_targets[name] = {
+                "status": "restore_failed", "detail": f"{rr.action}: {rr.detail}",
+                "first_seen": first_seen, "last_event_at": now_iso,
+                "restore_attempts": attempts,
+            }
+            events.append(f"{name}: restore failed ({rr.action})")
+
+    prior_events = _load_status(status_path).get("recent_events", [])
+    stamped = [f"{now_iso} {e}" for e in events]
+    payload = {
+        "version": _STATUS_VERSION,
+        "checked_at": now_iso,
+        "targets": out_targets,
+        "recent_events": (stamped + prior_events)[:_MAX_EVENTS],
+    }
+    _write_status(status_path, payload)
+    return payload
+
+
+def _isoparse(value: str) -> datetime:
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return datetime.min.replace(tzinfo=UTC)
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)

--- a/src/genesis/guardian/cred_watch.py
+++ b/src/genesis/guardian/cred_watch.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from genesis.guardian import cred_integrity
 from genesis.guardian.alert.base import Alert, AlertSeverity
-from genesis.guardian.cred_integrity import allowed_restore
+from genesis.guardian.cred_integrity import RESTORABLE_STATUSES, allowed_restore
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +212,14 @@ async def check_credential_integrity_and_alert(config, dispatcher) -> None:
         for name, r in results.items()
         if not r.get("ok", True) and r.get("status") != "absent"
     }
+    # Raw status per corrupt target — the guardian only auto-restores RESTORABLE
+    # statuses. "unreadable" (permission/IO) is ambiguous, not proven corruption,
+    # so it alerts but is never stepped-in on (mirrors the container self-heal).
+    corrupt_status: dict[str, str] = {
+        name: r.get("status", "")
+        for name, r in results.items()
+        if not r.get("ok", True) and r.get("status") != "absent"
+    }
 
     for name in set(list(corrupt) + list(episodes)):
         is_corrupt = name in corrupt
@@ -257,6 +265,17 @@ async def check_credential_integrity_and_alert(config, dispatcher) -> None:
             episode["last_status"] = corrupt[name]
             episode["stepped_in_at"] = now_iso
             episode["last_alert_at"] = now_iso
+            # Only auto-restore proven-corrupt (restorable) statuses. An
+            # "unreadable" verdict is ambiguous — alert for manual action, never
+            # overwrite a file that was not proven corrupt.
+            if corrupt_status.get(name) not in RESTORABLE_STATUSES:
+                await _send(dispatcher, AlertSeverity.CRITICAL,
+                            f"Credential unreadable: {name}",
+                            f"{name} is {corrupt[name]} and the container did not "
+                            f"resolve it in {cfg.grace_minutes} min. This is not a "
+                            "proven-corrupt state (permission/IO?), so the guardian "
+                            "will NOT auto-restore — manual intervention needed.")
+                continue
             if not allowed_restore(attempts, now, cfg.max_restores_per_day):
                 episode["restore_attempts"] = attempts
                 await _send(dispatcher, AlertSeverity.CRITICAL,

--- a/src/genesis/guardian/cred_watch.py
+++ b/src/genesis/guardian/cred_watch.py
@@ -1,0 +1,283 @@
+"""Guardian-side credential-integrity watch — the escalation-ladder backstop.
+
+The container self-heals first (its awareness tick). The guardian validates the
+same files independently via read-only ``incus exec``, WARNs on first sight
+(deferring to the container), and STEPS IN — running the restore inside the
+container — only if the corruption survives ``grace_minutes``. This covers the
+one window the container can't: a degraded/dead genesis-server whose awareness
+loop isn't running.
+
+Both the check and the restore run the SAME validator bytes as the container:
+the guardian pipes ``cred_integrity.py``'s source into the container's *system*
+python3 (survives a broken ``.venv``); only a JSON verdict crosses back, and the
+passphrase is resolved container-side, so the guardian never handles a secret.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.guardian import cred_integrity
+from genesis.guardian.alert.base import Alert, AlertSeverity
+from genesis.guardian.cred_integrity import allowed_restore
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = "cred_alert_state.json"
+
+
+@dataclass(frozen=True)
+class EpisodeDecision:
+    action: str   # none | warn | step_in | realert | resolved
+    reason: str
+
+
+def _parse(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def decide(name: str, is_corrupt: bool, episode: dict | None, now: datetime, cfg) -> EpisodeDecision:
+    """Pure escalation decision for one target (fully unit-tested)."""
+    if not is_corrupt:
+        if episode and episode.get("warned_at"):
+            return EpisodeDecision("resolved", "corruption cleared")
+        return EpisodeDecision("none", "healthy")
+
+    if episode is None:
+        return EpisodeDecision("warn", "first detection — defer to container self-heal")
+
+    first_seen = _parse(episode.get("first_seen")) or now
+    elapsed = (now - first_seen).total_seconds()
+    grace = cfg.grace_minutes * 60
+    stepped = bool(episode.get("stepped_in_at"))
+
+    if not stepped:
+        if elapsed < grace:
+            return EpisodeDecision("none", "in grace, deferring to container self-heal")
+        return EpisodeDecision("step_in", "grace expired — container did not self-heal")
+
+    # Already stepped in but still corrupt → re-alert on cadence only.
+    last_alert = _parse(episode.get("last_alert_at"))
+    if last_alert and (now - last_alert).total_seconds() < cfg.realert_hours * 3600:
+        return EpisodeDecision("none", "already stepped in, within re-alert window")
+    return EpisodeDecision("realert", "still corrupt after guardian step-in")
+
+
+async def _incus_exec_stdin(
+    container: str, cmd_str: str, stdin_data: bytes, timeout: float,
+) -> tuple[int, str]:
+    """Run ``su - ubuntu -c <cmd_str>`` in the container, piping stdin_data.
+
+    Mirrors the heartbeat writer (check.py) — collector._incus_exec has no stdin
+    support, so this is a local variant. Returns (rc, stdout)."""
+    proc = await asyncio.create_subprocess_exec(
+        "incus", "exec", container, "--",
+        "su", "-", "ubuntu", "-c", cmd_str,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await asyncio.wait_for(proc.communicate(input=stdin_data), timeout=timeout)
+    if proc.returncode != 0:
+        logger.debug(
+            "cred_watch incus exec rc=%s: %s",
+            proc.returncode, err.decode("utf-8", "replace")[:200],
+        )
+    return proc.returncode or 0, out.decode("utf-8", "replace")
+
+
+def _extract_json(stdout: str) -> dict | None:
+    """Parse the JSON verdict, tolerant of any login-shell preamble on stdout."""
+    for line in stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    return obj
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+def _build_cmd(subcmd_args: str, cfg) -> str:
+    import shlex
+    cmd = f"python3 - {subcmd_args}"
+    if cfg.container_home:
+        cmd += f" --home {shlex.quote(cfg.container_home)}"
+    if cfg.backup_dir:
+        cmd += f" --backup-dir {shlex.quote(cfg.backup_dir)}"
+    return cmd
+
+
+async def run_container_check(config) -> dict | None:
+    """Pipe the validator into the container and return its JSON verdict, or None
+    on any exec/parse failure (treated as 'no signal' — never a false alert)."""
+    cfg = config.cred_integrity
+    src = Path(cred_integrity.__file__).read_bytes()
+    cmd = _build_cmd("check --json", cfg)
+    try:
+        rc, out = await _incus_exec_stdin(
+            config.container_name, cmd, src, cfg.check_timeout_s,
+        )
+    except (TimeoutError, OSError):
+        logger.warning("cred_watch check exec failed", exc_info=True)
+        return None
+    if rc != 0:
+        return None
+    return _extract_json(out)
+
+
+async def run_container_restore(config, target_name: str) -> dict | None:
+    cfg = config.cred_integrity
+    src = Path(cred_integrity.__file__).read_bytes()
+    cmd = _build_cmd(f"restore --target {target_name} --json", cfg)
+    try:
+        rc, out = await _incus_exec_stdin(
+            config.container_name, cmd, src, cfg.restore_timeout_s,
+        )
+    except (TimeoutError, OSError):
+        logger.warning("cred_watch restore exec failed", exc_info=True)
+        return None
+    if rc != 0:
+        return None
+    return _extract_json(out)
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text()).get("episodes", {})
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_state(path: Path, episodes: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"version": 1, "episodes": episodes}))
+    except OSError:
+        logger.warning("failed to persist cred alert state", exc_info=True)
+
+
+async def check_credential_integrity_and_alert(config, dispatcher) -> None:
+    """Guardian tick: validate container credential files, escalate per the ladder.
+
+    Never raises into the tick. Alerts go through the host dispatcher (survives a
+    dead container — exactly the window the guardian is here for)."""
+    cfg = config.cred_integrity
+    if not cfg.enabled:
+        return
+
+    report = await run_container_check(config)
+    if report is None:
+        logger.debug("cred_watch: no verdict this tick (container unreachable?)")
+        return
+
+    results = report.get("results", {})
+    now = datetime.now(UTC)
+    now_iso = now.isoformat()
+    state_file = config.state_path / _STATE_FILE
+    episodes = _load_state(state_file)
+
+    corrupt: dict[str, str] = {
+        name: f"{r.get('status')}: {r.get('detail', '')}".strip(": ")
+        for name, r in results.items()
+        if not r.get("ok", True) and r.get("status") != "absent"
+    }
+
+    for name in set(list(corrupt) + list(episodes)):
+        is_corrupt = name in corrupt
+        episode = episodes.get(name)
+        decision = decide(name, is_corrupt, episode, now, cfg)
+
+        if decision.action == "none":
+            if is_corrupt and episode is not None:
+                episode["last_status"] = corrupt[name]
+            continue
+
+        if decision.action == "resolved":
+            episodes.pop(name, None)
+            await _send(dispatcher, AlertSeverity.INFO,
+                        "Credential file recovered",
+                        f"{name} is valid again — corruption cleared.")
+            continue
+
+        if decision.action == "warn":
+            episodes[name] = {
+                "first_seen": now_iso, "last_status": corrupt[name],
+                "warned_at": now_iso, "last_alert_at": now_iso,
+                "restore_attempts": [], "stepped_in_at": None,
+            }
+            await _send(dispatcher, AlertSeverity.WARNING,
+                        f"Credential corruption: {name}",
+                        f"{name} is {corrupt[name]}. Deferring to container "
+                        f"self-heal for {cfg.grace_minutes} min before the "
+                        "guardian steps in.")
+            continue
+
+        if decision.action == "realert":
+            episode["last_alert_at"] = now_iso
+            episode["last_status"] = corrupt[name]
+            await _send(dispatcher, AlertSeverity.CRITICAL,
+                        f"Credential still corrupt: {name}",
+                        f"{name} remains {corrupt[name]} after a guardian restore "
+                        "attempt — manual intervention needed.")
+            continue
+
+        if decision.action == "step_in":
+            attempts = list(episode.get("restore_attempts", []))
+            episode["last_status"] = corrupt[name]
+            episode["stepped_in_at"] = now_iso
+            episode["last_alert_at"] = now_iso
+            if not allowed_restore(attempts, now, cfg.max_restores_per_day):
+                episode["restore_attempts"] = attempts
+                await _send(dispatcher, AlertSeverity.CRITICAL,
+                            f"Credential restore rate-capped: {name}",
+                            f"{name} still {corrupt[name]} and the "
+                            f"{cfg.max_restores_per_day}/day restore cap is reached "
+                            "— the backup copy may itself be bad. Manual action needed.")
+                continue
+
+            attempts.append(now_iso)
+            episode["restore_attempts"] = attempts
+            result = await run_container_restore(config, name)
+            recheck = await run_container_check(config)
+            now_ok = bool(
+                recheck and recheck.get("results", {}).get(name, {}).get("ok")
+            )
+            if result and result.get("ok") and now_ok:
+                await _send(dispatcher, AlertSeverity.CRITICAL,
+                            f"Guardian restored credential: {name}",
+                            f"Container did not self-heal in {cfg.grace_minutes} min; "
+                            f"the guardian restored {name} from backup "
+                            f"(dated {result.get('backup_mtime', '?')}). "
+                            "Rotate it if it changed since the backup.")
+            else:
+                action = (result or {}).get("action", "exec_failed")
+                detail = (result or {}).get("detail", "")
+                await _send(dispatcher, AlertSeverity.CRITICAL,
+                            f"Guardian restore FAILED: {name}",
+                            f"{name} still corrupt — restore {action}: {detail}. "
+                            "Manual intervention needed.")
+
+    _save_state(state_file, episodes)
+
+
+async def _send(dispatcher, severity: AlertSeverity, title: str, body: str) -> None:
+    try:
+        await dispatcher.send(Alert(severity=severity, title=title, body=body))
+    except Exception:
+        logger.warning("failed to send cred integrity alert", exc_info=True)

--- a/src/genesis/guardian/cred_watch.py
+++ b/src/genesis/guardian/cred_watch.py
@@ -16,8 +16,10 @@ passphrase is resolved container-side, so the guardian never handles a secret.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+import shlex
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -88,7 +90,15 @@ async def _incus_exec_stdin(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    out, err = await asyncio.wait_for(proc.communicate(input=stdin_data), timeout=timeout)
+    try:
+        out, err = await asyncio.wait_for(
+            proc.communicate(input=stdin_data), timeout=timeout,
+        )
+    except TimeoutError:
+        # wait_for cancels communicate() but leaves the incus exec child running.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        raise
     if proc.returncode != 0:
         logger.debug(
             "cred_watch incus exec rc=%s: %s",
@@ -112,7 +122,6 @@ def _extract_json(stdout: str) -> dict | None:
 
 
 def _build_cmd(subcmd_args: str, cfg) -> str:
-    import shlex
     cmd = f"python3 - {subcmd_args}"
     if cfg.container_home:
         cmd += f" --home {shlex.quote(cfg.container_home)}"
@@ -141,8 +150,14 @@ async def run_container_check(config) -> dict | None:
 
 async def run_container_restore(config, target_name: str) -> dict | None:
     cfg = config.cred_integrity
+    # target_name originates from the container's own verdict / episode keys, but
+    # validate it against the known target set before it enters an incus `su -c`
+    # string — defense in depth, matching the shlex-quoting of the other args.
+    if target_name not in {t.name for t in cred_integrity.DEFAULT_TARGETS}:
+        logger.warning("cred_watch: refusing restore of unknown target %r", target_name)
+        return None
     src = Path(cred_integrity.__file__).read_bytes()
-    cmd = _build_cmd(f"restore --target {target_name} --json", cfg)
+    cmd = _build_cmd(f"restore --target {shlex.quote(target_name)} --json", cfg)
     try:
         rc, out = await _incus_exec_stdin(
             config.container_name, cmd, src, cfg.restore_timeout_s,
@@ -255,10 +270,14 @@ async def check_credential_integrity_and_alert(config, dispatcher) -> None:
             episode["restore_attempts"] = attempts
             result = await run_container_restore(config, name)
             recheck = await run_container_check(config)
-            now_ok = bool(
-                recheck and recheck.get("results", {}).get(name, {}).get("ok")
+            # A restore that reported ok is trusted unless a REACHABLE recheck
+            # contradicts it. If the recheck itself is unreachable (None), treat it
+            # as inconclusive — don't flip a real success into a false "FAILED".
+            recheck_ok = (
+                True if recheck is None
+                else bool(recheck.get("results", {}).get(name, {}).get("ok"))
             )
-            if result and result.get("ok") and now_ok:
+            if result and result.get("ok") and recheck_ok:
                 await _send(dispatcher, AlertSeverity.CRITICAL,
                             f"Guardian restored credential: {name}",
                             f"Container did not self-heal in {cfg.grace_minutes} min; "

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -744,6 +744,52 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         })
         current_ids.add(alert_id)
 
+    # Credential-file integrity — the container self-heal writes this status;
+    # corruption (or a failed/rate-capped restore) is CRITICAL, and a completed
+    # auto-restore is also CRITICAL (the user must know creds were replaced, and
+    # rotate any that may have changed since the backup).
+    cred_status_file = Path.home() / ".genesis" / "cred_integrity_status.json"
+    if cred_status_file.is_file():
+        try:
+            cred_data = json.loads(cred_status_file.read_text())
+            targets = cred_data.get("targets", {})
+            corrupt = {
+                n: t for n, t in targets.items()
+                if t.get("status") in ("corrupt", "corrupt_pending", "restore_failed")
+            }
+            restored = {
+                n: t for n, t in targets.items() if t.get("status") == "restored"
+            }
+            if corrupt:
+                detail = "; ".join(
+                    f"{n} ({t.get('detail', t.get('status'))})"
+                    for n, t in sorted(corrupt.items())
+                )
+                alert_id = "creds:corrupt"
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": f"Credential file corruption: {detail}",
+                })
+                current_ids.add(alert_id)
+            if restored:
+                detail = "; ".join(
+                    f"{n} (from backup {t.get('backup_mtime', '?')})"
+                    for n, t in sorted(restored.items())
+                )
+                alert_id = "creds:restored"
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Credential files auto-restored: {detail} — "
+                        "rotate any that changed since the backup"
+                    ),
+                })
+                current_ids.add(alert_id)
+        except (json.JSONDecodeError, OSError):
+            pass
+
     now = datetime.now(UTC).isoformat()
     for old_id in list(_alert_history.keys()):
         if old_id in current_ids:

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -753,9 +753,16 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         try:
             cred_data = json.loads(cred_status_file.read_text())
             targets = cred_data.get("targets", {})
+            if not isinstance(targets, dict):
+                targets = {}
+            targets = {n: t for n, t in targets.items() if isinstance(t, dict)}
+            # corrupt_pending is deliberately EXCLUDED: it is the 2-tick debounce
+            # window (a writer possibly caught mid-rewrite). It self-clears or
+            # escalates to a terminal status (restored / restore_failed) next
+            # tick, so alerting on it would defeat the debounce's whole purpose.
             corrupt = {
                 n: t for n, t in targets.items()
-                if t.get("status") in ("corrupt", "corrupt_pending", "restore_failed")
+                if t.get("status") in ("corrupt", "restore_failed")
             }
             restored = {
                 n: t for n, t in targets.items() if t.get("status") == "restored"

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -45,6 +45,9 @@ class OutreachConfig:
         # channel for real backup failures on installs where backups
         # are enabled. Prefix — matches backup:last_failed / backup:overdue.
         "backup:",
+        # Credential-file corruption / auto-restore — losing auth blinds
+        # Genesis (and the guardian brain). Prefix — creds:corrupt / creds:restored.
+        "creds:",
     )
     # Voice proactive chiming — the spoken-aloud allowlist. This IS the menu:
     # a request is spoken only if its signal_type or a source_id part matches
@@ -102,6 +105,7 @@ _DEFAULTS = OutreachConfig(
         "awareness:tick_overdue",
         "service:health_data_uninitialized",
         "backup:",  # Prefix — push channel now that backups are out of Sentinel scope
+        "creds:",   # Prefix — credential corruption / auto-restore (creds:corrupt/restored)
     ),
     delivery_routing={"default": "supergroup"},
 )

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -343,6 +343,12 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         _full = mode == "full"
         logger.info("GenesisRuntime bootstrap starting (mode=%s)", mode)
 
+        # Validate + restore corrupt credential files BEFORE loading secrets,
+        # so a zeroed/corrupt secrets.env is healed before load_dotenv reads it.
+        self._run_init_step(
+            "cred_integrity_startup", self._selfheal_credentials_startup,
+        )
+
         self._run_init_step("secrets", self._load_secrets)
         self._restore_pause_state()
 
@@ -368,6 +374,9 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
 
         if _full:
             await self._run_init_step_async("awareness", self._init_awareness)
+
+        if _full:
+            self._run_init_step("cred_integrity", self._init_cred_integrity)
 
         self._run_init_step("router", self._init_router)
 

--- a/src/genesis/runtime/_init_delegates.py
+++ b/src/genesis/runtime/_init_delegates.py
@@ -136,6 +136,14 @@ class _InitDelegatesMixin:
     async def _init_tasks(self) -> None:
         await tasks.init(self)
 
+    def _selfheal_credentials_startup(self) -> None:
+        from genesis.runtime.init.cred_integrity import selfheal_startup
+        selfheal_startup(self)
+
+    def _init_cred_integrity(self) -> None:
+        from genesis.runtime.init.cred_integrity import wire
+        wire(self)
+
     async def _init_guardian_monitoring(self) -> None:
         from genesis.runtime.init.guardian import init_guardian_monitoring
         await init_guardian_monitoring(self)

--- a/src/genesis/runtime/init/cred_integrity.py
+++ b/src/genesis/runtime/init/cred_integrity.py
@@ -1,0 +1,35 @@
+"""Credential-integrity init: startup self-heal + per-tick hook wiring.
+
+Two entry points, both defensive (a failure here must never block bootstrap):
+
+- ``selfheal_startup(rt)`` runs BEFORE secrets are loaded, so a corrupt/zeroed
+  ``secrets.env`` is restored from backup before ``load_dotenv`` reads it.
+- ``wire(rt)`` installs the per-tick check + self-heal on the awareness loop.
+  Wired independently of ``guardian_remote.yaml`` (unlike the credential
+  bridge) — integrity self-heal is valuable guardian-or-not.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.guardian.cred_selfheal import check_and_selfheal
+
+logger = logging.getLogger(__name__)
+
+
+def selfheal_startup(rt) -> None:
+    """Validate + restore credential files at startup (before secrets load)."""
+    try:
+        check_and_selfheal(startup=True)
+    except Exception:
+        logger.warning("startup credential self-heal failed", exc_info=True)
+
+
+def wire(rt) -> None:
+    """Install the per-tick credential integrity self-heal on the awareness loop."""
+    loop = getattr(rt, "_awareness_loop", None)
+    if loop is None:
+        return
+    loop.set_cred_integrity_fn(check_and_selfheal)
+    logger.debug("credential-integrity self-heal wired to awareness tick")

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -179,6 +179,12 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "the target and the credentials live outside the container. "
         "Escalate-notify only."
     ),
+    "creds:": (
+        "Credential-file corruption is already self-healed on the awareness "
+        "tick (guardian/cred_selfheal restores from the encrypted backup), "
+        "with the host guardian as a backstop. The creds:corrupt/restored "
+        "alerts are user-notification only — no separate Sentinel remediation."
+    ),
     "provider:credit_exhaustion:": (
         "Provider billing. Refilling credits is a user action, and a "
         "financial one (no-unsanctioned-transactions rule). Same reasoning "

--- a/tests/test_guardian/test_cred_integrity.py
+++ b/tests/test_guardian/test_cred_integrity.py
@@ -283,6 +283,27 @@ def test_pipe_mode_parity_and_no_genesis_imports(tmp_path):
     assert piped["claude_credentials"]["status"] == in_proc["claude_credentials"].status
 
 
+def test_cli_backup_dir_follows_home(tmp_path, capsys, monkeypatch):
+    """CLI --home must tie the default backup dir to the RESOLVED home, not $HOME
+    — otherwise a sandbox leaks to the real backup clone (missing vs absent)."""
+    from genesis.guardian.cred_integrity import main
+
+    # A real HOME with a backup clone that would (wrongly) be consulted.
+    real_home = tmp_path / "real"
+    (real_home / "backups" / "genesis-backups" / "secrets").mkdir(parents=True)
+    (real_home / "backups" / "genesis-backups" / "secrets" / "secrets.env.gpg").write_bytes(b"x")
+    monkeypatch.setenv("HOME", str(real_home))
+
+    sandbox = tmp_path / "sandbox"  # no backups here
+    sandbox.mkdir()
+    main(["check", "--json", "--home", str(sandbox)])
+    out = json.loads(capsys.readouterr().out)["results"]
+    # secrets.env is missing in the sandbox and there's NO sandbox backup →
+    # must be "absent", not "missing" (which would mean the real clone leaked in).
+    assert out["secrets_env"]["status"] == "absent"
+    assert out["secrets_env"]["backup_exists"] is False
+
+
 def test_secrets_env_small_but_valid_is_ok():
     """min_keys=1: a legitimate small secrets.env (few keys) must NOT be flagged
     corrupt — only a file that parses to ZERO keys is."""

--- a/tests/test_guardian/test_cred_integrity.py
+++ b/tests/test_guardian/test_cred_integrity.py
@@ -1,0 +1,292 @@
+"""Tests for the standalone credential-integrity validator + restore."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from genesis.guardian import cred_integrity as ci
+from genesis.guardian.cred_integrity import (
+    DEFAULT_TARGETS,
+    RESTORABLE_STATUSES,
+    allowed_restore,
+    check_all,
+    resolve_passphrase,
+    restore_file,
+    validate_bytes,
+    validate_file,
+)
+
+_HAS_GPG = shutil.which("gpg") is not None
+_PASS = "test-passphrase-1234"  # noqa: S105 — synthetic test value
+
+# ── validate_bytes: per-kind × corruption modes ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("kind", "data", "min_keys", "required", "status"),
+    [
+        ("dotenv", b"A=1\nB=2\nC=3\nD=4\nE=5\n", 5, (), "ok"),
+        ("dotenv", b"", 5, (), "empty"),
+        ("dotenv", b"   \n\n", 5, (), "empty"),
+        ("dotenv", b"A=1\x00\x00\x00", 5, (), "nul_bytes"),
+        ("dotenv", b"A=1\nB=2\n", 5, (), "parse_error"),          # too few keys
+        ("dotenv", b"A=1\nB=2\nC=3\nD=4\nE=5\n", 5, ("Z",), "missing_keys"),
+        ("json", b'{"claudeAiOauth": {"x": 1}}', 0, ("claudeAiOauth",), "ok"),
+        ("json", b'{"bad": ', 0, (), "parse_error"),
+        ("json", b"[]", 0, (), "parse_error"),                     # not a dict
+        ("json", b"{}", 0, (), "parse_error"),                     # empty dict
+        ("json", b'{"other": 1}', 0, ("claudeAiOauth",), "missing_keys"),
+        ("yaml", b"github.com:\n  user: x\n", 0, (), "ok"),
+        ("yaml", b"::: not yaml : [", 0, (), "parse_error"),
+        ("yaml", b"just a scalar", 0, (), "parse_error"),          # not a mapping
+        ("ssh_key", b"-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n", 0, (), "ok"),
+        ("ssh_key", b"ssh-ed25519 AAAA...\n", 0, (), "parse_error"),  # a public key
+        ("ssh_key", b"garbage", 0, (), "parse_error"),
+    ],
+)
+def test_validate_bytes(kind, data, min_keys, required, status):
+    result = validate_bytes(kind, data, required, min_keys)
+    assert result.status == status
+    assert result.ok == (status == "ok")
+
+
+def test_nul_bytes_beats_everything():
+    # A NUL-zeroed file (the outage signature) is corruption regardless of kind.
+    assert validate_bytes("json", b'{"claudeAiOauth":1}\x00', ("claudeAiOauth",)).status == "nul_bytes"
+
+
+def test_yaml_unavailable_degrades_to_ok(monkeypatch):
+    monkeypatch.setattr(ci, "_YAML_OK", False)
+    # Non-empty, no NUL → cannot prove corrupt without a parser → ok (never a
+    # false restore). Empty/NUL still caught by the pre-checks.
+    assert validate_bytes("yaml", b"anything non-empty").status == "ok"
+    assert validate_bytes("yaml", b"").status == "empty"
+
+
+# ── validate_file: missing vs absent disambiguation ─────────────────────────
+
+
+def test_missing_with_backup_is_corruption(tmp_path):
+    home = tmp_path / "home"
+    backup = tmp_path / "backup"
+    (backup / "secrets").mkdir(parents=True)
+    (backup / "secrets" / "secrets.env.gpg").write_bytes(b"x")
+    home.mkdir()
+    t = DEFAULT_TARGETS[0]  # secrets_env
+    r = validate_file(t, home, backup)
+    assert r.status == "missing" and r.ok is False
+
+
+def test_missing_without_backup_is_absent(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    t = DEFAULT_TARGETS[0]
+    r = validate_file(t, home, None)
+    assert r.status == "absent" and r.ok is True
+
+
+def test_check_all_healthy_install(tmp_path):
+    home = tmp_path / "home"
+    (home / "genesis").mkdir(parents=True)
+    (home / "genesis" / "secrets.env").write_text(
+        "A=1\nB=2\nC=3\nD=4\nE=5\nGENESIS_BACKUP_PASSPHRASE=p\n"
+    )
+    results = check_all((DEFAULT_TARGETS[0],), home, None)
+    assert results["secrets_env"].ok is True
+
+
+# ── restore_file (real gpg) ─────────────────────────────────────────────────
+
+
+def _encrypt(src_bytes: bytes, dst: Path, passphrase: str) -> None:
+    """Encrypt bytes to dst.gpg exactly as scripts/backup.sh does."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_suffix(".plain")
+    tmp.write_bytes(src_bytes)
+    try:
+        proc = subprocess.run(
+            ["gpg", "--batch", "--yes", "--quiet", "--passphrase-fd", "0",
+             "--symmetric", "--cipher-algo", "AES256", "-o", str(dst), str(tmp)],
+            input=passphrase.encode(),
+            capture_output=True,
+        )
+    finally:
+        tmp.unlink()
+    assert proc.returncode == 0, proc.stderr.decode()
+
+
+@pytest.mark.skipif(not _HAS_GPG, reason="gpg not available")
+def test_restore_happy_path(tmp_path):
+    home = tmp_path / "home"
+    backup = tmp_path / "backup"
+    good = b"A=1\nB=2\nC=3\nD=4\nE=5\nGENESIS_BACKUP_PASSPHRASE=p\n"
+    _encrypt(good, backup / "secrets" / "secrets.env.gpg", _PASS)
+    # Corrupt original present (NUL-zeroed).
+    target_path = home / "genesis" / "secrets.env"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_bytes(b"\x00" * 64)
+
+    t = DEFAULT_TARGETS[0]
+    r = restore_file(t, home=home, backup_dir=backup, passphrase=_PASS)
+    assert r.ok and r.action == "restored"
+    assert target_path.read_bytes() == good
+    assert oct(target_path.stat().st_mode)[-3:] == "600"
+    assert r.aside_path and Path(r.aside_path).read_bytes() == b"\x00" * 64
+    assert ".corrupt-" in r.aside_path
+
+
+@pytest.mark.skipif(not _HAS_GPG, reason="gpg not available")
+def test_restore_wrong_passphrase_leaves_original(tmp_path):
+    home = tmp_path / "home"
+    backup = tmp_path / "backup"
+    _encrypt(b"A=1\nB=2\nC=3\nD=4\nE=5\n", backup / "secrets" / "secrets.env.gpg", _PASS)
+    target_path = home / "genesis" / "secrets.env"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_bytes(b"\x00" * 8)
+
+    r = restore_file(DEFAULT_TARGETS[0], home=home, backup_dir=backup, passphrase="wrong")
+    assert not r.ok and r.action == "decrypt_failed"
+    assert target_path.read_bytes() == b"\x00" * 8  # untouched
+
+
+@pytest.mark.skipif(not _HAS_GPG, reason="gpg not available")
+def test_restore_invalid_backup_never_moves_original(tmp_path):
+    """The safety invariant: a backup that decrypts to garbage must NOT move the
+    (corrupt but present) original aside — validate-before-move."""
+    home = tmp_path / "home"
+    backup = tmp_path / "backup"
+    _encrypt(b"\x00\x00\x00", backup / "secrets" / "secrets.env.gpg", _PASS)  # bad content
+    target_path = home / "genesis" / "secrets.env"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_bytes(b"A=1\n")  # a present original
+
+    r = restore_file(DEFAULT_TARGETS[0], home=home, backup_dir=backup, passphrase=_PASS)
+    assert not r.ok and r.action == "backup_invalid"
+    assert target_path.read_bytes() == b"A=1\n"      # original untouched
+    assert r.aside_path is None
+    # No stray tmp/aside files left behind.
+    leftovers = [p.name for p in target_path.parent.iterdir()]
+    assert leftovers == ["secrets.env"]
+
+
+def test_restore_no_backup(tmp_path):
+    r = restore_file(DEFAULT_TARGETS[0], home=tmp_path / "h",
+                     backup_dir=tmp_path / "b", passphrase=_PASS)
+    assert not r.ok and r.action == "skipped_no_backup"
+
+
+@pytest.mark.skipif(not _HAS_GPG, reason="gpg not available")
+def test_restore_ssh_key_sets_dir_perms(tmp_path):
+    home = tmp_path / "home"
+    backup = tmp_path / "backup"
+    key = b"-----BEGIN OPENSSH PRIVATE KEY-----\nabcdef\n-----END OPENSSH PRIVATE KEY-----\n"
+    _encrypt(key, backup / "creds" / "ssh" / "id_ed25519.gpg", _PASS)
+    t = next(t for t in DEFAULT_TARGETS if t.name == "ssh_id_ed25519")
+    r = restore_file(t, home=home, backup_dir=backup, passphrase=_PASS)
+    assert r.ok and r.action == "restored"
+    assert oct((home / ".ssh").stat().st_mode)[-3:] == "700"
+    assert oct((home / ".ssh" / "id_ed25519").stat().st_mode)[-3:] == "600"
+
+
+# ── resolve_passphrase chain ────────────────────────────────────────────────
+
+
+def test_resolve_passphrase_env_wins(tmp_path, monkeypatch):
+    monkeypatch.setenv("GENESIS_BACKUP_PASSPHRASE", "from-env")
+    assert resolve_passphrase(tmp_path) == "from-env"
+
+
+def test_resolve_passphrase_from_secrets(tmp_path, monkeypatch):
+    monkeypatch.delenv("GENESIS_BACKUP_PASSPHRASE", raising=False)
+    (tmp_path / "genesis").mkdir()
+    (tmp_path / "genesis" / "secrets.env").write_text(
+        "A=1\nGENESIS_BACKUP_PASSPHRASE=from-secrets\n"
+    )
+    assert resolve_passphrase(tmp_path) == "from-secrets"
+
+
+def test_resolve_passphrase_corrupt_secrets_falls_to_escrow(tmp_path, monkeypatch):
+    """The circular case: secrets.env is what's corrupt, so its passphrase is
+    unusable — the escrow must win."""
+    monkeypatch.delenv("GENESIS_BACKUP_PASSPHRASE", raising=False)
+    (tmp_path / "genesis").mkdir()
+    (tmp_path / "genesis" / "secrets.env").write_bytes(b"\x00" * 32)  # zeroed
+    esc = tmp_path / ".genesis" / "shared" / "guardian"
+    esc.mkdir(parents=True)
+    (esc / "backup_passphrase.env").write_text("GENESIS_BACKUP_PASSPHRASE=from-escrow\n")
+    assert resolve_passphrase(tmp_path) == "from-escrow"
+
+
+def test_resolve_passphrase_none(tmp_path, monkeypatch):
+    monkeypatch.delenv("GENESIS_BACKUP_PASSPHRASE", raising=False)
+    assert resolve_passphrase(tmp_path) is None
+
+
+# ── allowed_restore rate-cap ────────────────────────────────────────────────
+
+
+def test_allowed_restore():
+    now = datetime.now(UTC)
+    recent = [(now - timedelta(hours=1)).isoformat(), (now - timedelta(hours=2)).isoformat()]
+    old = [(now - timedelta(days=2)).isoformat()]
+    assert allowed_restore(old, now, 3) is True
+    assert allowed_restore(recent, now, 3) is True
+    assert allowed_restore(recent, now, 2) is False
+    assert allowed_restore(recent + old, now, 2) is False  # old ones don't count
+    assert allowed_restore([], now, 0) is False
+
+
+def test_restorable_statuses_exclude_unreadable():
+    assert "unreadable" not in RESTORABLE_STATUSES
+    assert "absent" not in RESTORABLE_STATUSES
+    assert {"missing", "empty", "nul_bytes", "parse_error"} <= RESTORABLE_STATUSES
+
+
+# ── Standalone-ness: pipe mode must match in-process AND import no genesis.* ──
+
+
+def test_pipe_mode_parity_and_no_genesis_imports(tmp_path):
+    """The guardian runs this module by piping its SOURCE into a bare python3.
+    This proves (a) it runs with zero package context — failing the build if any
+    `genesis.*` import is added — and (b) the pipe verdict matches check_all()."""
+    home = tmp_path / "home"
+    (home / "genesis").mkdir(parents=True)
+    (home / "genesis" / "secrets.env").write_text("A=1\nB=2\nC=3\nD=4\nE=5\n")
+    (home / ".claude").mkdir()
+    (home / ".claude" / ".credentials.json").write_text("not json{")  # corrupt
+
+    module_src = Path(ci.__file__).read_text()
+    # Run in an isolated dir with NO access to the genesis package on sys.path.
+    proc = subprocess.run(
+        [sys.executable, "-", "check", "--json", "--home", str(home)],
+        input=module_src,
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+        env={"PATH": os.environ.get("PATH", ""), "HOME": str(home)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    piped = json.loads(proc.stdout)["results"]
+    assert piped["secrets_env"]["status"] == "ok"
+    assert piped["claude_credentials"]["status"] == "parse_error"
+
+    in_proc = check_all(None, home, None)
+    assert piped["secrets_env"]["status"] == in_proc["secrets_env"].status
+    assert piped["claude_credentials"]["status"] == in_proc["claude_credentials"].status
+
+
+def test_default_targets_match_backup_paths():
+    """Guard: every target's backup_rel matches scripts/backup.sh §8 naming."""
+    by_name = {t.name: t for t in DEFAULT_TARGETS}
+    assert by_name["secrets_env"].backup_rel == "secrets/secrets.env.gpg"
+    assert by_name["claude_credentials"].backup_rel == "creds/claude_credentials.json.gpg"
+    assert by_name["gh_hosts"].backup_rel == "creds/gh_hosts.yml.gpg"
+    assert by_name["ssh_guardian_key"].backup_rel == "creds/ssh/genesis_guardian_ed25519.gpg"

--- a/tests/test_guardian/test_cred_integrity.py
+++ b/tests/test_guardian/test_cred_integrity.py
@@ -283,6 +283,43 @@ def test_pipe_mode_parity_and_no_genesis_imports(tmp_path):
     assert piped["claude_credentials"]["status"] == in_proc["claude_credentials"].status
 
 
+def test_secrets_env_small_but_valid_is_ok():
+    """min_keys=1: a legitimate small secrets.env (few keys) must NOT be flagged
+    corrupt — only a file that parses to ZERO keys is."""
+    t = DEFAULT_TARGETS[0]
+    assert t.min_keys == 1
+    assert validate_bytes(t.kind, b"A=1\nB=2\n", t.required_keys, t.min_keys).ok
+    # Garbage with no key=value lines → 0 keys → parse_error (restorable).
+    assert validate_bytes(t.kind, b"just some prose\nno equals here\n",
+                          t.required_keys, t.min_keys).status == "parse_error"
+
+
+@pytest.mark.skipif(not _HAS_GPG, reason="gpg not available")
+def test_restore_placement_failure_leaves_no_plaintext_temp(tmp_path, monkeypatch):
+    """If placement fails after the decrypted temp is written, the plaintext temp
+    must be cleaned up (no secret left on disk)."""
+    home = tmp_path / "home"
+    backup = tmp_path / "backup"
+    _encrypt(b"A=1\nB=2\nC=3\n", backup / "secrets" / "secrets.env.gpg", _PASS)
+    target_path = home / "genesis" / "secrets.env"
+    target_path.parent.mkdir(parents=True)
+    target_path.write_bytes(b"\x00" * 8)
+
+    real_replace = os.replace
+
+    def failing_replace(src, dst):
+        # Fail only the final tmp→target placement, not the aside move.
+        if str(src).endswith(".restore-tmp-" + str(os.getpid())):
+            raise OSError("simulated placement failure")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+    r = restore_file(DEFAULT_TARGETS[0], home=home, backup_dir=backup, passphrase=_PASS)
+    assert not r.ok and r.action == "error"
+    leftovers = [p.name for p in target_path.parent.iterdir()]
+    assert not any(".restore-tmp-" in n for n in leftovers), leftovers
+
+
 def test_default_targets_match_backup_paths():
     """Guard: every target's backup_rel matches scripts/backup.sh §8 naming."""
     by_name = {t.name: t for t in DEFAULT_TARGETS}

--- a/tests/test_guardian/test_cred_selfheal.py
+++ b/tests/test_guardian/test_cred_selfheal.py
@@ -1,0 +1,154 @@
+"""Tests for the container-side credential self-heal policy."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.guardian import cred_selfheal
+from genesis.guardian.cred_integrity import CredTarget, RestoreResult
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """A sandbox home + backup dir + a single json target, restore patched."""
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    backup = tmp_path / "home" / "backups" / "genesis-backups" / "creds"
+    backup.mkdir(parents=True)
+    (backup / "claude_credentials.json.gpg").write_bytes(b"encrypted")  # presence only
+    status = home / ".genesis" / "cred_integrity_status.json"
+
+    target = CredTarget(
+        "claude_credentials", ".claude/.credentials.json",
+        "creds/claude_credentials.json.gpg", "json", required_keys=("claudeAiOauth",),
+    )
+
+    monkeypatch.setattr(cred_selfheal, "resolve_passphrase", lambda h: "p")
+
+    calls = {"restore": 0}
+
+    def fake_restore(t, *, home, backup_dir, passphrase):
+        calls["restore"] += 1
+        return RestoreResult(True, "restored", aside_path=str(home / "aside"),
+                             backup_mtime="2026-07-10T00:00:00+00:00", detail="ok")
+
+    monkeypatch.setattr(cred_selfheal, "restore_file", fake_restore)
+
+    def run(startup=False, max_per_day=3):
+        return cred_selfheal.check_and_selfheal(
+            home=home,
+            backup_dir=home / "backups" / "genesis-backups",
+            status_path=status,
+            targets=(target,),
+            startup=startup,
+            max_restores_per_day=max_per_day,
+        )
+
+    def write_creds(content: bytes):
+        (home / ".claude" / ".credentials.json").write_bytes(content)
+
+    return type("Env", (), {
+        "run": staticmethod(run), "write": staticmethod(write_creds),
+        "calls": calls, "home": home, "target": target,
+    })
+
+
+_GOOD = b'{"claudeAiOauth": {"t": 1}}'
+_BAD_JSON = b'{"claudeAiOauth": '   # parse_error (ambiguous → 2-tick)
+_ZEROED = b"\x00" * 16              # nul_bytes (immediate)
+
+
+def test_healthy_is_ok(env):
+    env.write(_GOOD)
+    out = env.run()
+    assert out["targets"]["claude_credentials"]["status"] == "ok"
+    assert env.calls["restore"] == 0
+
+
+def test_parse_error_needs_two_ticks(env):
+    env.write(_BAD_JSON)
+    first = env.run()
+    assert first["targets"]["claude_credentials"]["status"] == "corrupt_pending"
+    assert env.calls["restore"] == 0
+    second = env.run()  # still corrupt → confirmed → restore
+    assert second["targets"]["claude_credentials"]["status"] == "restored"
+    assert env.calls["restore"] == 1
+
+
+def test_nul_bytes_restores_immediately(env):
+    env.write(_ZEROED)
+    out = env.run()
+    assert out["targets"]["claude_credentials"]["status"] == "restored"
+    assert env.calls["restore"] == 1
+
+
+def test_startup_restores_parse_error_immediately(env):
+    env.write(_BAD_JSON)
+    out = env.run(startup=True)
+    assert out["targets"]["claude_credentials"]["status"] == "restored"
+    assert env.calls["restore"] == 1
+
+
+def test_rate_cap_blocks_restore(env, monkeypatch):
+    env.write(_ZEROED)
+    env.run(max_per_day=1)                      # first restore consumes the cap
+    assert env.calls["restore"] == 1
+    out = env.run(max_per_day=1)                # second is rate-capped
+    assert out["targets"]["claude_credentials"]["status"] == "restore_failed"
+    assert "rate cap" in out["targets"]["claude_credentials"]["detail"]
+    assert env.calls["restore"] == 1           # no new attempt
+
+
+def test_no_passphrase_is_restore_failed(env, monkeypatch):
+    monkeypatch.setattr(cred_selfheal, "resolve_passphrase", lambda h: None)
+    env.write(_ZEROED)
+    out = env.run()
+    assert out["targets"]["claude_credentials"]["status"] == "restore_failed"
+    assert "passphrase" in out["targets"]["claude_credentials"]["detail"]
+    assert env.calls["restore"] == 0
+
+
+def test_unreadable_is_alert_only(env, monkeypatch):
+    from genesis.guardian.cred_integrity import ValidationResult
+    monkeypatch.setattr(
+        cred_selfheal, "check_all",
+        lambda tgts, home, backup: {
+            "claude_credentials": ValidationResult(False, "unreadable", "perm denied")
+        },
+    )
+    out = env.run()
+    assert out["targets"]["claude_credentials"]["status"] == "corrupt"
+    assert env.calls["restore"] == 0
+
+
+def test_status_file_written_with_events(env):
+    env.write(_ZEROED)
+    env.run()
+    data = json.loads((env.home / ".genesis" / "cred_integrity_status.json").read_text())
+    assert data["version"] == 1
+    assert "checked_at" in data
+    assert any("restored" in e for e in data["recent_events"])
+
+
+def test_restored_persists_then_collapses(env, monkeypatch):
+    # Restore, then the file becomes valid → status stays "restored" within TTL.
+    env.write(_ZEROED)
+    env.run()
+    env.write(_GOOD)
+    out = env.run()
+    assert out["targets"]["claude_credentials"]["status"] == "restored"
+    # Force the restored record to be older than the TTL → collapses to ok.
+    monkeypatch.setattr(cred_selfheal, "_RESTORED_TTL_S", -1)
+    out2 = env.run()
+    assert out2["targets"]["claude_credentials"]["status"] == "ok"
+
+
+def test_never_raises_on_check_failure(env, monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(cred_selfheal, "check_all", boom)
+    # Must not raise; returns prior status (empty here).
+    out = env.run()
+    assert isinstance(out, dict)

--- a/tests/test_guardian/test_cred_watch.py
+++ b/tests/test_guardian/test_cred_watch.py
@@ -1,0 +1,202 @@
+"""Tests for the guardian-side credential-integrity watch (escalation ladder)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.guardian import cred_watch
+from genesis.guardian.alert.base import AlertSeverity
+from genesis.guardian.config import CredIntegrityConfig, GuardianConfig
+from genesis.guardian.cred_watch import (
+    check_credential_integrity_and_alert,
+    decide,
+)
+
+CFG = CredIntegrityConfig(grace_minutes=30, realert_hours=6.0)
+NOW = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+
+
+def _episode(**kw):
+    base = {"first_seen": NOW.isoformat(), "warned_at": NOW.isoformat(),
+            "stepped_in_at": None, "last_alert_at": NOW.isoformat(),
+            "restore_attempts": []}
+    base.update(kw)
+    return base
+
+
+# ── decide() matrix ─────────────────────────────────────────────────────────
+
+
+def test_decide_healthy_no_episode():
+    assert decide("x", False, None, NOW, CFG).action == "none"
+
+
+def test_decide_first_detection_warns():
+    assert decide("x", True, None, NOW, CFG).action == "warn"
+
+
+def test_decide_in_grace_defers():
+    ep = _episode(first_seen=(NOW - timedelta(minutes=10)).isoformat())
+    assert decide("x", True, ep, NOW, CFG).action == "none"
+
+
+def test_decide_past_grace_steps_in():
+    ep = _episode(first_seen=(NOW - timedelta(minutes=31)).isoformat())
+    assert decide("x", True, ep, NOW, CFG).action == "step_in"
+
+
+def test_decide_resolved_after_warn():
+    ep = _episode()
+    assert decide("x", False, ep, NOW, CFG).action == "resolved"
+
+
+def test_decide_realert_after_stepin_on_cadence():
+    ep = _episode(
+        first_seen=(NOW - timedelta(hours=2)).isoformat(),
+        stepped_in_at=(NOW - timedelta(hours=1)).isoformat(),
+        last_alert_at=(NOW - timedelta(hours=7)).isoformat(),  # older than realert_hours
+    )
+    assert decide("x", True, ep, NOW, CFG).action == "realert"
+
+
+def test_decide_stepped_in_within_realert_window_is_quiet():
+    ep = _episode(
+        stepped_in_at=(NOW - timedelta(hours=1)).isoformat(),
+        last_alert_at=(NOW - timedelta(hours=1)).isoformat(),
+    )
+    assert decide("x", True, ep, NOW, CFG).action == "none"
+
+
+# ── _extract_json tolerance ─────────────────────────────────────────────────
+
+
+def test_extract_json_skips_preamble():
+    out = "Last login: whatever\n{\"version\": 1, \"results\": {}}\n"
+    assert cred_watch._extract_json(out) == {"version": 1, "results": {}}
+
+
+def test_extract_json_none_on_garbage():
+    assert cred_watch._extract_json("no json here\n") is None
+
+
+# ── Orchestrator ────────────────────────────────────────────────────────────
+
+
+class _Dispatcher:
+    def __init__(self):
+        self.alerts = []
+
+    async def send(self, alert):
+        self.alerts.append(alert)
+        return True
+
+
+def _report(**statuses):
+    return {"version": 1, "results": {
+        n: {"ok": s == "ok", "status": s, "detail": s} for n, s in statuses.items()
+    }}
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    return GuardianConfig(state_dir=str(tmp_path))
+
+
+async def test_first_corruption_warns_and_records(cfg, monkeypatch):
+    monkeypatch.setattr(cred_watch, "run_container_check",
+                        _async(_report(secrets_env="nul_bytes")))
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert len(disp.alerts) == 1
+    assert disp.alerts[0].severity == AlertSeverity.WARNING
+    # State recorded.
+    state = (cfg.state_path / "cred_alert_state.json").read_text()
+    assert "secrets_env" in state and "first_seen" in state
+
+
+async def test_step_in_restores_and_criticals(cfg, monkeypatch):
+    # Pre-seed an episode past the grace window.
+    old = (datetime.now(UTC) - timedelta(minutes=40)).isoformat()
+    (cfg.state_path).mkdir(parents=True, exist_ok=True)
+    _seed_state(cfg, {"secrets_env": {
+        "first_seen": old, "warned_at": old, "stepped_in_at": None,
+        "last_alert_at": old, "restore_attempts": [],
+    }})
+    checks = iter([_report(secrets_env="nul_bytes"), _report(secrets_env="ok")])
+    monkeypatch.setattr(cred_watch, "run_container_check",
+                        lambda config: _next(checks))
+    restore_calls = {"n": 0}
+
+    async def fake_restore(config, name):
+        restore_calls["n"] += 1
+        return {"ok": True, "action": "restored", "backup_mtime": "2026-07-09T18:00:00+00:00"}
+
+    monkeypatch.setattr(cred_watch, "run_container_restore", fake_restore)
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert restore_calls["n"] == 1
+    assert any(a.severity == AlertSeverity.CRITICAL and "restored" in a.title.lower()
+               for a in disp.alerts)
+
+
+async def test_exec_failure_no_alert_no_state_change(cfg, monkeypatch):
+    monkeypatch.setattr(cred_watch, "run_container_check", _async(None))
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert disp.alerts == []
+    assert not (cfg.state_path / "cred_alert_state.json").exists()
+
+
+async def test_resolution_sends_info_and_clears(cfg, monkeypatch):
+    (cfg.state_path).mkdir(parents=True, exist_ok=True)
+    _seed_state(cfg, {"gh_hosts": _episode()})
+    monkeypatch.setattr(cred_watch, "run_container_check",
+                        _async(_report(gh_hosts="ok")))
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert any(a.severity == AlertSeverity.INFO for a in disp.alerts)
+    assert '"gh_hosts"' not in (cfg.state_path / "cred_alert_state.json").read_text()
+
+
+async def test_disabled_is_noop(cfg, monkeypatch):
+    cfg.cred_integrity.enabled = False
+
+    async def _should_not_run(config):
+        raise AssertionError("check must not run when disabled")
+
+    monkeypatch.setattr(cred_watch, "run_container_check", _should_not_run)
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert disp.alerts == []
+
+
+async def test_absent_targets_do_not_alert(cfg, monkeypatch):
+    monkeypatch.setattr(cred_watch, "run_container_check",
+                        _async(_report(genesis_yaml="absent", secrets_env="ok")))
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert disp.alerts == []
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _async(value):
+    async def _fn(config):
+        return value
+    return _fn
+
+
+def _next(it):
+    async def _coro():
+        return next(it)
+    return _coro()
+
+
+def _seed_state(cfg, episodes: dict) -> None:
+    import json
+    (cfg.state_path / "cred_alert_state.json").write_text(
+        json.dumps({"version": 1, "episodes": episodes})
+    )

--- a/tests/test_guardian/test_cred_watch.py
+++ b/tests/test_guardian/test_cred_watch.py
@@ -164,6 +164,31 @@ async def test_step_in_success_with_unreachable_recheck_is_not_failed(cfg, monke
     assert not any("FAILED" in a.title for a in disp.alerts)
 
 
+async def test_unreadable_past_grace_alerts_but_never_restores(cfg, monkeypatch):
+    """An 'unreadable' verdict is ambiguous (not RESTORABLE) — past grace the
+    guardian must ALERT but NOT call run_container_restore."""
+    old = (datetime.now(UTC) - timedelta(minutes=40)).isoformat()
+    (cfg.state_path).mkdir(parents=True, exist_ok=True)
+    _seed_state(cfg, {"secrets_env": {
+        "first_seen": old, "warned_at": old, "stepped_in_at": None,
+        "last_alert_at": old, "restore_attempts": [],
+    }})
+    monkeypatch.setattr(cred_watch, "run_container_check",
+                        _async(_report(secrets_env="unreadable")))
+    called = {"restore": 0}
+
+    async def fake_restore(config, name):
+        called["restore"] += 1
+        return {"ok": True, "action": "restored"}
+
+    monkeypatch.setattr(cred_watch, "run_container_restore", fake_restore)
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert called["restore"] == 0
+    assert any(a.severity == AlertSeverity.CRITICAL and "unreadable" in a.title.lower()
+               for a in disp.alerts)
+
+
 async def test_run_container_restore_rejects_unknown_target(cfg):
     result = await cred_watch.run_container_restore(cfg, "totally_bogus_target")
     assert result is None

--- a/tests/test_guardian/test_cred_watch.py
+++ b/tests/test_guardian/test_cred_watch.py
@@ -141,6 +141,34 @@ async def test_step_in_restores_and_criticals(cfg, monkeypatch):
                for a in disp.alerts)
 
 
+async def test_step_in_success_with_unreachable_recheck_is_not_failed(cfg, monkeypatch):
+    """Restore reports ok but the post-restore recheck is unreachable (None) →
+    must NOT be reported as FAILED (recheck-unreachable = inconclusive)."""
+    old = (datetime.now(UTC) - timedelta(minutes=40)).isoformat()
+    (cfg.state_path).mkdir(parents=True, exist_ok=True)
+    _seed_state(cfg, {"secrets_env": {
+        "first_seen": old, "warned_at": old, "stepped_in_at": None,
+        "last_alert_at": old, "restore_attempts": [],
+    }})
+    checks = iter([_report(secrets_env="nul_bytes"), None])  # 2nd check unreachable
+    monkeypatch.setattr(cred_watch, "run_container_check", lambda config: _next(checks))
+
+    async def fake_restore(config, name):
+        return {"ok": True, "action": "restored", "backup_mtime": "2026-07-09T18:00:00+00:00"}
+
+    monkeypatch.setattr(cred_watch, "run_container_restore", fake_restore)
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert any(a.severity == AlertSeverity.CRITICAL and "restored" in a.title.lower()
+               for a in disp.alerts)
+    assert not any("FAILED" in a.title for a in disp.alerts)
+
+
+async def test_run_container_restore_rejects_unknown_target(cfg):
+    result = await cred_watch.run_container_restore(cfg, "totally_bogus_target")
+    assert result is None
+
+
 async def test_exec_failure_no_alert_no_state_change(cfg, monkeypatch):
     monkeypatch.setattr(cred_watch, "run_container_check", _async(None))
     disp = _Dispatcher()

--- a/tests/test_mcp/test_health_mcp.py
+++ b/tests/test_mcp/test_health_mcp.py
@@ -763,6 +763,37 @@ async def test_creds_corrupt_and_restored_alerts(monkeypatch, tmp_path):
         health_mcp_mod._alert_history = old_history
 
 
+async def test_corrupt_pending_does_not_alert(monkeypatch, tmp_path):
+    """corrupt_pending is the 2-tick debounce window — it must NOT fire an alert
+    (else the debounce fails to suppress the false alarm it exists to prevent).
+    Malformed-but-valid-JSON status must also not crash the alert pass."""
+    import json
+    from pathlib import Path
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".genesis").mkdir(parents=True)
+    (fake_home / ".genesis" / "cred_integrity_status.json").write_text(json.dumps({
+        "version": 1,
+        "targets": {
+            "claude_json": {"status": "corrupt_pending", "detail": "parse_error"},
+            "bogus": "not-a-dict",  # must be tolerated, not crash
+        },
+    }))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    mock_svc = AsyncMock()
+    mock_svc.snapshot.return_value = _mock_snapshot()
+    old, old_history = health_mcp_mod._service, health_mcp_mod._alert_history.copy()
+    try:
+        health_mcp_mod._service = mock_svc
+        health_mcp_mod._alert_history = {}
+        alerts = await _impl_health_alerts()
+        assert not [a for a in alerts if a["id"].startswith("creds:")]
+    finally:
+        health_mcp_mod._service = old
+        health_mcp_mod._alert_history = old_history
+
+
 async def test_no_creds_alert_when_all_ok(monkeypatch, tmp_path):
     import json
     from pathlib import Path

--- a/tests/test_mcp/test_health_mcp.py
+++ b/tests/test_mcp/test_health_mcp.py
@@ -718,3 +718,70 @@ class TestBackupsEnabledHelper:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
         monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
         assert _backups_enabled() is True
+
+
+def _mock_snapshot():
+    return {
+        "call_sites": {}, "cc_sessions": {"background": {}},
+        "infrastructure": {}, "queues": {}, "awareness": {},
+    }
+
+
+async def test_creds_corrupt_and_restored_alerts(monkeypatch, tmp_path):
+    """A cred_integrity_status.json with corrupt + restored targets must emit
+    creds:corrupt and creds:restored CRITICAL alerts."""
+    import json
+    from pathlib import Path
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".genesis").mkdir(parents=True)
+    (fake_home / ".genesis" / "cred_integrity_status.json").write_text(json.dumps({
+        "version": 1, "checked_at": "2026-07-10T00:00:00+00:00",
+        "targets": {
+            "secrets_env": {"status": "corrupt", "detail": "nul_bytes"},
+            "gh_hosts": {"status": "restored", "backup_mtime": "2026-07-09T18:00:00+00:00"},
+            "claude_json": {"status": "ok"},
+        },
+    }))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    mock_svc = AsyncMock()
+    mock_svc.snapshot.return_value = _mock_snapshot()
+    old, old_history = health_mcp_mod._service, health_mcp_mod._alert_history.copy()
+    try:
+        health_mcp_mod._service = mock_svc
+        health_mcp_mod._alert_history = {}
+        alerts = await _impl_health_alerts()
+        corrupt = [a for a in alerts if a["id"] == "creds:corrupt"]
+        restored = [a for a in alerts if a["id"] == "creds:restored"]
+        assert len(corrupt) == 1 and corrupt[0]["severity"] == "CRITICAL"
+        assert "secrets_env" in corrupt[0]["message"]
+        assert len(restored) == 1 and restored[0]["severity"] == "CRITICAL"
+        assert "gh_hosts" in restored[0]["message"]
+    finally:
+        health_mcp_mod._service = old
+        health_mcp_mod._alert_history = old_history
+
+
+async def test_no_creds_alert_when_all_ok(monkeypatch, tmp_path):
+    import json
+    from pathlib import Path
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".genesis").mkdir(parents=True)
+    (fake_home / ".genesis" / "cred_integrity_status.json").write_text(json.dumps({
+        "version": 1, "targets": {"secrets_env": {"status": "ok"}},
+    }))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    mock_svc = AsyncMock()
+    mock_svc.snapshot.return_value = _mock_snapshot()
+    old, old_history = health_mcp_mod._service, health_mcp_mod._alert_history.copy()
+    try:
+        health_mcp_mod._service = mock_svc
+        health_mcp_mod._alert_history = {}
+        alerts = await _impl_health_alerts()
+        assert not [a for a in alerts if a["id"].startswith("creds:")]
+    finally:
+        health_mcp_mod._service = old
+        health_mcp_mod._alert_history = old_history

--- a/tests/test_outreach/test_health_outreach.py
+++ b/tests/test_outreach/test_health_outreach.py
@@ -254,3 +254,25 @@ async def test_dedup_does_not_suppress_old_delivery(db, bridge):
         result = await bridge.check_and_generate()
 
     assert len(result) == 1
+
+
+# ── creds: escalation (G.1) ──────────────────────────────────────────────
+
+
+async def test_creds_alerts_escalate_via_production_config(db):
+    """creds:corrupt / creds:restored must pass the escalation filter using the
+    REAL production whitelist (prefix match), so credential alerts reach Telegram."""
+    from genesis.outreach.config import _DEFAULTS
+
+    bridge = HealthOutreachBridge(
+        db, escalation_ids=frozenset(_DEFAULTS.immediate_escalation_alerts)
+    )
+    alerts = [
+        {"id": "creds:corrupt", "severity": "CRITICAL", "message": "secrets_env nul_bytes"},
+        {"id": "creds:restored", "severity": "CRITICAL", "message": "gh_hosts restored"},
+    ]
+    with _patch_alerts(alerts):
+        result = await bridge.check_and_generate()
+    ids = {r.source_id for r in result}
+    assert ids == {"creds:corrupt", "creds:restored"}
+    assert all(r.category == OutreachCategory.BLOCKER for r in result)


### PR DESCRIPTION
## What

Genesis now detects and repairs corrupted credential/wiring files on its own. If `secrets.env`, the Claude Code / GitHub credentials, an SSH key, `guardian_remote.yaml`, or `genesis.yaml` gets zeroed, truncated, or otherwise corrupted — the exact damage a storage outage causes mid-write — Genesis notices on its next cycle, restores the file from the encrypted backup (corrupt copy set aside), and alerts you to rotate anything that may have changed since the backup.

It acts **only on proven corruption** (missing-with-backup / empty / NUL-zeroed / unparseable / missing structural key), never on a merely-different file, and validates the decrypted backup **before** touching the original — a bad backup can never make things worse.

## Escalation ladder

- **Container is first responder** — the awareness tick validates + self-heals each cycle. Ambiguous parse errors debounce 2 ticks (avoids catching a live writer mid-rewrite, e.g. Claude Code rewriting `~/.claude.json`); the outage signature (NUL/empty/missing) restores immediately. A startup check runs **before** secrets load, so a corrupt `secrets.env` is healed before `load_dotenv` reads it.
- **Host guardian is the backstop** — it validates the same files via read-only `incus exec`, WARNs on first sight (deferring to the container), and STEPS IN (restores inside the container) only if corruption survives `grace_minutes` (default 30). This covers the window a degraded/dead server's awareness loop can't.

Both sides run the **same validator bytes**: the guardian pipes the standalone `cred_integrity.py` source into the container's *system* python3 (survives a broken venv); only a JSON verdict crosses back, and the passphrase is resolved container-side so the guardian never handles a secret.

## Safety

- Validate-decrypted-before-move; atomic placement; 0600 files / 0700 `~/.ssh`; plaintext temp cleaned up on every error path.
- Restores are rate-capped per target; a bad backup copy alerts instead of looping.
- Degrades cleanly: no backups configured → detection + alert only, no restore; container unreachable → guardian treats it as "no signal", never a false alert.
- Requires the backup-passphrase escrow from the previous release (breaks the circular trap where the only passphrase copy lives inside the file it encrypts).

Also restores the `backup:` prefix to `outreach.yaml`'s escalation list — it was in the code default but missing from the shipped yaml, so backup-failure alerts were silently non-escalating.

## Alerts

`creds:corrupt` / `creds:restored` (CRITICAL) → Telegram (added to the escalation whitelist). `corrupt_pending` (the debounce window) deliberately does not alert.

## Testing

- New unit suites: `test_cred_integrity` (validators × corruption modes, real-gpg restore incl. the validate-before-move invariant, passphrase chain, a subprocess parity test that fails the build on any `genesis.*` import), `test_cred_selfheal` (2-tick, startup, rate-cap, no-passphrase, status shape), `test_cred_watch` (escalation `decide()` matrix + orchestrator), plus `creds:` cases in the health-mcp + outreach tests.
- **E2E verified live** in a `--home` sandbox (real credentials never touched): healthy check; sabotage → detect → restore → re-check with correct perms + aside; container self-heal; the **circular passphrase case** (corrupt `secrets.env` + no env passphrase → escrow decrypts the backup); pipe-mode parity; and the guardian's exact pipe through **real incus** (`incus exec genesis -- su - ubuntu -c 'python3 - check --json'`) returning clean single-line JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)