### PR TITLE
fix(memory): recover crash-stranded .processing observation files

### DIFF
--- a/src/genesis/memory/session_observer.py
+++ b/src/genesis/memory/session_observer.py
@@ -39,6 +39,11 @@ MAX_PROCESSING_TIME_S = 45.0  # Budget per tick (leave headroom under 60s)
 # Files older than this are cleaned up (stale sessions)
 STALE_FILE_AGE_S = 7 * 24 * 3600  # 7 days
 
+# A .processing file older than this cannot belong to a live tick (45s budget,
+# single-flight) — it was stranded by a crash/restart mid-tick and no future
+# tick would ever scan it. Adopted back at tick start.
+STALE_PROCESSING_AGE_S = 3600
+
 _JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
 
 OBSERVER_PROMPT = """\
@@ -241,6 +246,11 @@ async def process_pending_observations(
     result = ProcessingResult()
     start = time.monotonic()
 
+    # Adopt crash-stranded .processing files before scanning: the finally-
+    # restore below only covers files renamed by THIS run, so a mid-tick
+    # crash would otherwise strand its renamed files forever.
+    _recover_stale_processing_files()
+
     obs_files = _find_observation_files()
     if not obs_files:
         return result
@@ -372,6 +382,31 @@ async def process_pending_observations(
         )
 
     return result
+
+
+def _recover_stale_processing_files() -> None:
+    """Restore .processing files stranded by a crash/restart mid-tick.
+
+    Fail-open: scan errors are swallowed — recovery must never break the
+    tick. Freshness guard: a file younger than STALE_PROCESSING_AGE_S may
+    belong to the current (single-flight) run and is left alone.
+    """
+    sessions_dir = _sessions_dir()
+    if not sessions_dir.exists():
+        return
+    now = time.time()
+    stranded: list[tuple[Path, Path]] = []
+    for processing_path in sessions_dir.glob("*/tool_observations.jsonl.processing"):
+        try:
+            if (now - processing_path.stat().st_mtime) < STALE_PROCESSING_AGE_S:
+                continue
+        except OSError:
+            continue
+        original = processing_path.parent / "tool_observations.jsonl"
+        stranded.append((original, processing_path))
+    if stranded:
+        logger.info("Recovering %d crash-stranded .processing file(s)", len(stranded))
+        _restore_processing_files(stranded)
 
 
 def _restore_processing_files(processing_files: list[tuple[Path, Path]]) -> None:

--- a/src/genesis/memory/session_observer.py
+++ b/src/genesis/memory/session_observer.py
@@ -17,6 +17,7 @@ This processor:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -263,10 +264,17 @@ async def process_pending_observations(
         processing_path = obs_file.with_suffix(".jsonl.processing")
         try:
             os.rename(obs_file, processing_path)
-            processing_files.append((obs_file, processing_path))
         except OSError:
             # File may have been removed or renamed by another process
             continue
+        # rename preserves the source mtime, so an hour-old backlog file
+        # would look "stale" to _recover_stale_processing_files the moment
+        # it's renamed. Stamp processing start so the guard measures
+        # time-since-rename. Best-effort: a missed stamp only matters if
+        # the single-flight invariant is ever broken.
+        with contextlib.suppress(OSError):
+            os.utime(processing_path)
+        processing_files.append((obs_file, processing_path))
 
     if not processing_files:
         _cleanup_stale_files(obs_files)
@@ -288,7 +296,6 @@ async def process_pending_observations(
 
     if not all_observations:
         # Clean up processing files (they were empty or unreadable)
-        import contextlib
         for _original, processing_path in processing_files:
             with contextlib.suppress(OSError):
                 processing_path.unlink(missing_ok=True)

--- a/tests/test_memory/test_session_observer.py
+++ b/tests/test_memory/test_session_observer.py
@@ -386,6 +386,43 @@ class TestRecoverStaleProcessingFiles:
         assert fresh.exists()
         assert not (session_dir / "tool_observations.jsonl").exists()
 
+    @pytest.mark.asyncio
+    async def test_rename_stamps_processing_start(self, tmp_path, monkeypatch):
+        """Renamed .processing files carry a fresh mtime, not the source's.
+
+        os.rename preserves st_mtime, so an hour-old backlog file would look
+        "stale" to _recover_stale_processing_files the instant it's renamed —
+        a recovery pass could then adopt a file mid-processing. Stamping at
+        rename makes the guard measure time-since-rename (Codex P2, PR #1044).
+        """
+        import os as _os
+        import time as _time
+
+        import genesis.memory.session_observer as mod
+
+        monkeypatch.setattr(mod, "_sessions_dir", lambda: tmp_path)
+        session_dir = tmp_path / "sid-1"
+        session_dir.mkdir()
+        obs_file = session_dir / "tool_observations.jsonl"
+        obs_file.write_text('{"tool": "Read"}\n')
+        old = obs_file.stat().st_mtime - (mod.STALE_PROCESSING_AGE_S + 60)
+        _os.utime(obs_file, (old, old))
+
+        monkeypatch.setattr(mod, "_find_observation_files", lambda: [obs_file])
+
+        captured = {}
+
+        def capture_read(path, limit=None):
+            captured["mtime"] = path.stat().st_mtime
+            return []
+
+        monkeypatch.setattr(mod, "_read_observations", capture_read)
+
+        await process_pending_observations(store=AsyncMock(), router=AsyncMock())
+
+        assert "mtime" in captured
+        assert _time.time() - captured["mtime"] < mod.STALE_PROCESSING_AGE_S
+
     def test_stale_processing_merges_into_recreated_original(self, tmp_path, monkeypatch):
         import genesis.memory.session_observer as mod
 

--- a/tests/test_memory/test_session_observer.py
+++ b/tests/test_memory/test_session_observer.py
@@ -14,6 +14,7 @@ from genesis.memory.session_observer import (
     _infer_wing_from_files,
     _parse_notes,
     _read_observations,
+    _recover_stale_processing_files,
     _restore_processing_files,
     process_pending_observations,
 )
@@ -214,8 +215,15 @@ class TestFindObservationFiles:
 
 
 @pytest.mark.asyncio
-async def test_process_pending_observations_no_files(monkeypatch):
+async def test_process_pending_observations_no_files(tmp_path, monkeypatch):
     """No observation files → immediate return with zero counts."""
+    # Isolate BOTH filesystem touchpoints: _find_observation_files AND the
+    # stale-recovery scan (_sessions_dir) — otherwise this unit test globs
+    # (and could rename) files under the real ~/.genesis/sessions.
+    monkeypatch.setattr(
+        "genesis.memory.session_observer._sessions_dir",
+        lambda: tmp_path,
+    )
     monkeypatch.setattr(
         "genesis.memory.session_observer._find_observation_files",
         lambda: [],
@@ -231,6 +239,11 @@ async def test_process_pending_observations_no_files(monkeypatch):
 @pytest.mark.asyncio
 async def test_process_pending_observations_stores_notes(tmp_path, monkeypatch):
     """Observations are read, LLM is called, notes are stored."""
+    # Keep the stale-recovery scan off the real ~/.genesis/sessions
+    monkeypatch.setattr(
+        "genesis.memory.session_observer._sessions_dir",
+        lambda: tmp_path,
+    )
     # Setup observation file in a realistic directory structure
     session_dir = tmp_path / "test-session"
     session_dir.mkdir()
@@ -328,3 +341,67 @@ class TestRestoreProcessingFiles:
 
         assert not original.exists()
         assert not processing.exists()
+class TestRecoverStaleProcessingFiles:
+    """Crash-stranded .processing files must be adopted back at tick start.
+
+    The restore in process_pending_observations only covers files renamed by
+    the CURRENT run — a server crash/restart mid-tick leaves a .processing
+    file no future tick would ever scan (found live: one stranded since
+    2026-05-13). Recovery: at tick start, restore any .processing older than
+    STALE_PROCESSING_AGE_S; a live tick never holds one that long (45s
+    budget, single-flight).
+    """
+
+    def test_stale_processing_is_recovered(self, tmp_path, monkeypatch):
+        import genesis.memory.session_observer as mod
+
+        monkeypatch.setattr(mod, "_sessions_dir", lambda: tmp_path)
+        session_dir = tmp_path / "sid-1"
+        session_dir.mkdir()
+        stale = session_dir / "tool_observations.jsonl.processing"
+        stale.write_text('{"tool": "Read"}\n')
+        import os as _os
+
+        old = stale.stat().st_mtime - (mod.STALE_PROCESSING_AGE_S + 60)
+        _os.utime(stale, (old, old))
+
+        _recover_stale_processing_files()
+
+        original = session_dir / "tool_observations.jsonl"
+        assert original.exists()
+        assert original.read_text() == '{"tool": "Read"}\n'
+        assert not stale.exists()
+
+    def test_fresh_processing_is_left_alone(self, tmp_path, monkeypatch):
+        import genesis.memory.session_observer as mod
+
+        monkeypatch.setattr(mod, "_sessions_dir", lambda: tmp_path)
+        session_dir = tmp_path / "sid-1"
+        session_dir.mkdir()
+        fresh = session_dir / "tool_observations.jsonl.processing"
+        fresh.write_text('{"tool": "Read"}\n')  # mtime = now (a live tick)
+
+        _recover_stale_processing_files()
+
+        assert fresh.exists()
+        assert not (session_dir / "tool_observations.jsonl").exists()
+
+    def test_stale_processing_merges_into_recreated_original(self, tmp_path, monkeypatch):
+        import genesis.memory.session_observer as mod
+
+        monkeypatch.setattr(mod, "_sessions_dir", lambda: tmp_path)
+        session_dir = tmp_path / "sid-1"
+        session_dir.mkdir()
+        original = session_dir / "tool_observations.jsonl"
+        original.write_text('{"tool": "Write"}\n')  # hook wrote since the crash
+        stale = session_dir / "tool_observations.jsonl.processing"
+        stale.write_text('{"tool": "Read"}\n')
+        import os as _os
+
+        old = stale.stat().st_mtime - (mod.STALE_PROCESSING_AGE_S + 60)
+        _os.utime(stale, (old, old))
+
+        _recover_stale_processing_files()
+
+        assert original.read_text() == '{"tool": "Write"}\n{"tool": "Read"}\n'
+        assert not stale.exists()


### PR DESCRIPTION
## What

Follow-up to #1038. The finally-block restore only covers files renamed by the CURRENT run — a server crash/restart mid-tick strands its renamed `.processing` files where no future tick ever scans them. Found live: one file stranded since 2026-05-13 (two months invisible; remediated by hand).

## Fix

`_recover_stale_processing_files()` at the start of `process_pending_observations`: adopts any `tool_observations.jsonl.processing` older than `STALE_PROCESSING_AGE_S` (1h) back to its original name via the existing `_restore_processing_files` helper. Race-safe: the observer is single-flight (`_session_observer_lock` held for the run's full lifetime including its own restore), so recovery can never see a live run's files — only files whose owning process is gone. Fail-open (pathlib glob swallows scan OSErrors internally; stat guarded; awareness-loop backstop unchanged).

## Tests

3 red-first tests (recover stale / leave fresh alone / merge into hook-recreated original). Review finding fixed: the two pre-existing `process_pending_observations` tests now also isolate `_sessions_dir`, so no unit test can touch the real `~/.genesis/sessions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)