### PR TITLE
feat(eval): A4 — upstream date-anchor conformance + per-question diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The memory benchmark now grades temporal questions fairly and explains
+  its misses.** The LongMemEval reader gets the question's date (the
+  benchmark's own convention — without it, "how many weeks ago…" questions
+  were unanswerable by construction), so temporal scores now measure memory,
+  not a missing calendar. New `--dump-dir` writes per-question diagnostics
+  (query, recalled memories, answer, verdict) for failure analysis, a new
+  evidence-coverage metric shows *how much* of the gold evidence was
+  retrieved (not just whether any was), and `--types` runs a single question
+  category — so a targeted slice no longer costs a full 500-question run.
+
 - **Claude Code sessions no longer forget what they were started for.** Long
   sessions compact their context many times, and each summary is biased toward
   recent work — after enough compactions a session can no longer connect

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -200,6 +200,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         "--db-path", default=None,
         help="results DB (default: production genesis.db; a fresh path is migrated)",
     )
+    lme_cmd.add_argument(
+        "--types", default=None,
+        help="comma-separated question types to run (filtered before --limit)",
+    )
+    lme_cmd.add_argument(
+        "--dump-dir", default=None,
+        help="write per-question diagnostics (one <arm>.jsonl per arm) here",
+    )
 
     eval_cmd.set_defaults(func=_run_eval_cli)
 
@@ -264,6 +272,8 @@ async def _cmd_longmemeval(args: argparse.Namespace) -> int:
         no_rerank=args.no_rerank,
         persist=not args.no_persist,
         db_path=Path(args.db_path) if args.db_path else None,
+        types=args.types,
+        dump_dir=Path(args.dump_dir) if args.dump_dir else None,
     )
     print_report(summaries)
     return 0

--- a/src/genesis/eval/longmemeval/__main__.py
+++ b/src/genesis/eval/longmemeval/__main__.py
@@ -33,6 +33,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="results DB (default: production genesis.db); a fresh path is migrated",
     )
+    p.add_argument(
+        "--types",
+        default=None,
+        help="comma-separated question types to run (filtered before --limit)",
+    )
+    p.add_argument(
+        "--dump-dir",
+        type=Path,
+        default=None,
+        help="write per-question diagnostics (one <arm>.jsonl per arm) here",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -52,6 +63,8 @@ def main(argv: list[str] | None = None) -> int:
             no_rerank=args.no_rerank,
             persist=not args.no_persist,
             db_path=args.db_path,
+            types=args.types,
+            dump_dir=args.dump_dir,
         ),
     )
     print_report(summaries)

--- a/src/genesis/eval/longmemeval/answer.py
+++ b/src/genesis/eval/longmemeval/answer.py
@@ -12,6 +12,14 @@ answers. The reader prompt is question-type-aware:
   reader answer "I don't know" and tanked this category to ~0.05.)
 * ``temporal-reasoning``: add a step-by-step-using-the-dated-memories nudge so
   interval/date arithmetic is worked out rather than guessed.
+
+The prompt also carries the UPSTREAM date anchor: LongMemEval's own reading
+prompt includes ``Current Date: {question_date}`` between the history and the
+question (arXiv 2410.10813). Without it, relative temporal questions ("how many
+weeks ago...") are ill-posed for the reader — the harness's first full-500 run
+omitted it and scored temporal-reasoning 0.40 non-conformantly. The raw
+``question_date`` string is used verbatim (upstream convention) for
+comparability with published numbers.
 """
 
 from __future__ import annotations
@@ -59,15 +67,21 @@ def build_answer_prompt(
     memories: Sequence[str],
     *,
     question_type: str | None = None,
+    question_date: str | None = None,
 ) -> str:
-    """Assemble the reader prompt from the question and recalled memories."""
+    """Assemble the reader prompt from the question and recalled memories.
+
+    ``question_date`` (raw upstream format) is injected as the
+    ``Current Date:`` anchor per the upstream reading-prompt convention.
+    """
     block = (
         "\n".join(f"- {m}" for m in memories)
         if memories
         else ("(no relevant memories were retrieved)")
     )
     system = _system_for(question_type)
-    return f"{system}\n\nMEMORIES:\n{block}\n\nQUESTION: {question}\n\nANSWER:"
+    date_block = f"Current Date: {question_date}\n\n" if question_date else ""
+    return f"{system}\n\nMEMORIES:\n{block}\n\n{date_block}QUESTION: {question}\n\nANSWER:"
 
 
 @dataclass(frozen=True)
@@ -86,9 +100,15 @@ def answer_question(
     model: str = DEFAULT_MODEL,
     max_tokens: int = 256,
     question_type: str | None = None,
+    question_date: str | None = None,
 ) -> AnswerResult:
     """Produce a hypothesis answer from the recalled memories."""
-    prompt = build_answer_prompt(question, memories, question_type=question_type)
+    prompt = build_answer_prompt(
+        question,
+        memories,
+        question_type=question_type,
+        question_date=question_date,
+    )
     completion = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.eval.longmemeval.client import load_secrets
-from genesis.eval.longmemeval.dataset import load_oracle
+from genesis.eval.longmemeval.dataset import filter_by_types, load_oracle
 from genesis.eval.longmemeval.runner import default_arms, run_longmemeval
 
 if TYPE_CHECKING:
@@ -62,10 +62,19 @@ async def execute(
     no_rerank: bool = False,
     persist: bool = True,
     db_path: Path | None = None,
+    types: str | None = None,
+    dump_dir: Path | None = None,
 ) -> dict[str, EvalRunSummary]:
-    """Load the dataset, run the harness, persist (optionally), return summaries."""
+    """Load the dataset, run the harness, persist (optionally), return summaries.
+
+    ``types`` (comma-separated question types) filters BEFORE ``limit`` so
+    ``--types temporal-reasoning --limit 20`` means "the first 20 temporal
+    questions", not "temporal questions among the first 20".
+    """
     load_secrets()
     instances = load_oracle(dataset_path)
+    if types:
+        instances = filter_by_types(instances, types)
     if limit:
         instances = instances[:limit]
     logger.info("loaded %d questions from %s", len(instances), dataset_path)
@@ -98,6 +107,7 @@ async def execute(
             k=k,
             concurrency=concurrency,
             reranker=reranker,
+            dump_dir=dump_dir,
         )
     finally:
         if db is not None:

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -42,11 +42,12 @@ def print_report(summaries: dict[str, EvalRunSummary]) -> None:
             f"\n[{arm_label}]  overall={s.aggregate_score}  "
             f"attempted={attempted}/{s.total_cases}{skip_note}",
         )
-        ev = s.scores.get("evidence_recall_rate")
-        if ev is not None:
-            print(f"    evidence_recall_rate: {ev}")
+        for metric in ("evidence_recall_rate", "evidence_coverage_mean"):
+            val = s.scores.get(metric)
+            if val is not None:
+                print(f"    {metric}: {val}")
         for qtype, acc in sorted(s.scores.items()):
-            if qtype == "evidence_recall_rate":
+            if qtype in ("evidence_recall_rate", "evidence_coverage_mean"):
                 continue
             print(f"    {qtype}: {acc}")
         cost = sum(r.cost_usd for r in s.results)

--- a/src/genesis/eval/longmemeval/dataset.py
+++ b/src/genesis/eval/longmemeval/dataset.py
@@ -106,3 +106,20 @@ def load_oracle(path: str | Path) -> list[LongMemEvalInstance]:
     """Load and parse a LongMemEval oracle JSON file into typed instances."""
     data = json.loads(Path(path).read_text())
     return [_parse_instance(raw) for raw in data]
+
+
+def filter_by_types(
+    instances: list[LongMemEvalInstance],
+    types_csv: str,
+) -> list[LongMemEvalInstance]:
+    """Keep only instances whose question_type is in the comma-separated list.
+
+    Validates every requested type against ``QUESTION_TYPES`` so a typo fails
+    loudly instead of silently returning an empty slice.
+    """
+    wanted = {t.strip() for t in types_csv.split(",") if t.strip()}
+    unknown = wanted - QUESTION_TYPES
+    if unknown:
+        msg = f"unknown question type(s): {sorted(unknown)}; valid: {sorted(QUESTION_TYPES)}"
+        raise ValueError(msg)
+    return [i for i in instances if i.question_type in wanted]

--- a/src/genesis/eval/longmemeval/dataset.py
+++ b/src/genesis/eval/longmemeval/dataset.py
@@ -118,6 +118,9 @@ def filter_by_types(
     loudly instead of silently returning an empty slice.
     """
     wanted = {t.strip() for t in types_csv.split(",") if t.strip()}
+    if not wanted:
+        msg = "no question types given (empty --types would silently select nothing)"
+        raise ValueError(msg)
     unknown = wanted - QUESTION_TYPES
     if unknown:
         msg = f"unknown question type(s): {sorted(unknown)}; valid: {sorted(QUESTION_TYPES)}"

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -86,6 +86,11 @@ class QuestionArmResult:
     hypothesis: str
     judged_correct: bool
     evidence_recalled: bool
+    #: |evidence ∩ recalled| / |evidence|; None when the question has no
+    #: evidence turns (abstention) — excluded from means, never counted as 0.
+    evidence_coverage: float | None = None
+    query: str = ""
+    recalled_ids: tuple[str, ...] = ()
     judge_raw: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
@@ -126,6 +131,11 @@ def build_run_summary(
             fmean(1 if r.evidence_recalled else 0 for r in results),
             4,
         )
+    # Mean evidence COVERAGE (any-hit recall is blind to partial recall on
+    # multi-evidence questions — the key multi-session diagnostic).
+    coverages = [r.evidence_coverage for r in results if r.evidence_coverage is not None]
+    if coverages:
+        scores["evidence_coverage_mean"] = round(fmean(coverages), 4)
 
     scored: list[ScoredOutput] = []
     for r in results:
@@ -208,7 +218,11 @@ async def run_question(
                 rerank=arm.rerank,
             )
             recalled_ids = {h.memory_id for h in hits}
-            evidence_recalled = bool(ingest.evidence_memory_ids & recalled_ids)
+            evidence_ids = ingest.evidence_memory_ids
+            evidence_recalled = bool(evidence_ids & recalled_ids)
+            evidence_coverage = (
+                len(evidence_ids & recalled_ids) / len(evidence_ids) if evidence_ids else None
+            )
             memories = [h.content for h in hits]
             # answer_question / judge_answer use the SYNC OpenAI client, so run
             # them in a worker thread — a blocking create() on the event loop
@@ -219,6 +233,7 @@ async def run_question(
                 memories,
                 client=client,
                 question_type=instance.question_type,
+                question_date=instance.question_date,
             )
             verdict = await asyncio.to_thread(
                 lambda a=ans: judge_answer(
@@ -238,6 +253,9 @@ async def run_question(
                     hypothesis=ans.hypothesis,
                     judged_correct=verdict.label,
                     evidence_recalled=evidence_recalled,
+                    evidence_coverage=evidence_coverage,
+                    query=query,
+                    recalled_ids=tuple(h.memory_id for h in hits),
                     judge_raw=verdict.raw,
                     input_tokens=ans.input_tokens + verdict.input_tokens,
                     output_tokens=ans.output_tokens + verdict.output_tokens,
@@ -245,6 +263,46 @@ async def run_question(
                 ),
             )
     return out
+
+
+def write_dump_jsonl(
+    path: Path,
+    results: Sequence[QuestionArmResult],
+    *,
+    skipped_case_ids: Sequence[str] = (),
+) -> None:
+    """Write one arm's per-question diagnostics as JSONL (one line/question).
+
+    This is the failure-analysis artifact the summary rows can't provide:
+    which memories each question actually recalled, the exact query, the
+    hypothesis, and the judge verdict. Skipped (errored) questions get a
+    ``{"skipped": true}`` marker line so the file accounts for the full N.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        for r in results:
+            fh.write(
+                json.dumps(
+                    {
+                        "question_id": r.question_id,
+                        "question_type": r.question_type,
+                        "arm": r.arm_label,
+                        "query": r.query,
+                        "recalled_ids": list(r.recalled_ids),
+                        "evidence_recalled": r.evidence_recalled,
+                        "evidence_coverage": r.evidence_coverage,
+                        "hypothesis": r.hypothesis,
+                        "judged_correct": r.judged_correct,
+                        "judge_raw": r.judge_raw,
+                        "input_tokens": r.input_tokens,
+                        "output_tokens": r.output_tokens,
+                        "latency_ms": round(r.latency_ms, 1),
+                    },
+                )
+                + "\n",
+            )
+        for qid in skipped_case_ids:
+            fh.write(json.dumps({"question_id": qid, "skipped": True}) + "\n")
 
 
 async def run_longmemeval(
@@ -257,6 +315,7 @@ async def run_longmemeval(
     client: object | None = None,
     embedding_provider: object | None = None,
     reranker: object | None = None,
+    dump_dir: Path | None = None,
 ) -> dict[str, EvalRunSummary]:
     """Run the full harness over ``instances``; return per-arm summaries.
 
@@ -264,7 +323,9 @@ async def run_longmemeval(
     multi-arm recall against a shared per-question store cannot re-rank memories
     across arms, and RESTORES the prior value afterwards so an in-process caller
     (e.g. the test suite) isn't polluted. Persists one run per arm when ``db``
-    is provided.
+    is provided. When ``dump_dir`` is set, writes one ``<arm>.jsonl``
+    per-question diagnostics file per arm and records its path in the
+    summary's metadata.
     """
     arms = list(arms) if arms is not None else default_arms()
     client = client or build_client()
@@ -342,13 +403,18 @@ async def run_longmemeval(
 
     summaries: dict[str, EvalRunSummary] = {}
     for arm in arms:
+        arm_results = by_arm.get(arm.label, [])
         summary = build_run_summary(
             arm_label=arm.label,
             skipped_case_ids=skipped_qids,
             model=DEFAULT_MODEL,
             dataset=_DATASET,
-            results=by_arm.get(arm.label, []),
+            results=arm_results,
         )
+        if dump_dir is not None:
+            dump_path = Path(dump_dir) / f"{arm.label}.jsonl"
+            write_dump_jsonl(dump_path, arm_results, skipped_case_ids=skipped_qids)
+            summary.metadata["dump_path"] = str(dump_path)
         summaries[arm.label] = summary
         if db is not None:
             from genesis.eval.db import insert_run

--- a/tests/test_eval/test_longmemeval_answer.py
+++ b/tests/test_eval/test_longmemeval_answer.py
@@ -106,3 +106,38 @@ def test_answer_question_passes_question_type_through():
     (call,) = client.calls
     prompt = call["messages"][0]["content"].lower()
     assert "don't know" not in prompt
+
+
+def test_prompt_includes_current_date_upstream_convention():
+    # Upstream LongMemEval's reading prompt includes the question date as
+    # "Current Date: {question_date}" (raw format) between the history and the
+    # question — conformance is required for comparability AND for temporal
+    # questions ("how many weeks ago...") to be well-posed at all.
+    p = build_answer_prompt(
+        "How many weeks ago did I leave my old job?",
+        ["[2023-04-11T09:15:00] [user] Today was my last day at the old company."],
+        question_type="temporal-reasoning",
+        question_date="2023/05/23 (Tue) 19:11",
+    )
+    assert "Current Date: 2023/05/23 (Tue) 19:11" in p
+    assert p.index("MEMORIES:") < p.index("Current Date:") < p.index("QUESTION:")
+
+
+def test_prompt_omits_date_line_when_absent():
+    p = build_answer_prompt("What degree did I graduate with?", ["m"])
+    assert "Current Date:" not in p
+    p = build_answer_prompt("What degree?", ["m"], question_date="")
+    assert "Current Date:" not in p
+
+
+def test_answer_question_threads_question_date():
+    client = _FakeClient("About six weeks ago.")
+    answer_question(
+        "How many weeks ago did I leave my old job?",
+        ["[2023-04-11T09:15:00] [user] last day"],
+        client=client,
+        question_type="temporal-reasoning",
+        question_date="2023/05/23 (Tue) 19:11",
+    )
+    (call,) = client.calls
+    assert "Current Date: 2023/05/23 (Tue) 19:11" in call["messages"][0]["content"]

--- a/tests/test_eval/test_longmemeval_dataset.py
+++ b/tests/test_eval/test_longmemeval_dataset.py
@@ -8,6 +8,7 @@ import pytest
 
 from genesis.eval.longmemeval.dataset import (
     LongMemEvalInstance,
+    filter_by_types,
     load_oracle,
 )
 
@@ -104,3 +105,17 @@ def test_empty_content_turns_are_still_iterated(oracle_file):
     # loader does not filter; ingest decides what to skip
     inst = load_oracle(oracle_file)[1]
     assert len(list(inst.iter_turns())) == 1
+
+
+def test_filter_by_types_selects_matching_instances(oracle_file):
+    instances = load_oracle(oracle_file)
+    only_pref = filter_by_types(instances, "single-session-preference")
+    assert [i.question_id for i in only_pref] == ["def456_abs"]
+    both = filter_by_types(instances, "single-session-user, single-session-preference")
+    assert len(both) == 2
+
+
+def test_filter_by_types_rejects_unknown_type(oracle_file):
+    instances = load_oracle(oracle_file)
+    with pytest.raises(ValueError, match="unknown question type"):
+        filter_by_types(instances, "temporal-reasoning,not-a-type")

--- a/tests/test_eval/test_longmemeval_dataset.py
+++ b/tests/test_eval/test_longmemeval_dataset.py
@@ -119,3 +119,10 @@ def test_filter_by_types_rejects_unknown_type(oracle_file):
     instances = load_oracle(oracle_file)
     with pytest.raises(ValueError, match="unknown question type"):
         filter_by_types(instances, "temporal-reasoning,not-a-type")
+
+
+def test_filter_by_types_rejects_empty_selection(oracle_file):
+    # an empty/whitespace csv would otherwise silently select nothing
+    instances = load_oracle(oracle_file)
+    with pytest.raises(ValueError, match="no question types"):
+        filter_by_types(instances, " , ")

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -94,6 +94,63 @@ def _instance(qid: str) -> LongMemEvalInstance:
     )
 
 
+class _PromptRecordingClient:
+    """Sync client that records every prompt and answers deterministically."""
+
+    def __init__(self):
+        self.prompts: list[str] = []
+        self._lock = threading.Lock()
+
+        chat = type("Chat", (), {})()
+        completions = type("Completions", (), {})()
+
+        def create(**kwargs):
+            with self._lock:
+                self.prompts.append(kwargs["messages"][0]["content"])
+            return _FakeCompletion("yes Business Administration")
+
+        completions.create = create
+        chat.completions = completions
+        self.chat = chat
+
+
+@pytest.mark.asyncio
+async def test_run_longmemeval_dumps_jsonl_and_anchors_date(tmp_path):
+    """--dump-dir writes one JSONL per arm with per-question diagnostics, and
+    the reader prompt carries the upstream 'Current Date:' anchor end-to-end."""
+    import json as _json
+
+    instances = [_instance("q1"), _instance("q2")]
+    client = _PromptRecordingClient()
+    summaries = await run_longmemeval(
+        instances,
+        db=None,
+        arms=[Arm(QueryArm.RAW, rerank=False)],
+        k=5,
+        concurrency=2,
+        client=client,
+        embedding_provider=_HashingEmbedder(),
+        dump_dir=tmp_path,
+    )
+    dump = tmp_path / "raw.jsonl"
+    assert dump.exists()
+    recs = [_json.loads(line) for line in dump.read_text().splitlines()]
+    assert len(recs) == 2
+    for rec in recs:
+        assert rec["arm"] == "raw"
+        assert rec["query"]
+        assert rec["recalled_ids"]
+        assert rec["evidence_coverage"] == 1.0  # single evidence turn, k=5
+        assert rec["hypothesis"]
+        assert "judged_correct" in rec
+    # dump path is recorded on the persisted summary metadata
+    assert summaries["raw"].metadata["dump_path"] == str(dump)
+    # reader prompts (not judge prompts) carry the upstream date anchor
+    reader_prompts = [p for p in client.prompts if "MEMORIES:" in p]
+    assert reader_prompts
+    assert all("Current Date: 2023/05/23 (Tue) 19:11" in p for p in reader_prompts)
+
+
 @pytest.mark.asyncio
 async def test_run_longmemeval_runs_questions_concurrently():
     instances = [_instance(f"q{i}") for i in range(4)]

--- a/tests/test_eval/test_longmemeval_runner.py
+++ b/tests/test_eval/test_longmemeval_runner.py
@@ -30,7 +30,7 @@ def test_default_arms_are_the_four_combinations():
     assert labels == {"raw", "raw+rerank", "keyword", "keyword+rerank"}
 
 
-def _r(qid, qtype, correct, evidence=True):  # noqa: FBT002
+def _r(qid, qtype, correct, evidence=True, coverage=None):  # noqa: FBT002
     return QuestionArmResult(
         question_id=qid,
         question_type=qtype,
@@ -38,6 +38,7 @@ def _r(qid, qtype, correct, evidence=True):  # noqa: FBT002
         hypothesis="h",
         judged_correct=correct,
         evidence_recalled=evidence,
+        evidence_coverage=coverage,
         judge_raw="yes" if correct else "no",
         input_tokens=10,
         output_tokens=2,
@@ -105,6 +106,80 @@ def test_build_run_summary_empty_results_is_safe():
     )
     assert summary.total_cases == 0
     assert summary.aggregate_score == 0.0
+
+
+def test_build_run_summary_reports_mean_evidence_coverage():
+    # coverage is |evidence ∩ recalled| / |evidence| per question; abstention
+    # questions (no evidence turns) carry None and are EXCLUDED from the mean,
+    # never counted as 0 — they have nothing to cover.
+    results = [
+        _r("q1", "multi-session", True, coverage=1.0),
+        _r("q2", "multi-session", False, coverage=0.5),
+        _r("q3_abs", "single-session-user", True, evidence=False, coverage=None),
+    ]
+    summary = build_run_summary(
+        arm_label="raw",
+        model="m",
+        dataset="longmemeval_oracle",
+        results=results,
+    )
+    assert summary.scores["evidence_coverage_mean"] == 0.75
+
+
+def test_build_run_summary_no_coverage_key_when_all_none():
+    results = [_r("q1_abs", "single-session-user", True, evidence=False, coverage=None)]
+    summary = build_run_summary(
+        arm_label="raw",
+        model="m",
+        dataset="longmemeval_oracle",
+        results=results,
+    )
+    assert "evidence_coverage_mean" not in summary.scores
+
+
+def test_write_dump_jsonl_round_trips_per_question_fields():
+    import json as _json
+
+    from genesis.eval.longmemeval.runner import write_dump_jsonl
+
+    results = [
+        QuestionArmResult(
+            question_id="q1",
+            question_type="temporal-reasoning",
+            arm_label="raw",
+            hypothesis="About six weeks.",
+            judged_correct=True,
+            evidence_recalled=True,
+            evidence_coverage=0.5,
+            query="how many weeks ago did I leave my old job",
+            recalled_ids=("m-1", "m-2"),
+            judge_raw="yes",
+            input_tokens=10,
+            output_tokens=2,
+            latency_ms=12.5,
+        ),
+    ]
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "raw.jsonl"
+        write_dump_jsonl(path, results, skipped_case_ids=["q9"])
+        lines = [_json.loads(line) for line in path.read_text().splitlines()]
+    assert len(lines) == 2
+    rec = lines[0]
+    assert rec["question_id"] == "q1"
+    assert rec["question_type"] == "temporal-reasoning"
+    assert rec["arm"] == "raw"
+    assert rec["query"] == "how many weeks ago did I leave my old job"
+    assert rec["recalled_ids"] == ["m-1", "m-2"]
+    assert rec["evidence_coverage"] == 0.5
+    assert rec["hypothesis"] == "About six weeks."
+    assert rec["judged_correct"] is True
+    assert rec["judge_raw"] == "yes"
+    skip_rec = lines[1]
+    assert skip_rec["question_id"] == "q9"
+    assert skip_rec["skipped"] is True
 
 
 def test_build_run_summary_skipped_do_not_tilt_accuracy():


### PR DESCRIPTION
## Summary

WS-1 A4 follow-up (sprint PR-A of A4-improvement): the definitive full-500 LongMemEval run (0.604 raw) exposed temporal-reasoning at 0.40 — and investigation found the harness reader was missing the **upstream reading-prompt convention**: LongMemEval's own prompt includes `Current Date: {question_date}` (arXiv 2410.10813). Without it, relative-time questions ("how many weeks ago…") are ill-posed by construction. This PR restores conformance and adds the diagnostics needed for honest failure analysis.

## Changes

- **Date anchor (conformance, not tuning):** reader prompt carries `Current Date: {question_date}` (raw upstream format, verbatim) between MEMORIES and QUESTION. Judge templates untouched — the comparability pin in `test_longmemeval_judge.py` holds.
- **`--dump-dir`:** one `<arm>.jsonl` per arm with per-question diagnostics (query, recalled memory ids, evidence flags, hypothesis, judge verdict, tokens, latency). Skipped questions get a marker line so the file accounts for the full N. Dump path recorded in the persisted run's `metadata_json`.
- **`evidence_coverage` metric:** `|evidence ∩ recalled| / |evidence|` per question + per-arm mean. The existing any-hit `evidence_recall_rate` is blind to partial recall on multi-evidence questions — this is the key multi-session diagnostic. Abstention questions (no evidence) carry `None` and are excluded from means, never counted as 0.
- **`--types` filter:** comma-separated question types, validated against `QUESTION_TYPES` (typos fail loudly), filtered **before** `--limit` — so a temporal-only slice no longer costs a full run. Mirrored on the `genesis eval longmemeval` subcommand.

## Testing

- TDD: 11 new tests written first and watched fail, then implementation (anchor presence/ordering/omission, threading through `answer_question`, coverage math incl. all-None case, dump JSONL round-trip, orchestration e2e with fakes proving the anchor reaches the reader prompt and the dump lands, `--types` filter + unknown-type rejection).
- Full `tests/test_eval/` suite: **351 passed** (342 baseline on latest main incl. #1042, +9 new).
- WS-3 coverage guards (`test_store_subsystem_coverage`, `test_recall_inject_coverage`): pass — no new `.store()`/`.recall()` sites.
- `ruff check --no-cache`: clean.

## Impact

CLI-only benchmark harness — no runtime/server paths touched, no deploy needed. Next: temporal-reasoning slice re-run + full-500 anchored re-baseline (also serves as the comparison baseline for the upcoming graph-arm PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)