### PR TITLE
feat(security): WS-3 B1 — injection gate (gate 4) in shadow + provenance-gate substrate

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -526,7 +526,7 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, env.py, _config_overlay.py]
-verified: 36563f95 2026-07-10
+verified: fa2e692a 2026-07-11
 ```
 
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
@@ -560,15 +560,24 @@ verified: 36563f95 2026-07-10
   `output_scanner` = deterministic outbound secrets/IP scan; `skill_scan`
   shells to external NVIDIA SkillSpector. NOT auth or secrets storage (that's
   `runtime/init/secrets.py` + `env.py`). **`immunity.py` = the WS-3 kill
-  switch (control surface LIVE, gates NOT built — B1)**: `gate_mode()`
-  re-reads `config/ws3_immunity.yaml` + its `.local.yaml` overlay per call
-  (no cache, no restart — the `ws3_immunity` settings domain is writable);
-  master `enabled: false` short-circuits every gate; `is_blockable()` is the
-  never-block-owner/first-party invariant every B1 gate must route through;
-  the gate-time fail-closed unknown→external rule lives ONLY in
-  `effective_origin_class()` (store-time derivation never fail-closes).
-  Auto-demote state is written INTO the overlay so state and behavior share
-  one file.
+  switch + gate policy**: `gate_mode()` re-reads `config/ws3_immunity.yaml` +
+  its `.local.yaml` overlay per call (no cache, no restart — the
+  `ws3_immunity` settings domain is writable); master `enabled: false`
+  short-circuits every gate; `is_blockable()` is the never-block-owner/
+  first-party invariant every gate routes through; the gate-time fail-closed
+  unknown→external rule lives ONLY in `effective_origin_class()` (store-time
+  derivation never fail-closes). Auto-demote state is written INTO the overlay
+  so state and behavior share one file. **B1: gate 4 (injection) is LIVE in
+  SHADOW** — `immunity_shadow.py` records a would-block into
+  `immunity_shadow_events` (migration 0055) at all 8 `wrap_external_recall`
+  inject sites + the proactive hook whenever `external_untrusted` content
+  reaches an action-capable prompt (observe-only — the item still reaches the
+  model; owner/first-party never recorded). The gate set is CI-locked in
+  `test_recall_inject_coverage.py` (a new inject site or a removed emit fails).
+  **Gates 1-3 (procedure/identity/autonomy) do NOT yet emit** — inert in
+  shadow until source provenance is threaded to their decision points
+  (flip-blocking follow-ups). Auto-demote wired but dormant (server + enforce
+  only); retention via `scripts/prune_immunity_shadow.py` (disk-hygiene).
 - **codebase/**: AST indexer (surplus task, set-difference deletes with
   CASCADE) behind the `codebase_navigate` MCP tool.
 - **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h

--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -11,6 +11,8 @@
 #   4. Age-prune ~/tmp direct children (>7d, excluding bg-cc-sessions)
 #   5. Label-aware attention-snapshot GC   → scripts/attention_snapshot_gc.py
 #      (home >60d / OMI >14d, but NEVER a snapshot a labeled event references)
+#   6. Retention prune of immunity_shadow_events (>45d) → scripts/prune_immunity_shadow.py
+#      (WS-3 B1 observe-only gate log; bounds the shadow store)
 #
 # Note: run under a hardened systemd sandbox (NoNewPrivileges, ProtectSystem=
 # strict), so disk_reclaim's --system (/var, sudo) path is intentionally NOT
@@ -74,6 +76,10 @@ main() {
     echo "--- attention snapshot GC (label-aware) ---"
     "$VENV_PY" "$REPO_DIR/scripts/attention_snapshot_gc.py" --home-days 60 --omi-days 14 \
         || echo "attention_snapshot_gc exited $?"
+
+    echo "--- immunity shadow retention prune (>45d) ---"
+    "$VENV_PY" "$REPO_DIR/scripts/prune_immunity_shadow.py" --days 45 \
+        || echo "prune_immunity_shadow exited $?"
 
     echo "=== genesis-disk-hygiene done ==="
 }

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1833,7 +1833,7 @@ async def _run(prompt: str, session_id: str = "") -> None:
                 try:
                     record_would_block_sync(
                         conn, gate="injection", source_kind="proactive_hook",
-                        source_ref="scripts/proactive_memory_hook.py::_format_results",
+                        source_ref="scripts/proactive_memory_hook.py::_run",
                         blockable_count=blockable,
                     )
                 finally:

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1809,6 +1809,38 @@ async def _run(prompt: str, session_id: str = "") -> None:
     if fused:
         await _increment_retrieved(fused)
 
+    # Post-output: WS-3 B1 gate 4 (injection) shadow-record. External-world hits
+    # in this proactive injection reach the CC-session prompt (action-capable).
+    # Fire-and-forget AFTER flush — never delays the injection, never crashes the
+    # hook; skipped live if the gate is off (master kill switch / per-gate off).
+    if fused:
+        try:
+            from genesis.security.immunity_shadow import (
+                item_is_blockable,
+                record_would_block_sync,
+            )
+
+            blockable = sum(
+                1
+                for r in fused
+                if item_is_blockable(
+                    collection=r.get("collection"),
+                    source_pipeline=r.get("source_pipeline"),
+                )
+            )
+            if blockable:
+                conn = sqlite3.connect(str(_DB_PATH), timeout=2)
+                try:
+                    record_would_block_sync(
+                        conn, gate="injection", source_kind="proactive_hook",
+                        source_ref="scripts/proactive_memory_hook.py::_format_results",
+                        blockable_count=blockable,
+                    )
+                finally:
+                    conn.close()
+        except Exception as exc:
+            print(f"Immunity shadow emit skipped: {exc}", file=sys.stderr)
+
     # ── Working-set measurement (H-1 PR1 record-only + PR2a shadow) ─
     # Overlap stats + the shadow novelty-gate projection feed the PR2b
     # enforcement decision. Runs after all stdout is flushed — never touches

--- a/scripts/prune_immunity_shadow.py
+++ b/scripts/prune_immunity_shadow.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Retention prune for immunity_shadow_events (WS-3 B1 shadow store).
+
+Deletes shadow observations older than a retention window (default 45 days) so
+the observe-only immunity gate log stays bounded. Invoked by
+``scripts/disk_hygiene.sh`` (the genesis-disk-hygiene.timer); also runnable by
+hand. Best-effort — a failure here must not skip other hygiene steps, and it
+no-ops cleanly before migration 0055 lands (the table-existence guard returns 0).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+async def _prune(days: int) -> int:
+    from genesis.db.connection import get_raw_db
+    from genesis.db.crud.immunity_shadow import prune_immunity_shadow_events
+
+    now = datetime.now(UTC).isoformat()
+    async with get_raw_db() as conn:
+        return await prune_immunity_shadow_events(conn, older_than_days=days, now=now)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--days",
+        type=int,
+        default=45,
+        help="retention window in days (rows older than this are deleted)",
+    )
+    args = ap.parse_args()
+    try:
+        deleted = asyncio.run(_prune(args.days))
+        print(f"immunity_shadow prune: deleted {deleted} row(s) older than {args.days}d")
+    except Exception as exc:
+        print(f"immunity_shadow prune error: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -22,6 +22,7 @@ from typing import Any
 from genesis.autonomy.executor.types import ResearchResult
 from genesis.cc.types import CCInvocation, CCModel, CCOutput, EffortLevel, background_session_dir
 from genesis.memory.provenance import is_external, wrap_external_recall
+from genesis.security import immunity_shadow
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +222,7 @@ class DeepResearcherImpl:
             if not results:
                 return ""
             lines = []
+            blockable = 0
             for r in results[:5]:
                 content = r.content[:200] if hasattr(r, "content") else str(r)[:200]
                 # Injection defense (PR2): recall defaults to source="both", so a
@@ -229,7 +231,20 @@ class DeepResearcherImpl:
                     content = wrap_external_recall(
                         content, source_pipeline=getattr(r, "source_pipeline", None),
                     )
+                    if immunity_shadow.item_is_blockable(
+                        collection=getattr(r, "collection", None),
+                        source_pipeline=getattr(r, "source_pipeline", None),
+                    ):
+                        blockable += 1
                 lines.append(f"- {content}")
+            # WS-3 B1 gate 4 (injection): the autonomous due-diligence path is the
+            # highest-write-capability recall site — shadow-record external content
+            # reaching it (observe-only; db=None -> self-resolve).
+            await immunity_shadow.record_would_block(
+                gate="injection", source_kind="recall_inject",
+                source_ref="autonomy/executor/research.py::_memory_recall",
+                process="server", blockable_count=blockable, db=None,
+            )
             return "\n".join(lines)
         except Exception as exc:
             logger.debug("Memory recall error in due diligence: %s", exc)

--- a/src/genesis/cc/context_injector.py
+++ b/src/genesis/cc/context_injector.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from genesis.memory.provenance import is_external, wrap_external_recall
+from genesis.security import immunity_shadow
 
 if TYPE_CHECKING:
     from genesis.memory.retrieval import HybridRetriever
@@ -55,6 +56,7 @@ class ContextInjector:
             return ""
 
         lines = ["## Relevant Prior Experience\n"]
+        blockable = 0
         for r in results:
             content = r.content[:200]
             # Injection defense (PR2): this path recalls source="episodic"
@@ -64,8 +66,21 @@ class ContextInjector:
                 content = wrap_external_recall(
                     content, source_pipeline=getattr(r, "source_pipeline", None),
                 )
+                if immunity_shadow.item_is_blockable(
+                    collection=getattr(r, "collection", None),
+                    source_pipeline=getattr(r, "source_pipeline", None),
+                ):
+                    blockable += 1
             lines.append(
                 f"- **[{r.memory_type}]** (score: {r.score:.2f}) {content}"
             )
 
+        # WS-3 B1 gate 4 (injection): shadow-record external content reaching the
+        # CC context prompt. Episodic-only today -> 0 rows; wired for future
+        # widening (observe-only; db=None -> self-resolve).
+        await immunity_shadow.record_would_block(
+            gate="injection", source_kind="recall_inject",
+            source_ref="cc/context_injector.py::inject", process="server",
+            blockable_count=blockable, db=None,
+        )
         return "\n".join(lines)

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from genesis.channels.tts_config import sanitize_for_speech
 from genesis.channels.voice.sessions import VoiceSessionManager
 from genesis.memory.provenance import is_external, wrap_external_recall
+from genesis.security import immunity_shadow
 
 if TYPE_CHECKING:
     from genesis.memory.retrieval import HybridRetriever
@@ -100,6 +101,7 @@ class VoiceConversationHandler:
         llm_memories_text = ""
         try:
             results = await self._retriever.recall(transcript, limit=5, rerank=False)
+            blockable = 0
             if results:
                 spoken_snippets = []
                 llm_snippets = []
@@ -116,11 +118,23 @@ class VoiceConversationHandler:
                                     content[:300], source_pipeline=source_pipeline,
                                 )
                             )
+                            if immunity_shadow.item_is_blockable(
+                                collection=getattr(r, "collection", None),
+                                source_pipeline=source_pipeline,
+                            ):
+                                blockable += 1
                         else:
                             llm_snippets.append(f"- {content[:300]}")
                 if spoken_snippets:
                     memories_text = "Recalled memories:\n" + "\n".join(spoken_snippets)
                     llm_memories_text = "Recalled memories:\n" + "\n".join(llm_snippets)
+            # WS-3 B1 gate 4 (injection): shadow-record external content reaching
+            # the voice LLM system prompt (observe-only; db=None -> self-resolve).
+            await immunity_shadow.record_would_block(
+                gate="injection", source_kind="recall_inject",
+                source_ref="channels/voice/handler.py::handle", process="server",
+                blockable_count=blockable, db=None,
+            )
         except Exception:
             logger.warning(
                 "Memory recall failed for voice session %s",

--- a/src/genesis/db/crud/immunity_shadow.py
+++ b/src/genesis/db/crud/immunity_shadow.py
@@ -1,0 +1,232 @@
+"""CRUD for immunity_shadow_events — the WS-3 B1 immunity-gate SHADOW store.
+
+Observe-only: rows are gate DECISIONS + provenance refs (which gate, at which
+site, for which origin_class) — NEVER recalled content, NEVER a block. In
+shadow mode the recalled item still reaches the prompt exactly as before (it
+was already wrapped by ``wrap_external_recall``); this store only records that
+a live gate WOULD have acted, so the ENFORCE stage (B4) can size the blast
+radius first.
+
+Written best-effort from TWO writer kinds against the same ``genesis.db``
+(WAL + busy_timeout):
+
+- the genesis-server async runtime (recall/inject sites) → :func:`record`
+  (aiosqlite);
+- the ``UserPromptSubmit`` proactive-memory hook, a foreground sync process →
+  :func:`record_sync` (stdlib ``sqlite3``).
+
+Neither writer runs migrations, so both record paths guard on table existence
+(cached per-process) and return ``False`` if the table isn't there yet (the
+brief pre-migration window). They NEVER create the table — migration 0055 is
+the sole schema authority, mirrored in ``db/schema/_tables.py`` for the
+fresh-DB path, so there is no inline-DDL-vs-migration divergence surface.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import aiosqlite
+
+COLUMNS = (
+    "id",
+    "observed_at",
+    "gate",
+    "mode",
+    "origin_class",
+    "would_block",
+    "source_kind",
+    "source_ref",
+    "detail",
+    "process",
+)
+
+_INSERT = (
+    "INSERT INTO immunity_shadow_events "
+    "(id, observed_at, gate, mode, origin_class, would_block, source_kind, "
+    "source_ref, detail, process) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+_TABLE_PROBE = "SELECT name FROM sqlite_master WHERE type='table' AND name='immunity_shadow_events'"
+
+# Per-process existence caches — one per connection flavor. Only the TRUE
+# result is cached; a missing table (pre-migration) is re-checked every call so
+# a subprocess writer self-heals the moment the server migration lands.
+_table_verified = False
+_table_verified_sync = False
+
+
+def _row_values(kw: dict) -> tuple:
+    return (
+        kw["id"],
+        kw["observed_at"],
+        kw["gate"],
+        kw["mode"],
+        kw["origin_class"],
+        1 if kw["would_block"] else 0,
+        kw["source_kind"],
+        kw["source_ref"],
+        kw["detail"],
+        kw["process"],
+    )
+
+
+# ── async writer (genesis-server runtime) ──────────────────────────────────
+async def _table_available(db: aiosqlite.Connection) -> bool:
+    global _table_verified
+    if _table_verified:
+        return True
+    cursor = await db.execute(_TABLE_PROBE)
+    exists = await cursor.fetchone() is not None
+    if exists:
+        _table_verified = True
+    return exists
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    observed_at: str,
+    gate: str,
+    mode: str,
+    origin_class: str,
+    would_block: bool,
+    source_kind: str | None,
+    source_ref: str | None,
+    detail: str | None,
+    process: str | None,
+) -> bool:
+    """Insert one shadow observation. Returns False (no-op) if the table doesn't
+    exist yet (subprocess pre-migration window); never creates it."""
+    if not await _table_available(db):
+        return False
+    await db.execute(_INSERT, _row_values(locals()))
+    await db.commit()
+    return True
+
+
+# ── sync writer (UserPromptSubmit proactive-memory hook) ────────────────────
+def _table_available_sync(conn: sqlite3.Connection) -> bool:
+    global _table_verified_sync
+    if _table_verified_sync:
+        return True
+    exists = conn.execute(_TABLE_PROBE).fetchone() is not None
+    if exists:
+        _table_verified_sync = True
+    return exists
+
+
+def record_sync(
+    conn: sqlite3.Connection,
+    *,
+    id: str,
+    observed_at: str,
+    gate: str,
+    mode: str,
+    origin_class: str,
+    would_block: bool,
+    source_kind: str | None,
+    source_ref: str | None,
+    detail: str | None,
+    process: str | None,
+) -> bool:
+    """Sync sibling of :func:`record` for the stdlib-``sqlite3`` proactive hook.
+    Same table-absent guard; same columns; never creates the table."""
+    if not _table_available_sync(conn):
+        return False
+    conn.execute(_INSERT, _row_values(locals()))
+    conn.commit()
+    return True
+
+
+# ── read / aggregation / retention ─────────────────────────────────────────
+async def count(db: aiosqlite.Connection) -> int:
+    cursor = await db.execute("SELECT COUNT(*) FROM immunity_shadow_events")
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def count_would_block(
+    db: aiosqlite.Connection,
+    *,
+    gate: str,
+    since: str,
+) -> int:
+    """Would-block rows for *gate* at/after ISO ``since`` — the auto-demote
+    signal (B4). would_block=0 rows and other gates are excluded."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM immunity_shadow_events "
+        "WHERE gate = ? AND would_block = 1 AND observed_at >= ?",
+        (gate, since),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def list_recent(
+    db: aiosqlite.Connection,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[dict]:
+    """Recent shadow observations, newest first (for review). Assumes a Row factory."""
+    lim = max(1, min(int(limit), 500))
+    off = max(0, int(offset))
+    cursor = await db.execute(
+        "SELECT * FROM immunity_shadow_events ORDER BY observed_at DESC LIMIT ? OFFSET ?",
+        (lim, off),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def summary(
+    db: aiosqlite.Connection,
+    *,
+    since: str | None = None,
+) -> list[dict]:
+    """Per-gate / per-site volume (COUNTS only — no content).
+
+    The observation deliverable: how much external content reaches each
+    action-capable inject site, so the ENFORCE stage can size the posture.
+    Optionally bounded to rows at/after ISO ``since``.
+    """
+    where = "WHERE observed_at >= ?" if since else ""
+    params = (since,) if since else ()
+    cursor = await db.execute(
+        "SELECT gate, source_ref, would_block, COUNT(*) AS n "
+        f"FROM immunity_shadow_events {where} "
+        "GROUP BY gate, source_ref, would_block "
+        "ORDER BY n DESC",
+        params,
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def prune_immunity_shadow_events(
+    db: aiosqlite.Connection,
+    *,
+    older_than_days: int = 45,
+    now: str,
+) -> int:
+    """Delete rows older than *older_than_days* relative to ISO ``now``.
+
+    Retention for the unbounded shadow log (wired into ``disk_hygiene.sh``).
+    ``now`` is injected (never wall-clock here) so the cutover is deterministic
+    and testable. Returns the number of rows deleted.
+    """
+    if not await _table_available(db):
+        return 0
+    cutoff = _iso_days_before(now, older_than_days)
+    cursor = await db.execute("DELETE FROM immunity_shadow_events WHERE observed_at < ?", (cutoff,))
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount is not None else 0
+
+
+def _iso_days_before(now_iso: str, days: int) -> str:
+    """Return the ISO8601 UTC timestamp *days* before ``now_iso``."""
+    from datetime import datetime, timedelta
+
+    dt = datetime.fromisoformat(now_iso)
+    return (dt - timedelta(days=days)).isoformat()

--- a/src/genesis/db/migrations/0055_immunity_shadow_events.py
+++ b/src/genesis/db/migrations/0055_immunity_shadow_events.py
@@ -34,7 +34,7 @@ async def up(db: aiosqlite.Connection) -> None:
             observed_at   TEXT NOT NULL,      -- ISO8601 UTC — when the recall/inject was observed
             gate          TEXT NOT NULL,      -- procedure | identity | autonomy | injection
             mode          TEXT NOT NULL,      -- shadow | enforce (mode at observation; 'off' never records)
-            origin_class  TEXT NOT NULL,      -- blockable origin (external_untrusted for gate 4); owner/first_party NEVER recorded
+            origin_class  TEXT NOT NULL,      -- blockable origin (external_untrusted for gate 4); a row is written only when the DERIVED origin is blockable
             would_block   INTEGER NOT NULL,   -- 1 = a live gate WOULD block; kept uniform for gates 1-3 forward-compat
             source_kind   TEXT,               -- site class: recall_inject | proactive_hook | ...
             source_ref    TEXT,               -- the site: 'mcp/memory/core.py::memory_recall'

--- a/src/genesis/db/migrations/0055_immunity_shadow_events.py
+++ b/src/genesis/db/migrations/0055_immunity_shadow_events.py
@@ -1,0 +1,61 @@
+"""Add immunity_shadow_events — the WS-3 B1 immunity-gate SHADOW store.
+
+Observe-only: at each recall/inject site where external-world content reaches
+an action-capable LLM prompt, Genesis records what a provenance gate WOULD
+decide (block vs allow) WITHOUT altering the recall — the item still reaches
+the prompt exactly as before (already wrapped by ``wrap_external_recall``).
+This gathers volume + per-site data before the ENFORCE stage (B4) turns any
+gate on; there is NO behavioural change to any recall.
+
+Firewall/privacy: rows are gate DECISIONS + provenance refs only — the gate,
+the site (``source_ref``), the ``origin_class``, and a freeform ``detail``
+(e.g. a blockable-item count). NEVER recalled content. owner/first_party
+origins are never blockable, so a row is only ever written for
+external_untrusted content (the never-block invariant lives in
+``security.immunity.is_blockable``).
+
+Additive + idempotent; the canonical DDL is mirrored in
+``db/schema/_tables.py`` for the fresh-DB path. Individual ``db.execute()``
+calls (never ``executescript``) so a concurrent ``CREATE TABLE IF NOT EXISTS``
+from a subprocess writer stays serialized under WAL. No commit — the runner
+owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS immunity_shadow_events (
+            id            TEXT PRIMARY KEY,
+            observed_at   TEXT NOT NULL,      -- ISO8601 UTC — when the recall/inject was observed
+            gate          TEXT NOT NULL,      -- procedure | identity | autonomy | injection
+            mode          TEXT NOT NULL,      -- shadow | enforce (mode at observation; 'off' never records)
+            origin_class  TEXT NOT NULL,      -- blockable origin (external_untrusted for gate 4); owner/first_party NEVER recorded
+            would_block   INTEGER NOT NULL,   -- 1 = a live gate WOULD block; kept uniform for gates 1-3 forward-compat
+            source_kind   TEXT,               -- site class: recall_inject | proactive_hook | ...
+            source_ref    TEXT,               -- the site: 'mcp/memory/core.py::memory_recall'
+            detail        TEXT,               -- freeform (e.g. blockable item count); NEVER recalled content
+            process       TEXT                -- server | proactive_hook | outreach_mcp | ...
+            -- WS-3 immunity SHADOW store: gate DECISIONS + provenance refs only. Observe-only
+            -- — no recall is blocked or altered here; the item still reaches the prompt
+            -- (wrapped as it already was). Never stores recalled content. Not read by any
+            -- cognition job.
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_immunity_shadow_events_observed_at "
+        "ON immunity_shadow_events(observed_at)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_immunity_shadow_events_gate "
+        "ON immunity_shadow_events(gate, observed_at)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS immunity_shadow_events")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -81,6 +81,24 @@ TABLES = {
             -- Observe-only — no hold/approval is created here; the send always proceeds.
         )
     """,
+    "immunity_shadow_events": """
+        CREATE TABLE IF NOT EXISTS immunity_shadow_events (
+            id            TEXT PRIMARY KEY,
+            observed_at   TEXT NOT NULL,      -- ISO8601 UTC — when the recall/inject was observed
+            gate          TEXT NOT NULL,      -- procedure | identity | autonomy | injection
+            mode          TEXT NOT NULL,      -- shadow | enforce (mode at observation; 'off' never records)
+            origin_class  TEXT NOT NULL,      -- blockable origin (external_untrusted for gate 4); owner/first_party NEVER recorded
+            would_block   INTEGER NOT NULL,   -- 1 = a live gate WOULD block; kept uniform for gates 1-3 forward-compat
+            source_kind   TEXT,               -- site class: recall_inject | proactive_hook | ...
+            source_ref    TEXT,               -- the site: 'mcp/memory/core.py::memory_recall'
+            detail        TEXT,               -- freeform (e.g. blockable item count); NEVER recalled content
+            process       TEXT                -- server | proactive_hook | outreach_mcp | ...
+            -- WS-3 immunity SHADOW store: gate DECISIONS + provenance refs only. Observe-only
+            -- — no recall is blocked or altered here; the item still reaches the prompt
+            -- (wrapped as it already was). Never stores recalled content. Not read by any
+            -- cognition job.
+        )
+    """,
     "observations": """
         CREATE TABLE IF NOT EXISTS observations (
             id               TEXT PRIMARY KEY,
@@ -1658,6 +1676,8 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_attention_events_unlabeled ON attention_events(acceptance_signal) WHERE acceptance_signal IS NULL",
     "CREATE INDEX IF NOT EXISTS idx_capability_shadow_events_observed_at ON capability_shadow_events(observed_at)",
     "CREATE INDEX IF NOT EXISTS idx_capability_shadow_events_cell ON capability_shadow_events(cell_domain, cell_verb, cell_risk_class)",
+    "CREATE INDEX IF NOT EXISTS idx_immunity_shadow_events_observed_at ON immunity_shadow_events(observed_at)",
+    "CREATE INDEX IF NOT EXISTS idx_immunity_shadow_events_gate ON immunity_shadow_events(gate, observed_at)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_task_type ON procedural_memory(task_type)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_draft ON procedural_memory(draft)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_activation_tier ON procedural_memory(activation_tier)",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -87,7 +87,7 @@ TABLES = {
             observed_at   TEXT NOT NULL,      -- ISO8601 UTC — when the recall/inject was observed
             gate          TEXT NOT NULL,      -- procedure | identity | autonomy | injection
             mode          TEXT NOT NULL,      -- shadow | enforce (mode at observation; 'off' never records)
-            origin_class  TEXT NOT NULL,      -- blockable origin (external_untrusted for gate 4); owner/first_party NEVER recorded
+            origin_class  TEXT NOT NULL,      -- blockable origin (external_untrusted for gate 4); a row is written only when the DERIVED origin is blockable
             would_block   INTEGER NOT NULL,   -- 1 = a live gate WOULD block; kept uniform for gates 1-3 forward-compat
             source_kind   TEXT,               -- site class: recall_inject | proactive_hook | ...
             source_ref    TEXT,               -- the site: 'mcp/memory/core.py::memory_recall'

--- a/src/genesis/knowledge/applications/resume_review.py
+++ b/src/genesis/knowledge/applications/resume_review.py
@@ -15,6 +15,7 @@ import logging
 from dataclasses import dataclass, field
 
 from genesis.memory.provenance import wrap_external_recall
+from genesis.security import immunity_shadow
 
 logger = logging.getLogger(__name__)
 
@@ -213,23 +214,38 @@ class ResumeReviewer:
             # KB FTS — every hit is external-world. Wrap both the vector
             # (`r.content`) and FTS (`body`) branches before they enter the
             # review LLM prompt so payloads are treated as data, not instructions.
+            blockable = 0
             for r in results:
                 if r.memory_id not in seen:
                     seen.add(r.memory_id)
-                    wrapped = wrap_external_recall(
-                        r.content, source_pipeline=getattr(r, "source_pipeline", None),
-                    )
+                    sp = getattr(r, "source_pipeline", None)
+                    wrapped = wrap_external_recall(r.content, source_pipeline=sp)
                     context_parts.append(f"[Knowledge: {r.source}]\n{wrapped}")
+                    if immunity_shadow.item_is_blockable(
+                        collection="knowledge_base", source_pipeline=sp,
+                    ):
+                        blockable += 1
 
             for fts in fts_results:
                 uid = fts["unit_id"]
                 if uid not in seen:
                     seen.add(uid)
                     concept = fts.get("concept", "")
-                    body = wrap_external_recall(
-                        fts.get("body", ""), source_pipeline=fts.get("source_pipeline"),
-                    )
+                    sp = fts.get("source_pipeline")
+                    body = wrap_external_recall(fts.get("body", ""), source_pipeline=sp)
                     context_parts.append(f"[Knowledge: {concept}]\n{body}")
+                    if immunity_shadow.item_is_blockable(
+                        collection="knowledge_base", source_pipeline=sp,
+                    ):
+                        blockable += 1
+
+            # WS-3 B1 gate 4 (injection): shadow-record external KB content
+            # reaching the resume-review LLM prompt (observe-only).
+            await immunity_shadow.record_would_block(
+                gate="injection", source_kind="recall_inject",
+                source_ref="knowledge/applications/resume_review.py::_query_knowledge_base",
+                process="server", blockable_count=blockable, db=memory_mod._db,
+            )
 
             return "\n\n---\n\n".join(context_parts[:20])
         except Exception:

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -15,6 +15,7 @@ from genesis.memory.provenance import (
     provenance_descriptor,
     wrap_external_recall,
 )
+from genesis.security import immunity_shadow
 
 from ..memory import mcp
 from ._scoring import DEFAULT_KB_FLOOR_RATIO, relative_kb_floor
@@ -406,11 +407,24 @@ async def memory_recall(
     # Injection defense (PR2): structurally delimit external-world content so
     # the model treats it as data, not first-party instructions. Gate on the
     # post-label collection so CRAG web-fallback items are covered too.
+    blockable = 0
     for d in enriched:
         if isinstance(d, dict) and is_external(d.get("collection")):
             d["content"] = wrap_external_recall(
                 d.get("content", ""), source_pipeline=d.get("source_pipeline"),
             )
+            if immunity_shadow.item_is_blockable(
+                collection=d.get("collection"),
+                source_pipeline=d.get("source_pipeline"),
+            ):
+                blockable += 1
+    # WS-3 B1 gate 4 (injection): shadow-record that external content reached
+    # this action-capable prompt (observe-only — the item still reaches the model).
+    await immunity_shadow.record_would_block(
+        gate="injection", source_kind="recall_inject",
+        source_ref="mcp/memory/core.py::memory_recall", process="server",
+        blockable_count=blockable, db=memory_mod._db,
+    )
     return enriched
 
 
@@ -518,6 +532,7 @@ async def memory_expand(
             logger.debug("eval: recall_used emit failed", exc_info=True)
 
     results = []
+    blockable = 0
     for point in points:
         mid = str(point.id)
         payload = point.payload or {}
@@ -551,6 +566,11 @@ async def memory_expand(
             d["content"] = wrap_external_recall(
                 d["content"], source_pipeline=payload.get("source_pipeline"),
             )
+            if immunity_shadow.item_is_blockable(
+                collection=_collection,
+                source_pipeline=payload.get("source_pipeline"),
+            ):
+                blockable += 1
 
         # Graph enrichment
         try:
@@ -571,6 +591,14 @@ async def memory_expand(
             logger.warning("Graph enrichment failed for %s", mid, exc_info=True)
 
         results.append(d)
+
+    # WS-3 B1 gate 4 (injection): shadow-record external content reaching this
+    # expand prompt (observe-only). memory_mod._db is asserted non-None above.
+    await immunity_shadow.record_would_block(
+        gate="injection", source_kind="recall_inject",
+        source_ref="mcp/memory/core.py::memory_expand", process="server",
+        blockable_count=blockable, db=memory_mod._db,
+    )
 
     if not_found or ambiguous:
         trailer = {"not_found": not_found}
@@ -660,13 +688,26 @@ async def memory_proactive(
     # can appear here and flow straight into prompt context — wrap external-world
     # items so the model treats them as data, not first-party instructions.
     out: list[dict] = []
+    blockable = 0
     for r in filtered:
         d = asdict(r)
         if is_external(r.collection):
             d["content"] = wrap_external_recall(
                 d.get("content", ""), source_pipeline=r.source_pipeline,
             )
+            if immunity_shadow.item_is_blockable(
+                collection=r.collection, source_pipeline=r.source_pipeline,
+            ):
+                blockable += 1
         out.append(d)
+    # WS-3 B1 gate 4 (injection): shadow-record external content reaching this
+    # proactive-recall prompt (observe-only). db=memory_mod._db when set, else
+    # the emit self-resolves a short-lived connection.
+    await immunity_shadow.record_would_block(
+        gate="injection", source_kind="recall_inject",
+        source_ref="mcp/memory/core.py::memory_proactive", process="server",
+        blockable_count=blockable, db=memory_mod._db,
+    )
     return out
 
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -335,6 +335,21 @@ async def memory_recall(
         pass  # instrumentation must never break recall
 
     if compact:
+        # WS-3 B1 gate 4 (injection): the compact branch returns external
+        # previews and RETURNS before the full-path wrap/emit below — record
+        # here too so compact recalls are not undercounted (observe-only).
+        blockable = sum(
+            1
+            for r in results
+            if immunity_shadow.item_is_blockable(
+                collection=r.collection, source_pipeline=r.source_pipeline,
+            )
+        )
+        await immunity_shadow.record_would_block(
+            gate="injection", source_kind="recall_inject",
+            source_ref="mcp/memory/core.py::memory_recall", process="server",
+            blockable_count=blockable, db=memory_mod._db, detail={"path": "compact"},
+        )
         return [
             {
                 "memory_id": r.memory_id,

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -16,6 +16,7 @@ from genesis.memory.reference_ops import (
 from genesis.memory.reference_ops import (
     delete_reference_entry,
 )
+from genesis.security import immunity_shadow
 
 from ..memory import mcp
 from ._scoring import DEFAULT_KB_FLOOR_RATIO, relative_kb_floor
@@ -212,11 +213,24 @@ async def knowledge_recall(
     # Injection defense (PR2): every knowledge_recall hit is external-world —
     # wrap the content (vector `r.content` and FTS `body` both land under the
     # `content` key here) so the model treats it as data, not instructions.
+    blockable = 0
     for d in final:
         if isinstance(d, dict) and "content" in d:
             d["content"] = wrap_external_recall(
                 d["content"], source_pipeline=d.get("source_pipeline"),
             )
+            if immunity_shadow.item_is_blockable(
+                collection=d.get("collection"),
+                source_pipeline=d.get("source_pipeline"),
+            ):
+                blockable += 1
+    # WS-3 B1 gate 4 (injection): shadow-record external content reaching this
+    # knowledge-recall prompt (observe-only — every hit is external-world).
+    await immunity_shadow.record_would_block(
+        gate="injection", source_kind="recall_inject",
+        source_ref="mcp/memory/knowledge.py::knowledge_recall", process="server",
+        blockable_count=blockable, db=memory_mod._db,
+    )
     return final
 
 

--- a/src/genesis/security/immunity_shadow.py
+++ b/src/genesis/security/immunity_shadow.py
@@ -44,38 +44,41 @@ from datetime import UTC, datetime, timedelta
 
 from genesis.db.connection import get_raw_db
 from genesis.db.crud import immunity_shadow as crud
-from genesis.memory.provenance import (
-    ORIGIN_EXTERNAL_UNTRUSTED,
-    derive_origin_class,
-    is_external,
-)
+from genesis.memory.provenance import ORIGIN_EXTERNAL_UNTRUSTED, is_external
 from genesis.security import immunity
 
 logger = logging.getLogger(__name__)
 
 
+# Pipelines that write genuine FIRST-PARTY content INTO the knowledge_base
+# (the B0 origin_class backfill set, migration 0054). Only these flip a
+# KB-collection item to first-party for the gate. A retrieval-MECHANISM tag
+# such as ``drift`` (which overwrites source_pipeline on drift-fallback
+# results) must NOT — otherwise drift recalls of external KB content go
+# uncounted, undercounting the gate-4 blast radius this shadow measures.
+_FIRST_PARTY_KB_PIPELINES = frozenset({"surplus", "reference_store", "extraction_job"})
+
+
 def item_is_blockable(*, collection: str | None, source_pipeline: str | None) -> bool:
     """True iff a recalled item would be blocked by the injection gate.
 
-    An item is blockable only when it is external by collection AND its derived
-    origin_class is ``external_untrusted``. First-party pipelines that live IN
-    the knowledge_base (surplus / reference_store / extraction_job) are NOT
-    blockable — so counting these keeps the never-block invariant honest at the
-    site, before the row is even emitted.
+    The AUTHORITATIVE external signal is the COLLECTION — ``knowledge_base`` ==
+    external-world, always known at recall time (unlike the per-item
+    source_pipeline, which drift recall overwrites with ``drift``). A KB item is
+    first-party (not blockable) ONLY when its source_pipeline is one that writes
+    first-party content INTO the KB (:data:`_FIRST_PARTY_KB_PIPELINES`) — never
+    because of a retrieval-mechanism tag. This keeps the never-block invariant
+    honest at the site AND counts drift-recalled external content.
 
-    NOTE (B4): this re-derives origin_class from the recall dict's
-    (source_pipeline, collection) because the retriever does not yet plumb the
-    STORED origin_class into results. It is conservative — the rare
-    subsystem-tagged first-party item in KB (no source_subsystem on the recall
-    dict) derives external here, so shadow may slightly over-observe. That is
-    safe in shadow (never blocks); ENFORCE (B4) must gate on the stored
-    origin_class, not this re-derivation. Tracked as a B1 follow-up.
+    NOTE (B4): this uses the recall dict's (collection, source_pipeline), not
+    the STORED origin_class (the retriever doesn't plumb it yet). Safe in shadow
+    (never blocks; conservative — over-observes only a first-party item stored
+    via a non-KB-content pipeline yet living in the KB); ENFORCE (B4) must gate
+    on the stored origin_class. Tracked as a B1 follow-up.
     """
     if not is_external(collection):
         return False
-    return immunity.is_blockable(
-        derive_origin_class(source_pipeline=source_pipeline, collection=collection)
-    )
+    return source_pipeline not in _FIRST_PARTY_KB_PIPELINES
 
 
 def _build_row(

--- a/src/genesis/security/immunity_shadow.py
+++ b/src/genesis/security/immunity_shadow.py
@@ -203,6 +203,9 @@ def record_would_block_sync(
         return False
 
 
+# GROUNDWORK(ws3-b1-readsurface): the B1 observability read. No live caller
+# yet (B4 / a dashboard card consumes it — see follow-up); do NOT delete as
+# dead code. crud.summary/list_recent are reached only through here.
 async def recent_summary(*, since: str | None = None, db=None) -> list[dict]:
     """Per-gate / per-site would-block rollup (COUNTS only, no content).
 

--- a/src/genesis/security/immunity_shadow.py
+++ b/src/genesis/security/immunity_shadow.py
@@ -1,0 +1,239 @@
+"""WS-3 B1 emit layer — record what an immunity gate WOULD block, in shadow.
+
+This is the thin, best-effort bridge the recall/inject sites call. It is the
+ONE place the never-block invariant + kill switch are enforced for shadow
+recording:
+
+- read :func:`genesis.security.immunity.gate_mode` LIVE — a master
+  ``enabled=false`` or a per-gate ``off`` short-circuits with no write, in
+  process, no restart;
+- honor the never-block invariant via
+  :func:`genesis.security.immunity.is_blockable` — owner/first_party origins
+  NEVER produce a row, in any mode;
+- write at most ONE row per recall event (the site passes a blockable-item
+  count), so hot paths pay a single INSERT, not one-per-item.
+
+Two writer flavors mirror the two runtime contexts:
+
+- :func:`record_would_block` (async) — genesis-server recall/inject sites. If
+  the caller has a live ``aiosqlite`` handle (the MCP recall tools do, via
+  ``memory_mod._db``) it reuses it; the retriever-based sites (research, voice,
+  cc.context_injector) pass ``db=None`` and the emit opens its own short-lived
+  connection via :func:`genesis.db.connection.get_raw_db`.
+- :func:`record_would_block_sync` (sync) — the ``UserPromptSubmit`` proactive
+  memory hook, a foreground ``sqlite3`` process. It never auto-demotes (a hook
+  subprocess must not mutate the immunity overlay on the hot path).
+
+Auto-demote is wired but DORMANT: it only acts from ``process=="server"`` AND
+only when the gate is already ``enforce`` (B4). In shadow it is a no-op.
+
+Everything here is fail-open: any error is swallowed (logged at debug) so a
+recall/inject is NEVER broken by shadow observability.
+
+Layering: imports only ``db.crud.immunity_shadow`` + ``db.connection`` +
+``security.immunity`` (+ provenance constants). It must never import the
+recall/inject sites that call it (no cycle), nor ``mcp.health.settings``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from genesis.db.connection import get_raw_db
+from genesis.db.crud import immunity_shadow as crud
+from genesis.memory.provenance import (
+    ORIGIN_EXTERNAL_UNTRUSTED,
+    derive_origin_class,
+    is_external,
+)
+from genesis.security import immunity
+
+logger = logging.getLogger(__name__)
+
+
+def item_is_blockable(*, collection: str | None, source_pipeline: str | None) -> bool:
+    """True iff a recalled item would be blocked by the injection gate.
+
+    An item is blockable only when it is external by collection AND its derived
+    origin_class is ``external_untrusted``. First-party pipelines that live IN
+    the knowledge_base (surplus / reference_store / extraction_job) are NOT
+    blockable — so counting these keeps the never-block invariant honest at the
+    site, before the row is even emitted.
+
+    NOTE (B4): this re-derives origin_class from the recall dict's
+    (source_pipeline, collection) because the retriever does not yet plumb the
+    STORED origin_class into results. It is conservative — the rare
+    subsystem-tagged first-party item in KB (no source_subsystem on the recall
+    dict) derives external here, so shadow may slightly over-observe. That is
+    safe in shadow (never blocks); ENFORCE (B4) must gate on the stored
+    origin_class, not this re-derivation. Tracked as a B1 follow-up.
+    """
+    if not is_external(collection):
+        return False
+    return immunity.is_blockable(
+        derive_origin_class(source_pipeline=source_pipeline, collection=collection)
+    )
+
+
+def _build_row(
+    *,
+    gate: str,
+    mode: str,
+    origin_class: str,
+    source_kind: str | None,
+    source_ref: str | None,
+    process: str | None,
+    blockable_count: int,
+    detail: dict | None,
+) -> dict:
+    payload = {"blockable": blockable_count}
+    if detail:
+        payload.update(detail)
+    return {
+        "id": uuid.uuid4().hex,
+        "observed_at": datetime.now(UTC).isoformat(),
+        "gate": gate,
+        "mode": mode,
+        "origin_class": origin_class,
+        "would_block": True,
+        "source_kind": source_kind,
+        "source_ref": source_ref,
+        "detail": json.dumps(payload, separators=(",", ":")),
+        "process": process,
+    }
+
+
+def _should_record(gate: str, origin_class: str, blockable_count: int) -> str | None:
+    """Return the effective mode to record under, or None to skip.
+
+    Skips when nothing is blockable, the gate is off (kill switch), or the
+    origin is not blockable (never-block-owner/first_party invariant).
+    """
+    if blockable_count <= 0:
+        return None
+    mode = immunity.gate_mode(gate)
+    if mode == "off":
+        return None
+    if not immunity.is_blockable(origin_class):
+        return None
+    return mode
+
+
+async def record_would_block(
+    *,
+    gate: str,
+    source_kind: str | None,
+    source_ref: str | None,
+    process: str | None,
+    blockable_count: int,
+    origin_class: str = ORIGIN_EXTERNAL_UNTRUSTED,
+    db=None,
+    detail: dict | None = None,
+) -> bool:
+    """Record one would-block shadow row (async). Best-effort, never raises.
+
+    Returns True iff a row was written. ``db`` is a live ``aiosqlite`` handle
+    to reuse; pass None to self-resolve a short-lived connection.
+    """
+    try:
+        mode = _should_record(gate, origin_class, blockable_count)
+        if mode is None:
+            return False
+        row = _build_row(
+            gate=gate,
+            mode=mode,
+            origin_class=origin_class,
+            source_kind=source_kind,
+            source_ref=source_ref,
+            process=process,
+            blockable_count=blockable_count,
+            detail=detail,
+        )
+        if db is not None:
+            wrote = await crud.record(db, **row)
+            if wrote:
+                await _maybe_auto_demote(db, gate=gate, mode=mode, process=process)
+            return wrote
+        async with get_raw_db() as conn:
+            wrote = await crud.record(conn, **row)
+            if wrote:
+                await _maybe_auto_demote(conn, gate=gate, mode=mode, process=process)
+            return wrote
+    except Exception:
+        logger.debug("immunity shadow emit failed (best-effort)", exc_info=True)
+        return False
+
+
+def record_would_block_sync(
+    conn,
+    *,
+    gate: str,
+    source_kind: str | None,
+    source_ref: str | None,
+    blockable_count: int,
+    origin_class: str = ORIGIN_EXTERNAL_UNTRUSTED,
+    process: str | None = "proactive_hook",
+    detail: dict | None = None,
+) -> bool:
+    """Sync sibling for the proactive-memory hook (stdlib ``sqlite3``).
+
+    Same invariant + kill-switch guards; never auto-demotes (a hook subprocess
+    must not mutate the immunity overlay). Best-effort, never raises.
+    """
+    try:
+        mode = _should_record(gate, origin_class, blockable_count)
+        if mode is None:
+            return False
+        row = _build_row(
+            gate=gate,
+            mode=mode,
+            origin_class=origin_class,
+            source_kind=source_kind,
+            source_ref=source_ref,
+            process=process,
+            blockable_count=blockable_count,
+            detail=detail,
+        )
+        return crud.record_sync(conn, **row)
+    except Exception:
+        logger.debug("immunity shadow sync emit failed (best-effort)", exc_info=True)
+        return False
+
+
+async def recent_summary(*, since: str | None = None, db=None) -> list[dict]:
+    """Per-gate / per-site would-block rollup (COUNTS only, no content).
+
+    The B1 observability read: how much external content reaches each
+    action-capable inject site, sizing the B4 enforce blast radius. Optionally
+    bounded to rows at/after ISO ``since``. Self-resolves a connection when
+    ``db`` is None. Best-effort: returns [] on error.
+    """
+    try:
+        if db is not None:
+            return await crud.summary(db, since=since)
+        async with get_raw_db() as conn:
+            return await crud.summary(conn, since=since)
+    except Exception:
+        logger.debug("immunity shadow summary read failed", exc_info=True)
+        return []
+
+
+async def _maybe_auto_demote(db, *, gate: str, mode: str, process: str | None) -> None:
+    """Demote *gate* enforce→shadow if would-blocks breach the configured
+    threshold. DORMANT in shadow: only acts from the server process AND only
+    when the gate is already ``enforce`` (B4). Never mutates config from a
+    hook subprocess."""
+    if process != "server" or mode != "enforce":
+        return
+    cfg = immunity.load_immunity_config().get("auto_demote", {})
+    if not cfg.get("enabled", True):
+        return
+    window = int(cfg.get("window_minutes", 60))
+    threshold = int(cfg.get("would_block_threshold", 5))
+    since = (datetime.now(UTC) - timedelta(minutes=window)).isoformat()
+    n = await crud.count_would_block(db, gate=gate, since=since)
+    if n >= threshold:
+        immunity.record_demotion(gate, f"auto-demote: {n} would-blocks in {window}m >= {threshold}")

--- a/tests/test_db/test_crud_immunity_shadow.py
+++ b/tests/test_db/test_crud_immunity_shadow.py
@@ -1,0 +1,188 @@
+"""crud.immunity_shadow: WS-3 B1 immunity SHADOW store.
+
+Best-effort record with a table-existence guard (async + sync writer paths),
+plus read/aggregation/retention helpers. Modeled on
+``crud.capability_shadow`` — the immunity gate is observe-only: rows are gate
+DECISIONS + provenance refs, never recalled content, never a block.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import immunity_shadow as crud
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+@pytest.fixture(autouse=True)
+def _reset_table_cache():
+    # Per-process existence caches (async + sync) would leak across tests
+    # (a test that creates the table would mark it verified for a later
+    # "no table" test).
+    crud._table_verified = False
+    crud._table_verified_sync = False
+    yield
+    crud._table_verified = False
+    crud._table_verified_sync = False
+
+
+async def _db(path, *, with_table=True):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    if with_table:
+        await conn.execute(TABLES["immunity_shadow_events"])
+        for idx in INDEXES:
+            if "immunity_shadow_events" in idx:
+                await conn.execute(idx)
+        await conn.commit()
+    return conn
+
+
+def _sync_db(path, *, with_table=True):
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    if with_table:
+        conn.execute(TABLES["immunity_shadow_events"])
+        for idx in INDEXES:
+            if "immunity_shadow_events" in idx:
+                conn.execute(idx)
+        conn.commit()
+    return conn
+
+
+def _kw(
+    n,
+    *,
+    gate="injection",
+    mode="shadow",
+    origin_class="external_untrusted",
+    would_block=True,
+    source_ref="mcp/memory/core.py::memory_recall",
+    source_kind="recall_inject",
+    process="server",
+    observed_at=None,
+):
+    return {
+        "id": f"im-{n}",
+        "observed_at": observed_at or f"2026-07-11T00:00:0{n}+00:00",
+        "gate": gate,
+        "mode": mode,
+        "origin_class": origin_class,
+        "would_block": would_block,
+        "source_kind": source_kind,
+        "source_ref": source_ref,
+        "detail": '{"blockable": 3}',
+        "process": process,
+    }
+
+
+@pytest.mark.asyncio
+async def test_record_inserts_and_count(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    assert await crud.record(db, **_kw(1)) is True
+    assert await crud.count(db) == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_record_noops_when_table_absent(tmp_path):
+    db = await _db(tmp_path / "g.db", with_table=False)
+    # Best-effort: subprocess pre-migration window — skip, do NOT raise, do NOT create.
+    assert await crud.record(db, **_kw(1)) is False
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='immunity_shadow_events'"
+    )
+    assert await cur.fetchone() is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_record_self_heals_after_table_created(tmp_path):
+    db = await _db(tmp_path / "g.db", with_table=False)
+    assert await crud.record(db, **_kw(1)) is False  # missing -> skip (cache stays False)
+    await db.execute(TABLES["immunity_shadow_events"])
+    await db.commit()
+    assert await crud.record(db, **_kw(2)) is True  # writes without a restart
+    assert await crud.count(db) == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_would_block_stored_as_int(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **_kw(1, would_block=True))
+    await crud.record(db, **_kw(2, would_block=False))
+    rows = {r["id"]: r["would_block"] for r in await crud.list_recent(db)}
+    assert rows == {"im-1": 1, "im-2": 0}
+    await db.close()
+
+
+def test_record_sync_inserts(tmp_path):
+    conn = _sync_db(tmp_path / "g.db")
+    assert crud.record_sync(conn, **_kw(1, process="proactive_hook")) is True
+    cur = conn.execute("SELECT COUNT(*) FROM immunity_shadow_events")
+    assert cur.fetchone()[0] == 1
+    conn.close()
+
+
+def test_record_sync_noops_when_table_absent(tmp_path):
+    conn = _sync_db(tmp_path / "g.db", with_table=False)
+    assert crud.record_sync(conn, **_kw(1)) is False
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='immunity_shadow_events'"
+    )
+    assert cur.fetchone() is None
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_count_would_block_filters_gate_and_since(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(
+        db, **_kw(1, gate="injection", would_block=True, observed_at="2026-07-11T10:00:00+00:00")
+    )
+    await crud.record(
+        db, **_kw(2, gate="injection", would_block=True, observed_at="2026-07-11T09:00:00+00:00")
+    )
+    # A would_block=0 row must NOT be counted.
+    await crud.record(
+        db, **_kw(3, gate="injection", would_block=False, observed_at="2026-07-11T10:00:00+00:00")
+    )
+    # A different gate must NOT be counted.
+    await crud.record(
+        db, **_kw(4, gate="procedure", would_block=True, observed_at="2026-07-11T10:00:00+00:00")
+    )
+    n = await crud.count_would_block(db, gate="injection", since="2026-07-11T09:30:00+00:00")
+    assert n == 1  # only im-1 (injection, would_block, after the cutoff)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_summary_groups_by_gate_and_source(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **_kw(1, source_ref="A", gate="injection"))
+    await crud.record(db, **_kw(2, source_ref="A", gate="injection"))
+    await crud.record(db, **_kw(3, source_ref="B", gate="injection"))
+    rows = await crud.summary(db)
+    top = rows[0]
+    assert top["source_ref"] == "A" and top["gate"] == "injection" and top["n"] == 2
+    assert any(r["source_ref"] == "B" and r["n"] == 1 for r in rows)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_deletes_only_old_rows(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **_kw(1, observed_at="2026-01-01T00:00:00+00:00"))  # old
+    await crud.record(db, **_kw(2, observed_at="2026-07-11T00:00:00+00:00"))  # fresh
+    deleted = await crud.prune_immunity_shadow_events(
+        db, older_than_days=45, now="2026-07-11T12:00:00+00:00"
+    )
+    assert deleted == 1
+    assert await crud.count(db) == 1
+    remaining = await crud.list_recent(db)
+    assert remaining[0]["id"] == "im-2"
+    await db.close()

--- a/tests/test_db/test_migration_0055_immunity_shadow_events.py
+++ b/tests/test_db/test_migration_0055_immunity_shadow_events.py
@@ -1,0 +1,94 @@
+"""Migration 0055 — create immunity_shadow_events (WS-3 B1 immunity SHADOW store).
+
+Verifies the table/columns/indexes, idempotency, and down().
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M55 = importlib.import_module("genesis.db.migrations.0055_immunity_shadow_events")
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _indexes(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?", (table,)
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+async def _table_exists(db: aiosqlite.Connection, table: str) -> bool:
+    cur = await db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,))
+    return await cur.fetchone() is not None
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_creates_table_with_expected_columns(db):
+    await M55.up(db)
+    cols = await _columns(db, "immunity_shadow_events")
+    assert {
+        "id",
+        "observed_at",
+        "gate",
+        "mode",
+        "origin_class",
+        "would_block",
+        "source_kind",
+        "source_ref",
+        "detail",
+        "process",
+    } == cols  # exact column set — no recalled-content column leaks in
+
+
+@pytest.mark.asyncio
+async def test_creates_indexes(db):
+    await M55.up(db)
+    idx = await _indexes(db, "immunity_shadow_events")
+    assert {
+        "idx_immunity_shadow_events_observed_at",
+        "idx_immunity_shadow_events_gate",
+    } <= idx
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_rerun(db):
+    await M55.up(db)
+    await M55.up(db)  # CREATE IF NOT EXISTS -> must not raise
+    assert await _table_exists(db, "immunity_shadow_events")
+
+
+@pytest.mark.asyncio
+async def test_down_drops_table(db):
+    await M55.up(db)
+    await M55.down(db)
+    assert not await _table_exists(db, "immunity_shadow_events")
+
+
+@pytest.mark.asyncio
+async def test_matches_schema_mirror(db):
+    """The migration and the fresh-DB mirror in _tables.py must agree."""
+    from genesis.db.schema._tables import TABLES
+
+    await M55.up(db)
+    migrated = await _columns(db, "immunity_shadow_events")
+
+    async with aiosqlite.connect(":memory:") as fresh:
+        await fresh.execute(TABLES["immunity_shadow_events"])
+        cur = await fresh.execute("PRAGMA table_info(immunity_shadow_events)")
+        mirror = {row[1] for row in await cur.fetchall()}
+    assert migrated == mirror

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -63,6 +63,7 @@ EXPECTED_TABLES = [
     "pending_email_sends",  # WS-8 PR-C: email autonomy gate hold store
     "autonomous_email_sends",  # WS-8 PR-D: autonomous-send ledger (visibility + flag + rate-limit)
     "capability_shadow_events",  # WS5 Stage 2: Discord capability shadow-gate observations
+    "immunity_shadow_events",  # WS-3 B1: provenance-gate (injection) shadow observations
     "build_candidates",  # capability-build lane: verdicts + calibration + build outcomes
 ]
 

--- a/tests/test_security/test_immunity_shadow.py
+++ b/tests/test_security/test_immunity_shadow.py
@@ -1,0 +1,234 @@
+"""WS-3 B1 emit layer — security.immunity_shadow.
+
+The emit is the ONE place the never-block invariant + kill switch are enforced
+for shadow recording: it writes a would-block row ONLY when the gate is not
+off, the origin is blockable (external_untrusted), and at least one item was
+blockable. owner/first_party never produce a row; master ``enabled=false``
+short-circuits live.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import immunity_shadow as crud
+from genesis.db.schema._tables import INDEXES, TABLES
+from genesis.security import immunity, immunity_shadow
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    crud._table_verified = False
+    crud._table_verified_sync = False
+    yield
+    crud._table_verified = False
+    crud._table_verified_sync = False
+
+
+async def _db(path):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute(TABLES["immunity_shadow_events"])
+    for idx in INDEXES:
+        if "immunity_shadow_events" in idx:
+            await conn.execute(idx)
+    await conn.commit()
+    return conn
+
+
+def _sync_db(path):
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(TABLES["immunity_shadow_events"])
+    conn.commit()
+    return conn
+
+
+_SITE = dict(
+    gate="injection",
+    source_kind="recall_inject",
+    source_ref="mcp/memory/core.py::memory_recall",
+    process="server",
+)
+
+
+@pytest.mark.asyncio
+async def test_shadow_external_records_one_row(tmp_path, monkeypatch):
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    db = await _db(tmp_path / "g.db")
+    wrote = await immunity_shadow.record_would_block(
+        **_SITE,
+        blockable_count=3,
+        origin_class="external_untrusted",
+        db=db,
+    )
+    assert wrote is True
+    rows = await crud.list_recent(db)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["gate"] == "injection" and r["mode"] == "shadow"
+    assert r["origin_class"] == "external_untrusted" and r["would_block"] == 1
+    assert '"blockable":3' in r["detail"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_zero_blockable_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    db = await _db(tmp_path / "g.db")
+    wrote = await immunity_shadow.record_would_block(
+        **_SITE,
+        blockable_count=0,
+        origin_class="external_untrusted",
+        db=db,
+    )
+    assert wrote is False
+    assert await crud.count(db) == 0
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_gate_off_short_circuits(tmp_path, monkeypatch):
+    # Kill switch: master enabled=false → gate_mode returns "off" → no row.
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "off")
+    db = await _db(tmp_path / "g.db")
+    wrote = await immunity_shadow.record_would_block(
+        **_SITE,
+        blockable_count=5,
+        origin_class="external_untrusted",
+        db=db,
+    )
+    assert wrote is False
+    assert await crud.count(db) == 0
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_first_party_never_recorded(tmp_path, monkeypatch):
+    # The never-block invariant — enforced centrally in the emit via is_blockable.
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    db = await _db(tmp_path / "g.db")
+    for oc in ("first_party", "owner"):
+        wrote = await immunity_shadow.record_would_block(
+            **_SITE,
+            blockable_count=9,
+            origin_class=oc,
+            db=db,
+        )
+        assert wrote is False
+    assert await crud.count(db) == 0
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_auto_demote_noop_in_shadow(tmp_path, monkeypatch):
+    # Even over the would-block threshold, shadow mode must NEVER demote.
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    demoted = []
+    monkeypatch.setattr(immunity, "record_demotion", lambda g, r: demoted.append((g, r)))
+    db = await _db(tmp_path / "g.db")
+    for _ in range(20):
+        await immunity_shadow.record_would_block(
+            **_SITE,
+            blockable_count=1,
+            origin_class="external_untrusted",
+            db=db,
+        )
+    assert demoted == []  # dormant until B4 flips a gate to enforce
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_db_none_self_resolves(tmp_path, monkeypatch):
+    # Retriever-based sites (research/voice/context_injector) pass db=None; the
+    # emit opens its own short-lived connection.
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    db = await _db(tmp_path / "resolved.db")
+
+    @contextlib.asynccontextmanager
+    async def _fake_raw():
+        yield db
+
+    monkeypatch.setattr(immunity_shadow, "get_raw_db", _fake_raw)
+    wrote = await immunity_shadow.record_would_block(
+        gate="injection",
+        source_kind="recall_inject",
+        source_ref="autonomy/executor/research.py::_memory_recall",
+        process="server",
+        blockable_count=2,
+        origin_class="external_untrusted",
+        db=None,
+    )
+    assert wrote is True
+    assert await crud.count(db) == 1
+    await db.close()
+
+
+def test_sync_emit_records(tmp_path, monkeypatch):
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    conn = _sync_db(tmp_path / "g.db")
+    wrote = immunity_shadow.record_would_block_sync(
+        conn,
+        gate="injection",
+        source_kind="proactive_hook",
+        source_ref="scripts/proactive_memory_hook.py::_format_results",
+        blockable_count=1,
+        origin_class="external_untrusted",
+    )
+    assert wrote is True
+    assert conn.execute("SELECT COUNT(*) FROM immunity_shadow_events").fetchone()[0] == 1
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "collection,source_pipeline,expected",
+    [
+        ("knowledge_base", "knowledge_ingest", True),  # external KB content
+        ("knowledge_base", None, True),  # KB default → external
+        ("knowledge_base", "surplus", False),  # first-party pipeline IN kb
+        ("knowledge_base", "reference_store", False),  # first-party pipeline IN kb
+        ("episodic_memory", "conversation", False),  # not external at all
+        (None, None, False),  # unknown → not external
+    ],
+)
+def test_item_is_blockable_honors_first_party_in_kb(collection, source_pipeline, expected):
+    assert (
+        immunity_shadow.item_is_blockable(collection=collection, source_pipeline=source_pipeline)
+        is expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_recent_summary_rolls_up(tmp_path, monkeypatch):
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    db = await _db(tmp_path / "g.db")
+    for _ in range(3):
+        await immunity_shadow.record_would_block(
+            **_SITE,
+            blockable_count=1,
+            origin_class="external_untrusted",
+            db=db,
+        )
+    rows = await immunity_shadow.recent_summary(db=db)
+    assert rows and rows[0]["n"] == 3
+    assert rows[0]["source_ref"] == _SITE["source_ref"]
+    await db.close()
+
+
+def test_sync_emit_gate_off(tmp_path, monkeypatch):
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "off")
+    conn = _sync_db(tmp_path / "g.db")
+    wrote = immunity_shadow.record_would_block_sync(
+        conn,
+        gate="injection",
+        source_kind="proactive_hook",
+        source_ref="scripts/proactive_memory_hook.py::_format_results",
+        blockable_count=1,
+        origin_class="external_untrusted",
+    )
+    assert wrote is False
+    conn.close()

--- a/tests/test_security/test_immunity_shadow.py
+++ b/tests/test_security/test_immunity_shadow.py
@@ -188,6 +188,7 @@ def test_sync_emit_records(tmp_path, monkeypatch):
     "collection,source_pipeline,expected",
     [
         ("knowledge_base", "knowledge_ingest", True),  # external KB content
+        ("knowledge_base", "drift", True),  # drift MECHANISM tag, not first-party
         ("knowledge_base", None, True),  # KB default → external
         ("knowledge_base", "surplus", False),  # first-party pipeline IN kb
         ("knowledge_base", "reference_store", False),  # first-party pipeline IN kb

--- a/tests/test_security/test_immunity_shadow_e2e.py
+++ b/tests/test_security/test_immunity_shadow_e2e.py
@@ -1,0 +1,198 @@
+"""WS-3 B1 end-to-end: real migration chain + real config + real emit + prune.
+
+Unlike the unit tests (which monkeypatch ``gate_mode``), this drives the ACTUAL
+``config/ws3_immunity.yaml`` through ``security.immunity.gate_mode`` and the
+real ``MigrationRunner``, proving the shadow injection gate flows data
+end-to-end with no mocks.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import immunity_shadow as crud
+from genesis.db.migrations.runner import MigrationRunner
+from genesis.security import immunity, immunity_shadow
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    crud._table_verified = False
+    crud._table_verified_sync = False
+    yield
+    crud._table_verified = False
+    crud._table_verified_sync = False
+
+
+async def _migrated(path) -> aiosqlite.Connection:
+    db = await aiosqlite.connect(str(path))
+    db.row_factory = aiosqlite.Row
+    await MigrationRunner(db).run_pending()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_full_migration_chain_creates_table(tmp_path):
+    """If the system migrates from scratch now, the 0055 chain lands the table
+    (+ indexes) — proving 0055 composes with every prior migration."""
+    db = await _migrated(tmp_path / "g.db")
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='immunity_shadow_events'"
+    )
+    assert await cur.fetchone() is not None
+    idx = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='immunity_shadow_events'"
+    )
+    names = {r[0] for r in await idx.fetchall()}
+    assert {
+        "idx_immunity_shadow_events_observed_at",
+        "idx_immunity_shadow_events_gate",
+    } <= names
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_real_config_drives_shadow_emit(tmp_path):
+    """Real config → emit integration, no mocks. Whatever the live merged
+    ws3_immunity config says for the injection gate, the emit honors it:
+    off → no row; shadow/enforce → an external row lands, first_party never."""
+    mode = immunity.gate_mode("injection")  # reads config/ws3_immunity.yaml live
+    assert mode in ("off", "shadow", "enforce")
+
+    db = await _migrated(tmp_path / "g.db")
+    wrote_ext = await immunity_shadow.record_would_block(
+        gate="injection",
+        source_kind="recall_inject",
+        source_ref="mcp/memory/core.py::memory_recall",
+        process="server",
+        blockable_count=2,
+        origin_class="external_untrusted",
+        db=db,
+    )
+    # The never-block invariant holds under the REAL config too.
+    wrote_fp = await immunity_shadow.record_would_block(
+        gate="injection",
+        source_kind="recall_inject",
+        source_ref="x",
+        process="server",
+        blockable_count=2,
+        origin_class="first_party",
+        db=db,
+    )
+    assert wrote_fp is False
+
+    if mode == "off":
+        assert wrote_ext is False
+        assert await crud.count(db) == 0
+    else:
+        assert wrote_ext is True
+        rows = await crud.list_recent(db)
+        assert len(rows) == 1
+        assert rows[0]["origin_class"] == "external_untrusted"
+        assert rows[0]["mode"] == mode
+        summary = await immunity_shadow.recent_summary(db=db)
+        assert summary and summary[0]["n"] == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_item_classifier_matches_store_derivation(tmp_path):
+    """The recall-time blockability classifier agrees with store-time
+    derivation for the common cases (external KB blockable; first-party
+    pipelines in KB not)."""
+    assert (
+        immunity_shadow.item_is_blockable(
+            collection="knowledge_base", source_pipeline="knowledge_ingest"
+        )
+        is True
+    )
+    assert (
+        immunity_shadow.item_is_blockable(collection="knowledge_base", source_pipeline="surplus")
+        is False
+    )
+    assert (
+        immunity_shadow.item_is_blockable(collection="episodic_memory", source_pipeline=None)
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_compact_branch_emits(tmp_path, monkeypatch):
+    """Regression (Fable GAP): the compact=True branch early-returns previews
+    BEFORE the full-path wrap/emit — it must still record the gate. Drives the
+    real memory_recall(compact=True) with a stubbed retriever + migrated DB."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import genesis.mcp.memory_mcp as mod
+    from genesis.memory.types import RetrievalResult
+
+    db = await _migrated(tmp_path / "g.db")
+    kb_hit = RetrievalResult(
+        memory_id="m1",
+        content="external doc body",
+        source="doc",
+        memory_type="fact",
+        score=0.9,
+        vector_rank=1,
+        fts_rank=None,
+        activation_score=0.5,
+        payload={"wing": "", "room": ""},
+        source_pipeline="knowledge_ingest",
+        memory_class="fact",
+        collection="knowledge_base",
+    )
+    retriever = AsyncMock()
+    retriever.recall = AsyncMock(return_value=[kb_hit])
+
+    old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+    try:
+        mod._store, mod._db, mod._retriever, mod._qdrant = (
+            MagicMock(),
+            db,
+            retriever,
+            MagicMock(),
+        )
+        from genesis.mcp.memory.core import memory_recall
+
+        out = await memory_recall.fn(
+            "q",
+            source="knowledge",
+            compact=True,
+            mode="standard",
+            corrective=False,
+            include_graph=False,
+            rerank=False,
+            expand_query_terms=False,
+        )
+        assert out and out[0]["memory_id"] == "m1"  # compact preview returned
+        rows = await crud.list_recent(db)
+        assert len(rows) == 1  # ...AND the gate recorded it
+        assert rows[0]["source_ref"] == "mcp/memory/core.py::memory_recall"
+        assert '"path":"compact"' in rows[0]["detail"]
+    finally:
+        mod._store, mod._db, mod._retriever, mod._qdrant = old
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_bounds_the_store(tmp_path):
+    db = await _migrated(tmp_path / "g.db")
+    common = dict(
+        gate="injection",
+        mode="shadow",
+        origin_class="external_untrusted",
+        would_block=True,
+        source_kind="recall_inject",
+        source_ref="x",
+        detail=None,
+        process="server",
+    )
+    await crud.record(db, id="old", observed_at="2026-01-01T00:00:00+00:00", **common)
+    await crud.record(db, id="new", observed_at="2026-07-11T00:00:00+00:00", **common)
+    deleted = await crud.prune_immunity_shadow_events(
+        db, older_than_days=45, now="2026-07-11T12:00:00+00:00"
+    )
+    assert deleted == 1
+    assert await crud.count(db) == 1
+    await db.close()

--- a/tests/test_security/test_recall_inject_coverage.py
+++ b/tests/test_security/test_recall_inject_coverage.py
@@ -138,7 +138,7 @@ _EXTRA_WRAPPED_SITES: dict[str, tuple[str, str]] = {
 # hatch for a future site that legitimately should not gate.
 INJECTION_GATE_SITES: dict[str, tuple[str, str]] = {
     "mcp/memory/core.py::memory_recall": (
-        "gated", "per-call blockable count over the enriched result set"),
+        "gated", "emits on BOTH the full (enriched) and compact-preview branches"),
     "mcp/memory/core.py::memory_proactive": (
         "gated", "source=both default; emits per-call blockable count"),
     "mcp/memory/knowledge.py::knowledge_recall": (
@@ -154,6 +154,14 @@ INJECTION_GATE_SITES: dict[str, tuple[str, str]] = {
     **_EXTRA_WRAPPED_SITES,
 }
 
+
+# OUT OF GATE-4 SCOPE (external-tool-output, not recall-inject): document_query
+# (mcp/memory/documents.py) sends a PDF to the external PageIndex QA service
+# and returns its SYNTHESIZED answer to the prompt; web_fetch / web_search
+# likewise return external tool output. These reach a prompt but carry no
+# origin_class / wrap_external_recall model, so they are a DIFFERENT gate
+# class (quarantine tool output), not part of the provenance-based recall
+# gate this registry enforces. Tracked as a separate WS-3 follow-up.
 
 def _functions_calling(attrs: set[str]) -> set[str]:
     """Return {"relpath::func"} for every function under src that calls a method

--- a/tests/test_security/test_recall_inject_coverage.py
+++ b/tests/test_security/test_recall_inject_coverage.py
@@ -26,7 +26,8 @@ import ast
 import pathlib
 
 # Repo-root-relative source tree.
-_SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "genesis"
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SRC = _REPO_ROOT / "src" / "genesis"
 
 # Valid dispositions for a recall call site.
 #   wrapped          — external-world content can reach an LLM prompt here; it is
@@ -109,6 +110,119 @@ def _discover_recall_sites() -> dict[str, int]:
                         best, enclosing = start, name
                 found.setdefault(f"{rel}::{enclosing}", node.lineno)
     return found
+
+
+# ── WS-3 B1: injection-gate (gate 4) coverage lock ─────────────────────────
+# Every `wrapped` recall site (external-world content reaching an
+# action-capable LLM prompt) must ALSO be classified here as `gated` (it emits
+# a shadow would-block via ``security.immunity_shadow``) or
+# `deferred-with-reason`. This converts gate coverage into a PR-time forcing
+# function: a new wrapped site cannot silently bypass the injection gate, and
+# removing an emit from a gated site fails CI (see
+# ``test_gated_sites_actually_emit``).
+_GATE_VALID = {"gated", "deferred-with-reason"}
+
+# Two wrapped inject sites reach an LLM prompt but are NOT captured by the
+# ``.recall()`` AST sweep above — ``memory_expand`` retrieves by-id via
+# ``_qdrant.retrieve``, and the proactive hook lives outside ``src/genesis``.
+# They are enumerated explicitly so the gate set is complete.
+_EXTRA_WRAPPED_SITES: dict[str, tuple[str, str]] = {
+    "mcp/memory/core.py::memory_expand": (
+        "gated", "by-id retrieve (not .recall); wraps + emits external hits"),
+    "scripts/proactive_memory_hook.py::_run": (
+        "gated", "sync emit after stdout flush; lives outside src/genesis"),
+}
+
+# file::func -> (gate disposition, why). All wrapped sites are gated now
+# (enumeration-complete); `deferred-with-reason` stays as the explicit escape
+# hatch for a future site that legitimately should not gate.
+INJECTION_GATE_SITES: dict[str, tuple[str, str]] = {
+    "mcp/memory/core.py::memory_recall": (
+        "gated", "per-call blockable count over the enriched result set"),
+    "mcp/memory/core.py::memory_proactive": (
+        "gated", "source=both default; emits per-call blockable count"),
+    "mcp/memory/knowledge.py::knowledge_recall": (
+        "gated", "every hit external-world; emits per-call blockable count"),
+    "knowledge/applications/resume_review.py::_query_knowledge_base": (
+        "gated", "source=knowledge; emits (user-facing but enumeration-complete)"),
+    "autonomy/executor/research.py::_memory_recall": (
+        "gated", "highest write-capability path; emits"),
+    "cc/context_injector.py::inject": (
+        "gated", "episodic today -> 0 rows; emit wired for a future source widening"),
+    "channels/voice/handler.py::handle": (
+        "gated", "wraps external into the LLM system prompt; emits"),
+    **_EXTRA_WRAPPED_SITES,
+}
+
+
+def _functions_calling(attrs: set[str]) -> set[str]:
+    """Return {"relpath::func"} for every function under src that calls a method
+    whose attribute name is in *attrs* (e.g. record_would_block)."""
+    found: set[str] = set()
+    for path in _SRC.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+        funcs = [
+            (n.lineno, getattr(n, "end_lineno", n.lineno), n.name)
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        rel = path.relative_to(_SRC).as_posix()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in attrs
+            ):
+                best, enclosing = -1, "<module>"
+                for start, end, name in funcs:
+                    if start <= node.lineno <= (end or start) and start > best:
+                        best, enclosing = start, name
+                found.add(f"{rel}::{enclosing}")
+    return found
+
+
+def test_injection_gate_dispositions_valid():
+    for key, (disp, why) in INJECTION_GATE_SITES.items():
+        assert disp in _GATE_VALID, f"{key}: invalid gate disposition {disp!r}"
+        assert why.strip(), f"{key}: empty rationale"
+
+
+def test_every_wrapped_recall_site_is_gate_classified():
+    wrapped = {k for k, (disp, _) in KNOWN_RECALL_SITES.items() if disp == "wrapped"}
+    classified = set(INJECTION_GATE_SITES)
+    missing = wrapped - classified
+    assert not missing, (
+        "wrapped recall site(s) not classified for the WS-3 injection gate:\n  "
+        + "\n  ".join(sorted(missing))
+        + "\n\nClassify each in INJECTION_GATE_SITES: wire "
+        "security.immunity_shadow.record_would_block and mark it 'gated', or "
+        "mark 'deferred-with-reason' with a rationale."
+    )
+
+
+def test_gated_sites_actually_emit():
+    """Every 'gated' site under src/genesis must call record_would_block[_sync]
+    — so deleting/moving the emit fails CI. (The proactive hook is verified by
+    test_proactive_hook_emits_sync; it lives outside src/genesis.)"""
+    emitters = _functions_calling({"record_would_block", "record_would_block_sync"})
+    for key, (disp, _why) in INJECTION_GATE_SITES.items():
+        if disp != "gated" or key.startswith("scripts/"):
+            continue
+        assert key in emitters, (
+            f"{key} is classified 'gated' but its function does not call "
+            "immunity_shadow.record_would_block[_sync] — the gate emit was "
+            "removed or moved. Re-wire it or reclassify with a reason."
+        )
+
+
+def test_proactive_hook_emits_sync():
+    hook = _REPO_ROOT / "scripts" / "proactive_memory_hook.py"
+    assert "record_would_block_sync" in hook.read_text(), (
+        "the proactive-memory hook no longer emits the injection shadow gate"
+    )
 
 
 def test_all_registry_dispositions_valid():


### PR DESCRIPTION
## What & why

WS-3 (Immunity) = provenance-based capability isolation: crafted external content must never become a procedure, an identity edit, autonomy evidence, or **reach a write-capable session** — by ORIGIN, not content inspection (matches the DeepMind CaMeL dual-LLM / quarantine pattern).

**B0** (#998) shipped the `origin_class` taxonomy + the `immunity.py` control surface (live kill switch, `is_blockable` never-block invariant) with **zero enforcement**. This PR ships **gate 4 (injection) in SHADOW**: at every site where external-world recalled content reaches an action-capable LLM prompt, it records what a live gate WOULD block into a new `immunity_shadow_events` table — **without altering any recall** (the item still reaches the model, already wrapped by `wrap_external_recall`). This gathers per-site volume to size the eventual ENFORCE stage (B4).

### Reshape (deliberate, scoped)
Due diligence found gates 1–3 (procedure/identity/autonomy) emit ~0 would-blocks in shadow — their sources are owner/first_party by construction until real provenance is threaded to their decision points. So this PR ships the parts that are **real**: the reusable shadow substrate + gate 4 for real + a CI enumeration lock. Gates 1–3 are deferred as explicit flip-blocking follow-ups (not shipped inert).

## What's in it
- **Substrate**: migration `0055_immunity_shadow_events` (+ fresh-DB mirror, 2 indexes), `db/crud/immunity_shadow.py` (async + sync writers, table-guarded; count/summary/list + deterministic retention prune).
- **Emit layer** `security/immunity_shadow.py`: the ONE place the never-block invariant + kill switch are enforced for recording — reads `gate_mode` LIVE, `is_blockable` gate, `item_is_blockable` classifier (first-party pipelines in the KB never count), one row per recall event (hot paths pay a single INSERT), self-resolves a connection for retriever sites, dormant auto-demote (B4). Fail-open throughout.
- **Gate 4 wired** at all 8 `wrap_external_recall` callers (incl. `memory_recall`'s full **and** compact branches) + the proactive-memory hook (sync, fire-and-forget after stdout flush). The site set is **derived** from the wrap-caller set (cross-checked vs the recall-inject registry + GitNexus's 8 direct callers), not hand-picked.
- **Enumeration lock**: `test_recall_inject_coverage.py` now fails CI if a `wrapped` site is unclassified or a `gated` site stops emitting (AST-verified) — no site can silently bypass the gate.
- **Retention**: `scripts/prune_immunity_shadow.py` wired into `disk_hygiene.sh`.

## Verification
- 259 targeted tests green (substrate / emit / wiring / coverage lock); zero regressions across every touched surface; ruff clean; subsystem-map clean.
- **E2E** (`test_immunity_shadow_e2e.py`, no mocks): full migration chain from scratch → table+indexes; the **real** `ws3_immunity` config drives the shadow emit; never-block invariant holds under the real config; compact-branch records; prune bounds the store.

## Review
- Adversarial **genesis-architect** review: **DONE_WITH_CONCERNS, no blockers** — safe to run in shadow (fail-open, kill-switched, never-block holds). SHOULD-FIX/NOTE items addressed inline (doc accuracy, source_ref, GROUNDWORK tag) or filed as follow-ups (gate_mode TTL cache; observability surfacing).
- **Fable enumeration checkpoint**: found one real gap — `memory_recall(compact=True)` returned before the emit — **fixed + regression-tested**. `document_query`/`web_fetch` classified as out-of-scope external-tool-output (separate gate class; follow-up filed).

## Deferred (follow-ups filed)
Gates 1–3 real provenance threading (B4 flip-blockers) · B4 must gate on **stored** origin_class (not recall-time re-derivation) · observability surfacing · external-tool-output gate class · pre-existing compact-preview wrap gap (PR2 defense) · capability_shadow_events retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)