### PR TITLE
feat(eval): A4 graph arm — linked ephemeral store + 1-hop recall expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The memory benchmark can now measure whether Genesis's memory graph
+  actually helps.** A new `--graph` mode runs every benchmark arm twice — once
+  against a plain store and once against a store where memories link to
+  similar earlier memories exactly as they do in production — and follows
+  those links at recall time to pull in related memories the search itself
+  missed. Baseline and graph runs use fully separate stores, so the
+  comparison is honest (links can't quietly tint the baseline's ranking). Per
+  question, the results record how many links formed and how much extra gold
+  evidence the graph surfaced, and a graph run that formed no links says so
+  loudly instead of silently matching its baseline. The memory linker's
+  similarity threshold is also now configurable per instance instead of fixed.
+
 - **The memory benchmark now grades temporal questions fairly and explains
   its misses.** The LongMemEval reader gets the question's date (the
   benchmark's own convention — without it, "how many weeks ago…" questions

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -94,10 +94,7 @@ async def batch_link_counts(
         for row in inbound_rows:
             inbound_map[row[0]] = inbound_map.get(row[0], 0) + row[1]
 
-    return {
-        mid: (total_map.get(mid, 0), inbound_map.get(mid, 0))
-        for mid in memory_ids
-    }
+    return {mid: (total_map.get(mid, 0), inbound_map.get(mid, 0)) for mid in memory_ids}
 
 
 async def inter_candidate_links(
@@ -126,6 +123,46 @@ async def inter_candidate_links(
     return [(row[0], row[1]) for row in rows]
 
 
+async def neighbors_of(
+    db: aiosqlite.Connection,
+    memory_ids: list[str],
+    *,
+    exclude: list[str] | tuple[str, ...] = (),
+    limit: int = 10,
+) -> list[dict]:
+    """1-hop neighbors of *memory_ids* via ``memory_links``, strongest first.
+
+    Both directions are followed and collapsed to ONE row per neighbor with
+    ``MAX(strength)`` — the PK is ``(source_id, target_id, link_type)`` (DLI-04),
+    so a pair with multiple link types yields multiple rows, and several seeds
+    can reach the same neighbor; a naive UNION would burn ``limit`` slots on
+    duplicates. Seeds themselves and ``exclude`` ids are never returned.
+
+    Returns ``[{"memory_id": ..., "strength": ...}]``. Used by recall-time
+    graph expansion (LongMemEval graph arm; prod graph/entity recall wiring
+    reuses this as the canonical neighbor query).
+    """
+    if not memory_ids:
+        return []
+    if len(memory_ids) > 499:
+        memory_ids = memory_ids[:499]
+    dropped = {*memory_ids, *exclude}
+    ph = ",".join("?" * len(memory_ids))
+    drop_ph = ",".join("?" * len(dropped))
+    rows = await db.execute_fetchall(
+        f"SELECT neighbor, MAX(strength) AS s FROM ("
+        f"  SELECT target_id AS neighbor, strength FROM memory_links"
+        f"    WHERE source_id IN ({ph})"
+        f"  UNION ALL"
+        f"  SELECT source_id AS neighbor, strength FROM memory_links"
+        f"    WHERE target_id IN ({ph})"
+        f") WHERE neighbor NOT IN ({drop_ph})"
+        f" GROUP BY neighbor ORDER BY s DESC LIMIT ?",
+        [*memory_ids, *memory_ids, *dropped, limit],
+    )
+    return [{"memory_id": row[0], "strength": row[1]} for row in rows]
+
+
 async def get_bidirectional(db: aiosqlite.Connection, memory_id: str) -> list[dict]:
     """Get all links where memory_id is source or target (undirected query)."""
     return await get_links_for(db, memory_id)
@@ -147,8 +184,7 @@ async def delete(
     """
     if link_type is not None:
         cursor = await db.execute(
-            "DELETE FROM memory_links "
-            "WHERE source_id = ? AND target_id = ? AND link_type = ?",
+            "DELETE FROM memory_links WHERE source_id = ? AND target_id = ? AND link_type = ?",
             (source_id, target_id, link_type),
         )
     else:
@@ -191,6 +227,7 @@ async def prune_weak(
     if pruned:
         try:
             from genesis.memory.graph import invalidate_graph_cache
+
             invalidate_graph_cache()
         except ImportError:
             pass

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 import aiosqlite
+
+logger = logging.getLogger(__name__)
 
 
 async def create(
@@ -123,12 +126,20 @@ async def inter_candidate_links(
     return [(row[0], row[1]) for row in rows]
 
 
+# Seed cap for neighbors_of: the query binds 2*len(seeds) (+ optional link
+# types) + 1 placeholders, so 450 keeps the worst case ~901 — under the 999
+# SQLITE_MAX_VARIABLE_NUMBER floor this file's IN-list convention targets.
+# (inter_candidate_links' 499 assumes its own 2n shape; don't borrow caps.)
+_NEIGHBOR_SEED_CAP = 450
+
+
 async def neighbors_of(
     db: aiosqlite.Connection,
     memory_ids: list[str],
     *,
     exclude: list[str] | tuple[str, ...] = (),
     limit: int = 10,
+    link_types: tuple[str, ...] | None = None,
 ) -> list[dict]:
     """1-hop neighbors of *memory_ids* via ``memory_links``, strongest first.
 
@@ -136,31 +147,52 @@ async def neighbors_of(
     ``MAX(strength)`` — the PK is ``(source_id, target_id, link_type)`` (DLI-04),
     so a pair with multiple link types yields multiple rows, and several seeds
     can reach the same neighbor; a naive UNION would burn ``limit`` slots on
-    duplicates. Seeds themselves and ``exclude`` ids are never returned.
+    duplicates. Ties break on neighbor id (deterministic across runs). Seeds
+    and ``exclude`` ids are never returned: exclusion happens in PYTHON, not
+    SQL, so (a) the placeholder count stays bounded regardless of exclude
+    size, and (b) capping an oversized seed list can never re-admit a
+    truncated seed as a "neighbor".
+
+    ``link_types`` optionally restricts which edge types are followed —
+    callers expanding into LLM-visible context should exclude adversarial
+    types like ``contradicts`` (the LongMemEval graph arm only ever stores
+    supports/extends, so it passes None).
 
     Returns ``[{"memory_id": ..., "strength": ...}]``. Used by recall-time
-    graph expansion (LongMemEval graph arm; prod graph/entity recall wiring
-    reuses this as the canonical neighbor query).
+    graph expansion (LongMemEval graph arm; intended canonical home for the
+    committed prod graph/entity recall wiring).
     """
-    if not memory_ids:
+    if not memory_ids or limit <= 0:
         return []
-    if len(memory_ids) > 499:
-        memory_ids = memory_ids[:499]
+    seeds = memory_ids
+    if len(seeds) > _NEIGHBOR_SEED_CAP:
+        logger.warning(
+            "neighbors_of: %d seed ids truncated to %d (placeholder budget)",
+            len(seeds),
+            _NEIGHBOR_SEED_CAP,
+        )
+        seeds = seeds[:_NEIGHBOR_SEED_CAP]
+    # Drop the FULL original seed list (not just the capped slice) + exclude.
     dropped = {*memory_ids, *exclude}
-    ph = ",".join("?" * len(memory_ids))
-    drop_ph = ",".join("?" * len(dropped))
+    ph = ",".join("?" * len(seeds))
+    type_clause = ""
+    type_params: list[str] = []
+    if link_types:
+        type_ph = ",".join("?" * len(link_types))
+        type_clause = f" AND link_type IN ({type_ph})"
+        type_params = list(link_types)
     rows = await db.execute_fetchall(
         f"SELECT neighbor, MAX(strength) AS s FROM ("
         f"  SELECT target_id AS neighbor, strength FROM memory_links"
-        f"    WHERE source_id IN ({ph})"
+        f"    WHERE source_id IN ({ph}){type_clause}"
         f"  UNION ALL"
         f"  SELECT source_id AS neighbor, strength FROM memory_links"
-        f"    WHERE target_id IN ({ph})"
-        f") WHERE neighbor NOT IN ({drop_ph})"
-        f" GROUP BY neighbor ORDER BY s DESC LIMIT ?",
-        [*memory_ids, *memory_ids, *dropped, limit],
+        f"    WHERE target_id IN ({ph}){type_clause}"
+        f") GROUP BY neighbor ORDER BY s DESC, neighbor LIMIT ?",
+        [*seeds, *type_params, *seeds, *type_params, limit + len(dropped)],
     )
-    return [{"memory_id": row[0], "strength": row[1]} for row in rows]
+    out = [{"memory_id": row[0], "strength": row[1]} for row in rows if row[0] not in dropped]
+    return out[:limit]
 
 
 async def get_bidirectional(db: aiosqlite.Connection, memory_id: str) -> list[dict]:

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -208,6 +208,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         "--dump-dir", default=None,
         help="write per-question diagnostics (one <arm>.jsonl per arm) here",
     )
+    lme_cmd.add_argument(
+        "--graph", action="store_true",
+        help="ADD a +graph variant of every selected arm (linked store + expansion)",
+    )
+    lme_cmd.add_argument(
+        "--graph-link-threshold", type=float, default=0.75,
+        help="cosine threshold for auto-linking on the graph arm's store",
+    )
 
     eval_cmd.set_defaults(func=_run_eval_cli)
 
@@ -274,6 +282,8 @@ async def _cmd_longmemeval(args: argparse.Namespace) -> int:
         db_path=Path(args.db_path) if args.db_path else None,
         types=args.types,
         dump_dir=Path(args.dump_dir) if args.dump_dir else None,
+        graph=args.graph,
+        graph_link_threshold=args.graph_link_threshold,
     )
     print_report(summaries)
     return 0

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -213,8 +213,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="ADD a +graph variant of every selected arm (linked store + expansion)",
     )
     lme_cmd.add_argument(
-        "--graph-link-threshold", type=float, default=0.75,
-        help="cosine threshold for auto-linking on the graph arm's store",
+        "--graph-link-threshold", type=float, default=None,
+        help="cosine threshold for auto-linking on the graph arm's store "
+        "(default: the prod linker default, 0.75)",
     )
 
     eval_cmd.set_defaults(func=_run_eval_cli)

--- a/src/genesis/eval/longmemeval/__main__.py
+++ b/src/genesis/eval/longmemeval/__main__.py
@@ -52,8 +52,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "--graph-link-threshold",
         type=float,
-        default=0.75,
-        help="cosine threshold for auto-linking on the graph arm's store",
+        default=None,
+        help="cosine threshold for auto-linking on the graph arm's store "
+        "(default: the prod linker default, 0.75)",
     )
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)

--- a/src/genesis/eval/longmemeval/__main__.py
+++ b/src/genesis/eval/longmemeval/__main__.py
@@ -44,6 +44,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="write per-question diagnostics (one <arm>.jsonl per arm) here",
     )
+    p.add_argument(
+        "--graph",
+        action="store_true",
+        help="ADD a +graph variant of every selected arm (linked store + 1-hop expansion)",
+    )
+    p.add_argument(
+        "--graph-link-threshold",
+        type=float,
+        default=0.75,
+        help="cosine threshold for auto-linking on the graph arm's store",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -65,6 +76,8 @@ def main(argv: list[str] | None = None) -> int:
             db_path=args.db_path,
             types=args.types,
             dump_dir=args.dump_dir,
+            graph=args.graph,
+            graph_link_threshold=args.graph_link_threshold,
         ),
     )
     print_report(summaries)

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -65,12 +65,17 @@ async def execute(
     db_path: Path | None = None,
     types: str | None = None,
     dump_dir: Path | None = None,
+    graph: bool = False,
+    graph_link_threshold: float = 0.75,
 ) -> dict[str, EvalRunSummary]:
     """Load the dataset, run the harness, persist (optionally), return summaries.
 
     ``types`` (comma-separated question types) filters BEFORE ``limit`` so
     ``--types temporal-reasoning --limit 20`` means "the first 20 temporal
     questions", not "temporal questions among the first 20".
+
+    ``graph`` ADDS a ``+graph`` variant of every selected arm (paired
+    baseline-vs-graph comparison in one run, one dump dir).
     """
     load_secrets()
     instances = load_oracle(dataset_path)
@@ -83,6 +88,10 @@ async def execute(
     arms = default_arms()
     if no_rerank:
         arms = [a for a in arms if not a.rerank]
+    if graph:
+        from dataclasses import replace
+
+        arms = [*arms, *(replace(a, graph=True) for a in arms)]
     reranker = None if no_rerank else build_reranker()
 
     db = None
@@ -109,6 +118,7 @@ async def execute(
             concurrency=concurrency,
             reranker=reranker,
             dump_dir=dump_dir,
+            link_threshold=graph_link_threshold,
         )
     finally:
         if db is not None:

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from genesis.eval.longmemeval.client import load_secrets
 from genesis.eval.longmemeval.dataset import filter_by_types, load_oracle
-from genesis.eval.longmemeval.runner import default_arms, run_longmemeval
+from genesis.eval.longmemeval.runner import run_longmemeval, select_arms
 
 if TYPE_CHECKING:
     from genesis.eval.types import EvalRunSummary
@@ -42,12 +42,22 @@ def print_report(summaries: dict[str, EvalRunSummary]) -> None:
             f"\n[{arm_label}]  overall={s.aggregate_score}  "
             f"attempted={attempted}/{s.total_cases}{skip_note}",
         )
-        for metric in ("evidence_recall_rate", "evidence_coverage_mean"):
+        headline = (
+            "evidence_recall_rate",
+            "evidence_coverage_mean",
+            "evidence_coverage_final_mean",
+        )
+        for metric in headline:
             val = s.scores.get(metric)
             if val is not None:
                 print(f"    {metric}: {val}")
+        # Graph-arm ingest/expansion volume lives in metadata, not scores.
+        for metric in ("links_created_mean", "expanded_mean"):
+            val = s.metadata.get(metric)
+            if val is not None:
+                print(f"    {metric}: {val}")
         for qtype, acc in sorted(s.scores.items()):
-            if qtype in ("evidence_recall_rate", "evidence_coverage_mean"):
+            if qtype in headline:
                 continue
             print(f"    {qtype}: {acc}")
         cost = sum(r.cost_usd for r in s.results)
@@ -66,7 +76,7 @@ async def execute(
     types: str | None = None,
     dump_dir: Path | None = None,
     graph: bool = False,
-    graph_link_threshold: float = 0.75,
+    graph_link_threshold: float | None = None,
 ) -> dict[str, EvalRunSummary]:
     """Load the dataset, run the harness, persist (optionally), return summaries.
 
@@ -85,13 +95,7 @@ async def execute(
         instances = instances[:limit]
     logger.info("loaded %d questions from %s", len(instances), dataset_path)
 
-    arms = default_arms()
-    if no_rerank:
-        arms = [a for a in arms if not a.rerank]
-    if graph:
-        from dataclasses import replace
-
-        arms = [*arms, *(replace(a, graph=True) for a in arms)]
+    arms = select_arms(no_rerank=no_rerank, graph=graph)
     reranker = None if no_rerank else build_reranker()
 
     db = None

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -23,6 +23,27 @@ logger = logging.getLogger("genesis.eval.longmemeval")
 DEFAULT_DATASET = Path.home() / "tmp" / "longmemeval" / "longmemeval_oracle.json"
 
 
+def require_results_db(path: Path) -> Path:
+    """Fail FAST if the default results DB doesn't exist yet.
+
+    ``get_db`` silently CREATES a missing DB — and a freshly-created one lacks
+    ``eval_runs`` (migration-only, not in create_all_tables), so a benchmark
+    run would burn its full API spend and then crash at persistence. The
+    classic trigger: running from a git worktree without ``GENESIS_REPO_ROOT``
+    pointing at the main tree, which resolves ``genesis_db_path()`` into the
+    worktree. (Bit the 2026-07-14 re-baseline: ~500 questions of spend, zero
+    rows persisted.)
+    """
+    if not Path(path).exists():
+        msg = (
+            f"results DB not found at {path} — running from a worktree without "
+            "GENESIS_REPO_ROOT? Set it to the main tree, pass --db-path, or "
+            "use --no-persist."
+        )
+        raise RuntimeError(msg)
+    return path
+
+
 def build_reranker():
     """Build a VoyageReranker (enabled iff API_KEY_VOYAGE is present)."""
     from genesis.memory.reranker import VoyageReranker
@@ -111,7 +132,7 @@ async def execute(
             db = await init_db(db_path)
             await MigrationRunner(db).run_pending()
         else:
-            db = await get_db(genesis_db_path())
+            db = await get_db(require_results_db(genesis_db_path()))
 
     try:
         return await run_longmemeval(

--- a/src/genesis/eval/longmemeval/ingest.py
+++ b/src/genesis/eval/longmemeval/ingest.py
@@ -52,8 +52,18 @@ async def ingest_haystack(
     *,
     origin_class: str = ORIGIN_FIRST_PARTY,
     source: str = _SOURCE,
+    auto_link: bool = False,
 ) -> IngestResult:
-    """Store every non-empty haystack turn as an episodic first-party memory."""
+    """Store every non-empty haystack turn as an episodic first-party memory.
+
+    ``auto_link=True`` (graph arm only; needs a store built ``with_linker``)
+    creates similarity links at insert time exactly as prod does: each turn
+    links against the ALREADY-ingested earlier turns, so link topology is
+    prod-faithful (later→earlier edges; a post-hoc pass would produce edges to
+    later memories that prod can never build). Baseline arms keep ``False`` —
+    links contaminate ranking for every arm sharing a store (graph boost AND
+    activation connectivity), so the graph arm gets its own store.
+    """
     stored = 0
     evidence: set[str] = set()
     for _session_idx, turn, date in instance.iter_turns():
@@ -69,10 +79,7 @@ async def ingest_haystack(
             memory_type="episodic",
             origin_class=origin_class,
             valid_at=normalize_date(date),
-            # No cross-memory linking: the linker is unwired for the ephemeral
-            # store, and the benchmark measures recall of stored evidence, not
-            # associative link quality. auto_link would be a no-op anyway.
-            auto_link=False,
+            auto_link=auto_link,
         )
         stored += 1
         if turn.has_answer:

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -1,17 +1,22 @@
 """Orchestration + aggregation for the LongMemEval harness.
 
-Per question: build a fresh ephemeral store, ingest the haystack ONCE, then run
-each arm (query-mode x rerank) against the frozen store (recall write-backs are
-suppressed via ``GENESIS_MEMORY_WRITEBACKS_OFF`` so arms don't contaminate each
-other). Each arm's recalled memories feed the reader; the hypothesis is graded
-by the gpt-4o judge. Results aggregate per-arm into an ``EvalRunSummary`` (one
-persisted run per arm) with overall + per-question-type accuracy.
+Per question: baseline arms (query-mode x rerank) share ONE fresh ephemeral
+store ingested link-free; graph arms get a SECOND store ingested with
+``auto_link=True`` plus 1-hop link expansion at recall time (links shift
+ranking for every arm sharing a store — graph boost AND activation
+connectivity — so baselines never see a linked store). Recall write-backs are
+suppressed via ``GENESIS_MEMORY_WRITEBACKS_OFF`` so arms don't contaminate
+each other. Each arm's recalled memories feed the reader; the hypothesis is
+graded by the gpt-4o judge. Results aggregate per-arm into an
+``EvalRunSummary`` (one persisted run per arm) with overall +
+per-question-type accuracy. A store-block failure skips ONLY that block's
+arms — completed (paid, judged) results from the other block are kept, so the
+skip ledger never records an attempted arm as "NOT attempted".
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import os
@@ -37,6 +42,7 @@ from genesis.eval.types import (
     ScorerType,
     TaskCategory,
 )
+from genesis.memory.linker import DEFAULT_SIMILARITY_THRESHOLD
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -44,6 +50,8 @@ if TYPE_CHECKING:
     import aiosqlite
 
     from genesis.eval.longmemeval.dataset import LongMemEvalInstance
+    from genesis.eval.longmemeval.ingest import IngestResult
+    from genesis.eval.longmemeval.store import EphemeralStore
 
 logger = logging.getLogger("genesis.eval.longmemeval")
 
@@ -86,6 +94,20 @@ def default_arms() -> list[Arm]:
     ]
 
 
+def select_arms(*, no_rerank: bool = False, graph: bool = False) -> list[Arm]:
+    """Build the CLI's arm list: default arms, optionally rerank-filtered,
+    optionally doubled with a ``+graph`` variant of every selected arm
+    (paired baseline-vs-graph comparison in one run)."""
+    from dataclasses import replace
+
+    arms = default_arms()
+    if no_rerank:
+        arms = [a for a in arms if not a.rerank]
+    if graph:
+        arms = [*arms, *(replace(a, graph=True) for a in arms)]
+    return arms
+
+
 @dataclass(frozen=True)
 class QuestionArmResult:
     question_id: str
@@ -124,6 +146,7 @@ def build_run_summary(
     dataset: str,
     results: Sequence[QuestionArmResult],
     skipped_case_ids: Sequence[str] = (),
+    graph_arm: bool | None = None,
 ) -> EvalRunSummary:
     """Aggregate one arm's per-question results into a persistable summary.
 
@@ -157,8 +180,12 @@ def build_run_summary(
     finals = [r.evidence_coverage_final for r in results if r.evidence_coverage_final is not None]
     if finals:
         scores["evidence_coverage_final_mean"] = round(fmean(finals), 4)
+    # Explicit flag from the caller (which has the Arm); label-suffix fallback
+    # only for direct build_run_summary callers that predate the flag.
+    if graph_arm is None:
+        graph_arm = "+graph" in arm_label
     graph_metadata: dict[str, float] = {}
-    if results and "+graph" in arm_label:
+    if results and graph_arm:
         graph_metadata["links_created_mean"] = round(fmean(r.links_created for r in results), 2)
         graph_metadata["expanded_mean"] = round(fmean(len(r.expanded_ids) for r in results), 2)
 
@@ -225,7 +252,7 @@ async def run_question(
     k: int,
     embedding_provider: object | None = None,
     reranker: object | None = None,
-    link_threshold: float = 0.75,
+    link_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
 ) -> list[QuestionArmResult]:
     """Run every arm for one question.
 
@@ -239,53 +266,123 @@ async def run_question(
     out: list[QuestionArmResult] = []
     base_arms = [a for a in arms if not a.graph]
     graph_arms = [a for a in arms if a.graph]
+    base_embedded: int | None = None
 
+    # Each store block fails INDEPENDENTLY: a graph-store failure must not
+    # discard already-completed (paid, judged) baseline results — that would
+    # record attempted arms as "NOT attempted" skips and make the same
+    # baseline arm label carry a different N in --graph vs plain runs.
     if base_arms:
-        async with ephemeral_store(
-            embedding_provider=embedding_provider,
-            reranker=reranker,
-        ) as es:
-            ingest = await ingest_haystack(es.store, instance)
-            for arm in base_arms:
-                out.append(await _run_arm(es, ingest, instance, arm, k=k, client=client))
+        try:
+            async with ephemeral_store(
+                embedding_provider=embedding_provider,
+                reranker=reranker,
+            ) as es:
+                ingest = await ingest_haystack(es.store, instance)
+                base_embedded = await _embedded_count(es.db)
+                for arm in base_arms:
+                    out.append(await _run_arm(es, ingest, instance, arm, k=k, client=client))
+        except Exception:
+            logger.exception(
+                "question %s: baseline store block failed; skipping baseline arms",
+                instance.question_id,
+            )
 
     if graph_arms:
-        async with ephemeral_store(
-            embedding_provider=embedding_provider,
-            reranker=reranker,
-            with_linker=True,
-            link_threshold=link_threshold,
-        ) as es:
-            ingest = await ingest_haystack(es.store, instance, auto_link=True)
-            cur = await es.db.execute("SELECT COUNT(*) FROM memory_links")
-            (links_created,) = await cur.fetchone()
-            if links_created == 0:
-                # No-silent-caps parity with the rerank warning: a link-free
-                # store makes graph arms equal their baseline twins.
-                logger.warning(
-                    "graph arm: store for %s formed zero links (threshold %.2f); "
-                    "graph arms will match their baseline twins on this question",
-                    instance.question_id,
-                    link_threshold,
-                )
-            for arm in graph_arms:
-                out.append(
-                    await _run_arm(
-                        es,
-                        ingest,
-                        instance,
-                        arm,
-                        k=k,
-                        client=client,
-                        links_created=links_created,
-                    ),
-                )
+        try:
+            async with ephemeral_store(
+                embedding_provider=embedding_provider,
+                reranker=reranker,
+                with_linker=True,
+                link_threshold=link_threshold,
+            ) as es:
+                ingest = await ingest_haystack(es.store, instance, auto_link=True)
+                rows = await es.db.execute_fetchall("SELECT COUNT(*) FROM memory_links")
+                links_created = rows[0][0]
+                if links_created == 0:
+                    # No-silent-caps parity with the rerank warning: a link-free
+                    # store makes graph arms equal their baseline twins.
+                    logger.warning(
+                        "graph arm: store for %s formed zero links (threshold %.2f); "
+                        "graph arms will match their baseline twins on this question",
+                        instance.question_id,
+                        link_threshold,
+                    )
+                # Corpus-parity guard: a transient embedding failure routes a
+                # turn to pending_embeddings (FTS5-only) SILENTLY — if the two
+                # stores diverge, a graph-vs-baseline delta on this question
+                # measures embedding weather, not graph value. Warn loudly.
+                graph_embedded = await _embedded_count(es.db)
+                if base_embedded is not None and graph_embedded != base_embedded:
+                    logger.warning(
+                        "question %s: store corpora diverged (baseline %d vs graph %d "
+                        "embedded memories) — graph-vs-baseline delta unreliable here",
+                        instance.question_id,
+                        base_embedded,
+                        graph_embedded,
+                    )
+                for arm in graph_arms:
+                    out.append(
+                        await _run_arm(
+                            es,
+                            ingest,
+                            instance,
+                            arm,
+                            k=k,
+                            client=client,
+                            links_created=links_created,
+                        ),
+                    )
+        except Exception:
+            logger.exception(
+                "question %s: graph store block failed; skipping graph arms "
+                "(baseline results kept)",
+                instance.question_id,
+            )
     return out
 
 
+async def _embedded_count(db: object) -> int:
+    """Count fully-embedded memories in an ephemeral store (parity check)."""
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM memory_metadata WHERE embedding_status = 'embedded'",
+    )
+    return rows[0][0]
+
+
+def _coverage(evidence_ids: set[str], ids: set[str]) -> tuple[bool, float | None]:
+    """(any-hit, |evidence ∩ ids| / |evidence|); coverage None when the
+    question has no evidence turns (abstention) — excluded from means."""
+    hit = bool(evidence_ids & ids)
+    cov = len(evidence_ids & ids) / len(evidence_ids) if evidence_ids else None
+    return hit, cov
+
+
+async def _expand_neighbors(db: object, seed_ids: list[str], *, k: int) -> list[tuple[str, str]]:
+    """1-hop expansion: (memory_id, content) for up to ``k`` linked neighbors.
+
+    Merges linked-but-unretrieved neighbors into the reader context (the prod
+    MCP layer only DECORATES results with neighbors; actually merging them is
+    what can lift multi-session coverage). Deliberately direct CRUD, not
+    graph.traverse — its process-global NetworkX cache is unsafe across the
+    concurrent ephemeral stores this runner creates. Dangling links (edge
+    rows whose neighbor memory no longer resolves) are skipped silently.
+    """
+    from genesis.db.crud import memory as memory_crud
+    from genesis.db.crud import memory_links as memory_links_crud
+
+    neighbors = await memory_links_crud.neighbors_of(db, seed_ids, limit=k)
+    expanded: list[tuple[str, str]] = []
+    for n in neighbors:
+        row = await memory_crud.get_by_id(db, n["memory_id"])
+        if row and row.get("content"):
+            expanded.append((n["memory_id"], row["content"]))
+    return expanded
+
+
 async def _run_arm(
-    es: object,
-    ingest: object,
+    es: EphemeralStore,
+    ingest: IngestResult,
     instance: LongMemEvalInstance,
     arm: Arm,
     *,
@@ -293,7 +390,12 @@ async def _run_arm(
     client: object,
     links_created: int = 0,
 ) -> QuestionArmResult:
-    """Recall (+ optional 1-hop graph expansion) -> answer -> judge, one arm."""
+    """Recall (+ optional 1-hop graph expansion) -> answer -> judge, one arm.
+
+    ``links_created`` is a STORE-WIDE ingest count for this question's linked
+    store — it is stamped identically on every graph arm of the question (an
+    ingest metric, not a per-arm measurement).
+    """
     t0 = time.monotonic()
     query = build_query(instance.question, arm.query_arm)
     hits = await es.retriever.recall(
@@ -310,37 +412,15 @@ async def _run_arm(
     evidence_recalled_final: bool | None = None
     evidence_coverage_final: float | None = None
     if arm.graph:
-        from genesis.db.crud import memory as memory_crud
-        from genesis.db.crud import memory_links as memory_links_crud
-
-        # 1-hop expansion: merge linked-but-unretrieved neighbors into the
-        # reader context (the prod MCP layer only DECORATES results with
-        # neighbors; actually merging them is what can lift multi-session
-        # coverage). Deliberately direct CRUD, not graph.traverse — its
-        # process-global NetworkX cache is unsafe across the concurrent
-        # ephemeral stores this runner creates.
-        neighbors = await memory_links_crud.neighbors_of(
-            es.db,
-            [h.memory_id for h in hits],
-            limit=k,
-        )
-        expanded: list[tuple[str, str]] = []
-        for n in neighbors:
-            row = await memory_crud.get_by_id(es.db, n["memory_id"])
-            if row and row.get("content"):
-                expanded.append((n["memory_id"], row["content"]))
+        expanded = await _expand_neighbors(es.db, [h.memory_id for h in hits], k=k)
         expanded_ids = tuple(mid for mid, _ in expanded)
         memories = [*memories, *(content for _, content in expanded)]
-        final_ids = recalled_ids | set(expanded_ids)
-        evidence_recalled_final = bool(evidence_ids & final_ids)
-        evidence_coverage_final = (
-            len(evidence_ids & final_ids) / len(evidence_ids) if evidence_ids else None
+        evidence_recalled_final, evidence_coverage_final = _coverage(
+            evidence_ids,
+            recalled_ids | set(expanded_ids),
         )
 
-    evidence_recalled = bool(evidence_ids & recalled_ids)
-    evidence_coverage = (
-        len(evidence_ids & recalled_ids) / len(evidence_ids) if evidence_ids else None
-    )
+    evidence_recalled, evidence_coverage = _coverage(evidence_ids, recalled_ids)
     # answer_question / judge_answer use the SYNC OpenAI client, so run
     # them in a worker thread — a blocking create() on the event loop
     # would stall ALL concurrent questions and defeat `concurrency`.
@@ -438,19 +518,29 @@ async def run_longmemeval(
     embedding_provider: object | None = None,
     reranker: object | None = None,
     dump_dir: Path | None = None,
-    link_threshold: float = 0.75,
+    link_threshold: float | None = None,
 ) -> dict[str, EvalRunSummary]:
     """Run the full harness over ``instances``; return per-arm summaries.
 
     Forces ``GENESIS_MEMORY_WRITEBACKS_OFF`` for the duration of the run so
-    multi-arm recall against a shared per-question store cannot re-rank memories
-    across arms, and RESTORES the prior value afterwards so an in-process caller
-    (e.g. the test suite) isn't polluted. Persists one run per arm when ``db``
-    is provided. When ``dump_dir`` is set, writes one ``<arm>.jsonl``
+    multi-arm recall against the shared per-question stores (baseline and, in
+    graph mode, a second linked store) cannot re-rank memories across arms,
+    and RESTORES the prior value afterwards so an in-process caller (e.g. the
+    test suite) isn't polluted. Persists one run per arm when ``db`` is
+    provided. When ``dump_dir`` is set, writes one ``<arm>.jsonl``
     per-question diagnostics file per arm and records its path in the
-    summary's metadata.
+    summary's metadata. Skips are attributed PER ARM: a store-block failure
+    inside ``run_question`` skips only that block's arms.
     """
+
+    if link_threshold is None:
+        link_threshold = DEFAULT_SIMILARITY_THRESHOLD
     arms = list(arms) if arms is not None else default_arms()
+    labels = [a.label for a in arms]
+    if len(labels) != len(set(labels)):
+        # Duplicate labels would double-persist identical eval_runs rows.
+        msg = f"duplicate arm labels: {sorted(labels)}"
+        raise ValueError(msg)
     client = client or build_client()
     prior_writebacks = os.environ.get(_WRITEBACKS_OFF_ENV)
     os.environ[_WRITEBACKS_OFF_ENV] = "1"
@@ -509,35 +599,38 @@ async def run_longmemeval(
         else:
             os.environ[_WRITEBACKS_OFF_ENV] = prior_writebacks
         if owns_embedder:
-            await _close_embedder(embedding_provider)
+            from genesis.eval.longmemeval.store import close_embedder
+
+            await close_embedder(embedding_provider)
             if run_cache_dir is not None:
                 shutil.rmtree(run_cache_dir, ignore_errors=True)
 
-    # Regroup by arm; a question with no results errored out (skipped) and is
-    # recorded per-arm so the denominator reflects the requested N and provider
+    # Regroup by arm with PER-ARM skip attribution: a question is skipped for
+    # an arm iff that arm produced no result (a store-block failure inside
+    # run_question skips only that block's arms; completed arms keep their
+    # results). Denominators reflect the requested N per arm and provider
     # failures surface instead of silently shrinking the sample.
     by_arm: dict[str, list[QuestionArmResult]] = {a.label: [] for a in arms}
-    skipped_qids: list[str] = []
-    for inst, question_results in zip(instances, gathered, strict=True):
-        if not question_results:
-            skipped_qids.append(inst.question_id)
-            continue
+    for question_results in gathered:
         for r in question_results:
             by_arm.setdefault(r.arm_label, []).append(r)
 
     summaries: dict[str, EvalRunSummary] = {}
     for arm in arms:
         arm_results = by_arm.get(arm.label, [])
+        answered = {r.question_id for r in arm_results}
+        arm_skipped = [i.question_id for i in instances if i.question_id not in answered]
         summary = build_run_summary(
             arm_label=arm.label,
-            skipped_case_ids=skipped_qids,
+            skipped_case_ids=arm_skipped,
             model=DEFAULT_MODEL,
             dataset=_DATASET,
             results=arm_results,
+            graph_arm=arm.graph,
         )
         if dump_dir is not None:
             dump_path = Path(dump_dir) / f"{arm.label}.jsonl"
-            write_dump_jsonl(dump_path, arm_results, skipped_case_ids=skipped_qids)
+            write_dump_jsonl(dump_path, arm_results, skipped_case_ids=arm_skipped)
             summary.metadata["dump_path"] = str(dump_path)
         summaries[arm.label] = summary
         if db is not None:
@@ -545,20 +638,3 @@ async def run_longmemeval(
 
             await insert_run(db, summary)
     return summaries
-
-
-async def _close_embedder(embedder: object) -> None:
-    """Best-effort close of an embedder's httpx clients + diskcache.
-
-    ``EmbeddingProvider`` exposes no ``close()``; reach in defensively so a
-    future internal change degrades to a no-op rather than raising.
-    """
-    for backend in getattr(embedder, "backends", []) or []:
-        http_client = getattr(backend, "_client", None)
-        if http_client is not None and hasattr(http_client, "aclose"):
-            with contextlib.suppress(Exception):
-                await http_client.aclose()
-    cache = getattr(embedder, "_disk_cache", None)
-    if cache is not None and hasattr(cache, "close"):
-        with contextlib.suppress(Exception):
-            cache.close()

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -57,14 +57,22 @@ _WRITEBACKS_OFF_ENV = "GENESIS_MEMORY_WRITEBACKS_OFF"
 
 @dataclass(frozen=True)
 class Arm:
-    """One evaluation arm: a query mode crossed with rerank on/off."""
+    """One evaluation arm: a query mode x rerank on/off x graph on/off.
+
+    ``graph`` arms run against a SEPARATE ephemeral store ingested with
+    ``auto_link=True`` (see ``run_question``) and add 1-hop link expansion
+    after top-K recall.
+    """
 
     query_arm: QueryArm
     rerank: bool
+    graph: bool = False
 
     @property
     def label(self) -> str:
-        suffix = "+rerank" if self.rerank else ""
+        # Deterministic suffix order (rerank before graph): model_profile
+        # "longmemeval:<label>" and dump filenames must be stable across runs.
+        suffix = ("+rerank" if self.rerank else "") + ("+graph" if self.graph else "")
         return f"{self.query_arm.value}{suffix}"
 
 
@@ -91,6 +99,14 @@ class QuestionArmResult:
     evidence_coverage: float | None = None
     query: str = ""
     recalled_ids: tuple[str, ...] = ()
+    #: Graph-arm diagnostics: links formed at ingest on this question's linked
+    #: store; neighbor ids merged by 1-hop expansion; evidence metrics over the
+    #: EXPANDED set (top-K ∪ expanded). All None/empty/0 on baseline arms —
+    #: top-K metrics above stay baseline-comparable.
+    links_created: int = 0
+    expanded_ids: tuple[str, ...] = ()
+    evidence_recalled_final: bool | None = None
+    evidence_coverage_final: float | None = None
     judge_raw: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
@@ -136,6 +152,15 @@ def build_run_summary(
     coverages = [r.evidence_coverage for r in results if r.evidence_coverage is not None]
     if coverages:
         scores["evidence_coverage_mean"] = round(fmean(coverages), 4)
+    # Graph-arm means: post-expansion coverage + link/expansion volume — how
+    # much the graph ADDED beyond top-K (ranking lift vs coverage lift split).
+    finals = [r.evidence_coverage_final for r in results if r.evidence_coverage_final is not None]
+    if finals:
+        scores["evidence_coverage_final_mean"] = round(fmean(finals), 4)
+    graph_metadata: dict[str, float] = {}
+    if results and "+graph" in arm_label:
+        graph_metadata["links_created_mean"] = round(fmean(r.links_created for r in results), 2)
+        graph_metadata["expanded_mean"] = round(fmean(len(r.expanded_ids) for r in results), 2)
 
     scored: list[ScoredOutput] = []
     for r in results:
@@ -187,7 +212,7 @@ def build_run_summary(
         skipped_cases=skipped,
         aggregate_score=round(passed / attempted, 4) if attempted else 0.0,
         scores=scores,
-        metadata={"arm": arm_label, "dataset": dataset, "skipped": skipped},
+        metadata={"arm": arm_label, "dataset": dataset, "skipped": skipped, **graph_metadata},
         results=scored,
     )
 
@@ -200,69 +225,162 @@ async def run_question(
     k: int,
     embedding_provider: object | None = None,
     reranker: object | None = None,
+    link_threshold: float = 0.75,
 ) -> list[QuestionArmResult]:
-    """Run every arm for one question against a fresh ephemeral store."""
+    """Run every arm for one question.
+
+    Baseline and graph arms use SEPARATE ephemeral stores: links shift ranking
+    for every arm sharing a store (graph boost AND activation connectivity,
+    ``activation.py`` link_count term), so a shared linked store would tint the
+    baselines and break comparability. The second ingest re-embeds through the
+    run-level embedding cache, so its marginal cost is in-memory upserts + one
+    local Qdrant search per turn.
+    """
     out: list[QuestionArmResult] = []
-    async with ephemeral_store(
-        embedding_provider=embedding_provider,
-        reranker=reranker,
-    ) as es:
-        ingest = await ingest_haystack(es.store, instance)
-        for arm in arms:
-            t0 = time.monotonic()
-            query = build_query(instance.question, arm.query_arm)
-            hits = await es.retriever.recall(
-                query,
-                source="episodic",
-                limit=k,
-                rerank=arm.rerank,
-            )
-            recalled_ids = {h.memory_id for h in hits}
-            evidence_ids = ingest.evidence_memory_ids
-            evidence_recalled = bool(evidence_ids & recalled_ids)
-            evidence_coverage = (
-                len(evidence_ids & recalled_ids) / len(evidence_ids) if evidence_ids else None
-            )
-            memories = [h.content for h in hits]
-            # answer_question / judge_answer use the SYNC OpenAI client, so run
-            # them in a worker thread — a blocking create() on the event loop
-            # would stall ALL concurrent questions and defeat `concurrency`.
-            ans = await asyncio.to_thread(
-                answer_question,
-                instance.question,
-                memories,
-                client=client,
-                question_type=instance.question_type,
-                question_date=instance.question_date,
-            )
-            verdict = await asyncio.to_thread(
-                lambda a=ans: judge_answer(
-                    instance.question_type,
-                    instance.question,
-                    instance.answer,
-                    a.hypothesis,
-                    abstention=instance.is_abstention,
-                    client=client,
-                ),
-            )
-            out.append(
-                QuestionArmResult(
-                    question_id=instance.question_id,
-                    question_type=instance.question_type,
-                    arm_label=arm.label,
-                    hypothesis=ans.hypothesis,
-                    judged_correct=verdict.label,
-                    evidence_recalled=evidence_recalled,
-                    evidence_coverage=evidence_coverage,
-                    query=query,
-                    recalled_ids=tuple(h.memory_id for h in hits),
-                    judge_raw=verdict.raw,
-                    input_tokens=ans.input_tokens + verdict.input_tokens,
-                    output_tokens=ans.output_tokens + verdict.output_tokens,
-                    latency_ms=(time.monotonic() - t0) * 1000,
-                ),
-            )
+    base_arms = [a for a in arms if not a.graph]
+    graph_arms = [a for a in arms if a.graph]
+
+    if base_arms:
+        async with ephemeral_store(
+            embedding_provider=embedding_provider,
+            reranker=reranker,
+        ) as es:
+            ingest = await ingest_haystack(es.store, instance)
+            for arm in base_arms:
+                out.append(await _run_arm(es, ingest, instance, arm, k=k, client=client))
+
+    if graph_arms:
+        async with ephemeral_store(
+            embedding_provider=embedding_provider,
+            reranker=reranker,
+            with_linker=True,
+            link_threshold=link_threshold,
+        ) as es:
+            ingest = await ingest_haystack(es.store, instance, auto_link=True)
+            cur = await es.db.execute("SELECT COUNT(*) FROM memory_links")
+            (links_created,) = await cur.fetchone()
+            if links_created == 0:
+                # No-silent-caps parity with the rerank warning: a link-free
+                # store makes graph arms equal their baseline twins.
+                logger.warning(
+                    "graph arm: store for %s formed zero links (threshold %.2f); "
+                    "graph arms will match their baseline twins on this question",
+                    instance.question_id,
+                    link_threshold,
+                )
+            for arm in graph_arms:
+                out.append(
+                    await _run_arm(
+                        es,
+                        ingest,
+                        instance,
+                        arm,
+                        k=k,
+                        client=client,
+                        links_created=links_created,
+                    ),
+                )
     return out
+
+
+async def _run_arm(
+    es: object,
+    ingest: object,
+    instance: LongMemEvalInstance,
+    arm: Arm,
+    *,
+    k: int,
+    client: object,
+    links_created: int = 0,
+) -> QuestionArmResult:
+    """Recall (+ optional 1-hop graph expansion) -> answer -> judge, one arm."""
+    t0 = time.monotonic()
+    query = build_query(instance.question, arm.query_arm)
+    hits = await es.retriever.recall(
+        query,
+        source="episodic",
+        limit=k,
+        rerank=arm.rerank,
+    )
+    recalled_ids = {h.memory_id for h in hits}
+    evidence_ids = ingest.evidence_memory_ids
+    memories = [h.content for h in hits]
+
+    expanded_ids: tuple[str, ...] = ()
+    evidence_recalled_final: bool | None = None
+    evidence_coverage_final: float | None = None
+    if arm.graph:
+        from genesis.db.crud import memory as memory_crud
+        from genesis.db.crud import memory_links as memory_links_crud
+
+        # 1-hop expansion: merge linked-but-unretrieved neighbors into the
+        # reader context (the prod MCP layer only DECORATES results with
+        # neighbors; actually merging them is what can lift multi-session
+        # coverage). Deliberately direct CRUD, not graph.traverse — its
+        # process-global NetworkX cache is unsafe across the concurrent
+        # ephemeral stores this runner creates.
+        neighbors = await memory_links_crud.neighbors_of(
+            es.db,
+            [h.memory_id for h in hits],
+            limit=k,
+        )
+        expanded: list[tuple[str, str]] = []
+        for n in neighbors:
+            row = await memory_crud.get_by_id(es.db, n["memory_id"])
+            if row and row.get("content"):
+                expanded.append((n["memory_id"], row["content"]))
+        expanded_ids = tuple(mid for mid, _ in expanded)
+        memories = [*memories, *(content for _, content in expanded)]
+        final_ids = recalled_ids | set(expanded_ids)
+        evidence_recalled_final = bool(evidence_ids & final_ids)
+        evidence_coverage_final = (
+            len(evidence_ids & final_ids) / len(evidence_ids) if evidence_ids else None
+        )
+
+    evidence_recalled = bool(evidence_ids & recalled_ids)
+    evidence_coverage = (
+        len(evidence_ids & recalled_ids) / len(evidence_ids) if evidence_ids else None
+    )
+    # answer_question / judge_answer use the SYNC OpenAI client, so run
+    # them in a worker thread — a blocking create() on the event loop
+    # would stall ALL concurrent questions and defeat `concurrency`.
+    ans = await asyncio.to_thread(
+        answer_question,
+        instance.question,
+        memories,
+        client=client,
+        question_type=instance.question_type,
+        question_date=instance.question_date,
+    )
+    verdict = await asyncio.to_thread(
+        lambda a=ans: judge_answer(
+            instance.question_type,
+            instance.question,
+            instance.answer,
+            a.hypothesis,
+            abstention=instance.is_abstention,
+            client=client,
+        ),
+    )
+    return QuestionArmResult(
+        question_id=instance.question_id,
+        question_type=instance.question_type,
+        arm_label=arm.label,
+        hypothesis=ans.hypothesis,
+        judged_correct=verdict.label,
+        evidence_recalled=evidence_recalled,
+        evidence_coverage=evidence_coverage,
+        query=query,
+        recalled_ids=tuple(h.memory_id for h in hits),
+        links_created=links_created if arm.graph else 0,
+        expanded_ids=expanded_ids,
+        evidence_recalled_final=evidence_recalled_final,
+        evidence_coverage_final=evidence_coverage_final,
+        judge_raw=verdict.raw,
+        input_tokens=ans.input_tokens + verdict.input_tokens,
+        output_tokens=ans.output_tokens + verdict.output_tokens,
+        latency_ms=(time.monotonic() - t0) * 1000,
+    )
 
 
 def write_dump_jsonl(
@@ -291,6 +409,10 @@ def write_dump_jsonl(
                         "recalled_ids": list(r.recalled_ids),
                         "evidence_recalled": r.evidence_recalled,
                         "evidence_coverage": r.evidence_coverage,
+                        "links_created": r.links_created,
+                        "expanded_ids": list(r.expanded_ids),
+                        "evidence_recalled_final": r.evidence_recalled_final,
+                        "evidence_coverage_final": r.evidence_coverage_final,
                         "hypothesis": r.hypothesis,
                         "judged_correct": r.judged_correct,
                         "judge_raw": r.judge_raw,
@@ -316,6 +438,7 @@ async def run_longmemeval(
     embedding_provider: object | None = None,
     reranker: object | None = None,
     dump_dir: Path | None = None,
+    link_threshold: float = 0.75,
 ) -> dict[str, EvalRunSummary]:
     """Run the full harness over ``instances``; return per-arm summaries.
 
@@ -371,6 +494,7 @@ async def run_longmemeval(
                     k=k,
                     embedding_provider=embedding_provider,
                     reranker=reranker,
+                    link_threshold=link_threshold,
                 )
             except Exception:
                 logger.exception("question %s failed; skipping", inst.question_id)

--- a/src/genesis/eval/longmemeval/store.py
+++ b/src/genesis/eval/longmemeval/store.py
@@ -1,6 +1,8 @@
 """Ephemeral Genesis memory store for LongMemEval — zero production contact.
 
-Each question gets a throwaway store built entirely from scratch:
+Each question gets one or two throwaway stores built entirely from scratch
+(baseline arms share a link-free store; graph arms get a second store built
+``with_linker`` — see ``runner.run_question``):
   * an in-process ``QdrantClient(":memory:")`` (never the production Qdrant),
   * a fresh temp SQLite created by ``init_db`` under ``~/tmp`` (never the
     production ``genesis.db``),
@@ -21,8 +23,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from genesis.memory.linker import DEFAULT_SIMILARITY_THRESHOLD
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+    import aiosqlite
 
     from genesis.memory.retrieval import HybridRetriever
     from genesis.memory.store import MemoryStore
@@ -39,7 +45,7 @@ class EphemeralStore:
     store: MemoryStore
     retriever: HybridRetriever
     workdir: Path
-    db: object = None
+    db: aiosqlite.Connection | None = None
 
 
 def _default_tmp_root() -> Path:
@@ -56,7 +62,7 @@ async def ephemeral_store(
     reranker: object | None = None,
     tmp_root: str | Path | None = None,
     with_linker: bool = False,
-    link_threshold: float = 0.75,
+    link_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
 ) -> AsyncIterator[EphemeralStore]:
     """Build a fresh ephemeral store; tear down all temp state on exit.
 
@@ -120,4 +126,27 @@ async def ephemeral_store(
             await db.close()
         with contextlib.suppress(Exception):
             qdrant.close()
+        if embedding_provider is None:
+            # We constructed this embedder: close its httpx clients + diskcache
+            # BEFORE deleting the workdir its cache lives under. Injected
+            # embedders belong to the caller (run_longmemeval shares one per
+            # run and closes it itself).
+            await close_embedder(embedder)
         shutil.rmtree(workdir, ignore_errors=True)
+
+
+async def close_embedder(embedder: object) -> None:
+    """Best-effort close of an embedder's httpx clients + diskcache.
+
+    ``EmbeddingProvider`` exposes no ``close()``; reach in defensively so a
+    future internal change degrades to a no-op rather than raising.
+    """
+    for backend in getattr(embedder, "backends", []) or []:
+        http_client = getattr(backend, "_client", None)
+        if http_client is not None and hasattr(http_client, "aclose"):
+            with contextlib.suppress(Exception):
+                await http_client.aclose()
+    cache = getattr(embedder, "_disk_cache", None)
+    if cache is not None and hasattr(cache, "close"):
+        with contextlib.suppress(Exception):
+            cache.close()

--- a/src/genesis/eval/longmemeval/store.py
+++ b/src/genesis/eval/longmemeval/store.py
@@ -30,11 +30,16 @@ if TYPE_CHECKING:
 
 @dataclass
 class EphemeralStore:
-    """A throwaway store + retriever pair sharing one in-memory Qdrant + temp DB."""
+    """A throwaway store + retriever pair sharing one in-memory Qdrant + temp DB.
+
+    ``db`` is the ephemeral SQLite connection — exposed so the graph arm can
+    run link queries (``memory_links.neighbors_of``) against this store.
+    """
 
     store: MemoryStore
     retriever: HybridRetriever
     workdir: Path
+    db: object = None
 
 
 def _default_tmp_root() -> Path:
@@ -50,6 +55,8 @@ async def ephemeral_store(
     embedding_provider: object | None = None,
     reranker: object | None = None,
     tmp_root: str | Path | None = None,
+    with_linker: bool = False,
+    link_threshold: float = 0.75,
 ) -> AsyncIterator[EphemeralStore]:
     """Build a fresh ephemeral store; tear down all temp state on exit.
 
@@ -57,6 +64,12 @@ async def ephemeral_store(
     omitted, Genesis's real cloud-first embedding chain is used. ``reranker``
     (a VoyageReranker) is wired into the retriever so the ``rerank`` arm is
     real; ``None`` makes ``recall(rerank=True)`` a graceful no-op.
+
+    ``with_linker`` wires a real ``MemoryLinker`` into the store so
+    ``store(auto_link=True)`` creates ``memory_links`` (the graph arm's store).
+    It is opt-in: ``MemoryStore.store()`` defaults ``auto_link=True``, so an
+    always-present linker would let any future direct ``store()`` call create
+    links silently on baseline stores.
     """
     from qdrant_client import QdrantClient
 
@@ -78,7 +91,21 @@ async def ephemeral_store(
         backends=EmbeddingProvider.build_chain(ollama_first=False),
         cache_dir=workdir / "cache",
     )
-    store = MemoryStore(embedding_provider=embedder, qdrant_client=qdrant, db=db)
+    linker = None
+    if with_linker:
+        from genesis.memory.linker import MemoryLinker
+
+        linker = MemoryLinker(
+            qdrant_client=qdrant,
+            db=db,
+            similarity_threshold=link_threshold,
+        )
+    store = MemoryStore(
+        embedding_provider=embedder,
+        qdrant_client=qdrant,
+        db=db,
+        linker=linker,
+    )
     retriever = HybridRetriever(
         embedding_provider=embedder,
         qdrant_client=qdrant,
@@ -87,7 +114,7 @@ async def ephemeral_store(
     )
 
     try:
-        yield EphemeralStore(store=store, retriever=retriever, workdir=workdir)
+        yield EphemeralStore(store=store, retriever=retriever, workdir=workdir, db=db)
     finally:
         with contextlib.suppress(Exception):
             await db.close()

--- a/src/genesis/memory/linker.py
+++ b/src/genesis/memory/linker.py
@@ -15,20 +15,43 @@ from genesis.qdrant.collections import search
 logger = logging.getLogger(__name__)
 
 # Valid typed link types from schema CHECK constraint
-_VALID_LINK_TYPES = frozenset({
-    "supports", "contradicts", "extends", "elaborates",
-    "discussed_in", "evaluated_for", "decided",
-    "action_item_for", "categorized_as", "related_to",
-    "succeeded_by", "preceded_by",
-})
+_VALID_LINK_TYPES = frozenset(
+    {
+        "supports",
+        "contradicts",
+        "extends",
+        "elaborates",
+        "discussed_in",
+        "evaluated_for",
+        "decided",
+        "action_item_for",
+        "categorized_as",
+        "related_to",
+        "succeeded_by",
+        "preceded_by",
+    }
+)
 
 
 class MemoryLinker:
-    """Find similar memories and create bidirectional links."""
+    """Find similar memories and create bidirectional links.
 
-    def __init__(self, *, qdrant_client: QdrantClient, db: aiosqlite.Connection) -> None:
+    ``similarity_threshold`` on the constructor becomes ``auto_link``'s
+    default: callers that never pass a per-call threshold (``MemoryStore.
+    store()``) inherit it, so a non-default linking policy needs only a
+    differently-constructed linker, not call-site churn.
+    """
+
+    def __init__(
+        self,
+        *,
+        qdrant_client: QdrantClient,
+        db: aiosqlite.Connection,
+        similarity_threshold: float = 0.75,
+    ) -> None:
         self._qdrant = qdrant_client
         self._db = db
+        self._similarity_threshold = similarity_threshold
 
     async def auto_link(
         self,
@@ -36,10 +59,12 @@ class MemoryLinker:
         vector: list[float],
         *,
         collection: str = "episodic_memory",
-        similarity_threshold: float = 0.75,
+        similarity_threshold: float | None = None,
         max_links: int = 5,
     ) -> list[LinkRecord]:
         """Find similar memories and create links."""
+        if similarity_threshold is None:
+            similarity_threshold = self._similarity_threshold
         results = search(
             self._qdrant,
             collection=collection,
@@ -84,6 +109,7 @@ class MemoryLinker:
 
         if links:
             from genesis.memory.graph import invalidate_graph_cache
+
             invalidate_graph_cache()
         return links
 
@@ -124,7 +150,8 @@ class MemoryLinker:
             if link_type not in _VALID_LINK_TYPES:
                 logger.debug(
                     "Skipping invalid link type %r for memory %s",
-                    link_type, memory_id,
+                    link_type,
+                    memory_id,
                 )
                 continue
 
@@ -133,7 +160,8 @@ class MemoryLinker:
             if not target_id:
                 logger.debug(
                     "No matching memory found for entity %r (link from %s)",
-                    target_name, memory_id,
+                    target_name,
+                    memory_id,
                 )
                 continue
 
@@ -162,12 +190,15 @@ class MemoryLinker:
                 # Likely duplicate primary key — link already exists
                 logger.debug(
                     "Link %s → %s (%s) already exists or failed",
-                    memory_id, target_id, link_type,
+                    memory_id,
+                    target_id,
+                    link_type,
                     exc_info=True,
                 )
 
         if links:
             from genesis.memory.graph import invalidate_graph_cache
+
             invalidate_graph_cache()
         return links
 

--- a/src/genesis/memory/linker.py
+++ b/src/genesis/memory/linker.py
@@ -14,6 +14,20 @@ from genesis.qdrant.collections import search
 
 logger = logging.getLogger(__name__)
 
+#: The prod-default auto-link cosine threshold. Single source of truth —
+#: eval/CLI layers reference this instead of repeating the literal.
+DEFAULT_SIMILARITY_THRESHOLD = 0.75
+
+
+def _validated_threshold(value: float) -> float:
+    """Reject out-of-range/NaN thresholds — ``NaN`` makes ``score < t`` always
+    False, silently linking EVERYTHING up to max_links (graph densification)."""
+    if not 0.0 <= value <= 1.0:  # NaN fails this comparison too
+        msg = f"similarity_threshold must be in [0, 1], got {value!r}"
+        raise ValueError(msg)
+    return value
+
+
 # Valid typed link types from schema CHECK constraint
 _VALID_LINK_TYPES = frozenset(
     {
@@ -47,11 +61,11 @@ class MemoryLinker:
         *,
         qdrant_client: QdrantClient,
         db: aiosqlite.Connection,
-        similarity_threshold: float = 0.75,
+        similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
     ) -> None:
         self._qdrant = qdrant_client
         self._db = db
-        self._similarity_threshold = similarity_threshold
+        self._similarity_threshold = _validated_threshold(similarity_threshold)
 
     async def auto_link(
         self,
@@ -65,6 +79,8 @@ class MemoryLinker:
         """Find similar memories and create links."""
         if similarity_threshold is None:
             similarity_threshold = self._similarity_threshold
+        else:
+            similarity_threshold = _validated_threshold(similarity_threshold)
         results = search(
             self._qdrant,
             collection=collection,
@@ -88,14 +104,26 @@ class MemoryLinker:
 
             link_type = "extends" if score >= 0.90 else "supports"
 
-            await memory_links.create(
-                self._db,
-                source_id=memory_id,
-                target_id=target_id,
-                link_type=link_type,
-                strength=score,
-                created_at=now,
-            )
+            try:
+                await memory_links.create(
+                    self._db,
+                    source_id=memory_id,
+                    target_id=target_id,
+                    link_type=link_type,
+                    strength=score,
+                    created_at=now,
+                )
+            except Exception:
+                # Duplicate PK / transient lock: one failed link must not abort
+                # the whole store() call (mirrors create_typed_links' guard).
+                logger.debug(
+                    "auto_link %s → %s (%s) already exists or failed",
+                    memory_id,
+                    target_id,
+                    link_type,
+                    exc_info=True,
+                )
+                continue
 
             links.append(
                 LinkRecord(

--- a/tests/test_db/test_memory_links.py
+++ b/tests/test_db/test_memory_links.py
@@ -227,3 +227,59 @@ async def test_neighbors_of_never_returns_seeds_or_empty(db):
     rows = await memory_links.neighbors_of(db, ["a", "b"])
     assert rows == []  # b is itself a seed, not a neighbor
     assert await memory_links.neighbors_of(db, []) == []
+
+
+async def test_neighbors_of_oversized_seed_list_and_exclude_no_error(db):
+    """600 seeds + a large exclude must not blow the SQL placeholder budget
+    (exclusion is Python-side; seeds are capped) and truncated seeds must
+    never come back as 'neighbors'."""
+    await memory_links.create(
+        db, source_id="seed_0", target_id="real_neighbor", link_type="supports",
+        strength=0.9, created_at="2026-01-01",
+    )
+    seeds = [f"seed_{i}" for i in range(600)]
+    exclude = [f"ex_{i}" for i in range(600)]
+    rows = await memory_links.neighbors_of(db, seeds, exclude=exclude, limit=5)
+    ids = [r["memory_id"] for r in rows]
+    assert ids == ["real_neighbor"]
+    assert not any(i.startswith("seed_") for i in ids)
+
+
+async def test_neighbors_of_limit_zero_and_negative(db):
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="supports",
+        strength=0.9, created_at="2026-01-01",
+    )
+    assert await memory_links.neighbors_of(db, ["a"], limit=0) == []
+    assert await memory_links.neighbors_of(db, ["a"], limit=-3) == []
+
+
+async def test_neighbors_of_ties_break_deterministically(db):
+    """Equal strengths order by neighbor id — expansion results (and the
+    metrics built on them) must be reproducible across runs/insert order."""
+    for tgt in ("n_c", "n_a", "n_b"):
+        await memory_links.create(
+            db, source_id="seed", target_id=tgt, link_type="supports",
+            strength=0.8, created_at="2026-01-01",
+        )
+    rows = await memory_links.neighbors_of(db, ["seed"], limit=2)
+    assert [r["memory_id"] for r in rows] == ["n_a", "n_b"]
+
+
+async def test_neighbors_of_link_types_filter(db):
+    """link_types restricts which edge types are followed — prod callers
+    expanding into LLM context can exclude adversarial types."""
+    await memory_links.create(
+        db, source_id="seed", target_id="friend", link_type="supports",
+        strength=0.9, created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="seed", target_id="foe", link_type="contradicts",
+        strength=0.95, created_at="2026-01-01",
+    )
+    all_rows = await memory_links.neighbors_of(db, ["seed"])
+    assert {r["memory_id"] for r in all_rows} == {"friend", "foe"}
+    safe = await memory_links.neighbors_of(
+        db, ["seed"], link_types=("supports", "extends"),
+    )
+    assert [r["memory_id"] for r in safe] == ["friend"]

--- a/tests/test_db/test_memory_links.py
+++ b/tests/test_db/test_memory_links.py
@@ -181,3 +181,49 @@ async def test_inter_candidate_links_empty(db):
     """Empty candidate set returns empty list."""
     edges = await memory_links.inter_candidate_links(db, [])
     assert edges == []
+
+
+async def test_neighbors_of_dedupes_directions_and_types(db):
+    """neighbors_of collapses multi-type rows + both directions to one row per
+    neighbor with MAX(strength), strongest first."""
+    # seed <-> n1 linked twice (two types, both directions), n2 weaker, n3 via inbound only
+    await memory_links.create(
+        db, source_id="seed", target_id="n1", link_type="supports",
+        strength=0.8, created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="n1", target_id="seed", link_type="extends",
+        strength=0.92, created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="seed", target_id="n2", link_type="supports",
+        strength=0.76, created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="n3", target_id="seed", link_type="supports",
+        strength=0.85, created_at="2026-01-01",
+    )
+    rows = await memory_links.neighbors_of(db, ["seed"])
+    ids = [r["memory_id"] for r in rows]
+    assert ids == ["n1", "n3", "n2"]  # strongest-first, n1 once (max 0.92)
+    assert rows[0]["strength"] == 0.92
+
+
+async def test_neighbors_of_excludes_and_caps(db):
+    for i, s in enumerate((0.9, 0.85, 0.8)):
+        await memory_links.create(
+            db, source_id="seed", target_id=f"n{i}", link_type="supports",
+            strength=s, created_at="2026-01-01",
+        )
+    rows = await memory_links.neighbors_of(db, ["seed"], exclude=["n0"], limit=1)
+    assert [r["memory_id"] for r in rows] == ["n1"]  # n0 excluded, capped to 1
+
+
+async def test_neighbors_of_never_returns_seeds_or_empty(db):
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="supports",
+        strength=0.9, created_at="2026-01-01",
+    )
+    rows = await memory_links.neighbors_of(db, ["a", "b"])
+    assert rows == []  # b is itself a seed, not a neighbor
+    assert await memory_links.neighbors_of(db, []) == []

--- a/tests/test_eval/lme_fixtures.py
+++ b/tests/test_eval/lme_fixtures.py
@@ -1,0 +1,35 @@
+"""Shared LongMemEval test fixtures (deterministic, no network, no private data).
+
+``make_linkable_instance`` builds the canonical "two near-identical evidence
+turns across two sessions" instance: the token-hashing test embedder scores
+the pair well above the 0.75 link threshold, and a ``k=1`` recall retrieves
+exactly one of them — so graph expansion is the ONLY way to reach full
+evidence coverage. Used by both the store wiring tests and the orchestration
+tests; keep the linkability recipe in ONE place.
+"""
+
+from __future__ import annotations
+
+from genesis.eval.longmemeval.dataset import LongMemEvalInstance, Turn
+
+_BASE = (
+    "I spent the whole afternoon repairing the old wooden fence around the "
+    "garden before the storm arrived"
+)
+
+
+def make_linkable_instance(qid: str = "q_link") -> LongMemEvalInstance:
+    return LongMemEvalInstance(
+        question_id=qid,
+        question_type="multi-session",
+        question="What did I repair around the garden before the storm arrived?",
+        answer="the wooden fence",
+        question_date="2023/05/23 (Tue) 19:11",
+        haystack_dates=["2023/05/01 (Mon) 10:00", "2023/05/02 (Tue) 10:00"],
+        haystack_session_ids=["s1", "s2"],
+        haystack_sessions=[
+            [Turn("user", f"{_BASE} yesterday.", True)],
+            [Turn("user", f"{_BASE} today.", True)],
+        ],
+        answer_session_ids=["a1", "a2"],
+    )

--- a/tests/test_eval/test_longmemeval_client.py
+++ b/tests/test_eval/test_longmemeval_client.py
@@ -66,3 +66,19 @@ def test_candidate_secret_paths_includes_maintree_fallback():
 
     paths = client_mod._candidate_secret_paths()
     assert Path.home() / "genesis" / "secrets.env" in paths
+
+
+def test_require_results_db_fails_fast_on_missing_db(tmp_path):
+    """A missing default results DB must fail BEFORE the paid run — get_db
+    would silently create a fresh DB lacking eval_runs (migration-only) and
+    the benchmark would crash at persistence after burning its API spend."""
+    import pytest
+
+    from genesis.eval.longmemeval.cli import require_results_db
+
+    existing = tmp_path / "genesis.db"
+    existing.touch()
+    assert require_results_db(existing) == existing
+
+    with pytest.raises(RuntimeError, match="GENESIS_REPO_ROOT"):
+        require_results_db(tmp_path / "nope" / "genesis.db")

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -151,6 +151,99 @@ async def test_run_longmemeval_dumps_jsonl_and_anchors_date(tmp_path):
     assert all("Current Date: 2023/05/23 (Tue) 19:11" in p for p in reader_prompts)
 
 
+def _multi_evidence_instance(qid: str) -> LongMemEvalInstance:
+    """Two near-identical evidence turns across two sessions: the hashing
+    embedder links them (cosine >> 0.75), and a k=1 recall retrieves exactly
+    one — so graph expansion is the ONLY way to reach full evidence coverage."""
+    base = (
+        "I spent the whole afternoon repairing the old wooden fence around the "
+        "garden before the storm arrived"
+    )
+    return LongMemEvalInstance(
+        question_id=qid,
+        question_type="multi-session",
+        question="What did I repair around the garden before the storm arrived?",
+        answer="the wooden fence",
+        question_date="2023/05/23 (Tue) 19:11",
+        haystack_dates=["2023/05/01 (Mon) 10:00", "2023/05/02 (Tue) 10:00"],
+        haystack_session_ids=["s1", "s2"],
+        haystack_sessions=[
+            [Turn("user", f"{base} yesterday.", True)],
+            [Turn("user", f"{base} today.", True)],
+        ],
+        answer_session_ids=["a1", "a2"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_graph_arm_isolated_dual_store_and_expansion(tmp_path):
+    """The graph arm runs on its OWN linked store (baseline store stays
+    link-free: activation-connectivity would otherwise tint baseline ranking),
+    and 1-hop expansion merges the linked-but-unretrieved evidence turn."""
+    import json as _json
+
+    instances = [_multi_evidence_instance("q1")]
+    client = _PromptRecordingClient()
+    summaries = await run_longmemeval(
+        instances,
+        db=None,
+        arms=[
+            Arm(QueryArm.RAW, rerank=False),
+            Arm(QueryArm.RAW, rerank=False, graph=True),
+        ],
+        k=1,
+        concurrency=1,
+        client=client,
+        embedding_provider=_HashingEmbedder(),
+        dump_dir=tmp_path,
+    )
+    base = _json.loads((tmp_path / "raw.jsonl").read_text().splitlines()[0])
+    graph = _json.loads((tmp_path / "raw+graph.jsonl").read_text().splitlines()[0])
+
+    # baseline arm: link-free store, no expansion fields populated
+    assert base["links_created"] == 0
+    assert base["expanded_ids"] == []
+    assert base["evidence_coverage"] == 0.5  # k=1 of 2 evidence turns
+
+    # graph arm: links were created at ingest on its own store
+    assert graph["links_created"] >= 1
+    # top-K metrics stay baseline-comparable...
+    assert graph["evidence_coverage"] == 0.5
+    # ...and expansion pulls the linked sibling: full coverage post-expansion
+    assert graph["expanded_ids"]
+    assert graph["evidence_coverage_final"] == 1.0
+    assert graph["evidence_recalled_final"] is True
+
+    # summary means surface the graph diagnostics
+    assert summaries["raw+graph"].scores["evidence_coverage_final_mean"] == 1.0
+    assert summaries["raw+graph"].metadata["links_created_mean"] >= 1
+    # the reader saw MORE memories in the graph arm (expanded context)
+    reader_prompts = [p for p in client.prompts if "MEMORIES:" in p]
+    assert max(p.count("\n- ") for p in reader_prompts) > min(
+        p.count("\n- ") for p in reader_prompts
+    )
+
+
+@pytest.mark.asyncio
+async def test_graph_arm_warns_on_zero_links(tmp_path, caplog):
+    """No-silent-caps parity: a graph arm whose store formed zero links must
+    say so loudly (it would otherwise silently equal its baseline twin)."""
+    instances = [_instance("q1")]  # single turn — nothing to link to
+    client = _PromptRecordingClient()
+    with caplog.at_level("WARNING", logger="genesis.eval.longmemeval"):
+        await run_longmemeval(
+            instances,
+            db=None,
+            arms=[Arm(QueryArm.RAW, rerank=False, graph=True)],
+            k=5,
+            concurrency=1,
+            client=client,
+            embedding_provider=_HashingEmbedder(),
+            dump_dir=tmp_path,
+        )
+    assert any("zero links" in r.message for r in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_run_longmemeval_runs_questions_concurrently():
     instances = [_instance(f"q{i}") for i in range(4)]

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -20,6 +20,7 @@ from genesis.eval.longmemeval.dataset import LongMemEvalInstance, Turn
 from genesis.eval.longmemeval.query import QueryArm
 from genesis.eval.longmemeval.runner import Arm, run_longmemeval
 from genesis.qdrant.collections import VECTOR_DIM
+from tests.test_eval.lme_fixtures import make_linkable_instance as _multi_evidence_instance
 
 _TOKEN = re.compile(r"[a-z0-9]+")
 
@@ -151,30 +152,6 @@ async def test_run_longmemeval_dumps_jsonl_and_anchors_date(tmp_path):
     assert all("Current Date: 2023/05/23 (Tue) 19:11" in p for p in reader_prompts)
 
 
-def _multi_evidence_instance(qid: str) -> LongMemEvalInstance:
-    """Two near-identical evidence turns across two sessions: the hashing
-    embedder links them (cosine >> 0.75), and a k=1 recall retrieves exactly
-    one — so graph expansion is the ONLY way to reach full evidence coverage."""
-    base = (
-        "I spent the whole afternoon repairing the old wooden fence around the "
-        "garden before the storm arrived"
-    )
-    return LongMemEvalInstance(
-        question_id=qid,
-        question_type="multi-session",
-        question="What did I repair around the garden before the storm arrived?",
-        answer="the wooden fence",
-        question_date="2023/05/23 (Tue) 19:11",
-        haystack_dates=["2023/05/01 (Mon) 10:00", "2023/05/02 (Tue) 10:00"],
-        haystack_session_ids=["s1", "s2"],
-        haystack_sessions=[
-            [Turn("user", f"{base} yesterday.", True)],
-            [Turn("user", f"{base} today.", True)],
-        ],
-        answer_session_ids=["a1", "a2"],
-    )
-
-
 @pytest.mark.asyncio
 async def test_graph_arm_isolated_dual_store_and_expansion(tmp_path):
     """The graph arm runs on its OWN linked store (baseline store stays
@@ -222,6 +199,98 @@ async def test_graph_arm_isolated_dual_store_and_expansion(tmp_path):
     assert max(p.count("\n- ") for p in reader_prompts) > min(
         p.count("\n- ") for p in reader_prompts
     )
+
+
+@pytest.mark.asyncio
+async def test_link_threshold_reaches_the_linker(tmp_path, caplog):
+    """The link_threshold plumbing chain (run_longmemeval -> run_question ->
+    ephemeral_store -> MemoryLinker) is real: a near-1.0 threshold makes the
+    otherwise-linkable pair form ZERO links and fires the loud warning."""
+    import json as _json
+
+    instances = [_multi_evidence_instance("q1")]
+    client = _PromptRecordingClient()
+    with caplog.at_level("WARNING", logger="genesis.eval.longmemeval"):
+        await run_longmemeval(
+            instances,
+            db=None,
+            arms=[Arm(QueryArm.RAW, rerank=False, graph=True)],
+            k=1,
+            concurrency=1,
+            client=client,
+            embedding_provider=_HashingEmbedder(),
+            dump_dir=tmp_path,
+            link_threshold=0.999,
+        )
+    rec = _json.loads((tmp_path / "raw+graph.jsonl").read_text().splitlines()[0])
+    assert rec["links_created"] == 0
+    assert rec["expanded_ids"] == []
+    assert any("zero links" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_graph_block_failure_keeps_baseline_results(tmp_path, caplog):
+    """A graph-store failure skips ONLY the graph arms: completed (judged)
+    baseline results are kept, and the skip ledger never records an attempted
+    arm as 'NOT attempted' (per-arm skip attribution)."""
+    import json as _json
+
+    instances = [_multi_evidence_instance("q1")]
+    client = _PromptRecordingClient()
+    with caplog.at_level("ERROR", logger="genesis.eval.longmemeval"):
+        summaries = await run_longmemeval(
+            instances,
+            db=None,
+            arms=[
+                Arm(QueryArm.RAW, rerank=False),
+                Arm(QueryArm.RAW, rerank=False, graph=True),
+            ],
+            k=1,
+            concurrency=1,
+            client=client,
+            embedding_provider=_HashingEmbedder(),
+            dump_dir=tmp_path,
+            link_threshold=5.0,  # invalid: MemoryLinker construction raises
+        )
+    # baseline arm: attempted and kept
+    assert summaries["raw"].total_cases == 1
+    assert summaries["raw"].skipped_cases == 0
+    base = _json.loads((tmp_path / "raw.jsonl").read_text().splitlines()[0])
+    assert "skipped" not in base
+    # graph arm: skipped, loudly
+    assert summaries["raw+graph"].skipped_cases == 1
+    graph = _json.loads((tmp_path / "raw+graph.jsonl").read_text().splitlines()[0])
+    assert graph["skipped"] is True
+    assert any("graph store block failed" in r.message for r in caplog.records)
+
+
+def test_select_arms_composition():
+    from genesis.eval.longmemeval.runner import select_arms
+
+    assert {a.label for a in select_arms()} == {
+        "raw",
+        "raw+rerank",
+        "keyword",
+        "keyword+rerank",
+    }
+    assert {a.label for a in select_arms(no_rerank=True, graph=True)} == {
+        "raw",
+        "keyword",
+        "raw+graph",
+        "keyword+graph",
+    }
+    assert len(select_arms(graph=True)) == 8
+
+
+@pytest.mark.asyncio
+async def test_duplicate_arm_labels_rejected():
+    with pytest.raises(ValueError, match="duplicate arm labels"):
+        await run_longmemeval(
+            [],
+            db=None,
+            arms=[Arm(QueryArm.RAW, rerank=False), Arm(QueryArm.RAW, rerank=False)],
+            client=object(),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_eval/test_longmemeval_runner.py
+++ b/tests/test_eval/test_longmemeval_runner.py
@@ -25,6 +25,13 @@ def test_arm_label():
     assert Arm(QueryArm.KEYWORD, rerank=True).label == "keyword+rerank"
 
 
+def test_arm_label_graph_suffix_is_deterministic():
+    # rerank before graph, always — model_profile stability across runs
+    assert Arm(QueryArm.RAW, rerank=False, graph=True).label == "raw+graph"
+    assert Arm(QueryArm.RAW, rerank=True, graph=True).label == "raw+rerank+graph"
+    assert Arm(QueryArm.KEYWORD, rerank=True, graph=True).label == "keyword+rerank+graph"
+
+
 def test_default_arms_are_the_four_combinations():
     labels = {a.label for a in default_arms()}
     assert labels == {"raw", "raw+rerank", "keyword", "keyword+rerank"}
@@ -106,6 +113,57 @@ def test_build_run_summary_empty_results_is_safe():
     )
     assert summary.total_cases == 0
     assert summary.aggregate_score == 0.0
+
+
+def test_build_run_summary_reports_graph_means_when_present():
+    results = [
+        QuestionArmResult(
+            question_id="q1",
+            question_type="multi-session",
+            arm_label="raw+graph",
+            hypothesis="h",
+            judged_correct=True,
+            evidence_recalled=True,
+            evidence_coverage=0.5,
+            evidence_coverage_final=1.0,
+            links_created=6,
+            expanded_ids=("n1", "n2"),
+            judge_raw="yes",
+        ),
+        QuestionArmResult(
+            question_id="q2",
+            question_type="multi-session",
+            arm_label="raw+graph",
+            hypothesis="h",
+            judged_correct=False,
+            evidence_recalled=True,
+            evidence_coverage=1.0,
+            evidence_coverage_final=1.0,
+            links_created=2,
+            expanded_ids=(),
+            judge_raw="no",
+        ),
+    ]
+    summary = build_run_summary(
+        arm_label="raw+graph",
+        model="m",
+        dataset="longmemeval_oracle",
+        results=results,
+    )
+    assert summary.scores["evidence_coverage_final_mean"] == 1.0
+    assert summary.metadata["links_created_mean"] == 4.0
+    assert summary.metadata["expanded_mean"] == 1.0
+
+
+def test_build_run_summary_omits_graph_means_for_baseline_arms():
+    summary = build_run_summary(
+        arm_label="raw",
+        model="m",
+        dataset="longmemeval_oracle",
+        results=[_r("q1", "multi-session", True, coverage=0.5)],
+    )
+    assert "evidence_coverage_final_mean" not in summary.scores
+    assert "links_created_mean" not in summary.metadata
 
 
 def test_build_run_summary_reports_mean_evidence_coverage():

--- a/tests/test_eval/test_longmemeval_store.py
+++ b/tests/test_eval/test_longmemeval_store.py
@@ -105,47 +105,57 @@ async def test_recall_surfaces_evidence_turn():
         assert result.evidence_memory_ids & ids
 
 
-def _linkable_instance() -> LongMemEvalInstance:
-    """Two near-identical turns → hashing-embedder cosine well above 0.75."""
-    base = (
-        "I spent the whole afternoon repairing the old wooden fence around the "
-        "garden before the storm arrived"
-    )
-    return LongMemEvalInstance(
-        question_id="q_link",
-        question_type="multi-session",
-        question="What did I repair before the storm?",
-        answer="the wooden fence",
-        question_date="2023/05/23 (Tue) 19:11",
-        haystack_dates=["2023/05/01 (Mon) 10:00", "2023/05/02 (Tue) 10:00"],
-        haystack_session_ids=["s1", "s2"],
-        haystack_sessions=[
-            [Turn("user", f"{base} yesterday.", True)],
-            [Turn("user", f"{base} today.", True)],
-        ],
-        answer_session_ids=["a1", "a2"],
-    )
-
-
 @pytest.mark.asyncio
 async def test_with_linker_ingest_creates_memory_links():
     """with_linker + auto_link wires the real MemoryLinker: near-identical
     turns link, the links land in the ephemeral SQLite, and es.db exposes it."""
+    from tests.test_eval.lme_fixtures import make_linkable_instance
+
     async with ephemeral_store(
         embedding_provider=_HashingEmbedder(),
         with_linker=True,
     ) as es:
-        await ingest_haystack(es.store, _linkable_instance(), auto_link=True)
-        cur = await es.db.execute("SELECT COUNT(*) FROM memory_links")
-        (n,) = await cur.fetchone()
-        assert n >= 1
+        await ingest_haystack(es.store, make_linkable_instance(), auto_link=True)
+        rows = await es.db.execute_fetchall("SELECT COUNT(*) FROM memory_links")
+        assert rows[0][0] >= 1
 
 
 @pytest.mark.asyncio
 async def test_default_store_has_no_linker_and_no_links():
     """Without with_linker, auto_link=True must stay a no-op (no silent links)."""
+    from tests.test_eval.lme_fixtures import make_linkable_instance
+
     async with ephemeral_store(embedding_provider=_HashingEmbedder()) as es:
-        await ingest_haystack(es.store, _linkable_instance(), auto_link=True)
-        cur = await es.db.execute("SELECT COUNT(*) FROM memory_links")
-        (n,) = await cur.fetchone()
-        assert n == 0
+        await ingest_haystack(es.store, make_linkable_instance(), auto_link=True)
+        rows = await es.db.execute_fetchall("SELECT COUNT(*) FROM memory_links")
+        assert rows[0][0] == 0
+
+
+@pytest.mark.asyncio
+async def test_expand_neighbors_skips_dangling_links():
+    """A memory_links edge whose neighbor no longer resolves must be skipped
+    silently — never crash expansion, never surface a ghost id."""
+    from genesis.db.crud import memory_links as memory_links_crud
+    from genesis.eval.longmemeval.runner import _expand_neighbors
+    from tests.test_eval.lme_fixtures import make_linkable_instance
+
+    async with ephemeral_store(
+        embedding_provider=_HashingEmbedder(),
+        with_linker=True,
+    ) as es:
+        result = await ingest_haystack(es.store, make_linkable_instance(), auto_link=True)
+        (seed_id, *_rest) = sorted(result.evidence_memory_ids)
+        # Fabricate a dangling edge: strongest link points at a ghost memory.
+        await memory_links_crud.create(
+            es.db,
+            source_id=seed_id,
+            target_id="ghost-no-such-memory",
+            link_type="supports",
+            strength=0.99,
+            created_at="2026-01-01",
+        )
+        expanded = await _expand_neighbors(es.db, [seed_id], k=5)
+        expanded_ids = {mid for mid, _ in expanded}
+        assert "ghost-no-such-memory" not in expanded_ids
+        # the real linked sibling still expands
+        assert expanded_ids & (result.evidence_memory_ids - {seed_id})

--- a/tests/test_eval/test_longmemeval_store.py
+++ b/tests/test_eval/test_longmemeval_store.py
@@ -103,3 +103,49 @@ async def test_recall_surfaces_evidence_turn():
         ids = {h.memory_id for h in hits}
         # at least one gold evidence turn is retrieved
         assert result.evidence_memory_ids & ids
+
+
+def _linkable_instance() -> LongMemEvalInstance:
+    """Two near-identical turns → hashing-embedder cosine well above 0.75."""
+    base = (
+        "I spent the whole afternoon repairing the old wooden fence around the "
+        "garden before the storm arrived"
+    )
+    return LongMemEvalInstance(
+        question_id="q_link",
+        question_type="multi-session",
+        question="What did I repair before the storm?",
+        answer="the wooden fence",
+        question_date="2023/05/23 (Tue) 19:11",
+        haystack_dates=["2023/05/01 (Mon) 10:00", "2023/05/02 (Tue) 10:00"],
+        haystack_session_ids=["s1", "s2"],
+        haystack_sessions=[
+            [Turn("user", f"{base} yesterday.", True)],
+            [Turn("user", f"{base} today.", True)],
+        ],
+        answer_session_ids=["a1", "a2"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_with_linker_ingest_creates_memory_links():
+    """with_linker + auto_link wires the real MemoryLinker: near-identical
+    turns link, the links land in the ephemeral SQLite, and es.db exposes it."""
+    async with ephemeral_store(
+        embedding_provider=_HashingEmbedder(),
+        with_linker=True,
+    ) as es:
+        await ingest_haystack(es.store, _linkable_instance(), auto_link=True)
+        cur = await es.db.execute("SELECT COUNT(*) FROM memory_links")
+        (n,) = await cur.fetchone()
+        assert n >= 1
+
+
+@pytest.mark.asyncio
+async def test_default_store_has_no_linker_and_no_links():
+    """Without with_linker, auto_link=True must stay a no-op (no silent links)."""
+    async with ephemeral_store(embedding_provider=_HashingEmbedder()) as es:
+        await ingest_haystack(es.store, _linkable_instance(), auto_link=True)
+        cur = await es.db.execute("SELECT COUNT(*) FROM memory_links")
+        (n,) = await cur.fetchone()
+        assert n == 0

--- a/tests/test_memory/test_linker.py
+++ b/tests/test_memory/test_linker.py
@@ -108,3 +108,25 @@ async def test_auto_link_empty_results(linker):
         links = await linker.auto_link("mem-1", [0.1] * 1024)
 
     assert links == []
+
+
+@pytest.mark.asyncio()
+async def test_constructor_threshold_is_auto_link_default(qdrant, db):
+    """A constructor-level similarity_threshold becomes auto_link's default —
+    the prod-shaped seam for callers (MemoryStore.store) that never pass one."""
+    linker = MemoryLinker(qdrant_client=qdrant, db=db, similarity_threshold=0.4)
+    with patch("genesis.memory.linker.search", return_value=[
+        _hit("weak", 0.5),
+    ]), patch("genesis.memory.linker.memory_links") as mock_crud:
+        mock_crud.create = AsyncMock(return_value=("s", "t"))
+        links = await linker.auto_link("mem-1", [0.1] * 1024)
+    assert len(links) == 1  # 0.5 >= 0.4 constructor default (dropped at 0.75)
+
+    with patch("genesis.memory.linker.search", return_value=[
+        _hit("weak", 0.5),
+    ]), patch("genesis.memory.linker.memory_links") as mock_crud:
+        mock_crud.create = AsyncMock(return_value=("s", "t"))
+        links = await linker.auto_link(
+            "mem-1", [0.1] * 1024, similarity_threshold=0.6,
+        )
+    assert links == []  # explicit call kwarg still overrides the constructor

--- a/tests/test_memory/test_linker.py
+++ b/tests/test_memory/test_linker.py
@@ -130,3 +130,17 @@ async def test_constructor_threshold_is_auto_link_default(qdrant, db):
             "mem-1", [0.1] * 1024, similarity_threshold=0.6,
         )
     assert links == []  # explicit call kwarg still overrides the constructor
+
+
+def test_invalid_similarity_threshold_rejected(qdrant, db):
+    """NaN/out-of-range thresholds silently densify the graph (NaN makes
+    score < t always False) — the constructor must reject them."""
+    for bad in (float("nan"), -0.1, 1.5):
+        with pytest.raises(ValueError, match="similarity_threshold"):
+            MemoryLinker(qdrant_client=qdrant, db=db, similarity_threshold=bad)
+
+
+@pytest.mark.asyncio()
+async def test_invalid_call_level_threshold_rejected(linker):
+    with pytest.raises(ValueError, match="similarity_threshold"):
+        await linker.auto_link("mem-1", [0.1] * 1024, similarity_threshold=float("nan"))

--- a/tests/test_security/test_recall_inject_coverage.py
+++ b/tests/test_security/test_recall_inject_coverage.py
@@ -46,9 +46,10 @@ _VALID = {"wrapped", "first-party", "user-facing", "display", "pipeline-internal
 
 # file (relative to src/genesis) :: enclosing function  ->  (disposition, why)
 KNOWN_RECALL_SITES: dict[str, tuple[str, str]] = {
-    "eval/longmemeval/runner.py::run_question": (
+    "eval/longmemeval/runner.py::_run_arm": (
         "first-party", "eval-harness recall against an EPHEMERAL store of "
-        "first_party LongMemEval haystack; no production trust boundary"),
+        "first_party LongMemEval haystack; no production trust boundary "
+        "(extracted from run_question for the dual-store graph arm)"),
     "mcp/memory/core.py::memory_recall": (
         "wrapped", "external items wrapped after label_result_dicts (full path)"),
     "mcp/memory/core.py::memory_proactive": (


### PR DESCRIPTION
## Summary

Sprint PR-B of the A4-improvement track: adds a **graph arm** to the LongMemEval harness to answer, with data, whether Genesis's memory graph lifts multi-session accuracy (0.33 on the definitive baseline). The arm ingests each question's haystack into a store with the real `MemoryLinker` wired (`auto_link=True`, prod-faithful later→earlier link topology), lets the retriever's existing data-driven graph boost activate, and adds the one piece prod doesn't have: **1-hop link expansion that actually merges linked-but-unretrieved neighbors into the reader context** (the MCP layer only decorates results with neighbors today).

## Key design decision (genesis-architect pre-review)

Baseline and graph arms run on **separate ephemeral stores**. Links shift ranking for every arm sharing a store through TWO channels — `_apply_graph_boost` AND activation connectivity (`activation.py` link_count term, ±15%, bidirectional, no floor gate) — so a shared linked store would tint the baselines and break comparability with published numbers. The second ingest re-embeds through the run-level embedding cache (marginal cost ≈ in-memory upserts + one local Qdrant search per turn).

## Changes

- `Arm` gains `graph`; deterministic label order (`raw+rerank+graph`) → stable `model_profile`/dump filenames.
- `ephemeral_store(with_linker=, link_threshold=)`: opt-in real `MemoryLinker`; exposes `db`. Opt-in because `MemoryStore.store()` defaults `auto_link=True` — an always-present linker would let future direct `store()` calls create links silently on baseline stores.
- `ingest_haystack(auto_link=)`: links form at insert time exactly as prod does (a post-hoc linking pass would create edges to *later* memories — a topology prod can never build).
- **New CRUD helper `memory_links.neighbors_of(db, ids, *, exclude, limit)`**: both directions, one row per neighbor via `GROUP BY` + `MAX(strength)` (the PK `(source,target,link_type)` allows multiple rows per pair; a naive UNION burns cap slots on duplicates). Canonical home next to `inter_candidate_links`; the committed prod graph/entity-recall wiring reuses it. Deliberately NOT `graph.traverse` — its process-global NetworkX cache is unsafe across the concurrent ephemeral stores this runner creates (documented in code).
- **Dual evidence metrics**: top-K (`evidence_recalled`/`evidence_coverage`, baseline-comparable) AND post-expansion (`*_final`) + `links_created`/`expanded_ids` per question in the JSONL dump, `links_created_mean`/`expanded_mean` in run metadata — splits ranking-lift (boost) from coverage-lift (expansion).
- **Zero-link graph store warns loudly** (no-silent-caps parity with the existing rerank warning) — a link-free graph arm would otherwise silently equal its baseline twin.
- `MemoryLinker`: constructor-level `similarity_threshold` becomes `auto_link`'s default — the kwarg default was unreachable from `MemoryStore.store()`'s call site (it passes no threshold). Both prod call sites are keyword-only and unchanged (default 0.75 preserved; verified: `mcp/memory/__init__.py`, `runtime/init/memory.py`).
- CLI: `--graph` ADDS a `+graph` variant of every selected arm (paired baseline-vs-graph in one run, one dump dir); `--graph-link-threshold`.

## Testing (TDD — 10 new tests written first, watched fail)

- `neighbors_of`: direction+type dedup w/ MAX(strength), exclusion, cap, seeds-never-returned, empty input (`tests/test_db/test_memory_links.py`).
- Linker: constructor threshold is auto_link's default; explicit kwarg still overrides; existing linker suites untouched and green.
- Harness: `with_linker` ingest creates `memory_links` rows in the ephemeral SQLite; default store stays link-free even with `auto_link=True` (no silent links); graph label determinism.
- **Orchestration (fakes, no network)**: dual-store isolation + expansion e2e — a 2-evidence multi-session question at k=1 shows baseline coverage 0.5 with 0 links, graph arm coverage 0.5 → `coverage_final` **1.0** via expansion of the linked sibling; zero-link warning fires on an unlinkable haystack.
- Full targeted suites: **408 passed** (eval + db links + linker + linker_typed + WS-3 coverage guards; the recall-site guard caught the `.recall()` move into `_run_arm` and the registry was updated accordingly).
- `ruff check --no-cache`: clean.

## Impact

Benchmark harness + two additive prod seams (linker constructor default, new CRUD read helper). No runtime/server behavior changes; no deploy needed. Next: link-density smoke → paired multi-session slice (raw vs raw+graph, 133 Qs) → full-500 graph run gated on ≥+5pp multi-session lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)