### PR TITLE
fix(outreach): provision approvals/outcomes never deduped (must always deliver)

### DIFF
--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -42,6 +42,17 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "surplus_opportunity": 24,
     "content_review": 1,  # Short window — distinct content pieces may share topics
     "cli_approval": 0,  # Never dedup — every approval request must be delivered
+    # Provisioning approvals + outcomes — same "must always deliver" class as
+    # cli_approval (#143). A synchronous, user-initiated grow approval that
+    # times out UNANSWERED still leaves a delivered_at row; at the 24h default
+    # that row then REJECTs the retry for 24h (observed 2026-07-18, Phase-C:
+    # a second provision_grow returned instantly denied). No autonomous
+    # re-asker exists on this path — the only callers of grow_via_pipeline are
+    # the synchronous MCP tool + dashboard route; the guardian pool-crit
+    # propose path is host-side and independently ledger-damped — so 0 is safe.
+    # Outcomes are distinct operational status events, like task_* below.
+    "provision_approval": 0,
+    "provision_outcome": 0,
     "ambient_health": 0,  # Never dedup — the monitor's state machine gates re-alerts/recovery
     # Task lifecycle notifications — never dedup. Each is a distinct status
     # event for one task (topic = "Task <id>"), and every _notify call site

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -41,6 +41,24 @@ _CHANNEL_FORMAT = {
 }
 
 
+def _awaited_dup_key(request: OutreachRequest) -> str:
+    """Identity of an awaited approval for the in-flight duplicate guard —
+    the same (signal_type, topic) a duplicate prompt would collide on."""
+    return f"{request.signal_type}\x00{request.topic}"
+
+
+def _suppressed_awaited_result() -> OutreachResult:
+    """Terminal result for a concurrent duplicate awaited approval that was
+    suppressed (never sent) because an identical prompt is still pending."""
+    return OutreachResult(
+        outreach_id=str(uuid.uuid4()),
+        status=OutreachStatus.REJECTED,
+        channel="",
+        message_content="",
+        governance_result=None,
+    )
+
+
 class OutreachPipeline:
     """Main outreach orchestrator."""
 
@@ -83,6 +101,15 @@ class OutreachPipeline:
         # email sends.  MUTED by default; the dashboard "Activity" ledger is the
         # primary visibility path.  Toggled via set_autonomous_send_notify().
         self._autonomous_send_notify: bool = False
+        # In-flight awaited approvals, keyed by (signal_type, topic). While
+        # one is pending, a concurrent duplicate awaited-approval is
+        # SUPPRESSED rather than delivered as a second prompt: two identical
+        # pending prompts in one chat make resolve_scoped_pending ambiguous
+        # (len(eligible) != 1), so a plain APPROVE would resolve NEITHER. The
+        # key is released when the wait ends (answer OR timeout), so a retry
+        # after a timed-out approval is never blocked — the distinction the
+        # stateless governance dedup window cannot make.
+        self._inflight_awaited: set[str] = set()
 
     def set_reply_waiter(self, waiter: ReplyWaiter) -> None:
         """Attach a ReplyWaiter for bidirectional outreach."""
@@ -299,22 +326,35 @@ class OutreachPipeline:
             result = await self.submit(request)
             return result, None
 
-        result = await self.submit(request)
-        if result.status != OutreachStatus.DELIVERED or not result.delivery_id:
-            return result, None
+        key = _awaited_dup_key(request)
+        if key in self._inflight_awaited:
+            logger.warning(
+                "submit_and_wait: concurrent duplicate awaited approval suppressed "
+                "(signal=%s topic=%r already awaiting a reply)",
+                request.signal_type,
+                request.topic,
+            )
+            return _suppressed_awaited_result(), None
+        self._inflight_awaited.add(key)
+        try:
+            result = await self.submit(request)
+            if result.status != OutreachStatus.DELIVERED or not result.delivery_id:
+                return result, None
 
-        # Register BEFORE attaching context: set_context drops keys with no
-        # registered waiter, so the old order (context first, registration
-        # deferred to wait_for_reply) left every waiter on this path
-        # contextless — standalone replies were structurally unresolvable
-        # (observed live 2026-07-16; every reply degraded to
-        # implicit_activity).
-        self._reply_waiter.register(result.delivery_id)
-        self._attach_waiter_context(result, result.delivery_id)
-        reply = await self._reply_waiter.wait_for_reply(
-            result.delivery_id, timeout_s=timeout_s,
-        )
-        return result, reply
+            # Register BEFORE attaching context: set_context drops keys with no
+            # registered waiter, so the old order (context first, registration
+            # deferred to wait_for_reply) left every waiter on this path
+            # contextless — standalone replies were structurally unresolvable
+            # (observed live 2026-07-16; every reply degraded to
+            # implicit_activity).
+            self._reply_waiter.register(result.delivery_id)
+            self._attach_waiter_context(result, result.delivery_id)
+            reply = await self._reply_waiter.wait_for_reply(
+                result.delivery_id, timeout_s=timeout_s,
+            )
+            return result, reply
+        finally:
+            self._inflight_awaited.discard(key)
 
     def _attach_waiter_context(self, result: OutreachResult, *keys: str) -> None:
         """Record the delivered chat+topic on waiter *keys* so standalone
@@ -356,39 +396,52 @@ class OutreachPipeline:
             result = await self.submit_raw(text, request, reply_markup=reply_markup)
             return result, None
 
-        # Pre-register waiter if button key provided
-        if waiter_key:
-            self._reply_waiter.register(waiter_key)
-
-        result = await self.submit_raw(text, request, reply_markup=reply_markup)
-        if result.status != OutreachStatus.DELIVERED or not result.delivery_id:
-            if waiter_key:
-                self._reply_waiter.cancel(waiter_key)
-            return result, None
-
-        # Alias so quote-reply (by Telegram message_id) also resolves the waiter
-        actual_key = waiter_key or result.delivery_id
-        if waiter_key and result.delivery_id != waiter_key:
-            self._reply_waiter.add_alias(result.delivery_id, waiter_key)
-        elif not waiter_key:
-            # No pre-registered button key: register the delivery_id NOW,
-            # before attaching context — same ordering trap as
-            # submit_and_wait (set_context silently drops unregistered
-            # keys, leaving the waiter ineligible for standalone replies).
-            self._reply_waiter.register(result.delivery_id)
-        self._attach_waiter_context(result, actual_key, result.delivery_id)
-
-        try:
-            reply = await self._reply_waiter.wait_for_reply(
-                actual_key, timeout_s=timeout_s,
+        key = _awaited_dup_key(request)
+        if key in self._inflight_awaited:
+            logger.warning(
+                "submit_raw_and_wait: concurrent duplicate awaited approval suppressed "
+                "(signal=%s topic=%r already awaiting a reply)",
+                request.signal_type,
+                request.topic,
             )
-        finally:
-            # Clean up both keys to prevent stale entries (resolve only
-            # pops one key; the counterpart would leak)
-            if waiter_key and result.delivery_id != waiter_key:
-                self._reply_waiter.remove(result.delivery_id, waiter_key)
+            return _suppressed_awaited_result(), None
+        self._inflight_awaited.add(key)
+        try:
+            # Pre-register waiter if button key provided
+            if waiter_key:
+                self._reply_waiter.register(waiter_key)
 
-        return result, reply
+            result = await self.submit_raw(text, request, reply_markup=reply_markup)
+            if result.status != OutreachStatus.DELIVERED or not result.delivery_id:
+                if waiter_key:
+                    self._reply_waiter.cancel(waiter_key)
+                return result, None
+
+            # Alias so quote-reply (by Telegram message_id) also resolves the waiter
+            actual_key = waiter_key or result.delivery_id
+            if waiter_key and result.delivery_id != waiter_key:
+                self._reply_waiter.add_alias(result.delivery_id, waiter_key)
+            elif not waiter_key:
+                # No pre-registered button key: register the delivery_id NOW,
+                # before attaching context — same ordering trap as
+                # submit_and_wait (set_context silently drops unregistered
+                # keys, leaving the waiter ineligible for standalone replies).
+                self._reply_waiter.register(result.delivery_id)
+            self._attach_waiter_context(result, actual_key, result.delivery_id)
+
+            try:
+                reply = await self._reply_waiter.wait_for_reply(
+                    actual_key, timeout_s=timeout_s,
+                )
+            finally:
+                # Clean up both keys to prevent stale entries (resolve only
+                # pops one key; the counterpart would leak)
+                if waiter_key and result.delivery_id != waiter_key:
+                    self._reply_waiter.remove(result.delivery_id, waiter_key)
+
+            return result, reply
+        finally:
+            self._inflight_awaited.discard(key)
 
     @staticmethod
     def _load_alert_prompt() -> str | None:

--- a/tests/test_outreach/test_governance.py
+++ b/tests/test_outreach/test_governance.py
@@ -668,3 +668,47 @@ async def test_dedup_window_zero_skips_check(db):
     )
     is_dup = await gate.is_duplicate(req)
     assert is_dup is False
+
+
+@pytest.mark.asyncio
+async def test_provision_approval_never_deduped(db):
+    """provision_approval / provision_outcome must never be deduped (window=0).
+
+    A grow approval that timed out UNANSWERED leaves a delivered_at row; at the
+    old 24h default that row REJECTed the retry for 24h (Phase-C, 2026-07-18).
+    Like cli_approval (#143), every provision approval/outcome must be delivered.
+    """
+    cfg = _cfg_no_quiet()
+    gate = GovernanceGate(cfg, db)
+    now = datetime.now(UTC).isoformat()
+
+    for i, signal in enumerate(("provision_approval", "provision_outcome")):
+        oid = f"prov-{i}"
+        await outreach_crud.create(
+            db,
+            id=oid,
+            signal_type=signal,
+            topic="Grow container root to 40 GiB?",
+            category="blocker",
+            salience_score=1.0,
+            channel="telegram",
+            message_content="reply APPROVE / DENY",
+            created_at=now,
+        )
+        await outreach_crud.record_delivery(db, oid, delivered_at=now)
+
+        # Identical signal_type + topic + category, delivered just now. window=0
+        # means never dedup, so a legitimate retry is not suppressed.
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="Grow container root to 40 GiB?",
+            context="reply APPROVE / DENY",
+            salience_score=1.0,
+            signal_type=signal,
+        )
+        assert await gate.is_duplicate(req) is False
+
+        # And the full blocker gate BYPASSes (delivers), never DENY-suppressed.
+        result = await gate.check(req)
+        assert result.verdict == GovernanceVerdict.BYPASS
+        assert "dedup" not in result.checks_failed

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -798,6 +798,7 @@ async def test_submit_and_wait_standalone_reply_resolves(config):
 
     pipeline = OutreachPipeline.__new__(OutreachPipeline)
     pipeline._reply_waiter = ReplyWaiter()
+    pipeline._inflight_awaited = set()
     pipeline.submit = AsyncMock(return_value=_delivered_result())
 
     task = asyncio.ensure_future(
@@ -818,6 +819,7 @@ async def test_submit_raw_and_wait_no_key_standalone_reply_resolves(config):
 
     pipeline = OutreachPipeline.__new__(OutreachPipeline)
     pipeline._reply_waiter = ReplyWaiter()
+    pipeline._inflight_awaited = set()
     pipeline.submit_raw = AsyncMock(return_value=_delivered_result())
 
     task = asyncio.ensure_future(
@@ -839,6 +841,7 @@ async def test_submit_raw_and_wait_with_key_still_resolves(config):
 
     pipeline = OutreachPipeline.__new__(OutreachPipeline)
     pipeline._reply_waiter = ReplyWaiter()
+    pipeline._inflight_awaited = set()
     pipeline.submit_raw = AsyncMock(return_value=_delivered_result())
 
     task = asyncio.ensure_future(
@@ -852,3 +855,78 @@ async def test_submit_raw_and_wait_with_key_still_resolves(config):
     assert set(keys) == {"uuid-1", "555"}
     result, reply = await task
     assert reply == "go"
+
+
+@pytest.mark.asyncio
+async def test_inflight_awaited_concurrent_duplicate_suppressed(config):
+    """While an awaited approval is pending, a second identical one is
+    SUPPRESSED (never sent) — two identical pending prompts would make a plain
+    APPROVE ambiguous (resolve_scoped_pending len(eligible) != 1)."""
+    from genesis.outreach.reply_waiter import ReplyWaiter
+
+    pipeline = OutreachPipeline.__new__(OutreachPipeline)
+    pipeline._reply_waiter = ReplyWaiter()
+    pipeline._inflight_awaited = set()
+    pipeline.submit_raw = AsyncMock(return_value=_delivered_result())
+
+    req = OutreachRequest(
+        category=OutreachCategory.BLOCKER,
+        topic="Grow container root to 40 GiB?",
+        context="reply APPROVE / DENY",
+        salience_score=1.0,
+        signal_type="provision_approval",
+    )
+
+    # First call starts waiting (registers a waiter, blocks on the reply).
+    task = asyncio.ensure_future(pipeline.submit_raw_and_wait("txt", req, timeout_s=5.0))
+    for _ in range(200):
+        if pipeline._reply_waiter.pending_count:
+            break
+        await asyncio.sleep(0.005)
+    assert pipeline._reply_waiter.pending_count == 1
+
+    # Second IDENTICAL call while the first is pending -> suppressed, no send.
+    pipeline.submit_raw.reset_mock()
+    result2, reply2 = await pipeline.submit_raw_and_wait("txt", req, timeout_s=5.0)
+    assert result2.status == OutreachStatus.REJECTED
+    assert reply2 is None
+    pipeline.submit_raw.assert_not_called()
+    assert pipeline._reply_waiter.pending_count == 1  # still exactly one prompt
+
+    # Resolve the first; its key releases on completion.
+    pipeline._reply_waiter.resolve_scoped_pending("APPROVE", thread_key="-100123:42")
+    _r1, reply1 = await task
+    assert reply1 == "APPROVE"
+    assert pipeline._inflight_awaited == set()
+
+
+@pytest.mark.asyncio
+async def test_inflight_awaited_released_after_timeout_allows_retry(config):
+    """A retry after the previous approval TIMED OUT is NOT suppressed — the
+    in-flight key releases when the wait ends, the distinction that keeps the
+    retry-after-timeout bug fixed (Phase-C 2026-07-18)."""
+    from genesis.outreach.reply_waiter import ReplyWaiter
+
+    pipeline = OutreachPipeline.__new__(OutreachPipeline)
+    pipeline._reply_waiter = ReplyWaiter()
+    pipeline._inflight_awaited = set()
+    pipeline.submit_raw = AsyncMock(return_value=_delivered_result())
+
+    req = OutreachRequest(
+        category=OutreachCategory.BLOCKER,
+        topic="Grow container root to 40 GiB?",
+        context="reply APPROVE / DENY",
+        salience_score=1.0,
+        signal_type="provision_approval",
+    )
+
+    # First call times out (no resolver) -> key released.
+    _r1, reply1 = await pipeline.submit_raw_and_wait("txt", req, timeout_s=0.05)
+    assert reply1 is None
+    assert pipeline._inflight_awaited == set()
+
+    # Retry the SAME request -> NOT suppressed, delivered again.
+    pipeline.submit_raw.reset_mock()
+    _r2, reply2 = await pipeline.submit_raw_and_wait("txt", req, timeout_s=0.05)
+    assert reply2 is None
+    pipeline.submit_raw.assert_called_once()


### PR DESCRIPTION
## Problem

`provision_approval` and `provision_outcome` were **absent** from
`_DEDUP_WINDOWS`, so they fell through to `_DEFAULT_DEDUP_HOURS = 24`. A
synchronous, user-initiated grow approval (`provision_grow` → `submit_raw_and_wait`
→ `submit_raw` → `governance.is_duplicate`) that **times out unanswered** still
writes a `delivered_at` row — and the 24h window then **REJECTs the retry for
24h**. Observed live 2026-07-18 during the Phase-C RAM grow: a second
`provision_grow` returned instantly denied, and `outreach_history` had to be
hand-edited to un-wedge it (data repair, not a fix).

## Fix

Add `provision_approval: 0` and `provision_outcome: 0` to the never-dedup
bucket — exactly what **#143** did for `cli_approval` ("every approval request
must be delivered"). This is the established policy for awaited approvals; these
two were simply never added when provisioning (PR-D) landed a year later.

## Why this is safe (no approval-spam regression)

- **Serena `find_referencing_symbols`** on `grow_via_pipeline` — the only
  container path that hits governance dedup — enumerates exactly **two
  production callers**, both synchronous/user-initiated: the `provision_grow`
  MCP tool and the dashboard `provision_grow_rpc` route. No autonomous re-asker.
- The **autonomous** pool-crit propose path (`guardian/flow.py maybe_propose_pool_grow`)
  is **host-side**, sends via the guardian's own dispatcher (never touches
  container governance), and is independently throttled by its ledger damper
  (`min_repropose_hours=24`). `window=0` on the container gate cannot affect it.
- The stale `delivered_at` row is harmless elsewhere: `_within_rate_limit` and
  `_engagement_throttle` both exempt `blocker`.

## Folded in: in-flight awaited-approval guard (Codex P2)

Codex flagged the residual race: with window=0, the same grow submitted twice
before the first prompt times out delivers BOTH prompts; two identical pending
waiters in one chat make `resolve_scoped_pending` ambiguous
(`len(eligible) != 1`), so a plain APPROVE resolves neither. Fixed **in this
PR** at the layer that knows waiter state: `submit_and_wait` /
`submit_raw_and_wait` track in-flight awaited approvals by
`(signal_type, topic)` — a concurrent duplicate is suppressed (REJECTED,
never sent), and the key releases in a `finally` when the wait ends (answer
OR timeout), so the retry-after-timeout fix is preserved. Both awaited entry
points guarded. 2 new tests pin suppressed-while-pending +
released-after-timeout.

## Test

`test_provision_approval_never_deduped` mirrors `test_dedup_window_zero_skips_check`:
for both signal types, a just-delivered identical row leaves `is_duplicate()`
False AND the full blocker `check()` returns `BYPASS` (delivers), not
DENY-suppressed. All 25 governance tests pass.

## Deploy

Container-only (runs in genesis-server): code-only deploy (reinstall the
editable package + `systemctl --user restart genesis-server`). No host/guardian
path touched.

Ledger: d849794d473d4527a7c72a7169065161

🤖 Generated with [Claude Code](https://claude.com/claude-code)