### PR TITLE
docs(voice-master): add Forum/Anonymous register row

### DIFF
--- a/src/genesis/skills/voice-master/SKILL.md
+++ b/src/genesis/skills/voice-master/SKILL.md
@@ -193,6 +193,7 @@ changes if asked).
 | Professional peers | 2–3 | OK | professional.md |
 | Formal / cold outreach | 3–4 | None | professional.md, longform.md |
 | Public content | 4–5 | None | longform.md |
+| Forum / Anonymous | Register varies | OK (if in-character) | references/media/forum.md |
 
 ## References
 


### PR DESCRIPTION
Adds a missing row to the voice-master **Register Quick Reference** covering the forum/anonymous register, linking it to the in-repo forum-writing craft reference `references/media/forum.md` (already shipped).

## Why
The register table jumped from "Public content" straight to the References section with no entry for forum/anonymous posting, even though the craft doc for it (`references/media/forum.md`, loaded when `medium=forum`) already exists. This closes that gap.

## Change
One line added to the table:

```
| Forum / Anonymous | Register varies | OK (if in-character) | references/media/forum.md |
```

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)