### PR TITLE
feat(ledger): WS-2 P1a — ledger_predictions substrate + metric registry + validating CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **Genesis now writes down its predictions before acting — the substrate.**
+  A new cognitive ledger stores falsifiable predictions ("this outreach will
+  get a reply within 72 hours, confidence 0.02") behind a hard validation
+  gate: a prediction that doesn't name a registered, mechanically-checkable
+  metric with a deadline literally cannot be written. Nine starter metrics
+  ship with their grading rules implemented and tested (replies, task
+  completion, clean job days, build greenlights, ego-proposal execution).
+  This is the foundation; the hooks that write predictions on every action
+  and the grader that scores them land next.
+
 ### Fixed
 
 - **Answering Genesis's questions with a plain message now actually works.**

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -617,7 +617,7 @@ Self-improvement loops and the instrumentation that keeps them honest.
 
 ```yaml subsystem-map
 entry: learning-evaluation
-modules: [learning, eval, experimentation, feedback, calibration]
+modules: [learning, eval, experimentation, feedback, calibration, ledger]
 verified: fe5d0945 2026-07-10
 ```
 
@@ -684,7 +684,16 @@ verified: fe5d0945 2026-07-10
   wired via outreach (engagement reconciliation). **Four distinct
   "calibration" surfaces exist** (this package, `learning/triage/calibration`,
   `feedback/calibration` ego-ECE, `eval/calibration` golden-set loader) —
-  don't conflate.
+  don't conflate. Slated for WS-2 sunset (P5) once the ledger's unified
+  calibration table bakes.
+- **ledger/** (WS-2 P1a): the cognitive ledger — falsifiable predictions in
+  `ledger_predictions` (migration 0064), written only through the validating
+  CRUD (`db/crud/ledger_predictions.py`) against the code registry
+  (`ledger/metrics.py`: 9 v1 metrics, each with a pure-SQL resolver; NO
+  import path to `genesis.routing`, locked by test). Substrate only so far:
+  writer hooks = P1b, grader = P2. Outreach metrics resolve off
+  `outreach_history.engagement_signal` (spike-measured 99.5% mechanical);
+  task/ego resolvers read state tables until the T1 bus emits mature.
 
 ## 11. Routing & providers
 

--- a/src/genesis/db/crud/ledger_predictions.py
+++ b/src/genesis/db/crud/ledger_predictions.py
@@ -31,6 +31,8 @@ _PROVENANCES = frozenset({"stated", "policy_prior"})
 # Target statuses resolve() may set; 'open' is birth-only.
 _TERMINAL_STATUSES = frozenset({"resolved", "fuzzy_resolved", "void", "unresolvable"})
 _QUEUE_STATUSES = frozenset({"fuzzy_pending"})
+# Statuses that MUST carry an outcome_value (everything else must not).
+_SCORED_STATUSES = frozenset({"resolved", "fuzzy_resolved"})
 _RESOLVERS = frozenset({"mechanical", "mechanical_absence", "llm_fallback", "user"})
 
 _COLUMNS = (
@@ -88,8 +90,13 @@ async def create(
         raise ValueError(f"provenance must be one of {sorted(_PROVENANCES)}, got {provenance!r}")
 
     canonical_deadline = canonical_iso(deadline_at)
-    if canonical_deadline is None:
-        raise ValueError(f"unparseable deadline_at {deadline_at!r}")
+    # canonical_iso passes bare YYYY-MM-DD through unchanged (a valid form for
+    # bitemporal valid_at fields, NOT for a deadline) — reject it here or the
+    # naive datetime would raise TypeError below instead of the gate's
+    # contractual ValueError. Everything else canonical_iso returns is
+    # tz-aware (+00:00).
+    if canonical_deadline is None or len(canonical_deadline) == 10:
+        raise ValueError(f"deadline_at must be a full ISO timestamp, got {deadline_at!r}")
     deadline = datetime.fromisoformat(canonical_deadline)
     if not now < deadline <= now + HORIZON_CAP:
         raise ValueError(
@@ -186,8 +193,16 @@ async def resolve(
         raise ValueError(f"outcome_value must be 0, 1 or None, got {outcome_value!r}")
     if resolver is not None and resolver not in _RESOLVERS:
         raise ValueError(f"invalid resolver {resolver!r}")
-    if outcome_value is not None and resolver is None:
-        raise ValueError("resolver is required when outcome_value is set")
+    # Status/outcome pairing: a scored status without a grade would silently
+    # drop the row from the grader's queue ungraded; a non-scored status
+    # (void/unresolvable/fuzzy_pending) must never carry a grade.
+    if status in _SCORED_STATUSES:
+        if outcome_value is None:
+            raise ValueError(f"status {status!r} requires an outcome_value")
+        if resolver is None:
+            raise ValueError("resolver is required when outcome_value is set")
+    elif outcome_value is not None:
+        raise ValueError(f"status {status!r} must not carry an outcome_value")
 
     now = now or datetime.now(UTC)
     cursor = await db.execute(

--- a/src/genesis/db/crud/ledger_predictions.py
+++ b/src/genesis/db/crud/ledger_predictions.py
@@ -1,0 +1,217 @@
+"""CRUD for ``ledger_predictions`` — gate 1 of the WS-2 falsifiability design.
+
+The writer refuses (``ValueError``) any prediction that cannot be mechanically
+graded: unknown metric, action_class not matching the metric's spec,
+comparator outside the metric's comparator domain, broken comparator/threshold
+pairing, confidence outside [0.01, 0.99], or a deadline outside
+``(now, now + HORIZON_CAP]``. There is no free-text prediction that gets
+graded — ``rationale`` is prose for humans and is never scored.
+
+Convention notes: functions commit their own writes (never call these inside a
+migration ``up()``); ALL validation happens before the first execute so a
+raise can never strand an uncommitted row on the shared connection (the
+no-rollback rule); timestamps go through ``canonical_iso`` (the single
+write-path gate). Dedupe violations of ``UNIQUE (action_class, subject_ref_id,
+metric)`` surface as ``sqlite3.IntegrityError`` — deliberately not swallowed
+here; the P1b writer hooks decide (they debug-log legitimate re-entries).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.timeutil import canonical_iso
+from genesis.ledger.metrics import HORIZON_CAP, REGISTRY
+
+_PROVENANCES = frozenset({"stated", "policy_prior"})
+# Target statuses resolve() may set; 'open' is birth-only.
+_TERMINAL_STATUSES = frozenset({"resolved", "fuzzy_resolved", "void", "unresolvable"})
+_QUEUE_STATUSES = frozenset({"fuzzy_pending"})
+_RESOLVERS = frozenset({"mechanical", "mechanical_absence", "llm_fallback", "user"})
+
+_COLUMNS = (
+    "id, created_at, action_class, subject_ref_type, subject_ref_id, domain, "
+    "metric, comparator, threshold, confidence, deadline_at, provenance, "
+    "predictor, source_session, rationale, status, outcome_value, resolved_at, "
+    "resolver, evidence_ref, brier, metadata"
+)
+
+
+async def create(
+    db: aiosqlite.Connection,
+    *,
+    action_class: str,
+    subject_ref_type: str,
+    subject_ref_id: str,
+    domain: str,
+    metric: str,
+    confidence: float,
+    deadline_at: str,
+    provenance: str,
+    predictor: str,
+    comparator: str = "is_true",
+    threshold: float | None = None,
+    source_session: str | None = None,
+    rationale: str | None = None,
+    metadata: dict | None = None,
+    id: str | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Write one prediction row, or raise ``ValueError`` (falsifiability gate 1)."""
+    now = now or datetime.now(UTC)
+
+    spec = REGISTRY.get(metric)
+    if spec is None:
+        raise ValueError(f"unknown metric {metric!r} — not in the ledger registry")
+    if action_class != spec.action_class:
+        raise ValueError(
+            f"metric {metric!r} belongs to action_class {spec.action_class!r}, got {action_class!r}"
+        )
+    if comparator not in spec.comparator_domain:
+        raise ValueError(
+            f"comparator {comparator!r} not allowed for metric {metric!r} "
+            f"(allowed: {sorted(spec.comparator_domain)})"
+        )
+    if (comparator == "is_true") != (threshold is None):
+        raise ValueError(
+            "threshold is required for 'le'/'ge' comparators and forbidden for 'is_true'"
+        )
+    if threshold is not None and not isinstance(threshold, (int, float)):
+        raise ValueError(f"threshold must be numeric, got {type(threshold).__name__}")
+    if not isinstance(confidence, (int, float)) or not 0.01 <= confidence <= 0.99:
+        raise ValueError(f"confidence must be in [0.01, 0.99], got {confidence!r}")
+    if provenance not in _PROVENANCES:
+        raise ValueError(f"provenance must be one of {sorted(_PROVENANCES)}, got {provenance!r}")
+
+    canonical_deadline = canonical_iso(deadline_at)
+    if canonical_deadline is None:
+        raise ValueError(f"unparseable deadline_at {deadline_at!r}")
+    deadline = datetime.fromisoformat(canonical_deadline)
+    if not now < deadline <= now + HORIZON_CAP:
+        raise ValueError(
+            f"deadline_at must be in (now, now + {HORIZON_CAP}], got {canonical_deadline}"
+        )
+
+    row_id = id or uuid.uuid4().hex[:16]
+    await db.execute(
+        """INSERT INTO ledger_predictions
+           (id, created_at, action_class, subject_ref_type, subject_ref_id,
+            domain, metric, comparator, threshold, confidence, deadline_at,
+            provenance, predictor, source_session, rationale, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            row_id,
+            canonical_iso(now.isoformat()),
+            action_class,
+            subject_ref_type,
+            subject_ref_id,
+            domain,
+            metric,
+            comparator,
+            threshold,
+            float(confidence),
+            canonical_deadline,
+            provenance,
+            predictor,
+            source_session,
+            rationale,
+            json.dumps(metadata) if metadata is not None else None,
+        ),
+    )
+    await db.commit()
+    created = await get_by_id(db, row_id)
+    if created is None:  # pragma: no cover — the row was committed one statement ago
+        raise RuntimeError(f"ledger prediction {row_id} vanished after insert")
+    return created
+
+
+async def get_by_id(db: aiosqlite.Connection, prediction_id: str) -> dict | None:
+    cursor = await db.execute(
+        f"SELECT {_COLUMNS} FROM ledger_predictions WHERE id = ?",  # noqa: S608 — column list is a module constant
+        (prediction_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row is not None else None
+
+
+async def list_due_open(
+    db: aiosqlite.Connection, *, now: datetime | None = None, limit: int = 500
+) -> list[dict]:
+    """Open rows whose deadline has passed — the grader's work queue.
+
+    Rides the partial index ``idx_lp_open_deadline`` (status='open').
+    """
+    now = now or datetime.now(UTC)
+    cursor = await db.execute(
+        f"SELECT {_COLUMNS} FROM ledger_predictions "  # noqa: S608
+        "WHERE status = 'open' AND deadline_at <= ? ORDER BY deadline_at LIMIT ?",
+        (canonical_iso(now.isoformat()), limit),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def list_by_subject(
+    db: aiosqlite.Connection, *, action_class: str, subject_ref_id: str
+) -> list[dict]:
+    cursor = await db.execute(
+        f"SELECT {_COLUMNS} FROM ledger_predictions "  # noqa: S608
+        "WHERE action_class = ? AND subject_ref_id = ? ORDER BY metric",
+        (action_class, subject_ref_id),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def resolve(
+    db: aiosqlite.Connection,
+    prediction_id: str,
+    *,
+    status: str,
+    outcome_value: int | None = None,
+    resolver: str | None = None,
+    evidence_ref: str | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Grade one row. Returns False if the row is missing or already terminal.
+
+    ``brier`` is computed in SQL from the stored confidence when an outcome is
+    set. The guarded WHERE makes double-grading a no-op (idempotent grader).
+    """
+    if status not in _TERMINAL_STATUSES | _QUEUE_STATUSES:
+        raise ValueError(f"invalid target status {status!r}")
+    if outcome_value not in (None, 0, 1):
+        raise ValueError(f"outcome_value must be 0, 1 or None, got {outcome_value!r}")
+    if resolver is not None and resolver not in _RESOLVERS:
+        raise ValueError(f"invalid resolver {resolver!r}")
+    if outcome_value is not None and resolver is None:
+        raise ValueError("resolver is required when outcome_value is set")
+
+    now = now or datetime.now(UTC)
+    cursor = await db.execute(
+        """UPDATE ledger_predictions
+           SET status = ?,
+               outcome_value = ?,
+               resolver = ?,
+               evidence_ref = ?,
+               resolved_at = ?,
+               brier = CASE WHEN ? IS NOT NULL
+                            THEN (confidence - ?) * (confidence - ?)
+                            ELSE brier END
+           WHERE id = ? AND status IN ('open', 'fuzzy_pending')""",
+        (
+            status,
+            outcome_value,
+            resolver,
+            evidence_ref,
+            canonical_iso(now.isoformat()),
+            outcome_value,
+            outcome_value,
+            outcome_value,
+            prediction_id,
+        ),
+    )
+    await db.commit()
+    return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0064_ledger_predictions.py
+++ b/src/genesis/db/migrations/0064_ledger_predictions.py
@@ -1,0 +1,83 @@
+"""Add ledger_predictions — the WS-2 Cognitive Ledger substrate (P1a).
+
+One row per falsifiable prediction: "proposition P about subject S will be
+TRUE by deadline D, with probability c." The three-gate design makes
+unmeasurable predictions structurally unwritable:
+
+1. The CRUD writer (``db/crud/ledger_predictions.py``) refuses any metric not
+   in the code registry (``genesis/ledger/metrics.py``), any comparator/
+   threshold pairing the metric spec disallows, any deadline outside
+   ``(now, now + HORIZON_CAP]``, any confidence outside [0.01, 0.99].
+2. The table CHECKs below are defense-in-depth against raw-SQL writers.
+3. The grader (P2) resolves rows whose metric has vanished from the registry
+   to ``unresolvable`` and alarms — schema-vs-code drift is a sensor, never
+   a silent skip.
+
+``rationale`` is prose for humans and is NEVER graded. The UNIQUE key makes
+writer hooks idempotent under retries/resends. The partial index carries the
+grader's hot query (open rows past deadline).
+
+Additive + idempotent; DDL mirrored in ``db/schema/_tables.py``. Individual
+``db.execute()`` calls, no commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ledger_predictions (
+            id               TEXT PRIMARY KEY,                     -- uuid4 hex16
+            created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+            action_class     TEXT NOT NULL CHECK (action_class IN
+                               ('outreach_send','task_execution','scheduled_job',
+                                'build_verdict','ego_proposal')),
+            subject_ref_type TEXT NOT NULL,      -- 'outreach' | 'task' | 'job_day' | ...
+            subject_ref_id   TEXT NOT NULL,      -- outreach_history.id / task_id / '<job>:<YYYY-MM-DD>' / ...
+            domain           TEXT NOT NULL,      -- dotted coarse domain: 'outreach.<category>', 'task.<type>', 'job.<name>'
+            metric           TEXT NOT NULL,      -- MUST exist in the code registry; grader refuses unknown metrics
+            comparator       TEXT NOT NULL DEFAULT 'is_true'
+                               CHECK (comparator IN ('is_true','le','ge')),
+            threshold        REAL,               -- required iff comparator != 'is_true'
+            confidence       REAL NOT NULL CHECK (confidence >= 0.01 AND confidence <= 0.99),
+            deadline_at      TEXT NOT NULL,      -- ISO-8601 UTC; writer enforces now < deadline <= now + horizon cap
+            provenance       TEXT NOT NULL CHECK (provenance IN ('stated','policy_prior')),
+            predictor        TEXT NOT NULL,      -- component id: 'outreach_pipeline','task_executor',...
+            source_session   TEXT,
+            rationale        TEXT,               -- optional prose; NEVER graded
+            status           TEXT NOT NULL DEFAULT 'open'
+                               CHECK (status IN ('open','resolved','fuzzy_pending',
+                                                 'fuzzy_resolved','void','unresolvable')),
+            outcome_value    INTEGER CHECK (outcome_value IN (0,1)),
+            resolved_at      TEXT,
+            resolver         TEXT CHECK (resolver IN ('mechanical','mechanical_absence',
+                                                      'llm_fallback','user')),
+            evidence_ref     TEXT,               -- 'table:rowid' of the grading evidence
+            brier            REAL,               -- (confidence - outcome_value)^2, set at grade time
+            metadata         TEXT,               -- JSON
+            CHECK ((comparator = 'is_true') = (threshold IS NULL)),
+            UNIQUE (action_class, subject_ref_id, metric)
+        )
+        """
+    )
+    # the grader's hot query: open rows whose deadline has passed
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_open_deadline "
+        "ON ledger_predictions(deadline_at) WHERE status = 'open'"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_domain "
+        "ON ledger_predictions(domain, action_class, metric)"
+    )
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_lp_status ON ledger_predictions(status)")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lp_subject "
+        "ON ledger_predictions(subject_ref_type, subject_ref_id)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS ledger_predictions")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1825,6 +1825,48 @@ TABLES = {
             resolved_at  TEXT                         -- NULL = still open
         )
     """,
+    # ── WS-2 Cognitive Ledger (P1a) ──────────────────────────────────────
+    # One row per falsifiable prediction ("P about subject S is TRUE by
+    # deadline D, probability c"). Three-gate falsifiability: the CRUD writer
+    # (db/crud/ledger_predictions.py) validates against the code registry
+    # (genesis/ledger/metrics.py); these CHECKs are defense-in-depth against
+    # raw-SQL writers; the grader (P2) alarms on registry-vanished metrics.
+    # rationale is prose for humans, NEVER graded. The UNIQUE key makes the
+    # commit-path writer hooks idempotent under retries/resends.
+    "ledger_predictions": """
+        CREATE TABLE IF NOT EXISTS ledger_predictions (
+            id               TEXT PRIMARY KEY,                     -- uuid4 hex16
+            created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+            action_class     TEXT NOT NULL CHECK (action_class IN
+                               ('outreach_send','task_execution','scheduled_job',
+                                'build_verdict','ego_proposal')),
+            subject_ref_type TEXT NOT NULL,      -- 'outreach' | 'task' | 'job_day' | ...
+            subject_ref_id   TEXT NOT NULL,      -- outreach_history.id / task_id / '<job>:<YYYY-MM-DD>' / ...
+            domain           TEXT NOT NULL,      -- dotted coarse domain: 'outreach.<category>', 'task.<type>', 'job.<name>'
+            metric           TEXT NOT NULL,      -- MUST exist in the code registry; grader refuses unknown metrics
+            comparator       TEXT NOT NULL DEFAULT 'is_true'
+                               CHECK (comparator IN ('is_true','le','ge')),
+            threshold        REAL,               -- required iff comparator != 'is_true'
+            confidence       REAL NOT NULL CHECK (confidence >= 0.01 AND confidence <= 0.99),
+            deadline_at      TEXT NOT NULL,      -- ISO-8601 UTC; writer enforces now < deadline <= now + horizon cap
+            provenance       TEXT NOT NULL CHECK (provenance IN ('stated','policy_prior')),
+            predictor        TEXT NOT NULL,      -- component id: 'outreach_pipeline','task_executor',...
+            source_session   TEXT,
+            rationale        TEXT,               -- optional prose; NEVER graded
+            status           TEXT NOT NULL DEFAULT 'open'
+                               CHECK (status IN ('open','resolved','fuzzy_pending',
+                                                 'fuzzy_resolved','void','unresolvable')),
+            outcome_value    INTEGER CHECK (outcome_value IN (0,1)),
+            resolved_at      TEXT,
+            resolver         TEXT CHECK (resolver IN ('mechanical','mechanical_absence',
+                                                      'llm_fallback','user')),
+            evidence_ref     TEXT,               -- 'table:rowid' of the grading evidence
+            brier            REAL,               -- (confidence - outcome_value)^2, set at grade time
+            metadata         TEXT,               -- JSON
+            CHECK ((comparator = 'is_true') = (threshold IS NULL)),
+            UNIQUE (action_class, subject_ref_id, metric)
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -2139,6 +2181,12 @@ INDEXES = [
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_ae_open_alert ON alert_events(alert_id) WHERE resolved_at IS NULL",
     "CREATE INDEX IF NOT EXISTS idx_ae_created ON alert_events(created_at)",
     "CREATE INDEX IF NOT EXISTS idx_ae_alert ON alert_events(alert_id, created_at)",
+    # WS-2 Cognitive Ledger (P1a) — the partial index carries the grader's
+    # hot query (open rows past deadline)
+    "CREATE INDEX IF NOT EXISTS idx_lp_open_deadline ON ledger_predictions(deadline_at) WHERE status = 'open'",
+    "CREATE INDEX IF NOT EXISTS idx_lp_domain ON ledger_predictions(domain, action_class, metric)",
+    "CREATE INDEX IF NOT EXISTS idx_lp_status ON ledger_predictions(status)",
+    "CREATE INDEX IF NOT EXISTS idx_lp_subject ON ledger_predictions(subject_ref_type, subject_ref_id)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/ledger/__init__.py
+++ b/src/genesis/ledger/__init__.py
@@ -1,0 +1,16 @@
+"""WS-2 Cognitive Ledger — falsifiable predictions, mechanically graded.
+
+P1a ships the substrate: the metric registry (``metrics.py``, gate 1 of the
+three-gate falsifiability design) and the ``ledger_predictions`` table
+(migration 0064). Writer hooks land in P1b; the grader in P2.
+"""
+
+from genesis.ledger.metrics import (
+    HORIZON_CAP,
+    REGISTRY,
+    TASK_GRACE,
+    MetricSpec,
+    Resolution,
+)
+
+__all__ = ["HORIZON_CAP", "REGISTRY", "TASK_GRACE", "MetricSpec", "Resolution"]

--- a/src/genesis/ledger/metrics.py
+++ b/src/genesis/ledger/metrics.py
@@ -12,8 +12,9 @@ on schedule. Each resolver takes the shared DB connection, the prediction row
 - ``outcome_value`` 1/0 — mechanically graded; ``None`` — not resolvable yet
   (lane ``open``), premise absent (lane ``void:*``), needs the LLM fallback
   (lane ``fuzzy_pending``), or broken evidence (lane ``unresolvable:*``).
-- ``lane`` names the mechanical rule that fired — persisted as grading
-  provenance so calibration can be audited per rule.
+- ``lane`` names the mechanical rule that fired — returned to the grader as
+  grading provenance (the P2 grader persists it with the grade so calibration
+  can be audited per rule).
 
 Evidence sources (locked in the design doc §2.3.1): outreach metrics resolve
 off ``outreach_history.engagement_signal`` (exists today, measured 99.5%

--- a/src/genesis/ledger/metrics.py
+++ b/src/genesis/ledger/metrics.py
@@ -1,0 +1,398 @@
+"""WS-2 Cognitive Ledger — the metric registry (falsifiability gate 1 of 3).
+
+A prediction can only be written for a metric registered here, and every
+registered metric carries a ``resolver_fn`` — pure SQL/Python over evidence
+tables, zero LLM calls. The resolver IS the falsifiability proof: adding a
+metric means implementing (and reviewing) the mechanical check that grades it.
+
+Resolvers are implemented and unit-tested in P1a; the P2 grader executes them
+on schedule. Each resolver takes the shared DB connection, the prediction row
+(dict), and ``now``, and returns a :class:`Resolution`:
+
+- ``outcome_value`` 1/0 — mechanically graded; ``None`` — not resolvable yet
+  (lane ``open``), premise absent (lane ``void:*``), needs the LLM fallback
+  (lane ``fuzzy_pending``), or broken evidence (lane ``unresolvable:*``).
+- ``lane`` names the mechanical rule that fired — persisted as grading
+  provenance so calibration can be audited per rule.
+
+Evidence sources (locked in the design doc §2.3.1): outreach metrics resolve
+off ``outreach_history.engagement_signal`` (exists today, measured 99.5%
+mechanical on the live DB); task/ego metrics resolve off their state tables
+until the T1 bus lane (P1b emits) matures. Migrating a resolver to
+``outcome_events`` later changes no registry contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, NamedTuple
+
+from genesis.outreach.types import POSITIVE_ENGAGEMENT_OUTCOMES
+
+# Writer-side global cap: no prediction may set a deadline beyond now + cap.
+# Headroom above the longest per-metric horizon; the §2.6 specificity audit
+# watches for deadlines drifting toward this ceiling ("calibration by
+# cowardice" via unfalsifiably-distant deadlines).
+HORIZON_CAP = timedelta(days=30)
+
+# Task predictions: no task-level timeout exists (only per-step bounds), so
+# the horizon is a constant bounded-runtime allowance plus this grace.
+TASK_GRACE = timedelta(hours=24)
+
+
+class Resolution(NamedTuple):
+    """One resolver verdict: outcome (or None), evidence pointer, rule lane."""
+
+    outcome_value: int | None
+    evidence_ref: str | None
+    lane: str
+
+
+Resolver = Callable[..., Awaitable[Resolution]]
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """Registry entry — the falsifiability contract for one metric."""
+
+    action_class: str  # the only action_class this metric may attach to
+    comparator_domain: frozenset[str]  # allowed comparators ('is_true' | 'le' | 'ge')
+    resolver_fn: Resolver
+    absence_semantics: str  # 'zero' | 'void' | 'fuzzy_pending' — no evidence at deadline means...
+    default_horizon: timedelta
+    fuzzy: bool = False  # True = grader routes to the bounded LLM fallback lane
+
+
+# ── Outreach lane maps (spike-validated 2026-07-16, §2.3.1 locked semantics) ──
+
+# Signals that mechanically mean "an actual reply was captured".
+_REPLY_SIGNALS = frozenset({"user_reply"})
+# Signals that mechanically mean "no direct reply": timeout is the 24h
+# verdict; the rest mean the user was active or engaged *elsewhere* — the
+# separate positive_engagement metric owns that softer signal.
+_NO_REPLY_SIGNALS = frozenset(
+    {"timeout", "implicit_activity", "auto_digest", "acted_on", "acknowledged"}
+)
+# 'useful' is what record_reply writes — a signal-less 'useful' is a legacy
+# reply row from before the engagement_signal column existed.
+_REPLY_OUTCOMES = frozenset({"useful"})
+_NO_REPLY_OUTCOMES = frozenset(
+    {"ignored", "ambivalent", "not_useful", "engaged", "acted_on", "acknowledged"}
+)
+
+# Terminal task phases that conclusively negate 'completed'.
+_TASK_FAILED_PHASES = frozenset({"failed", "cancelled"})
+# Ego proposal statuses that conclusively negate 'approved_and_executes'.
+_EGO_NEGATIVE_STATUSES = frozenset({"rejected", "expired", "failed", "tabled", "withdrawn"})
+
+
+def _past_deadline(prediction_row: dict, now: datetime) -> bool | None:
+    """True/False vs the row's deadline; None if the stored deadline is garbage."""
+    raw = prediction_row.get("deadline_at") or ""
+    try:
+        deadline = datetime.fromisoformat(raw)
+    except (TypeError, ValueError):
+        return None
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=UTC)
+    return now >= deadline
+
+
+async def _fetch_one(db: Any, sql: str, params: tuple) -> dict | None:
+    cursor = await db.execute(sql, params)
+    row = await cursor.fetchone()
+    return dict(row) if row is not None else None
+
+
+def _absence(prediction_row: dict, now: datetime) -> Resolution:
+    """Shared zero-absence tail: silence past the deadline IS the answer."""
+    past = _past_deadline(prediction_row, now)
+    if past is None:
+        return Resolution(None, None, "unresolvable:bad_deadline")
+    if past:
+        return Resolution(0, None, "mechanical_absence")
+    return Resolution(None, None, "open")
+
+
+# ── outreach_send ─────────────────────────────────────────────────────────────
+
+
+async def _resolve_reply_received(db: Any, prediction_row: dict, *, now: datetime) -> Resolution:
+    """Spike-validated lane map: did an actual reply arrive by deadline?"""
+    row = await _fetch_one(
+        db,
+        "SELECT id, engagement_signal, engagement_outcome, user_response "
+        "FROM outreach_history WHERE id = ?",
+        (prediction_row["subject_ref_id"],),
+    )
+    if row is None:
+        return Resolution(None, None, "unresolvable:subject_missing")
+    evidence = f"outreach_history:{row['id']}"
+    signal = row["engagement_signal"] or ""
+    outcome = row["engagement_outcome"] or ""
+
+    # Affirmative: a captured reply always wins, regardless of outcome label.
+    if signal in _REPLY_SIGNALS or row["user_response"]:
+        return Resolution(1, evidence, "user_reply")
+    if not signal and outcome in _REPLY_OUTCOMES:
+        return Resolution(1, evidence, f"legacy_outcome:{outcome}")
+
+    if signal in _NO_REPLY_SIGNALS:
+        return Resolution(0, evidence, f"signal:{signal}")
+    # Signal missing but a mechanical outcome label exists (legacy rows from
+    # pre-signal-column writers).
+    if not signal and outcome in _NO_REPLY_OUTCOMES:
+        return Resolution(0, evidence, f"outcome:{outcome}")
+
+    return _absence(prediction_row, now)
+
+
+async def _resolve_positive_engagement(
+    db: Any, prediction_row: dict, *, now: datetime
+) -> Resolution:
+    """Softer signal than a reply: any canonical positive engagement by deadline."""
+    row = await _fetch_one(
+        db,
+        "SELECT id, engagement_signal, engagement_outcome, user_response "
+        "FROM outreach_history WHERE id = ?",
+        (prediction_row["subject_ref_id"],),
+    )
+    if row is None:
+        return Resolution(None, None, "unresolvable:subject_missing")
+    evidence = f"outreach_history:{row['id']}"
+    signal = row["engagement_signal"] or ""
+    outcome = row["engagement_outcome"] or ""
+    if signal in _REPLY_SIGNALS or row["user_response"]:
+        return Resolution(1, evidence, "user_reply")
+    if outcome in POSITIVE_ENGAGEMENT_OUTCOMES:
+        return Resolution(1, evidence, f"positive_outcome:{outcome}")
+    # Negative labels before the deadline stay open — record_reply upgrades an
+    # earlier 'ignored'/'ambivalent' unconditionally, so only the deadline
+    # closes the question.
+    return _absence(prediction_row, now)
+
+
+# ── task_execution ────────────────────────────────────────────────────────────
+
+
+async def _resolve_completed(db: Any, prediction_row: dict, *, now: datetime) -> Resolution:
+    row = await _fetch_one(
+        db,
+        "SELECT task_id, current_phase FROM task_states WHERE task_id = ?",
+        (prediction_row["subject_ref_id"],),
+    )
+    if row is None:
+        return Resolution(None, None, "unresolvable:subject_missing")
+    evidence = f"task_states:{row['task_id']}"
+    phase = row["current_phase"] or ""
+    if phase == "completed":
+        return Resolution(1, evidence, "completed")
+    if phase in _TASK_FAILED_PHASES:
+        return Resolution(0, evidence, f"phase:{phase}")
+    return _absence(prediction_row, now)
+
+
+async def _resolve_completed_first_attempt(
+    db: Any, prediction_row: dict, *, now: datetime
+) -> Resolution:
+    """Completed AND no negative execution outcome recorded for the task.
+
+    Until the P1b executor emits land, failed attempts are only visible via
+    ``outcome_events`` rows — so pre-P1b this degrades to ``completed``
+    (documented limitation: ``task_states`` keeps no transition history).
+    """
+    base = await _resolve_completed(db, prediction_row, now=now)
+    if base.outcome_value != 1:
+        return base
+    negative = await _fetch_one(
+        db,
+        "SELECT id FROM outcome_events WHERE ref_type = 'task' AND ref_id = ? "
+        "AND signal_type = 'execution_outcome' AND polarity = 'negative' LIMIT 1",
+        (prediction_row["subject_ref_id"],),
+    )
+    if negative is not None:
+        return Resolution(0, f"outcome_events:{negative['id']}", "failed_attempt_evidence")
+    return Resolution(1, base.evidence_ref, "completed_first_attempt")
+
+
+async def _resolve_acceptance_pass(db: Any, prediction_row: dict, *, now: datetime) -> Resolution:
+    """Fuzzy by design (v1's only fuzzy metric) — the P2 grader queues it for
+    the bounded LLM fallback lane; there is no mechanical evidence source yet."""
+    return Resolution(None, None, "fuzzy_pending")
+
+
+# ── scheduled_job (subject_ref_id = '<job_name>:<YYYY-MM-DD>') ───────────────
+
+
+def _split_job_day(subject_ref_id: str) -> tuple[str, str] | None:
+    job_name, sep, day = subject_ref_id.rpartition(":")
+    if not sep or len(day) != 10:
+        return None
+    return job_name, day
+
+
+async def _resolve_runs_clean_day(db: Any, prediction_row: dict, *, now: datetime) -> Resolution:
+    from genesis.db.crud.job_run_events import list_runs_for_day
+
+    parsed = _split_job_day(prediction_row["subject_ref_id"])
+    if parsed is None:
+        return Resolution(None, None, "unresolvable:bad_subject_ref")
+    job_name, day = parsed
+    runs = await list_runs_for_day(db, job_name, day)
+    failed = [r for r in runs if r["status"] == "failed"]
+    if failed:
+        return Resolution(0, f"job_run_events:{failed[0]['id']}", "failed_runs")
+    past = _past_deadline(prediction_row, now)
+    if past is None:
+        return Resolution(None, None, "unresolvable:bad_deadline")
+    if not past:
+        return Resolution(None, None, "open")
+    if not runs:
+        # Premise absent: the job never fired that day — void, and itself a
+        # separate alarm (the grader counts voids per class).
+        return Resolution(None, None, "void:no_runs")
+    return Resolution(1, f"job_run_events:{runs[0]['id']}", "clean_day")
+
+
+async def _resolve_runtime_ms_le(db: Any, prediction_row: dict, *, now: datetime) -> Resolution:
+    from genesis.db.crud.job_run_events import list_runs_for_day
+
+    parsed = _split_job_day(prediction_row["subject_ref_id"])
+    if parsed is None:
+        return Resolution(None, None, "unresolvable:bad_subject_ref")
+    threshold = prediction_row.get("threshold")
+    if threshold is None:
+        return Resolution(None, None, "unresolvable:missing_threshold")
+    job_name, day = parsed
+    runs = [r for r in await list_runs_for_day(db, job_name, day) if r["duration_ms"] is not None]
+    exceeded = [r for r in runs if r["duration_ms"] > threshold]
+    if exceeded:
+        return Resolution(0, f"job_run_events:{exceeded[0]['id']}", "exceeded_threshold")
+    past = _past_deadline(prediction_row, now)
+    if past is None:
+        return Resolution(None, None, "unresolvable:bad_deadline")
+    if not past:
+        return Resolution(None, None, "open")
+    if not runs:
+        # duration_ms is only real where record_job_start marked the run —
+        # honest instrument: no measured runs means void, never a free pass.
+        return Resolution(None, None, "void:no_duration_data")
+    return Resolution(1, f"job_run_events:{runs[0]['id']}", "within_threshold")
+
+
+# ── build_verdict ─────────────────────────────────────────────────────────────
+
+
+async def _resolve_user_greenlights(db: Any, prediction_row: dict, *, now: datetime) -> Resolution:
+    row = await _fetch_one(
+        db,
+        "SELECT id, user_decision FROM build_candidates WHERE id = ?",
+        (prediction_row["subject_ref_id"],),
+    )
+    if row is None:
+        return Resolution(None, None, "unresolvable:subject_missing")
+    evidence = f"build_candidates:{row['id']}"
+    decision = row["user_decision"] or ""
+    if decision == "approved":
+        return Resolution(1, evidence, "approved")
+    if decision in ("rejected", "discussed"):
+        return Resolution(0, evidence, f"decision:{decision}")
+    return _absence(prediction_row, now)
+
+
+# ── ego_proposal ──────────────────────────────────────────────────────────────
+
+
+async def _resolve_approved_and_executes(
+    db: Any, prediction_row: dict, *, now: datetime
+) -> Resolution:
+    row = await _fetch_one(
+        db,
+        "SELECT id, status FROM ego_proposals WHERE id = ?",
+        (prediction_row["subject_ref_id"],),
+    )
+    if row is None:
+        return Resolution(None, None, "unresolvable:subject_missing")
+    evidence = f"ego_proposals:{row['id']}"
+    status = row["status"] or ""
+    if status == "executed":
+        return Resolution(1, evidence, "executed")
+    if status in _EGO_NEGATIVE_STATUSES:
+        return Resolution(0, evidence, f"status:{status}")
+    # 'pending'/'approved' without execution: the deadline decides — the
+    # metric is approved AND executes, not approved alone.
+    return _absence(prediction_row, now)
+
+
+# ── The v1 registry (complete list — design doc §2.3) ────────────────────────
+
+_IS_TRUE = frozenset({"is_true"})
+
+REGISTRY: dict[str, MetricSpec] = {
+    "reply_received": MetricSpec(
+        action_class="outreach_send",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_reply_received,
+        absence_semantics="zero",
+        default_horizon=timedelta(hours=72),
+    ),
+    "positive_engagement": MetricSpec(
+        action_class="outreach_send",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_positive_engagement,
+        absence_semantics="zero",
+        default_horizon=timedelta(hours=72),
+    ),
+    "completed": MetricSpec(
+        action_class="task_execution",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_completed,
+        absence_semantics="zero",
+        default_horizon=timedelta(hours=24) + TASK_GRACE,
+    ),
+    "completed_first_attempt": MetricSpec(
+        action_class="task_execution",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_completed_first_attempt,
+        absence_semantics="zero",
+        default_horizon=timedelta(hours=24) + TASK_GRACE,
+    ),
+    "acceptance_pass": MetricSpec(
+        action_class="task_execution",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_acceptance_pass,
+        absence_semantics="fuzzy_pending",
+        default_horizon=timedelta(hours=24) + TASK_GRACE,
+        fuzzy=True,
+    ),
+    "runs_clean_day": MetricSpec(
+        action_class="scheduled_job",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_runs_clean_day,
+        absence_semantics="void",
+        default_horizon=timedelta(hours=24),
+    ),
+    "runtime_ms_le": MetricSpec(
+        action_class="scheduled_job",
+        comparator_domain=frozenset({"le"}),
+        resolver_fn=_resolve_runtime_ms_le,
+        absence_semantics="void",
+        default_horizon=timedelta(hours=24),
+    ),
+    "user_greenlights": MetricSpec(
+        action_class="build_verdict",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_user_greenlights,
+        absence_semantics="zero",
+        default_horizon=timedelta(days=7),
+    ),
+    "approved_and_executes": MetricSpec(
+        action_class="ego_proposal",
+        comparator_domain=_IS_TRUE,
+        resolver_fn=_resolve_approved_and_executes,
+        absence_semantics="zero",
+        default_horizon=timedelta(days=7),
+    ),
+}

--- a/tests/test_db/test_ledger_predictions_crud.py
+++ b/tests/test_db/test_ledger_predictions_crud.py
@@ -1,0 +1,191 @@
+"""CRUD gate tests for ``ledger_predictions`` (WS-2 P1a, falsifiability gate 1).
+
+The writer must make unmeasurable predictions unwritable: every rejection in
+the matrix below is a ``ValueError`` raised BEFORE any SQL executes. All
+clocks are injected — no wall-clock dependence.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.db.crud import ledger_predictions as lp
+
+NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+DEADLINE = (NOW + timedelta(hours=24)).isoformat()
+
+
+async def _mk(db, **overrides) -> dict:
+    kwargs = dict(
+        action_class="outreach_send",
+        subject_ref_type="outreach",
+        subject_ref_id="o-1",
+        domain="outreach.reminder",
+        metric="reply_received",
+        confidence=0.5,
+        deadline_at=DEADLINE,
+        provenance="policy_prior",
+        predictor="test",
+        now=NOW,
+    )
+    kwargs.update(overrides)
+    return await lp.create(db, **kwargs)
+
+
+# ── round-trip ───────────────────────────────────────────────────────────────
+
+
+async def test_create_round_trip(db):
+    row = await _mk(db, rationale="because", metadata={"seed": "base_rate"})
+    assert row["status"] == "open"
+    assert row["comparator"] == "is_true"
+    assert row["confidence"] == 0.5
+    assert row["metric"] == "reply_received"
+    # canonical UTC-offset ISO on both stamped timestamps
+    assert row["created_at"].endswith("+00:00")
+    assert row["deadline_at"].endswith("+00:00")
+    assert row["brier"] is None
+    fetched = await lp.get_by_id(db, row["id"])
+    assert fetched == row
+
+
+async def test_get_by_id_missing(db):
+    assert await lp.get_by_id(db, "nope") is None
+
+
+# ── the rejection matrix (gate 1) ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"metric": "vibes_good"}, "unknown metric"),
+        # metric/action_class cross-wiring
+        ({"action_class": "task_execution"}, "belongs to action_class"),
+        # comparator outside the metric's domain
+        ({"comparator": "le", "threshold": 5.0}, "not allowed for metric"),
+        # threshold pairing, both directions
+        ({"threshold": 5.0}, "threshold is required.*forbidden"),
+        (
+            {
+                "metric": "runtime_ms_le",
+                "action_class": "scheduled_job",
+                "comparator": "le",
+                "threshold": None,
+            },
+            "threshold is required",
+        ),
+        # confidence bounds
+        ({"confidence": 0.0}, "confidence"),
+        ({"confidence": 0.005}, "confidence"),
+        ({"confidence": 0.995}, "confidence"),
+        ({"confidence": 1.0}, "confidence"),
+        # deadline horizon: past, exactly-now, beyond cap, garbage
+        ({"deadline_at": (NOW - timedelta(hours=1)).isoformat()}, "deadline_at"),
+        ({"deadline_at": NOW.isoformat()}, "deadline_at"),
+        ({"deadline_at": (NOW + timedelta(days=31)).isoformat()}, "deadline_at"),
+        ({"deadline_at": "not-a-date"}, "unparseable"),
+        ({"provenance": "vibes"}, "provenance"),
+    ],
+)
+async def test_writer_rejection_matrix(db, overrides, match):
+    with pytest.raises(ValueError, match=match):
+        await _mk(db, **overrides)
+    # nothing was written
+    assert await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-1") == []
+
+
+async def test_dedupe_unique_key_raises(db):
+    """Same (action_class, subject, metric) twice → IntegrityError for the
+    caller to decide (P1b hooks debug-log legitimate re-entries)."""
+    await _mk(db)
+    with pytest.raises(sqlite3.IntegrityError):
+        await _mk(db)
+    # different metric on the same subject is a distinct prediction
+    await _mk(db, metric="positive_engagement")
+
+
+# ── grade-side helpers ───────────────────────────────────────────────────────
+
+
+async def test_list_due_open_filters_and_orders(db):
+    late = await _mk(
+        db, subject_ref_id="o-late", deadline_at=(NOW + timedelta(hours=2)).isoformat()
+    )
+    early = await _mk(
+        db, subject_ref_id="o-early", deadline_at=(NOW + timedelta(hours=1)).isoformat()
+    )
+    await _mk(db, subject_ref_id="o-notdue", deadline_at=(NOW + timedelta(hours=20)).isoformat())
+
+    due = await lp.list_due_open(db, now=NOW + timedelta(hours=3))
+    assert [r["id"] for r in due] == [early["id"], late["id"]]
+
+    # resolved rows leave the queue
+    assert await lp.resolve(
+        db, early["id"], status="resolved", outcome_value=0, resolver="mechanical_absence"
+    )
+    due = await lp.list_due_open(db, now=NOW + timedelta(hours=3))
+    assert [r["id"] for r in due] == [late["id"]]
+
+
+async def test_list_by_subject(db):
+    await _mk(db)
+    await _mk(db, metric="positive_engagement")
+    rows = await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-1")
+    assert [r["metric"] for r in rows] == ["positive_engagement", "reply_received"]
+
+
+async def test_resolve_sets_outcome_brier_and_is_idempotent(db):
+    row = await _mk(db, confidence=0.8)
+    ok = await lp.resolve(
+        db,
+        row["id"],
+        status="resolved",
+        outcome_value=1,
+        resolver="mechanical",
+        evidence_ref="outreach_history:o-1",
+        now=NOW + timedelta(hours=25),
+    )
+    assert ok
+    graded = await lp.get_by_id(db, row["id"])
+    assert graded["status"] == "resolved"
+    assert graded["outcome_value"] == 1
+    assert graded["resolver"] == "mechanical"
+    assert graded["evidence_ref"] == "outreach_history:o-1"
+    assert graded["resolved_at"].endswith("+00:00")
+    assert graded["brier"] == pytest.approx((0.8 - 1) ** 2)
+    # double-grading is a no-op (guarded WHERE)
+    assert not await lp.resolve(
+        db, row["id"], status="resolved", outcome_value=0, resolver="mechanical"
+    )
+    assert (await lp.get_by_id(db, row["id"]))["outcome_value"] == 1
+
+
+async def test_resolve_via_fuzzy_queue(db):
+    """open → fuzzy_pending (queue) → fuzzy_resolved (the M8-bounded lane)."""
+    row = await _mk(db)
+    assert await lp.resolve(db, row["id"], status="fuzzy_pending")
+    mid = await lp.get_by_id(db, row["id"])
+    assert mid["status"] == "fuzzy_pending"
+    assert mid["outcome_value"] is None
+    assert await lp.resolve(
+        db, row["id"], status="fuzzy_resolved", outcome_value=0, resolver="llm_fallback"
+    )
+    assert (await lp.get_by_id(db, row["id"]))["status"] == "fuzzy_resolved"
+
+
+async def test_resolve_validation(db):
+    row = await _mk(db)
+    with pytest.raises(ValueError, match="invalid target status"):
+        await lp.resolve(db, row["id"], status="open")
+    with pytest.raises(ValueError, match="resolver is required"):
+        await lp.resolve(db, row["id"], status="resolved", outcome_value=1)
+    with pytest.raises(ValueError, match="invalid resolver"):
+        await lp.resolve(db, row["id"], status="resolved", outcome_value=1, resolver="oracle")
+    with pytest.raises(ValueError, match="outcome_value"):
+        await lp.resolve(db, row["id"], status="resolved", outcome_value=2, resolver="mechanical")
+    # row untouched by all rejected calls
+    assert (await lp.get_by_id(db, row["id"]))["status"] == "open"

--- a/tests/test_db/test_ledger_predictions_crud.py
+++ b/tests/test_db/test_ledger_predictions_crud.py
@@ -87,7 +87,9 @@ async def test_get_by_id_missing(db):
         ({"deadline_at": (NOW - timedelta(hours=1)).isoformat()}, "deadline_at"),
         ({"deadline_at": NOW.isoformat()}, "deadline_at"),
         ({"deadline_at": (NOW + timedelta(days=31)).isoformat()}, "deadline_at"),
-        ({"deadline_at": "not-a-date"}, "unparseable"),
+        ({"deadline_at": "not-a-date"}, "full ISO timestamp"),
+        # bare date is valid for bitemporal valid_at fields, NOT for a deadline
+        ({"deadline_at": "2026-07-20"}, "full ISO timestamp"),
         ({"provenance": "vibes"}, "provenance"),
     ],
 )
@@ -175,6 +177,26 @@ async def test_resolve_via_fuzzy_queue(db):
         db, row["id"], status="fuzzy_resolved", outcome_value=0, resolver="llm_fallback"
     )
     assert (await lp.get_by_id(db, row["id"]))["status"] == "fuzzy_resolved"
+
+
+async def test_resolve_status_outcome_pairing(db):
+    """Codex P2 (#1104): a scored status without a grade would silently drop
+    the row from the grader's queue ungraded; non-scored statuses must never
+    carry a grade."""
+    row = await _mk(db)
+    with pytest.raises(ValueError, match="requires an outcome_value"):
+        await lp.resolve(db, row["id"], status="resolved")
+    with pytest.raises(ValueError, match="requires an outcome_value"):
+        await lp.resolve(db, row["id"], status="fuzzy_resolved", resolver="llm_fallback")
+    with pytest.raises(ValueError, match="must not carry an outcome_value"):
+        await lp.resolve(db, row["id"], status="void", outcome_value=0, resolver="mechanical")
+    with pytest.raises(ValueError, match="must not carry an outcome_value"):
+        await lp.resolve(
+            db, row["id"], status="unresolvable", outcome_value=1, resolver="mechanical"
+        )
+    # non-scored terminal states without a grade are the legitimate form
+    assert await lp.resolve(db, row["id"], status="void")
+    assert (await lp.get_by_id(db, row["id"]))["status"] == "void"
 
 
 async def test_resolve_validation(db):

--- a/tests/test_db/test_migration_0064_ledger_predictions.py
+++ b/tests/test_db/test_migration_0064_ledger_predictions.py
@@ -1,0 +1,169 @@
+"""Migration 0064 — create ``ledger_predictions`` (WS-2 P1a substrate).
+
+Verifies the full column set, the four indexes (including the partial
+open-deadline index the grader rides), idempotency, the defense-in-depth
+CHECK matrix, the dedupe UNIQUE key, fresh-canonical parity with
+``_tables.py``, and ``down``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+import aiosqlite
+import pytest
+
+M64 = importlib.import_module("genesis.db.migrations.0064_ledger_predictions")
+
+_EXPECTED_COLUMNS = {
+    "id",
+    "created_at",
+    "action_class",
+    "subject_ref_type",
+    "subject_ref_id",
+    "domain",
+    "metric",
+    "comparator",
+    "threshold",
+    "confidence",
+    "deadline_at",
+    "provenance",
+    "predictor",
+    "source_session",
+    "rationale",
+    "status",
+    "outcome_value",
+    "resolved_at",
+    "resolver",
+    "evidence_ref",
+    "brier",
+    "metadata",
+}
+
+# Minimal valid row; tests override single fields to probe each CHECK.
+_BASE_ROW = {
+    "id": "p-1",
+    "action_class": "outreach_send",
+    "subject_ref_type": "outreach",
+    "subject_ref_id": "o-1",
+    "domain": "outreach.reminder",
+    "metric": "reply_received",
+    "comparator": "is_true",
+    "threshold": None,
+    "confidence": 0.5,
+    "deadline_at": "2026-07-19T12:00:00+00:00",
+    "provenance": "policy_prior",
+    "predictor": "test",
+}
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(ledger_predictions)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _insert(db: aiosqlite.Connection, **overrides) -> None:
+    row = {**_BASE_ROW, **overrides}
+    cols = ", ".join(row)
+    marks = ", ".join("?" for _ in row)
+    await db.execute(
+        f"INSERT INTO ledger_predictions ({cols}) VALUES ({marks})",  # noqa: S608 — test-local column names
+        tuple(row.values()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_up_creates_table_with_full_column_set(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M64.up(db)
+        assert await _columns(db) == _EXPECTED_COLUMNS
+
+
+@pytest.mark.asyncio
+async def test_up_creates_indexes_incl_partial(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M64.up(db)
+        cur = await db.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type='index' "
+            "AND tbl_name='ledger_predictions' AND name LIKE 'idx_lp%'"
+        )
+        indexes = {row[0]: row[1] for row in await cur.fetchall()}
+        assert set(indexes) == {
+            "idx_lp_open_deadline",
+            "idx_lp_domain",
+            "idx_lp_status",
+            "idx_lp_subject",
+        }
+        # the grader's hot query rides a PARTIAL index — open rows only
+        assert "WHERE status = 'open'" in indexes["idx_lp_open_deadline"]
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M64.up(db)
+        await M64.up(db)  # second run must not raise
+        assert await _columns(db) == _EXPECTED_COLUMNS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"action_class": "bogus_class"},
+        {"comparator": "eq"},
+        {"confidence": 0.0},
+        {"confidence": 1.0},
+        # comparator/threshold pairing, both directions
+        {"comparator": "le", "threshold": None},
+        {"comparator": "is_true", "threshold": 5.0},
+        {"provenance": "vibes"},
+        {"status": "bogus"},
+        {"outcome_value": 2},
+        {"resolver": "oracle"},
+    ],
+)
+async def test_check_matrix_rejects(tmp_path, overrides):
+    """Defense-in-depth CHECKs hold even for raw-SQL writers."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M64.up(db)
+        with pytest.raises(sqlite3.IntegrityError):
+            await _insert(db, **overrides)
+
+
+@pytest.mark.asyncio
+async def test_unique_dedupe_key(tmp_path):
+    """(action_class, subject_ref_id, metric) is idempotent under re-entry."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M64.up(db)
+        await _insert(db)
+        with pytest.raises(sqlite3.IntegrityError):
+            await _insert(db, id="p-2")  # same subject + metric, different id
+        # same subject, different metric is fine
+        await _insert(db, id="p-3", metric="positive_engagement")
+
+
+@pytest.mark.asyncio
+async def test_fresh_canonical_parity(tmp_path):
+    """_tables.py and the migration must build the identical column set."""
+    from genesis.db.schema import TABLES
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(TABLES["ledger_predictions"])
+        fresh_cols = await _columns(db)
+    async with aiosqlite.connect(str(tmp_path / "m.db")) as db:
+        await M64.up(db)
+        migrated_cols = await _columns(db)
+    assert fresh_cols == migrated_cols == _EXPECTED_COLUMNS
+
+
+@pytest.mark.asyncio
+async def test_down_drops_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M64.up(db)
+        await M64.down(db)
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='ledger_predictions'"
+        )
+        assert await cur.fetchone() is None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -72,6 +72,7 @@ EXPECTED_TABLES = [
     "data_migrations",  # WS-C: data-migration framework ledger
     "repo_pulse_runs",  # session-manager PR-4a: pulse worker run telemetry
     "repo_pulse_annotations",  # session-manager PR-4a: PR ↔ ledger-item matches
+    "ledger_predictions",  # WS-2 P1a: cognitive-ledger falsifiable prediction rows
 ]
 
 

--- a/tests/test_ledger/test_metrics.py
+++ b/tests/test_ledger/test_metrics.py
@@ -1,0 +1,324 @@
+"""Registry + resolver lane tests (WS-2 P1a).
+
+Every §2.3.1 lane for the spike-validated ``reply_received`` resolver is
+pinned here, plus each other metric's mechanical lanes. Resolvers get an
+injected ``now`` and prediction dicts — no wall-clock dependence, no
+``ledger_predictions`` rows needed (resolvers only read evidence tables).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.ledger.metrics import REGISTRY
+
+NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+PAST_DEADLINE = "2026-07-15T12:00:00+00:00"  # already passed at NOW
+FUTURE_DEADLINE = "2026-07-17T12:00:00+00:00"  # still open at NOW
+DAY = "2026-07-16"
+
+
+def _pred(subject: str, deadline: str = FUTURE_DEADLINE, threshold: float | None = None) -> dict:
+    return {"subject_ref_id": subject, "deadline_at": deadline, "threshold": threshold}
+
+
+async def _resolve(metric: str, db, pred: dict):
+    return await REGISTRY[metric].resolver_fn(db, pred, now=NOW)
+
+
+# ── seed helpers (evidence tables from the shared fixture) ───────────────────
+
+
+async def _seed_outreach(db, oid: str, *, signal=None, outcome=None, user_response=None):
+    await db.execute(
+        "INSERT INTO outreach_history (id, signal_type, topic, category, salience_score,"
+        " channel, message_content, created_at, engagement_signal, engagement_outcome,"
+        " user_response) VALUES (?, 't', 't', 'insight', 0.5, 'telegram', 'm',"
+        " '2026-07-14T00:00:00+00:00', ?, ?, ?)",
+        (oid, signal, outcome, user_response),
+    )
+    await db.commit()
+
+
+async def _seed_task(db, task_id: str, phase: str):
+    # task_states is trigger-guarded (intake gate) — go through the crud +
+    # a real token like every other test (never raw-insert into task_states).
+    from genesis.db.crud import task_states
+    from genesis.db.crud.task_states import create_intake_token
+
+    token = await create_intake_token(db)
+    await task_states.create(
+        db, task_id=task_id, description="d", current_phase=phase, intake_token=token
+    )
+
+
+async def _seed_outcome_event(db, *, ref_id: str, polarity: str):
+    await db.execute(
+        "INSERT INTO outcome_events (id, source, ref_type, ref_id, signal_type, signal_tier,"
+        " polarity, occurred_at) VALUES (?, 'autonomy', 'task', ?, 'execution_outcome', 1, ?,"
+        " '2026-07-16T10:00:00+00:00')",
+        (f"oe-{ref_id}-{polarity}", ref_id, polarity),
+    )
+    await db.commit()
+
+
+async def _seed_job_run(db, job: str, *, status: str, duration_ms=None, n=0):
+    await db.execute(
+        "INSERT INTO job_run_events (id, job_name, status, duration_ms, recorded_at)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (f"jre-{job}-{status}-{n}", job, status, duration_ms, f"{DAY}T0{n}:00:00+00:00"),
+    )
+    await db.commit()
+
+
+async def _seed_build(db, cid: str, decision=None):
+    await db.execute(
+        "INSERT INTO build_candidates (id, item_key, item_title, source_file, verdict,"
+        " user_decision) VALUES (?, 'k', 't', 'f', 'build', ?)",
+        (cid, decision),
+    )
+    await db.commit()
+
+
+async def _seed_proposal(db, pid: str, status: str):
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, created_at, status)"
+        " VALUES (?, 'research', 'c', '2026-07-16T00:00:00+00:00', ?)",
+        (pid, status),
+    )
+    await db.commit()
+
+
+# ── registry shape ───────────────────────────────────────────────────────────
+
+
+def test_registry_is_exactly_the_v1_set():
+    assert set(REGISTRY) == {
+        "reply_received",
+        "positive_engagement",
+        "completed",
+        "completed_first_attempt",
+        "acceptance_pass",
+        "runs_clean_day",
+        "runtime_ms_le",
+        "user_greenlights",
+        "approved_and_executes",
+    }
+
+
+def test_registry_specs_are_coherent():
+    ddl_classes = {
+        "outreach_send",
+        "task_execution",
+        "scheduled_job",
+        "build_verdict",
+        "ego_proposal",
+    }
+    for name, spec in REGISTRY.items():
+        assert spec.action_class in ddl_classes, name
+        assert spec.comparator_domain <= {"is_true", "le", "ge"} and spec.comparator_domain, name
+        assert spec.absence_semantics in ("zero", "void", "fuzzy_pending"), name
+        assert spec.default_horizon > timedelta(0), name
+        assert callable(spec.resolver_fn), name
+    assert REGISTRY["acceptance_pass"].fuzzy is True
+    assert REGISTRY["runtime_ms_le"].comparator_domain == {"le"}
+
+
+def test_no_llm_import_path():
+    """Importing the ledger must not pull ``genesis.routing`` (the no-LLM
+    lock — the P2 grader inherits it). Checked in a fresh interpreter because
+    this test process has long since imported routing via other suites."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys; import genesis.ledger.metrics; "
+        "bad = sorted(n for n in sys.modules if n.startswith('genesis.routing')); "
+        "print('pulled:', bad); sys.exit(1 if bad else 0)"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+
+# ── reply_received: every §2.3.1 lane ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("seed", "expected_outcome", "expected_lane"),
+    [
+        ({"signal": "user_reply"}, 1, "user_reply"),
+        ({"user_response": "sounds good"}, 1, "user_reply"),
+        ({"outcome": "useful"}, 1, "legacy_outcome:useful"),  # pre-signal-column reply row
+        ({"signal": "timeout", "outcome": "ignored"}, 0, "signal:timeout"),
+        ({"signal": "implicit_activity"}, 0, "signal:implicit_activity"),
+        ({"signal": "auto_digest"}, 0, "signal:auto_digest"),
+        ({"signal": "acted_on"}, 0, "signal:acted_on"),
+        ({"signal": "acknowledged"}, 0, "signal:acknowledged"),
+        ({"outcome": "ambivalent"}, 0, "outcome:ambivalent"),
+        ({"outcome": "ignored"}, 0, "outcome:ignored"),
+    ],
+)
+async def test_reply_received_signal_lanes(db, seed, expected_outcome, expected_lane):
+    await _seed_outreach(db, "o-1", **seed)
+    res = await _resolve("reply_received", db, _pred("o-1"))
+    assert (res.outcome_value, res.lane) == (expected_outcome, expected_lane)
+    assert res.evidence_ref == "outreach_history:o-1"
+
+
+async def test_reply_received_absence_and_open(db):
+    await _seed_outreach(db, "o-silent")
+    past = await _resolve("reply_received", db, _pred("o-silent", PAST_DEADLINE))
+    assert (past.outcome_value, past.lane) == (0, "mechanical_absence")
+    open_ = await _resolve("reply_received", db, _pred("o-silent", FUTURE_DEADLINE))
+    assert (open_.outcome_value, open_.lane) == (None, "open")
+
+
+async def test_reply_received_signal_beats_outcome_label(db):
+    """A captured reply wins even when an earlier label said ambivalent."""
+    await _seed_outreach(db, "o-up", signal="user_reply", outcome="ambivalent")
+    res = await _resolve("reply_received", db, _pred("o-up"))
+    assert (res.outcome_value, res.lane) == (1, "user_reply")
+
+
+async def test_reply_received_broken_evidence(db):
+    missing = await _resolve("reply_received", db, _pred("o-ghost"))
+    assert (missing.outcome_value, missing.lane) == (None, "unresolvable:subject_missing")
+    await _seed_outreach(db, "o-bad")
+    bad = await _resolve("reply_received", db, _pred("o-bad", "not-a-date"))
+    assert (bad.outcome_value, bad.lane) == (None, "unresolvable:bad_deadline")
+
+
+# ── positive_engagement ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("outcome", ["useful", "engaged", "acted_on", "acknowledged"])
+async def test_positive_engagement_canonical_positives(db, outcome):
+    await _seed_outreach(db, "o-pos", outcome=outcome)
+    res = await _resolve("positive_engagement", db, _pred("o-pos"))
+    assert (res.outcome_value, res.lane) == (1, f"positive_outcome:{outcome}")
+
+
+async def test_positive_engagement_negative_label_waits_for_deadline(db):
+    """record_reply upgrades an early 'ignored' unconditionally — only the
+    deadline closes the question."""
+    await _seed_outreach(db, "o-ig", signal="timeout", outcome="ignored")
+    open_ = await _resolve("positive_engagement", db, _pred("o-ig", FUTURE_DEADLINE))
+    assert (open_.outcome_value, open_.lane) == (None, "open")
+    past = await _resolve("positive_engagement", db, _pred("o-ig", PAST_DEADLINE))
+    assert (past.outcome_value, past.lane) == (0, "mechanical_absence")
+
+
+# ── task_execution ───────────────────────────────────────────────────────────
+
+
+async def test_completed_lanes(db):
+    await _seed_task(db, "t-done", "completed")
+    assert (await _resolve("completed", db, _pred("t-done"))).outcome_value == 1
+    await _seed_task(db, "t-fail", "failed")
+    res = await _resolve("completed", db, _pred("t-fail"))
+    assert (res.outcome_value, res.lane) == (0, "phase:failed")
+    await _seed_task(db, "t-run", "executing")
+    assert (await _resolve("completed", db, _pred("t-run", FUTURE_DEADLINE))).lane == "open"
+    late = await _resolve("completed", db, _pred("t-run", PAST_DEADLINE))
+    assert (late.outcome_value, late.lane) == (0, "mechanical_absence")
+    ghost = await _resolve("completed", db, _pred("t-ghost"))
+    assert ghost.lane == "unresolvable:subject_missing"
+
+
+async def test_completed_first_attempt(db):
+    await _seed_task(db, "t-clean", "completed")
+    clean = await _resolve("completed_first_attempt", db, _pred("t-clean"))
+    assert (clean.outcome_value, clean.lane) == (1, "completed_first_attempt")
+
+    await _seed_task(db, "t-retry", "completed")
+    await _seed_outcome_event(db, ref_id="t-retry", polarity="negative")
+    retried = await _resolve("completed_first_attempt", db, _pred("t-retry"))
+    assert (retried.outcome_value, retried.lane) == (0, "failed_attempt_evidence")
+
+    # a positive event is not a failed attempt
+    await _seed_task(db, "t-pos", "completed")
+    await _seed_outcome_event(db, ref_id="t-pos", polarity="positive")
+    assert (await _resolve("completed_first_attempt", db, _pred("t-pos"))).outcome_value == 1
+
+    # non-completed passes the base resolution through
+    await _seed_task(db, "t-nf", "failed")
+    assert (await _resolve("completed_first_attempt", db, _pred("t-nf"))).lane == "phase:failed"
+
+
+async def test_acceptance_pass_is_fuzzy(db):
+    res = await _resolve("acceptance_pass", db, _pred("t-any"))
+    assert (res.outcome_value, res.evidence_ref, res.lane) == (None, None, "fuzzy_pending")
+
+
+# ── scheduled_job ────────────────────────────────────────────────────────────
+
+
+async def test_runs_clean_day_lanes(db):
+    subject = f"dream_job:{DAY}"
+    # no runs, deadline passed → void (premise absent, separately alarmed)
+    void = await _resolve("runs_clean_day", db, _pred(subject, PAST_DEADLINE))
+    assert (void.outcome_value, void.lane) == (None, "void:no_runs")
+
+    await _seed_job_run(db, "dream_job", status="success", n=1)
+    open_ = await _resolve("runs_clean_day", db, _pred(subject, FUTURE_DEADLINE))
+    assert open_.lane == "open"
+    clean = await _resolve("runs_clean_day", db, _pred(subject, PAST_DEADLINE))
+    assert (clean.outcome_value, clean.lane) == (1, "clean_day")
+
+    # any failed run is conclusive regardless of deadline
+    await _seed_job_run(db, "dream_job", status="failed", n=2)
+    failed = await _resolve("runs_clean_day", db, _pred(subject, FUTURE_DEADLINE))
+    assert (failed.outcome_value, failed.lane) == (0, "failed_runs")
+
+    bad = await _resolve("runs_clean_day", db, _pred("no-day-here"))
+    assert bad.lane == "unresolvable:bad_subject_ref"
+
+
+async def test_runtime_ms_le_lanes(db):
+    subject = f"dream_job:{DAY}"
+    missing = await _resolve("runtime_ms_le", db, _pred(subject, PAST_DEADLINE))
+    assert missing.lane == "unresolvable:missing_threshold"
+
+    # no measured durations → void (honest instrument, never a free pass)
+    void = await _resolve("runtime_ms_le", db, _pred(subject, PAST_DEADLINE, threshold=5000))
+    assert (void.outcome_value, void.lane) == (None, "void:no_duration_data")
+
+    await _seed_job_run(db, "dream_job", status="success", duration_ms=3000, n=1)
+    within = await _resolve("runtime_ms_le", db, _pred(subject, PAST_DEADLINE, threshold=5000))
+    assert (within.outcome_value, within.lane) == (1, "within_threshold")
+
+    await _seed_job_run(db, "dream_job", status="success", duration_ms=9000, n=2)
+    over = await _resolve("runtime_ms_le", db, _pred(subject, FUTURE_DEADLINE, threshold=5000))
+    assert (over.outcome_value, over.lane) == (0, "exceeded_threshold")
+
+
+# ── build_verdict / ego_proposal ─────────────────────────────────────────────
+
+
+async def test_user_greenlights_lanes(db):
+    await _seed_build(db, "b-yes", "approved")
+    assert (await _resolve("user_greenlights", db, _pred("b-yes"))).outcome_value == 1
+    await _seed_build(db, "b-no", "rejected")
+    res = await _resolve("user_greenlights", db, _pred("b-no"))
+    assert (res.outcome_value, res.lane) == (0, "decision:rejected")
+    await _seed_build(db, "b-wait")
+    assert (await _resolve("user_greenlights", db, _pred("b-wait", FUTURE_DEADLINE))).lane == "open"
+    late = await _resolve("user_greenlights", db, _pred("b-wait", PAST_DEADLINE))
+    assert (late.outcome_value, late.lane) == (0, "mechanical_absence")
+
+
+async def test_approved_and_executes_lanes(db):
+    await _seed_proposal(db, "p-exec", "executed")
+    assert (await _resolve("approved_and_executes", db, _pred("p-exec"))).outcome_value == 1
+    await _seed_proposal(db, "p-rej", "rejected")
+    res = await _resolve("approved_and_executes", db, _pred("p-rej"))
+    assert (res.outcome_value, res.lane) == (0, "status:rejected")
+    # approved-but-not-executed: the metric is approved AND executes
+    await _seed_proposal(db, "p-appr", "approved")
+    assert (
+        await _resolve("approved_and_executes", db, _pred("p-appr", FUTURE_DEADLINE))
+    ).lane == "open"
+    late = await _resolve("approved_and_executes", db, _pred("p-appr", PAST_DEADLINE))
+    assert (late.outcome_value, late.lane) == (0, "mechanical_absence")


### PR DESCRIPTION
## Summary

First half of WS-2 PR-1 (cognitive ledger). Pure substrate — no runtime paths change until PR-1b wires the hooks.

- **Migration 0064** `ledger_predictions`: one row per falsifiable prediction ("P about subject S is TRUE by deadline D, probability c"). Defense-in-depth CHECKs (action_class/comparator/confidence/provenance/status/resolver enums, comparator↔threshold pairing), dedupe `UNIQUE (action_class, subject_ref_id, metric)`, and a partial index on open deadlines (the future grader's hot query). Mirrored in `_tables.py` (fresh-install parity) + registered in `test_schema.py`.
- **`genesis.ledger` package** (new): `metrics.py` holds the v1 registry — 9 metrics, each with a **pure-SQL resolver** implemented and unit-tested now, executed by the P2 grader later. `reply_received` ports the spike-validated lane map (measured 99.5% mechanical on live data) resolving off `outreach_history.engagement_signal`. A subprocess test locks the package against any import path to `genesis.routing` (zero-LLM guarantee).
- **`db/crud/ledger_predictions.py`**: falsifiability gate 1 — unknown metric, wrong action_class, disallowed comparator, broken threshold pairing, out-of-bounds confidence, or a deadline outside `(now, now+30d]` raise `ValueError` before any SQL executes. Grade-side helpers (`list_due_open`, `resolve` with SQL-computed Brier + idempotent guarded UPDATE) ship for PR-2.

## Notes for review

- Evidence sources deliberately deviate from the design doc's `outcome_events`-first sketch per the locked §2.3.1 note: outreach resolves off `engagement_signal` today; task/ego resolvers read state tables until the T1 bus emits (PR-1b) mature — migrating a resolver later changes no registry contract.
- `completed_first_attempt` degrades to `completed` until the executor emits negative execution events (task_states keeps no transition history) — documented in the resolver docstring.
- Job-day resolvers reuse `job_run_events.list_runs_for_day` (PR-0 shipped it anticipating exactly this consumer).

## Tests

100 green: migration CHECK matrix + partial-index + parity + idempotency; CRUD rejection matrix (14 cases) + round-trip + dedupe + fuzzy-queue path; every §2.3.1 lane per resolver; schema known-set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)