### PR TITLE
fix(guardian): write-probe the CC work dir before trusting it (audit idx 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The host recovery brain no longer goes blind on a misconfigured work
+  directory.** If the guardian's configured Claude Code work directory already
+  exists but isn't writable by the guardian (for example a root-owned
+  `/var/lib` path left over from an older install), it now detects that with a
+  real write probe and falls back to a user-writable directory instead of
+  handing the recovery session an unusable working directory. Previously only a
+  *non-creatable* directory triggered the fallback; an existing-but-unwritable
+  one slipped through and could blind the recovery brain exactly when it was
+  needed most.
+
 - **Disaster recovery no longer risks corrupting the thing it's recovering.** A
   script audit found three ways deploy/restore could bite at the worst moment,
   now fixed: (1) during a database restore, the health watchdog could restart

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -61,6 +61,24 @@ def _host_mem_available_gib() -> float | None:
 _WORK_DIR_FALLBACK = "~/.local/state/genesis-guardian/cc-sessions"
 
 
+def _dir_is_writable(path: Path) -> bool:
+    """Probe real write access with a create-and-delete file.
+
+    ``mkdir(exist_ok=True)`` and ``os.access`` both report success on a
+    pre-existing directory this process cannot actually write to (root-owned,
+    mode 0555), so only an actual write proves the CC subprocess can use it as
+    its cwd. Best-effort cleanup; a crash between touch and unlink leaves only a
+    hidden probe file the next probe overwrites.
+    """
+    probe = path / f".guardian-writeprobe-{os.getpid()}"
+    try:
+        probe.touch()
+        probe.unlink()
+        return True
+    except OSError:
+        return False
+
+
 def _ensure_work_dir(configured: Path, fallback: Path | None = None) -> Path:
     """Create the CC diagnosis work dir, returning the dir actually usable.
 
@@ -71,20 +89,34 @@ def _ensure_work_dir(configured: Path, fallback: Path | None = None) -> Path:
     alert-only — exactly the failure seen live during a freeze. Fall back to a
     user-writable state dir so the diagnosis brain still runs.
 
-    If the fallback itself can't be created, the OSError propagates — with no
-    writable work dir anywhere, alert-only is the honest degradation.
+    A directory that already *exists* but is not writable by the guardian user
+    (the same root-owned ``/var/lib`` path, where ``mkdir(exist_ok=True)`` is a
+    silent no-op) is just as blinding, so we write-probe before trusting either
+    the configured dir or the fallback. If neither is writable the OSError
+    propagates — with no writable work dir anywhere, alert-only is the honest
+    degradation.
     """
     fallback = fallback or Path(_WORK_DIR_FALLBACK).expanduser()
     try:
         configured.mkdir(parents=True, exist_ok=True)
-        return configured
+        if _dir_is_writable(configured):
+            return configured
+        logger.warning(
+            "guardian cc.work_dir %s exists but is not writable — falling back to %s",
+            configured, fallback,
+        )
     except OSError as exc:
         logger.warning(
             "guardian cc.work_dir %s not creatable (%s) — falling back to %s",
             configured, exc, fallback,
         )
-        fallback.mkdir(parents=True, exist_ok=True)
-        return fallback
+    fallback.mkdir(parents=True, exist_ok=True)
+    if not _dir_is_writable(fallback):
+        raise OSError(
+            f"guardian fallback work_dir {fallback} exists but is not writable — "
+            "no usable CC work dir (alert-only degradation)"
+        )
+    return fallback
 
 
 class CCDiagnosisError(Exception):

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -318,6 +319,40 @@ def test_ensure_work_dir_propagates_when_fallback_also_uncreatable(tmp_path):
     blocker.write_text("file")
     with pytest.raises(OSError):
         _ensure_work_dir(blocker / "wd", fallback=blocker / "fb")
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory write permissions")
+def test_ensure_work_dir_falls_back_when_configured_exists_but_unwritable(tmp_path):
+    # idx-0 gap: the dir EXISTS (mkdir(exist_ok=True) is a silent no-op) but is
+    # not writable by the guardian user (root-owned / mode 0555 on a vintage
+    # /var/lib install). The CC subprocess would run with an unwritable cwd and
+    # the recovery brain would be blinded — so we must write-probe and fall back.
+    configured = tmp_path / "cc-sessions"
+    configured.mkdir()
+    configured.chmod(0o555)
+    fallback = tmp_path / "state" / "cc-sessions"
+    try:
+        got = _ensure_work_dir(configured, fallback=fallback)
+        assert got == fallback and fallback.is_dir()
+    finally:
+        configured.chmod(0o755)  # let tmp_path cleanup remove it
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory write permissions")
+def test_ensure_work_dir_raises_when_fallback_exists_but_unwritable(tmp_path):
+    # configured uncreatable AND fallback exists-but-unwritable → no usable work
+    # dir anywhere → OSError propagates so diagnose() escalates alert-only,
+    # rather than silently handing back an unwritable fallback.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("file")
+    fallback = tmp_path / "fb"
+    fallback.mkdir()
+    fallback.chmod(0o555)
+    try:
+        with pytest.raises(OSError):
+            _ensure_work_dir(blocker / "wd", fallback=fallback)
+    finally:
+        fallback.chmod(0o755)
 
 
 def _stub_claude(tmp_path, body: str):

--- a/tests/test_guardian/test_gateway_redeploy_safety.py
+++ b/tests/test_guardian/test_gateway_redeploy_safety.py
@@ -1,0 +1,55 @@
+"""Regression lock: the guardian redeploy verb must always restart
+``genesis-guardian.timer`` on every exit path.
+
+Audit finding idx 24 (PR #171): with ``set -e``, ``guardian-gateway.sh`` can
+exit between stopping the timer for a redeploy and the final restart (a failing
+``cp``/``mv``, CLAUDE regen, or the ``deploy_state.json`` write), leaving the
+host guardian silently disabled until manual intervention. It is already fixed
+by an ``EXIT`` trap gated on ``_TIMER_STOPPED``; this test locks that invariant
+so a future edit to the (large, hand-maintained) gateway script can't remove it
+unnoticed. Structural assertions only — no shell execution, install-agnostic
+(the script path is resolved relative to this test file).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+
+def _gateway_text() -> str:
+    assert GATEWAY.is_file(), f"guardian gateway script missing at {GATEWAY}"
+    return GATEWAY.read_text()
+
+
+def test_redeploy_stops_the_guardian_timer():
+    # The timer IS stopped during redeploy — which is exactly why the restart
+    # guarantee below is load-bearing.
+    text = _gateway_text()
+    assert re.search(r"systemctl --user stop genesis-guardian\.timer", text), (
+        "redeploy no longer stops genesis-guardian.timer — invariant premise changed"
+    )
+
+
+def test_exit_trap_restarts_guardian_timer():
+    # An EXIT trap whose body restarts the timer → the guardian can never be
+    # left disabled by an early `set -e` abort mid-redeploy.
+    text = _gateway_text()
+    assert re.search(
+        r"trap\s+'[^']*systemctl --user start genesis-guardian\.timer[^']*'\s+EXIT",
+        text,
+    ), "the EXIT trap that restarts genesis-guardian.timer is gone (idx 24 regression)"
+
+
+def test_exit_trap_is_gated_on_timer_stopped_flag():
+    # The trap only restarts if the timer was actually stopped (_TIMER_STOPPED),
+    # and the flag is both raised (=1 after stop) and cleared (=0 after a clean
+    # restart) so a successful redeploy doesn't double-start.
+    text = _gateway_text()
+    assert re.search(r'\[ "\$_TIMER_STOPPED" = 1 \]', text), (
+        "EXIT trap no longer guards on _TIMER_STOPPED"
+    )
+    assert "_TIMER_STOPPED=1" in text, "_TIMER_STOPPED is never raised after the stop"
+    assert "_TIMER_STOPPED=0" in text, "_TIMER_STOPPED is never cleared after restart"


### PR DESCRIPTION
## What

Audit finding **idx 0**: the guardian's CC recovery brain could be silently
blinded by a misconfigured `cc.work_dir`. `_ensure_work_dir` did
`configured.mkdir(parents=True, exist_ok=True)` then returned the path — but
that mkdir is a *silent no-op* on a directory that already exists but isn't
writable by the guardian user (a root-owned `/var/lib/guardian-snapshots/cc-sessions`
left over from a vintage install). The CC subprocess then ran with an unwritable
`cwd`, so session/cache writes failed and the recovery brain stayed blinded
exactly when it was needed. #965 only handled the *non-creatable* case; the
*exists-but-unwritable* half slipped through.

**Fix:** a real write-probe (`_dir_is_writable` — create + delete a
`.guardian-writeprobe-<pid>` file, since `mkdir(exist_ok=True)` and `os.access`
both report success on a root-owned dir). `_ensure_work_dir` now probes the
configured dir (falls back if unwritable) and the fallback dir (raises `OSError`
if unwritable). The sole caller `_diagnose_with_cc` runs inside `diagnose()`'s
`try/except Exception → _escalate_without_cc`, so "no writable dir anywhere"
degrades cleanly to alert-only (prime directive), never a tick crash. All prior
behavior preserved.

## Also — idx 24 regression lock (no code change)

Audit finding **idx 24** (redeploy must restart `genesis-guardian.timer` on
every failure path) was **already fixed** in `guardian-gateway.sh` (an `EXIT`
trap gated on `_TIMER_STOPPED`). This PR adds a **structural regression-lock
test** so a future edit to the large hand-maintained gateway script can't
silently remove that invariant and leave a host guardian disabled.

## Tests / verification
- TDD: 2 new `_ensure_work_dir` tests (confirmed RED on old code → GREEN), 3
  pre-existing preserved; 3 gateway-invariant lock tests. Full
  `tests/test_guardian/` green (1000 passed).
- Live filesystem E2E on all four paths (writable→configured,
  exists-but-unwritable→fallback, none→OSError, `_dir_is_writable` direct) — PASS.
- Code review: DONE, scope CLEAN, no blocking findings.

## Deploy note (Host-Deploy Gate)
Touches `src/genesis/guardian/` → the host-deploy gate applies. After merge,
`scripts/update.sh` redeploys the guardian to the host and I verify via the
gateway `version` op + a healthy tick. Host is currently healthy and reachable;
idx 0 is latent-class here, not an active fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
