### PR TITLE
fix(observability): register process_reaper_would_kill observation TTL

### DIFF
--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -136,6 +136,11 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "user_model_delta": timedelta(days=14),
     "capability_improvement": timedelta(days=14),
     "strategic_analysis": timedelta(days=14),
+    # process_reaper dry-run audit trail — the WOULD-KILL evidence an operator
+    # reviews before arming the reaper (set_operator_armed). Kept 14d (vs the 3d
+    # process_reaper_kill above) so a multi-day audit window survives, and made
+    # explicit here so it no longer logs the unknown-type warning every tick.
+    "process_reaper_would_kill": timedelta(days=14),
     # ── 30-day (intake signals, need processing time) ──────────────────
     "finding": timedelta(days=30),
     "bugfix_committed": timedelta(days=30),

--- a/tests/test_db/test_observations.py
+++ b/tests/test_db/test_observations.py
@@ -205,3 +205,20 @@ async def test_query_by_category(db):
     rows = await observations.query(db, category="recon")
     assert len(rows) == 1
     assert rows[0]["id"] == "ocat1"
+
+
+def test_process_reaper_would_kill_ttl_registered(caplog):
+    """The dry-run reaper emits `process_reaper_would_kill` (audit-trail
+    counterpart to `process_reaper_kill`). It must be explicitly registered in
+    _TTL_BY_TYPE so it resolves to a real TTL WITHOUT logging the recurring
+    'Unknown observation type' warning on every reaper tick."""
+    import logging
+    from datetime import timedelta
+
+    assert "process_reaper_would_kill" in observations._TTL_BY_TYPE
+    with caplog.at_level(logging.WARNING, logger="genesis.db.crud.observations"):
+        ttl = observations._compute_ttl("process_reaper_would_kill")
+    assert ttl == timedelta(days=14)
+    assert not any(
+        "Unknown observation type" in r.getMessage() for r in caplog.records
+    ), "a registered type must not trigger the unknown-type warning"


### PR DESCRIPTION
## Why
The dry-run process reaper emits a `process_reaper_would_kill` observation each tick it finds a candidate (`process_reaper.py:483`), but that type was never registered in `_TTL_BY_TYPE` (only its real-kill sibling `process_reaper_kill` was). So **every emission logs an `Unknown observation type … assigning default TTL of 14 days` WARNING** — recurring noise (20+ lines over the last couple of days during the current dry-run audit).

## Change
Register `process_reaper_would_kill` explicitly at **14 days** — its current implicit default, so **zero behavior change** — mirroring the `provider_failure` precedent (an explicit entry added purely to silence the same warning). Documented as the audit-trail counterpart to `process_reaper_kill` (3d): the WOULD-KILL dry-run evidence is reviewed over multiple days before arming, so it keeps the longer window.

## Test
`tests/test_db/test_observations.py::test_process_reaper_would_kill_ttl_registered` — asserts the type is in `_TTL_BY_TYPE` and `_compute_ttl` resolves it without the unknown-type warning (TDD: failed before the fix, passes after). Full `test_observations.py` green (24), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)