### PR TITLE
fix(entity): stop the entity_adjudication orphan bleed — gate enqueue off

### DIFF
--- a/src/genesis/db/crud/entities.py
+++ b/src/genesis/db/crud/entities.py
@@ -425,6 +425,15 @@ async def delete_entities_cascade(
     return {"entities": deleted, "mentions": mentions, "links": links}
 
 
+# Dormant until a consumer exists. `enqueue_adjudication` writes
+# `entity_adjudication` rows to `deferred_work_queue` for an "entity_maintenance
+# job" that was never built — so the rows were a pure producer-with-no-consumer
+# leak (263 orphans in ~6 days, 0 ever drained). Gated OFF to stop the bleed
+# (follow-up 9127e8ed); the enqueue machinery is preserved GROUNDWORK for the
+# adjudication drainer, which flips this True when it lands. Do NOT delete.
+_ADJUDICATION_ENQUEUE_ENABLED = False
+
+
 async def enqueue_adjudication(
     db: aiosqlite.Connection,
     *,
@@ -437,7 +446,13 @@ async def enqueue_adjudication(
     Inline INSERT rather than ``deferred_work.create`` — that helper
     commits unconditionally, which would break callers batching under
     ``_commit=False`` (extraction transaction discipline).
+
+    No-op while ``_ADJUDICATION_ENQUEUE_ENABLED`` is False (no drainer exists —
+    see the module-level note). The caller's entity create + AMBIGUOUS status
+    are unaffected; only the orphan queue row is skipped.
     """
+    if not _ADJUDICATION_ENQUEUE_ENABLED:
+        return
     now = datetime.now(UTC).isoformat()
     await db.execute(
         """INSERT INTO deferred_work_queue

--- a/tests/test_memory/test_entity_layer.py
+++ b/tests/test_memory/test_entity_layer.py
@@ -182,7 +182,32 @@ class TestRegistry:
         assert prov == "EXTRACTED"
 
     @pytest.mark.asyncio
-    async def test_fuzzy_creates_ambiguous_and_enqueues(self, db):
+    async def test_fuzzy_ambiguous_but_no_enqueue_while_gated(self, db):
+        """Gate OFF (default): a fuzzy match still creates the entity and
+        returns AMBIGUOUS, but writes NO adjudication row — the enqueue is a
+        no-op until a drainer exists (stop-the-bleed, follow-up 9127e8ed)."""
+        await entity_registry.resolve_entity(
+            db, name="GENesis-Voice", entity_type="repo", aliases=_NO_ALIASES,
+        )
+        eid, prov = await entity_registry.resolve_entity(
+            db, name="GENesis-Voices", entity_type="repo", aliases=_NO_ALIASES,
+        )
+        assert prov == "AMBIGUOUS"
+        # Entity was still created (the fuzzy pair exists, just un-adjudicated).
+        assert await entities_crud.get_entity(db, eid) is not None
+        rows = await db.execute_fetchall(
+            "SELECT work_type FROM deferred_work_queue "
+            "WHERE work_type = 'entity_adjudication'"
+        )
+        assert rows == []  # no orphan row
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_enqueues_when_gate_enabled(self, db, monkeypatch):
+        """The enqueue machinery is intact GROUNDWORK — flipping the gate on
+        (what the drainer/A will do) restores the adjudication row."""
+        monkeypatch.setattr(
+            entities_crud, "_ADJUDICATION_ENQUEUE_ENABLED", True,
+        )
         await entity_registry.resolve_entity(
             db, name="GENesis-Voice", entity_type="repo", aliases=_NO_ALIASES,
         )


### PR DESCRIPTION
## What

`enqueue_adjudication` (`db/crud/entities.py`) writes `entity_adjudication` rows to `deferred_work_queue` for an "entity_maintenance job" that **was never built**. Nothing anywhere claims `work_type='entity_adjudication'` — pure producer-with-no-consumer. Live count: **263 pending, 0 ever drained, oldest 6d, growing ~44/day**, and it now surfaces as dashboard clutter.

## Fix (stop the bleed)

Gate the enqueue behind `_ADJUDICATION_ENQUEUE_ENABLED` (default `False`). A fuzzy `norm_name` match still creates the entity and returns `AMBIGUOUS` — only the orphan queue row is skipped. The enqueue machinery is preserved as **GROUNDWORK**: the adjudication drainer (follow-up `9127e8ed`) flips the flag `True` when it lands. This is the root-cause fix for the *growth* — clearing alone would silently refill.

The 263 existing orphans are cleared one-time out-of-band post-deploy (a data-migration would wrongly re-delete pending rows once the drainer re-enables enqueue).

## Testing

`test_fuzzy_ambiguous_but_no_enqueue_while_gated` (AMBIGUOUS + entity created + no orphan row) and `test_fuzzy_enqueues_when_gate_enabled` (flag-on restores the row — locks the seam A will flip). Full `test_entity_layer.py` green (17).

Follow-up: `9127e8ed` (the drainer = the "A" that turns this back on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)