### PR TITLE
feat(guardian): F.3 — durable alert queue (store-and-forward for down transports)

### DIFF
--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -168,3 +168,43 @@ edits and untracked files byte-identical); the old database is set aside as
 
 Exit codes: `0` healthy · `1` residual issues remain (escalate) · `2` aborted
 (no writable capture, or no origin URL resolvable for a config restore).
+
+## Durable Alert Queue (F.3)
+
+Alerts used to die silently when their transport was down: the host
+`AlertDispatcher` logged to journald and returned False, and
+`scripts/backup.sh`'s `_send_telegram` dropped the message if `curl` failed.
+F.3 adds a **store-and-forward queue** so an alert raised while Telegram is
+unreachable is persisted and delivered on the next drain.
+
+**Per-side topology — each side drains its OWN queue** (never a shared mount,
+which would invert reliability and race on delivery):
+
+| Side | Queue dir | Enqueue | Drain |
+|---|---|---|---|
+| Host guardian | `<state_path>/alerts/queue/` | `AlertDispatcher.send` when ALL channels fail | top of `run_check` (the 30s tick) |
+| Container | `~/.genesis/alerts/queue/` | shell (`scripts/lib/alert_queue.sh`) + any Python caller | awareness tick (`runtime/init/alert_drain.py`) |
+
+The queue (`genesis.guardian.alert.queue`) is one schema-v1 JSON file per alert
+(`{schema, ts, severity, source, title, body, dedupe_key, meta}`), written
+atomically at 0600. It is deliberately dependency-free so shell scripts write the
+same format via `queue_alert <severity> <source> <title> <body> [dedupe]`. The
+container queue lives in a `queue/` **subdir** so it never collides with
+`tmp_watchgod`'s `tmp_warning` / `tmp_emergency` flag files in
+`~/.genesis/alerts/`.
+
+**Delivery contract.** `drain(root, send)` calls `send(entry)` oldest-first:
+`True` = terminal (delivered OR intentionally deduped → unlink); `False` =
+transient failure (channel still down → keep the entry and stop the batch, retry
+next tick). The container drainer maps the outreach result: `DELIVERED`/
+`REJECTED` → terminal (a `REJECTED` dedup is redundant, not a failure to retry —
+treating it otherwise would wedge the entry forever); `FAILED`/`HELD`/`PENDING`
+→ keep. `prune()` bounds the queue (200 files / 14 days).
+
+**What pages vs. what stays quiet.** `tmp_watchgod` pages only the **emergency
+(red)** tier, transition-only (once per red episode, gated on the shared
+`tmp_emergency` flag). The **warning (orange)** tier stays dashboard-only — it is
+already surfaced via `~/.genesis/watchgod_state.json` →
+`service_status.collect_cc_tmp_usage()` → the dashboard `cc_tmp` tile — so it
+never touches the queue. `backup.sh` failures page (a backup that did not run is
+an emergency).

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -33,6 +33,15 @@ set -euo pipefail
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/backup_backends.sh
 source "$_SCRIPT_DIR/lib/backup_backends.sh"
+# Durable alert queue (F.3): if a Telegram alert can't send, persist it so the
+# container drainer delivers it on recovery instead of losing it to a log line.
+# Guarded no-op fallback if the lib is ever not co-located.
+if [ -f "$_SCRIPT_DIR/lib/alert_queue.sh" ]; then
+    # shellcheck source=scripts/lib/alert_queue.sh
+    source "$_SCRIPT_DIR/lib/alert_queue.sh"
+else
+    queue_alert() { :; }
+fi
 
 # ── Status tracking ──────────────────────────────────────────────────
 _STATUS_FILE="$HOME/.genesis/backup_status.json"
@@ -98,7 +107,15 @@ _send_telegram() {
         "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
         -H "Content-Type: application/json" \
         -d "{\"chat_id\":\"${TELEGRAM_FORUM_CHAT_ID}\",\"text\":$(printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'),\"parse_mode\":\"Markdown\"}" \
-        > /dev/null 2>&1 || log "WARNING: Telegram alert failed to send"
+        > /dev/null 2>&1 || {
+        # Send failed (network/token) — don't lose the alert. Content-derived
+        # dedupe key so distinct backup alerts stay separate but identical
+        # repeats collapse to one queued entry.
+        local _dkey
+        _dkey="backup:$(printf '%s' "$1" | md5sum 2>/dev/null | cut -c1-12)"
+        log "WARNING: Telegram alert failed to send — queued for retry"
+        queue_alert emergency "backup" "Backup alert (Telegram send failed)" "$1" "$_dkey"
+    }
 }
 
 # Large intermediate files (the multi-hundred-MB SQLite .dump) must NOT land in the

--- a/scripts/lib/alert_queue.sh
+++ b/scripts/lib/alert_queue.sh
@@ -1,0 +1,48 @@
+# shellcheck shell=bash
+# Durable alert enqueue for shell scripts (F.3).
+#
+# Writes a schema-v1 JSON entry to ~/.genesis/alerts/queue/ (atomically),
+# matching genesis.guardian.alert.queue. The container awareness tick drains it
+# to Telegram via the outreach pipeline, so an alert raised while the channel is
+# down survives instead of being lost to a log line.
+#
+# Best-effort by contract: every failure is swallowed so a queue problem can
+# NEVER break the calling script (backup runs, the tmp watchgod).
+#
+#   queue_alert <severity> <source> <title> <body> [dedupe_key]
+#
+# severity: info|warning|critical|emergency   source: short id (e.g. backup)
+# Title/body are passed via the environment (never interpolated into code), so
+# arbitrary quotes/newlines are safe.
+
+_ALERT_QUEUE_ROOT="${GENESIS_ALERT_QUEUE_ROOT:-$HOME/.genesis/alerts/queue}"
+
+queue_alert() {
+    local severity="${1:-warning}" source="${2:-shell}" title="${3:-}" body="${4:-}" dedupe="${5:-}"
+    mkdir -p "$_ALERT_QUEUE_ROOT" 2>/dev/null || return 0
+    ALERT_QUEUE_ROOT="$_ALERT_QUEUE_ROOT" \
+    ALERT_SEVERITY="$severity" ALERT_SOURCE="$source" \
+    ALERT_TITLE="$title" ALERT_BODY="$body" ALERT_DEDUPE="$dedupe" \
+    python3 - <<'PY' 2>/dev/null || true
+import json, os, time, uuid
+root = os.environ["ALERT_QUEUE_ROOT"]
+ts = time.time()
+entry = {
+    "schema": 1,
+    "ts": ts,
+    "severity": os.environ.get("ALERT_SEVERITY", "warning"),
+    "source": os.environ.get("ALERT_SOURCE", "shell"),
+    "title": os.environ.get("ALERT_TITLE", ""),
+    "body": os.environ.get("ALERT_BODY", ""),
+    "dedupe_key": os.environ.get("ALERT_DEDUPE") or None,
+    "meta": {},
+}
+tmp = os.path.join(root, ".%s.tmp" % uuid.uuid4().hex)
+fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+try:
+    os.write(fd, json.dumps(entry, ensure_ascii=False).encode("utf-8"))
+finally:
+    os.close(fd)
+os.replace(tmp, os.path.join(root, "%.6f-%s.json" % (ts, uuid.uuid4().hex)))
+PY
+}

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -18,6 +18,17 @@ STATE_FILE="$HOME/.genesis/watchgod_state.json"
 LOG_FILE="$HOME/.genesis/logs/tmp_watchgod.log"
 ALERT_DIR="$HOME/.genesis/alerts"
 
+# Durable alert queue (F.3) — emergency-tier events page Telegram via the
+# container drainer. Guarded: if the lib is ever not co-located, degrade to a
+# no-op so `set -e` can never take the service down over an alert.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$_SCRIPT_DIR/lib/alert_queue.sh" ]]; then
+    # shellcheck source=scripts/lib/alert_queue.sh
+    source "$_SCRIPT_DIR/lib/alert_queue.sh"
+else
+    queue_alert() { :; }
+fi
+
 # Defaults (overridden by config)
 CC_TMP_DIR="$HOME/.genesis/cc-tmp"
 CC_TMP_BUDGET_MB=500
@@ -181,8 +192,14 @@ clean_cc_red() {
     done < <(tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null \
              | grep ':0$' | cut -d: -f1 || true)
 
-    # Emergency alert
+    # Emergency alert — queue a page ONLY on the transition INTO red (flag not
+    # yet set), so a sustained red episode does not re-page every 30s poll.
     mkdir -p "$ALERT_DIR"
+    if [[ ! -f "$ALERT_DIR/tmp_emergency" ]]; then
+        queue_alert emergency "watchgod:cc" "CC temp CRITICAL (RED)" \
+            "cc-tmp blew its budget (${CC_TMP_BUDGET_MB}MB) — nuclear cleanup ran to protect active CC sessions. Investigate what filled it." \
+            "watchgod:tmp_emergency"
+    fi
     touch "$ALERT_DIR/tmp_emergency"
     log WARN "Zone A RED — nuclear cleanup complete"
 }
@@ -278,7 +295,15 @@ clean_sys_red() {
             -mmin +60 -delete 2>/dev/null || true
     fi
 
+    # Emergency alert — transition-only (see clean_cc_red). Zones A/B share the
+    # tmp_emergency flag, so a red episode pages once regardless of which zone
+    # tripped first — intentional (one page per episode, not per zone).
     mkdir -p "$ALERT_DIR"
+    if [[ ! -f "$ALERT_DIR/tmp_emergency" ]]; then
+        queue_alert emergency "watchgod:sys" "System /tmp CRITICAL (RED)" \
+            "/tmp usage exceeded 85% — aggressive cleanup ran. Something is filling /tmp." \
+            "watchgod:tmp_emergency"
+    fi
     touch "$ALERT_DIR/tmp_emergency"
     log WARN "Zone B RED — aggressive cleanup complete"
 }

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -988,6 +988,7 @@ class AwarenessLoop:
         self._sentinel = None
         self._credential_bridge_fn = None
         self._cred_integrity_fn = None
+        self._alert_queue_drainer_fn = None
         self._autonomous_cli_policy_export_fn = None
         self._briefing_writer_fn = None
         self._findings_ingest_fn = None
@@ -1355,6 +1356,14 @@ class AwarenessLoop:
                     self._cred_integrity_fn()
                 except Exception:
                     logger.error("Credential integrity self-heal failed", exc_info=True)
+
+            # F.3: drain durable alert queue (shell/Python alerts → Telegram).
+            # Async; never breaks the tick.
+            if self._alert_queue_drainer_fn:
+                try:
+                    await self._alert_queue_drainer_fn()
+                except Exception:
+                    logger.error("Alert queue drain failed", exc_info=True)
 
             if self._autonomous_cli_policy_export_fn:
                 try:
@@ -1921,6 +1930,16 @@ class AwarenessLoop:
     def set_cred_integrity_fn(self, fn) -> None:
         """Inject the credential-file integrity check + self-heal (per tick)."""
         self._cred_integrity_fn = fn
+
+    def set_alert_queue_drainer(self, fn) -> None:
+        """Inject the async container alert-queue drainer (per tick).
+
+        ``fn`` is an awaitable that flushes ``~/.genesis/alerts/queue`` to
+        Telegram via the outreach pipeline (F.3). Wired independently of the
+        guardian, since shell-written alerts (watchgod/backup) are valuable
+        guardian-or-not.
+        """
+        self._alert_queue_drainer_fn = fn
 
     def set_autonomous_cli_policy_exporter(self, fn) -> None:
         """Inject shared-mount exporter for effective autonomous CLI policy."""

--- a/src/genesis/guardian/alert/dispatcher.py
+++ b/src/genesis/guardian/alert/dispatcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 
 from genesis.guardian.alert.base import Alert, AlertChannel, AlertSeverity
 
@@ -18,19 +19,32 @@ class AlertDispatcher:
     """Dispatch alerts to all configured channels.
 
     Every alert is logged to journald regardless of channel success (F2).
-    If all channels fail, the journal is the backup record.
+    If all channels fail, the journal is the backup record — and, when a
+    ``fallback_queue_root`` is configured (F.3), the alert is persisted to the
+    durable queue so a recovered channel can replay it on the next drain,
+    instead of surviving only as a log line.
     """
 
-    def __init__(self, channels: list[AlertChannel] | None = None) -> None:
+    def __init__(
+        self,
+        channels: list[AlertChannel] | None = None,
+        *,
+        fallback_queue_root: Path | str | None = None,
+    ) -> None:
         self._channels: list[AlertChannel] = channels or []
+        self._fallback_queue_root = fallback_queue_root
 
     def add_channel(self, channel: AlertChannel) -> None:
         self._channels.append(channel)
 
-    async def send(self, alert: Alert) -> bool:
+    async def send(self, alert: Alert, *, allow_queue_fallback: bool = True) -> bool:
         """Send alert to all channels. Returns True if any succeeded.
 
-        Always logs to journal as fallback (F2 finding).
+        Always logs to journal as fallback (F2 finding). On total failure, when
+        ``allow_queue_fallback`` is set and a fallback queue is configured, the
+        alert is enqueued for later replay. The drain path passes
+        ``allow_queue_fallback=False`` so a still-down channel does not
+        re-enqueue an entry it is in the middle of replaying (double-queue trap).
         """
         # F2: Always log to journal, regardless of channel delivery
         logger.log(
@@ -43,6 +57,8 @@ class AlertDispatcher:
 
         if not self._channels:
             logger.warning("No alert channels configured — alert only in journal")
+            if allow_queue_fallback:
+                self._enqueue_fallback(alert)
             return False
 
         results = await asyncio.gather(
@@ -50,19 +66,40 @@ class AlertDispatcher:
             return_exceptions=True,
         )
 
-        successes = sum(
-            1 for r in results
-            if isinstance(r, bool) and r
-        )
+        successes = sum(1 for r in results if isinstance(r, bool) and r)
 
         if successes == 0:
             logger.error(
                 "All %d alert channels failed for: %s",
-                len(self._channels), alert.title,
+                len(self._channels),
+                alert.title,
             )
+            if allow_queue_fallback:
+                self._enqueue_fallback(alert)
             return False
 
         return True
+
+    def _enqueue_fallback(self, alert: Alert) -> None:
+        """Persist a failed-delivery alert to the durable queue (best-effort)."""
+        if not self._fallback_queue_root:
+            return
+        from genesis.guardian.alert.queue import enqueue_alert
+
+        enqueue_alert(
+            self._fallback_queue_root,
+            severity=str(alert.severity.value),
+            source="guardian",
+            title=alert.title,
+            body=alert.body,
+            # Repeated host alerts share a title → one queued copy at a time.
+            dedupe_key=alert.title,
+            meta={
+                "approval_url": alert.approval_url,
+                "likely_cause": alert.likely_cause,
+                "proposed_action": alert.proposed_action,
+            },
+        )
 
     async def test_all(self) -> dict[str, bool]:
         """Test connectivity for all channels. Returns {channel_class: success}."""
@@ -84,7 +121,9 @@ class AlertDispatcher:
         except Exception as exc:
             logger.error(
                 "Alert channel %s failed: %s",
-                type(channel).__name__, exc, exc_info=True,
+                type(channel).__name__,
+                exc,
+                exc_info=True,
             )
             return False
 

--- a/src/genesis/guardian/alert/queue.py
+++ b/src/genesis/guardian/alert/queue.py
@@ -1,0 +1,210 @@
+"""Durable alert queue — store-and-forward when the alert transport is down.
+
+The reliability floor under every other resiliency signal: an alert raised while
+Telegram is unreachable is persisted to disk and delivered on the next drain,
+instead of vanishing into a log line (the failure mode `backup.sh::_send_telegram`
+and the host `AlertDispatcher` both had).
+
+Per-side topology (F.3) — each side drains its OWN queue, never a shared mount
+(that would invert reliability and race on delivery):
+  - Host guardian: ``config.state_path/"alerts"/"queue"`` — drained at the top of
+    ``run_check`` (the 30s tick is the best drainer for host→Telegram outages).
+  - Container: ``~/.genesis/alerts/queue`` — drained on the awareness tick.
+    Lives in a ``queue/`` SUBDIR so it never collides with ``tmp_watchgod``'s
+    ``tmp_warning`` / ``tmp_emergency`` flag files in ``~/.genesis/alerts/``.
+
+This module is deliberately **dependency-free** (stdlib only, no ``genesis``
+imports): it operates on plain dict entries, so callers own the mapping to their
+transport (host → ``Alert``/``dispatcher``; container → ``OutreachRequest``/
+``submit_raw``). That keeps it unit-testable in isolation and lets shell scripts
+write the same schema via ``scripts/lib/alert_queue.sh`` without importing it.
+
+Schema v1 (one JSON file per alert, named ``<ts>-<uuid>.json``)::
+
+    {"schema": 1, "ts": <float>, "severity": str, "source": str,
+     "title": str, "body": str, "dedupe_key": str|null, "meta": {...}}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+_MAX_PER_RUN = 10
+_PRUNE_MAX_FILES = 200
+_PRUNE_MAX_AGE_S = 14 * 24 * 3600  # 14 days
+_DEDUPE_SCAN_LIMIT = 200  # bound the enqueue-time dedupe scan on a huge backlog
+
+
+def enqueue_alert(
+    root: Path | str,
+    *,
+    severity: str,
+    source: str,
+    title: str,
+    body: str,
+    dedupe_key: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> bool:
+    """Persist one alert to the queue. Best-effort — **never raises**.
+
+    Durability must never break its caller (a guardian tick, a dispatcher send,
+    a backup run): any failure is logged and swallowed, returning ``False``.
+
+    When ``dedupe_key`` is set and a live (undrained) entry already carries it,
+    the write is skipped and ``False`` is returned — so a condition that recurs
+    every tick while the channel is down leaves at most ONE queued entry per key.
+    """
+    try:
+        root = Path(root).expanduser()
+        root.mkdir(parents=True, exist_ok=True)
+        if dedupe_key and _has_live_dedupe_key(root, dedupe_key):
+            return False
+        ts = time.time()
+        entry = {
+            "schema": SCHEMA_VERSION,
+            "ts": ts,
+            "severity": severity,
+            "source": source,
+            "title": title,
+            "body": body,
+            "dedupe_key": dedupe_key,
+            "meta": meta or {},
+        }
+        _atomic_write_json(root / f"{ts:.6f}-{uuid.uuid4().hex}.json", entry)
+        return True
+    except Exception:
+        logger.warning("enqueue_alert failed — alert dropped from queue", exc_info=True)
+        return False
+
+
+def list_queued(root: Path | str) -> list[tuple[Path, dict[str, Any]]]:
+    """Return ``(path, entry)`` pairs oldest-first (by ``ts``, then filename).
+
+    A file that cannot be parsed as a v1 entry is renamed ``<name>.corrupt`` and
+    skipped, so one bad write can never wedge the drain.
+    """
+    root = Path(root).expanduser()
+    if not root.exists():
+        return []
+    out: list[tuple[float, str, Path, dict[str, Any]]] = []
+    for path in root.glob("*.json"):
+        try:
+            entry = json.loads(path.read_text())
+            if not isinstance(entry, dict) or "ts" not in entry:
+                raise ValueError("not a v1 alert entry")
+        except Exception:
+            _quarantine_corrupt(path)
+            continue
+        out.append((float(entry.get("ts", 0.0)), path.name, path, entry))
+    out.sort(key=lambda t: (t[0], t[1]))
+    return [(p, e) for _, _, p, e in out]
+
+
+async def drain(
+    root: Path | str,
+    send: Callable[[dict[str, Any]], Awaitable[bool]],
+    *,
+    max_per_run: int = _MAX_PER_RUN,
+) -> int:
+    """Deliver queued alerts oldest-first via ``send``. Returns the count removed.
+
+    ``send(entry) -> bool`` contract:
+      - ``True``  = **terminal** — the alert was delivered OR intentionally
+        dropped (e.g. the outreach pipeline's dedup returned ``REJECTED``). The
+        entry is unlinked. (REJECTED is NOT a failure to retry — treating it as
+        one would leave a deduped entry stuck in the queue forever.)
+      - ``False`` = **transient failure** — the channel is still down. The entry
+        is kept and the drain STOPS for this run (no point burning the batch
+        against a dead channel; the next tick retries from the same head).
+
+    ``send`` raising is treated as a transient failure (kept, stop).
+    """
+    removed = 0
+    for path, entry in list_queued(root)[:max_per_run]:
+        try:
+            terminal = await send(entry)
+        except Exception:
+            logger.warning("alert-queue send raised — keeping entry", exc_info=True)
+            break
+        if not terminal:
+            break
+        removed += _safe_unlink(path)
+    return removed
+
+
+def prune(
+    root: Path | str,
+    *,
+    max_files: int = _PRUNE_MAX_FILES,
+    max_age_s: float = _PRUNE_MAX_AGE_S,
+) -> int:
+    """Bound the queue: drop entries older than ``max_age_s``, then oldest over
+    ``max_files``. Best-effort — returns the number removed, never raises.
+    """
+    removed = 0
+    try:
+        entries = list_queued(root)
+        now = time.time()
+        survivors: list[tuple[Path, dict[str, Any]]] = []
+        for path, entry in entries:
+            if now - float(entry.get("ts", now)) > max_age_s:
+                removed += _safe_unlink(path)
+            else:
+                survivors.append((path, entry))
+        overflow = len(survivors) - max_files
+        for path, _ in survivors[: max(0, overflow)]:  # oldest-first already
+            removed += _safe_unlink(path)
+    except Exception:
+        logger.warning("alert-queue prune failed", exc_info=True)
+    return removed
+
+
+# --- internals ---------------------------------------------------------------
+
+
+def _has_live_dedupe_key(root: Path, dedupe_key: str) -> bool:
+    for i, (_, entry) in enumerate(list_queued(root)):
+        if i >= _DEDUPE_SCAN_LIMIT:
+            break
+        if entry.get("dedupe_key") == dedupe_key:
+            return True
+    return False
+
+
+def _atomic_write_json(path: Path, obj: dict[str, Any]) -> None:
+    tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    data = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    os.replace(tmp, path)
+
+
+def _quarantine_corrupt(path: Path) -> None:
+    try:
+        path.rename(path.with_suffix(path.suffix + ".corrupt"))
+    except Exception:
+        logger.debug("could not quarantine corrupt alert entry %s", path, exc_info=True)
+
+
+def _safe_unlink(path: Path) -> int:
+    try:
+        path.unlink()
+        return 1
+    except FileNotFoundError:
+        return 0
+    except Exception:
+        logger.debug("could not unlink alert entry %s", path, exc_info=True)
+        return 0

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -99,7 +99,9 @@ def _setup_logging() -> None:
 
 def _build_dispatcher(config: GuardianConfig) -> AlertDispatcher:
     """Build the alert dispatcher with configured channels."""
-    dispatcher = AlertDispatcher()
+    dispatcher = AlertDispatcher(
+        fallback_queue_root=config.state_path / "alerts" / "queue",
+    )
 
     token = config.alert.telegram_bot_token
     chat_id = config.alert.telegram_chat_id
@@ -137,6 +139,52 @@ def _build_dispatcher(config: GuardianConfig) -> AlertDispatcher:
         logger.warning("No Telegram credentials — alerts will only go to journal")
 
     return dispatcher
+
+
+def _alert_from_queue_entry(entry: dict) -> Alert:
+    """Rebuild an ``Alert`` from a persisted queue entry (schema v1)."""
+    meta = entry.get("meta") or {}
+    try:
+        severity = AlertSeverity(entry.get("severity", "warning"))
+    except ValueError:
+        severity = AlertSeverity.WARNING
+    return Alert(
+        severity=severity,
+        title=entry.get("title", ""),
+        body=entry.get("body", ""),
+        approval_url=meta.get("approval_url"),
+        likely_cause=meta.get("likely_cause"),
+        proposed_action=meta.get("proposed_action"),
+    )
+
+
+async def _drain_host_alert_queue(
+    config: GuardianConfig, dispatcher: AlertDispatcher,
+) -> None:
+    """Replay queued host alerts through the dispatcher, then bound the queue.
+
+    Never raises — a drain failure must not stop the health check. The replay
+    send disables the queue fallback so a still-down channel does not
+    re-enqueue the entry it is replaying (see ``AlertDispatcher.send``).
+    """
+    from genesis.guardian.alert import queue as alert_queue
+
+    root = config.state_path / "alerts" / "queue"
+
+    async def _send(entry: dict) -> bool:
+        # Host has no dedup layer: dispatcher.send returns True iff a channel
+        # delivered → terminal (unlink); False → still down → keep + stop.
+        return await dispatcher.send(
+            _alert_from_queue_entry(entry), allow_queue_fallback=False,
+        )
+
+    try:
+        drained = await alert_queue.drain(root, _send)
+        if drained:
+            logger.info("Replayed %d queued host alert(s)", drained)
+        alert_queue.prune(root)
+    except Exception:
+        logger.warning("host alert-queue drain failed", exc_info=True)
 
 
 def _build_provisioning_adapter(config: GuardianConfig):
@@ -291,6 +339,11 @@ async def run_check(config: GuardianConfig | None = None) -> None:
     snapshots = SnapshotManager(config)
     diagnosis_engine = DiagnosisEngine(config)
     recovery_engine = RecoveryEngine(config, sm, snapshots, dispatcher)
+
+    # F.3: drain any alerts queued while host→Telegram was down BEFORE running
+    # the cycle — a recovered channel flushes the backlog first, and new
+    # failures this tick re-enqueue behind it. Best-effort; never blocks a check.
+    await _drain_host_alert_queue(config, dispatcher)
 
     try:
         await _check_cycle(config, sm, dispatcher, snapshots, diagnosis_engine, recovery_engine)

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -393,6 +393,9 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         if _full:
             self._run_init_step("cred_integrity", self._init_cred_integrity)
 
+        if _full:
+            self._run_init_step("alert_drain", self._init_alert_drain)
+
         self._run_init_step("router", self._init_router)
 
         self._run_init_step("perception", self._init_perception)

--- a/src/genesis/runtime/_init_delegates.py
+++ b/src/genesis/runtime/_init_delegates.py
@@ -144,6 +144,10 @@ class _InitDelegatesMixin:
         from genesis.runtime.init.cred_integrity import wire
         wire(self)
 
+    def _init_alert_drain(self) -> None:
+        from genesis.runtime.init.alert_drain import wire
+        wire(self)
+
     async def _init_guardian_monitoring(self) -> None:
         from genesis.runtime.init.guardian import init_guardian_monitoring
         await init_guardian_monitoring(self)

--- a/src/genesis/runtime/init/alert_drain.py
+++ b/src/genesis/runtime/init/alert_drain.py
@@ -1,0 +1,88 @@
+"""Alert-drain init: wire the container alert-queue drainer to the awareness tick.
+
+F.3. Shell scripts (``tmp_watchgod.sh`` emergency tier, ``backup.sh`` failures)
+and any Python caller enqueue durable alerts to ``~/.genesis/alerts/queue`` via
+``genesis.guardian.alert.queue``. This drainer flushes that queue to Telegram
+through the outreach pipeline every awareness tick, so an alert raised while the
+channel was down is delivered when it recovers instead of vanishing.
+
+Wired **unconditionally** (like ``cred_integrity.wire`` — NOT the guardian init,
+which early-returns when ``guardian_remote.yaml`` is absent) because these alerts
+matter guardian-or-not. The drainer closure resolves ``rt._outreach_pipeline``
+**lazily per-tick**, so bootstrap init order is irrelevant — by the first
+meaningful tick outreach is up; until then entries are kept and retried.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_ROOT = Path.home() / ".genesis" / "alerts" / "queue"
+
+
+def wire(rt) -> None:
+    """Install the per-tick alert-queue drainer on the awareness loop."""
+    loop = getattr(rt, "_awareness_loop", None)
+    if loop is None:
+        return
+    loop.set_alert_queue_drainer(_make_drainer(rt))
+    logger.debug("alert-queue drainer wired to awareness tick")
+
+
+def _make_drainer(rt):
+    """Build the async, no-arg drainer bound to ``rt`` (lazy pipeline resolve)."""
+    from genesis.guardian.alert import queue as alert_queue
+
+    async def _send(entry: dict) -> bool:
+        """Deliver one queued entry via outreach. Returns True=terminal (unlink),
+        False=transient (keep + stop the drain).
+        """
+        pipeline = getattr(rt, "_outreach_pipeline", None)
+        if pipeline is None:
+            # Outreach not up yet (startup-transient) — keep and retry next tick.
+            return False
+
+        from genesis.outreach.types import (
+            OutreachCategory,
+            OutreachRequest,
+            OutreachStatus,
+        )
+
+        source = entry.get("source", "alert")
+        title = entry.get("title", "")
+        body = entry.get("body", "")
+        text = f"{title}\n\n{body}" if title and body else (title or body)
+        # Dedup identity is the (signal_type, topic, category) triple. Derive the
+        # topic from the alert's IDENTITY (dedupe_key) — NOT the source — so two
+        # distinct alerts that share a source (e.g. backup-failed vs
+        # offsite-failed, both source="backup") stay independently deliverable,
+        # while genuine repeats of the SAME alert still collapse.
+        identity = entry.get("dedupe_key") or source
+        result = await pipeline.submit_raw(
+            text,
+            OutreachRequest(
+                category=OutreachCategory.BLOCKER,
+                topic=f"alert:{identity}",
+                context=text,
+                salience_score=1.0,
+                # Constant signal_type keeps queued replays in their own dedup
+                # namespace (never cross-suppressing a live guardian_alert).
+                signal_type="queued_alert",
+                source_id=identity,
+            ),
+        )
+        # DELIVERED and REJECTED are both TERMINAL → unlink. REJECTED means the
+        # pipeline's own dedup found it redundant; retrying would wedge the entry
+        # in the queue forever. FAILED/HELD/PENDING → keep + retry next tick.
+        return result.status in (OutreachStatus.DELIVERED, OutreachStatus.REJECTED)
+
+    async def _drainer() -> None:
+        drained = await alert_queue.drain(_QUEUE_ROOT, _send)
+        if drained:
+            logger.info("Delivered %d queued alert(s) via outreach", drained)
+        alert_queue.prune(_QUEUE_ROOT)
+
+    return _drainer

--- a/tests/test_guardian/test_alert.py
+++ b/tests/test_guardian/test_alert.py
@@ -17,7 +17,6 @@ from genesis.guardian.alert.telegram import CONFLICT_SENTINEL, TelegramAlertChan
 
 
 class TestAlert:
-
     def test_basic_alert(self) -> None:
         alert = Alert(
             severity=AlertSeverity.CRITICAL,
@@ -52,7 +51,6 @@ class TestAlert:
 
 
 class TestTelegramChannel:
-
     @pytest.fixture
     def channel(self) -> TelegramAlertChannel:
         return TelegramAlertChannel(
@@ -139,7 +137,6 @@ class TestTelegramChannel:
 
 
 class TestAlertDispatcher:
-
     @pytest.mark.asyncio
     async def test_dispatch_to_multiple_channels(self) -> None:
         ch1 = AsyncMock(spec=AlertChannel)
@@ -160,7 +157,7 @@ class TestAlertDispatcher:
         ch1 = AsyncMock(spec=AlertChannel)
         ch1.send.return_value = False  # fails
         ch2 = AsyncMock(spec=AlertChannel)
-        ch2.send.return_value = True   # succeeds
+        ch2.send.return_value = True  # succeeds
 
         dispatcher = AlertDispatcher([ch1, ch2])
         alert = Alert(severity=AlertSeverity.INFO, title="Test", body="Test")
@@ -223,6 +220,70 @@ class TestAlertDispatcher:
         assert "AsyncMock" in str(results) or len(results) == 1
 
 
+class TestAlertDispatcherQueueFallback:
+    """F.3: a total-delivery failure persists the alert to a durable queue."""
+
+    @pytest.mark.asyncio
+    async def test_all_channels_fail_enqueues(self, tmp_path) -> None:
+        from genesis.guardian.alert import queue as alert_queue
+
+        root = tmp_path / "queue"
+        ch = AsyncMock(spec=AlertChannel)
+        ch.send.return_value = False
+        dispatcher = AlertDispatcher([ch], fallback_queue_root=root)
+        alert = Alert(severity=AlertSeverity.CRITICAL, title="boom", body="down")
+
+        assert await dispatcher.send(alert) is False
+        entries = [e for _, e in alert_queue.list_queued(root)]
+        assert len(entries) == 1
+        assert entries[0]["title"] == "boom"
+        assert entries[0]["source"] == "guardian"
+
+    @pytest.mark.asyncio
+    async def test_no_channels_enqueues(self, tmp_path) -> None:
+        from genesis.guardian.alert import queue as alert_queue
+
+        root = tmp_path / "queue"
+        dispatcher = AlertDispatcher(fallback_queue_root=root)
+        alert = Alert(severity=AlertSeverity.WARNING, title="w", body="b")
+        assert await dispatcher.send(alert) is False
+        assert len(alert_queue.list_queued(root)) == 1
+
+    @pytest.mark.asyncio
+    async def test_success_does_not_enqueue(self, tmp_path) -> None:
+        from genesis.guardian.alert import queue as alert_queue
+
+        root = tmp_path / "queue"
+        ch = AsyncMock(spec=AlertChannel)
+        ch.send.return_value = True
+        dispatcher = AlertDispatcher([ch], fallback_queue_root=root)
+        alert = Alert(severity=AlertSeverity.INFO, title="ok", body="b")
+        assert await dispatcher.send(alert) is True
+        assert alert_queue.list_queued(root) == []
+
+    @pytest.mark.asyncio
+    async def test_replay_path_does_not_re_enqueue(self, tmp_path) -> None:
+        # The drain path passes allow_queue_fallback=False so a still-down
+        # channel never re-queues the entry it is replaying (double-queue trap).
+        from genesis.guardian.alert import queue as alert_queue
+
+        root = tmp_path / "queue"
+        ch = AsyncMock(spec=AlertChannel)
+        ch.send.return_value = False
+        dispatcher = AlertDispatcher([ch], fallback_queue_root=root)
+        alert = Alert(severity=AlertSeverity.CRITICAL, title="x", body="y")
+        assert await dispatcher.send(alert, allow_queue_fallback=False) is False
+        assert alert_queue.list_queued(root) == []
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_root_is_safe(self) -> None:
+        ch = AsyncMock(spec=AlertChannel)
+        ch.send.return_value = False
+        dispatcher = AlertDispatcher([ch])  # no fallback configured
+        alert = Alert(severity=AlertSeverity.WARNING, title="w", body="b")
+        assert await dispatcher.send(alert) is False  # no crash
+
+
 # ── Keyword-reply recovery-approval gate ─────────────────────────────────
 
 
@@ -246,7 +307,9 @@ class TestTelegramKeywordGate:
     @pytest.fixture
     def channel(self) -> TelegramAlertChannel:
         return TelegramAlertChannel(
-            bot_token="test-token", chat_id="12345", thread_id="67890",
+            bot_token="test-token",
+            chat_id="12345",
+            thread_id="67890",
         )
 
     # --- _send_message returns the message_id (the reply target) ---
@@ -257,7 +320,8 @@ class TestTelegramKeywordGate:
             assert channel._send_message("hi") == 4242
 
     def test_send_message_returns_none_when_not_ok(
-        self, channel: TelegramAlertChannel,
+        self,
+        channel: TelegramAlertChannel,
     ) -> None:
         resp = _urlopen_returning({"ok": False, "description": "bad request"})
         with patch.object(urllib.request, "urlopen", return_value=resp):
@@ -266,29 +330,38 @@ class TestTelegramKeywordGate:
     # --- _poll_for_keyword_sync: reply-to filter + keyword match + 409 sentinel ---
 
     def test_poll_matches_keyword_reply_to_gate(
-        self, channel: TelegramAlertChannel,
+        self,
+        channel: TelegramAlertChannel,
     ) -> None:
         """A keyword reply to OUR gate message is returned, upper-cased."""
-        updates = {"ok": True, "result": [
-            {"message": {"text": "approve", "reply_to_message": {"message_id": 100}}},
-        ]}
+        updates = {
+            "ok": True,
+            "result": [
+                {"message": {"text": "approve", "reply_to_message": {"message_id": 100}}},
+            ],
+        }
         with patch.object(urllib.request, "urlopen", return_value=_urlopen_returning(updates)):
             kw = channel._poll_for_keyword_sync(100, frozenset({"APPROVE", "DENY"}))
         assert kw == "APPROVE"
 
     def test_poll_ignores_reply_to_other_message(
-        self, channel: TelegramAlertChannel,
+        self,
+        channel: TelegramAlertChannel,
     ) -> None:
         """A keyword reply to a DIFFERENT message is not ours — ignore it."""
-        updates = {"ok": True, "result": [
-            {"message": {"text": "APPROVE", "reply_to_message": {"message_id": 999}}},
-        ]}
+        updates = {
+            "ok": True,
+            "result": [
+                {"message": {"text": "APPROVE", "reply_to_message": {"message_id": 999}}},
+            ],
+        }
         with patch.object(urllib.request, "urlopen", return_value=_urlopen_returning(updates)):
             kw = channel._poll_for_keyword_sync(100, frozenset({"APPROVE", "DENY"}))
         assert kw is None
 
     def test_poll_ignores_non_reply_keyword(
-        self, channel: TelegramAlertChannel,
+        self,
+        channel: TelegramAlertChannel,
     ) -> None:
         """A bare keyword that is NOT a reply (e.g. someone chatting) is ignored."""
         updates = {"ok": True, "result": [{"message": {"text": "APPROVE"}}]}
@@ -297,18 +370,23 @@ class TestTelegramKeywordGate:
         assert kw is None
 
     def test_poll_ignores_non_keyword_reply(
-        self, channel: TelegramAlertChannel,
+        self,
+        channel: TelegramAlertChannel,
     ) -> None:
         """A reply to the gate that isn't an allowed keyword is ignored."""
-        updates = {"ok": True, "result": [
-            {"message": {"text": "maybe later", "reply_to_message": {"message_id": 100}}},
-        ]}
+        updates = {
+            "ok": True,
+            "result": [
+                {"message": {"text": "maybe later", "reply_to_message": {"message_id": 100}}},
+            ],
+        }
         with patch.object(urllib.request, "urlopen", return_value=_urlopen_returning(updates)):
             kw = channel._poll_for_keyword_sync(100, frozenset({"APPROVE", "DENY"}))
         assert kw is None
 
     def test_poll_returns_conflict_sentinel_on_409(
-        self, channel: TelegramAlertChannel,
+        self,
+        channel: TelegramAlertChannel,
     ) -> None:
         """HTTP 409 → CONFLICT_SENTINEL (main bot alive on same token), not None."""
         err = urllib.error.HTTPError("url", 409, "Conflict", {}, None)

--- a/tests/test_guardian/test_alert_drain.py
+++ b/tests/test_guardian/test_alert_drain.py
@@ -1,0 +1,116 @@
+"""Tests for the container alert-queue drainer — genesis.runtime.init.alert_drain.
+
+Covers the critical cross-module seam WARNING-2 flagged: the ``_send`` closure's
+mapping of outreach status → terminal(unlink)/transient(keep), the
+identity-derived topic, lazy pipeline resolution, and the unconditional ``wire``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.guardian.alert import queue as q
+from genesis.outreach.types import OutreachResult, OutreachStatus
+from genesis.runtime.init import alert_drain
+
+
+class _FakePipeline:
+    """Stand-in for OutreachPipeline.submit_raw returning a scripted status."""
+
+    def __init__(self, status: OutreachStatus) -> None:
+        self._status = status
+        self.calls: list = []
+
+    async def submit_raw(self, text, request, **kw) -> OutreachResult:
+        self.calls.append((text, request))
+        return OutreachResult(
+            outreach_id="x",
+            status=self._status,
+            channel="telegram",
+            message_content=text,
+            governance_result=None,
+        )
+
+
+class _RT:
+    def __init__(self, pipeline=None, loop=None) -> None:
+        self._outreach_pipeline = pipeline
+        self._awareness_loop = loop
+
+
+def _enqueue(root, **kw):
+    kw.setdefault("severity", "emergency")
+    kw.setdefault("source", "backup")
+    kw.setdefault("title", "Backup failed")
+    kw.setdefault("body", "disk full")
+    q.enqueue_alert(root, **kw)
+
+
+@pytest.mark.asyncio
+async def test_delivered_unlinks_and_uses_identity_topic(tmp_path, monkeypatch):
+    root = tmp_path / "queue"
+    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    _enqueue(root, dedupe_key="backup:k1")
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+
+    await alert_drain._make_drainer(_RT(pipeline=pipe))()
+
+    assert len(pipe.calls) == 1
+    _, req = pipe.calls[0]
+    assert req.topic == "alert:backup:k1"  # identity, not bare source
+    assert req.category.value == "blocker"
+    assert req.signal_type == "queued_alert"
+    assert q.list_queued(root) == []  # terminal → unlinked
+
+
+@pytest.mark.asyncio
+async def test_rejected_is_terminal_unlinks(tmp_path, monkeypatch):
+    # REJECTED (outreach dedup) must NOT wedge the entry forever.
+    root = tmp_path / "queue"
+    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    _enqueue(root, dedupe_key="backup:k1")
+    await alert_drain._make_drainer(_RT(pipeline=_FakePipeline(OutreachStatus.REJECTED)))()
+    assert q.list_queued(root) == []
+
+
+@pytest.mark.asyncio
+async def test_failed_keeps_for_retry(tmp_path, monkeypatch):
+    root = tmp_path / "queue"
+    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    _enqueue(root)
+    await alert_drain._make_drainer(_RT(pipeline=_FakePipeline(OutreachStatus.FAILED)))()
+    assert len(q.list_queued(root)) == 1  # transient → kept
+
+
+@pytest.mark.asyncio
+async def test_unwired_pipeline_keeps_entry(tmp_path, monkeypatch):
+    root = tmp_path / "queue"
+    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    _enqueue(root)
+    await alert_drain._make_drainer(_RT(pipeline=None))()  # outreach not up yet
+    assert len(q.list_queued(root)) == 1  # kept, never lost
+
+
+@pytest.mark.asyncio
+async def test_empty_queue_is_noop(tmp_path, monkeypatch):
+    root = tmp_path / "queue"
+    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    # No entries — drainer runs clean, no pipeline call.
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    await alert_drain._make_drainer(_RT(pipeline=pipe))()
+    assert pipe.calls == []
+
+
+def test_wire_noops_without_loop():
+    alert_drain.wire(_RT(loop=None))  # must not raise
+
+
+def test_wire_sets_drainer_when_loop_present():
+    installed = {}
+
+    class _Loop:
+        def set_alert_queue_drainer(self, fn):
+            installed["fn"] = fn
+
+    alert_drain.wire(_RT(loop=_Loop()))
+    assert callable(installed.get("fn"))

--- a/tests/test_guardian/test_alert_queue.py
+++ b/tests/test_guardian/test_alert_queue.py
@@ -11,6 +11,8 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
 from genesis.guardian.alert import queue as q
 
 
@@ -107,6 +109,7 @@ def test_malformed_entry_quarantined_not_wedging(tmp_path: Path) -> None:
     assert not (root / "bad.json").exists()
 
 
+@pytest.mark.asyncio
 async def test_drain_delivers_and_unlinks(tmp_path: Path) -> None:
     root = tmp_path / "queue"
     for i in range(3):
@@ -123,6 +126,7 @@ async def test_drain_delivers_and_unlinks(tmp_path: Path) -> None:
     assert _entries(root) == []
 
 
+@pytest.mark.asyncio
 async def test_drain_stops_on_transient_failure(tmp_path: Path) -> None:
     root = tmp_path / "queue"
     root.mkdir()
@@ -154,6 +158,7 @@ async def test_drain_stops_on_transient_failure(tmp_path: Path) -> None:
     assert remaining == ["t1", "t2"]
 
 
+@pytest.mark.asyncio
 async def test_drain_rejected_is_terminal_unlinks(tmp_path: Path) -> None:
     # A caller mapping REJECTED→True must see the entry removed, not stuck.
     root = tmp_path / "queue"
@@ -166,6 +171,7 @@ async def test_drain_rejected_is_terminal_unlinks(tmp_path: Path) -> None:
     assert _entries(root) == []
 
 
+@pytest.mark.asyncio
 async def test_drain_send_raising_keeps_entry(tmp_path: Path) -> None:
     root = tmp_path / "queue"
     q.enqueue_alert(root, severity="info", source="s", title="t", body="b")
@@ -178,6 +184,7 @@ async def test_drain_send_raising_keeps_entry(tmp_path: Path) -> None:
     assert len(_entries(root)) == 1  # kept, not lost
 
 
+@pytest.mark.asyncio
 async def test_drain_respects_max_per_run(tmp_path: Path) -> None:
     root = tmp_path / "queue"
     for i in range(5):
@@ -191,6 +198,7 @@ async def test_drain_respects_max_per_run(tmp_path: Path) -> None:
     assert len(_entries(root)) == 3
 
 
+@pytest.mark.asyncio
 async def test_drain_missing_root_is_noop(tmp_path: Path) -> None:
     async def send(entry: dict) -> bool:
         return True

--- a/tests/test_guardian/test_alert_queue.py
+++ b/tests/test_guardian/test_alert_queue.py
@@ -1,0 +1,250 @@
+"""Tests for the durable alert queue (F.3) — genesis.guardian.alert.queue.
+
+The queue is deliberately dependency-free, so these exercise it in isolation:
+enqueue atomicity/permissions/dedup, oldest-first draining, the
+terminal-vs-transient send contract, corrupt-entry quarantine, and prune caps.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from genesis.guardian.alert import queue as q
+
+
+def _entries(root: Path) -> list[dict]:
+    return [e for _, e in q.list_queued(root)]
+
+
+def test_enqueue_writes_readable_entry(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    assert q.enqueue_alert(
+        root,
+        severity="emergency",
+        source="backup",
+        title="T",
+        body="B",
+        dedupe_key="k1",
+        meta={"x": 1},
+    )
+    items = _entries(root)
+    assert len(items) == 1
+    e = items[0]
+    assert e["schema"] == q.SCHEMA_VERSION
+    assert (e["severity"], e["source"], e["title"], e["body"]) == ("emergency", "backup", "T", "B")
+    assert e["dedupe_key"] == "k1"
+    assert e["meta"] == {"x": 1}
+
+
+def test_enqueue_entry_is_0600(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    q.enqueue_alert(root, severity="warning", source="s", title="t", body="b")
+    path = next((root).glob("*.json"))
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_enqueue_never_raises_returns_false(tmp_path: Path) -> None:
+    # root path is a *file* → mkdir fails → best-effort returns False, no raise.
+    blocker = tmp_path / "not_a_dir"
+    blocker.write_text("x")
+    assert q.enqueue_alert(blocker, severity="warning", source="s", title="t", body="b") is False
+
+
+def test_dedupe_key_collapses_live_duplicates(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    assert (
+        q.enqueue_alert(root, severity="warning", source="s", title="t", body="b", dedupe_key="dup")
+        is True
+    )
+    assert (
+        q.enqueue_alert(
+            root, severity="warning", source="s", title="t2", body="b2", dedupe_key="dup"
+        )
+        is False
+    )
+    assert len(_entries(root)) == 1
+
+
+def test_no_dedupe_key_allows_multiple(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    q.enqueue_alert(root, severity="warning", source="s", title="a", body="b")
+    q.enqueue_alert(root, severity="warning", source="s", title="c", body="d")
+    assert len(_entries(root)) == 2
+
+
+def test_list_queued_oldest_first(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    root.mkdir()
+    for i, ts in enumerate([100.0, 50.0, 75.0]):
+        (root / f"{ts:.6f}-{i}.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "ts": ts,
+                    "severity": "info",
+                    "source": "s",
+                    "title": f"t{i}",
+                    "body": "",
+                    "dedupe_key": None,
+                    "meta": {},
+                }
+            )
+        )
+    order = [e["ts"] for e in _entries(root)]
+    assert order == [50.0, 75.0, 100.0]
+
+
+def test_malformed_entry_quarantined_not_wedging(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    root.mkdir()
+    (root / "bad.json").write_text("{not valid json")
+    q.enqueue_alert(root, severity="info", source="s", title="ok", body="b")
+    items = _entries(root)
+    assert len(items) == 1 and items[0]["title"] == "ok"
+    assert (root / "bad.json.corrupt").exists()
+    assert not (root / "bad.json").exists()
+
+
+async def test_drain_delivers_and_unlinks(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    for i in range(3):
+        q.enqueue_alert(root, severity="info", source="s", title=f"t{i}", body="b")
+    seen: list[str] = []
+
+    async def send(entry: dict) -> bool:
+        seen.append(entry["title"])
+        return True  # terminal → unlink
+
+    removed = await q.drain(root, send)
+    assert removed == 3
+    assert sorted(seen) == ["t0", "t1", "t2"]
+    assert _entries(root) == []
+
+
+async def test_drain_stops_on_transient_failure(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    root.mkdir()
+    for i, ts in enumerate([1.0, 2.0, 3.0]):
+        (root / f"{ts:.6f}-{i}.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "ts": ts,
+                    "severity": "info",
+                    "source": "s",
+                    "title": f"t{i}",
+                    "body": "",
+                    "dedupe_key": None,
+                    "meta": {},
+                }
+            )
+        )
+    calls: list[str] = []
+
+    async def send(entry: dict) -> bool:
+        calls.append(entry["title"])
+        return entry["title"] == "t0"  # first terminal, second transient-fails
+
+    removed = await q.drain(root, send)
+    assert removed == 1  # only t0 unlinked
+    assert calls == ["t0", "t1"]  # stopped after the failure, never tried t2
+    remaining = sorted(e["title"] for e in _entries(root))
+    assert remaining == ["t1", "t2"]
+
+
+async def test_drain_rejected_is_terminal_unlinks(tmp_path: Path) -> None:
+    # A caller mapping REJECTED→True must see the entry removed, not stuck.
+    root = tmp_path / "queue"
+    q.enqueue_alert(root, severity="info", source="s", title="dup", body="b")
+
+    async def send(entry: dict) -> bool:
+        return True  # caller decided terminal (delivered OR rejected)
+
+    assert await q.drain(root, send) == 1
+    assert _entries(root) == []
+
+
+async def test_drain_send_raising_keeps_entry(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    q.enqueue_alert(root, severity="info", source="s", title="t", body="b")
+
+    async def send(entry: dict) -> bool:
+        raise RuntimeError("boom")
+
+    removed = await q.drain(root, send)
+    assert removed == 0
+    assert len(_entries(root)) == 1  # kept, not lost
+
+
+async def test_drain_respects_max_per_run(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    for i in range(5):
+        q.enqueue_alert(root, severity="info", source="s", title=f"t{i}", body="b")
+
+    async def send(entry: dict) -> bool:
+        return True
+
+    removed = await q.drain(root, send, max_per_run=2)
+    assert removed == 2
+    assert len(_entries(root)) == 3
+
+
+async def test_drain_missing_root_is_noop(tmp_path: Path) -> None:
+    async def send(entry: dict) -> bool:
+        return True
+
+    assert await q.drain(tmp_path / "nope", send) == 0
+
+
+def test_prune_drops_aged_entries(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    root.mkdir()
+    now = time.time()
+    old = now - (20 * 24 * 3600)
+    (root / f"{old:.6f}-old.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "ts": old,
+                "severity": "info",
+                "source": "s",
+                "title": "old",
+                "body": "",
+                "dedupe_key": None,
+                "meta": {},
+            }
+        )
+    )
+    q.enqueue_alert(root, severity="info", source="s", title="fresh", body="b")
+    removed = q.prune(root, max_age_s=14 * 24 * 3600)
+    assert removed == 1
+    titles = [e["title"] for e in _entries(root)]
+    assert titles == ["fresh"]
+
+
+def test_prune_caps_file_count_oldest_first(tmp_path: Path) -> None:
+    root = tmp_path / "queue"
+    root.mkdir()
+    now = time.time()
+    for i in range(5):
+        ts = now - (5 - i)  # i=0 oldest
+        (root / f"{ts:.6f}-{i}.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "ts": ts,
+                    "severity": "info",
+                    "source": "s",
+                    "title": f"t{i}",
+                    "body": "",
+                    "dedupe_key": None,
+                    "meta": {},
+                }
+            )
+        )
+    removed = q.prune(root, max_files=2)
+    assert removed == 3
+    survivors = sorted(e["title"] for e in _entries(root))
+    assert survivors == ["t3", "t4"]  # newest kept

--- a/tests/test_scripts/test_alert_queue_sh.py
+++ b/tests/test_scripts/test_alert_queue_sh.py
@@ -1,0 +1,120 @@
+"""Tests for ``scripts/lib/alert_queue.sh`` + the watchgod transition-only guard.
+
+The lib writes schema-v1 JSON that ``genesis.guardian.alert.queue`` reads (the
+cross-language boundary), never breaks its caller, and — as wired into
+``tmp_watchgod.sh`` — pages EMERGENCY once per red episode, never for warnings.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_LIB = _ROOT / "scripts" / "lib" / "alert_queue.sh"
+_WATCHGOD = _ROOT / "scripts" / "tmp_watchgod.sh"
+
+
+def _run_bash(body: str, env: dict) -> subprocess.CompletedProcess:
+    script = f'set -euo pipefail\nsource "{_LIB}"\n{body}\n'
+    full_env = dict(os.environ)
+    full_env.update(env)
+    return subprocess.run(
+        ["bash", "-c", script],
+        env=full_env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _entries(queue_root: Path) -> list[dict]:
+    return [json.loads(p.read_text()) for p in sorted(queue_root.glob("*.json"))]
+
+
+def test_queue_alert_writes_valid_v1_json(tmp_path):
+    root = tmp_path / "queue"
+    r = _run_bash(
+        'queue_alert emergency backup "My title" "My body" "backup:k"',
+        {"GENESIS_ALERT_QUEUE_ROOT": str(root)},
+    )
+    assert r.returncode == 0, r.stderr
+    entries = _entries(root)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["schema"] == 1
+    assert (e["severity"], e["source"], e["title"], e["body"]) == (
+        "emergency",
+        "backup",
+        "My title",
+        "My body",
+    )
+    assert e["dedupe_key"] == "backup:k"
+    assert e["meta"] == {}
+
+
+def test_queue_alert_survives_quotes_and_newlines(tmp_path):
+    root = tmp_path / "queue"
+    body = "has \"double\" and 'single' quotes\nand a newline"
+    # Pass the tricky body via an env var so the test itself is injection-safe.
+    r = _run_bash(
+        'queue_alert warning src "t" "$BODY"',
+        {"GENESIS_ALERT_QUEUE_ROOT": str(root), "BODY": body},
+    )
+    assert r.returncode == 0, r.stderr
+    entries = _entries(root)
+    assert len(entries) == 1
+    assert entries[0]["body"] == body  # round-trips exactly
+
+
+def test_queue_alert_0600_permissions(tmp_path):
+    root = tmp_path / "queue"
+    _run_bash("queue_alert info s t b", {"GENESIS_ALERT_QUEUE_ROOT": str(root)})
+    path = next(root.glob("*.json"))
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_queue_alert_never_breaks_caller(tmp_path):
+    # Unwritable root (a file) must NOT abort the caller under set -e.
+    blocker = tmp_path / "blocked"
+    blocker.write_text("x")
+    r = _run_bash(
+        "queue_alert emergency s t b; echo REACHED",
+        {"GENESIS_ALERT_QUEUE_ROOT": str(blocker / "queue")},
+    )
+    assert r.returncode == 0
+    assert "REACHED" in r.stdout
+
+
+def test_watchgod_emergency_transition_only(tmp_path):
+    # Replicate the exact guard tmp_watchgod's red paths use, run it TWICE
+    # (two polls in one red episode) → exactly ONE queued page.
+    root = tmp_path / "queue"
+    alert_dir = tmp_path / "alerts"
+    alert_dir.mkdir()
+    guard = (
+        'mkdir -p "$ALERT_DIR"; '
+        'if [[ ! -f "$ALERT_DIR/tmp_emergency" ]]; then '
+        '  queue_alert emergency watchgod:cc "RED" "body" "watchgod:tmp_emergency"; '
+        "fi; "
+        'touch "$ALERT_DIR/tmp_emergency"'
+    )
+    env = {"GENESIS_ALERT_QUEUE_ROOT": str(root), "ALERT_DIR": str(alert_dir)}
+    assert _run_bash(guard, env).returncode == 0
+    assert _run_bash(guard, env).returncode == 0  # second poll, flag persists
+    assert len(_entries(root)) == 1  # only the transition paged
+
+
+def test_watchgod_warning_tier_never_queues():
+    # D2: the warning/orange cleaners must NOT call queue_alert (warnings stay
+    # dashboard-only via watchgod_state.json). Only the red cleaners page.
+    text = _WATCHGOD.read_text()
+
+    def _body(fn: str) -> str:
+        start = text.index(f"{fn}()")
+        return text[start : text.index("\n}\n", start)]  # to the closing brace
+
+    for fn in ("clean_cc_orange", "clean_sys_orange", "clean_sys_yellow"):
+        assert "queue_alert" not in _body(fn), f"{fn} must not page a warning"
+    for fn in ("clean_cc_red", "clean_sys_red"):
+        assert "queue_alert emergency" in _body(fn), f"{fn} must page emergency"


### PR DESCRIPTION
## What & why

Infrastructure alerts died silently when their transport was down: the host `AlertDispatcher` logged to journald and returned `False`, and `scripts/backup.sh` dropped its message if `curl` to Telegram failed. This adds a **durable, per-side alert queue** so an alert raised while the channel is unreachable is persisted and delivered on the next drain — the reliability floor under the guardian's other resiliency signals.

## Design — per-side topology

Each side drains its **own** queue (never a shared mount — that would invert reliability and race on delivery):

| Side | Queue | Enqueue | Drain |
|---|---|---|---|
| Host guardian | `<state>/alerts/queue/` | `AlertDispatcher.send` on total channel failure | top of `run_check` (30s tick) |
| Container | `~/.genesis/alerts/queue/` | `scripts/lib/alert_queue.sh` + Python callers | awareness tick (`runtime/init/alert_drain.py`) |

- **`genesis.guardian.alert.queue`** — dependency-free schema-v1 file queue: atomic `0600` writes, dedupe-key collapse, oldest-first `drain()` with a **terminal-vs-transient** send contract, `prune()` caps (200 files / 14 days). Container queue lives in a `queue/` subdir so it never collides with `tmp_watchgod`'s flag files.
- **Host** — `AlertDispatcher` gains `fallback_queue_root`; `run_check` drains-first each tick. The replay path passes `allow_queue_fallback=False` so a still-down channel never re-enqueues the entry it is replaying.
- **Container** — the drainer is wired unconditionally (valuable guardian-or-not) and resolves the outreach pipeline lazily per-tick, so bootstrap order is irrelevant. `REJECTED` (outreach dedup) is terminal → unlink (not a retry, else the entry wedges forever); the outreach `topic` derives from the alert identity so distinct alerts sharing a source stay independently deliverable.
- **Shell** — `tmp_watchgod` pages only the **emergency** tier, transition-only (once per red episode); the warning tier stays dashboard-only via `watchgod_state.json`. `backup.sh` queues on a failed send.

## Tests

51 targeted tests: queue primitive (atomicity/permissions/dedupe/oldest-first/terminal-vs-transient/quarantine/prune), dispatcher fallback + replay, shell lib round-trip + watchgod transition-only + a guard that the warning tier never pages. Plus a real-path E2E drill covering both drains end-to-end.