### PR TITLE
feat(autonomy): windowed earn-back evidence — autonomy_events ledger (0067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Demoted autonomy can actually earn its way back now.** Earn-back
+  eligibility used to be computed over a category's entire lifetime record,
+  so after a rough patch the math could require months of flawless behavior
+  before Genesis would even *propose* restoring a level — in practice the
+  demotion was permanent and the system nagged about it forever. Eligibility
+  now looks at a recent evidence window (45 days by default,
+  `earnback.window_days` in `config/autonomy.yaml`): old mistakes age out,
+  recent clean behavior counts, and promotion still always requires your
+  explicit approval. While an earn-back proposal is sitting in your queue,
+  the internal "autonomy regressed" alarm also calms down instead of firing
+  on every awareness tick.
+
 ### Added
 
 - **Genesis now tidies near-duplicate entities in its knowledge graph.** When

--- a/config/autonomy.yaml
+++ b/config/autonomy.yaml
@@ -35,6 +35,13 @@ approval_timeouts:
   task_proposal: null
   irreversible: null     # Wait forever
 
+# Earn-back evidence window (days). Eligibility to propose restoring a
+# demoted autonomy level is computed from the Bayesian posterior over
+# autonomy_events within this window — recent behavior, not lifetime
+# history. Promotion always requires explicit user approval.
+earnback:
+  window_days: 45
+
 # Regression policy
 regression:
   consecutive_corrections_threshold: 2  # Drop one level after this many

--- a/src/genesis/autonomy/state_machine.py
+++ b/src/genesis/autonomy/state_machine.py
@@ -99,6 +99,14 @@ class AutonomyManager:
         defaults = self._config.get("defaults", {})
         return int(defaults.get(category, 1))
 
+    def _earnback_window_days(self) -> int:
+        """Evidence window for earn-back eligibility (config lever)."""
+        earnback = self._config.get("earnback") or {}
+        try:
+            return int(earnback.get("window_days", 45))
+        except (TypeError, ValueError):
+            return 45
+
     # ------------------------------------------------------------------
     # State loading
     # ------------------------------------------------------------------
@@ -148,12 +156,22 @@ class AutonomyManager:
         """Categories whose autonomy can be earned back, gated on EVIDENCE.
 
         A category is a candidate iff it is demoted (``current_level <
-        earned_level``) AND the system's own Bayesian evidence now supports the
-        earned level again (``bayesian_level(successes, corrections) >=
-        earned_level``). This keeps proposals silent while the lower level is
-        genuinely correct and fires only once the category re-earns the level.
-        Promotion itself still requires explicit user approval — this only
-        identifies who is eligible.
+        earned_level``) AND recent evidence supports the earned level again:
+        ``bayesian_level(*windowed_counts(category))`` over the last
+        ``earnback.window_days`` (config, default 45) must reach the earned
+        level. This keeps proposals silent while the lower level is genuinely
+        correct and fires once the category re-earns the level with RECENT
+        behavior. Promotion itself still requires explicit user approval —
+        this only identifies who is eligible.
+
+        Why windowed, not lifetime: the lifetime posterior over
+        ``total_successes``/``total_corrections`` is dominated by history — a
+        category with a long mixed record needs dozens of consecutive
+        successes before the lifetime posterior recovers, making earn-back
+        mathematically unreachable after a deep regression. The
+        ``autonomy_events`` ledger (append-only, no backfill) scopes the
+        posterior to what the category has actually done lately. An empty
+        window means no evidence, not eligibility.
 
         Note: ``consecutive_corrections`` is deliberately NOT part of the gate.
         ``record_correction`` resets it to 0 on a regression, so it would be 0
@@ -161,25 +179,33 @@ class AutonomyManager:
         sufficient signal.
 
         Returns dicts: ``{category, current_level, target_level,
-        total_successes, total_corrections, posterior, last_regression_at}``.
+        total_successes, total_corrections, window_successes,
+        window_corrections, window_days, posterior, last_regression_at}``
+        where ``posterior`` is the WINDOWED posterior driving eligibility
+        (lifetime totals are included for context only).
         """
+        window_days = self._earnback_window_days()
         candidates: list[dict] = []
         for row in await crud.list_all(self._db):
             current = row["current_level"]
             earned = row["earned_level"]
             if current >= earned:
                 continue  # not demoted — nothing to earn back
-            successes = row.get("total_successes", 0)
-            corrections = row.get("total_corrections", 0)
-            if crud.bayesian_level(successes, corrections) < earned:
-                continue  # evidence does not yet support the earned level
+            w_successes, w_corrections = await crud.windowed_counts(
+                self._db, row["category"], window_days=window_days,
+            )
+            if crud.bayesian_level(w_successes, w_corrections) < earned:
+                continue  # recent evidence does not yet support the earned level
             candidates.append({
                 "category": row["category"],
                 "current_level": current,
                 "target_level": earned,
-                "total_successes": successes,
-                "total_corrections": corrections,
-                "posterior": crud.bayesian_posterior(successes, corrections),
+                "total_successes": row.get("total_successes", 0),
+                "total_corrections": row.get("total_corrections", 0),
+                "window_successes": w_successes,
+                "window_corrections": w_corrections,
+                "window_days": window_days,
+                "posterior": crud.bayesian_posterior(w_successes, w_corrections),
                 "last_regression_at": row.get("last_regression_at"),
             })
         return candidates

--- a/src/genesis/db/crud/autonomy.py
+++ b/src/genesis/db/crud/autonomy.py
@@ -1,6 +1,9 @@
-"""CRUD operations for autonomy_state table."""
+"""CRUD operations for autonomy_state + the autonomy_events evidence ledger."""
 
 from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
@@ -147,6 +150,9 @@ async def record_correction(
         posterior = bayesian_posterior(row["total_successes"], new_corrections)
         regression_reason = f"Bayesian regression (posterior={posterior:.3f}) at {corrected_at}"
         last_regression = corrected_at
+    await _insert_event(
+        db, category=row["category"], kind="correction", occurred_at=corrected_at,
+    )
     cursor = await db.execute(
         """UPDATE autonomy_state SET
            consecutive_corrections = ?, total_corrections = ?,
@@ -169,6 +175,9 @@ async def record_success(
         return False
     new_successes = row["total_successes"] + 1
 
+    await _insert_event(
+        db, category=row["category"], kind="success", occurred_at=updated_at,
+    )
     cursor = await db.execute(
         """UPDATE autonomy_state SET
            total_successes = ?, consecutive_corrections = 0,
@@ -178,6 +187,43 @@ async def record_success(
     )
     await db.commit()
     return cursor.rowcount > 0
+
+
+async def _insert_event(
+    db: aiosqlite.Connection, *, category: str, kind: str, occurred_at: str
+) -> None:
+    """Append to the autonomy_events evidence ledger (same transaction as the
+    counter update — the caller owns the commit)."""
+    await db.execute(
+        "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+        "VALUES (?, ?, ?, ?)",
+        (str(uuid.uuid4()), category, kind, occurred_at),
+    )
+
+
+async def windowed_counts(
+    db: aiosqlite.Connection,
+    category: str,
+    *,
+    window_days: int,
+    now: datetime | None = None,
+) -> tuple[int, int]:
+    """(successes, corrections) for *category* within the last *window_days*.
+
+    Reads the append-only ``autonomy_events`` ledger. Events predate nothing:
+    the ledger starts empty on migration (no backfill), so windowed evidence
+    accumulates only from genuine post-migration activity. *now* is
+    injectable for tests.
+    """
+    ref = now or datetime.now(UTC)
+    cutoff = (ref - timedelta(days=window_days)).isoformat()
+    cursor = await db.execute(
+        "SELECT kind, COUNT(*) FROM autonomy_events "
+        "WHERE category = ? AND occurred_at >= ? GROUP BY kind",
+        (category, cutoff),
+    )
+    counts = {row[0]: row[1] for row in await cursor.fetchall()}
+    return counts.get("success", 0), counts.get("correction", 0)
 
 
 async def promote(

--- a/src/genesis/db/migrations/0067_autonomy_events.py
+++ b/src/genesis/db/migrations/0067_autonomy_events.py
@@ -1,0 +1,43 @@
+"""Add ``autonomy_events`` — append-only success/correction evidence ledger.
+
+The earn-back gate (``AutonomyManager.detect_earnback_candidates``) previously
+computed the Bayesian posterior over LIFETIME counters
+(``autonomy_state.total_successes`` / ``total_corrections``). After a deep
+regression that gate is mathematically unreachable: a category with a long
+mixed history needs dozens of consecutive successes before the lifetime
+posterior recovers, so demoted autonomy stays pinned for months with no
+path back — while the awareness signal reports the regression forever.
+
+This ledger records each success/correction WITH its timestamp so eligibility
+can be computed over a recent evidence window (``earnback.window_days`` in
+``config/autonomy.yaml``). Regression math is untouched — lifetime counters
+remain the input for ``record_correction``'s level drops.
+
+Deliberately NO backfill: lifetime counters predate this ledger, and
+fabricating ``occurred_at`` timestamps would manufacture evidence. Categories
+become earn-back-eligible as genuine windowed evidence accumulates.
+
+Fresh/test DBs get the table from the canonical CREATE TABLE in
+``db/schema/_tables.py``; this numbered migration covers the existing-DB
+upgrade path. Idempotent: CREATE TABLE/INDEX IF NOT EXISTS. No commit — the
+runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """CREATE TABLE IF NOT EXISTS autonomy_events (
+            id          TEXT PRIMARY KEY,
+            category    TEXT NOT NULL,
+            kind        TEXT NOT NULL CHECK (kind IN ('success', 'correction')),
+            occurred_at TEXT NOT NULL
+        )"""
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_autonomy_events_cat_time "
+        "ON autonomy_events(category, occurred_at)"
+    )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -229,6 +229,14 @@ TABLES = {
             updated_at             TEXT NOT NULL
         )
     """,
+    "autonomy_events": """
+        CREATE TABLE IF NOT EXISTS autonomy_events (
+            id          TEXT PRIMARY KEY,
+            category    TEXT NOT NULL,
+            kind        TEXT NOT NULL CHECK (kind IN ('success', 'correction')),
+            occurred_at TEXT NOT NULL
+        )
+    """,
     "outreach_history": """
         CREATE TABLE IF NOT EXISTS outreach_history (
             id                  TEXT PRIMARY KEY,
@@ -1928,6 +1936,7 @@ KNOWLEDGE_FTS5_DDL = """
 # ─── Indexes ──────────────────────────────────────────────────────────────────
 
 INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_autonomy_events_cat_time ON autonomy_events(category, occurred_at)",
     "CREATE INDEX IF NOT EXISTS idx_attention_events_session ON attention_events(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_attention_events_ts ON attention_events(ts)",
     "CREATE INDEX IF NOT EXISTS idx_attention_events_unlabeled ON attention_events(acceptance_signal) WHERE acceptance_signal IS NULL",

--- a/src/genesis/learning/signals/autonomy_activity.py
+++ b/src/genesis/learning/signals/autonomy_activity.py
@@ -21,9 +21,13 @@ class AutonomyActivityCollector:
     | Stable (no corrections, no level gaps)        | 0.0         |
     | Corrections accumulating (consecutive > 0)    | 0.3         |
     | Near regression (consecutive >= threshold-1)  | 0.7         |
-    | Regression active (current < earned level)    | 1.0         |
+    | Regression, earn-back proposal pending        | 0.7         |
+    | Regression active, no earn-back path pending  | 1.0         |
 
     Checks ALL autonomy categories — the worst state drives the signal.
+    A regression with a pending ``autonomy_earnback`` proposal is dampened
+    to 0.7: the system has already surfaced the recovery path and is
+    waiting on the user, so a pinned 1.0 would be pure reflection noise.
     """
 
     signal_name = "autonomy_activity"
@@ -52,8 +56,14 @@ class AutonomyActivityCollector:
             category_name = cat.get("category", "unknown")
 
             if current_level < earned_level:
-                # Active regression — strongest signal
-                if worst_value < 1.0:
+                # Active regression — strongest signal, unless the recovery
+                # path is already sitting with the user as a pending
+                # earn-back proposal.
+                if await self._earnback_pending(category_name):
+                    if worst_value < 0.7:
+                        worst_value = 0.7
+                        worst_source = f"regression_pending_earnback_{category_name}"
+                elif worst_value < 1.0:
                     worst_value = 1.0
                     worst_source = f"regression_{category_name}"
             elif consecutive >= self._REGRESSION_THRESHOLD - 1:
@@ -68,11 +78,30 @@ class AutonomyActivityCollector:
 
         return self._reading(worst_value, worst_source)
 
+    async def _earnback_pending(self, category: str) -> bool:
+        """True if a pending earn-back proposal exists for *category*."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT 1 FROM ego_proposals WHERE status = 'pending' "
+                "AND action_type = 'autonomy_earnback' "
+                "AND action_category = ? LIMIT 1",
+                (category,),
+            )
+            return await cursor.fetchone() is not None
+        except Exception:
+            logger.debug("earnback-pending check failed", exc_info=True)
+            return False
+
     def _reading(self, value: float, source: str) -> SignalReading:
         return SignalReading(
             name=self.signal_name,
             value=value,
             source=source,
             collected_at=datetime.now(UTC).isoformat(),
-            baseline_note="0.0=stable autonomy (normal). 0.3=corrections accumulating, 0.7=near regression, 1.0=active regression",
+            baseline_note=(
+                "0.0=stable autonomy (normal). 0.3=corrections accumulating, "
+                "0.7=near regression OR regression with an earn-back proposal "
+                "awaiting the user, 1.0=active regression with no pending "
+                "earn-back path"
+            ),
         )

--- a/tests/ego/test_earnback.py
+++ b/tests/ego/test_earnback.py
@@ -4,7 +4,7 @@ cadence detection/anti-spam path."""
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
@@ -246,6 +246,15 @@ async def test_e2e_earnback_promotes_through_resolution(db):
     await db.execute(
         "UPDATE autonomy_state SET total_successes=50, total_corrections=2 WHERE id='ds'",
     )
+    # Windowed gate (migration 0067): eligibility reads recent autonomy_events,
+    # not lifetime counters — seed matching in-window evidence.
+    occurred = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    for i, kind in enumerate(["success"] * 50 + ["correction"] * 2):
+        await db.execute(
+            "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+            "VALUES (?, 'direct_session', ?, ?)",
+            (f"ev-{i}", kind, occurred),
+        )
     await db.commit()
 
     mgr = AutonomyManager(db=db)

--- a/tests/test_autonomy/test_state_machine.py
+++ b/tests/test_autonomy/test_state_machine.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
@@ -437,44 +437,194 @@ async def _seed_autonomy_state(
     await db.commit()
 
 
+async def _seed_autonomy_events(
+    db, category, *, successes=0, corrections=0, age_days=1,
+):
+    """Insert autonomy_events rows *age_days* old for windowed-gate tests."""
+    occurred = (datetime.now(UTC) - timedelta(days=age_days)).isoformat()
+    rows = [("success",)] * successes + [("correction",)] * corrections
+    for i, (kind,) in enumerate(rows):
+        await db.execute(
+            "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+            "VALUES (?, ?, ?, ?)",
+            (f"{category}-{kind}-{age_days}-{i}", category, kind, occurred),
+        )
+    await db.commit()
+
+
 class TestDetectEarnbackCandidates:
     @pytest.mark.asyncio
     async def test_candidate_when_demoted_and_evidence_recovered(self, manager, db):
-        # 50 successes / 2 corrections → posterior 0.94 → L4 supports earned L4.
+        # 50 in-window successes / 2 corrections → posterior 0.94 → L4.
         await _seed_autonomy_state(
             db, "direct_session", current=2, earned=4, successes=50, corrections=2,
+        )
+        await _seed_autonomy_events(
+            db, "direct_session", successes=50, corrections=2, age_days=1,
         )
         cands = await manager.detect_earnback_candidates()
         assert len(cands) == 1
         assert cands[0]["category"] == "direct_session"
         assert cands[0]["current_level"] == 2
         assert cands[0]["target_level"] == 4
+        assert cands[0]["window_successes"] == 50
+        assert cands[0]["window_corrections"] == 2
 
     @pytest.mark.asyncio
     async def test_no_candidate_when_not_demoted(self, manager, db):
         await _seed_autonomy_state(
             db, "direct_session", current=4, earned=4, successes=50, corrections=2,
         )
+        await _seed_autonomy_events(
+            db, "direct_session", successes=50, corrections=2, age_days=1,
+        )
         assert await manager.detect_earnback_candidates() == []
 
     @pytest.mark.asyncio
-    async def test_no_candidate_when_evidence_insufficient(self, manager, db):
-        # Live direct_session shape: 33S / 14C → posterior 0.694 → L3 < earned L4.
+    async def test_no_candidate_when_window_evidence_insufficient(self, manager, db):
+        # In-window 33S / 14C → posterior 0.694 → L3 < earned L4.
         await _seed_autonomy_state(
             db, "direct_session", current=3, earned=4, successes=33, corrections=14,
         )
+        await _seed_autonomy_events(
+            db, "direct_session", successes=33, corrections=14, age_days=1,
+        )
         assert await manager.detect_earnback_candidates() == []
+
+    @pytest.mark.asyncio
+    async def test_no_candidate_on_empty_window(self, manager, db):
+        # Lifetime counters look great, but NO events in the window (ledger
+        # empty — e.g. right after migration). No evidence ≠ eligibility.
+        await _seed_autonomy_state(
+            db, "direct_session", current=2, earned=4, successes=50, corrections=2,
+        )
+        assert await manager.detect_earnback_candidates() == []
+
+    @pytest.mark.asyncio
+    async def test_candidate_when_old_corrections_aged_out(self, manager, db):
+        # THE unreachable-gate fix: lifetime history is poisoned (38S/21C →
+        # lifetime L3 < earned L4), but the corrections are months old and
+        # recent behavior is clean → windowed posterior supports L4.
+        await _seed_autonomy_state(
+            db, "direct_session", current=3, earned=4, successes=38, corrections=21,
+        )
+        await _seed_autonomy_events(
+            db, "direct_session", corrections=21, age_days=100,  # outside 45d
+        )
+        await _seed_autonomy_events(
+            db, "direct_session", successes=12, age_days=5,  # inside window
+        )
+        cands = await manager.detect_earnback_candidates()
+        assert len(cands) == 1
+        assert cands[0]["category"] == "direct_session"
+        assert cands[0]["window_corrections"] == 0
+        assert cands[0]["posterior"] > 0.9
+
+    @pytest.mark.asyncio
+    async def test_recent_corrections_block_candidacy(self, manager, db):
+        # Same lifetime shape, but the corrections are RECENT → still blocked.
+        await _seed_autonomy_state(
+            db, "direct_session", current=3, earned=4, successes=38, corrections=21,
+        )
+        await _seed_autonomy_events(
+            db, "direct_session", successes=12, corrections=21, age_days=5,
+        )
+        assert await manager.detect_earnback_candidates() == []
+
+    @pytest.mark.asyncio
+    async def test_window_days_config_lever(self, db, tmp_path):
+        # window_days=200 pulls the "old" corrections back into scope.
+        cfg = tmp_path / "autonomy_window.yaml"
+        cfg.write_text(yaml.dump({"earnback": {"window_days": 200}}))
+        mgr = AutonomyManager(db=db, config_path=cfg)
+        await _seed_autonomy_state(
+            db, "direct_session", current=3, earned=4, successes=38, corrections=21,
+        )
+        await _seed_autonomy_events(db, "direct_session", corrections=21, age_days=100)
+        await _seed_autonomy_events(db, "direct_session", successes=12, age_days=5)
+        assert await mgr.detect_earnback_candidates() == []
 
     @pytest.mark.asyncio
     async def test_returns_only_eligible_categories(self, manager, db):
         await _seed_autonomy_state(
             db, "direct_session", current=2, earned=4, successes=50, corrections=2,
+        )
+        await _seed_autonomy_events(
+            db, "direct_session", successes=50, corrections=2, age_days=1,
         )  # eligible
         await _seed_autonomy_state(
             db, "outreach", current=1, earned=1, successes=0, corrections=0,
         )  # not demoted
         await _seed_autonomy_state(
             db, "sub_agent", current=2, earned=3, successes=3, corrections=14,
+        )
+        await _seed_autonomy_events(
+            db, "sub_agent", successes=3, corrections=14, age_days=1,
         )  # evidence too low (L1 < earned L3)
         cands = await manager.detect_earnback_candidates()
         assert [c["category"] for c in cands] == ["direct_session"]
+
+
+# ---------------------------------------------------------------------------
+# autonomy_events evidence ledger (windowed earn-back, migration 0067)
+# ---------------------------------------------------------------------------
+
+
+class TestAutonomyEventsLedger:
+    @pytest.mark.asyncio
+    async def test_record_success_writes_event(self, manager, db):
+        await manager.load_or_create_defaults()
+        await manager.record_success("direct_session")
+        cursor = await db.execute(
+            "SELECT category, kind FROM autonomy_events",
+        )
+        rows = [tuple(r) for r in await cursor.fetchall()]
+        assert rows == [("direct_session", "success")]
+
+    @pytest.mark.asyncio
+    async def test_record_correction_writes_event(self, manager, db):
+        await manager.load_or_create_defaults()
+        ts = datetime.now(UTC).isoformat()
+        await manager.record_correction("outreach", corrected_at=ts)
+        cursor = await db.execute(
+            "SELECT category, kind, occurred_at FROM autonomy_events",
+        )
+        rows = [tuple(r) for r in await cursor.fetchall()]
+        assert rows == [("outreach", "correction", ts)]
+
+    @pytest.mark.asyncio
+    async def test_windowed_counts_boundary(self, db):
+        from genesis.db.crud.autonomy import windowed_counts
+
+        now = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
+        inside = (now - timedelta(days=44)).isoformat()
+        outside = (now - timedelta(days=46)).isoformat()
+        for i, (kind, ts) in enumerate([
+            ("success", inside), ("success", outside),
+            ("correction", inside), ("correction", outside),
+        ]):
+            await db.execute(
+                "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+                "VALUES (?, 'direct_session', ?, ?)",
+                (f"ev-{i}", kind, ts),
+            )
+        await db.commit()
+        s, c = await windowed_counts(
+            db, "direct_session", window_days=45, now=now,
+        )
+        assert (s, c) == (1, 1)
+
+    @pytest.mark.asyncio
+    async def test_windowed_counts_scoped_to_category(self, db):
+        from genesis.db.crud.autonomy import windowed_counts
+
+        now = datetime(2026, 7, 18, 12, 0, tzinfo=UTC)
+        await db.execute(
+            "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+            "VALUES ('ev-x', 'outreach', 'success', ?)",
+            ((now - timedelta(days=1)).isoformat(),),
+        )
+        await db.commit()
+        assert await windowed_counts(
+            db, "direct_session", window_days=45, now=now,
+        ) == (0, 0)

--- a/tests/test_db/test_autonomy_events_migration.py
+++ b/tests/test_db/test_autonomy_events_migration.py
@@ -1,0 +1,63 @@
+"""Migration 0067 — autonomy_events ledger: idempotence + both build paths.
+
+The migration does NOT commit (the runner owns the transaction); these tests
+just read back on the same aiosqlite connection.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M67 = importlib.import_module("genesis.db.migrations.0067_autonomy_events")
+
+
+async def _table_and_index(db) -> tuple[bool, bool]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='autonomy_events'"
+    )
+    has_table = await cur.fetchone() is not None
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' "
+        "AND name='idx_autonomy_events_cat_time'"
+    )
+    has_index = await cur.fetchone() is not None
+    return has_table, has_index
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    db = await aiosqlite.connect(str(tmp_path / "m.db"))
+    try:
+        await M67.up(db)
+        await db.commit()
+        await M67.up(db)  # second run must be a no-op, not an error
+        await db.commit()
+        assert await _table_and_index(db) == (True, True)
+        # CHECK constraint enforced
+        await db.execute(
+            "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+            "VALUES ('e1', 'direct_session', 'success', '2026-07-18T00:00:00+00:00')"
+        )
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO autonomy_events (id, category, kind, occurred_at) "
+                "VALUES ('e2', 'direct_session', 'bogus', '2026-07-18T00:00:00+00:00')"
+            )
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_base_path_has_table(tmp_path):
+    """Fresh installs get the table from create_all_tables (both build paths)."""
+    from genesis.db.schema import create_all_tables
+
+    db = await aiosqlite.connect(str(tmp_path / "b.db"))
+    try:
+        await create_all_tables(db)
+        assert await _table_and_index(db) == (True, True)
+    finally:
+        await db.close()

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -74,6 +74,7 @@ EXPECTED_TABLES = [
     "repo_pulse_annotations",  # session-manager PR-4a: PR ↔ ledger-item matches
     "ledger_predictions",  # WS-2 P1a: cognitive-ledger falsifiable prediction rows
     "entity_adjudications",  # entity-node merge-vs-distinct decision ledger (drainer)
+    "autonomy_events",  # append-only success/correction ledger for windowed earn-back
 ]
 
 

--- a/tests/test_learning/test_new_signals.py
+++ b/tests/test_learning/test_new_signals.py
@@ -359,6 +359,49 @@ class TestAutonomyActivityCollector:
         r = await AutonomyActivityCollector(db).collect()
         assert r.value == 1.0
 
+    async def test_regression_with_pending_earnback_dampens(self, db):
+        """A regression whose earn-back proposal is already awaiting the user
+        reads 0.7, not a pinned 1.0 — the recovery path is out of the
+        system's hands."""
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        await self._insert_autonomy_state(
+            db, "background_cognitive",
+            current_level=2, earned_level=4,
+        )
+        await db.execute(
+            "INSERT INTO ego_proposals (id, action_type, action_category, "
+            "content, rationale, confidence, urgency, status, created_at) "
+            "VALUES ('eb1', 'autonomy_earnback', 'background_cognitive', "
+            "'Restore background_cognitive to L4', 'evidence recovered', "
+            "0.9, 'low', 'pending', ?)",
+            (_now_iso(),),
+        )
+        await db.commit()
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 0.7
+        assert r.source == "regression_pending_earnback_background_cognitive"
+
+    async def test_regression_with_resolved_earnback_stays_hot(self, db):
+        """A rejected/expired earn-back proposal does NOT dampen the signal."""
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        await self._insert_autonomy_state(
+            db, "background_cognitive",
+            current_level=2, earned_level=4,
+        )
+        await db.execute(
+            "INSERT INTO ego_proposals (id, action_type, action_category, "
+            "content, rationale, confidence, urgency, status, created_at) "
+            "VALUES ('eb2', 'autonomy_earnback', 'background_cognitive', "
+            "'Restore background_cognitive to L4', 'evidence recovered', "
+            "0.9, 'low', 'rejected', ?)",
+            (_now_iso(),),
+        )
+        await db.commit()
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 1.0
+
     async def test_isinstance_protocol(self, db):
         from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
 


### PR DESCRIPTION
## Problem

Earn-back eligibility (`detect_earnback_candidates`) computed `bayesian_level(total_successes, total_corrections)` over **lifetime** counters. After a deep regression this gate is mathematically unreachable — e.g. a category at 38S/21C (posterior 0.64) needs ~85 more *consecutive* successes to reach the L4 threshold. Result on a live install: a category demoted for 8 weeks, zero earn-back proposals ever created, and the `autonomy_activity` awareness signal pinned at 1.0 the whole time, generating recurring reflection noise about a condition the system could never resolve.

## Fix

- **`autonomy_events`** — append-only `(id, category, kind CHECK success|correction, occurred_at)` ledger + `(category, occurred_at)` index. `record_success`/`record_correction` append in the same transaction as the counter update. Migration `0067` (idempotent) + canonical DDL in `_tables.py` (both build paths).
- **Windowed gate** — `detect_earnback_candidates` now computes the posterior over `windowed_counts(category, window_days)`; `earnback.window_days` is a config lever in `config/autonomy.yaml` (default 45, code fallback identical). An empty window means *no evidence*, not eligibility. Candidate dicts carry `window_successes/window_corrections/window_days`; `posterior` is the windowed one (drives the proposal's stated confidence). Regression math and every other lifetime-counter consumer untouched.
- **No backfill** — lifetime counters predate the ledger; fabricating `occurred_at` would manufacture evidence. Categories become eligible as genuine windowed evidence accumulates.
- **Signal addendum** — `autonomy_activity`: regression **with** a pending `autonomy_earnback` proposal → 0.7 (`regression_pending_earnback_<cat>`); without → 1.0 as before. The dampened state means "recovery path is awaiting the user" — a pinned 1.0 there is pure noise.

## Tests

Migration idempotence + CHECK enforcement + base path; event writes through the manager; `windowed_counts` boundary (44d in / 46d out, injected clock) + category scoping; candidate matrix (recovered-in-window, insufficient-in-window, **empty window**, **old corrections aged out** — the unreachable-gate case, recent corrections still block, window_days lever); collector 0.7-vs-1.0 (pending vs resolved proposal); e2e earnback flow reseeded with windowed events. 130 passed across the five touched suites.

## Deploy path

Existing installs: git pull + restart (migration applies at boot). Fresh installs: base-path DDL. Config default works with zero overlay; `earnback.window_days` is the documented lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)