### PR TITLE
fix(resilience): zram unit — udevadm settle after hot_add (async node-creation race)

### DIFF
--- a/scripts/lib/host_swap.sh
+++ b/scripts/lib/host_swap.sh
@@ -60,7 +60,10 @@ _hostswap_size_mib() {
 # swaps early-exit keeps restarts idempotent (a second swapon would fail);
 # the hot_add read creates the device when the module ships ZERO static
 # devices (Ubuntu 6.8 does — live-E2E finding 2026-07-16; reading
-# /sys/class/zram-control/hot_add allocates the lowest free device);
+# /sys/class/zram-control/hot_add allocates the lowest free device, then
+# `udevadm settle` waits for udev to CREATE the /dev/zram0 node — hot_add is
+# async and back-to-back zramctl otherwise races the node into existence,
+# failing with "No such device" (live-E2E finding 2026-07-16));
 # the mounts guard refuses to touch a zram0 that carries someone's
 # FILESYSTEM (a zram-backed mount never shows in /proc/swaps — resetting it
 # would destroy data); the --reset before configure clears any stale
@@ -77,7 +80,7 @@ _hostswap_unit_content() {
         '[Service]' \
         'Type=oneshot' \
         'RemainAfterExit=yes' \
-        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; test -b /dev/zram0 || cat /sys/class/zram-control/hot_add >/dev/null; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
+        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; test -b /dev/zram0 || cat /sys/class/zram-control/hot_add >/dev/null; udevadm settle --timeout=10 2>/dev/null || true; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
         "ExecStop=/bin/sh -c 'swapoff /dev/zram0 2>/dev/null; zramctl --reset /dev/zram0 2>/dev/null; true'" \
         '' \
         '[Install]' \

--- a/tests/test_scripts/test_host_swap_sh.py
+++ b/tests/test_scripts/test_host_swap_sh.py
@@ -171,6 +171,8 @@ def test_fresh_apply_installs_unit_and_enables(tmp_path):
     # Ubuntu 6.8 ships the module with ZERO static devices (live-E2E finding):
     # the hot_add read must create /dev/zram0 when modprobe alone doesn't.
     assert "test -b /dev/zram0 || cat /sys/class/zram-control/hot_add" in content
+    # hot_add is async — udev must CREATE the node before zramctl touches it.
+    assert "udevadm settle" in content
     # P1 belt: never reset a zram0 carrying someone's filesystem.
     assert 'grep -q \"^/dev/zram0 \" /proc/mounts && exit 1' in content
     assert "$" not in content  # NO command substitution → no systemd escaping


### PR DESCRIPTION
## Summary

Second live-E2E finding on the real host, after the `hot_add` fix (#1098): `hot_add` allocates the zram device but udev creates the `/dev/zram0` **node** asynchronously. The unit's back-to-back `zramctl` raced ahead of node creation and failed with `zramctl: /dev/zram0: No such device` — the manual spike only passed because shell/network latency between commands masked the race.

`udevadm settle --timeout=10` between `hot_add` and `zramctl` makes node creation deterministic. **Proven live** on the host: settle → `zramctl … zstd` → `mkswap` → `swapon -p 100`, device active and swapping.

`udevadm` ships with systemd (no new dependency); the `test -b /dev/zram0` guard keeps `settle` a fast no-op on kernels that already have static devices.

One-line unit-template change + content assertion; 27 tests green, `bash -n` clean.

## Why two live hotfixes

This is exactly what live E2E is for: `modprobe`-device-count (#1098) and udev-node timing are host-kernel behaviors no sandbox stub can reproduce. Both surfaced only against the real 6.8 kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)