### PR TITLE
feat(entity): entity_adjudication drainer — LLM merge-vs-distinct for fuzzy pairs (PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,26 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **Genesis now tidies near-duplicate entities in its knowledge graph.** When
+  it learns about a "thing" (a project, tool, concept, person) whose name is
+  very close to one it already knows, it now decides whether they are the same
+  thing or genuinely different, and can merge the duplicates so its memory of
+  you stays coherent instead of fragmenting across "neural monitor" /
+  "neural-monitor" / "neural_monitor". Two independent models must agree before
+  anything merges, and pairs that only differ by a number (`PR #989` vs
+  `PR #990`) are never merged. It ships in **shadow mode by default** — it
+  records what it *would* merge without touching anything, so you can review the
+  proposals first; flip it to live with
+  `settings_update("entity_adjudication", {"mode": "live"})` (or turn it off
+  entirely). A background sweep also reconciles the entities it already had.
+
 ### Changed
+
+- **Finished background-queue rows are now pruned after 45 days.** The internal
+  deferred-work queue kept every completed item forever; it now retains 45 days
+  of history and drops the rest, so the queue can't slowly grow without bound.
 
 - **Every terminal door now leads to the same persistent session.** Running
   `claude` by hand over SSH or in the dashboard web terminal now lands in a

--- a/config/entity_adjudication.yaml
+++ b/config/entity_adjudication.yaml
@@ -1,0 +1,44 @@
+# Entity adjudication drainer — writable, SHADOW by default.
+#
+# The hourly learning-scheduler job (`entity_adjudication_drain`) re-reads the
+# merged config (this file + ~/.genesis/config/entity_adjudication.local.yaml)
+# on every run, so a settings_update("entity_adjudication", {...}) or a hand
+# edit takes effect on the next run — no restart.
+#
+# Master switch: false stops the job before any queue/LLM/merge work.
+enabled: true
+
+# Mode: off | propose_only | live
+#   off          — the job exits immediately (no drain, no sweep)
+#   propose_only — (default) LLM judges each fuzzy entity pair and RECORDS the
+#                  verdict; a "merge" is stored as `proposed_merge` and NOT
+#                  applied. Review the proposals, then flip to live.
+#   live         — a double-agreed "merge" is APPLIED (loser entity tombstoned
+#                  into the survivor via merge_entity). Stored proposed_merge
+#                  verdicts from the shadow period apply on the flip, guarded
+#                  against staleness (re-adjudicate if identity drifted).
+#
+# Merges are effectively irreversible (the loser's mentions/links are rewritten
+# onto the survivor), so the default is propose_only — the conservative posture
+# (a wrong merge is worse than a wrong split).
+#
+# Hook/env kill switch (separate lever): GENESIS_ENTITY_ADJUDICATION_DISABLED=1
+# forces the job to no-op regardless of this file.
+mode: propose_only
+
+# Max pending queue rows drained (LLM-judged) per hourly run. ~240 fuzzy pairs
+# exist here after the digit-guard; at 20/run the backlog clears in ~12 runs.
+drain_budget: 20
+
+# Reconcile sweep: rediscover fuzzy pairs among EXISTING entities (the producer
+# only catches newly-created ones). Sliced over the entity set, cursor in
+# ego_state; a full pass ≈ 15 hourly slices, then re-runs weekly (near-free —
+# already-judged pairs are skipped via the verdict table).
+sweep_enabled: true
+
+# Entities scanned per sweep slice (difflib runs off-thread). Bounds per-run CPU.
+sweep_slice_size: 200
+
+# Max NEW queue rows the sweep enqueues per run — a safety valve so a slice that
+# finds many candidates cannot flood the queue in one go.
+sweep_enqueue_cap: 50

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -413,6 +413,26 @@ call_sites:
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     retry_profile: background
+  # Entity-NODE merge-vs-distinct adjudication (entity_adjudication drainer).
+  # Same free-SLM shape as dream_cycle_entity_check; hourly, small backlog.
+  entity_adjudication:
+    chain:
+    - nvidia-nim-kimi
+    - groq-free
+    - mistral-small-free
+    - openrouter-free
+    - gemini-free
+    - mistral-large-free
+    - openrouter-gemma4
+    retry_profile: background
+  # Adversarial challenge of an entity-node "merge" verdict. Flipped pairing
+  # (DeepSeek challenges Kimi) so a single model's mistake cannot merge two
+  # distinct entities — both must agree before a merge.
+  entity_adjudication_challenge:
+    chain:
+    - nvidia-nim-deepseek
+    - openrouter-deepseek-v4-flash
+    retry_profile: background
   # One-shot supervised wing backfill (scripts/wing_backfill.py) — batch
   # classification of legacy general/uncategorized memories into wings.
   # Same free background family as the dream-cycle classification sites.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -36,7 +36,7 @@ side.
 ```yaml subsystem-map
 entry: memory
 modules: [memory, qdrant]
-verified: 36563f95 2026-07-10
+verified: 57fa1f18 2026-07-17
 ```
 
 **Retrieval is TIERED — the hottest auto-fired paths carry the thinnest
@@ -73,12 +73,21 @@ Easy-to-forget mechanisms:
 - **Entity layer (WS-H Pillar 2)** — typed entity nodes with identity:
   `entities`/`entity_mentions`/`entity_links` tables (migration 0051),
   `db/crud/entities.py` (recursive-CTE traversal, bi-temporal edge validity,
-  EXTRACTED/INFERRED/AMBIGUOUS provenance), `memory/entity_registry.py`
-  (string→ID resolution tiering; fuzzy matches queue `entity_adjudication`),
-  `memory/entity_seed.py` (curated spine incl. the repo-split rule).
-  Distinct from `memory/entity_resolution.py`, which is near-duplicate
-  memory-PAIR dedup. Bitemporal timestamps are canonicalized at the write
-  gate (`db/timeutil.canonical_iso`, migration 0050).
+  EXTRACTED/INFERRED/AMBIGUOUS provenance, `merge_entity` tombstone-with-
+  redirect), `memory/entity_registry.py` (string→ID resolution tiering; fuzzy
+  matches queue `entity_adjudication`), `memory/entity_seed.py` (curated spine
+  incl. the repo-split rule). **Adjudication drainer**
+  (`memory/entity_adjudication.py`, migration 0065 `entity_adjudications`
+  ledger): the hourly consumer of the `entity_adjudication` queue — a mechanical
+  digit-guard rules out numeric-suffix pairs, then a two-model LLM judgment
+  (`entity_adjudication` + flipped-provider `entity_adjudication_challenge`, both
+  must agree) decides merge-vs-distinct. `propose_only` by default (records, does
+  not apply); `live` applies via `merge_entity`. A cursor-managed reconcile sweep
+  rediscovers historical fuzzy pairs. Settings lever `entity_adjudication`
+  (off/propose_only/live) + `GENESIS_ENTITY_ADJUDICATION_DISABLED`. Distinct from
+  `memory/entity_resolution.py`, which is near-duplicate memory-PAIR dedup.
+  Bitemporal timestamps are canonicalized at the write gate
+  (`db/timeutil.canonical_iso`, migration 0050).
 
 **Consolidation (dream cycle)** — `memory/dream_cycle.py` (~1480 LOC):
 weekly clustering (Sun 4am) persists a value-ranked worklist to

--- a/src/genesis/db/crud/entities.py
+++ b/src/genesis/db/crud/entities.py
@@ -82,7 +82,8 @@ async def get_by_norm_name(
         )
     else:
         rows = await db.execute_fetchall(
-            "SELECT * FROM entities WHERE norm_name = ?", (norm_name,),
+            "SELECT * FROM entities WHERE norm_name = ?",
+            (norm_name,),
         )
     if not rows:
         return None
@@ -95,9 +96,19 @@ async def get_by_norm_name(
 
 async def get_entity(db: aiosqlite.Connection, entity_id: str) -> dict | None:
     rows = await db.execute_fetchall(
-        "SELECT * FROM entities WHERE entity_id = ?", (entity_id,),
+        "SELECT * FROM entities WHERE entity_id = ?",
+        (entity_id,),
     )
     return _row_to_dict(db, rows[0]) if rows else None
+
+
+async def count_entity_mentions(db: aiosqlite.Connection, entity_id: str) -> int:
+    """Number of memory↔entity mentions for one entity (attestation strength)."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM entity_mentions WHERE entity_id = ?", (entity_id,)
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
 
 
 async def list_norm_names(
@@ -119,8 +130,7 @@ async def list_norm_names(
         )
     else:
         rows = await db.execute_fetchall(
-            "SELECT norm_name, entity_id, entity_type FROM entities "
-            "WHERE status = 'active'",
+            "SELECT norm_name, entity_id, entity_type FROM entities WHERE status = 'active'",
         )
     return [(r[0], r[1], r[2]) for r in rows]
 
@@ -145,7 +155,11 @@ async def upsert_mention(
         "source = excluded.source "
         "WHERE excluded.confidence > entity_mentions.confidence",
         (
-            memory_id, entity_id, provenance, confidence, source,
+            memory_id,
+            entity_id,
+            provenance,
+            confidence,
+            source,
             datetime.now(UTC).isoformat(),
         ),
     )
@@ -202,8 +216,13 @@ async def upsert_link(
         "valid_at = COALESCE(excluded.valid_at, entity_links.valid_at) "
         "WHERE excluded.confidence > entity_links.confidence",
         (
-            source_id, target_id, slugify_link_type(link_type), provenance,
-            confidence, evidence_memory_id, canonical_iso(valid_at),
+            source_id,
+            target_id,
+            slugify_link_type(link_type),
+            provenance,
+            confidence,
+            evidence_memory_id,
+            canonical_iso(valid_at),
             datetime.now(UTC).isoformat(),
         ),
     )
@@ -272,11 +291,7 @@ async def connected_entities(
             for here, there in ((source_id, target_id), (target_id, source_id)):
                 if here not in frontier or there in seeds:
                     continue
-                path_conf = (
-                    frontier[here]
-                    * confidence
-                    * PROVENANCE_WEIGHTS.get(provenance, 0.5)
-                )
+                path_conf = frontier[here] * confidence * PROVENANCE_WEIGHTS.get(provenance, 0.5)
                 prior = reached.get(there)
                 if prior is None or path_conf > prior["path_confidence"]:
                     reached[there] = {
@@ -284,9 +299,7 @@ async def connected_entities(
                         "path_confidence": path_conf,
                         "via_link_type": link_type,
                     }
-                    next_frontier[there] = max(
-                        next_frontier.get(there, 0.0), path_conf
-                    )
+                    next_frontier[there] = max(next_frontier.get(there, 0.0), path_conf)
         frontier = next_frontier
     return reached
 
@@ -350,7 +363,8 @@ async def merge_entity(
         (survivor_id, loser_id),
     )
     await db.execute(
-        "DELETE FROM entity_mentions WHERE entity_id = ?", (loser_id,),
+        "DELETE FROM entity_mentions WHERE entity_id = ?",
+        (loser_id,),
     )
     for src_col, dst_col in (("source_id", "target_id"), ("target_id", "source_id")):
         # dst != survivor guard: a pre-existing loser↔survivor link
@@ -425,13 +439,15 @@ async def delete_entities_cascade(
     return {"entities": deleted, "mentions": mentions, "links": links}
 
 
-# Dormant until a consumer exists. `enqueue_adjudication` writes
-# `entity_adjudication` rows to `deferred_work_queue` for an "entity_maintenance
-# job" that was never built — so the rows were a pure producer-with-no-consumer
-# leak (263 orphans in ~6 days, 0 ever drained). Gated OFF to stop the bleed
-# (follow-up 9127e8ed); the enqueue machinery is preserved GROUNDWORK for the
-# adjudication drainer, which flips this True when it lands. Do NOT delete.
-_ADJUDICATION_ENQUEUE_ENABLED = False
+# Enabled: the entity_adjudication drainer (genesis.memory.entity_adjudication)
+# is the consumer. `enqueue_adjudication` writes `entity_adjudication` rows to
+# `deferred_work_queue`; the hourly drainer LLM-judges each fuzzy pair merge-vs-
+# distinct (propose_only by default). The whole feature is gated at runtime by
+# the entity_adjudication settings lever (mode=off no-ops the drainer); this
+# module-level flag stays as the producer kill switch of last resort. When the
+# drainer's mode is off, rows still enqueue but simply never drain — set this
+# False (or the lever off) if you want to stop enqueuing entirely.
+_ADJUDICATION_ENQUEUE_ENABLED = True
 
 
 async def enqueue_adjudication(
@@ -441,32 +457,41 @@ async def enqueue_adjudication(
     similar_entity_id: str,
     _commit: bool = True,
 ) -> None:
-    """Queue a fuzzy-match pair for LLM adjudication (entity_maintenance job).
+    """Queue a fuzzy-match pair for the entity_adjudication drainer.
 
     Inline INSERT rather than ``deferred_work.create`` — that helper
     commits unconditionally, which would break callers batching under
     ``_commit=False`` (extraction transaction discipline).
 
-    No-op while ``_ADJUDICATION_ENQUEUE_ENABLED`` is False (no drainer exists —
-    see the module-level note). The caller's entity create + AMBIGUOUS status
-    are unaffected; only the orphan queue row is skipped.
+    No-op while ``_ADJUDICATION_ENQUEUE_ENABLED`` is False. Deduped: if a pending
+    row already exists for this pair in EITHER orientation, no new row is written
+    (the producer has no natural dedup key, so a repeated fuzzy collision would
+    otherwise pile up duplicate rows — the exact leak that motivated the gate).
+    The caller's entity create + AMBIGUOUS status are unaffected.
     """
     if not _ADJUDICATION_ENQUEUE_ENABLED:
         return
     now = datetime.now(UTC).isoformat()
+    payload_fwd = json.dumps({"entity_id": entity_id, "similar_entity_id": similar_entity_id})
+    payload_rev = json.dumps({"entity_id": similar_entity_id, "similar_entity_id": entity_id})
     await db.execute(
         """INSERT INTO deferred_work_queue
-           (id, work_type, priority, payload_json, deferred_at,
+           (id, work_type, call_site_id, priority, payload_json, deferred_at,
             deferred_reason, created_at)
-           VALUES (?, 'entity_adjudication', 60, ?, ?, ?, ?)""",
+           SELECT ?, 'entity_adjudication', 'entity_adjudication', 60, ?, ?, ?, ?
+           WHERE NOT EXISTS (
+               SELECT 1 FROM deferred_work_queue
+               WHERE work_type = 'entity_adjudication' AND status = 'pending'
+                 AND payload_json IN (?, ?)
+           )""",
         (
             str(uuid.uuid4()),
-            json.dumps(
-                {"entity_id": entity_id, "similar_entity_id": similar_entity_id}
-            ),
+            payload_fwd,
             now,
             "fuzzy norm_name match at entity creation",
             now,
+            payload_fwd,
+            payload_rev,
         ),
     )
     if _commit:

--- a/src/genesis/db/crud/entity_adjudications.py
+++ b/src/genesis/db/crud/entity_adjudications.py
@@ -135,9 +135,19 @@ async def get_by_pair(db: aiosqlite.Connection, entity_a: str, entity_b: str) ->
 
 
 async def all_pair_keys(db: aiosqlite.Connection) -> set[str]:
-    """Every recorded pair_key — the sweep's dedup set (cheap: bounded by
-    total fuzzy pairs, low thousands)."""
+    """Every recorded pair_key (any verdict). Bounded by total fuzzy pairs
+    (low thousands)."""
     cursor = await db.execute("SELECT pair_key FROM entity_adjudications")
+    return {r[0] for r in await cursor.fetchall()}
+
+
+async def settled_pair_keys(db: aiosqlite.Connection) -> set[str]:
+    """pair_keys with a SETTLED verdict (merge/distinct/proposed_merge) — the
+    sweep's dedup set. Deliberately EXCLUDES ``stale``: a stale verdict means the
+    prior judgment no longer holds (identity drifted), so the sweep SHOULD
+    rediscover the pair and the drainer re-adjudicate it — otherwise a stale pair
+    would be a permanent dead end."""
+    cursor = await db.execute("SELECT pair_key FROM entity_adjudications WHERE verdict != 'stale'")
     return {r[0] for r in await cursor.fetchall()}
 
 

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -115,6 +115,20 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # each worker run is a fresh process
     ),
+    "entity_adjudication": SettingsDomain(
+        name="entity_adjudication",
+        description=(
+            "Entity adjudication drainer — master `enabled` + `mode` "
+            "off/propose_only/live, plus drain/sweep knobs. propose_only "
+            "(default) records merge verdicts without applying them; live "
+            "applies double-agreed merges (loser entity tombstoned into "
+            "survivor) and applies the shadow-period backlog on the flip. "
+            "Read live each hourly run — takes effect next run, no restart."
+        ),
+        config_filename="entity_adjudication.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every drain run
+    ),
     "resilience": SettingsDomain(
         name="resilience",
         description="Resilience thresholds (flapping detection, recovery, CC rate limits)",
@@ -876,7 +890,29 @@ def _validate_memory_recall(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_entity_adjudication(changes: dict) -> list[str]:
+    """Validate entity-adjudication lever changes (see
+    genesis.memory.entity_adjudication_config)."""
+    from genesis.memory.entity_adjudication_config import INT_KNOBS, MODES
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "mode", "sweep_enabled", *INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key in ("enabled", "sweep_enabled"):
+            if not isinstance(value, bool):
+                errors.append(f"'{key}' must be a boolean")
+        elif key == "mode":
+            if value not in MODES:
+                errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
+    "entity_adjudication": _validate_entity_adjudication,
     "tts": _validate_tts,
     "ws3_immunity": _validate_ws3_immunity,
     "memory_recall": _validate_memory_recall,

--- a/src/genesis/memory/entity_adjudication.py
+++ b/src/genesis/memory/entity_adjudication.py
@@ -1,0 +1,780 @@
+"""Entity adjudication drainer — decide merge-vs-distinct for fuzzy entity PAIRS.
+
+This is the consumer for ``work_type='entity_adjudication'`` rows in
+``deferred_work_queue`` (producer: ``entities.enqueue_adjudication``, fired when
+``resolve_entity`` creates an entity whose name is difflib-close to an existing
+one). It is NOT the memory-pair dedup lane (``dream_entity_scan`` /
+``entity_resolution_audit``) — this operates on entity NODES.
+
+Posture — conservative, because a wrong merge is worse than a wrong split:
+- A cheap **digit-guard** mechanically rules "distinct" for pairs that differ only
+  by digits (``pr #989`` vs ``pr #990``) — the ~76% of fuzzy hits that are
+  definitionally distinct — with zero LLM cost.
+- Otherwise a **two-model** judgment (primary + flipped-provider challenge) must
+  BOTH say "merge"; any disagreement or error falls to "distinct".
+- In ``propose_only`` mode (default) a merge is RECORDED as ``proposed_merge`` and
+  NOT applied. In ``live`` mode it is applied via ``merge_entity`` (loser
+  tombstoned into survivor), and stored proposals from the shadow period apply on
+  the flip, guarded against staleness.
+
+Every verdict is deduped and recorded in ``entity_adjudications`` (order-independent
+``pair_key``). One aggregate observation per run summarises what changed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import difflib
+import hashlib
+import json
+import logging
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from genesis.db.crud import deferred_work as dw_crud
+from genesis.db.crud import entities as entities_crud
+from genesis.db.crud import entity_adjudications as adj_crud
+from genesis.db.crud import memory as memory_crud
+from genesis.db.crud import observations
+from genesis.memory.adversarial_review import _JSON_BLOCK_RE
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from genesis.routing.router import Router
+
+logger = logging.getLogger(__name__)
+
+WORK_TYPE = "entity_adjudication"
+CALL_SITE_PRIMARY = "entity_adjudication"
+CALL_SITE_CHALLENGE = "entity_adjudication_challenge"
+
+_MAX_ATTEMPTS = 5
+# Fuzzy-comparison groups mirror entity_registry.resolve_entity: concept-cluster
+# types are compared cross-type within the cluster; person/org each same-type.
+_CONCEPT_CLUSTER = frozenset({"product", "device", "concept", "subsystem", "repo"})
+_FUZZY_THRESHOLD = 0.85
+_SNIPPET_CHARS = 300
+_MENTIONS_PER_ENTITY = 3
+
+_ADJUDICATION_PROMPT = """\
+You are deduplicating a knowledge graph's ENTITY NODES. These two entities already
+passed a text-similarity filter, so their names ARE close. Your job is to decide
+WHY they are close:
+
+- MERGE if the difference is purely COSMETIC — the same words/terms written
+  differently: spacing, hyphenation, underscores, casing, punctuation, delimiters,
+  or word order. These are one real-world thing recorded two ways.
+  Examples to merge: "neural monitor" / "neural-monitor" / "neural_monitor";
+  "dispatch: cli" / "dispatch=cli"; "dream cycle" / "dream-cycle" / "dream cycles".
+- DISTINCT if there is a SEMANTIC difference — a different word, a version/number/
+  letter suffix, or a specific sub-item vs its parent.
+  Examples to keep distinct: "system" vs "systemd" (different program);
+  "safety gate" vs "safety gap" (different word: gate ≠ gap); "PR-1" vs "PR-1a"
+  (different identifiers); a project vs a numbered issue under it.
+
+Entity A:
+{profile_a}
+
+Entity B:
+{profile_b}
+
+Respond with JSON only, no other text:
+{{"verdict": "merge|distinct", "reasoning": "one sentence"}}
+
+If a genuine semantic difference is plausible, choose "distinct" — a wrong merge
+erases a real distinction. But do NOT call a pure formatting difference "distinct"."""
+
+_CHALLENGE_PROMPT = """\
+A reviewer judged these two entity nodes to be the SAME real-world thing and wants
+to merge them (one is absorbed into the other, irreversibly). CHALLENGE that — but
+only on SEMANTIC grounds.
+
+Entity A:
+{profile_a}
+
+Entity B:
+{profile_b}
+
+The names are already known to be textually similar. A merge is WRONG only if
+there is a genuine MEANING difference — a different word, a distinguishing
+version/number/letter, or a specific sub-item vs its parent (e.g. "system" vs
+"systemd", "safety gate" vs "safety gap", "PR-1" vs "PR-1a"). A mere formatting
+difference (spacing, hyphenation, casing, punctuation, delimiter, word order of the
+SAME terms) is NOT a reason to keep them apart — that is the same thing written two
+ways.
+
+Respond with JSON only, no other text:
+{{"verdict": "merge|distinct", "reasoning": "one sentence"}}
+
+Say "distinct" ONLY if you can name a real semantic difference; otherwise "merge"."""
+
+
+# ── digit-guard ──────────────────────────────────────────────────────────────
+
+
+def _digit_collapse(s: str) -> str:
+    return re.sub(r"\d+", "#", s)
+
+
+def digit_only_difference(a: str, b: str) -> bool:
+    """True when two names differ ONLY by digit runs (``pr #989`` vs ``pr #990``).
+
+    These are definitionally distinct — a numbered series — and must never be
+    merged. Ruling them out mechanically saves the ~76% of fuzzy hits that are
+    numeric-suffix collisions from ever reaching the LLM.
+    """
+    return a != b and _digit_collapse(a) == _digit_collapse(b)
+
+
+# ── entity loading / redirect resolution ─────────────────────────────────────
+
+
+async def _resolve_active(db: aiosqlite.Connection, entity_id: str) -> dict | None:
+    """Follow ``merged_into`` redirects to the active survivor, or None if the
+    chain dead-ends in a merged-with-no-target / gone / missing entity.
+
+    Uses ``get_entity`` (raw row, does NOT follow merges) — the redirect walk is
+    done here."""
+    seen: set[str] = set()
+    current = entity_id
+    while current and current not in seen:
+        seen.add(current)
+        ent = await entities_crud.get_entity(db, current)
+        if ent is None:
+            return None
+        if ent["status"] == "active":
+            return ent
+        if ent["status"] == "merged" and ent["merged_into"]:
+            current = ent["merged_into"]
+            continue
+        return None  # gone, or merged with no target
+    return None
+
+
+# ── LLM adjudication ─────────────────────────────────────────────────────────
+
+
+async def _entity_profile(db: aiosqlite.Connection, ent: dict) -> str:
+    """Compact profile for the LLM: name, type, summary, top mention snippets."""
+    lines = [
+        f"Name: {ent['name']}",
+        f"Type: {ent['entity_type']}",
+        f"Summary: {ent.get('summary') or '(none)'}",
+    ]
+    try:
+        mentions = await entities_crud.memories_mentioning(
+            db, [ent["entity_id"]], limit_per_entity=_MENTIONS_PER_ENTITY
+        )
+    except Exception:
+        mentions = []
+    snippets: list[str] = []
+    for m in mentions:
+        mem = await memory_crud.get_by_id(db, m["memory_id"])
+        if mem and mem.get("content"):
+            snippets.append(mem["content"].strip().replace("\n", " ")[:_SNIPPET_CHARS])
+    if snippets:
+        lines.append("Mentioned in:")
+        lines.extend(f"- {s}" for s in snippets)
+    return "\n".join(lines)
+
+
+def _parse_verdict(text: str) -> dict[str, str] | None:
+    """Parse a ``{"verdict": ..., "reasoning": ...}`` JSON reply, fence-tolerant.
+
+    Returns None on any parse failure so the caller can fail safe to 'distinct'.
+    """
+    text = (text or "").strip()
+    match = _JSON_BLOCK_RE.search(text)
+    if match:
+        text = match.group(1).strip()
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+    verdict = data.get("verdict")
+    if verdict not in ("merge", "distinct"):
+        return None
+    return {"verdict": verdict, "reasoning": str(data.get("reasoning", ""))}
+
+
+def _retry(reason: str) -> dict[str, Any]:
+    """A non-answer (infra/parse failure): keep both for now, but signal the
+    caller to RETRY rather than record a permanent verdict — a transient outage
+    must not burn a pair to 'distinct' forever."""
+    return {"verdict": "distinct", "reasoning": reason, "provider": "error", "retryable": True}
+
+
+async def adjudicate_pair(router: Router, profile_a: str, profile_b: str) -> dict[str, Any]:
+    """Two-model merge-vs-distinct judgment. Returns
+    ``{"verdict": "merge"|"distinct", "reasoning": str, "provider": str,
+    "retryable": bool}``.
+
+    A "merge" requires the primary AND the flipped-provider challenge to BOTH
+    say merge. A model genuinely saying "distinct" is a real verdict (recorded).
+    An infra/parse failure sets ``retryable=True`` (fail-safe distinct, but the
+    caller re-queues instead of recording — a transient outage never burns a
+    pair to a permanent verdict).
+    """
+    prompt = _ADJUDICATION_PROMPT.format(profile_a=profile_a, profile_b=profile_b)
+    try:
+        primary = await router.route_call(
+            CALL_SITE_PRIMARY,
+            [{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
+        )
+    except Exception as exc:
+        logger.debug("Adjudication primary call error", exc_info=True)
+        return _retry(f"primary error: {exc}")
+    if not primary.success:
+        return _retry(f"primary LLM error: {primary.error}")
+    primary_verdict = _parse_verdict(primary.content or "")
+    if primary_verdict is None:
+        return _retry("primary parse error")
+    prov_p = primary.provider_used or "?"
+    if primary_verdict["verdict"] == "distinct":
+        return {**primary_verdict, "provider": prov_p, "retryable": False}
+
+    # Primary said merge — require the challenge to agree.
+    challenge_prompt = _CHALLENGE_PROMPT.format(profile_a=profile_a, profile_b=profile_b)
+    try:
+        challenge = await router.route_call(
+            CALL_SITE_CHALLENGE,
+            [{"role": "user", "content": challenge_prompt}],
+            suppress_dead_letter=True,
+        )
+    except Exception as exc:
+        logger.debug("Adjudication challenge call error", exc_info=True)
+        return _retry(f"challenge error: {exc}")
+    if not challenge.success:
+        return _retry(f"challenge LLM error: {challenge.error}")
+    challenge_verdict = _parse_verdict(challenge.content or "")
+    if challenge_verdict is None:
+        return _retry("challenge parse error")
+    if challenge_verdict["verdict"] != "merge":
+        # Real dissent — the challenge genuinely says distinct. Record it.
+        return {
+            "verdict": "distinct",
+            "reasoning": f"challenge overrode: {challenge_verdict['reasoning']}",
+            "provider": prov_p,
+            "retryable": False,
+        }
+    prov_c = challenge.provider_used or "?"
+    return {
+        "verdict": "merge",
+        "reasoning": primary_verdict["reasoning"],
+        "provider": f"{prov_p}+{prov_c}",
+        "retryable": False,
+    }
+
+
+# ── survivor selection ───────────────────────────────────────────────────────
+
+
+async def _pick_survivor(db: aiosqlite.Connection, ent_a: dict, ent_b: dict) -> tuple[str, str]:
+    """Return ``(survivor_id, loser_id)``: keep the better-attested entity.
+
+    More mentions wins (``merge_entity`` warns the loser is often the
+    better-attested record). Ties break to the older ``updated_at`` — the more
+    established node — falling back to id order for determinism.
+    """
+    ca = await entities_crud.count_entity_mentions(db, ent_a["entity_id"])
+    cb = await entities_crud.count_entity_mentions(db, ent_b["entity_id"])
+    if ca != cb:
+        return (
+            (ent_a["entity_id"], ent_b["entity_id"])
+            if ca > cb
+            else (ent_b["entity_id"], ent_a["entity_id"])
+        )
+    ua, ub = ent_a.get("updated_at") or "", ent_b.get("updated_at") or ""
+    if ua != ub:
+        return (
+            (ent_a["entity_id"], ent_b["entity_id"])
+            if ua < ub
+            else (ent_b["entity_id"], ent_a["entity_id"])
+        )
+    lo, hi = sorted((ent_a["entity_id"], ent_b["entity_id"]))
+    return lo, hi
+
+
+# ── drain ────────────────────────────────────────────────────────────────────
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def run_adjudication_drain(
+    db: aiosqlite.Connection,
+    router: Router,
+    *,
+    mode: str,
+    budget: int = 20,
+) -> dict[str, int]:
+    """Drain up to ``budget`` pending adjudication rows. Returns a counts summary.
+
+    In ``live`` mode a Phase 0 first applies any ``proposed_merge`` backlog stored
+    during the shadow period (with a staleness guard). Phase 1 then judges pending
+    queue rows. Emits one aggregate observation if anything changed.
+    """
+    counts = {
+        "judged": 0,
+        "distinct": 0,
+        "mechanical_distinct": 0,
+        "proposed": 0,
+        "merged": 0,
+        "stale": 0,
+        "noop": 0,
+        "discarded": 0,
+        "retried": 0,
+    }
+    example_merges: list[str] = []
+
+    if mode == "live":
+        await _apply_proposed_backlog(db, counts, example_merges, budget=budget)
+
+    rows = await dw_crud.query_pending(db, work_type=WORK_TYPE, limit=budget)
+    for item in rows:
+        try:
+            await _process_row(db, router, item, mode, counts, example_merges)
+        except Exception:
+            logger.exception("Adjudication row failed — resetting to pending: %s", item.get("id"))
+            await dw_crud.update_status(db, item["id"], status="pending")
+
+    await _emit_run_observation(db, counts, example_merges, mode)
+    return counts
+
+
+async def _process_row(
+    db: aiosqlite.Connection,
+    router: Router,
+    item: dict,
+    mode: str,
+    counts: dict[str, int],
+    example_merges: list[str],
+) -> None:
+    item_id = item["id"]
+    try:
+        payload = json.loads(item.get("payload_json") or "{}")
+        eid_new = payload["entity_id"]
+        eid_similar = payload["similar_entity_id"]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        await dw_crud.update_status(
+            db,
+            item_id,
+            status="discarded",
+            error_message="unparseable entity_adjudication payload",
+            completed_at=_now(),
+        )
+        counts["discarded"] += 1
+        return
+
+    if item.get("attempts", 0) >= _MAX_ATTEMPTS:
+        await _exhaust(db, item, counts)
+        return
+
+    ent_a = await _resolve_active(db, eid_new)
+    ent_b = await _resolve_active(db, eid_similar)
+    # Gone, or already converged to the same survivor → nothing to decide.
+    if ent_a is None or ent_b is None or ent_a["entity_id"] == ent_b["entity_id"]:
+        await dw_crud.update_status(db, item_id, status="completed", completed_at=_now())
+        counts["noop"] += 1
+        return
+
+    # Already judged this pair (non-stale verdict) → don't re-spend an LLM call.
+    existing = await adj_crud.get_by_pair(db, ent_a["entity_id"], ent_b["entity_id"])
+    if existing is not None and existing["verdict"] != "stale":
+        await dw_crud.update_status(db, item_id, status="completed", completed_at=_now())
+        counts["noop"] += 1
+        return
+
+    # Digit-guard — mechanical distinct, zero LLM cost.
+    if digit_only_difference(ent_a["norm_name"], ent_b["norm_name"]):
+        await adj_crud.record_verdict(
+            db,
+            entity_a=ent_a["entity_id"],
+            entity_b=ent_b["entity_id"],
+            verdict="distinct",
+            reasoning="names differ only by digits",
+            provider="mechanical",
+            mode=mode,
+            norm_a=ent_a["norm_name"],
+            norm_b=ent_b["norm_name"],
+        )
+        await dw_crud.update_status(db, item_id, status="completed", completed_at=_now())
+        counts["judged"] += 1
+        counts["mechanical_distinct"] += 1
+        return
+
+    await dw_crud.update_status(db, item_id, status="processing", last_attempt_at=_now())
+    profile_a = await _entity_profile(db, ent_a)
+    profile_b = await _entity_profile(db, ent_b)
+    result = await adjudicate_pair(router, profile_a, profile_b)
+
+    # Infra/parse non-answer → re-queue (attempts already incremented above; the
+    # top-of-function cap eventually discards a persistently-failing pair). Never
+    # record a permanent verdict from a transient outage.
+    if result.get("retryable"):
+        await dw_crud.update_status(db, item_id, status="pending")
+        counts["retried"] += 1
+        return
+
+    counts["judged"] += 1
+
+    common = dict(
+        entity_a=ent_a["entity_id"],
+        entity_b=ent_b["entity_id"],
+        reasoning=result["reasoning"],
+        provider=result["provider"],
+        mode=mode,
+        norm_a=ent_a["norm_name"],
+        norm_b=ent_b["norm_name"],
+        updated_a=ent_a.get("updated_at"),
+        updated_b=ent_b.get("updated_at"),
+    )
+
+    if result["verdict"] == "distinct":
+        await adj_crud.record_verdict(db, verdict="distinct", **common)
+        await dw_crud.update_status(db, item_id, status="completed", completed_at=_now())
+        counts["distinct"] += 1
+        return
+
+    # verdict == merge
+    if mode == "live":
+        # Extraction-race guard: profile-building + two LLM calls opened an await
+        # gap since we resolved these. Re-resolve immediately before the
+        # irreversible merge; if either side moved (merged/renamed/gone) or they
+        # converged, record the proposal instead of applying a stale merge.
+        fresh_a = await _resolve_active(db, ent_a["entity_id"])
+        fresh_b = await _resolve_active(db, ent_b["entity_id"])
+        if (
+            fresh_a is None
+            or fresh_b is None
+            or fresh_a["entity_id"] != ent_a["entity_id"]
+            or fresh_b["entity_id"] != ent_b["entity_id"]
+        ):
+            survivor_id, loser_id = await _pick_survivor(db, ent_a, ent_b)
+            await adj_crud.record_verdict(
+                db,
+                verdict="proposed_merge",
+                loser_id=loser_id,
+                survivor_id=survivor_id,
+                **common,
+            )
+            await dw_crud.update_status(db, item_id, status="completed", completed_at=_now())
+            counts["proposed"] += 1
+            return
+        # Pick the survivor from the FRESH entities — a concurrent write may have
+        # changed the mention counts survivor selection is based on, so choosing
+        # from the pre-race snapshot could tombstone the now-better-attested node.
+        survivor_id, loser_id = await _pick_survivor(db, fresh_a, fresh_b)
+        await entities_crud.merge_entity(db, loser_id=loser_id, survivor_id=survivor_id)
+        await adj_crud.record_verdict(
+            db,
+            verdict="merge",
+            loser_id=loser_id,
+            survivor_id=survivor_id,
+            applied_at=_now(),
+            **common,
+        )
+        counts["merged"] += 1
+        _note_merge(example_merges, ent_a, ent_b)
+    else:  # propose_only
+        survivor_id, loser_id = await _pick_survivor(db, ent_a, ent_b)
+        await adj_crud.record_verdict(
+            db,
+            verdict="proposed_merge",
+            loser_id=loser_id,
+            survivor_id=survivor_id,
+            **common,
+        )
+        counts["proposed"] += 1
+        _note_merge(example_merges, ent_a, ent_b)
+    await dw_crud.update_status(db, item_id, status="completed", completed_at=_now())
+
+
+async def _apply_proposed_backlog(
+    db: aiosqlite.Connection,
+    counts: dict[str, int],
+    example_merges: list[str],
+    *,
+    budget: int,
+) -> None:
+    """Live-mode Phase 0: apply proposed_merge verdicts stored during shadow.
+
+    Staleness guard: an identity that drifted since the proposal (one side
+    merged/renamed/gone) is marked ``stale`` and NOT applied.
+    """
+    proposals = await adj_crud.list_proposed_merges(db, limit=budget)
+    for p in proposals:
+        # A `stale` verdict is not a dead end: the reconcile sweep's dedup set
+        # (settled_pair_keys) excludes stale, so a stale pair is re-enqueued on
+        # the next sweep pass and re-adjudicated with its current identities.
+        ent_a = await _resolve_active(db, p["entity_a"])
+        ent_b = await _resolve_active(db, p["entity_b"])
+        if ent_a is None or ent_b is None or ent_a["entity_id"] == ent_b["entity_id"]:
+            await adj_crud.mark_stale(db, pair_key=p["pair_key"])
+            counts["stale"] += 1
+            continue
+        # norm_name drift → the thing we judged is not the thing we'd merge now.
+        if ent_a["norm_name"] != p.get("norm_a") or ent_b["norm_name"] != p.get("norm_b"):
+            await adj_crud.mark_stale(db, pair_key=p["pair_key"])
+            counts["stale"] += 1
+            continue
+        survivor_id, loser_id = await _pick_survivor(db, ent_a, ent_b)
+        await entities_crud.merge_entity(db, loser_id=loser_id, survivor_id=survivor_id)
+        await adj_crud.mark_applied(
+            db, pair_key=p["pair_key"], loser_id=loser_id, survivor_id=survivor_id
+        )
+        counts["merged"] += 1
+        _note_merge(example_merges, ent_a, ent_b)
+
+
+async def _exhaust(db: aiosqlite.Connection, item: dict, counts: dict[str, int]) -> None:
+    """Discard a row that has hit the attempt cap; surface it once in health."""
+    item_id = item["id"]
+    reason = f"entity_adjudication exhausted {_MAX_ATTEMPTS} attempts"
+    await dw_crud.update_status(
+        db, item_id, status="discarded", error_message=reason, completed_at=_now()
+    )
+    counts["discarded"] += 1
+    try:
+        content = json.dumps({"deferred_id": item_id, "payload": item.get("payload_json")})
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="entity_adjudication",
+            type="deferred_work_exhausted",
+            content=content,
+            priority="medium",
+            created_at=_now(),
+            content_hash=hashlib.sha256(reason.encode()).hexdigest(),
+            skip_if_duplicate=True,
+        )
+    except Exception:
+        logger.error("Failed to write exhaustion observation for %s", item_id, exc_info=True)
+
+
+def _note_merge(acc: list[str], ent_a: dict, ent_b: dict) -> None:
+    if len(acc) < 5:
+        acc.append(f"{ent_a['name']!r} ⇄ {ent_b['name']!r}")
+
+
+async def _emit_run_observation(
+    db: aiosqlite.Connection,
+    counts: dict[str, int],
+    example_merges: list[str],
+    mode: str,
+) -> None:
+    """One aggregate, user-visible observation per run that changed something.
+
+    Type ``entity_adjudication`` is deliberately NOT in INTERNAL_OBS_TYPES, so it
+    surfaces in the morning report (digest-note visibility). Aggregate, never
+    per-pair — a busy run is one line, not a flood.
+    """
+    changed = counts["merged"] + counts["proposed"] + counts["stale"]
+    if changed == 0:
+        return
+    if mode == "live":
+        headline = f"Genesis merged {counts['merged']} duplicate entities"
+    else:
+        headline = f"Genesis proposed {counts['proposed']} entity merges (shadow)"
+    content = json.dumps(
+        {
+            "headline": headline,
+            "mode": mode,
+            "merged": counts["merged"],
+            "proposed": counts["proposed"],
+            "stale": counts["stale"],
+            "judged": counts["judged"],
+            "examples": example_merges,
+        }
+    )
+    try:
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="entity_adjudication",
+            type="entity_adjudication",
+            content=content,
+            priority="low",
+            created_at=_now(),
+            content_hash=hashlib.sha256(content.encode()).hexdigest(),
+            skip_if_duplicate=True,
+        )
+    except Exception:
+        logger.error("Failed to write entity_adjudication run observation", exc_info=True)
+
+
+# ── reconcile sweep ──────────────────────────────────────────────────────────
+
+
+def _fuzzy_group(entity_type: str) -> str:
+    """The comparison scope for a type, mirroring resolve_entity."""
+    if entity_type in _CONCEPT_CLUSTER:
+        return "cluster"
+    return entity_type  # person / org compare same-type; others never fuzzy-match
+
+
+def _compute_sweep_pairs(
+    slice_entities: list[tuple[str, str, str]],
+    group_candidates: dict[str, list[tuple[str, str, str]]],
+    seen_pair_keys: set[str],
+    cap: int,
+) -> list[tuple[str, str]]:
+    """Pure-CPU pair discovery (runs off the event loop via ``to_thread``).
+
+    For each entity in the slice, find the fuzzy neighbours (difflib ≥ threshold,
+    same comparison group) that are not digit-only differences and not already
+    recorded/pending. Returns up to ``cap`` ``(entity_id, similar_entity_id)`` pairs.
+    """
+    out: list[tuple[str, str]] = []
+    for norm, eid, etype in slice_entities:
+        group = _fuzzy_group(etype)
+        candidates = group_candidates.get(group, ())
+        for cand_norm, cand_id, _ct in candidates:
+            # Skip only the SAME entity. Do NOT skip on ``cand_norm == norm``: two
+            # DIFFERENT entities can share a norm_name across types (UNIQUE is on
+            # norm_name+entity_type). Live resolve_entity reuses those cross-type,
+            # but historical/legacy duplicates are only recoverable HERE — an
+            # exact-norm cross-type pair is a legitimate merge candidate.
+            if cand_id == eid:
+                continue
+            key = f"{min(eid, cand_id)}|{max(eid, cand_id)}"
+            if key in seen_pair_keys:
+                continue
+            if digit_only_difference(norm, cand_norm):
+                continue
+            if difflib.SequenceMatcher(None, norm, cand_norm).ratio() >= _FUZZY_THRESHOLD:
+                seen_pair_keys.add(key)  # dedupe within this run too
+                out.append((eid, cand_id))
+                if len(out) >= cap:
+                    return out
+    return out
+
+
+async def _pending_pair_keys(db: aiosqlite.Connection) -> set[str]:
+    """pair_keys of currently-pending adjudication queue rows (both orientations
+    collapse via the sorted key)."""
+    rows = await dw_crud.query_pending(db, work_type=WORK_TYPE, limit=10000)
+    keys: set[str] = set()
+    for r in rows:
+        try:
+            p = json.loads(r.get("payload_json") or "{}")
+            a, b = p["entity_id"], p["similar_entity_id"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            continue
+        keys.add(f"{min(a, b)}|{max(a, b)}")
+    return keys
+
+
+_SWEEP_CURSOR_KEY = "entity_adjudication_sweep_cursor"
+_SWEEP_RERUN_DAYS = 7
+
+
+async def maybe_run_sweep(
+    db: aiosqlite.Connection,
+    *,
+    drain_budget: int,
+    slice_size: int,
+    enqueue_cap: int,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Advance the cursor-managed reconcile sweep by one slice, if appropriate.
+
+    Gated on a low-water mark — skip while the queue already holds ≥ 2×budget
+    pending rows, so the sweep never outruns the drain. Cursor lives in
+    ``ego_state``; a completed pass idles until it is ``_SWEEP_RERUN_DAYS`` old,
+    then restarts from offset 0 (weekly self-heal). Returns the sweep result, or
+    None when skipped.
+    """
+    from genesis.db.crud import ego as ego_crud
+
+    now = now or datetime.now(UTC)
+    pending = await dw_crud.count_pending(db, work_type=WORK_TYPE)
+    if pending >= 2 * drain_budget:
+        return None
+
+    raw = await ego_crud.get_state(db, _SWEEP_CURSOR_KEY)
+    state: dict[str, Any] = {}
+    if raw:
+        try:
+            state = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            state = {}
+    offset = int(state.get("offset", 0) or 0)
+    completed_at = state.get("completed_at")
+    if completed_at:
+        # Idle after a full pass — re-run only once it is a week stale.
+        try:
+            done = datetime.fromisoformat(completed_at)
+            if (now - done).days < _SWEEP_RERUN_DAYS:
+                return None
+        except (ValueError, TypeError):
+            pass
+        offset = 0  # start a fresh pass
+
+    result = await run_reconcile_sweep(
+        db, slice_size=slice_size, enqueue_cap=enqueue_cap, cursor_offset=offset
+    )
+    new_state = {
+        "offset": result["next_offset"],
+        "completed_at": now.isoformat() if result["completed"] else None,
+    }
+    await ego_crud.set_state(db, key=_SWEEP_CURSOR_KEY, value=json.dumps(new_state))
+    return result
+
+
+async def run_reconcile_sweep(
+    db: aiosqlite.Connection,
+    *,
+    slice_size: int = 200,
+    enqueue_cap: int = 50,
+    cursor_offset: int = 0,
+) -> dict[str, Any]:
+    """Rediscover fuzzy pairs among EXISTING entities (one bounded slice).
+
+    The producer only enqueues newly-created near-duplicates; this recovers the
+    historical backlog and heals any install. Slice bounds per-run CPU; the caller
+    advances/persists ``cursor_offset``. Difflib runs off-thread.
+
+    Returns ``{"enqueued": int, "next_offset": int, "completed": bool,
+    "total": int}``.
+    """
+    # Snapshot candidate lists on the loop; compute pairs off-thread.
+    cluster_types = list(_CONCEPT_CLUSTER)
+    cluster = await entities_crud.list_norm_names(db, entity_types=cluster_types)
+    persons = await entities_crud.list_norm_names(db, entity_types=["person"])
+    orgs = await entities_crud.list_norm_names(db, entity_types=["org"])
+    group_candidates = {"cluster": cluster, "person": persons, "org": orgs}
+
+    # Flat, stable ordering (by entity_id) over all fuzzy-eligible entities.
+    all_entities = sorted(cluster + persons + orgs, key=lambda t: t[1])
+    total = len(all_entities)
+    slice_entities = all_entities[cursor_offset : cursor_offset + slice_size]
+
+    # Settled verdicts (merge/distinct/proposed_merge) are skipped; `stale` pairs
+    # are deliberately NOT in this set so the sweep re-discovers and re-adjudicates
+    # them. Pending queue rows are also skipped (both orientations).
+    seen = await adj_crud.settled_pair_keys(db)
+    seen |= await _pending_pair_keys(db)
+
+    pairs = await asyncio.to_thread(
+        _compute_sweep_pairs, slice_entities, group_candidates, seen, enqueue_cap
+    )
+
+    enqueued = 0
+    for eid, cand_id in pairs:
+        await entities_crud.enqueue_adjudication(db, entity_id=eid, similar_entity_id=cand_id)
+        enqueued += 1
+
+    next_offset = cursor_offset + slice_size
+    completed = next_offset >= total
+    return {
+        "enqueued": enqueued,
+        "next_offset": 0 if completed else next_offset,
+        "completed": completed,
+        "total": total,
+    }

--- a/src/genesis/memory/entity_adjudication_config.py
+++ b/src/genesis/memory/entity_adjudication_config.py
@@ -1,0 +1,105 @@
+"""Config lever for the entity adjudication drainer.
+
+Cloned from ``session_awareness.repo_pulse_config``: fresh-read-per-call,
+degrade-toward-less-authority on damage, MODES tuple + env kill switch.
+
+Failure posture: a missing/corrupt config degrades to DEFAULTS; an invalid
+``mode`` degrades to ``propose_only`` (never a silent ``live`` — the shadow
+posture is the safe one). The env kill switch
+``GENESIS_ENTITY_ADJUDICATION_DISABLED=1`` forces ``off`` regardless of file.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``MODES`` and ``INT_KNOBS``
+from here (never the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "propose_only", "live")
+
+_CONFIG_NAME = "entity_adjudication.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_ENTITY_ADJUDICATION_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "mode": "propose_only",
+    "drain_budget": 20,
+    "sweep_enabled": True,
+    "sweep_slice_size": 200,
+    "sweep_enqueue_cap": 50,
+}
+
+# Public: the settings-domain validator imports this (with MODES) to check knobs.
+INT_KNOBS = ("drain_budget", "sweep_slice_size", "sweep_enqueue_cap")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        logger.warning("entity_adjudication base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("entity_adjudication overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode the drainer must run under — read live.
+
+    Env kill switch → ``off``. Master ``enabled: false`` → ``off``. An invalid
+    value degrades to ``propose_only`` (observable, no write authority — never a
+    silent ``off`` that would hide the feature, never a silent ``live``).
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("entity_adjudication has invalid mode %r — degrading to propose_only", mode)
+        return "propose_only"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never crashes
+    the drainer or zeroes a limit."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -539,6 +539,22 @@ _CALL_SITE_META: dict[str, dict] = {
         "wired": True,
         "see_also": ["dream_cycle_entity_check"],
     },
+    "entity_adjudication": {
+        "description": "Entity-NODE merge-vs-distinct adjudication — decides whether two fuzzily-similar entities are the same real-world thing. Hourly drainer over the entity_adjudication queue; digit-differing pairs skip the LLM (mechanical distinct).",
+        "category": "consolidation",
+        "frequency": "Hourly drain (:25), budget ~20 pairs/run; propose_only by default",
+        "model_tier": "slm",
+        "wired": True,
+        "see_also": ["entity_adjudication_challenge"],
+    },
+    "entity_adjudication_challenge": {
+        "description": "Adversarial second opinion on an entity-node 'merge' verdict. Flipped provider pairing (DeepSeek challenges Kimi). Both must agree before two entities are merged.",
+        "category": "consolidation",
+        "frequency": "Hourly drain (:25), fired on merge verdicts only",
+        "model_tier": "slm",
+        "wired": True,
+        "see_also": ["entity_adjudication"],
+    },
     "28_observation_sweep": {
         "description": "Functionally replaced by awareness loop's signal collection (awareness/loop.py:perform_tick). Kept as historical reference; no live consumers route through this call site.",
         "category": "processing",

--- a/src/genesis/resilience/deferred_work.py
+++ b/src/genesis/resilience/deferred_work.py
@@ -43,7 +43,12 @@ TTL = "ttl"
 # Kept here (low-level) rather than in ``memory/dream_cycle`` so the observability
 # snapshot can import it without a memory→observability dependency inversion.
 # A drift-guard test pins this against ``dream_cycle.WORKLIST_WORK_TYPE``.
-BATCH_WORK_TYPES: frozenset[str] = frozenset({"dream_synthesis_slice"})
+#
+# ``entity_adjudication``: the reconcile sweep enqueues bursts of near-duplicate
+# pairs (hundreds on first pass) that the hourly drainer works through at
+# ~20/run by design — a deep-but-healthy backlog, not stuck recovery work.
+# Excluded so those bursts don't page the deferred_recovery depth alarm.
+BATCH_WORK_TYPES: frozenset[str] = frozenset({"dream_synthesis_slice", "entity_adjudication"})
 
 # A batch worklist item pending longer than this is treated as genuinely stalled
 # (the daily drain has broken) and folded BACK into the recovery-backlog count so
@@ -95,12 +100,18 @@ class DeferredWorkQueue:
         except Exception:
             logger.error(
                 "Deferred work enqueue FAILED — work lost: type=%s priority=%d reason=%s",
-                work_type, priority, reason, exc_info=True,
+                work_type,
+                priority,
+                reason,
+                exc_info=True,
             )
             return None
         logger.info(
             "Deferred work enqueued: type=%s priority=%d reason=%s id=%s",
-            work_type, priority, reason, item_id,
+            work_type,
+            priority,
+            reason,
+            item_id,
         )
         return item_id
 
@@ -114,7 +125,10 @@ class DeferredWorkQueue:
         item at priority 20 was blocking reflection retries at priority 30).
         """
         items = await crud.query_pending(
-            self._db, work_type=work_type, max_priority=max_priority, limit=1,
+            self._db,
+            work_type=work_type,
+            max_priority=max_priority,
+            limit=1,
         )
         return items[0] if items else None
 
@@ -122,21 +136,31 @@ class DeferredWorkQueue:
         """Mark an item as being processed."""
         now = self._clock().isoformat()
         return await crud.update_status(
-            self._db, id, status="processing", last_attempt_at=now,
+            self._db,
+            id,
+            status="processing",
+            last_attempt_at=now,
         )
 
     async def mark_completed(self, id: str) -> bool:
         """Mark an item as completed."""
         now = self._clock().isoformat()
         return await crud.update_status(
-            self._db, id, status="completed", completed_at=now,
+            self._db,
+            id,
+            status="completed",
+            completed_at=now,
         )
 
     async def mark_discarded(self, id: str, reason: str) -> bool:
         """Mark an item as discarded."""
         now = self._clock().isoformat()
         return await crud.update_status(
-            self._db, id, status="discarded", error_message=reason, completed_at=now,
+            self._db,
+            id,
+            status="discarded",
+            error_message=reason,
+            completed_at=now,
         )
 
     async def expire_stuck_processing(self, max_age_hours: int = 2) -> int:
@@ -146,12 +170,14 @@ class DeferredWorkQueue:
         (e.g., bridge restart). Returns count reset.
         """
         count = await crud.expire_stuck_processing(
-            self._db, max_age_hours=max_age_hours,
+            self._db,
+            max_age_hours=max_age_hours,
         )
         if count > 0:
             logger.info(
                 "Reset %d stuck processing items to pending (age > %dh)",
-                count, max_age_hours,
+                count,
+                max_age_hours,
             )
         return count
 
@@ -179,9 +205,7 @@ class DeferredWorkQueue:
         """
         return await crud.count_pending_in(self._db, work_types=BATCH_WORK_TYPES)
 
-    async def count_recovery_pending(
-        self, stale_worklist_days: int = STALE_WORKLIST_DAYS
-    ) -> int:
+    async def count_recovery_pending(self, stale_worklist_days: int = STALE_WORKLIST_DAYS) -> int:
         """Count pending items that should trip the recovery-backlog depth alarm.
 
         Genuine resilience-recovery work always counts; batch worklist items are
@@ -206,7 +230,9 @@ class DeferredWorkQueue:
         worklist). Returns the count removed.
         """
         return await crud.delete_by_work_type(
-            self._db, work_type=work_type, exclude_status="processing",
+            self._db,
+            work_type=work_type,
+            exclude_status="processing",
         )
 
     async def drain_by_priority(self, limit: int = 10) -> list[dict]:

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -140,6 +140,31 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
         misfire_grace_time=3600,
     )
 
+    async def _prune_deferred_work() -> None:
+        if rt._db is None:
+            return
+        try:
+            from datetime import timedelta
+
+            from genesis.db.crud import deferred_work as _dw
+
+            cutoff = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+            removed = await _dw.prune_terminal(rt._db, cutoff_iso=cutoff)
+            rt.record_job_success("deferred_work_prune")
+            if removed:
+                logger.info("deferred_work prune: removed %d terminal rows (>45d)", removed)
+        except Exception as exc:
+            rt.record_job_failure("deferred_work_prune", str(exc))
+            logger.exception("deferred_work prune failed")
+
+    scheduler.add_job(
+        _prune_deferred_work,
+        CronTrigger(hour=5, minute=30, timezone=user_timezone()),
+        id="deferred_work_prune",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
 
 async def init(rt: GenesisRuntime) -> None:
     """Initialize learning pipeline, triage, calibration, harvest, and all scheduled jobs."""
@@ -672,6 +697,60 @@ async def init(rt: GenesisRuntime) -> None:
             id="dead_letter_redispatch",
             max_instances=1,
             misfire_grace_time=3600,
+        )
+
+        async def _run_entity_adjudication() -> None:
+            try:
+                if rt.paused:
+                    logger.debug("Entity adjudication skipped (Genesis paused)")
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping adjudication as precaution",
+                    exc_info=True,
+                )
+                return
+            if rt._db is None or rt._router is None:
+                return
+            try:
+                from genesis.memory import entity_adjudication as _adj
+                from genesis.memory.entity_adjudication_config import (
+                    effective_mode,
+                    knob_int,
+                    load_config,
+                )
+
+                mode = effective_mode()
+                if mode == "off":
+                    rt.record_job_success("entity_adjudication_drain")
+                    return
+                cfg = load_config()
+                budget = knob_int(cfg, "drain_budget")
+                counts = await _adj.run_adjudication_drain(
+                    rt._db, rt._router, mode=mode, budget=budget
+                )
+                if cfg.get("sweep_enabled", True):
+                    await _adj.maybe_run_sweep(
+                        rt._db,
+                        drain_budget=budget,
+                        slice_size=knob_int(cfg, "sweep_slice_size"),
+                        enqueue_cap=knob_int(cfg, "sweep_enqueue_cap"),
+                    )
+                rt.record_job_success("entity_adjudication_drain")
+                if counts.get("judged") or counts.get("merged") or counts.get("proposed"):
+                    logger.info("entity_adjudication drain (mode=%s): %s", mode, counts)
+            except Exception as exc:
+                rt.record_job_failure("entity_adjudication_drain", str(exc))
+                logger.exception("entity_adjudication drain failed")
+
+        # CronTrigger (not IntervalTrigger — resets on restart). :25 is a clean
+        # minute (:15 process_reaper, :30 procedure_promotion, :45 dead-letter).
+        rt._learning_scheduler.add_job(
+            _run_entity_adjudication,
+            CronTrigger(minute=25),
+            id="entity_adjudication_drain",
+            max_instances=1,
+            misfire_grace_time=600,
         )
 
         async def _run_procedure_promotion() -> None:

--- a/tests/test_db/test_entity_adjudications_crud.py
+++ b/tests/test_db/test_entity_adjudications_crud.py
@@ -57,6 +57,17 @@ async def test_all_pair_keys(db):
 
 
 @pytest.mark.asyncio
+async def test_settled_pair_keys_excludes_stale(db):
+    await adj.record_verdict(db, entity_a="a", entity_b="b", verdict="distinct")
+    await adj.record_verdict(db, entity_a="c", entity_b="d", verdict="merge")
+    await adj.record_verdict(db, entity_a="e", entity_b="f", verdict="proposed_merge")
+    await adj.record_verdict(db, entity_a="g", entity_b="h", verdict="stale")
+    # stale is excluded so the sweep can rediscover it; the rest are settled.
+    assert await adj.settled_pair_keys(db) == {"a|b", "c|d", "e|f"}
+    assert await adj.all_pair_keys(db) == {"a|b", "c|d", "e|f", "g|h"}
+
+
+@pytest.mark.asyncio
 async def test_list_proposed_merges_only_proposed(db):
     await adj.record_verdict(
         db, entity_a="a", entity_b="b", verdict="proposed_merge", loser_id="b", survivor_id="a"

--- a/tests/test_memory/test_entity_adjudication.py
+++ b/tests/test_memory/test_entity_adjudication.py
@@ -1,0 +1,441 @@
+"""Entity adjudication drainer — merge-vs-distinct decisions over fuzzy pairs.
+
+Uses the full in-memory ``db`` fixture and a scripted router (no live LLM).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.db.crud import deferred_work as dw_crud
+from genesis.db.crud import entities as entities_crud
+from genesis.db.crud import entity_adjudications as adj_crud
+from genesis.memory import entity_adjudication as adj
+
+# ── fixtures/helpers ─────────────────────────────────────────────────────────
+
+
+def _router(verdict_by_callsite: dict[str, str]) -> MagicMock:
+    """Router whose route_call returns a scripted verdict per call_site_id."""
+    router = MagicMock()
+
+    async def _call(call_site_id, messages, **kwargs):
+        v = verdict_by_callsite.get(call_site_id, "distinct")
+        return MagicMock(
+            success=True,
+            content=json.dumps({"verdict": v, "reasoning": "test"}),
+            provider_used=f"prov-{call_site_id}",
+            error=None,
+        )
+
+    router.route_call = AsyncMock(side_effect=_call)
+    return router
+
+
+async def _mk_entity(db, name, norm, etype="concept", summary=None):
+    return await entities_crud.create_entity(
+        db, name=name, norm_name=norm, entity_type=etype, summary=summary
+    )
+
+
+async def _enqueue(db, eid, similar):
+    item_id = str(uuid.uuid4())
+    await dw_crud.create(
+        db,
+        id=item_id,
+        work_type=adj.WORK_TYPE,
+        priority=60,
+        payload_json=json.dumps({"entity_id": eid, "similar_entity_id": similar}),
+        deferred_at="2026-07-17T00:00:00+00:00",
+        deferred_reason="fuzzy",
+        created_at="2026-07-17T00:00:00+00:00",
+        call_site_id="entity_adjudication",
+    )
+    return item_id
+
+
+async def _status(db, eid):
+    cur = await db.execute("SELECT status FROM entities WHERE entity_id = ?", (eid,))
+    return (await cur.fetchone())[0]
+
+
+# ── digit guard ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("pr #989", "pr #990", True),
+        ("2026-07-16", "2026-07-17", True),
+        ("system", "systemd", False),
+        ("pr-1", "pr-1a", False),
+        ("neural monitor", "neural-monitor", False),
+        ("same", "same", False),  # identical → not a "difference"
+    ],
+)
+def test_digit_only_difference(a, b, expected):
+    assert adj.digit_only_difference(a, b) is expected
+
+
+# ── adjudicate_pair ──────────────────────────────────────────────────────────
+
+
+def test_prompts_carry_cosmetic_vs_semantic_guidance():
+    """Regression guard for the live-E2E finding: without the cosmetic-vs-semantic
+    distinction, the challenge over-fires and merges nothing (formatting variants
+    like 'neural monitor'/'neural-monitor' get wrongly kept distinct). Both
+    prompts must keep that guidance."""
+    for prompt in (adj._ADJUDICATION_PROMPT, adj._CHALLENGE_PROMPT):
+        low = prompt.lower()
+        assert "cosmetic" in low or "formatting" in low
+        assert "semantic" in low
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_merge_requires_both_models():
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "merge"})
+    out = await adj.adjudicate_pair(router, "A", "B")
+    assert out["verdict"] == "merge"
+    assert "+" in out["provider"]  # both providers recorded
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_challenge_overrides_to_distinct():
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "distinct"})
+    out = await adj.adjudicate_pair(router, "A", "B")
+    assert out["verdict"] == "distinct"
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_primary_distinct_skips_challenge():
+    router = _router({"entity_adjudication": "distinct"})
+    out = await adj.adjudicate_pair(router, "A", "B")
+    assert out["verdict"] == "distinct"
+    # challenge call site never invoked
+    called_sites = [c.args[0] for c in router.route_call.call_args_list]
+    assert "entity_adjudication_challenge" not in called_sites
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_primary_error_is_retryable():
+    router = MagicMock()
+    router.route_call = AsyncMock(return_value=MagicMock(success=False, error="boom"))
+    out = await adj.adjudicate_pair(router, "A", "B")
+    assert out["verdict"] == "distinct" and out["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_adjudicate_challenge_dissent_is_not_retryable():
+    # Real dissent (challenge genuinely says distinct) is a recordable verdict,
+    # NOT a retry.
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "distinct"})
+    out = await adj.adjudicate_pair(router, "A", "B")
+    assert out["verdict"] == "distinct" and out["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_drain_requeues_on_llm_error_without_recording(db):
+    a = await _mk_entity(db, "flaky one", "flaky one")
+    b = await _mk_entity(db, "flaky onee", "flaky onee")
+    item_id = await _enqueue(db, a, b)
+    router = MagicMock()
+    router.route_call = AsyncMock(return_value=MagicMock(success=False, error="all providers down"))
+
+    counts = await adj.run_adjudication_drain(db, router, mode="propose_only", budget=10)
+
+    assert counts["retried"] == 1 and counts["judged"] == 0
+    # No verdict recorded — a transient outage must not burn the pair.
+    assert await adj_crud.get_by_pair(db, a, b) is None
+    # Row is back to pending (with attempts incremented) for the next run.
+    cur = await db.execute(
+        "SELECT status, attempts FROM deferred_work_queue WHERE id=?", (item_id,)
+    )
+    status, attempts = await cur.fetchone()
+    assert status == "pending" and attempts == 1
+
+
+# ── drain: propose_only ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_propose_only_records_but_never_mutates(db):
+    a = await _mk_entity(db, "neural monitor", "neural monitor")
+    b = await _mk_entity(db, "neural-monitor", "neural-monitor")
+    await _enqueue(db, a, b)
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "merge"})
+
+    counts = await adj.run_adjudication_drain(db, router, mode="propose_only", budget=10)
+
+    assert counts["proposed"] == 1 and counts["merged"] == 0
+    row = await adj_crud.get_by_pair(db, a, b)
+    assert row["verdict"] == "proposed_merge"
+    # HARD invariant: no entity mutated in shadow mode.
+    assert await _status(db, a) == "active"
+    assert await _status(db, b) == "active"
+
+
+@pytest.mark.asyncio
+async def test_digit_guard_skips_llm(db):
+    a = await _mk_entity(db, "pr #989", "pr #989")
+    b = await _mk_entity(db, "pr #990", "pr #990")
+    await _enqueue(db, a, b)
+    router = _router({})  # would return distinct, but must not be called
+
+    counts = await adj.run_adjudication_drain(db, router, mode="propose_only", budget=10)
+
+    assert counts["mechanical_distinct"] == 1
+    router.route_call.assert_not_called()
+    row = await adj_crud.get_by_pair(db, a, b)
+    assert row["verdict"] == "distinct" and row["provider"] == "mechanical"
+
+
+@pytest.mark.asyncio
+async def test_already_judged_pair_not_rejudged(db):
+    a = await _mk_entity(db, "alpha one", "alpha one")
+    b = await _mk_entity(db, "alpha onee", "alpha onee")
+    await adj_crud.record_verdict(db, entity_a=a, entity_b=b, verdict="distinct")
+    await _enqueue(db, a, b)
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "merge"})
+
+    counts = await adj.run_adjudication_drain(db, router, mode="propose_only", budget=10)
+
+    assert counts["noop"] == 1 and counts["judged"] == 0
+    router.route_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gone_entity_is_noop(db):
+    a = await _mk_entity(db, "ghost", "ghost")
+    b = await _mk_entity(db, "ghostt", "ghostt")
+    await _enqueue(db, a, b)
+    # b is merged away with no survivor target chain → resolve returns None path:
+    await db.execute("UPDATE entities SET status='gone' WHERE entity_id=?", (b,))
+    await db.commit()
+    router = _router({"entity_adjudication": "merge"})
+
+    counts = await adj.run_adjudication_drain(db, router, mode="propose_only", budget=10)
+    assert counts["noop"] == 1
+    router.route_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unparseable_payload_discarded(db):
+    item_id = str(uuid.uuid4())
+    await dw_crud.create(
+        db,
+        id=item_id,
+        work_type=adj.WORK_TYPE,
+        priority=60,
+        payload_json="{not json",
+        deferred_at="2026-07-17T00:00:00+00:00",
+        deferred_reason="fuzzy",
+        created_at="2026-07-17T00:00:00+00:00",
+    )
+    counts = await adj.run_adjudication_drain(db, _router({}), mode="propose_only", budget=10)
+    assert counts["discarded"] == 1
+    cur = await db.execute("SELECT status FROM deferred_work_queue WHERE id=?", (item_id,))
+    assert (await cur.fetchone())[0] == "discarded"
+
+
+@pytest.mark.asyncio
+async def test_attempts_exhausted_discards_with_observation(db):
+    a = await _mk_entity(db, "worn one", "worn one")
+    b = await _mk_entity(db, "worn onee", "worn onee")
+    item_id = await _enqueue(db, a, b)
+    await db.execute("UPDATE deferred_work_queue SET attempts=5 WHERE id=?", (item_id,))
+    await db.commit()
+
+    counts = await adj.run_adjudication_drain(db, _router({}), mode="propose_only", budget=10)
+    assert counts["discarded"] == 1
+    cur = await db.execute("SELECT COUNT(*) FROM observations WHERE type='deferred_work_exhausted'")
+    assert (await cur.fetchone())[0] == 1
+
+
+# ── drain: live ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_live_applies_merge(db):
+    a = await _mk_entity(db, "dispatch: cli", "dispatch: cli")
+    b = await _mk_entity(db, "dispatch=cli", "dispatch=cli")
+    # give `a` more mentions → a should survive
+    await entities_crud.upsert_mention(db, memory_id="m1", entity_id=a, provenance="EXTRACTED")
+    await entities_crud.upsert_mention(db, memory_id="m2", entity_id=a, provenance="EXTRACTED")
+    await _enqueue(db, b, a)  # payload order (new=b, similar=a) must not dictate survivor
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "merge"})
+
+    counts = await adj.run_adjudication_drain(db, router, mode="live", budget=10)
+
+    assert counts["merged"] == 1
+    assert await _status(db, a) == "active"  # better-attested survives
+    assert await _status(db, b) == "merged"
+    row = await adj_crud.get_by_pair(db, a, b)
+    assert row["verdict"] == "merge" and row["survivor_id"] == a and row["applied_at"]
+
+
+@pytest.mark.asyncio
+async def test_live_merge_race_guard_falls_back_to_proposed(db, monkeypatch):
+    """If a side moves between resolve and the merge (extraction race), the live
+    path records a proposal instead of applying a stale merge."""
+    a = await _mk_entity(db, "race a", "race a")
+    b = await _mk_entity(db, "race aa", "race aa")
+    await _enqueue(db, a, b)
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "merge"})
+
+    real_resolve = adj._resolve_active
+    calls = {"n": 0}
+
+    async def _flaky_resolve(db_, eid):
+        calls["n"] += 1
+        # First two calls (initial resolve of both) succeed; the re-check (3rd+)
+        # simulates the entity having been merged away mid-drain.
+        if calls["n"] > 2:
+            return None
+        return await real_resolve(db_, eid)
+
+    monkeypatch.setattr(adj, "_resolve_active", _flaky_resolve)
+
+    counts = await adj.run_adjudication_drain(db, router, mode="live", budget=10)
+
+    assert counts["merged"] == 0 and counts["proposed"] == 1
+    assert await _status(db, a) == "active" and await _status(db, b) == "active"
+    assert (await adj_crud.get_by_pair(db, a, b))["verdict"] == "proposed_merge"
+
+
+@pytest.mark.asyncio
+async def test_live_phase0_applies_proposed_backlog(db):
+    a = await _mk_entity(db, "kappa", "kappa")
+    b = await _mk_entity(db, "kappaa", "kappaa")
+    # a proposal recorded during a prior shadow run
+    await adj_crud.record_verdict(
+        db,
+        entity_a=a,
+        entity_b=b,
+        verdict="proposed_merge",
+        loser_id=b,
+        survivor_id=a,
+        norm_a="kappa",
+        norm_b="kappaa",
+    )
+    counts = await adj.run_adjudication_drain(db, _router({}), mode="live", budget=10)
+    assert counts["merged"] == 1
+    assert await _status(db, b) == "merged"
+    assert (await adj_crud.get_by_pair(db, a, b))["verdict"] == "merge"
+
+
+@pytest.mark.asyncio
+async def test_live_phase0_stale_on_norm_drift(db):
+    a = await _mk_entity(db, "lambda", "lambda")
+    b = await _mk_entity(db, "lambdaa", "lambdaa")
+    await adj_crud.record_verdict(
+        db,
+        entity_a=a,
+        entity_b=b,
+        verdict="proposed_merge",
+        loser_id=b,
+        survivor_id=a,
+        norm_a="lambda",
+        norm_b="OLD-DIFFERENT-NORM",
+    )
+    counts = await adj.run_adjudication_drain(db, _router({}), mode="live", budget=10)
+    assert counts["stale"] == 1 and counts["merged"] == 0
+    assert await _status(db, b) == "active"  # not applied
+    assert (await adj_crud.get_by_pair(db, a, b))["verdict"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_run_observation_emitted_and_user_visible(db):
+    from genesis.db.crud.observations import INTERNAL_OBS_TYPES
+
+    a = await _mk_entity(db, "omega x", "omega x")
+    b = await _mk_entity(db, "omega xx", "omega xx")
+    await _enqueue(db, a, b)
+    router = _router({"entity_adjudication": "merge", "entity_adjudication_challenge": "merge"})
+    await adj.run_adjudication_drain(db, router, mode="propose_only", budget=10)
+
+    cur = await db.execute("SELECT COUNT(*) FROM observations WHERE type='entity_adjudication'")
+    assert (await cur.fetchone())[0] == 1
+    # digest-visible: NOT excluded from the morning report
+    assert "entity_adjudication" not in INTERNAL_OBS_TYPES
+
+
+# ── sweep ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sweep_enqueues_fuzzy_pair(db):
+    await _mk_entity(db, "neural monitor", "neural monitor")
+    await _mk_entity(db, "neural-monitor", "neural-monitor")
+    await _mk_entity(db, "totally different", "totally different")
+
+    result = await adj.run_reconcile_sweep(db, slice_size=100, enqueue_cap=50)
+
+    assert result["enqueued"] == 1  # only the fuzzy pair
+    assert result["completed"] is True
+    pending = await dw_crud.query_pending(db, work_type=adj.WORK_TYPE, limit=100)
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_digit_pairs_and_existing_verdicts(db):
+    await _mk_entity(db, "pr #100", "pr #100")
+    await _mk_entity(db, "pr #101", "pr #101")
+    j1 = await _mk_entity(db, "judged a", "judged a")
+    j2 = await _mk_entity(db, "judged aa", "judged aa")
+    await adj_crud.record_verdict(db, entity_a=j1, entity_b=j2, verdict="distinct")
+
+    result = await adj.run_reconcile_sweep(db, slice_size=100, enqueue_cap=50)
+    assert result["enqueued"] == 0  # digit pair skipped mechanically; judged pair deduped
+
+
+@pytest.mark.asyncio
+async def test_sweep_queues_exact_norm_cross_type_pair(db):
+    # Two DIFFERENT entities sharing a norm_name across types (allowed by
+    # UNIQUE(norm_name, entity_type)) are legitimate merge candidates that only
+    # the sweep can recover — must be queued, not dropped (Codex P2).
+    await _mk_entity(db, "omi", "omi", etype="product")
+    await _mk_entity(db, "omi", "omi", etype="device")
+    result = await adj.run_reconcile_sweep(db, slice_size=100, enqueue_cap=50)
+    assert result["enqueued"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_rediscovers_stale_but_not_settled(db):
+    # A stale pair must be re-enqueued (identity drifted → re-adjudicate); a
+    # settled distinct pair must stay deduped.
+    s1 = await _mk_entity(db, "stale one", "stale one")
+    s2 = await _mk_entity(db, "stale onee", "stale onee")
+    await adj_crud.record_verdict(db, entity_a=s1, entity_b=s2, verdict="stale")
+    d1 = await _mk_entity(db, "settled one", "settled one")
+    d2 = await _mk_entity(db, "settled onee", "settled onee")
+    await adj_crud.record_verdict(db, entity_a=d1, entity_b=d2, verdict="distinct")
+
+    result = await adj.run_reconcile_sweep(db, slice_size=100, enqueue_cap=50)
+
+    assert result["enqueued"] == 1  # only the stale pair re-surfaces
+    pending = await dw_crud.query_pending(db, work_type=adj.WORK_TYPE, limit=100)
+    payload = json.loads(pending[0]["payload_json"])
+    assert {payload["entity_id"], payload["similar_entity_id"]} == {s1, s2}
+
+
+@pytest.mark.asyncio
+async def test_sweep_cursor_advances_and_completes(db):
+    for i in range(5):
+        await _mk_entity(db, f"ent {i}", f"ent {i}")
+    r1 = await adj.run_reconcile_sweep(db, slice_size=2, enqueue_cap=50, cursor_offset=0)
+    assert r1["next_offset"] == 2 and r1["completed"] is False
+    r2 = await adj.run_reconcile_sweep(db, slice_size=2, enqueue_cap=50, cursor_offset=4)
+    assert r2["completed"] is True and r2["next_offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_sweep_low_water_gate(db):
+    # Fill the queue past 2×budget so the sweep must skip.
+    for i in range(10):
+        await _enqueue(db, f"x{i}", f"y{i}")
+    out = await adj.maybe_run_sweep(db, drain_budget=2, slice_size=100, enqueue_cap=50)
+    assert out is None  # skipped: queue too deep

--- a/tests/test_memory/test_entity_adjudication_config.py
+++ b/tests/test_memory/test_entity_adjudication_config.py
@@ -1,0 +1,59 @@
+"""entity_adjudication config lever — mode degradation + env kill switch."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.memory import entity_adjudication_config as cfg
+
+
+def test_defaults_are_shadow():
+    assert cfg.DEFAULTS["mode"] == "propose_only"
+    assert cfg.DEFAULTS["enabled"] is True
+
+
+def test_effective_mode_reads_file(monkeypatch):
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": True, "mode": "live"})
+    assert cfg.effective_mode() == "live"
+
+
+def test_effective_mode_disabled_is_off(monkeypatch):
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": False, "mode": "live"})
+    assert cfg.effective_mode() == "off"
+
+
+def test_effective_mode_invalid_degrades_to_propose_only(monkeypatch):
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": True, "mode": "bogus"})
+    assert cfg.effective_mode() == "propose_only"
+
+
+def test_effective_mode_yaml_false_is_off(monkeypatch):
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": True, "mode": False})
+    assert cfg.effective_mode() == "off"
+
+
+def test_env_kill_switch_forces_off(monkeypatch):
+    monkeypatch.setenv(cfg._ENV_KILL_SWITCH, "1")
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": True, "mode": "live"})
+    assert cfg.effective_mode() == "off"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (5, 5),
+        (0, 20),
+        (-3, 20),
+        (True, 20),
+        ("x", 20),
+        (None, 20),
+    ],
+)
+def test_knob_int_falls_back_on_damage(value, expected):
+    assert cfg.knob_int({"drain_budget": value}, "drain_budget") == expected
+
+
+def test_load_config_returns_defaults_shape():
+    merged = cfg.load_config()
+    for k in cfg.DEFAULTS:
+        assert k in merged

--- a/tests/test_memory/test_entity_layer.py
+++ b/tests/test_memory/test_entity_layer.py
@@ -21,8 +21,7 @@ from genesis.memory.entity_seed import SEED_MENTIONS, apply_seed
 async def db():
     conn = await aiosqlite.connect(":memory:")
     conn.row_factory = aiosqlite.Row
-    for table in ("entities", "entity_mentions", "entity_links",
-                  "deferred_work_queue"):
+    for table in ("entities", "entity_mentions", "entity_links", "deferred_work_queue"):
         await conn.execute(TABLES[table])
     await conn.commit()
     yield conn
@@ -50,11 +49,17 @@ class TestCrud:
     async def test_mention_upsert_keeps_stronger(self, db):
         eid = await _mk(db, "Qdrant", "product")
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=eid, provenance="EXTRACTED",
+            db,
+            memory_id="m1",
+            entity_id=eid,
+            provenance="EXTRACTED",
             confidence=0.9,
         )
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=eid, provenance="INFERRED",
+            db,
+            memory_id="m1",
+            entity_id=eid,
+            provenance="INFERRED",
             confidence=0.4,
         )
         rows = await entities_crud.memories_mentioning(db, [eid])
@@ -66,12 +71,13 @@ class TestCrud:
         a = await _mk(db, "a")
         b = await _mk(db, "b")
         await entities_crud.upsert_link(
-            db, source_id=a, target_id=b, link_type="Is A!",
+            db,
+            source_id=a,
+            target_id=b,
+            link_type="Is A!",
             provenance="EXTRACTED",
         )
-        rows = await db.execute_fetchall(
-            "SELECT link_type FROM entity_links"
-        )
+        rows = await db.execute_fetchall("SELECT link_type FROM entity_links")
         assert rows[0][0] == "is_a"
 
     @pytest.mark.asyncio
@@ -80,12 +86,20 @@ class TestCrud:
         cat = await _mk(db, "voice-edge-device")
         rule = await _mk(db, "repo-split")
         await entities_crud.upsert_link(
-            db, source_id=omi, target_id=cat, link_type="is_a",
-            provenance="EXTRACTED", confidence=0.95,
+            db,
+            source_id=omi,
+            target_id=cat,
+            link_type="is_a",
+            provenance="EXTRACTED",
+            confidence=0.95,
         )
         await entities_crud.upsert_link(
-            db, source_id=cat, target_id=rule, link_type="constrained_by",
-            provenance="EXTRACTED", confidence=0.95,
+            db,
+            source_id=cat,
+            target_id=rule,
+            link_type="constrained_by",
+            provenance="EXTRACTED",
+            confidence=0.95,
         )
         reached = await entities_crud.connected_entities(db, [omi])
         assert reached[cat]["depth"] == 1
@@ -94,7 +108,10 @@ class TestCrud:
         # sibling via undirected hop through the category
         pe = await _mk(db, "haos voice pe", "device")
         await entities_crud.upsert_link(
-            db, source_id=pe, target_id=cat, link_type="is_a",
+            db,
+            source_id=pe,
+            target_id=cat,
+            link_type="is_a",
             provenance="EXTRACTED",
         )
         reached = await entities_crud.connected_entities(db, [omi])
@@ -105,11 +122,16 @@ class TestCrud:
         a = await _mk(db, "a")
         b = await _mk(db, "b")
         await entities_crud.upsert_link(
-            db, source_id=a, target_id=b, link_type="related_to",
+            db,
+            source_id=a,
+            target_id=b,
+            link_type="related_to",
             provenance="EXTRACTED",
         )
         n = await entities_crud.invalidate_links_for_entity(
-            db, entity_id=b, invalid_at="2026-01-01T00:00:00+00:00",
+            db,
+            entity_id=b,
+            invalid_at="2026-01-01T00:00:00+00:00",
             invalidated_by="test",
         )
         assert n == 1
@@ -117,7 +139,9 @@ class TestCrud:
         assert reached == {}
         # as_of BEFORE the invalidation still sees the edge
         reached = await entities_crud.connected_entities(
-            db, [a], as_of="2025-12-01T00:00:00+00:00",
+            db,
+            [a],
+            as_of="2025-12-01T00:00:00+00:00",
         )
         assert b in reached
 
@@ -126,8 +150,12 @@ class TestCrud:
         a = await _mk(db, "a")
         b = await _mk(db, "b")
         await entities_crud.upsert_link(
-            db, source_id=a, target_id=b, link_type="related_to",
-            provenance="AMBIGUOUS", confidence=1.0,
+            db,
+            source_id=a,
+            target_id=b,
+            link_type="related_to",
+            provenance="AMBIGUOUS",
+            confidence=1.0,
         )
         reached = await entities_crud.connected_entities(db, [a])
         assert reached[b]["path_confidence"] == pytest.approx(0.5)
@@ -138,10 +166,16 @@ class TestCrud:
         survivor = await _mk(db, "qdrant", "product")
         other = await _mk(db, "genesis", "product")
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=loser, provenance="EXTRACTED",
+            db,
+            memory_id="m1",
+            entity_id=loser,
+            provenance="EXTRACTED",
         )
         await entities_crud.upsert_link(
-            db, source_id=loser, target_id=other, link_type="part_of",
+            db,
+            source_id=loser,
+            target_id=other,
+            link_type="part_of",
             provenance="EXTRACTED",
         )
         await entities_crud.merge_entity(db, loser_id=loser, survivor_id=survivor)
@@ -151,7 +185,9 @@ class TestCrud:
         assert other in reached
         # norm lookup on the loser follows the merge to the survivor
         resolved = await entities_crud.get_by_norm_name(
-            db, norm_name="qdrantdb", entity_type="product",
+            db,
+            norm_name="qdrantdb",
+            entity_type="product",
         )
         assert resolved["entity_id"] == survivor
 
@@ -160,11 +196,15 @@ class TestRegistry:
     @pytest.mark.asyncio
     async def test_mechanical_exact_identity(self, db):
         eid1, prov = await entity_registry.resolve_entity(
-            db, name="src/genesis/memory/store.py", entity_type="code_file",
+            db,
+            name="src/genesis/memory/store.py",
+            entity_type="code_file",
             aliases=_NO_ALIASES,
         )
         eid2, _ = await entity_registry.resolve_entity(
-            db, name="src/genesis/memory/store.py", entity_type="code_file",
+            db,
+            name="src/genesis/memory/store.py",
+            entity_type="code_file",
             aliases=_NO_ALIASES,
         )
         assert eid1 == eid2
@@ -173,58 +213,103 @@ class TestRegistry:
     @pytest.mark.asyncio
     async def test_named_cross_cluster_reuse(self, db):
         eid1, _ = await entity_registry.resolve_entity(
-            db, name="OMI", entity_type="product", aliases=_NO_ALIASES,
+            db,
+            name="OMI",
+            entity_type="product",
+            aliases=_NO_ALIASES,
         )
         eid2, prov = await entity_registry.resolve_entity(
-            db, name="omi", entity_type="device", aliases=_NO_ALIASES,
+            db,
+            name="omi",
+            entity_type="device",
+            aliases=_NO_ALIASES,
         )
         assert eid1 == eid2
         assert prov == "EXTRACTED"
 
     @pytest.mark.asyncio
-    async def test_fuzzy_ambiguous_but_no_enqueue_while_gated(self, db):
-        """Gate OFF (default): a fuzzy match still creates the entity and
-        returns AMBIGUOUS, but writes NO adjudication row — the enqueue is a
-        no-op until a drainer exists (stop-the-bleed, follow-up 9127e8ed)."""
+    async def test_fuzzy_ambiguous_but_no_enqueue_while_gated(self, db, monkeypatch):
+        """Gate OFF (producer kill switch): a fuzzy match still creates the
+        entity and returns AMBIGUOUS, but writes NO adjudication row. The gate
+        now defaults ON (the drainer exists), so this explicitly forces it off."""
+        monkeypatch.setattr(entities_crud, "_ADJUDICATION_ENQUEUE_ENABLED", False)
         await entity_registry.resolve_entity(
-            db, name="GENesis-Voice", entity_type="repo", aliases=_NO_ALIASES,
+            db,
+            name="GENesis-Voice",
+            entity_type="repo",
+            aliases=_NO_ALIASES,
         )
         eid, prov = await entity_registry.resolve_entity(
-            db, name="GENesis-Voices", entity_type="repo", aliases=_NO_ALIASES,
+            db,
+            name="GENesis-Voices",
+            entity_type="repo",
+            aliases=_NO_ALIASES,
         )
         assert prov == "AMBIGUOUS"
         # Entity was still created (the fuzzy pair exists, just un-adjudicated).
         assert await entities_crud.get_entity(db, eid) is not None
         rows = await db.execute_fetchall(
-            "SELECT work_type FROM deferred_work_queue "
-            "WHERE work_type = 'entity_adjudication'"
+            "SELECT work_type FROM deferred_work_queue WHERE work_type = 'entity_adjudication'"
         )
         assert rows == []  # no orphan row
 
     @pytest.mark.asyncio
     async def test_fuzzy_enqueues_when_gate_enabled(self, db, monkeypatch):
-        """The enqueue machinery is intact GROUNDWORK — flipping the gate on
-        (what the drainer/A will do) restores the adjudication row."""
-        monkeypatch.setattr(
-            entities_crud, "_ADJUDICATION_ENQUEUE_ENABLED", True,
-        )
+        """Gate ON (default now the drainer exists): a fuzzy match enqueues an
+        adjudication row tagged call_site_id='entity_adjudication' (dashboard
+        shows the site, not 'unknown')."""
+        monkeypatch.setattr(entities_crud, "_ADJUDICATION_ENQUEUE_ENABLED", True)
         await entity_registry.resolve_entity(
-            db, name="GENesis-Voice", entity_type="repo", aliases=_NO_ALIASES,
+            db,
+            name="GENesis-Voice",
+            entity_type="repo",
+            aliases=_NO_ALIASES,
         )
         eid, prov = await entity_registry.resolve_entity(
-            db, name="GENesis-Voices", entity_type="repo", aliases=_NO_ALIASES,
+            db,
+            name="GENesis-Voices",
+            entity_type="repo",
+            aliases=_NO_ALIASES,
         )
         assert prov == "AMBIGUOUS"
         rows = await db.execute_fetchall(
-            "SELECT work_type, payload_json FROM deferred_work_queue"
+            "SELECT work_type, payload_json, call_site_id FROM deferred_work_queue"
         )
         assert rows and rows[0][0] == "entity_adjudication"
         assert eid in rows[0][1]
+        assert rows[0][2] == "entity_adjudication"
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_enqueue_deduped_both_orientations(self, db, monkeypatch):
+        """A repeated fuzzy collision for the same pair must NOT pile up rows —
+        the both-orientation NOT-EXISTS guard collapses it to one pending row."""
+        monkeypatch.setattr(entities_crud, "_ADJUDICATION_ENQUEUE_ENABLED", True)
+        e1 = await entities_crud.create_entity(
+            db,
+            name="alpha",
+            norm_name="alpha",
+            entity_type="concept",
+        )
+        e2 = await entities_crud.create_entity(
+            db,
+            name="alphaa",
+            norm_name="alphaa",
+            entity_type="concept",
+        )
+        await entities_crud.enqueue_adjudication(db, entity_id=e1, similar_entity_id=e2)
+        await entities_crud.enqueue_adjudication(db, entity_id=e2, similar_entity_id=e1)
+        rows = await db.execute_fetchall(
+            "SELECT COUNT(*) FROM deferred_work_queue WHERE work_type='entity_adjudication'"
+        )
+        assert rows[0][0] == 1
 
     @pytest.mark.asyncio
     async def test_distinct_name_is_extracted(self, db):
         _, prov = await entity_registry.resolve_entity(
-            db, name="Tailscale", entity_type="product", aliases=_NO_ALIASES,
+            db,
+            name="Tailscale",
+            entity_type="product",
+            aliases=_NO_ALIASES,
         )
         assert prov == "EXTRACTED"
 
@@ -262,12 +347,21 @@ class TestCodexRemediationCrud:
         b = await _mk(db, "B")
         # Undated weak claim, then a stronger dated one: date must land.
         await entities_crud.upsert_link(
-            db, source_id=a, target_id=b, link_type="is_a",
-            provenance="INFERRED", confidence=0.5,
+            db,
+            source_id=a,
+            target_id=b,
+            link_type="is_a",
+            provenance="INFERRED",
+            confidence=0.5,
         )
         await entities_crud.upsert_link(
-            db, source_id=a, target_id=b, link_type="is_a",
-            provenance="EXTRACTED", confidence=0.9, valid_at="2026-06-14",
+            db,
+            source_id=a,
+            target_id=b,
+            link_type="is_a",
+            provenance="EXTRACTED",
+            confidence=0.9,
+            valid_at="2026-06-14",
         )
         rows = await db.execute_fetchall(
             "SELECT valid_at, confidence FROM entity_links",
@@ -275,8 +369,12 @@ class TestCodexRemediationCrud:
         assert rows[0][0] == "2026-06-14" and rows[0][1] == 0.9
         # An even stronger UNdated claim must not erase the known date.
         await entities_crud.upsert_link(
-            db, source_id=a, target_id=b, link_type="is_a",
-            provenance="EXTRACTED", confidence=0.95,
+            db,
+            source_id=a,
+            target_id=b,
+            link_type="is_a",
+            provenance="EXTRACTED",
+            confidence=0.95,
         )
         rows = await db.execute_fetchall(
             "SELECT valid_at, confidence FROM entity_links",
@@ -290,23 +388,40 @@ class TestCodexRemediationCrud:
         other = await _mk(db, "voice-edge-device")
         # Survivor holds the WEAKER mention and link; loser the stronger.
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=survivor, provenance="INFERRED",
+            db,
+            memory_id="m1",
+            entity_id=survivor,
+            provenance="INFERRED",
             confidence=0.4,
         )
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=loser, provenance="EXTRACTED",
+            db,
+            memory_id="m1",
+            entity_id=loser,
+            provenance="EXTRACTED",
             confidence=0.9,
         )
         await entities_crud.upsert_link(
-            db, source_id=survivor, target_id=other, link_type="is_a",
-            provenance="INFERRED", confidence=0.3,
+            db,
+            source_id=survivor,
+            target_id=other,
+            link_type="is_a",
+            provenance="INFERRED",
+            confidence=0.3,
         )
         await entities_crud.upsert_link(
-            db, source_id=loser, target_id=other, link_type="is_a",
-            provenance="EXTRACTED", confidence=0.9, valid_at="2026-06-14",
+            db,
+            source_id=loser,
+            target_id=other,
+            link_type="is_a",
+            provenance="EXTRACTED",
+            confidence=0.9,
+            valid_at="2026-06-14",
         )
         await entities_crud.merge_entity(
-            db, loser_id=loser, survivor_id=survivor,
+            db,
+            loser_id=loser,
+            survivor_id=survivor,
         )
         mention = await db.execute_fetchall(
             "SELECT provenance, confidence FROM entity_mentions "
@@ -329,19 +444,31 @@ class TestCodexRemediationCrud:
         # Survivor: weaker ACTIVE link. Loser: stronger link already
         # CLOSED — the merge must not resurrect it as active.
         await entities_crud.upsert_link(
-            db, source_id=survivor, target_id=other, link_type="is_a",
-            provenance="INFERRED", confidence=0.3,
+            db,
+            source_id=survivor,
+            target_id=other,
+            link_type="is_a",
+            provenance="INFERRED",
+            confidence=0.3,
         )
         await entities_crud.upsert_link(
-            db, source_id=loser, target_id=other, link_type="is_a",
-            provenance="EXTRACTED", confidence=0.9,
+            db,
+            source_id=loser,
+            target_id=other,
+            link_type="is_a",
+            provenance="EXTRACTED",
+            confidence=0.9,
         )
         await entities_crud.invalidate_links_for_entity(
-            db, entity_id=loser, invalid_at="2026-07-01",
+            db,
+            entity_id=loser,
+            invalid_at="2026-07-01",
             invalidated_by="superseding-memory",
         )
         await entities_crud.merge_entity(
-            db, loser_id=loser, survivor_id=survivor,
+            db,
+            loser_id=loser,
+            survivor_id=survivor,
         )
         link = await db.execute_fetchall(
             "SELECT confidence, invalid_at, invalidated_by "
@@ -357,16 +484,26 @@ class TestCodexRemediationCrud:
         doomed = await _mk(db, "000000001", "commit")
         kept = await _mk(db, "OMI", "device")
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=doomed, provenance="EXTRACTED",
+            db,
+            memory_id="m1",
+            entity_id=doomed,
+            provenance="EXTRACTED",
             confidence=0.9,
         )
         await entities_crud.upsert_mention(
-            db, memory_id="m1", entity_id=kept, provenance="EXTRACTED",
+            db,
+            memory_id="m1",
+            entity_id=kept,
+            provenance="EXTRACTED",
             confidence=0.9,
         )
         await entities_crud.upsert_link(
-            db, source_id=doomed, target_id=kept, link_type="mentions",
-            provenance="EXTRACTED", confidence=0.8,
+            db,
+            source_id=doomed,
+            target_id=kept,
+            link_type="mentions",
+            provenance="EXTRACTED",
+            confidence=0.8,
         )
         counts = await entities_crud.delete_entities_cascade(db, [doomed])
         assert counts == {"entities": 1, "mentions": 1, "links": 1}
@@ -376,5 +513,7 @@ class TestCodexRemediationCrud:
         counts = await entities_crud.delete_entities_cascade(db, [doomed])
         assert counts == {"entities": 0, "mentions": 0, "links": 0}
         assert await entities_crud.delete_entities_cascade(db, []) == {
-            "entities": 0, "mentions": 0, "links": 0,
+            "entities": 0,
+            "mentions": 0,
+            "links": 0,
         }

--- a/tests/test_observability/test_deferred_work_segmentation.py
+++ b/tests/test_observability/test_deferred_work_segmentation.py
@@ -75,7 +75,7 @@ class TestQueueCounts:
         await _seed_worklist(db, 5, age_days=0.0)
 
         q = _queue(db)
-        assert await q.count_pending() == 8          # raw total, honest
+        assert await q.count_pending() == 8  # raw total, honest
         assert await q.count_worklist_pending() == 5  # batch subset
         assert await q.count_recovery_pending() == 3  # alarm-eligible subset
 
@@ -93,12 +93,12 @@ class TestQueueCounts:
 
     @pytest.mark.asyncio
     async def test_fresh_and_stale_worklist_mix(self, db):
-        await _seed_worklist(db, 3, age_days=1.0)                    # fresh, excluded
+        await _seed_worklist(db, 3, age_days=1.0)  # fresh, excluded
         await _seed_worklist(db, 2, age_days=STALE_WORKLIST_DAYS + 2)  # stale, folded
 
         q = _queue(db)
-        assert await q.count_worklist_pending() == 5   # all batch, display
-        assert await q.count_recovery_pending() == 2   # only the stale ones
+        assert await q.count_worklist_pending() == 5  # all batch, display
+        assert await q.count_recovery_pending() == 2  # only the stale ones
 
 
 class TestSnapshotSplit:
@@ -117,9 +117,9 @@ class TestSnapshotSplit:
         # (fresh age-0 worklist is excluded from recovery regardless of wall clock).
         result = await qmod.queues(db, _queue(db), None)
 
-        assert result["deferred_work"] == 8       # raw total
-        assert result["deferred_worklist"] == 6   # batch, display-only
-        assert result["deferred_recovery"] == 2   # alarm-eligible
+        assert result["deferred_work"] == 8  # raw total
+        assert result["deferred_worklist"] == 6  # batch, display-only
+        assert result["deferred_recovery"] == 2  # alarm-eligible
 
     @pytest.mark.asyncio
     async def test_queues_snapshot_no_queue_is_zero(self, db):
@@ -142,6 +142,13 @@ class TestDriftGuard:
         from genesis.memory.dream_cycle import WORKLIST_WORK_TYPE
 
         assert WORKLIST_WORK_TYPE in BATCH_WORK_TYPES
+
+    def test_batch_work_types_includes_entity_adjudication(self):
+        # The reconcile sweep parks deep-but-healthy backlogs; they must stay
+        # excluded from the deferred_recovery depth alarm.
+        from genesis.memory.entity_adjudication import WORK_TYPE
+
+        assert WORK_TYPE in BATCH_WORK_TYPES
 
 
 class TestAlarmSwap:

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -158,7 +158,9 @@ def test_load_full_yaml(monkeypatch):
     # 2026-07-15: 55 → 56 after wing_backfill added (one-shot legacy wing backfill).
     # 2026-07-16: 56 → 57 after repo_pulse added (session-manager PR-4a fuzzy
     # matcher neural-monitor registration).
-    assert len(cfg.call_sites) == 57
+    # 2026-07-17: 57 → 59 after entity_adjudication + entity_adjudication_challenge
+    # added (entity-node merge-vs-distinct drainer).
+    assert len(cfg.call_sites) == 59
     assert cfg.call_sites["repo_pulse"].dispatch == "cli"
     assert cfg.call_sites["repo_pulse"].chain == []
     assert cfg.call_sites["repo_pulse"].never_pays is True


### PR DESCRIPTION
## What

Activates the **entity_adjudication drainer** — the consumer for `work_type='entity_adjudication'` rows — and re-enables the producer (gated off in #1099). Builds on the PR-A substrate (#1112). Closes follow-up `9127e8ed`.

When `resolve_entity` creates an entity whose name is difflib-close (≥0.85) to an existing one, it queues the pair. This drains that queue: decide **merge** (same real-world thing) vs **distinct** (similar names, different things), conservatively — a wrong merge is worse than a wrong split.

## How it decides

1. **Digit-guard** — pairs differing only by digits (`pr #989` vs `pr #990`, ~76% of fuzzy hits, measured live) are mechanically ruled *distinct*, zero LLM cost.
2. **Two-model agreement** — the rest get a primary judgment (`entity_adjudication`) plus a flipped-provider adversarial challenge (`entity_adjudication_challenge`); **both must say merge**, else distinct. Cloned from the existing dream-cycle entity-dedup pattern.
3. Infra/parse errors **re-queue** (never burn a pair to a permanent verdict); genuine model dissent is recorded.

## Modes (settings lever `entity_adjudication`)

- **`propose_only` (default)** — records verdicts, **applies nothing**. Merges are effectively irreversible, so it ships in shadow: review the proposals, then flip.
- **`live`** — applies via `merge_entity` (survivor = better-attested node), re-resolving both sides immediately before the merge (extraction-race guard). Also applies the shadow-period `proposed_merge` backlog, guarded against identity drift (renamed/merged/gone → `stale`, re-discovered by the sweep).
- Plus `GENESIS_ENTITY_ADJUDICATION_DISABLED=1` kill switch; invalid config degrades to `propose_only`, never silent `live`.

## Reconcile sweep

The producer only catches *new* near-duplicates. A cursor-managed sweep (`ego_state`, off-thread difflib, low-water-gated, weekly re-run) rediscovers historical fuzzy pairs — recovers the 272 cleared in #1099 and self-heals any install.

## Also

- Producer dedup (both-orientation `NOT EXISTS`) + `call_site_id` so the dashboard shows the site, not "unknown".
- `entity_adjudication` added to `BATCH_WORK_TYPES` so sweep bursts don't page the `deferred_recovery` alarm.
- Hourly drain job + 45d deferred-work retention job on the learning scheduler.
- One aggregate, digest-visible observation per run (no per-pair flooding).

## Tests

30 drainer + config-lever + producer-dedup + CRUD + count/drift guards. Verified: propose_only = **zero mutation** (hard invariant), two-model agreement, live apply + phase-0 backlog + staleness matrix, survivor-by-evidence, retry-on-error, race guard, sweep dedup/cursor/low-water, stale-rediscovery, empty-state.

## Review

A code-reviewer pass over the combined diff returned DONE_WITH_CONCERNS with one NOTE (stale pairs were a dead end) — fixed in this PR (`settled_pair_keys` excludes stale so the sweep re-discovers them).

## Deploy

Runtime code + config default (works with zero overlay) — `git pull` + server restart. Empty-state safe. Ships `propose_only`; flip to live via `settings_update("entity_adjudication", {"mode": "live"})`.

Ledger: 9127e8ed9ac7420dbd3cb4f78f0bf9d1

🤖 Generated with [Claude Code](https://claude.com/claude-code)