### PR TITLE
fix(memory): heal embed-status orphans, restore project_type on recovery, unblock the store hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   now restores those fields. Separately, keyword-only memories were being scored as
   if created just now (maximum freshness), letting old notes outrank genuinely recent
   ones; they now use their real creation time.
+- **A failed re-embed no longer leaves a memory in a permanent limbo state, and
+  recovered memories keep their project_type recall filter.** When the embedding
+  provider gave up on a memory, its status was left saying "still queued" forever —
+  a stale marker that could trigger doomed writes to the vector store for a memory
+  that has no vector. Failed embeds are now recorded truthfully, a maintenance sweep
+  heals any that were already stranded, and deleting a memory now also clears its
+  entity mentions. Memories re-embedded after an outage also keep their `project_type`
+  so they stay visible in project-scoped recall.
+- **Storing a memory no longer briefly stalls other work while it talks to the
+  vector store.** The store, supersede, and delete paths made blocking vector-store
+  HTTP calls directly on the event loop, so a slow round-trip could momentarily
+  freeze concurrent Telegram, dashboard, and reflection activity. Those calls now
+  run off-thread (matching the background paths), keeping the system responsive
+  under load.
 - **Telegram no longer drops messages or breaks approval buttons when the
   legacy bridge gets started alongside the server.** Two Genesis processes
   polling the same bot token split incoming updates between them (observed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,9 +185,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   recovered memories keep their project_type recall filter.** When the embedding
   provider gave up on a memory, its status was left saying "still queued" forever —
   a stale marker that could trigger doomed writes to the vector store for a memory
-  that has no vector. Failed embeds are now recorded truthfully, a maintenance sweep
-  heals any that were already stranded, and deleting a memory now also clears its
-  entity mentions. Memories re-embedded after an outage also keep their `project_type`
+  that has no vector. Failed embeds are now recorded truthfully, and a
+  recovery pass heals any already-stranded rows — restoring the ones that did
+  embed and marking the ones that truly failed. Deleting a memory now also clears
+  its entity mentions. Memories re-embedded after an outage also keep their `project_type`
   so they stay visible in project-scoped recall.
 - **Storing a memory no longer briefly stalls other work while it talks to the
   vector store.** The store, supersede, and delete paths made blocking vector-store

--- a/src/genesis/db/crud/entities.py
+++ b/src/genesis/db/crud/entities.py
@@ -153,6 +153,28 @@ async def upsert_mention(
         await db.commit()
 
 
+async def delete_mentions_by_memory(
+    db: aiosqlite.Connection,
+    *,
+    memory_id: str,
+    _commit: bool = True,
+) -> int:
+    """Delete all entity mentions for a memory. Returns count deleted.
+
+    Mentions are written keyed by ``memory_id`` (see :func:`upsert_mention`,
+    called from memory/store.py's write path). ``MemoryStore.delete`` must
+    cascade here or a deleted memory leaves dangling mention rows pointing at
+    a memory_id that no longer exists.
+    """
+    cursor = await db.execute(
+        "DELETE FROM entity_mentions WHERE memory_id = ?",
+        (memory_id,),
+    )
+    if _commit:
+        await db.commit()
+    return cursor.rowcount
+
+
 async def upsert_link(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -361,6 +361,40 @@ async def get_metadata(
     }
 
 
+async def count_fts_metadata_drift(db: aiosqlite.Connection) -> tuple[int, int]:
+    """Return ``(fts_ghosts, fts_invisible)`` cross-store drift counts.
+
+    ``fts_ghosts``: ``memory_fts`` rows with no ``memory_metadata`` row (a
+    keyword hit whose provenance/status is unknown). ``fts_invisible``:
+    ``memory_metadata`` rows with no ``memory_fts`` row (a memory that can
+    never surface in keyword/hybrid search). Both are 0 when ``store()`` has
+    written both stores for every memory; a non-zero count flags a store-path
+    or migration regression worth surfacing.
+    """
+    # Set-difference via COUNT + INTERSECT (O(n log n)). A correlated
+    # NOT EXISTS in the memory_metadata->memory_fts direction would be O(n^2):
+    # ``memory_fts.memory_id`` is UNINDEXED, so each per-row lookup scans the
+    # whole FTS content table — pathologically slow at 20k+ rows and run under
+    # the shared-connection lock. Comparing distinct-id set sizes avoids it.
+    fts_rows = await db.execute_fetchall(
+        "SELECT COUNT(DISTINCT memory_id) FROM memory_fts"
+    )
+    meta_rows = await db.execute_fetchall(
+        "SELECT COUNT(DISTINCT memory_id) FROM memory_metadata"
+    )
+    both_rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM ("
+        "SELECT memory_id FROM memory_fts "
+        "INTERSECT SELECT memory_id FROM memory_metadata)"
+    )
+    fts = int(fts_rows[0][0]) if fts_rows else 0
+    meta = int(meta_rows[0][0]) if meta_rows else 0
+    both = int(both_rows[0][0]) if both_rows else 0
+    ghosts = fts - both  # memory_fts rows with no memory_metadata row
+    invisible = meta - both  # memory_metadata rows with no memory_fts row
+    return ghosts, invisible
+
+
 async def get_taxonomy(
     db: aiosqlite.Connection,
     memory_id: str,

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -395,6 +395,18 @@ async def count_fts_metadata_drift(db: aiosqlite.Connection) -> tuple[int, int]:
     return ghosts, invisible
 
 
+async def set_embedding_status(
+    db: aiosqlite.Connection, memory_id: str, status: str
+) -> bool:
+    """Set ``memory_metadata.embedding_status`` for a memory. Returns True if a row changed."""
+    cursor = await db.execute(
+        "UPDATE memory_metadata SET embedding_status = ? WHERE memory_id = ?",
+        (status, memory_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
 async def get_taxonomy(
     db: aiosqlite.Connection,
     memory_id: str,

--- a/src/genesis/db/crud/pending_embeddings.py
+++ b/src/genesis/db/crud/pending_embeddings.py
@@ -171,39 +171,35 @@ async def purge_completed(
     return cursor.rowcount
 
 
-async def reconcile_orphaned_metadata(
+async def query_orphaned_metadata(
     db: aiosqlite.Connection,
     *,
     min_age_seconds: int = 3600,
-) -> int:
-    """Relabel metadata orphans stuck at 'pending' with no queue row as 'failed'.
+) -> list[tuple[str, str]]:
+    """Return ``(memory_id, collection)`` for metadata orphans to reconcile.
 
-    When the recovery worker fails to embed an item it now marks BOTH the
-    queue row and ``memory_metadata.embedding_status`` 'failed'. But rows
-    that failed BEFORE this fix (or whose 'failed' queue row was already
-    reaped by :func:`purge_completed` after 30 days) are stranded at
-    'pending' in metadata with no queue row to ever retry them — no vector,
-    and a lying 'pending' status that passes ``_mark_superseded``'s
-    Qdrant-write guard (store.py) and drives a doomed ``update_payload``.
-    Relabel them 'failed' so the mirror tells the truth.
+    An orphan is a ``memory_metadata`` row stuck at 'pending' with no
+    ``pending_embeddings`` queue row. That happens two ways and they need
+    OPPOSITE fixes: the embed genuinely failed and its 'failed' queue row was
+    later reaped (no vector -> 'failed'), OR the embed SUCCEEDED but its
+    metadata update was lost and the queue row was reaped (vector present ->
+    'embedded'). Only Qdrant can tell them apart, so this query just surfaces
+    the candidates; the caller (EmbeddingRecoveryWorker) checks the vector and
+    sets the truthful status.
 
     ``min_age_seconds`` (default 1h) spares the brief mid-``store()`` window
-    between the create_metadata write and the pending_embeddings.create
-    write, where a legitimately-new row transiently has metadata but not yet
-    a queue row. Returns the count relabeled.
+    between the create_metadata write and the pending_embeddings.create write.
     """
     cutoff = (datetime.now(UTC) - timedelta(seconds=min_age_seconds)).isoformat()
-    cursor = await db.execute(
-        "UPDATE memory_metadata SET embedding_status = 'failed' "
+    rows = await db.execute_fetchall(
+        "SELECT memory_id, collection FROM memory_metadata "
         "WHERE embedding_status = 'pending' AND created_at < ? "
         "AND NOT EXISTS ("
-        "  SELECT 1 FROM pending_embeddings pe "
-        "  WHERE pe.memory_id = memory_metadata.memory_id"
-        ")",
+        "SELECT 1 FROM pending_embeddings pe "
+        "WHERE pe.memory_id = memory_metadata.memory_id)",
         (cutoff,),
     )
-    await db.commit()
-    return cursor.rowcount
+    return [(r[0], r[1]) for r in rows]
 
 
 async def count_pending(

--- a/src/genesis/db/crud/pending_embeddings.py
+++ b/src/genesis/db/crud/pending_embeddings.py
@@ -99,7 +99,28 @@ async def reset_failed_to_pending(
 
     If error_filter is provided, only reset items whose error_message
     contains the filter string.  Returns count of items reset.
+
+    Also flips the ``memory_metadata.embedding_status`` mirror back to
+    'pending' for the same memories, in the SAME transaction. The recovery
+    worker marks BOTH stores 'failed' on embed failure; re-queueing here
+    without resetting the mirror would leave metadata stuck 'failed' while
+    the queue row is 'pending' — a lie that _mark_superseded's Qdrant-write
+    guard reads (see store.py). Orphans with no queue row are untouched
+    (correctly stay 'failed' — nothing will retry them).
     """
+    # Capture the memory_ids being reset BEFORE the UPDATE, to mirror them.
+    if error_filter:
+        id_cursor = await db.execute(
+            "SELECT memory_id FROM pending_embeddings "
+            "WHERE status = 'failed' AND error_message LIKE ?",
+            (f"%{error_filter}%",),
+        )
+    else:
+        id_cursor = await db.execute(
+            "SELECT memory_id FROM pending_embeddings WHERE status = 'failed'"
+        )
+    memory_ids = [row[0] for row in await id_cursor.fetchall()]
+
     if error_filter:
         cursor = await db.execute(
             """UPDATE pending_embeddings
@@ -112,6 +133,13 @@ async def reset_failed_to_pending(
             """UPDATE pending_embeddings
                SET status = 'pending', error_message = NULL
                WHERE status = 'failed'"""
+        )
+    if memory_ids:
+        placeholders = ",".join("?" for _ in memory_ids)
+        await db.execute(
+            "UPDATE memory_metadata SET embedding_status = 'pending' "  # noqa: S608
+            f"WHERE embedding_status = 'failed' AND memory_id IN ({placeholders})",
+            memory_ids,
         )
     await db.commit()
     return cursor.rowcount
@@ -137,6 +165,41 @@ async def purge_completed(
     cursor = await db.execute(
         "DELETE FROM pending_embeddings "
         "WHERE status IN ('embedded', 'failed') AND created_at < ?",
+        (cutoff,),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def reconcile_orphaned_metadata(
+    db: aiosqlite.Connection,
+    *,
+    min_age_seconds: int = 3600,
+) -> int:
+    """Relabel metadata orphans stuck at 'pending' with no queue row as 'failed'.
+
+    When the recovery worker fails to embed an item it now marks BOTH the
+    queue row and ``memory_metadata.embedding_status`` 'failed'. But rows
+    that failed BEFORE this fix (or whose 'failed' queue row was already
+    reaped by :func:`purge_completed` after 30 days) are stranded at
+    'pending' in metadata with no queue row to ever retry them — no vector,
+    and a lying 'pending' status that passes ``_mark_superseded``'s
+    Qdrant-write guard (store.py) and drives a doomed ``update_payload``.
+    Relabel them 'failed' so the mirror tells the truth.
+
+    ``min_age_seconds`` (default 1h) spares the brief mid-``store()`` window
+    between the create_metadata write and the pending_embeddings.create
+    write, where a legitimately-new row transiently has metadata but not yet
+    a queue row. Returns the count relabeled.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(seconds=min_age_seconds)).isoformat()
+    cursor = await db.execute(
+        "UPDATE memory_metadata SET embedding_status = 'failed' "
+        "WHERE embedding_status = 'pending' AND created_at < ? "
+        "AND NOT EXISTS ("
+        "  SELECT 1 FROM pending_embeddings pe "
+        "  WHERE pe.memory_id = memory_metadata.memory_id"
+        ")",
         (cutoff,),
     )
     await db.commit()

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import aiosqlite
 from qdrant_client import QdrantClient
 
+from genesis.db.crud import entities as entities_crud
 from genesis.db.crud import memory as memory_crud
 from genesis.db.crud import memory_links as memory_links_crud
 from genesis.db.crud import pending_embeddings
@@ -247,6 +248,17 @@ class MemoryStore:
         ld_tag = f"life_domain:{life_domain}"
         if ld_tag not in resolved_tags:
             resolved_tags = [*resolved_tags, ld_tag]
+        # Append project_type tag (when set) so the FTS5-only fallback path
+        # preserves it — the recovery worker re-hydrates the Qdrant payload key
+        # from this tag on re-embed (see embedding_recovery.py). Mirrors the
+        # wing/life_domain tags above; #975 indexed project_type for faceted
+        # recall, so a re-embedded point lacking it would silently drop out of
+        # project_type= filtered recall. The payload key below is still set on
+        # the happy path; the tag is the breadcrumb for the fallback path.
+        if project_type:
+            pt_tag = f"project_type:{project_type}"
+            if pt_tag not in resolved_tags:
+                resolved_tags = [*resolved_tags, pt_tag]
 
         embedding_ok = not force_fts5_only
         if embedding_ok:
@@ -436,9 +448,13 @@ class MemoryStore:
         # SQLite: mark deprecated + record successor (via CRUD module)
         await memory_crud.mark_superseded(self._db, old_id, new_id, timestamp)
 
-        # Qdrant: look up collection from metadata, then update payload
+        # Qdrant: look up collection from metadata, then update payload.
+        # Only touch Qdrant when a vector actually exists (status 'embedded').
+        # 'fts5_only' (subsystem write), 'pending' (embed queued), and 'failed'
+        # (embed gave up) rows have NO point — the old `!= "fts5_only"` form
+        # fired a doomed update_payload on 'pending'/'failed' rows every time.
         meta = await memory_crud.get_metadata(self._db, old_id)
-        if meta and meta["embedding_status"] != "fts5_only":
+        if meta and meta["embedding_status"] == "embedded":
             try:
                 update_payload(
                     self._qdrant,
@@ -513,5 +529,18 @@ class MemoryStore:
         results["pending_deleted"] = await pending_embeddings.delete_by_memory(
             self._db, memory_id=memory_id,
         )
+
+        # 6. Cascade: entity_mentions (written keyed by memory_id on the store
+        # path via record_anchors -> upsert_mention; without this a deleted
+        # memory leaves dangling mentions pointing at a gone memory_id).
+        try:
+            results["mentions_deleted"] = await entities_crud.delete_mentions_by_memory(
+                self._db, memory_id=memory_id,
+            )
+        except Exception:
+            logger.error(
+                "entity_mentions delete failed for %s", memory_id, exc_info=True,
+            )
+            results["mentions_deleted"] = False
 
         return results

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -307,7 +308,12 @@ class MemoryStore:
                     if project_type:
                         payload["project_type"] = project_type
 
-                    upsert_point(
+                    # Sync Qdrant HTTP call — off the event loop so a slow
+                    # round-trip on this hot store() path doesn't stall every
+                    # other coroutine (background paths already do this; see
+                    # memory/health.py, dream_cycle.py, entity_resolution.py).
+                    await asyncio.to_thread(
+                        upsert_point,
                         self._qdrant,
                         collection=resolved_collection,
                         point_id=memory_id,
@@ -456,7 +462,8 @@ class MemoryStore:
         meta = await memory_crud.get_metadata(self._db, old_id)
         if meta and meta["embedding_status"] == "embedded":
             try:
-                update_payload(
+                await asyncio.to_thread(
+                    update_payload,
                     self._qdrant,
                     collection=meta["collection"],
                     point_id=old_id,
@@ -508,7 +515,9 @@ class MemoryStore:
         # 3. Qdrant — try both collections (collection column unreliable)
         for coll in ("episodic_memory", "knowledge_base"):
             try:
-                delete_point(self._qdrant, collection=coll, point_id=memory_id)
+                await asyncio.to_thread(
+                    delete_point, self._qdrant, collection=coll, point_id=memory_id,
+                )
                 results[f"qdrant_{coll}"] = True
             except Exception:
                 logger.error(

--- a/src/genesis/resilience/embedding_recovery.py
+++ b/src/genesis/resilience/embedding_recovery.py
@@ -67,14 +67,19 @@ class EmbeddingRecoveryWorker:
                 # normal write path sets all of them, see memory/store.py).
                 # wing/room live in memory_metadata (written by create_metadata
                 # in the same store() that enqueued this pending row, so the
-                # row is present at drain time); life_domain is not a metadata
-                # column — recover it from the `life_domain:` tag store.py
-                # appends. project_type is not persisted on this path (absent
-                # from metadata, pending_embeddings, and tags) → stays unset.
+                # row is present at drain time); life_domain and project_type
+                # are not metadata columns — recover them from the
+                # `life_domain:`/`project_type:` tags store.py appends (see the
+                # tag-mirror there so these faceting keys survive a re-embed).
                 taxo = await memory_crud.get_taxonomy(self._db, item["memory_id"])
                 life_domain = next(
                     (t.split(":", 1)[1] for t in tag_list
                      if t.startswith("life_domain:")),
+                    None,
+                )
+                project_type = next(
+                    (t.split(":", 1)[1] for t in tag_list
+                     if t.startswith("project_type:")),
                     None,
                 )
 
@@ -102,6 +107,8 @@ class EmbeddingRecoveryWorker:
                         payload["origin_class"] = taxo["origin_class"]
                 if life_domain:
                     payload["life_domain"] = life_domain
+                if project_type:
+                    payload["project_type"] = project_type
                 # Restore provenance fields if queued with them
                 for prov_key in (
                     "source_session_id", "transcript_path",
@@ -144,30 +151,56 @@ class EmbeddingRecoveryWorker:
                             "Auto-link failed for %s, continuing", item["memory_id"],
                         )
 
-                # Mark completed in pending_embeddings + update memory_metadata
+                # Record the embed in memory_metadata first, then flip the
+                # queue row (mark_embedded commits, flushing both). The vector
+                # already landed in Qdrant above. Metadata-first is self-healing:
+                # if only the metadata write lands, the queue row stays 'pending'
+                # and the item is simply re-drained (the upsert is idempotent),
+                # while metadata already reflects the real vector — so it is
+                # never mislabelled 'failed' by the orphan reconciler. No
+                # rollback: self._db is the shared SerializedConnection and a
+                # rollback discards EVERY coroutine's pending write (connection.py).
                 now = datetime.now(UTC).isoformat()
-                await crud.mark_embedded(self._db, item["id"], embedded_at=now)
                 try:
                     await self._db.execute(
                         "UPDATE memory_metadata SET embedding_status = 'embedded' "
                         "WHERE memory_id = ?",
                         (item["memory_id"],),
                     )
-                    await self._db.commit()
+                    await crud.mark_embedded(self._db, item["id"], embedded_at=now)
+                    processed += 1
                 except Exception:
-                    logger.debug(
-                        "Failed to update embedding_status for %s",
+                    logger.warning(
+                        "Failed to finalize embedding status for %s — will re-drain",
                         item["memory_id"], exc_info=True,
                     )
-                processed += 1
 
             except Exception as exc:
                 logger.error(
                     "Failed to embed pending item %s: %s", item["id"], exc,
                 )
-                await crud.mark_failed(
-                    self._db, item["id"], error_message=str(exc),
-                )
+                # Mirror the failure into memory_metadata first, then the queue
+                # row (mark_failed commits, flushing both). No rollback — this is
+                # the shared SerializedConnection (connection.py). If only the
+                # metadata write lands, the item is re-drained and retried; the
+                # embed is idempotent and a later success resets metadata to
+                # 'embedded'. reset_failed_to_pending flips both back together on
+                # retry; reconcile_orphaned_metadata is the longer-term backstop
+                # once a 'failed' queue row is purged.
+                try:
+                    await self._db.execute(
+                        "UPDATE memory_metadata SET embedding_status = 'failed' "
+                        "WHERE memory_id = ?",
+                        (item["memory_id"],),
+                    )
+                    await crud.mark_failed(
+                        self._db, item["id"], error_message=str(exc),
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to record embedding failure for %s",
+                        item["memory_id"], exc_info=True,
+                    )
 
             # Pace between items (skip delay after last item)
             if self._pace_delay > 0 and i < len(items) - 1:

--- a/src/genesis/resilience/embedding_recovery.py
+++ b/src/genesis/resilience/embedding_recovery.py
@@ -162,10 +162,8 @@ class EmbeddingRecoveryWorker:
                 # rollback discards EVERY coroutine's pending write (connection.py).
                 now = datetime.now(UTC).isoformat()
                 try:
-                    await self._db.execute(
-                        "UPDATE memory_metadata SET embedding_status = 'embedded' "
-                        "WHERE memory_id = ?",
-                        (item["memory_id"],),
+                    await memory_crud.set_embedding_status(
+                        self._db, item["memory_id"], "embedded"
                     )
                     await crud.mark_embedded(self._db, item["id"], embedded_at=now)
                     processed += 1
@@ -188,10 +186,8 @@ class EmbeddingRecoveryWorker:
                 # retry; reconcile_orphaned_metadata is the longer-term backstop
                 # once a 'failed' queue row is purged.
                 try:
-                    await self._db.execute(
-                        "UPDATE memory_metadata SET embedding_status = 'failed' "
-                        "WHERE memory_id = ?",
-                        (item["memory_id"],),
+                    await memory_crud.set_embedding_status(
+                        self._db, item["memory_id"], "failed"
                     )
                     await crud.mark_failed(
                         self._db, item["id"], error_message=str(exc),
@@ -210,3 +206,47 @@ class EmbeddingRecoveryWorker:
             "Embedding recovery: processed %d/%d items", processed, len(items),
         )
         return processed
+
+    async def reconcile_orphaned_metadata(self, *, min_age_seconds: int = 3600) -> int:
+        """Fix metadata orphans stuck 'pending' with no queue row.
+
+        Such a row is either a failed embed whose 'failed' queue row was reaped
+        (no vector -> 'failed') or a successful embed whose metadata update was
+        lost (vector present -> 'embedded'). Only Qdrant can tell them apart, so
+        check each candidate's point existence and set the truthful status.
+        Returns the number of rows reconciled.
+        """
+        candidates = await crud.query_orphaned_metadata(
+            self._db, min_age_seconds=min_age_seconds,
+        )
+        reconciled = 0
+        for memory_id, collection in candidates:
+            has_vector = await asyncio.to_thread(
+                self._point_exists, memory_id, collection,
+            )
+            status = "embedded" if has_vector else "failed"
+            await memory_crud.set_embedding_status(self._db, memory_id, status)
+            reconciled += 1
+        return reconciled
+
+    def _point_exists(self, memory_id: str, collection: str | None) -> bool:
+        """True if a Qdrant point for *memory_id* exists. Checks the metadata
+        collection first, then the other (the collection column can be stale).
+        Synchronous — call via ``asyncio.to_thread``.
+        """
+        collections = ["episodic_memory", "knowledge_base"]
+        if collection in collections:
+            collections.remove(collection)
+            collections.insert(0, collection)
+        for coll in collections:
+            try:
+                if self._qdrant.retrieve(
+                    collection_name=coll,
+                    ids=[memory_id],
+                    with_payload=False,
+                    with_vectors=False,
+                ):
+                    return True
+            except Exception:
+                continue
+        return False

--- a/src/genesis/resilience/recovery.py
+++ b/src/genesis/resilience/recovery.py
@@ -124,6 +124,18 @@ class RecoveryOrchestrator:
             # cycle output (extraction queues FTS5-only, recovery embeds at pace).
             report.embeddings_recovered = await self._embedding_worker.drain_pending(limit=500)
 
+            # 2b. Reconcile metadata orphans (pending, no queue row) against
+            # Qdrant — a lost metadata update can leave a vectored memory stuck
+            # 'pending'; mark it 'embedded' if the point exists, else 'failed'.
+            try:
+                reconciled = await self._embedding_worker.reconcile_orphaned_metadata()
+                if reconciled:
+                    logger.info(
+                        "Reconciled %d orphaned memory_metadata rows", reconciled,
+                    )
+            except Exception:
+                logger.warning("Failed to reconcile orphaned metadata", exc_info=True)
+
             # 3. Re-dispatch dead letters (or mark-only if no dispatch_fn).
             if self._dispatch_fn is not None and hasattr(self._dead_letter, "redispatch"):
                 succeeded, failed = await self._dead_letter.redispatch(self._dispatch_fn)

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -156,21 +156,6 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     except Exception:
         logger.warning("GC: pending_embeddings purge failed", exc_info=True)
 
-    # GC: reconcile metadata orphans stuck at 'pending' with no queue row.
-    # An embed that failed before the truthful-on-failure fix (or whose 'failed'
-    # queue row was already reaped above) leaves memory_metadata at 'pending'
-    # forever — no vector, and a lie that _mark_superseded's Qdrant guard reads.
-    try:
-        from genesis.db.crud import pending_embeddings as pe_crud
-        reconciled = await pe_crud.reconcile_orphaned_metadata(db)
-        if reconciled:
-            logger.info(
-                "Reconciled %d orphaned memory_metadata rows (pending->failed)",
-                reconciled,
-            )
-    except Exception:
-        logger.warning("GC: metadata orphan reconcile failed", exc_info=True)
-
     # GC tripwire: FTS <-> metadata store consistency, BOTH directions. An FTS
     # row with no metadata row is a ghost; a metadata row with no FTS row is
     # invisible to keyword/hybrid search. Both should be 0 (store() writes both

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -156,6 +156,48 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     except Exception:
         logger.warning("GC: pending_embeddings purge failed", exc_info=True)
 
+    # GC: reconcile metadata orphans stuck at 'pending' with no queue row.
+    # An embed that failed before the truthful-on-failure fix (or whose 'failed'
+    # queue row was already reaped above) leaves memory_metadata at 'pending'
+    # forever — no vector, and a lie that _mark_superseded's Qdrant guard reads.
+    try:
+        from genesis.db.crud import pending_embeddings as pe_crud
+        reconciled = await pe_crud.reconcile_orphaned_metadata(db)
+        if reconciled:
+            logger.info(
+                "Reconciled %d orphaned memory_metadata rows (pending->failed)",
+                reconciled,
+            )
+    except Exception:
+        logger.warning("GC: metadata orphan reconcile failed", exc_info=True)
+
+    # GC tripwire: FTS <-> metadata store consistency, BOTH directions. An FTS
+    # row with no metadata row is a ghost; a metadata row with no FTS row is
+    # invisible to keyword/hybrid search. Both should be 0 (store() writes both
+    # stores); non-zero means a store-path or migration regression — surface it
+    # rather than silently accumulate. (No repair job built: 0 live occurrences;
+    # this is the monitored tripwire that would justify one.)
+    try:
+        from genesis.db.crud import memory as mem_crud
+        fts_ghosts, fts_invisible = await mem_crud.count_fts_metadata_drift(db)
+        if fts_ghosts or fts_invisible:
+            logger.warning(
+                "FTS/metadata drift: %d FTS-ghost rows (no metadata), "
+                "%d metadata rows invisible to FTS",
+                fts_ghosts, fts_invisible,
+            )
+            from genesis.runtime import GenesisRuntime
+            rt = GenesisRuntime.instance()
+            if rt.event_bus:
+                await rt.event_bus.emit(
+                    Subsystem.MEMORY,
+                    Severity.WARNING,
+                    "memory.fts_metadata_drift",
+                    f"{fts_ghosts} FTS-ghost + {fts_invisible} FTS-invisible rows",
+                )
+    except Exception:
+        logger.warning("GC: FTS/metadata tripwire failed", exc_info=True)
+
     # GC: rotate heartbeat events older than 7 days
     try:
         from genesis.db.crud import events as events_crud

--- a/tests/test_db/test_pending_embeddings_crud.py
+++ b/tests/test_db/test_pending_embeddings_crud.py
@@ -202,21 +202,20 @@ class TestCountPending:
         assert await crud.count_pending(db) == 3
 
 
-class TestReconcileOrphanedMetadata:
-    """D5: relabel metadata orphans stuck 'pending' with no queue row as 'failed'."""
+class TestQueryOrphanedMetadata:
+    """D5: surface metadata orphans (pending, aged, no queue row) for reconcile."""
 
     @pytest.mark.asyncio
-    async def test_relabels_aged_orphan(self, db):
+    async def test_returns_aged_orphan_with_collection(self, db):
         from genesis.db.crud import memory as memory_crud
 
-        # metadata 'pending', old, with NO pending_embeddings row -> orphan.
+        # metadata 'pending', old, with NO pending_embeddings row -> candidate.
         await memory_crud.create_metadata(
             db, memory_id="orphan-1", created_at="2020-01-01T00:00:00",
-            embedding_status="pending",
+            collection="episodic_memory", embedding_status="pending",
         )
-        await crud.reconcile_orphaned_metadata(db)
-        meta = await memory_crud.get_metadata(db, "orphan-1")
-        assert meta["embedding_status"] == "failed"
+        cands = await crud.query_orphaned_metadata(db)
+        assert ("orphan-1", "episodic_memory") in cands
 
     @pytest.mark.asyncio
     async def test_spares_recent_orphan(self, db):
@@ -224,20 +223,19 @@ class TestReconcileOrphanedMetadata:
 
         from genesis.db.crud import memory as memory_crud
 
-        # A row younger than the age-gate is spared (mid-store() window).
+        # A row younger than the age-gate is not a candidate (mid-store() window).
         now = datetime.now(UTC).isoformat()
         await memory_crud.create_metadata(
             db, memory_id="fresh-1", created_at=now, embedding_status="pending",
         )
-        await crud.reconcile_orphaned_metadata(db)
-        meta = await memory_crud.get_metadata(db, "fresh-1")
-        assert meta["embedding_status"] == "pending"
+        cands = await crud.query_orphaned_metadata(db)
+        assert not any(mid == "fresh-1" for mid, _ in cands)
 
     @pytest.mark.asyncio
     async def test_ignores_pending_with_live_queue_row(self, db):
         from genesis.db.crud import memory as memory_crud
 
-        # Aged metadata 'pending' but WITH a live queue row -> not an orphan.
+        # Aged metadata 'pending' but WITH a live queue row -> not a candidate.
         await memory_crud.create_metadata(
             db, memory_id="queued-1", created_at="2020-01-01T00:00:00",
             embedding_status="pending",
@@ -247,9 +245,8 @@ class TestReconcileOrphanedMetadata:
             memory_type="episodic", collection="episodic_memory",
             created_at="2020-01-01T00:00:00",
         )
-        await crud.reconcile_orphaned_metadata(db)
-        meta = await memory_crud.get_metadata(db, "queued-1")
-        assert meta["embedding_status"] == "pending"
+        cands = await crud.query_orphaned_metadata(db)
+        assert not any(mid == "queued-1" for mid, _ in cands)
 
 
 class TestResetFailedMirror:

--- a/tests/test_db/test_pending_embeddings_crud.py
+++ b/tests/test_db/test_pending_embeddings_crud.py
@@ -200,3 +200,94 @@ class TestCountPending:
                 created_at=f"2026-03-11T12:00:0{i}",
             )
         assert await crud.count_pending(db) == 3
+
+
+class TestReconcileOrphanedMetadata:
+    """D5: relabel metadata orphans stuck 'pending' with no queue row as 'failed'."""
+
+    @pytest.mark.asyncio
+    async def test_relabels_aged_orphan(self, db):
+        from genesis.db.crud import memory as memory_crud
+
+        # metadata 'pending', old, with NO pending_embeddings row -> orphan.
+        await memory_crud.create_metadata(
+            db, memory_id="orphan-1", created_at="2020-01-01T00:00:00",
+            embedding_status="pending",
+        )
+        await crud.reconcile_orphaned_metadata(db)
+        meta = await memory_crud.get_metadata(db, "orphan-1")
+        assert meta["embedding_status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_spares_recent_orphan(self, db):
+        from datetime import UTC, datetime
+
+        from genesis.db.crud import memory as memory_crud
+
+        # A row younger than the age-gate is spared (mid-store() window).
+        now = datetime.now(UTC).isoformat()
+        await memory_crud.create_metadata(
+            db, memory_id="fresh-1", created_at=now, embedding_status="pending",
+        )
+        await crud.reconcile_orphaned_metadata(db)
+        meta = await memory_crud.get_metadata(db, "fresh-1")
+        assert meta["embedding_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_ignores_pending_with_live_queue_row(self, db):
+        from genesis.db.crud import memory as memory_crud
+
+        # Aged metadata 'pending' but WITH a live queue row -> not an orphan.
+        await memory_crud.create_metadata(
+            db, memory_id="queued-1", created_at="2020-01-01T00:00:00",
+            embedding_status="pending",
+        )
+        await crud.create(
+            db, id="pe-q1", memory_id="queued-1", content="x",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2020-01-01T00:00:00",
+        )
+        await crud.reconcile_orphaned_metadata(db)
+        meta = await memory_crud.get_metadata(db, "queued-1")
+        assert meta["embedding_status"] == "pending"
+
+
+class TestResetFailedMirror:
+    """F1: reset_failed_to_pending must flip the memory_metadata mirror too."""
+
+    @pytest.mark.asyncio
+    async def test_reset_flips_metadata_mirror(self, db):
+        from genesis.db.crud import memory as memory_crud
+
+        await crud.create(
+            db, id="pe-f1", memory_id="mem-f1", content="x",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+        )
+        await crud.mark_failed(db, "pe-f1", error_message="boom")
+        await memory_crud.create_metadata(
+            db, memory_id="mem-f1", created_at="2026-03-11T12:00:00",
+            embedding_status="failed",
+        )
+        reset = await crud.reset_failed_to_pending(db)
+        assert reset == 1
+        # queue row back to pending
+        assert any(it["memory_id"] == "mem-f1" for it in await crud.query_pending(db))
+        # metadata mirror back to pending (the F1 fix)
+        meta = await memory_crud.get_metadata(db, "mem-f1")
+        assert meta["embedding_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_reset_leaves_queueless_orphan_failed(self, db):
+        from genesis.db.crud import memory as memory_crud
+
+        # metadata 'failed' with NO queue row (a reconciled orphan) stays failed -
+        # nothing will retry it, so the mirror must keep telling the truth.
+        await memory_crud.create_metadata(
+            db, memory_id="orphan-f", created_at="2020-01-01T00:00:00",
+            embedding_status="failed",
+        )
+        reset = await crud.reset_failed_to_pending(db)
+        assert reset == 0
+        meta = await memory_crud.get_metadata(db, "orphan-f")
+        assert meta["embedding_status"] == "failed"

--- a/tests/test_memory/test_cross_store_integrity.py
+++ b/tests/test_memory/test_cross_store_integrity.py
@@ -1,0 +1,114 @@
+"""Cross-store integrity: delete completeness + FTS↔metadata drift tripwire.
+
+Uses the real in-memory ``db`` fixture (full schema) so the cross-store
+cascades and COUNT queries run against actual tables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import genesis.memory.store as store_mod
+from genesis.db.crud import entities as entities_crud
+from genesis.db.crud import memory as memory_crud
+from genesis.memory.store import MemoryStore
+
+
+def _store(db):
+    ep = MagicMock()
+    ep.embed = AsyncMock(return_value=[0.1] * 1024)
+    ep.enrich = MagicMock(return_value="episodic: x")
+    return MemoryStore(
+        embedding_provider=ep,
+        qdrant_client=MagicMock(),
+        db=db,
+        linker=None,
+    )
+
+
+class TestDeleteCascadesEntityMentions:
+    """F4: delete() must cascade entity_mentions or leave dangling rows."""
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_mentions(self, db):
+        eid = await entities_crud.create_entity(
+            db,
+            name="Qdrant",
+            norm_name="qdrant",
+            entity_type="product",
+        )
+        await entities_crud.upsert_mention(
+            db,
+            memory_id="mem-del",
+            entity_id=eid,
+            provenance="EXTRACTED",
+            confidence=0.9,
+        )
+        before = await db.execute_fetchall(
+            "SELECT COUNT(*) FROM entity_mentions WHERE memory_id = ?",
+            ("mem-del",),
+        )
+        assert before[0][0] == 1
+
+        results = await _store(db).delete("mem-del")
+
+        assert results["mentions_deleted"] == 1
+        after = await db.execute_fetchall(
+            "SELECT COUNT(*) FROM entity_mentions WHERE memory_id = ?",
+            ("mem-del",),
+        )
+        assert after[0][0] == 0
+
+
+class TestFtsMetadataDrift:
+    """F6: the GC tripwire counts BOTH orphan directions."""
+
+    @pytest.mark.asyncio
+    async def test_counts_both_orphan_directions(self, db):
+        g0, i0 = await memory_crud.count_fts_metadata_drift(db)
+
+        # ghost: an FTS row with no metadata row
+        await memory_crud.create(db, memory_id="ghost-1", content="ghost content")
+        # invisible: a metadata row with no FTS row
+        await memory_crud.create_metadata(
+            db,
+            memory_id="invisible-1",
+            created_at="2026-03-11T12:00:00",
+        )
+        # healthy: both stores agree — contributes to neither count
+        await memory_crud.create(db, memory_id="ok-1", content="ok content")
+        await memory_crud.create_metadata(
+            db,
+            memory_id="ok-1",
+            created_at="2026-03-11T12:00:00",
+        )
+
+        ghosts, invisible = await memory_crud.count_fts_metadata_drift(db)
+        assert ghosts == g0 + 1
+        assert invisible == i0 + 1
+
+
+class TestHotPathOffloadedToThread:
+    """D6(b): the hot-path sync Qdrant calls run via asyncio.to_thread so a
+    slow round-trip doesn't stall the event loop."""
+
+    @pytest.mark.asyncio
+    async def test_delete_offloads_qdrant_delete(self, db):
+        seen = []
+        orig = asyncio.to_thread
+
+        async def spy(func, *args, **kwargs):
+            seen.append(func)
+            return await orig(func, *args, **kwargs)
+
+        with (
+            patch.object(store_mod, "delete_point") as mock_del,
+            patch.object(store_mod.asyncio, "to_thread", spy),
+        ):
+            await _store(db).delete("mem-none")
+
+        # delete_point dispatched through to_thread (both collections)
+        assert mock_del in seen

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -333,3 +333,27 @@ async def test_qdrant_search_skips_deprecated_filter_when_included():
             getattr(cond, "key", None) == "deprecated"
             for cond in must_not
         )
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("status", ["pending", "failed", "fts5_only"])
+async def test_supersede_skips_qdrant_for_non_embedded(store, status):
+    """D5 F3: _mark_superseded must NOT touch Qdrant for a memory with no
+    vector. Only 'embedded' rows have a point; 'pending'/'failed'/'fts5_only'
+    have none, so an update_payload on them is a doomed write. The old guard
+    (`!= 'fts5_only'`) fired it for 'pending'/'failed' — this is the RED proof.
+    """
+    with patch("genesis.memory.store.update_payload") as mock_update, \
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links:
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": "old", "collection": "episodic_memory",
+            "embedding_status": status, "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_links.create = AsyncMock(return_value=("old", "new"))
+
+        await store._mark_superseded("old", "new", "2026-03-11T12:00:00")
+
+    mock_update.assert_not_called()

--- a/tests/test_resilience/test_embedding_recovery.py
+++ b/tests/test_resilience/test_embedding_recovery.py
@@ -217,3 +217,52 @@ class TestDrainPending:
         # metadata mirror also 'failed' — the D5 fix
         meta = await memory_crud.get_metadata(db, "mem-x")
         assert meta["embedding_status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphan_with_vector_marks_embedded(self, db, worker):
+        """A metadata orphan whose Qdrant point EXISTS was a lost-metadata-update
+        success -> reconcile heals it to 'embedded', not 'failed'."""
+        from genesis.db.crud import memory as memory_crud
+
+        w, _, qdrant = worker
+        await memory_crud.create_metadata(
+            db, memory_id="orph-vec", created_at="2020-01-01T00:00:00",
+            collection="episodic_memory", embedding_status="pending",
+        )
+        qdrant.retrieve = MagicMock(return_value=[object()])  # a point exists
+        assert await w.reconcile_orphaned_metadata() == 1
+        meta = await memory_crud.get_metadata(db, "orph-vec")
+        assert meta["embedding_status"] == "embedded"
+
+    @pytest.mark.asyncio
+    async def test_reconcile_orphan_without_vector_marks_failed(self, db, worker):
+        """A metadata orphan with NO Qdrant point was a genuine failed embed ->
+        reconcile marks it 'failed'."""
+        from genesis.db.crud import memory as memory_crud
+
+        w, _, qdrant = worker
+        await memory_crud.create_metadata(
+            db, memory_id="orph-novec", created_at="2020-01-01T00:00:00",
+            collection="episodic_memory", embedding_status="pending",
+        )
+        qdrant.retrieve = MagicMock(return_value=[])  # no point in either collection
+        assert await w.reconcile_orphaned_metadata() == 1
+        meta = await memory_crud.get_metadata(db, "orph-novec")
+        assert meta["embedding_status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_reconcile_spares_fresh_orphan(self, db, worker):
+        """A fresh orphan (< age gate) is not reconciled — the mid-store() window."""
+        from datetime import UTC, datetime
+
+        from genesis.db.crud import memory as memory_crud
+
+        w, _, qdrant = worker
+        qdrant.retrieve = MagicMock(return_value=[])
+        await memory_crud.create_metadata(
+            db, memory_id="fresh-orph", created_at=datetime.now(UTC).isoformat(),
+            embedding_status="pending",
+        )
+        assert await w.reconcile_orphaned_metadata() == 0
+        meta = await memory_crud.get_metadata(db, "fresh-orph")
+        assert meta["embedding_status"] == "pending"

--- a/tests/test_resilience/test_embedding_recovery.py
+++ b/tests/test_resilience/test_embedding_recovery.py
@@ -109,7 +109,8 @@ class TestDrainPending:
         # WS-3: origin_class restored from the authoritative metadata row so
         # an outage-recovered point carries the indexed provenance key.
         assert payload["origin_class"] == "first_party"
-        # project_type is not recoverable on this path — must stay absent
+        # this row carries no project_type: tag, so project_type stays absent
+        # (when tagged it IS recovered — see test_project_type_tag_restored)
         assert "project_type" not in payload
         # the stray memory_id key is dropped to match the normal write path
         assert "memory_id" not in payload
@@ -174,3 +175,45 @@ class TestDrainPending:
         count = await w.drain_pending(limit=2)
         assert count == 2
         assert await w.count_pending() == 3
+
+    @pytest.mark.asyncio
+    async def test_project_type_tag_restored(self, db, worker):
+        """Piece 2: a queued row carrying a ``project_type:`` tag has that
+        faceting key re-hydrated into the Qdrant payload on re-embed, so a
+        recovered point survives project_type= filtered recall (#975 index)."""
+        w, _, qdrant = worker
+        await crud.create(
+            db, id="pe-pt", memory_id="mem-pt", content="infra note",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+            tags="wing:infrastructure,project_type:genesis-infra",
+        )
+        assert await w.drain_pending() == 1
+        payload = qdrant.upsert.call_args.kwargs["points"][0].payload
+        assert payload["project_type"] == "genesis-infra"
+
+    @pytest.mark.asyncio
+    async def test_embed_failure_marks_metadata_failed(self, db, worker):
+        """D5: an embed failure marks BOTH the queue row and the
+        memory_metadata mirror 'failed' — never leaving metadata stuck
+        'pending' (which would later orphan and lie to the supersede guard)."""
+        from genesis.db.crud import memory as memory_crud
+
+        w, embedder, _ = worker
+        await crud.create(
+            db, id="pe-x", memory_id="mem-x", content="bad",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+        )
+        await memory_crud.create_metadata(
+            db, memory_id="mem-x", created_at="2026-03-11T12:00:00",
+            embedding_status="pending",
+        )
+        embedder.embed = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        assert await w.drain_pending() == 0
+        # queue row failed (nothing left pending)
+        assert await crud.count_pending(db) == 0
+        # metadata mirror also 'failed' — the D5 fix
+        meta = await memory_crud.get_metadata(db, "mem-x")
+        assert meta["embedding_status"] == "failed"


### PR DESCRIPTION
Cross-store integrity + hot-path latency fixes for the memory pipeline, which spans three stores that must stay reconciled: SQLite `memory_metadata` (`embedding_status`), the `pending_embeddings` retry queue, and Qdrant vectors.

## Integrity (`fix`)
- **Failed embeds no longer leave a memory in permanent limbo.** When the embedding provider gave up on a queued memory, its metadata status was left saying "still queued" forever — a stale marker with no vector behind it that could drive a doomed write to the vector store. The recovery worker now records the failure in `memory_metadata` too (metadata-first, self-healing), and a maintenance sweep (`reconcile_orphaned_metadata`) heals any rows that were already stranded (aged, with no queue row).
- **Re-queued failures stop lying.** `reset_failed_to_pending` now flips the `memory_metadata` mirror back to `pending` in the same transaction, so a retried item isn't reported as failed.
- **Supersession only touches Qdrant when a vector exists.** `_mark_superseded`'s guard tightened from `!= 'fts5_only'` to `== 'embedded'`, so it never fires an `update_payload` against a `pending`/`failed` row that has no point.
- **Recovered memories keep their `project_type` recall filter.** `project_type` was written to the Qdrant payload only, so it was lost on the FTS5-only fallback path; it's now mirrored to a tag breadcrumb (like `wing`/`life_domain`) and re-hydrated on re-embed.
- **Deleting a memory now clears its entity mentions too** (previously left dangling rows keyed by the gone `memory_id`).
- **A maintenance tripwire counts FTS↔metadata drift both directions** (via an O(n log n) set-difference) so a store-path/migration regression surfaces instead of silently accumulating.

## Hot path (`perf`)
- `store()` / `_mark_superseded()` / `delete()` made blocking synchronous vector-store HTTP calls directly on the event loop; they now run off-thread (`asyncio.to_thread`, matching the existing background paths), so a slow round-trip during a memory write no longer stalls concurrent work.

## Notes
- No schema change; introduces a fourth `embedding_status` value `'failed'` (the column has no CHECK constraint).
- No rollbacks on the shared serialized DB connection (a rollback there would discard unrelated coroutines' pending writes); divergence is handled by ordering + a self-healing re-drain.
- Tests: new coverage for the recovery failure/success paths, the reconcile sweep + age-gate, the mirror reset, the supersede guard (RED-proofed), `project_type` recovery, `delete()` cascade, the drift counter, and the hot-path offload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)