### PR TITLE
chore(hygiene): GitNexus injection off at the source + Generalizability Gate

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -313,6 +313,60 @@ Verify before any commit:
   only proposes it). Find ids via `session_charter` or the charter injection
   block.
 
+## Generalizability Gate — build for ANY install, not this one
+
+Genesis is a public, cloneable system. Every change must work on ANY user's
+install, not just the machine it was written on. Standing user directive.
+
+**Hardware/scale adaptivity.** Other installs have different RAM, disk, CPU
+count, and workload scale. Never hardcode absolute resource numbers or scale
+assumptions:
+
+- Memory/disk caps: percentage-of-available or config-derived, never fixed
+  GB (precedent: #1029 percentage-based memory caps). Concurrency: derive
+  from `os.cpu_count()`/config, never a literal core count.
+- Hard minimums are allowed but must be EXPLICIT (documented in install
+  docs/config comments), not implicit assumptions that fail mysteriously.
+- Workload scale varies (PR velocity, table sizes, transcript sizes):
+  enumerate with pagination/bounds and LOUD truncation markers, never
+  silent caps (precedent: repo-pulse `limit_hit`).
+- Optional dependencies (Ollama, GPU, individual API keys) must degrade
+  gracefully behind detection/config — presence is never assumed
+  (precedent: Ollama-optional, `API_KEY_VOYAGE`-gated reranker).
+
+**No install-specific values in code.** IPs, hostnames, usernames, absolute
+`/home/<user>` paths, GitHub slugs, timezones: these belong in generated
+local config (`~/.genesis/config/genesis.yaml`, written by
+`setup-local-config.sh`) or config overlays — never in committed code,
+defaults, or tests. Resolve repo paths via `genesis.env.repo_root()` /
+`genesis_db_path()` (GENESIS_REPO_ROOT-aware); resolve GitHub slugs LIVE
+(`gh repo view --json nameWithOwner`) — a configured slug can name a
+real-but-wrong repo and return plausible stale data. Shipped config defaults
+must work on a fresh install with ZERO overlay.
+
+**Deploy-path answer required — "how does this reach other installs?"**
+Every PR must have an answer for both an EXISTING install and a FRESH clone.
+Merged-but-undeployable-elsewhere is a bug. The standard paths:
+
+| Change type | Deploy path |
+|---|---|
+| Runtime code | `git pull` + server restart (update.sh does both) |
+| DB schema | additive idempotent migration — applies at restart |
+| One-off data fix / backfill | data-migration framework (post-boot, idempotent) — NEVER a hand-run script only this install executed |
+| Config default | repo config file (+ optional local overlay); works with no overlay |
+| systemd unit / timer | registered in bootstrap.sh AND the update path — never hand-`systemctl enable`d only here |
+| Hooks / MCP servers | land at next CC session start (note the mid-window in the PR) |
+| Guardian / host VM | `update.sh` redeploy (Host-Deploy Gate below) |
+
+**When a change CANNOT deploy through the standard paths** (one-time host
+action: packages, sudoers, cgroup settings, firmware), it must ship one of:
+(a) a gated self-heal that reconciles on a recurring tick (precedent: the
+guardian's swap reconcile — checks every tick, repairs config + live state,
+opt-out flag), or (b) an explicit, documented operator step in CHANGELOG +
+install docs. Silent "works here because I hand-fixed it" divergence is the
+failure mode this gate exists to kill — it bites hardest on guardian/host
+changes.
+
 ## Host-Deploy Gate (merged ≠ deployed)
 
 A merged PR that touches host-deployed paths is **NOT done at merge**. The
@@ -372,6 +426,14 @@ outlives its incident is a bug.
    findings"** — a clean PR returns `[]`. The merge-gate hook only blocks
    ERROR/[P1]/HARD BLOCK, so unread P2s pass silently (2026-07-10: 8 real
    P2s on the entity-layer PRs were merged past this exact way).
+8. **A CONFLICTING PR silently suppresses the whole CI suite.** When a PR
+   has a merge conflict with main, GitHub cannot build the merge ref, so
+   `pull_request`-triggered workflows (the entire ci.yml suite) never run —
+   while CodeQL still passes on the head SHA, making the check list LOOK
+   green. A thin check list (only Analyze/CodeQL) means CHECK
+   `gh pr view N --json mergeable` — `CONFLICTING` needs a rebase before any
+   CI verdict exists at all (2026-07-16: #1089 sat conflict-suppressed
+   through three pushes; main had moved under it via concurrent sessions).
 
 ## Reference Router
 

--- a/.gitnexusrc
+++ b/.gitnexusrc
@@ -1,0 +1,4 @@
+{
+  "skipAgentsMd": true,
+  "skipSkills": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,30 @@
-<!-- gitnexus:start -->
-# GitNexus — Code Intelligence
+# Agent Instructions
 
-This project is indexed by GitNexus as **GENesis-AGI** (44298 symbols, 71386 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+Cross-tool agent entry point (Codex, Cursor, OpenCode, …). The canonical
+project instructions live in **CLAUDE.md** — read it first; everything below
+is supplementary.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+## GitNexus — Code Intelligence (advisory)
 
-## Always Do
+This repo is indexed by GitNexus. The MCP tools (`impact`, `query`,
+`context`, `explain`, `trace`, `detect_changes`) give call-graph, blast-radius,
+and execution-flow answers that grep can't. Use them when they fit the
+question — **none is a mandatory pre-edit gate** (see CLAUDE.md → Code
+Intelligence for the tool-selection matrix; Serena is the live-symbol
+default, GitNexus is snapshot-based so run `node .gitnexus/run.cjs analyze`
+first when freshness matters).
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
-- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+Useful entry points:
 
-## Never Do
+| Tool/Resource | Use for |
+|---|---|
+| `impact({target, direction: "upstream"})` | multi-hop blast radius before large refactors |
+| `query({search_query})` | find execution flows by concept |
+| `context({name})` | callers/callees/flows for one symbol |
+| `detect_changes({scope: "compare", base_ref: "main"})` | regression-scope check on a branch |
+| `gitnexus://repo/GENesis-AGI/processes` | all indexed execution flows |
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
-- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Resources
-
-| Resource | Use for |
-|----------|---------|
-| `gitnexus://repo/GENesis-AGI/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/GENesis-AGI/clusters` | All functional areas |
-| `gitnexus://repo/GENesis-AGI/processes` | All execution flows |
-| `gitnexus://repo/GENesis-AGI/process/{name}` | Step-by-step execution trace |
-
-## CLI
-
-| Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
-
-<!-- gitnexus:end -->
+GitNexus doc/skill injection is disabled at the source via the committed
+`.gitnexusrc` (`skipAgentsMd` + `skipSkills`) — this file is hand-curated;
+`surplus/jobs/gitnexus.py` strips any marker block an rc-unaware GitNexus
+version re-injects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   outreach record exactly like a quote-reply, so Genesis's picture of what
   you actually respond to stops being systematically wrong.
 
+- **GitNexus stops rewriting your instruction files.** Every reindex used to
+  inject a block of "MUST run impact analysis before every edit"-style
+  mandates into CLAUDE.md and AGENTS.md (contradicting the project's own
+  advisory-tools principle) and regenerate its skill files, leaving the
+  working tree dirty enough to block deploy pulls. Injection is now disabled
+  at the source via a committed `.gitnexusrc` (`skipAgentsMd` + `skipSkills`)
+  that reaches every install with a plain pull; AGENTS.md is hand-curated
+  (useful GitNexus pointers kept, mandates gone), and the hourly strip job
+  stays as a safety net for rc-unaware GitNexus versions — now covering both
+  files.
+
 - **Genesis resumes learning about you.** The stream of "user model deltas" —
   the small observations reflections make about your preferences, constraints,
   and working style — had been effectively dead since the v3 release: the

--- a/src/genesis/surplus/jobs/gitnexus.py
+++ b/src/genesis/surplus/jobs/gitnexus.py
@@ -21,9 +21,15 @@ logger = logging.getLogger(__name__)
 
 
 # `gitnexus analyze` injects a `<!-- gitnexus:start --> … <!-- gitnexus:end -->`
-# block into BOTH CLAUDE.md and AGENTS.md, with no per-file flag. We keep it in
-# AGENTS.md (read by cross-tool agents — Codex/Cursor/etc.) but strip it from
-# CLAUDE.md so Claude Code's instructions file stays clean.
+# block into BOTH CLAUDE.md and AGENTS.md. PRIMARY control is now the
+# committed `.gitnexusrc` (`skipAgentsMd` + `skipSkills`), which stops the
+# injection at the source for EVERY analyze path (scheduled runner, MCP
+# staleness reindex) on every install via plain git pull. This job is the
+# SAFETY NET for rc-unaware GitNexus versions: it strips marker blocks from
+# both files. AGENTS.md is hand-curated (markerless GitNexus section, no
+# behavioral mandates — the injected "MUST run impact analysis" rules
+# contradict the project's no-mandatory-pre-edit-gate principle), so a
+# stripped re-injection never removes curated content.
 _GITNEXUS_BLOCK_RE = re.compile(
     r"\n*<!-- gitnexus:start -->.*?<!-- gitnexus:end -->[^\n]*\n?",
     re.DOTALL,
@@ -58,6 +64,7 @@ async def run_gitnexus_reindex() -> None:
     """
     try:
         from genesis.runtime import GenesisRuntime
+
         if GenesisRuntime.instance().paused:
             logger.debug("GitNexus reindex request skipped (Genesis paused)")
             return
@@ -92,23 +99,26 @@ async def run_gitnexus_reindex() -> None:
         logger.exception("GitNexus reindex request failed")
         with contextlib.suppress(Exception):
             GenesisRuntime.instance().record_job_failure(
-                "gitnexus_reindex", str(exc),
+                "gitnexus_reindex",
+                str(exc),
             )
 
 
 async def run_gitnexus_strip() -> None:
-    """Strip GitNexus's auto-injected block from CLAUDE.md (hourly + on startup).
+    """Strip GitNexus marker blocks from CLAUDE.md AND AGENTS.md (hourly + startup).
 
-    ``gitnexus analyze`` re-injects the block into CLAUDE.md on EVERY reindex,
-    including the out-of-band staleness reindex run by GitNexus's own MCP
-    server — which never triggers ``run_gitnexus_reindex``'s post-strip. This
-    decoupled job keeps CLAUDE.md clean regardless of what reindexed; AGENTS.md
-    intentionally keeps the block (read by cross-tool agents). Idempotent no-op
-    when the block is absent.
+    Safety net behind the committed ``.gitnexusrc`` (``skipAgentsMd`` +
+    ``skipSkills``), which disables the injection at the source for every
+    analyze path — including the out-of-band staleness reindex run by
+    GitNexus's own MCP server. An rc-unaware GitNexus version that injects
+    anyway gets cleaned here within the hour; AGENTS.md's curated GitNexus
+    section carries no markers, so stripping never touches it. Idempotent
+    no-op when no marker block is present.
     """
     try:
-        if _strip_gitnexus_block(Path.home() / "genesis" / "CLAUDE.md"):
-            logger.info("Stripped GitNexus block from CLAUDE.md (kept in AGENTS.md)")
+        for name in ("CLAUDE.md", "AGENTS.md"):
+            if _strip_gitnexus_block(Path.home() / "genesis" / name):
+                logger.info("Stripped GitNexus marker block from %s", name)
         record_success("gitnexus_strip")
     except Exception as exc:
         logger.warning("GitNexus strip failed", exc_info=True)

--- a/tests/test_surplus/test_gitnexus_strip.py
+++ b/tests/test_surplus/test_gitnexus_strip.py
@@ -55,3 +55,35 @@ def test_idempotent(tmp_path: Path) -> None:
 
 def test_missing_file_returns_false(tmp_path: Path) -> None:
     assert _strip_gitnexus_block(tmp_path / "nope.md") is False
+
+
+def test_curated_agents_md_survives_strip(tmp_path: Path) -> None:
+    """AGENTS.md is hand-curated with a MARKERLESS GitNexus section; the
+    safety-net strip removes only a re-injected marker block, never the
+    curated content. Also locks the shipped file's markerless invariant."""
+    curated = (
+        "# Agent Instructions\n\n"
+        "## GitNexus — Code Intelligence (advisory)\n\n"
+        "none is a mandatory pre-edit gate\n"
+    )
+    f = tmp_path / "AGENTS.md"
+    f.write_text(curated + "\n" + _BLOCK)  # rc-unaware version re-injected
+    assert _strip_gitnexus_block(f) is True
+    out = f.read_text()
+    assert "gitnexus:start" not in out
+    assert "mandatory pre-edit gate" in out  # curated section intact
+
+
+def test_shipped_agents_md_and_rc_invariants() -> None:
+    """The committed AGENTS.md must stay markerless (else the strip job would
+    eat curated content) and free of MUST-mandates; .gitnexusrc must keep the
+    at-the-source skips enabled."""
+    import json
+
+    repo = Path(__file__).resolve().parents[2]
+    agents = (repo / "AGENTS.md").read_text()
+    assert "gitnexus:start" not in agents
+    assert "MUST run impact analysis" not in agents
+    rc = json.loads((repo / ".gitnexusrc").read_text())
+    assert rc.get("skipAgentsMd") is True
+    assert rc.get("skipSkills") is True

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -28,8 +28,11 @@ def _make_scheduler(db, *, idle=True, lmstudio_up=False):
         idle_detector.mark_active()
     compute = ComputeAvailability(lmstudio_url="http://fake:1234/v1/models")
     return SurplusScheduler(
-        db=db, queue=SurplusQueue(db), idle_detector=idle_detector,
-        compute_availability=compute, executor=StubExecutor(),
+        db=db,
+        queue=SurplusQueue(db),
+        idle_detector=idle_detector,
+        compute_availability=compute,
+        executor=StubExecutor(),
     ), compute
 
 
@@ -44,6 +47,7 @@ async def test_restart_safe_hourly_returns_crontrigger_not_interval():
 async def test_restart_safe_hourly_subdaily_is_stepped_and_daily_differs():
     """4h -> every-4-hours step; >=24h -> a single daily fire (the _recently_completed
     cooldown is the real cadence gate). Assert on trigger fields, not the __str__ repr."""
+
     def _field(trig, name):
         return next(str(f) for f in trig.fields if f.name == name)
 
@@ -72,8 +76,10 @@ async def test_long_interval_jobs_use_restart_safe_crontriggers(db):
         sched._scheduler.shutdown(wait=False)
 
 
-async def test_run_gitnexus_strip_cleans_claude_md(db, tmp_path, monkeypatch):
-    """run_gitnexus_strip removes the GitNexus block from CLAUDE.md, not AGENTS.md."""
+async def test_run_gitnexus_strip_cleans_both_files(db, tmp_path, monkeypatch):
+    """run_gitnexus_strip removes marker blocks from CLAUDE.md AND AGENTS.md
+    (safety net behind .gitnexusrc; AGENTS.md is hand-curated markerless, so
+    only a re-injected block is ever removed)."""
     from pathlib import Path as _P
 
     sched, _ = _make_scheduler(db)  # build before patching Path.home
@@ -90,7 +96,9 @@ async def test_run_gitnexus_strip_cleans_claude_md(db, tmp_path, monkeypatch):
     claude = (genesis_dir / "CLAUDE.md").read_text()
     assert "gitnexus:start" not in claude, "block stripped from CLAUDE.md"
     assert "# Real instructions" in claude, "real content preserved"
-    assert "gitnexus:start" in (genesis_dir / "AGENTS.md").read_text(), "AGENTS.md kept"
+    agents = (genesis_dir / "AGENTS.md").read_text()
+    assert "gitnexus:start" not in agents, "block stripped from AGENTS.md too"
+    assert "# Agents" in agents, "curated content preserved"
 
 
 async def test_dispatch_skips_when_not_idle(db):
@@ -112,8 +120,13 @@ async def test_dispatch_reaps_old_terminal_rows(db):
     sched, compute = _make_scheduler(db, idle=False)  # not idle → returns early after reap
     old = (datetime.now(UTC) - timedelta(days=40)).isoformat()
     await surplus_tasks.create(
-        db, id="ancient", task_type="brainstorm_self", compute_tier="free_api",
-        priority=0.5, drive_alignment="curiosity", created_at=old,
+        db,
+        id="ancient",
+        task_type="brainstorm_self",
+        compute_tier="free_api",
+        priority=0.5,
+        drive_alignment="curiosity",
+        created_at=old,
     )
     await surplus_tasks.mark_completed(db, "ancient", completed_at=old)
     with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
@@ -182,9 +195,7 @@ async def test_dispatch_handles_executor_error(db):
 # Verified-correctness verdict (measurement-only quality judge — producer side)
 # --------------------------------------------------------------------------- #
 async def _completed_verdict(db) -> str | None:
-    cur = await db.execute(
-        "SELECT outcome_quality FROM surplus_tasks WHERE status='completed'"
-    )
+    cur = await db.execute("SELECT outcome_quality FROM surplus_tasks WHERE status='completed'")
     row = await cur.fetchone()
     return row[0]
 
@@ -202,16 +213,28 @@ async def _dispatch_with_judge(db, task_type, judge_return):
     sched, compute = _make_scheduler(db, idle=True)
     await sched._queue.enqueue(task_type, ComputeTier.FREE_API, 0.8, "curiosity")
     benign = IntakeStats(
-        findings_count=1, routed_knowledge=1, routed_observation=0, routed_discard=0,
+        findings_count=1,
+        routed_knowledge=1,
+        routed_observation=0,
+        routed_discard=0,
     )
     judge = AsyncMock(return_value=judge_return)
-    with patch.object(
-        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
-    ), patch(
-        "genesis.surplus.intake.run_intake",
-        new_callable=AsyncMock, return_value=benign,
-    ), patch(
-        "genesis.surplus.quality_judge.run_quality_judge", judge,
+    with (
+        patch.object(
+            compute,
+            "_ping_lmstudio",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "genesis.surplus.intake.run_intake",
+            new_callable=AsyncMock,
+            return_value=benign,
+        ),
+        patch(
+            "genesis.surplus.quality_judge.run_quality_judge",
+            judge,
+        ),
     ):
         assert await sched.dispatch_once() is True
     cur = await db.execute(
@@ -224,7 +247,9 @@ async def _dispatch_with_judge(db, task_type, judge_return):
 async def test_dispatch_records_useful_when_judge_passes(db):
     detail = '{"judge_score": 0.82, "rationale": "solid"}'
     row, judge = await _dispatch_with_judge(
-        db, TaskType.BRAINSTORM_USER, ("useful", 0.82, detail),
+        db,
+        TaskType.BRAINSTORM_USER,
+        ("useful", 0.82, detail),
     )
     assert row["outcome_quality"] == "useful"
     assert row["judge_score"] == 0.82
@@ -234,7 +259,9 @@ async def test_dispatch_records_useful_when_judge_passes(db):
 
 async def test_dispatch_records_hollow_when_judge_fails(db):
     row, _ = await _dispatch_with_judge(
-        db, TaskType.CODE_AUDIT, ("hollow", 0.30, '{"judge_score": 0.30}'),
+        db,
+        TaskType.CODE_AUDIT,
+        ("hollow", 0.30, '{"judge_score": 0.30}'),
     )
     assert row["outcome_quality"] == "hollow"
     assert row["judge_score"] == 0.30
@@ -243,7 +270,9 @@ async def test_dispatch_records_hollow_when_judge_fails(db):
 async def test_dispatch_judge_outage_stays_null(db):
     # Judge unavailable → (None, None, None) → positive-only, no false hollow.
     row, _ = await _dispatch_with_judge(
-        db, TaskType.WING_AUDIT, (None, None, None),
+        db,
+        TaskType.WING_AUDIT,
+        (None, None, None),
     )
     assert row["outcome_quality"] is None
     assert row["judge_score"] is None
@@ -258,22 +287,33 @@ async def test_code_audit_skips_generic_intake(db):
 
     sched, compute = _make_scheduler(db, idle=True)
     await sched._queue.enqueue(
-        TaskType.CODE_AUDIT, ComputeTier.FREE_API, 0.8, "curiosity",
+        TaskType.CODE_AUDIT,
+        ComputeTier.FREE_API,
+        0.8,
+        "curiosity",
     )
     intake_mock = AsyncMock(return_value=IntakeStats(findings_count=1))
-    with patch.object(
-        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
-    ), patch(
-        "genesis.surplus.intake.run_intake", intake_mock,
-    ), patch(
-        "genesis.surplus.quality_judge.run_quality_judge",
-        new_callable=AsyncMock, return_value=(None, None, None),
+    with (
+        patch.object(
+            compute,
+            "_ping_lmstudio",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "genesis.surplus.intake.run_intake",
+            intake_mock,
+        ),
+        patch(
+            "genesis.surplus.quality_judge.run_quality_judge",
+            new_callable=AsyncMock,
+            return_value=(None, None, None),
+        ),
     ):
         assert await sched.dispatch_once() is True
     intake_mock.assert_not_awaited()
     cur = await db.execute(
-        "SELECT status, result_staging_id FROM surplus_tasks "
-        "WHERE status='completed'"
+        "SELECT status, result_staging_id FROM surplus_tasks WHERE status='completed'"
     )
     row = await cur.fetchone()
     assert row is not None
@@ -283,7 +323,9 @@ async def test_code_audit_skips_generic_intake(db):
 async def test_dispatch_non_insight_type_skips_judge(db):
     # An action / non-insight type must NOT invoke the judge (cost) and stays NULL.
     row, judge = await _dispatch_with_judge(
-        db, TaskType.CODE_INDEX, ("hollow", 0.1, "{}"),
+        db,
+        TaskType.CODE_INDEX,
+        ("hollow", 0.1, "{}"),
     )
     assert row["outcome_quality"] is None
     judge.assert_not_awaited()
@@ -292,7 +334,9 @@ async def test_dispatch_non_insight_type_skips_judge(db):
 async def test_dispatch_pipeline_intermediate_skips_judge(db):
     # Pipeline-intermediate output feeds the next step, not the KB; excluded.
     row, judge = await _dispatch_with_judge(
-        db, TaskType.RESEARCH_QUERY_GEN, ("hollow", 0.1, "{}"),
+        db,
+        TaskType.RESEARCH_QUERY_GEN,
+        ("hollow", 0.1, "{}"),
     )
     assert row["outcome_quality"] is None
     judge.assert_not_awaited()
@@ -305,7 +349,10 @@ async def test_dispatch_short_content_skips_judge(db):
 
     sched, compute = _make_scheduler(db, idle=True)
     await sched._queue.enqueue(
-        TaskType.BRAINSTORM_USER, ComputeTier.FREE_API, 0.8, "curiosity",
+        TaskType.BRAINSTORM_USER,
+        ComputeTier.FREE_API,
+        0.8,
+        "curiosity",
     )
 
     async def _short(task):
@@ -317,9 +364,15 @@ async def test_dispatch_short_content_skips_judge(db):
 
     sched._executor.execute = _short
     judge = AsyncMock(return_value=("hollow", 0.1, "{}"))
-    with patch.object(
-        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
-    ), patch("genesis.surplus.quality_judge.run_quality_judge", judge):
+    with (
+        patch.object(
+            compute,
+            "_ping_lmstudio",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch("genesis.surplus.quality_judge.run_quality_judge", judge),
+    ):
         await sched.dispatch_once()
     judge.assert_not_awaited()
     assert await _completed_verdict(db) is None
@@ -332,7 +385,10 @@ async def test_dispatch_empty_insights_stays_null(db):
 
     sched, compute = _make_scheduler(db, idle=True)
     await sched._queue.enqueue(
-        TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API, 0.8, "curiosity",
+        TaskType.BRAINSTORM_SELF,
+        ComputeTier.FREE_API,
+        0.8,
+        "curiosity",
     )
 
     async def _nominal(task):
@@ -344,7 +400,10 @@ async def test_dispatch_empty_insights_stays_null(db):
 
     sched._executor.execute = _nominal
     with patch.object(
-        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
+        compute,
+        "_ping_lmstudio",
+        new_callable=AsyncMock,
+        return_value=False,
     ):
         await sched.dispatch_once()
     assert await _completed_verdict(db) is None
@@ -360,8 +419,10 @@ async def test_brainstorm_check_schedules_sessions(db):
 
 async def test_start_and_stop(db):
     sched, compute = _make_scheduler(db, idle=True)
-    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False), \
-         patch.object(sched, "run_gitnexus_strip", new_callable=AsyncMock):
+    with (
+        patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False),
+        patch.object(sched, "run_gitnexus_strip", new_callable=AsyncMock),
+    ):
         await sched.start()
     assert sched._scheduler.running is True
     # Verify jobs were registered
@@ -419,12 +480,15 @@ async def test_dispatch_drains_expired_tasks(db):
     with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
         await sched.dispatch_once()
     # Expired task should be drained
-    cursor = await db.execute("SELECT COUNT(*) FROM surplus_tasks WHERE id = 'old-task-1' AND status = 'pending'")
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM surplus_tasks WHERE id = 'old-task-1' AND status = 'pending'"
+    )
     row = await cursor.fetchone()
     assert row[0] == 0
 
 
 # ── DB integrity check (C1) ─────────────────────────────────────────────
+
 
 async def test_alarm_db_integrity_writes_observation_and_emits(db):
     """Corruption detail is persisted as a critical observation AND emitted."""
@@ -457,9 +521,7 @@ async def test_run_db_integrity_check_healthy_db_no_alarm(db):
     await sched.run_db_integrity_check()
 
     sched._event_bus.emit.assert_not_called()
-    cur = await db.execute(
-        "SELECT COUNT(*) FROM observations WHERE type = 'db_integrity_failure'"
-    )
+    cur = await db.execute("SELECT COUNT(*) FROM observations WHERE type = 'db_integrity_failure'")
     assert (await cur.fetchone())[0] == 0
 
 
@@ -482,6 +544,7 @@ async def test_start_registers_db_integrity_check(db):
 def _fake_runtime(db):
     """Runtime stand-in for the drain wrapper: healthy deps, no flags set."""
     from unittest.mock import MagicMock
+
     rt = MagicMock()
     rt.paused = False
     rt.heavy_workload = None  # MagicMock auto-attrs are truthy — must be explicit
@@ -495,8 +558,12 @@ def _fake_runtime(db):
 
 
 _DRAIN_REPORT = {
-    "run_id": "t", "dry_run": True, "drained": 2, "would_merge": 2,
-    "stale_skipped": 0, "errors": [],
+    "run_id": "t",
+    "dry_run": True,
+    "drained": 2,
+    "would_merge": 2,
+    "stale_skipped": 0,
+    "errors": [],
 }
 _RT_CLS = "genesis.runtime.GenesisRuntime"
 _DRAIN_FN = "genesis.memory.dream_cycle.run_synthesis_drain"
@@ -507,8 +574,10 @@ async def test_drain_wrapper_happy_path_shadow(db):
     observation, and clears its own heavy_workload flag."""
     sched, _ = _make_scheduler(db)
     rt = _fake_runtime(db)
-    with patch(_RT_CLS) as rt_cls, \
-         patch(_DRAIN_FN, new_callable=AsyncMock, return_value=dict(_DRAIN_REPORT)) as drain:
+    with (
+        patch(_RT_CLS) as rt_cls,
+        patch(_DRAIN_FN, new_callable=AsyncMock, return_value=dict(_DRAIN_REPORT)) as drain,
+    ):
         rt_cls.instance.return_value = rt
         await sched.run_dream_synthesis_drain()
 
@@ -531,8 +600,7 @@ async def test_drain_wrapper_paused_skips(db):
     sched, _ = _make_scheduler(db)
     rt = _fake_runtime(db)
     rt.paused = True
-    with patch(_RT_CLS) as rt_cls, \
-         patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
+    with patch(_RT_CLS) as rt_cls, patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
         rt_cls.instance.return_value = rt
         await sched.run_dream_synthesis_drain()
     drain.assert_not_awaited()
@@ -545,8 +613,7 @@ async def test_drain_wrapper_heavy_workload_skips(db):
     rt = _fake_runtime(db)
     rt.heavy_workload = "dream_cycle"
     rt._heavy_workload = "dream_cycle"
-    with patch(_RT_CLS) as rt_cls, \
-         patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
+    with patch(_RT_CLS) as rt_cls, patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
         rt_cls.instance.return_value = rt
         await sched.run_dream_synthesis_drain()
     drain.assert_not_awaited()
@@ -561,8 +628,7 @@ async def test_drain_wrapper_missing_deps_skip_before_job_start(db):
     sched, _ = _make_scheduler(db)
     rt = _fake_runtime(db)
     rt.db = None
-    with patch(_RT_CLS) as rt_cls, \
-         patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
+    with patch(_RT_CLS) as rt_cls, patch(_DRAIN_FN, new_callable=AsyncMock) as drain:
         rt_cls.instance.return_value = rt
         await sched.run_dream_synthesis_drain()
     drain.assert_not_awaited()
@@ -572,8 +638,10 @@ async def test_drain_wrapper_missing_deps_skip_before_job_start(db):
 async def test_drain_wrapper_failure_records_and_clears_flag(db):
     sched, _ = _make_scheduler(db)
     rt = _fake_runtime(db)
-    with patch(_RT_CLS) as rt_cls, \
-         patch(_DRAIN_FN, new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+    with (
+        patch(_RT_CLS) as rt_cls,
+        patch(_DRAIN_FN, new_callable=AsyncMock, side_effect=RuntimeError("boom")),
+    ):
         rt_cls.instance.return_value = rt
         await sched.run_dream_synthesis_drain()
     rt.record_job_failure.assert_called_once()
@@ -591,8 +659,10 @@ async def test_drain_wrapper_finally_is_owner_guarded(db):
         rt._heavy_workload = "dream_cycle"  # weekly job took the flag
         return dict(_DRAIN_REPORT)
 
-    with patch(_RT_CLS) as rt_cls, \
-         patch(_DRAIN_FN, new_callable=AsyncMock, side_effect=_drain_then_flag_stolen):
+    with (
+        patch(_RT_CLS) as rt_cls,
+        patch(_DRAIN_FN, new_callable=AsyncMock, side_effect=_drain_then_flag_stolen),
+    ):
         rt_cls.instance.return_value = rt
         await sched.run_dream_synthesis_drain()
     assert rt._heavy_workload == "dream_cycle"  # not clobbered
@@ -604,14 +674,21 @@ async def test_start_reclaims_orphaned_running_tasks_immediately(db):
     (Single-worker: nothing can legitimately be running before start().)"""
     recent = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
     await surplus_tasks.create(
-        db, id="st-orphan", task_type="brainstorm", compute_tier="slm",
-        priority=0.5, drive_alignment="curiosity", created_at="2026-03-04T00:00:00Z",
+        db,
+        id="st-orphan",
+        task_type="brainstorm",
+        compute_tier="slm",
+        priority=0.5,
+        drive_alignment="curiosity",
+        created_at="2026-03-04T00:00:00Z",
     )
     await surplus_tasks.mark_running(db, "st-orphan", started_at=recent)
 
     sched, compute = _make_scheduler(db, idle=True)
-    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False), \
-         patch.object(sched, "run_gitnexus_strip", new_callable=AsyncMock):
+    with (
+        patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False),
+        patch.object(sched, "run_gitnexus_strip", new_callable=AsyncMock),
+    ):
         await sched.start()
     try:
         row = await surplus_tasks.get_by_id(db, "st-orphan")


### PR DESCRIPTION
## What

Two standing-directive items:

**1. GitNexus doc-injection, fixed at the source.** Every `gitnexus analyze` (including the MCP server's own staleness reindexes) injected a mandate block into CLAUDE.md/AGENTS.md and regenerated skill files — the mandates ("MUST run impact analysis before editing any symbol") contradict the project's advisory-tools principle, Codex ingests AGENTS.md when reviewing, and the resulting dirty tree blocked a deploy pull this week. GitNexus ships first-class support for exactly this: a repo-committed `.gitnexusrc` with `skipAgentsMd` + `skipSkills` — validated live on a throwaway repo (without rc: both files injected; with rc: nothing). Because it's committed, it deploys to every install via plain `git pull`.

- AGENTS.md is now hand-curated: useful GitNexus entry points kept (advisory framing, pointer table), mandates gone, markerless.
- The hourly `run_gitnexus_strip` surplus job stays as the safety net for rc-unaware GitNexus versions, now stripping marker blocks from BOTH files (a re-injection can never eat the markerless curated section).
- Invariant tests lock the rc keys and the markerless/mandate-free AGENTS.md so drift fails CI.

**2. genesis-development skill — Generalizability Gate.** New section codifying the any-install directive: hardware/scale adaptivity (percentage/derived caps, loud truncation, optional-dep degradation), no install-specific values in committed code (generated config + `repo_root()`/live slug resolution), and a required deploy-path answer per change type — with the rule that a change the update script cannot carry must ship a gated self-heal (swap-reconcile precedent) or a documented operator step. Plus Pre-Merge Gate item 8: a CONFLICTING PR silently suppresses the whole ci.yml suite while CodeQL still passes on the head SHA (bit #1089 today).

## Tests

46 green across the surplus suites; new invariant tests (`test_curated_agents_md_survives_strip`, `test_shipped_agents_md_and_rc_invariants`); scheduler strip test updated to the both-files contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)