### PR TITLE
feat(memory): flip the entity lane live (E4b)

### DIFF
--- a/src/genesis/session_awareness/ranking.py
+++ b/src/genesis/session_awareness/ranking.py
@@ -68,7 +68,7 @@ PREVIEW_CHARS = 200
 # "live": entity candidates rank normally with a reserved floor.
 # "off": lane skipped entirely.
 # The E4b flip is this ONE constant → "live", gated on the OMI replay.
-ENTITY_LANE_MODE = "shadow"
+ENTITY_LANE_MODE = "live"
 ENTITY_RESERVED = 2  # entity-lane floor (live mode), mirrors DECISION_RESERVED
 ENTITY_DEPTH_DECAY = 0.7  # per-hop decay on top of edge confidences
 ENTITY_MENTIONS_PER_ENTITY = 10


### PR DESCRIPTION
## Summary
One-line flip: `ENTITY_LANE_MODE` `shadow` → `live` in `session_awareness/ranking.py`. Entity-lane candidates now enter the ambient worker's ranked set (with the `ENTITY_RESERVED=2` floor) and are visible to the arbiter. Still fully inside the WS-C shadow pipeline — nothing is injected into sessions until the separate WS-C delivery flip (PR5, own gate).

## Gate evidence (2026-07-10, live DB post-#992 + seed + hybrid backfill)

**OMI incident session (`246fe52b`, 355 genuine turns) — the class that structurally FAILED the WS-C kill criterion:**
```
TARGET 9d36f039: hit={turn: 3, lanes: ['entity']}  PASS=True
t_mention=3  entity_hit=turn 3  fail_reason=None
```
"omi" enters the entity ledger at turn 3; a drift-trigger fire lands on that turn; the repo-split decision memory arrives in the candidate set via the entity lane (mention → `is_a` voice-edge-device → `constrained_by` repo-split rule → mention). The target also carries an ORGANIC `backfill_fts` mention (via GENesis-Voice) — the hop path exists without the hand-seeded spine.

**Narrated-theme control (`b8ef6eb8`, 34 genuine turns):** 3 fires / 0 outlier skips with the lane live — identical to the documented pre-entity baseline. No regression.

## Revert
Single-constant revert restores exact shadow behavior (shadow-isolation invariants are test-enforced: `test_ranking_entity_lane.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)