### PR TITLE
fix(reaper): idle detached slot sessions are reapable — spare attached clients, not bare panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and benign look-alikes (hyphenated slugs such as "sk-learn-pipeline") stay
   unflagged.
 
+- **Idle abandoned sessions can now actually be cleaned up.** The process
+  reaper's "is anyone looking at this terminal?" check counted every tmux
+  pane as live — including sessions nothing is attached to. Under
+  persistent slot sessions that meant an abandoned session could never be
+  reclaimed, no matter how long it sat idle. A tmux pane now counts as live
+  only while its session has a client attached; a detached session is still
+  spared as long as it shows recent activity (so a dropped connection
+  mid-work is never at risk), and only one that is BOTH detached and idle
+  past the 7-day window becomes a cleanup candidate. The reaper remains in
+  observe-only mode — it reports what it would clean up and touches nothing
+  until explicitly armed.
+
 - **Answering Genesis's questions with a plain message now actually works.**
   When Genesis asked something and waited for your answer (approvals,
   provision prompts, send-and-wait questions), an internal ordering bug left

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -10,7 +10,11 @@ IDLE policy instead:
     2. idle beyond the activity window (no per-PID activity marker written
        by the session-activity hook within the last 7 days), AND
     3. detached from any live terminal (its controlling tty is not in the
-       union of tmux pane ttys and utmp login ttys).
+       union of CLIENT-ATTACHED tmux pane ttys and utmp login ttys —
+       WS-D2 2026-07-16: a detached tmux session's panes no longer count
+       as live, else the persistent cc-N slot model would make every slot
+       claude unreapable forever; an attached slot is spared indefinitely,
+       and a detached one stays spared while its activity marker is fresh).
 
 This is a strict subset of the old age-only rule (kill if age >= 7d),
 so arming the new logic can never reap something the current production
@@ -180,30 +184,58 @@ async def _process_tty(pid: int) -> str | None:
     return _normalize_tty(stdout.decode())
 
 
-async def _live_ttys() -> set[str]:
-    """Union of tmux pane ttys and utmp (``who``) login ttys, normalised.
+def _attached_pane_ttys(listing: str) -> set[str]:
+    """Pane ttys of CLIENT-ATTACHED tmux sessions from ``list-panes -a -F
+    '#{session_attached} #{pane_tty}'`` output. Pure — unit-tested directly.
 
-    This is the live-terminal discriminator: a process whose controlling
-    tty is in this set is attached to a real session (verified 2026-07-11 —
-    interactive sessions in-set, reparented zombies out-of-set).
+    A malformed line (no leading integer) is treated as attached: on parse
+    drift the reaper must fail toward sparing, never toward reaping.
     """
     ttys: set[str] = set()
-    # tmux panes
+    for line in listing.splitlines():
+        fields = line.split(None, 1)
+        if len(fields) != 2:
+            continue
+        attached_raw, tty_raw = fields
+        try:
+            attached = int(attached_raw)
+        except ValueError:
+            attached = 1  # fail-spare: unknown format counts as attached
+        if attached < 1:
+            continue
+        norm = _normalize_tty(tty_raw)
+        if norm:
+            ttys.add(norm)
+    return ttys
+
+
+async def _live_ttys() -> set[str]:
+    """Union of ATTACHED tmux pane ttys and utmp (``who``) login ttys.
+
+    This is the live-terminal discriminator: a process whose controlling
+    tty is in this set has a human plausibly looking at it (verified
+    2026-07-11 — interactive sessions in-set, reparented zombies
+    out-of-set). WS-D2 (2026-07-16): a tmux pane counts only while its
+    session has an attached client — under the persistent cc-N slot model
+    every interactive claude lives in tmux forever, so bare pane existence
+    spared everything and idle detached slots could never be reaped. A
+    detached slot mid-long-turn is still spared by its fresh activity
+    marker (checked before the tty guard).
+    """
+    ttys: set[str] = set()
+    # tmux panes of attached sessions only
     with contextlib.suppress(Exception):
         proc = await asyncio.create_subprocess_exec(
             "tmux",
             "list-panes",
             "-a",
             "-F",
-            "#{pane_tty}",
+            "#{session_attached} #{pane_tty}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
         stdout, _ = await proc.communicate()
-        for line in stdout.decode().splitlines():
-            norm = _normalize_tty(line)
-            if norm:
-                ttys.add(norm)
+        ttys |= _attached_pane_ttys(stdout.decode())
     # utmp login ttys
     with contextlib.suppress(Exception):
         proc = await asyncio.create_subprocess_exec(

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -188,13 +188,22 @@ def _attached_pane_ttys(listing: str) -> set[str]:
     """Pane ttys of CLIENT-ATTACHED tmux sessions from ``list-panes -a -F
     '#{session_attached} #{pane_tty}'`` output. Pure — unit-tested directly.
 
-    A malformed line (no leading integer) is treated as attached: on parse
-    drift the reaper must fail toward sparing, never toward reaping.
+    A malformed line is treated as attached: on ANY parse drift the reaper
+    must fail toward sparing, never toward reaping. That covers both a
+    non-integer first field and a tty-only line (e.g. output shaped like
+    the pre-WS-D2 ``#{pane_tty}`` format).
     """
     ttys: set[str] = set()
     for line in listing.splitlines():
         fields = line.split(None, 1)
-        if len(fields) != 2:
+        if not fields:
+            continue
+        if len(fields) == 1:
+            # Single-field line: format drift back to tty-only. Fail-spare —
+            # count it as attached (adding junk can only ever spare).
+            norm = _normalize_tty(fields[0])
+            if norm:
+                ttys.add(norm)
             continue
         attached_raw, tty_raw = fields
         try:

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -120,8 +120,14 @@ def test_attached_panes_malformed_line_fails_toward_sparing():
     assert pr._attached_pane_ttys("wat /dev/pts/7\n") == {"pts/7"}
 
 
+def test_attached_panes_tty_only_line_fails_toward_sparing():
+    # Format drift back to bare '#{pane_tty}' output: a tty-only line must
+    # read as attached, not silently vanish from the live set.
+    assert pr._attached_pane_ttys("/dev/pts/9\npts/3\n") == {"pts/9", "pts/3"}
+
+
 def test_attached_panes_garbage_and_blanks_ignored():
-    assert pr._attached_pane_ttys("\n?\n1 ?\n0\n") == set()
+    assert pr._attached_pane_ttys("\n?\n1 ?\n") == set()
 
 
 # ── Orchestrator harness ────────────────────────────────────────────────

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -103,6 +103,27 @@ def test_normalize_tty(raw, expected):
     assert _normalize_tty(raw) == expected
 
 
+# ── Attached-pane parsing (WS-D2: detached slots are reapable) ──────────
+def test_attached_panes_included_detached_excluded():
+    listing = "1 /dev/pts/5\n0 /dev/pts/9\n2 /dev/pts/2\n"
+    assert pr._attached_pane_ttys(listing) == {"pts/5", "pts/2"}
+
+
+def test_attached_panes_all_detached_yields_empty():
+    # The persistent-slot regression: bare pane existence must NOT read as
+    # live — an idle detached cc-N slot has to be reapable.
+    assert pr._attached_pane_ttys("0 /dev/pts/4\n0 /dev/pts/8\n") == set()
+
+
+def test_attached_panes_malformed_line_fails_toward_sparing():
+    # Unknown format → treated as attached (never reap on parse drift).
+    assert pr._attached_pane_ttys("wat /dev/pts/7\n") == {"pts/7"}
+
+
+def test_attached_panes_garbage_and_blanks_ignored():
+    assert pr._attached_pane_ttys("\n?\n1 ?\n0\n") == set()
+
+
 # ── Orchestrator harness ────────────────────────────────────────────────
 class _FakeRT:
     def __init__(self, *, pipeline=None):


### PR DESCRIPTION
## What

Companion to #1106 (idempotent session doors). With every interactive claude now living in a persistent cc-N tmux slot, the reaper's live-terminal check had a fatal blind spot: `tmux list-panes -a` reports panes of **detached** sessions too, so bare pane existence marked every slot claude as `live-tty` forever — an abandoned idle slot could never be reclaimed, armed or not.

## Change

- `_live_ttys()` now asks tmux for `#{session_attached} #{pane_tty}` and counts a pane only while its session has an attached client. Parsing lives in a new pure `_attached_pane_ttys()`; a malformed line **fails toward sparing** (counts as attached) so parse drift can never cause a wrongful reap.
- The classifier and its spare-priority order are untouched: attached → spared indefinitely; detached with a fresh activity marker (dropped SSH mid-long-turn) → spared; only detached AND idle >7d AND older than the 7d age floor → `stale-detached`.
- **Stays DRY-RUN** (operator decision): no arming change; it logs WOULD-KILL and writes an observation only.

## Verification

- 4 new pure-parser tests (attached/detached split, all-detached regression, fail-spare on malformed, garbage tolerance); all 28 reaper tests pass.
- Parser exercised against live tmux 3.4 output (5 attached slots parsed correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)