### PR TITLE
feat(security): WS-3 B0 — origin_class provenance taxonomy + ws3_immunity kill switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Every memory now carries a provenance class — and immunity gets its kill
+  switch before it gets its gates.** Everything Genesis stores is stamped
+  `owner`, `first_party`, or `external_untrusted` at write time (your words /
+  Genesis's own observations / content pulled off the world, including
+  ingested documents), with all existing memories backfilled. This is the
+  foundation for the WS-3 immunity gates: crafted external content becomes
+  blockable from turning into procedures, identity edits, or autonomy
+  evidence by *origin*, not content guessing. The control surface ships
+  first: a live-editable `ws3_immunity` settings domain (master switch +
+  per-gate off/shadow/enforce) that takes effect instantly with no restart —
+  and owner/first-party content can never be blocked in any mode, by
+  construction. No gates are active yet; they arrive in the next phase, in
+  observe-only shadow mode.
+
 - **`genesis eval bench` — a Genesis-vs-bare-Claude A/B benchmark you can run
   in one command.** Each task in a private task set runs through two arms: a
   cognition-enabled Genesis session (identity + read-only recall from your

--- a/config/ws3_immunity.yaml
+++ b/config/ws3_immunity.yaml
@@ -1,0 +1,34 @@
+# WS-3 Immunity kill switch — writable + LIVE (no restart needed).
+#
+# Consumers (genesis.security.immunity) re-read the merged config (this file
+# + ~/.genesis/config/ws3_immunity.local.yaml) on EVERY call, so a
+# settings_update("ws3_immunity", {...}) or a hand edit of the overlay takes
+# effect instantly in the running server.
+#
+# Master switch: false short-circuits every gate to "off" immediately.
+enabled: true
+
+# Per-gate mode: off | shadow | enforce
+#   off     — the gate does nothing
+#   shadow  — the gate evaluates and logs a would-block, but never blocks
+#   enforce — the gate blocks external_untrusted content
+#
+# Owner and first_party content is NEVER blocked in any mode — a tested
+# invariant (genesis.security.immunity.is_blockable), which caps the worst
+# case of an over-eager gate at "refuses external content".
+#
+# B0 ships this control surface only; the gates themselves land in B1 and
+# are born in shadow.
+procedure: {mode: shadow}   # external content -> procedure promotion
+identity: {mode: shadow}    # external content -> identity/user-model writes
+autonomy: {mode: shadow}    # external content -> capability-grant evidence
+injection: {mode: shadow}   # external content -> write-capable session context
+
+# Auto-demote monitor (B0: scaffold only, wired in B1): on a first-party
+# would-block spike a gate demotes enforce -> shadow (never off, never
+# escalate) and alerts loudly. Demotion state is written into the .local.yaml
+# overlay under auto_demote_state so state and behavior share one file.
+auto_demote:
+  enabled: true
+  window_minutes: 60
+  would_block_threshold: 5

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -36,7 +36,7 @@ side.
 ```yaml subsystem-map
 entry: memory
 modules: [memory, qdrant]
-verified: 3c6cf249 2026-07-09
+verified: 36563f95 2026-07-10
 ```
 
 **Retrieval is TIERED — the hottest auto-fired paths carry the thinnest
@@ -93,6 +93,17 @@ additive layer, not a leak.
 **Do not touch:** the drain's shadow hardwiring; the dry_run-independent link
 write. **Trap:** with no embedding provider registered, memory silently
 degrades to FTS5-only (see routing-providers entry).
+
+**origin_class (WS-3 B0):** every store stamps
+`owner | first_party | external_untrusted` into the Qdrant payload,
+`memory_metadata`, and (KB paths) `knowledge_units` — derived in
+`provenance.derive_origin_class` (explicit kwarg wins; external pipelines
+outrank `source_subsystem`; `curated` is external BY DECISION — authority
+tier, not authorship). Store-time derivation is conservative-first-party for
+unknown internal writers; the fail-closed unknown→external rule lives only
+at gate time (`security/immunity.py`). Migration 0053 backfilled history
+(no owner heuristics); `scripts/backfill_origin_class_qdrant.py` mirrors the
+payloads idempotently.
 
 ## 2. Execution — CC sessions (DirectSession)
 
@@ -505,7 +516,7 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, env.py, _config_overlay.py]
-verified: 9037d45b 2026-07-07
+verified: 36563f95 2026-07-10
 ```
 
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
@@ -538,7 +549,16 @@ verified: 9037d45b 2026-07-07
   LOG-ONLY for internal sources (perimeter EMAIL/INBOX can block);
   `output_scanner` = deterministic outbound secrets/IP scan; `skill_scan`
   shells to external NVIDIA SkillSpector. NOT auth or secrets storage (that's
-  `runtime/init/secrets.py` + `env.py`).
+  `runtime/init/secrets.py` + `env.py`). **`immunity.py` = the WS-3 kill
+  switch (control surface LIVE, gates NOT built — B1)**: `gate_mode()`
+  re-reads `config/ws3_immunity.yaml` + its `.local.yaml` overlay per call
+  (no cache, no restart — the `ws3_immunity` settings domain is writable);
+  master `enabled: false` short-circuits every gate; `is_blockable()` is the
+  never-block-owner/first-party invariant every B1 gate must route through;
+  the gate-time fail-closed unknown→external rule lives ONLY in
+  `effective_origin_class()` (store-time derivation never fail-closes).
+  Auto-demote state is written INTO the overlay so state and behavior share
+  one file.
 - **codebase/**: AST indexer (surplus task, set-difference deletes with
   CASCADE) behind the `codebase_navigate` MCP tool.
 - **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h

--- a/scripts/backfill_origin_class_qdrant.py
+++ b/scripts/backfill_origin_class_qdrant.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Backfill ``origin_class`` onto existing Qdrant payloads (WS-3 B0).
+
+Migration 0053 backfilled SQLite (memory_metadata + knowledge_units); Qdrant
+payloads of pre-existing points still lack the key. This script mirrors the
+SQLite truth onto the vectors via ``set_payload`` (MERGES fields — vectors
+and other payload fields untouched).
+
+Safe to lag / re-run:
+- Nothing reads the payload key in B0, and B1's reader falls back to SQLite
+  and normalizes missing values fail-closed at gate time.
+- Idempotent: points that already carry ``origin_class`` are skipped, so a
+  second run reports 0 updates.
+- SQLite is authoritative (post-0053 every row is classified); a Qdrant
+  point with no metadata row falls back to deriving from its own payload
+  (source_pipeline / source_subsystem / collection).
+
+Usage:
+    source ~/genesis/.venv/bin/activate
+    python scripts/backfill_origin_class_qdrant.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import httpx
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from genesis.env import genesis_db_path, qdrant_url  # noqa: E402
+from genesis.memory.provenance import derive_origin_class  # noqa: E402
+
+QDRANT_URL = qdrant_url()
+COLLECTIONS = ("episodic_memory", "knowledge_base")
+BATCH = 500
+
+
+def _scroll_missing(client: httpx.Client, collection: str) -> list[dict]:
+    """Scroll all points, returning those WITHOUT origin_class."""
+    points: list[dict] = []
+    offset = None
+    while True:
+        body: dict = {
+            "limit": 1000,
+            "with_payload": ["origin_class", "source_pipeline", "source_subsystem"],
+        }
+        if offset is not None:
+            body["offset"] = offset
+        resp = client.post(
+            f"{QDRANT_URL}/collections/{collection}/points/scroll", json=body,
+        )
+        resp.raise_for_status()
+        result = resp.json()["result"]
+        for p in result["points"]:
+            if not (p.get("payload") or {}).get("origin_class"):
+                points.append(p)
+        offset = result.get("next_page_offset")
+        if offset is None:
+            return points
+
+
+def _sqlite_classes(db: sqlite3.Connection, ids: list[str]) -> dict[str, str]:
+    """memory_metadata.origin_class for the given point ids (authoritative)."""
+    out: dict[str, str] = {}
+    for i in range(0, len(ids), 900):  # SQLite bound-parameter limit headroom
+        chunk = ids[i : i + 900]
+        placeholders = ",".join("?" * len(chunk))
+        rows = db.execute(
+            f"SELECT memory_id, origin_class FROM memory_metadata "  # noqa: S608 - IN-list placeholders; ids bound
+            f"WHERE memory_id IN ({placeholders}) AND origin_class IS NOT NULL",
+            chunk,
+        ).fetchall()
+        out.update(dict(rows))
+    return out
+
+
+def _set_payload(
+    client: httpx.Client, collection: str, ids: list[str], origin: str,
+) -> None:
+    for i in range(0, len(ids), BATCH):
+        resp = client.post(
+            f"{QDRANT_URL}/collections/{collection}/points/payload?wait=true",
+            json={"payload": {"origin_class": origin}, "points": ids[i : i + BATCH]},
+        )
+        resp.raise_for_status()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    totals: Counter[str] = Counter()
+    with httpx.Client(timeout=60) as client:
+        for collection in COLLECTIONS:
+            missing = _scroll_missing(client, collection)
+            print(f"{collection}: {len(missing)} points missing origin_class")
+            if not missing:
+                continue
+            ids = [str(p["id"]) for p in missing]
+            sqlite_map = _sqlite_classes(db, ids)
+            by_class: dict[str, list[str]] = defaultdict(list)
+            for p in missing:
+                pid = str(p["id"])
+                payload = p.get("payload") or {}
+                origin = sqlite_map.get(pid) or derive_origin_class(
+                    source_pipeline=payload.get("source_pipeline"),
+                    source_subsystem=payload.get("source_subsystem"),
+                    collection=collection,
+                )
+                by_class[origin].append(pid)
+            for origin, class_ids in sorted(by_class.items()):
+                orphans = sum(1 for pid in class_ids if pid not in sqlite_map)
+                print(
+                    f"  {origin}: {len(class_ids)} points"
+                    + (f" ({orphans} via payload fallback, no metadata row)" if orphans else "")
+                )
+                totals[origin] += len(class_ids)
+                if not args.dry_run:
+                    _set_payload(client, collection, class_ids, origin)
+    db.close()
+    verb = "would update" if args.dry_run else "updated"
+    print(f"Done: {verb} {sum(totals.values())} points — {dict(totals)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1198,6 +1198,9 @@ async def _try_ego_correction_store(ctx: HandlerContext, msg) -> bool:
                 memory_type="episodic",
                 wing="autonomy",
                 room="ego",
+                # WS-3: the content IS the owner's own message text — the
+                # one store() call site where "owner" is directly traceable.
+                origin_class="owner",
             )
             log.info("Stored ego user correction (%d chars)", len(msg.text))
             try:

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -45,6 +45,7 @@ async def insert(
     source_pipeline: str | None = None,
     purpose: str | None = None,
     ingestion_source: str | None = None,
+    origin_class: str | None = None,
     _commit: bool = True,
 ) -> str:
     """Insert a knowledge unit into both knowledge_units and knowledge_fts. Returns id.
@@ -59,12 +60,12 @@ async def insert(
            (id, project_type, domain, source_doc, source_platform, section_title,
             concept, body, relationships, caveats, tags, confidence,
             source_date, ingested_at, qdrant_id, embedding_model,
-            source_pipeline, purpose, ingestion_source)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            source_pipeline, purpose, ingestion_source, origin_class)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (unit_id, project_type, domain, source_doc, source_platform, section_title,
          concept, body, relationships, caveats, tags, confidence,
          source_date, now_iso, qdrant_id, embedding_model,
-         source_pipeline, purpose, ingestion_source),
+         source_pipeline, purpose, ingestion_source, origin_class),
     )
 
     await db.execute(

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -138,6 +138,7 @@ async def upsert(
     source_pipeline: str | None = None,
     purpose: str | None = None,
     ingestion_source: str | None = None,
+    origin_class: str | None = None,
     _commit: bool = True,
 ) -> tuple[str, bool]:
     """Insert or update a knowledge unit keyed on (project_type, domain, concept).
@@ -174,8 +175,8 @@ async def upsert(
            (id, project_type, domain, source_doc, source_platform, section_title,
             concept, body, relationships, caveats, tags, confidence,
             source_date, ingested_at, qdrant_id, embedding_model,
-            source_pipeline, purpose, ingestion_source)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            source_pipeline, purpose, ingestion_source, origin_class)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(project_type, domain, concept) DO UPDATE SET
                source_doc      = excluded.source_doc,
                source_platform = excluded.source_platform,
@@ -191,11 +192,12 @@ async def upsert(
                embedding_model = excluded.embedding_model,
                source_pipeline = excluded.source_pipeline,
                purpose         = excluded.purpose,
-               ingestion_source = excluded.ingestion_source""",
+               ingestion_source = excluded.ingestion_source,
+               origin_class    = excluded.origin_class""",
         (unit_id, project_type, domain, source_doc, source_platform, section_title,
          concept, body, relationships, caveats, tags, confidence,
          source_date, now_iso, qdrant_id, embedding_model,
-         source_pipeline, purpose, ingestion_source),
+         source_pipeline, purpose, ingestion_source, origin_class),
     )
 
     # Find the row that actually lives in the table — either the one we

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -255,6 +255,7 @@ async def create_metadata(
     valid_at: str | None = None,
     invalid_at: str | None = None,
     source_subsystem: str | None = None,
+    origin_class: str | None = None,
 ) -> str:
     """Insert a row into memory_metadata. Returns memory_id.
 
@@ -264,6 +265,10 @@ async def create_metadata(
     ``source_subsystem`` tags writes from automated subsystems (ego,
     triage, reflection) so foreground recall can default-filter them.
     NULL = user-sourced.
+    ``origin_class`` is the WS-3 provenance taxonomy
+    (owner/first_party/external_untrusted), derived in
+    ``MemoryStore.store()``; NULL = legacy/unclassified (gates treat it
+    fail-closed at gate time).
     """
     # Bitemporal columns are raw TEXT-compared everywhere — canonicalize
     # at the write gate. Unparseable valid_at (LLM temporal strings like
@@ -276,11 +281,12 @@ async def create_metadata(
     await db.execute(
         "INSERT OR IGNORE INTO memory_metadata "
         "(memory_id, created_at, collection, confidence, embedding_status, "
-        "memory_class, wing, room, valid_at, invalid_at, source_subsystem) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "memory_class, wing, room, valid_at, invalid_at, source_subsystem, "
+        "origin_class) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (memory_id, created_at, collection, confidence, embedding_status,
          memory_class, wing, room, resolved_valid_at,
-         canonical_iso(invalid_at), source_subsystem),
+         canonical_iso(invalid_at), source_subsystem, origin_class),
     )
     await db.commit()
     return memory_id

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -365,24 +365,25 @@ async def get_taxonomy(
     db: aiosqlite.Connection,
     memory_id: str,
 ) -> dict[str, str | None] | None:
-    """Return ``{"wing", "room"}`` for a memory_id, or None if no row.
+    """Return ``{"wing", "room", "origin_class"}`` for a memory_id, or None.
 
-    The embedding-recovery worker uses this to restore the faceting
-    fields onto the reconstructed Qdrant payload (see
-    ``resilience/embedding_recovery``) so a recovered point is not
-    silently dropped from ``wing=``/``room=`` filtered recall. Only
-    ``wing`` and ``room`` are metadata columns; ``life_domain`` is
-    recovered from the ``life_domain:`` tag and ``project_type`` is not
-    persisted on this path.
+    The embedding-recovery worker uses this to restore metadata fields onto
+    the reconstructed Qdrant payload (see ``resilience/embedding_recovery``)
+    so a recovered point is not silently dropped from ``wing=``/``room=``
+    filtered recall — nor (WS-3) from ``origin_class=`` filtered gates.
+    ``origin_class`` is read from ``memory_metadata`` (always written at
+    store time, even on the FTS5-only/pending path) rather than the pending
+    row, keeping ONE source of truth. ``life_domain`` is recovered from the
+    ``life_domain:`` tag and ``project_type`` is not persisted on this path.
     """
     rows = await db.execute_fetchall(
-        "SELECT wing, room FROM memory_metadata WHERE memory_id = ?",
+        "SELECT wing, room, origin_class FROM memory_metadata WHERE memory_id = ?",
         (memory_id,),
     )
     row = rows[0] if rows else None
     if not row:
         return None
-    return {"wing": row[0], "room": row[1]}
+    return {"wing": row[0], "room": row[1], "origin_class": row[2]}
 
 
 async def batch_created_at(

--- a/src/genesis/db/migrations/0053_origin_class.py
+++ b/src/genesis/db/migrations/0053_origin_class.py
@@ -1,0 +1,87 @@
+"""Add ``origin_class`` (WS-3 provenance taxonomy) + deterministic backfill.
+
+``origin_class ∈ {owner, first_party, external_untrusted}`` is stamped at
+store time (see ``genesis.memory.provenance.derive_origin_class``); future
+immunity gates key on ``external_untrusted`` vs not. Column is NULLable —
+NULL means "written before this migration by a path the backfill couldn't
+classify"; gates normalize NULL fail-closed at GATE time, so nullable is
+safe and the ADD COLUMN stays O(1) metadata-only (a NOT NULL DEFAULT would
+rewrite ~54K rows twice).
+
+Backfill is deterministic from columns that already exist, and deliberately
+emits only first_party/external_untrusted — the owner signal is weak in
+historical rows and is NEVER heuristically backfilled (binding WS-3
+decision):
+
+- knowledge_units: Genesis-authored pipelines (surplus, reference_store,
+  extraction_job) → first_party; every other KB unit (curated uploads/URLs,
+  knowledge_ingest*, recon, NULL-pipeline legacy) is world-derived text →
+  external_untrusted.
+- memory_metadata outside the knowledge_base collection → first_party
+  (episodic/self content; matches provenance.is_external's stance).
+- memory_metadata IN knowledge_base → the joined knowledge_units row's
+  class via qdrant_id, else external_untrusted (conservative for KB).
+
+All UPDATEs are guarded ``WHERE origin_class IS NULL`` → idempotent.
+Fresh/test DBs get the column from the canonical CREATE TABLE in
+``db/schema/_tables.py``; this migration covers the existing-DB path.
+No commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_FIRST_PARTY_KU_PIPELINES = ("surplus", "reference_store", "extraction_job")
+
+
+async def _has_table(db: aiosqlite.Connection, name: str) -> bool:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    )
+    return await cursor.fetchone() is not None
+
+
+async def _ensure_column(db: aiosqlite.Connection, table: str) -> None:
+    col_cursor = await db.execute(f"PRAGMA table_info({table})")  # noqa: S608 - fixed table names from this module only
+    cols = {row[1] for row in await col_cursor.fetchall()}
+    if "origin_class" not in cols:
+        await db.execute(
+            f"ALTER TABLE {table} ADD COLUMN origin_class TEXT"  # noqa: S608 - fixed table names from this module only
+        )
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    has_ku = await _has_table(db, "knowledge_units")
+    has_mm = await _has_table(db, "memory_metadata")
+
+    if has_ku:
+        await _ensure_column(db, "knowledge_units")
+        placeholders = ",".join("?" * len(_FIRST_PARTY_KU_PIPELINES))
+        await db.execute(
+            "UPDATE knowledge_units SET origin_class = CASE "
+            f"  WHEN source_pipeline IN ({placeholders}) THEN 'first_party' "  # noqa: S608 - placeholders for a fixed literal tuple
+            "  ELSE 'external_untrusted' END "
+            "WHERE origin_class IS NULL",
+            _FIRST_PARTY_KU_PIPELINES,
+        )
+
+    if has_mm:
+        await _ensure_column(db, "memory_metadata")
+        await db.execute(
+            "UPDATE memory_metadata SET origin_class = 'first_party' "
+            "WHERE origin_class IS NULL AND collection != 'knowledge_base'"
+        )
+        if has_ku:
+            await db.execute(
+                "UPDATE memory_metadata SET origin_class = COALESCE("
+                "  (SELECT ku.origin_class FROM knowledge_units ku"
+                "   WHERE ku.qdrant_id = memory_metadata.memory_id),"
+                "  'external_untrusted') "
+                "WHERE origin_class IS NULL AND collection = 'knowledge_base'"
+            )
+        else:
+            await db.execute(
+                "UPDATE memory_metadata SET origin_class = 'external_untrusted' "
+                "WHERE origin_class IS NULL AND collection = 'knowledge_base'"
+            )

--- a/src/genesis/db/migrations/0053_table_inbox_watch_markers.py
+++ b/src/genesis/db/migrations/0053_table_inbox_watch_markers.py
@@ -31,7 +31,7 @@ _WHERE = (
 
 async def up(db: aiosqlite.Connection) -> None:
     await db.execute(
-        f"UPDATE follow_ups SET kind = 'tabled' "
+        f"UPDATE follow_ups SET kind = 'tabled' "  # noqa: S608 - _WHERE is a literal constant, no user input
         f"WHERE {_WHERE} AND kind = 'follow_up'"
     )
 

--- a/src/genesis/db/migrations/0054_origin_class.py
+++ b/src/genesis/db/migrations/0054_origin_class.py
@@ -59,8 +59,8 @@ async def up(db: aiosqlite.Connection) -> None:
         await _ensure_column(db, "knowledge_units")
         placeholders = ",".join("?" * len(_FIRST_PARTY_KU_PIPELINES))
         await db.execute(
-            "UPDATE knowledge_units SET origin_class = CASE "
-            f"  WHEN source_pipeline IN ({placeholders}) THEN 'first_party' "  # noqa: S608 - placeholders for a fixed literal tuple
+            "UPDATE knowledge_units SET origin_class = CASE "  # noqa: S608 - literal SQL; the IN placeholders are bound params
+            f"  WHEN source_pipeline IN ({placeholders}) THEN 'first_party' "
             "  ELSE 'external_untrusted' END "
             "WHERE origin_class IS NULL",
             _FIRST_PARTY_KU_PIPELINES,

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -833,6 +833,7 @@ TABLES = {
             source_pipeline  TEXT,
             purpose          TEXT,
             ingestion_source TEXT,
+            origin_class     TEXT,
             UNIQUE(project_type, domain, concept)
         )
     """,
@@ -1125,7 +1126,8 @@ TABLES = {
             invalid_at       TEXT,
             source_subsystem TEXT,
             deprecated       INTEGER NOT NULL DEFAULT 0,
-            dream_cycle_run_id TEXT
+            dream_cycle_run_id TEXT,
+            origin_class     TEXT
         )
     """,
     "code_modules": """

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -181,6 +181,13 @@ async def _store_as_is(
         tags.append("user-context")
 
     # Store to Qdrant
+    # WS-3: curated ingest is external_untrusted (authority tier, not
+    # authorship); derived once, mirrored to both stores.
+    from genesis.memory.provenance import derive_origin_class
+
+    resolved_origin = derive_origin_class(
+        source_pipeline="curated", collection="knowledge_base",
+    )
     qdrant_id = await memory_mod._store.store(
         file_content,
         f"knowledge:{project_type}/{effective_domain}",
@@ -190,6 +197,7 @@ async def _store_as_is(
         confidence=0.95,
         auto_link=False,
         source_pipeline="curated",
+        origin_class=resolved_origin,
     )
 
     # Store to SQLite
@@ -213,6 +221,7 @@ async def _store_as_is(
         source_pipeline="curated",
         purpose=purpose_json,
         ingestion_source=file_path,
+        origin_class=resolved_origin,
         _commit=True,
     )
 

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -417,6 +417,13 @@ class KnowledgeOrchestrator:
                 old_qdrant_id = existing.get("qdrant_id") if existing else None
 
                 # Store to Qdrant via MemoryStore (non-transactional, immediate)
+                # WS-3: curated ingest is external_untrusted (authority tier,
+                # not authorship); derived once, mirrored to both stores.
+                from genesis.memory.provenance import derive_origin_class
+
+                resolved_origin = derive_origin_class(
+                    source_pipeline="curated", collection="knowledge_base",
+                )
                 qdrant_id = await memory_mod._store.store(
                     unit.body,
                     f"knowledge:{project_type}/{unit.domain}",
@@ -426,6 +433,7 @@ class KnowledgeOrchestrator:
                     confidence=unit.confidence,
                     auto_link=False,
                     source_pipeline="curated",
+                    origin_class=resolved_origin,
                 )
                 qdrant_ids.append(qdrant_id)
 
@@ -464,6 +472,7 @@ class KnowledgeOrchestrator:
                     source_pipeline="curated",
                     purpose=purpose_json,
                     ingestion_source=source,
+                    origin_class=resolved_origin,
                     _commit=False,
                 )
 

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -61,6 +61,19 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # read live per-invocation by genesis.cc.roster
     ),
+    "ws3_immunity": SettingsDomain(
+        name="ws3_immunity",
+        description=(
+            "WS-3 immunity kill switch — master `enabled` + per-gate "
+            "off/shadow/enforce for procedure/identity/autonomy/injection. "
+            "Read live per-call by genesis.security.immunity (no restart); "
+            "owner/first-party content is never blocked in any mode."
+        ),
+        config_filename="ws3_immunity.yaml",
+        readonly=False,
+        needs_restart=False,  # read live per-call by genesis.security.immunity
+        hidden_fields=frozenset({"auto_demote_state"}),
+    ),
     "resilience": SettingsDomain(
         name="resilience",
         description="Resilience thresholds (flapping detection, recovery, CC rate limits)",
@@ -674,8 +687,47 @@ def _validate_cc_roster(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_ws3_immunity(changes: dict) -> list[str]:
+    """Validate ws3_immunity kill-switch changes (see genesis.security.immunity)."""
+    from genesis.security.immunity import GATES, MODES
+
+    errors: list[str] = []
+    valid_top_keys = {"enabled", "auto_demote", "auto_demote_state", *GATES}
+    for key, value in changes.items():
+        if key not in valid_top_keys:
+            errors.append(
+                f"Unknown key '{key}'. Valid: {', '.join(sorted(valid_top_keys))}"
+            )
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key in GATES:
+            if not isinstance(value, dict):
+                errors.append(f"'{key}' must be a mapping like {{mode: shadow}}")
+            elif value.get("mode") not in MODES:
+                errors.append(
+                    f"'{key}.mode' must be one of {', '.join(MODES)}; "
+                    f"got {value.get('mode')!r}"
+                )
+        elif key == "auto_demote":
+            if not isinstance(value, dict):
+                errors.append("'auto_demote' must be a mapping")
+            else:
+                if "enabled" in value and not isinstance(value["enabled"], bool):
+                    errors.append("'auto_demote.enabled' must be a boolean")
+                for int_key in ("window_minutes", "would_block_threshold"):
+                    if int_key in value and (
+                        not isinstance(value[int_key], int) or value[int_key] <= 0
+                    ):
+                        errors.append(f"'auto_demote.{int_key}' must be a positive int")
+        # auto_demote_state: written by immunity.record_demotion via this
+        # same overlay; accepted opaquely (hidden from the UI).
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "tts": _validate_tts,
+    "ws3_immunity": _validate_ws3_immunity,
     "cc_roster": _validate_cc_roster,
     "resilience": _validate_resilience,
     "inbox_monitor": _validate_inbox_monitor,

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -717,7 +717,9 @@ def _validate_ws3_immunity(changes: dict) -> list[str]:
                     errors.append("'auto_demote.enabled' must be a boolean")
                 for int_key in ("window_minutes", "would_block_threshold"):
                     if int_key in value and (
-                        not isinstance(value[int_key], int) or value[int_key] <= 0
+                        not isinstance(value[int_key], int)
+                        or isinstance(value[int_key], bool)  # bool ⊂ int
+                        or value[int_key] <= 0
                     ):
                         errors.append(f"'auto_demote.{int_key}' must be a positive int")
         # auto_demote_state: written by immunity.record_demotion via this

--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -49,6 +49,7 @@ async def ingest_knowledge_unit(
     collection: str = "knowledge_base",
     memory_type: str = "knowledge",
     confidence: float = 0.85,
+    origin_class: str | None = None,
 ) -> str:
     """Ingest or upsert a knowledge unit, returning the stable unit_id.
 
@@ -109,6 +110,15 @@ async def ingest_knowledge_unit(
 
     source_pipeline_val = (provenance or {}).get("source_pipeline", "knowledge_ingest")
     source_session_id = (provenance or {}).get("session_id")
+    # WS-3: derive ONCE and pass the same value to both stores below — the
+    # same both-stores-consistent discipline as the source_pipeline mirror.
+    from genesis.memory.provenance import derive_origin_class
+
+    resolved_origin = derive_origin_class(
+        origin_class=origin_class,
+        source_pipeline=source_pipeline_val,
+        collection=collection,
+    )
     qdrant_memory_id = await store.store(
         content,
         f"knowledge:{project}/{domain}",
@@ -122,6 +132,7 @@ async def ingest_knowledge_unit(
         source_session_id=source_session_id,
         force_fts5_only=force_fts5_only,
         project_type=project,
+        origin_class=resolved_origin,
     )
 
     # If we replaced an existing entry whose Qdrant point ID differs from
@@ -161,6 +172,7 @@ async def ingest_knowledge_unit(
         source_pipeline=source_pipeline_val,
         purpose=json.dumps(purpose) if purpose else None,
         ingestion_source=ingestion_source,
+        origin_class=resolved_origin,
     )
 
     logger.info(

--- a/src/genesis/memory/provenance.py
+++ b/src/genesis/memory/provenance.py
@@ -59,6 +59,100 @@ _PIPELINE_SHORT: dict[str, str] = {
 # Placeholder ``source_doc`` values that carry no real provenance.
 _PLACEHOLDER_DOCS = {"", "manual"}
 
+# ── WS-3 origin_class taxonomy ────────────────────────────────────────────
+# Persisted at STORE time (memory_metadata / knowledge_units / Qdrant
+# payload), unlike the recall-time labels above which re-derive from the
+# collection on every read. Future immunity gates key on
+# external_untrusted vs not; owner and first_party are never blockable.
+
+ORIGIN_OWNER = "owner"
+ORIGIN_FIRST_PARTY = "first_party"
+ORIGIN_EXTERNAL_UNTRUSTED = "external_untrusted"
+ORIGIN_CLASSES = frozenset(
+    {ORIGIN_OWNER, ORIGIN_FIRST_PARTY, ORIGIN_EXTERNAL_UNTRUSTED}
+)
+
+# Pipelines whose CONTENT is text pulled off the world. ``curated`` is here
+# deliberately: "curated" is an authority tier, not authorship — URL/file
+# ingests land as curated and the body is third-party text even when the
+# owner initiated the ingest (user-decided 2026-07-10; if B1 shadow logs
+# show legitimate owner workflows would-block via curated units, split
+# curated_upload/first_party vs curated_url/external — ingest_source
+# already knows source_type). ``email``/``inbox``/``web_search``/
+# ``web_fetch`` have no store() writers today; reserving them means a
+# future writer is external BY DEFAULT rather than silently first-party.
+_EXTERNAL_PIPELINES = frozenset({
+    "crag_web",
+    "recon",
+    "knowledge_ingest",
+    "knowledge_ingest_source",
+    "curated",
+    "email",
+    "inbox",
+    "web_search",
+    "web_fetch",
+})
+
+# Pipelines that write Genesis's own observations/derivations or the
+# owner's conversational content.
+_FIRST_PARTY_PIPELINES = frozenset({
+    "conversation",
+    "session_observer",
+    "harvest",
+    "synthesis",
+    "event_calendar",
+    "dream_cycle",
+    "reflection",
+    "drift",
+    "extraction_job",
+    "surplus",
+    "reference_store",
+})
+
+
+def derive_origin_class(
+    *,
+    origin_class: str | None = None,
+    source_pipeline: str | None = None,
+    source_subsystem: str | None = None,
+    collection: str | None = None,
+) -> str:
+    """Deterministic store-time origin classification.
+
+    Precedence (each rule short-circuits):
+      1. explicit ``origin_class`` override — validated, wins outright
+      2. pipeline in the external set → external_untrusted (outranks
+         source_subsystem: e.g. the recon pipeline stores web-collected
+         signals WITH ``source_subsystem='triage'`` — content is external)
+      3. pipeline in the first-party set → first_party
+      4. any ``source_subsystem`` → first_party (internal subsystem writer)
+      5. ``collection == 'knowledge_base'`` → external_untrusted (the same
+         already-litigated discriminator :func:`is_external` uses)
+      6. default → first_party
+
+    This is the CONSERVATIVE store-time mapping (unknown internal writers
+    stay first-party, matching :func:`is_external`'s documented stance).
+    Fail-closed normalization of unknown/missing values to
+    external_untrusted happens only at GATE time, in
+    ``genesis.security.immunity.effective_origin_class`` — never here.
+    """
+    if origin_class is not None:
+        if origin_class not in ORIGIN_CLASSES:
+            raise ValueError(
+                f"invalid origin_class {origin_class!r}; "
+                f"expected one of {sorted(ORIGIN_CLASSES)}"
+            )
+        return origin_class
+    if source_pipeline in _EXTERNAL_PIPELINES:
+        return ORIGIN_EXTERNAL_UNTRUSTED
+    if source_pipeline in _FIRST_PARTY_PIPELINES:
+        return ORIGIN_FIRST_PARTY
+    if source_subsystem:
+        return ORIGIN_FIRST_PARTY
+    if collection == KNOWLEDGE_COLLECTION:
+        return ORIGIN_EXTERNAL_UNTRUSTED
+    return ORIGIN_FIRST_PARTY
+
 
 def is_external(collection: str | None) -> bool:
     """True when the memory came from the external-world knowledge base.

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -123,6 +123,7 @@ class MemoryStore:
         life_domain: str | None = None,
         project_type: str | None = None,
         supersedes: str | None = None,
+        origin_class: str | None = None,
     ) -> str:
         """Full store pipeline: embed -> Qdrant -> FTS5 -> auto-link. Returns memory_id.
 
@@ -136,6 +137,13 @@ class MemoryStore:
                 it for user-sourced content, nor for ``modules/**`` writers — a
                 module is an external capability, never a subsystem (see
                 modules/base.py; enforced by test_store_subsystem_coverage).
+            origin_class: WS-3 provenance taxonomy
+                (owner/first_party/external_untrusted). Explicit value wins
+                and is validated; when omitted it is DERIVED from
+                source_pipeline/source_subsystem/collection via
+                ``provenance.derive_origin_class`` and stamped into the
+                Qdrant payload, memory_metadata, and (for KB ingest paths)
+                knowledge_units.
         """
         # Validate life_domain if explicitly provided
         if life_domain is not None:
@@ -194,6 +202,16 @@ class MemoryStore:
         now_iso = datetime.now(UTC).isoformat()
         resolved_tags = tags or []
         resolved_collection = collection or _COLLECTION_MAP.get(memory_type, "episodic_memory")
+        # WS-3 origin classification — deferred import matches this
+        # function's cycle-avoidance style; validates an explicit override.
+        from genesis.memory.provenance import derive_origin_class
+
+        resolved_origin = derive_origin_class(
+            origin_class=origin_class,
+            source_pipeline=source_pipeline,
+            source_subsystem=source_subsystem,
+            collection=resolved_collection,
+        )
         resolved_class = memory_class or classify_memory(
             content, source=source, source_pipeline=source_pipeline or "",
         )
@@ -257,6 +275,9 @@ class MemoryStore:
                         "wing": wing,
                         "room": room,
                         "life_domain": life_domain,
+                        # Always non-None by construction (derived above) —
+                        # lives in the base dict, not the conditional block.
+                        "origin_class": resolved_origin,
                     }
                     # Provenance fields — trace memory back to source conversation
                     if source_session_id:
@@ -334,6 +355,7 @@ class MemoryStore:
             valid_at=valid_at,
             invalid_at=invalid_at,
             source_subsystem=source_subsystem,
+            origin_class=resolved_origin,
         )
 
         # Mechanical code anchors (entity layer) — regex-only, every write

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -49,6 +49,8 @@ INDEXED_PAYLOAD_FIELDS: dict[str, str] = {
     "source_type": "keyword",
     "source_pipeline": "keyword",
     "memory_class": "keyword",
+    # WS-3 provenance taxonomy — B1 immunity gates filter on it.
+    "origin_class": "keyword",
 }
 
 

--- a/src/genesis/recon/cc_update_analyzer.py
+++ b/src/genesis/recon/cc_update_analyzer.py
@@ -383,11 +383,15 @@ class CCUpdateAnalyzer:
             )
 
             from genesis.db.crud import knowledge as knowledge_crud
+            from genesis.memory.provenance import derive_origin_class
 
             # Use upsert so re-analysis of the same CC release version
             # replaces the stale row instead of failing on the
             # UNIQUE(project_type, domain, concept) constraint.  The concept
             # is derived from summary[:200] which is stable per-version.
+            # WS-3: mirror the store() call's provenance — the ON CONFLICT
+            # SET would otherwise regress a backfilled origin_class to NULL
+            # on re-analysis.
             _uid, inserted = await knowledge_crud.upsert(
                 self._db,
                 project_type="genesis-infra",
@@ -400,6 +404,10 @@ class CCUpdateAnalyzer:
                 qdrant_id=qdrant_id,
                 embedding_model=getattr(
                     self._memory_store._embeddings, "model_name", None,
+                ),
+                source_pipeline="recon",
+                origin_class=derive_origin_class(
+                    source_pipeline="recon", collection="knowledge_base",
                 ),
             )
             logger.info(

--- a/src/genesis/resilience/embedding_recovery.py
+++ b/src/genesis/resilience/embedding_recovery.py
@@ -94,6 +94,12 @@ class EmbeddingRecoveryWorker:
                         payload["wing"] = taxo["wing"]
                     if taxo.get("room"):
                         payload["room"] = taxo["room"]
+                    # WS-3: restore origin_class from the authoritative
+                    # metadata row so an outage-recovered point carries the
+                    # indexed provenance key B1 gates filter on. Missing
+                    # (legacy row) → key omitted; gates fail closed on it.
+                    if taxo.get("origin_class"):
+                        payload["origin_class"] = taxo["origin_class"]
                 if life_domain:
                     payload["life_domain"] = life_domain
                 # Restore provenance fields if queued with them

--- a/src/genesis/security/immunity.py
+++ b/src/genesis/security/immunity.py
@@ -115,6 +115,11 @@ def gate_mode(gate: str) -> str:
         return "off"
     gate_cfg = cfg.get(gate)
     mode = gate_cfg.get("mode") if isinstance(gate_cfg, dict) else None
+    if mode is False:
+        # A hand-edited unquoted `mode: off` parses as YAML-1.1 boolean
+        # False. That intent is unambiguous — honor it. (True is NOT
+        # mapped: `on` is not a mode, so it degrades to shadow below.)
+        mode = "off"
     if mode not in MODES:
         logger.warning(
             "ws3_immunity gate %s has invalid mode %r — degrading to shadow",

--- a/src/genesis/security/immunity.py
+++ b/src/genesis/security/immunity.py
@@ -1,0 +1,203 @@
+"""WS-3 immunity control surface — live-read kill switch + gate helpers.
+
+This module is the ONE place B1's provenance gates consult for policy:
+
+- :func:`gate_mode` — per-gate ``off | shadow | enforce``, re-read from the
+  merged YAML (``config/ws3_immunity.yaml`` + the user overlay
+  ``~/.genesis/config/ws3_immunity.local.yaml``) on EVERY call, cc_roster
+  style. No boot cache — a ``settings_update`` or hand edit takes effect in
+  the running process instantly. Master ``enabled: false`` short-circuits
+  every gate to ``off``.
+- :func:`is_blockable` — THE never-block-owner invariant. Only
+  ``external_untrusted`` is ever blockable; ``owner``/``first_party`` return
+  False by construction in every mode. Unknown/missing values normalize to
+  ``external_untrusted`` (fail-closed at GATE time — store-time derivation
+  in ``genesis.memory.provenance`` never does this).
+- :func:`record_demotion` — auto-demote scaffold (wired in B1): writes
+  ``{gate: {mode: shadow}}`` plus an audit entry into the SAME overlay file
+  ``gate_mode`` reads, so demotion state and gate behavior cannot drift
+  apart. Never demotes below shadow, never escalates.
+
+Failure posture: a missing/corrupt config degrades to DEFAULTS
+(master on, every gate shadow) — shadow never blocks, so config damage can
+only ever make the system MORE permissive-but-observable, never lock the
+owner out.
+
+Dependency rule: this module must stay importable from anywhere
+(memory/, learning/, mcp/) — stdlib + yaml + genesis.env +
+genesis._config_overlay only. It must NEVER import genesis.mcp.health.settings
+(settings imports GATES/MODES from here; one-way).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import json
+import logging
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import _user_config_dir, merge_local_overlay
+from genesis.env import repo_root
+from genesis.memory.provenance import (
+    ORIGIN_CLASSES,
+    ORIGIN_EXTERNAL_UNTRUSTED,
+)
+
+logger = logging.getLogger(__name__)
+
+GATES = ("procedure", "identity", "autonomy", "injection")
+MODES = ("off", "shadow", "enforce")
+
+_CONFIG_NAME = "ws3_immunity.yaml"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    **{gate: {"mode": "shadow"} for gate in GATES},
+    "auto_demote": {
+        "enabled": True,
+        "window_minutes": 60,
+        "would_block_threshold": 5,
+    },
+}
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_immunity_config() -> dict[str, Any]:
+    """Read the merged immunity config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS (master on, all
+    gates shadow — never silently ``enforce``, never silently ``off``).
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        logger.warning("ws3_immunity base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("ws3_immunity overlay merge failed", exc_info=True)
+    for key, value in base.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = {**merged[key], **value}
+        else:
+            merged[key] = value
+    return merged
+
+
+def gate_mode(gate: str) -> str:
+    """Effective mode for *gate*: ``off | shadow | enforce`` — read live.
+
+    Unknown gate names raise ``ValueError`` (a typo at a gate call site is a
+    bug, not a policy decision). Master ``enabled: false`` → ``off`` for
+    every gate. An invalid mode VALUE in the file degrades to ``shadow``
+    with a warning (observable, never blocking, never silently off).
+    """
+    if gate not in GATES:
+        raise ValueError(f"unknown immunity gate {gate!r}; expected one of {GATES}")
+    cfg = load_immunity_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    gate_cfg = cfg.get(gate)
+    mode = gate_cfg.get("mode") if isinstance(gate_cfg, dict) else None
+    if mode not in MODES:
+        logger.warning(
+            "ws3_immunity gate %s has invalid mode %r — degrading to shadow",
+            gate, mode,
+        )
+        return "shadow"
+    return mode
+
+
+def effective_origin_class(value: str | None) -> str:
+    """GATE-TIME normalizer: unknown/missing origin → ``external_untrusted``.
+
+    This is the ONLY place the fail-closed unknown→untrusted rule lives.
+    Store-time derivation (``provenance.derive_origin_class``) stays
+    conservative-first-party for internal writers; a NULL/garbage value that
+    reaches a gate is treated as untrusted so gates fail closed, never open.
+    """
+    if value in ORIGIN_CLASSES:
+        return value  # type: ignore[return-value]  # membership proves str
+    return ORIGIN_EXTERNAL_UNTRUSTED
+
+
+def is_blockable(origin_class: str | None) -> bool:
+    """THE never-block-owner/first-party invariant.
+
+    Only ``external_untrusted`` (including anything unknown, via the
+    fail-closed normalizer) is ever blockable. ``owner`` and ``first_party``
+    are False by construction in EVERY mode — B1 gates must route every
+    block decision through this helper.
+    """
+    return effective_origin_class(origin_class) == ORIGIN_EXTERNAL_UNTRUSTED
+
+
+def _overlay_path() -> Path:
+    return _user_config_dir() / "ws3_immunity.local.yaml"
+
+
+def record_demotion(gate: str, reason: str) -> None:
+    """Auto-demote scaffold: set *gate* to shadow + write an audit entry.
+
+    Writes into the ``.local.yaml`` overlay — the exact file
+    :func:`gate_mode` reads — so the demotion is effective on the very next
+    gate call, survives restarts, and is human-visible/editable. Never sets
+    ``off``, never escalates. Atomic tempfile+rename write; the residual
+    read-merge-write race with a concurrent ``settings_update`` is
+    last-writer-wins on DISJOINT keys (documented trade; B0 has no callers —
+    B1 wires the would-block counters that invoke this).
+    """
+    if gate not in GATES:
+        raise ValueError(f"unknown immunity gate {gate!r}; expected one of {GATES}")
+    path = _overlay_path()
+    overlay: dict[str, Any] = {}
+    try:
+        if path.is_file():
+            loaded = yaml.safe_load(path.read_text()) or {}
+            if isinstance(loaded, dict):
+                overlay = loaded
+    except Exception:
+        logger.warning("ws3_immunity overlay unreadable; rewriting", exc_info=True)
+
+    previous = gate_mode(gate)
+    overlay.setdefault(gate, {})
+    overlay[gate]["mode"] = "shadow"
+    state = overlay.setdefault("auto_demote_state", {})
+    state[gate] = {
+        "demoted_at": datetime.now(UTC).isoformat(),
+        "from_mode": previous,
+        "reason": reason,
+    }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".ws3_immunity.", suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w") as fh:
+            yaml.safe_dump(overlay, fh, default_flow_style=False, sort_keys=False)
+        os.replace(tmp_name, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+    logger.warning(
+        "ws3_immunity AUTO-DEMOTE: gate %s %s -> shadow (%s) — state: %s",
+        gate, previous, reason, json.dumps(state[gate]),
+    )

--- a/src/genesis/security/immunity.py
+++ b/src/genesis/security/immunity.py
@@ -43,7 +43,11 @@ from typing import Any
 
 import yaml
 
-from genesis._config_overlay import _user_config_dir, merge_local_overlay
+from genesis._config_overlay import (
+    _resolve_overlay_path,
+    _user_config_dir,
+    merge_local_overlay,
+)
 from genesis.env import repo_root
 from genesis.memory.provenance import (
     ORIGIN_CLASSES,
@@ -172,9 +176,14 @@ def record_demotion(gate: str, reason: str) -> None:
         raise ValueError(f"unknown immunity gate {gate!r}; expected one of {GATES}")
     path = _overlay_path()
     overlay: dict[str, Any] = {}
+    # Read from the SAME overlay the reader resolves (user-dir first, then
+    # the repo-sibling back-compat location) so a legacy repo-sibling
+    # overlay's keys are carried into the canonical user-dir file we write —
+    # otherwise creating the user-dir overlay would silently shadow them.
+    read_path = _resolve_overlay_path(_base_path())
     try:
-        if path.is_file():
-            loaded = yaml.safe_load(path.read_text()) or {}
+        if read_path.is_file():
+            loaded = yaml.safe_load(read_path.read_text()) or {}
             if isinstance(loaded, dict):
                 overlay = loaded
     except Exception:

--- a/tests/test_db/test_memory.py
+++ b/tests/test_db/test_memory.py
@@ -74,16 +74,19 @@ async def test_search_ranked_with_collection(db):
 async def test_get_taxonomy(db):
     await memory.create_metadata(
         db, memory_id="tx1", created_at="2020-01-01T00:00:00+00:00",
-        wing="infrastructure", room="watchdog",
+        wing="infrastructure", room="watchdog", origin_class="first_party",
     )
     assert await memory.get_taxonomy(db, "tx1") == {
         "wing": "infrastructure", "room": "watchdog",
+        "origin_class": "first_party",
     }
-    # room is optional — a wing-only row still resolves
+    # room/origin_class optional — a wing-only row still resolves
     await memory.create_metadata(
         db, memory_id="tx2", created_at="2020-01-01T00:00:00+00:00", wing="memory",
     )
-    assert await memory.get_taxonomy(db, "tx2") == {"wing": "memory", "room": None}
+    assert await memory.get_taxonomy(db, "tx2") == {
+        "wing": "memory", "room": None, "origin_class": None,
+    }
     assert await memory.get_taxonomy(db, "missing") is None
 
 

--- a/tests/test_db/test_origin_class_migration.py
+++ b/tests/test_db/test_origin_class_migration.py
@@ -1,0 +1,208 @@
+"""Migration 0053 — origin_class column + deterministic backfill.
+
+Simulates a PRE-0053 database: legacy CREATE TABLEs for knowledge_units and
+memory_metadata copied from the current DDL in ``db/schema/_tables.py`` minus
+the ``origin_class`` column. Seeds one row per backfill archetype, runs
+``up()``, and asserts per-row classes, zero NULLs, and idempotency (a second
+``up()`` leaves every row identical).
+
+The migration does NOT commit (the runner owns the transaction); these tests
+just read back on the same aiosqlite connection.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M53 = importlib.import_module("genesis.db.migrations.0053_origin_class")
+
+# Current knowledge_units DDL from _tables.py WITHOUT origin_class.
+_LEGACY_KNOWLEDGE_UNITS = """
+    CREATE TABLE knowledge_units (
+        id               TEXT PRIMARY KEY,
+        project_type     TEXT NOT NULL,
+        domain           TEXT NOT NULL,
+        source_doc       TEXT NOT NULL,
+        source_platform  TEXT,
+        section_title    TEXT,
+        concept          TEXT NOT NULL,
+        body             TEXT NOT NULL,
+        relationships    TEXT,
+        caveats          TEXT,
+        tags             TEXT,
+        confidence       REAL DEFAULT 0.85,
+        source_date      TEXT,
+        ingested_at      TEXT NOT NULL,
+        qdrant_id        TEXT,
+        embedding_model  TEXT,
+        retrieved_count  INTEGER NOT NULL DEFAULT 0,
+        source_pipeline  TEXT,
+        purpose          TEXT,
+        ingestion_source TEXT,
+        UNIQUE(project_type, domain, concept)
+    )
+"""
+
+# Current memory_metadata DDL from _tables.py WITHOUT origin_class.
+_LEGACY_MEMORY_METADATA = """
+    CREATE TABLE memory_metadata (
+        memory_id        TEXT PRIMARY KEY,
+        created_at       TEXT NOT NULL,
+        collection       TEXT NOT NULL DEFAULT 'episodic_memory',
+        confidence       REAL,
+        embedding_status TEXT NOT NULL DEFAULT 'embedded',
+        memory_class     TEXT DEFAULT 'fact',
+        wing             TEXT,
+        room             TEXT,
+        valid_at         TEXT,
+        invalid_at       TEXT,
+        source_subsystem TEXT,
+        deprecated       INTEGER NOT NULL DEFAULT 0,
+        dream_cycle_run_id TEXT
+    )
+"""
+
+_NOW = "2026-07-10T00:00:00+00:00"
+
+
+async def _seed_ku(
+    db: aiosqlite.Connection, *, id: str, source_pipeline: str | None,
+    qdrant_id: str | None = None,
+) -> None:
+    await db.execute(
+        "INSERT INTO knowledge_units "
+        "(id, project_type, domain, source_doc, concept, body, ingested_at, "
+        " qdrant_id, source_pipeline) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (id, "proj", "dom", "doc", f"concept-{id}", "body", _NOW,
+         qdrant_id, source_pipeline),
+    )
+
+
+async def _seed_mm(
+    db: aiosqlite.Connection, *, memory_id: str, collection: str,
+    source_subsystem: str | None = None,
+) -> None:
+    await db.execute(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, source_subsystem) "
+        "VALUES (?, ?, ?, ?)",
+        (memory_id, _NOW, collection, source_subsystem),
+    )
+
+
+async def _seed_archetypes(db: aiosqlite.Connection) -> None:
+    # (a) plain episodic row
+    await _seed_mm(db, memory_id="mm-episodic", collection="episodic_memory")
+    # (b) subsystem write (episodic, source_subsystem set)
+    await _seed_mm(
+        db, memory_id="mm-subsystem", collection="episodic_memory",
+        source_subsystem="triage",
+    )
+    # (c) KB row joined via qdrant_id to a ku with a Genesis-authored pipeline
+    await _seed_ku(
+        db, id="ku-surplus", source_pipeline="surplus", qdrant_id="mm-kb-surplus",
+    )
+    await _seed_mm(db, memory_id="mm-kb-surplus", collection="knowledge_base")
+    # (d) KB row joined to a ku with a world-derived pipeline
+    await _seed_ku(
+        db, id="ku-curated", source_pipeline="curated", qdrant_id="mm-kb-curated",
+    )
+    await _seed_mm(db, memory_id="mm-kb-curated", collection="knowledge_base")
+    # (e) KB row with NO matching ku
+    await _seed_mm(db, memory_id="mm-kb-orphan", collection="knowledge_base")
+    # (f) legacy ku with NULL source_pipeline (and no joined mm)
+    await _seed_ku(db, id="ku-null-pipeline", source_pipeline=None)
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    rows = await db.execute_fetchall(f"PRAGMA table_info({table})")
+    return {r[1] for r in rows}
+
+
+async def _mm_classes(db: aiosqlite.Connection) -> dict[str, str | None]:
+    rows = await db.execute_fetchall(
+        "SELECT memory_id, origin_class FROM memory_metadata"
+    )
+    return dict(rows)
+
+
+async def _ku_classes(db: aiosqlite.Connection) -> dict[str, str | None]:
+    rows = await db.execute_fetchall(
+        "SELECT id, origin_class FROM knowledge_units"
+    )
+    return dict(rows)
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    await conn.execute(_LEGACY_KNOWLEDGE_UNITS)
+    await conn.execute(_LEGACY_MEMORY_METADATA)
+    await _seed_archetypes(conn)
+    yield conn
+    await conn.close()
+
+
+async def test_up_adds_columns(db):
+    assert "origin_class" not in await _columns(db, "knowledge_units")
+    assert "origin_class" not in await _columns(db, "memory_metadata")
+    await M53.up(db)
+    assert "origin_class" in await _columns(db, "knowledge_units")
+    assert "origin_class" in await _columns(db, "memory_metadata")
+
+
+async def test_backfill_per_archetype(db):
+    await M53.up(db)
+
+    mm = await _mm_classes(db)
+    assert mm["mm-episodic"] == "first_party"          # (a)
+    assert mm["mm-subsystem"] == "first_party"         # (b)
+    assert mm["mm-kb-surplus"] == "first_party"        # (c) via ku join
+    assert mm["mm-kb-curated"] == "external_untrusted"  # (d) via ku join
+    assert mm["mm-kb-orphan"] == "external_untrusted"  # (e) no ku → conservative
+
+    ku = await _ku_classes(db)
+    assert ku["ku-surplus"] == "first_party"           # (c)
+    assert ku["ku-curated"] == "external_untrusted"    # (d)
+    assert ku["ku-null-pipeline"] == "external_untrusted"  # (f)
+
+
+async def test_backfill_leaves_no_nulls(db):
+    await M53.up(db)
+    for table in ("knowledge_units", "memory_metadata"):
+        rows = await db.execute_fetchall(
+            f"SELECT COUNT(*) FROM {table} WHERE origin_class IS NULL"  # noqa: S608 - fixed test table names
+        )
+        assert rows[0][0] == 0, f"{table} has NULL origin_class rows"
+
+
+async def test_up_is_idempotent(db):
+    await M53.up(db)
+    first_mm = await _mm_classes(db)
+    first_ku = await _ku_classes(db)
+
+    await M53.up(db)  # must not raise, must not change any row
+    assert await _mm_classes(db) == first_mm
+    assert await _ku_classes(db) == first_ku
+
+
+async def test_up_tolerates_missing_tables():
+    """PRAGMA-guarded: a DB without either table is a no-op, not an error."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await M53.up(conn)  # neither table exists
+        conn2_ddl_only = conn  # same connection, add just memory_metadata
+        await conn2_ddl_only.execute(_LEGACY_MEMORY_METADATA)
+        await _seed_mm(
+            conn2_ddl_only, memory_id="mm-kb", collection="knowledge_base",
+        )
+        await M53.up(conn2_ddl_only)  # ku table absent → KB rows external
+        rows = await conn2_ddl_only.execute_fetchall(
+            "SELECT origin_class FROM memory_metadata WHERE memory_id='mm-kb'"
+        )
+        assert rows[0][0] == "external_untrusted"
+    finally:
+        await conn.close()

--- a/tests/test_db/test_origin_class_migration.py
+++ b/tests/test_db/test_origin_class_migration.py
@@ -17,7 +17,7 @@ import importlib
 import aiosqlite
 import pytest
 
-M53 = importlib.import_module("genesis.db.migrations.0053_origin_class")
+M53 = importlib.import_module("genesis.db.migrations.0054_origin_class")
 
 # Current knowledge_units DDL from _tables.py WITHOUT origin_class.
 _LEGACY_KNOWLEDGE_UNITS = """

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -575,6 +575,11 @@ async def test_migration_on_stripped_db():
         col_names = {row[1] for row in await cursor.fetchall()}
         assert "deprecated" in col_names, "migration didn't add 'deprecated' column"
         assert "dream_cycle_run_id" in col_names, "migration didn't add 'dream_cycle_run_id'"
+        assert "origin_class" in col_names, "memory_metadata missing 'origin_class'"
+
+        cursor = await conn.execute("PRAGMA table_info(knowledge_units)")
+        ku_col_names = {row[1] for row in await cursor.fetchall()}
+        assert "origin_class" in ku_col_names, "knowledge_units missing 'origin_class'"
 
         # Create all indexes
         for idx_ddl in INDEXES:

--- a/tests/test_mcp/test_settings_ws3_immunity.py
+++ b/tests/test_mcp/test_settings_ws3_immunity.py
@@ -1,0 +1,79 @@
+"""ws3_immunity settings domain: registration + validator (WS-3 B0).
+
+Validator-level coverage only, mirroring test_settings_cc_roster.py — that
+file (the model for this one) does not exercise settings_update either, so
+the merged-preview/dry_run path is covered by the shared settings_update
+tests rather than duplicated per-domain here.
+"""
+from __future__ import annotations
+
+from genesis.mcp.health.settings import (
+    _DOMAIN_REGISTRY,
+    _DOMAIN_VALIDATORS,
+    _validate_ws3_immunity,
+)
+
+
+def test_ws3_immunity_domain_registered():
+    assert "ws3_immunity" in _DOMAIN_REGISTRY
+    d = _DOMAIN_REGISTRY["ws3_immunity"]
+    assert d.readonly is False
+    assert d.needs_restart is False  # read live per-call by genesis.security.immunity
+    assert d.config_filename == "ws3_immunity.yaml"
+    assert "auto_demote_state" in d.hidden_fields
+    assert "ws3_immunity" in _DOMAIN_VALIDATORS
+
+
+def test_validate_rejects_unknown_top_key():
+    errs = _validate_ws3_immunity({"procedures": {"mode": "shadow"}})
+    assert errs and "Unknown key 'procedures'" in errs[0]
+
+
+def test_validate_rejects_invalid_gate_mode():
+    errs = _validate_ws3_immunity({"procedure": {"mode": "block"}})
+    assert errs and "'procedure.mode'" in errs[0]
+
+
+def test_validate_rejects_non_mapping_gate():
+    assert _validate_ws3_immunity({"identity": "enforce"})
+
+
+def test_validate_rejects_non_bool_enabled():
+    errs = _validate_ws3_immunity({"enabled": "false"})
+    assert errs and "'enabled' must be a boolean" in errs[0]
+
+
+def test_validate_rejects_non_positive_auto_demote_ints():
+    assert _validate_ws3_immunity({"auto_demote": {"window_minutes": 0}})
+    assert _validate_ws3_immunity({"auto_demote": {"would_block_threshold": -1}})
+    assert _validate_ws3_immunity({"auto_demote": {"window_minutes": "60"}})
+
+
+def test_validate_accepts_master_off():
+    assert _validate_ws3_immunity({"enabled": False}) == []
+
+
+def test_validate_accepts_gate_enforce():
+    assert _validate_ws3_immunity({"identity": {"mode": "enforce"}}) == []
+
+
+def test_validate_accepts_auto_demote_state_passthrough():
+    # Written by immunity.record_demotion via the same overlay; accepted
+    # opaquely (hidden from the UI).
+    changes = {
+        "auto_demote_state": {
+            "identity": {
+                "demoted_at": "2026-07-10T00:00:00+00:00",
+                "from_mode": "enforce",
+                "reason": "would-block spike",
+            }
+        }
+    }
+    assert _validate_ws3_immunity(changes) == []
+
+
+def test_validate_accepts_valid_auto_demote():
+    assert _validate_ws3_immunity(
+        {"auto_demote": {"enabled": True, "window_minutes": 30,
+                         "would_block_threshold": 3}}
+    ) == []

--- a/tests/test_mcp/test_settings_ws3_immunity.py
+++ b/tests/test_mcp/test_settings_ws3_immunity.py
@@ -77,3 +77,10 @@ def test_validate_accepts_valid_auto_demote():
         {"auto_demote": {"enabled": True, "window_minutes": 30,
                          "would_block_threshold": 3}}
     ) == []
+
+
+def test_validate_rejects_bool_for_auto_demote_ints():
+    # bool is an int subclass in Python — {"window_minutes": true} would
+    # otherwise validate and write `window_minutes: true` to the overlay.
+    errors = _validate_ws3_immunity({"auto_demote": {"window_minutes": True}})
+    assert errors and "positive int" in errors[0]

--- a/tests/test_memory/test_bitemporal.py
+++ b/tests/test_memory/test_bitemporal.py
@@ -69,7 +69,8 @@ async def meta_db():
             room             TEXT,
             valid_at         TEXT,
             invalid_at       TEXT,
-            source_subsystem TEXT
+            source_subsystem TEXT,
+            origin_class     TEXT
         )
     """)
     await db.commit()

--- a/tests/test_memory/test_knowledge_ingest.py
+++ b/tests/test_memory/test_knowledge_ingest.py
@@ -74,3 +74,46 @@ async def test_ingest_unit_scan_failure_is_fail_open():
         unit_id = await _run("anything")
 
     assert unit_id == "unit-1"
+
+
+# ─── WS-3 origin_class: one derivation, both stores ─────────────────────────
+
+
+async def _run_capture(provenance: dict | None = None):
+    """Invoke ingest_knowledge_unit; return (store_mock, upsert_mock)."""
+    store = _mock_store()
+    with patch(
+        "genesis.memory.knowledge_ingest.knowledge_crud.find_by_unique_key",
+        new_callable=AsyncMock, return_value=None,
+    ), patch(
+        "genesis.memory.knowledge_ingest.knowledge_crud.upsert",
+        new_callable=AsyncMock, return_value=("unit-1", True),
+    ) as upsert_mock:
+        await ingest_knowledge_unit(
+            store=store,
+            db=MagicMock(),
+            content="some knowledge body",
+            project="proj",
+            domain="dom",
+            provenance=provenance,
+        )
+    return store, upsert_mock
+
+
+async def test_ingest_unit_default_origin_is_external_untrusted():
+    """Default provenance → source_pipeline='knowledge_ingest' → external,
+    and the SAME resolved value reaches store.store AND knowledge upsert."""
+    store, upsert_mock = await _run_capture()
+
+    assert store.store.call_args.kwargs["origin_class"] == "external_untrusted"
+    assert upsert_mock.call_args.kwargs["origin_class"] == "external_untrusted"
+
+
+async def test_ingest_unit_surplus_pipeline_is_first_party():
+    """Genesis-authored surplus insights stay first_party in both stores."""
+    store, upsert_mock = await _run_capture(
+        provenance={"source_pipeline": "surplus"},
+    )
+
+    assert store.store.call_args.kwargs["origin_class"] == "first_party"
+    assert upsert_mock.call_args.kwargs["origin_class"] == "first_party"

--- a/tests/test_memory/test_origin_class.py
+++ b/tests/test_memory/test_origin_class.py
@@ -1,0 +1,136 @@
+"""WS-3 ``derive_origin_class`` — full store-time derivation matrix.
+
+Precedence under test (each rule short-circuits; see
+``genesis.memory.provenance.derive_origin_class``):
+  1. explicit ``origin_class`` override (validated, ValueError on garbage)
+  2. pipeline in the external set → external_untrusted
+  3. pipeline in the first-party set → first_party
+  4. any ``source_subsystem`` → first_party
+  5. ``collection == 'knowledge_base'`` → external_untrusted
+  6. default → first_party
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.memory.provenance import (
+    ORIGIN_CLASSES,
+    ORIGIN_EXTERNAL_UNTRUSTED,
+    ORIGIN_FIRST_PARTY,
+    ORIGIN_OWNER,
+    derive_origin_class,
+)
+
+# Every literal external pipeline value — including the reserved ones
+# (email/inbox/web_search/web_fetch have no store() writers today; a future
+# writer must be external BY DEFAULT).
+EXTERNAL_PIPELINES = (
+    "crag_web",
+    "recon",
+    "knowledge_ingest",
+    "knowledge_ingest_source",
+    "curated",
+    "email",
+    "inbox",
+    "web_search",
+    "web_fetch",
+)
+
+# Every literal first-party pipeline value.
+FIRST_PARTY_PIPELINES = (
+    "conversation",
+    "session_observer",
+    "harvest",
+    "synthesis",
+    "event_calendar",
+    "dream_cycle",
+    "reflection",
+    "drift",
+    "extraction_job",
+    "surplus",
+    "reference_store",
+)
+
+
+@pytest.mark.parametrize("pipeline", EXTERNAL_PIPELINES)
+def test_external_pipelines_map_external(pipeline):
+    assert (
+        derive_origin_class(source_pipeline=pipeline)
+        == ORIGIN_EXTERNAL_UNTRUSTED
+    )
+
+
+@pytest.mark.parametrize("pipeline", FIRST_PARTY_PIPELINES)
+def test_first_party_pipelines_map_first_party(pipeline):
+    assert derive_origin_class(source_pipeline=pipeline) == ORIGIN_FIRST_PARTY
+
+
+@pytest.mark.parametrize("pipeline", FIRST_PARTY_PIPELINES)
+def test_first_party_pipelines_win_over_kb_collection(pipeline):
+    """Rule 3 outranks rule 5: a first-party pipeline writing INTO the KB
+    (e.g. surplus insights, saved references) stays first_party."""
+    assert (
+        derive_origin_class(source_pipeline=pipeline, collection="knowledge_base")
+        == ORIGIN_FIRST_PARTY
+    )
+
+
+def test_explicit_override_wins_over_contradicting_pipeline():
+    # 'recon' would derive external; the validated explicit value wins outright.
+    assert (
+        derive_origin_class(origin_class=ORIGIN_OWNER, source_pipeline="recon")
+        == ORIGIN_OWNER
+    )
+    assert (
+        derive_origin_class(
+            origin_class=ORIGIN_EXTERNAL_UNTRUSTED, source_pipeline="conversation"
+        )
+        == ORIGIN_EXTERNAL_UNTRUSTED
+    )
+
+
+@pytest.mark.parametrize("value", ["", "garbage", "OWNER", "first-party"])
+def test_invalid_explicit_override_raises(value):
+    assert value not in ORIGIN_CLASSES  # test-data sanity
+    with pytest.raises(ValueError, match="invalid origin_class"):
+        derive_origin_class(origin_class=value)
+
+
+def test_external_pipeline_outranks_source_subsystem():
+    """Rule-order: recon stores web-collected signals WITH
+    source_subsystem='triage' — the content is still external."""
+    assert (
+        derive_origin_class(source_pipeline="recon", source_subsystem="triage")
+        == ORIGIN_EXTERNAL_UNTRUSTED
+    )
+
+
+def test_source_subsystem_only_is_first_party():
+    assert (
+        derive_origin_class(source_subsystem="ego") == ORIGIN_FIRST_PARTY
+    )
+
+
+def test_unknown_pipeline_kb_collection_is_external():
+    assert (
+        derive_origin_class(
+            source_pipeline="some_new_pipeline", collection="knowledge_base"
+        )
+        == ORIGIN_EXTERNAL_UNTRUSTED
+    )
+
+
+def test_unknown_pipeline_episodic_collection_is_first_party():
+    assert (
+        derive_origin_class(
+            source_pipeline="some_new_pipeline", collection="episodic_memory"
+        )
+        == ORIGIN_FIRST_PARTY
+    )
+
+
+def test_all_none_defaults_first_party():
+    """Conservative store-time default — fail-closed normalization to
+    external_untrusted happens only at GATE time, never here."""
+    assert derive_origin_class() == ORIGIN_FIRST_PARTY

--- a/tests/test_memory/test_store.py
+++ b/tests/test_memory/test_store.py
@@ -218,6 +218,73 @@ async def test_store_scope_tag_external_for_knowledge_base(store):
     assert payload["scope"] == "external"
 
 
+# ─── WS-3 origin_class stamping ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_store_stamps_first_party_origin_by_default(store):
+    """A normal store carries origin_class='first_party' in BOTH the Qdrant
+    payload and the memory_metadata row."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        await store.store("test content", "src")
+
+    payload = mock_upsert.call_args.kwargs["payload"]
+    assert payload["origin_class"] == "first_party"
+    meta_kwargs = mock_mem.create_metadata.call_args.kwargs
+    assert meta_kwargs["origin_class"] == "first_party"
+
+
+@pytest.mark.asyncio()
+async def test_store_explicit_owner_origin_end_to_end(store):
+    """An explicit origin_class='owner' override reaches both stores."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        await store.store("owner note", "src", origin_class="owner")
+
+    assert mock_upsert.call_args.kwargs["payload"]["origin_class"] == "owner"
+    assert mock_mem.create_metadata.call_args.kwargs["origin_class"] == "owner"
+
+
+@pytest.mark.asyncio()
+async def test_store_subsystem_write_stamps_first_party_metadata(store):
+    """Subsystem writes are FTS5-only (no Qdrant) but memory_metadata still
+    gets origin_class='first_party'."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        await store.store("triage signal", "src", source_subsystem="triage")
+
+    mock_upsert.assert_not_called()  # FTS5-only path, no Qdrant point
+    meta_kwargs = mock_mem.create_metadata.call_args.kwargs
+    assert meta_kwargs["origin_class"] == "first_party"
+    assert meta_kwargs["source_subsystem"] == "triage"
+
+
+@pytest.mark.asyncio()
+async def test_store_recon_pipeline_stamps_external_untrusted(store):
+    """source_pipeline='recon' derives external_untrusted in both stores."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        await store.store("web finding", "recon", source_pipeline="recon")
+
+    payload = mock_upsert.call_args.kwargs["payload"]
+    assert payload["origin_class"] == "external_untrusted"
+    meta_kwargs = mock_mem.create_metadata.call_args.kwargs
+    assert meta_kwargs["origin_class"] == "external_untrusted"
+
+
 @pytest.mark.asyncio()
 async def test_store_falls_back_on_qdrant_connection_error(store):
     """When Qdrant upsert raises a connection error, store should fall back to FTS5."""

--- a/tests/test_memory/test_subsystem_sqlite_only.py
+++ b/tests/test_memory/test_subsystem_sqlite_only.py
@@ -24,7 +24,8 @@ async def _build_db(path: str) -> aiosqlite.Connection:
             room TEXT,
             valid_at TEXT,
             invalid_at TEXT,
-            source_subsystem TEXT
+            source_subsystem TEXT,
+            origin_class TEXT
         )
     """)
     await conn.execute("""

--- a/tests/test_resilience/test_embedding_recovery.py
+++ b/tests/test_resilience/test_embedding_recovery.py
@@ -92,7 +92,7 @@ class TestDrainPending:
         # row, so wing/room are guaranteed present at drain time.
         await memory_crud.create_metadata(
             db, memory_id="mem-facet", created_at="2026-03-11T12:00:00",
-            wing="infrastructure", room="watchdog",
+            wing="infrastructure", room="watchdog", origin_class="first_party",
         )
         await crud.create(
             db, id="pe-facet", memory_id="mem-facet", content="facet item",
@@ -106,6 +106,9 @@ class TestDrainPending:
         assert payload["wing"] == "infrastructure"
         assert payload["room"] == "watchdog"
         assert payload["life_domain"] == "health"
+        # WS-3: origin_class restored from the authoritative metadata row so
+        # an outage-recovered point carries the indexed provenance key.
+        assert payload["origin_class"] == "first_party"
         # project_type is not recoverable on this path — must stay absent
         assert "project_type" not in payload
         # the stray memory_id key is dropped to match the normal write path

--- a/tests/test_security/test_immunity.py
+++ b/tests/test_security/test_immunity.py
@@ -1,0 +1,182 @@
+"""WS-3 immunity control surface — live-read kill switch + gate helpers.
+
+Covers ``genesis.security.immunity``: defaults with no config at all, master
+short-circuit, per-gate modes, live re-read (NO cache — an overlay edit takes
+effect on the very next call in the same process), the never-block-owner
+invariant, and the auto-demote scaffold.
+
+Both config locations are redirected to tmp_path:
+- the base file  → monkeypatched ``immunity.repo_root`` (bound name in the
+  module namespace via ``from genesis.env import repo_root``)
+- the overlay    → ``_user_config_dir``, monkeypatched in BOTH namespaces
+  that resolve it: ``genesis._config_overlay`` (used by
+  ``merge_local_overlay`` inside ``load_immunity_config``) and
+  ``genesis.security.immunity`` (bound import, used by ``_overlay_path`` /
+  ``record_demotion``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from genesis.security import immunity
+
+
+@pytest.fixture
+def config_dirs(tmp_path, monkeypatch) -> tuple[Path, Path]:
+    """Redirect base + overlay config resolution into tmp dirs.
+
+    Returns ``(base_path, overlay_path)`` — neither file exists initially.
+    """
+    repo_dir = tmp_path / "repo"
+    user_dir = tmp_path / "user_config"
+    (repo_dir / "config").mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(immunity, "repo_root", lambda: repo_dir)
+    monkeypatch.setattr(
+        "genesis._config_overlay._user_config_dir", lambda: user_dir,
+    )
+    monkeypatch.setattr(immunity, "_user_config_dir", lambda: user_dir)
+
+    return (
+        repo_dir / "config" / "ws3_immunity.yaml",
+        user_dir / "ws3_immunity.local.yaml",
+    )
+
+
+def _write(path: Path, data: dict) -> None:
+    # yaml.safe_dump quotes 'off' so it round-trips as the string "off",
+    # not YAML 1.1 boolean False.
+    path.write_text(yaml.safe_dump(data))
+
+
+# ─── defaults / failure posture ──────────────────────────────────────────────
+
+
+def test_defaults_with_no_files_at_all(config_dirs):
+    cfg = immunity.load_immunity_config()
+    assert cfg["enabled"] is True
+    for gate in immunity.GATES:
+        assert immunity.gate_mode(gate) == "shadow"
+    assert cfg["auto_demote"]["enabled"] is True
+
+
+def test_corrupt_base_degrades_to_defaults(config_dirs):
+    base, _ = config_dirs
+    base.write_text(":: not yaml ::[")
+    assert immunity.gate_mode("procedure") == "shadow"
+
+
+# ─── master switch + per-gate modes ─────────────────────────────────────────
+
+
+def test_master_off_short_circuits_every_gate(config_dirs):
+    base, _ = config_dirs
+    _write(base, {"enabled": False, "procedure": {"mode": "enforce"}})
+    for gate in immunity.GATES:
+        assert immunity.gate_mode(gate) == "off"
+
+
+def test_per_gate_off(config_dirs):
+    base, _ = config_dirs
+    _write(base, {"procedure": {"mode": "off"}})
+    assert immunity.gate_mode("procedure") == "off"
+    assert immunity.gate_mode("identity") == "shadow"  # untouched gate keeps default
+
+
+def test_unknown_gate_raises(config_dirs):
+    with pytest.raises(ValueError, match="unknown immunity gate"):
+        immunity.gate_mode("telepathy")
+
+
+def test_invalid_mode_value_degrades_to_shadow(config_dirs):
+    base, _ = config_dirs
+    _write(base, {"procedure": {"mode": "block"}})
+    assert immunity.gate_mode("procedure") == "shadow"
+
+
+# ─── live read (no cache) ───────────────────────────────────────────────────
+
+
+def test_overlay_edit_takes_effect_without_reload(config_dirs):
+    """gate_mode re-reads the merged config on EVERY call: rewriting the
+    .local.yaml overlay mid-process flips the answer immediately."""
+    base, overlay = config_dirs
+    _write(base, {"procedure": {"mode": "shadow"}})
+    assert immunity.gate_mode("procedure") == "shadow"
+
+    _write(overlay, {"procedure": {"mode": "enforce"}})
+    assert immunity.gate_mode("procedure") == "enforce"  # same process, no reload
+
+
+# ─── never-block invariant ──────────────────────────────────────────────────
+
+
+def test_owner_and_first_party_are_never_blockable():
+    assert immunity.is_blockable("owner") is False
+    assert immunity.is_blockable("first_party") is False
+
+
+@pytest.mark.parametrize("value", ["external_untrusted", None, "garbage"])
+def test_external_unknown_and_missing_are_blockable(value):
+    assert immunity.is_blockable(value) is True
+
+
+def test_effective_origin_class_fails_closed():
+    assert immunity.effective_origin_class(None) == "external_untrusted"
+    assert immunity.effective_origin_class("garbage") == "external_untrusted"
+    assert immunity.effective_origin_class("owner") == "owner"
+    assert immunity.effective_origin_class("first_party") == "first_party"
+
+
+# ─── auto-demote scaffold ───────────────────────────────────────────────────
+
+
+def test_record_demotion_writes_overlay_and_takes_effect(config_dirs):
+    base, overlay = config_dirs
+    _write(base, {"identity": {"mode": "enforce"}})
+    assert immunity.gate_mode("identity") == "enforce"
+
+    immunity.record_demotion("identity", "test spike")
+
+    written = yaml.safe_load(overlay.read_text())
+    assert written["identity"]["mode"] == "shadow"
+    state = written["auto_demote_state"]["identity"]
+    assert state["from_mode"] == "enforce"
+    assert state["reason"] == "test spike"
+    assert state["demoted_at"]  # ISO timestamp present
+
+    # Effective on the very next call — overlay wins over the base enforce.
+    assert immunity.gate_mode("identity") == "shadow"
+
+
+def test_record_demotion_preserves_existing_overlay_keys(config_dirs):
+    _, overlay = config_dirs
+    _write(overlay, {"procedure": {"mode": "enforce"}})
+
+    immunity.record_demotion("identity", "spike")
+
+    written = yaml.safe_load(overlay.read_text())
+    assert written["procedure"]["mode"] == "enforce"  # untouched
+    assert written["identity"]["mode"] == "shadow"
+
+
+def test_record_demotion_unknown_gate_raises(config_dirs):
+    _, overlay = config_dirs
+    with pytest.raises(ValueError, match="unknown immunity gate"):
+        immunity.record_demotion("telepathy", "nope")
+    assert not overlay.exists()  # nothing written
+
+
+def test_hand_edited_unquoted_off_is_honored(config_dirs):
+    """YAML-1.1 parses an unquoted `mode: off` as boolean False — a hand
+    edit with that intent is unambiguous and must mean 'off', not degrade
+    to shadow. (`mode: on` is NOT a mode and still degrades to shadow.)"""
+    base, _ = config_dirs
+    base.write_text("enabled: true\nprocedure:\n  mode: off\nidentity:\n  mode: on\n")
+    assert immunity.gate_mode("procedure") == "off"
+    assert immunity.gate_mode("identity") == "shadow"

--- a/tests/test_security/test_immunity.py
+++ b/tests/test_security/test_immunity.py
@@ -180,3 +180,22 @@ def test_hand_edited_unquoted_off_is_honored(config_dirs):
     base.write_text("enabled: true\nprocedure:\n  mode: off\nidentity:\n  mode: on\n")
     assert immunity.gate_mode("procedure") == "off"
     assert immunity.gate_mode("identity") == "shadow"
+
+
+def test_record_demotion_carries_repo_sibling_overlay_keys(config_dirs):
+    """A legacy repo-sibling .local.yaml (the back-compat location the
+    reader honors) must have its keys carried into the canonical user-dir
+    overlay record_demotion writes — otherwise creating the user-dir file
+    would silently shadow them."""
+    base, user_overlay = config_dirs
+    assert not user_overlay.exists()
+    sibling = base.with_suffix(".local.yaml")
+    _write(sibling, {"procedure": {"mode": "enforce"}})
+    assert immunity.gate_mode("procedure") == "enforce"
+
+    immunity.record_demotion("identity", "spike")
+
+    written = yaml.safe_load(user_overlay.read_text())
+    assert written["procedure"]["mode"] == "enforce"  # carried over
+    assert written["identity"]["mode"] == "shadow"
+    assert immunity.gate_mode("procedure") == "enforce"  # still applies


### PR DESCRIPTION
First PR of the WS-3 Immunity track. **NO gates in B0** — taxonomy, persistence, backfill, and the control surface the B1 gates will be born behind.

## What

1. **`origin_class ∈ {owner, first_party, external_untrusted}`** stamped at store time in all three stores (Qdrant payload base dict, `memory_metadata`, `knowledge_units` incl. the ON CONFLICT SET so re-ingests refresh). Deterministic derivation in `memory/provenance.py`: explicit override wins (validated); external pipelines outrank `source_subsystem` (recon+triage lands external); **`curated` → external_untrusted by decision** — authority tier, not authorship; falsifier: if B1 shadow logs show legitimate owner workflows would-block via curated units, split `curated_upload`/`curated_url` (ingest_source already knows source_type). Reserved pipeline names (`email`/`inbox`/`web_search`/`web_fetch`) make future writers external by default. One explicit `owner` stamp (telegram ego-correction — content is literally the owner's message); owner is never heuristically backfilled.
2. **Migration 0053**: nullable O(1) ADD COLUMN + idempotent in-migration SQL backfill. E2E on a live-DB copy: 372ms, `knowledge_units` 3,043 first_party / 708 external (**exactly** the predicted counts), `memory_metadata` 53,553 / 764, zero NULLs, second run byte-identical. `scripts/backfill_origin_class_qdrant.py` mirrors payloads post-deploy (idempotent, SQLite-authoritative, --dry-run verified against prod Qdrant: 53,341 points, classes consistent).
3. **`ws3_immunity` kill switch** (`security/immunity.py` + settings domain, writable + `needs_restart=False`): `gate_mode()` re-reads the merged YAML per call (cc_roster pattern, no cache) — E2E proved `settings_update` flips a gate to enforce **in the same process with no restart**, master `enabled: false` short-circuits all gates, and `record_demotion` takes effect immediately. `is_blockable()` = the never-block-owner/first-party invariant (tested); the gate-time fail-closed unknown→external rule lives ONLY in `effective_origin_class()`. Corrupt/missing config degrades to all-shadow (shadow never blocks). Auto-demote state is written INTO the overlay so state and behavior share one file.
4. Qdrant `INDEXED_PAYLOAD_FIELDS` += origin_class (idempotent index at next boot; B1 filters on it).

## Known gap (documented, B1+)

Inbox/email content reaches memory only indirectly (inbox monitor → CC session → `memory_store` → `conversation` pipeline → first_party). Session-level origin threading is a B1+ item; gate-time fail-closed covers NULL/unknown meanwhile.

## Review

Inline review under the new protocol: scope CLEAN, no BLOCKERs; 1 SHOULD-FIX + 2 NOTEs all fixed in `6570e6f5` (the SHOULD-FIX was real: the recon cc_update_analyzer upsert would have regressed backfilled rows to NULL on re-analysis). 128 branch tests + regression files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)