### PR TITLE
fix(telegram): single-poller ownership — bridge yields to server; stall + dead-remediation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   now restores those fields. Separately, keyword-only memories were being scored as
   if created just now (maximum freshness), letting old notes outrank genuinely recent
   ones; they now use their real creation time.
+- **Telegram no longer drops messages or breaks approval buttons when the
+  legacy bridge gets started alongside the server.** Two Genesis processes
+  polling the same bot token split incoming updates between them (observed:
+  thousands of `Conflict` errors, unresponsive approval buttons, and a
+  corrupted health-status file monitored by the watchdog). The bridge now
+  yields cleanly at startup whenever the server is running — however it was
+  started (deploy script habit, manual, self-heal) — and the server calls out
+  a rogue bridge loudly instead of failing silently. The broken self-heal
+  rule that restarted the bridge on a stale awareness heartbeat (a leftover
+  from when the bridge owned the awareness loop) is gone; a health alert
+  takes its place, and server restarts for genuinely dead schedulers remain
+  with the external watchdog.
+- **Quiet hours no longer restart the Telegram poller.** The stall detector
+  only counted arriving messages as signs of life, so any 15+ minutes of
+  silence looked like a hung poller and triggered an updater restart, all day
+  long. Successful empty polls now count as liveness; real network hangs
+  still trigger the restart.
 
 - **Protected-path guarding now covers the real systemd unit sources.** The
   critical-path rules protected a stale copy of the watchdog unit under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,10 @@ journalctl --user -u genesis-server -n 50        # Logs
 systemctl --user list-units 'genesis-*' --all    # All units
 ```
 
-Other units: `genesis-bridge.service` (Telegram relay, on-demand),
+Other units: `genesis-bridge.service` (LEGACY fallback — full stack incl.
+Telegram, only when genesis-server is DOWN; it yields/exits 200 if the server
+lock is held, and must never run alongside the server — dual getUpdates
+pollers split updates and break approval buttons),
 `genesis-tmp-watchgod.service` (/tmp protection), `genesis-watchdog.timer`
 (health check), `genesis-backup.timer` (6h encrypted backup via
 `scripts/backup.sh`), `genesis-disk-hygiene.timer` (daily worktree reaping, cache reclaim, `~/tmp`

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -247,11 +247,17 @@ Every surface a human (or host process) talks to Genesis through.
 ```yaml subsystem-map
 entry: channels-interfaces
 modules: [channels, dashboard, mcp, hosting, browser, mail]
-verified: 8235a607 2026-07-08
+verified: 0eb21377 2026-07-10
 ```
 
 - **channels/**: adapter framework. Telegram (`bridge.py` =
-  `genesis-bridge.service`, boots a full headless runtime); voice (HA,
+  `genesis-bridge.service`, boots a full runtime — LEGACY FALLBACK ONLY:
+  it yields at startup, exit 200, when the genesis-server process lock is
+  held, because two runtimes dual-poll getUpdates and both write
+  status.json; the server hosts the same adapter via
+  `hosting/standalone.py`. The polling stall watchdog records liveness
+  from successful EMPTY getUpdates round trips too —
+  `LivenessHTTPXRequest` — so idle chat is not a stall); voice (HA,
   OUTBOUND-only — inbound voice arrives via `dashboard/routes/voice_api.py`;
   uses `media_player.play_media`, never `assist_satellite.announce` which
   reopens the mic); Discord webhook; email SMTP. All env-gated. "OpenClaw" here

--- a/src/genesis/autonomy/remediation.py
+++ b/src/genesis/autonomy/remediation.py
@@ -388,15 +388,24 @@ DEFAULT_REMEDIATIONS: list[RemediationAction] = [
         cooldown_s=300,
         max_attempts=3,
     ),
+    # The RESTART response to a stale scheduler heartbeat lives in the
+    # external watchdog (autonomy/watchdog.py zombie-scheduler path), which
+    # runs out-of-process every ~5 min with heavy-workload / boot-stabilization
+    # / deploy-window / backoff guards. In-loop we only ALERT: an action
+    # evaluated inside the awareness tick cannot restart a hung awareness
+    # loop anyway (its predecessor, awareness_restart, was doubly dead — its
+    # probe was never registered, and it restarted genesis-bridge, a stale
+    # mapping from when the awareness loop lived in the bridge; starting the
+    # bridge alongside the server causes a getUpdates dual-poller conflict).
     RemediationAction(
-        name="awareness_restart",
-        probe_name="awareness_tick",
-        condition="Awareness loop heartbeat stale >15min",
-        command=["systemctl", "--user", "restart", "genesis-bridge.service"],
-        governance_level=2,
+        name="scheduler_heartbeat_alert",
+        probe_name="scheduler_heartbeats",
+        condition="A scheduler heartbeat (awareness/surplus) stale >15min",
+        command=[],  # Alert-only, no command
+        governance_level=4,
         reversible=True,
-        cooldown_s=300,
-        max_attempts=3,
+        cooldown_s=3600,
+        max_attempts=1,
     ),
     RemediationAction(
         name="ollama_alert",

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -1,8 +1,16 @@
-"""Genesis channel bridge — entry point for the messaging bridge service.
+"""Genesis channel bridge — LEGACY FALLBACK entry point.
 
 Runs the Telegram bot with ConversationLoop routing messages through CC CLI.
 Bootstraps the full GenesisRuntime so all subsystems (awareness, memory,
 learning, reflection, inbox) are active during user conversation.
+
+genesis-server hosts the same Telegram adapter plus everything else, so the
+bridge only has a job when the server is NOT running. Two full runtimes on
+one install means duelling getUpdates pollers (telegram.error.Conflict, split
+updates, broken approval buttons), two status.json writers, and duplicate
+schedulers — so the bridge YIELDS at startup (exit 200, which the systemd
+unit's RestartPreventExitStatus treats as do-not-restart) whenever the
+genesis-server process lock is held.
 
 Must run outside a CC session (same constraint as terminal.py).
 
@@ -352,8 +360,29 @@ async def main():
     log.info("Bridge stopped.")
 
 
+def _yield_to_server(pid_dir=None) -> None:
+    """Exit (code 200) if genesis-server is running — it owns the full stack.
+
+    The check covers every start path (deploy-session restarts, watchdog
+    fallback, manual start): whoever starts the bridge while the server is
+    alive gets a clean refusal instead of a second runtime silently fighting
+    the server for getUpdates, status.json, and the schedulers. Exit 200 is
+    in the unit's RestartPreventExitStatus, so systemd does not crash-loop.
+    """
+    from genesis.util.process_lock import EXIT_ALREADY_RUNNING, ProcessLock
+
+    if ProcessLock.is_locked("genesis-server", pid_dir=pid_dir):
+        log.critical(
+            "genesis-server is running — bridge yields Telegram/runtime "
+            "ownership and exits (legacy fallback runs only when the server "
+            "is down)"
+        )
+        sys.exit(EXIT_ALREADY_RUNNING)
+
+
 if __name__ == "__main__":
     from genesis.util.process_lock import ProcessLock
 
+    _yield_to_server()
     with ProcessLock("bridge"):
         asyncio.run(main())

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -172,6 +172,13 @@ async def main():
         log.error("GenesisRuntime bootstrap failed — cannot start bridge")
         sys.exit(1)
 
+    # Re-probe before EITHER continuation (polling or headless): on a
+    # simultaneous co-start the __main__ probe can pass before the server
+    # acquires its lock, and even a headless bridge is a full duplicate
+    # runtime (schedulers, status.json writer). By the end of our ~90s
+    # bootstrap a co-started server definitely holds its lock.
+    await _late_yield_check(runtime)
+
     config = _load_bridge_config()
     if config is None:
         log.info("No Telegram token configured — running headless for background systems")
@@ -262,12 +269,6 @@ async def main():
     ev_loop = asyncio.get_running_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         ev_loop.add_signal_handler(sig, _signal_handler)
-
-    # Re-probe before polling starts: on a simultaneous co-start (e.g. a
-    # deploy restarting both units) the __main__ probe can pass before the
-    # server acquires its lock; by the end of our ~90s bootstrap a co-started
-    # server definitely holds it. Exiting here means we never poll.
-    await _late_yield_check(runtime)
 
     await adapter.start()
 
@@ -367,11 +368,12 @@ async def main():
 
 
 async def _late_yield_check(runtime, pid_dir=None) -> None:
-    """Second yield probe, run after bootstrap and before adapter.start().
+    """Second yield probe, run right after bootstrap in main().
 
     Closes the co-start race the __main__ probe can't see: if the server was
     started in the window since that probe, shut the runtime down cleanly and
-    exit 200 BEFORE this process ever issues a getUpdates poll.
+    exit 200 BEFORE this process polls getUpdates or continues headless
+    (a headless bridge is still a full duplicate runtime).
     """
     from genesis.util.process_lock import EXIT_ALREADY_RUNNING, ProcessLock
 

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -263,6 +263,12 @@ async def main():
     for sig in (signal.SIGINT, signal.SIGTERM):
         ev_loop.add_signal_handler(sig, _signal_handler)
 
+    # Re-probe before polling starts: on a simultaneous co-start (e.g. a
+    # deploy restarting both units) the __main__ probe can pass before the
+    # server acquires its lock; by the end of our ~90s bootstrap a co-started
+    # server definitely holds it. Exiting here means we never poll.
+    await _late_yield_check(runtime)
+
     await adapter.start()
 
     # Create TopicManager after start() — needs adapter._app.bot
@@ -358,6 +364,24 @@ async def main():
     await adapter.stop()
     await runtime.shutdown()
     log.info("Bridge stopped.")
+
+
+async def _late_yield_check(runtime, pid_dir=None) -> None:
+    """Second yield probe, run after bootstrap and before adapter.start().
+
+    Closes the co-start race the __main__ probe can't see: if the server was
+    started in the window since that probe, shut the runtime down cleanly and
+    exit 200 BEFORE this process ever issues a getUpdates poll.
+    """
+    from genesis.util.process_lock import EXIT_ALREADY_RUNNING, ProcessLock
+
+    if ProcessLock.is_locked("genesis-server", pid_dir=pid_dir):
+        log.critical(
+            "genesis-server started during bridge bootstrap — yielding "
+            "before polling begins (exit 200)"
+        )
+        await runtime.shutdown()
+        sys.exit(EXIT_ALREADY_RUNNING)
 
 
 def _yield_to_server(pid_dir=None) -> None:

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -30,7 +30,10 @@ from telegram.ext import (
 from genesis.channels.base import ChannelAdapter
 from genesis.channels.telegram.handlers_v2 import make_handlers_v2
 from genesis.channels.telegram.transport.offset_store import read_offset, write_offset
-from genesis.channels.telegram.transport.polling import PollingWatchdog
+from genesis.channels.telegram.transport.polling import (
+    LivenessHTTPXRequest,
+    PollingWatchdog,
+)
 from genesis.channels.telegram.transport.send import (
     safe_send_document,
     safe_send_message,
@@ -148,6 +151,18 @@ class TelegramAdapterV2(ChannelAdapter):
             .connect_timeout(10.0)
             .concurrent_updates(4)  # Bounded concurrency — prevents callback TTL stalls
             # while limiting race exposure on shared HandlerContext state
+            # Dedicated getUpdates pool (pool_size=1 mirrors PTB's default for
+            # it) that records poll liveness on every successful round trip —
+            # empty polls included — so idle chat ≠ stalled poller.
+            # self._watchdog is created below, before polling starts.
+            .get_updates_request(LivenessHTTPXRequest(
+                connection_pool_size=1,
+                on_success=lambda: (
+                    w.record_activity()
+                    if (w := getattr(self, "_watchdog", None)) is not None
+                    else None
+                ),
+            ))
             .build()
         )
 
@@ -181,8 +196,10 @@ class TelegramAdapterV2(ChannelAdapter):
         if "callback_query" in handlers:
             self._app.add_handler(CallbackQueryHandler(handlers["callback_query"]))
 
-        # Watchdog activity tracker — fires on ALL updates (not just user messages)
-        # so idle periods don't trigger false stall alarms
+        # Stall watchdog. Liveness is recorded from two directions: the
+        # LivenessHTTPXRequest above on every successful getUpdates round
+        # trip (idle chat ≠ stall), and the TypeHandler below on every
+        # processed update (belt — also persists the offset).
         self._watchdog = PollingWatchdog(on_stall=self._handle_polling_stall)
 
         async def _record_any_update(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/genesis/channels/telegram/transport/polling.py
+++ b/src/genesis/channels/telegram/transport/polling.py
@@ -17,6 +17,8 @@ import contextlib
 import logging
 import time
 
+from telegram.request import HTTPXRequest
+
 from genesis.util.tasks import tracked_task
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,38 @@ logger = logging.getLogger(__name__)
 STALL_THRESHOLD_S = 300.0  # 5 min — low-traffic bot; 90s was triggering on normal idle
 CHECK_INTERVAL_S = 60.0
 _MAX_STALL_THRESHOLD_S = 900.0  # 15 minutes — cap for backoff
+
+
+class LivenessHTTPXRequest(HTTPXRequest):
+    """getUpdates request pool that reports every successful poll round-trip.
+
+    PTB only surfaces updates that ARRIVE (handlers, incl. TypeHandler), so
+    an idle chat is indistinguishable from a hung poller to the stall
+    watchdog — which then restarts the updater every threshold window
+    (observed as all-day false-stall churn). This class is passed to
+    ``ApplicationBuilder.get_updates_request`` (a pool used exclusively by
+    getUpdates), and fires ``on_success`` on each HTTP-200 round trip,
+    empty result or not. Errors and exceptions deliberately do NOT report,
+    so genuine network hangs and persistent API failures still starve the
+    watchdog and trip the stall restart. Bots are slotted/locked in PTB, so
+    the request object is the supported seam for this.
+    """
+
+    __slots__ = ("_on_success",)
+
+    def __init__(self, *args, on_success=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._on_success = on_success
+
+    async def do_request(self, *args, **kwargs):
+        result = await super().do_request(*args, **kwargs)
+        code = result[0] if isinstance(result, tuple) else result
+        if code == 200 and self._on_success is not None:
+            try:
+                self._on_success()
+            except Exception:
+                logger.warning("poll-liveness callback failed", exc_info=True)
+        return result
 
 
 class PollingWatchdog:

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -516,6 +516,23 @@ class StandaloneAdapter:
             from genesis.channels.bridge import _load_bridge_config
             from genesis.channels.config import load_channel_defaults
 
+            # Belt for the bridge-side yield guard: a legacy bridge that
+            # predates the guard (or was started in the probe→bootstrap race
+            # window) would silently fight this adapter for getUpdates.
+            # The server is the owner — start anyway, but loudly.
+            try:
+                from genesis.util.process_lock import ProcessLock
+
+                if ProcessLock.is_locked("bridge"):
+                    logger.critical(
+                        "genesis-bridge is running alongside the server — "
+                        "dual getUpdates pollers will conflict (dropped "
+                        "updates, broken approval buttons). Stop it: "
+                        "systemctl --user stop genesis-bridge"
+                    )
+            except Exception:
+                logger.debug("Bridge-lock probe failed", exc_info=True)
+
             config = _load_bridge_config()
             if config is None:
                 logger.info("No Telegram token — running dashboard-only")

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -261,7 +261,19 @@ async def probe_scheduler_heartbeats(
         if job_health is None:
             from genesis.runtime import GenesisRuntime
 
-            job_health = GenesisRuntime.instance().job_health
+            # peek(), not instance(): a read-only probe must never
+            # lazy-construct a blank runtime (masks bootstrap failures).
+            rt = GenesisRuntime.peek()
+            if rt is None:
+                latency = (time.monotonic() - start) * 1000
+                return ProbeResult(
+                    name="scheduler_heartbeats",
+                    status=ProbeStatus.HEALTHY,
+                    latency_ms=round(latency, 2),
+                    message="no live runtime",
+                    checked_at=_clock().isoformat(),
+                )
+            job_health = rt.job_health
         now = _clock()
         stale: list[str] = []
         for job_name in ("awareness_tick", "surplus_dispatch"):

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -239,6 +239,63 @@ async def probe_scheduler(
         )
 
 
+async def probe_scheduler_heartbeats(
+    job_health: dict | None = None,
+    *,
+    stale_after_s: float = 900.0,
+    clock=None,
+) -> ProbeResult:
+    """DOWN if any scheduler heartbeat in rt.job_health is stale.
+
+    Reads the same last_run entries the status writer publishes as
+    ``scheduler_heartbeats`` for the external watchdog. The watchdog owns the
+    RESTART response (zombie-scheduler path, with heavy-workload/stabilization
+    guards); this probe only feeds the alert-only remediation lane. Because it
+    is evaluated inside the awareness tick, a fully hung awareness loop can
+    never alert on itself — this catches zombie SIBLING schedulers (e.g.
+    surplus dead while awareness alive). Missing entries don't alarm.
+    """
+    _clock = clock or (lambda: datetime.now(UTC))
+    start = time.monotonic()
+    try:
+        if job_health is None:
+            from genesis.runtime import GenesisRuntime
+
+            job_health = GenesisRuntime.instance().job_health
+        now = _clock()
+        stale: list[str] = []
+        for job_name in ("awareness_tick", "surplus_dispatch"):
+            last_run = job_health.get(job_name, {}).get("last_run")
+            if not last_run:
+                continue  # no data yet — don't alarm
+            try:
+                ts = datetime.fromisoformat(last_run)
+            except (ValueError, TypeError):
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=UTC)
+            age_s = (now - ts).total_seconds()
+            if age_s > stale_after_s:
+                stale.append(f"{job_name} ({int(age_s)}s stale)")
+        latency = (time.monotonic() - start) * 1000
+        return ProbeResult(
+            name="scheduler_heartbeats",
+            status=ProbeStatus.DOWN if stale else ProbeStatus.HEALTHY,
+            latency_ms=round(latency, 2),
+            message="; ".join(stale),
+            checked_at=_clock().isoformat(),
+        )
+    except Exception as exc:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeResult(
+            name="scheduler_heartbeats",
+            status=ProbeStatus.HEALTHY,  # can't evaluate ≠ schedulers dead
+            latency_ms=round(latency, 2),
+            message=f"heartbeat data unavailable: {exc}",
+            checked_at=_clock().isoformat(),
+        )
+
+
 async def probe_disk(
     mount_path: str = "/",
     *,
@@ -553,6 +610,7 @@ async def collect_probe_results(
         _safe("disk", probe_disk()),
         _safe("guardian", probe_guardian(guardian_remote=guardian_remote)),
         _safe("browser_processes", probe_browser_processes()),
+        _safe("scheduler_heartbeats", probe_scheduler_heartbeats()),
     ]
     if db is not None:
         tasks.append(_safe("db", probe_db(db)))

--- a/src/genesis/util/process_lock.py
+++ b/src/genesis/util/process_lock.py
@@ -1,6 +1,7 @@
 """Process singleton guard using fcntl file locking."""
 
 import contextlib
+import errno
 import fcntl
 import logging
 import os
@@ -57,7 +58,16 @@ class ProcessLock:
             return False
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
+        except OSError as exc:
+            if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN):
+                # I/O-level failure, not contention. Still report "locked":
+                # callers use this to avoid booting a duplicate runtime, and
+                # a dual runtime is worse than a skipped fallback start —
+                # but say so instead of silently conflating the two.
+                log.warning(
+                    "Lock probe for %s inconclusive (errno=%s) — "
+                    "treating as locked", name, exc.errno,
+                )
             return True
         else:
             fcntl.flock(fd, fcntl.LOCK_UN)

--- a/src/genesis/util/process_lock.py
+++ b/src/genesis/util/process_lock.py
@@ -38,6 +38,29 @@ class ProcessLock:
     def lock_path(self) -> Path:
         return self._lock_path
 
+    @staticmethod
+    def is_locked(name: str, pid_dir: Path | None = None) -> bool:
+        """Return True if a live process currently holds *name*'s lock.
+
+        Probe-only: briefly acquires the flock if free, then releases it
+        WITHOUT unlinking the file (an unlink could race a holder acquiring
+        between the probe and the unlink). flock auto-releases on holder
+        death, so a leftover file from a dead process reads as free.
+        """
+        lock_path = (pid_dir or _DEFAULT_PID_DIR) / f"{name}.lock"
+        if not lock_path.exists():
+            return False
+        fd = os.open(str(lock_path), os.O_RDWR)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return True
+        else:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+        finally:
+            os.close(fd)
+
     def __enter__(self) -> "ProcessLock":
         self._dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/genesis/util/process_lock.py
+++ b/src/genesis/util/process_lock.py
@@ -50,7 +50,11 @@ class ProcessLock:
         lock_path = (pid_dir or _DEFAULT_PID_DIR) / f"{name}.lock"
         if not lock_path.exists():
             return False
-        fd = os.open(str(lock_path), os.O_RDWR)
+        try:
+            fd = os.open(str(lock_path), os.O_RDWR)
+        except FileNotFoundError:
+            # Holder unlinked the file between exists() and open() — free.
+            return False
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError:

--- a/tests/test_autonomy/test_remediation.py
+++ b/tests/test_autonomy/test_remediation.py
@@ -125,9 +125,27 @@ class TestRegistration:
         assert len(reg.actions) == len(DEFAULT_REMEDIATIONS)
         names = {a.name for a in reg.actions}
         assert "qdrant_restart" in names
-        assert "awareness_restart" in names
+        assert "scheduler_heartbeat_alert" in names
         assert "ollama_alert" in names
         assert "disk_cleanup" in names
+        # The dead awareness_restart (unregistered probe; restarted the
+        # legacy bridge → dual-poller) must never come back.
+        assert "awareness_restart" not in names
+
+    def test_scheduler_heartbeat_alert_is_alert_only(self):
+        alert = [
+            a for a in DEFAULT_REMEDIATIONS
+            if a.name == "scheduler_heartbeat_alert"
+        ][0]
+        assert alert.governance_level == 4   # alert-only — restart is the
+        assert alert.command == []           # external watchdog's job
+        assert alert.probe_name == "scheduler_heartbeats"
+
+    def test_no_action_targets_genesis_bridge(self):
+        """Remediation must never (re)start the legacy bridge alongside the
+        server — that is the dual-getUpdates incident class."""
+        for action in DEFAULT_REMEDIATIONS:
+            assert "genesis-bridge.service" not in action.command, action.name
 
     def test_default_timeout_s(self):
         # New per-action timeout defaults to 30s (no behavior change for others).

--- a/tests/test_channels/test_bridge.py
+++ b/tests/test_channels/test_bridge.py
@@ -65,3 +65,51 @@ class TestLoadBridgeConfig:
         config = _load_bridge_config()
         assert config["forum_chat_id"] == 999
         os.unlink(path)
+
+
+class TestYieldToServer:
+    """The bridge must refuse to run alongside genesis-server (dual-runtime /
+    dual-getUpdates guard). Server not running → guard is a no-op (legacy
+    fallback preserved)."""
+
+    def test_exits_200_when_server_lock_held(self, tmp_path, monkeypatch):
+        import subprocess
+        import sys as _sys
+        import textwrap
+        import time
+
+        import pytest
+
+        from genesis.channels.bridge import _yield_to_server
+        from genesis.util.process_lock import EXIT_ALREADY_RUNNING
+
+        holder = subprocess.Popen(
+            [
+                _sys.executable,
+                "-c",
+                textwrap.dedent(f"""\
+                    import time
+                    from pathlib import Path
+                    from genesis.util.process_lock import ProcessLock
+                    with ProcessLock("genesis-server", pid_dir=Path("{tmp_path}")):
+                        time.sleep(30)
+                """),
+            ],
+        )
+        try:
+            lock_path = tmp_path / "genesis-server.lock"
+            for _ in range(100):
+                if lock_path.exists() and lock_path.read_text().strip():
+                    break
+                time.sleep(0.1)
+            with pytest.raises(SystemExit) as exc:
+                _yield_to_server(pid_dir=tmp_path)
+            assert exc.value.code == EXIT_ALREADY_RUNNING
+        finally:
+            holder.terminate()
+            holder.wait(timeout=10)
+
+    def test_noop_when_server_not_running(self, tmp_path):
+        from genesis.channels.bridge import _yield_to_server
+
+        _yield_to_server(pid_dir=tmp_path)  # must not raise

--- a/tests/test_channels/test_bridge.py
+++ b/tests/test_channels/test_bridge.py
@@ -113,3 +113,57 @@ class TestYieldToServer:
         from genesis.channels.bridge import _yield_to_server
 
         _yield_to_server(pid_dir=tmp_path)  # must not raise
+
+
+class TestLateYieldCheck:
+    """The pre-polling re-probe: a server that started during the bridge's
+    ~90s bootstrap is detected before the first getUpdates poll."""
+
+    async def test_shuts_down_and_exits_200_when_server_appeared(self, tmp_path):
+        import subprocess
+        import sys as _sys
+        import textwrap
+        import time
+        from unittest.mock import AsyncMock
+
+        import pytest
+
+        from genesis.channels.bridge import _late_yield_check
+        from genesis.util.process_lock import EXIT_ALREADY_RUNNING
+
+        holder = subprocess.Popen(
+            [
+                _sys.executable,
+                "-c",
+                textwrap.dedent(f"""\
+                    import time
+                    from pathlib import Path
+                    from genesis.util.process_lock import ProcessLock
+                    with ProcessLock("genesis-server", pid_dir=Path("{tmp_path}")):
+                        time.sleep(30)
+                """),
+            ],
+        )
+        try:
+            lock_path = tmp_path / "genesis-server.lock"
+            for _ in range(100):
+                if lock_path.exists() and lock_path.read_text().strip():
+                    break
+                time.sleep(0.1)
+            runtime = AsyncMock()
+            with pytest.raises(SystemExit) as exc:
+                await _late_yield_check(runtime, pid_dir=tmp_path)
+            assert exc.value.code == EXIT_ALREADY_RUNNING
+            runtime.shutdown.assert_awaited_once()
+        finally:
+            holder.terminate()
+            holder.wait(timeout=10)
+
+    async def test_noop_when_server_absent(self, tmp_path):
+        from unittest.mock import AsyncMock
+
+        from genesis.channels.bridge import _late_yield_check
+
+        runtime = AsyncMock()
+        await _late_yield_check(runtime, pid_dir=tmp_path)
+        runtime.shutdown.assert_not_awaited()

--- a/tests/test_channels/test_bridge.py
+++ b/tests/test_channels/test_bridge.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 
+import pytest
+
 from genesis.channels.bridge import _load_bridge_config
 
 
@@ -116,9 +118,10 @@ class TestYieldToServer:
 
 
 class TestLateYieldCheck:
-    """The pre-polling re-probe: a server that started during the bridge's
-    ~90s bootstrap is detected before the first getUpdates poll."""
+    """The post-bootstrap re-probe: a server that started during the bridge's
+    ~90s bootstrap is detected before polling OR headless continuation."""
 
+    @pytest.mark.asyncio
     async def test_shuts_down_and_exits_200_when_server_appeared(self, tmp_path):
         import subprocess
         import sys as _sys
@@ -159,6 +162,7 @@ class TestLateYieldCheck:
             holder.terminate()
             holder.wait(timeout=10)
 
+    @pytest.mark.asyncio
     async def test_noop_when_server_absent(self, tmp_path):
         from unittest.mock import AsyncMock
 

--- a/tests/test_channels/test_transport.py
+++ b/tests/test_channels/test_transport.py
@@ -433,3 +433,64 @@ class TestAdapterOffsetDebounce:
             # force=True bypasses the debounce check
             adapter._persist_offset(force=True)
             assert mock_write.call_count == 2
+
+
+class TestLivenessHTTPXRequest:
+    """The getUpdates request pool must report every successful poll
+    round-trip — including EMPTY ones — so a quiet chat doesn't read as a
+    stalled poller (false stalls restarted the updater every threshold
+    window all day on 2026-07-08)."""
+
+    def _make(self, do_request_result=None, do_request_exc=None):
+        from unittest.mock import AsyncMock, patch
+
+        from genesis.channels.telegram.transport.polling import (
+            LivenessHTTPXRequest,
+        )
+
+        calls = []
+        req = LivenessHTTPXRequest(
+            connection_pool_size=1, on_success=lambda: calls.append(1),
+        )
+        parent = AsyncMock()
+        if do_request_exc is not None:
+            parent.side_effect = do_request_exc
+        else:
+            parent.return_value = do_request_result
+        patcher = patch(
+            "telegram.request.HTTPXRequest.do_request", parent,
+        )
+        return req, calls, patcher
+
+    @pytest.mark.asyncio
+    async def test_successful_empty_poll_records(self):
+        req, calls, patcher = self._make(do_request_result=(200, b'{"ok":true,"result":[]}'))
+        with patcher:
+            await req.do_request(url="u", method="post")
+        assert calls == [1]
+
+    @pytest.mark.asyncio
+    async def test_http_error_does_not_record(self):
+        req, calls, patcher = self._make(do_request_result=(409, b"conflict"))
+        with patcher:
+            await req.do_request(url="u", method="post")
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_exception_does_not_record(self):
+        req, calls, patcher = self._make(do_request_exc=RuntimeError("net down"))
+        with patcher, pytest.raises(RuntimeError):
+            await req.do_request(url="u", method="post")
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_callback_is_safe(self):
+        from unittest.mock import AsyncMock, patch
+
+        from genesis.channels.telegram.transport.polling import (
+            LivenessHTTPXRequest,
+        )
+
+        req = LivenessHTTPXRequest(connection_pool_size=1)
+        with patch("telegram.request.HTTPXRequest.do_request", AsyncMock(return_value=(200, b""))):
+            await req.do_request(url="u", method="post")  # must not raise

--- a/tests/test_hosting/test_standalone_telegram_guard.py
+++ b/tests/test_hosting/test_standalone_telegram_guard.py
@@ -1,0 +1,42 @@
+"""The server-side dual-poller belt in StandaloneAdapter._start_telegram.
+
+The primary guard is bridge-side (the bridge yields when the server lock is
+held); this belt covers the reverse direction — a pre-guard bridge binary or
+a probe-race survivor — by logging CRITICAL while still starting the adapter
+(the server is the owner).
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from genesis.hosting.standalone import StandaloneAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_bridge_running_logs_critical(caplog):
+    adapter = StandaloneAdapter()
+    with patch(
+        "genesis.util.process_lock.ProcessLock.is_locked", return_value=True,
+    ), patch(
+        "genesis.channels.bridge._load_bridge_config", return_value=None,
+    ), caplog.at_level(logging.CRITICAL, logger="genesis.hosting.standalone"):
+        await adapter._start_telegram()
+    assert any(
+        "genesis-bridge is running" in r.message for r in caplog.records
+    ), "belt must announce the dual-poller condition loudly"
+
+
+async def test_no_bridge_no_noise(caplog):
+    adapter = StandaloneAdapter()
+    with patch(
+        "genesis.util.process_lock.ProcessLock.is_locked", return_value=False,
+    ), patch(
+        "genesis.channels.bridge._load_bridge_config", return_value=None,
+    ), caplog.at_level(logging.CRITICAL, logger="genesis.hosting.standalone"):
+        await adapter._start_telegram()
+    assert not any(
+        "genesis-bridge is running" in r.message for r in caplog.records
+    )

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -453,3 +453,14 @@ class TestProbeSchedulerHeartbeats:
               (now - timedelta(seconds=1200)).replace(tzinfo=None).isoformat()}}
         result = await probe_scheduler_heartbeats(jh, clock=FROZEN_CLOCK)
         assert result.status == ProbeStatus.DOWN
+
+    @pytest.mark.asyncio
+    async def test_no_runtime_does_not_construct_one(self):
+        """peek()-based read: with no live runtime the probe reports healthy
+        no-data and must NOT lazy-construct a blank singleton."""
+        with patch("genesis.runtime.GenesisRuntime.peek", return_value=None), \
+             patch("genesis.runtime.GenesisRuntime.instance") as inst:
+            result = await probe_scheduler_heartbeats(None, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.HEALTHY
+        assert "no live runtime" in result.message
+        inst.assert_not_called()

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -12,6 +12,7 @@ from genesis.observability.health import (
     probe_ollama,
     probe_qdrant,
     probe_scheduler,
+    probe_scheduler_heartbeats,
     probe_wal,
 )
 from genesis.observability.types import ProbeResult, ProbeStatus
@@ -404,3 +405,51 @@ class TestInfrastructureAmbientPlumbing:
             )
         assert infra["ambient"]["status"] == "error"
         assert "boom" in infra["ambient"]["error"]
+
+
+class TestProbeSchedulerHeartbeats:
+    """Alert-only staleness probe over rt.job_health — the same heartbeat
+    source status_writer publishes for the external watchdog."""
+
+    def _jh(self, *, awareness_age_s=60, surplus_age_s=60, now=None):
+        now = now or FROZEN_CLOCK()
+        return {
+            "awareness_tick": {
+                "last_run": (now - timedelta(seconds=awareness_age_s)).isoformat()
+            },
+            "surplus_dispatch": {
+                "last_run": (now - timedelta(seconds=surplus_age_s)).isoformat()
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_fresh_heartbeats_healthy(self):
+        result = await probe_scheduler_heartbeats(
+            self._jh(), clock=FROZEN_CLOCK,
+        )
+        assert result.status == ProbeStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_stale_heartbeat_down_and_named(self):
+        result = await probe_scheduler_heartbeats(
+            self._jh(surplus_age_s=1200), clock=FROZEN_CLOCK,
+        )
+        assert result.status == ProbeStatus.DOWN
+        assert "surplus_dispatch" in result.message
+
+    @pytest.mark.asyncio
+    async def test_no_data_does_not_alarm(self):
+        result = await probe_scheduler_heartbeats({}, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.HEALTHY
+        result = await probe_scheduler_heartbeats(
+            {"awareness_tick": {}}, clock=FROZEN_CLOCK,
+        )
+        assert result.status == ProbeStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_naive_timestamp_treated_as_utc(self):
+        now = FROZEN_CLOCK()
+        jh = {"awareness_tick": {"last_run":
+              (now - timedelta(seconds=1200)).replace(tzinfo=None).isoformat()}}
+        result = await probe_scheduler_heartbeats(jh, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DOWN

--- a/tests/test_util/test_process_lock.py
+++ b/tests/test_util/test_process_lock.py
@@ -164,3 +164,18 @@ def test_is_locked_true_while_held(tmp_path):
         holder.wait(timeout=10)
     # flock auto-releases on process death
     assert ProcessLock.is_locked("held", pid_dir=tmp_path) is False
+
+
+def test_is_locked_vanishing_file_is_free(tmp_path, monkeypatch):
+    """Holder unlinks the lock file between exists() and open() → free,
+    not a crash (TOCTOU guard)."""
+    (tmp_path / "gone.lock").write_text("1")
+    real_open = os.open
+
+    def _vanish(path, *a, **kw):
+        if path.endswith("gone.lock"):
+            raise FileNotFoundError(path)
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr(os, "open", _vanish)
+    assert ProcessLock.is_locked("gone", pid_dir=tmp_path) is False

--- a/tests/test_util/test_process_lock.py
+++ b/tests/test_util/test_process_lock.py
@@ -123,3 +123,44 @@ def test_creates_pid_dir(tmp_path):
     with ProcessLock("nested", pid_dir=nested):
         assert nested.exists()
         assert (nested / "nested.lock").exists()
+
+
+def test_is_locked_false_when_free(tmp_path):
+    """No holder (or no lock file at all) → not locked."""
+    assert ProcessLock.is_locked("free", pid_dir=tmp_path) is False
+    # Probing must not delete a pre-existing lock file left on disk
+    (tmp_path / "stale.lock").write_text("12345")
+    assert ProcessLock.is_locked("stale", pid_dir=tmp_path) is False
+    assert (tmp_path / "stale.lock").exists()
+
+
+def test_is_locked_true_while_held(tmp_path):
+    """A live holder in another process → locked; released → unlocked."""
+    import textwrap
+    import time
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(f"""\
+                import time
+                from pathlib import Path
+                from genesis.util.process_lock import ProcessLock
+                with ProcessLock("held", pid_dir=Path("{tmp_path}")):
+                    time.sleep(30)
+            """),
+        ],
+    )
+    try:
+        lock_path = tmp_path / "held.lock"
+        for _ in range(100):
+            if lock_path.exists() and lock_path.read_text().strip():
+                break
+            time.sleep(0.1)
+        assert ProcessLock.is_locked("held", pid_dir=tmp_path) is True
+    finally:
+        holder.send_signal(signal.SIGTERM)
+        holder.wait(timeout=10)
+    # flock auto-releases on process death
+    assert ProcessLock.is_locked("held", pid_dir=tmp_path) is False

--- a/tests/test_util/test_process_lock.py
+++ b/tests/test_util/test_process_lock.py
@@ -179,3 +179,21 @@ def test_is_locked_vanishing_file_is_free(tmp_path, monkeypatch):
 
     monkeypatch.setattr(os, "open", _vanish)
     assert ProcessLock.is_locked("gone", pid_dir=tmp_path) is False
+
+
+def test_is_locked_io_error_reports_locked_with_warning(tmp_path, monkeypatch, caplog):
+    """Non-contention flock failures (EIO etc.) read as locked — refusing a
+    fallback start is safer than risking a dual runtime — but loudly."""
+    import errno as _errno
+    import fcntl
+    import logging
+
+    (tmp_path / "weird.lock").write_text("1")
+
+    def _eio(*a, **kw):
+        raise OSError(_errno.EIO, "io error")
+
+    monkeypatch.setattr(fcntl, "flock", _eio)
+    with caplog.at_level(logging.WARNING):
+        assert ProcessLock.is_locked("weird", pid_dir=tmp_path) is True
+    assert any("inconclusive" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Root-cause fixes for the dual-poller incident (two full runtimes polled getUpdates on one bot token for ~2 days: thousands of `telegram.error.Conflict` errors, split/dropped updates, flaky approval buttons, and two processes fighting over status.json):

- **Bridge yields to the server (primary fix).** `bridge.py` is a legacy fallback that boots a full second runtime; it now probes the `genesis-server` process lock at startup and exits 200 (`RestartPreventExitStatus` — no crash-loop) when the server is alive, regardless of who started it. A second probe after bootstrap and before `adapter.start()` closes the co-start race (a deploy restarting both units simultaneously — the actual incident trigger). Legacy fallback (server down → bridge runs) is unchanged. New `ProcessLock.is_locked()` probe helper (flock, non-destructive, errno-aware).
- **Dead self-heal removed, honest alert added.** The `awareness_restart` remediation could never fire (its probe was never registered — `collect_probe_results`'s only caller passes no scheduler) and its command restarted **genesis-bridge**, a stale mapping from when the awareness loop lived there — i.e. the self-heal would have *caused* this incident class. Deleted; the restart response stays with the external watchdog's zombie-scheduler path (heavy-workload/stabilization/backoff guards). New `probe_scheduler_heartbeats` (reads the same `rt.job_health` entries the status writer publishes) feeds an L4 alert-only action. Regression pins: `awareness_restart` can't return; no remediation may target genesis-bridge.
- **Stall-detector false alarms fixed.** The polling watchdog only counted *arriving* updates as liveness, so any quiet 15+ minutes looked like a hung poller and restarted the updater all day (`consecutive=21` observed). `LivenessHTTPXRequest` on the dedicated getUpdates pool records every successful HTTP-200 round trip, empty or not; errors/exceptions still starve the watchdog so genuine outages trip it. Verified against PTB 22.7 internals (do_request seam, builder `get_updates_request` defaults reproduced exactly).
- **Server-side belt:** the server logs CRITICAL if a rogue bridge holds its lock when Telegram starts (log-only by design — the adapter being started is the very channel an alert would need).

## Review

Claude structured review: clean (PTB 22.7 compatibility verified against installed source; slots/builder checks; both sub-threshold observations fixed — TOCTOU guard in `is_locked`, `peek()` over `instance()` in the probe). Codex adversarial: co-start race + errno conflation adopted and fixed; remaining findings verified false (L4 empty-command path returns before execution; exception→HEALTHY is the documented can't-evaluate-≠-dead policy; timestamp semantics deliberately mirror the external watchdog's).

## Verification

- Targeted suites green: transport/adapter, bridge yield guard (real flock subprocess tests incl. SIGKILL release), remediation defaults + regression pins, heartbeat probe cases, hosting belt.
- Live E2E after merge: start genesis-bridge with the server up → immediate exit 200 with the yield log, zero new Conflict lines; single status.json writer (uptime_s already re-verified matching server uptime after the ops stop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)