### PR TITLE
feat(guardian): container-swap invariant reconciler — self-healing swap knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The guardian now keeps container swap enabled on its own.** Swap is what
+  turns a memory spike into graceful slowdown instead of a machine-wedging
+  thrash, but the setting only got applied when host setup ran — an install
+  that just pulls code updates could sit unprotected indefinitely (observed
+  live: a second install ran for weeks one memory spike away from the wedge).
+  The guardian now re-checks the setting every tick and repairs both halves
+  when drifted: the persistent config (so future restarts have it) and the
+  live cgroup (so protection is immediate, no restart needed). Repairs page an
+  INFO note; a repair that can't complete pages a warning at most daily. Hosts
+  where swap-off is deliberate can opt out (`swap_reconcile_enabled: false`).
+
 - **Genesis now remembers how its background jobs actually ran, not just a
   running tally.** Until now each scheduled job kept only a single cumulative
   row, so a job that failed for a week and then recovered looked identical to

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -374,6 +374,12 @@ verified: 4e483381 2026-07-15
   `/proc/meminfo` (the reliable axis). Both use the shared `_tier_for`/
   `decide_alert` hysteresis. Read-only `disk-status`/`ram-status` verbs expose
   the same measurement to the container.
+- **Container-swap invariant reconciler** (`swap_watch.py`) runs every tick:
+  re-asserts `limits.memory.swap=true` (incus config) and live-activates the
+  cgroup `memory.swap.max` (via `cgroup_ops`) when observed at `0` — the
+  self-heal for installs that advance via bare `git pull` and never re-run
+  host-setup. Heals page INFO; failures page WARNING (24h throttle); kill
+  switch `swap_reconcile_enabled: false`.
 - **sentinel/** is LIVE-wired but **shadow-only autonomy**: config mode
   `"live"` is NOT implemented (dispatcher warns + downgrades); every proposed
   action requires human approval. `InfrastructureMonitor` (call site 37, free

--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -52,7 +52,14 @@ remediation for the detected vantage — because the knob is never local:
 - **Inside a container** (LXC/Incus): swap capability is granted by the host.
   Fix on the host: `incus config set <container> limits.memory.swap true`,
   and make sure the host itself has swap. `host-setup.sh` does both for
-  managed installs (and warns if the host is swapless).
+  managed installs (and warns if the host is swapless). On guardian-managed
+  hosts the invariant is also **self-healing**: the guardian's swap
+  reconciler (`guardian/swap_watch.py`) re-asserts the config knob *and*
+  live-activates the cgroup (`memory.swap.max`) each tick — covering installs
+  that advance via bare `git pull` and never re-run host-setup. A heal pages
+  an INFO alert; opt a host out with `swap_reconcile_enabled: false` in the
+  guardian config (an explicitly-false knob is otherwise reconciled back to
+  true — swap-on is the install invariant).
 - **Bare metal / VM**: create a swapfile or LV sized to taste. Even a few
   GiB turns the OOM cliff into a ramp.
 

--- a/src/genesis/guardian/cgroup_ops.py
+++ b/src/genesis/guardian/cgroup_ops.py
@@ -87,6 +87,62 @@ async def relieve_io_max(container: str) -> bool:
         return False
 
 
+async def read_swap_max(container: str) -> str | None:
+    """Read memory.swap.max from the container's cgroup via sudo.
+
+    Read through sudo rather than directly: cgroup-delegation ownership of the
+    lxc.payload subtree varies, and a perm-denied plain read would be
+    indistinguishable from "knob absent" (the same reason
+    scripts/lib/container_swap.sh reads with ``sudo cat``). Returns the trimmed
+    value ("0", "max", or a byte count) or None when unreadable/absent
+    (container stopped, cgroup v1, non-standard layout) — None means
+    "no signal", never "healthy".
+    """
+    swap_path = _cgroup_path(container) / "memory.swap.max"
+    try:
+        rc, stdout, _stderr = await _run_subprocess(
+            "sudo", "cat", str(swap_path), timeout=10.0,
+        )
+        if rc != 0:
+            return None
+        return stdout.strip() or None
+    except Exception as exc:
+        logger.warning("Failed to read memory.swap.max for %s: %s", container, exc)
+        return None
+
+
+async def activate_swap_max(container: str) -> bool:
+    """Write 'max' to memory.swap.max — live-activate swap on a RUNNING container.
+
+    incus applies ``limits.memory.swap`` only when the container STARTS, so on
+    an already-running container the live cgroup keeps ``memory.swap.max=0``
+    until the next restart and every memory spike becomes the load-100 D-state
+    OOM-thrash wedge instead of degrading into swap. Writing ``max`` mirrors
+    what incus does at start (scripts/lib/container_swap.sh does the same from
+    host-setup); this is the guardian-side equivalent for installs that never
+    re-run host-setup.
+
+    Requires sudo because the cgroup is owned by root. Returns True on success.
+    """
+    swap_path = _cgroup_path(container) / "memory.swap.max"
+    try:
+        import shlex
+        rc, _stdout, stderr = await _run_subprocess(
+            "sudo", "sh", "-c", f"echo max > {shlex.quote(str(swap_path))}",
+            timeout=10.0,
+        )
+        if rc != 0:
+            logger.error(
+                "Failed to activate memory.swap.max for %s: %s", container, stderr,
+            )
+            return False
+        logger.info("Activated swap live for %s (memory.swap.max=max)", container)
+        return True
+    except Exception as exc:
+        logger.error("Failed to activate memory.swap.max for %s: %s", container, exc)
+        return False
+
+
 def list_container_pids(container: str) -> list[int]:
     """List all PIDs in the container's cgroup.
 

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -83,7 +83,7 @@ def _setup_logging() -> None:
         log_dir.mkdir(parents=True, exist_ok=True)
         file_handler = RotatingFileHandler(
             log_dir / "guardian.log",
-            maxBytes=1_000_000,   # 1 MB
+            maxBytes=1_000_000,  # 1 MB
             backupCount=3,
             encoding="utf-8",
         )
@@ -111,6 +111,7 @@ def _build_dispatcher(config: GuardianConfig) -> AlertDispatcher:
     # Treat each source as atomic — all-or-nothing, never mix sources
     if not token or not chat_id:
         from genesis.guardian.credential_bridge import load_telegram_credentials
+
         creds = load_telegram_credentials(config.state_dir)
         bridge_token = creds.get("TELEGRAM_BOT_TOKEN", "")
         bridge_chat = creds.get("TELEGRAM_CHAT_ID", "")
@@ -130,11 +131,13 @@ def _build_dispatcher(config: GuardianConfig) -> AlertDispatcher:
             thread_id = thread_id or secrets.get("TELEGRAM_THREAD_ID", "")
 
     if token and chat_id:
-        dispatcher.add_channel(TelegramAlertChannel(
-            bot_token=token,
-            chat_id=chat_id,
-            thread_id=thread_id or None,
-        ))
+        dispatcher.add_channel(
+            TelegramAlertChannel(
+                bot_token=token,
+                chat_id=chat_id,
+                thread_id=thread_id or None,
+            )
+        )
     else:
         logger.warning("No Telegram credentials — alerts will only go to journal")
 
@@ -159,7 +162,8 @@ def _alert_from_queue_entry(entry: dict) -> Alert:
 
 
 async def _drain_host_alert_queue(
-    config: GuardianConfig, dispatcher: AlertDispatcher,
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
 ) -> None:
     """Replay queued host alerts through the dispatcher, then bound the queue.
 
@@ -175,7 +179,8 @@ async def _drain_host_alert_queue(
         # Host has no dedup layer: dispatcher.send returns True iff a channel
         # delivered → terminal (unlink); False → still down → keep + stop.
         return await dispatcher.send(
-            _alert_from_queue_entry(entry), allow_queue_fallback=False,
+            _alert_from_queue_entry(entry),
+            allow_queue_fallback=False,
         )
 
     try:
@@ -214,6 +219,7 @@ def _build_provisioning_adapter(config: GuardianConfig):
 
     def _from_bridge() -> tuple[str, str]:
         from genesis.guardian.credential_bridge import load_provisioning_credentials
+
         creds = load_provisioning_credentials(config.state_dir)
         return (
             creds.get("PROXMOX_AUDIT_TOKEN", ""),
@@ -242,6 +248,7 @@ def _build_provisioning_adapter(config: GuardianConfig):
         return None
 
     from genesis.guardian.provisioning.proxmox import ProxmoxAdapter
+
     return ProxmoxAdapter(pc, audit_token=audit, provision_token=provision)
 
 
@@ -267,7 +274,10 @@ async def _maybe_propose_provisioning(
 
     try:
         await maybe_propose_pool_grow(
-            config, adapter, dispatcher, ProvisioningLedger(config.state_dir),
+            config,
+            adapter,
+            dispatcher,
+            ProvisioningLedger(config.state_dir),
         )
     except Exception:
         logger.warning("autonomous pool-grow proposal failed", exc_info=True)
@@ -279,17 +289,25 @@ async def _write_guardian_heartbeat(config: GuardianConfig) -> None:
     Uses stdin pipe instead of heredoc to avoid shell injection.
     """
     uptime_s = (datetime.now(UTC) - _STARTED_AT).total_seconds()
-    heartbeat = json.dumps({
-        "guardian_alive": True,
-        "timestamp": datetime.now(UTC).isoformat(),
-        "uptime_s": round(uptime_s),
-    })
+    heartbeat = json.dumps(
+        {
+            "guardian_alive": True,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "uptime_s": round(uptime_s),
+        }
+    )
 
     try:
         # Use stdin pipe — avoids heredoc injection risk
         proc = await asyncio.create_subprocess_exec(
-            "incus", "exec", config.container_name, "--",
-            "su", "-", "ubuntu", "-c",
+            "incus",
+            "exec",
+            config.container_name,
+            "--",
+            "su",
+            "-",
+            "ubuntu",
+            "-c",
             "mkdir -p ~/.genesis && cat > ~/.genesis/guardian_heartbeat.json",
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -369,13 +387,25 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # block on an APPROVE for up to approval_timeout_s — liveness must not
         # hinge on that optional, bounded wait completing.
         await _write_guardian_heartbeat(config)
+        # Container-swap invariant (silent-skip class): host-setup sets
+        # limits.memory.swap at creation, but an install that advances via bare
+        # git pull never re-runs host-setup — reconcile the knob (persistent
+        # config + live cgroup) on observed state so a memory spike degrades
+        # into swap pressure instead of the D-state OOM-thrash wedge. Runs
+        # BEFORE the storage-pool block: that path can wait up to
+        # approval_timeout_s on a Telegram APPROVE, and a box wedging on
+        # missing swap (the pool-crit + genesis_down case) must get the live
+        # cgroup fix at the START of the tick, not after a 30-minute wait. Two
+        # cheap reads on the healthy path.
+        await _check_container_swap_and_alert(config, dispatcher)
         # Storage-pool monitoring runs every cycle regardless of state — a
         # filling thin pool is the exact silent failure that caused the outage.
         # genesis_down gates the autonomous provisioning propose: only when
         # Genesis is CONFIRMED_DEAD is the main bot not polling, so only then
         # can the guardian read an APPROVE via getUpdates without a 409.
         await _check_storage_pool_and_alert(
-            config, dispatcher,
+            config,
+            dispatcher,
             genesis_down=(sm.current_state == GuardianState.CONFIRMED_DEAD),
         )
         # Guardian-side RAM tiered alert (E-rest PR-E1). The container's own RAM
@@ -396,12 +426,6 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # published bundle to a host-only dir + WARN if the archived bundle goes
         # stale. Host-side file ops only, independent of the container verdict.
         await _check_repo_bundle_and_alert(config, dispatcher)
-        # Container-swap invariant (silent-skip class): host-setup sets
-        # limits.memory.swap at creation, but an install that advances via bare
-        # git pull never re-runs host-setup — reconcile the knob (persistent
-        # config + live cgroup) on observed state so a memory spike degrades
-        # into swap pressure instead of the D-state OOM-thrash wedge.
-        await _check_container_swap_and_alert(config, dispatcher)
     finally:
         # Always save state, even on error
         sm.save_state(state_path)
@@ -424,7 +448,9 @@ async def _check_cycle(
 
     logger.info(
         "State: %s → %s (%s)",
-        transition.old_state, transition.new_state, transition.reason,
+        transition.old_state,
+        transition.new_state,
+        transition.reason,
     )
 
     state = sm.current_state
@@ -442,11 +468,13 @@ async def _check_cycle(
                 # approval / self-heal paths clear the flag at their own
                 # recovery point + emit their own success alert, so
                 # down_alert_sent is already False here for them — no double-ping.
-                await dispatcher.send(Alert(
-                    severity=AlertSeverity.INFO,
-                    title="Genesis recovered",
-                    body="Genesis is back online — all health signals passing.",
-                ))
+                await dispatcher.send(
+                    Alert(
+                        severity=AlertSeverity.INFO,
+                        title="Genesis recovered",
+                        body="Genesis is back online — all health signals passing.",
+                    )
+                )
             sm.clear_down_alert_sent()
         await _handle_healthy(config, snapshots)
 
@@ -461,7 +489,12 @@ async def _check_cycle(
 
     elif state == GuardianState.SURVEYING:
         await _handle_surveying(
-            config, sm, dispatcher, diagnosis_engine, recovery_engine, snapshot,
+            config,
+            sm,
+            dispatcher,
+            diagnosis_engine,
+            recovery_engine,
+            snapshot,
         )
 
     elif state == GuardianState.CONTACTING_GENESIS:
@@ -471,24 +504,34 @@ async def _check_cycle(
 
     elif state == GuardianState.AWAITING_SELF_HEAL:
         await _handle_awaiting_self_heal(
-            config, sm, dispatcher, diagnosis_engine, recovery_engine,
+            config,
+            sm,
+            dispatcher,
+            diagnosis_engine,
+            recovery_engine,
             snapshot,
         )
 
     elif state == GuardianState.CONFIRMED_DEAD:
         if transition.action_needed:
             await _handle_confirmed_dead(
-                config, sm, dispatcher, diagnosis_engine, recovery_engine,
+                config,
+                sm,
+                dispatcher,
+                diagnosis_engine,
+                recovery_engine,
             )
 
     elif state == GuardianState.PAUSED:
         if transition.action_needed:
             # Pause reminder or infrastructure failure while paused
-            await dispatcher.send(Alert(
-                severity=AlertSeverity.INFO,
-                title="Genesis pause reminder",
-                body=transition.reason,
-            ))
+            await dispatcher.send(
+                Alert(
+                    severity=AlertSeverity.INFO,
+                    title="Genesis pause reminder",
+                    body=transition.reason,
+                )
+            )
 
     elif state in (GuardianState.RECOVERING, GuardianState.RECOVERED):
         # These are transient states managed by the recovery engine
@@ -578,7 +621,8 @@ _POOL_TIER_SEVERITY = {
 
 
 async def _check_credential_integrity_and_alert(
-    config: GuardianConfig, dispatcher: AlertDispatcher,
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side credential-integrity backstop (delegates to cred_watch).
 
@@ -586,13 +630,15 @@ async def _check_credential_integrity_and_alert(
     alert (container-down is the state machine's job)."""
     try:
         from genesis.guardian.cred_watch import check_credential_integrity_and_alert
+
         await check_credential_integrity_and_alert(config, dispatcher)
     except Exception:
         logger.warning("credential-integrity watch failed", exc_info=True)
 
 
 async def _check_container_swap_and_alert(
-    config: GuardianConfig, dispatcher: AlertDispatcher,
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side container-swap invariant reconciler (delegates to swap_watch).
 
@@ -602,13 +648,15 @@ async def _check_container_swap_and_alert(
     Never raises into the tick."""
     try:
         from genesis.guardian.swap_watch import check_container_swap_and_alert
+
         await check_container_swap_and_alert(config, dispatcher)
     except Exception:
         logger.warning("container-swap watch failed", exc_info=True)
 
 
 async def _check_container_git_and_alert(
-    config: GuardianConfig, dispatcher: AlertDispatcher,
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side git-health watch (delegates to git_watch).
 
@@ -617,13 +665,15 @@ async def _check_container_git_and_alert(
     awareness-loop alerting down. Never raises into the tick."""
     try:
         from genesis.guardian.git_watch import check_container_git_and_alert
+
         await check_container_git_and_alert(config, dispatcher)
     except Exception:
         logger.warning("git-health watch failed", exc_info=True)
 
 
 async def _check_repo_bundle_and_alert(
-    config: GuardianConfig, dispatcher: AlertDispatcher,
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side offline-bundle archive + freshness watch (delegates to
     bundle_watch). Pure host-side file ops — archives the newest container-
@@ -631,6 +681,7 @@ async def _check_repo_bundle_and_alert(
     raises into the tick."""
     try:
         from genesis.guardian.bundle_watch import check_repo_bundle_and_alert
+
         await check_repo_bundle_and_alert(config, dispatcher)
     except Exception:
         logger.warning("repo-bundle watch failed", exc_info=True)
@@ -645,6 +696,7 @@ async def _check_memory_and_alert(
     pressure it detects. Never raises into the tick."""
     try:
         from genesis.guardian.memory_watch import check_memory_and_alert
+
         await check_memory_and_alert(config, dispatcher)
     except Exception:
         logger.warning("RAM watch failed", exc_info=True)
@@ -726,10 +778,14 @@ async def _check_storage_pool_and_alert(
     new_alert_at = now if decision.should_alert else last_alert_at
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text(json.dumps({
-            "tier": tier,
-            "last_alert_at": new_alert_at.isoformat() if new_alert_at else None,
-        }))
+        state_file.write_text(
+            json.dumps(
+                {
+                    "tier": tier,
+                    "last_alert_at": new_alert_at.isoformat() if new_alert_at else None,
+                }
+            )
+        )
     except OSError:
         logger.warning("failed to persist pool alert state", exc_info=True)
 
@@ -757,7 +813,9 @@ async def _handle_confirming(
 
     logger.info(
         "Recheck: %s → %s (%s)",
-        transition.old_state, transition.new_state, transition.reason,
+        transition.old_state,
+        transition.new_state,
+        transition.reason,
     )
 
 
@@ -800,7 +858,10 @@ async def _handle_surveying(
     if response.acknowledged:
         logger.info(
             "Genesis responded: status=%s action=%s eta=%ds context=%s",
-            response.status, response.action, response.eta_s, response.context,
+            response.status,
+            response.action,
+            response.eta_s,
+            response.context,
         )
 
         if response.status == DialogueStatus.HANDLING:
@@ -811,7 +872,8 @@ async def _handle_surveying(
             )
             logger.info(
                 "Genesis is handling it: %s (ETA: %ds)",
-                response.action, response.eta_s,
+                response.action,
+                response.eta_s,
             )
             return
 
@@ -826,12 +888,17 @@ async def _handle_surveying(
 
     else:
         logger.warning(
-            "Genesis unreachable or errored: %s", response.context,
+            "Genesis unreachable or errored: %s",
+            response.context,
         )
 
     # Step 2: Genesis can't help — full diagnosis and recovery pipeline
     await _proceed_to_diagnosis(
-        config, sm, dispatcher, diagnosis_engine, recovery_engine,
+        config,
+        sm,
+        dispatcher,
+        diagnosis_engine,
+        recovery_engine,
     )
 
 
@@ -861,11 +928,13 @@ async def _handle_awaiting_self_heal(
 
     if current == GuardianState.HEALTHY:
         logger.info("Genesis self-healed successfully")
-        await dispatcher.send(Alert(
-            severity=AlertSeverity.INFO,
-            title="Genesis self-healed",
-            body=f"Genesis fixed itself: {sm.state.dialogue_action}",
-        ))
+        await dispatcher.send(
+            Alert(
+                severity=AlertSeverity.INFO,
+                title="Genesis self-healed",
+                body=f"Genesis fixed itself: {sm.state.dialogue_action}",
+            )
+        )
         return
 
     # Re-query Genesis for updated Sentinel state on each tick.
@@ -899,7 +968,11 @@ async def _handle_awaiting_self_heal(
             sm.state.dialogue_action,
         )
         await _proceed_to_diagnosis(
-            config, sm, dispatcher, diagnosis_engine, recovery_engine,
+            config,
+            sm,
+            dispatcher,
+            diagnosis_engine,
+            recovery_engine,
         )
         return
 
@@ -919,12 +992,14 @@ async def _proceed_to_diagnosis(
     recovery_engine: RecoveryEngine,
 ) -> None:
     """Full diagnosis and recovery pipeline — Genesis is truly down."""
-    await dispatcher.send(Alert(
-        severity=AlertSeverity.CRITICAL,
-        title="Genesis down — running diagnostics",
-        body="Genesis could not be contacted or could not self-heal. "
-             "Running full diagnostics...",
-    ))
+    await dispatcher.send(
+        Alert(
+            severity=AlertSeverity.CRITICAL,
+            title="Genesis down — running diagnostics",
+            body="Genesis could not be contacted or could not self-heal. "
+            "Running full diagnostics...",
+        )
+    )
     # GUARD-R2-01: this episode's "down" alert has now fired — subsequent
     # CONFIRMED_DEAD ticks must NOT re-diagnose/re-alert (no 30s storm).
     sm.mark_down_alert_sent()
@@ -969,7 +1044,11 @@ async def _proceed_to_diagnosis(
     sm.set_confirmed_dead()
 
     await _execute_recovery_with_approval(
-        config, sm, dispatcher, recovery_engine, diagnosis,
+        config,
+        sm,
+        dispatcher,
+        recovery_engine,
+        diagnosis,
     )
 
 
@@ -1001,32 +1080,36 @@ async def _handle_cc_resolved(
         if sm.current_state != GuardianState.CONFIRMED_DEAD:
             sm.set_confirmed_dead()
         await _execute_recovery_with_approval(
-            config, sm, dispatcher, recovery_engine, diagnosis,
+            config,
+            sm,
+            dispatcher,
+            recovery_engine,
+            diagnosis,
         )
         return
 
     # Defensive: callers always pass recovery_engine, but never exit passively.
-    actions_str = (
-        ", ".join(diagnosis.actions_taken) if diagnosis.actions_taken else "unknown"
-    )
+    actions_str = ", ".join(diagnosis.actions_taken) if diagnosis.actions_taken else "unknown"
     cname = config.container_name
-    await dispatcher.send(Alert(
-        severity=AlertSeverity.CRITICAL,
-        title="Genesis down — CC claimed resolved (no approval pipeline)",
-        body=(
-            f"CC diagnosed: {diagnosis.likely_cause}\n"
-            f"CC reported steps: {actions_str}\n"
-            "CC claimed 'resolved' under propose-only mode — NOT trusted.\n"
-            "Approval-gated recovery pipeline unavailable.\n\n"
-            "IMMEDIATE ACTION REQUIRED:\n"
-            "1. SSH to host VM\n"
-            "2. Check Guardian log: ~/.local/state/genesis-guardian/guardian.log\n"
-            "3. Review latest diagnosis: ls -t "
-            "~/.local/state/genesis-guardian/shared/findings/ | head -1\n"
-            f"4. Manual restart: incus exec {cname} -- "
-            f"su - ubuntu -c 'systemctl --user restart genesis-server'"
-        ),
-    ))
+    await dispatcher.send(
+        Alert(
+            severity=AlertSeverity.CRITICAL,
+            title="Genesis down — CC claimed resolved (no approval pipeline)",
+            body=(
+                f"CC diagnosed: {diagnosis.likely_cause}\n"
+                f"CC reported steps: {actions_str}\n"
+                "CC claimed 'resolved' under propose-only mode — NOT trusted.\n"
+                "Approval-gated recovery pipeline unavailable.\n\n"
+                "IMMEDIATE ACTION REQUIRED:\n"
+                "1. SSH to host VM\n"
+                "2. Check Guardian log: ~/.local/state/genesis-guardian/guardian.log\n"
+                "3. Review latest diagnosis: ls -t "
+                "~/.local/state/genesis-guardian/shared/findings/ | head -1\n"
+                f"4. Manual restart: incus exec {cname} -- "
+                f"su - ubuntu -c 'systemctl --user restart genesis-server'"
+            ),
+        )
+    )
 
 
 async def _handle_confirmed_dead(
@@ -1103,13 +1186,17 @@ async def _handle_confirmed_dead(
             actions_taken=diagnosis.actions_taken,
             outcome=diagnosis.outcome,
             reasoning=f"Max recovery attempts ({sm.state.recovery_attempts}) exceeded. "
-                      + diagnosis.reasoning,
+            + diagnosis.reasoning,
             source=diagnosis.source,
             cc_failure_reason=diagnosis.cc_failure_reason,
         )
 
     await _execute_recovery_with_approval(
-        config, sm, dispatcher, recovery_engine, diagnosis,
+        config,
+        sm,
+        dispatcher,
+        recovery_engine,
+        diagnosis,
     )
 
 
@@ -1181,20 +1268,23 @@ async def _wait_for_gate_keyword(
             logger.warning(
                 "getUpdates 409 Conflict at %s gate (consecutive=%d) — main bot "
                 "is polling the same token",
-                gate_label, consecutive_conflicts,
+                gate_label,
+                consecutive_conflicts,
             )
             if consecutive_conflicts >= _APPROVAL_CONFLICT_ALERT_THRESHOLD:
-                await dispatcher.send(Alert(
-                    severity=AlertSeverity.WARNING,
-                    title="Cannot confirm main bot is down (getUpdates conflict)",
-                    body=(
-                        "Guardian is trying to read your APPROVE/DENY reply, but "
-                        "the main Genesis Telegram bot is actively polling the "
-                        "same token — which means it may still be alive. Manual "
-                        "check needed: verify whether Genesis is actually down "
-                        "before approving recovery."
-                    ),
-                ))
+                await dispatcher.send(
+                    Alert(
+                        severity=AlertSeverity.WARNING,
+                        title="Cannot confirm main bot is down (getUpdates conflict)",
+                        body=(
+                            "Guardian is trying to read your APPROVE/DENY reply, but "
+                            "the main Genesis Telegram bot is actively polling the "
+                            "same token — which means it may still be alive. Manual "
+                            "check needed: verify whether Genesis is actually down "
+                            "before approving recovery."
+                        ),
+                    )
+                )
                 consecutive_conflicts = 0  # re-arm; don't spam every loop
             await asyncio.sleep(_APPROVAL_CONFLICT_BACKOFF_S)
             waited_s += _APPROVAL_CONFLICT_BACKOFF_S
@@ -1209,9 +1299,9 @@ async def _wait_for_gate_keyword(
         waited_s += 25.0
         if waited_s - last_liveness_log >= _APPROVAL_LIVENESS_LOG_S:
             logger.info(
-                "Still awaiting %s approval reply (~%.0f min elapsed, Genesis "
-                "still down)",
-                gate_label, waited_s / 60.0,
+                "Still awaiting %s approval reply (~%.0f min elapsed, Genesis still down)",
+                gate_label,
+                waited_s / 60.0,
             )
             last_liveness_log = waited_s
 
@@ -1254,21 +1344,23 @@ async def _execute_recovery_with_approval(
             "alerting for manual intervention instead of auto-recovering",
         )
         cname = config.container_name
-        await dispatcher.send(Alert(
-            severity=AlertSeverity.CRITICAL,
-            title="Genesis down — approval gate unavailable (no Telegram)",
-            body=(
-                f"Proposed action: {diagnosis.recommended_action.value}\n"
-                f"Cause: {diagnosis.likely_cause}\n"
-                f"Confidence: {diagnosis.confidence_pct}%\n\n"
-                "Guardian cannot read an approval reply (no Telegram channel "
-                "configured) and will NOT auto-recover. Manual action:\n"
-                f"1. incus exec {cname} -- su - ubuntu -c "
-                f"'systemctl --user restart genesis-server'\n"
-                "2. Or re-trigger Guardian: systemctl --user restart "
-                "genesis-guardian.timer"
-            ),
-        ))
+        await dispatcher.send(
+            Alert(
+                severity=AlertSeverity.CRITICAL,
+                title="Genesis down — approval gate unavailable (no Telegram)",
+                body=(
+                    f"Proposed action: {diagnosis.recommended_action.value}\n"
+                    f"Cause: {diagnosis.likely_cause}\n"
+                    f"Confidence: {diagnosis.confidence_pct}%\n\n"
+                    "Guardian cannot read an approval reply (no Telegram channel "
+                    "configured) and will NOT auto-recover. Manual action:\n"
+                    f"1. incus exec {cname} -- su - ubuntu -c "
+                    f"'systemctl --user restart genesis-server'\n"
+                    "2. Or re-trigger Guardian: systemctl --user restart "
+                    "genesis-guardian.timer"
+                ),
+            )
+        )
         return
 
     failed_signals = [s.name for s in (await collect_all_signals(config)).failed_signals]
@@ -1285,15 +1377,17 @@ async def _execute_recovery_with_approval(
     gate1_msg_id = await telegram_channel.send_text(gate1_text)
     if gate1_msg_id is None:
         logger.error("Failed to send Gate 1 prompt — cannot run approval gate")
-        await dispatcher.send(Alert(
-            severity=AlertSeverity.CRITICAL,
-            title="Genesis down — could not send approval prompt",
-            body=(
-                "Guardian could not send the Telegram approval prompt. "
-                f"Proposed action: {diagnosis.recommended_action.value}. "
-                "No automated recovery performed."
-            ),
-        ))
+        await dispatcher.send(
+            Alert(
+                severity=AlertSeverity.CRITICAL,
+                title="Genesis down — could not send approval prompt",
+                body=(
+                    "Guardian could not send the Telegram approval prompt. "
+                    f"Proposed action: {diagnosis.recommended_action.value}. "
+                    "No automated recovery performed."
+                ),
+            )
+        )
         # A FAILED send is not a successful "alert once" — the user never saw a
         # prompt. Clear the episode flag so the next cycle retries delivery
         # rather than going permanently silent on a transient Telegram failure.
@@ -1301,7 +1395,12 @@ async def _execute_recovery_with_approval(
         return
 
     kw = await _wait_for_gate_keyword(
-        config, sm, dispatcher, telegram_channel, gate1_msg_id, "Gate 1 (investigate)",
+        config,
+        sm,
+        dispatcher,
+        telegram_channel,
+        gate1_msg_id,
+        "Gate 1 (investigate)",
     )
 
     if kw == "__RECOVERED__":
@@ -1366,8 +1465,10 @@ async def _execute_recovery_with_approval(
 
     logger.info(
         "Gate-1 approved; diagnosis: %s (confidence=%d%%, action=%s, source=%s)",
-        diagnosis.likely_cause, diagnosis.confidence_pct,
-        diagnosis.recommended_action.value, diagnosis.source,
+        diagnosis.likely_cause,
+        diagnosis.confidence_pct,
+        diagnosis.recommended_action.value,
+        diagnosis.source,
     )
 
     # Persist the proposed diagnosis to the shared mount for Genesis to ingest.
@@ -1398,20 +1499,27 @@ async def _execute_recovery_with_approval(
     gate2_msg_id = await telegram_channel.send_text(gate2_text)
     if gate2_msg_id is None:
         logger.error("Failed to send Gate 2 prompt — no recovery executed")
-        await dispatcher.send(Alert(
-            severity=AlertSeverity.CRITICAL,
-            title="Genesis down — could not send action-approval prompt",
-            body=(
-                f"Proposed action: {diagnosis.recommended_action.value}. "
-                "Guardian could not send the Telegram prompt. No recovery performed."
-            ),
-        ))
+        await dispatcher.send(
+            Alert(
+                severity=AlertSeverity.CRITICAL,
+                title="Genesis down — could not send action-approval prompt",
+                body=(
+                    f"Proposed action: {diagnosis.recommended_action.value}. "
+                    "Guardian could not send the Telegram prompt. No recovery performed."
+                ),
+            )
+        )
         # Failed delivery ≠ "already alerted" — let the next cycle retry.
         sm.clear_down_alert_sent()
         return
 
     kw2 = await _wait_for_gate_keyword(
-        config, sm, dispatcher, telegram_channel, gate2_msg_id, "Gate 2 (action)",
+        config,
+        sm,
+        dispatcher,
+        telegram_channel,
+        gate2_msg_id,
+        "Gate 2 (action)",
     )
 
     if kw2 == "__RECOVERED__":

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -83,7 +83,7 @@ def _setup_logging() -> None:
         log_dir.mkdir(parents=True, exist_ok=True)
         file_handler = RotatingFileHandler(
             log_dir / "guardian.log",
-            maxBytes=1_000_000,  # 1 MB
+            maxBytes=1_000_000,   # 1 MB
             backupCount=3,
             encoding="utf-8",
         )
@@ -111,7 +111,6 @@ def _build_dispatcher(config: GuardianConfig) -> AlertDispatcher:
     # Treat each source as atomic — all-or-nothing, never mix sources
     if not token or not chat_id:
         from genesis.guardian.credential_bridge import load_telegram_credentials
-
         creds = load_telegram_credentials(config.state_dir)
         bridge_token = creds.get("TELEGRAM_BOT_TOKEN", "")
         bridge_chat = creds.get("TELEGRAM_CHAT_ID", "")
@@ -131,13 +130,11 @@ def _build_dispatcher(config: GuardianConfig) -> AlertDispatcher:
             thread_id = thread_id or secrets.get("TELEGRAM_THREAD_ID", "")
 
     if token and chat_id:
-        dispatcher.add_channel(
-            TelegramAlertChannel(
-                bot_token=token,
-                chat_id=chat_id,
-                thread_id=thread_id or None,
-            )
-        )
+        dispatcher.add_channel(TelegramAlertChannel(
+            bot_token=token,
+            chat_id=chat_id,
+            thread_id=thread_id or None,
+        ))
     else:
         logger.warning("No Telegram credentials — alerts will only go to journal")
 
@@ -162,8 +159,7 @@ def _alert_from_queue_entry(entry: dict) -> Alert:
 
 
 async def _drain_host_alert_queue(
-    config: GuardianConfig,
-    dispatcher: AlertDispatcher,
+    config: GuardianConfig, dispatcher: AlertDispatcher,
 ) -> None:
     """Replay queued host alerts through the dispatcher, then bound the queue.
 
@@ -179,8 +175,7 @@ async def _drain_host_alert_queue(
         # Host has no dedup layer: dispatcher.send returns True iff a channel
         # delivered → terminal (unlink); False → still down → keep + stop.
         return await dispatcher.send(
-            _alert_from_queue_entry(entry),
-            allow_queue_fallback=False,
+            _alert_from_queue_entry(entry), allow_queue_fallback=False,
         )
 
     try:
@@ -219,7 +214,6 @@ def _build_provisioning_adapter(config: GuardianConfig):
 
     def _from_bridge() -> tuple[str, str]:
         from genesis.guardian.credential_bridge import load_provisioning_credentials
-
         creds = load_provisioning_credentials(config.state_dir)
         return (
             creds.get("PROXMOX_AUDIT_TOKEN", ""),
@@ -248,7 +242,6 @@ def _build_provisioning_adapter(config: GuardianConfig):
         return None
 
     from genesis.guardian.provisioning.proxmox import ProxmoxAdapter
-
     return ProxmoxAdapter(pc, audit_token=audit, provision_token=provision)
 
 
@@ -274,10 +267,7 @@ async def _maybe_propose_provisioning(
 
     try:
         await maybe_propose_pool_grow(
-            config,
-            adapter,
-            dispatcher,
-            ProvisioningLedger(config.state_dir),
+            config, adapter, dispatcher, ProvisioningLedger(config.state_dir),
         )
     except Exception:
         logger.warning("autonomous pool-grow proposal failed", exc_info=True)
@@ -289,25 +279,17 @@ async def _write_guardian_heartbeat(config: GuardianConfig) -> None:
     Uses stdin pipe instead of heredoc to avoid shell injection.
     """
     uptime_s = (datetime.now(UTC) - _STARTED_AT).total_seconds()
-    heartbeat = json.dumps(
-        {
-            "guardian_alive": True,
-            "timestamp": datetime.now(UTC).isoformat(),
-            "uptime_s": round(uptime_s),
-        }
-    )
+    heartbeat = json.dumps({
+        "guardian_alive": True,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "uptime_s": round(uptime_s),
+    })
 
     try:
         # Use stdin pipe — avoids heredoc injection risk
         proc = await asyncio.create_subprocess_exec(
-            "incus",
-            "exec",
-            config.container_name,
-            "--",
-            "su",
-            "-",
-            "ubuntu",
-            "-c",
+            "incus", "exec", config.container_name, "--",
+            "su", "-", "ubuntu", "-c",
             "mkdir -p ~/.genesis && cat > ~/.genesis/guardian_heartbeat.json",
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -404,8 +386,7 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # Genesis is CONFIRMED_DEAD is the main bot not polling, so only then
         # can the guardian read an APPROVE via getUpdates without a 409.
         await _check_storage_pool_and_alert(
-            config,
-            dispatcher,
+            config, dispatcher,
             genesis_down=(sm.current_state == GuardianState.CONFIRMED_DEAD),
         )
         # Guardian-side RAM tiered alert (E-rest PR-E1). The container's own RAM
@@ -448,9 +429,7 @@ async def _check_cycle(
 
     logger.info(
         "State: %s → %s (%s)",
-        transition.old_state,
-        transition.new_state,
-        transition.reason,
+        transition.old_state, transition.new_state, transition.reason,
     )
 
     state = sm.current_state
@@ -468,13 +447,11 @@ async def _check_cycle(
                 # approval / self-heal paths clear the flag at their own
                 # recovery point + emit their own success alert, so
                 # down_alert_sent is already False here for them — no double-ping.
-                await dispatcher.send(
-                    Alert(
-                        severity=AlertSeverity.INFO,
-                        title="Genesis recovered",
-                        body="Genesis is back online — all health signals passing.",
-                    )
-                )
+                await dispatcher.send(Alert(
+                    severity=AlertSeverity.INFO,
+                    title="Genesis recovered",
+                    body="Genesis is back online — all health signals passing.",
+                ))
             sm.clear_down_alert_sent()
         await _handle_healthy(config, snapshots)
 
@@ -489,12 +466,7 @@ async def _check_cycle(
 
     elif state == GuardianState.SURVEYING:
         await _handle_surveying(
-            config,
-            sm,
-            dispatcher,
-            diagnosis_engine,
-            recovery_engine,
-            snapshot,
+            config, sm, dispatcher, diagnosis_engine, recovery_engine, snapshot,
         )
 
     elif state == GuardianState.CONTACTING_GENESIS:
@@ -504,34 +476,24 @@ async def _check_cycle(
 
     elif state == GuardianState.AWAITING_SELF_HEAL:
         await _handle_awaiting_self_heal(
-            config,
-            sm,
-            dispatcher,
-            diagnosis_engine,
-            recovery_engine,
+            config, sm, dispatcher, diagnosis_engine, recovery_engine,
             snapshot,
         )
 
     elif state == GuardianState.CONFIRMED_DEAD:
         if transition.action_needed:
             await _handle_confirmed_dead(
-                config,
-                sm,
-                dispatcher,
-                diagnosis_engine,
-                recovery_engine,
+                config, sm, dispatcher, diagnosis_engine, recovery_engine,
             )
 
     elif state == GuardianState.PAUSED:
         if transition.action_needed:
             # Pause reminder or infrastructure failure while paused
-            await dispatcher.send(
-                Alert(
-                    severity=AlertSeverity.INFO,
-                    title="Genesis pause reminder",
-                    body=transition.reason,
-                )
-            )
+            await dispatcher.send(Alert(
+                severity=AlertSeverity.INFO,
+                title="Genesis pause reminder",
+                body=transition.reason,
+            ))
 
     elif state in (GuardianState.RECOVERING, GuardianState.RECOVERED):
         # These are transient states managed by the recovery engine
@@ -621,8 +583,7 @@ _POOL_TIER_SEVERITY = {
 
 
 async def _check_credential_integrity_and_alert(
-    config: GuardianConfig,
-    dispatcher: AlertDispatcher,
+    config: GuardianConfig, dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side credential-integrity backstop (delegates to cred_watch).
 
@@ -630,15 +591,13 @@ async def _check_credential_integrity_and_alert(
     alert (container-down is the state machine's job)."""
     try:
         from genesis.guardian.cred_watch import check_credential_integrity_and_alert
-
         await check_credential_integrity_and_alert(config, dispatcher)
     except Exception:
         logger.warning("credential-integrity watch failed", exc_info=True)
 
 
 async def _check_container_swap_and_alert(
-    config: GuardianConfig,
-    dispatcher: AlertDispatcher,
+    config: GuardianConfig, dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side container-swap invariant reconciler (delegates to swap_watch).
 
@@ -648,15 +607,13 @@ async def _check_container_swap_and_alert(
     Never raises into the tick."""
     try:
         from genesis.guardian.swap_watch import check_container_swap_and_alert
-
         await check_container_swap_and_alert(config, dispatcher)
     except Exception:
         logger.warning("container-swap watch failed", exc_info=True)
 
 
 async def _check_container_git_and_alert(
-    config: GuardianConfig,
-    dispatcher: AlertDispatcher,
+    config: GuardianConfig, dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side git-health watch (delegates to git_watch).
 
@@ -665,15 +622,13 @@ async def _check_container_git_and_alert(
     awareness-loop alerting down. Never raises into the tick."""
     try:
         from genesis.guardian.git_watch import check_container_git_and_alert
-
         await check_container_git_and_alert(config, dispatcher)
     except Exception:
         logger.warning("git-health watch failed", exc_info=True)
 
 
 async def _check_repo_bundle_and_alert(
-    config: GuardianConfig,
-    dispatcher: AlertDispatcher,
+    config: GuardianConfig, dispatcher: AlertDispatcher,
 ) -> None:
     """Guardian-side offline-bundle archive + freshness watch (delegates to
     bundle_watch). Pure host-side file ops — archives the newest container-
@@ -681,7 +636,6 @@ async def _check_repo_bundle_and_alert(
     raises into the tick."""
     try:
         from genesis.guardian.bundle_watch import check_repo_bundle_and_alert
-
         await check_repo_bundle_and_alert(config, dispatcher)
     except Exception:
         logger.warning("repo-bundle watch failed", exc_info=True)
@@ -696,7 +650,6 @@ async def _check_memory_and_alert(
     pressure it detects. Never raises into the tick."""
     try:
         from genesis.guardian.memory_watch import check_memory_and_alert
-
         await check_memory_and_alert(config, dispatcher)
     except Exception:
         logger.warning("RAM watch failed", exc_info=True)
@@ -778,14 +731,10 @@ async def _check_storage_pool_and_alert(
     new_alert_at = now if decision.should_alert else last_alert_at
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text(
-            json.dumps(
-                {
-                    "tier": tier,
-                    "last_alert_at": new_alert_at.isoformat() if new_alert_at else None,
-                }
-            )
-        )
+        state_file.write_text(json.dumps({
+            "tier": tier,
+            "last_alert_at": new_alert_at.isoformat() if new_alert_at else None,
+        }))
     except OSError:
         logger.warning("failed to persist pool alert state", exc_info=True)
 
@@ -813,9 +762,7 @@ async def _handle_confirming(
 
     logger.info(
         "Recheck: %s → %s (%s)",
-        transition.old_state,
-        transition.new_state,
-        transition.reason,
+        transition.old_state, transition.new_state, transition.reason,
     )
 
 
@@ -858,10 +805,7 @@ async def _handle_surveying(
     if response.acknowledged:
         logger.info(
             "Genesis responded: status=%s action=%s eta=%ds context=%s",
-            response.status,
-            response.action,
-            response.eta_s,
-            response.context,
+            response.status, response.action, response.eta_s, response.context,
         )
 
         if response.status == DialogueStatus.HANDLING:
@@ -872,8 +816,7 @@ async def _handle_surveying(
             )
             logger.info(
                 "Genesis is handling it: %s (ETA: %ds)",
-                response.action,
-                response.eta_s,
+                response.action, response.eta_s,
             )
             return
 
@@ -888,17 +831,12 @@ async def _handle_surveying(
 
     else:
         logger.warning(
-            "Genesis unreachable or errored: %s",
-            response.context,
+            "Genesis unreachable or errored: %s", response.context,
         )
 
     # Step 2: Genesis can't help — full diagnosis and recovery pipeline
     await _proceed_to_diagnosis(
-        config,
-        sm,
-        dispatcher,
-        diagnosis_engine,
-        recovery_engine,
+        config, sm, dispatcher, diagnosis_engine, recovery_engine,
     )
 
 
@@ -928,13 +866,11 @@ async def _handle_awaiting_self_heal(
 
     if current == GuardianState.HEALTHY:
         logger.info("Genesis self-healed successfully")
-        await dispatcher.send(
-            Alert(
-                severity=AlertSeverity.INFO,
-                title="Genesis self-healed",
-                body=f"Genesis fixed itself: {sm.state.dialogue_action}",
-            )
-        )
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.INFO,
+            title="Genesis self-healed",
+            body=f"Genesis fixed itself: {sm.state.dialogue_action}",
+        ))
         return
 
     # Re-query Genesis for updated Sentinel state on each tick.
@@ -968,11 +904,7 @@ async def _handle_awaiting_self_heal(
             sm.state.dialogue_action,
         )
         await _proceed_to_diagnosis(
-            config,
-            sm,
-            dispatcher,
-            diagnosis_engine,
-            recovery_engine,
+            config, sm, dispatcher, diagnosis_engine, recovery_engine,
         )
         return
 
@@ -992,14 +924,12 @@ async def _proceed_to_diagnosis(
     recovery_engine: RecoveryEngine,
 ) -> None:
     """Full diagnosis and recovery pipeline — Genesis is truly down."""
-    await dispatcher.send(
-        Alert(
-            severity=AlertSeverity.CRITICAL,
-            title="Genesis down — running diagnostics",
-            body="Genesis could not be contacted or could not self-heal. "
-            "Running full diagnostics...",
-        )
-    )
+    await dispatcher.send(Alert(
+        severity=AlertSeverity.CRITICAL,
+        title="Genesis down — running diagnostics",
+        body="Genesis could not be contacted or could not self-heal. "
+             "Running full diagnostics...",
+    ))
     # GUARD-R2-01: this episode's "down" alert has now fired — subsequent
     # CONFIRMED_DEAD ticks must NOT re-diagnose/re-alert (no 30s storm).
     sm.mark_down_alert_sent()
@@ -1044,11 +974,7 @@ async def _proceed_to_diagnosis(
     sm.set_confirmed_dead()
 
     await _execute_recovery_with_approval(
-        config,
-        sm,
-        dispatcher,
-        recovery_engine,
-        diagnosis,
+        config, sm, dispatcher, recovery_engine, diagnosis,
     )
 
 
@@ -1080,36 +1006,32 @@ async def _handle_cc_resolved(
         if sm.current_state != GuardianState.CONFIRMED_DEAD:
             sm.set_confirmed_dead()
         await _execute_recovery_with_approval(
-            config,
-            sm,
-            dispatcher,
-            recovery_engine,
-            diagnosis,
+            config, sm, dispatcher, recovery_engine, diagnosis,
         )
         return
 
     # Defensive: callers always pass recovery_engine, but never exit passively.
-    actions_str = ", ".join(diagnosis.actions_taken) if diagnosis.actions_taken else "unknown"
-    cname = config.container_name
-    await dispatcher.send(
-        Alert(
-            severity=AlertSeverity.CRITICAL,
-            title="Genesis down — CC claimed resolved (no approval pipeline)",
-            body=(
-                f"CC diagnosed: {diagnosis.likely_cause}\n"
-                f"CC reported steps: {actions_str}\n"
-                "CC claimed 'resolved' under propose-only mode — NOT trusted.\n"
-                "Approval-gated recovery pipeline unavailable.\n\n"
-                "IMMEDIATE ACTION REQUIRED:\n"
-                "1. SSH to host VM\n"
-                "2. Check Guardian log: ~/.local/state/genesis-guardian/guardian.log\n"
-                "3. Review latest diagnosis: ls -t "
-                "~/.local/state/genesis-guardian/shared/findings/ | head -1\n"
-                f"4. Manual restart: incus exec {cname} -- "
-                f"su - ubuntu -c 'systemctl --user restart genesis-server'"
-            ),
-        )
+    actions_str = (
+        ", ".join(diagnosis.actions_taken) if diagnosis.actions_taken else "unknown"
     )
+    cname = config.container_name
+    await dispatcher.send(Alert(
+        severity=AlertSeverity.CRITICAL,
+        title="Genesis down — CC claimed resolved (no approval pipeline)",
+        body=(
+            f"CC diagnosed: {diagnosis.likely_cause}\n"
+            f"CC reported steps: {actions_str}\n"
+            "CC claimed 'resolved' under propose-only mode — NOT trusted.\n"
+            "Approval-gated recovery pipeline unavailable.\n\n"
+            "IMMEDIATE ACTION REQUIRED:\n"
+            "1. SSH to host VM\n"
+            "2. Check Guardian log: ~/.local/state/genesis-guardian/guardian.log\n"
+            "3. Review latest diagnosis: ls -t "
+            "~/.local/state/genesis-guardian/shared/findings/ | head -1\n"
+            f"4. Manual restart: incus exec {cname} -- "
+            f"su - ubuntu -c 'systemctl --user restart genesis-server'"
+        ),
+    ))
 
 
 async def _handle_confirmed_dead(
@@ -1186,17 +1108,13 @@ async def _handle_confirmed_dead(
             actions_taken=diagnosis.actions_taken,
             outcome=diagnosis.outcome,
             reasoning=f"Max recovery attempts ({sm.state.recovery_attempts}) exceeded. "
-            + diagnosis.reasoning,
+                      + diagnosis.reasoning,
             source=diagnosis.source,
             cc_failure_reason=diagnosis.cc_failure_reason,
         )
 
     await _execute_recovery_with_approval(
-        config,
-        sm,
-        dispatcher,
-        recovery_engine,
-        diagnosis,
+        config, sm, dispatcher, recovery_engine, diagnosis,
     )
 
 
@@ -1268,23 +1186,20 @@ async def _wait_for_gate_keyword(
             logger.warning(
                 "getUpdates 409 Conflict at %s gate (consecutive=%d) — main bot "
                 "is polling the same token",
-                gate_label,
-                consecutive_conflicts,
+                gate_label, consecutive_conflicts,
             )
             if consecutive_conflicts >= _APPROVAL_CONFLICT_ALERT_THRESHOLD:
-                await dispatcher.send(
-                    Alert(
-                        severity=AlertSeverity.WARNING,
-                        title="Cannot confirm main bot is down (getUpdates conflict)",
-                        body=(
-                            "Guardian is trying to read your APPROVE/DENY reply, but "
-                            "the main Genesis Telegram bot is actively polling the "
-                            "same token — which means it may still be alive. Manual "
-                            "check needed: verify whether Genesis is actually down "
-                            "before approving recovery."
-                        ),
-                    )
-                )
+                await dispatcher.send(Alert(
+                    severity=AlertSeverity.WARNING,
+                    title="Cannot confirm main bot is down (getUpdates conflict)",
+                    body=(
+                        "Guardian is trying to read your APPROVE/DENY reply, but "
+                        "the main Genesis Telegram bot is actively polling the "
+                        "same token — which means it may still be alive. Manual "
+                        "check needed: verify whether Genesis is actually down "
+                        "before approving recovery."
+                    ),
+                ))
                 consecutive_conflicts = 0  # re-arm; don't spam every loop
             await asyncio.sleep(_APPROVAL_CONFLICT_BACKOFF_S)
             waited_s += _APPROVAL_CONFLICT_BACKOFF_S
@@ -1299,9 +1214,9 @@ async def _wait_for_gate_keyword(
         waited_s += 25.0
         if waited_s - last_liveness_log >= _APPROVAL_LIVENESS_LOG_S:
             logger.info(
-                "Still awaiting %s approval reply (~%.0f min elapsed, Genesis still down)",
-                gate_label,
-                waited_s / 60.0,
+                "Still awaiting %s approval reply (~%.0f min elapsed, Genesis "
+                "still down)",
+                gate_label, waited_s / 60.0,
             )
             last_liveness_log = waited_s
 
@@ -1344,23 +1259,21 @@ async def _execute_recovery_with_approval(
             "alerting for manual intervention instead of auto-recovering",
         )
         cname = config.container_name
-        await dispatcher.send(
-            Alert(
-                severity=AlertSeverity.CRITICAL,
-                title="Genesis down — approval gate unavailable (no Telegram)",
-                body=(
-                    f"Proposed action: {diagnosis.recommended_action.value}\n"
-                    f"Cause: {diagnosis.likely_cause}\n"
-                    f"Confidence: {diagnosis.confidence_pct}%\n\n"
-                    "Guardian cannot read an approval reply (no Telegram channel "
-                    "configured) and will NOT auto-recover. Manual action:\n"
-                    f"1. incus exec {cname} -- su - ubuntu -c "
-                    f"'systemctl --user restart genesis-server'\n"
-                    "2. Or re-trigger Guardian: systemctl --user restart "
-                    "genesis-guardian.timer"
-                ),
-            )
-        )
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.CRITICAL,
+            title="Genesis down — approval gate unavailable (no Telegram)",
+            body=(
+                f"Proposed action: {diagnosis.recommended_action.value}\n"
+                f"Cause: {diagnosis.likely_cause}\n"
+                f"Confidence: {diagnosis.confidence_pct}%\n\n"
+                "Guardian cannot read an approval reply (no Telegram channel "
+                "configured) and will NOT auto-recover. Manual action:\n"
+                f"1. incus exec {cname} -- su - ubuntu -c "
+                f"'systemctl --user restart genesis-server'\n"
+                "2. Or re-trigger Guardian: systemctl --user restart "
+                "genesis-guardian.timer"
+            ),
+        ))
         return
 
     failed_signals = [s.name for s in (await collect_all_signals(config)).failed_signals]
@@ -1377,17 +1290,15 @@ async def _execute_recovery_with_approval(
     gate1_msg_id = await telegram_channel.send_text(gate1_text)
     if gate1_msg_id is None:
         logger.error("Failed to send Gate 1 prompt — cannot run approval gate")
-        await dispatcher.send(
-            Alert(
-                severity=AlertSeverity.CRITICAL,
-                title="Genesis down — could not send approval prompt",
-                body=(
-                    "Guardian could not send the Telegram approval prompt. "
-                    f"Proposed action: {diagnosis.recommended_action.value}. "
-                    "No automated recovery performed."
-                ),
-            )
-        )
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.CRITICAL,
+            title="Genesis down — could not send approval prompt",
+            body=(
+                "Guardian could not send the Telegram approval prompt. "
+                f"Proposed action: {diagnosis.recommended_action.value}. "
+                "No automated recovery performed."
+            ),
+        ))
         # A FAILED send is not a successful "alert once" — the user never saw a
         # prompt. Clear the episode flag so the next cycle retries delivery
         # rather than going permanently silent on a transient Telegram failure.
@@ -1395,12 +1306,7 @@ async def _execute_recovery_with_approval(
         return
 
     kw = await _wait_for_gate_keyword(
-        config,
-        sm,
-        dispatcher,
-        telegram_channel,
-        gate1_msg_id,
-        "Gate 1 (investigate)",
+        config, sm, dispatcher, telegram_channel, gate1_msg_id, "Gate 1 (investigate)",
     )
 
     if kw == "__RECOVERED__":
@@ -1465,10 +1371,8 @@ async def _execute_recovery_with_approval(
 
     logger.info(
         "Gate-1 approved; diagnosis: %s (confidence=%d%%, action=%s, source=%s)",
-        diagnosis.likely_cause,
-        diagnosis.confidence_pct,
-        diagnosis.recommended_action.value,
-        diagnosis.source,
+        diagnosis.likely_cause, diagnosis.confidence_pct,
+        diagnosis.recommended_action.value, diagnosis.source,
     )
 
     # Persist the proposed diagnosis to the shared mount for Genesis to ingest.
@@ -1499,27 +1403,20 @@ async def _execute_recovery_with_approval(
     gate2_msg_id = await telegram_channel.send_text(gate2_text)
     if gate2_msg_id is None:
         logger.error("Failed to send Gate 2 prompt — no recovery executed")
-        await dispatcher.send(
-            Alert(
-                severity=AlertSeverity.CRITICAL,
-                title="Genesis down — could not send action-approval prompt",
-                body=(
-                    f"Proposed action: {diagnosis.recommended_action.value}. "
-                    "Guardian could not send the Telegram prompt. No recovery performed."
-                ),
-            )
-        )
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.CRITICAL,
+            title="Genesis down — could not send action-approval prompt",
+            body=(
+                f"Proposed action: {diagnosis.recommended_action.value}. "
+                "Guardian could not send the Telegram prompt. No recovery performed."
+            ),
+        ))
         # Failed delivery ≠ "already alerted" — let the next cycle retry.
         sm.clear_down_alert_sent()
         return
 
     kw2 = await _wait_for_gate_keyword(
-        config,
-        sm,
-        dispatcher,
-        telegram_channel,
-        gate2_msg_id,
-        "Gate 2 (action)",
+        config, sm, dispatcher, telegram_channel, gate2_msg_id, "Gate 2 (action)",
     )
 
     if kw2 == "__RECOVERED__":

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -396,6 +396,12 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # published bundle to a host-only dir + WARN if the archived bundle goes
         # stale. Host-side file ops only, independent of the container verdict.
         await _check_repo_bundle_and_alert(config, dispatcher)
+        # Container-swap invariant (silent-skip class): host-setup sets
+        # limits.memory.swap at creation, but an install that advances via bare
+        # git pull never re-runs host-setup — reconcile the knob (persistent
+        # config + live cgroup) on observed state so a memory spike degrades
+        # into swap pressure instead of the D-state OOM-thrash wedge.
+        await _check_container_swap_and_alert(config, dispatcher)
     finally:
         # Always save state, even on error
         sm.save_state(state_path)
@@ -583,6 +589,22 @@ async def _check_credential_integrity_and_alert(
         await check_credential_integrity_and_alert(config, dispatcher)
     except Exception:
         logger.warning("credential-integrity watch failed", exc_info=True)
+
+
+async def _check_container_swap_and_alert(
+    config: GuardianConfig, dispatcher: AlertDispatcher,
+) -> None:
+    """Guardian-side container-swap invariant reconciler (delegates to swap_watch).
+
+    host-setup sets limits.memory.swap at creation, but an install that
+    advances via bare git pull never re-runs host-setup — the guardian
+    re-asserts the knob (persistent config + live cgroup) on observed state.
+    Never raises into the tick."""
+    try:
+        from genesis.guardian.swap_watch import check_container_swap_and_alert
+        await check_container_swap_and_alert(config, dispatcher)
+    except Exception:
+        logger.warning("container-swap watch failed", exc_info=True)
 
 
 async def _check_container_git_and_alert(

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -317,6 +317,10 @@ class GuardianConfig:
     check_interval_s: int = 30
     state_dir: str = "~/.local/state/genesis-guardian"
     maintenance_file: str = "/var/lib/guardian-snapshots/.guardian-maintenance"
+    # Container-swap invariant reconciler (swap_watch): re-assert
+    # limits.memory.swap=true + live cgroup activation each tick. Kill switch
+    # for hosts where swap-off is a deliberate operator choice.
+    swap_reconcile_enabled: bool = True
 
     # Host VM details — used by container for bidirectional monitoring (SSH → gateway)
     host_ip: str = ""      # Auto-detected by installer; empty = not installed
@@ -582,6 +586,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         "container_name", "container_ip", "container_user",
         "health_api_port", "check_interval_s", "state_dir",
         "host_ip", "host_user", "maintenance_file",
+        "swap_reconcile_enabled",
     }
     top_kwargs = {k: v for k, v in raw.items() if k in top_fields}
 

--- a/src/genesis/guardian/swap_watch.py
+++ b/src/genesis/guardian/swap_watch.py
@@ -66,7 +66,10 @@ def _failure_alert_due(state_file, now: datetime) -> bool:
             return True
         last = datetime.fromisoformat(raw_at)
         return (now - last).total_seconds() >= _REALERT_HOURS * 3600
-    except (ValueError, OSError):
+    except (ValueError, OSError, TypeError, AttributeError):
+        # TypeError: aware-vs-naive timestamp; AttributeError: valid JSON that
+        # isn't a dict. Both mean "state unusable" -> alert is due, and neither
+        # may escape (module contract: never raises into the tick).
         return True
 
 
@@ -95,10 +98,14 @@ async def check_container_swap_and_alert(config, dispatcher) -> None:
     # 1. Persistent knob. `incus config get` on an unset key returns rc=0 with
     # empty output, so unset and explicit-false both land in the set branch.
     try:
+        # --expanded so a profile-inherited true reads as true (a plain get is
+        # local-only and would trigger a redundant local override + a false
+        # "was off" heal alert). Verified supported on live incus.
         rc, stdout, _stderr = await _run_subprocess(
             "incus",
             "config",
             "get",
+            "--expanded",
             container,
             "limits.memory.swap",
             timeout=_INCUS_TIMEOUT,

--- a/src/genesis/guardian/swap_watch.py
+++ b/src/genesis/guardian/swap_watch.py
@@ -1,0 +1,174 @@
+"""Container-swap reconciler — HOST-SIDE (guardian).
+
+``limits.memory.swap true`` is set by host-setup.sh at container creation and
+on manual re-runs, and #1079 activates it live there too — but an install that
+advances via bare ``git pull`` (observed on a sibling install) never re-runs
+host-setup, so the knob can sit unset (and the live cgroup at
+``memory.swap.max=0``) indefinitely. Every memory spike then becomes the
+load-100 D-state OOM-thrash wedge instead of degrading into swap pressure —
+the exact failure the setting exists to prevent, silent until it fires.
+
+The guardian is the only Genesis component that runs host-side with incus +
+sudo access *continuously*, so it reconciles on OBSERVED state each tick:
+
+1. **Persistent**: ``incus config get limits.memory.swap`` != ``true`` →
+   ``incus config set`` (covers unset AND false; applies at every future
+   container start).
+2. **Live**: cgroup ``memory.swap.max == "0"`` → write ``max`` now — what
+   incus would have written at start (``cgroup_ops.activate_swap_max``, the
+   guardian-side twin of scripts/lib/container_swap.sh).
+
+Healthy path = two cheap reads, no writes, no alerts. A heal emits one INFO
+alert (guardian self-actions must be visible); a failed heal emits a WARNING
+throttled by a state file (memory_watch idiom) so a persistent fault pages
+daily, not per-tick. Never raises into the tick.
+
+Deliberate override note: an operator who explicitly set
+``limits.memory.swap=false`` will be reconciled back to ``true`` — swap-on is
+a Genesis install invariant (docs/reference/memory-resilience.md). Disable the
+reconciler itself (``swap_reconcile_enabled: false`` in guardian config) to
+opt a host out.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from genesis.guardian._subprocess import run_subprocess as _run_subprocess
+from genesis.guardian.alert.base import Alert, AlertSeverity
+from genesis.guardian.cgroup_ops import activate_swap_max, read_swap_max
+
+logger = logging.getLogger(__name__)
+
+# A persistent failure re-pages at most this often (state-file throttle).
+_REALERT_HOURS = 24.0
+
+_INCUS_TIMEOUT = 10.0
+
+
+async def _send(dispatcher, severity: AlertSeverity, title: str, body: str) -> None:
+    try:
+        await dispatcher.send(Alert(severity=severity, title=title, body=body))
+    except Exception:
+        logger.warning("swap_watch alert dispatch failed", exc_info=True)
+
+
+def _failure_alert_due(state_file, now: datetime) -> bool:
+    """True when the WARNING throttle window has elapsed (or no state yet)."""
+    if not state_file.exists():
+        return True
+    try:
+        data = json.loads(state_file.read_text())
+        raw_at = data.get("last_failure_alert_at")
+        if not raw_at:
+            return True
+        last = datetime.fromisoformat(raw_at)
+        return (now - last).total_seconds() >= _REALERT_HOURS * 3600
+    except (ValueError, OSError):
+        return True
+
+
+def _record_failure_alert(state_file, now: datetime) -> None:
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(json.dumps({"last_failure_alert_at": now.isoformat()}))
+    except OSError:
+        logger.warning("could not persist swap_watch alert state", exc_info=True)
+
+
+async def check_container_swap_and_alert(config, dispatcher) -> None:
+    """Reconcile the container-swap invariant; alert on heal or failure.
+
+    Never raises into the tick. An unreadable signal (incus down, container
+    stopped, cgroup absent) is "no signal", not a defect — container-down is
+    the state machine's job, not this watch's.
+    """
+    if not getattr(config, "swap_reconcile_enabled", True):
+        return
+
+    container = config.container_name
+    healed: list[str] = []
+    problems: list[str] = []
+
+    # 1. Persistent knob. `incus config get` on an unset key returns rc=0 with
+    # empty output, so unset and explicit-false both land in the set branch.
+    try:
+        rc, stdout, _stderr = await _run_subprocess(
+            "incus",
+            "config",
+            "get",
+            container,
+            "limits.memory.swap",
+            timeout=_INCUS_TIMEOUT,
+        )
+    except Exception:
+        logger.warning("swap_watch: incus config get failed", exc_info=True)
+        rc, stdout = 1, ""
+    if rc == 0:
+        value = stdout.strip().lower()
+        if value != "true":
+            try:
+                rc_set, _out, err_set = await _run_subprocess(
+                    "incus",
+                    "config",
+                    "set",
+                    container,
+                    "limits.memory.swap",
+                    "true",
+                    timeout=_INCUS_TIMEOUT,
+                )
+            except Exception as exc:
+                rc_set, err_set = 1, str(exc)
+            if rc_set == 0:
+                healed.append(
+                    f"limits.memory.swap: {value or 'unset'} → true (persists across restarts)",
+                )
+            else:
+                problems.append(
+                    f"incus config set limits.memory.swap=true failed: {err_set.strip()}",
+                )
+    else:
+        logger.debug("swap_watch: no incus config signal (rc=%s)", rc)
+
+    # 2. Live cgroup. Only "0" is the defect; None = no signal (stopped
+    # container / cgroup v1), any other value already permits swap.
+    current = await read_swap_max(container)
+    if current == "0":
+        if await activate_swap_max(container):
+            healed.append("memory.swap.max: 0 → max (live, no restart needed)")
+        else:
+            problems.append(
+                "live cgroup write failed — swap stays off until the next "
+                "container start (config is set, so a restart will apply it)",
+            )
+
+    if healed:
+        logger.info("swap_watch healed: %s", "; ".join(healed))
+        await _send(
+            dispatcher,
+            AlertSeverity.INFO,
+            "Guardian enabled container swap",
+            "Container-swap invariant reconciled on "
+            f"'{container}':\n- "
+            + "\n- ".join(healed)
+            + "\n\nWithout this, a memory spike wedges the box into D-state "
+            "thrash instead of degrading into swap. If swap-off was "
+            "intentional, set swap_reconcile_enabled: false in guardian "
+            "config.",
+        )
+
+    if problems:
+        logger.warning("swap_watch problems: %s", "; ".join(problems))
+        now = datetime.now(UTC)
+        state_file = config.state_path / "swap_watch_state.json"
+        if _failure_alert_due(state_file, now):
+            await _send(
+                dispatcher,
+                AlertSeverity.WARNING,
+                "Container swap reconcile FAILED",
+                f"Guardian could not enforce the swap invariant on '{container}':\n- "
+                + "\n- ".join(problems),
+            )
+            _record_failure_alert(state_file, now)

--- a/src/genesis/guardian/swap_watch.py
+++ b/src/genesis/guardian/swap_watch.py
@@ -113,6 +113,7 @@ async def check_container_swap_and_alert(config, dispatcher) -> None:
     except Exception:
         logger.warning("swap_watch: incus config get failed", exc_info=True)
         rc, stdout = 1, ""
+    config_verified = rc == 0
     if rc == 0:
         value = stdout.strip().lower()
         if value != "true":
@@ -144,11 +145,25 @@ async def check_container_swap_and_alert(config, dispatcher) -> None:
     current = await read_swap_max(container)
     if current == "0":
         if await activate_swap_max(container):
-            healed.append("memory.swap.max: 0 → max (live, no restart needed)")
+            if config_verified:
+                healed.append("memory.swap.max: 0 → max (live, no restart needed)")
+            else:
+                # Live-healed, but the config read failed so the PERSISTENT knob
+                # was never verified/set — a restart can revert memory.swap.max
+                # to 0. Don't declare a clean "reconciled"; surface it so the
+                # persistent half gets fixed. (Config set failing outright
+                # already lands in problems above; this covers the read failing
+                # while the cgroup was still writable — e.g. an incus socket
+                # hiccup with the container running.)
+                problems.append(
+                    "activated swap live (memory.swap.max 0 → max) but could NOT "
+                    "verify the persistent limits.memory.swap knob (incus config "
+                    "read failed) — a container restart may revert swap to off",
+                )
         else:
             problems.append(
                 "live cgroup write failed — swap stays off until the next "
-                "container start (config is set, so a restart will apply it)",
+                "container start (set the persistent knob and restart to apply)",
             )
 
     if healed:

--- a/tests/test_guardian/test_swap_watch.py
+++ b/tests/test_guardian/test_swap_watch.py
@@ -41,6 +41,10 @@ def _subproc(responses):
 
     async def fake(*cmd, timeout=None):
         assert cmd[0] == "incus" and cmd[1] == "config"
+        if cmd[2] == "get":
+            # The get must read the EXPANDED config (profile-inherited true
+            # must not be treated as unset).
+            assert cmd[3] == "--expanded"
         fake.calls.append(cmd)
         return responses[cmd[2]]
 

--- a/tests/test_guardian/test_swap_watch.py
+++ b/tests/test_guardian/test_swap_watch.py
@@ -132,6 +132,26 @@ async def test_live_zero_activates_and_info_alerts(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_live_heal_with_unverified_config_warns_not_info(tmp_path):
+    """config read fails but the cgroup is still writable and at 0: activating
+    live must NOT claim a clean reconcile — the persistent knob is unverified
+    and a restart can revert swap to off, so this pages a WARNING, not INFO."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (1, "", "socket error")})  # config read fails
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="0")),
+        patch.object(swap_watch, "activate_swap_max", AsyncMock(return_value=True)),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert [c[2] for c in sp.calls] == ["get"]  # no set attempted (read failed)
+    assert _sent_severities(d) == [AlertSeverity.WARNING]
+    body = d.send.call_args.args[0].body
+    assert "persistent" in body and "revert" in body
+
+
+@pytest.mark.asyncio
 async def test_live_write_failure_warns_once_then_throttles(tmp_path):
     """A failed heal pages WARNING, but not again inside the throttle window."""
     cfg = _Cfg(tmp_path)

--- a/tests/test_guardian/test_swap_watch.py
+++ b/tests/test_guardian/test_swap_watch.py
@@ -1,0 +1,291 @@
+"""Tests for the guardian-side container-swap reconciler (swap_watch).
+
+The guardian re-asserts the swap invariant on observed state each tick:
+persistent ``incus config`` knob + live cgroup ``memory.swap.max``. Healthy
+path must be read-only and silent; heals emit one INFO alert; failures emit a
+throttled WARNING; an unreadable signal is NO signal. Subprocess and cgroup
+primitives are mocked at the swap_watch/cgroup_ops seams.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.guardian import cgroup_ops, swap_watch
+from genesis.guardian.alert.base import AlertSeverity
+
+
+class _Cfg:
+    """Minimal config stub exposing what swap_watch reads."""
+
+    def __init__(self, tmp_path, enabled=True):
+        self.container_name = "genesis"
+        self.swap_reconcile_enabled = enabled
+        self._sp = tmp_path
+
+    @property
+    def state_path(self):
+        return self._sp
+
+
+def _subproc(responses):
+    """Build a _run_subprocess mock keyed on the subcommand ('get'/'set').
+
+    ``responses`` maps 'get'/'set' → (rc, stdout, stderr). Records calls on
+    the returned mock's ``calls`` list.
+    """
+
+    async def fake(*cmd, timeout=None):
+        assert cmd[0] == "incus" and cmd[1] == "config"
+        fake.calls.append(cmd)
+        return responses[cmd[2]]
+
+    fake.calls = []
+    return fake
+
+
+def _dispatcher():
+    d = AsyncMock()
+    d.send = AsyncMock()
+    return d
+
+
+def _sent_severities(dispatcher):
+    return [call.args[0].severity for call in dispatcher.send.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_healthy_path_is_readonly_and_silent(tmp_path):
+    """Knob true + cgroup already max → no writes, no alerts."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "true\n", "")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="max")),
+        patch.object(swap_watch, "activate_swap_max", AsyncMock()) as act,
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert [c[2] for c in sp.calls] == ["get"]  # read-only: no config set
+    act.assert_not_awaited()
+    d.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unset_knob_is_set_and_info_alerted(tmp_path):
+    """`incus config get` on an unset key: rc=0, empty output → config set."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "", ""), "set": (0, "", "")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="max")),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert [c[2] for c in sp.calls] == ["get", "set"]
+    set_cmd = sp.calls[1]
+    assert set_cmd[3:] == ("genesis", "limits.memory.swap", "true")
+    assert _sent_severities(d) == [AlertSeverity.INFO]
+    assert "limits.memory.swap" in d.send.call_args.args[0].body
+
+
+@pytest.mark.asyncio
+async def test_explicit_false_knob_is_reconciled(tmp_path):
+    """Deliberate-override semantics: false → true (invariant wins; kill
+    switch is the opt-out, documented in the alert body)."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "false\n", ""), "set": (0, "", "")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="max")),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert [c[2] for c in sp.calls] == ["get", "set"]
+    assert "swap_reconcile_enabled" in d.send.call_args.args[0].body
+
+
+@pytest.mark.asyncio
+async def test_live_zero_activates_and_info_alerts(tmp_path):
+    """The sibling incident state: knob true but live cgroup still 0."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "true", "")})
+    act = AsyncMock(return_value=True)
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="0")),
+        patch.object(swap_watch, "activate_swap_max", act),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    act.assert_awaited_once_with("genesis")
+    assert _sent_severities(d) == [AlertSeverity.INFO]
+    assert "live" in d.send.call_args.args[0].body
+
+
+@pytest.mark.asyncio
+async def test_live_write_failure_warns_once_then_throttles(tmp_path):
+    """A failed heal pages WARNING, but not again inside the throttle window."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "true", "")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="0")),
+        patch.object(swap_watch, "activate_swap_max", AsyncMock(return_value=False)),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert _sent_severities(d) == [AlertSeverity.WARNING]  # one, not two
+    # After the window elapses, it re-pages.
+    stale = datetime.now(UTC) - timedelta(hours=swap_watch._REALERT_HOURS + 1)
+    (tmp_path / "swap_watch_state.json").write_text(
+        json.dumps({"last_failure_alert_at": stale.isoformat()}),
+    )
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="0")),
+        patch.object(swap_watch, "activate_swap_max", AsyncMock(return_value=False)),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert _sent_severities(d) == [AlertSeverity.WARNING, AlertSeverity.WARNING]
+
+
+@pytest.mark.asyncio
+async def test_config_set_failure_warns(tmp_path):
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "", ""), "set": (1, "", "boom")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="max")),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert _sent_severities(d) == [AlertSeverity.WARNING]
+    assert "boom" in d.send.call_args.args[0].body
+
+
+@pytest.mark.asyncio
+async def test_incus_unreachable_is_no_signal(tmp_path):
+    """config get rc!=0 → no set attempt, no alert (state machine's job)."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (1, "", "connection refused")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value=None)),
+        patch.object(swap_watch, "activate_swap_max", AsyncMock()) as act,
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    assert [c[2] for c in sp.calls] == ["get"]
+    act.assert_not_awaited()
+    d.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unreadable_cgroup_skips_live_half(tmp_path):
+    """read_swap_max None (stopped container / cgroup v1) → no live write."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    sp = _subproc({"get": (0, "true", "")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value=None)),
+        patch.object(swap_watch, "activate_swap_max", AsyncMock()) as act,
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    act.assert_not_awaited()
+    d.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_disables_everything(tmp_path):
+    cfg = _Cfg(tmp_path, enabled=False)
+    d = _dispatcher()
+    with (
+        patch.object(swap_watch, "_run_subprocess", AsyncMock()) as sp,
+        patch.object(swap_watch, "read_swap_max", AsyncMock()) as rd,
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)
+    sp.assert_not_awaited()
+    rd.assert_not_awaited()
+    d.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failure_never_raises(tmp_path):
+    """A dead dispatcher must not break the reconcile (heal still happened)."""
+    cfg = _Cfg(tmp_path)
+    d = _dispatcher()
+    d.send.side_effect = RuntimeError("transport down")
+    sp = _subproc({"get": (0, "", ""), "set": (0, "", "")})
+    with (
+        patch.object(swap_watch, "_run_subprocess", sp),
+        patch.object(swap_watch, "read_swap_max", AsyncMock(return_value="max")),
+    ):
+        await swap_watch.check_container_swap_and_alert(cfg, d)  # no raise
+    assert [c[2] for c in sp.calls] == ["get", "set"]
+
+
+# ── cgroup primitives ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_read_swap_max_reads_via_sudo():
+    async def fake(*cmd, timeout=None):
+        assert cmd[:2] == ("sudo", "cat")
+        assert cmd[2].endswith("lxc.payload.genesis/memory.swap.max")
+        return (0, "0\n", "")
+
+    with patch.object(cgroup_ops, "_run_subprocess", fake):
+        assert await cgroup_ops.read_swap_max("genesis") == "0"
+
+
+@pytest.mark.asyncio
+async def test_read_swap_max_failure_is_none():
+    with patch.object(
+        cgroup_ops,
+        "_run_subprocess",
+        AsyncMock(return_value=(1, "", "denied")),
+    ):
+        assert await cgroup_ops.read_swap_max("genesis") is None
+
+
+@pytest.mark.asyncio
+async def test_activate_swap_max_writes_max_via_sudo():
+    async def fake(*cmd, timeout=None):
+        assert cmd[:3] == ("sudo", "sh", "-c")
+        assert "echo max >" in cmd[3]
+        assert "lxc.payload.genesis/memory.swap.max" in cmd[3]
+        return (0, "", "")
+
+    with patch.object(cgroup_ops, "_run_subprocess", fake):
+        assert await cgroup_ops.activate_swap_max("genesis") is True
+
+
+@pytest.mark.asyncio
+async def test_activate_swap_max_failure_is_false():
+    with patch.object(
+        cgroup_ops,
+        "_run_subprocess",
+        AsyncMock(return_value=(1, "", "denied")),
+    ):
+        assert await cgroup_ops.activate_swap_max("genesis") is False
+
+
+# ── wiring ─────────────────────────────────────────────────────────────────
+
+
+def test_run_check_wires_the_watch():
+    """The reconciler is dead unless run_check actually calls it."""
+    from pathlib import Path
+
+    import genesis.guardian.check as check_mod
+
+    text = Path(check_mod.__file__).read_text()
+    assert "await _check_container_swap_and_alert(config, dispatcher)" in text
+    assert "from genesis.guardian.swap_watch import check_container_swap_and_alert" in text


### PR DESCRIPTION
## What

The guardian now keeps `limits.memory.swap` enabled on its own — re-asserting the persistent incus config knob **and** live-activating the cgroup each tick when it observes drift.

## Why

Swap is what turns a memory spike into graceful slowdown instead of a machine-wedging D-state thrash. But `limits.memory.swap=true` is only applied by `host-setup.sh` — at container creation or a manual re-run. An install that advances via bare `git pull` never re-runs host-setup, so the knob (and the live cgroup `memory.swap.max`) can sit at `0` indefinitely — one memory spike away from the wedge, silently. Observed live on a second install that ran for weeks in exactly this state.

`#1079` fixed the *live-activation* half at setup time (`scripts/lib/container_swap.sh`); this closes the gap for boxes that never re-run setup, by making the guardian — the only component with continuous host-side incus + sudo access — reconcile the invariant.

## How

- `src/genesis/guardian/swap_watch.py` (new): per-tick reconcile on **observed** state:
  1. **Persistent** — `incus config get --expanded` != `true` → `incus config set` (covers unset AND explicit false; `--expanded` so a profile-inherited true isn't misread as unset).
  2. **Live** — cgroup `memory.swap.max == "0"` → write `max` now (what incus does at container start).
- `src/genesis/guardian/cgroup_ops.py`: two new host-side primitives (`read_swap_max`, `activate_swap_max`) mirroring the existing `relieve_io_max` sudo/cgroup pattern.
- `src/genesis/guardian/check.py`: wired into `run_check` via the never-raises delegate-wrapper pattern (same shape as the git/cred/bundle watches).
- `config.py`: `swap_reconcile_enabled` kill switch (an explicitly-false knob is otherwise reconciled back to true — swap-on is the install invariant).

**Alerting:** the healthy path is two reads, no writes, no alerts. A heal pages one **INFO** note (guardian self-actions stay visible); a heal that can't complete pages a **WARNING** throttled to once/24h (the `memory_watch` state-file idiom).

Also hardens `memory_watch`'s identical throttle-parse idiom to catch corrupted-state exceptions (review parity).

## Tests / verification

- `tests/test_guardian/test_swap_watch.py` (new, 16 cases): unset/false/error config paths, live-zero heal, throttled-failure re-page, kill switch, no-signal degradation, dispatch-failure containment, cgroup primitives, run_check wiring. Full guardian suite green (91 passing across swap/check/config/memory).
- **E2E on real infrastructure:** healthy-path no-op verified against live incus + sudo; heal-path drilled by injecting the incident state (`swap.max=0`) and confirming the real module live-heals it to `max` with exactly one correct INFO alert.

## Deploy note

Touches host-deployed guardian paths (`src/genesis/guardian/`), so it is **not live at merge** — it reaches the host only via `scripts/update.sh`. Will deploy + verify on both machines post-merge per the host-deploy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)