### PR TITLE
fix(infra): activate container swap live on a running container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Enabling container swap no longer waits for a restart to take effect.**
+  Host setup lets the container's memory cgroup spill into host swap under
+  pressure, so a memory spike degrades into swapping instead of thrashing the
+  whole box into a wedge. But that setting only took effect the next time the
+  container *started*, so retrofitting an already-running install looked done
+  while swap stayed off until a reboot — leaving the box exposed to the exact
+  OOM wedge the setting exists to prevent. Setup now activates it live on the
+  running container, so the protection is real immediately.
+
 - **Genesis's inner monologue now knows who each thought is about.** Every
   ambient micro-reflection used to be tagged as relevant to "both" the user
   and Genesis — the tag was computed from which sensors *ran* (all of them,

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -563,6 +563,7 @@ echo "  + limits.memory.swap enabled (memory spikes degrade into swap, not thras
 # container (freshly created above, or an existing one being retrofitted) still
 # has memory.swap.max=0 until a restart — the setting silently no-ops meanwhile.
 # Activate it live now so swap works without a disruptive restart.
+# shellcheck source=lib/container_swap.sh
 . "$(cd "$(dirname "$0")" && pwd)/lib/container_swap.sh"
 container_swap_activate_live "$CONTAINER_NAME"
 if [ -z "$(swapon --noheadings --show 2>/dev/null)" ]; then

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -559,6 +559,12 @@ echo "  + boot.autostart enabled (container survives host reboots)"
 # block so re-running host-setup retrofits existing containers too.
 incus config set "$CONTAINER_NAME" limits.memory.swap true
 echo "  + limits.memory.swap enabled (memory spikes degrade into swap, not thrash)"
+# incus applies limits.memory.swap only at container START, so the running
+# container (freshly created above, or an existing one being retrofitted) still
+# has memory.swap.max=0 until a restart — the setting silently no-ops meanwhile.
+# Activate it live now so swap works without a disruptive restart.
+. "$(cd "$(dirname "$0")" && pwd)/lib/container_swap.sh"
+container_swap_activate_live "$CONTAINER_NAME"
 if [ -z "$(swapon --noheadings --show 2>/dev/null)" ]; then
     echo "  WARNING: this host has NO swap — limits.memory.swap has nothing to swap to."
     echo "           Add host swap (swapfile or LV); even a few GiB turns the container's"

--- a/scripts/lib/container_swap.sh
+++ b/scripts/lib/container_swap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Live-activate container memory swap on a RUNNING incus/LXC container.
+#
+# incus applies `limits.memory.swap` only when the container STARTS, so on an
+# already-running container — including one just created above, and every
+# retrofit run of host-setup — the live cgroup keeps `memory.swap.max=0` until
+# the next restart. The config is set but silently no-ops meanwhile (observed
+# 2026-07: a swap retrofit looked applied while the container stayed one memory
+# spike away from OOM-thrash, the exact failure the setting is meant to prevent).
+# This mirrors what incus does at start by writing the live cgroup now, so swap
+# is active immediately without a disruptive container restart.
+#
+# Best-effort and idempotent: it does nothing if the cgroup knob is absent
+# (container stopped, cgroup v1, or a non-standard layout — the config-set alone
+# still applies on the next start) or already non-zero. It never fails its
+# caller.
+#
+# Overridable for tests: CONTSWAP_CGROUP_BASE (default /sys/fs/cgroup); `sudo`
+# and `tee` are resolved from PATH.
+
+container_swap_activate_live() {
+    local name="$1"
+    [ -n "$name" ] || return 0
+    local base="${CONTSWAP_CGROUP_BASE:-/sys/fs/cgroup}"
+    local swap_max="$base/lxc.payload.$name/memory.swap.max"
+
+    # Absent → container not running, or a cgroup layout we can't address here;
+    # the persisted `limits.memory.swap=true` still applies on the next start.
+    [ -e "$swap_max" ] || return 0
+
+    # Already permitting swap (non-zero, e.g. "max") → idempotent no-op.
+    local cur
+    cur="$(cat "$swap_max" 2>/dev/null)"
+    [ "$cur" = "0" ] || return 0
+
+    if echo max | sudo tee "$swap_max" >/dev/null 2>&1; then
+        echo "  + activated swap live on the running container (memory.swap.max=max)"
+    else
+        echo "  WARNING: could not write $swap_max live — restart the container to activate swap."
+    fi
+    return 0
+}

--- a/scripts/lib/container_swap.sh
+++ b/scripts/lib/container_swap.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
 # Live-activate container memory swap on a RUNNING incus/LXC container.
+# Sourced, not executed (no shebang) — host-setup.sh dot-sources it and its
+# caller runs under `set -euo pipefail`, so every step here must be errexit-safe.
 #
 # incus applies `limits.memory.swap` only when the container STARTS, so on an
 # already-running container — including one just created above, and every
@@ -28,9 +29,14 @@ container_swap_activate_live() {
     # the persisted `limits.memory.swap=true` still applies on the next start.
     [ -e "$swap_max" ] || return 0
 
-    # Already permitting swap (non-zero, e.g. "max") → idempotent no-op.
-    local cur
-    cur="$(cat "$swap_max" 2>/dev/null)"
+    # Already permitting swap (non-zero, e.g. "max") → idempotent no-op. The
+    # cgroup knob is root-owned, so read it with sudo (host-setup runs as root
+    # or with passwordless sudo). The `|| cur=""` keeps a failed read — perm
+    # denied, or the container stopping between the -e check and the read — from
+    # tripping the caller's `set -e`; an unreadable knob falls through to a safe
+    # no-op rather than aborting the whole host-setup run.
+    local cur=""
+    cur="$(sudo cat "$swap_max" 2>/dev/null)" || cur=""
     [ "$cur" = "0" ] || return 0
 
     if echo max | sudo tee "$swap_max" >/dev/null 2>&1; then

--- a/tests/test_scripts/test_container_swap.py
+++ b/tests/test_scripts/test_container_swap.py
@@ -1,0 +1,104 @@
+"""Behavioral tests for container_swap_activate_live (scripts/lib/container_swap.sh).
+
+The function is sourced from the REAL lib and driven with a stubbed ``sudo`` on
+PATH plus a ``CONTSWAP_CGROUP_BASE`` override, so the logic under test is the
+shipped code: live-activate a running container's swap cgroup (write ``max`` when
+it is ``0``), idempotent when already set, and a graceful no-op when the cgroup
+knob is absent. This is the fix for incus applying ``limits.memory.swap`` only at
+container start — a retrofit on a running container would otherwise silently
+no-op until a restart.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts" / "lib" / "container_swap.sh"
+HOST_SETUP = REPO_ROOT / "scripts" / "host-setup.sh"
+
+_SUDO_PASSTHROUGH = """#!/bin/bash
+exec "$@"
+"""
+
+_SUDO_FAIL = """#!/bin/bash
+# Simulate a host where the privileged cgroup write is refused.
+exit 1
+"""
+
+
+def _run(tmp_path, *, name, sudo_stub=_SUDO_PASSTHROUGH):
+    """Source the real lib and invoke the function with a stubbed sudo + cgroup base."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    sudo = bindir / "sudo"
+    sudo.write_text(sudo_stub)
+    sudo.chmod(0o755)
+
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "CONTSWAP_CGROUP_BASE": str(tmp_path / "cgroup"),
+    }
+    script = f'source "{LIB}"; container_swap_activate_live "{name}"'
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+
+
+def _swap_file(tmp_path, name, value):
+    p = tmp_path / "cgroup" / f"lxc.payload.{name}" / "memory.swap.max"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(value)
+    return p
+
+
+def test_activates_when_zero(tmp_path):
+    """The incident state: memory.swap.max=0 on a running container -> write max."""
+    swap = _swap_file(tmp_path, "genesis", "0")
+    res = _run(tmp_path, name="genesis")
+    assert res.returncode == 0, res.stderr
+    assert swap.read_text().strip() == "max"
+    assert "activated swap live" in res.stdout
+
+
+def test_idempotent_when_already_max(tmp_path):
+    """Already permitting swap -> no write, no activation message."""
+    swap = _swap_file(tmp_path, "genesis", "max")
+    res = _run(tmp_path, name="genesis")
+    assert res.returncode == 0
+    assert swap.read_text().strip() == "max"
+    assert "activated swap live" not in res.stdout
+
+
+def test_noop_when_cgroup_absent(tmp_path):
+    """Container stopped / non-standard layout -> graceful no-op (config applies on start)."""
+    res = _run(tmp_path, name="genesis")  # no swap file created
+    assert res.returncode == 0
+    assert "activated swap live" not in res.stdout
+    assert "WARNING" not in res.stdout
+
+
+def test_empty_name_is_noop(tmp_path):
+    res = _run(tmp_path, name="")
+    assert res.returncode == 0
+    assert res.stdout.strip() == ""
+
+
+def test_write_failure_warns_and_leaves_value(tmp_path):
+    """A refused privileged write must warn loudly, not claim success."""
+    swap = _swap_file(tmp_path, "genesis", "0")
+    res = _run(tmp_path, name="genesis", sudo_stub=_SUDO_FAIL)
+    assert res.returncode == 0
+    assert swap.read_text().strip() == "0"  # unchanged
+    assert "WARNING" in res.stdout
+    assert "activated swap live" not in res.stdout
+
+
+def test_lib_parses_clean():
+    res = subprocess.run(["bash", "-n", str(LIB)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_host_setup_parses_clean():
+    """The host-setup.sh edit that sources + calls the lib must stay bash -n clean."""
+    res = subprocess.run(["bash", "-n", str(HOST_SETUP)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr

--- a/tests/test_scripts/test_container_swap.py
+++ b/tests/test_scripts/test_container_swap.py
@@ -1,12 +1,11 @@
 """Behavioral tests for container_swap_activate_live (scripts/lib/container_swap.sh).
 
-The function is sourced from the REAL lib and driven with a stubbed ``sudo`` on
-PATH plus a ``CONTSWAP_CGROUP_BASE`` override, so the logic under test is the
-shipped code: live-activate a running container's swap cgroup (write ``max`` when
-it is ``0``), idempotent when already set, and a graceful no-op when the cgroup
-knob is absent. This is the fix for incus applying ``limits.memory.swap`` only at
-container start — a retrofit on a running container would otherwise silently
-no-op until a restart.
+The function is sourced from the REAL lib and driven under the caller's shell
+mode (``set -euo pipefail``, as host-setup.sh uses) with a stubbed ``sudo`` on
+PATH plus a ``CONTSWAP_CGROUP_BASE`` override. A ``__DONE__`` sentinel printed
+after the call proves the function returned instead of tripping errexit — the
+failure modes here (unreadable / vanished cgroup knob, refused write) must never
+abort the host-setup run.
 """
 
 from __future__ import annotations
@@ -18,18 +17,27 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LIB = REPO_ROOT / "scripts" / "lib" / "container_swap.sh"
 HOST_SETUP = REPO_ROOT / "scripts" / "host-setup.sh"
 
+# Passthrough sudo: run the wrapped command as-is.
 _SUDO_PASSTHROUGH = """#!/bin/bash
 exec "$@"
 """
 
-_SUDO_FAIL = """#!/bin/bash
-# Simulate a host where the privileged cgroup write is refused.
-exit 1
+# Passthrough except the privileged WRITE (tee) is refused — read succeeds,
+# write fails.
+_SUDO_TEE_FAIL = """#!/bin/bash
+if [ "$1" = "tee" ]; then exit 1; fi
+exec "$@"
+"""
+
+# The READ itself is refused (permission denied on the root-owned cgroup knob).
+_SUDO_CAT_FAIL = """#!/bin/bash
+if [ "$1" = "cat" ]; then exit 1; fi
+exec "$@"
 """
 
 
 def _run(tmp_path, *, name, sudo_stub=_SUDO_PASSTHROUGH):
-    """Source the real lib and invoke the function with a stubbed sudo + cgroup base."""
+    """Source the real lib and invoke the function under `set -euo pipefail`."""
     bindir = tmp_path / "bin"
     bindir.mkdir(exist_ok=True)
     sudo = bindir / "sudo"
@@ -40,7 +48,9 @@ def _run(tmp_path, *, name, sudo_stub=_SUDO_PASSTHROUGH):
         "PATH": f"{bindir}:/usr/bin:/bin",
         "CONTSWAP_CGROUP_BASE": str(tmp_path / "cgroup"),
     }
-    script = f'source "{LIB}"; container_swap_activate_live "{name}"'
+    script = (
+        f'set -euo pipefail; source "{LIB}"; container_swap_activate_live "{name}"; echo __DONE__'
+    )
     return subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
 
 
@@ -56,6 +66,7 @@ def test_activates_when_zero(tmp_path):
     swap = _swap_file(tmp_path, "genesis", "0")
     res = _run(tmp_path, name="genesis")
     assert res.returncode == 0, res.stderr
+    assert "__DONE__" in res.stdout  # did not errexit-abort
     assert swap.read_text().strip() == "max"
     assert "activated swap live" in res.stdout
 
@@ -65,6 +76,7 @@ def test_idempotent_when_already_max(tmp_path):
     swap = _swap_file(tmp_path, "genesis", "max")
     res = _run(tmp_path, name="genesis")
     assert res.returncode == 0
+    assert "__DONE__" in res.stdout
     assert swap.read_text().strip() == "max"
     assert "activated swap live" not in res.stdout
 
@@ -73,6 +85,7 @@ def test_noop_when_cgroup_absent(tmp_path):
     """Container stopped / non-standard layout -> graceful no-op (config applies on start)."""
     res = _run(tmp_path, name="genesis")  # no swap file created
     assert res.returncode == 0
+    assert "__DONE__" in res.stdout
     assert "activated swap live" not in res.stdout
     assert "WARNING" not in res.stdout
 
@@ -80,17 +93,37 @@ def test_noop_when_cgroup_absent(tmp_path):
 def test_empty_name_is_noop(tmp_path):
     res = _run(tmp_path, name="")
     assert res.returncode == 0
-    assert res.stdout.strip() == ""
+    assert "__DONE__" in res.stdout
 
 
 def test_write_failure_warns_and_leaves_value(tmp_path):
-    """A refused privileged write must warn loudly, not claim success."""
+    """A refused privileged WRITE must warn loudly, not claim success."""
     swap = _swap_file(tmp_path, "genesis", "0")
-    res = _run(tmp_path, name="genesis", sudo_stub=_SUDO_FAIL)
+    res = _run(tmp_path, name="genesis", sudo_stub=_SUDO_TEE_FAIL)
     assert res.returncode == 0
+    assert "__DONE__" in res.stdout
     assert swap.read_text().strip() == "0"  # unchanged
     assert "WARNING" in res.stdout
     assert "activated swap live" not in res.stdout
+
+
+def test_read_failure_is_safe_noop_under_errexit(tmp_path):
+    """A refused READ must fall through to a no-op, NOT abort the caller's
+    `set -e` run — regression guard for a bare `cur=$(cat ...)` that would
+    propagate cat's nonzero status and errexit the whole host-setup."""
+    swap = _swap_file(tmp_path, "genesis", "0")
+    res = _run(tmp_path, name="genesis", sudo_stub=_SUDO_CAT_FAIL)
+    assert res.returncode == 0, res.stderr
+    assert "__DONE__" in res.stdout  # proves no errexit abort
+    assert swap.read_text().strip() == "0"  # untouched
+    assert "activated swap live" not in res.stdout
+
+
+def test_host_setup_wires_the_lib():
+    """The fix is dead unless host-setup.sh actually sources AND calls it."""
+    text = HOST_SETUP.read_text()
+    assert 'lib/container_swap.sh"' in text
+    assert "container_swap_activate_live" in text
 
 
 def test_lib_parses_clean():


### PR DESCRIPTION
## Problem

Host setup enables the container's memory cgroup to spill into host swap under pressure (`limits.memory.swap=true`), so a memory spike degrades into swapping instead of thrashing the whole box into an OOM wedge. But incus only applies that setting when the container **starts**.

On an **already-running** container — one freshly created earlier in the same host-setup run, or an existing one being retrofitted — the live cgroup keeps `memory.swap.max=0` until a restart. The config is set but silently no-ops meanwhile. A retrofit run looks done while the box stays one memory spike away from the exact wedge the setting is meant to prevent. (Observed firsthand: config showed `true`, container `memory.swap.max` stayed `0`, `free` showed no swap.)

## Fix

New `scripts/lib/container_swap.sh::container_swap_activate_live`, sourced and called by `host-setup.sh` immediately after the config set. It mirrors what incus does at start by writing the live cgroup now:

- Best-effort and idempotent: no-op when the cgroup knob is absent (container stopped, cgroup v1, non-standard layout — the persisted config still applies on next start) or already non-zero.
- Never fails its caller.
- On a refused privileged write it warns loudly (restart required) rather than claiming success.

This also fixes **fresh installs**, not just retrofits: the swap config is set after the container is already up, so without this the freshly-created container also sat at `swap.max=0` until its first reboot.

## Tests

`tests/test_scripts/test_container_swap.py` drives the real lib with a stubbed `sudo` on PATH + a cgroup-base override (the `test_memory_resilience.py` pattern): activates when `0`, idempotent when already `max`, graceful no-op when the cgroup is absent, empty-name no-op, warns (and leaves the value) on write failure, plus `bash -n` parse checks for the lib and the edited `host-setup.sh`.

## Deploy

Touches `scripts/host-setup.sh` (Host-Deploy Gate path). host-setup runs on the host during provisioning; the fix lands at source and applies on the next host-setup run. No update.sh redeploy needed for this container (swap was already activated live out-of-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)