### PR TITLE
feat(observability): WS-3 B1 read surface — immunity_status health MCP tool

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -577,7 +577,10 @@ verified: fa2e692a 2026-07-11
   **Gates 1-3 (procedure/identity/autonomy) do NOT yet emit** — inert in
   shadow until source provenance is threaded to their decision points
   (flip-blocking follow-ups). Auto-demote wired but dormant (server + enforce
-  only); retention via `scripts/prune_immunity_shadow.py` (disk-hygiene).
+  only); retention via `scripts/prune_immunity_shadow.py` (disk-hygiene). The
+  shadow log is readable via the `immunity_status` health MCP tool
+  (gate-agnostic: per-gate live mode + per-site would-block counts — sizes the
+  B4 enforce blast radius; gates 1-3 surface here automatically once they emit).
 - **codebase/**: AST indexer (surplus task, set-difference deletes with
   CASCADE) behind the `codebase_navigate` MCP tool.
 - **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -72,9 +72,12 @@ from genesis.mcp.health import evo_run as _evo_run  # noqa: E402, F401
 from genesis.mcp.health import experiment_run as _experiment_run  # noqa: E402, F401
 from genesis.mcp.health import experiment_status as _experiment_status  # noqa: E402, F401
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402
+from genesis.mcp.health import (  # noqa: E402
+    immunity_status,  # noqa: F401
+    loop_closure_status,  # noqa: F401
+)
 from genesis.mcp.health import inbox_digest as _inbox_digest  # noqa: E402
 from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
-from genesis.mcp.health import loop_closure_status  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
 from genesis.mcp.health import provider as _provider  # noqa: E402

--- a/src/genesis/mcp/health/immunity_status.py
+++ b/src/genesis/mcp/health/immunity_status.py
@@ -1,0 +1,101 @@
+"""immunity_status MCP tool — WS-3 B1 injection-gate SHADOW observability.
+
+The B1 deliverable, made readable: per-gate live mode + per-site would-block
+counts from ``immunity_shadow_events``, so the operator (and the eventual B4
+enforce decision) can see HOW MUCH external content reaches each action-capable
+inject site, and WHERE — the data that sizes the enforce blast radius.
+
+Read-only and **gate-agnostic**: it iterates the canonical
+:data:`genesis.security.immunity.GATES` for live modes and merges whatever gate
+rows exist in the shadow store, so when gates 1-3 (procedure / identity /
+autonomy) begin writing their own would-blocks they surface here with NO code
+change. Reuses :func:`genesis.security.immunity_shadow.recent_summary` (its
+self-resolving connection); no new SQL, no new schema, nothing blocked.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+from genesis.security import immunity, immunity_shadow
+
+logger = logging.getLogger(__name__)
+
+
+def _shape(
+    *,
+    summary_rows: list[dict],
+    gate_modes: dict[str, str],
+    master_enabled: bool,
+    since: str | None,
+) -> dict:
+    """Pure shaping: fold per-(gate, site) count rows into a per-gate view.
+
+    The gate set is the UNION of the canonical modes and any gate present in the
+    rows — an unexpected gate is surfaced with mode ``"unknown"`` rather than
+    silently dropped (a schema/emit drift must be visible). Only ``would_block``
+    rows count toward the totals.
+    """
+    gates: dict[str, dict] = {}
+    for name in set(gate_modes) | {r["gate"] for r in summary_rows}:
+        gates[name] = {
+            "mode": gate_modes.get(name, "unknown"),
+            "would_block_total": 0,
+            "by_site": [],
+        }
+
+    for r in summary_rows:
+        if not r.get("would_block"):
+            continue
+        entry = gates[r["gate"]]
+        n = int(r.get("n", 0))
+        entry["would_block_total"] += n
+        entry["by_site"].append({"source_ref": r.get("source_ref"), "count": n})
+
+    for entry in gates.values():
+        entry["by_site"].sort(key=lambda s: s["count"], reverse=True)
+
+    return {
+        "status": "ok",
+        "master_enabled": master_enabled,
+        "window": since or "all-time",
+        "gates": gates,
+        "note": (
+            "WS-3 immunity gates — SHADOW observability. would_block_total = "
+            "recall events where an external-untrusted item WOULD have been "
+            "blocked at that inject site (nothing is actually blocked in shadow); "
+            "owner/first-party never produce a row. Gate-agnostic: gates 1-3 "
+            "surface here once they emit. Read-only."
+        ),
+    }
+
+
+async def _impl_immunity_status(since: str | None = None) -> dict:
+    """Read live gate modes + shadow would-block counts. Best-effort read-only."""
+    try:
+        master_enabled = bool(immunity.load_immunity_config().get("enabled", True))
+        gate_modes = {gate: immunity.gate_mode(gate) for gate in immunity.GATES}
+        summary_rows = await immunity_shadow.recent_summary(since=since)
+        return _shape(
+            summary_rows=summary_rows,
+            gate_modes=gate_modes,
+            master_enabled=master_enabled,
+            since=since,
+        )
+    except Exception:
+        logger.debug("immunity_status read failed", exc_info=True)
+        return {"status": "unavailable", "message": "immunity shadow read failed"}
+
+
+@mcp.tool()
+async def immunity_status(since: str | None = None) -> dict:
+    """How much external content reaches each action-capable inject site — the
+    WS-3 immunity SHADOW readout.
+
+    Per-gate live mode (off / shadow / enforce) plus per-site would-block counts
+    from the immunity shadow log. In shadow NOTHING is blocked; these counts size
+    the enforce (B4) blast radius. Optionally bound to rows at/after ISO ``since``.
+    Read-only; does NOT change behaviour.
+    """
+    return await _impl_immunity_status(since=since)

--- a/src/genesis/security/immunity_shadow.py
+++ b/src/genesis/security/immunity_shadow.py
@@ -206,25 +206,27 @@ def record_would_block_sync(
         return False
 
 
-# GROUNDWORK(ws3-b1-readsurface): the B1 observability read. No live caller
-# yet (B4 / a dashboard card consumes it — see follow-up); do NOT delete as
-# dead code. crud.summary/list_recent are reached only through here.
+# GROUNDWORK(ws3-b1-readsurface): the B1 observability read. Consumed by the
+# immunity_status health MCP tool (per-gate would-block counts); crud.list_recent
+# stays GROUNDWORK (no caller yet — a detail/dashboard view consumes it). Do NOT
+# delete as dead code.
 async def recent_summary(*, since: str | None = None, db=None) -> list[dict]:
     """Per-gate / per-site would-block rollup (COUNTS only, no content).
 
     The B1 observability read: how much external content reaches each
     action-capable inject site, sizing the B4 enforce blast radius. Optionally
     bounded to rows at/after ISO ``since``. Self-resolves a connection when
-    ``db`` is None. Best-effort: returns [] on error.
+    ``db`` is None.
+
+    Unlike the emit path this does NOT swallow errors — a broken read (missing
+    table, wrong DB path, failed SELECT) RAISES, so a health caller reports
+    "unavailable" rather than a misleading healthy zero (a swallowed failure
+    would look identical to "genuinely 0 would-blocks").
     """
-    try:
-        if db is not None:
-            return await crud.summary(db, since=since)
-        async with get_raw_db() as conn:
-            return await crud.summary(conn, since=since)
-    except Exception:
-        logger.debug("immunity shadow summary read failed", exc_info=True)
-        return []
+    if db is not None:
+        return await crud.summary(db, since=since)
+    async with get_raw_db() as conn:
+        return await crud.summary(conn, since=since)
 
 
 async def _maybe_auto_demote(db, *, gate: str, mode: str, process: str | None) -> None:

--- a/tests/test_mcp/test_immunity_status.py
+++ b/tests/test_mcp/test_immunity_status.py
@@ -1,0 +1,178 @@
+"""Tests for the immunity_status health MCP tool (WS-3 B1 obs read surface).
+
+The tool wires the GROUNDWORK `immunity_shadow.recent_summary` read to a
+discoverable health surface: per-gate mode + per-site would-block counts. The
+core requirement is that it stays GATE-AGNOSTIC — when gates 1-3 land and write
+their own rows, they must surface here without a code change.
+"""
+
+from __future__ import annotations
+
+from genesis.mcp.health.immunity_status import _impl_immunity_status, _shape
+from genesis.security import immunity, immunity_shadow
+
+# ── pure shaping logic (gate-agnostic + counting) ──────────────────────────
+
+
+def test_shape_reports_all_canonical_gates_even_with_zero_rows():
+    out = _shape(
+        summary_rows=[
+            {
+                "gate": "injection",
+                "source_ref": "mcp/memory/core.py::memory_recall",
+                "would_block": 1,
+                "n": 3,
+            },
+        ],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since=None,
+    )
+    assert out["status"] == "ok"
+    assert set(out["gates"]) == set(immunity.GATES)
+    assert out["gates"]["injection"]["would_block_total"] == 3
+    # A gate with no rows still appears, with an empty site list.
+    assert out["gates"]["identity"]["would_block_total"] == 0
+    assert out["gates"]["identity"]["by_site"] == []
+
+
+def test_shape_is_gate_agnostic_surfaces_non_injection_rows():
+    # The whole point: a procedure-gate row (from the concurrent gates-1-3 work)
+    # surfaces here without any code change.
+    out = _shape(
+        summary_rows=[
+            {"gate": "procedure", "source_ref": "learning/spine.py", "would_block": 1, "n": 2},
+            {"gate": "injection", "source_ref": "mcp/memory/core.py", "would_block": 1, "n": 5},
+        ],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since=None,
+    )
+    assert out["gates"]["procedure"]["would_block_total"] == 2
+    assert out["gates"]["injection"]["would_block_total"] == 5
+
+
+def test_shape_never_drops_an_unknown_gate():
+    # A row for a gate not in the canonical set must NOT be silently dropped —
+    # it surfaces with mode "unknown" so a schema/emit drift is visible.
+    out = _shape(
+        summary_rows=[
+            {"gate": "future_gate", "source_ref": "x.py", "would_block": 1, "n": 4},
+        ],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since=None,
+    )
+    assert "future_gate" in out["gates"]
+    assert out["gates"]["future_gate"]["mode"] == "unknown"
+    assert out["gates"]["future_gate"]["would_block_total"] == 4
+
+
+def test_shape_aggregates_multiple_sites_sorted_desc():
+    out = _shape(
+        summary_rows=[
+            {"gate": "injection", "source_ref": "site_a", "would_block": 1, "n": 3},
+            {"gate": "injection", "source_ref": "site_b", "would_block": 1, "n": 5},
+        ],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since=None,
+    )
+    inj = out["gates"]["injection"]
+    assert inj["would_block_total"] == 8
+    # Highest-volume site first.
+    assert [s["source_ref"] for s in inj["by_site"]] == ["site_b", "site_a"]
+    assert [s["count"] for s in inj["by_site"]] == [5, 3]
+
+
+def test_shape_ignores_would_block_zero_rows():
+    # would_block=0 rows (forward-compat: gates 1-3 may write them) must not be
+    # counted as would-blocks.
+    out = _shape(
+        summary_rows=[
+            {"gate": "injection", "source_ref": "site_a", "would_block": 0, "n": 9},
+        ],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since=None,
+    )
+    assert out["gates"]["injection"]["would_block_total"] == 0
+    assert out["gates"]["injection"]["by_site"] == []
+
+
+def test_shape_reports_window():
+    out = _shape(
+        summary_rows=[],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since="2026-07-01T00:00:00+00:00",
+    )
+    assert out["window"] == "2026-07-01T00:00:00+00:00"
+    out2 = _shape(
+        summary_rows=[],
+        gate_modes={g: "shadow" for g in immunity.GATES},
+        master_enabled=True,
+        since=None,
+    )
+    assert out2["window"] == "all-time"
+
+
+# ── _impl wiring (mode join + read, no DB) ─────────────────────────────────
+
+
+async def test_impl_joins_live_modes(monkeypatch):
+    async def fake_summary(*, since=None, db=None):
+        return [{"gate": "injection", "source_ref": "s", "would_block": 1, "n": 1}]
+
+    monkeypatch.setattr(immunity_shadow, "recent_summary", fake_summary)
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    monkeypatch.setattr(immunity, "load_immunity_config", lambda: {"enabled": True})
+
+    out = await _impl_immunity_status()
+    assert out["status"] == "ok"
+    assert out["master_enabled"] is True
+    assert out["gates"]["injection"]["mode"] == "shadow"
+    assert out["gates"]["injection"]["would_block_total"] == 1
+
+
+async def test_impl_master_disabled_reports_off(monkeypatch):
+    async def fake_summary(*, since=None, db=None):
+        return []
+
+    monkeypatch.setattr(immunity_shadow, "recent_summary", fake_summary)
+    # Do NOT patch gate_mode — let it derive "off" from the disabled master.
+    monkeypatch.setattr(immunity, "load_immunity_config", lambda: {"enabled": False})
+
+    out = await _impl_immunity_status()
+    assert out["master_enabled"] is False
+    assert all(g["mode"] == "off" for g in out["gates"].values())
+
+
+async def test_impl_returns_unavailable_on_read_error(monkeypatch):
+    # The one operator-visible failure path: if the read raises past its own
+    # best-effort guard, the tool must report "unavailable", not silently-wrong data.
+    async def boom(*, since=None, db=None):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(immunity_shadow, "recent_summary", boom)
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    monkeypatch.setattr(immunity, "load_immunity_config", lambda: {"enabled": True})
+
+    out = await _impl_immunity_status()
+    assert out["status"] == "unavailable"
+
+
+async def test_impl_forwards_since_window(monkeypatch):
+    captured = {}
+
+    async def fake_summary(*, since=None, db=None):
+        captured["since"] = since
+        return []
+
+    monkeypatch.setattr(immunity_shadow, "recent_summary", fake_summary)
+    monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")
+    monkeypatch.setattr(immunity, "load_immunity_config", lambda: {"enabled": True})
+
+    out = await _impl_immunity_status(since="2026-07-01T00:00:00+00:00")
+    assert captured["since"] == "2026-07-01T00:00:00+00:00"
+    assert out["window"] == "2026-07-01T00:00:00+00:00"

--- a/tests/test_security/test_immunity_shadow.py
+++ b/tests/test_security/test_immunity_shadow.py
@@ -233,3 +233,15 @@ def test_sync_emit_gate_off(tmp_path, monkeypatch):
     )
     assert wrote is False
     conn.close()
+
+
+@pytest.mark.asyncio
+async def test_recent_summary_raises_on_broken_read(tmp_path):
+    # A read must NOT fail-open to [] — that would mask broken telemetry (missing
+    # table / wrong path / failed SELECT) as a healthy zero. It RAISES so a health
+    # caller can honestly report "unavailable" instead of "ok / 0 would-blocks".
+    conn = await aiosqlite.connect(tmp_path / "no_table.db")
+    conn.row_factory = aiosqlite.Row
+    with pytest.raises(sqlite3.OperationalError):
+        await immunity_shadow.recent_summary(db=conn)
+    await conn.close()


### PR DESCRIPTION
## What

Wires the GROUNDWORK `immunity_shadow.recent_summary` read to a discoverable **`immunity_status`** health MCP tool: per-gate live mode (off/shadow/enforce) + per-site would-block counts from `immunity_shadow_events`. This makes the WS-3 B1 deliverable readable — how much external content reaches each action-capable inject site, sizing the eventual B4 (enforce) blast radius — without manual SQL.

## Why

B1 shipped the shadow store but no human-consumable read surface, so the shadow telemetry was invisible (architect SHOULD-FIX; closes follow-up `3b1f2e2b`).

## Design

- **Gate-agnostic**: iterates the canonical `GATES` for live modes and merges whatever gate rows exist in the store, so the concurrent gates-1-3 work surfaces here automatically once it emits — no code change.
- Reuses `recent_summary(db=None)` (self-resolving connection); **no new SQL, schema, or migration**. Read-only; nothing blocked.
- Dedicated tool (not folded into `loop_closure_status`) — immunity is a distinct security concern with no existing home, so this is a first surface, not accretion (H1).

## Verification

- 10 unit tests: `_shape` gate-agnostic union, unknown-gate surfacing, multi-site sort, `would_block` filtering, mode-join, master-disabled→off, the `unavailable` error branch, and `since` passthrough.
- **Live E2E** against the real `genesis.db` (`immunity_shadow_events` present, 0 rows today): tool returns all 4 gates shadow / 0 counts correctly.
- code-reviewer: correctness confirmed sound; the two flagged test-coverage gaps (unavailable branch + since passthrough) were added.
- MCP tools activate on the next CC session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)