### PR TITLE
fix(observability): silence dashboard-poll access-log storm

### DIFF
--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -71,7 +71,7 @@ symbol/reference/impact questions.
 Genesis). Supports 66 languages. 3D visualization at `localhost:9749`.
 Indexed (reindex on local commit); if stale, run `index_repository`.
 Runs under a hard 2G memory cap (`.claude/mcp/run-codebase-memory` wraps it in
-a systemd scope) because upstream v0.8.1 leaks memory without bound on query
+a systemd scope) because upstream v0.9.0 still leaks memory without bound on query (issue #581 open)
 operations (DeusData/codebase-memory-mcp#581). If its tools suddenly error
 mid-session, the instance likely hit the cap and was killed — run `/mcp` to
 reconnect a fresh one; Serena/GitNexus/Grep are unaffected. Cap override:

--- a/.claude/mcp/run-codebase-memory
+++ b/.claude/mcp/run-codebase-memory
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Launcher for codebase-memory-mcp MCP server, with a hard memory cap.
 #
-# WHY THE CAP: upstream v0.8.1 (latest as of 2026-07-05) has a known unbounded
-# memory leak on query/read operations — DeusData/codebase-memory-mcp#581,
-# acknowledged by the maintainer, no fix shipped. Long-lived CC sessions grow
+# WHY THE CAP: upstream v0.9.0 (latest as of 2026-07-12) still has an unbounded
+# memory leak on query/read operations — DeusData/codebase-memory-mcp#581 is
+# OPEN (0.9.0 landed memory-safety fixes but not the leak). Long-lived CC sessions grow
 # an instance from ~10MB to multiple GB over hours/days; several concurrent
 # sessions can exhaust a container's (or host's) RAM. Until upstream ships a
 # fix, every instance runs inside a transient systemd scope with MemoryMax:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -320,8 +320,11 @@ echo "--- Installing code intelligence tools ---"
 # codebase-memory-mcp (code graph — 66 languages)
 # Always re-runs the upstream installer: it is idempotent and pulls the latest
 # release, so existing installs are upgraded in place.
+# --skip-config: the installer's own agent-config step registers the RAW binary
+# in ~/.claude/.mcp.json, bypassing our 2G-capped launcher. We register the
+# capped wrapper below via _register_mcp, so the installer must NOT self-register.
 echo "  codebase-memory-mcp: installing/upgrading..."
-curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui \
+curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui --skip-config \
     || echo "  WARNING: codebase-memory-mcp install/upgrade failed (non-critical)"
 if command -v codebase-memory-mcp &>/dev/null; then
     echo "  codebase-memory-mcp: $(codebase-memory-mcp --version 2>/dev/null || echo 'installed')"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -959,6 +959,9 @@ else
                 cat > "$HOME/.qdrant/config.yaml" <<QDCONF
 storage:
   storage_path: $HOME/.qdrant/storage
+# WARN drops the per-request actix access-log INFO lines (the dashboard polls
+# a dozen endpoints every few seconds); WARN+ still surfaces real problems.
+log_level: WARN
 service:
   # Bind to localhost only for security (prevents external access).
   # To allow remote access, change to 0.0.0.0 and add authentication.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -608,7 +608,10 @@ echo "    Installing code intelligence tools..."
 
 # Always re-runs the upstream installer: it is idempotent and pulls the latest
 # release, so existing installs are upgraded in place.
-curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui 2>/dev/null \
+# --skip-config: the installer would otherwise register the RAW binary in
+# ~/.claude/.mcp.json, bypassing our 2G-capped launcher (_register_mcp below
+# registers the capped wrapper instead).
+curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui --skip-config 2>/dev/null \
     && echo "    + codebase-memory-mcp installed/upgraded" \
     || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
 

--- a/src/genesis/observability/logging_config.py
+++ b/src/genesis/observability/logging_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 from datetime import UTC, datetime
 from logging.handlers import RotatingFileHandler
@@ -33,12 +34,36 @@ class GenesisFormatter(logging.Formatter):
         if record.exc_info and record.exc_info[0] is not None:
             import traceback
 
-            line += "\n" + "".join(
-                traceback.format_exception(*record.exc_info)
-            ).rstrip()
+            line += "\n" + "".join(traceback.format_exception(*record.exc_info)).rstrip()
         elif record.exc_text:
             line += "\n" + record.exc_text
         return line
+
+
+# Successful (2xx/3xx) GET/HEAD dashboard poll requests. The dashboard polls a
+# dozen ``/api/genesis/*`` endpoints every few seconds; at INFO each success
+# floods the journal. This matches ONLY those — every 4xx/5xx error, every
+# non-GET (state changes), and every non-dashboard path is preserved.
+_DASHBOARD_POLL_RE = re.compile(r'"(?:GET|HEAD) /api/genesis/\S* HTTP/[0-9.]+" [23]\d\d\b')
+
+
+class _WerkzeugPollFilter(logging.Filter):
+    """Drop werkzeug access-log lines for successful dashboard poll GETs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return _DASHBOARD_POLL_RE.search(record.getMessage()) is None
+
+
+def _install_werkzeug_poll_filter() -> None:
+    """Attach the poll filter to the ``werkzeug`` access logger (idempotent).
+
+    A filter on the origin logger drops the record before it reaches any
+    handler (including root via propagation), regardless of who configured
+    werkzeug's handlers.
+    """
+    wz = logging.getLogger("werkzeug")
+    if not any(isinstance(f, _WerkzeugPollFilter) for f in wz.filters):
+        wz.addFilter(_WerkzeugPollFilter())
 
 
 def configure_logging(
@@ -63,6 +88,10 @@ def configure_logging(
     genesis_logger = logging.getLogger("genesis")
     genesis_logger.setLevel(level)
     genesis_logger.propagate = False
+
+    # Silence the dashboard-poll access-log storm (idempotent; independent of
+    # the genesis-handler dedup below, so it installs even on repeat calls).
+    _install_werkzeug_poll_filter()
 
     # Avoid duplicate handlers on repeated calls
     if any(isinstance(h, logging.StreamHandler) for h in genesis_logger.handlers):

--- a/src/genesis/observability/logging_config.py
+++ b/src/genesis/observability/logging_config.py
@@ -45,13 +45,18 @@ class GenesisFormatter(logging.Formatter):
 # floods the journal. This matches ONLY those — every 4xx/5xx error, every
 # non-GET (state changes), and every non-dashboard path is preserved.
 _DASHBOARD_POLL_RE = re.compile(r'"(?:GET|HEAD) /api/genesis/\S* HTTP/[0-9.]+" [23]\d\d\b')
+# Werkzeug 3 colorizes the request line/status with ANSI when it thinks output
+# supports it — strip those before matching so styled poll lines are still
+# dropped (our journal is non-TTY so lines are plain, but a TTY context styles).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class _WerkzeugPollFilter(logging.Filter):
     """Drop werkzeug access-log lines for successful dashboard poll GETs."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return _DASHBOARD_POLL_RE.search(record.getMessage()) is None
+        msg = _ANSI_RE.sub("", record.getMessage())
+        return _DASHBOARD_POLL_RE.search(msg) is None
 
 
 def _install_werkzeug_poll_filter() -> None:

--- a/tests/test_observability/test_logging_config.py
+++ b/tests/test_observability/test_logging_config.py
@@ -5,7 +5,24 @@ import sys
 from datetime import UTC, datetime
 from logging.handlers import RotatingFileHandler
 
-from genesis.observability.logging_config import GenesisFormatter, configure_logging
+from genesis.observability.logging_config import (
+    GenesisFormatter,
+    _install_werkzeug_poll_filter,
+    _WerkzeugPollFilter,
+    configure_logging,
+)
+
+
+def _werkzeug_record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="werkzeug",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
 
 
 class TestGenesisFormatter:
@@ -23,7 +40,7 @@ class TestGenesisFormatter:
         )
         output = fmt.format(record)
         assert output == (
-            'ts=2026-03-04T12:00:00+00:00 level=WARNING '
+            "ts=2026-03-04T12:00:00+00:00 level=WARNING "
             'name=genesis.routing msg="breaker tripped for openrouter"'
         )
 
@@ -107,8 +124,62 @@ class TestConfigureLogging:
         genesis_logger = logging.getLogger("genesis")
         genesis_logger.handlers.clear()
         configure_logging(log_dir=str(tmp_path))
-        file_handlers = [
-            h for h in genesis_logger.handlers
-            if isinstance(h, RotatingFileHandler)
-        ]
+        file_handlers = [h for h in genesis_logger.handlers if isinstance(h, RotatingFileHandler)]
         assert len(file_handlers) == 0
+
+
+class TestWerkzeugPollFilter:
+    def test_drops_successful_dashboard_polls(self):
+        f = _WerkzeugPollFilter()
+        for path in (
+            "health",
+            "pause",
+            "heartbeat",
+            "ego/status",
+            "unified-errors?grouped=true&limit=6",
+        ):
+            rec = _werkzeug_record(
+                f'127.0.0.1 - - [12/Jul/2026 15:50:11] "GET /api/genesis/{path} HTTP/1.1" 200 -'
+            )
+            assert f.filter(rec) is False, path
+
+    def test_drops_304_and_head(self):
+        f = _WerkzeugPollFilter()
+        assert (
+            f.filter(_werkzeug_record('- - - [..] "GET /api/genesis/health HTTP/1.1" 304 -'))
+            is False
+        )
+        assert (
+            f.filter(_werkzeug_record('- - - [..] "HEAD /api/genesis/health HTTP/1.1" 200 -'))
+            is False
+        )
+
+    def test_keeps_error_responses(self):
+        """4xx/5xx on a polled endpoint must stay visible."""
+        f = _WerkzeugPollFilter()
+        for status in ("404", "500"):
+            rec = _werkzeug_record(f'- - - [..] "GET /api/genesis/health HTTP/1.1" {status} -')
+            assert f.filter(rec) is True, status
+
+    def test_keeps_non_get_and_non_dashboard(self):
+        f = _WerkzeugPollFilter()
+        # POST (state change) to a dashboard path stays.
+        assert (
+            f.filter(_werkzeug_record('- - - [..] "POST /api/genesis/pause HTTP/1.1" 200 -'))
+            is True
+        )
+        # A non-dashboard GET stays.
+        assert f.filter(_werkzeug_record('- - - [..] "GET /static/app.js HTTP/1.1" 200 -')) is True
+
+    def test_install_is_idempotent(self):
+        wz = logging.getLogger("werkzeug")
+        wz.filters = [x for x in wz.filters if not isinstance(x, _WerkzeugPollFilter)]
+        _install_werkzeug_poll_filter()
+        _install_werkzeug_poll_filter()
+        assert sum(isinstance(x, _WerkzeugPollFilter) for x in wz.filters) == 1
+
+    def test_configure_logging_installs_filter(self):
+        wz = logging.getLogger("werkzeug")
+        wz.filters = [x for x in wz.filters if not isinstance(x, _WerkzeugPollFilter)]
+        configure_logging()
+        assert any(isinstance(x, _WerkzeugPollFilter) for x in wz.filters)

--- a/tests/test_observability/test_logging_config.py
+++ b/tests/test_observability/test_logging_config.py
@@ -154,6 +154,12 @@ class TestWerkzeugPollFilter:
             is False
         )
 
+    def test_drops_ansi_styled_polls(self):
+        """Werkzeug-3 ANSI-styled request lines are still recognized as polls."""
+        f = _WerkzeugPollFilter()
+        styled = '- - - [..] "\x1b[36mGET /api/genesis/health HTTP/1.1\x1b[0m" 304 -'
+        assert f.filter(_werkzeug_record(styled)) is False
+
     def test_keeps_error_responses(self):
         """4xx/5xx on a polled endpoint must stay visible."""
         f = _WerkzeugPollFilter()

--- a/tests/test_scripts/test_run_codebase_memory_launcher.py
+++ b/tests/test_scripts/test_run_codebase_memory_launcher.py
@@ -1,6 +1,6 @@
 """Memory-cap launcher for codebase-memory-mcp (.claude/mcp/run-codebase-memory).
 
-Upstream v0.8.1 leaks memory without bound on query operations
+Upstream v0.9.0 still leaks memory without bound on query operations (#581)
 (DeusData/codebase-memory-mcp#581), so the launcher wraps the server in a
 transient systemd scope with MemoryMax, falling back to an address-space
 rlimit where no user manager is reachable.


### PR DESCRIPTION
## Problem
The dashboard polls a dozen `/api/genesis/*` endpoints every few seconds. At `INFO`, werkzeug logs each success, flooding the journal and burying real events.

## Fix
- A `logging.Filter` on the `werkzeug` logger drops **only** successful (2xx/3xx) `GET`/`HEAD` requests to `/api/genesis/*`. Every `4xx`/`5xx` error, every non-GET (state changes), and every non-dashboard path is preserved. Installed idempotently from `configure_logging` (runs at boot); a filter on the origin logger drops the record before any handler, including root via propagation.
- Fresh installs get `log_level: WARN` in the qdrant config so qdrant's equivalent per-request access-log INFO spam is suppressed too.
- Refreshes the codebase-memory-mcp launcher/docs to the current upstream version and notes the still-open memory-leak issue (the memory cap remains the protection).

## Tests
Filter unit tests (drops polls incl. 304/HEAD; keeps 4xx/5xx, POST, non-dashboard paths; idempotent install) validated against real journal lines. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)