### PR TITLE
refactor(deploy): minimal-downtime update.sh — fetch before stop, regen CLAUDE.md after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Updates are more resilient and briefly less disruptive.** `scripts/update.sh`
+  now downloads new code *before* stopping Genesis, so a slow or stalled network
+  fetch no longer prolongs the restart — and a failed fetch leaves the server
+  running, untouched. The machine-info blocks in `~/.claude/CLAUDE.md` are also
+  regenerated *after* services come back up instead of during the offline
+  window, trimming the downtime slightly.
+
 - **Finished background-queue rows are now pruned after 45 days.** The internal
   deferred-work queue kept every completed item forever; it now retains 45 days
   of history and drops the rest, so the queue can't slowly grow without bound.

--- a/docs/architecture/update-minimal-downtime-design.md
+++ b/docs/architecture/update-minimal-downtime-design.md
@@ -1,0 +1,145 @@
+# update.sh — Minimal-Downtime Reorder (scoped)
+
+**Status:** design (awaiting sign-off) · **Scope:** `scripts/update.sh` only ·
+**Author:** deploy-hardening program (R3) · 2026-07-18
+
+## Why (and why scoped)
+
+`update.sh` unconditionally stops `genesis-server` (line 561) but does not
+`git fetch` until line 797 — so the network fetch happens *inside* the downtime
+window, and a slow/hung fetch prolongs the outage. Two CLAUDE.md regenerations
+(1099–1129) also run while the server is down even though they need neither the
+server nor the network.
+
+The original R3 plan also proposed a pre-merge no-op early-exit (skip the stop
+entirely when there's nothing to pull). **Dropped**, because verification showed
+**nothing runs `update.sh` on a timer or cron** — it runs only when the operator
+or the dashboard triggers it, which is almost always a real delta. Optimizing the
+never-hit no-op path is not worth new surface area in the deploy script's
+rollback region. This scoped version keeps only the wins that apply to *every*
+real update.
+
+## What changes (two moves, ~15 lines relocated, no logic rewritten)
+
+### Move 1 — fetch before the stop
+
+Relocate the `git fetch` (currently 797) to **before** the stop block (561),
+gated by the existing `POST_MERGE` guard:
+
+```bash
+# (new, immediately before the "Pre-update DB snapshot" block ~547)
+if [[ "$POST_MERGE" == "false" ]]; then
+    echo "--- Fetching latest ---"
+    if ! git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main; then
+        echo "  Fetch failed (network?) — server NOT stopped, nothing changed."
+        exit 1
+    fi
+fi
+```
+
+The old fetch line at 797 is removed (its `--- Fetching latest ---` echo moves
+with it). The merge (836) still consumes `$UPDATE_REMOTE/main` — now already
+fetched.
+
+**Why an explicit `if ! … exit 1` and NOT the ERR trap:** the ERR trap arms at
+790, *after* the stop. Before the stop there is deliberately no trap — a failure
+there must exit cleanly leaving the repo/services untouched (the failed-stop
+abort at 571–576 uses exactly this idiom). Routing a pre-stop fetch failure
+through the trap would be **actively harmful**: `_do_rollback` (695)
+*unconditionally* stops the server and then restarts only `WERE_RUNNING`, which
+is empty before the stop — so a transient network blip would **leave the server
+down**. The explicit guard avoids the trap entirely and keeps the server up on a
+fetch failure. `POST_MERGE=true` (CC conflict-resolution re-entry) skips the
+fetch — its code is already merged.
+
+**Win:** the fetch's network time (seconds on a good link, longer on a slow one)
+now happens with the server **up**, excluded from the downtime window. Applies to
+every real update.
+
+### Move 2 — CLAUDE.md refreshes after the restart
+
+Relocate the two CLAUDE.md regenerations — network-identity (1099–1120) and
+container-specs (1122–1129) — from before the restart to **after** the
+health-verify block (after 1207), before `_record_update_history "success"`
+(1220) / `_write_state "done"` (1228).
+
+Both are pure-local (read local interfaces / a local yaml / the last-collected
+profile; no network, no server import — the container-specs block's own comment
+says "safe while the server is down"). Moving them out of the stop→restart window
+trims a small, fixed cost from downtime.
+
+**Race guard (must preserve):** the server's own infra_profile collector skips
+its CLAUDE.md write while `env.update_in_progress()` is true
+(`infra_profile/claude_md.py:80`). During a CLI run that stays true — via
+`update_state.json` (phase `health_check`, pid `$$`) — until `_write_state "done"`
+(1228). Landing Move 2 **after restart but before 1228** means the restarted
+server's collector is still gated, so update.sh's own refresh cannot race it.
+Keep the network-identity inline `python` heredoc at **column 0** (guardrail
+`test_update_host_sync.py:74`).
+
+## What deliberately does NOT move (irreducible offline work)
+
+`git merge` (836, trap-guarded), bootstrap/pip (1009–1015), and migrations
+(1050–1059) stay between the stop and the restart. They dominate the window and
+cannot move without blue-green (a single editable install swaps code at merge
+time). Honest estimate: for a run that merges real changes the wall-clock saving
+is **seconds** (fetch + CLAUDE.md out of the window), not a step-change. The value
+is robustness (a hung fetch no longer extends an outage), not a downtime rewrite.
+
+## Invariants preserved (each verified against the current script)
+
+- **tag → trap → first-mutation** order holds. The trap still arms at 790 (after
+  the stop, before the merge). The pre-stop fetch is NOT under the trap by design.
+- **`_do_rollback` force-stop is why Move 1 uses an explicit guard** — never route
+  a pre-stop failure through the trap.
+- **`_sync_deploy_targets` stays exactly 2 bare calls** (966 no-op path, 1212
+  success) — guardrail `test_update_settings_local_transition.py:137`. Move 2 adds
+  no call.
+- **`WERE_RUNNING` coherence:** populated at 577/584 (in the stop block); the
+  pre-stop fetch adds no reader of it. The restart/rollback consumers
+  (721/945/1140/1188) are untouched.
+- **`POST_MERGE` gating:** the pre-stop fetch is `POST_MERGE==false`-gated so the
+  `--post-merge` CC-conflict re-entry (which must not re-fetch) skips it.
+- **Marker race (Move 2):** refresh lands after restart, before `_write_state
+  "done"` (1228) — server collector stays gated.
+- **Alternate exits unchanged:** up-to-date (940–977) and merge-conflict (838+)
+  keep their own restart/exit semantics; the stop still precedes the merge.
+- `bash -n` clean; the 3 BEGIN/END marker blocks stay intact and isolated.
+
+## New test — phase-order lock
+
+`tests/test_scripts/test_update_phase_order.py` (extraction-style, reads the
+script text; no execution):
+- `index("git … fetch main")` < `index("Stopping services")` < `index("git …
+  merge")`.
+- the pre-stop fetch sits inside a `POST_MERGE == "false"` guard.
+- both CLAUDE.md sentinel-writer calls (`write_sentinel_block … network-identity`
+  and `--claude-md-block`) appear **after** the `Restarting services` marker and
+  **before** `_write_state "done"`.
+- rollback-tag creation < `trap _on_err ERR` < `Stopping services`.
+
+Plus extend any existing `test_update_*` that asserts on the moved regions.
+
+## Verification / E2E (post-merge, on this install)
+
+1. **Deploy run** ships the reorder (old logic governs the shipping run — bash
+   already loaded the old bytes; the reorder governs the *next* run).
+2. **Real-delta run** (next actual update): confirm the server-down window
+   (`systemctl --user show -p ActiveEnterTimestamp genesis-server`) no longer
+   spans the fetch (journal shows fetch before the stop), health gate passes,
+   rollback tag cleaned, CLAUDE.md blocks refreshed post-restart.
+3. **Fetch-failure injection (scratch clone, NOT prod):** point the remote at an
+   unreachable URL; confirm the server is **never stopped** and the script exits 1
+   without rollback.
+4. **Bootstrap-failure injection (scratch clone):** confirm `_do_rollback` still
+   restores + restarts (unchanged path).
+
+## Confidence: 88%
+
+Higher than the full-R3 85% because the riskiest edit (no-op early-exit above the
+stop) is dropped. Residual 12%: the exact placement of Move 2 vs the marker clear
+(mitigated — traced to line 1228) and that the pre-stop fetch must never reach the
+trap (mitigated — explicit guard + order-lock test + fetch-failure E2E).
+**DISPROVEN if:** a fetch failure leaves the server stopped, OR the restarted
+server's collector races update.sh's CLAUDE.md write, OR `_sync_deploy_targets`
+call count changes.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -389,7 +389,7 @@ _sync_deploy_targets() {
 # EXCEPTION — known-ephemeral tracked files (EPHEMERAL_DIRTY_RE): tracked files
 # that are routinely rewritten in place and are safe to ignore. They regenerate
 # themselves, and local edits to them are discarded right before the merge
-# (see "--- Fetching latest ---" below) so an incoming change to one of them
+# (cleared just before the merge below) so an incoming change to one of them
 # never aborts the merge with "local changes would be overwritten". Today:
 #   - top-level `AGENTS.md` (GitNexus rewrites its auto-stat block)
 #   - `config/procedure_triggers.yaml` (the L1 trigger cache rewrites it in
@@ -463,6 +463,26 @@ else
     echo "  Rollback tag: $ROLLBACK_TAG"
 fi
 echo ""
+
+# ── Fetch latest BEFORE stopping services (and before the deploy marker) ──
+# Hoisted above the stop so a slow/hung fetch does NOT extend the downtime
+# window, AND above `_write_state "fetching"` so env.update_in_progress() is not
+# yet true while the (network, potentially-hanging) fetch runs — the watchdog's
+# crash-restart guard stays fully active for the server during the fetch.
+# Guarded EXPLICITLY (not via the ERR trap, which arms only after the stop): the
+# trap's _do_rollback force-stops the server and restarts only WERE_RUNNING
+# (empty here) — a fetch failure routed through it would leave the server DOWN.
+# On failure, delete this run's freshly-created rollback tag and exit clean with
+# the server untouched. POST_MERGE re-entry skips it (code already merged).
+if [[ "$POST_MERGE" == "false" ]]; then
+    echo "--- Fetching latest ---"
+    if ! git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main; then
+        echo "  Fetch failed (network?) — server NOT stopped, nothing changed."
+        git -C "$GENESIS_ROOT" tag -d "$ROLLBACK_TAG" 2>/dev/null || true
+        rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid"
+        exit 1
+    fi
+fi
 
 _write_state "fetching"
 
@@ -792,9 +812,9 @@ trap _on_err ERR
 if [[ "$POST_MERGE" == "false" ]]; then
 _write_state "merging"
 
-# ── Fetch + Merge ────────────────────────────────────────
-echo "--- Fetching latest ---"
-git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main
+# ── Merge ────────────────────────────────────────────────
+# (git fetch was hoisted ABOVE the stop — see "Fetch latest BEFORE stopping
+# services" — so the network round-trip is no longer inside the downtime window.)
 
 # Clear local edits to known-ephemeral tracked files (EPHEMERAL_DIRTY_RE) before
 # merging. They are rewritten in place at runtime and regenerate themselves
@@ -1096,37 +1116,6 @@ section is safe to hand-edit; install scripts preserve it.
 reminders here.)
 UCLSEED
 fi
-echo "--- Refreshing Network Identity in ~/.claude/CLAUDE.md ---"
-# Block format + detection helpers are shared with host-setup.sh via the
-# lib — the two writers previously drifted (Tailscale line lost, container
-# IP mis-detected as the tailscale0 address).
-# shellcheck source=lib/claude_md_blocks.sh
-. "$SCRIPT_DIR/lib/claude_md_blocks.sh"
-_c_ip=$(detect_container_lan_ip)
-_c_ipv6=$(detect_container_lan_ipv6)
-_ts_ip=$(detect_tailscale_ip)
-_host_ip=$("$VENV_DIR/bin/python" -c "
-import yaml, pathlib
-p = pathlib.Path.home() / '.genesis' / 'guardian_remote.yaml'
-if p.exists():
-    cfg = yaml.safe_load(p.read_text())
-    print(cfg.get('host_ip', ''))
-" 2>/dev/null || true)
-[ -z "$_host_ip" ] && _host_ip=$(ip route | grep default | awk '{print $3}' || true)
-
-build_network_identity_block "$_c_ip" "$_c_ipv6" "$_host_ip" "" "$_ts_ip" \
-    | write_sentinel_block "$_user_claude" "network-identity"
-echo "  Network identity updated in ~/.claude/CLAUDE.md"
-echo ""
-
-# Refresh the container-specs block from the LAST collected infrastructure
-# profile (content owner: genesis.infra_profile.claude_md — no collection, no
-# runtime import; safe while the server is down). Skips gracefully pre-first-
-# collection or on older checkouts without the module.
-"$VENV_DIR/bin/python" -m genesis.infra_profile --claude-md-block 2>/dev/null \
-    && echo "  Container specs refreshed in ~/.claude/CLAUDE.md" \
-    || echo "  Container specs refresh skipped (no profile yet)"
-echo ""
 
 _write_state "health_check"
 
@@ -1210,6 +1199,55 @@ fi
 trap - ERR
 
 _sync_deploy_targets
+
+# ── Refresh CLAUDE.md blocks (hoisted OUT of the downtime window) ──────────
+# Pure-local regeneration (local ifaces / a local yaml / the last-collected
+# profile; no network, no server import). Relocated to AFTER the restart so it
+# no longer runs in the stop→restart window, but BEFORE _write_state "done"
+# (below) so the restarted server's infra_profile collector is still
+# update_in_progress-gated (infra_profile/claude_md.py) and cannot race this
+# write. COSMETIC + post-success + past `trap - ERR`: a hiccup here must NEVER
+# abort an already-healthy, already-restarted deploy — that would strand
+# update_state.json at "health_check" (deferring the watchdog restart guard for
+# hours) and skip the success record. errexit is live here and the multi-step
+# network-identity refresh (lib source + sed-based write) is not otherwise
+# guarded, so bracket the whole section with `set +e`.
+set +e
+echo "--- Refreshing Network Identity in ~/.claude/CLAUDE.md ---"
+# Block format + detection helpers are shared with host-setup.sh via the
+# lib — the two writers previously drifted (Tailscale line lost, container
+# IP mis-detected as the tailscale0 address).
+# shellcheck source=lib/claude_md_blocks.sh
+. "$SCRIPT_DIR/lib/claude_md_blocks.sh"
+_c_ip=$(detect_container_lan_ip)
+_c_ipv6=$(detect_container_lan_ipv6)
+_ts_ip=$(detect_tailscale_ip)
+_host_ip=$("$VENV_DIR/bin/python" -c "
+import yaml, pathlib
+p = pathlib.Path.home() / '.genesis' / 'guardian_remote.yaml'
+if p.exists():
+    cfg = yaml.safe_load(p.read_text())
+    print(cfg.get('host_ip', ''))
+" 2>/dev/null || true)
+[ -z "$_host_ip" ] && _host_ip=$(ip route | grep default | awk '{print $3}' || true)
+
+if build_network_identity_block "$_c_ip" "$_c_ipv6" "$_host_ip" "" "$_ts_ip" \
+    | write_sentinel_block "$_user_claude" "network-identity"; then
+    echo "  Network identity updated in ~/.claude/CLAUDE.md"
+else
+    echo "  WARNING: network-identity refresh failed (non-fatal)"
+fi
+echo ""
+
+# Refresh the container-specs block from the LAST collected infrastructure
+# profile (content owner: genesis.infra_profile.claude_md — no collection, no
+# runtime import; safe while the server is down). Skips gracefully pre-first-
+# collection or on older checkouts without the module.
+"$VENV_DIR/bin/python" -m genesis.infra_profile --claude-md-block 2>/dev/null \
+    && echo "  Container specs refreshed in ~/.claude/CLAUDE.md" \
+    || echo "  Container specs refresh skipped (no profile yet)"
+echo ""
+set -e
 
 # ── Clear update failure file on success ──────────────────
 if [ -f "$HOME/.genesis/last_update_failure.json" ]; then

--- a/tests/test_scripts/test_update_phase_order.py
+++ b/tests/test_scripts/test_update_phase_order.py
@@ -1,0 +1,133 @@
+"""Phase-order lock for scripts/update.sh (minimal-downtime reorder, R3).
+
+The reorder hoists ``git fetch`` above the service stop (so a slow/hung fetch no
+longer extends the downtime window) and moves the two CLAUDE.md regenerations
+out of the stop→restart window to after the restart. Both moves are safe ONLY if
+a strict phase order holds, so this test locks that order against the REAL
+script text (extraction-style, no execution) — it is what keeps the reorder from
+silently regressing.
+
+Critical safety invariant asserted here: the pre-stop fetch is guarded
+EXPLICITLY and runs BEFORE the ERR trap arms. Routing a pre-stop fetch failure
+through the trap would be harmful — ``_do_rollback`` force-stops the server and
+restarts only ``WERE_RUNNING`` (empty before the stop), leaving the server down
+on a transient network blip. The fetch-failure path must clean up and ``exit 1``
+without ``_do_rollback``.
+
+Markers are anchored on actual command lines (not echo strings or comment
+prose), so a comment that merely mentions a phase name cannot fool the ordering.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+
+# Command-line markers (unique real statements, not comment prose).
+FETCH = 'git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main'
+STOP = "--- Stopping services for update ---"
+TRAP = "\ntrap _on_err ERR"
+MERGE = 'git -C "$GENESIS_ROOT" merge "$UPDATE_REMOTE/main" --no-edit'
+RESTART = "--- Restarting services ---"
+REFRESH = "--- Refreshing Network Identity in ~/.claude/CLAUDE.md ---"
+DONE = '\n_write_state "done"'
+ROLLBACK_TAG = 'ROLLBACK_TAG="pre-update-'
+# The "active deploy marker": _write_state "fetching" flips
+# env.update_in_progress() true (defers the watchdog crash-restart guard).
+FETCHING_MARKER = '\n_write_state "fetching"'
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return UPDATE_SH.read_text()
+
+
+def _idx(text: str, marker: str) -> int:
+    i = text.find(marker)
+    assert i != -1, f"marker not found in update.sh: {marker!r}"
+    return i
+
+
+def test_fetch_appears_exactly_once(text):
+    """The old in-window fetch must be gone — no second fetch inside the stop
+    window, or downtime is not actually shortened."""
+    assert text.count(FETCH) == 1, "expected exactly one git fetch of the remote"
+    assert text.count('echo "--- Fetching latest ---"') == 1
+
+
+def test_fetch_before_stop_before_trap_before_merge(text):
+    """fetch (pre-stop, pre-trap) < stop < trap < merge."""
+    f, s, t, m = (_idx(text, x) for x in (FETCH, STOP, TRAP, MERGE))
+    assert f < s, "fetch must be hoisted ABOVE the service stop"
+    assert s < t, "the ERR trap must arm after the stop (unchanged)"
+    assert t < m, "the merge must run under the ERR trap"
+    assert f < t, (
+        "SAFETY: the pre-stop fetch must run BEFORE the ERR trap arms — a fetch "
+        "failure must not reach _do_rollback (which would leave the server down)"
+    )
+
+
+def test_rollback_tag_created_before_trap(text):
+    assert _idx(text, ROLLBACK_TAG) < _idx(text, TRAP)
+
+
+def test_fetch_before_active_deploy_marker(text):
+    """The fetch must run BEFORE `_write_state "fetching"` flips
+    env.update_in_progress() true — otherwise a slow/hung fetch runs with the
+    server up but the watchdog's crash-restart guard deferred (Codex P2)."""
+    assert _idx(text, FETCH) < _idx(text, FETCHING_MARKER), (
+        'pre-stop fetch must precede the _write_state "fetching" deploy marker'
+    )
+    # ...and the rollback tag must exist before the fetch, so the fetch-failure
+    # cleanup (git tag -d) references a real tag under set -u.
+    assert _idx(text, ROLLBACK_TAG) < _idx(text, FETCH)
+
+
+def test_pre_stop_fetch_is_post_merge_gated(text):
+    """The hoisted fetch must be inside an ``if [[ "$POST_MERGE" == "false" ]]``
+    so the --post-merge CC-conflict re-entry (code already merged) skips it."""
+    f = _idx(text, FETCH)
+    preamble = text[max(0, f - 300) : f]
+    assert '[[ "$POST_MERGE" == "false" ]]' in preamble, "pre-stop fetch must be POST_MERGE-gated"
+
+
+def test_fetch_failure_cleans_up_and_exits_without_rollback(text):
+    """On fetch failure: delete the rollback tag + state file, exit 1, and NEVER
+    call _do_rollback (server must stay up)."""
+    f = _idx(text, FETCH)
+    # The fetch block ends at the first standalone `fi` after the fetch.
+    block = text[f : text.index("\nfi\n", f)]
+    assert 'tag -d "$ROLLBACK_TAG"' in block, "fetch-failure must delete the rollback tag"
+    assert 'rm -f "$STATE_FILE"' in block, "fetch-failure must clear the state file"
+    assert "exit 1" in block, "fetch-failure must exit 1"
+    # Check CODE lines only — a comment may legitimately mention _do_rollback.
+    code = "\n".join(ln for ln in block.splitlines() if not ln.lstrip().startswith("#"))
+    assert "_do_rollback" not in code, "SAFETY: pre-stop fetch failure must NOT invoke _do_rollback"
+
+
+def test_claude_md_refresh_after_restart_before_done(text):
+    """CLAUDE.md regeneration moved out of the downtime window: after the
+    restart, before the 'done' state (so the restarted server's collector is
+    still update_in_progress-gated and cannot race the write)."""
+    assert text.count(REFRESH) == 1, "network-identity refresh must appear once"
+    r, restart, d = _idx(text, REFRESH), _idx(text, RESTART), _idx(text, DONE)
+    assert restart < r, "CLAUDE.md refresh must run AFTER the restart"
+    assert r < d, "CLAUDE.md refresh must run BEFORE _write_state 'done'"
+
+
+def test_sync_deploy_targets_still_two_bare_calls(text):
+    """Guardrail parity with test_update_settings_local_transition.py: the
+    reorder must not change the bare-call count."""
+    bare = [ln for ln in text.splitlines() if ln.strip() == "_sync_deploy_targets"]
+    assert len(bare) == 2, f"expected 2 bare _sync_deploy_targets calls, got {len(bare)}"
+
+
+def test_update_sh_syntax_ok():
+    """bash -n must pass after the reorder."""
+    r = subprocess.run(["bash", "-n", str(UPDATE_SH)], capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, r.stderr


### PR DESCRIPTION
## What

Scoped "minimal-downtime" reorder of `scripts/update.sh` (R3 of the deploy-hardening program). Design doc: `docs/architecture/update-minimal-downtime-design.md`. No merge / bootstrap / migration / rollback / health logic changed — only phase ordering.

1. **Fetch before the stop.** `git fetch` is hoisted above the service-stop block so a slow/hung fetch no longer extends the downtime window. It is `POST_MERGE`-gated and guarded **explicitly** (`if ! git fetch; then … exit 1`), **not** via the ERR trap — because `_do_rollback` unconditionally stops the server then restarts only `WERE_RUNNING` (empty before the stop), so a fetch failure routed through the trap would leave the server **down**. On failure it deletes the freshly-created rollback tag + state file and exits, leaving the server running and untouched.
2. **CLAUDE.md refreshes after the restart** instead of during the offline window — placed before `_write_state "done"` so the restarted server's infra_profile collector is still `update_in_progress`-gated and can't race the write. The whole cosmetic block is bracketed with `set +e` so a post-success refresh hiccup can never strand the deploy at `health_check`.

## Why

`update.sh` runs only on operator/dashboard trigger (no cron/timer), so the value is **robustness** — a network stall no longer prolongs an outage — more than a large downtime cut. The riskier no-op-early-exit from the original R3 design was intentionally dropped: that path is never hit without an auto-update timer, and it added surface area to the deploy script's rollback region.

## Tests

New `tests/test_scripts/test_update_phase_order.py` locks the phase order (fetch < stop < trap < merge; CLAUDE.md refresh after restart, before the `done` marker) and the fetch-failure-must-not-reach-`_do_rollback` safety invariant. All `test_scripts/` pass (724).

## Review

Pre-reviewed by a code-reviewer pass (DONE_WITH_CONCERNS). Its one SHOULD-FIX — a post-`trap - ERR` refresh that was not fail-soft under live `set -e` — is fixed here via the `set +e` bracket.

## Deploy

Touches `scripts/update.sh` → **Host-Deploy Gate**. After merge, `scripts/update.sh` is run in-session to self-deploy; the reorder governs the run *after* the one that ships it (bash already loaded the old bytes on the shipping run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)