### PR TITLE
docs(resilience): record live fire-drill findings — kernel vs oomd layering, full-vs-some PSI

### DIFF
--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -84,6 +84,36 @@ flags unprotected installs:
   ever kills `genesis-server` itself, the pressure limit is mis-tuned for
   that machine — raise the percentage or investigate what drove sustained
   PSI, and file the incident.
+
+## What a live fire drill proved (2026-07)
+
+The full stack was drilled on a production install (16 GiB container, 7.3 GiB
+host swap) with deliberate memory balloons. Findings worth knowing before you
+tune anything:
+
+- **The swap layer is what absorbs almost everything.** An idle 7.6 GiB
+  balloon was absorbed silently; a single 12 GiB *churning* balloon ran for
+  hours without wedging the machine — the exact stimulus class that
+  previously took the box down in minutes.
+- **At hard exhaustion, the KERNEL OOM killer fires first, and that's fine.**
+  A four-process churn storm (~13 GiB hot working set) exceeded RAM + swap
+  and was killed by the kernel within ~2 minutes (`memory.events` `oom_kill`
+  is the counter to check — inside a container you cannot see the host's
+  dmesg, and `journalctl -u systemd-oomd` staying empty does NOT mean nothing
+  fired). `genesis-server` survived on `OOMScoreAdjust=-500`.
+- **systemd-oomd thresholds against the *full* PSI metric** — the fraction of
+  time ALL tasks in the cgroup were stalled simultaneously (see
+  systemd.oomd(5)) — not the `some` line most dashboards show. A single
+  greedy process can push `some` past 60% while `full` stays in single
+  digits: oomd correctly stays quiet because everything else is still making
+  progress off swap. Its unique window — sustained all-tasks stall *without*
+  hard memory.max exhaustion — is narrow by design. Don't lower its
+  percentages chasing kills the kernel layer already delivers; that only buys
+  collateral kills during legitimate heavy bursts.
+- Net: the wedge fingerprint at the top of this doc is covered twice over —
+  swap turns the cliff into a ramp, and whichever of kernel-OOM (hard
+  exhaustion) or oomd (sustained all-stall) triggers first takes the greedy
+  tree while the server survives.
 - Quality-over-cost still applies: nothing here throttles or degrades
   Genesis under pressure; it only decides *what dies first* when the machine
   is already out of headroom.


### PR DESCRIPTION
## Why

The memory-resilience stack (#1059) was drilled live on a production install with escalating memory balloons. The results correct one implicit claim in the runbook — that systemd-oomd is the layer that kills before a wedge — and record hard-won observability facts so future operators (and future tuning sessions) don't rediscover them the expensive way.

## What the drill showed

- **Swap absorbs almost everything**: an idle 7.6 GiB balloon vanished into swap; a single 12 GiB *churning* balloon ran for hours without wedging the machine — the exact stimulus class that previously took the box down in minutes.
- **At hard exhaustion the kernel OOM killer fires first** (~2 minutes for a 4-process, ~13 GiB churn storm), and `genesis-server` survives on its `OOMScoreAdjust=-500`. The counter to check from inside a container is `memory.events` `oom_kill` — host dmesg is invisible, and an empty `journalctl -u systemd-oomd` does not mean nothing fired.
- **systemd-oomd thresholds on the *full* PSI metric** (all tasks stalled simultaneously), not the `some` line most tooling shows. A single greedy process can push `some` past 60% while `full` stays in single digits — oomd staying quiet there is correct. Its window is narrow by design; the doc now explicitly warns against lowering its percentages to chase kills the kernel layer already delivers.

Docs only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)