### PR TITLE
docs(autonomy): mark autonomous-CLI approval gate mandatory & non-negotiable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,14 @@ When a user shares a file path or URL in conversation:
 - **Ego** (`src/genesis/ego/`) — Live. Two egos: user (CEO/Opus) and
   Genesis (COO/Sonnet). Review cadence manager and budget controls
   before adding call sites.
+- **Autonomous-CLI approval gate is MANDATORY & non-negotiable.** The gate
+  (`autonomy/cli_policy.py` `manual_approval_required` +
+  `AutonomousCliApprovalGate`) requires explicit user approval before ANY
+  autonomous background Claude Code session runs. Never remove, bypass,
+  auto-approve, or default-off it — and never *propose* doing so. Approval
+  friction is a lifecycle-hygiene bug to fix around the gate (re-ask cadence,
+  key stability), never a reason to weaken it. Same for ego-proposal approvals.
+  Standing user directive.
 - **GROUNDWORK tags** — `# GROUNDWORK(id): why` is intentional. Never delete.
 - **IntervalTrigger** — Resets on restart. Use `CronTrigger` for intervals >1h.
 

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -3,6 +3,14 @@
 Manual-approval state machine: request → pending → approved/rejected.
 Handles Telegram inline-button approvals, quote-reply resolution,
 batch-approve, and re-ask cadence.
+
+MANDATORY SUBSYSTEM — NON-NEGOTIABLE. This gate is the hard trust boundary that
+requires explicit user approval before any autonomous background Claude Code
+session runs. It must never be removed, bypassed, auto-approved, or
+default-disabled — see the standing directive on ``AutonomousCliPolicy``
+(cli_policy.py), CLAUDE.md ("## Traps"), and CC memory ``cli_gate_not_negotiable``.
+Fix approval friction AROUND the gate (invalidation lifecycle, re-ask cadence,
+approval-key stability), never by loosening it.
 """
 
 from __future__ import annotations
@@ -203,6 +211,11 @@ class AutonomousCliApprovalGate:
         """
         policy = self._policy()
         if not policy.manual_approval_required:
+            # NON-NEGOTIABLE GATE: reachable ONLY when a config/test explicitly
+            # sets manual_approval_required=False. The shipped default is True
+            # and must stay True — never flip the default, and never add a code
+            # path that reaches this branch implicitly. See AutonomousCliPolicy
+            # (cli_policy.py) and CC memory `cli_gate_not_negotiable`.
             return ("approved", None, "manual approval disabled by config")
 
         # Serialize per (subsystem, policy_id) — prevents duplicate rows

--- a/src/genesis/autonomy/cli_policy.py
+++ b/src/genesis/autonomy/cli_policy.py
@@ -41,8 +41,31 @@ def _env_int(name: str, default: int) -> int:
 
 @dataclass(frozen=True)
 class AutonomousCliPolicy:
+    # ══════════════════════════════════════════════════════════════════════
+    # MANDATORY SUBSYSTEM — NON-NEGOTIABLE. DO NOT WEAKEN OR PROPOSE REMOVING.
+    #
+    # The autonomous-CLI approval gate (`manual_approval_required` +
+    # `AutonomousCliApprovalGate`) is a hard trust boundary: EVERY autonomous
+    # background Claude Code session must be rooted in an explicit user
+    # approval. This is the architectural guarantee behind earned autonomy —
+    # "user-dispatched and user-approved" is the definition of sanctioned
+    # background work.
+    #
+    # `manual_approval_required` defaults True and must STAY True. Never
+    # remove, bypass, auto-approve, default-off, or "temporarily" disable this
+    # gate — not as a feature, not to reduce approval churn, not as defence-
+    # in-depth cleanup. Approval-friction complaints (churn, re-ask storms,
+    # invalidation, key stability) are lifecycle-hygiene bugs to fix AROUND the
+    # gate, never an argument against the gate itself. A chain rooted in one
+    # explicit user approval is fine (e.g. /task submission covers its executor
+    # steps); the root approval must always exist and be the user's.
+    #
+    # Standing user directive (2026-07-07, reaffirmed 2026-07-15), not a
+    # reviewable trade-off. See CLAUDE.md ("## Traps") and CC memory
+    # `cli_gate_not_negotiable`.
+    # ══════════════════════════════════════════════════════════════════════
     autonomous_cli_fallback_enabled: bool = True
-    manual_approval_required: bool = True
+    manual_approval_required: bool = True  # MANDATORY — must stay True (see above)
     reask_interval_hours: int = 24
     approval_channel: str = "telegram"
     shared_export_enabled: bool = True

--- a/src/genesis/autonomy/dispatch_router.py
+++ b/src/genesis/autonomy/dispatch_router.py
@@ -101,7 +101,13 @@ class AutonomousDispatchRouter:
         dispatch_mode = self._resolve_dispatch_mode(request)
 
         # CLI-only: skip the API chain entirely and go straight to the
-        # approval gate + CLI fallback.
+        # approval gate + CLI fallback. "Forced to CLI" skips only the API
+        # provider chain — NOT approval: _cli_fallback_decision still runs the
+        # MANDATORY autonomous-CLI approval gate (manual_approval_required). The
+        # per-tick approvals this produces for CC-dispatched cognition (ego
+        # cycles, reflection) are the gate working as designed, not friction to
+        # remove — reduce their volume via approval-key stability / re-ask
+        # cadence only. See cli_policy.py and CC memory `cli_gate_not_negotiable`.
         if dispatch_mode == "cli":
             if not request.cli_fallback_allowed:
                 return AutonomousDispatchDecision(


### PR DESCRIPTION
## What

Adds authoritative **MANDATORY / non-negotiable** markers at every touchpoint of the autonomous-CLI approval gate, so it can never be mistaken for a reviewable design trade-off.

The gate (`autonomy/cli_policy.py` `manual_approval_required` + `AutonomousCliApprovalGate`) requires explicit user approval before **any** autonomous background Claude Code session runs. It is a hard trust boundary and a standing user directive — never remove, bypass, auto-approve, default-off, or *propose* removing it. Approval friction is a lifecycle-hygiene bug to fix *around* the gate (re-ask cadence, approval-key stability), never a reason to weaken it. The ego-proposal approval gate carries the same non-negotiable status.

## Touchpoints annotated
- `cli_policy.py` — MANDATORY block on `AutonomousCliPolicy` + inline note on the flag
- `approval_gate.py` — header docstring + the `manual_approval_required=False` config-bypass branch
- `dispatch_router.py` — the `dispatch=cli` branch (clarifies it skips the API chain, **not** approval)
- `CLAUDE.md` — a `## Traps` entry

## Risk
Comments + docs only. No behavior change. `ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)