### PR TITLE
feat(scripts): git_repair.py — operator-invoked corrupt-.git recovery (F.2)

### DIFF
--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -116,3 +116,55 @@ Two mechanisms make this observable and survivable without host access:
 You can mint the token proactively at install, or defer it entirely: the first
 auth-health alert is the cue, and the response becomes "mint + store from
 anywhere" instead of "SSH to the host and re-run `claude login`."
+
+## Git-Metadata Corruption Recovery (`scripts/git_repair.py`)
+
+A storage fault (the 2026-07-03 thin-pool outage) can leave the repo's *own*
+git metadata silently corrupt: an ext4 `data=ordered` journal replay preserves
+file **structure** while zeroing **unflushed data blocks**, so `.git/config`,
+`packed-refs`, and any loose objects being written read back as NUL — with **no
+git-level error**. This silently disables the guardian's `REVERT_CODE` recovery
+lever (it needs healthy local git). The F.1 detectors
+(`genesis.observability.git_health` on the container tick + the guardian's
+`git_watch` live probe) surface it and both alerts say **"run
+`scripts/git_repair.py`."** This is that tool.
+
+**Properties.** Stdlib-only, targets **system `python3`** (survives a broken
+venv), **dry-run by default** — `--apply` gates every mutation. It never touches
+the working tree or index in the automated rungs, and it **never swaps `.git`
+automatically** (the last resort only prints steps for a human).
+
+```bash
+# 1. See what's wrong + what it WOULD do — mutates nothing:
+python3 scripts/git_repair.py
+# 2. Repair (captures a recovery baseline first, then walks the ladder):
+python3 scripts/git_repair.py --apply
+# 3. If a-d cannot fix it, enable the guided last-resort re-clone (prints the
+#    .git-swap steps for you to run by hand; still never swaps automatically):
+python3 scripts/git_repair.py --apply --allow-reclone
+# Override the origin URL when .git/config is unrecoverable:
+python3 scripts/git_repair.py --apply --remote-url https://github.com/<owner>/<repo>.git
+```
+
+**Repair ladder** (re-diagnoses after each rung; stops when `fsck --full` is
+clean): (a) regenerate `.git/config` + a zeroed `.git/HEAD` from a template
+(origin URL resolved from existing config → `--remote-url` → `GENESIS_REPO_URL`
+→ the capture — never from a backup, which is circular); (b) **move** corrupt
+loose objects to `.git/RECOVERY-corrupt-objects/<ts>/` (they are mode 0444 — the
+tool moves, never overwrites); (c) `git fetch --refetch origin` (a *plain* fetch
+does **not** backfill a quarantined object — only `--refetch` does) + reflog tip
+repair; (d) `git repack -a -d` (only once the store is complete — repack
+hard-fails on a missing reachable object); (e) guided re-clone.
+
+**Re-clone caveat (the last resort).** Swapping `.git` orphans **every linked
+worktree** — their gitdir pointers reference `<main>/.git/worktrees/<name>`,
+which the fresh `.git` does not contain. The tool therefore refuses to swap
+automatically: with `--allow-reclone` it clones + `fsck`-verifies a fresh copy,
+enumerates the linked worktrees at risk, and prints the exact `mv`/`git reset
+--mixed HEAD`/`git worktree prune`+re-add steps for you to run after review. Your
+working tree is preserved (the swap + `git reset --mixed HEAD` leaves tracked
+edits and untracked files byte-identical); the old database is set aside as
+`.git-broken-<ts>` (moved *outside* the repo) so nothing is destroyed.
+
+Exit codes: `0` healthy · `1` residual issues remain (escalate) · `2` aborted
+(no writable capture, or no origin URL resolvable for a config restore).

--- a/scripts/capture_recovery_state.sh
+++ b/scripts/capture_recovery_state.sh
@@ -14,12 +14,16 @@ capture_repo() {
     local target="$OUT_DIR/$name"
 
     mkdir -p "$target"
-    git -C "$repo" rev-parse HEAD > "$target/head.txt"
-    git -C "$repo" branch --show-current > "$target/branch.txt"
-    git -C "$repo" status --short > "$target/status.txt"
+    # `|| true` on every git call: this script also runs mid-incident (git_repair.py
+    # invokes it on a CORRUPT repo), where any git command may fail. Under
+    # `set -e` an unguarded failure would abort the whole capture — losing the
+    # partial baseline we most need. Degrade gracefully, capture what we can.
+    git -C "$repo" rev-parse HEAD > "$target/head.txt" || true
+    git -C "$repo" branch --show-current > "$target/branch.txt" || true
+    git -C "$repo" status --short > "$target/status.txt" || true
     git -C "$repo" diff > "$target/unstaged.diff" || true
     git -C "$repo" diff --cached > "$target/staged.diff" || true
-    git -C "$repo" ls-files --others --exclude-standard > "$target/untracked.txt"
+    git -C "$repo" ls-files --others --exclude-standard > "$target/untracked.txt" || true
 }
 
 capture_repo genesis "$GENESIS_REPO"

--- a/scripts/git_repair.py
+++ b/scripts/git_repair.py
@@ -116,6 +116,11 @@ class Check:
 class Diagnosis:
     checks: list[Check] = field(default_factory=list)
     corrupt_objects: list[Path] = field(default_factory=list)  # loose object paths
+    # origin reachability is a PRECONDITION for the refetch/reclone rungs, NOT
+    # part of the local-health verdict: a fsck-clean repo whose origin is briefly
+    # unreachable (or a moved file:// origin) is still HEALTHY and must exit 0.
+    origin_reachable: bool = False
+    packed_refs_corrupt: bool = False
 
     @property
     def healthy(self) -> bool:
@@ -129,6 +134,11 @@ class Diagnosis:
         for c in self.checks:
             mark = "OK  " if c.ok else "FAIL"
             lines.append(f"  [{mark}] {c.name}" + (f" — {c.detail}" if c.detail else ""))
+        # informational, never part of `healthy`
+        lines.append(
+            f"  [{'OK  ' if self.origin_reachable else 'INFO'}] origin reachable"
+            " (precondition for refetch/reclone, not a health check)"
+        )
         return "\n".join(lines)
 
 
@@ -151,6 +161,20 @@ def _scan_zeroed_loose(git_dir: Path) -> list[Path]:
             if data and not any(data):  # non-empty and all bytes zero
                 zeroed.append(obj)
     return zeroed
+
+
+def _packed_refs_corrupt(git_dir: Path) -> bool:
+    """True if ``.git/packed-refs`` is present but zeroed/truncated. A valid
+    packed-refs is plain text; the outage zeroed it to NUL, which makes
+    ``for-each-ref``/``fsck``/``ls-remote`` all abort with 'unterminated line in
+    .git/packed-refs'. NUL detection covers the zeroed case cleanly."""
+    pr = git_dir / "packed-refs"
+    if not pr.is_file() or pr.stat().st_size == 0:
+        return False
+    try:
+        return b"\x00" in pr.read_bytes()
+    except OSError:
+        return True
 
 
 def _fsck_corrupt_paths(fsck_stderr: str, git_dir: Path) -> list[Path]:
@@ -198,6 +222,15 @@ def diagnose(repo: Path) -> Diagnosis:
         head_ok = r.returncode == 0
     d.add("HEAD resolvable", head_ok, "" if head_ok else "HEAD zeroed or unresolvable")
 
+    # packed-refs intact — a corrupt packed-refs aborts for-each-ref/fsck/ls-remote
+    pr_corrupt = _packed_refs_corrupt(git_dir)
+    d.packed_refs_corrupt = pr_corrupt
+    d.add(
+        "packed-refs intact",
+        not pr_corrupt,
+        "" if not pr_corrupt else ".git/packed-refs zeroed/truncated (NUL bytes)",
+    )
+
     # refs readable
     r = _git(repo, "for-each-ref")
     d.add("refs readable", r.returncode == 0, "" if r.returncode == 0 else r.stderr.strip()[:120])
@@ -233,13 +266,10 @@ def diagnose(repo: Path) -> Diagnosis:
     corrupt = set(zeroed) | set(_fsck_corrupt_paths(r.stderr, git_dir))
     d.corrupt_objects = sorted(corrupt)
 
-    # origin reachability (needed for refetch/reclone)
+    # origin reachability — a PRECONDITION for refetch/reclone, recorded on its
+    # own field so it never drags a locally-healthy repo's verdict to unhealthy.
     r = _git(repo, "ls-remote", "--exit-code", "origin", "HEAD", timeout=_LSREMOTE_TIMEOUT_S)
-    d.add(
-        "origin reachable",
-        r.returncode == 0,
-        "" if r.returncode == 0 else "cannot reach origin (refetch/reclone unavailable)",
-    )
+    d.origin_reachable = r.returncode == 0
 
     return d
 
@@ -334,7 +364,9 @@ def _detect_branch(repo: Path, capture: Path | None) -> str:
 
 
 def restore_config(repo: Path, url: str, branch: str, *, apply: bool) -> None:
-    git_dir = repo / ".git"
+    """Regenerate ``.git/config`` from a template. Called ONLY when config is
+    genuinely unparseable — a healthy config is never overwritten (that would
+    lose custom settings: credential helpers, extra remotes, user options)."""
     cfg_text = (
         "[core]\n"
         "\trepositoryformatversion = 0\n"
@@ -351,22 +383,60 @@ def restore_config(repo: Path, url: str, branch: str, *, apply: bool) -> None:
     if not apply:
         _log(f"WOULD RESTORE .git/config (url={url}, branch={branch})")
     else:
-        (git_dir / "config").write_text(cfg_text)
+        (repo / ".git" / "config").write_text(cfg_text)
         _log(f"RESTORED .git/config (url={url}, branch={branch})")
 
-    # zeroed/unresolvable HEAD → generated one-liner symref
-    head = git_dir / "HEAD"
+
+def restore_head(repo: Path, branch: str, *, apply: bool) -> None:
+    """Regenerate a zeroed/invalid ``.git/HEAD`` *file* (a one-line symref).
+    Self-guards: a valid HEAD whose branch tip merely went missing is NOT a
+    HEAD-file problem (that is a branch-tip restore) and is left untouched —
+    ``rev-parse --symbolic-full-name`` resolves a symref even with no tip."""
+    head = repo / ".git" / "HEAD"
     head_bad = (
         (not head.is_file())
         or head.stat().st_size == 0
         or _git(repo, "rev-parse", "--symbolic-full-name", "HEAD").returncode != 0
     )
-    if head_bad:
-        if not apply:
-            _log(f"WOULD RESTORE .git/HEAD → ref: refs/heads/{branch}")
-        else:
-            head.write_text(f"ref: refs/heads/{branch}\n")
-            _log(f"RESTORED .git/HEAD → ref: refs/heads/{branch}")
+    if not head_bad:
+        return
+    if not apply:
+        _log(f"WOULD RESTORE .git/HEAD → ref: refs/heads/{branch}")
+    else:
+        head.write_text(f"ref: refs/heads/{branch}\n")
+        _log(f"RESTORED .git/HEAD → ref: refs/heads/{branch}")
+
+
+def restore_branch_tips(repo: Path, branch: str, *, apply: bool) -> None:
+    """Recreate a local branch tip that was lost with a quarantined packed-refs.
+    Prefers the remote-tracking ref (restored by the refetch); falls back to the
+    reflog's last recorded tip. Self-guards if the tip is already present."""
+    if _git(repo, "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}").returncode == 0:
+        return
+    tip = ""
+    r = _git(repo, "rev-parse", "--verify", "--quiet", f"refs/remotes/origin/{branch}")
+    if r.returncode == 0 and r.stdout.strip():
+        tip = r.stdout.strip()
+    else:
+        log = repo / ".git" / "logs" / "refs" / "heads" / branch
+        if log.is_file():
+            lines = [ln for ln in log.read_text(errors="ignore").splitlines() if ln.strip()]
+            if lines:  # reflog line: "<old> <new> <who> <ts> <msg>"
+                parts = lines[-1].split()
+                if len(parts) >= 2 and _HEX40.fullmatch(parts[1]):
+                    tip = parts[1]
+    if not tip:
+        _log(f"could not restore refs/heads/{branch}: no remote-tracking ref or reflog tip")
+        return
+    if not apply:
+        _log(f"WOULD RESTORE refs/heads/{branch} → {tip[:12]}")
+        return
+    r = _git(repo, "update-ref", f"refs/heads/{branch}", tip)
+    _log(
+        f"RESTORED refs/heads/{branch} → {tip[:12]}"
+        if r.returncode == 0
+        else f"tip restore failed for {branch}: {r.stderr.strip()[:120]}"
+    )
 
 
 # ─── Rung b: quarantine ──────────────────────────────────────────────────────
@@ -396,6 +466,27 @@ def quarantine_objects(repo: Path, objs: list[Path], *, apply: bool) -> int:
         + (f" → {dest}" if apply else "")
     )
     return n
+
+
+def quarantine_packed_refs(repo: Path, *, apply: bool) -> None:
+    """MOVE a corrupt ``.git/packed-refs`` aside. Loose refs under .git/refs/
+    survive; branch tips that lived ONLY in packed-refs are then restored by the
+    refetch (origin refs) + reflog tip repair in rung c — the Phase-0 recipe. We
+    move (never delete) so the operator can inspect the original."""
+    pr = repo / ".git" / "packed-refs"
+    if not pr.is_file():
+        return
+    if not apply:
+        _log(f"WOULD QUARANTINE corrupt {pr} (refs restored via refetch/reflog)")
+        return
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    dest = repo / ".git" / "RECOVERY-corrupt-objects" / ts
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(pr), str(dest / "packed-refs"))
+        _log(f"QUARANTINED corrupt packed-refs → {dest} (refs restored via refetch/reflog)")
+    except OSError as exc:
+        _log(f"quarantine FAILED for {pr}: {exc}")
 
 
 # ─── Rung c: refetch + reflog tip repair ─────────────────────────────────────
@@ -500,6 +591,10 @@ def guided_reclone(repo: Path, url: str, *, apply: bool) -> None:
 # ─── Orchestration ───────────────────────────────────────────────────────────
 
 
+def _check_ok(d: Diagnosis, name: str) -> bool:
+    return any(c.name == name and c.ok for c in d.checks)
+
+
 def repair(repo: Path, *, apply: bool, remote_url: str | None, allow_reclone: bool) -> int:
     _log(f"git_repair starting on {repo} (mode={'APPLY' if apply else 'DRY-RUN'})")
 
@@ -534,11 +629,18 @@ def repair(repo: Path, *, apply: bool, remote_url: str | None, allow_reclone: bo
         return 1
 
     branch = _detect_branch(repo, capture)
+    packed_refs_was_corrupt = d.packed_refs_corrupt
 
-    # Rung a — config/HEAD
-    if not any(c.name == "config parses" and c.ok for c in d.checks) or not any(
-        c.name == "HEAD resolvable" and c.ok for c in d.checks
-    ):
+    # Rung a — structural metadata, in DEPENDENCY ORDER (a corrupt config or
+    # packed-refs makes for-each-ref/fsck/rev-parse abort, masking everything).
+    # a1: packed-refs FIRST — clears the 'unterminated line' abort so the rest of
+    #     the diagnosis reflects reality (branch tips may then read as missing).
+    if d.packed_refs_corrupt:
+        quarantine_packed_refs(repo, apply=True)
+        d = diagnose(repo)
+        _log("Post-packed-refs diagnosis:\n" + d.render())
+    # a2: config — ONLY when genuinely unparseable (never clobber a healthy one).
+    if not _check_ok(d, "config parses"):
         url = _resolve_url(repo, remote_url=remote_url, capture=capture)
         if not url:
             _log(
@@ -548,25 +650,35 @@ def repair(repo: Path, *, apply: bool, remote_url: str | None, allow_reclone: bo
             return 2
         restore_config(repo, url, branch, apply=True)
         d = diagnose(repo)
-        _log("Post-config diagnosis:\n" + d.render())
+    # a3: HEAD *file* (self-guards; a merely-missing tip is handled after refetch).
+    if not _check_ok(d, "HEAD resolvable"):
+        restore_head(repo, branch, apply=True)
+        d = diagnose(repo)
 
-    # Rung b — quarantine
+    # Rung b — quarantine corrupt loose objects
     if d.corrupt_objects:
         quarantine_objects(repo, d.corrupt_objects, apply=True)
         d = diagnose(repo)
 
     # Rung c — refetch (only if origin reachable; refetch() short-circuits so its
     # side effect fires only when the store is unhealthy AND origin is reachable)
-    if (
-        not d.healthy
-        and any(c.name == "origin reachable" and c.ok for c in d.checks)
-        and refetch(repo, apply=True)
-    ):
+    did_refetch = False
+    if not d.healthy and d.origin_reachable and refetch(repo, apply=True):
+        did_refetch = True
         d = diagnose(repo)
         _log("Post-refetch diagnosis:\n" + d.render())
 
-    # Rung d — repack (only once the store is complete again)
-    if any(c.name == "fsck --full clean" and c.ok for c in d.checks):
+    # Restore any branch tip lost with a quarantined packed-refs — from the
+    # remote-tracking ref (populated by the refetch) or the reflog. Self-guards.
+    if packed_refs_was_corrupt:
+        restore_branch_tips(repo, branch, apply=True)
+        d = diagnose(repo)
+        _log("Post-tip-restore diagnosis:\n" + d.render())
+
+    # Rung d — repack: consolidate ONLY after an actual refetch, and only once the
+    # store is complete again (repack hard-fails on a missing reachable object).
+    # Skipped on a config-only repair — there is nothing new to consolidate.
+    if did_refetch and _check_ok(d, "fsck --full clean"):
         repack(repo, apply=True)
         d = diagnose(repo)
 
@@ -594,16 +706,25 @@ def _dry_run_plan(
 ) -> None:
     """Show the ladder the tool WOULD walk, without mutating anything."""
     branch = _detect_branch(repo, capture)
-    if not all(c.ok for c in d.checks if c.name in ("config parses", "HEAD resolvable")):
+    if d.packed_refs_corrupt:
+        quarantine_packed_refs(repo, apply=False)
+    if not _check_ok(d, "config parses"):
         url = _resolve_url(repo, remote_url=remote_url, capture=capture)
         if url:
             restore_config(repo, url, branch, apply=False)
         else:
             _log("WOULD ABORT: no origin URL resolvable for config restore.")
+    if not _check_ok(d, "HEAD resolvable"):
+        restore_head(repo, branch, apply=False)
     if d.corrupt_objects:
         quarantine_objects(repo, d.corrupt_objects, apply=False)
-    refetch(repo, apply=False)
-    repack(repo, apply=False)
+    if d.origin_reachable:
+        refetch(repo, apply=False)
+        repack(repo, apply=False)
+    else:
+        _log("WOULD SKIP refetch/repack: origin unreachable")
+    if d.packed_refs_corrupt:
+        restore_branch_tips(repo, branch, apply=False)
     if allow_reclone:
         url = _resolve_url(repo, remote_url=remote_url, capture=capture)
         if url:

--- a/scripts/git_repair.py
+++ b/scripts/git_repair.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""Operator-invoked git-metadata repair — recovers a corrupt local `.git`.
+
+Companion to the F.1 detectors (``genesis.observability.git_health`` +
+``genesis.guardian.git_watch``). Those alerts say "run scripts/git_repair.py";
+this is that tool. It repairs the incident class from the 2026-07-03 thin-pool
+outage: an ext4 ``data=ordered`` journal replay preserved file *structure* while
+zeroing *unflushed data blocks*, so ``.git/config``, ``packed-refs``, and ~30
+loose objects read back as NUL with ZERO git-level error — silently disabling
+the guardian's ``REVERT_CODE`` recovery lever.
+
+NEVER auto-fired. It can, at the extreme, guide a ``.git`` swap, so a human runs
+it. It is **stdlib-only** (no ``genesis`` imports) and targets **system
+python3** so it survives a broken venv, and it is **dry-run by default** —
+``--apply`` gates every mutation.
+
+Repair ladder (re-diagnose after each rung; stop when healthy):
+
+  0. CAPTURE first — ``capture_recovery_state.sh`` best-effort + our own
+     git-independent raw copies of ``.git/{config,HEAD,packed-refs}`` + a refs
+     listing. ``--apply`` is REFUSED if the capture dir is unwritable.
+  1. DIAGNOSE — config validity (``git config --list`` rc, not a hand parse),
+     HEAD resolvable, refs readable, zeroed-loose-object scan, ``fsck --full``
+     (content-level; enumerates ALL corrupt objects), ``ls-remote`` reachability.
+  a. RESTORE ``.git/config`` (+ zeroed ``.git/HEAD``) from a GENERATED template.
+     URL chain: existing config → ``--remote-url`` → ``GENESIS_REPO_URL`` env →
+     the rung-0 raw capture → abort. Backup-sourced URL is rejected (circular).
+  b. QUARANTINE corrupt loose objects → ``.git/RECOVERY-corrupt-objects/<ts>/``.
+     Loose objects are mode 0444 → we MOVE them (never overwrite in place).
+  c. REFETCH — ``git fetch --refetch origin`` (a plain fetch does NOT backfill a
+     quarantined object; only ``--refetch`` does) + repair branch tips from
+     reflog (ref-only; never touches the worktree/index).
+  d. REPACK — ``git repack -a -d`` (no ``--prune=now``), and ONLY after a re-fsck
+     shows the store complete (repack hard-fails on a missing reachable object).
+  e. GUIDED RE-CLONE (``--allow-reclone``, last resort) — clone + fsck-verify a
+     fresh copy, then PRINT the exact operator steps for the ``.git`` swap. The
+     tool NEVER swaps ``.git`` itself: this repo has many linked worktrees whose
+     gitdir pointers live inside the main ``.git``; a swap orphans them, so a
+     human is the final gate on that irreversible move.
+
+Exit: 0 healthy · 1 residual issues remain · 2 aborted (no capture / no URL).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+HOME = Path.home()
+LOG_DIR = HOME / ".genesis" / "logs"
+
+# Timeouts — each justified by a concrete failure mode, not "defense in depth":
+#   fsck --full recomputes SHA-1 over the whole object store; measured ~6s on the
+#   ~82MB .123 store, 3600s = ~600x headroom for a scarred pool under IO stress.
+#   --refetch re-downloads full history (~100MB); 1800s covers a slow link.
+#   ls-remote is a single network round-trip; 60s catches a dead origin fast.
+_FSCK_TIMEOUT_S = 3600
+_FETCH_TIMEOUT_S = 1800
+_LSREMOTE_TIMEOUT_S = 60
+_PLUMBING_TIMEOUT_S = 30  # local rev-parse/config/for-each-ref are ms-scale
+
+_HEX40 = re.compile(r"\b[0-9a-f]{40}\b")
+_OBJ_PATH = re.compile(r"\.git/objects/[0-9a-f]{2}/[0-9a-f]{38}")
+
+
+# ─── Small subprocess + logging helpers ──────────────────────────────────────
+
+
+def _log(msg: str) -> None:
+    ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+    line = f"{ts} {msg}"
+    print(line, flush=True)
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        with (LOG_DIR / "git_repair.log").open("a") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+
+def _git(repo: Path, *args: str, timeout: int = _PLUMBING_TIMEOUT_S) -> subprocess.CompletedProcess:
+    """Run ``git -C <repo> <args>`` capturing text output. Never raises on a
+    non-zero exit (the caller inspects ``.returncode``); a timeout/OSError is
+    surfaced as a synthetic returncode 124/127 so callers stay branch-simple."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(args, 124, "", f"timeout after {timeout}s")
+    except OSError as exc:
+        return subprocess.CompletedProcess(args, 127, "", str(exc))
+
+
+# ─── Diagnosis ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class Diagnosis:
+    checks: list[Check] = field(default_factory=list)
+    corrupt_objects: list[Path] = field(default_factory=list)  # loose object paths
+
+    @property
+    def healthy(self) -> bool:
+        return all(c.ok for c in self.checks)
+
+    def add(self, name: str, ok: bool, detail: str = "") -> None:
+        self.checks.append(Check(name, ok, detail))
+
+    def render(self) -> str:
+        lines = []
+        for c in self.checks:
+            mark = "OK  " if c.ok else "FAIL"
+            lines.append(f"  [{mark}] {c.name}" + (f" — {c.detail}" if c.detail else ""))
+        return "\n".join(lines)
+
+
+def _scan_zeroed_loose(git_dir: Path) -> list[Path]:
+    """Return loose object files whose contents are entirely NUL (the outage
+    fingerprint). Fast pre-check; ``fsck --full`` is the authoritative detector,
+    but this pinpoints the exact files without parsing fsck text."""
+    zeroed: list[Path] = []
+    objroot = git_dir / "objects"
+    if not objroot.is_dir():
+        return zeroed
+    for sub in objroot.iterdir():
+        if not (sub.is_dir() and len(sub.name) == 2 and _HEX40.fullmatch(sub.name + "0" * 38)):
+            continue  # skip pack/, info/, non-fanout dirs
+        for obj in sub.iterdir():
+            try:
+                data = obj.read_bytes()
+            except OSError:
+                continue
+            if data and not any(data):  # non-empty and all bytes zero
+                zeroed.append(obj)
+    return zeroed
+
+
+def _fsck_corrupt_paths(fsck_stderr: str, git_dir: Path) -> list[Path]:
+    """Extract loose-object filesystem paths flagged corrupt by ``fsck --full``.
+
+    fsck prints e.g. ``error: unable to unpack header of .git/objects/22/3b..``
+    and ``error: <sha>: object corrupt or missing: .git/objects/22/3b..`` — we
+    take the concrete ``.git/objects/..`` paths (robust) plus resolve bare
+    40-hex ``object corrupt`` SHAs to their loose path if present on disk."""
+    paths: set[Path] = set()
+    repo_root = git_dir.parent
+    for m in _OBJ_PATH.finditer(fsck_stderr):
+        p = (repo_root / m.group(0)).resolve()
+        if p.exists():
+            paths.add(p)
+    for line in fsck_stderr.splitlines():
+        if "object corrupt or missing" in line or "object corrupt" in line:
+            for sha in _HEX40.findall(line):
+                cand = git_dir / "objects" / sha[:2] / sha[2:]
+                if cand.exists():
+                    paths.add(cand.resolve())
+    return sorted(paths)
+
+
+def diagnose(repo: Path) -> Diagnosis:
+    """Read-only health assessment of ``repo``'s git metadata."""
+    git_dir = repo / ".git"
+    d = Diagnosis()
+
+    # config validity — use git's own parser (git-config syntax is NOT INI:
+    # subsections/continuations/includes make hand-parsing subtly wrong). This
+    # is the same primitive the F.1b guardian probe settled on.
+    cfg = git_dir / "config"
+    cfg_ok = cfg.is_file() and cfg.stat().st_size > 0
+    if cfg_ok:
+        r = _git(repo, "config", "--list")
+        cfg_ok = r.returncode == 0 and bool(r.stdout.strip())
+    d.add("config parses", cfg_ok, "" if cfg_ok else f"{cfg} zeroed/unparseable")
+
+    # HEAD resolvable
+    head_txt = git_dir / "HEAD"
+    head_ok = head_txt.is_file() and head_txt.stat().st_size > 0
+    if head_ok:
+        r = _git(repo, "rev-parse", "HEAD")
+        head_ok = r.returncode == 0
+    d.add("HEAD resolvable", head_ok, "" if head_ok else "HEAD zeroed or unresolvable")
+
+    # refs readable
+    r = _git(repo, "for-each-ref")
+    d.add("refs readable", r.returncode == 0, "" if r.returncode == 0 else r.stderr.strip()[:120])
+
+    # zeroed loose objects (fast fingerprint scan)
+    zeroed = _scan_zeroed_loose(git_dir)
+    d.add(
+        "no zeroed loose objects",
+        not zeroed,
+        "" if not zeroed else f"{len(zeroed)} all-NUL loose object(s)",
+    )
+
+    # fsck --full — authoritative content-level scan, enumerates ALL corrupt
+    r = _git(repo, "fsck", "--full", "--no-progress", timeout=_FSCK_TIMEOUT_S)
+    # fsck exits non-zero on corruption; "dangling"/"notice" lines are normal.
+    fsck_errs = [
+        ln
+        for ln in r.stderr.splitlines()
+        if ln.startswith(("error:", "fatal:")) or "corrupt" in ln or "missing" in ln
+    ]
+    fsck_ok = r.returncode == 0 and not fsck_errs
+    d.add(
+        "fsck --full clean",
+        fsck_ok,
+        ""
+        if fsck_ok
+        else f"{len(fsck_errs)} error line(s); e.g. {fsck_errs[0][:100]}"
+        if fsck_errs
+        else f"rc={r.returncode}",
+    )
+
+    # merge fsck-reported corrupt paths with the zero-scan for the quarantine set
+    corrupt = set(zeroed) | set(_fsck_corrupt_paths(r.stderr, git_dir))
+    d.corrupt_objects = sorted(corrupt)
+
+    # origin reachability (needed for refetch/reclone)
+    r = _git(repo, "ls-remote", "--exit-code", "origin", "HEAD", timeout=_LSREMOTE_TIMEOUT_S)
+    d.add(
+        "origin reachable",
+        r.returncode == 0,
+        "" if r.returncode == 0 else "cannot reach origin (refetch/reclone unavailable)",
+    )
+
+    return d
+
+
+# ─── Rung 0: capture ─────────────────────────────────────────────────────────
+
+
+def capture_state(repo: Path, *, apply: bool) -> Path | None:
+    """Snapshot recovery baseline BEFORE any mutation. Returns the capture dir,
+    or None if it could not be created (which, under ``--apply``, is fatal).
+
+    Does its OWN git-independent raw copies (they survive a corrupt repo) AND
+    invokes ``capture_recovery_state.sh`` best-effort (it aborts on a broken
+    repo — see the ``|| true`` hardening — so we tolerate a partial result)."""
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    out = HOME / "tmp" / f"genesis-git-repair-{ts}"
+    raw = out / "raw"
+    try:
+        raw.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        _log(f"CAPTURE FAILED: cannot create {raw}: {exc}")
+        return None
+
+    git_dir = repo / ".git"
+    for rel in ("config", "HEAD", "packed-refs"):
+        src = git_dir / rel
+        if src.exists():
+            try:
+                shutil.copy2(src, raw / rel)
+            except OSError as exc:
+                _log(f"capture: could not copy {rel}: {exc}")
+    # a plain filesystem listing of refs/ (no git needed)
+    refs = git_dir / "refs"
+    if refs.is_dir():
+        try:
+            with (raw / "refs_listing.txt").open("w") as fh:
+                for p in sorted(refs.rglob("*")):
+                    if p.is_file():
+                        fh.write(f"{p.relative_to(git_dir)}\n")
+        except OSError:
+            pass
+
+    # best-effort richer capture via the shell script (never fatal)
+    script = repo / "scripts" / "capture_recovery_state.sh"
+    if script.exists():
+        try:
+            subprocess.run(
+                ["bash", str(script), str(out / "recovery_state")],
+                capture_output=True,
+                timeout=120,
+                env={**os.environ, "GENESIS_REPO": str(repo)},
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            _log(f"capture: capture_recovery_state.sh best-effort failed: {exc}")
+
+    _log(f"CAPTURE ok → {out}")
+    return out
+
+
+# ─── Rung a: restore config + HEAD ───────────────────────────────────────────
+
+
+def _resolve_url(repo: Path, *, remote_url: str | None, capture: Path | None) -> str | None:
+    """First hit wins: existing config → --remote-url → env → raw capture."""
+    r = _git(repo, "config", "--get", "remote.origin.url")
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip()
+    if remote_url:
+        return remote_url
+    env = os.environ.get("GENESIS_REPO_URL")
+    if env:
+        return env
+    if capture:
+        cap_cfg = capture / "raw" / "config"
+        if cap_cfg.is_file():
+            for line in cap_cfg.read_text(errors="ignore").splitlines():
+                line = line.strip()
+                if line.startswith("url ="):
+                    return line.split("=", 1)[1].strip()
+    return None
+
+
+def _detect_branch(repo: Path, capture: Path | None) -> str:
+    """Best-effort default branch for a regenerated HEAD."""
+    if capture:
+        cap_head = capture / "raw" / "HEAD"
+        if cap_head.is_file():
+            txt = cap_head.read_text(errors="ignore").strip()
+            if txt.startswith("ref: refs/heads/"):
+                return txt.rsplit("/", 1)[-1]
+    return "main"
+
+
+def restore_config(repo: Path, url: str, branch: str, *, apply: bool) -> None:
+    git_dir = repo / ".git"
+    cfg_text = (
+        "[core]\n"
+        "\trepositoryformatversion = 0\n"
+        "\tfilemode = true\n"
+        "\tbare = false\n"
+        "\tlogallrefupdates = true\n"
+        '[remote "origin"]\n'
+        f"\turl = {url}\n"
+        "\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+        f'[branch "{branch}"]\n'
+        "\tremote = origin\n"
+        f"\tmerge = refs/heads/{branch}\n"
+    )
+    if not apply:
+        _log(f"WOULD RESTORE .git/config (url={url}, branch={branch})")
+    else:
+        (git_dir / "config").write_text(cfg_text)
+        _log(f"RESTORED .git/config (url={url}, branch={branch})")
+
+    # zeroed/unresolvable HEAD → generated one-liner symref
+    head = git_dir / "HEAD"
+    head_bad = (
+        (not head.is_file())
+        or head.stat().st_size == 0
+        or _git(repo, "rev-parse", "--symbolic-full-name", "HEAD").returncode != 0
+    )
+    if head_bad:
+        if not apply:
+            _log(f"WOULD RESTORE .git/HEAD → ref: refs/heads/{branch}")
+        else:
+            head.write_text(f"ref: refs/heads/{branch}\n")
+            _log(f"RESTORED .git/HEAD → ref: refs/heads/{branch}")
+
+
+# ─── Rung b: quarantine ──────────────────────────────────────────────────────
+
+
+def quarantine_objects(repo: Path, objs: list[Path], *, apply: bool) -> int:
+    """MOVE corrupt loose objects aside (they are 0444 — never overwrite in
+    place). Returns count quarantined."""
+    if not objs:
+        return 0
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    dest = repo / ".git" / "RECOVERY-corrupt-objects" / ts
+    n = 0
+    for obj in objs:
+        if not apply:
+            _log(f"WOULD QUARANTINE {obj}")
+            n += 1
+            continue
+        try:
+            dest.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(obj), str(dest / obj.name))  # move handles 0444
+            n += 1
+        except OSError as exc:
+            _log(f"quarantine FAILED for {obj}: {exc}")
+    _log(
+        f"{'WOULD QUARANTINE' if not apply else 'QUARANTINED'} {n} object(s)"
+        + (f" → {dest}" if apply else "")
+    )
+    return n
+
+
+# ─── Rung c: refetch + reflog tip repair ─────────────────────────────────────
+
+
+def refetch(repo: Path, *, apply: bool) -> bool:
+    """``git fetch --refetch origin`` — a plain fetch will NOT backfill a
+    quarantined object; only --refetch re-downloads it. Returns True on success."""
+    if not apply:
+        _log("WOULD REFETCH: git fetch --refetch origin")
+        return True
+    _log("REFETCH: git fetch --refetch origin (re-downloads full history) …")
+    r = _git(repo, "fetch", "--refetch", "origin", timeout=_FETCH_TIMEOUT_S)
+    ok = r.returncode == 0
+    _log(f"REFETCH {'ok' if ok else 'FAILED'}" + ("" if ok else f": {r.stderr.strip()[:160]}"))
+    return ok
+
+
+# ─── Rung d: repack ──────────────────────────────────────────────────────────
+
+
+def repack(repo: Path, *, apply: bool) -> None:
+    """``git repack -a -d`` (no --prune=now). Guarded by a re-fsck upstream:
+    repack HARD-FAILS on a missing reachable object, so callers only invoke this
+    once the store is complete again."""
+    if not apply:
+        _log("WOULD REPACK: git repack -a -d")
+        return
+    r = _git(repo, "repack", "-a", "-d", timeout=_FETCH_TIMEOUT_S)
+    if r.returncode == 0:
+        _log("REPACKED: git repack -a -d")
+    else:
+        _log(f"REPACK skipped/failed (store still incomplete?): {r.stderr.strip()[:160]}")
+
+
+# ─── Rung e: guided re-clone (PRINTS steps; never swaps .git) ─────────────────
+
+
+def guided_reclone(repo: Path, url: str, *, apply: bool) -> None:
+    """Clone + fsck-verify a fresh copy, then PRINT the operator steps for the
+    ``.git`` swap. Never executes the swap — this repo has linked worktrees whose
+    gitdir pointers live in the main ``.git``; a swap orphans them, so a human is
+    the final gate. The fresh clone + fsck ARE performed (read-only wrt the real
+    repo) so the printed runbook is proven before it's handed over."""
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    tmp = HOME / "tmp" / f"genesis-reclone-{ts}"
+    _log("")
+    _log("═══ RUNG e: GUIDED RE-CLONE (last resort) ═══")
+
+    # enumerate linked worktrees + local-only branches at risk BEFORE anything
+    wt = _git(repo, "worktree", "list", "--porcelain")
+    linked = [
+        ln.split(" ", 1)[1]
+        for ln in wt.stdout.splitlines()
+        if ln.startswith("worktree ") and Path(ln.split(" ", 1)[1]).resolve() != repo.resolve()
+    ]
+    if linked:
+        _log(f"⚠ {len(linked)} LINKED WORKTREE(S) will be orphaned by a .git swap:")
+        for w in linked:
+            _log(f"    {w}")
+        _log("  Each must be re-created after the swap (steps below). Any uncommitted")
+        _log("  work in them is recoverable only from the set-aside .git-broken dir.")
+
+    _log(f"Cloning a fresh, verified copy to {tmp} …")
+    if not apply:
+        _log(f"WOULD CLONE --no-checkout {url} {tmp} and fsck-verify it")
+        _log("WOULD THEN PRINT the swap steps (never executed automatically).")
+        return
+    tmp.parent.mkdir(parents=True, exist_ok=True)
+    r = subprocess.run(
+        ["git", "clone", "--no-checkout", url, str(tmp)],
+        capture_output=True,
+        text=True,
+        timeout=_FETCH_TIMEOUT_S,
+    )
+    if r.returncode != 0:
+        _log(f"reclone FAILED at clone: {r.stderr.strip()[:160]}")
+        return
+    fr = _git(tmp, "fsck", "--full", "--no-progress", timeout=_FSCK_TIMEOUT_S)
+    if fr.returncode != 0:
+        _log("reclone ABORTED: the fresh clone did not fsck clean — do NOT swap.")
+        return
+    _log("Fresh clone fsck: CLEAN. It is safe to swap in. RUN THESE STEPS BY HAND:")
+    broken = f"{repo}/../.git-broken-{ts}"
+    print(f"""
+  # 1. Move the corrupt .git OUTSIDE the worktree (avoids ?? clutter / stray add):
+  mv {repo}/.git {broken}
+  # 2. Install the verified fresh database:
+  mv {tmp}/.git {repo}/.git
+  # 3. Repopulate the index from HEAD WITHOUT touching your working files:
+  git -C {repo} reset --mixed HEAD
+  # 4. Re-create each linked worktree (they were orphaned by the swap):
+  git -C {repo} worktree prune""")
+    for w in linked:
+        print(f"  #    git -C {repo} worktree add {w} <branch>   # was: {w}")
+    print(f"""  # 5. Verify:
+  git -C {repo} fsck --full && git -C {repo} status
+  # If anything is wrong, your original is intact at {broken}
+""")
+
+
+# ─── Orchestration ───────────────────────────────────────────────────────────
+
+
+def repair(repo: Path, *, apply: bool, remote_url: str | None, allow_reclone: bool) -> int:
+    _log(f"git_repair starting on {repo} (mode={'APPLY' if apply else 'DRY-RUN'})")
+
+    if (repo / ".git").is_file():
+        _log(
+            "ABORT: .git is a FILE — this looks like a linked worktree. Run "
+            "git_repair against the MAIN repository (the one with a .git DIR)."
+        )
+        return 2
+    if not (repo / ".git").is_dir():
+        _log(f"ABORT: {repo}/.git is not a directory — not a git repo.")
+        return 2
+
+    # Rung 0 — capture (fatal only under --apply)
+    capture = capture_state(repo, apply=apply)
+    if apply and capture is None:
+        _log("ABORT: cannot write a recovery capture; refusing to mutate blind.")
+        return 2
+
+    d = diagnose(repo)
+    _log("Diagnosis:\n" + d.render())
+    if d.healthy:
+        _log("HEALTHY — no repair needed.")
+        return 0
+    if not apply:
+        _log(
+            "DRY-RUN: issues found above. Re-run with --apply to repair "
+            "(add --allow-reclone to enable the last-resort guided re-clone)."
+        )
+        # still walk the ladder in dry-run to SHOW what it would do
+        _dry_run_plan(repo, d, remote_url=remote_url, capture=capture, allow_reclone=allow_reclone)
+        return 1
+
+    branch = _detect_branch(repo, capture)
+
+    # Rung a — config/HEAD
+    if not any(c.name == "config parses" and c.ok for c in d.checks) or not any(
+        c.name == "HEAD resolvable" and c.ok for c in d.checks
+    ):
+        url = _resolve_url(repo, remote_url=remote_url, capture=capture)
+        if not url:
+            _log(
+                "ABORT: config is corrupt and no origin URL could be resolved "
+                "(pass --remote-url or set GENESIS_REPO_URL)."
+            )
+            return 2
+        restore_config(repo, url, branch, apply=True)
+        d = diagnose(repo)
+        _log("Post-config diagnosis:\n" + d.render())
+
+    # Rung b — quarantine
+    if d.corrupt_objects:
+        quarantine_objects(repo, d.corrupt_objects, apply=True)
+        d = diagnose(repo)
+
+    # Rung c — refetch (only if origin reachable; refetch() short-circuits so its
+    # side effect fires only when the store is unhealthy AND origin is reachable)
+    if (
+        not d.healthy
+        and any(c.name == "origin reachable" and c.ok for c in d.checks)
+        and refetch(repo, apply=True)
+    ):
+        d = diagnose(repo)
+        _log("Post-refetch diagnosis:\n" + d.render())
+
+    # Rung d — repack (only once the store is complete again)
+    if any(c.name == "fsck --full clean" and c.ok for c in d.checks):
+        repack(repo, apply=True)
+        d = diagnose(repo)
+
+    # Rung e — guided reclone (last resort, gated)
+    if not d.healthy and allow_reclone:
+        url = _resolve_url(repo, remote_url=remote_url, capture=capture)
+        if url:
+            guided_reclone(repo, url, apply=True)
+
+    d = diagnose(repo)
+    _log("Final diagnosis:\n" + d.render())
+    if d.healthy:
+        _log("REPAIRED — fsck clean.")
+        return 0
+    _log(
+        "RESIDUAL issues remain."
+        + ("" if allow_reclone else " Consider re-running with --allow-reclone.")
+        + " See the guided steps above / escalate."
+    )
+    return 1
+
+
+def _dry_run_plan(
+    repo: Path, d: Diagnosis, *, remote_url: str | None, capture: Path | None, allow_reclone: bool
+) -> None:
+    """Show the ladder the tool WOULD walk, without mutating anything."""
+    branch = _detect_branch(repo, capture)
+    if not all(c.ok for c in d.checks if c.name in ("config parses", "HEAD resolvable")):
+        url = _resolve_url(repo, remote_url=remote_url, capture=capture)
+        if url:
+            restore_config(repo, url, branch, apply=False)
+        else:
+            _log("WOULD ABORT: no origin URL resolvable for config restore.")
+    if d.corrupt_objects:
+        quarantine_objects(repo, d.corrupt_objects, apply=False)
+    refetch(repo, apply=False)
+    repack(repo, apply=False)
+    if allow_reclone:
+        url = _resolve_url(repo, remote_url=remote_url, capture=capture)
+        if url:
+            guided_reclone(repo, url, apply=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Operator-invoked repair for a corrupt local .git (dry-run by default)."
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Actually repair (default is dry-run / report only)"
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(os.environ.get("GENESIS_REPO", HOME / "genesis")),
+        help="Repository to repair (default: $GENESIS_REPO or ~/genesis)",
+    )
+    parser.add_argument(
+        "--remote-url", default=None, help="Origin URL to use when .git/config is unrecoverable"
+    )
+    parser.add_argument(
+        "--allow-reclone",
+        action="store_true",
+        help="Enable the last-resort GUIDED re-clone (prints .git-swap "
+        "steps; never swaps automatically)",
+    )
+    args = parser.parse_args()
+
+    repo = args.repo.expanduser().resolve()
+    return repair(
+        repo, apply=args.apply, remote_url=args.remote_url, allow_reclone=args.allow_reclone
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scripts/test_git_repair.py
+++ b/tests/test_scripts/test_git_repair.py
@@ -271,3 +271,63 @@ def test_guided_reclone_dry_run_does_not_clone(repos, tmp_path, capsys):
     gr.guided_reclone(work, str(origin), apply=False)
     out = capsys.readouterr().out
     assert "WOULD CLONE" in out
+
+
+# ─── origin reachability is a precondition, NOT a health check (Codex P2) ─────
+
+
+def test_healthy_repo_with_unreachable_origin_is_healthy(repos, tmp_path):
+    _origin, work = repos
+    # break origin reachability WITHOUT touching local .git integrity
+    _git(work, "remote", "set-url", "origin", str(tmp_path / "gone.git"))
+    d = gr.diagnose(work)
+    assert d.origin_reachable is False
+    assert d.healthy  # local git is intact → healthy despite an unreachable origin
+    r = _run_tool(work, home=tmp_path)
+    assert r.returncode == 0
+    assert "HEALTHY" in r.stdout
+
+
+# ─── corrupt packed-refs repair (Codex P1) ───────────────────────────────────
+
+
+def test_diagnose_flags_corrupt_packed_refs(repos):
+    _origin, work = repos
+    _git(work, "pack-refs", "--all")  # move refs into packed-refs (prunes loose)
+    _zero(work / ".git" / "packed-refs")
+    d = gr.diagnose(work)
+    assert d.packed_refs_corrupt
+    assert not d.healthy
+
+
+def test_apply_repairs_zeroed_packed_refs(repos, tmp_path):
+    _origin, work = repos
+    _git(work, "pack-refs", "--all")
+    pr = work / ".git" / "packed-refs"
+    assert pr.is_file()
+    _zero(pr)
+    # sanity: git itself is now broken on this repo
+    assert (
+        subprocess.run(["git", "-C", str(work), "for-each-ref"], capture_output=True).returncode
+        != 0
+    )
+    r = _run_tool(work, "--apply", home=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert _fsck_clean(work)
+    # branch tip restored (from remote ref) + corrupt packed-refs quarantined
+    assert _git(work, "rev-parse", "--verify", "refs/heads/main").strip()
+    assert list((work / ".git" / "RECOVERY-corrupt-objects").glob("*/packed-refs"))
+
+
+def test_packed_refs_tip_restored_from_reflog_when_origin_down(repos, tmp_path):
+    """With packed-refs corrupt AND origin unreachable, the branch tip must still
+    be recoverable from the reflog (the offline path)."""
+    _origin, work = repos
+    want = _git(work, "rev-parse", "HEAD").strip()
+    _git(work, "pack-refs", "--all")
+    _git(work, "remote", "set-url", "origin", str(tmp_path / "gone.git"))  # origin down
+    _zero(work / ".git" / "packed-refs")
+    r = _run_tool(work, "--apply", home=tmp_path)
+    # tip restored from reflog even though refetch was impossible
+    assert _git(work, "rev-parse", "--verify", "refs/heads/main").strip() == want
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/tests/test_scripts/test_git_repair.py
+++ b/tests/test_scripts/test_git_repair.py
@@ -1,0 +1,273 @@
+"""Tests for scripts/git_repair.py — operator-invoked corrupt-.git repair.
+
+The tool is stdlib-only and dry-run-by-default. These tests use real ``file://``
+origin fixtures (no network) and reproduce the outage fingerprint (all-NUL loose
+objects / zeroed config). The load-bearing safety invariants under test:
+  * dry-run mutates NOTHING (.git fingerprint identical before/after);
+  * corrupt loose objects are MOVED, not overwritten (they are mode 0444);
+  * ``git fetch --refetch`` (not a plain fetch) is what backfills a quarantined
+    object — proven by the repaired object becoming readable again;
+  * the last-resort re-clone NEVER swaps ``.git`` itself (prints steps only) and
+    always enumerates the linked worktrees a swap would orphan;
+  * exit codes: 0 healthy · 1 residual/dry-run-with-issues · 2 aborted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "git_repair.py"
+_spec = importlib.util.spec_from_file_location("git_repair", _SCRIPT)
+gr = importlib.util.module_from_spec(_spec)
+sys.modules["git_repair"] = gr
+_spec.loader.exec_module(gr)
+
+
+# ─── fixtures / helpers ──────────────────────────────────────────────────────
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+@pytest.fixture
+def repos(tmp_path: Path) -> tuple[Path, Path]:
+    """A bare ``file://`` origin + a work clone with real history (loose objs)."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(origin)], check=True)
+    work = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(origin), str(work)], check=True)
+    _git(work, "config", "user.email", "s@s")
+    _git(work, "config", "user.name", "s")
+    for i in range(3):
+        (work / f"f{i}.txt").write_text(f"l{i}\n")
+        _git(work, "add", f"f{i}.txt")
+        _git(work, "commit", "-q", "-m", f"c{i}")
+    (work / "extra.txt").write_text("payload\n")
+    _git(work, "add", "extra.txt")
+    _git(work, "commit", "-q", "-m", "c-loose")
+    _git(work, "push", "-q", "origin", "main")
+    return origin, work
+
+
+def _loose_blob(work: Path) -> Path:
+    sha = _git(work, "rev-parse", "HEAD:extra.txt").strip()
+    return work / ".git" / "objects" / sha[:2] / sha[2:]
+
+
+def _zero(path: Path) -> None:
+    """Overwrite a file with NUL of the same length (mimics the block-zeroing);
+    chmod first because git loose objects are created read-only (0444)."""
+    n = path.stat().st_size
+    os.chmod(path, 0o644)
+    path.write_bytes(b"\x00" * n)
+
+
+def _fingerprint(git_dir: Path) -> list[tuple[str, int, str]]:
+    out = []
+    for p in sorted(git_dir.rglob("*")):
+        if p.is_file():
+            out.append(
+                (
+                    str(p.relative_to(git_dir)),
+                    p.stat().st_size,
+                    hashlib.sha1(p.read_bytes()).hexdigest(),
+                )
+            )
+    return out
+
+
+def _run_tool(repo: Path, *args: str, home: Path) -> subprocess.CompletedProcess:
+    """Invoke the tool as a subprocess with HOME redirected so its capture/log
+    side effects land under the test tmp dir, not the real ~/tmp."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), "--repo", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(home)},
+    )
+
+
+def _fsck_clean(repo: Path) -> bool:
+    r = subprocess.run(
+        ["git", "-C", str(repo), "fsck", "--full", "--no-progress"], capture_output=True, text=True
+    )
+    bad = [
+        ln
+        for ln in r.stderr.splitlines()
+        if "corrupt" in ln or "missing" in ln or ln.startswith(("error:", "fatal:"))
+    ]
+    return r.returncode == 0 and not bad
+
+
+# ─── diagnosis (pure) ────────────────────────────────────────────────────────
+
+
+def test_diagnose_healthy(repos):
+    _origin, work = repos
+    d = gr.diagnose(work)
+    assert d.healthy, d.render()
+    assert not d.corrupt_objects
+
+
+def test_diagnose_detects_zeroed_object(repos):
+    _origin, work = repos
+    blob = _loose_blob(work)
+    _zero(blob)
+    d = gr.diagnose(work)
+    assert not d.healthy
+    assert blob.resolve() in d.corrupt_objects
+    # the fast zero-scan and fsck both flag it
+    names = {c.name: c.ok for c in d.checks}
+    assert names["no zeroed loose objects"] is False
+    assert names["fsck --full clean"] is False
+
+
+def test_scan_zeroed_only_flags_all_nul(repos):
+    _origin, work = repos
+    # a valid loose object must NOT be flagged
+    assert gr._scan_zeroed_loose(work / ".git") == []
+    _zero(_loose_blob(work))
+    assert len(gr._scan_zeroed_loose(work / ".git")) == 1
+
+
+# ─── URL resolution chain ────────────────────────────────────────────────────
+
+
+def test_resolve_url_prefers_existing_config(repos, monkeypatch):
+    origin, work = repos
+    monkeypatch.delenv("GENESIS_REPO_URL", raising=False)
+    assert gr._resolve_url(work, remote_url="X", capture=None) == str(origin)
+
+
+def test_resolve_url_falls_back_to_arg_then_env(repos, tmp_path, monkeypatch):
+    origin, work = repos
+    _zero(work / ".git" / "config")  # existing config now unreadable
+    monkeypatch.delenv("GENESIS_REPO_URL", raising=False)
+    assert gr._resolve_url(work, remote_url="ARG_URL", capture=None) == "ARG_URL"
+    monkeypatch.setenv("GENESIS_REPO_URL", "ENV_URL")
+    assert gr._resolve_url(work, remote_url=None, capture=None) == "ENV_URL"
+
+
+def test_resolve_url_none_when_unresolvable(repos, monkeypatch):
+    _origin, work = repos
+    _zero(work / ".git" / "config")
+    monkeypatch.delenv("GENESIS_REPO_URL", raising=False)
+    assert gr._resolve_url(work, remote_url=None, capture=None) is None
+
+
+# ─── dry-run mutates nothing ─────────────────────────────────────────────────
+
+
+def test_dry_run_mutates_nothing(repos, tmp_path):
+    _origin, work = repos
+    _zero(_loose_blob(work))
+    before = _fingerprint(work / ".git")
+    r = _run_tool(work, home=tmp_path)
+    assert r.returncode == 1, r.stdout + r.stderr  # issues found, dry-run
+    after = _fingerprint(work / ".git")
+    assert before == after  # .git byte-identical — nothing moved/written
+
+
+# ─── apply repairs ───────────────────────────────────────────────────────────
+
+
+def test_apply_repairs_corrupt_object(repos, tmp_path):
+    _origin, work = repos
+    blob = _loose_blob(work)
+    _zero(blob)
+    r = _run_tool(work, "--apply", home=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert _fsck_clean(work)
+    # object is readable again and the corrupt one was quarantined (moved aside)
+    assert list((work / ".git" / "RECOVERY-corrupt-objects").glob("*/*"))
+
+
+def test_apply_repairs_zeroed_config(repos, tmp_path):
+    origin, work = repos
+    _zero(work / ".git" / "config")
+    r = _run_tool(work, "--apply", "--remote-url", str(origin), home=tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert _git(work, "config", "--get", "remote.origin.url").strip() == str(origin)
+    assert _fsck_clean(work)
+
+
+def test_zeroed_config_apply_aborts_without_url(repos, tmp_path, monkeypatch):
+    _origin, work = repos
+    _zero(work / ".git" / "config")
+    # no --remote-url, no env, no readable config → exit 2 abort
+    env_home = tmp_path
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--repo", str(work), "--apply"],
+        capture_output=True,
+        text=True,
+        env={k: v for k, v in os.environ.items() if k != "GENESIS_REPO_URL"}
+        | {"HOME": str(env_home)},
+    )
+    assert r.returncode == 2
+    assert "no origin URL" in (r.stdout + r.stderr)
+
+
+def test_healthy_repo_exit_zero(repos, tmp_path):
+    _origin, work = repos
+    r = _run_tool(work, home=tmp_path)
+    assert r.returncode == 0
+    assert "HEALTHY" in r.stdout
+
+
+def test_idempotent_second_apply(repos, tmp_path):
+    _origin, work = repos
+    _zero(_loose_blob(work))
+    assert _run_tool(work, "--apply", home=tmp_path).returncode == 0
+    r2 = _run_tool(work, "--apply", home=tmp_path)
+    assert r2.returncode == 0
+    assert "HEALTHY" in r2.stdout
+
+
+# ─── linked-worktree safety ──────────────────────────────────────────────────
+
+
+def test_refuses_when_pointed_at_linked_worktree(repos, tmp_path):
+    _origin, work = repos
+    wt = tmp_path / "wt"
+    _git(work, "worktree", "add", "-q", str(wt), "-b", "sidebr")
+    # a linked worktree's .git is a FILE → tool must abort (exit 2), not operate
+    r = _run_tool(wt, home=tmp_path)
+    assert r.returncode == 2
+    assert "linked worktree" in (r.stdout + r.stderr).lower()
+
+
+def test_guided_reclone_lists_worktrees_and_never_swaps(repos, tmp_path, capsys):
+    origin, work = repos
+    wt = tmp_path / "wt"
+    _git(work, "worktree", "add", "-q", str(wt), "-b", "sidebr")
+    git_before = _fingerprint(work / ".git")
+    gr.HOME = tmp_path  # redirect the temp clone destination
+    gr.guided_reclone(work, str(origin), apply=True)
+    out = capsys.readouterr().out
+    # printed the swap runbook, listed the linked worktree, never swapped .git
+    assert "RUN THESE STEPS BY HAND" in out
+    assert str(wt) in out
+    assert "worktree add" in out
+    assert (work / ".git").is_dir()
+    assert _fingerprint(work / ".git") == git_before  # main .git untouched
+
+
+def test_guided_reclone_dry_run_does_not_clone(repos, tmp_path, capsys):
+    origin, work = repos
+    gr.HOME = tmp_path
+    gr.guided_reclone(work, str(origin), apply=False)
+    out = capsys.readouterr().out
+    assert "WOULD CLONE" in out


### PR DESCRIPTION
## What

A storage-layer fault can leave a repository's own git metadata silently corrupt: an ext4 `data=ordered` journal replay preserves file *structure* while zeroing *unflushed data blocks*, so `.git/config`, `packed-refs`, and any loose objects mid-write read back as NUL — **with no git-level error**. This silently disables local git as a recovery substrate. `scripts/git_repair.py` is the operator-invoked tool that diagnoses and repairs that class of damage.

It complements the git-health *detectors* (`genesis.observability.git_health` + the guardian's `git_watch` probe): those surface the problem and point at the recovery runbook; this repairs it.

## Design

- **Stdlib-only**, targets **system `python3`** — survives a broken virtualenv.
- **Dry-run by default**; `--apply` gates every mutation. Never touches the working tree or index in the automated rungs.
- **Captures a recovery baseline first** (and refuses `--apply` if it can't).

**Repair ladder** (re-diagnoses after each rung; stops when `git fsck --full` is clean):
1. Regenerate `.git/config` + a zeroed `.git/HEAD` from a generated template (origin URL resolved from existing config → `--remote-url` → `GENESIS_REPO_URL` → the capture; never from a backup, which would be circular).
2. **Move** corrupt loose objects to `.git/RECOVERY-corrupt-objects/<ts>/` — loose objects are mode `0444`, so they are moved, never overwritten.
3. `git fetch --refetch origin` — a *plain* fetch does **not** backfill a quarantined object; only `--refetch` does.
4. `git repack -a -d` — only once the object store is complete again (repack hard-fails on a missing reachable object).
5. **Guided** re-clone (last resort, `--allow-reclone`): clones + `fsck`-verifies a fresh copy, then **prints** the exact `.git`-swap steps. It **never swaps `.git` automatically** — linked worktrees register inside the main `.git`, so an automatic swap would orphan them; a human is the final gate.

Exit codes: `0` healthy · `1` residual issues remain · `2` aborted (no writable capture / no resolvable origin URL).

## Verification

An empirical corruption spike de-risked the git-CLI behavior *before* implementation (the `--refetch` requirement, fsck enumeration, repack ordering, worktree preservation, and the 0444 constraint were all confirmed by experiment). The tool was then verified end-to-end against scratch `file://` repositories: dry-run mutates nothing (tree-hash proof), single-object repair, zeroed-config repair, combined config+object repair in one run, healthy no-op, idempotency, the linked-worktree abort, and the guided re-clone listing at-risk worktrees without swapping.

Also hardens `scripts/capture_recovery_state.sh` (`|| true` on every git call) so the baseline capture degrades gracefully when invoked mid-incident on a corrupt repo instead of aborting under `set -e`.

- Tests: `tests/test_scripts/test_git_repair.py` (15, `file://` fixtures) — all passing.
- Docs: new recovery section in `docs/reference/recovery-and-portability-workflow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)