### PR TITLE
fix(resilience): zram unit — create the device via hot_add (Ubuntu 6.8 ships zero static devices)

### DIFF
--- a/scripts/lib/host_swap.sh
+++ b/scripts/lib/host_swap.sh
@@ -58,6 +58,9 @@ _hostswap_size_mib() {
 # Fixed /dev/zram0 (modprobe creates it by default) means NO command
 # substitution inside ExecStart — no systemd `$`-escaping hazard. The
 # swaps early-exit keeps restarts idempotent (a second swapon would fail);
+# the hot_add read creates the device when the module ships ZERO static
+# devices (Ubuntu 6.8 does — live-E2E finding 2026-07-16; reading
+# /sys/class/zram-control/hot_add allocates the lowest free device);
 # the mounts guard refuses to touch a zram0 that carries someone's
 # FILESYSTEM (a zram-backed mount never shows in /proc/swaps — resetting it
 # would destroy data); the --reset before configure clears any stale
@@ -74,7 +77,7 @@ _hostswap_unit_content() {
         '[Service]' \
         'Type=oneshot' \
         'RemainAfterExit=yes' \
-        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
+        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; test -b /dev/zram0 || cat /sys/class/zram-control/hot_add >/dev/null; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
         "ExecStop=/bin/sh -c 'swapoff /dev/zram0 2>/dev/null; zramctl --reset /dev/zram0 2>/dev/null; true'" \
         '' \
         '[Install]' \

--- a/tests/test_scripts/test_host_swap_sh.py
+++ b/tests/test_scripts/test_host_swap_sh.py
@@ -168,6 +168,9 @@ def test_fresh_apply_installs_unit_and_enables(tmp_path):
     assert "--size 4096MiB --algorithm zstd" in content
     assert "|| { zramctl --reset /dev/zram0" in content  # fallback chain
     assert "swapon -p 100 /dev/zram0" in content
+    # Ubuntu 6.8 ships the module with ZERO static devices (live-E2E finding):
+    # the hot_add read must create /dev/zram0 when modprobe alone doesn't.
+    assert "test -b /dev/zram0 || cat /sys/class/zram-control/hot_add" in content
     # P1 belt: never reset a zram0 carrying someone's filesystem.
     assert 'grep -q \"^/dev/zram0 \" /proc/mounts && exit 1' in content
     assert "$" not in content  # NO command substitution → no systemd escaping


### PR DESCRIPTION
## Summary

Live E2E of #1095 on a real host caught what no sandbox could: `modprobe zram` on Ubuntu's 6.8 kernel loads the module with **zero static devices** — `/dev/zram0` never appears and `zram-swap.service` failed with `zramctl: /dev/zram0: No such device`.

The universal API is `/sys/class/zram-control/hot_add`: **reading** it allocates the lowest free device. The unit's ExecStart now runs `test -b /dev/zram0 || cat /sys/class/zram-control/hot_add >/dev/null` after `modprobe` — preserving the fixed-device, no-command-substitution design (still no `$` anywhere in the unit).

Spike-proven on the live host: hot_add → zram0 created → **zstd accepted natively** → mkswap → swapon prio 100 → device active and swapping.

One-line unit-template change + content assertion; 27 tests green, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)