### PR TITLE
feat(memory): reranker unification — actually rerank on the MCP recall tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   factual alert can never be creatively rewritten into a false claim. Reflection
   questions also keep their full text and every option intact. Generative
   content (marketing drafts) still uses the drafter, as intended.
+- **Memory search actually reranks now.** `memory_recall` and
+  `knowledge_recall` advertised Voyage cross-encoder reranking and defaulted it
+  on, but the recall tools were built without a reranker, so it silently never
+  ran — searches returned raw fusion order instead of the promised
+  relevance-reranked results. The reranker is now wired into the recall tools
+  (no change without an `API_KEY_VOYAGE`). It can be turned off live via the
+  `memory_recall` setting `reranker.mode: off` or `GENESIS_MEMORY_RERANK_OFF=1`
+  if you want to trade a little recall quality for lower latency/cost.
 - **The morning report's numbers are real now.** Report generation previously
   counted truncated display lists (reporting "5 follow-ups" when 268 existed),
   sometimes inverted protective facts into alarms (an active OOM-protection

--- a/config/memory_recall.yaml
+++ b/config/memory_recall.yaml
@@ -28,3 +28,14 @@ graph_expansion:
 # ("off" quoted: unquoted it parses as YAML-1.1 boolean False.)
 entity_lane:
   mode: "off"
+
+# Voyage cross-encoder reranking on the MCP recall tools (memory_recall,
+# knowledge_recall, reference_lookup). off | live — DEFAULT live: these tools
+# default rerank=True and their retriever now carries the Voyage reranker.
+# Kill switch for a Voyage cost / latency / outage concern: set mode "off"
+# (read live, no restart) or export GENESIS_MEMORY_RERANK_OFF=1. Reranking
+# still no-ops automatically when API_KEY_VOYAGE is unset. This gates ONLY the
+# MCP tool path — not the internal runtime context stack (long-standing) nor
+# the LongMemEval harness (hermetic). ("off" quoted per the YAML-1.1 note.)
+reranker:
+  mode: live

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -36,7 +36,7 @@ side.
 ```yaml subsystem-map
 entry: memory
 modules: [memory, qdrant]
-verified: 57fa1f18 2026-07-17
+verified: 9decfd6f 2026-07-18
 ```
 
 **Retrieval is TIERED — the hottest auto-fired paths carry the thinnest
@@ -56,9 +56,16 @@ Easy-to-forget mechanisms:
   frozen snapshot suppress this via `GENESIS_MEMORY_WRITEBACKS_OFF`
   (`env.memory_writebacks_off()`); any NEW write inside a read path must
   honor the same seam.
-- **VoyageReranker** (`memory/reranker.py`, rerank-2.5) exists and is
-  API_KEY_VOYAGE-gated; the `rerank=` param is off by default at the retriever
-  and applied by callers.
+- **VoyageReranker** (`memory/reranker.py`, rerank-2.5) is API_KEY_VOYAGE-gated
+  and wired into BOTH retriever stacks: the runtime context stack (long-standing)
+  and — since the MCP `init()` had passed no reranker, so it silently never ran —
+  the MCP recall tools. `recall()` defaults `rerank=True`; the recall tools
+  (`memory_recall` / `knowledge_recall` / `reference_lookup`) rerank subject to
+  `reranker.mode` in `config/memory_recall.yaml` (off|live, live default) plus the
+  `GENESIS_MEMORY_RERANK_OFF` kill, read live via
+  `graph_expansion.reranker_enabled()`. The gate is applied at the MCP tool
+  boundary only, so the internal runtime stack and the hermetic LongMemEval
+  harness (both pass explicit `rerank` kwargs) are unaffected.
 - **`drift_recall`** (`memory/drift.py`) is the degraded-mode fallback; its
   FTS drilldown searches every collection in `source_collections`,
   rank-merged across collections.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -64,8 +64,10 @@ Easy-to-forget mechanisms:
   `reranker.mode` in `config/memory_recall.yaml` (off|live, live default) plus the
   `GENESIS_MEMORY_RERANK_OFF` kill, read live via
   `graph_expansion.reranker_enabled()`. The gate is applied at the MCP tool
-  boundary only, so the internal runtime stack and the hermetic LongMemEval
-  harness (both pass explicit `rerank` kwargs) are unaffected.
+  boundary — the three recall tools plus the CRAG corrective-augmentation path
+  (`memory/corrective.py`), which runs inside those tools — so the internal
+  runtime stack and the hermetic LongMemEval harness (both pass explicit
+  `rerank` kwargs) are unaffected.
 - **`drift_recall`** (`memory/drift.py`) is the degraded-mode fallback; its
   FTS drilldown searches every collection in `source_collections`,
   rank-merged across collections.

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -148,6 +148,7 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
         # foreign_keys=False preserves the prior raw-connection behavior.
         db = await get_db(_DEFAULT_DB, foreign_keys=False)
         try:
+
             # Bootstrap standalone router for LLM-dependent tools
             try:
                 from genesis.routing.standalone import create_standalone_router
@@ -205,7 +206,6 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
             yield
         finally:
             from genesis.mcp.health.browser import async_cleanup as _browser_cleanup
-
             await _browser_cleanup()
             await db.close()
 
@@ -236,6 +236,7 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
         db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
+
             # Bootstrap standalone router for LLM-dependent tools
             try:
                 from genesis.routing.standalone import create_standalone_router
@@ -256,13 +257,8 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
             # memory_recall / knowledge_recall rerank here exactly as in the
             # full runtime. Degrades to a no-op without API_KEY_VOYAGE.
             reranker = VoyageReranker()
-            init(
-                db=db,
-                qdrant_client=qdrant,
-                embedding_provider=embedding,
-                activity_tracker=tracker,
-                reranker=reranker,
-            )
+            init(db=db, qdrant_client=qdrant, embedding_provider=embedding,
+                 activity_tracker=tracker, reranker=reranker)
             clear_mcp_crash("memory")
             yield
         finally:
@@ -290,6 +286,7 @@ def _bootstrap_recon(transport_kwargs: dict) -> None:
         db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
+
             # Bootstrap standalone router for LLM-dependent tools
             try:
                 from genesis.routing.standalone import create_standalone_router
@@ -350,10 +347,7 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
             tracker = ProviderActivityTracker()
             tracker.set_db(db)
             init_outreach_mcp(
-                pipeline=None,
-                engagement=None,
-                config=None,
-                db=db,
+                pipeline=None, engagement=None, config=None, db=db,
                 activity_tracker=tracker,
             )
             clear_mcp_crash("outreach")
@@ -468,16 +462,14 @@ def _bearer_auth_middleware(expected_token: str):
 
             if scope["type"] == "http":
                 body = _json.dumps({"error": "Unauthorized"}).encode()
-                await send(
-                    {
-                        "type": "http.response.start",
-                        "status": 401,
-                        "headers": [
-                            [b"content-type", b"application/json"],
-                            [b"content-length", str(len(body)).encode()],
-                        ],
-                    }
-                )
+                await send({
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [
+                        [b"content-type", b"application/json"],
+                        [b"content-length", str(len(body)).encode()],
+                    ],
+                })
                 await send({"type": "http.response.body", "body": body})
                 return
 
@@ -503,24 +495,16 @@ def main(argv: list[str] | None = None) -> None:
     # Without the API keys, EmbeddingProvider gets zero backends and silently degrades.
     _MCP_VARS = {
         # Infrastructure
-        "OLLAMA_URL",
-        "QDRANT_URL",
-        "GENESIS_DB_PATH",
-        "GENESIS_CC_PROJECT_ID",
+        "OLLAMA_URL", "QDRANT_URL", "GENESIS_DB_PATH", "GENESIS_CC_PROJECT_ID",
         # Browser (CDP remote backend)
         "GENESIS_CDP_URL",
         # Embedding providers (required for memory MCP)
-        "API_KEY_DEEPINFRA",
-        "API_KEY_QWEN",
+        "API_KEY_DEEPINFRA", "API_KEY_QWEN",
         # LLM providers (used by recon/outreach MCP tools)
-        "GOOGLE_API_KEY",
-        "API_KEY_GROQ",
-        "API_KEY_MISTRAL",
-        "API_KEY_OPENROUTER",
+        "GOOGLE_API_KEY", "API_KEY_GROQ", "API_KEY_MISTRAL", "API_KEY_OPENROUTER",
         "API_KEY_DEEPSEEK",
         # Ollama config
-        "GENESIS_ENABLE_OLLAMA",
-        "OLLAMA_EMBEDDING_MODEL",
+        "GENESIS_ENABLE_OLLAMA", "OLLAMA_EMBEDDING_MODEL",
         # HTTP transport auth
         "GENESIS_MCP_HTTP_TOKEN",
         # Discord bot (used by discord-bot MCP server)
@@ -587,17 +571,12 @@ def _record_mcp_crash(server_name: str) -> None:
         _MCP_CRASH_DIR.mkdir(parents=True, exist_ok=True)
         crash_file = _MCP_CRASH_DIR / f"{server_name}.json"
         tb = traceback.format_exc()
-        crash_file.write_text(
-            json.dumps(
-                {
-                    "server": server_name,
-                    "error": tb.splitlines()[-1] if tb.strip() else "unknown",
-                    "traceback": "\n".join(tb.splitlines()[-15:]),
-                    "timestamp": datetime.now(UTC).isoformat(),
-                },
-                indent=2,
-            )
-        )
+        crash_file.write_text(json.dumps({
+            "server": server_name,
+            "error": tb.splitlines()[-1] if tb.strip() else "unknown",
+            "traceback": "\n".join(tb.splitlines()[-15:]),
+            "timestamp": datetime.now(UTC).isoformat(),
+        }, indent=2))
     except Exception:
         pass  # Best-effort — don't mask the original crash
 

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -148,7 +148,6 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
         # foreign_keys=False preserves the prior raw-connection behavior.
         db = await get_db(_DEFAULT_DB, foreign_keys=False)
         try:
-
             # Bootstrap standalone router for LLM-dependent tools
             try:
                 from genesis.routing.standalone import create_standalone_router
@@ -206,6 +205,7 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
             yield
         finally:
             from genesis.mcp.health.browser import async_cleanup as _browser_cleanup
+
             await _browser_cleanup()
             await db.close()
 
@@ -229,13 +229,13 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
         from genesis.db.connection import get_db
         from genesis.mcp.memory_mcp import init
         from genesis.memory.embeddings import EmbeddingProvider
+        from genesis.memory.reranker import VoyageReranker
         from genesis.observability.provider_activity import ProviderActivityTracker
 
         # Long-lived shared connection via SerializedConnection (see _bootstrap_health).
         db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
-
             # Bootstrap standalone router for LLM-dependent tools
             try:
                 from genesis.routing.standalone import create_standalone_router
@@ -252,8 +252,17 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
             # thus the boundary — never attaches.
             tracker = ProviderActivityTracker()
             tracker.set_db(db)
-            init(db=db, qdrant_client=qdrant, embedding_provider=embedding,
-                 activity_tracker=tracker)
+            # Wire the Voyage reranker into the standalone MCP retriever too, so
+            # memory_recall / knowledge_recall rerank here exactly as in the
+            # full runtime. Degrades to a no-op without API_KEY_VOYAGE.
+            reranker = VoyageReranker()
+            init(
+                db=db,
+                qdrant_client=qdrant,
+                embedding_provider=embedding,
+                activity_tracker=tracker,
+                reranker=reranker,
+            )
             clear_mcp_crash("memory")
             yield
         finally:
@@ -281,7 +290,6 @@ def _bootstrap_recon(transport_kwargs: dict) -> None:
         db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
-
             # Bootstrap standalone router for LLM-dependent tools
             try:
                 from genesis.routing.standalone import create_standalone_router
@@ -342,7 +350,10 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
             tracker = ProviderActivityTracker()
             tracker.set_db(db)
             init_outreach_mcp(
-                pipeline=None, engagement=None, config=None, db=db,
+                pipeline=None,
+                engagement=None,
+                config=None,
+                db=db,
                 activity_tracker=tracker,
             )
             clear_mcp_crash("outreach")
@@ -457,14 +468,16 @@ def _bearer_auth_middleware(expected_token: str):
 
             if scope["type"] == "http":
                 body = _json.dumps({"error": "Unauthorized"}).encode()
-                await send({
-                    "type": "http.response.start",
-                    "status": 401,
-                    "headers": [
-                        [b"content-type", b"application/json"],
-                        [b"content-length", str(len(body)).encode()],
-                    ],
-                })
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 401,
+                        "headers": [
+                            [b"content-type", b"application/json"],
+                            [b"content-length", str(len(body)).encode()],
+                        ],
+                    }
+                )
                 await send({"type": "http.response.body", "body": body})
                 return
 
@@ -490,16 +503,24 @@ def main(argv: list[str] | None = None) -> None:
     # Without the API keys, EmbeddingProvider gets zero backends and silently degrades.
     _MCP_VARS = {
         # Infrastructure
-        "OLLAMA_URL", "QDRANT_URL", "GENESIS_DB_PATH", "GENESIS_CC_PROJECT_ID",
+        "OLLAMA_URL",
+        "QDRANT_URL",
+        "GENESIS_DB_PATH",
+        "GENESIS_CC_PROJECT_ID",
         # Browser (CDP remote backend)
         "GENESIS_CDP_URL",
         # Embedding providers (required for memory MCP)
-        "API_KEY_DEEPINFRA", "API_KEY_QWEN",
+        "API_KEY_DEEPINFRA",
+        "API_KEY_QWEN",
         # LLM providers (used by recon/outreach MCP tools)
-        "GOOGLE_API_KEY", "API_KEY_GROQ", "API_KEY_MISTRAL", "API_KEY_OPENROUTER",
+        "GOOGLE_API_KEY",
+        "API_KEY_GROQ",
+        "API_KEY_MISTRAL",
+        "API_KEY_OPENROUTER",
         "API_KEY_DEEPSEEK",
         # Ollama config
-        "GENESIS_ENABLE_OLLAMA", "OLLAMA_EMBEDDING_MODEL",
+        "GENESIS_ENABLE_OLLAMA",
+        "OLLAMA_EMBEDDING_MODEL",
         # HTTP transport auth
         "GENESIS_MCP_HTTP_TOKEN",
         # Discord bot (used by discord-bot MCP server)
@@ -566,12 +587,17 @@ def _record_mcp_crash(server_name: str) -> None:
         _MCP_CRASH_DIR.mkdir(parents=True, exist_ok=True)
         crash_file = _MCP_CRASH_DIR / f"{server_name}.json"
         tb = traceback.format_exc()
-        crash_file.write_text(json.dumps({
-            "server": server_name,
-            "error": tb.splitlines()[-1] if tb.strip() else "unknown",
-            "traceback": "\n".join(tb.splitlines()[-15:]),
-            "timestamp": datetime.now(UTC).isoformat(),
-        }, indent=2))
+        crash_file.write_text(
+            json.dumps(
+                {
+                    "server": server_name,
+                    "error": tb.splitlines()[-1] if tb.strip() else "unknown",
+                    "traceback": "\n".join(tb.splitlines()[-15:]),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+                indent=2,
+            )
+        )
     except Exception:
         pass  # Best-effort — don't mask the original crash
 

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -122,6 +122,25 @@ def memory_writebacks_off() -> bool:
     )
 
 
+def memory_rerank_off() -> bool:
+    """True when Voyage cross-encoder reranking on the MCP recall tools must be
+    suppressed (kill switch).
+
+    memory_recall / knowledge_recall / reference_lookup rerank by default once
+    the retriever has a reranker. This env kill (plus the ``reranker`` mode in
+    ``config/memory_recall.yaml``) lets an operator turn that tool-path rerank
+    off — for a Voyage cost/latency/outage concern — without a restart or code
+    change. Default off: reranking stays on. Does NOT gate the internal runtime
+    context stack (its reranking predates this switch); unset ``API_KEY_VOYAGE``
+    for a full stop.
+    """
+    return os.environ.get("GENESIS_MEMORY_RERANK_OFF", "").strip() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 # A real deploy completes in minutes (update.sh's health-check phase caps at
 # ~3 min). A state file whose start is older than this cutoff is a crashed or
 # abandoned deploy, not a live one — treating it as stale bounds the (rare)

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -79,7 +79,9 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         description=(
             "Memory recall wiring — 1-hop graph expansion over memory_links "
             "(`graph_expansion.mode` off/shadow/live + neighbor caps) and the "
-            "entity lane (PR-2, off/shadow for now). Read live per recall by "
+            "entity lane (PR-2, off/shadow for now), and the Voyage reranker on "
+            "the recall tools (`reranker.mode` off/live, default live; kill via "
+            "GENESIS_MEMORY_RERANK_OFF). Read live per recall by "
             "genesis.memory.graph_expansion (no restart); shadow only emits "
             "eval_events metrics, live appends linked neighbors after the "
             "organic results."
@@ -855,6 +857,8 @@ def _validate_memory_recall(changes: dict) -> list[str]:
     section_modes = {
         "graph_expansion": MODES,
         "entity_lane": ("off", "shadow"),
+        # Reranker on the MCP recall tools — off | live (no shadow).
+        "reranker": ("off", "live"),
     }
     for key, value in changes.items():
         if key == "enabled":
@@ -886,7 +890,9 @@ def _validate_memory_recall(changes: dict) -> list[str]:
                 else:
                     errors.append(f"Unknown key '{key}.{sub_key}'")
         else:
-            errors.append(f"Unknown key '{key}'. Valid: enabled, graph_expansion, entity_lane")
+            errors.append(
+                f"Unknown key '{key}'. Valid: enabled, graph_expansion, entity_lane, reranker"
+            )
     return errors
 
 

--- a/src/genesis/mcp/memory/__init__.py
+++ b/src/genesis/mcp/memory/__init__.py
@@ -53,6 +53,8 @@ if TYPE_CHECKING:
     import aiosqlite
     from qdrant_client import QdrantClient
 
+    from genesis.memory.reranker import VoyageReranker
+
 logger = logging.getLogger(__name__)
 
 mcp = FastMCP("genesis-memory")
@@ -67,6 +69,7 @@ def init(
     storage_embedding_provider: EmbeddingProvider | None = None,
     recall_embedding_provider: EmbeddingProvider | None = None,
     activity_tracker: object | None = None,
+    reranker: VoyageReranker | None = None,
     # Backward compat — old callers pass ``embedding_provider``
     embedding_provider: EmbeddingProvider | None = None,
 ) -> None:
@@ -76,6 +79,14 @@ def init(
     writes (MemoryStore) and ``recall_embedding_provider`` for reads
     (HybridRetriever).  If only ``embedding_provider`` is given (old
     callers), it is used for both paths.
+
+    ``reranker`` wires the Voyage cross-encoder into the MCP-path retriever so
+    ``memory_recall`` / ``knowledge_recall`` actually rerank (they default
+    ``rerank=True`` but were previously built with no reranker, so the
+    ``_maybe_rerank`` gate never fired). ``None`` preserves the legacy
+    no-rerank behavior; a reranker with no ``API_KEY_VOYAGE`` degrades to a
+    no-op exactly as the runtime stack does. The MCP recall tools additionally
+    honor the ``reranker`` config mode + ``GENESIS_MEMORY_RERANK_OFF`` kill.
     """
     from genesis.bookmark.manager import BookmarkManager
     from genesis.memory.linker import MemoryLinker
@@ -104,6 +115,7 @@ def init(
         embedding_provider=recall_emb,
         qdrant_client=qdrant_client,
         db=db,
+        reranker=reranker,
     )
     _user_model_evolver = UserModelEvolver(db=db)
     _bookmark_mgr = BookmarkManager(
@@ -144,7 +156,9 @@ def _resolve_session_id(session_id: str) -> str:
     if not sessions_dir.exists():
         return session_id
 
-    matches = [d.name for d in sessions_dir.iterdir() if d.is_dir() and d.name.startswith(session_id)]
+    matches = [
+        d.name for d in sessions_dir.iterdir() if d.is_dir() and d.name.startswith(session_id)
+    ]
     if len(matches) == 1:
         return matches[0]
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -205,7 +205,10 @@ async def memory_recall(
             expand_query_terms=expand_query_terms,
             include_subsystem=include_subsystem,
             only_subsystem=only_subsystem,
-            rerank=rerank,
+            # Reranking is gated at this MCP tool boundary (config mode +
+            # GENESIS_MEMORY_RERANK_OFF kill) so the switch never reaches the
+            # hermetic LongMemEval harness or the internal runtime stack.
+            rerank=rerank and graph_expansion.reranker_enabled(),
             include_deprecated=include_deprecated,
             event_id_sink=recall_event_sink,
         )

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -6,6 +6,7 @@ import json
 import logging
 from datetime import UTC, datetime
 
+from genesis.memory import graph_expansion
 from genesis.memory.provenance import label_result_dicts, wrap_external_recall
 from genesis.memory.reference_ops import (
     REFERENCE_KINDS as _REFERENCE_KINDS,
@@ -97,6 +98,9 @@ async def knowledge_recall(
         source="knowledge",
         limit=limit,
         project_type=project,
+        # recall() defaults rerank=True; gate it at this tool boundary so the
+        # config mode + GENESIS_MEMORY_RERANK_OFF kill apply (no-op without key).
+        rerank=graph_expansion.reranker_enabled(),
         event_id_sink=recall_event_sink,
     )
 
@@ -636,6 +640,8 @@ async def reference_lookup(
             query,
             source="episodic",
             limit=vector_limit,
+            # Gate rerank at the tool boundary (see knowledge_recall above).
+            rerank=graph_expansion.reranker_enabled(),
         )
         for r in vector_results:
             vector_hits.append(

--- a/src/genesis/memory/corrective.py
+++ b/src/genesis/memory/corrective.py
@@ -284,13 +284,16 @@ def _bucket(grades: list[float | None]) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _web_augment(query: str) -> list[dict]:
+async def _web_augment(query: str, *, rerank_enabled: bool = True) -> list[dict]:
     """Search + fetch + web-strip refine into result-shaped dicts.
 
     ONLY called for ``path == "knowledge"``. Search the web, fetch the top 1-2
     URLs, chunk each fetch into paragraphs, rerank the chunks against the query,
     and recompose the top chunks into a bounded snippet. Every web call is
     wrapped — any failure yields an empty list (skip web silently).
+
+    ``rerank_enabled=False`` (the reranker kill switch) skips the Voyage chunk
+    rerank entirely and falls back to leading chunks — no Voyage call is made.
     """
     from genesis.mcp.health.web_tools import _impl_web_fetch, _impl_web_search
     from genesis.memory.reranker import VoyageReranker
@@ -312,7 +315,9 @@ async def _web_augment(query: str) -> list[dict]:
     if not urls:
         return out
 
-    reranker = VoyageReranker()
+    # Kill switch off (rerank_enabled=False) → never instantiate/call Voyage;
+    # the leading-chunks fallback below covers it.
+    reranker = VoyageReranker() if rerank_enabled else None
     for url in urls:
         try:
             fetched = await _impl_web_fetch(url)
@@ -331,7 +336,7 @@ async def _web_augment(query: str) -> list[dict]:
         snippet = ""
         score = 0.0
         try:
-            reranked = await reranker.rerank(query, docs, top_k=_WEB_TOP_CHUNKS)
+            reranked = await reranker.rerank(query, docs, top_k=_WEB_TOP_CHUNKS) if reranker else []
         except Exception:
             reranked = []
         if reranked:
@@ -356,8 +361,9 @@ async def _web_augment(query: str) -> list[dict]:
                 }
             )
 
-    with contextlib.suppress(Exception):
-        await reranker.close()
+    if reranker is not None:
+        with contextlib.suppress(Exception):
+            await reranker.close()
     return out
 
 
@@ -400,7 +406,14 @@ async def _augment(
     path only), then merge with ``kept``, dedup, rerank, and trim to the
     original limit. Returns result-shaped dicts.
     """
+    from genesis.memory.graph_expansion import reranker_enabled
     from genesis.memory.reranker import VoyageReranker
+
+    # CRAG runs inside the memory_recall / knowledge_recall tool path, so it
+    # honors the same reranker kill switch (config mode + GENESIS_MEMORY_RERANK_OFF)
+    # as the primary recall — otherwise the switch would still leak Voyage calls
+    # through corrective augmentation.
+    rerank_on = reranker_enabled()
 
     candidates: list[dict] = list(kept)
 
@@ -415,7 +428,7 @@ async def _augment(
             life_domain=None,
             expand_query_terms=True,
             include_subsystem=True,
-            rerank=True,
+            rerank=rerank_on,
         )
         candidates.extend(_retrieval_to_dict(rr) for rr in relaxed)
     except Exception:
@@ -431,7 +444,9 @@ async def _augment(
     # 3. Web fallback — knowledge path ONLY, never for memory.
     if path == "knowledge":
         try:
-            web = await asyncio.wait_for(_web_augment(query), timeout=_WEB_TIMEOUT_S)
+            web = await asyncio.wait_for(
+                _web_augment(query, rerank_enabled=rerank_on), timeout=_WEB_TIMEOUT_S
+            )
             candidates.extend(web)
         except TimeoutError:
             logger.debug("CRAG: web augment timed out")
@@ -455,7 +470,7 @@ async def _augment(
         content = _norm(c)["content"]
         if content:
             docs.append({"id": str(i), "text": content})
-    if docs:
+    if docs and rerank_on:
         reranker = VoyageReranker()
         try:
             reranked = await reranker.rerank(query, docs, top_k=_ORIG_LIMIT)

--- a/src/genesis/memory/graph_expansion.py
+++ b/src/genesis/memory/graph_expansion.py
@@ -77,7 +77,18 @@ DEFAULTS: dict[str, Any] = {
     "entity_lane": {
         "mode": "off",
     },
+    # Voyage cross-encoder reranking on the MCP recall tools (memory_recall /
+    # knowledge_recall / reference_lookup). off | live — DEFAULT live (the tools
+    # promise reranking). Gates ONLY the MCP tool path, not the internal runtime
+    # context stack or the LongMemEval harness (both pass explicit rerank kwargs
+    # and must stay hermetic). Kill: mode off OR GENESIS_MEMORY_RERANK_OFF.
+    "reranker": {
+        "mode": "live",
+    },
 }
+
+# Reranker is a binary on/off (no shadow) — unlike graph_expansion's tri-state.
+_RERANKER_MODES = ("off", "live")
 
 # Neighbor ordering score: organic RRF-fused scores are O(0.01)+ and rerank
 # scores larger still, so 0.01 * strength (strength ∈ (0, 1]) sorts every
@@ -177,6 +188,43 @@ def _mode_from(cfg: dict[str, Any]) -> str:
 def expansion_mode() -> str:
     """Effective graph-expansion mode: ``off | shadow | live`` — read live."""
     return _mode_from(load_recall_config())
+
+
+def _reranker_mode_from(cfg: dict[str, Any]) -> str:
+    """Effective reranker mode from a loaded config — ``off | live``.
+
+    Master ``enabled: false`` forces off. An unquoted ``mode: off`` parses as
+    YAML-1.1 boolean ``False``; any other invalid value degrades to ``live``
+    (the tools promise reranking, so the safe default keeps it on).
+    """
+    if not cfg.get("enabled", True):
+        return "off"
+    section = cfg.get("reranker")
+    mode = section.get("mode") if isinstance(section, dict) else None
+    if mode is False:
+        mode = "off"
+    if mode not in _RERANKER_MODES:
+        logger.warning(
+            "memory_recall reranker has invalid mode %r — defaulting to live",
+            mode,
+        )
+        return "live"
+    return mode
+
+
+def reranker_enabled() -> bool:
+    """Whether the MCP recall tools should rerank — read live per call.
+
+    True unless the ``reranker`` config mode is ``off`` OR the
+    ``GENESIS_MEMORY_RERANK_OFF`` env kill is set. Gates ONLY the MCP tool
+    path; the internal runtime context stack and the LongMemEval harness pass
+    explicit ``rerank`` kwargs and never consult this.
+    """
+    from genesis.env import memory_rerank_off
+
+    if memory_rerank_off():
+        return False
+    return _reranker_mode_from(load_recall_config()) == "live"
 
 
 async def expand_neighbors(

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -20,7 +20,8 @@ logger = logging.getLogger("genesis.runtime")
 
 
 async def run_status_writer_loop(
-    runtime: GenesisRuntime, interval_s: float = _STATUS_WRITE_INTERVAL_S,
+    runtime: GenesisRuntime,
+    interval_s: float = _STATUS_WRITE_INTERVAL_S,
 ) -> None:
     """Background loop that refreshes status.json on a fixed cadence.
 
@@ -42,7 +43,8 @@ async def run_status_writer_loop(
         except Exception as exc:
             runtime.record_job_failure("status_writer_loop", str(exc))
             logger.error(
-                "Status writer loop iteration failed", exc_info=True,
+                "Status writer loop iteration failed",
+                exc_info=True,
             )
 
 
@@ -58,6 +60,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         qdrant = QdrantClient(url=qdrant_url(), timeout=5)
         from genesis.qdrant.collections import ensure_collections
+
         ensure_collections(qdrant)
         logger.info("Qdrant collections ensured")
 
@@ -124,8 +127,12 @@ async def init(rt: GenesisRuntime) -> None:
             storage_embedding_provider=storage_embedder,
             recall_embedding_provider=recall_embedder,
             activity_tracker=rt._activity_tracker,
+            # Share the SAME reranker the runtime stack uses so the MCP recall
+            # tools (memory_recall / knowledge_recall) actually rerank instead
+            # of silently building a reranker-less retriever.
+            reranker=reranker,
         )
-        logger.info("Memory MCP initialized (dual embedders)")
+        logger.info("Memory MCP initialized (dual embedders, shared reranker)")
 
         if rt._result_writer is not None:
             rt._result_writer._memory_store = rt._memory_store
@@ -150,11 +157,13 @@ async def init(rt: GenesisRuntime) -> None:
                 await rt._status_writer.write()
             except Exception:
                 logger.warning(
-                    "Initial status writer write failed", exc_info=True,
+                    "Initial status writer write failed",
+                    exc_info=True,
                 )
 
             rt._status_writer_task = tracked_task(
-                run_status_writer_loop(rt), name="status-writer-loop",
+                run_status_writer_loop(rt),
+                name="status-writer-loop",
             )
             logger.info(
                 "Status writer loop started (interval=%ds)",
@@ -203,23 +212,29 @@ async def init(rt: GenesisRuntime) -> None:
 
     except (ConnectionError, TimeoutError) as exc:
         logger.error(
-            "MemoryStore creation failed (Qdrant down?) — "
-            "continuing without vector memory",
+            "MemoryStore creation failed (Qdrant down?) — continuing without vector memory",
             exc_info=True,
         )
         from genesis.runtime._degradation import record_init_degradation
-        await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
+
+        await record_init_degradation(
+            rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error"
+        )
     except Exception as exc:
         logger.error(
             "MemoryStore creation failed — continuing without vector memory",
             exc_info=True,
         )
         from genesis.runtime._degradation import record_init_degradation
-        await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
+
+        await record_init_degradation(
+            rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error"
+        )
 
 
 async def _migrate_reference_vectors(
-    qdrant: QdrantClient, db: aiosqlite.Connection,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
 ) -> None:
     """One-time migration: move reference vectors from knowledge_base → episodic_memory.
 
@@ -272,9 +287,7 @@ async def _migrate_reference_vectors(
         for p in to_migrate:
             payload = dict(p.payload) if p.payload else {}
             payload["memory_type"] = "episodic"
-            points_to_upsert.append(
-                PointStruct(id=str(p.id), vector=p.vector, payload=payload)
-            )
+            points_to_upsert.append(PointStruct(id=str(p.id), vector=p.vector, payload=payload))
 
         qdrant.upsert(
             collection_name="episodic_memory",
@@ -290,8 +303,7 @@ async def _migrate_reference_vectors(
         )
 
         logger.info(
-            "Reference vector migration: moved %d points from "
-            "knowledge_base → episodic_memory",
+            "Reference vector migration: moved %d points from knowledge_base → episodic_memory",
             len(to_migrate),
         )
     except Exception:

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -20,8 +20,7 @@ logger = logging.getLogger("genesis.runtime")
 
 
 async def run_status_writer_loop(
-    runtime: GenesisRuntime,
-    interval_s: float = _STATUS_WRITE_INTERVAL_S,
+    runtime: GenesisRuntime, interval_s: float = _STATUS_WRITE_INTERVAL_S,
 ) -> None:
     """Background loop that refreshes status.json on a fixed cadence.
 
@@ -43,8 +42,7 @@ async def run_status_writer_loop(
         except Exception as exc:
             runtime.record_job_failure("status_writer_loop", str(exc))
             logger.error(
-                "Status writer loop iteration failed",
-                exc_info=True,
+                "Status writer loop iteration failed", exc_info=True,
             )
 
 
@@ -60,7 +58,6 @@ async def init(rt: GenesisRuntime) -> None:
 
         qdrant = QdrantClient(url=qdrant_url(), timeout=5)
         from genesis.qdrant.collections import ensure_collections
-
         ensure_collections(qdrant)
         logger.info("Qdrant collections ensured")
 
@@ -157,13 +154,11 @@ async def init(rt: GenesisRuntime) -> None:
                 await rt._status_writer.write()
             except Exception:
                 logger.warning(
-                    "Initial status writer write failed",
-                    exc_info=True,
+                    "Initial status writer write failed", exc_info=True,
                 )
 
             rt._status_writer_task = tracked_task(
-                run_status_writer_loop(rt),
-                name="status-writer-loop",
+                run_status_writer_loop(rt), name="status-writer-loop",
             )
             logger.info(
                 "Status writer loop started (interval=%ds)",
@@ -212,29 +207,23 @@ async def init(rt: GenesisRuntime) -> None:
 
     except (ConnectionError, TimeoutError) as exc:
         logger.error(
-            "MemoryStore creation failed (Qdrant down?) — continuing without vector memory",
+            "MemoryStore creation failed (Qdrant down?) — "
+            "continuing without vector memory",
             exc_info=True,
         )
         from genesis.runtime._degradation import record_init_degradation
-
-        await record_init_degradation(
-            rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error"
-        )
+        await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
     except Exception as exc:
         logger.error(
             "MemoryStore creation failed — continuing without vector memory",
             exc_info=True,
         )
         from genesis.runtime._degradation import record_init_degradation
-
-        await record_init_degradation(
-            rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error"
-        )
+        await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
 
 
 async def _migrate_reference_vectors(
-    qdrant: QdrantClient,
-    db: aiosqlite.Connection,
+    qdrant: QdrantClient, db: aiosqlite.Connection,
 ) -> None:
     """One-time migration: move reference vectors from knowledge_base → episodic_memory.
 
@@ -287,7 +276,9 @@ async def _migrate_reference_vectors(
         for p in to_migrate:
             payload = dict(p.payload) if p.payload else {}
             payload["memory_type"] = "episodic"
-            points_to_upsert.append(PointStruct(id=str(p.id), vector=p.vector, payload=payload))
+            points_to_upsert.append(
+                PointStruct(id=str(p.id), vector=p.vector, payload=payload)
+            )
 
         qdrant.upsert(
             collection_name="episodic_memory",
@@ -303,7 +294,8 @@ async def _migrate_reference_vectors(
         )
 
         logger.info(
-            "Reference vector migration: moved %d points from knowledge_base → episodic_memory",
+            "Reference vector migration: moved %d points from "
+            "knowledge_base → episodic_memory",
             len(to_migrate),
         )
     except Exception:

--- a/tests/test_mcp/test_memory_reranker_wiring.py
+++ b/tests/test_mcp/test_memory_reranker_wiring.py
@@ -12,7 +12,28 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 import genesis.mcp.memory as mem
+
+# init() rebinds these module globals; restore them so a populated state can't
+# leak into the *_requires_init tests (which assert an uninitialized module).
+_INIT_GLOBALS = (
+    "_store",
+    "_db",
+    "_qdrant",
+    "_retriever",
+    "_user_model_evolver",
+    "_bookmark_mgr",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_memory_globals():
+    saved = {name: getattr(mem, name) for name in _INIT_GLOBALS}
+    yield
+    for name, value in saved.items():
+        setattr(mem, name, value)
 
 
 def _stub_init_deps(monkeypatch) -> dict:

--- a/tests/test_mcp/test_memory_reranker_wiring.py
+++ b/tests/test_mcp/test_memory_reranker_wiring.py
@@ -1,0 +1,68 @@
+"""genesis.mcp.memory.init() must thread the Voyage reranker into the MCP-path
+HybridRetriever.
+
+Regression guard for the bug this fixes: the MCP retriever was built with no
+reranker, so memory_recall / knowledge_recall (which default rerank=True) never
+actually reranked — _maybe_rerank short-circuits on a None reranker. We stub the
+four constructors init() builds so the test is fast, network-free, and
+install-agnostic; only the reranker threading is under test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import genesis.mcp.memory as mem
+
+
+def _stub_init_deps(monkeypatch) -> dict:
+    """Replace the constructors init() calls; capture HybridRetriever kwargs."""
+    captured: dict = {}
+
+    class _FakeRetriever:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._reranker = kwargs.get("reranker")
+
+    # Local imports inside init() resolve these attributes at call time, so
+    # patching the source module attribute is sufficient.
+    monkeypatch.setattr("genesis.memory.retrieval.HybridRetriever", _FakeRetriever)
+    monkeypatch.setattr("genesis.memory.store.MemoryStore", lambda **kw: MagicMock(name="store"))
+    monkeypatch.setattr("genesis.memory.linker.MemoryLinker", lambda **kw: MagicMock(name="linker"))
+    monkeypatch.setattr(
+        "genesis.memory.user_model.UserModelEvolver", lambda **kw: MagicMock(name="ume")
+    )
+    monkeypatch.setattr(
+        "genesis.bookmark.manager.BookmarkManager", lambda **kw: MagicMock(name="bm")
+    )
+    return captured
+
+
+def test_init_threads_reranker_into_retriever(monkeypatch):
+    captured = _stub_init_deps(monkeypatch)
+    sentinel = object()
+
+    mem.init(
+        db=MagicMock(),
+        qdrant_client=MagicMock(),
+        embedding_provider=MagicMock(),
+        reranker=sentinel,
+    )
+
+    assert captured["reranker"] is sentinel
+    # The module retriever exposes the same reranker the tools will consult.
+    assert mem._retriever._reranker is sentinel
+
+
+def test_init_without_reranker_is_none(monkeypatch):
+    # Legacy call sites pass no reranker — behavior must be unchanged (None),
+    # which is exactly what left the MCP path un-reranked before this fix.
+    captured = _stub_init_deps(monkeypatch)
+
+    mem.init(
+        db=MagicMock(),
+        qdrant_client=MagicMock(),
+        embedding_provider=MagicMock(),
+    )
+
+    assert captured["reranker"] is None

--- a/tests/test_mcp/test_settings_memory_recall.py
+++ b/tests/test_mcp/test_settings_memory_recall.py
@@ -73,6 +73,22 @@ def test_exclude_link_types_must_be_str_list():
     assert _validate_memory_recall({"graph_expansion": {"exclude_link_types": []}}) == []
 
 
+def test_reranker_mode_accepts_off_and_live():
+    assert _validate_memory_recall({"reranker": {"mode": "off"}}) == []
+    assert _validate_memory_recall({"reranker": {"mode": "live"}}) == []
+
+
+def test_reranker_mode_rejects_shadow_and_garbage():
+    # Reranker is binary (no shadow) — shadow/other values must be rejected so a
+    # settings_update can't land a config that only degrades-with-warning.
+    assert _validate_memory_recall({"reranker": {"mode": "shadow"}})
+    assert _validate_memory_recall({"reranker": {"mode": "banana"}})
+
+
+def test_reranker_rejects_unknown_subkey():
+    assert _validate_memory_recall({"reranker": {"max_neighbors": 5}})
+
+
 def test_section_must_be_mapping():
     assert _validate_memory_recall({"graph_expansion": "live"})
     assert _validate_memory_recall({"entity_lane": []})

--- a/tests/test_memory/test_corrective.py
+++ b/tests/test_memory/test_corrective.py
@@ -330,6 +330,44 @@ async def test_incorrect_memory_path_no_web(retriever):
     assert any(r.get("memory_id") == "m99" for r in out)
 
 
+async def test_kill_switch_suppresses_crag_rerank(retriever, monkeypatch):
+    # GENESIS_MEMORY_RERANK_OFF must reach the corrective path: the relaxed
+    # re-retrieve goes out with rerank=False and no Voyage call is made.
+    monkeypatch.setenv("GENESIS_MEMORY_RERANK_OFF", "1")
+    results = [_mem_result("m1", "off-topic", 0.2)]
+    router = MagicMock()
+    router.route_call = AsyncMock(
+        return_value=_routing_result(success=True, content=_grade_content(0.05)),
+    )
+    aug = MagicMock()
+    aug.memory_id = "m99"
+    aug.content = "augmented"
+    aug.score = 0.8
+    aug.payload = {}
+    retriever.recall = AsyncMock(return_value=[aug])
+
+    mock_reranker = MagicMock()
+    mock_reranker.rerank = AsyncMock(return_value=[])
+    mock_reranker.close = AsyncMock()
+
+    with patch("genesis.memory.reranker.VoyageReranker", return_value=mock_reranker):
+        out = await maybe_correct_recall(
+            query="q",
+            results=results,
+            retriever=retriever,
+            db=MagicMock(),
+            path="memory",
+            router=router,
+        )
+
+    # The relaxed re-retrieve (first recall call) carried rerank=False.
+    assert retriever.recall.await_args_list[0].kwargs.get("rerank") is False
+    # Voyage was never called through the corrective merge-rerank.
+    mock_reranker.rerank.assert_not_called()
+    # Augmentation still works (dedup/trim), just without reranking.
+    assert any(r.get("memory_id") == "m99" for r in out)
+
+
 # ---------------------------------------------------------------------------
 # Behavior: Incorrect on knowledge path → MAY call web
 # ---------------------------------------------------------------------------

--- a/tests/test_memory/test_graph_expansion.py
+++ b/tests/test_memory/test_graph_expansion.py
@@ -489,3 +489,70 @@ async def test_expand_skips_deprecated_neighbor(db):
     out = await graph_expansion.expand_neighbors(db, ["seed-1"], cap=10)
 
     assert out == []
+
+
+# --- reranker mode + kill switch (MCP recall tool gate) --------------------
+# reranker_enabled() gates Voyage reranking on the MCP recall tools ONLY.
+# off | live (no shadow), DEFAULT live. Kill = config mode off OR the
+# GENESIS_MEMORY_RERANK_OFF env. Master ``enabled: false`` also forces off.
+
+
+def test_reranker_defaults_to_live_with_no_files(config_dirs, monkeypatch):
+    monkeypatch.delenv("GENESIS_MEMORY_RERANK_OFF", raising=False)
+    cfg = graph_expansion.load_recall_config()
+    assert cfg["reranker"]["mode"] == "live"
+    assert graph_expansion.reranker_enabled() is True
+
+
+def test_reranker_mode_off_via_base(config_dirs, monkeypatch):
+    monkeypatch.delenv("GENESIS_MEMORY_RERANK_OFF", raising=False)
+    base, _ = config_dirs
+    _write(base, {"reranker": {"mode": "off"}})
+    assert graph_expansion.reranker_enabled() is False
+
+
+def test_reranker_overlay_wins_over_base(config_dirs, monkeypatch):
+    monkeypatch.delenv("GENESIS_MEMORY_RERANK_OFF", raising=False)
+    base, overlay = config_dirs
+    _write(base, {"reranker": {"mode": "live"}})
+    _write(overlay, {"reranker": {"mode": "off"}})
+    assert graph_expansion.reranker_enabled() is False
+
+
+def test_reranker_master_enabled_false_forces_off(config_dirs, monkeypatch):
+    monkeypatch.delenv("GENESIS_MEMORY_RERANK_OFF", raising=False)
+    base, _ = config_dirs
+    _write(base, {"enabled": False, "reranker": {"mode": "live"}})
+    assert graph_expansion.reranker_enabled() is False
+
+
+def test_reranker_invalid_mode_degrades_to_live(config_dirs, monkeypatch):
+    # Unlike graph_expansion (degrades to shadow), the reranker has no shadow —
+    # an invalid value keeps reranking ON (the tools promise it).
+    monkeypatch.delenv("GENESIS_MEMORY_RERANK_OFF", raising=False)
+    base, _ = config_dirs
+    _write(base, {"reranker": {"mode": "banana"}})
+    assert graph_expansion.reranker_enabled() is True
+
+
+def test_reranker_unquoted_off_boolean_is_off(config_dirs, monkeypatch):
+    # A hand-edited unquoted ``mode: off`` parses as YAML-1.1 boolean False.
+    monkeypatch.delenv("GENESIS_MEMORY_RERANK_OFF", raising=False)
+    base, _ = config_dirs
+    base.write_text("reranker:\n  mode: off\n")
+    assert graph_expansion.reranker_enabled() is False
+
+
+def test_reranker_env_kill_forces_off_even_when_config_live(config_dirs, monkeypatch):
+    base, _ = config_dirs
+    _write(base, {"reranker": {"mode": "live"}})
+    monkeypatch.setenv("GENESIS_MEMORY_RERANK_OFF", "1")
+    assert graph_expansion.reranker_enabled() is False
+
+
+def test_reranker_env_kill_various_truthy(config_dirs, monkeypatch):
+    for val in ("1", "true", "yes"):
+        monkeypatch.setenv("GENESIS_MEMORY_RERANK_OFF", val)
+        assert graph_expansion.reranker_enabled() is False
+    monkeypatch.setenv("GENESIS_MEMORY_RERANK_OFF", "0")
+    assert graph_expansion.reranker_enabled() is True


### PR DESCRIPTION
## Problem

`memory_recall` and `knowledge_recall` default `rerank=True` and their docstrings promise Voyage cross-encoder reranking — but the MCP-path retriever was built in `genesis.mcp.memory.init()` with **no reranker**, so `HybridRetriever._maybe_rerank` (which short-circuits on a `None` reranker) never fired. Tool recall silently returned raw RRF-fusion order instead of reranked results. The runtime/context stack *did* build a `VoyageReranker()`, so only the tool path was dark.

## Fix

1. **Wire it (the bug fix).** Thread an optional `reranker` through `mcp.memory.init()` into the `HybridRetriever`, passed from both init sites: the runtime shares the reranker it already builds; the standalone MCP server builds its own. `reranker=None` stays a true no-op (legacy behavior); a reranker with no `API_KEY_VOYAGE` degrades to a no-op exactly as the runtime stack does.

2. **Kill switch (config + env, same PR).** `reranker.mode` (off|live, default live) in `config/memory_recall.yaml`, read live via `graph_expansion.reranker_enabled()` (no restart), plus `GENESIS_MEMORY_RERANK_OFF` (`env.memory_rerank_off()`). Registered in the `memory_recall` settings validator so `settings_update` can land it.

## Scope decision: gate at the MCP tool boundary, not the retriever

The gate is applied only at the three recall **tools** (`memory_recall`, `knowledge_recall`, `reference_lookup`) — deliberately **not** inside `_maybe_rerank`. Gating in the retriever would have coupled the hermetic LongMemEval benchmark harness (which builds its own reranked retriever and passes explicit `rerank` kwargs) and the internal runtime context stack to prod config — a prod `mode: off` would silently corrupt the benchmark's rerank arm. Unset `API_KEY_VOYAGE` remains the full global stop.

## Blast radius

- Newly reranked (latency-tolerant, +~300ms + a Voyage call): `memory_recall`, `knowledge_recall`, `reference_lookup`.
- Unchanged: the proactive/compact path (already `rerank=False`), the internal runtime context stack (already reranked), the LongMemEval harness (explicit kwargs).

## Tests

- `test_memory_reranker_wiring.py` — init threads the reranker; `None` default is a no-op.
- `test_graph_expansion.py` — the full gate matrix (default-live, config off, overlay override, master `enabled:false`, invalid→live, unquoted-`off`, env kill).
- `test_settings_memory_recall.py` — validator accepts off/live, rejects shadow/garbage/unknown-subkey.

The tool-gate line (`rerank and reranker_enabled()`) is verified E2E (live `memory_recall` reranks; config `mode: off` live → no rerank; standalone boots without a Voyage key) rather than by driving the full tool through mocks.

Ledger: d0866512b78c4f7f909c59848064a685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
