### PR TITLE
fix(awareness): git alerts self-heal on recovery + stop surplus amplifying infra alerts

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -191,8 +191,15 @@ Note: the *learning* package hosts the other big scheduler (see entry 10).
 ```yaml subsystem-map
 entry: scheduling-background
 modules: [surplus, scheduler, follow_ups]
-verified: d8d9b5e4 2026-07-09
+verified: 3403599d 2026-07-16
 ```
+
+- **Surplus generators are deliberately BLIND to `infrastructure_alert`
+  observations (2026-07-16)**: `_gather_context` excludes them so a stale/
+  unverified infra critical can never be amplified into an autonomous
+  "self-unblock" action (the git-corruption false alarm). Infra problems
+  reach the user via guardian/health-alerts/morning-report — not surplus
+  brainstorming. Don't "fix" the missing context.
 
 - `surplus/scheduler.py` (~790 LOC) is the system-job hub (dream cycle, recon,
   pipeline cycles, maintenance, code index, model evals…); job bodies
@@ -395,8 +402,16 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 47e7a132 2026-07-15
+verified: 3403599d 2026-07-16
 ```
+
+- **Git-health alerts self-heal, slot-scoped (2026-07-16)**: the per-tick cheap
+  probe auto-resolves open `git_cheap` observations on pass; the daily deep
+  fsck auto-resolves `git_deep` only (fsck READS — a passing fsck must never
+  clear a live `rootfs_readonly` cheap alert). Creates carry
+  `skip_if_duplicate=True` (atomic INSERT…WHERE NOT EXISTS — the only guard
+  that works across concurrent loops). Probe sensitivity is deliberately
+  single-failure; do not add consecutive-failure gating.
 
 - **awareness/**: the 5-min heartbeat. ~23 signal collectors (the richer
   `learning/signals/*` set REPLACES the bootstrap placeholders in

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -877,7 +877,28 @@ async def _check_git_health(db) -> None:
         logger.debug("git health probe failed", exc_info=True)
         return
 
-    if report.ok or db is None:
+    if report.ok:
+        # Self-heal: a passing structural probe clears any open cheap-scan
+        # alert so a transient failure can't sit as a stale critical and be
+        # amplified later (the 2026-07-16 false "git corruption" alarm).
+        # Scoped to category="git_cheap" — a structural pass says nothing
+        # about content integrity, so deep (fsck) alerts must survive it.
+        if db is not None:
+            try:
+                healed = await observations.resolve_by_source_and_type(
+                    db,
+                    source="git_health_monitor",
+                    type="infrastructure_alert",
+                    category="git_cheap",
+                    resolved_at=datetime.now(UTC).isoformat(),
+                    resolution_notes="auto-resolved: cheap git probe passed",
+                )
+                if healed:
+                    logger.info("git health recovered: resolved %d cheap alert(s)", healed)
+            except Exception:
+                logger.debug("git health auto-resolve failed", exc_info=True)
+        return
+    if db is None:
         return
     now = time.monotonic()
     if _last_git_alert_at is not None and now - _last_git_alert_at < _GIT_ALERT_COOLDOWN_S:
@@ -887,11 +908,18 @@ async def _check_git_health(db) -> None:
     _last_git_alert_at = now
     failures = ", ".join(report.failures)
     try:
-        await observations.create(
+        created = await observations.create(
             db,
             id=str(uuid.uuid4()),
             source="git_health_monitor",
             type="infrastructure_alert",
+            # category tags the scan slot so recovery is slot-scoped (see the
+            # report.ok branch above); skip_if_duplicate is the DB-level dedup
+            # AND the only cross-process guard — two concurrent awareness
+            # loops share the DB, so an in-memory cooldown can't stop the
+            # second one (it double-fired 12 min apart on 2026-07-15).
+            category="git_cheap",
+            skip_if_duplicate=True,
             content=(
                 f"Local git repository is UNHEALTHY ({failures}). This disables the "
                 f"guardian's REVERT_CODE recovery lever, which needs a healthy local "
@@ -903,7 +931,10 @@ async def _check_git_health(db) -> None:
             priority="critical",
             created_at=datetime.now(UTC).isoformat(),
         )
-        logger.error("git health alert: %s", failures)
+        if created:
+            logger.error("git health alert: %s", failures)
+        else:
+            logger.debug("git health alert suppressed (duplicate unresolved): %s", failures)
     except Exception:
         logger.debug("Failed to create git health alert observation", exc_info=True)
 
@@ -942,15 +973,43 @@ async def _check_git_health_deep(db) -> None:
         logger.debug("git deep-health scan failed", exc_info=True)
         return
 
-    if report.ok or db is None:
+    if report.ok:
+        # Self-heal: a passing content-verifying fsck clears EVERY open git
+        # alert — cheap, deep, and legacy pre-category rows alike (unscoped
+        # resolve). The verdict file already self-heals per slot; without
+        # this, the observations outlive recovery as stale criticals and get
+        # amplified into false actions (2026-07-16 "git corruption" alarm,
+        # seeded by a transient fsck race across ~112 worktrees).
+        if db is not None:
+            try:
+                healed = await observations.resolve_by_source_and_type(
+                    db,
+                    source="git_health_monitor",
+                    type="infrastructure_alert",
+                    resolved_at=datetime.now(UTC).isoformat(),
+                    resolution_notes="auto-resolved: git fsck --full passed",
+                )
+                if healed:
+                    logger.info("git deep-health recovered: resolved %d alert(s)", healed)
+            except Exception:
+                logger.debug("git deep-health auto-resolve failed", exc_info=True)
+        return
+    if db is None:
         return
     failures = ", ".join(report.failures)
     try:
-        await observations.create(
+        created = await observations.create(
             db,
             id=str(uuid.uuid4()),
             source="git_health_monitor",
             type="infrastructure_alert",
+            # Slot tag + DB-level dedup (the only cross-process guard; see
+            # the cheap-probe counterpart above). NOTE deliberately NO extra
+            # alert cooldown here: the 24h run-interval already bounds this
+            # path to one alert per process-day, and probe sensitivity must
+            # stay unchanged — recovery hygiene, not detection damping.
+            category="git_deep",
+            skip_if_duplicate=True,
             content=(
                 f"`git fsck --full` reported problems ({failures}) — objects are "
                 "missing or corrupt (incl. zeroed-but-present blobs), which disables "
@@ -960,7 +1019,10 @@ async def _check_git_health_deep(db) -> None:
             priority="critical",
             created_at=datetime.now(UTC).isoformat(),
         )
-        logger.error("git deep-health alert: %s", failures)
+        if created:
+            logger.error("git deep-health alert: %s", failures)
+        else:
+            logger.debug("git deep-health alert suppressed (duplicate unresolved): %s", failures)
     except Exception:
         logger.debug("Failed to create git deep-health observation", exc_info=True)
 

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -974,18 +974,23 @@ async def _check_git_health_deep(db) -> None:
         return
 
     if report.ok:
-        # Self-heal: a passing content-verifying fsck clears EVERY open git
-        # alert — cheap, deep, and legacy pre-category rows alike (unscoped
-        # resolve). The verdict file already self-heals per slot; without
-        # this, the observations outlive recovery as stale criticals and get
-        # amplified into false actions (2026-07-16 "git corruption" alarm,
-        # seeded by a transient fsck race across ~112 worktrees).
+        # Self-heal: a passing content-verifying fsck clears open DEEP alerts
+        # (category="git_deep" only). The verdict file already self-heals per
+        # slot; without this, the observations outlive recovery as stale
+        # criticals and get amplified into false actions (2026-07-16 "git
+        # corruption" alarm, seeded by a transient fsck race across ~112
+        # worktrees). Deliberately NOT unscoped: fsck only READS the object
+        # store, so a passing fsck proves nothing about cheap-probe failures
+        # like rootfs_readonly — clearing those here would silence a live
+        # incident for the 6h cheap cooldown (Codex P1, PR #1085). Cheap
+        # alerts self-heal via the per-tick cheap probe instead.
         if db is not None:
             try:
                 healed = await observations.resolve_by_source_and_type(
                     db,
                     source="git_health_monitor",
                     type="infrastructure_alert",
+                    category="git_deep",
                     resolved_at=datetime.now(UTC).isoformat(),
                     resolution_notes="auto-resolved: git fsck --full passed",
                 )

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -227,17 +227,6 @@ async def create(
     if content_hash is None and content and content.strip():
         content_hash = hashlib.sha256(content.encode()).hexdigest()
 
-    # Dedup gate: skip if identical unresolved observation exists
-    if (
-        skip_if_duplicate
-        and content_hash is not None
-        and await exists_by_hash(db, source=source, content_hash=content_hash, unresolved_only=True)
-    ):
-        logger.debug(
-            "Observation dedup: skipping duplicate (source=%s, hash=%s)", source, content_hash[:12]
-        )
-        return None
-
     # Auto-TTL: compute expires_at if not explicitly provided
     if expires_at is None:
         ttl = _compute_ttl(type)
@@ -251,25 +240,54 @@ async def create(
             except (ValueError, TypeError):
                 pass  # Invalid created_at — skip TTL, don't fail the write
 
+    params = (
+        id,
+        person_id,
+        source,
+        type,
+        category,
+        content,
+        priority,
+        speculative,
+        created_at,
+        expires_at,
+        content_hash,
+        origin_class,
+    )
+
+    if skip_if_duplicate and content_hash is not None:
+        # Atomic dedup: one INSERT … WHERE NOT EXISTS statement. A separate
+        # SELECT-then-INSERT is NOT a cross-process guard — two writers can
+        # both pass the check before either commits. SQLite serializes
+        # writers, so a single statement is race-free without needing a
+        # schema-level unique index (which would change semantics for every
+        # other observation writer).
+        cursor = await db.execute(
+            """INSERT INTO observations
+               (id, person_id, source, type, category, content, priority,
+                speculative, created_at, expires_at, content_hash, origin_class)
+               SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+               WHERE NOT EXISTS (
+                   SELECT 1 FROM observations
+                   WHERE source = ? AND content_hash = ? AND resolved = 0
+               )""",
+            (*params, source, content_hash),
+        )
+        await db.commit()
+        if cursor.rowcount == 0:
+            logger.debug(
+                "Observation dedup: skipping duplicate (source=%s, hash=%s)",
+                source, content_hash[:12],
+            )
+            return None
+        return id
+
     await db.execute(
         """INSERT INTO observations
            (id, person_id, source, type, category, content, priority,
             speculative, created_at, expires_at, content_hash, origin_class)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (
-            id,
-            person_id,
-            source,
-            type,
-            category,
-            content,
-            priority,
-            speculative,
-            created_at,
-            expires_at,
-            content_hash,
-            origin_class,
-        ),
+        params,
     )
     await db.commit()
     return id

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -625,17 +625,29 @@ async def resolve_by_source_and_type(
     type: str,
     resolved_at: str,
     resolution_notes: str,
+    category: str | None = None,
 ) -> int:
     """Resolve all unresolved observations matching a source + type pair.
 
+    ``category`` optionally narrows the resolve to rows with that exact
+    category (rows with a NULL/other category are left open). Used for
+    slot-scoped self-healing — e.g. a passing cheap git probe clears only
+    ``git_cheap`` alerts, never a deep content-corruption alert. Omit it to
+    clear every matching row regardless of category (including legacy
+    NULL-category rows).
+
     Returns the number of rows resolved.
     """
-    cursor = await db.execute(
+    sql = (
         "UPDATE observations SET resolved = 1, resolved_at = ?, "
         "resolution_notes = ? "
-        "WHERE source = ? AND type = ? AND resolved = 0",
-        (resolved_at, resolution_notes, source, type),
+        "WHERE source = ? AND type = ? AND resolved = 0"
     )
+    params: list[str] = [resolved_at, resolution_notes, source, type]
+    if category is not None:
+        sql += " AND category = ?"
+        params.append(category)
+    cursor = await db.execute(sql, params)
     await db.commit()
     return cursor.rowcount
 

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -768,10 +768,16 @@ class SurplusLLMExecutor:
                     parts.append("\n## User Profile")
                     parts.append(user_model)
 
-        # For analytical tasks: recent observations + basic stats
+        # For analytical tasks: recent observations + basic stats.
+        # infrastructure_alert is excluded: operational infra criticals have
+        # their own handling paths (guardian, health alerts, morning report)
+        # and must never be amplified by a generator into an autonomous
+        # "self-unblock" action — a stale git-corruption alert did exactly
+        # that on 2026-07-16 (false alarm, messaged to the user as fact).
         try:
             recent_obs = await observations.query(
                 self._db, resolved=False, limit=10,
+                exclude_types=("infrastructure_alert",),
             )
             if recent_obs:
                 parts.append("## Recent Unresolved Observations")

--- a/tests/test_awareness/test_git_health_check.py
+++ b/tests/test_awareness/test_git_health_check.py
@@ -209,3 +209,135 @@ class TestDeepCheck:
             git_health, "check_git_deep", AsyncMock(side_effect=RuntimeError("boom"))
         )
         await loop._check_git_health_deep(object())  # swallowed — never breaks the tick
+
+
+# ── Self-healing + dedup (git false-alarm fix) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cheap_pass_auto_resolves_cheap_alerts_only(monkeypatch):
+    monkeypatch.setattr(git_health, "check_git_cheap", AsyncMock(return_value=_report(True)))
+    monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+    resolve = AsyncMock(return_value=1)
+    monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
+
+    await loop._check_git_health(object())
+
+    resolve.assert_awaited_once()
+    kw = resolve.call_args.kwargs
+    assert kw["source"] == "git_health_monitor"
+    assert kw["type"] == "infrastructure_alert"
+    # A passing structural probe clears ONLY cheap-scan alerts — it cannot
+    # verify content integrity, so deep alerts must survive it.
+    assert kw["category"] == "git_cheap"
+
+
+@pytest.mark.asyncio
+async def test_cheap_pass_none_db_skips_resolve(monkeypatch):
+    monkeypatch.setattr(git_health, "check_git_cheap", AsyncMock(return_value=_report(True)))
+    monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+    resolve = AsyncMock()
+    monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
+
+    await loop._check_git_health(None)
+
+    resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cheap_alert_carries_category_and_dedup(monkeypatch):
+    monkeypatch.setattr(
+        git_health, "check_git_cheap", AsyncMock(return_value=_report(False, ["config_invalid"]))
+    )
+    monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+    obs = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", obs)
+
+    await loop._check_git_health(object())
+
+    kw = obs.call_args.kwargs
+    assert kw["category"] == "git_cheap"
+    # DB-level dedup: identical unresolved alerts must not stack (also the
+    # only cross-process guard — two concurrent loops share the DB).
+    assert kw["skip_if_duplicate"] is True
+
+
+@pytest.mark.asyncio
+async def test_cheap_resolve_error_never_raises(monkeypatch):
+    monkeypatch.setattr(git_health, "check_git_cheap", AsyncMock(return_value=_report(True)))
+    monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+    monkeypatch.setattr(
+        loop.observations,
+        "resolve_by_source_and_type",
+        AsyncMock(side_effect=RuntimeError("db locked")),
+    )
+
+    # Auto-resolve failure must never break the tick.
+    await loop._check_git_health(object())
+
+
+class TestDeepSelfHeal:
+    """Deep-scan pass resolves ALL open git alerts (deep verifies content)."""
+
+    @pytest.mark.asyncio
+    async def test_deep_pass_auto_resolves_all_git_alerts(self, monkeypatch):
+        monkeypatch.setattr(
+            git_health, "check_git_deep", AsyncMock(return_value=_deep_report(True))
+        )
+        monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+        resolve = AsyncMock(return_value=2)
+        monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
+
+        await loop._check_git_health_deep(object())
+
+        resolve.assert_awaited_once()
+        kw = resolve.call_args.kwargs
+        assert kw["source"] == "git_health_monitor"
+        assert kw["type"] == "infrastructure_alert"
+        # Unscoped: a content-verifying pass clears cheap + deep + legacy
+        # (pre-category) alerts alike.
+        assert "category" not in kw
+
+    @pytest.mark.asyncio
+    async def test_deep_pass_none_db_skips_resolve(self, monkeypatch):
+        monkeypatch.setattr(
+            git_health, "check_git_deep", AsyncMock(return_value=_deep_report(True))
+        )
+        monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+        resolve = AsyncMock()
+        monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
+
+        await loop._check_git_health_deep(None)
+
+        resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deep_alert_carries_category_and_dedup(self, monkeypatch):
+        monkeypatch.setattr(
+            git_health,
+            "check_git_deep",
+            AsyncMock(return_value=_deep_report(False, ["fsck_failed"])),
+        )
+        monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+        obs = AsyncMock()
+        monkeypatch.setattr(loop.observations, "create", obs)
+
+        await loop._check_git_health_deep(object())
+
+        kw = obs.call_args.kwargs
+        assert kw["category"] == "git_deep"
+        assert kw["skip_if_duplicate"] is True
+
+    @pytest.mark.asyncio
+    async def test_deep_resolve_error_never_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            git_health, "check_git_deep", AsyncMock(return_value=_deep_report(True))
+        )
+        monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+        monkeypatch.setattr(
+            loop.observations,
+            "resolve_by_source_and_type",
+            AsyncMock(side_effect=RuntimeError("db locked")),
+        )
+
+        await loop._check_git_health_deep(object())

--- a/tests/test_awareness/test_git_health_check.py
+++ b/tests/test_awareness/test_git_health_check.py
@@ -277,15 +277,16 @@ async def test_cheap_resolve_error_never_raises(monkeypatch):
 
 
 class TestDeepSelfHeal:
-    """Deep-scan pass resolves ALL open git alerts (deep verifies content)."""
+    """Deep-scan pass resolves open DEEP alerts only (fsck verifies content;
+    it proves nothing about cheap-probe failures like rootfs_readonly)."""
 
     @pytest.mark.asyncio
-    async def test_deep_pass_auto_resolves_all_git_alerts(self, monkeypatch):
+    async def test_deep_pass_auto_resolves_deep_alerts_only(self, monkeypatch):
         monkeypatch.setattr(
             git_health, "check_git_deep", AsyncMock(return_value=_deep_report(True))
         )
         monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
-        resolve = AsyncMock(return_value=2)
+        resolve = AsyncMock(return_value=1)
         monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
 
         await loop._check_git_health_deep(object())
@@ -294,9 +295,9 @@ class TestDeepSelfHeal:
         kw = resolve.call_args.kwargs
         assert kw["source"] == "git_health_monitor"
         assert kw["type"] == "infrastructure_alert"
-        # Unscoped: a content-verifying pass clears cheap + deep + legacy
-        # (pre-category) alerts alike.
-        assert "category" not in kw
+        # Scoped: fsck only READS the object store — a passing fsck must not
+        # clear a live rootfs_readonly / structural cheap alert (Codex P1).
+        assert kw["category"] == "git_deep"
 
     @pytest.mark.asyncio
     async def test_deep_pass_none_db_skips_resolve(self, monkeypatch):

--- a/tests/test_db/test_observations.py
+++ b/tests/test_db/test_observations.py
@@ -333,3 +333,59 @@ def test_process_reaper_would_kill_ttl_registered(caplog):
     assert not any("Unknown observation type" in r.getMessage() for r in caplog.records), (
         "a registered type must not trigger the unknown-type warning"
     )
+
+
+_GIT_ALERT = dict(
+    source="git_health_monitor",
+    type="infrastructure_alert",
+    content="git alert",
+    priority="critical",
+    created_at="2026-01-01T00:00:00",
+)
+
+
+async def test_resolve_by_source_and_type_category_scoped(db):
+    # cheap-scan alert, deep-scan alert, and a legacy row with NULL category
+    await observations.create(db, id="g1", **{**_GIT_ALERT, "category": "git_cheap"})
+    await observations.create(
+        db, id="g2", **{**_GIT_ALERT, "category": "git_deep", "content": "deep alert"}
+    )
+    await observations.create(db, id="g3", **{**_GIT_ALERT, "content": "legacy alert"})
+
+    n = await observations.resolve_by_source_and_type(
+        db,
+        source="git_health_monitor",
+        type="infrastructure_alert",
+        category="git_cheap",
+        resolved_at="2026-01-02T00:00:00",
+        resolution_notes="cheap probe passed",
+    )
+
+    # Only the matching-category row resolves; deep + legacy NULL stay open
+    # (a passing structural probe must never clear a content-corruption alert).
+    assert n == 1
+    assert (await observations.get_by_id(db, "g1"))["resolved"] == 1
+    assert (await observations.get_by_id(db, "g2"))["resolved"] == 0
+    assert (await observations.get_by_id(db, "g3"))["resolved"] == 0
+
+
+async def test_resolve_by_source_and_type_unscoped_clears_all_categories(db):
+    await observations.create(db, id="g4", **{**_GIT_ALERT, "category": "git_cheap"})
+    await observations.create(
+        db, id="g5", **{**_GIT_ALERT, "category": "git_deep", "content": "deep alert"}
+    )
+    await observations.create(db, id="g6", **{**_GIT_ALERT, "content": "legacy alert"})
+
+    n = await observations.resolve_by_source_and_type(
+        db,
+        source="git_health_monitor",
+        type="infrastructure_alert",
+        resolved_at="2026-01-02T00:00:00",
+        resolution_notes="deep fsck passed",
+    )
+
+    # Unscoped (deep-verified) resolve clears every open git alert,
+    # including pre-category legacy rows.
+    assert n == 3
+    for oid in ("g4", "g5", "g6"):
+        assert (await observations.get_by_id(db, oid))["resolved"] == 1

--- a/tests/test_db/test_observations.py
+++ b/tests/test_db/test_observations.py
@@ -389,3 +389,32 @@ async def test_resolve_by_source_and_type_unscoped_clears_all_categories(db):
     assert n == 3
     for oid in ("g4", "g5", "g6"):
         assert (await observations.get_by_id(db, oid))["resolved"] == 1
+
+
+async def test_skip_if_duplicate_is_atomic_single_statement(db):
+    """The dedup INSERT must be one INSERT…WHERE NOT EXISTS statement, not a
+    SELECT-then-INSERT — two processes can both pass a separate pre-check
+    before either commits (Codex P2, PR #1085). With the atomic form, the
+    second insert is a no-op regardless of interleaving."""
+    r1 = await observations.create(
+        db, id="atomic1", skip_if_duplicate=True, **_GIT_ALERT
+    )
+    r2 = await observations.create(
+        db, id="atomic2", skip_if_duplicate=True, **_GIT_ALERT
+    )
+    assert r1 == "atomic1"
+    assert r2 is None  # duplicate skipped
+    cur = await db.execute(
+        "SELECT count(*) FROM observations WHERE source = 'git_health_monitor'"
+    )
+    assert (await cur.fetchone())[0] == 1
+
+    # After the first is resolved, an identical alert may be created again
+    # (a recurrence after recovery is a NEW incident, not a duplicate).
+    await observations.resolve(
+        db, "atomic1", resolved_at="2026-01-02", resolution_notes="recovered"
+    )
+    r3 = await observations.create(
+        db, id="atomic3", skip_if_duplicate=True, **_GIT_ALERT
+    )
+    assert r3 == "atomic3"

--- a/tests/test_surplus/test_executor.py
+++ b/tests/test_surplus/test_executor.py
@@ -586,3 +586,32 @@ async def test_graceful_fallback_when_both_sources_fail():
     assert "test observation" in prompt
     assert "System Context" not in prompt
     assert "User Profile" not in prompt
+
+
+# 11. Infra alerts are excluded from surplus context — unverified/stale
+# infrastructure criticals must never be amplified into autonomous
+# "self-unblock" actions (2026-07-16 git-corruption false alarm).
+@pytest.mark.asyncio
+async def test_gather_context_excludes_infrastructure_alerts():
+    executor = _make_llm_executor()
+    task = _make_task(task_type=TaskType.SELF_UNBLOCK)
+
+    with patch(
+        "genesis.surplus.executor.observations.query",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as q:
+        await executor._gather_context(task)
+
+    # The recent-unresolved-observations query (the one without a type filter)
+    # must exclude infrastructure_alert.
+    recent_calls = [c for c in q.call_args_list if "type" not in c.kwargs]
+    assert recent_calls, "recent-observations query not issued"
+    for c in recent_calls:
+        assert "infrastructure_alert" in (c.kwargs.get("exclude_types") or ())
+
+    # ...and the typed past-findings query is NOT excluded (its type filter is
+    # the surplus task type, never infrastructure_alert — no exclusion needed).
+    typed_calls = [c for c in q.call_args_list if "type" in c.kwargs]
+    for c in typed_calls:
+        assert "exclude_types" not in c.kwargs


### PR DESCRIPTION
## Problem

The 2026-07-16 false "git repository corrupt" alarm: a transient `git fsck --full` non-zero (race across ~112 worktrees; the repo was clean before and after) created CRITICAL `git_health_monitor` observations that never resolved. The shared-mount verdict file self-heals per slot, but the observations didn't — and two concurrent awareness loops created two identical criticals 12 minutes apart (no dedup). Hours later the surplus self-unblock generator pulled the stale rows from its unresolved-observations context and amplified them into a false "repair the corrupt repo" action, messaged to the user as fact.

## Fix (amplifier-side; probe sensitivity deliberately UNCHANGED)

1. **Self-heal on pass** — a passing cheap probe auto-resolves open `git_cheap` alerts; a passing deep fsck auto-resolves open **`git_deep` alerts only** (`resolve_by_source_and_type` grows an optional `category` filter). Scoping matters in both directions: a structural pass can't verify content, and fsck only *reads* — a passing fsck must not clear a live `rootfs_readonly` cheap alert (Codex P1, fixed in-review). Prod has zero unresolved legacy NULL-category rows, so no legacy path is needed.
2. **Cross-process dedup** — git alert creates pass `skip_if_duplicate=True`, and the dedup path is now a single atomic `INSERT … WHERE NOT EXISTS` (Codex P2: SELECT-then-INSERT isn't a cross-process guard). Chose atomicity over a schema-level unique index to avoid changing semantics for other observation writers. Alert log fires only on actual insert.
3. **Amplification cut** — the surplus generator context excludes `type="infrastructure_alert"`: operational infra criticals have their own handling paths (guardian, health alerts, morning report) and must never become autonomous "self-unblock" actions.

**Deliberately NOT added:** consecutive-failure gating or a deep-path alert cooldown — the probe stays single-failure sensitive (disaster-recovery net untouched); the 24h run interval + atomic DB dedup already bound alert volume.

## Verification

- Tests: category-scoped vs unscoped resolve semantics, self-heal on pass for both probes (incl. db=None and resolve-error safety), dedup/category kwargs, atomic-dedup interleaving + fresh-alert-after-recovery, surplus exclusion scoped to the untyped query only (91 green).
- Real-DB lifecycle E2E: deep+cheap alerts coexist → deep pass clears only `git_deep` (live `rootfs_readonly` survives) → cheap pass clears the rest; duplicate scans keep one row.
- Independent code review: DONE, zero findings; backward compat verified across all 9 other `resolve_by_source_and_type` call sites. Codex P1/P2 fixed + replied inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)