### PR TITLE
feat(dashboard): Sessions tab cockpit — charter, ledger, waypoints, pulse (session-manager PR-4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   INFO note; a repair that can't complete pages a warning at most daily. Hosts
   where swap-off is deliberate can opt out (`swap_reconcile_enabled: false`).
 
+- **The dashboard has a Sessions cockpit.** A new Sessions tab shows every
+  CC session next to what it's actually FOR: the immutable origin prompt it
+  was born from, its living mission, the full TODO-ledger with status and
+  evidence, a compaction-waypoint timeline, and the repo-pulse panel —
+  "looks shipped by PR #N" proposals you can confirm (closes the item with
+  the PR as evidence) or reject with one click. The overview card's
+  quick-glance modal stays and links through to the full cockpit.
+
 - **Your session TODO ledger now notices when a merged PR ships an item.** N
   parallel sessions each carry open ledger rows, and until now closing them
   meant remembering to do it by hand — work shipped in one session left stale

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -575,8 +575,12 @@ verified: 3403599d 2026-07-16
   Cursor (`cursor.json`, gh-format mergedAt watermark) advances monotonically
   ONLY on recorded ok. Proposals surface in the charter injection block
   (≥ `inject_confidence_floor`, cap 3, confirm-hint) and resolve via
-  `session_ledger_update` → next reconcile sweep;
-  confirmed/(confirmed+rejected) is the fuzzy precision metric. Levers:
+  `session_ledger_update` → next reconcile sweep — or via the dashboard
+  Sessions tab cockpit (PR-4b: per-session charter/ledger/waypoints/pulse
+  detail at `/api/genesis/cc-sessions/<id>/charter`, confirm/reject POST
+  with hint-identical semantics; the waypoints.jsonl spine gets its first
+  reader here); confirmed/(confirmed+rejected) is the fuzzy precision
+  metric. Levers:
   settings domain `repo_pulse` (off|propose_only|live, default live — the
   lever gates only the reversible exact absorb; invalid degrades to
   propose_only). Retention 45d via `scripts/prune_repo_pulse.py`

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import aiosqlite
-from flask import jsonify
+from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
 
@@ -333,6 +333,71 @@ async def _collect_session_detail(
         "waypoints": _load_waypoints(cc_session_id, sessions_dir),
         "pulse": await _pulse_lookup(db, cc_session_id),
     }
+
+
+@blueprint.route("/api/genesis/cc-sessions/pulse/<annotation_id>/resolve", methods=["POST"])
+@_async_route
+async def cc_sessions_pulse_resolve(annotation_id: str):
+    """Resolve a proposed pulse annotation from the cockpit (comms resolve-
+    proposal contract: 400 bad status / 404 unknown / 503 unbootstrapped).
+
+    Confirm carries the SAME semantics as the injected in-session hint —
+    absorb the ledger item with PR evidence, then mark the annotation
+    confirmed — so both resolution paths teach the precision metric the same
+    lesson. Reject touches only the annotation; the ledger item stays open.
+    """
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "not bootstrapped"}), 503
+
+    data = request.get_json(silent=True) or {}
+    status = str(data.get("status", "")).strip().lower()
+    if status not in ("confirmed", "rejected"):
+        return jsonify({"error": "status must be 'confirmed' or 'rejected'"}), 400
+
+    payload, code = await _resolve_pulse(rt.db, annotation_id, status)
+    return jsonify(payload), code
+
+
+async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int]:
+    """Resolve core (extracted so tests exercise it on the fixture loop)."""
+    from genesis.db.crud.repo_pulse import resolve_annotation
+    from genesis.db.crud.session_charters import get_ledger_item, ledger_update
+
+    try:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute(
+            "SELECT * FROM repo_pulse_annotations WHERE id = ?", (annotation_id,)
+        )
+        row = await cursor.fetchone()
+        if row is None or row["status"] != "proposed":
+            return {"error": "unknown or already-resolved annotation"}, 404
+        absorbed = False
+        if status == "confirmed":
+            item = await get_ledger_item(db, row["item_id"])
+            if item is not None and item.get("status") in ("open", "in_progress"):
+                absorbed = await ledger_update(
+                    db,
+                    row["item_id"],
+                    status="absorbed",
+                    evidence=f"PR #{row['pr_number']}: {row['pr_title'] or ''} "
+                    f"[pulse confirm via dashboard]",
+                )
+        ok = await resolve_annotation(
+            db,
+            annotation_id,
+            status=status,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_ref="dashboard",
+        )
+    except (sqlite3.Error, aiosqlite.Error) as exc:
+        logger.error("pulse resolve failed: %s", exc)
+        return {"error": "pulse store unavailable"}, 503
+    if not ok:
+        return {"error": "unknown or already-resolved annotation"}, 404
+    return {"ok": True, "status": status, "item_absorbed": absorbed}, 200
 
 
 @blueprint.route("/api/genesis/cc-sessions/<cc_session_id>/charter")

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -276,12 +276,21 @@ async def _collect_session_detail(
     """Assemble the cockpit payload for one CC session, or None (→ 404) when
     neither a cc_sessions row nor a charter exists for the id."""
     from genesis.db.crud import session_charters as charter_crud
-    from genesis.db.crud.cc_sessions import list_by_cc_session_id
+    from genesis.db.crud.cc_sessions import get_by_id, list_by_cc_session_id
 
     now = now or datetime.now(UTC)
     db.row_factory = aiosqlite.Row
 
     rows = await list_by_cc_session_id(db, cc_session_id)
+    if not rows:
+        # A row registered before its transcript id is known (NULL
+        # cc_session_id — startup/stale-recovery window) is addressable
+        # only by DB row id; the tab's fallback click path sends that.
+        # Charter/waypoint/pulse lookups under a row id simply find
+        # nothing — the cockpit still shows the DB session details.
+        by_row_id = await get_by_id(db, cc_session_id)
+        if by_row_id is not None:
+            rows = [by_row_id]
     session = None
     if rows:
         newest = rows[0]
@@ -368,8 +377,21 @@ async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int
         row = await get_annotation(db, annotation_id)
         if row is None or row["status"] != "proposed":
             return {"error": "unknown or already-resolved annotation"}, 404
+        # Resolve the annotation FIRST: its conditional proposed→terminal
+        # UPDATE is the race arbiter. Two concurrent resolutions can't both
+        # win it, so the ledger absorb below only ever runs for the winner —
+        # never an absorbed item under a rejected annotation. (The inverse
+        # residue — confirmed annotation, absorb missed — is visible and
+        # human-fixable via the injected hint.)
+        ok = await resolve_annotation(
+            db,
+            annotation_id,
+            status=status,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_ref="dashboard",
+        )
         absorbed = False
-        if status == "confirmed":
+        if ok and status == "confirmed":
             item = await get_ledger_item(db, row["item_id"])
             if item is not None and item.get("status") in ("open", "in_progress"):
                 absorbed = await ledger_update(
@@ -379,13 +401,6 @@ async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int
                     evidence=f"PR #{row['pr_number']}: {row['pr_title'] or ''} "
                     f"[pulse confirm via dashboard]",
                 )
-        ok = await resolve_annotation(
-            db,
-            annotation_id,
-            status=status,
-            resolved_at=datetime.now(UTC).isoformat(),
-            resolution_ref="dashboard",
-        )
     except (sqlite3.Error, aiosqlite.Error) as exc:
         logger.error("pulse resolve failed: %s", exc)
         return {"error": "pulse store unavailable"}, 503

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -276,15 +276,12 @@ async def _collect_session_detail(
     """Assemble the cockpit payload for one CC session, or None (→ 404) when
     neither a cc_sessions row nor a charter exists for the id."""
     from genesis.db.crud import session_charters as charter_crud
+    from genesis.db.crud.cc_sessions import list_by_cc_session_id
 
     now = now or datetime.now(UTC)
     db.row_factory = aiosqlite.Row
 
-    cursor = await db.execute(
-        "SELECT * FROM cc_sessions WHERE cc_session_id = ? ORDER BY datetime(started_at) DESC",
-        (cc_session_id,),
-    )
-    rows = [dict(r) for r in await cursor.fetchall()]
+    rows = await list_by_cc_session_id(db, cc_session_id)
     session = None
     if rows:
         newest = rows[0]
@@ -363,15 +360,12 @@ async def cc_sessions_pulse_resolve(annotation_id: str):
 
 async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int]:
     """Resolve core (extracted so tests exercise it on the fixture loop)."""
-    from genesis.db.crud.repo_pulse import resolve_annotation
+    from genesis.db.crud.repo_pulse import get_annotation, resolve_annotation
     from genesis.db.crud.session_charters import get_ledger_item, ledger_update
 
     try:
         db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM repo_pulse_annotations WHERE id = ?", (annotation_id,)
-        )
-        row = await cursor.fetchone()
+        row = await get_annotation(db, annotation_id)
         if row is None or row["status"] != "proposed":
             return {"error": "unknown or already-resolved annotation"}, 404
         absorbed = False

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -1,18 +1,26 @@
-"""CC Sessions dashboard routes — the modal behind the CC Sessions health card.
+"""CC Sessions dashboard routes — list detail + the per-session cockpit.
 
-One endpoint joining the three views of "what CC sessions exist" that today
-never meet: cc_sessions DB rows (registered lifecycle state), the live /proc
-slot scan (actual claude processes), and session charters (what each session
-is FOR — session-manager tables, migration 0058). Their disagreements are the
-point: per-row discrepancy flags surface the divergence the overview card can
-only hint at.
+The list endpoint joins the three views of "what CC sessions exist" that
+otherwise never meet: cc_sessions DB rows (registered lifecycle state), the
+live /proc slot scan (actual claude processes), and session charters (what
+each session is FOR — session-manager tables, migration 0058). Their
+disagreements are the point: per-row discrepancy flags surface the
+divergence the overview card can only hint at. It feeds BOTH the overview
+modal and the Sessions tab list pane (session-manager PR-4b) — one payload,
+drift bounded by construction.
+
+The per-session endpoint is the cockpit detail: full charter (immutable
+origin + living mission/pointers), full ledger rows, the deterministic
+waypoint spine (this is its first reader), and repo-pulse annotations.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import aiosqlite
 from flask import jsonify
@@ -20,6 +28,9 @@ from flask import jsonify
 from genesis.dashboard._blueprint import _async_route, blueprint
 
 logger = logging.getLogger(__name__)
+
+ORIGIN_PROMPT_CAP = 4000  # chars — origins are typically short; a pasted wall is truncated
+WAYPOINT_TAIL = 200  # newest waypoint lines returned (compaction cadence makes this ~weeks)
 
 # Sessions shown in the modal: everything active plus recent history. The
 # cutoff arrives as a parameter (derived from the same `now` as the age
@@ -202,3 +213,144 @@ async def cc_sessions_detail():
 
     slots = enumerate_cc_slots()
     return jsonify(await _collect_detail(rt.db, slots))
+
+
+# ── per-session cockpit detail (session-manager PR-4b) ──────────────────────
+
+
+def _load_waypoints(cc_session_id: str, sessions_dir: Path | None = None) -> dict:
+    """Deterministic waypoint spine from ~/.genesis/sessions/<sid>/waypoints.jsonl.
+
+    This is the file's FIRST reader (the PreCompact hook only appends).
+    Newest WAYPOINT_TAIL lines, per-line corrupt-skip — one torn line must
+    not hide the rest of the spine.
+    """
+    base = sessions_dir or (Path.home() / ".genesis" / "sessions")
+    path = base / cc_session_id / "waypoints.jsonl"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {"available": False, "truncated": False, "items": []}
+    items = []
+    for line in lines[-WAYPOINT_TAIL:]:
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(entry, dict):
+            items.append(
+                {
+                    "ts": entry.get("ts"),
+                    "trigger": entry.get("trigger"),
+                    "transcript_bytes": entry.get("transcript_bytes"),
+                }
+            )
+    return {"available": True, "truncated": len(lines) > WAYPOINT_TAIL, "items": items}
+
+
+async def _pulse_lookup(db, cc_session_id: str) -> dict:
+    """Repo-pulse annotations for this session's ledger items (PR-4a store).
+
+    Defensive like _charter_lookup: pre-0062 installs have no pulse tables —
+    the panel then shows available=False instead of erroring. This degrade
+    path must survive forever (independent-mergeability regression contract).
+    """
+    try:
+        from genesis.db.crud.repo_pulse import list_annotations, summary
+
+        annotations = await list_annotations(db, session_id=cc_session_id, limit=100)
+        health = await summary(db)
+    except Exception as exc:
+        logger.debug("pulse tables unavailable (pre-0062 install?): %s", exc)
+        return {"available": False, "annotations": [], "health": None}
+    return {"available": True, "annotations": annotations, "health": health}
+
+
+async def _collect_session_detail(
+    db,
+    cc_session_id: str,
+    *,
+    sessions_dir: Path | None = None,
+    now: datetime | None = None,
+) -> dict | None:
+    """Assemble the cockpit payload for one CC session, or None (→ 404) when
+    neither a cc_sessions row nor a charter exists for the id."""
+    from genesis.db.crud import session_charters as charter_crud
+
+    now = now or datetime.now(UTC)
+    db.row_factory = aiosqlite.Row
+
+    cursor = await db.execute(
+        "SELECT * FROM cc_sessions WHERE cc_session_id = ? ORDER BY datetime(started_at) DESC",
+        (cc_session_id,),
+    )
+    rows = [dict(r) for r in await cursor.fetchall()]
+    session = None
+    if rows:
+        newest = rows[0]
+        session = {
+            "id": newest["id"],
+            "cc_session_id": cc_session_id,
+            "session_type": newest.get("session_type"),
+            "status": newest.get("status"),
+            "model": newest.get("model"),
+            "channel": newest.get("channel"),
+            "started_at": newest.get("started_at"),
+            "last_activity_at": newest.get("last_activity_at"),
+            "age_s": _age_seconds(newest.get("started_at"), now),
+            "idle_s": _age_seconds(newest.get("last_activity_at"), now),
+            "cost_usd": newest.get("cost_usd"),
+            "session_row_count": len(rows),
+        }
+
+    charter = None
+    ledger: dict = {"items": [], "counts": {}}
+    charters_available = True
+    try:
+        charter_row = await charter_crud.get(db, cc_session_id)
+        if charter_row is not None:
+            charter = dict(charter_row)
+            # crud.get already JSON-decodes pointers; guard the shape only.
+            if not isinstance(charter.get("pointers"), list):
+                charter["pointers"] = []
+            origin = str(charter.get("origin_prompt") or "")
+            charter["origin_truncated"] = len(origin) > ORIGIN_PROMPT_CAP
+            charter["origin_prompt"] = origin[:ORIGIN_PROMPT_CAP]
+        ledger["items"] = await charter_crud.ledger_list(db, cc_session_id)
+        ledger["counts"] = await charter_crud.ledger_counts(db, cc_session_id)
+    except (sqlite3.Error, aiosqlite.Error) as exc:
+        logger.debug("charter tables unavailable (pre-0058 install?): %s", exc)
+        charters_available = False
+
+    if session is None and charter is None:
+        return None
+
+    return {
+        "session": session,
+        "charters_available": charters_available,
+        "charter": charter,
+        "ledger": ledger,
+        "waypoints": _load_waypoints(cc_session_id, sessions_dir),
+        "pulse": await _pulse_lookup(db, cc_session_id),
+    }
+
+
+@blueprint.route("/api/genesis/cc-sessions/<cc_session_id>/charter")
+@_async_route
+async def cc_session_charter(cc_session_id: str):
+    """Full cockpit detail for one CC session: charter (immutable origin +
+    living mission/pointers), ledger rows, waypoint timeline, pulse panel."""
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "not bootstrapped"}), 503
+    # Traversal guard (mirrors the PreCompact hook): the id names a directory
+    # under ~/.genesis/sessions.
+    if "/" in cc_session_id or ".." in cc_session_id:
+        return jsonify({"error": "invalid session id"}), 400
+
+    detail = await _collect_session_detail(rt.db, cc_session_id)
+    if detail is None:
+        return jsonify({"error": "unknown session"}), 404
+    return jsonify(detail)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -55,6 +55,7 @@
   {%- include "partials/tabs/chat.html" %}
   {%- include "partials/tabs/files.html" %}
   {%- include "partials/tabs/work.html" %}
+  {%- include "partials/tabs/sessions.html" %}
   {%- include "partials/tabs/observations.html" %}
   {%- include "partials/tabs/follow_ups.html" %}
   {%- include "partials/tabs/traces.html" %}

--- a/src/genesis/dashboard/templates/partials/chrome/header.html
+++ b/src/genesis/dashboard/templates/partials/chrome/header.html
@@ -69,6 +69,8 @@
               @click="location.hash = 'chat'">Comms</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'work' }"
               @click="location.hash = 'work'">Work</button>
+      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'sessions' }"
+              @click="location.hash = 'sessions'">Sessions</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'follow-ups' }"
               @click="location.hash = 'follow-ups'">Follow-ups</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'observations' }"

--- a/src/genesis/dashboard/templates/partials/modals/cc_sessions.html
+++ b/src/genesis/dashboard/templates/partials/modals/cc_sessions.html
@@ -107,6 +107,12 @@
                 </template>
               </div>
             </template>
+
+            <!-- Bridge to the Sessions tab cockpit (session-manager PR-4b) -->
+            <div style="margin-top: 1rem; text-align: right;">
+              <a href="#sessions" style="font-size: 0.8rem; color: #3b82f6; cursor: pointer; text-decoration: none;"
+                 @click="$store.genesisDashboard.ccSessionsModal.open = false; $store.genesisDashboard.navigateTo('sessions')">full cockpit →</a>
+            </div>
           </div>
         </template>
       </div>

--- a/src/genesis/dashboard/templates/partials/tabs/sessions.html
+++ b/src/genesis/dashboard/templates/partials/tabs/sessions.html
@@ -1,0 +1,124 @@
+
+
+    <!-- Sessions tab — CC sessions cockpit (session-manager PR-4b).
+         List pane consumes the SAME /api/genesis/cc-sessions/detail payload as
+         the overview modal (drift bounded by construction); the detail pane is
+         the per-session cockpit: charter, ledger rows, waypoints, pulse. -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'sessions'" style="overflow-y: auto; max-height: calc(100vh - 180px);">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">terminal</span>
+        CC Sessions
+        <span class="panel-status">
+          <span class="status-dot" :style="`background:${$store.genesisDashboard.modalStateColor($store.genesisDashboard.sessionsTab)}`"></span>
+          <span x-text="$store.genesisDashboard.modalStateLabel($store.genesisDashboard.sessionsTab)"></span>
+        </span>
+      </div>
+      <div style="padding: 1rem;">
+        <div x-show="$store.genesisDashboard.sessionsTab.fetch.state === 'loading' && !$store.genesisDashboard.sessionsTab.data"
+             style="text-align: center; padding: 2rem; color: var(--color-text-secondary);">Loading...</div>
+        <div x-show="$store.genesisDashboard.sessionsTab.fetch.state === 'error' && !$store.genesisDashboard.sessionsTab.data"
+             class="empty-state">CC session detail unavailable.</div>
+        <template x-if="$store.genesisDashboard.sessionsTab.data">
+          <div style="display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap;">
+
+            <!-- ── List pane ── -->
+            <div style="flex: 1 1 460px; min-width: 420px;">
+              <!-- Summary stats (clickable filters — ported from the overview modal) -->
+              <div style="display: flex; gap: 0.5rem; margin-bottom: 0.6rem; flex-wrap: wrap;">
+                <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; transition: opacity 0.15s;"
+                     :style="`background: rgba(76,175,80,${$store.genesisDashboard.sessionsTab.filter === 'active' ? '0.3' : '0.12'}); color: #4caf50; opacity: ${!$store.genesisDashboard.sessionsTab.filter || $store.genesisDashboard.sessionsTab.filter === 'active' ? '1' : '0.5'}`"
+                     title="Sessions marked active in the DB"
+                     @click="$store.genesisDashboard.sessionsTab.filter = $store.genesisDashboard.sessionsTab.filter === 'active' ? null : 'active'">
+                  <span x-text="($store.genesisDashboard.sessionsTab.data.stats?.db_active || 0)"></span> db-active
+                </div>
+                <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px;"
+                     :style="`background: rgba(59,130,246,0.12); color: #3b82f6;`"
+                     title="Live claude processes carrying GENESIS_SLOT (from /proc) — informational, not a filter">
+                  <span x-text="($store.genesisDashboard.sessionsTab.data.stats?.live_procs || 0)"></span> live procs
+                </div>
+                <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; transition: opacity 0.15s;"
+                     :style="`background: rgba(217,83,79,${$store.genesisDashboard.sessionsTab.filter === 'discrepant' ? '0.3' : '0.12'}); color: #d9534f; opacity: ${!$store.genesisDashboard.sessionsTab.filter || $store.genesisDashboard.sessionsTab.filter === 'discrepant' ? '1' : '0.5'}`"
+                     title="Rows where DB state and live processes disagree — count includes live processes with no DB row (listed below the table)"
+                     @click="$store.genesisDashboard.sessionsTab.filter = $store.genesisDashboard.sessionsTab.filter === 'discrepant' ? null : 'discrepant'">
+                  <span x-text="($store.genesisDashboard.sessionsTab.data.stats?.discrepant || 0)"></span> discrepant
+                </div>
+                <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; transition: opacity 0.15s;"
+                     :style="`background: rgba(100,116,139,${$store.genesisDashboard.sessionsTab.filter === 'completed' ? '0.3' : '0.12'}); color: #94a3b8; opacity: ${!$store.genesisDashboard.sessionsTab.filter || $store.genesisDashboard.sessionsTab.filter === 'completed' ? '1' : '0.5'}`"
+                     @click="$store.genesisDashboard.sessionsTab.filter = $store.genesisDashboard.sessionsTab.filter === 'completed' ? null : 'completed'">
+                  <span x-text="($store.genesisDashboard.sessionsTab.data.stats?.completed_24h || 0)"></span> completed (24h)
+                </div>
+              </div>
+
+              <div style="font-size: 0.74rem; color: var(--color-text-secondary); margin-bottom: 1rem;"
+                   x-text="'Hourly budget: ' + ($store.genesisDashboard.health.cc_sessions?.background?.hourly_budget || '—') + ' sessions started this hour (a rate cap — not a session count)'"></div>
+
+              <template x-if="($store.genesisDashboard.sessionsTab.data.sessions || []).length === 0">
+                <div style="font-size: 0.78rem; color: var(--color-text-secondary); padding: 1rem; text-align: center;">
+                  No CC sessions in the last 24 hours.
+                </div>
+              </template>
+              <div style="max-height: 480px; overflow-y: auto;">
+                <template x-for="s in ($store.genesisDashboard.sessionsTab.data.sessions || []).filter(s => {
+                  const f = $store.genesisDashboard.sessionsTab.filter;
+                  if (!f) return true;
+                  if (f === 'discrepant') return (s.flags || []).length > 0;
+                  return s.status === f;
+                })" :key="s.id">
+                  <div style="font-size: 0.78rem; padding: 0.4rem 0.5rem; border-bottom: 1px solid var(--color-border); display: flex; align-items: center; gap: 0.5rem; cursor: pointer;"
+                       :style="$store.genesisDashboard.sessionsTab.selectedId === (s.cc_session_id || s.id) ? 'background: rgba(59,130,246,0.10);' : ''"
+                       @click="$store.genesisDashboard.openSessionRow(s)">
+                    <span class="status-dot" :style="`background: ${s.status === 'active' ? '#4caf50' : s.status === 'failed' ? '#d9534f' : s.status === 'completed' ? '#64748b' : '#f0ad4e'}`"></span>
+                    <span style="font-family: monospace; min-width: 74px;" :title="s.cc_session_id || s.id"
+                          x-text="(s.cc_session_id || s.id).slice(0, 8)"></span>
+                    <span style="min-width: 52px; color: var(--color-text-secondary);"
+                          x-text="s.session_type === 'foreground' ? 'fg' : s.session_type === 'background_reflection' ? 'bg-refl' : 'bg-task'"></span>
+                    <span style="min-width: 90px; color: var(--color-text-secondary); text-overflow: ellipsis; overflow: hidden; white-space: nowrap;"
+                          x-text="s.model || '-'" :title="s.model || ''"></span>
+                    <span style="min-width: 74px; color: var(--color-text-secondary);"
+                          x-text="s.idle_s != null ? $store.genesisDashboard.formatAgeSeconds(s.idle_s) + ' idle' : '-'"></span>
+                    <span style="min-width: 90px;" :style="`color: ${s.live ? '#3b82f6' : 'var(--color-text-secondary)'}`"
+                          x-text="s.live ? ('#' + s.live.slot + ' pid ' + s.live.pid) : '—'"></span>
+                    <template x-if="$store.genesisDashboard.sessionsTab.data.charters_available">
+                      <span style="min-width: 110px; flex: 1; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;"
+                            :title="s.charter ? ((s.charter.mission || 'no mission') + ' · ' + s.charter.compaction_count + ' compactions · ' + s.charter.ledger_open + ' open of ' + s.charter.ledger_total) : 'no charter'"
+                            x-text="s.charter ? ((s.charter.mission || '(no mission)').slice(0, 32) + ' ⟳' + s.charter.compaction_count + ' · ' + s.charter.ledger_open + ' open') : '—'"></span>
+                    </template>
+                    <template x-if="(s.flags || []).includes('db_active_no_proc')">
+                      <span style="font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; background: rgba(217,83,79,0.15); color: #d9534f; white-space: nowrap;">db-active, no proc</span>
+                    </template>
+                    <template x-if="(s.flags || []).includes('proc_but_db_inactive')">
+                      <span style="font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; background: rgba(240,173,78,0.15); color: #f0ad4e; white-space: nowrap;"
+                            x-text="'proc alive, db says ' + s.status"></span>
+                    </template>
+                  </div>
+                </template>
+              </div>
+
+              <template x-if="($store.genesisDashboard.sessionsTab.data.unmatched_slots || []).length > 0">
+                <div style="margin-top: 1rem; padding: 0.5rem 0.8rem; background: rgba(217,83,79,0.08); border-radius: 6px; border: 1px solid rgba(217,83,79,0.2);">
+                  <div style="font-size: 0.78rem; font-weight: 600; color: #d9534f; margin-bottom: 0.3rem;">Live processes with no DB session row</div>
+                  <template x-for="u in $store.genesisDashboard.sessionsTab.data.unmatched_slots" :key="u.pid">
+                    <div style="font-size: 0.75rem; color: #f87171;"
+                         x-text="'#' + u.slot + ' pid ' + u.pid + ' ' + (u.rss_mb / 1024).toFixed(1) + 'G (' + u.status + ')'"></div>
+                  </template>
+                </div>
+              </template>
+            </div>
+
+            <!-- ── Detail pane (cockpit) ── -->
+            <div style="flex: 1 1 480px; min-width: 420px;">
+              <template x-if="!$store.genesisDashboard.sessionsTab.selectedId">
+                <div class="empty-state" style="padding: 3rem 1rem;">Select a session to open its cockpit — charter, ledger, waypoints, pulse.</div>
+              </template>
+              <template x-if="$store.genesisDashboard.sessionsTab.detailError">
+                <div class="empty-state" x-text="$store.genesisDashboard.sessionsTab.detailError"></div>
+              </template>
+              <template x-if="$store.genesisDashboard.sessionsTab.selectedId && !$store.genesisDashboard.sessionsTab.detail && !$store.genesisDashboard.sessionsTab.detailError">
+                <div style="text-align: center; padding: 2rem; color: var(--color-text-secondary);">Loading cockpit...</div>
+              </template>
+            </div>
+
+          </div>
+        </template>
+      </div>
+    </div>

--- a/src/genesis/dashboard/templates/partials/tabs/sessions.html
+++ b/src/genesis/dashboard/templates/partials/tabs/sessions.html
@@ -116,6 +116,127 @@
               <template x-if="$store.genesisDashboard.sessionsTab.selectedId && !$store.genesisDashboard.sessionsTab.detail && !$store.genesisDashboard.sessionsTab.detailError">
                 <div style="text-align: center; padding: 2rem; color: var(--color-text-secondary);">Loading cockpit...</div>
               </template>
+              <template x-if="$store.genesisDashboard.sessionsTab.detail">
+                <div>
+                  <!-- Session header -->
+                  <div style="display: flex; align-items: baseline; gap: 0.6rem; margin-bottom: 0.8rem; flex-wrap: wrap;">
+                    <span style="font-family: monospace; font-size: 0.9rem; font-weight: 700;"
+                          x-text="$store.genesisDashboard.sessionsTab.selectedId.slice(0, 8)"
+                          :title="$store.genesisDashboard.sessionsTab.selectedId"></span>
+                    <template x-if="$store.genesisDashboard.sessionsTab.detail.session">
+                      <span style="font-size: 0.75rem; color: var(--color-text-secondary);"
+                            x-text="($store.genesisDashboard.sessionsTab.detail.session.session_type || '?') + ' · ' + ($store.genesisDashboard.sessionsTab.detail.session.status || '?') + ' · ' + ($store.genesisDashboard.sessionsTab.detail.session.model || '-') + ($store.genesisDashboard.sessionsTab.detail.session.session_row_count > 1 ? ' · ' + $store.genesisDashboard.sessionsTab.detail.session.session_row_count + ' db rows' : '')"></span>
+                    </template>
+                  </div>
+
+                  <!-- Charter: immutable origin + living mission/pointers -->
+                  <template x-if="$store.genesisDashboard.sessionsTab.detail.charter">
+                    <div style="margin-bottom: 1rem;">
+                      <div style="font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-secondary); margin-bottom: 0.3rem;">
+                        Origin <span style="font-style: italic;">(immutable — the prompt this session was born from,
+                        <span x-text="$store.genesisDashboard.sessionsTab.detail.charter.origin_ts || 'time unknown'"></span>)</span>
+                      </div>
+                      <div style="font-size: 0.8rem; background: var(--color-background); border-left: 3px solid #64748b; border-radius: 4px; padding: 0.6rem 0.8rem; white-space: pre-wrap; max-height: 180px; overflow-y: auto;"
+                           x-text="($store.genesisDashboard.sessionsTab.detail.charter.origin_prompt || '(origin not yet chartered)') + ($store.genesisDashboard.sessionsTab.detail.charter.origin_truncated ? ' …[truncated]' : '')"></div>
+                      <div style="display: flex; gap: 1rem; margin-top: 0.5rem; font-size: 0.78rem; flex-wrap: wrap;">
+                        <div><span style="color: var(--color-text-secondary);">Mission:</span>
+                          <span x-text="$store.genesisDashboard.sessionsTab.detail.charter.mission || '(unset)'"></span></div>
+                        <div><span style="color: var(--color-text-secondary);">Compactions:</span>
+                          <span x-text="$store.genesisDashboard.sessionsTab.detail.charter.compaction_count ?? 0"></span></div>
+                      </div>
+                      <template x-if="($store.genesisDashboard.sessionsTab.detail.charter.pointers || []).length > 0">
+                        <div style="font-size: 0.75rem; margin-top: 0.3rem;">
+                          <span style="color: var(--color-text-secondary);">Pointers:</span>
+                          <template x-for="p in $store.genesisDashboard.sessionsTab.detail.charter.pointers" :key="p">
+                            <div style="font-family: monospace; margin-left: 0.8rem;" x-text="p"></div>
+                          </template>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                  <template x-if="!$store.genesisDashboard.sessionsTab.detail.charter && $store.genesisDashboard.sessionsTab.detail.charters_available">
+                    <div style="font-size: 0.78rem; color: var(--color-text-secondary); margin-bottom: 1rem;">No charter yet — it persists at this session's first compaction.</div>
+                  </template>
+
+                  <!-- Ledger rows -->
+                  <div style="margin-bottom: 1rem;">
+                    <div style="font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-secondary); margin-bottom: 0.3rem;"
+                         x-text="'Ledger (' + Object.entries($store.genesisDashboard.sessionsTab.detail.ledger?.counts || {}).map(([k, v]) => v + ' ' + k).join(' · ') + ')' ">
+                    </div>
+                    <template x-if="($store.genesisDashboard.sessionsTab.detail.ledger?.items || []).length === 0">
+                      <div style="font-size: 0.78rem; color: var(--color-text-secondary);">No ledger rows.</div>
+                    </template>
+                    <template x-for="item in ($store.genesisDashboard.sessionsTab.detail.ledger?.items || [])" :key="item.id">
+                      <div style="font-size: 0.78rem; padding: 0.35rem 0.4rem; border-bottom: 1px solid var(--color-border);">
+                        <div style="display: flex; align-items: center; gap: 0.5rem;">
+                          <span style="font-size: 0.68rem; padding: 0.08rem 0.4rem; border-radius: 8px; white-space: nowrap;"
+                                :style="`background: ${item.status === 'open' ? 'rgba(76,175,80,0.15)' : item.status === 'in_progress' ? 'rgba(240,173,78,0.15)' : item.status === 'absorbed' ? 'rgba(59,130,246,0.15)' : item.status === 'dropped' ? 'rgba(217,83,79,0.15)' : 'rgba(100,116,139,0.15)'}; color: ${item.status === 'open' ? '#4caf50' : item.status === 'in_progress' ? '#f0ad4e' : item.status === 'absorbed' ? '#3b82f6' : item.status === 'dropped' ? '#d9534f' : '#94a3b8'}`"
+                                x-text="item.status"></span>
+                          <span style="font-size: 0.68rem; padding: 0.08rem 0.4rem; border-radius: 8px; white-space: nowrap;"
+                                :style="`background: ${item.added_by === 'pulse' ? 'rgba(168,85,247,0.15)' : 'rgba(100,116,139,0.10)'}; color: ${item.added_by === 'pulse' ? '#a855f7' : 'var(--color-text-secondary)'}`"
+                                x-text="item.added_by"></span>
+                          <span style="flex: 1;" x-text="item.text" :title="'id: ' + item.id + (item.source_ref ? ' · ref: ' + item.source_ref : '')"></span>
+                        </div>
+                        <template x-if="item.evidence">
+                          <details style="margin: 0.15rem 0 0 0.5rem;">
+                            <summary style="font-size: 0.72rem; color: var(--color-text-secondary); cursor: pointer;">evidence</summary>
+                            <div style="font-size: 0.74rem; color: var(--color-text-secondary); white-space: pre-wrap;" x-text="item.evidence"></div>
+                          </details>
+                        </template>
+                      </div>
+                    </template>
+                  </div>
+
+                  <!-- Waypoints timeline (first reader of the deterministic spine) -->
+                  <div style="margin-bottom: 1rem;">
+                    <div style="font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-secondary); margin-bottom: 0.3rem;">
+                      Waypoints <span x-show="$store.genesisDashboard.sessionsTab.detail.waypoints?.truncated" style="font-style: italic;">(newest 200)</span>
+                    </div>
+                    <template x-if="!$store.genesisDashboard.sessionsTab.detail.waypoints?.available || ($store.genesisDashboard.sessionsTab.detail.waypoints?.items || []).length === 0">
+                      <div style="font-size: 0.78rem; color: var(--color-text-secondary);">No waypoints — none recorded before the first compaction.</div>
+                    </template>
+                    <div style="max-height: 160px; overflow-y: auto;">
+                      <template x-for="(w, wi) in ($store.genesisDashboard.sessionsTab.detail.waypoints?.items || [])" :key="wi">
+                        <div style="font-size: 0.75rem; display: flex; gap: 0.6rem; padding: 0.15rem 0.3rem; color: var(--color-text-secondary);">
+                          <span style="min-width: 140px;" x-text="w.ts ? $store.genesisDashboard.formatDateTime(w.ts) : '?'"></span>
+                          <span style="font-size: 0.68rem; padding: 0.05rem 0.4rem; border-radius: 8px; background: rgba(59,130,246,0.12); color: #3b82f6;"
+                                x-text="w.trigger || '?'"></span>
+                          <span x-text="w.transcript_bytes != null ? (w.transcript_bytes / 1048576).toFixed(1) + ' MB' : '—'"></span>
+                          <span x-show="wi > 0 && w.transcript_bytes != null && $store.genesisDashboard.sessionsTab.detail.waypoints.items[wi-1].transcript_bytes != null"
+                                x-text="'(+' + ((w.transcript_bytes - ($store.genesisDashboard.sessionsTab.detail.waypoints.items[wi-1].transcript_bytes || 0)) / 1048576).toFixed(1) + ' MB)'"></span>
+                        </div>
+                      </template>
+                    </div>
+                  </div>
+
+                  <!-- Pulse panel (repo-pulse annotations; actions land with the resolve endpoint) -->
+                  <div>
+                    <div style="font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-secondary); margin-bottom: 0.3rem;">Pulse</div>
+                    <template x-if="!$store.genesisDashboard.sessionsTab.detail.pulse?.available">
+                      <div style="font-size: 0.78rem; color: var(--color-text-secondary);">Pulse store unavailable (pre-0062 install).</div>
+                    </template>
+                    <template x-if="$store.genesisDashboard.sessionsTab.detail.pulse?.available">
+                      <div>
+                        <div style="font-size: 0.74rem; color: var(--color-text-secondary); margin-bottom: 0.3rem;"
+                             x-text="'Runs: ' + Object.entries($store.genesisDashboard.sessionsTab.detail.pulse.health?.runs || {}).map(([k, v]) => v + ' ' + k).join(' · ') + ($store.genesisDashboard.sessionsTab.detail.pulse.health?.precision != null ? ' · fuzzy precision ' + $store.genesisDashboard.sessionsTab.detail.pulse.health.precision : '')"></div>
+                        <template x-if="($store.genesisDashboard.sessionsTab.detail.pulse.annotations || []).length === 0">
+                          <div style="font-size: 0.78rem; color: var(--color-text-secondary);">No PR matches for this session's ledger items yet.</div>
+                        </template>
+                        <template x-for="a in ($store.genesisDashboard.sessionsTab.detail.pulse.annotations || [])" :key="a.id">
+                          <div style="font-size: 0.78rem; padding: 0.3rem 0.4rem; border-bottom: 1px solid var(--color-border); display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;">
+                            <span style="font-size: 0.68rem; padding: 0.08rem 0.4rem; border-radius: 8px; white-space: nowrap;"
+                                  :style="`background: ${a.status === 'applied' ? 'rgba(59,130,246,0.15)' : a.status === 'proposed' ? 'rgba(240,173,78,0.15)' : a.status === 'confirmed' ? 'rgba(76,175,80,0.15)' : a.status === 'rejected' ? 'rgba(217,83,79,0.15)' : 'rgba(100,116,139,0.15)'}; color: ${a.status === 'applied' ? '#3b82f6' : a.status === 'proposed' ? '#f0ad4e' : a.status === 'confirmed' ? '#4caf50' : a.status === 'rejected' ? '#d9534f' : '#94a3b8'}`"
+                                  x-text="a.tier + ' · ' + a.status"></span>
+                            <span style="flex: 1; min-width: 200px;"
+                                  :title="(a.rationale || '') + (a.resolution_ref ? ' · resolved: ' + a.resolution_ref : '')"
+                                  x-text="'“' + (a.item_text || a.item_id).slice(0, 44) + '” ↔ PR #' + a.pr_number + (a.confidence != null ? ' @' + a.confidence : '')"></span>
+                          </div>
+                        </template>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
             </div>
 
           </div>

--- a/src/genesis/dashboard/templates/partials/tabs/sessions.html
+++ b/src/genesis/dashboard/templates/partials/tabs/sessions.html
@@ -230,6 +230,18 @@
                             <span style="flex: 1; min-width: 200px;"
                                   :title="(a.rationale || '') + (a.resolution_ref ? ' · resolved: ' + a.resolution_ref : '')"
                                   x-text="'“' + (a.item_text || a.item_id).slice(0, 44) + '” ↔ PR #' + a.pr_number + (a.confidence != null ? ' @' + a.confidence : '')"></span>
+                            <template x-if="a.status === 'proposed'">
+                              <span style="display: flex; gap: 0.3rem;">
+                                <button style="font-size: 0.7rem; padding: 0.1rem 0.5rem; border-radius: 4px; border: 1px solid rgba(76,175,80,0.4); background: rgba(76,175,80,0.12); color: #4caf50; cursor: pointer;"
+                                        :disabled="$store.genesisDashboard.sessionsTab.resolvingId === a.id"
+                                        title="Absorb the ledger item with this PR as evidence and count the match as confirmed"
+                                        @click="$store.genesisDashboard.resolvePulseAnnotation(a, 'confirmed')">confirm</button>
+                                <button style="font-size: 0.7rem; padding: 0.1rem 0.5rem; border-radius: 4px; border: 1px solid rgba(217,83,79,0.4); background: rgba(217,83,79,0.12); color: #d9534f; cursor: pointer;"
+                                        :disabled="$store.genesisDashboard.sessionsTab.resolvingId === a.id"
+                                        title="Not a real match — the ledger item stays open"
+                                        @click="$store.genesisDashboard.resolvePulseAnnotation(a, 'rejected')">reject</button>
+                              </span>
+                            </template>
                           </div>
                         </template>
                       </div>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3988,8 +3988,13 @@
             if (resp?.ok && this.sessionsTab.selectedId) {
               await this.fetchSessionCharter(this.sessionsTab.selectedId, { silent: true });
               this.fetchSessionsTab();
+            } else if (resp && !resp.ok) {
+              const body = await resp.json().catch(() => ({}));
+              alert(`Pulse resolve failed: ${body.error || resp.status}`);
             }
-          } catch { /* panel refresh shows the truth either way */ }
+          } catch {
+            alert("Pulse resolve failed: network error");
+          }
           this.sessionsTab.resolvingId = null;
         },
 

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -87,6 +87,15 @@
           filter: null,
           fetch: { state: "idle", lastSuccess: null, error: null },
         },
+        sessionsTab: {
+          data: null,
+          filter: null,
+          selectedId: null,
+          detail: null,
+          detailError: null,
+          resolvingId: null,
+          fetch: { state: "idle", lastSuccess: null, error: null },
+        },
         outreachModal: {
           open: false,
           messages: [],
@@ -302,6 +311,7 @@
         _activityInterval: null,
 
         _sessionsInterval: null,
+        _ccSessionsTabInterval: null,
         _modulesInterval: null,
         _routingInterval: null,
         _approvalsInterval: null,
@@ -372,6 +382,7 @@
           knowledge: [],
           campaigns: ["_campaignsInterval"],
           backup:    [],
+          sessions:  ["_ccSessionsTabInterval"],
         },
 
         // ── Campaigns ──
@@ -447,7 +458,7 @@
 
         initTab() {
           const hash = location.hash.replace("#", "") || "overview";
-          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "campaigns", "references", "backup"];
+          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "campaigns", "references", "backup", "sessions"];
           this.activeTab = valid.includes(hash) ? hash : "overview";
           window.addEventListener("hashchange", () => {
             const h = location.hash.replace("#", "");
@@ -539,6 +550,13 @@
               break;
             case "backup":
               if (first) { this.fetchBackupStatus(); this.fetchBackupConfig(); this.fetchUpdateStatus(); this.fetchUpdateProgress(); }
+              break;
+            case "sessions":
+              if (first) { this.fetchSessionsTab(); }
+              this._ccSessionsTabInterval = setInterval(() => {
+                this.fetchSessionsTab();
+                if (this.sessionsTab.selectedId) this.fetchSessionCharter(this.sessionsTab.selectedId, { silent: true });
+              }, 15000);
               break;
           }
         },
@@ -3929,6 +3947,51 @@
             }
           } catch {
             this.failModalFetch("ccSessionsModal", "CC session detail unavailable");
+          }
+        },
+
+        // ── Sessions tab (session-manager PR-4b cockpit) ──
+        // List pane shares /cc-sessions/detail with the overview modal — one
+        // payload, drift bounded by construction.
+        async fetchSessionsTab() {
+          this.startModalFetch("sessionsTab");
+          try {
+            const resp = await fetchApi("/api/genesis/cc-sessions/detail");
+            if (resp?.ok) {
+              this.sessionsTab.data = await resp.json();
+              this.finishModalFetch("sessionsTab");
+            } else {
+              this.failModalFetch("sessionsTab", "CC session detail unavailable");
+            }
+          } catch {
+            this.failModalFetch("sessionsTab", "CC session detail unavailable");
+          }
+        },
+
+        openSessionRow(s) {
+          const id = s.cc_session_id || s.id;
+          this.sessionsTab.selectedId = id;
+          this.sessionsTab.detail = null;
+          this.sessionsTab.detailError = null;
+          this.fetchSessionCharter(id);
+        },
+
+        async fetchSessionCharter(ccSessionId, opts = {}) {
+          try {
+            const resp = await fetchApi(`/api/genesis/cc-sessions/${encodeURIComponent(ccSessionId)}/charter`);
+            if (resp?.ok) {
+              // Discard a stale response if the user clicked another row meanwhile
+              if (this.sessionsTab.selectedId === ccSessionId) {
+                this.sessionsTab.detail = await resp.json();
+                this.sessionsTab.detailError = null;
+              }
+            } else if (!opts.silent && this.sessionsTab.selectedId === ccSessionId) {
+              this.sessionsTab.detailError = resp?.status === 404 ? "No charter or session row for this id." : "Session detail unavailable.";
+            }
+          } catch {
+            if (!opts.silent && this.sessionsTab.selectedId === ccSessionId) {
+              this.sessionsTab.detailError = "Session detail unavailable.";
+            }
           }
         },
 

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3976,6 +3976,23 @@
           this.fetchSessionCharter(id);
         },
 
+        async resolvePulseAnnotation(a, status) {
+          if (status === "rejected" && !confirm("Reject this pulse proposal? It counts against fuzzy precision.")) return;
+          this.sessionsTab.resolvingId = a.id;
+          try {
+            const resp = await fetchApi(`/api/genesis/cc-sessions/pulse/${encodeURIComponent(a.id)}/resolve`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ status }),
+            });
+            if (resp?.ok && this.sessionsTab.selectedId) {
+              await this.fetchSessionCharter(this.sessionsTab.selectedId, { silent: true });
+              this.fetchSessionsTab();
+            }
+          } catch { /* panel refresh shows the truth either way */ }
+          this.sessionsTab.resolvingId = null;
+        },
+
         async fetchSessionCharter(ccSessionId, opts = {}) {
           try {
             const resp = await fetchApi(`/api/genesis/cc-sessions/${encodeURIComponent(ccSessionId)}/charter`);

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -32,9 +32,22 @@ async def create(
             pid, started_at, last_activity_at, source_tag, metadata, thread_id,
             origin_class)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (id, session_type, user_id, channel, model, effort, status,
-         pid, started_at, last_activity_at, source_tag, metadata, thread_id,
-         origin_class),
+        (
+            id,
+            session_type,
+            user_id,
+            channel,
+            model,
+            effort,
+            status,
+            pid,
+            started_at,
+            last_activity_at,
+            source_tag,
+            metadata,
+            thread_id,
+            origin_class,
+        ),
     )
     await db.commit()
     return id
@@ -44,6 +57,19 @@ async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
     cursor = await db.execute("SELECT * FROM cc_sessions WHERE id = ?", (id,))
     row = await cursor.fetchone()
     return dict(row) if row else None
+
+
+async def list_by_cc_session_id(db: aiosqlite.Connection, cc_session_id: str) -> list[dict]:
+    """All rows sharing one CC transcript session id, newest started first.
+
+    A conversation can accumulate multiple lifecycle rows (restarts,
+    re-registrations) — the dashboard cockpit shows the newest and the count.
+    """
+    cursor = await db.execute(
+        "SELECT * FROM cc_sessions WHERE cc_session_id = ? ORDER BY datetime(started_at) DESC",
+        (cc_session_id,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
 
 
 async def get_active_foreground(
@@ -144,7 +170,8 @@ async def query_stale(
 async def set_pid(db: aiosqlite.Connection, id: str, pid: int) -> bool:
     """Write the subprocess PID to an existing cc_sessions row."""
     cursor = await db.execute(
-        "UPDATE cc_sessions SET pid = ? WHERE id = ?", (pid, id),
+        "UPDATE cc_sessions SET pid = ? WHERE id = ?",
+        (pid, id),
     )
     await db.commit()
     return cursor.rowcount > 0
@@ -189,7 +216,8 @@ async def merge_metadata(
     Returns True if the row exists and was updated.
     """
     cursor = await db.execute(
-        "SELECT metadata FROM cc_sessions WHERE id = ?", (id,),
+        "SELECT metadata FROM cc_sessions WHERE id = ?",
+        (id,),
     )
     row = await cursor.fetchone()
     if row is None:
@@ -392,8 +420,7 @@ async def update_extraction_watermark(
 ) -> bool:
     """Update the extraction watermark for a session."""
     cursor = await db.execute(
-        "UPDATE cc_sessions SET last_extracted_at = ?, last_extracted_line = ? "
-        "WHERE id = ?",
+        "UPDATE cc_sessions SET last_extracted_at = ?, last_extracted_line = ? WHERE id = ?",
         (last_extracted_at, last_extracted_line, id),
     )
     await db.commit()
@@ -403,7 +430,8 @@ async def update_extraction_watermark(
 async def get_keywords(db: aiosqlite.Connection, id: str) -> str | None:
     """Get the keywords string for a session."""
     cursor = await db.execute(
-        "SELECT keywords FROM cc_sessions WHERE id = ?", (id,),
+        "SELECT keywords FROM cc_sessions WHERE id = ?",
+        (id,),
     )
     row = await cursor.fetchone()
     return row[0] if row else None
@@ -520,15 +548,10 @@ async def reflection_window_origin(db: aiosqlite.Connection, *, end_iso: str) ->
         from datetime import datetime, timedelta
 
         since = (
-            datetime.fromisoformat(end_iso)
-            - timedelta(minutes=REFLECTION_ORIGIN_WINDOW_MINUTES)
+            datetime.fromisoformat(end_iso) - timedelta(minutes=REFLECTION_ORIGIN_WINDOW_MINUTES)
         ).isoformat()
-        if await any_external_session_overlapping(
-            db, since_iso=since, end_iso=end_iso
-        ):
+        if await any_external_session_overlapping(db, since_iso=since, end_iso=end_iso):
             return "external_untrusted"
     except Exception:
-        _logger.debug(
-            "reflection_window_origin failed; defaulting first_party", exc_info=True
-        )
+        _logger.debug("reflection_window_origin failed; defaulting first_party", exc_info=True)
     return "first_party"

--- a/src/genesis/db/crud/repo_pulse.py
+++ b/src/genesis/db/crud/repo_pulse.py
@@ -152,6 +152,15 @@ async def record_run(
     return True
 
 
+async def get_annotation(db: aiosqlite.Connection, annotation_id: str) -> dict | None:
+    """Single annotation row as a dict, or None (also pre-migration)."""
+    if not await _tables_available(db):
+        return None
+    cursor = await db.execute("SELECT * FROM repo_pulse_annotations WHERE id = ?", (annotation_id,))
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
 async def tables_available(db: aiosqlite.Connection) -> bool:
     """Public existence check for callers that must verify storage BEFORE
     taking a side effect elsewhere (the worker gates live-ledger absorbs on

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -28,7 +28,12 @@ import json
 import re
 
 PULSE_MODEL = "claude-haiku-4-5-20251001"  # arbiter/extractor smoke-tested contract
-PULSE_TIMEOUT_S = 120.0  # extractor precedent: ~24k-ch prompt ran 101s worst-case
+# 240s (was 120): live E2E measured 67s/122s/84s per call with TTFT alone
+# hitting 70s — 1 of 3 runs died at the old ceiling. The failure self-heals
+# (window re-covers) but wastes the Haiku call and delays proposals by a
+# boundary. 240s ≈ 2× observed worst case while still bounding the global
+# pulse.lock hold (user-approved 2026-07-16).
+PULSE_TIMEOUT_S = 240.0
 PROMPT_VERSION = "v2"  # v2: list-position-only PR lines (v1's #NNNN got echoed as 'pr')
 
 MAX_ITEMS = 40  # open ledger rows in the fuzzy prompt (live scale today: ~1)

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -103,7 +103,7 @@ async def _seed_charter_tables(db, *, with_rows: bool = False):
                 "INSERT INTO session_ledger (id, session_id, text, status,"
                 " added_by, created_at)"
                 f" VALUES ('l{i}', 'cc-abc', 'item {i}', ?, 'foreground',"
-                " '2026-07-13T00:00:00+00:00')",
+                f" '2026-07-13T00:00:0{i}+00:00')",
                 (status,),
             )
     await db.commit()
@@ -228,3 +228,167 @@ async def test_empty_state(db):
         "completed_24h": 0,
         "failed_24h": 0,
     }
+
+
+# ── Per-session cockpit endpoint (session-manager PR-4b) ─────────────────────
+
+
+def test_charter_route_registered(app):
+    rules = {rule.rule for rule in app.url_map.iter_rules()}
+    assert "/api/genesis/cc-sessions/<cc_session_id>/charter" in rules
+
+
+def test_charter_route_503_when_not_bootstrapped(client):
+    mock_rt = MagicMock()
+    mock_rt.is_bootstrapped = False
+    mock_rt.db = None
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = mock_rt
+        resp = client.get("/api/genesis/cc-sessions/cc-abc/charter")
+    assert resp.status_code == 503
+
+
+def test_charter_route_traversal_id_rejected(client):
+    mock_rt = MagicMock()
+    mock_rt.is_bootstrapped = True
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = mock_rt
+        resp = client.get("/api/genesis/cc-sessions/../charter")
+    assert resp.status_code in (400, 404)  # our guard or Flask routing — never a read
+    assert mock_rt.db.execute.call_count == 0
+
+
+async def _seed_cockpit(db, tmp_path, *, waypoint_lines=None):
+    """cc_sessions row + charter + ledger + waypoints + pulse annotation."""
+    from genesis.dashboard.routes.cc_sessions import _collect_session_detail
+
+    await _seed_charter_tables(db, with_rows=True)
+    await _seed_session(db, sid="cc-abc", cc_session_id="cc-abc")
+    sessions_dir = tmp_path / "sessions"
+    (sessions_dir / "cc-abc").mkdir(parents=True)
+    lines = (
+        waypoint_lines
+        if waypoint_lines is not None
+        else [
+            '{"ts": "2026-07-13T00:00:00+00:00", "trigger": "auto", "transcript_bytes": 100}',
+            "{corrupt json",
+            '{"ts": "2026-07-14T00:00:00+00:00", "trigger": "manual", "transcript_bytes": 200}',
+        ]
+    )
+    (sessions_dir / "cc-abc" / "waypoints.jsonl").write_text("\n".join(lines) + "\n")
+    await db.execute(
+        "INSERT INTO repo_pulse_runs (run_id, started_at, trigger, status)"
+        " VALUES ('r1', '2026-07-14T00:00:00+00:00', 'manual', 'ok')"
+    )
+    await db.execute(
+        "INSERT INTO repo_pulse_annotations (id, run_id, observed_at, tier,"
+        " item_id, item_session_id, item_text, pr_number, status, confidence)"
+        " VALUES ('a1', 'r1', '2026-07-14T00:00:00+00:00', 'fuzzy', 'l0',"
+        " 'cc-abc', 'item 0', 1081, 'proposed', 0.9)"
+    )
+    await db.commit()
+    return _collect_session_detail, sessions_dir
+
+
+async def test_cockpit_full_payload(db, tmp_path):
+    collect, sessions_dir = await _seed_cockpit(db, tmp_path)
+    detail = await collect(db, "cc-abc", sessions_dir=sessions_dir, now=_NOW)
+    assert detail["session"]["cc_session_id"] == "cc-abc"
+    assert detail["session"]["session_row_count"] == 1
+    assert detail["charters_available"] is True
+    assert detail["charter"]["origin_prompt"] == "the origin"
+    assert detail["charter"]["origin_truncated"] is False
+    assert detail["charter"]["mission"] == "ship it"
+    assert detail["charter"]["pointers"] == []
+    items = detail["ledger"]["items"]
+    assert [i["id"] for i in items] == ["l0", "l1", "l2"]
+    assert {"added_by", "source_ref", "evidence"} <= set(items[0])
+    assert detail["ledger"]["counts"] == {"open": 1, "in_progress": 1, "done": 1}
+    # waypoints: corrupt line skipped, others parsed in order
+    wp = detail["waypoints"]
+    assert wp["available"] is True and wp["truncated"] is False
+    assert [w["trigger"] for w in wp["items"]] == ["auto", "manual"]
+    # pulse panel live
+    pulse = detail["pulse"]
+    assert pulse["available"] is True
+    assert pulse["annotations"][0]["pr_number"] == 1081
+    assert pulse["health"]["runs"] == {"ok": 1}
+
+
+async def test_cockpit_unknown_session_is_none(db, tmp_path):
+    from genesis.dashboard.routes.cc_sessions import _collect_session_detail
+
+    await _seed_charter_tables(db)
+    assert (
+        await _collect_session_detail(db, "nope", sessions_dir=tmp_path / "sessions", now=_NOW)
+        is None
+    )
+
+
+async def test_cockpit_charter_only_session(db, tmp_path):
+    """A chartered session with no cc_sessions row (pre-registration) still
+    renders — session block None, charter present."""
+    from genesis.dashboard.routes.cc_sessions import _collect_session_detail
+
+    await _seed_charter_tables(db, with_rows=True)
+    detail = await _collect_session_detail(
+        db, "cc-abc", sessions_dir=tmp_path / "sessions", now=_NOW
+    )
+    assert detail["session"] is None
+    assert detail["charter"]["origin_prompt"] == "the origin"
+    assert detail["waypoints"]["available"] is False
+
+
+async def test_cockpit_origin_cap_and_truncated_flag(db, tmp_path):
+    from genesis.dashboard.routes.cc_sessions import (
+        ORIGIN_PROMPT_CAP,
+        _collect_session_detail,
+    )
+
+    await _seed_charter_tables(db)
+    await db.execute(
+        "INSERT INTO session_charters (session_id, origin_prompt, pointers, created_at)"
+        " VALUES ('cc-big', ?, '[\"a\"]', '2026-07-13T00:00:00+00:00')",
+        ("x" * (ORIGIN_PROMPT_CAP + 500),),
+    )
+    await db.commit()
+    detail = await _collect_session_detail(
+        db, "cc-big", sessions_dir=tmp_path / "sessions", now=_NOW
+    )
+    assert len(detail["charter"]["origin_prompt"]) == ORIGIN_PROMPT_CAP
+    assert detail["charter"]["origin_truncated"] is True
+    assert detail["charter"]["pointers"] == ["a"]
+
+
+async def test_cockpit_waypoint_tail_truncation(db, tmp_path):
+    from genesis.dashboard.routes.cc_sessions import WAYPOINT_TAIL
+
+    lines = [
+        f'{{"ts": "2026-07-13T00:00:{i % 60:02d}+00:00", "trigger": "auto", "transcript_bytes": {i}}}'
+        for i in range(WAYPOINT_TAIL + 5)
+    ]
+    collect, sessions_dir = await _seed_cockpit(db, tmp_path, waypoint_lines=lines)
+    detail = await collect(db, "cc-abc", sessions_dir=sessions_dir, now=_NOW)
+    wp = detail["waypoints"]
+    assert wp["truncated"] is True
+    assert len(wp["items"]) == WAYPOINT_TAIL
+    assert wp["items"][-1]["transcript_bytes"] == WAYPOINT_TAIL + 4  # newest kept
+
+
+async def test_cockpit_pulse_degrades_without_tables(db, tmp_path):
+    """Pre-0062 installs: the pulse panel degrades to available=False —
+    the independent-mergeability regression contract, kept forever."""
+    from genesis.dashboard.routes.cc_sessions import _collect_session_detail
+    from genesis.db.crud import repo_pulse as pulse_crud
+
+    await _seed_charter_tables(db, with_rows=True)
+    await db.execute("DROP TABLE repo_pulse_annotations")
+    await db.execute("DROP TABLE repo_pulse_runs")
+    await db.commit()
+    pulse_crud._tables_verified = False
+    detail = await _collect_session_detail(
+        db, "cc-abc", sessions_dir=tmp_path / "sessions", now=_NOW
+    )
+    pulse_crud._tables_verified = False
+    assert detail["pulse"] == {"available": False, "annotations": [], "health": None}
+    assert detail["charter"]["origin_prompt"] == "the origin"  # rest unaffected

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -507,3 +507,41 @@ async def test_pulse_confirm_on_closed_item_still_confirms_annotation(db):
     assert payload["item_absorbed"] is False
     assert await _ann_status(db) == "confirmed"
     assert (await _ledger_row(db))["status"] == "done"
+
+
+async def test_cockpit_falls_back_to_db_row_id(db, tmp_path):
+    """Rows registered before their transcript id is known (NULL
+    cc_session_id) are addressable by DB row id — the tab's fallback click
+    path must open a cockpit, not a 404 (Codex P2 on #1089)."""
+    from genesis.dashboard.routes.cc_sessions import _collect_session_detail
+
+    await _seed_charter_tables(db)
+    await _seed_session(db, sid="row-only", cc_session_id=None)
+    detail = await _collect_session_detail(
+        db, "row-only", sessions_dir=tmp_path / "sessions", now=_NOW
+    )
+    assert detail is not None
+    assert detail["session"]["id"] == "row-only"
+    assert detail["charter"] is None  # no charter under a row id — fine
+
+
+async def test_pulse_confirm_resolves_annotation_before_ledger_write(db, monkeypatch):
+    """Ordering lock (Codex P2 on #1089): the conditional proposed→confirmed
+    flip must WIN before the ledger absorb fires, so a concurrent reject can
+    never leave an absorbed item under a rejected annotation."""
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+    from genesis.db.crud import session_charters as sc
+
+    await _seed_charter_tables(db, with_rows=True)
+    await _seed_pulse_proposal(db)
+    order: list[str] = []
+    real_ledger_update = sc.ledger_update
+
+    async def probing_ledger_update(db_, item_id, **kw):
+        order.append(await _ann_status(db_, "a1"))
+        return await real_ledger_update(db_, item_id, **kw)
+
+    monkeypatch.setattr(sc, "ledger_update", probing_ledger_update)
+    payload, code = await _resolve_pulse(db, "a1", "confirmed")
+    assert code == 200 and payload["item_absorbed"] is True
+    assert order == ["confirmed"]  # annotation resolved BEFORE the ledger mutate

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -392,3 +392,118 @@ async def test_cockpit_pulse_degrades_without_tables(db, tmp_path):
     pulse_crud._tables_verified = False
     assert detail["pulse"] == {"available": False, "annotations": [], "health": None}
     assert detail["charter"]["origin_prompt"] == "the origin"  # rest unaffected
+
+
+# ── Pulse confirm/reject endpoint (PR-4b commit 5) ───────────────────────────
+
+
+def _mock_rt(db):
+    rt = MagicMock()
+    rt.is_bootstrapped = True
+    rt.db = db
+    return rt
+
+
+async def _seed_pulse_proposal(db, *, ann_id="a1", item_id="l0", status="proposed"):
+    await db.execute(
+        "INSERT INTO repo_pulse_runs (run_id, started_at, trigger, status)"
+        " VALUES ('r1', '2026-07-14T00:00:00+00:00', 'manual', 'ok')"
+    )
+    await db.execute(
+        "INSERT INTO repo_pulse_annotations (id, run_id, observed_at, tier,"
+        " item_id, item_session_id, item_text, pr_number, pr_title, status, confidence)"
+        " VALUES (?, 'r1', '2026-07-14T00:00:00+00:00', 'fuzzy', ?,"
+        " 'cc-abc', 'item 0', 1081, 'feat: thing', ?, 0.9)",
+        (ann_id, item_id, status),
+    )
+    await db.commit()
+
+
+async def _ann_status(db, ann_id="a1"):
+    cur = await db.execute("SELECT status FROM repo_pulse_annotations WHERE id = ?", (ann_id,))
+    return (await cur.fetchone())[0]
+
+
+async def _ledger_row(db, item_id="l0"):
+    cur = await db.execute("SELECT * FROM session_ledger WHERE id = ?", (item_id,))
+    return dict(await cur.fetchone())
+
+
+def test_pulse_resolve_route_registered(app):
+    rules = {rule.rule for rule in app.url_map.iter_rules()}
+    assert "/api/genesis/cc-sessions/pulse/<annotation_id>/resolve" in rules
+
+
+def test_pulse_resolve_503_and_400(client, db):
+    mock_rt = MagicMock()
+    mock_rt.is_bootstrapped = False
+    mock_rt.db = None
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = mock_rt
+        assert client.post(
+            "/api/genesis/cc-sessions/pulse/a1/resolve", json={"status": "confirmed"}
+        ).status_code == 503
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = _mock_rt(db)
+        assert client.post(
+            "/api/genesis/cc-sessions/pulse/a1/resolve", json={"status": "approved"}
+        ).status_code == 400
+        assert client.post(
+            "/api/genesis/cc-sessions/pulse/a1/resolve", json={}
+        ).status_code == 400
+
+
+async def test_pulse_confirm_absorbs_item_with_pr_evidence(db):
+    """Dashboard confirm == the injected in-session hint: absorb the item
+    with PR evidence, then mark the annotation confirmed — both resolution
+    paths teach the precision metric the same lesson."""
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+
+    await _seed_charter_tables(db, with_rows=True)
+    await _seed_pulse_proposal(db)
+    payload, code = await _resolve_pulse(db, "a1", "confirmed")
+    assert code == 200
+    assert payload["ok"] is True and payload["item_absorbed"] is True
+    assert await _ann_status(db) == "confirmed"
+    row = await _ledger_row(db)
+    assert row["status"] == "absorbed"
+    assert "PR #1081" in row["evidence"]
+
+
+async def test_pulse_reject_leaves_ledger_untouched(db):
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+
+    await _seed_charter_tables(db, with_rows=True)
+    await _seed_pulse_proposal(db)
+    payload, code = await _resolve_pulse(db, "a1", "rejected")
+    assert code == 200
+    assert await _ann_status(db) == "rejected"
+    row = await _ledger_row(db)
+    assert row["status"] == "open"
+    assert row["evidence"] is None
+
+
+async def test_pulse_resolve_404_unknown_and_terminal(db):
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+
+    await _seed_charter_tables(db, with_rows=True)
+    await _seed_pulse_proposal(db, ann_id="a-done", status="applied")
+    assert (await _resolve_pulse(db, "nope", "confirmed"))[1] == 404
+    assert (await _resolve_pulse(db, "a-done", "confirmed"))[1] == 404
+    assert await _ann_status(db, "a-done") == "applied"  # terminal rows never flip
+
+
+async def test_pulse_confirm_on_closed_item_still_confirms_annotation(db):
+    """Item already done/absorbed in-session: confirm records the metric
+    without re-touching the ledger."""
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+
+    await _seed_charter_tables(db, with_rows=True)
+    await db.execute("UPDATE session_ledger SET status = 'done' WHERE id = 'l0'")
+    await db.commit()
+    await _seed_pulse_proposal(db)
+    payload, code = await _resolve_pulse(db, "a1", "confirmed")
+    assert code == 200
+    assert payload["item_absorbed"] is False
+    assert await _ann_status(db) == "confirmed"
+    assert (await _ledger_row(db))["status"] == "done"


### PR DESCRIPTION
## What

The dashboard side of the PR-4 batch (backend merged as #1081 + #1084): a full **Sessions tab** — the per-session cockpit.

- **List pane** consumes the SAME `/api/genesis/cc-sessions/detail` payload as the existing overview modal (chips/table/unmatched-slots ported verbatim; drift bounded by construction). Rows click-select into the detail pane; 15s auto-refresh incl. silent re-fetch of the open detail with a stale-response guard.
- **Cockpit detail** (`GET /api/genesis/cc-sessions/<id>/charter`): immutable origin (4000ch cap + truncated flag) beside the living mission/pointers; FULL ledger rows with status pills, added_by badges (pulse distinct), expandable evidence; the **waypoints timeline** — first reader of the deterministic `waypoints.jsonl` spine (tail-200, per-line corrupt-skip, traversal-guarded id); the **pulse panel** with run health + fuzzy precision.
- **Pulse confirm/reject** (`POST /api/genesis/cc-sessions/pulse/<id>/resolve`, comms resolve-proposal contract): confirm carries the SAME semantics as the injected in-session hint — absorb the item with PR evidence, then mark the annotation confirmed — so both resolution paths teach the precision metric the same lesson. Reject touches only the annotation (confirm() gated). Terminal annotations never flip.
- **Modal stays** (user decision) as the quick-glance surface and gains a "full cockpit →" link.
- Charter and pulse reads degrade independently (`available=false`) on pre-0058/0062 installs — the pulse degrade path is a permanent regression contract.
- Rider: `PULSE_TIMEOUT_S` 120→240s — live E2E measured 67s/122s/84s per fuzzy call with 70s TTFT; 1 of 3 runs died at the old ceiling (user-approved).

## Tests

27 in the routes file (cockpit payload, origin cap, waypoint tail/corrupt-skip, pulse degrade, resolve semantics incl. closed-item confirm and terminal-never-flips) + JS-integrity green (store members unique; the Internals tab owns `sessionsList`/`_sessionsInterval` for Genesis DIRECT sessions — the new members are `sessionsTab`/`_ccSessionsTabInterval`).

## Notes

- Internal review: scope CLEAN, zero findings; the one actionable sub-threshold note (silent resolve failures) fixed in the final commit.
- Completes the PR-4 batch tracked by session-manager ledger row:

Ledger: 71337fabfa68499ba7148089f25224f2

🤖 Generated with [Claude Code](https://claude.com/claude-code)