### PR TITLE
fix(guardian): F.0 hotfix — redeploy membership gate fails on real archives (pipefail+SIGPIPE)

### DIFF
--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -465,11 +465,20 @@ PYEOF
         # like the sha check — runs BEFORE the running guardian is disturbed.
         TAR_LIST="$(tar -tf "$SPOOL" 2>/dev/null || true)"
         REDEPLOY_TREE_OK=true
+        # Whole-line membership via a PURE-BASH substring match — deliberately
+        # NOT `printf '%s\n' "$TAR_LIST" | grep -qxF`. Under `set -o pipefail`,
+        # grep -q short-circuits on a match and the writer (printf) then gets
+        # SIGPIPE, so the pipeline exits non-zero and a PRESENT file reads as
+        # missing — but only once the listing exceeds the ~64 KB pipe buffer
+        # (a real archive's `tar -tf` is ~86 KB). Wrapping the list in newlines
+        # and matching `\n<req>\n` as a substring has no subprocess, no pipe,
+        # and no SIGPIPE, so it is correct at any size.
+        _tar_wrapped=$'\n'"${TAR_LIST}"$'\n'
         for _req in src/genesis/guardian/check.py scripts/guardian-gateway.sh pyproject.toml; do
-            if ! printf '%s\n' "$TAR_LIST" | grep -qxF "$_req"; then
-                REDEPLOY_TREE_OK=false
-                break
-            fi
+            case "$_tar_wrapped" in
+                *$'\n'"$_req"$'\n'*) : ;;   # present
+                *) REDEPLOY_TREE_OK=false; break ;;
+            esac
         done
         if [ "$REDEPLOY_TREE_OK" != true ]; then
             echo '{"ok": false, "action": "redeploy", "error": "archive missing required files"}' >&2

--- a/tests/test_guardian/test_gateway_redeploy.py
+++ b/tests/test_guardian/test_gateway_redeploy.py
@@ -87,8 +87,11 @@ def sandbox(tmp_path):
     shim.chmod(0o755)
 
     return {
-        "home": home, "install": install, "state": state,
-        "fakebin": fakebin, "calls": calls,
+        "home": home,
+        "install": install,
+        "state": state,
+        "fakebin": fakebin,
+        "calls": calls,
     }
 
 
@@ -99,8 +102,11 @@ def _run(sandbox: dict, verb: str, stdin: bytes = b"") -> subprocess.CompletedPr
         "SSH_ORIGINAL_COMMAND": verb,
     }
     return subprocess.run(
-        ["bash", str(GATEWAY)], env=env, input=stdin,
-        capture_output=True, timeout=60,
+        ["bash", str(GATEWAY)],
+        env=env,
+        input=stdin,
+        capture_output=True,
+        timeout=60,
     )
 
 
@@ -132,6 +138,27 @@ class TestRedeployVerified:
         assert ds["tree_sha256"] == sha
         # New tree actually landed; old sentinel gone (clean extract, backup pruned).
         assert (sandbox["install"] / "src" / "genesis" / "guardian" / "__init__.py").exists()
+        assert _no_spool_left(sandbox)
+
+    def test_verified_deploy_with_large_archive(self, sandbox):
+        # Regression for the pipefail+SIGPIPE membership bug: a real git archive
+        # lists ~1900 entries (~86 KB), well over the 64 KB pipe buffer. The old
+        # `printf | grep -q` gate short-circuited, printf got SIGPIPE, and
+        # pipefail reported the PRESENT required files as missing. Build a tar
+        # whose `tar -tf` output far exceeds the pipe buffer, with the required
+        # files present, and confirm the verified deploy succeeds.
+        members = _good_members()
+        # ~3000 long-named dummy entries → listing well over 64 KB.
+        for i in range(3000):
+            members[f"src/genesis/pkg/really_long_module_name_number_{i:05d}.py"] = b"x\n"
+        tar = _make_tar(members)
+        sha = hashlib.sha256(tar).hexdigest()
+        res = _run(sandbox, f"redeploy abc1234 {sha}", stdin=tar)
+        assert res.returncode == 0, res.stderr
+        payload = json.loads(res.stdout)
+        assert payload["ok"] is True
+        assert payload["verified"] is True
+        assert _deploy_state(sandbox)["deployed_commit"] == "abc1234"
         assert _no_spool_left(sandbox)
 
     def test_version_advertises_redeploy_verify_and_tree_sha(self, sandbox):


### PR DESCRIPTION
## Hotfix for #1007 (F.0)

Found during live E2E of #1007. The redeploy required-file gate used:

\`\`\`bash
printf '%s\n' "$TAR_LIST" | grep -qxF "$_req"
\`\`\`

under \`set -o pipefail\`. On a **real** git archive the \`tar -tf\` listing is ~86 KB — over the 64 KB pipe buffer — so when \`grep -q\` short-circuits on an early match and exits, \`printf\` gets **SIGPIPE** and \`pipefail\` makes the pipeline exit non-zero. The gate then reports **present** required files as missing and rejects **every** real redeploy with \`archive missing required files\`.

The gate runs on both the verified and legacy redeploy forms, so the deployed F.0 gateway rejected all redeploys. The unit fixtures used ~4-entry tars (<64 KB listing → no SIGPIPE), so CI stayed green — the bug only surfaced live.

## Fix

Whole-line membership via a **pure-bash** substring match against the newline-wrapped listing (\`case "$_tar_wrapped" in *$'\n'"$_req"$'\n'*\`) — no subprocess, no pipe, no SIGPIPE, correct at any archive size.

## Regression test

\`test_verified_deploy_with_large_archive\` builds a ~3000-entry archive (listing >> 64 KB) with the required files present. Passes with the fix; **verified to FAIL** against the pre-fix piped-grep gate by swapping the old block back in. 42 gateway/redeploy tests green; shellcheck clean.

## Deploy note

The currently-deployed gateway can't accept redeploys, so this ships to the host via full-shell recovery (the redeploy verb is the thing that's broken), then a verified redeploy is confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)