### PR TITLE
fix(runtime): reaper arms only on explicit operator opt-in

### DIFF
--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -19,11 +19,12 @@ old rule wrongly killed (the 2026-07-11 incident: interactive sessions
 killed 77 min after they went quiet).
 
 Ships in DRY-RUN by default: it logs ``WOULD KILL`` and writes an
-observation but never signals a process. After a clean observation window
-(``_DRY_RUN_ARM_AFTER_SECS``) with the job running successfully, it
-auto-arms and sends the owner a Telegram summary (with disable
-instructions). State persists in a human-editable JSON file so the owner
-can force dry-run back by hand or a hard env kill-switch can veto arming.
+observation but never signals a process. It arms ONLY on an explicit
+operator opt-in — ``"armed_by_operator": true`` in the state JSON (set via
+``set_operator_armed``) or ``GENESIS_REAPER_ARMED=1`` in the environment.
+There is no automatic time-based arming: a human reviews the dry-run
+WOULD-KILL log and deliberately flips the switch. A hard env kill-switch
+(``GENESIS_REAPER_KILL_DISABLED``) forces dry-run regardless of the flag.
 """
 
 from __future__ import annotations
@@ -45,7 +46,6 @@ logger = logging.getLogger("genesis.runtime")
 # ── Policy constants ────────────────────────────────────────────────────
 _CLAUDE_AGE_FLOOR_SECS = 168 * 3600  # 7d — floor before a claude proc is even considered
 _CLAUDE_IDLE_WINDOW_SECS = 168 * 3600  # 7d — "active within" window (marker freshness)
-_DRY_RUN_ARM_AFTER_SECS = 3 * 86400  # arm after 3 clean dry-run days
 _KILL_GRACE_SECS = 5  # SIGTERM → SIGKILL grace (browsers flush SQLite)
 
 _GENESIS_DIR = Path.home() / ".genesis"
@@ -55,6 +55,13 @@ _STATE_PATH = _GENESIS_DIR / "reaper_state.json"
 # Hard kill-switch: when set (to a truthy value) the reaper can never arm —
 # it stays in dry-run regardless of persisted state. Owner's emergency brake.
 _ENV_HARD_DISABLE = "GENESIS_REAPER_KILL_DISABLED"
+
+# Operator opt-in to actually reap (env alternative to the state-file flag).
+# Absent both → dry-run. The reaper never arms itself; a human flips this.
+_ENV_ARM = "GENESIS_REAPER_ARMED"
+
+# State-file key an operator sets (via ``set_operator_armed``) to arm.
+_STATE_ARMED_KEY = "armed_by_operator"
 
 
 # ── Pure decision core (fully unit-testable) ────────────────────────────
@@ -250,6 +257,30 @@ def _save_state(state: dict) -> None:
         tmp.replace(_STATE_PATH)
 
 
+def _operator_armed(state: dict) -> bool:
+    """True only if a human explicitly opted in to real kills — via the
+    ``armed_by_operator`` state flag or the ``GENESIS_REAPER_ARMED`` env.
+    """
+    return bool(state.get(_STATE_ARMED_KEY)) or bool(os.environ.get(_ENV_ARM))
+
+
+def set_operator_armed(armed: bool) -> None:
+    """Operator switch: arm (real kills) or disarm (dry-run) the reaper.
+
+    Read-modify-writes the state JSON so the change takes effect on the next
+    pass (within the hour) with no server restart. Arming is a deliberate
+    human action taken after reviewing the dry-run WOULD-KILL log; disarming
+    clears the flag. The hard ``GENESIS_REAPER_KILL_DISABLED`` env stays an
+    independent emergency brake that overrides an armed flag.
+    """
+    state = _load_state()
+    if armed:
+        state[_STATE_ARMED_KEY] = True
+    else:
+        state.pop(_STATE_ARMED_KEY, None)
+    _save_state(state)
+
+
 def _gc_markers(live_pids: set[int]) -> None:
     """Delete activity markers for PIDs that are no longer alive."""
     with contextlib.suppress(FileNotFoundError, NotADirectoryError):
@@ -263,7 +294,9 @@ def _gc_markers(live_pids: set[int]) -> None:
 
 # ── Orchestrator ────────────────────────────────────────────────────────
 async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
-    """One reaper pass. Dry-run by default; auto-arms after a clean window.
+    """One reaper pass. Dry-run unless an operator has explicitly armed it
+    (``armed_by_operator`` state flag or ``GENESIS_REAPER_ARMED`` env); the
+    hard kill-switch overrides. There is no automatic arming.
 
     ``now`` is injectable (epoch secs) for deterministic tests.
     """
@@ -274,8 +307,9 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
 
     hard_disabled = bool(os.environ.get(_ENV_HARD_DISABLE))
     state = _load_state()
-    # Effective dry-run for THIS pass: persisted flag OR the hard kill-switch.
-    dry_run = bool(state.get("dry_run", True)) or hard_disabled
+    # Arm ONLY on explicit operator opt-in (state flag or env). The hard
+    # kill-switch overrides both. There is no automatic time-based arming.
+    dry_run = not (_operator_armed(state) and not hard_disabled)
 
     my_pid = os.getpid()
     protected = {my_pid, os.getppid()}
@@ -292,13 +326,6 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
         uptime_secs = _read_uptime()
         live_ttys = await _live_ttys()
         all_live_pids: set[int] = set()
-        # Proof-of-life for the hook: did we see ANY live claude PID with a
-        # fresh activity marker this pass? The marker is the sole trustworthy
-        # "user is active here" signal (process structure can't distinguish a
-        # live session from an orphan — verified 2026-07-11: all sessions had
-        # live bash/tmux parents). Auto-arm is gated on this, so the reaper
-        # never arms while its load-bearing signal is absent (hook not firing).
-        saw_fresh_marker = False
         # candidates: (root_pid, label, reason, is_claude, tree)
         candidates: list[tuple[int, str, str, bool, list[int]]] = []
 
@@ -315,8 +342,6 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
                 if is_claude:
                     tty = await _process_tty(pid)
                     marker = _marker_mtime(pid)
-                    if marker is not None and (now - marker) < _CLAUDE_IDLE_WINDOW_SECS:
-                        saw_fresh_marker = True
                     should_reap, reason = classify_claude_pid(
                         age_secs=age,
                         now=now,
@@ -336,15 +361,6 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
         _gc_markers(all_live_pids)
 
         if not candidates:
-            await _maybe_arm(
-                state,
-                now,
-                dry_run,
-                hard_disabled,
-                rt,
-                hook_active=saw_fresh_marker,
-                armed_summary=None,
-            )
             rt.record_job_success("process_reaper")
             return
 
@@ -360,15 +376,6 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
                     tree,
                 )
             await _record_observation(rt, candidates, dry_run=True)
-            await _maybe_arm(
-                state,
-                now,
-                dry_run,
-                hard_disabled,
-                rt,
-                hook_active=saw_fresh_marker,
-                armed_summary=_summarize(candidates),
-            )
             rt.record_job_success("process_reaper")
             return
 
@@ -409,80 +416,11 @@ def _summarize(candidates: list[tuple[int, str, str, bool, list[int]]]) -> str:
     return ", ".join(f"{root}({label}/{reason})" for root, label, reason, _, _ in candidates)
 
 
-async def _maybe_arm(
-    state: dict,
-    now: float,
-    dry_run: bool,
-    hard_disabled: bool,
-    rt: GenesisRuntime,
-    *,
-    hook_active: bool,
-    armed_summary: str | None,
-) -> None:
-    """Advance the dry-run→armed lifecycle. Never arms this pass; the flip
-    takes effect on the NEXT pass so the owner gets the notification + a
-    veto window before anything is signalled.
-
-    Auto-arm requires BOTH the elapsed dry-run window AND proof-of-life for
-    the hook (``hook_active`` — a fresh marker was seen at least once). The
-    marker is the reaper's only trustworthy activity signal, so arming while
-    it has never appeared would reap on the unreliable tty backstop alone.
-    ``hook_verified`` latches once true so a transient markerless pass (e.g.
-    all sessions momentarily idle) can't un-verify a hook already proven live.
-    """
-    if not dry_run or hard_disabled:
-        return  # already armed, or hard kill-switch engaged
-    changed = False
-    if not state.get("dry_run_since"):
-        state["dry_run_since"] = now
-        changed = True
-    if hook_active and not state.get("hook_verified"):
-        state["hook_verified"] = True
-        changed = True
-    elapsed = now - float(state["dry_run_since"])
-    if (
-        elapsed >= _DRY_RUN_ARM_AFTER_SECS
-        and state.get("hook_verified")
-        and not state.get("armed_at")
-    ):
-        # Arming REQUIRES a delivered veto notice: the owner must receive the
-        # heads-up + disable instructions before any real kill. If outreach is
-        # unavailable or delivery fails, stay in dry-run and retry next pass —
-        # never arm silently.
-        msg = (
-            "🔫 Process reaper auto-armed after "
-            f"{elapsed / 86400:.1f} clean dry-run days. It will now reap "
-            "claude processes that are >7d old AND idle >7d AND detached "
-            "from any live terminal (a strict subset of the old age-only "
-            "rule). Last dry-run would-kill set: "
-            f"{armed_summary or 'none'}. To keep it disabled, set "
-            '"dry_run": true in ~/.genesis/reaper_state.json or export '
-            f"{_ENV_HARD_DISABLE}=1."
-        )
-        if await _notify_owner(rt, msg):
-            state["dry_run"] = False
-            state["armed_at"] = now
-            changed = True
-            logger.warning(
-                "Process reaper auto-armed after %.1f clean dry-run days; "
-                "future passes will reap detached idle claude processes.",
-                elapsed / 86400,
-            )
-        else:
-            logger.warning(
-                "Process reaper met the auto-arm criteria but could not deliver "
-                "the owner veto notification; staying in dry-run, retrying next "
-                "pass."
-            )
-    if changed:
-        _save_state(state)
-
-
 async def _notify_owner(rt: GenesisRuntime, message: str) -> bool:
     """Send a verbatim ALERT to the owner. Returns True only if delivered.
 
-    The auto-arm gate relies on the return value — arming must not proceed
-    unless the owner actually received the veto notice.
+    Used to notify the owner when the (operator-armed) reaper actually kills
+    a detached claude process.
     """
     if rt._outreach_pipeline is None:
         return False

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -257,11 +257,21 @@ def _save_state(state: dict) -> None:
         tmp.replace(_STATE_PATH)
 
 
+_ENV_AFFIRMATIVE = frozenset({"1", "true", "yes", "on"})
+
+
 def _operator_armed(state: dict) -> bool:
     """True only if a human explicitly opted in to real kills — via the
-    ``armed_by_operator`` state flag or the ``GENESIS_REAPER_ARMED`` env.
+    ``armed_by_operator`` state flag or ``GENESIS_REAPER_ARMED`` set to an
+    explicit affirmative (``1``/``true``/``yes``/``on``).
+
+    The env value is parsed strictly: ``GENESIS_REAPER_ARMED=0`` / ``false`` —
+    a deployment documenting that the reaper is OFF — must NOT arm it (generic
+    truthiness would treat any non-empty string, including ``"0"``, as opt-in).
     """
-    return bool(state.get(_STATE_ARMED_KEY)) or bool(os.environ.get(_ENV_ARM))
+    if state.get(_STATE_ARMED_KEY):
+        return True
+    return os.environ.get(_ENV_ARM, "").strip().lower() in _ENV_AFFIRMATIVE
 
 
 def set_operator_armed(armed: bool) -> None:
@@ -403,8 +413,9 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
                 rt,
                 "⚠️ Process reaper killed a detached claude process "
                 f"(idle >7d, no live terminal): {_summarize(candidates)}. "
-                "If this was a live session, disable the reaper by setting "
-                '"dry_run": true in ~/.genesis/reaper_state.json.',
+                'To disarm, remove "armed_by_operator" from '
+                "~/.genesis/reaper_state.json (or call set_operator_armed(False)); "
+                f"to hard-stop immediately, export {_ENV_HARD_DISABLE}=1.",
             )
         rt.record_job_success("process_reaper")
     except Exception as exc:  # noqa: BLE001 — job boundary

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -1,9 +1,10 @@
-"""Tests for the idle-aware process reaper (fix/reaper-idle-semantics).
+"""Tests for the idle-aware process reaper.
 
-Covers the pure classifier, the dry-run/armed orchestrator, the auto-arm
-lifecycle, the hard kill-switch, non-claude age paths, marker GC, protected
-PIDs, and job wiring. The 2026-07-11 incident (interactive claude sessions
-killed purely on 7d age) is the regression these lock down.
+Covers the pure classifier, the dry-run/armed orchestrator, the manual
+operator-arm switch (state flag + env, with the hard kill-switch override),
+non-claude age paths, marker GC, protected PIDs, and job wiring. The
+2026-07-11 incident (interactive claude sessions killed purely on 7d age)
+is the regression these lock down.
 """
 
 from __future__ import annotations
@@ -164,6 +165,7 @@ def _patch_io(
     monkeypatch.setattr(pr, "_save_state", fake_save)
     monkeypatch.setattr(pr, "_KILL_GRACE_SECS", 0)
     monkeypatch.delenv(pr._ENV_HARD_DISABLE, raising=False)
+    monkeypatch.delenv(pr._ENV_ARM, raising=False)
     return signals, saved, gc_calls
 
 
@@ -203,7 +205,7 @@ async def test_armed_kills_detached_claude_tree(monkeypatch):
         ttys={},
         live_ttys=set(),
         descendants={900001: [900002]},
-        state={"dry_run": False, "armed_at": 1.0},
+        state={"armed_by_operator": True},
     )
     rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
@@ -221,7 +223,7 @@ async def test_armed_spares_fresh_marker_claude(monkeypatch):
         markers={900001: _NOW - 3600},  # …but active 1h ago
         ttys={},
         live_ttys=set(),
-        state={"dry_run": False, "armed_at": 1.0},
+        state={"armed_by_operator": True},
     )
     rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
@@ -236,7 +238,7 @@ async def test_armed_spares_live_tty_claude(monkeypatch):
         markers={},  # no marker (e.g. hooks didn't fire)
         ttys={900001: "pts/5"},
         live_ttys={"pts/5"},
-        state={"dry_run": False, "armed_at": 1.0},
+        state={"armed_by_operator": True},
     )
     rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
@@ -248,7 +250,7 @@ async def test_non_claude_reaped_by_age(monkeypatch):
         monkeypatch,
         pids_by_pattern={"opencode-ai": [900010, 900011]},
         ages={900010: 25 * 3600, 900011: 10 * 3600},  # 25h stale, 10h young
-        state={"dry_run": False, "armed_at": 1.0},
+        state={"armed_by_operator": True},
     )
     rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
@@ -267,7 +269,7 @@ async def test_protected_pid_never_signalled(monkeypatch):
         ttys={},
         live_ttys=set(),
         descendants={my_pid: []},
-        state={"dry_run": False, "armed_at": 1.0},
+        state={"armed_by_operator": True},
     )
     rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
@@ -279,132 +281,77 @@ async def test_marker_gc_receives_live_pids(monkeypatch):
         monkeypatch,
         pids_by_pattern={"claude": [900001], "opencode-ai": [900010]},
         ages={900001: 1 * _DAY, 900010: 1 * 3600},  # both young → no reap
-        state={"dry_run": False, "armed_at": 1.0},
+        state={"armed_by_operator": True},
     )
     rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
     assert gc_calls and {900001, 900010} <= gc_calls[0]
 
 
-async def test_auto_arm_lifecycle(monkeypatch):
-    notified: list[str] = []
-
-    async def fake_notify(rt, msg):
-        notified.append(msg)
-        return True  # delivered → arming may proceed
-
-    monkeypatch.setattr(pr, "_notify_owner", fake_notify)
-
-    # Pass 1: fresh dry-run. 900001 is a detached candidate; 900002 is a
-    # live session with a fresh marker (hook proof-of-life). Should record
-    # dry_run_since + hook_verified, but NOT arm, NOT signal.
-    signals, saved, _ = _patch_io(
+async def test_default_state_is_dry_run(monkeypatch):
+    """Empty state + no env → dry-run: the reaper never arms itself."""
+    signals, _, _ = _patch_io(
         monkeypatch,
-        pids_by_pattern={"claude": [900001, 900002]},
-        ages={900001: 8 * _DAY, 900002: 8 * _DAY},
-        markers={900002: _NOW - 100},  # fresh marker → hook is alive
+        pids_by_pattern={"claude": [900001]},
+        ages={900001: 30 * _DAY},  # ancient + detached — would reap IF armed
+        markers={},
         ttys={},
         live_ttys=set(),
+        descendants={900001: []},
         state={},
     )
-    rt = _FakeRT(pipeline=object())
+    rt = _FakeRT()
     await run_reaper(rt, now=_NOW)
-    assert signals == []
-    assert saved.get("dry_run_since") == _NOW
-    assert saved.get("hook_verified") is True
-    assert saved.get("dry_run", True) is True
-    assert not saved.get("armed_at")
-    assert notified == []
+    assert signals == []  # not armed → never signals
 
-    # Pass 2: >3 days later, hook already verified. Should FLIP to armed +
-    # notify, but still NOT signal this pass (arm gives the owner a veto window).
-    signals2, saved2, _ = _patch_io(
+
+async def test_env_arm_kills_detached_claude(monkeypatch):
+    """Arming via GENESIS_REAPER_ARMED (no state flag) reaps a detached idle claude."""
+    signals, _, _ = _patch_io(
         monkeypatch,
         pids_by_pattern={"claude": [900001]},
         ages={900001: 8 * _DAY},
         markers={},
         ttys={},
         live_ttys=set(),
-        state={"dry_run": True, "dry_run_since": _NOW, "hook_verified": True},
+        descendants={900001: []},
+        state={},  # no state flag…
     )
-    rt2 = _FakeRT(pipeline=object())
-    await run_reaper(rt2, now=_NOW + 3 * _DAY + 60)
-    assert signals2 == []  # arm pass does not kill
-    assert saved2.get("dry_run") is False
-    assert saved2.get("armed_at") == _NOW + 3 * _DAY + 60
-    assert len(notified) == 1 and "auto-armed" in notified[0]
+    monkeypatch.setenv(pr._ENV_ARM, "1")  # …armed via env
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert (900001, 15) in signals and (900001, 9) in signals
 
 
-async def test_no_arm_without_hook_proof(monkeypatch):
-    """Elapsed window alone must NOT arm — the hook must be proven live first."""
-    notified: list[str] = []
-
-    async def fake_notify(rt, msg):
-        notified.append(msg)
-
-    monkeypatch.setattr(pr, "_notify_owner", fake_notify)
-    signals, saved, _ = _patch_io(
-        monkeypatch,
-        pids_by_pattern={"claude": [900001]},
-        ages={900001: 8 * _DAY},
-        markers={},  # NO fresh marker anywhere → hook never proven
-        ttys={},
-        live_ttys=set(),
-        state={"dry_run": True, "dry_run_since": _NOW},  # no hook_verified
-    )
-    rt = _FakeRT(pipeline=object())
-    await run_reaper(rt, now=_NOW + 30 * _DAY)  # long past the window
-    assert signals == []
-    assert saved.get("armed_at") is None  # refused to arm without hook proof
-    assert notified == []
-
-
-async def test_no_arm_when_notification_fails(monkeypatch):
-    """All arm criteria met, but the owner veto notice can't be delivered →
-    stay in dry-run, do NOT arm (never arm silently)."""
-
-    async def fake_notify_fail(rt, msg):
-        return False  # delivery failed / outreach unavailable
-
-    monkeypatch.setattr(pr, "_notify_owner", fake_notify_fail)
-    signals, saved, _ = _patch_io(
+async def test_hard_disable_overrides_operator_arm(monkeypatch):
+    """The hard kill-switch forces dry-run even when the operator armed it."""
+    signals, _, _ = _patch_io(
         monkeypatch,
         pids_by_pattern={"claude": [900001]},
         ages={900001: 8 * _DAY},
         markers={},
         ttys={},
         live_ttys=set(),
-        state={"dry_run": True, "dry_run_since": _NOW, "hook_verified": True},
+        descendants={900001: []},
+        state={"armed_by_operator": True},  # operator armed…
     )
-    rt = _FakeRT(pipeline=object())
-    await run_reaper(rt, now=_NOW + 3 * _DAY + 60)
-    assert signals == []
-    assert saved.get("armed_at") is None  # not armed — notice undelivered
-    assert saved.get("dry_run", True) is True
+    monkeypatch.setenv(pr._ENV_HARD_DISABLE, "1")  # …but kill-switch engaged
+    rt = _FakeRT()
+    await run_reaper(rt, now=_NOW)
+    assert signals == []  # kill-switch wins over the arm flag
 
 
-async def test_hard_disable_prevents_arm(monkeypatch):
-    notified: list[str] = []
-
-    async def fake_notify(rt, msg):
-        notified.append(msg)
-
-    monkeypatch.setattr(pr, "_notify_owner", fake_notify)
-    signals, saved, _ = _patch_io(
-        monkeypatch,
-        pids_by_pattern={"claude": [900001]},
-        ages={900001: 8 * _DAY},
-        markers={},
-        ttys={},
-        live_ttys=set(),
-        state={"dry_run": True, "dry_run_since": _NOW},
-    )
-    monkeypatch.setenv(pr._ENV_HARD_DISABLE, "1")
-    rt = _FakeRT(pipeline=object())
-    await run_reaper(rt, now=_NOW + 10 * _DAY)
-    assert signals == []
-    assert saved.get("armed_at") is None  # never armed while kill-switch on
-    assert notified == []
+def test_set_operator_armed_roundtrip(tmp_path, monkeypatch):
+    """set_operator_armed flips the persisted flag; _operator_armed reflects it."""
+    monkeypatch.setattr(pr, "_STATE_PATH", tmp_path / "reaper_state.json")
+    monkeypatch.delenv(pr._ENV_ARM, raising=False)
+    assert pr._operator_armed(pr._load_state()) is False  # default: dry-run
+    pr.set_operator_armed(True)
+    assert pr._load_state().get("armed_by_operator") is True
+    assert pr._operator_armed(pr._load_state()) is True
+    pr.set_operator_armed(False)
+    assert "armed_by_operator" not in pr._load_state()
+    assert pr._operator_armed(pr._load_state()) is False
 
 
 async def test_job_failure_recorded(monkeypatch):

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -305,6 +305,25 @@ async def test_default_state_is_dry_run(monkeypatch):
     assert signals == []  # not armed → never signals
 
 
+async def test_env_arm_non_affirmative_does_not_arm(monkeypatch):
+    """GENESIS_REAPER_ARMED=0/false documents OFF and must NOT arm the reaper."""
+    for val in ("0", "false", "no", "off", ""):
+        signals, _, _ = _patch_io(
+            monkeypatch,
+            pids_by_pattern={"claude": [900001]},
+            ages={900001: 30 * _DAY},
+            markers={},
+            ttys={},
+            live_ttys=set(),
+            descendants={900001: []},
+            state={},
+        )
+        monkeypatch.setenv(pr._ENV_ARM, val)
+        rt = _FakeRT()
+        await run_reaper(rt, now=_NOW)
+        assert signals == [], f"value {val!r} wrongly armed the reaper"
+
+
 async def test_env_arm_kills_detached_claude(monkeypatch):
     """Arming via GENESIS_REAPER_ARMED (no state flag) reaps a detached idle claude."""
     signals, _, _ = _patch_io(


### PR DESCRIPTION
## Change
The idle-aware process reaper previously **auto-armed** after a clean dry-run window (elapsed time + activity-hook proof-of-life + a delivered notification). This replaces that with an **explicit operator opt-in**: the reaper stays in dry-run until a human sets `armed_by_operator` in `reaper_state.json` (via the new `set_operator_armed` helper) or exports `GENESIS_REAPER_ARMED=1`. The hard `GENESIS_REAPER_KILL_DISABLED` kill-switch still overrides the arm flag.

The reap-enable decision now belongs to the operator after they review the dry-run `WOULD KILL` log, rather than the reaper arming itself on a timer.

## Details
- Deletes the `_maybe_arm` lifecycle and the `dry_run_since` / `hook_verified` / `saw_fresh_marker` proof-of-life plumbing (net −115 LOC).
- Preserves everything else: the strict-subset classifier (age ≥ 7d AND idle ≥ 7d AND detached from any live terminal), `WOULD KILL` logging, observation recording, marker GC, the kill-switch, and the owner notification on an actual kill.
- Backward-compatible: an existing `reaper_state.json` without the new flag stays in dry-run, so a previously auto-armed state can never carry forward as armed.

## Tests
23 tests (classifier, dry-run/armed orchestrator, env + state-flag arming, kill-switch override, marker GC, wiring). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)