### PR TITLE
feat(db): data-migration framework — post-boot idempotent non-schema backfills (WS-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Data backfills now heal themselves on update.** Some upgrades need more than
+  a schema change — they need existing data reshaped (e.g. tagging every stored
+  memory's vector with its provenance class). Those backfills used to be
+  one-off scripts each install had to remember to run by hand, so an install
+  that skipped one silently drifted. Genesis now runs them automatically in the
+  background after startup, tracked in a ledger so each runs exactly once, never
+  blocks boot, and simply no-ops on an install that's already current — so a
+  lagging clone catches up on its next update with nothing to run manually. The
+  first one backfills provenance onto older memory vectors.
+
 - **Genesis now notices when merged code isn't actually deployed.** Pulling
   changes with a bare `git merge` between updates loads the new code on
   restart but silently skips everything only `update.sh` activates — new

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -600,18 +600,30 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, infra_profile, env.py, _config_overlay.py]
-verified: bca86011 2026-07-15
+verified: 95dee055 2026-07-15
 ```
 
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
   without it interleaved commits pin `in_transaction` until restart). Two
-  schema paths coexist: base DDL (~113 CREATE TABLE; docs still say "60+")
-  plus versioned migrations 0001..0046 run ONCE at startup before any other
-  init step touches data; a failed migration ABORTS bootstrap. Migration
+  schema paths coexist: base DDL (`schema/_tables.py`, ~113 CREATE TABLE; docs
+  still say "60+") plus versioned `migrations/` 0001..0060 run ONCE at startup
+  before any other init step touches data; a failed migration ABORTS bootstrap.
+  EVERY table must be in BOTH paths (fresh-install DDL + its numbered
+  migration) — the `test_db/test_schema.py` allow-list enforces it. Migration
   atomicity is hand-rolled (BEGIN IMMEDIATE + a proxy that blocks stray
   commits/DDL autocommit) with a post-commit reconcile and SQLITE_LOCKED
   retry (2026-06-25 incident guard). No TABLES-vs-sqlite_master parity test
   exists.
+  **DATA migrations (WS-C, `db/data_migrations/`) are the OPPOSITE contract:**
+  non-schema backfills (Qdrant payloads, entity graphs) that run POST-boot as a
+  background `tracked_task` (kicked from `runtime/_core`), never abort boot, are
+  idempotent, and are claimed atomically via the `data_migrations` ledger (so
+  server + bridge-fallback can't double-run). `dNNNN_*.py` modules expose sync
+  `migrate()`+`verify()` (runner offloads via `to_thread`); `requires_operator`
+  ones sit `operator_pending` and never auto-run. Shared file-discovery with the
+  schema runner (`db/_migration_discovery.py`), deliberately NOT the atomic-txn
+  proxy. Seed `d0001` mirrors SQLite `origin_class` onto Qdrant — idempotent, so
+  a lagging install self-heals on next pull+restart with no control plane.
 - **runtime/**: sequential bootstrap (secrets → db → … → sentinel, ~27 steps);
   each step records ok/degraded/failed in the manifest — only db aborts.
   `~/.genesis/capabilities.json` + `bootstrap_manifest.json` are projected at

--- a/scripts/backfill_origin_class_qdrant.py
+++ b/scripts/backfill_origin_class_qdrant.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python3
-"""Backfill ``origin_class`` onto existing Qdrant payloads (WS-3 B0).
+"""CLI shim for the origin_class Qdrant backfill (WS-3 B0).
 
-Migration 0053 backfilled SQLite (memory_metadata + knowledge_units); Qdrant
-payloads of pre-existing points still lack the key. This script mirrors the
-SQLite truth onto the vectors via ``set_payload`` (MERGES fields — vectors
-and other payload fields untouched).
-
-Safe to lag / re-run:
-- Nothing reads the payload key in B0, and B1's reader falls back to SQLite
-  and normalizes missing values fail-closed at gate time.
-- Idempotent: points that already carry ``origin_class`` are skipped, so a
-  second run reports 0 updates.
-- SQLite is authoritative (post-0053 every row is classified); a Qdrant
-  point with no metadata row falls back to deriving from its own payload
-  (source_pipeline / source_subsystem / collection).
+The implementation lives in ``genesis.memory.origin_class_backfill`` and is
+also run automatically by data-migration ``d0001`` on boot — this script is
+the manual/one-off entry point (and how the backfill was originally shipped).
 
 Usage:
     source ~/genesis/.venv/bin/activate
@@ -25,72 +15,16 @@ from __future__ import annotations
 import argparse
 import sqlite3
 import sys
-from collections import Counter, defaultdict
 from pathlib import Path
-
-import httpx
 
 REPO_DIR = Path(__file__).resolve().parent.parent
 SRC_DIR = REPO_DIR / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from genesis.env import genesis_db_path, qdrant_url  # noqa: E402
-from genesis.memory.provenance import derive_origin_class  # noqa: E402
-
-QDRANT_URL = qdrant_url()
-COLLECTIONS = ("episodic_memory", "knowledge_base")
-BATCH = 500
-
-
-def _scroll_missing(client: httpx.Client, collection: str) -> list[dict]:
-    """Scroll all points, returning those WITHOUT origin_class."""
-    points: list[dict] = []
-    offset = None
-    while True:
-        body: dict = {
-            "limit": 1000,
-            "with_payload": ["origin_class", "source_pipeline", "source_subsystem"],
-        }
-        if offset is not None:
-            body["offset"] = offset
-        resp = client.post(
-            f"{QDRANT_URL}/collections/{collection}/points/scroll", json=body,
-        )
-        resp.raise_for_status()
-        result = resp.json()["result"]
-        for p in result["points"]:
-            if not (p.get("payload") or {}).get("origin_class"):
-                points.append(p)
-        offset = result.get("next_page_offset")
-        if offset is None:
-            return points
-
-
-def _sqlite_classes(db: sqlite3.Connection, ids: list[str]) -> dict[str, str]:
-    """memory_metadata.origin_class for the given point ids (authoritative)."""
-    out: dict[str, str] = {}
-    for i in range(0, len(ids), 900):  # SQLite bound-parameter limit headroom
-        chunk = ids[i : i + 900]
-        placeholders = ",".join("?" * len(chunk))
-        rows = db.execute(
-            f"SELECT memory_id, origin_class FROM memory_metadata "  # noqa: S608 - IN-list placeholders; ids bound
-            f"WHERE memory_id IN ({placeholders}) AND origin_class IS NOT NULL",
-            chunk,
-        ).fetchall()
-        out.update(dict(rows))
-    return out
-
-
-def _set_payload(
-    client: httpx.Client, collection: str, ids: list[str], origin: str,
-) -> None:
-    for i in range(0, len(ids), BATCH):
-        resp = client.post(
-            f"{QDRANT_URL}/collections/{collection}/points/payload?wait=true",
-            json={"payload": {"origin_class": origin}, "points": ids[i : i + BATCH]},
-        )
-        resp.raise_for_status()
+from genesis.env import genesis_db_path  # noqa: E402
+from genesis.memory.origin_class_backfill import backfill_origin_class  # noqa: E402
+from genesis.qdrant.collections import get_client  # noqa: E402
 
 
 def main() -> int:
@@ -99,37 +33,12 @@ def main() -> int:
     args = parser.parse_args()
 
     db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
-    totals: Counter[str] = Counter()
-    with httpx.Client(timeout=60) as client:
-        for collection in COLLECTIONS:
-            missing = _scroll_missing(client, collection)
-            print(f"{collection}: {len(missing)} points missing origin_class")
-            if not missing:
-                continue
-            ids = [str(p["id"]) for p in missing]
-            sqlite_map = _sqlite_classes(db, ids)
-            by_class: dict[str, list[str]] = defaultdict(list)
-            for p in missing:
-                pid = str(p["id"])
-                payload = p.get("payload") or {}
-                origin = sqlite_map.get(pid) or derive_origin_class(
-                    source_pipeline=payload.get("source_pipeline"),
-                    source_subsystem=payload.get("source_subsystem"),
-                    collection=collection,
-                )
-                by_class[origin].append(pid)
-            for origin, class_ids in sorted(by_class.items()):
-                orphans = sum(1 for pid in class_ids if pid not in sqlite_map)
-                print(
-                    f"  {origin}: {len(class_ids)} points"
-                    + (f" ({orphans} via payload fallback, no metadata row)" if orphans else "")
-                )
-                totals[origin] += len(class_ids)
-                if not args.dry_run:
-                    _set_payload(client, collection, class_ids, origin)
-    db.close()
+    try:
+        totals = backfill_origin_class(db, get_client(), dry_run=args.dry_run)
+    finally:
+        db.close()
     verb = "would update" if args.dry_run else "updated"
-    print(f"Done: {verb} {sum(totals.values())} points — {dict(totals)}")
+    print(f"Done: {verb} {sum(totals.values())} points — {totals}")
     return 0
 
 

--- a/src/genesis/db/_migration_discovery.py
+++ b/src/genesis/db/_migration_discovery.py
@@ -1,0 +1,32 @@
+"""Shared file-discovery for the two migration runners.
+
+Both the schema-migration runner (``db/migrations/runner.py``, files
+``NNNN_desc.py``) and the data-migration runner (``db/data_migrations/
+runner.py``, files ``dNNNN_desc.py``) discover numbered module files the same
+way: sorted directory listing, regex match, ``group(1)`` is the stable id,
+``path.stem`` is the display name. Only the filename PATTERN differs — the two
+runners' EXECUTION semantics (atomic schema txn vs long-running idempotent
+data backfill) are deliberately NOT shared.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def discover_numbered_modules(
+    directory: Path, pattern: re.Pattern[str]
+) -> list[tuple[str, str, Path]]:
+    """Return ``[(id, stem, path)]`` for files matching ``pattern``, id-ordered.
+
+    ``pattern`` must capture the id in group 1 (e.g. ``r"^(\\d{4})_\\w+\\.py$"``
+    or ``r"^(d\\d{4})_\\w+\\.py$"``). Sorted filename order == id order because
+    the zero-padded numeric prefix sorts lexicographically.
+    """
+    out: list[tuple[str, str, Path]] = []
+    for path in sorted(directory.iterdir()):
+        m = pattern.match(path.name)
+        if m:
+            out.append((m.group(1), path.stem, path))
+    return out

--- a/src/genesis/db/crud/data_migrations.py
+++ b/src/genesis/db/crud/data_migrations.py
@@ -1,0 +1,99 @@
+"""CRUD for the ``data_migrations`` ledger (WS-C data-migration framework).
+
+The runner (``db/data_migrations/runner.py``) drives the state machine through
+these; nothing else writes the table. All writes go through the shared
+``SerializedConnection`` so the atomic-claim ``UPDATE`` is genuinely atomic
+against a concurrent runner.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aiosqlite
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def ensure_row(
+    db: aiosqlite.Connection, *, id: str, name: str, requires_operator: bool
+) -> None:
+    """Insert the migration's ledger row if absent (idempotent).
+
+    A brand-new migration starts ``operator_pending`` when it requires an
+    operator (the auto-runner never claims it) else ``pending``. Existing rows
+    are left untouched — status is the runner's to advance."""
+    status = "operator_pending" if requires_operator else "pending"
+    await db.execute(
+        "INSERT OR IGNORE INTO data_migrations (id, name, status, updated_at) VALUES (?, ?, ?, ?)",
+        (id, name, status, _now()),
+    )
+    await db.commit()
+
+
+async def reset_running_to_pending(db: aiosqlite.Connection) -> int:
+    """Reset orphaned ``running`` rows to ``pending`` (boot re-dispatch).
+
+    A row left ``running`` at boot was orphaned by a crash mid-migration — the
+    server and bridge-fallback never run together (documented invariant), so no
+    live peer owns it. Idempotent by contract, so re-running is safe. Returns
+    the number reset."""
+    cur = await db.execute(
+        "UPDATE data_migrations SET status='pending', updated_at=? WHERE status='running'",
+        (_now(),),
+    )
+    await db.commit()
+    return cur.rowcount
+
+
+async def claim(db: aiosqlite.Connection, id: str) -> bool:
+    """Atomically claim a runnable migration. True iff THIS caller won it.
+
+    ``UPDATE ... WHERE status IN ('pending','failed')`` is atomic on the
+    serialized connection: two concurrent runners racing the same row produce
+    exactly one rowcount==1 winner; the loser sees 0 and skips. ``failed`` is
+    claimable so a transient failure retries on the next boot."""
+    cur = await db.execute(
+        "UPDATE data_migrations "
+        "SET status='running', started_at=?, attempts=attempts+1, updated_at=?, error=NULL "
+        "WHERE id=? AND status IN ('pending', 'failed')",
+        (_now(), _now(), id),
+    )
+    await db.commit()
+    return cur.rowcount == 1
+
+
+async def mark_completed(db: aiosqlite.Connection, id: str, *, summary: str) -> None:
+    now = _now()
+    await db.execute(
+        "UPDATE data_migrations SET status='completed', completed_at=?, updated_at=?, "
+        "summary=?, error=NULL WHERE id=?",
+        (now, now, summary, id),
+    )
+    await db.commit()
+
+
+async def mark_failed(db: aiosqlite.Connection, id: str, *, error: str) -> None:
+    await db.execute(
+        "UPDATE data_migrations SET status='failed', updated_at=?, error=? WHERE id=?",
+        (_now(), error[:2000], id),
+    )
+    await db.commit()
+
+
+async def get_status(db: aiosqlite.Connection, id: str) -> str | None:
+    cur = await db.execute("SELECT status FROM data_migrations WHERE id=?", (id,))
+    row = await cur.fetchone()
+    return row[0] if row else None
+
+
+async def get_all(db: aiosqlite.Connection) -> list[dict]:
+    """All ledger rows (id-ordered) as dicts — introspection / dashboards."""
+    cur = await db.execute(
+        "SELECT id, name, status, attempts, started_at, completed_at, error, summary "
+        "FROM data_migrations ORDER BY id"
+    )
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, row, strict=True)) for row in await cur.fetchall()]

--- a/src/genesis/db/data_migrations/__init__.py
+++ b/src/genesis/db/data_migrations/__init__.py
@@ -1,0 +1,16 @@
+"""Data-migration framework (WS-C).
+
+Once-per-install backfills/transforms of NON-schema state — Qdrant payloads,
+entity graphs — that schema migrations (``db/migrations/``) can't express.
+Each ``dNNNN_*.py`` module exposes:
+
+    requires_operator: bool = False   # optional; True => auto-runner skips it
+    def migrate() -> dict:  ...        # sync, idempotent; returns a summary
+    def verify() -> bool:   ...        # sync; True iff the goal is now satisfied
+
+The runner (``runner.py``) claims each migration's ledger row atomically,
+runs ``migrate()`` then ``verify()`` off the event loop, and records
+completed/failed. Idempotency is each migration's own contract — a re-run on
+an already-migrated install must be a clean no-op (this is how a lagging peer
+install self-heals on its next pull+restart, with no control plane).
+"""

--- a/src/genesis/db/data_migrations/d0001_origin_class_qdrant.py
+++ b/src/genesis/db/data_migrations/d0001_origin_class_qdrant.py
@@ -1,0 +1,35 @@
+"""d0001 — backfill origin_class onto Qdrant payloads (WS-3 B0).
+
+Auto-runs on boot. On an install that already ran the manual
+``scripts/backfill_origin_class_qdrant.py`` this is a clean no-op (idempotent
+skip of already-classified points); on a LAGGING install it heals the Qdrant
+payloads on the next pull+restart with no control plane — which is the whole
+point of the data-migration framework.
+
+migrate()/verify() are SYNC (blocking SQLite + Qdrant I/O); the runner offloads
+them via ``asyncio.to_thread``. They open their OWN read connection — never the
+runtime's async ``rt._db``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from genesis.env import genesis_db_path
+from genesis.memory.origin_class_backfill import backfill_origin_class, count_missing_origin_class
+from genesis.qdrant.collections import get_client
+
+requires_operator = False
+
+
+def migrate() -> dict:
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        return backfill_origin_class(db, get_client(), dry_run=False)
+    finally:
+        db.close()
+
+
+def verify() -> bool:
+    """Complete when no point in either collection lacks origin_class."""
+    return count_missing_origin_class(get_client()) == 0

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -43,6 +43,21 @@ class DataMigrationRunner:
         task) and never blocks the others."""
         available = self._discover()
 
+        # Pre-flight: two files sharing a dNNNN prefix would collide on the
+        # ledger PRIMARY KEY. Unlike the schema runner (whose plain INSERT
+        # surfaces the clash as a UNIQUE error mid-run), our ensure_row uses
+        # INSERT OR IGNORE, so a collision would SILENTLY drop the second
+        # migration forever (its id is marked completed by the first). Catch it
+        # loudly here instead. Mirrors db/migrations/runner.py's guard.
+        seen: dict[str, str] = {}
+        for mid, name, _path in available:
+            if mid in seen:
+                raise RuntimeError(
+                    f"Duplicate data-migration prefix '{mid}': '{seen[mid]}' and "
+                    f"'{name}'. Rename one to the next free prefix."
+                )
+            seen[mid] = name
+
         # Register any new migrations, then re-dispatch orphaned 'running' rows
         # (crash mid-run) before claiming — both idempotent.
         for mid, name, path in available:

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -1,0 +1,114 @@
+"""Runner for data migrations (WS-C) — see ``__init__`` for the contract.
+
+Runs POST-boot as a background ``tracked_task`` (never in the critical boot
+path; a data-migration failure must not abort startup — the exact failure mode
+this framework exists to replace). Serialized: one migration at a time, in id
+order. Interruption-safe: idempotency covers a crash mid-run, and an orphaned
+``running`` row is reset to ``pending`` on the next boot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import re
+from pathlib import Path
+
+import aiosqlite
+
+from genesis.db._migration_discovery import discover_numbered_modules
+from genesis.db.crud import data_migrations as crud
+
+logger = logging.getLogger(__name__)
+
+_DATA_MIGRATIONS_DIR = Path(__file__).parent
+_DATA_MIGRATION_PATTERN = re.compile(r"^(d\d{4})_\w+\.py$")
+
+
+class DataMigrationRunner:
+    """Discovers and runs pending data migrations against the shared DB."""
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    def _discover(self) -> list[tuple[str, str, Path]]:
+        return discover_numbered_modules(_DATA_MIGRATIONS_DIR, _DATA_MIGRATION_PATTERN)
+
+    async def run_pending(self) -> list[dict]:
+        """Run every claimable data migration once. Returns per-migration outcomes.
+
+        Best-effort: a single migration's failure is recorded to the ledger and
+        the runner moves on — it never raises into the caller (the background
+        task) and never blocks the others."""
+        available = self._discover()
+
+        # Register any new migrations, then re-dispatch orphaned 'running' rows
+        # (crash mid-run) before claiming — both idempotent.
+        for mid, name, path in available:
+            requires_operator = _module_requires_operator(path)
+            await crud.ensure_row(self._db, id=mid, name=name, requires_operator=requires_operator)
+        reset = await crud.reset_running_to_pending(self._db)
+        if reset:
+            logger.info("Re-dispatched %d orphaned data-migration(s) to pending", reset)
+
+        outcomes: list[dict] = []
+        for mid, name, path in available:
+            status = await crud.get_status(self._db, mid)
+            if status in ("completed", "operator_pending"):
+                # Already done, or deliberately operator-gated — never auto-run.
+                continue
+            # Atomic claim: only the winner proceeds (server/bridge double-run guard).
+            if not await crud.claim(self._db, mid):
+                continue
+            outcomes.append(await self._run_one(mid, name, path))
+        return outcomes
+
+    async def _run_one(self, mid: str, name: str, path: Path) -> dict:
+        try:
+            mod = importlib.import_module(f"genesis.db.data_migrations.{path.stem}")
+            if not hasattr(mod, "migrate") or not hasattr(mod, "verify"):
+                raise AttributeError(f"Data migration {name} missing migrate()/verify()")
+
+            # migrate() and verify() are SYNC (they open their own sqlite/qdrant
+            # connections and do blocking I/O) — run off the event loop so a long
+            # backfill never stalls the loop the awareness/reflection ticks share.
+            summary = await asyncio.to_thread(mod.migrate)
+            verified = await asyncio.to_thread(mod.verify)
+            if not verified:
+                await crud.mark_failed(
+                    self._db, mid, error="verify() returned False after migrate()"
+                )
+                logger.error("Data migration %s did not verify — marked failed", name)
+                return {"id": mid, "name": name, "success": False, "error": "verify failed"}
+
+            summary_str = str(summary) if summary is not None else ""
+            await crud.mark_completed(self._db, mid, summary=summary_str)
+            logger.info("Data migration %s completed: %s", name, summary_str)
+            return {"id": mid, "name": name, "success": True, "summary": summary}
+        except Exception as exc:  # noqa: BLE001 — record + continue; never abort the batch
+            await crud.mark_failed(self._db, mid, error=repr(exc))
+            logger.error("Data migration %s failed: %s", name, exc, exc_info=True)
+            return {"id": mid, "name": name, "success": False, "error": str(exc)}
+
+
+def _module_requires_operator(path: Path) -> bool:
+    """Read a migration's ``requires_operator`` flag without running it.
+
+    Imported (not exec'd) so the flag is a plain module constant; defaults to
+    False when absent."""
+    try:
+        mod = importlib.import_module(f"genesis.db.data_migrations.{path.stem}")
+        return bool(getattr(mod, "requires_operator", False))
+    except Exception:
+        logger.warning("Could not read requires_operator for %s — treating as auto", path.stem)
+        return False
+
+
+async def run_data_migrations(db: aiosqlite.Connection) -> list[dict]:
+    """Module entry point for the post-boot kick. Never raises."""
+    try:
+        return await DataMigrationRunner(db).run_pending()
+    except Exception:
+        logger.error("Data-migration runner failed", exc_info=True)
+        return []

--- a/src/genesis/db/migrations/0060_data_migrations_ledger.py
+++ b/src/genesis/db/migrations/0060_data_migrations_ledger.py
@@ -1,0 +1,41 @@
+"""Ledger table for the data-migration framework (WS-C).
+
+Schema migrations (this directory) alter STRUCTURE and run once, atomically,
+blocking boot. DATA migrations (``db/data_migrations/``) backfill/transform
+non-schema state (Qdrant payloads, entity graphs) — long-running, idempotent,
+run post-boot in the background, and must never abort boot. This table is
+their once-per-install ledger; the runner claims a row atomically before
+running so the server + bridge-fallback cannot double-dispatch one migration.
+
+status: pending -> running -> completed | failed (retryable next boot);
+operator_pending is a migration declared ``requires_operator = True`` that the
+auto-runner never claims (it waits for a deliberate operator trigger).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE data_migrations (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (
+                status IN ('pending', 'running', 'completed', 'failed', 'operator_pending')
+            ),
+            attempts INTEGER NOT NULL DEFAULT 0,
+            started_at TEXT,
+            completed_at TEXT,
+            error TEXT,
+            summary TEXT,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS data_migrations")

--- a/src/genesis/db/migrations/0060_data_migrations_ledger.py
+++ b/src/genesis/db/migrations/0060_data_migrations_ledger.py
@@ -18,9 +18,13 @@ import aiosqlite
 
 
 async def up(db: aiosqlite.Connection) -> None:
+    # IF NOT EXISTS: init_db() runs create_all_tables() (which creates this
+    # table from schema/_tables.py) BEFORE the migration runner, so on a fresh
+    # install the table already exists when 0060 runs. A bare CREATE would raise
+    # "table already exists" and abort boot. Same pattern as 0059.
     await db.execute(
         """
-        CREATE TABLE data_migrations (
+        CREATE TABLE IF NOT EXISTS data_migrations (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
             status TEXT NOT NULL CHECK (

--- a/src/genesis/db/migrations/runner.py
+++ b/src/genesis/db/migrations/runner.py
@@ -230,14 +230,11 @@ class MigrationRunner:
 
     async def get_available(self) -> list[tuple[str, str, Path]]:
         """Return ordered list of (id, name, path) for all migration files."""
-        migrations = []
-        for path in sorted(_MIGRATIONS_DIR.iterdir()):
-            m = _MIGRATION_PATTERN.match(path.name)
-            if m:
-                mid = m.group(1)
-                name = path.stem  # e.g., "0001_add_update_history"
-                migrations.append((mid, name, path))
-        return migrations
+        # Shared file-discovery with the data-migration runner (only the
+        # filename pattern differs; execution semantics are deliberately not).
+        from genesis.db._migration_discovery import discover_numbered_modules
+
+        return discover_numbered_modules(_MIGRATIONS_DIR, _MIGRATION_PATTERN)
 
     async def get_pending(self) -> list[tuple[str, str, Path]]:
         """Return ordered list of migrations not yet applied."""

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1662,6 +1662,24 @@ TABLES = {
             updated_at       TEXT
         )
     """,
+    # Data-migration framework ledger (WS-C). Kept in LOCKSTEP with migration
+    # 0060 (upgrade path); this is the fresh-install path. See
+    # db/data_migrations/ for the runner + contract.
+    "data_migrations": """
+        CREATE TABLE IF NOT EXISTS data_migrations (
+            id           TEXT PRIMARY KEY,
+            name         TEXT NOT NULL,
+            status       TEXT NOT NULL CHECK (
+                status IN ('pending','running','completed','failed','operator_pending')
+            ),
+            attempts     INTEGER NOT NULL DEFAULT 0,
+            started_at   TEXT,
+            completed_at TEXT,
+            error        TEXT,
+            summary      TEXT,
+            updated_at   TEXT NOT NULL
+        )
+    """,
     "session_ledger": """
         CREATE TABLE IF NOT EXISTS session_ledger (
             id          TEXT PRIMARY KEY,

--- a/src/genesis/memory/origin_class_backfill.py
+++ b/src/genesis/memory/origin_class_backfill.py
@@ -1,0 +1,101 @@
+"""Pure core for the origin_class Qdrant backfill (WS-3 B0).
+
+Migration 0053 backfilled ``origin_class`` onto SQLite (memory_metadata +
+knowledge_units); Qdrant payloads of pre-existing points still lack the key.
+This mirrors the SQLite truth (authoritative post-0053) onto the vectors via a
+MERGING payload set — vectors and other payload fields untouched.
+
+Extracted from the old ``scripts/backfill_origin_class_qdrant.py`` so BOTH the
+CLI shim AND the data-migration ``d0001`` call ONE implementation (no fork).
+Sync + blocking (SQLite + Qdrant HTTP) BY DESIGN — the data-migration runner
+offloads it via ``asyncio.to_thread``; the CLI runs it directly.
+
+Idempotent and safe to lag / re-run:
+- points already carrying ``origin_class`` are skipped (a second run = 0 updates),
+- a Qdrant point with no SQLite metadata row derives from its own payload,
+- nothing reads the key destructively; a stale install self-heals on next run.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter, defaultdict
+
+from qdrant_client import QdrantClient
+
+from genesis.memory.provenance import derive_origin_class
+from genesis.qdrant.collections import scroll_points, set_payload_batch
+
+COLLECTIONS = ("episodic_memory", "knowledge_base")
+
+
+def _scroll_missing(client: QdrantClient, collection: str) -> list[dict]:
+    """All points in ``collection`` lacking a non-empty ``origin_class``."""
+    missing: list[dict] = []
+    offset: str | None = None
+    while True:
+        points, offset = scroll_points(client, collection=collection, limit=1000, offset=offset)
+        for p in points:
+            if not (p.get("payload") or {}).get("origin_class"):
+                missing.append(p)
+        if offset is None:
+            return missing
+
+
+def _sqlite_classes(db: sqlite3.Connection, ids: list[str]) -> dict[str, str]:
+    """``memory_metadata.origin_class`` for the given point ids (authoritative)."""
+    out: dict[str, str] = {}
+    for i in range(0, len(ids), 900):  # SQLite bound-parameter headroom
+        chunk = ids[i : i + 900]
+        placeholders = ",".join("?" * len(chunk))
+        rows = db.execute(
+            f"SELECT memory_id, origin_class FROM memory_metadata "  # noqa: S608 - placeholders bound
+            f"WHERE memory_id IN ({placeholders}) AND origin_class IS NOT NULL",
+            chunk,
+        ).fetchall()
+        out.update(dict(rows))
+    return out
+
+
+def count_missing_origin_class(client: QdrantClient) -> int:
+    """Total points across both collections still lacking ``origin_class``.
+
+    The verify() signal: 0 means the backfill is complete on this install."""
+    return sum(len(_scroll_missing(client, c)) for c in COLLECTIONS)
+
+
+def backfill_origin_class(
+    db: sqlite3.Connection, client: QdrantClient, *, dry_run: bool = False
+) -> dict[str, int]:
+    """Mirror SQLite ``origin_class`` onto Qdrant payloads. Returns per-class counts.
+
+    ``db`` is any read connection over genesis.db; ``client`` a QdrantClient.
+    Both are injected so the CLI (its own ro conn) and d0001 (the same) share
+    this body without either owning connection setup."""
+    totals: Counter[str] = Counter()
+    for collection in COLLECTIONS:
+        missing = _scroll_missing(client, collection)
+        if not missing:
+            continue
+        ids = [p["id"] for p in missing]
+        sqlite_map = _sqlite_classes(db, ids)
+        by_class: dict[str, list[str]] = defaultdict(list)
+        for p in missing:
+            pid = p["id"]
+            payload = p.get("payload") or {}
+            origin = sqlite_map.get(pid) or derive_origin_class(
+                source_pipeline=payload.get("source_pipeline"),
+                source_subsystem=payload.get("source_subsystem"),
+                collection=collection,
+            )
+            by_class[origin].append(pid)
+        for origin, class_ids in by_class.items():
+            totals[origin] += len(class_ids)
+            if not dry_run:
+                set_payload_batch(
+                    client,
+                    collection=collection,
+                    point_ids=class_ids,
+                    payload={"origin_class": origin},
+                )
+    return dict(totals)

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -124,6 +124,26 @@ def update_payload(
     )
 
 
+def set_payload_batch(
+    client: QdrantClient,
+    *,
+    collection: str,
+    point_ids: list[str],
+    payload: dict,
+) -> None:
+    """MERGE ``payload`` onto many points in one call (vectors untouched).
+
+    Batched form of ``update_payload`` for backfills. ``set_payload`` merges
+    (does not replace) the point's existing payload."""
+    if not point_ids:
+        return
+    client.set_payload(
+        collection_name=collection,
+        payload=payload,
+        points=point_ids,
+    )
+
+
 def search(
     client: QdrantClient,
     *,

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -515,6 +515,24 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             except Exception:
                 logger.warning("Boot session-reap kick failed", exc_info=True)
 
+        # Data migrations (WS-C): once-per-install backfills of NON-schema state
+        # (Qdrant payloads, entity graphs). POST-boot + background — unlike schema
+        # migrations these must NEVER abort startup, and can be long-running.
+        # tracked_task (fire-and-forget) mirrors the session-reap kick above. The
+        # runner is self-guarding (never raises) and idempotent; requires_operator
+        # migrations are skipped here and wait for a deliberate trigger.
+        if self._db is not None:
+            try:
+                from genesis.db.data_migrations.runner import run_data_migrations
+                from genesis.util.tasks import tracked_task
+
+                tracked_task(
+                    run_data_migrations(self._db),
+                    name="data_migrations",
+                )
+            except Exception:
+                logger.warning("Boot data-migration kick failed", exc_info=True)
+
         self._wire_job_retry_registry()
 
         critical_ok = all(

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -26,6 +26,26 @@ async def db():
     await conn.close()
 
 
+async def test_migration_0060_idempotent_after_create_all_tables():
+    """The REAL boot path: init_db runs create_all_tables (which creates
+    data_migrations from _tables.py) BEFORE the migration runner. Migration
+    0060 must be idempotent against that — a bare CREATE would abort boot."""
+    from genesis.db.migrations.runner import MigrationRunner
+
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await create_all_tables(conn)  # table now exists (fresh-install path)
+        results = await MigrationRunner(conn).run_pending()  # 0060 must not fail
+        failed = [r for r in results if not r.success]
+        assert failed == [], [(r.name, r.error) for r in failed]
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='data_migrations'"
+        )
+        assert await cur.fetchone() is not None
+    finally:
+        await conn.close()
+
+
 # ── ledger CRUD ──────────────────────────────────────────────────────
 
 

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -1,0 +1,198 @@
+"""Tests for the data-migration framework (WS-C): ledger CRUD + runner.
+
+The runner is driven against FAKE migration modules (monkeypatched discovery +
+import) so the state machine is exercised without real Qdrant/entity I/O — the
+seed d0001's own logic is tested in test_memory/test_origin_class_backfill.py.
+"""
+
+from __future__ import annotations
+
+import types
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import data_migrations as crud
+from genesis.db.data_migrations import runner as runner_mod
+from genesis.db.data_migrations.runner import DataMigrationRunner
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+# ── ledger CRUD ──────────────────────────────────────────────────────
+
+
+async def test_ensure_row_status_depends_on_operator_flag(db):
+    await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)
+    await crud.ensure_row(db, id="d0002", name="d0002_y", requires_operator=True)
+    assert await crud.get_status(db, "d0001") == "pending"
+    assert await crud.get_status(db, "d0002") == "operator_pending"
+
+
+async def test_ensure_row_is_idempotent_and_never_downgrades(db):
+    await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)
+    assert await crud.claim(db, "d0001")
+    await crud.mark_completed(db, "d0001", summary="{}")
+    # A second ensure_row must NOT reset a completed row back to pending.
+    await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)
+    assert await crud.get_status(db, "d0001") == "completed"
+
+
+async def test_claim_is_exclusive(db):
+    await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)
+    assert await crud.claim(db, "d0001") is True  # first wins
+    assert await crud.claim(db, "d0001") is False  # already running, loser
+    assert await crud.get_status(db, "d0001") == "running"
+
+
+async def test_claim_retries_failed_but_not_completed_or_operator(db):
+    await crud.ensure_row(db, id="d0001", name="a", requires_operator=False)
+    await crud.claim(db, "d0001")
+    await crud.mark_failed(db, "d0001", error="boom")
+    assert await crud.claim(db, "d0001") is True  # failed is retryable
+
+    await crud.ensure_row(db, id="d0002", name="b", requires_operator=True)
+    assert await crud.claim(db, "d0002") is False  # operator_pending never auto-claims
+
+    await crud.ensure_row(db, id="d0003", name="c", requires_operator=False)
+    await crud.claim(db, "d0003")
+    await crud.mark_completed(db, "d0003", summary="done")
+    assert await crud.claim(db, "d0003") is False  # completed never re-claims
+
+
+async def test_reset_running_to_pending(db):
+    await crud.ensure_row(db, id="d0001", name="a", requires_operator=False)
+    await crud.claim(db, "d0001")  # -> running
+    assert await crud.reset_running_to_pending(db) == 1
+    assert await crud.get_status(db, "d0001") == "pending"
+    # A completed row is NOT reset.
+    await crud.claim(db, "d0001")
+    await crud.mark_completed(db, "d0001", summary="x")
+    assert await crud.reset_running_to_pending(db) == 0
+
+
+async def test_mark_failed_records_error_and_get_all(db):
+    await crud.ensure_row(db, id="d0001", name="a", requires_operator=False)
+    await crud.claim(db, "d0001")
+    await crud.mark_failed(db, "d0001", error="kaboom")
+    rows = await crud.get_all(db)
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["error"] == "kaboom"
+    assert rows[0]["attempts"] == 1
+
+
+# ── runner state machine (fake migrations) ───────────────────────────
+
+
+def _fake_module(migrate, verify, requires_operator=False):
+    return types.SimpleNamespace(
+        migrate=migrate, verify=verify, requires_operator=requires_operator
+    )
+
+
+def _patch_migrations(monkeypatch, mods: dict):
+    """Wire discovery + import to a dict of {stem: fake module}."""
+    from pathlib import Path
+
+    available = [(stem[:5], stem, Path(f"/fake/{stem}.py")) for stem in mods]
+    monkeypatch.setattr(DataMigrationRunner, "_discover", lambda self: available)
+    monkeypatch.setattr(
+        runner_mod.importlib, "import_module", lambda name: mods[name.rsplit(".", 1)[-1]]
+    )
+
+
+async def test_runner_runs_pending_and_marks_completed(db, monkeypatch):
+    calls = {"migrate": 0, "verify": 0}
+
+    def migrate():
+        calls["migrate"] += 1
+        return {"updated": 3}
+
+    def verify():
+        calls["verify"] += 1
+        return True
+
+    _patch_migrations(monkeypatch, {"d0001_x": _fake_module(migrate, verify)})
+    outcomes = await DataMigrationRunner(db).run_pending()
+    assert outcomes == [
+        {"id": "d0001", "name": "d0001_x", "success": True, "summary": {"updated": 3}}
+    ]
+    assert calls == {"migrate": 1, "verify": 1}
+    assert await crud.get_status(db, "d0001") == "completed"
+
+    # Second run: already completed -> not re-run (idempotent skip).
+    outcomes2 = await DataMigrationRunner(db).run_pending()
+    assert outcomes2 == []
+    assert calls == {"migrate": 1, "verify": 1}
+
+
+async def test_runner_verify_failure_marks_failed(db, monkeypatch):
+    _patch_migrations(
+        monkeypatch,
+        {"d0001_x": _fake_module(lambda: {}, lambda: False)},
+    )
+    outcomes = await DataMigrationRunner(db).run_pending()
+    assert outcomes[0]["success"] is False
+    assert await crud.get_status(db, "d0001") == "failed"
+
+
+async def test_runner_exception_marks_failed_and_continues(db, monkeypatch):
+    def boom():
+        raise RuntimeError("qdrant down")
+
+    ran_second = {"v": False}
+
+    def ok_migrate():
+        ran_second["v"] = True
+        return {}
+
+    _patch_migrations(
+        monkeypatch,
+        {
+            "d0001_a": _fake_module(boom, lambda: True),
+            "d0002_b": _fake_module(ok_migrate, lambda: True),
+        },
+    )
+    outcomes = await DataMigrationRunner(db).run_pending()
+    assert {o["id"]: o["success"] for o in outcomes} == {"d0001": False, "d0002": True}
+    assert await crud.get_status(db, "d0001") == "failed"  # recorded, not raised
+    assert ran_second["v"] is True  # batch continued past the failure
+
+
+async def test_runner_skips_operator_gated(db, monkeypatch):
+    ran = {"v": False}
+
+    def migrate():
+        ran["v"] = True
+        return {}
+
+    _patch_migrations(
+        monkeypatch,
+        {"d0002_op": _fake_module(migrate, lambda: True, requires_operator=True)},
+    )
+    outcomes = await DataMigrationRunner(db).run_pending()
+    assert outcomes == []
+    assert ran["v"] is False
+    assert await crud.get_status(db, "d0002") == "operator_pending"
+
+
+async def test_runner_redispatches_orphaned_running(db, monkeypatch):
+    # A row left 'running' by a crashed prior boot must re-run.
+    await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)
+    await crud.claim(db, "d0001")  # -> running (orphaned)
+    ran = {"v": 0}
+    _patch_migrations(
+        monkeypatch,
+        {"d0001_x": _fake_module(lambda: ran.__setitem__("v", ran["v"] + 1) or {}, lambda: True)},
+    )
+    await DataMigrationRunner(db).run_pending()
+    assert ran["v"] == 1
+    assert await crud.get_status(db, "d0001") == "completed"

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -184,6 +184,22 @@ async def test_runner_skips_operator_gated(db, monkeypatch):
     assert await crud.get_status(db, "d0002") == "operator_pending"
 
 
+async def test_runner_rejects_duplicate_prefix(db, monkeypatch):
+    # Two files sharing d0001 would silently drop the second (INSERT OR IGNORE
+    # + completed-skip) — the runner must raise loudly instead.
+    from pathlib import Path
+
+    available = [
+        ("d0001", "d0001_a", Path("/fake/d0001_a.py")),
+        ("d0001", "d0001_b", Path("/fake/d0001_b.py")),
+    ]
+    monkeypatch.setattr(DataMigrationRunner, "_discover", lambda self: available)
+    with pytest.raises(RuntimeError, match="Duplicate data-migration prefix 'd0001'"):
+        await DataMigrationRunner(db).run_pending()
+    # run_data_migrations swallows it (never aborts boot) but logs.
+    assert await runner_mod.run_data_migrations(db) == []
+
+
 async def test_runner_redispatches_orphaned_running(db, monkeypatch):
     # A row left 'running' by a crashed prior boot must re-run.
     await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)

--- a/tests/test_db/test_migration_discovery.py
+++ b/tests/test_db/test_migration_discovery.py
@@ -1,0 +1,44 @@
+"""Tests for the shared migration file-discovery (db/_migration_discovery.py).
+
+Extracted from the two migration runners; this exercises it directly (the
+structural reviewer flagged it had only transitive coverage).
+"""
+
+from __future__ import annotations
+
+import re
+
+from genesis.db._migration_discovery import discover_numbered_modules
+
+
+def _make(dir_, *names):
+    for n in names:
+        (dir_ / n).write_text("")
+
+
+def test_matches_pattern_and_orders_by_id(tmp_path):
+    _make(tmp_path, "0002_b.py", "0001_a.py", "0010_c.py")
+    pat = re.compile(r"^(\d{4})_\w+\.py$")
+    out = discover_numbered_modules(tmp_path, pat)
+    assert [mid for mid, _, _ in out] == ["0001", "0002", "0010"]  # zero-pad sort
+    assert [stem for _, stem, _ in out] == ["0001_a", "0002_b", "0010_c"]
+
+
+def test_ignores_non_matching_files(tmp_path):
+    _make(tmp_path, "0001_ok.py", "README.md", "0001_ok.pyc", "notes.txt", "_helper.py")
+    pat = re.compile(r"^(\d{4})_\w+\.py$")
+    out = discover_numbered_modules(tmp_path, pat)
+    assert [stem for _, stem, _ in out] == ["0001_ok"]
+
+
+def test_data_migration_pattern_is_distinct(tmp_path):
+    # The d-prefixed pattern must NOT pick up schema-style files and vice versa.
+    _make(tmp_path, "0001_schema.py", "d0001_data.py")
+    schema_pat = re.compile(r"^(\d{4})_\w+\.py$")
+    data_pat = re.compile(r"^(d\d{4})_\w+\.py$")
+    assert [s for _, s, _ in discover_numbered_modules(tmp_path, schema_pat)] == ["0001_schema"]
+    assert [s for _, s, _ in discover_numbered_modules(tmp_path, data_pat)] == ["d0001_data"]
+
+
+def test_empty_dir_returns_empty(tmp_path):
+    assert discover_numbered_modules(tmp_path, re.compile(r"^(\d{4})_\w+\.py$")) == []

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -69,6 +69,7 @@ EXPECTED_TABLES = [
     "session_ledger",  # session-manager PR-2a: per-session TODO ledger rows
     "session_ledger_shadow_events",  # session-manager PR-3: ambient proposal shadow
     "session_ledger_shadow_runs",  # session-manager PR-3: extractor run telemetry
+    "data_migrations",  # WS-C: data-migration framework ledger
 ]
 
 

--- a/tests/test_memory/test_origin_class_backfill.py
+++ b/tests/test_memory/test_origin_class_backfill.py
@@ -1,0 +1,127 @@
+"""Tests for the origin_class backfill core (genesis.memory.origin_class_backfill).
+
+The Qdrant layer is faked (scroll_points / set_payload_batch monkeypatched); a
+real in-memory SQLite supplies the authoritative memory_metadata rows. Covers:
+SQLite-authoritative mapping, payload-fallback for orphan points, the
+idempotent skip of already-classified points, dry-run, and the verify counter.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from genesis.memory import origin_class_backfill as ocb
+
+
+@pytest.fixture
+def sqlite_db():
+    db = sqlite3.connect(":memory:")
+    db.execute("CREATE TABLE memory_metadata (memory_id TEXT PRIMARY KEY, origin_class TEXT)")
+    db.executemany(
+        "INSERT INTO memory_metadata (memory_id, origin_class) VALUES (?, ?)",
+        [("p1", "owner"), ("p2", "first_party")],
+    )
+    db.commit()
+    yield db
+    db.close()
+
+
+def _fake_scroll(pages_by_collection):
+    """Return a scroll_points stand-in that paginates the given points."""
+
+    def scroll(client, *, collection, limit=1000, offset=None):
+        pages = pages_by_collection.get(collection, [[]])
+        idx = int(offset) if offset is not None else 0
+        points = pages[idx]
+        next_offset = str(idx + 1) if idx + 1 < len(pages) else None
+        return points, next_offset
+
+    return scroll
+
+
+def test_backfill_maps_sqlite_and_skips_classified(sqlite_db, monkeypatch):
+    # p1/p2 missing origin_class in Qdrant; p3 already has it (must be skipped).
+    pages = {
+        "episodic_memory": [
+            [
+                {"id": "p1", "payload": {}},
+                {"id": "p2", "payload": {}},
+                {"id": "p3", "payload": {"origin_class": "owner"}},
+            ]
+        ],
+        "knowledge_base": [[]],
+    }
+    monkeypatch.setattr(ocb, "scroll_points", _fake_scroll(pages))
+    sets: list = []
+    monkeypatch.setattr(
+        ocb,
+        "set_payload_batch",
+        lambda client, *, collection, point_ids, payload: sets.append((point_ids, payload)),
+    )
+
+    totals = ocb.backfill_origin_class(sqlite_db, object(), dry_run=False)
+    assert totals == {"owner": 1, "first_party": 1}
+    # p3 (already classified) never appears in a set call.
+    set_ids = {pid for ids, _ in sets for pid in ids}
+    assert set_ids == {"p1", "p2"}
+
+
+def test_backfill_orphan_point_uses_payload_fallback(sqlite_db, monkeypatch):
+    # p9 has no memory_metadata row -> origin is DERIVED from payload, not skipped.
+    pages = {
+        "episodic_memory": [[{"id": "p9", "payload": {"source_subsystem": "reflection"}}]],
+        "knowledge_base": [[]],
+    }
+    monkeypatch.setattr(ocb, "scroll_points", _fake_scroll(pages))
+    captured: list = []
+    monkeypatch.setattr(
+        ocb,
+        "set_payload_batch",
+        lambda client, *, collection, point_ids, payload: captured.append((point_ids, payload)),
+    )
+    totals = ocb.backfill_origin_class(sqlite_db, object(), dry_run=False)
+    assert sum(totals.values()) == 1  # p9 classified via fallback
+    assert captured and captured[0][0] == ["p9"]
+    assert captured[0][1]["origin_class"]  # some non-empty derived class
+
+
+def test_backfill_dry_run_writes_nothing(sqlite_db, monkeypatch):
+    pages = {"episodic_memory": [[{"id": "p1", "payload": {}}]], "knowledge_base": [[]]}
+    monkeypatch.setattr(ocb, "scroll_points", _fake_scroll(pages))
+    calls = []
+    monkeypatch.setattr(ocb, "set_payload_batch", lambda *a, **k: calls.append(1))
+    totals = ocb.backfill_origin_class(sqlite_db, object(), dry_run=True)
+    assert totals == {"owner": 1}  # counted...
+    assert calls == []  # ...but not written
+
+
+def test_backfill_paginates(sqlite_db, monkeypatch):
+    pages = {
+        "episodic_memory": [
+            [{"id": "p1", "payload": {}}],
+            [{"id": "p2", "payload": {}}],
+        ],
+        "knowledge_base": [[]],
+    }
+    monkeypatch.setattr(ocb, "scroll_points", _fake_scroll(pages))
+    seen: list = []
+    monkeypatch.setattr(
+        ocb,
+        "set_payload_batch",
+        lambda client, *, collection, point_ids, payload: seen.extend(point_ids),
+    )
+    ocb.backfill_origin_class(sqlite_db, object(), dry_run=False)
+    assert set(seen) == {"p1", "p2"}  # both pages processed
+
+
+def test_count_missing_origin_class(monkeypatch):
+    pages = {
+        "episodic_memory": [
+            [{"id": "p1", "payload": {}}, {"id": "p2", "payload": {"origin_class": "owner"}}]
+        ],
+        "knowledge_base": [[{"id": "p3", "payload": {}}]],
+    }
+    monkeypatch.setattr(ocb, "scroll_points", _fake_scroll(pages))
+    assert ocb.count_missing_origin_class(object()) == 2  # p1 + p3 (p2 classified)


### PR DESCRIPTION
## Summary

Genesis has SCHEMA migrations (`db/migrations/`, run once at startup, abort boot on failure) but no framework for **data** migrations — once-per-install backfills of non-schema state (Qdrant payloads, entity graphs) that must be idempotent, can be long-running, and must **not** abort boot. Those have been one-off scripts each install had to remember to run, with no propagation path (a lagging clone silently drifts). This adds the framework and its first real seed.

## Design (genesis-architect reviewed → DONE_WITH_CONCERNS; lean-v1 per user)

- **Ledger** `data_migrations` (migration **0060** + `_tables.py` — both schema paths; registered in `test_schema` allow-list).
- **Runner** (`db/data_migrations/runner.py`): discovers `dNNNN_*.py`, **atomically claims** each ledger row (`UPDATE…WHERE status IN ('pending','failed')` — server + bridge-fallback can't double-run), runs sync `migrate()`+`verify()` **off the event loop** via `to_thread`, records `completed`/`failed`. Only writes `completed` if `verify()` passes. Orphaned `running` rows re-dispatch on next boot. `requires_operator` migrations sit `operator_pending` and never auto-run. Never raises into the caller.
- **Boot kick**: post-boot `tracked_task` in `runtime/_core` (mirrors the existing session-reap kick) — never in the critical boot path.
- **DRY**: shared file-discovery with the schema runner (`db/_migration_discovery.py`); deliberately **not** its atomic-transaction proxy (wrong semantics for long backfills).
- **Seed `d0001`** (origin_class Qdrant backfill): refactored out of the CLI script into an importable pure core (`genesis.memory.origin_class_backfill`) using runtime-native Qdrant helpers (added `set_payload_batch`); the script is now a thin shim over the same core. Idempotent → a lagging install self-heals on its next pull+restart with **no control plane**.

### Scope (lean-v1, user-approved)

Two items from the plan were deferred on the architect's recommendation: `blocking=True` (re-imports the boot-abort failure mode the framework exists to kill; no seed needs it) and the operator-**surfacing** layer (health/dashboard "pending operator" + WS-B wiring — a second subsystem for a consumer not in this PR). The `requires_operator` **mechanism** ships and is tested; #988's entity backfill will be the first operator-gated seed (`d0002`).

## Review-fix highlights (architect concerns applied)

- **BLOCKER**: `d0001` can't wrap the CLI-shaped script as-is (argparse/own conn/`sys.exit`, sync I/O under a task) → refactored a pure `backfill_origin_class(db, client, *, dry_run)` core, offloaded via `to_thread`.
- verify() enforced by the runner; running-row re-dispatch; atomic claim; shared discovery; runtime-native Qdrant ops.

## Tests

- `tests/test_db/test_data_migrations.py` — ledger CRUD + runner state machine against fake migrations (exclusive claim, retry failed/not completed/not operator, reset-running, verify-failure→failed, exception→failed-and-continue, operator skip, orphan re-dispatch, idempotent skip).
- `tests/test_memory/test_origin_class_backfill.py` — the core with a faked Qdrant client (SQLite-authoritative mapping, payload fallback for orphans, idempotent skip, dry-run, pagination, verify counter).
- Regression: `test_schema` (both-path parity), `test_migrations_runner` (shared-discovery refactor), `test_origin_class_migration` — all green. Full 60-migration sequence applies clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)