### PR TITLE
feat(backup): complete #907 crontab→systemd-timer migration + Backup tab overhaul

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -142,6 +142,20 @@ systemctl --user start genesis-backup.service   # fire one run now
 cat ~/.genesis/backup_status.json               # expect "success":true
 ```
 
+Or manage it from the dashboard **Backup** tab (Settings → Backup): the schedule
+toggle + interval (every 3h / 6h / 12h / daily), a **Run Now** button, and both
+destinations (GitHub Tier-1 and the off-site Tier-2) with live health. The tab
+drives the same `genesis-backup.timer` unit over `systemctl --user` — it does not
+use crontab.
+
+> **Migrating from an old crontab-based schedule?** Earlier installs scheduled
+> backups with a `crontab` line (`… /scripts/backup.sh …`). The systemd timer and
+> a leftover cron line will BOTH fire, running two backups that race on the same
+> repo. When you enable the timer, remove any legacy line:
+> ```bash
+> crontab -l | grep -v 'scripts/backup.sh' | crontab -
+> ```
+
 ## Verify Installation
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,11 @@ ignore = [
 # stays live outside these data-access layers.
 "src/genesis/db/crud/*" = ["S608"]
 "src/genesis/dashboard/routes/*" = ["S608"]
+# Schema/data migrations assemble literal SQL fragments (often from module-level
+# constants); they run at deploy against the schema and NEVER take runtime user
+# input, so S608 is a false positive here — same data-access-layer rationale as
+# db/crud/*. (0053's f-string UPDATE uses a trusted literal _WHERE constant.)
+"src/genesis/db/migrations/*" = ["S608"]
 # Type-narrowing asserts in MCP handlers (follow-up: convert to explicit raises).
 "src/genesis/mcp/memory/*" = ["S101"]
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -44,6 +44,12 @@ _MEMORY_COUNT=0
 _SECRETS_OK=false
 _SUCCESS=false
 _FAILURE_REASON=""
+# Tier-1 replication: true once the local repo is in sync with the GitHub remote.
+_TIER1_PUSHED=false
+# Off-site snapshot bookkeeping. _T2_SNAPSHOT_COUNT / _T2_PRUNED stay UNSET until
+# the GFS prune runs (only on a fully-uploaded off-site snapshot), so the status
+# line emits a JSON `null` (not 0) when off-site was skipped/partial — an honest
+# "unknown", and never an empty expansion (which would be invalid JSON).
 
 _write_status() {
     local _ended_at
@@ -57,7 +63,7 @@ _write_status() {
     if [ "${_T2_STATUS:-}" = "ok" ]; then _offsite_confirmed=true; fi
     mkdir -p "$(dirname "$_STATUS_FILE")"
     cat > "$_STATUS_FILE" <<STATUSEOF
-{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}","offsite_confirmed":$_offsite_confirmed}
+{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}","offsite_confirmed":$_offsite_confirmed,"tier2_backend":"${_T2_BACKEND:-none}","snapshot_id":"${_T2_STAMP:-}","snapshot_count":${_T2_SNAPSHOT_COUNT:-null},"pruned_count":${_T2_PRUNED:-null},"tier1_pushed":$_TIER1_PUSHED}
 STATUSEOF
 }
 trap '_write_status; backend_cleanup' EXIT
@@ -553,16 +559,23 @@ else
             )"
             _gfs_delete="$(printf '%s\n' "$_gfs_complete" \
                 | python3 "$_SCRIPT_DIR/gfs_select.py" --daily 7 --weekly 4 --monthly 6)" || _gfs_delete=""
+            # Count COMPLETE snapshots present this run (grep -c . not `wc -l`,
+            # which counts 1 for an empty var). _T2_PRUNED tracks successful
+            # deletes; retained = total - pruned, surfaced in backup_status.json.
+            _T2_PRUNED=0
+            _T2_COMPLETE_TOTAL=$(printf '%s\n' "$_gfs_complete" | grep -c . || true)
             for _st in $_gfs_delete; do
                 if [ "$_st" = "$_T2_STAMP" ]; then
                     continue   # never the current run's snapshot
                 fi
                 if backend_delete "$_T2_HOST_DIR/$_st"; then
+                    _T2_PRUNED=$(( _T2_PRUNED + 1 ))
                     log "GFS prune: removed off-site snapshot $_st"
                 else
                     log "WARNING: GFS prune failed for off-site snapshot $_st"
                 fi
             done
+            _T2_SNAPSHOT_COUNT=$(( _T2_COMPLETE_TOTAL - _T2_PRUNED ))
         fi
     fi
 fi
@@ -585,6 +598,11 @@ log "Committing backup..."
 git add -A
 if git diff --cached --quiet; then
     log "No changes since last backup"
+    # Remote is in sync only if HEAD is not ahead of upstream — a PRIOR run's push
+    # may have failed, leaving unpushed commits despite a clean worktree today.
+    if git rev-list --count '@{u}..HEAD' 2>/dev/null | grep -qx 0; then
+        _TIER1_PUSHED=true
+    fi
 else
     # Explicit error handling — set -e is suppressed by ||.
     # Without this, a corrupt git repo silently kills the script
@@ -594,6 +612,7 @@ else
             _FAILURE_REASON="git push failed — backup exists locally only (not replicated to remote)"
             log "ERROR: $_FAILURE_REASON"
         else
+            _TIER1_PUSHED=true
             log "Backup committed and pushed"
         fi
     else

--- a/src/genesis/dashboard/routes/backup.py
+++ b/src/genesis/dashboard/routes/backup.py
@@ -2,10 +2,17 @@
 
 Configuration is split by responsibility: the destination/credential env vars
 (GENESIS_BACKUP_*) are written through the hardened secrets writer reused from
-``secrets.py``; the cron SCHEDULE is managed with the read-filter-reinstall
-idiom (``crontab -l`` → drop the backup line → ``crontab -``), which preserves
-every other crontab entry and keeps the validated schedule in stdin content
-only — never on a command line.
+``secrets.py``; the backup SCHEDULE is the ``genesis-backup.timer`` systemd USER
+unit (the source of truth), managed via ``systemctl --user`` + an ``OnCalendar``
+drop-in.
+
+Why systemd, not crontab: ``genesis-server.service`` runs ``NoNewPrivileges=yes``,
+which neutralises the setgid ``crontab`` binary — ``crontab -l`` returns
+``Permission denied`` from inside the service, so the old crontab read/write path
+was silently dead (the dashboard reported "Not scheduled" while cron backups ran).
+``systemctl --user`` talks to the session manager over D-Bus (not setgid), so it
+works under the sandbox, and the drop-in file lives under ``$HOME`` (writable via
+the unit's ``ReadWritePaths=%h``). This completes the migration PR #907 began.
 """
 
 from __future__ import annotations
@@ -22,6 +29,7 @@ from flask import jsonify, request
 
 from genesis.dashboard._blueprint import blueprint
 from genesis.dashboard.auth import is_authenticated
+from genesis.util.systemd import systemctl_env
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +39,47 @@ _BACKUP_SCRIPT = _HOME / "genesis" / "scripts" / "backup.sh"
 _BACKUP_LOG = _HOME / "genesis" / "logs" / "backup.log"
 _BACKUP_DIR = _HOME / "backups" / "genesis-backups"
 
+# Systemd user units (source of truth for the backup schedule).
+_TIMER_UNIT = "genesis-backup.timer"
+_SERVICE_UNIT = "genesis-backup.service"
+_TIMER_DROPIN = (
+    _HOME / ".config" / "systemd" / "user"
+    / "genesis-backup.timer.d" / "schedule.conf"
+)
+
+# Preset schedules exposed by the dashboard. The value is the SHORT OnCalendar
+# spec we write into the drop-in; systemd normalises it on load to the long form
+# below, which is what ``systemctl show -p TimersCalendar`` reports.
+_INTERVAL_TO_CALENDAR = {
+    "3h": "00/3:10",
+    "6h": "00/6:10",
+    "12h": "00/12:10",
+    "daily": "04:10",
+}
+# Reverse map keyed on systemd's NORMALIZED OnCalendar form (verified via
+# ``systemd-analyze calendar``). test_calendar_maps_are_consistent guards drift.
+_CALENDAR_TO_INTERVAL = {
+    "*-*-* 00/3:10:00": "3h",
+    "*-*-* 00/6:10:00": "6h",
+    "*-*-* 00/12:10:00": "12h",
+    "*-*-* 04:10:00": "daily",
+}
+
+# The unauthenticated /status route echoes the parsed backup_status.json. Project
+# it through this allowlist so a future field added to backup.sh's status line
+# (e.g. an infra path) can never auto-leak. The raw off-site TARGET is
+# deliberately NOT here — it comes from /config's auth-gated _key_value instead.
+_STATUS_SAFE_FIELDS = frozenset({
+    "timestamp", "success", "sqlite_lines", "qdrant_collections",
+    "transcript_files", "memory_files", "secrets_encrypted", "duration_s",
+    "failure_reason", "tier2_status", "offsite_confirmed", "tier2_backend",
+    "snapshot_id", "snapshot_count", "pruned_count", "tier1_pushed",
+})
+
 _BACKENDS = {"none", "local", "smb"}
-_CRON_FIELD_RE = re.compile(r"^[0-9*,/-]+$")
 _NAS_RE = re.compile(r"^//[^/\s]+/[^\s]+$")
 _REPO_RE = re.compile(r"^(https?://|git@|ssh://).+")
+_ONCALENDAR_RE = re.compile(r"OnCalendar=(.+?)\s*;")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
@@ -57,104 +102,188 @@ def _strip_url_creds(url: str | None) -> str | None:
     return url
 
 
-def _current_cron_line() -> str | None:
-    """The active (uncommented) backup.sh crontab line, if any."""
-    try:
-        out = subprocess.run(
-            ["crontab", "-l"], capture_output=True, text=True, timeout=5,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return None
-    if out.returncode != 0:
-        return None
-    for line in out.stdout.splitlines():
-        s = line.strip()
-        if "backup.sh" in s and not s.startswith("#"):
-            return s
-    return None
+def _systemctl(*args: str, timeout: int = 5):
+    """Run ``systemctl --user <args>`` with the D-Bus session env injected.
 
-
-def _current_schedule() -> tuple[str | None, bool]:
-    """(cron expression, enabled) for the backup job."""
-    line = _current_cron_line()
-    if not line:
-        return None, False
-    fields = line.split()
-    if len(fields) >= 5:
-        return " ".join(fields[:5]), True
-    return None, True
-
-
-def _valid_cron(expr: str) -> bool:
-    fields = expr.split()
-    return len(fields) == 5 and all(_CRON_FIELD_RE.match(f) for f in fields)
-
-
-def _set_backup_cron(schedule: str | None) -> bool:
-    """Install (``schedule`` given) or remove (``None``) the backup.sh crontab
-    line, preserving every other entry — the read-filter-reinstall idiom done
-    in-process. ``crontab -`` is invoked with a constant argv; the (already
-    ``_valid_cron``-validated) schedule only ever appears in the stdin content,
-    never on a command line. Returns True on success.
+    Returns the CompletedProcess, or ``None`` on timeout/OSError. Works under the
+    hardened genesis-server namespace because D-Bus (unlike setgid ``crontab``) is
+    unaffected by ``NoNewPrivileges`` — the same path ``services.py`` already uses.
     """
     try:
-        # crontab -l: constant argv, no user data. Quick local op; the short
-        # bound guards a hung crontab from blocking this request thread.
-        read = subprocess.run(
-            ["crontab", "-l"], capture_output=True, text=True, timeout=10,
+        return subprocess.run(
+            ["systemctl", "--user", *args],
+            capture_output=True, text=True, timeout=timeout, env=systemctl_env(),
         )
     except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _parse_show(stdout: str) -> dict[str, str]:
+    """Parse ``systemctl show -p KEY`` ``KEY=VALUE`` lines into a dict."""
+    props: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            props[key] = value
+    return props
+
+
+def _interval_from_calendar(timers_calendar: str | None) -> str | None:
+    """Map systemd's ``TimersCalendar`` property back to a preset key.
+
+    ``TimersCalendar`` looks like ``{ OnCalendar=*-*-* 00/6:10:00 ; next_elapse=…}``.
+    Returns the preset key, ``"custom"`` for an unrecognised OnCalendar, or
+    ``None`` when the property is absent/empty.
+    """
+    if not timers_calendar:
+        return None
+    m = _ONCALENDAR_RE.search(timers_calendar)
+    if not m:
+        return None
+    return _CALENDAR_TO_INTERVAL.get(m.group(1).strip(), "custom")
+
+
+def _timer_state() -> dict:
+    """Backup schedule state read from the systemd user timer (source of truth).
+
+    Best-effort: any systemctl failure degrades to a disabled/None reading rather
+    than raising — the status route must never 500 on a schedule probe.
+    """
+    state = {
+        "mechanism": "systemd-timer", "enabled": False, "active": False,
+        "next_run": None, "last_trigger": None, "interval": None,
+    }
+    r = _systemctl("is-enabled", _TIMER_UNIT)
+    if r is not None:
+        state["enabled"] = r.stdout.strip() == "enabled"
+    r = _systemctl("is-active", _TIMER_UNIT)
+    if r is not None:
+        state["active"] = r.stdout.strip() == "active"
+    r = _systemctl("show", _TIMER_UNIT,
+                   "-p", "NextElapseUSecRealtime",
+                   "-p", "LastTriggerUSec",
+                   "-p", "TimersCalendar")
+    if r is not None and r.returncode == 0:
+        props = _parse_show(r.stdout)
+        state["next_run"] = props.get("NextElapseUSecRealtime") or None
+        state["last_trigger"] = props.get("LastTriggerUSec") or None
+        state["interval"] = _interval_from_calendar(props.get("TimersCalendar"))
+    return state
+
+
+def _set_timer_schedule(interval_key: str) -> bool:
+    """Write the OnCalendar drop-in for a preset and reload systemd.
+
+    The drop-in RESETS the additive base (an empty ``OnCalendar=`` line) before
+    setting the new value — systemd treats multiple ``OnCalendar=`` as additive,
+    so without the reset the template's 6h schedule would *also* keep firing.
+    A bare ``daemon-reload`` is sufficient for an already-active timer to
+    recompute its next elapse (verified) — no restart needed.
+    """
+    calendar = _INTERVAL_TO_CALENDAR.get(interval_key)
+    if calendar is None:
         return False
-    existing = read.stdout.splitlines() if read.returncode == 0 else []
-    lines = [ln for ln in existing if "backup.sh" not in ln]
-    if schedule:
-        lines.append(f"{schedule} {_BACKUP_SCRIPT} >> {_BACKUP_LOG} 2>&1")
-    content = "\n".join(lines)
-    if content:
-        content += "\n"
     try:
-        write = subprocess.run(
-            ["crontab", "-"], input=content, text=True,
-            capture_output=True, timeout=10,
+        _TIMER_DROPIN.parent.mkdir(parents=True, exist_ok=True)
+        _TIMER_DROPIN.write_text(
+            f"[Timer]\nOnCalendar=\nOnCalendar={calendar}\n"
+        )
+    except OSError:
+        logger.error("Failed to write backup timer drop-in", exc_info=True)
+        return False
+    r = _systemctl("daemon-reload", timeout=10)
+    return r is not None and r.returncode == 0
+
+
+def _set_timer_enabled(enabled: bool) -> bool:
+    """Enable+start (``enable --now``) or disable+stop (``disable --now``) the
+    backup timer. On an already-active timer ``enable --now`` is a no-op start
+    (it does not restart), which is fine — the drop-in reload already recomputed
+    the schedule."""
+    verb = "enable" if enabled else "disable"
+    r = _systemctl(verb, "--now", _TIMER_UNIT, timeout=10)
+    return r is not None and r.returncode == 0
+
+
+def _backup_repo_url() -> str | None:
+    """The Tier-1 (GitHub) origin URL of the local backups clone, cred-stripped."""
+    if not _BACKUP_DIR.is_dir():
+        return None
+    try:
+        remote = subprocess.run(
+            ["git", "-C", str(_BACKUP_DIR), "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=5,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return False
-    return write.returncode == 0
+        return None
+    return _strip_url_creds(remote.stdout.strip()) if remote.returncode == 0 else None
+
+
+def _destinations(status: dict | None, repo: str | None) -> dict:
+    """Build the two-tier destination health view for the dashboard.
+
+    Tier-1 = GitHub (git push); Tier-2 = off-site (none/local/smb). The Tier-2
+    TARGET (NAS share / local path) is infra detail — included ONLY for
+    authenticated callers, mirroring /config's gating. It is read from the
+    (auth-gated) secrets, NEVER from the status file, so /status stays safe to
+    serve unauthenticated.
+    """
+    from genesis.dashboard.routes.secrets import _key_value
+
+    status = status or {}
+    tier1 = {
+        "repo": repo,
+        "pushed": status.get("tier1_pushed"),
+        "last": status.get("timestamp"),
+    }
+    backend = (status.get("tier2_backend")
+               or _key_value("GENESIS_BACKUP_TIER2_BACKEND") or "none")
+    tier2 = {
+        "backend": backend,
+        "status": status.get("tier2_status"),
+        "confirmed": status.get("offsite_confirmed"),
+        "snapshot_id": status.get("snapshot_id"),
+        "snapshot_count": status.get("snapshot_count"),
+    }
+    if is_authenticated():
+        if backend == "smb":
+            tier2["target"] = _strip_url_creds(
+                _key_value("GENESIS_BACKUP_NAS")) or None
+        elif backend == "local":
+            tier2["target"] = _key_value("GENESIS_BACKUP_LOCAL_PATH") or None
+    return {"tier1": tier1, "tier2": tier2}
 
 
 # ── Routes ────────────────────────────────────────────────────────────
 
 @blueprint.route("/api/genesis/backup/status")
 def backup_status():
-    """Return last backup status from status file + cron + repo info."""
+    """Last backup status + schedule (systemd timer) + both destinations.
+
+    Reachable unauthenticated, so the parsed status file is projected through
+    ``_STATUS_SAFE_FIELDS`` and the Tier-2 target is withheld unless authenticated.
+    """
     result = {
         "configured": _BACKUP_SCRIPT.is_file(),
         "repo_configured": _BACKUP_DIR.is_dir(),
     }
 
+    last_backup: dict | None = None
     if _STATUS_FILE.is_file():
         try:
-            result["last_backup"] = json.loads(_STATUS_FILE.read_text())
+            raw = json.loads(_STATUS_FILE.read_text())
+            if isinstance(raw, dict):
+                # Allowlist projection — a future field in backup.sh's status
+                # line cannot auto-leak through this unauthenticated route.
+                last_backup = {k: v for k, v in raw.items()
+                               if k in _STATUS_SAFE_FIELDS}
         except (json.JSONDecodeError, OSError):
-            result["last_backup"] = None
-    else:
-        result["last_backup"] = None
+            last_backup = None
+    result["last_backup"] = last_backup
 
-    line = _current_cron_line()
-    result["cron_schedule"] = line
-
-    if _BACKUP_DIR.is_dir():
-        try:
-            remote = subprocess.run(
-                ["git", "-C", str(_BACKUP_DIR), "remote", "get-url", "origin"],
-                capture_output=True, text=True, timeout=5,
-            )
-            repo = remote.stdout.strip() if remote.returncode == 0 else None
-            result["repo"] = _strip_url_creds(repo)
-        except (subprocess.TimeoutExpired, OSError):
-            result["repo"] = None
-    else:
-        result["repo"] = None
+    result["repo"] = _backup_repo_url()
+    result["schedule"] = _timer_state()
+    result["destinations"] = _destinations(last_backup, result["repo"])
 
     return jsonify(result)
 
@@ -170,12 +299,13 @@ def backup_config_get():
     """
     from genesis.dashboard.routes.secrets import _key_value
 
-    schedule, enabled = _current_schedule()
+    timer = _timer_state()
     result = {
         "repo": _strip_url_creds(_key_value("GENESIS_BACKUP_REPO")),
         "tier2_backend": _key_value("GENESIS_BACKUP_TIER2_BACKEND") or "none",
-        "schedule": schedule,
-        "schedule_enabled": enabled,
+        "schedule_enabled": timer["enabled"],
+        # Preset key ("6h"/…), "custom" for a hand-edited OnCalendar, or None.
+        "schedule_interval": timer["interval"],
         "passphrase_set": bool(_key_value("GENESIS_BACKUP_PASSPHRASE")),
         "nas_pass_set": bool(_key_value("GENESIS_BACKUP_NAS_PASS")),
     }
@@ -189,12 +319,13 @@ def backup_config_get():
 
 @blueprint.route("/api/genesis/backup/config", methods=["POST"])
 def backup_config_set():
-    """Update backup destination/credentials (secrets.env) and schedule (cron).
+    """Update backup destination/credentials (secrets.env) and schedule (timer).
 
     Env changes take effect on the next backup run (backup.sh sources
-    secrets.env directly) — no server restart required.
+    secrets.env directly) — no server restart required. The schedule is applied
+    immediately to the ``genesis-backup.timer`` systemd user unit.
     """
-    # Privileged write (credentials + cron) — gate it. No-op when the dashboard
+    # Privileged write (credentials + schedule) — gate it. No-op when the dashboard
     # has no password configured (is_authenticated() returns True), so a
     # passwordless install is unaffected; a password-protected one is enforced.
     if not is_authenticated():
@@ -291,20 +422,22 @@ def backup_config_set():
                     "a fresh backup with the new one."
                 )
 
-    # Schedule — install/remove the cron line via the wrapper script.
-    cron_action: tuple[str, str | None] | None = None
-    if "schedule_enabled" in data or data.get("schedule"):
-        schedule = (data.get("schedule") or "").strip()
+    # Schedule — managed via the systemd user timer. Disabling must NOT require a
+    # valid interval (a host on a hand-edited "custom" schedule must still be able
+    # to turn backups off), so interval is validated only on the enable path.
+    schedule_action: tuple[str, str | None] | None = None
+    if "schedule_enabled" in data or "schedule_interval" in data:
         if data.get("schedule_enabled", True):
-            if not _valid_cron(schedule):
+            interval = (data.get("schedule_interval") or "").strip()
+            if interval and interval not in _INTERVAL_TO_CALENDAR:
                 errors.append(
-                    "schedule must be a 5-field cron expression "
-                    "(e.g. '0 */6 * * *')"
+                    "schedule_interval must be one of "
+                    f"{sorted(_INTERVAL_TO_CALENDAR)}"
                 )
             else:
-                cron_action = ("install", schedule)
+                schedule_action = ("enable", interval or None)
         else:
-            cron_action = ("remove", None)
+            schedule_action = ("disable", None)
 
     if errors:
         return jsonify({"error": "Validation failed", "details": errors}), 422
@@ -319,14 +452,28 @@ def backup_config_set():
             return jsonify({"error": "Failed to write secrets.env"}), 500
 
     schedule_result: str | None = None
-    if cron_action is not None:
-        action, expr = cron_action
-        if not _set_backup_cron(expr if action == "install" else None):
-            return jsonify({"error": "Failed to update backup schedule"}), 500
-        schedule_result = "installed" if action == "install" else "removed"
+    if schedule_action is not None:
+        action, interval = schedule_action
+        if action == "enable":
+            # Write the schedule (if the user picked one) BEFORE enabling, so the
+            # daemon-reload's recompute is already in place when the timer starts.
+            if interval and not _set_timer_schedule(interval):
+                return jsonify(
+                    {"error": "Failed to write backup schedule (drop-in)"}), 500
+            if not _set_timer_enabled(True):
+                return jsonify(
+                    {"error": "Schedule written but failed to enable the backup "
+                              "timer — retry, or check `systemctl --user status "
+                              "genesis-backup.timer`"}), 500
+            schedule_result = "enabled"
+        else:
+            if not _set_timer_enabled(False):
+                return jsonify({"error": "Failed to disable the backup timer"}), 500
+            schedule_result = "disabled"
 
     logger.info("Backup config updated: keys=%s schedule=%s",
-                sorted(env_updates.keys()), cron_action[0] if cron_action else None)
+                sorted(env_updates.keys()),
+                schedule_action[0] if schedule_action else None)
     return jsonify({
         "status": "ok",
         "updated": sorted(env_updates.keys()),
@@ -338,22 +485,25 @@ def backup_config_set():
 
 @blueprint.route("/api/genesis/backup/trigger", methods=["POST"])
 def backup_trigger():
-    """Trigger a manual backup run (async — returns immediately)."""
+    """Trigger a manual backup run via the systemd service (async).
+
+    Runs the SAME ``genesis-backup.service`` the timer fires, so Run-Now and the
+    scheduled run are identical — and the service's un-hardened namespace has the
+    gpg-agent socket + /tmp access backup.sh needs (the hardened genesis-server
+    namespace does not, so the old in-process ``bash backup.sh`` was a latent bug).
+    ``--no-block`` is REQUIRED: a ``Type=oneshot`` start otherwise blocks until the
+    backup finishes (~5 min), hanging this request thread.
+    """
     if not _BACKUP_SCRIPT.is_file():
         return jsonify({"error": "Backup script not found"}), 404
 
-    try:
-        proc = subprocess.Popen(
-            ["bash", str(_BACKUP_SCRIPT)],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,  # reparent to init — avoids zombie accumulation
-        )
-        logger.info("Manual backup triggered (pid %d)", proc.pid)
-        return jsonify({"status": "triggered", "pid": proc.pid})
-    except Exception as exc:
-        logger.error("Failed to trigger backup: %s", exc, exc_info=True)
-        return jsonify({"error": str(exc)}), 500
+    r = _systemctl("start", "--no-block", _SERVICE_UNIT, timeout=10)
+    if r is None or r.returncode != 0:
+        err = (r.stderr.strip() if r is not None else "systemctl unavailable")
+        logger.error("Failed to start %s: %s", _SERVICE_UNIT, err)
+        return jsonify({"error": err or "Failed to start backup service"}), 500
+    logger.info("Manual backup triggered via %s", _SERVICE_UNIT)
+    return jsonify({"status": "triggered", "unit": _SERVICE_UNIT})
 
 
 @blueprint.route("/api/genesis/backup/log")

--- a/src/genesis/dashboard/templates/partials/tabs/backup.html
+++ b/src/genesis/dashboard/templates/partials/tabs/backup.html
@@ -165,12 +165,19 @@
         </template>
         <template x-if="$store.genesisDashboard.backupStatus">
           <div>
-            <!-- Status card -->
+            <!-- Status headline card -->
             <div class="card" style="padding:1rem; margin-bottom:1rem;">
-              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.75rem;">
-                <h3 style="margin:0; font-size:1rem;">Backup Status</h3>
+              <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:0.75rem; gap:1rem;">
+                <div>
+                  <h3 style="margin:0 0 0.2rem 0; font-size:1rem;">Backups</h3>
+                  <div style="font-size:0.95rem; font-weight:600;"
+                       :style="'color:' + $store.genesisDashboard.backupHeadline().color"
+                       x-text="$store.genesisDashboard.backupHeadline().text"></div>
+                  <div style="font-size:0.78rem; color:var(--color-text-secondary); margin-top:0.15rem;"
+                       x-text="$store.genesisDashboard.backupScheduleLine()"></div>
+                </div>
                 <button @click="$store.genesisDashboard.triggerBackup()"
-                        style="background:var(--color-accent); color:#000; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;">
+                        style="background:var(--color-accent); color:#000; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem; white-space:nowrap;">
                   Run Now</button>
               </div>
               <template x-if="$store.genesisDashboard.backupStatus.last_backup">
@@ -217,23 +224,41 @@
                 <div style="color:var(--color-text-secondary);">No backup status file found. Run a backup to generate status.</div>
               </template>
             </div>
-            <!-- Config card -->
-            <div class="card" style="padding:1rem;">
-              <h3 style="margin:0 0 0.5rem 0; font-size:1rem;">Configuration</h3>
-              <div style="font-size:0.85rem;">
-                <div style="margin-bottom:0.25rem;">
-                  <span style="color:var(--color-text-secondary);">Repo:</span>
-                  <span x-text="$store.genesisDashboard.backupStatus.repo || 'Not configured'"></span>
-                </div>
-                <div style="margin-bottom:0.25rem;">
-                  <span style="color:var(--color-text-secondary);">Cron:</span>
-                  <code style="font-size:0.8rem;" x-text="$store.genesisDashboard.backupStatus.cron_schedule || 'Not scheduled'"></code>
-                </div>
+
+            <!-- Destinations card — where backups actually go (both tiers) -->
+            <div class="card" style="padding:1rem; margin-bottom:1rem;">
+              <h3 style="margin:0 0 0.6rem 0; font-size:1rem;">Destinations</h3>
+              <!-- Tier 1: GitHub -->
+              <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem; padding:0.4rem 0; border-bottom:1px solid var(--color-border);">
                 <div>
-                  <span style="color:var(--color-text-secondary);">Script:</span>
-                  <span x-text="$store.genesisDashboard.backupStatus.configured ? 'Installed' : 'Not found'"
-                        :style="$store.genesisDashboard.backupStatus.configured ? 'color:#81c784' : 'color:#ef9a9a'"></span>
+                  <div style="font-size:0.85rem;">GitHub <span style="color:var(--color-text-secondary); font-size:0.72rem;">· Tier 1 (memory, config, secrets)</span></div>
+                  <code style="font-size:0.72rem; color:var(--color-text-secondary);"
+                        x-text="$store.genesisDashboard.backupStatus.destinations?.tier1?.repo || 'Not configured'"></code>
                 </div>
+                <span style="font-size:0.8rem; white-space:nowrap;"
+                      :style="$store.genesisDashboard.backupStatus.destinations?.tier1?.pushed === true ? 'color:#81c784' : ($store.genesisDashboard.backupStatus.destinations?.tier1?.pushed === false ? 'color:#ef9a9a' : 'color:var(--color-text-secondary)')"
+                      x-text="$store.genesisDashboard.backupStatus.destinations?.tier1?.pushed === true ? 'Synced ✓' : ($store.genesisDashboard.backupStatus.destinations?.tier1?.pushed === false ? 'Not pushed ✗' : '—')"></span>
+              </div>
+              <!-- Tier 2: off-site -->
+              <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem; padding:0.5rem 0 0.2rem;">
+                <div>
+                  <div style="font-size:0.85rem;">Off-site
+                    <span style="color:var(--color-text-secondary); font-size:0.72rem;">· Tier 2 (Qdrant + SQL, large binaries)</span>
+                    <span x-show="$store.genesisDashboard.backupStatus.destinations?.tier2?.backend && $store.genesisDashboard.backupStatus.destinations?.tier2?.backend !== 'none'"
+                          style="font-size:0.7rem; color:var(--color-text-secondary); text-transform:uppercase;"
+                          x-text="'(' + $store.genesisDashboard.backupStatus.destinations?.tier2?.backend + ')'"></span>
+                  </div>
+                  <!-- NAS/local target only rendered when the API returned it (authenticated) -->
+                  <code x-show="$store.genesisDashboard.backupStatus.destinations?.tier2?.target"
+                        style="font-size:0.72rem; color:var(--color-text-secondary);"
+                        x-text="$store.genesisDashboard.backupStatus.destinations?.tier2?.target"></code>
+                  <div x-show="$store.genesisDashboard.backupStatus.destinations?.tier2?.snapshot_count != null"
+                       style="font-size:0.72rem; color:var(--color-text-secondary);"
+                       x-text="$store.genesisDashboard.backupStatus.destinations?.tier2?.snapshot_count + ' snapshot(s) retained' + ($store.genesisDashboard.backupStatus.destinations?.tier2?.snapshot_id ? ' · latest ' + $store.genesisDashboard.backupStatus.destinations.tier2.snapshot_id : '')"></div>
+                </div>
+                <span style="font-size:0.8rem; white-space:nowrap;"
+                      :style="'color:' + $store.genesisDashboard.tier2Health().color"
+                      x-text="$store.genesisDashboard.tier2Health().text"></span>
               </div>
             </div>
             <!-- Editable backup configuration -->
@@ -301,19 +326,27 @@
                   </div>
                 </template>
 
-                <!-- Schedule -->
+                <!-- Schedule (systemd timer) -->
                 <label style="display:flex; align-items:center; gap:0.4rem; margin-top:0.2rem;">
                   <input type="checkbox" x-model="$store.genesisDashboard.backupConfigForm.schedule_enabled"
                          @change="$store.genesisDashboard.scheduleDirty = true">
-                  <span>Scheduled (cron) backups</span>
+                  <span>Scheduled automatic backups</span>
                 </label>
                 <template x-if="$store.genesisDashboard.backupConfigForm.schedule_enabled">
                   <label style="display:flex; flex-direction:column; gap:0.15rem;">
-                    <span style="color:var(--color-text-secondary);">Cron schedule</span>
-                    <input type="text" x-model="$store.genesisDashboard.backupConfigForm.schedule" placeholder="0 */6 * * *"
-                           @input="$store.genesisDashboard.scheduleDirty = true"
-                           style="font-size:0.82rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary); font-family:monospace;">
-                    <span style="font-size:0.7rem; color:var(--color-text-secondary);">5-field cron — e.g. <code>0 */6 * * *</code> = every 6 hours</span>
+                    <span style="color:var(--color-text-secondary);">Run backups</span>
+                    <select x-model="$store.genesisDashboard.backupConfigForm.schedule_interval"
+                            @change="$store.genesisDashboard.scheduleDirty = true"
+                            style="font-size:0.82rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+                      <option value="3h">Every 3 hours</option>
+                      <option value="6h">Every 6 hours</option>
+                      <option value="12h">Every 12 hours</option>
+                      <option value="daily">Daily (4:10 AM)</option>
+                    </select>
+                    <!-- M4: a hand-edited OnCalendar the presets can't represent -->
+                    <span x-show="$store.genesisDashboard.backupConfig?.schedule_interval === 'custom'"
+                          style="font-size:0.7rem; color:#ffb74d;">
+                      ⚠ This host currently runs a custom schedule (set outside the dashboard). Choosing a preset above and saving will replace it.</span>
                   </label>
                 </template>
 

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -225,7 +225,7 @@
         backupConfigForm: {
           repo: '', tier2_backend: 'none', local_path: '',
           nas: '', nas_user: '', nas_pass: '', passphrase: '',
-          schedule: '0 */6 * * *', schedule_enabled: true,
+          schedule_interval: '6h', schedule_enabled: true,
         },
         backupConfigSaving: false,
         backupConfigMsg: null,
@@ -1771,10 +1771,58 @@
             if (resp && resp.ok) { this.backupStatus = await resp.json(); }
           } catch (e) { console.warn("Backup status failed:", e); }
         },
+        // Human labels for the interval preset keys the API speaks.
+        _intervalLabels: { '3h': 'every 3 hours', '6h': 'every 6 hours',
+          '12h': 'every 12 hours', daily: 'daily' },
+        // Headline health: is the backup system OK, at-risk, or failing?
+        backupHeadline() {
+          const bs = this.backupStatus;
+          const lb = bs && bs.last_backup;
+          const enabled = bs && bs.schedule && bs.schedule.enabled;
+          if (!lb) return { text: 'No backups yet', color: '#ffb74d' };
+          if (!lb.success) return { text: 'Failing', color: '#ef9a9a' };
+          if (!enabled) return { text: 'On demand only (not scheduled)', color: '#ffb74d' };
+          return { text: 'Active', color: '#81c784' };
+        },
+        // "every 6 hours · last 12:10 PM ✓ · next 6:10 PM" — the at-a-glance line.
+        backupScheduleLine() {
+          const bs = this.backupStatus;
+          const sch = bs && bs.schedule;
+          const lb = bs && bs.last_backup;
+          const parts = [];
+          if (sch && sch.enabled) {
+            const key = sch.interval;
+            if (key && key !== 'custom' && this._intervalLabels[key]) parts.push(this._intervalLabels[key]);
+            else if (key === 'custom') parts.push('custom schedule');
+            else parts.push('scheduled');
+          } else {
+            parts.push('not scheduled');
+          }
+          if (lb && lb.timestamp) {
+            const when = new Date(lb.timestamp).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+            parts.push('last ' + when + (lb.success ? ' ✓' : ' ✗'));
+          }
+          if (sch && sch.enabled && sch.next_run) parts.push('next ' + sch.next_run);
+          return parts.join(' · ');
+        },
+        // Off-site (Tier-2) health label + colour from the status/backend fields.
+        tier2Health() {
+          const t2 = this.backupStatus && this.backupStatus.destinations
+            && this.backupStatus.destinations.tier2;
+          if (!t2 || t2.backend === 'none' || !t2.backend)
+            return { text: 'Not configured', color: 'var(--color-text-secondary)' };
+          const s = t2.status;
+          if (s === 'ok') return { text: 'Off-site copy confirmed', color: '#81c784' };
+          if (s === 'partial') return { text: 'Partial — last off-site copy incomplete', color: '#ffb74d' };
+          if (s === 'no_smbclient') return { text: 'smbclient not installed', color: '#ef9a9a' };
+          if (s === 'not_configured') return { text: 'Not configured', color: 'var(--color-text-secondary)' };
+          return { text: s || 'unknown', color: '#ffb74d' };
+        },
         async triggerBackup() {
           try {
             const resp = await fetchApi("/api/genesis/backup/trigger", { method: "POST" });
-            if (resp && resp.ok) { alert("Backup triggered"); setTimeout(() => this.fetchBackupStatus(), 5000); }
+            // Type=oneshot backup runs ~5 min; status won't reflect it immediately.
+            if (resp && resp.ok) { alert("Backup started — a full run takes a few minutes."); setTimeout(() => this.fetchBackupStatus(), 8000); }
             else { alert("Trigger failed"); }
           } catch (e) { alert("Trigger failed: " + e.message); }
         },
@@ -1790,7 +1838,11 @@
               f.local_path = c.local_path || '';
               f.nas = c.nas || '';
               f.nas_user = c.nas_user || '';
-              f.schedule = c.schedule || '0 */6 * * *';
+              // A "custom"/null server interval can't be a preset dropdown value;
+              // default the control to 6h but DON'T mark dirty, so a plain Save
+              // never rewrites a hand-edited schedule (scheduleDirty gates it).
+              f.schedule_interval = (c.schedule_interval && c.schedule_interval !== 'custom')
+                ? c.schedule_interval : '6h';
               f.schedule_enabled = c.schedule_enabled !== false;
               this.scheduleDirty = false;   // loaded state is not a user change
               // passphrase / nas_pass are write-only — never populated.
@@ -1806,7 +1858,7 @@
             // The cron job is a stateful side-effect — only touch it when the
             // user actually changed the schedule controls.
             if (this.scheduleDirty) {
-              body.schedule = f.schedule;
+              body.schedule_interval = f.schedule_interval;
               body.schedule_enabled = f.schedule_enabled;
             }
             // Only send repo if the user actually changed it — re-sending the
@@ -1826,7 +1878,7 @@
             if (resp && resp.ok) {
               this.backupConfigMsg = {
                 ok: true,
-                text: "Saved — applies on the next backup run.",
+                text: "Saved. Schedule changes apply now; destination/credential changes apply on the next run.",
                 warnings: (data && data.warnings) || [],
               };
               f.nas_pass = ''; f.passphrase = '';   // clear write-only fields

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -1778,10 +1778,15 @@
         backupHeadline() {
           const bs = this.backupStatus;
           const lb = bs && bs.last_backup;
-          const enabled = bs && bs.schedule && bs.schedule.enabled;
+          const sch = bs && bs.schedule;
+          const enabled = sch && sch.enabled;
+          const active = sch && sch.active;
           if (!lb) return { text: 'No backups yet', color: '#ffb74d' };
           if (!lb.success) return { text: 'Failing', color: '#ef9a9a' };
           if (!enabled) return { text: 'On demand only (not scheduled)', color: '#ffb74d' };
+          // enabled but not loaded/running (e.g. stopped out-of-band, or failed to
+          // start) — the timer won't fire, so "Active" would misreport. Say so.
+          if (!active) return { text: 'Scheduled, but the timer is not running', color: '#ffb74d' };
           return { text: 'Active', color: '#81c784' };
         },
         // "every 6 hours · last 12:10 PM ✓ · next 6:10 PM" — the at-a-glance line.

--- a/tests/test_dashboard/test_backup_config_api.py
+++ b/tests/test_dashboard/test_backup_config_api.py
@@ -1,12 +1,19 @@
-"""Tests for the dashboard backup configuration routes.
+"""Tests for the dashboard backup configuration + status routes.
 
-Validation, the secrets-writer reuse, cron-wrapper invocation, credential
-redaction on reads, and auth-gated NAS fields. The secrets writer and the
-crontab subprocess are mocked — no real secrets.env / crontab is touched.
+The schedule is managed through the ``genesis-backup.timer`` systemd USER unit
+(the source of truth), NOT crontab — the hardened ``genesis-server`` namespace
+(``NoNewPrivileges=yes``) neutralises the setgid ``crontab`` binary, so the old
+crontab read/write path was dead. ``systemctl --user`` reaches the session
+manager over D-Bus and works under that sandbox.
+
+The secrets writer, the systemd helpers, and the drop-in file write are mocked —
+no real secrets.env / systemd unit / crontab is touched.
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -28,7 +35,7 @@ def client():
     return app.test_client()
 
 
-def _ok_proc(stdout="installed: ...", returncode=0, stderr=""):
+def _proc(stdout="", returncode=0, stderr=""):
     return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
 
 
@@ -45,7 +52,6 @@ def test_strip_url_creds_removes_token():
     from genesis.dashboard.routes.backup import _strip_url_creds
     assert _strip_url_creds("https://user:ghp_tok@github.com/u/r.git") == \
         "https://github.com/u/r.git"
-    # No creds → unchanged; scp-style git@ has no secret token → unchanged.
     assert _strip_url_creds("https://github.com/u/r.git") == \
         "https://github.com/u/r.git"
     assert _strip_url_creds("git@github.com:u/r.git") == "git@github.com:u/r.git"
@@ -53,33 +59,175 @@ def test_strip_url_creds_removes_token():
     assert _strip_url_creds(None) is None
 
 
+# ── _interval_from_calendar (pure) ────────────────────────────────────
+def test_interval_from_calendar_maps_presets():
+    from genesis.dashboard.routes.backup import _interval_from_calendar
+    assert _interval_from_calendar(
+        "{ OnCalendar=*-*-* 00/6:10:00 ; next_elapse=... }") == "6h"
+    assert _interval_from_calendar(
+        "{ OnCalendar=*-*-* 00/3:10:00 ; next_elapse=(null) }") == "3h"
+    assert _interval_from_calendar(
+        "{ OnCalendar=*-*-* 04:10:00 ; next_elapse=... }") == "daily"
+    # Unrecognised OnCalendar → "custom"; absent → None.
+    assert _interval_from_calendar(
+        "{ OnCalendar=*-*-* 09:00:00 ; next_elapse=... }") == "custom"
+    assert _interval_from_calendar("") is None
+    assert _interval_from_calendar(None) is None
+
+
+# ── _timer_state (parses systemctl) ───────────────────────────────────
+def test_timer_state_parses_enabled_active():
+    from genesis.dashboard.routes.backup import _timer_state
+
+    def fake_run(argv, **kw):
+        # ["systemctl", "--user", <subcommand>, <unit>, ...] → subcommand at [2].
+        assert argv[:2] == ["systemctl", "--user"]
+        sub = argv[2]
+        if sub == "is-enabled":
+            return _proc("enabled\n")
+        if sub == "is-active":
+            return _proc("active\n")
+        if sub == "show":
+            return _proc(
+                "NextElapseUSecRealtime=Fri 2026-07-10 18:10:00 EDT\n"
+                "LastTriggerUSec=Fri 2026-07-10 12:10:00 EDT\n"
+                "TimersCalendar={ OnCalendar=*-*-* 00/6:10:00 ; next_elapse=... }\n"
+            )
+        return _proc("", returncode=1)
+
+    with patch(f"{_BK}.subprocess.run", side_effect=fake_run):
+        st = _timer_state()
+    assert st["mechanism"] == "systemd-timer"
+    assert st["enabled"] is True and st["active"] is True
+    assert st["interval"] == "6h"
+    assert "18:10:00" in st["next_run"]
+    assert "12:10:00" in st["last_trigger"]
+
+
+def test_timer_state_disabled_inactive():
+    from genesis.dashboard.routes.backup import _timer_state
+
+    def fake_run(argv, **kw):
+        sub = argv[2]
+        if sub == "is-enabled":
+            return _proc("disabled\n")
+        if sub == "is-active":
+            return _proc("inactive\n", returncode=3)
+        if sub == "show":
+            return _proc(
+                "NextElapseUSecRealtime=\nLastTriggerUSec=\n"
+                "TimersCalendar={ OnCalendar=*-*-* 00/6:10:00 ; next_elapse=(null) }\n"
+            )
+        return _proc("", returncode=1)
+
+    with patch(f"{_BK}.subprocess.run", side_effect=fake_run):
+        st = _timer_state()
+    assert st["enabled"] is False and st["active"] is False
+    assert st["next_run"] is None and st["last_trigger"] is None
+    assert st["interval"] == "6h"
+
+
+def test_timer_state_survives_systemctl_failure():
+    from genesis.dashboard.routes.backup import _timer_state
+    with patch(f"{_BK}.subprocess.run", side_effect=OSError("no systemctl")):
+        st = _timer_state()
+    assert st == {
+        "mechanism": "systemd-timer", "enabled": False, "active": False,
+        "next_run": None, "last_trigger": None, "interval": None,
+    }
+
+
+# ── _set_timer_schedule (writes reset drop-in) ────────────────────────
+def test_set_timer_schedule_writes_reset_dropin(tmp_path):
+    from genesis.dashboard.routes import backup as bk
+    dropin = tmp_path / "genesis-backup.timer.d" / "schedule.conf"
+    with (
+        patch.object(bk, "_TIMER_DROPIN", dropin),
+        patch(f"{_BK}.subprocess.run", return_value=_proc("")) as run,
+    ):
+        assert bk._set_timer_schedule("12h") is True
+    content = dropin.read_text()
+    # The empty OnCalendar= line MUST precede the real one — it resets systemd's
+    # additive base so the template's 6h schedule does not also fire.
+    assert content == "[Timer]\nOnCalendar=\nOnCalendar=00/12:10\n"
+    # daemon-reload issued after the write.
+    assert any(c.args[0][:4] == ["systemctl", "--user", "daemon-reload"]
+               or c.args[0][3] == "daemon-reload" for c in run.call_args_list)
+
+
+def test_set_timer_schedule_rejects_unknown_interval(tmp_path):
+    from genesis.dashboard.routes import backup as bk
+    dropin = tmp_path / "schedule.conf"
+    with (
+        patch.object(bk, "_TIMER_DROPIN", dropin),
+        patch(f"{_BK}.subprocess.run") as run,
+    ):
+        assert bk._set_timer_schedule("7h") is False
+    assert not dropin.exists()
+    run.assert_not_called()
+
+
+# ── _set_timer_enabled ────────────────────────────────────────────────
+def test_set_timer_enabled_true_enables_now():
+    from genesis.dashboard.routes import backup as bk
+    with patch(f"{_BK}.subprocess.run", return_value=_proc("")) as run:
+        assert bk._set_timer_enabled(True) is True
+    argv = run.call_args.args[0]
+    assert argv[:2] == ["systemctl", "--user"]
+    assert "enable" in argv and "--now" in argv and bk._TIMER_UNIT in argv
+
+
+def test_set_timer_enabled_false_disables_now():
+    from genesis.dashboard.routes import backup as bk
+    with patch(f"{_BK}.subprocess.run", return_value=_proc("")) as run:
+        assert bk._set_timer_enabled(False) is True
+    argv = run.call_args.args[0]
+    assert "disable" in argv and "--now" in argv
+
+
+# ── M5: the two calendar maps stay in lockstep ────────────────────────
+@pytest.mark.skipif(shutil.which("systemd-analyze") is None,
+                    reason="systemd-analyze not available")
+def test_calendar_maps_are_consistent():
+    """Every short OnCalendar we WRITE must normalise (per systemd) to exactly
+    the long form we READ back — guards the two hand-maintained maps drifting."""
+    from genesis.dashboard.routes.backup import _CALENDAR_TO_INTERVAL, _INTERVAL_TO_CALENDAR
+    # Both maps describe the same 4 presets.
+    assert set(_INTERVAL_TO_CALENDAR) == set(_CALENDAR_TO_INTERVAL.values())
+    for key, short in _INTERVAL_TO_CALENDAR.items():
+        out = subprocess.run(["systemd-analyze", "calendar", short],
+                             capture_output=True, text=True, timeout=10)
+        norm = next((ln.split(":", 1)[1].strip()
+                     for ln in out.stdout.splitlines()
+                     if "Normalized form" in ln), None)
+        assert norm is not None, f"no normalized form for {short}"
+        assert _CALENDAR_TO_INTERVAL.get(norm) == key, (
+            f"{short} normalises to {norm!r}; reverse-map disagrees")
+
+
 # ── POST auth gate ────────────────────────────────────────────────────
 def test_set_requires_auth(client):
-    """The privileged write endpoint returns 401 when a dashboard password is
-    set but the caller is unauthenticated — and never writes anything."""
     with (
         patch(f"{_BK}.is_authenticated", return_value=False),
         patch(f"{_SEC}._update_secrets_file") as wr,
-        patch(f"{_BK}.subprocess.run") as run,
+        patch(f"{_BK}._set_timer_enabled") as en,
+        patch(f"{_BK}._set_timer_schedule") as sch,
     ):
         resp = client.post("/api/genesis/backup/config",
                            json={"tier2_backend": "none"})
     assert resp.status_code == 401
     wr.assert_not_called()
-    run.assert_not_called()
+    en.assert_not_called()
+    sch.assert_not_called()
 
 
 # ── POST validation ───────────────────────────────────────────────────
 def test_set_rejects_bad_backend(client):
-    with (
-        patch(f"{_SEC}._key_value", return_value=""),
-        patch(f"{_SEC}._update_secrets_file") as wr,
-    ):
+    with patch(f"{_SEC}._key_value", return_value=""):
         resp = client.post("/api/genesis/backup/config",
                            json={"tier2_backend": "ftp"})
     assert resp.status_code == 422
     assert any("tier2_backend" in e for e in resp.get_json()["details"])
-    wr.assert_not_called()
 
 
 def test_set_smb_requires_nas(client):
@@ -90,16 +238,16 @@ def test_set_smb_requires_nas(client):
     assert any("NAS" in e for e in resp.get_json()["details"])
 
 
-def test_set_rejects_bad_nas_and_cron(client):
-    with patch(f"{_SEC}._key_value", return_value=""):
+def test_set_rejects_bad_interval(client):
+    with (
+        patch(f"{_SEC}._key_value", return_value=""),
+        patch(f"{_BK}._set_timer_enabled") as en,
+    ):
         resp = client.post("/api/genesis/backup/config", json={
-            "tier2_backend": "smb", "nas": "not-a-share",
-            "schedule": "every 6 hours", "schedule_enabled": True,
-        })
-    details = resp.get_json()["details"]
+            "schedule_enabled": True, "schedule_interval": "7h"})
     assert resp.status_code == 422
-    assert any("nas must look like" in e for e in details)
-    assert any("cron" in e for e in details)
+    assert any("schedule_interval" in e for e in resp.get_json()["details"])
+    en.assert_not_called()
 
 
 def test_set_rejects_bad_repo(client):
@@ -110,61 +258,55 @@ def test_set_rejects_bad_repo(client):
 
 
 # ── POST happy paths ──────────────────────────────────────────────────
-def test_set_writes_env_and_installs_cron(client):
+def test_set_writes_env_and_enables_timer(client):
     with (
         patch(f"{_SEC}._key_value", return_value=""),
         patch(f"{_SEC}._update_secrets_file") as wr,
-        patch(f"{_BK}.subprocess.run", return_value=_ok_proc("")) as run,
+        patch(f"{_BK}._set_timer_schedule", return_value=True) as sch,
+        patch(f"{_BK}._set_timer_enabled", return_value=True) as en,
         patch.dict("os.environ", {}, clear=False),
     ):
         resp = client.post("/api/genesis/backup/config", json={
             "repo": "https://github.com/u/backups.git",
             "tier2_backend": "local", "local_path": "/mnt/bk",
-            "schedule": "0 */6 * * *", "schedule_enabled": True,
+            "schedule_interval": "12h", "schedule_enabled": True,
         })
     assert resp.status_code == 200
     written = wr.call_args.args[0]
     assert written["GENESIS_BACKUP_REPO"] == "https://github.com/u/backups.git"
     assert written["GENESIS_BACKUP_TIER2_BACKEND"] == "local"
-    assert written["GENESIS_BACKUP_LOCAL_PATH"] == "/mnt/bk"
-    # Cron written via `crontab -` (constant argv); the schedule appears only in
-    # the stdin content, never on a command line.
-    write_call = run.call_args                  # last call = the write
-    assert write_call.args[0] == ["crontab", "-"]
-    assert "0 */6 * * *" in write_call.kwargs["input"]
-    assert "backup.sh" in write_call.kwargs["input"]
+    sch.assert_called_once_with("12h")
+    en.assert_called_once_with(True)
+    assert resp.get_json()["schedule"] == "enabled"
 
 
-def test_set_schedule_disabled_removes_cron(client):
-    # Existing crontab has an unrelated entry + the backup line; remove must
-    # drop only the backup line and preserve the other.
-    read = _ok_proc("0 5 * * * /h/inbox_sync.sh\n"
-                    "0 */6 * * * /h/genesis/scripts/backup.sh >> /l 2>&1")
+def test_set_schedule_disabled_skips_interval_and_disables(client):
+    """M2: turning the schedule OFF must NOT validate the interval (a host on a
+    'custom' schedule must still be able to disable) — only disable the timer."""
     with (
         patch(f"{_SEC}._key_value", return_value=""),
         patch(f"{_SEC}._update_secrets_file"),
-        patch(f"{_BK}.subprocess.run", side_effect=[read, _ok_proc("")]) as run,
+        patch(f"{_BK}._set_timer_schedule") as sch,
+        patch(f"{_BK}._set_timer_enabled", return_value=True) as en,
         patch.dict("os.environ", {}, clear=False),
     ):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"schedule_enabled": False})
+        resp = client.post("/api/genesis/backup/config", json={
+            "schedule_enabled": False, "schedule_interval": "7h"})  # bad interval ignored
     assert resp.status_code == 200
-    write_call = run.call_args_list[1]
-    assert write_call.args[0] == ["crontab", "-"]
-    inp = write_call.kwargs["input"]
-    assert "inbox_sync" in inp and "backup.sh" not in inp
+    sch.assert_not_called()
+    en.assert_called_once_with(False)
+    assert resp.get_json()["schedule"] == "disabled"
 
 
 def test_set_secrets_only_written_when_provided(client):
     with (
         patch(f"{_SEC}._key_value", return_value=""),
         patch(f"{_SEC}._update_secrets_file") as wr,
-        patch(f"{_BK}.subprocess.run", return_value=_ok_proc()),
+        patch(f"{_BK}._set_timer_enabled", return_value=True),
         patch.dict("os.environ", {}, clear=False),
     ):
         client.post("/api/genesis/backup/config", json={
-            "passphrase": "s3cret", "schedule_enabled": False,
-        })
+            "passphrase": "s3cret", "schedule_enabled": False})
     written = wr.call_args.args[0]
     assert written.get("GENESIS_BACKUP_PASSPHRASE") == "s3cret"
     assert "GENESIS_BACKUP_NAS_PASS" not in written
@@ -176,25 +318,24 @@ def test_set_warns_on_passphrase_rotation(client):
     with (
         patch(f"{_SEC}._key_value", side_effect=keyval),
         patch(f"{_SEC}._update_secrets_file"),
-        patch(f"{_BK}.subprocess.run", return_value=_ok_proc()),
+        patch(f"{_BK}._set_timer_enabled", return_value=True),
         patch.dict("os.environ", {}, clear=False),
     ):
         resp = client.post("/api/genesis/backup/config",
                            json={"passphrase": "new-pass", "schedule_enabled": False})
-    warnings = resp.get_json()["warnings"]
-    assert any("re-encrypt" in w for w in warnings)
+    assert any("re-encrypt" in w for w in resp.get_json()["warnings"])
 
 
-def test_set_cron_failure_returns_500(client):
+def test_set_timer_enable_failure_returns_500(client):
     with (
         patch(f"{_SEC}._key_value", return_value=""),
         patch(f"{_SEC}._update_secrets_file"),
-        patch(f"{_BK}.subprocess.run",
-              return_value=_ok_proc(returncode=2, stderr="bad cron")),
+        patch(f"{_BK}._set_timer_schedule", return_value=True),
+        patch(f"{_BK}._set_timer_enabled", return_value=False),
         patch.dict("os.environ", {}, clear=False),
     ):
         resp = client.post("/api/genesis/backup/config",
-                           json={"schedule": "0 */6 * * *", "schedule_enabled": True})
+                           json={"schedule_interval": "6h", "schedule_enabled": True})
     assert resp.status_code == 500
 
 
@@ -211,19 +352,19 @@ def test_get_config_strips_creds_and_gates_nas(client):
     }
     with (
         patch(f"{_SEC}._key_value", side_effect=lambda k: values.get(k, "")),
-        patch(f"{_BK}.subprocess.run",
-              return_value=_ok_proc("0 */6 * * * /h/genesis/scripts/backup.sh >> x 2>&1")),
+        patch(f"{_BK}._timer_state", return_value={
+            "mechanism": "systemd-timer", "enabled": True, "active": True,
+            "next_run": None, "last_trigger": None, "interval": "6h"}),
         patch(f"{_BK}.is_authenticated", return_value=False),
     ):
         resp = client.get("/api/genesis/backup/config")
     data = resp.get_json()
-    # Token stripped; raw secrets never returned; auth-gated fields absent.
     assert data["repo"] == "https://github.com/u/r.git"
     assert "pp" not in str(data) and "np" not in str(data)
     assert data["passphrase_set"] is True and data["nas_pass_set"] is True
     # Infra paths/shares are auth-gated — absent for unauthenticated callers.
     assert "nas" not in data and "nas_user" not in data and "local_path" not in data
-    assert data["schedule"] == "0 */6 * * *" and data["schedule_enabled"] is True
+    assert data["schedule_interval"] == "6h" and data["schedule_enabled"] is True
 
 
 def test_get_config_returns_nas_when_authenticated(client):
@@ -233,7 +374,9 @@ def test_get_config_returns_nas_when_authenticated(client):
     }
     with (
         patch(f"{_SEC}._key_value", side_effect=lambda k: values.get(k, "")),
-        patch(f"{_BK}.subprocess.run", return_value=_ok_proc("")),
+        patch(f"{_BK}._timer_state", return_value={
+            "mechanism": "systemd-timer", "enabled": False, "active": False,
+            "next_run": None, "last_trigger": None, "interval": None}),
         patch(f"{_BK}.is_authenticated", return_value=True),
     ):
         resp = client.get("/api/genesis/backup/config")
@@ -242,17 +385,109 @@ def test_get_config_returns_nas_when_authenticated(client):
     assert data["local_path"] == "/mnt/bk"
 
 
-# ── Secrets-UI masking (the `_SENSITIVE_RE` change) ──────────────────────────
+# ── GET status: destinations + allowlist ──────────────────────────────
+def _status_env(tmp_path, status: dict, authed=True):
+    """Patch the status route's filesystem deps to a controlled fixture."""
+    from genesis.dashboard.routes import backup as bk
+    sf = tmp_path / "backup_status.json"
+    import json
+    sf.write_text(json.dumps(status))
+    return (
+        patch.object(bk, "_STATUS_FILE", sf),
+        patch.object(bk, "_BACKUP_SCRIPT", tmp_path / "backup.sh"),
+        patch.object(bk, "_BACKUP_DIR", tmp_path / "nope"),  # not a dir → repo None
+        patch(f"{_BK}._timer_state", return_value={
+            "mechanism": "systemd-timer", "enabled": True, "active": True,
+            "next_run": "x", "last_trigger": "y", "interval": "6h"}),
+        patch(f"{_BK}.is_authenticated", return_value=authed),
+    )
 
+
+def test_status_builds_destinations_and_schedule(client, tmp_path):
+    status = {
+        "timestamp": "2026-07-10T16:05:26Z", "success": True, "duration_s": 325,
+        "sqlite_lines": 599261, "qdrant_collections": 2, "transcript_files": 859,
+        "memory_files": 409, "secrets_encrypted": True, "failure_reason": "",
+        "tier2_status": "ok", "offsite_confirmed": True, "tier2_backend": "smb",
+        "snapshot_id": "20260710T160526Z", "snapshot_count": 17,
+        "pruned_count": 1, "tier1_pushed": True,
+    }
+    patches = _status_env(tmp_path, status, authed=True)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+            patch(f"{_SEC}._key_value", side_effect=lambda k:
+                  "//host/share" if k == "GENESIS_BACKUP_NAS" else ""):
+        resp = client.get("/api/genesis/backup/status")
+    data = resp.get_json()
+    assert "cron_schedule" not in data
+    assert data["schedule"]["interval"] == "6h"
+    d = data["destinations"]
+    assert d["tier2"]["backend"] == "smb" and d["tier2"]["confirmed"] is True
+    assert d["tier2"]["snapshot_count"] == 17
+    # Authenticated → NAS target visible.
+    assert d["tier2"]["target"] == "//host/share"
+    assert d["tier1"]["pushed"] is True
+
+
+def test_status_hides_nas_target_when_unauthenticated(client, tmp_path):
+    status = {"timestamp": "t", "success": True, "tier2_status": "ok",
+              "offsite_confirmed": True, "tier2_backend": "smb",
+              "snapshot_id": "s", "snapshot_count": 3, "tier1_pushed": True}
+    patches = _status_env(tmp_path, status, authed=False)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+            patch(f"{_SEC}._key_value", side_effect=lambda k:
+                  "//secret-host/share" if k == "GENESIS_BACKUP_NAS" else ""):
+        resp = client.get("/api/genesis/backup/status")
+    data = resp.get_json()
+    assert "target" not in data["destinations"]["tier2"]
+    # The NAS host must never appear anywhere in an unauthenticated response.
+    assert "secret-host" not in str(data)
+
+
+def test_status_allowlists_last_backup_fields(client, tmp_path):
+    """M6: a future/unknown field in the status file must NOT auto-leak through
+    the unauthenticated /status route — last_backup is projected to a known set."""
+    status = {"timestamp": "t", "success": True, "duration_s": 1,
+              "tier2_status": "ok", "offsite_confirmed": True,
+              "_leaked_nas_path": "//private-nas/secret-share"}
+    patches = _status_env(tmp_path, status, authed=False)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+            patch(f"{_SEC}._key_value", return_value=""):
+        resp = client.get("/api/genesis/backup/status")
+    data = resp.get_json()
+    assert "_leaked_nas_path" not in data["last_backup"]
+    assert "private-nas" not in str(data)
+
+
+# ── /trigger uses the service (non-blocking) ──────────────────────────
+def test_trigger_starts_service_no_block(client, tmp_path):
+    from genesis.dashboard.routes import backup as bk
+    script = tmp_path / "backup.sh"
+    script.write_text("#!/bin/bash\n")
+    with (
+        patch.object(bk, "_BACKUP_SCRIPT", script),
+        patch(f"{_BK}.subprocess.run", return_value=_proc("")) as run,
+    ):
+        resp = client.post("/api/genesis/backup/trigger")
+    assert resp.status_code == 200
+    argv = run.call_args.args[0]
+    # Type=oneshot: a plain `start` blocks ~325s until the backup finishes —
+    # --no-block returns immediately so the request thread never hangs.
+    assert "start" in argv and "--no-block" in argv
+    assert bk._SERVICE_UNIT in argv
+
+
+def test_trigger_missing_script_404(client, tmp_path):
+    from genesis.dashboard.routes import backup as bk
+    with patch.object(bk, "_BACKUP_SCRIPT", tmp_path / "absent.sh"):
+        resp = client.post("/api/genesis/backup/trigger")
+    assert resp.status_code == 404
+
+
+# ── Secrets-UI masking (unchanged secrets.py guard) ───────────────────
 def test_sensitive_re_masks_backup_nas_pass():
-    """The NAS password (and passphrase) render masked in the Secrets UI, while
-    the non-secret backup config fields stay visible. Guards the `_SENSITIVE_RE`
-    `_PASS` addition that this PR introduced."""
     from genesis.dashboard.routes.secrets import _SENSITIVE_RE
-
     assert _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_PASS")
     assert _SENSITIVE_RE.search("GENESIS_BACKUP_PASSPHRASE")
-    # Non-secret destination fields must NOT be masked (users need to see them).
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_SHARE")
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_USER")
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_LOCAL_PATH")

--- a/tests/test_scripts/test_backup_dr_signal.py
+++ b/tests/test_scripts/test_backup_dr_signal.py
@@ -153,6 +153,33 @@ def test_local_only_not_configured_no_alert(backup_env):
     assert not tg.strip(), f"local-only must not alert:\n{tg}"
 
 
+def test_status_enrichment_fields_nas_ok(backup_env):
+    """The dashboard reads these fields — assert the real script writes them with
+    the right JSON types on a successful two-tier run (guards the enriched
+    ``_write_status`` heredoc: counts are ints, not the ``null`` default)."""
+    proc, status, _ = _run(backup_env, smb_rc=0, nas=True)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert status["tier2_backend"] == "smb", status
+    # snapshot_id is this run's UTC stamp (YYYYMMDDTHHMMSSZ).
+    assert len(status["snapshot_id"]) == 16 and status["snapshot_id"].endswith("Z"), status
+    # GFS block ran (tier2 ok) → counts are integers (0 here: the smbclient stub
+    # lists nothing), NEVER null and NEVER the wc -l off-by-one 1.
+    assert status["snapshot_count"] == 0 and isinstance(status["snapshot_count"], int), status
+    assert status["pruned_count"] == 0 and isinstance(status["pruned_count"], int), status
+    assert status["tier1_pushed"] is True, status
+
+
+def test_status_enrichment_fields_local_only(backup_env):
+    """No off-site backend → snapshot bookkeeping stays JSON ``null`` (honest
+    'unknown', not 0), backend is 'none', but Tier-1 still pushed."""
+    proc, status, _ = _run(backup_env, nas=False)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert status["tier2_backend"] == "none", status
+    assert status["snapshot_id"] == "", status
+    assert status["snapshot_count"] is None and status["pruned_count"] is None, status
+    assert status["tier1_pushed"] is True, status
+
+
 def test_complete_marker_failure_is_offsite_failure(backup_env):
     """If payloads upload but the COMPLETE marker fails, restore would skip the
     snapshot — so it must report partial + offsite_confirmed:false + alert, not ok."""


### PR DESCRIPTION
## Why

The dashboard **Backup tab misreported backup state** — showing "Not scheduled" while backups actually ran and succeeded every 6h on both tiers. Root cause: `genesis-server.service` runs `NoNewPrivileges=yes`, which neutralizes the setgid `crontab` binary, so `crontab -l` returns *Permission denied* from inside the service. The crontab **read and write** paths were both silently dead.

PR #907 already established the policy (systemd `genesis-backup.timer`, installed-but-disabled) and removed crontab from onboarding — but never migrated the dashboard. **This completes #907**: the tab now drives the timer over `systemctl --user` (D-Bus, unaffected by `NoNewPrivileges` — the same path `services.py` uses), and finally answers the four questions the old tab couldn't: *is it running, where, on what schedule, what can I change.*

## What changed

**Route (`backup.py`)** — crontab helpers → `_timer_state` / `_set_timer_schedule` (OnCalendar drop-in with an additive-reset) / `_set_timer_enabled`:
- `GET /status`: drops `cron_schedule`; adds `schedule` (timer state) + `destinations` (Tier-1 GitHub + Tier-2 off-site health). `last_backup` is **allowlist-projected** so a future status field can't auto-leak through this unauthenticated route; the off-site target is auth-gated.
- `GET/POST /config`: preset `schedule_interval` (3h/6h/12h/daily) + on/off. Disable path skips interval validation.
- `POST /trigger`: `systemctl --user start --no-block genesis-backup.service` — same unit the timer fires (fixes a latent bug where an in-process `bash backup.sh` under the hardened server namespace would break gpg/tmp), and `--no-block` avoids the `Type=oneshot` blocking-start hang.

**Script (`backup.sh`)** — `_write_status` enriched: `tier2_backend`, `snapshot_id`, `snapshot_count`, `pruned_count` (JSON `null` until the GFS prune runs), `tier1_pushed`.

**Frontend** — health headline, at-a-glance schedule line, a **destinations block that makes the off-site NAS visible** (backend, retained-snapshot count, latest id; target only when authenticated), preset-interval dropdown + toggle. Redundant read-only card removed.

**Docs** — SETUP.md: dashboard-managed timer + legacy-crontab removal note.

## Testing

- `test_backup_config_api.py` (28): timer helpers, drop-in reset, calendar-map lockstep guard, enable/disable asymmetry, `/status` destinations + allowlist + unauth NAS-hiding, `/trigger --no-block`.
- `test_backup_dr_signal.py` (8, real script): enriched status fields — int counts on the NAS path, `null` on local-only, `tier1_pushed`.
- genesis-architect: GO. Independent code review: clean. Live read-path verified against the real timer.

## Host cutover (post-merge, separate step)

Enable the timer + remove the one leftover `backup.sh` crontab line so the two schedulers don't double-fire. Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)