### PR TITLE
feat(resilience): codify eth0 KeepConfiguration + self-healing networkd watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   rows get their metadata classified but remain wing-unreachable until the
   retrieval-side gap is closed (reported separately, not overstated). Dry-run
   by default; the bulk write is gated on a human-reviewed sample.
+
+- **Genesis survives — and now auto-recovers from — a wedged network.** Under
+  heavy memory pressure the container's networking daemon can hit kernel
+  timeouts, drop its DHCP lease, and take the machine off the network until
+  someone restarts the daemon by hand. Fresh and updated installs now (1) pin
+  the address so a networking failure keeps the connection instead of dropping
+  it, and (2) run a lightweight watchdog that detects a wedged/inactive
+  networking daemon and restarts it automatically (address-preserving, so no
+  blip). Heal events are recorded and surfaced in the infrastructure profile,
+  so a recurring fault is visible instead of silent. Networking runs a
+  different manager (e.g. NetworkManager) or lacks sudo? It skips cleanly.
+  See `docs/reference/network-resilience.md`.
+
 - **Genesis now notices when merged code isn't actually deployed.** Pulling
   changes with a bare `git merge` between updates loads the new code on
   restart but silently skips everything only `update.sh` activates — new

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -751,7 +751,12 @@ verified: bca86011 2026-07-15
   state) + `oomd_user_slice_kill` (config-plane scan of user.slice.d drop-ins,
   laid down by `scripts/lib/memory_resilience.sh` from bootstrap/update) and
   host-plane `swap_total_kb`, so the annotation layer flags unprotected
-  installs (see docs/reference/memory-resilience.md).
+  installs (see docs/reference/memory-resilience.md). Network-resilience
+  invariants are first-class too: container `networkd_keep_configuration` +
+  `network_watchdog_installed` (config-plane facts from
+  `scripts/lib/network_resilience.sh`) plus a volatile `watchdog` heal-telemetry
+  metric from `/run/genesis-network-watchdog.json` (see
+  docs/reference/network-resilience.md).
 - **restore/**: thin CLI → `scripts/restore.sh` (counterpart of the 6h
   encrypted `scripts/backup.sh` timer).
 - **util/**: `atomic_write_text`, `tracked_task` (logs swallowed exceptions),

--- a/docs/reference/network-resilience.md
+++ b/docs/reference/network-resilience.md
@@ -1,0 +1,109 @@
+# Network Resilience — KeepConfiguration + a self-healing networkd watchdog
+
+## The invariant
+
+**A systemd-networkd failure must degrade into "address retained, renewals
+paused, daemon auto-restarted" — never into a container that silently falls off
+the network and stays there until a human runs `systemctl restart` hours
+later.**
+
+Genesis is a memory-heavy system, and its worst incidents cluster: the same
+pressure spikes that wedge memory also make the kernel's rtnetlink socket time
+out. When that happens mid-DHCP-renewal, stock networkd drops the lease, tears
+down the address, and the box is gone. One 2026-07 incident series produced
+exactly this three times in three days — each time from an unrelated pressure
+event, each time recovered by hand.
+
+The fingerprint, if you're diagnosing it live:
+
+- `journalctl -u systemd-networkd` shows
+  `<iface>: Could not set route: Connection timed out` followed by
+  `<iface>: Failed` (often minutes apart, under load).
+- `networkctl status <iface>` shows **`State: routable (failed)`** —
+  `AdministrativeState=failed` (link SETUP failed) while `OperationalState`
+  stays `routable` (the address is still held, by KeepConfiguration).
+- Pre-fix only: the address then disappears (`ip addr` empty on the iface) and
+  connectivity dies until networkd is restarted.
+
+The administrative-vs-operational split is the key tell: dashboards that show
+only "routable" look healthy while the link is actually wedged. Check
+`networkctl status`, not just reachability.
+
+## What Genesis sets up
+
+`scripts/lib/network_resilience.sh` runs from `bootstrap.sh` on fresh installs
+and from every `update.sh` (existing installs retrofit automatically). It is
+idempotent — unchanged files produce no reload/restart churn — and **adaptive:
+the protected interface and its `.network` unit are discovered live (via
+`ip route` + `networkctl status`), never hardcoded**, so the same code fits any
+install.
+
+**Layer 1 — the address survives the failure.**
+`/etc/systemd/network/<iface-unit>.network.d/genesis-keep-config.conf` sets
+`KeepConfiguration=true`. `true` is the superset (`yes ⊃ dhcp ⊃ dhcp-on-stop`,
+per systemd.network(5)): the address and routes provided by DHCP are **never**
+dropped even if the lease expires or the daemon stops, and static/foreign
+config is kept too. It is exactly what netplan `critical: true` renders to, so
+one drop-in delivers the full protection. Written under `/etc` (not the
+`/run`-rendered unit), so it survives `netplan apply` regeneration.
+
+*Cost, by design:* re-addressing that interface then requires a full networkd
+restart (or manual flush) — a reconfigure request alone won't tear down kept
+config (networkd logs "considered critical, ignoring request to reconfigure").
+On a server whose whole job depends on the connection, that trade is correct.
+
+**Layer 2 — the daemon heals itself.**
+`genesis-network-watchdog.timer` runs `/usr/local/lib/genesis/network-watchdog.sh`
+as root every ~2 minutes. It restarts systemd-networkd when any of:
+
+1. the daemon is **inactive** (but not `masked` — a mask is operator intent);
+2. a managed link is in **`AdministrativeState=failed`** (the live
+   fingerprint); or
+3. there is **no IPv4 default route**.
+
+The restart is address-preserving because of Layer 1, so it heals the wedge
+without a connectivity blip. Safety rails: a **2-minute grace window** (skip a
+networkd that just (re)started, so we never fight a settling daemon) and a
+**10-minute rate limit** (a persistent fault logs loudly each tick instead of
+flap-restarting). The healthy path exits silently — no per-tick journal spam.
+
+Graceful degradation: no systemd, no `networkctl`, systemd-networkd not the
+active manager (NetworkManager hosts), or no non-interactive sudo each produce
+a one-line skip note and never a failure.
+
+## How the body schema surfaces it
+
+The infrastructure profile (`INFRASTRUCTURE.md`, `infra_profile` package)
+records the posture as facts, so the annotation layer flags an unprotected
+install on its own:
+
+| Key | Kind | Healthy | Defect |
+|---|---|---|---|
+| `networkd_keep_configuration` | fact | `true` | `false` |
+| `network_watchdog_installed` | fact | `true` | `false` |
+| `watchdog` (heal telemetry) | metric | rare/zero heals | frequent heals |
+
+`watchdog` is a **metric** (never hashed): the watchdog rewrites
+`/run/genesis-network-watchdog.json` every run
+(`last_check`/`last_heal`/`last_trigger`/`heal_count`/`last_action`), so heals
+show up in the rendered doc and dashboard instead of being buried in root logs
+— directly closing the "nothing noticed for 15 hours" half of the incident.
+
+## Notes
+
+- **Shared root cause with memory resilience.** The rtnetlink timeouts that
+  wedge networkd are driven by the same pressure spikes that
+  `docs/reference/memory-resilience.md` addresses. Fixing memory pressure
+  reduces how often networkd is stressed; this layer covers what happens when
+  it is stressed anyway. Treat them as two halves of one resilience story.
+- **These are last lines of defense, not a network manager.** If the watchdog
+  ever heals repeatedly (check the `watchdog` metric / `journalctl -u
+  genesis-network-watchdog`), a link is genuinely failing — investigate the
+  cause, don't lengthen the interval to hide it.
+- **Assumes an IPv4 default route** (the Genesis norm). On an IPv6-only or
+  route-less-by-design install, Layer 1 skips cleanly (nothing to protect) and
+  the watchdog's no-route trigger would be a false positive — adjust the
+  triggers before deploying there.
+- **Host networkd is out of scope.** The guardian owns host-VM reachability;
+  no host networkd incident has been observed. This covers the container plane
+  where the incidents happened.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -767,6 +767,18 @@ else
 fi
 echo
 
+# --- Network resilience (KeepConfiguration + networkd watchdog) ---
+# Same guarded-source contract as memory resilience: a partial checkout without
+# the lib degrades to a warning, never aborts bootstrap under set -e.
+if [[ -f "$SCRIPT_DIR/lib/network_resilience.sh" ]]; then
+    # shellcheck source=lib/network_resilience.sh
+    source "$SCRIPT_DIR/lib/network_resilience.sh"
+    network_resilience_apply
+else
+    echo "  WARNING: lib/network_resilience.sh missing — skipping network-resilience setup"
+fi
+echo
+
 # --- Systemd service sync ---
 echo "--- Syncing systemd service files ---"
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"

--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -146,10 +146,16 @@ network_resilience_apply() {
         echo "  Skipped: networkctl not present — not a systemd-networkd system."
         return 0
     fi
-    # networkd must be the active manager — skip NetworkManager/other stacks
-    # (their equivalent knobs differ; this fix is networkd-specific).
-    if ! systemctl is-active systemd-networkd >/dev/null 2>&1; then
-        echo "  Skipped: systemd-networkd not active — not the active network manager."
+    # systemd-networkd must be THIS box's manager — but "active" alone is too
+    # strict: a networkd that has crashed/stopped (exactly the state the
+    # watchdog exists to heal) is inactive yet still the manager. Treat it as
+    # ours if active OR enabled; skip only genuine NetworkManager/other stacks
+    # (networkd disabled/masked/absent). Part A self-degrades when networkd is
+    # down (networkctl discovery fails → skips); Part B still installs.
+    _netres_enabled_state="$(systemctl is-enabled systemd-networkd 2>/dev/null || true)"
+    if ! systemctl is-active systemd-networkd >/dev/null 2>&1 \
+        && [[ "$_netres_enabled_state" != "enabled" && "$_netres_enabled_state" != "enabled-runtime" ]]; then
+        echo "  Skipped: systemd-networkd not active or enabled — not this host's network manager."
         return 0
     fi
     if ! sudo -n true 2>/dev/null; then

--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -1,0 +1,174 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# network_resilience_apply — codify the 2026-07 eth0 networkd-wedge fix. Under
+# memory pressure the container's systemd-networkd hit rtnetlink timeouts
+# (`eth0: Could not set route: Connection timed out` → `eth0: Failed`) three
+# times in three days; the DHCP lease was then dropped and the box fell off the
+# network until a MANUAL `systemctl restart systemd-networkd` hours later. Two
+# layers, both codified here so fresh installs are born protected:
+#
+#   A. KeepConfiguration=true on the default-route link — a networkd failure
+#      RETAINS the address (renewals pause) instead of dropping it. Adaptive:
+#      the link and its .network unit are discovered live, never hardcoded.
+#   B. A root networkd watchdog (genesis-network-watchdog.timer) that detects a
+#      failed/inactive/route-less networkd and restarts it — automating the
+#      manual recovery. The restart is address-preserving under (A).
+#
+# Degrades gracefully: no systemd, no networkd, no networkctl, or no usable
+# sudo each produce a one-line skip note and rc=0 — must never abort
+# bootstrap.sh/update.sh under `set -e`. Idempotent: unchanged files produce no
+# reload/restart churn.
+#
+# Test seams (defaults are the real paths; pytest overrides these and stubs
+# sudo/systemctl/networkctl/ip on PATH):
+NETRES_ETC_ROOT="${NETRES_ETC_ROOT:-/etc}"
+NETRES_SYSTEMD_RUNTIME_DIR="${NETRES_SYSTEMD_RUNTIME_DIR:-/run/systemd/system}"
+NETRES_LIBEXEC_DIR="${NETRES_LIBEXEC_DIR:-/usr/local/lib/genesis}"
+# The watchdog script shipped alongside this lib (scripts/systemd/…). Resolved
+# at source time from this file's own location; overridable for tests. The
+# trailing `; true` keeps a failed resolution from aborting the sourcing caller
+# under `set -e` — a bad path is caught later by the readable-source guard.
+NETRES_WATCHDOG_SRC="${NETRES_WATCHDOG_SRC:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../systemd" 2>/dev/null && pwd; true)/genesis-network-watchdog.sh}"
+
+# KeepConfiguration=true (superset of =dhcp): retains BOTH DHCP-provided and
+# static/foreign config across a networkd failure or daemon stop. `true` is
+# exactly what netplan `critical: true` renders to, so one drop-in delivers the
+# full hand-applied protection. Cost (documented in the runbook): re-addressing
+# an interface then needs a full networkd restart, since reconfigure requests
+# won't tear down kept config.
+_NETRES_KEEP_CONF=$'[Network]\nKeepConfiguration=true'
+
+_NETRES_WATCHDOG_TIMER=$'[Unit]\nDescription=Genesis network watchdog — heal a wedged systemd-networkd\n\n[Timer]\nOnBootSec=3min\nOnUnitActiveSec=2min\nAccuracySec=20s\n\n[Install]\nWantedBy=timers.target'
+
+# Service content is built from the install dir so the ExecStart path tracks
+# NETRES_LIBEXEC_DIR (real install and test overrides stay consistent).
+_netres_service_content() {
+    printf '%s\n' \
+        '[Unit]' \
+        'Description=Genesis network watchdog (heal wedged systemd-networkd)' \
+        'After=systemd-networkd.service' \
+        '' \
+        '[Service]' \
+        'Type=oneshot' \
+        "ExecStart=$1"
+}
+
+# _netres_put_file <path> <content> <mode> — write-if-different via sudo. Bumps
+# _NETRES_WROTE on a real write; sets _NETRES_FAILED + WARNS on failure. Never
+# fails the caller (returns 0) so `set -e` callers are safe even outside an if.
+_netres_put_file() {
+    local path="$1" content="$2" mode="$3"
+    if [[ "$(sudo cat "$path" 2>/dev/null)" == "$content" ]]; then
+        return 0
+    fi
+    if ! sudo mkdir -p "$(dirname "$path")" 2>/dev/null \
+        || ! printf '%s\n' "$content" | sudo tee "$path" >/dev/null 2>&1; then
+        echo "  WARNING: could not write $path (read-only /etc?) — network resilience NOT fully applied."
+        _NETRES_FAILED=1
+        return 0
+    fi
+    sudo chmod "$mode" "$path" 2>/dev/null || true
+    _NETRES_WROTE=$((_NETRES_WROTE + 1))
+    return 0
+}
+
+# Part A — KeepConfiguration on the live default-route interface.
+_netres_apply_keepconfig() {
+    local iface
+    iface="$(ip -j route show default 2>/dev/null | python3 -c '
+import json, sys
+try:
+    routes = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for route in routes:
+    if route.get("dev"):
+        print(route["dev"])
+        break
+' 2>/dev/null)"
+    if [[ -z "$iface" ]]; then
+        echo "  KeepConfiguration: no IPv4 default route — skipping (nothing to protect)."
+        return 0
+    fi
+
+    # Resolve the .network unit governing this link (its basename names the
+    # drop-in dir). networkctl prints e.g. "Network File: /run/systemd/network/
+    # 10-netplan-eth0.network"; a link with no unit prints "n/a".
+    local netfile
+    netfile="$(networkctl status "$iface" 2>/dev/null | sed -n 's/.*Network File:[[:space:]]*//p' | head -1)"
+    if [[ -z "$netfile" || "$netfile" == "n/a" ]]; then
+        echo "  KeepConfiguration: no .network unit resolved for $iface — skipping."
+        return 0
+    fi
+
+    local base dropin
+    base="$(basename "$netfile")"
+    dropin="$NETRES_ETC_ROOT/systemd/network/$base.d/genesis-keep-config.conf"
+    local before=$_NETRES_WROTE
+    _netres_put_file "$dropin" "$_NETRES_KEEP_CONF" "0644"
+    if ((_NETRES_WROTE > before)); then
+        # Apply without a full restart: reload re-reads unit config; the kept
+        # (critical) address is not torn down.
+        sudo networkctl reload 2>/dev/null || true
+        echo "  KeepConfiguration=true set for $iface ($base)."
+    fi
+}
+
+# Part B — install the watchdog script + oneshot service + timer.
+_netres_install_watchdog() {
+    if [[ ! -r "$NETRES_WATCHDOG_SRC" ]]; then
+        echo "  WARNING: watchdog source missing ($NETRES_WATCHDOG_SRC) — watchdog NOT installed."
+        _NETRES_FAILED=1
+        return 0
+    fi
+    local dst="$NETRES_LIBEXEC_DIR/network-watchdog.sh"
+    local before=$_NETRES_WROTE
+    _netres_put_file "$dst" "$(cat "$NETRES_WATCHDOG_SRC")" "0755"
+    _netres_put_file "$NETRES_ETC_ROOT/systemd/system/genesis-network-watchdog.service" "$(_netres_service_content "$dst")" "0644"
+    _netres_put_file "$NETRES_ETC_ROOT/systemd/system/genesis-network-watchdog.timer" "$_NETRES_WATCHDOG_TIMER" "0644"
+    if ((_NETRES_WROTE > before)); then
+        sudo systemctl daemon-reload 2>/dev/null || true
+        sudo systemctl enable genesis-network-watchdog.timer 2>/dev/null || true
+        sudo systemctl start genesis-network-watchdog.timer 2>/dev/null || true
+    fi
+}
+
+# network_resilience_apply — the entrypoint. Always returns 0.
+network_resilience_apply() {
+    echo "--- Network resilience (KeepConfiguration + networkd watchdog) ---"
+
+    if [[ ! -d "$NETRES_SYSTEMD_RUNTIME_DIR" ]]; then
+        echo "  Skipped: not a systemd system (no $NETRES_SYSTEMD_RUNTIME_DIR)."
+        return 0
+    fi
+    if ! command -v networkctl >/dev/null 2>&1; then
+        echo "  Skipped: networkctl not present — not a systemd-networkd system."
+        return 0
+    fi
+    # networkd must be the active manager — skip NetworkManager/other stacks
+    # (their equivalent knobs differ; this fix is networkd-specific).
+    if ! systemctl is-active systemd-networkd >/dev/null 2>&1; then
+        echo "  Skipped: systemd-networkd not active — not the active network manager."
+        return 0
+    fi
+    if ! sudo -n true 2>/dev/null; then
+        echo "  Skipped: sudo unavailable non-interactively. To apply manually:"
+        echo "           sudo bash -c 'source scripts/lib/network_resilience.sh && network_resilience_apply'"
+        return 0
+    fi
+
+    _NETRES_WROTE=0
+    _NETRES_FAILED=""
+    _netres_apply_keepconfig
+    _netres_install_watchdog
+
+    if [[ -n "$_NETRES_FAILED" ]]; then
+        echo "  Network resilience NOT fully applied — see warnings above."
+    elif ((_NETRES_WROTE > 0)); then
+        echo "  Network resilience applied (KeepConfiguration + watchdog timer active)."
+    else
+        echo "  Network resilience already in place."
+    fi
+    return 0
+}

--- a/scripts/systemd/genesis-network-watchdog.sh
+++ b/scripts/systemd/genesis-network-watchdog.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# genesis-network-watchdog — detect a wedged systemd-networkd and heal it by
+# restarting the daemon. Codifies the manual `systemctl restart systemd-networkd`
+# recovery used twice during the 2026-07 eth0 rtnetlink-timeout incidents
+# (`eth0: Could not set route: Connection timed out` → `eth0: Failed`, leaving
+# the link in AdministrativeState=failed with renewals dead). Installed to
+# /usr/local/lib/genesis/network-watchdog.sh and run as root by
+# genesis-network-watchdog.timer (~every 2 min) via network_resilience.sh.
+#
+# The restart is address-preserving: with KeepConfiguration=true on the link
+# (network_resilience.sh lays that down), the kept address survives the daemon
+# bounce — networkd logs "considered critical, ignoring request to reconfigure".
+#
+# Triggers (any → heal, subject to grace + rate limit):
+#   1. systemd-networkd inactive — but NOT masked (mask = deliberate operator
+#      intent; we must not fight it).
+#   2. A managed link in AdministrativeState=failed — the live fingerprint:
+#      OperationalState stays "routable" (address held) while link SETUP failed.
+#   3. No IPv4 default route.
+#
+# Healthy path exits 0 silently (no per-tick journal spam). Every run rewrites a
+# /run telemetry file the infra profile reads as network metrics, so heals are
+# visible in INFRASTRUCTURE.md / the dashboard instead of buried in root logs.
+set -uo pipefail
+
+STATE_FILE="${NETWD_STATE_FILE:-/run/genesis-network-watchdog.json}"
+STAMP_FILE="${NETWD_STAMP_FILE:-/run/genesis-network-watchdog.last}"
+RATE_LIMIT_SEC="${NETWD_RATE_LIMIT_SEC:-600}"   # min seconds between heals
+GRACE_SEC="${NETWD_GRACE_SEC:-120}"             # skip if networkd just (re)started
+SYSTEMCTL="${NETWD_SYSTEMCTL:-systemctl}"
+NETWD_NOW="${NETWD_NOW:-$(date +%s)}"           # overridable for tests
+
+log() { printf 'genesis-network-watchdog: %s\n' "$1"; }
+
+# Persist telemetry. action ∈ {none, ratelimited, healed}. heal_count and
+# last_heal carry forward from the prior file; heal_count only increments on a
+# real heal. Written atomically, 0644 so the non-root infra collector can read.
+_write_state() {
+    local action="$1" trigger="$2"
+    NETWD_STATE_FILE="$STATE_FILE" A_NOW="$NETWD_NOW" A_ACTION="$action" \
+        A_TRIGGER="$trigger" python3 - <<'PY' 2>/dev/null || true
+import json, os
+path = os.environ["NETWD_STATE_FILE"]
+now = int(os.environ["A_NOW"])
+action = os.environ["A_ACTION"]
+trigger = os.environ["A_TRIGGER"] or None
+try:
+    with open(path) as fh:
+        prior = json.load(fh)
+    if not isinstance(prior, dict):
+        prior = {}
+except Exception:
+    prior = {}
+heal_count = int(prior.get("heal_count", 0) or 0)
+last_heal = prior.get("last_heal")
+last_trigger = prior.get("last_trigger")
+if action == "healed":
+    heal_count += 1
+    last_heal = now
+    last_trigger = trigger
+elif trigger:
+    last_trigger = trigger  # record the observed trigger even when rate-limited
+state = {
+    "last_check": now,
+    "last_heal": last_heal,
+    "last_trigger": last_trigger,
+    "heal_count": heal_count,
+    "last_action": action or "none",
+}
+tmp = f"{path}.tmp"
+with open(tmp, "w") as fh:
+    json.dump(state, fh)
+os.replace(tmp, path)
+try:
+    os.chmod(path, 0o644)
+except OSError:
+    pass
+PY
+}
+
+_networkd_start_epoch() {
+    local ts
+    ts="$("$SYSTEMCTL" show systemd-networkd -p ActiveEnterTimestamp --value 2>/dev/null)"
+    [[ -z "$ts" ]] && { echo 0; return 0; }
+    date -d "$ts" +%s 2>/dev/null || echo 0
+}
+
+# First managed link stuck in AdministrativeState=failed, or empty.
+_first_failed_link() {
+    networkctl --json=short list 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for iface in data.get("Interfaces", []):
+    if iface.get("AdministrativeState") == "failed":
+        print(iface.get("Name", "?"))
+        break
+' 2>/dev/null
+}
+
+_has_default_route() {
+    [[ -n "$(ip route show default 2>/dev/null)" ]]
+}
+
+main() {
+    # Masked = operator intent; never fight it.
+    if [[ "$("$SYSTEMCTL" is-enabled systemd-networkd 2>/dev/null || true)" == "masked" ]]; then
+        _write_state "none" ""
+        return 0
+    fi
+
+    local trigger=""
+    if [[ "$("$SYSTEMCTL" is-active systemd-networkd 2>/dev/null || true)" != "active" ]]; then
+        trigger="networkd-inactive"
+    else
+        # Active: give a fresh (re)start time to reconfigure before we judge its
+        # links failed — otherwise we could ping-pong a settling daemon.
+        local started; started="$(_networkd_start_epoch)"
+        if (( started > 0 && NETWD_NOW - started < GRACE_SEC )); then
+            _write_state "none" ""
+            return 0
+        fi
+        local failed; failed="$(_first_failed_link)"
+        if [[ -n "$failed" ]]; then
+            trigger="failed-link:$failed"
+        elif ! _has_default_route; then
+            trigger="no-default-route"
+        fi
+    fi
+
+    if [[ -z "$trigger" ]]; then
+        _write_state "none" ""
+        return 0
+    fi
+
+    # A trigger fired — heal unless we healed too recently (a persistent fault
+    # should page a human via loud logs, not flap-restart every 2 min).
+    local last_heal=0
+    [[ -f "$STAMP_FILE" ]] && last_heal="$(cat "$STAMP_FILE" 2>/dev/null || echo 0)"
+    if (( last_heal > 0 && NETWD_NOW - last_heal < RATE_LIMIT_SEC )); then
+        log "trigger=$trigger but a heal fired <${RATE_LIMIT_SEC}s ago — NOT restarting; networkd may need manual attention"
+        _write_state "ratelimited" "$trigger"
+        return 0
+    fi
+
+    log "healing: restarting systemd-networkd (trigger=$trigger)"
+    "$SYSTEMCTL" restart systemd-networkd
+    local rc=$?
+    echo "$NETWD_NOW" >"$STAMP_FILE" 2>/dev/null || true
+    _write_state "healed" "$trigger"
+    return "$rc"
+}
+
+main "$@"

--- a/scripts/systemd/genesis-network-watchdog.sh
+++ b/scripts/systemd/genesis-network-watchdog.sh
@@ -147,11 +147,21 @@ main() {
     fi
 
     log "healing: restarting systemd-networkd (trigger=$trigger)"
-    "$SYSTEMCTL" restart systemd-networkd
-    local rc=$?
-    echo "$NETWD_NOW" >"$STAMP_FILE" 2>/dev/null || true
-    _write_state "healed" "$trigger"
-    return "$rc"
+    if "$SYSTEMCTL" restart systemd-networkd; then
+        # Only a SUCCESSFUL restart counts: stamp the rate-limit window and
+        # record the heal. A failed restart must NOT claim a heal in telemetry
+        # and must NOT arm the rate limit (so the next tick retries promptly).
+        echo "$NETWD_NOW" >"$STAMP_FILE" 2>/dev/null || true
+        _write_state "healed" "$trigger"
+        return 0
+    else
+        # $? here is the failed restart's exit code (after `fi` it would be the
+        # if-compound's 0). Don't stamp; leave the rate limit disarmed to retry.
+        local rc=$?
+        log "restart FAILED (rc=$rc, trigger=$trigger) — will retry next tick"
+        _write_state "restart-failed" "$trigger"
+        return "$rc"
+    fi
 }
 
 main "$@"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1025,6 +1025,18 @@ if [ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]; then
     echo ""
 fi
 
+# ── Network resilience — re-run VISIBLY (same rationale as memory resilience:
+# bootstrap already applied it, but `tail -10` ate the output). The update path
+# is where an existing install retrofits the KeepConfiguration drop-in + the
+# networkd watchdog, and where a still-degraded networkd gets healed on the next
+# timer tick. Idempotent: already-applied → one no-op line.
+if [ -f "$SCRIPT_DIR/lib/network_resilience.sh" ]; then
+    # shellcheck source=lib/network_resilience.sh
+    . "$SCRIPT_DIR/lib/network_resilience.sh"
+    network_resilience_apply
+    echo ""
+fi
+
 # ── Verify Genesis is importable ──────────────────────────
 if ! "$VENV_DIR/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/dev/null; then
     _do_rollback "Genesis not importable after bootstrap"

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -160,6 +160,44 @@ def _oomd_user_slice_kill(etc_root: Path) -> bool:
     return effective == "kill"
 
 
+def _networkd_keep_configuration(etc_root: Path) -> bool:
+    """Whether a KeepConfiguration policy (any value other than "no") is set in
+    a systemd-networkd .network drop-in — the genesis-keep-config.conf that
+    scripts/lib/network_resilience.sh lays down so a networkd failure RETAINS
+    the address instead of dropping it (the 2026-07 eth0 wedge). Config-plane,
+    same last-assignment-wins semantics as _oomd_user_slice_kill; scans our
+    world-readable /etc drop-ins (the /run render is root-only)."""
+    net_dir = etc_root / "systemd/network"
+    if not net_dir.is_dir():
+        return False
+    effective: str | None = None
+    for conf in sorted(net_dir.glob("*.network.d/*.conf")):
+        raw = _read(conf) or ""
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("#", ";")):
+                continue
+            key, sep, value = stripped.partition("=")
+            if sep and key.strip() == "KeepConfiguration":
+                effective = value.strip()
+    return effective is not None and effective.lower() != "no"
+
+
+def _read_watchdog_state(run_root: Path) -> dict | None:
+    """Parse the network watchdog's /run telemetry (last_check / last_heal /
+    last_trigger / heal_count / last_action). Returns None when absent or
+    malformed — it is a METRIC, so a missing or garbage file just omits the key
+    rather than failing the section."""
+    raw = _read(run_root / "genesis-network-watchdog.json")
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _detect_root_device(proc_root: Path) -> str | None:
     """Block device major:minor for the root filesystem (via mountinfo)."""
     raw = _read(proc_root / "self/mountinfo") or ""
@@ -395,8 +433,12 @@ async def collect_kernel(
 # ── network ──────────────────────────────────────────────────────────────
 
 
-async def collect_network(etc_root: Path = Path("/etc")) -> SectionResult:
-    """Interfaces/MTU/addresses, DNS, default route, tailscale presence.
+async def collect_network(
+    etc_root: Path = Path("/etc"),
+    run_root: Path = Path("/run"),
+) -> SectionResult:
+    """Interfaces/MTU/addresses, DNS, default route, tailscale presence, plus
+    the network-resilience posture (KeepConfiguration + watchdog).
 
     Addresses are FACTS by design: an IP change on this plane is a real
     identity event worth a drift observation, not noise.
@@ -445,6 +487,20 @@ async def collect_network(etc_root: Path = Path("/etc")) -> SectionResult:
                 metrics["default_gateway"] = default[0].get("gateway")
         except (ValueError, IndexError, TypeError):
             pass
+
+    # Resilience posture (config-plane facts — see docs/reference/network-
+    # resilience.md). Deterministic file reads, so they belong in facts: the
+    # annotation layer flags an install that lacks either protection.
+    facts["networkd_keep_configuration"] = _networkd_keep_configuration(etc_root)
+    facts["network_watchdog_installed"] = (
+        etc_root / "systemd/system/genesis-network-watchdog.timer"
+    ).exists()
+
+    # Watchdog heal telemetry is volatile (heal_count/timestamps move), so it is
+    # a METRIC — never hashed. Absent file → key omitted (no drift churn).
+    watchdog = _read_watchdog_state(run_root)
+    if watchdog is not None:
+        metrics["watchdog"] = watchdog
 
     return SectionResult(name="network", facts=facts, metrics=metrics)
 

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -161,26 +161,35 @@ def _oomd_user_slice_kill(etc_root: Path) -> bool:
 
 
 def _networkd_keep_configuration(etc_root: Path) -> bool:
-    """Whether a KeepConfiguration policy (any value other than "no") is set in
-    a systemd-networkd .network drop-in — the genesis-keep-config.conf that
-    scripts/lib/network_resilience.sh lays down so a networkd failure RETAINS
-    the address instead of dropping it (the 2026-07 eth0 wedge). Config-plane,
-    same last-assignment-wins semantics as _oomd_user_slice_kill; scans our
-    world-readable /etc drop-ins (the /run render is root-only)."""
+    """True when at least one systemd-networkd link has an effective
+    KeepConfiguration policy (any value other than "no") — the
+    genesis-keep-config.conf that scripts/lib/network_resilience.sh lays down so
+    a networkd failure RETAINS the address instead of dropping it (the 2026-07
+    eth0 wedge). Scoped the way systemd scopes drop-ins: last-assignment-wins
+    WITHIN each `.network.d` directory (a later zz-*.conf reverting to `auto`/
+    `no` disables that link), then OR'd across links — an unrelated drop-in on
+    a *different* interface can neither fake protection nor mask it. Config-
+    plane: scans our world-readable /etc drop-ins (the /run render is root-only).
+    Comments are full-line only (unit files have no inline comments)."""
     net_dir = etc_root / "systemd/network"
     if not net_dir.is_dir():
         return False
-    effective: str | None = None
-    for conf in sorted(net_dir.glob("*.network.d/*.conf")):
-        raw = _read(conf) or ""
-        for line in raw.splitlines():
-            stripped = line.strip()
-            if stripped.startswith(("#", ";")):
-                continue
-            key, sep, value = stripped.partition("=")
-            if sep and key.strip() == "KeepConfiguration":
-                effective = value.strip()
-    return effective is not None and effective.lower() != "no"
+    for dropin_dir in sorted(net_dir.glob("*.network.d")):
+        if not dropin_dir.is_dir():
+            continue
+        effective: str | None = None
+        for conf in sorted(dropin_dir.glob("*.conf")):
+            raw = _read(conf) or ""
+            for line in raw.splitlines():
+                stripped = line.strip()
+                if stripped.startswith(("#", ";")):
+                    continue
+                key, sep, value = stripped.partition("=")
+                if sep and key.strip() == "KeepConfiguration":
+                    effective = value.strip()
+        if effective is not None and effective.lower() != "no":
+            return True
+    return False
 
 
 def _read_watchdog_state(run_root: Path) -> dict | None:

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -8,6 +8,7 @@ from genesis.infra_profile.collectors.container import (
     collect_cpu,
     collect_kernel,
     collect_memory,
+    collect_network,
     collect_os,
     collect_storage,
 )
@@ -180,4 +181,86 @@ async def test_collector_determinism(proc_root, sys_root):
 
     first = await collect_storage(proc_root=proc_root, sys_root=sys_root)
     second = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert section_hash(first.facts) == section_hash(second.facts)
+
+
+# ── network resilience facts (KeepConfiguration + watchdog) ──────────────────
+
+
+def _keepconf_dir(etc_root):
+    d = etc_root / "systemd/network/10-netplan-eth0.network.d"
+    d.mkdir(parents=True)
+    return d
+
+
+async def test_network_keep_configuration_fact(tmp_path):
+    # no drop-in dir at all -> unprotected
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["networkd_keep_configuration"] is False
+
+    # KeepConfiguration=no does NOT count as protection
+    d = _keepconf_dir(tmp_path)
+    d.joinpath("genesis-keep-config.conf").write_text("[Network]\nKeepConfiguration=no\n")
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["networkd_keep_configuration"] is False
+
+    # =true (any non-"no" value) counts, whitespace-tolerant, comments ignored
+    d.joinpath("genesis-keep-config.conf").write_text(
+        "[Network]\n# KeepConfiguration=no\nKeepConfiguration = true\n"
+    )
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["networkd_keep_configuration"] is True
+
+    # last-assignment-wins across lexicographic drop-ins: a later zz-*.conf
+    # reverting to `no` disables the protection — the fact must not lie.
+    d.joinpath("zz-off.conf").write_text("[Network]\nKeepConfiguration=no\n")
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["networkd_keep_configuration"] is False
+
+
+async def test_network_watchdog_installed_fact(tmp_path):
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["network_watchdog_installed"] is False
+
+    timer = tmp_path / "systemd/system/genesis-network-watchdog.timer"
+    timer.parent.mkdir(parents=True)
+    timer.write_text("[Timer]\nOnUnitActiveSec=2min\n")
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["network_watchdog_installed"] is True
+
+
+async def test_network_watchdog_metrics_from_run_state(tmp_path):
+    run = tmp_path / "run"
+    run.mkdir()
+
+    # absent telemetry file -> no metric key (no drift churn)
+    result = await collect_network(etc_root=tmp_path, run_root=run)
+    assert "watchdog" not in result.metrics
+
+    # valid telemetry -> parsed into METRICS, never facts
+    (run / "genesis-network-watchdog.json").write_text(
+        '{"last_check": 100, "last_heal": 90, "last_trigger": "failed-link:eth0",'
+        ' "heal_count": 2, "last_action": "healed"}'
+    )
+    result = await collect_network(etc_root=tmp_path, run_root=run)
+    assert result.metrics["watchdog"]["heal_count"] == 2
+    assert result.metrics["watchdog"]["last_trigger"] == "failed-link:eth0"
+    assert "watchdog" not in result.facts
+
+    # malformed JSON -> key omitted, section does not fail
+    (run / "genesis-network-watchdog.json").write_text("{not json")
+    result = await collect_network(etc_root=tmp_path, run_root=run)
+    assert "watchdog" not in result.metrics
+    assert result.status == STATUS_OK
+
+
+async def test_network_resilience_facts_are_deterministic(tmp_path):
+    """The new facts must not churn the section hash across identical reads."""
+    from genesis.infra_profile.hashing import section_hash
+
+    d = _keepconf_dir(tmp_path)
+    d.joinpath("genesis-keep-config.conf").write_text("[Network]\nKeepConfiguration=true\n")
+    first = await collect_network(etc_root=tmp_path)
+    second = await collect_network(etc_root=tmp_path)
+    assert first.facts["networkd_keep_configuration"] is True
     assert section_hash(first.facts) == section_hash(second.facts)

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -211,9 +211,30 @@ async def test_network_keep_configuration_fact(tmp_path):
     result = await collect_network(etc_root=tmp_path)
     assert result.facts["networkd_keep_configuration"] is True
 
-    # last-assignment-wins across lexicographic drop-ins: a later zz-*.conf
-    # reverting to `no` disables the protection — the fact must not lie.
+    # last-assignment-wins WITHIN the link's own drop-in dir: a later zz-*.conf
+    # reverting to `no` disables THIS link's protection — the fact must not lie.
     d.joinpath("zz-off.conf").write_text("[Network]\nKeepConfiguration=no\n")
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["networkd_keep_configuration"] is False
+
+
+async def test_network_keep_configuration_scoped_per_network_file(tmp_path):
+    # Drop-ins are scoped per .network file, not globally: a `no` on one
+    # interface must not mask protection on another, and last-assignment-wins is
+    # evaluated within each dir independently (Codex P2 — cross-interface bleed).
+    net = tmp_path / "systemd/network"
+    (net / "10-eth0.network.d").mkdir(parents=True)
+    (net / "20-eth1.network.d").mkdir(parents=True)
+    # eth1 (later-sorting) explicitly off; eth0 protected -> overall True.
+    (net / "10-eth0.network.d/genesis-keep-config.conf").write_text(
+        "[Network]\nKeepConfiguration=true\n"
+    )
+    (net / "20-eth1.network.d/other.conf").write_text("[Network]\nKeepConfiguration=no\n")
+    result = await collect_network(etc_root=tmp_path)
+    assert result.facts["networkd_keep_configuration"] is True
+
+    # remove the protected link -> only the `no` link remains -> False
+    (net / "10-eth0.network.d/genesis-keep-config.conf").unlink()
     result = await collect_network(etc_root=tmp_path)
     assert result.facts["networkd_keep_configuration"] is False
 

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -1,0 +1,404 @@
+"""Behavioral tests for network resilience (scripts/lib/network_resilience.sh
+and scripts/systemd/genesis-network-watchdog.sh).
+
+Both are driven from the REAL shipped files with stubbed
+``sudo``/``systemctl``/``networkctl``/``ip`` on PATH plus NETRES_*/NETWD_*
+overrides, so the logic under test is the shipped code: adaptive
+KeepConfiguration drop-in + watchdog install (idempotent, graceful degradation
+without systemd/networkd/networkctl/sudo), and the watchdog's detect→heal
+decision (grace window, rate limit, telemetry).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts" / "lib" / "network_resilience.sh"
+WATCHDOG = REPO_ROOT / "scripts" / "systemd" / "genesis-network-watchdog.sh"
+BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap.sh"
+UPDATE = REPO_ROOT / "scripts" / "update.sh"
+
+# ── stubs for the lib (network_resilience_apply) ──────────────────────────────
+
+_SUDO_STUB = """#!/bin/bash
+if [ "$1" = "-n" ] && [ "$2" = "true" ]; then exit "${SUDO_N_RC:-0}"; fi
+exec "$@"
+"""
+
+_SYSTEMCTL_STUB = """#!/bin/bash
+if [ "$1" = "is-active" ]; then exit "${NETWORKD_ACTIVE_RC:-0}"; fi
+echo "$@" >> "$SYSTEMCTL_LOG"
+exit 0
+"""
+
+# NB: stubs never embed JSON (or any `}`) in a bash ${VAR-default} — the `}`
+# prematurely closes the parameter expansion. Complex/default values are set
+# from Python (proper quoting) into the env; stubs just echo the env var.
+_NETWORKCTL_STUB = """#!/bin/bash
+case "$1" in
+    status) printf 'Network File: %s\\n' "${NETFILE:-/run/systemd/network/10-netplan-eth0.network}" ;;
+    reload) echo "reload" >> "$SYSTEMCTL_LOG" ;;
+esac
+exit 0
+"""
+
+_IP_STUB = """#!/bin/bash
+printf '%s' "${IP_ROUTE_OUT:-}"
+"""
+
+
+def _stage(tmp_path: Path) -> dict:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in (
+        ("sudo", _SUDO_STUB),
+        ("systemctl", _SYSTEMCTL_STUB),
+        ("networkctl", _NETWORKCTL_STUB),
+        ("ip", _IP_STUB),
+    ):
+        stub = bin_dir / name
+        stub.write_text(body)
+        stub.chmod(0o755)
+    return {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "SYSTEMCTL_LOG": str(tmp_path / "systemctl.log"),
+        "NETRES_ETC_ROOT": str(tmp_path / "etc"),
+        "NETRES_SYSTEMD_RUNTIME_DIR": "/run/systemd/system",
+        "NETRES_LIBEXEC_DIR": str(tmp_path / "libexec"),
+        "NETRES_WATCHDOG_SRC": str(WATCHDOG),
+        "IP_ROUTE_OUT": json.dumps([{"dev": "eth0"}]),
+    }
+
+
+def _run_apply(env_overlay: dict) -> subprocess.CompletedProcess:
+    # Absolute bash path so the child never needs PATH to find its shell — lets a
+    # test restrict PATH to the stub dir alone (e.g. to hide the real networkctl).
+    return subprocess.run(
+        ["/bin/bash", "-c", f'set -euo pipefail; source "{LIB}"; network_resilience_apply'],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"HOME": env_overlay.get("NETRES_ETC_ROOT", "/tmp"), **env_overlay},
+    )
+
+
+def _paths(env: dict) -> dict[str, Path]:
+    etc = Path(env["NETRES_ETC_ROOT"])
+    libexec = Path(env["NETRES_LIBEXEC_DIR"])
+    return {
+        "keepconf": etc / "systemd/network/10-netplan-eth0.network.d/genesis-keep-config.conf",
+        "service": etc / "systemd/system/genesis-network-watchdog.service",
+        "timer": etc / "systemd/system/genesis-network-watchdog.timer",
+        "script": libexec / "network-watchdog.sh",
+    }
+
+
+def test_fresh_apply_writes_dropin_units_and_reloads(tmp_path):
+    env = _stage(tmp_path)
+    result = _run_apply(env)
+    assert result.returncode == 0, result.stderr
+    assert "Network resilience applied" in result.stdout
+
+    p = _paths(env)
+    # KeepConfiguration=true (superset of dhcp) — not =dhcp, not a percentage.
+    assert p["keepconf"].read_text() == "[Network]\nKeepConfiguration=true\n"
+    assert p["timer"].exists()
+    # ExecStart tracks the (overridden) install dir, not a hardcoded path.
+    service = p["service"].read_text()
+    assert "Type=oneshot" in service
+    assert f"ExecStart={p['script']}" in service
+    assert p["script"].read_text() == WATCHDOG.read_text()
+
+    calls = Path(env["SYSTEMCTL_LOG"]).read_text()
+    assert "reload" in calls  # networkctl reload for the drop-in
+    assert "daemon-reload" in calls
+    assert "enable genesis-network-watchdog.timer" in calls
+    assert "start genesis-network-watchdog.timer" in calls
+
+
+def test_second_run_is_a_noop(tmp_path):
+    env = _stage(tmp_path)
+    _run_apply(env)
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "already in place" in result.stdout
+    assert Path(env["SYSTEMCTL_LOG"]).read_text() == ""  # no reload/daemon churn
+
+
+def test_no_systemd_skips_cleanly(tmp_path):
+    env = _stage(tmp_path)
+    env["NETRES_SYSTEMD_RUNTIME_DIR"] = str(tmp_path / "does-not-exist")
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "not a systemd system" in result.stdout
+    assert not _paths(env)["keepconf"].exists()
+
+
+def test_no_networkctl_skips_cleanly(tmp_path):
+    env = _stage(tmp_path)
+    bin_dir = Path(env["PATH"].split(":")[0])
+    (bin_dir / "networkctl").unlink()
+    # Restrict PATH to the stub dir ONLY, so `command -v networkctl` cannot fall
+    # through to the host's real /usr/bin/networkctl. The networkctl guard runs
+    # before any external binary is needed, so the stub dir alone is sufficient.
+    env["PATH"] = str(bin_dir)
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "networkctl not present" in result.stdout
+    assert not _paths(env)["keepconf"].exists()
+
+
+def test_networkd_inactive_skips_cleanly(tmp_path):
+    env = _stage(tmp_path)
+    env["NETWORKD_ACTIVE_RC"] = "1"  # systemd-networkd not the active manager
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "not active" in result.stdout
+    assert not _paths(env)["keepconf"].exists()
+
+
+def test_no_noninteractive_sudo_skips_with_remediation(tmp_path):
+    env = _stage(tmp_path)
+    env["SUDO_N_RC"] = "1"
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "sudo unavailable" in result.stdout
+    assert "network_resilience_apply" in result.stdout
+    assert not _paths(env)["keepconf"].exists()
+
+
+def test_no_default_route_skips_keepconfig_but_installs_watchdog(tmp_path):
+    env = _stage(tmp_path)
+    env["IP_ROUTE_OUT"] = "[]"  # no IPv4 default route
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "no IPv4 default route" in result.stdout
+    p = _paths(env)
+    assert not p["keepconf"].exists()  # nothing to protect
+    assert p["timer"].exists()  # watchdog still worthwhile
+
+
+def test_unresolved_network_file_skips_keepconfig_but_installs_watchdog(tmp_path):
+    env = _stage(tmp_path)
+    env["NETFILE"] = "n/a"  # link has no governing .network unit
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "no .network unit resolved" in result.stdout
+    p = _paths(env)
+    assert not p["keepconf"].exists()
+    assert p["timer"].exists()
+
+
+def test_watchdog_source_missing_warns_but_keepconfig_still_applies(tmp_path):
+    env = _stage(tmp_path)
+    env["NETRES_WATCHDOG_SRC"] = str(tmp_path / "no-such-watchdog.sh")
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "watchdog source missing" in result.stdout
+    assert "NOT fully applied" in result.stdout
+    p = _paths(env)
+    assert p["keepconf"].exists()  # Part A independent of Part B
+    assert not p["script"].exists()
+
+
+def test_failed_write_warns_instead_of_claiming_already_in_place(tmp_path):
+    env = _stage(tmp_path)
+    etc = Path(env["NETRES_ETC_ROOT"])
+    etc.mkdir()
+    etc.chmod(0o555)  # unwritable -> tee fails
+    try:
+        result = _run_apply(env)
+    finally:
+        etc.chmod(0o755)
+    assert result.returncode == 0
+    assert "could not write" in result.stdout
+    assert "already in place" not in result.stdout
+
+
+def test_keepconfig_is_true_not_dhcp_or_percentage(tmp_path):
+    # Guards the deliberate choice: =true is the netplan `critical: true`
+    # superset (retains DHCP + static/foreign), delivering both hand-applied
+    # protections through one mechanism.
+    env = _stage(tmp_path)
+    _run_apply(env)
+    body = _paths(env)["keepconf"].read_text()
+    assert "KeepConfiguration=true" in body
+    assert "=dhcp" not in body
+
+
+def test_bootstrap_wires_the_lib():
+    text = BOOTSTRAP.read_text()
+    assert 'source "$SCRIPT_DIR/lib/network_resilience.sh"' in text
+    assert "network_resilience_apply" in text
+
+
+def test_update_sh_wires_the_lib_visibly():
+    text = UPDATE.read_text()
+    assert "lib/network_resilience.sh" in text
+    assert text.count("network_resilience_apply") >= 1
+
+
+# ── stubs + harness for the watchdog script (detect→heal) ─────────────────────
+
+_WD_SYSTEMCTL_STUB = """#!/bin/bash
+case "$1" in
+    is-enabled) printf '%s' "${WD_ENABLED-enabled}" ;;
+    is-active)  printf '%s' "${WD_ACTIVE-active}" ;;
+    show)       printf '@%s' "${WD_START_EPOCH-0}" ;;
+    restart)    echo "restart $2" >> "$WD_RESTART_LOG" ;;
+esac
+exit 0
+"""
+
+_WD_NETWORKCTL_STUB = """#!/bin/bash
+# only `--json=short list` is used
+printf '%s' "${WD_LINKS_JSON:-}"
+"""
+
+_WD_IP_STUB = """#!/bin/bash
+# `ip route show default`
+printf '%s' "${WD_ROUTE_OUT:-}"
+"""
+
+
+def _stage_wd(tmp_path: Path) -> dict:
+    bin_dir = tmp_path / "wdbin"
+    bin_dir.mkdir()
+    (bin_dir / "networkctl").write_text(_WD_NETWORKCTL_STUB)
+    (bin_dir / "ip").write_text(_WD_IP_STUB)
+    sysctl = bin_dir / "sysctl-stub"
+    sysctl.write_text(_WD_SYSTEMCTL_STUB)
+    for f in bin_dir.iterdir():
+        f.chmod(0o755)
+    return {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "NETWD_SYSTEMCTL": str(sysctl),
+        "NETWD_STATE_FILE": str(tmp_path / "state.json"),
+        "NETWD_STAMP_FILE": str(tmp_path / "stamp"),
+        "NETWD_NOW": "100000",
+        "NETWD_RATE_LIMIT_SEC": "600",
+        "NETWD_GRACE_SEC": "120",
+        "WD_RESTART_LOG": str(tmp_path / "restart.log"),
+        # Healthy defaults (Python-quoted, no JSON-in-bash-default); individual
+        # tests override these to drive each trigger.
+        "WD_LINKS_JSON": json.dumps(
+            {"Interfaces": [{"Name": "eth0", "AdministrativeState": "configured"}]}
+        ),
+        "WD_ROUTE_OUT": "default via 10.0.0.1 dev eth0",
+    }
+
+
+def _run_wd(env_overlay: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(WATCHDOG)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"HOME": "/tmp", **env_overlay},
+    )
+
+
+def _restarted(env: dict) -> bool:
+    log = Path(env["WD_RESTART_LOG"])
+    return log.exists() and "systemd-networkd" in log.read_text()
+
+
+def _state(env: dict) -> dict:
+    return json.loads(Path(env["NETWD_STATE_FILE"]).read_text())
+
+
+def test_watchdog_healthy_does_not_restart(tmp_path):
+    env = _stage_wd(tmp_path)  # active, route present, no failed link
+    result = _run_wd(env)
+    assert result.returncode == 0
+    assert not _restarted(env)
+    st = _state(env)
+    assert st["last_action"] == "none"
+    assert st["heal_count"] == 0
+    assert st["last_check"] == 100000
+
+
+def test_watchdog_failed_link_heals(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_LINKS_JSON"] = json.dumps(
+        {"Interfaces": [{"Name": "eth0", "AdministrativeState": "failed"}]}
+    )
+    result = _run_wd(env)
+    assert result.returncode == 0
+    assert _restarted(env)
+    st = _state(env)
+    assert st["last_action"] == "healed"
+    assert st["heal_count"] == 1
+    assert st["last_trigger"] == "failed-link:eth0"
+
+
+def test_watchdog_networkd_inactive_heals(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_ACTIVE"] = "inactive"
+    _run_wd(env)
+    assert _restarted(env)
+    assert _state(env)["last_trigger"] == "networkd-inactive"
+
+
+def test_watchdog_masked_never_heals(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_ENABLED"] = "masked"
+    env["WD_ACTIVE"] = "inactive"  # even though inactive, mask = operator intent
+    _run_wd(env)
+    assert not _restarted(env)
+    assert _state(env)["last_action"] == "none"
+
+
+def test_watchdog_no_default_route_heals(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_ROUTE_OUT"] = ""  # no default route
+    _run_wd(env)
+    assert _restarted(env)
+    assert _state(env)["last_trigger"] == "no-default-route"
+
+
+def test_watchdog_grace_window_suppresses_heal(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_LINKS_JSON"] = json.dumps(
+        {"Interfaces": [{"Name": "eth0", "AdministrativeState": "failed"}]}
+    )
+    env["WD_START_EPOCH"] = "99950"  # started 50s ago < 120s grace
+    _run_wd(env)
+    assert not _restarted(env)  # settling, don't fight it
+    assert _state(env)["last_action"] == "none"
+
+
+def test_watchdog_rate_limit_suppresses_repeat_heal(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_LINKS_JSON"] = json.dumps(
+        {"Interfaces": [{"Name": "eth0", "AdministrativeState": "failed"}]}
+    )
+    Path(env["NETWD_STAMP_FILE"]).write_text("99500")  # healed 500s ago < 600s
+    _run_wd(env)
+    assert not _restarted(env)
+    st = _state(env)
+    assert st["last_action"] == "ratelimited"
+    assert st["last_trigger"] == "failed-link:eth0"  # trigger recorded even so
+
+
+def test_watchdog_heal_count_accumulates_across_runs(tmp_path):
+    env = _stage_wd(tmp_path)
+    env["WD_ACTIVE"] = "inactive"
+    _run_wd(env)
+    assert _state(env)["heal_count"] == 1
+    # second heal must clear the rate-limit window (advance NOW past it)
+    env["NETWD_NOW"] = "101000"  # 1000s later > 600s rate limit
+    _run_wd(env)
+    assert _state(env)["heal_count"] == 2
+
+
+def test_watchdog_state_file_is_world_readable(tmp_path):
+    env = _stage_wd(tmp_path)
+    _run_wd(env)
+    mode = Path(env["NETWD_STATE_FILE"]).stat().st_mode & 0o777
+    assert mode & 0o044  # infra collector reads it non-root

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -30,6 +30,7 @@ exec "$@"
 
 _SYSTEMCTL_STUB = """#!/bin/bash
 if [ "$1" = "is-active" ]; then exit "${NETWORKD_ACTIVE_RC:-0}"; fi
+if [ "$1" = "is-enabled" ]; then printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0; fi
 echo "$@" >> "$SYSTEMCTL_LOG"
 exit 0
 """
@@ -153,13 +154,28 @@ def test_no_networkctl_skips_cleanly(tmp_path):
     assert not _paths(env)["keepconf"].exists()
 
 
-def test_networkd_inactive_skips_cleanly(tmp_path):
+def test_networkd_disabled_and_inactive_skips_cleanly(tmp_path):
+    # Genuine other-manager host: networkd inactive AND not enabled -> skip.
     env = _stage(tmp_path)
-    env["NETWORKD_ACTIVE_RC"] = "1"  # systemd-networkd not the active manager
+    env["NETWORKD_ACTIVE_RC"] = "1"
+    env["NETWORKD_ENABLED"] = "disabled"
     result = _run_apply(env)
     assert result.returncode == 0
-    assert "not active" in result.stdout
+    assert "not active or enabled" in result.stdout
     assert not _paths(env)["keepconf"].exists()
+
+
+def test_networkd_inactive_but_enabled_still_installs_watchdog(tmp_path):
+    # The crashed-but-ours case: networkd is inactive (exactly what the watchdog
+    # heals) yet enabled — must NOT be skipped, or the machine that most needs
+    # the watchdog never gets it (Codex P2).
+    env = _stage(tmp_path)
+    env["NETWORKD_ACTIVE_RC"] = "1"
+    env["NETWORKD_ENABLED"] = "enabled"
+    result = _run_apply(env)
+    assert result.returncode == 0
+    assert "not active or enabled" not in result.stdout
+    assert _paths(env)["timer"].exists()
 
 
 def test_no_noninteractive_sudo_skips_with_remediation(tmp_path):
@@ -250,7 +266,7 @@ case "$1" in
     is-enabled) printf '%s' "${WD_ENABLED-enabled}" ;;
     is-active)  printf '%s' "${WD_ACTIVE-active}" ;;
     show)       printf '@%s' "${WD_START_EPOCH-0}" ;;
-    restart)    echo "restart $2" >> "$WD_RESTART_LOG" ;;
+    restart)    echo "restart $2" >> "$WD_RESTART_LOG"; exit "${WD_RESTART_RC:-0}" ;;
 esac
 exit 0
 """
@@ -384,6 +400,22 @@ def test_watchdog_rate_limit_suppresses_repeat_heal(tmp_path):
     st = _state(env)
     assert st["last_action"] == "ratelimited"
     assert st["last_trigger"] == "failed-link:eth0"  # trigger recorded even so
+
+
+def test_watchdog_failed_restart_not_recorded_as_healed(tmp_path):
+    # A restart that exits nonzero must NOT claim a heal or arm the rate limit
+    # (Codex P2): telemetry says restart-failed, heal_count stays 0, and no
+    # stamp is written so the next tick retries.
+    env = _stage_wd(tmp_path)
+    env["WD_ACTIVE"] = "inactive"
+    env["WD_RESTART_RC"] = "1"
+    result = _run_wd(env)
+    assert result.returncode != 0  # surfaces as a failed oneshot unit
+    assert _restarted(env)  # it DID attempt the restart
+    st = _state(env)
+    assert st["last_action"] == "restart-failed"
+    assert st["heal_count"] == 0
+    assert not Path(env["NETWD_STAMP_FILE"]).exists()  # rate limit not armed
 
 
 def test_watchdog_heal_count_accumulates_across_runs(tmp_path):


### PR DESCRIPTION
## Why

Under memory pressure the container's `systemd-networkd` hit rtnetlink timeouts three times in three days (Jul 12/13/14: `eth0: Could not set route: Connection timed out` → `eth0: Failed`), dropped its DHCP lease, and fell off the network until a **manual** `systemctl restart systemd-networkd` hours later. The fix was hand-applied live on one install only — every fresh install is still born with the defect, and the *detection/heal* half was never built (eth0 sat in `AdministrativeState=failed`, silently, for 15+ hours).

Two layers, mirroring the memory-resilience PR (#1059) — survive → self-heal — both codified so fresh **and** existing installs get them:

## What

**Layer 1 — the address survives the failure.** `scripts/lib/network_resilience.sh` writes `KeepConfiguration=true` as a drop-in on the default-route link's `.network` unit (interface + unit **discovered live**, never hardcoded). `true` is the `yes ⊃ dhcp ⊃ dhcp-on-stop` superset (systemd.network(5)) — exactly what netplan `critical: true` renders to — so one mechanism delivers both hand-applied protections.

**Layer 2 — the daemon heals itself.** `scripts/systemd/genesis-network-watchdog.sh` + a root `.timer` (~2 min) restart networkd on any of: daemon inactive (not masked), a managed link in `AdministrativeState=failed`, or no IPv4 default route. Address-preserving under Layer 1. Rails: 2-min grace (don't fight a settling daemon), 10-min rate limit (a persistent fault logs loudly instead of flapping). Writes `/run` heal telemetry.

**Wiring:** `bootstrap.sh` (fresh) + `update.sh` (existing installs retrofit, unpiped so warnings are visible). Both layers are container-side, so sibling-install parity is automatic on its next update.

**Body schema:** `collect_network` gains config-plane facts `networkd_keep_configuration` + `network_watchdog_installed` (annotation layer flags unprotected installs) and a volatile `watchdog` heal-telemetry metric.

Graceful degradation: no systemd / no networkctl / NetworkManager host / no sudo each skip cleanly.

## Tests

- `tests/test_scripts/test_network_resilience.py` (22): stubbed-PATH lib apply (idempotent drop-in/units, every guard skip, honest failed-write) + watchdog detect→heal (all three triggers, masked-skip, grace + rate limit, telemetry).
- `tests/test_infra_profile/test_collectors_container.py` (+5, first-ever `collect_network` tests): both facts via `etc_root` seam, watchdog metrics via `run_root` seam, determinism.

## Verification

Live assumptions verified this session: `networkctl status` Network-File parsing, `ActiveEnterTimestamp`→`date -d` grace parsing, `ip -j route` dev field, networkd enabled+active. The box's eth0 is `AdministrativeState=failed` **now** — post-merge E2E is a real fire: the watchdog's first tick heals it (address-preserving), plus an operator-approved stop-networkd drill.

Docs: `docs/reference/network-resilience.md` (runbook), `CURRENT.md`, `CHANGELOG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)