### PR TITLE
feat(guardian): Proxmox vzdump backups — arm the grow safety gate (WS1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis can now take a hypervisor backup of its own host VM — and grows
+  finally get their safety net.** The provisioning gate has always wanted a
+  recent backup before an irreversible grow, but nothing could take one, so
+  the check sat disabled. Now a stale backup turns a grow proposal into a
+  backup→verify→grow chain under one clearly-worded approval: the backup
+  starts immediately (vzdump, on a third API token that can back up but never
+  resize), verification runs in the background for however long the dump
+  takes, old backups rotate away automatically (keep-last, configurable), and
+  the grow executes only after the backup verifies and a fresh safety
+  re-check passes. Backups can also be taken on demand (`provision_vzdump`),
+  have their own weekly budget separate from grows (note: the existing
+  `max_actions_per_week` cap now counts grows only), and an interrupted
+  verification resumes after a restart with no state lost. Restore is
+  deliberately not included — that is a destructive operation with its own
+  upcoming review.
+
 - **The guardian now keeps container swap enabled on its own.** Swap is what
   turns a memory spike into graceful slowdown instead of a machine-wedging
   thrash, but the setting only got applied when host setup ran — an install

--- a/docs/reference/proxmox-provisioning.md
+++ b/docs/reference/proxmox-provisioning.md
@@ -100,9 +100,11 @@ pveum acl modify /vms/<VMID>       -user genesis@pve -role GenesisProvision
 # 4. Provision role ALSO on the storage (disk grow allocates space there)
 pveum acl modify /storage/<STORAGE> -user genesis@pve -role GenesisProvision
 
-# 5. Two privilege-separated tokens (privsep=1). Save the printed secrets.
+# 5. Privilege-separated tokens (privsep=1). Save the printed secrets.
 pveum user token add genesis@pve ro       --privsep 1
 pveum user token add genesis@pve provision --privsep 1
+# Optional third token — only if you enable vzdump backups (see "Backups"):
+pveum user token add genesis@pve backup    --privsep 1
 ```
 
 ### ⚠ The ACL gotcha (this WILL bite you)
@@ -224,12 +226,88 @@ curl -sk -X PUT -H "Authorization: $AUD" "$H/nodes/<NODE>/qemu/<VMID>/config" -d
   `<state_dir>/provisioning/ledger.json`; the gate refuses once
   `max_actions_per_week` is reached. Autonomous pool-crit re-proposals are
   damped by `min_repropose_hours` (`proposal_state.json`).
-- **`require_recent_backup`:** the backup-age check is not yet implemented for
-  Proxmox (`newest_backup_age_days()` returns `None`), and the gate treats an
-  unknown age as a refusal. So **setting `require_recent_backup: true` today
-  refuses every grow.** Leave it `false` until the backup-age query lands; a
-  grow is additive/grow-only and the container keeps a ≤24h healthy incus
-  snapshot lifeline, so a corrupting rollback risk from the grow itself is nil.
+- **`require_recent_backup`:** the backup-age query IS implemented
+  (`newest_backup_age_days()` reads the backup storage's `content=backup`
+  listing with the audit token — no extra privileges). The gate still treats an
+  unknown age as a refusal, so only flip this to `true` once a first verified
+  vzdump exists (see "Backups (vzdump)" below); with the JIT chain in place a
+  stale backup then turns a grow proposal into a backup→verify→grow chain
+  instead of a dead end.
+
+## Backups (vzdump) — two-phase, JIT + rotation
+
+Genesis can take a hypervisor backup of the host VM (`vzdump`), which both
+creates a real VM-level restore point and unblocks the grow gate's
+`require_recent_backup` check. Design properties:
+
+- **Just-in-time, not scheduled.** A backup is proposed as the precondition
+  step of a grow (when the gate would refuse on backup age, the grow proposal
+  becomes a backup→verify→grow **chain under one approval**, with the time gap
+  and auto-execute disclosed in the approval text) or on explicit ask
+  (`provision_vzdump` MCP tool). There is no cron and no recurring proposal.
+- **Two-phase.** `provision-vzdump` only STARTS the task and returns the PVE
+  UPID (a full-VM dump runs for tens of minutes+); `provision-vzdump-status
+  [UPID]` is a single verify probe (no arg = resume the latest in-flight
+  backup — restart-safe). The start is ledgered immediately: the row is the
+  rate-cap entry (`max_backups_per_week`, separate from the grow budget), the
+  in-flight latch, and the resume handle.
+- **Rotation is the only cleanup.** After a VERIFIED new backup, old ones are
+  pruned to `backup_keep_last` via the standalone `prunebackups` endpoint
+  (owner semantics — `Datastore.AllocateSpace` + `VM.Backup` suffice; the
+  inline vzdump `prune-backups` parameter would demand `Datastore.Allocate`
+  and is deliberately NOT used). There is no delete verb. Note the store
+  transiently holds `keep_last + 1` backups until rotation runs — size the
+  storage (or `backup_size_multiplier`) accordingly.
+- **Consistency class:** without a QEMU guest agent the backup is
+  crash-consistent (like a power cut — journaled fs + SQLite WAL recover);
+  with an agent, filesystem-consistent. The gate report shows which one you
+  are buying. **A backup you have never restored is unproven DR** — restore is
+  deliberately NOT implemented in this slice (it is a destructive verb with
+  its own review); treat these backups as a rollback point of last resort
+  until a restore path ships.
+
+Config fields (all generic; land per-install values via the audited
+`configure-provisioning` gateway verb): `backup_storage` (empty = same as
+`storage`), `backup_keep_last` (default 2), `max_backups_per_week` (default
+2), `backup_size_multiplier` (default 1.0 — worst-case incompressible
+estimate against the backup storage's free space), `vzdump_timeout_s`
+(default 7200 — the verify poller's wall bound; the backup itself is never
+killed).
+
+### The backup token
+
+The third token keeps the privsep model honest: `provision` stays grow-only
+(no `VM.Backup`), and `backup` cannot resize anything.
+
+```sh
+# Role: backup + the space to write it
+pveum role add GenesisBackup -privs "VM.Backup,Datastore.AllocateSpace"
+
+# ACLs — the same replacement gotcha as above applies: granting ANY ACL on a
+# path replaces what that path inherited, so re-grant audit alongside.
+pveum acl modify /vms/<VMID>              -token 'genesis@pve!backup' -role GenesisBackup
+pveum acl modify /storage/<BACKUP_STORE>  -token 'genesis@pve!backup' -role GenesisBackup
+pveum acl modify /storage/<BACKUP_STORE>  -user  genesis@pve          -role GenesisAudit
+pveum acl modify /storage/<BACKUP_STORE>  -token 'genesis@pve!ro'     -role GenesisAudit
+```
+
+Land the secret as `PROXMOX_BACKUP_TOKEN` next to the other two (container
+`secrets.env` → credential bridge, or the host guardian's own secrets file).
+An absent backup token degrades safely: backup verbs refuse pre-flight,
+grows are unaffected.
+
+Validate — positive AND negative (the boundary only exists if you probe it):
+
+```sh
+BAK='PVEAPIToken=genesis@pve!backup=<BACKUP_SECRET>'
+# Positive: token sees its own permissions on the two granted paths
+pveum user token permissions genesis@pve backup /vms/<VMID>            | grep -i VM.Backup
+pveum user token permissions genesis@pve backup /storage/<BACKUP_STORE> | grep -i AllocateSpace
+# Negative: the backup token must be REFUSED a resize (expect 403)
+curl -sk -X PUT -H "Authorization: $BAK" "$H/nodes/<NODE>/qemu/<VMID>/resize" -d 'disk=scsi1' -d 'size=+1G'
+# Negative: the provision token must be REFUSED a vzdump (expect 403)
+curl -sk -X POST -H "Authorization: $PRV" "$H/nodes/<NODE>/vzdump" -d 'vmid=<VMID>' -d 'storage=<BACKUP_STORE>'
+```
 
 ## `verify_tls: false`
 

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -27,6 +27,10 @@
 #   provision-grow-disk <disk> <GiB> — EXECUTE a pre-approved VM disk grow +
 #                     absorb (execute-only: NO Telegram gate; caller approves)
 #   provision-grow-memory <MiB>      — EXECUTE a pre-approved VM memory grow
+#   provision-vzdump          — EXECUTE a pre-approved backup START (two-phase:
+#                     launches vzdump, ledgers at start, returns the UPID)
+#   provision-vzdump-status [UPID]   — verify probe for a started backup (no
+#                     arg = resume latest in-flight; flips ledger + rotates)
 #   storage-expand            — absorb an already-grown disk into the storage
 #                     pool (LVM-thin: pvresize; btrfs-on-LVM: + lvextend/resize)
 #   configure-provisioning <k=v ...> — land host provisioning config as a
@@ -939,6 +943,57 @@ PYEOF
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
         GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
             timeout 120 "$VENV_PY" -m genesis.guardian --provision-grow-memory "$MIB"
+        ;;
+    provision-vzdump)
+        # EXECUTE-ONLY (approval is the CALLER's job — see provision-grow-disk).
+        # Phase 1 of 2: fresh gate re-check + ONE vzdump POST + ledger-at-start,
+        # returns the UPID immediately (a full-VM dump runs for tens of
+        # minutes+; verification is the separate status verb). Timeout covers
+        # only gate reads + the POST + alerts, never the backup itself.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "provision-vzdump", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+        GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
+            timeout 300 "$VENV_PY" -m genesis.guardian --provision-vzdump
+        ;;
+    provision-vzdump-status|provision-vzdump-status\ *)
+        # Phase 2 of 2: one verify probe (read-only + ledger flip + rotation on
+        # verified). Optional UPID arg — whole-string bash regex; a real UPID
+        # carries ':' '@' '!' so this charset is deliberately wider than other
+        # verbs' but still excludes whitespace/quotes/;/$ (no injection
+        # surface: always expanded quoted). No arg = resume latest in-flight.
+        # Timeout covers probe reads + on-verify prune task + alerts.
+        UPID=""
+        if [ "$SSH_ORIGINAL_COMMAND" != "provision-vzdump-status" ]; then
+            UPID="${SSH_ORIGINAL_COMMAND#provision-vzdump-status }"
+            UPID_RE='^UPID:[A-Za-z0-9:@!._-]{10,220}$'
+            if [[ ! "$UPID" =~ $UPID_RE ]]; then
+                echo '{"ok": false, "action": "provision-vzdump-status", "error": "invalid UPID"}' >&2
+                exit 1
+            fi
+        fi
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "provision-vzdump-status", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        if [ -n "$UPID" ]; then
+            PYTHONPATH="$INSTALL_DIR/src" \
+            GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
+                timeout 300 "$VENV_PY" -m genesis.guardian --provision-vzdump-status "$UPID"
+        else
+            PYTHONPATH="$INSTALL_DIR/src" \
+            GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
+                timeout 300 "$VENV_PY" -m genesis.guardian --provision-vzdump-status
+        fi
         ;;
     storage-expand)
         # Absorb an already-grown virtual disk into the LVM-thin pool

--- a/src/genesis/dashboard/routes/provision.py
+++ b/src/genesis/dashboard/routes/provision.py
@@ -54,3 +54,30 @@ async def provision_grow_rpc():
         timeout_s=float(data.get("timeout_seconds", 1800)),
     )
     return jsonify(result)
+
+
+@blueprint.route("/api/genesis/provision/vzdump", methods=["POST"])
+@_async_route
+async def provision_vzdump_rpc():
+    """Take a hypervisor backup (vzdump) — approval-gated, two-phase.
+
+    Body: {timeout_seconds, wall_seconds}. Blocks only for the APPROVE/DENY
+    reply + the start verb, then returns {stage: "started", upid}; a tracked
+    background task on the runtime loop polls verification and messages the
+    outcome. Same access posture as /provision/grow above: intrinsically
+    owner-approval-gated; a LAN caller can at worst prompt the owner.
+    """
+    from genesis.outreach.rpc import vzdump_via_pipeline
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.outreach_pipeline is None:
+        return jsonify({"ok": False, "error": "outreach pipeline not ready"}), 503
+
+    data = request.get_json(silent=True) or {}
+    result = await vzdump_via_pipeline(
+        rt.outreach_pipeline,
+        timeout_s=float(data.get("timeout_seconds", 1800)),
+        wall_s=float(data.get("wall_seconds", 7200)),
+    )
+    return jsonify(result)

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -12,6 +12,8 @@ Usage:
     python -m genesis.guardian --provision-status              # host capacity (read-only)
     python -m genesis.guardian --provision-grow-disk <disk> <GiB>  # EXECUTE (pre-approved)
     python -m genesis.guardian --provision-grow-memory <MiB>       # EXECUTE (pre-approved)
+    python -m genesis.guardian --provision-vzdump                   # EXECUTE (pre-approved) START a backup, returns UPID
+    python -m genesis.guardian --provision-vzdump-status [UPID]     # verify probe (read-only + ledger flip); no arg = latest in-flight
     python -m genesis.guardian --storage-expand               # absorb a grown disk
     python -m genesis.guardian --grow-root <GB>               # EXECUTE (pre-approved) grow container root
     python -m genesis.guardian --set-container-limits <mem_mib|-> <cpu|->  # EXECUTE (pre-approved) raise cgroup caps
@@ -70,6 +72,12 @@ def main() -> None:
 
     if "--provision-grow-memory" in sys.argv:
         sys.exit(asyncio.run(_provision_grow_memory(sys.argv)))
+
+    if "--provision-vzdump-status" in sys.argv:
+        sys.exit(asyncio.run(_provision_vzdump_status(sys.argv)))
+
+    if "--provision-vzdump" in sys.argv:
+        sys.exit(asyncio.run(_provision_vzdump()))
 
     if "--storage-expand" in sys.argv:
         sys.exit(asyncio.run(_storage_expand()))
@@ -309,14 +317,28 @@ async def _provision_status() -> int:
 
     from genesis.guardian.check import _build_provisioning_adapter
     from genesis.guardian.config import load_config
+    from genesis.guardian.provisioning.flow import _vzdump_in_flight_upid
+    from genesis.guardian.provisioning.ledger import ProvisioningLedger
 
-    adapter = _build_provisioning_adapter(load_config())
+    config = load_config()
+    adapter = _build_provisioning_adapter(config)
     if adapter is None:
         return _emit({"ok": False, "action": "provision-status",
                       "error": "provisioning disabled or unconfigured"})
     cap = await adapter.get_capacity()
+    pc = config.provisioning
+    # Backup context: lets the container decide the JIT backup→grow chain
+    # BEFORE proposing, so ONE approval can truthfully cover the whole chain.
+    backup = {
+        "age_days": await adapter.newest_backup_age_days(),
+        "require_recent_backup": pc.require_recent_backup,
+        "backup_max_age_days": pc.backup_max_age_days,
+        "in_flight_upid": _vzdump_in_flight_upid(
+            config, ProvisioningLedger(config.state_dir),
+        ),
+    }
     return _emit({"ok": cap.detected, "action": "provision-status",
-                  "capacity": dataclasses.asdict(cap)})
+                  "capacity": dataclasses.asdict(cap), "backup": backup})
 
 
 async def _provision_grow_disk(argv: list[str]) -> int:
@@ -385,6 +407,60 @@ async def _provision_grow_memory(argv: list[str]) -> int:
         config, request, adapter, _build_dispatcher(config),
         ProvisioningLedger(config.state_dir),
     )
+    return _emit(result)
+
+
+async def _provision_vzdump() -> int:
+    """EXECUTE (pre-approved) phase 1: START a vzdump, return its UPID.
+
+    Two-phase: this only launches (a full-VM dump runs for tens of minutes+).
+    The start is ledgered immediately — rate-cap entry, in-flight latch, and
+    restart-resume handle in one row. Verify via --provision-vzdump-status.
+    """
+    from genesis.guardian.check import _build_dispatcher, _build_provisioning_adapter
+    from genesis.guardian.config import load_config
+    from genesis.guardian.provisioning.flow import execute_vzdump_start
+    from genesis.guardian.provisioning.ledger import ProvisioningLedger
+
+    config = load_config()
+    adapter = _build_provisioning_adapter(config)
+    if adapter is None:
+        return _emit({"ok": False, "action": "provision-vzdump",
+                      "error": "provisioning disabled or unconfigured"})
+    result = await execute_vzdump_start(
+        config, adapter, _build_dispatcher(config),
+        ProvisioningLedger(config.state_dir),
+    )
+    result.setdefault("action", "provision-vzdump")
+    return _emit(result)
+
+
+async def _provision_vzdump_status(argv: list[str]) -> int:
+    """One verify probe for a started vzdump (phase 2; read-only + ledger flip).
+
+    Optional UPID arg; without it, resumes the latest unverified ledger entry
+    (restart-safe). ``state`` in the JSON is the caller's contract: running/
+    unknown = transient (retry), verified/failed = terminal. Exit 0 for any
+    usable probe answer; non-zero only for terminal failure / nothing in flight.
+    """
+    from genesis.guardian.check import _build_dispatcher, _build_provisioning_adapter
+    from genesis.guardian.config import load_config
+    from genesis.guardian.provisioning.flow import verify_vzdump_step
+    from genesis.guardian.provisioning.ledger import ProvisioningLedger
+
+    args = _args_after(argv, "--provision-vzdump-status", 1)
+    upid = args[0] if args else ""
+
+    config = load_config()
+    adapter = _build_provisioning_adapter(config)
+    if adapter is None:
+        return _emit({"ok": False, "action": "provision-vzdump-status",
+                      "error": "provisioning disabled or unconfigured"})
+    result = await verify_vzdump_step(
+        config, adapter, _build_dispatcher(config),
+        ProvisioningLedger(config.state_dir), upid=upid,
+    )
+    result.setdefault("action", "provision-vzdump-status")
     return _emit(result)
 
 

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -307,7 +307,12 @@ def _configure_provisioning(argv: list[str]) -> int:
                                    "api_port": p.api_port, "node": p.node, "vmid": p.vmid,
                                    "target_disk": p.target_disk, "storage": p.storage,
                                    "verify_tls": p.verify_tls,
-                                   "require_recent_backup": p.require_recent_backup}})
+                                   "require_recent_backup": p.require_recent_backup,
+                                   "backup_storage": p.backup_storage,
+                                   "backup_keep_last": p.backup_keep_last,
+                                   "max_backups_per_week": p.max_backups_per_week,
+                                   "backup_size_multiplier": p.backup_size_multiplier,
+                                   "vzdump_timeout_s": p.vzdump_timeout_s}})
 
 
 async def _provision_status() -> int:

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -206,33 +206,36 @@ def _build_provisioning_adapter(config: GuardianConfig):
         )
         return None
 
-    def _from_env() -> tuple[str, str]:
+    def _from_env() -> tuple[str, str, str]:
         return (
             os.environ.get("PROXMOX_AUDIT_TOKEN", ""),
             os.environ.get("PROXMOX_PROVISION_TOKEN", ""),
+            os.environ.get("PROXMOX_BACKUP_TOKEN", ""),
         )
 
-    def _from_bridge() -> tuple[str, str]:
+    def _from_bridge() -> tuple[str, str, str]:
         from genesis.guardian.credential_bridge import load_provisioning_credentials
         creds = load_provisioning_credentials(config.state_dir)
         return (
             creds.get("PROXMOX_AUDIT_TOKEN", ""),
             creds.get("PROXMOX_PROVISION_TOKEN", ""),
+            creds.get("PROXMOX_BACKUP_TOKEN", ""),
         )
 
-    def _from_legacy() -> tuple[str, str]:
+    def _from_legacy() -> tuple[str, str, str]:
         secrets = load_secrets()
         return (
             secrets.get("PROXMOX_AUDIT_TOKEN", ""),
             secrets.get("PROXMOX_PROVISION_TOKEN", ""),
+            secrets.get("PROXMOX_BACKUP_TOKEN", ""),
         )
 
-    audit = provision = ""
+    audit = provision = backup = ""
     for source in (_from_env, _from_bridge, _from_legacy):
-        a, p = source()
-        a, p = a.strip(), p.strip()
-        if a:  # all-or-nothing: this source owns both tokens
-            audit, provision = a, p
+        a, p, b = source()
+        a, p, b = a.strip(), p.strip(), b.strip()
+        if a:  # all-or-nothing: this source owns all its tokens
+            audit, provision, backup = a, p, b
             break
 
     if not audit:
@@ -242,7 +245,9 @@ def _build_provisioning_adapter(config: GuardianConfig):
         return None
 
     from genesis.guardian.provisioning.proxmox import ProxmoxAdapter
-    return ProxmoxAdapter(pc, audit_token=audit, provision_token=provision)
+    return ProxmoxAdapter(
+        pc, audit_token=audit, provision_token=provision, backup_token=backup,
+    )
 
 
 async def _maybe_propose_provisioning(

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -298,6 +298,23 @@ class ProvisioningConfig:
     # A recent successful backup is a precondition for an irreversible grow.
     require_recent_backup: bool = True
     backup_max_age_days: int = 14
+    # vzdump backups (JIT + rotation): taken as the precondition step of a grow
+    # (or on explicit ask), never on a schedule. Empty backup_storage = use
+    # ``storage``. Rotation (prune to keep_last via the standalone prunebackups
+    # endpoint) is the only cleanup path — deliberately no delete verb.
+    backup_storage: str = ""
+    backup_keep_last: int = 2
+    # Backups have their own weekly cap — they never consume the grow budget
+    # (and a runaway backup loop can fill a datastore just as surely as grows).
+    max_backups_per_week: int = 2
+    # Space check: refuse a vzdump unless the backup storage has at least
+    # (sum of VM disk allocation × this multiplier) free. 1.0 = incompressible
+    # worst case; zstd normally does far better.
+    backup_size_multiplier: float = 1.0
+    # Wall bound for the whole vzdump task (start → stopped). Scales with disk
+    # size and storage speed — a full-VM dump can legitimately run well over an
+    # hour, so this is the project's 2h timeout floor, not a "safety" value.
+    vzdump_timeout_s: int = 7200
     # Bounded wait for the Telegram APPROVE/DENY reply (guardian is oneshot).
     approval_timeout_s: int = 1800
     # Damper: don't re-propose the same autonomous pool-grow more than this often.
@@ -503,6 +520,8 @@ def _coerce_provisioning_value(default: object, value: object) -> object:
         return str(value).strip().lower() in ("1", "true", "yes", "on")
     if isinstance(default, int):
         return int(value)
+    if isinstance(default, float):
+        return float(value)
     return str(value)
 
 

--- a/src/genesis/guardian/credential_bridge.py
+++ b/src/genesis/guardian/credential_bridge.py
@@ -50,6 +50,8 @@ _PROVISIONING_FILENAME = "proxmox_creds.env"
 _KEY_MAP_PROVISIONING = {
     "PROXMOX_AUDIT_TOKEN": "PROXMOX_AUDIT_TOKEN",
     "PROXMOX_PROVISION_TOKEN": "PROXMOX_PROVISION_TOKEN",
+    # vzdump verbs: VM.Backup + Datastore.AllocateSpace(backup storage) only.
+    "PROXMOX_BACKUP_TOKEN": "PROXMOX_BACKUP_TOKEN",
 }
 
 # Backup-passphrase escrow. GENESIS_BACKUP_PASSPHRASE lives ONLY inside

--- a/src/genesis/guardian/provisioning/base.py
+++ b/src/genesis/guardian/provisioning/base.py
@@ -35,6 +35,13 @@ class HostCapacity:
     storage_total_bytes: int | None = None
     node_mem_total_bytes: int | None = None
     node_mem_available_bytes: int | None = None
+    # The BACKUP datastore's headroom (may differ from ``storage``) — the
+    # vzdump gate must check THIS, never storage_free_bytes (wrong datastore).
+    backup_storage_free_bytes: int | None = None
+    backup_storage_total_bytes: int | None = None
+    # QEMU guest agent enabled? None = unknown. Informational: with the agent a
+    # vzdump is filesystem-consistent (fsfreeze); without it, crash-consistent.
+    vm_agent_enabled: bool | None = None
     detail: str = ""
 
 
@@ -59,6 +66,39 @@ class ProvisionResult:
     # (disk: bytes). Lets the flow detect an unverified-but-landed grow and
     # avoid stacking a second RELATIVE disk grow. None when not applicable.
     target_bytes: int | None = None
+
+
+@dataclass(frozen=True)
+class BackupStartResult:
+    """Outcome of LAUNCHING a backup task (phase 1 of 2).
+
+    ``ok`` means the hypervisor accepted the job and returned a task handle —
+    NOT that the backup succeeded (that is :class:`BackupStatus`'s job).
+    ``attempted`` means the start request was actually sent: the caller must
+    ledger the action iff attempted (even on failure — the hypervisor may have
+    started work), and must NOT ledger pre-flight refusals (no token, bad
+    config) where no request ever left the process.
+    """
+
+    ok: bool
+    upid: str = ""
+    requested: str = ""
+    attempted: bool = False
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class BackupStatus:
+    """One probe of a started backup task (phase 2 of 2).
+
+    ``state``: running | verified | failed | unknown — see
+    :meth:`ProvisioningAdapter.vzdump_status` for the caller contract.
+    """
+
+    state: str
+    detail: str = ""
+    volid: str = ""
+    age_days: float | None = None
 
 
 class ProvisioningAdapter(ABC):
@@ -91,3 +131,39 @@ class ProvisioningAdapter(ABC):
         (when ``require_recent_backup`` is set) refuses rather than assuming.
         """
         return None
+
+    # ── two-phase backup verbs (concrete defaults — not every hypervisor
+    #    adapter must support backups; the not-supported forms keep the
+    #    never-raise contract and fail the gate/flow safely) ────────────────
+
+    async def vzdump_start(self) -> BackupStartResult:
+        """START a backup task; return its handle immediately (never block).
+
+        Two-phase by design: a full-VM backup runs for tens of minutes+, so the
+        adapter only launches it. Verification is :meth:`vzdump_status`, driven
+        by the caller's poll cadence against the returned ``upid``.
+        """
+        return BackupStartResult(
+            ok=False, error="backups not supported by this adapter",
+        )
+
+    async def vzdump_status(self, upid: str) -> BackupStatus:
+        """One status/verify probe for a started backup (single read, no loop).
+
+        ``state`` contract (poll-outcome discipline): ``running`` = keep
+        polling; ``verified`` = task finished AND the new backup is visible in
+        the datastore; ``failed`` = the task itself reported terminal failure;
+        ``unknown`` = this PROBE could not tell (transient read failure) — the
+        caller must treat it as transient and retry, never as failure.
+        """
+        return BackupStatus(
+            state="unknown", detail="backups not supported by this adapter",
+        )
+
+    async def prune_backups(self) -> tuple[bool, str]:
+        """Rotate this VM's backups down to the configured keep-last.
+
+        Runs only after a VERIFIED new backup. Returns (ok, detail). Rotation
+        is the only cleanup path — there is deliberately no delete verb.
+        """
+        return False, "backups not supported by this adapter"

--- a/src/genesis/guardian/provisioning/container.py
+++ b/src/genesis/guardian/provisioning/container.py
@@ -14,13 +14,19 @@ proposal→reply callable) so they are testable without the live outreach stack.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable
+
+from genesis.util.tasks import tracked_task
 
 logger = logging.getLogger(__name__)
 
 # ask(proposal_text) -> the user's reply text, or None on timeout.
 AskFn = Callable[[str], Awaitable[str | None]]
+# notify(text) -> fire-and-forget message to the owner (poller terminal states).
+NotifyFn = Callable[[str], Awaitable[None]]
 
 _GIB = 1024**3
 
@@ -49,17 +55,208 @@ def _approved(reply: str | None) -> bool:
     return (reply or "").strip().upper() == "APPROVE"
 
 
+def _backup_is_stale(backup: dict) -> bool:
+    """Would the host grow-gate's backup check refuse right now?
+
+    Mirrors gate._backup_check: required + (age unknown OR over limit).
+    Keyed on the STRUCTURED provision-status backup block, never on parsing
+    display strings.
+    """
+    if not backup.get("require_recent_backup"):
+        return False
+    age = backup.get("age_days")
+    try:
+        limit = float(backup.get("backup_max_age_days", 14))
+    except (TypeError, ValueError):
+        limit = 14.0
+    return age is None or float(age) > limit
+
+
+def _chain_proposal(cap: dict, backup: dict, disk: str, add_gib: int,
+                    wall_s: float) -> str:
+    """One approval covers the WHOLE chain — so the text must name every leg
+    and the time gap (the grow executes tens of minutes+ after this APPROVE,
+    behind a fresh host-side due-diligence re-check)."""
+    age = backup.get("age_days")
+    age_s = f"{age:.1f}d old" if isinstance(age, (int, float)) else "none exists"
+    disks = cap.get("disks") or {}
+    cur = disks.get(disk)
+    cur_s = _fmt_gib(cur) if cur is not None else "unknown"
+    new_s = _fmt_gib(cur + add_gib * _GIB) if isinstance(cur, (int, float)) else "?"
+    return (
+        f"🔧 Grow VM disk {disk} by {add_gib}G ({cur_s} → {new_s}) — but the "
+        f"hypervisor backup is stale ({age_s}; the safety gate requires "
+        f"≤{backup.get('backup_max_age_days', 14)}d), so this runs as a CHAIN "
+        "under this one approval:\n"
+        "1. START a vzdump backup now (reads the whole live VM disk — expect "
+        "I/O load; crash-consistent without a guest agent).\n"
+        f"2. When it VERIFIES (typically minutes-to-an-hour; abandoned as "
+        f"UNVERIFIED after {wall_s / 3600:.0f}h), old backups rotate and the "
+        "grow executes AUTOMATICALLY after a fresh due-diligence re-check.\n"
+        "3. If the backup fails or the re-check refuses, the grow does NOT "
+        "run and you are notified — nothing retries on its own.\n"
+        "Reply APPROVE to run the whole chain or DENY to cancel."
+    )
+
+
+async def _poll_vzdump(
+    remote,
+    notify: NotifyFn | None,
+    *,
+    upid: str,
+    poll_interval_s: float,
+    wall_s: float,
+    on_verified: Callable[[], Awaitable[dict]] | None = None,
+) -> dict:
+    """Drive the host status verb to a terminal state (tracked-task body).
+
+    Poll-outcome discipline: only state=="failed" is terminal failure;
+    transport errors / "denied" / running / unknown are TRANSIENT and retried
+    to the wall bound, which ends as UNVERIFIED (never "failed" — the backup
+    may still land; the host ledger keeps the row unverified and honest).
+    Host-side verify already alerts verified/failed via the guardian channel;
+    ``notify`` carries the chain outcome + the wall-bound case.
+    """
+    deadline = time.monotonic() + wall_s
+    while time.monotonic() < deadline:
+        res = await remote.request_vzdump_status(upid)
+        state = res.get("state", "")
+        if state == "verified":
+            if on_verified is None:
+                return res
+            follow = await on_verified()
+            if notify is not None:
+                if follow.get("ok"):
+                    await notify(
+                        f"✅ Chain complete: backup verified, grow executed "
+                        f"({follow.get('requested', '')} → {follow.get('after', '?')}).",
+                    )
+                else:
+                    await notify(
+                        "⚠️ Backup verified but the grow leg did NOT run "
+                        f"({follow.get('stage', follow.get('error', 'refused'))}). "
+                        "Nothing retries on its own — re-request the grow when ready.",
+                    )
+            return follow
+        if state == "failed":
+            if notify is not None:
+                await notify(
+                    "❌ Backup task failed — "
+                    + (f"the approved grow was NOT executed. ({res.get('error', '')})"
+                       if on_verified is not None else f"({res.get('error', '')})"),
+                )
+            return res
+        await asyncio.sleep(poll_interval_s)
+    if notify is not None:
+        await notify(
+            f"⚠️ Backup {upid} not verified within {wall_s / 3600:.1f}h — left "
+            "UNVERIFIED (it may still finish). Check `provision-vzdump-status`; "
+            + ("the approved grow was NOT executed." if on_verified is not None else ""),
+        )
+    return {"ok": False, "stage": "wall_bound", "upid": upid}
+
+
 async def coordinate_grow_disk(
     remote, ask: AskFn, *, disk: str, add_gib: int,
+    notify: NotifyFn | None = None,
+    poll_interval_s: float = 60.0,
+    vzdump_wall_s: float = 7200.0,
 ) -> dict:
-    """Capacity → ask the user → on APPROVE run the host disk-grow execute verb."""
+    """Capacity → ask the user → on APPROVE run the host disk-grow execute verb.
+
+    JIT backup chain: when the host reports the backup gate would refuse
+    (stale/absent backup) and nothing is in flight, the proposal becomes a
+    backup→verify→grow CHAIN under one truthful approval; the grow leg runs
+    from a tracked background task once the backup verifies (fresh host-side
+    re-check included). The wall bound uses the project 2h floor — a full-VM
+    dump legitimately runs long; this is not a safety timeout.
+    """
     status = await remote.provision_status()
     if not status.get("ok"):
         return {"ok": False, "stage": "no_capacity", "detail": status}
+
+    backup = status.get("backup") or {}
+    if _backup_is_stale(backup):
+        if backup.get("in_flight_upid"):
+            return {"ok": False, "stage": "backup_in_flight",
+                    "upid": backup["in_flight_upid"],
+                    "detail": "a backup is already running — retry the grow "
+                              "after it verifies"}
+        reply = await ask(_chain_proposal(
+            status.get("capacity", {}), backup, disk, add_gib, vzdump_wall_s,
+        ))
+        if not _approved(reply):
+            return {"ok": False, "stage": "denied", "reply": reply}
+        start = await remote.request_vzdump_start()
+        if not start.get("ok"):
+            return {"ok": False, "stage": "backup_start_failed", "detail": start}
+        upid = str(start.get("upid", ""))
+
+        async def _grow_leg() -> dict:
+            return await remote.request_grow_disk(disk, add_gib)
+
+        tracked_task(
+            _poll_vzdump(
+                remote, notify, upid=upid, poll_interval_s=poll_interval_s,
+                wall_s=vzdump_wall_s, on_verified=_grow_leg,
+            ),
+            name=f"vzdump-chain-{disk}",
+        )
+        return {"ok": True, "stage": "chain_started", "upid": upid,
+                "detail": "backup started; grow executes automatically once "
+                          "it verifies (you will be notified either way)"}
+
     reply = await ask(_disk_proposal(status.get("capacity", {}), disk, add_gib))
     if not _approved(reply):
         return {"ok": False, "stage": "denied", "reply": reply}
     return await remote.request_grow_disk(disk, add_gib)
+
+
+async def coordinate_vzdump(
+    remote, ask: AskFn, *, notify: NotifyFn | None = None,
+    poll_interval_s: float = 60.0, vzdump_wall_s: float = 7200.0,
+) -> dict:
+    """Explicit backup: ask the user → on APPROVE start a vzdump and track it.
+
+    Two-phase: returns as soon as the backup STARTS (a full-VM dump runs for
+    tens of minutes+); a tracked background task polls to the terminal state.
+    The host side alerts verified/failed on the guardian channel; ``notify``
+    additionally covers the wall-bound (abandoned-UNVERIFIED) case.
+    """
+    status = await remote.provision_status()
+    if not status.get("ok"):
+        return {"ok": False, "stage": "no_capacity", "detail": status}
+    backup = status.get("backup") or {}
+    if backup.get("in_flight_upid"):
+        return {"ok": False, "stage": "backup_in_flight",
+                "upid": backup["in_flight_upid"]}
+    age = backup.get("age_days")
+    age_s = f"{age:.1f}d old" if isinstance(age, (int, float)) else "none exists"
+    proposal = (
+        f"💾 Take a hypervisor backup (vzdump) of the host VM now? Newest: "
+        f"{age_s}.\n"
+        "Reads the whole live VM disk (expect I/O load; crash-consistent "
+        "without a guest agent), lands on the backup datastore, then rotates "
+        "old backups per keep-last.\n"
+        "Reply APPROVE to start or DENY to cancel."
+    )
+    reply = await ask(proposal)
+    if not _approved(reply):
+        return {"ok": False, "stage": "denied", "reply": reply}
+    start = await remote.request_vzdump_start()
+    if not start.get("ok"):
+        return {"ok": False, "stage": "backup_start_failed", "detail": start}
+    upid = str(start.get("upid", ""))
+    tracked_task(
+        _poll_vzdump(
+            remote, notify, upid=upid,
+            poll_interval_s=poll_interval_s, wall_s=vzdump_wall_s,
+        ),
+        name="vzdump-verify",
+    )
+    return {"ok": True, "stage": "started", "upid": upid,
+            "detail": "backup started; verification is tracked in the "
+                      "background (host alerts on the outcome)"}
 
 
 async def coordinate_grow_memory(remote, ask: AskFn, *, new_mib: int) -> dict:

--- a/src/genesis/guardian/provisioning/flow.py
+++ b/src/genesis/guardian/provisioning/flow.py
@@ -34,6 +34,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from html import escape as html_escape
 
 from genesis.guardian.alert.base import Alert, AlertSeverity
@@ -46,6 +47,7 @@ from genesis.guardian.provisioning.gate import (
     DueDiligenceReport,
     evaluate_disk_grow,
     evaluate_memory_grow,
+    evaluate_vzdump,
 )
 from genesis.guardian.provisioning.ledger import ProvisioningLedger
 
@@ -177,7 +179,7 @@ async def execute_provisioning_action(
     # 1. Fresh re-check (capacity + backup + rate cap) — no mutation on failure.
     cap = await adapter.get_capacity()
     report = _evaluate(
-        request, cap, config, ledger.actions_in_window(),
+        request, cap, config, ledger.actions_in_window(action_prefix="grow_"),
         await adapter.newest_backup_age_days(),
     )
     if not report.passed:
@@ -188,7 +190,8 @@ async def execute_provisioning_action(
                  + "\n".join(report.as_lines()),
         ))
         return {"ok": False, "stage": "recheck_failed", "requested": report.requested,
-                "checks": report.as_lines()}
+                "checks": report.as_lines(),
+                "failed_checks": report.failed_names()}
 
     # 1b. Anti-stack guard (disk only): a RELATIVE disk grow is non-idempotent.
     # If a prior grow of this disk was recorded unverified but the live size has
@@ -281,16 +284,31 @@ async def run_provisioning_flow(
     # 1-2. Capacity + due-diligence gate — fail ⇒ refuse + alert, NEVER propose.
     cap = await adapter.get_capacity()
     backup_age = await adapter.newest_backup_age_days()
-    report = _evaluate(request, cap, config, ledger.actions_in_window(), backup_age)
+    report = _evaluate(
+        request, cap, config,
+        ledger.actions_in_window(action_prefix="grow_"), backup_age,
+    )
 
     if not report.passed:
+        body = "Due-diligence gate failed:\n" + "\n".join(report.as_lines())
+        if "recent backup" in report.failed_names():
+            # Deliberate, audited escape hatch — named, not hidden. This path
+            # runs when Genesis is DOWN (host likely degraded); an hour-scale
+            # vzdump is NOT chained here in that state.
+            body += (
+                "\nBackup is stale/unknown. Take one from Genesis when it is "
+                "up (provision vzdump), or for THIS emergency only: gateway "
+                "verb `configure-provisioning require_recent_backup=false` "
+                "(audited; re-enable after)."
+            )
         await dispatcher.send(Alert(
             severity=AlertSeverity.WARNING,
             title=f"Provisioning refused: {report.requested}",
-            body="Due-diligence gate failed:\n" + "\n".join(report.as_lines()),
+            body=body,
         ))
         return {"ok": False, "stage": "refused_gate", "requested": report.requested,
-                "checks": report.as_lines()}
+                "checks": report.as_lines(),
+                "failed_checks": report.failed_names()}
 
     # 3. No channel ⇒ we cannot obtain approval ⇒ never mutate.
     channel = _find_telegram_channel(dispatcher)
@@ -346,3 +364,136 @@ async def maybe_propose_pool_grow(
         absorb_after=True, origin="autonomous (pool critical)",
     )
     return await run_provisioning_flow(config, request, adapter, dispatcher, ledger)
+
+
+def _vzdump_in_flight_upid(config: GuardianConfig, ledger: ProvisioningLedger) -> str:
+    """The UPID of a still-latched backup, or "".
+
+    Latch = the latest vzdump ledger entry is unverified, HAS a upid (an entry
+    without one is a failed start — nothing to resume, must never latch), and
+    is younger than the vzdump wall bound. Past the wall bound the latch
+    self-expires: the operation ends as UNVERIFIED, never blocks forever.
+    """
+    entry = ledger.latest_backup()
+    if not entry or entry.get("verified") or not entry.get("upid"):
+        return ""
+    try:
+        started = datetime.fromisoformat(str(entry.get("ts")))
+    except (TypeError, ValueError):
+        return ""
+    age_s = (datetime.now(UTC) - started).total_seconds()
+    if age_s >= config.provisioning.vzdump_timeout_s:
+        return ""
+    return str(entry.get("upid"))
+
+
+async def execute_vzdump_start(
+    config: GuardianConfig,
+    adapter: ProvisioningAdapter,
+    dispatcher: AlertDispatcher,
+    ledger: ProvisioningLedger,
+) -> dict:
+    """START an ALREADY-APPROVED vzdump (phase 1 of 2). No approval gate here.
+
+    Mirrors :func:`execute_provisioning_action`'s execute-only contract: fresh
+    gate re-check → launch once → ledger AT START (the POST consumed real
+    hypervisor work whether or not verification ever runs — the start row is
+    the rate-cap entry, the in-flight latch, and the restart-resume handle).
+    Returns immediately with the UPID; verification is
+    :func:`verify_vzdump_step`, driven on the caller's cadence.
+    """
+    cap = await adapter.get_capacity()
+    report = evaluate_vzdump(
+        cap, config.provisioning,
+        ledger.actions_in_window(action_prefix="vzdump"),
+        in_flight_upid=_vzdump_in_flight_upid(config, ledger),
+    )
+    if not report.passed:
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.WARNING,
+            title=f"Backup aborted before start: {report.requested}",
+            body="Due-diligence re-check failed at start time:\n"
+                 + "\n".join(report.as_lines()),
+        ))
+        return {"ok": False, "stage": "recheck_failed", "requested": report.requested,
+                "checks": report.as_lines(),
+                "failed_checks": report.failed_names()}
+
+    res = await adapter.vzdump_start()
+    if res.attempted:
+        # B1: ledger at start, even on a failed launch (conservative — the
+        # hypervisor may have begun work). A upid-less failure never latches.
+        ledger.record_action(
+            "vzdump", res.requested, ok=res.ok, verified=False, upid=res.upid,
+        )
+    if not res.ok:
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.CRITICAL,
+            title=f"Backup start FAILED: {res.requested}",
+            body=f"{res.error or 'unknown'}\nNo auto-retry — manual check needed.",
+        ))
+        return {"ok": False, "stage": "start_failed", "requested": res.requested,
+                "error": res.error}
+    logger.info("vzdump started: %s (%s)", res.requested, res.upid)
+    return {"ok": True, "stage": "started", "requested": res.requested,
+            "upid": res.upid}
+
+
+async def verify_vzdump_step(
+    config: GuardianConfig,
+    adapter: ProvisioningAdapter,
+    dispatcher: AlertDispatcher,
+    ledger: ProvisioningLedger,
+    upid: str = "",
+) -> dict:
+    """One verification probe for a started vzdump (phase 2 of 2).
+
+    No ``upid`` = resume the latest unverified ledger entry (restart-safe: a
+    new process can pick up an in-flight backup with zero extra state). The
+    result's ``state`` is the caller's contract — running/unknown are
+    TRANSIENT (retry to the wall bound), only ``failed`` is terminal;
+    ``ok`` only means "this probe reached a usable answer".
+
+    On ``verified``: flip the start row, rotate (prune to keep-last), alert.
+    On ``failed``: flip the row terminally, alert CRITICAL. Never auto-retries
+    the backup itself.
+    """
+    if not upid:
+        entry = ledger.latest_backup()
+        if not entry or entry.get("verified") or not entry.get("upid"):
+            return {"ok": False, "stage": "no_backup_in_flight",
+                    "error": "no unverified backup with a task handle in the ledger"}
+        upid = str(entry["upid"])
+
+    status = await adapter.vzdump_status(upid)
+
+    if status.state == "verified":
+        ledger.mark_latest_backup_verified(upid, ok=True)
+        prune_ok, prune_detail = await adapter.prune_backups()
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.INFO,
+            title="Backup verified",
+            body=(f"{status.volid or 'backup'} is on the datastore "
+                  f"(age {status.age_days:.2f}d).\n"
+                  f"Rotation: {'ok' if prune_ok else 'FAILED'} — {prune_detail}"
+                  if status.age_days is not None else
+                  f"{status.volid or 'backup'} is on the datastore.\n"
+                  f"Rotation: {'ok' if prune_ok else 'FAILED'} — {prune_detail}"),
+        ))
+        return {"ok": True, "stage": "verified", "state": "verified",
+                "upid": upid, "volid": status.volid,
+                "prune_ok": prune_ok, "prune": prune_detail}
+
+    if status.state == "failed":
+        ledger.mark_latest_backup_verified(upid, ok=False)
+        await dispatcher.send(Alert(
+            severity=AlertSeverity.CRITICAL,
+            title="Backup task FAILED",
+            body=f"{upid}\n{status.detail}\nNo auto-retry — manual check needed.",
+        ))
+        return {"ok": False, "stage": "task_failed", "state": "failed",
+                "upid": upid, "error": status.detail}
+
+    # running / unknown — transient by contract; no ledger change, no alert.
+    return {"ok": True, "stage": "pending", "state": status.state,
+            "upid": upid, "detail": status.detail}

--- a/src/genesis/guardian/provisioning/flow.py
+++ b/src/genesis/guardian/provisioning/flow.py
@@ -370,12 +370,15 @@ def _vzdump_in_flight_upid(config: GuardianConfig, ledger: ProvisioningLedger) -
     """The UPID of a still-latched backup, or "".
 
     Latch = the latest vzdump ledger entry is unverified, HAS a upid (an entry
-    without one is a failed start — nothing to resume, must never latch), and
+    without one is a failed start — nothing to resume, must never latch), is
+    NOT yet resolved (a terminal-failed row carries ``resolved_ts`` while
+    staying ``verified: false`` — the task is over, so it must not latch), and
     is younger than the vzdump wall bound. Past the wall bound the latch
     self-expires: the operation ends as UNVERIFIED, never blocks forever.
     """
     entry = ledger.latest_backup()
-    if not entry or entry.get("verified") or not entry.get("upid"):
+    if (not entry or entry.get("verified") or entry.get("resolved_ts")
+            or not entry.get("upid")):
         return ""
     try:
         started = datetime.fromisoformat(str(entry.get("ts")))

--- a/src/genesis/guardian/provisioning/gate.py
+++ b/src/genesis/guardian/provisioning/gate.py
@@ -38,6 +38,11 @@ class DueDiligenceReport:
             for c in self.checks
         ]
 
+    def failed_names(self) -> list[str]:
+        """Machine-readable failure surface — callers (e.g. the JIT
+        backup→grow chain) must branch on THIS, never parse as_lines()."""
+        return [c.name for c in self.checks if not c.passed]
+
 
 def _backup_check(
     config: ProvisioningConfig, backup_age_days: float | None,
@@ -53,11 +58,12 @@ def _backup_check(
     )
 
 
-def _rate_check(config: ProvisioningConfig, actions_in_window: int) -> Check:
-    ok = actions_in_window < config.max_actions_per_week
+def _rate_check(count: int, cap: int, label: str) -> Check:
+    """Per-action-CLASS rate cap (grows and backups have separate budgets)."""
+    ok = count < cap
     return Check(
         "rate cap", ok,
-        f"{actions_in_window} executed in last 7d (cap {config.max_actions_per_week})",
+        f"{count} {label} executed in last 7d (cap {cap})",
     )
 
 
@@ -95,7 +101,7 @@ def evaluate_disk_grow(
         if free is not None else "storage free unknown",
     ))
 
-    checks.append(_rate_check(config, actions_in_window))
+    checks.append(_rate_check(actions_in_window, config.max_actions_per_week, "grows"))
     checks.append(_backup_check(config, backup_age_days))
 
     return DueDiligenceReport(
@@ -123,7 +129,7 @@ def evaluate_memory_grow(
         checks.append(Check("grow-only", False, "cannot verify (current unknown)"))
         checks.append(Check("step within cap", False, "cannot verify (current unknown)"))
         checks.append(Check("node RAM headroom", False, "cannot verify (current unknown)"))
-        checks.append(_rate_check(config, actions_in_window))
+        checks.append(_rate_check(actions_in_window, config.max_actions_per_week, "grows"))
         checks.append(_backup_check(config, backup_age_days))
         return DueDiligenceReport(
             passed=False, action="grow_vm_memory", requested=requested, checks=checks,
@@ -153,10 +159,75 @@ def evaluate_memory_grow(
         if avail is not None else "node available memory unknown",
     ))
 
-    checks.append(_rate_check(config, actions_in_window))
+    checks.append(_rate_check(actions_in_window, config.max_actions_per_week, "grows"))
     checks.append(_backup_check(config, backup_age_days))
 
     return DueDiligenceReport(
         passed=all(c.passed for c in checks),
         action="grow_vm_memory", requested=requested, checks=checks,
+    )
+
+
+def evaluate_vzdump(
+    cap: HostCapacity,
+    config: ProvisioningConfig,
+    backups_in_window: int,
+    in_flight_upid: str = "",
+) -> DueDiligenceReport:
+    """Due diligence for STARTING a vzdump (non-destructive, but not free:
+    it reads the whole live VM disk and lands multi-GB on the datastore).
+
+    ``in_flight_upid``: a still-latched earlier backup (unverified, younger
+    than the vzdump wall bound) — a second start is refused while one may be
+    running; PVE would reject it anyway, but only as an opaque task failure
+    after another approval round.
+    """
+    storage_name = config.backup_storage or config.storage
+    requested = f"vzdump vmid {config.vmid} -> {storage_name}"
+    checks: list[Check] = []
+
+    checks.append(Check("capacity detected", cap.detected, cap.detail or ""))
+
+    # Estimated worst-case dump size = the VM's total disk allocation ×
+    # the configured multiplier (1.0 default = incompressible worst case).
+    # NOTE: prune runs AFTER the new backup lands, so the datastore
+    # transiently holds keep_last+1 backups — live avail self-enforces this;
+    # the detail names it so a post-rotation refusal reads as policy, not bug.
+    alloc = sum(cap.disks.values()) if cap.disks else 0
+    est = int(alloc * config.backup_size_multiplier)
+    avail = cap.backup_storage_free_bytes
+    space_ok = alloc > 0 and avail is not None and avail >= est
+    if avail is None:
+        space_detail = f"backup storage '{storage_name}' free space unknown — refusing"
+    elif alloc <= 0:
+        space_detail = "VM disk allocation unknown — cannot estimate dump size"
+    else:
+        space_detail = (
+            f"{avail / _GIB:.0f}G free ≥ ~{est / _GIB:.0f}G est. dump "
+            f"(alloc {alloc / _GIB:.0f}G × {config.backup_size_multiplier}; "
+            f"store holds keep-last+1 until rotation)"
+        )
+    checks.append(Check("backup storage headroom", space_ok, space_detail))
+
+    checks.append(_rate_check(backups_in_window, config.max_backups_per_week, "backups"))
+
+    checks.append(Check(
+        "no backup in flight", not in_flight_upid,
+        f"unverified backup still in flight ({in_flight_upid}) — "
+        "run provision-vzdump-status first" if in_flight_upid else "none in flight",
+    ))
+
+    # Informational only (always passes): which consistency class this buys.
+    if cap.vm_agent_enabled is True:
+        agent_detail = "guest agent enabled → filesystem-consistent (fsfreeze)"
+    elif cap.vm_agent_enabled is False:
+        agent_detail = ("no guest agent → crash-consistent "
+                        "(like a power cut: journaled fs + SQLite WAL recover)")
+    else:
+        agent_detail = "guest agent state unknown"
+    checks.append(Check("consistency class", True, agent_detail))
+
+    return DueDiligenceReport(
+        passed=all(c.passed for c in checks),
+        action="vzdump", requested=requested, checks=checks,
     )

--- a/src/genesis/guardian/provisioning/ledger.py
+++ b/src/genesis/guardian/provisioning/ledger.py
@@ -1,10 +1,12 @@
 """Provisioning ledger + proposal state (atomic, 0600, never-raise).
 
-``ledger.json`` records every EXECUTED mutation (a PUT was issued) — verified or
-not — so the weekly rate cap counts real hypervisor changes, including ones that
-didn't verify (an unverified mutation may well have landed). ``proposal_state.json``
-holds the autonomous-propose damper timestamp so a sustained pool-crit doesn't
-re-propose every tick.
+``ledger.json`` records every EXECUTED mutation (a PUT/POST was issued) —
+verified or not — so the weekly rate caps count real hypervisor changes,
+including ones that didn't verify (an unverified mutation may well have landed).
+Rate caps are per action CLASS (``actions_in_window(action_prefix=...)``):
+grows and backups have separate budgets so neither starves the other.
+``proposal_state.json`` holds the autonomous-propose damper timestamp so a
+sustained pool-crit doesn't re-propose every tick.
 """
 
 from __future__ import annotations
@@ -49,25 +51,33 @@ class ProvisioningLedger:
     # ── mutations ledger ──────────────────────────────────────────────────
     def record_action(
         self, action: str, requested: str, ok: bool, verified: bool,
-        target_bytes: int | None = None,
+        target_bytes: int | None = None, upid: str = "",
     ) -> None:
-        """Append an executed mutation. Called only after a PUT was issued.
+        """Append an executed mutation. Called only after a PUT/POST was issued.
 
         ``target_bytes`` records the absolute size the mutation aimed for (disk
         grows only) so an unverified-but-landed grow can be detected later and
         not stacked with a second relative grow.
+
+        ``upid`` (two-phase actions, e.g. vzdump) is the PVE task handle. The
+        start-time record IS the operation's durable state: the rate-cap entry,
+        the in-flight latch, and the restart-resume handle all in one row —
+        verification later flips ``verified`` in place, never appends.
         """
         entries = self._read_json(self._ledger, [])
         if not isinstance(entries, list):
             entries = []
-        entries.append({
+        entry: dict[str, Any] = {
             "ts": datetime.now(UTC).isoformat(),
             "action": action,
             "requested": requested,
             "ok": ok,
             "verified": verified,
             "target_bytes": target_bytes,
-        })
+        }
+        if upid:
+            entry["upid"] = upid
+        entries.append(entry)
         self._atomic_write(self._ledger, entries)
 
     def latest_unverified_disk(self, disk: str) -> dict | None:
@@ -106,14 +116,21 @@ class ProvisioningLedger:
                     self._atomic_write(self._ledger, entries)
                 return
 
-    def actions_in_window(self, days: int = 7) -> int:
-        """Count executed mutations within the rolling window."""
+    def actions_in_window(self, days: int = 7, action_prefix: str = "") -> int:
+        """Count executed mutations within the rolling window.
+
+        ``action_prefix`` scopes the count to one action class ("grow_" for the
+        grow budget, "vzdump" for the backup budget) so the classes never
+        consume each other's weekly cap. Empty prefix = all entries (legacy).
+        """
         entries = self._read_json(self._ledger, [])
         if not isinstance(entries, list):
             return 0
         cutoff = datetime.now(UTC) - timedelta(days=days)
         count = 0
         for e in entries:
+            if action_prefix and not str(e.get("action", "")).startswith(action_prefix):
+                continue
             try:
                 ts = datetime.fromisoformat(e["ts"])
             except (KeyError, TypeError, ValueError):
@@ -121,6 +138,43 @@ class ProvisioningLedger:
             if ts >= cutoff:
                 count += 1
         return count
+
+    def latest_backup(self) -> dict | None:
+        """The most recent vzdump entry, verified or not (None if none exist).
+
+        The unverified case is the two-phase state machine's whole state: the
+        in-flight latch (a second start must be refused while it is younger
+        than the vzdump wall-bound) and the restart-resume handle (a no-arg
+        status verb verifies THIS entry's upid).
+        """
+        entries = self._read_json(self._ledger, [])
+        if not isinstance(entries, list):
+            return None
+        for e in reversed(entries):
+            if str(e.get("action", "")).startswith("vzdump"):
+                return e
+        return None
+
+    def mark_latest_backup_verified(self, upid: str, ok: bool = True) -> bool:
+        """Flip the latest vzdump entry matching ``upid`` in place.
+
+        ``ok=True`` marks it verified (clears the in-flight latch); ``ok=False``
+        records the task terminally failed (also clears the latch — the work is
+        over either way, and the entry keeps counting against the backup cap).
+        Records NO new mutation. Returns True iff an entry was updated.
+        """
+        entries = self._read_json(self._ledger, [])
+        if not isinstance(entries, list):
+            return False
+        for e in reversed(entries):
+            if (str(e.get("action", "")).startswith("vzdump")
+                    and e.get("upid") == upid):
+                e["verified"] = bool(ok)
+                e["ok"] = bool(ok)
+                e["resolved_ts"] = datetime.now(UTC).isoformat()
+                self._atomic_write(self._ledger, entries)
+                return True
+        return False
 
     # ── proposal damper ───────────────────────────────────────────────────
     def load_proposal_state(self) -> dict:

--- a/src/genesis/guardian/provisioning/proxmox.py
+++ b/src/genesis/guardian/provisioning/proxmox.py
@@ -1,10 +1,20 @@
 """Proxmox VE provisioning adapter (stdlib urllib, never-raise).
 
-Talks to the PVE API (``/api2/json``) with two privilege-separated tokens:
-an AUDIT token for all reads (get_capacity, connectivity, verify re-reads) and
-a PROVISION token — scoped to VM.Config.Disk/Memory on this one VM only — for
-the two mutating PUTs. Code never parses the token's user/realm; the whole
-token string goes into the ``PVEAPIToken=`` header verbatim.
+Talks to the PVE API (``/api2/json``) with three privilege-separated tokens:
+an AUDIT token for all reads (get_capacity, connectivity, verify re-reads,
+backup-age/status), a PROVISION token — scoped to VM.Config.Disk/Memory on this
+one VM only — for the two grow PUTs, and a BACKUP token — VM.Backup on this VM
++ Datastore.AllocateSpace on the backup storage only — for vzdump-start and
+prune. Code never parses a token's user/realm; the whole token string goes into
+the ``PVEAPIToken=`` header verbatim. Absent backup token ⇒ backup verbs refuse
+pre-flight (safe degradation, never a crash, nothing ledgered).
+
+Backups are TWO-PHASE: ``vzdump_start`` only launches the task (a full-VM dump
+runs for tens of minutes+, far past ``_await_task``'s resize-sized default) and
+returns the UPID; ``vzdump_status`` is a single verify probe the caller polls.
+Verification anchors on the UPID's own embedded starttime — restart-safe with
+zero persisted adapter state — and requires the task's ``exitstatus == OK``
+AND a datastore content entry for this vmid with ``ctime >= starttime``.
 
 Response shapes were captured live from PVE 9.1.4 (2026-07-06):
 - ``/nodes/N/status`` → ``.data.memory{total,free,used,available}``, ``.data.cpuinfo.cpus``
@@ -21,6 +31,7 @@ import json
 import logging
 import re
 import ssl
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -28,6 +39,8 @@ from typing import Any
 
 from genesis.guardian.config import ProvisioningConfig
 from genesis.guardian.provisioning.base import (
+    BackupStartResult,
+    BackupStatus,
     HostCapacity,
     ProvisioningAdapter,
     ProvisionResult,
@@ -65,11 +78,13 @@ class ProxmoxAdapter(ProvisioningAdapter):
         config: ProvisioningConfig,
         audit_token: str,
         provision_token: str,
+        backup_token: str = "",
         request_timeout: float = 30.0,
     ) -> None:
         self._config = config
         self._audit = audit_token
         self._provision = provision_token
+        self._backup = backup_token
         self._timeout = request_timeout
         self._base = (
             f"https://{config.api_host}:{config.api_port}/api2/json"
@@ -205,6 +220,41 @@ class ProxmoxAdapter(ProvisioningAdapter):
                     break
         return out
 
+    @staticmethod
+    def _agent_enabled(vm_cfg: dict[str, Any]) -> bool | None:
+        """Parse the qemu ``agent`` config key ("1", "0", "enabled=1,...").
+
+        Absent key = agent not enabled (PVE default). Present-but-unparseable
+        = None (unknown) — informational only, never gates anything.
+        """
+        raw = vm_cfg.get("agent")
+        if raw is None:
+            return False
+        for part in str(raw).split(","):
+            part = part.strip()
+            if part in ("1", "0"):
+                return part == "1"
+            if part.startswith("enabled="):
+                return part[len("enabled="):] == "1"
+        return None
+
+    @staticmethod
+    def _upid_starttime(upid: str) -> int | None:
+        """The task's own start epoch, parsed from the UPID's hex field.
+
+        ``UPID:node:pid:pstart:starttime:type:id:user@realm!token:`` — field 4
+        is the start time in hex. This is what makes verify restart-safe with
+        no persisted state: "a backup newer than THIS task's start" is
+        well-defined even hours later, unlike any "age ≈ 0" heuristic.
+        """
+        parts = upid.split(":")
+        if len(parts) < 6 or parts[0] != "UPID":
+            return None
+        try:
+            return int(parts[4], 16)
+        except ValueError:
+            return None
+
     # ── capacity (audit token, read-only) ────────────────────────────────
     async def get_capacity(self) -> HostCapacity:
         cfg = self._config
@@ -236,11 +286,19 @@ class ProxmoxAdapter(ProvisioningAdapter):
         node_mem_available = mem.get("available")
 
         storage_free = storage_total = None
+        backup_free = backup_total = None
+        backup_storage = cfg.backup_storage or cfg.storage
         for s in storages:
-            if isinstance(s, dict) and s.get("storage") == cfg.storage:
+            if not isinstance(s, dict):
+                continue
+            if s.get("storage") == cfg.storage:
                 storage_free = s.get("avail")
                 storage_total = s.get("total")
-                break
+            if s.get("storage") == backup_storage:
+                # May be the same entry as ``storage`` — that's fine, the gate
+                # then checks the one shared datastore's headroom.
+                backup_free = s.get("avail")
+                backup_total = s.get("total")
 
         vm_mem_mib: int | None = None
         raw_mem = vm_cfg.get("memory")
@@ -260,6 +318,9 @@ class ProxmoxAdapter(ProvisioningAdapter):
             storage_total_bytes=storage_total,
             node_mem_total_bytes=node_mem_total,
             node_mem_available_bytes=node_mem_available,
+            backup_storage_free_bytes=backup_free,
+            backup_storage_total_bytes=backup_total,
+            vm_agent_enabled=self._agent_enabled(vm_cfg),
             detail="ok",
         )
 
@@ -421,3 +482,174 @@ class ProxmoxAdapter(ProvisioningAdapter):
             verified=verified, requires_reboot=requires_reboot,
             error="" if verified else "memory PUT issued but re-read did not confirm",
         )
+
+    # ── backups: two-phase vzdump + age + rotation ─────────────────────────
+    def _backup_storage(self) -> str:
+        return self._config.backup_storage or self._config.storage
+
+    async def newest_backup_age_days(self) -> float | None:
+        """Age in days of this VM's newest backup on the backup storage.
+
+        Audit token (Datastore.Audit). None on any read failure or when no
+        backup exists — the gate refuses on None when a recent backup is
+        required, never assumes. Filters on the content entry's ``vmid``
+        FIELD, never by volid substring (vmid-100 vs vmid-1000 collisions).
+        """
+        cfg = self._config
+        st, items, _err = await self._request(
+            "GET",
+            f"/nodes/{cfg.node}/storage/{self._backup_storage()}/content",
+            params={"content": "backup"},
+            token=self._audit,
+        )
+        if st != 200 or not isinstance(items, list):
+            return None
+        newest: int | None = None
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            try:
+                if int(item.get("vmid", -1)) != int(cfg.vmid):
+                    continue
+                ctime = int(item["ctime"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if newest is None or ctime > newest:
+                newest = ctime
+        if newest is None:
+            return None
+        return max(0.0, (time.time() - newest) / 86400.0)
+
+    async def vzdump_start(self) -> BackupStartResult:
+        """Launch a vzdump of this VM (backup token). Returns the UPID only.
+
+        Deliberately NOT awaited here: a full-VM dump runs for tens of
+        minutes+. ``prune-backups`` is NOT passed inline — that parameter
+        requires Datastore.Allocate; rotation uses the standalone prunebackups
+        endpoint (owner semantics) after verification instead.
+        """
+        cfg = self._config
+        requested = f"vzdump vmid {cfg.vmid} -> {self._backup_storage()}"
+        if not self._backup:
+            return BackupStartResult(
+                ok=False, requested=requested, attempted=False,
+                error="no backup token configured (PROXMOX_BACKUP_TOKEN)",
+            )
+        st, data, err = await self._request(
+            "POST", f"/nodes/{cfg.node}/vzdump",
+            params={
+                "vmid": cfg.vmid,
+                "storage": self._backup_storage(),
+                "mode": "snapshot",
+                "compress": "zstd",
+            },
+            token=self._backup,
+        )
+        if st != 200 or not (isinstance(data, str) and data.startswith("UPID:")):
+            return BackupStartResult(
+                ok=False, requested=requested, attempted=True,
+                error=f"vzdump POST failed: {err or st}",
+            )
+        return BackupStartResult(ok=True, upid=data, requested=requested, attempted=True)
+
+    async def vzdump_status(self, upid: str) -> BackupStatus:
+        """Single verify probe for a started vzdump (audit token, no loop).
+
+        verified = task ``exitstatus == OK`` AND a content entry for this vmid
+        with ``ctime >= `` the UPID's own starttime (corroboration that the
+        backup actually landed on the datastore). A probe that cannot tell
+        returns ``unknown`` — the CALLER treats that as transient and retries;
+        only the task's own terminal non-OK exitstatus is ``failed``.
+        """
+        cfg = self._config
+        encoded = urllib.parse.quote(upid, safe="")
+        st, data, err = await self._request(
+            "GET", f"/nodes/{cfg.node}/tasks/{encoded}/status", token=self._audit,
+        )
+        if st != 200 or not isinstance(data, dict):
+            return BackupStatus(state="unknown", detail=err or f"status read {st}")
+        if data.get("status") != "stopped":
+            return BackupStatus(state="running", detail="task still running")
+        exitstatus = str(data.get("exitstatus") or "").strip()
+        if exitstatus != "OK":
+            return BackupStatus(
+                state="failed", detail=f"task exitstatus: {exitstatus or 'unreported'}",
+            )
+        # Task says OK — corroborate on the datastore, anchored to the task's
+        # own start time (restart-safe; no persisted state, no age heuristic).
+        started = self._upid_starttime(upid)
+        if started is None:
+            raw = data.get("starttime")
+            started = raw if isinstance(raw, int) else None
+        stc, items, cerr = await self._request(
+            "GET",
+            f"/nodes/{cfg.node}/storage/{self._backup_storage()}/content",
+            params={"content": "backup"},
+            token=self._audit,
+        )
+        if stc != 200 or not isinstance(items, list):
+            # Task finished OK but this probe can't see the datastore — let the
+            # caller retry rather than declaring either outcome.
+            return BackupStatus(
+                state="unknown",
+                detail=f"task OK; content corroboration unavailable ({cerr or stc})",
+            )
+        best_volid, best_ctime = "", None
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            try:
+                if int(item.get("vmid", -1)) != int(cfg.vmid):
+                    continue
+                ctime = int(item["ctime"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if started is not None and ctime < started:
+                continue
+            if best_ctime is None or ctime > best_ctime:
+                best_ctime, best_volid = ctime, str(item.get("volid", ""))
+        if best_ctime is None:
+            # OK task but no new backup visible yet (listing lag is possible) —
+            # transient for the caller; a persistent mismatch ends UNVERIFIED
+            # at the wall bound, which is the honest outcome.
+            return BackupStatus(
+                state="unknown", detail="task OK but no new backup visible for this vmid yet",
+            )
+        return BackupStatus(
+            state="verified", volid=best_volid,
+            age_days=max(0.0, (time.time() - best_ctime) / 86400.0),
+            detail="task OK; new backup visible",
+        )
+
+    async def prune_backups(self) -> tuple[bool, str]:
+        """Rotate this VM's backups to ``backup_keep_last`` (backup token).
+
+        Standalone prunebackups endpoint — owner semantics (VM.Backup +
+        Datastore.AllocateSpace), unlike the inline vzdump ``prune-backups``
+        param which would demand Datastore.Allocate. Dry-run GET first for the
+        log, then the pruning POST, awaited (pruning is seconds, not minutes).
+        """
+        cfg = self._config
+        if not self._backup:
+            return False, "no backup token configured (PROXMOX_BACKUP_TOKEN)"
+        keep = max(1, int(cfg.backup_keep_last))
+        params = {
+            "prune-backups": f"keep-last={keep}",
+            "type": "qemu",
+            "vmid": cfg.vmid,
+        }
+        path = f"/nodes/{cfg.node}/storage/{self._backup_storage()}/prunebackups"
+        std, dry, _derr = await self._request("GET", path, params=params, token=self._audit)
+        if std == 200 and isinstance(dry, list):
+            doomed = [d.get("volid") for d in dry
+                      if isinstance(d, dict) and d.get("mark") == "remove"]
+            logger.info("prune dry-run (keep-last=%d): removing %s", keep, doomed or "nothing")
+        stp, data, err = await self._request("POST", path, params=params, token=self._backup)
+        if stp != 200:
+            return False, f"prune POST failed: {err or stp}"
+        if isinstance(data, str) and data.startswith("UPID:"):
+            task_ok, exitstatus = await self._await_task(data)
+            if not task_ok:
+                return False, f"prune task failed: {exitstatus}"
+        return True, f"pruned to keep-last={keep}"
+

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -11,7 +11,8 @@ enforces this restriction, not our code.
 Gateway allowlist: restart-timer, pause, resume, status, reset-state, version,
 update, sync-gateway, redeploy, update-cc, update-node, test-approval,
 disk-status, host-profile, reharden-key, ping, provision-status,
-provision-grow-disk, provision-grow-memory, storage-expand, grow-root,
+provision-grow-disk, provision-grow-memory, provision-vzdump,
+provision-vzdump-status, storage-expand, grow-root,
 set-container-limits.
 """
 
@@ -27,6 +28,11 @@ logger = logging.getLogger(__name__)
 
 # Client-side validation (defense in depth — the gateway re-validates too).
 _DISK_RE = re.compile(r"(scsi|virtio|sata)[0-9]{1,2}")
+# One shared strict UPID charset, mirrored byte-for-byte by the gateway's
+# bash regex (parity-tested): ':' '@' '!' are real UPID bytes, but nothing
+# shell-active (whitespace/quotes/;/$) is admitted, and it is always expanded
+# quoted on the host side.
+_UPID_RE = re.compile(r"UPID:[A-Za-z0-9:@!._\-]{10,220}")
 
 # Per-verb SSH wait timeouts. The grow/expand verbs run long host-side (a disk
 # grow + LVM absorb), so the client waits slightly LONGER than the gateway's own
@@ -41,6 +47,9 @@ _VERSION_TIMEOUT = 30.0      # gateway version verb: auth-status probe + version
 _HOST_PROFILE_TIMEOUT = 50.0  # gateway: timeout 45 (pool lvs + incus probes)
 _GROW_DISK_TIMEOUT = 660.0   # gateway: timeout 600 (PVE resize + storage-expand)
 _GROW_MEM_TIMEOUT = 180.0    # gateway: timeout 120 (config PUT + pending check)
+_VZDUMP_TIMEOUT = 330.0      # gateway: timeout 300 (start: gate+POST / status:
+                             # probe + on-verify prune task) — NEVER the backup
+                             # itself; that runs host-side under its own UPID
 _EXPAND_TIMEOUT = 660.0      # gateway: timeout 600 (pvresize + autoextend profile)
 _GROW_ROOT_TIMEOUT = 330.0   # gateway: timeout 300 (incus LV + fs online resize)
 _SET_LIMITS_TIMEOUT = 70.0   # gateway: timeout 60 (incus config set + verify)
@@ -337,6 +346,31 @@ class GuardianRemote:
             f"provision-grow-memory {new_mib}", timeout=_GROW_MEM_TIMEOUT,
         )
         return self._as_json(ok, out, "provision-grow-memory")
+
+    async def request_vzdump_start(self) -> dict:
+        """EXECUTE a pre-approved backup START (phase 1 — returns the UPID).
+
+        The gateway verb only launches the vzdump (ledger-at-start host-side);
+        the backup itself runs for tens of minutes+ under PVE. Poll
+        :meth:`request_vzdump_status` to verify.
+        """
+        ok, out = await self._ssh_command("provision-vzdump", timeout=_VZDUMP_TIMEOUT)
+        return self._as_json(ok, out, "provision-vzdump")
+
+    async def request_vzdump_status(self, upid: str = "") -> dict:
+        """One verify probe (phase 2). No upid = resume latest in-flight.
+
+        The JSON's ``state`` is the contract: running/unknown = transient
+        (retry on the caller's cadence), verified/failed = terminal. Transport
+        failures surface as ``{"ok": False, "error": ...}`` — treat those as
+        transient too (S7 discipline), never as a failed backup.
+        """
+        if upid and not _UPID_RE.fullmatch(upid):
+            return {"ok": False, "action": "provision-vzdump-status",
+                    "error": f"invalid UPID {upid[:60]!r}"}
+        cmd = f"provision-vzdump-status {upid}" if upid else "provision-vzdump-status"
+        ok, out = await self._ssh_command(cmd, timeout=_VZDUMP_TIMEOUT)
+        return self._as_json(ok, out, "provision-vzdump-status")
 
     async def storage_expand(self) -> dict:
         """Absorb an already-grown virtual disk into the LVM-thin pool."""

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -370,6 +370,18 @@ class GuardianRemote:
                     "error": f"invalid UPID {upid[:60]!r}"}
         cmd = f"provision-vzdump-status {upid}" if upid else "provision-vzdump-status"
         ok, out = await self._ssh_command(cmd, timeout=_VZDUMP_TIMEOUT)
+        # A terminally-FAILED task makes the host verb emit ok:false → SSH exits
+        # nonzero. But its JSON body still carries the authoritative ``state``
+        # ("failed"), and the poller keys on that to STOP + notify once. Parse
+        # the body regardless of exit code so a determined terminal state is
+        # never mistaken for a transient transport error (a real SSH/timeout
+        # failure yields non-JSON and falls through to the transient form).
+        try:
+            parsed = json.loads(out)
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict) and "state" in parsed:
+            return parsed
         return self._as_json(ok, out, "provision-vzdump-status")
 
     async def storage_expand(self) -> dict:

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -428,6 +428,39 @@ async def provision_grow(
 
 
 @mcp.tool()
+async def provision_vzdump(
+    timeout_seconds: int = 1800,
+    wall_seconds: int = 7200,
+) -> dict:
+    """Take a hypervisor backup (vzdump) of the host VM — approval-gated.
+
+    Sends an APPROVE/DENY request to your own channel; only on APPROVE starts
+    the backup, then RETURNS IMMEDIATELY with the task handle (a full-VM dump
+    runs for tens of minutes+). A background task polls it to completion and
+    messages the outcome; old backups rotate automatically once the new one
+    verifies. ``wall_seconds`` bounds only how long the poller waits before
+    abandoning as UNVERIFIED (the backup itself is never killed).
+
+    Backups normally happen just-in-time as the precondition of a grow — use
+    this for an explicit, user-requested backup.
+    """
+    if not _pipeline:
+        # Standalone MCP subprocess → bridge to genesis-server (owner-approval
+        # is enforced there). The RPC returns at START, so grace only covers
+        # approval wait + the start verb — never the backup duration.
+        return await _server_rpc(
+            "/api/genesis/provision/vzdump",
+            {"timeout_seconds": timeout_seconds, "wall_seconds": wall_seconds},
+            read_timeout_s=float(timeout_seconds) + 420.0,
+        )
+    from genesis.outreach.rpc import vzdump_via_pipeline
+
+    return await vzdump_via_pipeline(
+        _pipeline, timeout_s=float(timeout_seconds), wall_s=float(wall_seconds),
+    )
+
+
+@mcp.tool()
 async def outreach_engagement(
     outreach_id: str,
     signal: str,

--- a/src/genesis/outreach/rpc.py
+++ b/src/genesis/outreach/rpc.py
@@ -99,8 +99,19 @@ async def grow_via_pipeline(
         )
         return reply
 
+    async def _notify(text: str) -> None:
+        # Fire-and-forget outcome message (chain results, wall-bound). Raw for
+        # the same reason as _ask: these carry exact operational state.
+        req = OutreachRequest(
+            category=OutreachCategory("blocker"), topic=text[:100], context=text,
+            salience_score=1.0, signal_type="provision_outcome", channel="telegram",
+        )
+        await pipeline.submit_raw(text, req)
+
     if kind == "disk":
-        return await coordinate_grow_disk(remote, _ask, disk=disk, add_gib=gib)
+        return await coordinate_grow_disk(
+            remote, _ask, disk=disk, add_gib=gib, notify=_notify,
+        )
     if kind == "memory":
         return await coordinate_grow_memory(remote, _ask, new_mib=mib)
     if kind == "root":
@@ -110,3 +121,43 @@ async def grow_via_pipeline(
             remote, _ask, mem_mib=(mib or None), cpu=(cpu or None),
         )
     return {"ok": False, "error": f"invalid kind {kind!r} (disk|memory|root|limits)"}
+
+
+async def vzdump_via_pipeline(
+    pipeline: OutreachPipeline,
+    *,
+    timeout_s: float,
+    wall_s: float = 7200.0,
+) -> dict:
+    """Approval-gated hypervisor backup (vzdump): ask the owner, on APPROVE
+    START the backup and return immediately (two-phase — the dump runs for
+    tens of minutes+); a tracked background task polls it to a terminal state
+    and messages the outcome. Never mutates without an APPROVE reply.
+    """
+    from genesis.guardian.provisioning.container import coordinate_vzdump
+    from genesis.observability.health import _load_guardian_remote_from_config
+
+    remote = _load_guardian_remote_from_config()
+    if remote is None:
+        return {"ok": False, "error": "guardian remote not configured (no guardian_remote.yaml)"}
+
+    async def _ask(text: str) -> str | None:
+        req = OutreachRequest(
+            category=OutreachCategory("blocker"), topic=text[:100], context=text,
+            salience_score=1.0, signal_type="provision_approval", channel="telegram",
+        )
+        _result, reply = await pipeline.submit_raw_and_wait(
+            text, req, timeout_s=float(timeout_s),
+        )
+        return reply
+
+    async def _notify(text: str) -> None:
+        req = OutreachRequest(
+            category=OutreachCategory("blocker"), topic=text[:100], context=text,
+            salience_score=1.0, signal_type="provision_outcome", channel="telegram",
+        )
+        await pipeline.submit_raw(text, req)
+
+    return await coordinate_vzdump(
+        remote, _ask, notify=_notify, vzdump_wall_s=float(wall_s),
+    )

--- a/tests/test_guardian/test_check.py
+++ b/tests/test_guardian/test_check.py
@@ -228,10 +228,26 @@ class TestBuildProvisioningAdapter:
         _prov_cfg(config)
         monkeypatch.setenv("PROXMOX_AUDIT_TOKEN", "aud-tok")
         monkeypatch.setenv("PROXMOX_PROVISION_TOKEN", "prov-tok")
+        monkeypatch.setenv("PROXMOX_BACKUP_TOKEN", "bak-tok")
         adapter = _build_provisioning_adapter(config)
         assert adapter is not None
         assert adapter._audit == "aud-tok"
         assert adapter._provision == "prov-tok"
+        assert adapter._backup == "bak-tok"
+
+    def test_missing_backup_token_degrades_not_fails(
+        self,
+        config: GuardianConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No backup token → adapter still builds; only backup verbs refuse."""
+        _prov_cfg(config)
+        monkeypatch.setenv("PROXMOX_AUDIT_TOKEN", "aud-tok")
+        monkeypatch.setenv("PROXMOX_PROVISION_TOKEN", "prov-tok")
+        monkeypatch.delenv("PROXMOX_BACKUP_TOKEN", raising=False)
+        adapter = _build_provisioning_adapter(config)
+        assert adapter is not None
+        assert adapter._backup == ""
 
     def test_audit_only_is_readonly_adapter(
         self,

--- a/tests/test_guardian/test_config_provisioning_override.py
+++ b/tests/test_guardian/test_config_provisioning_override.py
@@ -99,3 +99,40 @@ def test_native_yaml_types_accepted(tmp_path):
     cfg = load_config(cfg_path)
     assert cfg.provisioning.enabled is True
     assert cfg.provisioning.vmid == 42
+
+
+# ── vzdump slice: new backup fields + float coercion ──────────────────────
+
+
+def test_backup_fields_have_generic_defaults():
+    """Nothing install-specific: empty backup_storage falls back to `storage`
+    at the consumer; caps/multiplier/wall-bound are generic defaults."""
+    pc = ProvisioningConfig()
+    assert pc.backup_storage == ""
+    assert pc.backup_keep_last == 2
+    assert pc.max_backups_per_week == 2
+    assert pc.backup_size_multiplier == 1.0
+    assert pc.vzdump_timeout_s == 7200
+
+
+def test_float_field_coerces_through_override(tmp_path):
+    """configure-provisioning sends strings — float fields must coerce (the
+    pre-existing coercer only knew bool/int/str)."""
+    state = tmp_path / "state"
+    dest = write_provisioning_override(str(state), {
+        "backup_storage": "backup",
+        "backup_keep_last": "3",
+        "backup_size_multiplier": "0.7",
+        "vzdump_timeout_s": "10800",
+    })
+    written = yaml.safe_load(dest.read_text())["provisioning"]
+    assert written["backup_storage"] == "backup"
+    assert written["backup_keep_last"] == 3
+    assert written["backup_size_multiplier"] == pytest.approx(0.7)
+    assert written["vzdump_timeout_s"] == 10800
+
+
+def test_bad_float_value_raises_value_error(tmp_path):
+    state = tmp_path / "state"
+    with pytest.raises(ValueError):
+        write_provisioning_override(str(state), {"backup_size_multiplier": "fast"})

--- a/tests/test_guardian/test_credential_bridge.py
+++ b/tests/test_guardian/test_credential_bridge.py
@@ -240,7 +240,7 @@ class TestRoundTrip:
 
 
 class TestProvisioningCredentials:
-    """Proxmox token propagation — only the two token keys ever cross."""
+    """Proxmox token propagation — only the three token keys ever cross."""
 
     def test_writes_only_proxmox_tokens(self, tmp_path: Path) -> None:
         from genesis.guardian.credential_bridge import (
@@ -253,6 +253,7 @@ class TestProvisioningCredentials:
             "ANTHROPIC_API_KEY=should-not-appear\n"
             "PROXMOX_AUDIT_TOKEN=genesis@pve!ro=aaa\n"
             "PROXMOX_PROVISION_TOKEN=genesis@pve!provision=bbb\n"
+            "PROXMOX_BACKUP_TOKEN=genesis@pve!backup=ccc\n"
             "TELEGRAM_BOT_TOKEN=should-not-appear-here\n"
         )
         shared = tmp_path / "state" / "shared"
@@ -262,6 +263,7 @@ class TestProvisioningCredentials:
         result = load_provisioning_credentials(str(tmp_path / "state"))
         assert result["PROXMOX_AUDIT_TOKEN"] == "genesis@pve!ro=aaa"
         assert result["PROXMOX_PROVISION_TOKEN"] == "genesis@pve!provision=bbb"
+        assert result["PROXMOX_BACKUP_TOKEN"] == "genesis@pve!backup=ccc"
         assert "ANTHROPIC_API_KEY" not in result
         assert "TELEGRAM_BOT_TOKEN" not in result
 

--- a/tests/test_guardian/test_guardian_gateway_provision.py
+++ b/tests/test_guardian/test_guardian_gateway_provision.py
@@ -133,3 +133,79 @@ def test_unknown_verb_denied(sandbox):
     r = _run(sandbox, "provision-nuke-everything")
     assert r.returncode == 1
     assert "denied" in r.stderr
+
+
+# ── vzdump verbs (two-phase) + UPID transit parity ────────────────────────
+
+# Synthetic UPID in the real PVE shape (node:pid:pstart:starttime:type:id:user):
+_UPID = "UPID:pve:000A1B2C:001122DD:68765432:vzdump:100:user@pve!backup:"
+
+
+@_needs_bash
+class TestProvisionVzdump:
+    def test_start_runs_the_cli(self, sandbox):
+        r = _run(sandbox, "provision-vzdump")
+        assert r.returncode == 0
+        argv = json.loads(r.stdout)["argv"]
+        assert argv[-1] == "--provision-vzdump"
+
+    def test_start_takes_no_args(self, sandbox):
+        r = _run(sandbox, "provision-vzdump --help; id")
+        assert r.returncode != 0, "argful start must fall through to denied"
+
+    def test_status_no_arg_resumes(self, sandbox):
+        r = _run(sandbox, "provision-vzdump-status")
+        assert r.returncode == 0
+        argv = json.loads(r.stdout)["argv"]
+        assert argv[-1] == "--provision-vzdump-status"
+
+    def test_status_forwards_valid_upid_quoted(self, sandbox):
+        r = _run(sandbox, f"provision-vzdump-status {_UPID}")
+        assert r.returncode == 0
+        argv = json.loads(r.stdout)["argv"]
+        assert argv[-2:] == ["--provision-vzdump-status", _UPID]
+
+    @pytest.mark.parametrize("bad", [
+        "provision-vzdump-status $(reboot)",
+        "provision-vzdump-status UPID:pve:1:1:1:vzdump:100:u@p!t: ; id",
+        "provision-vzdump-status UPID:pve:1:1:1:vzdump:100:u'@p!t:",
+        'provision-vzdump-status UPID:pve:1:1:1:vzdump:100:u"@p!t:',
+        "provision-vzdump-status notaupid",
+        "provision-vzdump-status UPID:x",  # below min length
+    ])
+    def test_status_rejects_shell_active_or_malformed(self, sandbox, bad):
+        r = _run(sandbox, bad)
+        assert r.returncode != 0, f"must reject: {bad!r}"
+        assert "invalid UPID" in (r.stderr + r.stdout) or "denied" in (r.stderr + r.stdout)
+
+
+class TestUpidThreeHopParity:
+    """S5: the same UPID must pass the remote-client regex, the gateway bash
+    regex, and the URL-encoding hop — drift between them = dead feature."""
+
+    def test_remote_client_regex_accepts_real_shape(self):
+        from genesis.guardian.remote import _UPID_RE
+        assert _UPID_RE.fullmatch(_UPID)
+
+    @_needs_bash
+    def test_gateway_and_client_agree(self, sandbox):
+        from genesis.guardian.remote import _UPID_RE
+        cases = [
+            (_UPID, True),
+            ("UPID:pve-node2:0000F00D:00000001:698A0001:vzdump:1002:root@pam!tok:", True),
+            ("UPID:pve:1:1:1:vzdump:100:u p!t:", False),   # space
+            ("UPID:pve:1:1:1:vzdump:100:u;p!t:", False),   # semicolon
+            ("upid:pve:000A1B2C:001122DD:68765432:vzdump:100:u@p!t:", False),  # case
+        ]
+        for upid, expect in cases:
+            client_ok = _UPID_RE.fullmatch(upid) is not None
+            r = _run(sandbox, f"provision-vzdump-status {upid}")
+            gateway_ok = r.returncode == 0
+            assert client_ok == expect, f"client regex drift on {upid!r}"
+            assert gateway_ok == expect, f"gateway regex drift on {upid!r}"
+
+    def test_url_encoding_round_trip(self):
+        import urllib.parse
+        encoded = urllib.parse.quote(_UPID, safe="")
+        assert "!" not in encoded and "@" not in encoded and ":" not in encoded
+        assert urllib.parse.unquote(encoded) == _UPID

--- a/tests/test_guardian/test_provisioning_container.py
+++ b/tests/test_guardian/test_provisioning_container.py
@@ -8,9 +8,12 @@ is shown to the user; APPROVE dispatches the correct host verb.
 
 from __future__ import annotations
 
+import genesis.guardian.provisioning.container as container_mod
 from genesis.guardian.provisioning.container import (
+    _poll_vzdump,
     coordinate_grow_disk,
     coordinate_grow_memory,
+    coordinate_vzdump,
 )
 
 _GIB = 1024**3
@@ -100,3 +103,193 @@ async def test_memory_grow_approve_dispatches():
     assert res["ok"] is True
     assert remote.grow_mem_args == 24576
     assert "reboot" in ask.prompt.lower()  # user warned about downtime
+
+
+# ── JIT backup→grow chain + explicit vzdump (two-phase, tracked poller) ───
+
+
+class FakeChainRemote(FakeRemote):
+    """FakeRemote + the vzdump verbs, with a scripted status sequence."""
+
+    def __init__(self, status, grow_result=None, *, start_result=None, states=None):
+        super().__init__(status, grow_result)
+        self.start_result = start_result or {
+            "ok": True, "stage": "started",
+            "upid": "UPID:pve:000A1B2C:001122DD:68765432:vzdump:100:u@pve!t:",
+        }
+        self.states = list(states or [])
+        self.start_calls = 0
+        self.status_calls = 0
+
+    async def request_vzdump_start(self):
+        self.start_calls += 1
+        return self.start_result
+
+    async def request_vzdump_status(self, upid=""):
+        self.status_calls += 1
+        return self.states.pop(0) if self.states else {"ok": True, "state": "unknown"}
+
+
+def _stale_status(in_flight=""):
+    s = _status_ok()
+    s["backup"] = {
+        "age_days": None, "require_recent_backup": True,
+        "backup_max_age_days": 14, "in_flight_upid": in_flight,
+    }
+    return s
+
+
+def _fresh_status():
+    s = _status_ok()
+    s["backup"] = {
+        "age_days": 1.0, "require_recent_backup": True,
+        "backup_max_age_days": 14, "in_flight_upid": "",
+    }
+    return s
+
+
+class _CapturedTask:
+    """Capture the poller coroutine instead of scheduling it, so tests drive
+    it deterministically."""
+
+    def __init__(self, monkeypatch):
+        self.coros = []
+        monkeypatch.setattr(
+            container_mod, "tracked_task",
+            lambda coro, **kw: self.coros.append(coro) or None,
+        )
+
+
+class _Notify:
+    def __init__(self):
+        self.messages = []
+
+    async def __call__(self, text):
+        self.messages.append(text)
+
+
+async def test_stale_backup_turns_grow_into_one_approval_chain(monkeypatch):
+    captured = _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(
+        _stale_status(),
+        states=[{"ok": True, "state": "running"}, {"ok": True, "state": "verified"}],
+    )
+    notify = _Notify()
+    ask = _ask("APPROVE")
+    res = await coordinate_grow_disk(
+        remote, ask, disk="scsi1", add_gib=32, notify=notify, poll_interval_s=0.0,
+    )
+    assert res["stage"] == "chain_started" and res["upid"].startswith("UPID:")
+    # S8: the single approval text must disclose the whole chain + the gap
+    assert "CHAIN" in ask.prompt and "AUTOMATICALLY" in ask.prompt
+    assert remote.grow_disk_args is None, "grow must NOT run before verification"
+    # drive the captured poller to completion
+    assert len(captured.coros) == 1
+    await captured.coros[0]
+    assert remote.grow_disk_args == ("scsi1", 32)
+    assert any("Chain complete" in m for m in notify.messages)
+
+
+async def test_stale_backup_deny_runs_nothing(monkeypatch):
+    captured = _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(_stale_status())
+    res = await coordinate_grow_disk(remote, _ask("DENY"), disk="scsi1", add_gib=32)
+    assert res["stage"] == "denied"
+    assert remote.start_calls == 0 and remote.grow_disk_args is None
+    assert captured.coros == []
+
+
+async def test_backup_in_flight_refuses_before_asking(monkeypatch):
+    _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(_stale_status(in_flight="UPID:pve:1:1:68765432:vzdump:100:u@p!t:"))
+    ask = _ask("APPROVE")
+    res = await coordinate_grow_disk(remote, ask, disk="scsi1", add_gib=32)
+    assert res["stage"] == "backup_in_flight"
+    assert not hasattr(ask, "prompt"), "must not prompt while a backup runs"
+
+
+async def test_fresh_backup_keeps_plain_grow(monkeypatch):
+    captured = _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(_fresh_status())
+    ask = _ask("APPROVE")
+    res = await coordinate_grow_disk(remote, ask, disk="scsi1", add_gib=32)
+    assert res == {"ok": True, "stage": "executed"}
+    assert "CHAIN" not in ask.prompt
+    assert remote.start_calls == 0 and captured.coros == []
+
+
+async def test_chain_backup_start_failure_aborts(monkeypatch):
+    captured = _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(
+        _stale_status(), start_result={"ok": False, "error": "denied"},
+    )
+    res = await coordinate_grow_disk(remote, _ask("APPROVE"), disk="scsi1", add_gib=32)
+    assert res["stage"] == "backup_start_failed"
+    assert remote.grow_disk_args is None and captured.coros == []
+
+
+async def test_poller_backup_failure_never_grows():
+    remote = FakeChainRemote(_stale_status(), states=[
+        {"ok": True, "state": "unknown"},  # transient probe tolerated
+        {"ok": False, "state": "failed", "error": "task exitstatus: job errors"},
+    ])
+    notify = _Notify()
+
+    async def _grow_leg():
+        return await remote.request_grow_disk("scsi1", 32)
+
+    res = await _poll_vzdump(
+        remote, notify, upid="UPID:x", poll_interval_s=0.0, wall_s=30.0,
+        on_verified=_grow_leg,
+    )
+    assert res["state"] == "failed"
+    assert remote.grow_disk_args is None
+    assert any("NOT executed" in m for m in notify.messages)
+
+
+async def test_poller_wall_bound_is_unverified_not_failed():
+    remote = FakeChainRemote(_stale_status())
+    notify = _Notify()
+    res = await _poll_vzdump(
+        remote, notify, upid="UPID:x", poll_interval_s=0.0, wall_s=0.0,
+    )
+    assert res["stage"] == "wall_bound"
+    assert any("UNVERIFIED" in m for m in notify.messages)
+
+
+async def test_chain_grow_leg_refusal_notifies_and_stops():
+    """S8: a failed post-backup re-check alerts and STOPS — never re-asks."""
+    remote = FakeChainRemote(
+        _stale_status(),
+        grow_result={"ok": False, "stage": "recheck_failed"},
+        states=[{"ok": True, "state": "verified"}],
+    )
+    notify = _Notify()
+
+    async def _grow_leg():
+        return await remote.request_grow_disk("scsi1", 32)
+
+    res = await _poll_vzdump(
+        remote, notify, upid="UPID:x", poll_interval_s=0.0, wall_s=30.0,
+        on_verified=_grow_leg,
+    )
+    assert res["stage"] == "recheck_failed"
+    assert any("did NOT run" in m for m in notify.messages)
+
+
+async def test_coordinate_vzdump_approve_starts_and_tracks(monkeypatch):
+    captured = _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(_fresh_status(), states=[{"ok": True, "state": "verified"}])
+    res = await coordinate_vzdump(remote, _ask("APPROVE"))
+    assert res["stage"] == "started" and res["upid"].startswith("UPID:")
+    assert len(captured.coros) == 1
+    await captured.coros[0]  # runs to verified without error
+
+
+async def test_coordinate_vzdump_deny_and_inflight(monkeypatch):
+    _CapturedTask(monkeypatch)
+    remote = FakeChainRemote(_fresh_status())
+    assert (await coordinate_vzdump(remote, _ask("DENY")))["stage"] == "denied"
+    assert remote.start_calls == 0
+    remote2 = FakeChainRemote(_stale_status(in_flight="UPID:pve:1:1:68765432:vzdump:100:u@p!t:"))
+    assert (await coordinate_vzdump(remote2, _ask("APPROVE")))["stage"] == "backup_in_flight"

--- a/tests/test_guardian/test_provisioning_flow.py
+++ b/tests/test_guardian/test_provisioning_flow.py
@@ -512,3 +512,35 @@ async def test_grow_rate_cap_ignores_backups(tmp_path):
         _cfg(max_actions_per_week=2), _disk_req(), adapter, disp, ledger,
     )
     assert res["ok"], f"two prior backups must not trip the 2-grow cap: {res}"
+
+
+# ── P2 fixes: failed backup releases the latch; terminal state is usable ───
+
+async def test_failed_backup_releases_in_flight_latch(tmp_path):
+    """Codex P2: after a terminally-failed backup the task is OVER — the row
+    stays verified:false but carries resolved_ts, and must NOT keep latching
+    (which would block a retry/grow chain for up to vzdump_timeout_s)."""
+    from genesis.guardian.provisioning.flow import _vzdump_in_flight_upid
+    ledger = ProvisioningLedger(tmp_path)
+    ledger.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=_UPID)
+    assert _vzdump_in_flight_upid(_cfg(), ledger) == _UPID  # in flight while running
+    ledger.mark_latest_backup_verified(_UPID, ok=False)      # terminal failure
+    assert _vzdump_in_flight_upid(_cfg(), ledger) == "", (
+        "a resolved (failed) backup must not keep latching"
+    )
+
+
+async def test_new_backup_allowed_after_failure(tmp_path):
+    """End-to-end of the latch fix: a fresh start passes the in-flight check
+    once the prior backup has terminally failed."""
+    ledger = ProvisioningLedger(tmp_path)
+    ledger.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=_UPID)
+    ledger.mark_latest_backup_verified(_UPID, ok=False)
+    adapter = FakeAdapter(_backup_cap())
+    adapter.start_result = BackupStartResult(
+        ok=True, upid=_UPID.replace("68765432", "68765499"), requested="x", attempted=True,
+    )
+    res = await execute_vzdump_start(
+        _cfg(max_backups_per_week=5), adapter, FakeDispatcher(), ledger,
+    )
+    assert res["ok"], f"a fresh backup must be allowed after a failed one: {res}"

--- a/tests/test_guardian/test_provisioning_flow.py
+++ b/tests/test_guardian/test_provisioning_flow.py
@@ -8,12 +8,19 @@ import pytest
 import genesis.guardian.provisioning.flow as flow_mod
 from genesis.guardian.alert.telegram import CONFLICT_SENTINEL, TelegramAlertChannel
 from genesis.guardian.config import GuardianConfig
-from genesis.guardian.provisioning.base import HostCapacity, ProvisionResult
+from genesis.guardian.provisioning.base import (
+    BackupStartResult,
+    BackupStatus,
+    HostCapacity,
+    ProvisionResult,
+)
 from genesis.guardian.provisioning.flow import (
     ProvisionRequest,
     execute_provisioning_action,
+    execute_vzdump_start,
     maybe_propose_pool_grow,
     run_provisioning_flow,
+    verify_vzdump_step,
 )
 from genesis.guardian.provisioning.ledger import ProvisioningLedger
 
@@ -69,6 +76,24 @@ class FakeAdapter:
 
     async def newest_backup_age_days(self):
         return self._backup
+
+    # ── backup verbs (vzdump slice) — knob-driven ──
+    start_result = None      # BackupStartResult to return
+    status_results = None    # list of BackupStatus, popped per probe
+    prune_result = (True, "pruned to keep-last=2")
+
+    async def vzdump_start(self):
+        self.vzdump_start_calls = getattr(self, "vzdump_start_calls", 0) + 1
+        return self.start_result
+
+    async def vzdump_status(self, upid):
+        self.status_upids = getattr(self, "status_upids", [])
+        self.status_upids.append(upid)
+        return self.status_results.pop(0)
+
+    async def prune_backups(self):
+        self.prune_calls = getattr(self, "prune_calls", 0) + 1
+        return self.prune_result
 
 
 def _cfg(**prov):
@@ -326,3 +351,164 @@ async def test_propose_fires_when_stale(tmp_path):
     assert res is not None and res["stage"] == "denied"
     assert ch.sent, "proposal was sent"
     assert led.hours_since_last_proposal("pool_grow") is not None  # marked
+
+
+# ── two-phase vzdump flow (start ledgers immediately; verify flips) ───────
+
+_UPID = "UPID:pve:000A1B2C:001122DD:68765432:vzdump:100:user@pve!backup:"
+
+
+def _backup_cap(**kw):
+    defaults = dict(
+        detected=True, vm_memory_mib=21500, cores=5,
+        disks={"scsi0": 32 * _GIB, "scsi1": 64 * _GIB},
+        storage_free_bytes=574 * _GIB,
+        node_mem_total_bytes=141 * _GIB, node_mem_available_bytes=65 * _GIB,
+        backup_storage_free_bytes=150 * _GIB,
+        backup_storage_total_bytes=500 * _GIB,
+        vm_agent_enabled=False, detail="ok",
+    )
+    defaults.update(kw)
+    return HostCapacity(**defaults)
+
+
+async def test_vzdump_start_ledgers_at_start_even_before_any_verify(tmp_path):
+    """B1: the start row is written the moment the POST is accepted — the
+    rate-cap entry, in-flight latch, and restart-resume handle in one row."""
+    adapter = FakeAdapter(_backup_cap())
+    adapter.start_result = BackupStartResult(
+        ok=True, upid=_UPID, requested="vzdump vmid 100 -> backup", attempted=True,
+    )
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    res = await execute_vzdump_start(_cfg(), adapter, disp, ledger)
+    assert res["ok"] and res["stage"] == "started" and res["upid"] == _UPID
+    entry = ledger.latest_backup()
+    assert entry is not None and entry["upid"] == _UPID
+    assert entry["verified"] is False
+    assert ledger.actions_in_window(action_prefix="vzdump") == 1
+    assert disp.alerts == [], "a clean start is not an alert"
+
+
+async def test_vzdump_start_gate_refusal_writes_nothing(tmp_path):
+    adapter = FakeAdapter(_backup_cap(backup_storage_free_bytes=None))
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    res = await execute_vzdump_start(_cfg(), adapter, disp, ledger)
+    assert not res["ok"] and res["stage"] == "recheck_failed"
+    assert "backup storage headroom" in res["failed_checks"]
+    assert ledger.latest_backup() is None, "refusals are never ledgered"
+    assert getattr(adapter, "vzdump_start_calls", 0) == 0
+
+
+async def test_vzdump_start_failed_post_is_ledgered_but_never_latches(tmp_path):
+    """A sent-but-failed POST counts against the cap (conservative) but a
+    upid-less row must not latch — there is nothing to resume."""
+    adapter = FakeAdapter(_backup_cap())
+    adapter.start_result = BackupStartResult(
+        ok=False, requested="vzdump vmid 100 -> backup", attempted=True,
+        error="HTTP 403: denied",
+    )
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    res = await execute_vzdump_start(_cfg(), adapter, disp, ledger)
+    assert not res["ok"] and res["stage"] == "start_failed"
+    assert ledger.actions_in_window(action_prefix="vzdump") == 1
+    assert _sev(disp.alerts) == ["critical"]
+    # and the latch is NOT set: a second start passes the in-flight check
+    adapter2 = FakeAdapter(_backup_cap())
+    adapter2.start_result = BackupStartResult(
+        ok=True, upid=_UPID, requested="x", attempted=True,
+    )
+    res2 = await execute_vzdump_start(_cfg(max_backups_per_week=5), adapter2, disp, ledger)
+    assert res2["ok"], f"upid-less failure must not latch: {res2}"
+
+
+async def test_vzdump_second_start_refused_while_latched(tmp_path):
+    adapter = FakeAdapter(_backup_cap())
+    adapter.start_result = BackupStartResult(
+        ok=True, upid=_UPID, requested="x", attempted=True,
+    )
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    assert (await execute_vzdump_start(_cfg(max_backups_per_week=5), adapter, disp, ledger))["ok"]
+    res2 = await execute_vzdump_start(_cfg(max_backups_per_week=5), adapter, disp, ledger)
+    assert not res2["ok"] and "no backup in flight" in res2["failed_checks"]
+    assert getattr(adapter, "vzdump_start_calls", 0) == 1
+
+
+async def test_verify_no_arg_resumes_latest_inflight_and_flips_prunes(tmp_path):
+    """S1: restart-safe resume — a fresh process verifies the ledger's UPID."""
+    adapter = FakeAdapter(_backup_cap())
+    adapter.status_results = [BackupStatus(
+        state="verified", volid="backup:backup/vzdump-qemu-100-x.vma.zst",
+        age_days=0.01, detail="task OK; new backup visible",
+    )]
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    ledger.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=_UPID)
+    res = await verify_vzdump_step(_cfg(), adapter, disp, ledger)  # NO upid arg
+    assert res["ok"] and res["state"] == "verified"
+    assert adapter.status_upids == [_UPID], "must probe the ledger's own UPID"
+    assert ledger.latest_backup()["verified"] is True
+    assert getattr(adapter, "prune_calls", 0) == 1, "rotation runs on verify"
+    assert _sev(disp.alerts) == ["info"]
+
+
+async def test_verify_terminal_failure_flips_and_alerts_critical(tmp_path):
+    adapter = FakeAdapter(_backup_cap())
+    adapter.status_results = [BackupStatus(state="failed", detail="task exitstatus: job errors")]
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    ledger.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=_UPID)
+    res = await verify_vzdump_step(_cfg(), adapter, disp, ledger, upid=_UPID)
+    assert not res["ok"] and res["state"] == "failed"
+    entry = ledger.latest_backup()
+    assert entry["ok"] is False, "terminal failure is recorded"
+    assert getattr(adapter, "prune_calls", 0) == 0, "never rotate on failure"
+    assert _sev(disp.alerts) == ["critical"]
+
+
+async def test_verify_transient_states_change_nothing(tmp_path):
+    """S7: running/unknown are TRANSIENT — no ledger flip, no alert, latch intact."""
+    adapter = FakeAdapter(_backup_cap())
+    adapter.status_results = [
+        BackupStatus(state="running", detail="task still running"),
+        BackupStatus(state="unknown", detail="status read 500"),
+    ]
+    disp = FakeDispatcher()
+    ledger = ProvisioningLedger(tmp_path)
+    ledger.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=_UPID)
+    for expected in ("running", "unknown"):
+        res = await verify_vzdump_step(_cfg(), adapter, disp, ledger, upid=_UPID)
+        assert res["ok"] and res["state"] == expected
+    assert ledger.latest_backup()["verified"] is False
+    assert disp.alerts == []
+
+
+async def test_verify_with_nothing_in_flight_errors(tmp_path):
+    adapter = FakeAdapter(_backup_cap())
+    disp = FakeDispatcher()
+    res = await verify_vzdump_step(_cfg(), adapter, disp, ProvisioningLedger(tmp_path))
+    assert not res["ok"] and res["stage"] == "no_backup_in_flight"
+
+
+async def test_grow_rate_cap_ignores_backups(tmp_path):
+    """N3/the collision the due-diligence round found: a backup must not
+    consume the grow budget."""
+    ledger = ProvisioningLedger(tmp_path)
+    ledger.record_action("vzdump", "vmid 100", ok=True, verified=True, upid=_UPID)
+    ledger.record_action("vzdump", "vmid 100 again", ok=True, verified=True,
+                         upid=_UPID.replace("68765432", "68765433"))
+    adapter = FakeAdapter(
+        _good_cap(),
+        disk_result=ProvisionResult(
+            ok=True, action="grow_vm_disk", requested="scsi1 +32G",
+            before="32.0G", after="64.0G", verified=True,
+        ),
+    )
+    disp = FakeDispatcher()
+    res = await execute_provisioning_action(
+        _cfg(max_actions_per_week=2), _disk_req(), adapter, disp, ledger,
+    )
+    assert res["ok"], f"two prior backups must not trip the 2-grow cap: {res}"

--- a/tests/test_guardian/test_provisioning_gate.py
+++ b/tests/test_guardian/test_provisioning_gate.py
@@ -7,6 +7,7 @@ from genesis.guardian.provisioning.base import HostCapacity
 from genesis.guardian.provisioning.gate import (
     evaluate_disk_grow,
     evaluate_memory_grow,
+    evaluate_vzdump,
 )
 
 _GIB = 1024**3
@@ -130,3 +131,80 @@ def test_report_as_lines_render():
     lines = r.as_lines()
     assert len(lines) == len(r.checks)
     assert all(line.startswith(("✅", "❌")) for line in lines)
+
+
+# ── evaluate_vzdump (backup start gate) ───────────────────────────────────
+
+def _backup_cap(**kw):
+    defaults = dict(
+        detected=True, vm_memory_mib=21500, cores=5,
+        disks={"scsi0": 32 * _GIB, "scsi1": 64 * _GIB},
+        storage_free_bytes=574 * _GIB,
+        backup_storage_free_bytes=150 * _GIB,
+        backup_storage_total_bytes=500 * _GIB,
+        vm_agent_enabled=False, detail="ok",
+    )
+    defaults.update(kw)
+    return HostCapacity(**defaults)
+
+
+def _bcfg(**kw):
+    return ProvisioningConfig(
+        enabled=True, vmid=100, storage="local-lvm", backup_storage="backup", **kw,
+    )
+
+
+def test_vzdump_passes_with_headroom_and_reports_consistency():
+    rep = evaluate_vzdump(_backup_cap(), _bcfg(), backups_in_window=0)
+    assert rep.passed and rep.action == "vzdump"
+    assert rep.failed_names() == []
+    consistency = next(c for c in rep.checks if c.name == "consistency class")
+    assert consistency.passed and "crash-consistent" in consistency.detail
+
+
+def test_vzdump_checks_backup_storage_not_grow_storage():
+    """S2: 96G alloc, grow storage has plenty, but the BACKUP storage has 50G
+    — the gate must refuse on the backup storage's headroom."""
+    cap = _backup_cap(backup_storage_free_bytes=50 * _GIB)
+    rep = evaluate_vzdump(cap, _bcfg(), backups_in_window=0)
+    assert not rep.passed
+    assert rep.failed_names() == ["backup storage headroom"]
+
+
+def test_vzdump_refuses_on_unknown_backup_storage_space():
+    cap = _backup_cap(backup_storage_free_bytes=None)
+    rep = evaluate_vzdump(cap, _bcfg(), backups_in_window=0)
+    assert not rep.passed
+    assert "backup storage headroom" in rep.failed_names()
+
+
+def test_vzdump_size_multiplier_scales_the_estimate():
+    # 96G alloc × 0.5 = 48G est → 50G free passes
+    cap = _backup_cap(backup_storage_free_bytes=50 * _GIB)
+    rep = evaluate_vzdump(cap, _bcfg(backup_size_multiplier=0.5), backups_in_window=0)
+    assert rep.passed, rep.as_lines()
+
+
+def test_vzdump_backup_rate_cap_is_its_own_class():
+    rep = evaluate_vzdump(_backup_cap(), _bcfg(max_backups_per_week=2), backups_in_window=2)
+    assert not rep.passed
+    assert rep.failed_names() == ["rate cap"]
+    rate = next(c for c in rep.checks if c.name == "rate cap")
+    assert "backups" in rate.detail, "the detail must name the class"
+
+
+def test_vzdump_in_flight_latch_refuses():
+    rep = evaluate_vzdump(
+        _backup_cap(), _bcfg(), backups_in_window=0,
+        in_flight_upid="UPID:pve:0A:0B:68765432:vzdump:100:u@pve!t:",
+    )
+    assert not rep.passed
+    assert rep.failed_names() == ["no backup in flight"]
+
+
+def test_grow_rate_check_names_its_class():
+    rep = evaluate_disk_grow(
+        _backup_cap(), _bcfg(), "scsi1", 8, actions_in_window=0, backup_age_days=1.0,
+    )
+    rate = next(c for c in rep.checks if c.name == "rate cap")
+    assert "grows" in rate.detail

--- a/tests/test_guardian/test_provisioning_ledger.py
+++ b/tests/test_guardian/test_provisioning_ledger.py
@@ -102,3 +102,76 @@ def test_mark_latest_disk_verified_clears_latch(tmp_path):
     assert led.latest_unverified_disk("scsi1") is None
     # does NOT add a new mutation (rate cap unchanged)
     assert led.actions_in_window() == 1
+
+
+# ── per-class rate caps + two-phase backup state (vzdump slice) ───────────
+
+
+def test_action_prefix_scopes_the_count(tmp_path):
+    """Grows and backups have separate budgets — neither consumes the other's."""
+    led = ProvisioningLedger(tmp_path)
+    led.record_action("grow_vm_disk", "scsi1 +32G", ok=True, verified=True)
+    led.record_action("grow_vm_memory", "24576MiB", ok=True, verified=True)
+    led.record_action("vzdump", "vmid 100 -> storage backup", ok=True,
+                      verified=False, upid="UPID:pve:0001:0002:0003:vzdump:100:u@pve!t:")
+    assert led.actions_in_window() == 3, "no prefix = legacy all-entries count"
+    assert led.actions_in_window(action_prefix="grow_") == 2
+    assert led.actions_in_window(action_prefix="vzdump") == 1
+
+
+def test_record_action_stores_upid_only_when_given(tmp_path):
+    led = ProvisioningLedger(tmp_path)
+    led.record_action("grow_vm_disk", "scsi1 +8G", ok=True, verified=True)
+    led.record_action("vzdump", "vmid 100", ok=True, verified=False,
+                      upid="UPID:pve:0001:0002:0003:vzdump:100:u@pve!t:")
+    entries = json.loads((tmp_path / "provisioning" / "ledger.json").read_text())
+    assert "upid" not in entries[0]
+    assert entries[1]["upid"].startswith("UPID:")
+
+
+def test_latest_backup_returns_newest_vzdump_entry(tmp_path):
+    led = ProvisioningLedger(tmp_path)
+    assert led.latest_backup() is None
+    led.record_action("vzdump", "first", ok=True, verified=True, upid="UPID:a:1:1:1:vzdump:100:u@p!t:")
+    led.record_action("grow_vm_disk", "scsi1 +8G", ok=True, verified=True)
+    led.record_action("vzdump", "second", ok=True, verified=False, upid="UPID:a:2:2:2:vzdump:100:u@p!t:")
+    latest = led.latest_backup()
+    assert latest is not None
+    assert latest["requested"] == "second"
+    assert latest["verified"] is False
+
+
+def test_mark_latest_backup_verified_flips_in_place_no_new_entry(tmp_path):
+    """Verification flips the START record — never appends (rate cap unchanged)."""
+    led = ProvisioningLedger(tmp_path)
+    upid = "UPID:a:2:2:2:vzdump:100:u@p!t:"
+    led.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=upid)
+    assert led.actions_in_window(action_prefix="vzdump") == 1
+    assert led.mark_latest_backup_verified(upid) is True
+    entries = json.loads((tmp_path / "provisioning" / "ledger.json").read_text())
+    assert len(entries) == 1, "flip must not append a second entry"
+    assert entries[0]["verified"] is True
+    assert entries[0]["ok"] is True
+    assert "resolved_ts" in entries[0]
+    assert led.actions_in_window(action_prefix="vzdump") == 1
+
+
+def test_mark_latest_backup_verified_terminal_failure(tmp_path):
+    led = ProvisioningLedger(tmp_path)
+    upid = "UPID:a:3:3:3:vzdump:100:u@p!t:"
+    led.record_action("vzdump", "vmid 100", ok=True, verified=False, upid=upid)
+    assert led.mark_latest_backup_verified(upid, ok=False) is True
+    entries = json.loads((tmp_path / "provisioning" / "ledger.json").read_text())
+    assert entries[0]["ok"] is False
+    assert entries[0]["verified"] is False
+    assert led.actions_in_window(action_prefix="vzdump") == 1, \
+        "a terminally-failed backup still counts against the backup cap"
+
+
+def test_mark_latest_backup_verified_unknown_upid_is_noop(tmp_path):
+    led = ProvisioningLedger(tmp_path)
+    led.record_action("vzdump", "vmid 100", ok=True, verified=False,
+                      upid="UPID:a:4:4:4:vzdump:100:u@p!t:")
+    assert led.mark_latest_backup_verified("UPID:a:9:9:9:vzdump:100:u@p!t:") is False
+    entries = json.loads((tmp_path / "provisioning" / "ledger.json").read_text())
+    assert entries[0]["verified"] is False

--- a/tests/test_guardian/test_provisioning_proxmox.py
+++ b/tests/test_guardian/test_provisioning_proxmox.py
@@ -71,6 +71,16 @@ class FakePVE:
         self.task_never_stops = False  # True → always 'running' (poll timeout)
         self.task_status_code = 200  # non-200 → task-status read failure
         self._task_polls = 0
+        # Backup (vzdump slice) knobs — synthetic identifiers only.
+        self.backups: list = []  # content=backup items ({volid, vmid, ctime})
+        self.content_status = 200  # non-200 → content list read failure
+        self.vzdump_status_code = 200
+        self.vzdump_upid = (
+            "UPID:pve:000A1B2C:001122DD:68765432:vzdump:100:user@pve!backup:"
+        )
+        self.prune_status = 200
+        self.prune_upid = None  # str → prune POST returns a task UPID
+        self.prune_dry: list = []  # GET prunebackups dry-run rows
 
     def __call__(self, method, path, params=None, token=""):
         self.calls.append((method, path, params, token))
@@ -83,6 +93,20 @@ class FakePVE:
             if self.task_never_stops or self._task_polls <= self.task_running_polls:
                 return 200, {"status": "running"}, ""
             return 200, {"status": "stopped", "exitstatus": self.task_exitstatus}, ""
+        if path.endswith("/prunebackups"):
+            if method == "GET":
+                return 200, list(self.prune_dry), ""
+            if self.prune_status != 200:
+                return self.prune_status, None, f"HTTP {self.prune_status}: denied"
+            return 200, self.prune_upid, ""
+        if method == "GET" and path.endswith("/content"):
+            if self.content_status != 200:
+                return self.content_status, None, f"HTTP {self.content_status}: denied"
+            return 200, [dict(b) for b in self.backups], ""
+        if method == "POST" and path.endswith("/vzdump"):
+            if self.vzdump_status_code != 200:
+                return self.vzdump_status_code, None, f"HTTP {self.vzdump_status_code}: denied"
+            return 200, self.vzdump_upid, ""
         if method == "GET" and path.endswith("/status"):
             return 200, self.status, ""
         if method == "GET" and path.endswith("/storage"):
@@ -116,7 +140,10 @@ def _adapter(fake: FakePVE) -> ProxmoxAdapter:
         enabled=True, api_host="10.0.0.9", api_port=8006, verify_tls=False,
         node="pve", vmid=100, target_disk="scsi1", storage="local-lvm",
     )
-    a = ProxmoxAdapter(cfg, audit_token="AUDIT", provision_token="PROVISION")
+    a = ProxmoxAdapter(
+        cfg, audit_token="AUDIT", provision_token="PROVISION",
+        backup_token="BACKUP",
+    )
     a._request_sync = fake  # type: ignore[assignment]
     return a
 
@@ -337,3 +364,217 @@ async def test_connectivity_true():
 def test_auth_header_prefix_idempotent():
     assert ProxmoxAdapter._auth_header("genesis@pve!ro=uuid") == "PVEAPIToken=genesis@pve!ro=uuid"
     assert ProxmoxAdapter._auth_header("PVEAPIToken=x") == "PVEAPIToken=x"
+
+
+# ── backups: two-phase vzdump + age + rotation (all identifiers synthetic) ─
+
+# The FakePVE default UPID's starttime field (index 4) in hex.
+_UPID_STARTTIME = int("68765432", 16)
+
+
+def _backup_item(ctime: int, vmid: int = 100, volid: str | None = None) -> dict:
+    return {
+        "volid": volid or f"backup:backup/vzdump-qemu-{vmid}-x.vma.zst",
+        "vmid": vmid,
+        "ctime": ctime,
+        "content": "backup",
+    }
+
+
+async def test_backup_age_picks_newest_for_this_vmid_only():
+    fake = FakePVE()
+    fake.backups = [
+        _backup_item(1000),
+        _backup_item(5000),
+        _backup_item(9000, vmid=1000),  # vmid FIELD filter — not volid substring
+    ]
+    a = _adapter(fake)
+    age = await a.newest_backup_age_days()
+    assert age is not None
+    import time as _t
+    assert age == pytest.approx((_t.time() - 5000) / 86400.0, rel=0.01)
+    # audit token on the content read
+    method, path, params, token = fake.calls[-1]
+    assert token == "AUDIT" and path.endswith("/content") and params == {"content": "backup"}
+
+
+async def test_backup_age_none_when_no_backups_or_read_fails():
+    fake = FakePVE()
+    a = _adapter(fake)
+    assert await a.newest_backup_age_days() is None  # empty list
+    fake.content_status = 500
+    assert await a.newest_backup_age_days() is None  # read failure
+    fake.transport_dead = True
+    assert await a.newest_backup_age_days() is None  # never raises
+
+
+async def test_backup_age_reads_configured_backup_storage():
+    fake = FakePVE()
+    cfg = ProvisioningConfig(
+        enabled=True, api_host="10.0.0.9", node="pve", vmid=100,
+        storage="local-lvm", backup_storage="backup", verify_tls=False,
+    )
+    a = ProxmoxAdapter(cfg, "AUDIT", "PROVISION", backup_token="BACKUP")
+    a._request_sync = fake  # type: ignore[assignment]
+    await a.newest_backup_age_days()
+    _m, path, _p, _t = fake.calls[-1]
+    assert "/storage/backup/content" in path
+
+
+async def test_vzdump_start_happy_returns_upid_with_backup_token():
+    fake = FakePVE()
+    a = _adapter(fake)
+    res = await a.vzdump_start()
+    assert res.ok and res.attempted
+    assert res.upid.startswith("UPID:")
+    method, path, params, token = fake.calls[-1]
+    assert (method, token) == ("POST", "BACKUP")
+    assert path.endswith("/vzdump")
+    assert params["mode"] == "snapshot" and params["compress"] == "zstd"
+    assert "prune-backups" not in params, (
+        "inline prune-backups needs Datastore.Allocate — rotation must use the "
+        "standalone endpoint instead"
+    )
+
+
+async def test_vzdump_start_without_token_is_preflight_refusal():
+    fake = FakePVE()
+    cfg = ProvisioningConfig(
+        enabled=True, api_host="10.0.0.9", node="pve", vmid=100, verify_tls=False,
+    )
+    a = ProxmoxAdapter(cfg, "AUDIT", "PROVISION")  # no backup token
+    a._request_sync = fake  # type: ignore[assignment]
+    res = await a.vzdump_start()
+    assert not res.ok and not res.attempted, "pre-flight refusal must not be ledgered"
+    assert fake.calls == [], "no request may leave the process without a token"
+
+
+async def test_vzdump_start_post_failure_is_attempted():
+    fake = FakePVE()
+    fake.vzdump_status_code = 403
+    a = _adapter(fake)
+    res = await a.vzdump_start()
+    assert not res.ok and res.attempted, "a sent-but-failed POST still counts (ledger it)"
+
+
+async def test_vzdump_status_running_then_verified_anchored_to_upid_starttime():
+    fake = FakePVE()
+    a = _adapter(fake)
+    upid = fake.vzdump_upid
+    # still running
+    fake.task_never_stops = True
+    assert (await a.vzdump_status(upid)).state == "running"
+    # stopped OK + a backup NEWER than the task start → verified
+    fake.task_never_stops = False
+    fake._task_polls = 0
+    fake.backups = [
+        _backup_item(_UPID_STARTTIME - 500),   # pre-existing backup: ignored
+        _backup_item(_UPID_STARTTIME + 120),   # the new one
+    ]
+    st = await a.vzdump_status(upid)
+    assert st.state == "verified"
+    assert st.volid and st.age_days is not None
+
+
+async def test_vzdump_status_task_ok_but_only_old_backups_is_unknown():
+    """An OLD backup must never verify THIS task (restart-safe anchor)."""
+    fake = FakePVE()
+    a = _adapter(fake)
+    fake.backups = [_backup_item(_UPID_STARTTIME - 500)]
+    st = await a.vzdump_status(fake.vzdump_upid)
+    assert st.state == "unknown"
+
+
+async def test_vzdump_status_terminal_failure_and_transient_reads():
+    fake = FakePVE()
+    a = _adapter(fake)
+    # terminal task failure
+    fake.task_exitstatus = "job errors"
+    assert (await a.vzdump_status(fake.vzdump_upid)).state == "failed"
+    # status endpoint unreadable → unknown (caller retries), never failed
+    fake.task_status_code = 500
+    assert (await a.vzdump_status(fake.vzdump_upid)).state == "unknown"
+    # task OK but content list unreadable → unknown
+    fake.task_status_code = 200
+    fake.task_exitstatus = "OK"
+    fake._task_polls = 0
+    fake.content_status = 500
+    assert (await a.vzdump_status(fake.vzdump_upid)).state == "unknown"
+
+
+async def test_prune_dry_runs_then_posts_with_backup_token():
+    fake = FakePVE()
+    fake.prune_dry = [
+        {"volid": "backup:backup/vzdump-qemu-100-old.vma.zst", "mark": "remove"},
+    ]
+    a = _adapter(fake)
+    ok, detail = await a.prune_backups()
+    assert ok and "keep-last=2" in detail
+    prune_calls = [c for c in fake.calls if c[1].endswith("/prunebackups")]
+    assert [(m, t) for m, _p, _pa, t in prune_calls] == [
+        ("GET", "AUDIT"), ("POST", "BACKUP"),
+    ]
+    _m, _p, params, _t = prune_calls[1]
+    assert params == {"prune-backups": "keep-last=2", "type": "qemu", "vmid": 100}
+
+
+async def test_prune_awaits_task_upid_and_reports_failure():
+    fake = FakePVE()
+    fake.prune_upid = "UPID:pve:000A1B2C:001122DD:68765433:imgdel:100:user@pve!backup:"
+    fake.task_exitstatus = "removal failed"
+    a = _adapter(fake)
+    ok, detail = await a.prune_backups()
+    assert not ok and "removal failed" in detail
+
+
+async def test_prune_without_token_refuses():
+    fake = FakePVE()
+    cfg = ProvisioningConfig(
+        enabled=True, api_host="10.0.0.9", node="pve", vmid=100, verify_tls=False,
+    )
+    a = ProxmoxAdapter(cfg, "AUDIT", "PROVISION")
+    a._request_sync = fake  # type: ignore[assignment]
+    ok, _detail = await a.prune_backups()
+    assert not ok and fake.calls == []
+
+
+async def test_capacity_carries_backup_storage_headroom_and_agent_flag():
+    fake = FakePVE()
+    fake.storage.append(
+        {"storage": "backup", "total": 500 * _GIB, "avail": 150 * _GIB, "used": 1},
+    )
+    cfg = ProvisioningConfig(
+        enabled=True, api_host="10.0.0.9", node="pve", vmid=100,
+        storage="local-lvm", backup_storage="backup", verify_tls=False,
+    )
+    a = ProxmoxAdapter(cfg, "AUDIT", "PROVISION", backup_token="BACKUP")
+    a._request_sync = fake  # type: ignore[assignment]
+    cap = await a.get_capacity()
+    assert cap.backup_storage_free_bytes == 150 * _GIB
+    assert cap.backup_storage_total_bytes == 500 * _GIB
+    assert cap.storage_free_bytes == 616384222882, "grow storage unchanged"
+    assert cap.vm_agent_enabled is False, "no agent key = not enabled"
+
+
+async def test_capacity_backup_storage_defaults_to_grow_storage():
+    fake = FakePVE()
+    a = _adapter(fake)  # backup_storage unset
+    cap = await a.get_capacity()
+    assert cap.backup_storage_free_bytes == cap.storage_free_bytes
+
+
+def test_agent_flag_parsing():
+    parse = ProxmoxAdapter._agent_enabled
+    assert parse({}) is False
+    assert parse({"agent": "1"}) is True
+    assert parse({"agent": "0"}) is False
+    assert parse({"agent": "enabled=1,fstrim_cloned_disks=1"}) is True
+    assert parse({"agent": "enabled=0"}) is False
+    assert parse({"agent": "weird"}) is None
+
+
+def test_upid_starttime_parses_hex_field():
+    parse = ProxmoxAdapter._upid_starttime
+    assert parse("UPID:pve:000A1B2C:001122DD:68765432:vzdump:100:u@pve!t:") == _UPID_STARTTIME
+    assert parse("not-a-upid") is None
+    assert parse("UPID:pve:x:y:GGGG:vzdump:100:u@pve!t:") is None

--- a/tests/test_guardian/test_remote.py
+++ b/tests/test_guardian/test_remote.py
@@ -417,3 +417,55 @@ class TestContainerCapacityExecutors:
             assert (await remote.request_set_container_limits(None, 0))["ok"] is False
             assert (await remote.request_set_container_limits(None, 1000))["ok"] is False
         m.assert_not_called()
+
+
+class TestVzdumpStatus:
+    """The verify probe must not lose a terminal state across the SSH boundary."""
+
+    @pytest.mark.asyncio
+    async def test_failed_state_survives_nonzero_exit(self, remote):
+        """Regression (Codex P2): a terminally-FAILED backup makes the host verb
+        emit ok:false → SSH exits nonzero. The JSON body still carries
+        state="failed"; the client must parse it, not discard it as transient
+        (which would make the poller wait the full wall bound instead of
+        stopping)."""
+        body = ('{"ok": false, "stage": "task_failed", "state": "failed", '
+                '"upid": "UPID:pve:1:1:1:vzdump:100:u@p!t:", "error": "job errors"}')
+        with patch.object(remote, "_ssh_command",
+                          return_value=(False, body)):  # nonzero exit
+            res = await remote.request_vzdump_status(
+                "UPID:pve:1:1:1:vzdump:100:u@p!t:",
+            )
+        assert res["state"] == "failed", "terminal state must survive nonzero exit"
+        assert res["error"] == "job errors"
+
+    @pytest.mark.asyncio
+    async def test_verified_and_running_states_parse(self, remote):
+        for state, exit_ok in [("verified", True), ("running", True)]:
+            with patch.object(remote, "_ssh_command",
+                              return_value=(exit_ok, f'{{"ok": true, "state": "{state}"}}')):
+                res = await remote.request_vzdump_status()
+            assert res["state"] == state
+
+    @pytest.mark.asyncio
+    async def test_real_transport_failure_is_transient_no_state(self, remote):
+        """A genuine SSH/timeout failure yields non-JSON → transient form with
+        no state, so the poller keeps retrying (never a false 'failed')."""
+        with patch.object(remote, "_ssh_command", return_value=(False, "timeout")):
+            res = await remote.request_vzdump_status()
+        assert res["ok"] is False
+        assert "state" not in res
+
+    @pytest.mark.asyncio
+    async def test_invalid_upid_rejected_before_ssh(self, remote):
+        called = False
+
+        async def _spy(*a, **k):
+            nonlocal called
+            called = True
+            return (True, "{}")
+
+        with patch.object(remote, "_ssh_command", new=_spy):
+            res = await remote.request_vzdump_status("not-a-upid")
+        assert not res["ok"] and "invalid UPID" in res["error"]
+        assert not called, "malformed UPID must never reach the gateway"

--- a/tests/test_guardian/test_vzdump_call_site_guardrail.py
+++ b/tests/test_guardian/test_vzdump_call_site_guardrail.py
@@ -1,0 +1,55 @@
+"""Coverage guardrail: vzdump mutation verbs stay inside the approved path.
+
+The vzdump start/prune surface is approval-gated by CONVENTION (approval is
+the caller's job; the execute layer only re-checks the gate). That convention
+only holds if no new call site sneaks in outside the audited chain:
+
+    MCP tool / dashboard RPC → outreach.rpc → provisioning.container
+        → GuardianRemote → gateway verb → __main__ → provisioning.flow
+        → ProxmoxAdapter
+
+Any other caller of the mutating entry points is a finding, not a style nit —
+it would bypass owner approval. Sweep the live tree, don't trust a list.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "genesis"
+
+# The full audited chain (module → why it may touch the verb).
+_ALLOWED = {
+    "guardian/provisioning/proxmox.py",     # the adapter itself
+    "guardian/provisioning/base.py",        # ABC defaults
+    "guardian/provisioning/flow.py",        # execute core (post-approval)
+    "guardian/provisioning/container.py",   # approval coordinator
+    "guardian/remote.py",                   # gateway client
+    "guardian/__main__.py",                 # host verb (gateway-invoked)
+    "outreach/rpc.py",                      # pipeline approval shim
+    "mcp/outreach_mcp.py",                  # MCP tool (approval via pipeline)
+    "dashboard/routes/provision.py",        # RPC bridge (approval via pipeline)
+}
+
+_MUTATORS = re.compile(
+    r"\.(vzdump_start|prune_backups|request_vzdump_start)\s*\("
+    r"|execute_vzdump_start\s*\(",
+)
+
+
+def test_vzdump_mutators_only_in_the_audited_chain():
+    offenders: list[str] = []
+    for py in SRC.rglob("*.py"):
+        rel = str(py.relative_to(SRC))
+        if rel in _ALLOWED:
+            continue
+        text = py.read_text(errors="replace")
+        for m in _MUTATORS.finditer(text):
+            line = text.count("\n", 0, m.start()) + 1
+            offenders.append(f"{rel}:{line}: {m.group(0)}")
+    assert not offenders, (
+        "vzdump mutation verbs outside the audited approval chain "
+        "(add the call site to the chain deliberately or remove it):\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_outreach/test_rpc.py
+++ b/tests/test_outreach/test_rpc.py
@@ -57,7 +57,10 @@ async def test_grow_via_pipeline_disk_asks_then_executes():
     assert out == {"ok": True, "stage": "executed"}
     # coordinate_grow_disk(remote, _ask, disk=..., add_gib=...)
     assert coord.call_args.args[0] is remote
-    assert coord.call_args.kwargs == {"disk": "scsi1", "add_gib": 2}
+    kwargs = dict(coord.call_args.kwargs)
+    notify = kwargs.pop("notify")
+    assert callable(notify), "chain outcomes need the fire-and-forget notifier"
+    assert kwargs == {"disk": "scsi1", "add_gib": 2}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

The Guardian's provisioning gate has always wanted a recent hypervisor backup
before an irreversible VM grow — but nothing could take one, so
`newest_backup_age_days()` returned `None` and the check had to be left
disabled (an unknown backup age is treated as a refusal). This adds the
missing capability: Genesis can now take a `vzdump` backup of its own host VM,
which both creates a real VM-level restore point and lets the grow gate be
armed.

This is the **vzdump-take slice** only. VM lifecycle verbs (start/stop/reboot)
and **restore** are deliberately out of scope — restore is a destructive verb
that gets its own security review.

## Design

- **Third, privilege-separated API token.** A `backup` token
  (`VM.Backup` + `Datastore.AllocateSpace` on the backup storage) keeps the
  existing `provision` token grow-only — it cannot back up, and the backup
  token cannot resize. Absent token degrades safely (backup verbs refuse
  pre-flight; grows unaffected).
- **Two-phase, because a full-VM dump runs for tens of minutes.** The start
  verb only launches the task and returns the PVE UPID; a separate status
  verb is one verify probe. The start is ledgered immediately — that row is
  the rate-cap entry, the in-flight latch, and the restart-resume handle, so
  an interrupted verification resumes after a process restart with no state
  lost. Verification anchors on the UPID's own start time, so an old backup
  can never verify a new task.
- **Just-in-time + rotation, not scheduled.** A backup is proposed as the
  precondition of a grow (a stale-backup grow proposal becomes a
  backup→verify→grow chain under **one** approval, with the time gap and
  automatic execution disclosed in the approval text) or on explicit request
  (`provision_vzdump`). Old backups rotate to a configured keep-last; there is
  no delete verb. Backups have their own weekly budget separate from grows
  (the existing `max_actions_per_week` now counts grows only).
- **Poll-outcome discipline.** Only the task's own terminal exit status is a
  failure; transport errors / still-running are transient and retried to a
  configurable wall bound, which ends as UNVERIFIED (never "failed" — the
  backup may still be landing).

New surface mirrors the existing grow path exactly: gateway verbs (execute-only,
approval is the caller's job), `GuardianRemote` client, container coordinator
(owner APPROVE via the pipeline), a sibling MCP tool, and the RPC bridge for
the standalone-MCP path.

## Safety / review

- Pre-build architecture review (state-machine durability, backup-storage
  headroom source, rate-cap class separation, chained-approval disclosure) —
  findings addressed.
- Security review of the new trust surface (gateway argument injection, token
  privilege separation, approval-gate bypass paths, credential handling) —
  no findings.
- The UPID argument crosses three hops (client regex ↔ gateway bash regex ↔
  URL-encoding) with a strict shared charset that admits real UPID bytes but
  nothing shell-active; a parity test pins the validators together.
- A coverage-guardrail test sweeps the tree so the backup mutation verbs can
  never gain a call site outside the audited approval chain.

## Testing

- 300+ targeted tests across the provisioning adapter, gate, two-phase flow,
  ledger, gateway verbs, credential bridge, container coordinator, MCP tool,
  and dashboard route.
- Read-path verified end-to-end against a live hypervisor: `newest_backup_age_days`,
  the backup-storage headroom extraction, guest-agent detection, and the
  backup gate all produce correct results on real API response shapes.
- The write path (start→verify→prune) is verified in a supervised first run
  after merge, once the backup token is provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
