### PR TITLE
fix(outreach): morning report grounding — ground-truth totals + verbatim single draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The morning report's numbers are real now.** Report generation previously
+  counted truncated display lists (reporting "5 follow-ups" when 268 existed),
+  sometimes inverted protective facts into alarms (an active OOM-protection
+  service reported as an OOM risk), and — worst — the carefully grounded
+  draft was silently re-drafted by a generic model with no grounding rules
+  before delivery. The report context now opens with an authoritative
+  Ground Truth section of exact totals, truncated lists are labeled
+  "showing N of M", protective mechanisms are tagged so they can't be read
+  as risks, and the grounded draft is delivered as-is (single draft pass).
+
 - **Demoted autonomy can actually earn its way back now.** Earn-back
   eligibility used to be computed over a category's entire lifetime record,
   so after a rough patch the math could require months of flawless behavior

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -35,6 +35,21 @@ message. Each rule below keeps it scannable and fast to read.
 Begin with the first section header and end with the last bullet — nothing
 framing the report before or after.
 
+## Numbers Are Ground Truth
+
+The context opens with a **Ground Truth** section of authoritative totals.
+Three hard rules:
+
+- **Restate ground-truth numbers EXACTLY.** Never round, estimate, or
+  recompute them from other sections.
+- **Never derive a total from a list section.** List sections are truncated
+  samples ("showing 5 of 268") — the length of a sample is not a count.
+  If a list shows 5 items and Ground Truth says 268, the report says 268.
+- **Protective facts are never risks.** An item tagged `[protective: …]`
+  describes a protection mechanism that is PRESENT and working (OOM
+  guards, swap/zram). Report it as protection, or omit it — never as an
+  active risk or alarm.
+
 ## Voice
 
 Senior advisor writing a daily briefing. State facts. Be direct. Every

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -920,12 +920,37 @@ class MorningReportGenerator:
         "swap enabled": "swap protection — its presence is protective",
     }
 
-    def _protective_tag(self, content: str) -> str:
+    # A protection named alongside any of these cues is being reported as
+    # ABSENT/broken — that IS a risk and must never be tagged protective
+    # (the tag would instruct the drafter to soften or omit it).
+    _NEGATION_CUES: tuple[str, ...] = (
+        "not ", "n't", "no ", "never", "disabled", "absent", "missing",
+        "unprotected", "inactive", "stopped", "failed", "broken", "off ",
+        "lost", "without",
+    )
+
+    # Sources that ONLY ever report missing/broken protections — never tag.
+    _NEVER_PROTECTIVE_SOURCES: frozenset[str] = frozenset({
+        "infra_protection_posture_monitor",
+    })
+
+    def _protective_tag(self, content: str, *, source: str = "") -> str:
         """Return ' [protective: …]' when the observation cites a known
-        protective mechanism, else ''."""
+        protective mechanism AS PRESENT, else ''.
+
+        Never tags posture-monitor alerts (that source exists to report
+        protections that are MISSING) and never tags content carrying a
+        negation cue — "systemd-oomd is not enforced" is a live risk, and
+        tagging it protective would invert (and, per the prompt rule,
+        suppress) exactly the alert class this map exists to protect.
+        """
+        if source in self._NEVER_PROTECTIVE_SOURCES:
+            return ""
         lowered = content.lower()
         for fact, note in self._PROTECTIVE_FACTS.items():
             if fact in lowered:
+                if any(cue in lowered for cue in self._NEGATION_CUES):
+                    return ""
                 return f" [protective: {note}]"
         return ""
 
@@ -962,7 +987,9 @@ class MorningReportGenerator:
             badge = {"critical": "🔴", "high": "🟠", "medium": "🟡"}.get(prio, "")
             content = obs["content"][:200].replace("\n", " ")
             age = _relative_age(obs.get("created_at", ""))
-            protective = self._protective_tag(content)
+            protective = self._protective_tag(
+                content, source=obs.get("source") or "",
+            )
             lines.append(
                 f"- {badge} **{prio}**{aged} ({age}): {content}{protective}"
             )

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -191,6 +191,11 @@ class MorningReportGenerator:
             context=draft.content.text,
             salience_score=0.0,
             signal_type="morning_report",
+            # The draft above ran with the MORNING_REPORT.md system prompt
+            # against grounded context. Without verbatim, the pipeline
+            # re-drafts it through the generic drafter (system_prompt=None),
+            # un-grounding every number. Formatter still applies.
+            verbatim=True,
         )
 
     async def confirm_delivery(self) -> None:
@@ -241,6 +246,16 @@ class MorningReportGenerator:
 
     async def _assemble_context(self) -> str:
         sections: list[str] = []
+
+        # 0. Ground truth — deterministic totals, assembled before any list
+        # section. List sections below are TRUNCATED SAMPLES; these numbers
+        # are the authoritative counts the report must restate exactly.
+        try:
+            ground = await self._ground_truth_section()
+            sections.append(ground)
+        except Exception:
+            logger.warning("Morning report: ground truth unavailable", exc_info=True)
+            await self._emit_warning("ground_truth", "Ground-truth totals unavailable")
 
         # 1. System Health
         try:
@@ -343,6 +358,71 @@ class MorningReportGenerator:
             logger.warning("Morning report: standing items unavailable", exc_info=True)
 
         return "\n\n".join(sections)
+
+    async def _ground_truth_section(self) -> str:
+        """Deterministic SQL totals — the report's authoritative numbers.
+
+        Every count here is a full COUNT/len over the un-truncated query,
+        never the length of a display slice. The system prompt instructs
+        the drafter to restate these exactly and never derive totals from
+        the (truncated) list sections.
+        """
+        from genesis.db.crud import approval_requests as approval_crud
+        from genesis.db.crud import ego as ego_crud
+        from genesis.db.crud import follow_ups
+        from genesis.db.crud.observations import count_unsurfaced
+
+        lines = [
+            "## Ground Truth (authoritative totals — restate these EXACTLY; "
+            "the list sections below are truncated samples)",
+        ]
+
+        # Same queries the list sections run (un-truncated lens), so these
+        # totals can never disagree with the samples below.
+        try:
+            needs_input = len(await follow_ups.get_pending(
+                self._db, strategy="user_input_needed", domain="user_world",
+            ))
+            pending_all = len(await follow_ups.get_pending(
+                self._db, domain="user_world",
+            ))
+            blocked = len(await follow_ups.get_by_status(
+                self._db, "blocked", domain="user_world",
+            ))
+            failed = len(await follow_ups.get_by_status(
+                self._db, "failed", domain="user_world",
+            ))
+            lines.append(
+                f"- Follow-ups (user-world): {needs_input} awaiting your "
+                f"input, {pending_all} pending total, {blocked} blocked, "
+                f"{failed} failed"
+            )
+        except Exception:
+            logger.warning("Ground truth: follow-up counts failed", exc_info=True)
+
+        try:
+            proposals = await ego_crud.list_pending_proposals(self._db)
+            lines.append(f"- Pending ego proposals: {len(proposals)}")
+        except Exception:
+            logger.warning("Ground truth: proposal count failed", exc_info=True)
+
+        try:
+            approvals = await approval_crud.list_pending(self._db)
+            lines.append(f"- Pending approval requests: {len(approvals)}")
+        except Exception:
+            logger.warning("Ground truth: approval count failed", exc_info=True)
+
+        try:
+            unsurfaced = await count_unsurfaced(
+                self._db,
+                priority_filter=("critical", "high", "medium"),
+                exclude_types=_INTERNAL_OBS_TYPES,
+            )
+            lines.append(f"- Unsurfaced observations (worth attention): {unsurfaced}")
+        except Exception:
+            logger.warning("Ground truth: observation count failed", exc_info=True)
+
+        return "\n".join(lines)
 
     async def _emit_warning(self, section: str, message: str) -> None:
         if not self._event_bus:
@@ -637,11 +717,16 @@ class MorningReportGenerator:
         # Pending ego proposals (user needs to approve/reject on dashboard)
         try:
             proposals = await ego_crud.list_pending_proposals(self._db)
+            total_proposals = len(proposals)
             proposals = proposals[:5]
             if proposals:
+                shown = (
+                    f" (showing {len(proposals)} of {total_proposals})"
+                    if total_proposals > len(proposals) else ""
+                )
                 lines.append(
-                    f"- {len(proposals)} pending ego proposal(s) "
-                    "(approve/reject on dashboard):"
+                    f"- {total_proposals} pending ego proposal(s) "
+                    f"(approve/reject on dashboard){shown}:"
                 )
                 for p in proposals:
                     lines.append(
@@ -656,10 +741,15 @@ class MorningReportGenerator:
         # Pending approval requests
         try:
             approvals = await approval_crud.list_pending(self._db)
+            total_approvals = len(approvals)
             approvals = approvals[:5]
             if approvals:
+                shown = (
+                    f" (showing {len(approvals)} of {total_approvals})"
+                    if total_approvals > len(approvals) else ""
+                )
                 lines.append(
-                    f"- {len(approvals)} pending approval request(s):"
+                    f"- {total_approvals} pending approval request(s){shown}:"
                 )
                 for a in approvals:
                     lines.append(f"  - {(a.get('description') or '?')[:150]}")
@@ -684,7 +774,10 @@ class MorningReportGenerator:
             self._db, strategy="user_input_needed", domain="user_world",
         )
         if user_items:
-            lines.append("**Needs your input:**")
+            shown = (
+                f" (showing 5 of {len(user_items)})" if len(user_items) > 5 else ""
+            )
+            lines.append(f"**Needs your input ({len(user_items)} total){shown}:**")
             for fu in user_items[:5]:
                 lines.append(
                     f"- {fu['content'][:200]} ({_relative_age(fu.get('created_at', ''))})"
@@ -694,7 +787,10 @@ class MorningReportGenerator:
         blocked = await follow_ups.get_by_status(self._db, "failed", domain="user_world")
         blocked += await follow_ups.get_by_status(self._db, "blocked", domain="user_world")
         if blocked:
-            lines.append("**Blocked/failed:**")
+            shown = (
+                f" (showing 5 of {len(blocked)})" if len(blocked) > 5 else ""
+            )
+            lines.append(f"**Blocked/failed ({len(blocked)} total){shown}:**")
             for fu in blocked[:5]:
                 reason = fu.get("blocked_reason", "") or "no reason recorded"
                 lines.append(
@@ -728,7 +824,13 @@ class MorningReportGenerator:
         if not resolved:
             return None
 
-        lines = [f"Ego resolved {len(resolved)} inbox follow-up(s) this week:"]
+        header_shown = (
+            f" (showing 10 of {len(resolved)})" if len(resolved) > 10 else ""
+        )
+        lines = [
+            f"Ego resolved {len(resolved)} inbox follow-up(s) this week"
+            f"{header_shown}:"
+        ]
         for fu in resolved[:10]:
             content = (fu.get("content") or "?")[:150]
             notes = (fu.get("resolution_notes") or "no notes")[:100]
@@ -807,6 +909,26 @@ class MorningReportGenerator:
 
         return "\n".join(lines)
 
+    # Fact-name → note map for conditions that are PROTECTIVE, not risks.
+    # Install-agnostic (matched against observation content, lowercase):
+    # the drafter has repeatedly inverted these into alarms ("systemd-oomd
+    # active" reported as an OOM risk).
+    _PROTECTIVE_FACTS: dict[str, str] = {
+        "systemd-oomd": "OOM-protection service — its presence is protective",
+        "earlyoom": "OOM-protection service — its presence is protective",
+        "zram": "compressed-swap protection — its presence is protective",
+        "swap enabled": "swap protection — its presence is protective",
+    }
+
+    def _protective_tag(self, content: str) -> str:
+        """Return ' [protective: …]' when the observation cites a known
+        protective mechanism, else ''."""
+        lowered = content.lower()
+        for fact, note in self._PROTECTIVE_FACTS.items():
+            if fact in lowered:
+                return f" [protective: {note}]"
+        return ""
+
     async def _get_observation_insights(self) -> str | None:
         """Surface unsurfaced observations that deserve user attention.
 
@@ -840,7 +962,10 @@ class MorningReportGenerator:
             badge = {"critical": "🔴", "high": "🟠", "medium": "🟡"}.get(prio, "")
             content = obs["content"][:200].replace("\n", " ")
             age = _relative_age(obs.get("created_at", ""))
-            lines.append(f"- {badge} **{prio}**{aged} ({age}): {content}")
+            protective = self._protective_tag(content)
+            lines.append(
+                f"- {badge} **{prio}**{aged} ({age}): {content}{protective}"
+            )
 
         # Defer surfacing until delivery is confirmed via confirm_delivery().
         # If delivery fails, these observations re-appear in the next report.

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -580,3 +580,85 @@ def test_goal_autonomous_action_is_user_visible():
 
     assert "goal_autonomous_action" not in INTERNAL_OBS_TYPES
     assert "goal_recommendation" not in INTERNAL_OBS_TYPES
+
+
+# ── Grounding (PR morning-report-grounding) ────────────────────────────────
+
+
+async def test_report_request_is_verbatim(db, mock_health, mock_drafter):
+    """The grounded draft IS the report — the pipeline must not re-draft it
+    through the generic drafter (which runs with system_prompt=None)."""
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    request = await gen.generate()
+    assert request.verbatim is True
+
+
+async def test_ground_truth_totals_precede_truncated_lists(db, mock_health, mock_drafter):
+    """Authoritative totals render from un-truncated queries; the pending
+    list shows 'showing 5 of N' rather than presenting the slice as the
+    count."""
+    from genesis.db.crud import ego as ego_crud
+
+    for i in range(7):
+        await ego_crud.create_proposal(
+            db, id=f"gt-{i}", action_type="t", content=f"proposal {i}",
+        )
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    context = await gen._assemble_context()
+
+    assert "## Ground Truth" in context
+    assert "- Pending ego proposals: 7" in context
+    assert "7 pending ego proposal(s)" in context
+    assert "(showing 5 of 7)" in context
+    # Ground truth section renders before any list section
+    assert context.index("## Ground Truth") < context.index("## Pending Items")
+
+
+async def test_ground_truth_follow_up_counts(db, mock_health, mock_drafter):
+    from genesis.db.crud import follow_ups
+
+    for i in range(8):
+        await follow_ups.create(
+            db,
+            id=f"fu-{i}",
+            content=f"item {i}",
+            source="test",
+            strategy="user_input_needed" if i < 3 else "ego_judgment",
+            domain="user_world",
+        )
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    context = await gen._assemble_context()
+    assert "3 awaiting your input, 8 pending total" in context
+
+
+async def test_protective_fact_tagged(db, mock_health, mock_drafter):
+    """A protective mechanism observation carries the [protective: …] tag so
+    the drafter cannot invert it into an active risk."""
+    import uuid as _uuid
+    from datetime import UTC, datetime
+
+    from genesis.db.crud import observations
+
+    await observations.create(
+        db,
+        id=str(_uuid.uuid4()),
+        source="awareness",
+        type="infra_posture",
+        content="systemd-oomd is active and monitoring memory pressure",
+        priority="high",
+        created_at=datetime.now(UTC).isoformat(),
+    )
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    context = await gen._assemble_context()
+    assert "[protective:" in context
+
+
+async def test_prompt_contract_grounding_rules():
+    """MORNING_REPORT.md carries the counts-are-totals + polarity rules."""
+    from genesis.outreach.morning_report import MorningReportGenerator as G
+
+    prompt = G._load_system_prompt()
+    assert prompt is not None
+    assert "Ground Truth" in prompt
+    assert "Never derive a total from a list section" in prompt
+    assert "Protective facts are never risks" in prompt

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -662,3 +662,44 @@ async def test_prompt_contract_grounding_rules():
     assert "Ground Truth" in prompt
     assert "Never derive a total from a list section" in prompt
     assert "Protective facts are never risks" in prompt
+
+
+async def test_negated_protection_never_tagged_protective(db, mock_health, mock_drafter):
+    """The REAL shipping alert class: 'systemd-oomd … is not enforced' is a
+    live risk. Tagging it protective would invert it and — via the prompt
+    rule — suppress it. Neither negated content nor posture-monitor alerts
+    may ever be tagged."""
+    import uuid as _uuid
+    from datetime import UTC, datetime
+
+    from genesis.db.crud import observations
+
+    now = datetime.now(UTC).isoformat()
+    await observations.create(
+        db,
+        id=str(_uuid.uuid4()),
+        source="infra_protection_posture_monitor",
+        type="infrastructure_alert",
+        content=(
+            "systemd-oomd pressure-kill is not enforced for user.slice — "
+            "nothing gracefully kills the memory hog before a hard OOM wedge"
+        ),
+        priority="high",
+        created_at=now,
+    )
+    # Negated phrasing from any other source must also stay untagged.
+    await observations.create(
+        db,
+        id=str(_uuid.uuid4()),
+        source="awareness",
+        type="infra_posture",
+        content="zram is disabled after the unmask sweep",
+        priority="high",
+        created_at=now,
+    )
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    context = await gen._assemble_context()
+    assert "[protective:" not in context
+    # ...and the alerts themselves still surface
+    assert "not enforced" in context
+    assert "zram is disabled" in context


### PR DESCRIPTION
## Problem

Verified claim-by-claim against a live report (2026-07-17): the morning report misstated follow-up counts ("5" vs 268 actual — the length of a display slice reported as the total), described embeddings/oomd state backwards (a protective OOM-guard reported as an active OOM risk), and its numbers had no anchor at all because the grounded draft (built with the MORNING_REPORT.md system prompt) was **silently re-drafted** by the pipeline's generic drafter (`system_prompt=None`) before delivery.

## Fix

1. **`_ground_truth_section()`** — renders FIRST in the context: deterministic totals (follow-ups awaiting input / pending / blocked / failed, pending proposals, pending approvals, unsurfaced observations) computed with the SAME un-truncated queries the list sections run, so the totals can never disagree with the samples. Labeled "authoritative — restate these EXACTLY; the list sections below are truncated samples."
2. **len-after-slice fixes** — proposals/approvals count before slicing; every truncated list ("Needs your input", "Blocked/failed", inbox digest, pending items) carries "(showing N of M)".
3. **Polarity** — a static `_PROTECTIVE_FACTS` map (systemd-oomd, earlyoom, zram, swap — install-agnostic names) tags matching observations `[protective: …]` in "What I Noticed".
4. **Single draft** — the report's `OutreachRequest` sets `verbatim=True`: the grounded draft is delivered as-is (channel formatter still applies via the existing verbatim branch; no second LLM pass). Existing pipeline test already proves verbatim skips the drafter.
5. **`MORNING_REPORT.md`** — new "Numbers Are Ground Truth" rules: restate exactly, never derive totals from list sections, protective facts are never risks.

## Tests

verbatim flag on the generated request; ground-truth totals precede lists and match seeded data exactly (7 proposals → "7" + "showing 5 of 7"); follow-up count semantics (3 awaiting input / 8 pending total); protective tag rendered; prompt-contract smoke. 83 passed across the outreach suites.

## Deploy path

Repo code + prompt file — existing installs: git pull + restart; fresh installs: in-repo. No migrations.

## Sequencing note

#1109 touches `pipeline.py::_deliver` only — disjoint from this change (`morning_report.py` + the request flag). Holding merge for the sequencing call alongside #1123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)