### PR TITLE
fix(research): wire search() on Tavily + Exa adapters so results reach the orchestrator

### DIFF
--- a/src/genesis/providers/exa_adapter.py
+++ b/src/genesis/providers/exa_adapter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from typing import TYPE_CHECKING
 
 from genesis.providers.types import (
     CostTier,
@@ -17,6 +18,9 @@ from genesis.providers.types import (
     ProviderResult,
     ProviderStatus,
 )
+
+if TYPE_CHECKING:
+    from genesis.research.types import SearchResult
 
 logger = logging.getLogger(__name__)
 
@@ -143,3 +147,45 @@ class ExaAdapter:
                 latency_ms=latency,
                 provider_name=self.name,
             )
+
+    async def search(self, query: str, *, max_results: int = 10) -> list[SearchResult]:
+        """Return normalized SearchResult objects for the research orchestrator.
+
+        Wraps ``invoke()`` (raw Exa dict) and maps each result's url/title/score
+        plus text (or highlights) into a SearchResult tagged ``source="exa"``.
+        Bridges the orchestrator's ``max_results`` onto Exa's ``num_results`` key
+        (the fallback path passed ``max_results``, which Exa ignored — always
+        defaulting to 5) and requests capped page text so snippets reach parity
+        with the other providers. Returns ``[]`` on any failure.
+        """
+        from genesis.research.types import SearchResult
+
+        result = await self.invoke(
+            {
+                "query": query,
+                "num_results": max_results,
+                "contents": {"text": {"max_characters": 500}},
+            }
+        )
+        if not result.success or not isinstance(result.data, dict):
+            return []
+        out: list[SearchResult] = []
+        for entry in result.data.get("results", []):
+            url = entry.get("url")
+            if not url:
+                continue
+            snippet = entry.get("text") or " ".join(entry.get("highlights") or []) or ""
+            try:
+                score = float(entry.get("score") or 0.0)
+            except (TypeError, ValueError):
+                score = 0.0
+            out.append(
+                SearchResult(
+                    title=entry.get("title") or "",
+                    url=url,
+                    snippet=snippet,
+                    source=self.name,
+                    score=score,
+                )
+            )
+        return out

--- a/src/genesis/providers/tavily_adapter.py
+++ b/src/genesis/providers/tavily_adapter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from typing import TYPE_CHECKING
 
 from genesis.providers.types import (
     CostTier,
@@ -17,6 +18,9 @@ from genesis.providers.types import (
     ProviderResult,
     ProviderStatus,
 )
+
+if TYPE_CHECKING:
+    from genesis.research.types import SearchResult
 
 logger = logging.getLogger(__name__)
 
@@ -123,3 +127,38 @@ class TavilyAdapter:
                 latency_ms=latency,
                 provider_name=self.name,
             )
+
+    async def search(self, query: str, *, max_results: int = 10) -> list[SearchResult]:
+        """Return normalized SearchResult objects for the research orchestrator.
+
+        Wraps ``invoke()`` (which returns the raw Tavily dict) and maps each
+        ``results[]`` entry's title/url/content/score into a SearchResult tagged
+        ``source="tavily"``. Returns ``[]`` on any failure so a degraded provider
+        never breaks the fan-out — matching WebSearchAdapter/PerplexityAdapter.
+        Without this method the orchestrator fell back to ``invoke()`` and its
+        ``isinstance(result.data, list)`` guard silently dropped the dict.
+        """
+        from genesis.research.types import SearchResult
+
+        result = await self.invoke({"query": query, "max_results": max_results})
+        if not result.success or not isinstance(result.data, dict):
+            return []
+        out: list[SearchResult] = []
+        for entry in result.data.get("results", []):
+            url = entry.get("url")
+            if not url:
+                continue
+            try:
+                score = float(entry.get("score") or 0.0)
+            except (TypeError, ValueError):
+                score = 0.0
+            out.append(
+                SearchResult(
+                    title=entry.get("title") or "",
+                    url=url,
+                    snippet=entry.get("content") or "",
+                    source=self.name,
+                    score=score,
+                )
+            )
+        return out

--- a/tests/test_providers/test_exa.py
+++ b/tests/test_providers/test_exa.py
@@ -156,3 +156,42 @@ class TestInvoke:
 
         assert isinstance(result, ProviderResult)
         assert result.success is False
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_returns_searchresults(self, adapter):
+        from genesis.research.types import SearchResult
+
+        r1 = MagicMock(url="https://a.com", title="T1", score=0.8, text="body text", highlights=[])
+        r2 = MagicMock(url="https://b.com", title="T2", score=0.4, text=None, highlights=["hl one", "hl two"])
+        mock_response = MagicMock(results=[r1, r2])
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+        with patch.dict("os.environ", ENV), \
+             patch("exa_py.AsyncExa", return_value=mock_client):
+            results = await adapter.search("q", max_results=7)
+
+        assert all(isinstance(r, SearchResult) for r in results)
+        assert [r.url for r in results] == ["https://a.com", "https://b.com"]
+        assert results[0].snippet == "body text"
+        assert results[1].snippet == "hl one hl two"
+        assert all(r.source == "exa" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_search_bridges_max_results_to_num_results(self, adapter):
+        mock_response = MagicMock(results=[])
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+        with patch.dict("os.environ", ENV), \
+             patch("exa_py.AsyncExa", return_value=mock_client):
+            await adapter.search("q", max_results=9)
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs["num_results"] == 9
+        assert "contents" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_search_empty_on_missing_key(self, adapter):
+        with patch.dict("os.environ", {}, clear=True):
+            results = await adapter.search("q")
+        assert results == []

--- a/tests/test_providers/test_tavily.py
+++ b/tests/test_providers/test_tavily.py
@@ -143,3 +143,45 @@ class TestInvoke:
 
         assert isinstance(result, ProviderResult)
         assert result.success is False
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_returns_searchresults(self, adapter):
+        from genesis.research.types import SearchResult
+
+        mock_response = {
+            "query": "q",
+            "results": [
+                {"title": "T1", "url": "https://a.com", "content": "snippet one", "score": 0.9},
+                {"title": "T2", "url": "https://b.com", "content": "snippet two", "score": 0.5},
+            ],
+            "answer": "ans",
+        }
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+        with patch.dict("os.environ", ENV), \
+             patch("tavily.AsyncTavilyClient", return_value=mock_client):
+            results = await adapter.search("q", max_results=5)
+
+        assert all(isinstance(r, SearchResult) for r in results)
+        assert [r.url for r in results] == ["https://a.com", "https://b.com"]
+        assert results[0].title == "T1"
+        assert results[0].snippet == "snippet one"
+        assert results[0].source == "tavily"
+        assert results[0].score == 0.9
+
+    @pytest.mark.asyncio
+    async def test_search_passes_max_results(self, adapter):
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value={"results": []})
+        with patch.dict("os.environ", ENV), \
+             patch("tavily.AsyncTavilyClient", return_value=mock_client):
+            await adapter.search("q", max_results=8)
+        assert mock_client.search.call_args.kwargs["max_results"] == 8
+
+    @pytest.mark.asyncio
+    async def test_search_empty_on_missing_key(self, adapter):
+        with patch.dict("os.environ", {}, clear=True):
+            results = await adapter.search("q")
+        assert results == []

--- a/tests/test_research/test_orchestrator.py
+++ b/tests/test_research/test_orchestrator.py
@@ -1,6 +1,7 @@
 """Tests for genesis.research.orchestrator."""
 
-from unittest.mock import AsyncMock
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -108,6 +109,45 @@ class TestOrchestrator:
         orch = ResearchOrchestrator(registry=reg)
         res = await orch.search("test", max_results=5)
         assert len(res.results) == 5
+
+    @pytest.mark.asyncio
+    async def test_real_adapters_surface_through_search(self):
+        """Regression: TavilyAdapter/ExaAdapter expose only invoke() returning a
+        DICT; before search() existed the orchestrator's isinstance(...,list)
+        guard silently dropped them (research ran with fewer sources). With
+        search() their results must flow through and dedup by URL."""
+        pytest.importorskip("tavily")
+        pytest.importorskip("exa_py")
+        from genesis.providers.exa_adapter import ExaAdapter
+        from genesis.providers.tavily_adapter import TavilyAdapter
+
+        tav_resp = {
+            "query": "q",
+            "results": [{"title": "TV", "url": "https://tav.com", "content": "c", "score": 0.7}],
+        }
+        tav_client = AsyncMock()
+        tav_client.search = AsyncMock(return_value=tav_resp)
+
+        exa_r = MagicMock(url="https://exa.com", title="EX", score=0.6, text="t", highlights=[])
+        exa_client = AsyncMock()
+        exa_client.search = AsyncMock(return_value=MagicMock(results=[exa_r]))
+
+        reg = ProviderRegistry()
+        reg.register(TavilyAdapter())
+        reg.register(ExaAdapter())
+        orch = ResearchOrchestrator(registry=reg)
+
+        with (
+            patch.dict(os.environ, {"API_KEY_TAVILY": "k", "API_KEY_EXA": "k"}),
+            patch("tavily.AsyncTavilyClient", return_value=tav_client),
+            patch("exa_py.AsyncExa", return_value=exa_client),
+        ):
+            res = await orch.search("q")
+
+        urls = {r.url for r in res.results}
+        assert "https://tav.com" in urls
+        assert "https://exa.com" in urls
+        assert {"tavily", "exa"} <= set(res.sources_queried)
 
     @pytest.mark.asyncio
     async def test_search_and_synthesize_returns_results(self):

--- a/tests/test_research/test_orchestrator.py
+++ b/tests/test_research/test_orchestrator.py
@@ -145,8 +145,8 @@ class TestOrchestrator:
             res = await orch.search("q")
 
         urls = {r.url for r in res.results}
-        assert "https://tav.com" in urls
-        assert "https://exa.com" in urls
+        # exact set equality (not substring `in`) — both providers surface, deduped
+        assert urls == {"https://tav.com", "https://exa.com"}
         assert {"tavily", "exa"} <= set(res.sources_queried)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`ResearchOrchestrator.search()` (`research/orchestrator.py` `_safe_search`) checks
`hasattr(provider, "search")`. `TavilyAdapter`/`ExaAdapter` exposed **only**
`invoke()`, which returns a `ProviderResult` whose `.data` is a **dict**. So the
orchestrator fell through to the `invoke()` fallback, whose `isinstance(result.data,
list)` guard was `False` for a dict → returned `[]` with **no warning**. Research
quietly ran with fewer sources — silent degradation, not a crash. (Extra Exa bug:
the fallback passed `max_results`, but Exa's `invoke()` reads `num_results`, so Exa
always defaulted to 5 even on the rare path it wasn't dropped.)

Both keys are configured in this install, so the drop was **live in production**,
not dormant.

## Fix

- Add `search(query, *, max_results) -> list[SearchResult]` to both adapters,
  mirroring `WebSearchAdapter`/`PerplexityAdapter`: it **wraps the existing
  `invoke()`** (reusing its SDK call + error handling) and maps the dict into
  `SearchResult(source=...)`. Returns `[]` on any failure so a degraded provider
  never breaks the fan-out.
- **Exa**: bridge `max_results` → Exa's `num_results` key, and request capped page
  text (`contents`, 500 chars) so snippets reach parity with the other providers.
- `invoke()` is **unchanged** on both — the MCP `web_tools.py` path depends on its
  dict return shape.

## Verification

- **TDD**: `search()` unit tests for both adapters (mapping, `max_results`/
  `num_results` bridge, empty-on-missing-key) + an orchestrator regression that
  registers the **real** adapters (SDK mocked) and asserts their results now flow
  through and dedup — genuinely RED before the fix (silently dropped). 63 provider+
  research tests pass, ruff clean.
- **Live E2E** (real API calls): `TavilyAdapter().search(...)` returned 3
  `SearchResult`s with full snippets + scores; `ExaAdapter().search(...)` returned 3
  with exactly-500-char capped snippets; both correctly `source`-tagged.
- Code-reviewed (adaptive protocol): verdict DONE, no blockers.

No host-deploy-gate paths touched. Effect: research fan-out now includes Tavily +
Exa results where it previously discarded them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)