### PR TITLE
feat(observability): WS-2 PR-0 — sensor fabric (job_run_events + alert_events + M7/M9/M10/M11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now remembers how its background jobs actually ran, not just a
+  running tally.** Until now each scheduled job kept only a single cumulative
+  row, so a job that failed for a week and then recovered looked identical to
+  one that never failed — the history was gone. Genesis now keeps a per-run
+  record (with real durations where a job marks its own start), so a bad patch
+  or an intermittent outage leaves a visible trace instead of vanishing into an
+  average. It stays cheap on purpose: a healthy or a stuck high-frequency job is
+  recorded at most hourly, so the log captures every distinct episode without
+  drowning in routine ticks.
+
+- **Alert history survives a restart.** The list of what's currently wrong used
+  to live only in memory and reset every time Genesis restarted, so an incident
+  that opened and closed while you weren't looking left no record. Alerts are now
+  written to a durable incident log — each one opened when it starts firing and
+  stamped resolved when it clears — so you can see what happened overnight, not
+  just what's broken right now.
+
+- **Genesis notices when it stops learning about you.** The stream that updates
+  Genesis's model of you from its own reflections had gone quiet for months with
+  nothing flagging it. Genesis now watches that stream and raises a (non-paging)
+  alert if it goes silent for more than two weeks, and clears it automatically
+  once fresh learning resumes.
+
 - **Data backfills now heal themselves on update.** Some upgrades need more than
   a schema change — they need existing data reshaped (e.g. tagging every stored
   memory's vector with its provenance class). Those backfills used to be

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -382,7 +382,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: bca86011 2026-07-15
+verified: 47e7a132 2026-07-15
 ```
 
 - **awareness/**: the 5-min heartbeat. ~23 signal collectors (the richer
@@ -403,8 +403,21 @@ verified: bca86011 2026-07-15
   deployed_commit via `~/.genesis/host_gateway_state.json`; collectors in
   `observability/snapshots/deploy_health.py`), `high` on any drift, `critical`
   only sustained (≥7d AND ≥20 commits, or a missing unit alerted >24h).
-  It does NOT drive the ego cadence (ego has its own
+  Also per-tick (WS-2 M10) the SINGLE designated `alert_events` writer:
+  `_persist_health_alerts` recomputes the firing set via the pure
+  `mcp/health/errors.py::_compute_alerts()` and reconciles a durable open-set
+  (open row per firing alert, `resolved_at` stamped on clear) — replacing the
+  in-memory, per-process, one-generation `_alert_history` dict so incident
+  history survives restart. It does NOT drive the ego cadence (ego has its own
   scheduler). Trap: PEP 562 lazy `__init__` — don't eager-import `loop.py`.
+- **scheduled-job telemetry (WS-2 M9)**: `runtime/_job_health.py` keeps the
+  cumulative `job_health` row AND now appends per-run `job_run_events` (era
+  attribution the cumulative row can't give). Writes are debounced off the
+  persisted `job_health` anchors — a success only when ≥1h since the last, a
+  failure on streak onset + hourly heartbeat — so a stuck sub-hourly poll costs
+  ~24 rows/day. `duration_ms` is honest-or-NULL (only from an explicit
+  `record_job_start` marker; never derived from `last_run`). 90-day prune via
+  `_wire_drip_retention_jobs`.
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
   reflection bridge. GROUNDWORK: user-model-synthesis, pre-execution-gate

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -191,6 +191,18 @@ _EMBED_BACKLOG_COOLDOWN_S = 3600  # one alert per band per hour max
 _last_embed_backlog_alert_at: float = 0.0
 _last_embed_backlog_band: str = ""
 
+# WS-2 M7 — user-model-delta stream staleness. The reflection user-impact path
+# writes deltas to observations(type='user_model_delta'); the stream flatlined
+# ~Mar–Jul 2026 (only 2 deltas ever under the v3 pipeline). Diagnosis
+# (2026-07-15): the 0.90 per-delta confidence gate in reflection_bridge/_output.py
+# sits above the light-reflection model's median output confidence, so almost
+# nothing passes — a THRESHOLD throttle, not a plumbing bug. The behavioral fix
+# (revisit the gate/prompt/model) is a separate PR; this only UN-BLINDS the
+# silence so a future recurrence is caught in days, not months.
+_USER_MODEL_STALE_DAYS = 14
+_USER_MODEL_STALE_COOLDOWN_S = 86400  # at most one alert per day while stale
+_last_user_model_stale_alert_at: float = 0.0
+
 
 def _embed_backlog_band(failed: int) -> str:
     """Bucket the failed-embedding count into a stable band (only meaningful at
@@ -321,6 +333,99 @@ async def _resolve_embedding_backlog(db) -> None:
             )
     except Exception:
         logger.debug("Failed to resolve embedding backlog alerts", exc_info=True)
+
+
+async def _check_user_model_staleness(db) -> None:
+    """WS-2 M7: alert (non-paging 'high') when the user_model_delta stream is silent >14d.
+
+    Surfaced via the established infrastructure_alert observation idiom (dashboard
+    + morning report), NOT alert_events — alert_events has no reader UI in PR-0, so
+    routing the alarm only there would be built-but-blind. Auto-resolves when a
+    fresh delta lands. Best-effort; the whole body never raises into the tick."""
+    global _last_user_model_stale_alert_at
+    if db is None:
+        return
+    try:
+        async with db.execute(
+            "SELECT MAX(created_at) FROM observations WHERE type = 'user_model_delta'"
+        ) as cur:
+            row = await cur.fetchone()
+        last = row[0] if row and row[0] else None
+
+        now_dt = datetime.now(UTC)
+        age_days: int | None = None
+        if last is not None:
+            try:
+                age_days = (now_dt - datetime.fromisoformat(last)).days
+            except (ValueError, TypeError):
+                age_days = None
+
+        is_stale = last is None or (age_days is not None and age_days >= _USER_MODEL_STALE_DAYS)
+        if not is_stale:
+            await _resolve_user_model_staleness(db)
+            return
+
+        now = time.monotonic()
+        if (
+            _last_user_model_stale_alert_at
+            and now - _last_user_model_stale_alert_at < _USER_MODEL_STALE_COOLDOWN_S
+        ):
+            return
+
+        detail = (
+            "no user_model_delta has ever been recorded under the current pipeline"
+            if last is None
+            else f"the last user_model_delta was {age_days}d ago ({last})"
+        )
+        content_hash = hashlib.sha256(b"user_model_staleness").hexdigest()
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="user_model_staleness_monitor",
+            type="infrastructure_alert",
+            content=(
+                f"The user-model learning stream is stale: {detail}. Reflection "
+                f"user-impact deltas (observations type='user_model_delta') feed the "
+                f"user-model evolution job, so a silent stream means Genesis has stopped "
+                f"updating its model of the user. Likely throttle (diagnosed 2026-07-15): "
+                f"the 0.90 per-delta confidence gate in reflection_bridge/_output.py sits "
+                f"above the light-reflection model's median output confidence, so almost "
+                f"no delta passes — a behavioral fix tracked separately."
+            ),
+            priority="high",
+            created_at=now_dt.isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        if created is None:
+            return  # An unresolved staleness alert already exists.
+        _last_user_model_stale_alert_at = now
+        logger.warning("User-model staleness alert: %s", detail)
+    except Exception:
+        logger.debug("Failed user-model staleness check", exc_info=True)
+
+
+async def _resolve_user_model_staleness(db) -> None:
+    """Resolve a standing user-model staleness alert once a fresh delta lands.
+
+    Unconditional (no in-memory guard) so it survives restart; a cheap no-op when
+    nothing matches. Clears the cooldown so a recovery -> re-staleness re-alerts."""
+    global _last_user_model_stale_alert_at
+    if db is None:
+        return
+    try:
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source="user_model_staleness_monitor",
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="auto-resolved: a fresh user_model_delta arrived within the window",
+        )
+        if resolved:
+            _last_user_model_stale_alert_at = 0.0
+            logger.info("Auto-resolved %d user-model staleness alert(s)", resolved)
+    except Exception:
+        logger.debug("Failed to resolve user-model staleness alerts", exc_info=True)
 
 
 # Deploy staleness (WS-B): merged ≠ deployed. A bare git-merge between
@@ -1801,6 +1906,10 @@ class AwarenessLoop:
                     # signal → hourly; self-resolves on recovery. Best-effort
                     # (guarded internally); collectors never do network I/O.
                     await _check_deploy_staleness(self._db)
+                    # User-model-delta stream staleness (WS-2 M7) — a >14d silent
+                    # stream means Genesis stopped updating its model of the user.
+                    # Slow (14d) signal → hourly; self-resolves on a fresh delta.
+                    await _check_user_model_staleness(self._db)
                 await _check_wal_health(self._db)
                 # WS-2 M10: persist the alert/incident open-set to alert_events.
                 # Every tick (5 min), not hourly — a short-lived alert that fires

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -77,10 +77,10 @@ async def _sqlite_wal_truncate(db) -> None:
 # a read snapshot from an unclosed/cancelled cursor) makes the WAL file grow
 # unbounded. Alert on abnormal WAL size so a stuck reader is caught in minutes,
 # not days. Surfaces via the critical-observations job (Telegram) + morning report.
-_WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024   # 100 MB → "high" (morning report)
-_WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024   # 500 MB → "critical" (Telegram now)
-_WAL_ALERT_COOLDOWN_S = 3600               # one alert per hour max
-_WAL_TRUNCATE_EVERY_N_TICKS = 12           # hourly TRUNCATE (tick ≈ 5 min)
+_WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024  # 100 MB → "high" (morning report)
+_WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024  # 500 MB → "critical" (Telegram now)
+_WAL_ALERT_COOLDOWN_S = 3600  # one alert per hour max
+_WAL_TRUNCATE_EVERY_N_TICKS = 12  # hourly TRUNCATE (tick ≈ 5 min)
 # None = "never alerted". Must NOT be 0.0: time.monotonic() is since boot, so on a
 # freshly-booted host `now - 0.0` is small and would wrongly suppress the first alert.
 _last_wal_alert_at: float | None = None
@@ -95,6 +95,7 @@ async def _check_wal_health(db) -> None:
         from pathlib import Path
 
         from genesis.env import genesis_db_path
+
         wal_path = Path(f"{genesis_db_path()}-wal")
         if not wal_path.exists():
             return
@@ -135,6 +136,39 @@ async def _check_wal_health(db) -> None:
         logger.debug("Failed to create WAL health alert observation", exc_info=True)
 
 
+async def _persist_health_alerts(db) -> None:
+    """WS-2 M10: reconcile the durable ``alert_events`` open-set from live health.
+
+    The single DESIGNATED writer for alert persistence — runs once per tick in the
+    one runtime process. It recomputes the firing alert set via the pure
+    ``_compute_alerts()`` and reconciles the durable open-set (open a row per
+    newly-firing alert, stamp ``resolved_at`` on any that stopped firing). Writing
+    here rather than inside the multi-caller ``_impl_health_alerts`` read path
+    avoids the cross-process double-write; the partial unique index makes the
+    reconcile idempotent regardless. Best-effort; never raises into the tick.
+    """
+    if db is None:
+        return
+    try:
+        from genesis.db.crud import alert_events as _ae
+        from genesis.mcp.health.errors import _compute_alerts
+
+        alerts, _current_ids = await _compute_alerts()
+        active = [
+            {
+                "alert_id": a["id"],
+                "source": a["id"].split(":", 1)[0] if ":" in a["id"] else "health",
+                "severity": a.get("severity", "WARNING"),
+                "message": a.get("message", ""),
+            }
+            for a in alerts
+            if a.get("id")
+        ]
+        await _ae.reconcile_open_set(db, active=active, now=datetime.now(UTC).isoformat())
+    except Exception:
+        logger.debug("alert_events persistence failed (best-effort)", exc_info=True)
+
+
 # Embedding-backlog degradation: memories stuck at embedding_status='failed' —
 # the embedding recovery worker gave up, so they are permanently keyword-only
 # (no vector/semantic search) and invisible to every rate/per-run embedding
@@ -149,9 +183,9 @@ async def _check_wal_health(db) -> None:
 # tunable module constants. NOTE: 'pending' (self-healing) is context in the
 # alert text only; a sustained-pending stuck-worker signal is a separate
 # recovery-worker health concern, tracked as a follow-up, not alerted here.
-_EMBED_BACKLOG_LOW = 50            # below this: quiet (+ resolve any prior alert)
-_EMBED_BACKLOG_HIGH = 1000         # at/above this: 'critical' (pages); else 'high'
-_EMBED_BACKLOG_COOLDOWN_S = 3600   # one alert per band per hour max
+_EMBED_BACKLOG_LOW = 50  # below this: quiet (+ resolve any prior alert)
+_EMBED_BACKLOG_HIGH = 1000  # at/above this: 'critical' (pages); else 'high'
+_EMBED_BACKLOG_COOLDOWN_S = 3600  # one alert per band per hour max
 # Safe as 0.0/"" (unlike _check_wal_health): the band guard below means a fresh
 # boot never matches the empty band, so the first real backlog always alerts.
 _last_embed_backlog_alert_at: float = 0.0
@@ -206,9 +240,7 @@ async def _check_embedding_backlog(db) -> None:
 
         priority = "critical" if failed >= _EMBED_BACKLOG_HIGH else "high"
         pending = counts.get("pending", 0)
-        content_hash = hashlib.sha256(
-            f"embedding_backlog:{band}".encode()
-        ).hexdigest()
+        content_hash = hashlib.sha256(f"embedding_backlog:{band}".encode()).hexdigest()
         # Keep exactly ONE active alert = the current band. Resolve any
         # stale other-band rows so a worsening (high->critical) OR a partial
         # recovery (critical->high) transition leaves only the current-band
@@ -277,8 +309,7 @@ async def _resolve_embedding_backlog(db) -> None:
             type="infrastructure_alert",
             resolved_at=datetime.now(UTC).isoformat(),
             resolution_notes=(
-                f"auto-resolved: failed-embedding backlog back under "
-                f"{_EMBED_BACKLOG_LOW}"
+                f"auto-resolved: failed-embedding backlog back under {_EMBED_BACKLOG_LOW}"
             ),
         )
         if resolved:
@@ -655,7 +686,9 @@ def _fs_type_for(path) -> str | None:
                 if len(parts) < 3:
                     continue
                 mnt, typ = parts[1], parts[2]
-                if (target == mnt or target.startswith(mnt.rstrip("/") + "/")) and len(mnt) > len(best):
+                if (target == mnt or target.startswith(mnt.rstrip("/") + "/")) and len(mnt) > len(
+                    best
+                ):
                     best, fstype = mnt, typ
         return fstype
     except OSError:
@@ -673,6 +706,7 @@ async def _check_db_nodatacow(db) -> None:
         import struct
 
         from genesis.env import genesis_db_path
+
         db_path = genesis_db_path()
         if not db_path.exists() or _fs_type_for(db_path) != "btrfs":
             return
@@ -884,6 +918,7 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
             SLOT_RSS_WARN_MB,
             enumerate_cc_slots,
         )
+
         if slots is None:
             slots = enumerate_cc_slots()
     except Exception:
@@ -933,9 +968,9 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
 # CCInvocation.expect_output; see runtime/init/cc_relay._on_cc_empty_output). This
 # check aggregates a run of them into a single critical alert. Same monotonic-
 # since-boot caveat as WAL/slot: None = "never alerted", never 0.0.
-_CAP_EMPTY_WINDOW_MIN = 60          # look back this many minutes for empties
-_CAP_EMPTY_THRESHOLD = 3           # ≥ this many empties in the window → alert
-_CAP_ALERT_COOLDOWN_S = 3600       # one alert per hour max
+_CAP_EMPTY_WINDOW_MIN = 60  # look back this many minutes for empties
+_CAP_EMPTY_THRESHOLD = 3  # ≥ this many empties in the window → alert
+_CAP_ALERT_COOLDOWN_S = 3600  # one alert per hour max
 _last_cap_alert_at: float | None = None
 
 
@@ -960,7 +995,10 @@ async def _check_cc_cap_detection(db) -> None:
     try:
         cutoff = (datetime.now(UTC) - timedelta(minutes=_CAP_EMPTY_WINDOW_MIN)).isoformat()
         count = await observations.count_recent_unresolved_by_type_and_source(
-            db, type="cc_cap_empty_event", source="cc_cap_monitor", since=cutoff,
+            db,
+            type="cc_cap_empty_event",
+            source="cc_cap_monitor",
+            since=cutoff,
         )
 
         if count < _CAP_EMPTY_THRESHOLD:
@@ -1012,7 +1050,8 @@ async def _check_cc_cap_detection(db) -> None:
             return  # an unresolved cap alert already exists — don't duplicate
         logger.warning(
             "CC cap detection alert: %d empty cognitive completions in %d min",
-            count, _CAP_EMPTY_WINDOW_MIN,
+            count,
+            _CAP_EMPTY_WINDOW_MIN,
         )
     except Exception:
         logger.debug("cc_cap detection failed — skipping this tick", exc_info=True)
@@ -1081,7 +1120,10 @@ async def perform_tick(
                 # Fix 3A: expire stale escalations (>8h) before checking
                 _STALE_ESCALATION_HOURS = 8
                 all_pending = await observations.query(
-                    db, type="light_escalation_pending", resolved=False, limit=10,
+                    db,
+                    type="light_escalation_pending",
+                    resolved=False,
+                    limit=10,
                 )
                 for stale in all_pending:
                     stale_created = stale.get("created_at", "")
@@ -1093,15 +1135,21 @@ async def perform_tick(
                         stale_age = 999
                     if stale_age >= _STALE_ESCALATION_HOURS:
                         await observations.resolve(
-                            db, stale["id"],
+                            db,
+                            stale["id"],
                             resolved_at=now,
                             resolution_notes=f"Expired (age {stale_age:.1f}h > {_STALE_ESCALATION_HOURS}h TTL)",
                         )
-                        logger.info("Auto-resolved stale escalation %s (%.1fh old)", stale["id"], stale_age)
+                        logger.info(
+                            "Auto-resolved stale escalation %s (%.1fh old)", stale["id"], stale_age
+                        )
 
                 # Re-query after cleanup
                 pending_escalations = await observations.query(
-                    db, type="light_escalation_pending", resolved=False, limit=1,
+                    db,
+                    type="light_escalation_pending",
+                    resolved=False,
+                    limit=1,
                 )
                 if pending_escalations:
                     esc_created = pending_escalations[0].get("created_at", "")
@@ -1116,7 +1164,9 @@ async def perform_tick(
                         # Fix 2A: daily escalation budget (max 2 per 24h)
                         _ESCALATION_BUDGET_PER_DAY = 2
                         resolved_recent = await observations.query(
-                            db, type="light_escalation_resolved", limit=20,
+                            db,
+                            type="light_escalation_resolved",
+                            limit=20,
                         )
                         resolved_24h_count = 0
                         resolved_2h_count = 0
@@ -1135,21 +1185,30 @@ async def perform_tick(
 
                         # Check emergency bypass -- critical signals override budget
                         esc_content = pending_escalations[0].get("content", "").lower()
-                        is_emergency = any(kw in esc_content for kw in (
-                            "critical_failure", "data_loss", "security_breach",
-                            "all providers", "container memory critical",
-                        ))
+                        is_emergency = any(
+                            kw in esc_content
+                            for kw in (
+                                "critical_failure",
+                                "data_loss",
+                                "security_breach",
+                                "all providers",
+                                "container memory critical",
+                            )
+                        )
 
                         if resolved_2h_count >= 1 and not is_emergency:
                             logger.info("Light escalation cooldown active (2h), skipping")
                         elif resolved_24h_count >= _ESCALATION_BUDGET_PER_DAY and not is_emergency:
                             logger.info(
                                 "Escalation budget exhausted (%d/%d in 24h), skipping",
-                                resolved_24h_count, _ESCALATION_BUDGET_PER_DAY,
+                                resolved_24h_count,
+                                _ESCALATION_BUDGET_PER_DAY,
                             )
                         else:
                             if is_emergency:
-                                logger.warning("Emergency escalation bypassing budget: %s", esc_content[:100])
+                                logger.warning(
+                                    "Emergency escalation bypassing budget: %s", esc_content[:100]
+                                )
                             classified_depth = Depth.DEEP
                             escalation_source = "light_escalation"
                             trigger_reason = f"light escalation: {pending_escalations[0].get('content', 'unknown')}"
@@ -1165,17 +1224,30 @@ async def perform_tick(
             db,
             id=tick_id,
             source=source,
-            signals_json=json.dumps([
-                {"name": s.name, "value": s.value, "source": s.source,
-                 "collected_at": s.collected_at}
-                for s in signals
-            ]),
-            scores_json=json.dumps([
-                {"depth": s.depth.value, "raw_score": s.raw_score,
-                 "time_multiplier": s.time_multiplier, "final_score": s.final_score,
-                 "threshold": s.threshold, "triggered": s.triggered}
-                for s in scores
-            ]),
+            signals_json=json.dumps(
+                [
+                    {
+                        "name": s.name,
+                        "value": s.value,
+                        "source": s.source,
+                        "collected_at": s.collected_at,
+                    }
+                    for s in signals
+                ]
+            ),
+            scores_json=json.dumps(
+                [
+                    {
+                        "depth": s.depth.value,
+                        "raw_score": s.raw_score,
+                        "time_multiplier": s.time_multiplier,
+                        "final_score": s.final_score,
+                        "threshold": s.threshold,
+                        "triggered": s.triggered,
+                    }
+                    for s in scores
+                ]
+            ),
             classified_depth=classified_depth.value if classified_depth else None,
             trigger_reason=trigger_reason,
             created_at=now,
@@ -1183,15 +1255,21 @@ async def perform_tick(
 
         # 5. If triggered, also create an observation (with content-hash dedup)
         if decision is not None:
-            obs_content = json.dumps({
-                "tick_id": tick_id,
-                "depth": classified_depth.value,
-                "reason": trigger_reason,
-                "scores": {s.depth.value: s.final_score for s in scores},
-            }, sort_keys=True)
+            obs_content = json.dumps(
+                {
+                    "tick_id": tick_id,
+                    "depth": classified_depth.value,
+                    "reason": trigger_reason,
+                    "scores": {s.depth.value: s.final_score for s in scores},
+                },
+                sort_keys=True,
+            )
             content_hash = hashlib.sha256(obs_content.encode()).hexdigest()
             is_dup = await observations.exists_by_hash(
-                db, source="awareness_loop", content_hash=content_hash, unresolved_only=True,
+                db,
+                source="awareness_loop",
+                content_hash=content_hash,
+                unresolved_only=True,
             )
             if not is_dup:
                 obs_id = str(uuid.uuid4())
@@ -1201,7 +1279,9 @@ async def perform_tick(
                     source="awareness_loop",
                     type="awareness_tick",
                     content=obs_content,
-                    priority="high" if classified_depth in (Depth.DEEP, Depth.STRATEGIC) else "medium",
+                    priority="high"
+                    if classified_depth in (Depth.DEEP, Depth.STRATEGIC)
+                    else "medium",
                     created_at=now,
                     content_hash=content_hash,
                     skip_if_duplicate=True,
@@ -1211,7 +1291,8 @@ async def perform_tick(
         db_available = False
         logger.warning(
             "Tick DB operations failed — degraded tick (signals collected, "
-            "scoring/persistence skipped): %s", db_exc,
+            "scoring/persistence skipped): %s",
+            db_exc,
         )
 
     result = TickResult(
@@ -1252,7 +1333,11 @@ async def perform_tick(
             except Exception:
                 logger.warning("Failed to enqueue deferred reflection")
 
-    if classified_depth == Depth.LIGHT and cc_reflection_bridge is None and reflection_engine is not None:
+    if (
+        classified_depth == Depth.LIGHT
+        and cc_reflection_bridge is None
+        and reflection_engine is not None
+    ):
         try:
             await reflection_engine.reflect(classified_depth, result, db=db)
         except Exception:
@@ -1270,7 +1355,11 @@ async def perform_tick(
                     )
                 except Exception:
                     logger.warning("Failed to enqueue deferred reflection")
-    elif cc_reflection_bridge is not None and classified_depth in (Depth.LIGHT, Depth.DEEP, Depth.STRATEGIC):
+    elif cc_reflection_bridge is not None and classified_depth in (
+        Depth.LIGHT,
+        Depth.DEEP,
+        Depth.STRATEGIC,
+    ):
         try:
             ref_result = await cc_reflection_bridge.reflect(
                 classified_depth,
@@ -1285,14 +1374,16 @@ async def perform_tick(
             if ref_result is not None and not ref_result.success:
                 logger.info(
                     "%s reflection deferred for tick %s: %s",
-                    classified_depth.value, tick_id,
+                    classified_depth.value,
+                    tick_id,
                     ref_result.reason or "unknown",
                 )
             # Resolve escalation after successful dispatch
             if escalation_pending_id and classified_depth == Depth.DEEP:
                 try:
                     await observations.resolve(
-                        db, escalation_pending_id,
+                        db,
+                        escalation_pending_id,
                         resolved_at=now,
                         resolution_notes="Escalation consumed by deep reflection",
                     )
@@ -1306,7 +1397,9 @@ async def perform_tick(
                         created_at=now,
                     )
                 except Exception:
-                    logger.warning("Failed to resolve escalation %s", escalation_pending_id, exc_info=True)
+                    logger.warning(
+                        "Failed to resolve escalation %s", escalation_pending_id, exc_info=True
+                    )
         except Exception:
             logger.exception("CC reflection failed for tick %s", tick_id)
             if deferred_queue and classified_depth:
@@ -1410,7 +1503,8 @@ class AwarenessLoop:
                 down = []
                 if self._circuit_breakers:
                     down = [
-                        name for name, cb in self._circuit_breakers._breakers.items()
+                        name
+                        for name, cb in self._circuit_breakers._breakers.items()
                         if not cb.is_available()
                     ]
                 detail = f"Providers down: {', '.join(sorted(down))}" if down else ""
@@ -1424,7 +1518,9 @@ class AwarenessLoop:
                 generated_by="awareness_loop",
                 created_at=now,
             )
-            logger.info("Resilience cognitive state updated: %s → %s", self._last_degradation_level, level)
+            logger.info(
+                "Resilience cognitive state updated: %s → %s", self._last_degradation_level, level
+            )
         except Exception:
             logger.warning("Failed to update resilience cognitive state", exc_info=True)
 
@@ -1454,7 +1550,8 @@ class AwarenessLoop:
             )
         except Exception:
             logger.warning(
-                "Failed to register scheduler job-event listener", exc_info=True,
+                "Failed to register scheduler job-event listener",
+                exc_info=True,
             )
         self._scheduler.start()
         logger.info("Awareness Loop started (interval=%dm, immediate first tick)", self._interval)
@@ -1483,10 +1580,7 @@ class AwarenessLoop:
             return
         if event_code == EVENT_JOB_MAX_INSTANCES:
             event_type = "tick.max_instances"
-            message = (
-                "Awareness tick dropped: previous tick still running "
-                "(max_instances=1)"
-            )
+            message = "Awareness tick dropped: previous tick still running (max_instances=1)"
         elif event_code == EVENT_JOB_MISSED:
             event_type = "tick.missed"
             message = "Awareness tick missed (past misfire grace time)"
@@ -1514,8 +1608,10 @@ class AwarenessLoop:
         async with self._tick_lock:
             logger.info("Force tick triggered: %s", reason)
             result = await perform_tick(
-                self._db, self._collectors,
-                source="critical_bypass", reason=reason,
+                self._db,
+                self._collectors,
+                source="critical_bypass",
+                reason=reason,
                 reflection_engine=self._reflection_engine,
                 cc_reflection_bridge=self._cc_reflection_bridge,
                 deferred_queue=self._deferred_queue,
@@ -1539,7 +1635,9 @@ class AwarenessLoop:
         async with self._tick_lock:
             try:
                 result = await perform_tick(
-                    self._db, self._collectors, source="scheduled",
+                    self._db,
+                    self._collectors,
+                    source="scheduled",
                     reflection_engine=self._reflection_engine,
                     cc_reflection_bridge=self._cc_reflection_bridge,
                     deferred_queue=self._deferred_queue,
@@ -1554,12 +1652,14 @@ class AwarenessLoop:
                 logger.exception("Awareness tick failed unexpectedly")
                 if self._event_bus:
                     await self._event_bus.emit(
-                        Subsystem.AWARENESS, Severity.ERROR,
+                        Subsystem.AWARENESS,
+                        Severity.ERROR,
                         "tick.failed",
                         "Awareness tick failed with exception",
                     )
                 try:
                     from genesis.runtime import GenesisRuntime
+
                     GenesisRuntime.instance().record_job_failure("awareness_tick", str(exc))
                 except Exception:
                     pass
@@ -1576,7 +1676,8 @@ class AwarenessLoop:
                 if result.classified_depth:
                     logger.info(
                         "Tick triggered %s: %s",
-                        result.classified_depth.value, result.trigger_reason,
+                        result.classified_depth.value,
+                        result.trigger_reason,
                     )
 
                 if not result.db_available:
@@ -1588,24 +1689,28 @@ class AwarenessLoop:
                 # Heartbeat — lets health MCP detect silent death
                 if self._event_bus:
                     await self._event_bus.emit(
-                        Subsystem.AWARENESS, Severity.DEBUG,
+                        Subsystem.AWARENESS,
+                        Severity.DEBUG,
                         "heartbeat",
                         "awareness_loop tick completed"
                         + (" (degraded)" if not result.db_available else ""),
                     )
                 try:
                     from genesis.runtime import GenesisRuntime
+
                     if result.db_available:
                         GenesisRuntime.instance().record_job_success("awareness_tick")
                     else:
                         GenesisRuntime.instance().record_job_failure(
-                            "awareness_tick", "DB unavailable (degraded tick)")
+                            "awareness_tick", "DB unavailable (degraded tick)"
+                        )
                 except Exception:
                     pass  # Runtime may not be available in tests
 
             # Update resilience memory axis based on DB availability
             if self._resilience_state_machine and result is not None:
                 from genesis.resilience.state import MemoryStatus
+
                 if result.db_available:
                     self._resilience_state_machine.update_memory(MemoryStatus.NORMAL)
                 else:
@@ -1697,6 +1802,11 @@ class AwarenessLoop:
                     # (guarded internally); collectors never do network I/O.
                     await _check_deploy_staleness(self._db)
                 await _check_wal_health(self._db)
+                # WS-2 M10: persist the alert/incident open-set to alert_events.
+                # Every tick (5 min), not hourly — a short-lived alert that fires
+                # and clears within the hour must still leave a durable incident
+                # row. Single designated writer; best-effort (guarded internally).
+                await _persist_health_alerts(self._db)
                 # Duplicate CC executor — a twin lasts MINUTES, so this pages
                 # per-tick (hourly would miss the incident window entirely);
                 # the scan is a small-dir glob + a few /proc stats. Owner-file
@@ -1722,6 +1832,7 @@ class AwarenessLoop:
             if self._remediation_registry:
                 try:
                     from genesis.observability.health import collect_probe_results
+
                     probe_results = await collect_probe_results(self._db)
                     outcomes = await self._remediation_registry.check_and_remediate(
                         probe_results,
@@ -1815,6 +1926,7 @@ class AwarenessLoop:
         # Kill switch — tick/heartbeats still run but no dispatches when paused
         try:
             from genesis.runtime import GenesisRuntime
+
             if GenesisRuntime.instance().paused:
                 logger.debug("Skipping reflection dispatch (Genesis paused)")
                 return
@@ -1872,7 +1984,8 @@ class AwarenessLoop:
                 if obs_result and obs_result.notes_stored > 0:
                     logger.info(
                         "Session observer: %d notes from %d observations",
-                        obs_result.notes_stored, obs_result.observations_read,
+                        obs_result.notes_stored,
+                        obs_result.observations_read,
                     )
             except Exception:
                 logger.warning("Session observer processing failed", exc_info=True)
@@ -1896,8 +2009,10 @@ class AwarenessLoop:
             return
         with contextlib.suppress(Exception):
             await self._event_bus.emit(
-                Subsystem.REFLECTION, Severity.DEBUG,
-                "heartbeat", "reflection idle (no depth triggered)",
+                Subsystem.REFLECTION,
+                Severity.DEBUG,
+                "heartbeat",
+                "reflection idle (no depth triggered)",
             )
 
     async def _dispatch_reflection(self, result: TickResult) -> None:
@@ -1909,7 +2024,8 @@ class AwarenessLoop:
         db = self._db
         logger.info(
             "Dispatch reflection: depth=%s, tick=%s, bridge=%s, engine=%s",
-            depth.value, tick_id[:8],
+            depth.value,
+            tick_id[:8],
             self._cc_reflection_bridge is not None,
             self._reflection_engine is not None,
         )
@@ -1918,10 +2034,10 @@ class AwarenessLoop:
             # Check for critical operational signals that warrant LLM analysis.
             # Routine micro ticks are silent (counted for escalation cascade only).
             critical_active = any(
-                s.value > 0 for s in result.signals
-                if s.name in _MICRO_CRITICAL_SIGNALS
+                s.value > 0 for s in result.signals if s.name in _MICRO_CRITICAL_SIGNALS
             ) or any(
-                s.value >= _SENTINEL_ANOMALY_THRESHOLD for s in result.signals
+                s.value >= _SENTINEL_ANOMALY_THRESHOLD
+                for s in result.signals
                 if s.name == "sentinel_activity"
             )
 
@@ -1936,8 +2052,10 @@ class AwarenessLoop:
                 if ref_result and ref_result.success and self._event_bus:
                     try:
                         await self._event_bus.emit(
-                            Subsystem.REFLECTION, Severity.DEBUG,
-                            "heartbeat", "micro-reflection completed",
+                            Subsystem.REFLECTION,
+                            Severity.DEBUG,
+                            "heartbeat",
+                            "micro-reflection completed",
                         )
                     except Exception:
                         logger.warning("Failed to emit reflection heartbeat", exc_info=True)
@@ -1956,7 +2074,8 @@ class AwarenessLoop:
                         await self._topic_manager.send_to_category("reflection_micro", text)
                         logger.info(
                             "Posted micro reflection to Telegram (tick=%s, salience=%.2f)",
-                            tick_id[:8], micro.salience,
+                            tick_id[:8],
+                            micro.salience,
                         )
                     except Exception:
                         logger.warning("Failed to post micro reflection to topic", exc_info=True)
@@ -1988,8 +2107,10 @@ class AwarenessLoop:
                 if self._event_bus:
                     with contextlib.suppress(Exception):
                         await self._event_bus.emit(
-                            Subsystem.REFLECTION, Severity.DEBUG,
-                            "heartbeat", "reflection idle (no critical signals)",
+                            Subsystem.REFLECTION,
+                            Severity.DEBUG,
+                            "heartbeat",
+                            "reflection idle (no critical signals)",
                         )
 
             # Always mark dispatched — cascade counting works on ticks
@@ -1999,7 +2120,11 @@ class AwarenessLoop:
                 logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
             return
 
-        if depth == Depth.LIGHT and self._cc_reflection_bridge is None and self._reflection_engine is not None:
+        if (
+            depth == Depth.LIGHT
+            and self._cc_reflection_bridge is None
+            and self._reflection_engine is not None
+        ):
             try:
                 await self._reflection_engine.reflect(depth, result, db=db)
                 # Emit reflection heartbeat so subsystem_heartbeats doesn't
@@ -2007,8 +2132,10 @@ class AwarenessLoop:
                 if self._event_bus:
                     with contextlib.suppress(Exception):
                         await self._event_bus.emit(
-                            Subsystem.REFLECTION, Severity.DEBUG,
-                            "heartbeat", "light-reflection completed (API)",
+                            Subsystem.REFLECTION,
+                            Severity.DEBUG,
+                            "heartbeat",
+                            "light-reflection completed (API)",
                         )
             except Exception:
                 logger.exception("Light reflection fallback (API) failed for tick %s", tick_id)
@@ -2027,7 +2154,11 @@ class AwarenessLoop:
                         logger.warning("Failed to enqueue deferred reflection")
             return
 
-        if self._cc_reflection_bridge is not None and depth in (Depth.LIGHT, Depth.DEEP, Depth.STRATEGIC):
+        if self._cc_reflection_bridge is not None and depth in (
+            Depth.LIGHT,
+            Depth.DEEP,
+            Depth.STRATEGIC,
+        ):
             try:
                 ref_result = await self._cc_reflection_bridge.reflect(
                     depth,
@@ -2051,7 +2182,8 @@ class AwarenessLoop:
                     if self._event_bus:
                         with contextlib.suppress(Exception):
                             await self._event_bus.emit(
-                                Subsystem.REFLECTION, Severity.DEBUG,
+                                Subsystem.REFLECTION,
+                                Severity.DEBUG,
                                 "heartbeat",
                                 f"{depth.value.lower()}-reflection completed",
                             )
@@ -2136,14 +2268,20 @@ class AwarenessLoop:
                     continue  # Another tick already consumed it
                 logger.info(
                     "Resuming %s reflection from approved request %s",
-                    depth_name, approved["id"][:8],
+                    depth_name,
+                    approved["id"][:8],
                 )
                 await self._cc_reflection_bridge.reflect(
-                    depth, tick, db=self._db, skip_approval=True,
+                    depth,
+                    tick,
+                    db=self._db,
+                    skip_approval=True,
                 )
             except Exception:
                 logger.error(
-                    "Failed to resume %s reflection", depth_name, exc_info=True,
+                    "Failed to resume %s reflection",
+                    depth_name,
+                    exc_info=True,
                 )
 
     async def _resume_approved_sentinel_dispatches(self) -> None:
@@ -2215,7 +2353,9 @@ class AwarenessLoop:
         await self._deferred_queue.mark_processing(item_id)
         logger.info(
             "Retrying deferred reflection: id=%s depth=%s attempt=%d",
-            item_id, depth.value, attempts + 1,
+            item_id,
+            depth.value,
+            attempts + 1,
         )
 
         try:
@@ -2225,7 +2365,8 @@ class AwarenessLoop:
                 result = await self._reflection_engine.reflect(depth, current_tick, db=self._db)
             else:
                 logger.warning(
-                    "No reflection handler for depth=%s — leaving pending", depth.value,
+                    "No reflection handler for depth=%s — leaving pending",
+                    depth.value,
                 )
                 await self._deferred_queue.reset_to_pending(item_id)
                 return
@@ -2239,13 +2380,18 @@ class AwarenessLoop:
                 await self._deferred_queue.reset_to_pending(item_id)
                 logger.info(
                     "Deferred reflection not ready: id=%s depth=%s reason=%s — will retry",
-                    item_id, depth.value, result.reason or "unknown",
+                    item_id,
+                    depth.value,
+                    result.reason or "unknown",
                 )
         except Exception:
             new_attempts = attempts + 1  # mark_processing already incremented in DB
             logger.warning(
                 "Deferred reflection retry failed: id=%s depth=%s attempt=%d",
-                item_id, depth.value, new_attempts, exc_info=True,
+                item_id,
+                depth.value,
+                new_attempts,
+                exc_info=True,
             )
             if new_attempts >= 3:
                 await self._deferred_queue.mark_discarded(
@@ -2254,7 +2400,8 @@ class AwarenessLoop:
                 )
                 if self._event_bus:
                     await self._event_bus.emit(
-                        Subsystem.AWARENESS, Severity.WARNING,
+                        Subsystem.AWARENESS,
+                        Severity.WARNING,
                         "deferred.max_attempts",
                         f"Deferred {depth.value} reflection failed after {new_attempts} attempts",
                     )
@@ -2268,7 +2415,8 @@ class AwarenessLoop:
 
         try:
             await observations.resolve(
-                self._db, pending_id,
+                self._db,
+                pending_id,
                 resolved_at=now,
                 resolution_notes="Escalation consumed by deep reflection",
             )

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -77,10 +77,10 @@ async def _sqlite_wal_truncate(db) -> None:
 # a read snapshot from an unclosed/cancelled cursor) makes the WAL file grow
 # unbounded. Alert on abnormal WAL size so a stuck reader is caught in minutes,
 # not days. Surfaces via the critical-observations job (Telegram) + morning report.
-_WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024  # 100 MB → "high" (morning report)
-_WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024  # 500 MB → "critical" (Telegram now)
-_WAL_ALERT_COOLDOWN_S = 3600  # one alert per hour max
-_WAL_TRUNCATE_EVERY_N_TICKS = 12  # hourly TRUNCATE (tick ≈ 5 min)
+_WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024   # 100 MB → "high" (morning report)
+_WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024   # 500 MB → "critical" (Telegram now)
+_WAL_ALERT_COOLDOWN_S = 3600               # one alert per hour max
+_WAL_TRUNCATE_EVERY_N_TICKS = 12           # hourly TRUNCATE (tick ≈ 5 min)
 # None = "never alerted". Must NOT be 0.0: time.monotonic() is since boot, so on a
 # freshly-booted host `now - 0.0` is small and would wrongly suppress the first alert.
 _last_wal_alert_at: float | None = None
@@ -95,7 +95,6 @@ async def _check_wal_health(db) -> None:
         from pathlib import Path
 
         from genesis.env import genesis_db_path
-
         wal_path = Path(f"{genesis_db_path()}-wal")
         if not wal_path.exists():
             return
@@ -183,9 +182,9 @@ async def _persist_health_alerts(db) -> None:
 # tunable module constants. NOTE: 'pending' (self-healing) is context in the
 # alert text only; a sustained-pending stuck-worker signal is a separate
 # recovery-worker health concern, tracked as a follow-up, not alerted here.
-_EMBED_BACKLOG_LOW = 50  # below this: quiet (+ resolve any prior alert)
-_EMBED_BACKLOG_HIGH = 1000  # at/above this: 'critical' (pages); else 'high'
-_EMBED_BACKLOG_COOLDOWN_S = 3600  # one alert per band per hour max
+_EMBED_BACKLOG_LOW = 50            # below this: quiet (+ resolve any prior alert)
+_EMBED_BACKLOG_HIGH = 1000         # at/above this: 'critical' (pages); else 'high'
+_EMBED_BACKLOG_COOLDOWN_S = 3600   # one alert per band per hour max
 # Safe as 0.0/"" (unlike _check_wal_health): the band guard below means a fresh
 # boot never matches the empty band, so the first real backlog always alerts.
 _last_embed_backlog_alert_at: float = 0.0
@@ -252,7 +251,9 @@ async def _check_embedding_backlog(db) -> None:
 
         priority = "critical" if failed >= _EMBED_BACKLOG_HIGH else "high"
         pending = counts.get("pending", 0)
-        content_hash = hashlib.sha256(f"embedding_backlog:{band}".encode()).hexdigest()
+        content_hash = hashlib.sha256(
+            f"embedding_backlog:{band}".encode()
+        ).hexdigest()
         # Keep exactly ONE active alert = the current band. Resolve any
         # stale other-band rows so a worsening (high->critical) OR a partial
         # recovery (critical->high) transition leaves only the current-band
@@ -321,7 +322,8 @@ async def _resolve_embedding_backlog(db) -> None:
             type="infrastructure_alert",
             resolved_at=datetime.now(UTC).isoformat(),
             resolution_notes=(
-                f"auto-resolved: failed-embedding backlog back under {_EMBED_BACKLOG_LOW}"
+                f"auto-resolved: failed-embedding backlog back under "
+                f"{_EMBED_BACKLOG_LOW}"
             ),
         )
         if resolved:
@@ -791,9 +793,7 @@ def _fs_type_for(path) -> str | None:
                 if len(parts) < 3:
                     continue
                 mnt, typ = parts[1], parts[2]
-                if (target == mnt or target.startswith(mnt.rstrip("/") + "/")) and len(mnt) > len(
-                    best
-                ):
+                if (target == mnt or target.startswith(mnt.rstrip("/") + "/")) and len(mnt) > len(best):
                     best, fstype = mnt, typ
         return fstype
     except OSError:
@@ -811,7 +811,6 @@ async def _check_db_nodatacow(db) -> None:
         import struct
 
         from genesis.env import genesis_db_path
-
         db_path = genesis_db_path()
         if not db_path.exists() or _fs_type_for(db_path) != "btrfs":
             return
@@ -1023,7 +1022,6 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
             SLOT_RSS_WARN_MB,
             enumerate_cc_slots,
         )
-
         if slots is None:
             slots = enumerate_cc_slots()
     except Exception:
@@ -1073,9 +1071,9 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
 # CCInvocation.expect_output; see runtime/init/cc_relay._on_cc_empty_output). This
 # check aggregates a run of them into a single critical alert. Same monotonic-
 # since-boot caveat as WAL/slot: None = "never alerted", never 0.0.
-_CAP_EMPTY_WINDOW_MIN = 60  # look back this many minutes for empties
-_CAP_EMPTY_THRESHOLD = 3  # ≥ this many empties in the window → alert
-_CAP_ALERT_COOLDOWN_S = 3600  # one alert per hour max
+_CAP_EMPTY_WINDOW_MIN = 60          # look back this many minutes for empties
+_CAP_EMPTY_THRESHOLD = 3           # ≥ this many empties in the window → alert
+_CAP_ALERT_COOLDOWN_S = 3600       # one alert per hour max
 _last_cap_alert_at: float | None = None
 
 
@@ -1100,10 +1098,7 @@ async def _check_cc_cap_detection(db) -> None:
     try:
         cutoff = (datetime.now(UTC) - timedelta(minutes=_CAP_EMPTY_WINDOW_MIN)).isoformat()
         count = await observations.count_recent_unresolved_by_type_and_source(
-            db,
-            type="cc_cap_empty_event",
-            source="cc_cap_monitor",
-            since=cutoff,
+            db, type="cc_cap_empty_event", source="cc_cap_monitor", since=cutoff,
         )
 
         if count < _CAP_EMPTY_THRESHOLD:
@@ -1155,8 +1150,7 @@ async def _check_cc_cap_detection(db) -> None:
             return  # an unresolved cap alert already exists — don't duplicate
         logger.warning(
             "CC cap detection alert: %d empty cognitive completions in %d min",
-            count,
-            _CAP_EMPTY_WINDOW_MIN,
+            count, _CAP_EMPTY_WINDOW_MIN,
         )
     except Exception:
         logger.debug("cc_cap detection failed — skipping this tick", exc_info=True)
@@ -1225,10 +1219,7 @@ async def perform_tick(
                 # Fix 3A: expire stale escalations (>8h) before checking
                 _STALE_ESCALATION_HOURS = 8
                 all_pending = await observations.query(
-                    db,
-                    type="light_escalation_pending",
-                    resolved=False,
-                    limit=10,
+                    db, type="light_escalation_pending", resolved=False, limit=10,
                 )
                 for stale in all_pending:
                     stale_created = stale.get("created_at", "")
@@ -1240,21 +1231,15 @@ async def perform_tick(
                         stale_age = 999
                     if stale_age >= _STALE_ESCALATION_HOURS:
                         await observations.resolve(
-                            db,
-                            stale["id"],
+                            db, stale["id"],
                             resolved_at=now,
                             resolution_notes=f"Expired (age {stale_age:.1f}h > {_STALE_ESCALATION_HOURS}h TTL)",
                         )
-                        logger.info(
-                            "Auto-resolved stale escalation %s (%.1fh old)", stale["id"], stale_age
-                        )
+                        logger.info("Auto-resolved stale escalation %s (%.1fh old)", stale["id"], stale_age)
 
                 # Re-query after cleanup
                 pending_escalations = await observations.query(
-                    db,
-                    type="light_escalation_pending",
-                    resolved=False,
-                    limit=1,
+                    db, type="light_escalation_pending", resolved=False, limit=1,
                 )
                 if pending_escalations:
                     esc_created = pending_escalations[0].get("created_at", "")
@@ -1269,9 +1254,7 @@ async def perform_tick(
                         # Fix 2A: daily escalation budget (max 2 per 24h)
                         _ESCALATION_BUDGET_PER_DAY = 2
                         resolved_recent = await observations.query(
-                            db,
-                            type="light_escalation_resolved",
-                            limit=20,
+                            db, type="light_escalation_resolved", limit=20,
                         )
                         resolved_24h_count = 0
                         resolved_2h_count = 0
@@ -1290,30 +1273,21 @@ async def perform_tick(
 
                         # Check emergency bypass -- critical signals override budget
                         esc_content = pending_escalations[0].get("content", "").lower()
-                        is_emergency = any(
-                            kw in esc_content
-                            for kw in (
-                                "critical_failure",
-                                "data_loss",
-                                "security_breach",
-                                "all providers",
-                                "container memory critical",
-                            )
-                        )
+                        is_emergency = any(kw in esc_content for kw in (
+                            "critical_failure", "data_loss", "security_breach",
+                            "all providers", "container memory critical",
+                        ))
 
                         if resolved_2h_count >= 1 and not is_emergency:
                             logger.info("Light escalation cooldown active (2h), skipping")
                         elif resolved_24h_count >= _ESCALATION_BUDGET_PER_DAY and not is_emergency:
                             logger.info(
                                 "Escalation budget exhausted (%d/%d in 24h), skipping",
-                                resolved_24h_count,
-                                _ESCALATION_BUDGET_PER_DAY,
+                                resolved_24h_count, _ESCALATION_BUDGET_PER_DAY,
                             )
                         else:
                             if is_emergency:
-                                logger.warning(
-                                    "Emergency escalation bypassing budget: %s", esc_content[:100]
-                                )
+                                logger.warning("Emergency escalation bypassing budget: %s", esc_content[:100])
                             classified_depth = Depth.DEEP
                             escalation_source = "light_escalation"
                             trigger_reason = f"light escalation: {pending_escalations[0].get('content', 'unknown')}"
@@ -1329,30 +1303,17 @@ async def perform_tick(
             db,
             id=tick_id,
             source=source,
-            signals_json=json.dumps(
-                [
-                    {
-                        "name": s.name,
-                        "value": s.value,
-                        "source": s.source,
-                        "collected_at": s.collected_at,
-                    }
-                    for s in signals
-                ]
-            ),
-            scores_json=json.dumps(
-                [
-                    {
-                        "depth": s.depth.value,
-                        "raw_score": s.raw_score,
-                        "time_multiplier": s.time_multiplier,
-                        "final_score": s.final_score,
-                        "threshold": s.threshold,
-                        "triggered": s.triggered,
-                    }
-                    for s in scores
-                ]
-            ),
+            signals_json=json.dumps([
+                {"name": s.name, "value": s.value, "source": s.source,
+                 "collected_at": s.collected_at}
+                for s in signals
+            ]),
+            scores_json=json.dumps([
+                {"depth": s.depth.value, "raw_score": s.raw_score,
+                 "time_multiplier": s.time_multiplier, "final_score": s.final_score,
+                 "threshold": s.threshold, "triggered": s.triggered}
+                for s in scores
+            ]),
             classified_depth=classified_depth.value if classified_depth else None,
             trigger_reason=trigger_reason,
             created_at=now,
@@ -1360,21 +1321,15 @@ async def perform_tick(
 
         # 5. If triggered, also create an observation (with content-hash dedup)
         if decision is not None:
-            obs_content = json.dumps(
-                {
-                    "tick_id": tick_id,
-                    "depth": classified_depth.value,
-                    "reason": trigger_reason,
-                    "scores": {s.depth.value: s.final_score for s in scores},
-                },
-                sort_keys=True,
-            )
+            obs_content = json.dumps({
+                "tick_id": tick_id,
+                "depth": classified_depth.value,
+                "reason": trigger_reason,
+                "scores": {s.depth.value: s.final_score for s in scores},
+            }, sort_keys=True)
             content_hash = hashlib.sha256(obs_content.encode()).hexdigest()
             is_dup = await observations.exists_by_hash(
-                db,
-                source="awareness_loop",
-                content_hash=content_hash,
-                unresolved_only=True,
+                db, source="awareness_loop", content_hash=content_hash, unresolved_only=True,
             )
             if not is_dup:
                 obs_id = str(uuid.uuid4())
@@ -1384,9 +1339,7 @@ async def perform_tick(
                     source="awareness_loop",
                     type="awareness_tick",
                     content=obs_content,
-                    priority="high"
-                    if classified_depth in (Depth.DEEP, Depth.STRATEGIC)
-                    else "medium",
+                    priority="high" if classified_depth in (Depth.DEEP, Depth.STRATEGIC) else "medium",
                     created_at=now,
                     content_hash=content_hash,
                     skip_if_duplicate=True,
@@ -1396,8 +1349,7 @@ async def perform_tick(
         db_available = False
         logger.warning(
             "Tick DB operations failed — degraded tick (signals collected, "
-            "scoring/persistence skipped): %s",
-            db_exc,
+            "scoring/persistence skipped): %s", db_exc,
         )
 
     result = TickResult(
@@ -1438,11 +1390,7 @@ async def perform_tick(
             except Exception:
                 logger.warning("Failed to enqueue deferred reflection")
 
-    if (
-        classified_depth == Depth.LIGHT
-        and cc_reflection_bridge is None
-        and reflection_engine is not None
-    ):
+    if classified_depth == Depth.LIGHT and cc_reflection_bridge is None and reflection_engine is not None:
         try:
             await reflection_engine.reflect(classified_depth, result, db=db)
         except Exception:
@@ -1460,11 +1408,7 @@ async def perform_tick(
                     )
                 except Exception:
                     logger.warning("Failed to enqueue deferred reflection")
-    elif cc_reflection_bridge is not None and classified_depth in (
-        Depth.LIGHT,
-        Depth.DEEP,
-        Depth.STRATEGIC,
-    ):
+    elif cc_reflection_bridge is not None and classified_depth in (Depth.LIGHT, Depth.DEEP, Depth.STRATEGIC):
         try:
             ref_result = await cc_reflection_bridge.reflect(
                 classified_depth,
@@ -1479,16 +1423,14 @@ async def perform_tick(
             if ref_result is not None and not ref_result.success:
                 logger.info(
                     "%s reflection deferred for tick %s: %s",
-                    classified_depth.value,
-                    tick_id,
+                    classified_depth.value, tick_id,
                     ref_result.reason or "unknown",
                 )
             # Resolve escalation after successful dispatch
             if escalation_pending_id and classified_depth == Depth.DEEP:
                 try:
                     await observations.resolve(
-                        db,
-                        escalation_pending_id,
+                        db, escalation_pending_id,
                         resolved_at=now,
                         resolution_notes="Escalation consumed by deep reflection",
                     )
@@ -1502,9 +1444,7 @@ async def perform_tick(
                         created_at=now,
                     )
                 except Exception:
-                    logger.warning(
-                        "Failed to resolve escalation %s", escalation_pending_id, exc_info=True
-                    )
+                    logger.warning("Failed to resolve escalation %s", escalation_pending_id, exc_info=True)
         except Exception:
             logger.exception("CC reflection failed for tick %s", tick_id)
             if deferred_queue and classified_depth:
@@ -1608,8 +1548,7 @@ class AwarenessLoop:
                 down = []
                 if self._circuit_breakers:
                     down = [
-                        name
-                        for name, cb in self._circuit_breakers._breakers.items()
+                        name for name, cb in self._circuit_breakers._breakers.items()
                         if not cb.is_available()
                     ]
                 detail = f"Providers down: {', '.join(sorted(down))}" if down else ""
@@ -1623,9 +1562,7 @@ class AwarenessLoop:
                 generated_by="awareness_loop",
                 created_at=now,
             )
-            logger.info(
-                "Resilience cognitive state updated: %s → %s", self._last_degradation_level, level
-            )
+            logger.info("Resilience cognitive state updated: %s → %s", self._last_degradation_level, level)
         except Exception:
             logger.warning("Failed to update resilience cognitive state", exc_info=True)
 
@@ -1655,8 +1592,7 @@ class AwarenessLoop:
             )
         except Exception:
             logger.warning(
-                "Failed to register scheduler job-event listener",
-                exc_info=True,
+                "Failed to register scheduler job-event listener", exc_info=True,
             )
         self._scheduler.start()
         logger.info("Awareness Loop started (interval=%dm, immediate first tick)", self._interval)
@@ -1685,7 +1621,10 @@ class AwarenessLoop:
             return
         if event_code == EVENT_JOB_MAX_INSTANCES:
             event_type = "tick.max_instances"
-            message = "Awareness tick dropped: previous tick still running (max_instances=1)"
+            message = (
+                "Awareness tick dropped: previous tick still running "
+                "(max_instances=1)"
+            )
         elif event_code == EVENT_JOB_MISSED:
             event_type = "tick.missed"
             message = "Awareness tick missed (past misfire grace time)"
@@ -1713,10 +1652,8 @@ class AwarenessLoop:
         async with self._tick_lock:
             logger.info("Force tick triggered: %s", reason)
             result = await perform_tick(
-                self._db,
-                self._collectors,
-                source="critical_bypass",
-                reason=reason,
+                self._db, self._collectors,
+                source="critical_bypass", reason=reason,
                 reflection_engine=self._reflection_engine,
                 cc_reflection_bridge=self._cc_reflection_bridge,
                 deferred_queue=self._deferred_queue,
@@ -1740,9 +1677,7 @@ class AwarenessLoop:
         async with self._tick_lock:
             try:
                 result = await perform_tick(
-                    self._db,
-                    self._collectors,
-                    source="scheduled",
+                    self._db, self._collectors, source="scheduled",
                     reflection_engine=self._reflection_engine,
                     cc_reflection_bridge=self._cc_reflection_bridge,
                     deferred_queue=self._deferred_queue,
@@ -1757,14 +1692,12 @@ class AwarenessLoop:
                 logger.exception("Awareness tick failed unexpectedly")
                 if self._event_bus:
                     await self._event_bus.emit(
-                        Subsystem.AWARENESS,
-                        Severity.ERROR,
+                        Subsystem.AWARENESS, Severity.ERROR,
                         "tick.failed",
                         "Awareness tick failed with exception",
                     )
                 try:
                     from genesis.runtime import GenesisRuntime
-
                     GenesisRuntime.instance().record_job_failure("awareness_tick", str(exc))
                 except Exception:
                     pass
@@ -1781,8 +1714,7 @@ class AwarenessLoop:
                 if result.classified_depth:
                     logger.info(
                         "Tick triggered %s: %s",
-                        result.classified_depth.value,
-                        result.trigger_reason,
+                        result.classified_depth.value, result.trigger_reason,
                     )
 
                 if not result.db_available:
@@ -1794,28 +1726,24 @@ class AwarenessLoop:
                 # Heartbeat — lets health MCP detect silent death
                 if self._event_bus:
                     await self._event_bus.emit(
-                        Subsystem.AWARENESS,
-                        Severity.DEBUG,
+                        Subsystem.AWARENESS, Severity.DEBUG,
                         "heartbeat",
                         "awareness_loop tick completed"
                         + (" (degraded)" if not result.db_available else ""),
                     )
                 try:
                     from genesis.runtime import GenesisRuntime
-
                     if result.db_available:
                         GenesisRuntime.instance().record_job_success("awareness_tick")
                     else:
                         GenesisRuntime.instance().record_job_failure(
-                            "awareness_tick", "DB unavailable (degraded tick)"
-                        )
+                            "awareness_tick", "DB unavailable (degraded tick)")
                 except Exception:
                     pass  # Runtime may not be available in tests
 
             # Update resilience memory axis based on DB availability
             if self._resilience_state_machine and result is not None:
                 from genesis.resilience.state import MemoryStatus
-
                 if result.db_available:
                     self._resilience_state_machine.update_memory(MemoryStatus.NORMAL)
                 else:
@@ -1941,7 +1869,6 @@ class AwarenessLoop:
             if self._remediation_registry:
                 try:
                     from genesis.observability.health import collect_probe_results
-
                     probe_results = await collect_probe_results(self._db)
                     outcomes = await self._remediation_registry.check_and_remediate(
                         probe_results,
@@ -2035,7 +1962,6 @@ class AwarenessLoop:
         # Kill switch — tick/heartbeats still run but no dispatches when paused
         try:
             from genesis.runtime import GenesisRuntime
-
             if GenesisRuntime.instance().paused:
                 logger.debug("Skipping reflection dispatch (Genesis paused)")
                 return
@@ -2093,8 +2019,7 @@ class AwarenessLoop:
                 if obs_result and obs_result.notes_stored > 0:
                     logger.info(
                         "Session observer: %d notes from %d observations",
-                        obs_result.notes_stored,
-                        obs_result.observations_read,
+                        obs_result.notes_stored, obs_result.observations_read,
                     )
             except Exception:
                 logger.warning("Session observer processing failed", exc_info=True)
@@ -2118,10 +2043,8 @@ class AwarenessLoop:
             return
         with contextlib.suppress(Exception):
             await self._event_bus.emit(
-                Subsystem.REFLECTION,
-                Severity.DEBUG,
-                "heartbeat",
-                "reflection idle (no depth triggered)",
+                Subsystem.REFLECTION, Severity.DEBUG,
+                "heartbeat", "reflection idle (no depth triggered)",
             )
 
     async def _dispatch_reflection(self, result: TickResult) -> None:
@@ -2133,8 +2056,7 @@ class AwarenessLoop:
         db = self._db
         logger.info(
             "Dispatch reflection: depth=%s, tick=%s, bridge=%s, engine=%s",
-            depth.value,
-            tick_id[:8],
+            depth.value, tick_id[:8],
             self._cc_reflection_bridge is not None,
             self._reflection_engine is not None,
         )
@@ -2143,10 +2065,10 @@ class AwarenessLoop:
             # Check for critical operational signals that warrant LLM analysis.
             # Routine micro ticks are silent (counted for escalation cascade only).
             critical_active = any(
-                s.value > 0 for s in result.signals if s.name in _MICRO_CRITICAL_SIGNALS
+                s.value > 0 for s in result.signals
+                if s.name in _MICRO_CRITICAL_SIGNALS
             ) or any(
-                s.value >= _SENTINEL_ANOMALY_THRESHOLD
-                for s in result.signals
+                s.value >= _SENTINEL_ANOMALY_THRESHOLD for s in result.signals
                 if s.name == "sentinel_activity"
             )
 
@@ -2161,10 +2083,8 @@ class AwarenessLoop:
                 if ref_result and ref_result.success and self._event_bus:
                     try:
                         await self._event_bus.emit(
-                            Subsystem.REFLECTION,
-                            Severity.DEBUG,
-                            "heartbeat",
-                            "micro-reflection completed",
+                            Subsystem.REFLECTION, Severity.DEBUG,
+                            "heartbeat", "micro-reflection completed",
                         )
                     except Exception:
                         logger.warning("Failed to emit reflection heartbeat", exc_info=True)
@@ -2183,8 +2103,7 @@ class AwarenessLoop:
                         await self._topic_manager.send_to_category("reflection_micro", text)
                         logger.info(
                             "Posted micro reflection to Telegram (tick=%s, salience=%.2f)",
-                            tick_id[:8],
-                            micro.salience,
+                            tick_id[:8], micro.salience,
                         )
                     except Exception:
                         logger.warning("Failed to post micro reflection to topic", exc_info=True)
@@ -2216,10 +2135,8 @@ class AwarenessLoop:
                 if self._event_bus:
                     with contextlib.suppress(Exception):
                         await self._event_bus.emit(
-                            Subsystem.REFLECTION,
-                            Severity.DEBUG,
-                            "heartbeat",
-                            "reflection idle (no critical signals)",
+                            Subsystem.REFLECTION, Severity.DEBUG,
+                            "heartbeat", "reflection idle (no critical signals)",
                         )
 
             # Always mark dispatched — cascade counting works on ticks
@@ -2229,11 +2146,7 @@ class AwarenessLoop:
                 logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
             return
 
-        if (
-            depth == Depth.LIGHT
-            and self._cc_reflection_bridge is None
-            and self._reflection_engine is not None
-        ):
+        if depth == Depth.LIGHT and self._cc_reflection_bridge is None and self._reflection_engine is not None:
             try:
                 await self._reflection_engine.reflect(depth, result, db=db)
                 # Emit reflection heartbeat so subsystem_heartbeats doesn't
@@ -2241,10 +2154,8 @@ class AwarenessLoop:
                 if self._event_bus:
                     with contextlib.suppress(Exception):
                         await self._event_bus.emit(
-                            Subsystem.REFLECTION,
-                            Severity.DEBUG,
-                            "heartbeat",
-                            "light-reflection completed (API)",
+                            Subsystem.REFLECTION, Severity.DEBUG,
+                            "heartbeat", "light-reflection completed (API)",
                         )
             except Exception:
                 logger.exception("Light reflection fallback (API) failed for tick %s", tick_id)
@@ -2263,11 +2174,7 @@ class AwarenessLoop:
                         logger.warning("Failed to enqueue deferred reflection")
             return
 
-        if self._cc_reflection_bridge is not None and depth in (
-            Depth.LIGHT,
-            Depth.DEEP,
-            Depth.STRATEGIC,
-        ):
+        if self._cc_reflection_bridge is not None and depth in (Depth.LIGHT, Depth.DEEP, Depth.STRATEGIC):
             try:
                 ref_result = await self._cc_reflection_bridge.reflect(
                     depth,
@@ -2291,8 +2198,7 @@ class AwarenessLoop:
                     if self._event_bus:
                         with contextlib.suppress(Exception):
                             await self._event_bus.emit(
-                                Subsystem.REFLECTION,
-                                Severity.DEBUG,
+                                Subsystem.REFLECTION, Severity.DEBUG,
                                 "heartbeat",
                                 f"{depth.value.lower()}-reflection completed",
                             )
@@ -2377,20 +2283,14 @@ class AwarenessLoop:
                     continue  # Another tick already consumed it
                 logger.info(
                     "Resuming %s reflection from approved request %s",
-                    depth_name,
-                    approved["id"][:8],
+                    depth_name, approved["id"][:8],
                 )
                 await self._cc_reflection_bridge.reflect(
-                    depth,
-                    tick,
-                    db=self._db,
-                    skip_approval=True,
+                    depth, tick, db=self._db, skip_approval=True,
                 )
             except Exception:
                 logger.error(
-                    "Failed to resume %s reflection",
-                    depth_name,
-                    exc_info=True,
+                    "Failed to resume %s reflection", depth_name, exc_info=True,
                 )
 
     async def _resume_approved_sentinel_dispatches(self) -> None:
@@ -2462,9 +2362,7 @@ class AwarenessLoop:
         await self._deferred_queue.mark_processing(item_id)
         logger.info(
             "Retrying deferred reflection: id=%s depth=%s attempt=%d",
-            item_id,
-            depth.value,
-            attempts + 1,
+            item_id, depth.value, attempts + 1,
         )
 
         try:
@@ -2474,8 +2372,7 @@ class AwarenessLoop:
                 result = await self._reflection_engine.reflect(depth, current_tick, db=self._db)
             else:
                 logger.warning(
-                    "No reflection handler for depth=%s — leaving pending",
-                    depth.value,
+                    "No reflection handler for depth=%s — leaving pending", depth.value,
                 )
                 await self._deferred_queue.reset_to_pending(item_id)
                 return
@@ -2489,18 +2386,13 @@ class AwarenessLoop:
                 await self._deferred_queue.reset_to_pending(item_id)
                 logger.info(
                     "Deferred reflection not ready: id=%s depth=%s reason=%s — will retry",
-                    item_id,
-                    depth.value,
-                    result.reason or "unknown",
+                    item_id, depth.value, result.reason or "unknown",
                 )
         except Exception:
             new_attempts = attempts + 1  # mark_processing already incremented in DB
             logger.warning(
                 "Deferred reflection retry failed: id=%s depth=%s attempt=%d",
-                item_id,
-                depth.value,
-                new_attempts,
-                exc_info=True,
+                item_id, depth.value, new_attempts, exc_info=True,
             )
             if new_attempts >= 3:
                 await self._deferred_queue.mark_discarded(
@@ -2509,8 +2401,7 @@ class AwarenessLoop:
                 )
                 if self._event_bus:
                     await self._event_bus.emit(
-                        Subsystem.AWARENESS,
-                        Severity.WARNING,
+                        Subsystem.AWARENESS, Severity.WARNING,
                         "deferred.max_attempts",
                         f"Deferred {depth.value} reflection failed after {new_attempts} attempts",
                     )
@@ -2524,8 +2415,7 @@ class AwarenessLoop:
 
         try:
             await observations.resolve(
-                self._db,
-                pending_id,
+                self._db, pending_id,
                 resolved_at=now,
                 resolution_notes="Escalation consumed by deep reflection",
             )

--- a/src/genesis/db/crud/alert_events.py
+++ b/src/genesis/db/crud/alert_events.py
@@ -1,0 +1,110 @@
+"""CRUD for ``alert_events`` — persisted alert/incident store (WS-2 M10).
+
+Replaces the in-memory, per-process, one-generation ``_alert_history`` dict
+(``mcp/health/__init__.py``) with a durable open-set. ONE designated writer
+(the awareness tick) calls :func:`reconcile_open_set` with the currently-firing
+alert set; the table itself is the transition state:
+
+- a new firing alert → an open row (``resolved_at IS NULL``);
+- an alert that stops firing → its open row gets ``resolved_at`` stamped.
+
+Idempotency is by construction: the partial UNIQUE index
+``idx_ae_open_alert`` (on ``alert_id`` WHERE ``resolved_at IS NULL``) permits at
+most one open row per alert, so ``INSERT OR IGNORE`` is safe even when the
+runtime process and the health-MCP process race to reconcile the same set.
+
+NOTE: severity/message are captured at first-fire and not rewritten while an
+alert stays open — a mid-incident escalation (WARNING→CRITICAL for the same
+alert_id) keeps the original open row. Acceptable for v1; the incident's
+created_at is the load-bearing fact.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import aiosqlite
+
+
+async def reconcile_open_set(
+    db: aiosqlite.Connection,
+    *,
+    active: list[dict],
+    now: str,
+) -> dict[str, int]:
+    """Reconcile the durable open-set against the currently-firing ``active`` alerts.
+
+    ``active`` is a list of ``{alert_id, source, severity, message}`` dicts.
+    Opens rows for newly-firing alerts (idempotent via the partial unique
+    index) and resolves any open row whose ``alert_id`` is no longer firing.
+    Returns ``{"opened": n, "resolved": n}``.
+    """
+    active_ids = [a["alert_id"] for a in active]
+
+    opened = 0
+    for a in active:
+        cursor = await db.execute(
+            """INSERT OR IGNORE INTO alert_events
+               (id, alert_id, source, severity, message, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                uuid.uuid4().hex,
+                a["alert_id"],
+                a["source"],
+                a["severity"],
+                a["message"],
+                now,
+            ),
+        )
+        opened += cursor.rowcount or 0
+
+    if active_ids:
+        placeholders = ",".join("?" for _ in active_ids)
+        cursor = await db.execute(
+            f"UPDATE alert_events SET resolved_at = ? "  # noqa: S608 - placeholders are bound params
+            f"WHERE resolved_at IS NULL AND alert_id NOT IN ({placeholders})",
+            (now, *active_ids),
+        )
+    else:
+        # nothing firing → resolve every open row
+        cursor = await db.execute(
+            "UPDATE alert_events SET resolved_at = ? WHERE resolved_at IS NULL",
+            (now,),
+        )
+    resolved = cursor.rowcount or 0
+
+    await db.commit()
+    return {"opened": opened, "resolved": resolved}
+
+
+async def list_open(db: aiosqlite.Connection) -> list[dict]:
+    """All currently-open alerts (resolved_at IS NULL), newest first."""
+    cursor = await db.execute(
+        "SELECT id, alert_id, source, severity, message, created_at, resolved_at "
+        "FROM alert_events WHERE resolved_at IS NULL ORDER BY created_at DESC"
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def list_recent(db: aiosqlite.Connection, *, since: str) -> list[dict]:
+    """Alert history (open + resolved) created at/after ``since`` (ISO), newest first."""
+    cursor = await db.execute(
+        "SELECT id, alert_id, source, severity, message, created_at, resolved_at "
+        "FROM alert_events WHERE created_at >= ? ORDER BY created_at DESC",
+        (since,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def prune_older_than(db: aiosqlite.Connection, *, days: int = 90) -> int:
+    """Delete RESOLVED alerts older than ``days``. Never deletes an open alert.
+
+    Signature matches the drip-retention prune contract.
+    """
+    cursor = await db.execute(
+        "DELETE FROM alert_events "
+        "WHERE resolved_at IS NOT NULL AND created_at < datetime('now', ?)",
+        (f"-{int(days)} days",),
+    )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount is not None else 0

--- a/src/genesis/db/crud/job_run_events.py
+++ b/src/genesis/db/crud/job_run_events.py
@@ -1,0 +1,82 @@
+"""CRUD for ``job_run_events`` — per-run scheduled-job history (WS-2 M9).
+
+Append-only sensor table. The debounce decision (which runs earn a row) lives
+at the write source in :mod:`genesis.runtime._job_health`; this module is the
+mechanical insert + the read/prune helpers. The ledger's ``scheduled_job``
+grader (WS-2 P2) reads ``list_runs_for_day`` to score ``runs_clean_day`` /
+``runtime_ms_le``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import aiosqlite
+
+
+async def record_run_event(
+    db: aiosqlite.Connection,
+    *,
+    job_name: str,
+    status: str,
+    run_started_at: str | None = None,
+    duration_ms: int | None = None,
+    error: str | None = None,
+    recorded_at: str,
+) -> None:
+    """Append one run event. ``status`` is 'success' or 'failed'.
+
+    ``recorded_at`` is supplied by the caller (the runtime already stamps a
+    single ``now`` per record_job_* call) so the event time matches the
+    ``job_health`` row written in the same tick.
+    """
+    await db.execute(
+        """INSERT INTO job_run_events
+           (id, job_name, status, run_started_at, duration_ms, error, recorded_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (
+            uuid.uuid4().hex,
+            job_name,
+            status,
+            run_started_at,
+            duration_ms,
+            error,
+            recorded_at,
+        ),
+    )
+    await db.commit()
+
+
+async def list_runs_for_day(db: aiosqlite.Connection, job_name: str, day: str) -> list[dict]:
+    """All run events for ``job_name`` on ``day`` (YYYY-MM-DD, matched on recorded_at)."""
+    cursor = await db.execute(
+        "SELECT id, job_name, status, run_started_at, duration_ms, error, recorded_at "
+        "FROM job_run_events WHERE job_name = ? AND substr(recorded_at, 1, 10) = ? "
+        "ORDER BY recorded_at",
+        (job_name, day),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def count_recent_by_status(db: aiosqlite.Connection, *, since: str) -> dict[str, int]:
+    """{status: count} for events recorded at/after ``since`` (ISO). Ops/coverage view."""
+    cursor = await db.execute(
+        "SELECT status, COUNT(*) FROM job_run_events WHERE recorded_at >= ? GROUP BY status",
+        (since,),
+    )
+    return {row[0]: row[1] for row in await cursor.fetchall()}
+
+
+async def prune_older_than(db: aiosqlite.Connection, *, days: int = 90) -> int:
+    """Delete run events older than ``days``. Returns rows deleted.
+
+    Signature matches the drip-retention prune contract
+    (``prune_older_than(db, *, days=...)``) so it registers cleanly in
+    ``_wire_drip_retention_jobs``.
+    """
+    cursor = await db.execute(
+        "DELETE FROM job_run_events WHERE recorded_at < datetime('now', ?)",
+        (f"-{int(days)} days",),
+    )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount is not None else 0

--- a/src/genesis/db/migrations/0061_job_run_events_alert_events.py
+++ b/src/genesis/db/migrations/0061_job_run_events_alert_events.py
@@ -1,0 +1,82 @@
+"""Add job_run_events + alert_events — the WS-2 sensor fabric (M9/M10).
+
+WS-2 PR-0 repairs the observability substrate the Cognitive Ledger grades
+against, before the ledger itself is built.
+
+- ``job_run_events`` (M9): per-run scheduled-job history. Today ``job_health``
+  is cumulative-only (one UPSERT row per ``job_name``), so there is no per-run
+  time series and no era attribution — a job that failed for a week then
+  recovered looks identical to one that never failed. The ledger's
+  ``scheduled_job`` predictions (``runs_clean_day`` / ``runtime_ms_le``) grade
+  from this table. Writes are debounced at the source
+  (``runtime/_job_health.py``): a success row only when ≥1h since the job's
+  last success; a failure row on streak onset + hourly heartbeat during a
+  sustained outage — so a stuck 60s poll costs ~24 rows/day, not ~1440.
+
+- ``alert_events`` (M10): a persisted alert/incident store. Today the only
+  alert memory is the in-memory ``_alert_history`` dict
+  (``mcp/health/__init__.py``), a per-process one-generation resolved tracker
+  that does not survive restart and cannot be read as history. The awareness
+  tick reconciles a durable open-set here: one open row (``resolved_at IS
+  NULL``) per currently-firing alert; resolution stamps ``resolved_at``. The
+  partial UNIQUE index makes the reconcile idempotent under the cross-process
+  race between the runtime and the health-MCP process.
+
+Additive + idempotent; DDL mirrored in ``db/schema/_tables.py``. Individual
+``db.execute()`` calls, no commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS job_run_events (
+            id             TEXT PRIMARY KEY,          -- uuid4 hex
+            job_name       TEXT NOT NULL,
+            status         TEXT NOT NULL CHECK (status IN ('success', 'failed')),
+            run_started_at TEXT,                      -- NULL unless record_job_start ran
+            duration_ms    INTEGER,                   -- NULL unless run_started_at present
+            error          TEXT,                      -- failure detail (NULL on success)
+            recorded_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS alert_events (
+            id           TEXT PRIMARY KEY,            -- uuid4 hex
+            alert_id     TEXT NOT NULL,               -- stable alert key (e.g. 'creds:corrupt')
+            source       TEXT NOT NULL,               -- component that raised it
+            severity     TEXT NOT NULL,               -- CRITICAL / WARNING / ... (computed)
+            message      TEXT NOT NULL,
+            created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+            resolved_at  TEXT                         -- NULL = still open
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_jre_job_time ON job_run_events(job_name, recorded_at)"
+    )
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_jre_recorded ON job_run_events(recorded_at)")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_jre_status ON job_run_events(status, recorded_at)"
+    )
+    # one open row per alert_id — makes the open-set reconcile idempotent even
+    # under the runtime/health-MCP cross-process race
+    await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_ae_open_alert "
+        "ON alert_events(alert_id) WHERE resolved_at IS NULL"
+    )
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_ae_created ON alert_events(created_at)")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ae_alert ON alert_events(alert_id, created_at)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS job_run_events")
+    await db.execute("DROP TABLE IF EXISTS alert_events")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -2076,10 +2076,6 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_jre_job_time ON job_run_events(job_name, recorded_at)",
     "CREATE INDEX IF NOT EXISTS idx_jre_recorded ON job_run_events(recorded_at)",
     "CREATE INDEX IF NOT EXISTS idx_jre_status ON job_run_events(status, recorded_at)",
-    # one open row per alert_id — makes the open-set reconcile idempotent
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ae_open_alert ON alert_events(alert_id) WHERE resolved_at IS NULL",
-    "CREATE INDEX IF NOT EXISTS idx_ae_created ON alert_events(created_at)",
-    "CREATE INDEX IF NOT EXISTS idx_ae_alert ON alert_events(alert_id, created_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────
@@ -2120,9 +2116,9 @@ DEPTH_THRESHOLDS_SEED = [
     # Thresholds tuned 2026-03-21: originals (0.5/0.8/0.55) were too conservative,
     # producing only ~12 reflections across 6800 ticks.  Deep lowered to 0.45 to
     # encourage more frequent consolidation (design doc says 48-72h floor).
-    ("Micro", 0.50, 1800, 2, 3600),  # floor 30min, max 2/hr
-    ("Light", 0.60, 10800, 1, 3600),  # floor 3h, max 1/hr
-    ("Deep", 0.45, 172800, 1, 86400),  # floor 48h, max 1/day
+    ("Micro", 0.50, 1800, 2, 3600),         # floor 30min, max 2/hr
+    ("Light", 0.60, 10800, 1, 3600),         # floor 3h, max 1/hr
+    ("Deep", 0.45, 172800, 1, 86400),        # floor 48h, max 1/day
     ("Strategic", 0.40, 604800, 1, 604800),  # floor 7d, max 1/wk
 ]
 
@@ -2138,3 +2134,4 @@ DRIVE_WEIGHTS_SEED = [
     ("cooperation", 0.25, 0.25, 0.10, 0.50),
     ("competence", 0.15, 0.15, 0.10, 0.50),
 ]
+

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1736,6 +1736,41 @@ TABLES = {
             mode            TEXT NOT NULL DEFAULT 'shadow'
         )
     """,
+    # ── WS-2 sensor fabric (M9/M10) ──────────────────────────────────────
+    # Per-run scheduled-job history. job_health is cumulative-only (one row
+    # per job_name); this is the era-attribution time series the ledger
+    # grades scheduled_job predictions against. Writes are debounced at the
+    # source (runtime/_job_health.py): successes only when ≥1h since the last
+    # success; failures on streak onset + hourly heartbeat — so a stuck 60s
+    # poll costs ~24 rows/day, not ~1440. 90-day self-prune (drip retention).
+    "job_run_events": """
+        CREATE TABLE IF NOT EXISTS job_run_events (
+            id             TEXT PRIMARY KEY,          -- uuid4 hex
+            job_name       TEXT NOT NULL,
+            status         TEXT NOT NULL CHECK (status IN ('success', 'failed')),
+            run_started_at TEXT,                      -- NULL unless record_job_start ran
+            duration_ms    INTEGER,                   -- NULL unless run_started_at present
+            error          TEXT,                      -- failure detail (NULL on success)
+            recorded_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """,
+    # Persisted alert/incident store. Replaces the in-memory one-generation
+    # _alert_history dict (mcp/health/__init__.py). One designated writer (the
+    # awareness tick) reconciles the durable open-set: an open row (resolved_at
+    # IS NULL) exists per currently-firing alert_id; resolution stamps
+    # resolved_at. The partial UNIQUE INDEX on (alert_id) WHERE resolved_at IS
+    # NULL makes INSERT OR IGNORE idempotent even under the cross-process race.
+    "alert_events": """
+        CREATE TABLE IF NOT EXISTS alert_events (
+            id           TEXT PRIMARY KEY,            -- uuid4 hex
+            alert_id     TEXT NOT NULL,               -- stable alert key (e.g. 'creds:corrupt')
+            source       TEXT NOT NULL,               -- component that raised it
+            severity     TEXT NOT NULL,               -- CRITICAL / WARNING / ... (computed)
+            message      TEXT NOT NULL,
+            created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+            resolved_at  TEXT                         -- NULL = still open
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -2037,6 +2072,14 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_slsr_started ON session_ledger_shadow_runs(started_at)",
     "CREATE INDEX IF NOT EXISTS idx_slse_session ON session_ledger_shadow_events(session_id, observed_at)",
     "CREATE INDEX IF NOT EXISTS idx_slse_observed ON session_ledger_shadow_events(observed_at)",
+    # WS-2 sensor fabric (M9/M10)
+    "CREATE INDEX IF NOT EXISTS idx_jre_job_time ON job_run_events(job_name, recorded_at)",
+    "CREATE INDEX IF NOT EXISTS idx_jre_recorded ON job_run_events(recorded_at)",
+    "CREATE INDEX IF NOT EXISTS idx_jre_status ON job_run_events(status, recorded_at)",
+    # one open row per alert_id — makes the open-set reconcile idempotent
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ae_open_alert ON alert_events(alert_id) WHERE resolved_at IS NULL",
+    "CREATE INDEX IF NOT EXISTS idx_ae_created ON alert_events(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_alert ON alert_events(alert_id, created_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────
@@ -2077,9 +2120,9 @@ DEPTH_THRESHOLDS_SEED = [
     # Thresholds tuned 2026-03-21: originals (0.5/0.8/0.55) were too conservative,
     # producing only ~12 reflections across 6800 ticks.  Deep lowered to 0.45 to
     # encourage more frequent consolidation (design doc says 48-72h floor).
-    ("Micro", 0.50, 1800, 2, 3600),         # floor 30min, max 2/hr
-    ("Light", 0.60, 10800, 1, 3600),         # floor 3h, max 1/hr
-    ("Deep", 0.45, 172800, 1, 86400),        # floor 48h, max 1/day
+    ("Micro", 0.50, 1800, 2, 3600),  # floor 30min, max 2/hr
+    ("Light", 0.60, 10800, 1, 3600),  # floor 3h, max 1/hr
+    ("Deep", 0.45, 172800, 1, 86400),  # floor 48h, max 1/day
     ("Strategic", 0.40, 604800, 1, 604800),  # floor 7d, max 1/wk
 ]
 
@@ -2095,4 +2138,3 @@ DRIVE_WEIGHTS_SEED = [
     ("cooperation", 0.25, 0.25, 0.10, 0.50),
     ("competence", 0.15, 0.15, 0.10, 0.50),
 ]
-

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -2076,6 +2076,10 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_jre_job_time ON job_run_events(job_name, recorded_at)",
     "CREATE INDEX IF NOT EXISTS idx_jre_recorded ON job_run_events(recorded_at)",
     "CREATE INDEX IF NOT EXISTS idx_jre_status ON job_run_events(status, recorded_at)",
+    # one open row per alert_id — makes the open-set reconcile idempotent
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ae_open_alert ON alert_events(alert_id) WHERE resolved_at IS NULL",
+    "CREATE INDEX IF NOT EXISTS idx_ae_created ON alert_events(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_alert ON alert_events(alert_id, created_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────
@@ -2134,4 +2138,3 @@ DRIVE_WEIGHTS_SEED = [
     ("cooperation", 0.25, 0.25, 0.10, 0.50),
     ("competence", 0.15, 0.15, 0.10, 0.50),
 ]
-

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -37,13 +37,15 @@ async def _impl_health_errors(
             items = await dl_crud.query_pending(_service._db)
             for item in items:
                 if item.get("created_at", "") >= cutoff:
-                    errors.append({
-                        "type": "dead_letter",
-                        "provider": item.get("target_provider", "unknown"),
-                        "reason": item.get("failure_reason", ""),
-                        "operation": item.get("operation_type", ""),
-                        "timestamp": item.get("created_at", ""),
-                    })
+                    errors.append(
+                        {
+                            "type": "dead_letter",
+                            "provider": item.get("target_provider", "unknown"),
+                            "reason": item.get("failure_reason", ""),
+                            "operation": item.get("operation_type", ""),
+                            "timestamp": item.get("created_at", ""),
+                        }
+                    )
         except Exception:
             logger.error("Failed to query dead letter errors", exc_info=True)
 
@@ -54,16 +56,19 @@ async def _impl_health_errors(
             try:
                 cb = _service._breakers.get(name)
                 if cb.state == ProviderState.OPEN:
-                    errors.append({
-                        "type": "circuit_breaker_open",
-                        "provider": name,
-                        "reason": "Circuit breaker tripped",
-                        "failures": cb.consecutive_failures,
-                    })
+                    errors.append(
+                        {
+                            "type": "circuit_breaker_open",
+                            "provider": name,
+                            "reason": "Circuit breaker tripped",
+                            "failures": cb.consecutive_failures,
+                        }
+                    )
             except Exception:
                 logger.error(
                     "Circuit breaker state check failed for provider %s",
-                    name, exc_info=True,
+                    name,
+                    exc_info=True,
                 )
 
     from datetime import timedelta as _td
@@ -82,21 +87,25 @@ async def _impl_health_errors(
                 limit=50,
             )
             for sev in ("error", "critical"):
-                db_rows.extend(await events_crud.query(
-                    _service._db,
-                    severity=sev,
-                    since=cutoff,
-                    limit=50,
-                ))
+                db_rows.extend(
+                    await events_crud.query(
+                        _service._db,
+                        severity=sev,
+                        since=cutoff,
+                        limit=50,
+                    )
+                )
             for row in db_rows:
-                errors.append({
-                    "type": "event_bus",
-                    "subsystem": row.get("subsystem", ""),
-                    "event_type": row.get("event_type", ""),
-                    "severity": row.get("severity", ""),
-                    "message": row.get("message", ""),
-                    "timestamp": row.get("timestamp", ""),
-                })
+                errors.append(
+                    {
+                        "type": "event_bus",
+                        "subsystem": row.get("subsystem", ""),
+                        "event_type": row.get("event_type", ""),
+                        "severity": row.get("severity", ""),
+                        "message": row.get("message", ""),
+                        "timestamp": row.get("timestamp", ""),
+                    }
+                )
             db_events_loaded = True
         except Exception:
             logger.error("Event log query failed", exc_info=True)
@@ -106,14 +115,16 @@ async def _impl_health_errors(
 
         for event in _event_bus.recent_events(min_severity=Severity.WARNING, limit=50):
             if event.timestamp >= cutoff:
-                errors.append({
-                    "type": "event_bus",
-                    "subsystem": event.subsystem.value,
-                    "event_type": event.event_type,
-                    "severity": event.severity.value,
-                    "message": event.message,
-                    "timestamp": event.timestamp,
-                })
+                errors.append(
+                    {
+                        "type": "event_bus",
+                        "subsystem": event.subsystem.value,
+                        "event_type": event.event_type,
+                        "severity": event.severity.value,
+                        "message": event.message,
+                        "timestamp": event.timestamp,
+                    }
+                )
 
     if pattern_group and errors:
         grouped: dict[str, dict] = {}
@@ -171,16 +182,31 @@ def _backups_enabled() -> bool:
         return True
 
 
-async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
+async def _compute_alerts() -> tuple[list[dict], set[str]]:
+    """Pure alert computation — recompute the firing alert set from live health.
+
+    Returns ``(alerts, current_ids)`` and carries NO ``_alert_history`` state.
+    Two consumers: ``_impl_health_alerts`` (adds the in-memory one-generation
+    resolved rendering, unchanged read contract) and the awareness-tick writer
+    (persists the DURABLE open-set into ``alert_events`` — WS-2 M10). Keeping this
+    a pure function is what lets a single designated writer own persistence
+    without the multi-caller / cross-process double-write the read path would
+    otherwise cause.
+    """
     import genesis.mcp.health_mcp as health_mcp_mod
 
     _service = health_mcp_mod._service
     _activity_tracker = health_mcp_mod._activity_tracker
     _job_retry_registry = health_mcp_mod._job_retry_registry
-    _alert_history = health_mcp_mod._alert_history
 
     if _service is None:
-        return [{"id": "service:health_data_uninitialized", "severity": "CRITICAL", "message": "HealthDataService not initialized"}]
+        return [
+            {
+                "id": "service:health_data_uninitialized",
+                "severity": "CRITICAL",
+                "message": "HealthDataService not initialized",
+            }
+        ], set()
 
     snap = await _service.snapshot()
     alerts: list[dict] = []
@@ -218,19 +244,23 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             # The Sentinel has no remediation path for external providers;
             # circuit breakers auto-reset. Emit WARNING (→ Tier 3, reflexes
             # only) instead of CRITICAL (→ Tier 2, wakes Sentinel).
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Call site {site_id} is DOWN (all providers exhausted)",
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Call site {site_id} is DOWN (all providers exhausted)",
+                }
+            )
             current_ids.add(alert_id)
         elif status_val == "degraded":
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Call site {site_id} is degraded (using fallback provider)",
-                "active_provider": site_info.get("active_provider"),
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Call site {site_id} is degraded (using fallback provider)",
+                    "active_provider": site_info.get("active_provider"),
+                }
+            )
             current_ids.add(alert_id)
 
     queues = snap.get("queues", {})
@@ -246,8 +276,12 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     # broken drain still surfaces. `deferred_work`/`deferred_worklist` stay in the
     # snapshot for honest display but are not depth-alarmed here.
     _QUEUE_DEPTH_FIELDS = {
-        "pending_embeddings", "dead_letters", "deferred_recovery",
-        "deferred_processing", "deferred_stuck", "failed_embeddings",
+        "pending_embeddings",
+        "dead_letters",
+        "deferred_recovery",
+        "deferred_processing",
+        "deferred_stuck",
+        "failed_embeddings",
         "discarded_count",
     }
     for queue_name, depth in queues.items():
@@ -255,22 +289,26 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             continue
         if isinstance(depth, int) and depth > 100:
             alert_id = f"queue:{queue_name}"
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Queue {queue_name} depth is {depth} (>100)",
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Queue {queue_name} depth is {depth} (>100)",
+                }
+            )
             current_ids.add(alert_id)
 
     cc = snap.get("cc_sessions", {})
     bg = cc.get("background", {})
     if bg.get("status") in ("throttled", "rate_limited"):
         alert_id = "cc:budget"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"CC sessions {bg['status']} (budget: {bg.get('hourly_budget', '?')})",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"CC sessions {bg['status']} (budget: {bg.get('hourly_budget', '?')})",
+            }
+        )
         current_ids.add(alert_id)
 
     # CC rate-limit / unavailability alert.
@@ -305,43 +343,51 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             )
         else:
             alert_id = "cc:quota_exhausted"
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"CC {cc_realtime.lower().replace('_', ' ')} — contingency mode active",
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"CC {cc_realtime.lower().replace('_', ' ')} — contingency mode active",
+                }
+            )
             current_ids.add(alert_id)
 
     awareness = snap.get("awareness", {})
     tick_age = awareness.get("time_since_last_tick_seconds")
     if tick_age is not None and tick_age > 360:
         alert_id = "awareness:tick_overdue"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"Awareness tick overdue by {int(tick_age)}s (>360s threshold)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"Awareness tick overdue by {int(tick_age)}s (>360s threshold)",
+            }
+        )
         current_ids.add(alert_id)
 
     dl_age = snap.get("queues", {}).get("dead_letter_oldest_age_seconds")
     if dl_age is not None and dl_age > 3600:
         alert_id = "queue:stale_dead_letters"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"Dead letter queue has items {int(dl_age)}s old (>1h threshold)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Dead letter queue has items {int(dl_age)}s old (>1h threshold)",
+            }
+        )
         current_ids.add(alert_id)
 
     disk = snap.get("infrastructure", {}).get("disk", {})
     free_pct = disk.get("free_pct")
     if free_pct is not None and free_pct < 15:
         alert_id = "infra:disk_low"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL" if free_pct < 10 else "WARNING",
-            "message": f"Disk space low: {free_pct}% free ({disk.get('free_gb', '?')}GB)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL" if free_pct < 10 else "WARNING",
+                "message": f"Disk space low: {free_pct}% free ({disk.get('free_gb', '?')}GB)",
+            }
+        )
         current_ids.add(alert_id)
 
     container_mem = snap.get("infrastructure", {}).get("container_memory", {})
@@ -355,22 +401,26 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         # both the Telegram alert AND the voice chime earlier. anon_pct is
         # non-reclaimable memory, so >85% is genuine pressure (the box idles
         # ~76-79%). 6h dedup prevents repeat spam.
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
+            }
+        )
         current_ids.add(alert_id)
 
     qdrant_cols = snap.get("infrastructure", {}).get("qdrant_collections", {})
     missing_cols = qdrant_cols.get("missing", [])
     if missing_cols:
         alert_id = "infra:qdrant_collections_missing"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"Qdrant collections missing: {', '.join(missing_cols)} — memory operations will fail",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"Qdrant collections missing: {', '.join(missing_cols)} — memory operations will fail",
+            }
+        )
         current_ids.add(alert_id)
 
     services = snap.get("services", {})
@@ -378,32 +428,38 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     if genesis_svc.get("active_state") not in ("active", "unknown"):
         svc_label = genesis_svc.get("service_unit", "genesis-server.service")
         alert_id = "service:genesis_down"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"{svc_label} is {genesis_svc.get('active_state', 'unknown')}",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"{svc_label} is {genesis_svc.get('active_state', 'unknown')}",
+            }
+        )
         current_ids.add(alert_id)
 
     watchdog_timer = services.get("watchdog_timer", {})
     if watchdog_timer.get("active_state") not in ("active", "unknown"):
         alert_id = "service:watchdog_blind"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": "genesis-watchdog.timer is inactive — infrastructure monitoring is blind",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": "genesis-watchdog.timer is inactive — infrastructure monitoring is blind",
+            }
+        )
         current_ids.add(alert_id)
 
     watchdog_state = services.get("watchdog", {})
     wd_failures = watchdog_state.get("consecutive_failures", 0)
     if wd_failures > 3:
         alert_id = "service:watchdog_failing"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
+            }
+        )
         current_ids.add(alert_id)
 
     # Guardian heartbeat — the host-side safety net
@@ -423,18 +479,17 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     guardian_status = guardian_info.get("status", "unknown")
     if guardian_status == "down":
         staleness = guardian_info.get("staleness_s")
-        stale_part = (
-            f" (stale {int(staleness)}s)" if isinstance(staleness, int | float) else ""
-        )
+        stale_part = f" (stale {int(staleness)}s)" if isinstance(staleness, int | float) else ""
         alert_id = "guardian:heartbeat_stale"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": (
-                f"Guardian heartbeat not updating{stale_part} — "
-                f"host-side safety net is blind"
-            ),
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": (
+                    f"Guardian heartbeat not updating{stale_part} — host-side safety net is blind"
+                ),
+            }
+        )
         current_ids.add(alert_id)
 
     ollama = snap.get("infrastructure", {}).get("ollama", {})
@@ -442,11 +497,13 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     if missing_models:
         alert_id = "infra:ollama_model_mismatch"
         names = ", ".join(f"{m['provider']}:{m['model']}" for m in missing_models)
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"Ollama missing configured models: {names}",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Ollama missing configured models: {names}",
+            }
+        )
         current_ids.add(alert_id)
 
     if _activity_tracker is not None:
@@ -457,14 +514,16 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             and emb_summary.get("error_rate", 0) > 0.5
         ):
             alert_id = "provider:embedding_failing"
-            alerts.append({
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": (
-                    f"Embedding provider error rate: {emb_summary['error_rate']:.0%} "
-                    f"({emb_summary['errors']}/{emb_summary['calls']} calls failed)"
-                ),
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Embedding provider error rate: {emb_summary['error_rate']:.0%} "
+                        f"({emb_summary['errors']}/{emb_summary['calls']} calls failed)"
+                    ),
+                }
+            )
             current_ids.add(alert_id)
 
         qdrant_summary = _activity_tracker.summary("qdrant.search")
@@ -482,14 +541,16 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             _qdrant_rate = qdrant_summary.get("error_rate", 0)
             _qdrant_errors = qdrant_summary.get("errors", 0)
             _qdrant_calls = qdrant_summary.get("calls", 0)
-            alerts.append({
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": (
-                    f"Qdrant search {_qdrant_rate:.0%} failure rate "
-                    f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
-                ),
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Qdrant search {_qdrant_rate:.0%} failure rate "
+                        f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
+                    ),
+                }
+            )
             current_ids.add(alert_id)
 
     # ── Credit exhaustion detection ─────────────────────────────────
@@ -505,6 +566,7 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             routing_config = None
             try:
                 from genesis.runtime import GenesisRuntime
+
                 rt = GenesisRuntime.instance()
                 routing_config = getattr(rt, "_routing_config", None)
             except Exception:
@@ -535,14 +597,8 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 # no provider config and are skipped. (Pre-fix this lookup was
                 # single-hop on the raw ``llm.<name>`` string, so it ALWAYS missed
                 # -> every provider read "dormant" -> the detector was 100% dead.)
-                prov_name = (
-                    prov[4:]
-                    if isinstance(prov, str) and prov.startswith("llm.")
-                    else prov
-                )
-                provider_cfg = (
-                    routing_config.providers.get(prov_name) if routing_config else None
-                )
+                prov_name = prov[4:] if isinstance(prov, str) and prov.startswith("llm.") else prov
+                provider_cfg = routing_config.providers.get(prov_name) if routing_config else None
                 if provider_cfg is None:
                     continue  # not a routed LLM provider (embeddings/mcp.*/qdrant.*)
                 prov_crit = crit_map.get(provider_cfg.provider_type, {})
@@ -586,16 +642,18 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 # seam for a future user-gated auto-credit-top-up; see
                 # remediation_map.UNMAPPED_BY_DESIGN["provider:credit_exhaustion:"].
                 alert_id = f"provider:credit_exhaustion:{prov_name}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": (
-                        f"Suspected credit/quota exhaustion for {prov_name}: "
-                        f"was {1 - baseline_error_rate:.0%} success over 7d, "
-                        f"now {recent_error_rate:.0%} errors in last hour "
-                        f"({recent_errors}/{recent_calls} calls)"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"Suspected credit/quota exhaustion for {prov_name}: "
+                            f"was {1 - baseline_error_rate:.0%} success over 7d, "
+                            f"now {recent_error_rate:.0%} errors in last hour "
+                            f"({recent_errors}/{recent_calls} calls)"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             logger.debug("Credit exhaustion detection failed", exc_info=True)
@@ -624,9 +682,7 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 CRITICAL_CALL_SITES,
             )
 
-            cs_cutoff = (
-                datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)
-            ).isoformat()
+            cs_cutoff = (datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)).isoformat()
             cs_cursor = await _service._db.execute(
                 "SELECT call_site_id, last_run_at, provider_used "
                 "FROM call_site_last_run WHERE success = 0 AND last_run_at >= ?",
@@ -636,16 +692,18 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 site_id, last_run_at, provider_used = cs_row
                 is_critical = site_id in CRITICAL_CALL_SITES
                 alert_id = f"callsite:down:{site_id}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL" if is_critical else "WARNING",
-                    "message": (
-                        f"Call site '{site_id}' last run failed "
-                        f"(provider {provider_used or 'unknown'}, last attempt "
-                        f"{str(last_run_at)[:19]})"
-                        + (" -- CRITICAL site" if is_critical else "")
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL" if is_critical else "WARNING",
+                        "message": (
+                            f"Call site '{site_id}' last run failed "
+                            f"(provider {provider_used or 'unknown'}, last attempt "
+                            f"{str(last_run_at)[:19]})"
+                            + (" -- CRITICAL site" if is_critical else "")
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             # call_site_last_run is a core table (migration 0015) -- a failure
@@ -656,11 +714,13 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         for job_name in _job_retry_registry.list_registered():
             if _job_retry_registry.is_quarantined(job_name):
                 alert_id = f"job:quarantined:{job_name}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
+                    }
+                )
                 current_ids.add(alert_id)
 
     # ── Silently-stale jobs ──────────────────────────────────────────
@@ -681,16 +741,18 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 _service._db, threshold_days=JOB_STALE_GAP_DAYS
             ):
                 alert_id = f"job_stale:{row['job_name']}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": (
-                        f"Scheduled job '{row['job_name']}' has run since but not "
-                        f"succeeded in {row['gap_days']:.0f} days (last success "
-                        f"{str(row['last_success'])[:10]}) — silently failing "
-                        f"(its failure counter resets on restart)"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"Scheduled job '{row['job_name']}' has run since but not "
+                            f"succeeded in {row['gap_days']:.0f} days (last success "
+                            f"{str(row['last_success'])[:10]}) — silently failing "
+                            f"(its failure counter resets on restart)"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             # job_health is a core table that always exists — a failure here is
@@ -713,11 +775,13 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 behind = data.get("commits_behind", "?")
                 tag = data.get("target_tag", "unknown")
                 alert_id = "genesis:update_available"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "INFO",
-                    "message": f"New Genesis version available: {tag} ({behind} commits behind) — update from dashboard",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "INFO",
+                        "message": f"New Genesis version available: {tag} ({behind} commits behind) — update from dashboard",
+                    }
+                )
                 current_ids.add(alert_id)
 
             # Check for update failure
@@ -730,14 +794,16 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             if row:
                 data = json.loads(row[0] if isinstance(row, tuple) else row["content"])
                 alert_id = "genesis:update_failed"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": (
-                        f"Genesis update to {data.get('new_tag', '?')} failed, "
-                        f"rolled back to {data.get('rollback_tag', '?')}"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": (
+                            f"Genesis update to {data.get('new_tag', '?')} failed, "
+                            f"rolled back to {data.get('rollback_tag', '?')}"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             logger.error("Genesis update alert check failed", exc_info=True)
@@ -763,11 +829,13 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 alert_id = "backup:last_failed"
                 reason = backup_data.get("failure_reason") or "check backup log"
                 ts = backup_data.get("timestamp", "unknown")
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": f"Last backup failed at {ts}: {reason}",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": f"Last backup failed at {ts}: {reason}",
+                    }
+                )
                 current_ids.add(alert_id)
             else:
                 # Check staleness — backup succeeded but too long ago
@@ -775,19 +843,18 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 if ts:
                     try:
                         last = datetime.fromisoformat(ts)
-                        age_h = (
-                            datetime.now(UTC) - last
-                        ).total_seconds() / 3600
+                        age_h = (datetime.now(UTC) - last).total_seconds() / 3600
                         if age_h > 8:  # 6h schedule + 2h grace
                             alert_id = "backup:overdue"
-                            alerts.append({
-                                "id": alert_id,
-                                "severity": "CRITICAL",
-                                "message": (
-                                    f"Backup overdue — last success "
-                                    f"was {age_h:.0f}h ago"
-                                ),
-                            })
+                            alerts.append(
+                                {
+                                    "id": alert_id,
+                                    "severity": "CRITICAL",
+                                    "message": (
+                                        f"Backup overdue — last success was {age_h:.0f}h ago"
+                                    ),
+                                }
+                            )
                             current_ids.add(alert_id)
                     except (ValueError, TypeError):
                         pass
@@ -795,25 +862,29 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                 t2_status = backup_data.get("tier2_status", "unknown")
                 if t2_status in ("not_configured", "no_smbclient"):
                     alert_id = "backup:tier2_unconfigured"
-                    alerts.append({
-                        "id": alert_id,
-                        "severity": "WARNING",
-                        "message": (
-                            "Large backup targets not configured — "
-                            "Qdrant/SQL snapshots are local-only"
-                        ),
-                    })
+                    alerts.append(
+                        {
+                            "id": alert_id,
+                            "severity": "WARNING",
+                            "message": (
+                                "Large backup targets not configured — "
+                                "Qdrant/SQL snapshots are local-only"
+                            ),
+                        }
+                    )
                     current_ids.add(alert_id)
         except (json.JSONDecodeError, OSError):
             pass
     else:
         # No status file = backups never configured or never ran
         alert_id = "backup:not_configured"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": "Backups not configured — no backup status file found",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": "Backups not configured — no backup status file found",
+            }
+        )
         current_ids.add(alert_id)
 
     # Credential-file integrity — the container self-heal writes this status;
@@ -833,23 +904,21 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             # escalates to a terminal status (restored / restore_failed) next
             # tick, so alerting on it would defeat the debounce's whole purpose.
             corrupt = {
-                n: t for n, t in targets.items()
-                if t.get("status") in ("corrupt", "restore_failed")
+                n: t for n, t in targets.items() if t.get("status") in ("corrupt", "restore_failed")
             }
-            restored = {
-                n: t for n, t in targets.items() if t.get("status") == "restored"
-            }
+            restored = {n: t for n, t in targets.items() if t.get("status") == "restored"}
             if corrupt:
                 detail = "; ".join(
-                    f"{n} ({t.get('detail', t.get('status'))})"
-                    for n, t in sorted(corrupt.items())
+                    f"{n} ({t.get('detail', t.get('status'))})" for n, t in sorted(corrupt.items())
                 )
                 alert_id = "creds:corrupt"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": f"Credential file corruption: {detail}",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": f"Credential file corruption: {detail}",
+                    }
+                )
                 current_ids.add(alert_id)
             if restored:
                 detail = "; ".join(
@@ -857,17 +926,35 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                     for n, t in sorted(restored.items())
                 )
                 alert_id = "creds:restored"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": (
-                        f"Credential files auto-restored: {detail} — "
-                        "rotate any that changed since the backup"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": (
+                            f"Credential files auto-restored: {detail} — "
+                            "rotate any that changed since the backup"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except (json.JSONDecodeError, OSError):
             pass
+
+    return alerts, current_ids
+
+
+async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
+    """Live alert list + the in-memory one-generation resolved rendering.
+
+    Read path — contract unchanged for all existing callers (sentinel, morning
+    report, dashboard, the health_alerts MCP tool). Durable persistence is NOT
+    done here (that would multi-write across the runtime + health-MCP processes);
+    it lives in the single awareness-tick ``alert_events`` writer (WS-2 M10).
+    """
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    alerts, current_ids = await _compute_alerts()
+    _alert_history = health_mcp_mod._alert_history
 
     now = datetime.now(UTC).isoformat()
     for old_id in list(_alert_history.keys()):
@@ -880,11 +967,13 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
 
     if not active_only:
         for resolved_id, resolved_at in _alert_history.items():
-            alerts.append({
-                "id": resolved_id,
-                "severity": "RESOLVED",
-                "message": f"Previously active alert resolved at {resolved_at}",
-            })
+            alerts.append(
+                {
+                    "id": resolved_id,
+                    "severity": "RESOLVED",
+                    "message": f"Previously active alert resolved at {resolved_at}",
+                }
+            )
 
     health_mcp_mod._alert_history = {aid: now for aid in current_ids}
 

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -37,15 +37,13 @@ async def _impl_health_errors(
             items = await dl_crud.query_pending(_service._db)
             for item in items:
                 if item.get("created_at", "") >= cutoff:
-                    errors.append(
-                        {
-                            "type": "dead_letter",
-                            "provider": item.get("target_provider", "unknown"),
-                            "reason": item.get("failure_reason", ""),
-                            "operation": item.get("operation_type", ""),
-                            "timestamp": item.get("created_at", ""),
-                        }
-                    )
+                    errors.append({
+                        "type": "dead_letter",
+                        "provider": item.get("target_provider", "unknown"),
+                        "reason": item.get("failure_reason", ""),
+                        "operation": item.get("operation_type", ""),
+                        "timestamp": item.get("created_at", ""),
+                    })
         except Exception:
             logger.error("Failed to query dead letter errors", exc_info=True)
 
@@ -56,19 +54,16 @@ async def _impl_health_errors(
             try:
                 cb = _service._breakers.get(name)
                 if cb.state == ProviderState.OPEN:
-                    errors.append(
-                        {
-                            "type": "circuit_breaker_open",
-                            "provider": name,
-                            "reason": "Circuit breaker tripped",
-                            "failures": cb.consecutive_failures,
-                        }
-                    )
+                    errors.append({
+                        "type": "circuit_breaker_open",
+                        "provider": name,
+                        "reason": "Circuit breaker tripped",
+                        "failures": cb.consecutive_failures,
+                    })
             except Exception:
                 logger.error(
                     "Circuit breaker state check failed for provider %s",
-                    name,
-                    exc_info=True,
+                    name, exc_info=True,
                 )
 
     from datetime import timedelta as _td
@@ -87,25 +82,21 @@ async def _impl_health_errors(
                 limit=50,
             )
             for sev in ("error", "critical"):
-                db_rows.extend(
-                    await events_crud.query(
-                        _service._db,
-                        severity=sev,
-                        since=cutoff,
-                        limit=50,
-                    )
-                )
+                db_rows.extend(await events_crud.query(
+                    _service._db,
+                    severity=sev,
+                    since=cutoff,
+                    limit=50,
+                ))
             for row in db_rows:
-                errors.append(
-                    {
-                        "type": "event_bus",
-                        "subsystem": row.get("subsystem", ""),
-                        "event_type": row.get("event_type", ""),
-                        "severity": row.get("severity", ""),
-                        "message": row.get("message", ""),
-                        "timestamp": row.get("timestamp", ""),
-                    }
-                )
+                errors.append({
+                    "type": "event_bus",
+                    "subsystem": row.get("subsystem", ""),
+                    "event_type": row.get("event_type", ""),
+                    "severity": row.get("severity", ""),
+                    "message": row.get("message", ""),
+                    "timestamp": row.get("timestamp", ""),
+                })
             db_events_loaded = True
         except Exception:
             logger.error("Event log query failed", exc_info=True)
@@ -115,16 +106,14 @@ async def _impl_health_errors(
 
         for event in _event_bus.recent_events(min_severity=Severity.WARNING, limit=50):
             if event.timestamp >= cutoff:
-                errors.append(
-                    {
-                        "type": "event_bus",
-                        "subsystem": event.subsystem.value,
-                        "event_type": event.event_type,
-                        "severity": event.severity.value,
-                        "message": event.message,
-                        "timestamp": event.timestamp,
-                    }
-                )
+                errors.append({
+                    "type": "event_bus",
+                    "subsystem": event.subsystem.value,
+                    "event_type": event.event_type,
+                    "severity": event.severity.value,
+                    "message": event.message,
+                    "timestamp": event.timestamp,
+                })
 
     if pattern_group and errors:
         grouped: dict[str, dict] = {}
@@ -190,8 +179,7 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     resolved rendering, unchanged read contract) and the awareness-tick writer
     (persists the DURABLE open-set into ``alert_events`` — WS-2 M10). Keeping this
     a pure function is what lets a single designated writer own persistence
-    without the multi-caller / cross-process double-write the read path would
-    otherwise cause.
+    without the multi-caller / cross-process double-write the read path causes.
     """
     import genesis.mcp.health_mcp as health_mcp_mod
 
@@ -200,13 +188,7 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     _job_retry_registry = health_mcp_mod._job_retry_registry
 
     if _service is None:
-        return [
-            {
-                "id": "service:health_data_uninitialized",
-                "severity": "CRITICAL",
-                "message": "HealthDataService not initialized",
-            }
-        ], set()
+        return [{"id": "service:health_data_uninitialized", "severity": "CRITICAL", "message": "HealthDataService not initialized"}], set()
 
     snap = await _service.snapshot()
     alerts: list[dict] = []
@@ -244,23 +226,19 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             # The Sentinel has no remediation path for external providers;
             # circuit breakers auto-reset. Emit WARNING (→ Tier 3, reflexes
             # only) instead of CRITICAL (→ Tier 2, wakes Sentinel).
-            alerts.append(
-                {
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": f"Call site {site_id} is DOWN (all providers exhausted)",
-                }
-            )
+            alerts.append({
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Call site {site_id} is DOWN (all providers exhausted)",
+            })
             current_ids.add(alert_id)
         elif status_val == "degraded":
-            alerts.append(
-                {
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": f"Call site {site_id} is degraded (using fallback provider)",
-                    "active_provider": site_info.get("active_provider"),
-                }
-            )
+            alerts.append({
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Call site {site_id} is degraded (using fallback provider)",
+                "active_provider": site_info.get("active_provider"),
+            })
             current_ids.add(alert_id)
 
     queues = snap.get("queues", {})
@@ -276,12 +254,8 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     # broken drain still surfaces. `deferred_work`/`deferred_worklist` stay in the
     # snapshot for honest display but are not depth-alarmed here.
     _QUEUE_DEPTH_FIELDS = {
-        "pending_embeddings",
-        "dead_letters",
-        "deferred_recovery",
-        "deferred_processing",
-        "deferred_stuck",
-        "failed_embeddings",
+        "pending_embeddings", "dead_letters", "deferred_recovery",
+        "deferred_processing", "deferred_stuck", "failed_embeddings",
         "discarded_count",
     }
     for queue_name, depth in queues.items():
@@ -289,26 +263,22 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             continue
         if isinstance(depth, int) and depth > 100:
             alert_id = f"queue:{queue_name}"
-            alerts.append(
-                {
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": f"Queue {queue_name} depth is {depth} (>100)",
-                }
-            )
+            alerts.append({
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Queue {queue_name} depth is {depth} (>100)",
+            })
             current_ids.add(alert_id)
 
     cc = snap.get("cc_sessions", {})
     bg = cc.get("background", {})
     if bg.get("status") in ("throttled", "rate_limited"):
         alert_id = "cc:budget"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"CC sessions {bg['status']} (budget: {bg.get('hourly_budget', '?')})",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "WARNING",
+            "message": f"CC sessions {bg['status']} (budget: {bg.get('hourly_budget', '?')})",
+        })
         current_ids.add(alert_id)
 
     # CC rate-limit / unavailability alert.
@@ -343,51 +313,43 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             )
         else:
             alert_id = "cc:quota_exhausted"
-            alerts.append(
-                {
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": f"CC {cc_realtime.lower().replace('_', ' ')} — contingency mode active",
-                }
-            )
+            alerts.append({
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"CC {cc_realtime.lower().replace('_', ' ')} — contingency mode active",
+            })
             current_ids.add(alert_id)
 
     awareness = snap.get("awareness", {})
     tick_age = awareness.get("time_since_last_tick_seconds")
     if tick_age is not None and tick_age > 360:
         alert_id = "awareness:tick_overdue"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": f"Awareness tick overdue by {int(tick_age)}s (>360s threshold)",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": f"Awareness tick overdue by {int(tick_age)}s (>360s threshold)",
+        })
         current_ids.add(alert_id)
 
     dl_age = snap.get("queues", {}).get("dead_letter_oldest_age_seconds")
     if dl_age is not None and dl_age > 3600:
         alert_id = "queue:stale_dead_letters"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Dead letter queue has items {int(dl_age)}s old (>1h threshold)",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "WARNING",
+            "message": f"Dead letter queue has items {int(dl_age)}s old (>1h threshold)",
+        })
         current_ids.add(alert_id)
 
     disk = snap.get("infrastructure", {}).get("disk", {})
     free_pct = disk.get("free_pct")
     if free_pct is not None and free_pct < 15:
         alert_id = "infra:disk_low"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL" if free_pct < 10 else "WARNING",
-                "message": f"Disk space low: {free_pct}% free ({disk.get('free_gb', '?')}GB)",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL" if free_pct < 10 else "WARNING",
+            "message": f"Disk space low: {free_pct}% free ({disk.get('free_gb', '?')}GB)",
+        })
         current_ids.add(alert_id)
 
     container_mem = snap.get("infrastructure", {}).get("container_memory", {})
@@ -401,26 +363,22 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         # both the Telegram alert AND the voice chime earlier. anon_pct is
         # non-reclaimable memory, so >85% is genuine pressure (the box idles
         # ~76-79%). 6h dedup prevents repeat spam.
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
+        })
         current_ids.add(alert_id)
 
     qdrant_cols = snap.get("infrastructure", {}).get("qdrant_collections", {})
     missing_cols = qdrant_cols.get("missing", [])
     if missing_cols:
         alert_id = "infra:qdrant_collections_missing"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": f"Qdrant collections missing: {', '.join(missing_cols)} — memory operations will fail",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": f"Qdrant collections missing: {', '.join(missing_cols)} — memory operations will fail",
+        })
         current_ids.add(alert_id)
 
     services = snap.get("services", {})
@@ -428,38 +386,32 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     if genesis_svc.get("active_state") not in ("active", "unknown"):
         svc_label = genesis_svc.get("service_unit", "genesis-server.service")
         alert_id = "service:genesis_down"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": f"{svc_label} is {genesis_svc.get('active_state', 'unknown')}",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": f"{svc_label} is {genesis_svc.get('active_state', 'unknown')}",
+        })
         current_ids.add(alert_id)
 
     watchdog_timer = services.get("watchdog_timer", {})
     if watchdog_timer.get("active_state") not in ("active", "unknown"):
         alert_id = "service:watchdog_blind"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": "genesis-watchdog.timer is inactive — infrastructure monitoring is blind",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "WARNING",
+            "message": "genesis-watchdog.timer is inactive — infrastructure monitoring is blind",
+        })
         current_ids.add(alert_id)
 
     watchdog_state = services.get("watchdog", {})
     wd_failures = watchdog_state.get("consecutive_failures", 0)
     if wd_failures > 3:
         alert_id = "service:watchdog_failing"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "WARNING",
+            "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
+        })
         current_ids.add(alert_id)
 
     # Guardian heartbeat — the host-side safety net
@@ -479,17 +431,18 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     guardian_status = guardian_info.get("status", "unknown")
     if guardian_status == "down":
         staleness = guardian_info.get("staleness_s")
-        stale_part = f" (stale {int(staleness)}s)" if isinstance(staleness, int | float) else ""
-        alert_id = "guardian:heartbeat_stale"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": (
-                    f"Guardian heartbeat not updating{stale_part} — host-side safety net is blind"
-                ),
-            }
+        stale_part = (
+            f" (stale {int(staleness)}s)" if isinstance(staleness, int | float) else ""
         )
+        alert_id = "guardian:heartbeat_stale"
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": (
+                f"Guardian heartbeat not updating{stale_part} — "
+                f"host-side safety net is blind"
+            ),
+        })
         current_ids.add(alert_id)
 
     ollama = snap.get("infrastructure", {}).get("ollama", {})
@@ -497,13 +450,11 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     if missing_models:
         alert_id = "infra:ollama_model_mismatch"
         names = ", ".join(f"{m['provider']}:{m['model']}" for m in missing_models)
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Ollama missing configured models: {names}",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "WARNING",
+            "message": f"Ollama missing configured models: {names}",
+        })
         current_ids.add(alert_id)
 
     if _activity_tracker is not None:
@@ -514,16 +465,14 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             and emb_summary.get("error_rate", 0) > 0.5
         ):
             alert_id = "provider:embedding_failing"
-            alerts.append(
-                {
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": (
-                        f"Embedding provider error rate: {emb_summary['error_rate']:.0%} "
-                        f"({emb_summary['errors']}/{emb_summary['calls']} calls failed)"
-                    ),
-                }
-            )
+            alerts.append({
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": (
+                    f"Embedding provider error rate: {emb_summary['error_rate']:.0%} "
+                    f"({emb_summary['errors']}/{emb_summary['calls']} calls failed)"
+                ),
+            })
             current_ids.add(alert_id)
 
         qdrant_summary = _activity_tracker.summary("qdrant.search")
@@ -541,16 +490,14 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             _qdrant_rate = qdrant_summary.get("error_rate", 0)
             _qdrant_errors = qdrant_summary.get("errors", 0)
             _qdrant_calls = qdrant_summary.get("calls", 0)
-            alerts.append(
-                {
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": (
-                        f"Qdrant search {_qdrant_rate:.0%} failure rate "
-                        f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
-                    ),
-                }
-            )
+            alerts.append({
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": (
+                    f"Qdrant search {_qdrant_rate:.0%} failure rate "
+                    f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
+                ),
+            })
             current_ids.add(alert_id)
 
     # ── Credit exhaustion detection ─────────────────────────────────
@@ -566,7 +513,6 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             routing_config = None
             try:
                 from genesis.runtime import GenesisRuntime
-
                 rt = GenesisRuntime.instance()
                 routing_config = getattr(rt, "_routing_config", None)
             except Exception:
@@ -597,8 +543,14 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 # no provider config and are skipped. (Pre-fix this lookup was
                 # single-hop on the raw ``llm.<name>`` string, so it ALWAYS missed
                 # -> every provider read "dormant" -> the detector was 100% dead.)
-                prov_name = prov[4:] if isinstance(prov, str) and prov.startswith("llm.") else prov
-                provider_cfg = routing_config.providers.get(prov_name) if routing_config else None
+                prov_name = (
+                    prov[4:]
+                    if isinstance(prov, str) and prov.startswith("llm.")
+                    else prov
+                )
+                provider_cfg = (
+                    routing_config.providers.get(prov_name) if routing_config else None
+                )
                 if provider_cfg is None:
                     continue  # not a routed LLM provider (embeddings/mcp.*/qdrant.*)
                 prov_crit = crit_map.get(provider_cfg.provider_type, {})
@@ -642,18 +594,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 # seam for a future user-gated auto-credit-top-up; see
                 # remediation_map.UNMAPPED_BY_DESIGN["provider:credit_exhaustion:"].
                 alert_id = f"provider:credit_exhaustion:{prov_name}"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "WARNING",
-                        "message": (
-                            f"Suspected credit/quota exhaustion for {prov_name}: "
-                            f"was {1 - baseline_error_rate:.0%} success over 7d, "
-                            f"now {recent_error_rate:.0%} errors in last hour "
-                            f"({recent_errors}/{recent_calls} calls)"
-                        ),
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": (
+                        f"Suspected credit/quota exhaustion for {prov_name}: "
+                        f"was {1 - baseline_error_rate:.0%} success over 7d, "
+                        f"now {recent_error_rate:.0%} errors in last hour "
+                        f"({recent_errors}/{recent_calls} calls)"
+                    ),
+                })
                 current_ids.add(alert_id)
         except Exception:
             logger.debug("Credit exhaustion detection failed", exc_info=True)
@@ -682,7 +632,9 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 CRITICAL_CALL_SITES,
             )
 
-            cs_cutoff = (datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)).isoformat()
+            cs_cutoff = (
+                datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)
+            ).isoformat()
             cs_cursor = await _service._db.execute(
                 "SELECT call_site_id, last_run_at, provider_used "
                 "FROM call_site_last_run WHERE success = 0 AND last_run_at >= ?",
@@ -692,18 +644,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 site_id, last_run_at, provider_used = cs_row
                 is_critical = site_id in CRITICAL_CALL_SITES
                 alert_id = f"callsite:down:{site_id}"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "CRITICAL" if is_critical else "WARNING",
-                        "message": (
-                            f"Call site '{site_id}' last run failed "
-                            f"(provider {provider_used or 'unknown'}, last attempt "
-                            f"{str(last_run_at)[:19]})"
-                            + (" -- CRITICAL site" if is_critical else "")
-                        ),
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL" if is_critical else "WARNING",
+                    "message": (
+                        f"Call site '{site_id}' last run failed "
+                        f"(provider {provider_used or 'unknown'}, last attempt "
+                        f"{str(last_run_at)[:19]})"
+                        + (" -- CRITICAL site" if is_critical else "")
+                    ),
+                })
                 current_ids.add(alert_id)
         except Exception:
             # call_site_last_run is a core table (migration 0015) -- a failure
@@ -714,13 +664,11 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         for job_name in _job_retry_registry.list_registered():
             if _job_retry_registry.is_quarantined(job_name):
                 alert_id = f"job:quarantined:{job_name}"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "WARNING",
-                        "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
+                })
                 current_ids.add(alert_id)
 
     # ── Silently-stale jobs ──────────────────────────────────────────
@@ -741,18 +689,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 _service._db, threshold_days=JOB_STALE_GAP_DAYS
             ):
                 alert_id = f"job_stale:{row['job_name']}"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "WARNING",
-                        "message": (
-                            f"Scheduled job '{row['job_name']}' has run since but not "
-                            f"succeeded in {row['gap_days']:.0f} days (last success "
-                            f"{str(row['last_success'])[:10]}) — silently failing "
-                            f"(its failure counter resets on restart)"
-                        ),
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": (
+                        f"Scheduled job '{row['job_name']}' has run since but not "
+                        f"succeeded in {row['gap_days']:.0f} days (last success "
+                        f"{str(row['last_success'])[:10]}) — silently failing "
+                        f"(its failure counter resets on restart)"
+                    ),
+                })
                 current_ids.add(alert_id)
         except Exception:
             # job_health is a core table that always exists — a failure here is
@@ -775,13 +721,11 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 behind = data.get("commits_behind", "?")
                 tag = data.get("target_tag", "unknown")
                 alert_id = "genesis:update_available"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "INFO",
-                        "message": f"New Genesis version available: {tag} ({behind} commits behind) — update from dashboard",
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "INFO",
+                    "message": f"New Genesis version available: {tag} ({behind} commits behind) — update from dashboard",
+                })
                 current_ids.add(alert_id)
 
             # Check for update failure
@@ -794,16 +738,14 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             if row:
                 data = json.loads(row[0] if isinstance(row, tuple) else row["content"])
                 alert_id = "genesis:update_failed"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "CRITICAL",
-                        "message": (
-                            f"Genesis update to {data.get('new_tag', '?')} failed, "
-                            f"rolled back to {data.get('rollback_tag', '?')}"
-                        ),
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Genesis update to {data.get('new_tag', '?')} failed, "
+                        f"rolled back to {data.get('rollback_tag', '?')}"
+                    ),
+                })
                 current_ids.add(alert_id)
         except Exception:
             logger.error("Genesis update alert check failed", exc_info=True)
@@ -829,13 +771,11 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 alert_id = "backup:last_failed"
                 reason = backup_data.get("failure_reason") or "check backup log"
                 ts = backup_data.get("timestamp", "unknown")
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "CRITICAL",
-                        "message": f"Last backup failed at {ts}: {reason}",
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": f"Last backup failed at {ts}: {reason}",
+                })
                 current_ids.add(alert_id)
             else:
                 # Check staleness — backup succeeded but too long ago
@@ -843,18 +783,19 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 if ts:
                     try:
                         last = datetime.fromisoformat(ts)
-                        age_h = (datetime.now(UTC) - last).total_seconds() / 3600
+                        age_h = (
+                            datetime.now(UTC) - last
+                        ).total_seconds() / 3600
                         if age_h > 8:  # 6h schedule + 2h grace
                             alert_id = "backup:overdue"
-                            alerts.append(
-                                {
-                                    "id": alert_id,
-                                    "severity": "CRITICAL",
-                                    "message": (
-                                        f"Backup overdue — last success was {age_h:.0f}h ago"
-                                    ),
-                                }
-                            )
+                            alerts.append({
+                                "id": alert_id,
+                                "severity": "CRITICAL",
+                                "message": (
+                                    f"Backup overdue — last success "
+                                    f"was {age_h:.0f}h ago"
+                                ),
+                            })
                             current_ids.add(alert_id)
                     except (ValueError, TypeError):
                         pass
@@ -862,29 +803,25 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 t2_status = backup_data.get("tier2_status", "unknown")
                 if t2_status in ("not_configured", "no_smbclient"):
                     alert_id = "backup:tier2_unconfigured"
-                    alerts.append(
-                        {
-                            "id": alert_id,
-                            "severity": "WARNING",
-                            "message": (
-                                "Large backup targets not configured — "
-                                "Qdrant/SQL snapshots are local-only"
-                            ),
-                        }
-                    )
+                    alerts.append({
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            "Large backup targets not configured — "
+                            "Qdrant/SQL snapshots are local-only"
+                        ),
+                    })
                     current_ids.add(alert_id)
         except (json.JSONDecodeError, OSError):
             pass
     else:
         # No status file = backups never configured or never ran
         alert_id = "backup:not_configured"
-        alerts.append(
-            {
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": "Backups not configured — no backup status file found",
-            }
-        )
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": "Backups not configured — no backup status file found",
+        })
         current_ids.add(alert_id)
 
     # Credential-file integrity — the container self-heal writes this status;
@@ -904,21 +841,23 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             # escalates to a terminal status (restored / restore_failed) next
             # tick, so alerting on it would defeat the debounce's whole purpose.
             corrupt = {
-                n: t for n, t in targets.items() if t.get("status") in ("corrupt", "restore_failed")
+                n: t for n, t in targets.items()
+                if t.get("status") in ("corrupt", "restore_failed")
             }
-            restored = {n: t for n, t in targets.items() if t.get("status") == "restored"}
+            restored = {
+                n: t for n, t in targets.items() if t.get("status") == "restored"
+            }
             if corrupt:
                 detail = "; ".join(
-                    f"{n} ({t.get('detail', t.get('status'))})" for n, t in sorted(corrupt.items())
+                    f"{n} ({t.get('detail', t.get('status'))})"
+                    for n, t in sorted(corrupt.items())
                 )
                 alert_id = "creds:corrupt"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "CRITICAL",
-                        "message": f"Credential file corruption: {detail}",
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": f"Credential file corruption: {detail}",
+                })
                 current_ids.add(alert_id)
             if restored:
                 detail = "; ".join(
@@ -926,16 +865,14 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                     for n, t in sorted(restored.items())
                 )
                 alert_id = "creds:restored"
-                alerts.append(
-                    {
-                        "id": alert_id,
-                        "severity": "CRITICAL",
-                        "message": (
-                            f"Credential files auto-restored: {detail} — "
-                            "rotate any that changed since the backup"
-                        ),
-                    }
-                )
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Credential files auto-restored: {detail} — "
+                        "rotate any that changed since the backup"
+                    ),
+                })
                 current_ids.add(alert_id)
         except (json.JSONDecodeError, OSError):
             pass
@@ -967,13 +904,11 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
 
     if not active_only:
         for resolved_id, resolved_at in _alert_history.items():
-            alerts.append(
-                {
-                    "id": resolved_id,
-                    "severity": "RESOLVED",
-                    "message": f"Previously active alert resolved at {resolved_at}",
-                }
-            )
+            alerts.append({
+                "id": resolved_id,
+                "severity": "RESOLVED",
+                "message": f"Previously active alert resolved at {resolved_at}",
+            })
 
     health_mcp_mod._alert_history = {aid: now for aid in current_ids}
 

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -164,9 +164,7 @@ def clear_stale_job_failures(rt: GenesisRuntime) -> int:
             continue
         logger.info(
             "Cleared stale failures for job %s (last_failure=%s, was=%d)",
-            job_name,
-            last_failure,
-            entry["consecutive_failures"],
+            job_name, last_failure, entry["consecutive_failures"],
         )
         entry["consecutive_failures"] = 0
         entry.pop("last_failure", None)
@@ -388,6 +386,7 @@ def register_channel(
         rt._outreach_pipeline._channels[name] = adapter
         if recipient:
             rt._outreach_pipeline._recipients[name] = recipient
-    if rt._outreach_scheduler is not None and not rt._outreach_scheduler.is_running:
+    if (rt._outreach_scheduler is not None
+            and not rt._outreach_scheduler.is_running):
         logger.info("First outreach channel '%s' registered — starting scheduler", name)
         rt._outreach_scheduler.start()

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -18,13 +18,91 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from genesis.runtime._core import GenesisRuntime
 
 logger = logging.getLogger("genesis.runtime")
+
+# WS-2 M9 — per-run job history debounce. A success earns a run_event only when
+# >= this long since the job's last success; a failure earns one on streak onset
+# and then at most once per interval during a sustained outage. Anchored on the
+# already-persisted job_health columns (last_success / last_failure /
+# consecutive_failures) so the debounce survives restart without new state.
+_RUN_EVENT_MIN_INTERVAL = timedelta(hours=1)
+
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+def _duration_ms(run_started_at: str | None, now_dt: datetime | None) -> int | None:
+    """Real run duration, or None when no start marker exists (never guess).
+
+    Deriving duration from ``last_run`` would yield the inter-run *cadence*, not
+    the duration — a lying instrument. Only ``record_job_start`` sets a start
+    marker, so duration is honest-or-NULL.
+    """
+    start_dt = _parse_iso(run_started_at)
+    if start_dt is None or now_dt is None:
+        return None
+    delta_ms = (now_dt - start_dt).total_seconds() * 1000
+    return int(delta_ms) if delta_ms >= 0 else None
+
+
+def _append_job_run_event(
+    rt: GenesisRuntime,
+    job_name: str,
+    *,
+    status: str,
+    run_started_at: str | None,
+    duration_ms: int | None,
+    error: str | None,
+    now: str,
+) -> None:
+    """Fire-and-forget append to ``job_run_events`` (mirrors ``_persist_job_start``).
+
+    Same loop-check-before-coroutine + ``tracked_task`` + swallow contract as the
+    job_health persist path — a run-event write must NEVER throw into the ~62
+    ``record_job_*`` callers, several on the 5-min awareness hot path.
+    """
+    if rt._db is None:
+        return
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    from genesis.db.crud import job_run_events as _jre
+    from genesis.util.tasks import tracked_task
+
+    async def _write() -> None:
+        try:
+            await _jre.record_run_event(
+                rt._db,
+                job_name=job_name,
+                status=status,
+                run_started_at=run_started_at,
+                duration_ms=duration_ms,
+                error=error,
+                recorded_at=now,
+            )
+        except sqlite3.Error:
+            logger.error("DB error recording job run event for %s", job_name, exc_info=True)
+        except Exception:
+            logger.error("Failed to record job run event for %s", job_name, exc_info=True)
+
+    try:
+        tracked_task(_write(), name=f"job-run-event-{job_name}")
+    except Exception:
+        logger.error("Failed to schedule job run event for %s", job_name, exc_info=True)
 
 
 async def load_persisted_job_health(rt: GenesisRuntime) -> None:
@@ -86,7 +164,9 @@ def clear_stale_job_failures(rt: GenesisRuntime) -> int:
             continue
         logger.info(
             "Cleared stale failures for job %s (last_failure=%s, was=%d)",
-            job_name, last_failure, entry["consecutive_failures"],
+            job_name,
+            last_failure,
+            entry["consecutive_failures"],
         )
         entry["consecutive_failures"] = 0
         entry.pop("last_failure", None)
@@ -215,6 +295,9 @@ def record_job_start(rt: GenesisRuntime, job_name: str) -> None:
     now = datetime.now(UTC).isoformat()
     entry = rt._job_health.setdefault(job_name, {"consecutive_failures": 0})
     entry["last_run"] = now
+    # WS-2 M9: in-memory start marker for honest duration_ms (consumed at
+    # success/failure). Not persisted — a mid-run restart loses it → NULL duration.
+    entry["run_started_at"] = now
     _persist_job_start(rt, job_name, now)
 
 
@@ -222,6 +305,8 @@ def record_job_success(rt: GenesisRuntime, job_name: str) -> None:
     """Record a successful scheduled job execution (in-memory + DB)."""
     now = datetime.now(UTC).isoformat()
     entry = rt._job_health.setdefault(job_name, {"consecutive_failures": 0})
+    prev_success = entry.get("last_success")  # capture BEFORE the overwrite below
+    run_started_at = entry.pop("run_started_at", None)  # consume start marker
     entry["last_run"] = now
     entry["last_success"] = now
     entry["consecutive_failures"] = 0
@@ -230,6 +315,22 @@ def record_job_success(rt: GenesisRuntime, job_name: str) -> None:
     entry.pop("last_failure", None)
     entry.pop("last_error", None)
     rt._persist_job_health(job_name, entry, now)
+
+    # WS-2 M9: debounced success run-event — first success ever, or >= 1h since
+    # the last one. Anchored on the just-captured prev_success (persisted +
+    # reloaded at boot), so a sub-hourly poll writes nothing until an hour elapses.
+    now_dt = _parse_iso(now)
+    prev_dt = _parse_iso(prev_success)
+    if prev_dt is None or now_dt is None or (now_dt - prev_dt) >= _RUN_EVENT_MIN_INTERVAL:
+        _append_job_run_event(
+            rt,
+            job_name,
+            status="success",
+            run_started_at=run_started_at,
+            duration_ms=_duration_ms(run_started_at, now_dt),
+            error=None,
+            now=now,
+        )
 
 
 def record_job_failure(rt: GenesisRuntime, job_name: str, error: str) -> None:
@@ -240,11 +341,34 @@ def record_job_failure(rt: GenesisRuntime, job_name: str, error: str) -> None:
     """
     now = datetime.now(UTC).isoformat()
     entry = rt._job_health.setdefault(job_name, {"consecutive_failures": 0})
+    prev_consecutive = entry.get("consecutive_failures", 0)  # 0 → this is a streak ONSET
+    prev_failure = entry.get("last_failure")  # heartbeat anchor (captured pre-overwrite)
+    run_started_at = entry.pop("run_started_at", None)  # consume start marker
     entry["last_run"] = now
     entry["last_failure"] = now
     entry["last_error"] = error
-    entry["consecutive_failures"] = entry.get("consecutive_failures", 0) + 1
+    entry["consecutive_failures"] = prev_consecutive + 1
     rt._persist_job_health(job_name, entry, now)
+
+    # WS-2 M9: failure run-event on streak ONSET (prev consecutive == 0) OR an
+    # hourly heartbeat during a sustained outage — bounds a stuck 60s poll to
+    # ~24 rows/day while preserving every distinct failure episode. Independent
+    # of and BEFORE the retry branch so neither can suppress the other.
+    now_dt = _parse_iso(now)
+    prev_fail_dt = _parse_iso(prev_failure)
+    heartbeat_due = (
+        prev_fail_dt is None or now_dt is None or (now_dt - prev_fail_dt) >= _RUN_EVENT_MIN_INTERVAL
+    )
+    if prev_consecutive == 0 or heartbeat_due:
+        _append_job_run_event(
+            rt,
+            job_name,
+            status="failed",
+            run_started_at=run_started_at,
+            duration_ms=_duration_ms(run_started_at, now_dt),
+            error=error,
+            now=now,
+        )
 
     consecutive = entry["consecutive_failures"]
     if consecutive >= 3 and rt._job_retry_registry is not None:
@@ -264,7 +388,6 @@ def register_channel(
         rt._outreach_pipeline._channels[name] = adapter
         if recipient:
             rt._outreach_pipeline._recipients[name] = recipient
-    if (rt._outreach_scheduler is not None
-            and not rt._outreach_scheduler.is_running):
+    if rt._outreach_scheduler is not None and not rt._outreach_scheduler.is_running:
         logger.info("First outreach channel '%s' registered — starting scheduler", name)
         rt._outreach_scheduler.start()

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -96,6 +96,50 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
         misfire_grace_time=3600,
     )
 
+    async def _prune_job_run_events() -> None:
+        if rt._db is None:
+            return
+        try:
+            from genesis.db.crud import job_run_events as _jre
+
+            removed = await _jre.prune_older_than(rt._db, days=90)
+            rt.record_job_success("job_run_events_prune")
+            if removed:
+                logger.info("job_run_events prune: removed %d rows (>90d)", removed)
+        except Exception as exc:
+            rt.record_job_failure("job_run_events_prune", str(exc))
+            logger.exception("job_run_events prune failed")
+
+    scheduler.add_job(
+        _prune_job_run_events,
+        CronTrigger(hour=5, minute=10, timezone=user_timezone()),
+        id="job_run_events_prune",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
+    async def _prune_alert_events() -> None:
+        if rt._db is None:
+            return
+        try:
+            from genesis.db.crud import alert_events as _ae
+
+            removed = await _ae.prune_older_than(rt._db, days=90)
+            rt.record_job_success("alert_events_prune")
+            if removed:
+                logger.info("alert_events prune: removed %d resolved rows (>90d)", removed)
+        except Exception as exc:
+            rt.record_job_failure("alert_events_prune", str(exc))
+            logger.exception("alert_events prune failed")
+
+    scheduler.add_job(
+        _prune_alert_events,
+        CronTrigger(hour=5, minute=20, timezone=user_timezone()),
+        id="alert_events_prune",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
 
 async def init(rt: GenesisRuntime) -> None:
     """Initialize learning pipeline, triage, calibration, harvest, and all scheduled jobs."""

--- a/tests/test_awareness/test_alert_events_persistence.py
+++ b/tests/test_awareness/test_alert_events_persistence.py
@@ -1,0 +1,149 @@
+"""WS-2 M10 — the awareness-tick alert_events open-set writer.
+
+_persist_health_alerts is the single designated writer that turns the live
+(recomputed-each-poll) health alert set into a durable incident log. These tests
+drive the firing set by monkeypatching the pure _compute_alerts() and assert the
+open-set reconcile: open on fire, resolve on clear, survive a fresh connection,
+and never raise into the tick.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.awareness.loop import _persist_health_alerts
+
+_CREATE_ALERT_EVENTS = """
+    CREATE TABLE IF NOT EXISTS alert_events (
+        id           TEXT PRIMARY KEY,
+        alert_id     TEXT NOT NULL,
+        source       TEXT NOT NULL,
+        severity     TEXT NOT NULL,
+        message      TEXT NOT NULL,
+        created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+        resolved_at  TEXT
+    )
+"""
+_CREATE_OPEN_IDX = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_ae_open_alert "
+    "ON alert_events(alert_id) WHERE resolved_at IS NULL"
+)
+
+
+async def _setup() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(_CREATE_ALERT_EVENTS)
+    await db.execute(_CREATE_OPEN_IDX)
+    await db.commit()
+    return db
+
+
+def _patch_compute(monkeypatch, alerts):
+    async def _fake():
+        return alerts, {a["id"] for a in alerts}
+
+    monkeypatch.setattr("genesis.mcp.health.errors._compute_alerts", _fake)
+
+
+async def _open_count(db) -> int:
+    async with db.execute("SELECT COUNT(*) FROM alert_events WHERE resolved_at IS NULL") as cur:
+        return (await cur.fetchone())[0]
+
+
+async def test_firing_alert_opens_row(monkeypatch):
+    db = await _setup()
+    try:
+        _patch_compute(
+            monkeypatch,
+            [{"id": "call_site:groq", "severity": "CRITICAL", "message": "down"}],
+        )
+        await _persist_health_alerts(db)
+        async with db.execute(
+            "SELECT alert_id, source, severity, resolved_at FROM alert_events"
+        ) as cur:
+            rows = list(await cur.fetchall())
+        assert len(rows) == 1
+        assert rows[0]["alert_id"] == "call_site:groq"
+        assert rows[0]["source"] == "call_site"  # derived from the id prefix
+        assert rows[0]["resolved_at"] is None
+    finally:
+        await db.close()
+
+
+async def test_repeated_fire_is_idempotent(monkeypatch):
+    db = await _setup()
+    try:
+        _patch_compute(
+            monkeypatch,
+            [{"id": "creds:corrupt", "severity": "CRITICAL", "message": "x"}],
+        )
+        await _persist_health_alerts(db)
+        await _persist_health_alerts(db)  # same alert still firing → no 2nd open row
+        assert await _open_count(db) == 1
+    finally:
+        await db.close()
+
+
+async def test_cleared_alert_is_resolved(monkeypatch):
+    db = await _setup()
+    try:
+        _patch_compute(
+            monkeypatch,
+            [{"id": "queue:dead_letter", "severity": "WARNING", "message": "y"}],
+        )
+        await _persist_health_alerts(db)
+        assert await _open_count(db) == 1
+        # Next tick: nothing firing → the open row must be resolved.
+        _patch_compute(monkeypatch, [])
+        await _persist_health_alerts(db)
+        assert await _open_count(db) == 0
+        async with db.execute(
+            "SELECT resolved_at FROM alert_events WHERE alert_id = 'queue:dead_letter'"
+        ) as cur:
+            assert (await cur.fetchone())["resolved_at"] is not None
+    finally:
+        await db.close()
+
+
+async def test_refire_after_resolve_opens_new_incident(monkeypatch):
+    db = await _setup()
+    try:
+        alert = [{"id": "creds:corrupt", "severity": "CRITICAL", "message": "x"}]
+        _patch_compute(monkeypatch, alert)
+        await _persist_health_alerts(db)
+        _patch_compute(monkeypatch, [])
+        await _persist_health_alerts(db)  # resolve
+        _patch_compute(monkeypatch, alert)
+        await _persist_health_alerts(db)  # re-fire → distinct incident row
+        async with db.execute(
+            "SELECT COUNT(*) FROM alert_events WHERE alert_id = 'creds:corrupt'"
+        ) as cur:
+            assert (await cur.fetchone())[0] == 2
+        assert await _open_count(db) == 1
+    finally:
+        await db.close()
+
+
+async def test_none_db_is_noop():
+    # Must not raise when the DB is unavailable (tick still runs).
+    await _persist_health_alerts(None)
+
+
+async def test_compute_failure_never_raises(monkeypatch):
+    db = await _setup()
+    try:
+
+        async def _boom():
+            raise RuntimeError("health snapshot exploded")
+
+        monkeypatch.setattr("genesis.mcp.health.errors._compute_alerts", _boom)
+        # Best-effort: a compute failure must be swallowed, not propagated.
+        await _persist_health_alerts(db)
+        assert await _open_count(db) == 0
+    finally:
+        await db.close()
+
+
+pytestmark = pytest.mark.asyncio

--- a/tests/test_awareness/test_user_model_staleness.py
+++ b/tests/test_awareness/test_user_model_staleness.py
@@ -1,0 +1,115 @@
+"""WS-2 M7 injected-failure — user_model_delta stream staleness alarm.
+
+The reflection user-impact path writes deltas to observations(type=
+'user_model_delta'); the stream can go silent (it flatlined ~Mar–Jul 2026)
+without anything noticing. This un-blinds that: a >14d gap raises a non-paging
+'high' infrastructure_alert that auto-resolves when a fresh delta lands.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.awareness import loop as _loop
+from genesis.awareness.loop import (
+    _check_user_model_staleness,
+    _resolve_user_model_staleness,
+)
+from genesis.db.crud import observations as obs
+from genesis.db.schema._tables import TABLES
+
+
+async def _setup() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(TABLES["observations"])
+    await db.commit()
+    return db
+
+
+async def _seed_delta(db, *, days_ago: int) -> None:
+    await obs.create(
+        db,
+        id=uuid.uuid4().hex,
+        source="reflection",
+        type="user_model_delta",
+        content="synthetic delta",
+        priority="low",
+        created_at=(datetime.now(UTC) - timedelta(days=days_ago)).isoformat(),
+    )
+
+
+async def _alerts(db) -> list[dict]:
+    async with db.execute(
+        "SELECT id, priority, resolved FROM observations "
+        "WHERE source = 'user_model_staleness_monitor' AND type = 'infrastructure_alert'"
+    ) as cur:
+        return [dict(r) for r in await cur.fetchall()]
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    _loop._last_user_model_stale_alert_at = 0.0
+    yield
+    _loop._last_user_model_stale_alert_at = 0.0
+
+
+async def test_stale_stream_raises_high_alert():
+    db = await _setup()
+    try:
+        await _seed_delta(db, days_ago=30)  # well past the 14d threshold
+        await _check_user_model_staleness(db)
+        alerts = await _alerts(db)
+        assert len(alerts) == 1
+        assert alerts[0]["priority"] == "high"  # non-paging by design
+        assert alerts[0]["resolved"] == 0
+    finally:
+        await db.close()
+
+
+async def test_never_any_delta_raises_alert():
+    db = await _setup()
+    try:
+        await _check_user_model_staleness(db)  # empty observations table
+        assert len(await _alerts(db)) == 1
+    finally:
+        await db.close()
+
+
+async def test_fresh_stream_no_alert():
+    db = await _setup()
+    try:
+        await _seed_delta(db, days_ago=3)  # within the window
+        await _check_user_model_staleness(db)
+        assert await _alerts(db) == []
+    finally:
+        await db.close()
+
+
+async def test_fresh_delta_resolves_prior_alert():
+    db = await _setup()
+    try:
+        await _seed_delta(db, days_ago=30)
+        await _check_user_model_staleness(db)
+        before = await _alerts(db)
+        assert len(before) == 1 and before[0]["resolved"] == 0
+
+        # A fresh delta arrives; the next check must resolve the standing alert.
+        await _seed_delta(db, days_ago=0)
+        await _check_user_model_staleness(db)
+        alerts = await _alerts(db)
+        assert all(a["resolved"] == 1 for a in alerts), "fresh delta must resolve staleness alert"
+    finally:
+        await db.close()
+
+
+async def test_none_db_and_resolve_are_noops():
+    await _check_user_model_staleness(None)  # must not raise
+    await _resolve_user_model_staleness(None)  # must not raise
+
+
+pytestmark = pytest.mark.asyncio

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -92,35 +92,66 @@ async def test_all_tables_exist(db):
 async def test_no_unexpected_tables(db):
     tables = await _get_tables(db)
     known = set(EXPECTED_TABLES) | {
-        "memory_fts", "memory_fts_data", "memory_fts_idx",
-        "memory_fts_content", "memory_fts_docsize", "memory_fts_config",
-        "knowledge_fts", "knowledge_fts_data", "knowledge_fts_idx",
-        "knowledge_fts_content", "knowledge_fts_docsize", "knowledge_fts_config",
-        "call_site_last_run", "resolved_errors", "job_health",
-        "processed_emails", "task_steps",
-        "ego_cycles", "ego_cycle_outcomes", "ego_proposals", "ego_state", "intervention_journal", "capability_map",
-        "behavioral_corrections", "behavioral_themes", "behavioral_treatments",
+        "memory_fts",
+        "memory_fts_data",
+        "memory_fts_idx",
+        "memory_fts_content",
+        "memory_fts_docsize",
+        "memory_fts_config",
+        "knowledge_fts",
+        "knowledge_fts_data",
+        "knowledge_fts_idx",
+        "knowledge_fts_content",
+        "knowledge_fts_docsize",
+        "knowledge_fts_config",
+        "call_site_last_run",
+        "resolved_errors",
+        "job_health",
+        "processed_emails",
+        "task_steps",
+        "ego_cycles",
+        "ego_cycle_outcomes",
+        "ego_proposals",
+        "ego_state",
+        "intervention_journal",
+        "capability_map",
+        "behavioral_corrections",
+        "behavioral_themes",
+        "behavioral_treatments",
         "memory_metadata",
-        "code_modules", "code_symbols", "code_imports",
-        "follow_ups", "surplus_tasks", "surplus_insights",
+        "code_modules",
+        "code_symbols",
+        "code_imports",
+        "follow_ups",
+        "surplus_tasks",
+        "surplus_insights",
         "knowledge_uploads",
         "file_modifications",
         "direct_session_queue",
-        "eval_events", "eval_snapshots",
+        "eval_events",
+        "eval_snapshots",
         "memory_events",
-        "user_goals", "user_contacts", "ego_directives",
+        "user_goals",
+        "user_contacts",
+        "ego_directives",
         "tool_call_outcomes",
-        "user_jobs", "user_job_runs",
+        "user_jobs",
+        "user_job_runs",
         "task_type_watermarks",
         "prompt_versions",
         "eval_subsystem_grades",
         "reflection_corpus",
-        "email_threads", "email_thread_messages",
+        "email_threads",
+        "email_thread_messages",
         "outcome_events",  # self-improvement outcome bus
         "ego_calibration_snapshots",  # measure-only ego calibration
         "otel_spans",  # tracing/spans backbone
         "cognitive_file_modifications",  # cognitive self-mod rollback ledger
-        "entities", "entity_mentions", "entity_links",  # entity layer (WS-H P2)
+        "entities",
+        "entity_mentions",
+        "entity_links",  # entity layer (WS-H P2)
+        "job_run_events",
+        "alert_events",  # WS-2 sensor fabric (M9/M10)
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"
@@ -173,8 +204,7 @@ async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
 
     # Sanity check: row exists before migration runs.
     cur = await db.execute(
-        "SELECT COUNT(*) FROM signal_weights "
-        "WHERE signal_name = 'unprocessed_memory_backlog'"
+        "SELECT COUNT(*) FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
     )
     assert (await cur.fetchone())[0] == 1
 
@@ -182,8 +212,7 @@ async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
     await _migrate_add_columns(db)
     await db.commit()
     cur = await db.execute(
-        "SELECT COUNT(*) FROM signal_weights "
-        "WHERE signal_name = 'unprocessed_memory_backlog'"
+        "SELECT COUNT(*) FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
     )
     assert (await cur.fetchone())[0] == 0
 
@@ -191,8 +220,7 @@ async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
     await _migrate_add_columns(db)
     await db.commit()
     cur = await db.execute(
-        "SELECT COUNT(*) FROM signal_weights "
-        "WHERE signal_name = 'unprocessed_memory_backlog'"
+        "SELECT COUNT(*) FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
     )
     assert (await cur.fetchone())[0] == 0
 
@@ -337,9 +365,7 @@ async def test_build_candidates_one_open_per_item_key(db):
             "VALUES ('c2', 'k1', 'title', 'notepad.md', 'build')"
         )
     # Close c1 with a decision — a fresh open candidate is then allowed.
-    await db.execute(
-        "UPDATE build_candidates SET user_decision = 'rejected' WHERE id = 'c1'"
-    )
+    await db.execute("UPDATE build_candidates SET user_decision = 'rejected' WHERE id = 'c1'")
     await db.execute(
         "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict) "
         "VALUES ('c3', 'k1', 'title', 'notepad.md', 'build')"
@@ -356,9 +382,7 @@ async def test_task_states_source_defaults_to_user(db):
         "INSERT INTO task_states (task_id, description, intake_token) "
         "VALUES ('t-x', 'd', 'tok-src')"
     )
-    cursor = await db.execute(
-        "SELECT source FROM task_states WHERE task_id = 't-x'"
-    )
+    cursor = await db.execute("SELECT source FROM task_states WHERE task_id = 't-x'")
     row = await cursor.fetchone()
     assert row[0] == "user"
 
@@ -465,8 +489,15 @@ async def test_dead_letter_table_columns(db):
     cursor = await db.execute("PRAGMA table_info(dead_letter)")
     cols = {row[1] for row in await cursor.fetchall()}
     expected = {
-        "id", "operation_type", "payload", "target_provider",
-        "failure_reason", "created_at", "retry_count", "last_retry_at", "status",
+        "id",
+        "operation_type",
+        "payload",
+        "target_provider",
+        "failure_reason",
+        "created_at",
+        "retry_count",
+        "last_retry_at",
+        "status",
     }
     assert expected == cols
 
@@ -531,6 +562,7 @@ async def test_migration_creates_all_indexed_columns():
         # 2. Run migrations (on a fresh DB this is a no-op, but it exercises
         #    all _try_alter paths to ensure they don't error)
         from genesis.db.schema._migrations import _migrate_add_columns
+
         await _migrate_add_columns(conn)
         await conn.commit()
 

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -92,66 +92,36 @@ async def test_all_tables_exist(db):
 async def test_no_unexpected_tables(db):
     tables = await _get_tables(db)
     known = set(EXPECTED_TABLES) | {
-        "memory_fts",
-        "memory_fts_data",
-        "memory_fts_idx",
-        "memory_fts_content",
-        "memory_fts_docsize",
-        "memory_fts_config",
-        "knowledge_fts",
-        "knowledge_fts_data",
-        "knowledge_fts_idx",
-        "knowledge_fts_content",
-        "knowledge_fts_docsize",
-        "knowledge_fts_config",
-        "call_site_last_run",
-        "resolved_errors",
-        "job_health",
-        "processed_emails",
-        "task_steps",
-        "ego_cycles",
-        "ego_cycle_outcomes",
-        "ego_proposals",
-        "ego_state",
-        "intervention_journal",
-        "capability_map",
-        "behavioral_corrections",
-        "behavioral_themes",
-        "behavioral_treatments",
+        "memory_fts", "memory_fts_data", "memory_fts_idx",
+        "memory_fts_content", "memory_fts_docsize", "memory_fts_config",
+        "knowledge_fts", "knowledge_fts_data", "knowledge_fts_idx",
+        "knowledge_fts_content", "knowledge_fts_docsize", "knowledge_fts_config",
+        "call_site_last_run", "resolved_errors", "job_health",
+        "processed_emails", "task_steps",
+        "ego_cycles", "ego_cycle_outcomes", "ego_proposals", "ego_state", "intervention_journal", "capability_map",
+        "behavioral_corrections", "behavioral_themes", "behavioral_treatments",
         "memory_metadata",
-        "code_modules",
-        "code_symbols",
-        "code_imports",
-        "follow_ups",
-        "surplus_tasks",
-        "surplus_insights",
+        "code_modules", "code_symbols", "code_imports",
+        "follow_ups", "surplus_tasks", "surplus_insights",
         "knowledge_uploads",
         "file_modifications",
         "direct_session_queue",
-        "eval_events",
-        "eval_snapshots",
+        "eval_events", "eval_snapshots",
         "memory_events",
-        "user_goals",
-        "user_contacts",
-        "ego_directives",
+        "user_goals", "user_contacts", "ego_directives",
         "tool_call_outcomes",
-        "user_jobs",
-        "user_job_runs",
+        "user_jobs", "user_job_runs",
         "task_type_watermarks",
         "prompt_versions",
         "eval_subsystem_grades",
         "reflection_corpus",
-        "email_threads",
-        "email_thread_messages",
+        "email_threads", "email_thread_messages",
         "outcome_events",  # self-improvement outcome bus
         "ego_calibration_snapshots",  # measure-only ego calibration
         "otel_spans",  # tracing/spans backbone
         "cognitive_file_modifications",  # cognitive self-mod rollback ledger
-        "entities",
-        "entity_mentions",
-        "entity_links",  # entity layer (WS-H P2)
-        "job_run_events",
-        "alert_events",  # WS-2 sensor fabric (M9/M10)
+        "entities", "entity_mentions", "entity_links",  # entity layer (WS-H P2)
+        "job_run_events", "alert_events",  # WS-2 sensor fabric (M9/M10)
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"
@@ -204,7 +174,8 @@ async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
 
     # Sanity check: row exists before migration runs.
     cur = await db.execute(
-        "SELECT COUNT(*) FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
+        "SELECT COUNT(*) FROM signal_weights "
+        "WHERE signal_name = 'unprocessed_memory_backlog'"
     )
     assert (await cur.fetchone())[0] == 1
 
@@ -212,7 +183,8 @@ async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
     await _migrate_add_columns(db)
     await db.commit()
     cur = await db.execute(
-        "SELECT COUNT(*) FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
+        "SELECT COUNT(*) FROM signal_weights "
+        "WHERE signal_name = 'unprocessed_memory_backlog'"
     )
     assert (await cur.fetchone())[0] == 0
 
@@ -220,7 +192,8 @@ async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
     await _migrate_add_columns(db)
     await db.commit()
     cur = await db.execute(
-        "SELECT COUNT(*) FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
+        "SELECT COUNT(*) FROM signal_weights "
+        "WHERE signal_name = 'unprocessed_memory_backlog'"
     )
     assert (await cur.fetchone())[0] == 0
 
@@ -365,7 +338,9 @@ async def test_build_candidates_one_open_per_item_key(db):
             "VALUES ('c2', 'k1', 'title', 'notepad.md', 'build')"
         )
     # Close c1 with a decision — a fresh open candidate is then allowed.
-    await db.execute("UPDATE build_candidates SET user_decision = 'rejected' WHERE id = 'c1'")
+    await db.execute(
+        "UPDATE build_candidates SET user_decision = 'rejected' WHERE id = 'c1'"
+    )
     await db.execute(
         "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict) "
         "VALUES ('c3', 'k1', 'title', 'notepad.md', 'build')"
@@ -382,7 +357,9 @@ async def test_task_states_source_defaults_to_user(db):
         "INSERT INTO task_states (task_id, description, intake_token) "
         "VALUES ('t-x', 'd', 'tok-src')"
     )
-    cursor = await db.execute("SELECT source FROM task_states WHERE task_id = 't-x'")
+    cursor = await db.execute(
+        "SELECT source FROM task_states WHERE task_id = 't-x'"
+    )
     row = await cursor.fetchone()
     assert row[0] == "user"
 
@@ -489,15 +466,8 @@ async def test_dead_letter_table_columns(db):
     cursor = await db.execute("PRAGMA table_info(dead_letter)")
     cols = {row[1] for row in await cursor.fetchall()}
     expected = {
-        "id",
-        "operation_type",
-        "payload",
-        "target_provider",
-        "failure_reason",
-        "created_at",
-        "retry_count",
-        "last_retry_at",
-        "status",
+        "id", "operation_type", "payload", "target_provider",
+        "failure_reason", "created_at", "retry_count", "last_retry_at", "status",
     }
     assert expected == cols
 
@@ -562,7 +532,6 @@ async def test_migration_creates_all_indexed_columns():
         # 2. Run migrations (on a fresh DB this is a no-op, but it exercises
         #    all _try_alter paths to ensure they don't error)
         from genesis.db.schema._migrations import _migrate_add_columns
-
         await _migrate_add_columns(conn)
         await conn.commit()
 

--- a/tests/test_db/test_sensor_fabric_schema.py
+++ b/tests/test_db/test_sensor_fabric_schema.py
@@ -1,0 +1,64 @@
+"""WS-2 M9/M10 base-schema parity — the sensor tables + their indexes exist
+when the schema is built from TABLES/INDEXES (create_all_tables), not just via
+the versioned migration.
+
+Regression lock for the gap Codex caught on #1077: the partial unique index
+`idx_ae_open_alert` is what makes `alert_events` reconcile idempotent, and it
+must be present on EVERY schema-build path — a fresh install goes through
+create_all_tables(), so an index that lives only in the migration would leave
+fresh installs accumulating duplicate open incident rows every tick.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import alert_events as ae
+from genesis.db.schema import create_all_tables
+
+
+async def _built_db() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await create_all_tables(db)
+    return db
+
+
+async def _index_names(db) -> set[str]:
+    async with db.execute("SELECT name FROM sqlite_master WHERE type='index'") as cur:
+        return {r[0] for r in await cur.fetchall()}
+
+
+async def test_sensor_tables_and_indexes_in_base_schema():
+    db = await _built_db()
+    try:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('job_run_events', 'alert_events')"
+        ) as cur:
+            tables = {r[0] for r in await cur.fetchall()}
+        assert tables == {"job_run_events", "alert_events"}
+
+        idx = await _index_names(db)
+        # The load-bearing one: without this the open-set reconcile is not idempotent.
+        assert "idx_ae_open_alert" in idx
+        assert {"idx_ae_created", "idx_ae_alert"} <= idx
+        assert {"idx_jre_job_time", "idx_jre_recorded", "idx_jre_status"} <= idx
+    finally:
+        await db.close()
+
+
+async def test_open_set_idempotent_on_base_schema():
+    """The partial unique index must actually dedup on a base-schema-built DB."""
+    db = await _built_db()
+    try:
+        alert = [{"alert_id": "e2e:probe", "source": "e2e", "severity": "CRITICAL", "message": "x"}]
+        await ae.reconcile_open_set(db, active=alert, now="2026-07-15T00:00:00")
+        await ae.reconcile_open_set(db, active=alert, now="2026-07-15T00:05:00")
+        assert len(await ae.list_open(db)) == 1, "repeat firing must not open a 2nd row"
+    finally:
+        await db.close()
+
+
+pytestmark = pytest.mark.asyncio

--- a/tests/test_outreach/test_morning_report_mq_closure.py
+++ b/tests/test_outreach/test_morning_report_mq_closure.py
@@ -1,0 +1,75 @@
+"""WS-2 M11 injected-failure E2E — message_queue findings are closable.
+
+Before #956, findings rendered into the morning report were never marked
+responded, so query_pending re-listed them every day until the 7-day expiry (it
+conflated "seen in a delivered report" with "never seen"). This pins the fix:
+after confirm_delivery, a rendered finding is marked responded and drops out of
+query_pending — it is not re-listed on day 2.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import message_queue as mq_crud
+from genesis.outreach.morning_report import MorningReportGenerator
+
+_CREATE_MESSAGE_QUEUE = """
+    CREATE TABLE IF NOT EXISTS message_queue (
+        id             TEXT PRIMARY KEY,
+        task_id        TEXT,
+        source         TEXT NOT NULL,
+        target         TEXT NOT NULL,
+        message_type   TEXT NOT NULL,
+        priority       TEXT NOT NULL DEFAULT 'medium',
+        content        TEXT NOT NULL,
+        response       TEXT,
+        session_id     TEXT,
+        created_at     TEXT NOT NULL,
+        responded_at   TEXT,
+        expired_at     TEXT
+    )
+"""
+
+
+async def test_delivered_finding_is_closed_not_relisted():
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    try:
+        await db.execute(_CREATE_MESSAGE_QUEUE)
+        await db.commit()
+
+        # Day 1: a finding lands in the queue and is pending.
+        await mq_crud.create(
+            db,
+            id="mq-1",
+            source="autonomy",
+            target="owner",
+            message_type="finding",
+            content="synthetic finding",
+            created_at="2026-07-15T06:00:00",
+        )
+        pending = await mq_crud.query_pending(db)
+        assert any(r["id"] == "mq-1" for r in pending), "finding should be pending pre-delivery"
+
+        # The report renders it, then confirm_delivery closes it.
+        gen = MorningReportGenerator.__new__(MorningReportGenerator)
+        gen._db = db
+        gen._pending_surface_ids = []
+        gen._pending_mq_ids = ["mq-1"]
+        await gen.confirm_delivery()
+
+        # Day 2: it must be marked responded and NOT re-listed.
+        row = await mq_crud.get_by_id(db, "mq-1")
+        assert row["response"] == "surfaced_in_morning_report"
+        assert row["responded_at"] is not None
+        pending_after = await mq_crud.query_pending(db)
+        assert not any(r["id"] == "mq-1" for r in pending_after), (
+            "delivered finding must not re-list"
+        )
+    finally:
+        await db.close()
+
+
+pytestmark = pytest.mark.asyncio

--- a/tests/test_runtime/test_job_run_events.py
+++ b/tests/test_runtime/test_job_run_events.py
@@ -1,0 +1,211 @@
+"""WS-2 M9 — job_run_events debounce, duration honesty, and write isolation.
+
+Per-run job history is written from record_job_success/failure with a debounce
+anchored on the persisted job_health columns (last_success / last_failure /
+consecutive_failures). These tests drive elapsed time by seeding those in-memory
+columns directly (the debounce reads them BEFORE overwriting), so no global-clock
+patching is needed. Real in-memory aiosqlite DB + tracked_task drain, matching
+test_job_health.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from genesis.runtime import GenesisRuntime
+
+_CREATE_JOB_HEALTH = """
+    CREATE TABLE IF NOT EXISTS job_health (
+        job_name         TEXT PRIMARY KEY,
+        last_run         TEXT,
+        last_success     TEXT,
+        last_failure     TEXT,
+        last_error       TEXT,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        total_runs       INTEGER NOT NULL DEFAULT 0,
+        total_successes  INTEGER NOT NULL DEFAULT 0,
+        total_failures   INTEGER NOT NULL DEFAULT 0,
+        updated_at       TEXT NOT NULL
+    )
+"""
+_CREATE_JOB_RUN_EVENTS = """
+    CREATE TABLE IF NOT EXISTS job_run_events (
+        id             TEXT PRIMARY KEY,
+        job_name       TEXT NOT NULL,
+        status         TEXT NOT NULL CHECK (status IN ('success', 'failed')),
+        run_started_at TEXT,
+        duration_ms    INTEGER,
+        error          TEXT,
+        recorded_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+"""
+
+
+async def _drain_pending() -> None:
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _make_runtime(db: aiosqlite.Connection | None) -> GenesisRuntime:
+    rt = GenesisRuntime.__new__(GenesisRuntime)
+    rt._job_health = {}
+    rt._db = db
+    rt._job_retry_registry = None
+    return rt
+
+
+async def _events(db: aiosqlite.Connection, job_name: str) -> list[tuple]:
+    async with db.execute(
+        "SELECT status, run_started_at, duration_ms, error FROM job_run_events "
+        "WHERE job_name = ? ORDER BY recorded_at",
+        (job_name,),
+    ) as cur:
+        return list(await cur.fetchall())
+
+
+async def _setup() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    await db.execute(_CREATE_JOB_HEALTH)
+    await db.execute(_CREATE_JOB_RUN_EVENTS)
+    await db.commit()
+    return db
+
+
+async def test_first_success_writes_run_event():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_success("job_a")
+        await _drain_pending()
+        rows = await _events(db, "job_a")
+        assert len(rows) == 1
+        assert rows[0][0] == "success"
+    finally:
+        await db.close()
+
+
+async def test_second_success_within_hour_is_debounced():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_success("job_a")  # first → writes
+        await _drain_pending()
+        rt.record_job_success("job_a")  # immediately again → last_success ~now → suppressed
+        await _drain_pending()
+        rows = await _events(db, "job_a")
+        assert len(rows) == 1, "sub-hourly repeat success must not write a second event"
+    finally:
+        await db.close()
+
+
+async def test_success_after_an_hour_writes_again():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_success("job_a")  # first
+        await _drain_pending()
+        # Simulate >1h elapsed by backdating the in-memory last_success anchor.
+        rt._job_health["job_a"]["last_success"] = (
+            datetime.now(UTC) - timedelta(hours=2)
+        ).isoformat()
+        rt.record_job_success("job_a")  # now > 1h since anchor → writes
+        await _drain_pending()
+        rows = await _events(db, "job_a")
+        assert len(rows) == 2
+    finally:
+        await db.close()
+
+
+async def test_failure_onset_writes_event_with_error():
+    """Injected-failure E2E: a job failure lands a status='failed' run-event with the error."""
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_failure("job_b", "boom")
+        await _drain_pending()
+        rows = await _events(db, "job_b")
+        assert len(rows) == 1
+        assert rows[0][0] == "failed"
+        assert rows[0][3] == "boom"
+    finally:
+        await db.close()
+
+
+async def test_repeated_failure_within_hour_is_debounced():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_failure("job_b", "boom")  # onset → writes
+        await _drain_pending()
+        rt.record_job_failure("job_b", "boom again")  # consec=1, within 1h → suppressed
+        await _drain_pending()
+        rows = await _events(db, "job_b")
+        assert len(rows) == 1, "sustained sub-hourly failures debounce to onset only"
+    finally:
+        await db.close()
+
+
+async def test_failure_heartbeat_after_an_hour():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_failure("job_b", "boom")  # onset
+        await _drain_pending()
+        # Simulate a sustained outage: streak continues, last failure >1h ago.
+        rt._job_health["job_b"]["last_failure"] = (
+            datetime.now(UTC) - timedelta(hours=2)
+        ).isoformat()
+        rt.record_job_failure("job_b", "still broken")  # heartbeat → writes
+        await _drain_pending()
+        rows = await _events(db, "job_b")
+        assert len(rows) == 2, "a sustained outage emits an hourly heartbeat row"
+    finally:
+        await db.close()
+
+
+async def test_duration_is_none_without_start_marker():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_success("job_c")  # no record_job_start → no honest duration
+        await _drain_pending()
+        rows = await _events(db, "job_c")
+        assert rows[0][2] is None, "duration must be NULL, never derived from last_run"
+    finally:
+        await db.close()
+
+
+async def test_duration_populated_from_start_marker():
+    db = await _setup()
+    try:
+        rt = _make_runtime(db)
+        rt.record_job_start("job_c")
+        # Backdate the in-memory start marker so the computed duration is positive.
+        rt._job_health["job_c"]["run_started_at"] = (
+            datetime.now(UTC) - timedelta(milliseconds=500)
+        ).isoformat()
+        rt.record_job_success("job_c")
+        await _drain_pending()
+        rows = await _events(db, "job_c")
+        assert rows[0][2] is not None and rows[0][2] >= 0, "duration should be real when started"
+    finally:
+        await db.close()
+
+
+async def test_run_event_write_failure_never_throws():
+    """A missing table (write path broken) must not propagate into the ~62 callers."""
+    db = await aiosqlite.connect(":memory:")
+    try:
+        await db.execute(_CREATE_JOB_HEALTH)  # job_health exists, job_run_events does NOT
+        await db.commit()
+        rt = _make_runtime(db)
+        # Must not raise despite the missing job_run_events table.
+        rt.record_job_success("job_d")
+        rt.record_job_failure("job_d", "boom")
+        await _drain_pending()
+    finally:
+        await db.close()

--- a/tests/test_runtime/test_learning_retention_jobs.py
+++ b/tests/test_runtime/test_learning_retention_jobs.py
@@ -13,7 +13,13 @@ from genesis.runtime.init.learning import _wire_drip_retention_jobs
 
 pytestmark = pytest.mark.asyncio
 
-_EXPECTED = ("execution_traces_prune", "cost_events_prune", "file_modifications_prune")
+_EXPECTED = (
+    "execution_traces_prune",
+    "cost_events_prune",
+    "file_modifications_prune",
+    "job_run_events_prune",
+    "alert_events_prune",
+)
 
 
 class _StubRT:
@@ -26,7 +32,7 @@ class _StubRT:
         pass
 
 
-async def test_wire_drip_retention_jobs_registers_all_three():
+async def test_wire_drip_retention_jobs_registers_all():
     sched = AsyncIOScheduler()
     _wire_drip_retention_jobs(sched, _StubRT())
     sched.start(paused=True)  # flush pending jobs into the jobstore without firing them


### PR DESCRIPTION
## What & why

First PR of the WS-2 Cognitive Ledger workstream — the **sensor fabric** the later ledger grades against. Repairs the observability instruments the ledger depends on *before* building the ledger, each with an injected-failure test (the anti-"built but blind" pattern). Design doc: `ws2-ledger-design.md` §6 (M-series); execution plan in-session. Architect-reviewed (SOUND-WITH-CHANGES; all resolutions applied).

Migration **0061** (0060 was taken by #1073 mid-plan — re-verified at cut).

## Contents

- **M9 — `job_run_events`** (new): per-run scheduled-job history. `job_health` is cumulative-only (one row/job), so a job that failed for a week then recovered was indistinguishable from one that never failed. Writes are **debounced off the persisted `job_health` anchors** (no new state, survives restart): a success only when ≥1h since the last; a failure on streak **onset** + hourly heartbeat during a sustained outage — so a stuck 60s poll costs ~24 rows/day, not ~1440. `duration_ms` is **honest-or-NULL** (only from an explicit `record_job_start` marker; never derived from `last_run`, which is the inter-run interval). Fire-and-forget, mirroring the persist contract — never throws into the ~62 callers. 90-day prune.

- **M10 — `alert_events`** (new): a durable alert/incident store replacing the in-memory, per-process, one-generation `_alert_history` dict. `_impl_health_alerts` is split into a pure `_compute_alerts()` (read contract unchanged for all existing callers) + a **single designated awareness-tick writer** that reconciles the open-set (open a row per firing alert, stamp `resolved_at` on clear). Idempotent under the runtime/health-MCP cross-process race via a **partial UNIQUE index** on `alert_id WHERE resolved_at IS NULL`. Every-tick cadence so short-lived transitions still leave a record.

- **M7 — user-model-delta staleness alarm** (new): the reflection user-impact delta stream (`observations type='user_model_delta'`) flatlined ~Mar–Jul 2026 with nothing noticing. A >14d gap now raises a non-paging `high` alert that auto-resolves on a fresh delta. **Diagnosis (this PR):** the stream is structurally intact (writes/parse/schema all work); the throttle is the `MIN_DELTA_CONFIDENCE = 0.90` per-delta gate sitting above the light-reflection model's median output confidence (avg 0.86; 63% of historical deltas <0.90). That's a **behavioral fix → separate PR** (tracked); PR-0 only un-blinds the silence.

- **M11 — injected-failure test** pinning the #956 message_queue-closure fix. (M2 and M12 injected-failure coverage already exist in `test_edit_failure_sensor.py` / `test_j9_eval.py`.)

## Verification

- Targeted suites green (59 tests: schema, M9 debounce/duration/isolation, M10 open-set reconcile + restart-survival, M7 staleness, M11 closure) + all existing alert-consumer suites pass in isolation.
- **Live-DB-copy E2E** (real 493 MB DB, never prod): migration idempotent + partial-unique index present; injected job failure → `('failed', …)` row; synthetic alert **survives a fresh connection** (restart); M7 query on live data → last delta 3d ago → **no false positive**.
- `ruff check` clean; diff reconstructed to strip ~600 lines of PostToolUse formatter churn (CI runs `ruff check` only).

## Notes for the reviewer

- Pre-existing (not introduced here): `tests/test_mcp/test_health_transport_smoke.py::…[health_errors]` and `[provider_activity]` fail only when that file runs **after** `test_standalone_health.py` in one process — cross-file pollution reproduced identically on clean `origin/main`. All three pass in isolation. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)