### PR TITLE
fix(db): 256 MiB page cache + synchronous=NORMAL on the shared connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis's database keeps more in memory and stops over-syncing.** The main
+  shared SQLite connection held only SQLite's tiny ~2 MiB default page cache and
+  fsynced on every single commit (`synchronous=FULL`), even though the
+  standalone connection helper already used the lighter, equally safe `NORMAL`
+  mode under WAL. Both connection paths now hold a 256 MiB page cache, and the
+  main connection matches `NORMAL` — fewer disk syncs and less page re-fetching
+  under load, with no durability loss beyond what WAL already implies.
+
 - **Genesis's inner monologue now knows who each thought is about.** Every
   ambient micro-reflection used to be tagged as relevant to "both" the user
   and Genesis — the tag was computed from which sensors *ran* (all of them,

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -26,6 +26,13 @@ DEFAULT_DB_PATH = genesis_db_path()
 
 BUSY_TIMEOUT_MS = 5000
 
+# Per-connection page cache. Negative = KiB (SQLite convention), so -262144 is
+# 256 MiB. SQLite's default is ~2 MiB, which forces hot read paths to keep
+# re-fetching pages instead of holding Genesis's working set resident. This is
+# per *connection*, so the long-lived server + MCP connections each hold up to
+# this much — a few GiB total against a 36 GiB budget, comfortably within range.
+CACHE_SIZE_KIB = -262144
+
 # Schema migrations run rarely (deploy / server startup) but must win the write
 # lock even when other processes (concurrent CC-session MCP servers) are writing.
 # A generous timeout lets the migration's BEGIN IMMEDIATE and its COMMIT-time
@@ -256,6 +263,13 @@ async def get_db(
             await conn.execute("PRAGMA foreign_keys=ON")
         await conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         await conn.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
+        # synchronous=NORMAL is the safe, standard setting under WAL (no
+        # corruption risk; at most the last txn is lost on power loss). get_db
+        # previously relied on the default FULL, so the hot serialized
+        # connection fsynced on every commit for durability get_raw_db already
+        # forgoes — align them.
+        await conn.execute("PRAGMA synchronous=NORMAL")
+        await conn.execute(f"PRAGMA cache_size={CACHE_SIZE_KIB}")  # 256 MiB page cache
 
     db = await aiosqlite.connect(str(path))
     await _configure(db)
@@ -295,6 +309,7 @@ async def get_raw_db(
         await db.execute("PRAGMA synchronous=NORMAL")
         await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
+        await db.execute(f"PRAGMA cache_size={CACHE_SIZE_KIB}")  # 256 MiB page cache
         # NOTE: intentionally NOT setting `foreign_keys=ON` here (get_db does).
         # These standalone sites never enforced FKs before, and none touch
         # FK-cascading tables. If a future caller needs cascade deletes, enable

--- a/tests/test_db/test_connection_pragmas.py
+++ b/tests/test_db/test_connection_pragmas.py
@@ -6,6 +6,7 @@ raised a thread-bound ProgrammingError that a bare except swallowed → no-op).
 """
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -81,5 +82,33 @@ async def test_wal_checkpoint_helpers_actually_run(tmp_path):
         await loop._sqlite_wal_truncate(db)
 
         assert (not wal.exists()) or wal.stat().st_size == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_pragmas_survive_reconnect(tmp_path):
+    """The reconnect closure reuses _configure, so a recovered connection must
+    keep cache_size + synchronous — guards against a future refactor inlining the
+    pragmas and dropping them on the reconnect path."""
+    db = await get_db(tmp_path / "g.db")
+    try:
+        orig_conn = db._conn
+
+        async def _raise_locked(*args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        # Force lock errors until the SerializedConnection trips its reconnect
+        # threshold and swaps in a fresh connection built by the REAL closure.
+        orig_conn.execute = _raise_locked
+        for _ in range(db._MAX_LOCK_ERRORS):
+            with pytest.raises(sqlite3.OperationalError):
+                await db.execute("SELECT 1")
+
+        assert db._conn is not orig_conn  # actually reconnected
+        rows = await db.execute_fetchall("PRAGMA cache_size")
+        assert rows[0][0] == _CACHE_SIZE
+        rows = await db.execute_fetchall("PRAGMA synchronous")
+        assert rows[0][0] == 1  # NORMAL
     finally:
         await db.close()

--- a/tests/test_db/test_connection_pragmas.py
+++ b/tests/test_db/test_connection_pragmas.py
@@ -14,6 +14,7 @@ from genesis.awareness import loop
 from genesis.db.connection import get_db, get_raw_db
 
 _LIMIT = 67108864  # 64 MB
+_CACHE_SIZE = -262144  # 256 MiB page cache (negative = KiB), matches CACHE_SIZE_KIB
 
 
 @pytest.mark.asyncio
@@ -31,6 +32,35 @@ async def test_get_raw_db_sets_journal_size_limit(tmp_path):
     async with get_raw_db(tmp_path / "g.db") as db:
         rows = await db.execute_fetchall("PRAGMA journal_size_limit")
         assert rows[0][0] == _LIMIT
+
+
+@pytest.mark.asyncio
+async def test_get_db_sets_cache_size(tmp_path):
+    db = await get_db(tmp_path / "g.db")
+    try:
+        rows = await db.execute_fetchall("PRAGMA cache_size")
+        assert rows[0][0] == _CACHE_SIZE
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_get_raw_db_sets_cache_size(tmp_path):
+    async with get_raw_db(tmp_path / "g.db") as db:
+        rows = await db.execute_fetchall("PRAGMA cache_size")
+        assert rows[0][0] == _CACHE_SIZE
+
+
+@pytest.mark.asyncio
+async def test_get_db_sets_synchronous_normal(tmp_path):
+    """get_db previously relied on the SQLite default FULL(2); it now aligns to
+    NORMAL(1) like get_raw_db — safe + standard under WAL, fewer fsyncs."""
+    db = await get_db(tmp_path / "g.db")
+    try:
+        rows = await db.execute_fetchall("PRAGMA synchronous")
+        assert rows[0][0] == 1  # 1 == NORMAL
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Two SQLite connection-tuning changes in `db/connection.py`:

1. **`cache_size = -262144` (256 MiB)** on *both* connection paths (`get_db` serialized + `get_raw_db` standalone). The live DB was on SQLite's ~2 MiB default, forcing hot read paths to keep re-fetching pages instead of holding Genesis's working set resident.
2. **`synchronous = NORMAL` on `get_db`** — the main serialized connection relied on the default `FULL`, fsyncing on every commit, while `get_raw_db` already used `NORMAL`. Under WAL, `NORMAL` is the safe, standard setting (no corruption risk; at most the last txn is lost on power loss). This aligns the hot connection with the standalone one.

## Why it's safe

- `cache_size` is per-connection; the long-lived server + MCP connections sum to a few GiB against a 36 GiB memory budget.
- `NORMAL` under WAL is the documented safe mode and is *already* what `get_raw_db` uses — this removes an inconsistency, it doesn't introduce a new risk. Both pragmas also flow through the `get_db` reconnect closure (`_reconnect → _configure`), so recovered connections keep them.

## Tests

`tests/test_db/test_connection_pragmas.py` extended: asserts `cache_size` on both paths and `synchronous == NORMAL(1)` on `get_db`. All pass; ruff clean.

## Deploy

Pure `src` change — no host-deploy path. Pragmas apply on the next server start (connection open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)