### PR TITLE
fix(outreach): deliver composed messages verbatim — stop the LLM drafter inverting meaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and a new in-flight guard suppresses a genuinely concurrent duplicate
   prompt (e.g. a double-click) so a plain APPROVE reply always resolves
   unambiguously.
+- **Messages Genesis sends you now arrive exactly as written — no silent
+  rewriting.** Notifications, reminders, and reply-and-wait prompts were
+  quietly run through an LLM "drafter" before delivery, which could reword or
+  even invert their meaning: a test message asking "please reply with a plain
+  message" went out as "…failed, reply to verify," inventing an alarming
+  status that was never there. Delivery paths (`outreach_send`, the
+  reply-and-wait tool, the queued-message drain) now deliver the composed text
+  verbatim, and the internal notification paths that relay a machine fact
+  (health-remediation alerts, "update available/failed," session-failure
+  alerts, ego notifications, surfaced reflection questions) do the same — so a
+  factual alert can never be creatively rewritten into a false claim. Reflection
+  questions also keep their full text and every option intact. Generative
+  content (marketing drafts) still uses the drafter, as intended.
 - **The morning report's numbers are real now.** Report generation previously
   counted truncated display lists (reporting "5 follow-ups" when 268 existed),
   sometimes inverted protective facts into alarms (an active OOM-protection

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1341,6 +1341,7 @@ class DirectSessionRunner:
                     topic="direct_session_fail",
                     context=body,
                     salience_score=0.9,
+                    verbatim=True,  # composed failure detail — never reword
                 )
             )
         except Exception:

--- a/src/genesis/cc/fallback_recovery.py
+++ b/src/genesis/cc/fallback_recovery.py
@@ -43,6 +43,7 @@ async def fire_fallback_alert(*, topic: str, context: str) -> None:
             topic=topic,
             context=context,
             salience_score=0.9,
+            verbatim=True,  # pre-composed recovery alert — never reword
         ))
     except Exception:
         logger.debug("fallback ALERT dispatch failed", exc_info=True)

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -2017,6 +2017,9 @@ class EgoSession:
                     salience_score=salience,
                     signal_type="ego_notification",
                     channel="telegram",
+                    # The ego already composed `content` — deliver it exactly,
+                    # never re-word an ego notification through the drafter.
+                    verbatim=True,
                 )
                 await self._outreach_pipeline.submit(request)
                 submitted += 1

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -524,6 +524,7 @@ class GenesisVersionCollector:
                 context=message,
                 salience_score=0.4,
                 signal_type="genesis_update",
+                verbatim=True,  # pre-composed factual notice — no LLM rewrite
             ))
         except Exception:
             logger.error("Failed to send update notification", exc_info=True)
@@ -612,6 +613,7 @@ class GenesisVersionCollector:
                     ),
                     salience_score=0.9,
                     signal_type="genesis_update_failed",
+                    verbatim=True,  # machine fact (rollback tags) — never reword
                 ))
             except Exception:
                 logger.error("Failed to send update failure alert", exc_info=True)

--- a/src/genesis/learning/skills/pipeline.py
+++ b/src/genesis/learning/skills/pipeline.py
@@ -140,6 +140,7 @@ class SkillEvolutionPipeline:
                 ),
                 salience_score=0.6,
                 signal_type="skill_proposal",
+                verbatim=True,  # composed proposal summary — never reword
             )
             await self._outreach_fn(request)
         except Exception:

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -62,6 +62,10 @@ async def outreach_send(
 ) -> str:
     """Queue a message for delivery. Returns outreach_id.
 
+    The message is delivered AS-IS — Genesis does not rewrite or rephrase it.
+    Compose the exact text you want the recipient to see (this is the tool for
+    reminders and literal notifications).
+
     For email replies, pass thread_id to route to the correct recipient.
     The thread_id maps to a registered email thread whose recipient is
     used for delivery.
@@ -143,6 +147,11 @@ async def outreach_send(
         labeled_surplus=labeled_surplus,
         validated_recipient=validated_recipient,
         thread_id=thread_id,
+        # The caller composed this message; deliver it exactly — never route an
+        # agent-authored message back through the LLM drafter (it once inverted
+        # a send_and_wait test message's meaning). The bridge/queue path mirrors
+        # this via the pending_outreach drain.
+        verbatim=True,
     )
     if urgency == "critical":
         result = await _pipeline.submit_urgent(req)

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -303,15 +303,25 @@ class OutreachPipeline:
         channel = request.channel or self._select_channel(request.category)
         format_target = _CHANNEL_FORMAT.get(channel, FormatTarget.GENERIC)
 
-        draft = await self._drafter.draft(DraftRequest(
-            topic=request.topic,
-            context=request.context,
-            target=format_target,
-            tone="urgent",
-            max_length=None,
-            system_prompt=self._load_alert_prompt(),
-        ))
-        formatted = self._formatter.format(draft.content.text, format_target)
+        if request.verbatim:
+            # Deliver `context` EXACTLY — no LLM in the path — same contract as
+            # submit(). An urgent caller that opts into verbatim is relaying a
+            # machine fact (e.g. process_reaper kill alerts) that must never be
+            # creatively rewritten. Fall back to `topic` so an empty context
+            # never delivers an empty string.
+            formatted = self._formatter.format(
+                request.context or request.topic, format_target,
+            )
+        else:
+            draft = await self._drafter.draft(DraftRequest(
+                topic=request.topic,
+                context=request.context,
+                target=format_target,
+                tone="urgent",
+                max_length=None,
+                system_prompt=self._load_alert_prompt(),
+            ))
+            formatted = self._formatter.format(draft.content.text, format_target)
         return await self._deliver(outreach_id, channel, formatted, request, None)
 
     async def submit_and_wait(

--- a/src/genesis/outreach/rpc.py
+++ b/src/genesis/outreach/rpc.py
@@ -46,6 +46,11 @@ async def send_and_wait_via_pipeline(
         salience_score=1.0,
         signal_type=category,
         channel=channel,
+        # Deliver the caller's message EXACTLY — never run it through the LLM
+        # drafter. A send_and_wait message is a literal prompt (frequently an
+        # exact instruction the reply is matched against); drafting once
+        # inverted one ("please reply with a plain message" -> "...failed").
+        verbatim=True,
     )
     result, reply = await pipeline.submit_and_wait(req, timeout_s=float(timeout_s))
     return {

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -732,6 +732,10 @@ class OutreachScheduler:
                         channel=channel,
                         thread_id=row.get("thread_id"),
                         validated_recipient=row.get("validated_recipient"),
+                        # The queue stores already-final agent messages
+                        # (outreach_send bridge path). Deliver them EXACTLY —
+                        # the LLM drafter must never re-word a stored message.
+                        verbatim=True,
                     )
                     if row.get("urgency") == "high":
                         result = await self._pipeline.submit_urgent(req)

--- a/src/genesis/recon/cc_update_analyzer.py
+++ b/src/genesis/recon/cc_update_analyzer.py
@@ -463,6 +463,7 @@ class CCUpdateAnalyzer:
             context=text,
             salience_score=0.9,
             signal_type="cc_version_update",
+            verbatim=True,  # composed changelog summary — never reword
         )
 
         try:

--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -449,13 +449,23 @@ class OutputRouter:
                         )
                     from genesis.outreach.types import OutreachCategory, OutreachRequest
 
+                    # Deliver the question verbatim — a literal question with
+                    # numbered options must never be LLM-rewritten. Verbatim
+                    # delivers `context`, so the question TEXT (kept in `topic`
+                    # as the short label) is folded into context here or it
+                    # would be dropped from what the user sees.
+                    question_body = (
+                        f"{output.user_question.text}\n\n"
+                        f"{output.user_question.context}{options_text}"
+                    )
                     await self._outreach_pipeline.submit(OutreachRequest(
                         category=OutreachCategory.SURPLUS,
                         topic=output.user_question.text[:100],
-                        context=output.user_question.context + options_text,
+                        context=question_body,
                         salience_score=0.8,
                         signal_type="reflection_question",
                         source_id=obs_id,
+                        verbatim=True,
                     ))
                     summary["question_surfaced"] = True
                     logger.info(

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -271,6 +271,8 @@ async def init(rt: GenesisRuntime) -> None:
                         salience_score=0.9,
                         signal_type="health_alert",
                         source_id=f"remediation:{title}",
+                        # Remediation body is a machine fact — deliver exactly.
+                        verbatim=True,
                     ))
                 outreach_fn = _outreach_submit
             rt._remediation_registry = RemediationRegistry(outreach_fn=outreach_fn)

--- a/tests/test_mcp/test_outreach_mcp.py
+++ b/tests/test_mcp/test_outreach_mcp.py
@@ -136,6 +136,40 @@ async def test_send_and_wait_success():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("urgency,method", [("low", "submit"), ("critical", "submit_urgent")])
+async def test_outreach_send_delivers_verbatim(urgency, method):
+    """outreach_send delivers the caller's message as-is on BOTH the normal and
+    critical routes — the LLM drafter never re-words an agent-composed message.
+    """
+    mock_result = MagicMock()
+    mock_result.outreach_id = "out-9"
+    mock_result.status.value = "delivered"
+    mock_result.channel = "telegram"
+    mock_result.error = None
+
+    mock_pipeline = AsyncMock()
+    getattr(mock_pipeline, method).return_value = mock_result
+
+    old_pipeline = mcp_mod._pipeline
+    try:
+        mcp_mod._pipeline = mock_pipeline
+        tools = await mcp.get_tools()
+        await tools["outreach_send"].fn(
+            message="Remind me to call the bank at 3pm — do NOT paraphrase this.",
+            category="notification",
+            channel="telegram",
+            urgency=urgency,
+        )
+        submit_mock = getattr(mock_pipeline, method)
+        submit_mock.assert_called_once()
+        req = submit_mock.call_args[0][0]
+        assert req.verbatim is True
+        assert req.context == "Remind me to call the bank at 3pm — do NOT paraphrase this."
+    finally:
+        mcp_mod._pipeline = old_pipeline
+
+
+@pytest.mark.asyncio
 async def test_send_and_wait_timeout():
     """Should indicate timeout when reply is None."""
     mock_result = MagicMock()

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -153,6 +153,66 @@ async def test_submit_urgent_bypasses_governance(config, db, mock_drafter, mock_
 
 
 @pytest.mark.asyncio
+async def test_submit_urgent_verbatim_skips_drafter(config, db, mock_drafter, mock_formatter, mock_channel):
+    """A verbatim urgent request delivers `context` exactly — no drafter.
+
+    submit_urgent previously ALWAYS drafted, silently ignoring request.verbatim
+    (making e.g. process_reaper's verbatim=True a no-op and letting the LLM
+    rewrite machine-factual kill alerts). It must honor the flag like submit().
+    """
+    gate = GovernanceGate(config, db)
+    pipeline = OutreachPipeline(
+        governance=gate,
+        drafter=mock_drafter,
+        formatter=mock_formatter,
+        channels={"telegram": mock_channel},
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    req = OutreachRequest(
+        category=OutreachCategory.BLOCKER,
+        topic="reaper killed pid 4242",
+        context="Reaped idle session cc-3 (pid 4242) after 300s idle.",
+        salience_score=1.0,
+        signal_type="process_reaper",
+        verbatim=True,
+    )
+    result = await pipeline.submit_urgent(req)
+    assert result.status == OutreachStatus.DELIVERED
+    # The drafter must NOT run — the exact context is delivered.
+    mock_drafter.draft.assert_not_called()
+    # The formatter receives the verbatim context, not a drafted string.
+    mock_formatter.format.assert_called_once()
+    assert mock_formatter.format.call_args[0][0] == req.context
+
+
+@pytest.mark.asyncio
+async def test_submit_urgent_non_verbatim_still_drafts(config, db, mock_drafter, mock_formatter, mock_channel):
+    """Regression: without verbatim, submit_urgent still routes through the drafter."""
+    gate = GovernanceGate(config, db)
+    pipeline = OutreachPipeline(
+        governance=gate,
+        drafter=mock_drafter,
+        formatter=mock_formatter,
+        channels={"telegram": mock_channel},
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    req = OutreachRequest(
+        category=OutreachCategory.BLOCKER,
+        topic="All APIs down",
+        context="Critical failure",
+        salience_score=1.0,
+        signal_type="critical_failure",
+    )
+    result = await pipeline.submit_urgent(req)
+    assert result.status == OutreachStatus.DELIVERED
+    mock_drafter.draft.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_submit_records_in_db(config, db, mock_drafter, mock_formatter, mock_channel):
     from genesis.db.crud import outreach as outreach_crud
 

--- a/tests/test_outreach/test_rpc.py
+++ b/tests/test_outreach/test_rpc.py
@@ -31,6 +31,31 @@ async def test_send_and_wait_via_pipeline_delivers():
                    "reply": "approved", "timed_out": False}
     # timeout threaded through as a float
     assert pipe.submit_and_wait.call_args.kwargs["timeout_s"] == 30.0
+    # The caller's message is delivered VERBATIM — never LLM-rewritten. A
+    # send_and_wait message is a literal prompt (often an exact instruction to
+    # reply to); the drafter once inverted one ("please reply..." -> "...failed").
+    assert pipe.submit_and_wait.call_args.args[0].verbatim is True
+    assert pipe.submit_and_wait.call_args.args[0].context == "approve?"
+
+
+@pytest.mark.asyncio
+async def test_send_and_wait_via_pipeline_full_message_survives_topic_truncation():
+    """The 100-char topic cap must not truncate the delivered message: verbatim
+    delivers `context` (full message), while topic stays the short label."""
+    res = MagicMock()
+    res.outreach_id = "o-2"
+    res.status.value = "delivered"
+    pipe = AsyncMock()
+    pipe.submit_and_wait = AsyncMock(return_value=(res, None))
+    long_msg = "A" * 250
+
+    await send_and_wait_via_pipeline(
+        pipe, message=long_msg, category="blocker", channel="telegram", timeout_s=5,
+    )
+    req = pipe.submit_and_wait.call_args.args[0]
+    assert req.verbatim is True
+    assert req.context == long_msg  # full message preserved for verbatim delivery
+    assert len(req.topic) <= 100  # label only
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -258,6 +258,31 @@ async def test_drain_reconstructs_request_with_thread_and_recipient(config, db):
     req = pipeline.submit.call_args[0][0]
     assert req.thread_id == "t1"
     assert req.validated_recipient == "real@prospect.com"
+    # The queue holds already-final agent messages (outreach_send bridge path);
+    # they must be delivered VERBATIM, never run back through the LLM drafter.
+    assert req.verbatim is True
+
+
+@pytest.mark.asyncio
+async def test_drain_delivers_verbatim_on_urgent_path(config, db):
+    """High-urgency queued rows go through submit_urgent — which must ALSO
+    receive verbatim=True so the drafter never rewrites the stored message."""
+    from genesis.db.crud import pending_outreach
+
+    await pending_outreach.enqueue(
+        db,
+        message="Deploy #1234 rolled back to 5ad2bff6.",
+        category="notification",
+        channel="telegram",
+        urgency="high",
+    )
+    pipeline = _drain_pipeline(OutreachStatus.DELIVERED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    pipeline.submit_urgent.assert_called_once()
+    assert pipeline.submit_urgent.call_args[0][0].verbatim is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_reflection/test_question_routing.py
+++ b/tests/test_reflection/test_question_routing.py
@@ -118,6 +118,36 @@ class TestRouteUserQuestion:
         assert "Options:" in request.context
 
     @pytest.mark.asyncio
+    async def test_route_question_verbatim_preserves_question_text(self):
+        """BLOCKER-1: the question is surfaced verbatim (no LLM rewrite of a
+        literal question + numbered options). Because verbatim delivers
+        `context`, the question TEXT (previously only in `topic`) must be folded
+        into context — else the user sees background + options with no question.
+        """
+        mock_gate = AsyncMock()
+        mock_gate.can_ask.return_value = True
+        mock_gate.record_question.return_value = "obs-9"
+        mock_pipeline = AsyncMock()
+        router = OutputRouter(question_gate=mock_gate, outreach_pipeline=mock_pipeline)
+        output = DeepReflectionOutput(
+            observations=["obs1"],
+            confidence=0.8,
+            user_question=UserQuestion(
+                text="Should we refactor the router?",
+                context="Complexity is growing",
+                options=["Yes, full refactor", "No, defer"],
+            ),
+        )
+        await router.route(output, AsyncMock())
+
+        request = mock_pipeline.submit.call_args[0][0]
+        assert request.verbatim is True
+        # The exact question, its background, and every option must be present.
+        assert "Should we refactor the router?" in request.context
+        assert "Complexity is growing" in request.context
+        assert "Yes, full refactor" in request.context
+
+    @pytest.mark.asyncio
     async def test_route_skips_when_pending(self):
         """Pending question → submit not called."""
         mock_gate = AsyncMock()


### PR DESCRIPTION
## Problem

Genesis's outreach pipeline silently ran **pre-composed messages** through the LLM `ContentDrafter` before delivery, which could reword or invert their meaning. Live incident: a `send_and_wait` test message *"please reply with a PLAIN standalone message"* was delivered as *"E2E test PR #1090 **failed**, reply to verify"* — a hallucinated "failed" (semantic inversion) with the operative instruction dropped.

**Root cause:** `OutreachRequest.verbatim` defaults `False` and only `submit()` honored it. Every "send this message" path drafted by default. The agent MCP path also runs with `_pipeline=None`, bridging through the `pending_outreach` queue / server RPC — so the flag had to travel the transport, not just request construction.

## Fix — verbatim-by-default on delivery paths (generative content unaffected)

Enumerated the whole class by dispatch method (`submit`/`submit_urgent` = at-risk; `submit_raw*` already verbatim), not just the reported case.

- **`submit_urgent`** now honors `request.verbatim` (was a silent no-op — un-breaks `process_reaper`'s existing flag; urgent alerts can no longer be reworded).
- **Delivery chokepoints** set verbatim: `outreach_send` (in-process), the **`pending_outreach` drain** (the dominant bridge/queue path), `send_and_wait_via_pipeline` (covers in-process + dashboard route).
- **Internal machine-fact notifications** set verbatim: ego notifications, "Genesis update available/failed", health-remediation alerts, session-failure alerts, CC-update summaries, skill-proposal notices.
- **`output_router` user-question:** folds the question text (previously `topic`-only) into `context` before verbatim delivery — otherwise the question itself would be dropped — and keeps every option intact.
- **Excluded:** morning report (owned by #1124, which added its own verbatim delivery); surplus-insight path (deregistered dead code).

The `draft` opt-out was intentionally **not** added: a "send this message" tool should deliver faithfully, and the caller is already an LLM that can phrase its own text (LLM-first).

## Tests (TDD)

New/extended coverage: `submit_urgent` verbatim + non-verbatim regression; `send_and_wait` verbatim + full-message-survives-topic-truncation; queue drain verbatim on both normal & urgent routes; `outreach_send` verbatim on both routes; and the BLOCKER — reflection question preserves its full text + options under verbatim. 117 targeted tests pass.

Design pre-reviewed by genesis-architect (verdict REVISE → both BLOCKER-class gaps fixed: question-text loss, and wiring the flag through the queue/RPC transports).

Follow-up: c72c8e58

🤖 Generated with [Claude Code](https://claude.com/claude-code)