### PR TITLE
fix(security): WS-3 B4 PR-1 — stored origin_class through recall + stored-first blockability

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -705,7 +705,8 @@ def _search_fts5(
                 f"""
                 SELECT memory_fts.memory_id, memory_fts.content,
                        memory_fts.source_type, memory_fts.collection,
-                       memory_fts.rank
+                       memory_fts.rank,
+                       memory_metadata.origin_class
                 FROM memory_fts
                 LEFT JOIN memory_metadata
                   ON memory_fts.memory_id = memory_metadata.memory_id
@@ -990,6 +991,8 @@ async def _search_qdrant(
                         # Provenance source tier for KB results (audit D12) — the
                         # label needs it; memory_metadata doesn't carry it.
                         "source_pipeline": payload.get("source_pipeline"),
+                        # WS-3 stored provenance (0054-stamped at store).
+                        "origin_class": payload.get("origin_class"),
                     })
                 return results
     except Exception as exc:
@@ -1230,8 +1233,8 @@ def _enrich_with_metadata(results: list[dict]) -> None:
             conn.row_factory = sqlite3.Row
             placeholders = ",".join("?" for _ in ids)
             rows = conn.execute(
-                f"SELECT memory_id, created_at, wing, collection FROM memory_metadata"  # noqa: S608
-                f" WHERE memory_id IN ({placeholders})",
+                f"SELECT memory_id, created_at, wing, collection, origin_class"  # noqa: S608
+                f" FROM memory_metadata WHERE memory_id IN ({placeholders})",
                 ids,
             ).fetchall()
             meta = {row["memory_id"]: dict(row) for row in rows}
@@ -1242,6 +1245,10 @@ def _enrich_with_metadata(results: list[dict]) -> None:
                     if not r.get("_wing"):
                         r["_wing"] = meta[mid].get("wing")
                     r.setdefault("collection", meta[mid].get("collection"))
+                    # WS-3 stored provenance — fills paths that lack the
+                    # Qdrant payload / FTS join value (setdefault: never
+                    # overrides a value the search path already carried).
+                    r.setdefault("origin_class", meta[mid].get("origin_class"))
         finally:
             conn.close()
     except Exception:
@@ -1826,6 +1833,7 @@ async def _run(prompt: str, session_id: str = "") -> None:
                 if item_is_blockable(
                     collection=r.get("collection"),
                     source_pipeline=r.get("source_pipeline"),
+                    origin_class=r.get("origin_class"),
                 )
             )
             if blockable:

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1245,10 +1245,12 @@ def _enrich_with_metadata(results: list[dict]) -> None:
                     if not r.get("_wing"):
                         r["_wing"] = meta[mid].get("wing")
                     r.setdefault("collection", meta[mid].get("collection"))
-                    # WS-3 stored provenance — fills paths that lack the
-                    # Qdrant payload / FTS join value (setdefault: never
-                    # overrides a value the search path already carried).
-                    r.setdefault("origin_class", meta[mid].get("origin_class"))
+                    # WS-3 stored provenance — fills paths whose search value
+                    # is missing OR None (Qdrant dicts always carry the key,
+                    # None for pre-backfill payloads, so setdefault would
+                    # refuse the fill). A real search-path value always wins.
+                    if r.get("origin_class") is None:
+                        r["origin_class"] = meta[mid].get("origin_class")
         finally:
             conn.close()
     except Exception:

--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -248,6 +248,7 @@ class DeepResearcherImpl:
                     if immunity_shadow.item_is_blockable(
                         collection=getattr(r, "collection", None),
                         source_pipeline=getattr(r, "source_pipeline", None),
+                        origin_class=getattr(r, "origin_class", None),
                     ):
                         blockable += 1
                 lines.append(f"- {content}")

--- a/src/genesis/cc/context_injector.py
+++ b/src/genesis/cc/context_injector.py
@@ -69,6 +69,7 @@ class ContextInjector:
                 if immunity_shadow.item_is_blockable(
                     collection=getattr(r, "collection", None),
                     source_pipeline=getattr(r, "source_pipeline", None),
+                    origin_class=getattr(r, "origin_class", None),
                 ):
                     blockable += 1
             lines.append(

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -121,6 +121,7 @@ class VoiceConversationHandler:
                             if immunity_shadow.item_is_blockable(
                                 collection=getattr(r, "collection", None),
                                 source_pipeline=source_pipeline,
+                                origin_class=getattr(r, "origin_class", None),
                             ):
                                 blockable += 1
                         else:

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -251,7 +251,8 @@ async def search_fts(
         return []
     sql = (
         "SELECT f.unit_id, f.concept, f.body, f.tags, f.domain, f.project_type,"
-        " f.rank, k.source_pipeline, k.ingested_at, k.confidence"
+        " f.rank, k.source_pipeline, k.ingested_at, k.confidence,"
+        " k.origin_class"
         " FROM knowledge_fts f"
         " LEFT JOIN knowledge_units k ON k.id = f.unit_id"
         " WHERE knowledge_fts MATCH ?"
@@ -271,6 +272,8 @@ async def search_fts(
             "unit_id": r[0], "concept": r[1], "body": r[2],
             "tags": r[3], "domain": r[4], "project_type": r[5], "rank": r[6],
             "source_pipeline": r[7], "ingested_at": r[8], "confidence": r[9],
+            # WS-3 stored provenance (0054-stamped at ingest).
+            "origin_class": r[10],
         }
         for r in rows
     ]

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -180,7 +180,8 @@ async def search_ranked(
     # filtering. Keeping the column-qualified SELECT format consistent.
     sql = (
         "SELECT memory_fts.memory_id, memory_fts.content, "
-        "memory_fts.source_type, memory_fts.collection, memory_fts.rank "
+        "memory_fts.source_type, memory_fts.collection, memory_fts.rank, "
+        "memory_metadata.origin_class "
         "FROM memory_fts LEFT JOIN memory_metadata "
         "ON memory_fts.memory_id = memory_metadata.memory_id "
         "WHERE memory_fts MATCH ?"
@@ -224,6 +225,9 @@ async def search_ranked(
         {
             "memory_id": r[0], "content": r[1], "source_type": r[2],
             "collection": r[3], "rank": r[4],
+            # WS-3 stored provenance — from the (already-joined)
+            # memory_metadata row; NULL for pre-0054 rows.
+            "origin_class": r[5],
         }
         for r in rows
     ]

--- a/src/genesis/knowledge/applications/resume_review.py
+++ b/src/genesis/knowledge/applications/resume_review.py
@@ -223,6 +223,7 @@ class ResumeReviewer:
                     context_parts.append(f"[Knowledge: {r.source}]\n{wrapped}")
                     if immunity_shadow.item_is_blockable(
                         collection="knowledge_base", source_pipeline=sp,
+                        origin_class=getattr(r, "origin_class", None),
                     ):
                         blockable += 1
 
@@ -236,6 +237,7 @@ class ResumeReviewer:
                     context_parts.append(f"[Knowledge: {concept}]\n{body}")
                     if immunity_shadow.item_is_blockable(
                         collection="knowledge_base", source_pipeline=sp,
+                        origin_class=fts.get("origin_class"),
                     ):
                         blockable += 1
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -355,6 +355,7 @@ async def memory_recall(
             if immunity_shadow.item_is_blockable(
                 collection=r.collection,
                 source_pipeline=r.source_pipeline,
+                origin_class=r.origin_class,
             )
         )
         await immunity_shadow.record_would_block(
@@ -454,6 +455,7 @@ async def memory_recall(
             if immunity_shadow.item_is_blockable(
                 collection=d.get("collection"),
                 source_pipeline=d.get("source_pipeline"),
+                origin_class=d.get("origin_class"),
             ):
                 blockable += 1
     # WS-3 B1 gate 4 (injection): shadow-record that external content reached
@@ -612,6 +614,7 @@ async def memory_expand(
             if immunity_shadow.item_is_blockable(
                 collection=_collection,
                 source_pipeline=payload.get("source_pipeline"),
+                origin_class=payload.get("origin_class"),
             ):
                 blockable += 1
 
@@ -769,6 +772,7 @@ async def memory_proactive(
             if immunity_shadow.item_is_blockable(
                 collection=r.collection,
                 source_pipeline=r.source_pipeline,
+                origin_class=r.origin_class,
             ):
                 blockable += 1
         out.append(d)
@@ -847,6 +851,10 @@ async def memory_core_facts(
                     "room": payload.get("room", ""),
                     "confidence": payload.get("confidence"),
                     "activation_score": round(act.final_score, 3),
+                    # WS-3 provenance — consumed by the injection-gate check
+                    # below and honest output metadata for callers.
+                    "source_pipeline": payload.get("source_pipeline"),
+                    "origin_class": payload.get("origin_class"),
                 },
                 act.final_score,
             )
@@ -854,6 +862,35 @@ async def memory_core_facts(
 
     scored.sort(key=lambda x: x[1], reverse=True)
     top = scored[:limit]
+
+    # WS-3 B4 gate 4 (injection): core_facts is a query-less AMBIENT surface
+    # that scrolls episodic directly — it bypasses HybridRetriever, so the
+    # .recall()-AST enumeration lock never saw it (gap caught during the B4
+    # planning pass). Wrap external-origin items and shadow-record the
+    # would-block (observe-only — the item still reaches the prompt; the
+    # enforce drop for dispatched sessions is PR-3). Blockability keys on the
+    # STORED origin_class: episodic content is only external when its stored
+    # class says so — the collection fallback alone can never flag it here.
+    blockable = 0
+    for item, _ in top:
+        if immunity_shadow.item_is_blockable(
+            collection="episodic_memory",
+            source_pipeline=item.get("source_pipeline"),
+            origin_class=item.get("origin_class"),
+        ):
+            item["content"] = wrap_external_recall(
+                item["content"],
+                source_pipeline=item.get("source_pipeline"),
+            )
+            blockable += 1
+    await immunity_shadow.record_would_block(
+        gate="injection",
+        source_kind="recall_inject",
+        source_ref="mcp/memory/core.py::memory_core_facts",
+        process="server",
+        blockable_count=blockable,
+        db=memory_mod._db,
+    )
 
     # Track retrieval so activation scores reflect actual usage.
     # (Suppressed under the eval bench's frozen-snapshot mode — see

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -130,6 +130,9 @@ async def knowledge_recall(
                 "retrieval_score": r.retrieval_score or r.score,
                 "origin": "vector",
                 "source_pipeline": r.source_pipeline,
+                # WS-3 stored provenance — carried so item_is_blockable can
+                # key on the stored class instead of re-deriving.
+                "origin_class": r.origin_class,
             }
         )
 
@@ -154,6 +157,8 @@ async def knowledge_recall(
                     "retrieval_score": fts_score,
                     "origin": "fts",
                     "source_pipeline": fts_row.get("source_pipeline"),
+                    # WS-3 stored provenance (search_fts JOINs knowledge_units).
+                    "origin_class": fts_row.get("origin_class"),
                 }
             )
 
@@ -234,6 +239,7 @@ async def knowledge_recall(
             if immunity_shadow.item_is_blockable(
                 collection=d.get("collection"),
                 source_pipeline=d.get("source_pipeline"),
+                origin_class=d.get("origin_class"),
             ):
                 blockable += 1
     # WS-3 B1 gate 4 (injection): shadow-record external content reaching this

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -436,10 +436,15 @@ def _assemble_results(
                 source_pipeline=_p.get("source_pipeline"),
                 # WS-3 stored provenance: read from ``payload`` (not ``_p``)
                 # so FTS5-only hits recover it too — their row dict carries
-                # ``origin_class`` from the search_ranked LEFT JOIN.
-                # ``source_pipeline`` stays Qdrant-only: it has no SQLite
-                # column for episodic and is NOT recoverable on the FTS path.
-                origin_class=payload.get("origin_class"),
+                # ``origin_class`` from the search_ranked LEFT JOIN. COALESCE
+                # to the FTS row for a Qdrant hit whose payload predates the
+                # 0054 backfill — SQLite is authoritative when the payload
+                # key is absent/None. ``source_pipeline`` stays Qdrant-only:
+                # it has no SQLite column and is NOT recoverable on FTS.
+                origin_class=(
+                    payload.get("origin_class")
+                    or (fts_hit.get("origin_class") if fts_hit else None)
+                ),
                 memory_class=_p.get("memory_class", "fact"),
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -434,6 +434,12 @@ def _assemble_results(
                 transcript_path=_p.get("transcript_path"),
                 source_line_range=tuple(_line_range) if _line_range else None,
                 source_pipeline=_p.get("source_pipeline"),
+                # WS-3 stored provenance: read from ``payload`` (not ``_p``)
+                # so FTS5-only hits recover it too — their row dict carries
+                # ``origin_class`` from the search_ranked LEFT JOIN.
+                # ``source_pipeline`` stays Qdrant-only: it has no SQLite
+                # column for episodic and is NOT recoverable on the FTS path.
+                origin_class=payload.get("origin_class"),
                 memory_class=_p.get("memory_class", "fact"),
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -443,7 +443,8 @@ def _assemble_results(
                 # it has no SQLite column and is NOT recoverable on FTS.
                 origin_class=(
                     payload.get("origin_class")
-                    or (fts_hit.get("origin_class") if fts_hit else None)
+                    if payload.get("origin_class") is not None
+                    else (fts_hit.get("origin_class") if fts_hit else None)
                 ),
                 memory_class=_p.get("memory_class", "fact"),
                 query_intent=intent.category,

--- a/src/genesis/memory/types.py
+++ b/src/genesis/memory/types.py
@@ -63,6 +63,12 @@ class RetrievalResult:
     # never masquerades as retrieval quality. 0.0 == not populated (paths
     # other than HybridRetriever.recall don't compute it).
     retrieval_score: float = 0.0
+    # WS-3 stored provenance (migration 0054): the origin_class stamped at
+    # store time (owner / first_party / external_untrusted). None == the
+    # retrieval path couldn't recover it (pre-0054 row or a surface that
+    # doesn't read it) — consumers fall back to the (collection,
+    # source_pipeline) re-derivation in security.immunity_shadow.
+    origin_class: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/genesis/security/immunity_shadow.py
+++ b/src/genesis/security/immunity_shadow.py
@@ -59,23 +59,41 @@ logger = logging.getLogger(__name__)
 _FIRST_PARTY_KB_PIPELINES = frozenset({"surplus", "reference_store", "extraction_job"})
 
 
-def item_is_blockable(*, collection: str | None, source_pipeline: str | None) -> bool:
+def item_is_blockable(
+    *,
+    collection: str | None,
+    source_pipeline: str | None,
+    origin_class: str | None = None,
+) -> bool:
     """True iff a recalled item would be blocked by the injection gate.
 
-    The AUTHORITATIVE external signal is the COLLECTION — ``knowledge_base`` ==
-    external-world, always known at recall time (unlike the per-item
-    source_pipeline, which drift recall overwrites with ``drift``). A KB item is
-    first-party (not blockable) ONLY when its source_pipeline is one that writes
-    first-party content INTO the KB (:data:`_FIRST_PARTY_KB_PIPELINES`) — never
-    because of a retrieval-mechanism tag. This keeps the never-block invariant
-    honest at the site AND counts drift-recalled external content.
+    STORED-FIRST (B4): when the item's stored ``origin_class`` (stamped at
+    store time, migration 0054; plumbed through recall by this PR) is
+    available, it is authoritative — ``immunity.is_blockable`` keys on it
+    directly. This is a deliberate semantic WIDENING vs the old re-derivation:
+    episodic ``external_untrusted`` rows (written by dispatched external
+    sessions, #1021) become observable/blockable, which is exactly what the
+    session-origin substrate built. It also FIXES the over-observe FP class:
+    a first-party item living in the KB via a non-whitelist pipeline no
+    longer counts blockable when its stored class says first_party.
 
-    NOTE (B4): this uses the recall dict's (collection, source_pipeline), not
-    the STORED origin_class (the retriever doesn't plumb it yet). Safe in shadow
-    (never blocks; conservative — over-observes only a first-party item stored
-    via a non-KB-content pipeline yet living in the KB); ENFORCE (B4) must gate
-    on the stored origin_class. Tracked as a B1 follow-up.
+    FALLBACK (stored value absent — pre-0054 row or a surface that doesn't
+    plumb it): the original (collection, source_pipeline) re-derivation. The
+    AUTHORITATIVE external signal there is the COLLECTION — ``knowledge_base``
+    == external-world, always known at recall time (unlike the per-item
+    source_pipeline, which drift recall overwrites with ``drift``). A KB item
+    is first-party (not blockable) ONLY when its source_pipeline is one that
+    writes first-party content INTO the KB
+    (:data:`_FIRST_PARTY_KB_PIPELINES`) — never because of a
+    retrieval-mechanism tag.
+
+    Either path keeps the never-block invariant honest: owner/first_party
+    stored classes are never blockable by construction
+    (``immunity.is_blockable``), and the fallback only ever flags
+    external-collection content.
     """
+    if origin_class is not None:
+        return immunity.is_blockable(origin_class)
     if not is_external(collection):
         return False
     return source_pipeline not in _FIRST_PARTY_KB_PIPELINES

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -438,3 +438,34 @@ async def test_proposal_list_pending_filters(db):
     )
     assert len(only_alpha) == 1
     assert only_alpha[0]["id"] == pid_a
+
+
+# ─── WS-3 B4: search_fts carries stored origin_class ─────────────────────────
+
+
+async def test_search_fts_carries_origin_class(db):
+    await knowledge.upsert(
+        db,
+        project_type="research",
+        domain="web",
+        source_doc="crawl-1",
+        concept="Zebra Migration Patterns",
+        body="Zebra migration corridors shift with seasonal rainfall.",
+        source_pipeline="crag_web",
+        origin_class="external_untrusted",
+    )
+    await knowledge.upsert(
+        db,
+        project_type="research",
+        domain="notes",
+        source_doc="note-1",
+        concept="Zebra Notes",
+        body="Zebra observation summary written first-party.",
+        source_pipeline="surplus",
+        origin_class="first_party",
+    )
+    results = await knowledge.search_fts(db, "zebra")
+    assert len(results) == 2
+    by_concept = {r["concept"]: r for r in results}
+    assert by_concept["Zebra Migration Patterns"]["origin_class"] == "external_untrusted"
+    assert by_concept["Zebra Notes"]["origin_class"] == "first_party"

--- a/tests/test_db/test_search_ranked_invalid_at.py
+++ b/tests/test_db/test_search_ranked_invalid_at.py
@@ -23,6 +23,7 @@ async def _build_db(path: str) -> aiosqlite.Connection:
             valid_at TEXT,
             invalid_at TEXT,
             source_subsystem TEXT,
+            origin_class TEXT,
             deprecated INTEGER NOT NULL DEFAULT 0,
             dream_cycle_run_id TEXT
         )

--- a/tests/test_db/test_search_ranked_subsystem.py
+++ b/tests/test_db/test_search_ranked_subsystem.py
@@ -23,6 +23,7 @@ async def _build_db(path: str) -> aiosqlite.Connection:
             valid_at TEXT,
             invalid_at TEXT,
             source_subsystem TEXT,
+            origin_class TEXT,
             deprecated INTEGER NOT NULL DEFAULT 0,
             dream_cycle_run_id TEXT
         )
@@ -139,5 +140,26 @@ async def test_collection_filter_combines_with_subsystem(tmp_path) -> None:
         )
         ids = {r["memory_id"] for r in rows}
         assert ids == {"user-1"}
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_rows_carry_origin_class(tmp_path) -> None:
+    """WS-3 B4: search_ranked returns memory_metadata.origin_class (the FTS5
+    path's only route to the stored provenance; NULL for pre-0054 rows)."""
+    conn = await _build_db(str(tmp_path / "fts.db"))
+    try:
+        await conn.execute(
+            "UPDATE memory_metadata SET origin_class = 'external_untrusted' "
+            "WHERE memory_id = 'user-1'"
+        )
+        await conn.commit()
+        rows = await memory_crud.search_ranked(
+            conn, query="decision recovery", include_only_subsystems=None,
+        )
+        by_id = {r["memory_id"]: r for r in rows}
+        assert by_id["user-1"]["origin_class"] == "external_untrusted"
+        assert by_id["ego-1"]["origin_class"] is None
     finally:
         await conn.close()

--- a/tests/test_hooks/test_proactive_invalid_at.py
+++ b/tests/test_hooks/test_proactive_invalid_at.py
@@ -306,3 +306,24 @@ def test_enrich_with_metadata_stamps_origin_class(tmp_path, monkeypatch):
     preset = [{"memory_id": "alive", "content": "x", "origin_class": "first_party"}]
     hook._enrich_with_metadata(preset)
     assert preset[0]["origin_class"] == "first_party"
+
+
+def test_enrich_with_metadata_fills_none_valued_key(tmp_path, monkeypatch):
+    """Qdrant hook dicts always carry the key (None for pre-backfill
+    payloads) — the metadata fill must treat None as missing (Codex P2)."""
+    db = tmp_path / "m.db"
+    _build_db(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "UPDATE memory_metadata SET origin_class = 'first_party' "
+            "WHERE memory_id = 'alive'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.setattr(hook, "_DB_PATH", db)
+
+    results = [{"memory_id": "alive", "content": "x", "origin_class": None}]
+    hook._enrich_with_metadata(results)
+    assert results[0]["origin_class"] == "first_party"

--- a/tests/test_hooks/test_proactive_invalid_at.py
+++ b/tests/test_hooks/test_proactive_invalid_at.py
@@ -56,6 +56,7 @@ def _build_db(path: str) -> None:
                 valid_at         TEXT,
                 invalid_at       TEXT,
                 source_subsystem TEXT,
+            origin_class TEXT,
                 deprecated       INTEGER NOT NULL DEFAULT 0,
                 dream_cycle_run_id TEXT
             )
@@ -257,3 +258,51 @@ def test_expired_memory_ids_boundary_future_kept(tmp_path) -> None:
     )
     assert got == {"expired"}
     assert "alive" not in got
+
+
+# ── WS-3 B4: _search_fts5 carries stored origin_class ────────────────────────
+
+
+def test_search_fts5_carries_origin_class(tmp_path):
+    db = tmp_path / "m.db"
+    _build_db(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "UPDATE memory_metadata SET origin_class = 'external_untrusted' "
+            "WHERE memory_id = 'alive'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    rows = hook._search_fts5(db, ["row"])
+    by_id = {r["memory_id"]: r for r in rows}
+    assert by_id["alive"]["origin_class"] == "external_untrusted"
+    # No stamped value -> NULL surfaces as None (fallback derivation decides).
+    assert by_id["future"]["origin_class"] is None
+
+
+def test_enrich_with_metadata_stamps_origin_class(tmp_path, monkeypatch):
+    """_enrich_with_metadata backfills origin_class for fused dicts that lack
+    it (e.g. wing-filter hits) without overriding a search-path value."""
+    db = tmp_path / "m.db"
+    _build_db(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "UPDATE memory_metadata SET origin_class = 'external_untrusted' "
+            "WHERE memory_id = 'alive'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.setattr(hook, "_DB_PATH", db)
+
+    results = [{"memory_id": "alive", "content": "x"}]
+    hook._enrich_with_metadata(results)
+    assert results[0]["origin_class"] == "external_untrusted"
+
+    # setdefault semantics: an origin the search path already carried wins.
+    preset = [{"memory_id": "alive", "content": "x", "origin_class": "first_party"}]
+    hook._enrich_with_metadata(preset)
+    assert preset[0]["origin_class"] == "first_party"

--- a/tests/test_hooks/test_proactive_invalid_at.py
+++ b/tests/test_hooks/test_proactive_invalid_at.py
@@ -56,7 +56,7 @@ def _build_db(path: str) -> None:
                 valid_at         TEXT,
                 invalid_at       TEXT,
                 source_subsystem TEXT,
-            origin_class TEXT,
+                origin_class TEXT,
                 deprecated       INTEGER NOT NULL DEFAULT 0,
                 dream_cycle_run_id TEXT
             )

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1660,3 +1660,81 @@ async def test_reference_store_forwards_session_origin(monkeypatch):
         assert captured["origin_class"] == "external_untrusted"
     finally:
         mod._store, mod._db, mod._qdrant, mod._retriever = old
+
+
+# ─── WS-3 B4: memory_core_facts wraps stored-external items + emits gate 4 ───
+
+
+async def test_memory_core_facts_wraps_external_and_emits(monkeypatch):
+    """core_facts scrolls episodic directly (bypasses HybridRetriever); B4
+    gates it: stored-external items are wrapped and shadow-recorded, first
+    party items untouched. Shadow-only — nothing is excluded."""
+    from types import SimpleNamespace
+
+    import aiosqlite
+
+    import genesis.mcp.memory_mcp as mod
+    from genesis.security import immunity_shadow
+
+    def _point(mid, origin_class, content):
+        payload = {
+            "content": content,
+            "source": "test",
+            "confidence": 0.9,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "retrieved_count": 1,
+            "memory_class": "fact",
+            "wing": "",
+            "room": "",
+            "source_pipeline": "conversation",
+        }
+        if origin_class is not None:
+            payload["origin_class"] = origin_class
+        return SimpleNamespace(id=mid, payload=payload)
+
+    emit = AsyncMock()
+    monkeypatch.setattr(immunity_shadow, "record_would_block", emit)
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        real_db.row_factory = aiosqlite.Row
+        from genesis.db.schema import create_all_tables
+        await create_all_tables(real_db)
+        await real_db.commit()
+
+        qdrant = MagicMock()
+        qdrant.scroll.return_value = (
+            [
+                _point("ext-1", "external_untrusted", "poisoned external text"),
+                _point("fp-1", "first_party", "own first party text"),
+                _point("old-1", None, "pre-0054 row with no stored class"),
+            ],
+            None,
+        )
+        qdrant.retrieve.return_value = []  # skip the retrieved_count writeback
+
+        old = (mod._store, mod._db, mod._qdrant, mod._retriever)
+        try:
+            mod._store = MagicMock()
+            mod._db = real_db
+            mod._qdrant = qdrant
+            mod._retriever = MagicMock()
+
+            tools = await _get_tools()
+            results = await tools["memory_core_facts"].fn(limit=10)
+        finally:
+            mod._store, mod._db, mod._qdrant, mod._retriever = old
+
+    by_id = {r["memory_id"]: r for r in results}
+    assert "<external-content" in by_id["ext-1"]["content"]
+    assert "poisoned external text" in by_id["ext-1"]["content"]
+    assert by_id["fp-1"]["content"] == "own first party text"
+    # No stored class + episodic collection -> fallback says not blockable.
+    assert by_id["old-1"]["content"] == "pre-0054 row with no stored class"
+    # Provenance rides the output dicts.
+    assert by_id["ext-1"]["origin_class"] == "external_untrusted"
+
+    emit.assert_awaited_once()
+    kwargs = emit.await_args.kwargs
+    assert kwargs["gate"] == "injection"
+    assert kwargs["source_ref"] == "mcp/memory/core.py::memory_core_facts"
+    assert kwargs["blockable_count"] == 1

--- a/tests/test_memory/test_origin_class_recall.py
+++ b/tests/test_memory/test_origin_class_recall.py
@@ -144,3 +144,26 @@ async def test_missing_stored_origin_is_none(mock_qdrant, mock_crud, mock_links,
     )
     assert results
     assert all(r.origin_class is None for r in results)
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_qdrant_payload_missing_coalesces_to_fts_row(mock_qdrant, mock_crud, mock_links, _):
+    """A Qdrant hit whose payload predates the 0054 backfill coalesces the
+    stored class from the joined FTS/SQLite row (Codex P2 on #1042)."""
+    retriever = _build_retriever()
+    mock_qdrant.search.return_value = [_qdrant_hit("dual-1", 0.9, origin_class=None)]
+    mock_crud.search_ranked = AsyncMock(
+        return_value=[_fts_row("dual-1", -5.0, origin_class="first_party")]
+    )
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test", source="episodic", limit=5, min_activation=0.0, rerank=False,
+    )
+    assert results
+    assert results[0].origin_class == "first_party"

--- a/tests/test_memory/test_origin_class_recall.py
+++ b/tests/test_memory/test_origin_class_recall.py
@@ -1,0 +1,146 @@
+"""WS-3 B4: stored ``origin_class`` is recovered by recall on BOTH pipelines.
+
+The Qdrant path passes the payload value through; the FTS5-only path reads the
+new ``memory_metadata.origin_class`` column carried on the ``search_ranked``
+row dict (pre-B4 that whole provenance family was silently ``None`` on FTS-only
+hits — the ``_p = {}`` gap). ``search_ranked`` itself is covered in
+``tests/test_db/test_search_ranked_subsystem.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.memory.retrieval import HybridRetriever
+
+
+def _qdrant_hit(mid: str, score: float, *, origin_class: str | None) -> dict:
+    payload = {
+        "content": f"content for {mid}",
+        "source": "test",
+        "memory_type": "episodic",
+        "tags": [],
+        "confidence": 0.8,
+        "created_at": datetime.now(UTC).isoformat(),
+        "retrieved_count": 5,
+        "source_type": "memory",
+    }
+    if origin_class is not None:
+        payload["origin_class"] = origin_class
+    return {"id": mid, "score": score, "payload": payload}
+
+
+def _fts_row(mid: str, rank: float, *, origin_class: str | None) -> dict:
+    return {
+        "memory_id": mid,
+        "content": f"fts content for {mid}",
+        "source_type": "memory",
+        "collection": "episodic_memory",
+        "rank": rank,
+        "origin_class": origin_class,
+    }
+
+
+def _build_retriever() -> HybridRetriever:
+    embed_provider = MagicMock()
+    embed_provider.embed = AsyncMock(return_value=[0.1] * 1024)
+    return HybridRetriever(
+        embedding_provider=embed_provider,
+        qdrant_client=MagicMock(),
+        db=MagicMock(spec_set=["execute", "commit"]),
+    )
+
+
+def _link_mocks(mock_links) -> None:
+    mock_links.count_links = AsyncMock(return_value=0)
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_qdrant_hit_carries_stored_origin(mock_qdrant, mock_crud, mock_links, _):
+    retriever = _build_retriever()
+    mock_qdrant.search.return_value = [
+        _qdrant_hit("ext-1", 0.9, origin_class="external_untrusted"),
+        _qdrant_hit("fp-1", 0.8, origin_class="first_party"),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test",
+        source="episodic",
+        limit=5,
+        min_activation=0.0,
+        rerank=False,
+    )
+    by_id = {r.memory_id: r for r in results}
+    assert by_id["ext-1"].origin_class == "external_untrusted"
+    assert by_id["fp-1"].origin_class == "first_party"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_fts_only_hit_carries_stored_origin(mock_qdrant, mock_crud, mock_links, _):
+    """The pre-B4 gap: an FTS5-only hit lost every payload-derived field."""
+    retriever = _build_retriever()
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(
+        return_value=[
+            _fts_row("fts-ext", -5.0, origin_class="external_untrusted"),
+        ]
+    )
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test",
+        source="episodic",
+        limit=5,
+        min_activation=0.0,
+        rerank=False,
+    )
+    assert results
+    assert results[0].origin_class == "external_untrusted"
+    # source_pipeline stays honestly unrecoverable on the FTS path.
+    assert results[0].source_pipeline is None
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_missing_stored_origin_is_none(mock_qdrant, mock_crud, mock_links, _):
+    """Pre-0054 rows (no stamped value) surface as None — the consumer
+    falls back to (collection, source_pipeline) re-derivation."""
+    retriever = _build_retriever()
+    mock_qdrant.search.return_value = [_qdrant_hit("old-1", 0.9, origin_class=None)]
+    mock_crud.search_ranked = AsyncMock(
+        return_value=[
+            _fts_row("old-2", -5.0, origin_class=None),
+        ]
+    )
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test",
+        source="episodic",
+        limit=5,
+        min_activation=0.0,
+        rerank=False,
+    )
+    assert results
+    assert all(r.origin_class is None for r in results)

--- a/tests/test_security/test_immunity_shadow.py
+++ b/tests/test_security/test_immunity_shadow.py
@@ -203,6 +203,36 @@ def test_item_is_blockable_honors_first_party_in_kb(collection, source_pipeline,
     )
 
 
+@pytest.mark.parametrize(
+    "origin_class,collection,source_pipeline,expected",
+    [
+        # Stored value is AUTHORITATIVE — the (collection, pipeline) fallback
+        # inputs below are chosen to DISAGREE with it, proving precedence.
+        # Widening: episodic external rows (dispatched sessions, #1021) count.
+        ("external_untrusted", "episodic_memory", "conversation", True),
+        # FP fix: first-party item in the KB via a non-whitelist pipeline no
+        # longer over-observes once its stored class says first_party.
+        ("first_party", "knowledge_base", "knowledge_ingest", False),
+        ("owner", "knowledge_base", "knowledge_ingest", False),
+        # Garbage stored value -> fail-closed external (immunity normalizer).
+        ("banana", "episodic_memory", "conversation", True),
+        # No stored value -> the original fallback derivation decides.
+        (None, "knowledge_base", "knowledge_ingest", True),
+        (None, "knowledge_base", "surplus", False),
+        (None, "episodic_memory", "conversation", False),
+    ],
+)
+def test_item_is_blockable_stored_first(origin_class, collection, source_pipeline, expected):
+    assert (
+        immunity_shadow.item_is_blockable(
+            collection=collection,
+            source_pipeline=source_pipeline,
+            origin_class=origin_class,
+        )
+        is expected
+    )
+
+
 @pytest.mark.asyncio
 async def test_recent_summary_rolls_up(tmp_path, monkeypatch):
     monkeypatch.setattr(immunity, "gate_mode", lambda g: "shadow")

--- a/tests/test_security/test_recall_inject_coverage.py
+++ b/tests/test_security/test_recall_inject_coverage.py
@@ -78,12 +78,11 @@ KNOWN_RECALL_SITES: dict[str, tuple[str, str]] = {
         "pipeline-internal", "CRAG re-retrieve; results flow back through wrapped recall"),
 }
 
-# NOTE: memory_expand (mcp/memory/core.py) is ALSO a wrapped inject site, but it
-# retrieves via ``_qdrant.retrieve(...)`` (by-id), not ``.recall(...)``, so it is
-# not captured by this AST sweep. Its wrapping is verified by its own unit test.
-# Likewise the proactive_memory_hook.py script lives outside src/genesis and is
-# covered by tests/test_hooks/test_proactive_provenance.py. If a future change
-# routes either through ``.recall(...)``, this registry will demand it be listed.
+# NOTE: memory_expand and memory_core_facts (mcp/memory/core.py) are ALSO
+# wrapped inject sites, but they read Qdrant directly (by-id retrieve / scroll),
+# not via ``.recall(...)`` — they are captured by the KNOWN_QDRANT_READ_SITES
+# sweep below. The proactive_memory_hook.py script lives outside src/genesis and
+# is covered by tests/test_hooks/test_proactive_provenance.py.
 
 
 def _discover_recall_sites() -> dict[str, int]:
@@ -132,6 +131,9 @@ _GATE_VALID = {"gated", "deferred-with-reason"}
 _EXTRA_WRAPPED_SITES: dict[str, tuple[str, str]] = {
     "mcp/memory/core.py::memory_expand": (
         "gated", "by-id retrieve (not .recall); wraps + emits external hits"),
+    "mcp/memory/core.py::memory_core_facts": (
+        "gated", "episodic scroll (not .recall); wraps stored-external items "
+        "+ emits (B4 — caught by the qdrant-read sweep below)"),
     "scripts/proactive_memory_hook.py::_run": (
         "gated", "sync emit after stdout flush; lives outside src/genesis"),
 }
@@ -261,3 +263,135 @@ def test_every_recall_site_is_classified():
         "Registered recall site(s) no longer found (rename/removal?) — update "
         "KNOWN_RECALL_SITES:\n  " + "\n  ".join(sorted(stale))
     )
+
+
+# ── WS-3 B4: non-recall Qdrant content-read sweep ───────────────────────────
+# ``memory_core_facts`` scrolled episodic and injected full content into a
+# prompt while being INVISIBLE to the ``.recall()`` sweep above — the header\'s
+# "hand enumeration does not converge" applied to the sweep itself. This second
+# sweep closes that class mechanically: every direct Qdrant ``.scroll(...)`` /
+# ``.retrieve(...)`` call site under src/genesis must be classified here.
+#
+#   prompt-gated         — payload CONTENT reaches an LLM prompt; the site wraps
+#                          blockable items and emits the gate-4 shadow record.
+#   infra                — counters/vectors/tags/existence/ops only; no content
+#                          flows into any prompt.
+#   library              — shared Qdrant helper; its CALLERS carry the
+#                          classification.
+#   deferred-with-reason — content DOES reach an LLM but gating is explicitly
+#                          tracked work (rationale must name the follow-up
+#                          concern).
+_QDRANT_READ_VALID = {"prompt-gated", "infra", "library", "deferred-with-reason"}
+
+KNOWN_QDRANT_READ_SITES: dict[str, tuple[str, str]] = {
+    "eval/bench/isolation.py::_scroll_usage": (
+        "infra", "bench snapshot usage-payload copy between collections"),
+    "mcp/memory/core.py::_increment_retrieved": (
+        "infra", "retrieved_count writeback; reads the counter only"),
+    "mcp/memory/core.py::memory_core_facts": (
+        "prompt-gated", "episodic confidence-scroll into the caller prompt; "
+        "wraps stored-external items + emits gate 4 (B4)"),
+    "mcp/memory/core.py::memory_expand": (
+        "prompt-gated", "by-id full-payload expand; wraps + emits gate 4"),
+    "memory/dream_cycle.py::_get_vector": (
+        "infra", "vectors only (with_vectors, no content use)"),
+    "memory/dream_cycle.py::_rehydrate_cluster": (
+        "deferred-with-reason", "cluster member CONTENT feeds the consolidation "
+        "LLM and the synthesized canonical memory does not inherit member "
+        "origin_class — an origin-LAUNDERING path, not a session-inject path. "
+        "Origin-aware consolidation is a tracked WS-3 follow-up; today only a "
+        "handful of episodic rows are external and daily-slice runs shadow."),
+    "memory/health.py::_scan_duplicates": (
+        "infra", "duplicate-detection metric; content hashed, never prompted"),
+    "memory/intent.py::expand_query": (
+        "infra", "tag-index rebuild; with_payload=[tags] only"),
+    "qdrant/collections.py::batch_retrieve_vectors": (
+        "library", "shared helper; callers classified individually"),
+    "qdrant/collections.py::get_point": (
+        "library", "shared helper; callers classified individually"),
+    "qdrant/collections.py::scroll_points": (
+        "library", "shared helper; callers classified individually"),
+    "resilience/embedding_recovery.py::_point_exists": (
+        "infra", "existence check for recovery bookkeeping"),
+    "runtime/init/memory.py::_migrate_reference_vectors": (
+        "infra", "boot-time vector migration"),
+    "session_awareness/ranking.py::rank_candidates": (
+        "deferred-with-reason", "candidate CONTENT reaches the ambient "
+        "attention ARBITER prompt (judgment-only CC run, output = pick "
+        "indices). Origin-aware arbiter handling is a tracked WS-3 follow-up; "
+        "episodic-external volume is currently negligible."),
+    "surplus/extraction_calibration.py::run_calibration": (
+        "infra", "confidence/retrieved_count aggregation only"),
+}
+
+
+def _discover_qdrant_read_sites() -> dict[str, int]:
+    """{"relpath::func": lineno} for every ``X.scroll(...)``/``X.retrieve(...)``
+    call site under src/genesis. Attribute-name match — a non-Qdrant object
+    with a ``.retrieve``/``.scroll`` method would surface here too; classify it
+    (usually ``infra``) rather than narrowing the sweep."""
+    found: dict[str, int] = {}
+    for path in _SRC.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+        funcs = [
+            (n.lineno, getattr(n, "end_lineno", n.lineno), n.name)
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+        rel = path.relative_to(_SRC).as_posix()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ("scroll", "retrieve")
+            ):
+                best, enclosing = -1, "<module>"
+                for start, end, name in funcs:
+                    if start <= node.lineno <= (end or start) and start > best:
+                        best, enclosing = start, name
+                found.setdefault(f"{rel}::{enclosing}", node.lineno)
+    return found
+
+
+def test_qdrant_read_dispositions_valid():
+    for key, (disp, why) in KNOWN_QDRANT_READ_SITES.items():
+        assert disp in _QDRANT_READ_VALID, f"{key}: invalid disposition {disp!r}"
+        assert why.strip(), f"{key}: empty rationale"
+
+
+def test_every_qdrant_read_site_is_classified():
+    discovered = set(_discover_qdrant_read_sites())
+    registered = set(KNOWN_QDRANT_READ_SITES)
+
+    unregistered = discovered - registered
+    assert not unregistered, (
+        "New Qdrant .scroll()/.retrieve() call site(s) not classified:\n  "
+        + "\n  ".join(sorted(unregistered))
+        + "\n\nClassify each in KNOWN_QDRANT_READ_SITES: if payload CONTENT "
+        "reaches an LLM prompt, wrap blockable items + emit gate 4 and mark it "
+        "'prompt-gated'; otherwise 'infra'/'library', or 'deferred-with-reason' "
+        "naming the tracked concern."
+    )
+
+    stale = registered - discovered
+    assert not stale, (
+        "Registered Qdrant read site(s) no longer found (rename/removal?) — "
+        "update KNOWN_QDRANT_READ_SITES:\n  " + "\n  ".join(sorted(stale))
+    )
+
+
+def test_prompt_gated_qdrant_sites_emit():
+    """Every 'prompt-gated' Qdrant read site must call record_would_block[_sync]
+    — deleting/moving the emit fails CI."""
+    emitters = _functions_calling({"record_would_block", "record_would_block_sync"})
+    for key, (disp, _why) in KNOWN_QDRANT_READ_SITES.items():
+        if disp != "prompt-gated":
+            continue
+        assert key in emitters, (
+            f"{key} is classified 'prompt-gated' but its function does not call "
+            "immunity_shadow.record_would_block[_sync]. Re-wire the emit or "
+            "reclassify with a reason."
+        )


### PR DESCRIPTION
## Summary

First of three B4 PRs (stored-origin plumbing → gate-2 substrate → enforce). Shadow behavior only — no blocking anywhere. Makes gate-4 shadow data **enforce-grade** by keying blockability on the origin_class **stamped at store time** (migration 0054) instead of re-deriving from (collection, source_pipeline) at recall.

- **`RetrievalResult.origin_class`** (defaulted-last field): populated on the Qdrant path (payload passthrough, zero I/O) AND the FTS5-only path via a new `memory_metadata.origin_class` column on `search_ranked`'s existing LEFT JOIN. Pre-B4, every payload-derived field was silently `None` on FTS-only hits; `origin_class` is now recovered there (`source_pipeline` intentionally is not — it has no SQLite column for episodic and is honestly unrecoverable on that path).
- **`item_is_blockable` is stored-first**: the stored class is authoritative when present; the old re-derivation remains the fallback for pre-0054 rows. Two deliberate semantic changes, both stated in the docstring: episodic `external_untrusted` rows (written by dispatched sessions) become observable (widening — it's what the session-origin substrate built), and a first-party item living in the KB via a non-whitelist pipeline no longer over-observes (FP fix). All 10 call sites pass the stored value.
- **`memory_core_facts` gated**: it Qdrant-scrolls episodic and injects full content while being invisible to the `.recall()` AST lock — caught during the B4 enumeration pass. Now wraps stored-external items + emits the gate-4 shadow record. Wrap + observe only; the enforce drop (dispatched sessions, pushed surfaces) is PR-3.
- **Enumeration lock gains a second mechanical sweep**: every Qdrant `.scroll()`/`.retrieve()` call site under `src/genesis` must be classified (`KNOWN_QDRANT_READ_SITES`, 15 sites). The sweep surfaced two additional content→LLM surfaces, registered `deferred-with-reason` and tracked as a follow-up: dream-cycle consolidation (origin laundering into the synthesized canonical memory) and session-awareness arbiter candidates.
- **Proactive hook**: `origin_class` through `_search_fts5` (JOIN column), `_search_qdrant` (payload), `_enrich_with_metadata` (setdefault backfill), and the sync gate emit.
- **`knowledge.search_fts` + `knowledge_recall`** reshape dicts carry the key.

## Verification

- Targeted suites green (~560 tests across the blast radius incl. new matrices); `ruff check --no-cache` clean.
- Live-DB-copy E2E: `search_ranked`/`search_fts`/hook rows all carry the column against real data; full `HybridRetriever.recall` against live Qdrant (writebacks off) returns stored origins on vector hits (both classes observed); stored-first semantics verified on the 4 real episodic-external rows (fallback False → stored True) and the FP direction unit-verified.
- Stored distribution on the copy matches 0054 predictions: 55,467 first_party / 768 external_untrusted / 1 NULL.

## Notes for review

- The plan checklist said "exclude/wrap" for core_facts; exclusion would be enforcement ahead of the gate flip (and would change supervised foreground behavior), so this PR wraps + emits — drops land in PR-3 behind `gate_mode == enforce` for dispatched sessions only.
- Closes follow-up 3bf419ca (stored-origin plumbing for gate-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)