### PR TITLE
fix(health): revive dead credit-exhaustion detector + unified critical call-site health

### DIFF
--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -74,6 +74,12 @@ health_alerts:
     - "provider:embedding_failing"
     - "provider:qdrant_unreachable"
     - "awareness:tick_overdue"
+    # A blind health system IS a highest-severity page: this is the ONLY alert
+    # emitted when HealthDataService is uninitialised (errors.py early-return),
+    # it is Sentinel-remediable (restart), and dropping it here silenced it.
+    # (Contrast provider:credit_exhaustion, deliberately absent — that is now a
+    # dashboard-only WARNING; refilling credits is a user financial action.)
+    - "service:health_data_uninitialized"
     # Prefixes. This list REPLACES the code default when present, so anything the
     # default escalates must be repeated here. backup: was missing (backup-failure
     # alerts were silently non-escalating); creds: is new for G.1.

--- a/src/genesis/mcp/health/critical_sites.py
+++ b/src/genesis/mcp/health/critical_sites.py
@@ -1,0 +1,79 @@
+"""Curated critical call sites — the "red if down" allowlist.
+
+The unified call-site health detector (``mcp/health/errors.py``) reads the
+``call_site_last_run`` table and, for any site whose last run failed within
+:data:`CALLSITE_DOWN_RECENCY_HOURS`, emits a ``callsite:down:<id>`` alert. A
+site in :data:`CRITICAL_CALL_SITES` renders **CRITICAL/red**; every other
+failing site renders **WARNING/yellow** (watched, not alarming). The detector
+is dashboard-only: ``callsite:down:`` is never on the outreach escalation
+whitelist and is UNMAPPED in the Sentinel remediation map, so it never pages
+Telegram and never wakes the firefighter (both fail-closed by design).
+
+Why a curated constant and NOT ``ESSENTIAL_CLOUD_SITES``:
+``routing/essential.py`` is calibrated for *cloud-coverage degradation* (it
+includes ``3_micro_reflection`` because losing cloud coverage there matters for
+the routing question) — a different lens from "is this important if the whole
+call site goes down." A fast-shedding eval site (``judge``) or a routine
+micro-reflection is NOT critical-if-down; memory formation and the ego cycles
+are. So this list is purpose-built for the availability question.
+
+There is deliberately no ``critical`` attribute on the call_site config: the
+runtime superset of call-site ids (this table) is larger than the routing YAML
+(it includes ``cc``-provider sites like the ego cycles and ``embedding``-provider
+sites), and criticality here is an operator judgment, not a routing property.
+
+GROUNDWORK(sentinel-auto-topup): this set is also the intended anchor for a
+future, user-gated auto-credit-top-up — the Sentinel could one day offer to
+refill credits ONLY when an exhausted provider is the sole route for a site in
+this set. Not built; the per-provider credit signal lives in ``errors.py`` and
+the exclusion rationale in ``sentinel/remediation_map.py``.
+"""
+
+from __future__ import annotations
+
+# How recently a site's LAST run must have failed for its failure to count as
+# a *current* problem. ``call_site_last_run`` is INSERT-OR-REPLACE (one row per
+# site = its latest run), so an old failed row means "hasn't succeeded since"
+# — but a weeks-old failure is almost always an abandoned/one-off site
+# (e.g. dream_cycle_* / models_md_synthesis were 600h+ stale in prod), not an
+# actionable outage. 24h is chosen from live cadence data: the frequently
+# cycling critical sites (embeddings, fact/procedure extraction, ego focus) and
+# the ~18h ego cycles all refresh within a day, while every observed stale
+# failure sat far outside it. Tunable — widen if slow-cadence critical sites
+# (weekly strategic/deep reflection) start under-surfacing. Dashboard-only, so
+# the cost of a miss is low and the cost of noise is low.
+CALLSITE_DOWN_RECENCY_HOURS = 24
+
+# Sites that render CRITICAL/red when their last run failed. Everything else
+# failing renders WARNING/yellow. Ids are runtime ``call_site_id`` values as
+# written to ``call_site_last_run`` (verified live 2026-07-12), NOT the neural-
+# monitor labels in ``_call_site_meta.py`` (which unify the two ego cycles under
+# ``7_ego_cycle``). ``autonomous_executor_reasoning`` is deliberately EXCLUDED
+# — it has a CC fallback, so chain exhaustion there is watched (yellow), not red.
+CRITICAL_CALL_SITES: frozenset[str] = frozenset(
+    {
+        # Memory formation & retrieval — losing these silently corrupts what
+        # Genesis learns and can recall.
+        "9_fact_extraction",
+        "40_knowledge_distillation",
+        "38_procedure_extraction",
+        "21_embeddings",
+        "21b_query_embedding",
+        # Memory continuity — the ambient drift arbiter decides which
+        # cross-session drift memories surface (entity/drift system).
+        "ambient_arbiter",
+        # Ego — the two live ego cycles (COO/Genesis + CEO/user) and focus
+        # selection. NOTE: 8_ego_compaction is deliberately EXCLUDED — the ego
+        # moved to ephemeral sessions (ego/compaction.py: "no LLM compaction";
+        # its call_site_id arg is a legacy-ignored param), so that site never
+        # routes and never records a last_run row — a dead id in a red set would
+        # be misleading. (essential.py + _call_site_meta.py still mark it LIVE;
+        # pre-existing staleness, tracked as a separate follow-up.)
+        "7_genesis_ego_cycle",
+        "7_user_ego_cycle",
+        "40_ego_focus_selection",
+        # Core cognition — the deep and strategic reflection depths.
+        "5_deep_reflection",
+        "6_strategic_reflection",
+    }
+)

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -528,7 +528,24 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
 
             for row in recent_rows:
                 prov, recent_calls, recent_errors = row
-                prov_crit = crit_map.get(prov, {})
+                # activity_log stores LLM calls as ``llm.<name>`` but crit_map
+                # (derive_criticality) is keyed by provider_type. Resolve in two
+                # hops: strip ``llm.`` prefix -> provider name -> provider_type ->
+                # criticality. Non-routed rows (embedding / qdrant.* / mcp.*) have
+                # no provider config and are skipped. (Pre-fix this lookup was
+                # single-hop on the raw ``llm.<name>`` string, so it ALWAYS missed
+                # -> every provider read "dormant" -> the detector was 100% dead.)
+                prov_name = (
+                    prov[4:]
+                    if isinstance(prov, str) and prov.startswith("llm.")
+                    else prov
+                )
+                provider_cfg = (
+                    routing_config.providers.get(prov_name) if routing_config else None
+                )
+                if provider_cfg is None:
+                    continue  # not a routed LLM provider (embeddings/mcp.*/qdrant.*)
+                prov_crit = crit_map.get(provider_cfg.provider_type, {})
                 criticality = prov_crit.get("criticality", "dormant")
                 if criticality == "dormant":
                     continue  # Skip providers not in any chain
@@ -557,20 +574,23 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 if baseline_error_rate > 0.05:
                     continue  # Wasn't healthy before — not credit exhaustion
 
-                # Was healthy (>95% success) over 7 days, now failing (>50% errors)
-                alert_id = f"provider:credit_exhaustion:{prov}"
-                is_free = prov_crit.get("is_free", False)
-                if criticality in ("sole", "systemic") and not is_free:
-                    severity = "CRITICAL"
-                elif criticality == "sole" and is_free:
-                    severity = "WARNING"
-                else:
-                    severity = "WARNING"
+                # Was healthy (>95% success) over 7 days, now failing (>50%
+                # errors). Dashboard WARNING ONLY -- never CRITICAL. Refilling
+                # credits/quota is a user (financial) action the Sentinel cannot
+                # take, and provider exhaustion alone is not an outage (routing
+                # fallbacks cover it). Telegram/Sentinel are reserved for genuine
+                # call-site-down + infra emergencies -- see the unified call-site
+                # health detector below for the "whole call site down" signal.
+                # GROUNDWORK(sentinel-auto-topup): CRITICAL_CALL_SITES
+                # (mcp/health/critical_sites.py) + this per-provider signal are the
+                # seam for a future user-gated auto-credit-top-up; see
+                # remediation_map.UNMAPPED_BY_DESIGN["provider:credit_exhaustion:"].
+                alert_id = f"provider:credit_exhaustion:{prov_name}"
                 alerts.append({
                     "id": alert_id,
-                    "severity": severity,
+                    "severity": "WARNING",
                     "message": (
-                        f"Suspected credit/quota exhaustion for {prov}: "
+                        f"Suspected credit/quota exhaustion for {prov_name}: "
                         f"was {1 - baseline_error_rate:.0%} success over 7d, "
                         f"now {recent_error_rate:.0%} errors in last hour "
                         f"({recent_errors}/{recent_calls} calls)"
@@ -579,6 +599,58 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 current_ids.add(alert_id)
         except Exception:
             logger.debug("Credit exhaustion detection failed", exc_info=True)
+
+    # ── Unified critical call-site health ────────────────
+    # "Is a whole call site down?" -- orthogonal to the per-provider credit
+    # signal above. call_site_last_run holds ONE row per site (its latest run,
+    # written by every execution path: router / cc / embedding / pipeline /
+    # gate), so success=0 on the last run is the honest "this site's last
+    # attempt failed" signal -- and it captures cc + embedding failures the
+    # provider-tier checks above miss. Sites in CRITICAL_CALL_SITES render
+    # CRITICAL/red; every other failing site renders WARNING/yellow (watched,
+    # not alarming). Dashboard-only BY CONSTRUCTION: ``callsite:down:`` is never
+    # on the outreach escalation whitelist (no Telegram) and is UNMAPPED in the
+    # Sentinel remediation map (no firefighter) -- both fail-closed. The recency
+    # window drops long-abandoned stale-failed rows (a weeks-old one-off is not
+    # an actionable outage). This deliberately overlaps the escalation-path
+    # alerts (cc:quota_exhausted / provider:embedding_failing) -- this is the
+    # glanceable unified availability view, those are the paging path.
+    if _service and _service._db:
+        try:
+            from datetime import timedelta as _td3
+
+            from genesis.mcp.health.critical_sites import (
+                CALLSITE_DOWN_RECENCY_HOURS,
+                CRITICAL_CALL_SITES,
+            )
+
+            cs_cutoff = (
+                datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)
+            ).isoformat()
+            cs_cursor = await _service._db.execute(
+                "SELECT call_site_id, last_run_at, provider_used "
+                "FROM call_site_last_run WHERE success = 0 AND last_run_at >= ?",
+                (cs_cutoff,),
+            )
+            for cs_row in await cs_cursor.fetchall():
+                site_id, last_run_at, provider_used = cs_row
+                is_critical = site_id in CRITICAL_CALL_SITES
+                alert_id = f"callsite:down:{site_id}"
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL" if is_critical else "WARNING",
+                    "message": (
+                        f"Call site '{site_id}' last run failed "
+                        f"(provider {provider_used or 'unknown'}, last attempt "
+                        f"{str(last_run_at)[:19]})"
+                        + (" -- CRITICAL site" if is_critical else "")
+                    ),
+                })
+                current_ids.add(alert_id)
+        except Exception:
+            # call_site_last_run is a core table (migration 0015) -- a failure
+            # here is a real operational fault, not an expected-absent case.
+            logger.error("Call-site health check failed", exc_info=True)
 
     if _job_retry_registry is not None:
         for job_name in _job_retry_registry.list_registered():

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -37,7 +37,10 @@ class OutreachConfig:
         "cc:quota_exhausted",
         "provider:embedding_failing",
         "provider:qdrant_unreachable",
-        "provider:credit_exhaustion",  # Prefix — matches any provider
+        # provider:credit_exhaustion deliberately NOT escalated — it is now a
+        # dashboard-only WARNING (refilling credits is a user financial action;
+        # provider exhaustion alone is not an outage, routing fallbacks cover
+        # it). See mcp/health/errors.py credit-exhaustion block.
         "awareness:tick_overdue",
         "service:health_data_uninitialized",
         # Backups are outside Sentinel scope (external target — see
@@ -101,11 +104,12 @@ _DEFAULTS = OutreachConfig(
         "cc:quota_exhausted",
         "provider:embedding_failing",
         "provider:qdrant_unreachable",
-        "provider:credit_exhaustion",  # Prefix — matches any provider
+        # provider:credit_exhaustion deliberately NOT escalated — dashboard-only
+        # WARNING now (see the dataclass default above and errors.py).
         "awareness:tick_overdue",
         "service:health_data_uninitialized",
         "backup:",  # Prefix — push channel now that backups are out of Sentinel scope
-        "creds:",   # Prefix — credential corruption / auto-restore (creds:corrupt/restored)
+        "creds:",  # Prefix — credential corruption / auto-restore (creds:corrupt/restored)
     ),
     delivery_routing={"default": "supergroup"},
 )
@@ -133,6 +137,7 @@ def validate_preferences(preferences: dict) -> list[str]:
                 val = qh.get(field)
                 if val is not None:
                     import re
+
                     if not re.fullmatch(r"\d{2}:\d{2}", str(val)):
                         errors.append(f"quiet_hours.{field} must be HH:MM format, got {val!r}")
             # timezone removed — uses genesis.env.user_timezone()
@@ -198,8 +203,10 @@ def save_outreach_config(config: OutreachConfig, path: Path | None = None) -> No
     }
 
     import tempfile
+
     tmp_fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent), suffix=".yaml.tmp",
+        dir=str(path.parent),
+        suffix=".yaml.tmp",
     )
     try:
         with open(tmp_fd, "w") as f:
@@ -244,11 +251,7 @@ def load_outreach_config(path: Path | None = None) -> OutreachConfig:
                 _DEFAULTS.immediate_escalation_alerts,
             )
         ),
-        voice_alert_ids=tuple(
-            raw.get("voice", {}).get("alert_ids", _DEFAULTS.voice_alert_ids)
-        ),
-        voice_hours=tuple(
-            raw.get("voice", {}).get("hours", _DEFAULTS.voice_hours)
-        ),
+        voice_alert_ids=tuple(raw.get("voice", {}).get("alert_ids", _DEFAULTS.voice_alert_ids)),
+        voice_hours=tuple(raw.get("voice", {}).get("hours", _DEFAULTS.voice_hours)),
         delivery_routing=raw.get("delivery_routing", {"default": "supergroup"}),
     )

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -94,6 +94,7 @@ def _host_resource_alloc() -> bool:
     path = Path.home() / ".genesis" / "guardian_remote.yaml"
     try:
         import yaml
+
         data = yaml.safe_load(path.read_text()) or {}
     except Exception:  # noqa: BLE001 — missing/unreadable/malformed ⇒ unavailable
         return False
@@ -150,9 +151,7 @@ REMEDIATION_MAP: dict[str, frozenset[str]] = {
     "awareness:tick_overdue": frozenset({"container.services"}),
     "guardian:heartbeat_stale": frozenset({"guardian.ssh_restart"}),
     "infra:disk_low": frozenset({"container.disk_reclaim", "host.resource_alloc"}),
-    "infra:container_memory_high": frozenset(
-        {"container.process_control", "host.resource_alloc"}
-    ),
+    "infra:container_memory_high": frozenset({"container.process_control", "host.resource_alloc"}),
     "infra:qdrant_collections_missing": frozenset({"qdrant.local"}),
     "provider:qdrant_unreachable": frozenset({"qdrant.local"}),
     "genesis:update_failed": frozenset({"container.services"}),
@@ -198,9 +197,7 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "The Sentinel's only response tool IS a CC session; waking it for "
         "CC budget/quota problems is self-defeating (see classifier note)."
     ),
-    "cc:quota_exhausted": (
-        "Self-defeating loop — see cc:budget / classifier Tier-1 note."
-    ),
+    "cc:quota_exhausted": ("Self-defeating loop — see cc:budget / classifier Tier-1 note."),
     "infra:ollama_model_mismatch": (
         "Ollama is optional and typically runs on a separate machine — "
         "model pulls there are not the container's to make."
@@ -209,15 +206,22 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "Backup configuration guidance, not an emergency (WARNING-level; "
         "also covered by the backup: prefix rule above)."
     ),
-    "genesis:update_available": (
-        "INFO-level notice; updating is a user/steward decision."
-    ),
+    "genesis:update_available": ("INFO-level notice; updating is a user/steward decision."),
     "call_site:": (
         "Provider call sites going down is dominated by external API "
         "outages the Sentinel cannot fix (user decision 2026-07-04: an API "
         "site being down is for the user/ego to know about, not the "
         "firefighter). In-container circuit-breaker resets can return as a "
         "dedicated tool later if the stuck-breaker case proves real."
+    ),
+    "callsite:down:": (
+        "Unified call-site health signal (last run failed) from the "
+        "call_site_last_run table — a dashboard-only availability view. Same "
+        "reasoning as call_site: above: the dominant cause is external "
+        "provider/API failure or exhausted credits, neither of which the "
+        "firefighter can remediate (credit refills are a user financial "
+        "action). GROUNDWORK(sentinel-auto-topup): a future user-gated "
+        "auto-credit-top-up keyed off CRITICAL_CALL_SITES would plug in here."
     ),
 }
 
@@ -237,7 +241,8 @@ def available_tools() -> frozenset[str]:
         except Exception:
             logger.warning(
                 "Remediation tool detector %s raised — treating as unavailable",
-                tool.id, exc_info=True,
+                tool.id,
+                exc_info=True,
             )
     return frozenset(available)
 

--- a/tests/test_mcp/test_callsite_health.py
+++ b/tests/test_mcp/test_callsite_health.py
@@ -1,0 +1,236 @@
+"""Tests for the unified critical call-site health detector (Part B/C).
+
+The detector reads ``call_site_last_run`` and emits ``callsite:down:<id>`` for
+any site whose LAST run failed within the recency window: CRITICAL/red for a
+site in ``CRITICAL_CALL_SITES``, WARNING/yellow otherwise. It is dashboard-only
+— never escalation-whitelisted (no Telegram), never Sentinel-mapped (no
+firefighter).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_service(callsite_rows):
+    """Mock HealthDataService whose call_site_last_run query returns
+    ``callsite_rows`` (list of ``(call_site_id, last_run_at, provider_used)``).
+
+    The credit-exhaustion and stale-job queries that also run in
+    ``_impl_health_alerts`` return empty, so only the call-site block produces
+    alerts here.
+    """
+    svc = MagicMock()
+    svc._db = AsyncMock()
+    svc.snapshot = AsyncMock(
+        return_value={
+            "call_sites": {},
+            "infrastructure": {},
+            "cc_sessions": {},
+            "resilience": {"level": "L0"},
+            "queues": {},
+        }
+    )
+
+    callsite_cursor = AsyncMock()
+    callsite_cursor.fetchall = AsyncMock(return_value=callsite_rows)
+
+    empty_cursor = AsyncMock()
+    empty_cursor.fetchall = AsyncMock(return_value=[])
+    empty_cursor.fetchone = AsyncMock(return_value=None)
+
+    async def mock_execute(query, params=None):
+        if "FROM call_site_last_run" in query:
+            return callsite_cursor
+        return empty_cursor
+
+    svc._db.execute = mock_execute
+    return svc
+
+
+_PATCHES = dict(
+    _activity_tracker=None,
+    _job_retry_registry=None,
+    _alert_history={},
+)
+
+
+async def _run(svc):
+    with (
+        patch("genesis.mcp.health_mcp._service", svc),
+        patch("genesis.mcp.health_mcp._activity_tracker", None),
+        patch("genesis.mcp.health_mcp._job_retry_registry", None),
+        patch("genesis.mcp.health_mcp._alert_history", {}),
+    ):
+        from genesis.mcp.health.errors import _impl_health_alerts
+
+        return await _impl_health_alerts(active_only=True)
+
+
+@pytest.mark.asyncio
+async def test_critical_site_down_is_critical():
+    """A failing site in CRITICAL_CALL_SITES → CRITICAL/red."""
+    svc = _make_service([("21_embeddings", "2026-07-12T10:00:00", "embedding")])
+    alerts = await _run(svc)
+    down = [a for a in alerts if a["id"] == "callsite:down:21_embeddings"]
+    assert len(down) == 1
+    assert down[0]["severity"] == "CRITICAL"
+
+
+@pytest.mark.asyncio
+async def test_noncritical_site_down_is_warning():
+    """A failing site NOT in the critical set → WARNING/yellow (watched)."""
+    svc = _make_service([("30_triage_calibration", "2026-07-12T10:00:00", "mistral")])
+    alerts = await _run(svc)
+    down = [a for a in alerts if a["id"] == "callsite:down:30_triage_calibration"]
+    assert len(down) == 1
+    assert down[0]["severity"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_autonomous_executor_is_warning_not_critical():
+    """autonomous_executor_reasoning is deliberately yellow (has CC fallback)."""
+    svc = _make_service([("autonomous_executor_reasoning", "2026-07-12T10:00:00", "openrouter")])
+    alerts = await _run(svc)
+    down = [a for a in alerts if a["id"] == "callsite:down:autonomous_executor_reasoning"]
+    assert len(down) == 1
+    assert down[0]["severity"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_no_failing_rows_no_alerts():
+    """No failing rows (all recovered / none stale) → no callsite:down alerts."""
+    svc = _make_service([])
+    alerts = await _run(svc)
+    assert [a for a in alerts if a["id"].startswith("callsite:down:")] == []
+
+
+@pytest.mark.asyncio
+async def test_recency_and_success_filter_via_real_db():
+    """SQL correctness against a REAL sqlite DB: only rows that are BOTH
+    failed (success=0) AND recent (within the window) surface; recovered rows
+    and stale-failed rows are excluded. Proves the WHERE clause, not a mock."""
+    import aiosqlite
+
+    from genesis.mcp.health.critical_sites import CALLSITE_DOWN_RECENCY_HOURS
+
+    now = datetime.now(UTC)
+    fresh = (now - timedelta(hours=1)).isoformat()
+    stale = (now - timedelta(hours=CALLSITE_DOWN_RECENCY_HOURS + 48)).isoformat()
+
+    async with aiosqlite.connect(":memory:") as db:
+        await db.execute(
+            "CREATE TABLE call_site_last_run ("
+            "call_site_id TEXT PRIMARY KEY, last_run_at TEXT, "
+            "provider_used TEXT, success INTEGER)"
+        )
+        await db.executemany(
+            "INSERT INTO call_site_last_run "
+            "(call_site_id, last_run_at, provider_used, success) VALUES (?,?,?,?)",
+            [
+                ("21_embeddings", fresh, "embedding", 0),  # fresh fail, critical
+                ("30_triage_calibration", fresh, "mistral", 0),  # fresh fail, non-crit
+                ("5_deep_reflection", stale, "cc", 0),  # STALE fail → excluded
+                ("9_fact_extraction", fresh, "groq", 1),  # recovered → excluded
+            ],
+        )
+        await db.commit()
+
+        svc = MagicMock()
+        svc._db = db
+        svc.snapshot = AsyncMock(
+            return_value={
+                "call_sites": {},
+                "infrastructure": {},
+                "cc_sessions": {},
+                "resilience": {"level": "L0"},
+                "queues": {},
+            }
+        )
+        alerts = await _run(svc)
+
+    down = {a["id"]: a["severity"] for a in alerts if a["id"].startswith("callsite:down:")}
+    assert down == {
+        "callsite:down:21_embeddings": "CRITICAL",
+        "callsite:down:30_triage_calibration": "WARNING",
+    }
+
+
+def test_callsite_down_not_escalation_whitelisted():
+    """callsite:down: must never match an outreach escalation whitelist entry
+    (prefix match) → no Telegram, ever."""
+    from genesis.outreach.config import _DEFAULTS
+
+    sample = "callsite:down:21_embeddings"
+    assert not any(sample.startswith(entry) for entry in _DEFAULTS.immediate_escalation_alerts)
+
+
+def test_callsite_down_unmapped_in_sentinel():
+    """callsite:down: must be UNMAPPED (fail-closed) → never wakes the Sentinel,
+    and explicitly listed in UNMAPPED_BY_DESIGN so the coverage lock passes."""
+    from genesis.sentinel.remediation_map import (
+        UNMAPPED_BY_DESIGN,
+        required_tools,
+    )
+
+    assert "callsite:down:" in UNMAPPED_BY_DESIGN
+    assert required_tools("callsite:down:21_embeddings") is None
+
+
+def test_critical_call_sites_membership():
+    """Part C: the curated red set — the 12 locked ids present, the deliberately
+    excluded ones absent."""
+    from genesis.mcp.health.critical_sites import CRITICAL_CALL_SITES
+
+    expected = {
+        "9_fact_extraction",
+        "40_knowledge_distillation",
+        "38_procedure_extraction",
+        "21_embeddings",
+        "21b_query_embedding",
+        "ambient_arbiter",
+        "7_genesis_ego_cycle",
+        "7_user_ego_cycle",
+        "40_ego_focus_selection",
+        "5_deep_reflection",
+        "6_strategic_reflection",
+    }
+    assert expected == CRITICAL_CALL_SITES
+    # Deliberately NOT red. autonomous_executor_reasoning = watched-yellow (CC
+    # fallback); 3_micro_reflection/judge = routine/eval-only; 8_ego_compaction =
+    # DEAD (ego went ephemeral, never records a last_run row — can never fire).
+    for excluded in (
+        "autonomous_executor_reasoning",
+        "3_micro_reflection",
+        "judge",
+        "8_ego_compaction",
+    ):
+        assert excluded not in CRITICAL_CALL_SITES
+
+
+def test_credit_exhaustion_removed_from_escalation_default():
+    """Part A: credit exhaustion is dashboard-only WARNING → removed from the
+    code escalation default (WARNING can never page anyway; kept out for
+    intent-clarity)."""
+    from genesis.outreach.config import _DEFAULTS
+
+    assert "provider:credit_exhaustion" not in _DEFAULTS.immediate_escalation_alerts
+
+
+def test_health_data_uninitialized_escalates_in_default_and_repo_yaml():
+    """Part E: a blind health system SHOULD page. It stays in the code default
+    AND is restored to the repo outreach.yaml (which REPLACES the default)."""
+    from genesis.outreach.config import (
+        _DEFAULTS,
+        _REPO_CONFIG,
+        load_outreach_config,
+    )
+
+    assert "service:health_data_uninitialized" in _DEFAULTS.immediate_escalation_alerts
+    repo_cfg = load_outreach_config(_REPO_CONFIG)
+    assert "service:health_data_uninitialized" in repo_cfg.immediate_escalation_alerts
+    # And credit_exhaustion stays OUT of the repo yaml (opposite treatment).
+    assert "provider:credit_exhaustion" not in repo_cfg.immediate_escalation_alerts

--- a/tests/test_mcp/test_credit_exhaustion.py
+++ b/tests/test_mcp/test_credit_exhaustion.py
@@ -59,7 +59,29 @@ def _mock_routing_config(*provider_names, sole=False):
     return _RoutingCfg(providers=providers, call_sites=call_sites)
 
 
-def _make_mock_service(*, rows_recent=None, rows_baseline=None, provider_names=None):
+def _mock_routing_config_typed(*name_type_pairs, sole=False, is_free=False):
+    """Routing config where provider NAME differs from provider_type.
+
+    Reproduces the production reality that activity_log stores ``llm.<name>``
+    while ``derive_criticality`` keys by ``provider_type`` -- the mismatch the
+    two-hop resolution fixes. Each arg is a ``(name, provider_type)`` tuple.
+    """
+    providers = {}
+    types = {t for _, t in name_type_pairs}
+    for name, ptype in name_type_pairs:
+        providers[name] = _ProviderCfg(name=name, provider_type=ptype, is_free=is_free)
+    if not sole:
+        providers["_fallback"] = _ProviderCfg(name="_fallback", provider_type="_fallback")
+    call_sites = {}
+    for i, ptype in enumerate(types):
+        names_of_type = [n for n, t in name_type_pairs if t == ptype]
+        chain = list(names_of_type) if sole else [*names_of_type, "_fallback"]
+        call_sites[f"site_{i}"] = _CallSiteCfg(id=f"site_{i}", chain=chain)
+    return _RoutingCfg(providers=providers, call_sites=call_sites)
+
+
+def _make_mock_service(*, rows_recent=None, rows_baseline=None, provider_names=None,
+                       routing_cfg=None):
     """Build a mock HealthDataService with a mock DB."""
     svc = MagicMock()
     svc._db = AsyncMock()
@@ -103,6 +125,11 @@ def _make_mock_service(*, rows_recent=None, rows_baseline=None, provider_names=N
 
     # Build a routing config with the provider names in chains so
     # derive_criticality() classifies them as active (not dormant).
+    if routing_cfg is not None:
+        mock_rt = MagicMock()
+        mock_rt._routing_config = routing_cfg
+        svc._mock_rt = mock_rt
+        return svc
     if provider_names is None:
         provider_names = [r[0] for r in (rows_recent or [])]
     if provider_names:
@@ -244,3 +271,88 @@ async def test_no_alert_with_insufficient_baseline():
 
     credit_alerts = [a for a in alerts if "credit_exhaustion" in a.get("id", "")]
     assert len(credit_alerts) == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_prefixed_provider_resolves_via_two_hop():
+    """PROD-FORMAT regression: activity_log stores ``llm.<name>`` but crit_map
+    is keyed by provider_type. The detector must strip the ``llm.`` prefix and
+    resolve name->provider_type->criticality (two-hop), else it is 100% dead.
+
+    Fails on pre-fix code: ``crit_map.get("llm.groq-free")`` misses -> dormant.
+    """
+    svc = _make_mock_service(
+        rows_recent=[("llm.groq-free", 20, 15)],
+        rows_baseline=(100, 2),
+        routing_cfg=_mock_routing_config_typed(("groq-free", "groq")),
+    )
+
+    with patch("genesis.mcp.health_mcp._service", svc), \
+         patch("genesis.mcp.health_mcp._activity_tracker", None), \
+         patch("genesis.mcp.health_mcp._job_retry_registry", None), \
+         patch("genesis.mcp.health_mcp._alert_history", {}), \
+         patch("genesis.runtime.GenesisRuntime.instance", return_value=svc._mock_rt):
+
+        from genesis.mcp.health.errors import _impl_health_alerts
+        alerts = await _impl_health_alerts(active_only=True)
+
+    credit_alerts = [a for a in alerts if "credit_exhaustion" in a.get("id", "")]
+    assert len(credit_alerts) == 1
+    # alert_id / message use the RESOLVED bare name, not the raw llm.* string.
+    assert credit_alerts[0]["id"] == "provider:credit_exhaustion:groq-free"
+    assert "llm." not in credit_alerts[0]["id"]
+    assert credit_alerts[0]["severity"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_non_llm_provider_row_is_skipped():
+    """A non-routed provider string (embedding/qdrant/mcp.*) resolves to no
+    provider config -> skipped cleanly, never alerts."""
+    svc = _make_mock_service(
+        rows_recent=[("embedding", 20, 15)],
+        rows_baseline=(100, 2),
+        routing_cfg=_mock_routing_config_typed(("groq-free", "groq")),
+    )
+
+    with patch("genesis.mcp.health_mcp._service", svc), \
+         patch("genesis.mcp.health_mcp._activity_tracker", None), \
+         patch("genesis.mcp.health_mcp._job_retry_registry", None), \
+         patch("genesis.mcp.health_mcp._alert_history", {}), \
+         patch("genesis.runtime.GenesisRuntime.instance", return_value=svc._mock_rt):
+
+        from genesis.mcp.health.errors import _impl_health_alerts
+        alerts = await _impl_health_alerts(active_only=True)
+
+    credit_alerts = [a for a in alerts if "credit_exhaustion" in a.get("id", "")]
+    assert len(credit_alerts) == 0
+
+
+@pytest.mark.asyncio
+async def test_sole_paid_provider_is_warning_not_critical():
+    """Credit exhaustion is dashboard-WARNING ONLY -- never CRITICAL (which
+    would page). A sole PAID provider used to escalate to CRITICAL; the
+    redesign makes every credit-exhaustion alert WARNING (Sentinel can't
+    refill credits; Telegram is reserved for genuine outages).
+
+    Fails on pre-fix code: sole+paid -> CRITICAL.
+    """
+    svc = _make_mock_service(
+        rows_recent=[("llm.openrouter-deepseek", 20, 15)],
+        rows_baseline=(100, 2),
+        routing_cfg=_mock_routing_config_typed(
+            ("openrouter-deepseek", "openrouter"), sole=True, is_free=False
+        ),
+    )
+
+    with patch("genesis.mcp.health_mcp._service", svc), \
+         patch("genesis.mcp.health_mcp._activity_tracker", None), \
+         patch("genesis.mcp.health_mcp._job_retry_registry", None), \
+         patch("genesis.mcp.health_mcp._alert_history", {}), \
+         patch("genesis.runtime.GenesisRuntime.instance", return_value=svc._mock_rt):
+
+        from genesis.mcp.health.errors import _impl_health_alerts
+        alerts = await _impl_health_alerts(active_only=True)
+
+    credit_alerts = [a for a in alerts if "credit_exhaustion" in a.get("id", "")]
+    assert len(credit_alerts) == 1
+    assert credit_alerts[0]["severity"] == "WARNING"


### PR DESCRIPTION
## Summary

Part of the 2026-07-10 Codex-findings remediation (PR-C). Two health-alert defects + a redesign around the right signal (call-site availability, not provider tier).

### A — credit-exhaustion detector was 100% dead in prod
`activity_log` stores LLM calls as `llm.<name>`, but `crit_map` (`derive_criticality`) is keyed by `provider_type`, so the single-hop `crit_map.get("llm.groq-free")` always missed → every provider read `dormant` → skipped. No alert could ever fire. Masked by a test that mocked `provider_type == name`.

**Fix:** two-hop resolution — strip `llm.` → provider name → `providers[name].provider_type` → `crit_map[type]`. Non-routed rows (embedding / `qdrant.*` / `mcp.*`) resolve to no config and are skipped cleanly. Severity is now **always WARNING** (dashboard-only): refilling credits is a user financial action the Sentinel can't take, and provider exhaustion alone isn't an outage — routing fallbacks cover it.

### B — new unified critical call-site health detector
`call_site_last_run` holds one row per site (its latest run, written by every execution path: router / cc / embedding / pipeline / gate), so `success=0` on the last run is the honest "this site's last attempt failed" signal — and it captures cc + embedding failures the provider-tier checks miss. Emits `callsite:down:<id>`: **CRITICAL/red** for a site in the curated `CRITICAL_CALL_SITES` set (memory formation/retrieval, the two live ego cycles, ego focus, core cognition, ambient arbiter), **WARNING/yellow** otherwise.

**Dashboard-only by construction:** `callsite:down:` is never on the outreach escalation whitelist (no Telegram) and is UNMAPPED in the Sentinel remediation map (no firefighter) — both fail-closed. A recency window (24h) drops long-abandoned stale-failed rows.

### E — escalation asymmetry
Restored `service:health_data_uninitialized` to the outreach escalation whitelist (a blind health system *should* page — it's Sentinel-remediable) and dropped `provider:credit_exhaustion` from the escalation default (WARNING can never page anyway).

## Notes
- `CRITICAL_CALL_SITES` deliberately excludes `8_ego_compaction` — that call site is dead (the ego moved to ephemeral sessions; its `call_site_id` is a legacy-ignored param with no route call), so it can never record a row or fire.
- Recency window is a documented tunable (`CALLSITE_DOWN_RECENCY_HOURS`), chosen from live call-site cadence data.
- No schema change (`call_site_last_run` exists since migration 0015).

## Testing
- New `test_callsite_health.py` (classification, real-in-memory-DB recency/success-filter, no-Telegram/no-Sentinel assertions, curated-set membership) + extended `test_credit_exhaustion.py` (prod-format `llm.`-prefix two-hop regression, sole-paid no-longer-CRITICAL, non-LLM skip).
- Sentinel alert-id enumeration lock green (new id explicitly dispositioned).
- E2E against a copy of the real DB with synthetic failing rows: fresh critical→CRITICAL, fresh non-critical→WARNING, real stale rows excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)