### PR TITLE
fix(runtime): idle-aware process reaper — spare active terminal sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,6 +80,15 @@
                         "timeout": 500
                     }
                 ]
+            },
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash ${CLAUDE_PROJECT_DIR}/scripts/hooks/session_activity_touch.sh",
+                        "timeout": 2000
+                    }
+                ]
             }
         ],
         "PreToolUse": [
@@ -383,6 +392,15 @@
                     {
                         "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook plan_bookmark_hook.py",
+                        "timeout": 2000
+                    }
+                ]
+            },
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash ${CLAUDE_PROJECT_DIR}/scripts/hooks/session_activity_touch.sh",
                         "timeout": 2000
                     }
                 ]

--- a/scripts/hooks/session_activity_touch.sh
+++ b/scripts/hooks/session_activity_touch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# session_activity_touch.sh — mark the nearest ancestor `claude` process active.
+#
+# Registered as a Claude Code hook on UserPromptSubmit + PostToolUse. Walks the
+# parent-PID chain from this hook process up to the nearest process whose comm
+# is exactly `claude`, then touches ~/.genesis/session-activity/<pid>. That
+# marker is the activity signal the Genesis process reaper reads: a `claude`
+# PID whose marker is fresher than the idle window is never reaped, so an
+# interactive session that has been active within the window survives even
+# past the 7-day age floor (the 2026-07-11 incident: active sessions killed
+# purely on age).
+#
+# Contract: must be fast and must NEVER block or fail the session — it always
+# exits 0, swallows every error, and does no network / DB work.
+
+marker_dir="${HOME}/.genesis/session-activity"
+pid=$PPID
+
+for _ in $(seq 1 20); do
+    [ -n "$pid" ] || break
+    [ "$pid" -gt 1 ] 2>/dev/null || break
+    comm_file="/proc/${pid}/comm"
+    [ -r "$comm_file" ] || break
+    comm=$(cat "$comm_file" 2>/dev/null)
+    if [ "$comm" = "claude" ]; then
+        mkdir -p "$marker_dir" 2>/dev/null
+        touch "${marker_dir}/${pid}" 2>/dev/null
+        break
+    fi
+    # Ascend: ppid is field 4 of /proc/<pid>/stat. The comm field (2) is
+    # parenthesised and may contain spaces/')', so split after the LAST ')'.
+    stat=$(cat "/proc/${pid}/stat" 2>/dev/null) || break
+    after=${stat##*') '}
+    # after = "<state> <ppid> <pgrp> ..." → field 2 is ppid.
+    # shellcheck disable=SC2086
+    set -- $after
+    pid=$2
+done
+
+exit 0

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import hashlib
 import logging
 from datetime import UTC, datetime
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.env import cc_project_dir, user_timezone
+from genesis.runtime.init.process_reaper import _wire_process_reaper
 
 if TYPE_CHECKING:
     from genesis.runtime._core import GenesisRuntime
@@ -35,6 +35,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             return
         try:
             from genesis.db.crud import execution_traces as _et
+
             removed = await _et.prune_older_than(rt._db, days=90)
             rt.record_job_success("execution_traces_prune")
             if removed:
@@ -56,6 +57,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             return
         try:
             from genesis.db.crud import cost_events as _ce
+
             removed = await _ce.prune_older_than(rt._db, days=90)
             rt.record_job_success("cost_events_prune")
             if removed:
@@ -77,6 +79,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             return
         try:
             from genesis.db.crud import file_modifications as _fm
+
             removed = await _fm.prune_older_than(rt._db, days=90)
             rt.record_job_success("file_modifications_prune")
             if removed:
@@ -98,8 +101,7 @@ async def init(rt: GenesisRuntime) -> None:
     """Initialize learning pipeline, triage, calibration, harvest, and all scheduled jobs."""
     if rt._db is None or rt._router is None:
         logger.warning(
-            "Learning skipped — missing prerequisites "
-            "(db=%s, router=%s)",
+            "Learning skipped — missing prerequisites (db=%s, router=%s)",
             rt._db is not None,
             rt._router is not None,
         )
@@ -254,7 +256,9 @@ async def init(rt: GenesisRuntime) -> None:
                     logger.debug("Triage calibration skipped (Genesis paused)")
                     return
             except Exception:
-                logger.warning("Pause check failed — skipping calibration as precaution", exc_info=True)
+                logger.warning(
+                    "Pause check failed — skipping calibration as precaution", exc_info=True
+                )
                 return
             try:
                 result = await _original_calibration()
@@ -287,7 +291,8 @@ async def init(rt: GenesisRuntime) -> None:
                     return
             except Exception:
                 logger.warning(
-                    "Pause check failed — skipping email gate drain", exc_info=True,
+                    "Pause check failed — skipping email gate drain",
+                    exc_info=True,
                 )
                 return
             try:
@@ -318,18 +323,21 @@ async def init(rt: GenesisRuntime) -> None:
                     return
             except Exception:
                 logger.warning(
-                    "Pause check failed — skipping capability decay", exc_info=True,
+                    "Pause check failed — skipping capability decay",
+                    exc_info=True,
                 )
                 return
             try:
                 decayed = await _cg.decay_stale_cells(
-                    rt._db, now=datetime.now(UTC).isoformat(),
+                    rt._db,
+                    now=datetime.now(UTC).isoformat(),
                 )
                 rt.record_job_success("capability_decay_sweep")
                 if decayed:
                     logger.info(
                         "Capability decay: %d stale grant(s) lapsed: %s",
-                        len(decayed), ", ".join(decayed),
+                        len(decayed),
+                        ", ".join(decayed),
                     )
             except Exception as exc:
                 rt.record_job_failure("capability_decay_sweep", str(exc))
@@ -364,13 +372,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         async def _harvest_and_store() -> None:
             try:
-                memory_dir = (
-                    Path.home()
-                    / ".claude"
-                    / "projects"
-                    / cc_project_dir()
-                    / "memory"
-                )
+                memory_dir = Path.home() / ".claude" / "projects" / cc_project_dir() / "memory"
                 items = harvest_auto_memory(memory_dir)
                 stored = 0
                 skipped = 0
@@ -399,7 +401,9 @@ async def init(rt: GenesisRuntime) -> None:
                 if items:
                     logger.info(
                         "Harvested %d auto-memory items (%d new, %d dedup-skipped)",
-                        len(items), stored, skipped,
+                        len(items),
+                        stored,
+                        skipped,
                     )
                 rt.record_job_success("auto_memory_harvest")
             except Exception as exc:
@@ -422,7 +426,8 @@ async def init(rt: GenesisRuntime) -> None:
                 if count or stale:
                     logger.info(
                         "Observation expiry sweep: resolved %d expired, %d stale persistent",
-                        count, stale,
+                        count,
+                        stale,
                     )
             except Exception as exc:
                 rt.record_job_failure("observation_expiry_sweep", str(exc))
@@ -444,7 +449,8 @@ async def init(rt: GenesisRuntime) -> None:
                 rt.record_job_success("follow_up_retention_sweep")
                 if count:
                     logger.info(
-                        "Follow-up retention sweep: purged %d old records", count,
+                        "Follow-up retention sweep: purged %d old records",
+                        count,
                     )
             except Exception as exc:
                 rt.record_job_failure("follow_up_retention_sweep", str(exc))
@@ -479,8 +485,8 @@ async def init(rt: GenesisRuntime) -> None:
                 rt.record_job_success("inbox_marker_decay")
                 if decayed:
                     logger.info(
-                        "Inbox marker decay: aged out %d stale attention "
-                        "marker(s)", decayed,
+                        "Inbox marker decay: aged out %d stale attention marker(s)",
+                        decayed,
                     )
             except Exception as exc:
                 rt.record_job_failure("inbox_marker_decay", str(exc))
@@ -535,6 +541,7 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=300,
         )
         from genesis.util.tasks import tracked_task as _tt
+
         _tt(_validate_keys(), name="initial_api_key_validation")
         # Boot kick: run recovery housekeeping (dead-letter replay, stuck-
         # processing expiry, pending embeddings) immediately instead of
@@ -564,9 +571,12 @@ async def init(rt: GenesisRuntime) -> None:
         async def _expire_stale_messages() -> None:
             try:
                 from genesis.db.crud import message_queue
+
                 now = datetime.now(UTC).isoformat()
                 expired = await message_queue.expire_older_than(
-                    rt._db, max_age_hours=168, expired_at=now,
+                    rt._db,
+                    max_age_hours=168,
+                    expired_at=now,
                 )
                 rt.record_job_success("message_queue_expiry")
                 if expired:
@@ -589,7 +599,9 @@ async def init(rt: GenesisRuntime) -> None:
                     logger.debug("Dead letter redispatch skipped (Genesis paused)")
                     return
             except Exception:
-                logger.warning("Pause check failed — skipping redispatch as precaution", exc_info=True)
+                logger.warning(
+                    "Pause check failed — skipping redispatch as precaution", exc_info=True
+                )
                 return
             if rt._dead_letter_queue is not None and rt._router is not None:
                 try:
@@ -600,11 +612,13 @@ async def init(rt: GenesisRuntime) -> None:
                     if ok or fail:
                         logger.info(
                             "Dead letter redispatch: %d succeeded, %d failed",
-                            ok, fail,
+                            ok,
+                            fail,
                         )
                 except Exception:
                     rt.record_job_failure(
-                        "dead_letter_redispatch", "redispatch failed",
+                        "dead_letter_redispatch",
+                        "redispatch failed",
                     )
                     logger.exception("Dead letter redispatch failed")
 
@@ -619,6 +633,7 @@ async def init(rt: GenesisRuntime) -> None:
         async def _run_procedure_promotion() -> None:
             try:
                 from genesis.learning.procedural.promoter import promote_and_demote
+
                 result = await promote_and_demote(rt._db)
                 rt.record_job_success("procedure_promotion")
                 if any(v > 0 for v in result.values()):
@@ -634,6 +649,7 @@ async def init(rt: GenesisRuntime) -> None:
                 from genesis.learning.procedural.promoter import (
                     backfill_missing_embeddings,
                 )
+
                 await backfill_missing_embeddings(rt._db)
             except Exception:
                 logger.exception("Procedure embedding backfill failed")
@@ -676,8 +692,7 @@ async def init(rt: GenesisRuntime) -> None:
                     identity_loader = getattr(rt, "_identity_loader", None)
                     if identity_loader is None:
                         logger.warning(
-                            "identity_loader not available, skipping "
-                            "USER_KNOWLEDGE.md synthesis",
+                            "identity_loader not available, skipping USER_KNOWLEDGE.md synthesis",
                         )
                     else:
                         narrative: str | None = None
@@ -698,8 +713,7 @@ async def init(rt: GenesisRuntime) -> None:
                             # synthesis can be rolled back (Option B: no loader change).
                             uk_path = identity_loader._dir / "USER_KNOWLEDGE.md"
                             prior_uk = (
-                                uk_path.read_text(encoding="utf-8")
-                                if uk_path.exists() else None
+                                uk_path.read_text(encoding="utf-8") if uk_path.exists() else None
                             )
                             identity_loader.write_user_knowledge_md(
                                 result.model,
@@ -733,8 +747,7 @@ async def init(rt: GenesisRuntime) -> None:
                                 )
                             if narrative:
                                 logger.info(
-                                    "USER_KNOWLEDGE.md updated via LLM "
-                                    "synthesis (call site 11)",
+                                    "USER_KNOWLEDGE.md updated via LLM synthesis (call site 11)",
                                 )
                             else:
                                 logger.info(
@@ -750,7 +763,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _evolve_user_model,
-            CronTrigger(hour=6, minute=30, timezone=user_timezone()),  # moved from 4:30 to avoid dream cycle window
+            CronTrigger(
+                hour=6, minute=30, timezone=user_timezone()
+            ),  # moved from 4:30 to avoid dream cycle window
             id="user_model_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -814,7 +829,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _refresh_capability_map,
-            CronTrigger(hour="9,21", minute=15, timezone=user_timezone()),  # moved from 4:15/16:15 to avoid dream cycle window
+            CronTrigger(
+                hour="9,21", minute=15, timezone=user_timezone()
+            ),  # moved from 4:15/16:15 to avoid dream cycle window
             id="capability_map_refresh",
             max_instances=1,
             misfire_grace_time=3600,
@@ -872,7 +889,8 @@ async def init(rt: GenesisRuntime) -> None:
                 if snap is not None:
                     logger.info(
                         "Ego calibration: ECE=%.4f n=%d%s",
-                        snap["ece"], snap["sample_count"],
+                        snap["ece"],
+                        snap["sample_count"],
                         " (low-confidence)" if snap["low_confidence"] else "",
                     )
             except Exception as exc:
@@ -961,156 +979,10 @@ async def init(rt: GenesisRuntime) -> None:
         # testable seam so the registration is covered, not just the crud prunes).
         _wire_drip_retention_jobs(rt._learning_scheduler, rt)
 
-        async def _reap_stale_processes() -> None:
-            """Kill leaked processes older than their configured threshold.
-
-            Targets:
-              - opencode-ai: 24 hours (pgrep -f, matches command line)
-              - claude: 7 days (pgrep -x, matches exact process name)
-
-            Kills the full descendant tree (children, grandchildren) of each
-            stale process to prevent orphaned MCP servers, Playwright, etc.
-            """
-            import asyncio
-            import os
-
-            from genesis.browser.types import BROWSER_PGREP_PATTERNS
-
-            # (pgrep_flag, pattern, max_age_hours, label)
-            targets = [
-                ("-f", "opencode-ai", 24, "opencode-ai"),
-                ("-x", "claude", 168, "claude"),  # 7 days
-            ]
-            # Browser processes — 4h max age. Idle timeout fires at 1h,
-            # MCP lifespan fires on session end. A 4h-old browser process
-            # has survived both layers and is definitively orphaned.
-            for bp in BROWSER_PGREP_PATTERNS:
-                targets.append(("-f", bp, 4, f"browser:{bp}"))
-            my_pid = os.getpid()
-            my_ppid = os.getppid()
-            protected = {my_pid, my_ppid}
-
-            async def _get_descendants(pid: int, depth: int = 0) -> list[int]:
-                """Return all descendant PIDs (children-first / bottom-up)."""
-                if depth >= 10:
-                    return []
-                proc = await asyncio.create_subprocess_exec(
-                    "pgrep", "-P", str(pid),
-                    stdout=asyncio.subprocess.PIPE,
-                )
-                stdout, _ = await proc.communicate()
-                if not stdout.strip():
-                    return []
-                children = [
-                    int(p.strip()) for p in stdout.decode().strip().split("\n")
-                    if p.strip()
-                ]
-                result: list[int] = []
-                for child in children:
-                    result.extend(await _get_descendants(child, depth + 1))
-                result.extend(children)
-                return result
-
-            try:
-                all_killed: list[tuple[int, str]] = []
-                for flag, pattern, max_age_h, label in targets:
-                    proc = await asyncio.create_subprocess_exec(
-                        "pgrep", flag, pattern,
-                        stdout=asyncio.subprocess.PIPE,
-                    )
-                    stdout, _ = await proc.communicate()
-                    if not stdout.strip():
-                        continue
-
-                    max_age = max_age_h * 3600
-                    clock_ticks = os.sysconf("SC_CLK_TCK")
-
-                    for pid_str in stdout.decode().strip().split("\n"):
-                        pid = int(pid_str.strip())
-                        if pid <= 1 or pid in protected:
-                            continue
-                        try:
-                            if not Path(f"/proc/{pid}/stat").exists():
-                                continue
-                            with open(f"/proc/{pid}/stat") as f:
-                                raw = f.read()
-                            # comm field (field 2) is in parens and may
-                            # contain spaces; split after the last ')'.
-                            after_comm = raw[raw.rfind(")") + 2:]
-                            start_ticks = int(after_comm.split()[19])
-                            with open("/proc/uptime") as f:
-                                uptime_secs = float(f.read().split()[0])
-                            age_secs = uptime_secs - (start_ticks / clock_ticks)
-                            if age_secs > max_age:
-                                # Collect descendants bottom-up, then the root
-                                tree = await _get_descendants(pid)
-                                tree.append(pid)
-                                for p in tree:
-                                    if p <= 1 or p in protected:
-                                        continue
-                                    with contextlib.suppress(ProcessLookupError):
-                                        os.kill(p, 15)  # SIGTERM
-                                    all_killed.append((p, label))
-                        except (ProcessLookupError, FileNotFoundError, ValueError):
-                            continue
-
-                if all_killed:
-                    # 5s grace period for graceful shutdown — browsers need
-                    # time to flush profile SQLite and release locks.
-                    await asyncio.sleep(5)
-                    for pid, _ in all_killed:
-                        with contextlib.suppress(ProcessLookupError):
-                            os.kill(pid, 9)  # SIGKILL
-                    logger.info(
-                        "Process reaper: killed %d stale process(es): %s",
-                        len(all_killed),
-                        all_killed,
-                    )
-                    # Create observation for visibility
-                    if rt._db is not None:
-                        try:
-                            import json
-                            from datetime import UTC, datetime
-                            from uuid import uuid4
-
-                            from genesis.db.crud import observations
-
-                            await observations.create(
-                                rt._db,
-                                id=f"reaper-{uuid4().hex[:8]}",
-                                source="process_reaper",
-                                type="process_reaper_kill",
-                                priority="low",
-                                content=json.dumps({
-                                    "killed_count": len(all_killed),
-                                    "processes": [
-                                        {"pid": p, "label": lbl}
-                                        for p, lbl in all_killed
-                                    ],
-                                }),
-                                created_at=datetime.now(UTC).isoformat(),
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to create reaper observation",
-                                exc_info=True,
-                            )
-                rt.record_job_success("process_reaper")
-            except Exception as exc:
-                rt.record_job_failure("process_reaper", str(exc))
-                logger.exception("Process reaper failed")
-
-        # CronTrigger instead of IntervalTrigger: IntervalTrigger resets on
-        # server restart, so the reaper never fires if the server restarts
-        # within the hour.  Runs at :15 past every hour to avoid collision
-        # with hour-boundary jobs.
-        rt._learning_scheduler.add_job(
-            _reap_stale_processes,
-            CronTrigger(minute=15),
-            id="process_reaper",
-            max_instances=1,
-            misfire_grace_time=600,
-        )
+        # Process reaper (leaked opencode/browser by age; claude by IDLE
+        # policy — activity markers + live-terminal gate, dry-run→auto-arm).
+        # Extracted to a testable seam; see process_reaper.py.
+        _wire_process_reaper(rt._learning_scheduler, rt)
 
         # ── Skill evolution pipeline (weekly backup trigger) ────────────────
         async def _run_skill_evolution() -> None:
@@ -1123,7 +995,9 @@ async def init(rt: GenesisRuntime) -> None:
                     outreach_fn = outreach_pipeline.submit
 
                 pipeline = SkillEvolutionPipeline(
-                    db=rt._db, router=rt._router, outreach_fn=outreach_fn,
+                    db=rt._db,
+                    router=rt._router,
+                    outreach_fn=outreach_fn,
                 )
                 result = await pipeline.run()
                 if result["proposed"] > 0 or result["applied"] > 0:
@@ -1135,7 +1009,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_skill_evolution,
-            CronTrigger(day_of_week="sat", hour=4, minute=0, timezone=user_timezone()),  # moved off Sunday to avoid dream cycle
+            CronTrigger(
+                day_of_week="sat", hour=4, minute=0, timezone=user_timezone()
+            ),  # moved off Sunday to avoid dream cycle
             id="skill_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -1146,6 +1022,7 @@ async def init(rt: GenesisRuntime) -> None:
         async def _run_j9_eval_aggregation():
             try:
                 from genesis.eval.j9_aggregator import run_weekly_aggregation
+
                 results = await run_weekly_aggregation(rt._db)
                 dims_computed = len(results)
                 logger.info("J9 weekly aggregation: %d dimensions computed", dims_computed)
@@ -1158,7 +1035,8 @@ async def init(rt: GenesisRuntime) -> None:
                     )
 
                     regressions = await check_and_alert_regressions(
-                        rt._db, getattr(rt, "_outreach_pipeline", None),
+                        rt._db,
+                        getattr(rt, "_outreach_pipeline", None),
                     )
                     if regressions:
                         logger.info(
@@ -1174,7 +1052,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_j9_eval_aggregation,
-            CronTrigger(day_of_week="sun", hour=7, minute=30, timezone=user_timezone()),  # :30 to avoid schedule_analytical at 7:00
+            CronTrigger(
+                day_of_week="sun", hour=7, minute=30, timezone=user_timezone()
+            ),  # :30 to avoid schedule_analytical at 7:00
             id="j9_eval_aggregation",
             max_instances=1,
             misfire_grace_time=3600,
@@ -1188,6 +1068,7 @@ async def init(rt: GenesisRuntime) -> None:
                 from genesis.eval.pr_review_harvest import (
                     harvest_pr_review_findings,
                 )
+
                 summary = await harvest_pr_review_findings(rt._db)
                 if summary.get("error"):
                     # Error-dict return (repo-resolve / pr-list failure):
@@ -1243,7 +1124,9 @@ async def init(rt: GenesisRuntime) -> None:
                 for model in models:
                     try:
                         summary = await run_gauntlet(
-                            model, db=rt._db, trigger=EvalTrigger.SCHEDULE,
+                            model,
+                            db=rt._db,
+                            trigger=EvalTrigger.SCHEDULE,
                         )
                     except RosterError:
                         logger.info(
@@ -1257,11 +1140,15 @@ async def init(rt: GenesisRuntime) -> None:
                     ran += 1
                     try:
                         await check_gauntlet_regression(
-                            rt._db, summary, getattr(rt, "_outreach_pipeline", None),
+                            rt._db,
+                            summary,
+                            getattr(rt, "_outreach_pipeline", None),
                         )
                     except Exception:
                         logger.warning(
-                            "gauntlet regression check failed for %s", model, exc_info=True,
+                            "gauntlet regression check failed for %s",
+                            model,
+                            exc_info=True,
                         )
                 logger.info("Model gauntlet: ran %d/%d roster model(s)", ran, len(models))
                 rt.record_job_success("model_gauntlet")
@@ -1285,4 +1172,7 @@ async def init(rt: GenesisRuntime) -> None:
     except Exception as exc:
         logger.exception("Failed to initialize learning")
         from genesis.runtime._degradation import record_init_degradation
-        await record_init_degradation(rt._db, rt._event_bus, "learning", "learning_scheduler", str(exc), severity="error")
+
+        await record_init_degradation(
+            rt._db, rt._event_bus, "learning", "learning_scheduler", str(exc), severity="error"
+        )

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -445,33 +445,52 @@ async def _maybe_arm(
         and state.get("hook_verified")
         and not state.get("armed_at")
     ):
-        state["dry_run"] = False
-        state["armed_at"] = now
-        changed = True
-        logger.warning(
-            "Process reaper auto-armed after %.1f clean dry-run days; "
-            "future passes will reap detached idle claude processes.",
-            elapsed / 86400,
+        # Arming REQUIRES a delivered veto notice: the owner must receive the
+        # heads-up + disable instructions before any real kill. If outreach is
+        # unavailable or delivery fails, stay in dry-run and retry next pass —
+        # never arm silently.
+        msg = (
+            "🔫 Process reaper auto-armed after "
+            f"{elapsed / 86400:.1f} clean dry-run days. It will now reap "
+            "claude processes that are >7d old AND idle >7d AND detached "
+            "from any live terminal (a strict subset of the old age-only "
+            "rule). Last dry-run would-kill set: "
+            f"{armed_summary or 'none'}. To keep it disabled, set "
+            '"dry_run": true in ~/.genesis/reaper_state.json or export '
+            f"{_ENV_HARD_DISABLE}=1."
         )
-        if rt._outreach_pipeline is not None:
-            msg = (
-                "🔫 Process reaper auto-armed after "
-                f"{elapsed / 86400:.1f} clean dry-run days. It will now reap "
-                "claude processes that are >7d old AND idle >7d AND detached "
-                "from any live terminal (a strict subset of the old age-only "
-                "rule). Last dry-run would-kill set: "
-                f"{armed_summary or 'none'}. To keep it disabled, set "
-                '"dry_run": true in ~/.genesis/reaper_state.json or export '
-                f"{_ENV_HARD_DISABLE}=1."
+        if await _notify_owner(rt, msg):
+            state["dry_run"] = False
+            state["armed_at"] = now
+            changed = True
+            logger.warning(
+                "Process reaper auto-armed after %.1f clean dry-run days; "
+                "future passes will reap detached idle claude processes.",
+                elapsed / 86400,
             )
-            await _notify_owner(rt, msg)
+        else:
+            logger.warning(
+                "Process reaper met the auto-arm criteria but could not deliver "
+                "the owner veto notification; staying in dry-run, retrying next "
+                "pass."
+            )
     if changed:
         _save_state(state)
 
 
-async def _notify_owner(rt: GenesisRuntime, message: str) -> None:
-    """Send a verbatim ALERT to the owner via the outreach pipeline."""
-    from genesis.outreach.types import OutreachCategory, OutreachRequest
+async def _notify_owner(rt: GenesisRuntime, message: str) -> bool:
+    """Send a verbatim ALERT to the owner. Returns True only if delivered.
+
+    The auto-arm gate relies on the return value — arming must not proceed
+    unless the owner actually received the veto notice.
+    """
+    if rt._outreach_pipeline is None:
+        return False
+    from genesis.outreach.types import (
+        OutreachCategory,
+        OutreachRequest,
+        OutreachStatus,
+    )
 
     req = OutreachRequest(
         category=OutreachCategory.ALERT,
@@ -482,8 +501,15 @@ async def _notify_owner(rt: GenesisRuntime, message: str) -> None:
         channel="telegram",
         verbatim=True,
     )
-    with contextlib.suppress(Exception):
-        await rt._outreach_pipeline.submit_urgent(req)
+    try:
+        result = await rt._outreach_pipeline.submit_urgent(req)
+    except Exception:
+        logger.warning("Process reaper owner notification failed", exc_info=True)
+        return False
+    return getattr(result, "status", None) in (
+        OutreachStatus.DELIVERED,
+        OutreachStatus.ENGAGED,
+    )
 
 
 async def _record_observation(

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -292,6 +292,13 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
         uptime_secs = _read_uptime()
         live_ttys = await _live_ttys()
         all_live_pids: set[int] = set()
+        # Proof-of-life for the hook: did we see ANY live claude PID with a
+        # fresh activity marker this pass? The marker is the sole trustworthy
+        # "user is active here" signal (process structure can't distinguish a
+        # live session from an orphan — verified 2026-07-11: all sessions had
+        # live bash/tmux parents). Auto-arm is gated on this, so the reaper
+        # never arms while its load-bearing signal is absent (hook not firing).
+        saw_fresh_marker = False
         # candidates: (root_pid, label, reason, is_claude, tree)
         candidates: list[tuple[int, str, str, bool, list[int]]] = []
 
@@ -307,10 +314,13 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
                     continue
                 if is_claude:
                     tty = await _process_tty(pid)
+                    marker = _marker_mtime(pid)
+                    if marker is not None and (now - marker) < _CLAUDE_IDLE_WINDOW_SECS:
+                        saw_fresh_marker = True
                     should_reap, reason = classify_claude_pid(
                         age_secs=age,
                         now=now,
-                        marker_mtime=_marker_mtime(pid),
+                        marker_mtime=marker,
                         controlling_tty=tty,
                         live_ttys=live_ttys,
                     )
@@ -326,7 +336,15 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
         _gc_markers(all_live_pids)
 
         if not candidates:
-            await _maybe_arm(state, now, dry_run, hard_disabled, rt, armed_summary=None)
+            await _maybe_arm(
+                state,
+                now,
+                dry_run,
+                hard_disabled,
+                rt,
+                hook_active=saw_fresh_marker,
+                armed_summary=None,
+            )
             rt.record_job_success("process_reaper")
             return
 
@@ -348,6 +366,7 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
                 dry_run,
                 hard_disabled,
                 rt,
+                hook_active=saw_fresh_marker,
                 armed_summary=_summarize(candidates),
             )
             rt.record_job_success("process_reaper")
@@ -397,11 +416,19 @@ async def _maybe_arm(
     hard_disabled: bool,
     rt: GenesisRuntime,
     *,
+    hook_active: bool,
     armed_summary: str | None,
 ) -> None:
     """Advance the dry-run→armed lifecycle. Never arms this pass; the flip
     takes effect on the NEXT pass so the owner gets the notification + a
     veto window before anything is signalled.
+
+    Auto-arm requires BOTH the elapsed dry-run window AND proof-of-life for
+    the hook (``hook_active`` — a fresh marker was seen at least once). The
+    marker is the reaper's only trustworthy activity signal, so arming while
+    it has never appeared would reap on the unreliable tty backstop alone.
+    ``hook_verified`` latches once true so a transient markerless pass (e.g.
+    all sessions momentarily idle) can't un-verify a hook already proven live.
     """
     if not dry_run or hard_disabled:
         return  # already armed, or hard kill-switch engaged
@@ -409,8 +436,15 @@ async def _maybe_arm(
     if not state.get("dry_run_since"):
         state["dry_run_since"] = now
         changed = True
+    if hook_active and not state.get("hook_verified"):
+        state["hook_verified"] = True
+        changed = True
     elapsed = now - float(state["dry_run_since"])
-    if elapsed >= _DRY_RUN_ARM_AFTER_SECS and not state.get("armed_at"):
+    if (
+        elapsed >= _DRY_RUN_ARM_AFTER_SECS
+        and state.get("hook_verified")
+        and not state.get("armed_at")
+    ):
         state["dry_run"] = False
         state["armed_at"] = now
         changed = True

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -1,0 +1,508 @@
+"""Process reaper — reap leaked/orphaned processes past their thresholds.
+
+Extracted from ``learning.py`` into a testable seam (cf.
+``_wire_drip_retention_jobs``). Non-``claude`` targets (opencode-ai, browser
+helpers) keep the original raw-age policy. ``claude`` TUI processes use an
+IDLE policy instead:
+
+  A ``claude`` process is a reap candidate ONLY when it is *all* of:
+    1. past the age floor (7 days since start), AND
+    2. idle beyond the activity window (no per-PID activity marker written
+       by the session-activity hook within the last 7 days), AND
+    3. detached from any live terminal (its controlling tty is not in the
+       union of tmux pane ttys and utmp login ttys).
+
+This is a strict subset of the old age-only rule (kill if age >= 7d),
+so arming the new logic can never reap something the current production
+reaper would have spared — it only *spares* active/attached sessions the
+old rule wrongly killed (the 2026-07-11 incident: interactive sessions
+killed 77 min after they went quiet).
+
+Ships in DRY-RUN by default: it logs ``WOULD KILL`` and writes an
+observation but never signals a process. After a clean observation window
+(``_DRY_RUN_ARM_AFTER_SECS``) with the job running successfully, it
+auto-arms and sends the owner a Telegram summary (with disable
+instructions). State persists in a human-editable JSON file so the owner
+can force dry-run back by hand or a hard env kill-switch can veto arming.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from genesis.runtime._core import GenesisRuntime
+
+logger = logging.getLogger("genesis.runtime")
+
+# ── Policy constants ────────────────────────────────────────────────────
+_CLAUDE_AGE_FLOOR_SECS = 168 * 3600  # 7d — floor before a claude proc is even considered
+_CLAUDE_IDLE_WINDOW_SECS = 168 * 3600  # 7d — "active within" window (marker freshness)
+_DRY_RUN_ARM_AFTER_SECS = 3 * 86400  # arm after 3 clean dry-run days
+_KILL_GRACE_SECS = 5  # SIGTERM → SIGKILL grace (browsers flush SQLite)
+
+_GENESIS_DIR = Path.home() / ".genesis"
+_MARKER_DIR = _GENESIS_DIR / "session-activity"
+_STATE_PATH = _GENESIS_DIR / "reaper_state.json"
+
+# Hard kill-switch: when set (to a truthy value) the reaper can never arm —
+# it stays in dry-run regardless of persisted state. Owner's emergency brake.
+_ENV_HARD_DISABLE = "GENESIS_REAPER_KILL_DISABLED"
+
+
+# ── Pure decision core (fully unit-testable) ────────────────────────────
+def classify_claude_pid(
+    *,
+    age_secs: float,
+    now: float,
+    marker_mtime: float | None,
+    controlling_tty: str | None,
+    live_ttys: set[str],
+    age_floor_secs: float = _CLAUDE_AGE_FLOOR_SECS,
+    idle_window_secs: float = _CLAUDE_IDLE_WINDOW_SECS,
+) -> tuple[bool, str]:
+    """Decide whether a ``claude`` process is a reap candidate.
+
+    Returns ``(should_reap, reason)``. Spares (``should_reap=False``) win
+    on the first matching guard, in priority order: young → fresh marker →
+    live terminal. Only a process that clears all three is a candidate.
+    """
+    if age_secs <= age_floor_secs:
+        return False, "young"
+    if marker_mtime is not None and (now - marker_mtime) < idle_window_secs:
+        return False, "fresh-marker"
+    if controlling_tty is not None and controlling_tty in live_ttys:
+        return False, "live-tty"
+    return True, "stale-detached"
+
+
+# ── I/O primitives (module-level so tests can monkeypatch them) ──────────
+async def _pgrep(flag: str, pattern: str) -> list[int]:
+    """Return PIDs matching ``pgrep <flag> <pattern>`` (empty on no match)."""
+    proc = await asyncio.create_subprocess_exec(
+        "pgrep",
+        flag,
+        pattern,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    if not stdout.strip():
+        return []
+    return [int(p) for p in stdout.decode().split() if p.strip().isdigit()]
+
+
+def _read_uptime() -> float:
+    with open("/proc/uptime") as f:
+        return float(f.read().split()[0])
+
+
+def _proc_age_secs(pid: int, uptime_secs: float, clock_ticks: int) -> float | None:
+    """Age of ``pid`` in seconds from ``/proc/<pid>/stat`` field 22, or None."""
+    stat_path = Path(f"/proc/{pid}/stat")
+    if not stat_path.exists():
+        return None
+    try:
+        raw = stat_path.read_text()
+    except (FileNotFoundError, ProcessLookupError):
+        return None
+    # comm field (field 2) is parenthesised and may contain spaces / ')';
+    # split after the LAST ')'. field 22 (start_time) is index 19 of the
+    # remainder (fields 3..N).
+    after_comm = raw[raw.rfind(")") + 2 :]
+    parts = after_comm.split()
+    if len(parts) < 20:
+        return None
+    try:
+        start_ticks = int(parts[19])
+    except ValueError:
+        return None
+    return uptime_secs - (start_ticks / clock_ticks)
+
+
+def _marker_mtime(pid: int) -> float | None:
+    """mtime (epoch secs) of the activity marker for ``pid``, or None."""
+    marker = _MARKER_DIR / str(pid)
+    try:
+        return marker.stat().st_mtime
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+
+
+def _normalize_tty(raw: str) -> str | None:
+    """Normalise a tty spec to ``pts/N`` / ``ttyN`` form, or None if not a tty."""
+    t = raw.strip()
+    if not t or t == "?":
+        return None
+    if t.startswith("/dev/"):
+        t = t[len("/dev/") :]
+    return t or None
+
+
+async def _process_tty(pid: int) -> str | None:
+    """Controlling terminal of ``pid`` (``pts/5``) via ``ps``, or None."""
+    proc = await asyncio.create_subprocess_exec(
+        "ps",
+        "-o",
+        "tty=",
+        "-p",
+        str(pid),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    return _normalize_tty(stdout.decode())
+
+
+async def _live_ttys() -> set[str]:
+    """Union of tmux pane ttys and utmp (``who``) login ttys, normalised.
+
+    This is the live-terminal discriminator: a process whose controlling
+    tty is in this set is attached to a real session (verified 2026-07-11 —
+    interactive sessions in-set, reparented zombies out-of-set).
+    """
+    ttys: set[str] = set()
+    # tmux panes
+    with contextlib.suppress(Exception):
+        proc = await asyncio.create_subprocess_exec(
+            "tmux",
+            "list-panes",
+            "-a",
+            "-F",
+            "#{pane_tty}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+        for line in stdout.decode().splitlines():
+            norm = _normalize_tty(line)
+            if norm:
+                ttys.add(norm)
+    # utmp login ttys
+    with contextlib.suppress(Exception):
+        proc = await asyncio.create_subprocess_exec(
+            "who",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+        for line in stdout.decode().splitlines():
+            fields = line.split()
+            if len(fields) >= 2:
+                norm = _normalize_tty(fields[1])
+                if norm:
+                    ttys.add(norm)
+    return ttys
+
+
+async def _get_descendants(pid: int, depth: int = 0) -> list[int]:
+    """Return all descendant PIDs (children-first / bottom-up)."""
+    if depth >= 10:
+        return []
+    proc = await asyncio.create_subprocess_exec(
+        "pgrep",
+        "-P",
+        str(pid),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    if not stdout.strip():
+        return []
+    children = [int(p) for p in stdout.decode().split() if p.strip().isdigit()]
+    result: list[int] = []
+    for child in children:
+        result.extend(await _get_descendants(child, depth + 1))
+    result.extend(children)
+    return result
+
+
+def _signal(pid: int, sig: int) -> None:
+    # Defence-in-depth: never signal pid<=1 (0/-1 fan out to every process in
+    # the container; 1 is init). Callers already guard, but a mock/parse slip
+    # must never reach os.kill with a fan-out target.
+    if pid <= 1:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, sig)
+
+
+# ── Persistent dry-run / arm state ──────────────────────────────────────
+def _load_state() -> dict:
+    try:
+        return json.loads(_STATE_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, NotADirectoryError):
+        return {}
+
+
+def _save_state(state: dict) -> None:
+    with contextlib.suppress(OSError):
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _STATE_PATH.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state, indent=2))
+        tmp.replace(_STATE_PATH)
+
+
+def _gc_markers(live_pids: set[int]) -> None:
+    """Delete activity markers for PIDs that are no longer alive."""
+    with contextlib.suppress(FileNotFoundError, NotADirectoryError):
+        for marker in _MARKER_DIR.iterdir():
+            if not marker.name.isdigit():
+                continue
+            if int(marker.name) not in live_pids:
+                with contextlib.suppress(OSError):
+                    marker.unlink()
+
+
+# ── Orchestrator ────────────────────────────────────────────────────────
+async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
+    """One reaper pass. Dry-run by default; auto-arms after a clean window.
+
+    ``now`` is injectable (epoch secs) for deterministic tests.
+    """
+    from genesis.browser.types import BROWSER_PGREP_PATTERNS
+
+    now = now if now is not None else datetime.now(UTC).timestamp()
+    clock_ticks = os.sysconf("SC_CLK_TCK")
+
+    hard_disabled = bool(os.environ.get(_ENV_HARD_DISABLE))
+    state = _load_state()
+    # Effective dry-run for THIS pass: persisted flag OR the hard kill-switch.
+    dry_run = bool(state.get("dry_run", True)) or hard_disabled
+
+    my_pid = os.getpid()
+    protected = {my_pid, os.getppid()}
+
+    # (pgrep_flag, pattern, max_age_hours, label, is_claude)
+    targets: list[tuple[str, str, int, str, bool]] = [
+        ("-f", "opencode-ai", 24, "opencode-ai", False),
+        ("-x", "claude", 168, "claude", True),
+    ]
+    for bp in BROWSER_PGREP_PATTERNS:
+        targets.append(("-f", bp, 4, f"browser:{bp}", False))
+
+    try:
+        uptime_secs = _read_uptime()
+        live_ttys = await _live_ttys()
+        all_live_pids: set[int] = set()
+        # candidates: (root_pid, label, reason, is_claude, tree)
+        candidates: list[tuple[int, str, str, bool, list[int]]] = []
+
+        for flag, pattern, max_age_h, label, is_claude in targets:
+            pids = await _pgrep(flag, pattern)
+            max_age = max_age_h * 3600
+            for pid in pids:
+                all_live_pids.add(pid)
+                if pid <= 1 or pid in protected:
+                    continue
+                age = _proc_age_secs(pid, uptime_secs, clock_ticks)
+                if age is None:
+                    continue
+                if is_claude:
+                    tty = await _process_tty(pid)
+                    should_reap, reason = classify_claude_pid(
+                        age_secs=age,
+                        now=now,
+                        marker_mtime=_marker_mtime(pid),
+                        controlling_tty=tty,
+                        live_ttys=live_ttys,
+                    )
+                else:
+                    should_reap = age > max_age
+                    reason = "stale" if should_reap else "young"
+                if not should_reap:
+                    continue
+                tree = await _get_descendants(pid)
+                tree.append(pid)
+                candidates.append((pid, label, reason, is_claude, tree))
+
+        _gc_markers(all_live_pids)
+
+        if not candidates:
+            await _maybe_arm(state, now, dry_run, hard_disabled, rt, armed_summary=None)
+            rt.record_job_success("process_reaper")
+            return
+
+        claude_hit = any(is_claude for _, _, _, is_claude, _ in candidates)
+
+        if dry_run:
+            for root, label, reason, _is_claude, tree in candidates:
+                logger.warning(
+                    "Process reaper DRY-RUN: WOULD KILL pid %d (%s, reason=%s, tree=%s)",
+                    root,
+                    label,
+                    reason,
+                    tree,
+                )
+            await _record_observation(rt, candidates, dry_run=True)
+            await _maybe_arm(
+                state,
+                now,
+                dry_run,
+                hard_disabled,
+                rt,
+                armed_summary=_summarize(candidates),
+            )
+            rt.record_job_success("process_reaper")
+            return
+
+        # ── Armed: actually reap ────────────────────────────────────────
+        killed: list[int] = []
+        for _root, _label, _reason, _is_claude, tree in candidates:
+            for p in tree:
+                if p <= 1 or p in protected:
+                    continue
+                _signal(p, 15)  # SIGTERM
+                killed.append(p)
+        if killed:
+            await asyncio.sleep(_KILL_GRACE_SECS)
+            for p in killed:
+                _signal(p, 9)  # SIGKILL
+        logger.info(
+            "Process reaper: killed %d process(es) across %d tree(s): %s",
+            len(killed),
+            len(candidates),
+            _summarize(candidates),
+        )
+        await _record_observation(rt, candidates, dry_run=False, claude_hit=claude_hit)
+        if claude_hit and rt._outreach_pipeline is not None:
+            await _notify_owner(
+                rt,
+                "⚠️ Process reaper killed a detached claude process "
+                f"(idle >7d, no live terminal): {_summarize(candidates)}. "
+                "If this was a live session, disable the reaper by setting "
+                '"dry_run": true in ~/.genesis/reaper_state.json.',
+            )
+        rt.record_job_success("process_reaper")
+    except Exception as exc:  # noqa: BLE001 — job boundary
+        rt.record_job_failure("process_reaper", str(exc))
+        logger.exception("Process reaper failed")
+
+
+def _summarize(candidates: list[tuple[int, str, str, bool, list[int]]]) -> str:
+    return ", ".join(f"{root}({label}/{reason})" for root, label, reason, _, _ in candidates)
+
+
+async def _maybe_arm(
+    state: dict,
+    now: float,
+    dry_run: bool,
+    hard_disabled: bool,
+    rt: GenesisRuntime,
+    *,
+    armed_summary: str | None,
+) -> None:
+    """Advance the dry-run→armed lifecycle. Never arms this pass; the flip
+    takes effect on the NEXT pass so the owner gets the notification + a
+    veto window before anything is signalled.
+    """
+    if not dry_run or hard_disabled:
+        return  # already armed, or hard kill-switch engaged
+    changed = False
+    if not state.get("dry_run_since"):
+        state["dry_run_since"] = now
+        changed = True
+    elapsed = now - float(state["dry_run_since"])
+    if elapsed >= _DRY_RUN_ARM_AFTER_SECS and not state.get("armed_at"):
+        state["dry_run"] = False
+        state["armed_at"] = now
+        changed = True
+        logger.warning(
+            "Process reaper auto-armed after %.1f clean dry-run days; "
+            "future passes will reap detached idle claude processes.",
+            elapsed / 86400,
+        )
+        if rt._outreach_pipeline is not None:
+            msg = (
+                "🔫 Process reaper auto-armed after "
+                f"{elapsed / 86400:.1f} clean dry-run days. It will now reap "
+                "claude processes that are >7d old AND idle >7d AND detached "
+                "from any live terminal (a strict subset of the old age-only "
+                "rule). Last dry-run would-kill set: "
+                f"{armed_summary or 'none'}. To keep it disabled, set "
+                '"dry_run": true in ~/.genesis/reaper_state.json or export '
+                f"{_ENV_HARD_DISABLE}=1."
+            )
+            await _notify_owner(rt, msg)
+    if changed:
+        _save_state(state)
+
+
+async def _notify_owner(rt: GenesisRuntime, message: str) -> None:
+    """Send a verbatim ALERT to the owner via the outreach pipeline."""
+    from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="Process reaper",
+        context=message,
+        salience_score=0.9,
+        signal_type="process_reaper",
+        channel="telegram",
+        verbatim=True,
+    )
+    with contextlib.suppress(Exception):
+        await rt._outreach_pipeline.submit_urgent(req)
+
+
+async def _record_observation(
+    rt: GenesisRuntime,
+    candidates: list[tuple[int, str, str, bool, list[int]]],
+    *,
+    dry_run: bool,
+    claude_hit: bool = False,
+) -> None:
+    if rt._db is None:
+        return
+    with contextlib.suppress(Exception):
+        from uuid import uuid4
+
+        from genesis.db.crud import observations
+
+        priority = "high" if (claude_hit and not dry_run) else "low"
+        await observations.create(
+            rt._db,
+            id=f"reaper-{uuid4().hex[:8]}",
+            source="process_reaper",
+            type="process_reaper_would_kill" if dry_run else "process_reaper_kill",
+            priority=priority,
+            content=json.dumps(
+                {
+                    "dry_run": dry_run,
+                    "count": len(candidates),
+                    "processes": [
+                        {"pid": root, "label": label, "reason": reason}
+                        for root, label, reason, _, _ in candidates
+                    ],
+                }
+            ),
+            created_at=datetime.now(UTC).isoformat(),
+        )
+
+
+def _wire_process_reaper(scheduler, rt) -> None:
+    """Register the hourly process reaper on the learning scheduler.
+
+    CronTrigger (not IntervalTrigger): IntervalTrigger resets on server
+    restart, so the reaper would never fire if the server restarts within
+    the hour. Runs at :15 past the hour to avoid hour-boundary collisions.
+    """
+    from apscheduler.triggers.cron import CronTrigger
+
+    async def _reap_stale_processes() -> None:
+        await run_reaper(rt)
+
+    scheduler.add_job(
+        _reap_stale_processes,
+        CronTrigger(minute=15),
+        id="process_reaper",
+        max_instances=1,
+        misfire_grace_time=600,
+    )

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -1,0 +1,397 @@
+"""Tests for the idle-aware process reaper (fix/reaper-idle-semantics).
+
+Covers the pure classifier, the dry-run/armed orchestrator, the auto-arm
+lifecycle, the hard kill-switch, non-claude age paths, marker GC, protected
+PIDs, and job wiring. The 2026-07-11 incident (interactive claude sessions
+killed purely on 7d age) is the regression these lock down.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+import genesis.runtime.init.process_reaper as pr
+from genesis.runtime.init.process_reaper import (
+    _normalize_tty,
+    _wire_process_reaper,
+    classify_claude_pid,
+    run_reaper,
+)
+
+# asyncio_mode = "auto" (pyproject) runs async tests automatically; the sync
+# classifier/normalize tests here run as plain functions — no global mark.
+
+_DAY = 86400.0
+_NOW = 1_000_000_000.0
+
+
+# ── Pure classifier ─────────────────────────────────────────────────────
+def test_classify_young_spares():
+    reap, reason = classify_claude_pid(
+        age_secs=100,
+        now=_NOW,
+        marker_mtime=None,
+        controlling_tty=None,
+        live_ttys=set(),
+    )
+    assert reap is False and reason == "young"
+
+
+def test_classify_fresh_marker_spares():
+    # Old process (8d) but active 2h ago → the incident case: must survive.
+    reap, reason = classify_claude_pid(
+        age_secs=8 * _DAY,
+        now=_NOW,
+        marker_mtime=_NOW - 2 * 3600,
+        controlling_tty=None,
+        live_ttys=set(),
+    )
+    assert reap is False and reason == "fresh-marker"
+
+
+def test_classify_stale_marker_live_tty_spares():
+    # No fresh marker, but attached to a live terminal → spare (backstop).
+    reap, reason = classify_claude_pid(
+        age_secs=8 * _DAY,
+        now=_NOW,
+        marker_mtime=_NOW - 9 * _DAY,
+        controlling_tty="pts/5",
+        live_ttys={"pts/5"},
+    )
+    assert reap is False and reason == "live-tty"
+
+
+def test_classify_detached_idle_reaps():
+    # 8d old, no fresh marker, tty not live → the true-leak class.
+    reap, reason = classify_claude_pid(
+        age_secs=8 * _DAY,
+        now=_NOW,
+        marker_mtime=None,
+        controlling_tty="pts/9",
+        live_ttys={"pts/5"},
+    )
+    assert reap is True and reason == "stale-detached"
+
+
+def test_classify_stale_marker_detached_reaps():
+    reap, reason = classify_claude_pid(
+        age_secs=8 * _DAY,
+        now=_NOW,
+        marker_mtime=_NOW - 10 * _DAY,
+        controlling_tty=None,
+        live_ttys={"pts/5"},
+    )
+    assert reap is True and reason == "stale-detached"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/dev/pts/5", "pts/5"),
+        ("pts/3", "pts/3"),
+        ("?", None),
+        ("", None),
+        ("  /dev/tty1 ", "tty1"),
+    ],
+)
+def test_normalize_tty(raw, expected):
+    assert _normalize_tty(raw) == expected
+
+
+# ── Orchestrator harness ────────────────────────────────────────────────
+class _FakeRT:
+    def __init__(self, *, pipeline=None):
+        self._db = None
+        self._outreach_pipeline = pipeline
+        self.successes: list[str] = []
+        self.failures: list[tuple[str, str]] = []
+
+    def record_job_success(self, name):
+        self.successes.append(name)
+
+    def record_job_failure(self, name, err):
+        self.failures.append((name, err))
+
+
+def _patch_io(
+    monkeypatch,
+    *,
+    pids_by_pattern,
+    ages,
+    markers=None,
+    ttys=None,
+    live_ttys=None,
+    descendants=None,
+    state=None,
+):
+    markers = markers or {}
+    ttys = ttys or {}
+    descendants = descendants or {}
+    signals: list[tuple[int, int]] = []
+    saved: dict = {}
+    gc_calls: list[set] = []
+
+    async def fake_pgrep(flag, pattern):
+        return list(pids_by_pattern.get(pattern, []))
+
+    async def fake_tty(pid):
+        return ttys.get(pid)
+
+    async def fake_live():
+        return set(live_ttys or [])
+
+    async def fake_desc(pid, depth=0):
+        return list(descendants.get(pid, []))
+
+    def fake_save(s):
+        saved.clear()
+        saved.update(s)
+
+    monkeypatch.setattr(pr, "_pgrep", fake_pgrep)
+    monkeypatch.setattr(pr, "_read_uptime", lambda: 10_000_000.0)
+    monkeypatch.setattr(pr, "_proc_age_secs", lambda pid, up, ct: ages.get(pid))
+    monkeypatch.setattr(pr, "_marker_mtime", lambda pid: markers.get(pid))
+    monkeypatch.setattr(pr, "_process_tty", fake_tty)
+    monkeypatch.setattr(pr, "_live_ttys", fake_live)
+    monkeypatch.setattr(pr, "_get_descendants", fake_desc)
+    monkeypatch.setattr(pr, "_gc_markers", lambda live: gc_calls.append(set(live)))
+    monkeypatch.setattr(pr, "_signal", lambda pid, s: signals.append((pid, s)))
+    monkeypatch.setattr(pr, "_load_state", lambda: dict(state or {}))
+    monkeypatch.setattr(pr, "_save_state", fake_save)
+    monkeypatch.setattr(pr, "_KILL_GRACE_SECS", 0)
+    monkeypatch.delenv(pr._ENV_HARD_DISABLE, raising=False)
+    return signals, saved, gc_calls
+
+
+async def test_dry_run_never_signals(monkeypatch, caplog):
+    signals, saved, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        state={},  # dry_run defaults True
+    )
+    captured = {}
+
+    async def fake_obs(rt, cands, *, dry_run, claude_hit=False):
+        captured["dry_run"] = dry_run
+        captured["count"] = len(cands)
+
+    monkeypatch.setattr(pr, "_record_observation", fake_obs)
+    rt = _FakeRT()
+    with caplog.at_level("WARNING"):
+        await run_reaper(rt, now=_NOW)
+
+    assert signals == []  # dry-run never signals
+    assert captured == {"dry_run": True, "count": 1}
+    assert "WOULD KILL pid 900001" in caplog.text
+    assert rt.successes == ["process_reaper"]
+
+
+async def test_armed_kills_detached_claude_tree(monkeypatch):
+    signals, _, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        descendants={900001: [900002]},
+        state={"dry_run": False, "armed_at": 1.0},
+    )
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    # SIGTERM (15) then SIGKILL (9) for both tree members.
+    assert (900001, 15) in signals and (900002, 15) in signals
+    assert (900001, 9) in signals and (900002, 9) in signals
+    assert rt.successes == ["process_reaper"]
+
+
+async def test_armed_spares_fresh_marker_claude(monkeypatch):
+    signals, _, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 30 * _DAY},  # very old…
+        markers={900001: _NOW - 3600},  # …but active 1h ago
+        ttys={},
+        live_ttys=set(),
+        state={"dry_run": False, "armed_at": 1.0},
+    )
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert signals == []  # active session never dies — the whole point
+
+
+async def test_armed_spares_live_tty_claude(monkeypatch):
+    signals, _, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 30 * _DAY},
+        markers={},  # no marker (e.g. hooks didn't fire)
+        ttys={900001: "pts/5"},
+        live_ttys={"pts/5"},
+        state={"dry_run": False, "armed_at": 1.0},
+    )
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert signals == []
+
+
+async def test_non_claude_reaped_by_age(monkeypatch):
+    signals, _, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"opencode-ai": [900010, 900011]},
+        ages={900010: 25 * 3600, 900011: 10 * 3600},  # 25h stale, 10h young
+        state={"dry_run": False, "armed_at": 1.0},
+    )
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    killed = {pid for pid, _ in signals}
+    assert 900010 in killed  # >24h
+    assert 900011 not in killed  # <24h
+
+
+async def test_protected_pid_never_signalled(monkeypatch):
+    my_pid = os.getpid()
+    signals, _, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [my_pid]},
+        ages={my_pid: 99 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        descendants={my_pid: []},
+        state={"dry_run": False, "armed_at": 1.0},
+    )
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert all(pid != my_pid for pid, _ in signals)
+
+
+async def test_marker_gc_receives_live_pids(monkeypatch):
+    _, _, gc_calls = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001], "opencode-ai": [900010]},
+        ages={900001: 1 * _DAY, 900010: 1 * 3600},  # both young → no reap
+        state={"dry_run": False, "armed_at": 1.0},
+    )
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert gc_calls and {900001, 900010} <= gc_calls[0]
+
+
+async def test_auto_arm_lifecycle(monkeypatch):
+    notified: list[str] = []
+
+    async def fake_notify(rt, msg):
+        notified.append(msg)
+
+    monkeypatch.setattr(pr, "_notify_owner", fake_notify)
+
+    # Pass 1: fresh dry-run, a detached candidate present. Should record
+    # dry_run_since and NOT arm, NOT signal.
+    signals, saved, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        state={},
+    )
+    rt = _FakeRT(pipeline=object())
+    await run_reaper(rt, now=_NOW)
+    assert signals == []
+    assert saved.get("dry_run_since") == _NOW
+    assert saved.get("dry_run", True) is True
+    assert not saved.get("armed_at")
+    assert notified == []
+
+    # Pass 2: >3 days later, still dry-run. Should FLIP to armed + notify,
+    # but still NOT signal this pass (arm gives the owner a veto window).
+    signals2, saved2, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        state={"dry_run": True, "dry_run_since": _NOW},
+    )
+    rt2 = _FakeRT(pipeline=object())
+    await run_reaper(rt2, now=_NOW + 3 * _DAY + 60)
+    assert signals2 == []  # arm pass does not kill
+    assert saved2.get("dry_run") is False
+    assert saved2.get("armed_at") == _NOW + 3 * _DAY + 60
+    assert len(notified) == 1 and "auto-armed" in notified[0]
+
+
+async def test_hard_disable_prevents_arm(monkeypatch):
+    notified: list[str] = []
+
+    async def fake_notify(rt, msg):
+        notified.append(msg)
+
+    monkeypatch.setattr(pr, "_notify_owner", fake_notify)
+    signals, saved, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        state={"dry_run": True, "dry_run_since": _NOW},
+    )
+    monkeypatch.setenv(pr._ENV_HARD_DISABLE, "1")
+    rt = _FakeRT(pipeline=object())
+    await run_reaper(rt, now=_NOW + 10 * _DAY)
+    assert signals == []
+    assert saved.get("armed_at") is None  # never armed while kill-switch on
+    assert notified == []
+
+
+async def test_job_failure_recorded(monkeypatch):
+    async def boom(flag, pattern):
+        raise RuntimeError("pgrep exploded")
+
+    monkeypatch.setattr(pr, "_pgrep", boom)
+    monkeypatch.setattr(pr, "_read_uptime", lambda: 10_000_000.0)
+
+    async def fake_live():
+        return set()
+
+    monkeypatch.setattr(pr, "_live_ttys", fake_live)
+    monkeypatch.setattr(pr, "_load_state", lambda: {})
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert rt.failures and rt.failures[0][0] == "process_reaper"
+    assert rt.successes == []
+
+
+# ── Wiring ──────────────────────────────────────────────────────────────
+class _StubRT:
+    _db = None
+
+    def record_job_success(self, *_a):
+        pass
+
+    def record_job_failure(self, *_a):
+        pass
+
+
+async def test_wire_process_reaper_registers_job():
+    sched = AsyncIOScheduler()
+    _wire_process_reaper(sched, _StubRT())
+    sched.start(paused=True)
+    try:
+        job = sched.get_job("process_reaper")
+        assert job is not None
+        assert isinstance(job.trigger, CronTrigger)
+    finally:
+        sched.shutdown(wait=False)

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -291,6 +291,7 @@ async def test_auto_arm_lifecycle(monkeypatch):
 
     async def fake_notify(rt, msg):
         notified.append(msg)
+        return True  # delivered → arming may proceed
 
     monkeypatch.setattr(pr, "_notify_owner", fake_notify)
 
@@ -356,6 +357,30 @@ async def test_no_arm_without_hook_proof(monkeypatch):
     assert signals == []
     assert saved.get("armed_at") is None  # refused to arm without hook proof
     assert notified == []
+
+
+async def test_no_arm_when_notification_fails(monkeypatch):
+    """All arm criteria met, but the owner veto notice can't be delivered →
+    stay in dry-run, do NOT arm (never arm silently)."""
+
+    async def fake_notify_fail(rt, msg):
+        return False  # delivery failed / outreach unavailable
+
+    monkeypatch.setattr(pr, "_notify_owner", fake_notify_fail)
+    signals, saved, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},
+        ttys={},
+        live_ttys=set(),
+        state={"dry_run": True, "dry_run_since": _NOW, "hook_verified": True},
+    )
+    rt = _FakeRT(pipeline=object())
+    await run_reaper(rt, now=_NOW + 3 * _DAY + 60)
+    assert signals == []
+    assert saved.get("armed_at") is None  # not armed — notice undelivered
+    assert saved.get("dry_run", True) is True
 
 
 async def test_hard_disable_prevents_arm(monkeypatch):

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -294,13 +294,14 @@ async def test_auto_arm_lifecycle(monkeypatch):
 
     monkeypatch.setattr(pr, "_notify_owner", fake_notify)
 
-    # Pass 1: fresh dry-run, a detached candidate present. Should record
-    # dry_run_since and NOT arm, NOT signal.
+    # Pass 1: fresh dry-run. 900001 is a detached candidate; 900002 is a
+    # live session with a fresh marker (hook proof-of-life). Should record
+    # dry_run_since + hook_verified, but NOT arm, NOT signal.
     signals, saved, _ = _patch_io(
         monkeypatch,
-        pids_by_pattern={"claude": [900001]},
-        ages={900001: 8 * _DAY},
-        markers={},
+        pids_by_pattern={"claude": [900001, 900002]},
+        ages={900001: 8 * _DAY, 900002: 8 * _DAY},
+        markers={900002: _NOW - 100},  # fresh marker → hook is alive
         ttys={},
         live_ttys=set(),
         state={},
@@ -309,12 +310,13 @@ async def test_auto_arm_lifecycle(monkeypatch):
     await run_reaper(rt, now=_NOW)
     assert signals == []
     assert saved.get("dry_run_since") == _NOW
+    assert saved.get("hook_verified") is True
     assert saved.get("dry_run", True) is True
     assert not saved.get("armed_at")
     assert notified == []
 
-    # Pass 2: >3 days later, still dry-run. Should FLIP to armed + notify,
-    # but still NOT signal this pass (arm gives the owner a veto window).
+    # Pass 2: >3 days later, hook already verified. Should FLIP to armed +
+    # notify, but still NOT signal this pass (arm gives the owner a veto window).
     signals2, saved2, _ = _patch_io(
         monkeypatch,
         pids_by_pattern={"claude": [900001]},
@@ -322,7 +324,7 @@ async def test_auto_arm_lifecycle(monkeypatch):
         markers={},
         ttys={},
         live_ttys=set(),
-        state={"dry_run": True, "dry_run_since": _NOW},
+        state={"dry_run": True, "dry_run_since": _NOW, "hook_verified": True},
     )
     rt2 = _FakeRT(pipeline=object())
     await run_reaper(rt2, now=_NOW + 3 * _DAY + 60)
@@ -330,6 +332,30 @@ async def test_auto_arm_lifecycle(monkeypatch):
     assert saved2.get("dry_run") is False
     assert saved2.get("armed_at") == _NOW + 3 * _DAY + 60
     assert len(notified) == 1 and "auto-armed" in notified[0]
+
+
+async def test_no_arm_without_hook_proof(monkeypatch):
+    """Elapsed window alone must NOT arm — the hook must be proven live first."""
+    notified: list[str] = []
+
+    async def fake_notify(rt, msg):
+        notified.append(msg)
+
+    monkeypatch.setattr(pr, "_notify_owner", fake_notify)
+    signals, saved, _ = _patch_io(
+        monkeypatch,
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 8 * _DAY},
+        markers={},  # NO fresh marker anywhere → hook never proven
+        ttys={},
+        live_ttys=set(),
+        state={"dry_run": True, "dry_run_since": _NOW},  # no hook_verified
+    )
+    rt = _FakeRT(pipeline=object())
+    await run_reaper(rt, now=_NOW + 30 * _DAY)  # long past the window
+    assert signals == []
+    assert saved.get("armed_at") is None  # refused to arm without hook proof
+    assert notified == []
 
 
 async def test_hard_disable_prevents_arm(monkeypatch):


### PR DESCRIPTION
## Problem

The hourly process reaper killed long-running `claude` (Claude Code) processes
by **raw age** — any process older than 7 days since start was terminated,
regardless of whether it was actively in use. An interactive session that had
been open and active for a week was killed the moment it crossed the age floor,
even seconds after the user's last action.

## Fix

Switch the `claude` reap policy from **age** to **idle**, and extract the reaper
from `learning.py` into a testable `process_reaper.py` seam. A `claude` process
is now a reap candidate only when it is **all** of:

1. past the 7-day age floor, **and**
2. idle beyond the 7-day activity window (no recent activity marker), **and**
3. detached from any live terminal (controlling tty not in tmux panes ∪ login ttys).

This is a strict subset of the old age-only rule, so it can never terminate
something the old reaper spared — it only spares active/attached sessions the
old rule wrongly killed. `opencode`/browser-helper targets keep the original
age policy.

Activity markers are written by a lightweight `UserPromptSubmit`/`PostToolUse`
hook that walks the parent-process chain to the owning `claude` process. The
tty check is a spare-only backstop (it can prevent a kill, never cause one), so
correctness rests on the marker — the one reliable "actively in use" signal.

## Safety

- **Ships in dry-run**: logs `WOULD KILL` and records an observation, but never
  signals a process.
- **Auto-arm is gated on proof-of-life**: the reaper only arms after it has
  observed a fresh activity marker on a live process AND a clean observation
  window has elapsed — it will not go live while its load-bearing signal is
  absent. State persists in a human-editable JSON file; an env kill-switch
  forces dry-run.
- On arming and on any interactive-process kill, the owner is notified with
  instructions to disable.

## Tests

22 tests covering the classifier, dry-run/armed orchestration, the auto-arm +
proof-of-life lifecycle, the kill-switch, non-claude age paths, marker GC,
protected PIDs, and job wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)