### PR TITLE
feat(memory): entity-layer write wiring — extraction identity, anchors, backfill (E3)

### DIFF
--- a/scripts/entity_backfill.py
+++ b/scripts/entity_backfill.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Entity-layer backfill (approved HYBRID strategy, 2026-07-09).
+
+Two passes, both mechanical — NO LLM calls:
+
+1. **Anchor pass** — regex code-anchor extraction over every
+   ``memory_fts`` row (paths, genesis.* symbols, PR#s, SHAs) →
+   ``entity_mentions`` with ``source='backfill_mechanical'``.
+2. **Seed-FTS pass** — for each seed entity, FTS5 MATCH on its name →
+   ``entity_mentions`` with provenance ``INFERRED``, confidence 0.6,
+   ``source='backfill_fts'``. This is what makes the repo-split memory
+   reachable ORGANICALLY (its content names GENesis-Voice / voice edge),
+   not only via the hand-seeded spine.
+
+Forward-only for LLM-extracted named entities (no 49.7K re-extraction):
+cost, near-duplicate enrichment waste, and it would distort the
+engine-re-evaluation load data (follow-up 3ae26455).
+
+Default is DRY-RUN (counts only). Pass --apply to write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+BATCH = 2000
+
+
+async def anchor_pass(db, apply: bool) -> dict:
+    from genesis.memory.entity_anchors import extract_anchors, record_anchors
+
+    scanned = mentions = memories_with = 0
+    last_rowid = 0
+    while True:
+        rows = await db.execute_fetchall(
+            "SELECT rowid, memory_id, content FROM memory_fts "
+            "WHERE rowid > ? ORDER BY rowid LIMIT ?",
+            (last_rowid, BATCH),
+        )
+        if not rows:
+            break
+        for rowid, memory_id, content in rows:
+            last_rowid = rowid
+            scanned += 1
+            if not content or not memory_id:
+                continue
+            anchors = extract_anchors(content)
+            if not anchors:
+                continue
+            memories_with += 1
+            if apply:
+                mentions += await record_anchors(
+                    db, memory_id, content, source="backfill_mechanical",
+                )
+            else:
+                mentions += len(anchors)
+        print(f"  anchor pass: {scanned} scanned, {mentions} mentions", end="\r")
+    print()
+    return {
+        "scanned": scanned,
+        "memories_with_anchors": memories_with,
+        "anchor_mentions": mentions,
+    }
+
+
+async def seed_fts_pass(db, apply: bool) -> dict:
+    from genesis.db.crud import entities as entities_crud
+    from genesis.memory.entity_registry import norm
+    from genesis.memory.entity_seed import SEED_ENTITIES
+
+    total = 0
+    per_entity: dict[str, int] = {}
+    for name, _entity_type, _summary in SEED_ENTITIES:
+        entity = await entities_crud.get_by_norm_name(db, norm_name=norm(name))
+        if entity is None:
+            print(f"  seed entity missing (run apply_entity_seed first): {name}")
+            continue
+        # Quoted phrase match; FTS5 default tokenizer folds case and
+        # splits hyphens, so "voice-edge-device" matches "voice edge".
+        query = '"' + name.replace('"', "") + '"'
+        try:
+            rows = await db.execute_fetchall(
+                "SELECT memory_id FROM memory_fts WHERE memory_fts MATCH ? "
+                "LIMIT 500",
+                (query,),
+            )
+        except Exception as exc:
+            print(f"  FTS query failed for {name!r}: {exc}")
+            continue
+        count = 0
+        for (memory_id,) in rows:
+            if not memory_id:
+                continue
+            if apply:
+                await entities_crud.upsert_mention(
+                    db, memory_id=memory_id, entity_id=entity["entity_id"],
+                    provenance="INFERRED", confidence=0.6,
+                    source="backfill_fts", _commit=False,
+                )
+            count += 1
+        if apply:
+            await db.commit()
+        per_entity[name] = count
+        total += count
+    return {"seed_mentions": total, "per_entity": per_entity}
+
+
+async def main() -> None:
+    import aiosqlite
+
+    from genesis import env as genesis_env
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="write (default: dry-run)")
+    parser.add_argument("--db", default=None)
+    args = parser.parse_args()
+    db_path = args.db or str(genesis_env.genesis_db_path())
+
+    db = await aiosqlite.connect(db_path)
+    try:
+        mode = "APPLY" if args.apply else "DRY-RUN"
+        print(f"[{mode}] entity backfill against {db_path}")
+        anchor = await anchor_pass(db, args.apply)
+        print(f"anchor pass: {anchor}")
+        seed = await seed_fts_pass(db, args.apply)
+        print(f"seed-FTS pass: {seed['seed_mentions']} mentions")
+        for name, count in sorted(seed["per_entity"].items(), key=lambda kv: -kv[1]):
+            print(f"  {name}: {count}")
+        target = "9d36f039-3126-4721-8c71-027df1a94e2a"
+        rows = await db.execute_fetchall(
+            "SELECT entity_id, provenance, source FROM entity_mentions "
+            "WHERE memory_id = ?",
+            (target,),
+        ) if args.apply else []
+        if args.apply:
+            print(f"repo-split memory ({target[:8]}) mentions: {list(rows)}")
+    finally:
+        await db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/entity_backfill.py
+++ b/scripts/entity_backfill.py
@@ -133,6 +133,9 @@ async def main() -> None:
         print(f"seed-FTS pass: {seed['seed_mentions']} mentions")
         for name, count in sorted(seed["per_entity"].items(), key=lambda kv: -kv[1]):
             print(f"  {name}: {count}")
+        # The GENesis-Voice repo-split decision memory — the OMI-incident
+        # acceptance target (E4 replay gate); zero rows here just means
+        # the seed/backfill didn't reach it on this install.
         target = "9d36f039-3126-4721-8c71-027df1a94e2a"
         rows = await db.execute_fetchall(
             "SELECT entity_id, provenance, source FROM entity_mentions "

--- a/src/genesis/db/crud/entities.py
+++ b/src/genesis/db/crud/entities.py
@@ -315,14 +315,16 @@ async def merge_entity(
         "DELETE FROM entity_mentions WHERE entity_id = ?", (loser_id,),
     )
     for src_col, dst_col in (("source_id", "target_id"), ("target_id", "source_id")):
+        # dst != survivor guard: a pre-existing loser↔survivor link
+        # (e.g. an LLM-emitted supersedes) must not become a self-loop.
         await db.execute(
             f"INSERT OR IGNORE INTO entity_links "  # noqa: S608
             f"({src_col}, {dst_col}, link_type, provenance, confidence, "
             f"evidence_memory_id, valid_at, invalid_at, invalidated_by, created_at) "
             f"SELECT ?, {dst_col}, link_type, provenance, confidence, "
             f"evidence_memory_id, valid_at, invalid_at, invalidated_by, created_at "
-            f"FROM entity_links WHERE {src_col} = ?",
-            (survivor_id, loser_id),
+            f"FROM entity_links WHERE {src_col} = ? AND {dst_col} != ?",
+            (survivor_id, loser_id, survivor_id),
         )
         await db.execute(
             f"DELETE FROM entity_links WHERE {src_col} = ?",  # noqa: S608

--- a/src/genesis/memory/entity_anchors.py
+++ b/src/genesis/memory/entity_anchors.py
@@ -1,0 +1,84 @@
+"""Mechanical code-anchor extraction — regex only, zero LLM, zero ambiguity.
+
+Anchors are exact identifiers whose norm_name IS the identifier: repo
+file paths, dotted ``genesis.*`` symbols, PR numbers, commit SHAs. They
+feed the entity layer from ``MemoryStore.store()`` (every write path)
+and power the anchor-revision belief-updater (E5): anchor's file/symbol
+gone from the code index ⇒ candidate for ``invalid_at``.
+
+Deliberately conservative patterns — a missed anchor costs a hop, a
+false anchor pollutes the graph. Prompt keywords / activity logs are
+NOT sources in v1 (content + provenance beat breadth).
+"""
+
+from __future__ import annotations
+
+import re
+
+import aiosqlite
+
+MENTION_CONFIDENCE = 0.9  # mechanical match in the memory's own content
+
+_PATH_RE = re.compile(
+    r"\b(?:src|tests|scripts|docs|config)/[A-Za-z0-9_\-./]+\.[A-Za-z]{1,6}\b"
+)
+_SYMBOL_RE = re.compile(r"\bgenesis(?:\.[a-z_][a-z0-9_]*){1,6}\b")
+_PR_RE = re.compile(r"\bPR\s?#(\d{1,6})\b|(?<![\w#])#(\d{2,6})\b")
+# Require ≥1 digit so all-letter hex-alphabet words ("deadbee...") skip.
+_SHA_RE = re.compile(r"\b(?=[0-9a-f]*\d)[0-9a-f]{7,40}\b")
+
+_MAX_ANCHORS_PER_MEMORY = 16
+
+
+def extract_anchors(text: str) -> list[tuple[str, str]]:
+    """``[(name, entity_type)]`` — deduped, ordered, capped."""
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+
+    def _add(name: str, entity_type: str) -> None:
+        if name not in seen and len(out) < _MAX_ANCHORS_PER_MEMORY:
+            seen.add(name)
+            out.append((name, entity_type))
+
+    for m in _PATH_RE.finditer(text):
+        _add(m.group(0).rstrip("."), "code_file")
+    for m in _SYMBOL_RE.finditer(text):
+        # Skip if it's a fragment of a matched path (paths use /, not .)
+        _add(m.group(0), "code_symbol")
+    for m in _PR_RE.finditer(text):
+        number = m.group(1) or m.group(2)
+        _add(f"pr#{number}", "pr")
+    for m in _SHA_RE.finditer(text):
+        _add(m.group(0)[:12], "commit")
+    return out
+
+
+async def record_anchors(
+    db: aiosqlite.Connection,
+    memory_id: str,
+    content: str,
+    *,
+    source: str = "mechanical",
+) -> int:
+    """Resolve + mention every anchor in *content*. Returns count.
+
+    Failure-isolated by the caller (the store() seam wraps this in a
+    suppress) — this function itself only touches the entity tables.
+    """
+    from genesis.db.crud import entities as entities_crud
+    from genesis.memory.entity_registry import resolve_entity
+
+    anchors = extract_anchors(content)
+    for name, entity_type in anchors:
+        entity_id, provenance = await resolve_entity(
+            db, name=name, entity_type=entity_type, source=source,
+            aliases={}, _commit=False,
+        )
+        await entities_crud.upsert_mention(
+            db, memory_id=memory_id, entity_id=entity_id,
+            provenance=provenance, confidence=MENTION_CONFIDENCE,
+            source=source, _commit=False,
+        )
+    if anchors:
+        await db.commit()
+    return len(anchors)

--- a/src/genesis/memory/entity_registry.py
+++ b/src/genesis/memory/entity_registry.py
@@ -110,6 +110,93 @@ async def resolve_entity(
     return entity_id, "EXTRACTED"
 
 
+async def record_extraction(
+    db: aiosqlite.Connection,
+    memory_id: str,
+    extraction,
+    *,
+    aliases: dict[str, str] | None = None,
+) -> dict:
+    """Give an extraction's entities/relationships identity (E3 wiring).
+
+    Runs after ``linker.create_typed_links`` in the extraction cycle —
+    the memory_links path stays intact in parallel; zero new LLM calls.
+    Named entities resolve as type ``concept``; concept-cluster
+    cross-type reuse folds them onto seeded/typed entities (extraction
+    calling OMI a concept still lands on the seeded device). Mechanical
+    anchors are NOT handled here — the ``MemoryStore.store()`` seam
+    covers every write path including this one.
+
+    Returns counts. Commits once at the end (the surrounding
+    ``store.store()`` already committed the memory row itself).
+    """
+    from genesis.db.crud import entities as entities_crud
+
+    if aliases is None:
+        aliases = load_aliases()
+    counts = {"mentions": 0, "links": 0, "ambiguous": 0}
+    cache: dict[str, tuple[str, str] | None] = {}
+
+    async def _resolve(name: str) -> tuple[str, str] | None:
+        if name not in cache:
+            try:
+                cache[name] = await resolve_entity(
+                    db, name=name, entity_type="concept",
+                    source="extracted", aliases=aliases, _commit=False,
+                )
+            except ValueError:
+                cache[name] = None
+        return cache[name]
+
+    for name in extraction.entities or []:
+        pair = await _resolve(name)
+        if pair is None:
+            continue
+        entity_id, provenance = pair
+        if provenance == "AMBIGUOUS":
+            counts["ambiguous"] += 1
+        await entities_crud.upsert_mention(
+            db, memory_id=memory_id, entity_id=entity_id,
+            provenance=provenance, confidence=extraction.confidence,
+            source="llm_extraction", _commit=False,
+        )
+        counts["mentions"] += 1
+
+    for rel in extraction.relationships or []:
+        from_name, to_name = rel.get("from", ""), rel.get("to", "")
+        link_type = rel.get("type", "")
+        if not from_name or not to_name or not link_type:
+            continue
+        source = await _resolve(from_name)
+        target = await _resolve(to_name)
+        if source is None or target is None or source[0] == target[0]:
+            continue
+        provenance = (
+            "AMBIGUOUS"
+            if rel.get("ambiguous") or "AMBIGUOUS" in (source[1], target[1])
+            else "EXTRACTED"
+        )
+        try:
+            confidence = float(rel.get("confidence", extraction.confidence))
+        except (TypeError, ValueError):
+            confidence = extraction.confidence
+        await entities_crud.upsert_link(
+            db,
+            source_id=source[0],
+            target_id=target[0],
+            link_type=link_type,
+            provenance=provenance,
+            confidence=confidence,
+            evidence_memory_id=memory_id,
+            valid_at=extraction.temporal,
+            _commit=False,
+        )
+        counts["links"] += 1
+
+    await db.commit()
+    return counts
+
+
 def _closest(
     norm_name: str, candidates: list[tuple[str, str, str]]
 ) -> str | None:

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -282,15 +282,24 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
         relationships = item.get("relationships", [])
         if not isinstance(relationships, list):
             relationships = []
-        # Validate relationship structure
+        # Validate relationship structure. The optional per-relationship
+        # confidence/ambiguous fields the prompt solicits must survive
+        # parsing — record_extraction consumes them for entity_links
+        # provenance (dropping them silently forces every link to
+        # EXTRACTED at extraction-level confidence).
         valid_rels: list[dict] = []
         for rel in relationships:
             if isinstance(rel, dict) and "from" in rel and "to" in rel and "type" in rel:
-                valid_rels.append({
+                entry = {
                     "from": str(rel["from"]),
                     "to": str(rel["to"]),
                     "type": str(rel["type"]),
-                })
+                }
+                if "confidence" in rel:
+                    entry["confidence"] = rel["confidence"]
+                if "ambiguous" in rel:
+                    entry["ambiguous"] = bool(rel["ambiguous"])
+                valid_rels.append(entry)
 
         temporal = item.get("temporal")
         if temporal is not None:

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -32,8 +32,13 @@ For each extraction, provide:
 - confidence: 0.0 to 1.0 (how certain are you this is correctly extracted?)
 - entities: Named entities mentioned (tools, projects, people, organizations)
 - relationships: Typed connections between entities
-  - type: One of: discussed_in, evaluated_for, decided, action_item_for,
-    categorized_as, related_to, succeeded_by, preceded_by
+  - type: Preferred vocabulary: is_a, part_of, constrained_by, depends_on,
+    supersedes, alternative_to, discussed_in, evaluated_for, decided,
+    action_item_for, categorized_as, related_to, succeeded_by, preceded_by.
+    Prefer is_a for category membership ("X is a voice device") and
+    constrained_by for rules/decisions that govern an entity.
+  - optionally add "confidence" (0.0-1.0) and "ambiguous": true when you
+    are unsure the two names refer to distinct known things
 - temporal: Date or time reference if mentioned (ISO format preferred)
 
 For each extraction that has a temporal reference AND describes a concrete

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -417,6 +417,29 @@ async def run_extraction_cycle(
                                 memory_id, exc_info=True,
                             )
 
+                    # Entity layer (E3): give extracted entities and
+                    # relationships IDENTITY (entities/entity_mentions/
+                    # entity_links). Parallel to memory_links, never a
+                    # replacement; fail-open per memory.
+                    if extraction.entities or extraction.relationships:
+                        try:
+                            from genesis.memory.entity_registry import (
+                                record_extraction,
+                            )
+
+                            entity_counts = await record_extraction(
+                                db, memory_id, extraction,
+                            )
+                            summary.setdefault("entity_mentions", 0)
+                            summary.setdefault("entity_links", 0)
+                            summary["entity_mentions"] += entity_counts["mentions"]
+                            summary["entity_links"] += entity_counts["links"]
+                        except Exception:
+                            logger.warning(
+                                "Entity-layer recording failed for %s",
+                                memory_id, exc_info=True,
+                            )
+
                     # Goal signal detection — DISABLED: keyword matcher
                     # produced ~95% false positives (277 garbage goals from
                     # conversation snippets). Replaced by explicit goal

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -336,6 +336,19 @@ class MemoryStore:
             source_subsystem=source_subsystem,
         )
 
+        # Mechanical code anchors (entity layer) — regex-only, every write
+        # path. Failure-isolated: a broken anchor write must never break
+        # the store itself.
+        try:
+            from genesis.memory.entity_anchors import record_anchors
+
+            await record_anchors(self._db, memory_id, content)
+        except Exception:
+            logger.debug(
+                "entity anchor extraction failed for %s",
+                memory_id, exc_info=True,
+            )
+
         if not embedding_ok and not is_subsystem_write:
             # Queue for later embedding — preserve provenance so the recovery
             # worker can reconstruct the full Qdrant payload.

--- a/tests/test_memory/test_entity_write_wiring.py
+++ b/tests/test_memory/test_entity_write_wiring.py
@@ -1,0 +1,178 @@
+"""E3 write wiring: mechanical anchors, record_extraction, store seam."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from genesis.db.crud import entities as entities_crud
+from genesis.db.schema._tables import TABLES
+from genesis.memory.entity_anchors import extract_anchors, record_anchors
+from genesis.memory.entity_registry import record_extraction
+
+
+@pytest_asyncio.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    for table in ("entities", "entity_mentions", "entity_links",
+                  "deferred_work_queue"):
+        await conn.execute(TABLES[table])
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+@dataclass
+class FakeExtraction:
+    content: str = "x"
+    extraction_type: str = "decision"
+    confidence: float = 0.8
+    entities: list = field(default_factory=list)
+    relationships: list = field(default_factory=list)
+    temporal: str | None = None
+
+
+class TestAnchorExtraction:
+    def test_paths_symbols_prs_shas(self):
+        text = (
+            "Fixed src/genesis/memory/store.py and genesis.memory.retrieval "
+            "in PR #977; squash 0eb21377 landed. See also #58."
+        )
+        anchors = dict(extract_anchors(text))
+        assert anchors["src/genesis/memory/store.py"] == "code_file"
+        assert anchors["genesis.memory.retrieval"] == "code_symbol"
+        assert anchors["pr#977"] == "pr"
+        assert anchors["pr#58"] == "pr"
+        assert anchors["0eb21377"] == "commit"
+
+    def test_hex_needs_digit_and_no_word_false_positives(self):
+        # all-letter hex-alphabet words must not match as SHAs
+        anchors = extract_anchors("a decade of cafebabe efforts, no facade")
+        assert not [a for a in anchors if a[1] == "commit"]
+        # markdown heading '# 1' style must not match as PR
+        assert not extract_anchors("# heading\n## another")
+
+    def test_dedupe_and_cap(self):
+        text = " ".join(f"src/genesis/m{i}.py" for i in range(30))
+        text += " src/genesis/m0.py"
+        anchors = extract_anchors(text)
+        assert len(anchors) == 16  # capped, deduped
+
+    @pytest.mark.asyncio
+    async def test_record_anchors_writes_mentions(self, db):
+        n = await record_anchors(
+            db, "mem-1", "touched src/genesis/memory/store.py in PR #977",
+        )
+        assert n == 2
+        rows = await db.execute_fetchall(
+            "SELECT entity_id FROM entity_mentions WHERE memory_id = 'mem-1'"
+        )
+        assert len(rows) == 2
+        entity = await entities_crud.get_by_norm_name(
+            db, norm_name="src/genesis/memory/store.py",
+        )
+        assert entity["entity_type"] == "code_file"
+        assert entity["source"] == "mechanical"
+
+
+class TestRecordExtraction:
+    @pytest.mark.asyncio
+    async def test_entities_become_mentions(self, db):
+        extraction = FakeExtraction(entities=["Qdrant", "Tailscale"])
+        counts = await record_extraction(db, "mem-1", extraction, aliases={})
+        assert counts == {"mentions": 2, "links": 0, "ambiguous": 0}
+        rows = await db.execute_fetchall(
+            "SELECT provenance, confidence, source FROM entity_mentions"
+        )
+        assert all(r[0] == "EXTRACTED" and r[1] == 0.8 for r in rows)
+        assert all(r[2] == "llm_extraction" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_relationships_become_links_with_temporal(self, db):
+        extraction = FakeExtraction(
+            entities=["OMI"],
+            relationships=[
+                {"from": "OMI", "to": "voice-edge-device", "type": "is_a"},
+            ],
+            temporal="2026-06-14T00:00:00Z",
+        )
+        counts = await record_extraction(db, "mem-1", extraction, aliases={})
+        assert counts["links"] == 1
+        rows = await db.execute_fetchall(
+            "SELECT link_type, valid_at, evidence_memory_id FROM entity_links"
+        )
+        assert rows[0][0] == "is_a"
+        assert rows[0][1] == "2026-06-14T00:00:00+00:00"  # canonicalized
+        assert rows[0][2] == "mem-1"
+
+    @pytest.mark.asyncio
+    async def test_relationship_ambiguous_flag_and_confidence(self, db):
+        extraction = FakeExtraction(
+            relationships=[
+                {"from": "A", "to": "B", "type": "related_to",
+                 "ambiguous": True, "confidence": 0.55},
+            ],
+        )
+        await record_extraction(db, "mem-1", extraction, aliases={})
+        rows = await db.execute_fetchall(
+            "SELECT provenance, confidence FROM entity_links"
+        )
+        assert rows[0][0] == "AMBIGUOUS"
+        assert rows[0][1] == 0.55
+
+    @pytest.mark.asyncio
+    async def test_reuses_seeded_typed_entity(self, db):
+        seeded = await entities_crud.create_entity(
+            db, name="OMI", norm_name="omi", entity_type="device",
+            source="seed",
+        )
+        extraction = FakeExtraction(entities=["omi"])
+        await record_extraction(db, "mem-1", extraction, aliases={})
+        rows = await db.execute_fetchall("SELECT entity_id FROM entity_mentions")
+        assert rows[0][0] == seeded  # concept-cluster cross-type reuse
+        n = (await db.execute_fetchall("SELECT COUNT(*) FROM entities"))[0][0]
+        assert n == 1  # no duplicate concept-typed OMI
+
+    @pytest.mark.asyncio
+    async def test_self_link_and_blank_names_skipped(self, db):
+        extraction = FakeExtraction(
+            relationships=[
+                {"from": "Genesis", "to": "genesis", "type": "related_to"},
+                {"from": "", "to": "X", "type": "related_to"},
+            ],
+        )
+        counts = await record_extraction(db, "mem-1", extraction, aliases={})
+        assert counts["links"] == 0
+
+
+class TestStoreSeamFailOpen:
+    @pytest.mark.asyncio
+    async def test_store_survives_anchor_failure(self):
+        from genesis.memory.store import MemoryStore
+
+        ep = MagicMock()
+        ep.embed = AsyncMock(return_value=[0.1] * 1024)
+        ep.enrich = MagicMock(return_value="episodic: x")
+        store = MemoryStore(
+            embedding_provider=ep, qdrant_client=MagicMock(),
+            db=AsyncMock(), linker=None,
+        )
+        with patch("genesis.memory.store.upsert_point"), \
+             patch("genesis.memory.store.memory_crud") as mock_mem, \
+             patch(
+                 "genesis.memory.entity_anchors.record_anchors",
+                 AsyncMock(side_effect=RuntimeError("boom")),
+             ):
+            mock_mem.upsert = AsyncMock(return_value="id")
+            mock_mem.create_metadata = AsyncMock(return_value=None)
+            memory_id = await store.store(
+                content="anchor src/genesis/memory/store.py present",
+                memory_type="episodic",
+                source="test",
+            )
+        assert memory_id  # anchor failure never breaks the store

--- a/tests/test_memory/test_entity_write_wiring.py
+++ b/tests/test_memory/test_entity_write_wiring.py
@@ -139,6 +139,48 @@ class TestRecordExtraction:
         assert n == 1  # no duplicate concept-typed OMI
 
     @pytest.mark.asyncio
+    async def test_parser_preserves_relationship_provenance_fields(self, db):
+        """END-TO-END through the real parser (review finding: the
+        earlier test hand-built dicts and masked a parser field-drop)."""
+        from genesis.memory.extraction import parse_extraction_response
+
+        raw = (
+            '{"extractions": [{"content": "OMI is a voice device", '
+            '"type": "entity", "confidence": 0.8, "entities": ["OMI"], '
+            '"relationships": [{"from": "OMI", "to": "voice-edge-device", '
+            '"type": "is_a", "confidence": 0.55, "ambiguous": true}], '
+            '"temporal": null}]}'
+        )
+        extractions = parse_extraction_response(raw)
+        assert extractions, "parser returned nothing"
+        await record_extraction(db, "mem-1", extractions[0], aliases={})
+        rows = await db.execute_fetchall(
+            "SELECT provenance, confidence FROM entity_links"
+        )
+        assert rows[0][0] == "AMBIGUOUS"
+        assert rows[0][1] == 0.55
+
+    @pytest.mark.asyncio
+    async def test_merge_no_self_loop_on_preexisting_pair_link(self, db):
+        """Review finding: merging entities that already link to each
+        other must not mint a self-loop edge."""
+        loser = await entities_crud.create_entity(
+            db, name="QdrantDB", norm_name="qdrantdb", entity_type="product",
+        )
+        survivor = await entities_crud.create_entity(
+            db, name="Qdrant", norm_name="qdrant", entity_type="product",
+        )
+        await entities_crud.upsert_link(
+            db, source_id=loser, target_id=survivor, link_type="supersedes",
+            provenance="EXTRACTED",
+        )
+        await entities_crud.merge_entity(db, loser_id=loser, survivor_id=survivor)
+        rows = await db.execute_fetchall(
+            "SELECT source_id, target_id FROM entity_links"
+        )
+        assert all(r[0] != r[1] for r in rows), f"self-loop minted: {list(rows)}"
+
+    @pytest.mark.asyncio
     async def test_self_link_and_blank_names_skipped(self, db):
         extraction = FakeExtraction(
             relationships=[


### PR DESCRIPTION
## Summary
Third PR of the entity-layer lane. **Zero new LLM calls** — the extraction pipeline already emits entity and relationship names; this PR gives them identity in the #983 substrate.

### Write wiring
- **`entity_registry.record_extraction()`** — `extraction.entities` → `entity_mentions`; `extraction.relationships` → bi-temporal `entity_links` (`valid_at` from the extraction temporal, canonicalized; `evidence_memory_id` set; per-relationship `confidence`/`ambiguous` honored). Wired into `run_extraction_cycle` immediately after `create_typed_links` — the `memory_links` path is untouched and parallel; fail-open per memory.
- **`entity_anchors.py`** — conservative regex extraction of repo paths, `genesis.*` symbols, PR#s, and SHAs (digit-required hex so hex-alphabet words never match; capped 16/memory). Wired at the `MemoryStore.store()` seam so EVERY write path records anchors; failure-isolated. Mechanical anchors skip the fuzzy tier entirely — no O(entities) scan on the hot path (reviewer-verified).
- **Extraction prompt** — preferred relation vocabulary (`is_a`, `part_of`, `constrained_by`, `depends_on`, …) + optional per-relationship `confidence`/`ambiguous`. Additive; unknown types are still skipped by the `memory_links` validator.
- **`scripts/entity_backfill.py`** (approved hybrid strategy) — mechanical anchor pass over all ~49.7K `memory_fts` rows + seed-entity FTS mention pass (`INFERRED`, 0.6) that makes the repo-split decision memory reachable organically. Dry-run by default, `--apply` gated. Forward-only for LLM named entities (cost + honest engine-re-eval load data).

### Code-review findings (inline reviewer over the combined E2+E3 diff) — both fixed here
1. `parse_extraction_response` stripped the optional per-relationship `confidence`/`ambiguous` fields, silently forcing every link to `EXTRACTED`; now preserved, with a regression test through the REAL parser path.
2. `merge_entity` minted a self-loop edge when the merged pair already linked to each other; rewrite now filters `dst == survivor`.

Reviewer verified clean: fail-open at both seams, commit discipline, regex boundedness, migration idempotence, backfill gating.

## Testing
- 24 tests across `test_entity_write_wiring.py` (anchor regex matrix incl. hex/heading false-positive guards, record_extraction incl. end-to-end parser path, store fail-open, merge self-loop guard) + `test_entity_layer.py`
- Neighbors green: `test_store.py`, `test_extraction_job.py`, `test_extraction.py`; ruff clean

## Post-merge (this session)
Apply seed + run backfill with `--apply` (user-gated), then verify the OMI spine end-to-end against the live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)