### PR TITLE
feat(deploy): bootstrap.sh refuses to run on a live system

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,7 +2,10 @@
 # Genesis full machine bootstrap.
 # Run once after cloning on a new machine.
 #
-# Usage: ./scripts/bootstrap.sh
+# Usage: ./scripts/bootstrap.sh [--force]
+#
+# Refuses to run while genesis-server is live (--force overrides): bootstrap
+# is a setup/repair tool, not a deploy path — see lib/live_system_guard.sh.
 
 set -euo pipefail
 
@@ -18,6 +21,13 @@ fi
 echo "=== Genesis Bootstrap ==="
 echo "Genesis root: $GENESIS_ROOT"
 echo
+
+# ── Live-system guard — BEFORE anything mutating (incl. the crash-recovery
+# block below, whose git reset --hard is also unsafe on a live system).
+# update.sh opts out via GENESIS_BOOTSTRAP_ALLOW_LIVE=1; humans use --force.
+# shellcheck source=lib/live_system_guard.sh
+. "$SCRIPT_DIR/lib/live_system_guard.sh"
+bootstrap_refuse_if_server_live "$@" || exit 3
 
 # ── Crash recovery: check for interrupted update ─────────
 UPDATE_STATE="$HOME/.genesis/update_state.json"

--- a/scripts/lib/live_system_guard.sh
+++ b/scripts/lib/live_system_guard.sh
@@ -1,0 +1,81 @@
+# shellcheck shell=bash
+# Live-system guard for bootstrap.sh — sourced, not executed.
+#
+# bootstrap_refuse_if_server_live [args...]
+#
+# bootstrap.sh is a setup/repair tool, NOT a deploy path. Running it on a
+# machine with a live genesis-server re-runs installers (curl|bash, npm -g,
+# pip), re-registers MCP servers + systemd units, and edits dotfiles on top
+# of a running system — the direct trigger of the 2026-07-13 eth0/load
+# incident. Code changes deploy via scripts/update.sh (or git pull +
+# pip install -e . + systemctl --user restart genesis-server).
+#
+# This function makes that rule mechanical: refuse to proceed while
+# genesis-server is live, unless one of two overrides applies:
+#
+#   GENESIS_BOOTSTRAP_ALLOW_LIVE=1  — sanctioned-caller opt-out. update.sh
+#       sets it on its bootstrap invocation: its ERR trap is armed there, so
+#       a guard refusal inside update.sh would trigger a FULL update rollback
+#       (git reset to the rollback tag) — the guard must never gate the
+#       sanctioned deploy path, which stops the server itself beforehand.
+#   --force  — human override for deliberate live repair. Proceeds with a
+#       loud warning.
+#
+# Server-live detection mirrors update.sh's _ensure_server_down check so the
+# two can't drift: live iff `systemctl --user is-active` reports active OR a
+# `python -m genesis serve` process exists. Detection is FAIL-OPEN: any other
+# outcome (unknown unit rc=4, no session D-Bus, pgrep miss/absent) reads as
+# not-running and bootstrap proceeds — a broken detector must never block a
+# fresh-install bootstrap (where no server exists yet).
+#
+# Return codes (caller decides severity, cf. venv_setup.sh):
+#   0 — proceed (not live, opt-out set, or --force given; warning printed
+#       when forcing past a live server)
+#   1 — refused: server is live, no override (message already printed)
+
+_genesis_server_is_live() {
+    if systemctl --user is-active --quiet genesis-server.service 2>/dev/null; then
+        return 0
+    fi
+    if pgrep -f "python -m genesis serve" >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+bootstrap_refuse_if_server_live() {
+    # Sanctioned-caller opt-out (update.sh deploy path) — silent, unconditional.
+    if [ -n "${GENESIS_BOOTSTRAP_ALLOW_LIVE:-}" ]; then
+        return 0
+    fi
+
+    local force=false arg
+    for arg in "$@"; do
+        [ "$arg" = "--force" ] && force=true
+    done
+
+    if ! _genesis_server_is_live; then
+        return 0
+    fi
+
+    if [ "$force" = "true" ]; then
+        echo "WARNING: proceeding on a LIVE system by --force (genesis-server is running)."
+        return 0
+    fi
+
+    cat >&2 <<'EOF'
+REFUSED: genesis-server is RUNNING — bootstrap.sh is a setup/repair tool,
+not a deploy path. Running it on a live system re-runs installers and
+re-registers services on top of a running server (this triggered the
+2026-07-13 eth0/load incident).
+
+To deploy code changes, use the sanctioned path instead:
+    scripts/update.sh
+  or, for a code-only change:
+    git pull && pip install -e . && systemctl --user restart genesis-server
+
+To run bootstrap for deliberate live repair anyway:
+    ./scripts/bootstrap.sh --force
+EOF
+    return 1
+}

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1029,8 +1029,12 @@ echo ""
 _write_state "bootstrap"
 
 # ── Run bootstrap (idempotent — handles deps, configs, hooks, systemd) ─
+# GENESIS_BOOTSTRAP_ALLOW_LIVE: opt out of bootstrap's live-system guard
+# (lib/live_system_guard.sh). This is the sanctioned deploy path — the server
+# was stopped above, and the ERR trap is armed here, so a guard refusal would
+# escalate into a full update rollback. The guard must never gate this call.
 echo "--- Running bootstrap ---"
-"$GENESIS_ROOT/scripts/bootstrap.sh" 2>&1 | tail -10
+GENESIS_BOOTSTRAP_ALLOW_LIVE=1 "$GENESIS_ROOT/scripts/bootstrap.sh" 2>&1 | tail -10
 echo "  Bootstrap complete"
 echo ""
 

--- a/tests/test_scripts/test_live_system_guard.py
+++ b/tests/test_scripts/test_live_system_guard.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/lib/live_system_guard.sh — bootstrap's live-system guard.
+
+Running bootstrap.sh on a live machine (installers, MCP/systemd re-registration,
+dotfile edits on top of a running server) was the direct trigger of the
+2026-07-13 eth0/load incident. The guard makes the "bootstrap is not a deploy
+path" rule mechanical: refuse while genesis-server is live, unless update.sh's
+GENESIS_BOOTSTRAP_ALLOW_LIVE opt-out or a human --force is present.
+
+Environment-independent: ``systemctl`` and ``pgrep`` are BOTH faked via PATH
+injection (the real ones would detect this dev machine's actually-live server),
+so the cases run identically in CI and on a workstation.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LIB = _REPO_ROOT / "scripts" / "lib" / "live_system_guard.sh"
+
+_SYSTEM_PATH = "/usr/bin:/bin"  # real bash for the harness
+
+
+def _write_exec(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _stub_detection(bindir: Path, *, systemctl_rc: int, pgrep_rc: int) -> None:
+    """Fake systemctl + pgrep with fixed exit codes (all the guard reads)."""
+    bindir.mkdir(exist_ok=True)
+    _write_exec(bindir / "systemctl", f"#!/usr/bin/env bash\nexit {systemctl_rc}\n")
+    _write_exec(bindir / "pgrep", f"#!/usr/bin/env bash\nexit {pgrep_rc}\n")
+
+
+def _run_guard(bindir: Path, *args: str, env_extra: dict | None = None):
+    env = {
+        "PATH": f"{bindir}:{_SYSTEM_PATH}",
+        "HOME": os.environ.get("HOME", "/tmp"),
+        **(env_extra or {}),
+    }
+    return subprocess.run(
+        ["bash", "-c", f'. "{_LIB}" && bootstrap_refuse_if_server_live "$@"', "guard", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_live_server_refused_without_override(tmp_path: Path) -> None:
+    """systemd reports active, no --force, no opt-out → refuse (rc=1)."""
+    bindir = tmp_path / "bin"
+    _stub_detection(bindir, systemctl_rc=0, pgrep_rc=1)
+    res = _run_guard(bindir)
+    assert res.returncode == 1
+    assert "REFUSED" in res.stderr
+    assert "scripts/update.sh" in res.stderr  # teaches the sanctioned deploy path
+    assert "--force" in res.stderr  # and the override
+
+
+def test_live_server_force_proceeds_with_warning(tmp_path: Path) -> None:
+    """--force on a live server → proceed (rc=0) but warn loudly."""
+    bindir = tmp_path / "bin"
+    _stub_detection(bindir, systemctl_rc=0, pgrep_rc=1)
+    res = _run_guard(bindir, "--force")
+    assert res.returncode == 0
+    assert "WARNING" in res.stdout
+    assert "LIVE" in res.stdout
+
+
+def test_allow_live_env_is_silent_optout(tmp_path: Path) -> None:
+    """update.sh's GENESIS_BOOTSTRAP_ALLOW_LIVE=1 → rc=0, no output at all.
+
+    This is the deploy path: update.sh's ERR trap is armed around its bootstrap
+    call, so any refusal here would escalate into a full update rollback.
+    """
+    bindir = tmp_path / "bin"
+    _stub_detection(bindir, systemctl_rc=0, pgrep_rc=0)  # maximally "live"
+    res = _run_guard(bindir, env_extra={"GENESIS_BOOTSTRAP_ALLOW_LIVE": "1"})
+    assert res.returncode == 0
+    assert res.stdout == ""
+    assert res.stderr == ""
+
+
+def test_inactive_server_proceeds_silently(tmp_path: Path) -> None:
+    """Unit unknown/inactive (rc=4) and no process → rc=0, silent (fail-open)."""
+    bindir = tmp_path / "bin"
+    _stub_detection(bindir, systemctl_rc=4, pgrep_rc=1)
+    res = _run_guard(bindir)
+    assert res.returncode == 0
+    assert res.stdout == ""
+    assert res.stderr == ""
+
+
+def test_pgrep_detects_live_when_systemd_unavailable(tmp_path: Path) -> None:
+    """No usable systemd (rc=4) but a bare `genesis serve` process → refuse."""
+    bindir = tmp_path / "bin"
+    _stub_detection(bindir, systemctl_rc=4, pgrep_rc=0)
+    res = _run_guard(bindir)
+    assert res.returncode == 1
+    assert "REFUSED" in res.stderr
+
+
+def test_bootstrap_sources_and_calls_guard() -> None:
+    """Wiring guardrail: bootstrap.sh must source the lib and gate on it
+    BEFORE the crash-recovery block (whose git reset --hard is unsafe live)."""
+    bootstrap = (_REPO_ROOT / "scripts" / "bootstrap.sh").read_text(encoding="utf-8")
+    source_pos = bootstrap.find("lib/live_system_guard.sh")
+    call_pos = bootstrap.find("bootstrap_refuse_if_server_live")
+    crash_pos = bootstrap.find("Crash recovery")
+    assert source_pos != -1, "bootstrap.sh no longer sources live_system_guard.sh"
+    assert call_pos != -1, "bootstrap.sh no longer calls bootstrap_refuse_if_server_live"
+    assert crash_pos != -1
+    assert call_pos < crash_pos, "guard must run before the crash-recovery git reset"
+
+
+def test_update_sh_sets_optout_on_bootstrap_call() -> None:
+    """Wiring guardrail: update.sh's bootstrap invocation must carry the
+    opt-out env — a refusal there would trigger a full ERR-trap rollback."""
+    update = (_REPO_ROOT / "scripts" / "update.sh").read_text(encoding="utf-8")
+    for line in update.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or "scripts/bootstrap.sh" not in stripped:
+            continue
+        # Only actual invocations (not comments/path lists) must carry the env.
+        if stripped.endswith("scripts/bootstrap.sh \\") or 'bootstrap.sh" 2>&1' in stripped:
+            assert "GENESIS_BOOTSTRAP_ALLOW_LIVE=1" in stripped, (
+                f"update.sh bootstrap invocation missing opt-out: {stripped}"
+            )


### PR DESCRIPTION
## Problem

`bootstrap.sh` is a **setup/repair tool, not a deploy path** — it re-runs installers (`curl|bash` for codebase-memory-mcp, `npm -g gitnexus`, pip), re-registers MCP servers + systemd units, self-installs systemd-oomd, edits `.bashrc`, and (via its crash-recovery block) does a hard `git reset`. Running it on a machine with a **live `genesis-server`** was the direct trigger of the 2026-07-13 eth0/load incident. The "don't run bootstrap on a live system; deploy via `update.sh`" rule lived only in session memory and `CLAUDE.md` — and `.claude/settings.local.json` even pre-allows `Bash(./scripts/bootstrap.sh)`, so the footgun was fully live.

## Fix

Make the rule **mechanical**. New sourced lib `scripts/lib/live_system_guard.sh` exposes `bootstrap_refuse_if_server_live`, which `bootstrap.sh` calls *before* any mutating step (including the crash-recovery hard reset):

- **Refuses** (exit 3, teaching message → stderr) when `genesis-server` is live.
- **Server-live detection mirrors `update.sh`'s `_ensure_server_down`** (`systemctl --user is-active` OR `pgrep -f "python -m genesis serve"`) so the two can't drift — annotated as a deliberate mirror rather than refactored into shared code (smaller blast radius).
- **Fail-open**: any detection ambiguity (unknown unit rc=4, no session D-Bus, pgrep miss) reads as *not running* → proceed. A broken detector must never block a fresh-install bootstrap, where no server exists yet.
- **Two overrides**: `--force` (human, deliberate live repair, loud warning) and `GENESIS_BOOTSTRAP_ALLOW_LIVE=1` (the sanctioned caller).

`update.sh` sets `GENESIS_BOOTSTRAP_ALLOW_LIVE=1` on its bootstrap invocation. This is load-bearing: `update.sh` stops the server itself beforehand, and its **ERR trap is armed** around the bootstrap call — so a guard refusal *inside* `update.sh` would escalate into a full update **rollback** (`git reset` to the rollback tag). The opt-out keeps the guard from ever gating the deploy path.

## Verification

- `bash -n` + `shellcheck` clean on all three scripts.
- `pytest tests/test_scripts/test_live_system_guard.py` — **7 pass**: four detection/override cases (live→refuse, `--force`→warn+proceed, opt-out→silent proceed, inactive→silent proceed), pgrep-only-live→refuse, plus two wiring guardrails (guard is sourced+called *before* crash-recovery; `update.sh`'s invocation carries the opt-out).
- **E2E against this machine's actually-running server**: full `bash scripts/bootstrap.sh` → banner, refusal, `exit 3`, zero installers run; opt-out env → silent proceed.
- Re-verified against the post-#1125 `update.sh` refactor: the server stop-flow is outside the `POST_MERGE` guards, the ERR trap (line 810) is armed before the bootstrap call (line 1033), and the env prefix lands on the pipeline head.

## Deploy

Runtime script change — reaches existing installs on the next `git pull` + `update.sh`; a fresh clone gets it from the checkout. No host/guardian path touched. Idempotent and generic — works on any install (fail-open detection means installs without systemd/pgrep are never blocked).

## Regression marker

If a future `update.sh` run ever aborts or rolls back at "Running bootstrap", the opt-out wiring broke. The `test_update_sh_sets_optout_on_bootstrap_call` guardrail makes shipping that regression near-impossible.

Resolves follow-up `1195dba4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
