### PR TITLE
fix(deploy): close 3 disaster-recovery BLOCKERs from the deploy-script audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
-- **The outbound secret scanner now catches modern API-key formats.** Before
+- **Disaster recovery no longer risks corrupting the thing it's recovering.** A
+  script audit found three ways deploy/restore could bite at the worst moment,
+  now fixed: (1) during a database restore, the health watchdog could restart
+  the server mid-rebuild — into a half-populated database that the next backup
+  would then capture as the newest "complete" snapshot; restore now holds the
+  same deploy-in-progress marker the watchdog already honors, so it stands down
+  until the restore finishes. (2) The pre-restore "undo" copy was taken from the
+  live database without its write-ahead log and then the original was deleted —
+  leaving a torn, stale rollback copy exactly when an operator needs to undo a
+  bad restore; the copy is now taken after the writer is stopped, via a
+  WAL-aware snapshot. (3) The Guardian installer aborted on any host without
+  Claude Code already installed — which is every fresh host, since the installer
+  runs before Node/CC are set up — because an "optional" CLI probe wasn't guarded
+  under strict mode; it now degrades gracefully as intended.
   sending on external channels (email, chat), Genesis scans messages and
   quarantines anything that looks like a leaked credential. Its API-key
   patterns predated today's key formats, so newer shapes slipped through

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -45,7 +45,17 @@
 # host-facing source IP — install_guardian.sh derives and installs this):
 #   from="CONTAINER_IP",command="~/.local/bin/guardian-gateway.sh",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 ...
 #
-# This gives Genesis a fixed allowlist of operations on the host. Nothing else.
+# This restricts Genesis to a fixed set of verbs on the host. Treat that as a
+# ROBUSTNESS boundary (a buggy or rogue command can't run arbitrary host ops),
+# NOT a security boundary against a *compromised* container. The `redeploy` verb
+# by design installs guardian code the container supplies, which the host then
+# runs as a passwordless-sudo user — so a compromised container can reach host
+# root through it. The sha256 on redeploy verifies TRANSFER INTEGRITY (the
+# container supplies that hash too), not PROVENANCE. Container compromise should
+# be treated as host compromise; the per-verb validation bounds blast radius from
+# bugs and mistakes, not from a hostile container. (Closing that gap would take a
+# host-side signature against a key the container does not hold — a deliberate
+# posture upgrade, not claimed here.)
 
 set -euo pipefail
 
@@ -429,6 +439,10 @@ PYEOF
         #   2. A membership gate checks the tar CONTAINS the required files
         #      (tar -tf, also pre-extraction) on BOTH forms — catching a
         #      wrong-pathspec / partial archive.
+        # These are ROBUSTNESS guards (they catch corruption/truncation/mistakes),
+        # NOT provenance: the sha256 is container-supplied, so a compromised
+        # container can ship attacker code with a matching hash. See the header
+        # note — redeploy is container-ships-code-the-host-runs by design.
         # Older update.sh clients that send only <hash> still work (sha skipped).
         REDEPLOY_ARGS="${SSH_ORIGINAL_COMMAND#redeploy }"
         COMMIT_HASH="${REDEPLOY_ARGS%% *}"

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -309,8 +309,12 @@ echo "  OK    Container '$CONTAINER_NAME': $CONTAINER_IP"
 # Sets the global TS_IP (host address the container reaches + approval URLs).
 derive_ts_ip
 
-# Claude CLI (optional)
-CLAUDE_PATH=$(command -v claude 2>/dev/null)
+# Claude CLI (optional). `|| true` is load-bearing: under `set -euo pipefail`
+# an unguarded `$(command -v claude)` exits non-zero when claude is absent and
+# aborts the whole installer — and host-setup.sh runs the Guardian install
+# BEFORE Node/CC exist, so every fresh host would fail here. Mirror the guarded
+# python3 probe at the top of this step.
+CLAUDE_PATH=$(command -v claude 2>/dev/null || true)
 CC_AUTHENTICATED=false
 if [ -n "$CLAUDE_PATH" ] && [ -f "$CLAUDE_PATH" ]; then
     echo "  OK    Claude CLI: $CLAUDE_PATH"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -81,7 +81,40 @@ _write_status() {
 {"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"dry_run":$DRY_RUN,"sqlite_restored":$_SQLITE_RESTORED,"qdrant_restored":$_QDRANT_RESTORED,"transcripts_restored":$_TRANSCRIPT_RESTORED,"memory_restored":$_MEMORY_RESTORED,"cc_memory_restored":$_CCMEM_RESTORED,"overlays_restored":$_OVERLAYS_RESTORED,"secrets_restored":$_SECRETS_RESTORED,"duration_s":$_duration,"failures":$_failures_json}
 STATUSEOF
 }
-trap '_write_status; backend_cleanup' EXIT
+# ── Deploy-in-progress marker ────────────────────────────────────────
+# While restore.sh holds the server stopped to rebuild the DB (a multi-minute
+# `.read` of a ~269MB dump), the autonomy watchdog (genesis-watchdog.timer,
+# ~every 300s) would otherwise see the inactive unit and restart genesis-server
+# into a HALF-BUILT database — which the 6h backup timer can then snapshot as the
+# newest COMPLETE backup. We hold the same marker `env.update_in_progress()`
+# already honors (~/.genesis/update_in_progress.pid, a bare live PID) so the
+# watchdog DEFERS its restart until the restore's EXIT trap clears it. We refuse
+# to clobber a marker a real update.sh/dashboard deploy already owns, and remove
+# it only if it is still OUR pid — never another deploy's.
+_UPDATE_PID_FILE="${GENESIS_HOME:-$HOME/.genesis}/update_in_progress.pid"
+_WROTE_UPDATE_MARKER=false
+_acquire_deploy_marker() {
+    mkdir -p "$(dirname "$_UPDATE_PID_FILE")"
+    if [ -f "$_UPDATE_PID_FILE" ]; then
+        local _other
+        _other="$(cat "$_UPDATE_PID_FILE" 2>/dev/null || true)"
+        if [[ "$_other" =~ ^[0-9]+$ ]] && [ "$_other" -gt 1 ] && kill -0 "$_other" 2>/dev/null; then
+            warn "a deploy already holds $_UPDATE_PID_FILE (pid $_other) — not overwriting; a concurrent update+restore is unsafe, verify the result"
+            return 0
+        fi
+    fi
+    echo "$$" > "$_UPDATE_PID_FILE"
+    _WROTE_UPDATE_MARKER=true
+    log "Holding deploy-in-progress marker (pid $$) so the watchdog won't revive genesis-server mid-restore"
+}
+_release_deploy_marker() {
+    $_WROTE_UPDATE_MARKER || return 0
+    # Remove only if it is still OUR pid (a later deploy may have taken over).
+    if [ -f "$_UPDATE_PID_FILE" ] && [ "$(cat "$_UPDATE_PID_FILE" 2>/dev/null || true)" = "$$" ]; then
+        rm -f "$_UPDATE_PID_FILE"
+    fi
+}
+trap '_write_status; _release_deploy_marker; backend_cleanup' EXIT
 
 # ── Setup ────────────────────────────────────────────────────────────
 GENESIS_DIR="${GENESIS_DIR:-$HOME/genesis}"
@@ -113,6 +146,9 @@ _SERVER_WAS_STOPPED=false
 _quiesce_genesis_server() {
     command -v systemctl >/dev/null 2>&1 || return 0
     if systemctl --user is-active --quiet genesis-server 2>/dev/null; then
+        # Hold the deploy marker BEFORE the stop so there is no window in which
+        # the watchdog sees an inactive unit without the defer signal in place.
+        _acquire_deploy_marker
         log "Stopping genesis-server before SQLite restore (will NOT auto-restart)..."
         # Only record "stopped" if the stop actually succeeded — otherwise the
         # end-of-run note would tell the operator to restart a server that never
@@ -390,14 +426,30 @@ if resolve_payload "$BACKUP_DIR/data/genesis.sql"; then
                 cp "$src" "$_SQL_TMP"
             fi
             if [ -s "$_SQL_TMP" ]; then
-                # Back up the existing DB before we overwrite it.
-                if [ -f "$DB_FILE" ]; then
-                    cp "$DB_FILE" "${DB_FILE}.pre-restore.$(date +%s)"
-                fi
-                # Fresh DB from the SQL dump. Stop the live writer first, and
-                # clear stale WAL/SHM sidecars — a leftover -wal would replay
-                # onto the new DB and corrupt it.
+                # Fresh DB from the SQL dump. Stop the live writer FIRST — both
+                # the pre-restore safety copy AND the new DB must be taken with
+                # no open WAL connection, or they are torn/stale.
                 _quiesce_genesis_server
+                # Back up the existing DB before we overwrite it. Taken AFTER
+                # quiescing and via `sqlite3 .backup` (WAL-aware) so the undo
+                # artifact is a consistent snapshot — the old behavior did a
+                # plain `cp` of only the main db file BEFORE quiescing, missing
+                # the -wal, so the sole rollback copy was torn exactly when an
+                # operator needs it to undo a bad restore. Fall back to copying
+                # the db + its sidecars together if sqlite3 is unavailable.
+                if [ -f "$DB_FILE" ]; then
+                    _PRE_RESTORE="${DB_FILE}.pre-restore.$(date +%s)"
+                    if command -v sqlite3 >/dev/null && sqlite3 "$DB_FILE" ".backup '$_PRE_RESTORE'" 2>/dev/null; then
+                        log "SQLite: pre-restore safety copy → $_PRE_RESTORE (sqlite3 .backup, WAL-correct)"
+                    else
+                        cp "$DB_FILE" "$_PRE_RESTORE"
+                        [ -f "$DB_FILE-wal" ] && cp "$DB_FILE-wal" "${_PRE_RESTORE}-wal"
+                        [ -f "$DB_FILE-shm" ] && cp "$DB_FILE-shm" "${_PRE_RESTORE}-shm"
+                        log "SQLite: pre-restore safety copy → $_PRE_RESTORE (cp + sidecars; sqlite3 unavailable)"
+                    fi
+                fi
+                # Clear stale WAL/SHM sidecars — a leftover -wal would replay
+                # onto the new DB and corrupt it.
                 rm -f "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"
                 if command -v sqlite3 >/dev/null; then
                     if sqlite3 "$DB_FILE" ".read $_SQL_TMP"; then

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -145,10 +145,15 @@ log "big-temp dir: $GENESIS_BIG_TMP"
 _SERVER_WAS_STOPPED=false
 _quiesce_genesis_server() {
     command -v systemctl >/dev/null 2>&1 || return 0
+    # Acquire the deploy marker UNCONDITIONALLY (systemctl exists → a watchdog
+    # could run). The watchdog revives an INACTIVE unit, so the marker matters
+    # MOST when the server is already stopped at restore start — a cautious
+    # operator may `systemctl --user stop genesis-server` before restoring, or it
+    # may have crashed. Gating the marker on is-active (as an earlier draft did)
+    # would leave that highest-risk case — the multi-minute .read — unprotected.
+    # Only the stop ACTION below is gated on liveness.
+    _acquire_deploy_marker
     if systemctl --user is-active --quiet genesis-server 2>/dev/null; then
-        # Hold the deploy marker BEFORE the stop so there is no window in which
-        # the watchdog sees an inactive unit without the defer signal in place.
-        _acquire_deploy_marker
         log "Stopping genesis-server before SQLite restore (will NOT auto-restart)..."
         # Only record "stopped" if the stop actually succeeded — otherwise the
         # end-of-run note would tell the operator to restart a server that never

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -56,6 +56,7 @@ def _local_config() -> dict:
         return {}
     try:
         import yaml  # noqa: PLC0415 — lazy import, yaml is always available
+
         with cfg_path.open() as fh:
             _LOCAL_CONFIG = yaml.safe_load(fh) or {}
     except Exception:
@@ -115,7 +116,9 @@ def memory_writebacks_off() -> bool:
     re-rank memories for later ones. Default off: production unaffected.
     """
     return os.environ.get("GENESIS_MEMORY_WRITEBACKS_OFF", "").strip() in (
-        "1", "true", "yes",
+        "1",
+        "true",
+        "yes",
     )
 
 
@@ -154,10 +157,12 @@ def update_in_progress() -> bool:
     and deadlocks bootstrap's procedure seed (incident IR-2). Two independent
     deploy signals are honored — either one alive → in progress:
 
-    * ``~/.genesis/update_in_progress.pid`` — a bare-integer PID written by the
-      dashboard-orchestrated update path (``dashboard/routes/updates.py``).
-      Present ONLY for dashboard-triggered updates; a CLI ``./scripts/update.sh``
-      run never writes it.
+    * ``~/.genesis/update_in_progress.pid`` — a bare-integer PID. Written by the
+      dashboard-orchestrated update path (``dashboard/routes/updates.py``) and by
+      ``scripts/restore.sh`` while it holds the server stopped to rebuild the DB
+      (so the watchdog does not revive it into a half-built database). A CLI
+      ``./scripts/update.sh`` run does not write it — it uses the state file
+      below. Any writer is honored: only liveness is checked, never identity.
     * ``~/.genesis/update_state.json`` — ``{phase, pid, started_at, ...}`` written
       per-phase by ``update.sh::_write_state`` (the CLI path; the incident path).
       Counts only while ``phase != "done"`` (``done`` is written immediately

--- a/tests/test_scripts/test_install_guardian_prereqs.py
+++ b/tests/test_scripts/test_install_guardian_prereqs.py
@@ -1,0 +1,41 @@
+"""Regression test for ``scripts/install_guardian.sh`` prerequisite probing.
+
+The Guardian installer runs under ``set -euo pipefail`` and host-setup.sh runs it
+BEFORE Node/Claude Code are installed. An unguarded ``CLAUDE_PATH=$(command -v
+claude)`` therefore aborts the whole installer on every fresh host (``command -v``
+exits non-zero when claude is absent → ``set -e`` kills the script) even though
+the CLI is documented as optional. This test extracts the actual probe line from
+the script and proves it survives the strict mode with claude absent.
+"""
+
+import subprocess
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "install_guardian.sh"
+
+
+def _claude_probe_line() -> str:
+    for line in _SCRIPT.read_text().splitlines():
+        if "CLAUDE_PATH=$(command -v claude" in line:
+            return line.strip()
+    raise AssertionError("CLAUDE_PATH probe line not found in install_guardian.sh")
+
+
+def test_claude_probe_is_set_e_safe_when_claude_absent():
+    """The real probe line, run under the script's own strict mode with claude
+    absent (empty PATH), must not abort — otherwise fresh-host installs die."""
+    line = _claude_probe_line()
+    # Empty PATH is set INSIDE the script (so `command -v claude` finds nothing);
+    # `command`/`true`/`echo` are builtins. subprocess still finds bash via the
+    # real inherited env.
+    script = f"export PATH=/nonexistent\nset -euo pipefail\n{line}\necho SURVIVED\n"
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"CLAUDE_PATH probe aborts under set -e when claude is absent "
+        f"(fresh-host install would fail here):\n{line}\nstderr: {proc.stderr}"
+    )
+    assert "SURVIVED" in proc.stdout, proc.stdout

--- a/tests/test_scripts/test_restore_safety.py
+++ b/tests/test_scripts/test_restore_safety.py
@@ -236,6 +236,46 @@ def test_restore_holds_deploy_marker_across_stop(sandbox):
     )
 
 
+def _write_sqlite3_marker_probe(bind: Path, calls: Path) -> None:
+    """sqlite3 wrapper that, on the dump `.read`, records whether the deploy
+    marker exists AT THAT MOMENT — proving the marker is held during the
+    multi-minute DB rebuild — then execs the real sqlite3."""
+    real = shutil.which("sqlite3")
+    _make_stub(
+        bind / "sqlite3",
+        "#!/usr/bin/env bash\n"
+        'for a in "$@"; do case "$a" in\n'
+        '  .read*) if [ -f "$HOME/.genesis/update_in_progress.pid" ]; then\n'
+        f'            echo MARKER_PRESENT_DURING_READ >> "{calls}"\n'
+        "          else\n"
+        f'            echo MARKER_ABSENT_DURING_READ >> "{calls}"\n'
+        "          fi ;;\n"
+        "esac; done\n"
+        f'exec {real} "$@"\n',
+    )
+
+
+def test_restore_holds_marker_when_server_already_inactive(sandbox):
+    """The watchdog revives an INACTIVE unit — so the marker must be held during
+    the DB rebuild even when genesis-server is already stopped at restore start
+    (operator pre-stop, or a crash): the highest-risk, longest window."""
+    _write_systemctl(sandbox["bind"], sandbox["calls"], active=False)
+    _write_sqlite3_marker_probe(sandbox["bind"], sandbox["calls"])
+    _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    calls = _calls(sandbox)
+    assert "stop genesis-server" not in calls, "stopped a server that wasn't active"
+    assert "MARKER_PRESENT_DURING_READ" in calls, (
+        "deploy marker NOT held during the DB rebuild when the server was already "
+        f"inactive — watchdog could revive mid-restore:\n{calls}\n{proc.stdout}"
+    )
+    assert "MARKER_ABSENT_DURING_READ" not in calls, calls
+    assert not (sandbox["home"] / ".genesis" / "update_in_progress.pid").exists(), (
+        "deploy marker not released by the EXIT trap"
+    )
+
+
 def test_restore_does_not_clobber_a_live_foreign_deploy_marker(sandbox):
     """If a real update.sh/dashboard deploy already owns the marker, restore must
     NOT overwrite it (and must not remove another deploy's marker in its trap);

--- a/tests/test_scripts/test_restore_safety.py
+++ b/tests/test_scripts/test_restore_safety.py
@@ -40,13 +40,13 @@ def _write_systemctl(bind: Path, calls: Path, *, active: bool = True, stop_rc: i
     active_rc = 0 if active else 3
     _make_stub(
         bind / "systemctl",
-        '#!/usr/bin/env bash\n'
+        "#!/usr/bin/env bash\n"
         f'echo "$*" >> "{calls}"\n'
         'case "$*" in\n'
-        f'  *is-active*) exit {active_rc} ;;\n'
-        f'  *stop*) exit {stop_rc} ;;\n'
-        'esac\n'
-        'exit 0\n',
+        f"  *is-active*) exit {active_rc} ;;\n"
+        f"  *stop*) exit {stop_rc} ;;\n"
+        "esac\n"
+        "exit 0\n",
     )
 
 
@@ -56,10 +56,10 @@ def _write_sqlite3_integrity_intercept(bind: Path) -> None:
     real = shutil.which("sqlite3")
     _make_stub(
         bind / "sqlite3",
-        '#!/usr/bin/env bash\n'
+        "#!/usr/bin/env bash\n"
         'for a in "$@"; do case "$a" in\n'
         '  *integrity_check*) echo "*** in database main ***"; exit 0 ;;\n'
-        'esac; done\n'
+        "esac; done\n"
         f'exec {real} "$@"\n',
     )
 
@@ -82,7 +82,8 @@ def _seed_live_db(gd: Path) -> Path:
     db = gd / "data" / "genesis.db"
     subprocess.run(
         ["sqlite3", str(db), "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
-        check=True, capture_output=True,
+        check=True,
+        capture_output=True,
     )
     (gd / "data" / "genesis.db-wal").write_bytes(b"STALE-WAL-SHOULD-BE-REMOVED")
     (gd / "data" / "genesis.db-shm").write_bytes(b"STALE-SHM-SHOULD-BE-REMOVED")
@@ -93,8 +94,7 @@ def _seed_backup(tmp_path: Path) -> Path:
     """Backup dir with a plaintext SQL dump (no GPG)."""
     bkp = tmp_path / "backup"
     (bkp / "data").mkdir(parents=True)
-    (bkp / "data" / "genesis.sql").write_text(
-        "CREATE TABLE t(x);\nINSERT INTO t VALUES(42);\n")
+    (bkp / "data" / "genesis.sql").write_text("CREATE TABLE t(x);\nINSERT INTO t VALUES(42);\n")
     return bkp
 
 
@@ -104,10 +104,13 @@ def _run_restore(sandbox):
     env["HOME"] = str(sandbox["home"])
     env["GENESIS_DIR"] = str(sandbox["gd"])
     env["QDRANT_URL"] = "http://127.0.0.1:1"  # dead → Qdrant restore skips fast
-    env["PATH"] = f'{sandbox["bind"]}:{env["PATH"]}'
+    env["PATH"] = f"{sandbox['bind']}:{env['PATH']}"
     return subprocess.run(
         ["bash", str(_RESTORE), "--from", str(bkp), "--force"],
-        env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL,
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
     )
 
 
@@ -121,8 +124,9 @@ def test_restore_stops_server_and_does_not_restart(sandbox):
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     calls = _calls(sandbox)
     assert "stop genesis-server" in calls, f"server not stopped before restore:\n{calls}"
-    assert "start genesis-server" not in calls and "restart genesis-server" not in calls, \
+    assert "start genesis-server" not in calls and "restart genesis-server" not in calls, (
         f"server must be left stopped (no auto-restart):\n{calls}"
+    )
 
 
 def test_restore_clears_stale_wal_shm(sandbox):
@@ -131,8 +135,7 @@ def test_restore_clears_stale_wal_shm(sandbox):
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert not (sandbox["gd"] / "data" / "genesis.db-wal").exists(), "stale -wal not removed"
     assert not (sandbox["gd"] / "data" / "genesis.db-shm").exists(), "stale -shm not removed"
-    out = subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
-                         capture_output=True, text=True)
+    out = subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"], capture_output=True, text=True)
     assert out.stdout.strip() == "42", f"DB not restored from backup dump: {out.stdout!r}"
 
 
@@ -143,8 +146,9 @@ def test_restore_verifies_db_after_restore(sandbox):
     proc = _run_restore(sandbox)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     # New code emits this exact marker only on a passing PRAGMA integrity_check.
-    assert "integrity_check ok" in proc.stdout.lower(), \
+    assert "integrity_check ok" in proc.stdout.lower(), (
         f"integrity_check not run/logged after restore:\n{proc.stdout}"
+    )
     status = json.loads((sandbox["home"] / ".genesis" / "restore_status.json").read_text())
     assert status["sqlite_restored"] is True, status
 
@@ -158,8 +162,12 @@ def test_restore_proceeds_and_warns_when_stop_fails(sandbox):
     assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"  # warn → failure → exit 1
     assert "could not stop genesis-server" in proc.stdout
     assert "left stopped" not in proc.stdout, "misleading note after a failed stop"
-    assert subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
-                          capture_output=True, text=True).stdout.strip() == "42"
+    assert (
+        subprocess.run(
+            ["sqlite3", str(db), "SELECT x FROM t;"], capture_output=True, text=True
+        ).stdout.strip()
+        == "42"
+    )
 
 
 def test_restore_skips_stop_when_server_inactive(sandbox):
@@ -170,8 +178,12 @@ def test_restore_skips_stop_when_server_inactive(sandbox):
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert "stop genesis-server" not in _calls(sandbox), "stopped a server that wasn't active"
     assert "left stopped" not in proc.stdout
-    assert subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
-                          capture_output=True, text=True).stdout.strip() == "42"
+    assert (
+        subprocess.run(
+            ["sqlite3", str(db), "SELECT x FROM t;"], capture_output=True, text=True
+        ).stdout.strip()
+        == "42"
+    )
 
 
 def test_restore_warns_on_integrity_failure(sandbox):
@@ -185,3 +197,113 @@ def test_restore_warns_on_integrity_failure(sandbox):
     status = json.loads((sandbox["home"] / ".genesis" / "restore_status.json").read_text())
     assert status["success"] is False
     assert status["failures"], "integrity failure not recorded in restore_status.json"
+
+
+# ── Deploy-in-progress marker (watchdog must not revive the server mid-restore) ──
+
+
+def _write_systemctl_marker_probe(bind: Path, calls: Path) -> None:
+    """systemctl stub that, on `stop`, records whether the deploy marker file
+    already exists — proving the marker is held BEFORE the server is stopped (the
+    window the watchdog would otherwise revive the half-built DB in)."""
+    _make_stub(
+        bind / "systemctl",
+        "#!/usr/bin/env bash\n"
+        f'echo "$*" >> "{calls}"\n'
+        'case "$*" in\n'
+        "  *is-active*) exit 0 ;;\n"
+        '  *stop*) [ -f "$HOME/.genesis/update_in_progress.pid" ] '
+        f'&& echo MARKER_PRESENT_AT_STOP >> "{calls}"; exit 0 ;;\n'
+        "esac\n"
+        "exit 0\n",
+    )
+
+
+def test_restore_holds_deploy_marker_across_stop(sandbox):
+    """While restore.sh holds genesis-server stopped, it must hold the
+    ``update_in_progress`` marker env.update_in_progress() honors — in place
+    BEFORE the stop and released by the EXIT trap — so the autonomy watchdog
+    defers instead of reviving the server into a half-built DB."""
+    _write_systemctl_marker_probe(sandbox["bind"], sandbox["calls"])
+    _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    calls = _calls(sandbox)
+    assert "MARKER_PRESENT_AT_STOP" in calls, f"deploy marker not held at stop time:\n{calls}"
+    assert "holding deploy-in-progress marker" in proc.stdout.lower(), proc.stdout
+    assert not (sandbox["home"] / ".genesis" / "update_in_progress.pid").exists(), (
+        "deploy marker not released by the EXIT trap (would disable the watchdog)"
+    )
+
+
+def test_restore_does_not_clobber_a_live_foreign_deploy_marker(sandbox):
+    """If a real update.sh/dashboard deploy already owns the marker, restore must
+    NOT overwrite it (and must not remove another deploy's marker in its trap);
+    the concurrency is surfaced as a warning (exit 1) but the restore proceeds."""
+    marker = sandbox["home"] / ".genesis" / "update_in_progress.pid"
+    sleeper = subprocess.Popen(["sleep", "30"])  # a live stand-in "other deploy"
+    try:
+        marker.write_text(str(sleeper.pid))
+        _seed_live_db(sandbox["gd"])
+        proc = _run_restore(sandbox)
+        assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"  # warn → exit 1
+        assert "not overwriting" in proc.stdout.lower(), proc.stdout
+        assert marker.exists() and marker.read_text().strip() == str(sleeper.pid), (
+            "a live foreign deploy marker was clobbered"
+        )
+        assert (
+            subprocess.run(
+                ["sqlite3", str(sandbox["gd"] / "data" / "genesis.db"), "SELECT x FROM t;"],
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            == "42"
+        ), "restore did not proceed"
+    finally:
+        sleeper.terminate()
+        sleeper.wait()
+        if marker.exists():
+            marker.unlink()
+
+
+# ── Pre-restore safety copy must be WAL-correct (a valid undo artifact) ──
+
+
+def _seed_wal_db(gd: Path) -> Path:
+    """A clean WAL-mode SQLite DB (the live-writer shape restore quiesces)."""
+    import sqlite3
+
+    db = gd / "data" / "genesis.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE t(x)")
+        conn.execute("INSERT INTO t VALUES(1)")
+        conn.commit()
+    finally:
+        conn.close()
+    return db
+
+
+def test_pre_restore_safety_copy_is_valid_and_taken_via_backup(sandbox):
+    """The pre-restore undo copy must be a STRUCTURALLY VALID sqlite db holding
+    the pre-restore state — taken via ``sqlite3 .backup`` (WAL-aware) after the
+    writer is quiesced, not a torn main-file-only ``cp`` from under a live WAL."""
+    _seed_wal_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    copies = [
+        c
+        for c in (sandbox["gd"] / "data").glob("genesis.db.pre-restore.*")
+        if not c.name.endswith(("-wal", "-shm"))
+    ]
+    assert len(copies) == 1, f"expected exactly one pre-restore copy, got {copies}"
+    integ = subprocess.run(
+        ["sqlite3", str(copies[0]), "PRAGMA integrity_check;"], capture_output=True, text=True
+    ).stdout.strip()
+    assert integ == "ok", f"pre-restore copy is not a valid db: {integ!r}"
+    val = subprocess.run(
+        ["sqlite3", str(copies[0]), "SELECT x FROM t;"], capture_output=True, text=True
+    ).stdout.strip()
+    assert val == "1", f"pre-restore copy missing the pre-restore state: {val!r}"
+    assert "wal-correct" in proc.stdout.lower(), proc.stdout


### PR DESCRIPTION
## Summary

Fixes the three **BLOCKER**-tier findings from the 2026-07-13 deploy-script audit (4 auditor reports, 55 findings total). Full ranked plan: `~/.genesis/output/deploy-audit-2026-07-13/00-REMEDIATION-PLAN.md`. The remaining 29 HIGH / 7 MED / 16 LOW are tracked for follow-up waves.

### 1. `restore.sh` — watchdog revives the server mid-restore (data-safety)
Restore stops `genesis-server` then rebuilds the DB via a multi-minute `.read` of a ~269MB dump, but wrote no deploy inhibitor. The health watchdog (~every 300s) could see the inactive unit and restart the server **into a half-built DB**, which the 6h backup timer would then snapshot as the newest COMPLETE backup — corrupting the very safety net a restore exists to rebuild.
**Fix:** hold the same `~/.genesis/update_in_progress.pid` marker `env.update_in_progress()` already honors — acquired **before** the stop (closing the watchdog window), released in the EXIT trap, and **non-clobbering** (refuses to overwrite or remove a marker a real `update.sh`/dashboard deploy owns).

### 2. `restore.sh` — pre-restore undo copy is torn (data-safety)
The undo copy was a plain `cp` of `genesis.db` (main file only) taken **before** quiescing the writer, then the original **and its `-wal`** were `rm`'d — so the only rollback artifact was missing all un-checkpointed WAL writes exactly when an operator needs to undo a bad restore.
**Fix:** quiesce first, then take the copy via `sqlite3 .backup` (WAL-aware); fall back to copying the db + its `-wal`/`-shm` sidecars together when sqlite3 is unavailable.

### 3. `install_guardian.sh` — installer aborts on every fresh host (installer)
`CLAUDE_PATH=$(command -v claude 2>/dev/null)` was unguarded under `set -euo pipefail`, so it exited non-zero and killed the installer when claude was absent — and `host-setup.sh` runs the Guardian install **before** Node/CC exist, so every fresh host failed here despite the CLI being documented "optional".
**Fix:** add `|| true` (mirrors the guarded python3 probe at `:280`).

## Tests
- `test_restore_safety.py`: + marker-held-across-stop (systemctl stub proves the marker is present when the server is stopped), + no-clobber of a live foreign marker (exit 1, marker untouched, restore proceeds), + WAL-correct undo copy (valid sqlite db holding pre-restore state via `.backup`).
- `test_install_guardian_prereqs.py` (new): extracts the real probe line and proves it survives strict mode with claude absent.
- Full restore-safety suite (9) + install-guardian test pass locally; `bash -n` + shellcheck clean; ruff clean.

## Deploy note
Touches `install_guardian.sh` → **Host-Deploy Gate applies** (update.sh redeploys the Guardian). `restore.sh` is not a live-runtime path — verified via the test suite + a dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)