### PR TITLE
chore(db): retention prune for capability_shadow_events (bound the WS-5 shadow log)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -161,7 +161,9 @@ verified: 9037d45b 2026-07-07
 - **Discord is shadow-gated** (`autonomy/shadow_gate.py`): three doors —
   `pipeline._deliver`, `outreach_poll` webhook, discord-bot `send_reply` —
   observe-only into `capability_shadow`, best-effort so it can NEVER break the
-  real send. Enforcement (hold-for-approval) is the designed next stage. CI
+  real send. Retention-pruned >45d via `scripts/prune_capability_shadow.py`
+  (disk-hygiene), mirroring the immunity shadow store. Enforcement
+  (hold-for-approval) is the designed next stage. CI
   backstop: `scripts/check_external_io.py` fails on new ungated egress
   endpoints.
 - **`content/egress.py gate()` is LIVE** in the pipeline: anti-slop scrub +

--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -13,6 +13,8 @@
 #      (home >60d / OMI >14d, but NEVER a snapshot a labeled event references)
 #   6. Retention prune of immunity_shadow_events (>45d) → scripts/prune_immunity_shadow.py
 #      (WS-3 B1 observe-only gate log; bounds the shadow store)
+#   7. Retention prune of capability_shadow_events (>45d) → scripts/prune_capability_shadow.py
+#      (WS-5 Discord observe-only gate log; bounds the shadow store)
 #
 # Note: run under a hardened systemd sandbox (NoNewPrivileges, ProtectSystem=
 # strict), so disk_reclaim's --system (/var, sudo) path is intentionally NOT
@@ -80,6 +82,10 @@ main() {
     echo "--- immunity shadow retention prune (>45d) ---"
     "$VENV_PY" "$REPO_DIR/scripts/prune_immunity_shadow.py" --days 45 \
         || echo "prune_immunity_shadow exited $?"
+
+    echo "--- capability shadow retention prune (>45d) ---"
+    "$VENV_PY" "$REPO_DIR/scripts/prune_capability_shadow.py" --days 45 \
+        || echo "prune_capability_shadow exited $?"
 
     echo "=== genesis-disk-hygiene done ==="
 }

--- a/scripts/prune_capability_shadow.py
+++ b/scripts/prune_capability_shadow.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Retention prune for capability_shadow_events (WS5 Discord SHADOW store).
+
+Deletes shadow observations older than a retention window (default 45 days) so
+the observe-only capability-gate log stays bounded. Invoked by
+``scripts/disk_hygiene.sh`` (the genesis-disk-hygiene.timer); also runnable by
+hand. Best-effort — a failure here must not skip other hygiene steps, and it
+no-ops cleanly if the table is absent (the table-existence guard returns 0).
+
+Mirrors ``scripts/prune_immunity_shadow.py`` — the two shadow stores share the
+same retention shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+async def _prune(days: int) -> int:
+    from genesis.db.connection import get_raw_db
+    from genesis.db.crud.capability_shadow import prune_capability_shadow_events
+
+    now = datetime.now(UTC).isoformat()
+    async with get_raw_db() as conn:
+        return await prune_capability_shadow_events(conn, older_than_days=days, now=now)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--days",
+        type=int,
+        default=45,
+        help="retention window in days (rows older than this are deleted)",
+    )
+    args = ap.parse_args()
+    try:
+        deleted = asyncio.run(_prune(args.days))
+        print(f"capability_shadow prune: deleted {deleted} row(s) older than {args.days}d")
+    except Exception as exc:
+        print(f"capability_shadow prune error: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/db/crud/capability_shadow.py
+++ b/src/genesis/db/crud/capability_shadow.py
@@ -109,3 +109,35 @@ async def summary(db: aiosqlite.Connection) -> list[dict]:
         "ORDER BY n DESC"
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def prune_capability_shadow_events(
+    db: aiosqlite.Connection,
+    *,
+    older_than_days: int = 45,
+    now: str,
+) -> int:
+    """Delete rows older than *older_than_days* relative to ISO ``now``.
+
+    Retention for the unbounded shadow log (wired into ``disk_hygiene.sh``),
+    mirroring ``crud.immunity_shadow.prune_immunity_shadow_events``. ``now`` is
+    injected (never wall-clock here) so the cutover is deterministic and
+    testable. No-ops (returns 0) before migration 0044's table exists; never
+    creates it. Returns the number of rows deleted.
+    """
+    if not await _table_available(db):
+        return 0
+    cutoff = _iso_days_before(now, older_than_days)
+    cursor = await db.execute(
+        "DELETE FROM capability_shadow_events WHERE observed_at < ?", (cutoff,)
+    )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount is not None else 0
+
+
+def _iso_days_before(now_iso: str, days: int) -> str:
+    """Return the ISO8601 timestamp *days* before ``now_iso``."""
+    from datetime import datetime, timedelta
+
+    dt = datetime.fromisoformat(now_iso)
+    return (dt - timedelta(days=days)).isoformat()

--- a/tests/test_db/test_crud_capability_shadow.py
+++ b/tests/test_db/test_crud_capability_shadow.py
@@ -111,3 +111,29 @@ async def test_summary_groups_by_door_and_verdict(tmp_path):
     assert top["path"] == "deliver" and top["would_hold"] == 1 and top["n"] == 2
     assert any(r["path"] == "reply" and r["would_hold"] == 0 and r["n"] == 1 for r in rows)
     await db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_deletes_only_old_rows(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **{**_kw(1), "observed_at": "2026-01-01T00:00:00+00:00"})  # old
+    await crud.record(db, **{**_kw(2), "observed_at": "2026-07-11T00:00:00+00:00"})  # fresh
+    deleted = await crud.prune_capability_shadow_events(
+        db, older_than_days=45, now="2026-07-11T12:00:00+00:00"
+    )
+    assert deleted == 1
+    assert await crud.count(db) == 1
+    remaining = await crud.list_recent(db)
+    assert remaining[0]["id"] == "sh-2"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_noops_when_table_absent(tmp_path):
+    # Best-effort, mirrors record(): a missing table returns 0, never raises/creates.
+    db = await _db(tmp_path / "g.db", with_table=False)
+    deleted = await crud.prune_capability_shadow_events(
+        db, older_than_days=45, now="2026-07-11T12:00:00+00:00"
+    )
+    assert deleted == 0
+    await db.close()


### PR DESCRIPTION
## What

Adds a retention prune for `capability_shadow_events` (the WS-5 Discord shadow-gate store, migration 0044), which had **no prune and grew unbounded** — the same latent debt WS-3 B1 just fixed for `immunity_shadow_events`.

## Change (mirrors the immunity prune exactly)

- `crud.capability_shadow.prune_capability_shadow_events` — `observed_at` cutoff, table-absent guard, injected `now` for deterministic testing.
- `scripts/prune_capability_shadow.py` — CLI mirroring `prune_immunity_shadow.py`.
- `scripts/disk_hygiene.sh` — a prune step alongside the immunity one (step 7).

## Verification

- Tests mirror the immunity prune tests (deletes only old rows; no-ops when the table is absent). Full `test_crud_capability_shadow.py` green (8 tests).
- **Live E2E** against the real DB: script wires end-to-end and correctly deletes 0 (store is young — 8 rows, none >45d today, so retention is correct-but-not-yet-urgent).

Closes the `capability_shadow_events` retention follow-up (`b10468b3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)