### PR TITLE
perf(memory): batch neighbor hydration in graph expansion (~5x faster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   context is unaffected by design: it never ingested these reflections in
   the first place.
 
+- **Recall-time graph expansion got ~5x faster.** The just-shipped 1-hop
+  expansion hydrated each linked neighbor with its own database query — and
+  because the memory content table is a full-text index (no plain lookup on
+  the id column), every one of those was a full scan. On a typical 10-neighbor
+  expansion that measured ~750-940ms of pure overhead on the recall path. It
+  now hydrates every neighbor in a single batched query (~80-130ms), returning
+  identical results. Purely a performance fix — same neighbors, same order,
+  same provenance and visibility filtering.
+
 - **A dashboard request during startup can no longer crash the server.** The
   async-route bridge falls back to a throwaway event loop when the runtime
   loop isn't available — but shared database connections are bound to the

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -259,6 +259,47 @@ async def origin_class_by_ids(db: aiosqlite.Connection, ids: list[str]) -> dict[
     return out
 
 
+async def hydrate_for_expansion(db: aiosqlite.Connection, ids: list[str]) -> dict[str, dict]:
+    """Batch memory_id → {content, source_type, tags, collection, origin_class,
+    invalid_at, deprecated} for graph-expansion neighbor hydration.
+
+    ONE FTS⋈metadata query replaces the recall-time expansion's former
+    per-neighbor ``get_by_id`` loop plus its separate ``origin_class_by_ids``
+    and visibility-filter passes (the N+1 that dominated expansion latency).
+    Neighbor lists are cap-bounded (≤25 by the settings validator), so a
+    single IN-clause never approaches the 999 bind-variable ceiling — no
+    chunking needed. Missing ids are omitted (dangling links). ``collection``
+    is read from the FTS row (authoritative at retrieval, matching
+    ``get_by_id``); the LEFT JOIN yields NULL metadata fields for a row with
+    no ``memory_metadata`` companion, which the caller treats as
+    visible/unclassified — identical to the prior separate-query behavior.
+    """
+    if not ids:
+        return {}
+    marks = ",".join("?" * len(ids))
+    rows = await db.execute_fetchall(
+        f"SELECT f.memory_id, f.content, f.source_type, f.tags, f.collection, "  # noqa: S608 - placeholders bound
+        f"       m.origin_class, m.invalid_at, "
+        f"       COALESCE(m.deprecated, 0) AS deprecated "
+        f"FROM memory_fts f "
+        f"LEFT JOIN memory_metadata m ON f.memory_id = m.memory_id "
+        f"WHERE f.memory_id IN ({marks})",
+        ids,
+    )
+    return {
+        r[0]: {
+            "content": r[1],
+            "source_type": r[2],
+            "tags": r[3],
+            "collection": r[4],
+            "origin_class": r[5],
+            "invalid_at": r[6],
+            "deprecated": r[7],
+        }
+        for r in rows
+    }
+
+
 async def delete(db: aiosqlite.Connection, *, memory_id: str) -> bool:
     """Delete a memory entry from the FTS5 index."""
     cursor = await db.execute("DELETE FROM memory_fts WHERE memory_id = ?", (memory_id,))

--- a/src/genesis/memory/graph_expansion.py
+++ b/src/genesis/memory/graph_expansion.py
@@ -183,26 +183,12 @@ async def expand_neighbors(
         return []
 
     neighbor_ids = [n["memory_id"] for n in neighbors]
-    # Visibility parity with normal recall (Codex #1069 P2): `get_by_id`
-    # applies neither the bitemporal expiry nor the deprecated predicate that
-    # `search_ranked`/`_expired_candidate_ids` enforce — without this, live
-    # expansion would resurface superseded facts that recall deliberately
-    # hides. NULL invalid_at = valid forever; NULL deprecated = legacy row,
-    # not deprecated (same semantics as the recall pipeline).
-    _ph = ",".join("?" * len(neighbor_ids))
-    hidden_rows = await db.execute_fetchall(
-        f"SELECT memory_id FROM memory_metadata "  # noqa: S608 - literal fragments; values bound
-        f"WHERE memory_id IN ({_ph}) AND "
-        f"((invalid_at IS NOT NULL AND invalid_at <= ?) OR deprecated = 1)",
-        [*neighbor_ids, datetime.now(UTC).isoformat()],
-    )
-    hidden = {r[0] for r in hidden_rows}
-    if hidden:
-        neighbors = [n for n in neighbors if n["memory_id"] not in hidden]
-        if not neighbors:
-            return []
-        neighbor_ids = [n["memory_id"] for n in neighbors]
-    origins = await memory_crud.origin_class_by_ids(db, neighbor_ids)
+    # ONE batched FTS⋈metadata fetch hydrates content + provenance + the
+    # visibility fields (was an N+1 get_by_id loop + a separate
+    # origin_class_by_ids + a separate visibility query — the latency the flip
+    # surfaced). Neighbor lists are cap-bounded (≤25), so no chunking needed.
+    hydrated = await memory_crud.hydrate_for_expansion(db, neighbor_ids)
+
     # Which seed(s) reach each neighbor — one bounded query over the
     # seed∪neighbor id set (direction-agnostic pair list).
     seed_set = set(seed_ids)
@@ -216,12 +202,19 @@ async def expand_neighbors(
         elif tgt in seed_set and src not in seed_set:
             linked_from.setdefault(src, set()).add(tgt)
 
+    now_iso = datetime.now(UTC).isoformat()
     results: list[RetrievalResult] = []
     for n in neighbors:
         mid = n["memory_id"]
-        row = await memory_crud.get_by_id(db, mid)
+        row = hydrated.get(mid)
         if not row or not row.get("content"):
             continue  # dangling link — edge outlived the memory
+        # Visibility parity with normal recall (Codex #1069 P2): skip rows
+        # normal recall hides — bitemporally expired (NULL invalid_at = valid
+        # forever) or deprecated/superseded (search_ranked filters these).
+        invalid_at = row.get("invalid_at")
+        if (invalid_at is not None and invalid_at <= now_iso) or row.get("deprecated"):
+            continue
         strength = float(n.get("strength") or 0.0)
         collection = row.get("collection") or "episodic_memory"
         results.append(
@@ -242,7 +235,7 @@ async def expand_neighbors(
                     },
                 },
                 source_pipeline=None,
-                origin_class=origins.get(mid),
+                origin_class=row.get("origin_class"),
                 collection=collection,
             ),
         )

--- a/tests/test_db/test_search_ranked_invalid_at.py
+++ b/tests/test_db/test_search_ranked_invalid_at.py
@@ -153,3 +153,39 @@ async def test_origin_class_by_ids_chunks_past_bind_cap(tmp_path):
         assert "absent-1" not in got
     finally:
         await conn.close()
+
+
+async def test_hydrate_for_expansion(tmp_path):
+    """Batched neighbor hydration for graph expansion: one query returns
+    content + provenance + visibility fields, replacing an N+1 get_by_id loop."""
+    conn = await _build_db(str(tmp_path / "h.db"))
+    try:
+        await conn.execute(
+            "UPDATE memory_metadata SET origin_class='external_untrusted' WHERE memory_id='alive'"
+        )
+        # collection is read from the FTS row (parity with get_by_id), not metadata
+        await conn.execute(
+            "UPDATE memory_fts SET tags='foo,bar', collection='knowledge_base' "
+            "WHERE memory_id='alive'"
+        )
+        await conn.execute("UPDATE memory_metadata SET deprecated=1 WHERE memory_id='future'")
+        await conn.commit()
+
+        got = await memory_crud.hydrate_for_expansion(
+            conn, ["alive", "future", "expired", "absent"]
+        )
+        assert set(got) == {"alive", "future", "expired"}  # absent omitted
+        alive = got["alive"]
+        assert alive["content"] == "this row never expires"
+        assert alive["source_type"] == "memory"
+        assert alive["tags"] == "foo,bar"
+        assert alive["collection"] == "knowledge_base"
+        assert alive["origin_class"] == "external_untrusted"
+        assert alive["invalid_at"] is None
+        assert alive["deprecated"] == 0
+        # visibility fields surface for filtering
+        assert got["future"]["deprecated"] == 1
+        assert got["expired"]["invalid_at"] == "2020-01-01T00:00:00+00:00"
+        assert await memory_crud.hydrate_for_expansion(conn, []) == {}
+    finally:
+        await conn.close()


### PR DESCRIPTION
## What

Fast-follow to #1069. Recall-time 1-hop graph expansion hydrated each linked neighbor with its own `memory_crud.get_by_id` call. Because `memory_fts` is an FTS5 virtual table with no plain index on `memory_id`, every one of those is a full-content scan — so a 10-neighbor expansion did 10 scans.

Replaced the N+1 loop (plus the separate `origin_class_by_ids` call and the separate visibility-filter query, which hit the same rows) with **one** batched `hydrate_for_expansion` query joining `memory_fts ⋈ memory_metadata`. Neighbor lists are cap-bounded (≤25 by the settings validator) so a single `IN` clause never approaches the 999 bind-variable ceiling — no chunking needed.

## Why (measured, live prod DB, read-only A/B)

```
OLD  10x get_by_id : 749-937 ms   (10 unindexed FTS scans)
NEW  1x batched    :  77-126 ms
```

~6-10x on the hydration portion; `expand_neighbors` overall drops from ~680ms to ~150-200ms. `neighbors_of` itself was already 1ms (indexed) — the FTS scan was the whole cost. This latency was the #1 regression marker flagged at the #1069 live flip.

## Behavior-preserving

Same neighbors, same order, same provenance (stored-first `origin_class`, `source_pipeline=None`), same expired/deprecated visibility filtering — now derived from the batched row instead of separate queries. Guarded by the full existing `test_graph_expansion` + `test_memory_recall_graph_expansion` suites (49 tests green), plus a new `test_hydrate_for_expansion` CRUD test pinning the contract (content/tags/collection from FTS, origin_class/invalid_at/deprecated from metadata, missing ids omitted).

## Deploy

MCP-child surfaces activate next CC session; the dashboard tool-API recall surface needs a `genesis-server` restart (same as #1069). Pure perf — no config, no behavior flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)