### PR TITLE
feat(dev-quality): inner-loop quick wins — advisory edit verifier, ruff S security lint, review-protocol graft

### DIFF
--- a/.claude/agents/genesis-architect.md
+++ b/.claude/agents/genesis-architect.md
@@ -9,6 +9,47 @@ Before reviewing, read `docs/architecture/CURRENT.md` if present — it is the
 judgment-layer map (subsystem maturity, unwired loops, do-not-touch list) that
 grounds scope calls below.
 
+## Step 0 — Prior-Learnings Pass
+
+Before reading the diff, call `procedure_recall` (task_type `code_review`,
+context_tags = the touched subsystems per `docs/architecture/CURRENT.md`) and
+scan the returned procedures for repeat offenses to check this diff against.
+At the END of the review, if you found a genuinely durable NEW lesson (a
+mistake class likely to recur, not a one-off), store it via `procedure_store`
+with task_type `code_review`. If the memory MCP tools are not available in
+this context, emit exactly one line — "prior-learnings pass skipped: memory
+MCP unavailable" — and continue; never block or retry on it.
+
+## Step 0.5 — Scope Drift Check
+
+Before reviewing code quality, check: did they build what was requested —
+nothing more, nothing less?
+
+1. Establish the **stated intent**: the plan file (if referenced in the
+   dispatch prompt), the PR description (`gh pr view` if a PR exists), and
+   commit messages (`git log origin/<base>..HEAD --oneline`).
+2. Run `git diff $(git merge-base origin/<base> HEAD) --stat` and compare
+   files changed vs stated intent.
+3. Detect **scope creep** (files unrelated to intent; features/refactors not
+   in the plan; "while I was in there" changes that expand blast radius) and
+   **missing requirements** (plan items unaddressed; test-coverage gaps for
+   stated requirements; partial implementations).
+4. When a plan file exists, cross-reference each plan item and classify:
+   DONE / PARTIAL / NOT DONE / CHANGED / UNVERIFIABLE. Honesty rule: code
+   that *handles* a deliverable is not the deliverable — point at the thing
+   itself, at a concrete path.
+5. Output this block before the main review:
+
+   ```
+   Scope Check: [CLEAN / DRIFT DETECTED / REQUIREMENTS MISSING]
+   Intent:    <1-line summary of what was requested>
+   Delivered: <1-line summary of what the diff actually does>
+   [If drift: list each out-of-scope change]
+   [If missing: list each unaddressed requirement]
+   ```
+
+This step is INFORMATIONAL — it never blocks the review.
+
 ## Genesis Design Principles (Non-Negotiable)
 
 1. **Flexibility > lock-in**: Every external dependency must be swappable. Adapter patterns, generic interfaces. A new provider should be a config change, not a refactor.
@@ -71,7 +112,53 @@ Full protocol: procedure `codebase_audit` / CC memory `audit-enumerate-not-spotc
 ## Review Output Format
 
 For each concern:
-1. **What**: specific file:line, exact code
-2. **Why it's a problem**: which principle violated, what failure mode
-3. **Confidence**: explicit percentage with rationale
-4. **Fix**: concrete code change, not a description of a change
+1. **Severity**: `BLOCKER` / `SHOULD-FIX` / `NOTE` (see ladder below)
+2. **What**: specific file:line, exact code
+3. **Why it's a problem**: which principle violated, what failure mode
+4. **Confidence**: explicit percentage with rationale (see gate below)
+5. **Fix**: concrete code change, not a description of a change
+
+### Severity ladder
+
+- **BLOCKER** — breaks a runtime path, corrupts data, violates a security or
+  privacy boundary, or contradicts a non-negotiable design principle. Must be
+  fixed before merge. (≈ Codex P1 ≈ surplus-auditor critical/high.)
+- **SHOULD-FIX** — real defect or liability, but bounded: wrong on an edge
+  path, misleading to maintainers, or debt that compounds. Fix in this PR
+  unless consciously accepted with a stated reason. (≈ P2 ≈ medium.)
+- **NOTE** — advisory: style, naming, small hardening, doc gaps. (≈ P3 ≈ low.)
+
+The surplus auditor (`src/genesis/identity/CODE_AUDITOR.md`) keeps its own
+`critical/high/medium/low` ladder — its JSON is machine-parsed into
+observations. Interactive reviews use the three-tier ladder above.
+
+### Confidence gate (pre-emit verification)
+
+Display thresholds: ≥90% = verified by reading the specific code — show
+normally; 70-85% = strong pattern match — show normally; 50-60% = could be a
+false positive — show with an explicit "verify this" caveat; 30-40% =
+suppress from the main report, appendix only; <30% = report only if the
+severity would be BLOCKER.
+
+**Before emitting any finding, quote the verbatim motivating line(s) at
+file:line.** If the finding is "field X doesn't exist", quote the class/table
+where it would live; if "this may be None", quote the initialization; if
+"race between A and B", quote both. **If you cannot quote the motivating
+line, the finding is unverified: force its confidence to 40-50% (appendix).
+Do not invent 70%+ confidence to dodge the gate.** When a symbol is generated
+by a framework construct (decorator, metaclass, migration, schema template),
+quote the generating construct — "I grepped for the name and didn't find it"
+is not verification.
+
+## Completion Status Protocol
+
+End every review with exactly one status:
+
+- **DONE** — review completed with evidence.
+- **DONE_WITH_CONCERNS** — completed; list the concerns.
+- **BLOCKED** — cannot proceed; state the blocker and what was tried.
+- **NEEDS_CONTEXT** — missing info; state exactly what is needed.
+
+Escalate (BLOCKED/NEEDS_CONTEXT instead of guessing) after 3 failed attempts
+at something, on uncertain security-sensitive changes, or on scope you cannot
+verify. Escalation format: `STATUS`, `REASON`, `ATTEMPTED`, `RECOMMENDATION`.

--- a/.claude/agents/genesis-architect.md
+++ b/.claude/agents/genesis-architect.md
@@ -11,9 +11,11 @@ grounds scope calls below.
 
 ## Step 0 — Prior-Learnings Pass
 
-Before reading the diff, call `procedure_recall` (task_type `code_review`,
-context_tags = the touched subsystems per `docs/architecture/CURRENT.md`) and
-scan the returned procedures for repeat offenses to check this diff against.
+Before reading the diff, call `procedure_recall` with a `task_description`
+describing this review (rows stored under task_type `code_review` will match)
+and `context_tags` = the touched subsystems per `docs/architecture/CURRENT.md`,
+then scan the returned procedures for repeat offenses to check this diff
+against.
 At the END of the review, if you found a genuinely durable NEW lesson (a
 mistake class likely to recur, not a one-off), store it via `procedure_store`
 with task_type `code_review`. If the memory MCP tools are not available in

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -312,8 +312,8 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "bash -c 'FILE=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r .file_path 2>/dev/null); if [[ \"$FILE\" == *.py ]]; then RUFF=/home/ubuntu/genesis/.venv/bin/ruff; \"$RUFF\" format --quiet \"$FILE\" 2>/dev/null; \"$RUFF\" check --fix --quiet \"$FILE\" 2>/dev/null; fi; true'",
-                        "timeout": 3000
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/edit_verify_advisory.py",
+                        "timeout": 6000
                     }
                 ]
             },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -313,7 +313,7 @@
                     {
                         "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/edit_verify_advisory.py",
-                        "timeout": 6000
+                        "timeout": 10
                     }
                 ]
             },

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -262,6 +262,22 @@ The enforcement hooks (`review_enforcement_prompt.py`,
 safety nets, not the decision-maker. This protocol provides the
 judgment framework.
 
+Two protocol steps apply to every review at "Code-reviewer inline" level or
+above (full definitions in `.claude/agents/genesis-architect.md`):
+
+- **Scope-drift check first**: compare stated intent (plan file / PR
+  description / commit messages) against `git diff --stat` vs the merge-base,
+  and open the review with the `Scope Check: CLEAN / DRIFT DETECTED /
+  REQUIREMENTS MISSING` + Intent/Delivered block. Informational, never
+  blocking.
+- **Completion status last**: every review (and every skill workflow that
+  concludes work) ends with exactly one of DONE / DONE_WITH_CONCERNS /
+  BLOCKED / NEEDS_CONTEXT — with concerns listed, or blocker + what was
+  tried, or exactly what context is missing. Findings use the
+  BLOCKER / SHOULD-FIX / NOTE severity ladder with per-finding confidence
+  and the pre-emit quote gate (a finding must quote its motivating
+  file:line or be confidence-capped).
+
 ## Pre-Commit Gate
 
 Verify before any commit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Lint feedback now reaches the session instead of disappearing.** The
+  edit-time ruff hook used to auto-fix what it could and silently swallow the
+  rest; now anything it can't fix comes back to the working session as a
+  short advisory note (capped, explicitly non-blocking) so problems surface
+  the moment they're written instead of at commit time. Security linting
+  (the full bandit ruleset via ruff's `S` family) is enabled repo-wide with
+  every suppression individually justified in-line — `shell=True` misuse now
+  fails lint everywhere, including CI.
+
+- **Code reviews follow a written protocol instead of convention.** The
+  architect reviewer now opens with a scope-drift check (did the change do
+  what was asked — nothing more, nothing less), grades findings on an
+  explicit BLOCKER / SHOULD-FIX / NOTE ladder, must quote the exact line
+  motivating each finding or have the finding's confidence capped, consults
+  prior review learnings before starting, and closes with an explicit
+  completion status. Adapted from the gstack review framework.
+
 - **`genesis eval bench` — a Genesis-vs-bare-Claude A/B benchmark you can run
   in one command.** Each task in a private task set runs through two arms: a
   cognition-enabled Genesis session (identity + read-only recall from your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,37 @@ select = [
     "B",    # flake8-bugbear (catches common gotchas)
     "SIM",  # flake8-simplify
     "UP",   # pyupgrade
+    "S",    # flake8-bandit (security) — see the documented ignores below
 ]
 ignore = [
     "E501",  # line length (handled by formatter)
+    # S603/S607 flag EVERY subprocess call regardless of safety; this codebase
+    # shells to git/gh/ruff by design. The real shell-risk rule, S602
+    # (shell=True), stays ENABLED.
+    "S603", "S607",
+    # S110/S112 (try-except-pass/continue): most hits implement the deliberate
+    # "hooks/best-effort telemetry never crash" convention. A linter cannot
+    # distinguish that from bad swallowing in data-returning code — the review
+    # protocol + CODE_AUDITOR taxonomy own that class with judgment. This is a
+    # documented trade, not noise cleanup (user-accepted 2026-07-10).
+    "S110", "S112",
+    # S311 (non-crypto random): all uses are timing jitter / sampling / backoff
+    # (browser stealth, retry spread). No token or secret generation uses
+    # `random` — re-grep before adding any such use; use `secrets` there.
+    "S311",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests assert, use fake credentials, /tmp literals, chmod fixtures,
+# subprocess/shell fixtures, and literal fixture SQL by nature.
+"tests/**" = ["S101", "S105", "S106", "S108", "S103", "S324", "S602", "S608"]
+# Parametrized dynamic-WHERE builder pattern: SQL fragments are literal
+# strings assembled in code; user values are ALWAYS bound parameters. S608
+# stays live outside these data-access layers.
+"src/genesis/db/crud/*" = ["S608"]
+"src/genesis/dashboard/routes/*" = ["S608"]
+# Type-narrowing asserts in MCP handlers (follow-up: convert to explicit raises).
+"src/genesis/mcp/memory/*" = ["S101"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ test = [
     "pytest-asyncio",
     "pytest-timeout",
     "aioresponses>=0.7.7",
+    # tests/test_hooks/test_edit_verify_advisory.py executes the real hook,
+    # which shells out to the venv's ruff — CI's test job installs only this
+    # extra, so ruff must be here (the lint job installs its own copy).
+    "ruff>=0.5",
 ]
 browser = [
     "playwright>=1.40",

--- a/scripts/cleanup_pipeline_noise.py
+++ b/scripts/cleanup_pipeline_noise.py
@@ -74,7 +74,7 @@ async def main(dry_run: bool = False) -> None:
             # Delete from memory_metadata
             placeholders = ",".join("?" * len(noise_ids))
             cursor = await db.execute(
-                f"DELETE FROM memory_metadata WHERE memory_id IN ({placeholders})",
+                f"DELETE FROM memory_metadata WHERE memory_id IN ({placeholders})",  # noqa: S608 - literal SQL fragments; values bound as parameters
                 noise_ids,
             )
             meta_deleted = cursor.rowcount

--- a/scripts/hooks/edit_verify_advisory.py
+++ b/scripts/hooks/edit_verify_advisory.py
@@ -30,9 +30,10 @@ import sys
 from pathlib import Path
 
 # Per-invocation cap, not a policy timeout: ruff on a single file is
-# ~50-300ms; the hook itself is killed by settings.json at 6s. This cap just
-# keeps one wedged invocation from eating the whole budget so the later
-# calls (and the advisory) still run. Fail-open on expiry.
+# ~50-300ms; the settings.json hook timeout (10, in SECONDS per the CC hooks
+# docs) is the outer kill. This cap just keeps one wedged invocation from
+# eating the whole budget so the later calls (and the advisory) still run.
+# Fail-open on expiry.
 _RUFF_TIMEOUT_S = 1.5
 
 # Advisory payload cap — enough to act on, small enough not to flood context.

--- a/scripts/hooks/edit_verify_advisory.py
+++ b/scripts/hooks/edit_verify_advisory.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""PostToolUse Edit|Write hook: ruff format + autofix, then ADVISORY report.
+
+Replaces the former inline settings.json ruff hook, which formatted and
+auto-fixed silently — unfixable diagnostics never reached the model, so
+edit-time feedback was fix-what-ruff-can and hide the rest. This hook keeps
+the exact same mutation behavior (format, then ``check --fix``) and then
+surfaces whatever ruff could NOT fix as PostToolUse ``additionalContext``.
+
+It is ONE hook rather than a fixer + a separate reporter because Claude Code
+runs all matching hooks for an event IN PARALLEL with no ordering guarantee
+(hooks docs) — a separate reporter would race the fixer and report
+diagnostics that are about to disappear.
+
+Contract (binding):
+- ADVISORY ONLY. Never exits non-zero on diagnostics, never blocks — the
+  enforcement points are the commit gate (review_enforcement_commit.py) and
+  CI lint. An edit-blocking lint gate is the auto-throttling anti-pattern.
+- Fail-open: any unexpected error exits 0 silently.
+- Model feedback uses the documented PostToolUse JSON channel
+  (``hookSpecificOutput.additionalContext``); plain stdout does not reach
+  the model. Precedent: scripts/content_safety_hook.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Per-invocation cap, not a policy timeout: ruff on a single file is
+# ~50-300ms; the hook itself is killed by settings.json at 6s. This cap just
+# keeps one wedged invocation from eating the whole budget so the later
+# calls (and the advisory) still run. Fail-open on expiry.
+_RUFF_TIMEOUT_S = 1.5
+
+# Advisory payload cap — enough to act on, small enough not to flood context.
+_MAX_DIAG_LINES = 12
+
+_ADVISORY_FOOTER = (
+    "(Advisory only — fix these now if they are in scope for your current "
+    "task, otherwise leave them; the commit-time review gate and CI lint are "
+    "the enforcement points. Do not treat this as a blocking instruction or "
+    "derail into unrelated lint cleanup.)"
+)
+
+
+def _ruff() -> Path | None:
+    ruff = Path(sys.executable).parent / "ruff"
+    return ruff if ruff.is_file() else None
+
+
+def _run(ruff: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603 - fixed venv binary, no shell
+        [str(ruff), *args],
+        capture_output=True,
+        text=True,
+        timeout=_RUFF_TIMEOUT_S,
+    )
+
+
+def _process(data: dict) -> None:
+    if data.get("tool_name") not in ("Edit", "Write"):
+        return
+    tool_input = data.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return
+    file_path = tool_input.get("file_path") or ""
+    if not file_path.endswith(".py"):
+        return
+    path = Path(file_path)
+    if not path.is_file():
+        return
+    ruff = _ruff()
+    if ruff is None:
+        return
+
+    # Same mutations the old inline hook performed, in the same order.
+    _run(ruff, "format", "--quiet", str(path))
+    _run(ruff, "check", "--fix", "--quiet", str(path))
+
+    # What remains after autofix is what the model should hear about.
+    result = _run(ruff, "check", "--output-format", "concise", str(path))
+    if result.returncode == 0:
+        return
+    diagnostics = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    # Drop ruff's "Found N errors" / fix-hint summary lines.
+    diagnostics = [
+        ln for ln in diagnostics
+        if not ln.startswith(("Found ", "[*]", "No fixes"))
+    ]
+    if not diagnostics:
+        return
+
+    total = len(diagnostics)
+    shown = diagnostics[:_MAX_DIAG_LINES]
+    if total > len(shown):
+        shown.append(f"... and {total - len(shown)} more")
+    context = (
+        f"[ruff advisory] {total} unresolved diagnostic(s) in {file_path} "
+        "after autofix:\n" + "\n".join(shown) + "\n" + _ADVISORY_FOOTER
+    )
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": context,
+            }
+        },
+        sys.stdout,
+    )
+
+
+def main() -> int:
+    try:
+        data = json.loads(sys.stdin.read())
+        _process(data)
+    except Exception:  # noqa: BLE001 - hooks fail open, never crash the session
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_curated_to_knowledge.py
+++ b/scripts/migrate_curated_to_knowledge.py
@@ -108,7 +108,7 @@ def main() -> None:
 
     to_move = [p for p in epi_points if str(p["id"]) not in kb_ids]
     to_skip = [p for p in epi_points if str(p["id"]) in kb_ids]
-    print(f"  To move: {len(to_move)}, already in KB (skip upsert, still delete from episodic): {len(to_skip)}")
+    print(f"  To move: {len(to_move)}, already in KB (skip upsert, still delete from episodic): {len(to_skip)}")  # noqa: S608 - progress message, not SQL
 
     all_ids = [str(p["id"]) for p in epi_points]
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -628,7 +628,7 @@ def _search_code_index(db_path: Path, keywords: list[str]) -> list[dict]:
                 WHERE ({placeholders}) AND cs.is_public = 1
                 ORDER BY cs.line_start
                 LIMIT 6
-                """,
+                """,  # noqa: S608 - literal SQL fragments; values bound as parameters
                 params,
             )
             rows = cursor.fetchall()

--- a/scripts/procedure_advisor.py
+++ b/scripts/procedure_advisor.py
@@ -66,7 +66,7 @@ def _record_procedures_surfaced(proc_ids: list[str]) -> None:
         conn = sqlite3.connect(str(db_path), timeout=1)
         try:
             conn.execute(
-                f"UPDATE procedural_memory "
+                f"UPDATE procedural_memory "  # noqa: S608 - literal SQL fragments; values bound as parameters
                 f"SET surfaced_count = surfaced_count + 1 WHERE id IN ({placeholders})",
                 proc_ids,
             )

--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from genesis.cc.types import CCModel, EffortLevel
 
 if TYPE_CHECKING:
-    pass
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ _READONLY_DISALLOWED = [
 # Hooks fire for ALL sessions including claude -p, so protection is global.
 
 def render_mcp_servers(
-    template_path, genesis_root: str, servers: set[str] | None = None,
+    template_path: Path, genesis_root: str, servers: set[str] | None = None,
 ) -> dict:
     """Render ``config/mcp.json.template`` into an MCP-config dict.
 

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -60,7 +60,7 @@ def _load_bridge_config() -> dict | None:
                 secrets[key.strip()] = value.strip().strip('"')
 
     token = secrets.get("TELEGRAM_BOT_TOKEN", "")
-    if not token or token == "PLACEHOLDER":
+    if not token or token == "PLACEHOLDER":  # noqa: S105 - sentinel placeholder, not a credential
         log.info("TELEGRAM_BOT_TOKEN not set — Telegram adapter will not start")
         return None
 

--- a/src/genesis/channels/voice/wyoming_stt.py
+++ b/src/genesis/channels/voice/wyoming_stt.py
@@ -252,7 +252,7 @@ class WyomingSTTServer:
         *,
         s2s_manager: S2SSessionManager | None = None,
         tts_server: WyomingTTSServer | None = None,
-        host: str = "0.0.0.0",
+        host: str = "0.0.0.0",  # noqa: S104 - Wyoming server must listen on LAN for the Voice PE device
         port: int | None = None,
     ) -> None:
         self._s2s_manager = s2s_manager

--- a/src/genesis/channels/voice/wyoming_tts.py
+++ b/src/genesis/channels/voice/wyoming_tts.py
@@ -173,7 +173,7 @@ class WyomingTTSServer:
     def __init__(
         self,
         *,
-        host: str = "0.0.0.0",
+        host: str = "0.0.0.0",  # noqa: S104 - Wyoming server must listen on LAN for the Voice PE device
         port: int | None = None,
     ) -> None:
         self._host = host

--- a/src/genesis/contribution/findings.py
+++ b/src/genesis/contribution/findings.py
@@ -21,7 +21,7 @@ class Severity(StrEnum):
 class FindingKind(StrEnum):
     """Taxonomy of things the sanitizer can detect."""
 
-    SECRET = "secret"                  # detect-secrets / gitleaks hit  # pragma: allowlist secret
+    SECRET = "secret"                  # detect-secrets / gitleaks hit  # pragma: allowlist secret  # noqa: S105 - enum label for the finding category, not a secret
     PORTABILITY = "portability"        # IPs, hostnames, absolute paths
     FINGERPRINT = "fingerprint"        # user-defined fingerprints
     EMAIL = "email"                    # personal email (outside allowlist)

--- a/src/genesis/dashboard/terminal_session.py
+++ b/src/genesis/dashboard/terminal_session.py
@@ -54,7 +54,7 @@ class TerminalSession:
             if slave > 2:
                 os.close(slave)
             os.chdir(self.cwd)
-            os.execvpe("bash", ["bash", "--login"], env)
+            os.execvpe("bash", ["bash", "--login"], env)  # noqa: S606 - intentional exec of a login shell in the PTY child
         else:
             # ── Parent process ──
             os.close(slave)

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -44,7 +44,7 @@ async def bulk_upsert_events(db: aiosqlite.Connection, rows: list[tuple]) -> int
     placeholders = ", ".join(["?"] * len(COLUMNS))
     set_clause = ", ".join(f"{c}=excluded.{c}" for c in _UPSERT_SET_COLS)
     await db.executemany(
-        f"INSERT INTO attention_events ({', '.join(COLUMNS)}) VALUES ({placeholders}) "  # noqa: S608
+        f"INSERT INTO attention_events ({', '.join(COLUMNS)}) VALUES ({placeholders}) "
         f"ON CONFLICT(id) DO UPDATE SET {set_clause} "
         f"WHERE attention_events.acceptance_signal IS NULL",
         rows,
@@ -121,7 +121,7 @@ async def list_events(
     off = max(0, int(offset))
     params.extend([lim, off])
     cursor = await db.execute(
-        f"SELECT * FROM attention_events{where_sql} "  # noqa: S608
+        f"SELECT * FROM attention_events{where_sql} "
         f"ORDER BY ts DESC LIMIT ? OFFSET ?",
         params,
     )
@@ -185,7 +185,7 @@ async def activation_stats(db: aiosqlite.Connection, config_version: str | None 
     """Per-activation event counts (hard / soft / suppressed) — the fire-rate breakdown."""
     where, params = _cv_clause(config_version)
     cursor = await db.execute(
-        f"SELECT activation, COUNT(*) AS n FROM attention_events{where} GROUP BY activation",  # noqa: S608
+        f"SELECT activation, COUNT(*) AS n FROM attention_events{where} GROUP BY activation",
         params,
     )
     return {r["activation"]: r["n"] for r in await cursor.fetchall()}
@@ -196,7 +196,7 @@ async def trigger_stats(db: aiosqlite.Connection, config_version: str | None = N
     where, params = _cv_clause(config_version, alias="ae")
     cursor = await db.execute(
         "SELECT json_extract(je.value, '$.name') AS name, COUNT(*) AS n "
-        f"FROM attention_events ae, json_each(ae.triggers_fired) je{where} "  # noqa: S608
+        f"FROM attention_events ae, json_each(ae.triggers_fired) je{where} "
         "GROUP BY name ORDER BY n DESC",
         params,
     )
@@ -208,7 +208,7 @@ async def suppressor_stats(db: aiosqlite.Connection, config_version: str | None 
     where, params = _cv_clause(config_version, alias="ae")
     cursor = await db.execute(
         "SELECT je.value AS name, COUNT(*) AS n "
-        f"FROM attention_events ae, json_each(ae.suppressors) je{where} "  # noqa: S608
+        f"FROM attention_events ae, json_each(ae.suppressors) je{where} "
         "GROUP BY name ORDER BY n DESC",
         params,
     )
@@ -219,7 +219,7 @@ async def label_counts(db: aiosqlite.Connection, config_version: str | None = No
     """total / labeled / unlabeled + a by-signal breakdown."""
     where, params = _cv_clause(config_version)
     cursor = await db.execute(
-        f"SELECT acceptance_signal, COUNT(*) AS n FROM attention_events{where} "  # noqa: S608
+        f"SELECT acceptance_signal, COUNT(*) AS n FROM attention_events{where} "
         "GROUP BY acceptance_signal",
         params,
     )

--- a/src/genesis/db/migrations/0015_rename_confusable_call_sites.py
+++ b/src/genesis/db/migrations/0015_rename_confusable_call_sites.py
@@ -61,12 +61,12 @@ async def up(db: aiosqlite.Connection) -> None:
             # would fail with a PK conflict. Delete the old row in that case
             # -- the new-ID row is the authoritative one going forward.
             await db.execute(
-                f"DELETE FROM {table} WHERE call_site_id = ?"
+                f"DELETE FROM {table} WHERE call_site_id = ?"  # noqa: S608 - table name from the fixed _RENAMES loop
                 f"  AND EXISTS (SELECT 1 FROM {table} WHERE call_site_id = ?)",
                 (old_id, new_id),
             )
             await db.execute(
-                f"UPDATE {table} SET call_site_id = ? WHERE call_site_id = ?",
+                f"UPDATE {table} SET call_site_id = ? WHERE call_site_id = ?",  # noqa: S608 - table name from the fixed _RENAMES loop
                 (new_id, old_id),
             )
 
@@ -81,6 +81,6 @@ async def down(db: aiosqlite.Connection) -> None:
             continue
         for old_id, new_id in _RENAMES:
             await db.execute(
-                f"UPDATE {table} SET call_site_id = ? WHERE call_site_id = ?",
+                f"UPDATE {table} SET call_site_id = ? WHERE call_site_id = ?",  # noqa: S608 - table name from the fixed _RENAMES loop
                 (old_id, new_id),
             )

--- a/src/genesis/db/migrations/runner.py
+++ b/src/genesis/db/migrations/runner.py
@@ -398,7 +398,7 @@ class MigrationRunner:
             # `result` is always set: every path in the retry loop either breaks
             # (success / reconciled / terminal failure) or continues to retry, and
             # the final attempt cannot continue.
-            assert result is not None
+            assert result is not None  # noqa: S101 - type-narrowing invariant
             results.append(result)
             if not result.success:
                 break  # Stop on first (terminal) failure

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -285,7 +285,7 @@ class GenesisEgoContextBuilder:
             # not in _USER_WORLD_CATEGORIES that isn't :user tagged.
             exclude_placeholders = ",".join("?" for _ in _USER_WORLD_CATEGORIES)
             cursor = await self._db.execute(
-                f"SELECT id, source, type, category, content, priority, created_at "
+                f"SELECT id, source, type, category, content, priority, created_at "  # noqa: S608 - literal SQL fragments; values bound as parameters
                 f"FROM observations "
                 f"WHERE resolved = 0 "
                 f"AND created_at >= datetime('now', '-48 hours') "

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -1464,7 +1464,7 @@ class UserEgoContextBuilder:
             cat_placeholders = ",".join("?" for _ in _GENESIS_CATEGORIES)
             type_placeholders = ",".join("?" for _ in INTERNAL_OBS_TYPES)
             cursor = await self._db.execute(
-                "SELECT type, category, COUNT(*) AS cnt, "
+                "SELECT type, category, COUNT(*) AS cnt, "  # noqa: S608 - literal SQL fragments; values bound as parameters
                 "  MAX(content) AS sample, MAX(created_at) AS latest "
                 "FROM observations "
                 "WHERE created_at >= datetime('now', '-3 days') "

--- a/src/genesis/eval/db.py
+++ b/src/genesis/eval/db.py
@@ -135,7 +135,7 @@ async def get_runs(
     params.append(limit)
 
     cursor = await db.execute(
-        f"SELECT * FROM eval_runs {where} ORDER BY created_at DESC LIMIT ?",
+        f"SELECT * FROM eval_runs {where} ORDER BY created_at DESC LIMIT ?",  # noqa: S608 - literal SQL fragments; values bound as parameters
         params,
     )
     cols = [d[0] for d in cursor.description]

--- a/src/genesis/eval/runner.py
+++ b/src/genesis/eval/runner.py
@@ -192,7 +192,7 @@ async def run_eval(
             ))
             continue
 
-        assert call_result is not None
+        assert call_result is not None  # noqa: S101 - type-narrowing invariant
         latency_ms = (time.monotonic() - case_start) * 1000
 
         if not call_result.success:

--- a/src/genesis/guardian/alert/telegram.py
+++ b/src/genesis/guardian/alert/telegram.py
@@ -104,8 +104,8 @@ class TelegramAlertChannel(AlertChannel):
         """Synchronous connectivity test."""
         try:
             url = f"{self._api_base}/getMe"
-            req = urllib.request.Request(url, method="GET")
-            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+            req = urllib.request.Request(url, method="GET")  # noqa: S310 - stdlib-only guardian; https endpoint from config
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310 - stdlib-only guardian; https endpoint from config
                 data = json.loads(resp.read())
                 return data.get("ok", False)
         except Exception as exc:
@@ -158,13 +158,13 @@ class TelegramAlertChannel(AlertChannel):
             payload["message_thread_id"] = int(self._thread_id)
 
         data = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
+        req = urllib.request.Request(  # noqa: S310 - stdlib-only guardian; https endpoint from config
             url, data=data, method="POST",
             headers={"Content-Type": "application/json"},
         )
 
         try:
-            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310 - stdlib-only guardian; https endpoint from config
                 result = json.loads(resp.read())
                 if result.get("ok"):
                     msg_id = result.get("result", {}).get("message_id")
@@ -231,7 +231,7 @@ class TelegramAlertChannel(AlertChannel):
             "allowed_updates": [],
         }
         data = json.dumps(payload).encode("utf-8")
-        req = urllib.request.Request(
+        req = urllib.request.Request(  # noqa: S310 - stdlib-only guardian; https endpoint from config
             url, data=data, method="POST",
             headers={"Content-Type": "application/json"},
         )
@@ -242,7 +242,7 @@ class TelegramAlertChannel(AlertChannel):
         socket_timeout = max(self._timeout, timeout_s + 10)
 
         try:
-            with urllib.request.urlopen(req, timeout=socket_timeout) as resp:
+            with urllib.request.urlopen(req, timeout=socket_timeout) as resp:  # noqa: S310 - stdlib-only guardian; https endpoint from config
                 result = json.loads(resp.read())
             if not result.get("ok"):
                 logger.warning("Telegram getUpdates returned not ok: %s", result)

--- a/src/genesis/guardian/briefing.py
+++ b/src/genesis/guardian/briefing.py
@@ -264,7 +264,7 @@ def _build_default_briefing() -> BriefingContent:
             "Awareness loop ticks every 5 minutes — heartbeat canary is tied to it.",
             "Python venv at ~/genesis/.venv. Config at ~/genesis/config/.",
             "Database at ~/genesis/data/genesis.db (SQLite, 60+ tables).",
-            "/tmp shares the root filesystem — avoid large temp file accumulation.",
+            "/tmp shares the root filesystem — avoid large temp file accumulation.",  # noqa: S108 - advisory message text, not a temp path
             "Cgroup memory limit is 24GiB. OOM kills target heaviest process.",
         ],
     )

--- a/src/genesis/guardian/collector.py
+++ b/src/genesis/guardian/collector.py
@@ -313,7 +313,7 @@ async def _collect_cpu(config: GuardianConfig) -> CPUInfo:
 async def _collect_disk(config: GuardianConfig) -> list[DiskInfo]:
     """Collect disk usage for key mount points."""
     disks = []
-    for mount in ["/", "/tmp", "/home"]:
+    for mount in ["/", "/tmp", "/home"]:  # noqa: S108 - monitoring host mounts, not creating temp files
         try:
             rc, out = await _incus_exec(
                 config.container_name,

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -60,7 +60,7 @@ _KEY_MAP_PROVISIONING = {
 # backslashes, unbalanced quotes) the two can diverge, so the escrowed value
 # would not match what encrypted the backup. The generated passphrase is a plain
 # token; keep any hand-set one shell-safe (alphanumeric / base64) to stay sound.
-_PASSPHRASE_FILENAME = "backup_passphrase.env"
+_PASSPHRASE_FILENAME = "backup_passphrase.env"  # noqa: S105 - filename constant, not a passphrase
 _KEY_MAP_PASSPHRASE = {
     "GENESIS_BACKUP_PASSPHRASE": "GENESIS_BACKUP_PASSPHRASE",
 }

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -96,7 +96,7 @@ _MIRROR_SRC_SUBDIRS = ("creds", "secrets")  # subtrees of the Tier-1 clone to mi
 # CLAUDE_CODE_OAUTH_TOKEN into every CONTAINER-side `claude` subprocess and
 # hijack the container's own CC auth. Keeping it out of secrets.env is
 # load-bearing, not tidiness.
-_CC_TOKEN_FILENAME = "cc_oauth_token.env"
+_CC_TOKEN_FILENAME = "cc_oauth_token.env"  # noqa: S105 - filename constant, not a token
 _CC_TOKEN_SOURCE = Path("~/.genesis/cc_oauth_token.env").expanduser()
 _KEY_MAP_CC_TOKEN = {
     "CLAUDE_CODE_OAUTH_TOKEN": "CLAUDE_CODE_OAUTH_TOKEN",

--- a/src/genesis/guardian/dialogue.py
+++ b/src/genesis/guardian/dialogue.py
@@ -142,7 +142,7 @@ async def send_dialogue(
         import urllib.error
         import urllib.request
 
-        req = urllib.request.Request(
+        req = urllib.request.Request(  # noqa: S310 - stdlib-only guardian; https endpoint from config
             url,
             data=payload,
             method="POST",
@@ -155,7 +155,7 @@ async def send_dialogue(
 
         def _do_post() -> tuple[int, str]:
             try:
-                with urllib.request.urlopen(req, timeout=15) as resp:
+                with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310 - stdlib-only guardian; https endpoint from config
                     body = resp.read().decode("utf-8", errors="replace")
                     return resp.status, body
             except urllib.error.HTTPError as exc:

--- a/src/genesis/guardian/health_signals.py
+++ b/src/genesis/guardian/health_signals.py
@@ -126,9 +126,9 @@ def parse_psi_content(content: str) -> dict[str, float]:
 
 def _http_get(url: str, timeout: float = 10.0) -> tuple[int, str]:
     """Synchronous HTTP GET via stdlib. Returns (status_code, body)."""
-    req = urllib.request.Request(url, method="GET")
+    req = urllib.request.Request(url, method="GET")  # noqa: S310 - stdlib-only guardian; https endpoint from config
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - stdlib-only guardian; https endpoint from config
             body = resp.read().decode("utf-8", errors="replace")
             return resp.status, body
     except urllib.error.HTTPError as exc:
@@ -410,7 +410,7 @@ async def check_tick_regularity(config: GuardianConfig) -> SuspiciousResult:
         rc, stdout, stderr = await _run_subprocess(
             "incus", "exec", config.container_name, "--",
             "su", "-", "ubuntu", "-c",
-            f"sqlite3 ~/genesis/data/genesis.db "
+            f"sqlite3 ~/genesis/data/genesis.db "  # noqa: S608 - config int into remote sqlite3 CLI; no binding over incus exec
             f"'SELECT created_at FROM awareness_ticks "
             f"ORDER BY created_at DESC LIMIT {count}'",
             timeout=config.probes.probe_timeout_s,
@@ -522,7 +522,7 @@ async def check_tmp_usage(config: GuardianConfig) -> SuspiciousResult:
     try:
         rc, stdout, stderr = await _run_subprocess(
             "incus", "exec", config.container_name, "--",
-            "df", "--output=pcent", "/tmp",
+            "df", "--output=pcent", "/tmp",  # noqa: S108 - monitoring host /tmp usage, not creating temp files
             timeout=config.probes.probe_timeout_s,
         )
         if rc != 0:

--- a/src/genesis/guardian/provisioning/proxmox.py
+++ b/src/genesis/guardian/provisioning/proxmox.py
@@ -110,9 +110,9 @@ class ProxmoxAdapter(ProvisioningAdapter):
             headers["Content-Type"] = "application/x-www-form-urlencoded"
         elif method == "GET" and params:
             url = f"{url}?{urllib.parse.urlencode(params)}"
-        req = urllib.request.Request(url, data=body, method=method, headers=headers)
+        req = urllib.request.Request(url, data=body, method=method, headers=headers)  # noqa: S310 - stdlib-only guardian; https endpoint from config
         try:
-            with urllib.request.urlopen(
+            with urllib.request.urlopen(  # noqa: S310 - stdlib-only guardian; https endpoint from config
                 req, timeout=self._timeout, context=self._ctx,
             ) as resp:
                 raw = resp.read().decode("utf-8", errors="replace")

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -275,7 +275,7 @@ class RecoveryEngine:
         # Clear /tmp (preserve essential sockets)
         rc, _, stderr = await _run_subprocess(
             "incus", "exec", container, "--",
-            "find", "/tmp", "-type", "f",
+            "find", "/tmp", "-type", "f",  # noqa: S108 - hygiene scan of host /tmp, not temp creation
             "-not", "-name", "*.sock",
             "-mmin", "+5", "-delete",
             timeout=30.0,

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -135,8 +135,8 @@ async def _store_as_is(
     import genesis.mcp.memory_mcp as memory_mod
 
     memory_mod._require_init()
-    assert memory_mod._store is not None
-    assert memory_mod._db is not None
+    assert memory_mod._store is not None  # noqa: S101 - type-narrowing invariant
+    assert memory_mod._db is not None  # noqa: S101 - type-narrowing invariant
 
     from genesis.db.crud import knowledge as knowledge_crud
 

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -388,8 +388,8 @@ class KnowledgeOrchestrator:
         import genesis.mcp.memory_mcp as memory_mod
 
         memory_mod._require_init()
-        assert memory_mod._store is not None
-        assert memory_mod._db is not None
+        assert memory_mod._store is not None  # noqa: S101 - type-narrowing invariant
+        assert memory_mod._db is not None  # noqa: S101 - type-narrowing invariant
 
         import uuid
         from datetime import UTC, datetime

--- a/src/genesis/mcp/health/direct_session_tools.py
+++ b/src/genesis/mcp/health/direct_session_tools.py
@@ -230,7 +230,7 @@ async def _impl_direct_session_list(
             WHERE source_tag = 'direct_session'
             {status_clause}
             ORDER BY started_at DESC
-            LIMIT ?""",
+            LIMIT ?""",  # noqa: S608 - literal SQL fragments; values bound as parameters
         (limit,),
     )
     rows = await cursor.fetchall()

--- a/src/genesis/memory/drift.py
+++ b/src/genesis/memory/drift.py
@@ -150,7 +150,7 @@ async def _identify_clusters(
     query = f"""
         SELECT memory_id, wing, room FROM memory_metadata
         WHERE memory_id IN ({placeholders}) AND wing IS NOT NULL
-    """
+    """  # noqa: S608 - literal SQL fragments; values bound as parameters
     async with db.execute(query, memory_ids) as cursor:
         async for row in cursor:
             wing = row[1]
@@ -219,7 +219,7 @@ async def _local_drilldown(
             wing_query = f"""
                 SELECT memory_id FROM memory_metadata
                 WHERE memory_id IN ({placeholders}) AND wing = ?
-            """
+            """  # noqa: S608 - literal SQL fragments; values bound as parameters
             async with db.execute(wing_query, [*fts_ids, wing]) as cursor:
                 wing_members = {row[0] async for row in cursor}
             fts_ids = [mid for mid in fts_ids if mid in wing_members]

--- a/src/genesis/memory/essential_knowledge.py
+++ b/src/genesis/memory/essential_knowledge.py
@@ -252,7 +252,7 @@ async def _recent_decisions(db: aiosqlite.Connection, days: int = 7) -> list[str
     placeholders = ",".join("?" * len(_EXCLUDED_TYPES))
     try:
         cursor = await db.execute(
-            "SELECT content FROM observations "
+            "SELECT content FROM observations "  # noqa: S608 - literal SQL fragments; values bound as parameters
             f"WHERE type NOT IN ({placeholders}) "
             "AND resolved = 0 "
             "AND created_at > datetime('now', ?) "

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -512,7 +512,7 @@ async def _expired_candidate_ids(
         as_of = datetime.now(UTC).isoformat()
     placeholders = ",".join("?" * len(candidate_ids))
     sql = (
-        f"SELECT memory_id FROM memory_metadata "
+        f"SELECT memory_id FROM memory_metadata "  # noqa: S608 - literal SQL fragments; values bound as parameters
         f"WHERE memory_id IN ({placeholders}) "
         f"AND invalid_at IS NOT NULL AND invalid_at <= ?"
     )

--- a/src/genesis/observability/snapshots/outreach.py
+++ b/src/genesis/observability/snapshots/outreach.py
@@ -26,7 +26,7 @@ async def outreach_stats(db: aiosqlite.Connection | None) -> dict:
                 SUM(CASE WHEN engagement_outcome IN ({_POSITIVE_IN}) THEN 1 ELSE 0 END) as engaged
             FROM outreach_history
             WHERE created_at >= datetime('now', '-7 days')
-              AND category != 'digest'"""
+              AND category != 'digest'"""  # noqa: S608 - literal SQL fragments; values bound as parameters
         )
         row = await cursor.fetchone()
         total = row["total"] if row else 0

--- a/src/genesis/observability/span_reader.py
+++ b/src/genesis/observability/span_reader.py
@@ -52,7 +52,7 @@ async def list_recent_traces(db: aiosqlite.Connection, *, limit: int = 50) -> li
     trace_ids = [r["trace_id"] for r in roots]
     placeholders = ", ".join("?" * len(trace_ids))
     cur = await db.execute(
-        f"SELECT trace_id, COUNT(*) FROM otel_spans "
+        f"SELECT trace_id, COUNT(*) FROM otel_spans "  # noqa: S608 - literal SQL fragments; values bound as parameters
         f"WHERE trace_id IN ({placeholders}) GROUP BY trace_id",
         trace_ids,
     )

--- a/src/genesis/observability/span_writer.py
+++ b/src/genesis/observability/span_writer.py
@@ -36,7 +36,7 @@ _COLS = (
     "input_tokens", "output_tokens", "cost_usd", "cost_known", "attributes_json",
 )
 _INSERT = (
-    f"INSERT OR IGNORE INTO otel_spans ({', '.join(_COLS)}) "
+    f"INSERT OR IGNORE INTO otel_spans ({', '.join(_COLS)}) "  # noqa: S608 - column names from the fixed _COLS list; values are placeholders
     f"VALUES ({', '.join('?' * len(_COLS))})"
 )
 

--- a/src/genesis/workflows/executor.py
+++ b/src/genesis/workflows/executor.py
@@ -166,7 +166,7 @@ def execute_deterministic_step(
     if not step.command:
         return False, "No command specified"
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S602 - user-authored workflow commands run behind the approval gate
             step.command,
             shell=True,  # noqa: S602 — trusted YAML source, see docstring
             capture_output=True,

--- a/src/genesis/workflows/executor.py
+++ b/src/genesis/workflows/executor.py
@@ -166,9 +166,9 @@ def execute_deterministic_step(
     if not step.command:
         return False, "No command specified"
     try:
-        result = subprocess.run(  # noqa: S602 - user-authored workflow commands run behind the approval gate
+        result = subprocess.run(  # noqa: S602 - trusted YAML from ~/.genesis/workflows/ only, see docstring
             step.command,
-            shell=True,  # noqa: S602 — trusted YAML source, see docstring
+            shell=True,
             capture_output=True,
             text=True,
             cwd=cwd,

--- a/tests/test_hooks/test_edit_verify_advisory.py
+++ b/tests/test_hooks/test_edit_verify_advisory.py
@@ -1,0 +1,131 @@
+"""Tests for scripts/hooks/edit_verify_advisory.py (PostToolUse Edit|Write).
+
+The hook is run as a real subprocess with fixture stdin JSON — the same shape
+Claude Code delivers — so these tests cover the actual contract: mutate via
+ruff format/autofix, report ONLY unfixable diagnostics via the PostToolUse
+``hookSpecificOutput.additionalContext`` JSON channel, and fail open (exit 0)
+on every malformed or out-of-scope input.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent.parent
+HOOK = REPO_DIR / "scripts" / "hooks" / "edit_verify_advisory.py"
+
+
+def _run_hook(stdin_text: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _invoke(file_path: str, tool_name: str = "Edit") -> subprocess.CompletedProcess:
+    payload = {
+        "tool_name": tool_name,
+        "tool_input": {"file_path": file_path},
+        "session_id": "test-session",
+    }
+    return _run_hook(json.dumps(payload))
+
+
+def _context_of(proc: subprocess.CompletedProcess) -> str | None:
+    if not proc.stdout.strip():
+        return None
+    out = json.loads(proc.stdout)
+    return out["hookSpecificOutput"]["additionalContext"]
+
+
+def test_autofixable_only_is_silent_and_mutates(tmp_path):
+    """Import order + spacing are fixed on disk; nothing is reported."""
+    f = tmp_path / "fixable.py"
+    f.write_text("import sys\nimport os\n\nprint(os.name, sys.argv)\n")
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+    assert f.read_text().startswith("import os\nimport sys\n")
+
+
+def test_unfixable_diagnostic_reported_as_additional_context(tmp_path):
+    f = tmp_path / "broken.py"
+    f.write_text("def f(x):\n    return undefined_name\n")
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    ctx = _context_of(proc)
+    assert ctx is not None
+    assert "F821" in ctx
+    assert "[ruff advisory]" in ctx
+    assert "Advisory only" in ctx  # never framed as blocking
+
+
+def test_write_tool_also_covered(tmp_path):
+    f = tmp_path / "broken.py"
+    f.write_text("def f():\n    return undefined_name\n")
+    proc = _invoke(str(f), tool_name="Write")
+    assert proc.returncode == 0
+    assert _context_of(proc) is not None
+
+
+def test_diagnostic_cap_honored(tmp_path):
+    """A file with many unfixable issues reports at most the cap + a marker."""
+    lines = [f"def f{i}():\n    return undef_{i}\n" for i in range(20)]
+    f = tmp_path / "many.py"
+    f.write_text("\n".join(lines))
+    proc = _invoke(str(f))
+    ctx = _context_of(proc)
+    assert ctx is not None
+    diag_lines = [ln for ln in ctx.splitlines() if ":" in ln and "F821" in ln]
+    assert len(diag_lines) <= 12
+    assert "more" in ctx
+
+
+def test_non_python_file_silent(tmp_path):
+    f = tmp_path / "notes.md"
+    f.write_text("# hello\n")
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_missing_file_silent(tmp_path):
+    proc = _invoke(str(tmp_path / "nope.py"))
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_other_tools_silent(tmp_path):
+    f = tmp_path / "broken.py"
+    f.write_text("def f():\n    return undefined_name\n")
+    proc = _invoke(str(f), tool_name="Read")
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_malformed_stdin_fails_open():
+    for bad in ("", "not json", '{"tool_name": "Edit"}', '{"tool_input": 5}'):
+        proc = _run_hook(bad)
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+
+def test_registered_in_settings_json():
+    """The Edit|Write PostToolUse matcher runs THIS script (replacing the old
+    inline silent fixer) — one hook, because parallel hooks on the same
+    matcher would race the autofix."""
+    settings = json.loads((REPO_DIR / ".claude" / "settings.json").read_text())
+    entries = [
+        e for e in settings["hooks"]["PostToolUse"]
+        if e.get("matcher") in ("Edit|Write", "Write|Edit")
+    ]
+    commands = [h["command"] for e in entries for h in e["hooks"]]
+    advisory = [c for c in commands if "edit_verify_advisory.py" in c]
+    assert len(advisory) == 1
+    assert not any("ruff" in c for c in commands if "edit_verify_advisory" not in c)


### PR DESCRIPTION
PR-1 of the dev-quality inner-loop program (verification moves inside the generation loop).

## What

1. **Advisory edit-time verifier** — `scripts/hooks/edit_verify_advisory.py` replaces the inline silent ruff autofix hook in `.claude/settings.json`. Same mutations (format + `check --fix`), then unfixable diagnostics reach the session as PostToolUse `additionalContext` (previously swallowed). Advisory by contract: never blocks, fails open; enforcement stays at the commit gate + CI. One hook, not fixer+reporter — CC runs matching hooks in parallel, so a separate reporter would race the autofix.
2. **ruff `S` (flake8-bandit) enabled repo-wide** — 23,407 raw findings triaged to zero: documented global ignores (S603/S607 every-subprocess noise; S110/S112 best-effort-telemetry convention — the review layer owns swallowed-error judgment, an explicitly accepted trade; S311 all timing jitter, grep-verified no credential generation via `random`), per-file-ignores (test fixtures; the parametrized WHERE-builder pattern in db/crud + dashboard routes; mcp/memory type-narrowing asserts), and 48 individually eyeballed inline noqas each with a one-line justification. **S602 (`shell=True`) stays enabled repo-wide.** semgrep evaluation deferred (follow-up).
3. **Review-protocol graft** into `.claude/agents/genesis-architect.md` + the genesis-development skill: BLOCKER/SHOULD-FIX/NOTE severity ladder (written down for the first time, with Codex P-level and surplus-auditor mappings), pre-emit quote gate (findings must quote their motivating file:line or get confidence-capped), scope-drift check with plan-item cross-reference, prior-learnings pass via procedure_recall/store, and DONE/DONE_WITH_CONCERNS/BLOCKED/NEEDS_CONTEXT completion statuses. Adapted from the gstack review framework — protocol only, no gstack plumbing.
4. `render_mcp_servers` `template_path: Path` annotation (deferred #978 NOTE).

## Review

Inline review ran UNDER the new protocol (E2E of the graft itself): scope check CLEAN, 1 BLOCKER + 3 SHOULD-FIX found and fixed in `486736c9` — including ruff missing from the CI test extra (the new tests execute the real hook) and the hook `timeout` field being seconds, not ms, per the CC hooks docs (pre-existing repo-wide ms-convention values filed as a follow-up).

## Accepted risks

- The advisory fires on .py files outside the repo too (parity with the old hook's mutation scope); the footer's non-blocking framing + 12-line cap bound the noise. Regression watch: sessions drifting into unrelated lint cleanup within the first week → tune the footer wording.
- S110/S112 + S311 global ignores are an honest documented trade, not cleanup; per-file re-enablement outside scripts/ is a filed follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)