### PR TITLE
fix(outreach): persist standalone-reply engagement — write-back was quote-reply-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Replying to Genesis without quote-replying now counts.** When Genesis
+  asked you something on Telegram and you answered with a plain message
+  (no quote-reply), your answer reached the waiting conversation but the
+  outreach record never learned it was answered — it would later be marked
+  "ignored" or "ambivalent" as if you'd said nothing. Only 3 of 1,021
+  outreach records ever carried a real reply signal because of this. A
+  standalone reply that resolves a pending question is now recorded on the
+  outreach record exactly like a quote-reply, so Genesis's picture of what
+  you actually respond to stops being systematically wrong.
+
 ### Added
 
 - **The guardian now keeps container swap enabled on its own.** Swap is what

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1298,15 +1298,45 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
     if ctx.reply_waiter and msg.text:
         thread_key = f"{msg.chat.id}:{getattr(msg, 'message_thread_id', None) or 'dm'}"
         try:
-            if ctx.reply_waiter.resolve_scoped_pending(
+            resolved_keys = ctx.reply_waiter.resolve_scoped_pending(
                 msg.text, thread_key=thread_key,
-            ):
-                log.info(
-                    "Standalone message resolved scoped waiter in %s", thread_key,
-                )
-                return
+            )
         except Exception:
+            resolved_keys = []
             log.warning("Scoped waiter resolution failed", exc_info=True)
+        if resolved_keys:
+            log.info(
+                "Standalone message resolved scoped waiter in %s", thread_key,
+            )
+            # Persist the reply on the outreach record, mirroring the
+            # quote-reply path above — without this write-back the row never
+            # learns it was answered (the waiter keys are the only
+            # correlation, and they live in memory only). Any key may be a
+            # UUID alias rather than the stored Telegram message_id, so try
+            # each. Best-effort: a write-back failure never blocks the
+            # already-resolved waiter.
+            if ctx.engagement_tracker and ctx.db:
+                try:
+                    from genesis.db.crud.outreach import find_by_delivery_id
+
+                    for key in resolved_keys:
+                        outreach_record = await find_by_delivery_id(ctx.db, key)
+                        if outreach_record:
+                            await ctx.engagement_tracker.record_reply(
+                                outreach_record["id"],
+                                msg.text,
+                            )
+                            log.info(
+                                "Engagement recorded for outreach %s (standalone reply)",
+                                outreach_record["id"],
+                            )
+                            break
+                except Exception:
+                    log.warning(
+                        "Failed to record engagement for standalone reply",
+                        exc_info=True,
+                    )
+            return
 
     # Record implicit engagement: user is active after receiving outreach
     if ctx.engagement_tracker and ctx.db:

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1317,6 +1317,9 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
             # already-resolved waiter.
             if ctx.engagement_tracker and ctx.db:
                 try:
+                    # Deferred import — matches this module's established
+                    # idiom for db.crud (8 sites incl. the quote-reply block
+                    # above): keeps db.crud off the handler's import path.
                     from genesis.db.crud.outreach import find_by_delivery_id
 
                     for key in resolved_keys:

--- a/src/genesis/outreach/reply_waiter.py
+++ b/src/genesis/outreach/reply_waiter.py
@@ -90,7 +90,7 @@ class ReplyWaiter:
         if future and not future.done():
             future.cancel()
 
-    def resolve_scoped_pending(self, reply_text: str, *, thread_key: str) -> bool:
+    def resolve_scoped_pending(self, reply_text: str, *, thread_key: str) -> list[str]:
         """Resolve a pending waiter with a standalone (non-quote-reply)
         message — but ONLY within the message's own chat+topic.
 
@@ -99,6 +99,12 @@ class ReplyWaiter:
         future is eligible; zero or several (ambiguous) resolve nothing.
         Contextless waiters are never eligible — guessing the destination
         is exactly the bug that got the unscoped version disabled.
+
+        Returns the resolved waiter's registry keys (canonical + aliases —
+        e.g. a pre-generated UUID and the Telegram message_id) so the
+        caller can correlate the reply back to the delivered outreach
+        record; empty list when nothing was resolved. Any single key may
+        be an alias, so callers should try each against the store.
         """
         eligible: dict[asyncio.Future[str], str] = {}
         for did, future in self._waiters.items():
@@ -108,21 +114,28 @@ class ReplyWaiter:
                 continue
             eligible.setdefault(future, did)  # aliases share one future
         if len(eligible) != 1:
-            return False
+            return []
         future, delivery_id = next(iter(eligible.items()))
-        self._pop_future(future)
+        keys = self._pop_future(future)
         future.set_result(reply_text)
         logger.info(
             "Resolved pending reply waiter %s via standalone message in %s",
             delivery_id, thread_key,
         )
-        return True
+        return keys
 
-    def _pop_future(self, future: asyncio.Future[str]) -> None:
-        """Drop every key (canonical + aliases) mapped to *future*."""
-        for key in [k for k, f in self._waiters.items() if f is future]:
+    def _pop_future(self, future: asyncio.Future[str]) -> list[str]:
+        """Drop every key (canonical + aliases) mapped to *future*.
+
+        Returns the dropped keys so callers can correlate the resolved
+        waiter back to a delivered message (registry keys are the only
+        link — they live in memory only).
+        """
+        keys = [k for k, f in self._waiters.items() if f is future]
+        for key in keys:
             self._waiters.pop(key, None)
             self._contexts.pop(key, None)
+        return keys
 
     def resolve_any_pending(self, reply_text: str) -> bool:
         """UNSCOPED single-pending resolution — kept for API compatibility

--- a/tests/test_channels/test_telegram_handlers_v2.py
+++ b/tests/test_channels/test_telegram_handlers_v2.py
@@ -480,7 +480,7 @@ def handlers_with_waiter(mock_loop, mock_adapter, dedupe):
     waiter.resolve = MagicMock(return_value=True)
     # Scoped standalone resolution defaults to "nothing pending here" so
     # unrelated messages continue to normal CC flow.
-    waiter.resolve_scoped_pending = MagicMock(return_value=False)
+    waiter.resolve_scoped_pending = MagicMock(return_value=[])
     return make_handlers_v2(
         mock_loop,
         allowed_users={123},
@@ -532,7 +532,7 @@ async def test_standalone_message_resolves_scoped_waiter(
     consumed (no CC invocation) — the scoped replacement for the disabled
     resolve_any_pending."""
     handlers, waiter = handlers_with_waiter
-    waiter.resolve_scoped_pending = MagicMock(return_value=True)
+    waiter.resolve_scoped_pending = MagicMock(return_value=["uuid-abc", "77"])
     update = _make_update(text="ok", message_id=201)
     update.message.reply_to_message = None
     ctx = _make_context()
@@ -541,6 +541,74 @@ async def test_standalone_message_resolves_scoped_waiter(
 
     waiter.resolve_scoped_pending.assert_called_once()
     assert waiter.resolve_scoped_pending.call_args.kwargs["thread_key"]
+    mock_loop.handle_message_streaming.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_standalone_resolution_records_engagement(mock_loop, mock_adapter, dedupe):
+    """A standalone reply that resolves a scoped waiter is persisted on the
+    outreach record via record_reply — the write-back that makes the reply
+    visible to the DB (only quote-replies had it before). Alias keys that
+    miss the store fall through to the key that matches."""
+    waiter = MagicMock()
+    waiter.resolve_scoped_pending = MagicMock(return_value=["uuid-abc", "77"])
+    tracker = MagicMock()
+    tracker.record_reply = AsyncMock(return_value=True)
+    handlers = make_handlers_v2(
+        mock_loop,
+        allowed_users={123},
+        whisper_model="base",
+        adapter=mock_adapter,
+        db=mock_loop._db,
+        dedupe=dedupe,
+        reply_waiter=waiter,
+        engagement_tracker=tracker,
+    )
+    update = _make_update(text="sounds good", message_id=202)
+    update.message.reply_to_message = None
+    ctx = _make_context()
+
+    async def fake_find(db, delivery_id):
+        # The UUID alias is unknown to the store; the message_id matches.
+        return {"id": "outreach-1"} if delivery_id == "77" else None
+
+    with patch(
+        "genesis.db.crud.outreach.find_by_delivery_id", side_effect=fake_find,
+    ):
+        await handlers["text"](update, ctx)
+
+    tracker.record_reply.assert_awaited_once_with("outreach-1", "sounds good")
+    mock_loop.handle_message_streaming.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_standalone_writeback_failure_still_consumes(mock_loop, mock_adapter, dedupe):
+    """A write-back failure never blocks the already-resolved waiter — the
+    message stays consumed (no CC invocation), errors are swallowed."""
+    waiter = MagicMock()
+    waiter.resolve_scoped_pending = MagicMock(return_value=["77"])
+    tracker = MagicMock()
+    tracker.record_reply = AsyncMock(side_effect=RuntimeError("db down"))
+    handlers = make_handlers_v2(
+        mock_loop,
+        allowed_users={123},
+        whisper_model="base",
+        adapter=mock_adapter,
+        db=mock_loop._db,
+        dedupe=dedupe,
+        reply_waiter=waiter,
+        engagement_tracker=tracker,
+    )
+    update = _make_update(text="ok", message_id=203)
+    update.message.reply_to_message = None
+    ctx = _make_context()
+
+    with patch(
+        "genesis.db.crud.outreach.find_by_delivery_id",
+        new_callable=AsyncMock, return_value={"id": "outreach-2"},
+    ):
+        await handlers["text"](update, ctx)
+
     mock_loop.handle_message_streaming.assert_not_called()
 
 

--- a/tests/test_outreach/test_reply_waiter.py
+++ b/tests/test_outreach/test_reply_waiter.py
@@ -90,7 +90,7 @@ async def test_scoped_resolution_matches_same_thread():
     w = ReplyWaiter()
     fut = w.register("d1")
     w.set_context("d1", "123:45")
-    assert w.resolve_scoped_pending("ok", thread_key="123:45") is True
+    assert w.resolve_scoped_pending("ok", thread_key="123:45") == ["d1"]
     assert fut.result() == "ok"
 
 
@@ -100,14 +100,14 @@ async def test_scoped_resolution_ignores_other_thread():
     w = ReplyWaiter()
     w.register("d1")
     w.set_context("d1", "123:45")
-    assert w.resolve_scoped_pending("ok", thread_key="999:dm") is False
+    assert w.resolve_scoped_pending("ok", thread_key="999:dm") == []
     assert w.pending_count == 1
 
 
 async def test_scoped_resolution_skips_contextless_waiters():
     w = ReplyWaiter()
     w.register("d1")  # no context recorded
-    assert w.resolve_scoped_pending("ok", thread_key="123:45") is False
+    assert w.resolve_scoped_pending("ok", thread_key="123:45") == []
 
 
 async def test_scoped_resolution_ambiguous_does_nothing():
@@ -116,7 +116,7 @@ async def test_scoped_resolution_ambiguous_does_nothing():
     w.register("d2")
     w.set_context("d1", "123:45")
     w.set_context("d2", "123:45")
-    assert w.resolve_scoped_pending("ok", thread_key="123:45") is False
+    assert w.resolve_scoped_pending("ok", thread_key="123:45") == []
     assert w.pending_count == 2
 
 
@@ -127,7 +127,11 @@ async def test_scoped_resolution_alias_counts_once():
     fut = w.register("uuid-key")
     w.set_context("uuid-key", "123:45")
     w.add_alias("msg-77", "uuid-key")
-    assert w.resolve_scoped_pending("go", thread_key="123:45") is True
+    # ALL keys for the matched future come back (canonical + alias) — any
+    # single one may be a UUID the outreach store doesn't know, so the
+    # caller needs the full set to correlate the reply to the DB row.
+    keys = w.resolve_scoped_pending("go", thread_key="123:45")
+    assert set(keys) == {"uuid-key", "msg-77"}
     assert fut.result() == "go"
     # Both keys are gone — no stale entries.
     assert w.pending_count == 0


### PR DESCRIPTION
## Problem

When Genesis sends a send-and-wait outreach and the user answers with a **standalone message** (no quote-reply), the Telegram handler resolves the in-memory `ReplyWaiter` and returns — **without ever writing back to `outreach_history`**. Only the quote-reply path calls `record_reply`. The row later degrades to `ignored` (24h timeout) or `ambivalent` (implicit activity), as if the user said nothing.

Live impact: only **3 of 1,021** outreach rows carry `engagement_signal='user_reply'`. This is the affirmative-reply lane the WS-2 cognitive-ledger grader will consume — found by the `reply_received` resolver spike.

## Fix

- **`resolve_scoped_pending` returns the matched waiter's registry keys** (`list[str]`, empty = unresolved) instead of `bool`. All keys matter: the alias mechanism maps both a pre-generated UUID and the Telegram message_id to the same future, and whichever iterates first may be the UUID — which `find_by_delivery_id` (keyed on message_id) would never match. `_pop_future` now returns the keys it drops.
- **Handler mirrors the quote-reply path** on scoped resolution: tries each key against `outreach_history` (first hit wins), calls `record_reply` (`'useful'`/`'user_reply'`, correctly upgrading a prior `ambivalent`), best-effort — a write-back failure never blocks the already-resolved waiter and the message stays consumed.
- Caller set enumerated (serena + literal grep): exactly one production caller. 5 waiter tests + 1 handler mock updated to the list contract; 2 new handler tests (write-back with alias fall-through; failure isolation).

## Known ceiling

Fire-and-forget outreach (no waiter registered) still can't correlate standalone replies — those keep landing as `implicit_activity`. Documented in the WS-2 design as the affirmative-lane ceiling; the ledger grades them as no-reply, which is mechanically honest.

## Verification

- 71 targeted tests green (`test_outreach/test_reply_waiter.py`, `test_channels/test_telegram_handlers_v2.py`); ruff clean.
- Live E2E planned post-deploy: send-and-wait outreach → standalone reply → verify the row gains `engagement_signal='user_reply'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)