### PR TITLE
feat(eval): WS2-0 retrieval-efficacy instrumentation

### DIFF
--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -17,6 +17,8 @@
 #      (WS-5 Discord observe-only gate log; bounds the shadow store)
 #   8. Retention prune of session_ledger_shadow_* (>45d) → scripts/prune_ledger_shadow.py
 #      (session-manager PR-3 ambient extractor shadow store; runs + events)
+#   9. Retention prune of ~/.genesis/output/retrieval_efficacy/*.md (>45d)
+#      (WS2-0 retrieval-efficacy report; dated md per run — file-age prune)
 #
 # Note: run under a hardened systemd sandbox (NoNewPrivileges, ProtectSystem=
 # strict), so disk_reclaim's --system (/var, sudo) path is intentionally NOT
@@ -96,6 +98,15 @@ main() {
     echo "--- repo pulse retention prune (>45d) ---"
     "$VENV_PY" "$REPO_DIR/scripts/prune_repo_pulse.py" --days 45 \
         || echo "prune_repo_pulse exited $?"
+
+    echo "--- retrieval-efficacy report retention prune (>45d) ---"
+    # WS2-0: retrieval_efficacy_report.py writes a dated md per run; bound the
+    # dir so a periodic report never slow-leaks disk on a smaller install.
+    if [ -d "$HOME/.genesis/output/retrieval_efficacy" ]; then
+        find "$HOME/.genesis/output/retrieval_efficacy" -maxdepth 1 -type f \
+            -name '*.md' -mtime +45 -delete 2>/dev/null \
+            || echo "retrieval_efficacy prune exited $?"
+    fi
 
     echo "=== genesis-disk-hygiene done ==="
 }

--- a/scripts/retrieval_efficacy_report.py
+++ b/scripts/retrieval_efficacy_report.py
@@ -83,6 +83,11 @@ def build_report(
                 "mrr": metrics.get("mrr"),
                 "total_recalls": metrics.get("total_recalls"),
                 "pool_episodic_total": pool,
+                # Retrievable pool (deprecated/expired excluded) — the denominator
+                # the drift hypothesis cares about. Only present from WS2-0 on;
+                # reconstructed weeks have no retrievable count (current-state
+                # flags can't be reconstructed historically) -> None.
+                "pool_episodic_retrievable": metrics.get("pool_episodic_retrievable"),
                 "pool_source": pool_source,
             }
         )
@@ -142,18 +147,19 @@ def render_md(report: dict, *, generated_at: str) -> str:
         "",
         "## Pool-growth vs quality trend",
         "",
-        "| Week ending | precision@5 | hit_rate | MRR | recalls | episodic pool | pool source |",
-        "|---|---|---|---|---|---|---|",
+        "| Week ending | precision@5 | hit_rate | MRR | recalls | "
+        "episodic pool | retrievable | pool source |",
+        "|---|---|---|---|---|---|---|---|",
     ]
     for row in report["trend"]:
         lines.append(
             f"| {_fmt(row['period_end'])} | {_fmt(row['precision_at_5'])} | "
             f"{_fmt(row['hit_rate'])} | {_fmt(row['mrr'])} | "
             f"{_fmt(row['total_recalls'])} | {_fmt(row['pool_episodic_total'])} | "
-            f"{row['pool_source']} |"
+            f"{_fmt(row.get('pool_episodic_retrievable'))} | {row['pool_source']} |"
         )
     if not report["trend"]:
-        lines.append("| _(no weekly memory snapshots yet)_ | | | | | | |")
+        lines.append("| _(no weekly memory snapshots yet)_ | | | | | | | |")
 
     lines += ["", "## Drift check", ""]
     drift = report["drift"]
@@ -206,19 +212,17 @@ async def _reconstruct_pool(db, period_ends: list[str]) -> dict[str, int]:
     """Episodic pool size as of each ``period_end`` from ``created_at``.
 
     APPROXIMATE — cannot see dedup/forgetting deletions, so biased high on older
-    weeks. Never written back; only used to fill pre-WS2-0 snapshots.
+    weeks. Never written back; only used to fill pre-WS2-0 snapshots. Delegates
+    the count to the CRUD layer (``episodic_count_created_before``).
     """
+    from genesis.db.crud import memory as memory_crud
+
     out: dict[str, int] = {}
     for pe in period_ends:
         if not pe:
             continue
         try:
-            rows = await db.execute_fetchall(
-                "SELECT COUNT(*) FROM memory_metadata "
-                "WHERE collection = 'episodic_memory' AND created_at <= ?",
-                (pe,),
-            )
-            out[pe] = int(rows[0][0]) if rows else 0
+            out[pe] = await memory_crud.episodic_count_created_before(db, pe)
         except Exception as exc:  # noqa: BLE001 - LOUD, never silently empty
             print(
                 f"retrieval_efficacy_report: pool reconstruct failed at {pe}: {exc}",

--- a/scripts/retrieval_efficacy_report.py
+++ b/scripts/retrieval_efficacy_report.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Retrieval-efficacy report — pool-growth-vs-quality trend + LongMemEval arms.
+
+The WS2 retrieval-drift work rests on a premise nobody had ever measured:
+retrieval quality degraded as the memory pool grew ("69%->38%"). This report is
+the first instrument that can substantiate or refute it. It joins the weekly
+J-9 memory-quality snapshots (precision@k / hit_rate / MRR) to the pool size
+they were measured over — using the ``pool_*`` keys stamped from WS2-0 onward,
+and a read-only historical reconstruction (from ``memory_metadata.created_at``)
+for pre-WS2-0 weeks. It also summarises the latest LongMemEval arm scores so a
+lever's paired arm is visible next to the live trend, and renders each lever's
+flip-gate checklist.
+
+Read-only (mode=ro URI). Output: markdown to
+``~/.genesis/output/retrieval_efficacy/`` (or ``--out``). Pure ``build_report``
+is unit-tested; ``_load`` is the only DB-touching seam.
+
+The historical pool reconstruction is an APPROXIMATION — it counts rows created
+on or before each period end and cannot see dedup/forgetting deletions, so it
+is biased high on older weeks. It is LABELLED as reconstructed in the output and
+NEVER written back to ``eval_snapshots``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+_DATASET = "longmemeval_oracle"
+
+# A lever does not flip live on this report alone — but the report renders the
+# gate so the numbers are read against the agreed bar (Jay pulls each flip).
+_GATE_CHECKLIST = (
+    (
+        "scope (PR-A)",
+        "shadow wing-agreement >=80% over >=200 derived-wing recalls AND "
+        "raw+scope arm evidence-coverage within noise of raw AND live fallback <30%",
+    ),
+    (
+        "budget (PR-B)",
+        "would-trim distribution sane (raise default rather than flip if >30% of "
+        "recalls trim at 10K) AND raw+budget arm accuracy >= -1pp vs its twin",
+    ),
+    (
+        "dedup (PR-C)",
+        ">=2wk shadow verdict distribution AND manual audit of sampled duplicate "
+        "verdicts >=95% precision AND raw+dedup arm >= -1pp with multi-session "
+        "evidence-coverage inspected",
+    ),
+)
+
+
+def build_report(
+    *,
+    snapshots: list[dict],
+    reconstructed_pool: dict[str, int],
+    lme_runs: list[dict],
+) -> dict:
+    """Assemble the report from already-loaded data (pure — no DB).
+
+    ``snapshots``: weekly memory snapshots, newest-first, each a dict with
+    ``period_end`` and a parsed ``metrics`` dict.
+    ``reconstructed_pool``: ``{period_end: episodic_count}`` fallback pool sizes.
+    ``lme_runs``: ``eval_runs`` rows (newest-first) for the LongMemEval dataset.
+    """
+    trend: list[dict] = []
+    for snap in reversed(snapshots):  # DESC -> chronological
+        metrics = snap.get("metrics", {}) or {}
+        period_end = snap.get("period_end")
+        pool = metrics.get("pool_episodic_total")
+        pool_source = "snapshot"
+        if pool is None:
+            pool = reconstructed_pool.get(period_end)
+            pool_source = "reconstructed" if pool is not None else "unknown"
+        trend.append(
+            {
+                "period_end": period_end,
+                "precision_at_5": metrics.get("precision_at_5"),
+                "hit_rate": metrics.get("hit_rate"),
+                "mrr": metrics.get("mrr"),
+                "total_recalls": metrics.get("total_recalls"),
+                "pool_episodic_total": pool,
+                "pool_source": pool_source,
+            }
+        )
+
+    # Drift check: earliest vs latest week that carries BOTH a quality number
+    # and a pool size. Informational — a real trend needs several weeks.
+    usable = [
+        t for t in trend if t["hit_rate"] is not None and t["pool_episodic_total"] is not None
+    ]
+    drift: dict | None = None
+    if len(usable) >= 2:
+        first, last = usable[0], usable[-1]
+        drift = {
+            "first_period": first["period_end"],
+            "last_period": last["period_end"],
+            "first_hit_rate": first["hit_rate"],
+            "last_hit_rate": last["hit_rate"],
+            "first_pool": first["pool_episodic_total"],
+            "last_pool": last["pool_episodic_total"],
+            "pool_grew": last["pool_episodic_total"] > first["pool_episodic_total"],
+            "quality_dropped": last["hit_rate"] < first["hit_rate"],
+            "weeks_compared": len(usable),
+        }
+
+    # LongMemEval: the latest run per arm (model_profile "longmemeval:<label>").
+    arms: dict[str, dict] = {}
+    for run in lme_runs:  # newest-first
+        profile = run.get("model_profile") or ""
+        if profile.startswith("longmemeval:") and profile not in arms:
+            arms[profile] = {
+                "arm": profile.split("longmemeval:", 1)[1],
+                "aggregate_score": run.get("aggregate_score"),
+                "created_at": run.get("created_at"),
+            }
+
+    return {
+        "trend": trend,
+        "drift": drift,
+        "longmemeval_arms": sorted(arms.values(), key=lambda a: a["arm"]),
+        "n_snapshots": len(snapshots),
+    }
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    return str(value)
+
+
+def render_md(report: dict, *, generated_at: str) -> str:
+    lines: list[str] = [
+        "# Retrieval-efficacy report",
+        "",
+        f"_Generated {generated_at} · {report['n_snapshots']} weekly memory snapshot(s)_",
+        "",
+        "## Pool-growth vs quality trend",
+        "",
+        "| Week ending | precision@5 | hit_rate | MRR | recalls | episodic pool | pool source |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for row in report["trend"]:
+        lines.append(
+            f"| {_fmt(row['period_end'])} | {_fmt(row['precision_at_5'])} | "
+            f"{_fmt(row['hit_rate'])} | {_fmt(row['mrr'])} | "
+            f"{_fmt(row['total_recalls'])} | {_fmt(row['pool_episodic_total'])} | "
+            f"{row['pool_source']} |"
+        )
+    if not report["trend"]:
+        lines.append("| _(no weekly memory snapshots yet)_ | | | | | | |")
+
+    lines += ["", "## Drift check", ""]
+    drift = report["drift"]
+    if drift is None:
+        lines.append(
+            "_Not enough usable weeks yet (need >=2 with both a quality number "
+            "and a pool size). The drift premise stays UNTESTED until then._"
+        )
+    else:
+        verdict = (
+            "consistent with pool-growth drift"
+            if drift["pool_grew"] and drift["quality_dropped"]
+            else "no pool-growth drift in this window"
+        )
+        lines += [
+            f"Comparing {drift['weeks_compared']} usable weeks "
+            f"({drift['first_period']} -> {drift['last_period']}):",
+            "",
+            f"- episodic pool: {drift['first_pool']} -> {drift['last_pool']} "
+            f"({'grew' if drift['pool_grew'] else 'did not grow'})",
+            f"- hit_rate: {_fmt(drift['first_hit_rate'])} -> "
+            f"{_fmt(drift['last_hit_rate'])} "
+            f"({'dropped' if drift['quality_dropped'] else 'held/improved'})",
+            f"- **Read: {verdict}.** Informational only — a few weeks is not a "
+            "trend, and reconstructed pool sizes are biased high on older weeks.",
+        ]
+
+    lines += ["", "## LongMemEval arms (latest run per arm)", ""]
+    if report["longmemeval_arms"]:
+        lines += ["| Arm | aggregate score | run |", "|---|---|---|"]
+        lines += [
+            f"| {a['arm']} | {_fmt(a['aggregate_score'])} | {_fmt(a['created_at'])} |"
+            for a in report["longmemeval_arms"]
+        ]
+    else:
+        lines.append("_(no LongMemEval runs recorded yet)_")
+
+    lines += ["", "## Lever flip-gate checklist", ""]
+    lines += [f"- **{name}**: {crit}" for name, crit in _GATE_CHECKLIST]
+    lines += [
+        "",
+        "_Each shadow->live flip is a per-lever decision made with this data in "
+        "hand — the gate is rendered here, not auto-applied._",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+async def _reconstruct_pool(db, period_ends: list[str]) -> dict[str, int]:
+    """Episodic pool size as of each ``period_end`` from ``created_at``.
+
+    APPROXIMATE — cannot see dedup/forgetting deletions, so biased high on older
+    weeks. Never written back; only used to fill pre-WS2-0 snapshots.
+    """
+    out: dict[str, int] = {}
+    for pe in period_ends:
+        if not pe:
+            continue
+        try:
+            rows = await db.execute_fetchall(
+                "SELECT COUNT(*) FROM memory_metadata "
+                "WHERE collection = 'episodic_memory' AND created_at <= ?",
+                (pe,),
+            )
+            out[pe] = int(rows[0][0]) if rows else 0
+        except Exception as exc:  # noqa: BLE001 - LOUD, never silently empty
+            print(
+                f"retrieval_efficacy_report: pool reconstruct failed at {pe}: {exc}",
+                file=sys.stderr,
+            )
+    return out
+
+
+async def _load(db_path: str) -> tuple[list[dict], dict[str, int], list[dict]]:
+    """Read memory snapshots, reconstructed pool, and LongMemEval runs (RO)."""
+    import aiosqlite
+
+    from genesis.db.crud import j9_eval
+    from genesis.eval import db as eval_db
+
+    async with aiosqlite.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5) as raw:
+        raw.row_factory = aiosqlite.Row
+
+        async def _safe(reader, label: str, **kwargs):
+            try:
+                return await reader(raw, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - LOUD; empty would mislead
+                print(f"retrieval_efficacy_report: {label} read failed: {exc}", file=sys.stderr)
+                return []
+
+        snapshots = await _safe(
+            j9_eval.get_snapshots,
+            "memory snapshots",
+            dimension="memory",
+            period_type="weekly",
+            limit=52,
+        )
+        lme_runs = await _safe(
+            eval_db.get_runs,
+            "longmemeval runs",
+            dataset=_DATASET,
+            limit=200,
+        )
+        period_ends = [s.get("period_end") for s in snapshots]
+        reconstructed = await _reconstruct_pool(raw, period_ends)
+        return snapshots, reconstructed, lme_runs
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", default=None, help="genesis.db path (default: repo data dir)")
+    ap.add_argument("--out", default=None, help="output md path (default: ~/.genesis/output/)")
+    args = ap.parse_args()
+
+    from genesis.env import genesis_db_path
+
+    db_path = args.db or str(genesis_db_path())
+    snapshots, reconstructed, lme_runs = asyncio.run(_load(db_path))
+    report = build_report(
+        snapshots=snapshots,
+        reconstructed_pool=reconstructed,
+        lme_runs=lme_runs,
+    )
+    now = datetime.now(UTC)
+    md = render_md(report, generated_at=now.isoformat())
+    out = Path(
+        args.out
+        or Path.home()
+        / ".genesis"
+        / "output"
+        / "retrieval_efficacy"
+        / f"retrieval_efficacy_{now.date()}.md"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(md)
+    drift = report["drift"]
+    drift_note = (
+        "untested (need >=2 usable weeks)"
+        if drift is None
+        else (
+            "drift-consistent"
+            if drift["pool_grew"] and drift["quality_dropped"]
+            else "no-drift-in-window"
+        )
+    )
+    print(
+        f"snapshots={report['n_snapshots']} arms={len(report['longmemeval_arms'])} "
+        f"drift={drift_note}"
+    )
+    print(f"report: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -677,3 +677,45 @@ async def count(
         rows = await db.execute_fetchall("SELECT COUNT(*) FROM memory_metadata")
     row = rows[0] if rows else None
     return row[0] if row else 0
+
+
+# Pool-size keys stamped onto the weekly J-9 memory snapshot. Exported so the
+# aggregator's failure-fallback and the efficacy report can reference the exact
+# key set without drifting from this function's output.
+POOL_COUNT_KEYS: tuple[str, ...] = (
+    "pool_episodic_total",
+    "pool_episodic_embedded",
+    "pool_knowledge_units_total",
+    "pool_memory_links_total",
+)
+
+
+async def pool_size_counts(db: aiosqlite.Connection) -> dict[str, int]:
+    """Return point-in-time pool-size counts for retrieval-efficacy trending.
+
+    Snapshotted alongside the J-9 weekly memory-quality metrics so retrieval
+    quality (precision@k, hit_rate, MRR) can be read against the size of the
+    pool it was measured over — the pool-growth-vs-quality trend the WS2
+    retrieval-drift work needs and that nothing measured before.
+
+    SQLite-side counts only (the weekly aggregator holds no Qdrant client), so
+    these may differ slightly from Qdrant ``points_count`` on rows still
+    pending embed. ``memory_metadata`` mixes the ``episodic_memory`` and
+    ``knowledge_base`` collections, so episodic is counted by collection, not
+    as the whole table. Keys match ``POOL_COUNT_KEYS``.
+    """
+    ep_total = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM memory_metadata WHERE collection = 'episodic_memory'"
+    )
+    ep_embedded = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM memory_metadata "
+        "WHERE collection = 'episodic_memory' AND embedding_status = 'embedded'"
+    )
+    ku = await db.execute_fetchall("SELECT COUNT(*) FROM knowledge_units")
+    links = await db.execute_fetchall("SELECT COUNT(*) FROM memory_links")
+    return {
+        "pool_episodic_total": int(ep_total[0][0]) if ep_total else 0,
+        "pool_episodic_embedded": int(ep_embedded[0][0]) if ep_embedded else 0,
+        "pool_knowledge_units_total": int(ku[0][0]) if ku else 0,
+        "pool_memory_links_total": int(links[0][0]) if links else 0,
+    }

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -684,6 +684,7 @@ async def count(
 # key set without drifting from this function's output.
 POOL_COUNT_KEYS: tuple[str, ...] = (
     "pool_episodic_total",
+    "pool_episodic_retrievable",
     "pool_episodic_embedded",
     "pool_knowledge_units_total",
     "pool_memory_links_total",
@@ -698,14 +699,31 @@ async def pool_size_counts(db: aiosqlite.Connection) -> dict[str, int]:
     pool it was measured over — the pool-growth-vs-quality trend the WS2
     retrieval-drift work needs and that nothing measured before.
 
+    ``pool_episodic_retrievable`` applies the SAME two filters the recall path
+    applies (``recall`` :195-203): NOT deprecated by the dream cycle AND still
+    bitemporally valid (``invalid_at`` NULL or in the future). That is the
+    denominator the drift hypothesis actually cares about — a deprecated/expired
+    row is not a candidate any recall dilutes. ``pool_episodic_total`` keeps the
+    raw count for reference (total minus retrievable = accumulated dead weight).
+
     SQLite-side counts only (the weekly aggregator holds no Qdrant client), so
-    these may differ slightly from Qdrant ``points_count`` on rows still
-    pending embed. ``memory_metadata`` mixes the ``episodic_memory`` and
-    ``knowledge_base`` collections, so episodic is counted by collection, not
-    as the whole table. Keys match ``POOL_COUNT_KEYS``.
+    these may differ slightly from Qdrant ``points_count`` on rows still pending
+    embed. ``memory_metadata`` mixes the ``episodic_memory`` and
+    ``knowledge_base`` collections, so episodic is counted by collection, not as
+    the whole table. Keys match ``POOL_COUNT_KEYS``.
     """
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
     ep_total = await db.execute_fetchall(
         "SELECT COUNT(*) FROM memory_metadata WHERE collection = 'episodic_memory'"
+    )
+    ep_retrievable = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM memory_metadata "
+        "WHERE collection = 'episodic_memory' "
+        "AND (deprecated IS NULL OR deprecated = 0) "
+        "AND (invalid_at IS NULL OR invalid_at > ?)",
+        (now,),
     )
     ep_embedded = await db.execute_fetchall(
         "SELECT COUNT(*) FROM memory_metadata "
@@ -715,7 +733,26 @@ async def pool_size_counts(db: aiosqlite.Connection) -> dict[str, int]:
     links = await db.execute_fetchall("SELECT COUNT(*) FROM memory_links")
     return {
         "pool_episodic_total": int(ep_total[0][0]) if ep_total else 0,
+        "pool_episodic_retrievable": int(ep_retrievable[0][0]) if ep_retrievable else 0,
         "pool_episodic_embedded": int(ep_embedded[0][0]) if ep_embedded else 0,
         "pool_knowledge_units_total": int(ku[0][0]) if ku else 0,
         "pool_memory_links_total": int(links[0][0]) if links else 0,
     }
+
+
+async def episodic_count_created_before(db: aiosqlite.Connection, ts: str) -> int:
+    """Count episodic rows created on or before ``ts`` (ISO-8601).
+
+    Used ONLY by the retrieval-efficacy report to reconstruct a pool size for
+    pre-WS2-0 weeks that carry no ``pool_*`` snapshot. Deliberately a total-
+    created count, not retrievable-as-of: ``deprecated``/``invalid_at`` are
+    current-state flags, so "retrievable in the past" cannot be reconstructed —
+    a row deprecated today was retrievable then. The report labels this an
+    approximation (biased high on older weeks) and never writes it back.
+    """
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM memory_metadata "
+        "WHERE collection = 'episodic_memory' AND created_at <= ?",
+        (ts,),
+    )
+    return int(rows[0][0]) if rows else 0

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -24,19 +24,25 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     # -- eval run --
     run_cmd = eval_sub.add_parser("run", help="Run eval against a provider")
     run_cmd.add_argument(
-        "--model", "-m", required=True,
+        "--model",
+        "-m",
+        required=True,
         help="Provider name from model_routing.yaml (e.g. cerebras-qwen)",
     )
     run_cmd.add_argument(
-        "--dataset", "-d", required=True,
+        "--dataset",
+        "-d",
+        required=True,
         help="Dataset name (without .yaml), or 'all' for all datasets",
     )
     run_cmd.add_argument(
-        "--system-prompt", "-s",
+        "--system-prompt",
+        "-s",
         help="Optional system prompt override",
     )
     run_cmd.add_argument(
-        "--no-db", action="store_true",
+        "--no-db",
+        action="store_true",
         help="Skip storing results in the database",
     )
 
@@ -44,33 +50,41 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     bench_cmd = eval_sub.add_parser(
         "benchmark",
         help="Run all enabled providers across all datasets (comparison table; "
-             "for the Genesis-vs-bare A/B see `bench`)",
+        "for the Genesis-vs-bare A/B see `bench`)",
     )
     bench_cmd.add_argument(
-        "--include-paid", action="store_true",
+        "--include-paid",
+        action="store_true",
         help="Include paid (non-free) providers",
     )
     bench_cmd.add_argument(
-        "--model", "-m",
+        "--model",
+        "-m",
         help="Run only this provider (single-provider mode)",
     )
     bench_cmd.add_argument(
-        "--no-db", action="store_true",
+        "--no-db",
+        action="store_true",
         help="Skip storing results in the database",
     )
 
     # -- eval results --
     results_cmd = eval_sub.add_parser("results", help="Show recent eval results")
     results_cmd.add_argument(
-        "--model", "-m",
+        "--model",
+        "-m",
         help="Filter by provider name",
     )
     results_cmd.add_argument(
-        "--dataset", "-d",
+        "--dataset",
+        "-d",
         help="Filter by dataset name",
     )
     results_cmd.add_argument(
-        "--last", "-n", type=int, default=5,
+        "--last",
+        "-n",
+        type=int,
+        default=5,
         help="Number of recent runs to show (default: 5)",
     )
 
@@ -80,7 +94,10 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Show comparison table from stored results (no re-running)",
     )
     compare_cmd.add_argument(
-        "--last", "-n", type=int, default=1,
+        "--last",
+        "-n",
+        type=int,
+        default=1,
         help="Most recent N runs per provider/dataset (default: 1)",
     )
 
@@ -90,7 +107,8 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Export benchmark results as markdown",
     )
     export_cmd.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         help="Write to file instead of stdout",
     )
 
@@ -107,15 +125,19 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     gauntlet_cmd.add_argument(
-        "--model", "-m", required=True,
+        "--model",
+        "-m",
+        required=True,
         help="Roster model name (e.g. claude, glm-5.2)",
     )
     gauntlet_cmd.add_argument(
-        "--no-db", action="store_true",
+        "--no-db",
+        action="store_true",
         help="Skip storing results in the database",
     )
     gauntlet_cmd.add_argument(
-        "--check-regression", action="store_true",
+        "--check-regression",
+        action="store_true",
         help="Also run the advisory PASS->FAIL regression check (files a proposal)",
     )
 
@@ -132,44 +154,59 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     ab_cmd.add_argument(
-        "--tasks", default=None,
+        "--tasks",
+        default=None,
         help="Task JSONL path (default: ~/.genesis/eval/bench_tasks_v1.jsonl; "
-             "must live OUTSIDE the repo)",
+        "must live OUTSIDE the repo)",
     )
     ab_cmd.add_argument(
-        "--model", "-m", default="sonnet",
+        "--model",
+        "-m",
+        default="sonnet",
         help="CC model for BOTH arms (default: sonnet)",
     )
     ab_cmd.add_argument(
-        "--effort", default="medium",
+        "--effort",
+        default="medium",
         help="CC effort for BOTH arms (default: medium)",
     )
     ab_cmd.add_argument(
-        "--limit", type=int, default=None, help="Run only the first N tasks",
+        "--limit",
+        type=int,
+        default=None,
+        help="Run only the first N tasks",
     )
     ab_cmd.add_argument(
-        "--task-id", default=None, help="Run a single task by id (shakedowns)",
+        "--task-id",
+        default=None,
+        help="Run a single task by id (shakedowns)",
     )
     ab_cmd.add_argument(
-        "--epsilon", type=float, default=0.05,
+        "--epsilon",
+        type=float,
+        default=0.05,
         help="Score-difference tie band for the win-rate (default: 0.05)",
     )
     ab_cmd.add_argument(
-        "--no-db", action="store_true",
+        "--no-db",
+        action="store_true",
         help="Skip persisting paired eval_runs rows",
     )
     ab_cmd.add_argument(
-        "--keep-workdir", action="store_true",
+        "--keep-workdir",
+        action="store_true",
         help="Keep ~/tmp/bench/<run_id> (snapshot, arm workdirs, transcripts)",
     )
     ab_cmd.add_argument(
-        "--no-verify-prod", action="store_true",
+        "--no-verify-prod",
+        action="store_true",
         help="Skip the prod-delta isolation probe (NOT recommended)",
     )
     ab_cmd.add_argument(
-        "--judge-provider", default=None,
+        "--judge-provider",
+        default=None,
         help="Start the judge chain at this routing provider (e.g. "
-             "openrouter-deepseek-v4 when the free NIM tier is down)",
+        "openrouter-deepseek-v4 when the free NIM tier is down)",
     )
 
     # -- eval longmemeval (external memory benchmark, WS-1 A4) --
@@ -184,43 +221,62 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     lme_cmd.add_argument(
-        "--dataset-path", default=None,
+        "--dataset-path",
+        default=None,
         help="oracle JSON (default: ~/tmp/longmemeval/longmemeval_oracle.json)",
     )
     lme_cmd.add_argument("--limit", type=int, default=None, help="first N questions")
     lme_cmd.add_argument("--k", type=int, default=10, help="recall top-K")
     lme_cmd.add_argument("--concurrency", type=int, default=4)
     lme_cmd.add_argument(
-        "--no-rerank", action="store_true", help="skip the Voyage rerank arms",
+        "--no-rerank",
+        action="store_true",
+        help="skip the Voyage rerank arms",
     )
     lme_cmd.add_argument(
-        "--no-persist", action="store_true", help="do not write eval_runs",
+        "--no-persist",
+        action="store_true",
+        help="do not write eval_runs",
     )
     lme_cmd.add_argument(
-        "--db-path", default=None,
+        "--db-path",
+        default=None,
         help="results DB (default: production genesis.db; a fresh path is migrated)",
     )
     lme_cmd.add_argument(
-        "--types", default=None,
+        "--types",
+        default=None,
         help="comma-separated question types to run (filtered before --limit)",
     )
     lme_cmd.add_argument(
-        "--dump-dir", default=None,
+        "--dump-dir",
+        default=None,
         help="write per-question diagnostics (one <arm>.jsonl per arm) here",
     )
     lme_cmd.add_argument(
-        "--graph", action="store_true",
+        "--graph",
+        action="store_true",
         help="ADD a +graph variant of every selected arm (linked store + expansion)",
     )
     lme_cmd.add_argument(
-        "--graph-link-threshold", type=float, default=None,
+        "--graph-link-threshold",
+        type=float,
+        default=None,
         help="cosine threshold for auto-linking on the graph arm's store "
         "(default: the prod linker default, 0.75)",
     )
     lme_cmd.add_argument(
-        "--arms", default=None,
+        "--arms",
+        default=None,
         help="comma-separated arm labels to run (filters the selected "
         "universe, e.g. --graph --arms raw,raw+graph); unknown labels error",
+    )
+    lme_cmd.add_argument(
+        "--variants",
+        default="",
+        help="comma-separated retrieval-config variants to pair against baseline "
+        "(each doubles every base arm with a +<variant> twin; a WS2 lever PR "
+        "registers each variant). Unknown variants error before any spend.",
     )
 
     eval_cmd.set_defaults(func=_run_eval_cli)
@@ -232,6 +288,7 @@ def _load_secrets() -> None:
         from dotenv import load_dotenv
 
         from genesis.env import secrets_path
+
         path = secrets_path()
         if path.is_file():
             load_dotenv(str(path), override=True)
@@ -291,6 +348,7 @@ async def _cmd_longmemeval(args: argparse.Namespace) -> int:
         graph=args.graph,
         graph_link_threshold=args.graph_link_threshold,
         arms_only=args.arms,
+        variants=tuple(v.strip() for v in args.variants.split(",") if v.strip()),
     )
     print_report(summaries)
     return 0
@@ -305,21 +363,19 @@ async def _cmd_run(args: argparse.Namespace) -> int:
             import aiosqlite  # noqa: I001
 
             from genesis.env import genesis_db_path
+
             db = await aiosqlite.connect(str(genesis_db_path()))
             await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         except Exception as e:
             print(f"warning: could not open DB ({e}), results won't be stored")
 
     try:
-        datasets = (
-            list_datasets() if args.dataset == "all"
-            else [args.dataset]
-        )
+        datasets = list_datasets() if args.dataset == "all" else [args.dataset]
 
         for ds_name in datasets:
-            print(f"\n{'='*60}")
+            print(f"\n{'=' * 60}")
             print(f"  Eval: {args.model} on {ds_name}")
-            print(f"{'='*60}\n")
+            print(f"{'=' * 60}\n")
 
             summary = await run_eval(
                 provider_name=args.model,
@@ -347,6 +403,7 @@ async def _cmd_gauntlet(args: argparse.Namespace) -> int:
             import aiosqlite  # noqa: I001
 
             from genesis.env import genesis_db_path
+
             db = await aiosqlite.connect(str(genesis_db_path()))
             await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         except Exception as e:
@@ -354,9 +411,9 @@ async def _cmd_gauntlet(args: argparse.Namespace) -> int:
 
     summary = None
     try:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"  Gauntlet: {args.model}")
-        print(f"{'='*60}\n")
+        print(f"{'=' * 60}\n")
         summary = await run_gauntlet(args.model, db=db, trigger=EvalTrigger.MANUAL)
         _print_summary(summary)
         for r in summary.results:
@@ -399,6 +456,7 @@ async def _cmd_bench(args: argparse.Namespace) -> int:
             import aiosqlite  # noqa: I001
 
             from genesis.env import genesis_db_path
+
             db = await aiosqlite.connect(str(genesis_db_path()))
             await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         except Exception as e:
@@ -453,7 +511,8 @@ async def _cmd_benchmark(args: argparse.Namespace) -> int:
         providers = [args.model]
     else:
         providers = [
-            name for name, cfg in sorted(config.providers.items())
+            name
+            for name, cfg in sorted(config.providers.items())
             if getattr(cfg, "enabled", True)  # skip explicitly disabled
             and getattr(cfg, "has_api_key", True)  # skip keyless — eval would 401
             and (args.include_paid or cfg.is_free)
@@ -468,6 +527,7 @@ async def _cmd_benchmark(args: argparse.Namespace) -> int:
         try:
             import aiosqlite  # noqa: I001
             from genesis.env import genesis_db_path
+
             db = await aiosqlite.connect(str(genesis_db_path()))
             await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
         except Exception as e:
@@ -500,11 +560,15 @@ async def _cmd_benchmark(args: argparse.Namespace) -> int:
                     )
                     attempted = summary.passed_cases + summary.failed_cases
                     results[provider_name][ds_name] = (
-                        summary.passed_cases, attempted, summary.skipped_cases,
+                        summary.passed_cases,
+                        attempted,
+                        summary.skipped_cases,
                     )
                     pct = (summary.passed_cases / attempted * 100) if attempted > 0 else 0
-                    print(f" {summary.passed_cases}/{attempted} ({pct:.0f}%) "
-                          f"[{summary.skipped_cases} skipped]  {summary.duration_s:.0f}s")
+                    print(
+                        f" {summary.passed_cases}/{attempted} ({pct:.0f}%) "
+                        f"[{summary.skipped_cases} skipped]  {summary.duration_s:.0f}s"
+                    )
                 except Exception as exc:
                     print(f" ERROR: {exc}")
                     results[provider_name][ds_name] = (0, 0, 0)
@@ -529,7 +593,10 @@ async def _cmd_results(args: argparse.Namespace) -> int:
         async with aiosqlite.connect(str(genesis_db_path())) as db:
             await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
             runs = await get_runs(
-                db, model_id=args.model, dataset=args.dataset, limit=args.last,
+                db,
+                model_id=args.model,
+                dataset=args.dataset,
+                limit=args.last,
             )
     except Exception as e:
         print(f"error: {e}", file=sys.stderr)
@@ -613,7 +680,11 @@ async def _cmd_export(args: argparse.Namespace) -> int:
         from genesis.eval.db import get_runs
         from genesis.routing.config import load_config
 
-        config_path = __import__("pathlib").Path(__file__).resolve().parents[3] / "config" / "model_routing.yaml"
+        config_path = (
+            __import__("pathlib").Path(__file__).resolve().parents[3]
+            / "config"
+            / "model_routing.yaml"
+        )
         config = load_config(config_path)
 
         datasets = list_datasets()
@@ -677,12 +748,8 @@ def _generate_export_markdown(
     lines.append(
         "Benchmark methodology: 3 datasets (classification, extraction, structured_output)"
     )
-    lines.append(
-        "with 37 total cases. Scores are `passed/attempted` — skipped cases (rate limits,"
-    )
-    lines.append(
-        "API errors) excluded from the denominator. All runs use the eval harness in"
-    )
+    lines.append("with 37 total cases. Scores are `passed/attempted` — skipped cases (rate limits,")
+    lines.append("API errors) excluded from the denominator. All runs use the eval harness in")
     lines.append("`src/genesis/eval/` with binary pass/fail scorers (no LLM-as-judge).\n")
     lines.append("## Current Results\n")
     lines.append("Best run per provider. Providers marked (free) cost $0; others are paid.\n")

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -36,9 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 async def _compute_cognitive_drift(
-    db: aiosqlite.Connection,
-    period_start: str,
-    period_end: str,
+    db: aiosqlite.Connection, period_start: str, period_end: str,
 ) -> tuple[dict, int]:
     """Dark drift metrics over ego_proposals (Phase 7 anti-overfitting baseline).
 
@@ -57,17 +55,13 @@ async def _compute_cognitive_drift(
     from collections import Counter
 
     rows = await ego_crud.get_proposals_for_drift(
-        db,
-        start=period_start,
-        end=period_end,
+        db, start=period_start, end=period_end,
     )
     total = len(rows)
     if total == 0:
         return {
-            "dissent_rate": None,
-            "alternative_rate": None,
-            "diversity_entropy": None,
-            "n_proposals": 0,
+            "dissent_rate": None, "alternative_rate": None,
+            "diversity_entropy": None, "n_proposals": 0,
         }, 0
 
     verdicts = [r["realist_verdict"] for r in rows if r["realist_verdict"]]
@@ -175,9 +169,7 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
             subsystem_results[sub_name] = grade_info
             logger.info(
                 "J9 subsystem %s: grade=%s score=%s (%d samples)",
-                sub_name,
-                grade_info["grade"],
-                grade_info["score"],
+                sub_name, grade_info["grade"], grade_info["score"],
                 grade_info["sample_count"],
             )
         except Exception:
@@ -215,9 +207,7 @@ def _dedupe_by_pair(events: list[dict]) -> list[dict]:
 
 
 async def _recall_entrenchment(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> dict:
     """MEM-005: weekly aggregation of the activation-entrenchment signal.
 
@@ -229,46 +219,30 @@ async def _recall_entrenchment(
     feeds the quality grade.
     """
     fired = await j9_eval.get_events(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
-        since=since,
-        until=until,
-        limit=5000,
+        db, dimension="memory", event_type="recall_fired",
+        since=since, until=until, limit=5000,
     )
-    corrs = [
-        m["entrenchment_corr"]
-        for ev in fired
-        if (m := ev.get("metrics", {})).get("entrenchment_corr") is not None
-    ]
-    ret_counts = [
-        ev.get("metrics", {})["mean_retrieved_count"]
-        for ev in fired
-        if ev.get("metrics", {}).get("mean_retrieved_count") is not None
-    ]
-    ages = [
-        ev.get("metrics", {})["mean_age_days"]
-        for ev in fired
-        if ev.get("metrics", {}).get("mean_age_days") is not None
-    ]
+    corrs = [m["entrenchment_corr"] for ev in fired
+             if (m := ev.get("metrics", {})).get("entrenchment_corr") is not None]
+    ret_counts = [ev.get("metrics", {})["mean_retrieved_count"] for ev in fired
+                  if ev.get("metrics", {}).get("mean_retrieved_count") is not None]
+    ages = [ev.get("metrics", {})["mean_age_days"] for ev in fired
+            if ev.get("metrics", {}).get("mean_age_days") is not None]
     return {
         "entrenchment_corr_mean": round(sum(corrs) / len(corrs), 4) if corrs else None,
         "entrenchment_mean_retrieved_count": (
-            round(sum(ret_counts) / len(ret_counts), 2) if ret_counts else None
-        ),
-        "entrenchment_mean_age_days": (round(sum(ages) / len(ages), 1) if ages else None),
+            round(sum(ret_counts) / len(ret_counts), 2) if ret_counts else None),
+        "entrenchment_mean_age_days": (
+            round(sum(ages) / len(ages), 1) if ages else None),
         "entrenchment_sample": len(corrs),
     }
 
 
 async def _pool_counts_safe(db: aiosqlite.Connection) -> dict:
-    """Point-in-time pool-size counts, isolated in its own try/except.
-
-    A count failure must degrade to None-valued ``pool_*`` keys (series shape
-    preserved) rather than sink the whole memory-quality snapshot — quality
-    metrics and pool size share the row, but the pool read is strictly additive
-    to the quality metrics.
-    """
+    """Point-in-time pool-size counts, isolated in its own try/except so a
+    count failure degrades to None-valued ``pool_*`` keys (series shape kept)
+    rather than sinking the whole memory-quality snapshot — the pool read is
+    strictly additive to the quality metrics."""
     try:
         return await memory_crud.pool_size_counts(db)
     except Exception:
@@ -277,45 +251,30 @@ async def _pool_counts_safe(db: aiosqlite.Connection) -> dict:
 
 
 async def _compute_memory_quality(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Precision@5, hit rate, MRR from recall_relevance events.
 
     Also folds in the MEM-005 entrenchment aggregation (separate read path over
-    recall_fired) as distinct ``entrenchment_*`` keys — monitor-only, not part
-    of the quality grade — and the point-in-time ``pool_*`` counts (WS2-0), so
-    retrieval quality is always readable against the pool size it was measured
-    over.
+    recall_fired) as distinct ``entrenchment_*`` keys — monitor-only — and the
+    point-in-time ``pool_*`` counts (WS2-0), so retrieval quality is always
+    readable against the pool size it was measured over.
     """
     entrenchment = await _recall_entrenchment(db, since, until)
     pool = await _pool_counts_safe(db)
     relevance_events = await j9_eval.get_events(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
-        since=since,
-        until=until,
-        limit=5000,
+        db, dimension="memory", event_type="recall_relevance",
+        since=since, until=until, limit=5000,
     )
     # Defensive dedup: duplicate (recall, memory) judgments must not skew the
     # average (pre-checkpoint batches could emit the same pair multiple times).
     relevance_events = _dedupe_by_pair(relevance_events)
 
     if not relevance_events:
-        return {
-            "precision_at_5": None,
-            "precision_at_3": None,
-            "precision_at_3_recalls": 0,
-            "judge_prompt_versions": [],
-            "hit_rate": None,
-            "mrr": None,
-            "usage_rate": None,
-            "total_recalls": 0,
-            **entrenchment,
-            **pool,
-        }, 0
+        return {"precision_at_5": None, "precision_at_3": None,
+                "precision_at_3_recalls": 0, "judge_prompt_versions": [],
+                "hit_rate": None, "mrr": None,
+                "usage_rate": None, "total_recalls": 0, **entrenchment, **pool}, 0
 
     # Group by recall_event_id
     by_recall: dict[str, list[dict]] = defaultdict(list)
@@ -369,12 +328,8 @@ async def _compute_memory_quality(
 
     # Also check recall_used events for usage rate
     used_events = await j9_eval.get_events(
-        db,
-        dimension="memory",
-        event_type="recall_used",
-        since=since,
-        until=until,
-        limit=5000,
+        db, dimension="memory", event_type="recall_used",
+        since=since, until=until, limit=5000,
     )
     used_events = _dedupe_by_pair(used_events)
     total_used = sum(1 for ev in used_events if ev.get("metrics", {}).get("used"))
@@ -383,18 +338,15 @@ async def _compute_memory_quality(
     # Judge-prompt versions seen in-window: a change here is a series break
     # (precision@k is judge-rated; a reworded judge prompt shifts the series
     # without any retrieval change). Pre-versioning events → "unversioned".
-    judge_prompt_versions = sorted(
-        {
-            (ev.get("metrics", {}) or {}).get("judge_prompt_version") or "unversioned"
-            for ev in relevance_events
-        }
-    )
+    judge_prompt_versions = sorted({
+        (ev.get("metrics", {}) or {}).get("judge_prompt_version") or "unversioned"
+        for ev in relevance_events
+    })
 
     metrics = {
         "precision_at_5": round(sum(precisions) / len(precisions), 4) if precisions else None,
         "precision_at_3": round(sum(precisions_at_3) / len(precisions_at_3), 4)
-        if precisions_at_3
-        else None,
+        if precisions_at_3 else None,
         # Coverage: recalls that qualified for the @3 metric (fully ranked)
         # vs total_recalls — thin coverage must be visible, not hidden.
         "precision_at_3_recalls": len(precisions_at_3),
@@ -418,9 +370,7 @@ async def _compute_memory_quality(
 
 
 async def _compute_system_composite(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Aggregate signals from cc_sessions, ego_proposals, observations, procedures."""
     # Session success rate
@@ -473,17 +423,9 @@ async def _compute_system_composite(
     mem_precision = mem_snapshot["metrics"].get("precision_at_5") if mem_snapshot else None
 
     # Composite: simple average of available signals (weighted equally)
-    signals = [
-        v
-        for v in [
-            session_success_pct,
-            ego_acceptance_pct,
-            obs_influence_pct,
-            proc_mean_conf,
-            mem_precision,
-        ]
-        if v is not None
-    ]
+    signals = [v for v in [session_success_pct, ego_acceptance_pct,
+                            obs_influence_pct, proc_mean_conf, mem_precision]
+               if v is not None]
     composite = round(sum(signals) / len(signals), 4) if signals else None
 
     sample_count = session_total + ego_total + obs_total
@@ -506,25 +448,17 @@ async def _compute_system_composite(
 
 
 async def _compute_ego_quality(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Approval rate, execution success, confidence calibration."""
     proposals = await ego_crud.get_proposals_for_quality(
-        db,
-        start=since,
-        end=until,
+        db, start=since, end=until,
     )
     total = len(proposals)
 
     if not total:
-        return {
-            "approval_rate": None,
-            "execution_success_rate": None,
-            "confidence_calibration": {},
-            "total_proposals": 0,
-        }, 0
+        return {"approval_rate": None, "execution_success_rate": None,
+                "confidence_calibration": {}, "total_proposals": 0}, 0
 
     # Approval rate (resolved proposals only)
     resolved = [p for p in proposals if p["status"] not in ("pending", "expired")]
@@ -542,13 +476,12 @@ async def _compute_ego_quality(
     for bucket_low in [0.0, 0.2, 0.4, 0.6, 0.8]:
         bucket_high = bucket_low + 0.2
         label = f"{bucket_low:.1f}-{bucket_high:.1f}"
-        in_bucket = [
-            p
-            for p in resolved
-            if p.get("confidence") is not None and bucket_low <= p["confidence"] < bucket_high
-        ]
+        in_bucket = [p for p in resolved
+                     if p.get("confidence") is not None
+                     and bucket_low <= p["confidence"] < bucket_high]
         if in_bucket:
-            bucket_approved = [p for p in in_bucket if p["status"] in ("approved", "executed")]
+            bucket_approved = [p for p in in_bucket
+                               if p["status"] in ("approved", "executed")]
             calibration[label] = {
                 "count": len(in_bucket),
                 "success_rate": round(len(bucket_approved) / len(in_bucket), 4),
@@ -568,9 +501,7 @@ async def _compute_ego_quality(
 
 
 async def _compute_cognitive_loop(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Compare sessions with proactive recall vs without."""
     # Get all sessions in the window
@@ -583,24 +514,17 @@ async def _compute_cognitive_loop(
     sessions = [dict(r) for r in await cursor.fetchall()]
 
     if not sessions:
-        return {
-            "sessions_with_recall": 0,
-            "sessions_without_recall": 0,
-            "success_rate_with": None,
-            "success_rate_without": None,
-            "delta": None,
-        }, 0
+        return {"sessions_with_recall": 0, "sessions_without_recall": 0,
+                "success_rate_with": None, "success_rate_without": None,
+                "delta": None}, 0
 
     # Find which sessions had recall_fired events
     recall_events = await j9_eval.get_events(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
-        since=since,
-        until=until,
-        limit=5000,
+        db, dimension="memory", event_type="recall_fired",
+        since=since, until=until, limit=5000,
     )
-    sessions_with_recall = {ev.get("session_id") for ev in recall_events if ev.get("session_id")}
+    sessions_with_recall = {ev.get("session_id") for ev in recall_events
+                            if ev.get("session_id")}
 
     with_recall = [s for s in sessions if s["id"] in sessions_with_recall]
     without_recall = [s for s in sessions if s["id"] not in sessions_with_recall]
@@ -632,30 +556,20 @@ async def _compute_cognitive_loop(
 
 
 async def _compute_procedural_effectiveness(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Invocation frequency, success rate, confidence calibration."""
     # Invocation events
     invocations = await j9_eval.get_events(
-        db,
-        dimension="procedure",
-        event_type="procedure_invoked",
-        since=since,
-        until=until,
-        limit=1000,
+        db, dimension="procedure", event_type="procedure_invoked",
+        since=since, until=until, limit=1000,
     )
     invocation_count = len(invocations)
 
     # Outcome events
     outcomes = await j9_eval.get_events(
-        db,
-        dimension="procedure",
-        event_type="procedure_outcome",
-        since=since,
-        until=until,
-        limit=1000,
+        db, dimension="procedure", event_type="procedure_outcome",
+        since=since, until=until, limit=1000,
     )
     successes = sum(1 for o in outcomes if o.get("metrics", {}).get("success"))
     outcome_total = len(outcomes)
@@ -696,8 +610,7 @@ async def _compute_procedural_effectiveness(
                 calibration[bucket]["success"] += 1
     for bucket in calibration:
         calibration[bucket]["rate"] = round(
-            calibration[bucket]["success"] / calibration[bucket]["total"],
-            4,
+            calibration[bucket]["success"] / calibration[bucket]["total"], 4,
         )
 
     metrics = {
@@ -721,9 +634,7 @@ _CHURN_ACTION_TYPE = "autonomous_cli_fallback"
 
 
 async def _compute_approvals(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Approval-request resolution metrics over ``approval_requests``.
 
@@ -769,7 +680,9 @@ async def _compute_approvals(
     total_created = (await cursor.fetchone())[0]
 
     # Point-in-time gauge, not windowed: what is open right now.
-    cursor = await db.execute("SELECT COUNT(*) FROM approval_requests WHERE status = 'pending'")
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM approval_requests WHERE status = 'pending'"
+    )
     pending_open = (await cursor.fetchone())[0]
 
     total_resolved = len(resolved)
@@ -778,10 +691,13 @@ async def _compute_approvals(
     auto_resolved = sum(1 for _r, c in classified if c == "system")
     unknown_rows = [r for r, c in classified if c == "unknown"]
 
-    churn_total = sum(1 for r in resolved if r["action_type"] == _CHURN_ACTION_TYPE)
+    churn_total = sum(
+        1 for r in resolved if r["action_type"] == _CHURN_ACTION_TYPE
+    )
     non_churn_total = total_resolved - churn_total
     user_non_churn = sum(
-        1 for r, c in classified if c == "human" and r["action_type"] != _CHURN_ACTION_TYPE
+        1 for r, c in classified
+        if c == "human" and r["action_type"] != _CHURN_ACTION_TYPE
     )
 
     metrics = {
@@ -790,21 +706,23 @@ async def _compute_approvals(
         "churn_total": churn_total,
         "churn_excluded_total": non_churn_total,
         "user_resolved": user_resolved,
-        "user_resolved_rate": round(user_resolved / total_resolved, 4) if total_resolved else None,
+        "user_resolved_rate": round(user_resolved / total_resolved, 4)
+        if total_resolved else None,
         "user_resolved_rate_excl_churn": round(user_non_churn / non_churn_total, 4)
-        if non_churn_total
-        else None,
+        if non_churn_total else None,
         "auto_resolved": auto_resolved,
         "auto_expired": sum(1 for r in resolved if r["status"] == "expired"),
         "system_cancelled": sum(
-            1 for r, c in classified if r["status"] == "cancelled" and c == "system"
+            1 for r, c in classified
+            if r["status"] == "cancelled" and c == "system"
         ),
         "rejection_count": sum(1 for r in resolved if r["status"] == "rejected"),
         # M12 scaffold: a human-resolved rejection = an explicit user denial.
         # Zero observed instances to date — derivation is unvalidated against
         # real deny data until a first real rejection occurs.
         "user_denied_count": sum(
-            1 for r, c in classified if r["status"] == "rejected" and c == "human"
+            1 for r, c in classified
+            if r["status"] == "rejected" and c == "human"
         ),
         "unknown_resolver_count": len(unknown_rows),
         "unknown_resolver_values": sorted(
@@ -819,9 +737,7 @@ async def _compute_approvals(
 
 
 async def _compute_goal_completion(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """``user_goals`` status ratios + completion rate.
 
@@ -838,7 +754,8 @@ async def _compute_goal_completion(
     Snapshot-only dimension (writes no eval_events).
     """
     cursor = await db.execute(
-        "SELECT status, COUNT(*) FROM user_goals WHERE origin = 'user' GROUP BY status"
+        "SELECT status, COUNT(*) FROM user_goals "
+        "WHERE origin = 'user' GROUP BY status"
     )
     by_status = {r[0]: r[1] for r in await cursor.fetchall()}
     total_goals = sum(by_status.values())
@@ -861,7 +778,8 @@ async def _compute_goal_completion(
     metrics = {
         "total_goals": total_goals,
         "by_status": {
-            s: by_status.get(s, 0) for s in ("active", "paused", "achieved", "abandoned")
+            s: by_status.get(s, 0)
+            for s in ("active", "paused", "achieved", "abandoned")
         },
         "terminal_count": terminal,
         "achieved_count": achieved,
@@ -878,9 +796,7 @@ async def _compute_goal_completion(
 
 
 async def _compute_noise_passivity(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Noise/passivity v1: loop-closure leaks + windowed ego-cycle activity.
 
@@ -917,7 +833,8 @@ async def _compute_noise_passivity(
     ego_cycles, empty_ego_cycles = row[0], row[1]
 
     cursor = await db.execute(
-        "SELECT COUNT(*) FROM ego_proposals WHERE created_at >= ? AND created_at < ?",
+        "SELECT COUNT(*) FROM ego_proposals "
+        "WHERE created_at >= ? AND created_at < ?",
         (since, until),
     )
     proposals_in_period = (await cursor.fetchone())[0]
@@ -962,7 +879,8 @@ async def _compute_noise_passivity(
         # Windowed flows
         "ego_cycles": ego_cycles,
         "empty_ego_cycles": empty_ego_cycles,
-        "empty_ego_cycle_pct": round(empty_ego_cycles / ego_cycles, 4) if ego_cycles else None,
+        "empty_ego_cycle_pct": round(empty_ego_cycles / ego_cycles, 4)
+        if ego_cycles else None,
         "proposals_in_period": proposals_in_period,
         # Decisions RESOLVED in window (not created-in-window cohort)
         "rejected_count": decision_counts.get("rejected", 0),
@@ -998,9 +916,7 @@ def _parse_iso_utc(value: str | None) -> datetime | None:
 
 
 async def _compute_dev_quality(
-    db: aiosqlite.Connection,
-    since: str,
-    until: str,
+    db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
     """Dev-quality metrics: PR-review findings + code-audit backlog + edit failures.
 
@@ -1049,8 +965,7 @@ async def _compute_dev_quality(
     prs_merged = 0
     review_findings_total = 0
     by_severity = dict.fromkeys(
-        ("blocker", "should_fix", "note", "unlabeled"),
-        0,
+        ("blocker", "should_fix", "note", "unlabeled"), 0,
     )
     review_count_total = 0
     for r in rows:
@@ -1107,24 +1022,25 @@ async def _compute_dev_quality(
         "prs_merged": prs_merged,
         "review_findings_total": review_findings_total,
         "review_findings_by_severity": by_severity,
-        "findings_per_pr": round(review_findings_total / prs_merged, 2) if prs_merged else None,
+        "findings_per_pr": round(review_findings_total / prs_merged, 2)
+        if prs_merged else None,
         "review_count_total": review_count_total,
-        "mean_reviews_per_pr": round(review_count_total / prs_merged, 2) if prs_merged else None,
+        "mean_reviews_per_pr": round(review_count_total / prs_merged, 2)
+        if prs_merged else None,
         "code_audit_open_findings": len(audit_rows),
         "code_audit_by_severity": audit_by_severity,
         "code_audit_by_category": audit_by_category,
         "edit_calls_total": edit_calls_total,
         "edit_failures": edit_failures,
         "edit_failure_rate": round(edit_failures / edit_calls_total, 4)
-        if edit_calls_total
-        else None,
+        if edit_calls_total else None,
         # Coverage honesty: all harvested PR rows, windowed or not.
         "harvest_prs_seen": harvest_prs_seen,
         "note": "scaffold: code_audit_* reflects only the observations-"
-        "published subset (bridge routes findings to intake/"
-        "surplus_insights, not observations — reconciliation "
-        "tracked); code_audit_by_category sparse until the audit "
-        "taxonomy prompt ships",
+                "published subset (bridge routes findings to intake/"
+                "surplus_insights, not observations — reconciliation "
+                "tracked); code_audit_by_category sparse until the audit "
+                "taxonomy prompt ships",
     }
     return metrics, prs_merged + edit_calls_total
 
@@ -1140,10 +1056,7 @@ async def _compute_composite_trends(db: aiosqlite.Connection) -> dict:
 
     for dim in dimensions:
         snapshots = await j9_eval.get_snapshots(
-            db,
-            dimension=dim,
-            period_type="weekly",
-            limit=12,
+            db, dimension=dim, period_type="weekly", limit=12,
         )
         snapshots.reverse()  # oldest first
         trends[dim] = _extract_trend_values(dim, snapshots)
@@ -1206,7 +1119,8 @@ def _simple_slope(values: list[float]) -> float | None:
 # ── Per-Subsystem Grading ───────────────────────────────────────────────────
 
 # Minimum samples required per subsystem before issuing a letter grade.
-_MIN_SAMPLES = {"memory": 10, "ego": 5, "procedural": 5, "awareness": 20, "reflection": 10}
+_MIN_SAMPLES = {"memory": 10, "ego": 5, "procedural": 5,
+                "awareness": 20, "reflection": 10}
 
 
 def _score_with_zero_fill(
@@ -1257,35 +1171,24 @@ async def _grade_memory(
     usage = metrics.get("usage_rate")
     total = metrics.get("total_recalls", 0)
 
-    factors = {"precision_at_5": p5, "mrr": mrr, "usage_rate": usage, "total_recalls": total}
+    factors = {"precision_at_5": p5, "mrr": mrr, "usage_rate": usage,
+               "total_recalls": total}
 
     available = [(p5, 0.4), (mrr, 0.3), (usage, 0.3)]
 
     if all(v is None for v, _ in available) or total < _MIN_SAMPLES["memory"]:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total,
-            "reason": f"insufficient data ({total} recalls, need {_MIN_SAMPLES['memory']})",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total,
+                "reason": f"insufficient data ({total} recalls, need {_MIN_SAMPLES['memory']})"}
 
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total,
-            "reason": "too many factors unavailable",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total,
+                "reason": "too many factors unavailable"}
 
-    return {
-        "grade": _score_to_grade(score),
-        "score": round(score, 1),
-        "factors": factors,
-        "sample_count": total,
-    }
+    return {"grade": _score_to_grade(score), "score": round(score, 1),
+            "factors": factors, "sample_count": total}
 
 
 async def _grade_ego(
@@ -1322,40 +1225,25 @@ async def _grade_ego(
             cal_errors.append(abs(expected - actual))
     cal_accuracy = 1.0 - (sum(cal_errors) / len(cal_errors)) if cal_errors else None
 
-    factors = {
-        "approval_rate": approval,
-        "execution_success_rate": exec_success,
-        "calibration_accuracy": cal_accuracy,
-        "total_proposals": total,
-    }
+    factors = {"approval_rate": approval, "execution_success_rate": exec_success,
+               "calibration_accuracy": cal_accuracy,
+               "total_proposals": total}
 
     available = [(cal_accuracy, 0.4), (exec_success, 0.4), (approval, 0.2)]
 
     if all(v is None for v, _ in available) or total < _MIN_SAMPLES["ego"]:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total,
-            "reason": f"insufficient data ({total} proposals, need {_MIN_SAMPLES['ego']})",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total,
+                "reason": f"insufficient data ({total} proposals, need {_MIN_SAMPLES['ego']})"}
 
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total,
-            "reason": "too many factors unavailable",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total,
+                "reason": "too many factors unavailable"}
 
-    return {
-        "grade": _score_to_grade(score),
-        "score": round(score, 1),
-        "factors": factors,
-        "sample_count": total,
-    }
+    return {"grade": _score_to_grade(score), "score": round(score, 1),
+            "factors": factors, "sample_count": total}
 
 
 async def _grade_procedural(
@@ -1379,52 +1267,32 @@ async def _grade_procedural(
     # >1.0 per procedure per week = healthy, cap at 1.0 for scoring.
     activity = min(invocations / max(total_procs, 1), 1.0) if invocations else 0.0
 
-    factors = {
-        "success_rate": success,
-        "mean_confidence": confidence,
-        "invocation_count": invocations,
-        "activity_ratio": round(activity, 4),
-        "total_procedures": total_procs,
-    }
+    factors = {"success_rate": success, "mean_confidence": confidence,
+               "invocation_count": invocations, "activity_ratio": round(activity, 4),
+               "total_procedures": total_procs}
 
     available = [(success, 0.5), (confidence, 0.25), (activity, 0.25)]
 
     if invocations < _MIN_SAMPLES["procedural"]:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": invocations,
-            "reason": f"insufficient data ({invocations} invocations, need {_MIN_SAMPLES['procedural']})",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": invocations,
+                "reason": f"insufficient data ({invocations} invocations, need {_MIN_SAMPLES['procedural']})"}
 
     # Primary factor gate: success_rate is the most important signal.
     # Without it, grading on confidence + activity alone is misleading.
     if success is None:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": invocations,
-            "reason": "primary metric (success_rate) not yet measurable",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": invocations,
+                "reason": "primary metric (success_rate) not yet measurable"}
 
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": invocations,
-            "reason": "too many factors unavailable",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": invocations,
+                "reason": "too many factors unavailable"}
 
-    return {
-        "grade": _score_to_grade(score),
-        "score": round(score, 1),
-        "factors": factors,
-        "sample_count": invocations,
-    }
+    return {"grade": _score_to_grade(score), "score": round(score, 1),
+            "factors": factors, "sample_count": invocations}
 
 
 async def _grade_awareness(
@@ -1447,7 +1315,8 @@ async def _grade_awareness(
     """
     # Total ticks in period
     cursor = await db.execute(
-        "SELECT COUNT(*) as cnt FROM awareness_ticks WHERE created_at >= ? AND created_at < ?",
+        "SELECT COUNT(*) as cnt FROM awareness_ticks "
+        "WHERE created_at >= ? AND created_at < ?",
         (since, until),
     )
     row = await cursor.fetchone()
@@ -1478,9 +1347,7 @@ async def _grade_awareness(
             pass
     # 18 expected signals (21 total minus 3 conditional: genesis/cc version, stale items)
     expected_signals = 18
-    signal_completeness = (
-        min(len(signal_names) / expected_signals, 1.0) if expected_signals else 0.0
-    )
+    signal_completeness = min(len(signal_names) / expected_signals, 1.0) if expected_signals else 0.0
 
     # Informational: classification stats (not scored)
     cursor = await db.execute(
@@ -1494,41 +1361,27 @@ async def _grade_awareness(
     depth_dist = {r["classified_depth"]: r["cnt"] for r in depth_rows}
     classified_count = sum(depth_dist.values())
 
-    factors = {
-        "tick_regularity": round(tick_regularity, 4),
-        "signal_completeness": round(signal_completeness, 4),
-        "unique_signals": len(signal_names),
-        "total_ticks": total_ticks,
-        "classified_count": classified_count,
-        "depth_distribution": depth_dist,
-    }
+    factors = {"tick_regularity": round(tick_regularity, 4),
+               "signal_completeness": round(signal_completeness, 4),
+               "unique_signals": len(signal_names),
+               "total_ticks": total_ticks,
+               "classified_count": classified_count,
+               "depth_distribution": depth_dist}
 
     if total_ticks < _MIN_SAMPLES["awareness"]:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total_ticks,
-            "reason": f"insufficient data ({total_ticks} ticks, need {_MIN_SAMPLES['awareness']})",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total_ticks,
+                "reason": f"insufficient data ({total_ticks} ticks, need {_MIN_SAMPLES['awareness']})"}
 
     available = [(tick_regularity, 0.6), (signal_completeness, 0.4)]
     score = _score_with_zero_fill(available, max_nulls=0)
     if score is None:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total_ticks,
-            "reason": "factors unavailable",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total_ticks,
+                "reason": "factors unavailable"}
 
-    return {
-        "grade": _score_to_grade(score),
-        "score": round(score, 1),
-        "factors": factors,
-        "sample_count": total_ticks,
-    }
+    return {"grade": _score_to_grade(score), "score": round(score, 1),
+            "factors": factors, "sample_count": total_ticks}
 
 
 async def _grade_reflection(
@@ -1572,38 +1425,22 @@ async def _grade_reflection(
     # Expect 3+ types for healthy diversity, cap at 1.0
     type_diversity = min(type_count / 3, 1.0) if type_count else 0.0
 
-    factors = {
-        "observation_volume": total_obs,
-        "volume_score": round(volume_score, 4),
-        "influence_rate": round(influence_rate, 4),
-        "type_diversity": round(type_diversity, 4),
-        "type_count": type_count,
-        "influenced_count": influenced,
-    }
+    factors = {"observation_volume": total_obs, "volume_score": round(volume_score, 4),
+               "influence_rate": round(influence_rate, 4),
+               "type_diversity": round(type_diversity, 4),
+               "type_count": type_count, "influenced_count": influenced}
 
     if total_obs < _MIN_SAMPLES["reflection"]:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total_obs,
-            "reason": f"insufficient data ({total_obs} observations, need {_MIN_SAMPLES['reflection']})",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total_obs,
+                "reason": f"insufficient data ({total_obs} observations, need {_MIN_SAMPLES['reflection']})"}
 
     available = [(volume_score, 0.25), (influence_rate, 0.5), (type_diversity, 0.25)]
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {
-            "grade": None,
-            "score": None,
-            "factors": factors,
-            "sample_count": total_obs,
-            "reason": "too many factors unavailable",
-        }
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": total_obs,
+                "reason": "too many factors unavailable"}
 
-    return {
-        "grade": _score_to_grade(score),
-        "score": round(score, 1),
-        "factors": factors,
-        "sample_count": total_obs,
-    }
+    return {"grade": _score_to_grade(score), "score": round(score, 1),
+            "factors": factors, "sample_count": total_obs}

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from genesis.db.crud import ego as ego_crud
 from genesis.db.crud import j9_eval
+from genesis.db.crud import memory as memory_crud
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -35,7 +36,9 @@ logger = logging.getLogger(__name__)
 
 
 async def _compute_cognitive_drift(
-    db: aiosqlite.Connection, period_start: str, period_end: str,
+    db: aiosqlite.Connection,
+    period_start: str,
+    period_end: str,
 ) -> tuple[dict, int]:
     """Dark drift metrics over ego_proposals (Phase 7 anti-overfitting baseline).
 
@@ -54,13 +57,17 @@ async def _compute_cognitive_drift(
     from collections import Counter
 
     rows = await ego_crud.get_proposals_for_drift(
-        db, start=period_start, end=period_end,
+        db,
+        start=period_start,
+        end=period_end,
     )
     total = len(rows)
     if total == 0:
         return {
-            "dissent_rate": None, "alternative_rate": None,
-            "diversity_entropy": None, "n_proposals": 0,
+            "dissent_rate": None,
+            "alternative_rate": None,
+            "diversity_entropy": None,
+            "n_proposals": 0,
         }, 0
 
     verdicts = [r["realist_verdict"] for r in rows if r["realist_verdict"]]
@@ -168,7 +175,9 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
             subsystem_results[sub_name] = grade_info
             logger.info(
                 "J9 subsystem %s: grade=%s score=%s (%d samples)",
-                sub_name, grade_info["grade"], grade_info["score"],
+                sub_name,
+                grade_info["grade"],
+                grade_info["score"],
                 grade_info["sample_count"],
             )
         except Exception:
@@ -206,7 +215,9 @@ def _dedupe_by_pair(events: list[dict]) -> list[dict]:
 
 
 async def _recall_entrenchment(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> dict:
     """MEM-005: weekly aggregation of the activation-entrenchment signal.
 
@@ -218,48 +229,93 @@ async def _recall_entrenchment(
     feeds the quality grade.
     """
     fired = await j9_eval.get_events(
-        db, dimension="memory", event_type="recall_fired",
-        since=since, until=until, limit=5000,
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        since=since,
+        until=until,
+        limit=5000,
     )
-    corrs = [m["entrenchment_corr"] for ev in fired
-             if (m := ev.get("metrics", {})).get("entrenchment_corr") is not None]
-    ret_counts = [ev.get("metrics", {})["mean_retrieved_count"] for ev in fired
-                  if ev.get("metrics", {}).get("mean_retrieved_count") is not None]
-    ages = [ev.get("metrics", {})["mean_age_days"] for ev in fired
-            if ev.get("metrics", {}).get("mean_age_days") is not None]
+    corrs = [
+        m["entrenchment_corr"]
+        for ev in fired
+        if (m := ev.get("metrics", {})).get("entrenchment_corr") is not None
+    ]
+    ret_counts = [
+        ev.get("metrics", {})["mean_retrieved_count"]
+        for ev in fired
+        if ev.get("metrics", {}).get("mean_retrieved_count") is not None
+    ]
+    ages = [
+        ev.get("metrics", {})["mean_age_days"]
+        for ev in fired
+        if ev.get("metrics", {}).get("mean_age_days") is not None
+    ]
     return {
         "entrenchment_corr_mean": round(sum(corrs) / len(corrs), 4) if corrs else None,
         "entrenchment_mean_retrieved_count": (
-            round(sum(ret_counts) / len(ret_counts), 2) if ret_counts else None),
-        "entrenchment_mean_age_days": (
-            round(sum(ages) / len(ages), 1) if ages else None),
+            round(sum(ret_counts) / len(ret_counts), 2) if ret_counts else None
+        ),
+        "entrenchment_mean_age_days": (round(sum(ages) / len(ages), 1) if ages else None),
         "entrenchment_sample": len(corrs),
     }
 
 
+async def _pool_counts_safe(db: aiosqlite.Connection) -> dict:
+    """Point-in-time pool-size counts, isolated in its own try/except.
+
+    A count failure must degrade to None-valued ``pool_*`` keys (series shape
+    preserved) rather than sink the whole memory-quality snapshot — quality
+    metrics and pool size share the row, but the pool read is strictly additive
+    to the quality metrics.
+    """
+    try:
+        return await memory_crud.pool_size_counts(db)
+    except Exception:
+        logger.warning("J9 pool-size counts failed", exc_info=True)
+        return dict.fromkeys(memory_crud.POOL_COUNT_KEYS, None)
+
+
 async def _compute_memory_quality(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Precision@5, hit rate, MRR from recall_relevance events.
 
     Also folds in the MEM-005 entrenchment aggregation (separate read path over
     recall_fired) as distinct ``entrenchment_*`` keys — monitor-only, not part
-    of the quality grade.
+    of the quality grade — and the point-in-time ``pool_*`` counts (WS2-0), so
+    retrieval quality is always readable against the pool size it was measured
+    over.
     """
     entrenchment = await _recall_entrenchment(db, since, until)
+    pool = await _pool_counts_safe(db)
     relevance_events = await j9_eval.get_events(
-        db, dimension="memory", event_type="recall_relevance",
-        since=since, until=until, limit=5000,
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        since=since,
+        until=until,
+        limit=5000,
     )
     # Defensive dedup: duplicate (recall, memory) judgments must not skew the
     # average (pre-checkpoint batches could emit the same pair multiple times).
     relevance_events = _dedupe_by_pair(relevance_events)
 
     if not relevance_events:
-        return {"precision_at_5": None, "precision_at_3": None,
-                "precision_at_3_recalls": 0, "judge_prompt_versions": [],
-                "hit_rate": None, "mrr": None,
-                "usage_rate": None, "total_recalls": 0, **entrenchment}, 0
+        return {
+            "precision_at_5": None,
+            "precision_at_3": None,
+            "precision_at_3_recalls": 0,
+            "judge_prompt_versions": [],
+            "hit_rate": None,
+            "mrr": None,
+            "usage_rate": None,
+            "total_recalls": 0,
+            **entrenchment,
+            **pool,
+        }, 0
 
     # Group by recall_event_id
     by_recall: dict[str, list[dict]] = defaultdict(list)
@@ -313,8 +369,12 @@ async def _compute_memory_quality(
 
     # Also check recall_used events for usage rate
     used_events = await j9_eval.get_events(
-        db, dimension="memory", event_type="recall_used",
-        since=since, until=until, limit=5000,
+        db,
+        dimension="memory",
+        event_type="recall_used",
+        since=since,
+        until=until,
+        limit=5000,
     )
     used_events = _dedupe_by_pair(used_events)
     total_used = sum(1 for ev in used_events if ev.get("metrics", {}).get("used"))
@@ -323,15 +383,18 @@ async def _compute_memory_quality(
     # Judge-prompt versions seen in-window: a change here is a series break
     # (precision@k is judge-rated; a reworded judge prompt shifts the series
     # without any retrieval change). Pre-versioning events → "unversioned".
-    judge_prompt_versions = sorted({
-        (ev.get("metrics", {}) or {}).get("judge_prompt_version") or "unversioned"
-        for ev in relevance_events
-    })
+    judge_prompt_versions = sorted(
+        {
+            (ev.get("metrics", {}) or {}).get("judge_prompt_version") or "unversioned"
+            for ev in relevance_events
+        }
+    )
 
     metrics = {
         "precision_at_5": round(sum(precisions) / len(precisions), 4) if precisions else None,
         "precision_at_3": round(sum(precisions_at_3) / len(precisions_at_3), 4)
-        if precisions_at_3 else None,
+        if precisions_at_3
+        else None,
         # Coverage: recalls that qualified for the @3 metric (fully ranked)
         # vs total_recalls — thin coverage must be visible, not hidden.
         "precision_at_3_recalls": len(precisions_at_3),
@@ -345,6 +408,8 @@ async def _compute_memory_quality(
         "total_memories_judged": sum(len(v) for v in by_recall.values()),
         # MEM-005 entrenchment signal (monitor-only, distinct from the grade).
         **entrenchment,
+        # Point-in-time pool sizes (WS2-0) — quality readable against pool size.
+        **pool,
     }
     return metrics, total_recalls
 
@@ -353,7 +418,9 @@ async def _compute_memory_quality(
 
 
 async def _compute_system_composite(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Aggregate signals from cc_sessions, ego_proposals, observations, procedures."""
     # Session success rate
@@ -406,9 +473,17 @@ async def _compute_system_composite(
     mem_precision = mem_snapshot["metrics"].get("precision_at_5") if mem_snapshot else None
 
     # Composite: simple average of available signals (weighted equally)
-    signals = [v for v in [session_success_pct, ego_acceptance_pct,
-                            obs_influence_pct, proc_mean_conf, mem_precision]
-               if v is not None]
+    signals = [
+        v
+        for v in [
+            session_success_pct,
+            ego_acceptance_pct,
+            obs_influence_pct,
+            proc_mean_conf,
+            mem_precision,
+        ]
+        if v is not None
+    ]
     composite = round(sum(signals) / len(signals), 4) if signals else None
 
     sample_count = session_total + ego_total + obs_total
@@ -431,17 +506,25 @@ async def _compute_system_composite(
 
 
 async def _compute_ego_quality(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Approval rate, execution success, confidence calibration."""
     proposals = await ego_crud.get_proposals_for_quality(
-        db, start=since, end=until,
+        db,
+        start=since,
+        end=until,
     )
     total = len(proposals)
 
     if not total:
-        return {"approval_rate": None, "execution_success_rate": None,
-                "confidence_calibration": {}, "total_proposals": 0}, 0
+        return {
+            "approval_rate": None,
+            "execution_success_rate": None,
+            "confidence_calibration": {},
+            "total_proposals": 0,
+        }, 0
 
     # Approval rate (resolved proposals only)
     resolved = [p for p in proposals if p["status"] not in ("pending", "expired")]
@@ -459,12 +542,13 @@ async def _compute_ego_quality(
     for bucket_low in [0.0, 0.2, 0.4, 0.6, 0.8]:
         bucket_high = bucket_low + 0.2
         label = f"{bucket_low:.1f}-{bucket_high:.1f}"
-        in_bucket = [p for p in resolved
-                     if p.get("confidence") is not None
-                     and bucket_low <= p["confidence"] < bucket_high]
+        in_bucket = [
+            p
+            for p in resolved
+            if p.get("confidence") is not None and bucket_low <= p["confidence"] < bucket_high
+        ]
         if in_bucket:
-            bucket_approved = [p for p in in_bucket
-                               if p["status"] in ("approved", "executed")]
+            bucket_approved = [p for p in in_bucket if p["status"] in ("approved", "executed")]
             calibration[label] = {
                 "count": len(in_bucket),
                 "success_rate": round(len(bucket_approved) / len(in_bucket), 4),
@@ -484,7 +568,9 @@ async def _compute_ego_quality(
 
 
 async def _compute_cognitive_loop(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Compare sessions with proactive recall vs without."""
     # Get all sessions in the window
@@ -497,17 +583,24 @@ async def _compute_cognitive_loop(
     sessions = [dict(r) for r in await cursor.fetchall()]
 
     if not sessions:
-        return {"sessions_with_recall": 0, "sessions_without_recall": 0,
-                "success_rate_with": None, "success_rate_without": None,
-                "delta": None}, 0
+        return {
+            "sessions_with_recall": 0,
+            "sessions_without_recall": 0,
+            "success_rate_with": None,
+            "success_rate_without": None,
+            "delta": None,
+        }, 0
 
     # Find which sessions had recall_fired events
     recall_events = await j9_eval.get_events(
-        db, dimension="memory", event_type="recall_fired",
-        since=since, until=until, limit=5000,
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        since=since,
+        until=until,
+        limit=5000,
     )
-    sessions_with_recall = {ev.get("session_id") for ev in recall_events
-                            if ev.get("session_id")}
+    sessions_with_recall = {ev.get("session_id") for ev in recall_events if ev.get("session_id")}
 
     with_recall = [s for s in sessions if s["id"] in sessions_with_recall]
     without_recall = [s for s in sessions if s["id"] not in sessions_with_recall]
@@ -539,20 +632,30 @@ async def _compute_cognitive_loop(
 
 
 async def _compute_procedural_effectiveness(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Invocation frequency, success rate, confidence calibration."""
     # Invocation events
     invocations = await j9_eval.get_events(
-        db, dimension="procedure", event_type="procedure_invoked",
-        since=since, until=until, limit=1000,
+        db,
+        dimension="procedure",
+        event_type="procedure_invoked",
+        since=since,
+        until=until,
+        limit=1000,
     )
     invocation_count = len(invocations)
 
     # Outcome events
     outcomes = await j9_eval.get_events(
-        db, dimension="procedure", event_type="procedure_outcome",
-        since=since, until=until, limit=1000,
+        db,
+        dimension="procedure",
+        event_type="procedure_outcome",
+        since=since,
+        until=until,
+        limit=1000,
     )
     successes = sum(1 for o in outcomes if o.get("metrics", {}).get("success"))
     outcome_total = len(outcomes)
@@ -593,7 +696,8 @@ async def _compute_procedural_effectiveness(
                 calibration[bucket]["success"] += 1
     for bucket in calibration:
         calibration[bucket]["rate"] = round(
-            calibration[bucket]["success"] / calibration[bucket]["total"], 4,
+            calibration[bucket]["success"] / calibration[bucket]["total"],
+            4,
         )
 
     metrics = {
@@ -617,7 +721,9 @@ _CHURN_ACTION_TYPE = "autonomous_cli_fallback"
 
 
 async def _compute_approvals(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Approval-request resolution metrics over ``approval_requests``.
 
@@ -663,9 +769,7 @@ async def _compute_approvals(
     total_created = (await cursor.fetchone())[0]
 
     # Point-in-time gauge, not windowed: what is open right now.
-    cursor = await db.execute(
-        "SELECT COUNT(*) FROM approval_requests WHERE status = 'pending'"
-    )
+    cursor = await db.execute("SELECT COUNT(*) FROM approval_requests WHERE status = 'pending'")
     pending_open = (await cursor.fetchone())[0]
 
     total_resolved = len(resolved)
@@ -674,13 +778,10 @@ async def _compute_approvals(
     auto_resolved = sum(1 for _r, c in classified if c == "system")
     unknown_rows = [r for r, c in classified if c == "unknown"]
 
-    churn_total = sum(
-        1 for r in resolved if r["action_type"] == _CHURN_ACTION_TYPE
-    )
+    churn_total = sum(1 for r in resolved if r["action_type"] == _CHURN_ACTION_TYPE)
     non_churn_total = total_resolved - churn_total
     user_non_churn = sum(
-        1 for r, c in classified
-        if c == "human" and r["action_type"] != _CHURN_ACTION_TYPE
+        1 for r, c in classified if c == "human" and r["action_type"] != _CHURN_ACTION_TYPE
     )
 
     metrics = {
@@ -689,23 +790,21 @@ async def _compute_approvals(
         "churn_total": churn_total,
         "churn_excluded_total": non_churn_total,
         "user_resolved": user_resolved,
-        "user_resolved_rate": round(user_resolved / total_resolved, 4)
-        if total_resolved else None,
+        "user_resolved_rate": round(user_resolved / total_resolved, 4) if total_resolved else None,
         "user_resolved_rate_excl_churn": round(user_non_churn / non_churn_total, 4)
-        if non_churn_total else None,
+        if non_churn_total
+        else None,
         "auto_resolved": auto_resolved,
         "auto_expired": sum(1 for r in resolved if r["status"] == "expired"),
         "system_cancelled": sum(
-            1 for r, c in classified
-            if r["status"] == "cancelled" and c == "system"
+            1 for r, c in classified if r["status"] == "cancelled" and c == "system"
         ),
         "rejection_count": sum(1 for r in resolved if r["status"] == "rejected"),
         # M12 scaffold: a human-resolved rejection = an explicit user denial.
         # Zero observed instances to date — derivation is unvalidated against
         # real deny data until a first real rejection occurs.
         "user_denied_count": sum(
-            1 for r, c in classified
-            if r["status"] == "rejected" and c == "human"
+            1 for r, c in classified if r["status"] == "rejected" and c == "human"
         ),
         "unknown_resolver_count": len(unknown_rows),
         "unknown_resolver_values": sorted(
@@ -720,7 +819,9 @@ async def _compute_approvals(
 
 
 async def _compute_goal_completion(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """``user_goals`` status ratios + completion rate.
 
@@ -737,8 +838,7 @@ async def _compute_goal_completion(
     Snapshot-only dimension (writes no eval_events).
     """
     cursor = await db.execute(
-        "SELECT status, COUNT(*) FROM user_goals "
-        "WHERE origin = 'user' GROUP BY status"
+        "SELECT status, COUNT(*) FROM user_goals WHERE origin = 'user' GROUP BY status"
     )
     by_status = {r[0]: r[1] for r in await cursor.fetchall()}
     total_goals = sum(by_status.values())
@@ -761,8 +861,7 @@ async def _compute_goal_completion(
     metrics = {
         "total_goals": total_goals,
         "by_status": {
-            s: by_status.get(s, 0)
-            for s in ("active", "paused", "achieved", "abandoned")
+            s: by_status.get(s, 0) for s in ("active", "paused", "achieved", "abandoned")
         },
         "terminal_count": terminal,
         "achieved_count": achieved,
@@ -779,7 +878,9 @@ async def _compute_goal_completion(
 
 
 async def _compute_noise_passivity(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Noise/passivity v1: loop-closure leaks + windowed ego-cycle activity.
 
@@ -816,8 +917,7 @@ async def _compute_noise_passivity(
     ego_cycles, empty_ego_cycles = row[0], row[1]
 
     cursor = await db.execute(
-        "SELECT COUNT(*) FROM ego_proposals "
-        "WHERE created_at >= ? AND created_at < ?",
+        "SELECT COUNT(*) FROM ego_proposals WHERE created_at >= ? AND created_at < ?",
         (since, until),
     )
     proposals_in_period = (await cursor.fetchone())[0]
@@ -862,8 +962,7 @@ async def _compute_noise_passivity(
         # Windowed flows
         "ego_cycles": ego_cycles,
         "empty_ego_cycles": empty_ego_cycles,
-        "empty_ego_cycle_pct": round(empty_ego_cycles / ego_cycles, 4)
-        if ego_cycles else None,
+        "empty_ego_cycle_pct": round(empty_ego_cycles / ego_cycles, 4) if ego_cycles else None,
         "proposals_in_period": proposals_in_period,
         # Decisions RESOLVED in window (not created-in-window cohort)
         "rejected_count": decision_counts.get("rejected", 0),
@@ -899,7 +998,9 @@ def _parse_iso_utc(value: str | None) -> datetime | None:
 
 
 async def _compute_dev_quality(
-    db: aiosqlite.Connection, since: str, until: str,
+    db: aiosqlite.Connection,
+    since: str,
+    until: str,
 ) -> tuple[dict, int]:
     """Dev-quality metrics: PR-review findings + code-audit backlog + edit failures.
 
@@ -948,7 +1049,8 @@ async def _compute_dev_quality(
     prs_merged = 0
     review_findings_total = 0
     by_severity = dict.fromkeys(
-        ("blocker", "should_fix", "note", "unlabeled"), 0,
+        ("blocker", "should_fix", "note", "unlabeled"),
+        0,
     )
     review_count_total = 0
     for r in rows:
@@ -1005,25 +1107,24 @@ async def _compute_dev_quality(
         "prs_merged": prs_merged,
         "review_findings_total": review_findings_total,
         "review_findings_by_severity": by_severity,
-        "findings_per_pr": round(review_findings_total / prs_merged, 2)
-        if prs_merged else None,
+        "findings_per_pr": round(review_findings_total / prs_merged, 2) if prs_merged else None,
         "review_count_total": review_count_total,
-        "mean_reviews_per_pr": round(review_count_total / prs_merged, 2)
-        if prs_merged else None,
+        "mean_reviews_per_pr": round(review_count_total / prs_merged, 2) if prs_merged else None,
         "code_audit_open_findings": len(audit_rows),
         "code_audit_by_severity": audit_by_severity,
         "code_audit_by_category": audit_by_category,
         "edit_calls_total": edit_calls_total,
         "edit_failures": edit_failures,
         "edit_failure_rate": round(edit_failures / edit_calls_total, 4)
-        if edit_calls_total else None,
+        if edit_calls_total
+        else None,
         # Coverage honesty: all harvested PR rows, windowed or not.
         "harvest_prs_seen": harvest_prs_seen,
         "note": "scaffold: code_audit_* reflects only the observations-"
-                "published subset (bridge routes findings to intake/"
-                "surplus_insights, not observations — reconciliation "
-                "tracked); code_audit_by_category sparse until the audit "
-                "taxonomy prompt ships",
+        "published subset (bridge routes findings to intake/"
+        "surplus_insights, not observations — reconciliation "
+        "tracked); code_audit_by_category sparse until the audit "
+        "taxonomy prompt ships",
     }
     return metrics, prs_merged + edit_calls_total
 
@@ -1039,7 +1140,10 @@ async def _compute_composite_trends(db: aiosqlite.Connection) -> dict:
 
     for dim in dimensions:
         snapshots = await j9_eval.get_snapshots(
-            db, dimension=dim, period_type="weekly", limit=12,
+            db,
+            dimension=dim,
+            period_type="weekly",
+            limit=12,
         )
         snapshots.reverse()  # oldest first
         trends[dim] = _extract_trend_values(dim, snapshots)
@@ -1102,8 +1206,7 @@ def _simple_slope(values: list[float]) -> float | None:
 # ── Per-Subsystem Grading ───────────────────────────────────────────────────
 
 # Minimum samples required per subsystem before issuing a letter grade.
-_MIN_SAMPLES = {"memory": 10, "ego": 5, "procedural": 5,
-                "awareness": 20, "reflection": 10}
+_MIN_SAMPLES = {"memory": 10, "ego": 5, "procedural": 5, "awareness": 20, "reflection": 10}
 
 
 def _score_with_zero_fill(
@@ -1154,24 +1257,35 @@ async def _grade_memory(
     usage = metrics.get("usage_rate")
     total = metrics.get("total_recalls", 0)
 
-    factors = {"precision_at_5": p5, "mrr": mrr, "usage_rate": usage,
-               "total_recalls": total}
+    factors = {"precision_at_5": p5, "mrr": mrr, "usage_rate": usage, "total_recalls": total}
 
     available = [(p5, 0.4), (mrr, 0.3), (usage, 0.3)]
 
     if all(v is None for v, _ in available) or total < _MIN_SAMPLES["memory"]:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total,
-                "reason": f"insufficient data ({total} recalls, need {_MIN_SAMPLES['memory']})"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total,
+            "reason": f"insufficient data ({total} recalls, need {_MIN_SAMPLES['memory']})",
+        }
 
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total,
-                "reason": "too many factors unavailable"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total,
+            "reason": "too many factors unavailable",
+        }
 
-    return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": total}
+    return {
+        "grade": _score_to_grade(score),
+        "score": round(score, 1),
+        "factors": factors,
+        "sample_count": total,
+    }
 
 
 async def _grade_ego(
@@ -1208,25 +1322,40 @@ async def _grade_ego(
             cal_errors.append(abs(expected - actual))
     cal_accuracy = 1.0 - (sum(cal_errors) / len(cal_errors)) if cal_errors else None
 
-    factors = {"approval_rate": approval, "execution_success_rate": exec_success,
-               "calibration_accuracy": cal_accuracy,
-               "total_proposals": total}
+    factors = {
+        "approval_rate": approval,
+        "execution_success_rate": exec_success,
+        "calibration_accuracy": cal_accuracy,
+        "total_proposals": total,
+    }
 
     available = [(cal_accuracy, 0.4), (exec_success, 0.4), (approval, 0.2)]
 
     if all(v is None for v, _ in available) or total < _MIN_SAMPLES["ego"]:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total,
-                "reason": f"insufficient data ({total} proposals, need {_MIN_SAMPLES['ego']})"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total,
+            "reason": f"insufficient data ({total} proposals, need {_MIN_SAMPLES['ego']})",
+        }
 
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total,
-                "reason": "too many factors unavailable"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total,
+            "reason": "too many factors unavailable",
+        }
 
-    return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": total}
+    return {
+        "grade": _score_to_grade(score),
+        "score": round(score, 1),
+        "factors": factors,
+        "sample_count": total,
+    }
 
 
 async def _grade_procedural(
@@ -1250,32 +1379,52 @@ async def _grade_procedural(
     # >1.0 per procedure per week = healthy, cap at 1.0 for scoring.
     activity = min(invocations / max(total_procs, 1), 1.0) if invocations else 0.0
 
-    factors = {"success_rate": success, "mean_confidence": confidence,
-               "invocation_count": invocations, "activity_ratio": round(activity, 4),
-               "total_procedures": total_procs}
+    factors = {
+        "success_rate": success,
+        "mean_confidence": confidence,
+        "invocation_count": invocations,
+        "activity_ratio": round(activity, 4),
+        "total_procedures": total_procs,
+    }
 
     available = [(success, 0.5), (confidence, 0.25), (activity, 0.25)]
 
     if invocations < _MIN_SAMPLES["procedural"]:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": invocations,
-                "reason": f"insufficient data ({invocations} invocations, need {_MIN_SAMPLES['procedural']})"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": invocations,
+            "reason": f"insufficient data ({invocations} invocations, need {_MIN_SAMPLES['procedural']})",
+        }
 
     # Primary factor gate: success_rate is the most important signal.
     # Without it, grading on confidence + activity alone is misleading.
     if success is None:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": invocations,
-                "reason": "primary metric (success_rate) not yet measurable"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": invocations,
+            "reason": "primary metric (success_rate) not yet measurable",
+        }
 
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": invocations,
-                "reason": "too many factors unavailable"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": invocations,
+            "reason": "too many factors unavailable",
+        }
 
-    return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": invocations}
+    return {
+        "grade": _score_to_grade(score),
+        "score": round(score, 1),
+        "factors": factors,
+        "sample_count": invocations,
+    }
 
 
 async def _grade_awareness(
@@ -1298,8 +1447,7 @@ async def _grade_awareness(
     """
     # Total ticks in period
     cursor = await db.execute(
-        "SELECT COUNT(*) as cnt FROM awareness_ticks "
-        "WHERE created_at >= ? AND created_at < ?",
+        "SELECT COUNT(*) as cnt FROM awareness_ticks WHERE created_at >= ? AND created_at < ?",
         (since, until),
     )
     row = await cursor.fetchone()
@@ -1330,7 +1478,9 @@ async def _grade_awareness(
             pass
     # 18 expected signals (21 total minus 3 conditional: genesis/cc version, stale items)
     expected_signals = 18
-    signal_completeness = min(len(signal_names) / expected_signals, 1.0) if expected_signals else 0.0
+    signal_completeness = (
+        min(len(signal_names) / expected_signals, 1.0) if expected_signals else 0.0
+    )
 
     # Informational: classification stats (not scored)
     cursor = await db.execute(
@@ -1344,27 +1494,41 @@ async def _grade_awareness(
     depth_dist = {r["classified_depth"]: r["cnt"] for r in depth_rows}
     classified_count = sum(depth_dist.values())
 
-    factors = {"tick_regularity": round(tick_regularity, 4),
-               "signal_completeness": round(signal_completeness, 4),
-               "unique_signals": len(signal_names),
-               "total_ticks": total_ticks,
-               "classified_count": classified_count,
-               "depth_distribution": depth_dist}
+    factors = {
+        "tick_regularity": round(tick_regularity, 4),
+        "signal_completeness": round(signal_completeness, 4),
+        "unique_signals": len(signal_names),
+        "total_ticks": total_ticks,
+        "classified_count": classified_count,
+        "depth_distribution": depth_dist,
+    }
 
     if total_ticks < _MIN_SAMPLES["awareness"]:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total_ticks,
-                "reason": f"insufficient data ({total_ticks} ticks, need {_MIN_SAMPLES['awareness']})"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total_ticks,
+            "reason": f"insufficient data ({total_ticks} ticks, need {_MIN_SAMPLES['awareness']})",
+        }
 
     available = [(tick_regularity, 0.6), (signal_completeness, 0.4)]
     score = _score_with_zero_fill(available, max_nulls=0)
     if score is None:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total_ticks,
-                "reason": "factors unavailable"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total_ticks,
+            "reason": "factors unavailable",
+        }
 
-    return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": total_ticks}
+    return {
+        "grade": _score_to_grade(score),
+        "score": round(score, 1),
+        "factors": factors,
+        "sample_count": total_ticks,
+    }
 
 
 async def _grade_reflection(
@@ -1408,22 +1572,38 @@ async def _grade_reflection(
     # Expect 3+ types for healthy diversity, cap at 1.0
     type_diversity = min(type_count / 3, 1.0) if type_count else 0.0
 
-    factors = {"observation_volume": total_obs, "volume_score": round(volume_score, 4),
-               "influence_rate": round(influence_rate, 4),
-               "type_diversity": round(type_diversity, 4),
-               "type_count": type_count, "influenced_count": influenced}
+    factors = {
+        "observation_volume": total_obs,
+        "volume_score": round(volume_score, 4),
+        "influence_rate": round(influence_rate, 4),
+        "type_diversity": round(type_diversity, 4),
+        "type_count": type_count,
+        "influenced_count": influenced,
+    }
 
     if total_obs < _MIN_SAMPLES["reflection"]:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total_obs,
-                "reason": f"insufficient data ({total_obs} observations, need {_MIN_SAMPLES['reflection']})"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total_obs,
+            "reason": f"insufficient data ({total_obs} observations, need {_MIN_SAMPLES['reflection']})",
+        }
 
     available = [(volume_score, 0.25), (influence_rate, 0.5), (type_diversity, 0.25)]
     score = _score_with_zero_fill(available, max_nulls=1)
     if score is None:
-        return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total_obs,
-                "reason": "too many factors unavailable"}
+        return {
+            "grade": None,
+            "score": None,
+            "factors": factors,
+            "sample_count": total_obs,
+            "reason": "too many factors unavailable",
+        }
 
-    return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": total_obs}
+    return {
+        "grade": _score_to_grade(score),
+        "score": round(score, 1),
+        "factors": factors,
+        "sample_count": total_obs,
+    }

--- a/src/genesis/eval/longmemeval/__main__.py
+++ b/src/genesis/eval/longmemeval/__main__.py
@@ -62,6 +62,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="comma-separated arm labels to run (filters the selected "
         "universe, e.g. --graph --arms raw,raw+graph); unknown labels error",
     )
+    p.add_argument(
+        "--variants",
+        default="",
+        help="comma-separated retrieval-config variants to pair against baseline "
+        "(each doubles every base arm with a +<variant> twin; a WS2 lever PR "
+        "registers each variant). Unknown variants error before any spend.",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -86,6 +93,7 @@ def main(argv: list[str] | None = None) -> int:
             graph=args.graph,
             graph_link_threshold=args.graph_link_threshold,
             arms_only=args.arms,
+            variants=tuple(v.strip() for v in args.variants.split(",") if v.strip()),
         ),
     )
     print_report(summaries)

--- a/src/genesis/eval/longmemeval/cli.py
+++ b/src/genesis/eval/longmemeval/cli.py
@@ -13,9 +13,16 @@ from typing import TYPE_CHECKING
 
 from genesis.eval.longmemeval.client import load_secrets
 from genesis.eval.longmemeval.dataset import filter_by_types, load_oracle
-from genesis.eval.longmemeval.runner import filter_arms, run_longmemeval, select_arms
+from genesis.eval.longmemeval.runner import (
+    filter_arms,
+    run_longmemeval,
+    select_arms,
+    validate_variants,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from genesis.eval.types import EvalRunSummary
 
 logger = logging.getLogger("genesis.eval.longmemeval")
@@ -99,6 +106,7 @@ async def execute(
     graph: bool = False,
     graph_link_threshold: float | None = None,
     arms_only: str | None = None,
+    variants: Sequence[str] = (),
 ) -> dict[str, EvalRunSummary]:
     """Load the dataset, run the harness, persist (optionally), return summaries.
 
@@ -119,11 +127,14 @@ async def execute(
         instances = instances[:limit]
     logger.info("loaded %d questions from %s", len(instances), dataset_path)
 
-    arms = select_arms(no_rerank=no_rerank, graph=graph)
+    arms = select_arms(no_rerank=no_rerank, graph=graph, variants=variants)
     if arms_only is not None:
         # An empty string still reaches filter_arms and raises there — a paid
         # run must never silently widen back to the full arm universe.
         arms = filter_arms(arms, arms_only)
+    # Fail-fast BEFORE any spend: unknown variant or a variant declaring a
+    # recall kwarg that recall() doesn't accept raises here, not mid-run.
+    validate_variants(arms)
     reranker = None if no_rerank else build_reranker()
 
     db = None

--- a/src/genesis/eval/longmemeval/runner.py
+++ b/src/genesis/eval/longmemeval/runner.py
@@ -45,7 +45,7 @@ from genesis.eval.types import (
 from genesis.memory.linker import DEFAULT_SIMILARITY_THRESHOLD
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     import aiosqlite
 
@@ -75,12 +75,21 @@ class Arm:
     query_arm: QueryArm
     rerank: bool
     graph: bool = False
+    #: A registered retrieval-config variant (WS2-0); "" = baseline. Each WS2
+    #: lever PR registers one in VARIANTS and adds its paired arm here.
+    variant: str = ""
 
     @property
     def label(self) -> str:
-        # Deterministic suffix order (rerank before graph): model_profile
-        # "longmemeval:<label>" and dump filenames must be stable across runs.
-        suffix = ("+rerank" if self.rerank else "") + ("+graph" if self.graph else "")
+        # Deterministic suffix order (rerank, then graph, then variant):
+        # model_profile "longmemeval:<label>" and dump filenames must be stable
+        # across runs, and every pre-WS2-0 label stays byte-identical because
+        # the +variant suffix only appears when a variant is set.
+        suffix = (
+            ("+rerank" if self.rerank else "")
+            + ("+graph" if self.graph else "")
+            + (f"+{self.variant}" if self.variant else "")
+        )
         return f"{self.query_arm.value}{suffix}"
 
 
@@ -94,10 +103,80 @@ def default_arms() -> list[Arm]:
     ]
 
 
-def select_arms(*, no_rerank: bool = False, graph: bool = False) -> list[Arm]:
+@dataclass(frozen=True)
+class ArmVariant:
+    """A registered retrieval-config variant an eval arm can carry (WS2-0).
+
+    The instrumentation PR ships the machinery with an EMPTY registry; each WS2
+    lever PR registers exactly one variant here and adds its paired arm, so the
+    levers stay additive instead of re-opening this file's core arm logic. Two
+    application seams cover the recall-side levers:
+
+    * ``recall_kwargs(instance, arm) -> dict`` — extra kwargs merged into the
+      per-question ``recall()`` call (e.g. scope routing derives ``wing`` from
+      the question text).
+    * ``post_recall(memories) -> memories`` — transforms the final content list
+      fed to the reader (e.g. an output token budget trims the relevance-sorted
+      tail). Evidence metrics are computed from the untrimmed recall, so a
+      budget arm stays coverage-comparable while its effect shows in the answer.
+
+    ``recall_kwarg_names`` declares the ``recall()`` kwargs the variant injects;
+    it is validated against the live ``recall()`` signature BEFORE any paid run
+    (fail-fast, mirroring ``filter_arms``' label check).
+    """
+
+    name: str
+    recall_kwarg_names: tuple[str, ...] = ()
+    recall_kwargs: Callable[[LongMemEvalInstance, Arm], dict] | None = None
+    post_recall: Callable[[list[str]], list[str]] | None = None
+
+
+#: Registered variants, keyed by name. Empty until a lever PR registers one.
+VARIANTS: dict[str, ArmVariant] = {}
+
+
+def register_variant(variant: ArmVariant) -> None:
+    """Register a retrieval-config variant (idempotent by name; last wins)."""
+    VARIANTS[variant.name] = variant
+
+
+def _recall_param_names() -> set[str]:
+    """The keyword parameters ``HybridRetriever.recall`` accepts."""
+    import inspect
+
+    from genesis.memory.retrieval import HybridRetriever
+
+    return set(inspect.signature(HybridRetriever.recall).parameters)
+
+
+def validate_variants(arms: list[Arm]) -> None:
+    """Fail-fast before any spend: every arm's variant must be registered and
+    its declared recall kwargs must exist on ``recall()``. Raises ValueError."""
+    recall_params = _recall_param_names()
+    for arm in arms:
+        if not arm.variant:
+            continue
+        variant = VARIANTS.get(arm.variant)
+        if variant is None:
+            msg = f"unknown arm variant {arm.variant!r}; registered: {sorted(VARIANTS)}"
+            raise ValueError(msg)
+        unknown = sorted(set(variant.recall_kwarg_names) - recall_params)
+        if unknown:
+            msg = f"variant {arm.variant!r} injects unknown recall kwargs {unknown}"
+            raise ValueError(msg)
+
+
+def select_arms(
+    *,
+    no_rerank: bool = False,
+    graph: bool = False,
+    variants: Sequence[str] = (),
+) -> list[Arm]:
     """Build the CLI's arm list: default arms, optionally rerank-filtered,
-    optionally doubled with a ``+graph`` variant of every selected arm
-    (paired baseline-vs-graph comparison in one run)."""
+    optionally doubled with a ``+graph`` variant of every selected arm, then
+    doubled again with each named ``+variant`` twin (paired baseline-vs-lever
+    comparison in one run). Variant twins are only made from non-variant arms,
+    so ``--variants`` never produces variant-of-variant labels."""
     from dataclasses import replace
 
     arms = default_arms()
@@ -105,6 +184,8 @@ def select_arms(*, no_rerank: bool = False, graph: bool = False) -> list[Arm]:
         arms = [a for a in arms if not a.rerank]
     if graph:
         arms = [*arms, *(replace(a, graph=True) for a in arms)]
+    for name in variants:
+        arms = [*arms, *(replace(a, variant=name) for a in arms if not a.variant)]
     return arms
 
 
@@ -414,11 +495,14 @@ async def _run_arm(
     """
     t0 = time.monotonic()
     query = build_query(instance.question, arm.query_arm)
+    variant = VARIANTS.get(arm.variant) if arm.variant else None
+    recall_extra = variant.recall_kwargs(instance, arm) if variant and variant.recall_kwargs else {}
     hits = await es.retriever.recall(
         query,
         source="episodic",
         limit=k,
         rerank=arm.rerank,
+        **recall_extra,
     )
     recalled_ids = {h.memory_id for h in hits}
     evidence_ids = ingest.evidence_memory_ids
@@ -437,6 +521,12 @@ async def _run_arm(
         )
 
     evidence_recalled, evidence_coverage = _coverage(evidence_ids, recalled_ids)
+    # Variant post-recall transform (e.g. output token budget) acts on the
+    # final content list fed to the reader — AFTER graph expansion and AFTER the
+    # evidence metrics above, so coverage stays comparable to baseline while the
+    # transform's effect surfaces only in the answer.
+    if variant and variant.post_recall:
+        memories = variant.post_recall(memories)
     # answer_question / judge_answer use the SYNC OpenAI client, so run
     # them in a worker thread — a blocking create() on the event loop
     # would stall ALL concurrent questions and defeat `concurrency`.

--- a/src/genesis/mcp/health/j9_eval.py
+++ b/src/genesis/mcp/health/j9_eval.py
@@ -8,6 +8,38 @@ from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
 
+# Metric keys pulled from each weekly memory snapshot into the retrieval trend.
+# pool_* land only from WS2-0 onward, so every key is read with .get → None on
+# older snapshots (the series shape stays stable, gaps are honest nulls).
+_TREND_METRIC_KEYS: tuple[str, ...] = (
+    "precision_at_5",
+    "precision_at_3",
+    "hit_rate",
+    "mrr",
+    "usage_rate",
+    "total_recalls",
+    "pool_episodic_total",
+    "pool_episodic_embedded",
+    "pool_knowledge_units_total",
+    "pool_memory_links_total",
+)
+
+
+def _retrieval_trend(mem_snapshots: list[dict]) -> list[dict]:
+    """Map weekly memory snapshots (newest-first) → a chronological trend series.
+
+    Reads every metric with ``.get`` so pre-WS2-0 snapshots (no ``pool_*``)
+    surface as explicit ``None`` rather than a fabricated value or a KeyError.
+    """
+    trend: list[dict] = []
+    for snap in reversed(mem_snapshots):  # DESC → chronological
+        metrics = snap.get("metrics", {}) or {}
+        row = {"period_end": snap.get("period_end")}
+        for key in _TREND_METRIC_KEYS:
+            row[key] = metrics.get(key)
+        trend.append(row)
+    return trend
+
 
 async def _impl_j9_eval_status() -> dict:
     """Get J-9 eval collection status across all 5 dimensions."""
@@ -52,11 +84,22 @@ async def _impl_j9_eval_status() -> dict:
             "weeks_of_data": composite["metrics"].get("weeks_of_data", 0),
         }
 
+    # Retrieval-efficacy trend: last 12 weekly memory snapshots, chronological,
+    # so quality (precision@k/hit_rate/MRR) is readable against pool size.
+    mem_snaps = await j9_eval.get_snapshots(
+        db,
+        dimension="memory",
+        period_type="weekly",
+        limit=12,
+    )
+    retrieval_trend = _retrieval_trend(mem_snaps)
+
     return {
         "event_counts": event_counts,
         "total_events": sum(event_counts.values()),
         "latest_snapshots": latest_snapshots,
         "go_status": go_status,
+        "retrieval_trend": retrieval_trend,
     }
 
 

--- a/src/genesis/mcp/health/j9_eval.py
+++ b/src/genesis/mcp/health/j9_eval.py
@@ -19,6 +19,7 @@ _TREND_METRIC_KEYS: tuple[str, ...] = (
     "usage_rate",
     "total_recalls",
     "pool_episodic_total",
+    "pool_episodic_retrievable",
     "pool_episodic_embedded",
     "pool_knowledge_units_total",
     "pool_memory_links_total",

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -1125,6 +1125,41 @@ async def memory_core_facts(
     return [item for item, _ in top]
 
 
+async def _memory_quality_block(db) -> dict | None:
+    """Latest J-9 memory-quality headline + subsystem grade, or None.
+
+    Joins the capacity surface (memory_stats) to the quality surface (weekly J-9
+    snapshots) so "recall efficacy at the current pool size" is one read.
+    Fully guarded — a missing table or an un-aggregated install returns None,
+    never breaking the capacity stats.
+    """
+    try:
+        from genesis.db.crud import j9_eval
+
+        snap = await j9_eval.get_latest_snapshot(db, dimension="memory")
+        if not snap:
+            return None
+        metrics = snap.get("metrics", {}) or {}
+        grades = await j9_eval.get_latest_subsystem_grades(db)
+        mem_grade = next((g for g in grades if g.get("subsystem") == "memory"), None)
+        return {
+            "period_end": snap.get("period_end"),
+            "precision_at_5": metrics.get("precision_at_5"),
+            "precision_at_3": metrics.get("precision_at_3"),
+            "hit_rate": metrics.get("hit_rate"),
+            "mrr": metrics.get("mrr"),
+            "usage_rate": metrics.get("usage_rate"),
+            "total_recalls": metrics.get("total_recalls"),
+            "pool_episodic_total": metrics.get("pool_episodic_total"),
+            "pool_knowledge_units_total": metrics.get("pool_knowledge_units_total"),
+            "grade": mem_grade.get("grade") if mem_grade else None,
+            "grade_score": mem_grade.get("score") if mem_grade else None,
+        }
+    except Exception:
+        logger.debug("Memory quality block unavailable", exc_info=True)
+        return None
+
+
 @mcp.tool()
 async def memory_stats() -> dict:
     """Health, capacity, and structural metrics for the memory system."""
@@ -1185,6 +1220,7 @@ async def memory_stats() -> dict:
         "extraction": extraction,
         "code_index": code_index,
         "essential_knowledge": ek_info,
+        "quality": await _memory_quality_block(memory_mod._db),
     }
 
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -1151,6 +1151,7 @@ async def _memory_quality_block(db) -> dict | None:
             "usage_rate": metrics.get("usage_rate"),
             "total_recalls": metrics.get("total_recalls"),
             "pool_episodic_total": metrics.get("pool_episodic_total"),
+            "pool_episodic_retrievable": metrics.get("pool_episodic_retrievable"),
             "pool_knowledge_units_total": metrics.get("pool_knowledge_units_total"),
             "grade": mem_grade.get("grade") if mem_grade else None,
             "grade_score": mem_grade.get("score") if mem_grade else None,

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -46,20 +46,26 @@ async def test_update_event_metrics_merges_in_place(db):
     """update_event_metrics enriches an existing event's metrics without
     creating a second row (audit MEM-003: one recall_fired per logical recall)."""
     eid = await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
         metrics={"query": "q", "result_count": 1},
     )
     updated = await j9_eval.update_event_metrics(
-        db, eid, result_count=5, mode="auto", pipeline_used="standard",
+        db,
+        eid,
+        result_count=5,
+        mode="auto",
+        pipeline_used="standard",
     )
     assert updated is True
 
     events = await j9_eval.get_events(db, event_type="recall_fired")
     assert len(events) == 1  # merged in place, NOT a second event
     m = events[0]["metrics"]
-    assert m["query"] == "q"          # pre-existing field preserved
-    assert m["result_count"] == 5      # overwritten
-    assert m["mode"] == "auto"         # new field added
+    assert m["query"] == "q"  # pre-existing field preserved
+    assert m["result_count"] == 5  # overwritten
+    assert m["mode"] == "auto"  # new field added
     assert m["pipeline_used"] == "standard"
 
 
@@ -78,13 +84,17 @@ async def test_recall_entrenchment_aggregates(db):
 
     for corr, rc, age in [(0.8, 5.0, 10.0), (0.6, 3.0, 20.0)]:
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_fired",
-            metrics={"entrenchment_corr": corr,
-                     "mean_retrieved_count": rc, "mean_age_days": age},
+            db,
+            dimension="memory",
+            event_type="recall_fired",
+            metrics={"entrenchment_corr": corr, "mean_retrieved_count": rc, "mean_age_days": age},
         )
     # An older-style event without entrenchment fields must not skew the means.
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired", metrics={"query": "q"},
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        metrics={"query": "q"},
     )
 
     result = await _recall_entrenchment(db, since="2000-01-01", until="2099-01-01")
@@ -100,13 +110,17 @@ async def test_memory_quality_includes_entrenchment_when_no_relevance(db):
     from genesis.eval.j9_aggregator import _compute_memory_quality
 
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
         metrics={"entrenchment_corr": 0.5, "mean_retrieved_count": 2.0},
     )
     metrics, sample = await _compute_memory_quality(
-        db, since="2000-01-01", until="2099-01-01",
+        db,
+        since="2000-01-01",
+        until="2099-01-01",
     )
-    assert metrics["precision_at_5"] is None      # no relevance events
+    assert metrics["precision_at_5"] is None  # no relevance events
     assert metrics["entrenchment_corr_mean"] == pytest.approx(0.5)
     assert metrics["entrenchment_sample"] == 1
 
@@ -137,6 +151,50 @@ async def test_pool_size_counts_splits_episodic_by_collection(db):
     counts = await memory_crud.pool_size_counts(db)
     assert counts["pool_episodic_total"] - base["pool_episodic_total"] == 2
     assert counts["pool_episodic_embedded"] - base["pool_episodic_embedded"] == 1
+
+
+async def test_pool_size_counts_retrievable_excludes_deprecated_and_expired(db):
+    """pool_episodic_retrievable applies the SAME filters as the recall path:
+    deprecated rows and bitemporally-expired rows count toward the total but
+    NOT the retrievable pool — the denominator the drift hypothesis cares about."""
+    from genesis.db.crud import memory as memory_crud
+
+    base = await memory_crud.pool_size_counts(db)
+    await _seed_memory_row(db, "live-1", "episodic_memory")  # retrievable
+    await db.execute(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, embedding_status, deprecated) "
+        "VALUES ('dep-1', '2026-07-17T00:00:00Z', 'episodic_memory', 'embedded', 1)",
+    )
+    await db.execute(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, embedding_status, invalid_at) "
+        "VALUES ('exp-1', '2026-07-17T00:00:00Z', 'episodic_memory', 'embedded', "
+        "'2000-01-01T00:00:00Z')",
+    )
+    await db.commit()
+
+    counts = await memory_crud.pool_size_counts(db)
+    # all three count toward the total; only the live one is retrievable
+    assert counts["pool_episodic_total"] - base["pool_episodic_total"] == 3
+    assert counts["pool_episodic_retrievable"] - base["pool_episodic_retrievable"] == 1
+
+
+async def test_episodic_count_created_before(db):
+    """The report's pool-reconstruction CRUD helper counts episodic rows created
+    on or before a cutoff."""
+    from genesis.db.crud import memory as memory_crud
+
+    await db.execute(
+        "INSERT INTO memory_metadata (memory_id, created_at, collection) VALUES "
+        "('old-1', '2026-01-01T00:00:00Z', 'episodic_memory'), "
+        "('new-1', '2026-12-01T00:00:00Z', 'episodic_memory')",
+    )
+    await db.commit()
+    before_mid = await memory_crud.episodic_count_created_before(db, "2026-06-15T00:00:00Z")
+    before_future = await memory_crud.episodic_count_created_before(db, "2027-01-01T00:00:00Z")
+    # new-1 (Dec) is excluded before mid-year, included before the future cutoff
+    assert before_future - before_mid == 1
 
 
 async def test_pool_size_counts_knowledge_units_and_links(db):
@@ -326,12 +384,18 @@ async def test_count_events(db):
 
 async def test_get_events_with_session_filter(db):
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
-        metrics={}, session_id="sess-A",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        metrics={},
+        session_id="sess-A",
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
-        metrics={}, session_id="sess-B",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        metrics={},
+        session_id="sess-B",
     )
     results = await j9_eval.get_events(db, session_id="sess-A")
     assert len(results) == 1
@@ -463,7 +527,9 @@ async def test_emit_proposal_resolved_survives_db_error():
     bad_db = AsyncMock(spec=["execute", "commit"])
     bad_db.execute.side_effect = Exception("kaboom")
     await emit_proposal_resolved(
-        bad_db, proposal_id="x", status="approved",
+        bad_db,
+        proposal_id="x",
+        status="approved",
     )
 
 
@@ -699,8 +765,12 @@ async def test_grade_reflection_from_observations(db):
             "INSERT INTO observations (id, type, source, content, priority, "
             "created_at, influenced_action) VALUES (?, ?, 'ego_cycle', 'test', "
             "'medium', ?, ?)",
-            (f"obs-{i}", ["task_detected", "pattern", "insight"][i % 3],
-             "2026-05-05T12:00:00Z", 1 if i < 10 else 0),
+            (
+                f"obs-{i}",
+                ["task_detected", "pattern", "insight"][i % 3],
+                "2026-05-05T12:00:00Z",
+                1 if i < 10 else 0,
+            ),
         )
     await db.commit()
 
@@ -781,16 +851,22 @@ async def test_memory_quality_ignores_duplicate_relevance(db):
     # (without dedup it would be 2/3 = 0.667).
     for rel in (1.0, 1.0):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
             metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": rel},
         )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0},
     )
 
     metrics, total_recalls = await _compute_memory_quality(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert total_recalls == 1
     assert metrics["precision_at_5"] == 0.5
@@ -809,15 +885,21 @@ async def test_memory_quality_mrr_uses_stored_rank_not_insert_order(db):
 
     # Out of rank order: rank-1 (irrelevant) first … rank-3 (relevant) last.
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 0.0, "rank": 1},
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0, "rank": 2},
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m3", "relevance": 1.0, "rank": 3},
     )
 
@@ -857,28 +939,44 @@ async def test_insert_run_persists_metadata_json_per_result(db):
 
     detail = _json.dumps({"judge_model": "x", "judge_score": 0.7, "rationale": "ok"})
     summary = EvalRunSummary(
-        run_id="run_meta_1", model_id="m", model_profile="p", dataset="d",
-        trigger=EvalTrigger.MANUAL, task_category=TaskCategory.CLASSIFICATION,
-        total_cases=2, passed_cases=2, failed_cases=0,
+        run_id="run_meta_1",
+        model_id="m",
+        model_profile="p",
+        dataset="d",
+        trigger=EvalTrigger.MANUAL,
+        task_category=TaskCategory.CLASSIFICATION,
+        total_cases=2,
+        passed_cases=2,
+        failed_cases=0,
         results=[
             ScoredOutput(
-                case_id="c1", passed=True, score=0.7, actual_output="out",
-                scorer_type=ScorerType.LLM_JUDGE, scorer_detail=detail,
+                case_id="c1",
+                passed=True,
+                score=0.7,
+                actual_output="out",
+                scorer_type=ScorerType.LLM_JUDGE,
+                scorer_detail=detail,
             ),
             # Non-judge scorer: scorer_detail is a plain (non-JSON) string, so
             # metadata_json (the queryable JSON view) must be NULL, not that string.
             ScoredOutput(
-                case_id="c2", passed=True, score=1.0, actual_output="3",
-                scorer_type=ScorerType.EXACT_MATCH, scorer_detail="expected=3, got=3",
+                case_id="c2",
+                passed=True,
+                score=1.0,
+                actual_output="3",
+                scorer_type=ScorerType.EXACT_MATCH,
+                scorer_detail="expected=3, got=3",
             ),
         ],
     )
     await eval_db.insert_run(db, summary)
     rows = {
         r[0]: r[1]
-        for r in await (await db.execute(
-            "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
-        )).fetchall()
+        for r in await (
+            await db.execute(
+                "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
+            )
+        ).fetchall()
     }
     assert rows["c1"] == detail  # judge result → JSON dual-write
     assert rows["c2"] is None  # non-judge result → NULL (not the plain string)
@@ -894,9 +992,15 @@ async def test_memory_quality_precision_at_3(db):
 
     for rank, rel in enumerate((1.0, 0.0, 1.0, 0.0, 1.0), 1):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
-            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
-                     "relevance": rel, "rank": rank},
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
+            metrics={
+                "recall_event_id": "r1",
+                "memory_id": f"m{rank}",
+                "relevance": rel,
+                "rank": rank,
+            },
         )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -912,9 +1016,15 @@ async def test_memory_quality_precision_at_3_fewer_than_three(db):
 
     for rank, rel in ((1, 1.0), (2, 0.0)):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
-            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
-                     "relevance": rel, "rank": rank},
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
+            metrics={
+                "recall_event_id": "r1",
+                "memory_id": f"m{rank}",
+                "relevance": rel,
+                "rank": rank,
+            },
         )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -928,14 +1038,21 @@ async def test_memory_quality_truncates_to_top5(db):
 
     for rank in range(1, 6):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
-            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
-                     "relevance": 0.0, "rank": rank},
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
+            metrics={
+                "recall_event_id": "r1",
+                "memory_id": f"m{rank}",
+                "relevance": 0.0,
+                "rank": rank,
+            },
         )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
-        metrics={"recall_event_id": "r1", "memory_id": "m6",
-                 "relevance": 1.0, "rank": 6},
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m6", "relevance": 1.0, "rank": 6},
     )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -950,7 +1067,9 @@ async def test_precision_at_3_skips_unranked_recalls(db):
 
     for i, rel in enumerate((1.0, 0.0, 1.0, 0.0), 1):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
             metrics={"recall_event_id": "r1", "memory_id": f"m{i}", "relevance": rel},
         )
 
@@ -966,14 +1085,22 @@ async def test_memory_quality_reports_judge_prompt_versions(db):
     from genesis.eval.j9_aggregator import _compute_memory_quality
 
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
-        metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 1.0,
-                 "rank": 1, "judge_prompt_version": "1"},
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        metrics={
+            "recall_event_id": "r1",
+            "memory_id": "m1",
+            "relevance": 1.0,
+            "rank": 1,
+            "judge_prompt_version": "1",
+        },
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
-        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0,
-                 "rank": 1},
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0, "rank": 1},
     )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -983,17 +1110,24 @@ async def test_memory_quality_reports_judge_prompt_versions(db):
 # ── WS-1 A2: approvals dimension ─────────────────────────────────────────────
 
 
-async def _approval(db, aid, *, action_type="other", status=None,
-                    resolved_at=None, resolved_by=None):
+async def _approval(
+    db, aid, *, action_type="other", status=None, resolved_at=None, resolved_by=None
+):
     from genesis.db.crud import approval_requests as ar
 
     await ar.create(
-        db, id=aid, action_type=action_type, action_class="reversible",
+        db,
+        id=aid,
+        action_type=action_type,
+        action_class="reversible",
         description="d",
     )
     if status is not None:
         assert await ar.resolve(
-            db, aid, status=status, resolved_at=resolved_at,
+            db,
+            aid,
+            status=status,
+            resolved_at=resolved_at,
             resolved_by=resolved_by,
         )
 
@@ -1005,37 +1139,47 @@ async def test_compute_approvals_buckets(db):
 
     ts = "2026-06-05T12:00:00+00:00"
     # churn class: one human approve, one fail-closed system cancel
-    await _approval(db, "a1", action_type="autonomous_cli_fallback",
-                    status="approved", resolved_at=ts,
-                    resolved_by="telegram:button:1")
-    await _approval(db, "a2", action_type="autonomous_cli_fallback",
-                    status="cancelled", resolved_at=ts, resolved_by="system")
+    await _approval(
+        db,
+        "a1",
+        action_type="autonomous_cli_fallback",
+        status="approved",
+        resolved_at=ts,
+        resolved_by="telegram:button:1",
+    )
+    await _approval(
+        db,
+        "a2",
+        action_type="autonomous_cli_fallback",
+        status="cancelled",
+        resolved_at=ts,
+        resolved_by="system",
+    )
     # non-churn: explicit human denial (M12), timeout expiry, unknown resolver
-    await _approval(db, "a3", status="rejected", resolved_at=ts,
-                    resolved_by="telegram:bare_text:1")
-    await _approval(db, "a4", status="expired", resolved_at=ts,
-                    resolved_by="timeout_auto_expire")
-    await _approval(db, "a5", status="approved", resolved_at=ts,
-                    resolved_by="manual_stale_cleanup")
+    await _approval(db, "a3", status="rejected", resolved_at=ts, resolved_by="telegram:bare_text:1")
+    await _approval(db, "a4", status="expired", resolved_at=ts, resolved_by="timeout_auto_expire")
+    await _approval(db, "a5", status="approved", resolved_at=ts, resolved_by="manual_stale_cleanup")
     # still pending — resolved-population excludes it; pending_open gauge sees it
     await _approval(db, "a6")
 
     metrics, sample = await _compute_approvals(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 5
     assert metrics["total_created"] == 6
     assert metrics["total_resolved"] == 5
     assert metrics["churn_total"] == 2
     assert metrics["churn_excluded_total"] == 3
-    assert metrics["user_resolved"] == 2          # a1 + a3
+    assert metrics["user_resolved"] == 2  # a1 + a3
     assert metrics["user_resolved_rate"] == 0.4
     assert metrics["user_resolved_rate_excl_churn"] == pytest.approx(1 / 3, abs=1e-3)
-    assert metrics["auto_resolved"] == 2          # a2 + a4
+    assert metrics["auto_resolved"] == 2  # a2 + a4
     assert metrics["auto_expired"] == 1
     assert metrics["system_cancelled"] == 1
     assert metrics["rejection_count"] == 1
-    assert metrics["user_denied_count"] == 1      # M12: human reject
+    assert metrics["user_denied_count"] == 1  # M12: human reject
     assert metrics["unknown_resolver_count"] == 1
     assert metrics["unknown_resolver_values"] == ["manual_stale_cleanup"]
     assert metrics["pending_open"] == 1
@@ -1046,7 +1190,9 @@ async def test_compute_approvals_empty_window_is_null(db):
     from genesis.eval.j9_aggregator import _compute_approvals
 
     metrics, sample = await _compute_approvals(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 0
     assert metrics["user_resolved_rate"] is None
@@ -1061,20 +1207,30 @@ async def test_compute_approvals_mixed_resolved_at_formats(db):
     from genesis.eval.j9_aggregator import _compute_approvals
 
     # in-window, one of each format
-    await _approval(db, "b1", status="approved",
-                    resolved_at="2026-06-05 12:00:00",
-                    resolved_by="telegram:button:1")
-    await _approval(db, "b2", status="approved",
-                    resolved_at="2026-06-06T12:00:00+00:00",
-                    resolved_by="dashboard")
+    await _approval(
+        db,
+        "b1",
+        status="approved",
+        resolved_at="2026-06-05 12:00:00",
+        resolved_by="telegram:button:1",
+    )
+    await _approval(
+        db,
+        "b2",
+        status="approved",
+        resolved_at="2026-06-06T12:00:00+00:00",
+        resolved_by="dashboard",
+    )
     # space-format AFTER the until bound — lexicographic compare against
     # '2026-06-30T00:00:00+00:00' would wrongly include it (' ' < 'T')
-    await _approval(db, "b3", status="approved",
-                    resolved_at="2026-06-30 12:00:00",
-                    resolved_by="dashboard")
+    await _approval(
+        db, "b3", status="approved", resolved_at="2026-06-30 12:00:00", resolved_by="dashboard"
+    )
 
     metrics, _ = await _compute_approvals(
-        db, since="2026-06-01T00:00:00+00:00", until="2026-06-30T00:00:00+00:00",
+        db,
+        since="2026-06-01T00:00:00+00:00",
+        until="2026-06-30T00:00:00+00:00",
     )
     assert metrics["total_resolved"] == 2  # b3 excluded
     assert metrics["user_resolved"] == 2
@@ -1093,7 +1249,9 @@ async def test_compute_goal_completion_zero_terminal_is_null(db):
     await user_goals.create(db, title="g2", category="learning")
 
     metrics, sample = await _compute_goal_completion(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 2
     assert metrics["total_goals"] == 2
@@ -1114,10 +1272,15 @@ async def test_compute_goal_completion_rate(db):
     await user_goals.mark_abandoned(db, g2)
 
     metrics, _ = await _compute_goal_completion(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert metrics["by_status"] == {
-        "active": 1, "paused": 0, "achieved": 1, "abandoned": 1,
+        "active": 1,
+        "paused": 0,
+        "achieved": 1,
+        "abandoned": 1,
     }
     assert metrics["terminal_count"] == 2
     assert metrics["achieved_count"] == 1
@@ -1141,17 +1304,20 @@ async def test_compute_noise_passivity(db):
     # follow-ups: one stale-pending (leak), one completed
     await db.execute(
         "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
-        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)", (old,),
+        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)",
+        (old,),
     )
     await db.execute(
         "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
-        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)", (old,),
+        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)",
+        (old,),
     )
     # observation: unresolved, un-actuated, old → stale leak
     await db.execute(
         "INSERT INTO observations "
         "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
-        "VALUES ('o1','s','generic','c','medium',?,0,0,0)", (old,),
+        "VALUES ('o1','s','generic','c','medium',?,0,0,0)",
+        (old,),
     )
     # ego proposals: rejected + withdrawn (decision buckets window on
     # resolved_at, which the reject/table/withdraw transitions set) +
@@ -1159,26 +1325,32 @@ async def test_compute_noise_passivity(db):
     await db.execute(
         "INSERT INTO ego_proposals "
         "(id, action_type, content, status, created_at, resolved_at, realist_verdict) "
-        "VALUES ('p1','investigate','c','rejected',?,?,'amend')", (old, old),
+        "VALUES ('p1','investigate','c','rejected',?,?,'amend')",
+        (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at, resolved_at) "
-        "VALUES ('p2','outreach','c','withdrawn',?,?)", (old, old),
+        "VALUES ('p2','outreach','c','withdrawn',?,?)",
+        (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
-        "VALUES ('p3','maintenance','c','pending',?)", (old,),
+        "VALUES ('p3','maintenance','c','pending',?)",
+        (old,),
     )
     # ego cycles: 2 empty, 1 productive
     for cid, n in (("c1", 0), ("c2", 0), ("c3", 2)):
         await db.execute(
             "INSERT INTO ego_cycle_outcomes (cycle_id, focus_type, num_proposals, created_at) "
-            "VALUES (?, 'signal', ?, ?)", (cid, n, old),
+            "VALUES (?, 'signal', ?, ?)",
+            (cid, n, old),
         )
     await db.commit()
 
     metrics, sample = await _compute_noise_passivity(
-        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+        db,
+        since="2000-01-01T00:00:00+00:00",
+        until="2100-01-01T00:00:00+00:00",
     )
     assert metrics["stale_followups"] == 1
     assert metrics["followups_pending"] == 1
@@ -1201,7 +1373,9 @@ async def test_compute_noise_passivity_zero_cycles_is_null(db):
     from genesis.eval.j9_aggregator import _compute_noise_passivity
 
     metrics, _ = await _compute_noise_passivity(
-        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+        db,
+        since="2000-01-01T00:00:00+00:00",
+        until="2100-01-01T00:00:00+00:00",
     )
     assert metrics["empty_ego_cycle_pct"] is None
 
@@ -1218,9 +1392,18 @@ async def test_run_weekly_aggregation_writes_new_dimensions(db):
 
     results = await run_weekly_aggregation(db)
 
-    expected = {"memory", "system", "ego", "cognitive", "procedure",
-                "cognitive_drift", "approvals", "goals", "noise",
-                "dev_quality"}
+    expected = {
+        "memory",
+        "system",
+        "ego",
+        "cognitive",
+        "procedure",
+        "cognitive_drift",
+        "approvals",
+        "goals",
+        "noise",
+        "dev_quality",
+    }
     missing = expected - results.keys()
     assert not missing, f"dimensions failed silently: {missing}"
 
@@ -1254,10 +1437,12 @@ async def test_noise_decision_buckets_window_on_resolved_at(db):
     await db.commit()
 
     metrics, _ = await _compute_noise_passivity(
-        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+        db,
+        since="2000-01-01T00:00:00+00:00",
+        until="2100-01-01T00:00:00+00:00",
     )
-    assert metrics["rejected_count"] == 1       # pb1: decided in window
-    assert metrics["withdrawn_count"] == 0      # pb2: decided before window
+    assert metrics["rejected_count"] == 1  # pb1: decided in window
+    assert metrics["withdrawn_count"] == 0  # pb2: decided before window
     assert metrics["proposals_in_period"] == 0  # neither was CREATED in window
     assert metrics["rejected_by_action_type"] == {"investigate": 1}
 
@@ -1288,20 +1473,31 @@ async def test_compute_goal_completion_excludes_ego_goals(db):
 
     u1 = await user_goals.create(db, title="user g", category="project")
     e1 = await user_goals.create(
-        db, title="ego g", category="project", origin="genesis_ego",
+        db,
+        title="ego g",
+        category="project",
+        origin="genesis_ego",
     )
     await user_goals.create(
-        db, title="ego g2", category="project", origin="genesis_ego",
+        db,
+        title="ego g2",
+        category="project",
+        origin="genesis_ego",
     )
     await user_goals.mark_achieved(db, u1)
     await user_goals.mark_achieved(db, e1)
 
     metrics, sample = await _compute_goal_completion(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 1  # the user goal only
     assert metrics["total_goals"] == 1
     assert metrics["by_status"] == {
-        "active": 0, "paused": 0, "achieved": 1, "abandoned": 0,
+        "active": 0,
+        "paused": 0,
+        "achieved": 1,
+        "abandoned": 0,
     }
     assert metrics["achieved_count"] == 1

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -46,26 +46,20 @@ async def test_update_event_metrics_merges_in_place(db):
     """update_event_metrics enriches an existing event's metrics without
     creating a second row (audit MEM-003: one recall_fired per logical recall)."""
     eid = await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
+        db, dimension="memory", event_type="recall_fired",
         metrics={"query": "q", "result_count": 1},
     )
     updated = await j9_eval.update_event_metrics(
-        db,
-        eid,
-        result_count=5,
-        mode="auto",
-        pipeline_used="standard",
+        db, eid, result_count=5, mode="auto", pipeline_used="standard",
     )
     assert updated is True
 
     events = await j9_eval.get_events(db, event_type="recall_fired")
     assert len(events) == 1  # merged in place, NOT a second event
     m = events[0]["metrics"]
-    assert m["query"] == "q"  # pre-existing field preserved
-    assert m["result_count"] == 5  # overwritten
-    assert m["mode"] == "auto"  # new field added
+    assert m["query"] == "q"          # pre-existing field preserved
+    assert m["result_count"] == 5      # overwritten
+    assert m["mode"] == "auto"         # new field added
     assert m["pipeline_used"] == "standard"
 
 
@@ -84,17 +78,13 @@ async def test_recall_entrenchment_aggregates(db):
 
     for corr, rc, age in [(0.8, 5.0, 10.0), (0.6, 3.0, 20.0)]:
         await j9_eval.insert_event(
-            db,
-            dimension="memory",
-            event_type="recall_fired",
-            metrics={"entrenchment_corr": corr, "mean_retrieved_count": rc, "mean_age_days": age},
+            db, dimension="memory", event_type="recall_fired",
+            metrics={"entrenchment_corr": corr,
+                     "mean_retrieved_count": rc, "mean_age_days": age},
         )
     # An older-style event without entrenchment fields must not skew the means.
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
-        metrics={"query": "q"},
+        db, dimension="memory", event_type="recall_fired", metrics={"query": "q"},
     )
 
     result = await _recall_entrenchment(db, since="2000-01-01", until="2099-01-01")
@@ -110,17 +100,13 @@ async def test_memory_quality_includes_entrenchment_when_no_relevance(db):
     from genesis.eval.j9_aggregator import _compute_memory_quality
 
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
+        db, dimension="memory", event_type="recall_fired",
         metrics={"entrenchment_corr": 0.5, "mean_retrieved_count": 2.0},
     )
     metrics, sample = await _compute_memory_quality(
-        db,
-        since="2000-01-01",
-        until="2099-01-01",
+        db, since="2000-01-01", until="2099-01-01",
     )
-    assert metrics["precision_at_5"] is None  # no relevance events
+    assert metrics["precision_at_5"] is None      # no relevance events
     assert metrics["entrenchment_corr_mean"] == pytest.approx(0.5)
     assert metrics["entrenchment_sample"] == 1
 
@@ -340,18 +326,12 @@ async def test_count_events(db):
 
 async def test_get_events_with_session_filter(db):
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
-        metrics={},
-        session_id="sess-A",
+        db, dimension="memory", event_type="recall_fired",
+        metrics={}, session_id="sess-A",
     )
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_fired",
-        metrics={},
-        session_id="sess-B",
+        db, dimension="memory", event_type="recall_fired",
+        metrics={}, session_id="sess-B",
     )
     results = await j9_eval.get_events(db, session_id="sess-A")
     assert len(results) == 1
@@ -483,9 +463,7 @@ async def test_emit_proposal_resolved_survives_db_error():
     bad_db = AsyncMock(spec=["execute", "commit"])
     bad_db.execute.side_effect = Exception("kaboom")
     await emit_proposal_resolved(
-        bad_db,
-        proposal_id="x",
-        status="approved",
+        bad_db, proposal_id="x", status="approved",
     )
 
 
@@ -721,12 +699,8 @@ async def test_grade_reflection_from_observations(db):
             "INSERT INTO observations (id, type, source, content, priority, "
             "created_at, influenced_action) VALUES (?, ?, 'ego_cycle', 'test', "
             "'medium', ?, ?)",
-            (
-                f"obs-{i}",
-                ["task_detected", "pattern", "insight"][i % 3],
-                "2026-05-05T12:00:00Z",
-                1 if i < 10 else 0,
-            ),
+            (f"obs-{i}", ["task_detected", "pattern", "insight"][i % 3],
+             "2026-05-05T12:00:00Z", 1 if i < 10 else 0),
         )
     await db.commit()
 
@@ -807,22 +781,16 @@ async def test_memory_quality_ignores_duplicate_relevance(db):
     # (without dedup it would be 2/3 = 0.667).
     for rel in (1.0, 1.0):
         await j9_eval.insert_event(
-            db,
-            dimension="memory",
-            event_type="recall_relevance",
+            db, dimension="memory", event_type="recall_relevance",
             metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": rel},
         )
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
+        db, dimension="memory", event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0},
     )
 
     metrics, total_recalls = await _compute_memory_quality(
-        db,
-        since="2000-01-01",
-        until="2100-01-01",
+        db, since="2000-01-01", until="2100-01-01",
     )
     assert total_recalls == 1
     assert metrics["precision_at_5"] == 0.5
@@ -841,21 +809,15 @@ async def test_memory_quality_mrr_uses_stored_rank_not_insert_order(db):
 
     # Out of rank order: rank-1 (irrelevant) first … rank-3 (relevant) last.
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
+        db, dimension="memory", event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 0.0, "rank": 1},
     )
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
+        db, dimension="memory", event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0, "rank": 2},
     )
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
+        db, dimension="memory", event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m3", "relevance": 1.0, "rank": 3},
     )
 
@@ -895,44 +857,28 @@ async def test_insert_run_persists_metadata_json_per_result(db):
 
     detail = _json.dumps({"judge_model": "x", "judge_score": 0.7, "rationale": "ok"})
     summary = EvalRunSummary(
-        run_id="run_meta_1",
-        model_id="m",
-        model_profile="p",
-        dataset="d",
-        trigger=EvalTrigger.MANUAL,
-        task_category=TaskCategory.CLASSIFICATION,
-        total_cases=2,
-        passed_cases=2,
-        failed_cases=0,
+        run_id="run_meta_1", model_id="m", model_profile="p", dataset="d",
+        trigger=EvalTrigger.MANUAL, task_category=TaskCategory.CLASSIFICATION,
+        total_cases=2, passed_cases=2, failed_cases=0,
         results=[
             ScoredOutput(
-                case_id="c1",
-                passed=True,
-                score=0.7,
-                actual_output="out",
-                scorer_type=ScorerType.LLM_JUDGE,
-                scorer_detail=detail,
+                case_id="c1", passed=True, score=0.7, actual_output="out",
+                scorer_type=ScorerType.LLM_JUDGE, scorer_detail=detail,
             ),
             # Non-judge scorer: scorer_detail is a plain (non-JSON) string, so
             # metadata_json (the queryable JSON view) must be NULL, not that string.
             ScoredOutput(
-                case_id="c2",
-                passed=True,
-                score=1.0,
-                actual_output="3",
-                scorer_type=ScorerType.EXACT_MATCH,
-                scorer_detail="expected=3, got=3",
+                case_id="c2", passed=True, score=1.0, actual_output="3",
+                scorer_type=ScorerType.EXACT_MATCH, scorer_detail="expected=3, got=3",
             ),
         ],
     )
     await eval_db.insert_run(db, summary)
     rows = {
         r[0]: r[1]
-        for r in await (
-            await db.execute(
-                "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
-            )
-        ).fetchall()
+        for r in await (await db.execute(
+            "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
+        )).fetchall()
     }
     assert rows["c1"] == detail  # judge result → JSON dual-write
     assert rows["c2"] is None  # non-judge result → NULL (not the plain string)
@@ -948,15 +894,9 @@ async def test_memory_quality_precision_at_3(db):
 
     for rank, rel in enumerate((1.0, 0.0, 1.0, 0.0, 1.0), 1):
         await j9_eval.insert_event(
-            db,
-            dimension="memory",
-            event_type="recall_relevance",
-            metrics={
-                "recall_event_id": "r1",
-                "memory_id": f"m{rank}",
-                "relevance": rel,
-                "rank": rank,
-            },
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
+                     "relevance": rel, "rank": rank},
         )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -972,15 +912,9 @@ async def test_memory_quality_precision_at_3_fewer_than_three(db):
 
     for rank, rel in ((1, 1.0), (2, 0.0)):
         await j9_eval.insert_event(
-            db,
-            dimension="memory",
-            event_type="recall_relevance",
-            metrics={
-                "recall_event_id": "r1",
-                "memory_id": f"m{rank}",
-                "relevance": rel,
-                "rank": rank,
-            },
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
+                     "relevance": rel, "rank": rank},
         )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -994,21 +928,14 @@ async def test_memory_quality_truncates_to_top5(db):
 
     for rank in range(1, 6):
         await j9_eval.insert_event(
-            db,
-            dimension="memory",
-            event_type="recall_relevance",
-            metrics={
-                "recall_event_id": "r1",
-                "memory_id": f"m{rank}",
-                "relevance": 0.0,
-                "rank": rank,
-            },
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
+                     "relevance": 0.0, "rank": rank},
         )
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
-        metrics={"recall_event_id": "r1", "memory_id": "m6", "relevance": 1.0, "rank": 6},
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m6",
+                 "relevance": 1.0, "rank": 6},
     )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -1023,9 +950,7 @@ async def test_precision_at_3_skips_unranked_recalls(db):
 
     for i, rel in enumerate((1.0, 0.0, 1.0, 0.0), 1):
         await j9_eval.insert_event(
-            db,
-            dimension="memory",
-            event_type="recall_relevance",
+            db, dimension="memory", event_type="recall_relevance",
             metrics={"recall_event_id": "r1", "memory_id": f"m{i}", "relevance": rel},
         )
 
@@ -1041,22 +966,14 @@ async def test_memory_quality_reports_judge_prompt_versions(db):
     from genesis.eval.j9_aggregator import _compute_memory_quality
 
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
-        metrics={
-            "recall_event_id": "r1",
-            "memory_id": "m1",
-            "relevance": 1.0,
-            "rank": 1,
-            "judge_prompt_version": "1",
-        },
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 1.0,
+                 "rank": 1, "judge_prompt_version": "1"},
     )
     await j9_eval.insert_event(
-        db,
-        dimension="memory",
-        event_type="recall_relevance",
-        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0, "rank": 1},
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0,
+                 "rank": 1},
     )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -1066,24 +983,17 @@ async def test_memory_quality_reports_judge_prompt_versions(db):
 # ── WS-1 A2: approvals dimension ─────────────────────────────────────────────
 
 
-async def _approval(
-    db, aid, *, action_type="other", status=None, resolved_at=None, resolved_by=None
-):
+async def _approval(db, aid, *, action_type="other", status=None,
+                    resolved_at=None, resolved_by=None):
     from genesis.db.crud import approval_requests as ar
 
     await ar.create(
-        db,
-        id=aid,
-        action_type=action_type,
-        action_class="reversible",
+        db, id=aid, action_type=action_type, action_class="reversible",
         description="d",
     )
     if status is not None:
         assert await ar.resolve(
-            db,
-            aid,
-            status=status,
-            resolved_at=resolved_at,
+            db, aid, status=status, resolved_at=resolved_at,
             resolved_by=resolved_by,
         )
 
@@ -1095,47 +1005,37 @@ async def test_compute_approvals_buckets(db):
 
     ts = "2026-06-05T12:00:00+00:00"
     # churn class: one human approve, one fail-closed system cancel
-    await _approval(
-        db,
-        "a1",
-        action_type="autonomous_cli_fallback",
-        status="approved",
-        resolved_at=ts,
-        resolved_by="telegram:button:1",
-    )
-    await _approval(
-        db,
-        "a2",
-        action_type="autonomous_cli_fallback",
-        status="cancelled",
-        resolved_at=ts,
-        resolved_by="system",
-    )
+    await _approval(db, "a1", action_type="autonomous_cli_fallback",
+                    status="approved", resolved_at=ts,
+                    resolved_by="telegram:button:1")
+    await _approval(db, "a2", action_type="autonomous_cli_fallback",
+                    status="cancelled", resolved_at=ts, resolved_by="system")
     # non-churn: explicit human denial (M12), timeout expiry, unknown resolver
-    await _approval(db, "a3", status="rejected", resolved_at=ts, resolved_by="telegram:bare_text:1")
-    await _approval(db, "a4", status="expired", resolved_at=ts, resolved_by="timeout_auto_expire")
-    await _approval(db, "a5", status="approved", resolved_at=ts, resolved_by="manual_stale_cleanup")
+    await _approval(db, "a3", status="rejected", resolved_at=ts,
+                    resolved_by="telegram:bare_text:1")
+    await _approval(db, "a4", status="expired", resolved_at=ts,
+                    resolved_by="timeout_auto_expire")
+    await _approval(db, "a5", status="approved", resolved_at=ts,
+                    resolved_by="manual_stale_cleanup")
     # still pending — resolved-population excludes it; pending_open gauge sees it
     await _approval(db, "a6")
 
     metrics, sample = await _compute_approvals(
-        db,
-        since="2000-01-01",
-        until="2100-01-01",
+        db, since="2000-01-01", until="2100-01-01",
     )
     assert sample == 5
     assert metrics["total_created"] == 6
     assert metrics["total_resolved"] == 5
     assert metrics["churn_total"] == 2
     assert metrics["churn_excluded_total"] == 3
-    assert metrics["user_resolved"] == 2  # a1 + a3
+    assert metrics["user_resolved"] == 2          # a1 + a3
     assert metrics["user_resolved_rate"] == 0.4
     assert metrics["user_resolved_rate_excl_churn"] == pytest.approx(1 / 3, abs=1e-3)
-    assert metrics["auto_resolved"] == 2  # a2 + a4
+    assert metrics["auto_resolved"] == 2          # a2 + a4
     assert metrics["auto_expired"] == 1
     assert metrics["system_cancelled"] == 1
     assert metrics["rejection_count"] == 1
-    assert metrics["user_denied_count"] == 1  # M12: human reject
+    assert metrics["user_denied_count"] == 1      # M12: human reject
     assert metrics["unknown_resolver_count"] == 1
     assert metrics["unknown_resolver_values"] == ["manual_stale_cleanup"]
     assert metrics["pending_open"] == 1
@@ -1146,9 +1046,7 @@ async def test_compute_approvals_empty_window_is_null(db):
     from genesis.eval.j9_aggregator import _compute_approvals
 
     metrics, sample = await _compute_approvals(
-        db,
-        since="2000-01-01",
-        until="2100-01-01",
+        db, since="2000-01-01", until="2100-01-01",
     )
     assert sample == 0
     assert metrics["user_resolved_rate"] is None
@@ -1163,30 +1061,20 @@ async def test_compute_approvals_mixed_resolved_at_formats(db):
     from genesis.eval.j9_aggregator import _compute_approvals
 
     # in-window, one of each format
-    await _approval(
-        db,
-        "b1",
-        status="approved",
-        resolved_at="2026-06-05 12:00:00",
-        resolved_by="telegram:button:1",
-    )
-    await _approval(
-        db,
-        "b2",
-        status="approved",
-        resolved_at="2026-06-06T12:00:00+00:00",
-        resolved_by="dashboard",
-    )
+    await _approval(db, "b1", status="approved",
+                    resolved_at="2026-06-05 12:00:00",
+                    resolved_by="telegram:button:1")
+    await _approval(db, "b2", status="approved",
+                    resolved_at="2026-06-06T12:00:00+00:00",
+                    resolved_by="dashboard")
     # space-format AFTER the until bound — lexicographic compare against
     # '2026-06-30T00:00:00+00:00' would wrongly include it (' ' < 'T')
-    await _approval(
-        db, "b3", status="approved", resolved_at="2026-06-30 12:00:00", resolved_by="dashboard"
-    )
+    await _approval(db, "b3", status="approved",
+                    resolved_at="2026-06-30 12:00:00",
+                    resolved_by="dashboard")
 
     metrics, _ = await _compute_approvals(
-        db,
-        since="2026-06-01T00:00:00+00:00",
-        until="2026-06-30T00:00:00+00:00",
+        db, since="2026-06-01T00:00:00+00:00", until="2026-06-30T00:00:00+00:00",
     )
     assert metrics["total_resolved"] == 2  # b3 excluded
     assert metrics["user_resolved"] == 2
@@ -1205,9 +1093,7 @@ async def test_compute_goal_completion_zero_terminal_is_null(db):
     await user_goals.create(db, title="g2", category="learning")
 
     metrics, sample = await _compute_goal_completion(
-        db,
-        since="2000-01-01",
-        until="2100-01-01",
+        db, since="2000-01-01", until="2100-01-01",
     )
     assert sample == 2
     assert metrics["total_goals"] == 2
@@ -1228,15 +1114,10 @@ async def test_compute_goal_completion_rate(db):
     await user_goals.mark_abandoned(db, g2)
 
     metrics, _ = await _compute_goal_completion(
-        db,
-        since="2000-01-01",
-        until="2100-01-01",
+        db, since="2000-01-01", until="2100-01-01",
     )
     assert metrics["by_status"] == {
-        "active": 1,
-        "paused": 0,
-        "achieved": 1,
-        "abandoned": 1,
+        "active": 1, "paused": 0, "achieved": 1, "abandoned": 1,
     }
     assert metrics["terminal_count"] == 2
     assert metrics["achieved_count"] == 1
@@ -1260,20 +1141,17 @@ async def test_compute_noise_passivity(db):
     # follow-ups: one stale-pending (leak), one completed
     await db.execute(
         "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
-        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)",
-        (old,),
+        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)", (old,),
     )
     await db.execute(
         "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
-        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)",
-        (old,),
+        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)", (old,),
     )
     # observation: unresolved, un-actuated, old → stale leak
     await db.execute(
         "INSERT INTO observations "
         "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
-        "VALUES ('o1','s','generic','c','medium',?,0,0,0)",
-        (old,),
+        "VALUES ('o1','s','generic','c','medium',?,0,0,0)", (old,),
     )
     # ego proposals: rejected + withdrawn (decision buckets window on
     # resolved_at, which the reject/table/withdraw transitions set) +
@@ -1281,32 +1159,26 @@ async def test_compute_noise_passivity(db):
     await db.execute(
         "INSERT INTO ego_proposals "
         "(id, action_type, content, status, created_at, resolved_at, realist_verdict) "
-        "VALUES ('p1','investigate','c','rejected',?,?,'amend')",
-        (old, old),
+        "VALUES ('p1','investigate','c','rejected',?,?,'amend')", (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at, resolved_at) "
-        "VALUES ('p2','outreach','c','withdrawn',?,?)",
-        (old, old),
+        "VALUES ('p2','outreach','c','withdrawn',?,?)", (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
-        "VALUES ('p3','maintenance','c','pending',?)",
-        (old,),
+        "VALUES ('p3','maintenance','c','pending',?)", (old,),
     )
     # ego cycles: 2 empty, 1 productive
     for cid, n in (("c1", 0), ("c2", 0), ("c3", 2)):
         await db.execute(
             "INSERT INTO ego_cycle_outcomes (cycle_id, focus_type, num_proposals, created_at) "
-            "VALUES (?, 'signal', ?, ?)",
-            (cid, n, old),
+            "VALUES (?, 'signal', ?, ?)", (cid, n, old),
         )
     await db.commit()
 
     metrics, sample = await _compute_noise_passivity(
-        db,
-        since="2000-01-01T00:00:00+00:00",
-        until="2100-01-01T00:00:00+00:00",
+        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
     )
     assert metrics["stale_followups"] == 1
     assert metrics["followups_pending"] == 1
@@ -1329,9 +1201,7 @@ async def test_compute_noise_passivity_zero_cycles_is_null(db):
     from genesis.eval.j9_aggregator import _compute_noise_passivity
 
     metrics, _ = await _compute_noise_passivity(
-        db,
-        since="2000-01-01T00:00:00+00:00",
-        until="2100-01-01T00:00:00+00:00",
+        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
     )
     assert metrics["empty_ego_cycle_pct"] is None
 
@@ -1348,18 +1218,9 @@ async def test_run_weekly_aggregation_writes_new_dimensions(db):
 
     results = await run_weekly_aggregation(db)
 
-    expected = {
-        "memory",
-        "system",
-        "ego",
-        "cognitive",
-        "procedure",
-        "cognitive_drift",
-        "approvals",
-        "goals",
-        "noise",
-        "dev_quality",
-    }
+    expected = {"memory", "system", "ego", "cognitive", "procedure",
+                "cognitive_drift", "approvals", "goals", "noise",
+                "dev_quality"}
     missing = expected - results.keys()
     assert not missing, f"dimensions failed silently: {missing}"
 
@@ -1393,12 +1254,10 @@ async def test_noise_decision_buckets_window_on_resolved_at(db):
     await db.commit()
 
     metrics, _ = await _compute_noise_passivity(
-        db,
-        since="2000-01-01T00:00:00+00:00",
-        until="2100-01-01T00:00:00+00:00",
+        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
     )
-    assert metrics["rejected_count"] == 1  # pb1: decided in window
-    assert metrics["withdrawn_count"] == 0  # pb2: decided before window
+    assert metrics["rejected_count"] == 1       # pb1: decided in window
+    assert metrics["withdrawn_count"] == 0      # pb2: decided before window
     assert metrics["proposals_in_period"] == 0  # neither was CREATED in window
     assert metrics["rejected_by_action_type"] == {"investigate": 1}
 
@@ -1429,31 +1288,20 @@ async def test_compute_goal_completion_excludes_ego_goals(db):
 
     u1 = await user_goals.create(db, title="user g", category="project")
     e1 = await user_goals.create(
-        db,
-        title="ego g",
-        category="project",
-        origin="genesis_ego",
+        db, title="ego g", category="project", origin="genesis_ego",
     )
     await user_goals.create(
-        db,
-        title="ego g2",
-        category="project",
-        origin="genesis_ego",
+        db, title="ego g2", category="project", origin="genesis_ego",
     )
     await user_goals.mark_achieved(db, u1)
     await user_goals.mark_achieved(db, e1)
 
     metrics, sample = await _compute_goal_completion(
-        db,
-        since="2000-01-01",
-        until="2100-01-01",
+        db, since="2000-01-01", until="2100-01-01",
     )
     assert sample == 1  # the user goal only
     assert metrics["total_goals"] == 1
     assert metrics["by_status"] == {
-        "active": 0,
-        "paused": 0,
-        "achieved": 1,
-        "abandoned": 0,
+        "active": 0, "paused": 0, "achieved": 1, "abandoned": 0,
     }
     assert metrics["achieved_count"] == 1

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -222,6 +222,97 @@ async def test_memory_quality_pool_failure_degrades_to_none(db, monkeypatch):
     assert "precision_at_5" in metrics  # quality series intact
 
 
+# ── WS2-0: retrieval-efficacy readers (j9_eval_status trend + memory_stats) ───
+
+
+def test_retrieval_trend_chronological_and_none_tolerant():
+    """Newest-first snapshots become an oldest-first trend; a pre-WS2-0 snapshot
+    (no pool_* keys) yields explicit None, never a KeyError or fabricated value."""
+    from genesis.mcp.health.j9_eval import _retrieval_trend
+
+    snaps = [  # DESC (newest-first), as get_snapshots returns
+        {
+            "period_end": "2026-07-17",
+            "metrics": {"precision_at_5": 0.8, "hit_rate": 0.7, "pool_episodic_total": 55000},
+        },
+        {"period_end": "2026-07-10", "metrics": {"precision_at_5": 0.6}},  # pre-WS2-0
+    ]
+    trend = _retrieval_trend(snaps)
+    assert [r["period_end"] for r in trend] == ["2026-07-10", "2026-07-17"]
+    assert trend[0]["pool_episodic_total"] is None  # older snapshot → honest gap
+    assert trend[1]["pool_episodic_total"] == 55000
+    assert trend[1]["hit_rate"] == 0.7
+
+
+def test_retrieval_trend_empty():
+    from genesis.mcp.health.j9_eval import _retrieval_trend
+
+    assert _retrieval_trend([]) == []
+
+
+async def test_memory_quality_block_joins_snapshot_and_grade(db):
+    """_memory_quality_block returns the latest memory snapshot headline joined
+    to the memory subsystem grade — capacity and quality on one surface."""
+    from genesis.mcp.memory.core import _memory_quality_block
+
+    await j9_eval.insert_snapshot(
+        db,
+        period_start="2026-07-10",
+        period_end="2026-07-17",
+        period_type="weekly",
+        dimension="memory",
+        metrics={
+            "precision_at_5": 0.82,
+            "hit_rate": 0.75,
+            "mrr": 0.6,
+            "total_recalls": 40,
+            "pool_episodic_total": 55000,
+            "pool_knowledge_units_total": 3900,
+        },
+        sample_count=40,
+    )
+    await j9_eval.insert_subsystem_grade(
+        db,
+        period_start="2026-07-10",
+        period_end="2026-07-17",
+        period_type="weekly",
+        subsystem="memory",
+        grade="B",
+        score=0.82,
+        factors={},
+        sample_count=40,
+    )
+    block = await _memory_quality_block(db)
+    assert block["precision_at_5"] == 0.82
+    assert block["pool_episodic_total"] == 55000
+    assert block["grade"] == "B"
+    assert block["grade_score"] == 0.82
+
+
+async def test_memory_quality_block_grade_missing_is_none(db):
+    """A snapshot with no grade row still returns the headline; grade is None."""
+    from genesis.mcp.memory.core import _memory_quality_block
+
+    await j9_eval.insert_snapshot(
+        db,
+        period_start="2026-07-10",
+        period_end="2026-07-17",
+        period_type="weekly",
+        dimension="memory",
+        metrics={"precision_at_5": 0.5},
+        sample_count=1,
+    )
+    block = await _memory_quality_block(db)
+    assert block["precision_at_5"] == 0.5
+    assert block["grade"] is None
+
+
+async def test_memory_quality_block_none_when_no_snapshot(db):
+    from genesis.mcp.memory.core import _memory_quality_block
+
+    assert await _memory_quality_block(db) is None
+
+
 async def test_get_events_filter_by_type(db):
     await j9_eval.insert_event(db, dimension="memory", event_type="recall_fired", metrics={})
     await j9_eval.insert_event(db, dimension="memory", event_type="recall_relevance", metrics={})

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -46,20 +46,26 @@ async def test_update_event_metrics_merges_in_place(db):
     """update_event_metrics enriches an existing event's metrics without
     creating a second row (audit MEM-003: one recall_fired per logical recall)."""
     eid = await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
         metrics={"query": "q", "result_count": 1},
     )
     updated = await j9_eval.update_event_metrics(
-        db, eid, result_count=5, mode="auto", pipeline_used="standard",
+        db,
+        eid,
+        result_count=5,
+        mode="auto",
+        pipeline_used="standard",
     )
     assert updated is True
 
     events = await j9_eval.get_events(db, event_type="recall_fired")
     assert len(events) == 1  # merged in place, NOT a second event
     m = events[0]["metrics"]
-    assert m["query"] == "q"          # pre-existing field preserved
-    assert m["result_count"] == 5      # overwritten
-    assert m["mode"] == "auto"         # new field added
+    assert m["query"] == "q"  # pre-existing field preserved
+    assert m["result_count"] == 5  # overwritten
+    assert m["mode"] == "auto"  # new field added
     assert m["pipeline_used"] == "standard"
 
 
@@ -78,13 +84,17 @@ async def test_recall_entrenchment_aggregates(db):
 
     for corr, rc, age in [(0.8, 5.0, 10.0), (0.6, 3.0, 20.0)]:
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_fired",
-            metrics={"entrenchment_corr": corr,
-                     "mean_retrieved_count": rc, "mean_age_days": age},
+            db,
+            dimension="memory",
+            event_type="recall_fired",
+            metrics={"entrenchment_corr": corr, "mean_retrieved_count": rc, "mean_age_days": age},
         )
     # An older-style event without entrenchment fields must not skew the means.
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired", metrics={"query": "q"},
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        metrics={"query": "q"},
     )
 
     result = await _recall_entrenchment(db, since="2000-01-01", until="2099-01-01")
@@ -100,15 +110,116 @@ async def test_memory_quality_includes_entrenchment_when_no_relevance(db):
     from genesis.eval.j9_aggregator import _compute_memory_quality
 
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
         metrics={"entrenchment_corr": 0.5, "mean_retrieved_count": 2.0},
     )
     metrics, sample = await _compute_memory_quality(
-        db, since="2000-01-01", until="2099-01-01",
+        db,
+        since="2000-01-01",
+        until="2099-01-01",
     )
-    assert metrics["precision_at_5"] is None      # no relevance events
+    assert metrics["precision_at_5"] is None  # no relevance events
     assert metrics["entrenchment_corr_mean"] == pytest.approx(0.5)
     assert metrics["entrenchment_sample"] == 1
+
+
+# ── WS2-0: pool-size counts stamped onto the weekly memory snapshot ───────────
+
+
+async def _seed_memory_row(db, memory_id, collection, embedding_status="embedded"):
+    await db.execute(
+        "INSERT INTO memory_metadata "
+        "(memory_id, created_at, collection, embedding_status) VALUES (?, ?, ?, ?)",
+        (memory_id, "2026-07-17T00:00:00Z", collection, embedding_status),
+    )
+    await db.commit()
+
+
+async def test_pool_size_counts_splits_episodic_by_collection(db):
+    """Episodic is counted by collection — a knowledge_base row in
+    memory_metadata must NOT inflate the episodic pool — and embedded is a
+    distinct sub-count. Delta-based to tolerate any seed rows."""
+    from genesis.db.crud import memory as memory_crud
+
+    base = await memory_crud.pool_size_counts(db)
+    await _seed_memory_row(db, "ep-1", "episodic_memory", "embedded")
+    await _seed_memory_row(db, "ep-2", "episodic_memory", "fts5_only")
+    await _seed_memory_row(db, "kb-1", "knowledge_base", "embedded")
+
+    counts = await memory_crud.pool_size_counts(db)
+    assert counts["pool_episodic_total"] - base["pool_episodic_total"] == 2
+    assert counts["pool_episodic_embedded"] - base["pool_episodic_embedded"] == 1
+
+
+async def test_pool_size_counts_knowledge_units_and_links(db):
+    from genesis.db.crud import memory as memory_crud
+
+    base = await memory_crud.pool_size_counts(db)
+    await db.execute(
+        "INSERT INTO knowledge_units "
+        "(id, project_type, domain, source_doc, concept, body, ingested_at) "
+        "VALUES ('ku-1','p','d','s','c','b','2026-07-17T00:00:00Z')",
+    )
+    await db.execute(
+        "INSERT INTO memory_links "
+        "(source_id, target_id, link_type, strength, created_at) "
+        "VALUES ('a','b','related_to',0.5,'2026-07-17T00:00:00Z')",
+    )
+    await db.commit()
+
+    counts = await memory_crud.pool_size_counts(db)
+    assert counts["pool_knowledge_units_total"] - base["pool_knowledge_units_total"] == 1
+    assert counts["pool_memory_links_total"] - base["pool_memory_links_total"] == 1
+
+
+async def test_pool_count_keys_match_output(db):
+    """POOL_COUNT_KEYS must be the exact key set pool_size_counts emits — the
+    aggregator's None-fallback keys are derived from it and must not drift."""
+    from genesis.db.crud import memory as memory_crud
+
+    counts = await memory_crud.pool_size_counts(db)
+    assert set(counts) == set(memory_crud.POOL_COUNT_KEYS)
+
+
+async def test_memory_quality_includes_pool_counts_on_early_return(db):
+    """The no-relevance early-return path still carries the pool_* keys, so the
+    trend series shape is stable from the first (empty) week onward."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    await _seed_memory_row(db, "ep-1", "episodic_memory")
+    metrics, _ = await _compute_memory_quality(
+        db,
+        since="2000-01-01",
+        until="2099-01-01",
+    )
+    assert metrics["precision_at_5"] is None
+    from genesis.db.crud import memory as memory_crud
+
+    for key in memory_crud.POOL_COUNT_KEYS:
+        assert key in metrics
+    assert metrics["pool_episodic_total"] >= 1
+
+
+async def test_memory_quality_pool_failure_degrades_to_none(db, monkeypatch):
+    """A pool-count failure degrades to None-valued pool keys WITHOUT losing the
+    quality metrics — the pool read is strictly additive."""
+    from genesis.db.crud import memory as memory_crud
+    from genesis.eval import j9_aggregator
+
+    async def _boom(_db):
+        raise RuntimeError("pool count blew up")
+
+    monkeypatch.setattr(memory_crud, "pool_size_counts", _boom)
+    metrics, _ = await j9_aggregator._compute_memory_quality(
+        db,
+        since="2000-01-01",
+        until="2099-01-01",
+    )
+    for key in memory_crud.POOL_COUNT_KEYS:
+        assert metrics[key] is None
+    assert "precision_at_5" in metrics  # quality series intact
 
 
 async def test_get_events_filter_by_type(db):
@@ -138,12 +249,18 @@ async def test_count_events(db):
 
 async def test_get_events_with_session_filter(db):
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
-        metrics={}, session_id="sess-A",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        metrics={},
+        session_id="sess-A",
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_fired",
-        metrics={}, session_id="sess-B",
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        metrics={},
+        session_id="sess-B",
     )
     results = await j9_eval.get_events(db, session_id="sess-A")
     assert len(results) == 1
@@ -275,7 +392,9 @@ async def test_emit_proposal_resolved_survives_db_error():
     bad_db = AsyncMock(spec=["execute", "commit"])
     bad_db.execute.side_effect = Exception("kaboom")
     await emit_proposal_resolved(
-        bad_db, proposal_id="x", status="approved",
+        bad_db,
+        proposal_id="x",
+        status="approved",
     )
 
 
@@ -511,8 +630,12 @@ async def test_grade_reflection_from_observations(db):
             "INSERT INTO observations (id, type, source, content, priority, "
             "created_at, influenced_action) VALUES (?, ?, 'ego_cycle', 'test', "
             "'medium', ?, ?)",
-            (f"obs-{i}", ["task_detected", "pattern", "insight"][i % 3],
-             "2026-05-05T12:00:00Z", 1 if i < 10 else 0),
+            (
+                f"obs-{i}",
+                ["task_detected", "pattern", "insight"][i % 3],
+                "2026-05-05T12:00:00Z",
+                1 if i < 10 else 0,
+            ),
         )
     await db.commit()
 
@@ -593,16 +716,22 @@ async def test_memory_quality_ignores_duplicate_relevance(db):
     # (without dedup it would be 2/3 = 0.667).
     for rel in (1.0, 1.0):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
             metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": rel},
         )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0},
     )
 
     metrics, total_recalls = await _compute_memory_quality(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert total_recalls == 1
     assert metrics["precision_at_5"] == 0.5
@@ -621,15 +750,21 @@ async def test_memory_quality_mrr_uses_stored_rank_not_insert_order(db):
 
     # Out of rank order: rank-1 (irrelevant) first … rank-3 (relevant) last.
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 0.0, "rank": 1},
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0, "rank": 2},
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
         metrics={"recall_event_id": "r1", "memory_id": "m3", "relevance": 1.0, "rank": 3},
     )
 
@@ -669,28 +804,44 @@ async def test_insert_run_persists_metadata_json_per_result(db):
 
     detail = _json.dumps({"judge_model": "x", "judge_score": 0.7, "rationale": "ok"})
     summary = EvalRunSummary(
-        run_id="run_meta_1", model_id="m", model_profile="p", dataset="d",
-        trigger=EvalTrigger.MANUAL, task_category=TaskCategory.CLASSIFICATION,
-        total_cases=2, passed_cases=2, failed_cases=0,
+        run_id="run_meta_1",
+        model_id="m",
+        model_profile="p",
+        dataset="d",
+        trigger=EvalTrigger.MANUAL,
+        task_category=TaskCategory.CLASSIFICATION,
+        total_cases=2,
+        passed_cases=2,
+        failed_cases=0,
         results=[
             ScoredOutput(
-                case_id="c1", passed=True, score=0.7, actual_output="out",
-                scorer_type=ScorerType.LLM_JUDGE, scorer_detail=detail,
+                case_id="c1",
+                passed=True,
+                score=0.7,
+                actual_output="out",
+                scorer_type=ScorerType.LLM_JUDGE,
+                scorer_detail=detail,
             ),
             # Non-judge scorer: scorer_detail is a plain (non-JSON) string, so
             # metadata_json (the queryable JSON view) must be NULL, not that string.
             ScoredOutput(
-                case_id="c2", passed=True, score=1.0, actual_output="3",
-                scorer_type=ScorerType.EXACT_MATCH, scorer_detail="expected=3, got=3",
+                case_id="c2",
+                passed=True,
+                score=1.0,
+                actual_output="3",
+                scorer_type=ScorerType.EXACT_MATCH,
+                scorer_detail="expected=3, got=3",
             ),
         ],
     )
     await eval_db.insert_run(db, summary)
     rows = {
         r[0]: r[1]
-        for r in await (await db.execute(
-            "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
-        )).fetchall()
+        for r in await (
+            await db.execute(
+                "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
+            )
+        ).fetchall()
     }
     assert rows["c1"] == detail  # judge result → JSON dual-write
     assert rows["c2"] is None  # non-judge result → NULL (not the plain string)
@@ -706,9 +857,15 @@ async def test_memory_quality_precision_at_3(db):
 
     for rank, rel in enumerate((1.0, 0.0, 1.0, 0.0, 1.0), 1):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
-            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
-                     "relevance": rel, "rank": rank},
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
+            metrics={
+                "recall_event_id": "r1",
+                "memory_id": f"m{rank}",
+                "relevance": rel,
+                "rank": rank,
+            },
         )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -724,9 +881,15 @@ async def test_memory_quality_precision_at_3_fewer_than_three(db):
 
     for rank, rel in ((1, 1.0), (2, 0.0)):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
-            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
-                     "relevance": rel, "rank": rank},
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
+            metrics={
+                "recall_event_id": "r1",
+                "memory_id": f"m{rank}",
+                "relevance": rel,
+                "rank": rank,
+            },
         )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -740,14 +903,21 @@ async def test_memory_quality_truncates_to_top5(db):
 
     for rank in range(1, 6):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
-            metrics={"recall_event_id": "r1", "memory_id": f"m{rank}",
-                     "relevance": 0.0, "rank": rank},
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
+            metrics={
+                "recall_event_id": "r1",
+                "memory_id": f"m{rank}",
+                "relevance": 0.0,
+                "rank": rank,
+            },
         )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
-        metrics={"recall_event_id": "r1", "memory_id": "m6",
-                 "relevance": 1.0, "rank": 6},
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m6", "relevance": 1.0, "rank": 6},
     )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -762,7 +932,9 @@ async def test_precision_at_3_skips_unranked_recalls(db):
 
     for i, rel in enumerate((1.0, 0.0, 1.0, 0.0), 1):
         await j9_eval.insert_event(
-            db, dimension="memory", event_type="recall_relevance",
+            db,
+            dimension="memory",
+            event_type="recall_relevance",
             metrics={"recall_event_id": "r1", "memory_id": f"m{i}", "relevance": rel},
         )
 
@@ -778,14 +950,22 @@ async def test_memory_quality_reports_judge_prompt_versions(db):
     from genesis.eval.j9_aggregator import _compute_memory_quality
 
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
-        metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 1.0,
-                 "rank": 1, "judge_prompt_version": "1"},
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        metrics={
+            "recall_event_id": "r1",
+            "memory_id": "m1",
+            "relevance": 1.0,
+            "rank": 1,
+            "judge_prompt_version": "1",
+        },
     )
     await j9_eval.insert_event(
-        db, dimension="memory", event_type="recall_relevance",
-        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0,
-                 "rank": 1},
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        metrics={"recall_event_id": "r2", "memory_id": "m2", "relevance": 0.0, "rank": 1},
     )
 
     metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
@@ -795,17 +975,24 @@ async def test_memory_quality_reports_judge_prompt_versions(db):
 # ── WS-1 A2: approvals dimension ─────────────────────────────────────────────
 
 
-async def _approval(db, aid, *, action_type="other", status=None,
-                    resolved_at=None, resolved_by=None):
+async def _approval(
+    db, aid, *, action_type="other", status=None, resolved_at=None, resolved_by=None
+):
     from genesis.db.crud import approval_requests as ar
 
     await ar.create(
-        db, id=aid, action_type=action_type, action_class="reversible",
+        db,
+        id=aid,
+        action_type=action_type,
+        action_class="reversible",
         description="d",
     )
     if status is not None:
         assert await ar.resolve(
-            db, aid, status=status, resolved_at=resolved_at,
+            db,
+            aid,
+            status=status,
+            resolved_at=resolved_at,
             resolved_by=resolved_by,
         )
 
@@ -817,37 +1004,47 @@ async def test_compute_approvals_buckets(db):
 
     ts = "2026-06-05T12:00:00+00:00"
     # churn class: one human approve, one fail-closed system cancel
-    await _approval(db, "a1", action_type="autonomous_cli_fallback",
-                    status="approved", resolved_at=ts,
-                    resolved_by="telegram:button:1")
-    await _approval(db, "a2", action_type="autonomous_cli_fallback",
-                    status="cancelled", resolved_at=ts, resolved_by="system")
+    await _approval(
+        db,
+        "a1",
+        action_type="autonomous_cli_fallback",
+        status="approved",
+        resolved_at=ts,
+        resolved_by="telegram:button:1",
+    )
+    await _approval(
+        db,
+        "a2",
+        action_type="autonomous_cli_fallback",
+        status="cancelled",
+        resolved_at=ts,
+        resolved_by="system",
+    )
     # non-churn: explicit human denial (M12), timeout expiry, unknown resolver
-    await _approval(db, "a3", status="rejected", resolved_at=ts,
-                    resolved_by="telegram:bare_text:1")
-    await _approval(db, "a4", status="expired", resolved_at=ts,
-                    resolved_by="timeout_auto_expire")
-    await _approval(db, "a5", status="approved", resolved_at=ts,
-                    resolved_by="manual_stale_cleanup")
+    await _approval(db, "a3", status="rejected", resolved_at=ts, resolved_by="telegram:bare_text:1")
+    await _approval(db, "a4", status="expired", resolved_at=ts, resolved_by="timeout_auto_expire")
+    await _approval(db, "a5", status="approved", resolved_at=ts, resolved_by="manual_stale_cleanup")
     # still pending — resolved-population excludes it; pending_open gauge sees it
     await _approval(db, "a6")
 
     metrics, sample = await _compute_approvals(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 5
     assert metrics["total_created"] == 6
     assert metrics["total_resolved"] == 5
     assert metrics["churn_total"] == 2
     assert metrics["churn_excluded_total"] == 3
-    assert metrics["user_resolved"] == 2          # a1 + a3
+    assert metrics["user_resolved"] == 2  # a1 + a3
     assert metrics["user_resolved_rate"] == 0.4
     assert metrics["user_resolved_rate_excl_churn"] == pytest.approx(1 / 3, abs=1e-3)
-    assert metrics["auto_resolved"] == 2          # a2 + a4
+    assert metrics["auto_resolved"] == 2  # a2 + a4
     assert metrics["auto_expired"] == 1
     assert metrics["system_cancelled"] == 1
     assert metrics["rejection_count"] == 1
-    assert metrics["user_denied_count"] == 1      # M12: human reject
+    assert metrics["user_denied_count"] == 1  # M12: human reject
     assert metrics["unknown_resolver_count"] == 1
     assert metrics["unknown_resolver_values"] == ["manual_stale_cleanup"]
     assert metrics["pending_open"] == 1
@@ -858,7 +1055,9 @@ async def test_compute_approvals_empty_window_is_null(db):
     from genesis.eval.j9_aggregator import _compute_approvals
 
     metrics, sample = await _compute_approvals(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 0
     assert metrics["user_resolved_rate"] is None
@@ -873,20 +1072,30 @@ async def test_compute_approvals_mixed_resolved_at_formats(db):
     from genesis.eval.j9_aggregator import _compute_approvals
 
     # in-window, one of each format
-    await _approval(db, "b1", status="approved",
-                    resolved_at="2026-06-05 12:00:00",
-                    resolved_by="telegram:button:1")
-    await _approval(db, "b2", status="approved",
-                    resolved_at="2026-06-06T12:00:00+00:00",
-                    resolved_by="dashboard")
+    await _approval(
+        db,
+        "b1",
+        status="approved",
+        resolved_at="2026-06-05 12:00:00",
+        resolved_by="telegram:button:1",
+    )
+    await _approval(
+        db,
+        "b2",
+        status="approved",
+        resolved_at="2026-06-06T12:00:00+00:00",
+        resolved_by="dashboard",
+    )
     # space-format AFTER the until bound — lexicographic compare against
     # '2026-06-30T00:00:00+00:00' would wrongly include it (' ' < 'T')
-    await _approval(db, "b3", status="approved",
-                    resolved_at="2026-06-30 12:00:00",
-                    resolved_by="dashboard")
+    await _approval(
+        db, "b3", status="approved", resolved_at="2026-06-30 12:00:00", resolved_by="dashboard"
+    )
 
     metrics, _ = await _compute_approvals(
-        db, since="2026-06-01T00:00:00+00:00", until="2026-06-30T00:00:00+00:00",
+        db,
+        since="2026-06-01T00:00:00+00:00",
+        until="2026-06-30T00:00:00+00:00",
     )
     assert metrics["total_resolved"] == 2  # b3 excluded
     assert metrics["user_resolved"] == 2
@@ -905,7 +1114,9 @@ async def test_compute_goal_completion_zero_terminal_is_null(db):
     await user_goals.create(db, title="g2", category="learning")
 
     metrics, sample = await _compute_goal_completion(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 2
     assert metrics["total_goals"] == 2
@@ -926,10 +1137,15 @@ async def test_compute_goal_completion_rate(db):
     await user_goals.mark_abandoned(db, g2)
 
     metrics, _ = await _compute_goal_completion(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert metrics["by_status"] == {
-        "active": 1, "paused": 0, "achieved": 1, "abandoned": 1,
+        "active": 1,
+        "paused": 0,
+        "achieved": 1,
+        "abandoned": 1,
     }
     assert metrics["terminal_count"] == 2
     assert metrics["achieved_count"] == 1
@@ -953,17 +1169,20 @@ async def test_compute_noise_passivity(db):
     # follow-ups: one stale-pending (leak), one completed
     await db.execute(
         "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
-        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)", (old,),
+        "VALUES ('f1','session_retro','x','ego_judgment','pending',?)",
+        (old,),
     )
     await db.execute(
         "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
-        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)", (old,),
+        "VALUES ('f2','session_retro','y','ego_judgment','completed',?)",
+        (old,),
     )
     # observation: unresolved, un-actuated, old → stale leak
     await db.execute(
         "INSERT INTO observations "
         "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
-        "VALUES ('o1','s','generic','c','medium',?,0,0,0)", (old,),
+        "VALUES ('o1','s','generic','c','medium',?,0,0,0)",
+        (old,),
     )
     # ego proposals: rejected + withdrawn (decision buckets window on
     # resolved_at, which the reject/table/withdraw transitions set) +
@@ -971,26 +1190,32 @@ async def test_compute_noise_passivity(db):
     await db.execute(
         "INSERT INTO ego_proposals "
         "(id, action_type, content, status, created_at, resolved_at, realist_verdict) "
-        "VALUES ('p1','investigate','c','rejected',?,?,'amend')", (old, old),
+        "VALUES ('p1','investigate','c','rejected',?,?,'amend')",
+        (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at, resolved_at) "
-        "VALUES ('p2','outreach','c','withdrawn',?,?)", (old, old),
+        "VALUES ('p2','outreach','c','withdrawn',?,?)",
+        (old, old),
     )
     await db.execute(
         "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
-        "VALUES ('p3','maintenance','c','pending',?)", (old,),
+        "VALUES ('p3','maintenance','c','pending',?)",
+        (old,),
     )
     # ego cycles: 2 empty, 1 productive
     for cid, n in (("c1", 0), ("c2", 0), ("c3", 2)):
         await db.execute(
             "INSERT INTO ego_cycle_outcomes (cycle_id, focus_type, num_proposals, created_at) "
-            "VALUES (?, 'signal', ?, ?)", (cid, n, old),
+            "VALUES (?, 'signal', ?, ?)",
+            (cid, n, old),
         )
     await db.commit()
 
     metrics, sample = await _compute_noise_passivity(
-        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+        db,
+        since="2000-01-01T00:00:00+00:00",
+        until="2100-01-01T00:00:00+00:00",
     )
     assert metrics["stale_followups"] == 1
     assert metrics["followups_pending"] == 1
@@ -1013,7 +1238,9 @@ async def test_compute_noise_passivity_zero_cycles_is_null(db):
     from genesis.eval.j9_aggregator import _compute_noise_passivity
 
     metrics, _ = await _compute_noise_passivity(
-        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+        db,
+        since="2000-01-01T00:00:00+00:00",
+        until="2100-01-01T00:00:00+00:00",
     )
     assert metrics["empty_ego_cycle_pct"] is None
 
@@ -1030,9 +1257,18 @@ async def test_run_weekly_aggregation_writes_new_dimensions(db):
 
     results = await run_weekly_aggregation(db)
 
-    expected = {"memory", "system", "ego", "cognitive", "procedure",
-                "cognitive_drift", "approvals", "goals", "noise",
-                "dev_quality"}
+    expected = {
+        "memory",
+        "system",
+        "ego",
+        "cognitive",
+        "procedure",
+        "cognitive_drift",
+        "approvals",
+        "goals",
+        "noise",
+        "dev_quality",
+    }
     missing = expected - results.keys()
     assert not missing, f"dimensions failed silently: {missing}"
 
@@ -1066,10 +1302,12 @@ async def test_noise_decision_buckets_window_on_resolved_at(db):
     await db.commit()
 
     metrics, _ = await _compute_noise_passivity(
-        db, since="2000-01-01T00:00:00+00:00", until="2100-01-01T00:00:00+00:00",
+        db,
+        since="2000-01-01T00:00:00+00:00",
+        until="2100-01-01T00:00:00+00:00",
     )
-    assert metrics["rejected_count"] == 1       # pb1: decided in window
-    assert metrics["withdrawn_count"] == 0      # pb2: decided before window
+    assert metrics["rejected_count"] == 1  # pb1: decided in window
+    assert metrics["withdrawn_count"] == 0  # pb2: decided before window
     assert metrics["proposals_in_period"] == 0  # neither was CREATED in window
     assert metrics["rejected_by_action_type"] == {"investigate": 1}
 
@@ -1100,20 +1338,31 @@ async def test_compute_goal_completion_excludes_ego_goals(db):
 
     u1 = await user_goals.create(db, title="user g", category="project")
     e1 = await user_goals.create(
-        db, title="ego g", category="project", origin="genesis_ego",
+        db,
+        title="ego g",
+        category="project",
+        origin="genesis_ego",
     )
     await user_goals.create(
-        db, title="ego g2", category="project", origin="genesis_ego",
+        db,
+        title="ego g2",
+        category="project",
+        origin="genesis_ego",
     )
     await user_goals.mark_achieved(db, u1)
     await user_goals.mark_achieved(db, e1)
 
     metrics, sample = await _compute_goal_completion(
-        db, since="2000-01-01", until="2100-01-01",
+        db,
+        since="2000-01-01",
+        until="2100-01-01",
     )
     assert sample == 1  # the user goal only
     assert metrics["total_goals"] == 1
     assert metrics["by_status"] == {
-        "active": 0, "paused": 0, "achieved": 1, "abandoned": 0,
+        "active": 0,
+        "paused": 0,
+        "achieved": 1,
+        "abandoned": 0,
     }
     assert metrics["achieved_count"] == 1

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -537,3 +537,17 @@ async def test_run_arm_applies_variant_recall_kwargs_and_post_recall(_variants_c
     assert "alpha_memory" in joined
     assert "beta_memory" not in joined
     assert result.arm_label == "raw+probe"
+
+
+def test_eval_cli_longmemeval_accepts_variants():
+    """The primary `genesis eval longmemeval` path exposes --variants (not just
+    the module __main__), so a lever's variant is reachable from both CLIs."""
+    import argparse
+
+    from genesis.eval.cli import add_parser
+
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers(dest="command")
+    add_parser(sub)
+    args = top.parse_args(["eval", "longmemeval", "--variants", "scope,budget"])
+    assert args.variants == "scope,budget"

--- a/tests/test_eval/test_longmemeval_orchestration.py
+++ b/tests/test_eval/test_longmemeval_orchestration.py
@@ -384,3 +384,156 @@ async def test_run_longmemeval_runs_questions_concurrently():
     # the offload lets multiple blocking LLM calls overlap; a blocking-on-loop
     # implementation would serialize to max_active == 1
     assert client.max_active >= 2
+
+
+# ── WS2-0: retrieval-config variant seam ─────────────────────────────────────
+
+
+@pytest.fixture
+def _variants_clean():
+    """Snapshot/restore the module-global VARIANTS registry so a test that
+    registers a variant never leaks into another test."""
+    from genesis.eval.longmemeval import runner
+
+    saved = dict(runner.VARIANTS)
+    try:
+        yield
+    finally:
+        runner.VARIANTS.clear()
+        runner.VARIANTS.update(saved)
+
+
+def test_select_arms_variants_double_without_variant_of_variant(_variants_clean):
+    from genesis.eval.longmemeval.runner import select_arms
+
+    arms = select_arms(no_rerank=True, variants=["scope"])
+    assert {a.label for a in arms} == {"raw", "keyword", "raw+scope", "keyword+scope"}
+    # two variants each double the BASE arms only — never variant-of-variant
+    labels = {a.label for a in select_arms(no_rerank=True, variants=["scope", "budget"])}
+    assert labels == {
+        "raw", "keyword",
+        "raw+scope", "keyword+scope",
+        "raw+budget", "keyword+budget",
+    }
+    assert not any("scope" in x and "budget" in x for x in labels)
+
+
+def test_validate_variants_rejects_unknown_variant():
+    from genesis.eval.longmemeval.query import QueryArm
+    from genesis.eval.longmemeval.runner import Arm, validate_variants
+
+    with pytest.raises(ValueError, match="unknown arm variant"):
+        validate_variants([Arm(QueryArm.RAW, rerank=False, variant="nope")])
+
+
+def test_validate_variants_rejects_unknown_recall_kwarg(_variants_clean):
+    from genesis.eval.longmemeval.query import QueryArm
+    from genesis.eval.longmemeval.runner import (
+        Arm,
+        ArmVariant,
+        register_variant,
+        validate_variants,
+    )
+
+    register_variant(ArmVariant(name="bad", recall_kwarg_names=("not_a_real_kwarg",)))
+    with pytest.raises(ValueError, match="unknown recall kwargs"):
+        validate_variants([Arm(QueryArm.RAW, rerank=False, variant="bad")])
+
+
+def test_validate_variants_passes_registered_valid_kwargs(_variants_clean):
+    from genesis.eval.longmemeval.query import QueryArm
+    from genesis.eval.longmemeval.runner import (
+        Arm,
+        ArmVariant,
+        register_variant,
+        validate_variants,
+    )
+
+    register_variant(ArmVariant(name="ok", recall_kwarg_names=("wing",)))
+    # 'wing' is a real recall() kwarg; baseline (no-variant) arms always pass
+    validate_variants([
+        Arm(QueryArm.RAW, rerank=False),
+        Arm(QueryArm.RAW, rerank=False, variant="ok"),
+    ])
+
+
+class _RecordAllClient:
+    """Sync client recording the full concatenated prompt of every call."""
+
+    def __init__(self):
+        self.prompts: list[str] = []
+        self._lock = threading.Lock()
+        chat = type("Chat", (), {})()
+        completions = type("Completions", (), {})()
+
+        def create(**kwargs):
+            with self._lock:
+                self.prompts.append(
+                    " ".join(m.get("content", "") for m in kwargs["messages"]),
+                )
+            return _FakeCompletion("yes Business Administration")
+
+        completions.create = create
+        chat.completions = completions
+        self.chat = chat
+
+
+@pytest.mark.asyncio
+async def test_run_arm_applies_variant_recall_kwargs_and_post_recall(_variants_clean):
+    """A variant's recall_kwargs reach recall(), and its post_recall transforms
+    the content list actually fed to the reader — proven directly via spies."""
+    from genesis.eval.longmemeval.query import QueryArm
+    from genesis.eval.longmemeval.runner import (
+        Arm,
+        ArmVariant,
+        _run_arm,
+        register_variant,
+    )
+
+    seen_recall_kwargs: dict = {}
+    seen_post_recall: list = []
+
+    class _Hit:
+        def __init__(self, mid, content):
+            self.memory_id = mid
+            self.content = content
+
+    class _Retriever:
+        async def recall(self, query, *, source, limit, rerank, **extra):
+            seen_recall_kwargs.update(extra)
+            return [_Hit("m1", "alpha_memory"), _Hit("m2", "beta_memory")]
+
+    class _ES:
+        retriever = _Retriever()
+        db = None
+
+    class _Ingest:
+        evidence_memory_ids = {"m1"}
+
+    def _derive(instance, arm):
+        return {"wing": "infrastructure"}
+
+    def _trim(memories):
+        seen_post_recall.append(list(memories))
+        return memories[:1]  # keep only the top memory
+
+    register_variant(
+        ArmVariant(
+            name="probe",
+            recall_kwarg_names=("wing",),
+            recall_kwargs=_derive,
+            post_recall=_trim,
+        ),
+    )
+
+    client = _RecordAllClient()
+    arm = Arm(QueryArm.RAW, rerank=False, variant="probe")
+    result = await _run_arm(_ES(), _Ingest(), _instance("q1"), arm, k=10, client=client)
+
+    assert seen_recall_kwargs == {"wing": "infrastructure"}     # kwargs reached recall()
+    assert seen_post_recall == [["alpha_memory", "beta_memory"]]  # got the recalled set
+    # the trimmed list (only alpha) reached the reader; beta was dropped
+    joined = " ".join(client.prompts)
+    assert "alpha_memory" in joined
+    assert "beta_memory" not in joined
+    assert result.arm_label == "raw+probe"

--- a/tests/test_eval/test_longmemeval_runner.py
+++ b/tests/test_eval/test_longmemeval_runner.py
@@ -37,6 +37,21 @@ def test_default_arms_are_the_four_combinations():
     assert labels == {"raw", "raw+rerank", "keyword", "keyword+rerank"}
 
 
+def test_arm_label_variant_suffix_is_last_and_baseline_is_byte_identical():
+    """WS2-0: the +variant suffix appends LAST (after rerank, after graph) and
+    only appears when a variant is set — so every pre-WS2-0 label is unchanged."""
+    # baseline labels byte-identical (variant defaults to "")
+    assert Arm(QueryArm.RAW, rerank=False).label == "raw"
+    assert Arm(QueryArm.RAW, rerank=True, graph=True).label == "raw+rerank+graph"
+    # variant appends last, in the documented order
+    assert Arm(QueryArm.RAW, rerank=False, variant="scope").label == "raw+scope"
+    assert (
+        Arm(QueryArm.RAW, rerank=True, graph=True, variant="scope").label
+        == "raw+rerank+graph+scope"
+    )
+    assert Arm(QueryArm.KEYWORD, rerank=True, variant="budget").label == "keyword+rerank+budget"
+
+
 def _r(qid, qtype, correct, evidence=True, coverage=None):  # noqa: FBT002
     return QuestionArmResult(
         question_id=qid,

--- a/tests/test_scripts/test_retrieval_efficacy_report.py
+++ b/tests/test_scripts/test_retrieval_efficacy_report.py
@@ -1,0 +1,141 @@
+"""Retrieval-efficacy report: pure build_report over synthetic snapshots
+(trend join, reconstructed-pool fallback for pre-WS2-0 weeks, drift detection,
+LongMemEval arm summary) + markdown rendering. No DB, no network."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "retrieval_efficacy_report", _SCRIPTS_DIR / "retrieval_efficacy_report.py"
+)
+_rep = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rep)
+
+
+def _snap(period_end: str, **metrics) -> dict:
+    return {"period_end": period_end, "metrics": metrics}
+
+
+def test_build_report_trend_is_chronological_and_uses_snapshot_pool():
+    # get_snapshots returns newest-first; the trend must come out oldest-first.
+    snapshots = [
+        _snap(
+            "2026-07-17",
+            precision_at_5=0.8,
+            hit_rate=0.7,
+            mrr=0.6,
+            total_recalls=40,
+            pool_episodic_total=55000,
+        ),
+        _snap(
+            "2026-07-10",
+            precision_at_5=0.75,
+            hit_rate=0.72,
+            mrr=0.55,
+            total_recalls=30,
+            pool_episodic_total=52000,
+        ),
+    ]
+    report = _rep.build_report(
+        snapshots=snapshots,
+        reconstructed_pool={},
+        lme_runs=[],
+    )
+    trend = report["trend"]
+    assert [r["period_end"] for r in trend] == ["2026-07-10", "2026-07-17"]
+    assert trend[0]["pool_episodic_total"] == 52000
+    assert trend[0]["pool_source"] == "snapshot"
+    assert trend[1]["hit_rate"] == 0.7
+
+
+def test_build_report_falls_back_to_reconstructed_pool_for_pre_ws2_0_weeks():
+    # A pre-WS2-0 snapshot has no pool_* — the reconstructed count fills it,
+    # tagged so a reader knows it is an approximation.
+    snapshots = [_snap("2026-06-01", precision_at_5=0.6, hit_rate=0.6)]
+    report = _rep.build_report(
+        snapshots=snapshots,
+        reconstructed_pool={"2026-06-01": 40000},
+        lme_runs=[],
+    )
+    row = report["trend"][0]
+    assert row["pool_episodic_total"] == 40000
+    assert row["pool_source"] == "reconstructed"
+
+
+def test_build_report_pool_unknown_when_neither_source_available():
+    snapshots = [_snap("2026-06-01", hit_rate=0.6)]
+    report = _rep.build_report(snapshots=snapshots, reconstructed_pool={}, lme_runs=[])
+    row = report["trend"][0]
+    assert row["pool_episodic_total"] is None
+    assert row["pool_source"] == "unknown"
+
+
+def test_build_report_drift_flags_grew_and_dropped():
+    snapshots = [
+        _snap("2026-07-17", hit_rate=0.4, pool_episodic_total=55000),
+        _snap("2026-06-01", hit_rate=0.69, pool_episodic_total=20000),
+    ]
+    report = _rep.build_report(snapshots=snapshots, reconstructed_pool={}, lme_runs=[])
+    drift = report["drift"]
+    assert drift is not None
+    assert drift["pool_grew"] is True
+    assert drift["quality_dropped"] is True
+    assert drift["first_period"] == "2026-06-01"
+    assert drift["last_period"] == "2026-07-17"
+
+
+def test_build_report_drift_none_with_fewer_than_two_usable_weeks():
+    # only one week carries both a quality number and a pool size
+    snapshots = [
+        _snap("2026-07-17", hit_rate=0.7, pool_episodic_total=55000),
+        _snap("2026-07-10", hit_rate=None),  # unusable
+    ]
+    report = _rep.build_report(snapshots=snapshots, reconstructed_pool={}, lme_runs=[])
+    assert report["drift"] is None
+
+
+def test_build_report_longmemeval_arms_latest_per_arm():
+    runs = [  # newest-first
+        {"model_profile": "longmemeval:raw", "aggregate_score": 0.65, "created_at": "2026-07-17"},
+        {
+            "model_profile": "longmemeval:raw",
+            "aggregate_score": 0.60,
+            "created_at": "2026-07-10",
+        },  # older, must be ignored
+        {
+            "model_profile": "longmemeval:raw+scope",
+            "aggregate_score": 0.68,
+            "created_at": "2026-07-17",
+        },
+        {
+            "model_profile": "bench:genesis",
+            "aggregate_score": 0.9,
+            "created_at": "2026-07-17",
+        },  # not longmemeval → excluded
+    ]
+    report = _rep.build_report(snapshots=[], reconstructed_pool={}, lme_runs=runs)
+    arms = {a["arm"]: a["aggregate_score"] for a in report["longmemeval_arms"]}
+    assert arms == {"raw": 0.65, "raw+scope": 0.68}
+
+
+def test_render_md_smoke_empty_and_populated():
+    # empty
+    empty = _rep.build_report(snapshots=[], reconstructed_pool={}, lme_runs=[])
+    md_empty = _rep.render_md(empty, generated_at="2026-07-17T00:00:00Z")
+    assert "Retrieval-efficacy report" in md_empty
+    assert "no weekly memory snapshots yet" in md_empty
+    assert "UNTESTED" in md_empty  # honest premise caveat
+
+    # populated
+    snapshots = [
+        _snap("2026-07-17", hit_rate=0.4, pool_episodic_total=55000),
+        _snap("2026-06-01", hit_rate=0.69, pool_episodic_total=20000),
+    ]
+    report = _rep.build_report(snapshots=snapshots, reconstructed_pool={}, lme_runs=[])
+    md = _rep.render_md(report, generated_at="2026-07-17T00:00:00Z")
+    assert "Drift check" in md
+    assert "drift" in md.lower()
+    assert "flip-gate checklist" in md

--- a/tests/test_scripts/test_retrieval_efficacy_report.py
+++ b/tests/test_scripts/test_retrieval_efficacy_report.py
@@ -139,3 +139,14 @@ def test_render_md_smoke_empty_and_populated():
     assert "Drift check" in md
     assert "drift" in md.lower()
     assert "flip-gate checklist" in md
+
+
+def test_build_report_carries_retrievable_pool_when_present():
+    snapshots = [
+        _snap("2026-07-17", hit_rate=0.7, pool_episodic_total=55000,
+              pool_episodic_retrievable=52000),
+    ]
+    report = _rep.build_report(snapshots=snapshots, reconstructed_pool={}, lme_runs=[])
+    assert report["trend"][0]["pool_episodic_retrievable"] == 52000
+    md = _rep.render_md(report, generated_at="2026-07-17T00:00:00Z")
+    assert "retrievable" in md


### PR DESCRIPTION
## What

The prerequisite for the WS2 retrieval-drift work: makes memory retrieval quality **measurable against pool size**, and gives the upcoming lever PRs a measurement seam. Zero schema change, \$0 spend, entirely additive.

Four parts:

1. **Pool stamping** — `pool_size_counts()` (episodic total/embedded by collection, knowledge units, memory links) folds `pool_*` keys into the weekly J-9 memory snapshot, in its own try/except so a count failure degrades to `None` keys without losing the quality metrics. Quality (precision@k/hit_rate/MRR) and pool size now land in the same row. No migration — `eval_snapshots.dimension` is unconstrained.

2. **Readers** — `j9_eval_status` gains `retrieval_trend` (last 12 weekly snapshots, chronological); `memory_stats` gains a `quality` block (latest snapshot headline + subsystem grade), closing the disjoint capacity-vs-quality surfaces. Both tolerate pre-WS2-0 snapshots (missing `pool_*` → honest `null`, never a KeyError) and un-aggregated installs (→ `None`, never break the capacity read).

3. **Variant seam** — a generic retrieval-config variant mechanism in the LongMemEval harness so each lever PR measures itself offline without re-opening the harness core. `Arm.variant` (label suffix appended **last**, so every pre-existing label stays byte-identical); a `VARIANTS` registry with two application seams (`recall_kwargs` per-question, `post_recall` transform); `validate_variants` fails fast **before any spend**; CLI `--variants` pairs each base arm with a `+variant` twin. Registry ships empty — the levers register theirs.

4. **Report + retention** — `scripts/retrieval_efficacy_report.py`: a read-only comparator that joins the weekly quality snapshots to the pool size they were measured over — the first artifact able to substantiate or refute the "69%→38% drift" premise. Pre-WS2-0 weeks are filled by a labelled, read-only historical reconstruction (never written back). `disk_hygiene.sh` gains a 45d file-age prune for the dated reports.

## Verification

- Targeted tests green across all touched + adjacent suites.
- Read-only E2E on the live DB: `pool_size_counts` returns live numbers; `_compute_memory_quality` stamps `pool_*` additively with quality intact; both readers degrade to `null` on the current (pre-WS2-0) snapshots; the report script renders the live pool-vs-quality trend.
- Adversarial code review: no material defects; additive/degradation contracts verified and directly tested.

## Deploy path

Runtime code (aggregator + MCP readers): `git pull` + server restart — the next weekly aggregation (Sunday) writes the first `pool_*`-bearing snapshot. MCP readers take effect at the next CC session. Report script + hygiene prune land via `git pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)