### PR TITLE
fix(outreach): register send-and-wait waiters before attaching delivery context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Answering Genesis's questions with a plain message now actually works.**
+  When Genesis asked something and waited for your answer (approvals,
+  provision prompts, send-and-wait questions), an internal ordering bug left
+  the waiting mechanism blind to where the question had been delivered — so
+  a plain (non-quote) reply never matched it. Your answer instead spawned an
+  unrelated conversation turn, and the question sat unanswered until it
+  timed out. The delivery context is now attached in the right order, plain
+  replies match the question they answer, and a tripwire warning fires if
+  this ordering ever regresses.
+
 - **Replying to Genesis without quote-replying now counts.** When Genesis
   asked you something on Telegram and you answered with a plain message
   (no quote-reply), your answer reached the waiting conversation but the

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -303,6 +303,13 @@ class OutreachPipeline:
         if result.status != OutreachStatus.DELIVERED or not result.delivery_id:
             return result, None
 
+        # Register BEFORE attaching context: set_context drops keys with no
+        # registered waiter, so the old order (context first, registration
+        # deferred to wait_for_reply) left every waiter on this path
+        # contextless — standalone replies were structurally unresolvable
+        # (observed live 2026-07-16; every reply degraded to
+        # implicit_activity).
+        self._reply_waiter.register(result.delivery_id)
         self._attach_waiter_context(result, result.delivery_id)
         reply = await self._reply_waiter.wait_for_reply(
             result.delivery_id, timeout_s=timeout_s,
@@ -318,7 +325,13 @@ class OutreachPipeline:
         thread_key = f"{result.chat_id}:{result.thread_id if result.thread_id is not None else 'dm'}"
         for key in keys:
             try:
-                self._reply_waiter.set_context(key, thread_key)
+                if not self._reply_waiter.set_context(key, thread_key):
+                    # Tripwire: a dropped context means an ordering bug —
+                    # the waiter must be registered before context attach.
+                    logger.warning(
+                        "set_context dropped for unregistered waiter %s — "
+                        "standalone replies will not resolve it", key,
+                    )
             except Exception:
                 logger.debug("set_context failed for %s", key, exc_info=True)
 
@@ -357,6 +370,12 @@ class OutreachPipeline:
         actual_key = waiter_key or result.delivery_id
         if waiter_key and result.delivery_id != waiter_key:
             self._reply_waiter.add_alias(result.delivery_id, waiter_key)
+        elif not waiter_key:
+            # No pre-registered button key: register the delivery_id NOW,
+            # before attaching context — same ordering trap as
+            # submit_and_wait (set_context silently drops unregistered
+            # keys, leaving the waiter ineligible for standalone replies).
+            self._reply_waiter.register(result.delivery_id)
         self._attach_waiter_context(result, actual_key, result.delivery_id)
 
         try:

--- a/src/genesis/outreach/reply_waiter.py
+++ b/src/genesis/outreach/reply_waiter.py
@@ -43,15 +43,22 @@ class ReplyWaiter:
         logger.info("Registered reply waiter for delivery %s", delivery_id)
         return future
 
-    def set_context(self, delivery_id: str, thread_key: str) -> None:
+    def set_context(self, delivery_id: str, thread_key: str) -> bool:
         """Attach the delivered message's "chat_id:thread_id" to a waiter.
 
         Called by the pipeline after delivery, when the destination is
         known. Waiters without a context are never eligible for
         standalone-text resolution (quote-reply and buttons still work).
+
+        Returns False when *delivery_id* has no registered waiter — the
+        context is DROPPED in that case, so callers must register first
+        (the silent drop is exactly the bug that left send-and-wait
+        waiters unresolvable by standalone replies).
         """
         if delivery_id in self._waiters:
             self._contexts[delivery_id] = thread_key
+            return True
+        return False
 
     def resolve(self, delivery_id: str, reply_text: str) -> bool:
         """Resolve a waiter with reply text. Returns True if waiter existed."""

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -760,3 +760,95 @@ async def test_voice_falls_back_to_full_text_without_voice_text(config, db, mock
 
     voice_channel.send_message.assert_called_once()
     assert voice_channel.send_message.call_args.args[1] == "Task completed: build a thing"
+
+
+# ── send-and-wait waiter ordering (context must attach to a REGISTERED waiter) ──
+#
+# Live failure 2026-07-16: submit_and_wait attached context before any waiter
+# existed (registration happened later, inside wait_for_reply). set_context
+# silently drops unregistered keys, so every waiter on this path was born
+# contextless and standalone replies could never resolve it — they all
+# degraded to implicit_activity. These tests drive the REAL ReplyWaiter
+# through both send-and-wait paths and assert a standalone reply arriving
+# mid-wait resolves the waiter.
+
+
+def _delivered_result():
+    from genesis.outreach.types import OutreachResult
+
+    return OutreachResult(
+        outreach_id="o-1", status=OutreachStatus.DELIVERED, channel="telegram",
+        message_content="hi", delivery_id="555", chat_id="-100123", thread_id=42,
+    )
+
+
+async def _resolve_when_pending(waiter, text, thread_key):
+    for _ in range(200):
+        if waiter.pending_count:
+            keys = waiter.resolve_scoped_pending(text, thread_key=thread_key)
+            if keys:
+                return keys
+        await asyncio.sleep(0.005)
+    return []
+
+
+@pytest.mark.asyncio
+async def test_submit_and_wait_standalone_reply_resolves(config):
+    from genesis.outreach.reply_waiter import ReplyWaiter
+
+    pipeline = OutreachPipeline.__new__(OutreachPipeline)
+    pipeline._reply_waiter = ReplyWaiter()
+    pipeline.submit = AsyncMock(return_value=_delivered_result())
+
+    task = asyncio.ensure_future(
+        pipeline.submit_and_wait(MagicMock(), timeout_s=5.0),
+    )
+    keys = await _resolve_when_pending(
+        pipeline._reply_waiter, "ok", "-100123:42",
+    )
+    assert keys == ["555"], "standalone reply did not resolve the waiter"
+    result, reply = await task
+    assert reply == "ok"
+    assert pipeline._reply_waiter.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_submit_raw_and_wait_no_key_standalone_reply_resolves(config):
+    from genesis.outreach.reply_waiter import ReplyWaiter
+
+    pipeline = OutreachPipeline.__new__(OutreachPipeline)
+    pipeline._reply_waiter = ReplyWaiter()
+    pipeline.submit_raw = AsyncMock(return_value=_delivered_result())
+
+    task = asyncio.ensure_future(
+        pipeline.submit_raw_and_wait("txt", MagicMock(), timeout_s=5.0),
+    )
+    keys = await _resolve_when_pending(
+        pipeline._reply_waiter, "approve", "-100123:42",
+    )
+    assert keys == ["555"]
+    result, reply = await task
+    assert reply == "approve"
+
+
+@pytest.mark.asyncio
+async def test_submit_raw_and_wait_with_key_still_resolves(config):
+    """The pre-registered button-key path keeps working (context on both
+    the uuid key and the delivery_id alias)."""
+    from genesis.outreach.reply_waiter import ReplyWaiter
+
+    pipeline = OutreachPipeline.__new__(OutreachPipeline)
+    pipeline._reply_waiter = ReplyWaiter()
+    pipeline.submit_raw = AsyncMock(return_value=_delivered_result())
+
+    task = asyncio.ensure_future(
+        pipeline.submit_raw_and_wait(
+            "txt", MagicMock(), timeout_s=5.0, waiter_key="uuid-1",
+        ),
+    )
+    keys = await _resolve_when_pending(
+        pipeline._reply_waiter, "go", "-100123:42",
+    )
+    assert set(keys) == {"uuid-1", "555"}
+    result, reply = await task
+    assert reply == "go"

--- a/tests/test_outreach/test_reply_waiter.py
+++ b/tests/test_outreach/test_reply_waiter.py
@@ -156,3 +156,13 @@ async def test_context_cleared_on_resolve_and_cancel():
     w.set_context("d2", "123:45")
     w.cancel("d2")
     assert "d2" not in w._contexts
+
+
+async def test_set_context_reports_unregistered_drop():
+    """set_context returns False (context DROPPED) for unregistered keys —
+    the silent version of this drop is the ordering bug that left
+    send-and-wait waiters unresolvable by standalone replies."""
+    w = ReplyWaiter()
+    assert w.set_context("ghost", "123:45") is False
+    w.register("d1")
+    assert w.set_context("d1", "123:45") is True


### PR DESCRIPTION
## Problem

`submit_and_wait` attached the delivered chat+topic context **before any waiter existed** — registration happened later, inside `wait_for_reply` — and `set_context` silently drops unregistered keys. Every waiter on this path was born contextless, making standalone (non-quote) replies structurally unresolvable. Same defect in `submit_raw_and_wait`'s no-`waiter_key` branch, which carries provision approvals (`rpc.py`) and the sentinel's text-only fallback.

Observed live during #1090's E2E: four standalone replies, each seconds after delivery, all degraded to `implicit_activity` — and each unresolved reply fell through to the conversation handler, spawning unrelated CC turns in the alerts topic. The #1090 write-back is wired correctly but was starved by this upstream ordering bug.

## Fix

- `submit_and_wait` and `submit_raw_and_wait` (no-key branch): **register the delivery_id waiter immediately after delivery, before context attach**. The pre-registered button-key branch was already correct and is unchanged.
- `set_context` now returns whether the context was recorded; `_attach_waiter_context` logs a WARNING tripwire on any dropped context — this class can never fail silently again.
- Regression tests drive the **real** `ReplyWaiter` through both paths: a standalone reply arriving mid-wait must resolve the waiter (plus button-key path via both keys).

## Verification

- 110 targeted tests green (`test_pipeline.py`, `test_reply_waiter.py`, `test_reply_waiter_alias.py`, `test_rpc.py`, `test_telegram_handlers_v2.py`); ruff clean.
- Post-deploy live E2E (combined with #1090): send-and-wait outreach → single standalone reply → `outreach_history` row gains `engagement_signal='user_reply'`.

Diagnosis credit: a concurrent session surfaced the ordering suspicion in the alerts channel; verified firsthand and fixed here per user direction (single-owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)