### PR TITLE
fix(resilience): zram unit — always-fresh device + restart-to-apply (3 live-E2E findings)

### DIFF
--- a/scripts/lib/host_swap.sh
+++ b/scripts/lib/host_swap.sh
@@ -55,20 +55,23 @@ _hostswap_size_mib() {
 }
 
 # _hostswap_unit_content <size_mib> — render the self-contained unit.
-# Fixed /dev/zram0 (modprobe creates it by default) means NO command
-# substitution inside ExecStart — no systemd `$`-escaping hazard. The
-# swaps early-exit keeps restarts idempotent (a second swapon would fail);
-# the hot_add read creates the device when the module ships ZERO static
-# devices (Ubuntu 6.8 does — live-E2E finding 2026-07-16; reading
-# /sys/class/zram-control/hot_add allocates the lowest free device, then
-# `udevadm settle` waits for udev to CREATE the /dev/zram0 node — hot_add is
-# async and back-to-back zramctl otherwise races the node into existence,
-# failing with "No such device" (live-E2E finding 2026-07-16));
-# the mounts guard refuses to touch a zram0 that carries someone's
-# FILESYSTEM (a zram-backed mount never shows in /proc/swaps — resetting it
-# would destroy data); the --reset before configure clears any stale
-# half-configured state; the fallback chain drops --algorithm zstd on
-# kernels without it.
+# Fixed /dev/zram0 with NO command substitution in ExecStart — no systemd
+# `$`-escaping hazard. Three live-E2E findings on a real Ubuntu 6.8 host shaped
+# this (2026-07-16):
+#   1. `modprobe zram` ships ZERO static devices — /dev/zram0 must be created
+#      by reading /sys/class/zram-control/hot_add (allocates the lowest free).
+#   2. hot_add is ASYNC — udev creates the node a beat later, so `udevadm
+#      settle` must follow before any userspace tool touches /dev/zram0.
+#   3. `zramctl --reset` on a device makes udev REMOVE the node (not merely
+#      deconfigure it), and a following configure then fails "No such device".
+# So we NEVER reset: instead we always start from a fresh device — hot_remove
+# a stale zram0 if one is present (the only way to resize/reconfigure safely),
+# then hot_add + settle + configure. This normalizes every non-swapping case
+# (cold, stale-configured, half-configured) to the one path proven to work.
+# The swaps early-exit keeps restarts idempotent; the mounts guard refuses to
+# touch a zram0 carrying someone's FILESYSTEM (never shows in /proc/swaps —
+# a reset/remove would destroy data); the zstd fallback drops --algorithm on
+# kernels without it (a fresh device has disksize 0, so --size retries cleanly).
 _hostswap_unit_content() {
     local size_mib="$1"
     printf '%s\n' \
@@ -80,8 +83,8 @@ _hostswap_unit_content() {
         '[Service]' \
         'Type=oneshot' \
         'RemainAfterExit=yes' \
-        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; test -b /dev/zram0 || cat /sys/class/zram-control/hot_add >/dev/null; udevadm settle --timeout=10 2>/dev/null || true; zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd 2>/dev/null || { zramctl --reset /dev/zram0 2>/dev/null; zramctl /dev/zram0 --size ${size_mib}MiB; }; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
-        "ExecStop=/bin/sh -c 'swapoff /dev/zram0 2>/dev/null; zramctl --reset /dev/zram0 2>/dev/null; true'" \
+        "ExecStart=/bin/sh -c 'grep -q \"^/dev/zram\" /proc/swaps && exit 0; grep -q \"^/dev/zram0 \" /proc/mounts && exit 1; modprobe zram; if [ -b /dev/zram0 ]; then echo 0 > /sys/class/zram-control/hot_remove 2>/dev/null; udevadm settle --timeout=10 2>/dev/null || true; fi; cat /sys/class/zram-control/hot_add >/dev/null; udevadm settle --timeout=10 2>/dev/null || true; zramctl /dev/zram0 --size ${size_mib}MiB --algorithm zstd || zramctl /dev/zram0 --size ${size_mib}MiB; mkswap /dev/zram0 && swapon -p 100 /dev/zram0'" \
+        "ExecStop=/bin/sh -c 'swapoff /dev/zram0 2>/dev/null; [ -b /dev/zram0 ] && echo 0 > /sys/class/zram-control/hot_remove 2>/dev/null; true'" \
         '' \
         '[Install]' \
         'WantedBy=multi-user.target'
@@ -171,27 +174,35 @@ host_swap_apply() {
     if [[ -n "$_HOSTSWAP_FAILED" ]]; then
         return 0
     fi
+    # `restart` (not `enable --now`) is deliberate: the unit is a
+    # RemainAfterExit oneshot, so once it has succeeded it stays "active" and
+    # `enable --now`/`start` become no-ops — they would NOT apply changed unit
+    # content, nor recover a device that was swapped off out from under an
+    # "active" unit. `restart` always re-runs ExecStop (frees the old device)
+    # then ExecStart (fresh device), which is what actually applies/heals.
+    # `enable` (without --now) just sets boot persistence.
     if [[ -n "$_HOSTSWAP_CHANGED" ]]; then
         # Best-effort: a hiccup here must never abort the caller — the unit is
         # on disk and the next boot applies it regardless.
         sudo systemctl daemon-reload 2>/dev/null || true
-        sudo systemctl enable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+        sudo systemctl enable "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+        sudo systemctl restart "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
         echo "  + zram swap unit installed (size ${size_mib}MiB, priority 100)."
     elif ! grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null; then
-        # Unchanged unit but no active zram swap: a previous enable failed, or
-        # an operator `disable`d without masking. The durable opt-out is MASK
-        # (guarded above) — a merely-disabled unit gets re-enabled, and a
-        # transient enable failure retries on the next apply instead of
-        # sticking forever. (No churn on healthy hosts: an active device
-        # skips this branch.)
-        sudo systemctl enable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
-        echo "  zram swap unit already in place (size ${size_mib}MiB) — re-enabled (was inactive)."
+        # Unchanged unit but no active zram swap: a previous start failed, or
+        # swap was removed from under the "active" unit. The durable opt-out is
+        # MASK (guarded above) — a merely-disabled/failed unit is re-started,
+        # so a transient failure heals on the next apply instead of sticking.
+        # (No churn on healthy hosts: an active device skips this branch.)
+        sudo systemctl enable "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+        sudo systemctl restart "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+        echo "  zram swap unit already in place (size ${size_mib}MiB) — restarted (was inactive)."
     else
         echo "  zram swap unit already in place (size ${size_mib}MiB)."
     fi
 
     # Verify the OUTCOME, not just the unit state: is a zram device actually
-    # swapping? (oneshot ExecStart runs synchronously under enable --now.)
+    # swapping? (oneshot ExecStart runs synchronously under restart.)
     if grep -q '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null; then
         echo "  + zram swap active: $(grep '^/dev/zram' "$HOSTSWAP_PROC_SWAPS" 2>/dev/null | awk '{print $1, "prio", $5}' | head -1)"
     else
@@ -212,7 +223,9 @@ host_swap_remove() {
     fi
     sudo systemctl disable --now "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
     sudo swapoff /dev/zram0 2>/dev/null || true
-    sudo zramctl --reset /dev/zram0 2>/dev/null || true
+    # hot_remove fully frees the device (a bare --reset leaves a stale node);
+    # ExecStop already ran on disable --now, so this is the belt to its braces.
+    sudo sh -c 'test -b /dev/zram0 && echo 0 > /sys/class/zram-control/hot_remove' 2>/dev/null || true
     sudo rm -f "$HOSTSWAP_ETC_ROOT/systemd/system/$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
     sudo systemctl daemon-reload 2>/dev/null || true
     echo "  + zram swap removed (mask the unit to prevent re-apply on update)."

--- a/tests/test_scripts/test_host_swap_sh.py
+++ b/tests/test_scripts/test_host_swap_sh.py
@@ -166,19 +166,23 @@ def test_fresh_apply_installs_unit_and_enables(tmp_path):
     content = unit.read_text()
     # Size baked in from the formula; fixed device; zstd with fallback; prio 100.
     assert "--size 4096MiB --algorithm zstd" in content
-    assert "|| { zramctl --reset /dev/zram0" in content  # fallback chain
+    assert "|| zramctl /dev/zram0 --size 4096MiB" in content  # zstd fallback
     assert "swapon -p 100 /dev/zram0" in content
-    # Ubuntu 6.8 ships the module with ZERO static devices (live-E2E finding):
-    # the hot_add read must create /dev/zram0 when modprobe alone doesn't.
-    assert "test -b /dev/zram0 || cat /sys/class/zram-control/hot_add" in content
-    # hot_add is async — udev must CREATE the node before zramctl touches it.
-    assert "udevadm settle" in content
-    # P1 belt: never reset a zram0 carrying someone's filesystem.
-    assert 'grep -q \"^/dev/zram0 \" /proc/mounts && exit 1' in content
+    # Always-fresh device (live-E2E findings): Ubuntu 6.8 ships ZERO static
+    # devices → hot_add creates one; a stale device is hot_removed first
+    # (--reset makes udev DELETE the node → "No such device" on configure).
+    assert "cat /sys/class/zram-control/hot_add" in content
+    assert "echo 0 > /sys/class/zram-control/hot_remove" in content
+    assert "zramctl --reset" not in content  # reset is the bug — never in the unit
+    # hot_add/hot_remove are async — udev must settle before zramctl touches it.
+    assert content.count("udevadm settle") >= 2
+    # never touch a zram0 carrying someone's filesystem.
+    assert 'grep -q "^/dev/zram0 " /proc/mounts && exit 1' in content
     assert "$" not in content  # NO command substitution → no systemd escaping
     log = _log(tmp_path)
     assert "daemon-reload" in log
-    assert "enable --now zram-swap.service" in log
+    assert "restart zram-swap.service" in log
+    assert "enable zram-swap.service" in log
     assert "zram swap unit installed" in res.stdout
 
 
@@ -212,13 +216,14 @@ def test_idempotent_rerun_no_systemd_churn(tmp_path):
     (tmp_path / "swaps").write_text(
         "Filename Type Size Used Priority\n/dev/zram0 partition 4194304 0 100\n"
     )
+
     # Mutating verbs only — the read-only `is-enabled` mask-check runs per
     # apply by design and must not count as churn.
     def _churn():
         return [
             line
             for line in _log(tmp_path).splitlines()
-            if "daemon-reload" in line or "enable --now" in line
+            if "daemon-reload" in line or "restart" in line
         ]
 
     churn_before = _churn()
@@ -297,7 +302,7 @@ def test_skip_foreign_nonswap_zram_not_destroyed(tmp_path):
     """Codex P1: a zram-backed MOUNT never appears in /proc/swaps — the guard
     must also see a configured device via zramctl, or the unit's reset would
     destroy it."""
-    busy_zramctl = "#!/bin/bash\nif [ \"$1\" = \"--noheadings\" ]; then echo \"/dev/zram0 lzo-rle 512M\"; fi\nexit 0\n"
+    busy_zramctl = '#!/bin/bash\nif [ "$1" = "--noheadings" ]; then echo "/dev/zram0 lzo-rle 512M"; fi\nexit 0\n'
     env = _sandbox(tmp_path, zramctl=busy_zramctl)  # swaps stays empty
     res = _run(env)
     assert res.returncode == 0
@@ -311,11 +316,11 @@ def test_unchanged_unit_inactive_retries_enable(tmp_path):
     only durable opt-out."""
     env = _sandbox(tmp_path)
     _run(env)  # install; stubbed systemctl never actually starts the device
-    enables_before = _log(tmp_path).count("enable --now")
+    restarts_before = _log(tmp_path).count("restart")
     res = _run(env)  # unchanged unit, swaps still empty → retry branch
     assert res.returncode == 0
-    assert "re-enabled (was inactive)" in res.stdout
-    assert _log(tmp_path).count("enable --now") == enables_before + 1
+    assert "restarted (was inactive)" in res.stdout
+    assert _log(tmp_path).count("restart") == restarts_before + 1
 
 
 def test_skip_without_sudo(tmp_path):
@@ -355,7 +360,7 @@ def test_write_failure_warns_and_skips_systemd(tmp_path):
     assert "NOT installed" in res.stdout
     log = _log(tmp_path)
     assert "daemon-reload" not in log
-    assert "enable --now" not in log
+    assert "restart" not in log
 
 
 # ── remove ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Full-chain live E2E of E3 on a real Ubuntu 6.8 host surfaced three kernel/systemd behaviors no sandbox stub can reproduce. This PR is the robust fix, validated end-to-end through the real `host_swap_apply` entrypoint across cold / idempotent / recovery paths.

**Root cause** of the persistent `zramctl: /dev/zram0: No such device` failures: `zramctl --reset` on a device makes udev **delete** the `/dev` node (not merely deconfigure it), so the immediately-following configure fails. The unit was resetting the very device it had just created.

## The fix — never reset; always start fresh

- Ubuntu 6.8 ships the module with **zero static devices** → read `/sys/class/zram-control/hot_add` to create `/dev/zram0`.
- `hot_add`/`hot_remove` are **async** → `udevadm settle` after each, before any userspace tool touches the node.
- A **stale pre-existing** device is `hot_remove`d (the only safe way to resize/reconfigure), then re-created — normalizing cold, stale-configured, and half-configured states to the single proven path.

## And: `restart`, not `enable --now`

The unit is a `RemainAfterExit` oneshot, so once active, `enable --now`/`start` are no-ops — they would neither apply changed unit content nor recover a device swapped-off from under an "active" unit. The lib now `restart`s (re-runs `ExecStop`(free) + `ExecStart`(fresh)); `enable` (without `--now`) just sets boot persistence.

## Verified live (real host, real `host_swap_apply`)

- **Cold** → `zram0` active at prio 100, zstd, 4 GiB
- **Idempotent** → "already in place", exactly one device, no systemd churn
- **Recovery** (external `swapoff`) → `restart` heals → RECOVERED

`ExecStop` + `host_swap_remove` switched to `hot_remove` for symmetric teardown. 27 tests green, `bash -n` + ruff clean.

## Why four live hotfixes total

This is exactly what the standing "verify E2E after review" directive is for: device-count, udev node-timing, reset-node-deletion, and RemainAfterExit-restart semantics are all live host-kernel behaviors invisible to unit-test stubs. Each surfaced only against the real 6.8 kernel, and each is now proven fixed on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)