### PR TITLE
feat(observability): surface Model Fusion (deliberate) on the neural monitor

### DIFF
--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -466,6 +466,10 @@ const SITE_META = {
         name: 'G. Background', desc: 'Autonomous background sessions for reflections, inbox, and surplus tasks.',
         category: 'core', frequency: 'On demand', costPolicy: 'Subscription',
     },
+    'model_fusion': {
+        name: 'Fusion', desc: 'On-demand panel-of-models consult (OpenRouter Fusion) — synthesized verdict plus explicit dissent for high-stakes decisions. Invoked via the deliberate MCP tool.',
+        category: 'reasoning', frequency: 'On demand (opt-in)', costPolicy: 'Paid (OpenRouter Fusion)',
+    },
     // ── Routing call sites — name + category only (desc/frequency/costPolicy from backend) ──
     '3_micro_reflection': { name: 'Micro Reflect', category: 'reflection' },
     '4_light_reflection': { name: 'Light Reflect', category: 'reflection' },
@@ -1905,6 +1909,11 @@ const SUBSYSTEM_GROUPS = {
                 '11_user_model_synthesis', '18_meta_prompting', '22_tagging',
                 '28_observation_sweep', '34_research_synthesis', '35_content_draft'],
     },
+    model_fusion: {
+        name: 'Model Fusion', domId: 'sub-model-fusion',
+        desc: 'On-demand panel-of-models consult (OpenRouter Fusion) — a custom panel + judge return a synthesized verdict plus explicit dissent for high-stakes, contested decisions. Invoked via the deliberate MCP tool.',
+        sites: ['model_fusion'],
+    },
 };
 
 function aggregateStatus(statuses) {
@@ -1928,7 +1937,7 @@ function statusDotColor(status) {
 const SUBSYSTEM_BORDER_COLORS = {
     ego: '#c084fc', reflection: '#818cf8', memory: '#38bdf8', surplus: '#4ade80',
     outreach: '#fbbf24', executor: '#a78bfa', learning: '#fb923c',
-    contingency: '#f87171', utility: '#94a3b8',
+    contingency: '#f87171', utility: '#94a3b8', model_fusion: '#e879f9',
 };
 
 
@@ -1962,6 +1971,7 @@ function updateSubsystemGrid(data) {
         executor:    [[5,5],[6,5],[5,6],[6,6]],
         outreach:    [[3,7],[4,7]],
         contingency: [[5,7],[6,7]],
+        model_fusion: [[7,7]],
     };
 
     for (const [key, group] of Object.entries(SUBSYSTEM_GROUPS)) {

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -929,11 +929,21 @@ function showDetail(item) {
     // Status + disabled banner
     const STATUS_COLORS = { healthy: '#4ade80', active: '#4ade80', warning: '#f59e0b', degraded: '#ffe600', down: '#ef4444', idle: '#888', disabled: '#888' };
     const statusColor = STATUS_COLORS[item.status] || '#888';
+    // A wired site seeded idle (status_reason WIRED) is available-but-not-yet-run
+    // \u2014 e.g. the on-demand Model Fusion consult \u2014 NOT groundwork. Distinguish it
+    // from true groundwork (wired=False, config-only sites) so a live tool isn't
+    // mislabeled "Disabled (groundwork)".
+    const isWiredIdle = item.status === 'idle' && item.data.status_reason === 'WIRED';
     let statusLabel = item.status;
-    if (item.status === 'idle') statusLabel = 'Disabled (groundwork)';
+    if (isWiredIdle) statusLabel = 'Idle \u2014 on-demand (not yet run)';
+    else if (item.status === 'idle') statusLabel = 'Disabled (groundwork)';
     else if (item.status === 'disabled') statusLabel = 'Disabled (no API key)';
     content.appendChild(sectionRow('Status', statusLabel, 'color:' + statusColor));
-    if (item.status === 'idle') {
+    if (isWiredIdle) {
+        const banner = el('div', null, 'Wired and available \u2014 this on-demand tool simply has not run yet. It records a run each time it is invoked.');
+        banner.style.cssText = 'background:rgba(167,139,250,0.15);color:#c4b5fd;padding:6px 10px;border-radius:4px;font-size:11px;margin:8px 0;';
+        content.appendChild(banner);
+    } else if (item.status === 'idle') {
         const banner = el('div', null, 'This call site is groundwork \u2014 config exists but no code invokes it yet.');
         banner.style.cssText = 'background:rgba(136,136,136,0.15);color:#888;padding:6px 10px;border-radius:4px;font-size:11px;margin:8px 0;';
         content.appendChild(banner);
@@ -1989,7 +1999,8 @@ function updateSubsystemGrid(data) {
             const dot = el('div', 'grid-dot ' + gridDotClass(status));
             dot.addEventListener('click', () => showDetail({ id: siteId, status, data: siteData }));
             const tipRows = [{ cls: 'dot-tip-name', text: meta.name }];
-            if (status === 'idle') tipRows.push({ text: 'Groundwork' });
+            if (status === 'idle' && siteData.status_reason === 'WIRED') tipRows.push({ text: 'On-demand · not yet run' });
+            else if (status === 'idle') tipRows.push({ text: 'Groundwork' });
             else if (status === 'disabled') tipRows.push({ text: 'No API key' });
             else tipRows.push({ text: status });
             if (siteData.active_provider) tipRows.push({ text: siteData.active_provider });

--- a/src/genesis/mcp/health/deliberation_tools.py
+++ b/src/genesis/mcp/health/deliberation_tools.py
@@ -28,6 +28,25 @@ async def _impl_deliberate(
     result = await deliberate(
         question, context=(context or None), stakes=stakes_arg, mode=mode, preset=preset_arg, backend="fusion"
     )
+    # Surface each deliberation on the neural monitor (model_fusion call site).
+    # Detached + best-effort: the health MCP server holds no server DB handle, so
+    # this opens its own short-lived connection via record_last_run_detached
+    # (the sanctioned seam, same as the contribution gate and ambient worker).
+    # A failed record is logged and swallowed — it must never break the tool.
+    try:
+        from genesis.env import genesis_db_path
+        from genesis.observability.call_site_recorder import record_last_run_detached
+
+        await record_last_run_detached(
+            str(genesis_db_path()),
+            "model_fusion",
+            provider="openrouter",
+            model_id=f"fusion:{result.preset_used or mode}",
+            response_text=(result.answer or result.error or "")[:200],
+            success=(result.error is None),
+        )
+    except Exception:
+        logger.debug("model_fusion call-site record failed", exc_info=True)
     return {
         "answer": result.answer,
         "consensus": result.consensus,

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -579,4 +579,19 @@ _CALL_SITE_META: dict[str, dict] = {
         "cc_model": "Haiku",
         "model_tier": "cc",
     },
+    "model_fusion": {
+        # Non-routing, on-demand paid consult: the deliberate MCP tool POSTs
+        # OpenRouter Fusion over raw httpx (NOT through the router), then records
+        # via record_last_run_detached. snapshots/call_sites.py seeds it idle so
+        # the node is always present. Manual cost_policy: it never touches a
+        # routing chain, so cost is not auto-derived. No `dispatch` (not CC) and
+        # no `wired` key (it IS wired — a wired:False would force it permanently
+        # idle via the groundwork block).
+        "description": "On-demand panel-of-models consult (OpenRouter Fusion): a custom panel + judge return a synthesized verdict PLUS explicit dissent for genuinely high-stakes or contested decisions. PAID + opt-in — invoked via the `deliberate` MCP tool, never a default judgment path.",
+        "category": "reasoning",
+        "frequency": "On demand (opt-in)",
+        "cost_policy": "Paid (OpenRouter Fusion)",
+        "model_tier": "frontier",
+        "status_reason": "WIRED",
+    },
 }

--- a/src/genesis/observability/snapshots/call_sites.py
+++ b/src/genesis/observability/snapshots/call_sites.py
@@ -216,6 +216,17 @@ async def call_sites(
         except sqlite3.Error:
             logger.debug("call_site_last_run query failed", exc_info=True)
 
+    # ── Model Fusion (non-routing, on-demand paid consult) ──────────────
+    # The `deliberate` MCP tool records via record_last_run_detached, so once it
+    # has run the loop above already added it as active. Seed it here so the node
+    # is ALWAYS present on the monitor — idle before its first run — since it is
+    # not a routing call site and would otherwise never appear until first use.
+    # setdefault → no-op when a last_run row already created it. Meta is layered
+    # per-key so both the idle seed and an existing active node self-describe.
+    mf = result.setdefault("model_fusion", {"status": "idle", "routing": False})
+    for _k, _v in _CALL_SITE_META.get("model_fusion", {}).items():
+        mf.setdefault(_k, _v)
+
     # ── Groundwork sites → idle (gray) ──────────────────────────────────
     # Sites with wired=False and no last_run record are groundwork/ceremonial.
     for sid, site_data in result.items():

--- a/tests/test_mcp/test_deliberation_tools.py
+++ b/tests/test_mcp/test_deliberation_tools.py
@@ -1,0 +1,82 @@
+"""The `deliberate` MCP tool records each run to the model_fusion call site.
+
+The Fusion backend POSTs OpenRouter over raw httpx — outside the router and
+call_site_recorder — so the MCP wrapper (`_impl_deliberate`) is the one seam
+that observes every invocation. These lock that it records to `model_fusion`
+(success + failure) and that recording is strictly best-effort (a recorder
+failure must never break the tool).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.deliberation import DeliberationResult
+from genesis.mcp.health.deliberation_tools import _impl_deliberate
+
+
+def _result(**kw) -> DeliberationResult:
+    base: dict = {"answer": "verdict", "preset_used": "budget", "error": None}
+    base.update(kw)
+    return DeliberationResult(**base)
+
+
+@pytest.mark.asyncio
+async def test_records_model_fusion_on_success():
+    rec = AsyncMock(return_value=True)
+    with (
+        patch("genesis.deliberation.deliberate", AsyncMock(return_value=_result())),
+        patch("genesis.observability.call_site_recorder.record_last_run_detached", rec),
+    ):
+        out = await _impl_deliberate("Should we ship?", preset="budget")
+    assert out["answer"] == "verdict"
+    rec.assert_awaited_once()
+    args, kwargs = rec.call_args
+    assert args[1] == "model_fusion"  # call_site_id
+    assert kwargs["provider"] == "openrouter"
+    assert kwargs["model_id"] == "fusion:budget"
+    assert kwargs["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_records_failure_when_error_set():
+    rec = AsyncMock(return_value=True)
+    with (
+        patch(
+            "genesis.deliberation.deliberate",
+            AsyncMock(return_value=_result(answer=None, error="panel timeout")),
+        ),
+        patch("genesis.observability.call_site_recorder.record_last_run_detached", rec),
+    ):
+        out = await _impl_deliberate("Q?", preset="budget")
+    assert out["error"] == "panel timeout"
+    rec.assert_awaited_once()
+    _, kwargs = rec.call_args
+    assert kwargs["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_recording_is_best_effort():
+    """A recorder exception must be swallowed — the tool still returns its verdict."""
+    with (
+        patch("genesis.deliberation.deliberate", AsyncMock(return_value=_result())),
+        patch(
+            "genesis.observability.call_site_recorder.record_last_run_detached",
+            AsyncMock(side_effect=RuntimeError("db gone")),
+        ),
+    ):
+        out = await _impl_deliberate("Q?", preset="budget")
+    assert out["answer"] == "verdict"
+    assert out["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_question_short_circuits_without_recording():
+    """The early input-validation return must not record a run."""
+    rec = AsyncMock(return_value=True)
+    with patch("genesis.observability.call_site_recorder.record_last_run_detached", rec):
+        out = await _impl_deliberate("   ")
+    assert "error" in out
+    rec.assert_not_awaited()

--- a/tests/test_observability/test_call_site_metadata.py
+++ b/tests/test_observability/test_call_site_metadata.py
@@ -211,3 +211,51 @@ async def test_api_site_auto_derives_and_has_no_cc_entry():
     assert result["judge"]["cost_policy"].startswith("Paid primary")
     chain = result["judge"]["chain_health"]
     assert not any(entry.get("is_cc") for entry in chain)
+
+
+# ── D: Model Fusion — non-routing node, seeded idle, active with a run ───────
+# The deliberate MCP tool (OpenRouter Fusion, raw httpx — not the router) is not
+# a routing call site, so it would never appear until its first run. call_sites()
+# seeds it idle so it is ALWAYS present on the monitor, then flips to active once
+# a call_site_last_run row exists.
+
+
+@pytest.mark.asyncio
+async def test_model_fusion_seeded_idle_without_run():
+    cfg = _config({}, {})
+    result = await call_sites(db=None, routing_config=cfg, breakers=_registry())
+    mf = result.get("model_fusion")
+    assert mf is not None, "model_fusion node missing from snapshot"
+    assert mf["status"] == "idle"
+    assert mf["routing"] is False
+    # Backend meta is layered onto the seed → self-describing payload.
+    assert mf["category"] == "reasoning"
+    assert mf["cost_policy"] == "Paid (OpenRouter Fusion)"
+
+
+@pytest.mark.asyncio
+async def test_model_fusion_active_with_recorded_run(tmp_path):
+    import aiosqlite
+
+    from genesis.observability.call_site_recorder import record_last_run
+
+    path = tmp_path / "cs.db"
+    async with aiosqlite.connect(str(path)) as conn:
+        await conn.execute(
+            """CREATE TABLE call_site_last_run (
+                call_site_id TEXT PRIMARY KEY, last_run_at TEXT NOT NULL,
+                provider_used TEXT, model_id TEXT, response_text TEXT,
+                input_tokens INTEGER, output_tokens INTEGER,
+                success INTEGER NOT NULL DEFAULT 1, updated_at TEXT NOT NULL)"""
+        )
+        await conn.commit()
+        await record_last_run(
+            conn, "model_fusion", provider="openrouter",
+            model_id="fusion:budget", response_text="verdict text",
+        )
+        result = await call_sites(db=conn, routing_config=_config({}, {}), breakers=_registry())
+    mf = result["model_fusion"]
+    assert mf["status"] == "active"  # seed no-ops; the recorded row drives active
+    assert mf["routing"] is False
+    assert mf["last_run_model"] == "fusion:budget"
+    assert mf["last_response"] == "verdict text"

--- a/tests/test_observability/test_call_site_metadata.py
+++ b/tests/test_observability/test_call_site_metadata.py
@@ -231,6 +231,10 @@ async def test_model_fusion_seeded_idle_without_run():
     # Backend meta is layered onto the seed → self-describing payload.
     assert mf["category"] == "reasoning"
     assert mf["cost_policy"] == "Paid (OpenRouter Fusion)"
+    # The monitor's detail panel/tooltip key off status_reason == "WIRED" to render
+    # this idle-but-wired on-demand node as "not yet run" instead of "groundwork".
+    # Lock it so the seed can't silently drop the flag the frontend depends on.
+    assert mf["status_reason"] == "WIRED"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

The `deliberate` MCP tool — **Model Fusion** (OpenRouter Fusion: a custom panel-of-models + judge for high-stakes/contested decisions) — POSTs raw httpx **outside** the router and `call_site_recorder`, so it fired completely unobserved: absent from `call_site_last_run` and every dashboard surface. This registers it as a **non-routing call site** so each real run renders on the neural monitor, and seeds it **idle** so the node is always present even before its first run.

Follows the `ambient_arbiter` (#1002) precedent for putting an off-router call site on the monitor, adapted for a non-CC, non-routed paid consult.

## Changes

- **`deliberation_tools.py`** — `_impl_deliberate` records every deliberation via `record_last_run_detached` (the sanctioned detached seam — the health MCP server holds no server DB handle). Best-effort: a failed record is logged and swallowed so it can never break the tool. `success` mirrors `result.error`.
- **`snapshots/call_sites.py`** — `setdefault`-seeds `model_fusion` as **idle** so it renders before its first run (non-routing sites otherwise never appear); no-ops once a `last_run` row has created it **active**. Backend meta layered per-key onto both states for a self-describing payload.
- **`_call_site_meta.py`** — `model_fusion` entry with a manual `cost_policy` (never touches a routing chain, so cost is not auto-derived; no `dispatch`, no `wired:False`).
- **`neural_monitor.html`** — new single-node **"Model Fusion"** subsystem group at free grid cell `[7,7]` + border color + `SITE_META` label (`Fusion`, category `reasoning`).

## Not in `model_routing.yaml` — by design

The Fusion backend never routes through Genesis, so `model_fusion` is **not** a routing call site. The routing site count is unchanged (no `test_config` churn).

## Tests

- `test_deliberation_tools.py` (new): `_impl_deliberate` records `model_fusion` on success/failure, recording is best-effort (recorder exception can't break the tool), and the empty-question short-circuit records nothing.
- `test_call_site_metadata.py`: `call_sites()` seeds `model_fusion` **idle** with no run, and flips **active** with a recorded row.
- Targeted suites green locally (metadata + MCP: 30 passed; health-assembly + config + recorder: 132 passed).

## Verification plan (post-merge)

1. Deploy (code-only: pull main + restart genesis-server) → idle node appears on the monitor with **zero** paid calls.
2. Data-flow: `curl /api/genesis/health` shows `call_sites.model_fusion` idle; synthetic row → flips active; row removed.
3. True E2E: one paid `budget` `deliberate` from a **fresh** session/direct call (the MCP-child recording code only loads on a new CC session) → live node active with the real verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)