### PR TITLE
feat(reflection): canonical signal formatter + phantom-claim guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reflections stop arguing with themselves about signals that never
+  fired.** All reflection depths now see live awareness signals in one
+  canonical format (previously light and deep cycles each got a different
+  shape, so one cycle couldn't recognize what the other had cited), the
+  prompt now clearly separates live tick signals from stored-observation
+  history, and a guard strips any signal-by-name-and-value claim from a
+  reflection's persisted narrative when that signal wasn't actually in the
+  live tick. This ends the loop where a phantom claim ("signal X=0.9") got
+  written into cognitive state, re-read by the next reflection, debunked,
+  and then re-asserted for days. The guard only annotates — it never blocks
+  or rejects a reflection's update.
+
 ### Added
 
 - **Genesis now tidies near-duplicate entities in its knowledge graph.** When

--- a/src/genesis/awareness/signal_format.py
+++ b/src/genesis/awareness/signal_format.py
@@ -1,0 +1,69 @@
+"""Canonical signal-line formatting for reflection prompts.
+
+Every reflection depth must present live tick signals in ONE format. Two
+divergent formatters (``perception/context.py`` rich lines vs
+``cc/reflection_bridge/_prompts.py`` compact comma-join) meant light and deep
+reflections saw differently-shaped signal blocks — a deep cycle could not
+recognize the signal a light cycle cited, feeding the assert/debunk loop.
+The rich variant is canonical: it carries source, thresholds, baseline
+ground truth, and persistence, all of which the model needs to cite a
+signal honestly. Both legacy call sites are thin delegates onto this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from genesis.awareness.types import SignalReading
+
+# Awareness loop tick interval — used only for the human-readable
+# "persistent ~Nh" annotation.
+_TICK_INTERVAL_MINUTES = 5
+
+
+def format_signal_line(s: SignalReading, *, unchanged_ticks: int = 0) -> str:
+    """One canonical line for one signal: name, value, source, threshold
+    status, baseline ground truth, persistence."""
+    line = f"{s.name}: {s.value} (source={s.source})"
+    if s.normal_max is not None:
+        status = (
+            "CRITICAL"
+            if s.critical_threshold is not None and s.value >= s.critical_threshold
+            else "WARNING"
+            if s.warning_threshold is not None and s.value >= s.warning_threshold
+            else "normal"
+        )
+        line += (
+            f" [{status}; normal<={s.normal_max},"
+            f" warn>={s.warning_threshold}, crit>={s.critical_threshold}]"
+        )
+    if s.baseline_note:
+        line += f" -- baseline: {s.baseline_note}"
+    if unchanged_ticks >= 2:
+        hours = unchanged_ticks * _TICK_INTERVAL_MINUTES / 60
+        line += f" (persistent ~{hours:.1f}h)"
+    return line
+
+
+def format_signals(
+    signals: Iterable[SignalReading],
+    *,
+    staleness: dict[str, int] | None = None,
+    excluded_signals: set[str] | None = None,
+    min_value: float = 0.0,
+    empty: str = "",
+) -> str:
+    """Newline-joined canonical lines for a signal collection.
+
+    ``min_value`` > 0 excludes signals at or below that value (bootstrap
+    placeholder filtering). ``excluded_signals`` drops names outright.
+    No silent truncation: every passing signal renders.
+    """
+    staleness = staleness or {}
+    lines = [
+        format_signal_line(s, unchanged_ticks=staleness.get(s.name, 0))
+        for s in signals
+        if not (excluded_signals is not None and s.name in excluded_signals)
+        and not (min_value > 0 and s.value <= min_value)
+    ]
+    return "\n".join(lines) if lines else empty

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -457,7 +457,9 @@ class CCReflectionBridge:
                     output.text, db=db, output_router=self._output_router,
                     gathered_obs_ids=gathered_obs_ids,
                     gathered_surplus_ids=gathered_surplus_ids,
-                    tick_signal_names={s.name for s in tick.signals},
+                    tick_signal_names=(
+                        {s.name for s in tick.signals} if tick.signals else None
+                    ),
                 )
                 if routing_summary.get("parse_failed") or routing_summary.get("empty_output"):
                     routing_failed = True

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -457,6 +457,7 @@ class CCReflectionBridge:
                     output.text, db=db, output_router=self._output_router,
                     gathered_obs_ids=gathered_obs_ids,
                     gathered_surplus_ids=gathered_surplus_ids,
+                    tick_signal_names={s.name for s in tick.signals},
                 )
                 if routing_summary.get("parse_failed") or routing_summary.get("empty_output"):
                     routing_failed = True

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -40,6 +40,7 @@ async def route_deep_output(
     output_router,
     gathered_obs_ids: tuple[str, ...] = (),
     gathered_surplus_ids: tuple[str, ...] = (),
+    tick_signal_names: set[str] | None = None,
 ) -> dict:
     """Parse and route deep reflection output via OutputRouter.
 
@@ -60,6 +61,7 @@ async def route_deep_output(
         parsed, db,
         gathered_obs_ids=gathered_obs_ids,
         gathered_surplus_ids=gathered_surplus_ids,
+        tick_signal_names=tick_signal_names,
     )
 
 
@@ -124,7 +126,10 @@ async def store_reflection_output(depth, tick, output, *, db) -> None:
 
     # Light: parse JSON for escalation, user_model_deltas, surplus_candidates
     if depth == Depth.LIGHT:
-        await _process_light_output(output, source=source, now=now, db=db)
+        await _process_light_output(
+            output, source=source, now=now, db=db,
+            tick_signal_names={s.name for s in tick.signals} if tick and tick.signals else None,
+        )
 
     # Extract and store focus_next_week from strategic output
     if depth == Depth.STRATEGIC:
@@ -138,8 +143,15 @@ async def store_reflection_output(depth, tick, output, *, db) -> None:
         )
 
 
-async def _process_light_output(output, *, source: str, now: str, db) -> None:
-    """Parse light reflection JSON and extract escalations, deltas, surplus."""
+async def _process_light_output(
+    output, *, source: str, now: str, db,
+    tick_signal_names: set[str] | None = None,
+) -> None:
+    """Parse light reflection JSON and extract escalations, deltas, surplus.
+
+    ``tick_signal_names``: live tick signal names for the phantom-signal
+    claim guard on the ``context_update`` narrative (None = skip).
+    """
     from genesis.db.crud import observations
 
     try:
@@ -292,11 +304,18 @@ async def _process_light_output(output, *, source: str, now: str, db) -> None:
                         pass  # unparseable — don't suppress (fail-open)
 
                 if hours_since_deep >= _DEEP_PRESERVE_HOURS:
+                    from genesis.reflection.signal_claims import guard_narrative
+
+                    guarded_update = await guard_narrative(
+                        db, context_update.strip(),
+                        tick_signal_names=tick_signal_names,
+                        source="light_reflection",
+                    )
                     await cognitive_state.replace_section(
                         db,
                         section="active_context",
                         id=str(uuid.uuid4()),
-                        content=context_update.strip(),
+                        content=guarded_update,
                         generated_by="light_reflection",
                         created_at=now,
                     )

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -13,6 +13,7 @@ import uuid as _uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from genesis.awareness.signal_format import format_signal_line, format_signals
 from genesis.awareness.types import Depth, SignalReading, TickResult
 from genesis.cc.types import CCModel
 
@@ -30,38 +31,23 @@ _TICK_INTERVAL_MINUTES = 5  # awareness loop tick interval
 
 
 def _format_signal(s: SignalReading, *, unchanged_ticks: int = 0) -> str:
-    """Format a signal with threshold and staleness annotations."""
-    base = f"{s.name}={s.value}"
-    if s.normal_max is not None:
-        status = (
-            "CRITICAL" if s.critical_threshold is not None and s.value >= s.critical_threshold
-            else "WARNING" if s.warning_threshold is not None and s.value >= s.warning_threshold
-            else "normal"
-        )
-        base += f" [{status}]"
-    if s.baseline_note:
-        base += f" -- baseline: {s.baseline_note}"
-    if unchanged_ticks >= 2:
-        hours = unchanged_ticks * _TICK_INTERVAL_MINUTES / 60
-        base += f" (persistent ~{hours:.1f}h)"
-    return base
+    """Thin delegate onto the canonical formatter (awareness.signal_format)."""
+    return format_signal_line(s, unchanged_ticks=unchanged_ticks)
 
 
-def _format_signals_from_tick(
-    tick: TickResult, *, limit: int = 10, min_value: float = 0.0,
-) -> str:
-    """Format signals with staleness annotations from a TickResult.
+def _format_signals_from_tick(tick: TickResult, *, min_value: float = 0.0) -> str:
+    """Canonical signal block for a TickResult (thin delegate).
 
-    When min_value > 0, signals at or below that value are excluded.
-    This filters out bootstrap placeholder signals that always return 0.0.
+    When min_value > 0, signals at or below that value are excluded
+    (bootstrap placeholder filtering). No silent truncation — every
+    passing signal renders, one canonical line each.
     """
-    staleness = tick.signal_staleness or {}
-    parts = [
-        _format_signal(s, unchanged_ticks=staleness.get(s.name, 0))
-        for s in tick.signals[:limit]
-        if s.value > min_value or min_value == 0.0
-    ]
-    return ", ".join(parts) if parts else "none"
+    return format_signals(
+        tick.signals,
+        staleness=tick.signal_staleness or {},
+        min_value=min_value,
+        empty="none",
+    )
 
 
 # ── Light reflection focus rotation ──────────────────────────────────
@@ -296,8 +282,10 @@ async def build_reflection_prompt(
             f"Perform a Light reflection.\n\n"
             f"Tick ID: {tick.tick_id}\n"
             f"Timestamp: {tick.timestamp}\n"
-            f"Trigger: {tick.trigger_reason or 'scheduled'}\n"
-            f"Signals: {signals_summary}\n"
+            f"Trigger: {tick.trigger_reason or 'scheduled'}\n\n"
+            f"## Live Tick Signals (canonical)\n"
+            f"These are the ONLY signals you may cite by name/value. Anything else in this prompt is stored context, not a live signal.\n"
+            f"{signals_summary}\n\n"
             f"Depth scores: {scores_summary}\n\n"
             f"## Current Cognitive State\n\n{cog_state}\n\n"
             f"{focus_instruction}\n\n"
@@ -308,8 +296,10 @@ async def build_reflection_prompt(
         f"Perform a {depth.value} reflection.\n\n"
         f"Tick ID: {tick.tick_id}\n"
         f"Timestamp: {tick.timestamp}\n"
-        f"Trigger: {tick.trigger_reason or 'scheduled'}\n"
-        f"Signals: {signals_summary}\n"
+        f"Trigger: {tick.trigger_reason or 'scheduled'}\n\n"
+        f"## Live Tick Signals (canonical)\n"
+        f"These are the ONLY signals you may cite by name/value. Anything else in this prompt is stored context, not a live signal.\n"
+        f"{signals_summary}\n\n"
         f"Depth scores: {scores_summary}\n\n"
         f"## Current Cognitive State\n\n{cog_state}\n\n"
         f"Analyze the current state, identify patterns and observations, "
@@ -340,7 +330,7 @@ async def build_strategic_prompt_enriched(
         f"Timestamp: {tick.timestamp}",
         f"User timezone: {tz_name}",
         f"Trigger: {tick.trigger_reason or 'scheduled'}",
-        f"Signals: {signals_summary}\n",
+        f"\n## Live Tick Signals (canonical)\nThese are the ONLY signals you may cite by name/value. Anything else in this prompt is stored context, not a live signal.\n{signals_summary}\n",
         f"## Current Cognitive State\n\n{cog_state}\n",
     ]
 
@@ -387,7 +377,7 @@ async def build_enriched_prompt(
 
     if tick.signals:
         signals = _format_signals_from_tick(tick)
-        parts.append(f"\n## Signals\n{signals}")
+        parts.append(f"\n## Live Tick Signals (canonical)\nThese are the ONLY signals you may cite by name/value. Anything else in this prompt is stored context, not a live signal.\n{signals}")
 
     parts.append(f"\n## Current Cognitive State\n{bundle.cognitive_state}")
 
@@ -439,7 +429,14 @@ async def build_enriched_prompt(
         counts = eval_ctx.get("signal_counts", {})
         has_signals = any(counts.get(k, 0) > 0 for k in counts)
         if has_signals:
-            ctx_parts = ["\n## Cross-Interaction Signals (for pattern synthesis)"]
+            ctx_parts = [
+                "\n## Cross-Interaction Context "
+                "(from stored observations — NOT live signals)"
+            ]
+            ctx_parts.append(
+                "These are stored-observation summaries for pattern "
+                "synthesis. Do not cite them as signal names/values."
+            )
             ctx_parts.append(
                 f"Signal counts: {json.dumps(counts)}"
             )
@@ -513,7 +510,7 @@ async def build_light_prompt_enriched(
         f"Tick ID: {tick.tick_id}",
         f"Timestamp: {tick.timestamp}",
         f"Trigger: {tick.trigger_reason or 'scheduled'}\n",
-        f"## Signals\n{ctx.signals_text}",
+        f"## Live Tick Signals (canonical)\nThese are the ONLY signals you may cite by name/value. Anything else in this prompt is stored context, not a live signal.\n{ctx.signals_text}",
         f"\n## Current Cognitive State\n{ctx.cognitive_state or '(none)'}",
     ]
 

--- a/src/genesis/identity/REFLECTION_DEEP.md
+++ b/src/genesis/identity/REFLECTION_DEEP.md
@@ -93,8 +93,11 @@ evolution system can propose improvements.
 
 ### Cross-Interaction Patterns (if evaluation context is provided)
 
-Look across recent signals from all channels — inbox evaluations, conversations,
-recon findings — for patterns the user or Genesis should know about:
+The prompt may include a "Cross-Interaction Context" section built from stored
+observations (inbox evaluations, conversations, recon findings). These are
+NOT live signals — never cite them as signal names/values; only the "Live
+Tick Signals (canonical)" block may be cited that way. Look across them for
+patterns the user or Genesis should know about:
 
 - **Recurring topics**: Is the user repeatedly exploring the same domain across
   different interactions? (3+ signals on the same topic = emerging interest)

--- a/src/genesis/perception/context.py
+++ b/src/genesis/perception/context.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
+from genesis.awareness.signal_format import format_signals
 from genesis.awareness.types import Depth, TickResult
 from genesis.db.crud import cognitive_state, observations, predictions, signal_weights
 from genesis.identity.loader import IdentityLoader
@@ -451,33 +452,13 @@ class ContextAssembler:
         excluded_signals: set[str] | None = None,
         min_value: float = 0.0,
     ) -> str:
-        staleness = tick.signal_staleness or {}
-        tick_interval_min = 5  # awareness loop tick interval
-        lines = []
-        for s in tick.signals:
-            if excluded_signals is not None and s.name in excluded_signals:
-                continue
-            if min_value > 0 and s.value <= min_value:
-                continue
-            line = f"{s.name}: {s.value} (source={s.source})"
-            if s.normal_max is not None:
-                status = (
-                    "CRITICAL" if s.critical_threshold is not None and s.value >= s.critical_threshold
-                    else "WARNING" if s.warning_threshold is not None and s.value >= s.warning_threshold
-                    else "normal"
-                )
-                line += (
-                    f" [{status}; normal<={s.normal_max},"
-                    f" warn>={s.warning_threshold}, crit>={s.critical_threshold}]"
-                )
-            if s.baseline_note:
-                line += f" -- baseline: {s.baseline_note}"
-            unchanged = staleness.get(s.name, 0)
-            if unchanged >= 2:
-                hours = unchanged * tick_interval_min / 60
-                line += f" (persistent ~{hours:.1f}h)"
-            lines.append(line)
-        return "\n".join(lines)
+        """Thin delegate onto the canonical formatter (awareness.signal_format)."""
+        return format_signals(
+            tick.signals,
+            staleness=tick.signal_staleness or {},
+            excluded_signals=excluded_signals,
+            min_value=min_value,
+        )
 
     def _extract_tick_number(self, tick: TickResult) -> int:
         """Derive a deterministic tick number from tick_id for template rotation.

--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from genesis.db.crud import cognitive_state, observations, procedural
 from genesis.perception.confidence import load_config as load_confidence_config
 from genesis.perception.confidence import should_gate
+from genesis.reflection.signal_claims import guard_narrative
 from genesis.reflection.types import (
     DeepReflectionOutput,
     DimensionScore,
@@ -239,6 +240,7 @@ class OutputRouter:
         self, output: DeepReflectionOutput, db: aiosqlite.Connection,
         *, gathered_obs_ids: tuple[str, ...] = (),
         gathered_surplus_ids: tuple[str, ...] = (),
+        tick_signal_names: set[str] | None = None,
     ) -> dict:
         """Route all components of a deep reflection output to their stores.
 
@@ -247,6 +249,10 @@ class OutputRouter:
         ``gathered_obs_ids``: observation IDs fed into the reflection context.
         Marked as "influenced" only when output is substantive.
         ``gathered_surplus_ids``: promoted surplus insight IDs fed into context.
+        ``tick_signal_names``: names of the live tick's signals. When provided,
+        narrative writes (cognitive_state_update, focus_next) pass through the
+        phantom-signal claim guard (annotate-and-strip, never blocking);
+        ``None`` skips validation (back-compat).
         Marked as consumed after successful routing.
         """
         summary: dict = {
@@ -361,11 +367,15 @@ class OutputRouter:
         # 3. Cognitive state update
         now = datetime.now(UTC).isoformat()
         if output.cognitive_state_update:
+            state_content = await guard_narrative(
+                db, output.cognitive_state_update,
+                tick_signal_names=tick_signal_names, source="deep_reflection",
+            )
             await cognitive_state.replace_section(
                 db,
                 section="active_context",
                 id=str(uuid.uuid4()),
-                content=output.cognitive_state_update,
+                content=state_content,
                 generated_by="deep_reflection",
                 created_at=now,
             )
@@ -377,7 +387,11 @@ class OutputRouter:
         # NOTE: replace_section is destructive — overwrites all state_flags content.
         # This is a known limitation of the cognitive_state schema (post-phase-9 fix).
         if output.focus_next:
-            focus_content = f"## Deep Reflection Focus Directive\n{output.focus_next}"
+            focus_text = await guard_narrative(
+                db, output.focus_next,
+                tick_signal_names=tick_signal_names, source="deep_reflection",
+            )
+            focus_content = f"## Deep Reflection Focus Directive\n{focus_text}"
             await cognitive_state.replace_section(
                 db,
                 section="state_flags",

--- a/src/genesis/reflection/signal_claims.py
+++ b/src/genesis/reflection/signal_claims.py
@@ -37,14 +37,39 @@ _CLAIM_RE = re.compile(
 
 
 async def registry_signal_names(db) -> set[str]:
-    """Names of all registered signals (``signal_weights``). Empty set on
-    any failure — which makes the guard a no-op, never a blocker."""
+    """Names of all known signals: ``signal_weights`` UNION names observed
+    in recent ``awareness_ticks``.
+
+    The union matters: several live collectors are not seeded into
+    signal_weights (they vary by install), so the weights table alone
+    leaves their claims unguardable. Recent ticks are ground truth for
+    what this install actually collects — install-agnostic, no seed-list
+    maintenance. Empty set on total failure — which makes the guard a
+    no-op, never a blocker."""
+    names: set[str] = set()
     try:
         cursor = await db.execute("SELECT signal_name FROM signal_weights")
-        return {row[0] for row in await cursor.fetchall()}
+        names.update(row[0] for row in await cursor.fetchall())
     except Exception:
-        logger.debug("signal registry query failed — guard disabled", exc_info=True)
-        return set()
+        logger.debug("signal_weights registry query failed", exc_info=True)
+    try:
+        cursor = await db.execute(
+            "SELECT signals_json FROM awareness_ticks "
+            "ORDER BY created_at DESC LIMIT 12"
+        )
+        for (signals_json,) in await cursor.fetchall():
+            try:
+                entries = json.loads(signals_json) if signals_json else []
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(entries, dict):
+                entries = list(entries.values())
+            for entry in entries:
+                if isinstance(entry, dict) and entry.get("name"):
+                    names.add(str(entry["name"]))
+    except Exception:
+        logger.debug("awareness_ticks registry query failed", exc_info=True)
+    return names
 
 
 def validate_signal_claims(

--- a/src/genesis/reflection/signal_claims.py
+++ b/src/genesis/reflection/signal_claims.py
@@ -1,0 +1,125 @@
+"""Phantom-signal claim guard for reflection narrative text.
+
+Deep/light reflections write free-text narrative into ``cognitive_state``
+(``active_context``, focus directives). When that narrative asserts a
+signal *by name and value* that was NOT in the live tick, the claim
+persists for days and re-enters every later reflection's context — the
+next cycle then "debunks" it, the one after re-asserts it (the phantom
+assert/debunk loop; follow-up d8603c0b).
+
+This guard validates ``name=value`` / ``name: value`` claims in narrative
+text against the actual tick signal set. A claim is a violation iff the
+name is a REGISTERED signal (``signal_weights``) that was absent from the
+tick — unknown names are left alone (prose, not signal claims). Violations
+are annotated-and-stripped, logged, and recorded as a
+``phantom_signal_claim`` observation. The guard NEVER rejects or blocks a
+cognitive-state update, and any internal error passes the text through
+unchanged — losing a narrative update over a guard bug would be worse
+than the noise it prevents.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+# snake_case identifier followed by = or : and a bare number. Requires ≥2
+# underscores-or-chars beyond a single word to look like a signal name is
+# too strict; instead we rely on registry membership for precision.
+_CLAIM_RE = re.compile(
+    r"\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\s*[=:]\s*(-?[0-9]+(?:\.[0-9]+)?)"
+)
+
+
+async def registry_signal_names(db) -> set[str]:
+    """Names of all registered signals (``signal_weights``). Empty set on
+    any failure — which makes the guard a no-op, never a blocker."""
+    try:
+        cursor = await db.execute("SELECT signal_name FROM signal_weights")
+        return {row[0] for row in await cursor.fetchall()}
+    except Exception:
+        logger.debug("signal registry query failed — guard disabled", exc_info=True)
+        return set()
+
+
+def validate_signal_claims(
+    text: str,
+    *,
+    tick_signal_names: set[str] | None,
+    registry_names: set[str],
+) -> tuple[str, list[str]]:
+    """Return ``(cleaned_text, violated_names)``.
+
+    A claim is stripped iff its name is in ``registry_names`` but not in
+    ``tick_signal_names``. ``tick_signal_names=None`` disables validation
+    (back-compat for callers that cannot provide the tick). Never raises.
+    """
+    if not text or tick_signal_names is None or not registry_names:
+        return text, []
+    try:
+        violations: list[str] = []
+
+        def _repl(match: re.Match) -> str:
+            name = match.group(1)
+            if name in registry_names and name not in tick_signal_names:
+                violations.append(name)
+                return f"[unverified signal claim removed: {name}]"
+            return match.group(0)
+
+        return _CLAIM_RE.sub(_repl, text), violations
+    except Exception:
+        logger.warning("signal-claim guard error — passing text through", exc_info=True)
+        return text, []
+
+
+async def guard_narrative(
+    db,
+    text: str | None,
+    *,
+    tick_signal_names: set[str] | None,
+    source: str,
+) -> str | None:
+    """Validate *text* against the tick; strip violations, log, and record a
+    ``phantom_signal_claim`` observation. Returns the (possibly annotated)
+    text — never ``None``-out, never raises, never blocks the update."""
+    if not text or tick_signal_names is None:
+        return text
+    try:
+        registry = await registry_signal_names(db)
+        cleaned, violations = validate_signal_claims(
+            text, tick_signal_names=tick_signal_names, registry_names=registry,
+        )
+        if violations:
+            logger.warning(
+                "Stripped %d unverified signal claim(s) from %s narrative: %s",
+                len(violations), source, violations,
+            )
+            try:
+                from genesis.db.crud import observations
+
+                await observations.create(
+                    db,
+                    id=str(uuid.uuid4()),
+                    source=source,
+                    type="phantom_signal_claim",
+                    content=json.dumps({
+                        "stripped_signals": violations,
+                        "note": (
+                            "Narrative asserted registered signals by "
+                            "name/value that were absent from the live tick."
+                        ),
+                    }),
+                    priority="low",
+                    created_at=datetime.now(UTC).isoformat(),
+                )
+            except Exception:
+                logger.debug("phantom_signal_claim observation write failed", exc_info=True)
+        return cleaned
+    except Exception:
+        logger.warning("signal-claim guard failed — passing text through", exc_info=True)
+        return text

--- a/tests/test_awareness/test_signal_format.py
+++ b/tests/test_awareness/test_signal_format.py
@@ -1,0 +1,56 @@
+"""Canonical signal formatter — one format for every reflection depth."""
+
+from genesis.awareness.signal_format import format_signal_line, format_signals
+from genesis.awareness.types import SignalReading
+
+
+def _sig(name="cpu_usage", value=0.3, source="system", **kw):
+    return SignalReading(
+        name=name, value=value, source=source,
+        collected_at="2026-07-18T00:00:00+00:00", **kw,
+    )
+
+
+def test_line_basic():
+    assert format_signal_line(_sig()) == "cpu_usage: 0.3 (source=system)"
+
+
+def test_line_thresholds_and_status():
+    line = format_signal_line(_sig(
+        value=0.9, normal_max=0.5, warning_threshold=0.7, critical_threshold=0.85,
+    ))
+    assert "[CRITICAL; normal<=0.5, warn>=0.7, crit>=0.85]" in line
+
+
+def test_line_baseline_note_and_persistence():
+    line = format_signal_line(
+        _sig(baseline_note="Baseline: 4.0/day. Recent: 27.0/day."),
+        unchanged_ticks=24,
+    )
+    assert "-- baseline: Baseline: 4.0/day. Recent: 27.0/day." in line
+    assert "(persistent ~2.0h)" in line
+
+
+def test_format_signals_no_truncation():
+    sigs = [_sig(name=f"signal_{i:02d}", value=0.5) for i in range(15)]
+    text = format_signals(sigs)
+    assert text.count("\n") == 14  # all 15 render — no silent [:10] cap
+
+
+def test_format_signals_min_value_and_excluded():
+    sigs = [
+        _sig(name="keep_me", value=0.5),
+        _sig(name="zero_bootstrap", value=0.0),
+        _sig(name="excluded_one", value=0.9),
+    ]
+    text = format_signals(
+        sigs, excluded_signals={"excluded_one"}, min_value=0.001,
+    )
+    assert "keep_me" in text
+    assert "zero_bootstrap" not in text
+    assert "excluded_one" not in text
+
+
+def test_format_signals_empty_token():
+    assert format_signals([], empty="none") == "none"
+    assert format_signals([]) == ""

--- a/tests/test_cc/test_reflection_bridge.py
+++ b/tests/test_cc/test_reflection_bridge.py
@@ -864,3 +864,61 @@ async def test_light_prompt_no_prior_context(db):
 
     assert "Previous Light Cycle Finding" not in prompt
     assert "Perform a Light reflection" in prompt
+
+
+# ── Signal integrity (PR-5b): canonical block + headings ───────────────────
+
+
+def _signal_tick():
+    from genesis.awareness.types import SignalReading
+
+    return TickResult(
+        tick_id="tick-sig-1",
+        timestamp="2026-03-07T12:00:00",
+        source="scheduled",
+        signals=[
+            SignalReading(
+                name="autonomy_activity", value=0.7, source="autonomy_state",
+                collected_at="2026-03-07T12:00:00+00:00",
+                baseline_note="0.0=stable",
+            ),
+            SignalReading(
+                name="memory_backlog", value=0.2, source="observations",
+                collected_at="2026-03-07T12:00:00+00:00",
+            ),
+        ],
+        scores=[],
+        classified_depth=Depth.DEEP,
+        trigger_reason="test",
+    )
+
+
+async def test_prompt_uses_canonical_signal_heading(db):
+    """Every depth's prompt labels the live tick block canonically."""
+    from genesis.cc.reflection_bridge._prompts import build_reflection_prompt
+
+    tick = _signal_tick()
+    for depth in (Depth.LIGHT, Depth.DEEP):
+        prompt, _o, _s = await build_reflection_prompt(
+            depth=depth, tick=tick, db=db,
+            context_gatherer=None, context_assembler=None,
+            prompt_dir=Path("/nonexistent"),
+        )
+        assert "## Live Tick Signals (canonical)" in prompt
+        assert "ONLY signals you may cite" in prompt
+        assert "Signals: " not in prompt  # old inline label gone
+
+
+async def test_prompt_signal_lines_are_canonical_format(db):
+    """The tick block uses the rich canonical line format (parity with the
+    ContextAssembler path) — name: value (source=...), newline-joined."""
+    from genesis.awareness.signal_format import format_signals
+    from genesis.cc.reflection_bridge._prompts import _format_signals_from_tick
+
+    tick = _signal_tick()
+    expected = format_signals(
+        tick.signals, staleness=tick.signal_staleness or {}, empty="none",
+    )
+    assert _format_signals_from_tick(tick) == expected
+    for s in tick.signals:
+        assert f"{s.name}: {s.value} (source={s.source})" in expected

--- a/tests/test_reflection/test_output_router.py
+++ b/tests/test_reflection/test_output_router.py
@@ -892,3 +892,77 @@ class TestWriteObservationDedup:
         row = await cursor.fetchone()
         assert row[0] is not None
         assert len(row[0]) == 64  # SHA-256 hex
+
+
+# ── Phantom-signal claim guard wiring (PR-5b) ──────────────────────────────
+
+
+class TestSignalClaimGuardWiring:
+    async def _register_signal(self, db, name):
+        await db.execute(
+            "INSERT OR IGNORE INTO signal_weights (signal_name, source_mcp, "
+            "current_weight, initial_weight, feeds_depths) "
+            "VALUES (?, 'test', 0.5, 0.5, ?)",
+            (name, '["Deep"]'),
+        )
+        await db.commit()
+
+    @pytest.mark.asyncio
+    async def test_route_strips_phantom_claim_from_cognitive_state(self, db, router):
+        await self._register_signal(db, "memory_backlog")
+        output = DeepReflectionOutput(
+            cognitive_state_update="Concern: memory_backlog=0.9 is rising.",
+        )
+        summary = await router.route(
+            output, db, tick_signal_names={"autonomy_activity"},
+        )
+        assert summary["cognitive_state_updated"]
+        rows = await db.execute_fetchall(
+            "SELECT content FROM cognitive_state WHERE section='active_context'"
+        )
+        stored = rows[-1]["content"]
+        assert "[unverified signal claim removed: memory_backlog]" in stored
+        assert "memory_backlog=0.9" not in stored
+        # ...and the violation is recorded for observability
+        obs = await db.execute_fetchall(
+            "SELECT content FROM observations WHERE type='phantom_signal_claim'"
+        )
+        assert len(obs) == 1
+
+    @pytest.mark.asyncio
+    async def test_route_keeps_claim_present_in_tick(self, db, router):
+        await self._register_signal(db, "memory_backlog")
+        output = DeepReflectionOutput(
+            cognitive_state_update="memory_backlog=0.9 confirmed by tick.",
+        )
+        await router.route(output, db, tick_signal_names={"memory_backlog"})
+        rows = await db.execute_fetchall(
+            "SELECT content FROM cognitive_state WHERE section='active_context'"
+        )
+        assert "memory_backlog=0.9 confirmed by tick." in rows[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_route_without_tick_names_skips_guard(self, db, router):
+        """Back-compat: callers that can't provide the tick are untouched."""
+        await self._register_signal(db, "memory_backlog")
+        output = DeepReflectionOutput(
+            cognitive_state_update="memory_backlog=0.9 asserted blind.",
+        )
+        await router.route(output, db)
+        rows = await db.execute_fetchall(
+            "SELECT content FROM cognitive_state WHERE section='active_context'"
+        )
+        assert "memory_backlog=0.9 asserted blind." in rows[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_route_guards_focus_next(self, db, router):
+        await self._register_signal(db, "memory_backlog")
+        output = DeepReflectionOutput(
+            focus_next="Chase memory_backlog=0.9 next cycle.",
+        )
+        await router.route(output, db, tick_signal_names=set())
+        rows = await db.execute_fetchall(
+            "SELECT content FROM cognitive_state WHERE section='state_flags'"
+        )
+        joined = " ".join(r["content"] for r in rows)
+        assert "[unverified signal claim removed: memory_backlog]" in joined

--- a/tests/test_reflection/test_signal_claims.py
+++ b/tests/test_reflection/test_signal_claims.py
@@ -1,0 +1,134 @@
+"""Phantom-signal claim guard — annotate-and-strip, never blocking."""
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+from genesis.reflection.signal_claims import (
+    guard_narrative,
+    validate_signal_claims,
+)
+
+_REGISTRY = {"memory_backlog", "autonomy_activity", "user_session_pattern"}
+
+
+def test_strips_registered_claim_absent_from_tick():
+    text = "Status stable, but memory_backlog=0.8 needs attention."
+    cleaned, violations = validate_signal_claims(
+        text, tick_signal_names={"autonomy_activity"}, registry_names=_REGISTRY,
+    )
+    assert violations == ["memory_backlog"]
+    assert "[unverified signal claim removed: memory_backlog]" in cleaned
+    assert "memory_backlog=0.8" not in cleaned
+
+
+def test_keeps_claim_present_in_tick():
+    text = "autonomy_activity: 1.0 remains pinned."
+    cleaned, violations = validate_signal_claims(
+        text, tick_signal_names={"autonomy_activity"}, registry_names=_REGISTRY,
+    )
+    assert violations == []
+    assert cleaned == text
+
+
+def test_unregistered_names_are_prose_not_claims():
+    text = "error_rate=0.02 and coffee_level: 9000 are not registered signals."
+    cleaned, violations = validate_signal_claims(
+        text, tick_signal_names=set(), registry_names=_REGISTRY,
+    )
+    assert violations == []
+    assert cleaned == text
+
+
+def test_none_tick_names_skips_validation():
+    text = "memory_backlog=0.8"
+    cleaned, violations = validate_signal_claims(
+        text, tick_signal_names=None, registry_names=_REGISTRY,
+    )
+    assert violations == []
+    assert cleaned == text
+
+
+def test_empty_registry_skips_validation():
+    cleaned, violations = validate_signal_claims(
+        "memory_backlog=0.8", tick_signal_names=set(), registry_names=set(),
+    )
+    assert violations == []
+
+
+def test_prose_without_numbers_untouched():
+    text = "The memory_backlog signal has been discussed before."
+    cleaned, violations = validate_signal_claims(
+        text, tick_signal_names=set(), registry_names=_REGISTRY,
+    )
+    assert violations == []
+    assert cleaned == text
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        yield conn
+
+
+async def _register(db, *names):
+    for n in names:
+        await db.execute(
+            "INSERT OR IGNORE INTO signal_weights (signal_name, source_mcp, "
+            "current_weight, initial_weight, feeds_depths) "
+            "VALUES (?, 'test', 0.5, 0.5, ?)",
+            (n, '["Deep"]'),
+        )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_guard_narrative_strips_and_records_observation(db):
+    await _register(db, "memory_backlog")
+    cleaned = await guard_narrative(
+        db, "Claim: memory_backlog=0.9 is critical.",
+        tick_signal_names={"other_signal"}, source="deep_reflection",
+    )
+    assert "[unverified signal claim removed: memory_backlog]" in cleaned
+    rows = await db.execute_fetchall(
+        "SELECT content FROM observations WHERE type='phantom_signal_claim'"
+    )
+    assert len(rows) == 1
+    assert "memory_backlog" in rows[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_guard_narrative_clean_text_no_observation(db):
+    await _register(db, "memory_backlog")
+    text = "All quiet on every front."
+    cleaned = await guard_narrative(
+        db, text, tick_signal_names={"memory_backlog"}, source="deep_reflection",
+    )
+    assert cleaned == text
+    rows = await db.execute_fetchall(
+        "SELECT id FROM observations WHERE type='phantom_signal_claim'"
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_guard_narrative_internal_error_passthrough():
+    class BoomDB:
+        async def execute(self, *a, **k):
+            raise RuntimeError("db down")
+
+    text = "memory_backlog=0.9"
+    cleaned = await guard_narrative(
+        BoomDB(), text, tick_signal_names=set(), source="deep_reflection",
+    )
+    assert cleaned == text  # guard failure NEVER loses the narrative
+
+
+@pytest.mark.asyncio
+async def test_guard_narrative_none_tick_passthrough(db):
+    text = "memory_backlog=0.9"
+    assert await guard_narrative(
+        db, text, tick_signal_names=None, source="x",
+    ) == text

--- a/tests/test_reflection/test_signal_claims.py
+++ b/tests/test_reflection/test_signal_claims.py
@@ -132,3 +132,23 @@ async def test_guard_narrative_none_tick_passthrough(db):
     assert await guard_narrative(
         db, text, tick_signal_names=None, source="x",
     ) == text
+
+
+@pytest.mark.asyncio
+async def test_registry_includes_recent_tick_signals(db):
+    """Signals absent from signal_weights but present in recent ticks are
+    still guardable (the registry is a union, not the weights table alone)."""
+    import json as _json
+
+    from genesis.reflection.signal_claims import registry_signal_names
+
+    await db.execute(
+        "INSERT INTO awareness_ticks (id, source, signals_json, created_at) "
+        "VALUES ('t1', 'scheduled', ?, '2026-07-18T00:00:00+00:00')",
+        (_json.dumps([
+            {"name": "container_memory_pct", "value": 0.4, "source": "host"},
+        ]),),
+    )
+    await db.commit()
+    names = await registry_signal_names(db)
+    assert "container_memory_pct" in names

--- a/tests/test_reflection/test_signal_claims.py
+++ b/tests/test_reflection/test_signal_claims.py
@@ -143,8 +143,9 @@ async def test_registry_includes_recent_tick_signals(db):
     from genesis.reflection.signal_claims import registry_signal_names
 
     await db.execute(
-        "INSERT INTO awareness_ticks (id, source, signals_json, created_at) "
-        "VALUES ('t1', 'scheduled', ?, '2026-07-18T00:00:00+00:00')",
+        "INSERT INTO awareness_ticks (id, source, signals_json, scores_json, "
+        "created_at) "
+        "VALUES ('t1', 'scheduled', ?, '[]', '2026-07-18T00:00:00+00:00')",
         (_json.dumps([
             {"name": "container_memory_pct", "value": 0.4, "source": "host"},
         ]),),


### PR DESCRIPTION
## Problem

Three compounding integrity gaps kept reflections looping on "phantom" signals for days (follow-up d8603c0b):

1. **Two divergent signal formatters** — the perception ContextAssembler rendered rich lines (`name: value (source=…) [status; thresholds] -- baseline …`) while the reflection-bridge prompt path rendered a compact comma-join (`name=value [STATUS]`), silently truncated at 10. Light and deep cycles literally saw differently-shaped signal blocks.
2. **A second "signals"-labeled block built from observations** (`## Cross-Interaction Signals`) taught the model that stored-observation history was citable as live signals.
3. **Unvalidated narrative persistence** — a claim like `memory_backlog=0.9` written into `cognitive_state.active_context` (72h TTL) re-entered every later reflection's context: next cycle debunks it, the one after re-asserts it.

## Fix

- **`awareness/signal_format.py`** — canonical `format_signal_line`/`format_signals` (rich variant). Both legacy formatters become thin delegates (names/signatures preserved; the unused `limit` param removed from `_format_signals_from_tick` — no caller passed it). No silent truncation.
- **Headings** — live tick block: `## Live Tick Signals (canonical)` + "the ONLY signals you may cite by name/value"; observation block: `## Cross-Interaction Context (from stored observations — NOT live signals)`. `REFLECTION_DEEP.md` aligned; repo-wide sweep found no other stale heading references.
- **`reflection/signal_claims.py`** — `validate_signal_claims` regexes `name=value`/`name: value` claims; a violation is a name in the `signal_weights` registry but absent from the live tick (unknown names are prose, untouched). `guard_narrative` annotates-and-strips (`[unverified signal claim removed: <name>]`), warns, records a `phantom_signal_claim` observation — and **never** rejects or blocks the update; any internal guard error passes text through unchanged. Wired into `OutputRouter.route` (`cognitive_state_update`, `focus_next`) and the light `context_update` path via a new `tick_signal_names` kwarg (default `None` = skip, so all existing callers are back-compatible — verified by enumeration).

Untouched: routed DB path, confidence gating, `_has_substance`, cooldowns.

## Tests

Formatter: canonical line contents, thresholds/baseline/persistence, no-truncation (15 signals), filtering, empty tokens. Guard matrix: strip / keep-in-tick / unknown-name / None-tick skip / empty-registry skip / prose untouched / observation written / internal-error passthrough. Wiring: route() strips from stored cognitive state, keeps tick-present claims, back-compat without tick names, focus_next guarded. Prompt: canonical heading at light+deep, old inline label gone, formatter parity across paths. 135 passed across six touched suites.

## Deploy path

Repo code + prompt files only — existing installs: git pull + restart; fresh installs: in-repo. No migrations.

Closes follow-up d8603c0b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)