### PR TITLE
feat(guardian): host CC auth-health signal + setup-token fallback sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The host Guardian now tells you before its AI recovery brain loses its
+  login — and can survive it without you touching the host.** The Guardian's
+  autonomous diagnosis runs on Claude Code authenticated by a one-time login at
+  install, which never refreshes; if it died, the brain silently went dark and
+  you'd only find out mid-incident. Genesis now watches that login's health and
+  alerts you (over Telegram) if it goes dead, and warns ~30 days before a
+  fallback token would expire. Optionally, mint a one-year token with `claude
+  setup-token` from any machine and pipe it to `scripts/store_cc_token.sh` —
+  Genesis syncs it to the host and uses it **only** as a fallback when the
+  host's own login is dead, never overriding a working login. The token is a
+  subscription token (not an API key), is stored 0600 and never logged, and the
+  health signal sends only status booleans — never the token or your account
+  details. You can set this up at install or just wait for the first alert.
+
 - **`genesis eval bench` — a Genesis-vs-bare-Claude A/B benchmark you can run
   in one command.** Each task in a private task set runs through two arms: a
   cognition-enabled Genesis session (identity + read-only recall from your

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -79,3 +79,39 @@ The guardian also emits a WARNING if the mirror goes stale (its newest
 credential older than `cred_integrity.mirror_stale_hours`, default 48h) — an
 early signal that backups have stopped landing and a container loss would not be
 recoverable from the host.
+
+## Host CC Authentication (Guardian Recovery Brain)
+
+The host Guardian's autonomous diagnosis uses `claude -p` (the "recovery
+brain"), authenticated at install by a one-time `claude login`. That login has
+no refresh, so if it dies the brain silently goes dark — discovered only
+mid-incident.
+
+Two mechanisms make this observable and survivable without host access:
+
+1. **Auth-health signal.** The gateway `version` verb reports `cc_logged_in`
+   (a 1h-cached `claude auth status` probe), `cc_token_present`, and
+   `cc_token_age_days`. The container-side `GuardianWatchdog._check_cc_auth`
+   reconciler alerts (Telegram) when the login is dead with no usable fallback
+   (after a 3-tick threshold), and warns ~30 days before a synced fallback
+   token expires. No token material or account identity ever crosses the wire —
+   only booleans and an age.
+
+2. **Fallback setup-token (optional, lazy).** Mint a 1-year token from ANY
+   machine with `claude setup-token` and pipe it to `scripts/store_cc_token.sh`
+   in the container (stdin only — never an argument). The credential-bridge
+   awareness tick syncs it to the host shared mount
+   (`~/.local/state/genesis-guardian/shared/guardian/cc_oauth_token.env`), and
+   `diagnosis.py` injects it via `CLAUDE_CODE_OAUTH_TOKEN` **only** when a
+   pre-flight `claude auth status` confirms the host's own login is dead — a
+   working login is never overridden. Remove it with
+   `scripts/store_cc_token.sh --remove`.
+
+   The token lives in a **dedicated** file, never `secrets.env` (which is
+   `load_dotenv`'d with `override=True` and would hijack the *container's* own
+   CC auth). It is a subscription-OAuth token, **not** an `ANTHROPIC_API_KEY` —
+   the no-API-key posture is unchanged.
+
+You can mint the token proactively at install, or defer it entirely: the first
+auth-health alert is the cue, and the response becomes "mint + store from
+anywhere" instead of "SSH to the host and re-run `claude login`."

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -148,9 +148,90 @@ PYEOF
                 fi
             fi
         fi
-        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "gateway_sha": "%s", "authkey_no_pty": %s, "authkey_has_from": %s, "authkey_from_matches": %s, "authkey_observed_src_hash": "%s", "authkey_opts_hash": "%s"}\n' \
+        # --- CC recovery-brain auth-health indicators (consumed by the
+        # container's _check_cc_auth reconciler). Least disclosure: emit ONLY
+        # loggedIn (tri-state), token presence, and age — NEVER token material,
+        # and NEVER the account email/orgId that `claude auth status` also prints.
+        # cc_logged_in is a JSON literal true/false/null (null = auth status
+        # unavailable/unparseable, so an old CC or a transient failure never
+        # false-alarms the reconciler).
+        #
+        # The loggedIn probe spawns `claude` (~1s, ~290MB transient RSS, no MCP),
+        # and `version` runs on EVERY 5-min awareness tick — so cache it host-side
+        # with a 1h TTL to keep that spawn off the hot path (host OOM history).
+        # loggedIn here is an early-warning SIGNAL, not an incident-time decision
+        # (the diagnosis path probes fresh, uncached), so ≤1h staleness is fine.
+        # Token presence/age are cheap stats → per-tick, uncached.
+        CC_NOW_EPOCH=$(date +%s)
+        CC_LOGGED_IN=null
+        CC_PROBE_CACHE="$STATE_DIR/cc_auth_probe.json"
+        CC_PROBE_TTL=3600
+        CC_PROBE_FRESH=false
+        if [ -f "$CC_PROBE_CACHE" ]; then
+            CC_CACHED=$(python3 -c '
+import sys, json
+try:
+    d = json.load(open(sys.argv[1]))
+    ts = int(d.get("checked_at", 0)); li = d.get("logged_in")
+    now = int(sys.argv[2]); ttl = int(sys.argv[3])
+    if 0 <= now - ts <= ttl and li in ("true", "false", "null"):
+        print(li)
+except Exception:
+    pass
+' "$CC_PROBE_CACHE" "$CC_NOW_EPOCH" "$CC_PROBE_TTL" 2>/dev/null || true)
+            if [ -n "$CC_CACHED" ]; then CC_LOGGED_IN="$CC_CACHED"; CC_PROBE_FRESH=true; fi
+        fi
+        if [ "$CC_PROBE_FRESH" = false ]; then
+            # timeout 15: node startup + a network round-trip, bounded so the
+            # version verb can't hang the awareness tick on a wedged claude.
+            CC_AUTH_JSON=$(timeout 15 claude auth status --json 2>/dev/null || true)
+            if [ -n "$CC_AUTH_JSON" ]; then
+                CC_LOGGED_IN=$(printf '%s' "$CC_AUTH_JSON" | python3 -c '
+import sys, json
+try:
+    v = json.load(sys.stdin).get("loggedIn")
+    print("true" if v is True else "false" if v is False else "null")
+except Exception:
+    print("null")
+' 2>/dev/null || echo null)
+            fi
+            [ -n "$CC_LOGGED_IN" ] || CC_LOGGED_IN=null
+            # Cache best-effort; a write failure just means we re-probe next tick.
+            mkdir -p "$STATE_DIR" 2>/dev/null || true
+            if printf '{"logged_in": "%s", "checked_at": %s}\n' "$CC_LOGGED_IN" "$CC_NOW_EPOCH" \
+                    > "$CC_PROBE_CACHE.tmp" 2>/dev/null; then
+                mv "$CC_PROBE_CACHE.tmp" "$CC_PROBE_CACHE" 2>/dev/null || true
+            fi
+        fi
+        # Synced setup-token fallback: presence + age (from the shared mount the
+        # credential-bridge writes to). Age drives a pre-expiry warning; -1 =
+        # unknown. Never read or emit the token value itself.
+        CC_TOKEN_FILE="$STATE_DIR/shared/guardian/cc_oauth_token.env"
+        CC_TOKEN_PRESENT=false
+        CC_TOKEN_AGE_DAYS=-1
+        if [ -f "$CC_TOKEN_FILE" ]; then
+            if grep -qE '^CLAUDE_CODE_OAUTH_TOKEN=.+' "$CC_TOKEN_FILE" 2>/dev/null; then
+                CC_TOKEN_PRESENT=true
+            fi
+            CC_TOKEN_CREATED=$(grep '^GENESIS_CC_TOKEN_CREATED_AT=' "$CC_TOKEN_FILE" 2>/dev/null \
+                | head -1 | cut -d= -f2- | tr -d '"' || true)
+            if printf '%s' "$CC_TOKEN_CREATED" | grep -qE '^[0-9]+$'; then
+                CC_TOKEN_AGE_DAYS=$(( (CC_NOW_EPOCH - CC_TOKEN_CREATED) / 86400 ))
+                # A future-dated created_at (clock skew / bad write) → clamp to 0,
+                # never a negative that the reconciler would misread as unknown.
+                if [ "$CC_TOKEN_AGE_DAYS" -lt 0 ]; then CC_TOKEN_AGE_DAYS=0; fi
+            else
+                CC_MTIME=$(stat -c %Y "$CC_TOKEN_FILE" 2>/dev/null || echo "")
+                if printf '%s' "$CC_MTIME" | grep -qE '^[0-9]+$'; then
+                    CC_TOKEN_AGE_DAYS=$(( (CC_NOW_EPOCH - CC_MTIME) / 86400 ))
+                    if [ "$CC_TOKEN_AGE_DAYS" -lt 0 ]; then CC_TOKEN_AGE_DAYS=0; fi
+                fi
+            fi
+        fi
+        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "gateway_sha": "%s", "authkey_no_pty": %s, "authkey_has_from": %s, "authkey_from_matches": %s, "authkey_observed_src_hash": "%s", "authkey_opts_hash": "%s", "cc_logged_in": %s, "cc_token_present": %s, "cc_token_age_days": %s}\n' \
             "$CC_VER" "$NODE_VER" "$CODE_VER" "$CODE_DATE" "$DEPLOYED" "$GW_SHA" \
-            "$AK_NO_PTY" "$AK_HAS_FROM" "$AK_FROM_MATCHES" "$AK_SRC_HASH" "$AK_OPTS_HASH"
+            "$AK_NO_PTY" "$AK_HAS_FROM" "$AK_FROM_MATCHES" "$AK_SRC_HASH" "$AK_OPTS_HASH" \
+            "$CC_LOGGED_IN" "$CC_TOKEN_PRESENT" "$CC_TOKEN_AGE_DAYS"
         ;;
     update)
         INSTALL_DIR="${HOME}/.local/share/genesis-guardian"

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -197,6 +197,12 @@ except Exception:
             fi
             [ -n "$CC_LOGGED_IN" ] || CC_LOGGED_IN=null
             # Cache best-effort; a write failure just means we re-probe next tick.
+            # We DELIBERATELY cache `null` too: the cache exists to bound the
+            # ~290MB claude spawn on this OOM-history host, and a broken/hung
+            # claude returns null every time — caching it keeps that at 1/hr
+            # instead of 1/tick. The cost is ≤1h latency to notice a recovered
+            # login (an early-warning signal only; the diagnosis path always
+            # probes fresh at incident time), which is an acceptable trade.
             mkdir -p "$STATE_DIR" 2>/dev/null || true
             if printf '{"logged_in": "%s", "checked_at": %s}\n' "$CC_LOGGED_IN" "$CC_NOW_EPOCH" \
                     > "$CC_PROBE_CACHE.tmp" 2>/dev/null; then
@@ -216,14 +222,16 @@ except Exception:
             CC_TOKEN_CREATED=$(grep '^GENESIS_CC_TOKEN_CREATED_AT=' "$CC_TOKEN_FILE" 2>/dev/null \
                 | head -1 | cut -d= -f2- | tr -d '"' || true)
             if printf '%s' "$CC_TOKEN_CREATED" | grep -qE '^[0-9]+$'; then
-                CC_TOKEN_AGE_DAYS=$(( (CC_NOW_EPOCH - CC_TOKEN_CREATED) / 86400 ))
+                # 10# forces base-10: a corrupt leading-zero created_at (e.g.
+                # 08…) would otherwise be read as octal → arithmetic error.
+                CC_TOKEN_AGE_DAYS=$(( (CC_NOW_EPOCH - 10#$CC_TOKEN_CREATED) / 86400 ))
                 # A future-dated created_at (clock skew / bad write) → clamp to 0,
                 # never a negative that the reconciler would misread as unknown.
                 if [ "$CC_TOKEN_AGE_DAYS" -lt 0 ]; then CC_TOKEN_AGE_DAYS=0; fi
             else
                 CC_MTIME=$(stat -c %Y "$CC_TOKEN_FILE" 2>/dev/null || echo "")
                 if printf '%s' "$CC_MTIME" | grep -qE '^[0-9]+$'; then
-                    CC_TOKEN_AGE_DAYS=$(( (CC_NOW_EPOCH - CC_MTIME) / 86400 ))
+                    CC_TOKEN_AGE_DAYS=$(( (CC_NOW_EPOCH - 10#$CC_MTIME) / 86400 ))
                     if [ "$CC_TOKEN_AGE_DAYS" -lt 0 ]; then CC_TOKEN_AGE_DAYS=0; fi
                 fi
             fi

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -351,6 +351,11 @@ if [ "$CC_ENABLED" = "true" ] && [ "$CC_AUTHENTICATED" = "false" ] && [ "$NON_IN
     echo "  Claude Code, but autonomous diagnosis — where Guardian"
     echo "  uses AI to investigate and fix problems — requires it."
     echo ""
+    echo "  Fallback (no re-SSH if this login ever dies): mint a 1-year token"
+    echo "  with 'claude setup-token' from ANY machine and pipe it to"
+    echo "  'scripts/store_cc_token.sh' in the container. Genesis syncs it here"
+    echo "  and uses it only as a fallback when this login is dead."
+    echo ""
     if [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
         echo "  Since you're on a headless machine:"
         echo "    1. It will print a URL — open it in YOUR browser"
@@ -367,10 +372,12 @@ if [ "$CC_ENABLED" = "true" ] && [ "$CC_AUTHENTICATED" = "false" ] && [ "$NON_IN
             echo "  + Claude Code authenticated"
         else
             echo "  WARNING: Login failed or was skipped"
-            echo "  To log in later: claude login (from this host)"
+            echo "  To log in later: claude login (from this host), or mint a"
+            echo "  setup-token from anywhere (see scripts/store_cc_token.sh)"
         fi
     else
-        echo "  Skipped. To log in later: claude login (from this host)"
+        echo "  Skipped. To log in later: claude login (from this host), or mint"
+        echo "  a setup-token from anywhere (see scripts/store_cc_token.sh)"
     fi
 fi
 

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# store_cc_token.sh — intake a `claude setup-token` OAuth token for the host
+# Guardian recovery brain's FALLBACK authentication.
+#
+# The host Guardian's `claude -p` recovery brain authenticates via a one-time
+# manual `claude login` (no refresh). If that login dies, the brain goes dark.
+# A `claude setup-token` 1-year OAuth token (used via CLAUDE_CODE_OAUTH_TOKEN —
+# NOT an ANTHROPIC_API_KEY) stored here is synced to the host by the
+# credential-bridge awareness tick and injected by diagnosis.py ONLY as a
+# fallback when the host's own login is dead (a working login is never touched).
+#
+# The token is read from STDIN ONLY (never argv — no shell-history / ps leak),
+# written 0600 to a DEDICATED file (NOT secrets.env, which is load_dotenv'd with
+# override=True and would hijack the container's own CC auth — see
+# credential_bridge.py), and stamped with its creation epoch. This script prints
+# ZERO token material.
+#
+# Usage:
+#   claude setup-token | scripts/store_cc_token.sh     # store (stdin only)
+#   scripts/store_cc_token.sh --remove                 # remove everywhere
+#   scripts/store_cc_token.sh --help
+
+set -euo pipefail
+
+TOKEN_FILE="${HOME}/.genesis/cc_oauth_token.env"
+SHARED_FILE="${HOME}/.genesis/shared/guardian/cc_oauth_token.env"
+
+usage() {
+    sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --remove)
+        removed=0
+        for f in "$TOKEN_FILE" "$SHARED_FILE"; do
+            if [ -f "$f" ]; then
+                rm -f "$f"
+                removed=1
+            fi
+        done
+        if [ "$removed" -eq 1 ]; then
+            echo "CC OAuth token removed (container source + shared mount)."
+            echo "The host will fall back to its own \`claude login\`."
+        else
+            echo "No CC OAuth token file found — nothing to remove."
+        fi
+        exit 0
+        ;;
+    "")
+        : # fall through to stdin intake
+        ;;
+    *)
+        echo "ERROR: unknown argument '$1'. Token must be piped via stdin — never passed as an argument." >&2
+        echo "  claude setup-token | $0" >&2
+        exit 1
+        ;;
+esac
+
+if [ -t 0 ]; then
+    echo "ERROR: token must be piped via stdin (never an argument), e.g.:" >&2
+    echo "  claude setup-token | $0" >&2
+    exit 1
+fi
+
+# Read the first non-empty line (setup-token prints one token line). Trailing
+# no-newline is handled by the `|| [ -n "$line" ]` guard.
+TOKEN=""
+while IFS= read -r line || [ -n "$line" ]; do
+    line="$(printf '%s' "$line" | tr -d '[:space:]')"
+    if [ -n "$line" ]; then
+        TOKEN="$line"
+        break
+    fi
+done
+
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: no token received on stdin." >&2
+    exit 1
+fi
+
+# Sanity-check the shape but do not hard-fail (the CLI format could evolve).
+case "$TOKEN" in
+    sk-ant-oat*) : ;;
+    *) echo "WARNING: token does not start with 'sk-ant-oat' — storing anyway." >&2 ;;
+esac
+
+mkdir -p "$(dirname "$TOKEN_FILE")"
+CREATED=$(date +%s)
+OLD_UMASK=$(umask)
+umask 077
+printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\nGENESIS_CC_TOKEN_CREATED_AT=%s\n' "$TOKEN" "$CREATED" > "$TOKEN_FILE.tmp"
+chmod 600 "$TOKEN_FILE.tmp"
+mv "$TOKEN_FILE.tmp" "$TOKEN_FILE"
+umask "$OLD_UMASK"
+
+WHEN=$(date -d "@$CREATED" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "$CREATED")
+echo "CC OAuth token stored: ${#TOKEN} chars, created_at=$CREATED ($WHEN)."
+echo "File: $TOKEN_FILE (0600). It syncs to the host on the next awareness tick (~5 min)."
+echo "The host uses it ONLY as a fallback when its own \`claude login\` is dead."

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -14,6 +14,7 @@ host reads from $STATE_DIR/shared/guardian/telegram_creds.env.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import shutil
@@ -24,10 +25,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "load_backup_passphrase",
+    "load_cc_oauth_token",
     "load_provisioning_credentials",
     "load_telegram_credentials",
     "mirror_credential_backup",
     "propagate_backup_passphrase",
+    "propagate_cc_oauth_token",
     "propagate_guardian_credentials",
     "propagate_provisioning_credentials",
     "propagate_telegram_credentials",
@@ -79,6 +82,26 @@ _KEY_MAP_PASSPHRASE = {
 _MIRROR_SUBDIR = "creds-mirror"      # under <shared>/guardian/
 _MIRROR_STAMP = "MIRROR_STAMP"       # completeness marker, written LAST
 _MIRROR_SRC_SUBDIRS = ("creds", "secrets")  # subtrees of the Tier-1 clone to mirror
+
+# CC recovery-brain OAuth setup-token sync. The host Guardian's `claude -p`
+# recovery brain authenticates via a one-time manual `claude login` (no refresh),
+# so if that login dies the brain silently goes dark. A `claude setup-token`
+# 1-year OAuth token (used via CLAUDE_CODE_OAUTH_TOKEN — NOT an ANTHROPIC_API_KEY)
+# minted anywhere and dropped in the dedicated container file below is synced to
+# the host shared mount; the host-side diagnosis path injects it ONLY as a
+# FALLBACK when its own login is dead (never degrades a working login). Two keys
+# cross: the token + its creation epoch (which drives the pre-expiry warning).
+# ⚠ The token lives in a DEDICATED file, NOT secrets.env: runtime/init/secrets.py
+# does load_dotenv(secrets.env, override=True), which would inject
+# CLAUDE_CODE_OAUTH_TOKEN into every CONTAINER-side `claude` subprocess and
+# hijack the container's own CC auth. Keeping it out of secrets.env is
+# load-bearing, not tidiness.
+_CC_TOKEN_FILENAME = "cc_oauth_token.env"
+_CC_TOKEN_SOURCE = Path("~/.genesis/cc_oauth_token.env").expanduser()
+_KEY_MAP_CC_TOKEN = {
+    "CLAUDE_CODE_OAUTH_TOKEN": "CLAUDE_CODE_OAUTH_TOKEN",
+    "GENESIS_CC_TOKEN_CREATED_AT": "GENESIS_CC_TOKEN_CREATED_AT",
+}
 
 # Keys to extract from container secrets.env
 # Maps source key name → output key name
@@ -320,12 +343,79 @@ def mirror_credential_backup(
     return dest_root
 
 
+def propagate_cc_oauth_token(
+    shared_dir: Path | None = None,
+    source_path: Path | None = None,
+    secrets_path: Path | None = None,
+) -> Path | None:
+    """Sync the CC setup-token (+ creation epoch) → host shared mount.
+
+    Reads the DEDICATED container file (``~/.genesis/cc_oauth_token.env``,
+    written by ``scripts/store_cc_token.sh``), NEVER secrets.env — see the
+    module note: secrets.env is ``load_dotenv``'d with ``override=True`` and a
+    token there would hijack the container's own CC auth. The host injects this
+    token ONLY as a fallback when its own ``claude login`` is dead. Opt-in /
+    lazy: absent file or no token → returns None (nothing propagated).
+
+    ``secrets_path`` is accepted (and ignored) so the combined bridge can call
+    every leg with a uniform signature; the token has its own source file.
+    """
+    src = source_path or _CC_TOKEN_SOURCE
+    out_dir = (shared_dir or _CONTAINER_SHARED_DIR) / _CREDS_SUBDIR
+
+    source_creds = _read_dotenv(src)
+    if not source_creds:
+        logger.debug("No CC token file at %s — skipping cc-token propagation", src)
+        return None
+
+    creds: dict[str, str] = {}
+    for src_key, dst_key in _KEY_MAP_CC_TOKEN.items():
+        value = source_creds.get(src_key, "")
+        if value:
+            creds[dst_key] = value
+
+    if not creds.get("CLAUDE_CODE_OAUTH_TOKEN"):
+        logger.debug("No CLAUDE_CODE_OAUTH_TOKEN present — skipping cc-token propagation")
+        return None
+
+    # Backfill the creation epoch from the source file's mtime if the intake
+    # script didn't stamp one — age drives the host's pre-expiry warning.
+    if not creds.get("GENESIS_CC_TOKEN_CREATED_AT"):
+        with contextlib.suppress(OSError):
+            creds["GENESIS_CC_TOKEN_CREATED_AT"] = str(int(src.stat().st_mtime))
+
+    out_path = _write_creds_atomic(out_dir, _CC_TOKEN_FILENAME, creds)
+    logger.debug("CC OAuth token propagated to %s", out_path)  # never logs the value
+    return out_path
+
+
+def load_cc_oauth_token(
+    state_dir: str = "~/.local/state/genesis-guardian",
+) -> dict[str, str]:
+    """Read the synced CC OAuth token from the shared mount (host side).
+
+    Returns {} when absent/unreadable — the host then relies on its own
+    ``claude login`` (the token is injected only when that login is dead).
+    """
+    creds_path = (
+        Path(state_dir).expanduser() / "shared" / _CREDS_SUBDIR / _CC_TOKEN_FILENAME
+    )
+    if not creds_path.exists():
+        logger.debug("Synced CC OAuth token not found at %s", creds_path)
+        return {}
+    try:
+        return _read_dotenv(creds_path)
+    except OSError as exc:
+        logger.warning("Failed to read synced CC OAuth token: %s", exc)
+        return {}
+
+
 def propagate_guardian_credentials(
     shared_dir: Path | None = None,
     secrets_path: Path | None = None,
 ) -> list[Path]:
     """Combined container-side bridge: telegram + provisioning + passphrase escrow
-    + encrypted-backup mirror.
+    + cc-token + encrypted-backup mirror.
 
     Wired to the awareness-loop tick (called zero-arg). A failure in one leg
     never blocks the others, and never raises into the loop.
@@ -335,6 +425,7 @@ def propagate_guardian_credentials(
         propagate_telegram_credentials,
         propagate_provisioning_credentials,
         propagate_backup_passphrase,
+        propagate_cc_oauth_token,
     ):
         try:
             path = fn(shared_dir=shared_dir, secrets_path=secrets_path)

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -495,6 +496,7 @@ class DiagnosisEngine:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(work_dir),
+            env=await self._resolve_cc_env(cc_path),
         )
 
         try:
@@ -526,6 +528,77 @@ class DiagnosisEngine:
                 "No valid JSON diagnosis found in CC response"
             )
         return result
+
+    async def _resolve_cc_env(self, cc_path: str) -> dict[str, str] | None:
+        """Resolve the environment for the CC recovery-brain subprocess.
+
+        FALLBACK-ONLY setup-token injection. Returns ``None`` (inherit
+        ``os.environ`` — the ``create_subprocess_exec`` default, identical to
+        today's behavior) UNLESS a pre-flight ``claude auth status`` confirms the
+        host's own ``claude login`` is DEAD, in which case it injects the synced
+        ``CLAUDE_CODE_OAUTH_TOKEN`` so the brain can still authenticate.
+
+        The pre-flight runs with the SAME inherited env the real brain gets in
+        the no-token case, so ``loggedIn: true`` faithfully predicts the real
+        invocation. ``{**os.environ, ...}`` preserves every inherited key (the
+        brain relies on inherited provider keys — no env scrub), adding only the
+        token.
+
+        ⚠ Honest boundary: ``CLAUDE_CODE_OAUTH_TOKEN`` *overrides* a stored
+        login, so "never degrade a working login" rests on the pre-flight
+        reporting ``loggedIn`` correctly. On a FALSE ``loggedIn: false`` (login
+        actually fine) coinciding with a STALE synced token, we would inject and
+        the brain would fail onto the bad token — but that lands as the existing
+        ``CCDiagnosisError`` → ``cc_unavailable`` escalation (a clean fail-safe,
+        NOT silent brain death), only in that rare double-coincidence. We never
+        inject on ambiguity (unparseable / timeout / ``loggedIn`` unknown) nor
+        when no token exists. Never raises; never logs the token value.
+
+        Cost: one ~1-3s ``auth status`` call per diagnosis. Diagnosis fires only
+        when Genesis is DOWN (rare), so it is deliberately NOT cached — caching
+        would reintroduce the auth-staleness class this whole feature kills.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                cc_path, "auth", "status", "--json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            try:
+                # 15s: node startup + a network round-trip, generous for a
+                # degraded host but bounded so a wedged probe can't hang the
+                # (already timeout-bounded) diagnosis. Never inherits the token.
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+            except TimeoutError:
+                if proc.returncode is None:
+                    proc.kill()
+                    await proc.wait()
+                return None  # ambiguous → inherit; fail-safe covers a real outage
+            try:
+                logged_in = json.loads(
+                    stdout.decode("utf-8", errors="replace"),
+                ).get("loggedIn")
+            except (json.JSONDecodeError, ValueError):
+                return None  # unparseable → never inject on ambiguity
+            if logged_in is not False:
+                # True (login works) or None (unknown) → inherit, never inject.
+                return None
+            # Host login is dead → inject the synced fallback token if present.
+            from genesis.guardian.credential_bridge import load_cc_oauth_token
+
+            token = load_cc_oauth_token(self._config.state_dir).get(
+                "CLAUDE_CODE_OAUTH_TOKEN",
+            )
+            if not token:
+                return None  # no fallback → inherit; cc_unavailable fail-safe fires
+            logger.warning(
+                "Host `claude login` reports logged-out — injecting the synced "
+                "setup-token as this diagnosis's fallback (token value not logged).",
+            )
+            return {**os.environ, "CLAUDE_CODE_OAUTH_TOKEN": token}
+        except Exception:
+            logger.debug("CC auth pre-flight failed; inheriting env", exc_info=True)
+            return None
 
     def _parse_cc_response(self, raw: str) -> DiagnosisResult | None:
         """Parse the CC response into a DiagnosisResult.

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -578,8 +578,10 @@ class DiagnosisEngine:
                 logged_in = json.loads(
                     stdout.decode("utf-8", errors="replace"),
                 ).get("loggedIn")
-            except (json.JSONDecodeError, ValueError):
-                return None  # unparseable → never inject on ambiguity
+            except (json.JSONDecodeError, ValueError, AttributeError, TypeError):
+                # Unparseable, or valid-but-non-object JSON (null/true/[] → no
+                # .get) → treat as ambiguity, never inject.
+                return None
             if logged_in is not False:
                 # True (login works) or None (unknown) → inherit, never inject.
                 return None

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -32,6 +32,11 @@ _DISK_RE = re.compile(r"(scsi|virtio|sata)[0-9]{1,2}")
 # `timeout N` so the gateway's timeout fires first with a clean JSON error
 # rather than the client killing the connection mid-op.
 _STATUS_TIMEOUT = 70.0       # gateway: timeout 60
+# version now also runs `claude auth status` (node startup + a network round-trip,
+# bounded host-side by `timeout 15`) on top of claude/node/git version reads, so
+# the 10s instance default is too tight — a slow verb would return `unreachable`
+# and silently skip EVERY drift/authkey/cc-auth reconciler that reuses this call.
+_VERSION_TIMEOUT = 30.0      # gateway version verb: auth-status probe + version reads
 _GROW_DISK_TIMEOUT = 660.0   # gateway: timeout 600 (PVE resize + storage-expand)
 _GROW_MEM_TIMEOUT = 180.0    # gateway: timeout 120 (config PUT + pending check)
 _EXPAND_TIMEOUT = 660.0      # gateway: timeout 600 (pvresize + autoextend profile)
@@ -153,7 +158,7 @@ class GuardianRemote:
 
     async def version(self) -> dict:
         """Query Guardian version info (CC, Node, code) from the host."""
-        ok, output = await self._ssh_command("version")
+        ok, output = await self._ssh_command("version", timeout=_VERSION_TIMEOUT)
         if ok:
             try:
                 return json.loads(output)

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -835,7 +835,14 @@ class GuardianWatchdog:
         if logged_in is not False:
             # logged_in is None (ambiguous / old CC / transient) AND no usable
             # token → never false-alarm on ambiguity; the diagnosis fail-safe
-            # still catches a genuine outage at incident time.
+            # still catches a genuine outage at incident time. We deliberately
+            # neither increment NOR reset the drift streak here: an ambiguous
+            # tick must not CLEAR a real dead signal (so a host that reports
+            # False/None/False, never True, still accumulates toward the alert),
+            # but it also isn't itself evidence of a dead brain. So this
+            # reconciler's threshold counts "ticks that never confirmed
+            # auth-able," which is intentionally looser than the strictly-
+            # consecutive semantics of the sibling reconcilers.
             return
         # logged_in is False AND no usable fallback token → genuinely dead brain.
         self._cc_auth_drift_count += 1

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -47,6 +47,8 @@ class GuardianWatchdog:
         "scripts/install_guardian.sh", "scripts/guardian-gateway.sh",
     ]
     DRIFT_ALERT_THRESHOLD = 3   # Consecutive drifted ticks before alerting
+    CC_TOKEN_WARN_AGE_DAYS = 335  # warn ~30d before a 1-year setup-token expires
+    _CC_TOKEN_MAX_AGE_DAYS = 365  # setup-token lifetime; older = expired/unusable
 
     def __init__(
         self,
@@ -77,6 +79,15 @@ class GuardianWatchdog:
         self._authkey_escalated: bool = False
         self._authkey_flap_escalated: bool = False
         self._authkey_last_src_hash: str | None = None
+        # CC recovery-brain auth health: alert when the host login is dead with
+        # no usable fallback token (dead-brain), and warn before the synced
+        # setup-token expires. Alert-only — no safe non-interactive remediation
+        # (claude login / setup-token both need a human; the token re-copy is the
+        # diagnosis fallback's + credential-bridge's job). The expiry-warning
+        # guard has its OWN token-refresh lifecycle, NOT the health reset.
+        self._cc_auth_drift_count: int = 0
+        self._cc_auth_escalated: bool = False
+        self._cc_token_expiry_warned: bool = False
 
     async def _alert_user(self, *, topic: str, context: str, source_id: str) -> None:
         """Deliver a user-facing (Telegram) alert about a Guardian degradation.
@@ -342,6 +353,11 @@ class GuardianWatchdog:
         # Own suppress so a failure here can't skip code-drift logic below.
         with contextlib.suppress(Exception):
             await self._check_authkey_hardening(version_info)
+
+        # CC recovery-brain auth-health reconciler reuses the same payload. Own
+        # suppress so a failure here can't skip code-drift logic below.
+        with contextlib.suppress(Exception):
+            await self._check_cc_auth(version_info)
 
         host_hash = version_info.get("deployed_commit", "unknown")
 
@@ -759,4 +775,142 @@ class GuardianWatchdog:
             topic="Guardian key source flapping",
             context=message,
             source_id="guardian:authkey_flap",
+        )
+
+    def _reset_cc_auth_state(self) -> None:
+        """Reset ONLY the dead-brain drift/escalation state (re-arm on health).
+
+        The expiry-warning guard (``_cc_token_expiry_warned``) is deliberately
+        NOT reset here — it has its own token-refresh lifecycle. Resetting it on
+        health would re-warn every tick a healthy login is up (spam); never
+        resetting it would one-shot forever and miss the NEXT token's expiry.
+        """
+        self._cc_auth_drift_count = 0
+        self._cc_auth_escalated = False
+
+    async def _check_cc_auth(self, version_info: dict) -> None:
+        """Alert when the host CC recovery brain cannot authenticate.
+
+        The host ``version`` verb reports ``cc_logged_in`` (tri-state True/
+        False/None), ``cc_token_present`` (bool), and ``cc_token_age_days``
+        (int, -1 unknown). Two independent concerns:
+
+        * **Pre-expiry WARNING** — the synced setup-token nears its ~1-year end.
+          Runs BEFORE the healthy early-return, so a token rotting while the
+          primary login is fine is still surfaced (its whole point is insurance
+          against a FUTURE login death).
+        * **Dead-brain ALERT** — the host ``claude login`` is dead AND no usable
+          fallback token exists. Needs ``DRIFT_ALERT_THRESHOLD`` ticks (mirrors
+          the authkey/staleness reconcilers) so a blip doesn't page.
+
+        Alert-only: unlike authkey (``reharden-key``) / gateway
+        (``sync-gateway``) there is NO safe non-interactive remediation —
+        ``claude login`` / ``setup-token`` both need a human, and the token
+        re-copy is already the diagnosis fallback's + credential-bridge's job.
+        Best-effort (invoked under _check_code_drift's suppress).
+        """
+        # Old gateway without the cc_* fields → nothing to reconcile.
+        if "cc_logged_in" not in version_info:
+            return
+        logged_in = version_info.get("cc_logged_in")  # True / False / None
+        token_present = version_info.get("cc_token_present") is True
+        age = version_info.get("cc_token_age_days")
+        age = age if isinstance(age, int) and not isinstance(age, bool) else -1
+
+        # 1. Pre-expiry warning — independent of login health, BEFORE the gate.
+        await self._check_cc_token_expiry(token_present, age)
+
+        # 2. Dead-brain gate. A usable fallback = present AND not past its 1-year
+        #    lifetime (age == -1 unknown → optimistically usable; the diagnosis
+        #    fail-safe still backstops a truly-expired unknown-age token).
+        token_usable = token_present and (
+            age == -1 or age < self._CC_TOKEN_MAX_AGE_DAYS
+        )
+        if logged_in is True or token_usable:
+            # Login works, or a usable fallback exists → brain can authenticate.
+            if self._cc_auth_drift_count > 0:
+                logger.info("Guardian CC recovery-brain auth recovered")
+            self._reset_cc_auth_state()
+            return
+        if logged_in is not False:
+            # logged_in is None (ambiguous / old CC / transient) AND no usable
+            # token → never false-alarm on ambiguity; the diagnosis fail-safe
+            # still catches a genuine outage at incident time.
+            return
+        # logged_in is False AND no usable fallback token → genuinely dead brain.
+        self._cc_auth_drift_count += 1
+        if self._cc_auth_drift_count < self.DRIFT_ALERT_THRESHOLD:
+            return
+        await self._escalate_cc_auth(token_present=token_present, age=age)
+
+    async def _check_cc_token_expiry(self, token_present: bool, age: int) -> None:
+        """One WARNING per episode as the synced fallback token nears expiry.
+
+        Re-arms on token refresh (age back below the warn threshold, or the
+        token going absent) — NOT on login health — so it neither spams a
+        healthy host nor one-shots forever and misses the next token's expiry.
+        """
+        if not token_present or age < 0:
+            # No token, or unknown age → nothing to warn about; re-arm.
+            self._cc_token_expiry_warned = False
+            return
+        if age < self.CC_TOKEN_WARN_AGE_DAYS:
+            self._cc_token_expiry_warned = False  # fresh / refreshed → re-arm
+            return
+        if self._cc_token_expiry_warned:
+            return
+        self._cc_token_expiry_warned = True
+        msg = (
+            f"Guardian's synced CC fallback setup-token is nearing expiry "
+            f"(age {age} d of a ~1-year lifetime). Re-run `claude setup-token` "
+            f"and pipe it to `scripts/store_cc_token.sh` to refresh it before "
+            f"the host login could ever need the fallback."
+        )
+        logger.warning(msg)
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.WARNING,
+                "guardian.cc_token_expiring", msg,
+            )
+        await self._alert_user(
+            topic="Guardian CC token expiring",
+            context=msg,
+            source_id="guardian:cc_token_expiring",
+        )
+
+    async def _escalate_cc_auth(self, *, token_present: bool, age: int) -> None:
+        """One dead-brain ALERT per episode (re-armed by _reset_cc_auth_state)."""
+        if self._cc_auth_escalated:
+            return
+        self._cc_auth_escalated = True
+        if token_present:
+            remedy = (
+                f"the synced setup-token appears expired/invalid (age {age} d) — "
+                f"re-run `claude setup-token` → `scripts/store_cc_token.sh`, or "
+                f"`claude login` on the host."
+            )
+        else:
+            remedy = (
+                "run `claude setup-token` and pipe it to "
+                "`scripts/store_cc_token.sh` (preferred — no host access needed), "
+                "or `claude login` on the host."
+            )
+        msg = (
+            "Guardian's CC recovery brain cannot authenticate: the host `claude "
+            f"login` is dead and no usable fallback token is available — {remedy} "
+            "Host self-diagnosis is unavailable until then (other recovery paths "
+            "still work)."
+        )
+        logger.error(msg)
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.ERROR,
+                "guardian.cc_auth_unhealthy", msg,
+            )
+        await self._alert_user(
+            topic="Guardian CC auth dead",
+            context=msg,
+            source_id="guardian:cc_auth_unhealthy",
         )

--- a/tests/test_guardian/test_credential_bridge.py
+++ b/tests/test_guardian/test_credential_bridge.py
@@ -486,3 +486,86 @@ class TestMirrorCredentialBackup:
         shared = tmp_path / "shared"
         shared.mkdir()
         assert mirror_credential_backup(shared_dir=shared, backup_dir=clone) is None
+
+
+class TestCCOAuthTokenSync:
+    """CC setup-token sync — dedicated source file, never secrets.env."""
+
+    def test_syncs_token_and_created_at(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import (
+            load_cc_oauth_token,
+            propagate_cc_oauth_token,
+        )
+        src = tmp_path / "container" / "cc_oauth_token.env"
+        src.parent.mkdir(parents=True)
+        src.write_text(
+            "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-SYNTHETIC\n"
+            "GENESIS_CC_TOKEN_CREATED_AT=1700000000\n",
+        )
+        shared = tmp_path / "state" / "shared"
+        out = propagate_cc_oauth_token(shared_dir=shared, source_path=src)
+        assert out is not None
+        assert out.name == "cc_oauth_token.env"
+        assert stat.S_IMODE(os.stat(out).st_mode) == 0o600
+        result = load_cc_oauth_token(str(tmp_path / "state"))
+        assert result == {
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-SYNTHETIC",
+            "GENESIS_CC_TOKEN_CREATED_AT": "1700000000",
+        }
+
+    def test_backfills_created_at_from_mtime(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import (
+            _read_dotenv,
+            propagate_cc_oauth_token,
+        )
+        src = tmp_path / "cc_oauth_token.env"
+        src.write_text("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-X\n")
+        out = propagate_cc_oauth_token(shared_dir=tmp_path / "shared", source_path=src)
+        assert out is not None
+        back = _read_dotenv(out)
+        assert back["GENESIS_CC_TOKEN_CREATED_AT"].isdigit()
+
+    def test_absent_source_skips(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import propagate_cc_oauth_token
+        assert propagate_cc_oauth_token(
+            shared_dir=tmp_path / "shared", source_path=tmp_path / "nope.env",
+        ) is None
+
+    def test_no_token_key_skips(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import propagate_cc_oauth_token
+        src = tmp_path / "cc_oauth_token.env"
+        src.write_text("GENESIS_CC_TOKEN_CREATED_AT=123\n")  # created_at, no token
+        assert propagate_cc_oauth_token(
+            shared_dir=tmp_path / "shared", source_path=src,
+        ) is None
+
+    def test_load_missing_returns_empty(self, tmp_path: Path) -> None:
+        from genesis.guardian.credential_bridge import load_cc_oauth_token
+        assert load_cc_oauth_token(str(tmp_path / "nope")) == {}
+
+    def test_combined_bridge_includes_cc_token(self, tmp_path: Path, monkeypatch) -> None:
+        # The composite calls the leg without source_path (module default), so
+        # point _CC_TOKEN_SOURCE at a tmp file for this test.
+        from genesis.guardian import credential_bridge as cb
+        src = tmp_path / "cc_oauth_token.env"
+        src.write_text("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-X\n")
+        monkeypatch.setattr(cb, "_CC_TOKEN_SOURCE", src)
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text("TELEGRAM_BOT_TOKEN=bot\nTELEGRAM_CHAT_ID=chat\n")
+        written = cb.propagate_guardian_credentials(
+            shared_dir=tmp_path / "state" / "shared", secrets_path=secrets,
+        )
+        assert "cc_oauth_token.env" in [p.name for p in written]
+
+    def test_never_reads_from_secrets_env(self, tmp_path: Path) -> None:
+        # A token in secrets.env must NOT be picked up — the leg reads only its
+        # dedicated file (guards the load_dotenv override hazard by construction).
+        from genesis.guardian.credential_bridge import propagate_cc_oauth_token
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text("CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-FROM-SECRETS\n")
+        out = propagate_cc_oauth_token(
+            shared_dir=tmp_path / "shared",
+            source_path=tmp_path / "absent.env",
+            secrets_path=secrets,
+        )
+        assert out is None  # secrets_path is ignored for this leg

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -318,3 +318,65 @@ def test_ensure_work_dir_propagates_when_fallback_also_uncreatable(tmp_path):
     blocker.write_text("file")
     with pytest.raises(OSError):
         _ensure_work_dir(blocker / "wd", fallback=blocker / "fb")
+
+
+def _stub_claude(tmp_path, body: str):
+    """A stub `claude` that prints ``body`` for `auth status --json`."""
+    stub = tmp_path / "claude"
+    stub.write_text(f"#!/bin/sh\ncat <<'STUBEOF'\n{body}\nSTUBEOF\n")
+    stub.chmod(0o755)
+    return str(stub)
+
+
+def _engine_with_token(tmp_path, *, token: bool) -> DiagnosisEngine:
+    cfg = GuardianConfig()
+    cfg.state_dir = str(tmp_path / "state")
+    if token:
+        d = tmp_path / "state" / "shared" / "guardian"
+        d.mkdir(parents=True)
+        (d / "cc_oauth_token.env").write_text(
+            "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-SYNTHETIC\n"
+            "GENESIS_CC_TOKEN_CREATED_AT=1700000000\n",
+        )
+    return DiagnosisEngine(cfg)
+
+
+class TestResolveCCEnv:
+    """FALLBACK-ONLY setup-token injection for the CC recovery brain."""
+
+    @pytest.mark.asyncio
+    async def test_logged_in_true_never_injects(self, tmp_path):
+        # Working login present → inherit env (None), even WITH a token synced.
+        cc = _stub_claude(tmp_path, '{"loggedIn": true}')
+        engine = _engine_with_token(tmp_path, token=True)
+        assert await engine._resolve_cc_env(cc) is None
+
+    @pytest.mark.asyncio
+    async def test_dead_login_with_token_injects_and_preserves_env(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("CANARY_ENV", "keepme")
+        cc = _stub_claude(tmp_path, '{"loggedIn": false}')
+        engine = _engine_with_token(tmp_path, token=True)
+        env = await engine._resolve_cc_env(cc)
+        assert isinstance(env, dict)
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-SYNTHETIC"
+        assert env["CANARY_ENV"] == "keepme"  # inherited env preserved
+
+    @pytest.mark.asyncio
+    async def test_dead_login_no_token_inherits(self, tmp_path):
+        cc = _stub_claude(tmp_path, '{"loggedIn": false}')
+        engine = _engine_with_token(tmp_path, token=False)
+        assert await engine._resolve_cc_env(cc) is None
+
+    @pytest.mark.asyncio
+    async def test_unparseable_status_never_injects(self, tmp_path):
+        # Ambiguous auth status + token present → still inherit (never inject).
+        cc = _stub_claude(tmp_path, "not json at all")
+        engine = _engine_with_token(tmp_path, token=True)
+        assert await engine._resolve_cc_env(cc) is None
+
+    @pytest.mark.asyncio
+    async def test_missing_binary_never_raises(self, tmp_path):
+        engine = _engine_with_token(tmp_path, token=True)
+        assert await engine._resolve_cc_env(str(tmp_path / "nonexistent")) is None

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -380,3 +380,11 @@ class TestResolveCCEnv:
     async def test_missing_binary_never_raises(self, tmp_path):
         engine = _engine_with_token(tmp_path, token=True)
         assert await engine._resolve_cc_env(str(tmp_path / "nonexistent")) is None
+
+    @pytest.mark.asyncio
+    async def test_non_object_json_never_injects(self, tmp_path):
+        # Valid JSON but not an object (null) → .get would raise; must be caught
+        # as ambiguity → inherit env, even with a token present.
+        cc = _stub_claude(tmp_path, "null")
+        engine = _engine_with_token(tmp_path, token=True)
+        assert await engine._resolve_cc_env(cc) is None

--- a/tests/test_guardian/test_gateway_cc_auth.py
+++ b/tests/test_guardian/test_gateway_cc_auth.py
@@ -169,3 +169,16 @@ def test_corrupt_cache_reprobes(sandbox):
     (sandbox["state"] / "cc_auth_probe.json").write_text("{not json")
     # Garbage cache must not crash the verb; it re-probes.
     assert _version(sandbox, logged_in="true")["cc_logged_in"] is True
+
+
+@_needs_bash
+def test_corrupt_leading_zero_created_at_no_crash(sandbox):
+    # A leading-zero created_at must not be read as octal (would error under
+    # set -e); the verb still emits valid JSON with a base-10 age.
+    sandbox["token_file"].write_text(
+        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-X\n"
+        "GENESIS_CC_TOKEN_CREATED_AT=0899999999\n",
+    )
+    v = _version(sandbox)  # _version asserts returncode 0 + json.loads
+    assert v["cc_token_present"] is True
+    assert isinstance(v["cc_token_age_days"], int)

--- a/tests/test_guardian/test_gateway_cc_auth.py
+++ b/tests/test_guardian/test_gateway_cc_auth.py
@@ -1,0 +1,171 @@
+"""Tests for the guardian-gateway.sh `version` verb CC-auth-health fields.
+
+Runs the REAL gateway script in a sandboxed $HOME with a PATH-shim stub
+`claude` (responds to both `--version` and `auth status --json`), so the
+tri-state `cc_logged_in`, the token presence/age derivation, the 1h probe
+cache, and — critically — the no-token-leak invariant get direct coverage.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GATEWAY = REPO_ROOT / "scripts" / "guardian-gateway.sh"
+
+_needs_bash = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("python3") is None,
+    reason="requires bash + python3",
+)
+
+SYNTHETIC_TOKEN = "sk-ant-oat01-SYNTHETIC-DO-NOT-USE-abc123"
+TEST_SSH_CONNECTION = "10.0.0.42 51234 10.0.0.1 22"
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    """Sandboxed HOME + a stub `claude` on PATH whose auth-status answer is
+    driven by $STUB_LOGGED_IN (true/false/garbage/fail)."""
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True)
+    state = home / ".local" / "state" / "genesis-guardian"
+    (state / "shared" / "guardian").mkdir(parents=True)
+
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    claude = fakebin / "claude"
+    claude.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "--version" ]; then echo "1.2.3 (Claude Code)"; exit 0; fi\n'
+        'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then\n'
+        '  case "${STUB_LOGGED_IN:-true}" in\n'
+        '    true) echo \'{"loggedIn": true, "email": "priv@example.com"}\'; exit 0;;\n'
+        '    false) echo \'{"loggedIn": false}\'; exit 0;;\n'
+        '    garbage) echo "not json at all"; exit 0;;\n'
+        '    fail) exit 1;;\n'
+        "  esac\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    claude.chmod(0o755)
+
+    return {"home": home, "state": state, "fakebin": fakebin,
+            "token_file": state / "shared" / "guardian" / "cc_oauth_token.env"}
+
+
+def _version(sandbox: dict, logged_in: str = "true") -> dict:
+    env = {
+        "HOME": str(sandbox["home"]),
+        "PATH": f"{sandbox['fakebin']}:/usr/bin:/bin",
+        "SSH_ORIGINAL_COMMAND": "version",
+        "SSH_CONNECTION": TEST_SSH_CONNECTION,
+        "STUB_LOGGED_IN": logged_in,
+    }
+    proc = subprocess.run(
+        ["bash", str(GATEWAY)], env=env, capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _write_token(sandbox: dict, *, created_at: int | None) -> None:
+    lines = [f"CLAUDE_CODE_OAUTH_TOKEN={SYNTHETIC_TOKEN}"]
+    if created_at is not None:
+        lines.append(f"GENESIS_CC_TOKEN_CREATED_AT={created_at}")
+    sandbox["token_file"].write_text("\n".join(lines) + "\n")
+
+
+@_needs_bash
+def test_logged_in_true(sandbox):
+    v = _version(sandbox, logged_in="true")
+    assert v["cc_logged_in"] is True
+    assert v["cc_token_present"] is False
+    assert v["cc_token_age_days"] == -1
+
+
+@_needs_bash
+def test_logged_in_false(sandbox):
+    assert _version(sandbox, logged_in="false")["cc_logged_in"] is False
+
+
+@_needs_bash
+def test_unparseable_auth_status_is_null(sandbox):
+    # Non-JSON output → tri-state null (never a false-alarm on old/odd CC).
+    assert _version(sandbox, logged_in="garbage")["cc_logged_in"] is None
+
+
+@_needs_bash
+def test_auth_status_failure_is_null(sandbox):
+    assert _version(sandbox, logged_in="fail")["cc_logged_in"] is None
+
+
+@_needs_bash
+def test_token_present_with_created_at_age(sandbox):
+    _write_token(sandbox, created_at=int(time.time()) - 3 * 86400)
+    v = _version(sandbox)
+    assert v["cc_token_present"] is True
+    assert v["cc_token_age_days"] == 3
+
+
+@_needs_bash
+def test_token_age_mtime_fallback(sandbox):
+    # No created_at line → age derived from the file mtime (>= 0).
+    _write_token(sandbox, created_at=None)
+    v = _version(sandbox)
+    assert v["cc_token_present"] is True
+    assert v["cc_token_age_days"] >= 0
+
+
+@_needs_bash
+def test_future_dated_created_at_clamps_to_zero(sandbox):
+    _write_token(sandbox, created_at=int(time.time()) + 10 * 86400)
+    assert _version(sandbox)["cc_token_age_days"] == 0
+
+
+@_needs_bash
+def test_token_value_never_leaks(sandbox):
+    _write_token(sandbox, created_at=int(time.time()))
+    env = {
+        "HOME": str(sandbox["home"]),
+        "PATH": f"{sandbox['fakebin']}:/usr/bin:/bin",
+        "SSH_ORIGINAL_COMMAND": "version",
+        "SSH_CONNECTION": TEST_SSH_CONNECTION,
+        "STUB_LOGGED_IN": "true",
+    }
+    proc = subprocess.run(
+        ["bash", str(GATEWAY)], env=env, capture_output=True, text=True, timeout=60,
+    )
+    # Neither the token value nor the account email may appear in any output.
+    assert SYNTHETIC_TOKEN not in proc.stdout
+    assert SYNTHETIC_TOKEN not in proc.stderr
+    assert "priv@example.com" not in proc.stdout
+
+
+@_needs_bash
+def test_probe_cache_reuse_and_expiry(sandbox):
+    # 1st call logs in true → caches it.
+    assert _version(sandbox, logged_in="true")["cc_logged_in"] is True
+    cache = sandbox["state"] / "cc_auth_probe.json"
+    assert cache.exists()
+
+    # 2nd call: stub now says false, but the fresh cache must be reused → true.
+    assert _version(sandbox, logged_in="false")["cc_logged_in"] is True
+
+    # Age the cache past the 1h TTL → the stub is re-probed → false.
+    d = json.loads(cache.read_text())
+    d["checked_at"] -= 7200
+    cache.write_text(json.dumps(d))
+    assert _version(sandbox, logged_in="false")["cc_logged_in"] is False
+
+
+@_needs_bash
+def test_corrupt_cache_reprobes(sandbox):
+    (sandbox["state"] / "cc_auth_probe.json").write_text("{not json")
+    # Garbage cache must not crash the verb; it re-probes.
+    assert _version(sandbox, logged_in="true")["cc_logged_in"] is True

--- a/tests/test_guardian/test_remote.py
+++ b/tests/test_guardian/test_remote.py
@@ -324,3 +324,28 @@ class TestProvisioningExecutors:
                           AsyncMock(return_value=(False, "timeout"))):
             res = await remote.request_grow_disk("scsi1", 32)
         assert res["ok"] is False and "timeout" in res["error"]
+
+
+class TestVersionTimeout:
+    """version() must pass a longer wait than the instance default — it now
+    also runs `claude auth status` host-side, which can exceed 10s and would
+    make version() return `unreachable`, skipping EVERY reconciler."""
+
+    @pytest.mark.asyncio
+    async def test_version_uses_extended_timeout(self, remote):
+        from genesis.guardian.remote import _VERSION_TIMEOUT
+        mock_ssh = AsyncMock(return_value=(True, "{}"))
+        with patch.object(remote, "_ssh_command", new=mock_ssh):
+            await remote.version()
+        mock_ssh.assert_awaited_once_with("version", timeout=_VERSION_TIMEOUT)
+        assert remote._timeout < _VERSION_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_version_passes_through_new_fields(self, remote):
+        payload = {"cc_version": "1.2.3", "cc_logged_in": True,
+                   "cc_token_present": False, "cc_token_age_days": -1}
+        with patch.object(remote, "_ssh_command",
+                          new=AsyncMock(return_value=(True, json.dumps(payload)))):
+            got = await remote.version()
+        assert got["cc_logged_in"] is True
+        assert got["cc_token_age_days"] == -1

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -931,3 +931,119 @@ class TestAuthkeyHardening:
             await wd._check_authkey_hardening(
                 _authkey_vi(from_matches=False, src_hash=_SRC_C))
         assert r.reharden_key.await_count == 2
+
+
+def _cc_watchdog():
+    """Watchdog wired with mock remote/event_bus/outreach for the CC-auth
+    reconciler (alert-only — no remote action)."""
+    r = AsyncMock()
+    event_bus = AsyncMock()
+    outreach = AsyncMock()
+    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_pipeline=outreach)
+    return wd, r, event_bus, outreach
+
+
+def _cc_vi(logged_in, present=False, age=-1):
+    return {
+        "cc_logged_in": logged_in,
+        "cc_token_present": present,
+        "cc_token_age_days": age,
+    }
+
+
+def _alert_source_ids(outreach) -> list[str]:
+    return [c.args[1].source_id for c in outreach.submit_raw.call_args_list]
+
+
+class TestCCAuthReconciler:
+    """Host CC recovery-brain auth-health: dead-brain alert + pre-expiry warn."""
+
+    @pytest.mark.asyncio
+    async def test_old_gateway_no_cc_fields_skips(self):
+        wd, _, eb, outreach = _cc_watchdog()
+        await wd._check_cc_auth({"cc_version": "1.2.3"})  # no cc_logged_in key
+        outreach.submit_raw.assert_not_called()
+        eb.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_logged_in_is_silent(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD + 2):
+            await wd._check_cc_auth(_cc_vi(True))
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_expiry_warns_while_login_healthy(self):
+        # The insurance token rots exactly while the primary login is fine —
+        # the warning MUST fire despite the healthy early-return.
+        wd, _, eb, outreach = _cc_watchdog()
+        await wd._check_cc_auth(_cc_vi(True, present=True, age=340))
+        ids = _alert_source_ids(outreach)
+        assert "guardian:cc_token_expiring" in ids
+        assert "guardian:cc_auth_unhealthy" not in ids
+        assert any("cc_token_expiring" in e for e in _emitted_events(eb))
+        # once per episode
+        await wd._check_cc_auth(_cc_vi(True, present=True, age=341))
+        assert _alert_source_ids(outreach).count("guardian:cc_token_expiring") == 1
+
+    @pytest.mark.asyncio
+    async def test_expiry_rearms_on_refresh(self):
+        wd, _, _, outreach = _cc_watchdog()
+        await wd._check_cc_auth(_cc_vi(True, present=True, age=340))   # warn
+        await wd._check_cc_auth(_cc_vi(True, present=True, age=5))     # refreshed
+        await wd._check_cc_auth(_cc_vi(True, present=True, age=336))   # warn again
+        assert _alert_source_ids(outreach).count("guardian:cc_token_expiring") == 2
+
+    @pytest.mark.asyncio
+    async def test_dead_brain_alerts_at_threshold(self):
+        wd, _, eb, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD - 1):
+            await wd._check_cc_auth(_cc_vi(False))
+        outreach.submit_raw.assert_not_called()
+        await wd._check_cc_auth(_cc_vi(False))
+        ids = _alert_source_ids(outreach)
+        assert ids.count("guardian:cc_auth_unhealthy") == 1
+        assert any("cc_auth_unhealthy" in e for e in _emitted_events(eb))
+        # once per episode
+        await wd._check_cc_auth(_cc_vi(False))
+        assert _alert_source_ids(outreach).count("guardian:cc_auth_unhealthy") == 1
+
+    @pytest.mark.asyncio
+    async def test_alert_text_names_setup_token(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD):
+            await wd._check_cc_auth(_cc_vi(False))
+        msg = outreach.submit_raw.call_args.args[0]
+        assert "setup-token" in msg and "store_cc_token.sh" in msg
+
+    @pytest.mark.asyncio
+    async def test_dead_login_with_usable_token_is_healthy(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD + 2):
+            await wd._check_cc_auth(_cc_vi(False, present=True, age=10))
+        assert "guardian:cc_auth_unhealthy" not in _alert_source_ids(outreach)
+
+    @pytest.mark.asyncio
+    async def test_dead_login_with_expired_token_alerts(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD):
+            await wd._check_cc_auth(_cc_vi(False, present=True, age=400))
+        assert "guardian:cc_auth_unhealthy" in _alert_source_ids(outreach)
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_null_never_alarms(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD + 3):
+            await wd._check_cc_auth(_cc_vi(None))
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recovery_rearms_dead_brain_alert(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD):
+            await wd._check_cc_auth(_cc_vi(False))
+        assert _alert_source_ids(outreach).count("guardian:cc_auth_unhealthy") == 1
+        await wd._check_cc_auth(_cc_vi(True))  # recovered → reset
+        for _ in range(_THRESHOLD):
+            await wd._check_cc_auth(_cc_vi(False))
+        assert _alert_source_ids(outreach).count("guardian:cc_auth_unhealthy") == 2


### PR DESCRIPTION
## What

Makes the host Guardian's `claude -p` recovery brain survive a dead `claude login` without manual host access — insurance against the silent-brain-death class (the login has no refresh; today, if it dies the brain silently goes dark, discovered only mid-incident).

Two mechanisms:

1. **Auth-health signal.** The gateway `version` verb additively reports `cc_logged_in` (a 1h-cached `claude auth status` probe), `cc_token_present`, and `cc_token_age_days`. A container-side reconciler (`GuardianWatchdog._check_cc_auth`) alerts over Telegram when the login is dead with no usable fallback (3-tick threshold) and warns ~30 days before a synced fallback token expires. Only booleans + an age ever cross the wire — never the token or account identity.

2. **Fallback setup-token (optional, lazy).** Mint a 1-year token with `claude setup-token` from anywhere and pipe it to `scripts/store_cc_token.sh` (stdin only). The credential-bridge awareness tick syncs it to the host shared mount, and `diagnosis.py` injects it via `CLAUDE_CODE_OAUTH_TOKEN` **only** when a pre-flight `claude auth status` confirms the host's own login is dead — a working login is never overridden. It is a subscription-OAuth token, **not** an `ANTHROPIC_API_KEY`.

## Design notes

- **Token lives in a dedicated file, never `secrets.env`** — `runtime/init/secrets.py` does `load_dotenv(override=True)`, which would hijack the *container's* own CC auth.
- **Fallback-only injection** — the pre-flight probe runs with the same inherited env the brain gets, so `loggedIn:true` faithfully predicts the real invocation; injection can only degrade a working login under a false-negative coinciding with a stale token, and even then it lands as the existing `cc_unavailable` fail-safe, never silent death.
- **1h probe cache** — `version()` runs every 5-min tick; `claude auth status` is a ~290MB transient spawn, so the `loggedIn` probe is cached host-side (token presence/age stay per-tick, cheap stats). The diagnosis path always probes fresh.
- **`_VERSION_TIMEOUT=30s`** — the auth probe can exceed the 10s default, which would make `version()` return `unreachable` and skip every reconciler.

## Verification

- 733 guardian tests pass (~33 new): gateway tri-state + token age + cache reuse/expiry/corruption + **no-leak invariant**; reconciler 9-scenario state machine (expiry-warns-while-healthy, re-arm lifecycles, dead-brain threshold, ambiguity-never-alarms); `_resolve_cc_env` injection matrix (working login never overridden, env preserved); credential-bridge roundtrip; version timeout.
- ruff + shellcheck clean.
- genesis-architect design review + 2-finder code review (Python + bash/security): no behavior-breaking bug; 2 findings fixed with regression tests (base-10 age arithmetic, non-object-JSON guard).

## Not covered (by design)

The exact logged-out `auth status` output shape and a real setup-token in the guardian's exact invocation are unexercised until a token is minted (lazy) — the tri-state design makes any shape safe and the diagnosis fail-safe backstops a bad token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)