### PR TITLE
feat(entity): entity_adjudications ledger + deferred-work retention (PR-A substrate)

### DIFF
--- a/src/genesis/db/crud/deferred_work.py
+++ b/src/genesis/db/crud/deferred_work.py
@@ -25,8 +25,19 @@ async def create(
            (id, work_type, call_site_id, priority, payload_json, deferred_at,
             deferred_reason, staleness_policy, staleness_ttl_s, status, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (id, work_type, call_site_id, priority, payload_json, deferred_at,
-         deferred_reason, staleness_policy, staleness_ttl_s, status, created_at),
+        (
+            id,
+            work_type,
+            call_site_id,
+            priority,
+            payload_json,
+            deferred_at,
+            deferred_reason,
+            staleness_policy,
+            staleness_ttl_s,
+            status,
+            created_at,
+        ),
     )
     await db.commit()
     return id
@@ -272,3 +283,25 @@ async def query_failed(
     db.row_factory = aiosqlite.Row
     cursor = await db.execute(sql, params)
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def prune_terminal(db: aiosqlite.Connection, *, cutoff_iso: str) -> int:
+    """Delete terminal rows (completed/discarded/expired) finished before *cutoff_iso*.
+
+    Terminal-row retention across ALL work types — the queue had no prune, so
+    finished rows accumulated forever (the leak class the entity_adjudication
+    orphans were a symptom of). Prunes on ``completed_at`` (when the row actually
+    finished), NOT ``created_at`` — a long-pending row that just completed must
+    not be swept by an age test against its birth. Rows with a NULL completed_at
+    are never pruned here (they are not truly terminal from a timing standpoint).
+    Returns the number of rows deleted.
+    """
+    cursor = await db.execute(
+        """DELETE FROM deferred_work_queue
+           WHERE status IN ('completed', 'discarded', 'expired')
+             AND completed_at IS NOT NULL
+             AND completed_at < ?""",
+        (cutoff_iso,),
+    )
+    await db.commit()
+    return cursor.rowcount

--- a/src/genesis/db/crud/entity_adjudications.py
+++ b/src/genesis/db/crud/entity_adjudications.py
@@ -1,0 +1,181 @@
+"""CRUD for entity_adjudications — the entity-node merge-vs-distinct ledger.
+
+One row per fuzzy entity PAIR (order-independent ``pair_key``). See the table
+docstring in ``db/schema/_tables.py`` and migration 0065 for the column model.
+This is NOT ``entity_resolution_audit`` (memory-pair dedup) — it records whether
+two ENTITY NODES are the same real-world thing.
+
+Reads build dicts from an explicit column list rather than relying on
+``row_factory`` (the shared connection's factory is not guaranteed).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+_COLS = (
+    "id",
+    "pair_key",
+    "entity_a",
+    "entity_b",
+    "loser_id",
+    "survivor_id",
+    "verdict",
+    "reasoning",
+    "provider",
+    "mode",
+    "norm_a",
+    "norm_b",
+    "updated_a",
+    "updated_b",
+    "created_at",
+    "applied_at",
+)
+
+
+def pair_key(entity_a: str, entity_b: str) -> str:
+    """Order-independent dedup key: sorted id pair joined by '|'."""
+    lo, hi = sorted((entity_a, entity_b))
+    return f"{lo}|{hi}"
+
+
+def _row_to_dict(row: tuple) -> dict:
+    return dict(zip(_COLS, row, strict=True))
+
+
+async def record_verdict(
+    db: aiosqlite.Connection,
+    *,
+    entity_a: str,
+    entity_b: str,
+    verdict: str,
+    reasoning: str | None = None,
+    provider: str | None = None,
+    mode: str | None = None,
+    loser_id: str | None = None,
+    survivor_id: str | None = None,
+    norm_a: str | None = None,
+    norm_b: str | None = None,
+    updated_a: str | None = None,
+    updated_b: str | None = None,
+    applied_at: str | None = None,
+    _commit: bool = True,
+) -> str:
+    """Upsert a verdict keyed on the order-independent pair.
+
+    Overwrite-on-conflict (latest judgment wins): a re-adjudicated ``stale``
+    pair records its fresh verdict rather than being silently ignored. Callers
+    that must not re-judge an already-decided pair check ``get_by_pair`` first.
+    Returns the row id (fresh uuid on insert; existing id on conflict-update).
+    """
+    key = pair_key(entity_a, entity_b)
+    now = datetime.now(UTC).isoformat()
+    row_id = uuid.uuid4().hex[:16]
+    cursor = await db.execute(
+        """INSERT INTO entity_adjudications
+           (id, pair_key, entity_a, entity_b, loser_id, survivor_id, verdict,
+            reasoning, provider, mode, norm_a, norm_b, updated_a, updated_b,
+            created_at, applied_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(pair_key) DO UPDATE SET
+             entity_a = excluded.entity_a,
+             entity_b = excluded.entity_b,
+             loser_id = excluded.loser_id,
+             survivor_id = excluded.survivor_id,
+             verdict = excluded.verdict,
+             reasoning = excluded.reasoning,
+             provider = excluded.provider,
+             mode = excluded.mode,
+             norm_a = excluded.norm_a,
+             norm_b = excluded.norm_b,
+             updated_a = excluded.updated_a,
+             updated_b = excluded.updated_b,
+             applied_at = excluded.applied_at""",
+        (
+            row_id,
+            key,
+            entity_a,
+            entity_b,
+            loser_id,
+            survivor_id,
+            verdict,
+            reasoning,
+            provider,
+            mode,
+            norm_a,
+            norm_b,
+            updated_a,
+            updated_b,
+            now,
+            applied_at,
+        ),
+    )
+    if _commit:
+        await db.commit()
+    # On conflict the stored id is the pre-existing one; return whatever the row holds.
+    if cursor.rowcount == 0:  # pragma: no cover — defensive; upsert always writes
+        existing = await get_by_pair(db, entity_a, entity_b)
+        return existing["id"] if existing else row_id
+    row = await get_by_pair(db, entity_a, entity_b)
+    return row["id"] if row else row_id
+
+
+async def get_by_pair(db: aiosqlite.Connection, entity_a: str, entity_b: str) -> dict | None:
+    """Fetch the verdict row for a pair (order-independent), or None."""
+    key = pair_key(entity_a, entity_b)
+    cursor = await db.execute(
+        f"SELECT {', '.join(_COLS)} FROM entity_adjudications WHERE pair_key = ?",
+        (key,),
+    )
+    row = await cursor.fetchone()
+    return _row_to_dict(row) if row else None
+
+
+async def all_pair_keys(db: aiosqlite.Connection) -> set[str]:
+    """Every recorded pair_key — the sweep's dedup set (cheap: bounded by
+    total fuzzy pairs, low thousands)."""
+    cursor = await db.execute("SELECT pair_key FROM entity_adjudications")
+    return {r[0] for r in await cursor.fetchall()}
+
+
+async def list_proposed_merges(db: aiosqlite.Connection, *, limit: int = 100) -> list[dict]:
+    """Rows awaiting application on the flip to live mode (verdict='proposed_merge'),
+    oldest first."""
+    cursor = await db.execute(
+        f"SELECT {', '.join(_COLS)} FROM entity_adjudications "
+        "WHERE verdict = 'proposed_merge' ORDER BY created_at ASC LIMIT ?",
+        (limit,),
+    )
+    return [_row_to_dict(r) for r in await cursor.fetchall()]
+
+
+async def mark_applied(
+    db: aiosqlite.Connection,
+    *,
+    pair_key: str,
+    loser_id: str,
+    survivor_id: str,
+    _commit: bool = True,
+) -> None:
+    """Promote a proposed_merge to an applied merge (verdict='merge')."""
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        "UPDATE entity_adjudications SET verdict = 'merge', loser_id = ?, "
+        "survivor_id = ?, applied_at = ? WHERE pair_key = ?",
+        (loser_id, survivor_id, now, pair_key),
+    )
+    if _commit:
+        await db.commit()
+
+
+async def mark_stale(db: aiosqlite.Connection, *, pair_key: str, _commit: bool = True) -> None:
+    """Mark a proposal that no longer holds (one side merged/renamed/gone)."""
+    await db.execute(
+        "UPDATE entity_adjudications SET verdict = 'stale' WHERE pair_key = ?",
+        (pair_key,),
+    )
+    if _commit:
+        await db.commit()

--- a/src/genesis/db/migrations/0051_entity_layer.py
+++ b/src/genesis/db/migrations/0051_entity_layer.py
@@ -14,17 +14,25 @@ from __future__ import annotations
 import aiosqlite
 
 _ENTITY_TABLES = ("entities", "entity_mentions", "entity_links")
-_ENTITY_INDEX_PREFIXES = ("idx_entities_", "idx_entity_")
+# Pinned historical snapshot — the exact indexes this migration created at its
+# point in history. Do NOT prefix-scan the live ``INDEXES`` list: a later
+# ``idx_entity_*`` index on a table THIS migration does not create (e.g.
+# ``idx_entity_adjud_verdict`` on ``entity_adjudications``, migration 0065) would
+# be swept in and fail with "no such table". Matches the 0033 explicit-DDL pattern.
+_ENTITY_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_entities_norm ON entities(norm_name)",
+    "CREATE INDEX IF NOT EXISTS idx_entity_mentions_entity ON entity_mentions(entity_id)",
+    "CREATE INDEX IF NOT EXISTS idx_entity_links_target ON entity_links(target_id)",
+)
 
 
 async def up(db: aiosqlite.Connection) -> None:
-    from genesis.db.schema._tables import INDEXES, TABLES
+    from genesis.db.schema._tables import TABLES
 
     for name in _ENTITY_TABLES:
         await db.execute(TABLES[name])
-    for ddl in INDEXES:
-        if any(prefix in ddl for prefix in _ENTITY_INDEX_PREFIXES):
-            await db.execute(ddl)
+    for ddl in _ENTITY_INDEXES:
+        await db.execute(ddl)
 
 
 async def down(db: aiosqlite.Connection) -> None:

--- a/src/genesis/db/migrations/0065_entity_adjudications.py
+++ b/src/genesis/db/migrations/0065_entity_adjudications.py
@@ -1,0 +1,62 @@
+"""Add entity_adjudications — the entity-node merge-vs-distinct decision ledger.
+
+One row per fuzzy entity PAIR that the ``entity_adjudication`` drainer judged.
+This is NOT ``entity_resolution_audit`` (that trails memory-pair dedup); this
+ledger records whether two ENTITY NODES are the same real-world thing.
+
+Design notes:
+- ``pair_key`` is order-independent (sorted entity-id pair joined by '|') with a
+  UNIQUE constraint — the dedup key the producer (``enqueue_adjudication``) never
+  had, so ``(A,B)`` and ``(B,A)`` collapse to one verdict.
+- ``verdict``: 'distinct' (keep both), 'merge' (applied — loser tombstoned via
+  ``merge_entity``), 'proposed_merge' (propose_only shadow: recorded, NOT applied
+  — applied later on the flip to live), 'stale' (a proposal that no longer holds
+  because one side merged/renamed/went away since it was recorded).
+- ``norm_*``/``updated_*`` snapshot the two entities at decision time; the
+  propose_only→live apply pass uses them as a staleness guard (re-adjudicate,
+  never blindly apply, if identity drifted).
+- ``provider`` is the deciding LLM provider, or 'mechanical' for a digit-guard
+  distinct verdict (zero LLM cost).
+
+Additive + idempotent; DDL mirrored in ``db/schema/_tables.py``. Individual
+``db.execute()`` calls, no commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS entity_adjudications (
+            id           TEXT PRIMARY KEY,
+            pair_key     TEXT NOT NULL UNIQUE,
+            entity_a     TEXT NOT NULL,
+            entity_b     TEXT NOT NULL,
+            loser_id     TEXT,
+            survivor_id  TEXT,
+            verdict      TEXT NOT NULL CHECK (verdict IN (
+                'merge','distinct','proposed_merge','stale'
+            )),
+            reasoning    TEXT,
+            provider     TEXT,
+            mode         TEXT,
+            norm_a       TEXT,
+            norm_b       TEXT,
+            updated_a    TEXT,
+            updated_b    TEXT,
+            created_at   TEXT NOT NULL,
+            applied_at   TEXT
+        )
+        """
+    )
+    # Hot query: the propose_only→live backlog scan (verdict='proposed_merge').
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_entity_adjud_verdict ON entity_adjudications(verdict)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS entity_adjudications")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1650,6 +1650,38 @@ TABLES = {
             PRIMARY KEY (source_id, target_id, link_type)
         )
     """,
+    # Entity-node merge-vs-distinct adjudication ledger (migration 0065). NOT
+    # the memory-pair dedup trail — that is entity_resolution_audit. One row per
+    # fuzzy entity PAIR (order-independent pair_key = sorted ids joined), written
+    # by the entity_adjudication drainer. `verdict`: 'distinct' (keep both),
+    # 'merge' (applied — loser tombstoned into survivor), 'proposed_merge'
+    # (propose_only shadow: recorded, NOT applied), 'stale' (a proposal that no
+    # longer holds — one side merged/renamed/gone since). norm_/updated_ snapshots
+    # power the propose_only→live staleness guard. `provider` is the deciding LLM
+    # provider or 'mechanical' (digit-guard). pair_key UNIQUE = the dedup key the
+    # producer never had.
+    "entity_adjudications": """
+        CREATE TABLE IF NOT EXISTS entity_adjudications (
+            id           TEXT PRIMARY KEY,
+            pair_key     TEXT NOT NULL UNIQUE,
+            entity_a     TEXT NOT NULL,
+            entity_b     TEXT NOT NULL,
+            loser_id     TEXT,
+            survivor_id  TEXT,
+            verdict      TEXT NOT NULL CHECK (verdict IN (
+                'merge','distinct','proposed_merge','stale'
+            )),
+            reasoning    TEXT,
+            provider     TEXT,
+            mode         TEXT,
+            norm_a       TEXT,
+            norm_b       TEXT,
+            updated_a    TEXT,
+            updated_b    TEXT,
+            created_at   TEXT NOT NULL,
+            applied_at   TEXT
+        )
+    """,
     # Session-manager durable spine (PR-2a, migration 0058). session_id is the
     # CC transcript session id (= cc_sessions.cc_session_id, NOT cc_sessions.id).
     # origin_prompt/origin_ts are write-once: nullable so MCP stubs can exist
@@ -1991,6 +2023,8 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_entities_norm ON entities(norm_name)",
     "CREATE INDEX IF NOT EXISTS idx_entity_mentions_entity ON entity_mentions(entity_id)",
     "CREATE INDEX IF NOT EXISTS idx_entity_links_target ON entity_links(target_id)",
+    # entity adjudication ledger — hot query is the propose_only→live backlog scan
+    "CREATE INDEX IF NOT EXISTS idx_entity_adjud_verdict ON entity_adjudications(verdict)",
     # pending embeddings
     "CREATE INDEX IF NOT EXISTS idx_pending_embeddings_status ON pending_embeddings(status)",
     "CREATE INDEX IF NOT EXISTS idx_pending_embeddings_memory ON pending_embeddings(memory_id)",

--- a/tests/test_db/test_deferred_work_prune.py
+++ b/tests/test_db/test_deferred_work_prune.py
@@ -1,0 +1,73 @@
+"""prune_terminal — retention for finished deferred_work_queue rows (all types)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import deferred_work as dw
+
+
+async def _seed(db, *, id, status, completed_at, work_type="entity_adjudication"):
+    await dw.create(
+        db,
+        id=id,
+        work_type=work_type,
+        priority=60,
+        payload_json="{}",
+        deferred_at="2026-01-01T00:00:00+00:00",
+        deferred_reason="test",
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+    if status != "pending":
+        await dw.update_status(db, id, status=status, completed_at=completed_at)
+
+
+@pytest.mark.asyncio
+async def test_prune_deletes_old_terminal_rows_all_types(db):
+    await _seed(
+        db,
+        id="old-done",
+        status="completed",
+        completed_at="2026-01-10T00:00:00+00:00",
+        work_type="reflection",
+    )
+    await _seed(
+        db,
+        id="old-discarded",
+        status="discarded",
+        completed_at="2026-01-10T00:00:00+00:00",
+        work_type="entity_adjudication",
+    )
+    deleted = await dw.prune_terminal(db, cutoff_iso="2026-06-01T00:00:00+00:00")
+    assert deleted == 2
+    remaining = await db.execute("SELECT COUNT(*) FROM deferred_work_queue")
+    assert (await remaining.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_spares_recent_terminal_rows(db):
+    await _seed(db, id="recent-done", status="completed", completed_at="2026-07-16T00:00:00+00:00")
+    deleted = await dw.prune_terminal(db, cutoff_iso="2026-06-01T00:00:00+00:00")
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_spares_pending_and_processing(db):
+    await _seed(db, id="pending", status="pending", completed_at=None)
+    await _seed(db, id="processing", status="processing", completed_at=None)
+    # Both are non-terminal / NULL completed_at — never pruned even if ancient.
+    deleted = await dw.prune_terminal(db, cutoff_iso="2027-01-01T00:00:00+00:00")
+    assert deleted == 0
+    cnt = await db.execute("SELECT COUNT(*) FROM deferred_work_queue")
+    assert (await cnt.fetchone())[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_prune_uses_completed_at_not_created_at(db):
+    # Row born long ago but completed recently must survive an age test.
+    await _seed(
+        db, id="late-finisher", status="completed", completed_at="2026-07-16T00:00:00+00:00"
+    )
+    # created_at is 2026-01-01 (well before cutoff), completed_at is after.
+    deleted = await dw.prune_terminal(db, cutoff_iso="2026-06-01T00:00:00+00:00")
+    assert deleted == 0

--- a/tests/test_db/test_entity_adjudications_crud.py
+++ b/tests/test_db/test_entity_adjudications_crud.py
@@ -1,0 +1,90 @@
+"""CRUD tests for entity_adjudications (uses the full in-memory ``db`` fixture,
+which exercises the canonical ``create_all_tables`` build path)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import entity_adjudications as adj
+
+
+def test_pair_key_order_independent():
+    assert adj.pair_key("e2", "e1") == adj.pair_key("e1", "e2") == "e1|e2"
+
+
+@pytest.mark.asyncio
+async def test_record_and_get_by_pair_order_independent(db):
+    await adj.record_verdict(
+        db,
+        entity_a="e1",
+        entity_b="e2",
+        verdict="distinct",
+        reasoning="different things",
+        provider="mechanical",
+    )
+    # Lookup with the pair reversed must find the same row.
+    row = await adj.get_by_pair(db, "e2", "e1")
+    assert row is not None
+    assert row["verdict"] == "distinct"
+    assert row["provider"] == "mechanical"
+    assert row["pair_key"] == "e1|e2"
+
+
+@pytest.mark.asyncio
+async def test_get_by_pair_missing_returns_none(db):
+    assert await adj.get_by_pair(db, "nope", "nada") is None
+
+
+@pytest.mark.asyncio
+async def test_record_verdict_upsert_overwrites_same_pair(db):
+    await adj.record_verdict(db, entity_a="e1", entity_b="e2", verdict="proposed_merge")
+    # Re-adjudicate the reversed pair with a new verdict — must overwrite, not dup.
+    await adj.record_verdict(
+        db, entity_a="e2", entity_b="e1", verdict="distinct", reasoning="second look"
+    )
+    keys = await adj.all_pair_keys(db)
+    assert keys == {"e1|e2"}  # deduped to one row
+    row = await adj.get_by_pair(db, "e1", "e2")
+    assert row["verdict"] == "distinct"
+    assert row["reasoning"] == "second look"
+
+
+@pytest.mark.asyncio
+async def test_all_pair_keys(db):
+    await adj.record_verdict(db, entity_a="a", entity_b="b", verdict="distinct")
+    await adj.record_verdict(db, entity_a="c", entity_b="d", verdict="merge")
+    assert await adj.all_pair_keys(db) == {"a|b", "c|d"}
+
+
+@pytest.mark.asyncio
+async def test_list_proposed_merges_only_proposed(db):
+    await adj.record_verdict(
+        db, entity_a="a", entity_b="b", verdict="proposed_merge", loser_id="b", survivor_id="a"
+    )
+    await adj.record_verdict(db, entity_a="c", entity_b="d", verdict="distinct")
+    await adj.record_verdict(db, entity_a="e", entity_b="f", verdict="merge")
+    proposed = await adj.list_proposed_merges(db)
+    assert [r["pair_key"] for r in proposed] == ["a|b"]
+    assert proposed[0]["survivor_id"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_mark_applied_promotes_proposed_to_merge(db):
+    await adj.record_verdict(db, entity_a="a", entity_b="b", verdict="proposed_merge")
+    await adj.mark_applied(db, pair_key="a|b", loser_id="b", survivor_id="a")
+    row = await adj.get_by_pair(db, "a", "b")
+    assert row["verdict"] == "merge"
+    assert row["loser_id"] == "b"
+    assert row["survivor_id"] == "a"
+    assert row["applied_at"] is not None
+    # No longer in the propose backlog.
+    assert await adj.list_proposed_merges(db) == []
+
+
+@pytest.mark.asyncio
+async def test_mark_stale(db):
+    await adj.record_verdict(db, entity_a="a", entity_b="b", verdict="proposed_merge")
+    await adj.mark_stale(db, pair_key="a|b")
+    row = await adj.get_by_pair(db, "a", "b")
+    assert row["verdict"] == "stale"
+    assert await adj.list_proposed_merges(db) == []

--- a/tests/test_db/test_migration_0065_entity_adjudications.py
+++ b/tests/test_db/test_migration_0065_entity_adjudications.py
@@ -1,0 +1,136 @@
+"""Migration 0065 — create ``entity_adjudications`` (entity-node merge ledger).
+
+Verifies the full column set, the verdict index, idempotency, the verdict
+CHECK, the pair_key UNIQUE dedupe key, fresh-canonical parity with
+``_tables.py``, and ``down``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+import aiosqlite
+import pytest
+
+M65 = importlib.import_module("genesis.db.migrations.0065_entity_adjudications")
+
+_EXPECTED_COLUMNS = {
+    "id",
+    "pair_key",
+    "entity_a",
+    "entity_b",
+    "loser_id",
+    "survivor_id",
+    "verdict",
+    "reasoning",
+    "provider",
+    "mode",
+    "norm_a",
+    "norm_b",
+    "updated_a",
+    "updated_b",
+    "created_at",
+    "applied_at",
+}
+
+_BASE_ROW = {
+    "id": "a-1",
+    "pair_key": "e1|e2",
+    "entity_a": "e1",
+    "entity_b": "e2",
+    "verdict": "distinct",
+    "created_at": "2026-07-17T12:00:00+00:00",
+}
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(entity_adjudications)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _insert(db: aiosqlite.Connection, **overrides) -> None:
+    row = {**_BASE_ROW, **overrides}
+    cols = ", ".join(row)
+    marks = ", ".join("?" for _ in row)
+    await db.execute(
+        f"INSERT INTO entity_adjudications ({cols}) VALUES ({marks})",  # noqa: S608 — test-local column names
+        tuple(row.values()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_up_creates_table_with_full_column_set(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        assert await _columns(db) == _EXPECTED_COLUMNS
+
+
+@pytest.mark.asyncio
+async def test_up_creates_verdict_index(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND tbl_name='entity_adjudications' AND name LIKE 'idx_entity_adjud%'"
+        )
+        assert {row[0] for row in await cur.fetchall()} == {"idx_entity_adjud_verdict"}
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        await M65.up(db)  # second run must not raise
+        assert await _columns(db) == _EXPECTED_COLUMNS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_verdict", ["approve", "keep", "", "MERGE"])
+async def test_verdict_check_rejects(tmp_path, bad_verdict):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        with pytest.raises(sqlite3.IntegrityError):
+            await _insert(db, verdict=bad_verdict)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verdict", ["merge", "distinct", "proposed_merge", "stale"])
+async def test_verdict_check_accepts_valid(tmp_path, verdict):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        await _insert(db, id=f"a-{verdict}", pair_key=f"k-{verdict}", verdict=verdict)
+
+
+@pytest.mark.asyncio
+async def test_pair_key_unique(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        await _insert(db)
+        with pytest.raises(sqlite3.IntegrityError):
+            await _insert(db, id="a-2")  # same pair_key, different id
+
+
+@pytest.mark.asyncio
+async def test_fresh_canonical_parity(tmp_path):
+    """_tables.py and the migration must build the identical column set."""
+    from genesis.db.schema import TABLES
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(TABLES["entity_adjudications"])
+        fresh_cols = await _columns(db)
+    async with aiosqlite.connect(str(tmp_path / "m.db")) as db:
+        await M65.up(db)
+        migrated_cols = await _columns(db)
+    assert fresh_cols == migrated_cols == _EXPECTED_COLUMNS
+
+
+@pytest.mark.asyncio
+async def test_down_drops_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M65.up(db)
+        await M65.down(db)
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='entity_adjudications'"
+        )
+        assert await cur.fetchone() is None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -73,6 +73,7 @@ EXPECTED_TABLES = [
     "repo_pulse_runs",  # session-manager PR-4a: pulse worker run telemetry
     "repo_pulse_annotations",  # session-manager PR-4a: PR ↔ ledger-item matches
     "ledger_predictions",  # WS-2 P1a: cognitive-ledger falsifiable prediction rows
+    "entity_adjudications",  # entity-node merge-vs-distinct decision ledger (drainer)
 ]
 
 


### PR DESCRIPTION
## What

Dark substrate for the **entity_adjudication drainer** (follow-up 9127e8ed) — the consumer that will decide merge-vs-distinct for fuzzy near-duplicate entity nodes. This PR adds only the schema, CRUD, and retention primitives; **no producer or consumer is wired**, so runtime behavior is unchanged.

## Why

`resolve_entity` creates a new entity when a name is fuzzily close (difflib ≥0.85) to an existing one, tags it AMBIGUOUS, and would enqueue an adjudication row — but the consumer was never built (gated off in #1099). This lands the decision ledger and dedup key that the drainer (PR-B) needs.

## Changes

- **`entity_adjudications` table** (migration 0065 + canonical `_tables.py`): one row per fuzzy entity pair, order-independent `pair_key UNIQUE` (the dedup key the producer never had). `verdict ∈ merge/distinct/proposed_merge/stale`; `norm_*`/`updated_*` snapshots power the propose-only→live staleness guard. Distinct from `entity_resolution_audit` (which trails memory-pair dedup — this records entity NODES).
- **`db/crud/entity_adjudications.py`**: `record_verdict` (upsert on pair_key), `get_by_pair` (order-independent), `all_pair_keys` (sweep dedup set), `list_proposed_merges`, `mark_applied`, `mark_stale`.
- **`deferred_work.prune_terminal`**: retention for finished queue rows across ALL work types, pruned on `completed_at` (not `created_at`) — closes a pre-existing accumulate-forever gap (2,348 completed rows, oldest 4 months).
- **Harden migration 0051**: pin its three entity indexes explicitly instead of prefix-scanning the live `INDEXES` list. The prefix scan swept in any future `idx_entity_*` index on a table 0051 does not create — a latent bug the 0065 index tripped. Matches the explicit-DDL pattern already used by migration 0033.

## Tests

60 pass: migration 0065 (full column set, index, idempotency, verdict CHECK, pair_key UNIQUE, fresh-canonical parity, down), CRUD (order-independence, upsert-dedup, proposed backlog, apply, stale), prune (completed_at semantics, spares pending/processing), schema allow-list.

## Deploy

Runtime code + additive idempotent migration — applies at server restart via `update.sh`. Empty-state safe (new table, no backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)