### PR TITLE
fix(ego): direction-neutral session-pattern reading + persisted baseline_note

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1510,7 +1510,11 @@ async def perform_tick(
             source=source,
             signals_json=json.dumps([
                 {"name": s.name, "value": s.value, "source": s.source,
-                 "collected_at": s.collected_at}
+                 "collected_at": s.collected_at,
+                 # Additive: ground-truth context (e.g. "Baseline: 4.0/day,
+                 # Recent: 27.0/day") so downstream consumers can't misread
+                 # a symmetric deviation score's direction.
+                 **({"baseline_note": s.baseline_note} if s.baseline_note else {})}
                 for s in signals
             ]),
             scores_json=json.dumps([

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -503,9 +503,12 @@ class UserEgoContextBuilder:
             (0.3, "oldest pending goal is moderately stale (7-14 days)"),
             (0.0, "pending goals are relatively fresh"),
         ],
+        # NOTE: user_session_pattern is a SYMMETRIC deviation score — both
+        # drops and surges raise it. Interpretation text must stay
+        # direction-neutral; the persisted baseline_note carries direction.
         "user_session_pattern": [
-            (0.7, "user activity is significantly below their baseline"),
-            (0.3, "user activity is somewhat below their baseline"),
+            (0.7, "user activity deviates significantly from their baseline"),
+            (0.3, "user activity deviates somewhat from their baseline"),
             (0.0, "user activity is near their normal pattern"),
         ],
         "stale_pending_items": [
@@ -583,9 +586,14 @@ class UserEgoContextBuilder:
             interpretation = self._interpret_signal(sig_name, float(value))
             if interpretation:
                 label = sig_name.replace("_", " ").title()
-                pulse_items.append(
-                    f"- **{label}**: {interpretation} (signal: {value:.2f})"
+                item = f"- **{label}**: {interpretation} (signal: {value:.2f})"
+                note = (
+                    sig_info.get("baseline_note")
+                    if isinstance(sig_info, dict) else None
                 )
+                if note:
+                    item += f" — {note}"
+                pulse_items.append(item)
 
         if not pulse_items:
             lines.append("*All user activity signals nominal.*\n")

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -654,11 +654,66 @@ class TestUserEgoContextBuilder:
         assert "User Goal Staleness" in result
         assert "moderately stale" in result
         assert "User Session Pattern" in result
-        assert "significantly below" in result
+        assert "deviates significantly" in result
         assert "Conversations Since Reflection" in result
         # Genesis-internal signal excluded
         assert "Software Error Spike" not in result
         assert "circuit_breakers" not in result
+
+    @pytest.mark.asyncio
+    async def test_activity_pulse_baseline_note_rendered(
+        self, db, mock_health_data, capabilities,
+    ):
+        """A persisted baseline_note is appended as ground truth, and the
+        interpretation text stays direction-neutral on a surge."""
+        signals = json.dumps([
+            {
+                "name": "user_session_pattern", "value": 0.8,
+                "source": "cc_sessions",
+                # A SURGE: recent far above baseline
+                "baseline_note": (
+                    "Baseline: 4.0 sessions/day (last 21d). "
+                    "Recent: 27.0/day (last 3d). 0.0=typical, 1.0=very unusual."
+                ),
+            },
+        ])
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, signals_json, classified_depth, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("tick_note", signals, "Micro", ),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "deviates significantly" in result
+        assert "Baseline: 4.0 sessions/day" in result
+        assert "Recent: 27.0/day" in result
+        # The old inverted reading must be gone
+        assert "below their baseline" not in result
+
+    @pytest.mark.asyncio
+    async def test_activity_pulse_old_tick_without_note(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Ticks persisted before baseline_note existed degrade gracefully
+        to the neutral interpretation with no note appended."""
+        signals = json.dumps([
+            {"name": "user_session_pattern", "value": 0.8, "source": "cc_sessions"},
+        ])
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, signals_json, classified_depth, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("tick_old", signals, "Micro", ),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "deviates significantly" in result
+        assert "Baseline:" not in result
 
     @pytest.mark.asyncio
     async def test_activity_pulse_all_zero(self, db, mock_health_data, capabilities):

--- a/tests/test_awareness/test_integration.py
+++ b/tests/test_awareness/test_integration.py
@@ -106,3 +106,39 @@ async def test_sequential_ticks_track_history(db):
     ticks = await awareness_ticks.query(db)
     assert len(ticks) == 2
     assert ticks[0]["id"] != ticks[1]["id"]
+
+
+async def test_baseline_note_persisted_additively(db):
+    """perform_tick persists baseline_note when a collector provides one,
+    and omits the key entirely when it does not (old-format compat)."""
+
+    class Noted:
+        signal_name = "user_session_pattern"
+
+        async def collect(self):
+            return SignalReading(
+                name="user_session_pattern", value=0.8, source="cc_sessions",
+                collected_at=datetime.now(UTC).isoformat(),
+                baseline_note=(
+                    "Baseline: 4.0 sessions/day (last 21d). "
+                    "Recent: 27.0/day (last 3d)."
+                ),
+            )
+
+    class Bare:
+        signal_name = "conversations_since_reflection"
+
+        async def collect(self):
+            return SignalReading(
+                name="conversations_since_reflection", value=0.2,
+                source="cc_sessions",
+                collected_at=datetime.now(UTC).isoformat(),
+            )
+
+    await perform_tick(db, [Noted(), Bare()], source="scheduled")
+
+    ticks = await awareness_ticks.query(db)
+    assert len(ticks) == 1
+    by_name = {s["name"]: s for s in json.loads(ticks[0]["signals_json"])}
+    assert "Baseline: 4.0 sessions/day" in by_name["user_session_pattern"]["baseline_note"]
+    assert "baseline_note" not in by_name["conversations_since_reflection"]


### PR DESCRIPTION
## Problem

`user_session_pattern` is a **symmetric** deviation score — both drops and surges in foreground activity raise it (collector: `learning/signals/user_session_pattern.py`). But the user-ego Activity Pulse hardcoded a directional reading: any value ≥0.3 rendered as *"user activity is … below their baseline"*. During an activity **surge** (e.g. baseline 4/day → recent 27/day) the ego was told the user had gone quiet — an inverted picture that fed wrong proposals and reflection noise.

## Fix

- **Persist ground truth**: `perform_tick` now includes each signal's `baseline_note` in the persisted `signals_json` (additive key, omitted when the collector doesn't set one — old-format consumers unaffected).
- **Neutral interpretation**: pulse text becomes "deviates significantly/somewhat from their baseline", with the persisted note appended ("Baseline: 4.0 sessions/day … Recent: 27.0/day") so the ego sees the direction from data, not from a guess.
- Old ticks without the key degrade gracefully to the neutral text.

Swept the repo for other directional baseline text: this was the only site.

## Tests

- `tests/test_awareness/test_integration.py`: baseline_note persisted when provided, key omitted when not.
- `tests/ego/test_user_context.py`: note rendered on a surge tick; never the old "below" text; pre-existing ticks without the key degrade to neutral.

## Deploy path

Repo code only — existing installs: git pull + restart; fresh installs: in-repo. No migrations (JSON key is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)