### PR TITLE
feat(resilience): host-side zram swap — compressed-RAM-first tier (E-rest E3)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -371,7 +371,7 @@ radius) and the container-side Sentinel (CC-driven diagnosis/repair).
 ```yaml subsystem-map
 entry: guardian-sentinel
 modules: [guardian, sentinel]
-verified: 8bd0a52b 2026-07-15
+verified: 159698d4 2026-07-16
 ```
 
 - **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
@@ -409,6 +409,15 @@ verified: 8bd0a52b 2026-07-15
   self-heal for installs that advance via bare `git pull` and never re-run
   host-setup. Heals page INFO; failures page WARNING (24h throttle); kill
   switch `swap_reconcile_enabled: false`.
+- **Host zram swap** (`scripts/lib/host_swap.sh`, E-rest E3): a
+  compressed-RAM-first swap tier on the host VM — `zram-swap.service` at swap
+  priority 100, sized `min(MemTotal/2, 4GiB)` (`HOSTSWAP_CAP_GIB` override).
+  Applied by `install_guardian.sh` Step 9c (fresh) and the gateway `redeploy`
+  verb (existing installs retrofit on next update; output to stderr, never
+  fails a redeploy). Degrades to one-line skips (container vantage, no
+  zram.ko/zramctl, external zram, no sudo); durable opt-out = `sudo systemctl
+  mask zram-swap.service`. Completes the swap story `memory_resilience.sh`
+  leaves as a warning — see `docs/reference/memory-resilience.md`.
 - **sentinel/** is LIVE-wired but **shadow-only autonomy**: config mode
   `"live"` is NOT implemented (dispatcher warns + downgrades); every proposed
   action requires human approval. `InfrastructureMonitor` (call site 37, free

--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -61,7 +61,37 @@ remediation for the detected vantage — because the knob is never local:
   guardian config (an explicitly-false knob is otherwise reconciled back to
   true — swap-on is the install invariant).
 - **Bare metal / VM**: create a swapfile or LV sized to taste. Even a few
-  GiB turns the OOM cliff into a ramp.
+  GiB turns the OOM cliff into a ramp. **On guardian hosts this is now
+  mechanical** — see the zram layer below.
+
+## The zram layer (guardian hosts)
+
+`scripts/lib/host_swap.sh` gives guardian host VMs a **compressed-RAM-first
+swap tier**: a zram device at swap priority 100, so memory pressure compresses
+into fast RAM before touching disk swap (which stays as the lower-priority
+fallback). On a host with *no* swap at all, this closes the wedge-defect gap
+mechanically instead of leaving the warning above as the only output.
+
+- **Size**: `min(MemTotal/2, 4 GiB)` — zram-generator's own upstream default
+  formula, computed per machine at apply time (a 2 GiB VPS gets 1 GiB, big
+  hosts cap at 4 GiB). Override the cap with `HOSTSWAP_CAP_GIB`.
+- **Unit**: a self-contained root-level `zram-swap.service` (oneshot,
+  `RemainAfterExit`) written to `/etc/systemd/system/` — fixed `/dev/zram0`,
+  zstd compression with automatic fallback to the kernel default, no
+  genesis-path dependencies. Idempotent: an unchanged unit produces no
+  systemd churn; a RAM change re-renders it.
+- **Applied from**: `install_guardian.sh` Step 9c (fresh installs) and the
+  gateway `redeploy` verb (existing installs retrofit on their next update).
+- **Degrades to a one-line skip** when the machine can't or shouldn't:
+  not-systemd, container vantage (zram needs the real host kernel), no
+  `zramctl`/`zram.ko`, no non-interactive sudo, `HOSTSWAP_DISABLE=1`, an
+  external zram setup already active (never shadows zram-generator or an
+  operator's own device), or a masked unit.
+- **Opt out permanently**: `sudo systemctl mask zram-swap.service` — apply
+  skips masked units. Remove cleanly with
+  `sudo bash -c 'source scripts/lib/host_swap.sh && host_swap_remove'`.
+- The host-plane `swap_total_kb` fact (table above) picks the device up
+  automatically, and `_memres_swap_check` stops warning once it's active.
 
 ## How the body schema surfaces it
 

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -603,6 +603,23 @@ PYEOF
         systemctl --user restart genesis-guardian.timer 2>/dev/null || true
         _TIMER_STOPPED=0  # cleanly restarted — don't let the EXIT trap re-start
 
+        # Host zram swap retrofit (E3): existing installs only ever receive
+        # code via this verb — installer steps never re-run — so apply the
+        # swap layer here. Runs AFTER the success JSON (this verb's stdout is
+        # a parsed contract; all lib output goes to stderr), whole-block
+        # best-effort so it can NEVER fail a redeploy, [ -f ] guarded for
+        # transition-deploys from pre-E3 archives, and time-bounded
+        # (`systemctl enable --now` could block on a wedged device; a stalled
+        # redeploy SSH would stall update.sh — 60s is ~10x the observed apply
+        # time and the block is best-effort by contract). The lib itself
+        # degrades to a one-line skip on hosts that can't or shouldn't
+        # (container vantage, no zram.ko, external zram, masked unit).
+        if [ -f "$INSTALL_DIR/scripts/lib/host_swap.sh" ]; then
+            timeout 60 bash -c \
+                ". '$INSTALL_DIR/scripts/lib/host_swap.sh' && host_swap_apply" \
+                1>&2 || true
+        fi
+
         # Clean up backup on success
         rm -rf "$BACKUP_DIR"
         ;;

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -669,6 +669,17 @@ else
     echo "  SKIP  I/O tuning (no passwordless sudo). See config/99-container-host.conf"
 fi
 
+# ── Step 9c: Host zram swap (compressed-RAM-first tier) ─────────────────
+# Completes the swap story memory_resilience.sh leaves as a warning: creates
+# a modest zram device (min(MemTotal/2, 4GiB), priority 100 over disk swap)
+# via a self-contained system unit. The lib degrades to a one-line skip on
+# hosts that can't or shouldn't (no zram.ko, container vantage, external
+# zram already active, masked unit, no sudo). Opt out permanently with:
+# sudo systemctl mask zram-swap.service
+# shellcheck source=lib/host_swap.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/host_swap.sh"
+host_swap_apply
+
 # ── Step 10: Install gateway script ────────────────────────────────────
 
 echo ""

--- a/scripts/lib/host_swap.sh
+++ b/scripts/lib/host_swap.sh
@@ -1,0 +1,198 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# host_swap_apply — host-side zram swap: a compressed-RAM-first swap tier for
+# the machine the Guardian runs on. Completes the swap story that
+# memory_resilience.sh (#1059) deliberately left as a warning: that layer
+# VERIFIES swap and warns when a bare/VM host has none; this layer CREATES a
+# modest zram device so the warning has a mechanical answer. On hosts that
+# already have disk swap, zram layers ABOVE it (priority 100) so memory
+# pressure compresses into fast RAM before touching disk.
+#
+# Adaptive by design (no machine constants): device size is computed at apply
+# time as min(MemTotal/2, HOSTSWAP_CAP_GIB) — zram-generator's own upstream
+# default formula — so a 2 GiB VPS gets 1 GiB and a 64 GiB workstation caps at
+# 4 GiB. The systemd unit is self-contained (fixed /dev/zram0, no genesis-path
+# dependencies) and survives removal of the install dir.
+#
+# Degrades gracefully: not-systemd, container vantage (zram needs the real
+# host kernel), no zramctl/modinfo, foreign zram already active (never shadow
+# zram-generator or an operator's own setup), no usable sudo, an operator
+# opt-out (`sudo systemctl mask zram-swap.service`), or HOSTSWAP_DISABLE=1
+# each produce a one-line skip note and rc=0 — this must never abort
+# install_guardian.sh or the gateway redeploy verb under `set -e`.
+#
+# Sourced by scripts/install_guardian.sh (fresh installs, Step 9c) and by the
+# guardian-gateway.sh `redeploy` verb (existing installs retrofit on their
+# next update). Idempotent: an unchanged unit is left untouched and produces
+# no systemd churn.
+#
+# Test seams (defaults are the real system paths; pytest overrides these and
+# stubs sudo/systemctl/systemd-detect-virt/modinfo/zramctl on PATH):
+HOSTSWAP_ETC_ROOT="${HOSTSWAP_ETC_ROOT:-/etc}"
+HOSTSWAP_SYSTEMD_RUNTIME_DIR="${HOSTSWAP_SYSTEMD_RUNTIME_DIR:-/run/systemd/system}"
+HOSTSWAP_MEMINFO="${HOSTSWAP_MEMINFO:-/proc/meminfo}"
+HOSTSWAP_PROC_SWAPS="${HOSTSWAP_PROC_SWAPS:-/proc/swaps}"
+HOSTSWAP_CAP_GIB="${HOSTSWAP_CAP_GIB:-4}"
+
+_HOSTSWAP_UNIT_NAME="zram-swap.service"
+
+# _hostswap_size_mib — min(MemTotal/2, cap) in MiB, from /proc/meminfo.
+# Echoes the integer; echoes nothing when MemTotal is unreadable (caller skips).
+_hostswap_size_mib() {
+    local kb half_mib cap_mib
+    kb="$(awk '/^MemTotal:/ {print $2}' "$HOSTSWAP_MEMINFO" 2>/dev/null)" || kb=""
+    if [[ -z "$kb" || ! "$kb" =~ ^[0-9]+$ || "$kb" -eq 0 ]]; then
+        return 0
+    fi
+    half_mib=$(( kb / 1024 / 2 ))
+    cap_mib=$(( HOSTSWAP_CAP_GIB * 1024 ))
+    if (( half_mib > cap_mib )); then
+        echo "$cap_mib"
+    else
+        echo "$half_mib"
+    fi
+}
+
+# _hostswap_unit_content <size_mib> — render the self-contained unit.
+# Fixed /dev/zram0 (modprobe creates it by default) means NO command
+# substitution inside ExecStart — no systemd `$`-escaping hazard. The
+# early-exit keeps restarts idempotent (a second swapon would fail); the
+# --reset before configure clears any stale half-configured state; the
+# fallback chain drops --algorithm zstd on kernels without it.
+_hostswap_unit_content() {
+    local size_mib="$1"
+    printf '%s\n' \
+        '[Unit]' \
+        'Description=Genesis zram swap (compressed-RAM-first tier)' \
+        '# Installed by genesis scripts/lib/host_swap.sh — size = min(MemTotal/2, cap).' \
+        '# Opt out permanently with: sudo systemctl mask zram-swap.service' \
+        '' \
+        '[Service]' \
+        'Type=oneshot' \
+        'RemainAfterExit=yes' \
+        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; modprobe zram; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
+        "ExecStop=/bin/sh -c 'swapoff /dev/zram0 2>/dev/null; zramctl --reset /dev/zram0 2>/dev/null; true'" \
+        '' \
+        '[Install]' \
+        'WantedBy=multi-user.target'
+}
+
+# _hostswap_install_unit <content> — write-if-different via sudo. Sets
+# _HOSTSWAP_CHANGED=1 when it wrote (a variable, NOT stdout — mirroring
+# memory_resilience.sh: capturing stdout as the change flag would let any
+# future diagnostic echo masquerade as "changed" and churn systemd on
+# idempotent runs). A failed write WARNS instead of falling through to
+# "already in place". Never fails the caller.
+_hostswap_install_unit() {
+    local content="$1"
+    local path="$HOSTSWAP_ETC_ROOT/systemd/system/$_HOSTSWAP_UNIT_NAME"
+    if [[ "$(sudo cat "$path" 2>/dev/null)" == "$content" ]]; then
+        return 0
+    fi
+    if ! sudo mkdir -p "$(dirname "$path")" 2>/dev/null \
+        || ! printf '%s\n' "$content" | sudo tee "$path" >/dev/null 2>&1; then
+        echo "  WARNING: could not write $path (read-only /etc?) — zram swap NOT installed."
+        _HOSTSWAP_FAILED=1
+        return 0
+    fi
+    _HOSTSWAP_CHANGED=1
+    return 0
+}
+
+# host_swap_apply — the entrypoint. Always returns 0.
+host_swap_apply() {
+    echo "--- Host zram swap (compressed-RAM-first tier) ---"
+
+    if [[ "${HOSTSWAP_DISABLE:-0}" == "1" ]]; then
+        echo "  Skipped: HOSTSWAP_DISABLE=1."
+        return 0
+    fi
+    if [[ ! -d "$HOSTSWAP_SYSTEMD_RUNTIME_DIR" ]]; then
+        echo "  Skipped: not a systemd system (no $HOSTSWAP_SYSTEMD_RUNTIME_DIR)."
+        return 0
+    fi
+    if systemd-detect-virt --container >/dev/null 2>&1; then
+        echo "  Skipped: container vantage — zram needs the real host kernel (configure swap on the host)."
+        return 0
+    fi
+    if ! command -v zramctl >/dev/null 2>&1; then
+        echo "  Skipped: zramctl not available (util-linux)."
+        return 0
+    fi
+    if ! modinfo zram >/dev/null 2>&1; then
+        echo "  Skipped: zram kernel module not available on this kernel."
+        return 0
+    fi
+    local unit_path="$HOSTSWAP_ETC_ROOT/systemd/system/$_HOSTSWAP_UNIT_NAME"
+    # Never shadow an EXTERNAL zram setup (zram-generator, Fedora defaults,
+    # an operator's own unit): zram swap already active but OUR unit was
+    # never installed → leave it alone.
+    if grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null \
+        && [[ ! -f "$unit_path" ]]; then
+        echo "  Skipped: external zram swap already active — not shadowing it."
+        return 0
+    fi
+    if ! sudo -n true 2>/dev/null; then
+        echo "  Skipped: sudo unavailable non-interactively. To apply manually:"
+        echo "           sudo bash -c 'source scripts/lib/host_swap.sh && host_swap_apply'"
+        return 0
+    fi
+    # Operator opt-out: a masked unit means "leave my swap alone", durably.
+    if [[ "$(systemctl is-enabled "$_HOSTSWAP_UNIT_NAME" 2>/dev/null)" == "masked" ]]; then
+        echo "  Skipped: $_HOSTSWAP_UNIT_NAME is masked (operator opt-out). Unmask to re-enable."
+        return 0
+    fi
+
+    local size_mib
+    size_mib="$(_hostswap_size_mib)"
+    if [[ -z "$size_mib" ]]; then
+        echo "  WARNING: cannot read MemTotal from $HOSTSWAP_MEMINFO — zram swap NOT installed."
+        return 0
+    fi
+
+    _HOSTSWAP_CHANGED=""
+    _HOSTSWAP_FAILED=""
+    _hostswap_install_unit "$(_hostswap_unit_content "$size_mib")"
+
+    if [[ -n "$_HOSTSWAP_FAILED" ]]; then
+        return 0
+    fi
+    if [[ -n "$_HOSTSWAP_CHANGED" ]]; then
+        # Best-effort: a hiccup here must never abort the caller — the unit is
+        # on disk and the next boot applies it regardless.
+        sudo systemctl daemon-reload 2>/dev/null || true
+        sudo systemctl enable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+        echo "  + zram swap unit installed (size ${size_mib}MiB, priority 100)."
+    else
+        echo "  zram swap unit already in place (size ${size_mib}MiB)."
+    fi
+
+    # Verify the OUTCOME, not just the unit state: is a zram device actually
+    # swapping? (oneshot ExecStart runs synchronously under enable --now.)
+    if grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null; then
+        echo "  + zram swap active: $(grep '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null | awk '{print $1, "prio", $5}' | head -1)"
+    else
+        echo "  WARNING: zram swap not (yet) active — check: systemctl status $_HOSTSWAP_UNIT_NAME"
+    fi
+    return 0
+}
+
+# host_swap_remove — the clean opt-out / rollback path (operator-invoked):
+#   sudo is required; removes the device, the unit, and reloads systemd.
+# Pair with `sudo systemctl mask zram-swap.service` to prevent re-apply on
+# the next update. Always returns 0.
+host_swap_remove() {
+    echo "--- Removing host zram swap ---"
+    if ! sudo -n true 2>/dev/null; then
+        echo "  Skipped: sudo unavailable non-interactively."
+        return 0
+    fi
+    sudo systemctl disable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+    sudo swapoff /dev/zram0 2>/dev/null || true
+    sudo zramctl --reset /dev/zram0 2>/dev/null || true
+    sudo rm -f "$HOSTSWAP_ETC_ROOT/systemd/system/$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+    sudo systemctl daemon-reload 2>/dev/null || true
+    echo "  + zram swap removed (mask the unit to prevent re-apply on update)."
+    return 0
+}

--- a/scripts/lib/host_swap.sh
+++ b/scripts/lib/host_swap.sh
@@ -57,9 +57,12 @@ _hostswap_size_mib() {
 # _hostswap_unit_content <size_mib> — render the self-contained unit.
 # Fixed /dev/zram0 (modprobe creates it by default) means NO command
 # substitution inside ExecStart — no systemd `$`-escaping hazard. The
-# early-exit keeps restarts idempotent (a second swapon would fail); the
-# --reset before configure clears any stale half-configured state; the
-# fallback chain drops --algorithm zstd on kernels without it.
+# swaps early-exit keeps restarts idempotent (a second swapon would fail);
+# the mounts guard refuses to touch a zram0 that carries someone's
+# FILESYSTEM (a zram-backed mount never shows in /proc/swaps — resetting it
+# would destroy data); the --reset before configure clears any stale
+# half-configured state; the fallback chain drops --algorithm zstd on
+# kernels without it.
 _hostswap_unit_content() {
     local size_mib="$1"
     printf '%s\n' \
@@ -71,7 +74,7 @@ _hostswap_unit_content() {
         '[Service]' \
         'Type=oneshot' \
         'RemainAfterExit=yes' \
-        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; modprobe zram; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
+        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
         "ExecStop=/bin/sh -c 'swapoff /dev/zram0 2>/dev/null; zramctl --reset /dev/zram0 2>/dev/null; true'" \
         '' \
         '[Install]' \
@@ -125,13 +128,17 @@ host_swap_apply() {
         return 0
     fi
     local unit_path="$HOSTSWAP_ETC_ROOT/systemd/system/$_HOSTSWAP_UNIT_NAME"
-    # Never shadow an EXTERNAL zram setup (zram-generator, Fedora defaults,
-    # an operator's own unit): zram swap already active but OUR unit was
-    # never installed → leave it alone.
-    if grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null \
-        && [[ ! -f "$unit_path" ]]; then
-        echo "  Skipped: external zram swap already active — not shadowing it."
-        return 0
+    # Never shadow or DESTROY an external zram consumer (zram-generator,
+    # Fedora defaults, a zram-backed mount, an operator's own unit): any
+    # configured zram device — swap OR non-swap (a zram mount never appears
+    # in /proc/swaps, but our unit's reset would wipe it) — while OUR unit
+    # was never installed → leave it alone.
+    if [[ ! -f "$unit_path" ]]; then
+        if grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null \
+            || [[ -n "$(zramctl --noheadings 2>/dev/null || true)" ]]; then
+            echo "  Skipped: external zram device already configured — not touching it."
+            return 0
+        fi
     fi
     if ! sudo -n true 2>/dev/null; then
         echo "  Skipped: sudo unavailable non-interactively. To apply manually:"
@@ -164,6 +171,15 @@ host_swap_apply() {
         sudo systemctl daemon-reload 2>/dev/null || true
         sudo systemctl enable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
         echo "  + zram swap unit installed (size ${size_mib}MiB, priority 100)."
+    elif ! grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null; then
+        # Unchanged unit but no active zram swap: a previous enable failed, or
+        # an operator `disable`d without masking. The durable opt-out is MASK
+        # (guarded above) — a merely-disabled unit gets re-enabled, and a
+        # transient enable failure retries on the next apply instead of
+        # sticking forever. (No churn on healthy hosts: an active device
+        # skips this branch.)
+        sudo systemctl enable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+        echo "  zram swap unit already in place (size ${size_mib}MiB) — re-enabled (was inactive)."
     else
         echo "  zram swap unit already in place (size ${size_mib}MiB)."
     fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -195,7 +195,7 @@ _sync_deploy_targets() {
             # TimeoutStartSec) registers as drift and triggers a redeploy — the
             # archive below ships those units and the gateway's redeploy verb
             # copies them, but none of that fires unless the drift gate sees them.
-            GUARDIAN_PATHS="src/genesis/guardian src/genesis/util src/genesis/env.py src/genesis/observability src/genesis/db config/guardian-claude.md config/genesis-guardian.service config/genesis-guardian.timer config/genesis-guardian-watchman.service config/genesis-guardian-watchman.timer pyproject.toml scripts/install_guardian.sh scripts/guardian-gateway.sh"
+            GUARDIAN_PATHS="src/genesis/guardian src/genesis/util src/genesis/env.py src/genesis/observability src/genesis/db config/guardian-claude.md config/genesis-guardian.service config/genesis-guardian.timer config/genesis-guardian-watchman.service config/genesis-guardian-watchman.timer pyproject.toml scripts/install_guardian.sh scripts/guardian-gateway.sh scripts/lib/host_swap.sh"
             DEPLOY_HASH=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 
             # ── Read host state ONCE: deployed_commit + node/cc versions ──

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -45,6 +45,7 @@ class GuardianWatchdog:
         "src/genesis/observability", "src/genesis/db",
         "config/guardian-claude.md", "pyproject.toml",
         "scripts/install_guardian.sh", "scripts/guardian-gateway.sh",
+        "scripts/lib/host_swap.sh",
     ]
     DRIFT_ALERT_THRESHOLD = 3   # Consecutive drifted ticks before alerting
     CC_TOKEN_WARN_AGE_DAYS = 335  # warn ~30d before a 1-year setup-token expires

--- a/src/genesis/observability/snapshots/deploy_health.py
+++ b/src/genesis/observability/snapshots/deploy_health.py
@@ -70,6 +70,7 @@ GUARDIAN_HOST_PATHS = (
     "pyproject.toml",
     "scripts/install_guardian.sh",
     "scripts/guardian-gateway.sh",
+    "scripts/lib/host_swap.sh",
 )
 
 _HOST_STATE_FILE = "host_gateway_state.json"

--- a/tests/test_scripts/test_host_swap_sh.py
+++ b/tests/test_scripts/test_host_swap_sh.py
@@ -1,0 +1,380 @@
+"""Behavioral tests for host_swap_apply / host_swap_remove (scripts/lib/host_swap.sh).
+
+The functions are sourced from the REAL lib and driven under the callers' shell
+mode (``set -euo pipefail`` — install_guardian.sh and the gateway redeploy verb
+both run that way) with stubbed ``sudo``/``systemctl``/``systemd-detect-virt``/
+``modinfo``/``zramctl`` on PATH plus HOSTSWAP_* path-override seams. A
+``__DONE__`` sentinel printed after the call proves the function returned
+instead of tripping errexit — every degrade path here must never abort an
+install or a redeploy.
+
+systemctl invocations are appended to a ``SYSTEMCTL_LOG`` file (the
+test_memory_resilience.py idiom) so idempotency can assert "no systemd churn"
+rather than just "no error".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts" / "lib" / "host_swap.sh"
+INSTALL_GUARDIAN = REPO_ROOT / "scripts" / "install_guardian.sh"
+GATEWAY = REPO_ROOT / "scripts" / "guardian-gateway.sh"
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+WATCHDOG = REPO_ROOT / "src" / "genesis" / "guardian" / "watchdog.py"
+DEPLOY_HEALTH = REPO_ROOT / "src" / "genesis" / "observability" / "snapshots" / "deploy_health.py"
+
+_SUDO_PASSTHROUGH = """#!/bin/bash
+if [ "$1" = "-n" ]; then shift; fi
+exec "$@"
+"""
+
+# Passthrough except the privileged WRITE (tee) is refused.
+_SUDO_TEE_FAIL = """#!/bin/bash
+if [ "$1" = "-n" ]; then shift; fi
+if [ "$1" = "tee" ]; then exit 1; fi
+exec "$@"
+"""
+
+# sudo -n itself refused (no passwordless sudo).
+_SUDO_N_FAIL = """#!/bin/bash
+exit 1
+"""
+
+# systemctl stub: logs every invocation; `is-enabled` answers from env.
+_SYSTEMCTL = """#!/bin/bash
+echo "$@" >> "$SYSTEMCTL_LOG"
+if [ "$1" = "is-enabled" ]; then echo "${SYSTEMCTL_IS_ENABLED:-disabled}"; exit 0; fi
+exit 0
+"""
+
+# systemd-detect-virt: exit 1 = not a container (the default vantage).
+_DETECT_VIRT_HOST = """#!/bin/bash
+exit 1
+"""
+_DETECT_VIRT_CONTAINER = """#!/bin/bash
+exit 0
+"""
+
+_MODINFO_OK = """#!/bin/bash
+exit 0
+"""
+_MODINFO_FAIL = """#!/bin/bash
+exit 1
+"""
+
+_ZRAMCTL = """#!/bin/bash
+exit 0
+"""
+
+_MEMINFO_20G = "MemTotal:       20971520 kB\nMemFree:        1000000 kB\n"
+_MEMINFO_2G = "MemTotal:       2097152 kB\nMemFree:        100000 kB\n"
+
+
+def _sandbox(
+    tmp_path,
+    *,
+    sudo=_SUDO_PASSTHROUGH,
+    detect_virt=_DETECT_VIRT_HOST,
+    modinfo=_MODINFO_OK,
+    zramctl=_ZRAMCTL,
+    meminfo=_MEMINFO_20G,
+    swaps="",
+    systemd_dir=True,
+):
+    """Build the stub bin/ + fixture files; return the env dict."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    for name, body in [
+        ("sudo", sudo),
+        ("systemctl", _SYSTEMCTL),
+        ("systemd-detect-virt", detect_virt),
+        ("modinfo", modinfo),
+    ]:
+        p = bindir / name
+        p.write_text(body)
+        p.chmod(0o755)
+    if zramctl is not None:
+        p = bindir / "zramctl"
+        p.write_text(zramctl)
+        p.chmod(0o755)
+    (tmp_path / "meminfo").write_text(meminfo)
+    (tmp_path / "swaps").write_text("Filename Type Size Used Priority\n" + swaps)
+    if systemd_dir:
+        (tmp_path / "run-systemd").mkdir(exist_ok=True)
+    (tmp_path / "systemctl.log").touch()
+    return {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "HOSTSWAP_ETC_ROOT": str(tmp_path / "etc"),
+        "HOSTSWAP_SYSTEMD_RUNTIME_DIR": str(tmp_path / "run-systemd"),
+        "HOSTSWAP_MEMINFO": str(tmp_path / "meminfo"),
+        "HOSTSWAP_PROC_SWAPS": str(tmp_path / "swaps"),
+        "SYSTEMCTL_LOG": str(tmp_path / "systemctl.log"),
+    }
+
+
+def _run(env, fn="host_swap_apply", extra_env=None):
+    """Source the real lib and invoke under the callers' `set -euo pipefail`."""
+    if extra_env:
+        env = {**env, **extra_env}
+    script = f'set -euo pipefail; source "{LIB}"; {fn}; echo __DONE__'
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+
+
+def _unit(tmp_path) -> Path:
+    return tmp_path / "etc" / "systemd" / "system" / "zram-swap.service"
+
+
+def _log(tmp_path) -> str:
+    return (tmp_path / "systemctl.log").read_text()
+
+
+# ── size formula ────────────────────────────────────────────────────────────
+
+
+def test_size_capped_at_4gib_on_big_host(tmp_path):
+    env = _sandbox(tmp_path)  # 20 GiB host → half=10240 > cap=4096
+    res = _run(env, fn="_hostswap_size_mib")
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.splitlines()[0] == "4096"
+
+
+def test_size_half_ram_on_small_host(tmp_path):
+    env = _sandbox(tmp_path, meminfo=_MEMINFO_2G)  # 2 GiB host → 1024 MiB
+    res = _run(env, fn="_hostswap_size_mib")
+    assert res.stdout.splitlines()[0] == "1024"
+
+
+def test_size_cap_env_override(tmp_path):
+    env = _sandbox(tmp_path)  # 20 GiB host, cap raised to 8 GiB
+    res = _run(env, fn="_hostswap_size_mib", extra_env={"HOSTSWAP_CAP_GIB": "8"})
+    assert res.stdout.splitlines()[0] == "8192"
+
+
+# ── apply: fresh install ────────────────────────────────────────────────────
+
+
+def test_fresh_apply_installs_unit_and_enables(tmp_path):
+    env = _sandbox(tmp_path)
+    res = _run(env)
+    assert res.returncode == 0, res.stderr
+    assert "__DONE__" in res.stdout
+    unit = _unit(tmp_path)
+    assert unit.is_file()
+    content = unit.read_text()
+    # Size baked in from the formula; fixed device; zstd with fallback; prio 100.
+    assert "--size 4096MiB --algorithm zstd" in content
+    assert "|| { zramctl --reset /dev/zram0" in content  # fallback chain
+    assert "swapon -p 100 /dev/zram0" in content
+    assert "$" not in content  # NO command substitution → no systemd escaping
+    log = _log(tmp_path)
+    assert "daemon-reload" in log
+    assert "enable --now zram-swap.service" in log
+    assert "zram swap unit installed" in res.stdout
+
+
+def test_fresh_apply_warns_when_not_yet_active(tmp_path):
+    """Stubbed systemctl can't actually start swap → the outcome check WARNs."""
+    env = _sandbox(tmp_path)
+    res = _run(env)
+    assert "WARNING: zram swap not (yet) active" in res.stdout
+
+
+def test_verify_reports_active_device(tmp_path):
+    """Once /proc/swaps shows the device, re-apply reports it active."""
+    env = _sandbox(tmp_path)
+    _run(env)  # install the unit first (so the foreign-zram guard passes)
+    (tmp_path / "swaps").write_text(
+        "Filename Type Size Used Priority\n/dev/zram0 partition 4194304 0 100\n"
+    )
+    res = _run(env)
+    assert "zram swap active" in res.stdout
+    assert "prio 100" in res.stdout
+
+
+# ── apply: idempotency ──────────────────────────────────────────────────────
+
+
+def test_idempotent_rerun_no_systemd_churn(tmp_path):
+    env = _sandbox(tmp_path)
+    _run(env)
+    # Mutating verbs only — the read-only `is-enabled` mask-check runs per
+    # apply by design and must not count as churn.
+    def _churn():
+        return [
+            line
+            for line in _log(tmp_path).splitlines()
+            if "daemon-reload" in line or "enable --now" in line
+        ]
+
+    churn_before = _churn()
+    res = _run(env)
+    assert res.returncode == 0
+    assert "already in place" in res.stdout
+    assert _churn() == churn_before  # zero new reload/enable calls
+
+
+def test_ram_change_rerenders_unit(tmp_path):
+    """write-if-different: a different computed size rewrites the unit."""
+    env = _sandbox(tmp_path)
+    _run(env)
+    assert "--size 4096MiB" in _unit(tmp_path).read_text()
+    (tmp_path / "meminfo").write_text(_MEMINFO_2G)
+    res = _run(env)
+    assert "zram swap unit installed" in res.stdout  # changed → re-applied
+    assert "--size 1024MiB" in _unit(tmp_path).read_text()
+
+
+# ── degrade-to-skip guards (each must return 0 under errexit) ───────────────
+
+
+def test_skip_on_disable_env(tmp_path):
+    env = _sandbox(tmp_path)
+    res = _run(env, extra_env={"HOSTSWAP_DISABLE": "1"})
+    assert res.returncode == 0
+    assert "HOSTSWAP_DISABLE" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_without_systemd(tmp_path):
+    env = _sandbox(tmp_path, systemd_dir=False)
+    res = _run(env)
+    assert res.returncode == 0
+    assert "not a systemd system" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_in_container_vantage(tmp_path):
+    """Guardian stack running inside LXC/Docker → zram needs the host kernel."""
+    env = _sandbox(tmp_path, detect_virt=_DETECT_VIRT_CONTAINER)
+    res = _run(env)
+    assert res.returncode == 0
+    assert "container vantage" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_without_zramctl(tmp_path):
+    env = _sandbox(tmp_path, zramctl=None)
+    res = _run(env)
+    assert res.returncode == 0
+    assert "zramctl not available" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_without_zram_module(tmp_path):
+    env = _sandbox(tmp_path, modinfo=_MODINFO_FAIL)
+    res = _run(env)
+    assert res.returncode == 0
+    assert "kernel module not available" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_foreign_zram_not_shadowed(tmp_path):
+    """zram-generator / an operator's own zram is active and OUR unit was never
+    installed → leave their setup alone."""
+    env = _sandbox(tmp_path, swaps="/dev/zram0 partition 8388608 0 100\n")
+    res = _run(env)
+    assert res.returncode == 0
+    assert "external zram swap already active" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_without_sudo(tmp_path):
+    env = _sandbox(tmp_path, sudo=_SUDO_N_FAIL)
+    res = _run(env)
+    assert res.returncode == 0
+    assert "sudo unavailable" in res.stdout
+    assert "host_swap_apply" in res.stdout  # manual remedy line
+    assert not _unit(tmp_path).exists()
+
+
+def test_skip_when_masked(tmp_path):
+    """`sudo systemctl mask zram-swap.service` is the durable operator opt-out."""
+    env = _sandbox(tmp_path)
+    res = _run(env, extra_env={"SYSTEMCTL_IS_ENABLED": "masked"})
+    assert res.returncode == 0
+    assert "operator opt-out" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_warn_on_unreadable_meminfo(tmp_path):
+    env = _sandbox(tmp_path)
+    (tmp_path / "meminfo").write_text("garbage\n")
+    res = _run(env)
+    assert res.returncode == 0
+    assert "__DONE__" in res.stdout
+    assert "cannot read MemTotal" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_write_failure_warns_and_skips_systemd(tmp_path):
+    """A refused privileged write must warn loudly, not claim success."""
+    env = _sandbox(tmp_path, sudo=_SUDO_TEE_FAIL)
+    res = _run(env)
+    assert res.returncode == 0
+    assert "__DONE__" in res.stdout
+    assert "NOT installed" in res.stdout
+    log = _log(tmp_path)
+    assert "daemon-reload" not in log
+    assert "enable --now" not in log
+
+
+# ── remove ──────────────────────────────────────────────────────────────────
+
+
+def test_remove_cleans_up(tmp_path):
+    env = _sandbox(tmp_path)
+    _run(env)
+    assert _unit(tmp_path).is_file()
+    res = _run(env, fn="host_swap_remove")
+    assert res.returncode == 0
+    assert "__DONE__" in res.stdout
+    assert not _unit(tmp_path).exists()
+    assert "disable --now zram-swap.service" in _log(tmp_path)
+
+
+# ── parse + wiring ──────────────────────────────────────────────────────────
+
+
+def test_lib_parses_clean():
+    res = subprocess.run(["bash", "-n", str(LIB)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_install_guardian_parses_clean():
+    res = subprocess.run(["bash", "-n", str(INSTALL_GUARDIAN)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_gateway_parses_clean():
+    res = subprocess.run(["bash", "-n", str(GATEWAY)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_install_guardian_wires_the_lib():
+    """Fresh installs: install_guardian.sh must source AND call the lib."""
+    text = INSTALL_GUARDIAN.read_text()
+    assert 'lib/host_swap.sh"' in text
+    assert "host_swap_apply" in text
+
+
+def test_gateway_redeploy_wires_the_lib():
+    """Existing installs only ever receive code via the redeploy verb — it must
+    invoke the lib (output to stderr, best-effort) or retrofit never happens."""
+    text = GATEWAY.read_text()
+    assert "host_swap.sh" in text
+    assert "host_swap_apply" in text
+    # The verb's stdout is a parsed JSON contract — the block must redirect.
+    apply_line_idx = text.index("host_swap_apply")
+    window = text[apply_line_idx : apply_line_idx + 200]
+    assert "1>&2" in window or ">&2" in window
+
+
+def test_guardian_paths_include_the_lib_everywhere():
+    """A host_swap.sh-only change must trigger a redeploy: the trigger list and
+    both Python mirrors stay in lockstep."""
+    assert "scripts/lib/host_swap.sh" in UPDATE_SH.read_text()
+    assert "scripts/lib/host_swap.sh" in WATCHDOG.read_text()
+    assert "scripts/lib/host_swap.sh" in DEPLOY_HEALTH.read_text()

--- a/tests/test_scripts/test_host_swap_sh.py
+++ b/tests/test_scripts/test_host_swap_sh.py
@@ -168,6 +168,8 @@ def test_fresh_apply_installs_unit_and_enables(tmp_path):
     assert "--size 4096MiB --algorithm zstd" in content
     assert "|| { zramctl --reset /dev/zram0" in content  # fallback chain
     assert "swapon -p 100 /dev/zram0" in content
+    # P1 belt: never reset a zram0 carrying someone's filesystem.
+    assert 'grep -q \"^/dev/zram0 \" /proc/mounts && exit 1' in content
     assert "$" not in content  # NO command substitution → no systemd escaping
     log = _log(tmp_path)
     assert "daemon-reload" in log
@@ -200,6 +202,11 @@ def test_verify_reports_active_device(tmp_path):
 def test_idempotent_rerun_no_systemd_churn(tmp_path):
     env = _sandbox(tmp_path)
     _run(env)
+    # Simulate the unit having started the device (the real steady state) —
+    # the P2 retry-enable branch only fires when zram is INACTIVE.
+    (tmp_path / "swaps").write_text(
+        "Filename Type Size Used Priority\n/dev/zram0 partition 4194304 0 100\n"
+    )
     # Mutating verbs only — the read-only `is-enabled` mask-check runs per
     # apply by design and must not count as churn.
     def _churn():
@@ -277,8 +284,33 @@ def test_skip_foreign_zram_not_shadowed(tmp_path):
     env = _sandbox(tmp_path, swaps="/dev/zram0 partition 8388608 0 100\n")
     res = _run(env)
     assert res.returncode == 0
-    assert "external zram swap already active" in res.stdout
+    assert "external zram device already configured" in res.stdout
     assert not _unit(tmp_path).exists()
+
+
+def test_skip_foreign_nonswap_zram_not_destroyed(tmp_path):
+    """Codex P1: a zram-backed MOUNT never appears in /proc/swaps — the guard
+    must also see a configured device via zramctl, or the unit's reset would
+    destroy it."""
+    busy_zramctl = "#!/bin/bash\nif [ \"$1\" = \"--noheadings\" ]; then echo \"/dev/zram0 lzo-rle 512M\"; fi\nexit 0\n"
+    env = _sandbox(tmp_path, zramctl=busy_zramctl)  # swaps stays empty
+    res = _run(env)
+    assert res.returncode == 0
+    assert "external zram device already configured" in res.stdout
+    assert not _unit(tmp_path).exists()
+
+
+def test_unchanged_unit_inactive_retries_enable(tmp_path):
+    """Codex P2: an unchanged unit with NO active zram (failed first enable, or
+    an operator disable-without-mask) must retry enable --now — mask is the
+    only durable opt-out."""
+    env = _sandbox(tmp_path)
+    _run(env)  # install; stubbed systemctl never actually starts the device
+    enables_before = _log(tmp_path).count("enable --now")
+    res = _run(env)  # unchanged unit, swaps still empty → retry branch
+    assert res.returncode == 0
+    assert "re-enabled (was inactive)" in res.stdout
+    assert _log(tmp_path).count("enable --now") == enables_before + 1
 
 
 def test_skip_without_sudo(tmp_path):


### PR DESCRIPTION
## Summary

Completes the swap story `memory_resilience.sh` (#1059) deliberately leaves as a warning: that layer VERIFIES swap and warns when a bare/VM host has none; this layer CREATES a modest zram device so the warning has a mechanical answer. On hosts that already have disk swap, zram layers above it (swap priority 100) so memory pressure compresses into fast RAM before touching disk.

## What's in it

- **NEW `scripts/lib/host_swap.sh`** — `host_swap_apply` (always-rc-0 entrypoint with a degrade-to-skip ladder: not-systemd, container vantage via `systemd-detect-virt`, no `zramctl`/`zram.ko`, external zram already active — never shadows zram-generator or an operator's own setup, no non-interactive sudo, `HOSTSWAP_DISABLE=1`, masked unit = the durable operator opt-out) + `host_swap_remove` (clean rollback). Size = `min(MemTotal/2, 4 GiB)` — zram-generator's own upstream default formula, computed per machine at apply time so a 2 GiB VPS gets 1 GiB and big hosts cap at 4 GiB (`HOSTSWAP_CAP_GIB` override). Write-if-different unit install with the changed-flag-as-a-variable defense (mirroring `memory_resilience.sh`) → zero systemd churn on idempotent re-runs.
- **`zram-swap.service`** — self-contained root-level oneshot on a FIXED `/dev/zram0` (no command substitution → no systemd `$`-escaping hazard), zstd compression with automatic fallback to the kernel default, idempotent across restarts, `ExecStop` tears down cleanly. No genesis-path dependencies.
- **`install_guardian.sh` Step 9c** — fresh installs apply on install.
- **`guardian-gateway.sh` `redeploy` verb** — existing installs only ever receive code via this verb (installer steps never re-run), so it retrofits here: runs AFTER the success JSON with all output to stderr (the verb's stdout is a parsed contract), `[ -f ]`-guarded for transition-deploys from pre-E3 archives, timeout-bounded, whole-block best-effort — can never fail a redeploy.
- **GUARDIAN_PATHS lockstep ×3** (`update.sh`, `watchdog.py`, `deploy_health.py`) — a `host_swap.sh`-only change now triggers a redeploy, load-bearing since the gateway executes the lib.
- **Tests** — 25 sandboxed behavioral tests (stubbed `sudo`/`systemctl`/`systemd-detect-virt`/`modinfo`/`zramctl` on PATH, `SYSTEMCTL_LOG` churn assertions, `__DONE__` errexit sentinel proving no degrade path can abort an install or redeploy) + wiring tests pinning the installer hook, the gateway hook, and the three-path lockstep.
- **Docs** — `docs/reference/memory-resilience.md` zram-layer section; `docs/architecture/CURRENT.md` guardian entry + stamp.

## Design notes

- Every guard prints a one-line skip and returns 0 — portability-first for the public repo (hosts without zram.ko, without sudo, or that are themselves containers all degrade gracefully).
- The unit content is a fixed heredoc; the only parameter is a size integer computed host-side from `/proc/meminfo` — no new trust boundary through the redeploy path.

103 tests green across the blast radius (incl. the redeploy-verb sandbox suite, memory_resilience, container_swap, deploy_health, update-host-sync). `bash -n` clean on all four touched shell files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)