### PR TITLE
fix(security): outbound scanner catches modern API-key + GitHub token formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The outbound secret scanner now catches modern API-key formats.** Before
+  sending on external channels (email, chat), Genesis scans messages and
+  quarantines anything that looks like a leaked credential. Its API-key
+  patterns predated today's key formats, so newer shapes slipped through
+  unflagged — OpenAI project and service-account keys (`sk-proj-…`,
+  `sk-svcacct-…`, `sk-admin-…`), OpenRouter keys (`sk-or-…`), and underscored
+  key bodies. The patterns now cover the full modern `sk-*` family, GitHub
+  tokens (`ghp_…`/`gho_…`/`github_pat_…`) are recognized for the first time,
+  and benign look-alikes (hyphenated slugs such as "sk-learn-pipeline") stay
+  unflagged.
+
 - **Answering Genesis's questions with a plain message now actually works.**
   When Genesis asked something and waited for your answer (approvals,
   provision prompts, send-and-wait questions), an internal ordering bug left

--- a/src/genesis/security/output_scanner.py
+++ b/src/genesis/security/output_scanner.py
@@ -48,11 +48,14 @@ _OUTPUT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
         re.compile(r"\bgsk_[a-zA-Z0-9]{20,}\b"),
     ),
     (
-        # GitHub tokens: classic (ghp_/gho_/ghu_/ghs_/ghr_ + 36 base62) and
-        # fine-grained (github_pat_ + 82). The '_' separator after the prefix
-        # is GitHub's own anti-base64-collision design, so prose FP is ~0.
+        # GitHub tokens, constrained to the real token shapes (high-confidence
+        # contract): classic ghp_/gho_/ghu_/ghs_/ghr_ + 36 base62, and
+        # fine-grained github_pat_ + 82. Prefixes are the exact {p,o,u,s,r}
+        # set (not any gh[a-z]_) and lengths track the real bodies, so a
+        # non-token like "ghi_abcdef…" cannot false-positive. The '_'
+        # separator is GitHub's own anti-base64-collision design.
         "api_key_github",
-        re.compile(r"\b(?:gh[a-z]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"),
+        re.compile(r"\b(?:gh[posur]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{50,})\b"),
     ),
     (
         "credential_assignment",
@@ -119,7 +122,9 @@ def scan_outbound(content: str) -> ScanResult:
 
     logger.warning(
         "Outbound content scan: %s patterns detected (%s): %s",
-        risk_level, len(detected), detected,
+        risk_level,
+        len(detected),
+        detected,
     )
 
     return ScanResult(safe=False, detected=detected, risk_level=risk_level)

--- a/src/genesis/security/output_scanner.py
+++ b/src/genesis/security/output_scanner.py
@@ -28,16 +28,31 @@ class ScanResult:
 # leakage. Intentionally conservative to minimize false positives.
 _OUTPUT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
+        # Covers the whole modern sk-* family: legacy, sk-proj-, sk-svcacct-,
+        # sk-admin- (OpenAI) and sk-or- (OpenRouter). The charset includes
+        # '_' and '-' because current keys embed them; the shipped
+        # [a-zA-Z0-9] charset silently missed every hyphen/underscore key
+        # shape. Floor stays 20 (real keys are 40-165 chars) — a lower floor
+        # false-positives on benign hyphenated slugs like "sk-learn-pipeline".
         "api_key_openai",
-        re.compile(r"\bsk-[a-zA-Z0-9]{20,}\b"),
+        re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
     ),
     (
+        # Anthropic key bodies contain underscores — the shipped charset
+        # (no '_') could truncate a real key below the length floor.
         "api_key_anthropic",
-        re.compile(r"\bsk-ant-[a-zA-Z0-9\-]{20,}\b"),
+        re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b"),
     ),
     (
         "api_key_groq",
         re.compile(r"\bgsk_[a-zA-Z0-9]{20,}\b"),
+    ),
+    (
+        # GitHub tokens: classic (ghp_/gho_/ghu_/ghs_/ghr_ + 36 base62) and
+        # fine-grained (github_pat_ + 82). The '_' separator after the prefix
+        # is GitHub's own anti-base64-collision design, so prose FP is ~0.
+        "api_key_github",
+        re.compile(r"\b(?:gh[a-z]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"),
     ),
     (
         "credential_assignment",
@@ -73,12 +88,15 @@ _OUTPUT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 # Patterns that indicate critical leakage (immediate quarantine).
 # credential_assignment is intentionally NOT critical — it matches
 # natural prose ("secret to our approach:", "token expiry is 86400s").
-_CRITICAL_PATTERNS = frozenset({
-    "api_key_openai",
-    "api_key_anthropic",
-    "api_key_groq",
-    "env_variable_secret",
-})
+_CRITICAL_PATTERNS = frozenset(
+    {
+        "api_key_openai",
+        "api_key_anthropic",
+        "api_key_groq",
+        "api_key_github",
+        "env_variable_secret",
+    }
+)
 
 
 def scan_outbound(content: str) -> ScanResult:

--- a/tests/test_security/test_output_scanner.py
+++ b/tests/test_security/test_output_scanner.py
@@ -1,8 +1,11 @@
 """Tests for the output content scanner."""
 
+import pytest
+
 from genesis.security.output_scanner import scan_outbound
 
 # --- Safe content ---
+
 
 def test_safe_plain_text():
     result = scan_outbound("Thanks for your interest in Genesis! Check out the repo.")
@@ -27,6 +30,7 @@ def test_safe_public_url():
 
 # --- API key detection ---
 
+
 def test_detects_openai_key():
     result = scan_outbound("My key is sk-abc123def456ghi789jkl012mno")
     assert not result.safe
@@ -49,6 +53,7 @@ def test_detects_groq_key():
 
 # --- Credential patterns ---
 
+
 def test_detects_credential_assignment():
     result = scan_outbound("Set password=MyS3cretP@ssw0rd123 in config")
     assert not result.safe
@@ -64,8 +69,9 @@ def test_detects_env_variable():
 
 # --- IP addresses ---
 
+
 def test_detects_rfc1918_ip():
-    result = scan_outbound("Connect to 192.168.50.77 for the dashboard")
+    result = scan_outbound("Connect to 192.168.1.100 for the dashboard")
     assert not result.safe
     assert "rfc1918_ip" in result.detected
     assert result.risk_level == "medium"
@@ -78,6 +84,7 @@ def test_ignores_public_ip():
 
 
 # --- File paths ---
+
 
 def test_detects_internal_file_path():
     result = scan_outbound("The config is at ~/.genesis/config/genesis.yaml")
@@ -93,6 +100,7 @@ def test_detects_home_path():
 
 # --- Localhost ---
 
+
 def test_detects_localhost_port():
     result = scan_outbound("Qdrant runs on localhost:6333")
     assert not result.safe
@@ -101,11 +109,87 @@ def test_detects_localhost_port():
 
 # --- Multiple patterns ---
 
+
 def test_multiple_patterns_detected():
     result = scan_outbound(
-        "Connect to 192.168.50.77 and use sk-ant-api03-testkey123456789xyz "
+        "Connect to 192.168.1.100 and use sk-ant-api03-testkey123456789xyz "
         "with password=admin123456"
     )
     assert not result.safe
     assert len(result.detected) >= 3
     assert result.risk_level == "high"
+
+
+# --- Modern key shapes the shipped [a-zA-Z0-9]{20,} charset MISSED ---
+# Regression guard: every one of these returned safe=True before the fix
+# because the prefix embeds '-'/'_' that the old charset excluded.
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "sk-proj-abc_defGHI-jklMNO123456789xyz",  # pragma: allowlist secret
+        "sk-svcacct-abcDEF123456_ghiJKL789mno",  # pragma: allowlist secret
+        "sk-admin-abcDEF123456789ghiJKL0mnop",  # pragma: allowlist secret
+        "sk-or-v1-0123456789abcdef0123456789abcdef",  # pragma: allowlist secret
+        "sk-test_abc123XYZ7890defghijk",  # pragma: allowlist secret
+    ],
+)
+def test_detects_modern_openai_family(key):
+    result = scan_outbound(f"here it is: {key}")
+    assert not result.safe
+    assert "api_key_openai" in result.detected
+    assert result.risk_level == "high"
+
+
+def test_detects_anthropic_key_with_underscore():
+    # Real Anthropic key bodies contain underscores — the old charset stopped
+    # at the first '_' and could truncate below the length floor.
+    key = "sk-ant-api03-abc_def-ghijklmnopqrstuvwxyz012345"  # pragma: allowlist secret
+    result = scan_outbound(f"key: {key}")
+    assert not result.safe
+    assert "api_key_anthropic" in result.detected
+    assert result.risk_level == "high"
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "ghp_abcdefghijklmnopqrstuvwxyz0123456789",  # pragma: allowlist secret
+        "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",  # pragma: allowlist secret
+        "ghs_0123456789abcdefghijklmnopqrstuvwxyz",  # pragma: allowlist secret
+        "ghu_abcdEFGH1234567890ijklMNOP567890qrst",  # pragma: allowlist secret
+        "github_pat_ABCdef012345_abcdefghijklmnopqrstuvwxyz012",  # pragma: allowlist secret
+    ],
+)
+def test_detects_github_tokens(token):
+    result = scan_outbound(f"token = {token}")
+    assert not result.safe
+    assert "api_key_github" in result.detected
+    assert result.risk_level == "high"
+
+
+# --- False-positive guardrails ---
+# Benign strings that superficially resemble a key prefix. A permissive
+# charset with too low a length floor flags these; the shipped floor of 20
+# (real keys are 40-165 chars) keeps them safe. Each was verified against
+# the candidate regexes before the fix landed.
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a risk-averse mindset pays off",
+        "let's have a desk-side chat about it",
+        "the SK-1024 model is deprecated",
+        "join the ask-me-anything session",
+        "see the sk-learn-pipeline notes",
+        "the sk-marketing-plan-q3 launch is set",
+        "query the ghi_data_warehouse_table_name view",
+        "ugh_oh that was a rough deploy",
+    ],
+)
+def test_benign_lookalikes_not_flagged(text):
+    result = scan_outbound(text)
+    assert result.safe is True
+    assert result.detected == []

--- a/tests/test_security/test_output_scanner.py
+++ b/tests/test_security/test_output_scanner.py
@@ -159,7 +159,9 @@ def test_detects_anthropic_key_with_underscore():
         "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",  # pragma: allowlist secret
         "ghs_0123456789abcdefghijklmnopqrstuvwxyz",  # pragma: allowlist secret
         "ghu_abcdEFGH1234567890ijklMNOP567890qrst",  # pragma: allowlist secret
-        "github_pat_ABCdef012345_abcdefghijklmnopqrstuvwxyz012",  # pragma: allowlist secret
+        "ghr_zyxwvutsrqponmlkjihgfedcba9876543210",  # pragma: allowlist secret
+        # fine-grained: github_pat_ + 22 + '_' + 59 (realistic 82-char body)
+        "github_pat_11ABCDEFGH0123456789AB_cdefghijklmnopqrstuvwxyz0123456789ABCDEFG",  # pragma: allowlist secret
     ],
 )
 def test_detects_github_tokens(token):
@@ -170,10 +172,11 @@ def test_detects_github_tokens(token):
 
 
 # --- False-positive guardrails ---
-# Benign strings that superficially resemble a key prefix. A permissive
-# charset with too low a length floor flags these; the shipped floor of 20
-# (real keys are 40-165 chars) keeps them safe. Each was verified against
-# the candidate regexes before the fix landed.
+# Benign strings that superficially resemble a key prefix. The length floors
+# (sk-* keeps 20; GitHub tracks the real 36/82 bodies) and the exact GitHub
+# prefix set keep these safe — real keys are far longer. The ghi_/short-ghp_
+# cases guard the specific false positive Codex flagged (a non-token
+# gh[a-z]_ prefix or a too-short body must not quarantine).
 
 
 @pytest.mark.parametrize(
@@ -187,6 +190,8 @@ def test_detects_github_tokens(token):
         "the sk-marketing-plan-q3 launch is set",
         "query the ghi_data_warehouse_table_name view",
         "ugh_oh that was a rough deploy",
+        "the ghi_abcdefghijklmnopqrstuv identifier",  # not a real gh prefix
+        "commit ghp_abc123 is too short to be a token",
     ],
 )
 def test_benign_lookalikes_not_flagged(text):


### PR DESCRIPTION
## What
The outbound secret scanner (`scan_outbound` — the sole PII/secret gate on external-delivery channels via `content/egress.py:gate`) missed every modern API-key shape. Its `api_key_openai` pattern `\bsk-[a-zA-Z0-9]{20,}\b` required 20+ **alphanumeric** chars after `sk-`, so keys embedding `-`/`_` slipped through unquarantined — OpenAI `sk-proj-`/`sk-svcacct-`/`sk-admin-`, OpenRouter `sk-or-`, and underscored/test keys. GitHub tokens weren't covered at all.

## Changes (`src/genesis/security/output_scanner.py`)
- **`api_key_openai`**: charset → `[A-Za-z0-9_-]`; floor stays **20** — empirically the zero-FP sweet spot (a lower floor false-positives on benign hyphenated slugs like `sk-learn-pipeline`). One rule now covers the whole modern `sk-*` family (incl. OpenRouter).
- **`api_key_anthropic`**: add `_` to the charset (real key bodies contain underscores).
- **New `api_key_github`** (critical): classic `gh[a-z]_` tokens + fine-grained `github_pat_`. The underscore-after-prefix is GitHub's own anti-base64-collision design, so prose false-positives are ~0.
- **Tests**: modern-shape regression guards (every previously-missed family), GitHub-token detection, and false-positive guardrails for benign look-alikes. Also scrubs a stray LAN IP from the existing rfc1918 fixtures to a generic RFC1918 example.

## Verification
- **68 targeted tests green** (scanner + egress + antislop).
- **Before/after E2E**: shipped code returns `safe=True` for `sk-test_`/`sk-proj-`/`ghp_` keys (the bug); the fix quarantines all three.
- **Regex safety**: single char-class repeats + non-overlapping alternation → linear time, no ReDoS (43ms on a 100k adversarial string).

Design was decided empirically (regex bench against 14 real key shapes vs 11 benign strings), not by reasoning — an initial floor-6 draft was rejected for false-positiving on hyphenated slugs. Closes the egress-guard gap found by the 2026-07 PII-scrubber benchmark (follow-up `83e8db57`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)