### PR TITLE
fix(resilience): zram apply — restore boot persistence lost to unmask sweep

### DIFF
--- a/scripts/lib/host_swap.sh
+++ b/scripts/lib/host_swap.sh
@@ -221,7 +221,17 @@ host_swap_apply() {
         sudo systemctl restart "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
         echo "  zram swap unit already in place (size ${size_mib}MiB) — restarted (was inactive)."
     else
-        echo "  zram swap unit already in place (size ${size_mib}MiB)."
+        # Healthy device but boot persistence may have been lost: `systemctl
+        # unmask` sweeps the multi-user.target.wants symlink along with the
+        # mask (live-E2E finding 2026-07-16), leaving the unit active-but-
+        # disabled — zram would silently not start on the next boot. Re-enable
+        # when needed; a no-op (read-only is-enabled) on healthy hosts.
+        if [[ "$(systemctl is-enabled "$_HOSTSWAP_UNIT_NAME" 2>/dev/null)" != "enabled" ]]; then
+            sudo systemctl enable "$_HOSTSWAP_UNIT_NAME" 2>/dev/null || true
+            echo "  zram swap unit already in place (size ${size_mib}MiB) — re-enabled for boot."
+        else
+            echo "  zram swap unit already in place (size ${size_mib}MiB)."
+        fi
     fi
 
     # Verify the OUTCOME, not just the unit state: is a zram device actually

--- a/tests/test_scripts/test_host_swap_sh.py
+++ b/tests/test_scripts/test_host_swap_sh.py
@@ -382,6 +382,34 @@ def test_remove_cleans_up(tmp_path):
     assert "disable --now zram-swap.service" in _log(tmp_path)
 
 
+def test_active_but_disabled_restores_boot_persistence(tmp_path):
+    """`systemctl unmask` sweeps the wants symlink with the mask (live-E2E
+    finding): an active-but-disabled unit must be re-enabled by apply, or zram
+    silently doesn't start on the next boot."""
+    env = _sandbox(tmp_path)
+    _run(env)  # install
+    (tmp_path / "swaps").write_text(
+        "Filename Type Size Used Priority\n/dev/zram0 partition 4194304 0 100\n"
+    )
+    res = _run(env, extra_env={"SYSTEMCTL_IS_ENABLED": "disabled"})
+    assert res.returncode == 0
+    assert "re-enabled for boot" in res.stdout
+    assert "enable zram-swap.service" in _log(tmp_path)
+
+
+def test_active_and_enabled_stays_quiet(tmp_path):
+    """Healthy steady state (active + enabled) must not churn systemctl."""
+    env = _sandbox(tmp_path)
+    _run(env)
+    (tmp_path / "swaps").write_text(
+        "Filename Type Size Used Priority\n/dev/zram0 partition 4194304 0 100\n"
+    )
+    before = _log(tmp_path).count("enable zram-swap.service")
+    res = _run(env, extra_env={"SYSTEMCTL_IS_ENABLED": "enabled"})
+    assert "already in place" in res.stdout and "re-enabled" not in res.stdout
+    assert _log(tmp_path).count("enable zram-swap.service") == before
+
+
 # ── unit location (mask must WORK) + legacy migration ──────────────────────
 
 


### PR DESCRIPTION
## Summary

The live mask/unmask opt-out drill (post-#1105) surfaced one final systemd quirk: **`systemctl unmask` removes the `multi-user.target.wants` enablement symlink along with the mask symlink**, leaving the unit active-but-disabled — zram would silently not start on the next boot, and apply's healthy path (device active → "already in place") never re-enabled it.

## Fix

The healthy branch now checks `is-enabled` and re-enables when needed: a read-only no-op on healthy hosts (zero systemd churn — pinned by test), a single `enable` when persistence was lost.

Observed live: after mask → unmask, `is-enabled` reported `disabled`; verified re-enable restores the symlink to the relocated unit path.

2 regression tests (restore fires + healthy-state stays quiet); 34 green, `bash -n` + ruff clean.

This closes the last behavior gap found by the E3 live-drill series — every advertised behavior (cold activation, idempotency, recovery, opt-out round-trip incl. boot persistence) has now been exercised against the real host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)