### PR TITLE
feat(infra): host clock sync-health in the infrastructure host plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now watches whether the host machine's clock is actually being
+  kept in sync.** The container shares its host's clock, so if the host's
+  time-sync daemon dies or stops syncing, TLS handshakes, log timestamps, and
+  scheduled jobs all quietly skew — and nothing noticed. The infrastructure
+  profile's host plane now reports which NTP daemon runs the clock and a
+  composite health state (synced / degraded / unsynced) that catches a dead
+  daemon even while the kernel's own sync flag still claims all is well; a
+  state flip surfaces as an infrastructure-drift observation like any other
+  change to the machine's vitals.
+
 - **Genesis now writes down its predictions before acting — the substrate.**
   A new cognitive ledger stores falsifiable predictions ("this outreach will
   get a reply within 72 hours, confidence 0.02") behind a hard validation

--- a/src/genesis/guardian/host_profile.py
+++ b/src/genesis/guardian/host_profile.py
@@ -1,7 +1,7 @@
 """Host-plane profile gather — the guardian's answer to ``host-profile``.
 
 Runs HOST-SIDE (via the gateway verb, ``python -m genesis.guardian
---host-profile``) and emits one JSON blob with three raw sub-dicts. The
+--host-profile``) and emits one JSON blob of raw per-section sub-dicts. The
 container's ``infra_profile.collectors.host`` owns the facts/metrics split —
 this module is a dumb, dependency-light data source and must never import
 beyond the guardian package (the guardian venv has no full Genesis install;
@@ -183,8 +183,78 @@ async def _host_virt(config) -> dict:
     return section
 
 
+# Daemons that can discipline the host clock, probed in preference order —
+# the first ACTIVE unit names the section's `ntp_service` fact. timesyncd
+# first (the stock Ubuntu/Debian daemon, and what the reference host runs —
+# verified live 2026-07-16); chrony/chronyd cover RHEL-family and opt-in
+# installs; ntp/ntpsec the legacy tail.
+_NTP_UNITS = ("systemd-timesyncd", "chrony", "chronyd", "ntp", "ntpsec")
+
+
+async def _host_time() -> dict:
+    """Host clock sync health: which daemon disciplines the clock, and is it working.
+
+    The container shares the host's kernel clock but its ``timedatectl`` view
+    (container collector's ``time`` section) cannot see the HOST daemon's
+    health. ``NTPSynchronized`` alone is not a liveness signal — it mirrors
+    the kernel sync flag, which can stay ``yes`` long after the daemon dies —
+    so ``ntp_sync_state`` composites unit-liveness AND the flag:
+
+    - ``unsynced``  — no known NTP daemon active
+    - ``synced``    — a daemon is active and the kernel flag confirms sync
+    - ``degraded``  — a daemon is active but the kernel flag says not synced
+
+    The bucket is the drift-worthy FACT; the raw flag and server details stay
+    volatile metrics (container-side allowlist in ``collectors/host.py``).
+    """
+
+    async def _active(unit: str) -> str | None:
+        # rc=0 ⇔ "active" (inactive/failed/absent all exit nonzero → None).
+        out = await _run("systemctl", "is-active", unit)
+        return unit if out is not None else None
+
+    def _props(output: str | None) -> dict:
+        if not output:
+            return {}
+        return dict(line.partition("=")[::2] for line in output.splitlines() if "=" in line)
+
+    show, timesync, *units = await asyncio.gather(
+        _run("timedatectl", "show"),
+        _run("timedatectl", "show-timesync"),
+        *[_active(unit) for unit in _NTP_UNITS],
+    )
+    active = next((u for u in units if u), None)
+    props = _props(show)
+
+    section: dict = {"ntp_service": active or "none"}
+    if "Timezone" in props:
+        section["timezone"] = props["Timezone"]
+    if "NTP" in props:
+        section["ntp_enabled"] = props["NTP"]
+    if "NTPSynchronized" in props:
+        section["ntp_synchronized_flag"] = props["NTPSynchronized"]
+
+    if active is None:
+        section["ntp_sync_state"] = "unsynced"
+    elif props.get("NTPSynchronized") == "yes":
+        section["ntp_sync_state"] = "synced"
+    else:
+        section["ntp_sync_state"] = "degraded"
+
+    # timesyncd-only detail (chrony hosts return nothing here — best-effort).
+    ts = _props(timesync)
+    for src, dst in (
+        ("ServerName", "ntp_server_name"),
+        ("ServerAddress", "ntp_server_address"),
+        ("PollIntervalUSec", "ntp_poll_interval"),
+    ):
+        if ts.get(src):
+            section[dst] = ts[src]
+    return section
+
+
 async def gather_host_profile(config) -> dict:
-    """Gather all three host sections; per-section failures degrade, not raise.
+    """Gather all host sections; per-section failures degrade, not raise.
 
     Sections run concurrently (they share no state) so the gather's worst case
     is its slowest section, not the sum — the gateway kills the process at 45s
@@ -206,18 +276,20 @@ async def gather_host_profile(config) -> dict:
     async def _system() -> dict:
         return _host_system()
 
-    host_system, host_storage_pool, host_virt = await asyncio.gather(
+    host_system, host_storage_pool, host_virt, host_time = await asyncio.gather(
         _guarded("host_system", _system()),
         _guarded(
             "host_storage_pool",
             asyncio.wait_for(_host_storage_pool(config), _POOL_TIMEOUT),
         ),
         _guarded("host_virt", _host_virt(config)),
+        _guarded("host_time", _host_time()),
     )
     sections = {
         "host_system": host_system,
         "host_storage_pool": host_storage_pool,
         "host_virt": host_virt,
+        "host_time": host_time,
     }
     all_failed = all(set(s) == {"error"} for s in sections.values())
     result: dict = {"ok": not all_failed, "action": "host-profile", **sections}

--- a/src/genesis/guardian/host_profile.py
+++ b/src/genesis/guardian/host_profile.py
@@ -186,9 +186,10 @@ async def _host_virt(config) -> dict:
 # Daemons that can discipline the host clock, probed in preference order —
 # the first ACTIVE unit names the section's `ntp_service` fact. timesyncd
 # first (the stock Ubuntu/Debian daemon, and what the reference host runs —
-# verified live 2026-07-16); chrony/chronyd cover RHEL-family and opt-in
-# installs; ntp/ntpsec the legacy tail.
-_NTP_UNITS = ("systemd-timesyncd", "chrony", "chronyd", "ntp", "ntpsec")
+# verified live 2026-07-16); chrony/chronyd cover Debian-/RHEL-family unit
+# names for chrony; ntp/ntpd/ntpsec the classic-ntpd tail (Debian ships
+# ntp.service / ntpsec.service, RHEL ships ntpd.service — Codex P2 #1087).
+_NTP_UNITS = ("systemd-timesyncd", "chrony", "chronyd", "ntp", "ntpd", "ntpsec")
 
 
 async def _host_time() -> dict:

--- a/src/genesis/infra_profile/collectors/host.py
+++ b/src/genesis/infra_profile/collectors/host.py
@@ -138,5 +138,23 @@ async def collect_host(guardian_remote=None) -> tuple[bool, str | None, list[Sec
             error = "host-profile gateway verb not deployed on host yet"
         return _unavailable(error[:200])
 
-    sections = [_split(name, blob.get(name, {}), _FACT_KEYS[name]) for name in HOST_SECTIONS]
+    sections = []
+    for name in HOST_SECTIONS:
+        raw = blob.get(name)
+        if raw is None:
+            # Key absent from an ok blob ⇔ the deployed guardian predates this
+            # section (every gathered section is emitted, even on failure).
+            # Unavailable — NOT empty-ok — so the persisted hash stays None and
+            # the facts arriving after the guardian redeploy read as a new
+            # section, not drift (Codex P2 #1087: hashing {} here turned the
+            # rollout itself into a phantom infrastructure_drift observation).
+            sections.append(
+                SectionResult.unavailable(
+                    name,
+                    "missing from host profile — guardian predates this section",
+                    plane=PLANE_HOST,
+                )
+            )
+            continue
+        sections.append(_split(name, raw, _FACT_KEYS[name]))
     return (True, None, sections)

--- a/src/genesis/infra_profile/collectors/host.py
+++ b/src/genesis/infra_profile/collectors/host.py
@@ -21,7 +21,7 @@ from genesis.infra_profile.types import PLANE_HOST, SectionResult
 
 logger = logging.getLogger(__name__)
 
-HOST_SECTIONS = ("host_system", "host_storage_pool", "host_virt")
+HOST_SECTIONS = ("host_system", "host_storage_pool", "host_virt", "host_time")
 
 
 def _unavailable(reason: str) -> tuple[bool, str, list[SectionResult]]:
@@ -88,10 +88,26 @@ _VIRT_FACTS = frozenset(
     }
 )
 
+# Host clock sync health. The bucketed `ntp_sync_state` (synced/degraded/
+# unsynced — composited host-side from daemon liveness + the kernel flag) is
+# the drift signal: a flip means the host stopped disciplining the clock the
+# container shares. The raw `ntp_synchronized_flag` stays a metric — it
+# mirrors the kernel STA_UNSYNC bit, which flaps independently of daemon
+# health and can lie for hours after a daemon dies.
+_TIME_FACTS = frozenset(
+    {
+        "timezone",
+        "ntp_service",
+        "ntp_enabled",
+        "ntp_sync_state",
+    }
+)
+
 _FACT_KEYS = {
     "host_system": _SYSTEM_FACTS,
     "host_storage_pool": _STORAGE_FACTS,
     "host_virt": _VIRT_FACTS,
+    "host_time": _TIME_FACTS,
 }
 
 

--- a/tests/test_guardian/test_host_profile.py
+++ b/tests/test_guardian/test_host_profile.py
@@ -61,6 +61,87 @@ class TestHostSystem:
         assert isinstance(section["swap_free_kb"], int)
 
 
+# Real `timedatectl show` / `show-timesync` shapes from the live host
+# (2026-07-16): systemd-timesyncd active, synced against ntp.ubuntu.com.
+_TIMEDATECTL_SHOW = """\
+Timezone=Etc/UTC
+LocalRTC=no
+CanNTP=yes
+NTP=yes
+NTPSynchronized=yes
+TimeUSec=Thu 2026-07-16 04:03:28 UTC
+RTCTimeUSec=Thu 2026-07-16 04:03:28 UTC
+"""
+_TIMEDATECTL_TIMESYNC = """\
+FallbackNTPServers=ntp.ubuntu.com
+ServerName=ntp.ubuntu.com
+ServerAddress=185.125.190.56
+RootDistanceMaxUSec=5s
+PollIntervalMinUSec=32s
+PollIntervalMaxUSec=34min 8s
+PollIntervalUSec=34min 8s
+"""
+
+
+def _time_run(active_units: set[str], show: str | None = _TIMEDATECTL_SHOW):
+    """A fake ``_run`` serving only the time-probe argvs (None otherwise)."""
+
+    async def fake_run(*argv):
+        if argv == ("timedatectl", "show"):
+            return show
+        if argv == ("timedatectl", "show-timesync"):
+            return _TIMEDATECTL_TIMESYNC if "systemd-timesyncd" in active_units else None
+        if argv[:2] == ("systemctl", "is-active"):
+            return "active\n" if argv[2] in active_units else None
+        return None
+
+    return fake_run
+
+
+class TestHostTime:
+    async def test_timesyncd_synced(self, monkeypatch) -> None:
+        monkeypatch.setattr(hp, "_run", _time_run({"systemd-timesyncd"}))
+        section = await hp._host_time()
+        assert section["ntp_service"] == "systemd-timesyncd"
+        assert section["ntp_enabled"] == "yes"
+        assert section["ntp_sync_state"] == "synced"
+        assert section["ntp_synchronized_flag"] == "yes"
+        assert section["timezone"] == "Etc/UTC"
+        assert section["ntp_server_name"] == "ntp.ubuntu.com"
+        assert section["ntp_poll_interval"] == "34min 8s"
+
+    async def test_chrony_synced_without_timesync_detail(self, monkeypatch) -> None:
+        monkeypatch.setattr(hp, "_run", _time_run({"chrony"}))
+        section = await hp._host_time()
+        assert section["ntp_service"] == "chrony"
+        assert section["ntp_sync_state"] == "synced"
+        assert "ntp_server_name" not in section  # timesyncd-only detail
+
+    async def test_daemon_dead_is_unsynced_even_with_stale_kernel_flag(self, monkeypatch) -> None:
+        """NTPSynchronized mirrors the kernel flag, which can stay 'yes' long
+        after the daemon dies — daemon liveness must win the composite."""
+        monkeypatch.setattr(hp, "_run", _time_run(set()))
+        section = await hp._host_time()
+        assert section["ntp_synchronized_flag"] == "yes"  # the lying flag
+        assert section["ntp_service"] == "none"
+        assert section["ntp_sync_state"] == "unsynced"
+
+    async def test_daemon_up_but_not_synced_is_degraded(self, monkeypatch) -> None:
+        show = _TIMEDATECTL_SHOW.replace("NTPSynchronized=yes", "NTPSynchronized=no")
+        monkeypatch.setattr(hp, "_run", _time_run({"systemd-timesyncd"}, show=show))
+        section = await hp._host_time()
+        assert section["ntp_service"] == "systemd-timesyncd"
+        assert section["ntp_sync_state"] == "degraded"
+
+    async def test_no_tools_at_all_degrades_not_raises(self, monkeypatch) -> None:
+        async def fake_run(*argv):
+            return None
+
+        monkeypatch.setattr(hp, "_run", fake_run)
+        section = await hp._host_time()
+        assert section == {"ntp_service": "none", "ntp_sync_state": "unsynced"}
+
+
 class TestGatherHostProfile:
     @pytest.fixture
     def config(self) -> GuardianConfig:
@@ -68,8 +149,11 @@ class TestGatherHostProfile:
 
     async def test_three_sections_present_and_ok(self, config, monkeypatch) -> None:
         pool_status = StoragePoolStatus(
-            detected=True, data_pct=61.19, metadata_pct=42.6,
-            vg_free_bytes=34359738368, detail="lvm vg0 data=61.19 meta=42.6",
+            detected=True,
+            data_pct=61.19,
+            metadata_pct=42.6,
+            vg_free_bytes=34359738368,
+            detail="lvm vg0 data=61.19 meta=42.6",
         )
 
         async def fake_measure(cfg):
@@ -82,6 +166,8 @@ class TestGatherHostProfile:
 
         monkeypatch.setattr("genesis.guardian.pool._detect_pool_name", fake_pool_name)
 
+        time_run = _time_run({"systemd-timesyncd"})
+
         async def fake_run(*argv):
             if argv == ("incus", "version"):
                 return "Client version: 6.0.0\nServer version: 6.0.0\n"
@@ -89,13 +175,13 @@ class TestGatherHostProfile:
                 return _INCUS_CONFIG_YAML
             if argv == ("systemd-detect-virt",):
                 return "kvm\n"
-            return None
+            return await time_run(*argv)
 
         monkeypatch.setattr(hp, "_run", fake_run)
 
         result = await hp.gather_host_profile(config)
         assert result["ok"] is True
-        assert set(result) >= {"host_system", "host_storage_pool", "host_virt"}
+        assert set(result) >= {"host_system", "host_storage_pool", "host_virt", "host_time"}
         pool = result["host_storage_pool"]
         assert pool["detected"] is True
         assert pool["data_pct"] == 61.19
@@ -106,6 +192,9 @@ class TestGatherHostProfile:
         assert virt["container_limits"] == {"limits.cpu": "8", "limits.memory": "16GiB"}
         assert virt["detect_virt"] == "kvm"
         assert virt["pve_version"] is None  # absent on the guardian VM
+        time_section = result["host_time"]
+        assert time_section["ntp_service"] == "systemd-timesyncd"
+        assert time_section["ntp_sync_state"] == "synced"
 
     async def test_section_failure_degrades_not_raises(self, config, monkeypatch) -> None:
         async def boom(cfg):
@@ -155,12 +244,17 @@ class TestGatherHostProfile:
 
         monkeypatch.setattr(hp, "_host_virt", virt_boom)
 
+        async def time_boom():
+            raise RuntimeError("time boom")
+
+        monkeypatch.setattr(hp, "_host_time", time_boom)
+
         result = await hp.gather_host_profile(config)
         assert result["ok"] is False
         assert result["error"] == "all host sections failed"
         assert all(
             "error" in result[name]
-            for name in ("host_system", "host_storage_pool", "host_virt")
+            for name in ("host_system", "host_storage_pool", "host_virt", "host_time")
         )
 
     def test_pool_status_fields_match_dataclass(self) -> None:
@@ -169,6 +263,10 @@ class TestGatherHostProfile:
         revisited (collectors/host.py allowlists)."""
         fields = {f.name for f in dataclasses.fields(StoragePoolStatus)}
         assert fields == {
-            "detected", "data_pct", "metadata_pct",
-            "vg_free_bytes", "pool_used_pct", "detail",
+            "detected",
+            "data_pct",
+            "metadata_pct",
+            "vg_free_bytes",
+            "pool_used_pct",
+            "detail",
         }

--- a/tests/test_infra_profile/test_collectors_host.py
+++ b/tests/test_infra_profile/test_collectors_host.py
@@ -49,6 +49,16 @@ _LIVE_BLOB = {
         "pve_version": None,
         "smartctl_present": False,
     },
+    "host_time": {
+        "ntp_service": "systemd-timesyncd",
+        "timezone": "Etc/UTC",
+        "ntp_enabled": "yes",
+        "ntp_synchronized_flag": "yes",
+        "ntp_sync_state": "synced",
+        "ntp_server_name": "ntp.ubuntu.com",
+        "ntp_server_address": "185.125.190.56",
+        "ntp_poll_interval": "34min 8s",
+    },
 }
 
 
@@ -76,11 +86,13 @@ async def test_no_guardian_is_unavailable() -> None:
 async def test_denied_gateway_is_unavailable_with_friendly_reason() -> None:
     # Realistic contract: _as_json embeds the gateway's RAW stderr JSON in the
     # error field on rc=1 — the quoted "denied" sentinel lives inside it.
-    remote = _FakeRemote({
-        "ok": False,
-        "action": "host-profile",
-        "error": '{"ok": false, "error": "denied"}',
-    })
+    remote = _FakeRemote(
+        {
+            "ok": False,
+            "action": "host-profile",
+            "error": '{"ok": false, "error": "denied"}',
+        }
+    )
     available, reason, sections = await collect_host(remote)
     assert available is False
     assert "not deployed" in reason
@@ -91,11 +103,13 @@ async def test_ssh_auth_failure_not_masked_as_not_deployed() -> None:
     # 'Permission denied (publickey)' contains bare 'denied' but NOT the
     # quoted gateway sentinel — it must surface as itself, not as a benign
     # not-deployed message (review 2026-07-13).
-    remote = _FakeRemote({
-        "ok": False,
-        "action": "host-profile",
-        "error": "Permission denied (publickey,password)",
-    })
+    remote = _FakeRemote(
+        {
+            "ok": False,
+            "action": "host-profile",
+            "error": "Permission denied (publickey,password)",
+        }
+    )
     available, reason, sections = await collect_host(remote)
     assert available is False
     assert "Permission denied" in reason
@@ -155,6 +169,19 @@ async def test_live_blob_splits_facts_and_metrics() -> None:
     assert virt.facts["container_limits"] == {"limits.cpu": "8", "limits.memory": "16GiB"}
     assert virt.facts["detect_virt"] == "kvm"
     assert virt.metrics == {}
+
+    time_section = by_name["host_time"]
+    assert time_section.facts == {
+        "ntp_service": "systemd-timesyncd",
+        "timezone": "Etc/UTC",
+        "ntp_enabled": "yes",
+        "ntp_sync_state": "synced",
+    }
+    # The raw kernel flag can lie (stays 'yes' after the daemon dies) and the
+    # server/poll details vary per refresh — none may churn the fact hash.
+    assert "ntp_synchronized_flag" in time_section.metrics
+    assert "ntp_server_name" in time_section.metrics
+    assert "ntp_poll_interval" in time_section.metrics
 
 
 async def test_unknown_host_field_lands_in_metrics_not_facts() -> None:

--- a/tests/test_infra_profile/test_collectors_host.py
+++ b/tests/test_infra_profile/test_collectors_host.py
@@ -217,9 +217,19 @@ async def test_partial_section_with_error_key_is_failed() -> None:
     assert "incus flaked" in virt.error
 
 
-async def test_missing_section_in_blob_is_empty_ok() -> None:
+async def test_missing_section_in_blob_is_unavailable_not_empty_ok() -> None:
+    """A key absent from an ok blob means the deployed guardian predates that
+    section (version skew). It must surface as UNAVAILABLE, never empty-ok:
+    an empty-ok section persists hash({}), so the facts arriving after the
+    guardian redeploys would read as drift — the rollout itself would page a
+    phantom infrastructure_drift observation (Codex P2 #1087). Unavailable
+    persists hash=None, and compute_drift skips hash-less sections."""
     blob = {k: v for k, v in _LIVE_BLOB.items() if k != "host_virt"}
-    _, _, sections = await collect_host(_FakeRemote(blob))
+    available, _, sections = await collect_host(_FakeRemote(blob))
+    assert available is True  # plane is up; one section predates the guardian
     virt = next(s for s in sections if s.name == "host_virt")
-    assert virt.status == STATUS_OK
+    assert virt.status == STATUS_UNAVAILABLE
+    assert "guardian predates" in virt.error
     assert virt.facts == {} and virt.metrics == {}
+    others = [s for s in sections if s.name != "host_virt"]
+    assert all(s.status == STATUS_OK for s in others)


### PR DESCRIPTION
## What

Adds a `host_time` section to the infrastructure profile's host plane: which NTP daemon disciplines the host clock, and a composite health state that notices when it stops working.

## Why

The container shares the host's kernel clock, but its own `timedatectl` view (the container-plane `time` section) cannot see the **host** daemon's health. If the host's time-sync daemon dies or degrades, TLS handshakes, log timestamps, and scheduled jobs silently skew — and nothing observed it.

## How

**Guardian side** (`guardian/host_profile.py`, runs host-side via the existing `host-profile` gateway verb):
- New `_host_time()` probe, concurrent with the other sections under `_guarded()` — `timedatectl show` / `show-timesync` plus `systemctl is-active` across known NTP units (timesyncd/chrony/chronyd/ntp/ntpsec). Best-effort throughout: missing tools degrade to a minimal section, never a raise; stays well inside the 45s gateway budget (10s per-probe cap, all concurrent).

**Container side** (`infra_profile/collectors/host.py`):
- `host_time` added to `HOST_SECTIONS` + a `_TIME_FACTS` allowlist.
- **Facts** (hashed → drift on flip): `ntp_service`, `ntp_enabled`, `timezone`, and bucketed `ntp_sync_state` ∈ {synced, degraded, unsynced}.
- **Metrics** (never hashed): the raw `NTPSynchronized` flag, server name/address, poll interval — refresh-variable, would churn the hash.

**The key design point:** `NTPSynchronized` mirrors the kernel sync flag, which can keep reporting `yes` long after the daemon dies — it is not a liveness signal. `ntp_sync_state` therefore composites daemon-unit liveness AND the flag; a dead daemon flips the fact (→ one `infrastructure_drift` observation) even while the kernel flag still lies. A dedicated test locks this exact scenario.

No new alerting machinery, no scheduler changes — the section rides the existing collection cadence and drift pipeline.

## Verification

- Probe shapes verified live against the reference host 2026-07-16 (systemd-timesyncd active + synced); test fixtures are the real outputs.
- 28 tests pass (`test_guardian/test_host_profile.py`, `test_infra_profile/test_collectors_host.py`, `test_collectors_edges.py`), ruff clean.
- Version-skew handled root-cause (Codex P2, commit 8487c577): a section key absent from an ok blob (deployed guardian predates it) surfaces as UNAVAILABLE with reason — hash stays None, so the facts arriving after the guardian redeploys read as a newly-appearing section, never phantom drift. Contract test updated to lock this.

Ledger: cd53f39f79a3440c94e1ab692b7d170a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
