### PR TITLE
feat(guardian): out-of-band RAM tiered alert (E-rest PR-E1)

### DIFF
--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -90,6 +90,21 @@ storage_pool:
   pool_used_crit_pct: 92
   realert_hours: 6
 
+# Guardian-side RAM tiered alert (E-rest PR-E1). The container's own RAM alert
+# (infra:container_memory_high) dies exactly when it thrashes/OOMs; the guardian
+# pages out-of-band over TWO axes, worst-of: container cgroup anon+kernel (via
+# incus-exec — best-effort) and host-VM used% (the guardian's own /proc/meminfo —
+# the reliable axis, no exec). Host tiers sit higher (the host idles busier).
+memory_tiers:
+  enabled: true
+  container_warn_pct: 75
+  container_high_pct: 85
+  container_crit_pct: 92
+  host_warn_pct: 80
+  host_high_pct: 88
+  host_crit_pct: 94
+  realert_hours: 6
+
 # Credential-file integrity backstop (G.1). The container self-heals corrupt
 # credential files first (its awareness tick); the guardian validates the same
 # files via read-only `incus exec`, WARNs on first sight, and STEPS IN (restores

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -348,7 +348,7 @@ radius) and the container-side Sentinel (CC-driven diagnosis/repair).
 ```yaml subsystem-map
 entry: guardian-sentinel
 modules: [guardian, sentinel]
-verified: 859ec256 2026-07-14
+verified: 4e483381 2026-07-15
 ```
 
 - **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
@@ -367,6 +367,13 @@ verified: 859ec256 2026-07-14
   `infra_profile` host plane; the CC diagnosis prompt inlines the shared-mount
   `INFRASTRUCTURE.md` (truncated) so the diagnostician starts with the body
   schema instead of re-deriving the machine's shape.
+- **Out-of-band tiered alerts** run every tick through the guardian's OWN
+  Telegram (survives a dead/thrashing container): storage-pool data%/metadata%
+  (`pool.py`) and **RAM** (`memory_watch.py`, E-rest) — the latter over two
+  axes worst-of, container cgroup (via incus-exec, best-effort) + host-VM
+  `/proc/meminfo` (the reliable axis). Both use the shared `_tier_for`/
+  `decide_alert` hysteresis. Read-only `disk-status`/`ram-status` verbs expose
+  the same measurement to the container.
 - **sentinel/** is LIVE-wired but **shadow-only autonomy**: config mode
   `"live"` is NOT implemented (dispatcher warns + downgrades); every proposed
   action requires human approval. `InfrastructureMonitor` (call site 37, free

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -814,6 +814,28 @@ PYEOF
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
             timeout 30 "$VENV_PY" -m genesis.guardian --disk-status
         ;;
+    ram-status)
+        # Read-only: print the guardian's RAM view JSON (container cgroup +
+        # host-VM axes + worst-of tier). Genesis's window onto the out-of-band
+        # RAM alert. No mutation, no secrets, no sudo.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "ram-status", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        # Skew guard (see host-profile): sync-gateway redeploys THIS script
+        # independently of the src tree. An old checkout has no --ram-status
+        # branch — the flag would fall through main()'s if-chain into run_check(),
+        # i.e. a FULL guardian recovery cycle triggered by a routine read-only poll.
+        if [ ! -f "$INSTALL_DIR/src/genesis/guardian/memory_watch.py" ]; then
+            echo '{"ok": false, "action": "ram-status", "error": "guardian src predates ram-status — run update to redeploy"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            timeout 30 "$VENV_PY" -m genesis.guardian --ram-status
+        ;;
     host-profile)
         # Read-only: print the host body-schema JSON (system identity, storage
         # pool, virtualization stack + this container's limits.*). Consumed by

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -6,6 +6,7 @@ Usage:
     python -m genesis.guardian --check-only  # one-shot health check (no recovery)
     python -m genesis.guardian --test-approval  # E2E test the keyword-reply gate
     python -m genesis.guardian --disk-status  # print storage-pool JSON (read-only)
+    python -m genesis.guardian --ram-status   # print RAM tier JSON (read-only)
     python -m genesis.guardian --host-profile  # host body-schema JSON (read-only)
     python -m genesis.guardian --bundle-status # offline repo-bundle archive JSON (read-only)
     python -m genesis.guardian --provision-status              # host capacity (read-only)
@@ -47,6 +48,10 @@ def main() -> None:
 
     if "--disk-status" in sys.argv:
         asyncio.run(_disk_status())
+        return
+
+    if "--ram-status" in sys.argv:
+        asyncio.run(_ram_status())
         return
 
     if "--host-profile" in sys.argv:
@@ -176,6 +181,21 @@ async def _disk_status() -> None:
         "tier": tier,
         "snapshots": snapshots,
     }))
+
+
+async def _ram_status() -> None:
+    """Print the guardian's RAM view as JSON (read-only).
+
+    Genesis's programmatic window into what the guardian's out-of-band RAM
+    alert sees — both axes (container cgroup + host-VM) and the worst-of tier.
+    Consumed by the `ram-status` gateway verb.
+    """
+    import json
+
+    from genesis.guardian.config import load_config
+    from genesis.guardian.memory_watch import memory_status_snapshot
+
+    print(json.dumps(await memory_status_snapshot(load_config())))
 
 
 async def _host_profile() -> int:

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -378,6 +378,12 @@ async def run_check(config: GuardianConfig | None = None) -> None:
             config, dispatcher,
             genesis_down=(sm.current_state == GuardianState.CONFIRMED_DEAD),
         )
+        # Guardian-side RAM tiered alert (E-rest PR-E1). The container's own RAM
+        # alert (infra:container_memory_high) dies exactly when it thrashes; the
+        # guardian pages out-of-band over two axes (container cgroup + host-VM),
+        # worst-of. Host /proc read + one best-effort incus-exec — the host axis
+        # still fires when the container read stalls.
+        await _check_memory_and_alert(config, dispatcher)
         # Credential-file integrity backstop. The container self-heals first; the
         # guardian WARNs on first sight and steps in only after the grace window —
         # covering the window a degraded/dead server's awareness loop can't.
@@ -606,6 +612,20 @@ async def _check_repo_bundle_and_alert(
         await check_repo_bundle_and_alert(config, dispatcher)
     except Exception:
         logger.warning("repo-bundle watch failed", exc_info=True)
+
+
+async def _check_memory_and_alert(
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
+) -> None:
+    """Guardian-side RAM tiered alert (delegates to memory_watch). Out-of-band
+    backstop for the container's own RAM alert, which dies under the exact
+    pressure it detects. Never raises into the tick."""
+    try:
+        from genesis.guardian.memory_watch import check_memory_and_alert
+        await check_memory_and_alert(config, dispatcher)
+    except Exception:
+        logger.warning("RAM watch failed", exc_info=True)
 
 
 async def _check_storage_pool_and_alert(

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -171,6 +171,34 @@ class StoragePoolConfig:
 
 
 @dataclass
+class MemoryTiersConfig:
+    """Host-side RAM monitoring thresholds (container cgroup + host-VM).
+
+    Complements the container's own `infra:container_memory_high` alert, which
+    dies exactly when the container thrashes/OOMs. The guardian — outside the
+    blast radius — pages out-of-band. TWO axes, worst-of:
+
+    - Container RAM: anon+kernel % of the container's memory.max (via incus-exec;
+      best-effort — the exec can itself stall under severe pressure).
+    - Host-VM RAM: 100 - MemAvailable/MemTotal on the guardian's own host (no
+      incus-exec -> the RELIABLE signal when the container read stalls).
+    """
+
+    enabled: bool = True
+    # Container cgroup anon+kernel % of memory.max.
+    container_warn_pct: float = 75.0
+    container_high_pct: float = 85.0
+    container_crit_pct: float = 92.0
+    # Host-VM used % (100 - MemAvailable/MemTotal). Host runs more services than
+    # the container cgroup and idles higher, so its tiers sit a little higher.
+    host_warn_pct: float = 80.0
+    host_high_pct: float = 88.0
+    host_crit_pct: float = 94.0
+    # Re-alert cadence while a tier is sustained. Tier increases alert immediately.
+    realert_hours: float = 6.0
+
+
+@dataclass
 class CredIntegrityConfig:
     """Guardian-side credential-file integrity watch (G.1 escalation ladder).
 
@@ -303,6 +331,7 @@ class GuardianConfig:
     snapshots: SnapshotConfig = field(default_factory=SnapshotConfig)
     recovery: RecoveryConfig = field(default_factory=RecoveryConfig)
     storage_pool: StoragePoolConfig = field(default_factory=StoragePoolConfig)
+    memory_tiers: MemoryTiersConfig = field(default_factory=MemoryTiersConfig)
     cred_integrity: CredIntegrityConfig = field(default_factory=CredIntegrityConfig)
     git_health: GitHealthConfig = field(default_factory=GitHealthConfig)
     repo_bundle: RepoBundleConfig = field(default_factory=RepoBundleConfig)
@@ -567,6 +596,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         snapshots=_build_sub(SnapshotConfig, raw, "snapshots"),
         recovery=_build_sub(RecoveryConfig, raw, "recovery"),
         storage_pool=_build_sub(StoragePoolConfig, raw, "storage_pool"),
+        memory_tiers=_build_sub(MemoryTiersConfig, raw, "memory_tiers"),
         cred_integrity=_build_sub(CredIntegrityConfig, raw, "cred_integrity"),
         git_health=_build_sub(GitHealthConfig, raw, "git_health"),
         repo_bundle=_build_sub(RepoBundleConfig, raw, "repo_bundle"),

--- a/src/genesis/guardian/health_signals.py
+++ b/src/genesis/guardian/health_signals.py
@@ -455,56 +455,64 @@ async def check_tick_regularity(config: GuardianConfig) -> SuspiciousResult:
         )
 
 
-async def check_memory_pressure(config: GuardianConfig) -> SuspiciousResult:
-    """Check container memory usage via cgroup v2.
+async def measure_container_mem_pct(config: GuardianConfig) -> tuple[float | None, str]:
+    """Measure container anon+kernel memory as a % of the cgroup memory.max.
 
-    Uses anon+kernel from memory.stat (non-reclaimable) for threshold
-    decisions instead of memory.current (which includes reclaimable page cache).
+    Uses anon+kernel from memory.stat (non-reclaimable) rather than
+    memory.current (which includes reclaimable page cache). Returns
+    ``(pct, detail)``; ``pct`` is None when the value is not measurable
+    (incus-exec failed, or no memory limit is set) — callers must treat None as
+    "no signal", never as 0/healthy. Shared by the suspicious-check
+    (:func:`check_memory_pressure`) and the guardian's tiered RAM alert
+    (:mod:`genesis.guardian.memory_watch`), so the measurement has one home.
+
+    May raise on a malformed memory.max (non-int, non-"max"); callers wrap it.
+    """
+    # Read memory.stat for anon+kernel (non-reclaimable memory)
+    rc, stdout, stderr = await _run_subprocess(
+        "incus", "exec", config.container_name, "--",
+        "cat", "/sys/fs/cgroup/memory.stat",
+        timeout=config.probes.probe_timeout_s,
+    )
+    if rc != 0:
+        return None, f"cgroup stat read failed: {stderr[:200]}"
+    # Parse anon and kernel values from memory.stat
+    stats: dict[str, int] = {}
+    for line in stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[0] in ("anon", "kernel"):
+            stats[parts[0]] = int(parts[1])
+    anon_kernel = stats.get("anon", 0) + stats.get("kernel", 0)
+
+    rc2, stdout2, stderr2 = await _run_subprocess(
+        "incus", "exec", config.container_name, "--",
+        "cat", "/sys/fs/cgroup/memory.max",
+        timeout=config.probes.probe_timeout_s,
+    )
+    if rc2 != 0:
+        return None, f"cgroup max read failed: {stderr2[:200]}"
+
+    max_mem = stdout2.strip()
+    if max_mem == "max":
+        return None, "no memory limit set"
+
+    max_bytes = int(max_mem)
+    pct = (anon_kernel / max_bytes) * 100 if max_bytes > 0 else 0.0
+    detail = f"{pct:.1f}% anon+kernel ({anon_kernel // (1024*1024)}M / {max_bytes // (1024*1024)}M)"
+    return pct, detail
+
+
+async def check_memory_pressure(config: GuardianConfig) -> SuspiciousResult:
+    """Check container memory usage via cgroup v2 ('healthy but suspicious').
+
+    Thin wrapper over :func:`measure_container_mem_pct` — an unmeasurable value
+    (None) is reported ok=True (no signal is not a warning).
     """
     name = "memory_pressure"
     t0 = datetime.now(UTC)
     try:
-        # Read memory.stat for anon+kernel (non-reclaimable memory)
-        rc, stdout, stderr = await _run_subprocess(
-            "incus", "exec", config.container_name, "--",
-            "cat", "/sys/fs/cgroup/memory.stat",
-            timeout=config.probes.probe_timeout_s,
-        )
-        if rc != 0:
-            return SuspiciousResult(
-                name=name, ok=True, detail=f"cgroup stat read failed: {stderr[:200]}",
-                collected_at=t0.isoformat(),
-            )
-        # Parse anon and kernel values from memory.stat
-        stats: dict[str, int] = {}
-        for line in stdout.splitlines():
-            parts = line.split()
-            if len(parts) == 2 and parts[0] in ("anon", "kernel"):
-                stats[parts[0]] = int(parts[1])
-        anon_kernel = stats.get("anon", 0) + stats.get("kernel", 0)
-
-        rc2, stdout2, stderr2 = await _run_subprocess(
-            "incus", "exec", config.container_name, "--",
-            "cat", "/sys/fs/cgroup/memory.max",
-            timeout=config.probes.probe_timeout_s,
-        )
-        if rc2 != 0:
-            return SuspiciousResult(
-                name=name, ok=True, detail=f"cgroup max read failed: {stderr2[:200]}",
-                collected_at=t0.isoformat(),
-            )
-
-        max_mem = stdout2.strip()
-        if max_mem == "max":
-            return SuspiciousResult(
-                name=name, ok=True, detail="no memory limit set",
-                collected_at=t0.isoformat(),
-            )
-
-        max_bytes = int(max_mem)
-        pct = (anon_kernel / max_bytes) * 100 if max_bytes > 0 else 0
-        ok = pct < config.suspicious.memory_warning_pct
-        detail = f"{pct:.1f}% anon+kernel ({anon_kernel // (1024*1024)}M / {max_bytes // (1024*1024)}M)"
+        pct, detail = await measure_container_mem_pct(config)
+        ok = pct is None or pct < config.suspicious.memory_warning_pct
         return SuspiciousResult(
             name=name, ok=ok, detail=detail, collected_at=t0.isoformat(),
         )

--- a/src/genesis/guardian/memory_watch.py
+++ b/src/genesis/guardian/memory_watch.py
@@ -1,0 +1,213 @@
+"""Guardian-side RAM tiered alerting — HOST-SIDE.
+
+Backstops a gap the disk-pool monitor already closed for storage: the ONLY
+whole-RAM Telegram alert today is container-side (`infra:container_memory_high`
+in the health snapshot), and that path dies exactly when the container
+thrashes/OOMs — the moment it matters most. The guardian runs OUTSIDE the
+container blast radius, so it can page out-of-band.
+
+Two axes, worst-of (mirrors the disk pool's data%/metadata%):
+
+- **Container RAM** — anon+kernel vs the container's cgroup ``memory.max``, read
+  via ``incus exec``. Best-effort: that exec can itself stall under severe
+  memory pressure, so this axis may go blind precisely when it matters.
+- **Host-VM RAM** — ``100 − MemAvailable/MemTotal`` from the guardian's OWN
+  ``/proc/meminfo``. Needs NO incus-exec → the RELIABLE signal in a thrash. The
+  worst-of means the host axis still fires the page when the container read
+  stalls.
+
+Design mirrors :mod:`genesis.guardian.pool`: the tier + hysteresis logic is the
+same pure, unit-tested code (``_tier_for``/``decide_alert``); the measurement
+glue is kept thin around it. Any measurement failure yields ``None`` (no
+signal), never a false ``0%``/healthy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from genesis.guardian.alert.base import Alert, AlertSeverity
+from genesis.guardian.alert.dispatcher import AlertDispatcher
+from genesis.guardian.config import GuardianConfig, MemoryTiersConfig
+from genesis.guardian.health_signals import measure_container_mem_pct
+from genesis.guardian.host_profile import _read_meminfo
+from genesis.guardian.pool import (
+    _TIER_RANK,
+    TIER_CRIT,
+    TIER_HIGH,
+    TIER_OK,
+    TIER_WARN,
+    _tier_for,
+    decide_alert,
+)
+
+logger = logging.getLogger(__name__)
+
+# WARN/HIGH are degradation (WARNING); CRIT is genuine pressure (CRITICAL).
+# Mirrors _POOL_TIER_SEVERITY so RAM and disk alerts read consistently.
+_MEM_TIER_SEVERITY = {
+    TIER_WARN: AlertSeverity.WARNING,
+    TIER_HIGH: AlertSeverity.WARNING,
+    TIER_CRIT: AlertSeverity.CRITICAL,
+}
+
+
+def measure_host_mem_pct() -> tuple[float | None, str]:
+    """Host-VM RAM used% (``100 − MemAvailable/MemTotal``) from /proc/meminfo.
+
+    The RELIABLE axis — read on the guardian's own host, no incus-exec — so it
+    still fires when the container is thrashing so hard that exec stalls.
+    Returns ``(pct, detail)``; ``pct`` is None if meminfo is unreadable (treat
+    as no signal, never 0/healthy). Reuses host_profile's canonical reader.
+    """
+    mem = _read_meminfo()
+    total = mem.get("MemTotal")
+    avail = mem.get("MemAvailable")
+    if not total or avail is None:
+        return None, "host meminfo unreadable"
+    used_pct = 100.0 * (1.0 - avail / total)
+    used_mb = (total - avail) // 1024
+    total_mb = total // 1024
+    return used_pct, f"{used_pct:.1f}% used ({used_mb}M / {total_mb}M)"
+
+
+def memory_worst_tier(
+    container_pct: float | None,
+    host_pct: float | None,
+    cfg: MemoryTiersConfig,
+) -> str:
+    """Highest tier across the container and host-VM RAM axes.
+
+    ``_tier_for`` maps a None pct to TIER_OK, so a blind axis never contributes;
+    the caller separately skips alerting when BOTH axes are None (no signal).
+    """
+    c = _tier_for(
+        container_pct,
+        cfg.container_warn_pct,
+        cfg.container_high_pct,
+        cfg.container_crit_pct,
+    )
+    h = _tier_for(
+        host_pct,
+        cfg.host_warn_pct,
+        cfg.host_high_pct,
+        cfg.host_crit_pct,
+    )
+    return c if _TIER_RANK[c] >= _TIER_RANK[h] else h
+
+
+async def _measure_axes(config: GuardianConfig) -> tuple[float | None, str, float | None, str]:
+    """Measure both RAM axes defensively. Never raises."""
+    container_pct: float | None = None
+    c_detail = "not measured"
+    host_pct: float | None = None
+    h_detail = "not measured"
+    try:
+        container_pct, c_detail = await measure_container_mem_pct(config)
+    except Exception:
+        logger.warning("container memory measure failed", exc_info=True)
+        c_detail = "container measure error"
+    try:
+        host_pct, h_detail = measure_host_mem_pct()
+    except Exception:
+        logger.warning("host memory measure failed", exc_info=True)
+        h_detail = "host measure error"
+    return container_pct, c_detail, host_pct, h_detail
+
+
+async def memory_status_snapshot(config: GuardianConfig) -> dict:
+    """Read-only RAM view for the `ram-status` gateway verb (both axes + tier)."""
+    cfg = config.memory_tiers
+    container_pct, c_detail, host_pct, h_detail = await _measure_axes(config)
+    tier = memory_worst_tier(container_pct, host_pct, cfg)
+    return {
+        "ok": True,
+        "action": "ram-status",
+        "enabled": cfg.enabled,
+        "tier": tier,
+        "container": {"used_pct": container_pct, "detail": c_detail},
+        "host": {"used_pct": host_pct, "detail": h_detail},
+    }
+
+
+async def check_memory_and_alert(
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
+) -> None:
+    """Measure container + host-VM RAM and emit tiered alerts with hysteresis.
+
+    State (last-alerted tier + timestamp) persists in the guardian state dir so
+    hysteresis survives across the stateless per-tick invocations. Alerts go
+    through the guardian's own dispatcher (host Telegram channel), which
+    survives a thrashing/dead container — exactly when this matters most.
+    Near-verbatim clone of check._check_storage_pool_and_alert.
+    """
+    cfg = config.memory_tiers
+    if not cfg.enabled:
+        return
+
+    container_pct, c_detail, host_pct, h_detail = await _measure_axes(config)
+    if container_pct is None and host_pct is None:
+        # No signal on EITHER axis — do not alert and do not record OK (which
+        # would falsely clear a prior alert). Mirrors pool's detected=False.
+        logger.debug("RAM not measurable (both axes): c=%s h=%s", c_detail, h_detail)
+        return
+
+    tier = memory_worst_tier(container_pct, host_pct, cfg)
+
+    state_file = config.state_path / "memory_alert_state.json"
+    last_tier = TIER_OK
+    last_alert_at: datetime | None = None
+    if state_file.exists():
+        try:
+            data = json.loads(state_file.read_text())
+            last_tier = data.get("tier", TIER_OK)
+            raw_at = data.get("last_alert_at")
+            last_alert_at = datetime.fromisoformat(raw_at) if raw_at else None
+        except (ValueError, OSError):
+            pass
+
+    now = datetime.now(UTC)
+    decision = decide_alert(tier, last_tier, last_alert_at, now, cfg.realert_hours)
+
+    if decision.should_alert:
+        if decision.is_resolution:
+            severity = AlertSeverity.INFO
+            title = "RAM pressure recovered"
+        else:
+            severity = _MEM_TIER_SEVERITY.get(tier, AlertSeverity.WARNING)
+            title = f"RAM {tier.upper()}"
+        parts = []
+        if container_pct is not None:
+            parts.append(f"container {container_pct:.0f}%")
+        if host_pct is not None:
+            parts.append(f"host {host_pct:.0f}%")
+        body = f"{decision.reason}. " + ", ".join(parts)
+        if tier == TIER_CRIT:
+            body += (
+                "\nMemory near exhaustion — the container's own alert path may be "
+                "unreliable under this pressure; free memory or grow limits."
+            )
+        try:
+            await dispatcher.send(Alert(severity=severity, title=title, body=body))
+        except Exception:
+            logger.warning("failed to send RAM alert", exc_info=True)
+
+    # Persist tier every cycle (even without an alert) so a later rise from a
+    # silently-decreased tier re-alerts correctly. Only advance the alert
+    # timestamp when we actually alerted.
+    new_alert_at = now if decision.should_alert else last_alert_at
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(
+            json.dumps(
+                {
+                    "tier": tier,
+                    "last_alert_at": new_alert_at.isoformat() if new_alert_at else None,
+                }
+            )
+        )
+    except OSError:
+        logger.warning("failed to persist RAM alert state", exc_info=True)

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -301,6 +301,17 @@ class GuardianRemote:
         ok, out = await self._ssh_command("bundle-status", timeout=_STATUS_TIMEOUT)
         return self._as_json(ok, out, "bundle-status")
 
+    async def ram_status(self) -> dict:
+        """Read-only RAM view (E-rest PR-E1) — what the guardian's out-of-band
+        RAM alert sees: container cgroup + host-VM axes and the worst-of tier.
+
+        Returns the gateway's JSON verbatim on success. A pre-redeploy gateway
+        answers ``denied`` (its unknown-verb default) -> ``{"ok": False,
+        "error": "denied"}``. No approval, no mutation.
+        """
+        ok, out = await self._ssh_command("ram-status", timeout=_STATUS_TIMEOUT)
+        return self._as_json(ok, out, "ram-status")
+
     async def request_grow_disk(self, disk: str, add_gib: int) -> dict:
         """EXECUTE a pre-approved VM disk grow + absorb into the thin pool."""
         if not _DISK_RE.fullmatch(disk):

--- a/tests/test_guardian/test_memory_alert.py
+++ b/tests/test_guardian/test_memory_alert.py
@@ -1,0 +1,226 @@
+"""Tests for the guardian-side RAM tiered alert (E-rest PR-E1, memory_watch.py).
+
+Covers the pure two-axis worst-of tier logic, the host-VM measurement, and the
+hysteresis alert flow (tier rise WARN→HIGH→CRIT, recovery INFO, sustained
+realert, disabled silent, both-axes-blind no-op, host-only axis) using a real
+GuardianConfig + a capturing dispatcher. Mirrors test_bundle_watch.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from genesis.guardian import memory_watch
+from genesis.guardian.alert.base import AlertSeverity
+from genesis.guardian.config import GuardianConfig, MemoryTiersConfig
+from genesis.guardian.memory_watch import (
+    check_memory_and_alert,
+    measure_host_mem_pct,
+    memory_status_snapshot,
+    memory_worst_tier,
+)
+
+
+class _FakeDispatcher:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, alert):
+        self.sent.append(alert)
+        return True
+
+
+def _config(tmp_path: Path, **cfg_kw) -> GuardianConfig:
+    config = GuardianConfig(state_dir=str(tmp_path))
+    config.memory_tiers = MemoryTiersConfig(**cfg_kw)
+    return config
+
+
+def _patch_axes(container_pct, host_pct):
+    """Patch both RAM measurement sources on the memory_watch module."""
+
+    async def _container(_config):
+        return container_pct, f"container {container_pct}"
+
+    def _host():
+        return host_pct, f"host {host_pct}"
+
+    return (
+        patch.object(memory_watch, "measure_container_mem_pct", _container),
+        patch.object(memory_watch, "measure_host_mem_pct", _host),
+    )
+
+
+# ── pure tier logic ─────────────────────────────────────────────────────────
+
+
+def test_worst_tier_matrix():
+    cfg = MemoryTiersConfig()
+    assert memory_worst_tier(None, None, cfg) == "ok"
+    assert memory_worst_tier(10.0, 10.0, cfg) == "ok"
+    assert memory_worst_tier(78.0, 10.0, cfg) == "warn"  # container 78 ≥ 75
+    assert memory_worst_tier(88.0, 10.0, cfg) == "high"  # container 88 ≥ 85
+    assert memory_worst_tier(95.0, 10.0, cfg) == "crit"  # container 95 ≥ 92
+    # host axis has higher thresholds (80/88/94)
+    assert memory_worst_tier(10.0, 82.0, cfg) == "warn"
+    assert memory_worst_tier(10.0, 90.0, cfg) == "high"
+    assert memory_worst_tier(10.0, 96.0, cfg) == "crit"
+    # worst-of: the higher tier wins across axes
+    assert memory_worst_tier(88.0, 82.0, cfg) == "high"  # container high beats host warn
+    # a blind axis (None) never contributes
+    assert memory_worst_tier(None, 82.0, cfg) == "warn"
+    assert memory_worst_tier(95.0, None, cfg) == "crit"
+
+
+def test_measure_host_mem_pct():
+    # 20% available → 80% used
+    with patch.object(
+        memory_watch,
+        "_read_meminfo",
+        return_value={"MemTotal": 20 * 1024**2, "MemAvailable": 4 * 1024**2},
+    ):
+        pct, detail = measure_host_mem_pct()
+    assert abs(pct - 80.0) < 0.01
+    assert "80.0%" in detail
+
+
+def test_measure_host_mem_pct_unreadable():
+    with patch.object(memory_watch, "_read_meminfo", return_value={}):
+        pct, detail = measure_host_mem_pct()
+    assert pct is None
+    assert "unreadable" in detail
+
+
+# ── hysteresis alert flow ───────────────────────────────────────────────────
+
+
+async def test_tier_rise_alerts_each_increase(tmp_path):
+    config = _config(tmp_path)
+    disp = _FakeDispatcher()
+    p_c, p_h = _patch_axes(78.0, 10.0)  # warn
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    assert len(disp.sent) == 1
+    assert disp.sent[0].severity == AlertSeverity.WARNING
+    assert "RAM WARN" in disp.sent[0].title
+
+    p_c, p_h = _patch_axes(95.0, 10.0)  # crit — an increase, alerts immediately
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    assert len(disp.sent) == 2
+    assert disp.sent[1].severity == AlertSeverity.CRITICAL
+    assert "RAM CRIT" in disp.sent[1].title
+    assert "container 95%" in disp.sent[1].body
+
+
+async def test_recovery_emits_info(tmp_path):
+    config = _config(tmp_path)
+    disp = _FakeDispatcher()
+    p_c, p_h = _patch_axes(95.0, 10.0)  # crit
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    p_c, p_h = _patch_axes(10.0, 10.0)  # back to ok
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    assert len(disp.sent) == 2
+    assert disp.sent[1].severity == AlertSeverity.INFO
+    assert "recovered" in disp.sent[1].title.lower()
+
+
+async def test_sustained_tier_damps_then_realerts(tmp_path):
+    config = _config(tmp_path, realert_hours=6.0)
+    disp = _FakeDispatcher()
+    p_c, p_h = _patch_axes(88.0, 10.0)  # high
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)  # alert 1
+        await check_memory_and_alert(config, disp)  # same tier, within window → damped
+    assert len(disp.sent) == 1
+
+    # backdate the persisted alert timestamp past the realert window
+    state_file = config.state_path / "memory_alert_state.json"
+    data = json.loads(state_file.read_text())
+    data["last_alert_at"] = (datetime.now(UTC) - timedelta(hours=7)).isoformat()
+    state_file.write_text(json.dumps(data))
+
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)  # sustained past window → realert
+    assert len(disp.sent) == 2
+    assert disp.sent[1].severity == AlertSeverity.WARNING  # HIGH → WARNING severity
+
+
+async def test_disabled_is_silent(tmp_path):
+    config = _config(tmp_path, enabled=False)
+    disp = _FakeDispatcher()
+    p_c, p_h = _patch_axes(99.0, 99.0)
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    assert disp.sent == []
+
+
+async def test_both_axes_blind_no_alert_no_state(tmp_path):
+    config = _config(tmp_path)
+    disp = _FakeDispatcher()
+    p_c, p_h = _patch_axes(None, None)
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    assert disp.sent == []
+    # must NOT record an OK tier (which would falsely clear a later alert)
+    assert not (config.state_path / "memory_alert_state.json").exists()
+
+
+async def test_host_only_axis_fires_when_container_blind(tmp_path):
+    """The reliability point: container read stalls (None) but host axis pages."""
+    config = _config(tmp_path)
+    disp = _FakeDispatcher()
+    p_c, p_h = _patch_axes(None, 96.0)  # host crit
+    with p_c, p_h:
+        await check_memory_and_alert(config, disp)
+    assert len(disp.sent) == 1
+    assert disp.sent[0].severity == AlertSeverity.CRITICAL
+    # the metric line (first line) carries only the host axis; the blind
+    # container axis is omitted (the CRIT advisory sentence below may still
+    # mention "container", so assert on the metric line specifically).
+    metric_line = disp.sent[0].body.splitlines()[0]
+    assert "host 96%" in metric_line
+    assert "container" not in metric_line
+
+
+async def test_status_snapshot_shape(tmp_path):
+    config = _config(tmp_path)
+    p_c, p_h = _patch_axes(50.0, 60.0)
+    with p_c, p_h:
+        snap = await memory_status_snapshot(config)
+    assert snap["ok"] is True
+    assert snap["action"] == "ram-status"
+    assert snap["enabled"] is True
+    assert snap["tier"] == "ok"
+    assert snap["container"]["used_pct"] == 50.0
+    assert snap["host"]["used_pct"] == 60.0
+
+
+# ── host-safe import isolation (F.4 minimal-venv lesson) ─────────────────────
+
+
+def test_memory_watch_imports_host_safe():
+    """The guardian runs a minimal venv WITHOUT aiohttp. memory_watch executes
+    host-side, so importing it must NOT pull genesis.observability / aiohttp.
+    Runs in a fresh interpreter to assert real import isolation."""
+    code = (
+        "import sys; import genesis.guardian.memory_watch;"
+        "assert 'aiohttp' not in sys.modules, 'aiohttp leaked';"
+        "assert 'genesis.observability' not in sys.modules, 'observability leaked';"
+        "print('ok')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"import isolation failed: {result.stderr}"
+    assert "ok" in result.stdout

--- a/tests/test_scripts/test_gateway_ram_status.py
+++ b/tests/test_scripts/test_gateway_ram_status.py
@@ -1,0 +1,79 @@
+"""Tests for the guardian-gateway.sh ``ram-status`` read-only verb (E-rest PR-E1).
+
+Runs the REAL gateway script against a throwaway ``$HOME`` install dir, focusing
+on the shell-specific guard branches where gateway bugs hide: the venv-missing
+guard, the src-skew guard (must NOT fall through to a full ``run_check`` recovery
+cycle on a stale gateway), and correct dispatch to ``-m genesis.guardian
+--ram-status`` when everything is present. The verb's JSON body is covered by
+``test_memory_alert.test_status_snapshot_shape``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+
+def _run(home: Path, verb: str):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["SSH_ORIGINAL_COMMAND"] = verb
+    return subprocess.run(
+        ["bash", str(_GATEWAY)],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _install(home: Path) -> Path:
+    d = home / ".local" / "share" / "genesis-guardian"
+    (d / "config").mkdir(parents=True)
+    (d / "config" / "guardian.yaml").write_text("container_name: genesis\n")
+    return d
+
+
+def _stub_python(install: Path, body: str) -> Path:
+    py = install / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_text(body)
+    py.chmod(0o755)
+    return py
+
+
+def test_ram_status_no_venv(tmp_path):
+    _install(tmp_path)  # no .venv/bin/python
+    proc = _run(tmp_path, "ram-status")
+    assert proc.returncode == 1
+    assert "guardian venv not found" in proc.stderr
+
+
+def test_ram_status_skew_guard_blocks_fallthrough(tmp_path):
+    """A gateway older than the src (no memory_watch.py) must return a clean error
+    — NEVER fall through main()'s if-chain into run_check (a full recovery cycle
+    on a routine read-only poll)."""
+    install = _install(tmp_path)
+    _stub_python(install, "#!/bin/sh\necho SHOULD_NOT_RUN\n")  # would print if invoked
+    # memory_watch.py deliberately absent.
+    proc = _run(tmp_path, "ram-status")
+    assert proc.returncode == 1
+    assert "predates ram-status" in proc.stderr
+    assert "SHOULD_NOT_RUN" not in proc.stdout
+
+
+def test_ram_status_dispatches_when_present(tmp_path):
+    """venv + memory_watch.py present → the verb invokes
+    `-m genesis.guardian --ram-status` (proven by a stub python echoing argv)."""
+    install = _install(tmp_path)
+    _stub_python(install, '#!/bin/sh\necho "ARGS: $*"\n')
+    mod = install / "src" / "genesis" / "guardian"
+    mod.mkdir(parents=True)
+    (mod / "memory_watch.py").write_text("# stub for the skew guard\n")
+
+    proc = _run(tmp_path, "ram-status")
+    assert proc.returncode == 0, proc.stderr
+    assert "--ram-status" in proc.stdout


### PR DESCRIPTION
## What & why

The only whole-RAM Telegram alert today is **container-side** (`infra:container_memory_high` in the health snapshot) — which dies exactly when the container thrashes/OOMs, the moment it matters most. The host-VM **guardian** (outside the container blast radius) already *measured* container RAM but never dispatched an alert. This wires it into the same tiered, hysteresis-damped alert path the disk pool already uses, so the guardian pages **out-of-band**.

## Design

Two axes, **worst-of** (mirrors the disk pool's data%/metadata%):
- **Container RAM** — anon+kernel % of the container's cgroup `memory.max`, via `incus exec`. Best-effort: that exec can itself stall under severe memory pressure.
- **Host-VM RAM** — `100 − MemAvailable/MemTotal` from the guardian's own `/proc/meminfo`. **No incus-exec → the reliable signal in a thrash.** The worst-of means the host axis still fires the page when the container read stalls.

Reuses `pool.py`'s pure `_tier_for`/`decide_alert`/`AlertDecision` hysteresis (verified pure by reading the source), a `memory_alert_state.json` for realert damping, and the guardian's own Telegram dispatcher.

## Changes
- **NEW** `guardian/memory_watch.py` — measurement + worst-of tier + alert orchestration
- `config.py` — `MemoryTiersConfig` (container 75/85/92, host 80/88/94, realert 6h)
- `health_signals.py` — extract `measure_container_mem_pct` (shared/DRY; `check_memory_pressure` behaviour preserved)
- `check.py` — `_check_memory_and_alert` wired after the storage-pool check (never-raise)
- gateway `ram-status` read-only verb (skew-guarded) + `remote.ram_status()` + `--ram-status`
- `config/guardian.yaml` `memory_tiers` section; `docs/architecture/CURRENT.md` guardian entry

## Tests / verification
- `test_memory_alert.py` — tier matrix, hysteresis (rise/recover/sustained-realert), disabled-silent, both-axes-blind no-op, **host-only-axis-fires-when-container-blind**, snapshot shape, host-safe import isolation (subprocess asserts no aiohttp — F.4 minimal-venv lesson)
- `test_gateway_ram_status.py` — venv-missing, skew-guard-blocks-fallthrough, dispatch-when-present
- 70 targeted tests green; live read-path smoke against real `/proc/meminfo`; ruff + `bash -n` clean.

## Deploy note
Touches `src/genesis/guardian/` + `scripts/guardian-gateway.sh` → host-guardian deploy via `scripts/update.sh` after merge (host-deploy gate). True both-axes host E2E runs post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)