### PR TITLE
feat(memory): entity-lane shadow probe in hybrid recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Groundwork: Genesis can now measure whether its entity graph would improve
+  recall, without changing any results yet.** A new shadow-only lane resolves a
+  recall query to entities in its knowledge graph, walks their relationships,
+  and records how many new, still-valid memories it would have surfaced that
+  ordinary search missed. This is measurement only (one internal metric per
+  recall); it ships off by default and never alters what recall returns, so the
+  data can decide whether building the live version is worth it.
 - **Genesis now tidies near-duplicate entities in its knowledge graph.** When
   it learns about a "thing" (a project, tool, concept, person) whose name is
   very close to one it already knows, it now decides whether they are the same

--- a/src/genesis/memory/entity_query.py
+++ b/src/genesis/memory/entity_query.py
@@ -111,14 +111,18 @@ def entity_lane_mode() -> str:
     """Effective entity-lane mode: ``off | shadow`` — read live from config.
 
     Reads the shared ``memory_recall`` config
-    (``graph_expansion.load_recall_config``, mtime-cached). Recognizes
-    ``off``/``shadow`` only; anything else — including ``live`` (reserved for
-    PR-2) and typos — degrades to ``off``. This is deliberately MORE
-    conservative than ``graph_expansion`` (which degrades unknown→shadow): an
-    unshipped lane must never start running the resolver's active-norm_name
-    scan on a hot recall path because of a hand-edit.
+    (``graph_expansion.load_recall_config``, mtime-cached). The module-wide
+    ``enabled: false`` master kill switch forces ``off`` (parity with
+    ``graph_expansion._mode_from``). Otherwise recognizes ``off``/``shadow``
+    only; anything else — including ``live`` (reserved for PR-2) and typos —
+    degrades to ``off``. This is deliberately MORE conservative than
+    ``graph_expansion`` (which degrades unknown→shadow): an unshipped lane must
+    never start running the resolver's active-norm_name scan on a hot recall
+    path because of a hand-edit.
     """
     cfg = graph_expansion.load_recall_config()
+    if not cfg.get("enabled", True):
+        return "off"
     section = cfg.get("entity_lane")
     mode = section.get("mode") if isinstance(section, dict) else None
     if mode == "shadow":

--- a/src/genesis/memory/entity_query.py
+++ b/src/genesis/memory/entity_query.py
@@ -1,0 +1,316 @@
+"""Query→entity resolution lane for hybrid recall — SHADOW-only probe.
+
+Measures — never changes — whether resolving a recall query to entity nodes
+and walking the entity graph would surface NOVEL, valid candidates the
+vector/FTS lanes miss. Off by default; ``entity_lane.mode: shadow`` in
+``memory_recall.yaml`` turns on measurement (an ``entity_lane_shadow``
+eval_event per recall). The live path — actually fusing the lane into RRF —
+is deferred to PR-2 (see the ``GROUNDWORK(PR-2)`` marker in
+:func:`entity_lane_mode`), gated on the shadow metrics.
+
+This is the ambient worker's E4 lane (``session_awareness/ranking.py``)
+transplanted into the main recall path as an observation. The scoring
+constants are DUPLICATED here rather than imported to keep ``memory/`` from
+depending on ``session_awareness/`` (wrong dependency direction) — keep them
+in sync with ``ranking.ENTITY_*`` if that lane's scoring changes.
+
+Measurement-integrity notes (why the numbers are honest):
+
+- ``novel_candidates`` counts only lane memories that pass the SAME validity
+  filter the main pipeline applies at ``retrieval._filter_expired_candidates``
+  (bitemporally-expired / deprecated / deleted are excluded via
+  ``hydrate_for_expansion`` — the visibility predicate the sibling graph lane
+  already uses). ``memories_mentioning`` has no such filter, so without this
+  the count would over-sell the lane.
+- ``topk_delta`` is the lane's marginal effect on pure RRF ordering — an
+  UPPER BOUND: it skips rerank / graph-boost / min_activation / diversity /
+  scope, which the production path would apply to novel candidates. Read it
+  as "the ceiling of what the lane could promote," not what it would.
+- ``embedding_available`` is emitted so analysis can stratify: under the
+  FTS5-only recall branch the base ranking is weaker, which inflates the
+  lane's apparent marginal effect.
+
+Merge-following: resolution matches against the ACTIVE norm_name set
+(``list_norm_names``), which is post-merge survivors. A query naming a
+merged-away surface form is missed (``get_by_norm_name`` would follow the
+merge). With the adjudication drainer in ``propose_only`` this set is ~empty,
+so the bias is a safe-direction undercount — acceptable for a probe. PR-2's
+live resolver should follow merges; do NOT copy the active-set shortcut
+forward as-is.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from genesis.db.crud import entities as entities_crud
+from genesis.db.crud import j9_eval
+from genesis.db.crud import memory as memory_crud
+from genesis.db.crud.entities import PROVENANCE_WEIGHTS
+from genesis.memory import graph_expansion
+from genesis.memory.entity_resolution import normalize_content
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# ── Scoring constants — comparability with session_awareness/ranking.py's E4
+# lane (do NOT import ranking.py from memory/ — wrong dependency direction).
+ENTITY_DEPTH_DECAY = 0.7  # per-hop decay on top of edge confidences (ranking.py:73)
+ENTITY_MENTIONS_PER_ENTITY = 10  # ranking.py:74
+ENTITY_LANE_LIMIT = 15  # max entity-lane candidates considered (ranking.py:75)
+ENTITY_MAX_DEPTH = 2
+
+_MAX_QUERY_ENTITIES = 8  # seed cap from one query
+_MAX_NGRAM = 3
+
+# Only single-token unigrams that are pure noise are skipped; multi-word
+# n-grams are never dropped (a real norm_name may contain a stopword).
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "of",
+        "to",
+        "in",
+        "on",
+        "and",
+        "or",
+        "for",
+        "with",
+        "at",
+        "by",
+        "it",
+        "this",
+        "that",
+        "what",
+        "did",
+        "do",
+        "does",
+        "about",
+        "we",
+        "i",
+        "you",
+        "be",
+        "as",
+        "from",
+    }
+)
+
+
+def entity_lane_mode() -> str:
+    """Effective entity-lane mode: ``off | shadow`` — read live from config.
+
+    Reads the shared ``memory_recall`` config
+    (``graph_expansion.load_recall_config``, mtime-cached). Recognizes
+    ``off``/``shadow`` only; anything else — including ``live`` (reserved for
+    PR-2) and typos — degrades to ``off``. This is deliberately MORE
+    conservative than ``graph_expansion`` (which degrades unknown→shadow): an
+    unshipped lane must never start running the resolver's active-norm_name
+    scan on a hot recall path because of a hand-edit.
+    """
+    cfg = graph_expansion.load_recall_config()
+    section = cfg.get("entity_lane")
+    mode = section.get("mode") if isinstance(section, dict) else None
+    if mode == "shadow":
+        return "shadow"
+    # GROUNDWORK(PR-2): when the live entity lane ships, recognize "live" HERE
+    # and add it to settings._validate_memory_recall's entity_lane allow-set in
+    # the SAME change — until both flip together, live→off (silent) so a
+    # premature config flip can never half-activate the lane.
+    return "off"
+
+
+async def resolve_query_entities(
+    db: aiosqlite.Connection,
+    query: str | None,
+    *,
+    max_entities: int = _MAX_QUERY_ENTITIES,
+) -> dict[str, float]:
+    """Resolve a free-text query to seed entity ids (weight 1.0 each).
+
+    ``normalize_content`` (alias-expand) → lowercase → whitespace n-grams
+    (1..``_MAX_NGRAM``) → O(1) membership against the ACTIVE norm_name set
+    (``list_norm_names``). Whitespace splitting preserves single tokens like
+    ``pr#1089``; multi-word norm_names (``concurrent workstream``) resolve via
+    the bi/tri-gram. Read-only: no writes, no entity creation, no LLM.
+    Returns ``{entity_id: 1.0}`` capped at *max_entities*.
+    """
+    norm = normalize_content(query or "").lower()
+    tokens = norm.split()
+    if not tokens:
+        return {}
+
+    ngrams: list[str] = []
+    seen: set[str] = set()
+    for n in range(1, _MAX_NGRAM + 1):
+        for i in range(len(tokens) - n + 1):
+            gram = " ".join(tokens[i : i + n])
+            if gram in seen:
+                continue
+            seen.add(gram)
+            if n == 1 and gram in _STOPWORDS:
+                continue
+            ngrams.append(gram)
+    if not ngrams:
+        return {}
+
+    # norm_name → [entity_id]; active-only (= post-merge survivors). One scan;
+    # the entity count is small enough to hold in-process (ranking.py precedent).
+    name_to_ids: dict[str, list[str]] = {}
+    for norm_name, entity_id, _etype in await entities_crud.list_norm_names(db):
+        name_to_ids.setdefault(norm_name, []).append(entity_id)
+
+    weights: dict[str, float] = {}
+    for gram in ngrams:
+        for entity_id in name_to_ids.get(gram, ()):
+            weights[entity_id] = 1.0
+            if len(weights) >= max_entities:
+                return weights
+    return weights
+
+
+async def compute_entity_lane(
+    db: aiosqlite.Connection,
+    weights: dict[str, float],
+    *,
+    as_of: str | None = None,
+) -> tuple[list[str], int]:
+    """Entity-graph candidate memory_ids for seed *weights*, strongest first.
+
+    ``connected_entities`` (≤``ENTITY_MAX_DEPTH`` bitemporal hops) with per-hop
+    ``ENTITY_DEPTH_DECAY`` → ``memories_mentioning`` → best-per-memory
+    ``path_score = weight × mention_confidence × provenance_weight``. Returns
+    ``(memory_ids capped at ENTITY_LANE_LIMIT, entities_reached_count)``. The
+    memory_ids are NOT visibility-filtered — the caller applies
+    ``hydrate_for_expansion``. Never raises.
+    """
+    if not weights:
+        return [], 0
+    try:
+        weights = dict(weights)  # seeds at 1.0; add decayed reached below
+        reached = await entities_crud.connected_entities(
+            db,
+            list(weights),
+            max_depth=ENTITY_MAX_DEPTH,
+            as_of=as_of,
+        )
+        for entity_id, info in reached.items():
+            weights[entity_id] = info["path_confidence"] * (ENTITY_DEPTH_DECAY ** info["depth"])
+        mentions = await entities_crud.memories_mentioning(
+            db,
+            list(weights),
+            limit_per_entity=ENTITY_MENTIONS_PER_ENTITY,
+        )
+        best: dict[str, float] = {}
+        for m in mentions:
+            score = (
+                weights.get(m["entity_id"], 0.0)
+                * (m["confidence"] or 0.0)
+                * PROVENANCE_WEIGHTS.get(m["provenance"], 0.5)
+            )
+            if score > best.get(m["memory_id"], -1.0):
+                best[m["memory_id"]] = score
+        ranked = sorted(best.items(), key=lambda kv: kv[1], reverse=True)
+        return [mid for mid, _ in ranked[:ENTITY_LANE_LIMIT]], len(reached)
+    except Exception:
+        logger.debug("entity lane compute failed", exc_info=True)
+        return [], 0
+
+
+def _rrf_top(ranked_lists: list[list[str]], limit: int) -> set[str]:
+    """Top-*limit* memory_ids by pure RRF over *ranked_lists* (no filters)."""
+    # Function-level import breaks the retrieval→entity_query import cycle
+    # (ranking.py uses the same pattern for _expired_candidate_ids).
+    from genesis.memory.retrieval import _rrf_fuse
+
+    fused = _rrf_fuse(ranked_lists)
+    return set(sorted(fused, key=lambda mid: fused[mid], reverse=True)[:limit])
+
+
+async def maybe_entity_lane_shadow(
+    db: aiosqlite.Connection,
+    *,
+    query: str | None,
+    ranked_lists: list[list[str]],
+    all_ids: set[str],
+    limit: int,
+    embedding_available: bool,
+    recall_event_id: str | None = None,
+) -> None:
+    """Shadow-measure the entity lane against a completed recall.
+
+    No-op unless ``entity_lane_mode() == "shadow"``. NEVER changes recall
+    output (returns ``None``); on any error logs and returns. Emits one
+    ``entity_lane_shadow`` eval_event with the fire/novelty/delta metrics that
+    drive the PR-2 flip decision.
+    """
+    if entity_lane_mode() != "shadow":
+        return
+    t0 = time.monotonic()
+    try:
+        weights = await resolve_query_entities(db, query)
+        lane_ids, entities_reached = await compute_entity_lane(db, weights) if weights else ([], 0)
+
+        # Measurement parity: drop lane candidates the main pipeline would have
+        # excluded (expired / deprecated / deleted) BEFORE counting novelty.
+        valid_ids = lane_ids
+        if lane_ids:
+            hydrated = await memory_crud.hydrate_for_expansion(db, lane_ids)
+            now_iso = datetime.now(UTC).isoformat()
+            valid_ids = []
+            for mid in lane_ids:
+                row = hydrated.get(mid)
+                if not row or not row.get("content"):
+                    continue
+                invalid_at = row.get("invalid_at")
+                if (invalid_at is not None and invalid_at <= now_iso) or row.get("deprecated"):
+                    continue
+                valid_ids.append(mid)
+
+        novel = [mid for mid in valid_ids if mid not in all_ids]
+
+        # topk_delta: isolated marginal RRF effect (pre-filter UPPER BOUND).
+        base_top = _rrf_top(ranked_lists, limit)
+        with_top = _rrf_top([*ranked_lists, valid_ids], limit) if valid_ids else base_top
+        topk_delta = len(with_top - base_top)
+
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        await j9_eval.insert_event(
+            db,
+            dimension="memory",
+            event_type="entity_lane_shadow",
+            subject_id=recall_event_id,
+            metrics={
+                "entities_resolved": len(weights),
+                "entities_reached": entities_reached,
+                "lane_candidates": len(valid_ids),
+                "lane_candidates_prefilter": len(lane_ids),
+                "novel_candidates": len(novel),
+                "topk_delta": topk_delta,
+                "sample_novel_ids": novel[:5],
+                "embedding_available": bool(embedding_available),
+                "latency_ms": latency_ms,
+            },
+        )
+        logger.info(
+            "entity_lane_shadow resolved=%d reached=%d lane=%d novel=%d "
+            "topk_delta=%d latency_ms=%d",
+            len(weights),
+            entities_reached,
+            len(valid_ids),
+            len(novel),
+            topk_delta,
+            latency_ms,
+        )
+    except Exception:
+        logger.warning("entity_lane_shadow failed — recall unaffected", exc_info=True)

--- a/src/genesis/memory/graph_expansion.py
+++ b/src/genesis/memory/graph_expansion.py
@@ -90,12 +90,49 @@ def _base_path():
     return repo_root() / "config" / _CONFIG_NAME
 
 
-def load_recall_config() -> dict[str, Any]:
-    """Read the merged memory_recall config fresh — per call, NO cache.
+# (stat-key, parsed-config) memo — see load_recall_config. Reset in tests via
+# the config_dirs fixture so a tmp-keyed entry can't leak across tests.
+_config_cache: tuple[tuple, dict[str, Any]] | None = None
 
-    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
-    corrupt files degrade layer-by-layer toward DEFAULTS.
+
+def _config_stat_key() -> tuple:
+    """``(base, overlay)`` ``(st_mtime_ns, st_size)`` pairs — the cache key.
+
+    A missing file contributes ``None``, so creating/removing/editing either
+    file (base yaml or ``.local.yaml`` overlay) changes the key and forces a
+    re-read on the next call.
     """
+    from genesis._config_overlay import _resolve_overlay_path
+
+    base_path = _base_path()
+
+    def _key(p) -> tuple[int, int] | None:
+        try:
+            st = p.stat()
+        except OSError:
+            return None
+        return (st.st_mtime_ns, st.st_size)
+
+    return (_key(base_path), _key(_resolve_overlay_path(base_path)))
+
+
+def load_recall_config() -> dict[str, Any]:
+    """Read the merged memory_recall config — mtime-cached, effectively live.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). The parse result
+    is memoized and reused until either file's ``(mtime, size)`` changes, so a
+    ``settings_update`` / hand-edit still takes effect on the next recall while
+    the steady-state hot path — ``recall()`` calls this per-recall for BOTH the
+    graph-expansion and entity-lane gates — pays a ``stat`` + dict lookup, not
+    two YAML reads and a parse. Missing or corrupt files degrade layer-by-layer
+    toward DEFAULTS. Callers always receive a fresh deep copy (the memo is never
+    handed out, so a caller mutation can't poison it).
+    """
+    global _config_cache
+    stat_key = _config_stat_key()
+    if _config_cache is not None and _config_cache[0] == stat_key:
+        return copy.deepcopy(_config_cache[1])
+
     merged = copy.deepcopy(DEFAULTS)
     base_path = _base_path()
     base: dict[str, Any] = {}
@@ -116,7 +153,8 @@ def load_recall_config() -> dict[str, Any]:
             merged[key] = {**merged[key], **value}
         else:
             merged[key] = value
-    return merged
+    _config_cache = (stat_key, merged)
+    return copy.deepcopy(merged)
 
 
 def _mode_from(cfg: dict[str, Any]) -> str:

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -567,6 +567,37 @@ class HybridRetriever:
         self._db = db
         self._reranker = reranker
 
+    async def _maybe_entity_lane_shadow(
+        self,
+        *,
+        query: str,
+        ranked_lists: list[list[str]],
+        all_ids: set[str],
+        limit: int,
+        embedding_available: bool,
+        recall_event_id: str | None,
+    ) -> None:
+        """Fire the entity-lane SHADOW probe (off by default). Fully contained
+        (its own guard belts the helper's internal try/except) — appends one
+        eval_event, never touches recall output. Called on BOTH the
+        empty-candidate early return (the lane's highest-value case: organic
+        recall found nothing) and the normal tail.
+        """
+        try:
+            from genesis.memory import entity_query
+
+            await entity_query.maybe_entity_lane_shadow(
+                self._db,
+                query=query,
+                ranked_lists=ranked_lists,
+                all_ids=all_ids,
+                limit=limit,
+                embedding_available=embedding_available,
+                recall_event_id=recall_event_id,
+            )
+        except Exception:
+            logger.debug("entity_lane_shadow call failed — recall unaffected", exc_info=True)
+
     async def recall(
         self,
         query: str,
@@ -686,17 +717,30 @@ class HybridRetriever:
 
         # 4. Union of all candidate memory_ids
         all_ids = set(qdrant_by_id) | set(fts_by_id) | set(event_memory_ids)
-        if not all_ids:
-            return []
 
         # 4b. Phase 1.5e: drop candidates past their bitemporal invalid_at.
-        all_ids, event_memory_ids = await self._filter_expired_candidates(
-            all_ids,
-            qdrant_by_id,
-            fts_by_id,
-            event_memory_ids,
-        )
+        # (No-op on an empty set — guard the call so both empty exits share one
+        # path below.)
+        if all_ids:
+            all_ids, event_memory_ids = await self._filter_expired_candidates(
+                all_ids,
+                qdrant_by_id,
+                fts_by_id,
+                event_memory_ids,
+            )
         if not all_ids:
+            # No organic candidates from vector/FTS/event lanes. Still measure
+            # whether the entity lane would surface something — its highest-value
+            # case (Codex #1121 P2: don't skip the zero-hit path). No ranked
+            # lists exist here, so lane novelty = its valid candidates.
+            await self._maybe_entity_lane_shadow(
+                query=query,
+                ranked_lists=[],
+                all_ids=set(),
+                limit=limit,
+                embedding_available=embedding_available,
+                recall_event_id=None,
+            )
             return []
 
         now_str = datetime.now(UTC).isoformat()
@@ -916,22 +960,15 @@ class HybridRetriever:
         # entity graph would surface novel valid candidates the vector/FTS lanes
         # miss — pure observation that appends one eval_event and NEVER touches
         # ``results``. Placed after the write-backs so its insert_event commit
-        # can't flush partial recall state; own guard belts the helper's own
-        # try/except (belt-and-suspenders — recall must never break here).
-        try:
-            from genesis.memory import entity_query
-
-            await entity_query.maybe_entity_lane_shadow(
-                self._db,
-                query=query,
-                ranked_lists=ranked_lists,
-                all_ids=all_ids,
-                limit=limit,
-                embedding_available=embedding_available,
-                recall_event_id=recall_event_id,
-            )
-        except Exception:
-            logger.debug("entity_lane_shadow call failed — recall unaffected", exc_info=True)
+        # can't flush partial recall state. See also the zero-hit call above.
+        await self._maybe_entity_lane_shadow(
+            query=query,
+            ranked_lists=ranked_lists,
+            all_ids=all_ids,
+            limit=limit,
+            embedding_available=embedding_available,
+            recall_event_id=recall_event_id,
+        )
 
         return results
 

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -911,6 +911,28 @@ class HybridRetriever:
             query_expanded=fts_query != query,
         )
 
+        # Entity-lane SHADOW probe (off by default; entity_lane.mode: shadow).
+        # Measures whether resolving the query to entity nodes + walking the
+        # entity graph would surface novel valid candidates the vector/FTS lanes
+        # miss — pure observation that appends one eval_event and NEVER touches
+        # ``results``. Placed after the write-backs so its insert_event commit
+        # can't flush partial recall state; own guard belts the helper's own
+        # try/except (belt-and-suspenders — recall must never break here).
+        try:
+            from genesis.memory import entity_query
+
+            await entity_query.maybe_entity_lane_shadow(
+                self._db,
+                query=query,
+                ranked_lists=ranked_lists,
+                all_ids=all_ids,
+                limit=limit,
+                embedding_available=embedding_available,
+                recall_event_id=recall_event_id,
+            )
+        except Exception:
+            logger.debug("entity_lane_shadow call failed — recall unaffected", exc_info=True)
+
         return results
 
     # --- recall() stage helpers (read-only gathers/computes) ---

--- a/tests/test_memory/test_entity_query.py
+++ b/tests/test_memory/test_entity_query.py
@@ -138,6 +138,16 @@ def test_entity_lane_mode(monkeypatch, section, expected):
     assert entity_query.entity_lane_mode() == expected
 
 
+def test_entity_lane_mode_honors_master_kill_switch(monkeypatch):
+    # enabled: false silences BOTH lanes even if entity_lane.mode is shadow.
+    monkeypatch.setattr(
+        graph_expansion,
+        "load_recall_config",
+        lambda: {"enabled": False, "entity_lane": {"mode": "shadow"}},
+    )
+    assert entity_query.entity_lane_mode() == "off"
+
+
 # ── resolve_query_entities ───────────────────────────────────────────────
 
 

--- a/tests/test_memory/test_entity_query.py
+++ b/tests/test_memory/test_entity_query.py
@@ -1,0 +1,264 @@
+"""Query→entity resolution lane for hybrid recall — SHADOW probe.
+
+Covers ``genesis.memory.entity_query``:
+
+- ``entity_lane_mode``: off/shadow recognized; live (reserved for PR-2) and
+  typos degrade to ``off`` (more conservative than graph_expansion — an
+  unshipped lane must not run 8k-row scans on a hot path from a hand-edit).
+- ``resolve_query_entities``: alias-normalized, lowercased, n-gram membership
+  against the active norm_name set; read-only (no writes / no entity creation).
+- ``compute_entity_lane``: connected-entity walk → mention scoring → cap;
+  never raises.
+- ``maybe_entity_lane_shadow``: emits ``entity_lane_shadow`` eval_events in
+  shadow mode, returns None always, filters expired/deprecated candidates out
+  of the novelty count (measurement parity with the main pipeline), and is a
+  silent no-op when off.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.db.crud import entities as entities_crud
+from genesis.db.crud import memory as memory_crud
+from genesis.memory import entity_query, graph_expansion
+
+TARGET = "9d36f039-0000-0000-0000-000000000000"
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+async def _seed_spine(db):
+    """omi →is_a→ voice-edge-device →constrained_by→ repo-split → TARGET."""
+    omi = await entities_crud.create_entity(
+        db,
+        name="OMI",
+        norm_name="omi",
+        entity_type="device",
+    )
+    cat = await entities_crud.create_entity(
+        db,
+        name="voice-edge-device",
+        norm_name="voice-edge-device",
+        entity_type="concept",
+    )
+    rule = await entities_crud.create_entity(
+        db,
+        name="repo-split",
+        norm_name="repo-split",
+        entity_type="concept",
+    )
+    await entities_crud.upsert_link(
+        db,
+        source_id=omi,
+        target_id=cat,
+        link_type="is_a",
+        provenance="EXTRACTED",
+        confidence=0.95,
+    )
+    await entities_crud.upsert_link(
+        db,
+        source_id=cat,
+        target_id=rule,
+        link_type="constrained_by",
+        provenance="EXTRACTED",
+        confidence=0.95,
+    )
+    await entities_crud.upsert_mention(
+        db,
+        memory_id=TARGET,
+        entity_id=rule,
+        provenance="EXTRACTED",
+        confidence=0.95,
+        source="seed",
+    )
+    return omi
+
+
+async def _seed_memory(db, memory_id, *, invalid_at=None, deprecated=0):
+    await memory_crud.create(
+        db,
+        memory_id=memory_id,
+        content=f"content of {memory_id}",
+        source_type="memory",
+        collection="episodic_memory",
+    )
+    await memory_crud.create_metadata(
+        db,
+        memory_id=memory_id,
+        created_at="2026-07-01T00:00:00Z",
+        collection="episodic_memory",
+        origin_class="owner",
+    )
+    if invalid_at is not None:
+        await db.execute(
+            "UPDATE memory_metadata SET invalid_at = ? WHERE memory_id = ?",
+            (invalid_at, memory_id),
+        )
+    if deprecated:
+        await db.execute(
+            "UPDATE memory_metadata SET deprecated = 1 WHERE memory_id = ?",
+            (memory_id,),
+        )
+    await db.commit()
+
+
+async def _events(db, event_type="entity_lane_shadow"):
+    cur = await db.execute(
+        "SELECT metrics_json FROM eval_events WHERE event_type = ?",
+        (event_type,),
+    )
+    return [json.loads(r[0]) for r in await cur.fetchall()]
+
+
+# ── entity_lane_mode ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "section,expected",
+    [
+        ({"mode": "off"}, "off"),
+        ({"mode": "shadow"}, "shadow"),
+        ({"mode": "live"}, "off"),  # reserved for PR-2 → conservative off
+        ({"mode": "banana"}, "off"),  # typo → off (never surprise-enable)
+        ({"mode": False}, "off"),  # YAML-1.1 unquoted `off`
+        ({}, "off"),
+        (None, "off"),
+    ],
+)
+def test_entity_lane_mode(monkeypatch, section, expected):
+    monkeypatch.setattr(
+        graph_expansion,
+        "load_recall_config",
+        lambda: {"enabled": True, "entity_lane": section},
+    )
+    assert entity_query.entity_lane_mode() == expected
+
+
+# ── resolve_query_entities ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_exact_and_multiword(db):
+    await _seed_spine(db)
+    # unigram
+    w = await entity_query.resolve_query_entities(db, "what about omi lately")
+    assert w and all(v == 1.0 for v in w.values())
+    # multiword norm_name resolves via bigram
+    w2 = await entity_query.resolve_query_entities(db, "the repo-split decision")
+    assert w2  # 'repo-split' is one whitespace token here
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_and_unresolvable(db):
+    assert await entity_query.resolve_query_entities(db, "") == {}
+    assert await entity_query.resolve_query_entities(db, "   ") == {}
+    # no entity matches these stopword-ish terms
+    await _seed_spine(db)
+    assert await entity_query.resolve_query_entities(db, "the a is of") == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_is_read_only(db):
+    await _seed_spine(db)
+    before = (await (await db.execute("SELECT COUNT(*) FROM entities")).fetchone())[0]
+    await entity_query.resolve_query_entities(db, "omi voice-edge-device repo-split")
+    after = (await (await db.execute("SELECT COUNT(*) FROM entities")).fetchone())[0]
+    assert after == before  # never creates entities
+
+
+# ── compute_entity_lane ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_compute_reaches_target_via_graph(db):
+    omi = await _seed_spine(db)
+    lane, reached = await entity_query.compute_entity_lane(db, {omi: 1.0})
+    assert TARGET in lane  # omi → … → repo-split → TARGET mention
+    assert reached >= 2  # voice-edge-device + repo-split reached
+
+
+@pytest.mark.asyncio
+async def test_compute_empty_weights(db):
+    assert await entity_query.compute_entity_lane(db, {}) == ([], 0)
+
+
+# ── maybe_entity_lane_shadow ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shadow_emits_event_and_returns_none(db, monkeypatch):
+    await _seed_spine(db)
+    await _seed_memory(db, TARGET)
+    monkeypatch.setattr(entity_query, "entity_lane_mode", lambda: "shadow")
+    ret = await entity_query.maybe_entity_lane_shadow(
+        db,
+        query="omi",
+        ranked_lists=[["some-other-mem"]],
+        all_ids={"some-other-mem"},
+        limit=10,
+        embedding_available=True,
+    )
+    assert ret is None  # NEVER changes recall output
+    events = await _events(db)
+    assert len(events) == 1
+    m = events[0]
+    assert m["entities_resolved"] == 1
+    assert TARGET in m["sample_novel_ids"]  # reached + not in all_ids
+    assert m["novel_candidates"] >= 1
+    assert m["embedding_available"] is True
+
+
+@pytest.mark.asyncio
+async def test_shadow_excludes_expired_from_novel(db, monkeypatch):
+    """SHOULD-FIX 1: an entity-reachable but bitemporally-expired memory must
+    NOT count as a novel win — the main pipeline drops it at L693."""
+    await _seed_spine(db)
+    await _seed_memory(db, TARGET, invalid_at="2020-01-01T00:00:00+00:00")
+    monkeypatch.setattr(entity_query, "entity_lane_mode", lambda: "shadow")
+    await entity_query.maybe_entity_lane_shadow(
+        db,
+        query="omi",
+        ranked_lists=[["x"]],
+        all_ids={"x"},
+        limit=10,
+        embedding_available=False,
+    )
+    m = (await _events(db))[0]
+    assert m["novel_candidates"] == 0  # expired filtered out
+    assert m["lane_candidates_prefilter"] >= 1  # it WAS reached, then dropped
+
+
+@pytest.mark.asyncio
+async def test_off_mode_emits_nothing(db, monkeypatch):
+    await _seed_spine(db)
+    await _seed_memory(db, TARGET)
+    monkeypatch.setattr(entity_query, "entity_lane_mode", lambda: "off")
+    ret = await entity_query.maybe_entity_lane_shadow(
+        db,
+        query="omi",
+        ranked_lists=[["x"]],
+        all_ids={"x"},
+        limit=10,
+        embedding_available=True,
+    )
+    assert ret is None
+    assert await _events(db) == []
+
+
+@pytest.mark.asyncio
+async def test_shadow_never_raises_on_bad_input(db, monkeypatch):
+    monkeypatch.setattr(entity_query, "entity_lane_mode", lambda: "shadow")
+    # query None, empty ranked_lists — must not raise
+    ret = await entity_query.maybe_entity_lane_shadow(
+        db,
+        query=None,
+        ranked_lists=[],
+        all_ids=set(),
+        limit=10,
+        embedding_available=True,
+    )
+    assert ret is None

--- a/tests/test_memory/test_graph_expansion.py
+++ b/tests/test_memory/test_graph_expansion.py
@@ -49,6 +49,8 @@ def config_dirs(tmp_path, monkeypatch) -> tuple[Path, Path]:
         "genesis._config_overlay._user_config_dir",
         lambda: user_dir,
     )
+    # Reset the module-level mtime cache so it can't leak across tests.
+    monkeypatch.setattr(graph_expansion, "_config_cache", None, raising=False)
 
     return (
         repo_dir / "config" / "memory_recall.yaml",
@@ -161,12 +163,36 @@ def test_corrupt_base_degrades_to_defaults(config_dirs):
     assert graph_expansion.expansion_mode() == "shadow"
 
 
-def test_live_reread_no_cache(config_dirs):
+def test_live_reread_on_file_change(config_dirs):
+    # A settings_update / hand-edit changes the file's mtime+size, so the
+    # mtime-keyed cache re-reads it on the next recall (the "takes effect on
+    # next recall" contract is preserved).
     base, _ = config_dirs
     _write(base, {"graph_expansion": {"mode": "off"}})
     assert graph_expansion.expansion_mode() == "off"
     _write(base, {"graph_expansion": {"mode": "live"}})
     assert graph_expansion.expansion_mode() == "live"
+
+
+def test_config_cached_until_file_changes(config_dirs, monkeypatch):
+    # Unchanged files must not be re-parsed on every recall (hot path). Count
+    # base-yaml parses: a second load with no file change is served from cache.
+    base, _ = config_dirs
+    _write(base, {"graph_expansion": {"mode": "shadow"}})
+    calls = {"n": 0}
+    real = graph_expansion.yaml.safe_load
+
+    def _counting(text):
+        calls["n"] += 1
+        return real(text)
+
+    monkeypatch.setattr(graph_expansion.yaml, "safe_load", _counting)
+    graph_expansion.load_recall_config()
+    graph_expansion.load_recall_config()
+    assert calls["n"] == 1  # second load served from cache
+    _write(base, {"graph_expansion": {"mode": "live"}})
+    graph_expansion.load_recall_config()
+    assert calls["n"] == 2  # file changed → cache invalidated, re-parsed
 
 
 # ─── expand_neighbors: the mode-independent primitive ────────────────────────

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -1063,3 +1063,54 @@ async def test_compute_activations_fts_ghost_falls_back_to_now(
         {"ghost"}, {}, now_str,
     )
     assert created_at_by_id["ghost"] == now_str
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_invokes_entity_lane_shadow(mock_qdrant, mock_crud, mock_links, _mock_expand):
+    """The entity-lane shadow probe is wired into recall() with the sets it
+    needs (ranked_lists/all_ids/limit/embedding_available/recall_event_id)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95)]
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-1", -5.0)])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _setup_link_mocks(mock_links, link_count=1)
+
+    spy = AsyncMock(return_value=None)
+    with patch("genesis.memory.entity_query.maybe_entity_lane_shadow", spy):
+        results = await retriever.recall("test query", limit=10)
+
+    assert len(results) > 0
+    spy.assert_awaited_once()
+    kw = spy.await_args.kwargs
+    assert kw["query"] == "test query"
+    assert isinstance(kw["ranked_lists"], list)
+    assert isinstance(kw["all_ids"], set)
+    assert kw["limit"] == 10
+    assert isinstance(kw["embedding_available"], bool)
+    assert "recall_event_id" in kw  # correlation id passed for joinable events
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_survives_entity_lane_shadow_failure(mock_qdrant, mock_crud, mock_links, _e):
+    """A raising shadow helper must not change recall's output (the call site's
+    own guard belts the helper's internal try/except)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95), _make_qdrant_hit("mem-2", 0.8)]
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-1", -5.0)])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _setup_link_mocks(mock_links, link_count=1)
+
+    # Baseline: real helper is a no-op (config ships mode: off).
+    baseline = await retriever.recall("test query", limit=10)
+    boom = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch("genesis.memory.entity_query.maybe_entity_lane_shadow", boom):
+        results = await retriever.recall("test query", limit=10)
+    assert [r.memory_id for r in results] == [r.memory_id for r in baseline]

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -1114,3 +1114,29 @@ async def test_recall_survives_entity_lane_shadow_failure(mock_qdrant, mock_crud
     with patch("genesis.memory.entity_query.maybe_entity_lane_shadow", boom):
         results = await retriever.recall("test query", limit=10)
     assert [r.memory_id for r in results] == [r.memory_id for r in baseline]
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_fires_entity_lane_shadow_on_zero_hits(mock_qdrant, mock_crud, mock_links, _e):
+    """Even when vector/FTS/event find nothing (recall returns []), the entity
+    lane shadow probe still fires with empty sets — its highest-value case
+    (organic recall found nothing, the lane might still surface something)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = []  # no vector hits
+    mock_crud.search_ranked = AsyncMock(return_value=[])  # no FTS hits
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _setup_link_mocks(mock_links)
+
+    spy = AsyncMock(return_value=None)
+    with patch("genesis.memory.entity_query.maybe_entity_lane_shadow", spy):
+        results = await retriever.recall("test query", limit=10)
+
+    assert results == []  # zero organic candidates
+    spy.assert_awaited_once()  # but the probe still ran
+    kw = spy.await_args.kwargs
+    assert kw["ranked_lists"] == []
+    assert kw["all_ids"] == set()


### PR DESCRIPTION
## What

Off-by-default **shadow measurement** of whether resolving a recall query to entity nodes and walking the entity graph would surface *novel, valid* candidates the vector/FTS lanes miss. This is the cheap experiment that resolves the full entity-lane's (PR-2) 50%-value uncertainty on **real production recalls** before committing to the live wiring. Pure observation: emits one `entity_lane_shadow` eval_event per recall and **never changes what recall returns**.

Continues PR #1069 (graph expansion) which laid the config/validator groundwork (`entity_lane.mode` already validated for `off/shadow`). Builds on the merged adjudication substrate (#1112/#1114); the entity CRUD contract it reads is unchanged.

## How

New `src/genesis/memory/entity_query.py`:
- `entity_lane_mode()` — off/shadow only; `live` (reserved for PR-2) and typos degrade to `off` (a `GROUNDWORK(PR-2)` marker flags where the live path flips).
- `resolve_query_entities()` — alias-normalized, lowercased n-gram membership against the **active** norm_name set. Read-only (test-pinned no-write invariant).
- `compute_entity_lane()` — `connected_entities` (2-hop, bitemporal, 0.7 decay) → `memories_mentioning` → best-per-memory path score, cap 15. Scoring constants duplicated from `session_awareness/ranking.py` (not imported — `memory/` must not depend on `session_awareness/`).
- `maybe_entity_lane_shadow()` — resolve → lane → validity-filter → emit.

`retrieval.recall()` — one call at the tail (after write-backs, before return), with its own `try/except` belting the helper's internal one. Result shape byte-identical to `mode=off`.

`graph_expansion.load_recall_config()` — now **mtime+size cached**, so the per-recall config read this adds to all `recall()` callers (incl. voice/proactive) costs a `stat` + dict lookup when off, not two YAML parses. The "takes effect on next recall" contract is preserved (a file change mints a new cache key).

## Measurement integrity (from architect pre-review)

- **`novel_candidates` counts only lane memories that pass the SAME validity filter the main pipeline applies** (via `hydrate_for_expansion`): bitemporally-expired / deprecated / deleted are excluded. `memories_mentioning` has no such filter, so without this the probe would over-sell the lane.
- **`topk_delta` is documented as a pre-filter upper bound** (isolated marginal RRF effect; skips rerank/activation/diversity/scope). `embedding_available` is emitted so the FTS5-only-branch confound can be stratified out.
- `subject_id` wired to `recall_event_id` so each shadow event joins its parent recall.

## Testing

- `test_entity_query.py` — resolver / lane / mode / shadow, incl. **expired-excluded-from-novel** and the no-write invariant.
- `test_graph_expansion.py` — config cached until file changes + live-reread-on-change.
- `test_retrieval.py` — recall() call-site wiring (right sets passed) + **a raising helper cannot change recall output**.
- WS-3 recall/store coverage guards pass (resolver reads entities; no new `.recall()`/`.store()` site). 110 passed across affected suites.

## Rollout

Ships `off`. After merge + server restart, flip `entity_lane.mode: shadow` via the `memory_recall.local.yaml` overlay and collect ~1-2 weeks of metrics. Decision gate for the live PR-2: fire-rate ≥10%, `novel_candidates` present, `topk_delta` > 0 on ≥25% of fired recalls, 20-sample relevance spot-check majority-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)