### PR TITLE
fix(memory): session-observer restore path orphaned every leftover file

### DIFF
--- a/src/genesis/memory/session_observer.py
+++ b/src/genesis/memory/session_observer.py
@@ -360,20 +360,7 @@ async def process_pending_observations(
         # Restore any `.processing` files still on disk. On normal completion
         # these are the budget-exceeded/unread ones; on cancellation this
         # restores everything not yet consumed so it's reprocessed next tick.
-        for _original, processing_path in processing_files:
-            if processing_path.exists():
-                try:
-                    original = processing_path.with_suffix(".jsonl")
-                    if original.exists():
-                        # Original was recreated by hook — append our unprocessed
-                        # data to the new file.
-                        with open(original, "a") as dst, open(processing_path) as src:
-                            dst.write(src.read())
-                        processing_path.unlink(missing_ok=True)
-                    else:
-                        os.rename(processing_path, original)
-                except OSError:
-                    logger.warning("Failed to restore %s", processing_path, exc_info=True)
+        _restore_processing_files(processing_files)
 
     result.files_processed = len(all_observations)
     result.elapsed_s = time.monotonic() - start
@@ -385,6 +372,31 @@ async def process_pending_observations(
         )
 
     return result
+
+
+def _restore_processing_files(processing_files: list[tuple[Path, Path]]) -> None:
+    """Restore leftover `.processing` files to their EXACT original path.
+
+    The original path MUST come from the rename tuple, never be re-derived
+    via `processing_path.with_suffix(".jsonl")`: with_suffix replaces only
+    the LAST suffix, so `tool_observations.jsonl.processing` became
+    `tool_observations.jsonl.jsonl` — a name `_find_observation_files` never
+    scans, silently orphaning every restored file (108 orphans found on
+    disk, 2026-07-13).
+    """
+    for original, processing_path in processing_files:
+        if processing_path.exists():
+            try:
+                if original.exists():
+                    # Original was recreated by hook — append our unprocessed
+                    # data to the new file.
+                    with open(original, "a") as dst, open(processing_path) as src:
+                        dst.write(src.read())
+                    processing_path.unlink(missing_ok=True)
+                else:
+                    os.rename(processing_path, original)
+            except OSError:
+                logger.warning("Failed to restore %s", processing_path, exc_info=True)
 
 
 def _cleanup_stale_files(files: list[Path]) -> None:

--- a/tests/test_memory/test_session_observer.py
+++ b/tests/test_memory/test_session_observer.py
@@ -14,6 +14,7 @@ from genesis.memory.session_observer import (
     _infer_wing_from_files,
     _parse_notes,
     _read_observations,
+    _restore_processing_files,
     process_pending_observations,
 )
 
@@ -282,3 +283,48 @@ async def test_process_pending_observations_stores_notes(tmp_path, monkeypatch):
     # then deleted after processing)
     assert not obs_file.exists()
     assert not obs_file.with_suffix(".jsonl.processing").exists()
+# ── restore path ────────────────────────────────────────────────────────
+
+
+class TestRestoreProcessingFiles:
+    """Leftover .processing files must return to their EXACT original path.
+
+    Regression guard for the with_suffix bug: Path.with_suffix replaces only
+    the LAST suffix, so deriving the original from the processing path turned
+    tool_observations.jsonl.processing into tool_observations.jsonl.jsonl —
+    a name the finder never scans, orphaning every restored file forever
+    (108 orphans found on disk, 2026-07-13).
+    """
+
+    def test_restores_to_exact_original_name(self, tmp_path):
+        original = tmp_path / "tool_observations.jsonl"
+        processing = tmp_path / "tool_observations.jsonl.processing"
+        processing.write_text('{"tool": "Read"}\n')
+
+        _restore_processing_files([(original, processing)])
+
+        assert original.exists()
+        assert original.read_text() == '{"tool": "Read"}\n'
+        assert not processing.exists()
+        assert not (tmp_path / "tool_observations.jsonl.jsonl").exists()
+
+    def test_appends_when_hook_recreated_original(self, tmp_path):
+        original = tmp_path / "tool_observations.jsonl"
+        original.write_text('{"tool": "Write"}\n')  # hook wrote while we processed
+        processing = tmp_path / "tool_observations.jsonl.processing"
+        processing.write_text('{"tool": "Read"}\n')
+
+        _restore_processing_files([(original, processing)])
+
+        assert original.read_text() == '{"tool": "Write"}\n{"tool": "Read"}\n'
+        assert not processing.exists()
+        assert not (tmp_path / "tool_observations.jsonl.jsonl").exists()
+
+    def test_already_consumed_processing_is_noop(self, tmp_path):
+        original = tmp_path / "tool_observations.jsonl"
+        processing = tmp_path / "tool_observations.jsonl.processing"
+
+        _restore_processing_files([(original, processing)])  # neither exists
+
+        assert not original.exists()
+        assert not processing.exists()


### PR DESCRIPTION
## What

`session_observer.py`'s finally-block restored leftover `.processing` files via `processing_path.with_suffix(".jsonl")` — but `with_suffix` replaces only the LAST suffix, so `tool_observations.jsonl.processing` was "restored" to `tool_observations.jsonl.jsonl`, a name `_find_observation_files` never scans. Every budget-exceeded or cancellation leftover was silently orphaned instead of reprocessed — the exact loss the restore comment claims to prevent. **108 orphaned files found on disk** under `~/.genesis/sessions` at diagnosis (2026-07-13).

## Fix

Extract `_restore_processing_files()` and use the EXACT original path already carried in the `(original, processing_path)` rename tuple — it was bound as `_original` and ignored. Behavior on the healthy paths (append-merge when the hook recreated the original; rename when absent; OSError → warning) is unchanged, and the helper cannot raise out of the `finally` block.

## Tests

Red-first regression tests (`TestRestoreProcessingFiles`): exact-name restore (the `.jsonl.jsonl` assertion fails on the old code), append-merge, and already-consumed no-op. Both observer suites green (30 tests).

## Remediation

The 108 on-disk orphans get a one-off rename back to `tool_observations.jsonl` at deploy (after the server restarts onto the fixed code — renaming earlier would let the old runtime re-orphan them), so they finally process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)