### PR TITLE
feat(guardian): container-capacity grows — grow-root + set-container-limits (E-rest PR-C)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -348,7 +348,7 @@ radius) and the container-side Sentinel (CC-driven diagnosis/repair).
 ```yaml subsystem-map
 entry: guardian-sentinel
 modules: [guardian, sentinel]
-verified: 4e483381 2026-07-15
+verified: 8bd0a52b 2026-07-15
 ```
 
 - **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
@@ -362,7 +362,13 @@ verified: 4e483381 2026-07-15
   skill). Known wart: the watchdog's stale-alert wording inverts when the
   deployed script is NEWER than the host checkout.
 - Provisioning verbs are EXECUTE-ONLY — approval is the CALLER's
-  responsibility (container obtains it via Telegram before invoking).
+  responsibility (container obtains it via Telegram before invoking). Two
+  families: Proxmox VM grows (`provision-grow-disk/-memory`, hypervisor API) and
+  LOCAL container-capacity grows (`grow-root`, `set-container-limits` in
+  `guardian/grow_capacity.py` — incus resizes the thin LV+fs / cgroup caps ONLINE,
+  grow-only, spike-proven). Both flow through `provision_grow(kind=disk|memory|
+  root|limits)` → owner-approval → the execute verb. The limits verb closes the
+  VM↔container coupling (a grown VM's RAM/cores reach the container).
 - Read-only `host-profile` verb (`guardian/host_profile.py`) feeds the
   `infra_profile` host plane; the CC diagnosis prompt inlines the shared-mount
   `INFRASTRUCTURE.md` (truncated) so the diagnostician starts with the body

--- a/docs/reference/proxmox-provisioning.md
+++ b/docs/reference/proxmox-provisioning.md
@@ -212,6 +212,14 @@ curl -sk -X PUT -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" -d
   it **takes effect only after a VM reboot** (hotplug is off on this install).
   The provision token deliberately lacks `VM.PowerMgmt` — power stays
   human/approved. Schedule the stop/start as a downtime window.
+- **Grow the CONTAINER (local, no Proxmox token):** `provision_grow`
+  (`kind="root"`) grows the container root volume to `<gib>` GB total — incus
+  resizes the thin LV + filesystem ONLINE, no restart (`guardian/grow_capacity.py`,
+  grow-only, refused if the thin pool is near-full). `provision_grow`
+  (`kind="limits"`) raises the container cgroup caps (`<mib>` MiB / `<cpu>` cores,
+  grow-only, applied live, memory hard-capped below host `MemTotal−reserve`). The
+  **Phase-C RAM completion**: after a `kind="memory"` VM grow + reboot, run
+  `kind="limits"` so the grown RAM actually reaches the container.
 - **Rate cap / ledger:** executed mutations are recorded in
   `<state_dir>/provisioning/ledger.json`; the gate refuses once
   `max_actions_per_week` is reached. Autonomous pool-crit re-proposals are

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -958,6 +958,58 @@ PYEOF
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
             timeout 600 "$VENV_PY" -m genesis.guardian --storage-expand
         ;;
+    grow-root\ *)
+        # EXECUTE-ONLY (approval is the CALLER's job — the container approves via
+        # its own bot BEFORE calling). Local incus op: grow the container root
+        # device to <GB> total (incus resizes the thin LV + filesystem online).
+        # Whole-string bash regex (NOT grep) rejects anything but exactly "<GB>";
+        # a digits-only arg can never word-split into a flag-shaped argv token.
+        GB="${SSH_ORIGINAL_COMMAND#grow-root }"
+        if [[ ! "$GB" =~ ^[1-9][0-9]{0,3}$ ]]; then
+            echo '{"ok": false, "action": "grow-root", "error": "invalid arg (expected <GB total 1-9999>)"}' >&2
+            exit 1
+        fi
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "grow-root", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        # Skew guard (see host-profile): an old checkout has no --grow-root branch
+        # — the flag would fall through main()'s if-chain into run_check().
+        if [ ! -f "$INSTALL_DIR/src/genesis/guardian/grow_capacity.py" ]; then
+            echo '{"ok": false, "action": "grow-root", "error": "guardian src predates grow-root — run update to redeploy"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            timeout 300 "$VENV_PY" -m genesis.guardian --grow-root "$GB"
+        ;;
+    set-container-limits\ *)
+        # EXECUTE-ONLY (see grow-root). Raise the container cgroup caps
+        # (limits.memory / limits.cpu), grow-only, applied live. Whole-string
+        # regex: two tokens, each digits-or-'-' (no flag-shaped token can match).
+        ARGS="${SSH_ORIGINAL_COMMAND#set-container-limits }"
+        if [[ ! "$ARGS" =~ ^([1-9][0-9]{2,6}|-)\ ([1-9][0-9]{0,2}|-)$ ]]; then
+            echo '{"ok": false, "action": "set-container-limits", "error": "invalid args (expected <mem_mib|-> <cpu|->)"}' >&2
+            exit 1
+        fi
+        MEM="${ARGS%% *}"
+        CPU="${ARGS##* }"
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "set-container-limits", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        if [ ! -f "$INSTALL_DIR/src/genesis/guardian/grow_capacity.py" ]; then
+            echo '{"ok": false, "action": "set-container-limits", "error": "guardian src predates set-container-limits — run update to redeploy"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            timeout 60 "$VENV_PY" -m genesis.guardian --set-container-limits "$MEM" "$CPU"
+        ;;
     configure-provisioning\ *)
         # Land/refresh host provisioning config as a state-dir override
         # (provisioning.local.yaml — survives redeploys, never edits the tracked

--- a/src/genesis/dashboard/routes/provision.py
+++ b/src/genesis/dashboard/routes/provision.py
@@ -50,6 +50,7 @@ async def provision_grow_rpc():
         disk=data.get("disk", "scsi1"),
         gib=int(data.get("gib", 0)),
         mib=int(data.get("mib", 0)),
+        cpu=int(data.get("cpu", 0)),
         timeout_s=float(data.get("timeout_seconds", 1800)),
     )
     return jsonify(result)

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -13,6 +13,8 @@ Usage:
     python -m genesis.guardian --provision-grow-disk <disk> <GiB>  # EXECUTE (pre-approved)
     python -m genesis.guardian --provision-grow-memory <MiB>       # EXECUTE (pre-approved)
     python -m genesis.guardian --storage-expand               # absorb a grown disk
+    python -m genesis.guardian --grow-root <GB>               # EXECUTE (pre-approved) grow container root
+    python -m genesis.guardian --set-container-limits <mem_mib|-> <cpu|->  # EXECUTE (pre-approved) raise cgroup caps
 
 The provisioning grow/expand verbs are EXECUTE-ONLY: they run the shared
 execute-core (fresh due-diligence re-check + rate cap + one attempt + ledger),
@@ -71,6 +73,12 @@ def main() -> None:
 
     if "--storage-expand" in sys.argv:
         sys.exit(asyncio.run(_storage_expand()))
+
+    if "--grow-root" in sys.argv:
+        sys.exit(asyncio.run(_grow_root(sys.argv)))
+
+    if "--set-container-limits" in sys.argv:
+        sys.exit(asyncio.run(_set_container_limits(sys.argv)))
 
     if "--configure-provisioning" in sys.argv:
         sys.exit(_configure_provisioning(sys.argv))
@@ -391,6 +399,48 @@ async def _storage_expand() -> int:
     result = await expand_storage(load_config())
     result.setdefault("action", "storage-expand")
     return _emit(result)
+
+
+async def _grow_root(argv: list[str]) -> int:
+    """EXECUTE (pre-approved) a container root-volume grow to <GB> total."""
+    import re
+
+    from genesis.guardian.config import load_config
+    from genesis.guardian.grow_capacity import grow_root
+
+    args = _args_after(argv, "--grow-root", 1)
+    if not args or not re.fullmatch(r"[1-9][0-9]{0,3}", args[0]):
+        return _emit({"ok": False, "action": "grow-root",
+                      "error": "usage: --grow-root <GB total, 1-9999>"})
+    return _emit(await grow_root(load_config(), int(args[0])))
+
+
+async def _set_container_limits(argv: list[str]) -> int:
+    """EXECUTE (pre-approved) a container cgroup limit raise (grow-only).
+
+    Args: <mem_mib> <cpu>; use '-' for an axis to leave it unchanged."""
+    import re
+
+    from genesis.guardian.config import load_config
+    from genesis.guardian.grow_capacity import set_container_limits
+
+    args = _args_after(argv, "--set-container-limits", 2)
+    if not args:
+        return _emit({"ok": False, "action": "set-container-limits",
+                      "error": "usage: --set-container-limits <mem_mib|-> <cpu|->"})
+    mem_s, cpu_s = args
+    if mem_s != "-" and not re.fullmatch(r"[1-9][0-9]{2,6}", mem_s):
+        return _emit({"ok": False, "action": "set-container-limits",
+                      "error": f"invalid mem_mib {mem_s!r} (100-9999999 or -)"})
+    if cpu_s != "-" and not re.fullmatch(r"[1-9][0-9]{0,2}", cpu_s):
+        return _emit({"ok": False, "action": "set-container-limits",
+                      "error": f"invalid cpu {cpu_s!r} (1-999 or -)"})
+    if mem_s == "-" and cpu_s == "-":
+        return _emit({"ok": False, "action": "set-container-limits",
+                      "error": "nothing to do (both axes '-')"})
+    mem_mib = None if mem_s == "-" else int(mem_s)
+    cpu = None if cpu_s == "-" else int(cpu_s)
+    return _emit(await set_container_limits(load_config(), mem_mib, cpu))
 
 
 async def _check_only() -> None:

--- a/src/genesis/guardian/grow_capacity.py
+++ b/src/genesis/guardian/grow_capacity.py
@@ -21,6 +21,7 @@ provisioning verbs.
 from __future__ import annotations
 
 import logging
+import os
 
 from genesis.guardian._subprocess import run_subprocess
 from genesis.guardian.config import GuardianConfig
@@ -215,7 +216,10 @@ async def set_container_limits(
                 "error": "cannot read host MemTotal from /proc/meminfo",
             }
 
-        # ── memory ──
+        # ── VALIDATE BOTH AXES UP FRONT (no mutation until every check passes,
+        # so a valid-memory + invalid-cpu request never leaves a partial set) ──
+        host_cores = os.cpu_count() or 1
+        new_mem_b: int | None = None
         if new_mem_mib is not None:
             new_mem_b = new_mem_mib * _MIB
             reserve_b = _host_reserve_bytes(mem_total_b)
@@ -242,6 +246,33 @@ async def set_container_limits(
                     "error": f"memory {new_mem_mib}MiB ({new_mem_b} B) exceeds host "
                     f"cap MemTotal−reserve ({cap_b} B) — would starve the host",
                 }
+
+        if new_cpu is not None:
+            rc, out, _ = await run("incus", "config", "get", c, "limits.cpu", timeout=15.0)
+            cur_cpu_raw = out.strip() if rc == 0 else ""
+            # An unset/empty limits.cpu means ALL host cores (unlimited); a numeric
+            # cap below that would REDUCE the container — so treat unset as
+            # host_cores for the grow-only comparison (Codex P2: cpu was not
+            # grow-only, a cpu=4 request could lower an existing cpu=8 cap).
+            cur_cpu = int(cur_cpu_raw) if cur_cpu_raw.isdigit() else host_cores
+            steps.append(f"cpu current={cur_cpu_raw!r} (eff {cur_cpu}), host cores={host_cores}")
+            if new_cpu < 1 or new_cpu > host_cores:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"cpu {new_cpu} out of range 1..{host_cores} (host cores)",
+                }
+            if new_cpu <= cur_cpu:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"grow-only: cpu {new_cpu} not greater than current {cur_cpu}",
+                }
+
+        # ── APPLY (all validations passed; both are live cgroup writes) ──
+        if new_mem_mib is not None:
             rc, out, err = await run(
                 "incus",
                 "config",
@@ -259,21 +290,7 @@ async def set_container_limits(
                 }
             steps.append(f"set limits.memory={new_mem_mib}MiB")
 
-        # ── cpu ──
         if new_cpu is not None:
-            try:
-                import os
-
-                host_cores = os.cpu_count() or 1
-            except Exception:
-                host_cores = 1
-            if new_cpu < 1 or new_cpu > host_cores:
-                return {
-                    "ok": False,
-                    "action": action,
-                    "steps": steps,
-                    "error": f"cpu {new_cpu} out of range 1..{host_cores} (host cores)",
-                }
             rc, out, err = await run(
                 "incus",
                 "config",

--- a/src/genesis/guardian/grow_capacity.py
+++ b/src/genesis/guardian/grow_capacity.py
@@ -1,0 +1,309 @@
+"""Host-side container capacity grows — grow-root (+ set-container-limits).
+
+LOCAL incus operations (NOT Proxmox — those live in ``provisioning/``). These
+grow the container's OWN resources after the VM underneath has room:
+
+- **grow-root**: raise the container root device ``size=`` — incus grows the
+  thin LV AND resizes the filesystem ONLINE (spike-proven 2026-07-15 on incus
+  6.0, LVM+ext4: df 1.7G→2.7G with no restart, container stayed RUNNING).
+- **set-container-limits**: raise the cgroup ``limits.memory``/``limits.cpu``
+  so a grown VM's RAM/cores actually reach the container (both apply LIVE —
+  cgroup ``memory.max`` rewrites without a restart, spike-proven).
+
+Both are **grow-only** and **verified** (re-read after the mutation). Strictly
+additive, JSON step-list out, stop at the first failure — mirrors
+``provisioning/expand.py``. incus commands run as the guardian user (in the
+``incus`` group); no sudo. Approval is the CALLER's job (the container obtains
+it before invoking the gateway verb), same two-owner model as the Proxmox
+provisioning verbs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.guardian._subprocess import run_subprocess
+from genesis.guardian.config import GuardianConfig
+from genesis.guardian.host_profile import _read_meminfo
+from genesis.guardian.pool import (
+    TIER_HIGH,
+    measure_storage_pool,
+    worst_tier,
+)
+
+logger = logging.getLogger(__name__)
+
+_GB = 1000**3  # incus expresses device sizes in decimal GB (30GB → 27.94 GiB LV)
+_GIB = 1024**3
+_MIB = 1024**2
+
+# Host RAM reserve kept OUT of the container cap: never let limits.memory climb
+# so high the host itself can't breathe. max(4 GiB, 20% of MemTotal) — mirrors
+# host-setup.sh's install-time reserve, config-overridable via the formula, never
+# a machine constant.
+_HOST_RESERVE_MIN_GIB = 4
+_HOST_RESERVE_FRACTION = 0.20
+
+
+def _parse_incus_size(s: str) -> int | None:
+    """Parse an incus size string ("30GB", "16GiB", "512MB", a bare byte int) to
+    bytes. Returns None if unparseable. incus uses decimal GB/MB and binary
+    GiB/MiB (IEC)."""
+    s = (s or "").strip()
+    if not s:
+        return None
+    units = [
+        ("GiB", _GIB),
+        ("MiB", _MIB),
+        ("KiB", 1024),
+        ("GB", _GB),
+        ("MB", 1000**2),
+        ("kB", 1000),
+        ("B", 1),
+    ]
+    for suf, mult in units:
+        if s.endswith(suf):
+            num = s[: -len(suf)].strip()
+            try:
+                return int(float(num) * mult)
+            except ValueError:
+                return None
+    try:
+        return int(s)  # bare byte count
+    except ValueError:
+        return None
+
+
+async def grow_root(
+    config: GuardianConfig,
+    new_gb: int,
+    *,
+    run=run_subprocess,
+) -> dict:
+    """Grow the container root device to ``new_gb`` GB total (grow-only).
+
+    ``new_gb`` is the new TOTAL size in incus GB (decimal), matching how the
+    device is expressed ("30GB"). Refuses a shrink, refuses when the thin pool is
+    already at/above its HIGH tier (don't grow virtual capacity into a nearly-full
+    pool), then ``incus config device set <c> root size=<new_gb>GB`` and verifies
+    the re-read. Never raises — returns a JSON step-list dict.
+    """
+    action = "grow-root"
+    steps: list[str] = []
+    c = config.container_name
+    try:
+        # 1. Current root size (grow-only anchor).
+        rc, out, err = await run(
+            "incus",
+            "config",
+            "device",
+            "get",
+            c,
+            "root",
+            "size",
+            timeout=15.0,
+        )
+        if rc != 0:
+            return {
+                "ok": False,
+                "action": action,
+                "error": f"cannot read current root size: {err[:200]}",
+            }
+        cur_bytes = _parse_incus_size(out)
+        new_bytes = new_gb * _GB
+        steps.append(f"current root size {out.strip() or '?'} ({cur_bytes} B)")
+        if cur_bytes is not None and new_bytes <= cur_bytes:
+            return {
+                "ok": False,
+                "action": action,
+                "steps": steps,
+                "error": f"grow-only: requested {new_gb}GB "
+                f"({new_bytes} B) not greater than current {cur_bytes} B",
+            }
+
+        # 2. Pool-headroom guard — never grow virtual capacity into a stressed pool.
+        status = await measure_storage_pool(config)
+        if status.detected:
+            tier = worst_tier(status, config.storage_pool)
+            steps.append(f"pool tier={tier} (data={status.data_pct} meta={status.metadata_pct})")
+            if tier in (TIER_HIGH, "crit"):
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"pool at {tier} tier — refusing to grow root into a "
+                    "nearly-full thin pool (free pool space first)",
+                }
+        else:
+            steps.append("pool headroom unmeasurable — proceeding (grow is virtual)")
+
+        # 3. Grow (incus resizes the thin LV + filesystem online).
+        rc, out, err = await run(
+            "incus",
+            "config",
+            "device",
+            "set",
+            c,
+            "root",
+            f"size={new_gb}GB",
+            timeout=300.0,
+        )
+        if rc != 0:
+            return {
+                "ok": False,
+                "action": action,
+                "steps": steps,
+                "error": f"incus device set failed: {err[:300]}",
+            }
+        steps.append(f"set root size={new_gb}GB")
+
+        # 4. Verify the re-read reflects the new size.
+        rc, out, err = await run(
+            "incus",
+            "config",
+            "device",
+            "get",
+            c,
+            "root",
+            "size",
+            timeout=15.0,
+        )
+        verified = rc == 0 and _parse_incus_size(out) == new_bytes
+        steps.append(f"verify root size now {out.strip()!r} (verified={verified})")
+        return {
+            "ok": verified,
+            "action": action,
+            "steps": steps,
+            "new_size_gb": new_gb,
+            "verified": verified,
+        }
+    except Exception as exc:  # noqa: BLE001 — the verb contract is JSON-always
+        logger.warning("grow-root failed", exc_info=True)
+        return {"ok": False, "action": action, "steps": steps, "error": repr(exc)}
+
+
+def _host_reserve_bytes(mem_total_bytes: int) -> int:
+    """RAM to keep out of the container cap: max(4 GiB, 20% of host MemTotal)."""
+    return max(_HOST_RESERVE_MIN_GIB * _GIB, int(mem_total_bytes * _HOST_RESERVE_FRACTION))
+
+
+async def set_container_limits(
+    config: GuardianConfig,
+    new_mem_mib: int | None,
+    new_cpu: int | None,
+    *,
+    run=run_subprocess,
+) -> dict:
+    """Raise the container's cgroup limits (grow-only), the VM↔container coupling.
+
+    After a Proxmox VM memory/cpu grow, nothing else raises the container's caps;
+    this does. ``limits.memory`` is capped hard below ``MemTotal − reserve`` so the
+    host always keeps headroom; ``limits.cpu`` is capped at the host core count.
+    Both apply LIVE (spike-proven). Grow-only: never lowers an existing cap.
+    Pass None to leave an axis unchanged. Never raises — JSON step-list dict.
+    """
+    action = "set-container-limits"
+    steps: list[str] = []
+    c = config.container_name
+    try:
+        mem = _read_meminfo()
+        mem_total_b = (mem.get("MemTotal") or 0) * 1024  # kB → B
+        if not mem_total_b:
+            return {
+                "ok": False,
+                "action": action,
+                "error": "cannot read host MemTotal from /proc/meminfo",
+            }
+
+        # ── memory ──
+        if new_mem_mib is not None:
+            new_mem_b = new_mem_mib * _MIB
+            reserve_b = _host_reserve_bytes(mem_total_b)
+            cap_b = mem_total_b - reserve_b
+            rc, out, _ = await run("incus", "config", "get", c, "limits.memory", timeout=15.0)
+            cur_b = _parse_incus_size(out) if rc == 0 else None
+            steps.append(
+                f"mem current={out.strip()!r} ({cur_b} B), "
+                f"host MemTotal={mem_total_b} B, cap={cap_b} B"
+            )
+            if cur_b is not None and new_mem_b <= cur_b:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"grow-only: memory {new_mem_mib}MiB not greater than "
+                    f"current {cur_b} B",
+                }
+            if new_mem_b >= cap_b:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"memory {new_mem_mib}MiB ({new_mem_b} B) exceeds host "
+                    f"cap MemTotal−reserve ({cap_b} B) — would starve the host",
+                }
+            rc, out, err = await run(
+                "incus",
+                "config",
+                "set",
+                c,
+                f"limits.memory={new_mem_mib}MiB",
+                timeout=30.0,
+            )
+            if rc != 0:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"set limits.memory failed: {err[:200]}",
+                }
+            steps.append(f"set limits.memory={new_mem_mib}MiB")
+
+        # ── cpu ──
+        if new_cpu is not None:
+            try:
+                import os
+
+                host_cores = os.cpu_count() or 1
+            except Exception:
+                host_cores = 1
+            if new_cpu < 1 or new_cpu > host_cores:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"cpu {new_cpu} out of range 1..{host_cores} (host cores)",
+                }
+            rc, out, err = await run(
+                "incus",
+                "config",
+                "set",
+                c,
+                f"limits.cpu={new_cpu}",
+                timeout=30.0,
+            )
+            if rc != 0:
+                return {
+                    "ok": False,
+                    "action": action,
+                    "steps": steps,
+                    "error": f"set limits.cpu failed: {err[:200]}",
+                }
+            steps.append(f"set limits.cpu={new_cpu}")
+
+        # Verify by re-read.
+        rc, out, _ = await run("incus", "config", "get", c, "limits.memory", timeout=15.0)
+        mem_now = out.strip() if rc == 0 else "?"
+        rc, out, _ = await run("incus", "config", "get", c, "limits.cpu", timeout=15.0)
+        cpu_now = out.strip() if rc == 0 else "?"
+        steps.append(f"verify limits.memory={mem_now!r} limits.cpu={cpu_now!r}")
+        return {
+            "ok": True,
+            "action": action,
+            "steps": steps,
+            "limits_memory": mem_now,
+            "limits_cpu": cpu_now,
+        }
+    except Exception as exc:  # noqa: BLE001 — the verb contract is JSON-always
+        logger.warning("set-container-limits failed", exc_info=True)
+        return {"ok": False, "action": action, "steps": steps, "error": repr(exc)}

--- a/src/genesis/guardian/provisioning/container.py
+++ b/src/genesis/guardian/provisioning/container.py
@@ -105,6 +105,10 @@ async def coordinate_set_container_limits(
     The VM<->container coupling: after a Proxmox VM grow, this makes the grown
     RAM/cores reach the container. The host verb caps memory below MemTotal-reserve.
     """
+    if mem_mib is None and cpu is None:
+        # Fail before asking the user to approve a no-op (empty proposal).
+        return {"ok": False, "stage": "invalid",
+                "error": "nothing to do (both axes None)"}
     parts = []
     if mem_mib is not None:
         parts.append(f"memory->{mem_mib}MiB")

--- a/src/genesis/guardian/provisioning/container.py
+++ b/src/genesis/guardian/provisioning/container.py
@@ -77,3 +77,45 @@ async def coordinate_grow_memory(remote, ask: AskFn, *, new_mib: int) -> dict:
     if not _approved(reply):
         return {"ok": False, "stage": "denied", "reply": reply}
     return await remote.request_grow_memory(new_mib)
+
+
+async def coordinate_grow_root(remote, ask: AskFn, *, new_gb: int) -> dict:
+    """Ask the user -> on APPROVE run the host container-root grow execute verb.
+
+    Local incus op (not Proxmox): incus resizes the thin LV + filesystem online,
+    no restart. The host verb enforces grow-only + a pool-headroom guard.
+    """
+    proposal = (
+        f"\U0001f527 Grow the CONTAINER root volume to {new_gb}GB total.\n"
+        "incus resizes the thin LV + filesystem online (no restart). Grow-only, "
+        "refused if the thin pool is near-full.\n"
+        "Reply APPROVE to execute or DENY to cancel."
+    )
+    reply = await ask(proposal)
+    if not _approved(reply):
+        return {"ok": False, "stage": "denied", "reply": reply}
+    return await remote.request_grow_root(new_gb)
+
+
+async def coordinate_set_container_limits(
+    remote, ask: AskFn, *, mem_mib: int | None = None, cpu: int | None = None,
+) -> dict:
+    """Ask the user -> on APPROVE raise the container cgroup caps (grow-only, live).
+
+    The VM<->container coupling: after a Proxmox VM grow, this makes the grown
+    RAM/cores reach the container. The host verb caps memory below MemTotal-reserve.
+    """
+    parts = []
+    if mem_mib is not None:
+        parts.append(f"memory->{mem_mib}MiB")
+    if cpu is not None:
+        parts.append(f"cpu->{cpu}")
+    proposal = (
+        f"\U0001f527 Raise container cgroup limits ({', '.join(parts)}) - grow-only, "
+        "applied live (no restart).\n"
+        "Reply APPROVE to execute or DENY to cancel."
+    )
+    reply = await ask(proposal)
+    if not _approved(reply):
+        return {"ok": False, "stage": "denied", "reply": reply}
+    return await remote.request_set_container_limits(mem_mib, cpu)

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -11,7 +11,8 @@ enforces this restriction, not our code.
 Gateway allowlist: restart-timer, pause, resume, status, reset-state, version,
 update, sync-gateway, redeploy, update-cc, update-node, test-approval,
 disk-status, host-profile, reharden-key, ping, provision-status,
-provision-grow-disk, provision-grow-memory, storage-expand.
+provision-grow-disk, provision-grow-memory, storage-expand, grow-root,
+set-container-limits.
 """
 
 from __future__ import annotations
@@ -41,6 +42,8 @@ _HOST_PROFILE_TIMEOUT = 50.0  # gateway: timeout 45 (pool lvs + incus probes)
 _GROW_DISK_TIMEOUT = 660.0   # gateway: timeout 600 (PVE resize + storage-expand)
 _GROW_MEM_TIMEOUT = 180.0    # gateway: timeout 120 (config PUT + pending check)
 _EXPAND_TIMEOUT = 660.0      # gateway: timeout 600 (pvresize + autoextend profile)
+_GROW_ROOT_TIMEOUT = 330.0   # gateway: timeout 300 (incus LV + fs online resize)
+_SET_LIMITS_TIMEOUT = 70.0   # gateway: timeout 60 (incus config set + verify)
 
 
 class GuardianRemote:
@@ -339,3 +342,33 @@ class GuardianRemote:
         """Absorb an already-grown virtual disk into the LVM-thin pool."""
         ok, out = await self._ssh_command("storage-expand", timeout=_EXPAND_TIMEOUT)
         return self._as_json(ok, out, "storage-expand")
+
+    async def request_grow_root(self, new_gb: int) -> dict:
+        """EXECUTE a pre-approved container root grow to <new_gb> GB total."""
+        if not 1 <= new_gb <= 9999:
+            return {"ok": False, "action": "grow-root",
+                    "error": f"invalid GB {new_gb} (1-9999)"}
+        ok, out = await self._ssh_command(
+            f"grow-root {new_gb}", timeout=_GROW_ROOT_TIMEOUT,
+        )
+        return self._as_json(ok, out, "grow-root")
+
+    async def request_set_container_limits(
+        self, mem_mib: int | None, cpu: int | None,
+    ) -> dict:
+        """EXECUTE a pre-approved cgroup limit raise (grow-only). None = unchanged."""
+        if mem_mib is not None and not 100 <= mem_mib <= 9999999:
+            return {"ok": False, "action": "set-container-limits",
+                    "error": f"invalid mem_mib {mem_mib} (100-9999999)"}
+        if cpu is not None and not 1 <= cpu <= 999:
+            return {"ok": False, "action": "set-container-limits",
+                    "error": f"invalid cpu {cpu} (1-999)"}
+        if mem_mib is None and cpu is None:
+            return {"ok": False, "action": "set-container-limits",
+                    "error": "nothing to do (both axes None)"}
+        mem_tok = str(mem_mib) if mem_mib is not None else "-"
+        cpu_tok = str(cpu) if cpu is not None else "-"
+        ok, out = await self._ssh_command(
+            f"set-container-limits {mem_tok} {cpu_tok}", timeout=_SET_LIMITS_TIMEOUT,
+        )
+        return self._as_json(ok, out, "set-container-limits")

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -392,9 +392,10 @@ async def provision_grow(
     disk: str = "scsi1",
     gib: int = 0,
     mib: int = 0,
+    cpu: int = 0,
     timeout_seconds: int = 1800,
 ) -> dict:
-    """Grow this VM's disk or RAM from the hypervisor — approval-gated.
+    """Grow this VM's or container's capacity — approval-gated.
 
     The container-owned approval path (used while Genesis is up): sends an
     APPROVE/DENY request to your own channel and, only on APPROVE, executes
@@ -402,7 +403,11 @@ async def provision_grow(
     Disabled or unconfigured installs return a clean error and never mutate.
 
     kind="disk" grows <disk> by <gib> GiB and absorbs it into the thin pool;
-    kind="memory" grows configured RAM to <mib> MiB (needs a later VM reboot).
+    kind="memory" grows configured VM RAM to <mib> MiB (needs a later VM reboot);
+    kind="root" grows the CONTAINER root volume to <gib> GB total (incus resizes
+      the thin LV + filesystem online, no restart);
+    kind="limits" raises the CONTAINER cgroup caps to <mib> MiB memory and/or
+      <cpu> cores (grow-only, applied live) — the VM↔container coupling.
     """
     if not _pipeline:
         # Standalone MCP subprocess → bridge to genesis-server (owner-approval is
@@ -410,14 +415,14 @@ async def provision_grow(
         # post-approval host execute verb.
         return await _server_rpc(
             "/api/genesis/provision/grow",
-            {"kind": kind, "disk": disk, "gib": gib, "mib": mib,
+            {"kind": kind, "disk": disk, "gib": gib, "mib": mib, "cpu": cpu,
              "timeout_seconds": timeout_seconds},
             read_timeout_s=float(timeout_seconds) + 180.0,
         )
     from genesis.outreach.rpc import grow_via_pipeline
 
     return await grow_via_pipeline(
-        _pipeline, kind=kind, disk=disk, gib=gib, mib=mib,
+        _pipeline, kind=kind, disk=disk, gib=gib, mib=mib, cpu=cpu,
         timeout_s=float(timeout_seconds),
     )
 

--- a/src/genesis/outreach/rpc.py
+++ b/src/genesis/outreach/rpc.py
@@ -64,6 +64,7 @@ async def grow_via_pipeline(
     gib: int,
     mib: int,
     timeout_s: float,
+    cpu: int = 0,
 ) -> dict:
     """Approval-gated disk/RAM grow: ask the owner, and on APPROVE run the host
     guardian execute verb (which re-checks the due-diligence gate). Returns the
@@ -75,6 +76,8 @@ async def grow_via_pipeline(
     from genesis.guardian.provisioning.container import (
         coordinate_grow_disk,
         coordinate_grow_memory,
+        coordinate_grow_root,
+        coordinate_set_container_limits,
     )
     from genesis.observability.health import _load_guardian_remote_from_config
 
@@ -100,4 +103,10 @@ async def grow_via_pipeline(
         return await coordinate_grow_disk(remote, _ask, disk=disk, add_gib=gib)
     if kind == "memory":
         return await coordinate_grow_memory(remote, _ask, new_mib=mib)
-    return {"ok": False, "error": f"invalid kind {kind!r} (disk|memory)"}
+    if kind == "root":
+        return await coordinate_grow_root(remote, _ask, new_gb=gib)
+    if kind == "limits":
+        return await coordinate_set_container_limits(
+            remote, _ask, mem_mib=(mib or None), cpu=(cpu or None),
+        )
+    return {"ok": False, "error": f"invalid kind {kind!r} (disk|memory|root|limits)"}

--- a/tests/test_guardian/test_container_grow_root.py
+++ b/tests/test_guardian/test_container_grow_root.py
@@ -66,3 +66,14 @@ async def test_set_limits_deny_no_execute():
     res = await coordinate_set_container_limits(remote, _ask("DENY"), mem_mib=20480, cpu=None)
     assert res["ok"] is False and res["stage"] == "denied"
     assert remote.set_limits_args is None
+
+
+async def test_set_limits_both_none_short_circuits_before_asking():
+    """NOTE fix: a no-op request must fail before sending an empty-parens
+    approval proposal to the user (and before dispatching the verb)."""
+    remote = FakeRemote()
+    ask = _ask("APPROVE")
+    res = await coordinate_set_container_limits(remote, ask, mem_mib=None, cpu=None)
+    assert res["ok"] is False and res["stage"] == "invalid"
+    assert remote.set_limits_args is None
+    assert getattr(ask, "prompt", None) is None  # user was never prompted

--- a/tests/test_guardian/test_container_grow_root.py
+++ b/tests/test_guardian/test_container_grow_root.py
@@ -1,0 +1,68 @@
+"""Container-side coordinators for grow-root + set-container-limits (PR-C).
+
+Same DI pattern as test_provisioning_container: a fake remote records the verb
+call, a scripted ask returns the reply. Proves no execute without APPROVE and
+that APPROVE dispatches the correct host verb with the right args.
+"""
+
+from __future__ import annotations
+
+from genesis.guardian.provisioning.container import (
+    coordinate_grow_root,
+    coordinate_set_container_limits,
+)
+
+
+class FakeRemote:
+    def __init__(self, result=None):
+        self._result = result or {"ok": True, "action": "executed"}
+        self.grow_root_arg = None
+        self.set_limits_args = None
+
+    async def request_grow_root(self, new_gb):
+        self.grow_root_arg = new_gb
+        return self._result
+
+    async def request_set_container_limits(self, mem_mib, cpu):
+        self.set_limits_args = (mem_mib, cpu)
+        return self._result
+
+
+def _ask(reply):
+    async def _inner(text):
+        _inner.prompt = text
+        return reply
+
+    return _inner
+
+
+async def test_grow_root_approve_dispatches():
+    remote = FakeRemote()
+    ask = _ask("APPROVE")
+    res = await coordinate_grow_root(remote, ask, new_gb=40)
+    assert res["ok"] is True
+    assert remote.grow_root_arg == 40
+    assert "40GB" in ask.prompt
+
+
+async def test_grow_root_deny_no_execute():
+    remote = FakeRemote()
+    res = await coordinate_grow_root(remote, _ask("DENY"), new_gb=40)
+    assert res["ok"] is False and res["stage"] == "denied"
+    assert remote.grow_root_arg is None
+
+
+async def test_set_limits_approve_dispatches():
+    remote = FakeRemote()
+    ask = _ask("APPROVE")
+    res = await coordinate_set_container_limits(remote, ask, mem_mib=20480, cpu=4)
+    assert res["ok"] is True
+    assert remote.set_limits_args == (20480, 4)
+    assert "memory" in ask.prompt and "cpu" in ask.prompt
+
+
+async def test_set_limits_deny_no_execute():
+    remote = FakeRemote()
+    res = await coordinate_set_container_limits(remote, _ask("DENY"), mem_mib=20480, cpu=None)
+    assert res["ok"] is False and res["stage"] == "denied"
+    assert remote.set_limits_args is None

--- a/tests/test_guardian/test_grow_capacity.py
+++ b/tests/test_guardian/test_grow_capacity.py
@@ -167,3 +167,46 @@ async def test_set_limits_meminfo_unreadable():
         res = await set_container_limits(_cfg(), 20480, None, run=run)
     assert res["ok"] is False
     assert "MemTotal" in res["error"]
+
+
+class _CpuAwareRun:
+    """Fake run that answers limits.cpu / limits.memory gets distinctly."""
+
+    def __init__(self, cur_cpu: str, cur_mem: str = "16GiB"):
+        self.cur_cpu = cur_cpu
+        self.cur_mem = cur_mem
+        self.calls: list[str] = []
+
+    async def __call__(self, *argv, timeout=None, stdin_data=None):
+        j = " ".join(argv)
+        self.calls.append(j)
+        if "get" in j and "limits.cpu" in j:
+            return (0, self.cur_cpu, "")
+        if "get" in j and "limits.memory" in j:
+            return (0, self.cur_mem, "")
+        return (0, "", "")
+
+
+async def test_set_limits_cpu_grow_only():
+    """Codex P2: cpu must be grow-only — a cpu=4 request must NOT lower cpu=8."""
+    run = _CpuAwareRun(cur_cpu="8")
+    with patch.object(grow_capacity, "_read_meminfo",
+                      return_value={"MemTotal": 64 * 1024 * 1024}), \
+         patch("os.cpu_count", return_value=16):
+        res = await set_container_limits(_cfg(), None, 4, run=run)
+    assert res["ok"] is False
+    assert "grow-only" in res["error"]
+    assert not any("config set" in c for c in run.calls)  # never mutated
+
+
+async def test_set_limits_invalid_cpu_does_not_set_memory():
+    """Codex P2: a valid-memory + invalid-cpu request must not partially set mem."""
+    run = _CpuAwareRun(cur_cpu="2")
+    with patch.object(grow_capacity, "_read_meminfo",
+                      return_value={"MemTotal": 64 * 1024 * 1024}), \
+         patch("os.cpu_count", return_value=4):
+        res = await set_container_limits(_cfg(), 20480, 99, run=run)  # cpu 99 > 4 cores
+    assert res["ok"] is False
+    assert "out of range" in res["error"]
+    # up-front validation means NO memory set was issued
+    assert not any("config set" in c and "limits.memory" in c for c in run.calls)

--- a/tests/test_guardian/test_grow_capacity.py
+++ b/tests/test_guardian/test_grow_capacity.py
@@ -1,0 +1,169 @@
+"""Tests for host-side container capacity grows (PR-C, guardian/grow_capacity.py).
+
+Covers grow_root (grow-only reject, pool-headroom refusal, success+verify) and
+set_container_limits (grow-only, host-cap refusal, cpu range, live set), driving
+a fake ``run`` (canned incus responses) so no real host is touched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from genesis.guardian import grow_capacity
+from genesis.guardian.config import GuardianConfig
+from genesis.guardian.grow_capacity import (
+    _parse_incus_size,
+    grow_root,
+    set_container_limits,
+)
+from genesis.guardian.pool import StoragePoolStatus
+
+
+class _FakeRun:
+    """Canned incus responses keyed by a substring of the joined argv.
+
+    ``size_after_set`` lets the 'get root size' read return the NEW size only
+    once a 'device set' has been issued (models incus applying the resize).
+    """
+
+    def __init__(self, responses: dict[str, tuple[int, str, str]], *, size_after_set=None):
+        self.responses = responses
+        self.size_after_set = size_after_set
+        self.set_done = False
+        self.calls: list[str] = []
+
+    async def __call__(self, *argv, timeout=None, stdin_data=None):
+        joined = " ".join(argv)
+        self.calls.append(joined)
+        if "device set" in joined:
+            self.set_done = True
+        if "config set" in joined:
+            self.set_done = True
+        if (
+            "device get" in joined
+            and "root size" in joined
+            and self.set_done
+            and self.size_after_set
+        ):
+            return (0, self.size_after_set, "")
+        for key, resp in self.responses.items():
+            if key in joined:
+                return resp
+        return (1, "", f"unmocked: {joined}")
+
+
+def _cfg() -> GuardianConfig:
+    return GuardianConfig()
+
+
+def _healthy_pool():
+    return StoragePoolStatus(detected=True, data_pct=50.0, metadata_pct=30.0)
+
+
+def _full_pool():
+    return StoragePoolStatus(detected=True, data_pct=90.0, metadata_pct=40.0)
+
+
+# ── size parsing ────────────────────────────────────────────────────────────
+
+
+def test_parse_incus_size():
+    assert _parse_incus_size("30GB") == 30 * 1000**3
+    assert _parse_incus_size("16GiB") == 16 * 1024**3
+    assert _parse_incus_size("512MiB") == 512 * 1024**2
+    assert _parse_incus_size(str(1024**3)) == 1024**3  # bare bytes
+    assert _parse_incus_size("") is None
+    assert _parse_incus_size("garbage") is None
+
+
+# ── grow_root ─────────────────────────────────────────────────────────────
+
+
+async def test_grow_root_rejects_shrink():
+    run = _FakeRun({"device get": (0, "30GB", "")})
+    with patch.object(grow_capacity, "measure_storage_pool", return_value=_healthy_pool()):
+        res = await grow_root(_cfg(), 20, run=run)  # 20GB < 30GB
+    assert res["ok"] is False
+    assert "grow-only" in res["error"]
+    assert not run.set_done  # never mutated
+
+
+async def test_grow_root_refuses_full_pool():
+    run = _FakeRun({"device get": (0, "30GB", "")})
+    with patch.object(grow_capacity, "measure_storage_pool", return_value=_full_pool()):
+        res = await grow_root(_cfg(), 40, run=run)
+    assert res["ok"] is False
+    assert "near-full" in res["error"] or "tier" in res["error"]
+    assert not run.set_done
+
+
+async def test_grow_root_success_and_verify():
+    run = _FakeRun(
+        {"device get": (0, "30GB", ""), "device set": (0, "", "")}, size_after_set="40GB"
+    )
+    with patch.object(grow_capacity, "measure_storage_pool", return_value=_healthy_pool()):
+        res = await grow_root(_cfg(), 40, run=run)
+    assert res["ok"] is True
+    assert res["verified"] is True
+    assert res["new_size_gb"] == 40
+    assert any("device set" in c and "size=40GB" in c for c in run.calls)
+
+
+async def test_grow_root_read_failure_is_clean_json():
+    run = _FakeRun({"device get": (1, "", "no such container")})
+    res = await grow_root(_cfg(), 40, run=run)
+    assert res["ok"] is False
+    assert "cannot read current root size" in res["error"]
+
+
+# ── set_container_limits ────────────────────────────────────────────────────
+
+
+async def test_set_limits_rejects_shrink():
+    run = _FakeRun({"config get": (0, "16GiB", "")})
+    # host MemTotal 21GiB
+    with patch.object(grow_capacity, "_read_meminfo", return_value={"MemTotal": 21 * 1024 * 1024}):
+        res = await set_container_limits(_cfg(), 8192, None, run=run)  # 8GiB < 16GiB
+    assert res["ok"] is False
+    assert "grow-only" in res["error"]
+    assert not run.set_done
+
+
+async def test_set_limits_refuses_starving_host():
+    run = _FakeRun({"config get": (0, "16GiB", "")})
+    # host 21GiB → reserve max(4GiB, 20%*21=4.2GiB)=4.2GiB → cap ~16.8GiB.
+    # request 20GiB ≥ cap → refuse.
+    with patch.object(grow_capacity, "_read_meminfo", return_value={"MemTotal": 21 * 1024 * 1024}):
+        res = await set_container_limits(_cfg(), 20480, None, run=run)
+    assert res["ok"] is False
+    assert "starve the host" in res["error"] or "exceeds host cap" in res["error"]
+    assert not run.set_done
+
+
+async def test_set_limits_success_memory():
+    run = _FakeRun({"config get": (0, "16GiB", ""), "config set": (0, "", "")})
+    with patch.object(
+        grow_capacity, "_read_meminfo", return_value={"MemTotal": 32 * 1024 * 1024}
+    ):  # 32GiB host
+        res = await set_container_limits(_cfg(), 20480, None, run=run)  # 20GiB, cap ~25.6GiB
+    assert res["ok"] is True
+    assert any("limits.memory=20480MiB" in c for c in run.calls)
+
+
+async def test_set_limits_cpu_range_guard():
+    run = _FakeRun({"config get": (0, "16GiB", "")})
+    with (
+        patch.object(grow_capacity, "_read_meminfo", return_value={"MemTotal": 32 * 1024 * 1024}),
+        patch("os.cpu_count", return_value=4),
+    ):
+        res = await set_container_limits(_cfg(), None, 99, run=run)  # 99 > 4 host cores
+    assert res["ok"] is False
+    assert "out of range" in res["error"]
+
+
+async def test_set_limits_meminfo_unreadable():
+    run = _FakeRun({})
+    with patch.object(grow_capacity, "_read_meminfo", return_value={}):
+        res = await set_container_limits(_cfg(), 20480, None, run=run)
+    assert res["ok"] is False
+    assert "MemTotal" in res["error"]

--- a/tests/test_guardian/test_remote.py
+++ b/tests/test_guardian/test_remote.py
@@ -349,3 +349,71 @@ class TestVersionTimeout:
             got = await remote.version()
         assert got["cc_logged_in"] is True
         assert got["cc_token_age_days"] == -1
+
+
+class TestContainerCapacityExecutors:
+    """EXECUTE-only container-capacity executors (PR-C): client-side range
+    validation, exact command + `-` sentinel token construction, per-call
+    timeout override. Approval is NOT done here (the caller obtains it)."""
+
+    @pytest.mark.asyncio
+    async def test_grow_root_valid_sends_exact_command(self, remote):
+        from genesis.guardian.remote import _GROW_ROOT_TIMEOUT
+        with patch.object(remote, "_ssh_command",
+                          AsyncMock(return_value=(True, '{"ok": true, "verified": true}'))) as m:
+            res = await remote.request_grow_root(40)
+        assert res["ok"] is True
+        assert m.call_args.args[0] == "grow-root 40"
+        assert m.call_args.kwargs["timeout"] == _GROW_ROOT_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_grow_root_out_of_range_never_dials(self, remote):
+        with patch.object(remote, "_ssh_command", AsyncMock()) as m:
+            assert (await remote.request_grow_root(0))["ok"] is False
+            assert (await remote.request_grow_root(10000))["ok"] is False
+        m.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_limits_both_axes_sends_exact_command(self, remote):
+        from genesis.guardian.remote import _SET_LIMITS_TIMEOUT
+        with patch.object(remote, "_ssh_command",
+                          AsyncMock(return_value=(True, '{"ok": true}'))) as m:
+            res = await remote.request_set_container_limits(20480, 4)
+        assert res["ok"] is True
+        assert m.call_args.args[0] == "set-container-limits 20480 4"
+        assert m.call_args.kwargs["timeout"] == _SET_LIMITS_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_set_limits_mem_only_uses_dash_sentinel(self, remote):
+        with patch.object(remote, "_ssh_command",
+                          AsyncMock(return_value=(True, '{"ok": true}'))) as m:
+            await remote.request_set_container_limits(20480, None)
+        assert m.call_args.args[0] == "set-container-limits 20480 -"
+
+    @pytest.mark.asyncio
+    async def test_set_limits_cpu_only_uses_dash_sentinel(self, remote):
+        with patch.object(remote, "_ssh_command",
+                          AsyncMock(return_value=(True, '{"ok": true}'))) as m:
+            await remote.request_set_container_limits(None, 4)
+        assert m.call_args.args[0] == "set-container-limits - 4"
+
+    @pytest.mark.asyncio
+    async def test_set_limits_both_none_never_dials(self, remote):
+        with patch.object(remote, "_ssh_command", AsyncMock()) as m:
+            res = await remote.request_set_container_limits(None, None)
+        assert res["ok"] is False and "nothing to do" in res["error"]
+        m.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_limits_bad_mem_never_dials(self, remote):
+        with patch.object(remote, "_ssh_command", AsyncMock()) as m:
+            assert (await remote.request_set_container_limits(99, None))["ok"] is False
+            assert (await remote.request_set_container_limits(10_000_000, None))["ok"] is False
+        m.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_limits_bad_cpu_never_dials(self, remote):
+        with patch.object(remote, "_ssh_command", AsyncMock()) as m:
+            assert (await remote.request_set_container_limits(None, 0))["ok"] is False
+            assert (await remote.request_set_container_limits(None, 1000))["ok"] is False
+        m.assert_not_called()

--- a/tests/test_mcp/test_outreach_mcp.py
+++ b/tests/test_mcp/test_outreach_mcp.py
@@ -11,18 +11,23 @@ from genesis.mcp.outreach_mcp import mcp
 
 async def test_all_tools_registered():
     tools = await mcp.get_tools()
-    for name in ["outreach_send", "outreach_poll", "outreach_queue",
-                 "outreach_engagement", "outreach_preferences",
-                 "outreach_digest", "outreach_send_and_wait", "provision_grow"]:
+    for name in [
+        "outreach_send",
+        "outreach_poll",
+        "outreach_queue",
+        "outreach_engagement",
+        "outreach_preferences",
+        "outreach_digest",
+        "outreach_send_and_wait",
+        "provision_grow",
+    ]:
         assert name in tools, f"Missing tool: {name}"
 
 
 async def test_outreach_send_without_pipeline():
     """Should return error string when pipeline not initialized."""
     tools = await mcp.get_tools()
-    result = await tools["outreach_send"].fn(
-        message="test", category="alert", channel="whatsapp"
-    )
+    result = await tools["outreach_send"].fn(message="test", category="alert", channel="whatsapp")
     assert "not initialized" in result.lower() or "error" in result.lower()
 
 
@@ -32,12 +37,20 @@ async def test_send_and_wait_bridges_to_server_when_no_pipeline():
     old_pipeline = mcp_mod._pipeline
     try:
         mcp_mod._pipeline = None
-        with patch("genesis.mcp.outreach_mcp._server_rpc", new_callable=AsyncMock,
-                   return_value={"outreach_id": "o1", "status": "delivered",
-                                 "reply": "yep", "timed_out": False}) as rpc:
+        with patch(
+            "genesis.mcp.outreach_mcp._server_rpc",
+            new_callable=AsyncMock,
+            return_value={
+                "outreach_id": "o1",
+                "status": "delivered",
+                "reply": "yep",
+                "timed_out": False,
+            },
+        ) as rpc:
             tools = await mcp.get_tools()
             result = await tools["outreach_send_and_wait"].fn(
-                message="test", timeout_seconds=42,
+                message="test",
+                timeout_seconds=42,
             )
         assert json.loads(result)["reply"] == "yep"
         path, payload = rpc.call_args.args
@@ -54,17 +67,29 @@ async def test_provision_grow_bridges_to_server_when_no_pipeline():
     old_pipeline = mcp_mod._pipeline
     try:
         mcp_mod._pipeline = None
-        with patch("genesis.mcp.outreach_mcp._server_rpc", new_callable=AsyncMock,
-                   return_value={"ok": True, "stage": "executed"}) as rpc:
+        with patch(
+            "genesis.mcp.outreach_mcp._server_rpc",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "stage": "executed"},
+        ) as rpc:
             tools = await mcp.get_tools()
             result = await tools["provision_grow"].fn(
-                kind="disk", disk="scsi1", gib=1, timeout_seconds=60,
+                kind="disk",
+                disk="scsi1",
+                gib=1,
+                timeout_seconds=60,
             )
         assert result == {"ok": True, "stage": "executed"}
         path, payload = rpc.call_args.args
         assert path == "/api/genesis/provision/grow"
-        assert payload == {"kind": "disk", "disk": "scsi1", "gib": 1, "mib": 0,
-                           "timeout_seconds": 60}
+        assert payload == {
+            "kind": "disk",
+            "disk": "scsi1",
+            "gib": 1,
+            "mib": 0,
+            "cpu": 0,
+            "timeout_seconds": 60,
+        }
         assert rpc.call_args.kwargs["read_timeout_s"] >= 60
     finally:
         mcp_mod._pipeline = old_pipeline
@@ -98,7 +123,9 @@ async def test_send_and_wait_success():
         mcp_mod._pipeline = mock_pipeline
         tools = await mcp.get_tools()
         result = await tools["outreach_send_and_wait"].fn(
-            message="Do you approve?", category="blocker", channel="telegram",
+            message="Do you approve?",
+            category="blocker",
+            channel="telegram",
         )
         data = json.loads(result)
         assert data["reply"] == "user said yes"
@@ -123,7 +150,8 @@ async def test_send_and_wait_timeout():
         mcp_mod._pipeline = mock_pipeline
         tools = await mcp.get_tools()
         result = await tools["outreach_send_and_wait"].fn(
-            message="Are you there?", timeout_seconds=5,
+            message="Are you there?",
+            timeout_seconds=5,
         )
         data = json.loads(result)
         assert data["reply"] is None
@@ -140,7 +168,8 @@ async def test_send_and_wait_invalid_category():
         mcp_mod._pipeline = mock_pipeline
         tools = await mcp.get_tools()
         result = await tools["outreach_send_and_wait"].fn(
-            message="test", category="nonexistent",
+            message="test",
+            category="nonexistent",
         )
         assert "invalid category" in result.lower()
     finally:
@@ -182,8 +211,10 @@ async def test_outreach_poll_success():
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
     env = {"DISCORD_WEBHOOK_ANNOUNCEMENTS": "https://discord.com/api/webhooks/123/tok"}
-    with patch.dict("os.environ", env, clear=False), \
-         patch("genesis.mcp.outreach_mcp.httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch.dict("os.environ", env, clear=False),
+        patch("genesis.mcp.outreach_mcp.httpx.AsyncClient", return_value=mock_client),
+    ):
         result = await tools["outreach_poll"].fn(
             channel="announcements",
             question="What do you think?",
@@ -218,7 +249,9 @@ async def test_outreach_poll_http_error():
     mock_response.status_code = 403
     mock_response.text = "Forbidden"
     mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "403", request=MagicMock(), response=mock_response,
+        "403",
+        request=MagicMock(),
+        response=mock_response,
     )
 
     mock_client = AsyncMock()
@@ -227,8 +260,10 @@ async def test_outreach_poll_http_error():
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
     env = {"DISCORD_WEBHOOK_GENERAL": "https://discord.com/api/webhooks/456/tok2"}
-    with patch.dict("os.environ", env, clear=False), \
-         patch("genesis.mcp.outreach_mcp.httpx.AsyncClient", return_value=mock_client):
+    with (
+        patch.dict("os.environ", env, clear=False),
+        patch("genesis.mcp.outreach_mcp.httpx.AsyncClient", return_value=mock_client),
+    ):
         result = await tools["outreach_poll"].fn(
             channel="general",
             question="Test?",
@@ -253,7 +288,9 @@ async def test_send_standalone_invalid_category():
         mcp_mod._db = mock_db
         tools = await mcp.get_tools()
         result = await tools["outreach_send"].fn(
-            message="Test", category="discord", channel="discord",
+            message="Test",
+            category="discord",
+            channel="discord",
         )
         data = json.loads(result)
         assert "error" in data
@@ -273,11 +310,19 @@ async def test_send_standalone_valid_category():
     try:
         mcp_mod._pipeline = None
         mcp_mod._db = AsyncMock()
-        with patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock), \
-             patch("genesis.db.crud.pending_outreach.enqueue", new_callable=AsyncMock, return_value="pending-123"):
+        with (
+            patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock),
+            patch(
+                "genesis.db.crud.pending_outreach.enqueue",
+                new_callable=AsyncMock,
+                return_value="pending-123",
+            ),
+        ):
             tools = await mcp.get_tools()
             result = await tools["outreach_send"].fn(
-                message="Test post", category="content", channel="discord",
+                message="Test post",
+                category="content",
+                channel="discord",
             )
         data = json.loads(result)
         assert data["status"] == "queued"
@@ -298,13 +343,20 @@ async def test_send_standalone_email_resolves_and_enqueues_thread_recipient():
     try:
         mcp_mod._pipeline = None
         mcp_mod._db = AsyncMock()
-        with patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock), \
-             patch("genesis.db.crud.pending_outreach.enqueue", enq), \
-             patch("genesis.db.crud.email_threads.get_thread", new_callable=AsyncMock,
-                   return_value={"recipient": "real@prospect.com"}):
+        with (
+            patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock),
+            patch("genesis.db.crud.pending_outreach.enqueue", enq),
+            patch(
+                "genesis.db.crud.email_threads.get_thread",
+                new_callable=AsyncMock,
+                return_value={"recipient": "real@prospect.com"},
+            ),
+        ):
             tools = await mcp.get_tools()
             result = await tools["outreach_send"].fn(
-                message="following up", category="notification", channel="email",
+                message="following up",
+                category="notification",
+                channel="email",
                 thread_id="t1",
             )
         assert json.loads(result)["status"] == "queued"
@@ -325,11 +377,15 @@ async def test_send_standalone_email_without_thread_enqueues_no_recipient():
     try:
         mcp_mod._pipeline = None
         mcp_mod._db = AsyncMock()
-        with patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock), \
-             patch("genesis.db.crud.pending_outreach.enqueue", enq):
+        with (
+            patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock),
+            patch("genesis.db.crud.pending_outreach.enqueue", enq),
+        ):
             tools = await mcp.get_tools()
             await tools["outreach_send"].fn(
-                message="orphan", category="notification", channel="email",
+                message="orphan",
+                category="notification",
+                channel="email",
             )
         kwargs = enq.call_args.kwargs
         assert kwargs["thread_id"] is None
@@ -353,10 +409,15 @@ async def test_init_schedules_ensure_table_via_tracked_task():
         return MagicMock()
 
     try:
-        with patch("genesis.util.tasks.tracked_task", side_effect=_capture), \
-             patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock):
+        with (
+            patch("genesis.util.tasks.tracked_task", side_effect=_capture),
+            patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock),
+        ):
             mcp_mod.init_outreach_mcp(
-                pipeline=None, engagement=None, config=None, db=AsyncMock(),
+                pipeline=None,
+                engagement=None,
+                config=None,
+                db=AsyncMock(),
             )
         assert scheduled, "ensure_table was not scheduled via tracked_task"
         assert scheduled[0].get("name") == "outreach-ensure-pending-table"

--- a/tests/test_outreach/test_rpc.py
+++ b/tests/test_outreach/test_rpc.py
@@ -69,3 +69,31 @@ async def test_grow_via_pipeline_invalid_kind():
         )
     assert out["ok"] is False
     assert "invalid kind" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_grow_via_pipeline_root_asks_then_executes():
+    remote = MagicMock()
+    coord = AsyncMock(return_value={"ok": True, "verified": True})
+    with patch("genesis.observability.health._load_guardian_remote_from_config",
+               return_value=remote), \
+         patch("genesis.guardian.provisioning.container.coordinate_grow_root", coord):
+        out = await grow_via_pipeline(
+            AsyncMock(), kind="root", disk="scsi1", gib=40, mib=0, timeout_s=5,
+        )
+    assert out["ok"] is True
+    assert coord.call_args.kwargs == {"new_gb": 40}
+
+
+@pytest.mark.asyncio
+async def test_grow_via_pipeline_limits_passes_mem_and_cpu():
+    remote = MagicMock()
+    coord = AsyncMock(return_value={"ok": True})
+    with patch("genesis.observability.health._load_guardian_remote_from_config",
+               return_value=remote), \
+         patch("genesis.guardian.provisioning.container.coordinate_set_container_limits", coord):
+        out = await grow_via_pipeline(
+            AsyncMock(), kind="limits", disk="scsi1", gib=0, mib=20480, cpu=4, timeout_s=5,
+        )
+    assert out["ok"] is True
+    assert coord.call_args.kwargs == {"mem_mib": 20480, "cpu": 4}

--- a/tests/test_scripts/test_gateway_grow_root.py
+++ b/tests/test_scripts/test_gateway_grow_root.py
@@ -1,0 +1,113 @@
+"""Tests for the guardian-gateway.sh grow-root / set-container-limits verbs (PR-C).
+
+Runs the REAL gateway against a throwaway ``$HOME`` install, exercising the
+shell guard branches where gateway bugs hide: arg-regex rejection (incl. a
+flag-shaped token that must NOT hijack main()'s if-chain), the venv-missing and
+src-skew guards, and correct dispatch when everything is present. The execute
+logic itself is covered by test_grow_capacity.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+
+def _run(home: Path, verb: str):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["SSH_ORIGINAL_COMMAND"] = verb
+    return subprocess.run(
+        ["bash", str(_GATEWAY)],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _install(home: Path) -> Path:
+    d = home / ".local" / "share" / "genesis-guardian"
+    (d / "config").mkdir(parents=True)
+    (d / "config" / "guardian.yaml").write_text("container_name: genesis\n")
+    return d
+
+
+def _stub_python(install: Path, body: str) -> None:
+    py = install / ".venv" / "bin" / "python"
+    py.parent.mkdir(parents=True, exist_ok=True)
+    py.write_text(body)
+    py.chmod(0o755)
+
+
+def _with_src(install: Path) -> None:
+    mod = install / "src" / "genesis" / "guardian"
+    mod.mkdir(parents=True, exist_ok=True)
+    (mod / "grow_capacity.py").write_text("# stub for the skew guard\n")
+
+
+# ── grow-root ─────────────────────────────────────────────────────────────
+
+
+def test_grow_root_rejects_nonnumeric(tmp_path):
+    _install(tmp_path)
+    proc = _run(tmp_path, "grow-root 40G")  # suffix not allowed
+    assert proc.returncode == 1
+    assert "invalid arg" in proc.stderr
+
+
+def test_grow_root_rejects_flag_shaped_token(tmp_path):
+    """A flag-shaped arg must be rejected by the regex, never word-split into a
+    hijacking argv token (the configure-provisioning lesson)."""
+    _install(tmp_path)
+    proc = _run(tmp_path, "grow-root --storage-expand")
+    assert proc.returncode == 1
+    assert "invalid arg" in proc.stderr
+
+
+def test_grow_root_skew_guard(tmp_path):
+    install = _install(tmp_path)
+    _stub_python(install, "#!/bin/sh\necho SHOULD_NOT_RUN\n")  # no grow_capacity.py
+    proc = _run(tmp_path, "grow-root 40")
+    assert proc.returncode == 1
+    assert "predates grow-root" in proc.stderr
+    assert "SHOULD_NOT_RUN" not in proc.stdout
+
+
+def test_grow_root_dispatches_when_present(tmp_path):
+    install = _install(tmp_path)
+    _stub_python(install, '#!/bin/sh\necho "ARGS: $*"\n')
+    _with_src(install)
+    proc = _run(tmp_path, "grow-root 40")
+    assert proc.returncode == 0, proc.stderr
+    assert "--grow-root 40" in proc.stdout
+
+
+# ── set-container-limits ────────────────────────────────────────────────────
+
+
+def test_set_limits_rejects_bad_args(tmp_path):
+    _install(tmp_path)
+    assert _run(tmp_path, "set-container-limits abc 2").returncode == 1
+    assert _run(tmp_path, "set-container-limits 20480").returncode == 1  # missing cpu
+
+
+def test_set_limits_accepts_dash_axis(tmp_path):
+    install = _install(tmp_path)
+    _stub_python(install, '#!/bin/sh\necho "ARGS: $*"\n')
+    _with_src(install)
+    proc = _run(tmp_path, "set-container-limits 20480 -")
+    assert proc.returncode == 0, proc.stderr
+    assert "--set-container-limits 20480 -" in proc.stdout
+
+
+def test_set_limits_skew_guard(tmp_path):
+    install = _install(tmp_path)
+    _stub_python(install, "#!/bin/sh\necho SHOULD_NOT_RUN\n")
+    proc = _run(tmp_path, "set-container-limits 20480 4")
+    assert proc.returncode == 1
+    assert "predates set-container-limits" in proc.stderr
+    assert "SHOULD_NOT_RUN" not in proc.stdout


### PR DESCRIPTION
## What & why

Two **local incus** capacity levers (NOT Proxmox) that grow the container's OWN resources after the VM underneath has room. Motivated live: the container root is currently **84% used**.

- **`grow-root <GB>`** — raise the container root device to `<GB>` total. incus resizes the thin LV **and** the ext4 filesystem **online, no restart** (spike-proven on this host: incus 6.0, LVM+ext4, df 1.7G→2.7G, container stayed RUNNING). Grow-only; refused if the thin pool is at/above its HIGH tier.
- **`set-container-limits <mem_mib|-> <cpu|->`** — raise cgroup `limits.memory`/`limits.cpu`, applied **live** (spike-proven: `memory.max` 512M→1G with no restart). Grow-only; memory hard-capped below host `MemTotal − reserve` (`max(4GiB, 20%)`, config-formula, never a machine constant). **This closes the VM↔container coupling** — the missing half of a Phase-C RAM grow (after a VM memory grow + reboot, this makes the grown RAM reach the container).

## Architecture

Local host ops (like `storage-expand`), NOT the Proxmox `flow.py` path. Two-owner approval: the caller (container) approves via its bot before invoking the EXECUTE-only gateway verb. Wired end-to-end:

`provision_grow(kind=root|limits)` MCP tool → `rpc.grow_via_pipeline` → owner APPROVE/DENY → `container.coordinate_*` → `remote.request_*` → gateway verb → `grow_capacity.{grow_root,set_container_limits}` → incus.

## Security

Gateway verbs use **whole-string bash regexes** (digits/`-` only) that reject flag-shaped tokens — a bare `--flag` arg can't word-split into argv and hijack `main()`'s `if "--x" in sys.argv` dispatch (the `configure-provisioning` lesson). Each verb has the src-skew guard (stale gateway → clean JSON, never a `run_check` recovery cycle).

## Tests (69 green)
- `test_grow_capacity` — grow-only reject, pool-headroom refusal, success+verify, host-cap (starve-host) refusal, cpu range, size parsing
- `test_gateway_grow_root` — arg-regex + **flag-token rejection**, venv-missing, skew guard, dispatch
- `test_container_grow_root` — coordinate approve→execute / deny→no-execute
- `test_rpc` — `kind=root|limits` dispatch + cpu passthrough
- ruff + `bash -n` clean; grow_capacity host-safe (no aiohttp — F.4 lesson)

## Deploy / E2E
Touches `guardian/` + `guardian-gateway.sh` → host-guardian deploy via `update.sh` after merge. **Live E2E (post-deploy)**: `grow-root` + `set-container-limits` on a throwaway scratch container via the deployed gateway verb (grow mechanism itself already spike-proven on this host). Grows the real container root (84%→more) offered separately as an approved op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)