### PR TITLE
feat(guardian): host-side credential mirror (G.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   row now shows "in N fallbacks (24h) · last …" beside its key status, so an
   ongoing fallback storm is visible at a glance instead of hiding in the logs.
 
+- **Your credentials now survive losing the whole container.** Genesis mirrors
+  its encrypted credential bundle (secrets, SSH keys including the guardian
+  control-plane key, and Claude/GitHub credentials — all GPG-encrypted) onto the
+  host, outside the container's blast radius, and the host guardian keeps a
+  second copy the container can't touch. If the container is ever destroyed, a
+  fresh one can be rebuilt with credentials intact from the host — no network and
+  no chicken-and-egg (previously the only backup copies lived *inside* the
+  container). The guardian also warns you if that mirror goes stale, so you find
+  out backups have stopped landing *before* you need them. See the
+  container-loss runbook in `docs/reference/recovery-and-portability-workflow.md`.
+
 - **Genesis now detects and repairs corrupted credential files on its own.**
   If a critical credential or wiring file (`secrets.env`, your Claude Code and
   GitHub credentials, SSH keys, `guardian_remote.yaml`, `genesis.yaml`) gets

--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -103,6 +103,7 @@ cred_integrity:
   max_restores_per_day: 3  # per-target guardian step-in cap
   check_timeout_s: 30
   restore_timeout_s: 60
+  mirror_stale_hours: 48   # WARN if the host-side credential mirror's newest cred is older
   # backup_dir: ""         # container-side backup path; empty = module default
   # container_home: ""     # empty = container's real home; set only for E2E
 

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -35,3 +35,47 @@ GitHub Release from the matching `CHANGELOG.md` section.
   lists from `capture_recovery_state.sh`.
 - Agent Zero compatibility must be evaluated against the exact local fork state,
   not a generic upstream release assumption.
+
+## Container-Loss Recovery — Credentials (host-side mirror)
+
+If the whole container is destroyed, its live credentials **and** the Tier-1
+backup clone (which lives inside the container filesystem) are gone with it, and
+the off-site Tier-2 copy needs the very git/GitHub credentials it would restore.
+To survive this, the container mirrors its **already-encrypted** credential
+bundle to the guardian shared mount every awareness cycle, and the guardian
+keeps a second, host-only copy the container can never reach:
+
+| Layer | Location | Survives container loss? |
+|---|---|---|
+| Live creds | container `~` | No |
+| Tier-1 clone | container `~/backups/genesis-backups/` | No |
+| **Shared-mount mirror** | host `…/genesis-guardian/shared/guardian/creds-mirror/` | Yes |
+| **Guardian archive** | host `…/genesis-guardian/creds-archive/` | Yes (container cannot write it) |
+| Passphrase escrow | host `…/shared/guardian/backup_passphrase.env` (+ archive copy) | Yes |
+| Tier-2 off-site | remote backend | Yes (but needs network + creds) |
+
+The mirror/archive carry only GPG-encrypted `*.gpg` files; the decryption
+passphrase is escrowed separately. The guardian **refuses to overwrite the
+archive from an empty or incomplete mirror**, so a container-side zeroing event
+can never propagate into the last-line copy.
+
+**Rebuild runbook (no network required):**
+
+1. Create a fresh container and re-attach the `guardian-shared` incus disk device
+   (host source `…/genesis-guardian/shared`), so the mirror + escrow are visible
+   at `~/.genesis/shared/guardian/`.
+2. Run `scripts/restore.sh`. When the Tier-1 clone payload is absent it
+   automatically falls back to the mirror (or, for a host-side run, the
+   `creds-archive/`), and reads the escrowed passphrase — no env var needed.
+   Override the source explicitly with `GENESIS_CREDS_MIRROR=<dir>` if desired.
+3. Credentials are **staged** to `~/.genesis/restore-creds/` (0700), never
+   auto-placed. Move them into position: `ssh/*` → `~/.ssh/`, `gh_hosts.yml` →
+   `~/.config/gh/hosts.yml`, `guardian_remote.yaml`/`genesis.yaml` →
+   `~/.genesis/`, `secrets.env` → `~/genesis/secrets.env`.
+4. The guardian control-plane key (`genesis_guardian_ed25519`) is in the bundle,
+   so the container↔host gateway is restored in the same step.
+
+The guardian also emits a WARNING if the mirror goes stale (its newest
+credential older than `cred_integrity.mirror_stale_hours`, default 48h) — an
+early signal that backups have stopped landing and a container loss would not be
+recoverable from the host.

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -154,20 +154,17 @@ fi
 # encrypted creds/secrets payloads (e.g. a freshly rebuilt container whose backup
 # clone has not been re-cloned yet), fall back to the host-side mirror on the
 # shared mount — or, for a host-side restore, the guardian's host-only archive.
-# Same two-path (+archive) probe discipline as the escrow above. Sections 7/8
-# consult $_MIRROR_ROOT only when the primary clone payload is absent.
-_MIRROR_ROOT=""
-for _m in \
-    "${GENESIS_CREDS_MIRROR:-}" \
-    "$HOME/.genesis/shared/guardian/creds-mirror" \
-    "$HOME/.local/state/genesis-guardian/shared/guardian/creds-mirror" \
-    "$HOME/.local/state/genesis-guardian/creds-archive"; do
-    [ -n "$_m" ] && [ -d "$_m" ] || continue
-    if [ -f "$_m/secrets/secrets.env.gpg" ] || [ -d "$_m/creds" ]; then
-        _MIRROR_ROOT="$_m"
-        break
-    fi
-done
+# Ordered candidate roots (shared mount preferred, then the host-only archive).
+# Sections 7/8 resolve the secrets source and the creds source INDEPENDENTLY,
+# each picking the first candidate that carries ITS OWN payload — so a partial
+# mirror (e.g. creds present but secrets lost) never masks a complete archive.
+_cred_fallback_sources() {
+    printf '%s\n' \
+        "${GENESIS_CREDS_MIRROR:-}" \
+        "$HOME/.genesis/shared/guardian/creds-mirror" \
+        "$HOME/.local/state/genesis-guardian/shared/guardian/creds-mirror" \
+        "$HOME/.local/state/genesis-guardian/creds-archive"
+}
 
 # decrypt_file <src.gpg> <dst>
 decrypt_file() {
@@ -620,9 +617,13 @@ fi
 # ── 7. Secrets ───────────────────────────────────────────────────────
 log "--- Secrets ---"
 SECRETS_SRC="$BACKUP_DIR/secrets/secrets.env.gpg"
-if [ ! -f "$SECRETS_SRC" ] && [ -n "$_MIRROR_ROOT" ] && [ -f "$_MIRROR_ROOT/secrets/secrets.env.gpg" ]; then
-    SECRETS_SRC="$_MIRROR_ROOT/secrets/secrets.env.gpg"
-    log "Secrets: Tier-1 clone payload absent — using host-side mirror $SECRETS_SRC"
+if [ ! -f "$SECRETS_SRC" ]; then
+    while IFS= read -r _d; do
+        [ -n "$_d" ] && [ -f "$_d/secrets/secrets.env.gpg" ] || continue
+        SECRETS_SRC="$_d/secrets/secrets.env.gpg"
+        log "Secrets: Tier-1 clone payload absent — using host-side mirror $SECRETS_SRC"
+        break
+    done < <(_cred_fallback_sources)
 fi
 if [ -f "$SECRETS_SRC" ]; then
     if [ -f "$SECRETS_FILE" ] && ! $FORCE; then
@@ -656,15 +657,17 @@ log "--- Credential & wiring files ---"
 CREDS_SRC_DIR="$BACKUP_DIR/creds"
 # Key the fallback on actual .gpg PAYLOAD presence, not directory existence:
 # backup.sh skips creds when the passphrase was unset (§8), which can leave an
-# empty/placeholder creds/ dir that would otherwise mask a good host mirror.
-# Symmetric with the secrets file test above; set -e-safe (checks live in `if`).
-_creds_has_payload=false
-if [ -d "$CREDS_SRC_DIR" ] && find "$CREDS_SRC_DIR" -name '*.gpg' -print -quit 2>/dev/null | grep -q .; then
-    _creds_has_payload=true
-fi
-if ! $_creds_has_payload && [ -n "$_MIRROR_ROOT" ] && [ -d "$_MIRROR_ROOT/creds" ]; then
-    CREDS_SRC_DIR="$_MIRROR_ROOT/creds"
-    log "Creds: Tier-1 clone payload absent — using host-side mirror $CREDS_SRC_DIR"
+# empty/placeholder creds/ dir; and a partial mirror may have creds/ without the
+# .gpg files. Pick the first candidate that actually carries creds payload, so a
+# hollow mirror never masks a complete archive. set -e-safe (checks in `if`).
+_creds_has_payload() { find "$1" -name '*.gpg' -print -quit 2>/dev/null | grep -q .; }
+if ! { [ -d "$CREDS_SRC_DIR" ] && _creds_has_payload "$CREDS_SRC_DIR"; }; then
+    while IFS= read -r _d; do
+        [ -n "$_d" ] && [ -d "$_d/creds" ] && _creds_has_payload "$_d/creds" || continue
+        CREDS_SRC_DIR="$_d/creds"
+        log "Creds: Tier-1 clone payload absent — using host-side mirror $CREDS_SRC_DIR"
+        break
+    done < <(_cred_fallback_sources)
 fi
 if [ -d "$CREDS_SRC_DIR" ]; then
     CREDS_STAGE="${GENESIS_CREDS_STAGE:-$HOME/.genesis/restore-creds}"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -654,7 +654,15 @@ fi
 # clone, so no off-site pull is needed.
 log "--- Credential & wiring files ---"
 CREDS_SRC_DIR="$BACKUP_DIR/creds"
-if [ ! -d "$CREDS_SRC_DIR" ] && [ -n "$_MIRROR_ROOT" ] && [ -d "$_MIRROR_ROOT/creds" ]; then
+# Key the fallback on actual .gpg PAYLOAD presence, not directory existence:
+# backup.sh skips creds when the passphrase was unset (§8), which can leave an
+# empty/placeholder creds/ dir that would otherwise mask a good host mirror.
+# Symmetric with the secrets file test above; set -e-safe (checks live in `if`).
+_creds_has_payload=false
+if [ -d "$CREDS_SRC_DIR" ] && find "$CREDS_SRC_DIR" -name '*.gpg' -print -quit 2>/dev/null | grep -q .; then
+    _creds_has_payload=true
+fi
+if ! $_creds_has_payload && [ -n "$_MIRROR_ROOT" ] && [ -d "$_MIRROR_ROOT/creds" ]; then
     CREDS_SRC_DIR="$_MIRROR_ROOT/creds"
     log "Creds: Tier-1 clone payload absent — using host-side mirror $CREDS_SRC_DIR"
 fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -135,7 +135,8 @@ if [ -z "$_BACKUP_PASSPHRASE" ]; then
     for _escrow in \
         "${GENESIS_PASSPHRASE_ESCROW:-}" \
         "$HOME/.genesis/shared/guardian/backup_passphrase.env" \
-        "$HOME/.local/state/genesis-guardian/shared/guardian/backup_passphrase.env"; do
+        "$HOME/.local/state/genesis-guardian/shared/guardian/backup_passphrase.env" \
+        "$HOME/.local/state/genesis-guardian/creds-archive/backup_passphrase.env"; do
         [ -n "$_escrow" ] && [ -f "$_escrow" ] || continue
         # Bridge writes exactly `GENESIS_BACKUP_PASSPHRASE=<value>` (no quotes);
         # tolerate an optional `export ` prefix. Do NOT strip quotes — the
@@ -148,6 +149,25 @@ if [ -z "$_BACKUP_PASSPHRASE" ]; then
         fi
     done
 fi
+
+# G.4 host-side credential mirror fallback. If the Tier-1 backup clone lacks the
+# encrypted creds/secrets payloads (e.g. a freshly rebuilt container whose backup
+# clone has not been re-cloned yet), fall back to the host-side mirror on the
+# shared mount — or, for a host-side restore, the guardian's host-only archive.
+# Same two-path (+archive) probe discipline as the escrow above. Sections 7/8
+# consult $_MIRROR_ROOT only when the primary clone payload is absent.
+_MIRROR_ROOT=""
+for _m in \
+    "${GENESIS_CREDS_MIRROR:-}" \
+    "$HOME/.genesis/shared/guardian/creds-mirror" \
+    "$HOME/.local/state/genesis-guardian/shared/guardian/creds-mirror" \
+    "$HOME/.local/state/genesis-guardian/creds-archive"; do
+    [ -n "$_m" ] && [ -d "$_m" ] || continue
+    if [ -f "$_m/secrets/secrets.env.gpg" ] || [ -d "$_m/creds" ]; then
+        _MIRROR_ROOT="$_m"
+        break
+    fi
+done
 
 # decrypt_file <src.gpg> <dst>
 decrypt_file() {
@@ -600,6 +620,10 @@ fi
 # ── 7. Secrets ───────────────────────────────────────────────────────
 log "--- Secrets ---"
 SECRETS_SRC="$BACKUP_DIR/secrets/secrets.env.gpg"
+if [ ! -f "$SECRETS_SRC" ] && [ -n "$_MIRROR_ROOT" ] && [ -f "$_MIRROR_ROOT/secrets/secrets.env.gpg" ]; then
+    SECRETS_SRC="$_MIRROR_ROOT/secrets/secrets.env.gpg"
+    log "Secrets: Tier-1 clone payload absent — using host-side mirror $SECRETS_SRC"
+fi
 if [ -f "$SECRETS_SRC" ]; then
     if [ -f "$SECRETS_FILE" ] && ! $FORCE; then
         log "Secrets: $SECRETS_FILE already exists — skipping (use --force to overwrite)"
@@ -630,6 +654,10 @@ fi
 # clone, so no off-site pull is needed.
 log "--- Credential & wiring files ---"
 CREDS_SRC_DIR="$BACKUP_DIR/creds"
+if [ ! -d "$CREDS_SRC_DIR" ] && [ -n "$_MIRROR_ROOT" ] && [ -d "$_MIRROR_ROOT/creds" ]; then
+    CREDS_SRC_DIR="$_MIRROR_ROOT/creds"
+    log "Creds: Tier-1 clone payload absent — using host-side mirror $CREDS_SRC_DIR"
+fi
 if [ -d "$CREDS_SRC_DIR" ]; then
     CREDS_STAGE="${GENESIS_CREDS_STAGE:-$HOME/.genesis/restore-creds}"
     _CREDS_STAGED=0

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -191,6 +191,10 @@ class CredIntegrityConfig:
     restore_timeout_s: int = 60
     backup_dir: str = ""             # container-side backup path; "" = module default
     container_home: str = ""         # "" = the container's real home; set only for E2E
+    # G.4 host-side credential mirror. The container mirrors the encrypted backup
+    # bundle to the shared mount each awareness tick; the guardian warns if that
+    # mirror goes stale (backups not landing) and keeps a host-only archive copy.
+    mirror_stale_hours: float = 48.0  # WARN if the mirror's newest cred is older (8 missed 6h cycles)
 
 
 @dataclass

--- a/src/genesis/guardian/cred_watch.py
+++ b/src/genesis/guardian/cred_watch.py
@@ -19,6 +19,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import shlex
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -28,9 +29,25 @@ from genesis.guardian import cred_integrity
 from genesis.guardian.alert.base import Alert, AlertSeverity
 from genesis.guardian.cred_integrity import RESTORABLE_STATUSES, allowed_restore
 
+# Shared file primitives (atomic copy / containment-guarded prune) live in the
+# credential_bridge module — imported here so the mirror and its host-only
+# archive use the identical copy/prune discipline. Import is side-effect-free.
+from genesis.guardian.credential_bridge import _atomic_copy, _prune_to_keep
+
 logger = logging.getLogger(__name__)
 
 _STATE_FILE = "cred_alert_state.json"
+
+# G.4 host-side credential mirror. The container's awareness tick mirrors the
+# encrypted backup bundle to the shared mount at <state>/shared/guardian/
+# creds-mirror/; the guardian warns if it goes stale and keeps a host-only
+# archive copy (<state>/creds-archive/) the container cannot reach.
+_MIRROR_STATE_FILE = "mirror_alert_state.json"
+_SHARED_GUARDIAN = ("shared", "guardian")   # under state_path → host view of the mount
+_MIRROR_SUBDIR = "creds-mirror"
+_MIRROR_STAMP = "MIRROR_STAMP"
+_ARCHIVE_SUBDIR = "creds-archive"
+_ESCROW_FILE = "backup_passphrase.env"
 
 
 @dataclass(frozen=True)
@@ -196,6 +213,14 @@ async def check_credential_integrity_and_alert(config, dispatcher) -> None:
     if not cfg.enabled:
         return
 
+    # G.4 mirror freshness + host-only archive hop. Host-side file ops only, so
+    # they run every enabled tick — independent of (and before) the container
+    # verdict below, which may be 'no signal' when genesis-server is degraded.
+    try:
+        await _check_mirror_and_archive(config, dispatcher)
+    except Exception:
+        logger.warning("cred mirror/archive check failed", exc_info=True)
+
     report = await run_container_check(config)
     if report is None:
         logger.debug("cred_watch: no verdict this tick (container unreachable?)")
@@ -312,6 +337,132 @@ async def check_credential_integrity_and_alert(config, dispatcher) -> None:
                             "Manual intervention needed.")
 
     _save_state(state_file, episodes)
+
+
+async def _check_mirror_and_archive(config, dispatcher) -> None:
+    """G.4: warn if the host-side credential mirror is stale, then keep a
+    host-only archive copy (container-unreachable) of the mirror + escrow.
+
+    Pure host-side file operations — no incus exec, no container dependency."""
+    shared_guardian = config.state_path.joinpath(*_SHARED_GUARDIAN)
+    mirror_dir = shared_guardian / _MIRROR_SUBDIR
+    escrow = shared_guardian / _ESCROW_FILE
+
+    # Freshness alerting only makes sense once backups are configured; the escrow
+    # file (written by the same bridge tick) is the proxy for "backups on".
+    if escrow.exists():
+        await _mirror_freshness_alert(config, dispatcher, mirror_dir)
+
+    _archive_mirror(config, mirror_dir, escrow)
+
+
+def _mirror_newest_mtime(mirror_dir: Path) -> datetime | None:
+    """Newest ``*.gpg`` mtime under the mirror, or None if the mirror is
+    incomplete. The MIRROR_STAMP completeness marker must be present — a
+    half-written mirror (files but no stamp) counts as 'no complete mirror'."""
+    if not (mirror_dir / _MIRROR_STAMP).exists():
+        return None
+    newest = 0.0
+    for f in mirror_dir.rglob("*.gpg"):
+        try:
+            newest = max(newest, f.stat().st_mtime)
+        except OSError:
+            continue
+    if newest <= 0:
+        return None
+    return datetime.fromtimestamp(newest, tz=UTC)
+
+
+async def _mirror_freshness_alert(config, dispatcher, mirror_dir: Path) -> None:
+    cfg = config.cred_integrity
+    now = datetime.now(UTC)
+    state_file = config.state_path / _MIRROR_STATE_FILE
+    state = _load_mirror_state(state_file)
+
+    newest = _mirror_newest_mtime(mirror_dir)
+    if newest is not None:
+        age_h = (now - newest).total_seconds() / 3600
+        stale = age_h > cfg.mirror_stale_hours
+    else:
+        age_h = None
+        stale = True
+
+    if not stale:
+        if state.get("warned_at"):
+            _save_mirror_state(state_file, {})
+            await _send(dispatcher, AlertSeverity.INFO,
+                        "Credential mirror fresh again",
+                        "The host-side encrypted credential mirror is updating "
+                        "normally again.")
+        return
+
+    last_alert = _parse(state.get("last_alert_at"))
+    if last_alert and (now - last_alert).total_seconds() < cfg.realert_hours * 3600:
+        return
+    detail = (
+        f"newest backed-up credential is {age_h:.1f}h old" if age_h is not None
+        else "no complete mirror found (missing MIRROR_STAMP)"
+    )
+    _save_mirror_state(state_file, {
+        "warned_at": state.get("warned_at") or now.isoformat(),
+        "last_alert_at": now.isoformat(),
+    })
+    await _send(dispatcher, AlertSeverity.WARNING,
+                "Credential backup mirror stale",
+                f"The host-side credential mirror is stale: {detail} "
+                f"(threshold {cfg.mirror_stale_hours:.0f}h). Encrypted backups may "
+                "not be landing — a container loss right now could not be recovered "
+                "from the host. Check the backup timer and the awareness loop.")
+
+
+def _archive_mirror(config, mirror_dir: Path, escrow: Path) -> None:
+    """Copy the mirror tree + escrow → a host-only archive the container cannot
+    reach. Refuse an empty or stamp-less mirror so a zeroed shared mount can
+    never propagate into (and destroy) the last-line archive."""
+    stamp = mirror_dir / _MIRROR_STAMP
+    if not stamp.exists():
+        logger.debug("cred archive: mirror has no STAMP (incomplete/absent) — skipping")
+        return
+    gpg_files = [f for f in mirror_dir.rglob("*.gpg") if f.is_file()]
+    if not gpg_files:
+        logger.debug("cred archive: mirror has no encrypted files — refusing to overwrite archive")
+        return
+
+    archive = config.state_path / _ARCHIVE_SUBDIR
+    try:
+        archive.mkdir(parents=True, exist_ok=True)
+        os.chmod(archive, 0o700)
+        keep: set[Path] = set()
+        for f in gpg_files:
+            rel = f.relative_to(mirror_dir)
+            _atomic_copy(f, archive / rel)
+            keep.add(rel)
+        _atomic_copy(stamp, archive / _MIRROR_STAMP)
+        keep.add(Path(_MIRROR_STAMP))
+        if escrow.exists():
+            _atomic_copy(escrow, archive / _ESCROW_FILE)
+            keep.add(Path(_ESCROW_FILE))
+        _prune_to_keep(archive, keep)
+    except OSError:
+        logger.warning("cred archive hop failed", exc_info=True)
+
+
+def _load_mirror_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        obj = json.loads(path.read_text())
+        return obj if isinstance(obj, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_mirror_state(path: Path, state: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state))
+    except OSError:
+        logger.warning("failed to persist cred mirror alert state", exc_info=True)
 
 
 async def _send(dispatcher, severity: AlertSeverity, title: str, body: str) -> None:

--- a/src/genesis/guardian/cred_watch.py
+++ b/src/genesis/guardian/cred_watch.py
@@ -29,10 +29,10 @@ from genesis.guardian import cred_integrity
 from genesis.guardian.alert.base import Alert, AlertSeverity
 from genesis.guardian.cred_integrity import RESTORABLE_STATUSES, allowed_restore
 
-# Shared file primitives (atomic copy / containment-guarded prune) live in the
-# credential_bridge module — imported here so the mirror and its host-only
-# archive use the identical copy/prune discipline. Import is side-effect-free.
-from genesis.guardian.credential_bridge import _atomic_copy, _prune_to_keep
+# Shared atomic-copy primitive lives in the credential_bridge module — imported
+# here so the host-only archive uses the identical copy discipline as the
+# container-side mirror. Import is side-effect-free.
+from genesis.guardian.credential_bridge import _atomic_copy
 
 logger = logging.getLogger(__name__)
 
@@ -352,6 +352,12 @@ async def _check_mirror_and_archive(config, dispatcher) -> None:
     # file (written by the same bridge tick) is the proxy for "backups on".
     if escrow.exists():
         await _mirror_freshness_alert(config, dispatcher, mirror_dir)
+    else:
+        # Backups not configured (or turned off): drop any lingering stale-warn
+        # state so a later re-enable starts clean. No alert — absence is expected.
+        state_file = config.state_path / _MIRROR_STATE_FILE
+        if _load_mirror_state(state_file).get("warned_at"):
+            _save_mirror_state(state_file, {})
 
     _archive_mirror(config, mirror_dir, escrow)
 
@@ -417,32 +423,34 @@ async def _mirror_freshness_alert(config, dispatcher, mirror_dir: Path) -> None:
 
 def _archive_mirror(config, mirror_dir: Path, escrow: Path) -> None:
     """Copy the mirror tree + escrow → a host-only archive the container cannot
-    reach. Refuse an empty or stamp-less mirror so a zeroed shared mount can
-    never propagate into (and destroy) the last-line archive."""
+    reach. Refuse an empty or stamp-less mirror so a zeroed shared mount never
+    even starts an archive round.
+
+    The archive is deliberately GROW-ONLY (it never prunes). It is the last line
+    of defence, so it must never delete a credential based on a single —
+    possibly transient or partial — view of the mirror (e.g. a backup.sh rewrite
+    window that briefly drops a .gpg, then the container's own mirror prunes it,
+    then this tick sees the shrunken set). Stale extra encrypted blobs are
+    harmless on restore; losing the only surviving copy is not. Same-named creds
+    are still refreshed in place, so rotations propagate."""
     stamp = mirror_dir / _MIRROR_STAMP
     if not stamp.exists():
         logger.debug("cred archive: mirror has no STAMP (incomplete/absent) — skipping")
         return
     gpg_files = [f for f in mirror_dir.rglob("*.gpg") if f.is_file()]
     if not gpg_files:
-        logger.debug("cred archive: mirror has no encrypted files — refusing to overwrite archive")
+        logger.debug("cred archive: mirror has no encrypted files — skipping")
         return
 
     archive = config.state_path / _ARCHIVE_SUBDIR
     try:
         archive.mkdir(parents=True, exist_ok=True)
         os.chmod(archive, 0o700)
-        keep: set[Path] = set()
         for f in gpg_files:
-            rel = f.relative_to(mirror_dir)
-            _atomic_copy(f, archive / rel)
-            keep.add(rel)
+            _atomic_copy(f, archive / f.relative_to(mirror_dir))
         _atomic_copy(stamp, archive / _MIRROR_STAMP)
-        keep.add(Path(_MIRROR_STAMP))
         if escrow.exists():
             _atomic_copy(escrow, archive / _ESCROW_FILE)
-            keep.add(Path(_ESCROW_FILE))
-        _prune_to_keep(archive, keep)
     except OSError:
         logger.warning("cred archive hop failed", exc_info=True)
 

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -388,6 +388,9 @@ def _needs_copy(src: Path, dest: Path) -> bool:
 
     Steady state is stat-only: ``_atomic_copy`` preserves the source mtime, so an
     unchanged source (the common per-tick case) compares equal and is skipped.
+    This is only an optimisation — on an exotic shared mount that does not
+    round-trip mtime, the worst case is re-copying a ~100 KB bundle each tick,
+    which is harmless (the copy is atomic and the outcome identical).
     """
     if not dest.exists():
         return True

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import stat
 from pathlib import Path
 
@@ -25,6 +26,7 @@ __all__ = [
     "load_backup_passphrase",
     "load_provisioning_credentials",
     "load_telegram_credentials",
+    "mirror_credential_backup",
     "propagate_backup_passphrase",
     "propagate_guardian_credentials",
     "propagate_provisioning_credentials",
@@ -64,6 +66,19 @@ _PASSPHRASE_FILENAME = "backup_passphrase.env"
 _KEY_MAP_PASSPHRASE = {
     "GENESIS_BACKUP_PASSPHRASE": "GENESIS_BACKUP_PASSPHRASE",
 }
+
+# Credential-backup mirror (G.4). The encrypted creds+secrets bundle that
+# backup.sh produces lives ONLY in the Tier-1 backup clone inside the container
+# FS — a destroyed container loses it, and the Tier-2 off-site copy needs the
+# very git/gh credentials it would restore (chicken-and-egg). Mirroring the
+# already-encrypted bundle to the host-side shared mount lets a rebuilt container
+# recover creds + the guardian control-plane key with zero network. Only .gpg
+# files cross (already encrypted); the passphrase is escrowed separately by
+# propagate_backup_passphrase. The guardian makes a second, host-only copy
+# (creds-archive) that the container cannot reach — see cred_watch.
+_MIRROR_SUBDIR = "creds-mirror"      # under <shared>/guardian/
+_MIRROR_STAMP = "MIRROR_STAMP"       # completeness marker, written LAST
+_MIRROR_SRC_SUBDIRS = ("creds", "secrets")  # subtrees of the Tier-1 clone to mirror
 
 # Keys to extract from container secrets.env
 # Maps source key name → output key name
@@ -242,14 +257,78 @@ def load_backup_passphrase(
         return {}
 
 
+def mirror_credential_backup(
+    shared_dir: Path | None = None,
+    backup_dir: Path | None = None,
+) -> Path | None:
+    """Mirror the encrypted creds+secrets bundle → the host-side shared mount.
+
+    Source = the Tier-1 backup clone (default ``~/backups/genesis-backups`` via
+    ``cred_integrity._default_backup_dir``). Only ``*.gpg`` files under ``creds/``
+    and ``secrets/`` are copied — already encrypted at rest. Copy-if-changed
+    (size+mtime), prune mirror-side files whose source vanished, then write the
+    ``MIRROR_STAMP`` completeness marker LAST. Returns the mirror dir on success
+    (>=1 file mirrored), else None. Skips silently when the shared mount or the
+    backup clone is absent (a no-backup / no-guardian install). Never raises.
+    """
+    # Local import: cred_integrity is the standalone validator (stdlib-only); we
+    # reuse only its pure path helper so the Tier-1 layout stays defined once.
+    from genesis.guardian.cred_integrity import _default_backup_dir
+
+    src_root = backup_dir or _default_backup_dir(Path.home())
+    shared_base = shared_dir or _CONTAINER_SHARED_DIR
+    if not shared_base.exists():
+        logger.debug("Shared mount %s absent — skipping cred mirror", shared_base)
+        return None
+    if not src_root.exists():
+        logger.debug("No backup clone at %s — skipping cred mirror", src_root)
+        return None
+
+    # Enumerate the encrypted artifacts to mirror (rel-path → absolute source).
+    src_files: dict[Path, Path] = {}
+    for sub in _MIRROR_SRC_SUBDIRS:
+        base = src_root / sub
+        if not base.is_dir():
+            continue
+        for f in base.rglob("*.gpg"):
+            if f.is_file():
+                src_files[f.relative_to(src_root)] = f
+
+    if not src_files:
+        logger.debug("Backup clone %s has no encrypted creds to mirror", src_root)
+        return None
+
+    dest_root = shared_base / _CREDS_SUBDIR / _MIRROR_SUBDIR
+    dest_root.mkdir(parents=True, exist_ok=True)
+    os.chmod(dest_root, stat.S_IRWXU)  # 0700
+
+    for rel, srcf in src_files.items():
+        destf = dest_root / rel
+        if _needs_copy(srcf, destf):
+            _atomic_copy(srcf, destf)
+
+    # Prune mirror files whose source vanished (containment-guarded); keep the
+    # source rel-paths plus the STAMP we are about to (re)write.
+    _prune_to_keep(dest_root, set(src_files) | {Path(_MIRROR_STAMP)})
+
+    # Completeness marker LAST — its presence means "a full mirror round finished".
+    _atomic_write_text(
+        dest_root / _MIRROR_STAMP,
+        f"mirrored_at={_utc_now_iso()}\ncount={len(src_files)}\n",
+    )
+    logger.debug("Mirrored %d encrypted creds → %s", len(src_files), dest_root)
+    return dest_root
+
+
 def propagate_guardian_credentials(
     shared_dir: Path | None = None,
     secrets_path: Path | None = None,
 ) -> list[Path]:
-    """Combined container-side bridge: telegram + provisioning + passphrase escrow.
+    """Combined container-side bridge: telegram + provisioning + passphrase escrow
+    + encrypted-backup mirror.
 
     Wired to the awareness-loop tick (called zero-arg). A failure in one leg
-    never blocks the other, and never raises into the loop.
+    never blocks the others, and never raises into the loop.
     """
     written: list[Path] = []
     for fn in (
@@ -264,6 +343,17 @@ def propagate_guardian_credentials(
             continue
         if path:
             written.append(path)
+
+    # Mirror leg has a different source (the backup clone, not secrets.env), so it
+    # is called explicitly rather than in the secrets-path loop above.
+    try:
+        mirror = mirror_credential_backup(shared_dir=shared_dir)
+    except Exception as exc:  # noqa: BLE001 — must never break the tick
+        logger.warning("credential backup mirror failed: %s", exc)
+        mirror = None
+    if mirror:
+        written.append(mirror)
+
     return written
 
 
@@ -285,6 +375,77 @@ def _write_creds_atomic(out_dir: Path, filename: str, creds: dict[str, str]) -> 
     os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)  # 600
     os.replace(tmp_path, out_path)
     return out_path
+
+
+def _utc_now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+def _needs_copy(src: Path, dest: Path) -> bool:
+    """True if dest is missing or differs from src by size or mtime.
+
+    Steady state is stat-only: ``_atomic_copy`` preserves the source mtime, so an
+    unchanged source (the common per-tick case) compares equal and is skipped.
+    """
+    if not dest.exists():
+        return True
+    try:
+        s, d = src.stat(), dest.stat()
+    except OSError:
+        return True
+    return s.st_size != d.st_size or int(s.st_mtime) != int(d.st_mtime)
+
+
+def _atomic_copy(src: Path, dest: Path, mode: int = 0o600) -> None:
+    """Copy src → dest atomically (same-dir tmp + os.replace), preserving mtime.
+
+    ``copy2`` preserves the source mtime so ``_needs_copy`` can skip unchanged
+    files on later ticks. The destination is forced to ``mode`` (0600) after copy
+    — never inherit the source's mode.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f".{dest.name}.tmp"
+    shutil.copy2(src, tmp)
+    os.chmod(tmp, mode)
+    os.replace(tmp, dest)
+
+
+def _atomic_write_text(dest: Path, text: str, mode: int = 0o600) -> None:
+    """Atomic 0600 text write (same-dir tmp + os.replace)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f".{dest.name}.tmp"
+    tmp.write_text(text)
+    os.chmod(tmp, mode)
+    os.replace(tmp, dest)
+
+
+def _prune_to_keep(root: Path, keep: set[Path]) -> None:
+    """Delete files under ``root`` whose rel-path is not in ``keep``.
+
+    Containment-guarded: only unlinks regular files that resolve to a path
+    strictly under ``root`` (a symlink escaping the tree is never followed to a
+    delete). Empty directories are left behind (harmless).
+    """
+    try:
+        root_res = root.resolve()
+    except OSError:
+        return
+    for f in root.rglob("*"):
+        if not f.is_file():
+            continue
+        try:
+            rel = f.relative_to(root)
+        except ValueError:
+            continue
+        if rel in keep:
+            continue
+        try:
+            if f.resolve().is_relative_to(root_res):
+                f.unlink()
+        except OSError:
+            logger.warning("cred mirror prune: could not remove %s", f, exc_info=True)
 
 
 def _read_dotenv(path: Path) -> dict[str, str]:

--- a/tests/test_guardian/test_cred_watch.py
+++ b/tests/test_guardian/test_cred_watch.py
@@ -377,18 +377,45 @@ async def test_archive_refuses_stampless_mirror(cfg):
     assert not (arc / "creds" / "x.gpg").exists()
 
 
-async def test_archive_prunes_vanished_cred(cfg):
+async def test_archive_is_grow_only_partial_mirror_keeps_creds(cfg):
+    """The last-line archive must NEVER lose a cred to a transient/partial mirror
+    (e.g. a backup.sh rewrite window) — it is grow-only."""
     _escrow(cfg)
     mdir = _mirror(cfg, rels=("creds/a.gpg", "creds/b.gpg"), age_h=1.0)
     disp = _Dispatcher()
     await cred_watch._check_mirror_and_archive(cfg, disp)
     arc = cfg.state_path / "creds-archive"
     assert (arc / "creds" / "a.gpg").exists()
-    # Drop b from the mirror, re-archive → pruned from the archive too.
+    assert (arc / "creds" / "b.gpg").exists()
+    # b momentarily vanishes from the mirror (partial round) → archive KEEPS it.
     (mdir / "creds" / "b.gpg").unlink()
     await cred_watch._check_mirror_and_archive(cfg, disp)
-    assert not (arc / "creds" / "b.gpg").exists()
+    assert (arc / "creds" / "b.gpg").exists()  # grow-only: last copy preserved
     assert (arc / "creds" / "a.gpg").exists()
+
+
+async def test_archive_keeps_escrow_across_transient_read_miss(cfg):
+    """A one-tick escrow read-miss must not drop the archived passphrase."""
+    esc = _escrow(cfg)
+    _mirror(cfg, age_h=1.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    arc = cfg.state_path / "creds-archive"
+    assert (arc / "backup_passphrase.env").exists()
+    esc.unlink()  # transient miss
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert (arc / "backup_passphrase.env").exists()  # grow-only: kept
+
+
+async def test_stale_warn_state_cleared_when_escrow_disappears(cfg):
+    _escrow(cfg)
+    _mirror(cfg, age_h=60.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)  # WARNING + state written
+    assert "warned_at" in (cfg.state_path / "mirror_alert_state.json").read_text()
+    (cfg.state_path / "shared" / "guardian" / "backup_passphrase.env").unlink()
+    await cred_watch._check_mirror_and_archive(cfg, disp)  # escrow gone → cleared
+    assert (cfg.state_path / "mirror_alert_state.json").read_text() == "{}"
 
 
 async def test_orchestrator_runs_mirror_even_when_container_unreachable(cfg, monkeypatch):

--- a/tests/test_guardian/test_cred_watch.py
+++ b/tests/test_guardian/test_cred_watch.py
@@ -253,3 +253,150 @@ def _seed_state(cfg, episodes: dict) -> None:
     (cfg.state_path / "cred_alert_state.json").write_text(
         json.dumps({"version": 1, "episodes": episodes})
     )
+
+
+# ── G.4 mirror freshness + host-only archive hop ────────────────────────────
+
+import os  # noqa: E402
+
+
+def _mirror(cfg, *, stamp=True, rels=("creds/x.gpg", "secrets/secrets.env.gpg"),
+            age_h=0.0):
+    """Build a host-view mirror under <state>/shared/guardian/creds-mirror."""
+    mdir = cfg.state_path / "shared" / "guardian" / "creds-mirror"
+    mdir.mkdir(parents=True, exist_ok=True)
+    for rel in rels:
+        p = mdir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"ENC")
+        if age_h:
+            t = (datetime.now(UTC) - timedelta(hours=age_h)).timestamp()
+            os.utime(p, (t, t))
+    if stamp:
+        (mdir / "MIRROR_STAMP").write_text("mirrored_at=x\ncount=2\n")
+    return mdir
+
+
+def _escrow(cfg):
+    esc = cfg.state_path / "shared" / "guardian" / "backup_passphrase.env"
+    esc.parent.mkdir(parents=True, exist_ok=True)
+    esc.write_text("GENESIS_BACKUP_PASSPHRASE=pw\n")
+    return esc
+
+
+async def test_mirror_fresh_no_alert(cfg):
+    _escrow(cfg)
+    _mirror(cfg, age_h=1.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert disp.alerts == []
+
+
+async def test_mirror_stale_warns(cfg):
+    _escrow(cfg)
+    _mirror(cfg, age_h=60.0)  # > 48h default
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert len(disp.alerts) == 1
+    assert disp.alerts[0].severity == AlertSeverity.WARNING
+    assert "stale" in disp.alerts[0].title.lower()
+    assert (cfg.state_path / "mirror_alert_state.json").exists()
+
+
+async def test_mirror_missing_stamp_warns(cfg):
+    _escrow(cfg)
+    _mirror(cfg, stamp=False, age_h=1.0)  # fresh files but incomplete round
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert len(disp.alerts) == 1
+    assert disp.alerts[0].severity == AlertSeverity.WARNING
+
+
+async def test_mirror_no_escrow_is_silent(cfg):
+    # No escrow ⇒ backups not configured ⇒ no freshness judgement.
+    _mirror(cfg, stamp=False, age_h=99.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert disp.alerts == []
+
+
+async def test_mirror_stale_realert_damped(cfg):
+    _escrow(cfg)
+    _mirror(cfg, age_h=60.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    await cred_watch._check_mirror_and_archive(cfg, disp)  # within realert window
+    assert len(disp.alerts) == 1  # second call damped
+
+
+async def test_mirror_recovered_sends_info(cfg):
+    _escrow(cfg)
+    _mirror(cfg, age_h=60.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)  # WARNING + state
+    # Freshen the mirror, re-run → INFO recovery + state cleared.
+    _mirror(cfg, age_h=0.0)
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert disp.alerts[-1].severity == AlertSeverity.INFO
+    state = (cfg.state_path / "mirror_alert_state.json").read_text()
+    assert "warned_at" not in state
+
+
+async def test_archive_populates_from_mirror(cfg):
+    _escrow(cfg)
+    _mirror(cfg, age_h=1.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    arc = cfg.state_path / "creds-archive"
+    assert (arc / "creds" / "x.gpg").exists()
+    assert (arc / "secrets" / "secrets.env.gpg").exists()
+    assert (arc / "MIRROR_STAMP").exists()
+    assert (arc / "backup_passphrase.env").read_text() == "GENESIS_BACKUP_PASSPHRASE=pw\n"
+
+
+async def test_archive_refuses_empty_mirror(cfg):
+    # Seed a prior archive, then present a stamp-present but gpg-empty mirror.
+    arc = cfg.state_path / "creds-archive"
+    (arc / "creds").mkdir(parents=True)
+    (arc / "creds" / "old.gpg").write_bytes(b"OLD")
+    (arc / "MIRROR_STAMP").write_text("old\n")
+    mdir = cfg.state_path / "shared" / "guardian" / "creds-mirror"
+    mdir.mkdir(parents=True)
+    (mdir / "MIRROR_STAMP").write_text("x\n")  # stamp present, NO gpg files
+    cred_watch._archive_mirror(cfg, mdir, cfg.state_path / "nope-escrow")
+    assert (arc / "creds" / "old.gpg").read_bytes() == b"OLD"  # untouched
+
+
+async def test_archive_refuses_stampless_mirror(cfg):
+    arc = cfg.state_path / "creds-archive"
+    (arc).mkdir(parents=True)
+    (arc / "sentinel").write_text("keep")
+    mdir = _mirror(cfg, stamp=False)  # gpg present, no STAMP
+    cred_watch._archive_mirror(cfg, mdir, cfg.state_path / "nope")
+    assert (arc / "sentinel").read_text() == "keep"
+    assert not (arc / "creds" / "x.gpg").exists()
+
+
+async def test_archive_prunes_vanished_cred(cfg):
+    _escrow(cfg)
+    mdir = _mirror(cfg, rels=("creds/a.gpg", "creds/b.gpg"), age_h=1.0)
+    disp = _Dispatcher()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    arc = cfg.state_path / "creds-archive"
+    assert (arc / "creds" / "a.gpg").exists()
+    # Drop b from the mirror, re-archive → pruned from the archive too.
+    (mdir / "creds" / "b.gpg").unlink()
+    await cred_watch._check_mirror_and_archive(cfg, disp)
+    assert not (arc / "creds" / "b.gpg").exists()
+    assert (arc / "creds" / "a.gpg").exists()
+
+
+async def test_orchestrator_runs_mirror_even_when_container_unreachable(cfg, monkeypatch):
+    # container check returns None (no signal), but the host-side mirror/archive
+    # still runs — the archive must be populated.
+    _escrow(cfg)
+    _mirror(cfg, age_h=1.0)
+    monkeypatch.setattr(cred_watch, "run_container_check", _async(None))
+    disp = _Dispatcher()
+    await check_credential_integrity_and_alert(cfg, disp)
+    assert (cfg.state_path / "creds-archive" / "creds" / "x.gpg").exists()

--- a/tests/test_guardian/test_credential_bridge.py
+++ b/tests/test_guardian/test_credential_bridge.py
@@ -6,6 +6,8 @@ import os
 import stat
 from pathlib import Path
 
+import pytest
+
 from genesis.guardian.credential_bridge import (
     load_telegram_credentials,
     propagate_telegram_credentials,
@@ -289,6 +291,13 @@ class TestProvisioningCredentials:
 class TestCombinedBridge:
     """propagate_guardian_credentials fans out to both, each guarded."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_home(self, tmp_path: Path, monkeypatch):
+        # The mirror leg defaults its source to ~/backups/genesis-backups. Isolate
+        # HOME to a clone-free sandbox so these telegram/proxmox assertions stay
+        # deterministic regardless of the host having a real backup clone.
+        monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+
     def test_writes_both_when_present(self, tmp_path: Path) -> None:
         from genesis.guardian.credential_bridge import propagate_guardian_credentials
         secrets = tmp_path / "secrets.env"
@@ -354,8 +363,13 @@ class TestBackupPassphraseEscrow:
         from genesis.guardian.credential_bridge import load_backup_passphrase
         assert load_backup_passphrase(str(tmp_path / "nope")) == {}
 
-    def test_combined_bridge_includes_passphrase(self, tmp_path: Path) -> None:
+    def test_combined_bridge_includes_passphrase(self, tmp_path: Path, monkeypatch) -> None:
         from genesis.guardian.credential_bridge import propagate_guardian_credentials
+        # Isolate HOME so the mirror leg (which defaults its source to
+        # ~/backups/genesis-backups) is a deterministic no-op here — no clone in
+        # the sandbox home means no "creds-mirror" entry. Mirror is covered by
+        # TestMirrorCredentialBackup below.
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
         secrets = tmp_path / "secrets.env"
         secrets.write_text(
             "TELEGRAM_BOT_TOKEN=bot\nTELEGRAM_FORUM_CHAT_ID=chat\n"
@@ -367,3 +381,108 @@ class TestBackupPassphraseEscrow:
         )
         names = sorted(p.name for p in written)
         assert names == ["backup_passphrase.env", "proxmox_creds.env", "telegram_creds.env"]
+
+    def test_combined_bridge_includes_mirror_when_clone_present(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """With a backup clone present, the combined bridge also mirrors it."""
+        from genesis.guardian.credential_bridge import propagate_guardian_credentials
+        home = tmp_path / "home"
+        clone = home / "backups" / "genesis-backups"
+        (clone / "secrets").mkdir(parents=True)
+        (clone / "secrets" / "secrets.env.gpg").write_bytes(b"ENC")
+        monkeypatch.setenv("HOME", str(home))
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text("GENESIS_BACKUP_PASSPHRASE=pp\n")
+        written = propagate_guardian_credentials(
+            shared_dir=tmp_path / "state" / "shared", secrets_path=secrets,
+        )
+        names = sorted(p.name for p in written)
+        assert "creds-mirror" in names
+        assert "backup_passphrase.env" in names
+
+
+class TestMirrorCredentialBackup:
+    """G.4 container-side encrypted-backup mirror to the shared mount."""
+
+    def _clone(self, root: Path, rels=("creds/claude.json.gpg",
+                                       "creds/ssh/id_ed25519.gpg",
+                                       "secrets/secrets.env.gpg")) -> Path:
+        clone = root / "clone"
+        for rel in rels:
+            p = clone / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"ENCRYPTED-" + rel.encode())
+        return clone
+
+    def test_mirrors_encrypted_files_0600_with_stamp(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        clone = self._clone(tmp_path)
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        dest = mirror_credential_backup(shared_dir=shared, backup_dir=clone)
+        assert dest is not None
+        assert (dest / "creds" / "claude.json.gpg").read_bytes().startswith(b"ENCRYPTED-")
+        assert (dest / "creds" / "ssh" / "id_ed25519.gpg").exists()
+        assert (dest / "secrets" / "secrets.env.gpg").exists()
+        assert (dest / "MIRROR_STAMP").exists()
+        mode = stat.S_IMODE(os.stat(dest / "creds" / "claude.json.gpg").st_mode)
+        assert mode == 0o600
+
+    def test_skips_unchanged_on_second_run(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        clone = self._clone(tmp_path)
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        dest = mirror_credential_backup(shared_dir=shared, backup_dir=clone)
+        f = dest / "secrets" / "secrets.env.gpg"
+        ino1 = os.stat(f).st_ino
+        mirror_credential_backup(shared_dir=shared, backup_dir=clone)
+        # Unchanged source ⇒ no rewrite ⇒ same inode (os.replace would swap it).
+        assert os.stat(f).st_ino == ino1
+
+    def test_prunes_vanished_source(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        clone = self._clone(tmp_path)
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        dest = mirror_credential_backup(shared_dir=shared, backup_dir=clone)
+        assert (dest / "creds" / "claude.json.gpg").exists()
+        (clone / "creds" / "claude.json.gpg").unlink()
+        mirror_credential_backup(shared_dir=shared, backup_dir=clone)
+        assert not (dest / "creds" / "claude.json.gpg").exists()
+        assert (dest / "secrets" / "secrets.env.gpg").exists()  # survivor kept
+
+    def test_prune_containment_leaves_siblings(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        clone = self._clone(tmp_path)
+        shared = tmp_path / "shared"
+        (shared / "guardian").mkdir(parents=True)
+        sibling = shared / "guardian" / "telegram_creds.env"  # sibling of creds-mirror
+        sibling.write_text("TELEGRAM_BOT_TOKEN=keepme\n")
+        mirror_credential_backup(shared_dir=shared, backup_dir=clone)
+        assert sibling.read_text() == "TELEGRAM_BOT_TOKEN=keepme\n"
+
+    def test_absent_shared_mount_returns_none(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        clone = self._clone(tmp_path)
+        assert mirror_credential_backup(
+            shared_dir=tmp_path / "nonexistent", backup_dir=clone,
+        ) is None
+
+    def test_absent_clone_returns_none(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        assert mirror_credential_backup(
+            shared_dir=shared, backup_dir=tmp_path / "no-clone",
+        ) is None
+
+    def test_clone_without_gpg_returns_none(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import mirror_credential_backup
+        clone = tmp_path / "clone"
+        (clone / "creds").mkdir(parents=True)
+        (clone / "creds" / "readme.txt").write_text("not encrypted")
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        assert mirror_credential_backup(shared_dir=shared, backup_dir=clone) is None


### PR DESCRIPTION
## What & why

Every copy of Genesis's credentials lived **inside the container**: the live files *and* the Tier-1 backup clone (`~/backups/genesis-backups/`). A destroyed container loses both, and the off-site Tier-2 copy needs the very git/GitHub credentials it would restore (chicken-and-egg). G.4 mirrors the **already-encrypted** credential bundle onto the host — outside the container's blast radius — so a rebuilt container can recover credentials (including the guardian control-plane SSH key) with zero network.

This is the last piece of the G credential-resilience track, building on the G.2 passphrase escrow (#967) which already proved the shared-mount escape hatch.

## How

- **Container side** (`credential_bridge.py`): `mirror_credential_backup()` copies `creds/*.gpg` + `secrets/*.gpg` from the Tier-1 clone to `<shared>/guardian/creds-mirror/` on each awareness tick (copy-if-changed, containment-guarded prune, `MIRROR_STAMP` written last). Wired into the existing `propagate_guardian_credentials` composite — zero new plumbing.
- **Guardian side** (`cred_watch.py`): warns if the mirror goes stale (newest credential older than `mirror_stale_hours`, default 48h — an early "backups aren't landing" signal), and keeps a second, **host-only** archive (`creds-archive/`) the container can't reach. The archive is **grow-only**: it never deletes a credential based on one possibly-partial view of the mirror, because it is the last line of defence.
- **Restore** (`restore.sh`): falls back to the mirror (or, host-side, the archive) and its escrowed passphrase when the Tier-1 clone payload is absent — the rebuild path with no network.
- Config field + `guardian.yaml`, container-loss runbook in `docs/reference/recovery-and-portability-workflow.md`, user-voiced CHANGELOG.

## Security posture

Only GPG-encrypted `*.gpg` files cross; the passphrase is escrowed separately. The mirror sits next to the escrow on the host — but the host already has root over the container (`incus exec`) and can read every plaintext original today, so this is not new exposure. Mirror/archive dirs `0700`, files `0600`.

## Verification

- `tests/test_guardian/` — 718 pass (incl. 24 new G.4 tests); ruff + `bash -n` clean.
- **Code review** (2 finders, single round): 3 findings fixed — grow-only archive (don't let a partial mirror destroy the last copy), stale-state clear, payload-keyed restore fallback.
- **Live pre-merge E2E**: real `restore.sh` rebuilt creds from a mirror-only sandbox via the escrowed passphrase (incl. empty-placeholder-`creds/` edge); mirror one-shot against the real backup clone produced a byte-identical 0600 tree of all 18 production credentials.
- **Post-merge** (host-deploy gate — `cred_watch.py` is guardian-deployed): redeploy the host guardian via `update.sh`/`git archive | ssh redeploy`, then verify the mirror appears host-side after one awareness tick, the archive populates after a guardian tick, and a backdated-stamp drill fires the stale WARNING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)