### PR TITLE
feat(awareness): infra protection posture check — an unprotected box now alerts

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -132,6 +132,17 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   server restarts more frequently than the interval, the job never
   fires. Use `CronTrigger` for anything longer than a few hours.
   Bit us with `user_model_evolution` (48h interval, daily restarts).
+- **Silent skips are banned (provision-or-surface).** A setup/resilience
+  feature that gracefully skips on a missing prerequisite (a package, a
+  host knob) must either PROVISION the prerequisite (bootstrap.sh /
+  host-setup.sh / a guardian reconciler) or register an effective-fact in
+  `infra_profile` that the awareness posture check
+  (`awareness/loop.py::_check_infra_protection_posture`) reads — so an
+  unprotected box raises a standing alert instead of staying silent. A
+  graceful skip with neither = a box that runs unprotected with zero
+  signal (a sibling install ran weeks without swap/systemd-oomd until a
+  memory spike wedged it, 2026-07). Guardrail:
+  `tests/test_awareness/test_infra_protection_posture.py`.
 - **Modules are NEVER subsystems.** A capability *module*
   (`src/genesis/modules/**`, an external pluggable capability — "hands,
   not brain", see `modules/base.py`) is not an internal Genesis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **An unprotected box now tells you.** If a memory-crash protection is
+  missing on your install — container swap disabled, systemd-oomd
+  pressure-kill not configured, no host swap, or the container's swap
+  allowance switched off — Genesis now raises a standing alert (dashboard +
+  morning report) naming what's missing and how to fix it, and clears it
+  automatically once the protection is restored. Previously a box that was
+  *always* unprotected produced no signal at all; only a *change* was
+  detected. If the infrastructure self-profile stops refreshing (>3 days
+  old), you get a distinct "posture unknown" alert instead of stale claims.
+
 ### Fixed
 
 - **Replying to Genesis without quote-replying now counts.** When Genesis

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -424,8 +424,21 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 3403599d 2026-07-16
+verified: 159698d4 2026-07-16
 ```
+
+- **Infra protection posture (2026-07-16)**: hourly
+  `_check_infra_protection_posture` reads the infra profile's effective facts
+  and raises one `high` `infrastructure_alert` when a memory-plane protection
+  is missing (container `memory.swap.max=0`, oomd pressure-kill off, host swap
+  absent, incus swap knob explicitly `"false"`) or the profile is stale (>3d =
+  refresh broken → distinct "posture UNKNOWN" alert). Only EXPLICIT defect
+  values alert — absent/`None` facts stay silent (no guardian plane, cgroup
+  v1, fresh install). One open row per source via `supersede_except_hash`;
+  auto-resolves on recovery. Completes the silent-skip closure: provision
+  (bootstrap, #1082) → reconcile (guardian, #1083) → alert (this). The
+  provision-or-surface convention: a resilience feature that skips on a
+  missing prereq must either provision it or register a fact this check reads.
 
 - **Git-health alerts self-heal, slot-scoped (2026-07-16)**: the per-tick cheap
   probe auto-resolves open `git_cheap` observations on pass; the daily deep

--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -74,6 +74,21 @@ flags unprotected installs:
 | `cgroup_memory_swap_max` | container | `"max"` (or an int) | `0` |
 | `oomd_user_slice_kill` | container | `true` | `false` |
 | `swap_total_kb` | host | > 0 | `0` |
+| `container_limits["limits.memory.swap"]` | host_virt | `"true"`/absent | `"false"` |
+
+**The posture alert (active signal).** Facts and annotations alone proved
+insufficient — `infra_profile` only emits `infrastructure_drift` on a fact
+*change*, so a box that was *always* unprotected produced no signal at all
+(observed live: a sibling install ran for weeks with swap disabled and no
+systemd-oomd until a memory spike wedged it). The awareness loop's hourly
+`_check_infra_protection_posture` (`awareness/loop.py`) closes that: any
+wedge-defect value in the table above raises one non-paging `high`
+`infrastructure_alert` (dashboard + morning report) naming the missing
+protections and their remediation, auto-resolving when the profile shows them
+restored. Only *explicit* defect values alert — absent/`None` facts stay
+silent (no guardian host plane, cgroup v1, fresh install), so partial installs
+never false-alarm. A profile older than 3 days raises a distinct
+"posture UNKNOWN — refresh broken" alert instead of asserting from dead facts.
 
 ## Notes
 

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -502,8 +502,15 @@ def _infra_missing_protections(profile: dict) -> list[str]:
     sections = profile.get("sections") or {}
 
     def _facts(plane: str) -> dict:
+        # Only a status=="ok" section is trusted: on a per-section collector
+        # failure _merge_section RETAINS the previous facts (status=error/
+        # unavailable) while still bumping the top-level collected_at, so
+        # without this gate the rules would assert posture from stale facts
+        # that the >3d staleness check cannot see (Codex P2, PR #1096).
         section = sections.get(plane)
-        facts = section.get("facts") if isinstance(section, dict) else None
+        if not isinstance(section, dict) or section.get("status") != "ok":
+            return {}
+        facts = section.get("facts")
         return facts if isinstance(facts, dict) else {}
 
     def _explicit_zero(value: object) -> bool:
@@ -532,6 +539,29 @@ def _infra_missing_protections(profile: dict) -> list[str]:
     if isinstance(limits, dict) and limits.get("limits.memory.swap") == "false":
         missing.append("container_swap_knob_off")
     return sorted(missing)
+
+
+_POSTURE_PLANES = ("memory", "host_system", "host_virt")
+
+
+def _infra_unverifiable_planes(profile: dict) -> list[str]:
+    """Posture planes whose section is present but NOT ok while carrying
+    retained (stale) facts — we previously knew something there and currently
+    cannot verify it, so an all-clear must be held. A not-ok section with
+    EMPTY facts (e.g. host planes on a guardian-less install, permanently
+    "unavailable") never contributed a rule and blocks nothing."""
+    sections = profile.get("sections") or {}
+    unverifiable: list[str] = []
+    for plane in _POSTURE_PLANES:
+        section = sections.get(plane)
+        if (
+            isinstance(section, dict)
+            and section.get("status") != "ok"
+            and isinstance(section.get("facts"), dict)
+            and section.get("facts")
+        ):
+            unverifiable.append(plane)
+    return unverifiable
 
 
 async def _check_infra_protection_posture(db) -> None:
@@ -569,7 +599,13 @@ async def _check_infra_protection_posture(db) -> None:
             )
         else:
             missing = _infra_missing_protections(profile)
+            unverifiable = _infra_unverifiable_planes(profile)
             if not missing:
+                if unverifiable:
+                    # A plane with retained-but-unverifiable facts: neither
+                    # alarm nor all-clear — hold the current state until the
+                    # section collector recovers.
+                    return
                 await _resolve_infra_protection_posture(db)
                 return
             key = ",".join(missing)
@@ -581,6 +617,11 @@ async def _check_infra_protection_posture(db) -> None:
                 f"wedge the container instead of being absorbed (2026-07 "
                 f"incident class)."
             )
+            if unverifiable:
+                content += (
+                    f" Additionally unverifiable (section collector failing, "
+                    f"facts retained but stale): {', '.join(unverifiable)}."
+                )
 
         now = time.monotonic()
         if (

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -31,6 +31,7 @@ from genesis.awareness.signals import SignalCollector, collect_all
 from genesis.awareness.types import Depth, TickResult
 from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 from genesis.db.crud import awareness_ticks, observations
+from genesis.infra_profile.store import load_profile
 from genesis.observability.events import GenesisEventBus
 from genesis.observability.types import Severity, Subsystem
 from genesis.resilience.state import CloudStatus
@@ -428,6 +429,222 @@ async def _resolve_user_model_staleness(db) -> None:
             logger.info("Auto-resolved %d user-model staleness alert(s)", resolved)
     except Exception:
         logger.debug("Failed to resolve user-model staleness alerts", exc_info=True)
+
+
+# Infra protection posture (silent-skip closure, Phase 3): a memory-plane
+# protection that is MISSING must raise a visible alert. infra_profile records
+# the effective facts but only emits infrastructure_drift on a fact-hash
+# CHANGE (diff.py) — a STABLE unprotected box produced no signal at all
+# (observed live: a sibling install ran for weeks with container swap disabled
+# and no systemd-oomd, silently, until a memory spike wedged it — the 2026-07
+# incident class). Rules read the profile's effective facts; only an EXPLICIT
+# defect value alerts — absent/None facts are silence (no guardian host plane,
+# cgroup v1, pre-first-refresh), never a false alarm on a public install.
+_INFRA_POSTURE_SOURCE = "infra_protection_posture_monitor"
+_INFRA_PROFILE_STALE_DAYS = 3.0  # refresh is boot + daily; >3d = refresh broken
+# Same-state re-alert bound; the atomic dedup + daily profile-refresh cadence
+# are the real guards, this only saves no-op writes (deploy-staleness idiom:
+# a CHANGED state bypasses the cooldown via the key comparison).
+_INFRA_POSTURE_COOLDOWN_S = 86400.0
+_INFRA_POSTURE_SUPERSEDED_NOTE = "superseded: protection posture changed"
+_last_infra_posture_alert_at: float = 0.0
+_last_infra_posture_key: str = ""
+
+# Human-readable defect + remediation per rule slug (alert content).
+_INFRA_POSTURE_DETAIL = {
+    "container_swap_disabled": (
+        "container cgroup memory.swap.max is 0 — memory spikes thrash in D-state "
+        "instead of spilling to swap (the 2026-07 wedge state). The host "
+        "guardian's swap reconciler normally heals this within a tick: check "
+        "guardian health on the host, or re-run scripts/host-setup.sh"
+    ),
+    "oomd_pressure_kill_off": (
+        "systemd-oomd pressure-kill is not enforced for user.slice — nothing "
+        "gracefully kills the memory hog before a hard OOM wedge. Re-run "
+        "scripts/bootstrap.sh (installs systemd-oomd and lays the user.slice "
+        "drop-in via lib/memory_resilience.sh)"
+    ),
+    "host_swap_absent": (
+        "the host has no swap — the container's swap allowance has nowhere to "
+        "spill, so it is protection on paper only. Add host swap "
+        "(scripts/host-setup.sh prints the swapfile recipe)"
+    ),
+    "container_swap_knob_off": (
+        "incus limits.memory.swap is explicitly false — swap stays disabled "
+        "across container restarts. On the host: incus config set <container> "
+        "limits.memory.swap true (scripts/host-setup.sh sets this; the host "
+        "guardian also reconciles it when healthy)"
+    ),
+}
+
+
+def _infra_profile_age_days(profile: dict) -> float | None:
+    """Age of the profile snapshot in days; None = missing/unparseable stamp."""
+    collected_at = profile.get("collected_at")
+    if not collected_at:
+        return None
+    try:
+        collected = datetime.fromisoformat(collected_at)
+    except (TypeError, ValueError):
+        return None
+    if collected.tzinfo is None:
+        collected = collected.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - collected).total_seconds() / 86400.0
+
+
+def _infra_missing_protections(profile: dict) -> list[str]:
+    """Evaluate the memory-plane protection rules against profile facts.
+
+    Only an EXPLICIT defect value counts — absent/None facts stay silent.
+    Tri-state contract for cgroup_memory_swap_max (collectors/container.py):
+    int 0 = the wedge state, "max"/nonzero int = healthy, None = unreadable
+    (cgroup v1). Returns sorted rule slugs (keys of _INFRA_POSTURE_DETAIL)."""
+    sections = profile.get("sections") or {}
+
+    def _facts(plane: str) -> dict:
+        section = sections.get(plane)
+        facts = section.get("facts") if isinstance(section, dict) else None
+        return facts if isinstance(facts, dict) else {}
+
+    def _explicit_zero(value: object) -> bool:
+        # bool is an int subclass (False == 0), so a malformed bool fact must
+        # never read as "explicitly zero".
+        return isinstance(value, int) and not isinstance(value, bool) and value == 0
+
+    missing: list[str] = []
+    memory = _facts("memory")
+    swap_max = memory.get("cgroup_memory_swap_max")
+    if _explicit_zero(swap_max):
+        missing.append("container_swap_disabled")
+    # Gated on a readable cgroup swap knob (a cgroup-v2 proxy): on v1 the
+    # pressure-kill policy cannot work, so False there is not actionable.
+    if swap_max is not None and memory.get("oomd_user_slice_kill") is False:
+        missing.append("oomd_pressure_kill_off")
+    # host_system comes from the guardian host plane; absent = no guardian =
+    # no signal. NOT memory.facts.swap_total — that reads 0 on a HEALTHY
+    # container (meminfo swap isn't virtualized; verified live 2026-07-16).
+    if _explicit_zero(_facts("host_system").get("swap_total_kb")):
+        missing.append("host_swap_absent")
+    # Persistent incus knob, visible container-side. Explicit "false" only —
+    # the incus default is true, so absent/unset is healthy. Covers installs
+    # WITHOUT a working guardian (the guardian reconciles this knob itself).
+    limits = _facts("host_virt").get("container_limits")
+    if isinstance(limits, dict) and limits.get("limits.memory.swap") == "false":
+        missing.append("container_swap_knob_off")
+    return sorted(missing)
+
+
+async def _check_infra_protection_posture(db) -> None:
+    """Alert when a memory-plane protection is missing or the profile is stale.
+
+    One 'high' infrastructure_alert (dashboard + morning report; the WS-2 M10
+    reconciler absorbs it into the durable open-set) describing the CURRENT
+    posture. Invariant: at most one open row for this source — a posture
+    change supersedes the previous row (same "exactly one active alert = the
+    current state" pattern as deploy staleness). A stale profile (>3d; refresh
+    is boot + daily) raises its own distinct alert INSTEAD of asserting
+    posture from dead facts. Auto-resolves when the profile is fresh and no
+    protection is missing. Best-effort; never raises into the tick."""
+    global _last_infra_posture_alert_at, _last_infra_posture_key
+    if db is None:
+        return
+    try:
+        profile = await asyncio.to_thread(load_profile)
+        if not profile:
+            return  # pre-first-refresh (fresh install) — nothing to assert
+        age_days = _infra_profile_age_days(profile)
+        if age_days is None:
+            return  # no usable collected_at stamp — cannot assert anything
+        collected_at = profile.get("collected_at")
+
+        if age_days > _INFRA_PROFILE_STALE_DAYS:
+            key = "profile_stale"
+            content = (
+                f"Infra protection posture is UNKNOWN — the infrastructure "
+                f"profile is stale (collected {collected_at}, {age_days:.1f}d "
+                f"ago; the refresh runs at boot + daily). The refresh pipeline "
+                f"is broken — check genesis-server logs for infra_profile "
+                f"refresh errors. Posture rules were skipped; any prior "
+                f"posture findings are unverifiable until a fresh profile lands."
+            )
+        else:
+            missing = _infra_missing_protections(profile)
+            if not missing:
+                await _resolve_infra_protection_posture(db)
+                return
+            key = ",".join(missing)
+            details = "; ".join(f"[{slug}] {_INFRA_POSTURE_DETAIL[slug]}" for slug in missing)
+            content = (
+                f"Memory-protection posture: {len(missing)} protection(s) "
+                f"missing on this install (profile collected {collected_at}): "
+                f"{details}. A missing protection means a memory spike can "
+                f"wedge the container instead of being absorbed (2026-07 "
+                f"incident class)."
+            )
+
+        now = time.monotonic()
+        if (
+            _last_infra_posture_alert_at
+            and now - _last_infra_posture_alert_at < _INFRA_POSTURE_COOLDOWN_S
+            and key == _last_infra_posture_key
+        ):
+            return
+        content_hash = hashlib.sha256(f"infra_posture:{key}".encode()).hexdigest()
+        # Keep exactly ONE active alert = the current state (deploy-staleness
+        # pattern): retire any other-state sibling — including a prior
+        # stale-profile row once fresh facts arrive, and vice versa.
+        await observations.supersede_except_hash(
+            db,
+            source=_INFRA_POSTURE_SOURCE,
+            type="infrastructure_alert",
+            keep_content_hash=content_hash,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=_INFRA_POSTURE_SUPERSEDED_NOTE,
+        )
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source=_INFRA_POSTURE_SOURCE,
+            type="infrastructure_alert",
+            content=content,
+            priority="high",
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        _last_infra_posture_alert_at = now
+        _last_infra_posture_key = key
+        if created is not None:
+            logger.warning("Infra protection posture alert: %s", key)
+    except Exception:
+        logger.debug("Failed infra protection posture check", exc_info=True)
+
+
+async def _resolve_infra_protection_posture(db) -> None:
+    """Resolve standing posture alerts once the profile is fresh and complete.
+
+    Unconditional (no in-memory guard) so it survives restart; a cheap no-op
+    when nothing matches. Clears the cooldown key so recovery → re-degradation
+    re-alerts promptly."""
+    global _last_infra_posture_alert_at, _last_infra_posture_key
+    if db is None:
+        return
+    try:
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source=_INFRA_POSTURE_SOURCE,
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=(
+                "auto-resolved: all memory-plane protections present and the profile is fresh"
+            ),
+        )
+        if resolved:
+            _last_infra_posture_alert_at = 0.0
+            _last_infra_posture_key = ""
+            logger.info("Auto-resolved %d infra protection posture alert(s)", resolved)
+    except Exception:
+        logger.debug("Failed to resolve infra posture alerts", exc_info=True)
 
 
 # Deploy staleness (WS-B): merged ≠ deployed. A bare git-merge between
@@ -1905,6 +2122,12 @@ class AwarenessLoop:
                     # stream means Genesis stopped updating its model of the user.
                     # Slow (14d) signal → hourly; self-resolves on a fresh delta.
                     await _check_user_model_staleness(self._db)
+                    # Infra protection posture (silent-skip closure, Phase 3) —
+                    # a stable-unprotected box must never be silent: a missing
+                    # memory-plane protection (or a stale profile) raises one
+                    # 'high' infrastructure_alert; self-resolves on recovery.
+                    # Facts change at most ~daily (profile refresh) → hourly.
+                    await _check_infra_protection_posture(self._db)
                 await _check_wal_health(self._db)
                 # WS-2 M10: persist the alert/incident open-set to alert_events.
                 # Every tick (5 min), not hourly — a short-lived alert that fires

--- a/tests/test_awareness/test_infra_protection_posture.py
+++ b/tests/test_awareness/test_infra_protection_posture.py
@@ -1,0 +1,349 @@
+"""Silent-skip closure Phase 3 — infra protection posture alarm.
+
+#1082 provisions systemd-oomd and #1083 reconciles the container swap knob,
+but a STABLE unprotected box still produced no signal anywhere (infra_profile
+only fires infrastructure_drift on a fact-hash CHANGE — observed live: a
+sibling install ran for weeks with swap disabled and no systemd-oomd until a
+memory spike wedged it). The posture check un-blinds that: missing memory-plane
+protections raise one non-paging 'high' infrastructure_alert that supersedes on
+posture change and auto-resolves on recovery; a stale profile (>3d) raises a
+distinct posture-UNKNOWN alert instead of asserting from dead facts.
+"""
+
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.awareness import loop as _loop
+from genesis.awareness.loop import (
+    _check_infra_protection_posture,
+    _infra_missing_protections,
+    _resolve_infra_protection_posture,
+)
+from genesis.db.schema._tables import TABLES
+
+SOURCE = "infra_protection_posture_monitor"
+
+
+async def _setup() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(TABLES["observations"])
+    await db.commit()
+    return db
+
+
+async def _alerts(db) -> list[dict]:
+    async with db.execute(
+        "SELECT id, priority, resolved, content, content_hash, resolution_notes "
+        "FROM observations WHERE source = ? AND type = 'infrastructure_alert'",
+        (SOURCE,),
+    ) as cur:
+        return [dict(r) for r in await cur.fetchall()]
+
+
+def _open(alerts: list[dict]) -> list[dict]:
+    return [a for a in alerts if a["resolved"] == 0]
+
+
+def _profile(
+    *,
+    swap_max: object = "max",
+    oomd: object = True,
+    host_swap_kb: object = 8_000_000,
+    knob: object = "true",
+    age_days: float = 0.0,
+    collected_at: object = "auto",
+) -> dict:
+    """Fabricate a profile in the real on-disk shape (sections.<plane>.facts)."""
+    if collected_at == "auto":
+        collected_at = (datetime.now(UTC) - timedelta(days=age_days)).isoformat()
+    profile: dict = {
+        "sections": {
+            "memory": {
+                "facts": {
+                    "cgroup_memory_swap_max": swap_max,
+                    "oomd_user_slice_kill": oomd,
+                    # meminfo swap is NOT virtualized: 0 here on a HEALTHY
+                    # container (verified live 2026-07-16) — the check must
+                    # never key on it.
+                    "swap_total": 0,
+                }
+            },
+            "host_system": {"facts": {"swap_total_kb": host_swap_kb}},
+            "host_virt": {"facts": {"container_limits": {"limits.memory.swap": knob}}},
+        }
+    }
+    if collected_at is not None:
+        profile["collected_at"] = collected_at
+    return profile
+
+
+def _use_profile(monkeypatch, profile: dict) -> None:
+    monkeypatch.setattr(_loop, "load_profile", lambda: profile)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    _loop._last_infra_posture_alert_at = 0.0
+    _loop._last_infra_posture_key = ""
+    yield
+    _loop._last_infra_posture_alert_at = 0.0
+    _loop._last_infra_posture_key = ""
+
+
+# ── rule semantics ──────────────────────────────────────────────────────────
+
+
+def test_all_defects_detected():
+    missing = _infra_missing_protections(
+        _profile(swap_max=0, oomd=False, host_swap_kb=0, knob="false")
+    )
+    assert missing == [
+        "container_swap_disabled",
+        "container_swap_knob_off",
+        "host_swap_absent",
+        "oomd_pressure_kill_off",
+    ]
+
+
+def test_healthy_profile_no_defects():
+    assert _infra_missing_protections(_profile()) == []
+
+
+def test_absent_facts_are_silent():
+    # No guardian host plane, no host_virt, empty memory facts — a public
+    # install missing optional planes must never false-alarm.
+    assert _infra_missing_protections({"sections": {"memory": {"facts": {}}}}) == []
+    assert _infra_missing_protections({}) == []
+
+
+def test_cgroup_v1_gates_oomd_rule():
+    # swap knob unreadable (None = cgroup v1) → oomd pressure-kill cannot work
+    # there, so oomd=False must not alert.
+    assert _infra_missing_protections(_profile(swap_max=None, oomd=False)) == []
+
+
+def test_bool_false_is_not_explicit_zero():
+    # bool is an int subclass (False == 0); a malformed bool fact must not
+    # read as "explicitly zero".
+    assert "container_swap_disabled" not in _infra_missing_protections(_profile(swap_max=False))
+    assert "host_swap_absent" not in _infra_missing_protections(_profile(host_swap_kb=False))
+
+
+def test_nonzero_swap_limit_is_healthy():
+    # A numeric limit is a SET limit, not the wedge state.
+    assert _infra_missing_protections(_profile(swap_max=1_073_741_824)) == []
+
+
+def test_absent_knob_is_healthy():
+    # incus default is true — only an explicit "false" alerts.
+    profile = _profile()
+    del profile["sections"]["host_virt"]["facts"]["container_limits"]
+    assert _infra_missing_protections(profile) == []
+
+
+# ── alert lifecycle ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unprotected_profile_raises_high_alert(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0, oomd=False))
+        await _check_infra_protection_posture(db)
+        alerts = await _alerts(db)
+        assert len(alerts) == 1
+        assert alerts[0]["priority"] == "high"  # non-paging by design
+        assert alerts[0]["resolved"] == 0
+        assert "container_swap_disabled" in alerts[0]["content"]
+        assert "oomd_pressure_kill_off" in alerts[0]["content"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_healthy_profile_is_silent(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile())
+        await _check_infra_protection_posture(db)
+        assert await _alerts(db) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_empty_profile_is_silent(monkeypatch):
+    # Pre-first-refresh (fresh install): load_profile() returns {}.
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, {})
+        await _check_infra_protection_posture(db)
+        assert await _alerts(db) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_missing_collected_at_is_silent(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0, collected_at=None))
+        await _check_infra_protection_posture(db)
+        assert await _alerts(db) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_stable_state_keeps_one_open_row(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0))
+        await _check_infra_protection_posture(db)
+        # Same state within the cooldown → early return.
+        await _check_infra_protection_posture(db)
+        # Same state past the cooldown (simulated by reset) → atomic dedup
+        # (source + content_hash + resolved=0) still keeps one row.
+        _loop._last_infra_posture_alert_at = 0.0
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_posture_change_supersedes_old_row(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0, oomd=False))
+        await _check_infra_protection_posture(db)
+        # oomd healed, swap still bad — a NEW key bypasses the cooldown and
+        # supersedes the old row: exactly one open row = the current state.
+        _use_profile(monkeypatch, _profile(swap_max=0))
+        await _check_infra_protection_posture(db)
+
+        alerts = await _alerts(db)
+        assert len(alerts) == 2
+        open_rows = _open(alerts)
+        assert len(open_rows) == 1
+        assert "oomd_pressure_kill_off" not in open_rows[0]["content"]
+        superseded = [a for a in alerts if a["resolved"] == 1]
+        assert superseded[0]["resolution_notes"] == _loop._INFRA_POSTURE_SUPERSEDED_NOTE
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_recovery_resolves_alert(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0))
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+
+        _use_profile(monkeypatch, _profile())
+        await _check_infra_protection_posture(db)
+        alerts = await _alerts(db)
+        assert all(a["resolved"] == 1 for a in alerts)
+        # Cooldown cleared → a re-degradation re-alerts promptly.
+        assert _loop._last_infra_posture_alert_at == 0.0
+        _use_profile(monkeypatch, _profile(swap_max=0))
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_profile_alerts_unknown_not_posture(monkeypatch):
+    db = await _setup()
+    try:
+        # Defect facts present, but the profile is 10 days old — the refresh
+        # pipeline is broken; posture must NOT be asserted from dead facts.
+        _use_profile(monkeypatch, _profile(swap_max=0, age_days=10))
+        await _check_infra_protection_posture(db)
+        alerts = await _alerts(db)
+        assert len(alerts) == 1
+        assert "UNKNOWN" in alerts[0]["content"]
+        assert "container_swap_disabled" not in alerts[0]["content"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_profile_supersedes_stale_alert(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(age_days=10))
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+
+        # A fresh, healthy profile lands → the stale-UNKNOWN row resolves.
+        _use_profile(monkeypatch, _profile())
+        await _check_infra_protection_posture(db)
+        assert _open(await _alerts(db)) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_none_db_and_resolve_are_noops():
+    await _check_infra_protection_posture(None)  # must not raise
+    await _resolve_infra_protection_posture(None)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_load_profile_error_never_raises(monkeypatch):
+    db = await _setup()
+    try:
+
+        def _boom():
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(_loop, "load_profile", _boom)
+        await _check_infra_protection_posture(db)  # must not raise into the tick
+        assert await _alerts(db) == []
+    finally:
+        await db.close()
+
+
+# ── coverage guardrails (provision-or-surface convention) ──────────────────
+
+
+def test_every_rule_slug_has_detail_text():
+    # The alert content is built via _INFRA_POSTURE_DETAIL[slug] — a rule slug
+    # without detail text would KeyError inside the (swallowed) check. Derive
+    # the producible set from the rules themselves.
+    producible = set(
+        _infra_missing_protections(_profile(swap_max=0, oomd=False, host_swap_kb=0, knob="false"))
+    )
+    assert producible == set(_loop._INFRA_POSTURE_DETAIL)
+
+
+def test_memory_resilience_facts_are_covered():
+    # Provision-or-surface: every memory-resilience effective-fact must be
+    # read by the posture rules, so a protection can't silently lose its
+    # surfacing signal in a refactor. (Adding a NEW protection fact requires
+    # extending both the rules and this list — that is the point.)
+    src = inspect.getsource(_infra_missing_protections)
+    for fact in (
+        "cgroup_memory_swap_max",
+        "oomd_user_slice_kill",
+        "swap_total_kb",
+        "limits.memory.swap",
+    ):
+        assert fact in src, f"posture rules no longer read {fact!r}"
+
+
+def test_check_is_wired_into_the_tick():
+    # Level-3 wiring proof: the check must have a live call site in the tick
+    # pipeline, not just exist as a function.
+    src = inspect.getsource(_loop)
+    assert "await _check_infra_protection_posture(self._db)" in src
+

--- a/tests/test_awareness/test_infra_protection_posture.py
+++ b/tests/test_awareness/test_infra_protection_posture.py
@@ -65,6 +65,7 @@ def _profile(
     profile: dict = {
         "sections": {
             "memory": {
+                "status": "ok",
                 "facts": {
                     "cgroup_memory_swap_max": swap_max,
                     "oomd_user_slice_kill": oomd,
@@ -72,10 +73,13 @@ def _profile(
                     # container (verified live 2026-07-16) — the check must
                     # never key on it.
                     "swap_total": 0,
-                }
+                },
             },
-            "host_system": {"facts": {"swap_total_kb": host_swap_kb}},
-            "host_virt": {"facts": {"container_limits": {"limits.memory.swap": knob}}},
+            "host_system": {"status": "ok", "facts": {"swap_total_kb": host_swap_kb}},
+            "host_virt": {
+                "status": "ok",
+                "facts": {"container_limits": {"limits.memory.swap": knob}},
+            },
         }
     }
     if collected_at is not None:
@@ -118,8 +122,23 @@ def test_healthy_profile_no_defects():
 def test_absent_facts_are_silent():
     # No guardian host plane, no host_virt, empty memory facts — a public
     # install missing optional planes must never false-alarm.
-    assert _infra_missing_protections({"sections": {"memory": {"facts": {}}}}) == []
+    assert (
+        _infra_missing_protections(
+            {"sections": {"memory": {"status": "ok", "facts": {}}}}
+        )
+        == []
+    )
     assert _infra_missing_protections({}) == []
+
+
+def test_not_ok_section_facts_are_ignored():
+    # Codex P2 (PR #1096): a per-section collector failure RETAINS the
+    # previous facts (status=error/unavailable) while the top-level
+    # collected_at still bumps — rules must never assert from those.
+    profile = _profile(swap_max=0, oomd=False, host_swap_kb=0, knob="false")
+    for plane in ("memory", "host_system", "host_virt"):
+        profile["sections"][plane]["status"] = "error"
+    assert _infra_missing_protections(profile) == []
 
 
 def test_cgroup_v1_gates_oomd_rule():
@@ -309,6 +328,65 @@ async def test_load_profile_error_never_raises(monkeypatch):
         monkeypatch.setattr(_loop, "load_profile", _boom)
         await _check_infra_protection_posture(db)  # must not raise into the tick
         assert await _alerts(db) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unverifiable_plane_holds_resolve(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0))
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+
+        # The memory collector starts failing: facts retained, status=error.
+        # We can neither verify the defect nor the recovery — the alert must
+        # HOLD (no false all-clear from stale facts), not resolve.
+        broken = _profile(swap_max=0)
+        broken["sections"]["memory"]["status"] = "error"
+        _use_profile(monkeypatch, broken)
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_empty_section_does_not_block_resolve(monkeypatch):
+    db = await _setup()
+    try:
+        _use_profile(monkeypatch, _profile(swap_max=0))
+        await _check_infra_protection_posture(db)
+        assert len(_open(await _alerts(db))) == 1
+
+        # Guardian-less install: host planes permanently "unavailable" with
+        # EMPTY facts. They never contributed a rule and must not hold a
+        # container-plane recovery hostage.
+        healed = _profile()
+        for plane in ("host_system", "host_virt"):
+            healed["sections"][plane]["status"] = "unavailable"
+            healed["sections"][plane]["facts"] = {}
+        _use_profile(monkeypatch, healed)
+        await _check_infra_protection_posture(db)
+        assert _open(await _alerts(db)) == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_alert_notes_unverifiable_planes(monkeypatch):
+    db = await _setup()
+    try:
+        # A real defect in an ok section still alerts even while another
+        # plane is unverifiable — and the content names the failing plane.
+        profile = _profile(swap_max=0)
+        profile["sections"]["host_system"]["status"] = "error"
+        _use_profile(monkeypatch, profile)
+        await _check_infra_protection_posture(db)
+        open_rows = _open(await _alerts(db))
+        assert len(open_rows) == 1
+        assert "host_system" in open_rows[0]["content"]
     finally:
         await db.close()
 


### PR DESCRIPTION
## What

Phase 3 of the silent-skip closure (provision #1082 → reconcile #1083 → **alert**, this PR): a new hourly awareness check, `_check_infra_protection_posture`, reads the infrastructure profile's effective facts and raises one non-paging `high` `infrastructure_alert` (dashboard + morning report; the WS-2 M10 reconciler absorbs it into the durable open-set) when a memory-plane protection is missing — and auto-resolves it when the protection is restored.

## Why

`infra_profile` records the facts but only emits `infrastructure_drift` on a fact-hash **change** — a box that was *always* unprotected produced no signal anywhere. Observed live: an install ran for weeks with container swap disabled and no systemd-oomd, silently, until a memory spike wedged it.

## Rules (memory plane v1; explicit defect values only — absent/None facts stay silent)

| Fact | Defect | Meaning |
|---|---|---|
| `memory.facts.cgroup_memory_swap_max` | `0` (int) | container swap disabled — the wedge state |
| `memory.facts.oomd_user_slice_kill` | `False` (gated on a readable swap knob = cgroup-v2 proxy) | oomd pressure-kill not enforced |
| `host_system.facts.swap_total_kb` | `0` | host has no swap to spill into |
| `host_virt.facts.container_limits["limits.memory.swap"]` | `"false"` (explicit only) | persistent knob off — covers guardian-less installs |

A profile older than 3 days (refresh is boot + daily) raises a distinct "posture UNKNOWN — refresh broken" alert instead of asserting posture from dead facts.

## Design

- Mirrors `_check_user_model_staleness` (emit idiom) + the deploy-staleness "exactly one active alert = the current state" pattern: `supersede_except_hash(keep=current)` before `create(skip_if_duplicate=True)` — a posture change retires the old row, the atomic dedup keeps a stable state at one row across concurrent loops.
- Never raises into the tick; keyed 24h cooldown only saves no-op writes (a CHANGED posture bypasses it).
- Network-plane posture deferred: `networkd_keep_configuration=False` is ambiguous on NetworkManager hosts — needs a `networkd_active` disambiguation fact first (follow-up filed).

## Tests

21 new tests: tri-state rule semantics (bool-footgun guard, cgroup-v1 oomd gate, absent-fact silence), full alert lifecycle (dedup, supersede-on-change, auto-resolve + cooldown clear, stale-UNKNOWN path, load-failure safety), and provision-or-surface guardrails (every rule slug has remediation text, every memory-resilience fact is read by the rules, the check is wired into the tick). Verified against the real on-disk profile shape: healthy profile → silent; fabricated defects → one high alert.

Ledger: 5fcef45c093342d08628d2415f2421a5

🤖 Generated with [Claude Code](https://claude.com/claude-code)