### PR TITLE
fix(dashboard): _async_route degrades to 503 instead of crashing in the startup window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A dashboard request during startup can no longer crash the server.** The
+  async-route bridge falls back to a throwaway event loop when the runtime
+  loop isn't available — but shared database connections are bound to the
+  runtime loop, so a health poll landing in that window raised cross-loop
+  errors that could take the whole process down (observed as exit code 2).
+  Both windows now degrade to a clean HTTP 503 instead: a configured-but-not-
+  yet-running loop never executes the handler at all, and the loop-less
+  fallback catches the cross-loop failure and logs it rather than crashing.
+
 - **Code-intelligence indexing can no longer storm the machine.** Keeping the
   code graph fresh used to fire a full reindex on every commit, in the
   background, with no coordination — and if disk cleanup had reclaimed the index

--- a/src/genesis/dashboard/_blueprint.py
+++ b/src/genesis/dashboard/_blueprint.py
@@ -12,6 +12,28 @@ from flask import Blueprint
 
 logger = logging.getLogger("genesis.dashboard")
 
+# Substrings that identify an asyncio *loop-binding* RuntimeError — a coroutine
+# or shared async object (aiosqlite connection, asyncio.Lock) reached on a loop
+# other than the one it was created on, or with no running loop at all. These
+# are the failures the loop-less fallback should degrade to 503; any OTHER
+# RuntimeError (a real handler/dependency bug like RuntimeError("database gone"))
+# must keep propagating to normal 500 error handling.
+_LOOP_BINDING_SIGNATURES = (
+    "different event loop",
+    "different loop",
+    "no current event loop",
+    "no running event loop",
+    "event loop is closed",
+    "attached to a different",
+    "bound to a different",
+)
+
+
+def _is_loop_binding_error(exc: RuntimeError) -> bool:
+    msg = str(exc).lower()
+    return any(sig in msg for sig in _LOOP_BINDING_SIGNATURES)
+
+
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 
 blueprint = Blueprint(
@@ -97,13 +119,18 @@ def _async_route(f=None, *, timeout: float | None = None):
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(fn(*args, **kwargs))
-            except RuntimeError:
-                # The handler touched a shared async object bound to the
-                # (absent) runtime loop — aiosqlite raises "attached to a
-                # different loop" / "no current event loop". This used to
-                # propagate and could crash the server (observed exit 2 when
-                # a health poll landed during a broken startup). Degrade to
-                # 503 instead; the traceback still lands in the log.
+            except RuntimeError as exc:
+                # Only a loop-binding failure means "the handler touched a
+                # shared async object bound to the (absent) runtime loop" —
+                # aiosqlite raises "attached to a different loop" / "no current
+                # event loop". This used to propagate and could crash the server
+                # (observed exit 2 when a health poll landed during a broken
+                # startup). Degrade THAT to 503; re-raise every other
+                # RuntimeError so genuine handler/dependency bugs still surface
+                # as 500s (esp. under embedded hosting, where this fallback is
+                # the permanent request path).
+                if not _is_loop_binding_error(exc):
+                    raise
                 logger.exception(
                     "async route %s failed in loop-less fallback — returning 503",
                     getattr(fn, "__name__", "?"),

--- a/src/genesis/dashboard/_blueprint.py
+++ b/src/genesis/dashboard/_blueprint.py
@@ -39,7 +39,11 @@ def _async_route(f=None, *, timeout: float | None = None):
     the coroutine even though it executes on the runtime thread.
 
     Falls back to a per-request ``new_event_loop()`` when no runtime loop
-    is configured (e.g. during unit tests).
+    is configured (e.g. during unit tests). When a runtime loop IS
+    configured but not (yet) running — the startup/shutdown window — the
+    route answers 503 instead: shared async objects are bound to that loop,
+    and running the handler anywhere else raises cross-loop errors that
+    historically could take the whole server down.
 
     ``timeout`` (seconds) optionally bounds how long the Flask worker thread
     waits for the coroutine. On expiry the route returns HTTP 503 instead of
@@ -74,10 +78,39 @@ def _async_route(f=None, *, timeout: float | None = None):
                         {"status": "unavailable", "error": "request timed out"}
                     ), 503
 
-            # Fallback for tests or pre-runtime contexts
+            if loop is not None:
+                # Runtime loop configured but not running (startup/shutdown
+                # window). Shared async objects (aiosqlite connections,
+                # asyncio locks) are bound to that loop — running the handler
+                # on a fresh loop would raise mid-request. Same idiom as
+                # voice_api / openclaw completions: answer 503 until ready.
+                logger.warning(
+                    "async route %s hit before runtime loop is running — returning 503",
+                    getattr(fn, "__name__", "?"),
+                )
+                return jsonify(
+                    {"status": "unavailable", "error": "runtime starting"}
+                ), 503
+
+            # Fallback for tests or pre-runtime contexts (no runtime loop
+            # configured at all)
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(fn(*args, **kwargs))
+            except RuntimeError:
+                # The handler touched a shared async object bound to the
+                # (absent) runtime loop — aiosqlite raises "attached to a
+                # different loop" / "no current event loop". This used to
+                # propagate and could crash the server (observed exit 2 when
+                # a health poll landed during a broken startup). Degrade to
+                # 503 instead; the traceback still lands in the log.
+                logger.exception(
+                    "async route %s failed in loop-less fallback — returning 503",
+                    getattr(fn, "__name__", "?"),
+                )
+                return jsonify(
+                    {"status": "unavailable", "error": "runtime not ready"}
+                ), 503
             finally:
                 loop.close()
 

--- a/tests/test_dashboard/test_async_route.py
+++ b/tests/test_dashboard/test_async_route.py
@@ -12,6 +12,7 @@ import asyncio
 import threading
 import time
 
+import pytest
 from flask import Flask
 
 from genesis.dashboard._blueprint import _async_route
@@ -121,6 +122,19 @@ def test_async_route_loopless_fallback_runtimeerror_returns_503():
         resp, status = cross_loop()
     assert status == 503
     assert resp.get_json()["status"] == "unavailable"
+
+
+def test_async_route_loopless_fallback_reraises_non_loop_runtimeerror():
+    """A genuine handler RuntimeError (not loop-binding) must propagate, not be
+    masked as 503 — otherwise embedded hosts hide real failures."""
+    app = Flask(__name__)  # GENESIS_EVENT_LOOP never set
+
+    @_async_route
+    async def real_bug():
+        raise RuntimeError("database gone")
+
+    with app.test_request_context("/"), pytest.raises(RuntimeError, match="database gone"):
+        real_bug()
 
 
 def test_async_route_loopless_fallback_still_runs_handlers():

--- a/tests/test_dashboard/test_async_route.py
+++ b/tests/test_dashboard/test_async_route.py
@@ -83,3 +83,55 @@ def test_async_route_timeout_allows_fast_handler():
             assert quick() == "fine"
     finally:
         loop.call_soon_threadsafe(loop.stop)
+def test_async_route_configured_but_stopped_loop_returns_503():
+    """A configured-but-not-running loop (startup window) -> 503, never a
+    fresh event loop running the handler against cross-loop state."""
+    loop = asyncio.new_event_loop()  # configured, NOT running
+    app = Flask(__name__)
+    app.config["GENESIS_EVENT_LOOP"] = loop
+
+    ran = []
+
+    @_async_route
+    async def handler():
+        ran.append(True)
+        return "should not run"
+
+    try:
+        with app.test_request_context("/"):
+            resp, status = handler()
+        assert status == 503
+        assert resp.get_json()["status"] == "unavailable"
+        assert not ran  # handler must not execute on any substitute loop
+    finally:
+        loop.close()
+
+
+def test_async_route_loopless_fallback_runtimeerror_returns_503():
+    """No loop configured + handler raising the cross-loop RuntimeError
+    (aiosqlite bound to a different loop) -> 503, not a propagated crash
+    (the pre-fix behavior took the server down with exit code 2)."""
+    app = Flask(__name__)  # GENESIS_EVENT_LOOP never set
+
+    @_async_route
+    async def cross_loop():
+        raise RuntimeError("Lock is bound to a different event loop")
+
+    with app.test_request_context("/"):
+        resp, status = cross_loop()
+    assert status == 503
+    assert resp.get_json()["status"] == "unavailable"
+
+
+def test_async_route_loopless_fallback_still_runs_handlers():
+    """The loop-is-None fallback keeps executing plain handlers (unit-test
+    contract) — only RuntimeError degrades to 503."""
+    app = Flask(__name__)
+
+    @_async_route
+    async def plain():
+        await asyncio.sleep(0)
+        return "ok"
+
+    with app.test_request_context("/"):
+        assert plain() == "ok"


### PR DESCRIPTION
## Problem

`_async_route` wraps every dashboard Flask route. When the Genesis runtime loop is unavailable, it falls back to running the handler on a fresh per-request event loop. But shared async objects (aiosqlite connections, asyncio locks) are bound to the runtime loop — on that fallback path a handler touching the DB raises cross-loop `RuntimeError`s ("Lock is bound to a different event loop" → "no current event loop"), which propagated and could crash the whole server (observed exit code 2 when a health poll landed during a misconfigured startup).

## Fix

Two degradation legs, converging on the 503 idiom the voice API and OpenClaw completions routes already use:

- **Loop configured but not running** (startup/shutdown window): return 503 `{"status": "unavailable"}` without executing the handler on any substitute loop.
- **No loop configured** (unit tests / non-standalone hosting): keep the fallback, but degrade a `RuntimeError` escaping the handler to a logged 503 instead of a propagated crash. Handlers still execute normally on this path — only the error disposition changes.

## Tests

Three new tests pin both legs (stopped-loop → 503 with the handler never invoked; cross-loop `RuntimeError` → 503; plain handlers still execute on the loop-less path). Full `tests/test_dashboard/` suite: 291 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)