### PR TITLE
feat(resilience): adaptive OOM resilience — swap + systemd-oomd, codified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   no longer forces the full four-arm spend. Unknown labels fail fast with
   the selectable universe listed — a paid run never silently widens.
 
+- **A memory spike now degrades gracefully instead of wedging the machine.**
+  On systems that ran out of memory with no swap and no userspace OOM killer,
+  one greedy process could drag the whole box into unrecoverable thrash —
+  load in the hundreds, SSH dead, everything down together. Installs now set
+  up systemd-oomd with pressure-percentage kill policies (adaptive to any
+  machine size, applied automatically on bootstrap and on your next update,
+  skipped cleanly where systemd/oomd/PSI aren't available), the Genesis
+  server marks itself `avoid` so the greedy session tree dies first, managed
+  container installs get swap enabled (`limits.memory.swap`), and setup warns
+  with exact remediation when swap is missing or disabled. The infrastructure
+  profile records the swap/oomd state as facts, so an unprotected install is
+  flagged in `INFRASTRUCTURE.md`. Runbook: `docs/reference/memory-resilience.md`.
+
 - **The CC Sessions card now tells the truth, and clicking it shows why.**
   The dashboard card used to show a DB-side "active" count that routinely
   disagreed with the processes actually running, plus a bare "3/20" that

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -348,7 +348,7 @@ radius) and the container-side Sentinel (CC-driven diagnosis/repair).
 ```yaml subsystem-map
 entry: guardian-sentinel
 modules: [guardian, sentinel]
-verified: 3d5234b9 2026-07-13
+verified: 859ec256 2026-07-14
 ```
 
 - **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
@@ -564,7 +564,7 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, infra_profile, env.py, _config_overlay.py]
-verified: 3d5234b9 2026-07-13
+verified: 859ec256 2026-07-14
 ```
 
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
@@ -663,7 +663,12 @@ verified: 3d5234b9 2026-07-13
   + the user-CLAUDE.md `container-specs` block (content owner:
   `infra_profile/claude_md.py`; update.sh invokes `--claude-md-block`).
   Distinct from `observability/snapshots/infrastructure.py` (dynamic health) —
-  don't merge them.
+  don't merge them. Memory-resilience invariants are first-class facts:
+  container `cgroup_memory_swap_max` (tri-state — "0" IS the 2026-07 wedge
+  state) + `oomd_user_slice_kill` (config-plane scan of user.slice.d drop-ins,
+  laid down by `scripts/lib/memory_resilience.sh` from bootstrap/update) and
+  host-plane `swap_total_kb`, so the annotation layer flags unprotected
+  installs (see docs/reference/memory-resilience.md).
 - **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h
   encrypted `scripts/backup.sh` timer).
 - **util/**: `atomic_write_text`, `tracked_task` (logs swallowed exceptions),

--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -1,0 +1,82 @@
+# Memory Resilience — swap + systemd-oomd, the adaptive way
+
+## The invariant
+
+**A memory spike must degrade into swap pressure and a userspace OOM kill of
+the greedy process tree — never into load-100 D-state thrash that wedges the
+whole machine.**
+
+Genesis is a process-heavy system: a cognitive server, per-session Claude Code
+trees, MCP servers, indexers. On a box with no swap and no userspace OOM
+killer, the first component to over-allocate doesn't fail alone — the kernel
+enters direct-reclaim thrash, load climbs into the tens or hundreds, SSH stops
+answering, and *everything* on the machine dies together. One incident series
+(2026-07) produced exactly this failure mode four times from four unrelated
+causes; the common factor was the missing relief valve, not any single leak.
+
+The fingerprint, if you're diagnosing it live:
+
+- load average 50–130 with mostly-idle CPUs (processes stuck in `D` state)
+- SSH connections drop or hang; `incus exec` hangs from the host
+- inside a container: `cat /sys/fs/cgroup/memory.swap.max` shows `0`
+- `swapon --show` empty on the host/VM
+
+## What Genesis sets up (and what it only warns about)
+
+`scripts/lib/memory_resilience.sh` runs from `bootstrap.sh` on fresh installs
+and from every `update.sh` (which re-runs bootstrap), so existing installs
+retrofit automatically. It is idempotent and **adaptive — every threshold is a
+pressure percentage, never an absolute byte value**, so the same config
+right-sizes from a small VPS to a large workstation:
+
+- `/etc/systemd/system/user.slice.d/genesis-oomd.conf` —
+  `ManagedOOMMemoryPressure=kill` at **60%** memory-pressure (PSI) on the
+  user slice: the backstop monitor.
+- `/etc/systemd/system/user@.service.d/genesis-oomd.conf` — `kill` for the
+  per-user manager. In practice this is the operative monitor (many distros
+  ship a 50% default limit for it; ours guarantees `kill` where the distro
+  ships `auto` or nothing).
+- `/etc/systemd/oomd.conf.d/genesis.conf` — swap-use limit 90%, default
+  pressure limit 60%, 20s duration.
+- `genesis-server.service` carries `ManagedOOMPreference=avoid` (plus the
+  kernel-side `OOMScoreAdjust=-500`), so oomd prefers killing the greedy
+  session tree over the cognitive core. `avoid` is honored by the per-user
+  monitor (same-UID cgroup ownership) — see systemd.resource-control(5).
+
+Graceful degradation: no systemd, no `systemd-oomd`, no kernel PSI, or no
+non-interactive sudo each produce a one-line skip note, never a failure.
+
+**Swap itself is verified, not created.** The setup warns — with the exact
+remediation for the detected vantage — because the knob is never local:
+
+- **Inside a container** (LXC/Incus): swap capability is granted by the host.
+  Fix on the host: `incus config set <container> limits.memory.swap true`,
+  and make sure the host itself has swap. `host-setup.sh` does both for
+  managed installs (and warns if the host is swapless).
+- **Bare metal / VM**: create a swapfile or LV sized to taste. Even a few
+  GiB turns the OOM cliff into a ramp.
+
+## How the body schema surfaces it
+
+The infrastructure profile (`INFRASTRUCTURE.md`, `infra_profile` package)
+records the invariant as facts, so drift is observed and the annotation layer
+flags unprotected installs:
+
+| Fact | Plane | Healthy | Wedge-defect |
+|---|---|---|---|
+| `cgroup_memory_swap_max` | container | `"max"` (or an int) | `0` |
+| `oomd_user_slice_kill` | container | `true` | `false` |
+| `swap_total_kb` | host | > 0 | `0` |
+
+## Notes
+
+- Inside a container, systemd-oomd's swap-based kills are inert (the
+  container can't see swap devices); the **pressure** path is the active
+  mechanism. The swap limit line matters on bare/VM installs.
+- These kills are a last line of defense, not a workload manager. If oomd
+  ever kills `genesis-server` itself, the pressure limit is mis-tuned for
+  that machine — raise the percentage or investigate what drove sustained
+  PSI, and file the incident.
+- Quality-over-cost still applies: nothing here throttles or degrades
+  Genesis under pressure; it only decides *what dies first* when the machine
+  is already out of headroom.

--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -70,6 +70,13 @@ flags unprotected installs:
 
 ## Notes
 
+- This userspace layer is complementary to the **kernel-side** OOM tuning
+  Genesis already applies on guardian hosts
+  (`/etc/sysctl.d/99-genesis-oom-tuning.conf` via `install_guardian.sh` /
+  `host-setup.sh`: `vm.min_free_kbytes`, `vm.watermark_scale_factor`,
+  `vm.oom_kill_allocating_task`). The sysctls shape *kernel reclaim and the
+  kernel OOM killer*; systemd-oomd acts *earlier*, on pressure, in userspace.
+  Tune them as two layers of one defense, not competing knobs.
 - Inside a container, systemd-oomd's swap-based kills are inert (the
   container can't see swap devices); the **pressure** path is the active
   mechanism. The swap limit line matters on bare/VM installs.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -646,9 +646,15 @@ fi
 echo
 
 # --- Memory resilience (systemd-oomd pressure-kill + swap invariant) ---
-# shellcheck source=lib/memory_resilience.sh
-source "$SCRIPT_DIR/lib/memory_resilience.sh"
-memory_resilience_apply
+# Guarded: a tree mid-update/partial checkout without the lib must degrade,
+# not abort bootstrap under set -e (the lib's own never-abort contract).
+if [[ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]]; then
+    # shellcheck source=lib/memory_resilience.sh
+    source "$SCRIPT_DIR/lib/memory_resilience.sh"
+    memory_resilience_apply
+else
+    echo "  WARNING: lib/memory_resilience.sh missing — skipping OOM-resilience setup"
+fi
 echo
 
 # --- Systemd service sync ---

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -645,6 +645,12 @@ else
 fi
 echo
 
+# --- Memory resilience (systemd-oomd pressure-kill + swap invariant) ---
+# shellcheck source=lib/memory_resilience.sh
+source "$SCRIPT_DIR/lib/memory_resilience.sh"
+memory_resilience_apply
+echo
+
 # --- Systemd service sync ---
 echo "--- Syncing systemd service files ---"
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -552,6 +552,20 @@ incus config set "$CONTAINER_NAME" boot.autostart true
 incus config set "$CONTAINER_NAME" boot.autostart.delay 5
 echo "  + boot.autostart enabled (container survives host reboots)"
 
+# Let the container's memory cgroup swap to host swap. Without this the
+# container gets memory.swap.max=0 and any memory spike becomes load-100
+# D-state thrash that wedges the box instead of degrading into swap pressure
+# (root cause of the 2026-07 incident series). Applied outside the creation
+# block so re-running host-setup retrofits existing containers too.
+incus config set "$CONTAINER_NAME" limits.memory.swap true
+echo "  + limits.memory.swap enabled (memory spikes degrade into swap, not thrash)"
+if [ -z "$(swapon --noheadings --show 2>/dev/null)" ]; then
+    echo "  WARNING: this host has NO swap — limits.memory.swap has nothing to swap to."
+    echo "           Add host swap (swapfile or LV); even a few GiB turns the container's"
+    echo "           OOM cliff into a ramp. Example: fallocate -l 4G /swap.img &&"
+    echo "           chmod 600 /swap.img && mkswap /swap.img && swapon /swap.img (+ fstab)."
+fi
+
 # ── Split-disk: ensure container home has adequate space ─────────────────────
 # If /home is on a separate larger disk but the Incus pool was initialized on
 # root (common when Incus was pre-installed before host-setup.sh ran, e.g. on

--- a/scripts/lib/memory_resilience.sh
+++ b/scripts/lib/memory_resilience.sh
@@ -33,7 +33,8 @@ MEMRES_CGROUP_SWAP_MAX="${MEMRES_CGROUP_SWAP_MAX:-/sys/fs/cgroup/memory.swap.max
 
 # The pressure policy, mirrored from the config proven live on the reference
 # install (2026-07-13 incident fix). user.slice is the backstop at 60%; the
-# per-user manager (user@N.service) is the operative monitor — Ubuntu ships a
+# per-user manager (systemd's per-user instance units) is the operative
+# monitor — Ubuntu ships a
 # kill@50% default for it, and our drop-in guarantees `kill` on distros that
 # ship `auto` or nothing (limit then falls back to DefaultMemoryPressureLimit).
 # SwapUsedLimit only acts where oomd can see swap (bare/VM installs; inside a
@@ -43,16 +44,22 @@ _MEMRES_USER_SERVICE_CONF=$'[Service]\nManagedOOMMemoryPressure=kill'
 _MEMRES_OOMD_CONF=$'[OOM]\nSwapUsedLimit=90%\nDefaultMemoryPressureLimit=60%\nDefaultMemoryPressureDurationSec=20s'
 
 # _memres_install_dropin <abs-path> <content> — write-if-different via sudo.
-# Prints "changed" when it wrote. Never fails the caller.
+# Sets _MEMRES_CHANGED=1 when it wrote (a variable, NOT stdout — capturing
+# stdout as the change flag would let any future diagnostic echo masquerade
+# as "changed" and churn systemd on idempotent runs). A failed write WARNS
+# instead of falling through to "already in place". Never fails the caller.
 _memres_install_dropin() {
     local path="$1" content="$2"
     if [[ "$(sudo cat "$path" 2>/dev/null)" == "$content" ]]; then
         return 0
     fi
-    sudo mkdir -p "$(dirname "$path")" 2>/dev/null || return 0
-    if printf '%s\n' "$content" | sudo tee "$path" >/dev/null 2>&1; then
-        echo "changed"
+    if ! sudo mkdir -p "$(dirname "$path")" 2>/dev/null \
+        || ! printf '%s\n' "$content" | sudo tee "$path" >/dev/null 2>&1; then
+        echo "  WARNING: could not write $path (read-only /etc?) — oomd policy NOT applied."
+        _MEMRES_FAILED=1
+        return 0
     fi
+    _MEMRES_CHANGED=1
     return 0
 }
 
@@ -66,13 +73,12 @@ _memres_swap_check() {
     fi
 
     if [[ "$swap_max" == "0" ]]; then
+        echo "  WARNING: cgroup memory.swap.max is 0 — memory spikes will thrash instead of swapping."
         if systemd-detect-virt --container >/dev/null 2>&1; then
-            echo "  WARNING: cgroup memory.swap.max is 0 — memory spikes will thrash instead of swapping."
             echo "           Fix on the HOST (not from inside this container):"
             echo "             incus config set <container-name> limits.memory.swap true"
             echo "           and ensure the host itself has swap (swapon --show)."
         else
-            echo "  WARNING: cgroup memory.swap.max is 0 — memory spikes will thrash instead of swapping."
             echo "           Remove the swap.max=0 override (systemctl show -p MemorySwapMax) or re-enable swap."
         fi
         return 0
@@ -110,19 +116,26 @@ memory_resilience_apply() {
         return 0
     fi
 
-    local changed=""
-    [[ -n "$(_memres_install_dropin "$MEMRES_ETC_ROOT/systemd/system/user.slice.d/genesis-oomd.conf" "$_MEMRES_USER_SLICE_CONF")" ]] && changed=1
-    [[ -n "$(_memres_install_dropin "$MEMRES_ETC_ROOT/systemd/system/user@.service.d/genesis-oomd.conf" "$_MEMRES_USER_SERVICE_CONF")" ]] && changed=1
-    [[ -n "$(_memres_install_dropin "$MEMRES_ETC_ROOT/systemd/oomd.conf.d/genesis.conf" "$_MEMRES_OOMD_CONF")" ]] && changed=1
+    _MEMRES_CHANGED=""
+    _MEMRES_FAILED=""
+    _memres_install_dropin "$MEMRES_ETC_ROOT/systemd/system/user.slice.d/genesis-oomd.conf" "$_MEMRES_USER_SLICE_CONF"
+    _memres_install_dropin "$MEMRES_ETC_ROOT/systemd/system/user@.service.d/genesis-oomd.conf" "$_MEMRES_USER_SERVICE_CONF"
+    _memres_install_dropin "$MEMRES_ETC_ROOT/systemd/oomd.conf.d/genesis.conf" "$_MEMRES_OOMD_CONF"
 
-    if [[ -n "$changed" ]]; then
+    if [[ -n "$_MEMRES_CHANGED" ]]; then
         # daemon-reload propagates the ManagedOOM* unit properties to oomd;
-        # the oomd restart picks up oomd.conf.d. Best-effort: a hiccup here
-        # must never abort bootstrap/update — the drop-ins are on disk and
-        # the next boot applies them regardless.
+        # the restart picks up oomd.conf.d (and starts oomd if stopped, so a
+        # separate `enable --now` would just double the start transition).
+        # Runs even on a partial apply — whatever DID land should take effect.
+        # Best-effort: a hiccup here must never abort bootstrap/update — the
+        # drop-ins are on disk and the next boot applies them regardless.
         sudo systemctl daemon-reload 2>/dev/null || true
-        sudo systemctl enable --now systemd-oomd 2>/dev/null || true
+        sudo systemctl enable systemd-oomd 2>/dev/null || true
         sudo systemctl restart systemd-oomd 2>/dev/null || true
+    fi
+    if [[ -n "$_MEMRES_FAILED" ]]; then
+        echo "  systemd-oomd policy NOT fully applied — see warnings above."
+    elif [[ -n "$_MEMRES_CHANGED" ]]; then
         echo "  systemd-oomd pressure-kill policy applied (user.slice kill @60% PSI; per-user manager kill)."
     else
         echo "  systemd-oomd pressure-kill policy already in place."

--- a/scripts/lib/memory_resilience.sh
+++ b/scripts/lib/memory_resilience.sh
@@ -1,0 +1,133 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# memory_resilience_apply — adaptive OOM-resilience setup for the machine
+# Genesis runs on. Codifies the 2026-07 blast-radius Layer-3 fix: a memory
+# spike must degrade into swap pressure + a userspace OOM kill of the greedy
+# process tree, never into load-100 D-state thrash that wedges the box (the
+# failure mode behind four separate incidents: no swap + no oomd meant the
+# kernel had nowhere to reclaim to and nothing killed the offender).
+#
+# Adaptive by design (no absolute byte limits anywhere):
+#   - systemd-oomd acts on PSI memory-pressure PERCENTAGES, so the same
+#     config right-sizes from an 8 GiB VPS to a 64 GiB workstation.
+#   - Swap itself is only VERIFIED here, never created: inside a container
+#     the knob lives on the host (incus `limits.memory.swap`), and on bare
+#     metal creating swap is an operator decision (disk layout varies).
+#     We warn with the exact remediation for the detected vantage.
+#
+# Degrades gracefully: no systemd, no systemd-oomd, no PSI, or no usable
+# sudo each produce a one-line skip note and rc=0 — this must never abort
+# bootstrap.sh/update.sh under `set -e`.
+#
+# Sourced by scripts/bootstrap.sh (fresh installs) and scripts/update.sh
+# (existing installs retrofit on their next update). Idempotent: unchanged
+# drop-ins are left untouched and produce no systemd churn.
+#
+# Test seams (defaults are the real system paths; pytest overrides these and
+# stubs sudo/systemctl/swapon/systemd-detect-virt on PATH):
+MEMRES_ETC_ROOT="${MEMRES_ETC_ROOT:-/etc}"
+MEMRES_SYSTEMD_RUNTIME_DIR="${MEMRES_SYSTEMD_RUNTIME_DIR:-/run/systemd/system}"
+MEMRES_PSI_FILE="${MEMRES_PSI_FILE:-/proc/pressure/memory}"
+MEMRES_CGROUP_SWAP_MAX="${MEMRES_CGROUP_SWAP_MAX:-/sys/fs/cgroup/memory.swap.max}"
+
+# The pressure policy, mirrored from the config proven live on the reference
+# install (2026-07-13 incident fix). user.slice is the backstop at 60%; the
+# per-user manager (user@N.service) is the operative monitor — Ubuntu ships a
+# kill@50% default for it, and our drop-in guarantees `kill` on distros that
+# ship `auto` or nothing (limit then falls back to DefaultMemoryPressureLimit).
+# SwapUsedLimit only acts where oomd can see swap (bare/VM installs; inside a
+# container the host owns swap and the pressure path is the active mechanism).
+_MEMRES_USER_SLICE_CONF=$'[Slice]\nManagedOOMMemoryPressure=kill\nManagedOOMMemoryPressureLimit=60%'
+_MEMRES_USER_SERVICE_CONF=$'[Service]\nManagedOOMMemoryPressure=kill'
+_MEMRES_OOMD_CONF=$'[OOM]\nSwapUsedLimit=90%\nDefaultMemoryPressureLimit=60%\nDefaultMemoryPressureDurationSec=20s'
+
+# _memres_install_dropin <abs-path> <content> — write-if-different via sudo.
+# Prints "changed" when it wrote. Never fails the caller.
+_memres_install_dropin() {
+    local path="$1" content="$2"
+    if [[ "$(sudo cat "$path" 2>/dev/null)" == "$content" ]]; then
+        return 0
+    fi
+    sudo mkdir -p "$(dirname "$path")" 2>/dev/null || return 0
+    if printf '%s\n' "$content" | sudo tee "$path" >/dev/null 2>&1; then
+        echo "changed"
+    fi
+    return 0
+}
+
+# _memres_swap_check — warn (never fail) when the swap invariant is violated.
+# The invariant: the memory cgroup must be ABLE to swap (swap.max != 0) and,
+# outside containers, a swap device must exist. Violation = the wedge defect.
+_memres_swap_check() {
+    local swap_max=""
+    if [[ -r "$MEMRES_CGROUP_SWAP_MAX" ]]; then
+        swap_max="$(cat "$MEMRES_CGROUP_SWAP_MAX" 2>/dev/null)"
+    fi
+
+    if [[ "$swap_max" == "0" ]]; then
+        if systemd-detect-virt --container >/dev/null 2>&1; then
+            echo "  WARNING: cgroup memory.swap.max is 0 — memory spikes will thrash instead of swapping."
+            echo "           Fix on the HOST (not from inside this container):"
+            echo "             incus config set <container-name> limits.memory.swap true"
+            echo "           and ensure the host itself has swap (swapon --show)."
+        else
+            echo "  WARNING: cgroup memory.swap.max is 0 — memory spikes will thrash instead of swapping."
+            echo "           Remove the swap.max=0 override (systemctl show -p MemorySwapMax) or re-enable swap."
+        fi
+        return 0
+    fi
+
+    # Bare/VM vantage: no swap device at all is the same defect one layer down.
+    if ! systemd-detect-virt --container >/dev/null 2>&1; then
+        if [[ -z "$(swapon --noheadings --show 2>/dev/null)" ]]; then
+            echo "  WARNING: no swap device configured — memory pressure has nowhere to reclaim to."
+            echo "           Add swap (swapfile or LV) sized to taste; even a few GiB turns the OOM cliff into a ramp."
+        fi
+    fi
+    return 0
+}
+
+# memory_resilience_apply — the entrypoint. Always returns 0.
+memory_resilience_apply() {
+    echo "--- Memory resilience (systemd-oomd + swap invariant) ---"
+
+    if [[ ! -d "$MEMRES_SYSTEMD_RUNTIME_DIR" ]]; then
+        echo "  Skipped: not a systemd system (no $MEMRES_SYSTEMD_RUNTIME_DIR)."
+        return 0
+    fi
+    if ! systemctl list-unit-files systemd-oomd.service --no-legend 2>/dev/null | grep -q systemd-oomd; then
+        echo "  Skipped: systemd-oomd not available on this system (install the systemd-oomd package to enable pressure-kill protection)."
+        return 0
+    fi
+    if [[ ! -f "$MEMRES_PSI_FILE" ]]; then
+        echo "  Skipped: kernel PSI not available ($MEMRES_PSI_FILE missing) — systemd-oomd needs pressure accounting."
+        return 0
+    fi
+    if ! sudo -n true 2>/dev/null; then
+        echo "  Skipped: sudo unavailable non-interactively. To apply manually:"
+        echo "           sudo bash -c 'source scripts/lib/memory_resilience.sh && memory_resilience_apply'"
+        return 0
+    fi
+
+    local changed=""
+    [[ -n "$(_memres_install_dropin "$MEMRES_ETC_ROOT/systemd/system/user.slice.d/genesis-oomd.conf" "$_MEMRES_USER_SLICE_CONF")" ]] && changed=1
+    [[ -n "$(_memres_install_dropin "$MEMRES_ETC_ROOT/systemd/system/user@.service.d/genesis-oomd.conf" "$_MEMRES_USER_SERVICE_CONF")" ]] && changed=1
+    [[ -n "$(_memres_install_dropin "$MEMRES_ETC_ROOT/systemd/oomd.conf.d/genesis.conf" "$_MEMRES_OOMD_CONF")" ]] && changed=1
+
+    if [[ -n "$changed" ]]; then
+        # daemon-reload propagates the ManagedOOM* unit properties to oomd;
+        # the oomd restart picks up oomd.conf.d. Best-effort: a hiccup here
+        # must never abort bootstrap/update — the drop-ins are on disk and
+        # the next boot applies them regardless.
+        sudo systemctl daemon-reload 2>/dev/null || true
+        sudo systemctl enable --now systemd-oomd 2>/dev/null || true
+        sudo systemctl restart systemd-oomd 2>/dev/null || true
+        echo "  systemd-oomd pressure-kill policy applied (user.slice kill @60% PSI; per-user manager kill)."
+    else
+        echo "  systemd-oomd pressure-kill policy already in place."
+    fi
+
+    _memres_swap_check
+    return 0
+}

--- a/scripts/systemd/genesis-server.service.template
+++ b/scripts/systemd/genesis-server.service.template
@@ -23,6 +23,11 @@ Environment=PATH=__VENV__/bin:__CC_BIN_DIR__:__HOME__/.local/bin:/usr/local/bin:
 MemoryMax=80%
 LimitNOFILE=65536
 OOMScoreAdjust=-500
+# systemd-oomd counterpart of OOMScoreAdjust: when the per-user manager's
+# pressure monitor picks a kill candidate, prefer the greedy CC/MCP tree over
+# the server. (Effective for the user@N monitor — same-UID cgroup owner — but
+# ignored by the root-owned user.slice monitor; see systemd.resource-control(5).)
+ManagedOOMPreference=avoid
 StandardOutput=journal
 StandardError=journal
 NoNewPrivileges=yes

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -960,6 +960,17 @@ echo "--- Running bootstrap ---"
 echo "  Bootstrap complete"
 echo ""
 
+# ── Memory resilience — re-run VISIBLY. Bootstrap already applied it, but
+# its output is eaten by the `tail -10` above, and the update path is exactly
+# where an existing swapless install retrofits and must SEE the warn-only
+# swap-invariant output. Idempotent: already-applied → one no-op line.
+if [ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]; then
+    # shellcheck source=lib/memory_resilience.sh
+    . "$SCRIPT_DIR/lib/memory_resilience.sh"
+    memory_resilience_apply
+    echo ""
+fi
+
 # ── Verify Genesis is importable ──────────────────────────
 if ! "$VENV_DIR/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/dev/null; then
     _do_rollback "Genesis not importable after bootstrap"

--- a/src/genesis/guardian/host_profile.py
+++ b/src/genesis/guardian/host_profile.py
@@ -59,7 +59,7 @@ def _read_meminfo() -> dict:
     try:
         for line in Path("/proc/meminfo").read_text().splitlines():
             key, _, rest = line.partition(":")
-            if key in ("MemTotal", "MemAvailable"):
+            if key in ("MemTotal", "MemAvailable", "SwapTotal", "SwapFree"):
                 out[key] = int(rest.split()[0])  # kB
     except (OSError, ValueError, IndexError):
         pass
@@ -74,6 +74,12 @@ def _host_system() -> dict:
         section["mem_total_kb"] = mem["MemTotal"]
     if "MemAvailable" in mem:
         section["mem_available_kb"] = mem["MemAvailable"]
+    # Host swap is the container's pressure-relief valve (the container's own
+    # meminfo always shows 0): total is topology, free is a reading.
+    if "SwapTotal" in mem:
+        section["swap_total_kb"] = mem["SwapTotal"]
+    if "SwapFree" in mem:
+        section["swap_free_kb"] = mem["SwapFree"]
     section["nproc"] = os.cpu_count()
     uname = platform.uname()
     section["kernel_release"] = uname.release

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -119,6 +119,38 @@ def _read_cgroup_memory_max(sys_root: Path) -> int | None:
         return None
 
 
+def _read_cgroup_memory_swap_max(sys_root: Path) -> int | str | None:
+    """Unlike memory.max (where "max" collapses to None = no limit), the
+    swap knob keeps its raw tri-state: "0" IS the incident state (memory
+    spikes thrash instead of swapping — the 2026-07 wedge series), "max"
+    is the healthy state, None means unreadable/cgroup-v1."""
+    raw = _read(sys_root / "fs/cgroup/memory.swap.max")
+    if raw is None or raw == "max":
+        return raw
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _oomd_user_slice_kill(etc_root: Path) -> bool:
+    """Whether a systemd-oomd pressure-kill policy is configured for
+    user.slice (ManagedOOMMemoryPressure=kill in any user.slice.d drop-in,
+    e.g. the genesis-oomd.conf that scripts/lib/memory_resilience.sh lays
+    down). Config-plane deliberately: the runtime signal candidate (the
+    /run/systemd/io.systemd.ManagedOOM socket) was probed live and predates
+    protection — it means "oomd installed", not "policy configured"."""
+    dropin_dir = etc_root / "systemd/system/user.slice.d"
+    if not dropin_dir.is_dir():
+        return False
+    for conf in sorted(dropin_dir.glob("*.conf")):
+        raw = _read(conf) or ""
+        for line in raw.splitlines():
+            if line.split("#", 1)[0].strip().replace(" ", "") == "ManagedOOMMemoryPressure=kill":
+                return True
+    return False
+
+
 def _detect_root_device(proc_root: Path) -> str | None:
     """Block device major:minor for the root filesystem (via mountinfo)."""
     raw = _read(proc_root / "self/mountinfo") or ""
@@ -224,12 +256,15 @@ async def collect_cpu(
 async def collect_memory(
     proc_root: Path = Path("/proc"),
     sys_root: Path = Path("/sys"),
+    etc_root: Path = Path("/etc"),
 ) -> SectionResult:
-    """Cgroup limit, swap/zram config, THP; availability as metrics."""
+    """Cgroup limit, swap/zram config, oomd policy, THP; availability as metrics."""
     facts: dict = {}
     metrics: dict = {}
 
     facts["cgroup_memory_max"] = _read_cgroup_memory_max(sys_root)
+    facts["cgroup_memory_swap_max"] = _read_cgroup_memory_swap_max(sys_root)
+    facts["oomd_user_slice_kill"] = _oomd_user_slice_kill(etc_root)
 
     meminfo = _read(proc_root / "meminfo") or ""
     mem: dict[str, int] = {}
@@ -300,7 +335,6 @@ async def collect_storage(
             if root_dev in devs:
                 facts["io_scheduler"] = _read(disk_dir / "queue/scheduler")
                 break
-
 
     # /tmp is a MEASUREMENT TARGET here (small tmpfs = known incident class),
     # not a temp-file location.

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -143,12 +143,21 @@ def _oomd_user_slice_kill(etc_root: Path) -> bool:
     dropin_dir = etc_root / "systemd/system/user.slice.d"
     if not dropin_dir.is_dir():
         return False
+    # systemd semantics, not grep semantics: drop-ins apply in lexicographic
+    # order and the LAST assignment wins (a later zz-local.conf reverting to
+    # `auto` disables the policy — first-match would report a lie), and unit
+    # files have no inline comments (only full-line # / ; lines).
+    effective: str | None = None
     for conf in sorted(dropin_dir.glob("*.conf")):
         raw = _read(conf) or ""
         for line in raw.splitlines():
-            if line.split("#", 1)[0].strip().replace(" ", "") == "ManagedOOMMemoryPressure=kill":
-                return True
-    return False
+            stripped = line.strip()
+            if stripped.startswith(("#", ";")):
+                continue
+            key, sep, value = stripped.partition("=")
+            if sep and key.strip() == "ManagedOOMMemoryPressure":
+                effective = value.strip()
+    return effective == "kill"
 
 
 def _detect_root_device(proc_root: Path) -> str | None:

--- a/src/genesis/infra_profile/collectors/host.py
+++ b/src/genesis/infra_profile/collectors/host.py
@@ -59,6 +59,10 @@ def _split(name: str, raw: dict[str, Any], fact_keys: frozenset[str]) -> Section
 _SYSTEM_FACTS = frozenset(
     {
         "mem_total_kb",
+        # Host swap total: topology (the container's pressure-relief valve —
+        # its disappearance is exactly the 2026-07 wedge precondition, worth
+        # a drift observation). swap_free_kb stays a metric.
+        "swap_total_kb",
         "nproc",
         "kernel_release",
         "architecture",

--- a/tests/test_guardian/test_host_profile.py
+++ b/tests/test_guardian/test_host_profile.py
@@ -55,6 +55,10 @@ class TestHostSystem:
         assert section["hostname"]
         assert section["mem_total_kb"] > 0
         assert isinstance(section.get("loadavg", []), list)
+        # Every /proc/meminfo carries SwapTotal/SwapFree (0 when swapless) —
+        # the container-side collector files total as a fact, free as a metric.
+        assert isinstance(section["swap_total_kb"], int)
+        assert isinstance(section["swap_free_kb"], int)
 
 
 class TestGatherHostProfile:

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -133,6 +133,15 @@ async def test_oomd_policy_fact_from_dropins(proc_root, sys_root, tmp_path):
     result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
     assert result.facts["oomd_user_slice_kill"] is True
 
+    # systemd applies drop-ins lexicographically, LAST assignment wins: an
+    # operator zz-override reverting to auto disables the policy — the fact
+    # must not report a protection that is no longer effective.
+    dropins.joinpath("zz-local.conf").write_text(
+        "[Slice]\nManagedOOMMemoryPressure=auto\n",
+    )
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["oomd_user_slice_kill"] is False
+
 
 async def test_storage_mounts_sorted_and_filtered(proc_root, sys_root):
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -93,6 +93,47 @@ async def test_memory_facts(proc_root, sys_root):
     assert "mem_available" not in result.facts
 
 
+async def test_memory_swap_max_tristate(proc_root, sys_root, tmp_path):
+    # "max" (healthy) survives as the string; "0" (the 2026-07 wedge state)
+    # as an int; an absent file (cgroup v1) as None. All three are facts —
+    # the 0/max flip is exactly the drift the body schema exists to catch.
+    cg = sys_root / "fs/cgroup"
+    cg.joinpath("memory.swap.max").write_text("max\n")
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["cgroup_memory_swap_max"] == "max"
+
+    cg.joinpath("memory.swap.max").write_text("0\n")
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["cgroup_memory_swap_max"] == 0
+
+    cg.joinpath("memory.swap.max").unlink()
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["cgroup_memory_swap_max"] is None
+
+
+async def test_oomd_policy_fact_from_dropins(proc_root, sys_root, tmp_path):
+    dropins = tmp_path / "systemd/system/user.slice.d"
+
+    # no drop-in dir at all -> unprotected
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["oomd_user_slice_kill"] is False
+
+    # a commented-out or auto policy does not count
+    dropins.mkdir(parents=True)
+    dropins.joinpath("genesis-oomd.conf").write_text(
+        "[Slice]\n# ManagedOOMMemoryPressure=kill\nManagedOOMMemoryPressure=auto\n",
+    )
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["oomd_user_slice_kill"] is False
+
+    # the real policy (whitespace-tolerant) counts
+    dropins.joinpath("genesis-oomd.conf").write_text(
+        "[Slice]\nManagedOOMMemoryPressure = kill\nManagedOOMMemoryPressureLimit=60%\n",
+    )
+    result = await collect_memory(proc_root=proc_root, sys_root=sys_root, etc_root=tmp_path)
+    assert result.facts["oomd_user_slice_kill"] is True
+
+
 async def test_storage_mounts_sorted_and_filtered(proc_root, sys_root):
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
     mounts = result.facts["mounts"]

--- a/tests/test_infra_profile/test_collectors_host.py
+++ b/tests/test_infra_profile/test_collectors_host.py
@@ -20,6 +20,8 @@ _LIVE_BLOB = {
     "host_system": {
         "mem_total_kb": 21508924,
         "mem_available_kb": 7394656,
+        "swap_total_kb": 7712764,
+        "swap_free_kb": 4508388,
         "nproc": 5,
         "kernel_release": "6.8.0-134-generic",
         "architecture": "x86_64",
@@ -126,6 +128,7 @@ async def test_live_blob_splits_facts_and_metrics() -> None:
     system = by_name["host_system"]
     assert system.facts == {
         "mem_total_kb": 21508924,
+        "swap_total_kb": 7712764,
         "nproc": 5,
         "kernel_release": "6.8.0-134-generic",
         "architecture": "x86_64",
@@ -136,6 +139,10 @@ async def test_live_blob_splits_facts_and_metrics() -> None:
     assert "loadavg" in system.metrics
     assert "mem_available_kb" in system.metrics
     assert "uptime_seconds" in system.metrics
+    # Host swap: total is topology (its disappearance = the wedge
+    # precondition, drift-worthy); free is a reading.
+    assert "swap_free_kb" in system.metrics
+    assert "swap_free_kb" not in system.facts
 
     pool = by_name["host_storage_pool"]
     assert pool.facts == {"detected": True, "pool_name": "default"}

--- a/tests/test_scripts/test_memory_resilience.py
+++ b/tests/test_scripts/test_memory_resilience.py
@@ -1,0 +1,216 @@
+"""Behavioral tests for memory_resilience_apply (scripts/lib/memory_resilience.sh).
+
+The function is sourced from the REAL lib and driven with stubbed
+``sudo``/``systemctl``/``systemd-detect-virt``/``swapon`` on PATH plus
+MEMRES_* path overrides, so the logic under test is the shipped code:
+adaptive systemd-oomd pressure-kill setup (idempotent drop-ins, graceful
+degradation without systemd/oomd/PSI/sudo) and the warn-only swap
+invariant check (vantage-aware: container vs bare/VM).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts" / "lib" / "memory_resilience.sh"
+BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap.sh"
+
+_SUDO_STUB = """#!/bin/bash
+# Passthrough sudo: "-n true" honors $SUDO_N_RC (0 = passwordless ok).
+if [ "$1" = "-n" ] && [ "$2" = "true" ]; then exit "${SUDO_N_RC:-0}"; fi
+exec "$@"
+"""
+
+_SYSTEMCTL_STUB = """#!/bin/bash
+if [ "$1" = "list-unit-files" ]; then
+    printf '%s' "${OOMD_UNIT_LINE-systemd-oomd.service enabled enabled}"
+    exit 0
+fi
+echo "$@" >> "$SYSTEMCTL_LOG"
+exit 0
+"""
+
+_DETECT_VIRT_STUB = """#!/bin/bash
+# --container: rc 0 = we are a container, rc 1 = bare/VM.
+exit "${DETECT_VIRT_RC:-0}"
+"""
+
+_SWAPON_STUB = """#!/bin/bash
+printf '%s' "${SWAPON_OUT-}"
+"""
+
+
+def _stage(tmp_path: Path) -> dict:
+    """Stub bin dir + fake roots; returns the env overlay for _run."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in (
+        ("sudo", _SUDO_STUB),
+        ("systemctl", _SYSTEMCTL_STUB),
+        ("systemd-detect-virt", _DETECT_VIRT_STUB),
+        ("swapon", _SWAPON_STUB),
+    ):
+        stub = bin_dir / name
+        stub.write_text(body)
+        stub.chmod(0o755)
+
+    psi = tmp_path / "pressure" / "memory"
+    psi.parent.mkdir()
+    psi.write_text("some avg10=0.00 avg60=0.00 avg300=0.00 total=0\n")
+    swap_max = tmp_path / "cgroup" / "memory.swap.max"
+    swap_max.parent.mkdir()
+    swap_max.write_text("max\n")
+
+    return {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "SYSTEMCTL_LOG": str(tmp_path / "systemctl.log"),
+        "MEMRES_ETC_ROOT": str(tmp_path / "etc"),
+        # Real path: the test host runs systemd, so this guard passes there;
+        # the no-systemd test overrides it with a missing dir.
+        "MEMRES_SYSTEMD_RUNTIME_DIR": "/run/systemd/system",
+        "MEMRES_PSI_FILE": str(psi),
+        "MEMRES_CGROUP_SWAP_MAX": str(swap_max),
+    }
+
+
+def _run(env_overlay: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", f'set -euo pipefail; source "{LIB}"; memory_resilience_apply'],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"HOME": env_overlay.get("MEMRES_ETC_ROOT", "/tmp"), **env_overlay},
+    )
+
+
+def _dropins(env: dict) -> dict[str, str]:
+    etc = Path(env["MEMRES_ETC_ROOT"])
+    return {
+        "user_slice": (etc / "systemd/system/user.slice.d/genesis-oomd.conf"),
+        "user_service": (etc / "systemd/system/user@.service.d/genesis-oomd.conf"),
+        "oomd_conf": (etc / "systemd/oomd.conf.d/genesis.conf"),
+    }
+
+
+def test_fresh_apply_writes_dropins_and_reloads(tmp_path):
+    env = _stage(tmp_path)
+    result = _run(env)
+    assert result.returncode == 0, result.stderr
+    assert "policy applied" in result.stdout
+
+    files = _dropins(env)
+    assert (
+        files["user_slice"].read_text()
+        == "[Slice]\nManagedOOMMemoryPressure=kill\nManagedOOMMemoryPressureLimit=60%\n"
+    )
+    assert files["user_service"].read_text() == "[Service]\nManagedOOMMemoryPressure=kill\n"
+    assert files["oomd_conf"].read_text() == (
+        "[OOM]\nSwapUsedLimit=90%\nDefaultMemoryPressureLimit=60%\n"
+        "DefaultMemoryPressureDurationSec=20s\n"
+    )
+    # Pressure thresholds are percentages only — the adaptive contract.
+    for body in (f.read_text() for f in files.values()):
+        for line in body.splitlines():
+            if "Limit" in line and "Sec" not in line:
+                assert line.endswith("%"), f"non-percentage limit: {line}"
+
+    calls = Path(env["SYSTEMCTL_LOG"]).read_text()
+    assert "daemon-reload" in calls
+    assert "enable --now systemd-oomd" in calls
+    assert "restart systemd-oomd" in calls
+
+
+def test_second_run_is_a_noop(tmp_path):
+    env = _stage(tmp_path)
+    _run(env)
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    result = _run(env)
+    assert result.returncode == 0
+    assert "already in place" in result.stdout
+    assert Path(env["SYSTEMCTL_LOG"]).read_text() == ""  # no systemd churn
+
+
+def test_no_systemd_skips_cleanly(tmp_path):
+    env = _stage(tmp_path)
+    env["MEMRES_SYSTEMD_RUNTIME_DIR"] = str(tmp_path / "does-not-exist")
+    result = _run(env)
+    assert result.returncode == 0
+    assert "not a systemd system" in result.stdout
+    assert not _dropins(env)["user_slice"].exists()
+
+
+def test_no_oomd_unit_skips_cleanly(tmp_path):
+    env = _stage(tmp_path)
+    env["OOMD_UNIT_LINE"] = ""  # list-unit-files finds nothing
+    result = _run(env)
+    assert result.returncode == 0
+    assert "systemd-oomd not available" in result.stdout
+    assert not _dropins(env)["user_slice"].exists()
+
+
+def test_no_psi_skips_cleanly(tmp_path):
+    env = _stage(tmp_path)
+    env["MEMRES_PSI_FILE"] = str(tmp_path / "no-psi-here")
+    result = _run(env)
+    assert result.returncode == 0
+    assert "PSI not available" in result.stdout
+    assert not _dropins(env)["user_slice"].exists()
+
+
+def test_no_noninteractive_sudo_skips_with_remediation(tmp_path):
+    env = _stage(tmp_path)
+    env["SUDO_N_RC"] = "1"
+    result = _run(env)
+    assert result.returncode == 0
+    assert "sudo unavailable" in result.stdout
+    assert "memory_resilience_apply" in result.stdout  # manual remediation line
+    assert not _dropins(env)["user_slice"].exists()
+
+
+def test_swap_max_zero_container_vantage_names_host_remediation(tmp_path):
+    env = _stage(tmp_path)
+    Path(env["MEMRES_CGROUP_SWAP_MAX"]).write_text("0\n")
+    env["DETECT_VIRT_RC"] = "0"  # container
+    result = _run(env)
+    assert result.returncode == 0
+    assert "memory.swap.max is 0" in result.stdout
+    assert "limits.memory.swap true" in result.stdout  # host-side knob named
+
+
+def test_swap_max_zero_bare_vantage_generic_remediation(tmp_path):
+    env = _stage(tmp_path)
+    Path(env["MEMRES_CGROUP_SWAP_MAX"]).write_text("0\n")
+    env["DETECT_VIRT_RC"] = "1"  # bare/VM
+    result = _run(env)
+    assert result.returncode == 0
+    assert "memory.swap.max is 0" in result.stdout
+    assert "limits.memory.swap" not in result.stdout  # container knob NOT suggested
+
+
+def test_bare_vantage_without_swap_device_warns(tmp_path):
+    env = _stage(tmp_path)
+    env["DETECT_VIRT_RC"] = "1"  # bare/VM
+    env["SWAPON_OUT"] = ""  # no swap devices
+    result = _run(env)
+    assert result.returncode == 0
+    assert "no swap device configured" in result.stdout
+
+
+def test_container_vantage_ignores_missing_swap_device(tmp_path):
+    # Inside a container swapon shows nothing even when host swap exists —
+    # the device check must not fire there (the cgroup knob is the signal).
+    env = _stage(tmp_path)
+    env["DETECT_VIRT_RC"] = "0"  # container
+    env["SWAPON_OUT"] = ""
+    result = _run(env)
+    assert result.returncode == 0
+    assert "no swap device" not in result.stdout
+
+
+def test_bootstrap_wires_the_lib():
+    text = BOOTSTRAP.read_text()
+    assert 'source "$SCRIPT_DIR/lib/memory_resilience.sh"' in text
+    assert "memory_resilience_apply" in text

--- a/tests/test_scripts/test_memory_resilience.py
+++ b/tests/test_scripts/test_memory_resilience.py
@@ -118,7 +118,7 @@ def test_fresh_apply_writes_dropins_and_reloads(tmp_path):
 
     calls = Path(env["SYSTEMCTL_LOG"]).read_text()
     assert "daemon-reload" in calls
-    assert "enable --now systemd-oomd" in calls
+    assert "enable systemd-oomd" in calls  # no --now: restart below does the single start
     assert "restart systemd-oomd" in calls
 
 
@@ -210,7 +210,40 @@ def test_container_vantage_ignores_missing_swap_device(tmp_path):
     assert "no swap device" not in result.stdout
 
 
+def test_failed_write_warns_instead_of_claiming_already_in_place(tmp_path):
+    env = _stage(tmp_path)
+    # Existing etc content differs AND the target dir is unwritable via the
+    # stub (make the etc root a read-only dir) -> tee fails.
+    etc = Path(env["MEMRES_ETC_ROOT"])
+    etc.mkdir()
+    etc.chmod(0o555)
+    try:
+        result = _run(env)
+    finally:
+        etc.chmod(0o755)
+    assert result.returncode == 0
+    assert "could not write" in result.stdout
+    assert "already in place" not in result.stdout
+
+
+def test_later_dropin_reverting_policy_not_detected_as_protected():
+    # Companion to the collector fact: the lib writes genesis-oomd.conf, but
+    # systemd applies drop-ins lexicographically with last-assignment-wins.
+    # This is covered collector-side (test_collectors_container) — here we
+    # only pin that the lib's own drop-in name sorts BEFORE a conventional
+    # zz-*.conf operator override, so operators can override us, not vice versa.
+    assert "genesis-oomd.conf" < "zz-local.conf"
+
+
 def test_bootstrap_wires_the_lib():
     text = BOOTSTRAP.read_text()
     assert 'source "$SCRIPT_DIR/lib/memory_resilience.sh"' in text
     assert "memory_resilience_apply" in text
+
+
+def test_update_sh_wires_the_lib_visibly():
+    # update.sh pipes bootstrap through `tail -10`, which eats the swap
+    # warning — the retrofit path re-runs the (idempotent) apply unpiped.
+    text = (REPO_ROOT / "scripts" / "update.sh").read_text()
+    assert 'lib/memory_resilience.sh' in text
+    assert text.count("memory_resilience_apply") >= 1


### PR DESCRIPTION
## Why

A machine that runs out of memory with **no swap and no userspace OOM killer** doesn't lose one process — it loses everything at once. The kernel enters direct-reclaim thrash, load climbs into the hundreds with processes stuck in uninterruptible sleep, SSH stops answering, and the box wedges until someone power-cycles it. One incident series produced this same end state four times from four unrelated triggers; the common factor was the missing relief valve, not any single leak. The fix was proven live (swap + pressure-based systemd-oomd) — this PR codifies it so every install is born protected and existing installs retrofit automatically.

## What

**Setup (adaptive — pressure percentages, never absolute bytes):**
- `scripts/lib/memory_resilience.sh`: idempotent systemd-oomd pressure-kill policy (user.slice kill @60% PSI backstop + per-user-manager kill, the operative monitor in practice) + a **warn-only** swap invariant check with vantage-aware remediation (container: the host-side `limits.memory.swap` knob; bare/VM: add swap). Degrades gracefully without systemd, systemd-oomd, kernel PSI, or non-interactive sudo. Honest reporting: a failed write warns and the summary says NOT fully applied.
- `bootstrap.sh` runs it on fresh installs; `update.sh` re-runs it visibly (its bootstrap invocation pipes through `tail -10`, which would eat the warning on exactly the retrofit path).
- `host-setup.sh`: `limits.memory.swap=true` on managed containers (retrofittable) + warns when the host itself is swapless.
- `genesis-server.service`: `ManagedOOMPreference=avoid` — the systemd-oomd counterpart of the existing `OOMScoreAdjust=-500`, honored by the per-user pressure monitor, so the greedy session tree dies before the cognitive core.

**Body schema (infra_profile):**
- Container facts: `cgroup_memory_swap_max` (tri-state; `0` IS the wedge state) and `oomd_user_slice_kill` (config-plane scan with real systemd drop-in semantics: lexicographic, last assignment wins, full-line comments only).
- Host plane: `swap_total_kb` fact (its disappearance is the wedge precondition — drift-worthy) + `swap_free_kb` metric.
- The annotation layer flags unprotected installs from these facts — no special-case code.

**Docs:** `docs/reference/memory-resilience.md` — the invariant, the diagnostic fingerprint, what is set up vs only warned about, and how this layers with the existing kernel-side sysctl OOM tuning.

## Tests

41 targeted tests green: the lib is exercised as shipped (sourced real, stubbed `sudo`/`systemctl`/`systemd-detect-virt`/`swapon` on PATH) — exact drop-in content with a percentages-only tripwire, idempotent second run with zero systemd churn, all four graceful skips, vantage-aware warnings, failed-write honesty; collector facts cover the swap tri-state, drop-in override ordering, and the host facts/metrics split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)