### PR TITLE
feat(dashboard): surface per-provider fallback counts on the API-keys modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   recall's own usage counters are suppressed for the run so benchmarking
   never distorts what your live Genesis considers important.
 
+- **The API Keys panel now shows how often each provider is causing fallbacks.**
+  A provider that is misconfigured or failing — for example one whose key is
+  missing yet is still wired in as the preferred choice on many call sites — used
+  to read only "missing (fallback active)" with no sense of scale. Each provider
+  row now shows "in N fallbacks (24h) · last …" beside its key status, so an
+  ongoing fallback storm is visible at a glance instead of hiding in the logs.
+
 - **Genesis now detects and repairs corrupted credential files on its own.**
   If a critical credential or wiring file (`secrets.env`, your Claude Code and
   GitHub credentials, SSH keys, `guardian_remote.yaml`, `genesis.yaml`) gets

--- a/src/genesis/dashboard/templates/partials/modals/api_keys.html
+++ b/src/genesis/dashboard/templates/partials/modals/api_keys.html
@@ -43,6 +43,10 @@
                         :style="`color: ${$store.genesisDashboard.providerCbState(name) === 'closed' ? '#4caf50' : $store.genesisDashboard.providerCbState(name) === 'open' ? '#d9534f' : '#f0ad4e'}`"
                         x-text="'CB: ' + $store.genesisDashboard.providerCbState(name)"></span>
                 </template>
+                <template x-if="info.recent_fallbacks">
+                  <span style="font-size: 0.68rem; color: #f0ad4e; margin-left: 0.3rem;"
+                        x-text="'⚠ in ' + info.recent_fallbacks + ' fallbacks (24h)' + (info.last_fallback_at ? ' · last ' + $store.genesisDashboard.relativeTime(info.last_fallback_at) : '')"></span>
+                </template>
               </div>
             </template>
             <!-- Provider → Call Site Usage -->

--- a/src/genesis/db/crud/events.py
+++ b/src/genesis/db/crud/events.py
@@ -374,3 +374,46 @@ async def query_grouped_errors(
         params,
     )
     return [dict(r) for r in rows]
+
+
+async def recent_provider_fallback_counts(
+    db: aiosqlite.Connection,
+    *,
+    since: str,
+) -> dict[str, dict]:
+    """Per-provider fallback counts from ``provider.fallback`` events since ``since``.
+
+    A ``provider.fallback`` event's ``details.failed_providers`` lists the
+    providers that were SKIPPED or FAILED before the successful fallback, keyed by
+    provider *config name* (e.g. ``nvidia-nim-deepseek``) — the same key the
+    API-key health snapshot uses. This unnests that array (``json_each``) and
+    counts how often each provider appears, so a missing/failing provider's churn
+    can be surfaced next to its key status.
+
+    Semantics note: ``failed_providers`` is dominated by config *skips* (missing
+    key, circuit-breaker open, budget) rather than true call failures, so callers
+    must label this "fallbacks", not "failures". ``breaker.tripped`` (genuine
+    call failures) is a distinct signal already carried by the CB state and is
+    intentionally NOT merged here.
+
+    Filters on ``timestamp`` (index ``idx_events_ts``; same ISO value as
+    ``created_at`` on insert). Rows whose ``details`` lacks ``failed_providers``
+    contribute nothing — ``json_extract`` returns NULL and ``json_each(NULL)``
+    yields zero rows. Returns ``{provider: {"count": n, "last_at": iso}}``.
+    """
+    rows = await db.execute_fetchall(
+        """SELECT je.value AS provider,
+                  COUNT(*) AS n,
+                  MAX(e.timestamp) AS last_at
+           FROM events e,
+                json_each(json_extract(e.details, '$.failed_providers')) je
+           WHERE e.event_type = 'provider.fallback' AND e.timestamp >= ?
+           GROUP BY je.value
+           ORDER BY n DESC""",
+        (since,),
+    )
+    return {
+        str(r[0]): {"count": int(r[1]), "last_at": r[2]}
+        for r in rows
+        if r[0] is not None
+    }

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -158,6 +158,29 @@ class HealthDataService:
             if exc is not None:
                 logger.debug("Orphaned health snapshot compute failed", exc_info=exc)
 
+    async def _recent_provider_fallbacks(self) -> dict:
+        """Per-provider fallback counts (last 24h) for the API-keys card.
+
+        Sources ``provider.fallback`` events — the only place a skipped/failed
+        provider's identity is recorded (the activity tracker never sees
+        missing-key / circuit-breaker skips, which bail before ``.record()``).
+        Self-contained error handling returns ``{}`` on any failure so a bad
+        query can never poison the ``api_keys`` section (its result is consumed
+        synchronously outside the gather's ``_or_error`` isolation).
+        """
+        if self._db is None:
+            return {}
+        try:
+            from genesis.db.crud import events as events_crud
+
+            since = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
+            return await events_crud.recent_provider_fallback_counts(
+                self._db, since=since,
+            )
+        except Exception:
+            logger.debug("recent provider-fallback counts query failed", exc_info=True)
+            return {}
+
     async def _compute_snapshot(self) -> dict:
         """Build the full system health state as a dict (uncoalesced)."""
         from genesis.observability.snapshots import (
@@ -224,6 +247,8 @@ class HealthDataService:
             services_async(),
             asyncio.to_thread(conversation_activity),
             asyncio.to_thread(proactive_memory_metrics),
+            # APPENDED last so the 16 existing positions are untouched (see unpack).
+            self._recent_provider_fallbacks(),
             return_exceptions=True,
         )
         # Isolate any failed section uniformly: one raising sub-snapshot degrades
@@ -233,7 +258,7 @@ class HealthDataService:
             r_call_sites, r_cc_sessions, r_infrastructure, r_queues, r_surplus,
             r_cost, r_awareness, r_outreach, r_mcp, r_provider_activity,
             r_memory_health, r_eval_staleness, r_vcr,
-            r_services, r_conversation, r_proactive,
+            r_services, r_conversation, r_proactive, r_provider_fallbacks,
         ) = results
 
         # Surface infra probe healthy<->unhealthy transitions to the activity
@@ -242,6 +267,16 @@ class HealthDataService:
             await self._emit_probe_transitions(r_infrastructure)
         except Exception:
             logger.debug("Probe-transition emit pass failed", exc_info=True)
+
+        # Fallback counts feed the API-keys card. Defensive guard: the method
+        # already swallows its own errors → {}, but if _or_error ever injected a
+        # {"status": "error"} sentinel we must not pass that as the provider map.
+        recent_fallbacks = (
+            r_provider_fallbacks
+            if isinstance(r_provider_fallbacks, dict)
+            and "status" not in r_provider_fallbacks
+            else {}
+        )
 
         return {
             "timestamp": now,
@@ -255,7 +290,10 @@ class HealthDataService:
             "awareness": r_awareness,
             "outreach_stats": r_outreach,
             "services": r_services,
-            "api_keys": api_key_health(self._routing_config, breakers=self._breakers),
+            "api_keys": api_key_health(
+                self._routing_config, breakers=self._breakers,
+                recent_fallbacks=recent_fallbacks,
+            ),
             "mcp_servers": r_mcp,
             "conversation": r_conversation,
             "provider_activity": r_provider_activity,

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -268,14 +268,11 @@ class HealthDataService:
         except Exception:
             logger.debug("Probe-transition emit pass failed", exc_info=True)
 
-        # Fallback counts feed the API-keys card. Defensive guard: the method
-        # already swallows its own errors → {}, but if _or_error ever injected a
-        # {"status": "error"} sentinel we must not pass that as the provider map.
+        # Fallback counts feed the API-keys card. _recent_provider_fallbacks
+        # self-isolates its errors to {}, so this is always a provider map; the
+        # isinstance keeps the attach loop safe if that contract ever changes.
         recent_fallbacks = (
-            r_provider_fallbacks
-            if isinstance(r_provider_fallbacks, dict)
-            and "status" not in r_provider_fallbacks
-            else {}
+            r_provider_fallbacks if isinstance(r_provider_fallbacks, dict) else {}
         )
 
         return {

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -48,6 +48,7 @@ def has_api_key(provider_cfg) -> bool:
 def api_key_health(
     routing_config: RoutingConfig | None,
     breakers: object | None = None,
+    recent_fallbacks: dict | None = None,
 ) -> dict:
     """Provider API key health with chain-aware criticality and CB state.
 
@@ -56,6 +57,10 @@ def api_key_health(
     Each provider entry includes the original fields (status, provider_type)
     plus chain_count, criticality, is_free, cb_state, cb_reason, and
     alert_severity — derived from the routing config and circuit breakers.
+    When ``recent_fallbacks`` (``{provider: {"count", "last_at"}}``, keyed by
+    provider config name) is supplied, a matched provider also gets
+    ``recent_fallbacks`` / ``last_fallback_at`` — additive display context only,
+    never used for severity or color.
 
     The ``alerts`` list contains pre-computed attention-strip items for
     critical/warning conditions (credit exhaustion, missing critical keys).
@@ -176,6 +181,14 @@ def api_key_health(
             essential_uncovered=essential_uncovered,
         )
         entry["key_health"] = _key_health_color(entry["status"], cb_state)
+        # Attach recent fallback churn (by config name) so a missing/failing
+        # provider's key status reads next to how often it's causing fallbacks.
+        # Additive display context only — no severity/color branching on it.
+        if recent_fallbacks:
+            rf = recent_fallbacks.get(name)
+            if rf and rf.get("count"):
+                entry["recent_fallbacks"] = rf["count"]
+                entry["last_fallback_at"] = rf.get("last_at")
         results[name] = entry
 
     # Include disabled providers for visibility — but mark as "disabled",

--- a/tests/test_db/test_events_extended.py
+++ b/tests/test_db/test_events_extended.py
@@ -264,3 +264,84 @@ class TestQueryGroupedErrors:
         groups = await crud.query_grouped_errors(db, subsystem="memory")
         assert len(groups) == 1
         assert groups[0]["subsystem"] == "memory"
+
+
+# ── recent_provider_fallback_counts ──────────────────────────────────────
+
+
+class TestRecentProviderFallbackCounts:
+    @pytest.mark.asyncio
+    async def test_counts_and_unnests_failed_providers(self, db):
+        # Two fallbacks blame nvidia; the second also blames gemini (2-elem array)
+        await crud.insert(
+            db, subsystem="routing", severity="warning",
+            event_type="provider.fallback", message="fb1",
+            details={"call_site": "9_fact_extraction", "provider": "groq-free",
+                     "failed_providers": ["nvidia-nim-deepseek"]},
+            timestamp="2026-03-14T10:00:00",
+        )
+        await crud.insert(
+            db, subsystem="routing", severity="warning",
+            event_type="provider.fallback", message="fb2",
+            details={"call_site": "judge", "provider": "openrouter-free",
+                     "failed_providers": ["nvidia-nim-deepseek", "gemini-free"]},
+            timestamp="2026-03-14T11:00:00",
+        )
+        # A breaker.tripped event names nvidia too — must NOT be counted here
+        # (this crud is fallback-only; the CB state carries breaker signal).
+        await crud.insert(
+            db, subsystem="routing", severity="warning",
+            event_type="breaker.tripped", message="trip",
+            details={"provider": "nvidia-nim-deepseek", "call_site": "x"},
+            timestamp="2026-03-14T12:00:00",
+        )
+
+        out = await crud.recent_provider_fallback_counts(
+            db, since="2026-03-14T00:00:00",
+        )
+        # nvidia appears in both fallbacks → 2 (NOT 3 — breaker.tripped ignored)
+        assert out["nvidia-nim-deepseek"]["count"] == 2
+        assert out["gemini-free"]["count"] == 1
+        # last_at = MAX(timestamp) across the two nvidia fallback rows
+        assert out["nvidia-nim-deepseek"]["last_at"] == "2026-03-14T11:00:00"
+
+    @pytest.mark.asyncio
+    async def test_since_window_excludes_old(self, db):
+        await crud.insert(
+            db, subsystem="routing", severity="warning",
+            event_type="provider.fallback", message="old",
+            details={"failed_providers": ["groq-free"]},
+            timestamp="2026-03-10T00:00:00",
+        )
+        await crud.insert(
+            db, subsystem="routing", severity="warning",
+            event_type="provider.fallback", message="new",
+            details={"failed_providers": ["groq-free"]},
+            timestamp="2026-03-14T00:00:00",
+        )
+        out = await crud.recent_provider_fallback_counts(
+            db, since="2026-03-12T00:00:00",
+        )
+        assert out["groq-free"]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_failed_providers_key_contributes_nothing(self, db):
+        # A provider.fallback event lacking failed_providers: json_extract → NULL,
+        # json_each(NULL) → 0 rows, so it contributes nothing (no crash).
+        await crud.insert(
+            db, subsystem="routing", severity="warning",
+            event_type="provider.fallback", message="nokey",
+            details={"call_site": "x", "provider": "groq-free"},
+            timestamp="2026-03-14T00:00:00",
+        )
+        out = await crud.recent_provider_fallback_counts(
+            db, since="2026-03-14T00:00:00",
+        )
+        assert out == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_returns_empty_dict(self, db):
+        out = await crud.recent_provider_fallback_counts(
+            db, since="2026-01-01T00:00:00",
+        )
+        assert out == {}

--- a/tests/test_observability/test_api_keys.py
+++ b/tests/test_observability/test_api_keys.py
@@ -193,3 +193,72 @@ def test_api_key_health_critical_when_essential_uncovered(monkeypatch):
     assert orp["key_health"] == "red"
     assert orp["alert_severity"] == "critical"  # essential uncovered → critical
     assert any(a["severity"] == "critical" for a in out["alerts"])
+
+
+# --- recent_fallbacks: additive display context, keyed by provider config name ---
+
+
+def _env(monkeypatch):
+    from genesis.observability.snapshots import api_keys as ak
+
+    monkeypatch.setenv("API_KEY_OPENROUTER", "sk-test")
+    monkeypatch.setenv("GOOGLE_API_KEY", "g-test")
+    ak._api_validation_cache.clear()
+    return ak
+
+
+def test_recent_fallbacks_attached_by_config_name(monkeypatch):
+    ak = _env(monkeypatch)
+    config = _routing_config()
+    reg = _registry(config)
+
+    out = ak.api_key_health(config, breakers=reg, recent_fallbacks={
+        "openrouter-x": {"count": 42, "last_at": "2026-03-14T11:00:00"},
+    })
+    orp = out["providers"]["openrouter-x"]
+    assert orp["recent_fallbacks"] == 42
+    assert orp["last_fallback_at"] == "2026-03-14T11:00:00"
+    # A provider absent from the map gets no attach (selective by name).
+    assert "recent_fallbacks" not in out["providers"]["gemini-free"]
+
+
+def test_recent_fallbacks_none_safe(monkeypatch):
+    ak = _env(monkeypatch)
+    config = _routing_config()
+    reg = _registry(config)
+
+    out = ak.api_key_health(config, breakers=reg)  # no kwarg
+    for entry in out["providers"].values():
+        assert "recent_fallbacks" not in entry
+        assert "last_fallback_at" not in entry
+
+
+def test_recent_fallbacks_zero_count_not_attached(monkeypatch):
+    ak = _env(monkeypatch)
+    config = _routing_config()
+    reg = _registry(config)
+
+    out = ak.api_key_health(config, breakers=reg, recent_fallbacks={
+        "openrouter-x": {"count": 0, "last_at": None},
+    })
+    assert "recent_fallbacks" not in out["providers"]["openrouter-x"]
+
+
+def test_recent_fallbacks_does_not_change_severity_or_color(monkeypatch):
+    from genesis.routing.types import ErrorCategory
+
+    ak = _env(monkeypatch)
+    config = _routing_config()
+    reg = _registry(config)
+    for _ in range(3):
+        reg.get("openrouter-x").record_failure(ErrorCategory.QUOTA_EXHAUSTED)
+
+    without = ak.api_key_health(config, breakers=reg)
+    with_fb = ak.api_key_health(config, breakers=reg, recent_fallbacks={
+        "openrouter-x": {"count": 99, "last_at": "2026-03-14T11:00:00"},
+    })
+    for name in without["providers"]:
+        w, f = without["providers"][name], with_fb["providers"][name]
+        assert w["key_health"] == f["key_health"]
+        assert w.get("alert_severity") == f.get("alert_severity")
+    assert without["alerts"] == with_fb["alerts"]


### PR DESCRIPTION
## What

The API-keys modal now shows, per provider, how many fallbacks it was involved in over the last 24h — e.g. \`⚠ in 54 fallbacks (24h) · last 3m ago\` — beside its key status. A provider whose key is missing but which is still wired in as a preferred choice across many call sites previously read only "missing (fallback active)" with no sense of scale; the churn was invisible outside the logs.

## Why

Completes the last item from the dashboard monitor/correctness audit. The earlier attempt was dropped because it sourced from \`dead_letter\`, which live-samples as 100% an \`'all'\` sentinel (never matches a provider key). The real per-provider signal lives in \`provider.fallback\` events' \`details.failed_providers\`.

## Design decisions

- **"Fallbacks", not "failures".** \`failed_providers\` is dominated by config *skips* (missing key, circuit-breaker open, budget) rather than true call failures, so the label is deliberately "fallbacks". \`breaker.tripped\` (genuine call failures) is a distinct signal already carried by the CB-state badge and is intentionally **excluded** to avoid conflation and double-counting.
- **Join key = provider config name**, which matches the keys the api-keys card already renders (verified against the live health payload — this is the check the \`dead_letter\` approach failed).
- **Additive display context only** — no change to alert severity, key colors, or the attention strip (a test asserts this).

## How

- \`db/crud/events.py\`: \`recent_provider_fallback_counts\` — \`json_each\` over \`failed_providers\`, index-backed on \`timestamp\`, one bounded scan per (coalesced) snapshot.
- \`observability/health_data.py\`: appended to the health gather (existing unpack positions untouched); result passed to \`api_key_health\`.
- \`observability/snapshots/api_keys.py\`: optional \`recent_fallbacks\` kwarg attaches \`recent_fallbacks\`/\`last_fallback_at\` per matched provider.
- \`dashboard/…/modals/api_keys.html\`: warning-orange span gated on a positive count.

## Testing

- New crud tests: unnesting multi-element \`failed_providers\`, 24h window boundary, rows missing the key contribute nothing, \`last_at = MAX(timestamp)\`.
- New \`api_key_health\` tests: attach-by-config-name, None-safe, zero-count guard, and no severity/color change with vs. without the map.
- Existing health-snapshot + webui-integrity tests pass (gather-unpack alignment). 52 targeted tests green.
- Live E2E to follow post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)