### PR TITLE
chore(routing,db): drop keyless minimax-m25 from chains + purge infra-monitor fossil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   colour and ◆ glyph), and pending approvals no longer drag the overall
   dashboard health to "degraded" — they ride along as a note on an otherwise
   healthy system.
+- **A long-retired background job no longer haunts the job-health view.** The
+  infra-monitor job was replaced months ago, but its stale record lingered and
+  showed as a perpetually-"healthy" job (the staleness check only catches jobs
+  that run-but-fail, not ones that stopped running entirely). Its fossil record
+  is now purged on upgrade.
 - **Provisioning approvals can be retried, and never race each other.** A
   grow/limits approval prompt that timed out unanswered used to silently block
   every retry for 24 hours (the generic outreach dedup window treated the

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -446,7 +446,6 @@ call_sites:
   27_pre_execution_assessment:
     chain:
     - glm51
-    - minimax-m25
     - openrouter-deepseek-v4-flash
     default_paid: true
     retry_profile: user_facing
@@ -455,7 +454,6 @@ call_sites:
   # (awareness/loop.py:perform_tick). Kept as historical; no live consumers.
   28_observation_sweep:
     chain:
-    - minimax-m25
     - openrouter-deepseek-v4-flash
     - glm51
     - groq-free

--- a/src/genesis/db/data_migrations/d0004_purge_retired_job_health.py
+++ b/src/genesis/db/data_migrations/d0004_purge_retired_job_health.py
@@ -1,0 +1,74 @@
+"""d0004 — purge job_health rows for jobs whose registration was removed.
+
+A retired scheduled job leaves its ``job_health`` row behind forever:
+nothing deletes ``job_health`` rows on retirement, and the staleness
+annotator (``mcp/health/manifest.py::_annotate_staleness``) measures the
+``last_run − last_success`` gap — which stays 0 for a job that STOPPED
+FIRING entirely (its ``last_run`` freezes). So the fossil row renders as a
+perpetually-healthy job in ``job_health`` / the dashboard.
+
+``schedule_infra_monitor`` is the observed case: its registration and method
+were removed in #147 (superseded by ``infra_profile_refresh`` +
+``awareness/loop.py::_check_infra_protection_posture``), yet its row (last
+run 2026-04) still reports ``stale: false``.
+
+ONLY jobs whose CODE is gone are purged here (verified by grep: zero
+registration refs). A dormant-but-registered job (``build_lane_poll``) or a
+disabled-module pipeline row (``pipeline:<profile>``, whose module still
+exists and re-registers when enabled) is NOT a fossil and keeps its row.
+The general "registered job silently stopped firing" detector — which needs
+the live APScheduler registry, unavailable to a post-boot migration — is
+tracked separately, not built here.
+
+migrate()/verify() are SYNC (framework contract, cf. d0001/d0002); own
+connections only — never the runtime's async ``rt._db``. Idempotent: the
+DELETE is a no-op once purged and on a fresh install (no such row).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from genesis.env import genesis_db_path
+
+requires_operator = False
+
+# Job names whose registration has been REMOVED from the codebase. Extend
+# ONLY with jobs whose code is gone (grep-verified: no add_job/registration
+# ref) — never a merely-dormant but still-registered job.
+_RETIRED_JOBS = (
+    "schedule_infra_monitor",  # removed in #147 → infra_profile_refresh + posture check
+)
+
+
+def _placeholders() -> str:
+    return ",".join("?" * len(_RETIRED_JOBS))
+
+
+def migrate() -> dict:
+    """Delete job_health rows for every job in _RETIRED_JOBS; return purge count."""
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    try:
+        cur = db.execute(
+            # noqa string interpolates only `?` placeholders; values stay
+            # parameterized and _RETIRED_JOBS is a module constant of literals.
+            f"DELETE FROM job_health WHERE job_name IN ({_placeholders()})",  # noqa: S608
+            _RETIRED_JOBS,
+        )
+        db.commit()
+        return {"purged": cur.rowcount}
+    finally:
+        db.close()
+
+
+def verify() -> bool:
+    """Complete when no retired job name remains in job_health."""
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        row = db.execute(
+            f"SELECT COUNT(*) FROM job_health WHERE job_name IN ({_placeholders()})",  # noqa: S608
+            _RETIRED_JOBS,
+        ).fetchone()
+        return row[0] == 0
+    finally:
+        db.close()

--- a/tests/test_db/test_d0004_purge_retired_job_health.py
+++ b/tests/test_db/test_d0004_purge_retired_job_health.py
@@ -1,0 +1,75 @@
+"""d0004 — purge job_health rows for jobs whose registration was removed.
+
+Only the code-removed fossil (schedule_infra_monitor, gone in #147) is
+purged; a live/dormant-but-registered job keeps its row. Idempotent, and a
+no-op on a fresh install (no such row).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import genesis.db.data_migrations.d0004_purge_retired_job_health as d0004
+
+
+def _seed_db(path, *, with_fossil: bool = True) -> None:
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE job_health (job_name TEXT PRIMARY KEY, last_run TEXT, "
+        "last_success TEXT, last_failure TEXT, last_error TEXT, "
+        "consecutive_failures INTEGER DEFAULT 0, total_runs INTEGER DEFAULT 0, "
+        "total_successes INTEGER DEFAULT 0, total_failures INTEGER DEFAULT 0, "
+        "updated_at TEXT)"
+    )
+    rows = [
+        # live/dormant-but-registered jobs — MUST survive
+        ("build_lane_poll", "2026-07-07T19:10:03Z"),
+        ("infra_profile_refresh", "2026-07-18T10:20:02Z"),
+        ("pipeline:prediction-markets", "2026-03-22T21:55:20Z"),
+    ]
+    if with_fossil:
+        rows.append(("schedule_infra_monitor", "2026-04-25T15:42:49Z"))
+    db.executemany("INSERT INTO job_health (job_name, last_run) VALUES (?, ?)", rows)
+    db.commit()
+    db.close()
+
+
+def test_purges_only_the_retired_fossil(tmp_path, monkeypatch):
+    db_path = tmp_path / "genesis.db"
+    _seed_db(db_path)
+    monkeypatch.setattr(d0004, "genesis_db_path", lambda: str(db_path))
+
+    assert d0004.verify() is False
+    assert d0004.migrate() == {"purged": 1}
+    assert d0004.verify() is True
+
+    db = sqlite3.connect(db_path)
+    remaining = {r[0] for r in db.execute("SELECT job_name FROM job_health").fetchall()}
+    db.close()
+    # the fossil is gone; every live/dormant-but-registered row survives
+    assert "schedule_infra_monitor" not in remaining
+    assert remaining == {
+        "build_lane_poll",
+        "infra_profile_refresh",
+        "pipeline:prediction-markets",
+    }
+
+
+def test_migrate_is_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "genesis.db"
+    _seed_db(db_path)
+    monkeypatch.setattr(d0004, "genesis_db_path", lambda: str(db_path))
+
+    assert d0004.migrate() == {"purged": 1}
+    assert d0004.migrate() == {"purged": 0}
+    assert d0004.verify() is True
+
+
+def test_fresh_install_no_fossil_is_noop(tmp_path, monkeypatch):
+    """Empty-state: an install that never ran the retired job purges nothing."""
+    db_path = tmp_path / "genesis.db"
+    _seed_db(db_path, with_fossil=False)
+    monkeypatch.setattr(d0004, "genesis_db_path", lambda: str(db_path))
+
+    assert d0004.verify() is True  # already clean
+    assert d0004.migrate() == {"purged": 0}


### PR DESCRIPTION
## What

Two small hygiene items closing out the dashboard health-honesty effort.

**WS-D — routing config truthfulness** (`config/model_routing.yaml`): the keyless `minimax-m25` provider sat as a chain entry in `27_pre_execution_assessment` (live: executor review + decomposer) and was the primary of `28_observation_sweep` (dead — no router consumers; "no live consumers" per its own comment). Removed from both chains. **Behaviour-preserving** — a keyless provider is already skipped at runtime, so this only stops the config from claiming a provider it can't use. The provider *definition* stays (now 0 chain refs → grades `dormant`, emits no alert; a key can be added later).

**WS-E — purge the infra-monitor fossil** (data migration `d0004`): `schedule_infra_monitor`'s registration + method were removed in #147 (superseded by `infra_profile_refresh` + `awareness/loop.py::_check_infra_protection_posture`), but its `job_health` row lingered. The staleness annotator measures `last_run − last_success`, which stays `0` for a job that **stopped firing entirely** — so the fossil rendered as a perpetually-`healthy` job. `d0004` purges it (idempotent; no-op on fresh installs).

Only the **code-removed** job is purged. Dormant-but-registered jobs (`build_lane_poll`, 6 refs) and disabled-module pipeline rows (`pipeline:<profile>` — the modules still exist and re-register when enabled) are deliberately left intact. The general "registered job silently stopped firing" detector needs the live APScheduler registry (unavailable to a post-boot migration) and is tracked as a follow-up, not built here.

## Verification

`d0004` test — purges only the fossil, preserves live/dormant rows, idempotent, no-op empty-state (3 pass); data-migration runner discovers it with no prefix collision (13 pass); `model_routing.yaml` parses with both chains stripped and the provider def retained; `ruff` clean.

**Deploy:** needs a `genesis-server` restart — the routing config loads at startup and the migration runs post-boot. I'll restart + verify (migration purged the row; routing loaded) as part of E2E.

Completes the dashboard health-honesty effort (PR-3 of 3).
Ledger: 8d00aa825aeb4931b05ee8bccc2cca5e

🤖 Generated with [Claude Code](https://claude.com/claude-code)