### PR TITLE
feat(observability): deploy-staleness — merged-vs-deployed drift snapshot + hybrid alert (WS-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now notices when merged code isn't actually deployed.** Pulling
+  changes with a bare `git merge` between updates loads the new code on
+  restart but silently skips everything only `update.sh` activates — new
+  systemd units, the host guardian redeploy, tool pins. One install ran six
+  days like that with a shipped timer never installed and zero signal
+  anywhere. The health snapshot now has a `deploy_health` section (days since
+  the last update, commits behind, missing units, host-guardian drift — no
+  network calls), and the awareness loop raises a dashboard alert on any
+  drift, escalating to a Telegram page only when it's sustained (a week stale
+  and 20+ commits behind, or a missing unit ignored for a day). The fix is
+  always the same and the alert says so: run `scripts/update.sh`.
+
 - **A resumed conversation can no longer run twice at once.** If an SSH drop
   leaves a Claude Code session executing headless and you resume that same
   conversation elsewhere, both processes used to write to the same transcript

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -382,7 +382,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 94637bae 2026-07-14
+verified: bca86011 2026-07-15
 ```
 
 - **awareness/**: the 5-min heartbeat. ~23 signal collectors (the richer
@@ -397,7 +397,12 @@ verified: 94637bae 2026-07-14
   and GCs stale registry files; newest executor wins, older one's repo-mutating
   tools are denied), and (hourly) embedding-backlog degradation — counts
   `memory_metadata.embedding_status='failed'` (permanently keyword-only rows the
-  rate alert misses), hybrid `high` (dashboard) / `critical` (Telegram) by band.
+  rate alert misses), hybrid `high` (dashboard) / `critical` (Telegram) by band —
+  plus (hourly) deploy staleness: merged-vs-deployed drift (update.sh age,
+  commits behind from local refs, missing systemd units, host-guardian
+  deployed_commit via `~/.genesis/host_gateway_state.json`; collectors in
+  `observability/snapshots/deploy_health.py`), `high` on any drift, `critical`
+  only sustained (≥7d AND ≥20 commits, or a missing unit alerted >24h).
   It does NOT drive the ego cadence (ego has its own
   scheduler). Trap: PEP 562 lazy `__init__` — don't eager-import `loop.py`.
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
@@ -595,7 +600,7 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, infra_profile, env.py, _config_overlay.py]
-verified: 859ec256 2026-07-14
+verified: bca86011 2026-07-15
 ```
 
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
@@ -623,7 +628,12 @@ verified: 859ec256 2026-07-14
   persist-queue overflow drops events but emits a rate-limited "dropped"
   meta-event (WS-17). Two health layers (async probes vs systemd shell-out);
   `/health` is a dashboard route, not an MCP tool; `job_health` state machine
-  is runtime-owned.
+  is runtime-owned. `snapshots/deploy_health.py` = merged-vs-deployed drift
+  (never does network I/O; host guardian state comes from
+  `~/.genesis/host_gateway_state.json`, written by `cc_align_host_sync` on
+  every gateway version probe — update.sh and the nightly cc-align timer);
+  its `GUARDIAN_HOST_PATHS` must stay in LOCKSTEP with update.sh
+  GUARDIAN_PATHS.
 - **security/**: prompt-injection defense + outbound scanning — sanitizer is
   LOG-ONLY for internal sources (perimeter EMAIL/INBOX can block);
   `output_scanner` = deterministic outbound secrets/IP scan; `skill_scan`

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -356,6 +356,33 @@ cc_align_host_sync() {
         | grep -oE '"cc_version": "[0-9]+\.[0-9]+\.[0-9]+' \
         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
 
+    # ── Persist the probe for the deploy-staleness check ──
+    # observability/snapshots/deploy_health.py reads deployed_commit from this
+    # state file so the health path never SSHes. Both writers (update.sh and
+    # the nightly cc-align timer) funnel through here. Atomic tmp+mv; a failed
+    # parse (gateway emitted non-JSON) or unreachable probe (early return
+    # above) never clobbers the last-known-good state.
+    local _state_file="$HOME/.genesis/host_gateway_state.json"
+    local _state_tmp="${_state_file}.tmp.$$"
+    if GENESIS_HOST_VER_RAW="$host_ver_raw" python3 - "$_state_tmp" 2>/dev/null <<'PYEOF'
+import json
+import os
+import sys
+from datetime import UTC, datetime
+
+payload = {
+    "checked_at": datetime.now(UTC).isoformat(),
+    "version": json.loads(os.environ["GENESIS_HOST_VER_RAW"]),
+}
+with open(sys.argv[1], "w") as f:
+    json.dump(payload, f, indent=2)
+PYEOF
+    then
+        mv -f "$_state_tmp" "$_state_file" 2>/dev/null || rm -f "$_state_tmp"
+    else
+        rm -f "$_state_tmp"
+    fi
+
     # ── Node.js major sync (prerequisite for CC) ──
     if printf '%s' "${NODE_MAJOR:-}" | grep -qE '^[0-9]{1,2}$'; then
         if [ "$host_node_major" = "$NODE_MAJOR" ]; then

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -309,6 +309,19 @@ _sync_deploy_targets() {
                 fi
                 rm -f "$GUARDIAN_ARCHIVE" 2>/dev/null || true
                 unset -f _redeploy_ssh
+                # A redeploy just changed the host's deployed_commit — re-probe
+                # so the pin sync AND the host_gateway_state.json persistence
+                # (both inside cc_align_host_sync below) see post-redeploy
+                # reality. Without this the state file keeps the PRE-redeploy
+                # payload and deploy_health reports host_guardian_drift until
+                # the nightly align timer re-probes. Best-effort: an empty
+                # re-probe keeps the original payload rather than degrading
+                # the pin sync.
+                _post_redeploy_raw="$(ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 \
+                    "${HOST_USER}@${HOST_IP}" version 2>/dev/null || true)"
+                if [ -n "$_post_redeploy_raw" ]; then
+                    HOST_VER_RAW="$_post_redeploy_raw"
+                fi
             else
                 echo "--- Guardian in sync (host ${HOST_DEPLOYED_COMMIT:-unknown} @ HEAD $DEPLOY_HASH) — skipping host redeploy ---"
             fi
@@ -882,7 +895,48 @@ fi
 NEW_TAG=$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "untagged")
 NEW_COMMIT=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 
-if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
+# BEGIN tier2-baseline-check (extracted by tests/test_scripts/test_update_tier2_baseline.py)
+# Tier-2 pending vs the RECORDED baseline: bare merges may have advanced HEAD
+# past the last update.sh run without activating tier-2 (units, hooks, pins).
+# "No new commits from THIS pull" is then the wrong shortcut — the deploy-
+# staleness alert explicitly advertises "run scripts/update.sh" as the
+# recovery, so a no-op pull must still fall through to full activation
+# (bootstrap + migrations + restart + a fresh update_history baseline) when
+# update.sh-only paths changed since the last recorded success. Returns 0
+# (pending) when the diff is non-empty OR errors (fail toward the full run);
+# baseline unknown/unresolvable (pre-first-update install, rewritten history)
+# returns 1 — shortcut as before, the awareness alert still covers it. Keep
+# the path list in LOCKSTEP with TIER2_PATHS in
+# src/genesis/observability/snapshots/deploy_health.py.
+_tier2_pending_since_baseline() {
+    local _baseline=""
+    if [ -f "$GENESIS_ROOT/data/genesis.db" ] && [ -x "$VENV_DIR/bin/python" ]; then
+        _baseline=$(GH_DB_PATH="$GENESIS_ROOT/data/genesis.db" \
+            "$VENV_DIR/bin/python" - 2>/dev/null <<'PYEOF' || true
+import os
+import sqlite3
+
+conn = sqlite3.connect(f"file:{os.environ['GH_DB_PATH']}?mode=ro", uri=True)
+row = conn.execute(
+    "SELECT new_commit FROM update_history WHERE status='success' "
+    "ORDER BY datetime(completed_at) DESC LIMIT 1"
+).fetchone()
+print((row[0] or "").strip() if row else "")
+PYEOF
+        )
+    fi
+    [ -n "$_baseline" ] || return 1
+    git -C "$GENESIS_ROOT" cat-file -e "${_baseline}^{commit}" 2>/dev/null || return 1
+    ! git -C "$GENESIS_ROOT" diff --quiet "$_baseline" HEAD -- \
+        scripts/systemd scripts/bootstrap.sh scripts/update.sh \
+        scripts/lib/cc_version.sh scripts/hooks pyproject.toml 2>/dev/null
+}
+# END tier2-baseline-check
+
+if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]] && _tier2_pending_since_baseline; then
+    echo "  No new commits, but update.sh-only paths changed since the last recorded"
+    echo "  update — running full activation (bootstrap + migrations + restart)."
+elif [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
     echo "  Already up to date ($NEW_COMMIT)."
     # Clean up unnecessary rollback tag and disarm trap
     trap - ERR

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -359,30 +359,28 @@ async def _check_deploy_staleness(db) -> None:
             # new missing unit months later would inherit this incident's
             # clock via MIN(created_at) and page instantly instead of after
             # 24h. Cheap no-op when nothing matches.
-            await db.execute(
-                "UPDATE observations SET resolution_notes='deploy staleness cleared' "
-                "WHERE source='deploy_staleness_monitor' "
-                "AND content LIKE '%missing_units%' AND resolution_notes=?",
-                (_DEPLOY_SUPERSEDED_NOTE,),
+            await observations.rewrite_resolution_notes(
+                db,
+                source="deploy_staleness_monitor",
+                from_notes=_DEPLOY_SUPERSEDED_NOTE,
+                to_notes="deploy staleness cleared",
+                content_like="%missing_units%",
             )
-            await db.commit()
         if not critical and "missing_units" in classes:
             # Escalate a missing unit that has been alerted for >24h. Anchor =
             # oldest prior alert naming missing units that is either still
             # unresolved or was superseded by a state change (NOT one resolved
             # by genuine recovery) — restart-safe, and immune to the
             # escalated row resetting the clock.
-            cur = await db.execute(
-                "SELECT MIN(created_at) FROM observations "
-                "WHERE source='deploy_staleness_monitor' "
-                "AND content LIKE '%missing_units%' "
-                "AND (resolved=0 OR resolution_notes=?)",
-                (_DEPLOY_SUPERSEDED_NOTE,),
+            anchor_created_at = await observations.oldest_created_at(
+                db,
+                source="deploy_staleness_monitor",
+                content_like="%missing_units%",
+                resolution_notes=_DEPLOY_SUPERSEDED_NOTE,
             )
-            row = await cur.fetchone()
-            if row and row[0]:
+            if anchor_created_at:
                 try:
-                    first = datetime.fromisoformat(row[0])
+                    first = datetime.fromisoformat(anchor_created_at)
                     if first.tzinfo is None:
                         first = first.replace(tzinfo=UTC)
                     age_s = (datetime.now(UTC) - first).total_seconds()
@@ -402,13 +400,14 @@ async def _check_deploy_staleness(db) -> None:
         content_hash = hashlib.sha256(f"deploy_staleness:{alert_key}".encode()).hexdigest()
         # Keep exactly ONE active alert = the current state (same rationale as
         # the embedding-backlog band supersede above).
-        await db.execute(
-            "UPDATE observations SET resolved=1, resolved_at=?, resolution_notes=? "
-            "WHERE source='deploy_staleness_monitor' "
-            "AND type='infrastructure_alert' AND resolved=0 AND content_hash != ?",
-            (datetime.now(UTC).isoformat(), _DEPLOY_SUPERSEDED_NOTE, content_hash),
+        await observations.supersede_except_hash(
+            db,
+            source="deploy_staleness_monitor",
+            type="infrastructure_alert",
+            keep_content_hash=content_hash,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=_DEPLOY_SUPERSEDED_NOTE,
         )
-        await db.commit()
 
         missing_units = snap.get("missing_units") or []
         tier2 = snap.get("tier2_pending") or []
@@ -475,12 +474,12 @@ async def _resolve_deploy_staleness(db) -> None:
             resolved_at=datetime.now(UTC).isoformat(),
             resolution_notes="auto-resolved: deploy staleness cleared",
         )
-        await db.execute(
-            "UPDATE observations SET resolution_notes='deploy staleness cleared' "
-            "WHERE source='deploy_staleness_monitor' AND resolution_notes=?",
-            (_DEPLOY_SUPERSEDED_NOTE,),
+        await observations.rewrite_resolution_notes(
+            db,
+            source="deploy_staleness_monitor",
+            from_notes=_DEPLOY_SUPERSEDED_NOTE,
+            to_notes="deploy staleness cleared",
         )
-        await db.commit()
         if resolved:
             _last_deploy_alert_at = 0.0
             _last_deploy_alert_key = ""

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -293,6 +293,192 @@ async def _resolve_embedding_backlog(db) -> None:
         logger.debug("Failed to resolve embedding backlog alerts", exc_info=True)
 
 
+# Deploy staleness (WS-B): merged ≠ deployed. A bare git-merge between
+# update.sh runs deploys code but silently skips tier-2 activation (systemd
+# unit installation, guardian host redeploy, CC/Node pins) — observed live
+# 2026-07-13: six days of manual merges left a shipped timer uninstalled and
+# the host guardian a week behind, with zero signal anywhere. The collectors
+# live in observability/snapshots/deploy_health.py (shared with the health
+# snapshot); this check is the alerting layer. Hybrid severity: any drift is
+# a non-paging 'high' (dashboard); 'critical' (pages Telegram) only when
+# SUSTAINED — the last successful update is ≥7 days old AND the repo is ≥20
+# commits behind, or a missing systemd unit has been alerted for >24h.
+# Slow-moving by nature → hourly cadence (the WAL-truncate block).
+_DEPLOY_STALE_DAYS = 7.0
+_DEPLOY_STALE_COMMITS = 20
+_DEPLOY_MISSING_UNIT_CRITICAL_S = 24 * 3600
+_DEPLOY_ALERT_COOLDOWN_S = 6 * 3600  # same-state re-alerts at most every 6h
+# The exact note written when a row is superseded by a state change. The >24h
+# missing-unit escalation anchors on the OLDEST row still carrying this note
+# (or unresolved) so escalating cannot reset its own clock; recovery rewrites
+# the note so retired anchors can never resurrect a future alert.
+_DEPLOY_SUPERSEDED_NOTE = "superseded by a new deploy-staleness alert state"
+_last_deploy_alert_at: float = 0.0
+_last_deploy_alert_key: str = ""
+
+
+async def _check_deploy_staleness(db) -> None:
+    """Alert when merged changes have not been DEPLOYED here (see block comment).
+
+    Best-effort — the whole body is guarded and never raises into the tick."""
+    global _last_deploy_alert_at, _last_deploy_alert_key
+    if db is None:
+        return
+    try:
+        # Submodule import (the package __init__ shadows the submodule name
+        # with the function of the same name) — resolved per call, so tests
+        # can monkeypatch the module attribute.
+        from genesis.observability.snapshots.deploy_health import deploy_health
+
+        snap = await deploy_health(db)
+        if snap.get("status") == "error":
+            return
+        findings = snap.get("findings") or []
+        if not findings:
+            await _resolve_deploy_staleness(db)
+            return
+
+        # Alert identity keys on the finding CLASSES, not the raw keys —
+        # per-run count drift (behind_upstream:52 -> :53) must not defeat
+        # dedup or churn out a new observation every hour.
+        classes = sorted({f.split(":", 1)[0] for f in findings})
+
+        update = snap.get("last_update") or {}
+        git_facts = snap.get("git") or {}
+        age_days = update.get("age_days")
+        behind = git_facts.get("commits_behind_upstream")
+        critical = (
+            age_days is not None
+            and behind is not None
+            and age_days >= _DEPLOY_STALE_DAYS
+            and behind >= _DEPLOY_STALE_COMMITS
+        )
+        if not critical and "missing_units" in classes:
+            # Escalate a missing unit that has been alerted for >24h. Anchor =
+            # oldest prior alert naming missing units that is either still
+            # unresolved or was superseded by a state change (NOT one resolved
+            # by genuine recovery) — restart-safe, and immune to the
+            # escalated row resetting the clock.
+            cur = await db.execute(
+                "SELECT MIN(created_at) FROM observations "
+                "WHERE source='deploy_staleness_monitor' "
+                "AND content LIKE '%missing_units%' "
+                "AND (resolved=0 OR resolution_notes=?)",
+                (_DEPLOY_SUPERSEDED_NOTE,),
+            )
+            row = await cur.fetchone()
+            if row and row[0]:
+                try:
+                    first = datetime.fromisoformat(row[0])
+                    if first.tzinfo is None:
+                        first = first.replace(tzinfo=UTC)
+                    age_s = (datetime.now(UTC) - first).total_seconds()
+                    critical = age_s >= _DEPLOY_MISSING_UNIT_CRITICAL_S
+                except ValueError:
+                    pass
+
+        priority = "critical" if critical else "high"
+        alert_key = ",".join(classes) + ":" + priority
+        now = time.monotonic()
+        if (
+            now - _last_deploy_alert_at < _DEPLOY_ALERT_COOLDOWN_S
+            and alert_key == _last_deploy_alert_key
+        ):
+            return
+
+        content_hash = hashlib.sha256(f"deploy_staleness:{alert_key}".encode()).hexdigest()
+        # Keep exactly ONE active alert = the current state (same rationale as
+        # the embedding-backlog band supersede above).
+        await db.execute(
+            "UPDATE observations SET resolved=1, resolved_at=?, resolution_notes=? "
+            "WHERE source='deploy_staleness_monitor' "
+            "AND type='infrastructure_alert' AND resolved=0 AND content_hash != ?",
+            (datetime.now(UTC).isoformat(), _DEPLOY_SUPERSEDED_NOTE, content_hash),
+        )
+        await db.commit()
+
+        missing_units = snap.get("missing_units") or []
+        tier2 = snap.get("tier2_pending") or []
+        host = snap.get("host_gateway") or {}
+        detail: list[str] = []
+        if age_days is not None:
+            detail.append(f"last successful update.sh: {age_days} days ago")
+        if behind is not None:
+            fetch_age = git_facts.get("fetch_age_hours")
+            detail.append(
+                f"{behind} commits behind upstream"
+                + (f" (as of last fetch, {fetch_age}h ago)" if fetch_age is not None else "")
+            )
+        if missing_units:
+            detail.append("missing systemd units: " + ", ".join(missing_units))
+        if tier2:
+            detail.append(f"{len(tier2)} update.sh-only file(s) changed since the last update")
+        if host.get("status") in ("drift", "unknown_commit"):
+            detail.append(
+                f"host guardian: {host.get('status')} "
+                f"(deployed_commit={host.get('deployed_commit')})"
+            )
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="deploy_staleness_monitor",
+            type="infrastructure_alert",
+            content=(
+                "Merged changes are NOT fully deployed on this install — "
+                + "; ".join(detail)
+                + ". Bare git merges deploy code but skip tier-2 activation "
+                "(systemd units, guardian host redeploy, CC/Node pins). "
+                "Recovery: run scripts/update.sh from ~/genesis. "
+                f"[findings: {', '.join(findings)}]"
+            ),
+            priority=priority,
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        if created is None:
+            return  # An unresolved alert for this exact state already exists.
+        _last_deploy_alert_at = now
+        _last_deploy_alert_key = alert_key
+        logger.warning("Deploy staleness alert (%s): %s", priority, ", ".join(findings))
+    except Exception:
+        logger.debug("Failed deploy staleness check", exc_info=True)
+
+
+async def _resolve_deploy_staleness(db) -> None:
+    """Resolve outstanding deploy-staleness alerts once no findings remain.
+
+    Also rewrites the superseded-row note so retired rows stop serving as
+    >24h escalation anchors — without this, a missing unit months from now
+    would inherit an ancient anchor and page instantly."""
+    global _last_deploy_alert_at, _last_deploy_alert_key
+    if db is None:
+        return
+    try:
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source="deploy_staleness_monitor",
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="auto-resolved: deploy staleness cleared",
+        )
+        await db.execute(
+            "UPDATE observations SET resolution_notes='deploy staleness cleared' "
+            "WHERE source='deploy_staleness_monitor' AND resolution_notes=?",
+            (_DEPLOY_SUPERSEDED_NOTE,),
+        )
+        await db.commit()
+        if resolved:
+            _last_deploy_alert_at = 0.0
+            _last_deploy_alert_key = ""
+            logger.info(
+                "Auto-resolved %d deploy-staleness alert observation(s) on recovery",
+                resolved,
+            )
+    except Exception:
+        logger.debug("Failed to resolve deploy staleness alerts", exc_info=True)
+
+
 # Duplicate CC executor: two live `claude` processes executing the SAME
 # conversation transcript (2026-07-13 incident: dropped SSH left a session
 # running headless; resume spawned a second executor over one transcript —
@@ -1494,6 +1680,11 @@ class AwarenessLoop:
                     # healing, so the hourly cadence fits; self-resolves when the
                     # backlog clears. Best-effort (guarded internally).
                     await _check_embedding_backlog(self._db)
+                    # Deploy staleness — merged-vs-deployed drift (update.sh age,
+                    # commits behind, missing units, host guardian). Day-scale
+                    # signal → hourly; self-resolves on recovery. Best-effort
+                    # (guarded internally); collectors never do network I/O.
+                    await _check_deploy_staleness(self._db)
                 await _check_wal_health(self._db)
                 # Duplicate CC executor — a twin lasts MINUTES, so this pages
                 # per-tick (hourly would miss the incident window entirely);

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -215,15 +215,14 @@ async def _check_embedding_backlog(db) -> None:
         # row active, instead of a lingering peak-severity row until the
         # backlog fully clears (< LOW). DB-based (not the in-memory band), so
         # it is restart-safe; a no-op in steady state at a fixed band.
-        await db.execute(
-            "UPDATE observations SET resolved=1, resolved_at=?, "
-            "resolution_notes='superseded by a new embedding-backlog band' "
-            "WHERE source='embedding_backlog_monitor' "
-            "AND type='infrastructure_alert' AND resolved=0 "
-            "AND content_hash != ?",
-            (datetime.now(UTC).isoformat(), content_hash),
+        await observations.supersede_except_hash(
+            db,
+            source="embedding_backlog_monitor",
+            type="infrastructure_alert",
+            keep_content_hash=content_hash,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="superseded by a new embedding-backlog band",
         )
-        await db.commit()
         created = await observations.create(
             db,
             id=str(uuid.uuid4()),

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -301,11 +301,11 @@ async def _resolve_embedding_backlog(db) -> None:
 # live in observability/snapshots/deploy_health.py (shared with the health
 # snapshot); this check is the alerting layer. Hybrid severity: any drift is
 # a non-paging 'high' (dashboard); 'critical' (pages Telegram) only when
-# SUSTAINED — the last successful update is ≥7 days old AND the repo is ≥20
-# commits behind, or a missing systemd unit has been alerted for >24h.
+# SUSTAINED — the 'stale_update' finding class (last successful update ≥7
+# days old AND ≥20 commits behind; thresholds live beside derive_findings in
+# deploy_health.py, the single producer of finding keys), or a missing
+# systemd unit that has been alerted for >24h.
 # Slow-moving by nature → hourly cadence (the WAL-truncate block).
-_DEPLOY_STALE_DAYS = 7.0
-_DEPLOY_STALE_COMMITS = 20
 _DEPLOY_MISSING_UNIT_CRITICAL_S = 24 * 3600
 _DEPLOY_ALERT_COOLDOWN_S = 6 * 3600  # same-state re-alerts at most every 6h
 # The exact note written when a row is superseded by a state change. The >24h
@@ -347,12 +347,25 @@ async def _check_deploy_staleness(db) -> None:
         git_facts = snap.get("git") or {}
         age_days = update.get("age_days")
         behind = git_facts.get("commits_behind_upstream")
-        critical = (
-            age_days is not None
-            and behind is not None
-            and age_days >= _DEPLOY_STALE_DAYS
-            and behind >= _DEPLOY_STALE_COMMITS
-        )
+        # The sustained condition is a finding CLASS (derive_findings owns the
+        # ≥7d AND ≥20-commits formula) — deriving it from raw facts here would
+        # re-open the gap where the facts say "critical" but no finding
+        # survived the gate, so nothing alerted at all.
+        critical = "stale_update" in classes
+        if "missing_units" not in classes:
+            # Partial recovery: the missing-units class cleared while OTHER
+            # drift persists. Retire any superseded missing-units anchors NOW
+            # (full recovery does this in _resolve_deploy_staleness) — else a
+            # new missing unit months later would inherit this incident's
+            # clock via MIN(created_at) and page instantly instead of after
+            # 24h. Cheap no-op when nothing matches.
+            await db.execute(
+                "UPDATE observations SET resolution_notes='deploy staleness cleared' "
+                "WHERE source='deploy_staleness_monitor' "
+                "AND content LIKE '%missing_units%' AND resolution_notes=?",
+                (_DEPLOY_SUPERSEDED_NOTE,),
+            )
+            await db.commit()
         if not critical and "missing_units" in classes:
             # Escalate a missing unit that has been alerted for >24h. Anchor =
             # oldest prior alert naming missing units that is either still

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -651,6 +651,87 @@ async def resolve_by_content_hash(
     return cursor.rowcount
 
 
+async def supersede_except_hash(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    type: str,
+    keep_content_hash: str,
+    resolved_at: str,
+    resolution_notes: str,
+) -> int:
+    """Resolve every unresolved source+type row EXCEPT the given content_hash.
+
+    The "exactly one active alert = the current state" pattern (embedding
+    backlog, deploy staleness): the caller is about to create/keep the
+    current-state row and retires any other-state siblings so a state
+    transition never leaves a stale peak-severity row standing.
+
+    Returns the number of rows superseded.
+    """
+    cursor = await db.execute(
+        "UPDATE observations SET resolved = 1, resolved_at = ?, "
+        "resolution_notes = ? "
+        "WHERE source = ? AND type = ? AND resolved = 0 AND content_hash != ?",
+        (resolved_at, resolution_notes, source, type, keep_content_hash),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def oldest_created_at(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    content_like: str,
+    resolution_notes: str,
+) -> str | None:
+    """MIN(created_at) over rows of a source whose content matches
+    ``content_like`` (SQL LIKE pattern) and that are either unresolved or
+    carry exactly ``resolution_notes``.
+
+    The deploy-staleness >24h escalation anchor: superseded-by-state-change
+    rows keep anchoring (so escalating can't reset its own clock) while
+    genuinely-recovered rows (different notes) never do.
+    """
+    cursor = await db.execute(
+        "SELECT MIN(created_at) FROM observations "
+        "WHERE source = ? AND content LIKE ? "
+        "AND (resolved = 0 OR resolution_notes = ?)",
+        (source, content_like, resolution_notes),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row and row[0] else None
+
+
+async def rewrite_resolution_notes(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    from_notes: str,
+    to_notes: str,
+    content_like: str | None = None,
+) -> int:
+    """Rewrite ``resolution_notes`` on a source's rows (optionally content-
+    filtered) — retiring rows from note-keyed roles such as the escalation
+    anchor above. Returns the number of rows rewritten.
+    """
+    if content_like is None:
+        cursor = await db.execute(
+            "UPDATE observations SET resolution_notes = ? "
+            "WHERE source = ? AND resolution_notes = ?",
+            (to_notes, source, from_notes),
+        )
+    else:
+        cursor = await db.execute(
+            "UPDATE observations SET resolution_notes = ? "
+            "WHERE source = ? AND resolution_notes = ? AND content LIKE ?",
+            (to_notes, source, from_notes, content_like),
+        )
+    await db.commit()
+    return cursor.rowcount
+
+
 # -- Surfacing ----------------------------------------------------------------
 
 

--- a/src/genesis/db/crud/update_history.py
+++ b/src/genesis/db/crud/update_history.py
@@ -23,3 +23,20 @@ async def last_successful_deploy_commit(db: aiosqlite.Connection) -> str | None:
     )
     row = await cur.fetchone()
     return str(row[0]).strip() if row and row[0] else None
+
+
+async def last_successful_update(db: aiosqlite.Connection) -> tuple[str, str] | None:
+    """``(completed_at, new_commit)`` of the most recent successful update.
+
+    None when the table is empty (pre-first-update install). Ordered by
+    ``datetime(completed_at)`` — the deploy-staleness age axis cares about
+    when the update FINISHED, and datetime() compares mixed-offset ISO
+    timestamps by true instant."""
+    cur = await db.execute(
+        "SELECT completed_at, new_commit FROM update_history "
+        "WHERE status = 'success' ORDER BY datetime(completed_at) DESC LIMIT 1"
+    )
+    row = await cur.fetchone()
+    if not row or not row[0]:
+        return None
+    return str(row[0]), str(row[1] or "")

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -190,6 +190,7 @@ class HealthDataService:
             cc_sessions,
             conversation_activity,
             cost,
+            deploy_health,
             eval_staleness,
             infrastructure,
             mcp_status,
@@ -249,6 +250,9 @@ class HealthDataService:
             asyncio.to_thread(proactive_memory_metrics),
             # APPENDED last so the 16 existing positions are untouched (see unpack).
             self._recent_provider_fallbacks(),
+            # Deploy staleness — merged-vs-deployed drift (update.sh age, commits
+            # behind, missing units, host guardian). Does its own to_thread.
+            deploy_health(self._db),
             return_exceptions=True,
         )
         # Isolate any failed section uniformly: one raising sub-snapshot degrades
@@ -259,6 +263,7 @@ class HealthDataService:
             r_cost, r_awareness, r_outreach, r_mcp, r_provider_activity,
             r_memory_health, r_eval_staleness, r_vcr,
             r_services, r_conversation, r_proactive, r_provider_fallbacks,
+            r_deploy_health,
         ) = results
 
         # Surface infra probe healthy<->unhealthy transitions to the activity
@@ -298,6 +303,7 @@ class HealthDataService:
             "memory_health": r_memory_health,
             "provider_health": self._serialize_provider_health(),
             "eval_staleness": r_eval_staleness,
+            "deploy_health": r_deploy_health,
             "vcr": r_vcr,
         }
 

--- a/src/genesis/observability/snapshots/__init__.py
+++ b/src/genesis/observability/snapshots/__init__.py
@@ -12,6 +12,7 @@ from genesis.observability.snapshots.call_sites import call_sites
 from genesis.observability.snapshots.cc_sessions import cc_sessions
 from genesis.observability.snapshots.conversation import conversation_activity
 from genesis.observability.snapshots.cost import cost
+from genesis.observability.snapshots.deploy_health import deploy_health
 from genesis.observability.snapshots.eval_staleness import eval_staleness
 from genesis.observability.snapshots.infrastructure import (
     infrastructure,
@@ -33,6 +34,7 @@ __all__ = [
     "cc_sessions",
     "conversation_activity",
     "cost",
+    "deploy_health",
     "eval_staleness",
     "infrastructure",
     "mcp_status",

--- a/src/genesis/observability/snapshots/deploy_health.py
+++ b/src/genesis/observability/snapshots/deploy_health.py
@@ -231,14 +231,12 @@ async def last_success_update(db: aiosqlite.Connection | None) -> dict:
     if db is None:
         return {"completed_at": None, "new_commit": None, "age_days": None}
     try:
-        cursor = await db.execute(
-            "SELECT completed_at, new_commit FROM update_history "
-            "WHERE status='success' ORDER BY completed_at DESC LIMIT 1"
-        )
-        row = await cursor.fetchone()
-        if not row or not row[0]:
+        from genesis.db.crud.update_history import last_successful_update
+
+        row = await last_successful_update(db)
+        if row is None:
             return {"completed_at": None, "new_commit": None, "age_days": None}
-        completed_at, new_commit = row[0], row[1]
+        completed_at, new_commit = row[0], (row[1] or None)
         age_days = None
         try:
             completed_dt = datetime.fromisoformat(completed_at)

--- a/src/genesis/observability/snapshots/deploy_health.py
+++ b/src/genesis/observability/snapshots/deploy_health.py
@@ -257,18 +257,32 @@ async def last_success_update(db: aiosqlite.Connection | None) -> dict:
         return {"completed_at": None, "new_commit": None, "age_days": None}
 
 
+# Sustained-staleness thresholds (the awareness check's paging axis). A
+# finding-CLASS boundary, so they live here beside derive_findings — the
+# single producer of finding keys — not in the awareness layer: an alert
+# formula written against facts the findings gate can filter out first is
+# exactly the bug this placement prevents.
+STALE_UPDATE_DAYS = 7.0
+STALE_UPDATE_COMMITS = 20
+
+
 def derive_findings(
     *,
     missing_units: list[str] | None,
     tier2_pending: list[str] | None,
     host_gateway: dict,
     commits_behind: int | None,
+    update_age_days: float | None = None,
     behind_threshold: int = 50,
 ) -> list[str]:
     """Stable, order-deterministic finding keys — the alert/dedup contract.
 
     Keys (not prose) so the awareness check can hash them for observation
-    dedup and tests can assert exactly."""
+    dedup and tests can assert exactly. Two behind-related classes with
+    DIFFERENT thresholds: ``stale_update`` (≥STALE_UPDATE_DAYS old AND
+    ≥STALE_UPDATE_COMMITS behind — the sustained condition the awareness
+    check pages on) and ``behind_upstream`` (> behind_threshold regardless
+    of update age — a plain volume signal)."""
     findings: list[str] = []
     if missing_units:
         findings.append("missing_units:" + ",".join(sorted(missing_units)))
@@ -278,6 +292,13 @@ def derive_findings(
         findings.append("host_guardian_drift")
     elif host_gateway.get("status") == "unknown_commit":
         findings.append("host_guardian_unknown_commit")
+    if (
+        update_age_days is not None
+        and commits_behind is not None
+        and update_age_days >= STALE_UPDATE_DAYS
+        and commits_behind >= STALE_UPDATE_COMMITS
+    ):
+        findings.append(f"stale_update:{round(update_age_days, 1)}d,{commits_behind}behind")
     if commits_behind is not None and commits_behind > behind_threshold:
         findings.append(f"behind_upstream:{commits_behind}")
     return findings
@@ -315,6 +336,7 @@ async def deploy_health(db: aiosqlite.Connection | None) -> dict:
             tier2_pending=tier2,
             host_gateway=collected["host_gateway"],
             commits_behind=collected["git"].get("commits_behind_upstream"),
+            update_age_days=update.get("age_days"),
         )
         return {
             "status": "attention" if findings else "healthy",

--- a/src/genesis/observability/snapshots/deploy_health.py
+++ b/src/genesis/observability/snapshots/deploy_health.py
@@ -1,0 +1,330 @@
+"""Deploy-staleness snapshot — is what's MERGED actually DEPLOYED here?
+
+Genesis installs pull merged PRs two ways: a full ``scripts/update.sh`` run
+(bootstrap + migrations + systemd sync + guardian redeploy + pin healing) or a
+bare ``git merge`` between updates. The bare merge deploys tier-1 (code loads
+on restart, schema migrations self-apply at boot) but silently skips tier-2 —
+systemd unit installation, guardian host redeploy, CC/Node pins. Observed
+live 2026-07-13: six days of manual merges left a shipped timer uninstalled
+and the host guardian 67 files behind, with zero signal anywhere.
+
+This snapshot makes that drift visible:
+
+- ``last_update``  — most recent successful ``update_history`` row + age
+- ``git``          — commits behind upstream, fetch age (local refs only —
+  NEVER fetches; a health probe must not do network I/O)
+- ``units``        — systemd unit files missing vs ``scripts/systemd/*.template``
+- ``tier2_pending`` — update.sh-only paths changed since the last successful
+  update (the predictive "you need to run update.sh" signal)
+- ``host_gateway`` — guardian host deployed_commit drift vs HEAD, read from
+  the state file the nightly cc-align timer / update.sh write (no SSH here)
+
+The awareness tick's ``_check_deploy_staleness`` consumes the same collectors
+to raise a dashboard/morning-report observation. Everything is best-effort:
+collectors degrade to ``None``/empty and never raise into the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+# Same-package probe helper: never raises, rc -1 = timeout, -2 = exec failure.
+from genesis.observability.git_health import _CHEAP_TIMEOUT_S, _run_git
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Paths whose changes only ACTIVATE via scripts/update.sh (tier-2). A bare
+# git-merge that touches these leaves the install running stale plumbing until
+# update.sh runs. File-level granularity is deliberate — a docs-only edit to
+# bootstrap.sh costs one advisory observation, not a missed deploy.
+TIER2_PATHS = (
+    "scripts/systemd",
+    "scripts/bootstrap.sh",
+    "scripts/update.sh",
+    "scripts/lib/cc_version.sh",
+    "scripts/hooks",
+    "pyproject.toml",
+)
+
+# Guardian-relevant paths — keep in LOCKSTEP with update.sh GUARDIAN_PATHS
+# (the redeploy trigger). If update.sh's list changes, change this one.
+GUARDIAN_HOST_PATHS = (
+    "src/genesis/guardian",
+    "src/genesis/util",
+    "src/genesis/env.py",
+    "src/genesis/observability",
+    "src/genesis/db",
+    "config/guardian-claude.md",
+    "config/genesis-guardian.service",
+    "config/genesis-guardian.timer",
+    "config/genesis-guardian-watchman.service",
+    "config/genesis-guardian-watchman.timer",
+    "pyproject.toml",
+    "scripts/install_guardian.sh",
+    "scripts/guardian-gateway.sh",
+)
+
+_HOST_STATE_FILE = "host_gateway_state.json"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+# ── Collectors (sync, injectable paths, never raise) ────────────────
+
+
+def collect_git_facts(repo: Path, now: datetime | None = None) -> dict:
+    """Local-refs-only git staleness facts. No network, ever."""
+    now = now or _utcnow()
+    facts: dict = {
+        "head": None,
+        "commits_behind_upstream": None,
+        "fetch_age_hours": None,
+    }
+    try:
+        rc, out, _ = _run_git(repo, "rev-parse", "--short", "HEAD", timeout=_CHEAP_TIMEOUT_S)
+        if rc == 0:
+            facts["head"] = out.strip()
+        # Behind-count against the current branch's upstream (origin/main on a
+        # standard install). Counts against the LAST FETCHED state — pair with
+        # fetch_age_hours to judge how trustworthy the number is.
+        rc, out, _ = _run_git(
+            repo, "rev-list", "--count", "HEAD..@{upstream}", timeout=_CHEAP_TIMEOUT_S
+        )
+        if rc == 0:
+            facts["commits_behind_upstream"] = int(out.strip())
+        rc, gcd, _ = _run_git(repo, "rev-parse", "--git-common-dir", timeout=_CHEAP_TIMEOUT_S)
+        if rc == 0 and gcd.strip():
+            git_dir = Path(gcd.strip())
+            if not git_dir.is_absolute():
+                git_dir = repo / git_dir
+            fetch_head = git_dir / "FETCH_HEAD"
+            if fetch_head.exists():
+                age_s = now.timestamp() - fetch_head.stat().st_mtime
+                facts["fetch_age_hours"] = round(age_s / 3600, 1)
+    except Exception:
+        logger.debug("deploy_health: git facts collection failed", exc_info=True)
+    return facts
+
+
+def collect_missing_units(template_dir: Path, unit_dir: Path) -> list[str] | None:
+    """Systemd unit files expected from templates but absent from the user
+    unit dir. Bootstrap syncs EVERY ``*.template`` (opt-in applies to timer
+    ENABLEMENT, not file presence), so any missing file means bootstrap has
+    not run since that template landed. ``None`` = could not determine."""
+    try:
+        if not template_dir.is_dir():
+            return None
+        expected = sorted(t.name.removesuffix(".template") for t in template_dir.glob("*.template"))
+        if not expected:
+            return None
+        return [name for name in expected if not (unit_dir / name).exists()]
+    except Exception:
+        logger.debug("deploy_health: unit comparison failed", exc_info=True)
+        return None
+
+
+def collect_tier2_pending(repo: Path, since_commit: str | None) -> list[str] | None:
+    """Tier-2 files changed since the last successful update.sh commit.
+
+    Non-empty means "a bare merge brought update.sh-only changes" — the
+    predictive signal. ``None`` = no baseline (no successful update recorded,
+    or its commit no longer resolves after a rebase/gc)."""
+    if not since_commit:
+        return None
+    try:
+        rc, _, _ = _run_git(
+            repo, "cat-file", "-e", f"{since_commit}^{{commit}}", timeout=_CHEAP_TIMEOUT_S
+        )
+        if rc != 0:
+            return None
+        rc, out, _ = _run_git(
+            repo,
+            "diff",
+            "--name-only",
+            f"{since_commit}..HEAD",
+            "--",
+            *TIER2_PATHS,
+            timeout=_CHEAP_TIMEOUT_S,
+        )
+        if rc != 0:
+            return None
+        return [line for line in out.splitlines() if line.strip()]
+    except Exception:
+        logger.debug("deploy_health: tier2 diff failed", exc_info=True)
+        return None
+
+
+def collect_host_gateway(repo: Path, state_path: Path, now: datetime | None = None) -> dict:
+    """Guardian host deploy drift, from the state file cc_align_host_sync
+    writes on every gateway ``version`` probe (update.sh + nightly timer).
+
+    ``status`` values: ``no_data`` (guardian-less install or probe never ran),
+    ``ok`` (host at HEAD or no guardian-path delta), ``drift`` (guardian paths
+    changed since the host's deployed commit), ``unknown_commit`` (host commit
+    doesn't resolve locally — converge via update.sh)."""
+    now = now or _utcnow()
+    try:
+        if not state_path.exists():
+            return {"status": "no_data"}
+        data = json.loads(state_path.read_text())
+        version = data.get("version") or {}
+        deployed = (version.get("deployed_commit") or "").strip()
+        checked_at = data.get("checked_at")
+        age_hours = None
+        if checked_at:
+            try:
+                checked_dt = datetime.fromisoformat(checked_at)
+                if checked_dt.tzinfo is None:
+                    checked_dt = checked_dt.replace(tzinfo=UTC)
+                age_hours = round((now - checked_dt).total_seconds() / 3600, 1)
+            except ValueError:
+                pass
+        out: dict = {
+            "deployed_commit": deployed or None,
+            "checked_at": checked_at,
+            "age_hours": age_hours,
+        }
+        if not deployed or deployed == "unknown":
+            out["status"] = "unknown_commit"
+            return out
+        rc, _, _ = _run_git(
+            repo, "cat-file", "-e", f"{deployed}^{{commit}}", timeout=_CHEAP_TIMEOUT_S
+        )
+        if rc != 0:
+            out["status"] = "unknown_commit"
+            return out
+        rc, diff_out, _ = _run_git(
+            repo,
+            "diff",
+            "--name-only",
+            f"{deployed}..HEAD",
+            "--",
+            *GUARDIAN_HOST_PATHS,
+            timeout=_CHEAP_TIMEOUT_S,
+        )
+        if rc != 0:
+            out["status"] = "unknown_commit"
+            return out
+        drift_files = [line for line in diff_out.splitlines() if line.strip()]
+        out["drift_files"] = len(drift_files)
+        out["status"] = "drift" if drift_files else "ok"
+        return out
+    except Exception:
+        logger.debug("deploy_health: host gateway check failed", exc_info=True)
+        return {"status": "no_data"}
+
+
+async def last_success_update(db: aiosqlite.Connection | None) -> dict:
+    """Most recent successful update_history row (age computed by caller UIs).
+
+    ``None`` fields = table missing/empty (pre-first-update install)."""
+    if db is None:
+        return {"completed_at": None, "new_commit": None, "age_days": None}
+    try:
+        cursor = await db.execute(
+            "SELECT completed_at, new_commit FROM update_history "
+            "WHERE status='success' ORDER BY completed_at DESC LIMIT 1"
+        )
+        row = await cursor.fetchone()
+        if not row or not row[0]:
+            return {"completed_at": None, "new_commit": None, "age_days": None}
+        completed_at, new_commit = row[0], row[1]
+        age_days = None
+        try:
+            completed_dt = datetime.fromisoformat(completed_at)
+            if completed_dt.tzinfo is None:
+                completed_dt = completed_dt.replace(tzinfo=UTC)
+            age_days = round((_utcnow() - completed_dt).total_seconds() / 86400, 1)
+        except ValueError:
+            pass
+        return {
+            "completed_at": completed_at,
+            "new_commit": new_commit,
+            "age_days": age_days,
+        }
+    except Exception:
+        logger.debug("deploy_health: update_history query failed", exc_info=True)
+        return {"completed_at": None, "new_commit": None, "age_days": None}
+
+
+def derive_findings(
+    *,
+    missing_units: list[str] | None,
+    tier2_pending: list[str] | None,
+    host_gateway: dict,
+    commits_behind: int | None,
+    behind_threshold: int = 50,
+) -> list[str]:
+    """Stable, order-deterministic finding keys — the alert/dedup contract.
+
+    Keys (not prose) so the awareness check can hash them for observation
+    dedup and tests can assert exactly."""
+    findings: list[str] = []
+    if missing_units:
+        findings.append("missing_units:" + ",".join(sorted(missing_units)))
+    if tier2_pending:
+        findings.append(f"tier2_pending:{len(tier2_pending)}")
+    if host_gateway.get("status") == "drift":
+        findings.append("host_guardian_drift")
+    elif host_gateway.get("status") == "unknown_commit":
+        findings.append("host_guardian_unknown_commit")
+    if commits_behind is not None and commits_behind > behind_threshold:
+        findings.append(f"behind_upstream:{commits_behind}")
+    return findings
+
+
+# ── Snapshot entry point (HealthDataService) ────────────────────────
+
+
+def _collect_sync(repo: Path, genesis_home_dir: Path) -> dict:
+    """All filesystem/git collectors in one worker-thread hop."""
+    git_facts = collect_git_facts(repo)
+    missing_units = collect_missing_units(
+        repo / "scripts" / "systemd",
+        Path.home() / ".config" / "systemd" / "user",
+    )
+    host_gateway = collect_host_gateway(repo, genesis_home_dir / _HOST_STATE_FILE)
+    return {
+        "git": git_facts,
+        "missing_units": missing_units,
+        "host_gateway": host_gateway,
+    }
+
+
+async def deploy_health(db: aiosqlite.Connection | None) -> dict:
+    """Snapshot section for HealthDataService — see module docstring."""
+    try:
+        from genesis.env import genesis_home, repo_root
+
+        repo = repo_root()
+        collected = await asyncio.to_thread(_collect_sync, repo, genesis_home())
+        update = await last_success_update(db)
+        tier2 = await asyncio.to_thread(collect_tier2_pending, repo, update.get("new_commit"))
+        findings = derive_findings(
+            missing_units=collected["missing_units"],
+            tier2_pending=tier2,
+            host_gateway=collected["host_gateway"],
+            commits_behind=collected["git"].get("commits_behind_upstream"),
+        )
+        return {
+            "status": "attention" if findings else "healthy",
+            "findings": findings,
+            "last_update": update,
+            "git": collected["git"],
+            "missing_units": collected["missing_units"],
+            "tier2_pending": tier2,
+            "host_gateway": collected["host_gateway"],
+        }
+    except Exception:
+        logger.error("deploy_health snapshot failed", exc_info=True)
+        return {"status": "error"}

--- a/tests/test_awareness/test_deploy_staleness_check.py
+++ b/tests/test_awareness/test_deploy_staleness_check.py
@@ -1,0 +1,207 @@
+"""Tests for the deploy-staleness awareness check (_check_deploy_staleness).
+
+The collectors (observability/snapshots/deploy_health.py) have their own tests;
+here the snapshot function is monkeypatched so each test controls the exact
+drift state. What's under test is the ALERTING state machine: hybrid severity
+(high on any drift, critical only sustained), class-keyed dedup that survives
+per-run count drift, the >24h missing-unit escalation anchor (restart-safe,
+immune to its own escalation resetting the clock), supersede-on-state-change,
+and resolve-on-recovery.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.awareness import loop
+from genesis.db.schema import create_all_tables
+
+# The snapshots package __init__ shadows the submodule name with the function
+# of the same name, so a plain `import … as dh_module` binds the FUNCTION.
+# import_module returns the real module — the attribute loop.py resolves at
+# call time, so patching it here is what the check actually sees.
+dh_module = importlib.import_module("genesis.observability.snapshots.deploy_health")
+
+SOURCE = "deploy_staleness_monitor"
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldowns(monkeypatch):
+    monkeypatch.setattr(loop, "_last_deploy_alert_at", 0.0)
+    monkeypatch.setattr(loop, "_last_deploy_alert_key", "")
+
+
+def _snap(
+    findings,
+    *,
+    age_days=None,
+    behind=None,
+    missing_units=None,
+    tier2=None,
+    host_status="ok",
+):
+    return {
+        "status": "attention" if findings else "healthy",
+        "findings": findings,
+        "last_update": {"age_days": age_days, "new_commit": "abc", "completed_at": "x"},
+        "git": {"head": "abc", "commits_behind_upstream": behind, "fetch_age_hours": 1.0},
+        "missing_units": missing_units or [],
+        "tier2_pending": tier2 or [],
+        "host_gateway": {"status": host_status},
+    }
+
+
+def _patch_snapshot(monkeypatch, snap):
+    async def fake(db):
+        return snap
+
+    monkeypatch.setattr(dh_module, "deploy_health", fake)
+
+
+async def _rows(db, resolved=0):
+    cur = await db.execute(
+        "SELECT id, priority, content, content_hash, created_at, resolution_notes "
+        f"FROM observations WHERE source='{SOURCE}' AND resolved={resolved}"
+    )
+    return list(await cur.fetchall())
+
+
+async def test_no_findings_is_quiet(db, monkeypatch):
+    _patch_snapshot(monkeypatch, _snap([]))
+    await loop._check_deploy_staleness(db)
+    assert await _rows(db) == []
+
+
+async def test_drift_raises_high_once(db, monkeypatch):
+    _patch_snapshot(
+        monkeypatch,
+        _snap(["tier2_pending:2"], age_days=1.0, behind=3, tier2=["a", "b"]),
+    )
+    await loop._check_deploy_staleness(db)
+    rows = await _rows(db)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "high"
+    assert "update.sh" in rows[0]["content"]
+    # Second run, same state: content_hash dedup + cooldown — no second row.
+    await loop._check_deploy_staleness(db)
+    assert len(await _rows(db)) == 1
+
+
+async def test_count_drift_does_not_churn_alert(db, monkeypatch):
+    """behind_upstream:52 -> :53 is the same alert state, not a new alert."""
+    _patch_snapshot(monkeypatch, _snap(["behind_upstream:52"], behind=52))
+    await loop._check_deploy_staleness(db)
+    first = await _rows(db)
+    monkeypatch.setattr(loop, "_last_deploy_alert_at", 0.0)  # bypass cooldown
+    _patch_snapshot(monkeypatch, _snap(["behind_upstream:53"], behind=53))
+    await loop._check_deploy_staleness(db)
+    rows = await _rows(db)
+    assert len(rows) == 1
+    assert rows[0]["content_hash"] == first[0]["content_hash"]
+
+
+async def test_sustained_staleness_is_critical(db, monkeypatch):
+    _patch_snapshot(
+        monkeypatch,
+        _snap(["behind_upstream:25"], age_days=8.0, behind=25),
+    )
+    await loop._check_deploy_staleness(db)
+    rows = await _rows(db)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "critical"
+
+
+async def test_escalation_supersedes_high_row(db, monkeypatch):
+    _patch_snapshot(monkeypatch, _snap(["behind_upstream:25"], age_days=1.0, behind=25))
+    await loop._check_deploy_staleness(db)
+    assert (await _rows(db))[0]["priority"] == "high"
+    monkeypatch.setattr(loop, "_last_deploy_alert_at", 0.0)
+    _patch_snapshot(monkeypatch, _snap(["behind_upstream:25"], age_days=8.0, behind=25))
+    await loop._check_deploy_staleness(db)
+    active = await _rows(db)
+    assert len(active) == 1
+    assert active[0]["priority"] == "critical"
+    superseded = await _rows(db, resolved=1)
+    assert len(superseded) == 1
+    assert superseded[0]["resolution_notes"] == loop._DEPLOY_SUPERSEDED_NOTE
+
+
+async def test_missing_unit_escalates_after_24h(db, monkeypatch):
+    snap = _snap(
+        ["missing_units:x.timer"],
+        age_days=1.0,
+        behind=0,
+        missing_units=["x.timer"],
+    )
+    _patch_snapshot(monkeypatch, snap)
+    await loop._check_deploy_staleness(db)
+    rows = await _rows(db)
+    assert rows[0]["priority"] == "high"
+    # Age the anchor row past 24h; the same state now escalates.
+    old = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    await db.execute(f"UPDATE observations SET created_at=? WHERE source='{SOURCE}'", (old,))
+    await db.commit()
+    monkeypatch.setattr(loop, "_last_deploy_alert_at", 0.0)
+    await loop._check_deploy_staleness(db)
+    active = await _rows(db)
+    assert len(active) == 1
+    assert active[0]["priority"] == "critical"
+    # The escalated row must NOT reset the clock: the superseded high row (old
+    # created_at, superseded note) still anchors, so the state STAYS critical.
+    monkeypatch.setattr(loop, "_last_deploy_alert_at", 0.0)
+    await loop._check_deploy_staleness(db)
+    active = await _rows(db)
+    assert len(active) == 1
+    assert active[0]["priority"] == "critical"
+
+
+async def test_recovery_resolves_and_retires_anchors(db, monkeypatch):
+    snap = _snap(["missing_units:x.timer"], age_days=1.0, behind=0, missing_units=["x.timer"])
+    _patch_snapshot(monkeypatch, snap)
+    await loop._check_deploy_staleness(db)
+    # Simulate a prior superseded row too (escalation happened at some point).
+    await db.execute(
+        "INSERT INTO observations (id, source, type, content, priority, created_at,"
+        " resolved, resolution_notes) VALUES ('old', ?, 'infrastructure_alert',"
+        " 'missing_units:x.timer', 'high', '2020-01-01T00:00:00+00:00', 1, ?)",
+        (SOURCE, loop._DEPLOY_SUPERSEDED_NOTE),
+    )
+    await db.commit()
+    _patch_snapshot(monkeypatch, _snap([]))
+    await loop._check_deploy_staleness(db)
+    assert await _rows(db) == []  # active alert resolved
+    # Anchor retired: no row carries the superseded note anymore, so a future
+    # missing unit cannot inherit this incident's clock and page instantly.
+    cur = await db.execute(
+        "SELECT COUNT(*) FROM observations WHERE source=? AND resolution_notes=?",
+        (SOURCE, loop._DEPLOY_SUPERSEDED_NOTE),
+    )
+    assert (await cur.fetchone())[0] == 0
+
+
+async def test_snapshot_error_is_quiet(db, monkeypatch):
+    _patch_snapshot(monkeypatch, {"status": "error"})
+    await loop._check_deploy_staleness(db)
+    assert await _rows(db) == []
+
+
+async def test_check_never_raises_into_tick(db, monkeypatch):
+    async def boom(db):
+        raise RuntimeError("collector exploded")
+
+    monkeypatch.setattr(dh_module, "deploy_health", boom)
+    await loop._check_deploy_staleness(db)  # must not raise
+    assert await _rows(db) == []

--- a/tests/test_awareness/test_deploy_staleness_check.py
+++ b/tests/test_awareness/test_deploy_staleness_check.py
@@ -113,23 +113,50 @@ async def test_count_drift_does_not_churn_alert(db, monkeypatch):
     assert rows[0]["content_hash"] == first[0]["content_hash"]
 
 
-async def test_sustained_staleness_is_critical(db, monkeypatch):
-    _patch_snapshot(
-        monkeypatch,
-        _snap(["behind_upstream:25"], age_days=8.0, behind=25),
+def _real_findings(*, age_days, behind, missing_units=None, tier2=None, host_status="ok"):
+    """Drive the REAL derive_findings — regression guard for the review
+    BLOCKER where the awareness formula (≥7d AND ≥20 commits) was written
+    against facts the findings gate filtered out below its own separate
+    50-commit threshold, so a genuinely stale install alerted NOTHING."""
+    return dh_module.derive_findings(
+        missing_units=missing_units or [],
+        tier2_pending=tier2,
+        host_gateway={"status": host_status},
+        commits_behind=behind,
+        update_age_days=age_days,
     )
+
+
+async def test_sustained_staleness_is_critical_via_real_findings(db, monkeypatch):
+    # 25 behind is BELOW the standalone behind_upstream threshold (50) — the
+    # stale_update class must still carry it through the findings gate.
+    findings = _real_findings(age_days=8.0, behind=25)
+    assert findings == ["stale_update:8.0d,25behind"]
+    _patch_snapshot(monkeypatch, _snap(findings, age_days=8.0, behind=25))
     await loop._check_deploy_staleness(db)
     rows = await _rows(db)
     assert len(rows) == 1
     assert rows[0]["priority"] == "critical"
 
 
+async def test_recent_update_below_behind_threshold_is_quiet(db, monkeypatch):
+    # Fresh update + modestly behind: no finding classes, no alert.
+    assert _real_findings(age_days=1.0, behind=25) == []
+    _patch_snapshot(monkeypatch, _snap([], age_days=1.0, behind=25))
+    await loop._check_deploy_staleness(db)
+    assert await _rows(db) == []
+
+
 async def test_escalation_supersedes_high_row(db, monkeypatch):
-    _patch_snapshot(monkeypatch, _snap(["behind_upstream:25"], age_days=1.0, behind=25))
+    _patch_snapshot(
+        monkeypatch, _snap(_real_findings(age_days=1.0, behind=60), age_days=1.0, behind=60)
+    )
     await loop._check_deploy_staleness(db)
     assert (await _rows(db))[0]["priority"] == "high"
     monkeypatch.setattr(loop, "_last_deploy_alert_at", 0.0)
-    _patch_snapshot(monkeypatch, _snap(["behind_upstream:25"], age_days=8.0, behind=25))
+    _patch_snapshot(
+        monkeypatch, _snap(_real_findings(age_days=8.0, behind=60), age_days=8.0, behind=60)
+    )
     await loop._check_deploy_staleness(db)
     active = await _rows(db)
     assert len(active) == 1
@@ -190,6 +217,35 @@ async def test_recovery_resolves_and_retires_anchors(db, monkeypatch):
         (SOURCE, loop._DEPLOY_SUPERSEDED_NOTE),
     )
     assert (await cur.fetchone())[0] == 0
+
+
+async def test_partial_recovery_retires_missing_unit_anchors(db, monkeypatch):
+    """Missing units clear while OTHER drift persists (so full recovery never
+    fires): the superseded missing-units anchor must still be retired, or a
+    new missing unit months later inherits this incident's clock and pages
+    instantly instead of after 24h."""
+    await db.execute(
+        "INSERT INTO observations (id, source, type, content, priority, created_at,"
+        " resolved, resolution_notes) VALUES ('old', ?, 'infrastructure_alert',"
+        " 'missing_units:x.timer', 'high', '2020-01-01T00:00:00+00:00', 1, ?)",
+        (SOURCE, loop._DEPLOY_SUPERSEDED_NOTE),
+    )
+    await db.commit()
+    # Current state: host drift only — missing_units is NOT among the classes.
+    _patch_snapshot(
+        monkeypatch,
+        _snap(["host_guardian_drift"], age_days=1.0, behind=0, host_status="drift"),
+    )
+    await loop._check_deploy_staleness(db)
+    cur = await db.execute(
+        "SELECT COUNT(*) FROM observations WHERE source=? AND resolution_notes=?",
+        (SOURCE, loop._DEPLOY_SUPERSEDED_NOTE),
+    )
+    assert (await cur.fetchone())[0] == 0  # anchor retired despite ongoing drift
+    # And the ongoing drift still alerted normally.
+    rows = await _rows(db)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "high"
 
 
 async def test_snapshot_error_is_quiet(db, monkeypatch):

--- a/tests/test_observability/test_deploy_health.py
+++ b/tests/test_observability/test_deploy_health.py
@@ -224,11 +224,13 @@ def test_derive_findings_keys_are_stable():
         tier2_pending=["scripts/update.sh"],
         host_gateway={"status": "drift"},
         commits_behind=60,
+        update_age_days=8.0,
     )
     assert findings == [
         "missing_units:a.service,b.timer",  # sorted -> deterministic
         "tier2_pending:1",
         "host_guardian_drift",
+        "stale_update:8.0d,60behind",
         "behind_upstream:60",
     ]
 
@@ -240,6 +242,32 @@ def test_derive_findings_quiet_when_healthy():
             tier2_pending=None,
             host_gateway={"status": "ok"},
             commits_behind=3,
+            update_age_days=0.5,
         )
         == []
     )
+
+
+def test_stale_update_fires_below_behind_threshold():
+    """Review BLOCKER regression guard: 7+ days stale and 20-49 commits behind
+    must produce a finding — previously the only behind-axis finding required
+    >50 commits, so this exact range (a genuinely stale install) alerted
+    NOTHING while the awareness formula was written against >=20."""
+    findings = derive_findings(
+        missing_units=[],
+        tier2_pending=None,
+        host_gateway={"status": "ok"},
+        commits_behind=25,
+        update_age_days=7.5,
+    )
+    assert findings == ["stale_update:7.5d,25behind"]
+
+
+def test_stale_update_requires_both_axes():
+    common = dict(missing_units=[], tier2_pending=None, host_gateway={"status": "ok"})
+    # Recently updated, even if well behind at last fetch: not stale.
+    assert derive_findings(**common, commits_behind=25, update_age_days=2.0) == []
+    # Old update but nearly caught up by bare merges: not the paging condition.
+    assert derive_findings(**common, commits_behind=5, update_age_days=30.0) == []
+    # Unknown age (no update_history yet): never fabricates staleness.
+    assert derive_findings(**common, commits_behind=25, update_age_days=None) == []

--- a/tests/test_observability/test_deploy_health.py
+++ b/tests/test_observability/test_deploy_health.py
@@ -1,0 +1,245 @@
+"""Tests for the deploy-staleness snapshot collectors (deploy_health.py).
+
+The collectors answer "is what's MERGED actually DEPLOYED here?" — a bare
+git-merge deploys code but silently skips tier-2 activation (systemd units,
+guardian host redeploy, CC/Node pins). Everything is best-effort: collectors
+degrade to None/empty and never raise.
+
+Git-facts tests build a real throwaway repo (subprocess git) — the collector
+shells out to git, so a fake would test nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from genesis.observability.snapshots.deploy_health import (
+    GUARDIAN_HOST_PATHS,
+    collect_git_facts,
+    collect_host_gateway,
+    collect_missing_units,
+    collect_tier2_pending,
+    derive_findings,
+    last_success_update,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "HOME": str(repo),
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def repo_with_upstream(tmp_path):
+    """A clone whose origin is 2 commits ahead (fetched, not merged)."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    (origin / "a.txt").write_text("1")
+    _git(origin, "add", "a.txt")
+    _git(origin, "commit", "-qm", "c1")
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(origin), str(clone))
+    for i in (2, 3):
+        (origin / "a.txt").write_text(str(i))
+        _git(origin, "add", "a.txt")
+        _git(origin, "commit", "-qm", f"c{i}")
+    _git(clone, "fetch", "-q", "origin")
+    return clone
+
+
+# ── git facts ────────────────────────────────────────────────────────
+
+
+def test_git_facts_counts_behind_and_fetch_age(repo_with_upstream):
+    facts = collect_git_facts(repo_with_upstream)
+    assert facts["head"]
+    assert facts["commits_behind_upstream"] == 2
+    assert facts["fetch_age_hours"] is not None
+    assert facts["fetch_age_hours"] < 1
+
+
+def test_git_facts_degrade_on_non_repo(tmp_path):
+    facts = collect_git_facts(tmp_path / "not-a-repo")
+    assert facts["head"] is None
+    assert facts["commits_behind_upstream"] is None
+
+
+# ── missing units ────────────────────────────────────────────────────
+
+
+def test_missing_units_lists_absent_files(tmp_path):
+    templates = tmp_path / "templates"
+    units = tmp_path / "units"
+    templates.mkdir()
+    units.mkdir()
+    (templates / "a.service.template").write_text("")
+    (templates / "b.timer.template").write_text("")
+    (units / "a.service").write_text("")
+    assert collect_missing_units(templates, units) == ["b.timer"]
+
+
+def test_missing_units_none_when_undeterminable(tmp_path):
+    assert collect_missing_units(tmp_path / "nope", tmp_path) is None
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert collect_missing_units(empty, tmp_path) is None
+
+
+# ── tier-2 pending ───────────────────────────────────────────────────
+
+
+def test_tier2_pending_lists_update_only_changes(repo_with_upstream):
+    repo = repo_with_upstream
+    baseline = _git(repo, "rev-parse", "HEAD")
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "update.sh").write_text("#!/bin/bash\n")
+    (repo / "unrelated.py").write_text("x = 1\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "tier2 change")
+    pending = collect_tier2_pending(repo, baseline)
+    assert pending == ["scripts/update.sh"]  # unrelated.py is not tier-2
+
+
+def test_tier2_pending_none_without_baseline(repo_with_upstream):
+    assert collect_tier2_pending(repo_with_upstream, None) is None
+    assert collect_tier2_pending(repo_with_upstream, "0" * 40) is None
+
+
+# ── host gateway ─────────────────────────────────────────────────────
+
+
+def _write_state(path: Path, deployed: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "checked_at": datetime.now(UTC).isoformat(),
+                "version": {"deployed_commit": deployed},
+            }
+        )
+    )
+
+
+def test_host_gateway_no_data_without_state_file(tmp_path, repo_with_upstream):
+    assert collect_host_gateway(repo_with_upstream, tmp_path / "nope.json") == {"status": "no_data"}
+
+
+def test_host_gateway_unknown_commit(tmp_path, repo_with_upstream):
+    state = tmp_path / "state.json"
+    _write_state(state, "unknown")
+    assert collect_host_gateway(repo_with_upstream, state)["status"] == "unknown_commit"
+    _write_state(state, "deadbeef")  # does not resolve in this repo
+    assert collect_host_gateway(repo_with_upstream, state)["status"] == "unknown_commit"
+
+
+def test_host_gateway_ok_at_head(tmp_path, repo_with_upstream):
+    state = tmp_path / "state.json"
+    _write_state(state, _git(repo_with_upstream, "rev-parse", "HEAD"))
+    out = collect_host_gateway(repo_with_upstream, state)
+    assert out["status"] == "ok"
+    assert out["drift_files"] == 0
+    assert out["age_hours"] is not None
+
+
+def test_host_gateway_drift_on_guardian_path_change(tmp_path, repo_with_upstream):
+    repo = repo_with_upstream
+    deployed = _git(repo, "rev-parse", "HEAD")
+    guardian_file = repo / GUARDIAN_HOST_PATHS[0] / "core.py"
+    guardian_file.parent.mkdir(parents=True)
+    guardian_file.write_text("x = 1\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "guardian change")
+    state = tmp_path / "state.json"
+    _write_state(state, deployed)
+    out = collect_host_gateway(repo, state)
+    assert out["status"] == "drift"
+    assert out["drift_files"] == 1
+
+
+# ── last successful update ───────────────────────────────────────────
+
+
+async def _update_history_db() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    await db.execute(
+        "CREATE TABLE update_history (id TEXT PRIMARY KEY, old_tag TEXT, new_tag TEXT,"
+        " old_commit TEXT, new_commit TEXT, status TEXT, rollback_tag TEXT,"
+        " failure_reason TEXT, degraded_subsystems TEXT, started_at TEXT, completed_at TEXT)"
+    )
+    return db
+
+
+async def test_last_success_update_age():
+    db = await _update_history_db()
+    old = (datetime.now(UTC) - timedelta(days=9)).isoformat()
+    newer = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    await db.execute(
+        "INSERT INTO update_history (id, status, new_commit, completed_at) VALUES"
+        f" ('1', 'success', 'aaa', '{old}'), ('2', 'failed', 'bbb', '{newer}'),"
+        f" ('3', 'success', 'ccc', '{newer}')"
+    )
+    out = await last_success_update(db)
+    await db.close()
+    assert out["new_commit"] == "ccc"  # newest SUCCESS, failed row ignored
+    assert 1.9 < out["age_days"] < 2.1
+
+
+async def test_last_success_update_empty_table():
+    db = await _update_history_db()
+    out = await last_success_update(db)
+    await db.close()
+    assert out == {"completed_at": None, "new_commit": None, "age_days": None}
+
+
+async def test_last_success_update_no_db():
+    out = await last_success_update(None)
+    assert out["age_days"] is None
+
+
+# ── findings contract ────────────────────────────────────────────────
+
+
+def test_derive_findings_keys_are_stable():
+    findings = derive_findings(
+        missing_units=["b.timer", "a.service"],
+        tier2_pending=["scripts/update.sh"],
+        host_gateway={"status": "drift"},
+        commits_behind=60,
+    )
+    assert findings == [
+        "missing_units:a.service,b.timer",  # sorted -> deterministic
+        "tier2_pending:1",
+        "host_guardian_drift",
+        "behind_upstream:60",
+    ]
+
+
+def test_derive_findings_quiet_when_healthy():
+    assert (
+        derive_findings(
+            missing_units=[],
+            tier2_pending=None,
+            host_gateway={"status": "ok"},
+            commits_behind=3,
+        )
+        == []
+    )

--- a/tests/test_scripts/test_update_tier2_baseline.py
+++ b/tests/test_scripts/test_update_tier2_baseline.py
@@ -1,0 +1,138 @@
+"""Tests for update.sh's _tier2_pending_since_baseline (extracted snippet).
+
+The no-op ("Already up to date") path must fall through to full activation
+when update.sh-only paths changed since the last RECORDED update — the
+recovery the deploy-staleness alert advertises. These tests run the exact
+shipped bash function against a throwaway git repo + sqlite update_history.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+
+_BEGIN = "# BEGIN tier2-baseline-check"
+_END = "# END tier2-baseline-check"
+
+
+def _extract_function() -> str:
+    text = UPDATE_SH.read_text()
+    assert _BEGIN in text and _END in text, "extraction markers missing from update.sh"
+    # Drop the rest of the BEGIN marker line itself (it carries a prose suffix).
+    after_marker = text.split(_BEGIN, 1)[1].split("\n", 1)[1]
+    return after_marker.split(_END, 1)[0]
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "HOME": str(repo),
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def genesis_root(tmp_path):
+    """Throwaway GENESIS_ROOT: git repo + data/genesis.db + fake venv python."""
+    root = tmp_path / "root"
+    (root / "data").mkdir(parents=True)
+    (root / "scripts").mkdir()
+    _git(tmp_path, "init", "-q", "-b", "main", str(root))
+    (root / "scripts" / "update.sh").write_text("# v1\n")
+    (root / "unrelated.py").write_text("x = 1\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "c1")
+
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(sys.executable)
+
+    db = sqlite3.connect(root / "data" / "genesis.db")
+    db.execute(
+        "CREATE TABLE update_history (id TEXT PRIMARY KEY, old_tag TEXT, new_tag TEXT,"
+        " old_commit TEXT, new_commit TEXT, status TEXT, rollback_tag TEXT,"
+        " failure_reason TEXT, degraded_subsystems TEXT, started_at TEXT, completed_at TEXT)"
+    )
+    db.commit()
+    db.close()
+    return root, venv
+
+
+def _record_success(root: Path, commit: str, completed_at: str = "2026-01-01T00:00:00+00:00"):
+    db = sqlite3.connect(root / "data" / "genesis.db")
+    db.execute(
+        "INSERT INTO update_history (id, status, new_commit, completed_at)"
+        " VALUES (?, 'success', ?, ?)",
+        (f"row-{commit}-{completed_at}", commit, completed_at),
+    )
+    db.commit()
+    db.close()
+
+
+def _run_check(root: Path, venv: Path) -> int:
+    harness = (
+        "set -u\n"
+        f'GENESIS_ROOT="{root}"\n'
+        f'VENV_DIR="{venv}"\n' + _extract_function() + "\n_tier2_pending_since_baseline\n"
+    )
+    result = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=60)
+    assert result.stderr == "", result.stderr
+    return result.returncode
+
+
+def test_tier2_change_since_baseline_is_pending(genesis_root):
+    root, venv = genesis_root
+    _record_success(root, _git(root, "rev-parse", "--short", "HEAD"))
+    (root / "scripts" / "update.sh").write_text("# v2\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "tier2 change (bare merge)")
+    assert _run_check(root, venv) == 0  # pending -> full activation
+
+
+def test_non_tier2_change_is_not_pending(genesis_root):
+    root, venv = genesis_root
+    _record_success(root, _git(root, "rev-parse", "--short", "HEAD"))
+    (root / "unrelated.py").write_text("x = 2\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "code-only change")
+    assert _run_check(root, venv) == 1  # shortcut path stays
+
+
+def test_no_baseline_is_not_pending(genesis_root):
+    root, venv = genesis_root  # empty update_history
+    assert _run_check(root, venv) == 1
+
+
+def test_unresolvable_baseline_is_not_pending(genesis_root):
+    root, venv = genesis_root
+    _record_success(root, "deadbeef")  # does not resolve in this repo
+    assert _run_check(root, venv) == 1
+
+
+def test_newest_success_row_wins(genesis_root):
+    root, venv = genesis_root
+    old_head = _git(root, "rev-parse", "--short", "HEAD")
+    _record_success(root, old_head, "2026-01-01T00:00:00+00:00")
+    (root / "scripts" / "update.sh").write_text("# v2\n")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "tier2 change")
+    # A NEWER success row at current HEAD: baseline advanced, nothing pending.
+    _record_success(root, _git(root, "rev-parse", "--short", "HEAD"), "2026-02-01T00:00:00+00:00")
+    assert _run_check(root, venv) == 1


### PR DESCRIPTION
## Summary

A bare \`git merge\` between \`update.sh\` runs deploys code but silently skips tier-2 activation (systemd unit installation, guardian host redeploy, CC/Node pins). Observed live 2026-07-13: six days of manual merges left a shipped timer uninstalled and the host guardian a week behind, with zero signal anywhere. This PR makes that drift visible and pageable.

## What's included

- **\`observability/snapshots/deploy_health.py\`** — collectors + a new \`deploy_health\` health-snapshot section:
  - days since the last successful \`update_history\` row
  - commits behind upstream from **local refs only** (+ FETCH_HEAD age) — the health path never does network I/O
  - systemd units missing vs \`scripts/systemd/*.template\`
  - tier-2 files changed since the last successful update (the predictive "you need update.sh" signal)
  - host guardian \`deployed_commit\` drift, read from a state file (no SSH in the health path)
  - stable, order-deterministic finding keys (the alert/dedup contract)
- **Awareness check (hourly)** — \`_check_deploy_staleness\`: hybrid severity — \`high\` (dashboard) on any drift; \`critical\` (Telegram page) only **sustained**: last update ≥7 days old AND ≥20 commits behind, or a missing unit alerted for >24h. Class-keyed dedup (per-run count drift can't churn alerts), supersede-on-state-change, a restart-safe >24h escalation anchor that can't reset its own clock, resolve-on-recovery.
- **\`cc_align_host_sync\`** (shared by \`update.sh\` and the nightly cc-align timer) now persists each gateway \`version\` probe to \`~/.genesis/host_gateway_state.json\` — atomic write; unreachable probes never clobber the last-known-good state.
- \`GUARDIAN_HOST_PATHS\` reconciled with \`update.sh\`'s \`GUARDIAN_PATHS\` (the collector's list had drifted by 4 config paths).

## Tests

- \`tests/test_observability/test_deploy_health.py\` — 15 collector tests against a real throwaway git repo (behind-count, fetch age, missing units, tier-2 diff, host-gateway state machine, update-history age, findings contract).
- \`tests/test_awareness/test_deploy_staleness_check.py\` — 9 alerting state-machine tests (quiet when healthy, high-once dedup, count-drift immunity, sustained→critical, escalation supersede, 24h anchor immune to its own escalation, recovery retires anchors, error paths never raise into the tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)