### PR TITLE
fix(resilience): bootstrap self-installs systemd-oomd so OOM protection deploys everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Setup now installs the package its OOM protection depends on.** Genesis's
+  memory-pressure protection (systemd-oomd) was applied by setup but only *if*
+  the `systemd-oomd` package already happened to be installed — on a minimal
+  install where it wasn't, setup quietly skipped the whole layer and left the
+  box exposed to the exact OOM-thrash wedge the protection exists to prevent,
+  with no signal beyond a line in setup output nobody reads. Bootstrap now
+  provisions the package before applying the layer, so the protection actually
+  deploys everywhere. Idempotent (a no-op when already present) and it never
+  forces oomd on a kernel that can't support it.
+
 - **Wing-filtered memory recall stops missing memories it should return.**
   Asking for memories in a specific wing (e.g. `infrastructure`) silently
   under-returned two kinds of rows: memories with no vector (FTS-only) were

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -759,6 +759,16 @@ echo
 # Guarded: a tree mid-update/partial checkout without the lib must degrade,
 # not abort bootstrap under set -e (the lib's own never-abort contract).
 if [[ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]]; then
+    # systemd-oomd is a SEPARATE apt/dnf package, absent on minimal installs.
+    # memory_resilience_apply *silently skips* pressure-kill setup when it's
+    # missing (it only warns to setup output), so a box can look bootstrapped
+    # while sitting unprotected against the OOM-thrash wedge — the exact
+    # silent-skip gap a sibling install exposed. Provision it here so the oomd
+    # layer self-deploys everywhere. install_pkg is idempotent (no-op when
+    # present) and degrades to a warning on failure; memory_resilience_apply
+    # still guards on PSI/systemd independently, so this never forces oomd on a
+    # kernel that can't support it.
+    install_pkg systemd-oomd || echo "  WARNING: Could not install systemd-oomd — pressure-kill protection will be skipped."
     # shellcheck source=lib/memory_resilience.sh
     source "$SCRIPT_DIR/lib/memory_resilience.sh"
     memory_resilience_apply

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -768,7 +768,9 @@ if [[ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]]; then
     # present) and degrades to a warning on failure; memory_resilience_apply
     # still guards on PSI/systemd independently, so this never forces oomd on a
     # kernel that can't support it.
-    install_pkg systemd-oomd || echo "  WARNING: Could not install systemd-oomd — pressure-kill protection will be skipped."
+    # (dnf arg: Fedora ships oomd inside the main systemd package; the
+    # installable subpackage there is systemd-oomd-defaults.)
+    install_pkg systemd-oomd systemd-oomd-defaults || echo "  WARNING: Could not install systemd-oomd — if the next step reports 'systemd-oomd not available', pressure-kill protection is off."
     # shellcheck source=lib/memory_resilience.sh
     source "$SCRIPT_DIR/lib/memory_resilience.sh"
     memory_resilience_apply

--- a/tests/test_scripts/test_memory_resilience.py
+++ b/tests/test_scripts/test_memory_resilience.py
@@ -241,9 +241,27 @@ def test_bootstrap_wires_the_lib():
     assert "memory_resilience_apply" in text
 
 
+def test_bootstrap_provisions_the_oomd_package():
+    """The oomd layer is dead unless bootstrap installs the systemd-oomd package.
+
+    memory_resilience_apply SKIPS pressure-kill setup when systemd-oomd is
+    absent (a separate apt/dnf package on minimal installs), leaving the box
+    silently unprotected — the exact gap a sibling install exposed. bootstrap
+    must provision it, and BEFORE it applies the lib (install → apply order),
+    so the same run that would otherwise skip now succeeds.
+    """
+    text = BOOTSTRAP.read_text()
+    assert "install_pkg systemd-oomd" in text
+    # Ordering: the install must precede sourcing/applying the lib, or the first
+    # run still skips. Anchor to the `source` code line (unambiguous — the string
+    # "memory_resilience_apply" also appears in the explanatory comment above).
+    source_line = 'source "$SCRIPT_DIR/lib/memory_resilience.sh"'
+    assert text.index("install_pkg systemd-oomd") < text.index(source_line)
+
+
 def test_update_sh_wires_the_lib_visibly():
     # update.sh pipes bootstrap through `tail -10`, which eats the swap
     # warning — the retrofit path re-runs the (idempotent) apply unpiped.
     text = (REPO_ROOT / "scripts" / "update.sh").read_text()
-    assert 'lib/memory_resilience.sh' in text
+    assert "lib/memory_resilience.sh" in text
     assert text.count("memory_resilience_apply") >= 1


### PR DESCRIPTION
## What

Bootstrap now installs the `systemd-oomd` package before applying the memory-resilience layer, so the OOM pressure-kill protection actually deploys on every install — not only on the ones where the package happened to be present already.

## Why

`memory_resilience_apply` (in `scripts/lib/memory_resilience.sh`) **silently skips** pressure-kill setup when `systemd-oomd` is absent — it's a separate apt/dnf package on minimal installs. Nothing in setup provisioned it. The result: a box could look fully bootstrapped while sitting unprotected against the exact OOM-thrash wedge the layer exists to prevent, with no signal beyond a line in setup output nobody reads. This is the "silent-skip" class — a setup feature that no-ops on a prerequisite nothing installs.

## How

- `scripts/bootstrap.sh`: `install_pkg systemd-oomd systemd-oomd-defaults` inside the memory-resilience block, before sourcing/applying the lib (install → apply order, so the same run that used to skip now succeeds).
  - Idempotent (`apt-get install` is a no-op when present); `install_pkg` degrades to a warning on failure.
  - The lib still independently guards on kernel PSI + systemd, so this never forces oomd on a kernel that can't support it.
  - dnf arm uses `systemd-oomd-defaults` (Fedora ships the oomd daemon inside the main `systemd` package; `systemd-oomd` is not an installable name there).
- `update.sh` runs `bootstrap.sh` on every real update before its visible resilience re-run, so one insertion point covers fresh installs **and** every retrofit — no duplication needed.

## Tests / verification

- New coverage test in `tests/test_scripts/test_memory_resilience.py` asserts bootstrap provisions the package **and** does so before the apply (ordering guard). 15/15 in that file pass.
- Verified the exact install command is a clean idempotent no-op on a host where oomd is already present and active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)