### PR TITLE
fix(eval): A4 — question-type-aware reader prompt (preference personalization)

### DIFF
--- a/src/genesis/eval/longmemeval/answer.py
+++ b/src/genesis/eval/longmemeval/answer.py
@@ -1,9 +1,17 @@
 """The reader step: retrieved memories + question -> a short hypothesis answer.
 
 A fixed model (gpt-4o via OpenRouter) reads ONLY the recalled memories and
-answers. The prompt grants an explicit "I don't know" affordance so abstention
-(``_abs``) questions — whose evidence is absent by design — can be answered
-correctly (the judge rewards a model that recognises unanswerability).
+answers. The reader prompt is question-type-aware:
+
+* default (factual QA + abstention): a concise answer with an explicit "I don't
+  know" affordance so abstention (``_abs``) questions — whose evidence is absent
+  by design — are answered correctly.
+* ``single-session-preference``: these ask for a RECOMMENDATION tailored to the
+  user's recalled preferences, so the reader is told to USE those preferences
+  and make a concrete suggestion — NOT to abstain. (A generic QA prompt made the
+  reader answer "I don't know" and tanked this category to ~0.05.)
+* ``temporal-reasoning``: add a step-by-step-using-the-dated-memories nudge so
+  interval/date arithmetic is worked out rather than guessed.
 """
 
 from __future__ import annotations
@@ -16,21 +24,50 @@ from genesis.eval.longmemeval.client import DEFAULT_MODEL
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-_SYSTEM = (
+_DEFAULT_SYSTEM = (
     "You are answering a question using ONLY the retrieved memory snippets from "
     "the user's past conversations. Answer concisely and directly. If the "
     "snippets do not contain the information needed, say you don't know rather "
     "than guessing."
 )
 
+_PREFERENCE_SYSTEM = (
+    "The user is asking for a recommendation or suggestion. Using the retrieved "
+    "memory snippets about their past conversations, personal details, and stated "
+    "preferences, give a concrete, tailored recommendation that reflects what you "
+    "know about them. Always make a specific suggestion informed by their "
+    "preferences; never decline or claim you lack enough information."
+)
 
-def build_answer_prompt(question: str, memories: Sequence[str]) -> str:
+_TEMPORAL_SUFFIX = (
+    " Each memory is prefixed with its date. For questions about durations, "
+    "intervals, or when something happened, reason step by step using those "
+    "dates, then state the final answer."
+)
+
+
+def _system_for(question_type: str | None) -> str:
+    if question_type == "single-session-preference":
+        return _PREFERENCE_SYSTEM
+    if question_type == "temporal-reasoning":
+        return _DEFAULT_SYSTEM + _TEMPORAL_SUFFIX
+    return _DEFAULT_SYSTEM
+
+
+def build_answer_prompt(
+    question: str,
+    memories: Sequence[str],
+    *,
+    question_type: str | None = None,
+) -> str:
     """Assemble the reader prompt from the question and recalled memories."""
-    if memories:
-        block = "\n".join(f"- {m}" for m in memories)
-    else:
-        block = "(no relevant memories were retrieved)"
-    return f"{_SYSTEM}\n\nMEMORIES:\n{block}\n\nQUESTION: {question}\n\nANSWER:"
+    block = (
+        "\n".join(f"- {m}" for m in memories)
+        if memories
+        else ("(no relevant memories were retrieved)")
+    )
+    system = _system_for(question_type)
+    return f"{system}\n\nMEMORIES:\n{block}\n\nQUESTION: {question}\n\nANSWER:"
 
 
 @dataclass(frozen=True)
@@ -48,9 +85,10 @@ def answer_question(
     client: object,
     model: str = DEFAULT_MODEL,
     max_tokens: int = 256,
+    question_type: str | None = None,
 ) -> AnswerResult:
     """Produce a hypothesis answer from the recalled memories."""
-    prompt = build_answer_prompt(question, memories)
+    prompt = build_answer_prompt(question, memories, question_type=question_type)
     completion = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -218,6 +218,7 @@ async def run_question(
                 instance.question,
                 memories,
                 client=client,
+                question_type=instance.question_type,
             )
             verdict = await asyncio.to_thread(
                 lambda a=ans: judge_answer(

--- a/tests/test_eval/test_longmemeval_answer.py
+++ b/tests/test_eval/test_longmemeval_answer.py
@@ -65,3 +65,44 @@ def test_answer_question_handles_empty_memories():
     assert result.hypothesis
     # still one call; prompt notes there are no memories
     assert len(client.calls) == 1
+
+
+def test_default_prompt_keeps_dont_know_affordance():
+    p = build_answer_prompt("What degree?", ["m"], question_type="single-session-user")
+    assert "don't know" in p.lower() or "do not know" in p.lower()
+
+
+def test_preference_prompt_personalizes_and_drops_abstention():
+    p = build_answer_prompt(
+        "Can you recommend some video editing resources?",
+        ["[user] I use Adobe Premiere Pro."],
+        question_type="single-session-preference",
+    )
+    low = p.lower()
+    # preference: recommend + tailor to the user's known preferences
+    assert "recommend" in low or "tailor" in low or "personal" in low or "preference" in low
+    # must NOT tell the reader to abstain — that was the bug that scored ~0.05
+    assert "don't know" not in low
+    assert "do not know" not in low
+
+
+def test_temporal_prompt_has_stepwise_reasoning():
+    p = build_answer_prompt(
+        "How many days between my two trips?",
+        ["[2023/05/01] [user] first trip"],
+        question_type="temporal-reasoning",
+    )
+    assert "step" in p.lower()
+
+
+def test_answer_question_passes_question_type_through():
+    client = _FakeClient("Try Premiere Pro tutorials on the official Adobe site.")
+    answer_question(
+        "Can you recommend video editing resources?",
+        ["[user] I use Adobe Premiere Pro."],
+        client=client,
+        question_type="single-session-preference",
+    )
+    (call,) = client.calls
+    prompt = call["messages"][0]["content"].lower()
+    assert "don't know" not in prompt


### PR DESCRIPTION
Follow-up to #1032. The LongMemEval reader used one generic QA prompt with an
"if it's not in the snippets, say you don't know" affordance. That tanked
**single-session-preference** questions — which ask for a recommendation
tailored to the user's recalled preferences — because the reader *abstained*
instead of personalizing, despite ~0.90 evidence recall. The gap was the
reader, not the memory.

### Fix
- **single-session-preference**: a dedicated reader prompt that uses the recalled
  preferences to give a concrete, tailored recommendation and never abstains.
- **temporal-reasoning**: a step-by-step-using-the-dated-memories nudge.
- **default (factual QA + abstention)**: unchanged — keeps the "don't know"
  affordance that `_abs` questions rely on.

`question_type` threads `answer_question` → `build_answer_prompt`; the runner
passes `instance.question_type`. TDD: type-aware prompt tests.

### Validated on the same 150-question stratified set (25/type, both non-rerank arms)

| type | raw before → after | keyword before → after |
|---|---|---|
| single-session-preference | **0.04 → 0.68** | **0.08 → 0.60** |
| single-session-user | 0.92 → 1.00 | 1.00 → 1.00 |
| **overall** | **0.553 → 0.653** | **0.567 → 0.647** |

Evidence-recall unchanged at 0.92 (recall was never the issue). The preference
fix is a clear, large win. **The temporal nudge is inconclusive at n=25** (net
noise) and is kept as a standard technique pending full-scale confirmation —
not claimed as a win here.

Mini-runs used a temp DB (nothing persisted to prod `eval_runs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)