### PR TITLE
fix(security): Tier-1 safety-gate hardening — rm guard, fail-closed merge gate, dotenv-safe secrets, gitleaks CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,23 @@ jobs:
           fi
           echo "Secret scan: CLEAN (0 findings)"
 
+      - name: Leak scan (gitleaks)
+        # Blocking. Covers the whole tree (incl. docs/) with the repo's
+        # .gitleaks.toml PII/infrastructure rules — the scans above only
+        # cover src/config/scripts/.github. Version+checksum pinned;
+        # --redact is MANDATORY: these logs are public, a found secret
+        # must never be echoed into them.
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION=8.22.1
+          GITLEAKS_SHA256=2f92ab3b8e08319ac30836c32b90818e01519c3a4982771e4f45a7f5607872f7
+          curl -sSfL -o /tmp/gitleaks.tgz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tgz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
+          /tmp/gitleaks detect --no-git --redact -c .gitleaks.toml --source .
+          echo "Leak scan (gitleaks): CLEAN"
+
       - name: Portability scan (user-specific content)
         run: |
           set -euo pipefail

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -53,4 +53,17 @@ paths = [
     '''src/genesis/contribution/sanitize\.py''',
     '''scripts/hooks/commit-msg''',
     '''\.gitleaks\.toml''',
+    '''secrets\.env\.example''',
+]
+# Match allowlist regexes against the whole LINE (default is the captured
+# secret, which never includes the /10 and /48 suffixes that mark these
+# as range notation rather than host addresses).
+regexTarget = "line"
+regexes = [
+    # RFC 6598 CGNAT range notation in security docs — a range, not an
+    # address of anything.
+    '''100\.64\.0\.0/10''',
+    # Tailscale ULA prefix notation in code comments — the prefix
+    # itself, not a host address.
+    '''fd7a::/48''',
 ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,8 +134,12 @@ Genesis uses an environment-file approach for secrets:
   only).
 - The `genesis.env` module (`src/genesis/env.py`) resolves the secrets path
   at runtime, with support for `SECRETS_PATH` environment variable override.
-- A `detect-secrets` scan runs as part of the public release process to verify
-  no secrets leak into the distribution repo.
+- A `detect-secrets` scan and a blocking `gitleaks` scan (`.gitleaks.toml`
+  rules: API keys plus install-specific IP/hostname patterns) run in CI on
+  every PR to verify no secrets leak into the public repo.
+- Scripts read `secrets.env` as data (`scripts/lib/load_secrets.sh` or the
+  Python dotenv reader) — never `source` it; a sourced value containing
+  `$(...)` would execute.
 
 **Rules:**
 - Never commit API keys, tokens, or credentials to version control.

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -25,7 +25,8 @@ documentation.
 
 The public repo (`GENesis-AGI`) is the primary repo, so there is no separate
 "strip and stage" step. Leak protection is enforced on every PR by the
-`leak-detector` job in `.github/workflows/ci.yml` (detect-secrets + portability
+`leak-detector` job in `.github/workflows/ci.yml` (detect-secrets + gitleaks
+with the repo's `.gitleaks.toml` PII/infrastructure rules + portability
 + email scans). Releases are cut by tagging `vX.Y` on `main` and publishing a
 GitHub Release from the matching `CHANGELOG.md` section.
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -72,13 +72,12 @@ SECRETS_FILE="${SECRETS_PATH:-$GENESIS_DIR/secrets.env}"
 QDRANT_URL="${QDRANT_URL:-http://localhost:6333}"
 LOG_PREFIX="[genesis-backup]"
 
-# Source secrets for backup passphrase (cron doesn't inherit shell env)
-if [ -f "$SECRETS_FILE" ]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$SECRETS_FILE"
-    set +a
-fi
+# Load secrets for the backup passphrase (cron doesn't inherit shell
+# env) WITHOUT shell-evaluating the file — `source` would execute any
+# command substitution embedded in a value.
+# shellcheck source=scripts/lib/load_secrets.sh
+source "$_SCRIPT_DIR/lib/load_secrets.sh"
+load_secrets_file "$SECRETS_FILE"
 
 log() { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 

--- a/scripts/bash_safety_hook.sh
+++ b/scripts/bash_safety_hook.sh
@@ -87,13 +87,13 @@ fi
 # below, because the generic "git push" warning (exit 0) would otherwise
 # short-circuit a force-push before this block could hard-block it.
 case "$CMD" in
-    *"rm -rf /"*|*"rm -rf ~"*|*"rm -rf ."*|*"rm -rf .."*)
+    *"rm -rf /"*|*"rm -rf ~"*|*"rm -rf ."*)  # "rm -rf ." also covers ".."
         echo "BLOCKED: rm -rf on broad paths is not allowed. Be specific or ask the user." >&2
         exit 2;;
     *"git reset --hard"*)
         echo "BLOCKED: git reset --hard destroys uncommitted work. Use git stash or ask the user." >&2
         exit 2;;
-    *"git clean -f"*|*"git clean -fd"*)
+    *"git clean -f"*)  # substring also covers -fd
         echo "BLOCKED: git clean removes untracked files permanently. Ask the user first." >&2
         exit 2;;
 esac
@@ -125,7 +125,9 @@ fi
 # used to skip this check entirely (2026-07-10 P1 triage).
 if echo "$CMD" | grep -qE "^gh pr merge|[;&|] *gh pr merge"; then
     _pr_num=$(echo "$CMD" | grep -oE 'merge +#?[0-9]+' | grep -oE '[0-9]+' | head -1)
-    _repo_flag=$(echo "$CMD" | grep -oP -- '--repo \S+' || true)
+    _repo_args=()
+    _repo=$(echo "$CMD" | grep -oP -- '--repo \K\S+' || true)
+    [ -n "$_repo" ] && _repo_args=(--repo "$_repo")
     if [ -z "$_pr_num" ]; then
         # No number in the command — resolve the current branch's open PR
         _pr_num=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
@@ -135,7 +137,7 @@ if echo "$CMD" | grep -qE "^gh pr merge|[;&|] *gh pr merge"; then
         echo "Specify the PR number: gh pr merge <N> --squash --admin" >&2
         exit 2
     fi
-    _mergeable=$(gh pr view "$_pr_num" $_repo_flag --json mergeable --jq '.mergeable' 2>/dev/null)
+    _mergeable=$(gh pr view "$_pr_num" "${_repo_args[@]}" --json mergeable --jq '.mergeable' 2>/dev/null)
     if [ "$_mergeable" = "UNKNOWN" ]; then
         echo "BLOCKED: PR #$_pr_num mergeable status is UNKNOWN." >&2
         echo "GitHub hasn't finished conflict analysis. Wait until mergeable status is known before retrying." >&2

--- a/scripts/bash_safety_hook.sh
+++ b/scripts/bash_safety_hook.sh
@@ -120,23 +120,31 @@ if echo "$CMD" | grep -qE "^gh pr create|[;&|] *gh pr create"; then
     exit 0
 fi
 
-# gh pr merge — hard-block if GitHub hasn't confirmed the PR is conflict-free
+# gh pr merge — hard-block if GitHub hasn't confirmed the PR is conflict-free.
+# Fail CLOSED on an unresolvable PR: a no-arg `gh pr merge` from the PR branch
+# used to skip this check entirely (2026-07-10 P1 triage).
 if echo "$CMD" | grep -qE "^gh pr merge|[;&|] *gh pr merge"; then
-    _pr_num=$(echo "$CMD" | grep -oE '[0-9]+' | head -1)
+    _pr_num=$(echo "$CMD" | grep -oE 'merge +#?[0-9]+' | grep -oE '[0-9]+' | head -1)
     _repo_flag=$(echo "$CMD" | grep -oP -- '--repo \S+' || true)
-    _mergeable=""
-    if [ -n "$_pr_num" ]; then
-        _mergeable=$(gh pr view "$_pr_num" $_repo_flag --json mergeable --jq '.mergeable' 2>/dev/null)
-        if [ "$_mergeable" = "UNKNOWN" ]; then
-            echo "BLOCKED: PR #$_pr_num mergeable status is UNKNOWN." >&2
-            echo "GitHub hasn't finished conflict analysis. Wait until mergeable status is known before retrying." >&2
-            exit 2
-        fi
-        if [ "$_mergeable" = "CONFLICTING" ]; then
-            echo "BLOCKED: PR #$_pr_num has merge conflicts. Resolve before merging." >&2
-            exit 2
-        fi
+    if [ -z "$_pr_num" ]; then
+        # No number in the command — resolve the current branch's open PR
+        _pr_num=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
     fi
-    echo "⚠️  STOP: gh pr merge detected (mergeable=$_mergeable). Have you received explicit user approval for this merge?" >&2
+    if [ -z "$_pr_num" ]; then
+        echo "BLOCKED: cannot resolve which PR this merges (no number in the command, no open PR for the current branch)." >&2
+        echo "Specify the PR number: gh pr merge <N> --squash --admin" >&2
+        exit 2
+    fi
+    _mergeable=$(gh pr view "$_pr_num" $_repo_flag --json mergeable --jq '.mergeable' 2>/dev/null)
+    if [ "$_mergeable" = "UNKNOWN" ]; then
+        echo "BLOCKED: PR #$_pr_num mergeable status is UNKNOWN." >&2
+        echo "GitHub hasn't finished conflict analysis. Wait until mergeable status is known before retrying." >&2
+        exit 2
+    fi
+    if [ "$_mergeable" = "CONFLICTING" ]; then
+        echo "BLOCKED: PR #$_pr_num has merge conflicts. Resolve before merging." >&2
+        exit 2
+    fi
+    echo "⚠️  STOP: gh pr merge detected (PR #$_pr_num, mergeable=$_mergeable). Have you received explicit user approval for this merge?" >&2
     exit 0
 fi

--- a/scripts/bash_safety_hook.sh
+++ b/scripts/bash_safety_hook.sh
@@ -133,6 +133,10 @@ if echo "$CMD" | grep -qE "^gh pr merge|[;&|] *gh pr merge"; then
     # shlex tokenizer).
     _after="${CMD#*gh pr merge}"
     _after=$(printf '%s' "$_after" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+    # Stop at the first shell separator — a chained `; echo 456` must not
+    # let its digits stand in for this merge's PR (2026-07-10 review).
+    # Quotes were dropped above, so any remaining separator is real.
+    _after="${_after%%[;&|]*}"
     _pr_num=""
     for _tok in $_after; do
         case "$_tok" in

--- a/scripts/bash_safety_hook.sh
+++ b/scripts/bash_safety_hook.sh
@@ -124,7 +124,29 @@ fi
 # Fail CLOSED on an unresolvable PR: a no-arg `gh pr merge` from the PR branch
 # used to skip this check entirely (2026-07-10 P1 triage).
 if echo "$CMD" | grep -qE "^gh pr merge|[;&|] *gh pr merge"; then
-    _pr_num=$(echo "$CMD" | grep -oE 'merge +#?[0-9]+' | grep -oE '[0-9]+' | head -1)
+    # PR number can appear AFTER a flag (`gh pr merge --admin 123` is valid
+    # gh syntax), so scan all args after 'merge', skipping flags — an
+    # anchored "merge <digits>" match would miss it and silently fall back
+    # to the current branch's PR, checking/merging the WRONG one
+    # (2026-07-10 review). Drop quoted substrings first so digits inside
+    # e.g. --subject "fix 123" can't false-match (mirrors the Python hook's
+    # shlex tokenizer).
+    _after="${CMD#*gh pr merge}"
+    _after=$(printf '%s' "$_after" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+    _pr_num=""
+    for _tok in $_after; do
+        case "$_tok" in
+            -*) continue ;;                       # flag — never the PR number
+            \#[0-9]*) _tok="${_tok#\#}" ;;        # #123 → 123
+            *pull/[0-9]*)
+                _tok=$(printf '%s' "$_tok" | grep -oE 'pull/[0-9]+' \
+                    | grep -oE '[0-9]+' | head -1) ;;
+        esac
+        case "$_tok" in
+            *[!0-9]*|'') continue ;;              # not a pure integer
+            *) _pr_num="$_tok"; break ;;
+        esac
+    done
     _repo_args=()
     _repo=$(echo "$CMD" | grep -oP -- '--repo \K\S+' || true)
     [ -n "$_repo" ] && _repo_args=(--repo "$_repo")

--- a/scripts/bash_safety_hook.sh
+++ b/scripts/bash_safety_hook.sh
@@ -135,7 +135,9 @@ if echo "$CMD" | grep -qE "^gh pr merge|[;&|] *gh pr merge"; then
     _after=$(printf '%s' "$_after" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
     # Stop at the first shell separator — a chained `; echo 456` must not
     # let its digits stand in for this merge's PR (2026-07-10 review).
-    # Quotes were dropped above, so any remaining separator is real.
+    # Quotes were dropped above, so any remaining separator is real. A
+    # newline ends the command too, so cut there first.
+    _after="${_after%%$'\n'*}"
     _after="${_after%%[;&|]*}"
     _pr_num=""
     for _tok in $_after; do

--- a/scripts/hooks/destructive_command_guard.py
+++ b/scripts/hooks/destructive_command_guard.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""PreToolUse hook (Bash): block rm -rf on broad paths.
+"""PreToolUse hook (Bash): block rm with recursive+force on broad paths.
 
 Catches rm with recursive+force flags targeting shallow paths that
 could wipe important directories. A path must be at least 4 components
 deep (e.g., /home/user/project/some_dir) to pass.
 
-Blocks:  rm -rf /  |  rm -rf ~  |  rm -rf .  |  rm -rf ~/project
+Blocks:  rm -rf /  |  rm -r -f ~  |  rm --recursive --force .  |
+         rm -Rf ~/project  |  rm -rf -- /  |  rm -rf deep/path /
 Allows:  rm -rf /home/user/project/.claude/worktrees/old-branch
 
-Depth threshold is 4 components (e.g., /home/user/project/subdir).
+Parsing is token-based (shlex): flags accumulate across tokens, `--`
+ends flag parsing, and every operand is depth-checked individually —
+the 2026-07-10 P1 triage empirically confirmed the old single-token
+regex missed the `-r -f`, `--recursive --force`, `-Rf`, and `-- /`
+spellings, and folded multiple operands into one pseudo-path.
 
-Stdlib-only. Fail-open on parse errors.
+Stdlib-only. Unparseable commands fall back to the legacy regex match
+(fail-open beyond that — this guard must not block legitimate work).
 """
 
 from __future__ import annotations
@@ -18,9 +24,11 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 
-# Matches rm with any combination of -r and -f flags
+# Legacy single-token pattern — kept as the fallback when shlex cannot
+# tokenize the command (unmatched quotes etc.).
 _RM_RF_PATTERN = re.compile(
     r"\brm\s+"
     r"(?:-[a-zA-Z]*r[a-zA-Z]*f[a-zA-Z]*|-[a-zA-Z]*f[a-zA-Z]*r[a-zA-Z]*)"
@@ -28,31 +36,79 @@ _RM_RF_PATTERN = re.compile(
 )
 
 # Dangerous special targets — always block regardless of depth
-_ALWAYS_BLOCK = {".", "..", "/"}
+_ALWAYS_BLOCK = {".", "..", "/", "~", "*"}
+
+# Command separators that start a new simple command within one Bash
+# string. Tokens matching these end an rm invocation's argument list.
+_SEPARATORS = {"|", "||", "&&", ";", "&", "\n"}
 
 
 def _path_depth(path: str) -> int:
     """Count meaningful path components after expansion."""
     expanded = os.path.expanduser(path)
     expanded = os.path.normpath(expanded)
-    # Count non-empty components
     parts = [p for p in expanded.split("/") if p]
     return len(parts)
 
 
-def _extract_rm_targets(cmd: str) -> list[str]:
-    """Extract target paths from rm -rf commands."""
-    targets: list[str] = []
-    # Find all rm -rf occurrences and grab the paths after flags
-    for match in _RM_RF_PATTERN.finditer(cmd):
-        rest = cmd[match.end():]
-        # Grab paths until a command separator
-        for token in re.split(r"[|;&]|\s+\d*[<>]", rest):
-            token = token.strip()
-            if not token or token.startswith("-"):
-                break
-            targets.append(token)
-    return targets
+def _check_target(target: str) -> str | None:
+    """Reason string if *target* is too broad to rm recursively."""
+    clean = target.strip("'\"")
+    if clean in _ALWAYS_BLOCK:
+        return f"rm -rf on '{clean}' is not allowed."
+    depth = _path_depth(clean)
+    if depth < 4:
+        return f"rm -rf on '{clean}' (depth {depth}) is too broad."
+    return None
+
+
+def _rm_violations(cmd: str) -> list[str] | None:
+    """Reasons to block, or None when the command cannot be tokenized."""
+    # Make separators standalone tokens so `rm -rf x; other` parses.
+    spaced = re.sub(r"(\|\||&&|[|;&\n])", r" \1 ", cmd)
+    try:
+        tokens = shlex.split(spaced)
+    except ValueError:
+        return None  # unparseable — caller falls back to the legacy regex
+
+    violations: list[str] = []
+    i = 0
+    while i < len(tokens):
+        if os.path.basename(tokens[i]) != "rm":
+            i += 1
+            continue
+
+        # Parse this rm invocation until the next command separator.
+        recursive = force = False
+        operands: list[str] = []
+        flags_done = False
+        i += 1
+        while i < len(tokens) and tokens[i] not in _SEPARATORS:
+            arg = tokens[i]
+            i += 1
+            if not flags_done and arg == "--":
+                flags_done = True
+                continue
+            if not flags_done and arg.startswith("--"):
+                if arg == "--recursive":
+                    recursive = True
+                elif arg == "--force":
+                    force = True
+                continue  # other long flags carry no target
+            if not flags_done and arg.startswith("-") and len(arg) > 1:
+                if any(c in "rR" for c in arg[1:]):
+                    recursive = True
+                if "f" in arg[1:]:
+                    force = True
+                continue
+            operands.append(arg)
+
+        if recursive and force:
+            for operand in operands:
+                reason = _check_target(operand)
+                if reason:
+                    violations.append(reason)
+    return violations
 
 
 def main() -> int:
@@ -63,37 +119,29 @@ def main() -> int:
 
         data = json.loads(raw)
         cmd = data.get("command", "")
-        if not cmd:
+        if not cmd or "rm" not in cmd:
             return 0
 
-        if not _RM_RF_PATTERN.search(cmd):
-            return 0
+        violations = _rm_violations(cmd)
+        if violations is None:
+            # Tokenizer failed — the legacy regex still catches the
+            # common spelling; beyond that we fail open by design.
+            if not _RM_RF_PATTERN.search(cmd):
+                return 0
+            violations = [
+                "recursive+force rm inside an unparseable command — "
+                "blocked conservatively."
+            ]
 
-        targets = _extract_rm_targets(cmd)
-        for target in targets:
-            clean = target.strip("'\"")
-
-            # Always block special targets
-            if clean in _ALWAYS_BLOCK:
-                print(
-                    f"BLOCKED: rm -rf on '{clean}' is not allowed.",
-                    file=sys.stderr,
-                )
-                return 2
-
-            # Block shallow paths (fewer than 3 components)
-            depth = _path_depth(clean)
-            if depth < 4:
-                print(
-                    f"BLOCKED: rm -rf on '{clean}' (depth {depth}) is too broad.",
-                    file=sys.stderr,
-                )
-                print(
-                    "Target must be at least 4 levels deep. "
-                    "If intentional, ask the user to confirm.",
-                    file=sys.stderr,
-                )
-                return 2
+        if violations:
+            for reason in violations:
+                print(f"BLOCKED: {reason}", file=sys.stderr)
+            print(
+                "Recursive+force rm targets must be at least 4 levels deep. "
+                "If intentional, ask the user to confirm.",
+                file=sys.stderr,
+            )
+            return 2
 
     except (json.JSONDecodeError, KeyError):
         pass  # Fail-open

--- a/scripts/hooks/destructive_command_guard.py
+++ b/scripts/hooks/destructive_command_guard.py
@@ -43,22 +43,24 @@ _ALWAYS_BLOCK = {".", "..", "/", "~", "*"}
 _SEPARATORS = {"|", "||", "&&", ";", "&", "\n"}
 
 
-def _path_depth(path: str) -> int:
-    """Count meaningful path components after expansion."""
-    expanded = os.path.expanduser(path)
-    expanded = os.path.normpath(expanded)
-    parts = [p for p in expanded.split("/") if p]
-    return len(parts)
-
-
 def _check_target(target: str) -> str | None:
     """Reason string if *target* is too broad to rm recursively."""
     clean = target.strip("'\"")
     if clean in _ALWAYS_BLOCK:
         return f"rm -rf on '{clean}' is not allowed."
-    depth = _path_depth(clean)
-    if depth < 4:
-        return f"rm -rf on '{clean}' (depth {depth}) is too broad."
+    expanded = os.path.normpath(os.path.expanduser(clean))
+    parts = [p for p in expanded.split("/") if p]
+    # A surviving '..' means the path traverses upward from a base the
+    # hook cannot know (its cwd need not match the Bash invocation's).
+    # normpath collapses interior '..' only against an absolute/~-anchored
+    # path; a leading '..' on a RELATIVE path survives and is counted as
+    # depth — so `rm -rf ../../../etc` reports depth 4 yet resolves to
+    # /etc from filesystem root. Refuse rather than guess. (2026-07-10
+    # review: this was a live bypass.)
+    if ".." in parts:
+        return f"rm -rf on '{clean}' traverses upward ('..') — refusing."
+    if len(parts) < 4:
+        return f"rm -rf on '{clean}' (depth {len(parts)}) is too broad."
     return None
 
 
@@ -90,9 +92,14 @@ def _rm_violations(cmd: str) -> list[str] | None:
                 flags_done = True
                 continue
             if not flags_done and arg.startswith("--"):
-                if arg == "--recursive":
+                # GNU getopt_long accepts unambiguous prefix abbreviations,
+                # so `--rec`/`--f` are valid spellings of --recursive/
+                # --force. Match by prefix (len>=3 skips the bare '--').
+                # Over-matching only over-blocks, which is safe here.
+                # (2026-07-10 review: `rm --rec --f /` was a live bypass.)
+                if len(arg) >= 3 and "--recursive".startswith(arg):
                     recursive = True
-                elif arg == "--force":
+                elif len(arg) >= 3 and "--force".startswith(arg):
                     force = True
                 continue  # other long flags carry no target
             if not flags_done and arg.startswith("-") and len(arg) > 1:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -81,10 +81,14 @@ def _extract_pr_number(cmd: str) -> str | None:
     match = re.search(r"\bgh pr merge\b(.*)$", cmd, re.DOTALL)
     if not match:
         return None
+    # A newline ends the command too, but shlex collapses it to plain
+    # whitespace (so a `\n echo 456` chain would leak its digits) — cut
+    # the tail at the first newline before tokenizing.
+    tail = match.group(1).split("\n", 1)[0]
     # Pre-space shell separators into standalone tokens (shlex keeps them
     # attached, e.g. '123;'). Quotes still protect a separator inside an
     # arg value — shlex parses the quoted region as one token afterwards.
-    spaced = re.sub(r"(\|\||&&|[|;&])", r" \1 ", match.group(1))
+    spaced = re.sub(r"(\|\||&&|[|;&])", r" \1 ", tail)
     try:
         # shlex keeps quoted args whole so digits inside a --subject
         # string are never mistaken for the PR number.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -81,13 +81,23 @@ def _extract_pr_number(cmd: str) -> str | None:
     match = re.search(r"\bgh pr merge\b(.*)$", cmd, re.DOTALL)
     if not match:
         return None
+    # Pre-space shell separators into standalone tokens (shlex keeps them
+    # attached, e.g. '123;'). Quotes still protect a separator inside an
+    # arg value — shlex parses the quoted region as one token afterwards.
+    spaced = re.sub(r"(\|\||&&|[|;&])", r" \1 ", match.group(1))
     try:
         # shlex keeps quoted args whole so digits inside a --subject
         # string are never mistaken for the PR number.
-        tokens = shlex.split(match.group(1))
+        tokens = shlex.split(spaced)
     except ValueError:
-        tokens = match.group(1).split()
+        tokens = spaced.split()
     for tok in tokens:
+        # Stop at the end of THIS command — tokens after a separator
+        # belong to a chained command, and their digits must not be read
+        # as this merge's target (`gh pr merge 123; echo 456` merges 123
+        # but this loop would otherwise return 456). 2026-07-10 review.
+        if tok in {";", "&", "|", "&&", "||"}:
+            break
         if tok.isdigit():
             return tok
         if tok.startswith("#") and tok[1:].isdigit():

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -76,9 +77,50 @@ def _get_push_remote_and_branch(cmd: str) -> tuple[str | None, str | None]:
 
 
 def _extract_pr_number(cmd: str) -> str | None:
-    """Extract PR number from a gh pr merge command."""
-    match = re.search(r"gh pr merge\s+(\d+)", cmd)
-    return match.group(1) if match else None
+    """PR number from a gh pr merge command (bare number, #N, or URL)."""
+    match = re.search(r"\bgh pr merge\b(.*)$", cmd, re.DOTALL)
+    if not match:
+        return None
+    try:
+        # shlex keeps quoted args whole so digits inside a --subject
+        # string are never mistaken for the PR number.
+        tokens = shlex.split(match.group(1))
+    except ValueError:
+        tokens = match.group(1).split()
+    for tok in tokens:
+        if tok.isdigit():
+            return tok
+        if tok.startswith("#") and tok[1:].isdigit():
+            return tok[1:]
+        url = re.match(r"\S*/pull/(\d+)\b", tok)
+        if url:
+            return url.group(1)
+    return None
+
+
+def _resolve_pr_number(cmd: str) -> str | None:
+    """Command PR number, else the current branch's open PR.
+
+    No-arg `gh pr merge` from a PR branch is valid gh usage, but it
+    used to skip EVERY merge gate here (the gates only ran under
+    `if pr_num:`) — the 2026-07-10 audit points at this as a mechanism
+    behind findings-ignored merges. Resolution failure is the caller's
+    signal to fail CLOSED for merge commands.
+    """
+    pr_num = _extract_pr_number(cmd)
+    if pr_num:
+        return pr_num
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number", "--jq", ".number"],
+            capture_output=True, text=True, timeout=10,
+        )
+        resolved = result.stdout.strip()
+        if result.returncode == 0 and resolved.isdigit():
+            return resolved
+    except Exception:
+        pass
+    return None
 
 
 def _check_mergeable(pr_num: str) -> str | None:
@@ -364,8 +406,22 @@ def main() -> int:
                 )
                 return 2
 
-            # Check mergeable status before allowing merge
-            pr_num = _extract_pr_number(cmd)
+            # Check mergeable status before allowing merge. Merge is
+            # the one command that fails CLOSED: if we can't tell which
+            # PR this is, we can't run the gates, so we don't merge.
+            pr_num = _resolve_pr_number(cmd)
+            if pr_num is None:
+                print(
+                    "BLOCKED: cannot resolve which PR this merges "
+                    "(no number in the command and no open PR for the "
+                    "current branch).",
+                    file=sys.stderr,
+                )
+                print(
+                    "Specify the PR number: gh pr merge <N> --squash --admin",
+                    file=sys.stderr,
+                )
+                return 2
             if pr_num:
                 mergeable = _check_mergeable(pr_num)
                 if mergeable == "UNKNOWN":

--- a/scripts/lib/load_secrets.sh
+++ b/scripts/lib/load_secrets.sh
@@ -1,0 +1,63 @@
+# shellcheck shell=bash
+# Genesis — dotenv-safe secrets loader. Sourced, not executed.
+#
+# load_secrets_file <path> — export KEY=VALUE pairs from a secrets file
+# WITHOUT shell-evaluating it. `set -a; source secrets.env` executes the
+# file: a value containing $(...) or backticks RUNS that code with the
+# caller's privileges. This reader treats the file strictly as data
+# (2026-07-10 safety-gate remediation).
+#
+# Line grammar (kept in step with the escrow reader in
+# src/genesis/guardian/credential_bridge.py::_read_dotenv):
+#   - blank lines and full-line '#' comments are skipped
+#   - an optional leading "export " is accepted
+#   - KEY must match [A-Za-z_][A-Za-z0-9_]* — other lines are skipped
+#   - value = everything after the first '='
+#   - a value fully wrapped in matching single or double quotes is
+#     unwrapped one layer, contents verbatim (no escape processing)
+#   - unquoted values drop a trailing inline comment (whitespace + '#'
+#     onward) and trailing whitespace — matching what `source` yielded
+#     for such lines, so the switch is behavior-identical
+# Values are exported LITERALLY — never expanded, never executed.
+
+load_secrets_file() {
+    local file="$1" line key value
+    [ -f "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Trim surrounding whitespace.
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        case "$line" in
+            '' | '#'*) continue ;;
+        esac
+        case "$line" in
+            'export '*) line="${line#export }" ;;
+        esac
+        case "$line" in
+            *=*) ;;
+            *) continue ;;
+        esac
+        key="${line%%=*}"
+        value="${line#*=}"
+        case "$key" in
+            '' | [0-9]* | *[!A-Za-z0-9_]*) continue ;;
+        esac
+        case "$value" in
+            \"*\")
+                value="${value#\"}"
+                value="${value%\"}"
+                ;;
+            \'*\')
+                value="${value#\'}"
+                value="${value%\'}"
+                ;;
+            *)
+                # sed keeps leftmost-match semantics: 'x #a #b' → 'x',
+                # exactly what shell comment parsing gave under source.
+                value="$(printf '%s' "$value" \
+                    | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//')"
+                ;;
+        esac
+        export "$key=$value"
+    done < "$file"
+}

--- a/scripts/lib/load_secrets.sh
+++ b/scripts/lib/load_secrets.sh
@@ -13,8 +13,10 @@
 #   - an optional leading "export " is accepted
 #   - KEY must match [A-Za-z_][A-Za-z0-9_]* — other lines are skipped
 #   - value = everything after the first '='
-#   - a value fully wrapped in matching single or double quotes is
-#     unwrapped one layer, contents verbatim (no escape processing)
+#   - a value that STARTS with a single or double quote is the content up
+#     to the matching closing quote; anything after it (e.g. an inline
+#     comment) is discarded — matches `source` and the Python
+#     _read_dotenv reader (contents verbatim, no escape processing)
 #   - unquoted values drop a trailing inline comment (whitespace + '#'
 #     onward) and trailing whitespace — matching what `source` yielded
 #     for such lines, so the switch is behavior-identical
@@ -43,13 +45,19 @@ load_secrets_file() {
             '' | [0-9]* | *[!A-Za-z0-9_]*) continue ;;
         esac
         case "$value" in
-            \"*\")
+            \"*)
+                # Value is up to the FIRST closing quote; drop everything
+                # after it (a trailing inline comment). `%%\"*` removes the
+                # longest suffix starting at the leftmost '"', leaving the
+                # quoted content. Without this, `KEY="a b" # c` kept the
+                # quotes and diverged from source → wrong backup passphrase
+                # (2026-07-10 review).
                 value="${value#\"}"
-                value="${value%\"}"
+                value="${value%%\"*}"
                 ;;
-            \'*\')
+            \'*)
                 value="${value#\'}"
-                value="${value%\'}"
+                value="${value%%\'*}"
                 ;;
             *)
                 # sed keeps leftmost-match semantics: 'x #a #b' → 'x',

--- a/src/genesis/db/migrations/0053_table_inbox_watch_markers.py
+++ b/src/genesis/db/migrations/0053_table_inbox_watch_markers.py
@@ -31,7 +31,7 @@ _WHERE = (
 
 async def up(db: aiosqlite.Connection) -> None:
     await db.execute(
-        f"UPDATE follow_ups SET kind = 'tabled' "
+        f"UPDATE follow_ups SET kind = 'tabled' "  # noqa: S608 - _WHERE is a module constant, no user input
         f"WHERE {_WHERE} AND kind = 'follow_up'"
     )
 

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -59,12 +59,13 @@ _KEY_MAP_PROVISIONING = {
 # circle: a rebuilt/fresh container can decrypt the backup from the host copy.
 # The passphrase is as sensitive as everything it decrypts; the escrow file is
 # 0600 on the host mount (same trust level as the telegram/proxmox tokens here).
-# NOTE: backup.sh obtains the passphrase by `source`-ing secrets.env (full shell
-# parsing) while this escrow reads it via _read_dotenv (strip one quote layer).
-# For a passphrase containing unescaped shell metacharacters (``$``, backticks,
-# backslashes, unbalanced quotes) the two can diverge, so the escrowed value
-# would not match what encrypted the backup. The generated passphrase is a plain
-# token; keep any hand-set one shell-safe (alphanumeric / base64) to stay sound.
+# NOTE: backup.sh reads secrets.env via scripts/lib/load_secrets.sh (dotenv-safe
+# line parser, no shell evaluation) while this escrow reads it via _read_dotenv.
+# Both strip one quote layer; they can still diverge on exotic values (embedded
+# newlines are impossible in a single line; unbalanced quotes differ), in which
+# case the escrowed value would not match what encrypted the backup. The
+# generated passphrase is a plain token; keep any hand-set one shell-safe
+# (alphanumeric / base64) to stay sound.
 _PASSPHRASE_FILENAME = "backup_passphrase.env"
 _KEY_MAP_PASSPHRASE = {
     "GENESIS_BACKUP_PASSPHRASE": "GENESIS_BACKUP_PASSPHRASE",

--- a/tests/test_hooks/test_inline_hooks.py
+++ b/tests/test_hooks/test_inline_hooks.py
@@ -290,6 +290,68 @@ class TestBashHookRmRf:
         result = run_hook(rm_rf_hook_command, {"command": "rm foo.txt"})
         assert result.returncode == 0
 
+    # -- Token-parse regressions: the 4 bypasses confirmed live by the
+    # -- 2026-07-10 P1 triage (single-token regex missed all of these),
+    # -- plus multi-operand and separator handling.
+
+    def test_rm_split_flags_blocked(self, rm_rf_hook_command: str) -> None:
+        """rm -r -f / -> BLOCKED (flags accumulate across tokens)."""
+        result = run_hook(rm_rf_hook_command, {"command": "rm -r -f /"})
+        assert result.returncode == 2
+
+    def test_rm_long_flags_blocked(self, rm_rf_hook_command: str) -> None:
+        """rm --recursive --force . -> BLOCKED."""
+        result = run_hook(
+            rm_rf_hook_command, {"command": "rm --recursive --force ."}
+        )
+        assert result.returncode == 2
+
+    def test_rm_capital_r_blocked(self, rm_rf_hook_command: str) -> None:
+        """rm -Rf ~ -> BLOCKED (-R is recursive too)."""
+        result = run_hook(rm_rf_hook_command, {"command": "rm -Rf ~"})
+        assert result.returncode == 2
+
+    def test_rm_double_dash_blocked(self, rm_rf_hook_command: str) -> None:
+        """rm -rf -- / -> BLOCKED ('--' ends flags, operands still checked)."""
+        result = run_hook(rm_rf_hook_command, {"command": "rm -rf -- /"})
+        assert result.returncode == 2
+
+    def test_rm_broad_second_operand_blocked(
+        self, rm_rf_hook_command: str
+    ) -> None:
+        """rm -rf deep/ok/nested/path / -> BLOCKED (each operand checked)."""
+        result = run_hook(
+            rm_rf_hook_command,
+            {"command": "rm -rf ./some/specific/deep/path /"},
+        )
+        assert result.returncode == 2
+
+    def test_rm_after_separator_blocked(self, rm_rf_hook_command: str) -> None:
+        """echo ok && rm -r -f ~ -> BLOCKED (rm found past separators)."""
+        result = run_hook(
+            rm_rf_hook_command, {"command": "echo ok && rm -r -f ~"}
+        )
+        assert result.returncode == 2
+
+    def test_rm_unparseable_falls_back_to_regex(
+        self, rm_rf_hook_command: str
+    ) -> None:
+        """Unclosed quote (shlex fails) + classic spelling -> legacy block."""
+        result = run_hook(
+            rm_rf_hook_command, {"command": "rm -rf / 'unclosed"}
+        )
+        assert result.returncode == 2
+
+    def test_rm_split_flags_deep_path_allowed(
+        self, rm_rf_hook_command: str
+    ) -> None:
+        """rm -r -f on a 4+-deep path -> allowed (parity with -rf)."""
+        result = run_hook(
+            rm_rf_hook_command,
+            {"command": "rm -r -f ./some/specific/deep/path"},
+        )
+        assert result.returncode == 0
+
 
 # ---------------------------------------------------------------------------
 # Bash hook: git push --force / -f

--- a/tests/test_hooks/test_inline_hooks.py
+++ b/tests/test_hooks/test_inline_hooks.py
@@ -352,6 +352,47 @@ class TestBashHookRmRf:
         )
         assert result.returncode == 0
 
+    # -- 2026-07-10 review findings: leading-'..' traversal + abbreviated
+    # -- GNU long flags were both live bypasses.
+
+    @pytest.mark.parametrize("target", [
+        "../../../etc",
+        "../../../../../../../../etc",  # bottoms out at /etc from root
+        "../foo/bar/baz/qux",           # depth 4 textually, still traverses up
+        "a/b/../../../../etc",          # interior '..' escapes past the base
+    ])
+    def test_rm_rf_upward_traversal_blocked(
+        self, rm_rf_hook_command: str, target: str
+    ) -> None:
+        """rm -rf on any path whose normalized form keeps a '..' -> BLOCKED.
+
+        A relative '..' cannot be depth-bounded without the real cwd, so
+        the guard refuses (`../../../etc` used to report depth 4 and pass
+        while resolving to /etc)."""
+        result = run_hook(
+            rm_rf_hook_command, {"command": f"rm -rf {target}"}
+        )
+        assert result.returncode == 2
+
+    def test_rm_rf_abbrev_long_flags_blocked(
+        self, rm_rf_hook_command: str
+    ) -> None:
+        """rm --rec --f / -> BLOCKED (GNU unambiguous prefix abbreviations)."""
+        result = run_hook(
+            rm_rf_hook_command, {"command": "rm --rec --f /"}
+        )
+        assert result.returncode == 2
+
+    def test_rm_non_destructive_long_flags_allowed(
+        self, rm_rf_hook_command: str
+    ) -> None:
+        """--dir/--verbose are not recursive+force -> deep path allowed."""
+        result = run_hook(
+            rm_rf_hook_command,
+            {"command": "rm --dir --verbose /a/b/c/d/e"},
+        )
+        assert result.returncode == 0
+
 
 # ---------------------------------------------------------------------------
 # Bash hook: git push --force / -f

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -446,6 +446,8 @@ class TestResolvePrNumber:
             ("gh pr merge 123 && echo 999", "123"),
             ("gh pr merge --admin xyz; echo 456", None),  # no number → fall back
             ("gh pr merge 5 | tee 777", "5"),
+            ("gh pr merge --admin xyz\necho 456", None),  # newline chain
+            ("gh pr merge 123\necho 456", "123"),
         ],
     )
     def test_stops_at_shell_separator(self, guard_module, cmd, expected):

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -437,6 +437,20 @@ class TestResolvePrNumber:
     def test_extract_variants(self, guard_module, cmd, expected):
         assert guard_module._extract_pr_number(cmd) == expected
 
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            # Digits in a CHAINED command must not stand in for the target
+            # (`; echo 456` merges 123, not 456). 2026-07-10 review P1.
+            ("gh pr merge --admin 123; echo 456", "123"),
+            ("gh pr merge 123 && echo 999", "123"),
+            ("gh pr merge --admin xyz; echo 456", None),  # no number → fall back
+            ("gh pr merge 5 | tee 777", "5"),
+        ],
+    )
+    def test_stops_at_shell_separator(self, guard_module, cmd, expected):
+        assert guard_module._extract_pr_number(cmd) == expected
+
     def test_quoted_digits_not_a_pr_number(self, guard_module):
         # shlex keeps the quoted arg whole — '123' inside --subject must
         # not resolve as the PR number.

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -419,3 +419,44 @@ class TestCheckInlineReviewFindings:
             block, _ = guard_module._check_inline_review_findings("100")
         # type=User AND not in the inline bot set → not an automated finding
         assert block is False
+
+
+class TestResolvePrNumber:
+    """Fail-closed PR resolution: no-arg `gh pr merge` used to skip
+    every merge gate (the gates only ran under `if pr_num:`)."""
+
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            ("gh pr merge 123 --squash", "123"),
+            ("gh pr merge #77 --admin", "77"),
+            ("gh pr merge https://github.com/o/r/pull/456 --squash", "456"),
+            ('gh pr merge --subject "fix 123 things" 55', "55"),
+        ],
+    )
+    def test_extract_variants(self, guard_module, cmd, expected):
+        assert guard_module._extract_pr_number(cmd) == expected
+
+    def test_quoted_digits_not_a_pr_number(self, guard_module):
+        # shlex keeps the quoted arg whole — '123' inside --subject must
+        # not resolve as the PR number.
+        cmd = 'gh pr merge --subject "fix 123"'
+        assert guard_module._extract_pr_number(cmd) is None
+
+    def test_resolves_current_branch_pr(self, guard_module):
+        with patch.object(
+            guard_module.subprocess, "run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="88\n", stderr="",
+            ),
+        ):
+            assert guard_module._resolve_pr_number("gh pr merge --squash") == "88"
+
+    def test_unresolvable_returns_none(self, guard_module):
+        with patch.object(
+            guard_module.subprocess, "run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="no pr",
+            ),
+        ):
+            assert guard_module._resolve_pr_number("gh pr merge --squash") is None

--- a/tests/test_scripts/test_bash_safety_hook.py
+++ b/tests/test_scripts/test_bash_safety_hook.py
@@ -215,3 +215,43 @@ def test_merge_numbered_conflicting_blocks(tmp_path):
     result = _run("gh pr merge 123 --squash", env_extra=env)
     assert result.returncode == 2
     assert "merge conflicts" in result.stderr
+
+
+# --- gh pr merge: PR number after a FLAG must resolve correctly ---
+# (2026-07-10 review: an anchored "merge <digits>" match missed
+#  `gh pr merge --admin 123` and fell back to the WRONG branch PR.)
+
+@pytest.mark.parametrize("cmd", [
+    "gh pr merge --admin 123",
+    "gh pr merge 123 --admin",
+    "gh pr merge --squash 123 --admin",
+    "gh pr merge https://github.com/o/r/pull/123 --squash",
+])
+def test_merge_number_after_flag_resolves_correctly(tmp_path, cmd):
+    """The PR named in the command is checked, regardless of flag order.
+
+    The gh stub returns branch-PR #55; a correct parse must report #123,
+    not #55.
+    """
+    env = _gh_stub(
+        tmp_path,
+        'case "$*" in *"--json number"*) echo 55;; '
+        '*"--json mergeable"*) echo MERGEABLE;; esac',
+    )
+    result = _run(cmd, env_extra=env)
+    assert "PR #123" in result.stderr
+    assert "PR #55" not in result.stderr
+
+
+def test_merge_digits_in_quoted_subject_not_a_pr(tmp_path):
+    """Digits inside a quoted --subject must not be taken as the PR."""
+    env = _gh_stub(
+        tmp_path,
+        'case "$*" in *"--json number"*) echo 77;; '
+        '*"--json mergeable"*) echo MERGEABLE;; esac',
+    )
+    # Only digits present are inside the quoted subject -> fall back to
+    # the branch PR (#77), never "999".
+    result = _run('gh pr merge --subject "merge 999 now"', env_extra=env)
+    assert "PR #77" in result.stderr
+    assert "999" not in result.stderr

--- a/tests/test_scripts/test_bash_safety_hook.py
+++ b/tests/test_scripts/test_bash_safety_hook.py
@@ -255,3 +255,15 @@ def test_merge_digits_in_quoted_subject_not_a_pr(tmp_path):
     result = _run('gh pr merge --subject "merge 999 now"', env_extra=env)
     assert "PR #77" in result.stderr
     assert "999" not in result.stderr
+
+
+def test_merge_chained_command_digits_ignored(tmp_path):
+    """`gh pr merge 123; echo 456` must check PR #123, not #456 (a chained
+    command's digits are not this merge's target). 2026-07-10 review."""
+    env = _gh_stub(
+        tmp_path,
+        'case "$*" in *"--json mergeable"*) echo MERGEABLE;; esac',
+    )
+    result = _run("gh pr merge 123 --admin; echo 456", env_extra=env)
+    assert "PR #123" in result.stderr
+    assert "456" not in result.stderr

--- a/tests/test_scripts/test_bash_safety_hook.py
+++ b/tests/test_scripts/test_bash_safety_hook.py
@@ -175,3 +175,43 @@ def test_worktree_serve_blocked(cmd, tmp_path):
 def test_non_worktree_serve_paths_allowed(cmd, tmp_path):
     """Server management and plain serve (outside a worktree) pass this guard."""
     assert _run_cwd(cmd, tmp_path).returncode == 0
+
+
+# --- gh pr merge: PR resolution fails CLOSED (2026-07-10 P1 triage) ---
+
+def _gh_stub(tmp_path: Path, script: str) -> dict[str, str]:
+    """Put a fake `gh` first on PATH so no test touches the network."""
+    stub = tmp_path / "gh"
+    stub.write_text(f"#!/usr/bin/env bash\n{script}\n")
+    stub.chmod(0o755)
+    return {"PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+
+def test_merge_no_arg_unresolvable_blocks(tmp_path):
+    """No number in the command AND no open PR for the branch -> exit 2."""
+    env = _gh_stub(tmp_path, "exit 1")
+    result = _run("gh pr merge --squash --admin", env_extra=env)
+    assert result.returncode == 2
+    assert "cannot resolve" in result.stderr
+
+
+def test_merge_no_arg_resolves_branch_pr(tmp_path):
+    """No number, but the branch has an open PR -> gates run against it."""
+    env = _gh_stub(
+        tmp_path,
+        'case "$*" in *"--json number"*) echo 42;; '
+        '*"--json mergeable"*) echo MERGEABLE;; esac',
+    )
+    result = _run("gh pr merge --squash", env_extra=env)
+    assert result.returncode == 0
+    assert "PR #42" in result.stderr
+
+
+def test_merge_numbered_conflicting_blocks(tmp_path):
+    env = _gh_stub(
+        tmp_path,
+        'case "$*" in *"--json mergeable"*) echo CONFLICTING;; esac',
+    )
+    result = _run("gh pr merge 123 --squash", env_extra=env)
+    assert result.returncode == 2
+    assert "merge conflicts" in result.stderr

--- a/tests/test_scripts/test_load_secrets.py
+++ b/tests/test_scripts/test_load_secrets.py
@@ -94,6 +94,18 @@ class TestLoadSecrets:
         assert sourced.returncode == 0, sourced.stderr
         assert loader_vals == sourced.stdout.split("\0")[:-1]
 
+    def test_quoted_value_with_inline_comment(self, tmp_path):
+        """`KEY="a b" # c` -> `a b` (quotes AND comment stripped), matching
+        `source`. Leaving the quotes would corrupt the backup passphrase
+        (2026-07-10 review P2)."""
+        content = (
+            'PP="abc def" # backup\n'
+            "SQ='x y' # note\n"
+            'DQEMBED="a#b" # c\n'
+        )
+        vals = _load_and_dump(tmp_path, content, ["PP", "SQ", "DQEMBED"])
+        assert vals == ["abc def", "x y", "a#b"]
+
     def test_missing_file_is_noop(self, tmp_path):
         proc = subprocess.run(
             ["bash", "-c",

--- a/tests/test_scripts/test_load_secrets.py
+++ b/tests/test_scripts/test_load_secrets.py
@@ -1,0 +1,105 @@
+"""Tests for scripts/lib/load_secrets.sh — reads secrets as DATA.
+
+The loader replaced `set -a; source secrets.env` in backup.sh
+(2026-07-10 safety-gate remediation): sourcing executes the file, so a
+value containing $(...) runs code. The loader must (1) never evaluate,
+and (2) stay behavior-identical to `source` for every value shape the
+file legitimately holds.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+LIB = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "load_secrets.sh"
+
+_FIXTURE = """\
+# full-line comment
+PLAIN=abc
+EMPTY=
+
+DQ="a b"
+SQ='c d'
+TRAIL=xval  # trailing comment
+HASH=a#b
+export EXPORTED=ok
+1BAD=nope
+BAD-KEY=nope
+   INDENTED=fine
+"""
+
+
+def _load_and_dump(tmp_path: Path, content: str, keys: list[str]) -> list[str]:
+    """Run the loader on a fixture file, return values NUL-separated."""
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text(content)
+    dump = " ".join(f'printf "%s\\0" "${{{k}}}";' for k in keys)
+    proc = subprocess.run(
+        ["bash", "-c", f'source "{LIB}"; load_secrets_file "{secrets}"; {dump}'],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.split("\0")[:-1]
+
+
+class TestLoadSecrets:
+    def test_value_shapes_match_source_semantics(self, tmp_path):
+        values = _load_and_dump(
+            tmp_path, _FIXTURE,
+            ["PLAIN", "EMPTY", "DQ", "SQ", "TRAIL", "HASH",
+             "EXPORTED", "INDENTED"],
+        )
+        assert values == [
+            "abc", "", "a b", "c d", "xval", "a#b", "ok", "fine",
+        ]
+
+    def test_invalid_keys_skipped(self, tmp_path):
+        secrets = tmp_path / "secrets.env"
+        secrets.write_text(_FIXTURE)
+        proc = subprocess.run(
+            ["bash", "-c",
+             f'source "{LIB}"; load_secrets_file "{secrets}"; env'],
+            capture_output=True, text=True, cwd=tmp_path,
+        )
+        assert "nope" not in proc.stdout
+
+    def test_never_executes_values(self, tmp_path):
+        evil = (
+            "EVIL=$(touch pwned-subst)\n"
+            "EVIL2=`touch pwned-backtick`\n"
+            "EVIL3=x; touch pwned-chain\n"
+        )
+        values = _load_and_dump(tmp_path, evil, ["EVIL", "EVIL2", "EVIL3"])
+        # Values are the LITERAL text — nothing ran.
+        assert values == [
+            "$(touch pwned-subst)", "`touch pwned-backtick`",
+            "x; touch pwned-chain",
+        ]
+        assert not list(tmp_path.glob("pwned*"))
+
+    def test_equivalent_to_source_for_shell_safe_file(self, tmp_path):
+        """For the shapes secrets.env legitimately holds, the loader and
+        `source` must export IDENTICAL values (regression: silent value
+        drift would corrupt the backup passphrase)."""
+        keys = ["PLAIN", "EMPTY", "DQ", "SQ", "TRAIL", "HASH",
+                "EXPORTED", "INDENTED"]
+        loader_vals = _load_and_dump(tmp_path, _FIXTURE, keys)
+        secrets = tmp_path / "secrets.env"
+        dump = " ".join(f'printf "%s\\0" "${{{k}}}";' for k in keys)
+        sourced = subprocess.run(
+            ["bash", "-c", f'set -a; source "{secrets}"; set +a; {dump}'],
+            capture_output=True, text=True, cwd=tmp_path,
+        )
+        assert sourced.returncode == 0, sourced.stderr
+        assert loader_vals == sourced.stdout.split("\0")[:-1]
+
+    def test_missing_file_is_noop(self, tmp_path):
+        proc = subprocess.run(
+            ["bash", "-c",
+             f'source "{LIB}"; load_secrets_file "{tmp_path}/absent.env"; '
+             f'echo alive'],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode == 0
+        assert "alive" in proc.stdout


### PR DESCRIPTION
## What & why

Tier-1 of the safety-gate remediation from the 2026-07-10 audit. Four gates were empirically bypassable or missing; this closes all four. Each fix has regression tests reproducing the exact bypass.

### 1. `rm` guard — token-based rewrite (`destructive_command_guard.py`)
The old single-token regex missed real destructive spellings. Now shlex-tokenized: recursive/force flags accumulate across tokens (`-r -f`, `-Rf`, `--recursive --force`), `--` ends flag parsing, and every operand is depth-checked. Closes, with tests:
- `rm -r -f /`, `rm -Rf ~`, `rm --recursive --force .` (split/bundled/long flags)
- `rm -rf ../../../etc` — a leading `..` on a relative path used to inflate the depth count and pass; any surviving `..` is now refused (cwd-independent).
- `rm --rec --f /` — GNU unambiguous long-flag abbreviations are now prefix-matched.
- `rm -rf -- /`, multi-operand, and rm found past `;`/`&&`.

Legacy regex kept as a fallback when a command can't be tokenized.

### 2. Fail-closed merge-PR resolution (`git_push_guard.py` + `bash_safety_hook.sh`)
A no-arg `gh pr merge` from a PR branch previously skipped every merge gate. Both hooks now resolve the PR (bare `N` / `#N` / pull URL, else `gh pr view`) and **block** when it can't be resolved. The bash hook also now scans all post-`merge` tokens so `gh pr merge --admin 123` checks PR #123, not the current branch's PR (quoted substrings dropped so a `--subject` digit can't false-match).

### 3. Dotenv-safe secrets loader (`scripts/lib/load_secrets.sh`, `backup.sh`)
`backup.sh` no longer `source`s `secrets.env` — a value containing `$(...)` would execute. The new loader reads it as data (export literal `KEY=VALUE`, one quote layer unwrapped, inline comments stripped). Verified hash-identical to `source` for every key shape a real secrets file holds; a `$(...)`/backtick value stays literal.

### 4. Blocking gitleaks scan in CI (`ci.yml`, `.gitleaks.toml`)
New `leak-detector` step: gitleaks v8.22.1 (version + sha256 pinned), `detect --no-git --redact` (redact mandatory — public Actions logs must never echo a found secret), whole-tree with the repo's PII/infrastructure rules. Allowlist gains line-target regexes for CGNAT/ULA range *notation* and `secrets.env.example`.

## Verification
- 214 targeted tests pass (`test_inline_hooks`, `test_merge_review_gate`, `test_bash_safety_hook`, `test_load_secrets`).
- ruff + shellcheck + gitleaks clean; privacy-scanned.
- All four gates re-verified against their exact bypass inputs after the review pass that found findings 1–3 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)