### PR TITLE
feat(guardian): nightly host CC/Node pin-alignment timer + runtime linger health signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The recovery brain no longer drifts behind a version bump.** A nightly
+  job re-aligns the host's Claude Code and Node.js to the pinned versions.
+  Previously this happened only when you ran an update, so a pin bump could
+  leave the host's autonomous-recovery Claude Code lagging for days. It heals
+  only real drift, is a clean no-op when everything is already aligned, and a
+  failed alignment now shows up as a failed timer instead of going quiet.
+
+- **Genesis notices if systemd "linger" gets turned off.** Linger is what
+  keeps Genesis's background services alive after you log out — if it is ever
+  disabled, everything dies silently at the next logout. A new health check
+  watches both the host and the container and raises a single alert (with the
+  exact re-enable command) when linger is off, before the next logout can bite.
+
 - **Code quality is now a measured series, not a feeling.** A new
   `dev_quality` dimension in the weekly eval snapshots tracks review
   findings per merged PR (by severity, harvested from the PR bots' inline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,10 @@ pollers split updates and break approval buttons),
 `genesis-tmp-watchgod.service` (/tmp protection), `genesis-watchdog.timer`
 (health check), `genesis-backup.timer` (6h encrypted backup via
 `scripts/backup.sh`), `genesis-disk-hygiene.timer` (daily worktree reaping, cache reclaim, `~/tmp`
-prune, and label-aware attention-snapshot GC; see `scripts/disk_hygiene.sh`). MCP servers are CC child processes
+prune, and label-aware attention-snapshot GC; see `scripts/disk_hygiene.sh`),
+`genesis-cc-align.timer` (nightly host CC/Node pin alignment via the guardian
+gateway, so the host recovery brain never lags a pin bump between updates; see
+`scripts/cc_align_host.sh`). MCP servers are CC child processes
 (not systemd) — code changes take effect on next CC session start.
 
 ## Common Commands

--- a/scripts/cc_align_host.sh
+++ b/scripts/cc_align_host.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# cc_align_host.sh — nightly HOST Claude Code / Node.js pin alignment.
+#
+# WHY: the host VM's CC/Node are re-aligned to the repo pins ONLY when
+# scripts/update.sh runs. Between updates, a repo pin bump leaves the host's
+# `claude -p` recovery brain (guardian/diagnosis.py — the highest-stakes CC
+# call in the system) lagging the pin. This timer closes that window: it re-runs
+# the SAME host-alignment logic update.sh uses (cc_align_host_sync in
+# scripts/lib/cc_version.sh), nightly, via the guardian gateway.
+#
+# HOST-ONLY by design: it only issues gateway SSH calls (the host-side
+# update-cc/update-node verbs handle their own privilege), so it needs no local
+# sudo and is safe under a NoNewPrivileges/ProtectSystem=strict systemd unit.
+# The CONTAINER's own CC is already aligned on every update.sh run
+# (unconditional), so there is no container leg here.
+#
+# Non-fatal and idempotent: a guardian-less install is a clean no-op; an
+# unreachable host is logged (guardian's own health probe surfaces a down host)
+# and exits 0; only a GENUINE heal failure (host reachable but update-cc /
+# update-node rejected) exits non-zero so the systemd unit enters `failed` and
+# the miss is visible in `systemctl --user status genesis-cc-align.service`.
+#
+# Invoked by scripts/systemd/genesis-cc-align.{service,timer}.template.
+
+set -u
+
+GENESIS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CC_ENV="$GENESIS_ROOT/scripts/lib/cc_version.sh"
+VENV_PY="$GENESIS_ROOT/.venv/bin/python"
+GUARDIAN_CONFIG="$HOME/.genesis/guardian_remote.yaml"
+SSH_KEY="$HOME/.ssh/genesis_guardian_ed25519"
+
+# ── Single-flight guard: never let two alignment runs issue concurrent
+# `update-cc` npm installs at the host prefix (they are not serialized host
+# side). Non-blocking — if a run is already in flight, this one is redundant.
+LOCKFILE="$HOME/.genesis/locks/cc_align_host.lock"
+mkdir -p "$(dirname "$LOCKFILE")" 2>/dev/null || true
+if ! exec {LOCK_FD}>"$LOCKFILE"; then
+    echo "cc_align_host: cannot open lockfile $LOCKFILE — skipping (non-fatal)"
+    exit 0
+fi
+if ! flock -n "$LOCK_FD"; then
+    echo "cc_align_host: another cc_align_host run is in progress — skipping"
+    exit 0
+fi
+
+# ── Guardian-less install → clean no-op ──
+if [ ! -f "$GUARDIAN_CONFIG" ]; then
+    echo "cc_align_host: no guardian_remote.yaml — host alignment not applicable (no-op)"
+    exit 0
+fi
+if [ ! -f "$CC_ENV" ]; then
+    echo "cc_align_host: $CC_ENV missing — cannot resolve pins (skipping)"
+    exit 0
+fi
+if [ ! -f "$SSH_KEY" ]; then
+    echo "cc_align_host: guardian SSH key $SSH_KEY missing — cannot reach host (skipping)"
+    exit 0
+fi
+
+# ── Resolve the repo pins + the shared aligner. unset first so an inherited
+# env override never beats the repo pin (the exact bug cc_version.sh warns
+# about); the source defines cc_align_host_sync AND sets CC_VERSION/NODE_MAJOR.
+HOST_CC_DEGRADED=""
+unset CC_VERSION NODE_MAJOR
+# shellcheck source=/dev/null
+source "$CC_ENV"
+
+# ── Parse host_ip / host_user (yaml.safe_load for robustness, mirroring
+# update.sh). A missing/broken venv python or unparseable config → clean skip.
+HOST_IP=""
+HOST_USER="ubuntu"
+if [ -x "$VENV_PY" ]; then
+    HOST_IP=$("$VENV_PY" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_ip', ''))" 2>/dev/null || true)
+    HOST_USER=$("$VENV_PY" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_user', 'ubuntu'))" 2>/dev/null || echo "ubuntu")
+else
+    echo "cc_align_host: venv python ($VENV_PY) unavailable — cannot parse guardian config (skipping)"
+    exit 0
+fi
+if [ -z "$HOST_IP" ]; then
+    echo "cc_align_host: host_ip unparseable in $GUARDIAN_CONFIG — skipping (non-fatal)"
+    exit 0
+fi
+
+# ── Read host state once (deployed CC/Node come from this single response) ──
+HOST_VER_RAW="$(ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 \
+    "${HOST_USER}@${HOST_IP}" version 2>/dev/null || true)"
+
+echo "cc_align_host: aligning host ${HOST_USER}@${HOST_IP} to pins (CC=${CC_VERSION:-?}, Node major=${NODE_MAJOR:-?})"
+cc_align_host_sync "$HOST_USER" "$HOST_IP" "$SSH_KEY" "$HOST_VER_RAW" || true
+
+# ── Surface the result. A genuine heal FAILURE (host reachable but update-cc /
+# update-node rejected → guardian_host_cc/node) exits non-zero so the unit is
+# marked failed. A merely-unreachable host is NOT a timer failure (guardian's
+# own health probe already alerts on a down host), so it exits 0.
+case "$HOST_CC_DEGRADED" in
+    *guardian_host_cc*|*guardian_host_node*)
+        echo "cc_align_host: WARNING — host alignment FAILED to heal drift ($HOST_CC_DEGRADED); the host recovery brain may lag the pin"
+        exit 3
+        ;;
+    *guardian_host_unreachable*)
+        echo "cc_align_host: host unreachable this run ($HOST_CC_DEGRADED) — guardian health covers a down host; nothing to heal"
+        exit 0
+        ;;
+    "")
+        echo "cc_align_host: host aligned (or already at pins)"
+        exit 0
+        ;;
+    *)
+        echo "cc_align_host: completed with note ($HOST_CC_DEGRADED)"
+        exit 0
+        ;;
+esac

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -244,13 +244,26 @@ except Exception:
                 fi
             fi
         fi
+        # --- systemd linger health (consumed by the container's _check_linger
+        # host leg). Linger keeps this user's timers/services alive after logout;
+        # if it is ever disabled the guardian's user timers die silently on the
+        # next logout. Fail-safe: emit a JSON literal true/false/null — `null`
+        # (NOT false) on any probe error, so a transient loginctl failure can
+        # never false-alarm as "linger disabled". Only an explicit `Linger=no`
+        # yields false. System-bus call (logind) — no PATH/login-shell dependence.
+        HOST_LINGER=null
+        _LINGER_RAW=$(loginctl show-user "$(id -un)" --property=Linger 2>/dev/null || true)
+        case "$_LINGER_RAW" in
+            Linger=yes) HOST_LINGER=true ;;
+            Linger=no)  HOST_LINGER=false ;;
+        esac
         # Surface the deployed tree_sha256 (F.0, read above) so the container can
         # tell a verified deploy from a legacy one, and advertise redeploy_verify
         # so a newer update.sh knows this gateway understands the sha-checked form.
-        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "deployed_tree_sha256": "%s", "redeploy_verify": true, "gateway_sha": "%s", "authkey_no_pty": %s, "authkey_has_from": %s, "authkey_from_matches": %s, "authkey_observed_src_hash": "%s", "authkey_opts_hash": "%s", "cc_logged_in": %s, "cc_token_present": %s, "cc_token_age_days": %s}\n' \
+        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "deployed_tree_sha256": "%s", "redeploy_verify": true, "gateway_sha": "%s", "authkey_no_pty": %s, "authkey_has_from": %s, "authkey_from_matches": %s, "authkey_observed_src_hash": "%s", "authkey_opts_hash": "%s", "cc_logged_in": %s, "cc_token_present": %s, "cc_token_age_days": %s, "host_linger": %s}\n' \
             "$CC_VER" "$NODE_VER" "$CODE_VER" "$CODE_DATE" "$DEPLOYED" "$DEPLOYED_TREE_SHA" "$GW_SHA" \
             "$AK_NO_PTY" "$AK_HAS_FROM" "$AK_FROM_MATCHES" "$AK_SRC_HASH" "$AK_OPTS_HASH" \
-            "$CC_LOGGED_IN" "$CC_TOKEN_PRESENT" "$CC_TOKEN_AGE_DAYS"
+            "$CC_LOGGED_IN" "$CC_TOKEN_PRESENT" "$CC_TOKEN_AGE_DAYS" "$HOST_LINGER"
         ;;
     update)
         INSTALL_DIR="${HOME}/.local/share/genesis-guardian"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1093,14 +1093,25 @@ if [ -f "$SYSTEMD_USER_DIR/qdrant.service" ]; then
     fi
 fi
 
-if [ -f "$SYSTEMD_USER_DIR/genesis-watchdog.timer" ]; then
-    systemctl --user enable --now genesis-watchdog.timer 2>/dev/null && \
-        echo "    + genesis-watchdog.timer enabled + started" || true
-fi
-
-if [ -f "$SYSTEMD_USER_DIR/genesis-disk-hygiene.timer" ]; then
-    systemctl --user enable --now genesis-disk-hygiene.timer 2>/dev/null && \
-        echo "    + genesis-disk-hygiene.timer enabled + started" || true
+# Enable + start every rendered timer (idempotent), EXCEPT genesis-backup.timer
+# — that one is a deliberate setup step (it needs a passphrase + a verify run
+# before it should fire; auto-enabling a 6h schedule gives a false sense of
+# safety while data is still local-only). Generic loop (mirrors bootstrap.sh) so
+# a newly-added timer is never left rendered-but-dead in the fresh-install path —
+# the exact gap that left genesis-cc-align.timer disabled under the old
+# hardcoded per-timer list.
+if [ -d "$SYSTEMD_TEMPLATE_DIR" ]; then
+    for template in "$SYSTEMD_TEMPLATE_DIR"/*.timer.template; do
+        [ -f "$template" ] || continue
+        timer_name=$(basename "$template" .template)
+        case "$timer_name" in
+            genesis-backup.timer) continue ;;  # deliberate setup step
+        esac
+        if [ -f "$SYSTEMD_USER_DIR/$timer_name" ]; then
+            systemctl --user enable --now "$timer_name" 2>/dev/null && \
+                echo "    + $timer_name enabled + started" || true
+        fi
+    done
 fi
 
 # Enable AND start tmp watchgod (OS-level temp protection)

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -318,3 +318,89 @@ _cc_remove_shadow() {
     [ -n "$pkg_dir" ] && "${rm_pkg[@]}"
     return 0
 }
+
+
+# cc_align_host_sync — align the HOST VM's Node.js major + Claude Code to the
+# repo pins via the guardian gateway, healing drift. Extracted from update.sh's
+# _sync_deploy_targets so BOTH update.sh and the nightly genesis-cc-align timer
+# (scripts/cc_align_host.sh) share ONE implementation — a pin bump reaches the
+# host's `claude -p` recovery brain without waiting for the next manual update.
+#
+# Args: <host_user> <host_ip> <ssh_key> <host_ver_raw>
+#   host_ver_raw = raw JSON from a prior `ssh … version` call. The CALLER fetches
+#   it once (update.sh reuses the same response for its redeploy decision), so
+#   this function never issues the version probe itself.
+# Reads globals: NODE_MAJOR, CC_VERSION (set at the top of this file when sourced).
+# APPENDS any alignment failure to the global HOST_CC_DEGRADED (comma-joined; the
+#   `:+` form is set -u-safe). It NEVER re-inits that global — the caller owns the
+#   init and may set sibling sentinels (guardian_config_unreadable) in branches
+#   this function doesn't cover. Progress → stdout.
+# Non-fatal by contract: ALWAYS returns 0 so a host hiccup can't abort an
+#   update run under set -e (the ERR trap is already disarmed by then). Call as
+#   `cc_align_host_sync … || true` to match the cc_ensure_local convention.
+cc_align_host_sync() {
+    local host_user="$1" host_ip="$2" ssh_key="$3" host_ver_raw="$4"
+    local host_node_major host_cc
+
+    # HOST_VER_RAW empty = genuinely could not reach/parse the gateway — DISTINCT
+    # from "CC absent" (the conflation the old inline message got wrong).
+    if [ -z "$host_ver_raw" ]; then
+        echo "  Host gateway unreachable (no version response) — skipping Node/CC sync (non-fatal)"
+        HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_unreachable"
+        return 0
+    fi
+
+    host_node_major="$(printf '%s' "$host_ver_raw" \
+        | grep -oE '"node_version": "v[0-9]+' | grep -oE '[0-9]+' || true)"
+    host_cc="$(printf '%s' "$host_ver_raw" \
+        | grep -oE '"cc_version": "[0-9]+\.[0-9]+\.[0-9]+' \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+
+    # ── Node.js major sync (prerequisite for CC) ──
+    if printf '%s' "${NODE_MAJOR:-}" | grep -qE '^[0-9]{1,2}$'; then
+        if [ "$host_node_major" = "$NODE_MAJOR" ]; then
+            echo "  Host Node.js already at major $NODE_MAJOR — no Node sync needed"
+        else
+            echo "--- Host Node.js: ${host_node_major:-unknown} → syncing to major $NODE_MAJOR ---"
+            # 600s: NodeSource repo-add + apt install is heavier than an npm
+            # install (update-cc uses 300s); bounds a hung dpkg lock.
+            if timeout 600 ssh -i "$ssh_key" -o BatchMode=yes -o ConnectTimeout=30 \
+                "${host_user}@${host_ip}" "update-node $NODE_MAJOR" 2>&1; then
+                echo "  Host Node.js updated to major $NODE_MAJOR"
+                host_node_major="$NODE_MAJOR"
+            else
+                echo "  WARNING: Host Node.js sync failed — CC install will likely fail (host stays on ${host_node_major:-unknown})"
+                HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_node"
+            fi
+        fi
+    fi
+
+    # ── Claude Code sync: absence => INSTALL, drift => update ──
+    if printf '%s' "${CC_VERSION:-}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        if [ -z "$host_cc" ]; then
+            # cc_version was "unavailable"/unparseable → CC is NOT installed on the
+            # host. INSTALL it (do not skip) — the exact case the old code silently
+            # ignored, leaving Guardian's recovery brain offline.
+            echo "--- Host Claude Code not installed — installing $CC_VERSION ---"
+            if timeout 300 ssh -i "$ssh_key" -o BatchMode=yes -o ConnectTimeout=30 \
+                "${host_user}@${host_ip}" "update-cc $CC_VERSION" 2>&1; then
+                echo "  Host Claude Code installed ($CC_VERSION)"
+            else
+                echo "  WARNING: Host Claude Code install FAILED — Guardian intelligent recovery is OFFLINE"
+                HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_cc"
+            fi
+        elif [ "$host_cc" = "$CC_VERSION" ]; then
+            echo "  Host Claude Code already at pin ($CC_VERSION) — no CC sync needed"
+        else
+            echo "--- Host Claude Code drift: $host_cc → syncing to $CC_VERSION ---"
+            if timeout 300 ssh -i "$ssh_key" -o BatchMode=yes -o ConnectTimeout=30 \
+                "${host_user}@${host_ip}" "update-cc $CC_VERSION" 2>&1; then
+                echo "  Host Claude Code updated to $CC_VERSION"
+            else
+                echo "  WARNING: Host Claude Code sync failed — host remains on $host_cc"
+                HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_cc"
+            fi
+        fi
+    fi
+    return 0
+}

--- a/scripts/systemd/genesis-cc-align.service.template
+++ b/scripts/systemd/genesis-cc-align.service.template
@@ -1,0 +1,21 @@
+[Unit]
+Description=Genesis Host CC/Node Alignment — nightly pin sync to the guardian host
+After=genesis-server.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=__REPO_DIR__
+ExecStart=/bin/bash __REPO_DIR__/scripts/cc_align_host.sh
+# The script bounds each SSH op itself (600s node / 300s cc); cap the unit
+# generously above the worst single op so a slow host update-node isn't SIGTERMed.
+TimeoutStartSec=900
+# Needs ssh + flock (/usr/bin) and the venv python (called by absolute path).
+# No npm/sudo here — the host-side update-cc/update-node verbs own their privilege,
+# so NoNewPrivileges + ProtectSystem=strict are safe (unlike a container-CC align).
+Environment=PATH=__VENV__/bin:__CC_BIN_DIR__:__HOME__/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=journal
+StandardError=journal
+# Home-scoped: the only file it writes is the single-flight lock under ~/.genesis.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=%h

--- a/scripts/systemd/genesis-cc-align.timer.template
+++ b/scripts/systemd/genesis-cc-align.timer.template
@@ -1,0 +1,14 @@
+[Unit]
+Description=Genesis Host CC/Node Alignment — nightly schedule
+
+[Timer]
+# 03:30 — offset from disk-hygiene (04:00) so the two housekeeping jobs don't
+# contend. Persistent catches a missed run after downtime; RandomizedDelaySec
+# spreads load and de-correlates from other timers.
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+AccuracySec=1h
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -327,68 +327,15 @@ _sync_deploy_targets() {
                 echo "  WARNING: $_cc_env missing — skipping host Node/CC sync"
             fi
 
-            # HOST_VER_RAW was fetched up front (feeds the redeploy decision too);
-            # parse node/cc from that same single `version` response here.
-            if [ -z "$HOST_VER_RAW" ]; then
-                # Genuinely could not reach/parse the gateway — DISTINCT from "CC
-                # absent" (the conflation the old message got wrong).
-                echo "  Host gateway unreachable (no version response) — skipping Node/CC sync (non-fatal)"
-                HOST_CC_DEGRADED="guardian_host_unreachable"
-            else
-                HOST_NODE_MAJOR="$(printf '%s' "$HOST_VER_RAW" \
-                    | grep -oE '"node_version": "v[0-9]+' | grep -oE '[0-9]+' || true)"
-                HOST_CC="$(printf '%s' "$HOST_VER_RAW" \
-                    | grep -oE '"cc_version": "[0-9]+\.[0-9]+\.[0-9]+' \
-                    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
-
-                # ── Node.js major sync (prerequisite for CC) ──
-                if printf '%s' "${NODE_MAJOR:-}" | grep -qE '^[0-9]{1,2}$'; then
-                    if [ "$HOST_NODE_MAJOR" = "$NODE_MAJOR" ]; then
-                        echo "  Host Node.js already at major $NODE_MAJOR — no Node sync needed"
-                    else
-                        echo "--- Host Node.js: ${HOST_NODE_MAJOR:-unknown} → syncing to major $NODE_MAJOR ---"
-                        # 600s: NodeSource repo-add + apt install is heavier than an
-                        # npm install (update-cc uses 300s); bounds a hung dpkg lock.
-                        if timeout 600 ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=30 \
-                            "${HOST_USER}@${HOST_IP}" "update-node $NODE_MAJOR" 2>&1; then
-                            echo "  Host Node.js updated to major $NODE_MAJOR"
-                            HOST_NODE_MAJOR="$NODE_MAJOR"
-                        else
-                            echo "  WARNING: Host Node.js sync failed — CC install will likely fail (host stays on ${HOST_NODE_MAJOR:-unknown})"
-                            HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_node"
-                        fi
-                    fi
-                fi
-
-                # ── Claude Code sync: absence => INSTALL, drift => update ──
-                if printf '%s' "${CC_VERSION:-}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-                    if [ -z "$HOST_CC" ]; then
-                        # cc_version was "unavailable"/unparseable → CC is NOT installed
-                        # on the host. INSTALL it (do not skip) — this is the exact case
-                        # the old code silently ignored, leaving Guardian's recovery
-                        # brain offline.
-                        echo "--- Host Claude Code not installed — installing $CC_VERSION ---"
-                        if timeout 300 ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=30 \
-                            "${HOST_USER}@${HOST_IP}" "update-cc $CC_VERSION" 2>&1; then
-                            echo "  Host Claude Code installed ($CC_VERSION)"
-                        else
-                            echo "  WARNING: Host Claude Code install FAILED — Guardian intelligent recovery is OFFLINE"
-                            HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_cc"
-                        fi
-                    elif [ "$HOST_CC" = "$CC_VERSION" ]; then
-                        echo "  Host Claude Code already at pin ($CC_VERSION) — no CC sync needed"
-                    else
-                        echo "--- Host Claude Code drift: $HOST_CC → syncing to $CC_VERSION ---"
-                        if timeout 300 ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=30 \
-                            "${HOST_USER}@${HOST_IP}" "update-cc $CC_VERSION" 2>&1; then
-                            echo "  Host Claude Code updated to $CC_VERSION"
-                        else
-                            echo "  WARNING: Host Claude Code sync failed — host remains on $HOST_CC"
-                            HOST_CC_DEGRADED="${HOST_CC_DEGRADED:+$HOST_CC_DEGRADED,}guardian_host_cc"
-                        fi
-                    fi
-                fi
-            fi
+            # HOST_VER_RAW was fetched up front (it also feeds the redeploy
+            # decision above). The shared cc_align_host_sync (defined in the
+            # cc_version.sh sourced just above) parses node/cc from that same
+            # single `version` response and heals drift via the gateway,
+            # APPENDING any failure to HOST_CC_DEGRADED. Factored so the nightly
+            # genesis-cc-align timer runs the IDENTICAL logic between updates.
+            # `|| true`: the function is non-fatal by contract (always returns 0),
+            # but set -e is live here (ERR trap disarmed) — guard the call anyway.
+            cc_align_host_sync "$HOST_USER" "$HOST_IP" "$SSH_KEY" "$HOST_VER_RAW" || true
             echo ""
         else
             # guardian_remote.yaml exists but is unusable — never skip silently:

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -88,6 +88,15 @@ class GuardianWatchdog:
         self._cc_auth_drift_count: int = 0
         self._cc_auth_escalated: bool = False
         self._cc_token_expiry_warned: bool = False
+        # systemd-linger health: alert when linger is disabled (user timers die
+        # silently on next logout). Two INDEPENDENT legs with separate episode
+        # state — host (read from the gateway version payload) and container (a
+        # local loginctl probe). Alert-only: enable-linger is privileged +
+        # interactive, so there is no safe non-interactive remediation this ship.
+        self._host_linger_drift_count: int = 0
+        self._host_linger_escalated: bool = False
+        self._container_linger_drift_count: int = 0
+        self._container_linger_escalated: bool = False
 
     async def _alert_user(self, *, topic: str, context: str, source_id: str) -> None:
         """Deliver a user-facing (Telegram) alert about a Guardian degradation.
@@ -152,6 +161,15 @@ class GuardianWatchdog:
         # Drift detection runs regardless of health status — its purpose is
         # to catch stale host code even when Guardian appears healthy.
         await self._check_code_drift()
+
+        # Container-local systemd-linger health — runs on EVERY tick, deliberately
+        # NOT inside _check_code_drift: a purely-local probe must not be disabled
+        # by a feature-branch checkout, a missing update baseline, or a down host
+        # (all of which early-return in the drift path). Own suppress so a probe
+        # failure can't perturb recovery below.
+        import contextlib
+        with contextlib.suppress(Exception):
+            await self._check_container_linger()
 
         result = await probe_guardian(guardian_remote=self._remote)
 
@@ -358,6 +376,11 @@ class GuardianWatchdog:
         # suppress so a failure here can't skip code-drift logic below.
         with contextlib.suppress(Exception):
             await self._check_cc_auth(version_info)
+
+        # Host systemd-linger health reconciler reuses the same version() payload.
+        # Own suppress so a failure here can't skip the code-drift logic below.
+        with contextlib.suppress(Exception):
+            await self._check_host_linger(version_info)
 
         host_hash = version_info.get("deployed_commit", "unknown")
 
@@ -787,6 +810,138 @@ class GuardianWatchdog:
         """
         self._cc_auth_drift_count = 0
         self._cc_auth_escalated = False
+
+    def _reset_host_linger_state(self) -> None:
+        """Re-arm the host-linger episode on confirmed health."""
+        self._host_linger_drift_count = 0
+        self._host_linger_escalated = False
+
+    def _reset_container_linger_state(self) -> None:
+        """Re-arm the container-linger episode on confirmed health."""
+        self._container_linger_drift_count = 0
+        self._container_linger_escalated = False
+
+    async def _check_host_linger(self, version_info: dict) -> None:
+        """Alert when the HOST guardian user's systemd linger is disabled.
+
+        Linger keeps the host user's timers/services (incl. the guardian's own
+        units) alive after logout; disabled, they die silently on the next host
+        logout. The ``version`` verb reports ``host_linger`` (True/False/None):
+
+        * key absent (old gateway) -> skip, nothing to reconcile.
+        * True -> healthy; reset the episode.
+        * None -> probe error / ambiguous; never false-alarm AND never clear a
+          real disabled streak (mirrors _check_cc_auth's None handling).
+        * False (Linger=no) for DRIFT_ALERT_THRESHOLD ticks -> one alert/episode.
+
+        Alert-only — ``loginctl enable-linger`` is privileged + interactive, so
+        there is no safe non-interactive remediation. Best-effort (invoked under
+        _check_code_drift's suppress).
+        """
+        if "host_linger" not in version_info:
+            return  # old gateway without the field — nothing to reconcile
+        linger = version_info.get("host_linger")  # True / False / None
+        if linger is True:
+            if self._host_linger_drift_count > 0:
+                logger.info("Guardian host linger re-enabled")
+            self._reset_host_linger_state()
+            return
+        if linger is not False:
+            # None -> ambiguous/probe error: never false-alarm, never clear.
+            return
+        # linger is False -> genuinely disabled.
+        self._host_linger_drift_count += 1
+        if self._host_linger_drift_count < self.DRIFT_ALERT_THRESHOLD:
+            return
+        await self._escalate_host_linger()
+
+    async def _check_container_linger(self) -> None:
+        """Alert when the CONTAINER user's systemd linger is disabled.
+
+        Dispatched from check_and_recover on EVERY tick (not the drift path), so
+        this purely-local check survives a feature-branch checkout / down host.
+        If linger is disabled here, genesis-server itself dies on the next
+        logout. Probes the local logind over the SYSTEM bus (no login shell / no
+        PATH dependence). Fail-safe: any probe error -> treat as unknown (never
+        false-alarm, never clear a real streak). Alert-only (enable-linger is
+        privileged + interactive).
+        """
+        import asyncio
+        import getpass
+
+        user = getpass.getuser()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "loginctl", "show-user", user, "--property=Linger",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except Exception:
+            # loginctl missing / bus unreachable / timeout -> unknown; never
+            # false-alarm, and leave the drift streak untouched.
+            return
+        value = out.decode(errors="replace").strip()
+        if value == "Linger=yes":
+            if self._container_linger_drift_count > 0:
+                logger.info("Container linger re-enabled")
+            self._reset_container_linger_state()
+            return
+        if value != "Linger=no":
+            # Unexpected output / no user record -> ambiguous; never false-alarm.
+            return
+        # Linger=no -> genuinely disabled.
+        self._container_linger_drift_count += 1
+        if self._container_linger_drift_count < self.DRIFT_ALERT_THRESHOLD:
+            return
+        await self._escalate_container_linger(user)
+
+    async def _escalate_host_linger(self) -> None:
+        """One host-linger ALERT per episode (re-armed by _reset_host_linger_state)."""
+        if self._host_linger_escalated:
+            return
+        self._host_linger_escalated = True
+        msg = (
+            "Guardian HOST systemd linger is DISABLED — the host user's timers "
+            "and services (including the guardian's own units) will die silently "
+            "on the next host logout. Re-enable it on the host: "
+            "`sudo loginctl enable-linger <guardian-user>` (or re-run the installer)."
+        )
+        logger.error(msg)
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.ERROR,
+                "guardian.host_linger_disabled", msg,
+            )
+        await self._alert_user(
+            topic="Guardian host linger disabled",
+            context=msg,
+            source_id="guardian:host_linger_disabled",
+        )
+
+    async def _escalate_container_linger(self, user: str) -> None:
+        """One container-linger ALERT per episode (re-armed on health)."""
+        if self._container_linger_escalated:
+            return
+        self._container_linger_escalated = True
+        msg = (
+            f"Container systemd linger is DISABLED for '{user}' — genesis-server "
+            "and all Genesis user timers will die silently on the next logout. "
+            f"Re-enable it: `sudo loginctl enable-linger {user}`."
+        )
+        logger.error(msg)
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.GUARDIAN, Severity.ERROR,
+                "guardian.container_linger_disabled", msg,
+            )
+        await self._alert_user(
+            topic="Container linger disabled",
+            context=msg,
+            source_id="guardian:container_linger_disabled",
+        )
 
     async def _check_cc_auth(self, version_info: dict) -> None:
         """Alert when the host CC recovery brain cannot authenticate.

--- a/tests/test_guardian/test_gateway_reharden.py
+++ b/tests/test_guardian/test_gateway_reharden.py
@@ -256,3 +256,14 @@ class TestOptionsDivergenceGuardrail:
 
     def test_gateway_and_installer_opts_identical(self):
         assert self._extract(GATEWAY) == self._extract(INSTALLER)
+
+
+def test_version_reports_host_linger_tristate(sandbox):
+    """host_linger is always emitted as a JSON true/false/null literal — `null`
+    (never a bogus `false`) when loginctl can't be probed. Environment-robust:
+    asserts the field is present and well-formed regardless of logind state."""
+    res = _run(sandbox, "version")
+    assert res.returncode == 0, res.stderr
+    payload = json.loads(res.stdout)
+    assert "host_linger" in payload
+    assert payload["host_linger"] in (True, False, None)

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -1047,3 +1047,153 @@ class TestCCAuthReconciler:
         for _ in range(_THRESHOLD):
             await wd._check_cc_auth(_cc_vi(False))
         assert _alert_source_ids(outreach).count("guardian:cc_auth_unhealthy") == 2
+
+
+# ─────────────────────────── F4-linger reconcilers ───────────────────────────
+def _host_linger_vi(linger):
+    """A version() payload carrying just host_linger (or 'absent' = old gateway)."""
+    if linger == "absent":
+        return {"cc_version": "1.2.3"}  # no host_linger key
+    return {"host_linger": linger}
+
+
+def _loginctl_returning(output: bytes):
+    """Replacement for asyncio.create_subprocess_exec yielding a fake proc whose
+    communicate() returns the given loginctl stdout."""
+    async def _fake(*_a, **_k):
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(output, b""))
+        return proc
+    return _fake
+
+
+async def _raise_exec(*_a, **_k):
+    raise OSError("loginctl unavailable")
+
+
+class TestHostLingerReconciler:
+    """Host systemd-linger health, read from the gateway version payload."""
+
+    @pytest.mark.asyncio
+    async def test_old_gateway_no_field_skips(self):
+        wd, _, eb, outreach = _cc_watchdog()
+        await wd._check_host_linger(_host_linger_vi("absent"))
+        outreach.submit_raw.assert_not_called()
+        eb.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_is_silent(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD + 2):
+            await wd._check_host_linger(_host_linger_vi(True))
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_none_never_alarms(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD + 3):
+            await wd._check_host_linger(_host_linger_vi(None))
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_alerts_at_threshold_once(self):
+        wd, _, eb, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD - 1):
+            await wd._check_host_linger(_host_linger_vi(False))
+        outreach.submit_raw.assert_not_called()
+        await wd._check_host_linger(_host_linger_vi(False))
+        ids = _alert_source_ids(outreach)
+        assert ids.count("guardian:host_linger_disabled") == 1
+        assert any("host_linger_disabled" in e for e in _emitted_events(eb))
+        await wd._check_host_linger(_host_linger_vi(False))  # still 1/episode
+        assert _alert_source_ids(outreach).count("guardian:host_linger_disabled") == 1
+
+    @pytest.mark.asyncio
+    async def test_alert_text_names_enable_linger(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD):
+            await wd._check_host_linger(_host_linger_vi(False))
+        msg = outreach.submit_raw.call_args.args[0]
+        assert "enable-linger" in msg
+
+    @pytest.mark.asyncio
+    async def test_recovery_rearms(self):
+        wd, _, _, outreach = _cc_watchdog()
+        for _ in range(_THRESHOLD):
+            await wd._check_host_linger(_host_linger_vi(False))
+        assert _alert_source_ids(outreach).count("guardian:host_linger_disabled") == 1
+        await wd._check_host_linger(_host_linger_vi(True))  # recovered → reset
+        for _ in range(_THRESHOLD):
+            await wd._check_host_linger(_host_linger_vi(False))
+        assert _alert_source_ids(outreach).count("guardian:host_linger_disabled") == 2
+
+
+class TestContainerLingerReconciler:
+    """Container-local systemd-linger health via a local loginctl probe."""
+
+    @pytest.mark.asyncio
+    async def test_enabled_is_silent(self):
+        wd, _, _, outreach = _cc_watchdog()
+        with patch("asyncio.create_subprocess_exec",
+                   new=_loginctl_returning(b"Linger=yes\n")):
+            for _ in range(_THRESHOLD + 2):
+                await wd._check_container_linger()
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_alerts_at_threshold_once(self):
+        wd, _, eb, outreach = _cc_watchdog()
+        with patch("asyncio.create_subprocess_exec",
+                   new=_loginctl_returning(b"Linger=no\n")):
+            for _ in range(_THRESHOLD - 1):
+                await wd._check_container_linger()
+            outreach.submit_raw.assert_not_called()
+            await wd._check_container_linger()
+        ids = _alert_source_ids(outreach)
+        assert ids.count("guardian:container_linger_disabled") == 1
+        assert any("container_linger_disabled" in e for e in _emitted_events(eb))
+
+    @pytest.mark.asyncio
+    async def test_probe_error_never_alarms(self):
+        wd, _, _, outreach = _cc_watchdog()
+        with patch("asyncio.create_subprocess_exec", new=_raise_exec):
+            for _ in range(_THRESHOLD + 3):
+                await wd._check_container_linger()
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_output_never_alarms(self):
+        wd, _, _, outreach = _cc_watchdog()
+        with patch("asyncio.create_subprocess_exec",
+                   new=_loginctl_returning(b"")):  # no user record
+            for _ in range(_THRESHOLD + 3):
+                await wd._check_container_linger()
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_alert_names_user_and_remedy(self):
+        wd, _, _, outreach = _cc_watchdog()
+        with patch("getpass.getuser", return_value="testuser"), \
+                patch("asyncio.create_subprocess_exec",
+                      new=_loginctl_returning(b"Linger=no\n")):
+            for _ in range(_THRESHOLD):
+                await wd._check_container_linger()
+        msg = outreach.submit_raw.call_args.args[0]
+        assert "testuser" in msg and "enable-linger" in msg
+
+    @pytest.mark.asyncio
+    async def test_recovery_rearms(self):
+        wd, _, _, outreach = _cc_watchdog()
+        with patch("asyncio.create_subprocess_exec",
+                   new=_loginctl_returning(b"Linger=no\n")):
+            for _ in range(_THRESHOLD):
+                await wd._check_container_linger()
+        assert _alert_source_ids(outreach).count("guardian:container_linger_disabled") == 1
+        with patch("asyncio.create_subprocess_exec",
+                   new=_loginctl_returning(b"Linger=yes\n")):
+            await wd._check_container_linger()  # recovered → reset
+        with patch("asyncio.create_subprocess_exec",
+                   new=_loginctl_returning(b"Linger=no\n")):
+            for _ in range(_THRESHOLD):
+                await wd._check_container_linger()
+        assert _alert_source_ids(outreach).count("guardian:container_linger_disabled") == 2

--- a/tests/test_scripts/test_cc_align_host.py
+++ b/tests/test_scripts/test_cc_align_host.py
@@ -145,3 +145,17 @@ def test_timer_script_sources_shared_aligner_and_self_guards():
 def test_timer_script_parses_clean():
     res = subprocess.run(["bash", "-n", str(ALIGN_SH)], capture_output=True, text=True)
     assert res.returncode == 0, res.stderr
+
+
+def test_install_sh_enables_timers_generically():
+    """install.sh must enable timers via a GENERIC loop over the timer templates
+    (mirrors bootstrap.sh), not a hardcoded per-timer list — otherwise a newly
+    added timer like genesis-cc-align is left rendered-but-dead in the fresh
+    install path (the exact gap Codex caught on PR #1025)."""
+    txt = (REPO_ROOT / "scripts" / "install.sh").read_text()
+    assert 'for template in "$SYSTEMD_TEMPLATE_DIR"/*.timer.template' in txt, (
+        "install.sh must enable rendered timers with a generic loop over the "
+        "timer templates, not a hardcoded per-timer enable list"
+    )
+    # backup stays a deliberate opt-in setup step — never auto-enabled here.
+    assert "genesis-backup.timer) continue" in txt

--- a/tests/test_scripts/test_cc_align_host.py
+++ b/tests/test_scripts/test_cc_align_host.py
@@ -1,0 +1,147 @@
+"""Behavioral tests for the shared host-alignment function cc_align_host_sync
+(scripts/lib/cc_version.sh) and the nightly timer entrypoint scripts/cc_align_host.sh.
+
+cc_align_host_sync was factored OUT of update.sh's _sync_deploy_targets so the
+nightly genesis-cc-align timer and update.sh run the IDENTICAL host CC/Node
+alignment. The drift→update-cc/update-node logic previously had no direct
+behavioral test (only the config-unreadable path and structural greps in
+test_update_host_sync.py), so it is covered here: the function is sourced from
+the REAL cc_version.sh and driven with a stubbed ``ssh`` on PATH that records
+its calls, so the logic under test is the shipped code.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CC_ENV = REPO_ROOT / "scripts" / "lib" / "cc_version.sh"
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+ALIGN_SH = REPO_ROOT / "scripts" / "cc_align_host.sh"
+
+
+def _pins() -> tuple[str, str]:
+    """The repo CC + Node pins (read from cc_version.sh so the tests track a
+    pin bump instead of hardcoding a version that goes stale)."""
+    out = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'unset CC_VERSION NODE_MAJOR; source "{CC_ENV}"; '
+            'printf "%s\\n%s\\n" "$CC_VERSION" "$NODE_MAJOR"',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert out.returncode == 0, out.stderr
+    cc, node = out.stdout.split()
+    return cc, node
+
+
+def _run_align(host_ver_raw: str, tmp_path, ssh_rc: int = 0):
+    """Source cc_version.sh and invoke cc_align_host_sync with a stub ``ssh`` on
+    PATH (records its args to a file, exits ssh_rc). Returns (proc, ssh_calls)."""
+    bind = tmp_path / "bin"
+    bind.mkdir(exist_ok=True)
+    record = tmp_path / "ssh_calls.txt"
+    ssh_stub = bind / "ssh"
+    ssh_stub.write_text(
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> '{record}'\nexit {ssh_rc}\n"
+    )
+    ssh_stub.chmod(0o755)
+    harness = (
+        f'export PATH="{bind}:$PATH"\n'
+        "unset CC_VERSION NODE_MAJOR\n"
+        f'source "{CC_ENV}"\n'
+        'HOST_CC_DEGRADED=""\n'
+        "cc_align_host_sync 'opuser' '192.0.2.7' '/nonexistent/key' "
+        f"{shlex.quote(host_ver_raw)}\n"
+        'echo "RC=$?"\n'
+        'echo "DEGRADED=$HOST_CC_DEGRADED"\n'
+    )
+    proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=60)
+    calls = record.read_text() if record.exists() else ""
+    return proc, calls
+
+
+def _vi(cc: str, node_major: str) -> str:
+    return f'{{"cc_version": "{cc} (Claude Code)", "node_version": "v{node_major}.0.0"}}'
+
+
+def test_aligned_host_issues_no_ssh(tmp_path):
+    cc, node = _pins()
+    proc, calls = _run_align(_vi(cc, node), tmp_path)
+    assert "RC=0" in proc.stdout, proc.stdout
+    assert "update-cc" not in calls and "update-node" not in calls, calls
+    assert "DEGRADED=\n" in proc.stdout or proc.stdout.rstrip().endswith("DEGRADED=")
+
+
+def test_cc_drift_issues_update_cc(tmp_path):
+    cc, node = _pins()
+    proc, calls = _run_align(_vi("0.0.1", node), tmp_path)
+    assert f"update-cc {cc}" in calls, calls
+    assert "update-node" not in calls, calls
+    assert proc.stdout.rstrip().endswith("DEGRADED=")  # success → no degrade
+
+
+def test_node_drift_issues_update_node(tmp_path):
+    cc, node = _pins()
+    proc, calls = _run_align(_vi(cc, "1"), tmp_path)
+    assert f"update-node {node}" in calls, calls
+
+
+def test_cc_absent_installs_pin(tmp_path):
+    cc, node = _pins()
+    proc, calls = _run_align(_vi("unavailable", node), tmp_path)
+    assert f"update-cc {cc}" in calls, calls
+
+
+def test_ssh_failure_marks_degraded(tmp_path):
+    cc, node = _pins()
+    proc, calls = _run_align(_vi("0.0.1", node), tmp_path, ssh_rc=1)
+    assert "DEGRADED=" in proc.stdout
+    degraded = proc.stdout.split("DEGRADED=", 1)[1].strip()
+    assert "guardian_host_cc" in degraded, proc.stdout
+    assert "RC=0" in proc.stdout  # non-fatal contract: always returns 0
+
+
+def test_unreachable_marks_degraded_and_issues_no_ssh(tmp_path):
+    proc, calls = _run_align("", tmp_path)
+    degraded = proc.stdout.split("DEGRADED=", 1)[1].strip()
+    assert degraded == "guardian_host_unreachable", proc.stdout
+    assert calls == "", calls  # no probe when the host is unreachable
+    assert "RC=0" in proc.stdout
+
+
+def test_always_returns_zero_on_node_failure(tmp_path):
+    """Non-fatal by contract even when a sync fails — a host hiccup must never
+    abort the calling update run under set -e."""
+    cc, node = _pins()
+    proc, _ = _run_align(_vi(cc, "1"), tmp_path, ssh_rc=1)
+    assert "RC=0" in proc.stdout, proc.stdout
+
+
+def test_update_sh_delegates_to_shared_aligner():
+    """update.sh must call the shared aligner, not re-inline host sync — the
+    whole point of the factoring is that the timer and update.sh cannot diverge."""
+    assert "cc_align_host_sync " in UPDATE_SH.read_text(), (
+        "update.sh must delegate host CC/Node alignment to cc_align_host_sync"
+    )
+
+
+def test_timer_script_sources_shared_aligner_and_self_guards():
+    """The timer must source the shared aligner (not duplicate the logic), guard
+    against concurrent runs, and reset the degraded accumulator before use."""
+    txt = ALIGN_SH.read_text()
+    assert "cc_align_host_sync " in txt, "timer must call the shared aligner"
+    assert "flock -n" in txt, "timer must single-flight to avoid concurrent update-cc"
+    assert 'HOST_CC_DEGRADED=""' in txt, "timer must init the degraded accumulator (set -u)"
+    assert "unset CC_VERSION NODE_MAJOR" in txt, "timer must let the repo pin win"
+
+
+def test_timer_script_parses_clean():
+    res = subprocess.run(["bash", "-n", str(ALIGN_SH)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr


### PR DESCRIPTION
Tier-2 guardian/infra closers — two low-risk, additive, alert-only/idempotent changes that prevent silent host drift (the class that has bitten before, where the guardian's recovery brain goes dark and is only noticed mid-incident).

## G3 — nightly host CC/Node pin-alignment timer
Host CC/Node re-alignment currently runs ONLY when `scripts/update.sh` is invoked, so a repo pin bump leaves the host guardian's `claude -p` recovery brain lagging the pin until the next manual update.

- Factored the host-sync logic out of `update.sh`'s `_sync_deploy_targets` into a shared `cc_align_host_sync()` in `lib/cc_version.sh` (update.sh delegates; net −57 lines). It **mutates the existing `HOST_CC_DEGRADED` global** (append pattern) — preserving update.sh's exact accumulation semantics — and is non-fatal by contract (always returns 0, called `|| true`).
- New `scripts/cc_align_host.sh` timer entrypoint + host-only systemd templates (`genesis-cc-align.{service,timer}`). Host-only by design: it only issues gateway SSH calls, so it needs no local sudo and is safe under `NoNewPrivileges` + `ProtectSystem=strict`.
- `flock -n` single-flight guard against overlapping timer runs; a genuine heal failure exits non-zero (unit enters `failed`, visible in `systemctl status`); a merely-unreachable host is not a timer failure.
- The container's own CC is already aligned on every update.sh run, so there is no container leg.

## F4 — runtime systemd-linger health signal (host + container)
systemd linger is enabled once at install; nothing verifies it at runtime. If it is ever disabled, this user's timers/services die silently on the next logout — host-side that kills the guardian's units, container-side it kills genesis-server itself.

- Gateway `version` op emits a **fail-safe `host_linger` tri-state** (true/false/null) — `null` (never a bogus `false`) on any `loginctl` probe error.
- Two INDEPENDENT reconciler legs (mirroring the shipped CC-auth signal), separate episode state, distinct alert topics, alert-only (no privileged actuator this ship):
  - **host leg** reads `host_linger` from the version payload (old gateway without the field → skip; `None` → never false-alarm).
  - **container leg** runs a LOCAL `loginctl` probe, dispatched from `check_and_recover` on **every** tick — deliberately NOT behind the code-drift/branch/host-reachability early-returns, so a feature-branch checkout or a down host can't silence a purely-local check.

## Verification
- 154 targeted tests pass, including `test_update_host_sync.py` (the guard for the exact logic factored) staying green, new `test_cc_align_host.py` (drift→update-cc/update-node behavioral coverage), and `TestHostLingerReconciler` + `TestContainerLingerReconciler`. ruff / shellcheck / `bash -n` clean.
- Live E2E: gateway emits `host_linger=true`; `cc_align_host.sh` no-op-aligns the real host and exits 0; flock skips a concurrent run; reconcilers behave correctly against real `loginctl`; templates render clean.
- Genesis-architect design review pre-build (container-leg placement + timer failure surfacing fixed).

## Deploy note
Touches host-deployed paths (`guardian-gateway.sh`, `update.sh`, `lib/cc_version.sh`, systemd templates) → **Host-Deploy Gate applies**: after merge, `scripts/update.sh` on the guardian machines, then confirm the gateway reports `host_linger` and `genesis-cc-align.timer` is `active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)