### PR TITLE
fix(backup): resolve Tier-2 backend via backward-compat (NAS-only → smb)

### DIFF
--- a/src/genesis/dashboard/routes/backup.py
+++ b/src/genesis/dashboard/routes/backup.py
@@ -42,10 +42,7 @@ _BACKUP_DIR = _HOME / "backups" / "genesis-backups"
 # Systemd user units (source of truth for the backup schedule).
 _TIMER_UNIT = "genesis-backup.timer"
 _SERVICE_UNIT = "genesis-backup.service"
-_TIMER_DROPIN = (
-    _HOME / ".config" / "systemd" / "user"
-    / "genesis-backup.timer.d" / "schedule.conf"
-)
+_TIMER_DROPIN = _HOME / ".config" / "systemd" / "user" / "genesis-backup.timer.d" / "schedule.conf"
 
 # Preset schedules exposed by the dashboard. The value is the SHORT OnCalendar
 # spec we write into the drop-in; systemd normalises it on load to the long form
@@ -69,12 +66,26 @@ _CALENDAR_TO_INTERVAL = {
 # it through this allowlist so a future field added to backup.sh's status line
 # (e.g. an infra path) can never auto-leak. The raw off-site TARGET is
 # deliberately NOT here — it comes from /config's auth-gated _key_value instead.
-_STATUS_SAFE_FIELDS = frozenset({
-    "timestamp", "success", "sqlite_lines", "qdrant_collections",
-    "transcript_files", "memory_files", "secrets_encrypted", "duration_s",
-    "failure_reason", "tier2_status", "offsite_confirmed", "tier2_backend",
-    "snapshot_id", "snapshot_count", "pruned_count", "tier1_pushed",
-})
+_STATUS_SAFE_FIELDS = frozenset(
+    {
+        "timestamp",
+        "success",
+        "sqlite_lines",
+        "qdrant_collections",
+        "transcript_files",
+        "memory_files",
+        "secrets_encrypted",
+        "duration_s",
+        "failure_reason",
+        "tier2_status",
+        "offsite_confirmed",
+        "tier2_backend",
+        "snapshot_id",
+        "snapshot_count",
+        "pruned_count",
+        "tier1_pushed",
+    }
+)
 
 _BACKENDS = {"none", "local", "smb"}
 _NAS_RE = re.compile(r"^//[^/\s]+/[^\s]+$")
@@ -83,6 +94,7 @@ _ONCALENDAR_RE = re.compile(r"OnCalendar=(.+?)\s*;")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
+
 
 def _strip_url_creds(url: str | None) -> str | None:
     """Remove any embedded ``user:token@`` from an http(s) URL.
@@ -112,7 +124,10 @@ def _systemctl(*args: str, timeout: int = 5):
     try:
         return subprocess.run(
             ["systemctl", "--user", *args],
-            capture_output=True, text=True, timeout=timeout, env=systemctl_env(),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=systemctl_env(),
         )
     except (subprocess.TimeoutExpired, OSError):
         return None
@@ -150,8 +165,12 @@ def _timer_state() -> dict:
     than raising — the status route must never 500 on a schedule probe.
     """
     state = {
-        "mechanism": "systemd-timer", "enabled": False, "active": False,
-        "next_run": None, "last_trigger": None, "interval": None,
+        "mechanism": "systemd-timer",
+        "enabled": False,
+        "active": False,
+        "next_run": None,
+        "last_trigger": None,
+        "interval": None,
     }
     r = _systemctl("is-enabled", _TIMER_UNIT)
     if r is not None:
@@ -159,10 +178,16 @@ def _timer_state() -> dict:
     r = _systemctl("is-active", _TIMER_UNIT)
     if r is not None:
         state["active"] = r.stdout.strip() == "active"
-    r = _systemctl("show", _TIMER_UNIT,
-                   "-p", "NextElapseUSecRealtime",
-                   "-p", "LastTriggerUSec",
-                   "-p", "TimersCalendar")
+    r = _systemctl(
+        "show",
+        _TIMER_UNIT,
+        "-p",
+        "NextElapseUSecRealtime",
+        "-p",
+        "LastTriggerUSec",
+        "-p",
+        "TimersCalendar",
+    )
     if r is not None and r.returncode == 0:
         props = _parse_show(r.stdout)
         state["next_run"] = props.get("NextElapseUSecRealtime") or None
@@ -185,9 +210,7 @@ def _set_timer_schedule(interval_key: str) -> bool:
         return False
     try:
         _TIMER_DROPIN.parent.mkdir(parents=True, exist_ok=True)
-        _TIMER_DROPIN.write_text(
-            f"[Timer]\nOnCalendar=\nOnCalendar={calendar}\n"
-        )
+        _TIMER_DROPIN.write_text(f"[Timer]\nOnCalendar=\nOnCalendar={calendar}\n")
     except OSError:
         logger.error("Failed to write backup timer drop-in", exc_info=True)
         return False
@@ -212,11 +235,33 @@ def _backup_repo_url() -> str | None:
     try:
         remote = subprocess.run(
             ["git", "-C", str(_BACKUP_DIR), "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
     except (subprocess.TimeoutExpired, OSError):
         return None
     return _strip_url_creds(remote.stdout.strip()) if remote.returncode == 0 else None
+
+
+def _resolved_backend() -> str:
+    """The active Tier-2 backend, replicating ``backup_backends.sh`` resolution.
+
+    An explicit ``GENESIS_BACKUP_TIER2_BACKEND`` wins; otherwise a configured
+    ``GENESIS_BACKUP_NAS`` with no selector means ``smb`` (the documented
+    backward-compat, ``scripts/lib/backup_backends.sh:_backend_resolve``); else
+    ``none``. Without this, a NAS-only install (the common legacy setup) reads as
+    ``none`` in the UI even while off-site backups succeed — and a config save
+    would then write ``TIER2_BACKEND=none`` and silently disable them.
+    """
+    from genesis.dashboard.routes.secrets import _key_value
+
+    b = (_key_value("GENESIS_BACKUP_TIER2_BACKEND") or "").strip()
+    if b:
+        return b
+    if (_key_value("GENESIS_BACKUP_NAS") or "").strip():
+        return "smb"
+    return "none"
 
 
 def _destinations(status: dict | None, repo: str | None) -> dict:
@@ -236,8 +281,7 @@ def _destinations(status: dict | None, repo: str | None) -> dict:
         "pushed": status.get("tier1_pushed"),
         "last": status.get("timestamp"),
     }
-    backend = (status.get("tier2_backend")
-               or _key_value("GENESIS_BACKUP_TIER2_BACKEND") or "none")
+    backend = status.get("tier2_backend") or _resolved_backend()
     tier2 = {
         "backend": backend,
         "status": status.get("tier2_status"),
@@ -247,14 +291,14 @@ def _destinations(status: dict | None, repo: str | None) -> dict:
     }
     if is_authenticated():
         if backend == "smb":
-            tier2["target"] = _strip_url_creds(
-                _key_value("GENESIS_BACKUP_NAS")) or None
+            tier2["target"] = _strip_url_creds(_key_value("GENESIS_BACKUP_NAS")) or None
         elif backend == "local":
             tier2["target"] = _key_value("GENESIS_BACKUP_LOCAL_PATH") or None
     return {"tier1": tier1, "tier2": tier2}
 
 
 # ── Routes ────────────────────────────────────────────────────────────
+
 
 @blueprint.route("/api/genesis/backup/status")
 def backup_status():
@@ -275,8 +319,7 @@ def backup_status():
             if isinstance(raw, dict):
                 # Allowlist projection — a future field in backup.sh's status
                 # line cannot auto-leak through this unauthenticated route.
-                last_backup = {k: v for k, v in raw.items()
-                               if k in _STATUS_SAFE_FIELDS}
+                last_backup = {k: v for k, v in raw.items() if k in _STATUS_SAFE_FIELDS}
         except (json.JSONDecodeError, OSError):
             last_backup = None
     result["last_backup"] = last_backup
@@ -302,7 +345,7 @@ def backup_config_get():
     timer = _timer_state()
     result = {
         "repo": _strip_url_creds(_key_value("GENESIS_BACKUP_REPO")),
-        "tier2_backend": _key_value("GENESIS_BACKUP_TIER2_BACKEND") or "none",
+        "tier2_backend": _resolved_backend(),
         "schedule_enabled": timer["enabled"],
         # Preset key ("6h"/…), "custom" for a hand-edited OnCalendar, or None.
         "schedule_interval": timer["interval"],
@@ -392,9 +435,7 @@ def backup_config_set():
     # Cross-field: a selected backend needs its destination (new or already set).
     if backend == "smb" and not (nas or _key_value("GENESIS_BACKUP_NAS")):
         errors.append("smb backend requires a NAS share (//host/share)")
-    if backend == "local" and not (
-        local_path or _key_value("GENESIS_BACKUP_LOCAL_PATH")
-    ):
+    if backend == "local" and not (local_path or _key_value("GENESIS_BACKUP_LOCAL_PATH")):
         errors.append("local backend requires a local_path")
 
     # Secrets — only written when a non-empty value is supplied, so leaving the
@@ -430,10 +471,7 @@ def backup_config_set():
         if data.get("schedule_enabled", True):
             interval = (data.get("schedule_interval") or "").strip()
             if interval and interval not in _INTERVAL_TO_CALENDAR:
-                errors.append(
-                    "schedule_interval must be one of "
-                    f"{sorted(_INTERVAL_TO_CALENDAR)}"
-                )
+                errors.append(f"schedule_interval must be one of {sorted(_INTERVAL_TO_CALENDAR)}")
             else:
                 schedule_action = ("enable", interval or None)
         else:
@@ -458,29 +496,35 @@ def backup_config_set():
             # Write the schedule (if the user picked one) BEFORE enabling, so the
             # daemon-reload's recompute is already in place when the timer starts.
             if interval and not _set_timer_schedule(interval):
-                return jsonify(
-                    {"error": "Failed to write backup schedule (drop-in)"}), 500
+                return jsonify({"error": "Failed to write backup schedule (drop-in)"}), 500
             if not _set_timer_enabled(True):
                 return jsonify(
-                    {"error": "Schedule written but failed to enable the backup "
-                              "timer — retry, or check `systemctl --user status "
-                              "genesis-backup.timer`"}), 500
+                    {
+                        "error": "Schedule written but failed to enable the backup "
+                        "timer — retry, or check `systemctl --user status "
+                        "genesis-backup.timer`"
+                    }
+                ), 500
             schedule_result = "enabled"
         else:
             if not _set_timer_enabled(False):
                 return jsonify({"error": "Failed to disable the backup timer"}), 500
             schedule_result = "disabled"
 
-    logger.info("Backup config updated: keys=%s schedule=%s",
-                sorted(env_updates.keys()),
-                schedule_action[0] if schedule_action else None)
-    return jsonify({
-        "status": "ok",
-        "updated": sorted(env_updates.keys()),
-        "schedule": schedule_result,
-        "warnings": warnings,
-        "needs_restart": False,
-    })
+    logger.info(
+        "Backup config updated: keys=%s schedule=%s",
+        sorted(env_updates.keys()),
+        schedule_action[0] if schedule_action else None,
+    )
+    return jsonify(
+        {
+            "status": "ok",
+            "updated": sorted(env_updates.keys()),
+            "schedule": schedule_result,
+            "warnings": warnings,
+            "needs_restart": False,
+        }
+    )
 
 
 @blueprint.route("/api/genesis/backup/trigger", methods=["POST"])
@@ -499,7 +543,7 @@ def backup_trigger():
 
     r = _systemctl("start", "--no-block", _SERVICE_UNIT, timeout=10)
     if r is None or r.returncode != 0:
-        err = (r.stderr.strip() if r is not None else "systemctl unavailable")
+        err = r.stderr.strip() if r is not None else "systemctl unavailable"
         logger.error("Failed to start %s: %s", _SERVICE_UNIT, err)
         return jsonify({"error": err or "Failed to start backup service"}), 500
     logger.info("Manual backup triggered via %s", _SERVICE_UNIT)

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -1859,8 +1859,14 @@
           this.backupConfigMsg = null;
           try {
             const f = this.backupConfigForm;
-            const body = { tier2_backend: f.tier2_backend };
-            // The cron job is a stateful side-effect — only touch it when the
+            const body = {};
+            // Only send the backend when the user actually changed it — the
+            // loaded value may be a backward-compat resolution (NAS-only → smb);
+            // re-sending it unchanged would gratuitously pin an explicit selector.
+            if (f.tier2_backend !== (this.backupConfig?.tier2_backend || 'none')) {
+              body.tier2_backend = f.tier2_backend;
+            }
+            // The schedule is a stateful side-effect — only touch it when the
             // user actually changed the schedule controls.
             if (this.scheduleDirty) {
               body.schedule_interval = f.schedule_interval;

--- a/tests/test_dashboard/test_backup_config_api.py
+++ b/tests/test_dashboard/test_backup_config_api.py
@@ -50,10 +50,11 @@ def _authed():
 # ── _strip_url_creds ──────────────────────────────────────────────────
 def test_strip_url_creds_removes_token():
     from genesis.dashboard.routes.backup import _strip_url_creds
-    assert _strip_url_creds("https://user:ghp_tok@github.com/u/r.git") == \
-        "https://github.com/u/r.git"
-    assert _strip_url_creds("https://github.com/u/r.git") == \
-        "https://github.com/u/r.git"
+
+    assert (
+        _strip_url_creds("https://user:ghp_tok@github.com/u/r.git") == "https://github.com/u/r.git"
+    )
+    assert _strip_url_creds("https://github.com/u/r.git") == "https://github.com/u/r.git"
     assert _strip_url_creds("git@github.com:u/r.git") == "git@github.com:u/r.git"
     assert _strip_url_creds("") == ""
     assert _strip_url_creds(None) is None
@@ -62,15 +63,12 @@ def test_strip_url_creds_removes_token():
 # ── _interval_from_calendar (pure) ────────────────────────────────────
 def test_interval_from_calendar_maps_presets():
     from genesis.dashboard.routes.backup import _interval_from_calendar
-    assert _interval_from_calendar(
-        "{ OnCalendar=*-*-* 00/6:10:00 ; next_elapse=... }") == "6h"
-    assert _interval_from_calendar(
-        "{ OnCalendar=*-*-* 00/3:10:00 ; next_elapse=(null) }") == "3h"
-    assert _interval_from_calendar(
-        "{ OnCalendar=*-*-* 04:10:00 ; next_elapse=... }") == "daily"
+
+    assert _interval_from_calendar("{ OnCalendar=*-*-* 00/6:10:00 ; next_elapse=... }") == "6h"
+    assert _interval_from_calendar("{ OnCalendar=*-*-* 00/3:10:00 ; next_elapse=(null) }") == "3h"
+    assert _interval_from_calendar("{ OnCalendar=*-*-* 04:10:00 ; next_elapse=... }") == "daily"
     # Unrecognised OnCalendar → "custom"; absent → None.
-    assert _interval_from_calendar(
-        "{ OnCalendar=*-*-* 09:00:00 ; next_elapse=... }") == "custom"
+    assert _interval_from_calendar("{ OnCalendar=*-*-* 09:00:00 ; next_elapse=... }") == "custom"
     assert _interval_from_calendar("") is None
     assert _interval_from_calendar(None) is None
 
@@ -129,17 +127,23 @@ def test_timer_state_disabled_inactive():
 
 def test_timer_state_survives_systemctl_failure():
     from genesis.dashboard.routes.backup import _timer_state
+
     with patch(f"{_BK}.subprocess.run", side_effect=OSError("no systemctl")):
         st = _timer_state()
     assert st == {
-        "mechanism": "systemd-timer", "enabled": False, "active": False,
-        "next_run": None, "last_trigger": None, "interval": None,
+        "mechanism": "systemd-timer",
+        "enabled": False,
+        "active": False,
+        "next_run": None,
+        "last_trigger": None,
+        "interval": None,
     }
 
 
 # ── _set_timer_schedule (writes reset drop-in) ────────────────────────
 def test_set_timer_schedule_writes_reset_dropin(tmp_path):
     from genesis.dashboard.routes import backup as bk
+
     dropin = tmp_path / "genesis-backup.timer.d" / "schedule.conf"
     with (
         patch.object(bk, "_TIMER_DROPIN", dropin),
@@ -151,12 +155,15 @@ def test_set_timer_schedule_writes_reset_dropin(tmp_path):
     # additive base so the template's 6h schedule does not also fire.
     assert content == "[Timer]\nOnCalendar=\nOnCalendar=00/12:10\n"
     # daemon-reload issued after the write.
-    assert any(c.args[0][:4] == ["systemctl", "--user", "daemon-reload"]
-               or c.args[0][3] == "daemon-reload" for c in run.call_args_list)
+    assert any(
+        c.args[0][:4] == ["systemctl", "--user", "daemon-reload"] or c.args[0][3] == "daemon-reload"
+        for c in run.call_args_list
+    )
 
 
 def test_set_timer_schedule_rejects_unknown_interval(tmp_path):
     from genesis.dashboard.routes import backup as bk
+
     dropin = tmp_path / "schedule.conf"
     with (
         patch.object(bk, "_TIMER_DROPIN", dropin),
@@ -170,6 +177,7 @@ def test_set_timer_schedule_rejects_unknown_interval(tmp_path):
 # ── _set_timer_enabled ────────────────────────────────────────────────
 def test_set_timer_enabled_true_enables_now():
     from genesis.dashboard.routes import backup as bk
+
     with patch(f"{_BK}.subprocess.run", return_value=_proc("")) as run:
         assert bk._set_timer_enabled(True) is True
     argv = run.call_args.args[0]
@@ -179,6 +187,7 @@ def test_set_timer_enabled_true_enables_now():
 
 def test_set_timer_enabled_false_disables_now():
     from genesis.dashboard.routes import backup as bk
+
     with patch(f"{_BK}.subprocess.run", return_value=_proc("")) as run:
         assert bk._set_timer_enabled(False) is True
     argv = run.call_args.args[0]
@@ -186,23 +195,30 @@ def test_set_timer_enabled_false_disables_now():
 
 
 # ── M5: the two calendar maps stay in lockstep ────────────────────────
-@pytest.mark.skipif(shutil.which("systemd-analyze") is None,
-                    reason="systemd-analyze not available")
+@pytest.mark.skipif(shutil.which("systemd-analyze") is None, reason="systemd-analyze not available")
 def test_calendar_maps_are_consistent():
     """Every short OnCalendar we WRITE must normalise (per systemd) to exactly
     the long form we READ back — guards the two hand-maintained maps drifting."""
     from genesis.dashboard.routes.backup import _CALENDAR_TO_INTERVAL, _INTERVAL_TO_CALENDAR
+
     # Both maps describe the same 4 presets.
     assert set(_INTERVAL_TO_CALENDAR) == set(_CALENDAR_TO_INTERVAL.values())
     for key, short in _INTERVAL_TO_CALENDAR.items():
-        out = subprocess.run(["systemd-analyze", "calendar", short],
-                             capture_output=True, text=True, timeout=10)
-        norm = next((ln.split(":", 1)[1].strip()
-                     for ln in out.stdout.splitlines()
-                     if "Normalized form" in ln), None)
+        out = subprocess.run(
+            ["systemd-analyze", "calendar", short], capture_output=True, text=True, timeout=10
+        )
+        norm = next(
+            (
+                ln.split(":", 1)[1].strip()
+                for ln in out.stdout.splitlines()
+                if "Normalized form" in ln
+            ),
+            None,
+        )
         assert norm is not None, f"no normalized form for {short}"
         assert _CALENDAR_TO_INTERVAL.get(norm) == key, (
-            f"{short} normalises to {norm!r}; reverse-map disagrees")
+            f"{short} normalises to {norm!r}; reverse-map disagrees"
+        )
 
 
 # ── POST auth gate ────────────────────────────────────────────────────
@@ -213,8 +229,7 @@ def test_set_requires_auth(client):
         patch(f"{_BK}._set_timer_enabled") as en,
         patch(f"{_BK}._set_timer_schedule") as sch,
     ):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"tier2_backend": "none"})
+        resp = client.post("/api/genesis/backup/config", json={"tier2_backend": "none"})
     assert resp.status_code == 401
     wr.assert_not_called()
     en.assert_not_called()
@@ -224,16 +239,14 @@ def test_set_requires_auth(client):
 # ── POST validation ───────────────────────────────────────────────────
 def test_set_rejects_bad_backend(client):
     with patch(f"{_SEC}._key_value", return_value=""):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"tier2_backend": "ftp"})
+        resp = client.post("/api/genesis/backup/config", json={"tier2_backend": "ftp"})
     assert resp.status_code == 422
     assert any("tier2_backend" in e for e in resp.get_json()["details"])
 
 
 def test_set_smb_requires_nas(client):
     with patch(f"{_SEC}._key_value", return_value=""):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"tier2_backend": "smb"})
+        resp = client.post("/api/genesis/backup/config", json={"tier2_backend": "smb"})
     assert resp.status_code == 422
     assert any("NAS" in e for e in resp.get_json()["details"])
 
@@ -243,8 +256,9 @@ def test_set_rejects_bad_interval(client):
         patch(f"{_SEC}._key_value", return_value=""),
         patch(f"{_BK}._set_timer_enabled") as en,
     ):
-        resp = client.post("/api/genesis/backup/config", json={
-            "schedule_enabled": True, "schedule_interval": "7h"})
+        resp = client.post(
+            "/api/genesis/backup/config", json={"schedule_enabled": True, "schedule_interval": "7h"}
+        )
     assert resp.status_code == 422
     assert any("schedule_interval" in e for e in resp.get_json()["details"])
     en.assert_not_called()
@@ -252,8 +266,7 @@ def test_set_rejects_bad_interval(client):
 
 def test_set_rejects_bad_repo(client):
     with patch(f"{_SEC}._key_value", return_value=""):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"repo": "ftp://nope"})
+        resp = client.post("/api/genesis/backup/config", json={"repo": "ftp://nope"})
     assert resp.status_code == 422
 
 
@@ -266,11 +279,16 @@ def test_set_writes_env_and_enables_timer(client):
         patch(f"{_BK}._set_timer_enabled", return_value=True) as en,
         patch.dict("os.environ", {}, clear=False),
     ):
-        resp = client.post("/api/genesis/backup/config", json={
-            "repo": "https://github.com/u/backups.git",
-            "tier2_backend": "local", "local_path": "/mnt/bk",
-            "schedule_interval": "12h", "schedule_enabled": True,
-        })
+        resp = client.post(
+            "/api/genesis/backup/config",
+            json={
+                "repo": "https://github.com/u/backups.git",
+                "tier2_backend": "local",
+                "local_path": "/mnt/bk",
+                "schedule_interval": "12h",
+                "schedule_enabled": True,
+            },
+        )
     assert resp.status_code == 200
     written = wr.call_args.args[0]
     assert written["GENESIS_BACKUP_REPO"] == "https://github.com/u/backups.git"
@@ -290,8 +308,10 @@ def test_set_schedule_disabled_skips_interval_and_disables(client):
         patch(f"{_BK}._set_timer_enabled", return_value=True) as en,
         patch.dict("os.environ", {}, clear=False),
     ):
-        resp = client.post("/api/genesis/backup/config", json={
-            "schedule_enabled": False, "schedule_interval": "7h"})  # bad interval ignored
+        resp = client.post(
+            "/api/genesis/backup/config",
+            json={"schedule_enabled": False, "schedule_interval": "7h"},
+        )  # bad interval ignored
     assert resp.status_code == 200
     sch.assert_not_called()
     en.assert_called_once_with(False)
@@ -305,8 +325,9 @@ def test_set_secrets_only_written_when_provided(client):
         patch(f"{_BK}._set_timer_enabled", return_value=True),
         patch.dict("os.environ", {}, clear=False),
     ):
-        client.post("/api/genesis/backup/config", json={
-            "passphrase": "s3cret", "schedule_enabled": False})
+        client.post(
+            "/api/genesis/backup/config", json={"passphrase": "s3cret", "schedule_enabled": False}
+        )
     written = wr.call_args.args[0]
     assert written.get("GENESIS_BACKUP_PASSPHRASE") == "s3cret"
     assert "GENESIS_BACKUP_NAS_PASS" not in written
@@ -315,14 +336,16 @@ def test_set_secrets_only_written_when_provided(client):
 def test_set_warns_on_passphrase_rotation(client):
     def keyval(k):
         return "old-pass" if k == "GENESIS_BACKUP_PASSPHRASE" else ""
+
     with (
         patch(f"{_SEC}._key_value", side_effect=keyval),
         patch(f"{_SEC}._update_secrets_file"),
         patch(f"{_BK}._set_timer_enabled", return_value=True),
         patch.dict("os.environ", {}, clear=False),
     ):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"passphrase": "new-pass", "schedule_enabled": False})
+        resp = client.post(
+            "/api/genesis/backup/config", json={"passphrase": "new-pass", "schedule_enabled": False}
+        )
     assert any("re-encrypt" in w for w in resp.get_json()["warnings"])
 
 
@@ -334,8 +357,9 @@ def test_set_timer_enable_failure_returns_500(client):
         patch(f"{_BK}._set_timer_enabled", return_value=False),
         patch.dict("os.environ", {}, clear=False),
     ):
-        resp = client.post("/api/genesis/backup/config",
-                           json={"schedule_interval": "6h", "schedule_enabled": True})
+        resp = client.post(
+            "/api/genesis/backup/config", json={"schedule_interval": "6h", "schedule_enabled": True}
+        )
     assert resp.status_code == 500
 
 
@@ -352,9 +376,17 @@ def test_get_config_strips_creds_and_gates_nas(client):
     }
     with (
         patch(f"{_SEC}._key_value", side_effect=lambda k: values.get(k, "")),
-        patch(f"{_BK}._timer_state", return_value={
-            "mechanism": "systemd-timer", "enabled": True, "active": True,
-            "next_run": None, "last_trigger": None, "interval": "6h"}),
+        patch(
+            f"{_BK}._timer_state",
+            return_value={
+                "mechanism": "systemd-timer",
+                "enabled": True,
+                "active": True,
+                "next_run": None,
+                "last_trigger": None,
+                "interval": "6h",
+            },
+        ),
         patch(f"{_BK}.is_authenticated", return_value=False),
     ):
         resp = client.get("/api/genesis/backup/config")
@@ -369,14 +401,23 @@ def test_get_config_strips_creds_and_gates_nas(client):
 
 def test_get_config_returns_nas_when_authenticated(client):
     values = {
-        "GENESIS_BACKUP_NAS": "//host/share", "GENESIS_BACKUP_NAS_USER": "bk",
+        "GENESIS_BACKUP_NAS": "//host/share",
+        "GENESIS_BACKUP_NAS_USER": "bk",
         "GENESIS_BACKUP_LOCAL_PATH": "/mnt/bk",
     }
     with (
         patch(f"{_SEC}._key_value", side_effect=lambda k: values.get(k, "")),
-        patch(f"{_BK}._timer_state", return_value={
-            "mechanism": "systemd-timer", "enabled": False, "active": False,
-            "next_run": None, "last_trigger": None, "interval": None}),
+        patch(
+            f"{_BK}._timer_state",
+            return_value={
+                "mechanism": "systemd-timer",
+                "enabled": False,
+                "active": False,
+                "next_run": None,
+                "last_trigger": None,
+                "interval": None,
+            },
+        ),
         patch(f"{_BK}.is_authenticated", return_value=True),
     ):
         resp = client.get("/api/genesis/backup/config")
@@ -389,33 +430,61 @@ def test_get_config_returns_nas_when_authenticated(client):
 def _status_env(tmp_path, status: dict, authed=True):
     """Patch the status route's filesystem deps to a controlled fixture."""
     from genesis.dashboard.routes import backup as bk
+
     sf = tmp_path / "backup_status.json"
     import json
+
     sf.write_text(json.dumps(status))
     return (
         patch.object(bk, "_STATUS_FILE", sf),
         patch.object(bk, "_BACKUP_SCRIPT", tmp_path / "backup.sh"),
         patch.object(bk, "_BACKUP_DIR", tmp_path / "nope"),  # not a dir → repo None
-        patch(f"{_BK}._timer_state", return_value={
-            "mechanism": "systemd-timer", "enabled": True, "active": True,
-            "next_run": "x", "last_trigger": "y", "interval": "6h"}),
+        patch(
+            f"{_BK}._timer_state",
+            return_value={
+                "mechanism": "systemd-timer",
+                "enabled": True,
+                "active": True,
+                "next_run": "x",
+                "last_trigger": "y",
+                "interval": "6h",
+            },
+        ),
         patch(f"{_BK}.is_authenticated", return_value=authed),
     )
 
 
 def test_status_builds_destinations_and_schedule(client, tmp_path):
     status = {
-        "timestamp": "2026-07-10T16:05:26Z", "success": True, "duration_s": 325,
-        "sqlite_lines": 599261, "qdrant_collections": 2, "transcript_files": 859,
-        "memory_files": 409, "secrets_encrypted": True, "failure_reason": "",
-        "tier2_status": "ok", "offsite_confirmed": True, "tier2_backend": "smb",
-        "snapshot_id": "20260710T160526Z", "snapshot_count": 17,
-        "pruned_count": 1, "tier1_pushed": True,
+        "timestamp": "2026-07-10T16:05:26Z",
+        "success": True,
+        "duration_s": 325,
+        "sqlite_lines": 599261,
+        "qdrant_collections": 2,
+        "transcript_files": 859,
+        "memory_files": 409,
+        "secrets_encrypted": True,
+        "failure_reason": "",
+        "tier2_status": "ok",
+        "offsite_confirmed": True,
+        "tier2_backend": "smb",
+        "snapshot_id": "20260710T160526Z",
+        "snapshot_count": 17,
+        "pruned_count": 1,
+        "tier1_pushed": True,
     }
     patches = _status_env(tmp_path, status, authed=True)
-    with patches[0], patches[1], patches[2], patches[3], patches[4], \
-            patch(f"{_SEC}._key_value", side_effect=lambda k:
-                  "//host/share" if k == "GENESIS_BACKUP_NAS" else ""):
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            f"{_SEC}._key_value",
+            side_effect=lambda k: "//host/share" if k == "GENESIS_BACKUP_NAS" else "",
+        ),
+    ):
         resp = client.get("/api/genesis/backup/status")
     data = resp.get_json()
     assert "cron_schedule" not in data
@@ -429,13 +498,28 @@ def test_status_builds_destinations_and_schedule(client, tmp_path):
 
 
 def test_status_hides_nas_target_when_unauthenticated(client, tmp_path):
-    status = {"timestamp": "t", "success": True, "tier2_status": "ok",
-              "offsite_confirmed": True, "tier2_backend": "smb",
-              "snapshot_id": "s", "snapshot_count": 3, "tier1_pushed": True}
+    status = {
+        "timestamp": "t",
+        "success": True,
+        "tier2_status": "ok",
+        "offsite_confirmed": True,
+        "tier2_backend": "smb",
+        "snapshot_id": "s",
+        "snapshot_count": 3,
+        "tier1_pushed": True,
+    }
     patches = _status_env(tmp_path, status, authed=False)
-    with patches[0], patches[1], patches[2], patches[3], patches[4], \
-            patch(f"{_SEC}._key_value", side_effect=lambda k:
-                  "//secret-host/share" if k == "GENESIS_BACKUP_NAS" else ""):
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            f"{_SEC}._key_value",
+            side_effect=lambda k: "//secret-host/share" if k == "GENESIS_BACKUP_NAS" else "",
+        ),
+    ):
         resp = client.get("/api/genesis/backup/status")
     data = resp.get_json()
     assert "target" not in data["destinations"]["tier2"]
@@ -446,12 +530,23 @@ def test_status_hides_nas_target_when_unauthenticated(client, tmp_path):
 def test_status_allowlists_last_backup_fields(client, tmp_path):
     """M6: a future/unknown field in the status file must NOT auto-leak through
     the unauthenticated /status route — last_backup is projected to a known set."""
-    status = {"timestamp": "t", "success": True, "duration_s": 1,
-              "tier2_status": "ok", "offsite_confirmed": True,
-              "_leaked_nas_path": "//private-nas/secret-share"}
+    status = {
+        "timestamp": "t",
+        "success": True,
+        "duration_s": 1,
+        "tier2_status": "ok",
+        "offsite_confirmed": True,
+        "_leaked_nas_path": "//private-nas/secret-share",
+    }
     patches = _status_env(tmp_path, status, authed=False)
-    with patches[0], patches[1], patches[2], patches[3], patches[4], \
-            patch(f"{_SEC}._key_value", return_value=""):
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(f"{_SEC}._key_value", return_value=""),
+    ):
         resp = client.get("/api/genesis/backup/status")
     data = resp.get_json()
     assert "_leaked_nas_path" not in data["last_backup"]
@@ -461,6 +556,7 @@ def test_status_allowlists_last_backup_fields(client, tmp_path):
 # ── /trigger uses the service (non-blocking) ──────────────────────────
 def test_trigger_starts_service_no_block(client, tmp_path):
     from genesis.dashboard.routes import backup as bk
+
     script = tmp_path / "backup.sh"
     script.write_text("#!/bin/bash\n")
     with (
@@ -478,14 +574,85 @@ def test_trigger_starts_service_no_block(client, tmp_path):
 
 def test_trigger_missing_script_404(client, tmp_path):
     from genesis.dashboard.routes import backup as bk
+
     with patch.object(bk, "_BACKUP_SCRIPT", tmp_path / "absent.sh"):
         resp = client.post("/api/genesis/backup/trigger")
     assert resp.status_code == 404
 
 
+# ── Tier-2 backend resolution (backward-compat) ───────────────────────
+def test_resolved_backend_backward_compat():
+    """Mirrors backup_backends.sh:_backend_resolve — explicit selector wins;
+    NAS-only (no selector) → smb; nothing → none."""
+    from genesis.dashboard.routes import backup as bk
+
+    with patch(
+        f"{_SEC}._key_value",
+        side_effect=lambda k: "local" if k == "GENESIS_BACKUP_TIER2_BACKEND" else "",
+    ):
+        assert bk._resolved_backend() == "local"
+    with patch(
+        f"{_SEC}._key_value",
+        side_effect=lambda k: "//host/share" if k == "GENESIS_BACKUP_NAS" else "",
+    ):
+        assert bk._resolved_backend() == "smb"
+    with patch(f"{_SEC}._key_value", return_value=""):
+        assert bk._resolved_backend() == "none"
+
+
+def test_get_config_backend_backward_compat(client):
+    """A NAS-only install (no explicit selector) must report backend 'smb', not
+    'none' — otherwise the form misleads and a save could write TIER2_BACKEND=none
+    and silently disable off-site backups."""
+    values = {"GENESIS_BACKUP_NAS": "//host/share"}
+    with (
+        patch(f"{_SEC}._key_value", side_effect=lambda k: values.get(k, "")),
+        patch(
+            f"{_BK}._timer_state",
+            return_value={
+                "mechanism": "systemd-timer",
+                "enabled": True,
+                "active": True,
+                "next_run": None,
+                "last_trigger": None,
+                "interval": "6h",
+            },
+        ),
+        patch(f"{_BK}.is_authenticated", return_value=True),
+    ):
+        resp = client.get("/api/genesis/backup/config")
+    assert resp.get_json()["tier2_backend"] == "smb"
+
+
+def test_status_destinations_backend_backward_compat(client, tmp_path):
+    """When the status file predates tier2_backend, destinations still resolves
+    the backend via backward-compat (NAS set → smb), not 'none'."""
+    status = {
+        "timestamp": "t",
+        "success": True,
+        "tier2_status": "ok",
+        "offsite_confirmed": True,
+    }  # no tier2_backend field (old script)
+    patches = _status_env(tmp_path, status, authed=False)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            f"{_SEC}._key_value",
+            side_effect=lambda k: "//host/share" if k == "GENESIS_BACKUP_NAS" else "",
+        ),
+    ):
+        resp = client.get("/api/genesis/backup/status")
+    assert resp.get_json()["destinations"]["tier2"]["backend"] == "smb"
+
+
 # ── Secrets-UI masking (unchanged secrets.py guard) ───────────────────
 def test_sensitive_re_masks_backup_nas_pass():
     from genesis.dashboard.routes.secrets import _SENSITIVE_RE
+
     assert _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_PASS")
     assert _SENSITIVE_RE.search("GENESIS_BACKUP_PASSPHRASE")
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_SHARE")


### PR DESCRIPTION
## Why

Follow-up to #1004, found during live E2E. A NAS-only install — `GENESIS_BACKUP_NAS` set with **no** explicit `GENESIS_BACKUP_TIER2_BACKEND` selector, the common legacy setup — resolves to `smb` in `backup_backends.sh` (`_backend_resolve`), but the dashboard read the selector env directly and reported backend **`none`**.

Two problems:
1. **Misreport** — the off-site destination showed "Not configured" even though NAS backups succeed (exactly the "where do backups actually go" confusion this work set out to fix).
2. **Footgun** — the config form loaded `none`, and since `saveBackupConfig` always sent `tier2_backend`, a save could write `GENESIS_BACKUP_TIER2_BACKEND=none` and **silently disable off-site backups**.

## Fix

- `_resolved_backend()` mirrors `backup_backends.sh:_backend_resolve` (explicit selector wins; NAS-only → `smb`; else `none`). Used by `/config` GET and `_destinations`' fallback. The status-file `tier2_backend` still wins once the enriched script has run — this covers the config dropdown and the pre-first-run window.
- `saveBackupConfig` only sends `tier2_backend` when the user actually changed it, so a plain save no longer pins an explicit selector over the backward-compat resolution.

## Tests

`test_resolved_backend_backward_compat`, `test_get_config_backend_backward_compat`, `test_status_destinations_backend_backward_compat` (31 pass total). Verified live: after the first enriched backup run, `/status` shows `tier2.backend: "smb"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)