### PR TITLE
fix(outreach): clear NULL-id pending_outreach churn loop

### DIFF
--- a/src/genesis/db/crud/pending_outreach.py
+++ b/src/genesis/db/crud/pending_outreach.py
@@ -37,8 +37,17 @@ async def enqueue(
            (id, message, category, channel, urgency, deliver_after, created_at,
             thread_id, validated_recipient)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (pending_id, message, category, channel, urgency, deliver_after, now,
-         thread_id, validated_recipient),
+        (
+            pending_id,
+            message,
+            category,
+            channel,
+            urgency,
+            deliver_after,
+            now,
+            thread_id,
+            validated_recipient,
+        ),
     )
     await db.commit()
     return pending_id
@@ -49,9 +58,17 @@ async def drain(
     *,
     now: str,
 ) -> list[dict]:
-    """Fetch undelivered messages ready for delivery (max 20 per cycle)."""
+    """Fetch undelivered messages ready for delivery (max 20 per cycle).
+
+    Exposes the always-present ``rowid`` alongside the columns so a row whose
+    ``id`` is NULL (legacy rows inserted before ``enqueue`` set a uuid) can
+    still be marked delivered by rowid — otherwise ``mark_delivered`` matches
+    ``WHERE id = NULL`` (zero rows), the row never clears, and it is
+    re-drained every cycle forever (a churn/log-noise loop the 24h age-out
+    could not break because the age-out drop *is* a ``mark_delivered`` call).
+    """
     cursor = await db.execute(
-        """SELECT * FROM pending_outreach
+        """SELECT rowid AS rowid, * FROM pending_outreach
            WHERE delivered = 0
              AND (deliver_after IS NULL OR deliver_after <= ?)
            ORDER BY created_at ASC
@@ -67,10 +84,29 @@ async def mark_delivered(
     *,
     delivered_at: str,
 ) -> bool:
-    """Mark a pending message as delivered."""
+    """Mark a pending message as delivered by its ``id`` primary key."""
     cursor = await db.execute(
         "UPDATE pending_outreach SET delivered = 1, delivered_at = ? WHERE id = ?",
         (delivered_at, pending_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def mark_delivered_by_rowid(
+    db: aiosqlite.Connection,
+    rowid: int,
+    *,
+    delivered_at: str,
+) -> bool:
+    """Mark a pending message as delivered by ``rowid``.
+
+    Fallback for rows with a NULL ``id`` (see ``drain``). ``rowid`` is always
+    present and unique, so this always targets exactly the intended row.
+    """
+    cursor = await db.execute(
+        "UPDATE pending_outreach SET delivered = 1, delivered_at = ? WHERE rowid = ?",
+        (delivered_at, rowid),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0056_pending_outreach_null_id_backfill.py
+++ b/src/genesis/db/migrations/0056_pending_outreach_null_id_backfill.py
@@ -1,0 +1,45 @@
+"""Backfill NULL ``id`` rows in ``pending_outreach`` and clear the churn loop.
+
+SQLite allows NULL in a ``TEXT PRIMARY KEY``, so legacy rows inserted before
+``enqueue`` began stamping a uuid have ``id = NULL``. The drain job marks
+delivery with ``WHERE id = ?`` → ``WHERE id = NULL`` matches zero rows, so such
+a row never clears: every cycle it is re-drained, re-processed, and re-logged
+("aged out … dropping") forever. The 24h age-out cap can't break the loop
+because the cap's own drop *is* a ``mark_delivered`` call.
+
+The CRUD fix (drain exposes ``rowid``; ``mark_delivered_by_rowid``) stops new
+occurrences, but existing NULL-id rows must be reconciled once. Give each a
+deterministic synthetic id and mark it delivered — these are, by definition,
+legacy rows (the sanctioned insert path has stamped a uuid for months), so
+dropping their (long-stale) delivery is correct.
+
+Guarded ``WHERE id IS NULL`` → idempotent. No commit — the runner owns the
+transaction.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aiosqlite
+
+
+async def _has_table(db: aiosqlite.Connection, name: str) -> bool:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    )
+    return await cursor.fetchone() is not None
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    if not await _has_table(db, "pending_outreach"):
+        return
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        "UPDATE pending_outreach "
+        "SET id = 'nullid-backfill-' || rowid, "
+        "    delivered = 1, "
+        "    delivered_at = COALESCE(delivered_at, ?) "
+        "WHERE id IS NULL",
+        (now,),
+    )

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -18,11 +18,19 @@ logger = logging.getLogger(__name__)
 
 # Discord sub-channel names used by campaign sessions in pending_outreach.
 # The outreach pipeline routes via adapter name ("discord"), not sub-channel.
-_DISCORD_CHANNELS = frozenset({
-    "announcements", "dev-discussion", "general", "showcase",
-    "getting-started", "design", "bug-reports", "feature-requests",
-    "troubleshooting",
-})
+_DISCORD_CHANNELS = frozenset(
+    {
+        "announcements",
+        "dev-discussion",
+        "general",
+        "showcase",
+        "getting-started",
+        "design",
+        "bug-reports",
+        "feature-requests",
+        "troubleshooting",
+    }
+)
 
 
 class OutreachScheduler:
@@ -148,9 +156,13 @@ class OutreachScheduler:
             replace_existing=True,
         )
         self._scheduler.start()
-        logger.info("OutreachScheduler started (morning=%s:%s %s, engagement=%dm, health=30m, drain=5m, critical_obs=5m)",
-                     hour, minute, tz,
-                     self._config.engagement_poll_minutes)
+        logger.info(
+            "OutreachScheduler started (morning=%s:%s %s, engagement=%dm, health=30m, drain=5m, critical_obs=5m)",
+            hour,
+            minute,
+            tz,
+            self._config.engagement_poll_minutes,
+        )
 
     async def stop(self) -> None:
         if self._scheduler:
@@ -168,8 +180,10 @@ class OutreachScheduler:
                 from genesis.observability.types import Severity, Subsystem
 
                 await self._event_bus.emit(
-                    Subsystem.OUTREACH, Severity.ERROR,
-                    f"{name}.failed", f"Scheduled job {name} failed: {error}",
+                    Subsystem.OUTREACH,
+                    Severity.ERROR,
+                    f"{name}.failed",
+                    f"Scheduled job {name} failed: {error}",
                 )
         else:
             rt.record_job_success(name)
@@ -178,14 +192,17 @@ class OutreachScheduler:
                 from genesis.observability.types import Severity, Subsystem
 
                 await self._event_bus.emit(
-                    Subsystem.OUTREACH, Severity.DEBUG,
-                    "heartbeat", f"{name} completed",
+                    Subsystem.OUTREACH,
+                    Severity.DEBUG,
+                    "heartbeat",
+                    f"{name} completed",
                 )
 
     @staticmethod
     def _is_paused() -> bool:
         try:
             from genesis.runtime import GenesisRuntime
+
             return GenesisRuntime.instance().paused
         except Exception:
             return False
@@ -290,9 +307,8 @@ class OutreachScheduler:
             from datetime import datetime
 
             from genesis.outreach.health_outreach import HealthOutreachBridge
-            escalation_ids = frozenset(
-                self._config.immediate_escalation_alerts
-            )
+
+            escalation_ids = frozenset(self._config.immediate_escalation_alerts)
             bridge = HealthOutreachBridge(self._db, escalation_ids=escalation_ids)
             requests = await bridge.check_and_generate()
 
@@ -304,6 +320,7 @@ class OutreachScheduler:
             # This is the primary dedup layer; the DB query in
             # HealthOutreachBridge is the secondary (cross-restart) layer.
             from genesis.outreach.health_outreach import _DEDUP_HOURS
+
             dedup_window_s = _DEDUP_HOURS * 3600
             now_mono = time.monotonic()
             deduped = []
@@ -355,7 +372,8 @@ class OutreachScheduler:
             result = await self._pipeline.submit_raw(batched_text, envelope)
             logger.info(
                 "Health outreach (batched %d alert(s)): %s",
-                len(requests), result.status.value,
+                len(requests),
+                result.status.value,
             )
             # Record send time in memory — regardless of whether DB
             # write succeeded. This prevents re-send on next cycle.
@@ -407,7 +425,8 @@ class OutreachScheduler:
                 if self._cached_critical_obs and cache_age < _MAX_CACHE_AGE_S:
                     logger.warning(
                         "Critical obs DB query failed — using cache (%d items, %.0fs old)",
-                        len(self._cached_critical_obs), cache_age,
+                        len(self._cached_critical_obs),
+                        cache_age,
                     )
                     observations = self._cached_critical_obs
                 else:
@@ -421,17 +440,14 @@ class OutreachScheduler:
             # In-memory dedup — filter out observations already alerted recently
             # (protects against mark_surfaced DB failure causing repeat alerts)
             import time
+
             now_mono = time.monotonic()
             dedup_window = 30 * 60  # 30 minutes
             # Evict expired entries
             self._critical_obs_sent = {
-                k: v for k, v in self._critical_obs_sent.items()
-                if (now_mono - v) < dedup_window
+                k: v for k, v in self._critical_obs_sent.items() if (now_mono - v) < dedup_window
             }
-            observations = [
-                obs for obs in observations
-                if obs["id"] not in self._critical_obs_sent
-            ]
+            observations = [obs for obs in observations if obs["id"] not in self._critical_obs_sent]
             if not observations:
                 await self._record_job_result("critical_observations")
                 return
@@ -469,11 +485,13 @@ class OutreachScheduler:
             result = await self._pipeline.submit_raw(batched_text, envelope)
             logger.info(
                 "Critical observations outreach (%d obs): %s",
-                len(observations), result.status.value,
+                len(observations),
+                result.status.value,
             )
 
             # Only mark surfaced if delivery succeeded AND DB is available
             from genesis.outreach.types import OutreachStatus
+
             ids = [obs["id"] for obs in observations]
             if result.status == OutreachStatus.DELIVERED and db_ok:
                 try:
@@ -485,6 +503,7 @@ class OutreachScheduler:
             # In-memory dedup — prevent re-alerting if mark_surfaced fails
             # after delivery, or if delivery was rejected by dedup layer.
             import time
+
             now_mono = time.monotonic()
             for obs_id in ids:
                 self._critical_obs_sent[obs_id] = now_mono
@@ -553,7 +572,9 @@ class OutreachScheduler:
                         source_id=f"ambient_health:{verdict.status}",
                     )
                     result = await self._pipeline.submit_raw(text, envelope)
-                    logger.info("Ambient health alert (%s): %s", verdict.status, result.status.value)
+                    logger.info(
+                        "Ambient health alert (%s): %s", verdict.status, result.status.value
+                    )
                 self._ambient_health_status = verdict.status
                 self._ambient_health_causes = set(verdict.causes)
             elif verdict.status == "ok":
@@ -613,6 +634,30 @@ class OutreachScheduler:
             logger.exception("Calibration job failed")
             await self._record_job_result("calibration", error=str(exc))
 
+    async def _mark_row_delivered(self, row: dict, delivered_at: str) -> None:
+        """Mark a drained row delivered, keying on ``id`` or falling back to
+        ``rowid`` when ``id`` is NULL.
+
+        Legacy rows with a NULL ``id`` would otherwise never clear (``WHERE
+        id = NULL`` matches nothing), so every drain cycle re-processes and
+        re-logs them forever. ``rowid`` is always present, so the fallback
+        always clears the exact row.
+        """
+        from genesis.db.crud import pending_outreach
+
+        if row.get("id") is not None:
+            await pending_outreach.mark_delivered(
+                self._db,
+                row["id"],
+                delivered_at=delivered_at,
+            )
+        else:
+            await pending_outreach.mark_delivered_by_rowid(
+                self._db,
+                row["rowid"],
+                delivered_at=delivered_at,
+            )
+
     async def _drain_pending_job(self) -> None:
         """Drain pending_outreach table — deliver queued messages from foreground sessions."""
         if self._is_paused():
@@ -646,14 +691,11 @@ class OutreachScheduler:
                         except (ValueError, TypeError):
                             age = None
                         if age is not None and age > timedelta(hours=24):
-                            await pending_outreach.mark_delivered(
-                                self._db, row["id"],
-                                delivered_at=datetime.now(UTC).isoformat(),
-                            )
+                            await self._mark_row_delivered(row, datetime.now(UTC).isoformat())
                             logger.warning(
-                                "Pending outreach %s aged out (%.1fh, never "
-                                "delivered) — dropping",
-                                row["id"], age.total_seconds() / 3600,
+                                "Pending outreach %s aged out (%.1fh, never delivered) — dropping",
+                                row.get("id") or f"rowid:{row.get('rowid')}",
+                                age.total_seconds() / 3600,
                             )
                             continue
 
@@ -671,7 +713,8 @@ class OutreachScheduler:
                         if raw_cat not in _CATEGORY_ALIASES:
                             logger.warning(
                                 "Unknown category '%s' in pending outreach %s, using DIGEST",
-                                raw_cat, row["id"],
+                                raw_cat,
+                                row["id"],
                             )
 
                     # Map Discord sub-channel names to adapter name.
@@ -708,22 +751,24 @@ class OutreachScheduler:
                         OutreachStatus.IGNORED,
                     ):
                         delivered_at = datetime.now(UTC).isoformat()
-                        await pending_outreach.mark_delivered(
-                            self._db, row["id"], delivered_at=delivered_at,
-                        )
+                        await self._mark_row_delivered(row, delivered_at)
                         logger.info(
                             "Drained pending outreach %s: %s (terminal)",
-                            row["id"], result.status.value,
+                            row.get("id") or f"rowid:{row.get('rowid')}",
+                            result.status.value,
                         )
                     else:
                         logger.warning(
                             "Pending outreach %s not delivered (%s: %s) — will retry",
-                            row["id"], result.status.value, result.error or "",
+                            row["id"],
+                            result.status.value,
+                            result.error or "",
                         )
                 except Exception:
                     logger.error(
                         "Failed to deliver pending outreach %s — will retry next cycle",
-                        row["id"], exc_info=True,
+                        row["id"],
+                        exc_info=True,
                     )
 
             await self._record_job_result("drain_pending")

--- a/tests/test_db/test_migration_0056_null_id_backfill.py
+++ b/tests/test_db/test_migration_0056_null_id_backfill.py
@@ -1,0 +1,96 @@
+"""Migration 0056 — backfill NULL-id pending_outreach rows + clear the loop.
+
+SQLite permits NULL in a TEXT PRIMARY KEY, so legacy rows (pre-uuid enqueue)
+have id=NULL and can never be marked delivered by id — they re-drain forever.
+The migration gives each a deterministic synthetic id and marks it delivered.
+Idempotent (WHERE id IS NULL); normal rows are untouched.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M56 = importlib.import_module("genesis.db.migrations.0056_pending_outreach_null_id_backfill")
+
+
+async def _build(conn: aiosqlite.Connection) -> None:
+    await conn.execute(
+        """
+        CREATE TABLE pending_outreach (
+            id              TEXT PRIMARY KEY,
+            message         TEXT NOT NULL,
+            category        TEXT NOT NULL,
+            channel         TEXT NOT NULL DEFAULT 'telegram',
+            urgency         TEXT NOT NULL DEFAULT 'low',
+            deliver_after   TEXT,
+            created_at      TEXT NOT NULL,
+            delivered       INTEGER NOT NULL DEFAULT 0,
+            delivered_at    TEXT
+        )
+        """
+    )
+    # Two NULL-id undelivered legacy rows + one normal undelivered row.
+    await conn.execute(
+        "INSERT INTO pending_outreach (message, category, created_at, delivered) "
+        "VALUES ('a', 'alert', '2026-04-20T00:00:00+00:00', 0)"
+    )
+    await conn.execute(
+        "INSERT INTO pending_outreach (message, category, created_at, delivered) "
+        "VALUES ('b', 'alert', '2026-04-21T00:00:00+00:00', 0)"
+    )
+    await conn.execute(
+        "INSERT INTO pending_outreach (id, message, category, created_at, delivered) "
+        "VALUES ('keep', 'c', 'notification', '2026-07-01T00:00:00+00:00', 0)"
+    )
+    await conn.commit()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await _build(conn)
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_backfills_null_ids_and_marks_delivered(db):
+    await M56.up(db)
+
+    cur = await db.execute("SELECT id, delivered FROM pending_outreach WHERE id IS NULL")
+    assert await cur.fetchall() == []  # no NULL ids remain
+
+    cur = await db.execute(
+        "SELECT id, delivered FROM pending_outreach WHERE id LIKE 'nullid-backfill-%' ORDER BY id"
+    )
+    backfilled = await cur.fetchall()
+    assert len(backfilled) == 2
+    assert all(r["delivered"] == 1 for r in backfilled)
+
+    # The normal row is untouched (still undelivered, id intact).
+    cur = await db.execute("SELECT delivered FROM pending_outreach WHERE id = 'keep'")
+    assert (await cur.fetchone())["delivered"] == 0
+
+
+@pytest.mark.asyncio
+async def test_idempotent(db):
+    await M56.up(db)
+    cur = await db.execute(
+        "SELECT id, delivered, delivered_at FROM pending_outreach ORDER BY rowid"
+    )
+    first = [tuple(r) for r in await cur.fetchall()]
+    await M56.up(db)  # second run is a no-op (no NULL ids left)
+    cur = await db.execute(
+        "SELECT id, delivered, delivered_at FROM pending_outreach ORDER BY rowid"
+    )
+    assert [tuple(r) for r in await cur.fetchall()] == first
+
+
+@pytest.mark.asyncio
+async def test_no_table_is_safe(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "empty.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await M56.up(conn)  # must not raise when the table is absent

--- a/tests/test_db/test_pending_outreach.py
+++ b/tests/test_db/test_pending_outreach.py
@@ -49,9 +49,54 @@ async def test_enqueue_persists_thread_and_recipient(db):
 @pytest.mark.asyncio
 async def test_enqueue_defaults_to_none(db):
     await pending_outreach.enqueue(
-        db, message="m", category="notification", channel="telegram",
+        db,
+        message="m",
+        category="notification",
+        channel="telegram",
     )
     rows = await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
     assert len(rows) == 1
     assert rows[0]["thread_id"] is None
     assert rows[0]["validated_recipient"] is None
+
+
+@pytest.mark.asyncio
+async def test_drain_exposes_rowid(db):
+    """drain must surface rowid so NULL-id rows can be cleared by rowid."""
+    await pending_outreach.enqueue(
+        db,
+        message="m",
+        category="notification",
+        channel="telegram",
+    )
+    rows = await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
+    assert len(rows) == 1
+    assert isinstance(rows[0]["rowid"], int)
+
+
+@pytest.mark.asyncio
+async def test_mark_delivered_by_rowid_clears_null_id_row(db):
+    """A NULL-id row can't be marked by id (WHERE id=NULL matches nothing);
+    mark_delivered_by_rowid targets it by its always-present rowid."""
+    await db.execute(
+        "INSERT INTO pending_outreach (message, category, channel, urgency, "
+        "created_at, delivered) VALUES ('m', 'notification', 'telegram', "
+        "'low', '2020-01-01T00:00:00+00:00', 0)",
+    )
+    await db.commit()
+    rows = await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
+    assert len(rows) == 1 and rows[0]["id"] is None
+    rowid = rows[0]["rowid"]
+
+    # id-keyed mark is a no-op on a NULL id; rowid-keyed clears it.
+    assert (
+        await pending_outreach.mark_delivered(db, None, delivered_at="2026-01-01T00:00:00+00:00")
+        is False
+    )
+    assert (
+        await pending_outreach.mark_delivered_by_rowid(
+            db, rowid, delivered_at="2026-01-01T00:00:00+00:00"
+        )
+        is True
+    )
+    assert await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00") == []

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -17,9 +17,13 @@ def config():
         quiet_hours=QuietHours(start="22:00", end="07:00"),
         channel_preferences={"default": "telegram"},
         thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
-        max_daily=5, surplus_daily=1, content_daily=3, notification_daily=10,
+        max_daily=5,
+        surplus_daily=1,
+        content_daily=3,
+        notification_daily=10,
         morning_report_time="07:00",
-        engagement_timeout_hours=24, engagement_poll_minutes=60,
+        engagement_timeout_hours=24,
+        engagement_poll_minutes=60,
     )
 
 
@@ -37,6 +41,7 @@ def test_scheduler_creates(config):
     morning = AsyncMock()
     engagement = AsyncMock()
     import unittest.mock
+
     mock_db = unittest.mock.MagicMock()
     scheduler = OutreachScheduler(pipeline, morning, engagement, config, mock_db)
     assert scheduler is not None
@@ -68,8 +73,11 @@ async def test_morning_report_job(config, db):
     pipeline = AsyncMock()
     morning = AsyncMock()
     morning.generate.return_value = OutreachRequest(
-        category=OutreachCategory.DIGEST, topic="Morning Report",
-        context="Content", salience_score=0.0, signal_type="morning_report",
+        category=OutreachCategory.DIGEST,
+        topic="Morning Report",
+        context="Content",
+        salience_score=0.0,
+        signal_type="morning_report",
     )
     engagement = AsyncMock()
     scheduler = OutreachScheduler(pipeline, morning, engagement, config, db)
@@ -210,7 +218,10 @@ async def test_health_check_single_alert_still_batches(config, db):
 def _drain_pipeline(status):
     pipeline = AsyncMock()
     result = OutreachResult(
-        outreach_id="o", status=status, channel="email", message_content="",
+        outreach_id="o",
+        status=status,
+        channel="email",
+        message_content="",
     )
     pipeline.submit = AsyncMock(return_value=result)
     pipeline.submit_urgent = AsyncMock(return_value=result)
@@ -220,6 +231,7 @@ def _drain_pipeline(status):
 async def _remaining(db):
     """Rows still eligible for the next drain (delivered=0)."""
     from genesis.db.crud import pending_outreach
+
     return await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
 
 
@@ -228,9 +240,14 @@ async def test_drain_reconstructs_request_with_thread_and_recipient(config, db):
     """A queued email row must rebuild an OutreachRequest carrying its thread_id
     + validated_recipient — so _deliver routes to the real recipient, not self."""
     from genesis.db.crud import pending_outreach
+
     await pending_outreach.enqueue(
-        db, message="follow up", category="notification", channel="email",
-        thread_id="t1", validated_recipient="real@prospect.com",
+        db,
+        message="follow up",
+        category="notification",
+        channel="email",
+        thread_id="t1",
+        validated_recipient="real@prospect.com",
     )
     pipeline = _drain_pipeline(OutreachStatus.DELIVERED)
     scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
@@ -248,8 +265,12 @@ async def test_drain_held_is_terminal_not_retried(config, db):
     """HELD = handed off to the gate's approval queue; the queue row is done.
     Re-submitting every cycle is exactly the spam multiplier we are killing."""
     from genesis.db.crud import pending_outreach
+
     await pending_outreach.enqueue(
-        db, message="x", category="notification", channel="email",
+        db,
+        message="x",
+        category="notification",
+        channel="email",
     )
     pipeline = _drain_pipeline(OutreachStatus.HELD)
     scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
@@ -262,8 +283,12 @@ async def test_drain_held_is_terminal_not_retried(config, db):
 @pytest.mark.asyncio
 async def test_drain_ignored_is_terminal(config, db):
     from genesis.db.crud import pending_outreach
+
     await pending_outreach.enqueue(
-        db, message="x", category="notification", channel="email",
+        db,
+        message="x",
+        category="notification",
+        channel="email",
     )
     pipeline = _drain_pipeline(OutreachStatus.IGNORED)
     scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
@@ -277,8 +302,12 @@ async def test_drain_ignored_is_terminal(config, db):
 async def test_drain_rejected_is_retried(config, db):
     """A transient governance rejection (e.g. quiet_hours) stays queued."""
     from genesis.db.crud import pending_outreach
+
     await pending_outreach.enqueue(
-        db, message="x", category="notification", channel="telegram",
+        db,
+        message="x",
+        category="notification",
+        channel="telegram",
     )
     pipeline = _drain_pipeline(OutreachStatus.REJECTED)
     scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
@@ -293,6 +322,7 @@ async def test_drain_ages_out_perpetually_stuck_row(config, db):
     """A row that never reaches a terminal status must be dropped after 24h
     instead of looping forever (the churn that locked the DB)."""
     from datetime import UTC, datetime, timedelta
+
     old = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
     await db.execute(
         "INSERT INTO pending_outreach (id, message, category, channel, urgency, "
@@ -307,7 +337,52 @@ async def test_drain_ages_out_perpetually_stuck_row(config, db):
     await scheduler._drain_pending_job()
 
     pipeline.submit.assert_not_called()  # aged out BEFORE re-submitting
-    assert await _remaining(db) == []    # dropped
+    assert await _remaining(db) == []  # dropped
+
+
+@pytest.mark.asyncio
+async def test_drain_null_id_row_is_cleared_not_looped(config, db):
+    """A legacy NULL-id row must be cleared via the rowid fallback, not
+    re-drained forever. Before the fix, mark_delivered(WHERE id=NULL) matched
+    nothing, so the row (aged out every cycle) never left the queue."""
+    from datetime import UTC, datetime, timedelta
+
+    old = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    # NULL id: omit the id column (SQLite allows NULL in a TEXT PRIMARY KEY).
+    await db.execute(
+        "INSERT INTO pending_outreach (message, category, channel, urgency, "
+        "created_at, delivered) VALUES ('x', 'notification', 'telegram', "
+        "'low', ?, 0)",
+        (old,),
+    )
+    await db.commit()
+    pipeline = _drain_pipeline(OutreachStatus.REJECTED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    assert await _remaining(db) == []  # cleared by rowid, not looping forever
+
+
+@pytest.mark.asyncio
+async def test_drain_null_id_row_delivered_terminal(config, db):
+    """A deliverable NULL-id row reaches a terminal status and clears by rowid."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        "INSERT INTO pending_outreach (message, category, channel, urgency, "
+        "created_at, delivered) VALUES ('x', 'notification', 'telegram', "
+        "'low', ?, 0)",
+        (now,),
+    )
+    await db.commit()
+    pipeline = _drain_pipeline(OutreachStatus.DELIVERED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    assert await _remaining(db) == []  # delivered + marked via rowid fallback
 
 
 @pytest.mark.asyncio
@@ -315,9 +390,8 @@ async def test_drain_ages_out_naive_timestamp_row(config, db):
     """A created_at WITHOUT a tz offset must still age out — a naive timestamp
     must not silently bypass the cap (and loop forever)."""
     from datetime import UTC, datetime, timedelta
-    old_naive = (
-        (datetime.now(UTC) - timedelta(hours=25)).replace(tzinfo=None).isoformat()
-    )
+
+    old_naive = (datetime.now(UTC) - timedelta(hours=25)).replace(tzinfo=None).isoformat()
     assert "+00:00" not in old_naive  # genuinely naive
     await db.execute(
         "INSERT INTO pending_outreach (id, message, category, channel, urgency, "


### PR DESCRIPTION
## Problem
SQLite permits `NULL` in a `TEXT PRIMARY KEY`, so legacy `pending_outreach` rows inserted before `enqueue` began stamping a UUID have `id = NULL`. The drain job marks delivery with `WHERE id = ?` → `WHERE id = NULL` matches zero rows, so such a row never clears: every cycle it is re-drained, re-processed, and re-logged (`aged out … dropping`) forever. The 24h age-out cap can't break the loop because the cap's own drop *is* a `mark_delivered` call.

## Fix
- `drain()` now surfaces `rowid`; new `mark_delivered_by_rowid` clears a row by its always-present rowid.
- Scheduler falls back to the rowid path at both mark sites (age-out + delivered).
- Idempotent migration `0056` backfills existing NULL-id rows with a deterministic synthetic id and marks them delivered (these are, by definition, long-stale legacy rows).

## Tests
28 targeted tests (crud round-trip, scheduler both paths, migration idempotency + no-table safety). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)