### PR TITLE
feat(ego): activate additive goal autonomy — trusted creation + own-goal review (PR-3b)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -348,13 +348,28 @@ verified: 7968d85a 2026-07-16
   cycle, close/priority-increase/delete — keeps the recommend-only proposal
   path (`goal_actions.py`). The approval gates (proposal + autonomous-CLI) are
   untouched: the ego skips proposal CREATION only for its own additive
-  artifacts. **Dormant until PR-3**, which must wire BOTH halves: (1) a
-  trusted genesis-ego creation path — the `ego_goal_create` MCP tool has NO
-  origin argument (Codex P1: caller input must never stamp provenance); only
-  the CRUD accepts `origin`, for trusted code — and (2) a genesis-cycle goal
-  review: today's staleness scan (`cadence._check_stale_goals`) is
-  user-ego-only, so no scheduled path reaches the direct-apply branch yet
-  (Codex P2).
+  artifacts. **ACTIVE since PR-3 (2026-07-16)** — two parsed output keys on
+  the genesis ego cycle, both source_tag-gated in `_process_cycle_output`:
+  `own_goal_creations` (`session._process_own_goal_creations` — THE only code
+  stamping `origin='genesis_ego'`; validated in `_validate_output`; caps: 1
+  per cycle + `config.max_active_ego_goals` active; `find_similar` dedupe
+  across active+paused of both origins) and `own_goal_reviews`
+  (`_process_own_goal_reviews` — own-lane only, non-ego goals skipped never
+  proposed; routes into the #1086 double-gated direct-apply). The
+  `ego_goal_create` MCP tool still has NO origin argument (provenance is
+  never caller input) and all three goal-mutation MCP tools (create/update/
+  progress — the last resets the staleness clock via updated_at) are
+  DISALLOWED in ego cycle sessions (`_EGO_CYCLE_DISALLOWED_TOOLS` →
+  `--disallowedTools`).
+  Every user-facing goal surface (user-ego scanner/context, morning report,
+  world snapshot, dispatch prompts, computed focus, j9 metric, extraction
+  dedupe) filters `origin='user'`; the genesis context renders the own-goal
+  lane (`genesis_context._own_goals_section`, staleness-annotated — what
+  makes own-goal review non-blind). Visibility: `goal_autonomous_action`
+  observations are user-visible by default (NOT in INTERNAL_OBS_TYPES,
+  locked by test) + a morning-report own-goals count line. Paused own-goal
+  tail is deliberately unbounded (user decision 2026-07-16), watched via
+  that count line.
 - **identity/**: SOUL/USER/VOICE/STEERING CAPS-markdown + `IdentityLoader`
   (wired via perception). `cc/session_config` reads SOUL+VOICE directly, not
   via the loader. **USER.md auto-synthesis is PERMANENTLY DISABLED** — the

--- a/src/genesis/db/crud/user_goals.py
+++ b/src/genesis/db/crud/user_goals.py
@@ -216,6 +216,7 @@ async def find_similar(
     threshold: float = 0.6,
     statuses: tuple[str, ...] = ("active",),
     origin: str | None = None,
+    limit: int = 50,
 ) -> dict | None:
     """Find an existing goal with a similar title (simple word overlap).
 
@@ -227,7 +228,9 @@ async def find_similar(
     recreating it; achieved/abandoned are deliberately never matched — a
     finished title stays re-openable. ``origin`` scopes by provenance
     (the extraction path passes "user" so conversation-derived signals
-    never reinforce ego-owned goals).
+    never reinforce ego-owned goals). ``limit`` bounds the scan (newest
+    first) — dedupe callers that must see the whole live set pass a high
+    value; the default preserves the original 50-newest behavior.
     """
     placeholders = ", ".join("?" for _ in statuses)
     params: list[object] = list(statuses)
@@ -237,8 +240,8 @@ async def find_similar(
         params.append(origin)
     cursor = await db.execute(
         f"SELECT * FROM user_goals WHERE status IN ({placeholders}) "  # noqa: S608
-        f"{origin_clause}ORDER BY created_at DESC LIMIT 50",
-        params,
+        f"{origin_clause}ORDER BY created_at DESC LIMIT ?",
+        [*params, limit],
     )
     goals = [dict(r) for r in await cursor.fetchall()]
     if not goals:

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -137,6 +137,10 @@ def validate_ego_config(changes: dict) -> list[str]:
         v = changes["genesis_max_interval_minutes"]
         if not isinstance(v, (int, float)) or v < 60:
             errors.append("genesis_max_interval_minutes must be >= 60")
+    if "max_active_ego_goals" in changes:
+        v = changes["max_active_ego_goals"]
+        if not isinstance(v, int) or v < 0:
+            errors.append("max_active_ego_goals must be integer >= 0")
     if "dispatch_model_overrides" in changes:
         v = changes["dispatch_model_overrides"]
         valid_models = VALID_MODEL_NAMES

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -84,6 +84,7 @@ class GenesisEgoContextBuilder:
             ("signals", self._signals_section),
             ("observations", self._observations_section),
             ("follow_ups", self._follow_ups_section),
+            ("own_goals", self._own_goals_section),
             # Cost section removed — the genesis ego's identity doc says
             # "Do NOT opine on config values... budget caps... are user
             # decisions."  Feeding cost data every cycle caused a 10+
@@ -666,6 +667,77 @@ class GenesisEgoContextBuilder:
         return "\n".join(lines)
 
 
+    async def _own_goals_section(self, *, depth: str = "deep") -> str:
+        """The genesis ego's OWN goal lane (origin='genesis_ego').
+
+        Renders active + paused own goals with staleness annotations. This
+        section is what makes own-goal review non-blind — the ego only ever
+        reviews goals it can see here — and doubles as the dedupe context
+        for own_goal_creations. User goals are deliberately absent: they are
+        user-ego jurisdiction (user_context renders those, filtered to
+        origin='user').
+        """
+        try:
+            cursor = await self._db.execute(
+                "SELECT * FROM user_goals WHERE origin = 'genesis_ego' "
+                "AND status IN ('active', 'paused') "
+                "ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END, "
+                "updated_at ASC LIMIT 30",
+            )
+            goals = [dict(r) for r in await cursor.fetchall()]
+        except Exception:
+            logger.error("Failed to query own goals", exc_info=True)
+            return "## Your Own Goals\n\n*Could not query own goals.*\n"
+
+        lines = ["## Your Own Goals\n"]
+        if not goals:
+            lines.append(
+                "*None yet. When an operational objective needs tracking "
+                "across cycles, you may create one via `own_goal_creations` "
+                "(see Output Contract).*\n"
+            )
+            return "\n".join(lines)
+
+        n_active = sum(1 for g in goals if g["status"] == "active")
+        n_paused = len(goals) - n_active
+        lines.append(f"*{n_active} active, {n_paused} paused.*\n")
+        if depth == "light":
+            return "\n".join(lines)
+
+        # Staleness threshold mirrors the goal-review default: per-goal
+        # cadence_days override, else the EgoConfig dataclass default.
+        from genesis.ego.types import EgoConfig
+
+        default_days = EgoConfig.goal_review_staleness_days
+        now = datetime.now(UTC)
+        for g in goals:
+            updated_at = g.get("updated_at") or g.get("created_at") or ""
+            days: int | str = "?"
+            stale_tag = ""
+            try:
+                updated = datetime.fromisoformat(updated_at)
+                if updated.tzinfo is None:
+                    updated = updated.replace(tzinfo=UTC)
+                days = (now - updated).days
+                per_goal = g.get("cadence_days")
+                threshold = (
+                    per_goal
+                    if isinstance(per_goal, int) and per_goal > 0
+                    else default_days
+                )
+                if g["status"] == "active" and days >= threshold:
+                    stale_tag = " — STALE, review due (own_goal_reviews)"
+            except (ValueError, TypeError):
+                pass
+            lines.append(
+                f"- [{g['status'].upper()}] "
+                f"**{(g.get('title') or '?')[:100]}** "
+                f"(id: {g['id']}, {g.get('priority', 'medium')}, "
+                f"{g.get('category', '?')}, updated {days}d ago){stale_tag}"
+            )
+        lines.append("")
+        return "\n".join(lines)
+
     @staticmethod
     def _output_contract_section(*, depth: str = "deep") -> str:
         """Remind the Genesis ego of its output format.
@@ -705,10 +777,21 @@ class GenesisEgoContextBuilder:
             '  "resolved_follow_ups": [{"id": "follow_up_id", "resolution": "why resolved"}],\n'
             '  "intentions": {"review": [{"id": "...", "action": "keep|fire|withdraw|renew"}], '
             '"new": [{"content": "...", "trigger_condition": "...", "reasoning": "..."}]},\n'
-            '  "communication_decision": "send_digest|urgent_notify|stay_quiet"\n'
+            '  "communication_decision": "send_digest|urgent_notify|stay_quiet",\n'
+            '  "own_goal_creations": [{"title": "...", "description": "...", '
+            '"category": "project|learning|other", "priority": "low|medium|high", '
+            '"goal_type": "milestone|continuous", "cadence_days": 14}],\n'
+            '  "own_goal_reviews": [{"goal_id": "...", '
+            '"recommendation": "continue|pause|deprioritize|close", '
+            '"assessment": "..."}]\n'
             "}\n"
             "```\n\n"
             "If you cannot resolve an issue, add it to escalations — "
             "the user ego will see it and decide what the user needs to know.\n\n"
-            "No morning_report — that belongs to the user ego.\n"
+            "No morning_report — that belongs to the user ego.\n\n"
+            "own_goal_creations / own_goal_reviews touch ONLY your own lane "
+            "(origin=genesis_ego, listed under 'Your Own Goals'): max 1 "
+            "creation per cycle and a cap on active own goals; reviews of "
+            "anything not in that list are ignored. Omit both keys when "
+            "nothing changes.\n"
         )

--- a/src/genesis/ego/goal_actions.py
+++ b/src/genesis/ego/goal_actions.py
@@ -49,6 +49,13 @@ VALID_GOAL_CATEGORIES = frozenset(
 VALID_GOAL_PRIORITIES = _VALID_PRIORITY
 VALID_GOAL_TYPES = frozenset({"milestone", "continuous"})
 
+# The genesis ego's OWN goals are restricted to operational lanes — a strict
+# subset of the full category set. career/financial/relationship are
+# user-life lanes; an ego-owned goal there would breach the jurisdiction
+# boundary in GENESIS_EGO_SESSION.md even with correct provenance (Codex P2,
+# PR #1094). Keep in sync with the output contract + prompt doc.
+VALID_OWN_GOAL_CATEGORIES = frozenset({"project", "learning", "other"})
+
 
 def _parse_expected_outputs(expected_outputs: object) -> dict | None:
     """Extract the ``{change, value}`` spec from a proposal's expected_outputs.

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -572,6 +572,9 @@ class EgoSession:
                     continue
                 duplicate = await goals_crud.find_similar(
                     self._db, title, statuses=("active", "paused"),
+                    # Shadow-duplicate protection must see the WHOLE live
+                    # goal set, not the 50 newest (Codex P2, PR #1094).
+                    limit=1000,
                 )
                 if duplicate:
                     logger.info(
@@ -2850,8 +2853,8 @@ def _validate_output(data: dict) -> dict | None:
         cleaned: list[dict] = []
         if isinstance(raw, list):
             from genesis.ego.goal_actions import (
-                VALID_GOAL_CATEGORIES,
                 VALID_GOAL_TYPES,
+                VALID_OWN_GOAL_CATEGORIES,
             )
 
             for entry in raw:
@@ -2860,7 +2863,10 @@ def _validate_output(data: dict) -> dict | None:
                 title = entry.get("title")
                 if not isinstance(title, str) or not title.strip():
                     continue
-                if entry.get("category") not in VALID_GOAL_CATEGORIES:
+                # Operational lanes only — career/financial/relationship are
+                # user-life categories, out of the genesis ego's jurisdiction
+                # even for its own goals.
+                if entry.get("category") not in VALID_OWN_GOAL_CATEGORIES:
                     continue
                 # 'critical' is reserved for the user's goals — an own goal
                 # never outranks a user directive by construction.

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -98,6 +98,11 @@ _EGO_CYCLE_DISALLOWED_TOOLS = (
     "mcp__genesis-health__ego_goal_progress",
 )
 
+# Per-cycle cap on autonomous own-goal creations (genesis ego). One per cycle
+# keeps the lane's growth rate bounded and reviewable; the global bound is
+# config.max_active_ego_goals (active own goals).
+_MAX_OWN_GOAL_CREATIONS_PER_CYCLE = 1
+
 
 class CycleBlockedError(Exception):
     """Raised when the ego cycle is blocked by an approval gate.
@@ -505,6 +510,175 @@ class EgoSession:
                 exc_info=True,
             )
 
+    async def _process_own_goal_creations(
+        self, creations: list[dict], cycle_id: str,
+    ) -> None:
+        """Create genesis_ego-owned goals from the cycle's parsed output.
+
+        THE trusted creation path (PR-3b) — the only code that stamps
+        ``origin='genesis_ego'``. Trust argument: the input is the genesis
+        ego cycle's own LLM output (single construction site in
+        runtime/init/ego.py, single run_unified_cycle caller under the
+        cadence lock), never caller/tool input — the MCP surface refuses an
+        origin argument by design. Guards, in order:
+
+        1. source_tag gate — only the genesis ego cycle owns this lane.
+        2. Per-cycle cap (_MAX_OWN_GOAL_CREATIONS_PER_CYCLE) and global
+           active cap (config.max_active_ego_goals).
+        3. Similarity dedupe across active+paused goals of BOTH origins —
+           an own goal must never shadow-duplicate a user goal, and pausing
+           an own goal doesn't reopen the door to recreating it.
+
+        Every creation is audited via a goal_autonomous_action observation —
+        user-visible by default (the type is deliberately NOT in
+        INTERNAL_OBS_TYPES) — and counted in the morning report's own-goals
+        line. Dropped entries are logged, never silent.
+        """
+        if self._source_tag != "genesis_ego_cycle":
+            logger.warning(
+                "own_goal_creations ignored: emitted by %s, not the genesis "
+                "ego cycle (%d entr%s dropped)",
+                self._source_tag, len(creations),
+                "y" if len(creations) == 1 else "ies",
+            )
+            return
+
+        import uuid
+
+        from genesis.db.crud import observations as obs_crud
+        from genesis.db.crud import user_goals as goals_crud
+
+        try:
+            counts = await goals_crud.count_by_status(
+                self._db, origin="genesis_ego",
+            )
+            active = counts.get("active", 0)
+            cap = getattr(self._config, "max_active_ego_goals", 5)
+            created = 0
+            for entry in creations:
+                title = entry.get("title") or "?"
+                if created >= _MAX_OWN_GOAL_CREATIONS_PER_CYCLE:
+                    logger.info(
+                        "own_goal_creations: per-cycle cap (%d) reached — "
+                        "'%s' dropped (re-emit next cycle if still needed)",
+                        _MAX_OWN_GOAL_CREATIONS_PER_CYCLE, title[:60],
+                    )
+                    continue
+                if active + created >= cap:
+                    logger.info(
+                        "own_goal_creations: active own-goal cap (%d) "
+                        "reached — '%s' dropped", cap, title[:60],
+                    )
+                    continue
+                duplicate = await goals_crud.find_similar(
+                    self._db, title, statuses=("active", "paused"),
+                )
+                if duplicate:
+                    logger.info(
+                        "own_goal_creations: '%s' too similar to existing "
+                        "goal %s ('%s') — dropped", title[:60],
+                        duplicate["id"][:12],
+                        (duplicate.get("title") or "?")[:60],
+                    )
+                    continue
+
+                goal_id = await goals_crud.create(
+                    self._db,
+                    title=title,
+                    category=entry["category"],
+                    description=entry.get("description"),
+                    priority=entry.get("priority", "medium"),
+                    goal_type=entry.get("goal_type", "milestone"),
+                    cadence_days=entry.get("cadence_days"),
+                    evidence_source=f"ego_cycle:{cycle_id}",
+                    origin="genesis_ego",
+                )
+                created += 1
+                logger.info(
+                    "Autonomously created own goal %s: '%s' (%s, %s)",
+                    goal_id[:12], title[:60], entry["category"],
+                    entry.get("priority", "medium"),
+                )
+                try:
+                    desc = entry.get("description")
+                    await obs_crud.create(
+                        self._db,
+                        id=str(uuid.uuid4()),
+                        source=self._source_tag,
+                        type="goal_autonomous_action",
+                        content=(
+                            f"Autonomously created own goal '{title}' "
+                            f"({entry['category']}, priority "
+                            f"{entry.get('priority', 'medium')}). Ego-created "
+                            f"(origin=genesis_ego) — user goals are never "
+                            f"touched autonomously."
+                            + (f" Description: {desc[:300]}" if desc else "")
+                        ),
+                        priority="medium",
+                        category="goal_review",
+                        created_at=datetime.now(UTC).isoformat(),
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to write own-goal-creation audit observation",
+                        exc_info=True,
+                    )
+        except Exception:
+            logger.warning(
+                "own_goal_creations processing failed", exc_info=True,
+            )
+
+    async def _process_own_goal_reviews(self, reviews: list[dict]) -> None:
+        """Apply the genesis ego's review verdicts on its OWN goals.
+
+        Own-lane only: an entry referencing a non-genesis_ego goal is
+        skipped and logged — this channel never converts into a user-facing
+        proposal (user goals keep their own goal_review pipeline).
+        pause/deprioritize route through _propose_goal_status_change, whose
+        origin+source_tag double gate direct-applies for genuine own goals
+        (#1086); ``continue`` is a no-op; ``close`` surfaces a passive
+        observation — terminal calls stay the user's, for every goal.
+        """
+        if self._source_tag != "genesis_ego_cycle":
+            logger.warning(
+                "own_goal_reviews ignored: emitted by %s, not the genesis "
+                "ego cycle (%d entr%s dropped)",
+                self._source_tag, len(reviews),
+                "y" if len(reviews) == 1 else "ies",
+            )
+            return
+
+        from genesis.db.crud import user_goals as goals_crud
+
+        for entry in reviews:
+            goal_id = entry["goal_id"]
+            recommendation = entry["recommendation"]
+            if recommendation == "continue":
+                continue
+            try:
+                goal = await goals_crud.get_by_id(self._db, goal_id)
+                if not goal or (goal.get("origin") or "user") != "genesis_ego":
+                    logger.warning(
+                        "own_goal_reviews: %s is not an ego-owned goal — "
+                        "skipped (user goals keep the goal_review pipeline)",
+                        goal_id[:12],
+                    )
+                    continue
+                assessment = entry.get("assessment")
+                assessment = (
+                    assessment[:500] if isinstance(assessment, str) else ""
+                )
+                await self._surface_goal_recommendation(
+                    goal_id=goal_id,
+                    recommendation=recommendation,
+                    assessment=assessment,
+                )
+            except Exception:
+                logger.warning(
+                    "own_goal_reviews: failed for %s", goal_id[:12],
+                    exc_info=True,
+                )
+
     async def _surface_goal_recommendation(
         self,
         *,
@@ -676,8 +850,9 @@ class EgoSession:
 
         The additive-autonomy path (2026-07-16): no proposal is created, but
         the action is audited — an observation records what was applied and
-        why, and surfaces to the user through the normal awareness digest
-        (visibility, NOT an approval prompt). Reuses goal_actions' validated
+        why, and surfaces to the user via the morning report's unsurfaced-
+        observation pipeline (the type is deliberately NOT in
+        INTERNAL_OBS_TYPES — visibility, NOT an approval prompt). Reuses goal_actions' validated
         value sets so the autonomous path can never apply a value the gated
         path couldn't. Reversible by the user at any time (resume/re-raise
         via ego_goal_update).
@@ -986,6 +1161,16 @@ class EgoSession:
             intentions_data = parsed.get("intentions")
             if intentions_data and isinstance(intentions_data, dict):
                 await self._process_intentions(intentions_data)
+
+            # 10e. Additive ego autonomy — the genesis ego's OWN goal lane
+            # (origin='genesis_ego'). Both handlers hard-gate on source_tag
+            # internally; for any other session the keys are ignored+logged.
+            own_creations = parsed.get("own_goal_creations", [])
+            if isinstance(own_creations, list) and own_creations:
+                await self._process_own_goal_creations(own_creations, cycle.id)
+            own_reviews = parsed.get("own_goal_reviews", [])
+            if isinstance(own_reviews, list) and own_reviews:
+                await self._process_own_goal_reviews(own_reviews)
 
             # 11. Compute and store factual focus summary.
             # The ego's authored focus is already logged in ego_cycles
@@ -2654,5 +2839,59 @@ def _validate_output(data: dict) -> dict | None:
         and data["goal_status_recommendation"] not in _VALID_GOAL_RECS
     ):
         del data["goal_status_recommendation"]
+
+    # Sanitize own_goal_creations / own_goal_reviews — the genesis ego's
+    # additive-autonomy keys (PR-3b). Structural validation only (types,
+    # enums, length clamps mirroring the user_goals CHECK constraints);
+    # jurisdiction (source_tag), caps, and dedupe are enforced by the
+    # handlers in _process_cycle_output.
+    if "own_goal_creations" in data:
+        raw = data["own_goal_creations"]
+        cleaned: list[dict] = []
+        if isinstance(raw, list):
+            from genesis.ego.goal_actions import (
+                VALID_GOAL_CATEGORIES,
+                VALID_GOAL_TYPES,
+            )
+
+            for entry in raw:
+                if not isinstance(entry, dict):
+                    continue
+                title = entry.get("title")
+                if not isinstance(title, str) or not title.strip():
+                    continue
+                if entry.get("category") not in VALID_GOAL_CATEGORIES:
+                    continue
+                # 'critical' is reserved for the user's goals — an own goal
+                # never outranks a user directive by construction.
+                if entry.get("priority", "medium") not in ("low", "medium", "high"):
+                    entry["priority"] = "medium"
+                if entry.get("goal_type", "milestone") not in VALID_GOAL_TYPES:
+                    entry["goal_type"] = "milestone"
+                entry["title"] = title.strip()[:120]
+                desc = entry.get("description")
+                entry["description"] = (
+                    desc.strip()[:1000] if isinstance(desc, str) else None
+                )
+                cd = entry.get("cadence_days")
+                if isinstance(cd, bool) or not isinstance(cd, int):
+                    entry["cadence_days"] = None
+                else:
+                    # 3–60d: no self-assigned daily review churn, and never
+                    # an unreviewable-forever horizon.
+                    entry["cadence_days"] = max(3, min(60, cd))
+                cleaned.append(entry)
+        data["own_goal_creations"] = cleaned
+
+    if "own_goal_reviews" in data:
+        raw = data["own_goal_reviews"]
+        data["own_goal_reviews"] = [
+            r
+            for r in (raw if isinstance(raw, list) else [])
+            if isinstance(r, dict)
+            and isinstance(r.get("goal_id"), str)
+            and r["goal_id"]
+            and r.get("recommendation") in _VALID_GOAL_RECS
+        ]
 
     return data

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -140,6 +140,11 @@ class EgoConfig:
     genesis_cadence_minutes: int = 90  # base interval for genesis ego
     genesis_max_interval_minutes: int = 240  # backoff ceiling for genesis ego
     max_pending_proposals: int = 15  # auto-table oldest unranked when exceeded
+    # Additive ego autonomy — cap on ACTIVE goals in the genesis ego's OWN
+    # lane (origin='genesis_ego'). Pausing frees a slot; the paused tail is
+    # deliberately unbounded (user decision 2026-07-16) and reported in the
+    # morning report's own-goals count line.
+    max_active_ego_goals: int = 5
     # Per-action-type model overrides for proposal dispatch.
     # Keys are action_type strings (e.g. "investigate"), values are model
     # names ("opus", "sonnet", "haiku").  Falls back to profile-based

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -278,6 +278,31 @@ when its conditions have been met, use the `resolved_follow_ups` array:
 ]
 ```
 
+## Your Own Goals (Additive Autonomy)
+
+You may maintain a small set of YOUR OWN goals — Genesis-internal
+operational objectives that need tracking across cycles (e.g. "retire the
+legacy bridge fallback", "drive dead-letter backlog to zero"). These are a
+SEPARATE lane from the user's goals:
+
+- **Your goals never replace, duplicate, or compete with the user's.** The
+  user's goals remain entirely user-ego jurisdiction — the Domain
+  Boundaries above are unchanged. When in doubt, don't create.
+- **Same HARD BOUNDARY as your proposals**: infrastructure/operational
+  objectives only. Never career, content, personal, or external-tool goals.
+- **Create** via `own_goal_creations` (max 1 per cycle; capped active lane —
+  your current goals appear under "Your Own Goals" in your context). Don't
+  recreate anything similar to a listed goal, including paused ones.
+- **Review** via `own_goal_reviews` when a listed goal is marked stale:
+  `continue`, `pause`, or `deprioritize` (applied directly with an audit
+  record — reversible, additive-safe), or `close` (surfaced to the user;
+  terminal calls are theirs).
+- These keys mechanically apply ONLY to goals with origin=genesis_ego. You
+  cannot create or mutate user goals through them, and the foreground goal
+  tools (ego_goal_create / ego_goal_update) are disabled in your cycles.
+- Every autonomous goal action is visible to the user (audit observations +
+  the morning report). Act as if the user is watching — they are.
+
 ## Output Format
 
 Use MCP tools first, then output valid JSON:
@@ -325,6 +350,19 @@ Use MCP tools first, then output valid JSON:
     }
   ],
   "focus_summary": "One line: what Genesis is focused on",
+  "own_goal_creations": [
+    {
+      "title": "Own operational goal (infrastructure only)",
+      "description": "Why this needs tracking across cycles",
+      "category": "project|learning|other",
+      "priority": "low|medium|high",
+      "goal_type": "milestone|continuous",
+      "cadence_days": 14
+    }
+  ],
+  "own_goal_reviews": [
+    {"goal_id": "goal_id_from_Your_Own_Goals", "recommendation": "continue|pause|deprioritize|close", "assessment": "why"}
+  ],
   "resolved_follow_ups": [
     {"id": "follow_up_id", "resolution": "Why it's resolved"}
   ],

--- a/tests/ego/test_calibration_injection.py
+++ b/tests/ego/test_calibration_injection.py
@@ -140,7 +140,10 @@ class TestSection:
         full = await _builder(db).build()
         assert "## Confidence Calibration" in full
         # rendered before the output contract (highest salience for the confidence field)
-        assert full.index("Confidence Calibration") < full.index("Output Contract")
+        # Heading-anchored: plain substrings collide with body text that
+        # *mentions* other sections (e.g. the own-goals affordance line says
+        # "see Output Contract").
+        assert full.index("## Confidence Calibration") < full.index("## Output Contract")
 
     @pytest.mark.asyncio
     async def test_null_flag_stays_on(self, db, monkeypatch):

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -137,3 +137,14 @@ class TestValidateEgoConfig:
 
     def test_empty_changes_valid(self):
         assert validate_ego_config({}) == []
+
+
+class TestMaxActiveEgoGoalsValidation:
+    def test_valid(self):
+        assert validate_ego_config({"max_active_ego_goals": 3}) == []
+        assert validate_ego_config({"max_active_ego_goals": 0}) == []
+
+    def test_invalid(self):
+        assert validate_ego_config({"max_active_ego_goals": -1})
+        assert validate_ego_config({"max_active_ego_goals": 2.5})
+        assert validate_ego_config({"max_active_ego_goals": "5"})

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -62,6 +62,9 @@ async def db():
                 created_at       TEXT NOT NULL
             )
         """)
+        from genesis.db.schema import TABLES
+
+        await conn.execute(TABLES["user_goals"])
         await conn.execute("""
             CREATE TABLE ego_cycles (
                 id              TEXT PRIMARY KEY,
@@ -662,3 +665,74 @@ class TestGenesisEgoContextBuilder:
         )
         result = await builder.build()
         assert "repo/branch/status" in result
+
+
+class TestOwnGoalsSection:
+    """PR-3b: the genesis ego's own-goal lane rendering — what makes
+    own-goal review non-blind."""
+
+    def _builder(self, db):
+        return GenesisEgoContextBuilder(db=db, health_data=None, capabilities={})
+
+    async def _insert_goal(self, db, *, gid, title, origin, status="active",
+                           updated="2026-01-01T00:00:00+00:00", cadence_days=None):
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, status, priority, origin, cadence_days, "
+            " created_at, updated_at) "
+            "VALUES (?, ?, 'project', ?, 'medium', ?, ?, ?, ?)",
+            (gid, title, status, origin, cadence_days, updated, updated),
+        )
+        await db.commit()
+
+    async def test_empty_lane_shows_affordance(self, db):
+        section = await self._builder(db)._own_goals_section()
+        assert "## Your Own Goals" in section
+        assert "own_goal_creations" in section
+
+    async def test_lists_own_goals_with_staleness(self, db):
+        await self._insert_goal(
+            db, gid="og1", title="Retire legacy bridge", origin="genesis_ego",
+        )
+        section = await self._builder(db)._own_goals_section()
+        assert "Retire legacy bridge" in section
+        assert "og1" in section  # id present — reviews reference it
+        assert "STALE, review due" in section  # updated in 2026-01 → stale
+
+    async def test_fresh_goal_not_stale(self, db):
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC).isoformat()
+        await self._insert_goal(
+            db, gid="og2", title="Fresh objective", origin="genesis_ego",
+            updated=now,
+        )
+        section = await self._builder(db)._own_goals_section()
+        assert "Fresh objective" in section
+        assert "STALE" not in section
+
+    async def test_paused_listed_user_goals_absent(self, db):
+        await self._insert_goal(
+            db, gid="og3", title="Paused own goal", origin="genesis_ego",
+            status="paused",
+        )
+        await self._insert_goal(
+            db, gid="ug1", title="User career goal", origin="user",
+        )
+        section = await self._builder(db)._own_goals_section()
+        assert "Paused own goal" in section
+        assert "[PAUSED]" in section
+        assert "User career goal" not in section
+        # a PAUSED goal is never marked review-due
+        assert "STALE" not in section
+
+    async def test_build_includes_section_and_contract_keys(
+        self, db, mock_health_data, capabilities,
+    ):
+        builder = GenesisEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        context = await builder.build()
+        assert "## Your Own Goals" in context
+        assert "own_goal_creations" in context   # output contract
+        assert "own_goal_reviews" in context

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -1114,3 +1114,242 @@ class TestEgoCycleDisallowedTools:
 
         src = inspect.getsource(session_mod)
         assert "disallowed_tools=list(_EGO_CYCLE_DISALLOWED_TOOLS)" in src
+
+
+class TestValidateOwnGoalKeys:
+    """_validate_output sanitization for the additive-autonomy keys."""
+
+    @staticmethod
+    def _base(**extra):
+        data = {"proposals": [], "focus_summary": "x"}
+        data.update(extra)
+        return data
+
+    def test_creations_sanitized(self):
+        from genesis.ego.session import _validate_output
+
+        out = _validate_output(self._base(own_goal_creations=[
+            {"title": "  Fix dead-letter backlog  ", "category": "project",
+             "priority": "critical", "goal_type": "bogus",
+             "cadence_days": 1, "description": "d" * 2000},
+            {"title": "T" * 300, "category": "learning", "cadence_days": 999},
+            {"title": "No category"},                      # dropped
+            {"category": "project"},                       # dropped (no title)
+            {"title": "Bad category", "category": "career-ops"},  # dropped
+            "not a dict",                                  # dropped
+        ]))
+        cleaned = out["own_goal_creations"]
+        assert len(cleaned) == 2
+        first, second = cleaned
+        assert first["title"] == "Fix dead-letter backlog"
+        assert first["priority"] == "medium"      # critical reserved for user
+        assert first["goal_type"] == "milestone"  # invalid → default
+        assert first["cadence_days"] == 3         # clamped up
+        assert len(first["description"]) == 1000  # clamped
+        assert len(second["title"]) == 120        # clamped
+        assert second["cadence_days"] == 60       # clamped down
+
+    def test_reviews_sanitized(self):
+        from genesis.ego.session import _validate_output
+
+        out = _validate_output(self._base(own_goal_reviews=[
+            {"goal_id": "g1", "recommendation": "pause", "assessment": "a"},
+            {"goal_id": "g2", "recommendation": "resume"},  # invalid rec
+            {"recommendation": "pause"},                     # no goal_id
+            {"goal_id": "", "recommendation": "close"},      # empty id
+            "not a dict",
+        ]))
+        assert out["own_goal_reviews"] == [
+            {"goal_id": "g1", "recommendation": "pause", "assessment": "a"},
+        ]
+
+
+class TestOwnGoalCreations:
+    """_process_own_goal_creations — THE trusted origin='genesis_ego' path."""
+
+    @pytest.fixture
+    async def goals_db(self, db):
+        await db.execute(TABLES["user_goals"])
+        await db.execute(TABLES["observations"])
+        await db.commit()
+        return db
+
+    @staticmethod
+    def _entry(title="Drive dead-letter backlog to zero", **extra):
+        entry = {"title": title, "category": "project", "priority": "medium",
+                 "goal_type": "milestone", "description": None,
+                 "cadence_days": None}
+        entry.update(extra)
+        return entry
+
+    @staticmethod
+    async def _ego_goals(conn):
+        cur = await conn.execute(
+            "SELECT title, origin, status FROM user_goals "
+            "WHERE origin = 'genesis_ego'",
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def test_source_tag_gate(self, ego_session, goals_db):
+        """The key is inert for any session but the genesis ego cycle."""
+        ego_session._source_tag = "user_ego_cycle"
+        await ego_session._process_own_goal_creations([self._entry()], "c1")
+        assert await self._ego_goals(goals_db) == []
+
+    async def test_creates_with_origin_and_audit(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await ego_session._process_own_goal_creations([self._entry()], "c1")
+
+        goals = await self._ego_goals(goals_db)
+        assert len(goals) == 1
+        assert goals[0]["origin"] == "genesis_ego"
+        cur = await goals_db.execute(
+            "SELECT source, content FROM observations "
+            "WHERE type = 'goal_autonomous_action'",
+        )
+        row = await cur.fetchone()
+        assert row is not None
+        assert row["source"] == "genesis_ego_cycle"
+        assert "created own goal" in row["content"]
+
+    async def test_per_cycle_cap(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await ego_session._process_own_goal_creations(
+            [self._entry(), self._entry(title="Second unrelated objective")],
+            "c1",
+        )
+        assert len(await self._ego_goals(goals_db)) == 1
+
+    async def test_global_active_cap(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        from genesis.db.crud import user_goals as goals_crud
+
+        for i in range(5):
+            await goals_crud.create(
+                goals_db, title=f"Existing lane occupant {i} {'x' * i}",
+                category="project", origin="genesis_ego",
+            )
+        await ego_session._process_own_goal_creations([self._entry()], "c1")
+        assert len(await self._ego_goals(goals_db)) == 5  # unchanged
+
+    async def test_paused_frees_a_slot(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        from genesis.db.crud import user_goals as goals_crud
+
+        for i in range(5):
+            gid = await goals_crud.create(
+                goals_db, title=f"Existing lane occupant {i} {'y' * i}",
+                category="project", origin="genesis_ego",
+            )
+        await goals_crud.update(goals_db, gid, status="paused")
+        await ego_session._process_own_goal_creations([self._entry()], "c1")
+        assert len(await self._ego_goals(goals_db)) == 6  # 4 active + paused + new
+
+    async def test_dedupe_against_paused_own_goal(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        from genesis.db.crud import user_goals as goals_crud
+
+        gid = await goals_crud.create(
+            goals_db, title="Drive dead-letter backlog to zero",
+            category="project", origin="genesis_ego",
+        )
+        await goals_crud.update(goals_db, gid, status="paused")
+        await ego_session._process_own_goal_creations([self._entry()], "c1")
+        assert len(await self._ego_goals(goals_db)) == 1  # only the paused one
+
+    async def test_dedupe_against_user_goal(self, ego_session, goals_db):
+        """An own goal must never shadow-duplicate a USER goal."""
+        ego_session._source_tag = "genesis_ego_cycle"
+        from genesis.db.crud import user_goals as goals_crud
+
+        await goals_crud.create(
+            goals_db, title="Drive dead-letter backlog to zero",
+            category="project",  # origin defaults to 'user'
+        )
+        await ego_session._process_own_goal_creations([self._entry()], "c1")
+        assert await self._ego_goals(goals_db) == []
+
+
+class TestOwnGoalReviews:
+    """_process_own_goal_reviews — own-lane review verdicts."""
+
+    @pytest.fixture
+    async def goals_db(self, db):
+        await db.execute(TABLES["user_goals"])
+        await db.execute(TABLES["observations"])
+        await db.execute(TABLES["ego_proposals"])
+        await db.commit()
+        return db
+
+    @staticmethod
+    async def _insert_goal(conn, *, gid, origin, status="active"):
+        await conn.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, status, priority, origin, created_at, updated_at) "
+            "VALUES (?, 'Own Goal', 'project', ?, 'medium', ?, "
+            "'2026-06-01', '2026-06-01')",
+            (gid, status, origin),
+        )
+        await conn.commit()
+
+    @staticmethod
+    async def _status(conn, gid):
+        cur = await conn.execute(
+            "SELECT status FROM user_goals WHERE id = ?", (gid,),
+        )
+        return (await cur.fetchone())["status"]
+
+    async def test_pause_own_goal_direct_applies(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="og1", origin="genesis_ego")
+
+        await ego_session._process_own_goal_reviews([
+            {"goal_id": "og1", "recommendation": "pause", "assessment": "idle"},
+        ])
+
+        assert await self._status(goals_db, "og1") == "paused"
+        ego_session._proposals.create_batch.assert_not_awaited()
+        cur = await goals_db.execute(
+            "SELECT source FROM observations WHERE type = 'goal_autonomous_action'",
+        )
+        row = await cur.fetchone()
+        assert row is not None and row["source"] == "genesis_ego_cycle"
+
+    async def test_user_goal_is_skipped_not_proposed(self, ego_session, goals_db):
+        """This channel never converts into a user-facing proposal."""
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="ug1", origin="user")
+
+        await ego_session._process_own_goal_reviews([
+            {"goal_id": "ug1", "recommendation": "pause", "assessment": "x"},
+        ])
+
+        assert await self._status(goals_db, "ug1") == "active"
+        ego_session._proposals.create_batch.assert_not_awaited()
+
+    async def test_close_surfaces_observation_only(self, ego_session, goals_db):
+        ego_session._source_tag = "genesis_ego_cycle"
+        await self._insert_goal(goals_db, gid="og2", origin="genesis_ego")
+
+        await ego_session._process_own_goal_reviews([
+            {"goal_id": "og2", "recommendation": "close", "assessment": "done"},
+        ])
+
+        assert await self._status(goals_db, "og2") == "active"
+        ego_session._proposals.create_batch.assert_not_awaited()
+        cur = await goals_db.execute(
+            "SELECT source FROM observations WHERE type = 'goal_recommendation'",
+        )
+        row = await cur.fetchone()
+        assert row is not None and row["source"] == "genesis_ego_cycle"
+
+    async def test_source_tag_gate(self, ego_session, goals_db):
+        ego_session._source_tag = "user_ego_cycle"
+        await self._insert_goal(goals_db, gid="og3", origin="genesis_ego")
+
+        await ego_session._process_own_goal_reviews([
+            {"goal_id": "og3", "recommendation": "pause", "assessment": "x"},
+        ])
+
+        assert await self._status(goals_db, "og3") == "active"
+        ego_session._proposals.create_batch.assert_not_awaited()

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -1136,6 +1136,9 @@ class TestValidateOwnGoalKeys:
             {"title": "No category"},                      # dropped
             {"category": "project"},                       # dropped (no title)
             {"title": "Bad category", "category": "career-ops"},  # dropped
+            # valid USER-goal category, but a user-life lane — out of the
+            # ego's jurisdiction even for its own goals (Codex P2 #1094)
+            {"title": "Own career goal", "category": "career"},    # dropped
             "not a dict",                                  # dropped
         ]))
         cleaned = out["own_goal_creations"]

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -570,3 +570,13 @@ async def test_activity_summary_no_ego_goal_line_when_none(db, mock_health, mock
     gen = MorningReportGenerator(mock_health, db, mock_drafter)
     summary = await gen._get_activity_summary()
     assert "Genesis's own goals" not in summary
+
+
+def test_goal_autonomous_action_is_user_visible():
+    """Lock: autonomous goal actions surface through the generic morning-
+    report observation pipeline — adding the type to INTERNAL_OBS_TYPES
+    would silently remove the user's visibility into ego autonomy."""
+    from genesis.db.crud.observations import INTERNAL_OBS_TYPES
+
+    assert "goal_autonomous_action" not in INTERNAL_OBS_TYPES
+    assert "goal_recommendation" not in INTERNAL_OBS_TYPES


### PR DESCRIPTION
## What

The activation half of ego goal autonomy (completes the program: #1072 → #1075 → #1085 → #1086 → #1093 → this). Two new parsed output keys on the **genesis ego cycle**, both hard-gated on `source_tag == "genesis_ego_cycle"` in `_process_cycle_output`:

- **`own_goal_creations`** — THE trusted path stamping `origin='genesis_ego'` (the only code that does; the input is the cycle's own LLM output — single construction site, single caller under the cadence lock — never caller/tool input; the MCP surface still refuses an origin argument). Guards in order: structural sanitization in `_validate_output` (category/priority/goal_type enums mirroring the DB CHECKs, title ≤120, description ≤1000, `cadence_days` clamped 3–60, **`critical` reserved for the user's goals**), per-cycle cap **1**, global cap **`max_active_ego_goals` (config, default 5)** counted via unbounded `count_by_status`, and `find_similar` dedupe across **active+paused goals of both origins** (an own goal never shadow-duplicates a user goal; pausing doesn't reopen recreation). Every creation writes a `goal_autonomous_action` audit observation; drops are logged, never silent.
- **`own_goal_reviews`** — own-lane review verdicts. A non-`genesis_ego` goal id is skipped+logged, **never converted into a user-facing proposal** (user goals keep their existing goal_review pipeline). `pause`/`deprioritize` route through `_propose_goal_status_change` into the #1086 double-gated direct-apply; `continue` is a no-op; `close` stays a passive observation — terminal calls are the user's, for every goal.

Supporting pieces:
- **`genesis_context._own_goals_section`** — active+paused own goals with staleness annotations (per-goal `cadence_days`, else the goal-review default). This is what makes own-goal review non-blind (the genesis context builder ignores `focus_id`, so mirroring the user-ego cron/focus pipeline would have reviewed goals the model never saw — deliberately avoided). Output contract documents both keys.
- **`GENESIS_EGO_SESSION.md`** grants the lane with additive-only framing, explicitly reconciled with the existing jurisdiction boundaries (infrastructure objectives only; user goals remain out of jurisdiction; the disabled in-cycle goal tools are named).
- **Visibility**: `goal_autonomous_action` observations surface via the morning report's generic unsurfaced-observation pipeline (user-visible by default); a lock-test now prevents the type from ever being reclassified internal. Plus the own-goals count line from #1093.
- `max_active_ego_goals` config field + validator.

## Invariants (unchanged)

Ego-proposal approval gate and autonomous-CLI approval gate untouched — the ego skips proposal *creation* only for its own additive artifacts. `origin` immutable, never caller input. User goals mechanically untouchable outside approved proposals; ego goals capped, deduped, audited, and user-visible.

## Testing

22 new tests: validation matrix (clamps, enum rejection, critical-reservation), creation gate/cap/dedupe matrix (incl. paused-frees-a-slot and never-shadow-a-user-goal), review matrix (direct-apply + audit, user-goal skip, close-is-observation, source gate), own-goals section rendering (staleness, paused, user-goal absence, contract keys), config validation, visibility lock. 242 tests green across the touched suites.

Ledger: follow-up aefeae35c23a (both halves complete at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)