### PR TITLE
feat(dashboard): distinct "needs action" chip state for pending approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   normal in-flight worklist the background drainer churns through.
   The API Keys "N ok / M" tally is also correct now (it previously double-
   counted local providers, so the numbers didn't add up).
+- **The Ego card says "needs action" instead of "degraded" when approvals are
+  waiting.** Pending ego proposals are a review queue awaiting you, not a system
+  fault — so the card no longer paints itself amber-degraded when more than a
+  handful pile up. It shows a distinct "needs action" state (its own accent
+  colour and ◆ glyph), and pending approvals no longer drag the overall
+  dashboard health to "degraded" — they ride along as a note on an otherwise
+  healthy system.
 - **Provisioning approvals can be retried, and never race each other.** A
   grow/limits approval prompt that timed out unanswered used to silently block
   every retry for 24 hours (the generic outreach dedup window treated the

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -449,8 +449,8 @@
                 </div>
               </div>
               <div class="health-card-reason"
-                   :style="$store.genesisDashboard.egoSemantic().reason?.includes('proposals awaiting') ? 'cursor:pointer; text-decoration:underline;' : ''"
-                   @click="if ($store.genesisDashboard.egoSemantic().reason?.includes('proposals awaiting')) { location.hash = 'chat'; $store.genesisDashboard.commsTab = 'proposals'; $store.genesisDashboard.commsProposalFilter = 'pending'; $store.genesisDashboard.fetchComms(); }"
+                   :style="$store.genesisDashboard.egoSemantic().state === 'needs action' ? 'cursor:pointer; text-decoration:underline;' : ''"
+                   @click="if ($store.genesisDashboard.egoSemantic().state === 'needs action') { location.hash = 'chat'; $store.genesisDashboard.commsTab = 'proposals'; $store.genesisDashboard.commsProposalFilter = 'pending'; $store.genesisDashboard.fetchComms(); }"
                    x-text="$store.genesisDashboard.egoSemantic().reason"></div>
             </div>
           </template>

--- a/src/genesis/dashboard/webui/css/components.css
+++ b/src/genesis/dashboard/webui/css/components.css
@@ -40,6 +40,9 @@
  * informational/neutral chips applied via static class, e.g. count badges. */
 .chip--info  { color: var(--info);  background: color-mix(in srgb, var(--info-dim) 45%, transparent);  border-color: var(--info-dim); }
 .chip--stale { color: var(--stale); background: color-mix(in srgb, var(--stale) 12%, transparent);     border-color: color-mix(in srgb, var(--stale) 35%, transparent); }
+/* chip--action = "needs your action" (e.g. pending approvals). Reuses the
+ * ego/cognitive accent so it reads as attention, not fault (warn) or fine (ok). */
+.chip--action { color: var(--accent); background: color-mix(in srgb, var(--accent) 18%, transparent); border-color: color-mix(in srgb, var(--accent) 42%, transparent); }
 .chip--off   { color: var(--t3);    background: transparent;                                           border-color: var(--border); }
 
 /* ── Skeleton shimmer (loading placeholder) ──────────────────────────────

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3185,7 +3185,7 @@
           // chipState() the chips use, so the two surfaces can never disagree
           // about what a state means. Values match the token palette
           // (--ok/--warn/--err); off/idle/unknown keep the historical dot gray.
-          const colors = { ok: "#4caf50", warn: "#f0ad4e", err: "#d9534f", stale: "#9e9e9e", off: "#888" };
+          const colors = { ok: "#4caf50", warn: "#f0ad4e", err: "#d9534f", stale: "#9e9e9e", action: "#7c4dff", off: "#888" };
           return colors[chipState(state)] || "#888";
         },
 
@@ -3368,9 +3368,11 @@
             const which = ueCad?.is_paused ? "CEO" : "COO";
             return { state: "degraded", reason: `${which} paused` };
           }
-          // Proposals piling up
+          // Proposals piling up: this is a review queue awaiting the user, not
+          // a fault. Surface it as "needs action" (distinct from degraded) so it
+          // reads as a to-do, not a system problem.
           if (ego.pending_proposals > 5) {
-            return { state: "degraded", reason: `${ego.pending_proposals} proposals awaiting review` };
+            return { state: "needs action", reason: `${ego.pending_proposals} pending approvals — needs action` };
           }
           return { state: "healthy", reason: ego.focus_summary || "ego active" };
         },
@@ -3572,18 +3574,23 @@
           const hasError = checks.some(c => c.state === "error");
           const hasDegraded = checks.some(c => c.state === "degraded" || c.state === "fallback");
           const hasUnknown = checks.some(c => c.state === "unknown");
+          // "needs action" is not a fault — it means Genesis is waiting on the
+          // user (e.g. pending approvals). It NEVER degrades overall health; it
+          // rides along as an appended note on whatever the real status is.
+          const actionReasons = checks.filter(c => c.state === "needs action").map(c => c.reason);
+          const actionNote = actionReasons.length ? ` · ${actionReasons.join("; ")}` : "";
           if (hasError) {
             const reasons = checks.filter(c => c.state === "error").map(c => c.reason);
-            return { state: "error", reason: reasons.join("; ") };
+            return { state: "error", reason: reasons.join("; ") + actionNote };
           }
           if (hasDegraded) {
             const reasons = checks.filter(c => c.state === "degraded" || c.state === "fallback").map(c => c.reason);
-            return { state: "degraded", reason: reasons.join("; ") };
+            return { state: "degraded", reason: reasons.join("; ") + actionNote };
           }
           if (hasUnknown) {
-            return { state: "unknown", reason: "some subsystems have unknown status" };
+            return { state: "unknown", reason: "some subsystems have unknown status" + actionNote };
           }
-          return { state: "healthy", reason: "all core subsystems operational" };
+          return { state: "healthy", reason: "all core subsystems operational" + actionNote };
         },
 
         routingSemantic() {

--- a/src/genesis/dashboard/webui/js/ui-utils.js
+++ b/src/genesis/dashboard/webui/js/ui-utils.js
@@ -47,6 +47,10 @@ export function chipState(health, lastRun = null, nowMs = Date.now()) {
   // "idle"/"unknown" render neutral-gray today (semanticStateColor #888) — keep
   // that meaning: quiet, not alarming.
   if (["off", "disabled", "inactive", "paused", "idle", "unknown"].includes(h)) return "off";
+  // "needs action" — Genesis is waiting on a user decision (e.g. pending
+  // approvals). Not a fault and not neutral-quiet: its own visible state so it
+  // never masquerades as degraded (a fault) or healthy (nothing to do).
+  if (["needs action", "action", "attention"].includes(h)) return "action";
   return "warn"; // genuinely novel health value: surface it, don't hide it
 }
 
@@ -59,7 +63,7 @@ export function chipClass(state) {
  * ("info" is not a health state — chipState never returns it — but chips
  * using .chip--info via static class can still ask for its glyph.) */
 export function chipGlyph(state) {
-  return { ok: "●", warn: "▲", err: "✕", stale: "◔", info: "ℹ", off: "○" }[state] ?? "●";
+  return { ok: "●", warn: "▲", err: "✕", stale: "◔", info: "ℹ", action: "◆", off: "○" }[state] ?? "●";
 }
 
 function _toMs(ts) {


### PR DESCRIPTION
## What

The Ego card painted itself **degraded** (a fault colour) whenever more than a handful of ego proposals were pending review. But a pending-approval queue is a *to-do awaiting the user*, not a system fault. This adds a distinct **"needs action"** chip state.

- `ui-utils.js` — `chipState` maps `needs action` / `action` / `attention` → a new `action` bucket (novel values still fail loud → `warn`); `chipGlyph` adds `◆`.
- `components.css` — `.chip--action` reuses the existing `--accent` (ego/cognitive purple) via `color-mix` (no new token); `semanticStateColor` adds the dot colour.
- `egoSemantic` — returns `needs action` (keeps the `>5` trigger, per plan decision); fault branches (circuit-open → error, paused → degraded) unchanged.
- `overallHealthSemantic` — treats `needs action` as **non-degrading**: pending approvals never turn overall dashboard health amber; they ride along as an appended note.

## Why

Pending approvals were mislabelled as degradation — training the eye to read the amber card as "something is broken" when nothing is. Scope is Ego-only (the auto-drained adjudication panel is not awaiting the user; discarded items stay a genuine error).

## Verification

Node harness imports the **real** `ui-utils.js` and asserts `chipState('needs action')→action`, glyph `◆`, all existing states unchanged, novel→warn, and the 7-day stale-override; plus `overallHealthSemantic` (needs-action never degrades; error/degraded precedence + note append) — **14/14 pass**. Both JS files parse clean as ES modules. Full browser E2E after merge (the live Ego card has 8 pending, which exercises the new state).

Part of the dashboard health-honesty effort (PR-2 of 3); ledger 8d00aa825aeb4931b05ee8bccc2cca5e (completion marker on PR-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)