### PR TITLE
feat(runtime): percentage-based memory caps for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Genesis is a full system, not a pip package. It runs best on a dedicated Linux m
 | Resource | Minimum | Recommended | Notes |
 |---|---|---|---|
 | **OS** | Ubuntu 22.04+ | Ubuntu 24.04 LTS | Debian-based required for auto-install. Other Linux works with manual setup. |
-| **RAM** | 8 GB | 16 GB+ | Genesis + Qdrant + Claude Code + background tasks. 8 GB is tight under load. |
+| **RAM** | 8 GB | 16 GB+ | Genesis + Qdrant + Claude Code + background tasks. 8 GB is tight under load. Service memory caps are percentage-based, so Genesis right-sizes itself to the box — scaling down on an 8 GB host and up on a 32 GB+ one. |
 | **Disk** | 10 GB | 40 GB+ | Fresh install ~400 MB. Memory, logs, and caches grow steadily with use. |
 | **CPU** | 2 cores | 4-8 cores | Concurrent background tasks benefit from parallelism. |
 | **Network** | Internet access | Always-on | Cloud LLM APIs required. Offline not supported. |

--- a/config/genesis-guardian.service
+++ b/config/genesis-guardian.service
@@ -21,11 +21,14 @@ StandardError=journal
 TimeoutStartSec=3900
 
 # Resource limits — prevent CC diagnostic from consuming unbounded host memory.
-# 6G covers the guardian Python process + one CC session + tool subprocesses.
+# 30% of host RAM covers the guardian Python process + one CC session + tool
+# subprocesses, and scales with the host (systemd resolves the % at runtime),
+# so there is no hardcoded ceiling to re-tune per install — and it auto-shrinks
+# on small hosts, protecting an 8 GiB box a fixed 6G would have starved.
 # MemorySwapMax=0 prevents I/O thrashing under pressure.
 # OOMScoreAdjust=500 (positive) makes guardian first to be OOM-killed vs
 # genesis (-500) or ollama — guardian is expendable, primary workloads are not.
-MemoryMax=6G
+MemoryMax=30%
 MemorySwapMax=0
 OOMScoreAdjust=500
 

--- a/config/guardian-claude.md
+++ b/config/guardian-claude.md
@@ -100,7 +100,7 @@ Before recommending IO_TRIAGE, check the PSI trend:
   check cycle is skipped entirely
 - CC diagnosis runs in `/var/lib/guardian-snapshots/cc-sessions` (isolated work dir)
 - Diagnosis refused if pool usage > 90% (disk space preflight)
-- Guardian service limited to 6GB memory (MemoryMax=6G), OOMScoreAdjust=500
+- Guardian service limited to 30% of host RAM (MemoryMax=30%), OOMScoreAdjust=500
 - Snapshot gating: headroom-based check (requires free > max(5GB, 2x avg recent
   snapshots)), not fixed percentage
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1021,7 +1021,8 @@ Type=simple
 ExecStart="$QDRANT_BIN" "--config-path" "$HOME/.qdrant/config.yaml"
 Restart=on-failure
 RestartSec=5
-MemoryMax=4G
+# 25% of container RAM (scales with the box); live qdrant RSS is ~0.3G.
+MemoryMax=25%
 LimitNOFILE=65536
 OOMScoreAdjust=-500
 StandardOutput=journal

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1036,7 +1036,16 @@ WantedBy=default.target
 QDSERVICE
     echo "    + qdrant.service created"
 elif [ -f "$SYSTEMD_USER_DIR/qdrant.service" ]; then
-    echo "    . qdrant.service already exists"
+    # Migrate the legacy hardcoded cap to the portable percentage in place.
+    # Only the exact old default is touched, so a custom value is never clobbered.
+    if grep -q '^MemoryMax=4G$' "$SYSTEMD_USER_DIR/qdrant.service"; then
+        sed -i 's/^MemoryMax=4G$/MemoryMax=25%/' "$SYSTEMD_USER_DIR/qdrant.service"
+        systemctl --user daemon-reload 2>/dev/null || true
+        systemctl --user try-restart qdrant.service 2>/dev/null || true
+        echo "    ~ qdrant.service MemoryMax 4G -> 25% (portable)"
+    else
+        echo "    . qdrant.service already exists"
+    fi
 else
     echo "    - Qdrant binary not found — skipping service"
 fi

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -60,6 +60,12 @@ def _build_scope_args() -> list[str]:
     limits.  Each session gets its own cgroup under app.slice/run-XXXX.scope,
     separate from genesis-server.service.
 
+    Memory limits are PERCENTAGES so they scale with the host: systemd
+    resolves ``N%`` against the container's memory cgroup (verified: on a
+    16 GiB container ``62%``→9.9 GiB soft, ``75%``→12 GiB hard). This keeps
+    a heavy CC build from OOM-ing the box while auto-scaling up on larger
+    installs and down on the 8 GiB floor — no hardcoded ceiling to re-tune.
+
     Returns an empty list if systemd-run is unavailable (graceful degradation).
     """
     if not shutil.which("systemd-run"):
@@ -72,9 +78,9 @@ def _build_scope_args() -> list[str]:
         "-p",
         "IOWeight=100",
         "-p",
-        "MemoryHigh=22G",
+        "MemoryHigh=62%",
         "-p",
-        "MemoryMax=27G",
+        "MemoryMax=75%",
         "--",
     ]
 

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -32,7 +32,7 @@ from genesis.guardian.config import GuardianConfig
 logger = logging.getLogger(__name__)
 
 # Pre-flight memory thresholds.  Guardian must always attempt diagnosis
-# above the hard floor.  The systemd MemoryMax=6G cap on the Guardian
+# above the hard floor.  The systemd MemoryMax=30%-of-host-RAM cap on the Guardian
 # service is the real safety boundary — Python-level checks are advisory.
 # Hard floor: refuse only at catastrophic levels (host is almost dead).
 # Warn floor: log warning but proceed (Guardian's job is to diagnose).
@@ -428,7 +428,7 @@ class DiagnosisEngine:
         except Exception as exc:
             logger.warning("Disk space preflight failed (non-fatal): %s", exc)
 
-        # Pre-flight: check host memory.  The systemd MemoryMax=6G on the
+        # Pre-flight: check host memory.  The systemd MemoryMax=30% of host RAM on the
         # Guardian service is the real safety boundary — this Python check
         # is advisory.  Only refuse at catastrophic levels (< 2 GiB means
         # the host is almost dead, not just Genesis).
@@ -450,7 +450,7 @@ class DiagnosisEngine:
             if available_gib < _CC_PREFLIGHT_WARN_GiB:
                 logger.warning(
                     "Host memory low (%.1f GiB free < %.0f GiB) "
-                    "— proceeding with CC diagnosis (MemoryMax=6G caps usage)",
+                    "— proceeding with CC diagnosis (MemoryMax=30% of host RAM caps usage)",
                     available_gib, _CC_PREFLIGHT_WARN_GiB,
                 )
         else:


### PR DESCRIPTION
## Motivation
Several memory ceilings were hardcoded absolute values that assumed one machine's RAM. On a public install with varying RAM, a fixed cap is either a no-op (above the box's limit) or dangerously large (could starve a small host). This converts **workload** caps to systemd percentages so Genesis right-sizes itself to the host.

## Changes
- **CC invoker scope** (`cc/invoker.py`): `MemoryHigh=22G` / `MemoryMax=27G` → `62%` / `75%`. On a 16 GiB container that resolves to ~9.9 GiB soft / 12 GiB hard (verified: systemd resolves `%` against the container memory cgroup for a `--user --scope`). The old absolute values sat *above* the container limit — a non-functional ceiling.
- **Qdrant** (`scripts/install.sh`): `MemoryMax=4G` → `25%`.
- **Guardian** (`config/genesis-guardian.service`): `MemoryMax=6G` → `30%`, with the diagnosis preflight log/comments updated in lockstep. Auto-shrinks on a small host that a fixed 6G could starve.

Percentages auto-scale **up** on 32/64 GiB installs and **down** toward the 8 GiB floor, with no hardcoded ceiling to re-tune.

## Deliberately unchanged
Leak-containment caps (codebase-memory-mcp, code-intel index) stay **absolute 2G** — they bound tools that should never balloon, so a percentage would wrongly let them grow on a big box. README RAM note documents the auto-scaling.

## Tests
Invoker suite (100) passes; `systemd-analyze verify` accepts the guardian unit; install.sh syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)