### PR TITLE
feat(security): WS-3 B1 gates 2-3 — identity + autonomy provenance gates (shadow)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -576,13 +576,27 @@ verified: fa2e692a 2026-07-11
   reaches an action-capable prompt (observe-only — the item still reaches the
   model; owner/first-party never recorded). The gate set is CI-locked in
   `test_recall_inject_coverage.py` (a new inject site or a removed emit fails).
-  **Gates 1-3 (procedure/identity/autonomy) do NOT yet emit** — inert in
-  shadow until source provenance is threaded to their decision points
-  (flip-blocking follow-ups). Auto-demote wired but dormant (server + enforce
-  only); retention via `scripts/prune_immunity_shadow.py` (disk-hygiene). The
-  shadow log is readable via the `immunity_status` health MCP tool
-  (gate-agnostic: per-gate live mode + per-site would-block counts — sizes the
-  B4 enforce blast radius; gates 1-3 surface here automatically once they emit).
+  **Gates 2-3 (identity/autonomy) are LIVE in SHADOW.** Gate 2: the steering
+  write (`learning/pipeline.py`) emits with a CHANNEL allow-map origin
+  (`_CHANNEL_ORIGIN`: terminal/telegram/whatsapp/web = owner; voice + unknown
+  channels fail CLOSED to external_untrusted — the polarity fix for the
+  fail-open `_AUTONOMOUS_CHANNELS` deny-list, so a deny-list escape is now
+  OBSERVED), and the USER_KNOWLEDGE synthesis (`runtime/init/learning.py`)
+  emits first_party-by-authorship (FLIP BLOCKER: observations carry no
+  origin_class, so externally-planted user-facts remain first_party until
+  delta-level provenance lands). Gate 3: the emit lives INSIDE
+  `db/crud/capability_grants.py` (record_success/record_correction/apply_event
+  — `origin_class` is a REQUIRED kwarg so every future caller must state
+  provenance); all six live callers thread owner/first_party → zero rows today
+  by construction. Locks: `test_identity_autonomy_gate_coverage.py` pins the
+  loader's 4-method write_text surface by set-equality + the dashboard PUT
+  writer manually, and discovers grant-mutation callers ALIAS-RESOLVED (bare
+  `record_success` name collisions excluded). The legacy `autonomy_state`
+  evidence store is a documented out-of-scope exclusion. Auto-demote wired but
+  dormant (server + enforce only); retention via
+  `scripts/prune_immunity_shadow.py` (disk-hygiene). The shadow log is readable
+  via the `immunity_status` health MCP tool (gate-agnostic: per-gate live mode
+  + per-site would-block counts — sizes the B4 enforce blast radius).
 - **codebase/**: AST indexer (surplus task, set-difference deletes with
   CASCADE) behind the `codebase_navigate` MCP tool.
 - **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h

--- a/src/genesis/autonomy/email_gate.py
+++ b/src/genesis/autonomy/email_gate.py
@@ -49,8 +49,8 @@ EMAIL_GATE_ACTION_TYPE = "email_capability_gate"
 #: WS-8 PR-D deterministic pre-send scope guards for a GRANTED cell.  A trip is
 #: treated as scope drift inside the grant ⇒ the send is HELD and the cell is
 #: demoted (recorded as a correction).  Conservative defaults; calibration here.
-_RATE_LIMIT_WINDOW = timedelta(hours=1)   # g3: per-cell autonomous-send window
-_RATE_LIMIT_MAX = 10                      # g3: max autonomous sends per cell per window
+_RATE_LIMIT_WINDOW = timedelta(hours=1)  # g3: per-cell autonomous-send window
+_RATE_LIMIT_MAX = 10  # g3: max autonomous sends per cell per window
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,11 @@ class EmailAutonomyGate:
         self._event_bus = event_bus
 
     async def check(
-        self, *, request: object, recipient: str, message_text: str,
+        self,
+        *,
+        request: object,
+        recipient: str,
+        message_text: str,
     ) -> GateDecision:
         """Allow or hold an outbound email. ``recipient`` is the resolved
         delivery address (validated thread recipient or pipeline default)."""
@@ -109,8 +113,14 @@ class EmailAutonomyGate:
         #    Suppress InvalidTransition: the cell may already be past ASK.
         with contextlib.suppress(InvalidTransition):
             await cg.apply_event(
-                self._db, domain=domain, verb=verb, risk_class=risk,
-                event=CellEvent.CLASSIFY, updated_at=now,
+                self._db,
+                domain=domain,
+                verb=verb,
+                risk_class=risk,
+                event=CellEvent.CLASSIFY,
+                updated_at=now,
+                # WS-3 gate-3: Genesis's own deterministic classifier.
+                origin_class="first_party",
             )
         cell = await cg.get_cell(self._db, domain, verb, risk)
         state = CellState(cell["state"]) if cell else CellState.ASK
@@ -122,15 +132,27 @@ class EmailAutonomyGate:
             trip = await self._scope_guard_trip(request, recipient, domain, verb, risk)
             if trip is None:
                 return GateDecision(
-                    allow=True, reason="granted", cell=(domain, verb, risk),
+                    allow=True,
+                    reason="granted",
+                    cell=(domain, verb, risk),
                 )
             logger.warning(
                 "Email scope guard '%s' tripped on GRANTED cell %s:%s:%s "
                 "(recipient=%s) — demoting + holding",
-                trip, domain, verb, risk, recipient,
+                trip,
+                domain,
+                verb,
+                risk,
+                recipient,
             )
             await cg.record_correction(
-                self._db, domain=domain, verb=verb, risk_class=risk, updated_at=now,
+                self._db,
+                domain=domain,
+                verb=verb,
+                risk_class=risk,
+                updated_at=now,
+                # WS-3 gate-3: Genesis's own deterministic scope guard tripped.
+                origin_class="first_party",
             )
             return await self._hold(request, message_text, classification, recipient, now)
 
@@ -145,7 +167,12 @@ class EmailAutonomyGate:
         return await et.has_inbound(self._db, thread_id)
 
     async def _scope_guard_trip(
-        self, request: object, recipient: str, domain: str, verb: str, risk: str,
+        self,
+        request: object,
+        recipient: str,
+        domain: str,
+        verb: str,
+        risk: str,
     ) -> str | None:
         """Deterministic pre-send scope guards for a GRANTED cell.
 
@@ -165,7 +192,10 @@ class EmailAutonomyGate:
         # g3 (primary): a burst of autonomous sends for one cell = a runaway loop.
         since = (datetime.now(UTC) - _RATE_LIMIT_WINDOW).isoformat()
         count = await aes.count_for_cell_since(
-            self._db, cell_domain=domain, cell_verb=verb, cell_risk_class=risk,
+            self._db,
+            cell_domain=domain,
+            cell_verb=verb,
+            cell_risk_class=risk,
             since=since,
         )
         if count >= _RATE_LIMIT_MAX:
@@ -173,7 +203,9 @@ class EmailAutonomyGate:
         return None
 
     async def _recipient_in_thread(
-        self, thread_id: str | None, recipient: str,
+        self,
+        thread_id: str | None,
+        recipient: str,
     ) -> bool:
         """True iff ``recipient`` is a known participant (received-message sender)
         of the thread.  The inbound path always records ``sender`` (the From
@@ -187,21 +219,27 @@ class EmailAutonomyGate:
         return await et.recipient_in_thread(self._db, thread_id, recipient)
 
     async def _hold(
-        self, request: object, message_text: str, classification: object,
-        recipient: str, now: str,
+        self,
+        request: object,
+        message_text: str,
+        classification: object,
+        recipient: str,
+        now: str,
     ) -> GateDecision:
         domain, verb, risk = classification.cell_key
         thread_id = getattr(request, "thread_id", None)
         category = getattr(request, "category", None)
         category_val = category.value if category is not None else "outreach"
-        context = json.dumps({
-            "kind": EMAIL_GATE_ACTION_TYPE,
-            "cell": [domain, verb, risk],
-            "validated_recipient": recipient,
-            "thread_id": thread_id,
-            "subject": getattr(request, "topic", "") or "",
-            "category": category_val,
-        })
+        context = json.dumps(
+            {
+                "kind": EMAIL_GATE_ACTION_TYPE,
+                "cell": [domain, verb, risk],
+                "validated_recipient": recipient,
+                "thread_id": thread_id,
+                "subject": getattr(request, "topic", "") or "",
+                "category": category_val,
+            }
+        )
 
         # Approval row FIRST — so a crash between the two writes never leaves a
         # pending_email_sends row pointing at a non-existent approval.
@@ -229,10 +267,18 @@ class EmailAutonomyGate:
         await self._emit_held(classification, recipient)
         logger.info(
             "Email gate HELD %s send to %s (cell=%s:%s:%s, request=%s)",
-            classification.sub_class, recipient, domain, verb, risk, request_id,
+            classification.sub_class,
+            recipient,
+            domain,
+            verb,
+            risk,
+            request_id,
         )
         return GateDecision(
-            allow=False, pending_id=pending_id, request_id=request_id, reason="held",
+            allow=False,
+            pending_id=pending_id,
+            request_id=request_id,
+            reason="held",
         )
 
     async def _emit_held(self, classification: object, recipient: str) -> None:

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -58,7 +58,8 @@ async def drain_pending_email_sends(rt: object) -> int:
         if approval is None:
             await pes.mark_rejected(db, row["id"], rejected_at=now, expired=True)
             logger.warning(
-                "Held email %s orphaned (approval missing) — expired", row["id"],
+                "Held email %s orphaned (approval missing) — expired",
+                row["id"],
             )
             resolved += 1
             continue
@@ -81,19 +82,26 @@ async def drain_pending_email_sends(rt: object) -> int:
             # mark sent/consumed — a transient failure leaves the row held for
             # the next cycle (the drain owns resume retries).
             result = await pipeline.deliver_approved(
-                row, subject=_subject(approval.get("context")),
+                row,
+                subject=_subject(approval.get("context")),
             )
             if result.status == OutreachStatus.DELIVERED:
                 await approval_crud.mark_consumed(db, row["request_id"], consumed_at=now)
                 await pes.mark_sent(db, row["id"], sent_at=now)
                 await cg.record_success(
-                    db, domain=row["cell_domain"], verb=row["cell_verb"],
-                    risk_class=row["cell_risk_class"], updated_at=now,
+                    db,
+                    domain=row["cell_domain"],
+                    verb=row["cell_verb"],
+                    risk_class=row["cell_risk_class"],
+                    updated_at=now,
+                    # WS-3 gate-3: the OWNER approved this send — owner evidence.
+                    origin_class="owner",
                 )
                 resolved += 1
                 logger.info(
                     "Resolved held email %s → sent to %s",
-                    row["id"], row["validated_recipient"],
+                    row["id"],
+                    row["validated_recipient"],
                 )
             elif result.status == OutreachStatus.IGNORED:
                 # The pipeline terminally SKIPPED this approved send (self-
@@ -103,7 +111,9 @@ async def drain_pending_email_sends(rt: object) -> int:
                 # approved/unconsumed row. No correction (a guard, not owner intent).
                 if await pes.mark_rejected(db, row["id"], rejected_at=now):
                     await approval_crud.mark_consumed(
-                        db, row["request_id"], consumed_at=now,
+                        db,
+                        row["request_id"],
+                        consumed_at=now,
                     )
                     resolved += 1
                 logger.warning(
@@ -113,13 +123,19 @@ async def drain_pending_email_sends(rt: object) -> int:
             else:
                 logger.warning(
                     "Held email %s delivery failed (%s) — retry next cycle",
-                    row["id"], result.status.value,
+                    row["id"],
+                    result.status.value,
                 )
         elif status in ("rejected", "cancelled"):
             if await pes.mark_rejected(db, row["id"], rejected_at=now):
                 await cg.record_correction(
-                    db, domain=row["cell_domain"], verb=row["cell_verb"],
-                    risk_class=row["cell_risk_class"], updated_at=now,
+                    db,
+                    domain=row["cell_domain"],
+                    verb=row["cell_verb"],
+                    risk_class=row["cell_risk_class"],
+                    updated_at=now,
+                    # WS-3 gate-3: the OWNER rejected/cancelled — owner decision.
+                    origin_class="owner",
                 )
                 resolved += 1
         elif status == "expired":

--- a/src/genesis/dashboard/routes/autonomy.py
+++ b/src/genesis/dashboard/routes/autonomy.py
@@ -89,13 +89,20 @@ async def autonomy_flag_send(send_id: str):
     if newly_flagged:
         state = await cg.record_correction(
             rt.db,
-            domain=send["cell_domain"], verb=send["cell_verb"],
-            risk_class=send["cell_risk_class"], updated_at=now,
+            domain=send["cell_domain"],
+            verb=send["cell_verb"],
+            risk_class=send["cell_risk_class"],
+            updated_at=now,
+            # WS-3 gate-3: the OWNER flagged this send from the dashboard.
+            origin_class="owner",
         )
         cell_state = state.value
         logger.info(
             "Owner flagged autonomous send %s — corrected cell %s:%s:%s (now %s)",
-            send_id, send["cell_domain"], send["cell_verb"],
-            send["cell_risk_class"], cell_state,
+            send_id,
+            send["cell_domain"],
+            send["cell_verb"],
+            send["cell_risk_class"],
+            cell_state,
         )
     return jsonify({"flagged": newly_flagged, "cell_state": cell_state})

--- a/src/genesis/db/crud/capability_grants.py
+++ b/src/genesis/db/crud/capability_grants.py
@@ -57,9 +57,7 @@ def cell_id(domain: str, verb: str, risk_class: str) -> str:
     return f"{domain}:{verb}:{risk_class}"
 
 
-def cell_posterior(
-    successes: int, corrections: int, weighted_corrections: float = 0.0
-) -> float:
+def cell_posterior(successes: int, corrections: int, weighted_corrections: float = 0.0) -> float:
     """Beta(1,1) posterior mean, re-earn flavour (WS-8 PR-D).
 
     ``weighted_corrections`` is the Σ of consequence-weighted corrections; when
@@ -102,8 +100,7 @@ async def ensure_cell(
              (id, domain, verb, risk_class, state, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO NOTHING""",
-        (cid, domain, verb, risk_class,
-         CellState.NOT_DETERMINED.value, updated_at, updated_at),
+        (cid, domain, verb, risk_class, CellState.NOT_DETERMINED.value, updated_at, updated_at),
     )
     await db.commit()
     row = await get_cell(db, domain, verb, risk_class)
@@ -113,9 +110,7 @@ async def ensure_cell(
 
 
 async def list_all(db: aiosqlite.Connection) -> list[dict]:
-    cursor = await db.execute(
-        "SELECT * FROM capability_grants ORDER BY domain, verb, risk_class"
-    )
+    cursor = await db.execute("SELECT * FROM capability_grants ORDER BY domain, verb, risk_class")
     return [dict(r) for r in await cursor.fetchall()]
 
 
@@ -123,11 +118,41 @@ async def list_granted(db: aiosqlite.Connection) -> list[dict]:
     """All GRANTED cells — what Genesis is authorized to do autonomously (the
     'standing autonomy' pane of the owner-visibility Activity tab)."""
     cursor = await db.execute(
-        "SELECT * FROM capability_grants WHERE state = ? "
-        "ORDER BY domain, verb, risk_class",
+        "SELECT * FROM capability_grants WHERE state = ? ORDER BY domain, verb, risk_class",
         (CellState.GRANTED.value,),
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def _emit_autonomy_gate(
+    db: aiosqlite.Connection,
+    *,
+    fn: str,
+    origin_class: str,
+    domain: str,
+    verb: str,
+    risk_class: str,
+    extra: dict | None = None,
+) -> None:
+    """WS-3 B1 gate-3 (autonomy) shadow emit — the SINGLE choke for grant
+    evidence/state mutations. Self-guarding + fail-open (record_would_block
+    swallows everything); owner/first_party origins and the kill switch produce
+    NO row. Detail carries the cell key only — never content."""
+    from genesis.security import immunity_shadow
+
+    detail: dict = {"cell": f"{domain}:{verb}:{risk_class}"}
+    if extra:
+        detail.update(extra)
+    await immunity_shadow.record_would_block(
+        gate="autonomy",
+        source_kind="grant_evidence",
+        source_ref=f"db/crud/capability_grants.py::{fn}",
+        process="server",
+        blockable_count=1,
+        origin_class=origin_class,
+        db=db,
+        detail=detail,
+    )
 
 
 async def apply_event(
@@ -138,12 +163,20 @@ async def apply_event(
     risk_class: str,
     event: CellEvent,
     updated_at: str,
+    origin_class: str,
 ) -> CellState:
     """Apply a state-machine event to the cell and persist the new state.
 
     Raises :class:`genesis.autonomy.capabilities.InvalidTransition` if the
     event is illegal from the current state.  Sets ``granted_at`` when the
     cell first reaches GRANTED.
+
+    ``origin_class`` (REQUIRED — WS-3 gate-3) is the provenance of whatever
+    prompted this state change: ``owner`` for owner decisions
+    (approve/reject), ``first_party`` for Genesis's own deterministic
+    guards/classifiers. Required, not defaulted, so every future caller must
+    STATE provenance — a silent first_party default would be a permanently
+    inert gate.
     """
     row = await ensure_cell(
         db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
@@ -164,6 +197,15 @@ async def apply_event(
         (new_state.value, granted_at, updated_at, row["id"]),
     )
     await db.commit()
+    await _emit_autonomy_gate(
+        db,
+        fn="apply_event",
+        origin_class=origin_class,
+        domain=domain,
+        verb=verb,
+        risk_class=risk_class,
+        extra={"event": event.value},
+    )
     return new_state
 
 
@@ -174,8 +216,13 @@ async def record_success(
     verb: str,
     risk_class: str,
     updated_at: str,
+    origin_class: str,
 ) -> bool:
-    """Increment the success counter.  Promotion stays explicit (user approve)."""
+    """Increment the success counter.  Promotion stays explicit (user approve).
+
+    ``origin_class`` (REQUIRED — WS-3 gate-3): provenance of the success
+    evidence. See :func:`apply_event`.
+    """
     row = await ensure_cell(
         db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
     )
@@ -186,6 +233,14 @@ async def record_success(
         (updated_at, updated_at, row["id"]),
     )
     await db.commit()
+    await _emit_autonomy_gate(
+        db,
+        fn="record_success",
+        origin_class=origin_class,
+        domain=domain,
+        verb=verb,
+        risk_class=risk_class,
+    )
     return cursor.rowcount > 0
 
 
@@ -196,6 +251,7 @@ async def record_correction(
     verb: str,
     risk_class: str,
     updated_at: str,
+    origin_class: str,
     consequence_weight: float | None = None,
 ) -> CellState:
     """Record a correction on a cell and, if it was GRANTED, DEMOTE it to ASK.
@@ -214,11 +270,7 @@ async def record_correction(
     row = await ensure_cell(
         db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
     )
-    weight = (
-        consequence_weight
-        if consequence_weight is not None
-        else correction_weight(risk_class)
-    )
+    weight = consequence_weight if consequence_weight is not None else correction_weight(risk_class)
     new_corrections = row["corrections"] + 1
     new_weighted = (row["weighted_corrections"] or 0.0) + weight
 
@@ -233,10 +285,17 @@ async def record_correction(
              SET corrections = ?, weighted_corrections = ?, state = ?,
                  granted_at = ?, updated_at = ?
            WHERE id = ?""",
-        (new_corrections, new_weighted, new_state.value, granted_at,
-         updated_at, row["id"]),
+        (new_corrections, new_weighted, new_state.value, granted_at, updated_at, row["id"]),
     )
     await db.commit()
+    await _emit_autonomy_gate(
+        db,
+        fn="record_correction",
+        origin_class=origin_class,
+        domain=domain,
+        verb=verb,
+        risk_class=risk_class,
+    )
     return new_state
 
 
@@ -294,7 +353,10 @@ async def detect_promotable_cells(
 
 
 async def decay_stale_cells(
-    db: aiosqlite.Connection, *, now: str, half_life_days: int = 90,
+    db: aiosqlite.Connection,
+    *,
+    now: str,
+    half_life_days: int = 90,
 ) -> list[str]:
     """Decay GRANTED cells idle longer than the half-life back to NOT_DETERMINED
     (the ``DECAY`` transition, applied in bulk).
@@ -304,9 +366,7 @@ async def decay_stale_cells(
     so a long-unused standing autonomy lapses rather than entrenching.  Atomic
     ``UPDATE…RETURNING``.  Returns the decayed cell ids.
     """
-    cutoff = (
-        datetime.fromisoformat(now) - timedelta(days=half_life_days)
-    ).isoformat()
+    cutoff = (datetime.fromisoformat(now) - timedelta(days=half_life_days)).isoformat()
     cursor = await db.execute(
         """UPDATE capability_grants
              SET state = ?, granted_at = NULL, last_decayed_at = ?, updated_at = ?

--- a/src/genesis/ego/cell_promotion.py
+++ b/src/genesis/ego/cell_promotion.py
@@ -109,9 +109,11 @@ async def handle_cell_promotion_resolution(
         and current["state"] == CellState.ASK.value
         and current["successes"] >= cg.MIN_PROMOTE_N
         and cg.cell_posterior(
-            current["successes"], current["corrections"],
+            current["successes"],
+            current["corrections"],
             current["weighted_corrections"] or 0.0,
-        ) >= cg.PROMOTE_THRESHOLD
+        )
+        >= cg.PROMOTE_THRESHOLD
     )
     if not still_promotable:
         logger.info(
@@ -120,20 +122,30 @@ async def handle_cell_promotion_resolution(
         )
         with contextlib.suppress(Exception):
             await ego_crud.execute_proposal(
-                db, proposal["id"], status="executed",
+                db,
+                proposal["id"],
+                status="executed",
                 user_response="cell promotion skipped: evidence changed",
             )
         return False
 
     try:
         await cg.apply_event(
-            db, domain=domain, verb=verb, risk_class=risk,
-            event=CellEvent.APPROVE, updated_at=now,
+            db,
+            domain=domain,
+            verb=verb,
+            risk_class=risk,
+            event=CellEvent.APPROVE,
+            updated_at=now,
+            # WS-3 gate-3: executing an OWNER-approved promotion proposal.
+            origin_class="owner",
         )
         ok = True
     except Exception:
         logger.warning(
-            "cell_promotion apply_event failed for %s", cell_key, exc_info=True,
+            "cell_promotion apply_event failed for %s",
+            cell_key,
+            exc_info=True,
         )
         ok = False
 
@@ -141,9 +153,12 @@ async def handle_cell_promotion_resolution(
     # (which would clutter the board AND let the sweep dispatch it as a session).
     with contextlib.suppress(Exception):
         await ego_crud.execute_proposal(
-            db, proposal["id"], status="executed",
+            db,
+            proposal["id"],
+            status="executed",
             user_response=(
-                f"cell {cell_key} promoted to GRANTED" if ok
+                f"cell {cell_key} promoted to GRANTED"
+                if ok
                 else f"cell {cell_key} promotion failed"
             ),
         )

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -29,6 +29,22 @@ logger = logging.getLogger(__name__)
 # that should fire only on foreground activity (e.g., STEERING.md auto-update).
 _AUTONOMOUS_CHANNELS = {"inbox", "mail", "reflection", "surplus"}
 
+# WS-3 gate-2 (identity): channel -> origin for a steering-rule write. An
+# ALLOW-map of positively-owner channels (ChannelType StrEnum values; all four
+# are owner-gated surfaces), defaulting fail-closed to external_untrusted --
+# deliberately the OPPOSITE polarity of _AUTONOMOUS_CHANNELS above, which is a
+# deny-list that fails OPEN for any new/unlisted channel. `voice` is absent on
+# purpose: ambient multi-speaker STT means user_text can be a non-owner human
+# in the room. The gate only OBSERVES (shadow) -- a deny-list escape that
+# writes a steering rule now produces a would-block row instead of being
+# invisible.
+_CHANNEL_ORIGIN = {
+    "terminal": "owner",
+    "telegram": "owner",
+    "whatsapp": "owner",
+    "web": "owner",
+}
+
 
 # A STEERING.md rule must READ as a terse imperative directive addressed to
 # Genesis — not a chatty, multi-sentence status update. This guard is why the
@@ -222,9 +238,7 @@ def build_triage_pipeline(
             or (outcome == OutcomeClass.SUCCESS and is_autonomous)
         ):
             try:
-                logger.debug(
-                    "Running deprecated procedure extraction (legacy 500-char path)"
-                )
+                logger.debug("Running deprecated procedure extraction (legacy 500-char path)")
                 summary_text = f"User: {summary.user_text}\nOutput: {summary.response_text[:500]}"
                 await extract_procedure(
                     db,
@@ -245,7 +259,29 @@ def build_triage_pipeline(
             and summary.channel not in _AUTONOMOUS_CHANNELS
         ):
             try:
-                _extract_steering_rule(summary, identity_loader)
+                written_rule = _extract_steering_rule(summary, identity_loader)
+                if written_rule:
+                    # WS-3 B1 gate-2 (identity): shadow-record the steering
+                    # write, classified by CHANNEL (allow-map; unknown/voice ->
+                    # external_untrusted, fail-closed) -- so a deny-list escape
+                    # is OBSERVED. Owner channels self-guard to no row.
+                    # Best-effort, never raises; counts only, never content.
+                    from genesis.memory.provenance import ORIGIN_EXTERNAL_UNTRUSTED
+                    from genesis.security import immunity_shadow
+
+                    await immunity_shadow.record_would_block(
+                        gate="identity",
+                        source_kind="identity_write",
+                        source_ref="learning/pipeline.py::_run_pipeline",
+                        process="server",
+                        blockable_count=1,
+                        origin_class=_CHANNEL_ORIGIN.get(
+                            summary.channel,
+                            ORIGIN_EXTERNAL_UNTRUSTED,
+                        ),
+                        db=db,
+                        detail={"mode": "steering", "channel": summary.channel},
+                    )
             except Exception:
                 logger.error("Steering rule extraction failed (non-fatal)", exc_info=True)
 
@@ -253,7 +289,9 @@ def build_triage_pipeline(
             # GROUNDWORK(bis): Additive — steering rule behavior unchanged.
             try:
                 await _record_behavioral_correction(
-                    db, summary, observation_writer,
+                    db,
+                    summary,
+                    observation_writer,
                 )
             except Exception:
                 logger.error("BIS correction capture failed (non-fatal)", exc_info=True)
@@ -271,8 +309,9 @@ def build_triage_pipeline(
             )
 
     def _extract_steering_rule(
-        summary: Any, loader: Any,
-    ) -> None:
+        summary: Any,
+        loader: Any,
+    ) -> str | None:
         """Extract a steering rule from a user correction and add to STEERING.md.
 
         Fires only on approach_failure (gated upstream). A rule is written ONLY
@@ -288,14 +327,20 @@ def build_triage_pipeline(
         """
         user_text = (summary.user_text or "").strip()
         if not _looks_like_directive(user_text):
-            return
+            return None
 
         rule = user_text if len(user_text) <= 200 else user_text[:200] + "..."
         loader.add_steering_rule(rule)
         logger.info("Auto-added steering rule from user correction: %.80s...", rule)
+        # Return the written rule so the caller can distinguish a REAL write
+        # from a directive-filter reject (the WS-3 gate-2 emit fires only on
+        # actual writes -- a reject is a non-event).
+        return rule
 
     async def _record_behavioral_correction(
-        db_conn: Any, summary: Any, obs_writer: ObservationWriter,
+        db_conn: Any,
+        summary: Any,
+        obs_writer: ObservationWriter,
     ) -> None:
         """Capture a raw behavioral correction for BIS theme clustering.
 
@@ -355,7 +400,9 @@ def build_triage_pipeline(
 
         attributions = set()
         if delta and hasattr(delta, "attributions"):
-            attributions = {a.value if hasattr(a, "value") else str(a) for a in (delta.attributions or [])}
+            attributions = {
+                a.value if hasattr(a, "value") else str(a) for a in (delta.attributions or [])
+            }
 
         outcome_val = outcome.value if hasattr(outcome, "value") else str(outcome)
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -35,6 +35,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             return
         try:
             from genesis.db.crud import execution_traces as _et
+
             removed = await _et.prune_older_than(rt._db, days=90)
             rt.record_job_success("execution_traces_prune")
             if removed:
@@ -56,6 +57,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             return
         try:
             from genesis.db.crud import cost_events as _ce
+
             removed = await _ce.prune_older_than(rt._db, days=90)
             rt.record_job_success("cost_events_prune")
             if removed:
@@ -77,6 +79,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             return
         try:
             from genesis.db.crud import file_modifications as _fm
+
             removed = await _fm.prune_older_than(rt._db, days=90)
             rt.record_job_success("file_modifications_prune")
             if removed:
@@ -98,8 +101,7 @@ async def init(rt: GenesisRuntime) -> None:
     """Initialize learning pipeline, triage, calibration, harvest, and all scheduled jobs."""
     if rt._db is None or rt._router is None:
         logger.warning(
-            "Learning skipped — missing prerequisites "
-            "(db=%s, router=%s)",
+            "Learning skipped — missing prerequisites (db=%s, router=%s)",
             rt._db is not None,
             rt._router is not None,
         )
@@ -254,7 +256,9 @@ async def init(rt: GenesisRuntime) -> None:
                     logger.debug("Triage calibration skipped (Genesis paused)")
                     return
             except Exception:
-                logger.warning("Pause check failed — skipping calibration as precaution", exc_info=True)
+                logger.warning(
+                    "Pause check failed — skipping calibration as precaution", exc_info=True
+                )
                 return
             try:
                 result = await _original_calibration()
@@ -287,7 +291,8 @@ async def init(rt: GenesisRuntime) -> None:
                     return
             except Exception:
                 logger.warning(
-                    "Pause check failed — skipping email gate drain", exc_info=True,
+                    "Pause check failed — skipping email gate drain",
+                    exc_info=True,
                 )
                 return
             try:
@@ -318,18 +323,21 @@ async def init(rt: GenesisRuntime) -> None:
                     return
             except Exception:
                 logger.warning(
-                    "Pause check failed — skipping capability decay", exc_info=True,
+                    "Pause check failed — skipping capability decay",
+                    exc_info=True,
                 )
                 return
             try:
                 decayed = await _cg.decay_stale_cells(
-                    rt._db, now=datetime.now(UTC).isoformat(),
+                    rt._db,
+                    now=datetime.now(UTC).isoformat(),
                 )
                 rt.record_job_success("capability_decay_sweep")
                 if decayed:
                     logger.info(
                         "Capability decay: %d stale grant(s) lapsed: %s",
-                        len(decayed), ", ".join(decayed),
+                        len(decayed),
+                        ", ".join(decayed),
                     )
             except Exception as exc:
                 rt.record_job_failure("capability_decay_sweep", str(exc))
@@ -364,13 +372,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         async def _harvest_and_store() -> None:
             try:
-                memory_dir = (
-                    Path.home()
-                    / ".claude"
-                    / "projects"
-                    / cc_project_dir()
-                    / "memory"
-                )
+                memory_dir = Path.home() / ".claude" / "projects" / cc_project_dir() / "memory"
                 items = harvest_auto_memory(memory_dir)
                 stored = 0
                 skipped = 0
@@ -399,7 +401,9 @@ async def init(rt: GenesisRuntime) -> None:
                 if items:
                     logger.info(
                         "Harvested %d auto-memory items (%d new, %d dedup-skipped)",
-                        len(items), stored, skipped,
+                        len(items),
+                        stored,
+                        skipped,
                     )
                 rt.record_job_success("auto_memory_harvest")
             except Exception as exc:
@@ -422,7 +426,8 @@ async def init(rt: GenesisRuntime) -> None:
                 if count or stale:
                     logger.info(
                         "Observation expiry sweep: resolved %d expired, %d stale persistent",
-                        count, stale,
+                        count,
+                        stale,
                     )
             except Exception as exc:
                 rt.record_job_failure("observation_expiry_sweep", str(exc))
@@ -444,7 +449,8 @@ async def init(rt: GenesisRuntime) -> None:
                 rt.record_job_success("follow_up_retention_sweep")
                 if count:
                     logger.info(
-                        "Follow-up retention sweep: purged %d old records", count,
+                        "Follow-up retention sweep: purged %d old records",
+                        count,
                     )
             except Exception as exc:
                 rt.record_job_failure("follow_up_retention_sweep", str(exc))
@@ -479,8 +485,8 @@ async def init(rt: GenesisRuntime) -> None:
                 rt.record_job_success("inbox_marker_decay")
                 if decayed:
                     logger.info(
-                        "Inbox marker decay: aged out %d stale attention "
-                        "marker(s)", decayed,
+                        "Inbox marker decay: aged out %d stale attention marker(s)",
+                        decayed,
                     )
             except Exception as exc:
                 rt.record_job_failure("inbox_marker_decay", str(exc))
@@ -535,6 +541,7 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=300,
         )
         from genesis.util.tasks import tracked_task as _tt
+
         _tt(_validate_keys(), name="initial_api_key_validation")
         # Boot kick: run recovery housekeeping (dead-letter replay, stuck-
         # processing expiry, pending embeddings) immediately instead of
@@ -564,9 +571,12 @@ async def init(rt: GenesisRuntime) -> None:
         async def _expire_stale_messages() -> None:
             try:
                 from genesis.db.crud import message_queue
+
                 now = datetime.now(UTC).isoformat()
                 expired = await message_queue.expire_older_than(
-                    rt._db, max_age_hours=168, expired_at=now,
+                    rt._db,
+                    max_age_hours=168,
+                    expired_at=now,
                 )
                 rt.record_job_success("message_queue_expiry")
                 if expired:
@@ -589,7 +599,9 @@ async def init(rt: GenesisRuntime) -> None:
                     logger.debug("Dead letter redispatch skipped (Genesis paused)")
                     return
             except Exception:
-                logger.warning("Pause check failed — skipping redispatch as precaution", exc_info=True)
+                logger.warning(
+                    "Pause check failed — skipping redispatch as precaution", exc_info=True
+                )
                 return
             if rt._dead_letter_queue is not None and rt._router is not None:
                 try:
@@ -600,11 +612,13 @@ async def init(rt: GenesisRuntime) -> None:
                     if ok or fail:
                         logger.info(
                             "Dead letter redispatch: %d succeeded, %d failed",
-                            ok, fail,
+                            ok,
+                            fail,
                         )
                 except Exception:
                     rt.record_job_failure(
-                        "dead_letter_redispatch", "redispatch failed",
+                        "dead_letter_redispatch",
+                        "redispatch failed",
                     )
                     logger.exception("Dead letter redispatch failed")
 
@@ -619,6 +633,7 @@ async def init(rt: GenesisRuntime) -> None:
         async def _run_procedure_promotion() -> None:
             try:
                 from genesis.learning.procedural.promoter import promote_and_demote
+
                 result = await promote_and_demote(rt._db)
                 rt.record_job_success("procedure_promotion")
                 if any(v > 0 for v in result.values()):
@@ -634,6 +649,7 @@ async def init(rt: GenesisRuntime) -> None:
                 from genesis.learning.procedural.promoter import (
                     backfill_missing_embeddings,
                 )
+
                 await backfill_missing_embeddings(rt._db)
             except Exception:
                 logger.exception("Procedure embedding backfill failed")
@@ -676,8 +692,7 @@ async def init(rt: GenesisRuntime) -> None:
                     identity_loader = getattr(rt, "_identity_loader", None)
                     if identity_loader is None:
                         logger.warning(
-                            "identity_loader not available, skipping "
-                            "USER_KNOWLEDGE.md synthesis",
+                            "identity_loader not available, skipping USER_KNOWLEDGE.md synthesis",
                         )
                     else:
                         narrative: str | None = None
@@ -698,13 +713,36 @@ async def init(rt: GenesisRuntime) -> None:
                             # synthesis can be rolled back (Option B: no loader change).
                             uk_path = identity_loader._dir / "USER_KNOWLEDGE.md"
                             prior_uk = (
-                                uk_path.read_text(encoding="utf-8")
-                                if uk_path.exists() else None
+                                uk_path.read_text(encoding="utf-8") if uk_path.exists() else None
                             )
                             identity_loader.write_user_knowledge_md(
                                 result.model,
                                 evidence_count=result.evidence_count,
                                 narrative=narrative,
+                            )
+                            # WS-3 B1 gate-2 (identity): shadow-record the
+                            # USER_KNOWLEDGE write. first_party BY AUTHORSHIP
+                            # (Genesis's own reflection-derived user-model
+                            # deltas) -> self-guards to NO row today. FLIP
+                            # BLOCKER (do not enforce past this): observation
+                            # rows carry no origin_class, so externally-planted
+                            # "facts about the user" in reflected transcripts
+                            # remain first_party until delta-level provenance
+                            # lands. Counts only, never content.
+                            from genesis.security import immunity_shadow
+
+                            await immunity_shadow.record_would_block(
+                                gate="identity",
+                                source_kind="identity_write",
+                                source_ref=("runtime/init/learning.py::_evolve_user_model"),
+                                process="server",
+                                blockable_count=1,
+                                origin_class="first_party",
+                                db=rt._db,
+                                detail={
+                                    "mode": "narrative" if narrative else "rules",
+                                    "evidence_count": result.evidence_count,
+                                },
                             )
                             try:
                                 from genesis.learning.cognitive_ledger import (
@@ -733,8 +771,7 @@ async def init(rt: GenesisRuntime) -> None:
                                 )
                             if narrative:
                                 logger.info(
-                                    "USER_KNOWLEDGE.md updated via LLM "
-                                    "synthesis (call site 11)",
+                                    "USER_KNOWLEDGE.md updated via LLM synthesis (call site 11)",
                                 )
                             else:
                                 logger.info(
@@ -750,7 +787,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _evolve_user_model,
-            CronTrigger(hour=6, minute=30, timezone=user_timezone()),  # moved from 4:30 to avoid dream cycle window
+            CronTrigger(
+                hour=6, minute=30, timezone=user_timezone()
+            ),  # moved from 4:30 to avoid dream cycle window
             id="user_model_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -814,7 +853,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _refresh_capability_map,
-            CronTrigger(hour="9,21", minute=15, timezone=user_timezone()),  # moved from 4:15/16:15 to avoid dream cycle window
+            CronTrigger(
+                hour="9,21", minute=15, timezone=user_timezone()
+            ),  # moved from 4:15/16:15 to avoid dream cycle window
             id="capability_map_refresh",
             max_instances=1,
             misfire_grace_time=3600,
@@ -872,7 +913,8 @@ async def init(rt: GenesisRuntime) -> None:
                 if snap is not None:
                     logger.info(
                         "Ego calibration: ECE=%.4f n=%d%s",
-                        snap["ece"], snap["sample_count"],
+                        snap["ece"],
+                        snap["sample_count"],
                         " (low-confidence)" if snap["low_confidence"] else "",
                     )
             except Exception as exc:
@@ -995,15 +1037,16 @@ async def init(rt: GenesisRuntime) -> None:
                 if depth >= 10:
                     return []
                 proc = await asyncio.create_subprocess_exec(
-                    "pgrep", "-P", str(pid),
+                    "pgrep",
+                    "-P",
+                    str(pid),
                     stdout=asyncio.subprocess.PIPE,
                 )
                 stdout, _ = await proc.communicate()
                 if not stdout.strip():
                     return []
                 children = [
-                    int(p.strip()) for p in stdout.decode().strip().split("\n")
-                    if p.strip()
+                    int(p.strip()) for p in stdout.decode().strip().split("\n") if p.strip()
                 ]
                 result: list[int] = []
                 for child in children:
@@ -1015,7 +1058,9 @@ async def init(rt: GenesisRuntime) -> None:
                 all_killed: list[tuple[int, str]] = []
                 for flag, pattern, max_age_h, label in targets:
                     proc = await asyncio.create_subprocess_exec(
-                        "pgrep", flag, pattern,
+                        "pgrep",
+                        flag,
+                        pattern,
                         stdout=asyncio.subprocess.PIPE,
                     )
                     stdout, _ = await proc.communicate()
@@ -1036,7 +1081,7 @@ async def init(rt: GenesisRuntime) -> None:
                                 raw = f.read()
                             # comm field (field 2) is in parens and may
                             # contain spaces; split after the last ')'.
-                            after_comm = raw[raw.rfind(")") + 2:]
+                            after_comm = raw[raw.rfind(")") + 2 :]
                             start_ticks = int(after_comm.split()[19])
                             with open("/proc/uptime") as f:
                                 uptime_secs = float(f.read().split()[0])
@@ -1081,13 +1126,14 @@ async def init(rt: GenesisRuntime) -> None:
                                 source="process_reaper",
                                 type="process_reaper_kill",
                                 priority="low",
-                                content=json.dumps({
-                                    "killed_count": len(all_killed),
-                                    "processes": [
-                                        {"pid": p, "label": lbl}
-                                        for p, lbl in all_killed
-                                    ],
-                                }),
+                                content=json.dumps(
+                                    {
+                                        "killed_count": len(all_killed),
+                                        "processes": [
+                                            {"pid": p, "label": lbl} for p, lbl in all_killed
+                                        ],
+                                    }
+                                ),
                                 created_at=datetime.now(UTC).isoformat(),
                             )
                         except Exception:
@@ -1123,7 +1169,9 @@ async def init(rt: GenesisRuntime) -> None:
                     outreach_fn = outreach_pipeline.submit
 
                 pipeline = SkillEvolutionPipeline(
-                    db=rt._db, router=rt._router, outreach_fn=outreach_fn,
+                    db=rt._db,
+                    router=rt._router,
+                    outreach_fn=outreach_fn,
                 )
                 result = await pipeline.run()
                 if result["proposed"] > 0 or result["applied"] > 0:
@@ -1135,7 +1183,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_skill_evolution,
-            CronTrigger(day_of_week="sat", hour=4, minute=0, timezone=user_timezone()),  # moved off Sunday to avoid dream cycle
+            CronTrigger(
+                day_of_week="sat", hour=4, minute=0, timezone=user_timezone()
+            ),  # moved off Sunday to avoid dream cycle
             id="skill_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -1146,6 +1196,7 @@ async def init(rt: GenesisRuntime) -> None:
         async def _run_j9_eval_aggregation():
             try:
                 from genesis.eval.j9_aggregator import run_weekly_aggregation
+
                 results = await run_weekly_aggregation(rt._db)
                 dims_computed = len(results)
                 logger.info("J9 weekly aggregation: %d dimensions computed", dims_computed)
@@ -1158,7 +1209,8 @@ async def init(rt: GenesisRuntime) -> None:
                     )
 
                     regressions = await check_and_alert_regressions(
-                        rt._db, getattr(rt, "_outreach_pipeline", None),
+                        rt._db,
+                        getattr(rt, "_outreach_pipeline", None),
                     )
                     if regressions:
                         logger.info(
@@ -1174,7 +1226,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_j9_eval_aggregation,
-            CronTrigger(day_of_week="sun", hour=7, minute=30, timezone=user_timezone()),  # :30 to avoid schedule_analytical at 7:00
+            CronTrigger(
+                day_of_week="sun", hour=7, minute=30, timezone=user_timezone()
+            ),  # :30 to avoid schedule_analytical at 7:00
             id="j9_eval_aggregation",
             max_instances=1,
             misfire_grace_time=3600,
@@ -1188,6 +1242,7 @@ async def init(rt: GenesisRuntime) -> None:
                 from genesis.eval.pr_review_harvest import (
                     harvest_pr_review_findings,
                 )
+
                 summary = await harvest_pr_review_findings(rt._db)
                 if summary.get("error"):
                     # Error-dict return (repo-resolve / pr-list failure):
@@ -1243,7 +1298,9 @@ async def init(rt: GenesisRuntime) -> None:
                 for model in models:
                     try:
                         summary = await run_gauntlet(
-                            model, db=rt._db, trigger=EvalTrigger.SCHEDULE,
+                            model,
+                            db=rt._db,
+                            trigger=EvalTrigger.SCHEDULE,
                         )
                     except RosterError:
                         logger.info(
@@ -1257,11 +1314,15 @@ async def init(rt: GenesisRuntime) -> None:
                     ran += 1
                     try:
                         await check_gauntlet_regression(
-                            rt._db, summary, getattr(rt, "_outreach_pipeline", None),
+                            rt._db,
+                            summary,
+                            getattr(rt, "_outreach_pipeline", None),
                         )
                     except Exception:
                         logger.warning(
-                            "gauntlet regression check failed for %s", model, exc_info=True,
+                            "gauntlet regression check failed for %s",
+                            model,
+                            exc_info=True,
                         )
                 logger.info("Model gauntlet: ran %d/%d roster model(s)", ran, len(models))
                 rt.record_job_success("model_gauntlet")
@@ -1285,4 +1346,7 @@ async def init(rt: GenesisRuntime) -> None:
     except Exception as exc:
         logger.exception("Failed to initialize learning")
         from genesis.runtime._degradation import record_init_degradation
-        await record_init_degradation(rt._db, rt._event_bus, "learning", "learning_scheduler", str(exc), severity="error")
+
+        await record_init_degradation(
+            rt._db, rt._event_bus, "learning", "learning_scheduler", str(exc), severity="error"
+        )

--- a/tests/ego/test_cell_promotion.py
+++ b/tests/ego/test_cell_promotion.py
@@ -33,17 +33,24 @@ async def db():
 
 async def _promotable_cell(db, successes=5):
     """An ASK cell with enough approved successes to be promotable."""
-    await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_CELL)
+    await cg.apply_event(
+        db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_CELL
+    )
     for _ in range(successes):
-        await cg.record_success(db, updated_at=_TS, **_CELL)
+        await cg.record_success(db, origin_class="first_party", updated_at=_TS, **_CELL)
 
 
-async def _make_proposal(db, *, status="approved", action_type="cell_promotion",
-                         cell=("email", "send", "standard")):
+async def _make_proposal(
+    db, *, status="approved", action_type="cell_promotion", cell=("email", "send", "standard")
+):
     pid = "cp1"
     await ego_crud.create_proposal(
-        db, id=pid, action_type=action_type, action_category=":".join(cell),
-        content="promote", status="pending",
+        db,
+        id=pid,
+        action_type=action_type,
+        action_category=":".join(cell),
+        content="promote",
+        status="pending",
         created_at="2026-06-20T00:00:00+00:00",
         expected_outputs=json.dumps({"cell": list(cell)}),
     )
@@ -84,9 +91,13 @@ async def test_rejected_sets_cooldown_no_promote(db):
 
     assert ok is False
     assert (await cg.get_cell(db, **_CELL))["state"] == CellState.ASK.value
-    assert await ego_crud.get_state(
-        db, "cell_promotion_reject:email:send:standard",
-    ) is not None
+    assert (
+        await ego_crud.get_state(
+            db,
+            "cell_promotion_reject:email:send:standard",
+        )
+        is not None
+    )
 
 
 async def test_non_cell_proposal_is_noop(db):

--- a/tests/test_autonomy/test_email_gate.py
+++ b/tests/test_autonomy/test_email_gate.py
@@ -46,8 +46,11 @@ def _gate(db):
 
 def _req(**kw):
     base = dict(
-        category=OutreachCategory.BLOCKER, topic="hi", context="body",
-        salience_score=0.5, channel="email",
+        category=OutreachCategory.BLOCKER,
+        topic="hi",
+        context="body",
+        salience_score=0.5,
+        channel="email",
     )
     base.update(kw)
     return OutreachRequest(**base)
@@ -77,8 +80,15 @@ async def _add_inbound_from(db, thread_id, sender):
 
 async def _grant_standard(db):
     for event in (CellEvent.CLASSIFY, CellEvent.APPROVE):
-        await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
-                             event=event, updated_at=_TS)
+        await cg.apply_event(
+            db,
+            origin_class="first_party",
+            domain="email",
+            verb="send",
+            risk_class="standard",
+            event=event,
+            updated_at=_TS,
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -109,10 +119,24 @@ async def test_cold_ungranted_email_is_held(db):
 async def test_granted_known_thread_reply_is_allowed(db):
     # pre-grant the standard (known-thread reply) cell, with the recipient as a
     # recorded thread participant so the g1 recipient-match guard passes.
-    await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
-                         event=CellEvent.CLASSIFY, updated_at=_TS)
-    await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
-                         event=CellEvent.APPROVE, updated_at=_TS)
+    await cg.apply_event(
+        db,
+        origin_class="first_party",
+        domain="email",
+        verb="send",
+        risk_class="standard",
+        event=CellEvent.CLASSIFY,
+        updated_at=_TS,
+    )
+    await cg.apply_event(
+        db,
+        origin_class="first_party",
+        domain="email",
+        verb="send",
+        risk_class="standard",
+        event=CellEvent.APPROVE,
+        updated_at=_TS,
+    )
     await _add_inbound_from(db, "t1", "alice@example.com")
 
     gate = _gate(db)
@@ -127,14 +151,29 @@ async def test_granted_known_thread_reply_is_allowed(db):
 @pytest.mark.asyncio
 async def test_financial_is_hardline_held_without_a_cell(db):
     # Even pre-granting a financial cell must not let a financial email through.
-    await cg.apply_event(db, domain="email", verb="send", risk_class="financial",
-                         event=CellEvent.CLASSIFY, updated_at=_TS)
-    await cg.apply_event(db, domain="email", verb="send", risk_class="financial",
-                         event=CellEvent.APPROVE, updated_at=_TS)
+    await cg.apply_event(
+        db,
+        origin_class="first_party",
+        domain="email",
+        verb="send",
+        risk_class="financial",
+        event=CellEvent.CLASSIFY,
+        updated_at=_TS,
+    )
+    await cg.apply_event(
+        db,
+        origin_class="first_party",
+        domain="email",
+        verb="send",
+        risk_class="financial",
+        event=CellEvent.APPROVE,
+        updated_at=_TS,
+    )
     gate = _gate(db)
     req = _req(validated_recipient="alice@example.com", thread_id="t1")
     decision = await gate.check(
-        request=req, recipient="alice@example.com",
+        request=req,
+        recipient="alice@example.com",
         message_text="Please wire transfer the invoice balance to this IBAN.",
     )
     assert decision.allow is False  # hardline — held despite the granted cell
@@ -165,11 +204,13 @@ async def test_approve_all_pending_excludes_email_gate(db):
 
     mgr = ApprovalManager(db=db)
     email_rid = await mgr.request_approval(
-        action_type=EMAIL_GATE_ACTION_TYPE, action_class="costly_reversible",
+        action_type=EMAIL_GATE_ACTION_TYPE,
+        action_class="costly_reversible",
         description="email send",
     )
     other_rid = await mgr.request_approval(
-        action_type="autonomous_cli_fallback", action_class="reversible",
+        action_type="autonomous_cli_fallback",
+        action_class="reversible",
         description="cli action",
     )
     gate = AutonomousCliApprovalGate(runtime=MagicMock(), approval_manager=mgr)
@@ -194,7 +235,9 @@ async def test_granted_reply_recipient_mismatch_demotes_and_holds(db):
     gate = _gate(db)
     req = _req(validated_recipient="mallory@evil.com", thread_id="t1")
     decision = await gate.check(
-        request=req, recipient="mallory@evil.com", message_text="re",
+        request=req,
+        recipient="mallory@evil.com",
+        message_text="re",
     )
     assert decision.allow is False  # held
     cell = await cg.get_cell(db, "email", "send", "standard")
@@ -213,7 +256,9 @@ async def test_granted_reply_unknown_sender_trips_guard(db):
     gate = _gate(db)
     req = _req(validated_recipient="anyone@example.com", thread_id="t1")
     decision = await gate.check(
-        request=req, recipient="anyone@example.com", message_text="re",
+        request=req,
+        recipient="anyone@example.com",
+        message_text="re",
     )
     assert decision.allow is False  # held — ambiguous scope is not waved through
     assert (await cg.get_cell(db, "email", "send", "standard"))["state"] == "ask"
@@ -228,13 +273,20 @@ async def test_granted_rate_limit_burst_demotes_and_holds(db):
     now = datetime.now(UTC).isoformat()
     for i in range(_RATE_LIMIT_MAX):
         await aes.create(
-            db, id=f"a{i}", recipient="alice@example.com", sent_at=now,
-            cell_domain="email", cell_verb="send", cell_risk_class="standard",
+            db,
+            id=f"a{i}",
+            recipient="alice@example.com",
+            sent_at=now,
+            cell_domain="email",
+            cell_verb="send",
+            cell_risk_class="standard",
         )
     gate = _gate(db)
     req = _req(validated_recipient="alice@example.com", thread_id="t1")
     decision = await gate.check(
-        request=req, recipient="alice@example.com", message_text="re",
+        request=req,
+        recipient="alice@example.com",
+        message_text="re",
     )
     assert decision.allow is False  # rate-limit tripped
     assert (await cg.get_cell(db, "email", "send", "standard"))["state"] == "ask"

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -43,7 +43,10 @@ class _FakePipeline:
     async def deliver_approved(self, row, *, subject=None):
         self.calls.append((row["id"], subject))
         return OutreachResult(
-            outreach_id="o", status=self._status, channel="email", message_content="",
+            outreach_id="o",
+            status=self._status,
+            channel="email",
+            message_content="",
         )
 
 
@@ -55,16 +58,24 @@ class _FakeRt:
 
 async def _hold(db, *, pid, rid):
     await pes.create(
-        db, id=pid, request_id=rid, validated_recipient="a@b.c",
-        category="outreach", message="body", held_at=_TS, **_CELL,
+        db,
+        id=pid,
+        request_id=rid,
+        validated_recipient="a@b.c",
+        category="outreach",
+        message="body",
+        held_at=_TS,
+        **_CELL,
     )
 
 
 async def _approval(db, *, status):
     mgr = ApprovalManager(db=db)
     rid = await mgr.request_approval(
-        action_type="email_capability_gate", action_class="costly_reversible",
-        description="d", context=json.dumps({"subject": "hi"}),
+        action_type="email_capability_gate",
+        action_class="costly_reversible",
+        description="d",
+        context=json.dumps({"subject": "hi"}),
     )
     if status != "pending":
         await mgr.resolve(rid, status=status)

--- a/tests/test_db/test_capability_grants.py
+++ b/tests/test_db/test_capability_grants.py
@@ -44,8 +44,7 @@ class TestSchema:
     @pytest.mark.asyncio
     async def test_table_and_index_exist(self, db):
         cur = await db.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' "
-            "AND name='capability_grants'"
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='capability_grants'"
         )
         assert await cur.fetchone() is not None
         cur = await db.execute(
@@ -62,8 +61,7 @@ class TestSchema:
             await MIGRATION.up(conn)  # IF NOT EXISTS → must not raise
             await conn.commit()
             cur = await conn.execute(
-                "SELECT COUNT(*) FROM sqlite_master "
-                "WHERE type='table' AND name='capability_grants'"
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='capability_grants'"
             )
             assert (await cur.fetchone())[0] == 1
 
@@ -75,8 +73,7 @@ class TestSchema:
             await MIGRATION.down(conn)
             await conn.commit()
             cur = await conn.execute(
-                "SELECT COUNT(*) FROM sqlite_master "
-                "WHERE type='table' AND name='capability_grants'"
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='capability_grants'"
             )
             assert (await cur.fetchone())[0] == 0
 
@@ -90,8 +87,7 @@ class TestSchema:
             await create_all_tables(conn)
             await conn.commit()
             cur = await conn.execute(
-                "SELECT COUNT(*) FROM sqlite_master "
-                "WHERE type='table' AND name='capability_grants'"
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='capability_grants'"
             )
             assert (await cur.fetchone())[0] == 1
 
@@ -129,10 +125,16 @@ class TestCrud:
 
     @pytest.mark.asyncio
     async def test_classify_then_approve_grants_and_stamps(self, db):
-        s1 = await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        s1 = await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
         assert s1 == CellState.ASK
         s2 = await cg.apply_event(
-            db, event=CellEvent.APPROVE, updated_at="2026-06-21T01:00:00", **_EMAIL
+            db,
+            origin_class="first_party",
+            event=CellEvent.APPROVE,
+            updated_at="2026-06-21T01:00:00",
+            **_EMAIL,
         )
         assert s2 == CellState.GRANTED
         row = await cg.get_cell(db, **_EMAIL)
@@ -143,22 +145,28 @@ class TestCrud:
     async def test_illegal_event_raises(self, db):
         # APPROVE from NOT_DETERMINED is illegal.
         with pytest.raises(InvalidTransition):
-            await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+            await cg.apply_event(
+                db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+            )
 
     @pytest.mark.asyncio
     async def test_record_success_increments(self, db):
-        await cg.record_success(db, updated_at=_TS, **_EMAIL)
-        await cg.record_success(db, updated_at=_TS, **_EMAIL)
+        await cg.record_success(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
+        await cg.record_success(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         row = await cg.get_cell(db, **_EMAIL)
         assert row["successes"] == 2
         assert row["last_used_at"] == _TS
 
     @pytest.mark.asyncio
     async def test_correction_regresses_granted_cell_below_floor(self, db):
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+        )
         # 0 successes, 1 correction → posterior 1/3 < 0.50 → regress to ASK.
-        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        state = await cg.record_correction(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         assert state == CellState.ASK
         row = await cg.get_cell(db, **_EMAIL)
         assert row["state"] == CellState.ASK.value
@@ -169,11 +177,15 @@ class TestCrud:
         # WS-8 PR-D "easy to lose": even a heavily-supported GRANTED cell
         # regresses to ASK on a SINGLE correction (deterministic, NOT posterior-
         # gated).  The well-supported counters only make it cheaper to re-earn.
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+        )
         for _ in range(5):
-            await cg.record_success(db, updated_at=_TS, **_EMAIL)
-        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+            await cg.record_success(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
+        state = await cg.record_correction(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         assert state == CellState.ASK
         row = await cg.get_cell(db, **_EMAIL)
         assert row["state"] == CellState.ASK.value
@@ -181,8 +193,10 @@ class TestCrud:
 
     @pytest.mark.asyncio
     async def test_correction_on_non_granted_is_inert(self, db):
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        state = await cg.record_correction(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         assert state == CellState.ASK  # unchanged; only counter moved
         row = await cg.get_cell(db, **_EMAIL)
         assert row["corrections"] == 1
@@ -191,22 +205,35 @@ class TestCrud:
     async def test_regrant_restamps_granted_at(self, db):
         # grant → correction-regress → re-approve must refresh granted_at to the
         # most recent grant (the decay clock must not see it as stale-old).
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+        )
         assert (await cg.get_cell(db, **_EMAIL))["granted_at"] == _TS
         # 0 successes + 1 correction → regress to ASK.
-        assert await cg.record_correction(db, updated_at=_TS, **_EMAIL) == CellState.ASK
+        assert (
+            await cg.record_correction(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
+            == CellState.ASK
+        )
         later = "2026-06-22T12:00:00"
-        s = await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=later, **_EMAIL)
+        s = await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=later, **_EMAIL
+        )
         assert s == CellState.GRANTED
         assert (await cg.get_cell(db, **_EMAIL))["granted_at"] == later
 
     @pytest.mark.asyncio
     async def test_correction_atomic_single_state(self, db):
         # The counter increment and regression land together (one UPDATE).
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
-        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+        )
+        state = await cg.record_correction(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         row = await cg.get_cell(db, **_EMAIL)
         assert state == CellState.ASK
         assert row["state"] == CellState.ASK.value and row["corrections"] == 1
@@ -227,13 +254,23 @@ class TestPRDCompetence:
     async def test_correction_accumulates_severity_weight(self, db):
         # A standard correction adds 1.0; a bulk correction adds 2.0.
         await cg.record_correction(
-            db, updated_at=_TS, domain="email", verb="send", risk_class="standard"
+            db,
+            origin_class="first_party",
+            updated_at=_TS,
+            domain="email",
+            verb="send",
+            risk_class="standard",
         )
         assert (await cg.get_cell(db, "email", "send", "standard"))[
             "weighted_corrections"
         ] == pytest.approx(1.0)
         await cg.record_correction(
-            db, updated_at=_TS, domain="email", verb="send", risk_class="bulk"
+            db,
+            origin_class="first_party",
+            updated_at=_TS,
+            domain="email",
+            verb="send",
+            risk_class="bulk",
         )
         assert (await cg.get_cell(db, "email", "send", "bulk"))[
             "weighted_corrections"
@@ -241,7 +278,9 @@ class TestPRDCompetence:
 
     @pytest.mark.asyncio
     async def test_consequence_weight_override(self, db):
-        await cg.record_correction(db, updated_at=_TS, consequence_weight=3.5, **_EMAIL)
+        await cg.record_correction(
+            db, origin_class="first_party", updated_at=_TS, consequence_weight=3.5, **_EMAIL
+        )
         row = await cg.get_cell(db, **_EMAIL)
         assert row["weighted_corrections"] == pytest.approx(3.5)
         assert row["corrections"] == 1
@@ -250,12 +289,12 @@ class TestPRDCompetence:
     async def test_correction_on_ask_accrues_crater_without_regress(self, db):
         # Demotion fires only on GRANTED; an ASK cell stays ASK but still
         # accumulates the weighted crater (a rejected held send is negative).
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        state = await cg.record_correction(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         assert state == CellState.ASK
-        assert (await cg.get_cell(db, **_EMAIL))[
-            "weighted_corrections"
-        ] == pytest.approx(1.0)
+        assert (await cg.get_cell(db, **_EMAIL))["weighted_corrections"] == pytest.approx(1.0)
 
     @pytest.mark.asyncio
     async def test_touch_used_bumps_last_used_not_successes(self, db):
@@ -267,21 +306,29 @@ class TestPRDCompetence:
 
     @pytest.mark.asyncio
     async def test_detect_promotable_requires_min_n_and_threshold(self, db):
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
         for _ in range(4):  # below MIN_PROMOTE_N
-            await cg.record_success(db, updated_at=_TS, **_EMAIL)
+            await cg.record_success(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         assert await cg.detect_promotable_cells(db) == []
-        await cg.record_success(db, updated_at=_TS, **_EMAIL)  # 5th → promotable
+        await cg.record_success(
+            db, origin_class="first_party", updated_at=_TS, **_EMAIL
+        )  # 5th → promotable
         cands = await cg.detect_promotable_cells(db)
         assert [c["id"] for c in cands] == ["email:send:standard"]
         assert cands[0]["posterior"] > 0.70
 
     @pytest.mark.asyncio
     async def test_detect_promotable_excludes_granted(self, db):
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+        )
         for _ in range(5):
-            await cg.record_success(db, updated_at=_TS, **_EMAIL)
+            await cg.record_success(db, origin_class="first_party", updated_at=_TS, **_EMAIL)
         assert await cg.detect_promotable_cells(db) == []  # already GRANTED
 
     @pytest.mark.asyncio
@@ -293,27 +340,50 @@ class TestPRDCompetence:
     @pytest.mark.asyncio
     async def test_list_granted_returns_only_granted(self, db):
         # standard → GRANTED; bulk left at ASK.
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
-        await cg.apply_event(db, domain="email", verb="send", risk_class="bulk",
-                             event=CellEvent.CLASSIFY, updated_at=_TS)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL
+        )
+        await cg.apply_event(
+            db,
+            origin_class="first_party",
+            domain="email",
+            verb="send",
+            risk_class="bulk",
+            event=CellEvent.CLASSIFY,
+            updated_at=_TS,
+        )
         granted = await cg.list_granted(db)
         assert [g["id"] for g in granted] == ["email:send:standard"]
 
     @pytest.mark.asyncio
     async def test_decay_lapses_only_stale_grants(self, db):
         from datetime import UTC, datetime, timedelta
+
         now_dt = datetime(2026, 6, 21, tzinfo=UTC)
         now = now_dt.isoformat()
         # fresh grant (used today) — must NOT decay
-        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=now, **_EMAIL)
-        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=now, **_EMAIL)
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.CLASSIFY, updated_at=now, **_EMAIL
+        )
+        await cg.apply_event(
+            db, origin_class="first_party", event=CellEvent.APPROVE, updated_at=now, **_EMAIL
+        )
         await cg.touch_used(db, used_at=now, **_EMAIL)
         # stale grant (granted 100d ago, never used) — must decay
         old = (now_dt - timedelta(days=100)).isoformat()
         for ev in (CellEvent.CLASSIFY, CellEvent.APPROVE):
-            await cg.apply_event(db, domain="email", verb="send", risk_class="bulk",
-                                 event=ev, updated_at=old)
+            await cg.apply_event(
+                db,
+                origin_class="first_party",
+                domain="email",
+                verb="send",
+                risk_class="bulk",
+                event=ev,
+                updated_at=old,
+            )
 
         decayed = await cg.decay_stale_cells(db, now=now, half_life_days=90)
 

--- a/tests/test_outreach/test_autonomous_send_ledger.py
+++ b/tests/test_outreach/test_autonomous_send_ledger.py
@@ -30,9 +30,13 @@ def config():
         quiet_hours=QuietHours(start="22:00", end="07:00"),
         channel_preferences={"default": "email"},
         thresholds={"blocker": 0.0, "surplus": 0.0},
-        max_daily=50, surplus_daily=50, content_daily=50, notification_daily=50,
+        max_daily=50,
+        surplus_daily=50,
+        content_daily=50,
+        notification_daily=50,
         morning_report_time="07:00",
-        engagement_timeout_hours=24, engagement_poll_minutes=60,
+        engagement_timeout_hours=24,
+        engagement_poll_minutes=60,
     )
 
 
@@ -55,7 +59,8 @@ def email_adapter():
 def _pipeline(config, db, email_adapter):
     formatter = MagicMock()
     formatter.format.return_value = FormattedContent(
-        text="re: hello", target=FormatTarget.EMAIL,
+        text="re: hello",
+        target=FormatTarget.EMAIL,
     )
     pipeline = OutreachPipeline(
         governance=GovernanceGate(config, db),
@@ -75,7 +80,13 @@ def _pipeline(config, db, email_adapter):
 async def _grant_standard(db):
     for ev in (CellEvent.CLASSIFY, CellEvent.APPROVE):
         await cg.apply_event(
-            db, domain="email", verb="send", risk_class="standard", event=ev, updated_at=_TS,
+            db,
+            origin_class="first_party",
+            domain="email",
+            verb="send",
+            risk_class="standard",
+            event=ev,
+            updated_at=_TS,
         )
 
 
@@ -91,9 +102,14 @@ async def _add_inbound(db, thread_id, sender="alice@example.com"):
 
 def _req():
     return OutreachRequest(
-        category=OutreachCategory.SURPLUS, topic="re: hello", context="body",
-        salience_score=0.9, signal_type="email_reply", channel="email",
-        validated_recipient="alice@example.com", thread_id="t1",
+        category=OutreachCategory.SURPLUS,
+        topic="re: hello",
+        context="body",
+        salience_score=0.9,
+        signal_type="email_reply",
+        channel="email",
+        validated_recipient="alice@example.com",
+        thread_id="t1",
     )
 
 
@@ -138,8 +154,10 @@ async def test_resume_path_is_not_logged(config, db, email_adapter):
     await _add_inbound(db, "t1")
     pipeline = _pipeline(config, db, email_adapter)
     pending = {
-        "category": "surplus", "message": "approved reply",
-        "validated_recipient": "alice@example.com", "thread_id": "t1",
+        "category": "surplus",
+        "message": "approved reply",
+        "validated_recipient": "alice@example.com",
+        "thread_id": "t1",
     }
 
     result = await pipeline.deliver_approved(pending, subject="re: hello")

--- a/tests/test_outreach/test_ws8_full_slice_e2e.py
+++ b/tests/test_outreach/test_ws8_full_slice_e2e.py
@@ -51,9 +51,13 @@ def config():
         quiet_hours=QuietHours(start="22:00", end="07:00"),
         channel_preferences={"default": "email"},
         thresholds={"blocker": 0.0, "surplus": 0.0},
-        max_daily=999, surplus_daily=999, content_daily=999, notification_daily=999,
+        max_daily=999,
+        surplus_daily=999,
+        content_daily=999,
+        notification_daily=999,
         morning_report_time="07:00",
-        engagement_timeout_hours=24, engagement_poll_minutes=60,
+        engagement_timeout_hours=24,
+        engagement_poll_minutes=60,
     )
 
 
@@ -70,8 +74,12 @@ def _pipeline(config, db, adapter):
     formatter = MagicMock()
     formatter.format.return_value = FormattedContent(text="re: hi", target=FormatTarget.EMAIL)
     pipe = OutreachPipeline(
-        governance=GovernanceGate(config, db), drafter=AsyncMock(), formatter=formatter,
-        channels={"email": adapter}, db=db, config=config,
+        governance=GovernanceGate(config, db),
+        drafter=AsyncMock(),
+        formatter=formatter,
+        channels={"email": adapter},
+        db=db,
+        config=config,
         recipients={"email": "fallback@example.com"},
     )
     pipe.set_autonomy_gate(
@@ -91,9 +99,14 @@ async def _add_inbound(db, thread, sender):
 
 def _reply(recipient="alice@example.com", thread="t1"):
     return OutreachRequest(
-        category=OutreachCategory.SURPLUS, topic="re: hi", context="body",
-        salience_score=0.9, signal_type="email_reply", channel="email",
-        validated_recipient=recipient, thread_id=thread,
+        category=OutreachCategory.SURPLUS,
+        topic="re: hi",
+        context="body",
+        salience_score=0.9,
+        signal_type="email_reply",
+        channel="email",
+        validated_recipient=recipient,
+        thread_id=thread,
     )
 
 
@@ -154,7 +167,7 @@ async def test_full_earn_grant_send_flag_demote_loop(config, db):
     now = datetime.now(UTC).isoformat()
     flagged = await aes.mark_flagged(db, log[0]["id"], flagged_at=now)
     assert flagged is True
-    state = await cg.record_correction(db, updated_at=now, **_CELL)
+    state = await cg.record_correction(db, origin_class="first_party", updated_at=now, **_CELL)
     assert state == CellState.ASK
     cell = await cg.get_cell(db, **_CELL)
     assert cell["state"] == CellState.ASK.value

--- a/tests/test_security/test_identity_autonomy_gate_coverage.py
+++ b/tests/test_security/test_identity_autonomy_gate_coverage.py
@@ -1,0 +1,338 @@
+"""WS-3 B1 gates 2-3 (identity / autonomy) coverage locks.
+
+Same forcing-function idea as ``test_recall_inject_coverage.py`` (gate 4) and
+``test_procedure_gate_coverage.py`` (gate 1): discovery is AST-based, every
+discovered site needs an explicit disposition, and every 'gated' site must
+actually emit — so a new writer/caller can't ship provenance-unclassified and
+a removed emit fails CI.
+
+GATE-2 (identity): the choke methods are identity/loader.py's ``write_text``
+enclosers, pinned by SET-EQUALITY (a new/moved raw write in loader.py fails).
+Callers of the public writers are discovered and must be registered. The
+dashboard config-file PUT writer (outside loader.py, generic ``write_text``)
+is pinned MANUALLY — an AST sweep scoped to loader can't see it.
+
+GATE-3 (autonomy): discovery is IMPORT-ALIAS-RESOLVED — only ``Attribute``
+calls on names bound to ``genesis.db.crud.capability_grants`` count, which
+excludes the many unrelated ``record_success`` collisions (telegram typing
+breakers, routing circuit breaker, AutonomyManager's legacy autonomy_state
+path). The emits live INSIDE the crud choke (``_emit_autonomy_gate``); callers
+THREAD origin_class (a REQUIRED kwarg — locked below — so a future caller must
+state provenance or fail loudly at call time).
+
+OUT OF GATE-3 SCOPE: the legacy ``autonomy_state`` evidence store
+(db/crud/autonomy.py record_success/record_correction via AutonomyManager —
+audit.py, surplus/dispatch.py, learning/pipeline.py). Same threat shape on a
+parallel LIVE store, but all writers are Genesis's own execution telemetry
+(first_party) and the store is slated to stay authoritative for non-email
+readers (capability_grants.py module docstring). Documented exclusion, not
+silent — revisit if any external-influenced writer appears.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SRC = _REPO_ROOT / "src" / "genesis"
+
+_GATE_VALID = {"gated", "gated-via", "deferred-with-reason", "exempt-with-reason"}
+
+
+def _parse(path: pathlib.Path) -> ast.AST | None:
+    try:
+        return ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError:
+        return None
+
+
+def _funcs(tree: ast.AST) -> list[tuple[int, int, str]]:
+    return [
+        (n.lineno, getattr(n, "end_lineno", n.lineno), n.name)
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+
+def _enclosing(funcs: list[tuple[int, int, str]], lineno: int) -> str:
+    best, enclosing = -1, "<module>"
+    for start, end, name in funcs:
+        if start <= lineno <= (end or start) and start > best:
+            best, enclosing = start, name
+    return enclosing
+
+
+def _functions_calling_attr(attrs: set[str]) -> set[str]:
+    """{"relpath::func"} for every function calling a METHOD named in *attrs*."""
+    found: set[str] = set()
+    for path in _SRC.rglob("*.py"):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        funcs = _funcs(tree)
+        rel = path.relative_to(_SRC).as_posix()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in attrs
+            ):
+                found.add(f"{rel}::{_enclosing(funcs, node.lineno)}")
+    return found
+
+
+# ═══════════════════════════════ GATE 2 — identity ══════════════════════════
+
+# The complete raw-write surface of identity/loader.py. write_user_md is
+# comment-disabled with zero callers, but fully callable — pinning it means a
+# future caller that re-enables USER.md synthesis must come through this
+# registry.
+_LOADER_WRITE_METHODS = {
+    "write_user_md",
+    "write_user_knowledge_md",
+    "_write_narrative_knowledge",
+    "_write_steering",
+}
+
+# Public writer entry points whose CALLERS must be classified.
+_IDENTITY_WRITER_NAMES = {"add_steering_rule", "write_user_knowledge_md", "write_user_md"}
+
+# discovered caller "relpath::func" -> (disposition, emitter_ref | None, why)
+# emitter_ref: for 'gated-via', the enclosing function that carries the emit
+# (the write call and the emit may live in different frames).
+IDENTITY_GATE_SITES: dict[str, tuple[str, str | None, str]] = {
+    "learning/pipeline.py::_extract_steering_rule": (
+        "gated-via",
+        "learning/pipeline.py::_run_pipeline",
+        "steering write; the async caller emits ONLY on a real write (the "
+        "directive-filter reject is a non-event), origin from _CHANNEL_ORIGIN "
+        "(owner allow-map, unknown/voice -> external_untrusted fail-closed)",
+    ),
+    "runtime/init/learning.py::_evolve_user_model": (
+        "gated",
+        None,
+        "USER_KNOWLEDGE synthesis; first_party by authorship (reflection-"
+        "derived deltas). FLIP BLOCKER: observations carry no origin_class, so "
+        "externally-planted user-facts stay first_party until delta-level "
+        "provenance lands",
+    ),
+}
+
+# Identity-file writers OUTSIDE loader.py that a loader-scoped sweep cannot
+# see — pinned manually (the gate-4 _EXTRA_WRAPPED_SITES pattern).
+IDENTITY_EXTRA_SITES: dict[str, tuple[str, str | None, str]] = {
+    "dashboard/routes/config.py::config_file_update": (
+        "exempt-with-reason",
+        None,
+        "owner-direct edit surface (HTTP-auth'd dashboard PUT into "
+        "_IDENTITY_DIR) — owner origin by construction; never a would-block",
+    ),
+}
+
+
+def test_loader_write_surface_is_pinned():
+    """SET-EQUALITY on identity/loader.py's write_text enclosers — a new or
+    moved raw write method fails CI and must be classified here."""
+    tree = _parse(_SRC / "identity" / "loader.py")
+    assert tree is not None
+    funcs = _funcs(tree)
+    writers = {
+        _enclosing(funcs, node.lineno)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "write_text"
+    }
+    assert writers == _LOADER_WRITE_METHODS, (
+        f"identity/loader.py raw-write surface changed: {sorted(writers)} != "
+        f"{sorted(_LOADER_WRITE_METHODS)}. Update _LOADER_WRITE_METHODS and "
+        "classify any new writer's callers in IDENTITY_GATE_SITES."
+    )
+
+
+def test_every_identity_writer_caller_is_classified():
+    discovered = _functions_calling_attr(_IDENTITY_WRITER_NAMES)
+    # The loader's own internals (write_user_knowledge_md delegating to
+    # _write_narrative_knowledge etc.) are covered by the surface pin above.
+    discovered = {d for d in discovered if not d.startswith("identity/loader.py::")}
+    registered = set(IDENTITY_GATE_SITES)
+    unregistered = discovered - registered
+    assert not unregistered, (
+        "Identity-writer caller(s) not classified for WS-3 gate-2:\n  "
+        + "\n  ".join(sorted(unregistered))
+        + "\n\nClassify each in IDENTITY_GATE_SITES (wire "
+        "security.immunity_shadow.record_would_block with a derived origin and "
+        "mark 'gated'/'gated-via', or exempt with a reason)."
+    )
+    stale = registered - discovered
+    assert not stale, (
+        "Registered identity site(s) no longer found — update "
+        "IDENTITY_GATE_SITES:\n  " + "\n  ".join(sorted(stale))
+    )
+
+
+def test_identity_gated_sites_actually_emit():
+    emitters = _functions_calling_attr({"record_would_block", "record_would_block_sync"})
+    for key, (disp, emitter_ref, _why) in {
+        **IDENTITY_GATE_SITES,
+        **IDENTITY_EXTRA_SITES,
+    }.items():
+        assert disp in _GATE_VALID, f"{key}: invalid disposition {disp!r}"
+        if disp == "gated":
+            assert key in emitters, f"{key} is 'gated' but does not emit"
+        elif disp == "gated-via":
+            assert emitter_ref in emitters, (
+                f"{key} is 'gated-via' {emitter_ref}, which does not emit — "
+                "the gate emit was removed or moved"
+            )
+
+
+def test_dashboard_identity_writer_still_exists():
+    """The manual pin must track reality: the dashboard PUT writer's enclosing
+    function must still exist (rename/removal updates the registry)."""
+    tree = _parse(_SRC / "dashboard" / "routes" / "config.py")
+    assert tree is not None
+    names = {name for _, _, name in _funcs(tree)}
+    assert "config_file_update" in names, (
+        "dashboard/routes/config.py::config_file_update not found — update "
+        "IDENTITY_EXTRA_SITES to the new identity-file write surface"
+    )
+
+
+# ═══════════════════════════════ GATE 3 — autonomy ══════════════════════════
+
+_CG_MODULE = "genesis.db.crud"
+_CG_NAME = "capability_grants"
+_CG_MUTATORS = {"record_success", "record_correction", "apply_event"}
+# Non-evidence mutations, exempt by design: touch_used (usage telemetry),
+# ensure_cell (mechanical row creation), decay_stale_cells (time decay).
+
+# discovered caller "relpath::func" -> (disposition, why). All callers THREAD
+# origin_class into the crud choke, where the single emit lives.
+AUTONOMY_GATE_SITES: dict[str, tuple[str, str]] = {
+    "autonomy/email_gate.py::check": (
+        "gated-via",
+        "CLASSIFY apply_event + scope-guard record_correction; both thread "
+        "origin_class='first_party' (Genesis's own deterministic guards) into "
+        "the crud choke emit",
+    ),
+    "autonomy/email_gate_watcher.py::drain_pending_email_sends": (
+        "gated-via",
+        "owner approve -> record_success / owner reject -> record_correction; "
+        "threads origin_class='owner' (owner decisions are the evidence)",
+    ),
+    "dashboard/routes/autonomy.py::autonomy_flag_send": (
+        "gated-via",
+        "owner flags an autonomous send from the dashboard; threads origin_class='owner'",
+    ),
+    "ego/cell_promotion.py::handle_cell_promotion_resolution": (
+        "gated-via",
+        "executes an OWNER-approved promotion proposal (APPROVE apply_event); "
+        "threads origin_class='owner'",
+    ),
+}
+
+
+def _cg_bound_names(tree: ast.AST) -> set[str]:
+    """Local names bound to the capability_grants module in this file."""
+    bound: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == _CG_MODULE:
+            for alias in node.names:
+                if alias.name == _CG_NAME:
+                    bound.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == f"{_CG_MODULE}.{_CG_NAME}":
+                    # `import genesis.db.crud.capability_grants` binds the top
+                    # package; calls would be fully dotted — treat the full
+                    # dotted tail as the bound name marker (none exist today).
+                    bound.add(alias.asname or _CG_NAME)
+    return bound
+
+
+def _discover_cg_mutation_callers() -> set[str]:
+    """{"relpath::func"} for alias-resolved capability_grants mutation calls."""
+    found: set[str] = set()
+    for path in _SRC.rglob("*.py"):
+        tree = _parse(path)
+        if tree is None:
+            continue
+        bound = _cg_bound_names(tree)
+        if not bound:
+            continue
+        funcs = _funcs(tree)
+        rel = path.relative_to(_SRC).as_posix()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in _CG_MUTATORS
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in bound
+            ):
+                found.add(f"{rel}::{_enclosing(funcs, node.lineno)}")
+    return found
+
+
+def test_every_grant_mutation_caller_is_classified():
+    discovered = _discover_cg_mutation_callers()
+    registered = set(AUTONOMY_GATE_SITES)
+    unregistered = discovered - registered
+    assert not unregistered, (
+        "capability_grants mutation caller(s) not classified for WS-3 gate-3:\n  "
+        + "\n  ".join(sorted(unregistered))
+        + "\n\nEach caller must thread origin_class (required kwarg) and be "
+        "registered in AUTONOMY_GATE_SITES."
+    )
+    stale = registered - discovered
+    assert not stale, (
+        "Registered gate-3 site(s) no longer found — update "
+        "AUTONOMY_GATE_SITES:\n  " + "\n  ".join(sorted(stale))
+    )
+
+
+def test_autonomy_dispositions_valid():
+    for key, (disp, why) in AUTONOMY_GATE_SITES.items():
+        assert disp in _GATE_VALID, f"{key}: invalid disposition {disp!r}"
+        assert why.strip(), f"{key}: empty rationale"
+
+
+def test_crud_choke_emits_for_all_three_mutators():
+    """The single emit helper must be called by ALL THREE mutation functions —
+    deleting/moving an emit fails CI."""
+    tree = _parse(_SRC / "db" / "crud" / "capability_grants.py")
+    assert tree is not None
+    funcs = _funcs(tree)
+    emitting = {
+        _enclosing(funcs, node.lineno)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_emit_autonomy_gate"
+    }
+    assert emitting >= _CG_MUTATORS, (
+        f"capability_grants mutators missing the gate-3 emit: {sorted(_CG_MUTATORS - emitting)}"
+    )
+    # And the helper itself performs the shadow emit.
+    assert "db/crud/capability_grants.py::_emit_autonomy_gate" in (
+        _functions_calling_attr({"record_would_block"})
+    )
+
+
+def test_origin_class_is_required_on_all_mutators():
+    """origin_class must stay a REQUIRED kwarg (no default) on all three
+    mutators — a silent first_party default would be a permanently inert gate."""
+    tree = _parse(_SRC / "db" / "crud" / "capability_grants.py")
+    assert tree is not None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in _CG_MUTATORS:
+            kwonly = {a.arg for a in node.args.kwonlyargs}
+            assert "origin_class" in kwonly, f"{node.name}: origin_class missing"
+            defaults = {
+                a.arg: d
+                for a, d in zip(node.args.kwonlyargs, node.args.kw_defaults, strict=True)
+                if d is not None
+            }
+            assert "origin_class" not in defaults, f"{node.name}: origin_class must have NO default"

--- a/tests/test_security/test_identity_autonomy_gates.py
+++ b/tests/test_security/test_identity_autonomy_gates.py
@@ -1,0 +1,148 @@
+"""WS-3 B1 gates 2-3 — emit contract under the REAL config + migration chain.
+
+Mirrors test_procedure_gate.py's integration shape: external origin → one row,
+owner/first_party → never a row (never-block invariant), kill switch → nothing,
+for both the identity and autonomy gates. Also drives the REAL crud choke
+(capability_grants mutators) end-to-end so the emit placement is proven, not
+assumed.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import immunity_shadow as crud
+from genesis.db.migrations.runner import MigrationRunner
+from genesis.security import immunity, immunity_shadow
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    crud._table_verified = False
+    crud._table_verified_sync = False
+    yield
+    crud._table_verified = False
+    crud._table_verified_sync = False
+
+
+async def _migrated(path):
+    db = await aiosqlite.connect(str(path))
+    db.row_factory = aiosqlite.Row
+    await MigrationRunner(db).run_pending()
+    return db
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("gate", ["identity", "autonomy"])
+async def test_gate_records_external_never_owner_or_firstparty(tmp_path, gate):
+    mode = immunity.gate_mode(gate)
+    assert mode in ("off", "shadow", "enforce")
+    db = await _migrated(tmp_path / "g.db")
+
+    wrote_ext = await immunity_shadow.record_would_block(
+        gate=gate,
+        source_kind="test",
+        source_ref="t",
+        process="server",
+        blockable_count=1,
+        origin_class="external_untrusted",
+        db=db,
+    )
+    wrote_fp = await immunity_shadow.record_would_block(
+        gate=gate,
+        source_kind="test",
+        source_ref="t",
+        process="server",
+        blockable_count=1,
+        origin_class="first_party",
+        db=db,
+    )
+    wrote_owner = await immunity_shadow.record_would_block(
+        gate=gate,
+        source_kind="test",
+        source_ref="t",
+        process="server",
+        blockable_count=1,
+        origin_class="owner",
+        db=db,
+    )
+    assert wrote_fp is False and wrote_owner is False
+    if mode == "off":
+        assert wrote_ext is False
+        assert await crud.count(db) == 0
+    else:
+        assert wrote_ext is True
+        rows = await crud.list_recent(db)
+        assert len(rows) == 1 and rows[0]["gate"] == gate
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_gate3_crud_choke_emits_end_to_end(tmp_path):
+    """Drive the REAL mutators: a synthetic external-origin evidence write →
+    one gate=autonomy row with the cell key in detail; the owner/first-party
+    paths (every live caller today) → zero rows."""
+    from genesis.autonomy.types import CellEvent
+
+    db = await _migrated(tmp_path / "g.db")
+    ts = "2026-07-12T00:00:00+00:00"
+    cell = dict(domain="email", verb="send", risk_class="standard")
+
+    # First-party CLASSIFY (the live email-gate path) → no row.
+    await cg.apply_event(
+        db,
+        **cell,
+        event=CellEvent.CLASSIFY,
+        updated_at=ts,
+        origin_class="first_party",
+    )
+    # Owner-approved success (the live watcher path) → no row.
+    await cg.record_success(db, **cell, updated_at=ts, origin_class="owner")
+    assert await crud.count(db) == 0
+
+    # Synthetic FUTURE external-influenced evidence → exactly one row.
+    await cg.record_success(
+        db,
+        **cell,
+        updated_at=ts,
+        origin_class="external_untrusted",
+    )
+    rows = await crud.list_recent(db)
+    assert len(rows) == 1
+    assert rows[0]["gate"] == "autonomy"
+    assert rows[0]["source_ref"] == "db/crud/capability_grants.py::record_success"
+    assert "email:send:standard" in rows[0]["detail"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_gate3_kill_switch_off_records_nothing(tmp_path, monkeypatch):
+    db = await _migrated(tmp_path / "g.db")
+    monkeypatch.setattr(immunity, "gate_mode", lambda gate: "off")
+    await cg.record_correction(
+        db,
+        domain="email",
+        verb="send",
+        risk_class="standard",
+        updated_at="2026-07-12T00:00:00+00:00",
+        origin_class="external_untrusted",
+    )
+    assert await crud.count(db) == 0
+    await db.close()
+
+
+def test_channel_origin_map_is_fail_closed():
+    """Gate-2 steering origin: owner ALLOW-map only; voice and any unknown
+    channel classify external_untrusted (fail-closed — the polarity fix for
+    the fail-open _AUTONOMOUS_CHANNELS deny-list)."""
+    from genesis.learning.pipeline import _CHANNEL_ORIGIN
+
+    assert _CHANNEL_ORIGIN.get("telegram") == "owner"
+    assert _CHANNEL_ORIGIN.get("terminal") == "owner"
+    assert "voice" not in _CHANNEL_ORIGIN  # ambient multi-speaker STT
+    assert _CHANNEL_ORIGIN.get("voice", "external_untrusted") == "external_untrusted"
+    assert _CHANNEL_ORIGIN.get("some_future_channel", "external_untrusted") == (
+        "external_untrusted"
+    )


### PR DESCRIPTION
## WS-3 B1 gates 2-3 (identity / autonomy) — SHADOW

Completes the B1 gate set (gate 4 shipped #1009; gate 1 in #1014). Both gates emit shadow would-blocks via the shared substrate and record **~nothing today by construction** (all live inputs are owner/first-party) — the value is the **CI enumeration locks** + **fail-closed origin derivations** that make a future external→identity/autonomy path *observed* instead of invisible.

### Gate 2 — identity writes
- **Steering** (`learning/pipeline.py`): origin from a channel **allow-map** (`terminal/telegram/whatsapp/web` = owner), defaulting **fail-closed** to `external_untrusted` — the opposite polarity of the fail-open `_AUTONOMOUS_CHANNELS` deny-list, so a deny-list escape (voice ambient STT, any future channel) now produces a row. Emits only on a **real write** (directive-filter rejects are non-events).
- **USER_KNOWLEDGE synthesis** (`runtime/init/learning.py`): `first_party` by authorship; the flip blocker (observations carry no `origin_class` → transcript-laundered external user-facts) is documented in-code and filed as follow-up `61c57093`.

### Gate 3 — capability-grant evidence
- Emit lives **inside the crud choke** (`capability_grants.py`: `record_success`/`record_correction`/**`apply_event`** — the grant mutation itself, not just counters). `origin_class` is a **required kwarg**: every future caller must state provenance or fail loudly. All 6 live callers thread `owner`/`first_party`.

### Locks
`test_identity_autonomy_gate_coverage.py`: identity raw-write surface pinned by **set-equality** over all 4 `write_text` enclosers (incl. comment-disabled `write_user_md`) + the dashboard config PUT writer pinned manually; grant-mutation discovery is **import-alias-resolved** (excludes the bare `record_success` collisions: telegram typing breakers, routing CB, the legacy `autonomy_state` path — documented out-of-scope). Required-kwarg lock on all three mutators.

### Review provenance
genesis-architect design review applied — including its BLOCKER: the originally-planned hardcoded `origin=owner` for steering sat above a **fail-open deny-list**, which would have made the gate blind to its own threat class; and the `state_machine.py` misattribution (legacy `crud.autonomy`, not `capability_grants`).

### Scope / safety
Shadow-only; observe-only; owner/first-party never produce rows (tested). Enforce is gate-wide blocked on the stored-origin retriever work (tracked separately). Zero migrations. 13 new tests; 82 green across affected suites (grants, email gate, watcher, promotion, ledger, pipeline). Touched files carry ruff-format reflow from the advisory edit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)