### PR TITLE
feat(guardian): F.4 — offline git-bundle lifeline (daily verified bundle + host archive)

### DIFF
--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -117,6 +117,15 @@ git_health:
   realert_hours: 6         # re-alert cadence while unhealthy persists
   check_timeout_s: 30
 
+# F.4 offline git-bundle lifeline. The container publishes a verified `git bundle`
+# of the repo to the shared mount DAILY (health-gated); the guardian archives the
+# newest bundle host-side (container-unreachable) and WARNs when it goes stale.
+repo_bundle:
+  enabled: true
+  keep: 3                  # host-side archived bundle copies (never below 1)
+  stale_days: 3            # WARN if the newest verified bundle is older (daily cadence)
+  realert_hours: 24        # re-alert cadence while stale persists
+
 recovery:
   verification_delay_s: 30
   max_escalations: 3

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -208,3 +208,51 @@ already surfaced via `~/.genesis/watchgod_state.json` →
 `service_status.collect_cc_tmp_usage()` → the dashboard `cc_tmp` tile — so it
 never touches the queue. `backup.sh` failures page (a backup that did not run is
 an emergency).
+
+## Offline Repo Bundle (F.4)
+
+`REVERT_CODE` needs a healthy local `.git`; snapshot rollback needs a healthy
+pool; `claude -p` and a GitHub re-clone need the network. The thin-pool outage
+could have taken all of those at once. F.4 adds the **offline lifeline**: a
+verified `git bundle` of the main repo, kept on the host outside the container's
+blast radius, so the repo can be re-cloned with zero network from a snapshot of
+its own history.
+
+**Per-side topology.**
+
+| Side | What runs | Where |
+|---|---|---|
+| Container | `guardian/repo_bundle.py` — daily publish (awareness tick, monotonic-guard) | writes `~/.genesis/shared/guardian/repo-bundle/genesis-<head>.bundle` + `BUNDLE_STAMP` |
+| Host guardian | `guardian/bundle_watch.py` — archive + freshness (`run_check` tick) | copies newest bundle → host-only `<state_path>/repo-archive/` (keep 3), WARNs when stale |
+
+**Publish is gated twice.** It runs only when `git_health.check_git_cheap` reports
+the repo healthy (never overwrite the last good bundle with an attempt from a
+degraded repo — run `scripts/git_repair.py` first) and only ships a bundle that
+passes `git bundle verify`. When `HEAD` is unchanged since the last publish it
+rewrites just the tiny stamp's `last_verified_at` (not the bundle), so a
+quiet-commit period stays "fresh". Freshness alerts key on `last_verified_at`, so
+a stale WARN means the awareness loop is not publishing OR the repo has been
+unhealthy for `stale_days` (3) — the latter complements `git_watch`'s direct
+corruption alert.
+
+**On-demand:** `python -m genesis.guardian.repo_bundle --force` (bypasses the
+HEAD-unchanged skip; the health + verify gates still apply). **Inspect from the
+container:** the read-only `bundle-status` gateway verb
+(`GuardianRemote.bundle_status()`) lists the archived bundles + newest stamp.
+
+**Rebuilding the repo from the host bundle** (on the host, if the container's git
+is unrecoverable):
+
+```bash
+# 1. Find the newest archived bundle:
+ls -t <state_path>/repo-archive/genesis-*.bundle | head -1
+# 2. Verify then clone it (no network needed):
+git bundle verify <bundle>
+git clone <bundle> genesis-recovered
+# 3. Re-point origin at the real remote to resume fetch/push:
+cd genesis-recovered
+git remote set-url origin <your public GENesis-AGI URL>
+```
+
+The clone checks out the exact `HEAD` the bundle captured (`--all` records HEAD +
+every branch/tag), so the working tree matches the container at publish time.

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -21,6 +21,8 @@
 #   host-profile    — read-only host body-schema JSON (meminfo/nproc/kernel,
 #                     storage pool, incus version + container limits.*) for the
 #                     container's infra_profile host plane
+#   bundle-status   — read-only offline repo-bundle archive JSON (host-only
+#                     archived `git bundle` copies + newest stamp; F.4 lifeline)
 #   provision-status          — read-only Proxmox host capacity (audit token)
 #   provision-grow-disk <disk> <GiB> — EXECUTE a pre-approved VM disk grow +
 #                     absorb (execute-only: NO Telegram gate; caller approves)
@@ -834,6 +836,28 @@ PYEOF
         PYTHONPATH="$INSTALL_DIR/src" \
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
             timeout 45 "$VENV_PY" -m genesis.guardian --host-profile
+        ;;
+    bundle-status)
+        # Read-only: print the offline repo-bundle archive JSON (host-only
+        # archived `git bundle` copies + the newest stamp). The container's window
+        # onto its offline re-clone lifeline. No mutation, no secrets, no sudo.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "bundle-status", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        # Skew guard (see host-profile): sync-gateway redeploys THIS script
+        # independently of the src tree. An old checkout has no --bundle-status
+        # branch — the flag would fall through main()'s if-chain into run_check(),
+        # i.e. a FULL guardian recovery cycle triggered by a routine read-only poll.
+        if [ ! -f "$INSTALL_DIR/src/genesis/guardian/bundle_watch.py" ]; then
+            echo '{"ok": false, "action": "bundle-status", "error": "guardian src predates bundle-status — run update to redeploy"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            timeout 30 "$VENV_PY" -m genesis.guardian --bundle-status
         ;;
     provision-status)
         # Read-only host capacity via the Proxmox AUDIT token (VM cores/RAM,

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -487,6 +487,41 @@ async def _check_git_health_deep(db) -> None:
         logger.debug("Failed to create git deep-health observation", exc_info=True)
 
 
+# Daily offline git-bundle publish (F.4). Publishes a *verified* `git bundle` of
+# the main repo to the shared mount so the host guardian can archive it OUTSIDE
+# the container's blast radius — the offline re-clone lifeline for when both the
+# local git AND the network are gone. Monotonic >=24h guard (same rationale as the
+# deep fsck above: fires once on the first tick after any restart; no
+# IntervalTrigger reset-starvation). publish_repo_bundle is health-gated,
+# verify-gated, and does its own to_thread for the blocking git work, so this
+# never blocks the tick. None = "never run this boot".
+_BUNDLE_PUBLISH_INTERVAL_S = 24 * 3600
+_last_bundle_publish_at: float | None = None
+
+
+async def _publish_repo_bundle_if_due() -> None:
+    """Publish the offline repo-bundle lifeline at most once per ~24h (and once on
+    the first tick after a restart). Best-effort; never raises. The health gate
+    (skip when the repo is unhealthy) and verify gate live in publish_repo_bundle."""
+    global _last_bundle_publish_at
+    now = time.monotonic()
+    if (
+        _last_bundle_publish_at is not None
+        and now - _last_bundle_publish_at < _BUNDLE_PUBLISH_INTERVAL_S
+    ):
+        return
+    # Claim the slot BEFORE running so an error can't retry every tick.
+    _last_bundle_publish_at = now
+    try:
+        from genesis.guardian.repo_bundle import publish_repo_bundle
+
+        result = await publish_repo_bundle()
+        if result and result.get("action") == "published":
+            logger.info("Offline repo bundle published: %s", result.get("bundle"))
+    except Exception:
+        logger.debug("repo bundle publish failed", exc_info=True)
+
+
 # Per-CC-slot RSS alerting. Same monotonic-since-boot caveat as WAL above: use a
 # key-existence check (a missing key means "never alerted"), NEVER a default of
 # 0.0 — on a host booted <cooldown ago, `now - 0.0` is small and would wrongly
@@ -1292,6 +1327,12 @@ class AwarenessLoop:
             # thread. Loop-driven (not the learning scheduler) so it survives a
             # router-degraded startup.
             await _check_git_health_deep(self._db)
+            # Daily offline git-bundle publish (F.4) — a verified `git bundle` of
+            # the repo to the shared mount, health-gated, so the host guardian can
+            # archive an offline re-clone lifeline. Self-guards to ~daily and runs
+            # its blocking work in a thread. Loop-driven for the same
+            # degraded-startup coverage as the deep fsck above.
+            await _publish_repo_bundle_if_due()
 
             # SQLite WAL checkpoint — prevent unbounded WAL growth from
             # external scripts or concurrent writers. PASSIVE is non-blocking.

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -7,6 +7,7 @@ Usage:
     python -m genesis.guardian --test-approval  # E2E test the keyword-reply gate
     python -m genesis.guardian --disk-status  # print storage-pool JSON (read-only)
     python -m genesis.guardian --host-profile  # host body-schema JSON (read-only)
+    python -m genesis.guardian --bundle-status # offline repo-bundle archive JSON (read-only)
     python -m genesis.guardian --provision-status              # host capacity (read-only)
     python -m genesis.guardian --provision-grow-disk <disk> <GiB>  # EXECUTE (pre-approved)
     python -m genesis.guardian --provision-grow-memory <MiB>       # EXECUTE (pre-approved)
@@ -50,6 +51,9 @@ def main() -> None:
 
     if "--host-profile" in sys.argv:
         sys.exit(asyncio.run(_host_profile()))
+
+    if "--bundle-status" in sys.argv:
+        sys.exit(_bundle_status())
 
     if "--provision-status" in sys.argv:
         sys.exit(asyncio.run(_provision_status()))
@@ -190,6 +194,27 @@ async def _host_profile() -> int:
         result = await gather_host_profile(load_config())
     except Exception as exc:  # noqa: BLE001 — the verb contract is JSON-always
         result = {"ok": False, "action": "host-profile", "error": repr(exc)}
+    print(json.dumps(result))
+    return 0 if result.get("ok") else 1
+
+
+def _bundle_status() -> int:
+    """Print the offline-bundle archive status as JSON (read-only).
+
+    Consumed by the `bundle-status` gateway verb → the container's programmatic
+    window onto the host-only offline re-clone lifeline (archived bundles + the
+    newest stamp). No mutation, no secrets, no sudo. Emits JSON even on failure so
+    the client never has to guess.
+    """
+    import json
+
+    from genesis.guardian.bundle_watch import bundle_archive_status
+    from genesis.guardian.config import load_config
+
+    try:
+        result = bundle_archive_status(load_config())
+    except Exception as exc:  # noqa: BLE001 — the verb contract is JSON-always
+        result = {"ok": False, "action": "bundle-status", "error": repr(exc)}
     print(json.dumps(result))
     return 0 if result.get("ok") else 1
 

--- a/src/genesis/guardian/bundle_watch.py
+++ b/src/genesis/guardian/bundle_watch.py
@@ -34,6 +34,7 @@ from genesis.guardian.alert.base import Alert, AlertSeverity
 # Reuse the identical atomic-copy discipline as the container-side publish /
 # credential mirror (same-dir tmp + os.replace, preserves mtime, forces 0600).
 from genesis.guardian.credential_bridge import _atomic_copy, _needs_copy
+from genesis.guardian.repo_bundle import is_valid_bundle_name
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +98,13 @@ def _archive_bundles(cfg, source_dir: Path, archive_dir: Path) -> None:
         logger.debug("bundle archive: no stamp at %s (incomplete/absent) — skipping", stamp_src)
         return
     bundle_name = stamp.get("bundle")
-    if not bundle_name:
-        logger.debug("bundle archive: stamp has no bundle name — skipping")
+    # The stamp is read from the CONTAINER-writable shared mount. Validate the
+    # bundle name is a plain basename (no ``..``/absolute) BEFORE building any path
+    # from it — otherwise a malformed/compromised stamp could make the host
+    # guardian read/write outside source_dir/archive_dir, defeating the host-only
+    # archive boundary (Codex P1). Absolute/traversal names → skip.
+    if not bundle_name or not is_valid_bundle_name(str(bundle_name)):
+        logger.debug("bundle archive: invalid/absent stamp bundle name %r — skipping", bundle_name)
         return
     bundle_src = source_dir / str(bundle_name)
     if not bundle_src.is_file():

--- a/src/genesis/guardian/bundle_watch.py
+++ b/src/genesis/guardian/bundle_watch.py
@@ -1,0 +1,249 @@
+"""Guardian-side offline-bundle watch — archive + freshness (F.4).
+
+The container publishes a verified ``git bundle`` of the main repo to the shared
+mount (``guardian/repo_bundle.py``). This host-side module, run each guardian
+tick, does two things the container cannot:
+
+1. **Archive** the newest bundle + its stamp to a host-only directory
+   (``<state_path>/repo-archive/``) the container cannot reach — so a destroyed
+   container still leaves a ``git clone``-able snapshot on the host. Versioned,
+   pruned to ``keep`` copies, NEVER below one.
+2. **Freshness alert** — WARN (damped) when the newest archived bundle's
+   ``last_verified_at`` is older than ``stale_days``. Keying on
+   ``last_verified_at`` (rewritten every healthy publish check, even when HEAD is
+   unchanged) rather than the bundle's mtime means a quiet-commit period never
+   false-alarms, while a dead awareness loop OR a repo that has been unhealthy for
+   ``stale_days`` (publish is health-gated) both surface — the latter complements
+   ``git_watch``'s direct corruption alert.
+
+Pure host-side file operations — no incus exec, no container dependency — so it
+runs on every enabled tick, independent of the container's state (mirrors
+``cred_watch._check_mirror_and_archive``). Never raises into the tick.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.guardian.alert.base import Alert, AlertSeverity
+
+# Reuse the identical atomic-copy discipline as the container-side publish /
+# credential mirror (same-dir tmp + os.replace, preserves mtime, forces 0600).
+from genesis.guardian.credential_bridge import _atomic_copy, _needs_copy
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = "bundle_alert_state.json"
+_ARCHIVE_SUBDIR = "repo-archive"
+_SHARED_BUNDLE_SUBDIR = ("guardian", "repo-bundle")  # under <state_path>/shared/
+_STAMP_NAME = "BUNDLE_STAMP"
+_BUNDLE_GLOB = "genesis-*.bundle"
+
+
+def _parse(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def _read_stamp(path: Path) -> dict | None:
+    try:
+        obj = json.loads(path.read_text())
+        return obj if isinstance(obj, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+async def check_repo_bundle_and_alert(config, dispatcher) -> None:
+    """Guardian tick entry: archive the newest bundle, then freshness-alert.
+
+    Never raises into the tick. Both halves are best-effort and independent."""
+    cfg = config.repo_bundle
+    if not cfg.enabled:
+        return
+    source_dir = config.shared_path.joinpath(*_SHARED_BUNDLE_SUBDIR)
+    archive_dir = config.state_path / _ARCHIVE_SUBDIR
+
+    try:
+        _archive_bundles(cfg, source_dir, archive_dir)
+    except Exception:
+        logger.warning("bundle archive hop failed", exc_info=True)
+
+    try:
+        await _freshness_alert(config, dispatcher, archive_dir)
+    except Exception:
+        logger.warning("bundle freshness check failed", exc_info=True)
+
+
+def _archive_bundles(cfg, source_dir: Path, archive_dir: Path) -> None:
+    """Copy the newest published bundle + stamp → a host-only archive the
+    container cannot reach, then prune to ``keep`` copies (never below one).
+
+    REFUSE a stamp-less or empty source (a zeroed/half-written shared mount must
+    never even start an archive round — ``cred_watch._archive_mirror`` semantics).
+    The stamp names the current bundle; only that file is copied (older heads were
+    already pruned on the shared side)."""
+    stamp_src = source_dir / _STAMP_NAME
+    stamp = _read_stamp(stamp_src)
+    if not stamp:
+        logger.debug("bundle archive: no stamp at %s (incomplete/absent) — skipping", stamp_src)
+        return
+    bundle_name = stamp.get("bundle")
+    if not bundle_name:
+        logger.debug("bundle archive: stamp has no bundle name — skipping")
+        return
+    bundle_src = source_dir / str(bundle_name)
+    if not bundle_src.is_file():
+        logger.debug("bundle archive: stamped bundle %s missing — skipping", bundle_name)
+        return
+
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(archive_dir, 0o700)
+
+    bundle_dest = archive_dir / str(bundle_name)
+    if _needs_copy(bundle_src, bundle_dest):
+        _atomic_copy(bundle_src, bundle_dest)
+    # Stamp is tiny and rewritten every healthy tick (last_verified_at) — always
+    # refresh it so the freshness reader sees the latest verification time.
+    _atomic_copy(stamp_src, archive_dir / _STAMP_NAME)
+
+    _prune_archive(archive_dir, keep=max(1, int(cfg.keep)))
+
+
+def _prune_archive(archive_dir: Path, keep: int) -> None:
+    """Keep the ``keep`` newest ``genesis-*.bundle`` files by mtime; delete older.
+
+    ``_atomic_copy`` preserves the source mtime, so mtime ordering is the
+    chronological publish order. Never deletes below one bundle by construction
+    (``keep`` >= 1 and the current bundle was just (re)copied)."""
+    bundles = [f for f in archive_dir.glob(_BUNDLE_GLOB) if f.is_file()]
+    if len(bundles) <= keep:
+        return
+    bundles.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+    for stale in bundles[keep:]:
+        try:
+            stale.unlink()
+        except OSError:
+            logger.debug("bundle archive: could not prune %s", stale, exc_info=True)
+
+
+def _load_state(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        obj = json.loads(path.read_text())
+        return obj if isinstance(obj, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_state(path: Path, state: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state))
+    except OSError:
+        logger.warning("failed to persist bundle alert state", exc_info=True)
+
+
+async def _freshness_alert(config, dispatcher, archive_dir: Path) -> None:
+    """WARN (damped) when the newest archived bundle is stale.
+
+    Feature-active gate: if no stamp has ever been archived, this is a
+    never-configured install (or the first tick before the first publish) — no
+    alert, just clear any lingering warn state (mirrors ``cred_watch``'s
+    escrow-proxy gate)."""
+    cfg = config.repo_bundle
+    now = datetime.now(UTC)
+    state_file = config.state_path / _STATE_FILE
+    stamp = _read_stamp(archive_dir / _STAMP_NAME)
+
+    if not stamp:
+        if _load_state(state_file).get("warned_at"):
+            _save_state(state_file, {})
+        return
+
+    verified = _parse(stamp.get("last_verified_at")) or _parse(stamp.get("created_at"))
+    if verified is None:
+        age_days = None
+        stale = True
+    else:
+        age_days = (now - verified).total_seconds() / 86400
+        stale = age_days > cfg.stale_days
+
+    state = _load_state(state_file)
+    if not stale:
+        if state.get("warned_at"):
+            _save_state(state_file, {})
+            await _send(
+                dispatcher,
+                AlertSeverity.INFO,
+                "Offline repo bundle fresh again",
+                "The host-side offline git bundle is updating normally again.",
+            )
+        return
+
+    last_alert = _parse(state.get("last_alert_at"))
+    if last_alert and (now - last_alert).total_seconds() < cfg.realert_hours * 3600:
+        return
+    detail = (
+        f"newest verified bundle is {age_days:.1f} days old"
+        if age_days is not None
+        else "the archived bundle stamp has no verification time"
+    )
+    _save_state(
+        state_file,
+        {
+            "warned_at": state.get("warned_at") or now.isoformat(),
+            "last_alert_at": now.isoformat(),
+        },
+    )
+    await _send(
+        dispatcher,
+        AlertSeverity.WARNING,
+        "Offline repo bundle stale",
+        f"The host-side offline git bundle is stale: {detail} "
+        f"(threshold {cfg.stale_days:.0f} days). Either the awareness loop "
+        "isn't publishing or the container's git has been unhealthy that "
+        "long — the offline re-clone lifeline may be out of date. Check the "
+        "awareness loop and scripts/git_repair.py.",
+    )
+
+
+def bundle_archive_status(config) -> dict:
+    """Read-only snapshot of the host-only bundle archive (backs the
+    ``bundle-status`` gateway verb). Lists archived bundles + the newest stamp so
+    the container can confirm the offline re-clone lifeline exists and how fresh
+    it is. No mutation, no secrets."""
+    archive_dir = config.state_path / _ARCHIVE_SUBDIR
+    stamp = _read_stamp(archive_dir / _STAMP_NAME)
+    bundles: list[dict] = []
+    if archive_dir.is_dir():
+        for f in sorted(archive_dir.glob(_BUNDLE_GLOB)):
+            try:
+                st = f.stat()
+            except OSError:
+                continue
+            bundles.append({"name": f.name, "size": st.st_size, "mtime": st.st_mtime})
+    return {
+        "ok": True,
+        "action": "bundle-status",
+        "archive_dir": str(archive_dir),
+        "count": len(bundles),
+        "bundles": bundles,
+        "stamp": stamp,
+    }
+
+
+async def _send(dispatcher, severity: AlertSeverity, title: str, body: str) -> None:
+    try:
+        await dispatcher.send(Alert(severity=severity, title=title, body=body))
+    except Exception:
+        logger.warning("failed to send bundle freshness alert", exc_info=True)

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -386,6 +386,10 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # that zeroed .git and disabled REVERT_CODE; a live incus-exec probe, since
         # the container's own awareness check may be dead exactly when it matters.
         await _check_container_git_and_alert(config, dispatcher)
+        # Offline git-bundle lifeline (F.4) — archive the newest container-
+        # published bundle to a host-only dir + WARN if the archived bundle goes
+        # stale. Host-side file ops only, independent of the container verdict.
+        await _check_repo_bundle_and_alert(config, dispatcher)
     finally:
         # Always save state, even on error
         sm.save_state(state_path)
@@ -588,6 +592,20 @@ async def _check_container_git_and_alert(
         await check_container_git_and_alert(config, dispatcher)
     except Exception:
         logger.warning("git-health watch failed", exc_info=True)
+
+
+async def _check_repo_bundle_and_alert(
+    config: GuardianConfig, dispatcher: AlertDispatcher,
+) -> None:
+    """Guardian-side offline-bundle archive + freshness watch (delegates to
+    bundle_watch). Pure host-side file ops — archives the newest container-
+    published bundle to a host-only dir and WARNs when it goes stale. Never
+    raises into the tick."""
+    try:
+        from genesis.guardian.bundle_watch import check_repo_bundle_and_alert
+        await check_repo_bundle_and_alert(config, dispatcher)
+    except Exception:
+        logger.warning("repo-bundle watch failed", exc_info=True)
 
 
 async def _check_storage_pool_and_alert(

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -215,6 +215,25 @@ class GitHealthConfig:
 
 
 @dataclass
+class RepoBundleConfig:
+    """Offline git-bundle lifeline (F.4).
+
+    The container publishes a verified ``git bundle`` of the main repo to the
+    shared mount DAILY (health-gated); the guardian archives the newest bundle to
+    a host-only directory the container cannot reach and WARNs when the archived
+    bundle goes stale. This is the offline re-clone path for when both the
+    container's local git AND the network are gone.
+    """
+
+    enabled: bool = True
+    keep: int = 3  # host-side archived bundle copies (never below 1)
+    # WARN if the newest verified bundle is older than this (daily cadence → 3
+    # missed healthy publishes means the loop or the repo is broken).
+    stale_days: float = 3.0
+    realert_hours: float = 24.0  # re-alert cadence while stale persists
+
+
+@dataclass
 class ProvisioningConfig:
     """Hypervisor provisioning (rung 5 of the escalation ladder).
 
@@ -286,6 +305,7 @@ class GuardianConfig:
     storage_pool: StoragePoolConfig = field(default_factory=StoragePoolConfig)
     cred_integrity: CredIntegrityConfig = field(default_factory=CredIntegrityConfig)
     git_health: GitHealthConfig = field(default_factory=GitHealthConfig)
+    repo_bundle: RepoBundleConfig = field(default_factory=RepoBundleConfig)
     provisioning: ProvisioningConfig = field(default_factory=ProvisioningConfig)
 
     @property
@@ -549,6 +569,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         storage_pool=_build_sub(StoragePoolConfig, raw, "storage_pool"),
         cred_integrity=_build_sub(CredIntegrityConfig, raw, "cred_integrity"),
         git_health=_build_sub(GitHealthConfig, raw, "git_health"),
+        repo_bundle=_build_sub(RepoBundleConfig, raw, "repo_bundle"),
         provisioning=_build_sub(ProvisioningConfig, raw, "provisioning"),
     )
 

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -290,6 +290,17 @@ class GuardianRemote:
         ok, out = await self._ssh_command("host-profile", timeout=_HOST_PROFILE_TIMEOUT)
         return self._as_json(ok, out, "host-profile")
 
+    async def bundle_status(self) -> dict:
+        """Read-only offline repo-bundle archive status (F.4).
+
+        Lists the host-only archived ``git bundle`` copies + the newest stamp so
+        the container can confirm its offline re-clone lifeline exists and how
+        fresh it is. A pre-redeploy gateway answers ``denied`` (its unknown-verb
+        default) → ``{"ok": False, "error": "denied"}``. No approval, no mutation.
+        """
+        ok, out = await self._ssh_command("bundle-status", timeout=_STATUS_TIMEOUT)
+        return self._as_json(ok, out, "bundle-status")
+
     async def request_grow_disk(self, disk: str, add_gib: int) -> dict:
         """EXECUTE a pre-approved VM disk grow + absorb into the thin pool."""
         if not _DISK_RE.fullmatch(disk):

--- a/src/genesis/guardian/repo_bundle.py
+++ b/src/genesis/guardian/repo_bundle.py
@@ -1,0 +1,323 @@
+"""Offline git-bundle lifeline — CONTAINER-side publish (F.4).
+
+Publishes a *verified* ``git bundle`` of the main repo to the shared mount so the
+host guardian can archive it OUTSIDE the container's blast radius
+(``guardian/bundle_watch.py``). If both the container's local git AND the network
+are gone, the host still holds a self-contained, ``git clone``-able snapshot of
+the repo — the offline recovery path the thin-pool outage proved was missing
+(``claude -p`` and a GitHub re-clone are both internet-bound, and snapshot
+rollback needs a healthy pool).
+
+Runs CONTAINER-side (the repo lives here), driven DAILY from the awareness tick
+(``_publish_repo_bundle_if_due`` — a monotonic-interval guard, mirroring
+``git_health``'s deep-fsck cadence, NOT an ``IntervalTrigger`` that resets on
+restart) plus an operator ``--force`` CLI (``python -m genesis.guardian.repo_bundle
+--force``).
+
+Placement note: this lives under ``guardian/`` (drift-covered by
+``watchdog._GUARDIAN_PATHS``) though it executes container-side — the same split
+as ``credential_bridge``, whose ``propagate_*`` functions also run container-side
+from the awareness tick.
+
+Two safety gates, both load-bearing:
+- **Health gate** — refuse to publish when ``git_health.check_git_cheap`` reports
+  the repo unhealthy, so a known-good bundle is never overwritten by an attempt
+  from a degraded repo (capturing a snapshot WHILE healthy is the whole point).
+- **Verify gate** — ``git bundle verify`` the freshly-created bundle BEFORE it
+  replaces the last good one; an unverifiable bundle is worse than a stale one.
+
+Never raises into the caller — a lifeline that crashes the tick is worse than a
+stale bundle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.env import genesis_home, repo_root
+from genesis.observability.git_health import check_git_cheap
+
+logger = logging.getLogger(__name__)
+
+# Where the container publishes (under ~/.genesis/shared/guardian/); the host
+# sees the same bytes at <state_path>/shared/guardian/repo-bundle/.
+_SHARED_SUBDIR = ("guardian", "repo-bundle")
+_STAMP_NAME = "BUNDLE_STAMP"
+_BUNDLE_PREFIX = "genesis-"
+_BUNDLE_SUFFIX = ".bundle"
+_STAMP_SCHEMA = 1
+
+# `git bundle create --all` on this repo's ~59 MB store is <2 s / 18 MB (spike-
+# measured 2026-07-14); 1800 s is vast headroom that only trips on a genuinely
+# wedged fs, itself a signal. `verify` is even cheaper; 600 s bounds it. A short
+# `rev-parse` uses the git_health cheap budget.
+_CREATE_TIMEOUT_S = 1800
+_VERIFY_TIMEOUT_S = 600
+_REVPARSE_TIMEOUT_S = 10
+# Refuse to build a bundle unless free space is at least this multiple of the
+# object store — the bundle is smaller than .git, so 2x is deliberately generous.
+_FREE_SPACE_MULTIPLE = 2
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _run_git(repo: Path, *args: str, timeout: float) -> tuple[int, str, str]:
+    """Run a git command; never raises. Returns (rc, stdout, stderr).
+
+    rc = -1 on timeout (the wedged-fs signal), -2 on any other exec failure.
+    Mirrors ``git_health._run_git`` (kept local to avoid coupling to a private
+    symbol in another module)."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return -1, "", "timeout"
+    except Exception as exc:  # git missing, repo path gone, etc.
+        return -2, "", str(exc)
+
+
+def _git_store_size(repo: Path) -> int:
+    """Sum of regular-file bytes under the git common dir (.git). Best-effort:
+    an unreadable tree returns what it could sum, never raises."""
+    rc, gcd, _ = _run_git(repo, "rev-parse", "--git-common-dir", timeout=_REVPARSE_TIMEOUT_S)
+    if rc != 0 or not gcd.strip():
+        git_dir = repo / ".git"
+    else:
+        gc = Path(gcd.strip())
+        git_dir = gc if gc.is_absolute() else (repo / gc)
+    total = 0
+    for root, _dirs, files in os.walk(git_dir):
+        for name in files:
+            try:
+                total += (Path(root) / name).stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _read_stamp(dest_dir: Path) -> dict | None:
+    try:
+        obj = json.loads((dest_dir / _STAMP_NAME).read_text())
+        return obj if isinstance(obj, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_stamp(dest_dir: Path, stamp: dict) -> None:
+    """Atomic 0600 stamp write (same-dir tmp + os.replace). Written LAST in a
+    publish so its presence means 'a complete bundle round finished'."""
+    tmp = dest_dir / f".{_STAMP_NAME}.tmp"
+    tmp.write_text(json.dumps(stamp, indent=2))
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, dest_dir / _STAMP_NAME)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _prune_to_newest(dest_dir: Path, keep_name: str) -> None:
+    """Delete every ``genesis-*.bundle`` in ``dest_dir`` except ``keep_name``."""
+    for f in dest_dir.glob(f"{_BUNDLE_PREFIX}*{_BUNDLE_SUFFIX}"):
+        if f.name == keep_name:
+            continue
+        try:
+            f.unlink()
+        except OSError:
+            logger.debug("repo_bundle: could not prune old bundle %s", f, exc_info=True)
+
+
+async def publish_repo_bundle(
+    *,
+    force: bool = False,
+    repo: Path | None = None,
+    shared_dir: Path | None = None,
+) -> dict | None:
+    """Publish a verified bundle of ``repo`` to the shared mount. Never raises.
+
+    Returns a result dict describing the action, or None when there is no shared
+    mount (a no-guardian install). ``force`` bypasses the cadence/HEAD-unchanged
+    skip only; the health gate and the verify gate ALWAYS apply.
+    """
+    repo = repo or repo_root()
+    shared_base = shared_dir or (genesis_home() / "shared")
+    try:
+        if not shared_base.exists():
+            logger.debug("repo_bundle: shared mount %s absent — skipping", shared_base)
+            return None
+
+        # HEALTH GATE — never overwrite the last good bundle with an attempt from
+        # a degraded repo. check_git_cheap is ms-scale and already threaded.
+        report = await check_git_cheap(repo)
+        if not report.ok:
+            logger.warning(
+                "repo_bundle: repo unhealthy (%s) — refusing to publish; run scripts/git_repair.py",
+                ", ".join(report.failures),
+            )
+            return {
+                "action": "refused",
+                "reason": "git_unhealthy",
+                "failures": list(report.failures),
+            }
+
+        # All remaining work is blocking (git subprocess + file IO) — one thread
+        # hop keeps the awareness tick responsive.
+        return await asyncio.to_thread(_publish_core_sync, repo, shared_base, force)
+    except Exception:
+        logger.warning("repo_bundle: publish failed", exc_info=True)
+        return {"action": "error", "reason": "exception"}
+
+
+def _publish_core_sync(repo: Path, shared_base: Path, force: bool) -> dict:
+    """Synchronous publish core (runs in a worker thread). Assumes the health
+    gate already passed. Never raises (wrapped by the caller)."""
+    dest_dir = shared_base.joinpath(*_SHARED_SUBDIR)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(dest_dir, 0o700)
+
+    rc, head_out, _ = _run_git(repo, "rev-parse", "HEAD", timeout=_REVPARSE_TIMEOUT_S)
+    if rc != 0 or not head_out.strip():
+        return {"action": "refused", "reason": "head_unresolvable"}
+    head = head_out.strip()
+    now = _utc_now_iso()
+
+    stamp = _read_stamp(dest_dir)
+
+    # HEAD unchanged and not forced → the bundle content is still current. Rewrite
+    # ONLY the tiny stamp's last_verified_at (records this healthy check for the
+    # host freshness alert) — do NOT rebuild the bundle. This decouples freshness
+    # from commit activity: a quiet-commit period stays "fresh" as long as the
+    # daily healthy check keeps advancing last_verified_at.
+    if not force and stamp and stamp.get("head") == head and stamp.get("bundle"):
+        bundle_path = dest_dir / str(stamp["bundle"])
+        if bundle_path.exists():
+            stamp["last_verified_at"] = now
+            _write_stamp(dest_dir, stamp)
+            return {"action": "verified_unchanged", "head": head}
+        # Stamp claims a bundle that vanished → fall through and rebuild.
+
+    # Free-space guard: refuse when free < 2x the object store (bundle is smaller
+    # than .git, so this is generous; a full mount must not be half-filled).
+    store_size = _git_store_size(repo)
+    try:
+        free = shutil.disk_usage(dest_dir).free
+    except OSError:
+        free = 0
+    if store_size and free < _FREE_SPACE_MULTIPLE * store_size:
+        logger.warning(
+            "repo_bundle: insufficient free space (%d < %dx %d) — skipping",
+            free,
+            _FREE_SPACE_MULTIPLE,
+            store_size,
+        )
+        return {
+            "action": "refused",
+            "reason": "insufficient_space",
+            "free": free,
+            "store_size": store_size,
+        }
+
+    # Create into a same-directory .partial so the final os.replace is atomic (a
+    # ~/tmp→shared replace would be cross-device and fail). --all bundles every
+    # ref + HEAD → clone-safe (spike-verified: reclone HEAD matches container).
+    tmp = dest_dir / f".bundle-{os.getpid()}.partial"
+    try:
+        rc, _, err = _run_git(
+            repo,
+            "bundle",
+            "create",
+            str(tmp),
+            "--all",
+            timeout=_CREATE_TIMEOUT_S,
+        )
+        if rc != 0 or not tmp.exists():
+            logger.warning("repo_bundle: bundle create failed (rc=%s): %s", rc, err[:200])
+            return {"action": "refused", "reason": "create_failed", "rc": rc}
+
+        # VERIFY GATE — never publish a bundle that does not verify.
+        rc, _, err = _run_git(
+            repo,
+            "bundle",
+            "verify",
+            str(tmp),
+            timeout=_VERIFY_TIMEOUT_S,
+        )
+        if rc != 0:
+            logger.warning("repo_bundle: bundle verify failed (rc=%s): %s", rc, err[:200])
+            return {"action": "refused", "reason": "verify_failed", "rc": rc}
+
+        size = tmp.stat().st_size
+        digest = _sha256(tmp)
+        os.chmod(tmp, 0o600)
+        bundle_name = f"{_BUNDLE_PREFIX}{head[:12]}{_BUNDLE_SUFFIX}"
+        os.replace(tmp, dest_dir / bundle_name)
+    finally:
+        # A create/verify failure leaves the .partial behind — clean it up.
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+
+    # Keep only the just-published bundle on the shared side (host archive keeps N).
+    _prune_to_newest(dest_dir, bundle_name)
+
+    # Stamp LAST (completeness marker). last_verified_at == created_at on a build.
+    _write_stamp(
+        dest_dir,
+        {
+            "version": _STAMP_SCHEMA,
+            "head": head,
+            "bundle": bundle_name,
+            "size": size,
+            "sha256": digest,
+            "created_at": now,
+            "last_verified_at": now,
+        },
+    )
+    logger.info("repo_bundle: published %s (%d bytes) for HEAD %s", bundle_name, size, head[:12])
+    return {"action": "published", "head": head, "bundle": bundle_name, "size": size}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``python -m genesis.guardian.repo_bundle [--force]``.
+
+    Operator on-demand publish. ``--force`` bypasses the HEAD-unchanged skip; the
+    health + verify gates still apply (an unhealthy repo is refused, not
+    overwritten). Exit 0 on published/verified_unchanged, 1 on refused/error.
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    force = "--force" in argv
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+    result = asyncio.run(publish_repo_bundle(force=force))
+    print(
+        json.dumps(
+            result if result is not None else {"action": "skipped", "reason": "no_shared_mount"}
+        )
+    )
+    if result is None:
+        return 0  # no-guardian install: nothing to do is not an error
+    return 0 if result.get("action") in ("published", "verified_unchanged") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genesis/guardian/repo_bundle.py
+++ b/src/genesis/guardian/repo_bundle.py
@@ -38,6 +38,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -56,6 +57,19 @@ _STAMP_NAME = "BUNDLE_STAMP"
 _BUNDLE_PREFIX = "genesis-"
 _BUNDLE_SUFFIX = ".bundle"
 _STAMP_SCHEMA = 1
+# A published bundle name is always ``genesis-<12+ hex>.bundle``. The stamp that
+# carries this name is read by the host guardian from the CONTAINER-writable
+# shared mount, so it must be validated as a plain basename before it is ever
+# used as a path component — a stamp with ``..``/absolute path would otherwise let
+# a compromised container escape the host-only archive boundary (see bundle_watch).
+_BUNDLE_NAME_RE = re.compile(r"genesis-[0-9a-f]{7,40}\.bundle\Z")
+
+
+def is_valid_bundle_name(name: str) -> bool:
+    """True iff ``name`` is a safe published-bundle basename (no path separators,
+    no ``..``, not absolute) — the guard for any path built from stamp data."""
+    return bool(_BUNDLE_NAME_RE.fullmatch(name))
+
 
 # `git bundle create --all` on this repo's ~59 MB store is <2 s / 18 MB (spike-
 # measured 2026-07-14); 1800 s is vast headroom that only trips on a genuinely
@@ -209,13 +223,24 @@ def _publish_core_sync(repo: Path, shared_base: Path, force: bool) -> dict:
     # host freshness alert) — do NOT rebuild the bundle. This decouples freshness
     # from commit activity: a quiet-commit period stays "fresh" as long as the
     # daily healthy check keeps advancing last_verified_at.
-    if not force and stamp and stamp.get("head") == head and stamp.get("bundle"):
+    if (
+        not force
+        and stamp
+        and stamp.get("head") == head
+        and is_valid_bundle_name(str(stamp.get("bundle", "")))
+    ):
         bundle_path = dest_dir / str(stamp["bundle"])
-        if bundle_path.exists():
+        # Do NOT advance freshness on existence alone — a bundle truncated or
+        # corrupted after publish would then read "verified" forever, silently
+        # breaking the offline re-clone in the exact scenario this exists for.
+        # Re-hash and compare to the recorded digest: a match proves the bytes are
+        # unchanged since the publish that ran `git bundle verify`, so it is still
+        # verifiable. A mismatch/miss falls through to rebuild (health gate passed).
+        if bundle_path.exists() and stamp.get("sha256") and _sha256(bundle_path) == stamp["sha256"]:
             stamp["last_verified_at"] = now
             _write_stamp(dest_dir, stamp)
             return {"action": "verified_unchanged", "head": head}
-        # Stamp claims a bundle that vanished → fall through and rebuild.
+        # Missing / corrupt / digest-mismatch → fall through and rebuild.
 
     # Free-space guard: refuse when free < 2x the object store (bundle is smaller
     # than .git, so this is generous; a full mount must not be half-filled).

--- a/tests/test_guardian/test_bundle_watch.py
+++ b/tests/test_guardian/test_bundle_watch.py
@@ -110,6 +110,33 @@ def test_archive_refuses_stampless_source(tmp_path):
     assert not archive.exists() or not list(archive.glob("genesis-*.bundle"))
 
 
+def test_archive_rejects_traversal_bundle_name(tmp_path):
+    """Codex P1: a malicious stamp (container-writable) naming an escape path must
+    NOT make the host guardian read/write outside the archive."""
+    config = _config(tmp_path)
+    source = _source_dir(config)
+    source.mkdir(parents=True)
+    for evil in ("../../evil.bundle", "/tmp/evil.bundle", "genesis-XYZ.bundle"):
+        (source / "BUNDLE_STAMP").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "head": "a" * 40,
+                    "bundle": evil,
+                    "size": 1,
+                    "sha256": "x",
+                    "created_at": "t",
+                    "last_verified_at": "t",
+                }
+            )
+        )
+        archive = config.state_path / "repo-archive"
+        bundle_watch._archive_bundles(config.repo_bundle, source, archive)
+        assert not (tmp_path / "evil.bundle").exists()
+        assert not (Path("/tmp/evil.bundle")).exists()
+        assert not archive.exists() or not list(archive.glob("*.bundle"))
+
+
 def test_archive_noop_on_absent_source(tmp_path):
     config = _config(tmp_path)
     archive = config.state_path / "repo-archive"

--- a/tests/test_guardian/test_bundle_watch.py
+++ b/tests/test_guardian/test_bundle_watch.py
@@ -1,0 +1,227 @@
+"""Tests for the guardian-side offline-bundle watch (F.4, guardian/bundle_watch.py).
+
+Covers the host-only archive hop (refuse stamp-less/empty, keep-N prune never
+below one) and the freshness alert (stale WARN, damped realert, recovery INFO,
+never-configured no-warn), using a real GuardianConfig + a capturing dispatcher.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from genesis.guardian import bundle_watch
+from genesis.guardian.alert.base import AlertSeverity
+from genesis.guardian.bundle_watch import (
+    bundle_archive_status,
+    check_repo_bundle_and_alert,
+)
+from genesis.guardian.config import GuardianConfig, RepoBundleConfig
+
+
+class _FakeDispatcher:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, alert):
+        self.sent.append(alert)
+        return True
+
+
+def _config(tmp_path: Path, **cfg_kw) -> GuardianConfig:
+    config = GuardianConfig(state_dir=str(tmp_path))
+    config.repo_bundle = RepoBundleConfig(
+        **{"keep": 3, "stale_days": 3.0, "realert_hours": 24.0, **cfg_kw}
+    )
+    return config
+
+
+def _source_dir(config: GuardianConfig) -> Path:
+    return config.shared_path / "guardian" / "repo-bundle"
+
+
+def _write_publish(
+    source_dir: Path, head: str, *, verified_at: str | None = None, data: bytes = b"BUNDLEDATA"
+) -> str:
+    source_dir.mkdir(parents=True, exist_ok=True)
+    name = f"genesis-{head[:12]}.bundle"
+    (source_dir / name).write_bytes(data)
+    now = verified_at or datetime.now(UTC).isoformat()
+    (source_dir / "BUNDLE_STAMP").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "head": head,
+                "bundle": name,
+                "size": len(data),
+                "sha256": "deadbeef",
+                "created_at": now,
+                "last_verified_at": now,
+            }
+        )
+    )
+    return name
+
+
+def _write_archive_stamp(archive_dir: Path, last_verified_at: str, bundle="genesis-x.bundle"):
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    (archive_dir / bundle).write_bytes(b"x")
+    (archive_dir / "BUNDLE_STAMP").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "head": "x" * 40,
+                "bundle": bundle,
+                "size": 1,
+                "sha256": "x",
+                "created_at": last_verified_at,
+                "last_verified_at": last_verified_at,
+            }
+        )
+    )
+
+
+# ── archive hop ────────────────────────────────────────────────────────────
+
+
+def test_archive_copies_newest_bundle_and_stamp(tmp_path):
+    config = _config(tmp_path)
+    source = _source_dir(config)
+    name = _write_publish(source, "abc123def4567")
+    archive = config.state_path / "repo-archive"
+
+    bundle_watch._archive_bundles(config.repo_bundle, source, archive)
+
+    assert (archive / name).exists()
+    assert (archive / "BUNDLE_STAMP").exists()
+    assert (archive.stat().st_mode & 0o777) == 0o700
+
+
+def test_archive_refuses_stampless_source(tmp_path):
+    config = _config(tmp_path)
+    source = _source_dir(config)
+    source.mkdir(parents=True)
+    (source / "genesis-orphan.bundle").write_bytes(b"x")  # bundle but NO stamp
+    archive = config.state_path / "repo-archive"
+
+    bundle_watch._archive_bundles(config.repo_bundle, source, archive)
+    assert not archive.exists() or not list(archive.glob("genesis-*.bundle"))
+
+
+def test_archive_noop_on_absent_source(tmp_path):
+    config = _config(tmp_path)
+    archive = config.state_path / "repo-archive"
+    # Source dir never created → clean no-op, no crash.
+    bundle_watch._archive_bundles(config.repo_bundle, _source_dir(config), archive)
+    assert not archive.exists()
+
+
+def test_prune_keeps_n_never_below_one(tmp_path):
+    archive = tmp_path / "repo-archive"
+    archive.mkdir()
+    # Five bundles with staggered mtimes.
+    for i in range(5):
+        f = archive / f"genesis-{i:012d}.bundle"
+        f.write_bytes(b"x")
+        os.utime(f, (1000 + i, 1000 + i))
+    bundle_watch._prune_archive(archive, keep=3)
+    remaining = sorted(f.name for f in archive.glob("genesis-*.bundle"))
+    # Newest 3 by mtime kept (indices 2,3,4).
+    assert remaining == [
+        "genesis-000000000002.bundle",
+        "genesis-000000000003.bundle",
+        "genesis-000000000004.bundle",
+    ]
+
+
+def test_archive_prune_integration_keeps_keep(tmp_path):
+    """Successive publishes of different heads accumulate in the archive, pruned
+    to keep=2."""
+    config = _config(tmp_path, keep=2)
+    source = _source_dir(config)
+    archive = config.state_path / "repo-archive"
+    for i, head in enumerate((b"a", b"b", b"c")):
+        name = _write_publish(source, head.decode() * 40)
+        # Stagger the SOURCE bundle mtime; _atomic_copy preserves it, so archive
+        # prune order is deterministic (newest-by-mtime kept).
+        os.utime(source / name, (1000 + i, 1000 + i))
+        bundle_watch._archive_bundles(config.repo_bundle, source, archive)
+    bundles = list(archive.glob("genesis-*.bundle"))
+    assert len(bundles) == 2
+
+
+# ── freshness alert ─────────────────────────────────────────────────────────
+
+
+async def test_freshness_warns_when_stale_then_damps(tmp_path):
+    config = _config(tmp_path, stale_days=3.0)
+    archive = config.state_path / "repo-archive"
+    old = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+    _write_archive_stamp(archive, old)
+    disp = _FakeDispatcher()
+
+    await check_repo_bundle_and_alert(config, disp)
+    assert len(disp.sent) == 1
+    assert disp.sent[0].severity == AlertSeverity.WARNING
+
+    # Second call immediately → within realert window → no new alert.
+    await check_repo_bundle_and_alert(config, disp)
+    assert len(disp.sent) == 1
+
+
+async def test_freshness_recovers_with_info(tmp_path):
+    config = _config(tmp_path, stale_days=3.0)
+    archive = config.state_path / "repo-archive"
+    disp = _FakeDispatcher()
+
+    _write_archive_stamp(archive, (datetime.now(UTC) - timedelta(days=5)).isoformat())
+    await check_repo_bundle_and_alert(config, disp)
+    assert len(disp.sent) == 1  # WARNING
+
+    # Fresh stamp → recovery INFO.
+    _write_archive_stamp(archive, datetime.now(UTC).isoformat())
+    await check_repo_bundle_and_alert(config, disp)
+    assert len(disp.sent) == 2
+    assert disp.sent[1].severity == AlertSeverity.INFO
+
+
+async def test_freshness_no_alert_when_never_configured(tmp_path):
+    config = _config(tmp_path)
+    disp = _FakeDispatcher()
+    # No archive stamp at all → never-configured install → silence.
+    await check_repo_bundle_and_alert(config, disp)
+    assert disp.sent == []
+
+
+async def test_disabled_is_silent(tmp_path):
+    config = _config(tmp_path, enabled=False, stale_days=3.0)
+    archive = config.state_path / "repo-archive"
+    _write_archive_stamp(archive, (datetime.now(UTC) - timedelta(days=10)).isoformat())
+    disp = _FakeDispatcher()
+    await check_repo_bundle_and_alert(config, disp)
+    assert disp.sent == []
+
+
+# ── status verb helper ──────────────────────────────────────────────────────
+
+
+def test_bundle_archive_status_shape(tmp_path):
+    config = _config(tmp_path)
+    archive = config.state_path / "repo-archive"
+    _write_archive_stamp(archive, datetime.now(UTC).isoformat(), bundle="genesis-abc.bundle")
+    status = bundle_archive_status(config)
+    assert status["ok"] is True
+    assert status["action"] == "bundle-status"
+    assert status["count"] == 1
+    assert status["bundles"][0]["name"] == "genesis-abc.bundle"
+    assert status["stamp"]["bundle"] == "genesis-abc.bundle"
+
+
+def test_bundle_archive_status_empty(tmp_path):
+    config = _config(tmp_path)
+    status = bundle_archive_status(config)
+    assert status["ok"] is True
+    assert status["count"] == 0
+    assert status["stamp"] is None

--- a/tests/test_guardian/test_repo_bundle.py
+++ b/tests/test_guardian/test_repo_bundle.py
@@ -184,6 +184,44 @@ async def test_insufficient_space_refuses(tmp_path, monkeypatch):
     assert result["reason"] == "insufficient_space"
 
 
+async def test_unchanged_rebuilds_when_bundle_corrupted(tmp_path):
+    """Codex P1: an unchanged HEAD must NOT advance freshness on existence alone —
+    a bundle corrupted after publish (digest mismatch) is rebuilt, not blessed."""
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    first = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    bundle = _bundle_dir(shared) / first["bundle"]
+    bundle.write_bytes(b"CORRUPT")  # truncate/corrupt after publish
+
+    second = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    assert second["action"] == "published"  # rebuilt, NOT verified_unchanged
+    rebuilt = _bundle_dir(shared) / second["bundle"]
+    assert (
+        subprocess.run(
+            ["git", "-C", str(repo), "bundle", "verify", str(rebuilt)],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def test_is_valid_bundle_name():
+    from genesis.guardian.repo_bundle import is_valid_bundle_name
+
+    assert is_valid_bundle_name("genesis-0123456789ab.bundle")
+    assert is_valid_bundle_name("genesis-0123456789abcdef01234567.bundle")
+    # Path-traversal / absolute / non-hex / wrong shape all rejected.
+    assert not is_valid_bundle_name("../genesis-0123456789ab.bundle")
+    assert not is_valid_bundle_name("/etc/passwd")
+    assert not is_valid_bundle_name("genesis-0123456789ab.bundle/../x")
+    assert not is_valid_bundle_name("genesis-ZZZZ.bundle")
+    assert not is_valid_bundle_name("evil.bundle")
+    assert not is_valid_bundle_name("")
+
+
 def test_cli_main_no_shared_mount(tmp_path, monkeypatch, capsys):
     """CLI entrypoint exits 0 and prints JSON when there's no shared mount."""
     monkeypatch.setenv("GENESIS_HOME", str(tmp_path / "nope"))

--- a/tests/test_guardian/test_repo_bundle.py
+++ b/tests/test_guardian/test_repo_bundle.py
@@ -1,0 +1,195 @@
+"""Tests for the offline git-bundle publish (F.4, guardian/repo_bundle.py).
+
+Uses real scratch git repos + a scratch shared dir (no mocks of git) so the
+bundle create/verify/clone behavior is exercised for real — the one thing the
+spike proved and these lock in as regressions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from genesis.guardian import repo_bundle
+from genesis.guardian.repo_bundle import publish_repo_bundle
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _make_repo(path: Path, content: str = "hello") -> str:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "f.txt").write_text(content)
+    _git(path, "add", ".")
+    _git(path, "commit", "-qm", "init")
+    return _git(path, "rev-parse", "HEAD").strip()
+
+
+def _bundle_dir(shared: Path) -> Path:
+    return shared / "guardian" / "repo-bundle"
+
+
+async def test_publish_creates_verifiable_bundle(tmp_path):
+    repo = tmp_path / "repo"
+    head = _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    result = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    assert result and result["action"] == "published"
+    assert result["head"] == head
+
+    bdir = _bundle_dir(shared)
+    bundle = bdir / result["bundle"]
+    assert bundle.exists()
+    # The published bundle actually verifies as a real git bundle.
+    rc = subprocess.run(
+        ["git", "-C", str(repo), "bundle", "verify", str(bundle)],
+        capture_output=True,
+    ).returncode
+    assert rc == 0
+
+    stamp = json.loads((bdir / "BUNDLE_STAMP").read_text())
+    assert stamp["head"] == head
+    assert stamp["bundle"] == result["bundle"]
+    assert stamp["sha256"] and stamp["size"] > 0
+    assert stamp["created_at"] == stamp["last_verified_at"]
+    # 0600 on the bundle, 0700 on the dir.
+    assert (bundle.stat().st_mode & 0o777) == 0o600
+
+
+async def test_reclone_matches_head(tmp_path):
+    """The actual lifeline: a clone from the published bundle checks out the
+    exact container HEAD."""
+    repo = tmp_path / "repo"
+    head = _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    result = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    bundle = _bundle_dir(shared) / result["bundle"]
+
+    dest = tmp_path / "reclone"
+    subprocess.run(["git", "clone", "-q", str(bundle), str(dest)], check=True)
+    re_head = _git(dest, "rev-parse", "HEAD").strip()
+    assert re_head == head
+
+
+async def test_skips_unchanged_head_but_refreshes_verified_at(tmp_path):
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    first = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    assert first["action"] == "published"
+    stamp1 = json.loads((_bundle_dir(shared) / "BUNDLE_STAMP").read_text())
+    bundle_mtime1 = (_bundle_dir(shared) / first["bundle"]).stat().st_mtime_ns
+
+    second = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    assert second["action"] == "verified_unchanged"
+    stamp2 = json.loads((_bundle_dir(shared) / "BUNDLE_STAMP").read_text())
+    # Bundle content NOT rebuilt (same file untouched)...
+    assert (_bundle_dir(shared) / first["bundle"]).stat().st_mtime_ns == bundle_mtime1
+    # ...but last_verified_at advanced (created_at unchanged).
+    assert stamp2["created_at"] == stamp1["created_at"]
+    assert stamp2["last_verified_at"] >= stamp1["last_verified_at"]
+
+
+async def test_force_rebuilds_unchanged(tmp_path):
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    await publish_repo_bundle(repo=repo, shared_dir=shared)
+    forced = await publish_repo_bundle(repo=repo, shared_dir=shared, force=True)
+    assert forced["action"] == "published"
+
+
+async def test_new_commit_publishes_and_prunes_shared_to_one(tmp_path):
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    r1 = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    # New commit → new HEAD → new bundle; shared side keeps only the newest.
+    (repo / "f2.txt").write_text("more")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "second")
+    r2 = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    assert r2["action"] == "published"
+    assert r2["bundle"] != r1["bundle"]
+    bundles = list(_bundle_dir(shared).glob("genesis-*.bundle"))
+    assert len(bundles) == 1
+    assert bundles[0].name == r2["bundle"]
+
+
+async def test_health_gate_refuses_unhealthy_repo(tmp_path):
+    """A zeroed .git/config makes check_git_cheap fail → publish refuses and the
+    last good bundle is left untouched."""
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    good = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    good_bundle = _bundle_dir(shared) / good["bundle"]
+    good_sha_before = repo_bundle._sha256(good_bundle)
+
+    # Corrupt the config the way the outage did (null-fill).
+    cfg = repo / ".git" / "config"
+    cfg.write_bytes(b"\x00" * cfg.stat().st_size)
+
+    result = await publish_repo_bundle(repo=repo, shared_dir=shared, force=True)
+    assert result["action"] == "refused"
+    assert result["reason"] == "git_unhealthy"
+    # Last good bundle untouched.
+    assert good_bundle.exists()
+    assert repo_bundle._sha256(good_bundle) == good_sha_before
+
+
+async def test_no_shared_mount_returns_none(tmp_path):
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    result = await publish_repo_bundle(repo=repo, shared_dir=tmp_path / "absent")
+    assert result is None
+
+
+async def test_insufficient_space_refuses(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _make_repo(repo)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    import shutil as _shutil
+
+    class _DU:
+        free = 1  # 1 byte free — well under 2x the store
+
+    monkeypatch.setattr(_shutil, "disk_usage", lambda _p: _DU())
+    result = await publish_repo_bundle(repo=repo, shared_dir=shared)
+    assert result["action"] == "refused"
+    assert result["reason"] == "insufficient_space"
+
+
+def test_cli_main_no_shared_mount(tmp_path, monkeypatch, capsys):
+    """CLI entrypoint exits 0 and prints JSON when there's no shared mount."""
+    monkeypatch.setenv("GENESIS_HOME", str(tmp_path / "nope"))
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(tmp_path / "repo"))
+    _make_repo(tmp_path / "repo")
+    rc = repo_bundle.main(["--force"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["action"] in ("skipped", "published", "refused", "verified_unchanged")

--- a/tests/test_scripts/test_gateway_bundle_status.py
+++ b/tests/test_scripts/test_gateway_bundle_status.py
@@ -1,0 +1,79 @@
+"""Tests for the guardian-gateway.sh ``bundle-status`` read-only verb (F.4).
+
+Runs the REAL gateway script against a throwaway ``$HOME`` install dir, focusing
+on the shell-specific guard branches where gateway bugs hide (the F.0 SIGPIPE
+lesson): the venv-missing guard, the src-skew guard (must NOT fall through to a
+full ``run_check`` recovery cycle on a stale gateway), and correct dispatch to
+``-m genesis.guardian --bundle-status`` when everything is present. The verb's
+actual JSON body is covered by ``test_bundle_watch.bundle_archive_status``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+
+def _run(home: Path, verb: str):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["SSH_ORIGINAL_COMMAND"] = verb
+    return subprocess.run(
+        ["bash", str(_GATEWAY)],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _install(home: Path) -> Path:
+    d = home / ".local" / "share" / "genesis-guardian"
+    (d / "config").mkdir(parents=True)
+    (d / "config" / "guardian.yaml").write_text("container_name: genesis\n")
+    return d
+
+
+def _stub_python(install: Path, body: str) -> Path:
+    py = install / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_text(body)
+    py.chmod(0o755)
+    return py
+
+
+def test_bundle_status_no_venv(tmp_path):
+    _install(tmp_path)  # no .venv/bin/python
+    proc = _run(tmp_path, "bundle-status")
+    assert proc.returncode == 1
+    assert "guardian venv not found" in proc.stderr
+
+
+def test_bundle_status_skew_guard_blocks_fallthrough(tmp_path):
+    """A gateway older than the src (no bundle_watch.py) must return a clean error
+    — NEVER fall through main()'s if-chain into run_check (a full recovery cycle
+    on a routine read-only poll)."""
+    install = _install(tmp_path)
+    _stub_python(install, "#!/bin/sh\necho SHOULD_NOT_RUN\n")  # would print if invoked
+    # bundle_watch.py deliberately absent.
+    proc = _run(tmp_path, "bundle-status")
+    assert proc.returncode == 1
+    assert "predates bundle-status" in proc.stderr
+    assert "SHOULD_NOT_RUN" not in proc.stdout
+
+
+def test_bundle_status_dispatches_when_present(tmp_path):
+    """venv + bundle_watch.py present → the verb invokes
+    `-m genesis.guardian --bundle-status` (proven by a stub python echoing argv)."""
+    install = _install(tmp_path)
+    _stub_python(install, '#!/bin/sh\necho "ARGS: $*"\n')
+    mod = install / "src" / "genesis" / "guardian"
+    mod.mkdir(parents=True)
+    (mod / "bundle_watch.py").write_text("# stub for the skew guard\n")
+
+    proc = _run(tmp_path, "bundle-status")
+    assert proc.returncode == 0, proc.stderr
+    assert "--bundle-status" in proc.stdout


### PR DESCRIPTION
## What

Adds the **offline git-bundle lifeline** (F.4, last item in the Storage & Credential Resiliency Sprint's F-rest queue). `REVERT_CODE` needs healthy local git, snapshot rollback needs a healthy pool, and `claude -p` / a GitHub re-clone need the network — the thin-pool outage could take all of those at once. F.4 keeps a **verified `git bundle` of the repo on the host**, re-clone-able with zero network.

## How (per-side topology)

| Side | Module | Behavior |
|---|---|---|
| Container | `guardian/repo_bundle.py` | DAILY publish (awareness tick, monotonic-guard — mirrors F.1's deep-fsck cadence, no `IntervalTrigger` reset-starvation) + `--force` CLI. Writes a verified bundle + stamp to `~/.genesis/shared/guardian/repo-bundle/`. |
| Host guardian | `guardian/bundle_watch.py` | Archives the newest bundle to a container-unreachable `<state_path>/repo-archive/` (keep 3, never below 1); WARNs (damped) when it goes stale. |

**Two gates on publish:** health (`git_health.check_git_cheap` — never overwrite the last good bundle from a degraded repo; run `scripts/git_repair.py` first) and verify (`git bundle verify` before publish). HEAD-unchanged refreshes only the stamp's `last_verified_at` (not the 50MB bundle), so freshness is decoupled from commit activity — a quiet-commit weekend never false-alarms, but a dead loop or a repo unhealthy for `stale_days` (3) does.

**Read-only `bundle-status` gateway verb** (+ src-skew guard so a stale gateway returns a clean JSON error instead of falling through to a full `run_check`).

## Spike (pre-build, on this repo)

`git bundle create --all` → 18 MB, <2 s; `verify` passes; `git clone` of the bundle checks out the exact container HEAD (3083 files, clean); 26 linked worktrees add only harmless `worktrees/*/HEAD` pseudo-refs. Confirmed the lifeline actually re-clones before writing a line of ladder code.

## Tests (23, all green locally)

Real scratch-repo `create/verify/reclone-matches-HEAD`, health-gate refusal (zeroed `.git/config` → last good bundle untouched), archive keep-N prune (never below 1), freshness stale/recover/never-configured, gateway venv + skew guards. Regression sweep on `test_check`/`test_config`/`test_remote`/`test_loop` (142) also green.

## Deploy note

Touches `src/genesis/guardian/` + `scripts/guardian-gateway.sh` → needs **both** container (git pull + genesis-server restart) AND host guardian (`scripts/update.sh` redeploy, tree-verified via F.0). Live E2E after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)