### PR TITLE
fix(reflection): topic delivery builds from parsed fields — raw output never reaches Telegram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reflection updates in Telegram are now real summaries.** The reflection
+  topic previously relayed the model's raw output, so a malformed reflection
+  could leak internal tool-call chatter to your Telegram verbatim. Messages
+  are now built only from the parsed reflection fields (assessment, key
+  observations, next focus); when a reflection's output can't be parsed you
+  get a short "completed — stored for review" notice instead of noise, and
+  unparseable output is no longer stored as a reflection summary that later
+  reflections would re-read and argue with.
+
 ### Added
 
 - **Genesis now tidies near-duplicate entities in its knowledge graph.** When

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -21,6 +21,7 @@ from genesis.autonomy.types import ActionClass, ApprovalDecision, AutonomyCatego
 from genesis.awareness.types import Depth
 from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 from genesis.cc.reflection_bridge._output import (
+    format_topic_summary,
     route_deep_output,
     send_to_topic,
     store_reflection_output,
@@ -477,8 +478,11 @@ class CCReflectionBridge:
                 except Exception:
                     logger.warning("Failed to mark influenced observations", exc_info=True)
 
-        # 6. Send to topic
-        await send_to_topic(session_id, depth, output, topic_manager=self._topic_manager)
+        # 6. Send to topic — parsed-fields summary only, never raw output.text
+        await send_to_topic(
+            session_id, depth, format_topic_summary(depth, output),
+            topic_manager=self._topic_manager,
+        )
 
         logger.info(
             "%s %s reflection completed (cost=$%.4f, tokens=%d+%d)",

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -417,19 +417,26 @@ def format_topic_summary(depth, output) -> str:
         return fallback
 
     parts = [header]
-    assessment = data.get("assessment") or data.get("cognitive_state_update")
-    if isinstance(assessment, str) and assessment.strip():
-        parts.append(_html.escape(assessment[:1500]))
-    obs_lines = []
-    for obs in (data.get("observations") or [])[:3]:
-        text = obs if isinstance(obs, str) else ""
-        if text.strip():
-            obs_lines.append(f"• {_html.escape(text[:300])}")
-    if obs_lines:
-        parts.append("\n".join(obs_lines))
-    focus = data.get("focus_next_week") or data.get("focus_next")
-    if isinstance(focus, str) and focus.strip():
-        parts.append(f"<b>Focus:</b> {_html.escape(focus[:500])}")
+    try:
+        assessment = data.get("assessment") or data.get("cognitive_state_update")
+        if isinstance(assessment, str) and assessment.strip():
+            parts.append(_html.escape(assessment[:1500]))
+        obs = data.get("observations") or []
+        obs_lines = []
+        for entry in (obs if isinstance(obs, list) else [])[:3]:
+            text = entry if isinstance(entry, str) else ""
+            if text.strip():
+                obs_lines.append(f"• {_html.escape(text[:300])}")
+        if obs_lines:
+            parts.append("\n".join(obs_lines))
+        focus = data.get("focus_next_week") or data.get("focus_next")
+        if isinstance(focus, str) and focus.strip():
+            parts.append(f"<b>Focus:</b> {_html.escape(focus[:500])}")
+    except Exception:
+        # A schema-violating field shape must degrade to the liveness
+        # one-liner, never crash the reflection at the delivery step.
+        logger.warning("format_topic_summary field extraction failed", exc_info=True)
+        return fallback
 
     if len(parts) == 1:
         return (

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -8,6 +8,7 @@ storage, light-output parsing, and topic forwarding.
 from __future__ import annotations
 
 import hashlib
+import html as _html
 import json
 import logging
 import re
@@ -358,8 +359,15 @@ async def _store_reflection_summary(
                 if obs:
                     summary_parts.append(str(obs))
     except (json.JSONDecodeError, TypeError):
-        if output.text.strip():
-            summary_parts.append(output.text[:2000])
+        # Unparseable output is NOT a reflection summary — storing the raw
+        # text creates a reflection_summary observation full of tool-call
+        # chatter that later re-surfaces in reflection context (the
+        # phantom-claim feedback loop). Log and skip.
+        logger.warning(
+            "Reflection summary skipped: %s output was not parseable JSON",
+            source,
+        )
+        return
     if summary_parts:
         # Cooldown: skip if a reflection_summary from this source exists
         # within the last 30 minutes.
@@ -387,8 +395,53 @@ async def _store_reflection_summary(
             )
 
 
-async def send_to_topic(session_id: str, depth, output, *, topic_manager) -> None:
-    """Send a reflection summary to the depth-specific topic."""
+def format_topic_summary(depth, output) -> str:
+    """Build the Telegram topic message from PARSED reflection fields only.
+
+    Raw ``output.text`` must never reach the topic: when the model output is
+    unparseable (tool-call chatter, truncation, partial JSON) the raw text is
+    internal noise, not a summary — it has leaked mid-session artifacts to
+    the user verbatim. The topic stays a liveness surface: parse failure
+    still produces a one-liner, never silence and never raw text.
+    """
+    header = f"<b>{depth.value} Reflection</b>"
+    fallback = (
+        f"{header}\n\nReflection completed — output was not parseable; "
+        "stored for review."
+    )
+    try:
+        data = json.loads(_extract_fenced_json(output.text))
+    except (json.JSONDecodeError, TypeError):
+        return fallback
+    if not isinstance(data, dict):
+        return fallback
+
+    parts = [header]
+    assessment = data.get("assessment") or data.get("cognitive_state_update")
+    if isinstance(assessment, str) and assessment.strip():
+        parts.append(_html.escape(assessment[:1500]))
+    obs_lines = []
+    for obs in (data.get("observations") or [])[:3]:
+        text = obs if isinstance(obs, str) else ""
+        if text.strip():
+            obs_lines.append(f"• {_html.escape(text[:300])}")
+    if obs_lines:
+        parts.append("\n".join(obs_lines))
+    focus = data.get("focus_next_week") or data.get("focus_next")
+    if isinstance(focus, str) and focus.strip():
+        parts.append(f"<b>Focus:</b> {_html.escape(focus[:500])}")
+
+    if len(parts) == 1:
+        return (
+            f"{header}\n\nReflection completed — no summary fields in "
+            "output; stored for review."
+        )
+    return "\n\n".join(parts)
+
+
+async def send_to_topic(session_id: str, depth, text: str, *, topic_manager) -> None:
+    """Send pre-built topic text (see ``format_topic_summary``) to the
+    depth-specific topic. Never receives raw model output."""
     if not topic_manager:
         logger.warning(
             "send_to_topic: topic_manager not set — skipping %s topic send",
@@ -396,11 +449,7 @@ async def send_to_topic(session_id: str, depth, output, *, topic_manager) -> Non
         )
         return
     category = f"reflection_{depth.value.lower()}"
-    summary = (
-        f"<b>{depth.value} Reflection</b>\n\n"
-        f"{output.text[:3000]}"
-    )
     try:
-        await topic_manager.send_to_category(category, summary)
+        await topic_manager.send_to_category(category, text)
     except Exception:
         logger.warning("Failed to send reflection to topic %s", category, exc_info=True)

--- a/tests/test_cc/test_reflection_bridge.py
+++ b/tests/test_cc/test_reflection_bridge.py
@@ -864,3 +864,102 @@ async def test_light_prompt_no_prior_context(db):
 
     assert "Previous Light Cycle Finding" not in prompt
     assert "Perform a Light reflection" in prompt
+
+
+# ── Topic delivery gating (PR-5a): parsed fields only, never raw text ──────
+
+
+def _cc_output(text: str) -> CCOutput:
+    return CCOutput(
+        session_id="refl-topic-1",
+        text=text,
+        model_used="haiku",
+        cost_usd=0.001,
+        input_tokens=100,
+        output_tokens=50,
+        duration_ms=1000,
+        exit_code=0,
+    )
+
+
+def test_topic_summary_parse_failure_one_liner():
+    """Unparseable output → liveness one-liner; raw text NEVER leaks."""
+    from genesis.cc.reflection_bridge._output import format_topic_summary
+
+    raw = "That last tool call was a mistake INTERNAL-CHATTER-MARKER {broken"
+    msg = format_topic_summary(Depth.DEEP, _cc_output(raw))
+    assert "Deep Reflection" in msg
+    assert "not parseable" in msg
+    assert "INTERNAL-CHATTER-MARKER" not in msg
+
+
+def test_topic_summary_structured_fields():
+    from genesis.cc.reflection_bridge._output import format_topic_summary
+
+    payload = json.dumps({
+        "assessment": "Steady state; memory pipeline healthy.",
+        "observations": ["obs one", "obs two", "obs three", "obs four"],
+        "focus_next": "Watch the embedding backlog.",
+        "confidence": 0.8,
+    })
+    msg = format_topic_summary(Depth.LIGHT, _cc_output(f"```json\n{payload}\n```"))
+    assert "Light Reflection" in msg
+    assert "Steady state; memory pipeline healthy." in msg
+    assert "obs one" in msg and "obs three" in msg
+    assert "obs four" not in msg  # capped at 3
+    assert "Watch the embedding backlog." in msg
+
+
+def test_topic_summary_no_fields_one_liner():
+    from genesis.cc.reflection_bridge._output import format_topic_summary
+
+    msg = format_topic_summary(
+        Depth.DEEP, _cc_output(json.dumps({"confidence": 0.9})),
+    )
+    assert "no summary fields" in msg
+
+
+def test_topic_summary_escapes_html():
+    from genesis.cc.reflection_bridge._output import format_topic_summary
+
+    payload = json.dumps({"assessment": "a <b>bold</b> & risky claim"})
+    msg = format_topic_summary(Depth.LIGHT, _cc_output(payload))
+    assert "&lt;b&gt;" in msg
+    assert "&amp;" in msg
+
+
+@pytest.mark.asyncio
+async def test_send_to_topic_sends_prebuilt_text():
+    from unittest.mock import AsyncMock
+
+    from genesis.cc.reflection_bridge._output import send_to_topic
+
+    tm = AsyncMock()
+    await send_to_topic("sid", Depth.DEEP, "<b>Deep Reflection</b>\n\nready", topic_manager=tm)
+    tm.send_to_category.assert_awaited_once_with(
+        "reflection_deep", "<b>Deep Reflection</b>\n\nready",
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_reflection_summary_skips_unparseable(db):
+    """Parse failure no longer stores raw text as a reflection_summary
+    observation (the phantom-claim feedback loop source)."""
+    from genesis.cc.reflection_bridge._output import store_reflection_output
+
+    tick = TickResult(
+        tick_id="tick-garbage-1",
+        timestamp="2026-05-30T14:00:00",
+        source="scheduled",
+        signals=[],
+        scores=[],
+        classified_depth=Depth.LIGHT,
+        trigger_reason="test",
+    )
+    output = _cc_output("tool-call chatter, definitely { not json")
+    await store_reflection_output(Depth.LIGHT, tick, output, db=db)
+
+    rows = await db.execute_fetchall(
+        "SELECT content FROM observations WHERE type = 'reflection_summary'"
+    )
+    assert rows == []


### PR DESCRIPTION
## Problem

Two raw-text passthroughs in the reflection output path:

1. `send_to_topic` sent `output.text[:3000]` to the Telegram reflection topic verbatim. When a reflection's output was unparseable (tool-call chatter, truncation, partial JSON), the user received internal mid-session artifacts — an actual leak observed on a live install ("That last tool call was a mistake…").
2. `_store_reflection_summary`'s parse-failure fallback stored `output.text[:2000]` as a `reflection_summary` observation. That observation later re-enters reflection context, seeding the assert/debunk phantom-claim loop.

## Fix

- **`format_topic_summary(depth, output)`** — builds the topic message from PARSED fields only (`assessment`/`cognitive_state_update`, first 3 `observations`, `focus_next[_week]`), HTML-escaped. Parse failure → "Reflection completed — output was not parseable; stored for review." Parseable-but-empty → "no summary fields" one-liner. The topic stays a liveness surface on every path; raw text reaches it on none.
- **`send_to_topic`** now takes pre-built text; the single caller (`_bridge.py`) passes `format_topic_summary(...)`.
- **`_store_reflection_summary`** — parse failure logs and skips instead of storing raw text.

Untouched: the routed deep path, confidence gating, `_has_substance`, cooldowns.

## Tests

Parse-failure one-liner with a leak-marker assertion (raw text absent); structured rendering (obs capped at 3); no-fields one-liner; HTML escaping; `send_to_topic` passthrough contract; parse failure stores NO `reflection_summary` observation. 49 passed across the touched suites.

## Deploy path

Repo code only — existing installs: git pull + restart; fresh installs: in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)