### PR TITLE
fix(code-intel): runner unit PATH includes ~/.local/bin — cbm indexing was dead

### DIFF
--- a/scripts/systemd/genesis-code-intel.service.template
+++ b/scripts/systemd/genesis-code-intel.service.template
@@ -11,12 +11,15 @@ ExecStart=/bin/bash __REPO_DIR__/scripts/code_intel_runner.sh
 # throttled (duty-cycled) full rebuild is never SIGTERMed mid-flight. A wedged
 # runner is still bounded by its own self-flock (one tick at a time).
 TimeoutStartSec=16200
-# PATH MUST include ~/.npm-global/bin — that's where codebase-memory-mcp and
-# gitnexus live. If they are absent from the unit PATH the entrypoint exits 3
-# ("requested tool missing") and the runner keeps the marker instead of silently
-# stamping a fake success. Also needs systemctl/systemd-run (the watchdog's
+# PATH MUST include BOTH tool dirs: gitnexus lives in ~/.npm-global/bin, and
+# codebase-memory-mcp installs to ~/.local/bin (the vendor install.sh default,
+# cf. .claude/mcp/run-codebase-memory). If either is absent from the unit PATH
+# the entrypoint exits 3 ("requested tool missing") and the runner keeps the
+# marker instead of silently stamping a fake success — which is exactly what
+# happened when ~/.local/bin was omitted: cbm indexing was dead for days while
+# gitnexus kept working. Also needs systemctl/systemd-run (the watchdog's
 # cgroup freeze), flock, ps, awk, git (/usr/bin) and the venv python.
-Environment=PATH=__VENV__/bin:__HOME__/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=__VENV__/bin:__HOME__/.npm-global/bin:__HOME__/.local/bin:/usr/local/bin:/usr/bin:/bin
 StandardOutput=journal
 StandardError=journal
 # Writes only under $HOME (index-request markers + locks under ~/.genesis, the

--- a/tests/test_scripts/test_code_intel_service_template.py
+++ b/tests/test_scripts/test_code_intel_service_template.py
@@ -1,0 +1,59 @@
+"""Regression guard for the code-intel runner systemd unit's PATH.
+
+The idle-gated runner (genesis-code-intel.service) invokes two external
+indexers: ``gitnexus`` (installed to ~/.npm-global/bin) and
+``codebase-memory-mcp`` (installed to ~/.local/bin — the vendor install.sh
+default, cf. .claude/mcp/run-codebase-memory). The unit's Environment=PATH
+MUST contain BOTH dirs, or the entrypoint exits 3 ("requested tool missing")
+and the runner keeps the marker forever without indexing.
+
+This is not hypothetical: ~/.local/bin was omitted from the template, so cbm
+indexing was silently dead for days (156 rc=3 "nothing indexed", zero rc=0,
+the runner re-escalating "first full cbm index due" every 5 min) while
+gitnexus kept working. This test locks in both dirs so the regression can't
+ship again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE = _REPO_ROOT / "scripts" / "systemd" / "genesis-code-intel.service.template"
+_CBM_LAUNCHER = _REPO_ROOT / ".claude" / "mcp" / "run-codebase-memory"
+
+
+def _path_line() -> str:
+    for line in _TEMPLATE.read_text(encoding="utf-8").splitlines():
+        if line.startswith("Environment=PATH="):
+            return line
+    raise AssertionError("no Environment=PATH= line in genesis-code-intel.service.template")
+
+
+def test_runner_path_includes_cbm_and_gitnexus_dirs() -> None:
+    path_line = _path_line()
+    # gitnexus lives here; cbm installs here. Both are required — omitting either
+    # makes the entrypoint exit 3 and the runner index nothing.
+    assert "__HOME__/.local/bin" in path_line, (
+        "code-intel runner PATH omits ~/.local/bin — codebase-memory-mcp indexing "
+        "will silently fail (rc=3, nothing indexed). This is the exact regression "
+        "that killed cbm indexing for days."
+    )
+    assert "__HOME__/.npm-global/bin" in path_line, (
+        "code-intel runner PATH omits ~/.npm-global/bin — gitnexus analyze will fail."
+    )
+
+
+def test_cbm_launcher_default_dir_is_on_runner_path() -> None:
+    """The launcher's default binary dir must be a segment of the runner PATH.
+
+    Guards against the two drifting apart: if the vendor default install dir in
+    run-codebase-memory ever changes, this fails until the unit PATH follows.
+    """
+    launcher = _CBM_LAUNCHER.read_text(encoding="utf-8")
+    # run-codebase-memory:  BINARY="${CODEBASE_MEMORY_MCP_BIN:-${HOME}/.local/bin/codebase-memory-mcp}"
+    assert "${HOME}/.local/bin/codebase-memory-mcp" in launcher, (
+        "cbm launcher default path changed — update this test and the unit PATH together."
+    )
+    # Template uses __HOME__ where the launcher uses ${HOME}; the tail dir must match.
+    assert "__HOME__/.local/bin" in _path_line()

--- a/tests/test_scripts/test_code_intel_service_template.py
+++ b/tests/test_scripts/test_code_intel_service_template.py
@@ -40,7 +40,7 @@ def test_runner_path_includes_cbm_and_gitnexus_dirs() -> None:
         "that killed cbm indexing for days."
     )
     assert "__HOME__/.npm-global/bin" in path_line, (
-        "code-intel runner PATH omits ~/.npm-global/bin — gitnexus analyze will fail."
+        "code-intel runner PATH omits ~/.npm-global/bin — gitnexus indexing will fail."
     )
 
 


### PR DESCRIPTION
## Problem

CBM code-graph indexing (`codebase-memory-mcp`) had been **100% dead for days** and nothing surfaced. The idle-gated runner (`genesis-code-intel.service`) logged **156× `rc=3` "requested tool(s) missing from PATH: cbm — nothing indexed"**, **zero `rc=0`**, and re-escalated *"first full cbm index due"* every 5 minutes forever — the full CBM index never completed, so the condition never cleared.

**Root cause:** the runner's systemd unit hardcoded a PATH that omits `~/.local/bin` — the *only* location of the `codebase-memory-mcp` binary (the vendor `install.sh` default; see `.claude/mcp/run-codebase-memory`, which resolves `${HOME}/.local/bin/codebase-memory-mcp`). gitnexus kept working only because it lives in `~/.npm-global/bin`, which the PATH *did* include. The template comment even misattributed cbm to `~/.npm-global/bin`. Sibling `genesis-server` / `genesis-bridge` templates already include `.local/bin` — this unit was the outlier. Ships to **every install**.

**Impact:** the CBM graph (architecture / `trace_path` / `search_graph`) was silently stale for ~5+ days. The MCP *query* server kept answering — off stale data — so nothing screamed.

## Fix

One line in `scripts/systemd/genesis-code-intel.service.template`: add `__HOME__/.local/bin` to the unit PATH (keeping `.npm-global/bin` for gitnexus), plus a corrected comment explaining both tool dirs and this exact failure mode.

## Verification

- `pytest tests/test_scripts/test_code_intel_service_template.py` — new regression guard: asserts the unit PATH carries **both** tool dirs and stays aligned with the launcher's default cbm binary dir.
- **Deployed to this install** (re-render unit + `daemon-reload`) and triggered the runner E2E: a `-cbm-` index scope ran for the first time (previously only ever `-gitnexus-`), completed **clean** (`index.supervisor.reap outcome=clean exit_code=0 signal=0`, `"status":"indexed"`), built a **35,035-node / 217,967-edge** graph, and wrote `.codebase-memory/graph.db.zst`. **No OOM** under the 2G scope cap.

## Deploy

Runtime unit-template change — reaches existing installs on the next `git pull` + `update.sh` (which re-renders units + `daemon-reload`); fresh clones get it at bootstrap. Generalizable: fixes any install whose cbm lands in `~/.local/bin` (the vendor default).

## Regression marker

If `genesis-code-intel.service` ever logs `rc=3 "cbm missing from PATH"` again, or the runner re-escalates "first full cbm index due" indefinitely, the PATH regressed. The new test blocks that at CI.

Related: surfaced while running the `251ee0dd` cold-index diagnostic. The 2G-cap-under-cold-CBM question that follow-up tracks is now testable for real (it was previously moot — cbm never ran); fast-mode cold index is clean, full-mode re-check tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
