### PR TITLE
feat(eval): dev-quality metrics, subsystem-trap injection, code-audit taxonomy (rider e/f/g)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -329,6 +329,11 @@
                         "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook edit_failure_sensor.py",
                         "timeout": 500
+                    },
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/subsystem_traps_hook.py",
+                        "timeout": 5
                     }
                 ]
             },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -333,7 +333,7 @@
                     {
                         "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/subsystem_traps_hook.py",
-                        "timeout": 5
+                        "timeout": 10
                     }
                 ]
             },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Code quality is now a measured series, not a feeling.** A new
+  `dev_quality` dimension in the weekly eval snapshots tracks review
+  findings per merged PR (by severity, harvested from the PR bots' inline
+  comments every Sunday), open code-audit findings, and the edit-failure
+  rate — so "the codebase is getting better" is a falsifiable trend on the
+  dashboard, honest about small numbers (rates go null, not zero, when
+  there's no data).
+
+- **Editing a file now surfaces that subsystem's traps.** The first time a
+  session touches each subsystem, its do-not-touch edges and easy-to-forget
+  mechanisms from the architecture map are injected right at the edit — the
+  invariants arrive while the code is being written instead of at review
+  time.
+
+- **The idle-time code auditor got a sharper brief.** Its instructions now
+  use a four-class failure taxonomy tuned to AI-generated code (structural,
+  async/state, error-handling, tests), it picks targets from real
+  import-graph data (highest fan-in modules first), and findings carry a
+  category. Also fixes a long-standing bug where the auditor could never
+  report a critical-severity finding — its output schema simply didn't
+  include the word.
+
 - **`genesis eval bench` — a Genesis-vs-bare-Claude A/B benchmark you can run
   in one command.** Each task in a private task set runs through two arms: a
   cognition-enabled Genesis session (identity + read-only recall from your

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -415,7 +415,7 @@ Self-improvement loops and the instrumentation that keeps them honest.
 ```yaml subsystem-map
 entry: learning-evaluation
 modules: [learning, eval, experimentation, feedback, calibration]
-verified: 3c6cf249 2026-07-09
+verified: fe5d0945 2026-07-10
 ```
 
 - **learning/** is the de-facto cron host: `rt._learning_scheduler` registers
@@ -430,10 +430,16 @@ verified: 3c6cf249 2026-07-09
   "cannot break production" contract — hooks must never raise) + weekly Sunday
   aggregation (hard 7-day window) + an on-demand batch judge as a surplus
   task. The model gauntlet is weekly but OFF by default (paid inference) and
-  NEVER auto-mutates the roster. Nine snapshot dimensions: the original five
+  NEVER auto-mutates the roster. Ten snapshot dimensions: the original five
   (memory/system/ego/cognitive/procedure) + cognitive_drift + three
   snapshot-only WS-1 A2 series (approvals gate-throughput, goals scaffold,
-  noise/passivity). `run_weekly_aggregation` swallows per-dimension failures
+  noise/passivity) + `dev_quality` (findings-per-PR by severity, code-audit
+  gauge, edit-failure flow; fed by the `pr_review_harvest` job — Sun 06:45
+  user-tz, 45 min BEFORE the 07:30 aggregation, deliberately a separate job
+  so a gh outage degrades to stale rows instead of silently nulling the
+  dimension; the harvester reads INLINE PR comments via
+  `gh api pulls/N/comments` — `gh pr view --json reviews,comments` misses
+  bot findings). `run_weekly_aggregation` swallows per-dimension failures
   silently — the registration test in `tests/test_eval/test_j9_eval.py` is
   the guard; keep it in sync when adding a dimension. Resolver-origin
   classification for the approvals series is canonical in

--- a/scripts/hooks/subsystem_traps_hook.py
+++ b/scripts/hooks/subsystem_traps_hook.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""PostToolUse Edit|Write hook: inject the edited file's subsystem traps.
+
+Code-locality-aware context injection (dev-quality component e): editing a
+file under ``src/genesis/<module>/`` surfaces THAT subsystem's
+easy-to-forget mechanisms and do-not-touch edges from
+``docs/architecture/CURRENT.md`` — once per session per subsystem — so
+invariants arrive at edit time instead of at review time.
+
+Design constraints:
+- Pure file parse, no LLM calls, no caching (the file is ~25KB; a regex
+  parse is <10ms — an mtime cache is unjustified complexity).
+- Injected once per session per subsystem entry (dedup file in the session
+  dir, same shape as skill_injection_hook's nudge dedup).
+- SHORT: trap/do-not-touch lines + first-line-only bullets, hard cap.
+- Fail-open: any error exits 0 silently. Advisory context only — the
+  documented PostToolUse ``additionalContext`` channel; never blocks.
+- Worktree-correct by construction: the genesis-hook wrapper resolves this
+  script inside the worktree being edited, so the injected map matches the
+  branch's own CURRENT.md.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Same fence pattern the CI guard (scripts/check_subsystem_map.py) enforces,
+# so the modules->entry mapping this hook relies on is guaranteed complete.
+_BLOCK_RE = re.compile(r"^```yaml[ \t]+subsystem-map[ \t]*$")
+_SECTION_RE = re.compile(r"^## ", re.MULTILINE)
+
+_MAX_BULLETS = 6
+_MAX_CHARS = 1200
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _current_md_path() -> Path:
+    override = os.environ.get("GENESIS_CURRENT_MD_PATH")
+    if override:
+        return Path(override)
+    return _repo_root() / "docs" / "architecture" / "CURRENT.md"
+
+
+def _sessions_dir() -> Path:
+    override = os.environ.get("GENESIS_SESSIONS_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".genesis" / "sessions"
+
+
+def _parse_sections(text: str) -> list[dict]:
+    """Split CURRENT.md into ## sections carrying entry/modules + body."""
+    sections = []
+    starts = [m.start() for m in _SECTION_RE.finditer(text)]
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(text)
+        body = text[start:end]
+        lines = body.splitlines()
+        entry, modules = None, []
+        in_block = False
+        for line in lines:
+            if _BLOCK_RE.match(line):
+                in_block = True
+                continue
+            if in_block:
+                if line.startswith("```"):
+                    in_block = False
+                    continue
+                if line.startswith("entry:"):
+                    entry = line.split(":", 1)[1].strip()
+                elif line.startswith("modules:"):
+                    raw = line.split(":", 1)[1].strip().strip("[]")
+                    modules = [m.strip() for m in raw.split(",") if m.strip()]
+        if entry:
+            sections.append(
+                {"title": lines[0].lstrip("# ").strip(), "entry": entry,
+                 "modules": modules, "body": body}
+            )
+    return sections
+
+
+def _extract_traps(body: str) -> list[str]:
+    """Priority: **Do not touch:**/**Trap:** lines, then top-level bullets."""
+    picked: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("**Do not touch:**", "**Trap:**")):
+            picked.append(stripped)
+    for line in body.splitlines():
+        if len(picked) >= _MAX_BULLETS:
+            break
+        if line.startswith("- "):  # top-level bullets only, first line only
+            picked.append(line[2:].strip())
+    return picked[:_MAX_BULLETS]
+
+
+def _top_module(file_path: str) -> str | None:
+    parts = Path(file_path).parts
+    try:
+        idx = len(parts) - 1 - parts[::-1].index("genesis")
+    except ValueError:
+        return None
+    # .../src/genesis/<top>/... or .../src/genesis/<top>.py
+    if idx == 0 or parts[idx - 1] != "src" or idx + 1 >= len(parts):
+        return None
+    top = parts[idx + 1]
+    return top[:-3] if top.endswith(".py") else top
+
+
+def _already_nudged(session_id: str, entry: str) -> bool:
+    if not _SESSION_ID_RE.match(session_id):
+        return True  # refuse traversal-shaped ids: stay silent
+    dedup = _sessions_dir() / session_id / "subsystem_nudges.json"
+    seen: list[str] = []
+    try:
+        if dedup.is_file():
+            loaded = json.loads(dedup.read_text())
+            if isinstance(loaded, list):
+                seen = [s for s in loaded if isinstance(s, str)]
+    except Exception:
+        seen = []
+    if entry in seen:
+        return True
+    try:
+        dedup.parent.mkdir(parents=True, exist_ok=True)
+        dedup.write_text(json.dumps([*seen, entry]))
+    except Exception:
+        pass  # dedup write failure => worst case a repeat nudge later
+    return False
+
+
+def _process(data: dict) -> None:
+    if data.get("tool_name") not in ("Edit", "Write"):
+        return
+    tool_input = data.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return
+    file_path = tool_input.get("file_path") or ""
+    top = _top_module(file_path)
+    if not top:
+        return
+    md_path = _current_md_path()
+    if not md_path.is_file():
+        return
+    section = next(
+        (s for s in _parse_sections(md_path.read_text(encoding="utf-8"))
+         if top in s["modules"]),
+        None,
+    )
+    if section is None:
+        return
+    session_id = str(data.get("session_id") or "")
+    if not session_id or _already_nudged(session_id, section["entry"]):
+        return
+    traps = _extract_traps(section["body"])
+    if not traps:
+        return
+    lines = "\n".join(f"- {t}" for t in traps)
+    context = (
+        f"[Subsystem map] You are editing '{top}' — subsystem "
+        f"'{section['title']}' (docs/architecture/CURRENT.md). "
+        f"Load-bearing traps:\n{lines}\n"
+        "(Injected once per session per subsystem; consult the full entry "
+        "before structural changes.)"
+    )[:_MAX_CHARS]
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": context,
+            }
+        },
+        sys.stdout,
+    )
+
+
+def main() -> int:
+    # Hooks fail open — never crash the session.
+    with contextlib.suppress(Exception):
+        _process(json.loads(sys.stdin.read()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/subsystem_traps_hook.py
+++ b/scripts/hooks/subsystem_traps_hook.py
@@ -57,6 +57,12 @@ def _sessions_dir() -> Path:
     return Path.home() / ".genesis" / "sessions"
 
 
+def _split_modules(raw: str) -> list[str]:
+    """Parse a (possibly multi-line-joined) ``[a, b, c]`` module list."""
+    raw = raw.strip().strip("[]")
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
 def _parse_sections(text: str) -> list[dict]:
     """Split CURRENT.md into ## sections carrying entry/modules + body."""
     sections = []
@@ -67,6 +73,8 @@ def _parse_sections(text: str) -> list[dict]:
         lines = body.splitlines()
         entry, modules = None, []
         in_block = False
+        collecting = False  # accumulating a multi-line `modules: [ ... ]`
+        mod_buf = ""
         for line in lines:
             if _BLOCK_RE.match(line):
                 in_block = True
@@ -74,12 +82,24 @@ def _parse_sections(text: str) -> list[dict]:
             if in_block:
                 if line.startswith("```"):
                     in_block = False
+                    collecting = False
+                    continue
+                if collecting:
+                    mod_buf += " " + line
+                    if "]" in line:
+                        modules = _split_modules(mod_buf)
+                        collecting = False
                     continue
                 if line.startswith("entry:"):
                     entry = line.split(":", 1)[1].strip()
                 elif line.startswith("modules:"):
-                    raw = line.split(":", 1)[1].strip().strip("[]")
-                    modules = [m.strip() for m in raw.split(",") if m.strip()]
+                    # The list may wrap onto continuation lines (e.g. the
+                    # platform-data entry) — keep reading until the ']'.
+                    mod_buf = line.split(":", 1)[1]
+                    if "]" in mod_buf:
+                        modules = _split_modules(mod_buf)
+                    else:
+                        collecting = True
         if entry:
             sections.append(
                 {"title": lines[0].lstrip("# ").strip(), "entry": entry,
@@ -112,8 +132,11 @@ def _top_module(file_path: str) -> str | None:
     # .../src/genesis/<top>/... or .../src/genesis/<top>.py
     if idx == 0 or parts[idx - 1] != "src" or idx + 1 >= len(parts):
         return None
-    top = parts[idx + 1]
-    return top[:-3] if top.endswith(".py") else top
+    # Return the segment VERBATIM: CURRENT.md names package dirs bare
+    # (`memory`) but loose top-level modules WITH the suffix (`env.py`,
+    # `_config_overlay.py`), matching scripts/check_subsystem_map.py's
+    # live_modules(). Stripping `.py` would make loose-module edits miss.
+    return parts[idx + 1]
 
 
 def _already_nudged(session_id: str, entry: str) -> bool:

--- a/scripts/hooks/subsystem_traps_hook.py
+++ b/scripts/hooks/subsystem_traps_hook.py
@@ -159,10 +159,14 @@ def _process(data: dict) -> None:
     if section is None:
         return
     session_id = str(data.get("session_id") or "")
-    if not session_id or _already_nudged(session_id, section["entry"]):
+    if not session_id:
         return
+    # Extract BEFORE marking the dedup: a section with no extractable traps
+    # must not consume the once-per-session slot without injecting anything.
     traps = _extract_traps(section["body"])
     if not traps:
+        return
+    if _already_nudged(session_id, section["entry"]):
         return
     lines = "\n".join(f"- {t}" for t in traps)
     context = (

--- a/src/genesis/dashboard/routes/eval.py
+++ b/src/genesis/dashboard/routes/eval.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 _DIMENSIONS = (
     "memory", "system", "ego", "cognitive", "procedure",
-    "approvals", "goals", "noise",
+    "approvals", "goals", "noise", "dev_quality",
 )
 
 # Which metric to extract as the "headline" value per dimension
@@ -25,6 +25,7 @@ _HEADLINE_METRIC = {
     "approvals": "user_resolved_rate",
     "goals": "completion_rate",
     "noise": "empty_ego_cycle_pct",
+    "dev_quality": "findings_per_pr",
 }
 
 # Valence of a RISING headline value per dimension: True = improving,
@@ -41,6 +42,8 @@ _HIGHER_IS_BETTER = {
     "approvals": None,
     "goals": True,
     "noise": False,
+    # fewer findings/PR = better code OR a weaker review — direction-ambiguous
+    "dev_quality": None,
 }
 
 

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -13,6 +13,8 @@ Dimensions:
 7. Approvals (WS-1 A2): approval-gate resolution throughput
 8. Goals (WS-1 A2, scaffold): user_goals status ratios + completion rate
 9. Noise/passivity (WS-1 A2): loop-closure leaks + empty-ego-cycle rate
+10. Dev quality (component g): PR-review findings + code-audit backlog +
+    edit-failure rate
 """
 
 from __future__ import annotations
@@ -107,6 +109,7 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
         ("approvals", _compute_approvals),
         ("goals", _compute_goal_completion),
         ("noise", _compute_noise_passivity),
+        ("dev_quality", _compute_dev_quality),
     ]:
         try:
             metrics, sample_count = await fn(db, period_start, period_end)
@@ -868,6 +871,145 @@ async def _compute_noise_passivity(
         "realist_quality_hold": verdicts.get("quality_hold", 0),
     }
     return metrics, ego_cycles + proposals_in_period
+
+
+# ── Dimension 10: Dev Quality (component g) ──────────────────────────────────
+
+
+def _parse_iso_utc(value: str | None) -> datetime | None:
+    """Lenient ISO-8601 parse → aware UTC datetime (None on garbage).
+
+    pr_review_findings ``merged_at`` comes from GitHub (``...Z``); the window
+    bounds are Python isoformat (``+00:00``) — fromisoformat handles both,
+    and naive values are assumed UTC.
+    """
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+async def _compute_dev_quality(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Dev-quality metrics: PR-review findings + code-audit backlog + edit failures.
+
+    Three read paths, no writes:
+    - observations category='pr_review_findings' (written by
+      eval/pr_review_harvest.py, Sundays 06:45 — 45 min before this runs):
+      windowed on the ``merged_at`` INSIDE the content JSON, not the row's
+      created_at (re-harvest refreshes rows without changing what week the
+      PR merged). ``harvest_prs_seen`` counts ALL rows regardless of window
+      so thin harvest coverage is visible, not hidden.
+    - observations source='recon' category='code_audit', unresolved — an
+      all-time backlog gauge (stock, not flow). ``code_audit_by_category``
+      stays sparse until the audit taxonomy prompt ships (see ``note``).
+    - tool_call_outcomes windowed on timestamp (Edit/Write rows written by
+      scripts/edit_failure_sensor.py). datetime() normalization mirrors the
+      approvals dimension: both formats seen in the wild must window.
+
+    Honesty rules: every rate carries its raw numerator + denominator, and
+    is None on a zero denominator — NEVER 0.0 on 0/0. Ambiguity is
+    acknowledged where it exists (fewer findings/PR = better code OR weaker
+    review — the dashboard renders this dimension direction-neutral).
+
+    Snapshot-only dimension (writes no eval_events — the eval_events CHECK
+    constraint does not include 'dev_quality', and must not: this is weekly
+    aggregate telemetry, not an event stream).
+    """
+    start_dt = _parse_iso_utc(since)
+    end_dt = _parse_iso_utc(until)
+
+    # ── PR-review findings (windowed on content merged_at) ──────────────
+    cursor = await db.execute(
+        "SELECT content FROM observations WHERE category = 'pr_review_findings'",
+    )
+    rows = await cursor.fetchall()
+    harvest_prs_seen = len(rows)
+
+    prs_merged = 0
+    review_findings_total = 0
+    by_severity = dict.fromkeys(
+        ("blocker", "should_fix", "note", "unlabeled"), 0,
+    )
+    review_count_total = 0
+    for r in rows:
+        try:
+            payload = json.loads(r["content"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        merged = _parse_iso_utc(payload.get("merged_at"))
+        if merged is None or start_dt is None or end_dt is None:
+            continue
+        if not (start_dt <= merged < end_dt):
+            continue
+        prs_merged += 1
+        review_count_total += int(payload.get("review_count") or 0)
+        for f in payload.get("findings") or []:
+            review_findings_total += 1
+            sev = f.get("severity")
+            # Unknown severity strings fold into the honest bucket, never
+            # a guessed one.
+            by_severity[sev if sev in by_severity else "unlabeled"] += 1
+
+    # ── Code-audit backlog (all-time stock; mirrors the surplus panel's
+    #    source='recon' + unresolved population so the numbers agree) ─────
+    cursor = await db.execute(
+        "SELECT content FROM observations "
+        "WHERE source = 'recon' AND category = 'code_audit' AND resolved = 0",
+    )
+    audit_rows = await cursor.fetchall()
+    audit_by_severity: dict[str, int] = {}
+    audit_by_category: dict[str, int] = {}
+    for r in audit_rows:
+        try:
+            parsed = json.loads(r["content"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            parsed = {}
+        sev = parsed.get("severity") or "unknown"
+        audit_by_severity[sev] = audit_by_severity.get(sev, 0) + 1
+        cat = parsed.get("category")
+        if cat:
+            audit_by_category[cat] = audit_by_category.get(cat, 0) + 1
+
+    # ── Edit failures (windowed flow; Edit/Write only — the sensor's
+    #    contract — so a future emitter of other tools can't skew this) ───
+    cursor = await db.execute(
+        "SELECT COUNT(*), COALESCE(SUM(success = 0), 0) FROM tool_call_outcomes "
+        "WHERE tool_name IN ('Edit', 'Write') "
+        "AND datetime(timestamp) >= datetime(?) AND datetime(timestamp) < datetime(?)",
+        (since, until),
+    )
+    row = await cursor.fetchone()
+    edit_calls_total, edit_failures = row[0], row[1]
+
+    metrics = {
+        "prs_merged": prs_merged,
+        "review_findings_total": review_findings_total,
+        "review_findings_by_severity": by_severity,
+        "findings_per_pr": round(review_findings_total / prs_merged, 2)
+        if prs_merged else None,
+        "review_count_total": review_count_total,
+        "mean_reviews_per_pr": round(review_count_total / prs_merged, 2)
+        if prs_merged else None,
+        "code_audit_open_findings": len(audit_rows),
+        "code_audit_by_severity": audit_by_severity,
+        "code_audit_by_category": audit_by_category,
+        "edit_calls_total": edit_calls_total,
+        "edit_failures": edit_failures,
+        "edit_failure_rate": round(edit_failures / edit_calls_total, 4)
+        if edit_calls_total else None,
+        # Coverage honesty: all harvested PR rows, windowed or not.
+        "harvest_prs_seen": harvest_prs_seen,
+        "note": "scaffold: code_audit_by_category sparse until the audit "
+                "taxonomy prompt ships",
+    }
+    return metrics, prs_merged + edit_calls_total
 
 
 # ── Composite Trends ─────────────────────────────────────────────────────────

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -907,8 +907,17 @@ async def _compute_dev_quality(
       PR merged). ``harvest_prs_seen`` counts ALL rows regardless of window
       so thin harvest coverage is visible, not hidden.
     - observations source='recon' category='code_audit', unresolved — an
-      all-time backlog gauge (stock, not flow). ``code_audit_by_category``
-      stays sparse until the audit taxonomy prompt ships (see ``note``).
+      all-time backlog gauge (stock, not flow). This reads the SAME source
+      the existing dashboard surplus panel reads (`routes/surplus.py`), so
+      the two agree — but note that source is currently under-populated: the
+      live surplus code-audit pipeline routes findings through
+      `FindingsBridge` into intake/knowledge or the `surplus_insights`
+      staging table, NOT back into `observations`. So this gauge reflects
+      only the observations-published subset (today, stale/expired rows),
+      not total audit output. Reconciling the code-audit finding store
+      across the bridge, the dashboard panel, and this metric is a tracked
+      follow-up. ``code_audit_by_category`` additionally stays sparse until
+      the audit-taxonomy prompt ships (see ``note``).
     - tool_call_outcomes windowed on timestamp (Edit/Write rows written by
       scripts/edit_failure_sensor.py). datetime() normalization mirrors the
       approvals dimension: both formats seen in the wild must window.
@@ -1006,7 +1015,10 @@ async def _compute_dev_quality(
         if edit_calls_total else None,
         # Coverage honesty: all harvested PR rows, windowed or not.
         "harvest_prs_seen": harvest_prs_seen,
-        "note": "scaffold: code_audit_by_category sparse until the audit "
+        "note": "scaffold: code_audit_* reflects only the observations-"
+                "published subset (bridge routes findings to intake/"
+                "surplus_insights, not observations — reconciliation "
+                "tracked); code_audit_by_category sparse until the audit "
                 "taxonomy prompt ships",
     }
     return metrics, prs_merged + edit_calls_total

--- a/src/genesis/eval/pr_review_harvest.py
+++ b/src/genesis/eval/pr_review_harvest.py
@@ -1,0 +1,245 @@
+"""Harvest merged-PR review findings into observations (dev-quality component g).
+
+Pulls the last N merged PRs via the gh CLI, collects the review findings the
+bots left on them, parses a severity per finding, and upserts one observation
+per PR (deterministic id → idempotent re-harvest). The weekly ``dev_quality``
+J-9 dimension reads these rows.
+
+HARD-WON PRODUCTION LESSON — where the findings actually live: the Codex
+review bot posts its findings as INLINE review comments, which only
+``gh api repos/<owner>/<repo>/pulls/N/comments`` returns.
+``gh pr view --json reviews,comments`` MISSES them entirely (``comments`` is
+issue-level conversation, ``reviews`` carries only the top-level review
+bodies). Do not "simplify" this back to ``gh pr view``.
+
+The ``/reviews`` endpoint is still queried separately: the structural review
+bot posts reviews with state COMMENTED, so the per-PR review count is a
+distinct coverage signal from the finding count.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from genesis.db.crud import observations as obs_crud
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    import aiosqlite
+
+    Runner = Callable[[list[str]], Awaitable[tuple[int, str, str]]]
+
+logger = logging.getLogger(__name__)
+
+# 30s per gh call: each is one GitHub API round-trip (network-bound, normally
+# <2s). A hung call must not stall the weekly learning-scheduler job; the
+# total run is bounded by ~2 calls per PR x the PR limit, so worst case stays
+# well under the scheduler's misfire grace.
+_GH_TIMEOUT_S = 30
+
+# 90 days: long enough to cover any J-9 lookback window, short enough that
+# re-harvested rows don't accumulate forever if a repo goes quiet.
+_EXPIRES_DAYS = 90
+
+# Severity vocab, lenient + case-insensitive. P1/P2/P3 (bare or bracketed —
+# ``\b`` treats ``[``/``]`` as boundaries) map to the same canonical buckets
+# as the spelled-out labels. A comment matching neither is ``unlabeled`` —
+# an honest bucket, never a guess.
+_P_LEVEL_RE = re.compile(r"\bP([123])\b", re.IGNORECASE)
+_WORD_LEVEL_RE = re.compile(r"\b(BLOCKER|SHOULD-FIX|NOTE)\b", re.IGNORECASE)
+_P_TO_BUCKET = {"1": "blocker", "2": "should_fix", "3": "note"}
+_WORD_TO_BUCKET = {"blocker": "blocker", "should-fix": "should_fix", "note": "note"}
+
+SEVERITY_BUCKETS = ("blocker", "should_fix", "note", "unlabeled")
+
+
+async def _default_runner(argv: list[str]) -> tuple[int, str, str]:
+    """Run a gh CLI command, returning (returncode, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GH_TIMEOUT_S,
+        )
+    except TimeoutError:
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.communicate()
+        return 124, "", f"timed out after {_GH_TIMEOUT_S}s: {' '.join(argv)}"
+    return proc.returncode or 0, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+
+
+def parse_severity(body: str) -> str:
+    """Map a review-comment body to a canonical severity bucket."""
+    m = _P_LEVEL_RE.search(body or "")
+    if m:
+        return _P_TO_BUCKET[m.group(1)]
+    m = _WORD_LEVEL_RE.search(body or "")
+    if m:
+        return _WORD_TO_BUCKET[m.group(1).lower()]
+    return "unlabeled"
+
+
+def _parse_concat_json(text: str) -> list[dict]:
+    """Parse gh output that may be several concatenated JSON documents.
+
+    ``gh api --paginate`` on an array endpoint emits one JSON array PER PAGE,
+    back to back — the combined output is not a single valid document.
+    raw_decode walks the stream and flattens the arrays.
+    """
+    decoder = json.JSONDecoder()
+    items: list[dict] = []
+    idx = 0
+    length = len(text)
+    while idx < length:
+        while idx < length and text[idx].isspace():
+            idx += 1
+        if idx >= length:
+            break
+        value, idx = decoder.raw_decode(text, idx)
+        if isinstance(value, list):
+            items.extend(v for v in value if isinstance(v, dict))
+        elif isinstance(value, dict):
+            items.append(value)
+    return items
+
+
+async def _harvest_one_pr(
+    db: aiosqlite.Connection, runner: Runner, repo: str, pr: dict, now: datetime,
+) -> dict:
+    """Fetch findings + review count for one PR and upsert its observation.
+
+    Returns {"findings": [...], "review_count": int}. Raises on gh failure —
+    the caller logs and skips (one bad PR must not kill the harvest).
+    """
+    number = int(pr["number"])
+
+    rc, out, err = await runner(
+        ["gh", "api", f"repos/{repo}/pulls/{number}/comments", "--paginate"],
+    )
+    if rc != 0:
+        raise RuntimeError(f"inline-comments fetch failed (rc={rc}): {err.strip()}")
+    comments = _parse_concat_json(out)
+
+    rc, out, err = await runner(
+        ["gh", "api", f"repos/{repo}/pulls/{number}/reviews", "--paginate"],
+    )
+    if rc != 0:
+        raise RuntimeError(f"reviews fetch failed (rc={rc}): {err.strip()}")
+    review_count = len(_parse_concat_json(out))
+
+    findings = []
+    for c in comments:  # one finding per inline review comment
+        body = c.get("body") or ""
+        findings.append({
+            "severity": parse_severity(body),
+            "author": (c.get("user") or {}).get("login"),
+            "path": c.get("path"),
+            "excerpt": " ".join(body.split())[:120],
+        })
+
+    content = json.dumps({
+        "pr": number,
+        "title": pr.get("title"),
+        "merged_at": pr.get("mergedAt"),
+        "review_count": review_count,
+        "findings": findings,
+    })
+    # Deterministic id → the weekly re-harvest of a still-in-window PR
+    # updates its row in place instead of duplicating it.
+    await obs_crud.upsert(
+        db,
+        id=f"prrev-{number}",
+        source="recon",
+        type="pr_review_findings",
+        category="pr_review_findings",
+        content=content,
+        priority="low",
+        created_at=now.isoformat(),
+        # Explicit (not auto-TTL): the retention contract is this module's,
+        # not the observation-type table's default.
+        expires_at=(now + timedelta(days=_EXPIRES_DAYS)).isoformat(),
+    )
+    return {"findings": findings, "review_count": review_count}
+
+
+async def harvest_pr_review_findings(
+    db: aiosqlite.Connection,
+    *,
+    repo: str | None = None,
+    lookback_days: int = 30,
+    limit: int = 50,
+    runner: Runner | None = None,
+) -> dict[str, Any]:
+    """Harvest review findings for recently merged PRs into observations.
+
+    ``runner`` is an injectable ``async (argv) -> (rc, stdout, stderr)``
+    subprocess callable (tests pass a fake); defaults to the gh CLI.
+
+    Returns a summary dict {repo, prs_seen, findings_total, by_severity,
+    errors}. A failed repo-resolve or PR-list returns {"error": ...} without
+    raising; per-PR failures are logged, recorded in ``errors``, and skipped.
+    """
+    run = runner or _default_runner
+    now = datetime.now(UTC)
+
+    if repo is None:
+        rc, out, err = await run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        )
+        repo = out.strip()
+        if rc != 0 or not repo:
+            return {"error": f"repo resolve failed (rc={rc}): {err.strip()}"}
+
+    merged_since = (now - timedelta(days=lookback_days)).date().isoformat()
+    rc, out, err = await run([
+        "gh", "pr", "list",
+        "--repo", repo,
+        "--state", "merged",
+        "--search", f"merged:>={merged_since}",
+        "--json", "number,mergedAt,title",
+        "--limit", str(limit),
+    ])
+    if rc != 0:
+        return {"error": f"pr list failed (rc={rc}): {err.strip()}"}
+    try:
+        prs = json.loads(out)
+    except json.JSONDecodeError as exc:
+        return {"error": f"pr list returned invalid JSON: {exc}"}
+
+    findings_total = 0
+    by_severity = dict.fromkeys(SEVERITY_BUCKETS, 0)
+    errors: list[str] = []
+    for pr in prs:
+        try:
+            result = await _harvest_one_pr(db, run, repo, pr, now)
+        except Exception as exc:
+            # One bad PR (deleted branch, API 5xx, timeout) must not kill
+            # the whole harvest — record and move on.
+            msg = f"PR #{pr.get('number')}: {exc}"
+            logger.warning("pr_review_harvest skipped %s", msg)
+            errors.append(msg)
+            continue
+        for f in result["findings"]:
+            findings_total += 1
+            by_severity[f["severity"]] += 1
+
+    summary = {
+        "repo": repo,
+        "prs_seen": len(prs),
+        "findings_total": findings_total,
+        "by_severity": by_severity,
+        "errors": errors,
+    }
+    logger.info("pr_review_harvest: %s", summary)
+    return summary

--- a/src/genesis/eval/pr_review_harvest.py
+++ b/src/genesis/eval/pr_review_harvest.py
@@ -156,10 +156,12 @@ async def _harvest_one_pr(
         "findings": findings,
     })
     # Deterministic id → the weekly re-harvest of a still-in-window PR
-    # updates its row in place instead of duplicating it.
+    # updates its row in place instead of duplicating it. Repo-scoped so a
+    # repo rename/switch can never silently upsert PR #N of one repo over
+    # PR #N of another.
     await obs_crud.upsert(
         db,
-        id=f"prrev-{number}",
+        id=f"prrev-{repo.replace('/', '-')}-{number}",
         source="recon",
         type="pr_review_findings",
         category="pr_review_findings",

--- a/src/genesis/identity/CODE_AUDITOR.md
+++ b/src/genesis/identity/CODE_AUDITOR.md
@@ -13,16 +13,15 @@ Focus areas:
 ## AI-Generated-Code Failure Modes (hunt these specifically)
 
 This codebase is built iteratively with LLMs, so audit for the defect classes
-that iterative AI development is known to produce:
+that iterative AI development is known to produce. They fall into four named
+classes — tag every finding with the matching `category`.
 
-- **Swallowed async errors**: an except block that logs and returns None (or
-  nothing) so the caller proceeds on a missing value with no failure signal.
-- **Orphan state**: state written on some paths but read without guards on
-  others; listeners/timers/subscriptions registered with no teardown;
-  callbacks that mutate state after cancellation.
-- **Race surface**: two async paths writing shared state (file, table row,
-  in-memory dict) with no lock or serialization; polling loops without
-  cancellation; non-atomic read-modify-write on shared files.
+### structural
+
+- **Narrating comments**: excessive comments that describe what the code does
+  line-by-line, substituting for clarity instead of providing it.
+- **Monolith growth**: features bolted onto a module with zero refactoring —
+  the file keeps absorbing responsibilities as generation context fills up.
 - **Phantom guards**: checks for conditions that cannot occur, unreachable
   else branches, speculative parameters nothing passes — noise that
   masquerades as safety.
@@ -33,14 +32,68 @@ that iterative AI development is known to produce:
 - **Pattern abandonment**: a convention established early (repository
   pattern, error wrapper, naming scheme) silently dropped in later-added
   modules — usually marks the seam where context decayed.
+- **Naming-convention drift**: naming style shifting mid-file or mid-package
+  (snake_case to camelCase, verb-noun to noun-verb) — same seam marker.
 - **Iteration scars**: constraints, validation, or type enforcement that an
   earlier version had and a later "improvement" quietly removed. When you
   can see history, compare — refinement cycles are where safety erodes.
+
+### async_state
+
+- **Swallowed async errors**: an except block that logs and returns None (or
+  nothing) so the caller proceeds on a missing value with no failure signal.
+- **Catch-log-return-nothing**: the broader form — any handler that logs and
+  exits without rethrowing, returning a typed fallback, or notifying anyone.
+- **Orphan state**: state written on some paths but read without guards on
+  others; listeners/timers/subscriptions registered with no teardown;
+  callbacks that mutate state after cancellation.
+- **Race surface**: two async paths writing shared state (file, table row,
+  in-memory dict) with no lock or serialization; non-atomic
+  read-modify-write on shared files.
+- **Polling without cancellation**: polling loops with no cancellation path —
+  they outlive their purpose and leak work.
+
+### error_handling
+
+- **Missing boundary validation**: input crossing a trust boundary (user
+  input, subprocess output, LLM output, network response) used without
+  validation. This is the single most common flaw class in LLM-generated
+  code — weight your attention accordingly.
+- **Reveals too much vs handles too little**: error responses that leak
+  stack traces, paths, or schema details — or the opposite failure, one
+  generic message flattening every distinct failure mode.
+
+### tests
+
+- **High count, low depth**: many tests asserting the happy path N different
+  ways while no test exercises a failure path.
+- **Edge inputs never probed**: empty collections, None/null, zero, and
+  single-element inputs absent from the test suite for collection- and
+  boundary-handling code.
+
+## Audit Priorities
+
+You get ONE response — a single shot, no follow-up passes. Order your
+ATTENTION, not passes. Your context includes an Audit Targets inventory
+(module fan-in, god-modules). Spend budget in order:
+
+0. Pick targets from the inventory — highest fan-in first. A defect in a
+   module with many importers matters more than one in a leaf.
+1. structural
+2. async_state
+3. error_handling
+4. tests
+
+You see summaries and snippets, not full sources. Phrase every finding as a
+verifiable pointer — file, approximate location, what to look for — that a
+follow-up session can confirm against the real source. Never phrase a
+finding as if you read the whole file.
 
 Output format: JSON array of findings, each with:
 - file: path relative to project root
 - line: approximate line number
 - severity: critical | high | medium | low
+- category: structural | async_state | error_handling | tests | security | other
 - description: what's wrong and why it matters
 - suggestion: how to fix it (one sentence)
 - confidence: 0.0 to 1.0 — how certain you are this is a real issue

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1144,6 +1144,39 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        # PR-review findings harvest (Sundays 6:45am — 45 min BEFORE the
+        # 07:30 j9_eval_aggregation reads the pr_review_findings rows, and
+        # in the SAME timezone so the ordering can't invert across DST).
+        async def _run_pr_review_harvest():
+            try:
+                from genesis.eval.pr_review_harvest import (
+                    harvest_pr_review_findings,
+                )
+                summary = await harvest_pr_review_findings(rt._db)
+                if summary.get("error"):
+                    # Error-dict return (repo-resolve / pr-list failure):
+                    # the harvest didn't raise, but the job did no work —
+                    # surface it as a job failure, not a false green.
+                    raise RuntimeError(str(summary["error"]))
+                logger.info(
+                    "PR review harvest: %d PRs, %d findings, %d errors",
+                    summary.get("prs_seen", 0),
+                    summary.get("findings_total", 0),
+                    len(summary.get("errors") or []),
+                )
+                rt.record_job_success("pr_review_harvest")
+            except Exception as exc:
+                rt.record_job_failure("pr_review_harvest", str(exc))
+                logger.exception("PR review harvest failed")
+
+        rt._learning_scheduler.add_job(
+            _run_pr_review_harvest,
+            CronTrigger(day_of_week="sun", hour=6, minute=45, timezone=user_timezone()),
+            id="pr_review_harvest",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         # Model-roster gauntlet (weekly, Sat 5am). Validates each runnable roster
         # member can still drive CC through a coding fix-loop; a PASS->FAIL
         # regression surfaces an advisory BLOCKER alert + human-gated proposal

--- a/src/genesis/surplus/code_audit.py
+++ b/src/genesis/surplus/code_audit.py
@@ -50,7 +50,28 @@ def _safe_float(val: object, *, default: float = 0.5) -> float:
         return float(val)  # type: ignore[arg-type]
     except (ValueError, TypeError):
         return default
-_MAX_CONTEXT_CHARS = 4000
+
+
+# Taxonomy classes findings are tagged with (mirrors CODE_AUDITOR.md).
+# Anything the LLM emits outside this set is normalized to "other".
+_AUDIT_CATEGORIES = frozenset(
+    {"structural", "async_state", "error_handling", "tests", "security", "other"}
+)
+
+
+def _safe_category(val: object) -> str:
+    """Normalize an LLM-supplied category to the known taxonomy, else 'other'."""
+    if isinstance(val, str):
+        normalized = val.strip().lower()
+        if normalized in _AUDIT_CATEGORIES:
+            return normalized
+    return "other"
+
+
+# 6000 (was 4000): the Audit Targets inventory (fan-in + god-modules) adds two
+# ~400-char sections that materially improve targeting. This is an idle-time
+# surplus task, so the marginal token cost is acceptable.
+_MAX_CONTEXT_CHARS = 6000
 _SUBPROCESS_TIMEOUT = 10
 
 
@@ -117,17 +138,71 @@ class CodebaseContextGatherer:
         except Exception:
             return ""
 
+    async def _get_audit_targets(self) -> str:
+        """Build the Audit Targets inventory from the code_imports index.
+
+        Two cheap queries: top fan-in modules (many distinct importers =
+        highest-value audit targets) and god-modules (source files importing
+        from >=5 distinct internal top-level genesis packages). Returns ""
+        when the index is empty or missing so the section is omitted.
+
+        Note on semantics (see codebase/indexer.py): target_module is the raw
+        dotted name from the AST — relative imports are stored unresolved
+        (e.g. "types", is_relative=1), so the LIKE 'genesis%' filter counts
+        absolute internal imports only. This undercounts intra-package fan-in
+        but is the right signal for cross-package audit targeting.
+        """
+        try:
+            cursor = await self._db.execute(
+                "SELECT target_module, COUNT(DISTINCT source_path) AS c "
+                "FROM code_imports WHERE target_module LIKE 'genesis%' "
+                "GROUP BY 1 ORDER BY c DESC LIMIT 10"
+            )
+            fan_in_rows = await cursor.fetchall()
+
+            # Top-level package of an absolute internal import: the segment
+            # after "genesis." up to the next dot (substr offset 9 skips the
+            # 8-char "genesis." prefix). "genesis" alone names no subpackage,
+            # hence LIKE 'genesis.%' here.
+            cursor = await self._db.execute(
+                "SELECT source_path, COUNT(DISTINCT "
+                "  CASE WHEN instr(substr(target_module, 9), '.') > 0 "
+                "       THEN substr(target_module, 9, "
+                "                   instr(substr(target_module, 9), '.') - 1) "
+                "       ELSE substr(target_module, 9) END) AS pkgs "
+                "FROM code_imports WHERE target_module LIKE 'genesis.%' "
+                "GROUP BY source_path HAVING pkgs >= 5 "
+                "ORDER BY pkgs DESC LIMIT 10"
+            )
+            god_rows = await cursor.fetchall()
+
+            lines: list[str] = []
+            if fan_in_rows:
+                lines.append("Top fan-in (module: distinct importers):")
+                lines.extend(f"- {mod}: {count}" for mod, count in fan_in_rows)
+            if god_rows:
+                lines.append("God-modules (import >=5 internal packages):")
+                lines.extend(
+                    f"- {path}: {pkgs} packages" for path, pkgs in god_rows
+                )
+            return "\n".join(lines)
+        except Exception:
+            return ""
+
     async def gather(self) -> str:
-        """Assemble codebase context, capped at ~4000 chars.
+        """Assemble codebase context, capped at _MAX_CONTEXT_CHARS.
 
         Prefers the code_modules index (fast, structured) over subprocess
         calls. Falls back to subprocess if the index is empty.
         """
-        git_log, git_diff, index_summary, prev_findings = await asyncio.gather(
-            self._run_cmd("git", "log", "--oneline", "-20"),
-            self._run_cmd("git", "diff", "HEAD~5", "--stat"),
-            self._get_index_summary(),
-            self._get_previous_findings(),
+        git_log, git_diff, index_summary, audit_targets, prev_findings = (
+            await asyncio.gather(
+                self._run_cmd("git", "log", "--oneline", "-20"),
+                self._run_cmd("git", "diff", "HEAD~5", "--stat"),
+                self._get_index_summary(),
+                self._get_audit_targets(),
+                self._get_previous_findings(),
+            )
         )
 
         # Use index-based summary if available, otherwise fall back to find
@@ -144,6 +219,10 @@ class CodebaseContextGatherer:
         sections.append("## Recent Commits\n" + (git_log or "(none)"))
         sections.append("## Recent Changes (stat)\n" + (git_diff or "(none)"))
         sections.append(file_section)
+        if audit_targets:
+            sections.append(
+                "## Audit Targets (fan-in / god-modules)\n" + audit_targets
+            )
         if prev_findings:
             sections.append("## Previous Unresolved Findings\n" + prev_findings)
 
@@ -193,7 +272,9 @@ class CodeAuditExecutor:
         prompt = (
             "Analyze this codebase for issues. Return a JSON array of findings.\n"
             'Each finding: {"file": "...", "line": null, "severity": '
-            '"low|medium|high", "suggestion": "...", "confidence": 0.0-1.0}\n\n'
+            '"critical|high|medium|low", "category": '
+            '"structural|async_state|error_handling|tests|security|other", '
+            '"suggestion": "...", "confidence": 0.0-1.0}\n\n'
             f"{context}"
         )
 
@@ -269,6 +350,7 @@ class CodeAuditExecutor:
                 "file": None,
                 "line": None,
                 "severity": "low",
+                "category": "other",
                 "suggestion": text[:500] if text else "No findings",
             }]
 
@@ -293,6 +375,7 @@ class CodeAuditExecutor:
                 "file": item.get("file"),
                 "line": item.get("line"),
                 "severity": item.get("severity", "low"),
+                "category": _safe_category(item.get("category", "other")),
                 "suggestion": suggestion,
             })
 
@@ -305,5 +388,6 @@ class CodeAuditExecutor:
             "file": None,
             "line": None,
             "severity": "low",
+            "category": "other",
             "suggestion": "No findings",
         }]

--- a/tests/test_eval/test_j9_dev_quality.py
+++ b/tests/test_eval/test_j9_dev_quality.py
@@ -1,0 +1,162 @@
+"""Tests for the J-9 ``dev_quality`` dimension (component g).
+
+Uses the shared in-memory migrated ``db`` fixture (tests/conftest.py) and
+seeds the three read paths directly: pr_review_findings observations,
+code_audit observations, and tool_call_outcomes rows.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.db.crud import j9_eval
+from genesis.eval.j9_aggregator import _compute_dev_quality
+
+_SINCE = "2026-07-01T00:00:00+00:00"
+_UNTIL = "2026-07-08T00:00:00+00:00"
+_IN_WINDOW = "2026-07-03T10:00:00Z"       # GitHub-style Z suffix on purpose
+_OUT_OF_WINDOW = "2026-06-01T10:00:00Z"
+
+
+async def _seed_pr_row(db, number: int, *, merged_at: str,
+                       findings: list[dict], review_count: int) -> None:
+    content = json.dumps({
+        "pr": number, "title": f"pr {number}", "merged_at": merged_at,
+        "review_count": review_count, "findings": findings,
+    })
+    await db.execute(
+        "INSERT INTO observations (id, source, type, category, content, "
+        "priority, created_at) VALUES (?, 'recon', 'pr_review_findings', "
+        "'pr_review_findings', ?, 'low', ?)",
+        (f"prrev-{number}", content, "2026-07-06T00:00:00+00:00"),
+    )
+
+
+async def _seed_audit_row(db, oid: str, *, severity: str,
+                          category: str | None = None,
+                          resolved: int = 0) -> None:
+    payload: dict = {"severity": severity}
+    if category:
+        payload["category"] = category
+    await db.execute(
+        "INSERT INTO observations (id, source, type, category, content, "
+        "priority, created_at, resolved) VALUES (?, 'recon', 'code_audit', "
+        "'code_audit', ?, 'medium', '2026-01-01T00:00:00+00:00', ?)",
+        (oid, json.dumps(payload), resolved),
+    )
+
+
+async def _seed_tool_outcome(db, *, tool_name: str = "Edit",
+                             success: int = 1, timestamp: str) -> None:
+    await db.execute(
+        "INSERT INTO tool_call_outcomes (tool_name, success, timestamp) "
+        "VALUES (?, ?, ?)",
+        (tool_name, success, timestamp),
+    )
+
+
+async def test_dev_quality_metrics_exact(db):
+    # PR in window: blocker + should_fix, 2 reviews. PR out of window: ignored
+    # by the windowed metrics but still counted by harvest_prs_seen.
+    await _seed_pr_row(
+        db, 1, merged_at=_IN_WINDOW, review_count=2,
+        findings=[{"severity": "blocker"}, {"severity": "should_fix"}],
+    )
+    await _seed_pr_row(
+        db, 2, merged_at=_OUT_OF_WINDOW, review_count=1,
+        findings=[{"severity": "note"}],
+    )
+    # Open audit finding (counts) + resolved one (must not count).
+    await _seed_audit_row(db, "au1", severity="should_fix", category="correctness")
+    await _seed_audit_row(db, "au2", severity="blocker", resolved=1)
+    # Edit/Write outcomes: 3 in window (1 failure), 1 out of window, and one
+    # in-window non-Edit tool that must be excluded.
+    await _seed_tool_outcome(db, timestamp="2026-07-02T09:00:00+00:00")
+    await _seed_tool_outcome(db, tool_name="Write",
+                             timestamp="2026-07-03T09:00:00+00:00")
+    await _seed_tool_outcome(db, success=0, timestamp="2026-07-04T09:00:00+00:00")
+    await _seed_tool_outcome(db, timestamp="2026-06-01T09:00:00+00:00")
+    await _seed_tool_outcome(db, tool_name="Bash",
+                             timestamp="2026-07-02T09:30:00+00:00")
+    await db.commit()
+
+    metrics, sample = await _compute_dev_quality(db, _SINCE, _UNTIL)
+
+    assert metrics["prs_merged"] == 1
+    assert metrics["review_findings_total"] == 2
+    assert metrics["review_findings_by_severity"] == {
+        "blocker": 1, "should_fix": 1, "note": 0, "unlabeled": 0,
+    }
+    assert metrics["findings_per_pr"] == 2.0
+    assert metrics["review_count_total"] == 2
+    assert metrics["mean_reviews_per_pr"] == 2.0
+    assert metrics["harvest_prs_seen"] == 2  # coverage: windowed or not
+
+    assert metrics["code_audit_open_findings"] == 1
+    assert metrics["code_audit_by_severity"] == {"should_fix": 1}
+    assert metrics["code_audit_by_category"] == {"correctness": 1}
+
+    assert metrics["edit_calls_total"] == 3
+    assert metrics["edit_failures"] == 1
+    assert metrics["edit_failure_rate"] == pytest.approx(1 / 3, abs=1e-3)
+
+    assert sample == 1 + 3  # prs_merged + edit_calls_total
+    assert "note" in metrics  # taxonomy scaffold status stays visible
+
+
+async def test_dev_quality_unknown_severity_folds_to_unlabeled(db):
+    """A severity string outside the canonical vocab is never dropped or
+    guessed — it lands in the honest ``unlabeled`` bucket."""
+    await _seed_pr_row(
+        db, 3, merged_at=_IN_WINDOW, review_count=0,
+        findings=[{"severity": "critical"}, {}],
+    )
+    await db.commit()
+
+    metrics, _ = await _compute_dev_quality(db, _SINCE, _UNTIL)
+    assert metrics["review_findings_total"] == 2
+    assert metrics["review_findings_by_severity"]["unlabeled"] == 2
+
+
+async def test_dev_quality_empty_db_rates_none_never_zero(db):
+    metrics, sample = await _compute_dev_quality(db, _SINCE, _UNTIL)
+
+    assert sample == 0
+    assert metrics["prs_merged"] == 0
+    assert metrics["review_findings_total"] == 0
+    assert metrics["review_findings_by_severity"] == {
+        "blocker": 0, "should_fix": 0, "note": 0, "unlabeled": 0,
+    }
+    assert metrics["findings_per_pr"] is None       # 0/0 → None, NEVER 0.0
+    assert metrics["review_count_total"] == 0
+    assert metrics["mean_reviews_per_pr"] is None
+    assert metrics["code_audit_open_findings"] == 0
+    assert metrics["code_audit_by_severity"] == {}
+    assert metrics["code_audit_by_category"] == {}
+    assert metrics["edit_calls_total"] == 0
+    assert metrics["edit_failures"] == 0
+    assert metrics["edit_failure_rate"] is None
+    assert metrics["harvest_prs_seen"] == 0
+
+
+async def test_run_weekly_aggregation_includes_dev_quality_snapshot_only(db):
+    """E2E guard: the dimension is registered (run_weekly_aggregation swallows
+    per-dimension exceptions, so absence = silent production failure) AND it
+    writes ZERO eval_events — the eval_events CHECK constraint does not
+    include 'dev_quality'; this dimension is snapshot-only."""
+    from genesis.eval.j9_aggregator import run_weekly_aggregation
+
+    results = await run_weekly_aggregation(db)
+
+    assert "dev_quality" in results, "dev_quality failed silently"
+    snap = await j9_eval.get_latest_snapshot(db, dimension="dev_quality")
+    assert snap is not None
+    assert "findings_per_pr" in snap["metrics"]
+    assert "edit_failure_rate" in snap["metrics"]
+
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM eval_events WHERE dimension = 'dev_quality'",
+    )
+    assert (await cursor.fetchone())[0] == 0

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -1031,7 +1031,8 @@ async def test_run_weekly_aggregation_writes_new_dimensions(db):
     results = await run_weekly_aggregation(db)
 
     expected = {"memory", "system", "ego", "cognitive", "procedure",
-                "cognitive_drift", "approvals", "goals", "noise"}
+                "cognitive_drift", "approvals", "goals", "noise",
+                "dev_quality"}
     missing = expected - results.keys()
     assert not missing, f"dimensions failed silently: {missing}"
 

--- a/tests/test_eval/test_pr_review_harvest.py
+++ b/tests/test_eval/test_pr_review_harvest.py
@@ -63,9 +63,10 @@ def _comment(body: str, *, author: str = "codex-bot", path: str = "src/a.py") ->
     return {"body": body, "user": {"login": author}, "path": path}
 
 
-async def _one_pr_observation(db, number: int) -> dict:
+async def _one_pr_observation(db, number: int, repo: str = "acme/widget") -> dict:
     cursor = await db.execute(
-        "SELECT * FROM observations WHERE id = ?", (f"prrev-{number}",),
+        "SELECT * FROM observations WHERE id = ?",
+        (f"prrev-{repo.replace('/', '-')}-{number}",),
     )
     rows = await cursor.fetchall()
     assert len(rows) == 1
@@ -222,7 +223,7 @@ async def test_per_pr_failure_skips_but_harvest_continues(db):
     await _one_pr_observation(db, 101)
     await _one_pr_observation(db, 103)
     cursor = await db.execute(
-        "SELECT COUNT(*) FROM observations WHERE id = 'prrev-102'",
+        "SELECT COUNT(*) FROM observations WHERE id LIKE 'prrev-%-102'",
     )
     assert (await cursor.fetchone())[0] == 0
 

--- a/tests/test_eval/test_pr_review_harvest.py
+++ b/tests/test_eval/test_pr_review_harvest.py
@@ -1,0 +1,264 @@
+"""Tests for eval/pr_review_harvest.py — merged-PR review-finding harvest.
+
+All gh traffic goes through the injectable ``runner`` seam; the fake below
+dispatches on argv shape and records every call so tests can assert the
+exact CLI surface (incl. that inline comments come from the ``/comments``
+API endpoint, NOT ``gh pr view``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.eval.pr_review_harvest import (
+    harvest_pr_review_findings,
+    parse_severity,
+)
+
+# ── fake runner ──────────────────────────────────────────────────────────────
+
+
+def _fake_runner(
+    *,
+    repo_rc: int = 0,
+    pr_list: list[dict] | None = None,
+    pr_list_rc: int = 0,
+    comments: dict[int, list[dict]] | None = None,
+    reviews: dict[int, list[dict]] | None = None,
+    fail_comments_for: tuple[int, ...] = (),
+):
+    """Return an async runner dispatching on argv, with a ``.calls`` log."""
+    comments = comments or {}
+    reviews = reviews or {}
+    calls: list[list[str]] = []
+
+    async def runner(argv: list[str]) -> tuple[int, str, str]:
+        calls.append(list(argv))
+        if argv[:3] == ["gh", "repo", "view"]:
+            if repo_rc != 0:
+                return repo_rc, "", "gh: not a repo"
+            return 0, "acme/widget\n", ""
+        if argv[:3] == ["gh", "pr", "list"]:
+            if pr_list_rc != 0:
+                return pr_list_rc, "", "gh: search failed"
+            return 0, json.dumps(pr_list or []), ""
+        if argv[:2] == ["gh", "api"] and argv[2].endswith("/comments"):
+            number = int(argv[2].rstrip("/").split("/")[-2])
+            if number in fail_comments_for:
+                return 1, "", "HTTP 502"
+            return 0, json.dumps(comments.get(number, [])), ""
+        if argv[:2] == ["gh", "api"] and argv[2].endswith("/reviews"):
+            number = int(argv[2].rstrip("/").split("/")[-2])
+            return 0, json.dumps(reviews.get(number, [])), ""
+        raise AssertionError(f"unexpected argv: {argv}")
+
+    runner.calls = calls
+    return runner
+
+
+def _comment(body: str, *, author: str = "codex-bot", path: str = "src/a.py") -> dict:
+    return {"body": body, "user": {"login": author}, "path": path}
+
+
+async def _one_pr_observation(db, number: int) -> dict:
+    cursor = await db.execute(
+        "SELECT * FROM observations WHERE id = ?", (f"prrev-{number}",),
+    )
+    rows = await cursor.fetchall()
+    assert len(rows) == 1
+    return dict(rows[0])
+
+
+# ── severity parsing ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("P1: this races under load", "blocker"),
+        ("[P2] consider bounding the retry loop", "should_fix"),
+        ("p3 nit about naming", "note"),
+        ("BLOCKER: writes to the shared connection", "blocker"),
+        ("This is a Should-Fix in my opinion", "should_fix"),
+        ("NOTE: docstring drift", "note"),
+        ("looks good to me", "unlabeled"),
+        ("", "unlabeled"),
+        # P4 is not in the vocabulary — never guessed into a bucket
+        ("P4 hypothetical severity", "unlabeled"),
+    ],
+)
+def test_parse_severity_matrix(body, expected):
+    assert parse_severity(body) == expected
+
+
+# ── harvest behavior ─────────────────────────────────────────────────────────
+
+
+async def test_harvest_writes_findings_and_review_count(db):
+    """Inline comments AND the /reviews count are merged into one row per PR."""
+    merged_at = datetime.now(UTC).isoformat()
+    runner = _fake_runner(
+        pr_list=[{"number": 101, "mergedAt": merged_at, "title": "fix: races"}],
+        comments={101: [
+            _comment("P1: race on shutdown"),
+            _comment("[P2] tighten the timeout"),
+            _comment("just curious — why 30s?", author="human"),
+        ]},
+        reviews={101: [{"state": "COMMENTED"}, {"state": "APPROVED"}]},
+    )
+
+    summary = await harvest_pr_review_findings(db, runner=runner)
+
+    assert summary["repo"] == "acme/widget"
+    assert summary["prs_seen"] == 1
+    assert summary["findings_total"] == 3
+    assert summary["by_severity"] == {
+        "blocker": 1, "should_fix": 1, "note": 0, "unlabeled": 1,
+    }
+    assert summary["errors"] == []
+
+    obs = await _one_pr_observation(db, 101)
+    assert obs["source"] == "recon"
+    assert obs["category"] == "pr_review_findings"
+    assert obs["type"] == "pr_review_findings"
+    content = json.loads(obs["content"])
+    assert content["pr"] == 101
+    assert content["title"] == "fix: races"
+    assert content["merged_at"] == merged_at
+    assert content["review_count"] == 2
+    severities = [f["severity"] for f in content["findings"]]
+    assert severities == ["blocker", "should_fix", "unlabeled"]
+    assert content["findings"][0]["author"] == "codex-bot"
+    assert content["findings"][0]["path"] == "src/a.py"
+    assert all(len(f["excerpt"]) <= 120 for f in content["findings"])
+
+
+async def test_harvest_argv_shapes(db):
+    """The gh surface is exact: pulls/N/comments --paginate (NOT gh pr view),
+    a merged:>= search on pr list, and the caller-supplied limit."""
+    runner = _fake_runner(
+        pr_list=[{"number": 7, "mergedAt": datetime.now(UTC).isoformat(), "title": "t"}],
+    )
+    await harvest_pr_review_findings(db, lookback_days=14, limit=25, runner=runner)
+
+    repo_call, list_call, comments_call, reviews_call = runner.calls
+    assert repo_call[:3] == ["gh", "repo", "view"]
+    assert "nameWithOwner" in " ".join(repo_call)
+
+    assert list_call[:3] == ["gh", "pr", "list"]
+    assert list_call[list_call.index("--state"):][:2] == ["--state", "merged"]
+    expected_since = (datetime.now(UTC) - timedelta(days=14)).date().isoformat()
+    assert f"merged:>={expected_since}" in list_call
+    assert list_call[list_call.index("--limit"):][:2] == ["--limit", "25"]
+
+    # The production lesson, pinned: findings come from the inline review
+    # comments endpoint, which `gh pr view --json reviews,comments` misses.
+    assert comments_call[:2] == ["gh", "api"]
+    assert comments_call[2] == "repos/acme/widget/pulls/7/comments"
+    assert "--paginate" in comments_call
+    assert reviews_call[2] == "repos/acme/widget/pulls/7/reviews"
+
+
+async def test_harvest_explicit_repo_skips_resolve(db):
+    runner = _fake_runner(pr_list=[])
+    summary = await harvest_pr_review_findings(db, repo="me/mine", runner=runner)
+    assert summary["repo"] == "me/mine"
+    assert all(c[:3] != ["gh", "repo", "view"] for c in runner.calls)
+    assert "--repo" in runner.calls[0]
+
+
+async def test_double_harvest_single_row_per_pr(db):
+    """Deterministic prrev-<n> id → re-harvest updates in place, no dupes."""
+    merged_at = datetime.now(UTC).isoformat()
+    runner = _fake_runner(
+        pr_list=[{"number": 5, "mergedAt": merged_at, "title": "t"}],
+        comments={5: [_comment("P1: bad")]},
+    )
+    await harvest_pr_review_findings(db, runner=runner)
+    await harvest_pr_review_findings(db, runner=runner)
+
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM observations WHERE category = 'pr_review_findings'",
+    )
+    assert (await cursor.fetchone())[0] == 1
+    await _one_pr_observation(db, 5)  # asserts exactly one row
+
+
+async def test_harvest_sets_expires_at_90d(db):
+    runner = _fake_runner(
+        pr_list=[{"number": 9, "mergedAt": datetime.now(UTC).isoformat(), "title": "t"}],
+    )
+    await harvest_pr_review_findings(db, runner=runner)
+
+    obs = await _one_pr_observation(db, 9)
+    expires = datetime.fromisoformat(obs["expires_at"])
+    delta = expires - datetime.now(UTC)
+    assert timedelta(days=89) < delta < timedelta(days=91)
+
+
+async def test_per_pr_failure_skips_but_harvest_continues(db):
+    """One bad PR must not kill the harvest: it lands in errors, the rest
+    are still written."""
+    merged_at = datetime.now(UTC).isoformat()
+    runner = _fake_runner(
+        pr_list=[
+            {"number": 101, "mergedAt": merged_at, "title": "good"},
+            {"number": 102, "mergedAt": merged_at, "title": "bad"},
+            {"number": 103, "mergedAt": merged_at, "title": "also good"},
+        ],
+        comments={101: [_comment("P2: hmm")], 103: []},
+        fail_comments_for=(102,),
+    )
+    summary = await harvest_pr_review_findings(db, runner=runner)
+
+    assert summary["prs_seen"] == 3
+    assert len(summary["errors"]) == 1
+    assert "102" in summary["errors"][0]
+    assert summary["findings_total"] == 1
+
+    await _one_pr_observation(db, 101)
+    await _one_pr_observation(db, 103)
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM observations WHERE id = 'prrev-102'",
+    )
+    assert (await cursor.fetchone())[0] == 0
+
+
+async def test_repo_resolve_failure_returns_error_dict(db):
+    runner = _fake_runner(repo_rc=1)
+    summary = await harvest_pr_review_findings(db, runner=runner)
+    assert "error" in summary
+    assert "prs_seen" not in summary
+
+
+async def test_pr_list_failure_returns_error_dict(db):
+    runner = _fake_runner(pr_list_rc=1)
+    summary = await harvest_pr_review_findings(db, runner=runner)
+    assert "error" in summary
+
+
+async def test_paginated_concatenated_arrays_are_parsed(db):
+    """``gh api --paginate`` emits one JSON array per page back to back —
+    the harvest must parse the concatenation, not choke on it."""
+    merged_at = datetime.now(UTC).isoformat()
+    page1 = json.dumps([_comment("P1: a")])
+    page2 = json.dumps([_comment("P3: b"), _comment("NOTE: c")])
+
+    async def runner(argv: list[str]) -> tuple[int, str, str]:
+        if argv[:3] == ["gh", "repo", "view"]:
+            return 0, "acme/widget", ""
+        if argv[:3] == ["gh", "pr", "list"]:
+            return 0, json.dumps(
+                [{"number": 1, "mergedAt": merged_at, "title": "t"}],
+            ), ""
+        if argv[2].endswith("/comments"):
+            return 0, page1 + "\n" + page2, ""
+        return 0, "[]", ""
+
+    summary = await harvest_pr_review_findings(db, runner=runner)
+    assert summary["findings_total"] == 3
+    assert summary["by_severity"]["blocker"] == 1
+    assert summary["by_severity"]["note"] == 2

--- a/tests/test_hooks/test_subsystem_traps_hook.py
+++ b/tests/test_hooks/test_subsystem_traps_hook.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/hooks/subsystem_traps_hook.py (PostToolUse Edit|Write).
+
+Runs the hook as a real subprocess with fixture stdin JSON and a synthetic
+CURRENT.md (via GENESIS_CURRENT_MD_PATH) + isolated session dir (via
+GENESIS_SESSIONS_DIR), covering: subsystem match + trap extraction,
+once-per-session-per-subsystem dedup, non-src silence, garbled-file
+fail-open, and the payload cap.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent.parent
+HOOK = REPO_DIR / "scripts" / "hooks" / "subsystem_traps_hook.py"
+
+FIXTURE_MD = """# Map
+
+## 1. Memory — retrieval and store
+
+```yaml subsystem-map
+entry: memory
+modules: [memory, qdrant]
+verified: abc123 2026-07-10
+```
+
+- **CRAG** lives in the MCP wrapper only.
+- **Recall is read-MOSTLY** — hits bump usage counters.
+  second line of this bullet must NOT appear.
+
+**Do not touch:** the drain's shadow hardwiring. **Trap:** FTS5 fallback.
+
+## 2. Execution
+
+```yaml subsystem-map
+entry: execution-cc
+modules: [cc]
+verified: abc123 2026-07-10
+```
+
+- Profile machinery lives in direct_session.py.
+"""
+
+
+def _run(payload: dict, tmp_path: Path, md_text: str = FIXTURE_MD) -> subprocess.CompletedProcess:
+    md = tmp_path / "CURRENT.md"
+    md.write_text(md_text)
+    env = {
+        "GENESIS_CURRENT_MD_PATH": str(md),
+        "GENESIS_SESSIONS_DIR": str(tmp_path / "sessions"),
+        "PATH": "/usr/bin:/bin",
+    }
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def _edit(file_path: str, session_id: str = "sess-1") -> dict:
+    return {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": file_path},
+        "session_id": session_id,
+    }
+
+
+def _context(proc: subprocess.CompletedProcess) -> str | None:
+    if not proc.stdout.strip():
+        return None
+    return json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+def test_memory_edit_injects_entry_and_traps(tmp_path):
+    proc = _run(_edit("/repo/src/genesis/memory/retrieval.py"), tmp_path)
+    assert proc.returncode == 0
+    ctx = _context(proc)
+    assert ctx is not None
+    assert "'memory'" in ctx and "Memory — retrieval and store" in ctx
+    assert "Do not touch:" in ctx and "CRAG" in ctx
+    assert "second line of this bullet" not in ctx  # first-line-only bullets
+
+
+def test_second_edit_same_subsystem_silent(tmp_path):
+    assert _context(_run(_edit("/r/src/genesis/memory/store.py"), tmp_path))
+    proc = _run(_edit("/r/src/genesis/memory/drift.py"), tmp_path)
+    assert proc.returncode == 0 and proc.stdout.strip() == ""
+
+
+def test_different_subsystem_same_session_injects(tmp_path):
+    assert _context(_run(_edit("/r/src/genesis/memory/store.py"), tmp_path))
+    ctx = _context(_run(_edit("/r/src/genesis/cc/invoker.py"), tmp_path))
+    assert ctx is not None and "Execution" in ctx
+
+
+def test_qdrant_module_maps_to_memory_entry(tmp_path):
+    ctx = _context(_run(_edit("/r/src/genesis/qdrant/collections.py"), tmp_path))
+    assert ctx is not None and "Memory" in ctx
+
+
+def test_non_src_paths_silent(tmp_path):
+    for path in ("/r/scripts/foo.py", "/r/tests/test_memory/test_x.py",
+                 "/r/docs/notes.md", "/r/src/genesis"):
+        proc = _run(_edit(path), tmp_path)
+        assert proc.returncode == 0 and proc.stdout.strip() == "", path
+
+
+def test_garbled_current_md_fails_open(tmp_path):
+    proc = _run(
+        _edit("/r/src/genesis/memory/store.py"), tmp_path,
+        md_text="not markdown \x00 at all",
+    )
+    assert proc.returncode == 0 and proc.stdout.strip() == ""
+
+
+def test_payload_cap(tmp_path):
+    bullets = "\n".join(f"- trap number {i} " + "x" * 300 for i in range(20))
+    md = FIXTURE_MD.replace("- **CRAG** lives in the MCP wrapper only.", bullets)
+    proc = _run(_edit("/r/src/genesis/memory/store.py"), tmp_path, md_text=md)
+    ctx = _context(proc)
+    assert ctx is not None and len(ctx) <= 1200
+
+
+def test_traversal_session_id_silent(tmp_path):
+    proc = _run(_edit("/r/src/genesis/memory/store.py", session_id="../evil"), tmp_path)
+    assert proc.returncode == 0 and proc.stdout.strip() == ""
+
+
+def test_malformed_stdin_fails_open(tmp_path):
+    md = tmp_path / "CURRENT.md"
+    md.write_text(FIXTURE_MD)
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)], input="not json", capture_output=True,
+        text=True, timeout=30,
+        env={"GENESIS_CURRENT_MD_PATH": str(md), "PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0 and proc.stdout.strip() == ""
+
+
+def test_registered_in_settings_json():
+    settings = json.loads((REPO_DIR / ".claude" / "settings.json").read_text())
+    commands = [
+        h["command"]
+        for e in settings["hooks"]["PostToolUse"]
+        for h in e.get("hooks", [])
+        if e.get("matcher") in ("Write|Edit", "Edit|Write")
+    ]
+    assert any("subsystem_traps_hook.py" in c for c in commands)

--- a/tests/test_hooks/test_subsystem_traps_hook.py
+++ b/tests/test_hooks/test_subsystem_traps_hook.py
@@ -132,6 +132,49 @@ def test_traversal_session_id_silent(tmp_path):
     assert proc.returncode == 0 and proc.stdout.strip() == ""
 
 
+# The real platform-data entry: modules wrap onto a continuation line, and
+# loose top-level modules are named WITH `.py` (matching check_subsystem_map).
+_WRAPPED_MD = """# Map
+
+## 12. Platform & data
+
+```yaml subsystem-map
+entry: platform-data
+modules: [db, runtime, resilience, observability, security, codebase,
+          restore, util, env.py, _config_overlay.py]
+verified: abc123 2026-07-10
+```
+
+- **Do not touch:** the migration runner's transaction proxy.
+"""
+
+
+def test_multiline_modules_continuation_dir_module(tmp_path):
+    """A dir module on the wrapped continuation line still matches (parser
+    reads until ']', not just the first modules: line)."""
+    for module in ("util", "restore"):
+        proc = _run(
+            _edit(f"/r/src/genesis/{module}/x.py", session_id=module),
+            tmp_path, md_text=_WRAPPED_MD,
+        )
+        ctx = _context(proc)
+        assert ctx is not None, module
+        assert "Platform & data" in ctx
+
+
+def test_loose_top_level_py_module_matches_with_suffix(tmp_path):
+    """A loose top-level module edited as src/genesis/env.py matches the
+    map's `env.py` entry — the segment is kept verbatim, not .py-stripped."""
+    for i, module in enumerate(("env.py", "_config_overlay.py")):
+        proc = _run(
+            _edit(f"/r/src/genesis/{module}", session_id=f"loose-{i}"),
+            tmp_path, md_text=_WRAPPED_MD,
+        )
+        ctx = _context(proc)
+        assert ctx is not None, module
+        assert "Platform & data" in ctx
+
+
 def test_malformed_stdin_fails_open(tmp_path):
     md = tmp_path / "CURRENT.md"
     md.write_text(FIXTURE_MD)

--- a/tests/test_surplus/test_code_audit.py
+++ b/tests/test_surplus/test_code_audit.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiosqlite
 import pytest
 
-from genesis.surplus.code_audit import CodeAuditExecutor, CodebaseContextGatherer, _is_slop
+from genesis.surplus.code_audit import (
+    _MAX_CONTEXT_CHARS,
+    CodeAuditExecutor,
+    CodebaseContextGatherer,
+    _is_slop,
+)
 from genesis.surplus.types import (
     ComputeTier,
     ExecutorResult,
@@ -82,7 +88,7 @@ async def test_gatherer_assembles_context():
 
 @pytest.mark.asyncio
 async def test_gatherer_caps_context_length():
-    """Context is truncated to ~4000 chars."""
+    """Context is truncated to _MAX_CONTEXT_CHARS (6000)."""
     db = AsyncMock()
     cursor_mock = AsyncMock()
     cursor_mock.fetchall = AsyncMock(return_value=[])
@@ -92,13 +98,13 @@ async def test_gatherer_caps_context_length():
 
     with patch.object(gatherer, "_run_cmd", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.side_effect = [
-            "x" * 2000,
-            "y" * 2000,
-            "z" * 2000,
+            "x" * 3000,
+            "y" * 3000,
+            "z" * 3000,
         ]
         ctx = await gatherer.gather()
 
-    assert len(ctx) <= 4100  # 4000 + truncation notice
+    assert len(ctx) <= _MAX_CONTEXT_CHARS + 100  # cap + truncation notice
     assert "truncated" in ctx
 
 
@@ -380,3 +386,210 @@ def test_parse_findings_all_slop_returns_no_findings():
     assert len(results) == 1
     assert results[0]["suggestion"] == "No findings"
     assert results[0]["confidence"] == 0.15
+    assert results[0]["category"] == "other"
+
+
+# ---------------------------------------------------------------------------
+# Category passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_parse_findings_passes_through_valid_category():
+    """A known taxonomy category survives parsing unchanged."""
+    findings_json = json.dumps([
+        {"file": "a.py", "severity": "high", "category": "async_state",
+         "suggestion": "Swallowed error in poll loop", "confidence": 0.9},
+    ])
+    results = CodeAuditExecutor._parse_findings(
+        findings_json, provider="test", drive_alignment="competence",
+    )
+    assert len(results) == 1
+    assert results[0]["category"] == "async_state"
+
+
+def test_parse_findings_missing_category_defaults_to_other():
+    """A finding without a category gets 'other'."""
+    findings_json = json.dumps([
+        {"file": "a.py", "severity": "low",
+         "suggestion": "Unused import asyncio", "confidence": 0.9},
+    ])
+    results = CodeAuditExecutor._parse_findings(
+        findings_json, provider="test", drive_alignment="competence",
+    )
+    assert results[0]["category"] == "other"
+
+
+def test_parse_findings_garbage_category_normalized_to_other():
+    """An unknown or non-string category is normalized to 'other'."""
+    findings_json = json.dumps([
+        {"file": "a.py", "severity": "low", "category": "vibes",
+         "suggestion": "Finding one", "confidence": 0.9},
+        {"file": "b.py", "severity": "low", "category": 42,
+         "suggestion": "Finding two", "confidence": 0.9},
+        {"file": "c.py", "severity": "low", "category": ["tests"],
+         "suggestion": "Finding three", "confidence": 0.9},
+    ])
+    results = CodeAuditExecutor._parse_findings(
+        findings_json, provider="test", drive_alignment="competence",
+    )
+    assert [r["category"] for r in results] == ["other", "other", "other"]
+
+
+def test_parse_findings_category_case_insensitive():
+    """Category matching normalizes case/whitespace before validating."""
+    findings_json = json.dumps([
+        {"file": "a.py", "severity": "low", "category": " Structural ",
+         "suggestion": "Duplicate helper pair", "confidence": 0.9},
+    ])
+    results = CodeAuditExecutor._parse_findings(
+        findings_json, provider="test", drive_alignment="competence",
+    )
+    assert results[0]["category"] == "structural"
+
+
+@pytest.mark.asyncio
+async def test_prompt_schema_includes_critical_and_category():
+    """The inline prompt schema allows 'critical' severity and asks for a category."""
+    routing_result = MagicMock()
+    routing_result.success = True
+    routing_result.content = "[]"
+    routing_result.provider_used = "test"
+    routing_result.error = None
+
+    router = AsyncMock()
+    router.route_call = AsyncMock(return_value=routing_result)
+
+    db = AsyncMock()
+    cursor_mock = AsyncMock()
+    cursor_mock.fetchall = AsyncMock(return_value=[])
+    db.execute = AsyncMock(return_value=cursor_mock)
+
+    executor = CodeAuditExecutor(router=router, db=db, repo_root="/tmp/fake")
+
+    with patch.object(executor._gatherer, "_run_cmd", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = ["log", "diff", "files"]
+        await executor.execute(_make_task())
+
+    call_site, messages = router.route_call.call_args.args
+    assert call_site == "36_code_auditor"
+    user_prompt = messages[-1]["content"]
+    assert '"critical|high|medium|low"' in user_prompt
+    assert '"category"' in user_prompt
+    assert "structural|async_state|error_handling|tests|security|other" in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# Audit Targets inventory (fan-in / god-modules)
+# ---------------------------------------------------------------------------
+
+
+async def _index_db(*, seed: bool) -> aiosqlite.Connection:
+    """In-memory DB with the real code index tables (see codebase/indexer.py)."""
+    from genesis.codebase.indexer import ensure_tables
+
+    conn = await aiosqlite.connect(":memory:")
+    await ensure_tables(conn)
+    if seed:
+        modules = [
+            ("src/genesis/routing/router.py", "routing", "router"),
+            ("src/genesis/memory/store.py", "memory", "store"),
+            ("src/genesis/surplus/types.py", "surplus", "types"),
+            ("src/genesis/runtime/bootstrap.py", "runtime", "bootstrap"),
+        ]
+        for path, pkg, name in modules:
+            await conn.execute(
+                "INSERT INTO code_modules "
+                "(path, package, module_name, loc, file_mtime, last_indexed_at) "
+                "VALUES (?, ?, ?, 100, 0.0, '2026-07-10T00:00:00')",
+                (path, pkg, name),
+            )
+        # Fan-in: genesis.routing.router imported by 3 distinct sources,
+        # genesis.memory.store by 1.
+        imports = [
+            ("src/genesis/memory/store.py", "genesis.routing.router"),
+            ("src/genesis/surplus/types.py", "genesis.routing.router"),
+            ("src/genesis/runtime/bootstrap.py", "genesis.routing.router"),
+            ("src/genesis/runtime/bootstrap.py", "genesis.memory.store"),
+            # God-module: bootstrap.py imports from 5 distinct top-level
+            # genesis packages (routing, memory, surplus, ego, channels).
+            ("src/genesis/runtime/bootstrap.py", "genesis.surplus.types"),
+            ("src/genesis/runtime/bootstrap.py", "genesis.ego.core"),
+            ("src/genesis/runtime/bootstrap.py", "genesis.channels.telegram"),
+            # Relative import stored unresolved — must NOT count as internal.
+            ("src/genesis/routing/router.py", "types"),
+            # Stdlib import — must not appear anywhere.
+            ("src/genesis/routing/router.py", "asyncio"),
+        ]
+        for source, target in imports:
+            await conn.execute(
+                "INSERT INTO code_imports (source_path, target_module) "
+                "VALUES (?, ?)",
+                (source, target),
+            )
+        await conn.commit()
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_gatherer_audit_targets_from_seeded_index():
+    """Seeded code_imports produce the Audit Targets section in context."""
+    conn = await _index_db(seed=True)
+    try:
+        gatherer = CodebaseContextGatherer(conn, repo_root="/tmp/fake")
+        with patch.object(gatherer, "_run_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.side_effect = ["log", "diff"]
+            ctx = await gatherer.gather()
+    finally:
+        await conn.close()
+
+    assert "## Audit Targets (fan-in / god-modules)" in ctx
+    # Fan-in leader with its distinct-importer count
+    assert "genesis.routing.router: 3" in ctx
+    # God-module (5 distinct internal top-level packages)
+    assert "src/genesis/runtime/bootstrap.py: 5 packages" in ctx
+    assert "asyncio" not in ctx.split("## Audit Targets")[1]
+
+
+@pytest.mark.asyncio
+async def test_gatherer_audit_targets_god_module_threshold():
+    """Sources importing from <5 internal packages are not god-modules."""
+    conn = await _index_db(seed=True)
+    try:
+        gatherer = CodebaseContextGatherer(conn, repo_root="/tmp/fake")
+        targets = await gatherer._get_audit_targets()
+    finally:
+        await conn.close()
+
+    god_section = targets.split("God-modules")[1]
+    # bootstrap.py qualifies (5 packages); store.py (1 import) must not.
+    assert "src/genesis/runtime/bootstrap.py" in god_section
+    assert "src/genesis/memory/store.py" not in god_section
+
+
+@pytest.mark.asyncio
+async def test_gatherer_empty_index_omits_audit_targets():
+    """Empty index tables: no crash, no Audit Targets section."""
+    conn = await _index_db(seed=False)
+    try:
+        gatherer = CodebaseContextGatherer(conn, repo_root="/tmp/fake")
+        with patch.object(gatherer, "_run_cmd", new_callable=AsyncMock) as mock_cmd:
+            mock_cmd.side_effect = ["log", "diff", "files"]
+            ctx = await gatherer.gather()
+    finally:
+        await conn.close()
+
+    assert "Audit Targets" not in ctx
+    assert "Recent Commits" in ctx
+
+
+@pytest.mark.asyncio
+async def test_gatherer_missing_index_tables_omit_audit_targets():
+    """A DB without the code index tables degrades to an empty inventory."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        gatherer = CodebaseContextGatherer(conn, repo_root="/tmp/fake")
+        targets = await gatherer._get_audit_targets()
+    finally:
+        await conn.close()
+
+    assert targets == ""


### PR DESCRIPTION
PR-3 (final) of the dev-quality inner-loop program. Companions: #997 (quick wins), independent of #998.

## What

1. **(e) Subsystem-trap locality injection** — new PostToolUse Edit|Write hook: the first time a session touches each subsystem, its do-not-touch edges and easy-to-forget mechanisms from `docs/architecture/CURRENT.md` are injected as `additionalContext` right at the edit. Pure regex parse of the same fenced blocks the subsystem-map CI guard pins (mapping guaranteed complete), once per session per subsystem, 1,200-char cap, fail-open everywhere.
2. **(f) Code-audit taxonomy upgrade** — `CODE_AUDITOR.md` reorganized into the ai-code-audit four-class taxonomy (structural / async_state / error_handling / tests) with an honest single-shot "audit priorities" section (orders attention, not passes); findings now carry a `category`; the context gatherer feeds real import-graph targeting (top-10 fan-in + god-modules from the existing code index — queries verified against prod read-only). **Fixes a pre-existing bug: the executor's inline prompt schema said `low|medium|high` while the identity file defines `critical` — the auditor could never emit a critical finding.**
3. **(g) `dev_quality` eval dimension + PR-review harvester** — weekly job (Sun 06:45 user-tz, 45 min before the 07:30 aggregation; deliberately a separate job so a gh outage degrades to stale rows instead of silently nulling the dimension inside the swallowing j9 loop) pulls merged-PR findings from **inline** review comments (`gh api pulls/N/comments` — `gh pr view --json reviews,comments` misses bot findings; encoded in the module docstring). Lenient severity parse into blocker/should_fix/note/**unlabeled** (honest bucket). Snapshot-only dimension per the A2 honesty rules (raw numerator+denominator, None on 0/0, no composite, scaffolds labeled); dashboard trend direction deliberately None (fewer findings = better code OR weaker review).

## E2E already run

Live harvester against this repo + a prod-DB copy: 10 merged PRs, 12 findings (1 blocker / 9 should_fix / 2 unlabeled), deterministic rows written; `_compute_dev_quality` on the same copy: **findings_per_pr 1.2, mean 1.1 reviews/PR, 1,829 edit calls windowed** — the baseline series exists. Live-fixture traps-hook run verified via its subprocess tests.

## Review

Inline review under the new protocol: scope CLEAN, no BLOCKERs; 1 SHOULD-FIX (registration-guard sync — the exact drift this PR's own docs warn about) + 3 of 4 NOTEs fixed in `e4d47ba4`; the prose-'note' severity leniency is consciously accepted (bot comments dominate the population; the unlabeled bucket absorbs drift visibly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)