### PR TITLE
fix(inbox): route WATCH/BOOKMARK to tabled lane + soft decay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,7 +325,13 @@ When a user shares a file path or URL in conversation:
   derail this session — or the user directs it as separate. Otherwise do it
   now, even if unrelated/unasked; "already noted in a PR/comment" is not a
   reason to also create a row. Valid ones: create via `follow_up_create` MCP,
-  never leave as just text. (Genuine someday/maybe → `tabled`, not a follow-up.)
+  never leave as just text. **Two lanes** (`kind` on a follow-up): `follow_up`
+  = committed work, actionable, dispatched/surfaced (the FIX-NOW-or-valid-defer
+  cases above); `tabled` = an awareness record — "tracked, keep a record, not
+  acting near-term" — bug-tracker semantics, never dispatched or surfaced as
+  action. Genuine someday/maybe and deferred known bugs go to `tabled`, not a
+  `follow_up` row. (Inbox WATCH/BOOKMARK markers auto-route to `tabled` and
+  soft-decay after 60d.)
 - **No laziness.** Find root causes. No temporary fixes. No shortcuts.
   Don't EVER mute the symptom — fix the problem.
 - **Read before writing.** Never modify code you haven't fully read.
@@ -334,7 +340,9 @@ When a user shares a file path or URL in conversation:
   mistakes, not just document them.
 - **NEVER hide broken things — FIX THEM.** Fix the root cause, not the
   symptom. This is a thinking rule, not just a code rule.
-- **Bugs you see get fixed or tracked — never ignored.**
+- **Bugs you see get fixed or tracked — never ignored.** Fix now by default; a
+  bug you consciously defer becomes a `tabled` record (bug-tracker lane above),
+  never a silent drop.
 - **Telegram reminders**: use `outreach_send` with `preferred_timing`,
   NOT the `/schedule` skill (that's Claude Code's remote scheduler).
 - **Cognitive co-pilot, not order taker.** On every task, ask: "what else

--- a/src/genesis/dashboard/routes/work.py
+++ b/src/genesis/dashboard/routes/work.py
@@ -69,9 +69,16 @@ async def unified_work():
     if type_filter in (None, "follow_up"):
         try:
             if view == "active":
-                fups = await follow_ups.get_by_status(rt.db, "pending")
-                fups += await follow_ups.get_by_status(rt.db, "in_progress")
-                fups += await follow_ups.get_by_status(rt.db, "blocked")
+                # Exclude tabled markers (e.g. inbox WATCH/BOOKMARK attention
+                # markers) from the ACTIVE work ledger — they are tracked, not
+                # actionable. They remain browsable in the recent view below
+                # (get_recent defaults include_tabled=True).
+                fups = await follow_ups.get_by_status(
+                    rt.db, "pending", include_tabled=False)
+                fups += await follow_ups.get_by_status(
+                    rt.db, "in_progress", include_tabled=False)
+                fups += await follow_ups.get_by_status(
+                    rt.db, "blocked", include_tabled=False)
             else:
                 fups = await follow_ups.get_recent(rt.db, limit=limit)
             for f in fups:
@@ -90,7 +97,10 @@ async def unified_work():
                     "blocked_reason": f.get("blocked_reason", ""),
                     "raw": f,
                 })
-            fu_counts = await follow_ups.get_summary_counts(rt.db)
+            # Active view's badge must agree with its list (actionable lane
+            # only); the recent view counts every kind, matching get_recent.
+            fu_counts = await follow_ups.get_summary_counts(
+                rt.db, include_tabled=(view != "active"))
             counts["follow_ups"] = fu_counts
         except Exception:
             logger.error("Failed to fetch follow-ups for work view", exc_info=True)

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -403,11 +403,21 @@ async def get_recently_resolved(
     source: str | None = None,
     days: int = 7,
     limit: int = 20,
+    include_tabled: bool = False,
 ) -> list[dict]:
-    """Get recently completed follow-ups, optionally filtered by source."""
+    """Get recently completed follow-ups, optionally filtered by source.
+
+    Tabled follow-ups are excluded unless include_tabled=True. A decayed inbox
+    attention marker is flipped to ``completed`` by the decay sweep, so without
+    this filter it would surface here as if the ego had actively resolved it —
+    misreporting a mechanical TTL as work done (e.g. in the morning report /
+    inbox digest). The two callers both want the exclusion.
+    """
     days = max(1, days)
     query = "SELECT * FROM follow_ups WHERE status = 'completed'"
     params: list[str | int] = []
+    if not include_tabled:
+        query += " AND kind = 'follow_up'"
     if source:
         query += " AND source = ?"
         params.append(source)
@@ -441,23 +451,73 @@ async def purge_completed(
     return cursor.rowcount
 
 
+async def decay_stale_inbox_markers(
+    db: aiosqlite.Connection,
+    *,
+    older_than_days: int = 60,
+) -> int:
+    """Soft-decay stale inbox attention markers (the WATCH/BOOKMARK tabled lane).
+
+    Inbox evaluation routes WATCH/BOOKMARK recommendations into the ``tabled``
+    lane as attention markers — tracked, never dispatched, and never resolved by
+    ego judgment (the ego has no authority to discard a user-curated marker). A
+    marker that is never promoted eventually goes stale; this sweep ages such
+    markers out by marking them ``completed`` with a decay note after
+    *older_than_days*.
+
+    This is a SOFT transition (a status flip, not a DELETE): the row is retained
+    and could be reactivated before the retention sweep (``purge_completed``)
+    eventually hard-deletes it. It targets every NON-TERMINAL tabled inbox
+    marker (``pending`` and — defensively — ``blocked``/``in_progress``/
+    ``scheduled`` a marker could be moved into via the cockpit/ego): terminal
+    ``completed``/``failed`` rows already carry a ``completed_at`` and are reaped
+    by ``purge_completed``, so excluding them here keeps the two sweeps'
+    responsibilities disjoint. Without this breadth a ``blocked`` tabled marker
+    would be immortal — decay (pending-only) and purge (completed/failed-only)
+    would both skip it. Non-inbox / non-tabled follow-ups are left untouched.
+
+    Returns the number of markers decayed.
+    """
+    older_than_days = max(1, older_than_days)
+    cutoff = (datetime.now(UTC) - timedelta(days=older_than_days)).isoformat()
+    cursor = await db.execute(
+        "UPDATE follow_ups "
+        "SET status = 'completed', completed_at = ?, resolution_notes = ? "
+        "WHERE source = 'inbox_evaluation' "
+        "AND kind = 'tabled' "
+        "AND status NOT IN ('completed', 'failed') "
+        "AND created_at < ?",
+        (_now_iso(), f"decayed: not promoted within {older_than_days}d", cutoff),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def get_recently_completed(
     db: aiosqlite.Connection,
     *,
     hours: int = 24,
     limit: int = 5,
     domain: str | None = None,
+    include_tabled: bool = False,
 ) -> list[dict]:
     """Get follow-ups completed within the given time window.
 
     domain (exact match) scopes to that domain only and is applied in SQL
     BEFORE the LIMIT (so the cap samples within the scoped domain — a Python
     post-filter would be wrong here). None = all domains (no-op).
+
+    Tabled follow-ups are excluded unless include_tabled=True. A decayed inbox
+    attention marker is flipped to ``completed`` by the decay sweep, so without
+    this filter it would appear in the morning report's "Completed (24h)"
+    section as if the ego actively resolved it. The one caller wants exclusion.
     """
     dom_clause, dom_params = _domain_eq(domain)
+    kind_and = "" if include_tabled else "AND kind = 'follow_up' "
     cursor = await db.execute(
         "SELECT content, resolution_notes FROM follow_ups "
         "WHERE status = 'completed' "
+        f"{kind_and}"
         f"AND completed_at >= datetime('now', ? || ' hours'){dom_clause} "
         "ORDER BY completed_at DESC LIMIT ?",
         (f"-{hours}", *dom_params, limit),

--- a/src/genesis/db/migrations/0053_table_inbox_watch_markers.py
+++ b/src/genesis/db/migrations/0053_table_inbox_watch_markers.py
@@ -1,0 +1,46 @@
+"""Re-classify existing inbox WATCH/BOOKMARK follow-ups into the tabled lane.
+
+Inbox evaluation used to route WATCH/BOOKMARK recommendations into the
+actionable ``ego_judgment`` lane, where they piled up forever — the ego never
+elects to "close a watch marker", so only dedup ever drained them. They are
+attention markers, not tasks, and now route to ``kind='tabled'`` at creation
+time (see inbox/monitor.py ``_ACTION_MAP``). This migration moves the rows that
+were already created under the old behaviour so they stop polluting the
+actionable ledger + reports.
+
+Keyed on the content prefix (``[WATCH]``/``[BOOKMARK]``) as belt-and-suspenders
+in addition to source — verified against the live DB to catch exactly the
+WATCH/BOOKMARK markers and zero ADOPT/ADAPT/EXPLORE rows. Only NON-TERMINAL rows
+are moved (``status NOT IN ('completed', 'failed')`` — i.e. pending / blocked /
+in_progress / scheduled), the exact set ``decay_stale_inbox_markers`` reaps, so
+every moved row has a reaper. Terminal completed/failed rows keep their history
+(and, being terminal with a completed_at, are handled by ``purge_completed``).
+Idempotent: re-running is a no-op once the rows are already tabled.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_WHERE = (
+    "source = 'inbox_evaluation' "
+    "AND status NOT IN ('completed', 'failed') "
+    "AND (content LIKE '[WATCH]%' OR content LIKE '[BOOKMARK]%')"
+)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        f"UPDATE follow_ups SET kind = 'tabled' "
+        f"WHERE {_WHERE} AND kind = 'follow_up'"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    # Intentional no-op. This is a one-way data reclassification: once the new
+    # _ACTION_MAP creates WATCH/BOOKMARK rows natively as kind='tabled', a blanket
+    # `kind='follow_up'` revert could not tell those apart from the rows this
+    # migration moved, and would wrongly promote user-curated markers back into
+    # the actionable lane. Leaving the reclassification in place is the safe
+    # reverse (matches the no-op-down convention of other data-only migrations).
+    pass

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -1722,13 +1722,21 @@ class InboxMonitor:
     # Follow-up creation from evaluation Recommendation blocks
     # ------------------------------------------------------------------
 
-    # Classification → (strategy, priority, pinned)
-    _ACTION_MAP: dict[str, tuple[str, str, bool]] = {
-        "adopt":  ("user_input_needed", "high",   True),
-        "adapt":  ("user_input_needed", "medium", True),
-        "watch":  ("ego_judgment",      "low",    False),
-        "explore": ("user_input_needed", "medium", True),
-        "bookmark": ("ego_judgment",     "low",    False),
+    # Classification → (strategy, priority, pinned, kind)
+    #
+    # WATCH/BOOKMARK are attention markers, not tasks: they route to the
+    # ``tabled`` lane (tracked, never dispatched or surfaced as action). The ego
+    # therefore never sees them (get_actionable excludes tabled) and has no
+    # authority to discard a user-curated marker — their honest fates are DECAY
+    # (soft age-out via decay_stale_inbox_markers) and ACTIVATION (surfaced when
+    # relevant). ADOPT/ADAPT/EXPLORE are intent-to-act → the actionable
+    # ``follow_up`` lane, pinned and user-owned.
+    _ACTION_MAP: dict[str, tuple[str, str, bool, str]] = {
+        "adopt":  ("user_input_needed", "high",   True,  "follow_up"),
+        "adapt":  ("user_input_needed", "medium", True,  "follow_up"),
+        "watch":  ("ego_judgment",      "low",    False, "tabled"),
+        "explore": ("user_input_needed", "medium", True, "follow_up"),
+        "bookmark": ("ego_judgment",     "low",    False, "tabled"),
     }
 
     async def _create_follow_ups_from_eval(
@@ -1763,7 +1771,7 @@ class InboxMonitor:
                 )
                 continue
 
-            strategy, priority, pinned = mapping
+            strategy, priority, pinned, kind = mapping
 
             title = rec.item_title or "Untitled"
             content = f"[{rec.action.upper()}] {title}: {rec.next_step}"
@@ -1798,6 +1806,7 @@ class InboxMonitor:
                     strategy=strategy,
                     priority=priority,
                     pinned=pinned,
+                    kind=kind,
                     # The evaluator judges each item genesis-vs-user; reuse it.
                     domain=(
                         "internal" if rec.classification == "genesis"

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -458,6 +458,42 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        async def _inbox_marker_decay_sweep() -> None:
+            # Soft-age-out stale inbox WATCH/BOOKMARK attention markers (the
+            # tabled lane): status→completed after 60d. Mechanical TTL, so it
+            # lives here (learning scheduler), NOT in the ego — the ego has no
+            # authority to close a user-curated marker.
+            try:
+                if rt.paused:
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping inbox marker decay",
+                    exc_info=True,
+                )
+                return
+            try:
+                from genesis.db.crud import follow_ups
+
+                decayed = await follow_ups.decay_stale_inbox_markers(rt._db)
+                rt.record_job_success("inbox_marker_decay")
+                if decayed:
+                    logger.info(
+                        "Inbox marker decay: aged out %d stale attention "
+                        "marker(s)", decayed,
+                    )
+            except Exception as exc:
+                rt.record_job_failure("inbox_marker_decay", str(exc))
+                logger.exception("Inbox marker decay sweep failed")
+
+        rt._learning_scheduler.add_job(
+            _inbox_marker_decay_sweep,
+            CronTrigger(hour=4, minute=35, timezone=user_timezone()),
+            id="inbox_marker_decay",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         async def _run_recovery() -> None:
             if rt._recovery_orchestrator is not None:
                 try:

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -380,3 +380,139 @@ async def test_query_page_status_sort_ranks_by_actionability(db):
     # Alphabetical 'completed' < 'in_progress' would invert this — the rank CASE
     # must put in_progress first.
     assert order.index(active) < order.index(done)
+
+
+# ─── Inbox attention-marker decay (WATCH/BOOKMARK tabled lane) ────────────────
+
+
+async def _make_marker(db, *, age_days: int, kind="tabled",
+                       source="inbox_evaluation", content="[WATCH] x",
+                       status="pending"):
+    """Create a follow-up, backdate created_at by *age_days*, set *status*."""
+    fid = await follow_ups.create(
+        db, source=source, content=content, reason="r",
+        strategy="ego_judgment", priority="low", kind=kind,
+    )
+    from datetime import UTC, datetime, timedelta
+
+    old = (datetime.now(UTC) - timedelta(days=age_days)).isoformat()
+    await db.execute(
+        "UPDATE follow_ups SET created_at = ?, status = ? WHERE id = ?",
+        (old, status, fid),
+    )
+    await db.commit()
+    return fid
+
+
+async def test_decay_stale_inbox_markers_ages_out_old(db):
+    """A tabled inbox marker older than the threshold is completed with a note."""
+    fid = await _make_marker(db, age_days=61)
+
+    count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
+    assert count == 1
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"
+    assert row["completed_at"] is not None
+    assert "decayed" in (row["resolution_notes"] or "")
+
+
+async def test_decay_ages_out_blocked_marker(db):
+    """Regression: a BLOCKED tabled marker must decay too, else it is immortal.
+
+    purge_completed only reaps completed/failed (which carry completed_at); a
+    blocked tabled row has no completed_at, so if decay skipped it (pending-only)
+    nothing would ever reap it.
+    """
+    fid = await _make_marker(db, age_days=61, status="blocked")
+
+    count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
+    assert count == 1
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"
+    assert "decayed" in (row["resolution_notes"] or "")
+
+
+async def test_decay_skips_terminal_markers(db):
+    """Already completed/failed tabled markers are left to purge_completed."""
+    done = await _make_marker(db, age_days=200, status="completed")
+    failed = await _make_marker(db, age_days=200, status="failed")
+
+    count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
+    assert count == 0
+    assert (await follow_ups.get_by_id(db, done))["status"] == "completed"
+    assert (await follow_ups.get_by_id(db, failed))["status"] == "failed"
+
+
+async def test_decay_keeps_recent_marker(db):
+    """A tabled inbox marker younger than the threshold is untouched."""
+    fid = await _make_marker(db, age_days=30)
+
+    count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
+    assert count == 0
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "pending"
+
+
+async def test_decay_ignores_actionable_follow_up_lane(db):
+    """An old ADOPT/ADAPT/EXPLORE follow_up (not tabled) is never decayed."""
+    fid = await _make_marker(
+        db, age_days=200, kind="follow_up", content="[ADAPT] x",
+    )
+
+    count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
+    assert count == 0
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "pending"
+
+
+async def test_decay_ignores_non_inbox_tabled(db):
+    """A tabled marker from another source (e.g. a tracked bug) is never decayed."""
+    fid = await _make_marker(db, age_days=200, source="manual_bug_tracker")
+
+    count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
+    assert count == 0
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "pending"
+
+
+async def test_get_recently_resolved_excludes_tabled(db):
+    """Decayed (completed) tabled markers must not read as ego-resolved work."""
+    fu = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_status(db, fu, status="completed")
+    marker = await follow_ups.create(db, **_BASE, kind="tabled")
+    await follow_ups.update_status(db, marker, status="completed")
+
+    ids = {r["id"] for r in await follow_ups.get_recently_resolved(db)}
+    assert fu in ids
+    assert marker not in ids
+
+    ids_all = {
+        r["id"]
+        for r in await follow_ups.get_recently_resolved(db, include_tabled=True)
+    }
+    assert marker in ids_all
+
+
+async def test_get_recently_completed_excludes_tabled(db):
+    """The daily morning-report 'Completed (24h)' path also drops tabled.
+
+    get_recently_completed selects content/resolution_notes (not id), so assert
+    on the content of a decayed marker vs a genuinely-completed follow-up.
+    """
+    await follow_ups.create(db, **{**_BASE, "content": "real work done"})
+    fu = (await follow_ups.get_pending(db))[0]["id"]
+    await follow_ups.update_status(db, fu, status="completed")
+    marker = await follow_ups.create(
+        db, **{**_BASE, "content": "[BOOKMARK] decayed"}, kind="tabled",
+    )
+    await follow_ups.update_status(db, marker, status="completed")
+
+    contents = {r["content"] for r in await follow_ups.get_recently_completed(db)}
+    assert "real work done" in contents
+    assert "[BOOKMARK] decayed" not in contents
+
+    contents_all = {
+        r["content"]
+        for r in await follow_ups.get_recently_completed(db, include_tabled=True)
+    }
+    assert "[BOOKMARK] decayed" in contents_all

--- a/tests/test_db/test_migration_0053_table_inbox_watch_markers.py
+++ b/tests/test_db/test_migration_0053_table_inbox_watch_markers.py
@@ -1,0 +1,101 @@
+"""Migration 0053 — re-classify existing inbox WATCH/BOOKMARK follow-ups.
+
+Verifies pending WATCH/BOOKMARK inbox rows move to the tabled lane, that
+ADOPT/ADAPT/EXPLORE rows and already-completed markers are left untouched, and
+that up() is idempotent. Mirrors the 0052 single-migration test style.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M53 = importlib.import_module(
+    "genesis.db.migrations.0053_table_inbox_watch_markers"
+)
+
+_DDL = """
+    CREATE TABLE follow_ups (
+        id TEXT PRIMARY KEY, source TEXT, content TEXT, status TEXT,
+        kind TEXT DEFAULT 'follow_up'
+    )
+"""
+
+
+async def _seed(db, id_, *, source, content, status, kind="follow_up"):
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, status, kind) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (id_, source, content, status, kind),
+    )
+
+
+async def _kind(db, id_) -> str:
+    cur = await db.execute("SELECT kind FROM follow_ups WHERE id = ?", (id_,))
+    return (await cur.fetchone())[0]
+
+
+@pytest.mark.asyncio
+async def test_up_tables_all_non_terminal_watch_bookmark(tmp_path):
+    """Every non-terminal state (pending/blocked/in_progress/scheduled) moves —
+    the exact set decay_stale_inbox_markers reaps, so none is left immortal."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_DDL)
+        await _seed(db, "w", source="inbox_evaluation",
+                    content="[WATCH] a", status="pending")
+        await _seed(db, "b", source="inbox_evaluation",
+                    content="[BOOKMARK] c", status="pending")
+        await _seed(db, "blk", source="inbox_evaluation",
+                    content="[WATCH] blocked", status="blocked")
+        await _seed(db, "prog", source="inbox_evaluation",
+                    content="[WATCH] wip", status="in_progress")
+        await _seed(db, "sched", source="inbox_evaluation",
+                    content="[BOOKMARK] later", status="scheduled")
+        await db.commit()
+
+        await M53.up(db)
+
+        for id_ in ("w", "b", "blk", "prog", "sched"):
+            assert await _kind(db, id_) == "tabled", id_
+
+
+@pytest.mark.asyncio
+async def test_up_leaves_actionable_and_terminal_rows(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_DDL)
+        # Actionable lanes — never moved.
+        await _seed(db, "adopt", source="inbox_evaluation",
+                    content="[ADOPT] a", status="pending")
+        await _seed(db, "adapt", source="inbox_evaluation",
+                    content="[ADAPT] a", status="pending")
+        await _seed(db, "explore", source="inbox_evaluation",
+                    content="[EXPLORE] a", status="pending")
+        # Terminal WATCH rows — history preserved (purge_completed reaps them).
+        await _seed(db, "done", source="inbox_evaluation",
+                    content="[WATCH] old", status="completed")
+        await _seed(db, "failed", source="inbox_evaluation",
+                    content="[WATCH] failed", status="failed")
+        # A WATCH-looking row from another source — not an inbox marker.
+        await _seed(db, "other", source="manual",
+                    content="[WATCH] x", status="pending")
+        await db.commit()
+
+        await M53.up(db)
+
+        for id_ in ("adopt", "adapt", "explore", "done", "failed", "other"):
+            assert await _kind(db, id_) == "follow_up", id_
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_DDL)
+        await _seed(db, "w", source="inbox_evaluation",
+                    content="[WATCH] a", status="pending")
+        await db.commit()
+
+        await M53.up(db)
+        await M53.up(db)  # second run must not raise or double-move
+        assert await _kind(db, "w") == "tabled"

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -711,6 +711,60 @@ async def test_followup_integrity_error_does_not_abort_remaining_recs(
     assert created == 1, "first raised+caught, second created"
 
 
+def _rec(url: str, action: str, scope: str) -> str:
+    return (
+        f"## {url}\n\n"
+        "**Classification:** Genesis-relevant | **Decision:** Research\n\n"
+        "### Recommendation\n\n"
+        "```yaml\n"
+        f"action: {action}\n"
+        f'next_step: "step for {action}"\n'
+        f"effort: Small\nscope: {scope}\n"
+        "confidence: high\narchitecture_impact: extends\n"
+        "```\n"
+    )
+
+
+_FOUR_LANES = (
+    "# Inbox Evaluation — test\n\n"
+    + _rec("https://ex.com/adopt", "ADOPT", "V4")
+    + "\n" + _rec("https://ex.com/watch", "WATCH", "V4")
+    + "\n" + _rec("https://ex.com/explore", "EXPLORE", "V4")
+    + "\n" + _rec("https://ex.com/bookmark", "BOOKMARK", "V4")
+)
+
+
+@pytest.mark.asyncio
+async def test_watch_bookmark_route_to_tabled_lane(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """WATCH/BOOKMARK → tabled (never actionable); ADOPT/EXPLORE → follow_up."""
+    from genesis.db.crud import follow_ups
+
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    created = await mon._create_follow_ups_from_eval(
+        evaluation_text=_FOUR_LANES, batch_id="b1",
+        source_files=[str(inbox_dir / "Genesis.md")],
+    )
+    assert created == 4
+
+    rows = [dict(r) for r in await (await db.execute(
+        "SELECT content, kind FROM follow_ups WHERE source = 'inbox_evaluation'",
+    )).fetchall()]
+    by_action = {r["content"].split("]")[0].lstrip("["): r for r in rows}
+    assert by_action["ADOPT"]["kind"] == "follow_up"
+    assert by_action["EXPLORE"]["kind"] == "follow_up"
+    assert by_action["WATCH"]["kind"] == "tabled"
+    assert by_action["BOOKMARK"]["kind"] == "tabled"
+
+    # The ego/actionable feed must never see the markers.
+    actionable = " ".join(
+        r["content"] for r in await follow_ups.get_actionable(db)
+    )
+    assert "[ADOPT]" in actionable and "[EXPLORE]" in actionable
+    assert "[WATCH]" not in actionable and "[BOOKMARK]" not in actionable
+
+
 @pytest.mark.asyncio
 async def test_consume_approval_returns_bool(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path):
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)


### PR DESCRIPTION
## Problem

Inbox evaluation created `follow_ups` rows from ADOPT/ADAPT/WATCH/EXPLORE/BOOKMARK recommendation blocks. ADOPT/ADAPT/EXPLORE → pinned actionable follow-ups (works). But **WATCH/BOOKMARK** landed in the actionable `ego_judgment` queue, and the ego never elects to "close a watch marker" — so ~36 live rows piled up forever, polluting the follow-up ledger, the morning report, and the dashboard. Only dedup ever drained them.

## Reframe

WATCH/BOOKMARK are **attention markers, not tasks**. They now route to the existing `kind='tabled'` lane (tracked, never dispatched or surfaced as action), so the ego *structurally* cannot see or discard a user-curated marker (`get_actionable` excludes tabled by default). Their honest fate is a soft **60-day decay** (`status`→`completed` + note, recoverable — not a hard delete), hosted as a mechanical TTL sweep in the learning scheduler rather than ego judgment.

## Changes

- **Routing** — `monitor._ACTION_MAP`: `watch`/`bookmark` → `kind='tabled'`; `adopt`/`adapt`/`explore` unchanged (actionable `follow_up`, pinned).
- **Decay** — `follow_ups.decay_stale_inbox_markers()` reaps every **non-terminal** tabled inbox marker (`pending` + defensively `blocked`/`in_progress`/`scheduled`) so none can become immortal; terminal `completed`/`failed` are left to `purge_completed`. New daily `inbox_marker_decay` CronTrigger job.
- **Report leaks** — `get_recently_resolved` (weekly ego digest) and `get_recently_completed` (daily morning report) now exclude tabled by default, so a decayed marker is never misreported as ego-resolved work.
- **Dashboard** — `/work` active view + its badge count exclude tabled; markers stay browsable in the recent view.
- **Migration 0053** — reclassifies the existing WATCH/BOOKMARK rows (one-way data migration; `down()` is an intentional no-op).
- **Docs** — CLAUDE.md documents the `follow_up` (committed work) vs `tabled` (awareness record / bug-tracker) two-lane model.

## Verification

- Unit tests: routing (watch/bookmark→tabled, adopt/adapt/explore→follow_up, tabled absent from `get_actionable`), decay boundary + `blocked`-marker regression + terminal-skip, both report-leak exclusions, migration reclassification + idempotency.
- E2E against a `.backup` snapshot of the live DB: migration moves exactly 36 markers (0 adopt/adapt/explore), decay ages backdated markers with note, both leak-fixes proven by exact delta, idempotent on re-run.
- Reviewed by architecture + implementation + adversarial passes; the adversarial pass caught an immortal-`blocked`-marker class (fixed by broadening decay to all non-terminal states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)