### PR TITLE
feat(ego): goal provenance + additive autonomy over the ego's own goals

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -315,7 +315,7 @@ them.
 ```yaml subsystem-map
 entry: ego-self-model
 modules: [ego, identity, deliberation]
-verified: 9037d45b 2026-07-07
+verified: 7968d85a 2026-07-16
 ```
 
 - **Two egos, both LIVE**: user ego (CEO, Opus, MCP profile `user_reflection`)
@@ -332,6 +332,18 @@ verified: 9037d45b 2026-07-07
   `_NEVER_DISPATCH_ACTION_TYPES` blocklist lives in `session.py`. Dispatches
   record `follow_ups` rows for accountability. `integrity.py` chain-verify is
   GROUNDWORK, explicitly NOT wired.
+- **Goal provenance + additive autonomy (2026-07-16)**: `user_goals.origin`
+  ('user' | 'genesis_ego', immutable after create — excluded from `update()`'s
+  allow-list; CHECK-constrained; migration 0063). A `genesis_ego`-origin goal
+  reviewed from the genesis ego cycle is paused/deprioritized DIRECTLY
+  (`session._apply_own_goal_change`: no proposal, audit observation
+  `goal_autonomous_action`); everything else — user-origin goals, the user-ego
+  cycle, close/priority-increase/delete — keeps the recommend-only proposal
+  path (`goal_actions.py`). The approval gates (proposal + autonomous-CLI) are
+  untouched: the ego skips proposal CREATION only for its own additive
+  artifacts. Autonomous goal CREATION (caps + ego-prompt wiring) is a staged
+  follow-on (PR-3), not yet built — `ego_goal_create(origin=…)` exists but no
+  autonomous path calls it.
 - **identity/**: SOUL/USER/VOICE/STEERING CAPS-markdown + `IdentityLoader`
   (wired via perception). `cc/session_config` reads SOUL+VOICE directly, not
   via the loader. **USER.md auto-synthesis is PERMANENTLY DISABLED** — the

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -341,9 +341,13 @@ verified: 7968d85a 2026-07-16
   cycle, close/priority-increase/delete — keeps the recommend-only proposal
   path (`goal_actions.py`). The approval gates (proposal + autonomous-CLI) are
   untouched: the ego skips proposal CREATION only for its own additive
-  artifacts. Autonomous goal CREATION (caps + ego-prompt wiring) is a staged
-  follow-on (PR-3), not yet built — `ego_goal_create(origin=…)` exists but no
-  autonomous path calls it.
+  artifacts. **Dormant until PR-3**, which must wire BOTH halves: (1) a
+  trusted genesis-ego creation path — the `ego_goal_create` MCP tool has NO
+  origin argument (Codex P1: caller input must never stamp provenance); only
+  the CRUD accepts `origin`, for trusted code — and (2) a genesis-cycle goal
+  review: today's staleness scan (`cadence._check_stale_goals`) is
+  user-ego-only, so no scheduled path reaches the direct-apply branch yet
+  (Codex P2).
 - **identity/**: SOUL/USER/VOICE/STEERING CAPS-markdown + `IdentityLoader`
   (wired via perception). `cc/session_config` reads SOUL+VOICE directly, not
   via the loader. **USER.md auto-synthesis is PERMANENTLY DISABLED** — the

--- a/src/genesis/db/crud/user_goals.py
+++ b/src/genesis/db/crud/user_goals.py
@@ -23,20 +23,29 @@ async def create(
     confidence: float = 0.5,
     goal_type: str = "milestone",
     cadence_days: int | None = None,
+    origin: str = "user",
 ) -> str:
-    """Create a new goal. Returns the goal ID."""
+    """Create a new goal. Returns the goal ID.
+
+    ``origin`` is the goal's provenance ('user' | 'genesis_ego') and is
+    IMMUTABLE after create — deliberately absent from ``update()``'s
+    allow-list, because the additive-autonomy branch in the ego's goal
+    review trusts it (an ego that could relabel a user goal would gain
+    autonomous control over it). Defaults to 'user': fail-safe — an
+    unstamped goal is a user directive.
+    """
     goal_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
     await db.execute(
         """INSERT INTO user_goals
            (id, title, category, description, priority, status,
             timeline, parent_goal_id, evidence_source, confidence,
-            goal_type, cadence_days, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            goal_type, cadence_days, origin, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             goal_id, title, category, description, priority, status,
             timeline, parent_goal_id, evidence_source, confidence,
-            goal_type, cadence_days, now, now,
+            goal_type, cadence_days, origin, now, now,
         ),
     )
     await db.commit()
@@ -48,7 +57,12 @@ async def update(
     goal_id: str,
     **fields: object,
 ) -> bool:
-    """Update goal fields. Returns True if row was updated."""
+    """Update goal fields. Returns True if row was updated.
+
+    ``origin`` is deliberately NOT in the allow-list: provenance is stamped
+    at create and immutable — it is the security boundary for additive ego
+    autonomy (see ``create``). Do not add it.
+    """
     allowed = {
         "title", "description", "category", "priority", "status",
         "timeline", "parent_goal_id", "evidence_source", "confidence",

--- a/src/genesis/db/migrations/0063_user_goals_origin.py
+++ b/src/genesis/db/migrations/0063_user_goals_origin.py
@@ -1,0 +1,38 @@
+"""Add ``user_goals.origin`` — goal provenance (additive ego autonomy).
+
+Who owns a goal: ``'user'`` (a user directive — the default) or
+``'genesis_ego'`` (created by the Genesis ego for its own agenda). This is
+the security boundary for additive ego autonomy: the ego may autonomously
+pause/deprioritize ONLY goals it created; any mutation of a user-origin goal
+stays gated behind an approved ``goal_status_change`` proposal. The column is
+deliberately immutable after create — ``user_goals.update()`` excludes it
+from its allow-list, so no path can relabel a user goal into ego control.
+
+``NOT NULL DEFAULT 'user'`` — every pre-existing goal predates ego autonomy,
+so it IS a user directive (never autonomously touchable). The CHECK makes an
+unknown origin a hard integrity error, not a silent third state.
+
+Fresh/test DBs get the column from the canonical CREATE TABLE in
+``db/schema/_tables.py``; this numbered migration covers the existing-DB
+upgrade path. Idempotent: PRAGMA-guarded ADD COLUMN. No commit — the runner
+owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='user_goals'"
+    )
+    if await cursor.fetchone():
+        col_cursor = await db.execute("PRAGMA table_info(user_goals)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        if "origin" not in cols:
+            await db.execute(
+                "ALTER TABLE user_goals "
+                "ADD COLUMN origin TEXT NOT NULL DEFAULT 'user' "
+                "CHECK (origin IN ('user', 'genesis_ego'))"
+            )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1371,6 +1371,12 @@ TABLES = {
             confidence      REAL NOT NULL DEFAULT 0.5,
             goal_type       TEXT NOT NULL DEFAULT 'milestone'
                             CHECK (goal_type IN ('milestone', 'continuous')),
+            -- Provenance: who owns this goal. 'user' = a user directive
+            -- (NEVER autonomously mutable); 'genesis_ego' = ego-created
+            -- (the ego may pause/deprioritize it without a proposal).
+            -- Immutable after create — update() excludes it (migration 0063).
+            origin          TEXT NOT NULL DEFAULT 'user'
+                            CHECK (origin IN ('user', 'genesis_ego')),
             cadence_days    INTEGER,              -- per-goal review cadence override (NULL = global default)
             created_at      TEXT NOT NULL
                             DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -498,12 +498,16 @@ class EgoSession:
     ) -> None:
         """Route the ego's goal status recommendation to the user.
 
-        Recommend-only — nothing is applied autonomously. The reversible
-        recommendations (``pause`` / ``deprioritize``) become an *approvable*
-        ``goal_status_change`` proposal applied ONLY on user approval (see
-        ``ego/goal_actions.py``). Terminal/other recommendations (``close`` →
-        achieve vs abandon) stay a passive observation — that call is genuinely
-        the user's. The ego assesses; the user decides.
+        The reversible recommendations (``pause`` / ``deprioritize``) become
+        an *approvable* ``goal_status_change`` proposal applied ONLY on user
+        approval (see ``ego/goal_actions.py``) — with ONE additive-autonomy
+        exception: a goal the genesis ego itself created
+        (``origin='genesis_ego'``), reviewed from the genesis ego cycle, is
+        paused/deprioritized directly with an audit observation instead of a
+        proposal (see ``_propose_goal_status_change``). User-origin goals are
+        NEVER mutated autonomously. Terminal/other recommendations (``close``
+        → achieve vs abandon) stay a passive observation — that call is
+        genuinely the user's, for every goal.
         """
         if recommendation in ("pause", "deprioritize"):
             await self._propose_goal_status_change(
@@ -559,7 +563,12 @@ class EgoSession:
         Delivered out-of-band via the proposal workflow (``create_batch`` +
         ``send_digest``), bypassing the realist gate — mirrors how autonomy
         earn-back proposals are surfaced. The change is applied ONLY when the
-        user approves the proposal (``ego/goal_actions.py``), never here.
+        user approves the proposal (``ego/goal_actions.py``) — except for the
+        additive-autonomy case: a ``genesis_ego``-origin goal reviewed from
+        the genesis ego cycle is applied directly (``_apply_own_goal_change``)
+        with an audit observation, no proposal. The approval gates themselves
+        are untouched; the ego skips proposal CREATION only for its own
+        additive artifacts, and only for reversible changes.
         """
         try:
             from genesis.db.crud import user_goals
@@ -585,6 +594,21 @@ class EgoSession:
                     "medium": "low", "low": "low",
                 }
                 value, change, verb = lower.get(current, "low"), "priority", "Deprioritize"
+
+            # Additive autonomy (2026-07-16): the genesis ego pauses/
+            # deprioritizes a goal IT created without a proposal. Both gates
+            # must hold: goal.origin='genesis_ego' (never a user directive —
+            # origin is immutable, stamped at create) AND this is the genesis
+            # ego cycle ("its OWN goals" — a user-ego recommendation on an
+            # ego goal still proposes). Reversible changes only; close/
+            # priority-increase/delete have no autonomous path.
+            origin = ((goal.get("origin") if goal else None) or "user")
+            if origin == "genesis_ego" and self._source_tag == "genesis_ego_cycle":
+                await self._apply_own_goal_change(
+                    goal_id=goal_id, title=title, change=change,
+                    value=value, verb=verb, assessment=assessment,
+                )
+                return
 
             prop = {
                 "action_type": "goal_status_change",
@@ -618,6 +642,73 @@ class EgoSession:
         except Exception:
             logger.warning(
                 "Failed to surface goal status-change proposal", exc_info=True,
+            )
+
+    async def _apply_own_goal_change(
+        self,
+        *,
+        goal_id: str,
+        title: str,
+        change: str,
+        value: str,
+        verb: str,
+        assessment: str,
+    ) -> None:
+        """Directly apply a pause/deprioritize to a genesis_ego-owned goal.
+
+        The additive-autonomy path (2026-07-16): no proposal is created, but
+        the action is audited — an observation records what was applied and
+        why, and surfaces to the user through the normal awareness digest
+        (visibility, NOT an approval prompt). Reuses goal_actions' validated
+        value sets so the autonomous path can never apply a value the gated
+        path couldn't. Reversible by the user at any time (resume/re-raise
+        via ego_goal_update).
+        """
+        import uuid
+
+        from genesis.db.crud import observations as obs_crud
+        from genesis.db.crud import user_goals as goals_crud
+        from genesis.ego.goal_actions import _VALID_PRIORITY, _VALID_STATUS
+
+        valid = _VALID_STATUS if change == "status" else _VALID_PRIORITY
+        if change not in ("status", "priority") or value not in valid:
+            logger.warning(
+                "Autonomous goal change rejected (invalid %s=%r) for %s",
+                change, value, goal_id[:12],
+            )
+            return
+
+        applied = await goals_crud.update(self._db, goal_id, **{change: value})
+        if not applied:
+            logger.warning(
+                "Autonomous goal change: update failed for %s", goal_id[:12],
+            )
+            return
+
+        logger.info(
+            "Autonomously applied %s to own goal %s (%s → %s)",
+            verb.lower(), goal_id[:12], change, value,
+        )
+        try:
+            await obs_crud.create(
+                self._db,
+                id=str(uuid.uuid4()),
+                source=self._source_tag,
+                type="goal_autonomous_action",
+                content=(
+                    f"Autonomously applied {verb.lower()} to own goal "
+                    f"'{title}' ({change} → {value}). The goal is ego-created "
+                    f"(origin=genesis_ego); user goals are never touched "
+                    f"autonomously. Assessment: {assessment[:400]}"
+                ),
+                priority="medium",
+                category="goal_review",
+                created_at=datetime.now(UTC).isoformat(),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to write autonomous goal-change audit observation",
+                exc_info=True,
             )
 
     # -- Output processing --------------------------------------------------

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -21,8 +21,6 @@ _VALID_EGO_TARGETS = frozenset({"user_ego", "genesis_ego"})
 _VALID_GOAL_CATEGORIES = frozenset({"career", "project", "learning", "relationship", "financial", "other"})
 _VALID_GOAL_PRIORITIES = frozenset({"low", "medium", "high", "critical"})
 _VALID_GOAL_TYPES = frozenset({"milestone", "continuous"})
-# Goal provenance — the security boundary for additive ego autonomy.
-_VALID_GOAL_ORIGINS = frozenset({"user", "genesis_ego"})
 
 
 def _get_db_path():
@@ -155,7 +153,6 @@ async def _impl_ego_goal_create(
     parent_goal_id: str = "",
     goal_type: str = "milestone",
     cadence_days: int = 0,
-    origin: str = "user",
 ) -> dict:
     """Create a new user goal for the ego system.
 
@@ -172,12 +169,11 @@ async def _impl_ego_goal_create(
         parent_goal_id: ID of the parent goal (for subgoals)
         goal_type: milestone (achievable) or continuous (ongoing)
         cadence_days: Review frequency in days (0 = use global default)
-        origin: Goal provenance — who owns it. "user" (default) for any goal
-            created on the user's behalf or direction. "genesis_ego" ONLY when
-            the Genesis ego creates a goal for its own agenda: ego-owned goals
-            may later be paused/deprioritized by the ego autonomously (no
-            proposal), so NEVER set genesis_ego for a user-directed goal.
-            Immutable after create.
+    Provenance: every goal created through this tool is stamped
+    origin='user' in code. The MCP surface deliberately does NOT accept an
+    origin argument — 'genesis_ego' (which unlocks additive autonomous
+    pause/deprioritize) may only ever be stamped by a trusted Genesis-ego
+    code path (PR-3), never by caller input (Codex P1, PR #1086).
     """
     if category not in _VALID_GOAL_CATEGORIES:
         return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
@@ -185,8 +181,6 @@ async def _impl_ego_goal_create(
         return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_GOAL_PRIORITIES)}"}
     if goal_type not in _VALID_GOAL_TYPES:
         return {"status": "error", "reason": f"Invalid goal_type: {goal_type!r}. Must be 'milestone' or 'continuous'"}
-    if origin not in _VALID_GOAL_ORIGINS:
-        return {"status": "error", "reason": f"Invalid origin: {origin!r}. Must be one of: {sorted(_VALID_GOAL_ORIGINS)}"}
 
     from genesis.db.connection import get_raw_db
     from genesis.db.crud import user_goals
@@ -211,7 +205,10 @@ async def _impl_ego_goal_create(
             goal_type=goal_type,
             cadence_days=cadence_days if cadence_days > 0 else None,
             confidence=0.9,
-            origin=origin,
+            # NEVER caller-controlled: the tool surface has no origin arg —
+            # genesis_ego provenance requires a trusted code path (see
+            # docstring). This hardcode IS the security property.
+            origin="user",
         )
 
     return {
@@ -222,7 +219,7 @@ async def _impl_ego_goal_create(
         "priority": priority,
         "parent_goal_id": parent_goal_id or None,
         "goal_type": goal_type,
-        "origin": origin,
+        "origin": "user",
     }
 
 
@@ -236,7 +233,6 @@ async def ego_goal_create(
     parent_goal_id: str = "",
     goal_type: str = "milestone",
     cadence_days: int = 0,
-    origin: str = "user",
 ) -> dict:
     """Create a new user goal for the ego system.
 
@@ -253,18 +249,17 @@ async def ego_goal_create(
         parent_goal_id: ID of the parent goal (for subgoals)
         goal_type: milestone (achievable) or continuous (ongoing)
         cadence_days: Review frequency in days (0 = use global default)
-        origin: Goal provenance — who owns it. "user" (default) for any goal
-            created on the user's behalf or direction. "genesis_ego" ONLY when
-            the Genesis ego creates a goal for its own agenda: ego-owned goals
-            may later be paused/deprioritized by the ego autonomously (no
-            proposal), so NEVER set genesis_ego for a user-directed goal.
-            Immutable after create.
+
+    All goals created here are stamped origin='user' (a user directive).
+    There is deliberately no origin argument — ego-owned provenance
+    ('genesis_ego') can only be stamped by trusted Genesis-ego code, never
+    caller input.
     """
     return await _impl_ego_goal_create(
         title=title, category=category, priority=priority,
         description=description, timeline=timeline,
         parent_goal_id=parent_goal_id, goal_type=goal_type,
-        cadence_days=cadence_days, origin=origin,
+        cadence_days=cadence_days,
     )
 
 

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -21,6 +21,8 @@ _VALID_EGO_TARGETS = frozenset({"user_ego", "genesis_ego"})
 _VALID_GOAL_CATEGORIES = frozenset({"career", "project", "learning", "relationship", "financial", "other"})
 _VALID_GOAL_PRIORITIES = frozenset({"low", "medium", "high", "critical"})
 _VALID_GOAL_TYPES = frozenset({"milestone", "continuous"})
+# Goal provenance — the security boundary for additive ego autonomy.
+_VALID_GOAL_ORIGINS = frozenset({"user", "genesis_ego"})
 
 
 def _get_db_path():
@@ -144,8 +146,7 @@ async def ego_directive(
     }
 
 
-@mcp.tool()
-async def ego_goal_create(
+async def _impl_ego_goal_create(
     title: str,
     category: str = "project",
     priority: str = "medium",
@@ -154,6 +155,7 @@ async def ego_goal_create(
     parent_goal_id: str = "",
     goal_type: str = "milestone",
     cadence_days: int = 0,
+    origin: str = "user",
 ) -> dict:
     """Create a new user goal for the ego system.
 
@@ -170,6 +172,12 @@ async def ego_goal_create(
         parent_goal_id: ID of the parent goal (for subgoals)
         goal_type: milestone (achievable) or continuous (ongoing)
         cadence_days: Review frequency in days (0 = use global default)
+        origin: Goal provenance — who owns it. "user" (default) for any goal
+            created on the user's behalf or direction. "genesis_ego" ONLY when
+            the Genesis ego creates a goal for its own agenda: ego-owned goals
+            may later be paused/deprioritized by the ego autonomously (no
+            proposal), so NEVER set genesis_ego for a user-directed goal.
+            Immutable after create.
     """
     if category not in _VALID_GOAL_CATEGORIES:
         return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
@@ -177,6 +185,8 @@ async def ego_goal_create(
         return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_GOAL_PRIORITIES)}"}
     if goal_type not in _VALID_GOAL_TYPES:
         return {"status": "error", "reason": f"Invalid goal_type: {goal_type!r}. Must be 'milestone' or 'continuous'"}
+    if origin not in _VALID_GOAL_ORIGINS:
+        return {"status": "error", "reason": f"Invalid origin: {origin!r}. Must be one of: {sorted(_VALID_GOAL_ORIGINS)}"}
 
     from genesis.db.connection import get_raw_db
     from genesis.db.crud import user_goals
@@ -201,6 +211,7 @@ async def ego_goal_create(
             goal_type=goal_type,
             cadence_days=cadence_days if cadence_days > 0 else None,
             confidence=0.9,
+            origin=origin,
         )
 
     return {
@@ -211,7 +222,50 @@ async def ego_goal_create(
         "priority": priority,
         "parent_goal_id": parent_goal_id or None,
         "goal_type": goal_type,
+        "origin": origin,
     }
+
+
+@mcp.tool()
+async def ego_goal_create(
+    title: str,
+    category: str = "project",
+    priority: str = "medium",
+    description: str = "",
+    timeline: str = "",
+    parent_goal_id: str = "",
+    goal_type: str = "milestone",
+    cadence_days: int = 0,
+    origin: str = "user",
+) -> dict:
+    """Create a new user goal for the ego system.
+
+    Goals are visible to the ego in its thinking cycles. The ego considers
+    goals when deciding what to propose. Use parent_goal_id to create
+    subgoals under an existing goal.
+
+    Args:
+        title: Goal title (concise, actionable)
+        category: career, project, learning, relationship, financial, other
+        priority: low, medium, high, or critical
+        description: Detailed description of the goal
+        timeline: Expected timeline (e.g., "Q2 2026")
+        parent_goal_id: ID of the parent goal (for subgoals)
+        goal_type: milestone (achievable) or continuous (ongoing)
+        cadence_days: Review frequency in days (0 = use global default)
+        origin: Goal provenance — who owns it. "user" (default) for any goal
+            created on the user's behalf or direction. "genesis_ego" ONLY when
+            the Genesis ego creates a goal for its own agenda: ego-owned goals
+            may later be paused/deprioritized by the ego autonomously (no
+            proposal), so NEVER set genesis_ego for a user-directed goal.
+            Immutable after create.
+    """
+    return await _impl_ego_goal_create(
+        title=title, category=category, priority=priority,
+        description=description, timeline=timeline,
+        parent_goal_id=parent_goal_id, goal_type=goal_type,
+        cadence_days=cadence_days, origin=origin,
+    )
 
 
 @mcp.tool()

--- a/src/genesis/memory/goal_tracker.py
+++ b/src/genesis/memory/goal_tracker.py
@@ -105,13 +105,15 @@ async def process_extraction(
         )
         return True
 
-    # Create new goal
+    # Create new goal. origin="user": extraction goals are machine-INFERRED
+    # from user conversation — they are user directives, never ego-owned.
     await user_goals.create(
         db,
         title=signal["title"],
         category=signal["category"],
         confidence=signal["confidence"],
         evidence_source=f"extraction:{source_session_id or 'unknown'}",
+        origin="user",
     )
     logger.info(
         "New goal detected from extraction: %s (%s, conf=%.2f)",

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -917,3 +917,148 @@ class TestPromptLoading:
                 db=db,
             )
             assert session._static_prompt.strip()
+
+
+# ---------------------------------------------------------------------------
+# Additive ego autonomy — genesis_ego-owned goals self-manage (PR-2, 2026-07-16)
+# ---------------------------------------------------------------------------
+
+
+class TestAutonomousOwnGoalManagement:
+    """A genesis_ego-origin goal reviewed by the GENESIS ego cycle is paused/
+    deprioritized directly (no proposal) with an audit observation. Everything
+    else — user-origin goals, the user-ego cycle, non-reversible recs — keeps
+    the recommend-only proposal path. The approval gates are untouched: this
+    is the ego skipping proposal CREATION for its own additive artifacts, not
+    a gate bypass."""
+
+    @pytest.fixture
+    async def goals_db(self, db):
+        await db.execute(TABLES["user_goals"])
+        await db.execute(TABLES["observations"])
+        await db.commit()
+        return db
+
+    @staticmethod
+    async def _insert_goal(conn, *, gid, origin="user", status="active", priority="high"):
+        await conn.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, status, priority, origin, created_at, updated_at) "
+            "VALUES (?, 'My Goal', 'project', ?, ?, ?, '2026-06-01', '2026-06-01')",
+            (gid, status, priority, origin),
+        )
+        await conn.commit()
+
+    @staticmethod
+    async def _goal_row(conn, gid):
+        cursor = await conn.execute(
+            "SELECT status, priority, origin FROM user_goals WHERE id = ?", (gid,)
+        )
+        return await cursor.fetchone()
+
+    async def test_ego_goal_pause_applies_directly(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="eg1", origin="genesis_ego")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="eg1", recommendation="pause", assessment="stale for weeks",
+        )
+
+        row = await self._goal_row(goals_db, "eg1")
+        assert row["status"] == "paused"
+        ego_session._proposals.create_batch.assert_not_awaited()
+
+    async def test_ego_goal_pause_writes_audit_observation(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="eg2", origin="genesis_ego")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="eg2", recommendation="pause", assessment="done exploring",
+        )
+
+        cursor = await goals_db.execute(
+            "SELECT type, source, content FROM observations "
+            "WHERE type = 'goal_autonomous_action'",
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row["source"] == "genesis_ego_cycle"
+        assert "My Goal" in row["content"]
+
+    async def test_ego_goal_deprioritize_applies_directly(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="eg3", origin="genesis_ego", priority="high")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="eg3", recommendation="deprioritize", assessment="lower it",
+        )
+
+        row = await self._goal_row(goals_db, "eg3")
+        assert row["priority"] == "medium"  # one notch down, applied directly
+        ego_session._proposals.create_batch.assert_not_awaited()
+
+    async def test_user_goal_still_requires_proposal(self, ego_session, goals_db):
+        """The hard invariant: an origin='user' goal is NEVER mutated
+        autonomously — even by the genesis ego cycle."""
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="ug1", origin="user")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="ug1", recommendation="pause", assessment="stuck",
+        )
+
+        row = await self._goal_row(goals_db, "ug1")
+        assert row["status"] == "active"  # untouched
+        ego_session._proposals.create_batch.assert_awaited_once()  # proposal path
+
+    async def test_user_ego_cycle_never_direct_applies(self, ego_session, goals_db):
+        """Ego-owned goals self-manage only from the GENESIS ego cycle; a
+        user-ego recommendation on an ego goal still goes through a proposal."""
+        ego_session._source_tag = "user_ego_cycle"
+        await self._insert_goal(goals_db, gid="eg4", origin="genesis_ego")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="eg4", recommendation="pause", assessment="from user ego",
+        )
+
+        row = await self._goal_row(goals_db, "eg4")
+        assert row["status"] == "active"
+        ego_session._proposals.create_batch.assert_awaited_once()
+
+    async def test_default_origin_goal_requires_proposal(self, ego_session, goals_db):
+        """A goal inserted without an explicit origin defaults to 'user' via
+        the schema — and therefore stays proposal-gated."""
+        ego_session._source_tag = "genesis_ego_cycle"
+        await goals_db.execute(
+            "INSERT INTO user_goals (id, title, category, created_at, updated_at) "
+            "VALUES ('dg1', 'Default Goal', 'project', '2026-06-01', '2026-06-01')",
+        )
+        await goals_db.commit()
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="dg1", recommendation="pause", assessment="stale",
+        )
+
+        row = await self._goal_row(goals_db, "dg1")
+        assert row["status"] == "active"
+        ego_session._proposals.create_batch.assert_awaited_once()
+
+    async def test_close_recommendation_still_observation_even_for_ego_goal(
+        self, ego_session, goals_db,
+    ):
+        """close (achieve-vs-abandon) is terminal — never auto-applied, even
+        on an ego-owned goal. Only pause/deprioritize are additive-safe."""
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="eg5", origin="genesis_ego")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="eg5", recommendation="close", assessment="looks finished",
+        )
+
+        row = await self._goal_row(goals_db, "eg5")
+        assert row["status"] == "active"
+        ego_session._proposals.create_batch.assert_not_awaited()
+        cursor = await goals_db.execute(
+            "SELECT type FROM observations WHERE type = 'goal_recommendation'",
+        )
+        assert await cursor.fetchone() is not None

--- a/tests/test_db/test_migration_0063_user_goals_origin.py
+++ b/tests/test_db/test_migration_0063_user_goals_origin.py
@@ -1,0 +1,108 @@
+"""Migration 0063 — add ``user_goals.origin`` (goal provenance).
+
+Verifies the column is added to a pre-existing table with the 'user' default
+backfilled onto existing rows (every pre-migration goal predates ego
+autonomy, so it is a user directive), the CHECK rejects unknown origins, the
+add is idempotent (fresh DBs already have it from _tables.py), and a missing
+table is a safe no-op. Mirrors 0048.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+import aiosqlite
+import pytest
+
+M63 = importlib.import_module("genesis.db.migrations.0063_user_goals_origin")
+
+# A minimal PRE-0063 user_goals (no origin) — the existing-DB upgrade path.
+_OLD_DDL = """
+    CREATE TABLE user_goals (
+        id TEXT PRIMARY KEY, title TEXT NOT NULL,
+        category TEXT NOT NULL, priority TEXT NOT NULL DEFAULT 'medium',
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+"""
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(user_goals)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_adds_origin_column_to_existing_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        assert "origin" not in await _columns(db)
+        await M63.up(db)
+        assert "origin" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_existing_rows_backfilled_as_user(tmp_path):
+    """Every pre-migration goal predates genesis-ego autonomy — treat it as a
+    user directive (never autonomously touchable)."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await db.execute(
+            "INSERT INTO user_goals (id, title, category) VALUES ('g-old', 't', 'project')"
+        )
+        await M63.up(db)
+        cur = await db.execute("SELECT origin FROM user_goals WHERE id = 'g-old'")
+        row = await cur.fetchone()
+        assert row[0] == "user"
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_unknown_origin(tmp_path):
+    """origin is the security boundary for additive ego autonomy — the CHECK
+    must reject anything outside {'user','genesis_ego'}."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await M63.up(db)
+        with pytest.raises(sqlite3.IntegrityError):
+            await db.execute(
+                "INSERT INTO user_goals (id, title, category, origin) "
+                "VALUES ('g-bad', 't', 'project', 'bogus')"
+            )
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await M63.up(db)
+        await M63.up(db)  # second run must NOT raise "duplicate column"
+        assert "origin" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_up_noop_when_table_absent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M63.up(db)  # no user_goals table — must be a safe no-op
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='user_goals'"
+        )
+        assert await cur.fetchone() is None
+
+
+@pytest.mark.asyncio
+async def test_fresh_canonical_table_has_origin(tmp_path):
+    """Fresh installs get origin from the canonical CREATE TABLE."""
+    from genesis.db.schema import TABLES
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(TABLES["user_goals"])
+        cols = await _columns(db)
+        assert "origin" in cols
+        # Default must be 'user' (fail-safe: an unstamped create is a user goal).
+        await db.execute(
+            "INSERT INTO user_goals (id, title, category) VALUES ('g-f', 't', 'project')"
+        )
+        cur = await db.execute("SELECT origin FROM user_goals WHERE id = 'g-f'")
+        assert (await cur.fetchone())[0] == "user"

--- a/tests/test_mcp/test_ego_goal_create_origin.py
+++ b/tests/test_mcp/test_ego_goal_create_origin.py
@@ -1,0 +1,95 @@
+"""ego_goal_create origin (provenance) — additive ego autonomy PR-2.
+
+The tool stamps who owns a goal: 'user' (default, fail-safe) or
+'genesis_ego' (ego-created, later self-manageable additively). Origin is
+immutable after create — user_goals.update() must silently drop it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import user_goals
+from genesis.db.schema import TABLES
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db_path = tmp_path / "test.db"
+    async with aiosqlite.connect(str(db_path)) as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["user_goals"])
+        await conn.commit()
+        yield conn, db_path
+
+
+async def _origin_of(conn, goal_id: str) -> str:
+    cur = await conn.execute("SELECT origin FROM user_goals WHERE id = ?", (goal_id,))
+    return (await cur.fetchone())["origin"]
+
+
+class TestEgoGoalCreateOrigin:
+    async def test_default_origin_is_user(self, db):
+        conn, db_path = db
+        from genesis.mcp.health.ego_tools import _impl_ego_goal_create as ego_goal_create
+
+        with patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path):
+            result = await ego_goal_create(title="A user goal")
+
+        assert result["status"] == "created"
+        assert result["origin"] == "user"
+        assert await _origin_of(conn, result["goal_id"]) == "user"
+
+    async def test_genesis_ego_origin_stamped(self, db):
+        conn, db_path = db
+        from genesis.mcp.health.ego_tools import _impl_ego_goal_create as ego_goal_create
+
+        with patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path):
+            result = await ego_goal_create(title="An ego goal", origin="genesis_ego")
+
+        assert result["status"] == "created"
+        assert result["origin"] == "genesis_ego"
+        assert await _origin_of(conn, result["goal_id"]) == "genesis_ego"
+
+    async def test_invalid_origin_rejected(self, db):
+        _conn, db_path = db
+        from genesis.mcp.health.ego_tools import _impl_ego_goal_create as ego_goal_create
+
+        with patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path):
+            result = await ego_goal_create(title="Bad", origin="admin")
+
+        assert result["status"] == "error"
+        assert "origin" in result["reason"].lower()
+
+
+class TestOriginImmutable:
+    async def test_update_silently_drops_origin(self, db):
+        """origin is the security boundary — if it were mutable, the ego could
+        relabel a user goal and gain autonomous control over it."""
+        conn, _db_path = db
+        gid = await user_goals.create(conn, title="mine", category="project")
+        assert await _origin_of(conn, gid) == "user"
+
+        changed = await user_goals.update(conn, gid, origin="genesis_ego")
+
+        # Dropped by the allow-list: no update happened (or at minimum origin
+        # is unchanged even if other fields were passed alongside).
+        assert changed is False
+        assert await _origin_of(conn, gid) == "user"
+
+    async def test_update_with_origin_and_valid_field_keeps_origin(self, db):
+        conn, _db_path = db
+        gid = await user_goals.create(conn, title="mine", category="project")
+
+        changed = await user_goals.update(conn, gid, origin="genesis_ego", priority="low")
+
+        assert changed is True  # priority applied
+        assert await _origin_of(conn, gid) == "user"  # origin untouched
+
+    async def test_crud_create_accepts_origin(self, db):
+        conn, _db_path = db
+        gid = await user_goals.create(conn, title="ego's", category="project", origin="genesis_ego")
+        assert await _origin_of(conn, gid) == "genesis_ego"

--- a/tests/test_mcp/test_ego_goal_create_origin.py
+++ b/tests/test_mcp/test_ego_goal_create_origin.py
@@ -32,7 +32,7 @@ async def _origin_of(conn, goal_id: str) -> str:
 
 
 class TestEgoGoalCreateOrigin:
-    async def test_default_origin_is_user(self, db):
+    async def test_tool_always_stamps_user(self, db):
         conn, db_path = db
         from genesis.mcp.health.ego_tools import _impl_ego_goal_create as ego_goal_create
 
@@ -43,26 +43,41 @@ class TestEgoGoalCreateOrigin:
         assert result["origin"] == "user"
         assert await _origin_of(conn, result["goal_id"]) == "user"
 
-    async def test_genesis_ego_origin_stamped(self, db):
-        conn, db_path = db
-        from genesis.mcp.health.ego_tools import _impl_ego_goal_create as ego_goal_create
-
-        with patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path):
-            result = await ego_goal_create(title="An ego goal", origin="genesis_ego")
-
-        assert result["status"] == "created"
-        assert result["origin"] == "genesis_ego"
-        assert await _origin_of(conn, result["goal_id"]) == "genesis_ego"
-
-    async def test_invalid_origin_rejected(self, db):
+    async def test_tool_surface_has_no_origin_argument(self, db):
+        """Codex P1 (PR #1086): the MCP tool is reachable by any caller, so
+        provenance must never be caller input. Passing origin must be a
+        TypeError on both the impl and the registered tool schema —
+        'genesis_ego' can only be stamped by trusted code via the CRUD."""
         _conn, db_path = db
-        from genesis.mcp.health.ego_tools import _impl_ego_goal_create as ego_goal_create
+        from genesis.mcp.health.ego_tools import _impl_ego_goal_create
 
-        with patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path):
-            result = await ego_goal_create(title="Bad", origin="admin")
+        with (
+            patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path),
+            pytest.raises(TypeError),
+        ):
+            await _impl_ego_goal_create(title="sneaky", origin="genesis_ego")
 
-        assert result["status"] == "error"
-        assert "origin" in result["reason"].lower()
+    async def test_registered_tool_schema_excludes_origin(self):
+        """The @mcp.tool wrapper (what remote callers see) must not expose an
+        origin parameter either."""
+        import inspect
+
+        from genesis.mcp.health import ego_tools
+
+        tool = ego_tools.ego_goal_create
+        fn = getattr(tool, "fn", tool)  # FunctionTool wraps the coroutine
+        assert "origin" not in inspect.signature(fn).parameters
+
+    async def test_crud_invalid_origin_hits_check_constraint(self, db):
+        """The CRUD trusted path is still constrained: the schema CHECK
+        rejects unknown origins outright."""
+        import sqlite3
+
+        conn, _db_path = db
+        with pytest.raises(sqlite3.IntegrityError):
+            await user_goals.create(
+                conn, title="bad", category="project", origin="admin"
+            )
 
 
 class TestOriginImmutable:


### PR DESCRIPTION
## What

Implements the July 9 ego goal-autonomy request, scoped **additive-only**: the ego gains autonomy ONLY over artifacts it created, and can never touch a user directive. **The approval gates (ego-proposal + autonomous-CLI) are untouched** — the ego skips proposal *creation* for a narrow class of its own additive actions; nothing bypasses an existing gate.

### Provenance (the security boundary)
- `user_goals.origin` — `'user'` | `'genesis_ego'`, stamped at create, **immutable** (excluded from `update()`'s allow-list: an ego that could relabel a user goal would gain autonomous control over it), CHECK-constrained.
- Migration `0063` backfills every existing goal as `'user'`. Verified against a copy of the live DB: 8 goals → `origin='user'`, CHECK enforced, idempotent.
- **Provenance is never caller input** (Codex P1, fixed in-review): the `ego_goal_create` MCP tool has NO `origin` argument — every tool-created goal is stamped `'user'` in code. `'genesis_ego'` can only be stamped by a trusted Genesis-ego code path via the CRUD (the PR-3 creation wiring). Tests assert the surface property itself. Tool split into `_impl_` + thin `@mcp.tool` wrapper per convention; extraction-path goals stamp `'user'`.

### Additive autonomy (ships dormant)
- In the ego's goal review: `origin='genesis_ego'` **AND** `source_tag='genesis_ego_cycle'` **AND** recommendation ∈ {pause, deprioritize} → applied directly (same validated value sets as the gated path) + a `goal_autonomous_action` audit observation (visibility, not an approval prompt), no proposal.
- Everything else — user-origin goals, the user-ego cycle, close / priority-increase / delete — keeps the recommend-only proposal path byte-identical.
- **Dormant until PR-3** (follow-up filed), which wires both halves: a trusted genesis-ego creation path (with grounded caps + ego-prompt update) and a genesis-cycle goal-review scan (today's staleness scan is user-ego-only — Codex P2, confirmed against cadence.py).

### Docs
- Subsystem map `ego-self-model` entry updated + re-stamped, including the honest dormancy note.

## Verification
- Tests green across all touched suites: migration add/backfill/CHECK/idempotency/fresh-DDL; tool-surface-has-no-origin (TypeError on impl, no param in registered schema); **origin immutability** via `update()`; CRUD CHECK constraint; the session branch matrix (ego-goal pause/deprioritize direct + audited; user goal / user-ego cycle / default-origin / close all still gated).
- Independent security-focused review: **DONE, zero findings** — all six invariants verified, including a repo-wide enumeration of every `user_goals` write path (no origin bypass; the raw-SQL `add_progress_note` only touches `progress_notes`).
- Real-DB migration E2E on a copy of production data. Codex P1 fixed + P2 folded into PR-3 scope, both replied inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)