### PR TITLE
feat(observability): put the ambient arbiter on the neural monitor (call-site registration + telemetry)

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -699,6 +699,19 @@ call_sites:
       deepseek-v4-pro (100% clean, different vendor) fallback; both free, so never_pays
       keeps a valid chain. NON-Groq deliberately \u2014 Groq's 8B is EOL 2026-08-16 and its
       gpt-oss-20b replacement breaks strict JSON.
+  ambient_arbiter:
+    chain: []
+    dispatch: cli
+    cc_model: Haiku
+    never_pays: true
+    description: >-
+      Ambient session-awareness arbiter: judges which drift-fire candidate
+      memories deserve surfacing (headless CC, model PINNED in
+      session_awareness/arbiter.py). The chain is empty BY DESIGN: no API
+      fallback exists (a failed call records an empty verdict, never a guess)
+      and the router never dispatches this site. The detached ambient worker
+      spawns CC directly and reports each run via record_last_run; registered
+      here for neural-monitor visibility and central declaration.
 retry:
   # max_total_s: aggregate wall-clock ceiling (seconds) across a single
   # route_call's retries x chain length. A safety net against pathological

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -364,7 +364,7 @@ The loops that make Genesis think between conversations.
 ```yaml subsystem-map
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness]
-verified: 8dac642c 2026-07-09
+verified: 780cc8de 2026-07-10
 ```
 
 - **awareness/**: the 5-min heartbeat. ~23 signal collectors (the richer
@@ -404,9 +404,12 @@ verified: 8dac642c 2026-07-09
   payload indexes drops valid results; found 2026-07-09). Headless-
   Haiku arbiter judges candidates per fire (fail-closed parse, group-
   kill on timeout). Verdicts → `ambient_verdict.json`, tuning →
-  size-capped shadow log. **Zero DB/Qdrant writes — never bumps
-  retrieved_count** (protects MEM-005/H-1 baselines). Fail-open at the
-  hook boundary. Kill switch: `GENESIS_SESSION_AWARENESS_DISABLED=1`.
+  size-capped shadow log; each real arbiter run also records a
+  `call_site_last_run` row (`ambient_arbiter`, neural monitor) via its
+  own short-lived RW connection. **Zero memory-row writes — never bumps
+  retrieved_count** (retrieval connection is mode=ro; protects
+  MEM-005/H-1 baselines). Fail-open at the hook boundary. Kill switch:
+  `GENESIS_SESSION_AWARENESS_DISABLED=1`.
 
 ## 10. Learning & evaluation
 

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -404,9 +404,10 @@ verified: 780cc8de 2026-07-10
   payload indexes drops valid results; found 2026-07-09). Headless-
   Haiku arbiter judges candidates per fire (fail-closed parse, group-
   kill on timeout). Verdicts → `ambient_verdict.json`, tuning →
-  size-capped shadow log; each real arbiter run also records a
-  `call_site_last_run` row (`ambient_arbiter`, neural monitor) via its
-  own short-lived RW connection. **Zero memory-row writes — never bumps
+  size-capped shadow log; each arbiter attempt (incl. pre-spawn
+  failures, success=0 with reason) also records a `call_site_last_run`
+  row (`ambient_arbiter`, neural monitor) via its own short-lived RW
+  connection. **Zero memory-row writes — never bumps
   retrieved_count** (retrieval connection is mode=ro; protects
   MEM-005/H-1 baselines). Fail-open at the hook boundary. Kill switch:
   `GENESIS_SESSION_AWARENESS_DISABLED=1`.

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -350,21 +350,21 @@ async def _call_llm(prompt: str, model: str) -> str:
 async def _record_to_monitor(model: str, response_text: str | None, *, success: bool) -> None:
     """Best-effort recording to neural monitor. Never raises."""
     try:
-        from genesis.db.connection import get_raw_db
         from genesis.env import genesis_db_path
-        from genesis.observability.call_site_recorder import record_last_run
+        from genesis.observability.call_site_recorder import (
+            record_last_run_detached,
+        )
 
         # Extract provider prefix from litellm model string (e.g. "anthropic/..." → "anthropic")
         provider = model.split("/", 1)[0] if "/" in model else model
         model_id = model.split("/", 1)[1] if "/" in model else model
 
-        async with get_raw_db(str(genesis_db_path())) as db:
-            await record_last_run(
-                db, _CALL_SITE_ID,
-                provider=provider, model_id=model_id,
-                response_text=(response_text or "")[:200],
-                success=success,
-            )
+        await record_last_run_detached(
+            str(genesis_db_path()), _CALL_SITE_ID,
+            provider=provider, model_id=model_id,
+            response_text=(response_text or "")[:200],
+            success=success,
+        )
     except Exception:
         logger.debug("Failed to record contribution_gate to neural monitor", exc_info=True)
 

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -1998,13 +1998,16 @@ function updateSubsystemGrid(data) {
                     const ps = c.probe_status;
                     return ps ? ps === 'reachable' : c.state !== 'open';
                 }).length;
-                let chainSummary = apiUp + '/' + apiChain.length + ' API';
+                // CC-only sites (empty API chain, e.g. ambient_arbiter) skip
+                // the API fraction — '0/0 API' reads as a broken chain.
+                const summaryParts = [];
+                if (apiChain.length > 0) summaryParts.push(apiUp + '/' + apiChain.length + ' API');
                 if (ccChain.length > 0) {
                     const ccPs = ccChain[0].probe_status;
                     const ccOk = ccPs ? ccPs !== 'unreachable' : ccChain[0].state !== 'open';
-                    chainSummary += ', CC ' + (ccOk ? 'up' : 'down');
+                    summaryParts.push('CC ' + (ccOk ? 'up' : 'down'));
                 }
-                tipRows.push({ text: chainSummary });
+                if (summaryParts.length > 0) tipRows.push({ text: summaryParts.join(', ') });
             }
             dot.dataset.tip = JSON.stringify(tipRows);
             dot.addEventListener('mouseenter', () => showTip(dot));

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -491,6 +491,7 @@ const SITE_META = {
     '40_knowledge_distillation': { name: 'Knowledge Distill', category: 'learning' },
     '41_resume_review_pass1': { name: 'Resume Review P1', category: 'memory' },
     '42_resume_review_pass2': { name: 'Resume Review P2', category: 'memory' },
+    'ambient_arbiter': { name: 'Ambient Arbiter', category: 'memory' },
     // Partially wired
     '27_pre_execution_assessment': { name: 'Pre-Exec', category: 'reasoning' },
     '33_skill_refiner': { name: 'Skill Refine', category: 'content' },
@@ -1867,7 +1868,7 @@ const SUBSYSTEM_GROUPS = {
         name: 'Memory', domId: 'sub-memory',
         desc: 'Storage, fact extraction, embeddings, knowledge retrieval, and resume review',
         sites: ['9_fact_extraction', '21_embeddings', '21b_query_embedding',
-                '41_resume_review_pass1', '42_resume_review_pass2'],
+                '41_resume_review_pass1', '42_resume_review_pass2', 'ambient_arbiter'],
     },
     surplus: {
         name: 'Surplus', domId: 'sub-surplus',
@@ -1956,7 +1957,7 @@ function updateSubsystemGrid(data) {
         learning:    [[4,1],[5,1],[6,1],[7,1],[4,2],[5,2],[6,2],[7,2]],
         reflection:  [[4,3],[5,3],[6,3],[4,4],[5,4],[6,4]],
         ego:         [[7,3],[7,4],[7,5]],
-        memory:      [[1,4],[3,4],[1,5],[2,5],[2,4]],
+        memory:      [[1,4],[3,4],[1,5],[2,5],[2,4],[1,6]],
         surplus:     [[3,5],[4,5],[3,6],[4,6]],
         executor:    [[5,5],[6,5],[5,6],[6,6]],
         outreach:    [[3,7],[4,7]],

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -568,4 +568,15 @@ _CALL_SITE_META: dict[str, dict] = {
         "model_tier": "frontier",
         "wired": True,
     },
+    "ambient_arbiter": {
+        # Manual cost_policy on purpose: the chain is empty by design (no API
+        # fallback), so auto-derivation would mislabel it "Not configured".
+        "description": "Ambient session-awareness arbiter: judges which drift-fire candidate memories deserve surfacing. Headless CC (pinned Haiku) spawned by the detached ambient worker; the router never dispatches it.",
+        "category": "memory",
+        "frequency": "Per drift-trigger fire (max 8/session)",
+        "cost_policy": "CC subscription (Haiku)",
+        "dispatch": "cli",
+        "cc_model": "Haiku",
+        "model_tier": "cc",
+    },
 }

--- a/src/genesis/observability/call_site_recorder.py
+++ b/src/genesis/observability/call_site_recorder.py
@@ -27,11 +27,13 @@ async def record_last_run(
     input_tokens: int = 0,
     output_tokens: int = 0,
     success: bool = True,
-) -> None:
-    """Record last run for any call site.
+) -> bool:
+    """Record last run for any call site. Returns True iff the row landed.
 
     Called from router, CC reflection bridge, conversation loop, embedding, etc.
-    Uses INSERT OR REPLACE keyed on call_site_id (primary key).
+    Uses INSERT OR REPLACE keyed on call_site_id (primary key). Never raises —
+    a failed write is logged and reported as False so callers that account for
+    telemetry (the detached ambient worker) don't claim a row that isn't there.
     """
     now = datetime.now(UTC).isoformat()
     try:
@@ -46,8 +48,45 @@ async def record_last_run(
             ),
         )
         await db.commit()
+        return True
     except Exception:
         logger.error(
             "Failed to record call_site_last_run for %s", call_site_id,
             exc_info=True,
         )
+        return False
+
+
+async def record_last_run_detached(
+    db_path: str,
+    call_site_id: str,
+    provider: str,
+    model_id: str,
+    response_text: str | None,
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    success: bool = True,
+) -> bool:
+    """``record_last_run`` for processes that don't hold a server DB handle.
+
+    Opens its own short-lived connection via ``get_raw_db`` (WAL +
+    busy_timeout) — the sanctioned seam for detached workers, hooks, and
+    gate code (contribution version gate, ambient worker). Best-effort:
+    never raises; True only when the row demonstrably landed.
+    """
+    try:
+        from genesis.db.connection import get_raw_db
+
+        async with get_raw_db(db_path) as db:
+            return await record_last_run(
+                db, call_site_id, provider, model_id, response_text,
+                input_tokens=input_tokens, output_tokens=output_tokens,
+                success=success,
+            )
+    except Exception:
+        logger.debug(
+            "Detached last-run record failed for %s", call_site_id,
+            exc_info=True,
+        )
+        return False

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -354,8 +354,18 @@ def update_call_site_in_yaml(
     base_cs = base_raw["call_sites"][call_site_id]
     effective_cs = _deep_merge(base_cs, local_cs)
 
+    # The dispatch this update will leave in effect. Mirrors the loader's
+    # empty-chain exemption (_parse: an empty chain is valid ONLY for cli
+    # sites, which spawn CC directly). Without it the first empty-chain
+    # cli site (ambient_arbiter) is un-editable — the dashboard editor
+    # round-trips the chain, and [] was rejected unconditionally here.
+    intended_dispatch = _normalize_dispatch(
+        dispatch if dispatch is not None else effective_cs.get("dispatch"),
+        call_site_name=call_site_id,
+    )
+
     if chain is not None:
-        if not chain:
+        if not chain and intended_dispatch != "cli":
             msg = "Chain must have at least one provider"
             raise ValueError(msg)
         if len(chain) != len(set(chain)):
@@ -406,9 +416,14 @@ def update_call_site_in_yaml(
             local_cs.pop("cc_model", None)
             local_cs.pop("cc_position", None)
 
-    # Validate: never_pays sites must have at least one free provider
+    # Validate: never_pays sites must have at least one free provider.
+    # Vacuous for an empty-chain cli site (nothing to pay for — the same
+    # class the loader exempts), so skip it there or the site can never
+    # revalidate through this path.
     effective_chain = effective_cs.get("chain", base_cs.get("chain", []))
-    if effective_cs.get("never_pays"):
+    if effective_cs.get("never_pays") and not (
+        intended_dispatch == "cli" and not effective_chain
+    ):
         free_in_chain = [p for p in effective_chain if providers.get(p, {}).get("free")]
         if not free_in_chain:
             msg = f"never_pays site '{call_site_id}' must have at least one free provider"

--- a/src/genesis/session_awareness/worker.py
+++ b/src/genesis/session_awareness/worker.py
@@ -10,7 +10,9 @@ Writes three places:
 - ``~/.genesis/session_awareness/shadow_log.jsonl`` — append-only tuning
   record (size-capped; skips are counted in the verdict, never silent)
 - ``call_site_last_run`` row ``ambient_arbiter`` — neural-monitor
-  telemetry, ONLY when the arbiter subprocess actually ran. This uses a
+  telemetry, one row per arbiter ATTEMPT (including pre-spawn failures,
+  which record success=0 with the reason; empty candidate sets record
+  nothing — judge_candidates short-circuits without spawning CC). Uses a
   separate short-lived RW connection; the retrieval connection stays
   ``mode=ro`` so the zero-write invariant on memory rows holds.
 
@@ -60,14 +62,14 @@ async def _record_arbiter_telemetry(
 ) -> bool:
     """Best-effort ``call_site_last_run`` row for the neural monitor.
 
-    Mirrors ``contribution.version_gate._record_to_monitor``: own
-    short-lived RW connection (``get_raw_db`` — WAL + busy_timeout), never
-    raises. Returns False when the write could not be attempted, so the
-    verdict/shadow log stays honest about missing telemetry.
+    Never raises; True only when the row demonstrably landed (a swallowed
+    INSERT failure reports False), so the verdict/shadow log stays honest
+    about missing telemetry.
     """
     try:
-        from genesis.db.connection import get_raw_db
-        from genesis.observability.call_site_recorder import record_last_run
+        from genesis.observability.call_site_recorder import (
+            record_last_run_detached,
+        )
 
         from .arbiter import ARBITER_MODEL
 
@@ -80,16 +82,14 @@ async def _record_arbiter_telemetry(
         ]
         if verdict.get("reason"):
             parts.append(str(verdict["reason"])[:80])
-        async with get_raw_db(str(db_path)) as db:
-            await record_last_run(
-                db,
-                "ambient_arbiter",
-                provider="cc",
-                model_id=ARBITER_MODEL,
-                response_text="|".join(parts),
-                success=arbiter == "ok",
-            )
-        return True
+        return await record_last_run_detached(
+            str(db_path),
+            "ambient_arbiter",
+            provider="cc",
+            model_id=ARBITER_MODEL,
+            response_text="|".join(parts),
+            success=arbiter == "ok",
+        )
     except Exception:
         return False
 
@@ -126,11 +126,9 @@ async def run_worker(
     def finish(verdict: dict) -> dict:
         verdict.setdefault("session_id", session_id)
         verdict.setdefault("generated_at", now_iso)
-        _atomic_write_json(verdict_path, verdict)
-        logged = _append_shadow_log(verdict, state_root)
-        if not logged:
+        if not _append_shadow_log(verdict, state_root):
             verdict["shadow_log_skipped"] = True
-            _atomic_write_json(verdict_path, verdict)
+        _atomic_write_json(verdict_path, verdict)
         return verdict
 
     state = load_state(session_id, base=sessions_root)

--- a/src/genesis/session_awareness/worker.py
+++ b/src/genesis/session_awareness/worker.py
@@ -3,11 +3,16 @@
 Spawned by the proactive hook (``start_new_session=True``) when a
 session theme settles. Opens its OWN read-only DB connection, Qdrant
 client, and embedding provider — it must never touch server state.
-Writes exactly two places, both under ``~/.genesis``:
+Writes three places:
 
-- ``sessions/<id>/ambient_verdict.json`` — the latest outcome (atomic)
-- ``session_awareness/shadow_log.jsonl`` — append-only tuning record
-  (size-capped; skips are counted in the verdict, never silent)
+- ``~/.genesis/sessions/<id>/ambient_verdict.json`` — the latest outcome
+  (atomic)
+- ``~/.genesis/session_awareness/shadow_log.jsonl`` — append-only tuning
+  record (size-capped; skips are counted in the verdict, never silent)
+- ``call_site_last_run`` row ``ambient_arbiter`` — neural-monitor
+  telemetry, ONLY when the arbiter subprocess actually ran. This uses a
+  separate short-lived RW connection; the retrieval connection stays
+  ``mode=ro`` so the zero-write invariant on memory rows holds.
 
 PR2 runs ``--no-arbiter`` only; PR3 adds the arbiter judgment stage.
 """
@@ -17,6 +22,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -47,6 +53,45 @@ def _atomic_write_json(path: Path, data: dict) -> None:
     finally:
         os.close(fd)
     os.replace(tmp, str(path))
+
+
+async def _record_arbiter_telemetry(
+    db_path: Path | str, verdict: dict, n_candidates: int,
+) -> bool:
+    """Best-effort ``call_site_last_run`` row for the neural monitor.
+
+    Mirrors ``contribution.version_gate._record_to_monitor``: own
+    short-lived RW connection (``get_raw_db`` — WAL + busy_timeout), never
+    raises. Returns False when the write could not be attempted, so the
+    verdict/shadow log stays honest about missing telemetry.
+    """
+    try:
+        from genesis.db.connection import get_raw_db
+        from genesis.observability.call_site_recorder import record_last_run
+
+        from .arbiter import ARBITER_MODEL
+
+        arbiter = verdict.get("arbiter", "unknown")
+        parts = [
+            f"arbiter={arbiter}",
+            f"picks={len(verdict.get('picks') or [])}",
+            f"candidates={n_candidates}",
+            f"lat_ms={verdict.get('arbiter_latency_ms', 0)}",
+        ]
+        if verdict.get("reason"):
+            parts.append(str(verdict["reason"])[:80])
+        async with get_raw_db(str(db_path)) as db:
+            await record_last_run(
+                db,
+                "ambient_arbiter",
+                provider="cc",
+                model_id=ARBITER_MODEL,
+                response_text="|".join(parts),
+                success=arbiter == "ok",
+            )
+        return True
+    except Exception:
+        return False
 
 
 def _append_shadow_log(record: dict, state_root: Path) -> bool:
@@ -145,8 +190,12 @@ async def run_worker(
             # machinery (and its genesis.security/env imports).
             from .arbiter import judge_candidates
 
+            arbiter_t0 = time.monotonic()
             verdict.update(
                 await judge_candidates(theme_stats, entity_query, candidates)
+            )
+            verdict["arbiter_latency_ms"] = int(
+                (time.monotonic() - arbiter_t0) * 1000
             )
             picks = verdict.get("picks") or []
             verdict["picked_memory_ids"] = [
@@ -154,6 +203,12 @@ async def run_worker(
                 for n in picks
                 if 1 <= n <= len(candidates)
             ]
+            if candidates:
+                # Empty candidate sets short-circuit judge_candidates without
+                # spawning CC — no run happened, so nothing to record.
+                verdict["telemetry_recorded"] = await _record_arbiter_telemetry(
+                    resolved_db, verdict, len(candidates)
+                )
         return finish(verdict)
     except Exception as exc:  # recorded, never raised — detached process
         return finish({"status": "error", "error": f"{type(exc).__name__}: {exc}"})

--- a/tests/test_observability/test_call_site_recorder.py
+++ b/tests/test_observability/test_call_site_recorder.py
@@ -29,12 +29,13 @@ async def db(tmp_path):
 
 @pytest.mark.asyncio
 async def test_record_inserts_new(db):
-    await record_last_run(
+    landed = await record_last_run(
         db, "test_site",
         provider="openrouter", model_id="haiku-3.5",
         response_text="hello world",
         input_tokens=100, output_tokens=50,
     )
+    assert landed is True  # contract: True iff the row landed
     cursor = await db.execute("SELECT * FROM call_site_last_run WHERE call_site_id = ?", ("test_site",))
     row = await cursor.fetchone()
     assert row is not None
@@ -70,8 +71,17 @@ async def test_record_failure(db):
 
 @pytest.mark.asyncio
 async def test_record_survives_missing_table(tmp_path):
-    """Should not raise even if table doesn't exist — just logs a warning."""
+    """Should not raise even if table doesn't exist — just logs a warning
+    and reports False (a swallowed INSERT failure is not a landed row).
+
+    This is the unit-level guard for the contract the ambient worker's
+    telemetry_recorded flag depends on: callers that account for
+    telemetry must not be told a row landed when it silently didn't.
+    """
     path = tmp_path / "empty.db"
     async with aiosqlite.connect(str(path)) as conn:
-        # No table created — should not raise
-        await record_last_run(conn, "x", provider="p", model_id="m", response_text="t")
+        # No table created — should not raise, and must report False
+        landed = await record_last_run(
+            conn, "x", provider="p", model_id="m", response_text="t",
+        )
+        assert landed is False

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -148,10 +148,17 @@ def test_load_full_yaml(monkeypatch):
     # 2026-06-20: 51 → 52 after crag_grade added (W-CRAG selective corrective retrieval, PR #711).
     # 2026-06-30: 52 → 53 after 38a_procedure_novelty_llm added (C2b cross-type procedure dedup).
     # 2026-07-01: 53 → 54 after attention_salience added (PR3b L1.5 salience gate).
-    assert len(cfg.call_sites) == 54
+    # 2026-07-10: 54 → 55 after ambient_arbiter added (WS-C arbiter neural-monitor registration).
+    assert len(cfg.call_sites) == 55
     assert "crag_grade" in cfg.call_sites  # W-CRAG runtime grader (2026-06-20)
     assert "38a_procedure_novelty_llm" in cfg.call_sites  # C2b cross-type dedup (2026-06-30)
     assert "attention_salience" in cfg.call_sites  # PR3b L1.5 salience gate (2026-07-01)
+    # ambient_arbiter: display-only cli site — the detached ambient worker spawns
+    # CC directly (model pinned in session_awareness/arbiter.py); empty chain BY
+    # DESIGN (no API fallback). First empty-chain cli site — lock the shape.
+    assert cfg.call_sites["ambient_arbiter"].dispatch == "cli"
+    assert cfg.call_sites["ambient_arbiter"].chain == []
+    assert cfg.call_sites["ambient_arbiter"].never_pays is True
     assert "models_md_synthesis" not in cfg.call_sites  # removed 2026-05-24
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)

--- a/tests/test_routing/test_config_save.py
+++ b/tests/test_routing/test_config_save.py
@@ -30,6 +30,14 @@ def config_file(tmp_path):
                 "default_paid": True,
                 "never_pays": False,
             },
+            # Empty-chain cli site (the ambient_arbiter class): the loader
+            # keeps it, so the save path must round-trip it too.
+            "ambient_arbiter": {
+                "chain": [],
+                "dispatch": "cli",
+                "cc_model": "Haiku",
+                "never_pays": True,
+            },
         },
     }
     path = tmp_path / "model_routing.yaml"
@@ -97,6 +105,33 @@ def test_reject_never_pays_without_free(config_file):
             chain=["openrouter_sonnet"],  # not free
             never_pays=True,
         )
+
+
+def test_empty_chain_cli_site_round_trips(config_file):
+    """The editor always sends the chain; [] must be accepted for a cli
+    site (mirrors the loader's exemption) or the site is un-editable."""
+    new_config = update_call_site_in_yaml(
+        config_file, "ambient_arbiter", chain=[], cc_model="Sonnet",
+    )
+    cs = new_config.call_sites["ambient_arbiter"]
+    assert cs.chain == []
+    assert cs.dispatch == "cli"
+
+
+def test_never_pays_vacuous_on_empty_chain_cli(config_file):
+    """The never_pays free-provider check must not block a chainless cli
+    site (nothing to pay for) — any edit would 400 forever otherwise."""
+    new_config = update_call_site_in_yaml(
+        config_file, "ambient_arbiter", never_pays=True,
+    )
+    assert new_config.call_sites["ambient_arbiter"].never_pays is True
+
+
+def test_empty_chain_still_rejected_for_api_sites(config_file):
+    """The cli exemption must not leak: a dual/api site keeps the
+    non-empty-chain requirement (2_triage has no dispatch -> dual)."""
+    with pytest.raises(ValueError, match="at least one provider"):
+        update_call_site_in_yaml(config_file, "2_triage", chain=[])
 
 
 def test_update_default_paid(config_file):

--- a/tests/test_session_awareness/conftest.py
+++ b/tests/test_session_awareness/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures/helpers for session_awareness tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.session_awareness.statefiles import empty_state, save_state
+
+DIM = 8
+
+
+def seed_theme(
+    sessions_root: Path, session_id: str, *, ema: list[float] | None = None,
+) -> None:
+    """Write a settled theme state ready to fire.
+
+    ``updated_at`` is NOW-relative, never hardcoded: run_worker's
+    load_state compares it against the wall clock (STALE_AFTER softening
+    shrinks the ring → stability 0.0). A hardcoded stamp is a time bomb —
+    green when written, red for every run after the staleness horizon
+    passes (broke main CI on 2026-07-10).
+    """
+    s = empty_state(session_id)
+    s["ema"] = ema or [1.0] + [0.0] * (DIM - 1)
+    s["ema_turns"] = 4
+    s["ring"] = [s["ema"]] * 3
+    s["entities"] = {"genesis": 2.0, "voice": 1.1, "faint": 0.06}
+    s["updated_at"] = datetime.now(UTC).isoformat()
+    save_state(session_id, s, base=sessions_root)

--- a/tests/test_session_awareness/test_worker.py
+++ b/tests/test_session_awareness/test_worker.py
@@ -7,7 +7,6 @@ import os
 import sqlite3
 import subprocess
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -15,29 +14,20 @@ import pytest
 
 from genesis.session_awareness import worker as worker_mod
 from genesis.session_awareness.slots import try_acquire_slot
-from genesis.session_awareness.statefiles import empty_state, save_state
 from genesis.session_awareness.worker import run_worker
+
+from .conftest import DIM, seed_theme
 
 REPO_DIR = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_DIR / "scripts" / "ambient_awareness_worker.py"
 
-DIM = 8
 SID = "worker-test-1"
 
 
 def _seed_theme(sessions_root: Path, *, ema=None) -> None:
-    s = empty_state(SID)
-    s["ema"] = ema or [1.0] + [0.0] * (DIM - 1)
-    s["ema_turns"] = 4
-    s["ring"] = [s["ema"]] * 3
-    s["entities"] = {"genesis": 2.0, "voice": 1.1, "faint": 0.06}
-    # NOW-relative, never hardcoded: run_worker's load_state compares
-    # updated_at against the wall clock (STALE_AFTER softening shrinks the
-    # ring → stability 0.0). The original hardcoded 2026-07-09 stamp was a
-    # time bomb — green when written, red for every run after the staleness
-    # horizon passed (broke main CI on 2026-07-10).
-    s["updated_at"] = datetime.now(UTC).isoformat()
-    save_state(SID, s, base=sessions_root)
+    # Shared helper (conftest.seed_theme) owns the theme recipe and the
+    # NOW-relative updated_at discipline — see its docstring.
+    seed_theme(sessions_root, SID, ema=ema)
 
 
 def _tmp_db(tmp_path: Path) -> Path:

--- a/tests/test_session_awareness/test_worker_telemetry.py
+++ b/tests/test_session_awareness/test_worker_telemetry.py
@@ -1,61 +1,41 @@
 """Arbiter neural-monitor telemetry — call_site_last_run recording.
 
-The worker records one ``ambient_arbiter`` row per real arbiter run
-(judged verdicts only, and only when candidates existed — an empty set
+The worker records one ``ambient_arbiter`` row per arbiter ATTEMPT
+(judged verdicts with a non-empty candidate set — an empty set
 short-circuits judge_candidates without spawning CC). The write goes
-through its own short-lived RW connection; the retrieval connection
-stays read-only, and telemetry failure must never affect the verdict.
+through ``record_last_run_detached`` (own short-lived RW connection);
+the retrieval connection stays read-only, telemetry failure must never
+affect the verdict, and ``telemetry_recorded`` must be True only when
+the row demonstrably landed.
 """
 
 from __future__ import annotations
 
 import sqlite3
-from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import aiosqlite
 import pytest
 
+from genesis.db.schema import create_all_tables
 from genesis.session_awareness import worker as worker_mod
 from genesis.session_awareness.arbiter import ARBITER_MODEL
-from genesis.session_awareness.statefiles import empty_state, save_state
 from genesis.session_awareness.worker import run_worker
 
-DIM = 8
+from .conftest import seed_theme
+
 SID = "worker-telemetry-1"
 
-_TABLE_DDL = """
-    CREATE TABLE call_site_last_run (
-        call_site_id TEXT PRIMARY KEY,
-        last_run_at TEXT NOT NULL,
-        provider_used TEXT,
-        model_id TEXT,
-        response_text TEXT,
-        input_tokens INTEGER,
-        output_tokens INTEGER,
-        success INTEGER NOT NULL DEFAULT 1,
-        updated_at TEXT NOT NULL
-    )
-"""
 
-
-def _seed_theme(sessions_root: Path) -> None:
-    s = empty_state(SID)
-    s["ema"] = [1.0] + [0.0] * (DIM - 1)
-    s["ema_turns"] = 4
-    s["ring"] = [s["ema"]] * 3
-    s["entities"] = {"genesis": 2.0}
-    s["updated_at"] = datetime.now(UTC).isoformat()
-    save_state(SID, s, base=sessions_root)
-
-
-def _tmp_db(tmp_path: Path) -> Path:
-    db = tmp_path / "g.db"
-    con = sqlite3.connect(str(db))
-    con.execute(_TABLE_DDL)
-    con.commit()
-    con.close()
-    return db
+async def _real_schema_db(tmp_path: Path) -> Path:
+    """Temp file DB with the REAL schema — no hand-copied DDL to drift."""
+    db_path = tmp_path / "g.db"
+    conn = await aiosqlite.connect(str(db_path))
+    await create_all_tables(conn)
+    await conn.commit()
+    await conn.close()
+    return db_path
 
 
 def _last_run_row(db: Path) -> sqlite3.Row | None:
@@ -70,7 +50,7 @@ def _last_run_row(db: Path) -> sqlite3.Row | None:
 
 async def _run(tmp_path, *, db: Path, arbiter_verdict: dict, candidates: list):
     sessions, state = tmp_path / "s", tmp_path / "sa"
-    _seed_theme(sessions)
+    seed_theme(sessions, SID)
     with (
         patch.object(
             worker_mod, "rank_candidates", new=AsyncMock(return_value=candidates),
@@ -88,7 +68,7 @@ async def _run(tmp_path, *, db: Path, arbiter_verdict: dict, candidates: list):
 
 @pytest.mark.asyncio
 async def test_judged_run_records_last_run_row(tmp_path):
-    db = _tmp_db(tmp_path)
+    db = await _real_schema_db(tmp_path)
     result = await _run(
         tmp_path, db=db,
         arbiter_verdict={"arbiter": "ok", "picks": [1], "prompt_version": "v1"},
@@ -110,7 +90,7 @@ async def test_judged_run_records_last_run_row(tmp_path):
 
 @pytest.mark.asyncio
 async def test_arbiter_failure_records_red_row(tmp_path):
-    db = _tmp_db(tmp_path)
+    db = await _real_schema_db(tmp_path)
     result = await _run(
         tmp_path, db=db,
         arbiter_verdict={
@@ -126,7 +106,7 @@ async def test_arbiter_failure_records_red_row(tmp_path):
 
 @pytest.mark.asyncio
 async def test_no_run_paths_do_not_record(tmp_path):
-    db = _tmp_db(tmp_path)
+    db = await _real_schema_db(tmp_path)
 
     # no_theme: no arbiter, no row
     sessions, state = tmp_path / "s0", tmp_path / "sa0"
@@ -136,7 +116,7 @@ async def test_no_run_paths_do_not_record(tmp_path):
 
     # --no-arbiter: candidates ranked but arbiter never invoked
     sessions, state = tmp_path / "s1", tmp_path / "sa1"
-    _seed_theme(sessions)
+    seed_theme(sessions, SID)
     with patch.object(
         worker_mod, "rank_candidates",
         new=AsyncMock(return_value=[{"memory_id": "m1", "score": 0.9}]),
@@ -164,7 +144,7 @@ async def test_no_run_paths_do_not_record(tmp_path):
 async def test_telemetry_failure_never_breaks_verdict(tmp_path):
     """A dead telemetry path degrades to telemetry_recorded=False —
     the verdict still writes and the shadow log still appends."""
-    db = _tmp_db(tmp_path)
+    db = await _real_schema_db(tmp_path)
     with patch(
         "genesis.db.connection.get_raw_db",
         side_effect=RuntimeError("db exploded"),
@@ -185,15 +165,33 @@ async def test_telemetry_failure_never_breaks_verdict(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_swallowed_insert_failure_reports_false(tmp_path):
+    """record_last_run swallows INSERT errors internally — the flag must
+    still come back False, not a false-positive True. A schemaless DB
+    (missing call_site_last_run, e.g. migration-lagged install) is the
+    concrete reachable case."""
+    db_path = tmp_path / "empty.db"
+    sqlite3.connect(str(db_path)).close()  # no tables at all
+    result = await _run(
+        tmp_path, db=db_path,
+        arbiter_verdict={"arbiter": "ok", "picks": [], "prompt_version": "v1"},
+        candidates=[{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}],
+    )
+    assert result["status"] == "judged"
+    assert result["telemetry_recorded"] is False
+
+
+@pytest.mark.asyncio
 async def test_retrieval_rows_untouched_by_telemetry(tmp_path):
-    """The RW telemetry connection writes ONLY call_site_last_run — the
-    zero-write invariant on memory rows (retrieved_count) holds."""
-    db = _tmp_db(tmp_path)
+    """The RW telemetry connection writes ONLY call_site_last_run — rows
+    carrying retrieved_count (real schema: observations) stay untouched."""
+    db = await _real_schema_db(tmp_path)
     con = sqlite3.connect(str(db))
     con.execute(
-        "CREATE TABLE memory_metadata (id TEXT PRIMARY KEY, retrieved_count INTEGER)"
+        "INSERT INTO observations (id, source, type, content, priority,"
+        " retrieved_count, created_at)"
+        " VALUES ('o1', 'test', 'note', 'x', 'low', 7, '2026-07-10T00:00:00Z')"
     )
-    con.execute("INSERT INTO memory_metadata VALUES ('m1', 7)")
     con.commit()
     con.close()
 
@@ -204,7 +202,7 @@ async def test_retrieval_rows_untouched_by_telemetry(tmp_path):
     )
     con = sqlite3.connect(str(db))
     count = con.execute(
-        "SELECT retrieved_count FROM memory_metadata WHERE id='m1'"
+        "SELECT retrieved_count FROM observations WHERE id='o1'"
     ).fetchone()[0]
     con.close()
     assert count == 7

--- a/tests/test_session_awareness/test_worker_telemetry.py
+++ b/tests/test_session_awareness/test_worker_telemetry.py
@@ -1,0 +1,211 @@
+"""Arbiter neural-monitor telemetry — call_site_last_run recording.
+
+The worker records one ``ambient_arbiter`` row per real arbiter run
+(judged verdicts only, and only when candidates existed — an empty set
+short-circuits judge_candidates without spawning CC). The write goes
+through its own short-lived RW connection; the retrieval connection
+stays read-only, and telemetry failure must never affect the verdict.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.session_awareness import worker as worker_mod
+from genesis.session_awareness.arbiter import ARBITER_MODEL
+from genesis.session_awareness.statefiles import empty_state, save_state
+from genesis.session_awareness.worker import run_worker
+
+DIM = 8
+SID = "worker-telemetry-1"
+
+_TABLE_DDL = """
+    CREATE TABLE call_site_last_run (
+        call_site_id TEXT PRIMARY KEY,
+        last_run_at TEXT NOT NULL,
+        provider_used TEXT,
+        model_id TEXT,
+        response_text TEXT,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        success INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL
+    )
+"""
+
+
+def _seed_theme(sessions_root: Path) -> None:
+    s = empty_state(SID)
+    s["ema"] = [1.0] + [0.0] * (DIM - 1)
+    s["ema_turns"] = 4
+    s["ring"] = [s["ema"]] * 3
+    s["entities"] = {"genesis": 2.0}
+    s["updated_at"] = datetime.now(UTC).isoformat()
+    save_state(SID, s, base=sessions_root)
+
+
+def _tmp_db(tmp_path: Path) -> Path:
+    db = tmp_path / "g.db"
+    con = sqlite3.connect(str(db))
+    con.execute(_TABLE_DDL)
+    con.commit()
+    con.close()
+    return db
+
+
+def _last_run_row(db: Path) -> sqlite3.Row | None:
+    con = sqlite3.connect(str(db))
+    con.row_factory = sqlite3.Row
+    row = con.execute(
+        "SELECT * FROM call_site_last_run WHERE call_site_id='ambient_arbiter'"
+    ).fetchone()
+    con.close()
+    return row
+
+
+async def _run(tmp_path, *, db: Path, arbiter_verdict: dict, candidates: list):
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    _seed_theme(sessions)
+    with (
+        patch.object(
+            worker_mod, "rank_candidates", new=AsyncMock(return_value=candidates),
+        ),
+        patch(
+            "genesis.session_awareness.arbiter.judge_candidates",
+            new=AsyncMock(return_value=arbiter_verdict),
+        ),
+    ):
+        return await run_worker(
+            SID, sessions_root=sessions, state_root=state,
+            db_path=db, qdrant_url="http://127.0.0.1:1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_judged_run_records_last_run_row(tmp_path):
+    db = _tmp_db(tmp_path)
+    result = await _run(
+        tmp_path, db=db,
+        arbiter_verdict={"arbiter": "ok", "picks": [1], "prompt_version": "v1"},
+        candidates=[{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}],
+    )
+    assert result["status"] == "judged"
+    assert result["telemetry_recorded"] is True
+    assert isinstance(result["arbiter_latency_ms"], int)
+    row = _last_run_row(db)
+    assert row is not None
+    assert row["provider_used"] == "cc"
+    assert row["model_id"] == ARBITER_MODEL
+    assert row["success"] == 1
+    assert "arbiter=ok" in row["response_text"]
+    assert "picks=1" in row["response_text"]
+    assert "candidates=1" in row["response_text"]
+    assert "lat_ms=" in row["response_text"]
+
+
+@pytest.mark.asyncio
+async def test_arbiter_failure_records_red_row(tmp_path):
+    db = _tmp_db(tmp_path)
+    result = await _run(
+        tmp_path, db=db,
+        arbiter_verdict={
+            "arbiter": "timeout", "picks": [], "prompt_version": "v1",
+        },
+        candidates=[{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}],
+    )
+    assert result["telemetry_recorded"] is True
+    row = _last_run_row(db)
+    assert row["success"] == 0
+    assert "arbiter=timeout" in row["response_text"]
+
+
+@pytest.mark.asyncio
+async def test_no_run_paths_do_not_record(tmp_path):
+    db = _tmp_db(tmp_path)
+
+    # no_theme: no arbiter, no row
+    sessions, state = tmp_path / "s0", tmp_path / "sa0"
+    result = await run_worker(SID, sessions_root=sessions, state_root=state)
+    assert result["status"] == "no_theme"
+    assert _last_run_row(db) is None
+
+    # --no-arbiter: candidates ranked but arbiter never invoked
+    sessions, state = tmp_path / "s1", tmp_path / "sa1"
+    _seed_theme(sessions)
+    with patch.object(
+        worker_mod, "rank_candidates",
+        new=AsyncMock(return_value=[{"memory_id": "m1", "score": 0.9}]),
+    ):
+        result = await run_worker(
+            SID, no_arbiter=True, sessions_root=sessions, state_root=state,
+            db_path=db, qdrant_url="http://127.0.0.1:1",
+        )
+    assert result["status"] == "no_arbiter"
+    assert "telemetry_recorded" not in result
+    assert _last_run_row(db) is None
+
+    # Empty candidate set: judge_candidates short-circuits, no CC spawned
+    result = await _run(
+        tmp_path, db=db,
+        arbiter_verdict={"arbiter": "ok", "picks": [], "prompt_version": "v1"},
+        candidates=[],
+    )
+    assert result["status"] == "judged"
+    assert "telemetry_recorded" not in result
+    assert _last_run_row(db) is None
+
+
+@pytest.mark.asyncio
+async def test_telemetry_failure_never_breaks_verdict(tmp_path):
+    """A dead telemetry path degrades to telemetry_recorded=False —
+    the verdict still writes and the shadow log still appends."""
+    db = _tmp_db(tmp_path)
+    with patch(
+        "genesis.db.connection.get_raw_db",
+        side_effect=RuntimeError("db exploded"),
+    ):
+        result = await _run(
+            tmp_path, db=db,
+            arbiter_verdict={"arbiter": "ok", "picks": [], "prompt_version": "v1"},
+            candidates=[{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}],
+        )
+    assert result["status"] == "judged"
+    assert result["telemetry_recorded"] is False
+    assert _last_run_row(db) is None
+    # Verdict file + shadow log both written despite the telemetry failure
+    verdict_file = tmp_path / "s" / SID / "ambient_verdict.json"
+    assert verdict_file.exists()
+    log = (tmp_path / "sa" / "shadow_log.jsonl").read_text()
+    assert '"telemetry_recorded": false' in log
+
+
+@pytest.mark.asyncio
+async def test_retrieval_rows_untouched_by_telemetry(tmp_path):
+    """The RW telemetry connection writes ONLY call_site_last_run — the
+    zero-write invariant on memory rows (retrieved_count) holds."""
+    db = _tmp_db(tmp_path)
+    con = sqlite3.connect(str(db))
+    con.execute(
+        "CREATE TABLE memory_metadata (id TEXT PRIMARY KEY, retrieved_count INTEGER)"
+    )
+    con.execute("INSERT INTO memory_metadata VALUES ('m1', 7)")
+    con.commit()
+    con.close()
+
+    await _run(
+        tmp_path, db=db,
+        arbiter_verdict={"arbiter": "ok", "picks": [1], "prompt_version": "v1"},
+        candidates=[{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}],
+    )
+    con = sqlite3.connect(str(db))
+    count = con.execute(
+        "SELECT retrieved_count FROM memory_metadata WHERE id='m1'"
+    ).fetchone()[0]
+    con.close()
+    assert count == 7
+    assert _last_run_row(db) is not None


### PR DESCRIPTION
## What

The WS-C ambient arbiter — a headless pinned-Haiku CC subprocess spawned by the detached session-awareness worker on every drift-trigger fire — was firing **completely unobserved**: absent from the routing registry, `call_site_last_run`, and every dashboard surface. Its only trace was a JSONL file on disk. This registers it as a `dispatch: cli` call site (the `14_weekly_self_assessment` species) so each run renders on the neural monitor.

**Scope decision (2026-07-10): register + telemetry, model stays PINNED.** The YAML `cc_model: Haiku` reflects reality but the code never reads it — no governance path, zero risk to the determinism guarantee. Governance (reading `cc_model` live) is explicitly deferred.

## Changes

- **`config/model_routing.yaml`**: `ambient_arbiter`, `dispatch: cli`, `cc_model: Haiku`, `chain: []` **by design** — no API fallback exists (a failed arbiter call records an empty verdict, never a guess) and the router never dispatches it. First empty-chain cli site; loader-sanctioned (`config.py` keeps empty-chain cli sites).
- **`_call_site_meta.py`**: manual `cost_policy` (empty chain would auto-derive "Not configured"); `dispatch`/`cc_model` mirror YAML for the metadata drift guard.
- **`neural_monitor.html`**: memory-group grid cell + `SITE_META` label; tooltip skips the API fraction for CC-only sites (`0/0 API` read as a broken chain).
- **`session_awareness/worker.py`**: records one `call_site_last_run` row per arbiter **attempt** (judged verdicts with candidates; empty sets short-circuit without spawning CC). Own short-lived RW connection — the retrieval connection stays `mode=ro`, so the zero-memory-row-write invariant holds (test-asserted). `arbiter`/`picks`/`candidates`/`lat_ms` fold into `response_text` (no schema change).
- **`call_site_recorder.py`**: `record_last_run` now returns a landed-bool (additive; all callers ignored the return); new `record_last_run_detached` shared helper used by both detached emitters (this worker + `version_gate._record_to_monitor`, which previously hand-rolled the pattern).
- **`config.py`**: the dashboard save-path validator (`update_call_site_in_yaml`) now honors the same empty-chain cli exemption the loader has — without it the new site was permanently un-editable via the dashboard (loader accepts it, save path 400'd). The exemption does **not** leak to api/dual sites (test-locked).

## Verification

- **Targeted tests green**: `tests/test_session_awareness/` (incl. new `test_worker_telemetry.py`), `tests/test_routing/test_config.py` (54→55 + shape lock), `tests/test_routing/test_config_save.py` (3 new empty-chain cli tests), `tests/test_observability/test_call_site_metadata.py` + `test_call_site_recorder.py`, `tests/test_contribution/test_version_gate.py`. Ruff clean; subsystem-map guard clean.
- **Full E2E against real infra** (real Qdrant + real DB + **real Haiku arbiter subprocess**): worker pass judged 9 candidates, arbiter ran (`arbiter=ok`, 22s, picked 1), telemetry row landed in the real `genesis.db` (`success=1`, correct model + `response_text`), worktree snapshot rendered it as a proper registered site (cost policy, dispatch, full last-run detail), and the **live deployed `/health`** surfaces the row (as `routing=false` orphan pre-merge — upgrades to a proper cell after deploy).
- **High-effort multi-agent code review** run before merge: 2 confirmed bugs (dashboard-uneditable site; `telemetry_recorded` false-positive on swallowed INSERT failures) + 4 cleanups, all fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)