### PR TITLE
feat(memory): session-awareness entity lane, shadow-first (E4)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -383,15 +383,18 @@ verified: 8dac642c 2026-07-09
   into a per-session EMA + entity ledger
   (`~/.genesis/sessions/<id>/session_theme.json`); on a drift-trigger
   fire it spawns the detached worker (2-slot flock semaphore), which
-  retrieves+ranks candidates over three lanes — vector, decisions
-  (`tags~decision`, the OMI-incident class), entity-keyword drift — all
-  Qdrant lanes EXACT search (filtered HNSW without payload indexes
-  drops valid results; found 2026-07-09). Verdicts →
-  `ambient_verdict.json`, tuning → size-capped shadow log. **Zero
-  DB/Qdrant writes — never bumps retrieved_count** (protects
-  MEM-005/H-1 baselines). Fail-open at the hook boundary. Kill switch:
-  `GENESIS_SESSION_AWARENESS_DISABLED=1`. Arbiter (PR3) + replay gate
-  (PR4) pending.
+  retrieves+ranks candidates over four lanes — vector, decisions
+  (`tags~decision`, the OMI-incident class), entity-keyword drift, and
+  the **entity lane** (ledger keywords → entity nodes → ≤2 typed hops →
+  mentions; `ranking.ENTITY_LANE_MODE`, SHADOW — entity-only hits ride
+  `entity_shadow` telemetry, never candidates, until the OMI-replay-
+  gated flip) — all Qdrant lanes EXACT search (filtered HNSW without
+  payload indexes drops valid results; found 2026-07-09). Headless-
+  Haiku arbiter judges candidates per fire (fail-closed parse, group-
+  kill on timeout). Verdicts → `ambient_verdict.json`, tuning →
+  size-capped shadow log. **Zero DB/Qdrant writes — never bumps
+  retrieved_count** (protects MEM-005/H-1 baselines). Fail-open at the
+  hook boundary. Kill switch: `GENESIS_SESSION_AWARENESS_DISABLED=1`.
 
 ## 10. Learning & evaluation
 

--- a/scripts/ambient_replay.py
+++ b/scripts/ambient_replay.py
@@ -176,6 +176,7 @@ async def replay(args) -> dict:
     genuine = 0
     trace: list[dict] = []
     fires: list[dict] = []
+    t_mention: int | None = None  # first turn the target entity is in the ledger
     as_of_cutoff: str | None = None if args.as_of in (None, "auto") else args.as_of
 
     db = qdrant = None
@@ -239,6 +240,15 @@ async def replay(args) -> dict:
             }
             trace.append(row)
 
+            # Track first turn the target entity enters the ledger
+            # (t_mention anchors the E4 acceptance window).
+            if (
+                args.target_entity
+                and t_mention is None
+                and args.target_entity in state.get("entities", {})
+            ):
+                t_mention = genuine
+
             if fired:
                 record_fire(state, now_iso)
                 fire_rec: dict = {"turn": genuine, "ts": now_iso}
@@ -246,6 +256,7 @@ async def replay(args) -> dict:
                     from genesis.session_awareness.accumulator import top_entities
                     from genesis.session_awareness.ranking import rank_candidates
 
+                    entity_shadow: list[dict] = []
                     candidates = await rank_candidates(
                         ema=state["ema"],
                         entity_query=" ".join(top_entities(state, 8)),
@@ -253,16 +264,30 @@ async def replay(args) -> dict:
                         qdrant_client=qdrant,
                         embedding_provider=provider,
                         created_before=as_of_cutoff,
+                        entity_lane=args.entity_lane,
+                        entity_shadow_out=entity_shadow,
                     )
                     fire_rec["candidates"] = [
                         {
                             "memory_id": c["memory_id"],
                             "score": round(c["score"], 4),
                             "lanes": c["lanes"],
+                            "entity_path": c.get("entity_path"),
                             "preview": c["preview"][:60],
                         }
                         for c in candidates
                     ]
+                    if entity_shadow:
+                        fire_rec["entity_shadow"] = [
+                            {
+                                "memory_id": s["memory_id"],
+                                "path_score": round(
+                                    s["entity_path"]["path_score"], 4
+                                ),
+                                "already_candidate": s["already_candidate"],
+                            }
+                            for s in entity_shadow
+                        ]
                 fires.append(fire_rec)
     finally:
         if db is not None:
@@ -282,13 +307,51 @@ async def replay(args) -> dict:
         for f in fires:
             for c in f.get("candidates", []):
                 if c["memory_id"].startswith(args.target):
-                    hit = {"turn": f["turn"], "memory_id": c["memory_id"]}
+                    hit = {
+                        "turn": f["turn"],
+                        "memory_id": c["memory_id"],
+                        "lanes": c.get("lanes", []),
+                    }
                     break
             if hit:
                 break
         result["target"] = args.target
         result["target_hit"] = hit
-        result["PASS"] = bool(hit and hit["turn"] <= 10)
+        if args.target_entity:
+            # E4 criterion: a fire within [t_mention, t_mention+10]
+            # whose candidates include the target VIA the entity lane.
+            # (The mention window replaces the original fixed turn<=10 —
+            # mentions can arrive late in a session.) A miss with no
+            # fire in the window is a trigger-cadence failure, reported
+            # distinctly from a lane failure.
+            result["target_entity"] = args.target_entity
+            result["t_mention"] = t_mention
+            window_fires = [
+                f for f in fires
+                if t_mention is not None
+                and t_mention <= f["turn"] <= t_mention + 10
+            ]
+            entity_hit = None
+            for f in window_fires:
+                for c in f.get("candidates", []):
+                    if (
+                        c["memory_id"].startswith(args.target)
+                        and "entity" in c.get("lanes", [])
+                    ):
+                        entity_hit = {"turn": f["turn"], "memory_id": c["memory_id"]}
+                        break
+                if entity_hit:
+                    break
+            result["entity_hit"] = entity_hit
+            result["PASS"] = bool(entity_hit)
+            if not entity_hit:
+                result["fail_reason"] = (
+                    "no_mention" if t_mention is None
+                    else "no_fire_in_window" if not window_fires
+                    else "target_not_in_entity_lane"
+                )
+        else:
+            result["PASS"] = bool(hit and hit["turn"] <= 10)
     return result
 
 
@@ -297,6 +360,20 @@ def main() -> None:
     parser.add_argument("--session-id", required=True)
     parser.add_argument("--transcript", default=None)
     parser.add_argument("--target", default=None, help="memory-id prefix to hunt")
+    parser.add_argument(
+        "--target-entity",
+        default=None,
+        help="normalized ledger keyword (e.g. 'omi'); switches PASS to the "
+             "E4 criterion: target reached VIA the entity lane within 10 "
+             "turns of the keyword first entering the ledger",
+    )
+    parser.add_argument(
+        "--entity-lane",
+        default=None,
+        choices=["off", "shadow", "live"],
+        help="override ranking.ENTITY_LANE_MODE for this replay (the "
+             "acceptance run uses 'live'; production stays shadow)",
+    )
     parser.add_argument("--max-genuine-turns", type=int, default=0)
     parser.add_argument("--no-retrieve", action="store_true")
     parser.add_argument(
@@ -329,6 +406,10 @@ def main() -> None:
     if args.target:
         print(f"TARGET {args.target}: hit={result['target_hit']} "
               f"PASS={result.get('PASS')}")
+        if args.target_entity:
+            print(f"  t_mention={result.get('t_mention')} "
+                  f"entity_hit={result.get('entity_hit')} "
+                  f"fail_reason={result.get('fail_reason')}")
 
 
 if __name__ == "__main__":

--- a/src/genesis/session_awareness/ranking.py
+++ b/src/genesis/session_awareness/ranking.py
@@ -14,6 +14,13 @@ memory):
 - **Drift lane** — the entity ledger's top keywords as a query string
   through ``drift_recall`` (it has no vector entry point; it re-embeds
   internally and only READS retrieval bookkeeping).
+- **Entity lane (E4, shadow-first)** — ledger keywords resolved to
+  entity nodes (ledger keys == norm_names by construction), expanded
+  ≤2 typed hops through ``entity_links``, then their ``entity_mentions``
+  become candidates. This is the categorical-inference lane: a single
+  "OMI" mention reaches the repo-split decision via
+  OMI →is_a→ voice-edge-device →constrained_by→ rule. Gated by
+  ``ENTITY_LANE_MODE`` (see below).
 
 Bitemporal parity with the main retrieval path via
 ``_expired_candidate_ids``. Rank mirrors the graph-boost shape from
@@ -52,6 +59,21 @@ BACKLINK_COEF = 0.05  # mirrors retrieval._BACKLINK_BOOST_COEF
 DEFAULT_CONFIDENCE = 0.5
 PREVIEW_CHARS = 200
 
+# ── Entity lane (E4) ─────────────────────────────────────────────────
+# "shadow": lane computed and reported via ``entity_shadow_out``, but
+# entity-only candidates never enter the returned set and existing
+# candidates' ``lanes`` stay untouched (the arbiter prompt renders
+# lanes — shadow must not perturb judgments; entity info rides in the
+# separate ``entity_path`` key the arbiter never reads).
+# "live": entity candidates rank normally with a reserved floor.
+# "off": lane skipped entirely.
+# The E4b flip is this ONE constant → "live", gated on the OMI replay.
+ENTITY_LANE_MODE = "shadow"
+ENTITY_RESERVED = 2  # entity-lane floor (live mode), mirrors DECISION_RESERVED
+ENTITY_DEPTH_DECAY = 0.7  # per-hop decay on top of edge confidences
+ENTITY_MENTIONS_PER_ENTITY = 10
+ENTITY_LANE_LIMIT = 15  # max entity-lane candidates considered
+
 
 def _preview(content: str) -> str:
     return content[:PREVIEW_CHARS]
@@ -66,11 +88,16 @@ async def rank_candidates(
     embedding_provider: EmbeddingProvider,
     top_n: int = TOP_N,
     created_before: str | None = None,
+    entity_lane: str | None = None,
+    entity_shadow_out: list | None = None,
 ) -> list[dict]:
-    """Gather both lanes, filter expired, rank, return the top *top_n*.
+    """Gather the lanes, filter expired, rank, return the top *top_n*.
 
     Each candidate: memory_id, score, cosine, confidence, memory_class,
-    inbound_links, lanes, preview.
+    inbound_links, lanes, preview (+ entity_path when the entity lane
+    reached it). *entity_lane* overrides ``ENTITY_LANE_MODE``; in shadow
+    mode entity-only candidates are appended to *entity_shadow_out*
+    (when given) instead of the returned set.
     """
     from genesis.db.crud.memory_links import batch_link_counts
     from genesis.memory.classification import CLASS_WEIGHTS
@@ -134,28 +161,117 @@ async def rank_candidates(
                 "lanes": ["drift"],
             }
 
+    # ── Entity lane (E4) ─────────────────────────────────────────────
+    # Ledger keywords ARE norm_names by construction (both normalize via
+    # entity_resolution.normalize_content) — resolution doubles as the
+    # noise filter: STT filler words resolve to nothing and drop out.
+    mode = entity_lane or ENTITY_LANE_MODE
+    if mode in ("shadow", "live"):
+        try:
+            from genesis.db.crud import entities as entities_crud
+            from genesis.db.crud.entities import PROVENANCE_WEIGHTS
+
+            weights: dict[str, float] = {}
+            for keyword in entity_query.split():
+                ent = await entities_crud.get_by_norm_name(
+                    db, norm_name=keyword,
+                )
+                if ent and ent.get("status") == "active":
+                    weights[ent["entity_id"]] = 1.0
+            if weights:
+                reached = await entities_crud.connected_entities(
+                    db, list(weights), max_depth=2, as_of=created_before,
+                )
+                for eid, info in reached.items():
+                    weights[eid] = info["path_confidence"] * (
+                        ENTITY_DEPTH_DECAY ** info["depth"]
+                    )
+                mentions = await entities_crud.memories_mentioning(
+                    db, list(weights),
+                    limit_per_entity=ENTITY_MENTIONS_PER_ENTITY,
+                )
+                entity_meta: dict[str, dict] = {}
+                for m in mentions:
+                    path_score = (
+                        weights[m["entity_id"]]
+                        * m["confidence"]
+                        * PROVENANCE_WEIGHTS.get(m["provenance"], 0.5)
+                    )
+                    prev = entity_meta.get(m["memory_id"])
+                    if prev is None or path_score > prev["path_score"]:
+                        entity_meta[m["memory_id"]] = {
+                            "path_score": path_score,
+                            "via_entity": m["entity_id"],
+                            "provenance": m["provenance"],
+                        }
+                ranked_hits = sorted(
+                    entity_meta.items(),
+                    key=lambda kv: kv[1]["path_score"],
+                    reverse=True,
+                )[:ENTITY_LANE_LIMIT]
+                for mid, meta in ranked_hits:
+                    if mid in by_id:
+                        by_id[mid]["entity_path"] = meta
+                        if mode == "live":
+                            by_id[mid]["lanes"].append("entity")
+                    else:
+                        by_id[mid] = {
+                            "memory_id": mid,
+                            "cosine": None,  # backfilled below
+                            "confidence": None,
+                            "memory_class": None,
+                            "preview": "",
+                            "lanes": ["entity"],
+                            "entity_path": meta,
+                            "_shadow_only": mode == "shadow",
+                        }
+        except Exception:
+            pass  # additive lane — never breaks the worker
+
     if not by_id:
         return []
 
-    # Drift-only candidates need their stored vector for cosine-vs-EMA.
+    # Drift/entity-only candidates need vector (cosine-vs-EMA) + payload.
     missing = [mid for mid, c in by_id.items() if c["cosine"] is None]
     if missing:
         try:
             points = qdrant_client.retrieve(
                 collection_name="episodic_memory",
                 ids=missing,
-                with_payload=False,
+                with_payload=True,
                 with_vectors=True,
             )
             for p in points:
+                cand = by_id.get(str(p.id))
+                if cand is None:
+                    continue
                 vec = p.vector if isinstance(p.vector, list) else None
                 if vec:
-                    by_id[str(p.id)]["cosine"] = cosine(ema, vec)
+                    cand["cosine"] = cosine(ema, vec)
+                payload = p.payload or {}
+                if not cand["preview"]:
+                    cand["preview"] = _preview(payload.get("content", ""))
+                if cand["confidence"] is None:
+                    cand["confidence"] = payload.get("confidence")
+                if cand["memory_class"] is None:
+                    cand["memory_class"] = payload.get("memory_class")
+                cand.setdefault("created_at", payload.get("created_at"))
         except Exception:
             pass  # cosine stays None → scored at 0 below, not dropped info
         for mid in missing:
             if by_id[mid]["cosine"] is None:
                 by_id[mid]["cosine"] = 0.0
+
+    # As-of parity for entity-only candidates: mentions don't carry the
+    # memory's created_at, so the cutoff applies via the payload fetched
+    # above (other lanes were already cutoff-filtered at search time).
+    if created_before:
+        for mid in [
+            m for m, c in by_id.items()
+            if c["lanes"] == ["entity"]
+            and str(c.get("created_at") or "") > created_before
+        ]:
+            by_id.pop(mid)
 
     # ── Bitemporal parity ────────────────────────────────────────────
     expired = await _expired_candidate_ids(db, set(by_id))
@@ -180,7 +296,12 @@ async def rank_candidates(
             * max(cand["cosine"] or 0.0, 0.0)
         )
 
-    ranked = sorted(by_id.values(), key=lambda c: c["score"], reverse=True)
+    # Shadow-only entity candidates never enter the live ranking; they
+    # are reported through entity_shadow_out for telemetry/replay.
+    shadow_only = [c for c in by_id.values() if c.pop("_shadow_only", False)]
+    live_pool = [c for c in by_id.values() if c not in shadow_only]
+
+    ranked = sorted(live_pool, key=lambda c: c["score"], reverse=True)
     picked = ranked[:top_n]
 
     # Stratified floor: guarantee decision-lane representation. Without
@@ -199,5 +320,45 @@ async def rank_candidates(
                 + extras
             )
             picked.sort(key=lambda c: c["score"], reverse=True)
+
+    # Entity floor (live mode only) — same crowd-out logic as decisions.
+    if mode == "live":
+        entity_in = sum(1 for c in picked if "entity" in c["lanes"])
+        if entity_in < ENTITY_RESERVED:
+            extras = [
+                c for c in ranked[top_n:]
+                if "entity" in c["lanes"] and c not in picked
+            ][: ENTITY_RESERVED - entity_in]
+            if extras:
+                protected = [
+                    c for c in picked
+                    if "entity" in c["lanes"] or "decision" in c["lanes"]
+                ]
+                fill = [c for c in picked if c not in protected]
+                picked = (
+                    protected
+                    + fill[: max(0, top_n - len(protected) - len(extras))]
+                    + extras
+                )
+                picked.sort(key=lambda c: c["score"], reverse=True)
+
+    # Shadow report: what the entity lane WOULD have contributed.
+    if entity_shadow_out is not None and mode == "shadow":
+        report = shadow_only + [
+            c for c in live_pool if "entity_path" in c
+        ]
+        report.sort(
+            key=lambda c: c["entity_path"]["path_score"], reverse=True,
+        )
+        entity_shadow_out.extend(
+            {
+                "memory_id": c["memory_id"],
+                "score": c["score"],
+                "entity_path": c["entity_path"],
+                "already_candidate": c not in shadow_only,
+                "preview": c["preview"],
+            }
+            for c in report
+        )
 
     return picked

--- a/src/genesis/session_awareness/worker.py
+++ b/src/genesis/session_awareness/worker.py
@@ -113,12 +113,14 @@ async def run_worker(
             qdrant = QdrantClient(url=url, timeout=10)
             provider = EmbeddingProvider()
             entity_query = " ".join(top_entities(state, ENTITY_QUERY_TERMS))
+            entity_shadow: list[dict] = []
             candidates = await rank_candidates(
                 ema=state["ema"],
                 entity_query=entity_query,
                 db=db,
                 qdrant_client=qdrant,
                 embedding_provider=provider,
+                entity_shadow_out=entity_shadow,
             )
         finally:
             await db.close()
@@ -134,6 +136,9 @@ async def run_worker(
             "theme": theme_stats,
             "entity_query": entity_query,
             "candidates": candidates,
+            # E4 shadow telemetry: what the entity lane would have added
+            # (empty once the lane goes live — hits then ride candidates).
+            "entity_shadow": entity_shadow,
         }
         if not no_arbiter:
             # Deferred: --no-arbiter runs never load the subprocess

--- a/tests/test_session_awareness/test_ranking_entity_lane.py
+++ b/tests/test_session_awareness/test_ranking_entity_lane.py
@@ -1,0 +1,183 @@
+"""E4 entity lane: shadow isolation, live floor, resolution filtering.
+
+Real in-memory entity substrate; other lanes mocked. The invariant
+under test: SHADOW mode is behavior-identical to pre-E4 (entity-only
+candidates never returned, existing candidates' ``lanes`` untouched —
+the arbiter prompt renders lanes), while the shadow report captures
+what the lane would have contributed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from genesis.db.crud import entities as entities_crud
+from genesis.db.schema._tables import TABLES
+from genesis.session_awareness.ranking import rank_candidates
+
+DIM = 8
+EMA = [1.0] + [0.0] * (DIM - 1)
+TARGET = "9d36f039-0000-0000-0000-000000000000"
+
+
+@pytest_asyncio.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    for table in ("entities", "entity_mentions", "entity_links",
+                  "deferred_work_queue"):
+        await conn.execute(TABLES[table])
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+async def _seed_spine(db):
+    """omi →is_a→ voice-edge-device →constrained_by→ rule → TARGET."""
+    omi = await entities_crud.create_entity(
+        db, name="OMI", norm_name="omi", entity_type="device",
+    )
+    cat = await entities_crud.create_entity(
+        db, name="voice-edge-device", norm_name="voice-edge-device",
+        entity_type="concept",
+    )
+    rule = await entities_crud.create_entity(
+        db, name="repo-split", norm_name="repo-split", entity_type="concept",
+    )
+    await entities_crud.upsert_link(
+        db, source_id=omi, target_id=cat, link_type="is_a",
+        provenance="EXTRACTED", confidence=0.95,
+    )
+    await entities_crud.upsert_link(
+        db, source_id=cat, target_id=rule, link_type="constrained_by",
+        provenance="EXTRACTED", confidence=0.95,
+    )
+    await entities_crud.upsert_mention(
+        db, memory_id=TARGET, entity_id=rule, provenance="EXTRACTED",
+        confidence=0.95, source="seed",
+    )
+    return omi
+
+
+def _hit(mid: str, score: float):
+    return {
+        "id": mid,
+        "score": score,
+        "payload": {"confidence": 0.8, "memory_class": "fact", "content": "c"},
+    }
+
+
+def _point(mid: str, *, cos=0.3):
+    p = MagicMock()
+    p.id = mid
+    p.vector = [cos] + [0.0] * (DIM - 1)
+    p.payload = {
+        "confidence": 0.9,
+        "memory_class": "decision",
+        "content": "the repo-split decision",
+        "created_at": "2026-06-14T00:00:00+00:00",
+    }
+    return p
+
+
+def _lane_patches(qdrant_hits, retrieve_points):
+    qdrant = MagicMock()
+    qdrant.retrieve = MagicMock(return_value=retrieve_points)
+    return qdrant, (
+        patch("genesis.qdrant.collections.search", side_effect=[qdrant_hits, []]),
+        patch("genesis.memory.drift.drift_recall", new=AsyncMock(return_value=[])),
+        patch(
+            "genesis.memory.retrieval._expired_candidate_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "genesis.db.crud.memory_links.batch_link_counts",
+            new=AsyncMock(return_value={}),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_shadow_excludes_entity_only_and_reports(db):
+    await _seed_spine(db)
+    qdrant, patches = _lane_patches([_hit("other-mem", 0.9)], [_point(TARGET)])
+    shadow: list[dict] = []
+    with patches[0], patches[1], patches[2], patches[3]:
+        picked = await rank_candidates(
+            ema=EMA, entity_query="omi noiseword", db=db,
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+            entity_lane="shadow", entity_shadow_out=shadow,
+        )
+    ids = [c["memory_id"] for c in picked]
+    assert TARGET not in ids  # shadow: never in the returned set
+    assert all("entity" not in c["lanes"] for c in picked)  # lanes untouched
+    assert shadow and shadow[0]["memory_id"] == TARGET
+    assert shadow[0]["already_candidate"] is False
+    assert shadow[0]["entity_path"]["path_score"] > 0
+
+
+@pytest.mark.asyncio
+async def test_live_includes_target_via_entity_lane_with_floor(db):
+    await _seed_spine(db)
+    # 10 strong operational candidates try to crowd the target out
+    wall = [_hit(f"op-{i}", 0.95) for i in range(10)]
+    qdrant, patches = _lane_patches(wall, [_point(TARGET, cos=0.2)])
+    with patches[0], patches[1], patches[2], patches[3]:
+        picked = await rank_candidates(
+            ema=EMA, entity_query="omi", db=db,
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+            entity_lane="live",
+        )
+    target = next((c for c in picked if c["memory_id"] == TARGET), None)
+    assert target is not None, "entity floor must protect the target"
+    assert "entity" in target["lanes"]
+    assert target["entity_path"]["path_score"] > 0
+
+
+@pytest.mark.asyncio
+async def test_off_mode_never_touches_entity_tables(db):
+    called = AsyncMock()
+    qdrant, patches = _lane_patches([_hit("m1", 0.9)], [])
+    with patches[0], patches[1], patches[2], patches[3], patch(
+        "genesis.db.crud.entities.get_by_norm_name", new=called,
+    ):
+        await rank_candidates(
+            ema=EMA, entity_query="omi", db=db,
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+            entity_lane="off",
+        )
+    called.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_keywords_are_noise_filtered(db):
+    # No entities at all → lane finds nothing, ranking unaffected
+    qdrant, patches = _lane_patches([_hit("m1", 0.9)], [])
+    shadow: list[dict] = []
+    with patches[0], patches[1], patches[2], patches[3]:
+        picked = await rank_candidates(
+            ema=EMA, entity_query="confidence honest proceed", db=db,
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+            entity_lane="shadow", entity_shadow_out=shadow,
+        )
+    assert [c["memory_id"] for c in picked] == ["m1"]
+    assert shadow == []
+
+
+@pytest.mark.asyncio
+async def test_created_before_drops_future_entity_candidates(db):
+    await _seed_spine(db)
+    qdrant, patches = _lane_patches([_hit("m1", 0.9)], [_point(TARGET)])
+    shadow: list[dict] = []
+    with patches[0], patches[1], patches[2], patches[3]:
+        await rank_candidates(
+            ema=EMA, entity_query="omi", db=db,
+            qdrant_client=qdrant, embedding_provider=MagicMock(),
+            entity_lane="shadow", entity_shadow_out=shadow,
+            created_before="2026-06-01T00:00:00+00:00",  # before memory created
+        )
+    assert shadow == []  # post-cutoff memory filtered even from shadow


### PR DESCRIPTION
## Summary
Fourth candidate lane for the ambient worker — the categorical-inference lane. Ledger keywords resolve to entity nodes (ledger keys equal `norm_name`s by construction, so resolution doubles as the STT-noise filter), expand ≤2 typed hops through `entity_links` (validity-filtered, provenance-weighted path confidence, 0.7/hop decay), and their `entity_mentions` become candidates. One 'OMI' mention reaches the repo-split decision via `is_a` → `constrained_by`.

### Shadow discipline (`ENTITY_LANE_MODE='shadow'`)
- Entity-only candidates NEVER enter the returned set — they ride the new `entity_shadow` telemetry (worker verdicts + replay fire records).
- Existing candidates' `lanes` stay untouched: **the arbiter prompt renders lanes**, so shadow must not perturb judgments. Entity info rides the separate `entity_path` key the arbiter never reads.
- As-of parity: entity-only candidates are cutoff-filtered via payload `created_at` (mentions carry no memory timestamp).
- Fail-open: any entity-lane exception skips the lane, never the worker.

### Live mode (E4b, one-line flip gated on the OMI replay)
`ENTITY_RESERVED=2` stratified floor mirroring `DECISION_RESERVED`; entity hits tag `lanes` and enter ranking normally.

### Replay acceptance instrument
`ambient_replay.py` gains `--target-entity` / `--entity-lane {off,shadow,live}`. PASS = target reached **via the entity lane** within 10 turns of `t_mention` (first turn the keyword enters the ledger — replaces the fixed turn≤10; mentions can arrive late). Distinct `fail_reason`: `no_mention` / `no_fire_in_window` (trigger-cadence, not lane) / `target_not_in_entity_lane`.

### Live-DB state backing this lane (applied this session, post-#988)
Migrations 0050/0051/0052 applied via the runner (canonicalization census verified clean); seed applied — spine reachable on prod (OMI → voice-edge-device d1 → repo-split rule d2, target memory mention present); hybrid backfill applied: 12,481 mechanical anchor mentions (6,995 memories), 6,644 seed-FTS mentions; the target memory carries an ORGANIC `backfill_fts` mention via GENesis-Voice in addition to the seeded spine.

## Testing
- 5 new lane tests (shadow isolation incl. lanes-untouched invariant, live floor under a 10-candidate operational wall, off-mode never touches entity tables, noise-word filtering, as-of cutoff) + full session_awareness suite: 84 passed
- ruff + subsystem-map guard clean; map entry updated (three lanes → four, arbiter status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)