### PR TITLE
feat(eval): --arms label filter for LongMemEval runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Benchmark runs can now select exactly the arms they pay for.** The
+  LongMemEval harness gained `--arms` (comma-separated labels, e.g.
+  `--graph --arms raw,raw+graph`), so a paired baseline-vs-graph comparison
+  no longer forces the full four-arm spend. Unknown labels fail fast with
+  the selectable universe listed — a paid run never silently widens.
+
 - **The CC Sessions card now tells the truth, and clicking it shows why.**
   The dashboard card used to show a DB-side "active" count that routinely
   disagreed with the processes actually running, plus a bare "3/20" that

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -217,6 +217,11 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="cosine threshold for auto-linking on the graph arm's store "
         "(default: the prod linker default, 0.75)",
     )
+    lme_cmd.add_argument(
+        "--arms", default=None,
+        help="comma-separated arm labels to run (filters the selected "
+        "universe, e.g. --graph --arms raw,raw+graph); unknown labels error",
+    )
 
     eval_cmd.set_defaults(func=_run_eval_cli)
 
@@ -285,6 +290,7 @@ async def _cmd_longmemeval(args: argparse.Namespace) -> int:
         dump_dir=Path(args.dump_dir) if args.dump_dir else None,
         graph=args.graph,
         graph_link_threshold=args.graph_link_threshold,
+        arms_only=args.arms,
     )
     print_report(summaries)
     return 0

--- a/src/genesis/eval/longmemeval/__main__.py
+++ b/src/genesis/eval/longmemeval/__main__.py
@@ -56,6 +56,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="cosine threshold for auto-linking on the graph arm's store "
         "(default: the prod linker default, 0.75)",
     )
+    p.add_argument(
+        "--arms",
+        default=None,
+        help="comma-separated arm labels to run (filters the selected "
+        "universe, e.g. --graph --arms raw,raw+graph); unknown labels error",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -79,6 +85,7 @@ def main(argv: list[str] | None = None) -> int:
             dump_dir=args.dump_dir,
             graph=args.graph,
             graph_link_threshold=args.graph_link_threshold,
+            arms_only=args.arms,
         ),
     )
     print_report(summaries)

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 from genesis.eval.longmemeval.client import load_secrets
 from genesis.eval.longmemeval.dataset import filter_by_types, load_oracle
-from genesis.eval.longmemeval.runner import run_longmemeval, select_arms
+from genesis.eval.longmemeval.runner import filter_arms, run_longmemeval, select_arms
 
 if TYPE_CHECKING:
     from genesis.eval.types import EvalRunSummary
@@ -98,6 +98,7 @@ async def execute(
     dump_dir: Path | None = None,
     graph: bool = False,
     graph_link_threshold: float | None = None,
+    arms_only: str | None = None,
 ) -> dict[str, EvalRunSummary]:
     """Load the dataset, run the harness, persist (optionally), return summaries.
 
@@ -106,7 +107,9 @@ async def execute(
     questions", not "temporal questions among the first 20".
 
     ``graph`` ADDS a ``+graph`` variant of every selected arm (paired
-    baseline-vs-graph comparison in one run, one dump dir).
+    baseline-vs-graph comparison in one run, one dump dir). ``arms_only``
+    (comma-separated labels) then filters that universe down — the budget
+    lever for single-arm or paired runs.
     """
     load_secrets()
     instances = load_oracle(dataset_path)
@@ -117,6 +120,8 @@ async def execute(
     logger.info("loaded %d questions from %s", len(instances), dataset_path)
 
     arms = select_arms(no_rerank=no_rerank, graph=graph)
+    if arms_only:
+        arms = filter_arms(arms, arms_only)
     reranker = None if no_rerank else build_reranker()
 
     db = None

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -120,7 +120,9 @@ async def execute(
     logger.info("loaded %d questions from %s", len(instances), dataset_path)
 
     arms = select_arms(no_rerank=no_rerank, graph=graph)
-    if arms_only:
+    if arms_only is not None:
+        # An empty string still reaches filter_arms and raises there — a paid
+        # run must never silently widen back to the full arm universe.
         arms = filter_arms(arms, arms_only)
     reranker = None if no_rerank else build_reranker()
 

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -108,6 +108,26 @@ def select_arms(*, no_rerank: bool = False, graph: bool = False) -> list[Arm]:
     return arms
 
 
+def filter_arms(arms: list[Arm], only: str) -> list[Arm]:
+    """Keep only the arms whose label appears in the CSV ``only``.
+
+    Filters the already-selected universe (``select_arms`` output), preserving
+    its order. Raises ``ValueError`` on labels outside that universe (e.g. a
+    ``+graph`` label without ``--graph``) and on an empty selection — a paid
+    run must never silently fall back to more arms than asked for.
+    """
+    wanted = {label.strip() for label in only.split(",") if label.strip()}
+    if not wanted:
+        msg = "no arms selected: --arms was empty"
+        raise ValueError(msg)
+    available = [a.label for a in arms]
+    unknown = sorted(wanted - set(available))
+    if unknown:
+        msg = f"unknown arm labels {unknown}; selectable here: {available}"
+        raise ValueError(msg)
+    return [a for a in arms if a.label in wanted]
+
+
 @dataclass(frozen=True)
 class QuestionArmResult:
     question_id: str

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -304,6 +304,37 @@ def test_filter_arms_rejects_unknown_and_empty():
 
 
 @pytest.mark.asyncio
+async def test_execute_empty_arms_string_raises_not_widens(tmp_path):
+    """`--arms ""` (e.g. an unset shell var) must raise, NEVER silently fall
+    back to the full unfiltered universe — that would widen paid spend."""
+    import json as _json
+
+    from genesis.eval.longmemeval.cli import execute
+
+    dataset = tmp_path / "oracle.json"
+    dataset.write_text(
+        _json.dumps(
+            [
+                {
+                    "question_id": "q1",
+                    "question_type": "single-session-user",
+                    "question": "q?",
+                    "answer": "a",
+                    "haystack_sessions": [],
+                },
+            ],
+        ),
+    )
+    with pytest.raises(ValueError, match="no arms selected"):
+        await execute(
+            dataset_path=dataset,
+            no_rerank=True,
+            persist=False,
+            arms_only="",
+        )
+
+
+@pytest.mark.asyncio
 async def test_duplicate_arm_labels_rejected():
     with pytest.raises(ValueError, match="duplicate arm labels"):
         await run_longmemeval(

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -282,6 +282,27 @@ def test_select_arms_composition():
     assert len(select_arms(graph=True)) == 8
 
 
+def test_filter_arms_selects_by_label_preserving_order():
+    from genesis.eval.longmemeval.runner import filter_arms, select_arms
+
+    arms = select_arms(no_rerank=True, graph=True)
+    picked = filter_arms(arms, "raw,raw+graph")
+    assert [a.label for a in picked] == ["raw", "raw+graph"]
+    # whitespace tolerated; output keeps the arm-universe order, not CSV order
+    assert [a.label for a in filter_arms(arms, " keyword , raw ")] == ["raw", "keyword"]
+
+
+def test_filter_arms_rejects_unknown_and_empty():
+    from genesis.eval.longmemeval.runner import filter_arms, select_arms
+
+    arms = select_arms(no_rerank=True)  # raw, keyword only
+    # unknown label names the selectable universe (raw+graph needs --graph)
+    with pytest.raises(ValueError, match="raw\\+graph"):
+        filter_arms(arms, "raw+graph")
+    with pytest.raises(ValueError, match="no arms selected"):
+        filter_arms(arms, " , ")
+
+
 @pytest.mark.asyncio
 async def test_duplicate_arm_labels_rejected():
     with pytest.raises(ValueError, match="duplicate arm labels"):


### PR DESCRIPTION
## What

Adds `--arms` (comma-separated arm labels) to the LongMemEval harness — both `python -m genesis.eval.longmemeval` and `genesis eval longmemeval` — filtering the `select_arms` universe down to exactly the requested arms.

## Why

The merged graph-arm CLI (#1057) can only widen the arm set (`--no-rerank --graph` = 4 arms). A paired baseline-vs-graph full-500 run therefore costs ~2× what the experiment needs. `--arms raw,raw+graph` is the budget lever: single-arm re-baselines and paired comparisons at exactly the intended spend.

## Design

- `filter_arms(arms, only)` in `runner.py` next to `select_arms`: order-preserving filter over the already-selected universe.
- Unknown labels raise `ValueError` naming the selectable universe (asking for `raw+graph` without `--graph` is an explicit error, not a silent skip).
- Empty selection raises — a paid run never silently falls back to more arms than asked for.

## Tests

`tests/test_eval/test_longmemeval_orchestration.py`: label selection + order preservation + whitespace tolerance; unknown-label and empty-selection rejection. 10/10 pass, `ruff check --no-cache` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)