### PR TITLE
feat(ego): origin-aware goal surfaces + ego-cycle side-door closure (PR-3a)

### DIFF
--- a/src/genesis/db/crud/user_goals.py
+++ b/src/genesis/db/crud/user_goals.py
@@ -86,11 +86,26 @@ async def list_active(
     db: aiosqlite.Connection,
     *,
     limit: int = 20,
+    origin: str | None = None,
 ) -> list[dict]:
-    """List active goals ordered by priority (critical first)."""
+    """List active goals ordered by priority (critical first).
+
+    ``origin`` filters by provenance ('user' | 'genesis_ego'). User-facing
+    surfaces (user-ego context, morning report, dispatch prompts, world
+    snapshot) pass ``origin="user"`` so ego-owned goals never render as user
+    directives; ``None`` keeps the unfiltered view for provenance-aware
+    callers.
+    """
+    params: list[object] = []
+    origin_clause = ""
+    if origin is not None:
+        origin_clause = "AND origin = ? "
+        params.append(origin)
+    params.append(limit)
     cursor = await db.execute(
-        """SELECT * FROM user_goals
+        f"""SELECT * FROM user_goals
            WHERE status = 'active'
+           {origin_clause}
            ORDER BY
              CASE priority
                WHEN 'critical' THEN 0
@@ -99,10 +114,30 @@ async def list_active(
                WHEN 'low' THEN 3
              END,
              created_at DESC
-           LIMIT ?""",
-        (limit,),
+           LIMIT ?""",  # noqa: S608 — clause is a fixed literal, values bound
+        params,
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def count_by_status(
+    db: aiosqlite.Connection,
+    *,
+    origin: str | None = None,
+) -> dict[str, int]:
+    """Count goals grouped by status, optionally filtered by provenance.
+
+    Unbounded (no LIMIT) — the cap check for autonomous ego-goal creation
+    uses this, so it must never silently truncate.
+    """
+    if origin is not None:
+        cursor = await db.execute(
+            "SELECT status, COUNT(*) FROM user_goals WHERE origin = ? GROUP BY status",
+            (origin,),
+        )
+    else:
+        cursor = await db.execute("SELECT status, COUNT(*) FROM user_goals GROUP BY status")
+    return {r[0]: r[1] for r in await cursor.fetchall()}
 
 
 async def list_by_category(
@@ -113,8 +148,7 @@ async def list_by_category(
 ) -> list[dict]:
     """List goals by category."""
     cursor = await db.execute(
-        "SELECT * FROM user_goals WHERE category = ? "
-        "ORDER BY created_at DESC LIMIT ?",
+        "SELECT * FROM user_goals WHERE category = ? ORDER BY created_at DESC LIMIT ?",
         (category, limit),
     )
     return [dict(r) for r in await cursor.fetchall()]
@@ -125,9 +159,7 @@ async def get_by_id(
     goal_id: str,
 ) -> dict | None:
     """Get a single goal by ID."""
-    cursor = await db.execute(
-        "SELECT * FROM user_goals WHERE id = ?", (goal_id,)
-    )
+    cursor = await db.execute("SELECT * FROM user_goals WHERE id = ?", (goal_id,))
     row = await cursor.fetchone()
     return dict(row) if row else None
 
@@ -162,10 +194,12 @@ async def add_progress_note(
         notes = json.loads(goal.get("progress_notes") or "[]")
     except (json.JSONDecodeError, TypeError):
         notes = []
-    notes.append({
-        "date": datetime.now(UTC).isoformat()[:10],
-        "note": note,
-    })
+    notes.append(
+        {
+            "date": datetime.now(UTC).isoformat()[:10],
+            "note": note,
+        }
+    )
     now = datetime.now(UTC).isoformat()
     cursor = await db.execute(
         "UPDATE user_goals SET progress_notes = ?, updated_at = ? WHERE id = ?",
@@ -180,12 +214,33 @@ async def find_similar(
     title: str,
     *,
     threshold: float = 0.6,
+    statuses: tuple[str, ...] = ("active",),
+    origin: str | None = None,
 ) -> dict | None:
     """Find an existing goal with a similar title (simple word overlap).
 
     Returns the best match above the threshold, or None.
+
+    ``statuses`` scopes the search (default preserves the original
+    active-only behavior). The autonomous ego-goal creation path passes
+    ``("active", "paused")`` so pausing a goal doesn't reopen the door to
+    recreating it; achieved/abandoned are deliberately never matched — a
+    finished title stays re-openable. ``origin`` scopes by provenance
+    (the extraction path passes "user" so conversation-derived signals
+    never reinforce ego-owned goals).
     """
-    goals = await list_active(db, limit=50)
+    placeholders = ", ".join("?" for _ in statuses)
+    params: list[object] = list(statuses)
+    origin_clause = ""
+    if origin is not None:
+        origin_clause = "AND origin = ? "
+        params.append(origin)
+    cursor = await db.execute(
+        f"SELECT * FROM user_goals WHERE status IN ({placeholders}) "  # noqa: S608
+        f"{origin_clause}ORDER BY created_at DESC LIMIT 50",
+        params,
+    )
+    goals = [dict(r) for r in await cursor.fetchall()]
     if not goals:
         return None
 
@@ -271,9 +326,7 @@ async def check_completion_cascade(
     if not children:
         return None
 
-    live_children = [
-        c for c in children if c.get("status") != "abandoned"
-    ]
+    live_children = [c for c in children if c.get("status") != "abandoned"]
     if not live_children:
         return None
 

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -197,8 +197,11 @@ class EgoCadenceManager:
             misfire_grace_time=60,
         )
         # Goal staleness scanner: push goal_review signals for stale goals.
-        # User ego only — genesis ego has no goal jurisdiction. Skipped at
-        # runtime via source_tag check but also gate registration for clarity.
+        # User ego only — USER goals are user-ego jurisdiction. (The genesis
+        # ego reviews its own origin='genesis_ego' goals through a separate
+        # path: an own-goals context section + parsed output keys, never this
+        # scanner.) Skipped at runtime via source_tag check but also gate
+        # registration for clarity.
         if self._session._source_tag == "user_ego_cycle":
             self._scheduler.add_job(
                 self._check_stale_goals,
@@ -404,9 +407,11 @@ class EgoCadenceManager:
         """Push goal_review signals for goals stale beyond threshold.
 
         Queries user_goals.updated_at and pushes one signal per stale goal.
-        Only meaningful for the user ego — the genesis ego has no goal
-        jurisdiction.  Registration is gated in start() but we double-check
-        source_tag here as defense-in-depth.
+        User ego only, USER goals only (origin='user') — ego-owned goals are
+        reviewed by the genesis ego's own path, and a user-ego review of an
+        ego goal would surface approval proposals for internal ops goals.
+        Registration is gated in start() but we double-check source_tag here
+        as defense-in-depth.
         """
         if self._session._source_tag != "user_ego_cycle":
             return
@@ -418,7 +423,9 @@ class EgoCadenceManager:
             from genesis.db.crud import user_goals
             from genesis.ego.types import GOAL_STUCK_EXECUTED_THRESHOLD
 
-            goals = await user_goals.list_active(self._session._db)
+            goals = await user_goals.list_active(
+                self._session._db, origin="user",
+            )
             if not goals:
                 return
 

--- a/src/genesis/ego/computed_focus.py
+++ b/src/genesis/ego/computed_focus.py
@@ -71,7 +71,7 @@ async def compute_focus_summary(
         if "genesis" not in ego_key:
             from genesis.db.crud import user_goals
 
-            goals = await user_goals.list_active(db, limit=5)
+            goals = await user_goals.list_active(db, limit=5, origin="user")
             if goals:
                 titles = [g.get("title", "")[:40] for g in goals[:3]]
                 suffix = f" (+{len(goals) - 3} more)" if len(goals) > 3 else ""

--- a/src/genesis/ego/goal_actions.py
+++ b/src/genesis/ego/goal_actions.py
@@ -38,6 +38,17 @@ GOAL_STATUS_CHANGE_ACTION_TYPE = "goal_status_change"
 _VALID_STATUS = frozenset({"paused"})
 _VALID_PRIORITY = frozenset({"low", "medium", "high", "critical"})
 
+# Shared goal-field validation sets — single source of truth for BOTH the MCP
+# tool surface (mcp/health/ego_tools.py imports these) and the ego session's
+# own-goal creation path. They mirror the user_goals CHECK constraints in
+# db/schema/_tables.py; change them together. Import direction is always INTO
+# the MCP layer — the runtime ego must never import MCP server modules.
+VALID_GOAL_CATEGORIES = frozenset(
+    {"career", "project", "learning", "relationship", "financial", "other"}
+)
+VALID_GOAL_PRIORITIES = _VALID_PRIORITY
+VALID_GOAL_TYPES = frozenset({"milestone", "continuous"})
+
 
 def _parse_expected_outputs(expected_outputs: object) -> dict | None:
     """Extract the ``{change, value}`` spec from a proposal's expected_outputs.

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -83,6 +83,17 @@ _NEVER_DISPATCH_ACTION_TYPES = (
     "gauntlet_regression",
 )
 
+# MCP tools the ego CYCLE session must never call directly. In-cycle goal
+# mutation goes through the parsed-output path (source_tag-gated, validated,
+# audited) — never the foreground goal tools: ego_goal_create stamps
+# origin='user' (masquerading as a user directive) and ego_goal_update can
+# mutate ANY goal with no approval gate. Foreground CC sessions keep both
+# (user-authorized surface). Read-only goal tools stay available.
+_EGO_CYCLE_DISALLOWED_TOOLS = (
+    "mcp__genesis-health__ego_goal_create",
+    "mcp__genesis-health__ego_goal_update",
+)
+
 
 class CycleBlockedError(Exception):
     """Raised when the ego cycle is blocked by an approval gate.
@@ -313,6 +324,7 @@ class EgoSession:
             skip_permissions=True,
             working_dir=background_session_dir(),
             mcp_config=self._mcp_config_path,
+            disallowed_tools=list(_EGO_CYCLE_DISALLOWED_TOOLS),
         )
 
         # Autonomous dispatch check
@@ -534,7 +546,9 @@ class EgoSession:
             await obs_crud.create(
                 self._db,
                 id=str(uuid.uuid4()),
-                source="user_ego",
+                # Provenance: whichever ego cycle produced the review —
+                # hardcoding "user_ego" misattributed genesis-cycle output.
+                source=self._source_tag,
                 type="goal_recommendation",
                 content=content,
                 priority="medium",
@@ -2170,7 +2184,10 @@ class EgoSession:
             try:
                 from genesis.db.crud import user_goals
 
-                goals = await user_goals.list_active(self._db)
+                # origin="user": dispatched-session prompts label these as
+                # the user's goals — ego-authored text must never masquerade
+                # as a user directive downstream (injection surface).
+                goals = await user_goals.list_active(self._db, origin="user")
                 if goals:
                     goal_lines = [
                         f"- {g['title']} ({g['category']}, {g['priority']})" for g in goals[:5]

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -86,12 +86,16 @@ _NEVER_DISPATCH_ACTION_TYPES = (
 # MCP tools the ego CYCLE session must never call directly. In-cycle goal
 # mutation goes through the parsed-output path (source_tag-gated, validated,
 # audited) — never the foreground goal tools: ego_goal_create stamps
-# origin='user' (masquerading as a user directive) and ego_goal_update can
-# mutate ANY goal with no approval gate. Foreground CC sessions keep both
-# (user-authorized surface). Read-only goal tools stay available.
+# origin='user' (masquerading as a user directive), ego_goal_update can
+# mutate ANY goal with no approval gate, and ego_goal_progress writes
+# progress_notes AND refreshes updated_at — silently resetting the user's
+# staleness-review clock (Codex P1, PR #1093). Foreground CC sessions keep
+# all of them (user-authorized surface). Only truly read-only goal tools
+# (ego_goal_list) stay available in-cycle.
 _EGO_CYCLE_DISALLOWED_TOOLS = (
     "mcp__genesis-health__ego_goal_create",
     "mcp__genesis-health__ego_goal_update",
+    "mcp__genesis-health__ego_goal_progress",
 )
 
 

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -267,7 +267,11 @@ class UserEgoContextBuilder:
 
         try:
             from genesis.db.crud import user_goals
-            goals = await user_goals.list_active(self._db, limit=20)
+            # origin="user": ego-owned goals must never render as user
+            # directives in the user ego's world model.
+            goals = await user_goals.list_active(
+                self._db, limit=20, origin="user",
+            )
         except Exception:
             logger.debug("Failed to query user goals", exc_info=True)
             lines.append("*Goal tracking not yet populated.*\n")

--- a/src/genesis/ego/world_snapshot.py
+++ b/src/genesis/ego/world_snapshot.py
@@ -135,7 +135,9 @@ async def build(db: aiosqlite.Connection) -> WorldSnapshot:
     # 1. Active goals
     try:
         from genesis.db.crud import user_goals
-        snapshot.goals = await user_goals.list_active(db, limit=10)
+        # origin="user": the world snapshot feeds user-facing context —
+        # ego-owned goals are not part of the user's world model.
+        snapshot.goals = await user_goals.list_active(db, limit=10, origin="user")
     except Exception:
         logger.debug("Failed to query goals for world snapshot", exc_info=True)
 

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -731,10 +731,14 @@ async def _compute_goal_completion(
     criteria (a ``success_criteria`` column + population wiring) are
     deliberately deferred; until then any non-null rate is unvalidated.
 
+    Scoped to origin='user' — ego-owned (genesis_ego) goals must not
+    contaminate the user-goal eval signal.
+
     Snapshot-only dimension (writes no eval_events).
     """
     cursor = await db.execute(
-        "SELECT status, COUNT(*) FROM user_goals GROUP BY status"
+        "SELECT status, COUNT(*) FROM user_goals "
+        "WHERE origin = 'user' GROUP BY status"
     )
     by_status = {r[0]: r[1] for r in await cursor.fetchall()}
     total_goals = sum(by_status.values())
@@ -744,7 +748,7 @@ async def _compute_goal_completion(
 
     cursor = await db.execute(
         "SELECT COUNT(*) FROM user_goals "
-        "WHERE achieved_at >= ? AND achieved_at < ?",
+        "WHERE origin = 'user' AND achieved_at >= ? AND achieved_at < ?",
         (since, until),
     )
     achieved_in_period = (await cursor.fetchone())[0]

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -11,6 +11,15 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+from genesis.ego.goal_actions import (
+    VALID_GOAL_CATEGORIES as _VALID_GOAL_CATEGORIES,
+)
+from genesis.ego.goal_actions import (
+    VALID_GOAL_PRIORITIES as _VALID_GOAL_PRIORITIES,
+)
+from genesis.ego.goal_actions import (
+    VALID_GOAL_TYPES as _VALID_GOAL_TYPES,
+)
 from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
@@ -18,9 +27,8 @@ logger = logging.getLogger(__name__)
 # Validation sets matching DB CHECK constraints
 _VALID_DIRECTIVE_PRIORITIES = frozenset({"low", "normal", "high", "critical"})
 _VALID_EGO_TARGETS = frozenset({"user_ego", "genesis_ego"})
-_VALID_GOAL_CATEGORIES = frozenset({"career", "project", "learning", "relationship", "financial", "other"})
-_VALID_GOAL_PRIORITIES = frozenset({"low", "medium", "high", "critical"})
-_VALID_GOAL_TYPES = frozenset({"milestone", "continuous"})
+# Goal-field sets now live in genesis.ego.goal_actions (shared with the ego
+# session's own-goal creation path) — imported above.
 
 
 def _get_db_path():
@@ -283,6 +291,9 @@ async def ego_goal_list() -> dict:
                 "category": g.get("category", ""),
                 "priority": g.get("priority", "medium"),
                 "status": g.get("status", "active"),
+                # Provenance display: 'user' vs 'genesis_ego' (ego-owned) —
+                # the user must always be able to tell whose goal is whose.
+                "origin": g.get("origin", "user"),
             }
             for g in goals
         ],

--- a/src/genesis/memory/goal_tracker.py
+++ b/src/genesis/memory/goal_tracker.py
@@ -89,8 +89,10 @@ async def process_extraction(
 
     from genesis.db.crud import user_goals
 
-    # Check for existing similar goal
-    existing = await user_goals.find_similar(db, signal["title"])
+    # Check for existing similar goal. origin="user": a conversation-derived
+    # signal must never reinforce (mutate confidence/notes of) an ego-owned
+    # goal — extraction only ever speaks for the user's lane.
+    existing = await user_goals.find_similar(db, signal["title"], origin="user")
     if existing:
         # Update confidence and add progress note
         new_conf = max(existing["confidence"], signal["confidence"])

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -430,12 +430,30 @@ class MorningReportGenerator:
             for t in topics:
                 lines.append(f"  - {t[:120]}")
 
-        # Active user goals — enables the LLM to note priority alignment/drift
-        goal_rows = await goals_crud.list_active(self._db, limit=10)
+        # Active user goals — enables the LLM to note priority alignment/drift.
+        # origin="user": ego-owned goals are not user goals (counted below).
+        goal_rows = await goals_crud.list_active(self._db, limit=10, origin="user")
         if goal_rows:
             lines.append("- Active user goals:")
             for g in goal_rows:
                 lines.append(f"  - [{g['priority']}] ({g['category']}) {g['title']}")
+
+        # Genesis's own goals (origin='genesis_ego', additive ego autonomy) —
+        # ambient visibility + the paused-tail watch surface. Compact count
+        # only; autonomous actions get their own report lines via the
+        # goal_autonomous_action observation surfacing.
+        try:
+            ego_goal_counts = await goals_crud.count_by_status(
+                self._db, origin="genesis_ego",
+            )
+            n_active = ego_goal_counts.get("active", 0)
+            n_paused = ego_goal_counts.get("paused", 0)
+            if n_active or n_paused:
+                lines.append(
+                    f"- Genesis's own goals: {n_active} active, {n_paused} paused"
+                )
+        except Exception:
+            logger.warning("Failed to count Genesis-ego goals", exc_info=True)
 
         # Inbox items — only report genuinely pending DB items
         pending_inbox = await inbox_crud.count_pending(self._db)

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1266,6 +1266,24 @@ class TestGoalStaleness:
         assert sig.metadata["executed_proposals"] == 1
 
 
+    async def test_genesis_origin_goal_not_scanned(self, goal_cadence, goal_db):
+        """PR-3a: the user-ego scanner reviews USER goals only — a stale
+        origin='genesis_ego' goal must not generate a user-facing goal_review
+        signal (the genesis ego reviews its own lane separately)."""
+        twenty_days_ago = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, origin, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("goal-ego", "Ego Ops Goal", "project", "high", "active",
+             "genesis_ego", twenty_days_ago, twenty_days_ago),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+        assert goal_cadence._signal_queue.empty()
+
+
 class TestJobHealthKeyPerEgo:
     """Each ego records job health under its OWN key, never a shared 'ego_cycle'.
 

--- a/tests/ego/test_computed_focus.py
+++ b/tests/ego/test_computed_focus.py
@@ -37,16 +37,12 @@ async def db():
             user_response TEXT
         )
     """)
-    await conn.execute("""
-        CREATE TABLE user_goals (
-            id TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
-            status TEXT NOT NULL DEFAULT 'active',
-            priority TEXT NOT NULL DEFAULT 'medium',
-            category TEXT DEFAULT 'project',
-            created_at TEXT NOT NULL DEFAULT (datetime('now'))
-        )
-    """)
+    # Canonical schema (not a hand-rolled subset): compute_focus_summary
+    # filters on columns like origin, so a drifted inline DDL breaks silently
+    # behind the function's fallback path.
+    from genesis.db.schema import TABLES
+
+    await conn.execute(TABLES["user_goals"])
     await conn.commit()
     yield conn
     await conn.close()
@@ -87,8 +83,8 @@ async def test_with_board_proposals(db):
 async def test_with_goals(db):
     """User goals appear for user ego but not genesis ego."""
     await db.execute(
-        "INSERT INTO user_goals (id, title, status, priority) "
-        "VALUES ('g1', 'Suki AI application', 'active', 'high')"
+        "INSERT INTO user_goals (id, title, category, status, priority) "
+        "VALUES ('g1', 'Suki AI application', 'career', 'active', 'high')"
     )
     await db.commit()
 
@@ -125,8 +121,8 @@ async def test_combined_state(db):
         "VALUES ('p1', 'Research infrastructure costs', 'pending')"
     )
     await db.execute(
-        "INSERT INTO user_goals (id, title, status, priority) "
-        "VALUES ('g1', 'Panel preparation', 'active', 'high')"
+        "INSERT INTO user_goals (id, title, category, status, priority) "
+        "VALUES ('g1', 'Panel preparation', 'project', 'active', 'high')"
     )
     await db.commit()
 

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -1096,10 +1096,12 @@ class TestEgoCycleDisallowedTools:
 
         assert "mcp__genesis-health__ego_goal_create" in _EGO_CYCLE_DISALLOWED_TOOLS
         assert "mcp__genesis-health__ego_goal_update" in _EGO_CYCLE_DISALLOWED_TOOLS
-        # Read-only goal tools stay available in-cycle.
+        # ego_goal_progress mutates too: add_progress_note() refreshes
+        # updated_at, silently resetting the staleness-review clock.
+        assert "mcp__genesis-health__ego_goal_progress" in _EGO_CYCLE_DISALLOWED_TOOLS
+        # The truly read-only goal tool stays available in-cycle.
         assert not any(
-            "ego_goal_list" in t or "ego_goal_progress" in t
-            for t in _EGO_CYCLE_DISALLOWED_TOOLS
+            "ego_goal_list" in t for t in _EGO_CYCLE_DISALLOWED_TOOLS
         )
 
     def test_cycle_invocation_wires_the_disallow_list(self):

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -809,7 +809,9 @@ class TestGoalStatusRecommendationRouting:
 
         ego_session._proposals.create_batch.assert_not_awaited()
         cursor = await goals_db.execute(
-            "SELECT type, category FROM observations WHERE source = 'user_ego'",
+            # source carries the producing cycle's source_tag (PR-3a fixed
+            # the hardcoded "user_ego" misattribution).
+            "SELECT type, category FROM observations WHERE source = 'user_ego_cycle'",
         )
         row = await cursor.fetchone()
         assert row is not None
@@ -1062,3 +1064,51 @@ class TestAutonomousOwnGoalManagement:
             "SELECT type FROM observations WHERE type = 'goal_recommendation'",
         )
         assert await cursor.fetchone() is not None
+
+    async def test_close_observation_source_is_genesis_cycle(
+        self, ego_session, goals_db,
+    ):
+        """The passive goal_recommendation observation carries the cycle that
+        produced it — a genesis-cycle review must not masquerade as user_ego
+        (pre-PR-3a the source was hardcoded)."""
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="eg6", origin="genesis_ego")
+
+        await ego_session._surface_goal_recommendation(
+            goal_id="eg6", recommendation="close", assessment="likely done",
+        )
+
+        cursor = await goals_db.execute(
+            "SELECT source FROM observations WHERE type = 'goal_recommendation'",
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row["source"] == "genesis_ego_cycle"
+
+
+class TestEgoCycleDisallowedTools:
+    """Side-door closure: the ego CYCLE session must not see the foreground
+    goal-mutation MCP tools — in-cycle goal changes go through the parsed-
+    output path (gated, validated, audited) only."""
+
+    def test_constant_contents(self):
+        from genesis.ego.session import _EGO_CYCLE_DISALLOWED_TOOLS
+
+        assert "mcp__genesis-health__ego_goal_create" in _EGO_CYCLE_DISALLOWED_TOOLS
+        assert "mcp__genesis-health__ego_goal_update" in _EGO_CYCLE_DISALLOWED_TOOLS
+        # Read-only goal tools stay available in-cycle.
+        assert not any(
+            "ego_goal_list" in t or "ego_goal_progress" in t
+            for t in _EGO_CYCLE_DISALLOWED_TOOLS
+        )
+
+    def test_cycle_invocation_wires_the_disallow_list(self):
+        """Wiring lock: the CCInvocation the cycle builds must carry the
+        constant (module-source assertion; E2E verifies the actual tool-list
+        shrink on a live cycle)."""
+        import inspect
+
+        import genesis.ego.session as session_mod
+
+        src = inspect.getsource(session_mod)
+        assert "disallowed_tools=list(_EGO_CYCLE_DISALLOWED_TOOLS)" in src

--- a/tests/ego/test_world_model.py
+++ b/tests/ego/test_world_model.py
@@ -359,3 +359,89 @@ class TestMemoryEventsExtended:
         )
         deadlines = await memory_events.approaching_deadlines(db, days=365*100)
         assert len(deadlines) == 1
+
+
+# -- Goal origin scoping (PR-3a: origin-aware surfaces) --
+
+
+class TestGoalOriginScoping:
+    """Origin-aware queries: user-facing surfaces filter to origin='user';
+    the ego's own lane queries origin='genesis_ego'."""
+
+    async def _seed(self, db):
+        await user_goals.create(
+            db, title="User goal", category="career", priority="high",
+        )
+        await user_goals.create(
+            db, title="Ego ops goal", category="project",
+            priority="medium", origin="genesis_ego",
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_active_origin_filter(self, db):
+        await self._seed(db)
+        both = {g["title"] for g in await user_goals.list_active(db)}
+        assert both == {"User goal", "Ego ops goal"}
+        users = [g["title"] for g in await user_goals.list_active(db, origin="user")]
+        assert users == ["User goal"]
+        ego = [g["title"] for g in await user_goals.list_active(db, origin="genesis_ego")]
+        assert ego == ["Ego ops goal"]
+
+    @pytest.mark.asyncio
+    async def test_count_by_status(self, db):
+        await self._seed(db)
+        gid = await user_goals.create(
+            db, title="Paused ego goal", category="other", origin="genesis_ego",
+        )
+        await user_goals.update(db, gid, status="paused")
+        counts = await user_goals.count_by_status(db, origin="genesis_ego")
+        assert counts == {"active": 1, "paused": 1}
+        all_counts = await user_goals.count_by_status(db)
+        assert all_counts["active"] == 2
+        assert all_counts["paused"] == 1
+
+    @pytest.mark.asyncio
+    async def test_find_similar_matches_paused_when_scoped(self, db):
+        """The autonomous-creation dedupe passes ("active", "paused") so
+        pausing an ego goal doesn't reopen the door to recreating it."""
+        gid = await user_goals.create(
+            db, title="Reduce nightly maintenance backlog",
+            category="project", origin="genesis_ego",
+        )
+        await user_goals.update(db, gid, status="paused")
+        assert await user_goals.find_similar(
+            db, "Reduce nightly maintenance backlog",
+        ) is None  # default active-only behavior preserved
+        match = await user_goals.find_similar(
+            db, "Reduce nightly maintenance backlog",
+            statuses=("active", "paused"),
+        )
+        assert match is not None
+        assert match["id"] == gid
+
+    @pytest.mark.asyncio
+    async def test_find_similar_never_matches_achieved(self, db):
+        """A finished title stays re-openable — terminal goals never block."""
+        gid = await user_goals.create(
+            db, title="Ship the quarterly report pipeline", category="project",
+        )
+        await user_goals.mark_achieved(db, gid)
+        assert await user_goals.find_similar(
+            db, "Ship the quarterly report pipeline",
+            statuses=("active", "paused"),
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_find_similar_origin_scope(self, db):
+        """Extraction dedupe (origin='user') must never match an ego goal —
+        conversation-derived signals only speak for the user's lane."""
+        await user_goals.create(
+            db, title="Improve memory recall quality",
+            category="project", origin="genesis_ego",
+        )
+        assert await user_goals.find_similar(
+            db, "Improve memory recall quality", origin="user",
+        ) is None
+        assert await user_goals.find_similar(
+            db, "Improve memory recall quality",
+        ) is not None

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -1090,3 +1090,30 @@ async def test_j9_eval_status_reports_new_snapshot_dimensions(db, monkeypatch):
     for dim in ("approvals", "goals", "noise"):
         assert dim in res["latest_snapshots"], f"missing {dim}"
         assert res["latest_snapshots"][dim] is not None
+
+
+async def test_compute_goal_completion_excludes_ego_goals(db):
+    """PR-3a: origin='genesis_ego' goals must not contaminate the user-goal
+    eval signal — neither the status ratios nor the achieved window."""
+    from genesis.db.crud import user_goals
+    from genesis.eval.j9_aggregator import _compute_goal_completion
+
+    u1 = await user_goals.create(db, title="user g", category="project")
+    e1 = await user_goals.create(
+        db, title="ego g", category="project", origin="genesis_ego",
+    )
+    await user_goals.create(
+        db, title="ego g2", category="project", origin="genesis_ego",
+    )
+    await user_goals.mark_achieved(db, u1)
+    await user_goals.mark_achieved(db, e1)
+
+    metrics, sample = await _compute_goal_completion(
+        db, since="2000-01-01", until="2100-01-01",
+    )
+    assert sample == 1  # the user goal only
+    assert metrics["total_goals"] == 1
+    assert metrics["by_status"] == {
+        "active": 0, "paused": 0, "achieved": 1, "abandoned": 0,
+    }
+    assert metrics["achieved_count"] == 1

--- a/tests/test_mcp/test_ego_goal_create_origin.py
+++ b/tests/test_mcp/test_ego_goal_create_origin.py
@@ -108,3 +108,25 @@ class TestOriginImmutable:
         conn, _db_path = db
         gid = await user_goals.create(conn, title="ego's", category="project", origin="genesis_ego")
         assert await _origin_of(conn, gid) == "genesis_ego"
+
+
+class TestEgoGoalListShowsOrigin:
+    async def test_list_includes_origin_field(self, db):
+        """PR-3a display fix: every row carries its provenance so the user
+        can always tell whose goal is whose."""
+        conn, db_path = db
+        await user_goals.create(conn, title="User goal", category="career")
+        await user_goals.create(
+            conn, title="Ego goal", category="project", origin="genesis_ego",
+        )
+        await conn.commit()
+
+        from genesis.mcp.health import ego_tools
+
+        fn = getattr(ego_tools.ego_goal_list, "fn", ego_tools.ego_goal_list)
+        with patch("genesis.mcp.health.ego_tools._get_db_path", return_value=db_path):
+            result = await fn()
+
+        assert result["status"] == "ok"
+        origins = {g["title"]: g["origin"] for g in result["goals"]}
+        assert origins == {"User goal": "user", "Ego goal": "genesis_ego"}

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -537,3 +537,36 @@ async def test_checkpoint_question_rows_never_closed(db, mock_health, mock_draft
 
     row = await _mq_row(db, "q1")
     assert row["responded_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_activity_summary_scopes_goals_by_origin(db, mock_health, mock_drafter):
+    """PR-3a: 'Active user goals' excludes ego-owned goals; Genesis's own
+    goals appear only as the compact count line (active + paused)."""
+    from genesis.db.crud import user_goals
+
+    await user_goals.create(
+        db, title="User career goal", category="career", priority="high",
+    )
+    await user_goals.create(
+        db, title="Ego ops goal", category="project", origin="genesis_ego",
+    )
+    paused = await user_goals.create(
+        db, title="Paused ego goal", category="other", origin="genesis_ego",
+    )
+    await user_goals.update(db, paused, status="paused")
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    summary = await gen._get_activity_summary()
+
+    assert "User career goal" in summary
+    assert "Ego ops goal" not in summary
+    assert "Genesis's own goals: 1 active, 1 paused" in summary
+
+
+@pytest.mark.asyncio
+async def test_activity_summary_no_ego_goal_line_when_none(db, mock_health, mock_drafter):
+    """No ego goals → no count line (the section stays user-pure)."""
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    summary = await gen._get_activity_summary()
+    assert "Genesis's own goals" not in summary


### PR DESCRIPTION
## What

First half of ego goal-autonomy **activation** (PR-3 of the additive-autonomy program: #1072 → #1075 → #1085 → #1086 → this). Dormant-safe hygiene: zero behavior change while no `origin='genesis_ego'` goals exist, load-bearing the moment PR-3b (trusted creation path) lands.

## Why

#1086 established `user_goals.origin` as the immutable security boundary and shipped the direct-apply branch for the ego's own goals — but every goal-rendering surface still treats all goals as user goals, and the ego cycle session carries ungated foreground goal tools. Both must be fixed **before** the first ego-owned goal can exist:

- **User-facing surfaces filter to `origin='user'`** (enumerated live via LSP references, 9 sites): user-ego staleness scanner (else the user ego sends approval proposals about internal ops goals), user-ego goals section, morning report, world snapshot, **dispatched-session prompts** (ego-authored text labeled "User's active goals" downstream would be a masquerade + injection surface), computed focus, j9 goal-completion eval metric, extraction dedupe.
- **Side-door closure**: ego cycle `CCInvocation` now disallows `ego_goal_create`/`ego_goal_update` (the former stamps `origin='user'`, the latter mutates ANY goal with no approval gate). In-cycle goal mutation goes exclusively through the parsed-output path (source_tag-gated, validated, audited — #1086). Foreground CC sessions keep all tools; read-only goal tools stay in-cycle.
- **CRUD**: `origin`/`statuses` scoping on `list_active`/`find_similar`, new unbounded `count_by_status` for the PR-3b cap check.
- **Visibility**: morning report gains `Genesis's own goals: N active, M paused` (the paused-tail watch surface); `ego_goal_list` returns each goal's `origin`.
- **Fix**: `_surface_goal_recommendation` observation `source` was hardcoded `"user_ego"` — misattributed genesis-cycle output; now carries the producing cycle's source_tag.
- Shared goal-field validation sets moved to `ego/goal_actions.py` (import direction: into the MCP layer, never the reverse).
- Stale test fixture in `test_computed_focus.py` (hand-rolled `user_goals` DDL without `origin`) replaced with canonical `TABLES`.

## Invariants (unchanged)

Ego-proposal approval gate and autonomous-CLI approval gate untouched. `origin` remains immutable and never caller input. User-origin goals remain mechanically untouchable outside approved proposals.

## Testing

15 new tests (origin scoping matrix, scanner exclusion, morning-report purity + count line, j9 exclusion, ego_goal_list origin, disallow-list contents + wiring lock, source_tag attribution) + full adjacent suites green (289 tests).

Part of follow-up aefeae35c23a (completes with PR-3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)