### PR TITLE
feat(observability): WS-3 B3 — embedding-backlog degradation alert (hybrid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now notices when memories quietly lose semantic search.** When an
+  embedding permanently fails, that memory becomes keyword-only — findable by
+  exact words but invisible to meaning-based recall — and nothing flagged the
+  pile building up (the existing alert only caught embeddings failing *right
+  now*, not the backlog left behind). A new hourly check counts these
+  permanently-stuck memories: a modest pile shows on the dashboard, and a large
+  one (a real chunk of the store gone semantically dark) pages you on Telegram.
+  It clears itself once the memories are re-embedded.
+
 - **The recovery brain no longer drifts behind a version bump.** A nightly
   job re-aligns the host's Claude Code and Node.js to the pinned versions.
   Previously this happened only when you ran an update, so a pin bump could

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -386,7 +386,10 @@ verified: 780cc8de 2026-07-10
   collectors). Tick → depth classification (MICRO/LIGHT/DEEP/STRATEGIC) →
   reflection dispatch. Also per-tick `_check_*` housekeeping: CC-slot RSS leak
   watch, subscription-cap detection, SQLite WAL hygiene, resilience-axis folds,
-  liveness heartbeat. It does NOT drive the ego cadence (ego has its own
+  liveness heartbeat, and (hourly) embedding-backlog degradation — counts
+  `memory_metadata.embedding_status='failed'` (permanently keyword-only rows the
+  rate alert misses), hybrid `high` (dashboard) / `critical` (Telegram) by band.
+  It does NOT drive the ego cadence (ego has its own
   scheduler). Trap: PEP 562 lazy `__init__` — don't eager-import `loop.py`.
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -234,9 +234,12 @@ async def _check_embedding_backlog(db) -> None:
                 f"permanently keyword-only (no vector/semantic search) and "
                 f"invisible to the rate-based embedding-failure alert (the outage "
                 f"that created them is over). {pending} more are 'pending' and "
-                f"still self-healing. To recover: reset the failed rows to "
-                f"'pending' so the recovery worker retries, and check embedding-"
-                f"provider health."
+                f"still self-healing. Recovery: these failed rows have no "
+                f"live pending_embeddings queue entry (it was reaped), so a "
+                f"plain failed->pending reset will NOT retry them (nothing "
+                f"auto-recovers a reaped failure) — re-enqueue the affected "
+                f"memories for embedding (a fresh pending_embeddings row "
+                f"each) after checking embedding-provider health."
             ),
             priority=priority,
             created_at=datetime.now(UTC).isoformat(),

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -134,6 +134,161 @@ async def _check_wal_health(db) -> None:
         logger.debug("Failed to create WAL health alert observation", exc_info=True)
 
 
+# Embedding-backlog degradation: memories stuck at embedding_status='failed' —
+# the embedding recovery worker gave up, so they are permanently keyword-only
+# (no vector/semantic search) and invisible to every rate/per-run embedding
+# alert (the outage that created them is over). Baseline is 0 (verified live).
+# HYBRID surfacing: a real-but-modest pile records a NON-paging 'high'
+# observation (dashboard / morning report only); only a large pile — a serious
+# permanent-loss backlog (HIGH ~= 1.8% of a ~55k store) — escalates to
+# 'critical', which the critical-observations job pages to Telegram. The
+# always-on count also feeds the neural-monitor via memory_health(). The metric
+# fluctuates and partially self-heals, so band + cooldown + auto-resolve is the
+# right shape (mirrors the dead-letter accumulation alert). Thresholds are
+# tunable module constants. NOTE: 'pending' (self-healing) is context in the
+# alert text only; a sustained-pending stuck-worker signal is a separate
+# recovery-worker health concern, tracked as a follow-up, not alerted here.
+_EMBED_BACKLOG_LOW = 50            # below this: quiet (+ resolve any prior alert)
+_EMBED_BACKLOG_HIGH = 1000         # at/above this: 'critical' (pages); else 'high'
+_EMBED_BACKLOG_COOLDOWN_S = 3600   # one alert per band per hour max
+# Safe as 0.0/"" (unlike _check_wal_health): the band guard below means a fresh
+# boot never matches the empty band, so the first real backlog always alerts.
+_last_embed_backlog_alert_at: float = 0.0
+_last_embed_backlog_band: str = ""
+
+
+def _embed_backlog_band(failed: int) -> str:
+    """Bucket the failed-embedding count into a stable band (only meaningful at
+    or above ``_EMBED_BACKLOG_LOW``). The alert's content_hash keys on the band,
+    not the raw count, so per-tick count drift does not defeat dedup; the exact
+    count still appears in the content. A band change is escalation-worthy and
+    bypasses the cooldown."""
+    if failed < 200:
+        return "50-199"
+    if failed < _EMBED_BACKLOG_HIGH:
+        return "200-999"
+    if failed < 5000:
+        return "1000-4999"
+    return "5000+"
+
+
+async def _check_embedding_backlog(db) -> None:
+    """Alert when embedding_status='failed' memories accumulate.
+
+    Hybrid: a modest pile records a non-paging 'high' observation (dashboard
+    only); a large pile (>= HIGH) records a 'critical' one that pages Telegram
+    via the critical-observations job. Best-effort — the whole body is guarded
+    and never raises into the tick."""
+    global _last_embed_backlog_alert_at, _last_embed_backlog_band
+    if db is None:
+        return
+    try:
+        from genesis.db.crud.memory import embedding_status_counts
+
+        counts = await embedding_status_counts(db)
+        failed = counts.get("failed", 0)
+
+        if failed < _EMBED_BACKLOG_LOW:
+            # Under threshold — clear any standing alert and stop.
+            await _resolve_embedding_backlog(db)
+            return
+
+        band = _embed_backlog_band(failed)
+        now = time.monotonic()
+        # Same-band re-alerts respect the cooldown; a band change (worsening or
+        # improving transition) is escalation-worthy and bypasses it.
+        if (
+            now - _last_embed_backlog_alert_at < _EMBED_BACKLOG_COOLDOWN_S
+            and band == _last_embed_backlog_band
+        ):
+            return
+
+        priority = "critical" if failed >= _EMBED_BACKLOG_HIGH else "high"
+        pending = counts.get("pending", 0)
+        content_hash = hashlib.sha256(
+            f"embedding_backlog:{band}".encode()
+        ).hexdigest()
+        # Keep exactly ONE active alert = the current band. Resolve any
+        # stale other-band rows so a worsening (high->critical) OR a partial
+        # recovery (critical->high) transition leaves only the current-band
+        # row active, instead of a lingering peak-severity row until the
+        # backlog fully clears (< LOW). DB-based (not the in-memory band), so
+        # it is restart-safe; a no-op in steady state at a fixed band.
+        await db.execute(
+            "UPDATE observations SET resolved=1, resolved_at=?, "
+            "resolution_notes='superseded by a new embedding-backlog band' "
+            "WHERE source='embedding_backlog_monitor' "
+            "AND type='infrastructure_alert' AND resolved=0 "
+            "AND content_hash != ?",
+            (datetime.now(UTC).isoformat(), content_hash),
+        )
+        await db.commit()
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="embedding_backlog_monitor",
+            type="infrastructure_alert",
+            content=(
+                f"{failed} memories are stuck at embedding_status='failed' — the "
+                f"embedding recovery worker gave up on them, so they are "
+                f"permanently keyword-only (no vector/semantic search) and "
+                f"invisible to the rate-based embedding-failure alert (the outage "
+                f"that created them is over). {pending} more are 'pending' and "
+                f"still self-healing. To recover: reset the failed rows to "
+                f"'pending' so the recovery worker retries, and check embedding-"
+                f"provider health."
+            ),
+            priority=priority,
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        if created is None:
+            return  # An unresolved alert for this band already exists.
+        _last_embed_backlog_alert_at = now
+        _last_embed_backlog_band = band
+        logger.warning(
+            "Embedding backlog alert: %d failed memories (%s observation created)",
+            failed,
+            priority,
+        )
+    except Exception:
+        logger.debug("Failed embedding backlog check", exc_info=True)
+
+
+async def _resolve_embedding_backlog(db) -> None:
+    """Resolve outstanding embedding-backlog alerts once the failed count drops
+    back under ``_EMBED_BACKLOG_LOW``.
+
+    Unconditional (no in-memory "is an alert active?" guard) so it survives a
+    restart; the UPDATE is a cheap no-op when nothing matches. Resolving on a
+    non-zero count clears the cooldown globals so a genuine recovery -> re-spike
+    re-alerts cleanly."""
+    global _last_embed_backlog_alert_at, _last_embed_backlog_band
+    if db is None:
+        return
+    try:
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source="embedding_backlog_monitor",
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=(
+                f"auto-resolved: failed-embedding backlog back under "
+                f"{_EMBED_BACKLOG_LOW}"
+            ),
+        )
+        if resolved:
+            _last_embed_backlog_alert_at = 0.0
+            _last_embed_backlog_band = ""
+            logger.info(
+                "Auto-resolved %d embedding-backlog alert observation(s) on recovery",
+                resolved,
+            )
+    except Exception:
+        logger.debug("Failed to resolve embedding backlog alerts", exc_info=True)
+
+
 # nodatacow (chattr +C) drift detection: on btrfs, a CoW SQLite DB suffers WAL
 # write-amplification + chronic fragmentation. The install sets +C on data/;
 # this catches regressions (a restore/recreate that dropped the flag). Static
@@ -1146,6 +1301,11 @@ class AwarenessLoop:
                     # nodatacow drift check (btrfs-only, daily alert cooldown) —
                     # static condition, so the slow hourly cadence is plenty.
                     await _check_db_nodatacow(self._db)
+                    # Embedding-backlog degradation — count memories permanently
+                    # stuck at embedding_status='failed'. Slow-moving and self-
+                    # healing, so the hourly cadence fits; self-resolves when the
+                    # backlog clears. Best-effort (guarded internally).
+                    await _check_embedding_backlog(self._db)
                 await _check_wal_health(self._db)
 
             # Status file writes are handled by a dedicated loop in

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -2154,6 +2154,18 @@ function updateSubsystemGrid(data) {
             if (q.pending_embeddings) { enrichment.appendChild(sectionRow('Pending', String(q.pending_embeddings), 'color:#ffe600')); hasEnrichment = true; }
             if (q.failed_embeddings) { enrichment.appendChild(sectionRow('Failed', String(q.failed_embeddings), 'color:#ef4444')); hasEnrichment = true; }
 
+            // Permanent embedding backlog: memory_metadata rows stuck at
+            // embedding_status='failed' (keyword-only forever). Distinct from the
+            // transient queue 'Failed' above (pending_embeddings table, TTL-reaped)
+            // — this durable mirror survives the reaper and is what the awareness
+            // probe escalates on. Shown only when non-zero (baseline is 0).
+            const eb = mh.embedding_backlog || {};
+            if (eb.failed) {
+                const ebVal = eb.failed + ' no-vector (permanent)' + (eb.pending ? ' · ' + eb.pending + ' pending' : '');
+                enrichment.appendChild(sectionRow('Embed backlog', ebVal, 'color:#ef4444'));
+                hasEnrichment = true;
+            }
+
             if (mh.growth) {
                 const g = mh.growth;
                 if (g.last_7d !== undefined) { enrichment.appendChild(sectionRow('+7d', String(g.last_7d))); hasEnrichment = true; }

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -395,6 +395,27 @@ async def count_fts_metadata_drift(db: aiosqlite.Connection) -> tuple[int, int]:
     return ghosts, invisible
 
 
+async def embedding_status_counts(db: aiosqlite.Connection) -> dict[str, int]:
+    """Return a ``{embedding_status: count}`` map over ``memory_metadata``.
+
+    A single grouped aggregate — the one source of truth shared by both the
+    dashboard memory-health snapshot and the awareness embedding-backlog probe.
+    Statuses with zero rows are simply absent from the map (callers use
+    ``.get(status, 0)``). ``embedding_status`` is ``NOT NULL`` in the schema, so
+    no NULL/None key can occur.
+
+    Status meanings: ``embedded`` (has a vector — the healthy default);
+    ``pending`` (embed failed and is queued — self-heals via the recovery
+    worker); ``fts5_only`` (a deliberate, permanent keyword-only write, NOT a
+    failure); ``failed`` (recovery gave up — permanently non-vector-searchable).
+    """
+    rows = await db.execute_fetchall(
+        "SELECT embedding_status, COUNT(*) FROM memory_metadata "
+        "GROUP BY embedding_status"
+    )
+    return {str(status): int(cnt) for status, cnt in rows}
+
+
 async def set_embedding_status(
     db: aiosqlite.Connection, memory_id: str, status: str
 ) -> bool:

--- a/src/genesis/observability/snapshots/memory_health.py
+++ b/src/genesis/observability/snapshots/memory_health.py
@@ -141,6 +141,27 @@ async def _code_index_stats(db: aiosqlite.Connection) -> dict:
         return {}
 
 
+async def _embedding_backlog(db: aiosqlite.Connection) -> dict:
+    """Non-vector-searchable memory counts for the neural-monitor dashboard.
+
+    ``failed`` = the embedding recovery worker gave up (permanent, keyword-only
+    — the signal the awareness probe escalates on); ``pending`` = embed queued
+    and still self-healing. ``fts5_only`` is deliberately excluded — it is a
+    permanent keyword-only write by design, not degradation. Shares the one
+    grouped aggregate the awareness probe uses (SQLite is authoritative)."""
+    try:
+        from genesis.db.crud.memory import embedding_status_counts
+
+        counts = await embedding_status_counts(db)
+        return {
+            "failed": counts.get("failed", 0),
+            "pending": counts.get("pending", 0),
+        }
+    except Exception:
+        logger.debug("embedding backlog query failed", exc_info=True)
+        return {}
+
+
 def _essential_knowledge_stats() -> dict:
     """EK file age and size."""
     try:
@@ -183,6 +204,7 @@ async def memory_health(db: aiosqlite.Connection | None) -> dict:
         links = await _link_distribution(db)
         extraction = await _extraction_coverage(db)
         code_index = await _code_index_stats(db)
+        embedding_backlog = await _embedding_backlog(db)
         ek = _essential_knowledge_stats()
 
         # Derive health status
@@ -203,6 +225,7 @@ async def memory_health(db: aiosqlite.Connection | None) -> dict:
             "links": links,
             "extraction": extraction,
             "code_index": code_index,
+            "embedding_backlog": embedding_backlog,
             "essential_knowledge": ek,
         }
     except ImportError:

--- a/tests/test_awareness/test_embedding_backlog.py
+++ b/tests/test_awareness/test_embedding_backlog.py
@@ -1,0 +1,238 @@
+"""Tests for the embedding-backlog degradation alert (_check_embedding_backlog).
+
+A pile of memories stuck at ``embedding_status='failed'`` is permanently non-
+vector-searchable (keyword-only) and invisible to the rate-based embedding-
+failure alert (the outage that created them is over). This probe counts the
+standing backlog off ``memory_metadata`` (the durable mirror — the
+``pending_embeddings`` queue is TTL-reaped) and surfaces it HYBRID: a modest
+pile records a non-paging ``high`` observation (dashboard only); a large pile
+records a ``critical`` one that the critical-observations job pages to Telegram.
+
+Determinism: the cooldown globals are reset around every test and
+``time.monotonic`` is pinned, so nothing depends on the wall clock.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.awareness import loop
+from genesis.db.crud import observations as obs_crud
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    loop._last_embed_backlog_alert_at = 0.0
+    loop._last_embed_backlog_band = ""
+    # Pin monotonic so the band-guarded cooldown is fully deterministic.
+    monkeypatch.setattr(loop.time, "monotonic", lambda: 1000.0)
+    yield
+    loop._last_embed_backlog_alert_at = 0.0
+    loop._last_embed_backlog_band = ""
+
+
+async def _seed(db, status: str, n: int, *, start: int = 0) -> None:
+    """Insert ``n`` memory_metadata rows with the given embedding_status."""
+    rows = [
+        (f"{status}-{start + i}", "2026-01-01T00:00:00", "episodic_memory", 0.5, status)
+        for i in range(n)
+    ]
+    await db.executemany(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, confidence, embedding_status) "
+        "VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    await db.commit()
+
+
+async def _unresolved(db) -> list[aiosqlite.Row]:
+    cur = await db.execute(
+        "SELECT priority, content_hash FROM observations "
+        "WHERE source='embedding_backlog_monitor' AND type='infrastructure_alert' "
+        "AND resolved=0"
+    )
+    return list(await cur.fetchall())
+
+
+async def _total(db) -> int:
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM observations WHERE source='embedding_backlog_monitor'"
+    )
+    return rows[0][0]
+
+
+# -- Pure band mapping (no DB) -------------------------------------------------
+
+
+def test_band_boundaries():
+    assert loop._embed_backlog_band(50) == "50-199"
+    assert loop._embed_backlog_band(199) == "50-199"
+    assert loop._embed_backlog_band(200) == "200-999"
+    assert loop._embed_backlog_band(999) == "200-999"
+    assert loop._embed_backlog_band(1000) == "1000-4999"
+    assert loop._embed_backlog_band(4999) == "1000-4999"
+    assert loop._embed_backlog_band(5000) == "5000+"
+
+
+# -- Threshold / priority matrix ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_below_low_no_alert_and_resolves(db):
+    """failed < LOW → no observation; resolve path runs (harmless no-op)."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_LOW - 1)
+    # fts5_only is a healthy permanent state and must never count toward failed.
+    await _seed(db, "fts5_only", 900, start=10_000)
+    await loop._check_embedding_backlog(db)
+    assert await _total(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_modest_backlog_is_high_and_does_not_page(db):
+    """LOW <= failed < HIGH → one 'high' row, INVISIBLE to the critical-obs poll."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_LOW + 10)
+    await loop._check_embedding_backlog(db)
+
+    rows = await _unresolved(db)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "high"
+
+    # The critical-observations job (Telegram) polls priority_filter=("critical",)
+    # excluding INTERNAL_OBS_TYPES — a 'high' row must NOT be returned.
+    surfaced = await obs_crud.get_unsurfaced(
+        db,
+        priority_filter=("critical",),
+        exclude_types=tuple(obs_crud.INTERNAL_OBS_TYPES),
+    )
+    assert not any(o["source"] == "embedding_backlog_monitor" for o in surfaced)
+
+
+@pytest.mark.asyncio
+async def test_large_backlog_is_critical_and_pages(db):
+    """failed >= HIGH → one 'critical' row, VISIBLE to the critical-obs poll."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_HIGH + 5)
+    await loop._check_embedding_backlog(db)
+
+    rows = await _unresolved(db)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "critical"
+
+    surfaced = await obs_crud.get_unsurfaced(
+        db,
+        priority_filter=("critical",),
+        exclude_types=tuple(obs_crud.INTERNAL_OBS_TYPES),
+    )
+    assert any(o["source"] == "embedding_backlog_monitor" for o in surfaced)
+
+
+@pytest.mark.asyncio
+async def test_same_band_dedups_across_restart(db):
+    """A repeat in the same band produces no 2nd row even when the in-memory
+    cooldown is cleared (simulating a restart) — skip_if_duplicate is DB-backed."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_LOW + 10)
+    await loop._check_embedding_backlog(db)
+    assert await _total(db) == 1
+
+    # Simulate a restart: cooldown globals lost, DB row survives.
+    loop._last_embed_backlog_alert_at = 0.0
+    loop._last_embed_backlog_band = ""
+    await loop._check_embedding_backlog(db)
+    assert await _total(db) == 1  # DB dedup held
+
+
+@pytest.mark.asyncio
+async def test_band_escalation_high_to_critical_supersedes(db):
+    """A worsening band transition (high → critical) writes the critical row
+    within the same cooldown window (escalation bypass) AND supersedes the stale
+    'high' row, so exactly one alert (the current band) stays active."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_LOW + 10)
+    await loop._check_embedding_backlog(db)
+
+    # Grow the pile past HIGH — new (critical) band, same cooldown window.
+    await _seed(db, "failed", loop._EMBED_BACKLOG_HIGH, start=500_000)
+    await loop._check_embedding_backlog(db)
+
+    rows = await _unresolved(db)
+    assert [r["priority"] for r in rows] == ["critical"]  # high superseded
+    assert await _total(db) == 2  # one resolved high + one active critical
+
+
+@pytest.mark.asyncio
+async def test_partial_recovery_critical_to_high_supersedes(db):
+    """A PARTIAL recovery (critical → high, still >= LOW) supersedes the peak
+    'critical' row so it does not linger, leaving only the current 'high' row —
+    which does NOT page. Regression for the fluctuating-metric case."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_HIGH + 5)
+    await loop._check_embedding_backlog(db)
+    assert [r["priority"] for r in await _unresolved(db)] == ["critical"]
+
+    # Recover to a modest (high-band) pile — still above LOW.
+    await db.execute("DELETE FROM memory_metadata WHERE embedding_status='failed'")
+    await db.commit()
+    await _seed(db, "failed", loop._EMBED_BACKLOG_LOW + 10, start=900_000)
+    await loop._check_embedding_backlog(db)
+
+    rows = await _unresolved(db)
+    assert [r["priority"] for r in rows] == ["high"]  # critical superseded
+    # The lingering critical must NOT still be visible to the paging poll.
+    surfaced = await obs_crud.get_unsurfaced(
+        db,
+        priority_filter=("critical",),
+        exclude_types=tuple(obs_crud.INTERNAL_OBS_TYPES),
+    )
+    assert not any(o["source"] == "embedding_backlog_monitor" for o in surfaced)
+
+
+@pytest.mark.asyncio
+async def test_recovery_resolves_and_reclears_cooldown(db):
+    """Backlog drops below LOW → the standing alert resolves and the cooldown
+    globals reset so a fresh spike re-alerts cleanly."""
+    await _seed(db, "failed", loop._EMBED_BACKLOG_HIGH + 5)
+    await loop._check_embedding_backlog(db)
+    assert len(await _unresolved(db)) == 1
+
+    # Drain: delete the failed rows, re-run — should resolve.
+    await db.execute("DELETE FROM memory_metadata WHERE embedding_status='failed'")
+    await db.commit()
+    await loop._check_embedding_backlog(db)
+
+    assert await _unresolved(db) == []
+    assert loop._last_embed_backlog_alert_at == 0.0
+    assert loop._last_embed_backlog_band == ""
+
+
+@pytest.mark.asyncio
+async def test_pending_is_context_not_a_trigger(db):
+    """A pile of 'pending' (self-healing) with zero 'failed' must not alert —
+    pending spikes are the rate-based alert's job, not this depth probe's."""
+    await _seed(db, "pending", loop._EMBED_BACKLOG_HIGH + 100)
+    await loop._check_embedding_backlog(db)
+    assert await _total(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_none_db_is_noop():
+    await loop._check_embedding_backlog(None)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_body_swallows_errors(db, monkeypatch):
+    """A failure inside the probe never raises into the tick."""
+
+    async def _boom(_db):
+        raise RuntimeError("reader down")
+
+    monkeypatch.setattr("genesis.db.crud.memory.embedding_status_counts", _boom)
+    await loop._check_embedding_backlog(db)  # swallowed

--- a/tests/test_db/test_embedding_status_counts.py
+++ b/tests/test_db/test_embedding_status_counts.py
@@ -1,0 +1,58 @@
+"""Tests for db.crud.memory.embedding_status_counts — the shared grouped
+aggregate over memory_metadata.embedding_status used by both the dashboard
+memory-health snapshot and the awareness embedding-backlog probe."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import memory as mem_crud
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _seed(db, status, n, *, start=0):
+    rows = [
+        (f"{status}-{start + i}", "2026-01-01T00:00:00", "episodic_memory", 0.5, status)
+        for i in range(n)
+    ]
+    await db.executemany(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, confidence, embedding_status) "
+        "VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_empty_table_returns_empty_map(db):
+    assert await mem_crud.embedding_status_counts(db) == {}
+
+
+@pytest.mark.asyncio
+async def test_counts_by_status(db):
+    await _seed(db, "embedded", 5)
+    await _seed(db, "fts5_only", 3, start=100)
+    await _seed(db, "failed", 2, start=200)
+    await _seed(db, "pending", 1, start=300)
+
+    counts = await mem_crud.embedding_status_counts(db)
+    assert counts == {"embedded": 5, "fts5_only": 3, "failed": 2, "pending": 1}
+
+
+@pytest.mark.asyncio
+async def test_absent_statuses_are_missing_not_zero(db):
+    await _seed(db, "embedded", 4)
+    counts = await mem_crud.embedding_status_counts(db)
+    assert counts == {"embedded": 4}
+    assert counts.get("failed", 0) == 0  # callers use .get()

--- a/tests/test_observability/test_memory_health_backlog.py
+++ b/tests/test_observability/test_memory_health_backlog.py
@@ -1,0 +1,59 @@
+"""Snapshot test: memory_health() surfaces the embedding_backlog key with
+failed/pending counts drawn from memory_metadata (the durable mirror), which
+feeds the neural-monitor dashboard's always-on backlog display."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+from genesis.observability.snapshots.memory_health import memory_health
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _seed(db, status, n, *, start=0):
+    rows = [
+        (f"{status}-{start + i}", "2026-01-01T00:00:00", "episodic_memory", 0.5, status)
+        for i in range(n)
+    ]
+    await db.executemany(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, confidence, embedding_status) "
+        "VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_embedding_backlog_key_present_and_counts(db):
+    await _seed(db, "embedded", 10)
+    await _seed(db, "failed", 4, start=100)
+    await _seed(db, "pending", 2, start=200)
+    await _seed(db, "fts5_only", 7, start=300)  # healthy — must NOT count
+
+    snap = await memory_health(db)
+    assert "embedding_backlog" in snap
+    assert snap["embedding_backlog"] == {"failed": 4, "pending": 2}
+
+
+@pytest.mark.asyncio
+async def test_embedding_backlog_zero_baseline(db):
+    await _seed(db, "embedded", 5)
+    snap = await memory_health(db)
+    assert snap["embedding_backlog"] == {"failed": 0, "pending": 0}
+
+
+@pytest.mark.asyncio
+async def test_no_db_unavailable_has_no_backlog_key(db):
+    snap = await memory_health(None)
+    assert snap == {"status": "unavailable"}


### PR DESCRIPTION
## What

Adds an **embedding-backlog degradation alert**: counts `memory_metadata.embedding_status='failed'` rows — memories that are permanently keyword-only (no vector/semantic search) because the embedding recovery worker gave up on them.

## Why (the genuine gap)

Existing coverage does **not** catch this backlog:
- `provider:embedding_failing` (rate-based) only fires *while* embeddings are actively failing — silent once the outage that created the failed rows is over.
- The dashboard's existing "Failed"/"Pending" rows read the **transient** `pending_embeddings` queue table, which the TTL reaper purges. The durable `memory_metadata.embedding_status` mirror survives reaping — so a permanent pile of keyword-only memories accumulates uncounted.

Prod baseline is `failed=0` (verified live), so the signal is clean.

## Design — one probe, two surfaces, zero migrations

- **Shared reader** `db.crud.memory.embedding_status_counts` — one grouped aggregate, the single source of truth.
- **Always-on dashboard**: `memory_health()` returns `embedding_backlog: {failed, pending}` → a distinct "Embed backlog" row on the neural-monitor (clearly separated from the transient queue rows).
- **Awareness hourly probe** (`_check_embedding_backlog`): hybrid, keyed on `failed`:
  - `<50` → quiet + auto-resolve
  - `50–999` → `high` (dashboard/morning-report only — does **not** page)
  - `≥1000` → `critical` (pages Telegram via `_critical_observations_job`, which polls `priority_filter=("critical",)`)
  - band + cooldown + `skip_if_duplicate` dedup; unconditional auto-resolve on recovery; best-effort guarded so it never raises into the tick.

Mirrors the existing dead-letter accumulation alert, and **improves on it**: each active check supersedes stale other-band rows, so a worsening (`high→critical`) or partial recovery (`critical→high`) transition leaves exactly one active alert = the current band, instead of a peak-severity row lingering until full recovery.

## Verification

- New targeted tests (probe band/priority/dedup/resolve/supersede matrix, shared reader, snapshot key) — all green; `ruff` clean.
- Regression: `test_loop`, `test_queues_dead_letter`, `test_wal_health`, `test_memory` all green.
- **Live-DB E2E on a scratch copy of prod**: prod-shape baseline → 0 rows; 1200 failed → one `critical` (visible to the paging poll); partial recover to 300 → supersedes to one `high` (invisible to the paging poll); full recover → resolved.
- Code-reviewer pass: no BLOCKER/SHOULD-FIX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)