### PR TITLE
feat(memory): recall-time 1-hop graph expansion, shadow-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and 20+ commits behind, or a missing unit ignored for a day). The fix is
   always the same and the alert says so: run `scripts/update.sh`.
 
+- **Recall now follows memory links — the benchmark-proven +12.6pp mechanism
+  lands in production, shadow-first.** LongMemEval showed that appending
+  1-hop linked neighbors to recalled results lifts answer accuracy from 64.8%
+  to 77.4% (temporal reasoning +23pp, multi-session +17pp), but that expansion
+  only existed in the eval harness. It's now wired into every MCP recall
+  surface (full, compact previews, proactive injection), shipping in `shadow`
+  mode: expansion is computed and measured (`eval_events`) without changing
+  any output until the `memory_recall` settings domain flips
+  `graph_expansion.mode` to `live` — no restart needed, and `off` is the
+  instant kill switch. Expanded neighbors carry their stored provenance and
+  pass the exact same injection defenses (wrap/count/drop) as organic
+  results; `contradicts` links are never followed, and neighbors are flagged
+  `via_graph` so callers can weigh them. The benchmark harness now calls this
+  same production primitive, so future eval numbers measure shipped code.
+
 - **A resumed conversation can no longer run twice at once.** If an SSH drop
   leaves a Claude Code session executing headless and you resume that same
   conversation elsewhere, both processes used to write to the same transcript

--- a/config/memory_recall.yaml
+++ b/config/memory_recall.yaml
@@ -1,0 +1,30 @@
+# Memory recall wiring — graph expansion + entity lane (shadow-first).
+#
+# Read LIVE per recall by genesis.memory.graph_expansion (no restart needed
+# for a mode change in a running process). User overrides land in
+# ~/.genesis/config/memory_recall.local.yaml via the dashboard/MCP settings
+# writer — edit that overlay, not this file.
+#
+# Benchmark provenance: 1-hop expansion at max_neighbors=10 measured +12.6pp
+# overall on LongMemEval (temporal +23pp, multi-session +17pp), 2026-07-14
+# graph-DB decision memo.
+
+enabled: true
+
+graph_expansion:
+  # off | shadow | live — shadow computes + emits eval_events metrics but
+  # never changes recall output; live appends linked neighbors after the
+  # organic results. Kill switch: mode off (or master enabled: false).
+  mode: shadow
+  # Neighbor cap for the full/compact MCP recall surfaces (eval parity: k=10).
+  max_neighbors: 10
+  # Proactive injection is token-budgeted — keep this tiny.
+  proactive_max_neighbors: 2
+  # Edge types never followed into LLM-visible context.
+  exclude_link_types:
+    - contradicts
+
+# Entity lane in hybrid recall (PR-2) — inert until that lands; ships off.
+# ("off" quoted: unquoted it parses as YAML-1.1 boolean False.)
+entity_lane:
+  mode: "off"

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -126,8 +126,9 @@ async def inter_candidate_links(
     return [(row[0], row[1]) for row in rows]
 
 
-# Seed cap for neighbors_of: the query binds 2*len(seeds) (+ optional link
-# types) + 1 placeholders, so 450 keeps the worst case ~901 — under the 999
+# Seed cap for neighbors_of: the query binds 2*len(seeds) (+ optional
+# include/exclude link types, a handful each) + 1 placeholders, so 450 keeps
+# the worst case ~901 — under the 999
 # SQLITE_MAX_VARIABLE_NUMBER floor this file's IN-list convention targets.
 # (inter_candidate_links' 499 assumes its own 2n shape; don't borrow caps.)
 _NEIGHBOR_SEED_CAP = 450
@@ -140,6 +141,7 @@ async def neighbors_of(
     exclude: list[str] | tuple[str, ...] = (),
     limit: int = 10,
     link_types: tuple[str, ...] | None = None,
+    exclude_link_types: tuple[str, ...] | list[str] = (),
 ) -> list[dict]:
     """1-hop neighbors of *memory_ids* via ``memory_links``, strongest first.
 
@@ -156,7 +158,11 @@ async def neighbors_of(
     ``link_types`` optionally restricts which edge types are followed —
     callers expanding into LLM-visible context should exclude adversarial
     types like ``contradicts`` (the LongMemEval graph arm only ever stores
-    supports/extends, so it passes None).
+    supports/extends, so it passes None). ``exclude_link_types`` is the
+    deny-list complement (prod recall expansion excludes ``contradicts`` via
+    config); both compose — followed = ``link_types`` minus
+    ``exclude_link_types``. Both filter IN SQL, inside both UNION branches,
+    so an excluded edge never consumes the ``LIMIT`` budget.
 
     Returns ``[{"memory_id": ..., "strength": ...}]``. Used by recall-time
     graph expansion (LongMemEval graph arm; intended canonical home for the
@@ -181,6 +187,11 @@ async def neighbors_of(
         type_ph = ",".join("?" * len(link_types))
         type_clause = f" AND link_type IN ({type_ph})"
         type_params = list(link_types)
+    if exclude_link_types:
+        # link_type is a PK member (NOT NULL) — NOT IN has no NULL trap here.
+        excl_ph = ",".join("?" * len(exclude_link_types))
+        type_clause += f" AND link_type NOT IN ({excl_ph})"
+        type_params = [*type_params, *exclude_link_types]
     rows = await db.execute_fetchall(
         f"SELECT neighbor, MAX(strength) AS s FROM ("
         f"  SELECT target_id AS neighbor, strength FROM memory_links"

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -381,23 +381,19 @@ def _coverage(evidence_ids: set[str], ids: set[str]) -> tuple[bool, float | None
 async def _expand_neighbors(db: object, seed_ids: list[str], *, k: int) -> list[tuple[str, str]]:
     """1-hop expansion: (memory_id, content) for up to ``k`` linked neighbors.
 
-    Merges linked-but-unretrieved neighbors into the reader context (the prod
-    MCP layer only DECORATES results with neighbors; actually merging them is
-    what can lift multi-session coverage). Deliberately direct CRUD, not
-    graph.traverse — its process-global NetworkX cache is unsafe across the
-    concurrent ephemeral stores this runner creates. Dangling links (edge
-    rows whose neighbor memory no longer resolves) are skipped silently.
+    Thin adapter over the PRODUCTION primitive
+    ``genesis.memory.graph_expansion.expand_neighbors`` — the benchmark must
+    measure the shipped recall-expansion code, not a harness re-implementation.
+    The primitive is mode-independent (reads NO prod config; this harness
+    passes explicit args only): dangling links skipped, dedup +
+    MAX(strength) ordering, seeds never returned. No ``exclude_link_types``
+    passed — eval ingest only ever stores supports/extends edges, so prod's
+    configured ``contradicts`` exclusion is a no-op here by construction.
     """
-    from genesis.db.crud import memory as memory_crud
-    from genesis.db.crud import memory_links as memory_links_crud
+    from genesis.memory.graph_expansion import expand_neighbors
 
-    neighbors = await memory_links_crud.neighbors_of(db, seed_ids, limit=k)
-    expanded: list[tuple[str, str]] = []
-    for n in neighbors:
-        row = await memory_crud.get_by_id(db, n["memory_id"])
-        if row and row.get("content"):
-            expanded.append((n["memory_id"], row["content"]))
-    return expanded
+    expanded = await expand_neighbors(db, seed_ids, cap=k)
+    return [(r.memory_id, r.content) for r in expanded]
 
 
 async def _run_arm(

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -74,6 +74,20 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         needs_restart=False,  # read live per-call by genesis.security.immunity
         hidden_fields=frozenset({"auto_demote_state"}),
     ),
+    "memory_recall": SettingsDomain(
+        name="memory_recall",
+        description=(
+            "Memory recall wiring — 1-hop graph expansion over memory_links "
+            "(`graph_expansion.mode` off/shadow/live + neighbor caps) and the "
+            "entity lane (PR-2, off/shadow for now). Read live per recall by "
+            "genesis.memory.graph_expansion (no restart); shadow only emits "
+            "eval_events metrics, live appends linked neighbors after the "
+            "organic results."
+        ),
+        config_filename="memory_recall.yaml",
+        readonly=False,
+        needs_restart=False,  # read live per-call by genesis.memory.graph_expansion
+    ),
     "session_ledger_shadow": SettingsDomain(
         name="session_ledger_shadow",
         description=(
@@ -764,15 +778,66 @@ def _validate_session_ledger_shadow(changes: dict) -> list[str]:
             if not isinstance(value, bool):
                 errors.append("'enabled' must be a boolean")
         elif value not in MODES:
-            errors.append(
-                f"'mode' must be one of {', '.join(MODES)}; got {value!r}"
-            )
+            errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+    return errors
+
+
+def _validate_memory_recall(changes: dict) -> list[str]:
+    """Validate memory_recall changes (see genesis.memory.graph_expansion).
+
+    Rejects anything ``load_recall_config`` would misread so a
+    ``settings_update`` can never land a config that only degrades-with-
+    warning at recall time. ``entity_lane.mode`` accepts off/shadow only —
+    ``live`` is reserved until the lane's live path ships (PR-2 flip
+    criteria) — while ``graph_expansion.mode`` accepts the full
+    ``graph_expansion.MODES``.
+    """
+    from genesis.memory.graph_expansion import MODES
+
+    errors: list[str] = []
+    _CAPS = ("max_neighbors", "proactive_max_neighbors")
+    section_modes = {
+        "graph_expansion": MODES,
+        "entity_lane": ("off", "shadow"),
+    }
+    for key, value in changes.items():
+        if key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key in section_modes:
+            if not isinstance(value, dict):
+                errors.append(f"'{key}' must be a mapping like {{mode: shadow}}")
+                continue
+            allowed = section_modes[key]
+            for sub_key, sub_value in value.items():
+                if sub_key == "mode":
+                    if sub_value not in allowed:
+                        errors.append(
+                            f"'{key}.mode' must be one of {', '.join(allowed)}; got {sub_value!r}"
+                        )
+                elif sub_key in _CAPS and key == "graph_expansion":
+                    if (
+                        not isinstance(sub_value, int)
+                        or isinstance(sub_value, bool)  # bool ⊂ int
+                        or not (0 <= sub_value <= 25)
+                    ):
+                        errors.append(f"'{key}.{sub_key}' must be an int in 0..25")
+                elif sub_key == "exclude_link_types" and key == "graph_expansion":
+                    if not isinstance(sub_value, list) or not all(
+                        isinstance(t, str) for t in sub_value
+                    ):
+                        errors.append(f"'{key}.exclude_link_types' must be a list of strings")
+                else:
+                    errors.append(f"Unknown key '{key}.{sub_key}'")
+        else:
+            errors.append(f"Unknown key '{key}'. Valid: enabled, graph_expansion, entity_lane")
     return errors
 
 
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "tts": _validate_tts,
     "ws3_immunity": _validate_ws3_immunity,
+    "memory_recall": _validate_memory_recall,
     "session_ledger_shadow": _validate_session_ledger_shadow,
     "cc_roster": _validate_cc_roster,
     "resilience": _validate_resilience,

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -811,7 +811,15 @@ async def memory_proactive(
     current_message: str,
     limit: int = 5,
 ) -> list[dict]:
-    """Cross-session context injection for prompts."""
+    """Cross-session context injection for prompts.
+
+    ``limit`` bounds the ORGANIC (query-ranked) results. When graph expansion
+    is live, up to ``proactive_max_neighbors`` (default 2, settings-capped)
+    linked neighbors may be appended beyond it, flagged ``via_graph`` — a
+    deliberate contract: the benchmark-proven lift comes from adding linked
+    context the ranked top-K missed, so trimming the total to ``limit`` would
+    displace the organic results expansion is meant to supplement.
+    """
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._retriever is not None

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -7,6 +7,7 @@ import re
 from dataclasses import asdict
 from datetime import UTC, datetime
 
+from genesis.memory import graph_expansion
 from genesis.memory.activation import compute_activation
 from genesis.memory.graph import traverse as graph_traverse
 from genesis.memory.provenance import (
@@ -346,6 +347,16 @@ async def memory_recall(
         pass  # instrumentation must never break recall
 
     if compact:
+        # Graph expansion (benchmark-proven +12.6pp): merge 1-hop linked
+        # neighbors BEFORE the blockable count and preview loop below, so
+        # neighbors are counted/recorded/previewed identically to organic
+        # results. Shadow mode only emits metrics; live appends.
+        results = await graph_expansion.maybe_expand(
+            memory_mod._db,
+            results,
+            surface="compact",
+            recall_event_id=recall_event_id,
+        )
         # WS-3 B1 gate 4 (injection): the compact branch returns external
         # previews and RETURNS before the full-path wrap/emit below — record
         # here too so compact recalls are not undercounted (observe-only).
@@ -388,6 +399,9 @@ async def memory_recall(
                     source_doc=r.source,
                     origin_class=r.origin_class,
                 ),
+                # Expanded neighbors are linkage-reached, not query-ranked —
+                # flag them so callers can weigh (and memory_expand them).
+                **({"via_graph": True} if r.payload.get("graph_expansion") else {}),
             }
             for r in results
         ]
@@ -441,6 +455,27 @@ async def memory_recall(
             pipeline_used=pipeline_used,
             recall_event_id=recall_event_id,
         )
+    # Graph expansion (benchmark-proven +12.6pp): merge 1-hop linked neighbors
+    # of the recalled top-K — seeded from the retriever's results exactly like
+    # the LongMemEval graph arm. AFTER CRAG (additive: CRAG dedups/trims to
+    # limit and would evict neighbors) and BEFORE the label/wrap/count loops
+    # below, so neighbors get the identical provenance labeling + injection
+    # defenses with zero loop changes. Shadow mode only emits metrics.
+    try:
+        _expanded = await graph_expansion.maybe_expand(
+            memory_mod._db,
+            results,
+            surface="full",
+            recall_event_id=recall_event_id,
+        )
+        _existing_ids = {d.get("memory_id") for d in enriched if isinstance(d, dict)}
+        enriched.extend(
+            asdict(n) | {"via_graph": True}
+            for n in _expanded[len(results) :]
+            if n.memory_id not in _existing_ids  # CRAG may have re-added one
+        )
+    except Exception:
+        logger.warning("graph expansion merge failed — recall unaffected", exc_info=True)
     # Provenance pass (audit D12): label original + any CRAG-augmented items as
     # first-party vs external-world. Runs regardless of `corrective` so the
     # output contract is uniform.
@@ -813,6 +848,7 @@ async def memory_proactive(
     # can appear here and flow straight into prompt context — wrap external-world
     # items so the model treats them as data, not first-party instructions.
     out: list[dict] = []
+    kept: list = []  # RetrievalResults behind `out` — graph-expansion seeds
     blockable = 0
     dropped = 0
     for r in filtered:
@@ -850,6 +886,46 @@ async def memory_proactive(
         if _blockable:
             blockable += 1
         out.append(d)
+        kept.append(r)
+    # Graph expansion (benchmark-proven; tiny proactive cap): 1-hop neighbors
+    # of the DELIVERED set, run through the SAME memory_operation filter,
+    # enforce-drop, and blockable+wrap pipeline as organic items — expansion
+    # must never be a bypass around the gate-4 pushed-surface defenses. Merged
+    # BEFORE the emit below so neighbors are counted. Shadow only emits.
+    _expanded = await graph_expansion.maybe_expand(
+        memory_mod._db,
+        kept,
+        surface="proactive",
+    )
+    for nr in _expanded[len(kept) :]:
+        # Neighbor tags come from the FTS row as a STRING — substring check
+        # mirrors the organic list-membership filter above.
+        if "memory_operation" in (nr.payload.get("tags") or ""):
+            continue
+        if immunity_shadow.should_enforce_drop(
+            gate="injection",
+            collection=nr.collection,
+            source_pipeline=nr.source_pipeline,
+            origin_class=nr.origin_class,
+            pushed_surface=True,
+            unsupervised=_unsupervised,
+        ):
+            dropped += 1
+            continue
+        nd = asdict(nr) | {"via_graph": True}
+        _nb = immunity_shadow.item_is_blockable(
+            collection=nr.collection,
+            source_pipeline=nr.source_pipeline,
+            origin_class=nr.origin_class,
+        )
+        if _nb or is_external(nr.collection):
+            nd["content"] = wrap_external_recall(
+                nd.get("content", ""),
+                source_pipeline=nr.source_pipeline,
+            )
+        if _nb:
+            blockable += 1
+        out.append(nd)
     # WS-3 B1 gate 4 (injection): shadow-record external content reaching this
     # proactive-recall prompt (observe-only). db=memory_mod._db when set, else
     # the emit self-resolves a short-lived connection. `enforced_drops` in the

--- a/src/genesis/memory/graph_expansion.py
+++ b/src/genesis/memory/graph_expansion.py
@@ -1,0 +1,307 @@
+"""Recall-time 1-hop graph expansion over ``memory_links`` — shadow-first.
+
+The A4 LongMemEval sprint proved that appending 1-hop linked neighbors to the
+recalled top-K is worth +12.6pp overall (temporal +23pp, multi-session +17pp)
+on the eval harness (memo: 2026-07-14 graph-DB decision). This module is the
+production home of that mechanism, consumed by the MCP recall wrappers
+(``genesis.mcp.memory.core``) — deliberately NOT a ``HybridRetriever.recall()``
+kwarg, so:
+
+- the ~11 direct ``.recall()`` callers (ego, voice, executor, CRAG…) are
+  untouched — several post-filter results and must not receive neighbors;
+- CRAG's corrective re-recall can never recurse through expansion;
+- neighbors get no write-back/J-9 retrieval credit (they are linkage-reached,
+  not query-relevant) — the merge happens after the retriever returns.
+
+Three layers:
+
+- config — ``DEFAULTS`` ← ``config/memory_recall.yaml`` ←
+  ``~/.genesis/config/memory_recall.local.yaml``, re-read on EVERY call
+  (``ws3_immunity`` pattern: no boot cache, a ``settings_update`` takes
+  effect on the next recall in the running process). ``mode: off`` is the
+  kill switch; there is no auto-demote — expansion never blocks anything.
+- :func:`expand_neighbors` — the mode-independent primitive (also the
+  LongMemEval graph arm's expansion, so the benchmark measures shipped prod
+  code). Reads NO config; callers pass caps/exclusions explicitly.
+- :func:`maybe_expand` — the surface wrapper: ``off`` passthrough, ``shadow``
+  compute + emit metrics but return results unchanged, ``live`` append.
+  Best-effort throughout — an expansion or metric failure never breaks
+  recall.
+
+Failure posture mirrors ``security/immunity.py``: missing/corrupt config
+degrades layer-by-layer to DEFAULTS (mode ``shadow`` — observable, never
+behavior-changing); an invalid mode VALUE degrades to ``shadow`` with a
+warning, never silently ``live``.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.db.crud import j9_eval
+from genesis.db.crud import memory as memory_crud
+from genesis.db.crud import memory_links as memory_links_crud
+from genesis.env import repo_root
+from genesis.memory.types import RetrievalResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "shadow", "live")
+
+_CONFIG_NAME = "memory_recall.yaml"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "graph_expansion": {
+        "mode": "shadow",
+        # eval parity: k=10 expansion won the +12.6pp
+        "max_neighbors": 10,
+        # proactive injection is token-budgeted — tiny cap
+        "proactive_max_neighbors": 2,
+        # never follow adversarial edges into LLM-visible context
+        "exclude_link_types": ["contradicts"],
+    },
+    # PR-2 (entity lane in hybrid recall) reads this section; inert until then.
+    "entity_lane": {
+        "mode": "off",
+    },
+}
+
+# Neighbor ordering score: organic RRF-fused scores are O(0.01)+ and rerank
+# scores larger still, so 0.01 * strength (strength ∈ (0, 1]) sorts every
+# neighbor strictly after every organic result while preserving
+# strength order among neighbors.
+_NEIGHBOR_SCORE_SCALE = 0.01
+
+
+def _base_path():
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_recall_config() -> dict[str, Any]:
+    """Read the merged memory_recall config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        # The base file ships in-repo; its absence (tests, trimmed installs)
+        # is normal — DEFAULTS are the same values.
+        logger.debug("memory_recall base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("memory_recall overlay merge failed", exc_info=True)
+    for key, value in base.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = {**merged[key], **value}
+        else:
+            merged[key] = value
+    return merged
+
+
+def _mode_from(cfg: dict[str, Any]) -> str:
+    if not cfg.get("enabled", True):
+        return "off"
+    section = cfg.get("graph_expansion")
+    mode = section.get("mode") if isinstance(section, dict) else None
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        mode = "off"
+    if mode not in MODES:
+        logger.warning(
+            "memory_recall graph_expansion has invalid mode %r — degrading to shadow",
+            mode,
+        )
+        return "shadow"
+    return mode
+
+
+def expansion_mode() -> str:
+    """Effective graph-expansion mode: ``off | shadow | live`` — read live."""
+    return _mode_from(load_recall_config())
+
+
+async def expand_neighbors(
+    db: aiosqlite.Connection,
+    seed_ids: Sequence[str],
+    *,
+    cap: int,
+    exclude_ids: Iterable[str] = (),
+    exclude_link_types: Sequence[str] = (),
+) -> list[RetrievalResult]:
+    """1-hop linked neighbors of *seed_ids* as ``RetrievalResult`` objects.
+
+    Mode-independent primitive — reads NO config (the LongMemEval graph arm
+    calls it directly; :func:`maybe_expand` passes prod config values).
+
+    Provenance is STORED-FIRST and never synthetic: ``collection`` comes from
+    the FTS row, ``origin_class`` from the batched ``memory_metadata`` lookup
+    (0054-backfilled; ``None`` for a hypothetical unbackfilled row keeps the
+    gate's fail-closed normalization honest), and ``source_pipeline`` stays
+    ``None`` — it has no SQLite column and must not be fabricated, because
+    ``item_is_blockable`` re-derives from these exact fields when the stored
+    class is absent.
+
+    Neighbors score ``0.01 * strength`` (sorts after any organic result) and
+    carry ``payload["graph_expansion"] = {"linked_from": [...], "strength": s}``
+    plus the FTS ``tags`` string (surfaces apply their own tag filters).
+    Dangling links (edge rows whose neighbor no longer resolves) are skipped.
+    """
+    if not seed_ids or cap <= 0:
+        return []
+    neighbors = await memory_links_crud.neighbors_of(
+        db,
+        list(seed_ids),
+        exclude=list(exclude_ids),
+        limit=cap,
+        exclude_link_types=tuple(exclude_link_types),
+    )
+    if not neighbors:
+        return []
+
+    neighbor_ids = [n["memory_id"] for n in neighbors]
+    origins = await memory_crud.origin_class_by_ids(db, neighbor_ids)
+    # Which seed(s) reach each neighbor — one bounded query over the
+    # seed∪neighbor id set (direction-agnostic pair list).
+    seed_set = set(seed_ids)
+    linked_from: dict[str, set[str]] = {}
+    for src, tgt in await memory_links_crud.inter_candidate_links(
+        db,
+        [*seed_ids, *neighbor_ids],
+    ):
+        if src in seed_set and tgt not in seed_set:
+            linked_from.setdefault(tgt, set()).add(src)
+        elif tgt in seed_set and src not in seed_set:
+            linked_from.setdefault(src, set()).add(tgt)
+
+    results: list[RetrievalResult] = []
+    for n in neighbors:
+        mid = n["memory_id"]
+        row = await memory_crud.get_by_id(db, mid)
+        if not row or not row.get("content"):
+            continue  # dangling link — edge outlived the memory
+        strength = float(n.get("strength") or 0.0)
+        collection = row.get("collection") or "episodic_memory"
+        results.append(
+            RetrievalResult(
+                memory_id=mid,
+                content=row["content"],
+                source=row.get("source_type") or "memory",
+                memory_type=collection,
+                score=_NEIGHBOR_SCORE_SCALE * strength,
+                vector_rank=None,
+                fts_rank=None,
+                activation_score=0.0,
+                payload={
+                    "tags": row.get("tags") or "",
+                    "graph_expansion": {
+                        "linked_from": sorted(linked_from.get(mid, ())),
+                        "strength": strength,
+                    },
+                },
+                source_pipeline=None,
+                origin_class=origins.get(mid),
+                collection=collection,
+            ),
+        )
+    return results
+
+
+async def maybe_expand(
+    db: aiosqlite.Connection,
+    results: list[RetrievalResult],
+    *,
+    surface: str,
+    recall_event_id: str | None = None,
+) -> list[RetrievalResult]:
+    """Apply configured graph expansion to a recall surface's results.
+
+    ``off`` → passthrough. ``shadow`` → compute + emit metrics, return
+    *results* unchanged. ``live`` → return *results* + neighbors (neighbors
+    sort after organic results by score; dedup vs results is by construction —
+    seeds are excluded in ``neighbors_of``).
+
+    *surface* ∈ ``compact | full | proactive`` selects the neighbor cap
+    (``proactive_max_neighbors`` vs ``max_neighbors``). Best-effort: any
+    failure logs and returns *results* unchanged — expansion must never
+    break recall.
+    """
+    if not results:
+        return results
+    cfg = load_recall_config()
+    mode = _mode_from(cfg)
+    if mode == "off":
+        return results
+    section = cfg.get("graph_expansion")
+    if not isinstance(section, dict):
+        section = DEFAULTS["graph_expansion"]
+    cap_key = "proactive_max_neighbors" if surface == "proactive" else "max_neighbors"
+    cap = section.get(cap_key, DEFAULTS["graph_expansion"][cap_key])
+    exclude_types = tuple(section.get("exclude_link_types") or ())
+
+    t0 = time.monotonic()
+    try:
+        seed_ids = [r.memory_id for r in results]
+        neighbors = await expand_neighbors(
+            db,
+            seed_ids,
+            cap=cap,
+            exclude_ids=seed_ids,
+            exclude_link_types=exclude_types,
+        )
+    except Exception:
+        logger.warning(
+            "graph expansion failed (surface=%s) — recall unaffected",
+            surface,
+            exc_info=True,
+        )
+        return results
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="memory",
+            event_type=f"graph_expansion_{mode}",
+            subject_id=recall_event_id,
+            metrics={
+                "surface": surface,
+                "seed_count": len(seed_ids),
+                "neighbors_returned": len(neighbors),
+                "neighbor_ids": [n.memory_id for n in neighbors[:10]],
+                "latency_ms": latency_ms,
+            },
+        )
+    except Exception:
+        logger.warning("graph expansion metric emit failed", exc_info=True)
+    logger.info(
+        "graph_expansion mode=%s surface=%s seeds=%d neighbors=%d latency_ms=%d",
+        mode,
+        surface,
+        len(results),
+        len(neighbors),
+        latency_ms,
+    )
+
+    if mode == "live" and neighbors:
+        return [*results, *neighbors]
+    return results

--- a/src/genesis/memory/graph_expansion.py
+++ b/src/genesis/memory/graph_expansion.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import copy
 import logging
 import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -164,7 +165,10 @@ async def expand_neighbors(
     Neighbors score ``0.01 * strength`` (sorts after any organic result) and
     carry ``payload["graph_expansion"] = {"linked_from": [...], "strength": s}``
     plus the FTS ``tags`` string (surfaces apply their own tag filters).
-    Dangling links (edge rows whose neighbor no longer resolves) are skipped.
+    Dangling links (edge rows whose neighbor no longer resolves) are skipped,
+    as are neighbors normal recall would hide (bitemporally expired or
+    deprecated/superseded rows) — expansion widens recall, it never
+    resurfaces what the pipeline deliberately filters.
     """
     if not seed_ids or cap <= 0:
         return []
@@ -179,6 +183,25 @@ async def expand_neighbors(
         return []
 
     neighbor_ids = [n["memory_id"] for n in neighbors]
+    # Visibility parity with normal recall (Codex #1069 P2): `get_by_id`
+    # applies neither the bitemporal expiry nor the deprecated predicate that
+    # `search_ranked`/`_expired_candidate_ids` enforce — without this, live
+    # expansion would resurface superseded facts that recall deliberately
+    # hides. NULL invalid_at = valid forever; NULL deprecated = legacy row,
+    # not deprecated (same semantics as the recall pipeline).
+    _ph = ",".join("?" * len(neighbor_ids))
+    hidden_rows = await db.execute_fetchall(
+        f"SELECT memory_id FROM memory_metadata "  # noqa: S608 - literal fragments; values bound
+        f"WHERE memory_id IN ({_ph}) AND "
+        f"((invalid_at IS NOT NULL AND invalid_at <= ?) OR deprecated = 1)",
+        [*neighbor_ids, datetime.now(UTC).isoformat()],
+    )
+    hidden = {r[0] for r in hidden_rows}
+    if hidden:
+        neighbors = [n for n in neighbors if n["memory_id"] not in hidden]
+        if not neighbors:
+            return []
+        neighbor_ids = [n["memory_id"] for n in neighbors]
     origins = await memory_crud.origin_class_by_ids(db, neighbor_ids)
     # Which seed(s) reach each neighbor — one bounded query over the
     # seed∪neighbor id set (direction-agnostic pair list).

--- a/src/genesis/memory/graph_expansion.py
+++ b/src/genesis/memory/graph_expansion.py
@@ -251,15 +251,18 @@ async def maybe_expand(
     mode = _mode_from(cfg)
     if mode == "off":
         return results
-    section = cfg.get("graph_expansion")
-    if not isinstance(section, dict):
-        section = DEFAULTS["graph_expansion"]
-    cap_key = "proactive_max_neighbors" if surface == "proactive" else "max_neighbors"
-    cap = section.get(cap_key, DEFAULTS["graph_expansion"][cap_key])
-    exclude_types = tuple(section.get("exclude_link_types") or ())
-
     t0 = time.monotonic()
     try:
+        # Config value extraction stays INSIDE the guard: the overlay is a
+        # hand-editable file (settings_update validates, a text editor does
+        # not) — a malformed cap or exclude list must degrade like any other
+        # expansion failure, never crash a recall surface.
+        section = cfg.get("graph_expansion")
+        if not isinstance(section, dict):
+            section = DEFAULTS["graph_expansion"]
+        cap_key = "proactive_max_neighbors" if surface == "proactive" else "max_neighbors"
+        cap = section.get(cap_key, DEFAULTS["graph_expansion"][cap_key])
+        exclude_types = tuple(section.get("exclude_link_types") or ())
         seed_ids = [r.memory_id for r in results]
         neighbors = await expand_neighbors(
             db,

--- a/tests/test_db/test_memory_links.py
+++ b/tests/test_db/test_memory_links.py
@@ -11,7 +11,11 @@ from genesis.db.crud import memory_links
 
 async def test_create_and_retrieve(db):
     pk = await memory_links.create(
-        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     assert pk == ("a", "b")
     links = await memory_links.get_links_for(db, "a")
@@ -22,20 +26,36 @@ async def test_create_and_retrieve(db):
 
 async def test_count_links(db):
     await memory_links.create(
-        db, source_id="c1", target_id="c2", link_type="extends", created_at="2026-01-01",
+        db,
+        source_id="c1",
+        target_id="c2",
+        link_type="extends",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="c3", target_id="c1", link_type="contradicts", created_at="2026-01-01",
+        db,
+        source_id="c3",
+        target_id="c1",
+        link_type="contradicts",
+        created_at="2026-01-01",
     )
     assert await memory_links.count_links(db, "c1") == 2
 
 
 async def test_get_links_for_both_directions(db):
     await memory_links.create(
-        db, source_id="d1", target_id="d2", link_type="elaborates", created_at="2026-01-01",
+        db,
+        source_id="d1",
+        target_id="d2",
+        link_type="elaborates",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="d3", target_id="d1", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="d3",
+        target_id="d1",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     links = await memory_links.get_links_for(db, "d1")
     assert len(links) == 2
@@ -43,7 +63,11 @@ async def test_get_links_for_both_directions(db):
 
 async def test_get_bidirectional_same_as_get_links_for(db):
     await memory_links.create(
-        db, source_id="e1", target_id="e2", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="e1",
+        target_id="e2",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     links = await memory_links.get_bidirectional(db, "e1")
     assert len(links) == 1
@@ -51,7 +75,11 @@ async def test_get_bidirectional_same_as_get_links_for(db):
 
 async def test_delete(db):
     await memory_links.create(
-        db, source_id="f1", target_id="f2", link_type="extends", created_at="2026-01-01",
+        db,
+        source_id="f1",
+        target_id="f2",
+        link_type="extends",
+        created_at="2026-01-01",
     )
     assert await memory_links.delete(db, source_id="f1", target_id="f2") is True
     assert await memory_links.delete(db, source_id="f1", target_id="f2") is False
@@ -64,11 +92,19 @@ async def test_delete_nonexistent(db):
 async def test_same_triplet_raises(db):
     """The same (source, target, link_type) twice still violates the PK."""
     await memory_links.create(
-        db, source_id="g1", target_id="g2", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="g1",
+        target_id="g2",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     with pytest.raises(IntegrityError):
         await memory_links.create(
-            db, source_id="g1", target_id="g2", link_type="supports", created_at="2026-01-02",
+            db,
+            source_id="g1",
+            target_id="g2",
+            link_type="supports",
+            created_at="2026-01-02",
         )
 
 
@@ -79,10 +115,18 @@ async def test_different_link_type_same_pair_persists(db):
     (source_id, target_id, link_type) keeps both edges.
     """
     await memory_links.create(
-        db, source_id="g1", target_id="g2", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="g1",
+        target_id="g2",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="g1", target_id="g2", link_type="contradicts", created_at="2026-01-02",
+        db,
+        source_id="g1",
+        target_id="g2",
+        link_type="contradicts",
+        created_at="2026-01-02",
     )
     links = await memory_links.get_links_for(db, "g1")
     types = sorted(link["link_type"] for link in links)
@@ -92,10 +136,18 @@ async def test_different_link_type_same_pair_persists(db):
 async def test_inter_candidate_links_dedupes_multi_type_pairs(db):
     """Adjacency boost is binary per pair — a multi-type pair counts once."""
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="contradicts", created_at="2026-01-02",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="contradicts",
+        created_at="2026-01-02",
     )
     edges = await memory_links.inter_candidate_links(db, ["a", "b"])
     assert edges == [("a", "b")]  # deduped, not [("a","b"), ("a","b")]
@@ -104,15 +156,29 @@ async def test_inter_candidate_links_dedupes_multi_type_pairs(db):
 async def test_delete_by_link_type(db):
     """delete(link_type=...) removes only that type; without it, all types go."""
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="contradicts", created_at="2026-01-02",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="contradicts",
+        created_at="2026-01-02",
     )
     # Targeted delete removes only the typed link.
-    assert await memory_links.delete(
-        db, source_id="a", target_id="b", link_type="supports",
-    ) is True
+    assert (
+        await memory_links.delete(
+            db,
+            source_id="a",
+            target_id="b",
+            link_type="supports",
+        )
+        is True
+    )
     remaining = await memory_links.get_links_for(db, "a")
     assert [link["link_type"] for link in remaining] == ["contradicts"]
     # Untyped delete removes whatever is left for the pair.
@@ -127,13 +193,25 @@ async def test_batch_link_counts(db):
     """batch_link_counts returns (total, inbound) per memory_id."""
     # c1 -> c2, c1 -> c3, c3 -> c2
     await memory_links.create(
-        db, source_id="c1", target_id="c2", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="c1",
+        target_id="c2",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="c1", target_id="c3", link_type="extends", created_at="2026-01-01",
+        db,
+        source_id="c1",
+        target_id="c3",
+        link_type="extends",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="c3", target_id="c2", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="c3",
+        target_id="c2",
+        link_type="supports",
+        created_at="2026-01-01",
     )
 
     counts = await memory_links.batch_link_counts(db, ["c1", "c2", "c3"])
@@ -161,13 +239,25 @@ async def test_batch_link_counts_no_links(db):
 async def test_inter_candidate_links(db):
     """inter_candidate_links returns only edges within the candidate set."""
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="supports",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="b", target_id="c", link_type="extends", created_at="2026-01-01",
+        db,
+        source_id="b",
+        target_id="c",
+        link_type="extends",
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="d", target_id="e", link_type="supports", created_at="2026-01-01",
+        db,
+        source_id="d",
+        target_id="e",
+        link_type="supports",
+        created_at="2026-01-01",
     )
 
     edges = await memory_links.inter_candidate_links(db, ["a", "b", "c"])
@@ -188,20 +278,36 @@ async def test_neighbors_of_dedupes_directions_and_types(db):
     neighbor with MAX(strength), strongest first."""
     # seed <-> n1 linked twice (two types, both directions), n2 weaker, n3 via inbound only
     await memory_links.create(
-        db, source_id="seed", target_id="n1", link_type="supports",
-        strength=0.8, created_at="2026-01-01",
+        db,
+        source_id="seed",
+        target_id="n1",
+        link_type="supports",
+        strength=0.8,
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="n1", target_id="seed", link_type="extends",
-        strength=0.92, created_at="2026-01-01",
+        db,
+        source_id="n1",
+        target_id="seed",
+        link_type="extends",
+        strength=0.92,
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="seed", target_id="n2", link_type="supports",
-        strength=0.76, created_at="2026-01-01",
+        db,
+        source_id="seed",
+        target_id="n2",
+        link_type="supports",
+        strength=0.76,
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="n3", target_id="seed", link_type="supports",
-        strength=0.85, created_at="2026-01-01",
+        db,
+        source_id="n3",
+        target_id="seed",
+        link_type="supports",
+        strength=0.85,
+        created_at="2026-01-01",
     )
     rows = await memory_links.neighbors_of(db, ["seed"])
     ids = [r["memory_id"] for r in rows]
@@ -212,8 +318,12 @@ async def test_neighbors_of_dedupes_directions_and_types(db):
 async def test_neighbors_of_excludes_and_caps(db):
     for i, s in enumerate((0.9, 0.85, 0.8)):
         await memory_links.create(
-            db, source_id="seed", target_id=f"n{i}", link_type="supports",
-            strength=s, created_at="2026-01-01",
+            db,
+            source_id="seed",
+            target_id=f"n{i}",
+            link_type="supports",
+            strength=s,
+            created_at="2026-01-01",
         )
     rows = await memory_links.neighbors_of(db, ["seed"], exclude=["n0"], limit=1)
     assert [r["memory_id"] for r in rows] == ["n1"]  # n0 excluded, capped to 1
@@ -221,8 +331,12 @@ async def test_neighbors_of_excludes_and_caps(db):
 
 async def test_neighbors_of_never_returns_seeds_or_empty(db):
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="supports",
-        strength=0.9, created_at="2026-01-01",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="supports",
+        strength=0.9,
+        created_at="2026-01-01",
     )
     rows = await memory_links.neighbors_of(db, ["a", "b"])
     assert rows == []  # b is itself a seed, not a neighbor
@@ -234,8 +348,12 @@ async def test_neighbors_of_oversized_seed_list_and_exclude_no_error(db):
     (exclusion is Python-side; seeds are capped) and truncated seeds must
     never come back as 'neighbors'."""
     await memory_links.create(
-        db, source_id="seed_0", target_id="real_neighbor", link_type="supports",
-        strength=0.9, created_at="2026-01-01",
+        db,
+        source_id="seed_0",
+        target_id="real_neighbor",
+        link_type="supports",
+        strength=0.9,
+        created_at="2026-01-01",
     )
     seeds = [f"seed_{i}" for i in range(600)]
     exclude = [f"ex_{i}" for i in range(600)]
@@ -247,8 +365,12 @@ async def test_neighbors_of_oversized_seed_list_and_exclude_no_error(db):
 
 async def test_neighbors_of_limit_zero_and_negative(db):
     await memory_links.create(
-        db, source_id="a", target_id="b", link_type="supports",
-        strength=0.9, created_at="2026-01-01",
+        db,
+        source_id="a",
+        target_id="b",
+        link_type="supports",
+        strength=0.9,
+        created_at="2026-01-01",
     )
     assert await memory_links.neighbors_of(db, ["a"], limit=0) == []
     assert await memory_links.neighbors_of(db, ["a"], limit=-3) == []
@@ -259,8 +381,12 @@ async def test_neighbors_of_ties_break_deterministically(db):
     metrics built on them) must be reproducible across runs/insert order."""
     for tgt in ("n_c", "n_a", "n_b"):
         await memory_links.create(
-            db, source_id="seed", target_id=tgt, link_type="supports",
-            strength=0.8, created_at="2026-01-01",
+            db,
+            source_id="seed",
+            target_id=tgt,
+            link_type="supports",
+            strength=0.8,
+            created_at="2026-01-01",
         )
     rows = await memory_links.neighbors_of(db, ["seed"], limit=2)
     assert [r["memory_id"] for r in rows] == ["n_a", "n_b"]
@@ -270,16 +396,87 @@ async def test_neighbors_of_link_types_filter(db):
     """link_types restricts which edge types are followed — prod callers
     expanding into LLM context can exclude adversarial types."""
     await memory_links.create(
-        db, source_id="seed", target_id="friend", link_type="supports",
-        strength=0.9, created_at="2026-01-01",
+        db,
+        source_id="seed",
+        target_id="friend",
+        link_type="supports",
+        strength=0.9,
+        created_at="2026-01-01",
     )
     await memory_links.create(
-        db, source_id="seed", target_id="foe", link_type="contradicts",
-        strength=0.95, created_at="2026-01-01",
+        db,
+        source_id="seed",
+        target_id="foe",
+        link_type="contradicts",
+        strength=0.95,
+        created_at="2026-01-01",
     )
     all_rows = await memory_links.neighbors_of(db, ["seed"])
     assert {r["memory_id"] for r in all_rows} == {"friend", "foe"}
     safe = await memory_links.neighbors_of(
-        db, ["seed"], link_types=("supports", "extends"),
+        db,
+        ["seed"],
+        link_types=("supports", "extends"),
     )
     assert [r["memory_id"] for r in safe] == ["friend"]
+
+
+async def test_neighbors_of_exclude_link_types_sql_level(db):
+    """exclude_link_types filters IN SQL — an excluded edge must not consume
+    the LIMIT budget (a Python post-filter after LIMIT would under-fill)."""
+    await memory_links.create(
+        db,
+        source_id="seed",
+        target_id="foe",
+        link_type="contradicts",
+        strength=0.95,
+        created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db,
+        source_id="seed",
+        target_id="friend",
+        link_type="supports",
+        strength=0.4,
+        created_at="2026-01-01",
+    )
+    rows = await memory_links.neighbors_of(
+        db,
+        ["seed"],
+        limit=1,
+        exclude_link_types=("contradicts",),
+    )
+    assert [r["memory_id"] for r in rows] == ["friend"]
+
+
+async def test_neighbors_of_exclude_link_types_composes_with_include(db):
+    """include + exclude compose: followed = link_types minus exclude."""
+    for target, lt in (("a", "supports"), ("b", "extends"), ("c", "contradicts")):
+        await memory_links.create(
+            db,
+            source_id="seed",
+            target_id=target,
+            link_type=lt,
+            strength=0.5,
+            created_at="2026-01-01",
+        )
+    rows = await memory_links.neighbors_of(
+        db,
+        ["seed"],
+        link_types=("supports", "extends", "contradicts"),
+        exclude_link_types=("contradicts",),
+    )
+    assert {r["memory_id"] for r in rows} == {"a", "b"}
+
+
+async def test_neighbors_of_exclude_link_types_empty_is_noop(db):
+    await memory_links.create(
+        db,
+        source_id="seed",
+        target_id="n1",
+        link_type="contradicts",
+        strength=0.5,
+        created_at="2026-01-01",
+    )
+    rows = await memory_links.neighbors_of(db, ["seed"], exclude_link_types=())
+    assert [r["memory_id"] for r in rows] == ["n1"]

--- a/tests/test_mcp/test_memory_recall_graph_expansion.py
+++ b/tests/test_mcp/test_memory_recall_graph_expansion.py
@@ -383,3 +383,30 @@ async def test_proactive_shadow_output_unchanged_and_emits(db, expansion_config,
         "SELECT event_type FROM eval_events WHERE event_type LIKE 'graph_expansion_%'",
     )
     assert [r[0] for r in rows] == ["graph_expansion_shadow"]
+
+
+async def test_full_live_dedups_neighbor_crag_already_added(
+    db, expansion_config, record_spy, monkeypatch,
+):
+    """CRAG's corrective augmentation can independently re-add an item that
+    is also a 1-hop neighbor — the expansion merge must not duplicate it in
+    the model-facing output."""
+    import genesis.memory.corrective as corrective_mod
+
+    expansion_config("live")
+    await _seed_neighbor(db, "seed-1", "nbr-1")
+
+    async def _fake_correct(*, results, **_k):
+        # CRAG re-adds the neighbor as its own augmentation
+        return [*results, {"memory_id": "nbr-1", "content": "crag copy of nbr-1"}]
+
+    monkeypatch.setattr(corrective_mod, "maybe_correct_recall", _fake_correct)
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_recall"].fn(
+            query="q", compact=False, include_graph=False, corrective=True,
+        )
+
+    ids = [d["memory_id"] for d in out]
+    assert ids.count("nbr-1") == 1  # CRAG's copy kept, expansion did not duplicate
+    assert set(ids) == {"seed-1", "nbr-1"}

--- a/tests/test_mcp/test_memory_recall_graph_expansion.py
+++ b/tests/test_mcp/test_memory_recall_graph_expansion.py
@@ -1,0 +1,385 @@
+"""Graph expansion at the MCP recall surfaces (compact / full / proactive).
+
+The graph_expansion module's own behavior (config layering, primitive,
+maybe_expand modes) is covered in ``tests/test_memory/test_graph_expansion.py``.
+This file pins the WIRING: each surface merges neighbors at the right point so
+they flow through the existing provenance/label/wrap/count/drop machinery —
+an expanded neighbor must be indistinguishable from an organic result to
+WS-3's defenses.
+
+Harness follows ``test_memory_mcp.py``: real in-memory DB (``db`` fixture),
+mocked retriever returning canned RetrievalResults, module state swapped on
+``genesis.mcp.memory_mcp``. Config redirected into tmp dirs so tests control
+the expansion mode (the repo ships ``mode: shadow``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+from genesis.db.crud import memory as memory_crud
+from genesis.db.crud import memory_links as memory_links_crud
+from genesis.mcp.memory_mcp import mcp
+from genesis.memory import graph_expansion
+from genesis.memory.types import RetrievalResult
+from genesis.security import immunity_shadow
+
+
+async def _get_tools():
+    return await mcp.get_tools()
+
+
+@pytest.fixture
+def expansion_config(tmp_path, monkeypatch):
+    """Redirect memory_recall config into tmp dirs; write via returned fn."""
+    repo_dir = tmp_path / "repo"
+    (repo_dir / "config").mkdir(parents=True)
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()
+    monkeypatch.setattr(graph_expansion, "repo_root", lambda: repo_dir)
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: user_dir)
+
+    def _set(mode: str, **kwargs) -> None:
+        (repo_dir / "config" / "memory_recall.yaml").write_text(
+            yaml.safe_dump({"graph_expansion": {"mode": mode, **kwargs}}),
+        )
+
+    return _set
+
+
+@pytest.fixture
+def record_spy(monkeypatch):
+    """Capture immunity_shadow.record_would_block calls (core.py namespace)."""
+    calls: list[dict] = []
+
+    async def _spy(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(immunity_shadow, "record_would_block", _spy)
+    return calls
+
+
+def _rr(
+    mid: str, *, collection: str = "episodic_memory", origin_class: str | None = "owner"
+) -> RetrievalResult:
+    return RetrievalResult(
+        memory_id=mid,
+        content=f"content of {mid}",
+        source="memory",
+        memory_type=collection,
+        score=0.9,
+        vector_rank=1,
+        fts_rank=None,
+        activation_score=0.2,
+        payload={"tags": []},
+        source_pipeline="hybrid",
+        origin_class=origin_class,
+        collection=collection,
+    )
+
+
+async def _seed_neighbor(
+    db,
+    seed_id: str,
+    nbr_id: str,
+    *,
+    strength: float = 0.8,
+    collection: str = "episodic_memory",
+    origin_class: str | None = "owner",
+    tags: str = "",
+) -> None:
+    """DB rows for the SEED (links only resolve via memory_links) + neighbor."""
+    for mid, coll, oc in (
+        (seed_id, "episodic_memory", "owner"),
+        (nbr_id, collection, origin_class),
+    ):
+        exists = await memory_crud.get_by_id(db, mid)
+        if not exists:
+            await memory_crud.create(
+                db,
+                memory_id=mid,
+                content=f"content of {mid}",
+                tags=tags if mid == nbr_id else "",
+                collection=coll,
+            )
+            await memory_crud.create_metadata(
+                db,
+                memory_id=mid,
+                created_at="2026-07-01T00:00:00Z",
+                collection=coll,
+                origin_class=oc,
+            )
+    await memory_links_crud.create(
+        db,
+        source_id=seed_id,
+        target_id=nbr_id,
+        link_type="supports",
+        strength=strength,
+        created_at="2026-07-01T00:00:00Z",
+    )
+
+
+class _SwappedState:
+    """Context manager swapping memory_mcp module state (store/db/retriever)."""
+
+    def __init__(self, db, results: list[RetrievalResult]):
+        import genesis.mcp.memory_mcp as mod
+
+        self.mod = mod
+        self.db = db
+        self.results = results
+
+    def __enter__(self):
+        mod = self.mod
+        self.old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+        retriever = AsyncMock()
+
+        async def _recall(*_a, event_id_sink=None, **_k):
+            return list(self.results)
+
+        retriever.recall = _recall
+        retriever._embeddings = MagicMock()
+        mod._store = MagicMock()
+        mod._db = self.db
+        mod._retriever = retriever
+        mod._qdrant = MagicMock()
+        return mod
+
+    def __exit__(self, *exc):
+        (self.mod._store, self.mod._db, self.mod._retriever, self.mod._qdrant) = self.old
+        return False
+
+
+# ─── compact surface ─────────────────────────────────────────────────────────
+
+
+async def test_compact_live_appends_neighbor_preview_with_via_graph(
+    db,
+    expansion_config,
+    record_spy,
+):
+    expansion_config("live")
+    await _seed_neighbor(db, "seed-1", "nbr-1")
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_recall"].fn(query="q", compact=True)
+
+    assert [d["memory_id"] for d in out] == ["seed-1", "nbr-1"]
+    assert out[1]["via_graph"] is True
+    assert "via_graph" not in out[0]
+    assert out[1]["preview"].startswith("content of nbr-1")
+
+
+async def test_compact_live_counts_external_neighbor_blockable(
+    db,
+    expansion_config,
+    record_spy,
+):
+    expansion_config("live")
+    await _seed_neighbor(
+        db,
+        "seed-1",
+        "nbr-ext",
+        collection="knowledge_base",
+        origin_class="external_untrusted",
+    )
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        await tools["memory_recall"].fn(query="q", compact=True)
+
+    compact_calls = [c for c in record_spy if c.get("detail") == {"path": "compact"}]
+    assert len(compact_calls) == 1
+    assert compact_calls[0]["blockable_count"] == 1  # the neighbor, not the seed
+
+
+async def test_compact_shadow_output_unchanged(db, expansion_config, record_spy):
+    expansion_config("shadow")
+    await _seed_neighbor(db, "seed-1", "nbr-1")
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_recall"].fn(query="q", compact=True)
+
+    assert [d["memory_id"] for d in out] == ["seed-1"]
+    rows = await db.execute_fetchall(
+        "SELECT event_type FROM eval_events WHERE event_type LIKE 'graph_expansion_%'",
+    )
+    assert [r[0] for r in rows] == ["graph_expansion_shadow"]
+
+
+# ─── full surface ────────────────────────────────────────────────────────────
+
+
+async def test_full_live_merges_neighbor_dict_wrapped_and_counted(
+    db,
+    expansion_config,
+    record_spy,
+):
+    expansion_config("live")
+    await _seed_neighbor(
+        db,
+        "seed-1",
+        "nbr-ext",
+        collection="knowledge_base",
+        origin_class="external_untrusted",
+    )
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_recall"].fn(
+            query="q",
+            compact=False,
+            include_graph=False,
+            corrective=False,
+        )
+
+    by_id = {d["memory_id"]: d for d in out}
+    assert set(by_id) == {"seed-1", "nbr-ext"}
+    nbr = by_id["nbr-ext"]
+    assert nbr["via_graph"] is True
+    # went through label_result_dicts (provenance) AND the wrap loop
+    assert nbr.get("provenance")
+    assert nbr["content"] != "content of nbr-ext"  # wrapped external
+    assert "content of nbr-ext" in nbr["content"]
+    full_calls = [c for c in record_spy if c.get("detail") is None]
+    assert len(full_calls) == 1
+    assert full_calls[0]["blockable_count"] == 1
+
+
+async def test_full_shadow_output_unchanged_and_emits(db, expansion_config, record_spy):
+    expansion_config("shadow")
+    await _seed_neighbor(db, "seed-1", "nbr-1")
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_recall"].fn(
+            query="q",
+            compact=False,
+            include_graph=False,
+            corrective=False,
+        )
+
+    assert [d["memory_id"] for d in out] == ["seed-1"]
+    rows = await db.execute_fetchall(
+        "SELECT event_type FROM eval_events WHERE event_type LIKE 'graph_expansion_%'",
+    )
+    assert [r[0] for r in rows] == ["graph_expansion_shadow"]
+
+
+async def test_full_off_no_expansion_no_event(db, expansion_config, record_spy):
+    expansion_config("off")
+    await _seed_neighbor(db, "seed-1", "nbr-1")
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_recall"].fn(
+            query="q",
+            compact=False,
+            include_graph=False,
+            corrective=False,
+        )
+
+    assert [d["memory_id"] for d in out] == ["seed-1"]
+    rows = await db.execute_fetchall(
+        "SELECT event_type FROM eval_events WHERE event_type LIKE 'graph_expansion_%'",
+    )
+    assert rows == []
+
+
+# ─── proactive surface ───────────────────────────────────────────────────────
+
+
+async def test_proactive_live_appends_defended_neighbor(
+    db,
+    expansion_config,
+    record_spy,
+):
+    expansion_config("live")
+    await _seed_neighbor(
+        db,
+        "seed-1",
+        "nbr-ext",
+        collection="knowledge_base",
+        origin_class="external_untrusted",
+    )
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_proactive"].fn(current_message="hello")
+
+    assert [d["memory_id"] for d in out] == ["seed-1", "nbr-ext"]
+    nbr = out[1]
+    assert nbr["via_graph"] is True
+    assert nbr["content"] != "content of nbr-ext"  # wrapped external
+    assert "content of nbr-ext" in nbr["content"]
+    assert len(record_spy) == 1
+    assert record_spy[0]["blockable_count"] == 1  # neighbor counted
+
+
+async def test_proactive_live_respects_proactive_cap(db, expansion_config, record_spy):
+    expansion_config("live", proactive_max_neighbors=2)
+    for i, s in enumerate((0.9, 0.8, 0.7)):
+        await _seed_neighbor(db, "seed-1", f"nbr-{i}", strength=s)
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_proactive"].fn(current_message="hello")
+
+    assert [d["memory_id"] for d in out] == ["seed-1", "nbr-0", "nbr-1"]
+
+
+async def test_proactive_neighbor_memory_operation_tag_filtered(
+    db,
+    expansion_config,
+    record_spy,
+):
+    """The organic pool filters memory_operation-tagged items — a neighbor
+    carrying that tag (string form, from the FTS row) must be filtered too."""
+    expansion_config("live")
+    await _seed_neighbor(db, "seed-1", "nbr-memop", tags="memory_operation,foo")
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_proactive"].fn(current_message="hello")
+
+    assert [d["memory_id"] for d in out] == ["seed-1"]
+
+
+async def test_proactive_neighbor_runs_enforce_drop(
+    db,
+    expansion_config,
+    record_spy,
+    monkeypatch,
+):
+    """A neighbor the enforce branch would drop must be dropped (and counted
+    in enforced_drops), exactly like an organic item — expansion must not be
+    a bypass around the gate-4 pushed-surface cut."""
+    expansion_config("live")
+    await _seed_neighbor(
+        db,
+        "seed-1",
+        "nbr-ext",
+        collection="knowledge_base",
+        origin_class="external_untrusted",
+    )
+
+    def _drop_external(**kwargs):
+        return kwargs.get("origin_class") == "external_untrusted"
+
+    monkeypatch.setattr(immunity_shadow, "should_enforce_drop", _drop_external)
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_proactive"].fn(current_message="hello")
+
+    assert [d["memory_id"] for d in out] == ["seed-1"]
+    assert record_spy[0]["detail"] == {"enforced_drops": 1}
+
+
+async def test_proactive_shadow_output_unchanged_and_emits(db, expansion_config, record_spy):
+    expansion_config("shadow")
+    await _seed_neighbor(db, "seed-1", "nbr-1")
+    with _SwappedState(db, [_rr("seed-1")]):
+        tools = await _get_tools()
+        out = await tools["memory_proactive"].fn(current_message="hello")
+
+    assert [d["memory_id"] for d in out] == ["seed-1"]
+    rows = await db.execute_fetchall(
+        "SELECT event_type FROM eval_events WHERE event_type LIKE 'graph_expansion_%'",
+    )
+    assert [r[0] for r in rows] == ["graph_expansion_shadow"]

--- a/tests/test_mcp/test_settings_memory_recall.py
+++ b/tests/test_mcp/test_settings_memory_recall.py
@@ -1,0 +1,78 @@
+"""memory_recall settings domain: registration + validator (graph expansion).
+
+Mirrors ``test_settings_ws3_immunity.py`` — the domain is read live per call
+by ``genesis.memory.graph_expansion`` (needs_restart=False), and the
+validator must reject anything ``load_recall_config`` would misread, so a
+``settings_update`` can never write a config that degrades-with-warning.
+"""
+
+from __future__ import annotations
+
+from genesis.mcp.health.settings import (
+    _DOMAIN_REGISTRY,
+    _DOMAIN_VALIDATORS,
+    _validate_memory_recall,
+)
+
+
+def test_memory_recall_domain_registered():
+    assert "memory_recall" in _DOMAIN_REGISTRY
+    d = _DOMAIN_REGISTRY["memory_recall"]
+    assert d.readonly is False
+    assert d.needs_restart is False  # read live per-call by graph_expansion
+    assert d.config_filename == "memory_recall.yaml"
+    assert "memory_recall" in _DOMAIN_VALIDATORS
+
+
+def test_valid_changes_pass():
+    assert _validate_memory_recall({"enabled": True}) == []
+    assert (
+        _validate_memory_recall(
+            {
+                "graph_expansion": {
+                    "mode": "live",
+                    "max_neighbors": 10,
+                    "proactive_max_neighbors": 2,
+                    "exclude_link_types": ["contradicts"],
+                },
+            },
+        )
+        == []
+    )
+    assert _validate_memory_recall({"entity_lane": {"mode": "off"}}) == []
+
+
+def test_unknown_top_key_rejected():
+    errs = _validate_memory_recall({"graph_expansions": {"mode": "live"}})
+    assert errs and "graph_expansions" in errs[0]
+
+
+def test_invalid_mode_rejected():
+    errs = _validate_memory_recall({"graph_expansion": {"mode": "enforce"}})
+    assert errs
+    # entity_lane has no "live" implementation yet — off/shadow only for now
+    assert _validate_memory_recall({"entity_lane": {"mode": "banana"}})
+
+
+def test_enabled_must_be_bool():
+    assert _validate_memory_recall({"enabled": "yes"})
+
+
+def test_caps_must_be_bounded_ints():
+    assert _validate_memory_recall({"graph_expansion": {"max_neighbors": -1}})
+    assert _validate_memory_recall({"graph_expansion": {"max_neighbors": 26}})
+    assert _validate_memory_recall({"graph_expansion": {"max_neighbors": True}})
+    assert _validate_memory_recall({"graph_expansion": {"proactive_max_neighbors": "2"}})
+    assert _validate_memory_recall({"graph_expansion": {"max_neighbors": 0}}) == []
+    assert _validate_memory_recall({"graph_expansion": {"max_neighbors": 25}}) == []
+
+
+def test_exclude_link_types_must_be_str_list():
+    assert _validate_memory_recall({"graph_expansion": {"exclude_link_types": "contradicts"}})
+    assert _validate_memory_recall({"graph_expansion": {"exclude_link_types": [1]}})
+    assert _validate_memory_recall({"graph_expansion": {"exclude_link_types": []}}) == []
+
+
+def test_section_must_be_mapping():
+    assert _validate_memory_recall({"graph_expansion": "live"})
+    assert _validate_memory_recall({"entity_lane": []})

--- a/tests/test_memory/test_graph_expansion.py
+++ b/tests/test_memory/test_graph_expansion.py
@@ -410,3 +410,21 @@ async def test_maybe_expand_expansion_failure_never_raises(db, config_dirs, monk
     out = await graph_expansion.maybe_expand(db, results, surface="full")
 
     assert [r.memory_id for r in out] == ["seed-1"]
+
+
+async def test_maybe_expand_malformed_config_values_never_raise(db, config_dirs):
+    """Config extraction is inside the best-effort guard: a hand-edited
+    non-iterable exclude_link_types or non-int cap must degrade (results
+    unchanged), never crash the recall surface (compact/proactive have no
+    outer guard)."""
+    base, _ = config_dirs
+    await _seed_linked_pair(db)
+    results = [_result("seed-1")]
+
+    _write(base, {"graph_expansion": {"mode": "live", "exclude_link_types": 5}})
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+    assert [r.memory_id for r in out] == ["seed-1"]
+
+    _write(base, {"graph_expansion": {"mode": "live", "max_neighbors": "ten"}})
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+    assert [r.memory_id for r in out] == ["seed-1"]

--- a/tests/test_memory/test_graph_expansion.py
+++ b/tests/test_memory/test_graph_expansion.py
@@ -1,0 +1,412 @@
+"""Recall-time 1-hop graph expansion (``genesis.memory.graph_expansion``).
+
+Covers the three layers of the module:
+
+- config: DEFAULTS ← ``config/memory_recall.yaml`` ← ``.local.yaml`` overlay,
+  re-read on EVERY call (no cache — a ``settings_update`` takes effect on the
+  next recall in the same process), master ``enabled: false`` short-circuit,
+  invalid mode degrading to ``shadow`` (observable, never behavior-changing —
+  the ws3_immunity posture).
+- ``expand_neighbors``: the mode-independent primitive (also reused by the
+  LongMemEval graph arm) — stored-first provenance, deterministic ordering,
+  dangling-link skips, seed/exclude discipline, link-type exclusion.
+- ``maybe_expand``: the MCP-surface wrapper — off passthrough, shadow
+  emit-but-don't-touch, live append, per-surface caps, and the
+  metrics-never-raise guarantee.
+
+Config paths are redirected into tmp dirs exactly like
+``tests/test_security/test_immunity.py`` (base via ``repo_root``, overlay via
+``_user_config_dir`` in both namespaces).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from genesis.db.crud import memory as memory_crud
+from genesis.db.crud import memory_links as memory_links_crud
+from genesis.memory import graph_expansion
+from genesis.memory.types import RetrievalResult
+
+
+@pytest.fixture
+def config_dirs(tmp_path, monkeypatch) -> tuple[Path, Path]:
+    """Redirect base + overlay config resolution into tmp dirs.
+
+    Returns ``(base_path, overlay_path)`` — neither file exists initially.
+    """
+    repo_dir = tmp_path / "repo"
+    user_dir = tmp_path / "user_config"
+    (repo_dir / "config").mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(graph_expansion, "repo_root", lambda: repo_dir)
+    monkeypatch.setattr(
+        "genesis._config_overlay._user_config_dir",
+        lambda: user_dir,
+    )
+
+    return (
+        repo_dir / "config" / "memory_recall.yaml",
+        user_dir / "memory_recall.local.yaml",
+    )
+
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data))
+
+
+async def _seed_memory(
+    db,
+    memory_id: str,
+    *,
+    content: str | None = None,
+    collection: str = "episodic_memory",
+    origin_class: str | None = "owner",
+) -> None:
+    await memory_crud.create(
+        db,
+        memory_id=memory_id,
+        content=content if content is not None else f"content of {memory_id}",
+        source_type="memory",
+        collection=collection,
+    )
+    await memory_crud.create_metadata(
+        db,
+        memory_id=memory_id,
+        created_at="2026-07-01T00:00:00Z",
+        collection=collection,
+        origin_class=origin_class,
+    )
+
+
+async def _link(
+    db, source: str, target: str, *, strength: float = 0.8, link_type: str = "supports"
+) -> None:
+    await memory_links_crud.create(
+        db,
+        source_id=source,
+        target_id=target,
+        link_type=link_type,
+        strength=strength,
+        created_at="2026-07-01T00:00:00Z",
+    )
+
+
+def _result(memory_id: str = "seed-1") -> RetrievalResult:
+    return RetrievalResult(
+        memory_id=memory_id,
+        content=f"content of {memory_id}",
+        source="memory",
+        memory_type="episodic_memory",
+        score=0.9,
+        vector_rank=1,
+        fts_rank=None,
+        activation_score=0.0,
+        payload={},
+    )
+
+
+# ─── config: defaults / layering / live re-read ──────────────────────────────
+
+
+def test_defaults_with_no_files_at_all(config_dirs):
+    cfg = graph_expansion.load_recall_config()
+    assert cfg["enabled"] is True
+    assert cfg["graph_expansion"]["mode"] == "shadow"
+    assert cfg["graph_expansion"]["max_neighbors"] == 10
+    assert cfg["graph_expansion"]["proactive_max_neighbors"] == 2
+    assert cfg["graph_expansion"]["exclude_link_types"] == ["contradicts"]
+    assert cfg["entity_lane"]["mode"] == "off"
+    assert graph_expansion.expansion_mode() == "shadow"
+
+
+def test_base_yaml_overrides_defaults(config_dirs):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "live", "max_neighbors": 5}})
+    cfg = graph_expansion.load_recall_config()
+    assert cfg["graph_expansion"]["mode"] == "live"
+    assert cfg["graph_expansion"]["max_neighbors"] == 5
+    # untouched keys keep defaults
+    assert cfg["graph_expansion"]["proactive_max_neighbors"] == 2
+    assert graph_expansion.expansion_mode() == "live"
+
+
+def test_local_overlay_wins_over_base(config_dirs):
+    base, overlay = config_dirs
+    _write(base, {"graph_expansion": {"mode": "live"}})
+    _write(overlay, {"graph_expansion": {"mode": "off"}})
+    assert graph_expansion.expansion_mode() == "off"
+
+
+def test_master_enabled_false_short_circuits_to_off(config_dirs):
+    base, _ = config_dirs
+    _write(base, {"enabled": False, "graph_expansion": {"mode": "live"}})
+    assert graph_expansion.expansion_mode() == "off"
+
+
+def test_invalid_mode_degrades_to_shadow(config_dirs, caplog):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "banana"}})
+    assert graph_expansion.expansion_mode() == "shadow"
+
+
+def test_corrupt_base_degrades_to_defaults(config_dirs):
+    base, _ = config_dirs
+    base.write_text(":: not yaml ::[")
+    assert graph_expansion.expansion_mode() == "shadow"
+
+
+def test_live_reread_no_cache(config_dirs):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "off"}})
+    assert graph_expansion.expansion_mode() == "off"
+    _write(base, {"graph_expansion": {"mode": "live"}})
+    assert graph_expansion.expansion_mode() == "live"
+
+
+# ─── expand_neighbors: the mode-independent primitive ────────────────────────
+
+
+async def test_expand_returns_stored_provenance_and_marker(db):
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "nbr-1", collection="knowledge_base", origin_class="external_untrusted")
+    await _link(db, "seed-1", "nbr-1", strength=0.9)
+
+    out = await graph_expansion.expand_neighbors(db, ["seed-1"], cap=10)
+
+    assert len(out) == 1
+    r = out[0]
+    assert isinstance(r, RetrievalResult)
+    assert r.memory_id == "nbr-1"
+    assert r.content == "content of nbr-1"
+    # stored-first provenance: never synthetic values
+    assert r.collection == "knowledge_base"
+    assert r.origin_class == "external_untrusted"
+    assert r.source_pipeline is None  # no SQLite column; never fabricated
+    # sorts after any organic result
+    assert r.score == pytest.approx(0.01 * 0.9)
+    marker = r.payload["graph_expansion"]
+    assert marker["linked_from"] == ["seed-1"]
+    assert marker["strength"] == pytest.approx(0.9)
+
+
+async def test_expand_skips_dangling_neighbors(db):
+    await _seed_memory(db, "seed-1")
+    # link rows exist but the neighbor memory does not resolve
+    await _link(db, "seed-1", "ghost-1", strength=0.9)
+    await _seed_memory(db, "nbr-1")
+    await _link(db, "seed-1", "nbr-1", strength=0.5)
+
+    out = await graph_expansion.expand_neighbors(db, ["seed-1"], cap=10)
+
+    assert [r.memory_id for r in out] == ["nbr-1"]
+
+
+async def test_expand_cap_and_strength_ordering(db):
+    await _seed_memory(db, "seed-1")
+    for i, s in enumerate((0.3, 0.9, 0.6)):
+        await _seed_memory(db, f"nbr-{i}")
+        await _link(db, "seed-1", f"nbr-{i}", strength=s)
+
+    out = await graph_expansion.expand_neighbors(db, ["seed-1"], cap=2)
+
+    assert [r.memory_id for r in out] == ["nbr-1", "nbr-2"]  # 0.9, 0.6
+
+
+async def test_expand_never_returns_seeds_or_excluded(db):
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "seed-2")
+    await _seed_memory(db, "nbr-1")
+    await _link(db, "seed-1", "seed-2", strength=0.9)  # seed↔seed link
+    await _link(db, "seed-1", "nbr-1", strength=0.8)
+    await _seed_memory(db, "already-in-results")
+    await _link(db, "seed-1", "already-in-results", strength=0.7)
+
+    out = await graph_expansion.expand_neighbors(
+        db,
+        ["seed-1", "seed-2"],
+        cap=10,
+        exclude_ids=["already-in-results"],
+    )
+
+    assert [r.memory_id for r in out] == ["nbr-1"]
+
+
+async def test_expand_exclude_link_types_is_sql_level(db):
+    """A stronger excluded-type link must not consume the LIMIT budget.
+
+    With ``cap=1`` and a stronger ``contradicts`` edge, a Python post-filter
+    after ``LIMIT`` would return nothing; the SQL-level exclusion returns the
+    ``supports`` neighbor.
+    """
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "nbr-contra")
+    await _seed_memory(db, "nbr-support")
+    await _link(db, "seed-1", "nbr-contra", strength=0.95, link_type="contradicts")
+    await _link(db, "seed-1", "nbr-support", strength=0.4, link_type="supports")
+
+    out = await graph_expansion.expand_neighbors(
+        db,
+        ["seed-1"],
+        cap=1,
+        exclude_link_types=("contradicts",),
+    )
+
+    assert [r.memory_id for r in out] == ["nbr-support"]
+
+
+async def test_expand_empty_seeds_returns_empty(db):
+    assert await graph_expansion.expand_neighbors(db, [], cap=10) == []
+
+
+async def test_expand_multi_seed_linked_from_collapses(db):
+    """A neighbor reached from several seeds appears ONCE, listing all seeds."""
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "seed-2")
+    await _seed_memory(db, "nbr-1")
+    await _link(db, "seed-1", "nbr-1", strength=0.6)
+    await _link(db, "seed-2", "nbr-1", strength=0.9)
+
+    out = await graph_expansion.expand_neighbors(db, ["seed-1", "seed-2"], cap=10)
+
+    assert len(out) == 1
+    marker = out[0].payload["graph_expansion"]
+    assert sorted(marker["linked_from"]) == ["seed-1", "seed-2"]
+    assert marker["strength"] == pytest.approx(0.9)  # MAX(strength)
+
+
+# ─── maybe_expand: surface wrapper ───────────────────────────────────────────
+
+
+async def _seed_linked_pair(db) -> None:
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "nbr-1")
+    await _link(db, "seed-1", "nbr-1", strength=0.8)
+
+
+async def _event_rows(db) -> list[dict]:
+    rows = await db.execute_fetchall(
+        "SELECT event_type, subject_id, metrics_json FROM eval_events "
+        "WHERE event_type LIKE 'graph_expansion_%'",
+    )
+    return [{"event_type": r[0], "subject_id": r[1], "metrics": json.loads(r[2])} for r in rows]
+
+
+async def test_maybe_expand_off_is_passthrough_no_event(db, config_dirs):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "off"}})
+    await _seed_linked_pair(db)
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+
+    assert out is results
+    assert await _event_rows(db) == []
+
+
+async def test_maybe_expand_shadow_returns_unchanged_and_emits(db, config_dirs):
+    await _seed_linked_pair(db)  # defaults: mode=shadow
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(
+        db,
+        results,
+        surface="full",
+        recall_event_id="evt-123",
+    )
+
+    assert [r.memory_id for r in out] == ["seed-1"]
+    events = await _event_rows(db)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "graph_expansion_shadow"
+    assert events[0]["subject_id"] == "evt-123"
+    m = events[0]["metrics"]
+    assert m["surface"] == "full"
+    assert m["seed_count"] == 1
+    assert m["neighbors_returned"] == 1
+    assert m["neighbor_ids"] == ["nbr-1"]
+    assert "latency_ms" in m
+
+
+async def test_maybe_expand_live_appends_neighbors_and_emits(db, config_dirs):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "live"}})
+    await _seed_linked_pair(db)
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+
+    assert [r.memory_id for r in out] == ["seed-1", "nbr-1"]
+    assert out[1].payload["graph_expansion"]["linked_from"] == ["seed-1"]
+    events = await _event_rows(db)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "graph_expansion_live"
+
+
+async def test_maybe_expand_proactive_uses_proactive_cap(db, config_dirs):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "live"}})
+    await _seed_memory(db, "seed-1")
+    for i, s in enumerate((0.9, 0.8, 0.7)):
+        await _seed_memory(db, f"nbr-{i}")
+        await _link(db, "seed-1", f"nbr-{i}", strength=s)
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(db, results, surface="proactive")
+
+    # default proactive_max_neighbors == 2
+    assert [r.memory_id for r in out] == ["seed-1", "nbr-0", "nbr-1"]
+
+
+async def test_maybe_expand_excludes_contradicts_by_default(db, config_dirs):
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "live"}})
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "nbr-contra")
+    await _link(db, "seed-1", "nbr-contra", strength=0.9, link_type="contradicts")
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+
+    assert [r.memory_id for r in out] == ["seed-1"]
+
+
+async def test_maybe_expand_empty_results_is_passthrough_no_event(db, config_dirs):
+    out = await graph_expansion.maybe_expand(db, [], surface="full")
+    assert out == []
+    assert await _event_rows(db) == []
+
+
+async def test_maybe_expand_metric_failure_never_raises(db, config_dirs, monkeypatch):
+    await _seed_linked_pair(db)
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("eval_events unavailable")
+
+    monkeypatch.setattr(graph_expansion.j9_eval, "insert_event", _boom)
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+
+    assert [r.memory_id for r in out] == ["seed-1"]  # shadow: unchanged
+
+
+async def test_maybe_expand_expansion_failure_never_raises(db, config_dirs, monkeypatch):
+    """A broken expansion query must never break recall itself."""
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "live"}})
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(graph_expansion, "expand_neighbors", _boom)
+    results = [_result("seed-1")]
+
+    out = await graph_expansion.maybe_expand(db, results, surface="full")
+
+    assert [r.memory_id for r in out] == ["seed-1"]

--- a/tests/test_memory/test_graph_expansion.py
+++ b/tests/test_memory/test_graph_expansion.py
@@ -428,3 +428,38 @@ async def test_maybe_expand_malformed_config_values_never_raise(db, config_dirs)
     _write(base, {"graph_expansion": {"mode": "live", "max_neighbors": "ten"}})
     out = await graph_expansion.maybe_expand(db, results, surface="full")
     assert [r.memory_id for r in out] == ["seed-1"]
+
+
+async def test_expand_skips_expired_neighbor(db):
+    """Bitemporal parity with normal recall (Codex #1069 P2): a neighbor whose
+    invalid_at has passed must not resurface via expansion."""
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "nbr-live")
+    await _seed_memory(db, "nbr-expired")
+    await db.execute(
+        "UPDATE memory_metadata SET invalid_at = '2020-01-01T00:00:00+00:00' "
+        "WHERE memory_id = 'nbr-expired'",
+    )
+    await db.commit()
+    await _link(db, "seed-1", "nbr-expired", strength=0.9)
+    await _link(db, "seed-1", "nbr-live", strength=0.5)
+
+    out = await graph_expansion.expand_neighbors(db, ["seed-1"], cap=10)
+
+    assert [r.memory_id for r in out] == ["nbr-live"]
+
+
+async def test_expand_skips_deprecated_neighbor(db):
+    """Deprecated (superseded) memories are filtered by search_ranked — the
+    expansion path must not readmit them."""
+    await _seed_memory(db, "seed-1")
+    await _seed_memory(db, "nbr-dep")
+    await db.execute(
+        "UPDATE memory_metadata SET deprecated = 1 WHERE memory_id = 'nbr-dep'",
+    )
+    await db.commit()
+    await _link(db, "seed-1", "nbr-dep", strength=0.9)
+
+    out = await graph_expansion.expand_neighbors(db, ["seed-1"], cap=10)
+
+    assert out == []


### PR DESCRIPTION
## What

Wires the LongMemEval-proven 1-hop `memory_links` expansion (+12.6pp overall: 0.648 → 0.774; temporal +23pp, multi-session +17pp; paired full-500 run 2026-07-14) into production recall — shadow-first, settings-gated, kill-switchable.

- **New `genesis/memory/graph_expansion.py`** — three layers:
  - live-read config (`DEFAULTS` ← `config/memory_recall.yaml` ← `~/.genesis/config/memory_recall.local.yaml`, re-read per call, `ws3_immunity` pattern; invalid mode degrades to `shadow`, master `enabled: false` → off);
  - `expand_neighbors(db, seed_ids, *, cap, exclude_ids, exclude_link_types)` — mode-independent primitive: `neighbors_of` → per-neighbor content via `get_by_id` (dangling links skipped) → batched `origin_class_by_ids`. Provenance is **stored-first and never synthetic** (`source_pipeline` stays `None` — no SQLite column; `item_is_blockable` re-derivation depends on honest fields). Score `0.01 × strength` sorts neighbors after all organic results; `payload["graph_expansion"]` carries `linked_from` + `strength`;
  - `maybe_expand(...)` — surface wrapper: `off` passthrough / `shadow` compute + emit `eval_events` metrics, results unchanged / `live` append. Best-effort throughout: expansion or metric failure logs and never breaks recall.
- **`neighbors_of` gains `exclude_link_types`** — SQL `NOT IN` inside both UNION branches (an excluded edge never consumes the LIMIT budget; composes with the existing `link_types` allow-list). Prod config excludes `contradicts`.
- **Three MCP merge points** (`mcp/memory/core.py`), each placed so neighbors flow through the *existing* WS-3 machinery with zero loop changes:
  - **compact**: merged before the blockable count → counted, recorded, previewed (`via_graph: true`);
  - **full**: merged after CRAG (additive — CRAG would evict neighbors) and before `label_result_dicts` → labeled, wrapped, counted identically to organic items;
  - **proactive**: seeded from the *delivered* set, tiny cap (2), and each neighbor runs the same `memory_operation` tag filter, `should_enforce_drop` (counted in `enforced_drops`), and blockable+wrap pipeline — expansion is not a bypass around the gate-4 pushed-surface cut.
- **`memory_recall` settings domain** + validator (modes per section — `entity_lane.mode` accepts off/shadow only until its live path ships; caps 0–25; `needs_restart=False`, read live).
- **Eval harness now calls the prod primitive** — `runner.py::_expand_neighbors` is a thin adapter over `graph_expansion.expand_neighbors`, so the upcoming 3-arm prod-parity benchmark (and all future runs) measures shipped code, not a harness re-implementation.

## Ships in `shadow`

No recall output changes at merge. Flip plan (user-approved): verify shadow `eval_events` rows + a 20-row neighbor-relevance spot-check on prod links, then `settings_update("memory_recall", {"graph_expansion": {"mode": "live"}})`. Rollback = mode `off`/`shadow`, instant, no restart. Note: genesis-server restart required once for the dashboard tool-API surface (imports `mcp.memory.core` in-process); CC-child MCP servers pick the code up on next session start.

## Tests

- `tests/test_memory/test_graph_expansion.py` (22) — config layering/live-reread/degradation; primitive provenance, ordering, caps, dangling/seed/exclude discipline, SQL-level type exclusion, multi-seed `linked_from` collapse; `maybe_expand` off/shadow/live, per-surface caps, metrics-never-raise, expansion-never-raises.
- `tests/test_mcp/test_memory_recall_graph_expansion.py` (11) — per-surface wiring: `via_graph` flags, external neighbor wrapped + counted blockable on all three surfaces, enforce-drop applies to neighbors, `memory_operation` filter, proactive cap, shadow emits-without-changing, off emits nothing.
- `tests/test_mcp/test_settings_memory_recall.py` (8) + 3 new `neighbors_of` exclusion tests.
- Regression: `test_memory_mcp`, `test_redteam_enforce`, `test_immunity_shadow_e2e`, `test_recall_inject_coverage`, `test_mcp_integration`, `test_store_subsystem_coverage`, `test_longmemeval_store/runner` — all green locally.

## Notes for reviewers

- Deliberately **not** a `HybridRetriever.recall()` kwarg: ~11 direct `.recall()` callers (ego/voice/executor post-filter results) stay untouched; CRAG can never recurse; neighbors get no write-back/J-9 retrieval credit.
- Known pre-existing edge (not introduced here, tracked): `memory_expand` is Qdrant-only, so an FTS5-only id (organic or neighbor) returns `not_found` from the compact→expand path.
- `entity_lane` config section ships inert (`off`) — PR-2 lands the lane itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)