### PR TITLE
fix(perception): admit >=0.85 user-model deltas — the 0.90 gate starved the stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Genesis resumes learning about you.** The stream of "user model deltas" —
+  the small observations reflections make about your preferences, constraints,
+  and working style — had been effectively dead since the v3 release: the
+  quality gate demanded more certainty (0.90) than the reflection model ever
+  expresses (its honest "high certainty" sits at 0.85), so almost nothing
+  passed — 2 deltas in 3.5 months. The gate now matches the model's real
+  confidence scale, and the reflection prompt no longer contradicts itself
+  about the bar (it demanded 0.9, called 0.85 "high certainty", and showed a
+  0.8 example all at once). If the stream stays silent anyway, the staleness
+  alarm shipped in the sensor-fabric release will say so within two weeks.
+
 ### Added
 
 - **The guardian now keeps container swap enabled on its own.** Swap is what

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -389,10 +389,10 @@ async def _check_user_model_staleness(db) -> None:
                 f"The user-model learning stream is stale: {detail}. Reflection "
                 f"user-impact deltas (observations type='user_model_delta') feed the "
                 f"user-model evolution job, so a silent stream means Genesis has stopped "
-                f"updating its model of the user. Likely throttle (diagnosed 2026-07-15): "
-                f"the 0.90 per-delta confidence gate in reflection_bridge/_output.py sits "
-                f"above the light-reflection model's median output confidence, so almost "
-                f"no delta passes — a behavioral fix tracked separately."
+                f"updating its model of the user. Check the per-delta confidence gate "
+                f"(MIN_DELTA_CONFIDENCE, perception/types.py) against the light model's "
+                f"actual output confidence, and the user_impact rotation's emission "
+                f"volume (how many deltas reflections propose at all)."
             ),
             priority="high",
             created_at=now_dt.isoformat(),

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -82,7 +82,7 @@ LIGHT_FOCUS_INSTRUCTIONS: dict[str, str] = {
         "## Focus: User Impact Analysis\n"
         "Analyze how current conditions affect the user's goals and work.\n"
         "This is the ONLY rotation that produces user_model_updates.\n"
-        "Each delta MUST have confidence >= 0.9 and cite specific evidence.\n"
+        "Each delta MUST have confidence >= 0.85 and cite specific evidence.\n"
         "Do NOT produce surplus_candidates (set to empty list).\n"
         "Focus on: assessment, user_model_updates, recommendations."
     ),

--- a/src/genesis/identity/LIGHT_TEMPLATE_USER_IMPACT.md
+++ b/src/genesis/identity/LIGHT_TEMPLATE_USER_IMPACT.md
@@ -19,7 +19,7 @@ that produces user model updates.
 
 **User model updates:** Only propose a delta if:
 1. You have specific signal or observation evidence (cite it)
-2. Confidence >= 0.9
+2. Confidence >= 0.85
 3. The delta is genuinely NEW information not already established
 
 Do NOT produce surplus_candidates — set to empty list.
@@ -35,7 +35,7 @@ Respond in JSON:
   "assessment": "2-4 sentences on user impact, citing evidence.",
   "patterns": ["user-relevant pattern (max 3)"],
   "user_model_updates": [
-    {{"field": "field_name", "value": "observed_value", "evidence": "specific signal/observation citation", "confidence": 0.8}}
+    {{"field": "field_name", "value": "observed_value", "evidence": "specific signal/observation citation", "confidence": 0.85}}
   ],
   "recommendations": ["actionable for user (max 3)"],
   "confidence": 0.7,

--- a/src/genesis/perception/templates/light/user_impact.txt
+++ b/src/genesis/perception/templates/light/user_impact.txt
@@ -23,7 +23,7 @@ a short "no material user impact change" with confidence 0.3 is correct.
 
 **User model updates:** Only propose a delta if:
 1. You have specific signal or observation evidence (cite it)
-2. Confidence >= 0.9
+2. Confidence >= 0.85
 3. The delta is genuinely NEW information not already established
 
 Do NOT produce surplus_candidates — set to empty list.
@@ -39,7 +39,7 @@ Respond in JSON:
   "assessment": "2-4 sentences on user impact, citing evidence.",
   "patterns": ["user-relevant pattern (max 3)"],
   "user_model_updates": [
-    {{"field": "field_name", "value": "observed_value", "evidence": "specific signal/observation citation", "confidence": 0.8}}
+    {{"field": "field_name", "value": "observed_value", "evidence": "specific signal/observation citation", "confidence": 0.85}}
   ],
   "recommendations": ["actionable for user (max 3)"],
   "confidence": 0.7,

--- a/src/genesis/perception/types.py
+++ b/src/genesis/perception/types.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass, field  # noqa: F401 — field used by downstr
 # Used by both perception engine (context.py, writer.py) and CC bridge
 # (reflection_bridge.py). Defined once to prevent drift.
 LIGHT_FOCUS_ROTATION: list[str] = ["situation", "user_impact", "anomaly"]
-MIN_DELTA_CONFIDENCE: float = 0.90
+# 0.85 admits the model's "high certainty" clusters (0.85/0.90/0.95) while still
+# dropping the 0.80 filler tier. The original 0.90 sat above the light model's
+# median output confidence and starved the stream (2 deltas in 3.5 months).
+MIN_DELTA_CONFIDENCE: float = 0.85
 
 
 @dataclass(frozen=True)

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -403,8 +403,9 @@ class ResultWriter:
             db, end_iso=tick.timestamp,
         )
         for delta in output.user_model_updates:
-            # Confidence gate: LLM clusters at 0.80/0.85/0.90/0.95; gate at 0.90
-            # filters ~60% of overconfident filler deltas.
+            # Confidence gate: LLM clusters at 0.80/0.85/0.90/0.95; gate at 0.85
+            # keeps the "high certainty" clusters and drops the 0.80 filler tier
+            # (0.90 starved the stream — 2 deltas in 3.5 months).
             if delta.confidence < MIN_DELTA_CONFIDENCE:
                 logger.debug(
                     "Skipping delta below confidence gate: %s (%.2f < %.2f)",

--- a/tests/test_cc/test_delta_confidence_gate.py
+++ b/tests/test_cc/test_delta_confidence_gate.py
@@ -1,0 +1,60 @@
+"""M7 fix: the per-delta confidence gate admits >=0.85 on the CC-bridge path.
+
+Regression lock for the user_model_delta starvation: the original 0.90 gate
+sat above the light model's median output confidence (avg 0.86), so almost
+no delta ever passed — 2 in 3.5 months. Boundary: 0.85 stored, 0.84 dropped.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from genesis.awareness.types import Depth, TickResult
+from genesis.cc.reflection_bridge._output import store_reflection_output
+from genesis.cc.types import CCOutput
+from genesis.perception.types import MIN_DELTA_CONFIDENCE
+
+pytestmark = pytest.mark.asyncio
+
+
+def _tick(now: str) -> TickResult:
+    return TickResult(
+        tick_id="tick-m7", timestamp=now, source="scheduled",
+        signals=[], scores=[], classified_depth=Depth.LIGHT,
+        trigger_reason="test",
+    )
+
+
+def _output(deltas: list[dict]) -> CCOutput:
+    return CCOutput(
+        session_id="refl-m7",
+        text=json.dumps({
+            "assessment": "ok", "patterns": [], "recommendations": [],
+            "confidence": 0.9, "focus_area": "user_impact",
+            "escalate_to_deep": False, "escalation_reason": "",
+            "user_model_updates": deltas,
+            "surplus_candidates": [],
+        }),
+        model_used="haiku", cost_usd=0.0, input_tokens=1, output_tokens=1,
+        duration_ms=1, exit_code=0,
+    )
+
+
+async def test_gate_boundary_admits_085_drops_below(db):
+    assert MIN_DELTA_CONFIDENCE == 0.85
+    now = datetime.now(UTC).isoformat()
+    deltas = [
+        {"field": "at_boundary", "value": "v", "evidence": "e", "confidence": 0.85},
+        {"field": "below_boundary", "value": "v", "evidence": "e", "confidence": 0.84},
+        {"field": "filler_tier", "value": "v", "evidence": "e", "confidence": 0.80},
+    ]
+    await store_reflection_output(Depth.LIGHT, _tick(now), _output(deltas), db=db)
+
+    rows = await db.execute_fetchall(
+        "SELECT content FROM observations WHERE type='user_model_delta'",
+    )
+    stored = {json.loads(r[0])["field"] for r in rows}
+    assert stored == {"at_boundary"}

--- a/tests/test_cc/test_delta_confidence_gate.py
+++ b/tests/test_cc/test_delta_confidence_gate.py
@@ -58,3 +58,39 @@ async def test_gate_boundary_admits_085_drops_below(db):
     )
     stored = {json.loads(r[0])["field"] for r in rows}
     assert stored == {"at_boundary"}
+
+
+def test_prompt_sources_agree_with_gate():
+    """Every prompt source that states a delta-confidence bar states the SAME
+    bar as the enforcing constant, and no exemplar shows a delta the gate
+    would drop. Prompts cannot import constants, so this test is the drift
+    lock. Locks the full class (Codex P2 on #1088: the identity override
+    template — the one PromptBuilder actually prefers — was still at 0.9
+    after the fallback template was fixed)."""
+    import re
+    from pathlib import Path
+
+    import genesis
+    from genesis.cc.reflection_bridge._prompts import LIGHT_FOCUS_INSTRUCTIONS
+
+    root = Path(genesis.__file__).parent
+    sources = {
+        "cc_bridge": LIGHT_FOCUS_INSTRUCTIONS["user_impact"],
+        "fallback_template": (
+            root / "perception/templates/light/user_impact.txt"
+        ).read_text(encoding="utf-8"),
+        "identity_override": (
+            root / "identity/LIGHT_TEMPLATE_USER_IMPACT.md"
+        ).read_text(encoding="utf-8"),
+    }
+    for name, text in sources.items():
+        stated = re.search(r"[Cc]onfidence >= (0\.\d+)", text)
+        assert stated, f"{name} lost its confidence instruction"
+        assert float(stated.group(1)) == MIN_DELTA_CONFIDENCE, (
+            f"{name} states {stated.group(1)}, gate enforces {MIN_DELTA_CONFIDENCE}"
+        )
+        exemplar = re.search(r'"confidence": (0\.\d+)\}', text)
+        if exemplar:
+            assert float(exemplar.group(1)) >= MIN_DELTA_CONFIDENCE, (
+                f"{name} exemplar delta would be dropped by the gate"
+            )

--- a/tests/test_cc/test_delta_confidence_gate.py
+++ b/tests/test_cc/test_delta_confidence_gate.py
@@ -15,6 +15,7 @@ import pytest
 from genesis.awareness.types import Depth, TickResult
 from genesis.cc.reflection_bridge._output import store_reflection_output
 from genesis.cc.types import CCOutput
+from genesis.db.crud import observations
 from genesis.perception.types import MIN_DELTA_CONFIDENCE
 
 pytestmark = pytest.mark.asyncio
@@ -53,10 +54,8 @@ async def test_gate_boundary_admits_085_drops_below(db):
     ]
     await store_reflection_output(Depth.LIGHT, _tick(now), _output(deltas), db=db)
 
-    rows = await db.execute_fetchall(
-        "SELECT content FROM observations WHERE type='user_model_delta'",
-    )
-    stored = {json.loads(r[0])["field"] for r in rows}
+    rows = await observations.query(db, type="user_model_delta")
+    stored = {json.loads(r["content"])["field"] for r in rows}
     assert stored == {"at_boundary"}
 
 

--- a/tests/test_perception/test_writer.py
+++ b/tests/test_perception/test_writer.py
@@ -338,7 +338,7 @@ async def test_user_model_delta_dedup(db):
 
 
 async def test_delta_confidence_gate(db):
-    """Deltas below MIN_DELTA_CONFIDENCE (0.90) are filtered out."""
+    """Deltas below MIN_DELTA_CONFIDENCE (0.85) are filtered out; 0.85 is admitted."""
     from genesis.db.crud import observations
     from genesis.perception.writer import ResultWriter
 
@@ -349,8 +349,9 @@ async def test_delta_confidence_gate(db):
         patterns=[],
         user_model_updates=[
             UserModelDelta(field="role", value="engineer", evidence="mentioned", confidence=0.92),
-            UserModelDelta(field="lang", value="Python", evidence="guessed", confidence=0.85),
-            UserModelDelta(field="os", value="Linux", evidence="weak", confidence=0.89),
+            UserModelDelta(field="lang", value="Python", evidence="stated", confidence=0.85),
+            UserModelDelta(field="os", value="Linux", evidence="weak", confidence=0.84),
+            UserModelDelta(field="editor", value="vim", evidence="filler", confidence=0.80),
         ],
         recommendations=[],
         confidence=0.8,
@@ -360,10 +361,9 @@ async def test_delta_confidence_gate(db):
     await writer.write(output, Depth.LIGHT, tick, db=db)
 
     rows = await observations.query(db, type="user_model_delta")
-    assert len(rows) == 1
-    content = json.loads(rows[0]["content"])
-    assert content["field"] == "role"
-    assert content["confidence"] == 0.92
+    stored = {json.loads(r["content"])["field"] for r in rows}
+    # 0.85 boundary passes; 0.84 and the 0.80 filler tier are filtered.
+    assert stored == {"role", "lang"}
 
 
 async def test_delta_field_value_dedup(db):


### PR DESCRIPTION
## Problem

The `user_model_delta` stream — how Genesis learns about its user — has been effectively dead since the v3 public release. `MIN_DELTA_CONFIDENCE = 0.90` was born at 0.90 and never tuned; the light-reflection model's median output confidence is ~0.86 (784 pre-gate deltas: clusters at 0.80/0.85/0.90/0.95, 63% below 0.90). Result: **2 deltas in 3.5 months**, and `UserModelEvolver` starved. Diagnosed during WS-2 PR-0 (#1077), tracked as follow-up 4519f6cb.

Worse, the prompt was self-contradictory in both sources: it demanded `confidence >= 0.9`, stated "0.85+ means high certainty", and showed a **0.8 exemplar** that the gate silently drops — training the model to emit exactly what gets filtered.

## Fix

- **Gate 0.90 → 0.85** (`perception/types.py`): admits the model's "high certainty" clusters (71% of the historical distribution vs 37%), still drops the 0.80 filler tier the gate exists to suppress. The constant is read by exactly the two `user_model_delta` producers (serena + literal grep enumerated) — no other stream is affected.
- **Prompt reconciliation** in both sources (`reflection_bridge/_prompts.py`, `templates/light/user_impact.txt`): instruction, "high certainty" language, and the exemplar now all agree at 0.85.
- **M7 alarm text** (`awareness/loop.py`) no longer hard-codes the now-stale 0.90 diagnosis.
- **Boundary tests on both producer paths** (0.85 stored, 0.84 dropped): updated perception-writer gate test + new `tests/test_cc/test_delta_confidence_gate.py`.

## Verification

- 59 targeted tests green (`test_perception/test_writer.py`, `test_cc/test_delta_confidence_gate.py`, `test_cc/test_gate2_substrate.py`, `test_awareness/test_user_model_staleness.py`, `test_perception/test_types.py`); ruff clean.
- **Regression markers:** the M7 staleness alarm (shipped in #1077) re-fires within 14d if the stream stays dead — that would point at emission volume, not the gate. Filler deltas polluting the user model would surface as low-value `user_model_delta` observations; the counter-lever is a prompt fix, not re-raising the gate blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)