### PR TITLE
fix(guardian): F.4 — lazy-import check_git_cheap for host guardian venv

### DIFF
--- a/src/genesis/guardian/repo_bundle.py
+++ b/src/genesis/guardian/repo_bundle.py
@@ -46,7 +46,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from genesis.env import genesis_home, repo_root
-from genesis.observability.git_health import check_git_cheap
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +182,11 @@ async def publish_repo_bundle(
 
         # HEALTH GATE — never overwrite the last good bundle with an attempt from
         # a degraded repo. check_git_cheap is ms-scale and already threaded.
+        # Imported lazily: this module is imported host-side (bundle_watch →
+        # repo_bundle) where the minimal guardian venv lacks genesis.observability's
+        # aiohttp chain — and the host never runs publish, so it never needs this.
+        from genesis.observability.git_health import check_git_cheap
+
         report = await check_git_cheap(repo)
         if not report.ok:
             logger.warning(

--- a/tests/test_guardian/test_bundle_watch.py
+++ b/tests/test_guardian/test_bundle_watch.py
@@ -252,3 +252,29 @@ def test_bundle_archive_status_empty(tmp_path):
     assert status["ok"] is True
     assert status["count"] == 0
     assert status["stamp"] is None
+
+
+def test_import_is_host_guardian_venv_safe():
+    """Regression: bundle_watch + repo_bundle run in the MINIMAL host guardian
+    venv (no aiohttp). Importing them must NOT eagerly pull
+    genesis.observability (whose __init__ loads the aiohttp health chain) —
+    check_git_cheap is lazy-imported inside publish (a container-only path).
+
+    Run in a fresh subprocess so import-cache state from other tests can't mask a
+    regression. A live E2E on the host guardian caught this the hard way (2026-07-15):
+    the every-30s tick threw ModuleNotFoundError: aiohttp and the archive never ran.
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "import sys\n"
+        "import genesis.guardian.bundle_watch\n"
+        "import genesis.guardian.repo_bundle\n"
+        "bad = [m for m in ('genesis.observability.git_health', 'aiohttp') "
+        "if m in sys.modules]\n"
+        "assert not bad, f'host-unsafe eager imports: {bad}'\n"
+        "print('ok')\n"
+    )
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert r.returncode == 0, f"stdout={r.stdout!r} stderr={r.stderr!r}"


### PR DESCRIPTION
## Bug (live-E2E-caught during #1061 deploy)

The host guardian runs a **minimal venv without `aiohttp`**. `repo_bundle` imported `check_git_cheap` at module level, and `genesis.observability.__init__` eagerly loads the aiohttp health chain — so the host importing `bundle_watch → repo_bundle` threw `ModuleNotFoundError: No module named 'aiohttp'` on **every 30s tick**, and F.4's host-side archive + freshness never ran. The never-raise wrapper kept the guardian up (only a logged traceback), so CI + container tests couldn't see it — the container venv has aiohttp.

## Fix

`check_git_cheap` is only used **container-side** (the publish health gate). Move it to a **lazy import inside `publish_repo_bundle`**; module-level `repo_bundle` now imports only `genesis.env` (host-safe). Adds a **subprocess regression test** asserting `bundle_watch` + `repo_bundle` import without pulling `genesis.observability.git_health` / `aiohttp`.

Verified locally: `import genesis.guardian.bundle_watch` no longer loads `git_health`/`aiohttp`; `is_valid_bundle_name` still exported; publish still gets the health gate (container path). 24 F.4 tests green.

Deploy: touches `src/genesis/guardian/` → host guardian redeploy via `scripts/update.sh` after merge, then re-run the F.4 archive E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)