### PR TITLE
feat(infra): guardian host plane for the infrastructure body schema

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -348,7 +348,7 @@ radius) and the container-side Sentinel (CC-driven diagnosis/repair).
 ```yaml subsystem-map
 entry: guardian-sentinel
 modules: [guardian, sentinel]
-verified: 9037d45b 2026-07-07
+verified: 3d5234b9 2026-07-13
 ```
 
 - **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
@@ -363,6 +363,10 @@ verified: 9037d45b 2026-07-07
   deployed script is NEWER than the host checkout.
 - Provisioning verbs are EXECUTE-ONLY — approval is the CALLER's
   responsibility (container obtains it via Telegram before invoking).
+- Read-only `host-profile` verb (`guardian/host_profile.py`) feeds the
+  `infra_profile` host plane; the CC diagnosis prompt inlines the shared-mount
+  `INFRASTRUCTURE.md` (truncated) so the diagnostician starts with the body
+  schema instead of re-deriving the machine's shape.
 - **sentinel/** is LIVE-wired but **shadow-only autonomy**: config mode
   `"live"` is NOT implemented (dispatcher warns + downgrades); every proposed
   action requires human approval. `InfrastructureMonitor` (call site 37, free
@@ -549,7 +553,7 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, infra_profile, env.py, _config_overlay.py]
-verified: 613ff6ff 2026-07-12
+verified: 3d5234b9 2026-07-13
 ```
 
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
@@ -635,7 +639,8 @@ verified: 613ff6ff 2026-07-12
 - **codebase/**: AST indexer (surplus task, set-difference deletes with
   CASCADE) behind the `codebase_navigate` MCP tool.
 - **infra_profile/**: the infrastructure body schema — deterministic fact
-  collectors (container plane; host plane via a PR2 guardian verb, degrades to
+  collectors (container plane + host plane via the guardian `host-profile`
+  gateway verb; a missing guardian or un-redeployed gateway degrades to
   "not visible from this vantage") → per-section hashed `profile.json` +
   rendered `INFRASTRUCTURE.md` under `~/.genesis/infrastructure/`. **The
   facts/metrics split is load-bearing**: only `facts` are hashed; a hash change

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -18,6 +18,9 @@
 #   test-approval   — E2E test the keyword-reply approval gate (no recovery)
 #   disk-status     — read-only storage-pool + snapshot JSON (Genesis's window
 #                     into host capacity: lvs data%/metadata%, VG free, snapshots)
+#   host-profile    — read-only host body-schema JSON (meminfo/nproc/kernel,
+#                     storage pool, incus version + container limits.*) for the
+#                     container's infra_profile host plane
 #   provision-status          — read-only Proxmox host capacity (audit token)
 #   provision-grow-disk <disk> <GiB> — EXECUTE a pre-approved VM disk grow +
 #                     absorb (execute-only: NO Telegram gate; caller approves)
@@ -789,6 +792,29 @@ PYEOF
         PYTHONPATH="$INSTALL_DIR/src" \
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
             timeout 30 "$VENV_PY" -m genesis.guardian --disk-status
+        ;;
+    host-profile)
+        # Read-only: print the host body-schema JSON (system identity, storage
+        # pool, virtualization stack + this container's limits.*). Consumed by
+        # the container's infra_profile host-plane collector. No mutation, no
+        # secrets, no sudo.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "host-profile", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        # Skew guard: sync-gateway redeploys THIS script independently of the
+        # src tree. An old checkout has no --host-profile branch — the flag
+        # would fall through main()'s if-chain into run_check(), i.e. a FULL
+        # guardian recovery cycle triggered by a routine read-only poll.
+        if [ ! -f "$INSTALL_DIR/src/genesis/guardian/host_profile.py" ]; then
+            echo '{"ok": false, "action": "host-profile", "error": "guardian src predates host-profile — run update to redeploy"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            timeout 45 "$VENV_PY" -m genesis.guardian --host-profile
         ;;
     provision-status)
         # Read-only host capacity via the Proxmox AUDIT token (VM cores/RAM,

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -6,6 +6,7 @@ Usage:
     python -m genesis.guardian --check-only  # one-shot health check (no recovery)
     python -m genesis.guardian --test-approval  # E2E test the keyword-reply gate
     python -m genesis.guardian --disk-status  # print storage-pool JSON (read-only)
+    python -m genesis.guardian --host-profile  # host body-schema JSON (read-only)
     python -m genesis.guardian --provision-status              # host capacity (read-only)
     python -m genesis.guardian --provision-grow-disk <disk> <GiB>  # EXECUTE (pre-approved)
     python -m genesis.guardian --provision-grow-memory <MiB>       # EXECUTE (pre-approved)
@@ -46,6 +47,9 @@ def main() -> None:
     if "--disk-status" in sys.argv:
         asyncio.run(_disk_status())
         return
+
+    if "--host-profile" in sys.argv:
+        sys.exit(asyncio.run(_host_profile()))
 
     if "--provision-status" in sys.argv:
         sys.exit(asyncio.run(_provision_status()))
@@ -168,6 +172,26 @@ async def _disk_status() -> None:
         "tier": tier,
         "snapshots": snapshots,
     }))
+
+
+async def _host_profile() -> int:
+    """Print the host body-schema JSON (read-only).
+
+    Consumed by the `host-profile` gateway verb → the container's
+    ``infra_profile.collectors.host``, which owns the facts/metrics split.
+    Emits JSON even on total failure so the client never has to guess.
+    """
+    import json
+
+    from genesis.guardian.config import load_config
+    from genesis.guardian.host_profile import gather_host_profile
+
+    try:
+        result = await gather_host_profile(load_config())
+    except Exception as exc:  # noqa: BLE001 — the verb contract is JSON-always
+        result = {"ok": False, "action": "host-profile", "error": repr(exc)}
+    print(json.dumps(result))
+    return 0 if result.get("ok") else 1
 
 
 def _emit(obj: dict) -> int:

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -341,6 +341,11 @@ class GuardianConfig:
         return Path(self.state_dir).expanduser()
 
     @property
+    def shared_path(self) -> Path:
+        """Host-side root of the container's ~/.genesis/shared mount."""
+        return self.state_path / self.briefing.shared_subdir
+
+    @property
     def briefing_path(self) -> Path:
         """Full path to the Guardian briefing file on the host."""
         return (

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -144,8 +144,18 @@ def _build_diagnosis_prompt(
     signal_summary: str,
     container_name: str,
     briefing_context: str | None = None,
+    shared_dir: Path | None = None,
 ) -> str:
-    """Build the full prompt for the CC diagnostic instance."""
+    """Build the full prompt for the CC diagnostic instance.
+
+    ``shared_dir`` is the HOST-side mount of the container's
+    ``~/.genesis/shared`` (``config.shared_path`` — the guardian runs on the
+    host, where ``~/.genesis/shared`` does not exist; verified live
+    2026-07-13). Defaults to the container-side spelling only for legacy
+    callers/tests.
+    """
+    if shared_dir is None:
+        shared_dir = Path.home() / ".genesis" / "shared"
     briefing_section = ""
     if briefing_context:
         briefing_section = f"""
@@ -161,8 +171,7 @@ service baselines, metric norms, and recent history that may help your diagnosis
     sentinel_section = ""
     try:
         import json as _json
-        from pathlib import Path as _Path
-        sentinel_last = _Path.home() / ".genesis" / "shared" / "sentinel" / "last_run.json"
+        sentinel_last = shared_dir / "sentinel" / "last_run.json"
         if sentinel_last.exists():
             sdata = _json.loads(sentinel_last.read_text())
             sentinel_section = f"""
@@ -196,6 +205,35 @@ repeat the same actions. Either try something different or escalate.
 """
     except Exception:
         logger.debug("Failed to read essential knowledge for guardian", exc_info=True)
+
+    # Infrastructure body schema — Genesis's programmatically-maintained map of
+    # what it runs on (CPU/memory/storage stack/limits + operational gotchas),
+    # projected to the shared mount by infra_profile on every refresh. Truncated
+    # hard: the doc runs ~700 lines and the diagnostician needs the headline
+    # facts + annotations, not every sysctl.
+    infra_section = ""
+    try:
+        infra_doc = shared_dir / "infrastructure" / "INFRASTRUCTURE.md"
+        if infra_doc.exists():
+            raw_doc = infra_doc.read_text()
+            if len(raw_doc) > 4096:
+                # Truncate at a line boundary — a fact sliced mid-value
+                # ("limits.memory: 16") is worse than a shorter inline.
+                cut = raw_doc.rfind("\n", 0, 4096)
+                raw_doc = raw_doc[: cut if cut > 0 else 4096]
+            infra_text = raw_doc.strip()
+            if infra_text:
+                infra_section = f"""
+## Infrastructure Body Schema (from shared filesystem, truncated)
+
+Genesis maintains a programmatic profile of its own infrastructure. Use it to
+ground hypotheses (memory limits, storage stack, known gotchas) instead of
+re-deriving the machine's shape:
+
+{infra_text}
+"""
+    except Exception:
+        logger.debug("Failed to read infrastructure profile for guardian", exc_info=True)
 
     return f"""You are the Genesis Guardian — the system's last line of defense.
 Genesis appears to be down. You are running on the host VM with full tool access.
@@ -261,6 +299,7 @@ can cause catastrophic damage:
 {signal_summary}
 {briefing_section}
 {ek_section}
+{infra_section}
 {_FAILURE_INVENTORY}
 
 ## Available Commands
@@ -406,6 +445,7 @@ class DiagnosisEngine:
 
         prompt = _build_diagnosis_prompt(
             diagnostic, signal_summary, container_name, briefing_context,
+            shared_dir=self._config.shared_path,
         )
         cc_path = str(Path(self._config.cc.path).expanduser())
         work_dir = _ensure_work_dir(Path(self._config.cc.work_dir).expanduser())

--- a/src/genesis/guardian/host_profile.py
+++ b/src/genesis/guardian/host_profile.py
@@ -1,0 +1,217 @@
+"""Host-plane profile gather — the guardian's answer to ``host-profile``.
+
+Runs HOST-SIDE (via the gateway verb, ``python -m genesis.guardian
+--host-profile``) and emits one JSON blob with three raw sub-dicts. The
+container's ``infra_profile.collectors.host`` owns the facts/metrics split —
+this module is a dumb, dependency-light data source and must never import
+beyond the guardian package (the guardian venv has no full Genesis install;
+it runs from ``PYTHONPATH=$INSTALL_DIR/src``).
+
+Every probe is best-effort: a missing tool or unreadable file yields an
+omitted/None field, never an exception. Empirically verified against the
+live host 2026-07-12: ``incus config show <name>`` exposes ``limits.*`` at
+the top-level ``config:`` map without ``--expanded`` or sudo; ``pveversion``
+and ``smartctl`` are absent (Proxmox is a layer below the guardian VM);
+``measure_storage_pool`` returns real LVM-thin percentages as the
+unprivileged guardian user (no sudo).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import dataclasses
+import logging
+import os
+import platform
+import shutil
+import socket
+from pathlib import Path
+
+from genesis.guardian._subprocess import run_subprocess
+
+logger = logging.getLogger(__name__)
+
+# Bounds a single external probe (incus/systemd-detect-virt/pveversion).
+# Failure mode: an incus daemon wedged on a stuck storage pool can hang a
+# `config show` indefinitely. 10s per probe keeps one wedged tool bounded
+# while staying far above the ~100ms these commands take healthy.
+_PROBE_TIMEOUT = 10.0
+
+# measure_storage_pool issues up to ~4 SEQUENTIAL subprocesses (pool-name
+# detect, storage show, lvs, vgs), each with its own 10s bound but no
+# aggregate cap — a wedged pool could burn ~40s and push the whole gather
+# past the gateway's `timeout 45`, SIGKILLing it before any JSON is printed
+# (total loss of the healthy sections too). This cap bounds the section so
+# the worst case stays inside the gateway budget (review 2026-07-13).
+_POOL_TIMEOUT = 30.0
+
+
+async def _run(*argv: str) -> str | None:
+    """Probe stdout on rc=0, else None — thin adapter over the shared
+    guardian subprocess helper (timeout kill + OSError → rc=-1 live there)."""
+    rc, stdout, _ = await run_subprocess(*argv, timeout=_PROBE_TIMEOUT)
+    return stdout if rc == 0 else None
+
+
+def _read_meminfo() -> dict:
+    out: dict = {}
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            key, _, rest = line.partition(":")
+            if key in ("MemTotal", "MemAvailable"):
+                out[key] = int(rest.split()[0])  # kB
+    except (OSError, ValueError, IndexError):
+        pass
+    return out
+
+
+def _host_system() -> dict:
+    """Static-ish host identity + current memory/load readings."""
+    section: dict = {}
+    mem = _read_meminfo()
+    if "MemTotal" in mem:
+        section["mem_total_kb"] = mem["MemTotal"]
+    if "MemAvailable" in mem:
+        section["mem_available_kb"] = mem["MemAvailable"]
+    section["nproc"] = os.cpu_count()
+    uname = platform.uname()
+    section["kernel_release"] = uname.release
+    section["architecture"] = uname.machine
+    section["hostname"] = socket.gethostname()
+    with contextlib.suppress(OSError, ValueError, IndexError):
+        section["uptime_seconds"] = float(
+            Path("/proc/uptime").read_text().split()[0],
+        )
+    with contextlib.suppress(OSError, ValueError):
+        section["loadavg"] = [float(x) for x in Path("/proc/loadavg").read_text().split()[:3]]
+    try:
+        for line in Path("/etc/os-release").read_text().splitlines():
+            if line.startswith("PRETTY_NAME="):
+                section["os_pretty_name"] = line.partition("=")[2].strip().strip('"')
+                break
+    except OSError:
+        pass
+    return section
+
+
+async def _host_storage_pool(config) -> dict:
+    """The guardian's own pool measurement, verbatim (asdict of the dataclass)."""
+    from genesis.guardian.pool import measure_storage_pool, worst_tier
+
+    status = await measure_storage_pool(config)
+    section = dataclasses.asdict(status)
+    section["tier"] = worst_tier(status, config.storage_pool) if status.detected else "unknown"
+    section["pool_name"] = getattr(config.storage_pool, "pool_name", None)
+    return section
+
+
+def _parse_incus_limits(config_yaml: str) -> dict:
+    """Top-level ``config:`` map ``limits.*`` keys from `incus config show`.
+
+    yaml.safe_load, not a line scan: device-nested ``limits.read/write`` live
+    under ``devices:`` — a different top-level map — so they cannot leak in,
+    and the parse is immune to incus indentation/quoting changes (a line scan
+    hard-coding two-space indents silently returned {} on any format drift —
+    review 2026-07-13). Any parse failure degrades to {}.
+    """
+    import yaml
+
+    try:
+        data = yaml.safe_load(config_yaml)
+        config_map = (data or {}).get("config") or {}
+        return {
+            key: str(value)
+            for key, value in config_map.items()
+            if isinstance(key, str) and key.startswith("limits.")
+        }
+    except Exception:
+        logger.warning("host_profile: incus config parse failed", exc_info=True)
+        return {}
+
+
+async def _host_virt(config) -> dict:
+    """Virtualization stack: incus version, our container's cage, nesting."""
+    container_name = getattr(config, "container_name", None)
+
+    async def _config_show() -> str | None:
+        if not container_name:
+            return None
+        return await _run("incus", "config", "show", container_name)
+
+    async def _pveversion() -> str | None:
+        # Best-effort layer-below probe: absent on a plain VM (Proxmox lives
+        # one level down from the guardian).
+        if not shutil.which("pveversion"):
+            return None
+        return await _run("pveversion")
+
+    # Independent read-only probes — run concurrently so the section's worst
+    # case is one _PROBE_TIMEOUT, not their sum (gateway budget is 45s total).
+    incus_version, config_yaml, detect_virt, pveversion = await asyncio.gather(
+        _run("incus", "version"),
+        _config_show(),
+        _run("systemd-detect-virt"),
+        _pveversion(),
+    )
+
+    section: dict = {"pve_version": pveversion.strip() if pveversion else None}
+    if incus_version:
+        for line in incus_version.splitlines():
+            key, _, value = line.partition(":")
+            key = key.strip().lower()
+            if key == "client version":
+                section["incus_client_version"] = value.strip()
+            elif key == "server version":
+                section["incus_server_version"] = value.strip()
+    if container_name:
+        section["container_name"] = container_name
+        if config_yaml:
+            section["container_limits"] = _parse_incus_limits(config_yaml)
+    if detect_virt:
+        section["detect_virt"] = detect_virt.strip()
+    section["smartctl_present"] = shutil.which("smartctl") is not None
+    return section
+
+
+async def gather_host_profile(config) -> dict:
+    """Gather all three host sections; per-section failures degrade, not raise.
+
+    Sections run concurrently (they share no state) so the gather's worst case
+    is its slowest section, not the sum — the gateway kills the process at 45s
+    and a SIGKILL loses even the healthy sections' JSON. ``ok`` is False only
+    when EVERY section failed: that is indistinguishable from a dead gather,
+    so the container degrades the plane instead of rendering three error rows.
+    """
+
+    async def _guarded(name: str, awaitable) -> dict:
+        try:
+            return await awaitable
+        except TimeoutError:
+            logger.warning("host_profile: %s timed out", name)
+            return {"error": f"{name} timed out"}
+        except Exception as exc:  # noqa: BLE001 — gather must always emit JSON
+            logger.warning("host_profile: %s failed", name, exc_info=True)
+            return {"error": repr(exc)}
+
+    async def _system() -> dict:
+        return _host_system()
+
+    host_system, host_storage_pool, host_virt = await asyncio.gather(
+        _guarded("host_system", _system()),
+        _guarded(
+            "host_storage_pool",
+            asyncio.wait_for(_host_storage_pool(config), _POOL_TIMEOUT),
+        ),
+        _guarded("host_virt", _host_virt(config)),
+    )
+    sections = {
+        "host_system": host_system,
+        "host_storage_pool": host_storage_pool,
+        "host_virt": host_virt,
+    }
+    all_failed = all(set(s) == {"error"} for s in sections.values())
+    result: dict = {"ok": not all_failed, "action": "host-profile", **sections}
+    if all_failed:
+        result["error"] = "all host sections failed"
+    return result

--- a/src/genesis/guardian/host_profile.py
+++ b/src/genesis/guardian/host_profile.py
@@ -97,12 +97,15 @@ def _host_system() -> dict:
 
 async def _host_storage_pool(config) -> dict:
     """The guardian's own pool measurement, verbatim (asdict of the dataclass)."""
-    from genesis.guardian.pool import measure_storage_pool, worst_tier
+    from genesis.guardian.pool import _detect_pool_name, measure_storage_pool, worst_tier
 
     status = await measure_storage_pool(config)
     section = dataclasses.asdict(status)
     section["tier"] = worst_tier(status, config.storage_pool) if status.detected else "unknown"
-    section["pool_name"] = getattr(config.storage_pool, "pool_name", None)
+    # The incus pool NAME lives in pool.py's detection helper, not in
+    # StoragePoolConfig (which is thresholds-only — reading pool_name off it
+    # always yielded None; Codex P2 2026-07-13).
+    section["pool_name"] = await _detect_pool_name(config)
     return section
 
 

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -10,8 +10,8 @@ enforces this restriction, not our code.
 
 Gateway allowlist: restart-timer, pause, resume, status, reset-state, version,
 update, sync-gateway, redeploy, update-cc, update-node, test-approval,
-disk-status, reharden-key, ping, provision-status, provision-grow-disk,
-provision-grow-memory, storage-expand.
+disk-status, host-profile, reharden-key, ping, provision-status,
+provision-grow-disk, provision-grow-memory, storage-expand.
 """
 
 from __future__ import annotations
@@ -37,6 +37,7 @@ _STATUS_TIMEOUT = 70.0       # gateway: timeout 60
 # the 10s instance default is too tight — a slow verb would return `unreachable`
 # and silently skip EVERY drift/authkey/cc-auth reconciler that reuses this call.
 _VERSION_TIMEOUT = 30.0      # gateway version verb: auth-status probe + version reads
+_HOST_PROFILE_TIMEOUT = 50.0  # gateway: timeout 45 (pool lvs + incus probes)
 _GROW_DISK_TIMEOUT = 660.0   # gateway: timeout 600 (PVE resize + storage-expand)
 _GROW_MEM_TIMEOUT = 180.0    # gateway: timeout 120 (config PUT + pending check)
 _EXPAND_TIMEOUT = 660.0      # gateway: timeout 600 (pvresize + autoextend profile)
@@ -277,6 +278,17 @@ class GuardianRemote:
         """Read-only host capacity (audit token). No approval, no mutation."""
         ok, out = await self._ssh_command("provision-status", timeout=_STATUS_TIMEOUT)
         return self._as_json(ok, out, "provision-status")
+
+    async def host_profile(self) -> dict:
+        """Read-only host body-schema blob for the infra_profile host plane.
+
+        Returns the gateway's JSON verbatim on success. A pre-redeploy gateway
+        answers ``denied`` (its unknown-verb default) — that surfaces here as
+        ``{"ok": False, "error": "denied"}``, which the host-plane collector
+        renders as plane-unavailable. No approval, no mutation.
+        """
+        ok, out = await self._ssh_command("host-profile", timeout=_HOST_PROFILE_TIMEOUT)
+        return self._as_json(ok, out, "host-profile")
 
     async def request_grow_disk(self, disk: str, add_gib: int) -> dict:
         """EXECUTE a pre-approved VM disk grow + absorb into the thin pool."""

--- a/src/genesis/infra_profile/collectors/host.py
+++ b/src/genesis/infra_profile/collectors/host.py
@@ -1,14 +1,21 @@
 """Host/hypervisor-plane collection via the guardian SSH gateway.
 
-PR1 ships the plane-unavailable contract only; the real gateway verb
-(``host-profile``) and its client land in PR2. The section names and the
-"not visible from this vantage" degradation are stable API from day one so
+``GuardianRemote.host_profile()`` (gateway verb ``host-profile``) returns one
+raw JSON blob gathered host-side by ``guardian/host_profile.py``; this module
+owns the facts/metrics split — stable identity/topology goes in ``facts``
+(hashed → drift detection + annotation pinning), volatile readings go in
+``metrics`` (rendered, never hashed).
+
+Degradation contract (stable API since PR1): with no guardian configured, a
+pre-redeploy gateway (``denied``), an SSH failure, or a host-side error, every
+host section is ``unavailable`` with a reason and ``available`` is False —
 consumers (renderer, sentinel digest) never special-case the rollout.
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from genesis.infra_profile.types import PLANE_HOST, SectionResult
 
@@ -17,27 +24,99 @@ logger = logging.getLogger(__name__)
 HOST_SECTIONS = ("host_system", "host_storage_pool", "host_virt")
 
 
-async def collect_host(guardian_remote=None) -> tuple[bool, str | None, list[SectionResult]]:
-    """Collect host-plane sections.
-
-    Returns ``(available, reason, sections)``. With no guardian configured —
-    or (PR1) the gateway verb not yet deployed — every host section is
-    ``unavailable`` and ``available`` is False.
-    """
-    if guardian_remote is None:
-        reason = "no guardian configured on this install"
-        return (
-            False,
-            reason,
-            [SectionResult.unavailable(name, reason, plane=PLANE_HOST) for name in HOST_SECTIONS],
-        )
-
-    # GROUNDWORK(infra-host-plane): PR2 wires GuardianRemote.host_profile()
-    # (gateway verb `host-profile`) and splits its JSON blob into the
-    # HOST_SECTIONS facts/metrics here.
-    reason = "host-profile gateway verb not yet available"
+def _unavailable(reason: str) -> tuple[bool, str, list[SectionResult]]:
     return (
         False,
         reason,
         [SectionResult.unavailable(name, reason, plane=PLANE_HOST) for name in HOST_SECTIONS],
     )
+
+
+def _split(name: str, raw: dict[str, Any], fact_keys: frozenset[str]) -> SectionResult:
+    """Split one raw host sub-dict into a SectionResult by fact-key membership.
+
+    A host-side per-section failure arrives as ``{"error": ...}`` — surfaced
+    as an error section (prior facts/hash are preserved by the merge in
+    ``service.py``, same contract as a failed container collector).
+    """
+    if not isinstance(raw, dict):
+        return SectionResult.failed(name, f"unexpected payload: {raw!r}", plane=PLANE_HOST)
+    # "error" is a RESERVED key at this boundary — its presence marks a
+    # host-side section failure even alongside partial data (a partial dict
+    # silently filed under metrics would render a failure as a healthy
+    # reading — review 2026-07-13).
+    if "error" in raw:
+        return SectionResult.failed(name, str(raw["error"]), plane=PLANE_HOST)
+    facts = {k: v for k, v in raw.items() if k in fact_keys}
+    metrics = {k: v for k, v in raw.items() if k not in fact_keys}
+    return SectionResult(name=name, plane=PLANE_HOST, facts=facts, metrics=metrics)
+
+
+# Facts = slow-changing configuration/topology; everything else in the blob is
+# a volatile reading. Deliberately allowlists (not blocklists) so a NEW field
+# added host-side lands in metrics — never silently hash-churning facts across
+# a version skew between host and container.
+_SYSTEM_FACTS = frozenset(
+    {
+        "mem_total_kb",
+        "nproc",
+        "kernel_release",
+        "architecture",
+        "hostname",
+        "os_pretty_name",
+    }
+)
+# Pool percentages/free-space are volatile. `detected` flipping IS a topology
+# signal (measurement path broke or backend changed) — worth a drift
+# observation, so it lives in facts. `detail` looks identity-ish but embeds
+# the live data%/meta% numbers (verified live: "lvm vg0 data=61.19 meta=42.6")
+# — hashing it would churn every refresh, so it is a metric.
+_STORAGE_FACTS = frozenset({"detected", "pool_name"})
+_VIRT_FACTS = frozenset(
+    {
+        "incus_client_version",
+        "incus_server_version",
+        "container_name",
+        "container_limits",
+        "detect_virt",
+        "pve_version",
+        "smartctl_present",
+    }
+)
+
+_FACT_KEYS = {
+    "host_system": _SYSTEM_FACTS,
+    "host_storage_pool": _STORAGE_FACTS,
+    "host_virt": _VIRT_FACTS,
+}
+
+
+async def collect_host(guardian_remote=None) -> tuple[bool, str | None, list[SectionResult]]:
+    """Collect host-plane sections.
+
+    Returns ``(available, reason, sections)``.
+    """
+    if guardian_remote is None:
+        return _unavailable("no guardian configured on this install")
+
+    try:
+        blob = await guardian_remote.host_profile()
+    except Exception as exc:  # noqa: BLE001 — plane degradation, never a raise
+        logger.warning("infra_profile: host_profile call raised", exc_info=True)
+        return _unavailable(f"host-profile call failed: {exc!r}")
+
+    if not isinstance(blob, dict) or not blob.get("ok"):
+        error = "no response"
+        if isinstance(blob, dict):
+            error = str(blob.get("error") or blob.get("raw") or "no response")
+        # A pre-redeploy gateway answers its unknown-verb default — the JSON
+        # sentinel {"ok": false, "error": "denied"}, which _as_json embeds RAW
+        # in the error field. Match the QUOTED form only: an SSH auth failure
+        # ('Permission denied (publickey)') also contains bare 'denied' and
+        # must NOT be masked as a benign not-deployed state (review 2026-07-13).
+        if '"denied"' in error:
+            error = "host-profile gateway verb not deployed on host yet"
+        return _unavailable(error[:200])
+
+    sections = [_split(name, blob.get(name, {}), _FACT_KEYS[name]) for name in HOST_SECTIONS]
+    return (True, None, sections)

--- a/src/genesis/infra_profile/diff.py
+++ b/src/genesis/infra_profile/diff.py
@@ -69,8 +69,12 @@ def compute_drift(
         prev = prev_sections.get(name)
         if prev is None:
             continue  # newly appeared ≠ drift
-        if curr.get("status") == "unavailable" or prev.get("status") == "unavailable":
-            continue  # plane availability change ≠ drift
+        # No status gate: the hash guards below already absorb availability
+        # flips (a never-ok section has no hash; an unavailable/error section
+        # keeps its prior facts+hash through the outage), while a fact that
+        # REALLY changed during an outage window still surfaces on recovery —
+        # a status gate silently swallowed exactly that case (review
+        # 2026-07-13).
         old_hash, new_hash = prev.get("hash"), curr.get("hash")
         if not old_hash or not new_hash or old_hash == new_hash:
             continue

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -388,3 +388,69 @@ class TestResolveCCEnv:
         cc = _stub_claude(tmp_path, "null")
         engine = _engine_with_token(tmp_path, token=True)
         assert await engine._resolve_cc_env(cc) is None
+
+
+# ── Infrastructure body-schema integration ─────────────────────────────
+
+
+class TestInfraSectionIntegration:
+    """The infra_profile shared-mount doc is inlined into the CC prompt."""
+
+    def test_prompt_includes_infra_doc_when_present(self, tmp_path, monkeypatch) -> None:
+        from pathlib import Path
+
+        from genesis.guardian.diagnosis import _build_diagnosis_prompt
+
+        infra_dir = tmp_path / ".genesis" / "shared" / "infrastructure"
+        infra_dir.mkdir(parents=True)
+        (infra_dir / "INFRASTRUCTURE.md").write_text(
+            "# Infrastructure\n- memory.max: 16GiB\n- thin pool: vg0 (shared with host)\n",
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        prompt = _build_diagnosis_prompt(_snap(container_status="Running"), "", "genesis")
+        assert "Infrastructure Body Schema" in prompt
+        assert "memory.max: 16GiB" in prompt
+
+    def test_prompt_truncates_large_infra_doc(self, tmp_path, monkeypatch) -> None:
+        from pathlib import Path
+
+        from genesis.guardian.diagnosis import _build_diagnosis_prompt
+
+        infra_dir = tmp_path / ".genesis" / "shared" / "infrastructure"
+        infra_dir.mkdir(parents=True)
+        (infra_dir / "INFRASTRUCTURE.md").write_text("A" * 20000)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        prompt = _build_diagnosis_prompt(_snap(container_status="Running"), "", "genesis")
+        # The doc is 20000 A's; the inlined copy is capped at 4096 chars.
+        import re
+
+        longest_run = max(len(run) for run in re.findall(r"A+", prompt))
+        assert 100 <= longest_run <= 4096
+
+    def test_shared_dir_param_overrides_home(self, tmp_path) -> None:
+        """The engine passes config.shared_path (host-side STATE_DIR mount) —
+        verified live 2026-07-13 that ~/.genesis/shared does NOT exist on the
+        host, so the param, not Path.home(), must drive the reads."""
+        from genesis.guardian.diagnosis import _build_diagnosis_prompt
+
+        shared = tmp_path / "state" / "shared"
+        (shared / "infrastructure").mkdir(parents=True)
+        (shared / "infrastructure" / "INFRASTRUCTURE.md").write_text(
+            "- thin pool: vg0\n",
+        )
+        prompt = _build_diagnosis_prompt(
+            _snap(container_status="Running"), "", "genesis", shared_dir=shared,
+        )
+        assert "thin pool: vg0" in prompt
+
+    def test_prompt_without_infra_doc(self, tmp_path, monkeypatch) -> None:
+        from pathlib import Path
+
+        from genesis.guardian.diagnosis import _build_diagnosis_prompt
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        prompt = _build_diagnosis_prompt(_snap(container_status="Running"), "", "genesis")
+        assert "Infrastructure Body Schema" not in prompt
+        assert "Genesis Guardian" in prompt

--- a/tests/test_guardian/test_host_profile.py
+++ b/tests/test_guardian/test_host_profile.py
@@ -1,0 +1,160 @@
+"""Tests for the host-side ``host-profile`` gather (guardian/host_profile.py)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from genesis.guardian import host_profile as hp
+from genesis.guardian.config import GuardianConfig
+from genesis.guardian.pool import StoragePoolStatus
+
+# Real YAML shape from `incus config show genesis` on the live host
+# (2026-07-12): limits.* at the top-level config map, PLUS device-nested
+# limits.read/write that a naive scan would wrongly absorb.
+_INCUS_CONFIG_YAML = """\
+architecture: x86_64
+config:
+  boot.autostart: "true"
+  limits.cpu: "8"
+  limits.memory: 16GiB
+  image.description: Ubuntu noble
+devices:
+  root:
+    limits.read: 190MB
+    limits.write: 90MB
+    path: /
+    pool: default
+    type: disk
+name: genesis
+"""
+
+
+class TestParseIncusLimits:
+    def test_extracts_top_level_limits_only(self) -> None:
+        limits = hp._parse_incus_limits(_INCUS_CONFIG_YAML)
+        assert limits == {"limits.cpu": "8", "limits.memory": "16GiB"}
+
+    def test_device_nested_limits_excluded(self) -> None:
+        limits = hp._parse_incus_limits(_INCUS_CONFIG_YAML)
+        assert "limits.read" not in limits
+        assert "limits.write" not in limits
+
+    def test_empty_input(self) -> None:
+        assert hp._parse_incus_limits("") == {}
+        assert hp._parse_incus_limits("name: genesis\n") == {}
+
+
+class TestHostSystem:
+    def test_shape_from_real_proc(self) -> None:
+        """Runs against the real /proc — every field best-effort, no raise."""
+        section = hp._host_system()
+        assert section["nproc"] >= 1
+        assert section["kernel_release"]
+        assert section["hostname"]
+        assert section["mem_total_kb"] > 0
+        assert isinstance(section.get("loadavg", []), list)
+
+
+class TestGatherHostProfile:
+    @pytest.fixture
+    def config(self) -> GuardianConfig:
+        return GuardianConfig()
+
+    async def test_three_sections_present_and_ok(self, config, monkeypatch) -> None:
+        pool_status = StoragePoolStatus(
+            detected=True, data_pct=61.19, metadata_pct=42.6,
+            vg_free_bytes=34359738368, detail="lvm vg0 data=61.19 meta=42.6",
+        )
+
+        async def fake_measure(cfg):
+            return pool_status
+
+        monkeypatch.setattr("genesis.guardian.pool.measure_storage_pool", fake_measure)
+
+        async def fake_run(*argv):
+            if argv == ("incus", "version"):
+                return "Client version: 6.0.0\nServer version: 6.0.0\n"
+            if argv[:3] == ("incus", "config", "show"):
+                return _INCUS_CONFIG_YAML
+            if argv == ("systemd-detect-virt",):
+                return "kvm\n"
+            return None
+
+        monkeypatch.setattr(hp, "_run", fake_run)
+
+        result = await hp.gather_host_profile(config)
+        assert result["ok"] is True
+        assert set(result) >= {"host_system", "host_storage_pool", "host_virt"}
+        pool = result["host_storage_pool"]
+        assert pool["detected"] is True
+        assert pool["data_pct"] == 61.19
+        assert pool["tier"] in ("ok", "warn", "high", "crit", "unknown")
+        virt = result["host_virt"]
+        assert virt["incus_server_version"] == "6.0.0"
+        assert virt["container_limits"] == {"limits.cpu": "8", "limits.memory": "16GiB"}
+        assert virt["detect_virt"] == "kvm"
+        assert virt["pve_version"] is None  # absent on the guardian VM
+
+    async def test_section_failure_degrades_not_raises(self, config, monkeypatch) -> None:
+        async def boom(cfg):
+            raise RuntimeError("lvs exploded")
+
+        monkeypatch.setattr("genesis.guardian.pool.measure_storage_pool", boom)
+
+        async def fake_run(*argv):
+            return None  # every external tool missing
+
+        monkeypatch.setattr(hp, "_run", fake_run)
+
+        result = await hp.gather_host_profile(config)
+        assert result["ok"] is True  # partial data still ok — sections degrade
+        assert "error" in result["host_storage_pool"]
+        assert "lvs exploded" in result["host_storage_pool"]["error"]
+        # host_virt with no tools: best-effort fields only, never a raise
+        assert result["host_virt"]["pve_version"] is None
+        assert result["host_system"]["nproc"] >= 1
+
+    async def test_undetected_pool_reports_unknown_tier(self, config, monkeypatch) -> None:
+        async def fake_measure(cfg):
+            return StoragePoolStatus(detected=False, detail="incus unavailable")
+
+        monkeypatch.setattr("genesis.guardian.pool.measure_storage_pool", fake_measure)
+        section = await hp._host_storage_pool(config)
+        assert section["detected"] is False
+        assert section["tier"] == "unknown"
+
+    async def test_all_sections_failed_flips_ok_false(self, config, monkeypatch) -> None:
+        """Total host-side collapse must be distinguishable from a healthy
+        plane: ok=False → exit 1 → the container degrades the plane instead
+        of rendering three error rows (review 2026-07-13)."""
+
+        async def boom(cfg):
+            raise RuntimeError("pool boom")
+
+        monkeypatch.setattr("genesis.guardian.pool.measure_storage_pool", boom)
+        monkeypatch.setattr(hp, "_host_system", lambda: (_ for _ in ()).throw(OSError("no /proc")))
+
+        async def virt_boom(cfg):
+            raise RuntimeError("virt boom")
+
+        monkeypatch.setattr(hp, "_host_virt", virt_boom)
+
+        result = await hp.gather_host_profile(config)
+        assert result["ok"] is False
+        assert result["error"] == "all host sections failed"
+        assert all(
+            "error" in result[name]
+            for name in ("host_system", "host_storage_pool", "host_virt")
+        )
+
+    def test_pool_status_fields_match_dataclass(self) -> None:
+        """The gather emits StoragePoolStatus verbatim — if the dataclass gains
+        or renames fields, the container-side facts/metrics split must be
+        revisited (collectors/host.py allowlists)."""
+        fields = {f.name for f in dataclasses.fields(StoragePoolStatus)}
+        assert fields == {
+            "detected", "data_pct", "metadata_pct",
+            "vg_free_bytes", "pool_used_pct", "detail",
+        }

--- a/tests/test_guardian/test_host_profile.py
+++ b/tests/test_guardian/test_host_profile.py
@@ -73,6 +73,11 @@ class TestGatherHostProfile:
 
         monkeypatch.setattr("genesis.guardian.pool.measure_storage_pool", fake_measure)
 
+        async def fake_pool_name(cfg):
+            return "default"
+
+        monkeypatch.setattr("genesis.guardian.pool._detect_pool_name", fake_pool_name)
+
         async def fake_run(*argv):
             if argv == ("incus", "version"):
                 return "Client version: 6.0.0\nServer version: 6.0.0\n"
@@ -91,6 +96,7 @@ class TestGatherHostProfile:
         assert pool["detected"] is True
         assert pool["data_pct"] == 61.19
         assert pool["tier"] in ("ok", "warn", "high", "crit", "unknown")
+        assert pool["pool_name"] == "default"
         virt = result["host_virt"]
         assert virt["incus_server_version"] == "6.0.0"
         assert virt["container_limits"] == {"limits.cpu": "8", "limits.memory": "16GiB"}
@@ -120,7 +126,11 @@ class TestGatherHostProfile:
         async def fake_measure(cfg):
             return StoragePoolStatus(detected=False, detail="incus unavailable")
 
+        async def fake_pool_name(cfg):
+            return None
+
         monkeypatch.setattr("genesis.guardian.pool.measure_storage_pool", fake_measure)
+        monkeypatch.setattr("genesis.guardian.pool._detect_pool_name", fake_pool_name)
         section = await hp._host_storage_pool(config)
         assert section["detected"] is False
         assert section["tier"] == "unknown"

--- a/tests/test_infra_profile/test_collectors_edges.py
+++ b/tests/test_infra_profile/test_collectors_edges.py
@@ -32,9 +32,10 @@ async def test_host_plane_without_guardian():
     assert all(s.status == "unavailable" and s.plane == PLANE_HOST for s in sections)
 
 
-async def test_host_plane_with_guardian_still_unavailable_pre_pr2():
-    """GROUNDWORK contract: even with a guardian handle, PR1 reports the verb missing."""
+async def test_host_plane_with_incompatible_remote_degrades():
+    """A remote without host_profile() (pre-PR2 GuardianRemote build) degrades
+    to plane-unavailable — never raises into the refresh."""
     available, reason, sections = await collect_host(object())
     assert available is False
-    assert "host-profile" in reason
+    assert "host-profile call failed" in reason
     assert len(sections) == len(HOST_SECTIONS)

--- a/tests/test_infra_profile/test_collectors_host.py
+++ b/tests/test_infra_profile/test_collectors_host.py
@@ -36,7 +36,7 @@ _LIVE_BLOB = {
         "pool_used_pct": None,
         "detail": "lvm vg0 data=61.19 meta=42.6",
         "tier": "ok",
-        "pool_name": "IncusThinPool",
+        "pool_name": "default",
     },
     "host_virt": {
         "incus_client_version": "6.0.0",
@@ -138,7 +138,7 @@ async def test_live_blob_splits_facts_and_metrics() -> None:
     assert "uptime_seconds" in system.metrics
 
     pool = by_name["host_storage_pool"]
-    assert pool.facts == {"detected": True, "pool_name": "IncusThinPool"}
+    assert pool.facts == {"detected": True, "pool_name": "default"}
     # `detail` embeds live percentages — a fact would churn every refresh.
     assert "detail" in pool.metrics
     assert "data_pct" in pool.metrics

--- a/tests/test_infra_profile/test_collectors_host.py
+++ b/tests/test_infra_profile/test_collectors_host.py
@@ -1,0 +1,191 @@
+"""Tests for the host-plane collector (infra_profile/collectors/host.py)."""
+
+from __future__ import annotations
+
+from genesis.infra_profile.collectors.host import HOST_SECTIONS, collect_host
+from genesis.infra_profile.types import (
+    PLANE_HOST,
+    STATUS_ERROR,
+    STATUS_OK,
+    STATUS_UNAVAILABLE,
+)
+
+# The real GuardianRemote.host_profile() returns the gateway JSON verbatim on
+# success and {"ok": False, "action": ..., "error": ...} on failure — fakes
+# below implement exactly that contract (real method name, real return shape).
+
+_LIVE_BLOB = {
+    "ok": True,
+    "action": "host-profile",
+    "host_system": {
+        "mem_total_kb": 21508924,
+        "mem_available_kb": 7394656,
+        "nproc": 5,
+        "kernel_release": "6.8.0-134-generic",
+        "architecture": "x86_64",
+        "hostname": "guardian-host",
+        "os_pretty_name": "Ubuntu 24.04.4 LTS",
+        "uptime_seconds": 850000.0,
+        "loadavg": [8.49, 16.36, 11.05],
+    },
+    "host_storage_pool": {
+        "detected": True,
+        "data_pct": 61.19,
+        "metadata_pct": 42.6,
+        "vg_free_bytes": 34359738368,
+        "pool_used_pct": None,
+        "detail": "lvm vg0 data=61.19 meta=42.6",
+        "tier": "ok",
+        "pool_name": "IncusThinPool",
+    },
+    "host_virt": {
+        "incus_client_version": "6.0.0",
+        "incus_server_version": "6.0.0",
+        "container_name": "genesis",
+        "container_limits": {"limits.cpu": "8", "limits.memory": "16GiB"},
+        "detect_virt": "kvm",
+        "pve_version": None,
+        "smartctl_present": False,
+    },
+}
+
+
+class _FakeRemote:
+    def __init__(self, response):
+        self._response = response
+
+    async def host_profile(self) -> dict:
+        return self._response
+
+
+class _RaisingRemote:
+    async def host_profile(self) -> dict:
+        raise OSError("ssh binary missing")
+
+
+async def test_no_guardian_is_unavailable() -> None:
+    available, reason, sections = await collect_host(None)
+    assert available is False
+    assert "no guardian" in reason
+    assert [s.name for s in sections] == list(HOST_SECTIONS)
+    assert all(s.status == STATUS_UNAVAILABLE and s.plane == PLANE_HOST for s in sections)
+
+
+async def test_denied_gateway_is_unavailable_with_friendly_reason() -> None:
+    # Realistic contract: _as_json embeds the gateway's RAW stderr JSON in the
+    # error field on rc=1 — the quoted "denied" sentinel lives inside it.
+    remote = _FakeRemote({
+        "ok": False,
+        "action": "host-profile",
+        "error": '{"ok": false, "error": "denied"}',
+    })
+    available, reason, sections = await collect_host(remote)
+    assert available is False
+    assert "not deployed" in reason
+    assert all(s.status == STATUS_UNAVAILABLE for s in sections)
+
+
+async def test_ssh_auth_failure_not_masked_as_not_deployed() -> None:
+    # 'Permission denied (publickey)' contains bare 'denied' but NOT the
+    # quoted gateway sentinel — it must surface as itself, not as a benign
+    # not-deployed message (review 2026-07-13).
+    remote = _FakeRemote({
+        "ok": False,
+        "action": "host-profile",
+        "error": "Permission denied (publickey,password)",
+    })
+    available, reason, sections = await collect_host(remote)
+    assert available is False
+    assert "Permission denied" in reason
+    assert "not deployed" not in reason
+
+
+async def test_ssh_failure_is_unavailable() -> None:
+    remote = _FakeRemote({"ok": False, "action": "host-profile", "error": "timeout"})
+    available, reason, sections = await collect_host(remote)
+    assert available is False
+    assert reason == "timeout"
+    assert all(s.status == STATUS_UNAVAILABLE for s in sections)
+
+
+async def test_raising_remote_degrades_not_raises() -> None:
+    available, reason, sections = await collect_host(_RaisingRemote())
+    assert available is False
+    assert "ssh binary missing" in reason
+    assert all(s.status == STATUS_UNAVAILABLE for s in sections)
+
+
+async def test_live_blob_splits_facts_and_metrics() -> None:
+    available, reason, sections = await collect_host(_FakeRemote(_LIVE_BLOB))
+    assert available is True
+    assert reason is None
+    by_name = {s.name: s for s in sections}
+    assert set(by_name) == set(HOST_SECTIONS)
+    assert all(s.status == STATUS_OK and s.plane == PLANE_HOST for s in sections)
+
+    system = by_name["host_system"]
+    assert system.facts == {
+        "mem_total_kb": 21508924,
+        "nproc": 5,
+        "kernel_release": "6.8.0-134-generic",
+        "architecture": "x86_64",
+        "hostname": "guardian-host",
+        "os_pretty_name": "Ubuntu 24.04.4 LTS",
+    }
+    # Volatile readings must NOT be hashed — they live in metrics.
+    assert "loadavg" in system.metrics
+    assert "mem_available_kb" in system.metrics
+    assert "uptime_seconds" in system.metrics
+
+    pool = by_name["host_storage_pool"]
+    assert pool.facts == {"detected": True, "pool_name": "IncusThinPool"}
+    # `detail` embeds live percentages — a fact would churn every refresh.
+    assert "detail" in pool.metrics
+    assert "data_pct" in pool.metrics
+    assert "tier" in pool.metrics
+
+    virt = by_name["host_virt"]
+    assert virt.facts["container_limits"] == {"limits.cpu": "8", "limits.memory": "16GiB"}
+    assert virt.facts["detect_virt"] == "kvm"
+    assert virt.metrics == {}
+
+
+async def test_unknown_host_field_lands_in_metrics_not_facts() -> None:
+    """A NEW field added host-side (version skew) must not churn fact hashes."""
+    blob = {**_LIVE_BLOB, "host_system": {**_LIVE_BLOB["host_system"], "new_probe": 42}}
+    _, _, sections = await collect_host(_FakeRemote(blob))
+    system = next(s for s in sections if s.name == "host_system")
+    assert "new_probe" not in system.facts
+    assert system.metrics["new_probe"] == 42
+
+
+async def test_host_side_section_error_becomes_error_section() -> None:
+    blob = {**_LIVE_BLOB, "host_storage_pool": {"error": "RuntimeError('lvs exploded')"}}
+    available, _, sections = await collect_host(_FakeRemote(blob))
+    assert available is True  # plane is up; one section failed
+    pool = next(s for s in sections if s.name == "host_storage_pool")
+    assert pool.status == STATUS_ERROR
+    assert "lvs exploded" in pool.error
+    ok_sections = [s for s in sections if s.name != "host_storage_pool"]
+    assert all(s.status == STATUS_OK for s in ok_sections)
+
+
+async def test_partial_section_with_error_key_is_failed() -> None:
+    # "error" is a reserved key at this boundary — even alongside data keys it
+    # marks the section failed (never silently filed under metrics).
+    blob = {
+        **_LIVE_BLOB,
+        "host_virt": {**_LIVE_BLOB["host_virt"], "error": "incus flaked mid-gather"},
+    }
+    _, _, sections = await collect_host(_FakeRemote(blob))
+    virt = next(s for s in sections if s.name == "host_virt")
+    assert virt.status == STATUS_ERROR
+    assert "incus flaked" in virt.error
+
+
+async def test_missing_section_in_blob_is_empty_ok() -> None:
+    blob = {k: v for k, v in _LIVE_BLOB.items() if k != "host_virt"}
+    _, _, sections = await collect_host(_FakeRemote(blob))
+    virt = next(s for s in sections if s.name == "host_virt")
+    assert virt.status == STATUS_OK
+    assert virt.facts == {} and virt.metrics == {}

--- a/tests/test_infra_profile/test_diff.py
+++ b/tests/test_infra_profile/test_diff.py
@@ -42,8 +42,31 @@ def test_new_section_is_not_drift():
 
 
 def test_unavailable_transitions_are_not_drift():
+    # A section that was never ok has no hash — first data ≠ drift.
     prev = _profile({"host_system": _section(None, status="unavailable")})
     curr = _profile({"host_system": _section("x", {"cores": 8})})
+    assert compute_drift(prev, curr) == []
+
+
+def test_fact_change_across_outage_window_is_drift():
+    # service.py preserves last-ok facts+hash through an unavailable window;
+    # a fact that REALLY changed while the plane was down must surface on
+    # recovery (review 2026-07-13 — a status gate used to swallow this).
+    prev = _profile(
+        {"host_virt": _section("old", {"limits": "8"}, status="unavailable")},
+    )
+    curr = _profile({"host_virt": _section("new", {"limits": "5"})})
+    drift = compute_drift(prev, curr)
+    assert len(drift) == 1
+    assert drift[0]["section"] == "host_virt"
+
+
+def test_going_unavailable_keeps_hash_no_drift():
+    # Curr unavailable keeps the prior hash (service merge) — no drift.
+    prev = _profile({"host_virt": _section("same", {"limits": "8"})})
+    curr = _profile(
+        {"host_virt": _section("same", {"limits": "8"}, status="unavailable")},
+    )
     assert compute_drift(prev, curr) == []
 
 


### PR DESCRIPTION
## Summary

PR2 of the infrastructure body schema (#1019 shipped the container plane). Flips the 3 host-plane sections — `host_system`, `host_storage_pool`, `host_virt` — from the unavailable-stub to live data via a new **read-only `host-profile` gateway verb**.

**Host side**
- `guardian/host_profile.py` (new): concurrent, best-effort gather — meminfo/nproc/kernel/os-release, the guardian's own `measure_storage_pool` (+tier, 30s cap so a wedged pool can't blow the gateway's 45s budget and SIGKILL away healthy sections), incus version + this container's `limits.*` (yaml.safe_load; device-nested `limits.read/write` can't leak in), `systemd-detect-virt`, pveversion/smartctl presence. `ok:false` only when *every* section failed, so total collapse degrades the plane instead of posing as healthy.
- `--host-profile` CLI flag (JSON-always) + gateway verb (no secrets, no sudo) with a **skew guard**: `sync-gateway` redeploys the script independently of src, and on an old checkout the unknown flag would fall through into `run_check()` — a full recovery cycle triggered by a routine poll. The verb refuses with a JSON error when the deployed src predates it.

**Container side**
- `GuardianRemote.host_profile()` (50s client > 45s gateway, per convention).
- Real `collectors/host.py`: facts/metrics split — hashed identity/topology (incl. `container_limits` for cross-plane cage checks) vs volatile readings; allowlist-based so unknown new host fields land in metrics and never hash-churn across version skew. `"error"` is a reserved key; the not-deployed discriminator matches only the quoted `"denied"` gateway sentinel (an SSH `Permission denied` surfaces as itself).
- Diagnosis prompt inlines the shared-mount `INFRASTRUCTURE.md` (4KB, line-boundary truncation) via the new `config.shared_path` — which also fixes the pre-existing sentinel read that pointed at a container-side path not present on the host and silently no-op'd.
- `diff.py`: availability flips are absorbed by hash guards instead of a status gate, so a fact that really changed during a guardian outage now surfaces on recovery.

Graceful degradation is unchanged: no guardian, an un-redeployed gateway, or SSH failure → the 3 sections render "not visible from this vantage". Host effects land only after a host redeploy.

## Test plan
- `tests/test_guardian/test_host_profile.py` (new), `tests/test_infra_profile/test_collectors_host.py` (new), diagnosis + diff + edges extensions — 69 targeted tests green; ruff clean; gateway `bash -n` clean.
- Post-merge: container deploy → verify graceful degradation against the un-redeployed gateway, then host redeploy → verify the plane flips live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)