### PR TITLE
fix(memory): close wing-recall cross-store gaps (fts5_only + Qdrant payload)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,8 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   batch pass through a new `wing_backfill` routing call site for the rows
   keywords can't reach — and writes wing/room/life-domain to both SQLite
   metadata and the Qdrant payload (with revert-on-failure so the stores never
-  diverge). Embedded rows become reachable by wing-filtered recall; fts5_only
-  rows get their metadata classified but remain wing-unreachable until the
-  retrieval-side gap is closed (reported separately, not overstated). Dry-run
-  by default; the bulk write is gated on a human-reviewed sample.
+  diverge), making them reachable by wing-filtered recall. Dry-run by default;
+  the bulk write is gated on a human-reviewed sample.
 
 - **Genesis survives — and now auto-recovers from — a wedged network.** Under
   heavy memory pressure the container's networking daemon can hit kernel
@@ -132,6 +130,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   live processes with no session row at all.
 
 ### Fixed
+
+- **Wing-filtered memory recall stops missing memories it should return.**
+  Asking for memories in a specific wing (e.g. `infrastructure`) silently
+  under-returned two kinds of rows: memories with no vector (FTS-only) were
+  dropped outright because the wing filter had no wing to check against them,
+  and thousands of older embedded memories were excluded because their vector
+  carried no wing tag even though their record did. Recall now checks each
+  memory's authoritative wing (from its stored record) rather than a
+  denormalized copy, so FTS-only rows are reachable; and a one-shot supervised
+  re-sync (`scripts/wing_payload_resync.py`) backfills the missing wing tag
+  onto ~5.3K older vectors so vector-based wing recall returns them too.
+  Dry-run by default; the bulk re-sync is gated on a human-reviewed sample.
 
 - **Genesis's inner monologue now knows who each thought is about.** Every
   ambient micro-reflection used to be tagged as relevant to "both" the user

--- a/scripts/wing_backfill.py
+++ b/scripts/wing_backfill.py
@@ -20,10 +20,11 @@ Writes go to BOTH stores or neither (cross-store mirror discipline):
 on the Qdrant payload for embedded rows (``fts5_only`` rows have no point).
 On a Qdrant failure the SQLite row is reverted and the id logged.
 
-NOTE: ``fts5_only`` rows get their SQLite metadata classified but are NOT yet
-reachable by wing-filtered recall — retrieval's ``_filter_scope_fts_only``
-checks only ``life_domain:`` in the FTS tag string, never ``wing:``. Those
-rows are reported separately so the outcome is not overstated.
+NOTE: ``fts5_only`` rows have no Qdrant point, so their wing lives only in
+SQLite metadata. As of the 2026-07-15 retrieval fix, wing-filtered recall
+reaches them via the authoritative ``memory_metadata.wing`` (retrieval's
+``_filter_scope_fts_only`` reads the wing projected by ``search_ranked``).
+They are still reported separately since they are metadata-only writes.
 
 Dry-run by default; ``--apply`` performs the writes. Idempotent: reclassified
 rows drop out of the backlog WHERE clause.
@@ -393,10 +394,10 @@ async def main(args: argparse.Namespace) -> int:
         qdrant = QdrantClient(url=qdrant_url(), timeout=10)
         result = await apply_updates(db, qdrant, rows_by_id, classifications)
         print(
-            f"APPLIED: {result['embedded']} rows updated in BOTH stores "
-            f"(wing-filter-reachable); {result['metadata_only']} fts5_only rows "
-            f"updated in metadata ONLY (not yet wing-filter-reachable — see "
-            f"follow-up); {result['failed']} reverted on Qdrant failure"
+            f"APPLIED: {result['embedded']} rows updated in BOTH stores; "
+            f"{result['metadata_only']} fts5_only rows updated in metadata "
+            f"(reachable via authoritative wing); "
+            f"{result['failed']} reverted on Qdrant failure"
         )
         return 0 if result["failed"] == 0 else 1
     finally:

--- a/scripts/wing_payload_resync.py
+++ b/scripts/wing_payload_resync.py
@@ -168,9 +168,15 @@ def apply_resync(
 
     written = 0
     for (wing, room), point_ids in groups.items():
-        payload: dict = {"wing": wing, "life_domain": classify_life_domain(wing)}
-        if room:
-            payload["room"] = room
+        # Always write room (null when SQLite has none). set_payload MERGES, so
+        # omitting a null room would leave a STALE Qdrant room in place and let
+        # `wing=X & room=stale` vector recall false-match a memory whose SQLite
+        # room is null — overwrite it to match the authoritative record.
+        payload: dict = {
+            "wing": wing,
+            "room": room,
+            "life_domain": classify_life_domain(wing),
+        }
         if apply:
             set_payload_batch(client, collection=collection, point_ids=point_ids, payload=payload)
         written += len(point_ids)

--- a/scripts/wing_payload_resync.py
+++ b/scripts/wing_payload_resync.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""One-shot supervised Qdrant payload wing re-sync.
+
+``memory_metadata.wing`` (SQLite) is authoritative, but embedded rows
+classified before/outside the store-time payload write (historical backfills,
+e.g. ``scripts/backfill_memory_taxonomy.py``) can carry a real wing in SQLite
+while their Qdrant point payload's ``wing`` is missing or stale (``general``).
+Qdrant applies wing as a hard ``must`` filter, so those points are excluded
+from vector-path wing-filtered recall despite carrying a real wing.
+
+This re-syncs the Qdrant payload from SQLite (one-shot, idempotent):
+
+1. Scroll the points whose payload ``wing`` is missing or ``general``.
+2. Look up the authoritative ``wing``/``room`` in ``memory_metadata``.
+3. Where the SQLite wing is real (not NULL/``general``),
+   ``set_payload({wing, room, life_domain})`` — merged onto the point,
+   vectors and other payload keys untouched. ``life_domain`` is derived from
+   the wing via the same mapping the write path uses.
+
+Driven from Qdrant (not SQLite) so it only touches points that actually exist
+— embedded-metadata rows with no Qdrant point are never dereferenced. There is
+no runtime writer of ``memory_metadata.wing`` (only one-shot backfill scripts),
+so this re-sync is durable, not a recurring patch.
+
+Dry-run by default; ``--apply`` performs the writes. Idempotent: re-synced
+points drop out of the scroll filter.
+
+Closes the Qdrant half of follow-up 40d36a4e. The retrieval-side FTS fix ships
+in the same PR.
+
+Usage:
+    python scripts/wing_payload_resync.py --sample 20   # dry-run a sample
+    python scripts/wing_payload_resync.py               # dry-run everything
+    python scripts/wing_payload_resync.py --apply       # supervised write
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Ensure genesis package is importable when run as a script
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from dotenv import load_dotenv
+
+from genesis.env import secrets_path
+
+logger = logging.getLogger("wing_payload_resync")
+
+# Collections whose points carry a wing payload used by wing-filtered recall.
+COLLECTIONS = ("episodic_memory", "knowledge_base")
+SCROLL_PAGE = 1000
+# SQLite has a variable limit (~999 default) on IN (...) — chunk below it.
+SQLITE_IN_CHUNK = 900
+# Values that are NOT a real wing (skip — the point legitimately has no wing).
+_NON_WINGS = {None, "", "general"}
+
+
+def scroll_stale_wing_ids(client, collection: str, cap: int | None = None) -> list[dict]:
+    """Point records whose payload ``wing`` is missing or ``general``.
+
+    Returns dicts ``{"id", "pwing", "proom"}`` (payload wing/room fetched so a
+    dry-run can show the before-state). Vectors are never fetched.
+    """
+    from qdrant_client.models import (
+        FieldCondition,
+        Filter,
+        IsEmptyCondition,
+        MatchValue,
+        PayloadField,
+    )
+
+    # should = OR: payload wing absent OR equal to the placeholder 'general'.
+    stale_filter = Filter(
+        should=[
+            IsEmptyCondition(is_empty=PayloadField(key="wing")),
+            FieldCondition(key="wing", match=MatchValue(value="general")),
+        ]
+    )
+
+    out: list[dict] = []
+    offset = None
+    while True:
+        points, offset = client.scroll(
+            collection_name=collection,
+            scroll_filter=stale_filter,
+            limit=SCROLL_PAGE,
+            offset=offset,
+            with_payload=["wing", "room"],
+            with_vectors=False,
+        )
+        for p in points:
+            payload = p.payload or {}
+            out.append(
+                {
+                    "id": str(p.id),
+                    "pwing": payload.get("wing"),
+                    "proom": payload.get("room"),
+                }
+            )
+        if offset is None or (cap is not None and len(out) >= cap):
+            break
+    return out[:cap] if cap is not None else out
+
+
+def fetch_metadata_wings(conn, ids: list[str]) -> dict[str, tuple[str | None, str | None]]:
+    """memory_id -> (wing, room) from memory_metadata for the given ids.
+
+    Batched IN queries under the SQLite variable limit. Missing ids are absent
+    from the result (no Qdrant-only ghost gets a fabricated wing).
+    """
+    meta: dict[str, tuple[str | None, str | None]] = {}
+    for start in range(0, len(ids), SQLITE_IN_CHUNK):
+        chunk = ids[start : start + SQLITE_IN_CHUNK]
+        placeholders = ",".join("?" * len(chunk))
+        rows = conn.execute(
+            f"SELECT memory_id, wing, room FROM memory_metadata "  # noqa: S608 - bound params
+            f"WHERE memory_id IN ({placeholders})",
+            chunk,
+        ).fetchall()
+        for memory_id, wing, room in rows:
+            meta[memory_id] = (wing, room)
+    return meta
+
+
+def plan_groups(
+    stale: list[dict],
+    meta: dict[str, tuple[str | None, str | None]],
+) -> tuple[dict[tuple[str, str | None], list[str]], int, int]:
+    """Group re-syncable point ids by (wing, room).
+
+    Returns ``(groups, skipped_no_wing, missing_metadata)``. A point is
+    re-syncable only when its SQLite wing is real (not NULL/empty/``general``).
+    """
+    groups: dict[tuple[str, str | None], list[str]] = defaultdict(list)
+    skipped_no_wing = 0
+    missing_metadata = 0
+    for rec in stale:
+        mid = rec["id"]
+        if mid not in meta:
+            missing_metadata += 1
+            continue
+        wing, room = meta[mid]
+        if wing in _NON_WINGS:
+            skipped_no_wing += 1
+            continue
+        groups[(wing, room)].append(mid)
+    return groups, skipped_no_wing, missing_metadata
+
+
+def apply_resync(
+    client,
+    collection: str,
+    groups: dict[tuple[str, str | None], list[str]],
+    *,
+    apply: bool,
+) -> int:
+    """set_payload({wing, room, life_domain}) per (wing, room) group.
+
+    Returns the number of points written (or that WOULD be written in dry-run).
+    """
+    from genesis.memory.taxonomy import classify_life_domain
+    from genesis.qdrant.collections import set_payload_batch
+
+    written = 0
+    for (wing, room), point_ids in groups.items():
+        payload: dict = {"wing": wing, "life_domain": classify_life_domain(wing)}
+        if room:
+            payload["room"] = room
+        if apply:
+            set_payload_batch(client, collection=collection, point_ids=point_ids, payload=payload)
+        written += len(point_ids)
+    return written
+
+
+def process_collection(
+    client, conn, collection: str, *, cap: int | None, sample: int | None, apply: bool
+) -> dict:
+    """Scroll → plan → (optionally) write for one collection. Returns counts."""
+    stale = scroll_stale_wing_ids(client, collection, cap=cap)
+    if not stale:
+        print(f"[{collection}] no points with missing/general wing.")
+        return {"stale": 0, "synced": 0, "skipped_no_wing": 0, "missing_metadata": 0}
+
+    ids = [r["id"] for r in stale]
+    meta = fetch_metadata_wings(conn, ids)
+    groups, skipped_no_wing, missing_metadata = plan_groups(stale, meta)
+    resyncable = sum(len(v) for v in groups.values())
+
+    print(
+        f"[{collection}] stale={len(stale)} resyncable={resyncable} "
+        f"skipped_no_wing={skipped_no_wing} missing_metadata={missing_metadata} "
+        f"groups={len(groups)}"
+    )
+
+    if sample:
+        shown = 0
+        for rec in stale:
+            mid = rec["id"]
+            if mid not in meta:
+                continue
+            wing, room = meta[mid]
+            if wing in _NON_WINGS:
+                continue
+            from genesis.memory.taxonomy import classify_life_domain
+
+            print(
+                f"  {mid[:8]}  payload.wing={rec['pwing']!r} -> "
+                f"wing={wing!r} room={room!r} life_domain={classify_life_domain(wing)!r}"
+            )
+            shown += 1
+            if shown >= sample:
+                break
+
+    synced = apply_resync(client, collection, groups, apply=apply)
+    return {
+        "stale": len(stale),
+        "synced": synced,
+        "skipped_no_wing": skipped_no_wing,
+        "missing_metadata": missing_metadata,
+    }
+
+
+def main(args: argparse.Namespace) -> int:
+    import sqlite3
+
+    from genesis.env import genesis_db_path, qdrant_url
+
+    load_dotenv(secrets_path())
+
+    from qdrant_client import QdrantClient
+
+    client = QdrantClient(url=qdrant_url(), timeout=30)
+    # Read-only, WAL-aware connection (mode=ro sees un-checkpointed writes,
+    # unlike immutable=1) — this script only READS SQLite; all writes go to Qdrant.
+    conn = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        totals = {"stale": 0, "synced": 0, "skipped_no_wing": 0, "missing_metadata": 0}
+        for collection in COLLECTIONS:
+            counts = process_collection(
+                client,
+                conn,
+                collection,
+                cap=args.limit,
+                sample=args.sample,
+                apply=args.apply,
+            )
+            for k in totals:
+                totals[k] += counts[k]
+
+        if not args.apply:
+            print(
+                f"\nDRY RUN — no writes. TOTAL resyncable={totals['synced']} "
+                f"across {len(COLLECTIONS)} collections. Re-run with --apply to write."
+            )
+        else:
+            print(
+                f"\nAPPLIED: {totals['synced']} points re-synced "
+                f"(wing/room/life_domain merged onto payload); "
+                f"{totals['skipped_no_wing']} skipped (no real SQLite wing); "
+                f"{totals['missing_metadata']} had no metadata row."
+            )
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="perform writes (default: dry-run)")
+    parser.add_argument("--limit", type=int, default=None, help="cap points scanned per collection")
+    parser.add_argument(
+        "--sample",
+        type=int,
+        default=None,
+        help="print up to N per-point before/after lines for review",
+    )
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+    raise SystemExit(main(parser.parse_args()))

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -182,7 +182,8 @@ async def search_ranked(
         "SELECT memory_fts.memory_id, memory_fts.content, "
         "memory_fts.source_type, memory_fts.collection, memory_fts.rank, "
         "memory_metadata.origin_class, "
-        "memory_metadata.wing, memory_metadata.room "
+        "memory_metadata.wing, memory_metadata.room, "
+        "memory_fts.tags "
         "FROM memory_fts LEFT JOIN memory_metadata "
         "ON memory_fts.memory_id = memory_metadata.memory_id "
         "WHERE memory_fts MATCH ?"
@@ -231,6 +232,11 @@ async def search_ranked(
             # never classified.
             "wing": r[6],
             "room": r[7],
+            # FTS tag string (space-separated). Carries the explicit
+            # ``life_domain:``/``project_type:`` tokens set at store time, so
+            # the scope filter can honor an explicit life_domain override
+            # rather than inferring solely from wing.
+            "tags": r[8],
         }
         for r in rows
     ]

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -181,7 +181,8 @@ async def search_ranked(
     sql = (
         "SELECT memory_fts.memory_id, memory_fts.content, "
         "memory_fts.source_type, memory_fts.collection, memory_fts.rank, "
-        "memory_metadata.origin_class "
+        "memory_metadata.origin_class, "
+        "memory_metadata.wing, memory_metadata.room "
         "FROM memory_fts LEFT JOIN memory_metadata "
         "ON memory_fts.memory_id = memory_metadata.memory_id "
         "WHERE memory_fts MATCH ?"
@@ -223,6 +224,13 @@ async def search_ranked(
             # WS-3 stored provenance — from the (already-joined)
             # memory_metadata row; NULL for pre-0054 rows.
             "origin_class": r[5],
+            # Authoritative structural taxonomy from the already-joined
+            # memory_metadata row — lets the FTS path scope-filter FTS-only
+            # candidates by wing/room without depending on the denormalized
+            # FTS tag token (which can drift from metadata). NULL for rows
+            # never classified.
+            "wing": r[6],
+            "room": r[7],
         }
         for r in rows
     ]

--- a/src/genesis/memory/drift.py
+++ b/src/genesis/memory/drift.py
@@ -208,21 +208,14 @@ async def _local_drilldown(
                 include_only_subsystems=include_only_subsystems,
             ))
         fts_rows.sort(key=lambda r: r["rank"])
-        # Rank order preserved; drop cross-collection duplicates
-        fts_ids = list(dict.fromkeys(r["memory_id"] for r in fts_rows))
-        # Filter results by wing in post-processing (FTS5 doesn't support wing filter)
-        if fts_ids:
-            # Verify wing membership. Filter as a SET and keep the ranked
-            # order — the IN-clause SELECT returns rows in table-scan
-            # order, which would rescramble the rank merge above.
-            placeholders = ",".join("?" * len(fts_ids))
-            wing_query = f"""
-                SELECT memory_id FROM memory_metadata
-                WHERE memory_id IN ({placeholders}) AND wing = ?
-            """  # noqa: S608 - literal SQL fragments; values bound as parameters
-            async with db.execute(wing_query, [*fts_ids, wing]) as cursor:
-                wing_members = {row[0] async for row in cursor}
-            fts_ids = [mid for mid in fts_ids if mid in wing_members]
+        # Verify wing membership against the authoritative wing now projected
+        # by search_ranked (from the joined memory_metadata) — no separate
+        # query needed. Rank order preserved; drop cross-collection duplicates.
+        fts_ids = list(
+            dict.fromkeys(
+                r["memory_id"] for r in fts_rows if r.get("wing") == wing
+            )
+        )
         local_ids.extend(fts_ids)
 
     # Scoped vector search with wing filter

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -360,12 +360,16 @@ def _filter_scope_fts_only(
         if room and fhit.get("room") != room:
             continue
         if life_domain:
-            # No life_domain column on memory_metadata; derive from the
-            # authoritative wing (explicit life_domain: tag overrides at
-            # store time aren't visible here, so this is wing-inferred).
+            # No life_domain column on memory_metadata; derive it the same way
+            # the write path does — classify_life_domain honors an explicit
+            # ``life_domain:`` tag (carried in the FTS ``tags`` string) and
+            # otherwise infers from wing. This keeps the FTS path consistent
+            # with the stored payload the Qdrant path filters on.
             from genesis.memory.taxonomy import classify_life_domain
 
-            if classify_life_domain(row_wing or "general") != life_domain:
+            tags_str = fhit.get("tags") or ""
+            tag_list = tags_str.split() if tags_str else None
+            if classify_life_domain(row_wing or "general", tags=tag_list) != life_domain:
                 continue
         filtered.append(mid)
     return filtered

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -329,28 +329,46 @@ def _filter_scope_fts_only(
     """Filter FTS5-only candidates by wing/room/life_domain (Qdrant results
     are already filtered at query time; this catches FTS5-only candidates
     that don't match the requested filters). No-op when no filter is set.
+
+    FTS5-only candidates carry no vector, so they never appear in Qdrant's
+    already-filtered results. We verify their membership against the
+    AUTHORITATIVE ``wing``/``room`` now projected onto the FTS row by
+    ``search_ranked`` (from the joined ``memory_metadata``) — not the
+    denormalized FTS ``tags`` token, which can drift from metadata (that
+    stale-token dependence is exactly why fts5_only rows were previously
+    unreachable by wing-filtered recall). ``life_domain`` has no metadata
+    column, so it is derived from the authoritative wing via the same
+    mapping the write path uses.
     """
-    if wing or room or life_domain:
-        filtered: list[str] = []
-        for mid in candidates:
-            qhit = qdrant_by_id.get(mid)
-            if qhit:
-                # Qdrant already filtered — guaranteed match
-                filtered.append(mid)
-            elif life_domain and not wing and not room:
-                # FTS5-only + life_domain filter: check the tag string
-                fhit = fts_by_id.get(mid)
-                if fhit:
-                    tags_str = fhit.get("tags", "")
-                    if f"life_domain:{life_domain}" in tags_str:
-                        filtered.append(mid)
-            else:
-                # FTS5-only candidate with wing/room filter — no
-                # wing/room data in FTS5, exclude since we can't
-                # verify membership.
-                pass
-        candidates = filtered
-    return candidates
+    if not (wing or room or life_domain):
+        return candidates
+
+    filtered: list[str] = []
+    for mid in candidates:
+        if qdrant_by_id.get(mid):
+            # Qdrant already applied wing/room/life_domain at query time —
+            # a returned hit is a guaranteed match.
+            filtered.append(mid)
+            continue
+        fhit = fts_by_id.get(mid)
+        if fhit is None:
+            # No FTS row to verify against — can't confirm membership, exclude.
+            continue
+        row_wing = fhit.get("wing")
+        if wing and row_wing != wing:
+            continue
+        if room and fhit.get("room") != room:
+            continue
+        if life_domain:
+            # No life_domain column on memory_metadata; derive from the
+            # authoritative wing (explicit life_domain: tag overrides at
+            # store time aren't visible here, so this is wing-inferred).
+            from genesis.memory.taxonomy import classify_life_domain
+
+            if classify_life_domain(row_wing or "general") != life_domain:
+                continue
+        filtered.append(mid)
+    return filtered
 
 
 def _assemble_results(

--- a/tests/test_db/test_search_ranked_subsystem.py
+++ b/tests/test_db/test_search_ranked_subsystem.py
@@ -182,6 +182,9 @@ async def test_rows_carry_wing_and_room(tmp_path) -> None:
         by_id = {r["memory_id"]: r for r in rows}
         assert by_id["user-1"]["wing"] == "routing"
         assert by_id["user-1"]["room"] == "fallback"
+        # FTS tag string is projected too (empty for these seed rows) — the
+        # scope filter reads it to honor explicit life_domain overrides.
+        assert by_id["user-1"]["tags"] == ""
         # Unclassified rows project NULL wing/room, not a missing key.
         assert by_id["ego-1"]["wing"] is None
         assert by_id["ego-1"]["room"] is None

--- a/tests/test_db/test_search_ranked_subsystem.py
+++ b/tests/test_db/test_search_ranked_subsystem.py
@@ -163,3 +163,27 @@ async def test_rows_carry_origin_class(tmp_path) -> None:
         assert by_id["ego-1"]["origin_class"] is None
     finally:
         await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_rows_carry_wing_and_room(tmp_path) -> None:
+    """search_ranked projects the authoritative memory_metadata.wing/room so
+    the FTS path can scope-filter fts5_only candidates (follow-up 0a3741c4)."""
+    conn = await _build_db(str(tmp_path / "fts.db"))
+    try:
+        await conn.execute(
+            "UPDATE memory_metadata SET wing = 'routing', room = 'fallback' "
+            "WHERE memory_id = 'user-1'"
+        )
+        await conn.commit()
+        rows = await memory_crud.search_ranked(
+            conn, query="decision recovery", include_only_subsystems=None,
+        )
+        by_id = {r["memory_id"]: r for r in rows}
+        assert by_id["user-1"]["wing"] == "routing"
+        assert by_id["user-1"]["room"] == "fallback"
+        # Unclassified rows project NULL wing/room, not a missing key.
+        assert by_id["ego-1"]["wing"] is None
+        assert by_id["ego-1"]["room"] is None
+    finally:
+        await conn.close()

--- a/tests/test_memory/test_drift.py
+++ b/tests/test_memory/test_drift.py
@@ -268,31 +268,6 @@ class TestLocalDrilldownCollections:
     """
 
     @staticmethod
-    def _wing_cursor(rows):
-        """Async context-manager cursor for the wing post-filter query."""
-
-        class _Cursor:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *exc):
-                return False
-
-            def __aiter__(self):
-                async def gen():
-                    for r in rows:
-                        yield r
-
-                return gen()
-
-        return _Cursor()
-
-    def _db_with_wing_rows(self, rows):
-        db = MagicMock()
-        db.execute = MagicMock(return_value=self._wing_cursor(rows))
-        return db
-
-    @staticmethod
     def _failing_embeddings():
         embeddings = AsyncMock()
         embeddings.embed = AsyncMock(side_effect=Exception("no embeddings"))
@@ -301,16 +276,18 @@ class TestLocalDrilldownCollections:
     @pytest.mark.asyncio
     async def test_fts_drilldown_searches_all_source_collections(self):
         """With source='both'-style collections, FTS must hit each one."""
-        # Both ids pass the wing post-filter
-        db = self._db_with_wing_rows([("ep1",), ("kb1",)])
+        # Both ids carry the requested wing (projected by search_ranked)
+        db = MagicMock()
         seen_collections: list[str | None] = []
 
         async def fake_search_ranked(db_, *, query, limit,
                                      collection=None, **kw):
             seen_collections.append(collection)
             if collection == "knowledge_base":
-                return [{"memory_id": "kb1", "content": "kb", "rank": -1.0}]
-            return [{"memory_id": "ep1", "content": "ep", "rank": -2.0}]
+                return [{"memory_id": "kb1", "content": "kb", "rank": -1.0,
+                         "wing": "memory"}]
+            return [{"memory_id": "ep1", "content": "ep", "rank": -2.0,
+                     "wing": "memory"}]
 
         with patch(
             "genesis.memory.drift.memory_crud.search_ranked",
@@ -337,13 +314,14 @@ class TestLocalDrilldownCollections:
     @pytest.mark.asyncio
     async def test_fts_drilldown_episodic_only_unchanged(self):
         """Default episodic source still searches exactly one collection."""
-        db = self._db_with_wing_rows([("ep1",)])
+        db = MagicMock()
         seen_collections: list[str | None] = []
 
         async def fake_search_ranked(db_, *, query, limit,
                                      collection=None, **kw):
             seen_collections.append(collection)
-            return [{"memory_id": "ep1", "content": "ep", "rank": -2.0}]
+            return [{"memory_id": "ep1", "content": "ep", "rank": -2.0,
+                     "wing": "memory"}]
 
         with patch(
             "genesis.memory.drift.memory_crud.search_ranked",
@@ -371,17 +349,20 @@ class TestLocalDrilldownCollections:
         hit of the first collection above the second's regardless of
         relevance. Ranks are comparable — same memory_fts table, same query.
         """
-        # Wing filter passes all three (single shared cursor is fine — the
-        # filter must also PRESERVE the rank-merged order, not rescramble it)
-        db = self._db_with_wing_rows([("ep1",), ("ep2",), ("kb1",)])
+        # Wing filter passes all three (wing projected by search_ranked) — the
+        # filter must also PRESERVE the rank-merged order, not rescramble it
+        db = MagicMock()
         rows_by_collection = {
             "episodic_memory": [
-                {"memory_id": "ep1", "content": "e1", "rank": -5.0},
-                {"memory_id": "ep2", "content": "e2", "rank": -3.0},
+                {"memory_id": "ep1", "content": "e1", "rank": -5.0,
+                 "wing": "memory"},
+                {"memory_id": "ep2", "content": "e2", "rank": -3.0,
+                 "wing": "memory"},
             ],
             # kb1 outranks both episodic hits (more negative = better)
             "knowledge_base": [
-                {"memory_id": "kb1", "content": "k1", "rank": -9.0},
+                {"memory_id": "kb1", "content": "k1", "rank": -9.0,
+                 "wing": "memory"},
             ],
         }
 
@@ -406,4 +387,40 @@ class TestLocalDrilldownCollections:
 
         assert ids == ["kb1", "ep1", "ep2"], (
             f"expected rank-merged order [kb1, ep1, ep2], got {ids!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fts_drilldown_filters_nonmatching_wing(self):
+        """Rows whose authoritative wing (projected by search_ranked) differs
+        from the requested wing are dropped; NULL wing is dropped too."""
+        db = MagicMock()
+
+        async def fake_search_ranked(db_, *, query, limit,
+                                     collection=None, **kw):
+            return [
+                {"memory_id": "keep", "content": "k", "rank": -5.0,
+                 "wing": "memory"},
+                {"memory_id": "drop", "content": "d", "rank": -4.0,
+                 "wing": "routing"},
+                {"memory_id": "null", "content": "n", "rank": -3.0,
+                 "wing": None},
+            ]
+
+        with patch(
+            "genesis.memory.drift.memory_crud.search_ranked",
+            new=AsyncMock(side_effect=fake_search_ranked),
+        ):
+            ids = await _local_drilldown(
+                "test query",
+                db=db,
+                qdrant_client=MagicMock(),
+                embedding_provider=self._failing_embeddings(),
+                source_collections=["episodic_memory"],
+                wing="memory",
+                room=None,
+                global_ids=[],
+            )
+
+        assert ids == ["keep"], (
+            f"only the wing='memory' row should survive, got {ids!r}"
         )

--- a/tests/test_memory/test_filter_scope_fts_only.py
+++ b/tests/test_memory/test_filter_scope_fts_only.py
@@ -15,9 +15,9 @@ from genesis.memory.retrieval import _filter_scope_fts_only
 from genesis.memory.taxonomy import classify_life_domain
 
 
-def _fts(wing=None, room=None):
-    """A search_ranked-shaped FTS row carrying the projected wing/room."""
-    return {"wing": wing, "room": room}
+def _fts(wing=None, room=None, tags=None):
+    """A search_ranked-shaped FTS row carrying the projected wing/room/tags."""
+    return {"wing": wing, "room": room, "tags": tags}
 
 
 def test_no_filter_is_noop():
@@ -129,6 +129,25 @@ def test_life_domain_derived_from_authoritative_wing():
         life_domain=other,
     )
     assert dropped == []
+
+
+def test_life_domain_explicit_tag_overrides_wing():
+    # An explicit life_domain: tag (set at write time, carried in the FTS tags
+    # string) must win over the wing-inferred domain — matching the Qdrant path
+    # which filters on the stored payload value.
+    wing = "employment"
+    inferred = classify_life_domain(wing)
+    override = next(d for d in ("personal", "employment", "genesis") if d != inferred)
+    fhit = _fts(wing=wing, tags=f"some_tag wing:{wing} life_domain:{override}")
+    # Reachable under its EXPLICIT domain...
+    assert _filter_scope_fts_only(
+        ["m1"], {}, {"m1": fhit}, wing=None, room=None, life_domain=override
+    ) == ["m1"]
+    # ...and NOT under the wing-inferred one.
+    assert (
+        _filter_scope_fts_only(["m1"], {}, {"m1": fhit}, wing=None, room=None, life_domain=inferred)
+        == []
+    )
 
 
 def test_order_preserved_across_mixed_candidates():

--- a/tests/test_memory/test_filter_scope_fts_only.py
+++ b/tests/test_memory/test_filter_scope_fts_only.py
@@ -1,0 +1,147 @@
+"""Unit tests for ``_filter_scope_fts_only`` — the wing/room/life_domain
+scope filter for FTS5-only recall candidates.
+
+FTS5-only candidates (no Qdrant vector) never appear in Qdrant's already
+wing-filtered results, so this function verifies their membership against the
+AUTHORITATIVE wing/room now projected onto the FTS row by ``search_ranked``
+(from the joined ``memory_metadata``), rather than the denormalized FTS tag
+token. This is the fix that makes fts5_only rows reachable by wing-filtered
+recall (follow-up 0a3741c4).
+"""
+
+from __future__ import annotations
+
+from genesis.memory.retrieval import _filter_scope_fts_only
+from genesis.memory.taxonomy import classify_life_domain
+
+
+def _fts(wing=None, room=None):
+    """A search_ranked-shaped FTS row carrying the projected wing/room."""
+    return {"wing": wing, "room": room}
+
+
+def test_no_filter_is_noop():
+    candidates = ["a", "b", "c"]
+    out = _filter_scope_fts_only(candidates, {}, {}, wing=None, room=None, life_domain=None)
+    assert out == candidates
+
+
+def test_qdrant_hit_always_kept_under_wing_filter():
+    # A Qdrant hit was already wing-filtered at query time → always kept,
+    # regardless of any FTS-side data.
+    out = _filter_scope_fts_only(
+        ["q1"],
+        {"q1": {"id": "q1"}},
+        {},
+        wing="memory",
+        room=None,
+        life_domain=None,
+    )
+    assert out == ["q1"]
+
+
+def test_fts_only_matching_wing_kept():
+    out = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing="routing")},
+        wing="routing",
+        room=None,
+        life_domain=None,
+    )
+    assert out == ["m1"]
+
+
+def test_fts_only_nonmatching_wing_dropped():
+    out = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing="memory")},
+        wing="routing",
+        room=None,
+        life_domain=None,
+    )
+    assert out == []
+
+
+def test_fts_only_null_wing_dropped_under_wing_filter():
+    out = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing=None)},
+        wing="routing",
+        room=None,
+        life_domain=None,
+    )
+    assert out == []
+
+
+def test_fts_only_missing_from_fts_map_dropped():
+    # Candidate has no FTS row to verify against → excluded.
+    out = _filter_scope_fts_only(["ghost"], {}, {}, wing="routing", room=None, life_domain=None)
+    assert out == []
+
+
+def test_room_filter_matches_and_drops():
+    kept = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing="routing", room="fallback")},
+        wing="routing",
+        room="fallback",
+        life_domain=None,
+    )
+    assert kept == ["m1"]
+    dropped = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing="routing", room="other")},
+        wing="routing",
+        room="fallback",
+        life_domain=None,
+    )
+    assert dropped == []
+
+
+def test_life_domain_derived_from_authoritative_wing():
+    # life_domain has no metadata column; it is derived from the wing. Use the
+    # same mapping the write path uses so the test tracks the real derivation.
+    wing = "employment"
+    ld = classify_life_domain(wing)
+    kept = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing=wing)},
+        wing=None,
+        room=None,
+        life_domain=ld,
+    )
+    assert kept == ["m1"]
+
+    # A different life_domain than the wing derives → dropped.
+    other = next(d for d in ("personal", "employment", "genesis") if d != ld)
+    dropped = _filter_scope_fts_only(
+        ["m1"],
+        {},
+        {"m1": _fts(wing=wing)},
+        wing=None,
+        room=None,
+        life_domain=other,
+    )
+    assert dropped == []
+
+
+def test_order_preserved_across_mixed_candidates():
+    out = _filter_scope_fts_only(
+        ["q1", "drop", "m1"],
+        {"q1": {"id": "q1"}},
+        {
+            "drop": _fts(wing="memory"),
+            "m1": _fts(wing="routing"),
+        },
+        wing="routing",
+        room=None,
+        life_domain=None,
+    )
+    # q1 kept (qdrant), drop excluded (wing mismatch), m1 kept — order intact.
+    assert out == ["q1", "m1"]

--- a/tests/test_scripts/test_wing_payload_resync.py
+++ b/tests/test_scripts/test_wing_payload_resync.py
@@ -1,0 +1,164 @@
+"""Tests for scripts/wing_payload_resync.py — the one-shot Qdrant wing
+payload re-sync.
+
+Covers the pure planning/grouping logic (real-wing grouping, skip of
+NULL/general metadata, missing-metadata accounting), the batched payload
+write (payload shape + dry-run no-op), the metadata read, and the paginated
+stale-point scroll.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Load the script as a module (it's not a package — use importlib).
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "wing_payload_resync.py"
+_spec = importlib.util.spec_from_file_location("wing_payload_resync", _SCRIPT_PATH)
+wr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wr)
+
+from genesis.memory.taxonomy import classify_life_domain  # noqa: E402
+
+# ── plan_groups ─────────────────────────────────────────────────────────
+
+
+def test_plan_groups_real_wing_grouped_by_wing_room():
+    stale = [{"id": "p1"}, {"id": "p2"}, {"id": "p3"}]
+    meta = {
+        "p1": ("routing", "fallback"),
+        "p2": ("routing", "fallback"),
+        "p3": ("memory", "recall"),
+    }
+    groups, skipped, missing = wr.plan_groups(stale, meta)
+    assert groups[("routing", "fallback")] == ["p1", "p2"]
+    assert groups[("memory", "recall")] == ["p3"]
+    assert skipped == 0
+    assert missing == 0
+
+
+def test_plan_groups_skips_null_and_general_wing():
+    stale = [{"id": "p1"}, {"id": "p2"}, {"id": "p3"}]
+    meta = {
+        "p1": (None, None),
+        "p2": ("general", "uncategorized"),
+        "p3": ("", None),
+    }
+    groups, skipped, missing = wr.plan_groups(stale, meta)
+    assert groups == {}
+    assert skipped == 3
+    assert missing == 0
+
+
+def test_plan_groups_counts_missing_metadata():
+    stale = [{"id": "ghost"}, {"id": "p1"}]
+    meta = {"p1": ("memory", None)}
+    groups, skipped, missing = wr.plan_groups(stale, meta)
+    assert groups[("memory", None)] == ["p1"]
+    assert skipped == 0
+    assert missing == 1
+
+
+# ── apply_resync ────────────────────────────────────────────────────────
+
+
+def test_apply_resync_writes_expected_payload():
+    client = MagicMock()
+    groups = {("routing", "fallback"): ["p1", "p2"]}
+    written = wr.apply_resync(client, "episodic_memory", groups, apply=True)
+    assert written == 2
+    client.set_payload.assert_called_once()
+    _, kwargs = client.set_payload.call_args
+    assert kwargs["collection_name"] == "episodic_memory"
+    assert sorted(kwargs["points"]) == ["p1", "p2"]
+    assert kwargs["payload"] == {
+        "wing": "routing",
+        "room": "fallback",
+        "life_domain": classify_life_domain("routing"),
+    }
+
+
+def test_apply_resync_omits_room_when_null():
+    client = MagicMock()
+    groups = {("memory", None): ["p1"]}
+    wr.apply_resync(client, "episodic_memory", groups, apply=True)
+    _, kwargs = client.set_payload.call_args
+    assert "room" not in kwargs["payload"]
+    assert kwargs["payload"]["wing"] == "memory"
+
+
+def test_apply_resync_dry_run_no_write_but_counts():
+    client = MagicMock()
+    groups = {("routing", "fallback"): ["p1", "p2"], ("memory", None): ["p3"]}
+    written = wr.apply_resync(client, "episodic_memory", groups, apply=False)
+    assert written == 3
+    client.set_payload.assert_not_called()
+
+
+# ── fetch_metadata_wings ────────────────────────────────────────────────
+
+
+def _mem_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE memory_metadata (memory_id TEXT PRIMARY KEY, wing TEXT, room TEXT)")
+    conn.executemany(
+        "INSERT INTO memory_metadata (memory_id, wing, room) VALUES (?, ?, ?)",
+        [("p1", "routing", "fallback"), ("p2", "memory", None)],
+    )
+    conn.commit()
+    return conn
+
+
+def test_fetch_metadata_wings_returns_wing_room():
+    conn = _mem_db()
+    try:
+        meta = wr.fetch_metadata_wings(conn, ["p1", "p2", "absent"])
+        assert meta == {"p1": ("routing", "fallback"), "p2": ("memory", None)}
+        assert "absent" not in meta
+    finally:
+        conn.close()
+
+
+def test_fetch_metadata_wings_chunks(monkeypatch):
+    # Force a tiny chunk so the IN-batching loop runs multiple times.
+    monkeypatch.setattr(wr, "SQLITE_IN_CHUNK", 1)
+    conn = _mem_db()
+    try:
+        meta = wr.fetch_metadata_wings(conn, ["p1", "p2"])
+        assert set(meta) == {"p1", "p2"}
+    finally:
+        conn.close()
+
+
+# ── scroll_stale_wing_ids ───────────────────────────────────────────────
+
+
+def _pt(pid, wing=None, room=None):
+    return SimpleNamespace(id=pid, payload={"wing": wing, "room": room})
+
+
+def test_scroll_stale_wing_ids_paginates_and_extracts_payload():
+    client = MagicMock()
+    # Two pages, then exhausted (next offset None).
+    client.scroll.side_effect = [
+        ([_pt("p1", wing=None), _pt("p2", wing="general", room="x")], "cursor"),
+        ([_pt("p3", wing=None)], None),
+    ]
+    out = wr.scroll_stale_wing_ids(client, "episodic_memory")
+    assert [r["id"] for r in out] == ["p1", "p2", "p3"]
+    assert out[1] == {"id": "p2", "pwing": "general", "proom": "x"}
+    assert client.scroll.call_count == 2
+
+
+def test_scroll_stale_wing_ids_respects_cap():
+    client = MagicMock()
+    client.scroll.side_effect = [
+        ([_pt("p1"), _pt("p2"), _pt("p3")], "cursor"),
+    ]
+    out = wr.scroll_stale_wing_ids(client, "episodic_memory", cap=2)
+    assert [r["id"] for r in out] == ["p1", "p2"]
+    # Cap reached on first page → no second scroll call.
+    assert client.scroll.call_count == 1

--- a/tests/test_scripts/test_wing_payload_resync.py
+++ b/tests/test_scripts/test_wing_payload_resync.py
@@ -81,13 +81,18 @@ def test_apply_resync_writes_expected_payload():
     }
 
 
-def test_apply_resync_omits_room_when_null():
+def test_apply_resync_writes_null_room_to_overwrite_stale():
+    # set_payload MERGES, so a null SQLite room must be written explicitly
+    # (room=None) to overwrite any stale Qdrant room — not omitted.
     client = MagicMock()
     groups = {("memory", None): ["p1"]}
     wr.apply_resync(client, "episodic_memory", groups, apply=True)
     _, kwargs = client.set_payload.call_args
-    assert "room" not in kwargs["payload"]
-    assert kwargs["payload"]["wing"] == "memory"
+    assert kwargs["payload"] == {
+        "wing": "memory",
+        "room": None,
+        "life_domain": classify_life_domain("memory"),
+    }
 
 
 def test_apply_resync_dry_run_no_write_but_counts():


### PR DESCRIPTION
## Problem

Wing-filtered `memory_recall`/`memory_proactive` silently **under-returned** memories. `memory_metadata.wing` (SQLite) is authoritative, but the two wing-filtered recall paths each read a *denormalized mirror* that had drifted:

- **FTS path:** `_filter_scope_fts_only` hard-dropped every FTS-only candidate under a wing/room filter (the FTS row carried no wing), and its `life_domain` escape branch read a `tags` key `search_ranked` never returns — so it was **dead** (always empty). Result: **1,368 fts5_only rows** with a real wing were unreachable by `wing=` recall.
- **Qdrant path:** vector search applies wing as a hard `must` payload filter, but **~5.3K embedded points** carry no `wing` payload key (a historical backfill artifact — no runtime writer drifts it), so they were excluded despite a real SQLite wing.

## Fix

**Part A — retrieval (reads the source of truth):**
- `search_ranked` projects `wing`/`room` from the already-joined `memory_metadata` (additive, zero extra query — same pattern as `origin_class` in #1042).
- `_filter_scope_fts_only` verifies FTS-only candidates against that authoritative wing/room and derives `life_domain` from the wing — fixing the dead branch and honoring combined wing+life_domain filters consistently with the vector path.
- `drift.py` `_local_drilldown` drops its now-redundant wing-membership query and filters on the projected wing (DRY; one fewer query per drift recall).

**Part C — data (`scripts/wing_payload_resync.py`):**
- One-shot, idempotent, **supervised** re-sync of the Qdrant `wing`/`room`/`life_domain` payload from `memory_metadata`. Qdrant-driven (only touches points whose payload wing is missing/`general`), skips points with no real SQLite wing, groups by `(wing,room)` and `set_payload` merges per group (vectors untouched). Dry-run by default; `--apply` gated on a human-reviewed sample. **Runs after merge**, not in this PR.

## Verification

- 117 targeted tests pass (9 new direct unit tests for the filter, a `search_ranked` projection test, a drift non-matching-wing test, 10 script tests); no regression across 6 other `search_ranked`-consuming suites.
- **Live proof (read-only):** a real fts5_only row (`wing=infrastructure`) is now returned by `search_ranked` with its wing projected and kept by `_filter_scope_fts_only` under `wing=infrastructure`, dropped under `wing=routing`.
- **Part C dry-run (live):** 5,277 resyncable across both collections, correct wing/room/life_domain derivation, correctly skips 102 orphan points + 67 no-real-wing rows.

Closes the retrieval half of follow-up `0a3741c4` and the Qdrant half of `40d36a4e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)