### PR TITLE
fix(follow-ups,observability): completed_at re-stamp fix + neural monitor "Other" group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .assets
 .env
 secrets.env
+# Any secrets.env backup/variant (e.g. secrets.env.pre-*-bak-*) must never be
+# committable — only the tracked template is allowed.
+secrets.env.*
+!secrets.env.example
 secrets.json
 *.pyc
 dist/
@@ -24,6 +28,12 @@ botpy.log
 .worktrees/
 .claude/worktrees/
 .claude/.session-locks/
+# Local tooling artifacts written into the repo tree (keep the tree clean)
+.claude/database.db
+.claude/hookify.*.local.md
+.serena/
+# Malformed sqlite path artifacts (e.g. genesis.db?mode=ro used as a literal file)
+data/*mode=ro
 # Background sessions now live at ~/.genesis/background-sessions/ (outside repo)
 data/sqlite/*.db
 data/sqlite/*.db-journal

--- a/docs/reference/routing-call-sites.md
+++ b/docs/reference/routing-call-sites.md
@@ -143,6 +143,27 @@ see the linked commit / PR.
 
 ## Changelog
 
+### 2026-07-12 — Neural monitor "Other" group for ungrouped call sites
+
+The battleship grid (`neural_monitor.html` `SUBSYSTEM_GROUPS`) renders only call
+sites assigned to a subsystem group. Sites the backend snapshot emits but that
+aren't in any group — e.g. `40_ego_focus_selection`, `43_task_retrospective`,
+`44_task_premortem`, `45_intelligence_intake`, `46_infra_annotation`, `judge`,
+`crag_grade`, `attention_salience`, the `dream_cycle_*` sites, `voice_conversation`
+— rendered nowhere and were invisible. A new "Other" enrichment card, computed at
+render time from `Object.keys(callSites)` minus the grouped ids, surfaces them
+(clickable, opens the detail panel) and self-maintains as new sites are added.
+
+Two related grouping gaps are tracked separately, not fixed here: (a) `2_triage`
+and `bookmark_enrichment` remain in `SUBSYSTEM_GROUPS` but are no longer emitted by
+the snapshot, so they render as permanently-idle dead tiles; (b) the `ego` group
+still lists the legacy `7_ego_cycle` (last run ~79d ago) alongside `8_ego_compaction`,
+while the current ego call sites (`7_genesis_ego_cycle`, `7_user_ego_cycle`,
+`40_ego_focus_selection` — all active) are emitted and now surface under "Other"
+rather than the Ego group; the group's site list should be refreshed to the current
+ids. (Verified against the live `/api/genesis/health` snapshot, which emits from
+`call_site_last_run` + `_CALL_SITE_META`, not just `config/model_routing.yaml`.)
+
 ### 2026-05-10 — Confusable call-site ID rename (PR #311, Tier 3)
 
 Three IDs whose descriptors collided were renamed to lead with the domain:

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -2288,6 +2288,53 @@ function updateSubsystemGrid(data) {
         if (hasEnrichment) card.appendChild(enrichment);
         enrichGrid.appendChild(card);
     }
+
+    // ── "Other": call sites the backend emits that aren't assigned to any
+    // subsystem group above. The 7×7 battleship grid is a fixed hand-placed
+    // layout, so an ungrouped site would otherwise render nowhere and stay
+    // invisible. Computed from the live data, so it self-maintains as new
+    // sites are added; rendered as an enrichment card (no grid cell) to avoid
+    // disturbing the fixed layout.
+    const groupedIds = new Set();
+    for (const g of Object.values(SUBSYSTEM_GROUPS)) {
+        for (const s of g.sites) groupedIds.add(s);
+    }
+    const ungrouped = Object.keys(callSites).filter((id) => !groupedIds.has(id)).sort();
+    if (ungrouped.length > 0) {
+        const card = el('div', 'enrich-card');
+        card.id = 'enrich-other';
+        card.style.borderLeftColor = '#64748b';
+
+        const memberStatuses = ungrouped.map((id) => callSites[id].status || 'unknown');
+        const aggStatus = aggregateStatus(memberStatuses);
+        const activeCount = memberStatuses.filter((s) => s === 'healthy' || s === 'active').length;
+
+        const header = el('div', 'region-header');
+        const aggDot = el('span', 'agg-dot');
+        aggDot.style.background = statusDotColor(aggStatus);
+        header.appendChild(aggDot);
+        header.appendChild(el('h3', null, 'Other'));
+        header.appendChild(el('span', 'region-count', activeCount + '/' + ungrouped.length));
+        card.appendChild(header);
+
+        card.appendChild(el('div', 'region-desc', 'Ungrouped call sites not assigned to a subsystem'));
+
+        const enrichment = el('div', 'region-enrichment');
+        for (const siteId of ungrouped) {
+            const info = callSites[siteId] || {};
+            const st = info.status || 'unknown';
+            const row = el('div', 'cat-health');
+            row.style.cursor = 'pointer';
+            row.appendChild(el('span', 'cat-name', getMeta(siteId).name));
+            const dot = el('span', 'agg-dot');
+            dot.style.background = statusDotColor(st);
+            row.appendChild(dot);
+            row.addEventListener('click', () => showDetail({ id: siteId, status: st, data: info }));
+            enrichment.appendChild(row);
+        }
+        card.appendChild(enrichment);
+        enrichGrid.appendChild(card);
+    }
 }
 
 // ── Polling ─────────────────────────────────────────────────────────

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -233,7 +233,13 @@ async def update_status(
     parts = ["status = ?"]
     params: list[str | None] = [status]
     if status in ("completed", "failed"):
-        parts.append("completed_at = ?")
+        # Stamp completed_at fresh only on a genuine transition INTO a terminal
+        # state; preserve it on an idempotent re-write (same status back — e.g.
+        # a notes-only update) so a mechanical re-write never resets the
+        # reaper/GC windows keyed off completed_at. SQLite evaluates SET RHS
+        # against the pre-update row, so `status` in the CASE is the OLD status.
+        parts.append("completed_at = CASE WHEN status = ? THEN completed_at ELSE ? END")
+        params.append(status)
         params.append(_now_iso())
     if resolution_notes is not None:
         parts.append("resolution_notes = ?")
@@ -654,7 +660,13 @@ async def update_status_batch(
     parts = ["status = ?"]
     params: list[str | None] = [status]
     if status in ("completed", "failed"):
-        parts.append("completed_at = ?")
+        # Stamp completed_at fresh only on a genuine transition INTO a terminal
+        # state; preserve it on an idempotent re-write (same status back — e.g.
+        # a notes-only update) so a mechanical re-write never resets the
+        # reaper/GC windows keyed off completed_at. SQLite evaluates SET RHS
+        # against the pre-update row, so `status` in the CASE is the OLD status.
+        parts.append("completed_at = CASE WHEN status = ? THEN completed_at ELSE ? END")
+        params.append(status)
         params.append(_now_iso())
     if resolution_notes is not None:
         parts.append("resolution_notes = ?")

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -232,6 +232,69 @@ async def test_update_status_batch_stamps_completed_at(db):
         assert row["resolution_notes"] == "bulk done"
 
 
+# ─── completed_at re-stamp semantics (idempotent terminal re-write) ──────────
+# completed_at feeds three GC/report windows (get_recently_resolved /
+# purge_completed / get_recently_completed). A notes-only status update passes
+# an already-terminal status back in; it must NOT reset completed_at (which
+# would silently move the row in those windows / reset the reaper clock). But a
+# GENUINE transition INTO a terminal state — e.g. the ego resolving a `failed`
+# follow-up to `completed` (ego/dispatch.py) — MUST stamp fresh.
+
+_OLD = "2025-01-01T00:00:00+00:00"
+
+
+async def _force_terminal(db, fid, status, completed_at=_OLD):
+    await db.execute(
+        "UPDATE follow_ups SET status = ?, completed_at = ? WHERE id = ?",
+        (status, completed_at, fid),
+    )
+    await db.commit()
+
+
+async def test_notes_only_rewrite_preserves_completed_at(db):
+    """Re-writing a completed row with the same status (notes-only) keeps completed_at."""
+    fid = await follow_ups.create(db, **_BASE)
+    await _force_terminal(db, fid, "completed")
+    await follow_ups.update_status(db, fid, "completed", resolution_notes="later note")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["completed_at"] == _OLD  # preserved, NOT re-stamped
+    assert row["resolution_notes"] == "later note"
+
+
+async def test_failed_to_completed_stamps_fresh(db):
+    """A genuine failed→completed transition (ego resolution) stamps completed_at fresh."""
+    fid = await follow_ups.create(db, **_BASE)
+    await _force_terminal(db, fid, "failed")
+    await follow_ups.update_status(db, fid, "completed", resolution_notes="ego resolved")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"
+    # ISO-8601 sorts lexically: a fresh 2026+ stamp is strictly greater than the sentinel.
+    assert row["completed_at"] > _OLD  # fresh, NOT frozen at the failure time
+
+
+async def test_batch_notes_only_rewrite_preserves_completed_at(db):
+    """update_status_batch mirrors: idempotent terminal re-write preserves completed_at."""
+    ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]
+    for fid in ids:
+        await _force_terminal(db, fid, "completed")
+    await follow_ups.update_status_batch(db, ids, "completed", resolution_notes="bulk note")
+    for fid in ids:
+        row = await follow_ups.get_by_id(db, fid)
+        assert row["completed_at"] == _OLD
+        assert row["resolution_notes"] == "bulk note"
+
+
+async def test_batch_failed_to_completed_stamps_fresh(db):
+    """update_status_batch: genuine failed→completed transition stamps fresh."""
+    ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]
+    for fid in ids:
+        await _force_terminal(db, fid, "failed")
+    await follow_ups.update_status_batch(db, ids, "completed")
+    for fid in ids:
+        row = await follow_ups.get_by_id(db, fid)
+        assert row["completed_at"] > _OLD
+
+
 async def test_update_status_batch_rejects_invalid_status(db):
     fid = await follow_ups.create(db, **_BASE)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

Two independent fixes (the planned "PR-I" pair) plus gitignore hardening and a doc note.

### 1. Follow-ups: preserve `completed_at` on an idempotent terminal re-write
`update_status` / `update_status_batch` re-stamped `completed_at` on *every* terminal write. A notes-only update passes the already-terminal status back in — the confirmed instance is the cockpit "add a note to a completed follow-up" path (`mcp/health/follow_up_tools.py:220`, the `elif resolution_notes or blocked_reason:` branch) — which silently reset the reaper/GC windows keyed off `completed_at` (`get_recently_resolved`, `purge_completed`, `get_recently_completed`).

Fix: `completed_at = CASE WHEN status = ? THEN completed_at ELSE ? END` — preserve on an idempotent same-status re-write, stamp fresh on a genuine transition. SQLite evaluates SET RHS against the pre-update row, so `status` in the CASE reads the OLD value. This still stamps fresh on the regular `failed→completed` ego-resolution path (`ego/dispatch.py`), which a naive `COALESCE` would have frozen at the failure time.

(The dispatcher pinned branch `follow_ups/dispatcher.py:230` passes `fu["status"]` but only ever receives `scheduled`/`in_progress` rows from `get_linked_active`, so it never actually re-stamped — the fix is defensive there.)

### 2. Neural monitor: surface ungrouped call sites in an "Other" group
The battleship grid renders only call sites in `SUBSYSTEM_GROUPS`; the live snapshot emits ~67, so ~25 ungrouped sites (ego-split, dream-cycle, task pre/post-mortem, judge, crag/attention grading, voice, etc.) rendered nowhere. A new "Other" enrichment card, computed at render time from `Object.keys(callSites)` minus the grouped ids, surfaces them (clickable → detail panel). Self-maintaining as new sites are added; the fixed 7×7 grid is untouched.

### 3. `.gitignore` hardening
Ignore `secrets.env.*` backups (with a `!secrets.env.example` negation so the tracked template stays committable) + local tooling artifacts (`.claude/database.db`, `.claude/hookify.*.local.md`, `.serena/`, `data/*mode=ro`).

## Testing
- TDD (RED→GREEN); 85 targeted tests pass (CRUD + all follow-ups consumers + cockpit API); ruff clean.
- **E2E**: CRUD verified on a real DB snapshot (notes-only → preserved, `failed→completed` → fresh); dashboard verified in a real browser against live health data (Other card renders 25/25, battleship grid intact, no errors).

## Follow-ups (tabled)
Two grouping gaps tracked separately, not fixed here: dead grid tiles (`2_triage`, `bookmark_enrichment`, both absent from the live snapshot) and the Ego group still listing the legacy `7_ego_cycle` while the current ego sites surface under "Other".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
