### PR TITLE
fix(ego): purge extraction-derived garbage user_goals (d0003)

### DIFF
--- a/src/genesis/db/data_migrations/d0003_purge_extraction_goals.py
+++ b/src/genesis/db/data_migrations/d0003_purge_extraction_goals.py
@@ -1,0 +1,63 @@
+"""d0003 — purge extraction-derived garbage rows from ``user_goals``.
+
+The keyword goal-signal matcher (``memory/goal_tracker.py``) was ~95% false
+positive — it fired on any conversation snippet containing a goal-ish keyword,
+including Genesis's OWN status commentary, and wrote them into ``user_goals``
+as ``origin='user'`` directives. It produced ~277 garbage goals before being
+disabled at the ``extraction_job.py`` call site (explicit MCP/foreground goal
+creation replaced it). The residue still poisons downstream readers: e.g.
+``ego/computed_focus.py`` surfaces active user goals into ``ego_focus_summary``,
+so a row titled "Migration 0020 applied to add goal_id column to proposals"
+leaks a migration-log string into the ego's factual focus line.
+
+This purges the whole extraction-derived cohort. It is safe because the ONLY
+writer of ``evidence_source LIKE 'extraction:%'`` goals was that disabled
+matcher — legitimate goals created via ``ego_goal_create`` (MCP) or a
+foreground session carry ``evidence_source=NULL`` and are never matched. Being
+a data migration, it also cleans any peer install still carrying the residue on
+its next pull+restart, with no per-install hand-fix.
+
+migrate()/verify() are SYNC (framework contract, cf. d0001/d0002); the runner
+offloads via ``asyncio.to_thread``. Own connections only — never the runtime's
+async ``rt._db``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from genesis.env import genesis_db_path
+
+requires_operator = False
+
+# The WHERE clause (inlined as a literal in both statements — no interpolation,
+# so no injection surface): origin='user' scopes to the user lane (ego-owned
+# goals are origin='genesis_ego' and were never written by the matcher);
+# evidence_source LIKE 'extraction:%' is the matcher's exclusive signature
+# (goal_tracker.py stamps f"extraction:{session_id}") — explicit-creation paths
+# (ego_goal_create / foreground) leave evidence_source NULL and are never matched.
+
+
+def migrate() -> dict:
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    try:
+        cur = db.execute(
+            "DELETE FROM user_goals WHERE origin = 'user' AND evidence_source LIKE 'extraction:%'"
+        )
+        db.commit()
+        return {"purged": cur.rowcount}
+    finally:
+        db.close()
+
+
+def verify() -> bool:
+    """Complete when no extraction-derived user goal remains."""
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        row = db.execute(
+            "SELECT COUNT(*) FROM user_goals "
+            "WHERE origin = 'user' AND evidence_source LIKE 'extraction:%'"
+        ).fetchone()
+        return row[0] == 0
+    finally:
+        db.close()

--- a/tests/test_db/test_d0003_purge_extraction_goals.py
+++ b/tests/test_db/test_d0003_purge_extraction_goals.py
@@ -1,0 +1,82 @@
+"""d0003 — purge extraction-derived garbage rows from ``user_goals``.
+
+The disabled keyword goal matcher was the ONLY writer of
+``evidence_source LIKE 'extraction:%'`` goals (all stamped ``origin='user'``).
+Explicit creation (``ego_goal_create`` / foreground) leaves
+``evidence_source`` NULL, and ego-owned goals are ``origin='genesis_ego'`` —
+both must survive the purge.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import genesis.db.data_migrations.d0003_purge_extraction_goals as d0003
+
+
+def _seed_db(path) -> None:
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE user_goals (id TEXT PRIMARY KEY, title TEXT, "
+        "origin TEXT, evidence_source TEXT)"
+    )
+    db.executemany(
+        "INSERT INTO user_goals (id, title, origin, evidence_source) VALUES (?, ?, ?, ?)",
+        [
+            # garbage — matcher-written, must be purged
+            ("g1", "Migration 0020 applied to add goal_id column", "user", "extraction:f06ace55"),
+            (
+                "g2",
+                "Genesis has a 60% overall confidence in the plan",
+                "user",
+                "extraction:ed0eb3c8",
+            ),
+            # legit user goal via explicit creation — evidence_source NULL, keep
+            ("keep-user", "Land a data-analyst role", "user", None),
+            # ego-owned goal — origin genesis_ego, keep even if evidence looks
+            # extraction-ish (matcher never wrote this lane)
+            ("keep-ego", "Improve recall precision", "genesis_ego", "extraction:should-not-match"),
+        ],
+    )
+    db.commit()
+    db.close()
+
+
+def test_purges_only_extraction_user_goals(tmp_path, monkeypatch):
+    db_path = tmp_path / "genesis.db"
+    _seed_db(db_path)
+    monkeypatch.setattr(d0003, "genesis_db_path", lambda: str(db_path))
+
+    assert d0003.verify() is False
+    assert d0003.migrate() == {"purged": 2}
+    assert d0003.verify() is True
+
+    db = sqlite3.connect(db_path)
+    remaining = {r[0] for r in db.execute("SELECT id FROM user_goals").fetchall()}
+    db.close()
+    # Both garbage rows gone; the legit user goal and the ego goal survive.
+    assert remaining == {"keep-user", "keep-ego"}
+
+
+def test_migrate_is_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "genesis.db"
+    _seed_db(db_path)
+    monkeypatch.setattr(d0003, "genesis_db_path", lambda: str(db_path))
+
+    assert d0003.migrate() == {"purged": 2}
+    assert d0003.migrate() == {"purged": 0}
+    assert d0003.verify() is True
+
+
+def test_untouched_db_verifies_clean(tmp_path, monkeypatch):
+    db_path = tmp_path / "genesis.db"
+    db = sqlite3.connect(db_path)
+    db.execute(
+        "CREATE TABLE user_goals (id TEXT PRIMARY KEY, title TEXT, "
+        "origin TEXT, evidence_source TEXT)"
+    )
+    db.commit()
+    db.close()
+    monkeypatch.setattr(d0003, "genesis_db_path", lambda: str(db_path))
+    assert d0003.verify() is True
+    assert d0003.migrate() == {"purged": 0}


### PR DESCRIPTION
## Problem

The keyword goal-signal matcher (`memory/goal_tracker.py`, ~95% false positive) wrote Genesis's own status commentary into `user_goals` as `origin='user'` directives before it was disabled at the `extraction_job.py` call site. Two residual garbage rows remain on this install (e.g. *"Migration 0020 applied to add goal_id column to proposals"*), and `ego/computed_focus.py` surfaces active user goals into `ego_focus_summary` — so the residue leaks a migration-log string into the ego's factual focus line (observed live: `...goals: Genes`).

## Fix

`d0003` data-migration purges the whole extraction-derived cohort: `origin='user' AND evidence_source LIKE 'extraction:%'`. Safe because the disabled matcher was the *only* writer of `extraction:%` evidence; legitimate goals (`ego_goal_create` / foreground) carry `evidence_source=NULL` and are never matched. Idempotent and generic, so it also cleans any peer install carrying the residue on its next pull+restart.

No display-layer change — `computed_focus` is faithful; the root was the bad rows plus the (already-disabled) writer.

## Verification

- Targeted tests (`test_d0003_*`): purges only the extraction/user cohort, keeps NULL-evidence user goals and `genesis_ego` goals, idempotent, clean on empty DB.
- Framework discovery/runner tests green (17 passed).
- **E2E against a WAL-safe copy of the live DB**: 2 rows purged, `verify()` True, re-run purges 0.
- No cross-table orphans: `ego_proposals`/`follow_ups` have 0 refs to the ids; `user_goals.create` writes no Qdrant mirror.

## Deploy

Merge, then redeploy via the standard code path (git pull + server restart); the data-migration runner executes `d0003` post-boot automatically.

Resolves follow-up `41269e5e` (ego_focus_summary junk) and action 2 of `38f7f6e2` (prune bad rows). Actions 1 (re-enable design decision) and 3 (seed real goals, gated on the job-pipeline reconcile) remain open.

Ledger: ec4a7ce6e8ba4d6f9c46891a87ba07c3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
