### PR TITLE
feat(ledger): WS-2 P2a — mechanical grader closes the predict→grade loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Those predictions now get graded.** A mechanical grader runs twice daily
+  and settles every prediction whose deadline has passed — reading the actual
+  outcome straight from the system's own records (did the reply arrive, did the
+  task complete, did the job run clean), with zero LLM calls on that path. Each
+  prediction gets a real accuracy score, so the system's confidence starts
+  being measured against what actually happened instead of never being checked.
+  A prediction that references a metric no longer in the code, or whose grader
+  hits an error, surfaces as a health alert rather than silently rotting.
+
 - **Every significant action now commits with a falsifiable prediction.**
   Outreach sends, autonomous task claims, build-lane verdicts, and ego
   proposals each write their prediction rows the moment they commit — code

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -652,7 +652,7 @@ Self-improvement loops and the instrumentation that keeps them honest.
 ```yaml subsystem-map
 entry: learning-evaluation
 modules: [learning, eval, experimentation, feedback, calibration, ledger]
-verified: fe5d0945 2026-07-10
+verified: 1828ee2f 2026-07-18
 ```
 
 - **learning/** is the de-facto cron host: `rt._learning_scheduler` registers
@@ -732,8 +732,18 @@ verified: fe5d0945 2026-07-10
   0.5) and stated-confidence seams (`OutreachRequest.stated_confidence`;
   `task_submit` optional field → outputs JSON envelope). Hook failures
   increment a counter surfaced as `ledger:write_failed:<class>` via
-  `_compute_alerts` (never block the action). Grader = P2 (read side still
-  dark). Outreach metrics resolve off `outreach_history.engagement_signal`
+  `_compute_alerts` (never block the action). **Grader LIVE (P2a)**:
+  `ledger/grader.py` runs twice daily (`ledger_grader` 6:15/18:15, env
+  kill-switch `GENESIS_LEDGER_GRADER_DISABLED`) — mechanically resolves due
+  predictions (`list_due_open`) by running each metric's resolver, mapping
+  keyed on `outcome_value` (non-None ⟺ `resolved`), and writing outcome+Brier
+  through the CRUD's idempotent `resolve()`; ZERO LLM calls (own no-`routing`
+  import lock). Registry drift / resolver faults alarm
+  `ledger:metric_vanished:<class>` / `ledger:grade_failed:<class>` via the same
+  counter→`_compute_alerts` path. The autonomy-evidence rewire (demote the LLM
+  self-grade feed) and calibration-cell aggregation are later PRs; the fuzzy
+  LLM-fallback lane is deferred (no `acceptance_pass` writer yet). Outreach
+  metrics resolve off `outreach_history.engagement_signal`
   (spike-measured 99.5% mechanical); the engagement_outcome CHECK now
   ENFORCES the canonical vocabulary (rebuild #4 in the
   `_migrate_add_columns` chain — its DDL must preserve the three older

--- a/src/genesis/ledger/grader.py
+++ b/src/genesis/ledger/grader.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from genesis.db.crud import ledger_predictions as lp_crud
@@ -157,8 +157,13 @@ async def grade_due_predictions(
     """Grade every open prediction whose deadline has passed. Idempotent.
 
     ``now`` is injectable for tests (also threaded into ``list_due_open`` and
-    each resolver so a single frozen clock drives the whole pass).
+    each resolver so a single frozen clock drives the whole pass). Default it
+    HERE — the production call site passes none, and the resolvers'
+    ``_past_deadline`` check does ``now >= deadline`` with no fallback, so a
+    ``None`` would TypeError every absence-path row into ``grade_failed``
+    instead of resolving it.
     """
+    now = now or datetime.now(UTC)
     report = GradeReport()
     rows = await lp_crud.list_due_open(db, now=now, limit=limit)
     report.scanned = len(rows)

--- a/src/genesis/ledger/grader.py
+++ b/src/genesis/ledger/grader.py
@@ -1,0 +1,196 @@
+"""WS-2 Cognitive Ledger — the mechanical grader (P2).
+
+Reads open predictions whose deadline has passed, runs the registered
+``resolver_fn`` for each (pure SQL/Python over evidence tables — ZERO LLM
+calls, enforced by ``test_no_llm_import_path``), and writes the mechanical
+grade through ``ledger_predictions.resolve``. This closes the loop the
+proto-ledger never did: predictions stop rotting ungraded.
+
+Mapping is keyed on ``outcome_value`` FIRST — the invariant across all nine
+resolvers (``metrics.py``) is that ``outcome_value`` is non-None **iff** the
+row is ``resolved``; every None-outcome return is ``open`` / ``unresolvable:*``
+/ ``void:*`` / ``fuzzy_pending``. Keying on the lane instead would risk calling
+``resolve('resolved', outcome_value=None)``, which the CRUD's scored-status
+guard rejects.
+
+The one fuzzy metric (``acceptance_pass``) is parked as ``fuzzy_pending`` here;
+the bounded LLM fallback that drains it is a separate module/job, deferred
+until any ``acceptance_pass`` prediction is actually written (no writer emits
+one in v1). Keeping the fallback out of this module is what lets the no-LLM
+import lock hold.
+
+Alarm surface mirrors ``ledger/writers.py``: registry-vanished metrics
+(schema-vs-code drift) and resolver exceptions bump per-class process counters
+read by ``mcp/health/errors._compute_alerts`` → the M10 awareness-tick
+``alert_events`` writer. Resolver-returned ``void:*`` / ``unresolvable:*`` are
+recorded in the report but do NOT alarm — they are normal grading outcomes
+(premise absent / subject row deleted), not code faults.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from genesis.db.crud import ledger_predictions as lp_crud
+from genesis.ledger.metrics import REGISTRY
+
+logger = logging.getLogger(__name__)
+
+# ── Per-class grader alarm counters (process-global, mirror writers.py:60) ────
+# Nonzero in the runtime process surfaces as ledger:metric_vanished:<class> /
+# ledger:grade_failed:<class> via _compute_alerts. Restart resets them; the
+# durable trail is the alert_events row the awareness tick persisted while the
+# counter was nonzero. The health-MCP process always reads zero (read-only),
+# consistent with the single-designated-writer rule.
+_metric_vanished: Counter[str] = Counter()
+_grade_failed: Counter[str] = Counter()
+
+
+def grade_failure_counts() -> dict[str, dict[str, int]]:
+    """Grader alarm counters since process start.
+
+    ``{'metric_vanished': {<action_class>: n}, 'grade_failed': {<action_class>: n}}``.
+    """
+    return {
+        "metric_vanished": dict(_metric_vanished),
+        "grade_failed": dict(_grade_failed),
+    }
+
+
+def _reset_grade_failure_counts_for_tests() -> None:
+    _metric_vanished.clear()
+    _grade_failed.clear()
+
+
+@dataclass
+class GradeReport:
+    """One grading pass, tallied for the job log + the coverage falsifier."""
+
+    scanned: int = 0
+    resolved: int = 0
+    mechanical: int = 0  # resolved via a mechanical rule (evidence present)
+    absence: int = 0  # resolved via mechanical_absence (silence past deadline)
+    void: int = 0
+    unresolvable: int = 0
+    fuzzy_pending: int = 0
+    left_open: int = 0
+    per_class: dict[str, Counter[str]] = field(default_factory=dict)
+
+    def _bump(self, action_class: str, kind: str) -> None:
+        self.per_class.setdefault(action_class, Counter())[kind] += 1
+
+    def mechanical_share(self) -> float | None:
+        """Fraction of graded (non-void) rows resolved mechanically — the §7
+        falsifier watches this (<70% over 2 weeks ⇒ redesign the registry)."""
+        graded = self.mechanical + self.absence
+        denom = graded + self.fuzzy_pending
+        return graded / denom if denom else None
+
+    def summary(self) -> str:
+        share = self.mechanical_share()
+        share_s = f"{share:.2f}" if share is not None else "n/a"
+        return (
+            f"scanned={self.scanned} resolved={self.resolved} "
+            f"(mechanical={self.mechanical} absence={self.absence}) "
+            f"void={self.void} unresolvable={self.unresolvable} "
+            f"fuzzy_pending={self.fuzzy_pending} left_open={self.left_open} "
+            f"mechanical_share={share_s}"
+        )
+
+
+async def _apply(db: Any, row: dict, res, report: GradeReport, *, now: datetime | None) -> None:
+    """Translate one :class:`Resolution` into a ``resolve()`` call.
+
+    Keyed on ``outcome_value`` first (the resolved-iff-non-None invariant),
+    then the lane for the None-outcome dispositions.
+    """
+    action_class = row["action_class"]
+    if res.outcome_value is not None:
+        resolver = "mechanical_absence" if res.lane == "mechanical_absence" else "mechanical"
+        changed = await lp_crud.resolve(
+            db,
+            row["id"],
+            status="resolved",
+            outcome_value=res.outcome_value,
+            resolver=resolver,
+            evidence_ref=res.evidence_ref,
+            now=now,
+        )
+        if changed:
+            report.resolved += 1
+            if resolver == "mechanical_absence":
+                report.absence += 1
+            else:
+                report.mechanical += 1
+            report._bump(action_class, f"resolved:{res.lane}")
+        return
+
+    lane = res.lane
+    if lane.startswith("void"):
+        if await lp_crud.resolve(db, row["id"], status="void", now=now):
+            report.void += 1
+            report._bump(action_class, lane)
+    elif lane.startswith("unresolvable"):
+        if await lp_crud.resolve(db, row["id"], status="unresolvable", now=now):
+            report.unresolvable += 1
+            report._bump(action_class, lane)
+    elif lane == "fuzzy_pending":
+        if await lp_crud.resolve(db, row["id"], status="fuzzy_pending", now=now):
+            report.fuzzy_pending += 1
+            report._bump(action_class, lane)
+    else:
+        # lane == "open": the resolver judged the deadline not actually past —
+        # a canonicalization edge vs list_due_open's filter that should not
+        # occur. Leave the row open, count it (a persistent nonzero here is a
+        # clock/canonicalization bug worth noticing in the report).
+        report.left_open += 1
+        report._bump(action_class, "left_open")
+
+
+async def grade_due_predictions(
+    db: Any, *, now: datetime | None = None, limit: int = 500
+) -> GradeReport:
+    """Grade every open prediction whose deadline has passed. Idempotent.
+
+    ``now`` is injectable for tests (also threaded into ``list_due_open`` and
+    each resolver so a single frozen clock drives the whole pass).
+    """
+    report = GradeReport()
+    rows = await lp_crud.list_due_open(db, now=now, limit=limit)
+    report.scanned = len(rows)
+    for row in rows:
+        action_class = row["action_class"]
+        metric = row["metric"]
+        spec = REGISTRY.get(metric)
+        if spec is None:
+            # Gate 3: the metric vanished from the registry (a code rollback).
+            # Never silently skip — mark unresolvable and alarm (schema-vs-code
+            # drift sensor).
+            _metric_vanished[action_class] += 1
+            if await lp_crud.resolve(db, row["id"], status="unresolvable", now=now):
+                report.unresolvable += 1
+                report._bump(action_class, "unresolvable:metric_vanished")
+            continue
+        try:
+            res = await spec.resolver_fn(db, row, now=now)
+        except Exception:
+            # A resolver must never abort the batch: count it, leave the row
+            # open, move on. logger.error (not debug) — a raising resolver is a
+            # real bug, surfaced as ledger:grade_failed:<class>.
+            _grade_failed[action_class] += 1
+            logger.error(
+                "ledger resolver raised for %s/%s (row %s) — left open",
+                action_class,
+                metric,
+                row["id"],
+                exc_info=True,
+            )
+            report.left_open += 1
+            report._bump(action_class, "grade_failed")
+            continue
+        await _apply(db, row, res, report, now=now)
+    return report

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -37,13 +37,15 @@ async def _impl_health_errors(
             items = await dl_crud.query_pending(_service._db)
             for item in items:
                 if item.get("created_at", "") >= cutoff:
-                    errors.append({
-                        "type": "dead_letter",
-                        "provider": item.get("target_provider", "unknown"),
-                        "reason": item.get("failure_reason", ""),
-                        "operation": item.get("operation_type", ""),
-                        "timestamp": item.get("created_at", ""),
-                    })
+                    errors.append(
+                        {
+                            "type": "dead_letter",
+                            "provider": item.get("target_provider", "unknown"),
+                            "reason": item.get("failure_reason", ""),
+                            "operation": item.get("operation_type", ""),
+                            "timestamp": item.get("created_at", ""),
+                        }
+                    )
         except Exception:
             logger.error("Failed to query dead letter errors", exc_info=True)
 
@@ -54,16 +56,19 @@ async def _impl_health_errors(
             try:
                 cb = _service._breakers.get(name)
                 if cb.state == ProviderState.OPEN:
-                    errors.append({
-                        "type": "circuit_breaker_open",
-                        "provider": name,
-                        "reason": "Circuit breaker tripped",
-                        "failures": cb.consecutive_failures,
-                    })
+                    errors.append(
+                        {
+                            "type": "circuit_breaker_open",
+                            "provider": name,
+                            "reason": "Circuit breaker tripped",
+                            "failures": cb.consecutive_failures,
+                        }
+                    )
             except Exception:
                 logger.error(
                     "Circuit breaker state check failed for provider %s",
-                    name, exc_info=True,
+                    name,
+                    exc_info=True,
                 )
 
     from datetime import timedelta as _td
@@ -82,21 +87,25 @@ async def _impl_health_errors(
                 limit=50,
             )
             for sev in ("error", "critical"):
-                db_rows.extend(await events_crud.query(
-                    _service._db,
-                    severity=sev,
-                    since=cutoff,
-                    limit=50,
-                ))
+                db_rows.extend(
+                    await events_crud.query(
+                        _service._db,
+                        severity=sev,
+                        since=cutoff,
+                        limit=50,
+                    )
+                )
             for row in db_rows:
-                errors.append({
-                    "type": "event_bus",
-                    "subsystem": row.get("subsystem", ""),
-                    "event_type": row.get("event_type", ""),
-                    "severity": row.get("severity", ""),
-                    "message": row.get("message", ""),
-                    "timestamp": row.get("timestamp", ""),
-                })
+                errors.append(
+                    {
+                        "type": "event_bus",
+                        "subsystem": row.get("subsystem", ""),
+                        "event_type": row.get("event_type", ""),
+                        "severity": row.get("severity", ""),
+                        "message": row.get("message", ""),
+                        "timestamp": row.get("timestamp", ""),
+                    }
+                )
             db_events_loaded = True
         except Exception:
             logger.error("Event log query failed", exc_info=True)
@@ -106,14 +115,16 @@ async def _impl_health_errors(
 
         for event in _event_bus.recent_events(min_severity=Severity.WARNING, limit=50):
             if event.timestamp >= cutoff:
-                errors.append({
-                    "type": "event_bus",
-                    "subsystem": event.subsystem.value,
-                    "event_type": event.event_type,
-                    "severity": event.severity.value,
-                    "message": event.message,
-                    "timestamp": event.timestamp,
-                })
+                errors.append(
+                    {
+                        "type": "event_bus",
+                        "subsystem": event.subsystem.value,
+                        "event_type": event.event_type,
+                        "severity": event.severity.value,
+                        "message": event.message,
+                        "timestamp": event.timestamp,
+                    }
+                )
 
     if pattern_group and errors:
         grouped: dict[str, dict] = {}
@@ -187,7 +198,6 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     _activity_tracker = health_mcp_mod._activity_tracker
     _job_retry_registry = health_mcp_mod._job_retry_registry
 
-
     # WS-2 P1b: ledger writer-hook failures — checked BEFORE the
     # uninitialized-service early return because the counter needs no health
     # snapshot (and a dropping commit path must surface even then). The
@@ -203,21 +213,69 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         for action_class, count in sorted(write_failure_counts().items()):
             if count > 0:
                 alert_id = f"ledger:write_failed:{action_class}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": (
-                        f"{count} ledger prediction write(s) failed for "
-                        f"{action_class} since process start — the commit-path "
-                        "hook is dropping predictions (coverage gap)"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"{count} ledger prediction write(s) failed for "
+                            f"{action_class} since process start — the commit-path "
+                            "hook is dropping predictions (coverage gap)"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
     except Exception:
         logger.debug("ledger write-failure alert check failed", exc_info=True)
 
+    # WS-2 P2: ledger grader alarms — registry-vanished metrics (schema-vs-code
+    # drift) and resolver exceptions. Same per-process counter contract as the
+    # writer-hook alarm above; checked before the uninitialized-service return.
+    try:
+        from genesis.ledger.grader import grade_failure_counts
+
+        _gfc = grade_failure_counts()
+        for action_class, count in sorted(_gfc["metric_vanished"].items()):
+            if count > 0:
+                alert_id = f"ledger:metric_vanished:{action_class}"
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"{count} {action_class} prediction(s) reference a metric "
+                            "no longer in the ledger registry — the grader marked "
+                            "them unresolvable (schema-vs-code drift)"
+                        ),
+                    }
+                )
+                current_ids.add(alert_id)
+        for action_class, count in sorted(_gfc["grade_failed"].items()):
+            if count > 0:
+                alert_id = f"ledger:grade_failed:{action_class}"
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"{count} {action_class} prediction(s) raised in their "
+                            "resolver during grading — left open (grader bug or "
+                            "malformed evidence)"
+                        ),
+                    }
+                )
+                current_ids.add(alert_id)
+    except Exception:
+        logger.debug("ledger grade-failure alert check failed", exc_info=True)
+
     if _service is None:
-        alerts.append({"id": "service:health_data_uninitialized", "severity": "CRITICAL", "message": "HealthDataService not initialized"})
+        alerts.append(
+            {
+                "id": "service:health_data_uninitialized",
+                "severity": "CRITICAL",
+                "message": "HealthDataService not initialized",
+            }
+        )
         return alerts, current_ids
 
     snap = await _service.snapshot()
@@ -254,19 +312,23 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             # The Sentinel has no remediation path for external providers;
             # circuit breakers auto-reset. Emit WARNING (→ Tier 3, reflexes
             # only) instead of CRITICAL (→ Tier 2, wakes Sentinel).
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Call site {site_id} is DOWN (all providers exhausted)",
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Call site {site_id} is DOWN (all providers exhausted)",
+                }
+            )
             current_ids.add(alert_id)
         elif status_val == "degraded":
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Call site {site_id} is degraded (using fallback provider)",
-                "active_provider": site_info.get("active_provider"),
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Call site {site_id} is degraded (using fallback provider)",
+                    "active_provider": site_info.get("active_provider"),
+                }
+            )
             current_ids.add(alert_id)
 
     queues = snap.get("queues", {})
@@ -282,8 +344,12 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     # broken drain still surfaces. `deferred_work`/`deferred_worklist` stay in the
     # snapshot for honest display but are not depth-alarmed here.
     _QUEUE_DEPTH_FIELDS = {
-        "pending_embeddings", "dead_letters", "deferred_recovery",
-        "deferred_processing", "deferred_stuck", "failed_embeddings",
+        "pending_embeddings",
+        "dead_letters",
+        "deferred_recovery",
+        "deferred_processing",
+        "deferred_stuck",
+        "failed_embeddings",
         "discarded_count",
     }
     for queue_name, depth in queues.items():
@@ -291,22 +357,26 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             continue
         if isinstance(depth, int) and depth > 100:
             alert_id = f"queue:{queue_name}"
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"Queue {queue_name} depth is {depth} (>100)",
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"Queue {queue_name} depth is {depth} (>100)",
+                }
+            )
             current_ids.add(alert_id)
 
     cc = snap.get("cc_sessions", {})
     bg = cc.get("background", {})
     if bg.get("status") in ("throttled", "rate_limited"):
         alert_id = "cc:budget"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"CC sessions {bg['status']} (budget: {bg.get('hourly_budget', '?')})",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"CC sessions {bg['status']} (budget: {bg.get('hourly_budget', '?')})",
+            }
+        )
         current_ids.add(alert_id)
 
     # CC rate-limit / unavailability alert.
@@ -341,43 +411,51 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             )
         else:
             alert_id = "cc:quota_exhausted"
-            alerts.append({
-                "id": alert_id,
-                "severity": "WARNING",
-                "message": f"CC {cc_realtime.lower().replace('_', ' ')} — contingency mode active",
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": f"CC {cc_realtime.lower().replace('_', ' ')} — contingency mode active",
+                }
+            )
             current_ids.add(alert_id)
 
     awareness = snap.get("awareness", {})
     tick_age = awareness.get("time_since_last_tick_seconds")
     if tick_age is not None and tick_age > 360:
         alert_id = "awareness:tick_overdue"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"Awareness tick overdue by {int(tick_age)}s (>360s threshold)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"Awareness tick overdue by {int(tick_age)}s (>360s threshold)",
+            }
+        )
         current_ids.add(alert_id)
 
     dl_age = snap.get("queues", {}).get("dead_letter_oldest_age_seconds")
     if dl_age is not None and dl_age > 3600:
         alert_id = "queue:stale_dead_letters"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"Dead letter queue has items {int(dl_age)}s old (>1h threshold)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Dead letter queue has items {int(dl_age)}s old (>1h threshold)",
+            }
+        )
         current_ids.add(alert_id)
 
     disk = snap.get("infrastructure", {}).get("disk", {})
     free_pct = disk.get("free_pct")
     if free_pct is not None and free_pct < 15:
         alert_id = "infra:disk_low"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL" if free_pct < 10 else "WARNING",
-            "message": f"Disk space low: {free_pct}% free ({disk.get('free_gb', '?')}GB)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL" if free_pct < 10 else "WARNING",
+                "message": f"Disk space low: {free_pct}% free ({disk.get('free_gb', '?')}GB)",
+            }
+        )
         current_ids.add(alert_id)
 
     container_mem = snap.get("infrastructure", {}).get("container_memory", {})
@@ -391,22 +469,26 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         # both the Telegram alert AND the voice chime earlier. anon_pct is
         # non-reclaimable memory, so >85% is genuine pressure (the box idles
         # ~76-79%). 6h dedup prevents repeat spam.
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
+            }
+        )
         current_ids.add(alert_id)
 
     qdrant_cols = snap.get("infrastructure", {}).get("qdrant_collections", {})
     missing_cols = qdrant_cols.get("missing", [])
     if missing_cols:
         alert_id = "infra:qdrant_collections_missing"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"Qdrant collections missing: {', '.join(missing_cols)} — memory operations will fail",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"Qdrant collections missing: {', '.join(missing_cols)} — memory operations will fail",
+            }
+        )
         current_ids.add(alert_id)
 
     services = snap.get("services", {})
@@ -414,32 +496,38 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     if genesis_svc.get("active_state") not in ("active", "unknown"):
         svc_label = genesis_svc.get("service_unit", "genesis-server.service")
         alert_id = "service:genesis_down"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": f"{svc_label} is {genesis_svc.get('active_state', 'unknown')}",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": f"{svc_label} is {genesis_svc.get('active_state', 'unknown')}",
+            }
+        )
         current_ids.add(alert_id)
 
     watchdog_timer = services.get("watchdog_timer", {})
     if watchdog_timer.get("active_state") not in ("active", "unknown"):
         alert_id = "service:watchdog_blind"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": "genesis-watchdog.timer is inactive — infrastructure monitoring is blind",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": "genesis-watchdog.timer is inactive — infrastructure monitoring is blind",
+            }
+        )
         current_ids.add(alert_id)
 
     watchdog_state = services.get("watchdog", {})
     wd_failures = watchdog_state.get("consecutive_failures", 0)
     if wd_failures > 3:
         alert_id = "service:watchdog_failing"
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
+            }
+        )
         current_ids.add(alert_id)
 
     # Guardian heartbeat — the host-side safety net
@@ -459,18 +547,17 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     guardian_status = guardian_info.get("status", "unknown")
     if guardian_status == "down":
         staleness = guardian_info.get("staleness_s")
-        stale_part = (
-            f" (stale {int(staleness)}s)" if isinstance(staleness, int | float) else ""
-        )
+        stale_part = f" (stale {int(staleness)}s)" if isinstance(staleness, int | float) else ""
         alert_id = "guardian:heartbeat_stale"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": (
-                f"Guardian heartbeat not updating{stale_part} — "
-                f"host-side safety net is blind"
-            ),
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": (
+                    f"Guardian heartbeat not updating{stale_part} — host-side safety net is blind"
+                ),
+            }
+        )
         current_ids.add(alert_id)
 
     ollama = snap.get("infrastructure", {}).get("ollama", {})
@@ -478,11 +565,13 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     if missing_models:
         alert_id = "infra:ollama_model_mismatch"
         names = ", ".join(f"{m['provider']}:{m['model']}" for m in missing_models)
-        alerts.append({
-            "id": alert_id,
-            "severity": "WARNING",
-            "message": f"Ollama missing configured models: {names}",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Ollama missing configured models: {names}",
+            }
+        )
         current_ids.add(alert_id)
 
     if _activity_tracker is not None:
@@ -493,14 +582,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             and emb_summary.get("error_rate", 0) > 0.5
         ):
             alert_id = "provider:embedding_failing"
-            alerts.append({
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": (
-                    f"Embedding provider error rate: {emb_summary['error_rate']:.0%} "
-                    f"({emb_summary['errors']}/{emb_summary['calls']} calls failed)"
-                ),
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Embedding provider error rate: {emb_summary['error_rate']:.0%} "
+                        f"({emb_summary['errors']}/{emb_summary['calls']} calls failed)"
+                    ),
+                }
+            )
             current_ids.add(alert_id)
 
         qdrant_summary = _activity_tracker.summary("qdrant.search")
@@ -518,14 +609,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             _qdrant_rate = qdrant_summary.get("error_rate", 0)
             _qdrant_errors = qdrant_summary.get("errors", 0)
             _qdrant_calls = qdrant_summary.get("calls", 0)
-            alerts.append({
-                "id": alert_id,
-                "severity": "CRITICAL",
-                "message": (
-                    f"Qdrant search {_qdrant_rate:.0%} failure rate "
-                    f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
-                ),
-            })
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": (
+                        f"Qdrant search {_qdrant_rate:.0%} failure rate "
+                        f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
+                    ),
+                }
+            )
             current_ids.add(alert_id)
 
     # ── Credit exhaustion detection ─────────────────────────────────
@@ -541,6 +634,7 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             routing_config = None
             try:
                 from genesis.runtime import GenesisRuntime
+
                 rt = GenesisRuntime.instance()
                 routing_config = getattr(rt, "_routing_config", None)
             except Exception:
@@ -571,14 +665,8 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 # no provider config and are skipped. (Pre-fix this lookup was
                 # single-hop on the raw ``llm.<name>`` string, so it ALWAYS missed
                 # -> every provider read "dormant" -> the detector was 100% dead.)
-                prov_name = (
-                    prov[4:]
-                    if isinstance(prov, str) and prov.startswith("llm.")
-                    else prov
-                )
-                provider_cfg = (
-                    routing_config.providers.get(prov_name) if routing_config else None
-                )
+                prov_name = prov[4:] if isinstance(prov, str) and prov.startswith("llm.") else prov
+                provider_cfg = routing_config.providers.get(prov_name) if routing_config else None
                 if provider_cfg is None:
                     continue  # not a routed LLM provider (embeddings/mcp.*/qdrant.*)
                 prov_crit = crit_map.get(provider_cfg.provider_type, {})
@@ -622,16 +710,18 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 # seam for a future user-gated auto-credit-top-up; see
                 # remediation_map.UNMAPPED_BY_DESIGN["provider:credit_exhaustion:"].
                 alert_id = f"provider:credit_exhaustion:{prov_name}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": (
-                        f"Suspected credit/quota exhaustion for {prov_name}: "
-                        f"was {1 - baseline_error_rate:.0%} success over 7d, "
-                        f"now {recent_error_rate:.0%} errors in last hour "
-                        f"({recent_errors}/{recent_calls} calls)"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"Suspected credit/quota exhaustion for {prov_name}: "
+                            f"was {1 - baseline_error_rate:.0%} success over 7d, "
+                            f"now {recent_error_rate:.0%} errors in last hour "
+                            f"({recent_errors}/{recent_calls} calls)"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             logger.debug("Credit exhaustion detection failed", exc_info=True)
@@ -660,9 +750,7 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 CRITICAL_CALL_SITES,
             )
 
-            cs_cutoff = (
-                datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)
-            ).isoformat()
+            cs_cutoff = (datetime.now(UTC) - _td3(hours=CALLSITE_DOWN_RECENCY_HOURS)).isoformat()
             cs_cursor = await _service._db.execute(
                 "SELECT call_site_id, last_run_at, provider_used "
                 "FROM call_site_last_run WHERE success = 0 AND last_run_at >= ?",
@@ -672,16 +760,18 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 site_id, last_run_at, provider_used = cs_row
                 is_critical = site_id in CRITICAL_CALL_SITES
                 alert_id = f"callsite:down:{site_id}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL" if is_critical else "WARNING",
-                    "message": (
-                        f"Call site '{site_id}' last run failed "
-                        f"(provider {provider_used or 'unknown'}, last attempt "
-                        f"{str(last_run_at)[:19]})"
-                        + (" -- CRITICAL site" if is_critical else "")
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL" if is_critical else "WARNING",
+                        "message": (
+                            f"Call site '{site_id}' last run failed "
+                            f"(provider {provider_used or 'unknown'}, last attempt "
+                            f"{str(last_run_at)[:19]})"
+                            + (" -- CRITICAL site" if is_critical else "")
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             # call_site_last_run is a core table (migration 0015) -- a failure
@@ -692,11 +782,13 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         for job_name in _job_retry_registry.list_registered():
             if _job_retry_registry.is_quarantined(job_name):
                 alert_id = f"job:quarantined:{job_name}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
+                    }
+                )
                 current_ids.add(alert_id)
 
     # ── Silently-stale jobs ──────────────────────────────────────────
@@ -717,16 +809,18 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 _service._db, threshold_days=JOB_STALE_GAP_DAYS
             ):
                 alert_id = f"job_stale:{row['job_name']}"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "WARNING",
-                    "message": (
-                        f"Scheduled job '{row['job_name']}' has run since but not "
-                        f"succeeded in {row['gap_days']:.0f} days (last success "
-                        f"{str(row['last_success'])[:10]}) — silently failing "
-                        f"(its failure counter resets on restart)"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"Scheduled job '{row['job_name']}' has run since but not "
+                            f"succeeded in {row['gap_days']:.0f} days (last success "
+                            f"{str(row['last_success'])[:10]}) — silently failing "
+                            f"(its failure counter resets on restart)"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             # job_health is a core table that always exists — a failure here is
@@ -749,11 +843,13 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 behind = data.get("commits_behind", "?")
                 tag = data.get("target_tag", "unknown")
                 alert_id = "genesis:update_available"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "INFO",
-                    "message": f"New Genesis version available: {tag} ({behind} commits behind) — update from dashboard",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "INFO",
+                        "message": f"New Genesis version available: {tag} ({behind} commits behind) — update from dashboard",
+                    }
+                )
                 current_ids.add(alert_id)
 
             # Check for update failure
@@ -766,14 +862,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             if row:
                 data = json.loads(row[0] if isinstance(row, tuple) else row["content"])
                 alert_id = "genesis:update_failed"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": (
-                        f"Genesis update to {data.get('new_tag', '?')} failed, "
-                        f"rolled back to {data.get('rollback_tag', '?')}"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": (
+                            f"Genesis update to {data.get('new_tag', '?')} failed, "
+                            f"rolled back to {data.get('rollback_tag', '?')}"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except Exception:
             logger.error("Genesis update alert check failed", exc_info=True)
@@ -799,11 +897,13 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 alert_id = "backup:last_failed"
                 reason = backup_data.get("failure_reason") or "check backup log"
                 ts = backup_data.get("timestamp", "unknown")
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": f"Last backup failed at {ts}: {reason}",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": f"Last backup failed at {ts}: {reason}",
+                    }
+                )
                 current_ids.add(alert_id)
             else:
                 # Check staleness — backup succeeded but too long ago
@@ -811,19 +911,18 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 if ts:
                     try:
                         last = datetime.fromisoformat(ts)
-                        age_h = (
-                            datetime.now(UTC) - last
-                        ).total_seconds() / 3600
+                        age_h = (datetime.now(UTC) - last).total_seconds() / 3600
                         if age_h > 8:  # 6h schedule + 2h grace
                             alert_id = "backup:overdue"
-                            alerts.append({
-                                "id": alert_id,
-                                "severity": "CRITICAL",
-                                "message": (
-                                    f"Backup overdue — last success "
-                                    f"was {age_h:.0f}h ago"
-                                ),
-                            })
+                            alerts.append(
+                                {
+                                    "id": alert_id,
+                                    "severity": "CRITICAL",
+                                    "message": (
+                                        f"Backup overdue — last success was {age_h:.0f}h ago"
+                                    ),
+                                }
+                            )
                             current_ids.add(alert_id)
                     except (ValueError, TypeError):
                         pass
@@ -831,25 +930,29 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 t2_status = backup_data.get("tier2_status", "unknown")
                 if t2_status in ("not_configured", "no_smbclient"):
                     alert_id = "backup:tier2_unconfigured"
-                    alerts.append({
-                        "id": alert_id,
-                        "severity": "WARNING",
-                        "message": (
-                            "Large backup targets not configured — "
-                            "Qdrant/SQL snapshots are local-only"
-                        ),
-                    })
+                    alerts.append(
+                        {
+                            "id": alert_id,
+                            "severity": "WARNING",
+                            "message": (
+                                "Large backup targets not configured — "
+                                "Qdrant/SQL snapshots are local-only"
+                            ),
+                        }
+                    )
                     current_ids.add(alert_id)
         except (json.JSONDecodeError, OSError):
             pass
     else:
         # No status file = backups never configured or never ran
         alert_id = "backup:not_configured"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL",
-            "message": "Backups not configured — no backup status file found",
-        })
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "CRITICAL",
+                "message": "Backups not configured — no backup status file found",
+            }
+        )
         current_ids.add(alert_id)
 
     # Credential-file integrity — the container self-heal writes this status;
@@ -869,23 +972,21 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             # escalates to a terminal status (restored / restore_failed) next
             # tick, so alerting on it would defeat the debounce's whole purpose.
             corrupt = {
-                n: t for n, t in targets.items()
-                if t.get("status") in ("corrupt", "restore_failed")
+                n: t for n, t in targets.items() if t.get("status") in ("corrupt", "restore_failed")
             }
-            restored = {
-                n: t for n, t in targets.items() if t.get("status") == "restored"
-            }
+            restored = {n: t for n, t in targets.items() if t.get("status") == "restored"}
             if corrupt:
                 detail = "; ".join(
-                    f"{n} ({t.get('detail', t.get('status'))})"
-                    for n, t in sorted(corrupt.items())
+                    f"{n} ({t.get('detail', t.get('status'))})" for n, t in sorted(corrupt.items())
                 )
                 alert_id = "creds:corrupt"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": f"Credential file corruption: {detail}",
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": f"Credential file corruption: {detail}",
+                    }
+                )
                 current_ids.add(alert_id)
             if restored:
                 detail = "; ".join(
@@ -893,14 +994,16 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                     for n, t in sorted(restored.items())
                 )
                 alert_id = "creds:restored"
-                alerts.append({
-                    "id": alert_id,
-                    "severity": "CRITICAL",
-                    "message": (
-                        f"Credential files auto-restored: {detail} — "
-                        "rotate any that changed since the backup"
-                    ),
-                })
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL",
+                        "message": (
+                            f"Credential files auto-restored: {detail} — "
+                            "rotate any that changed since the backup"
+                        ),
+                    }
+                )
                 current_ids.add(alert_id)
         except (json.JSONDecodeError, OSError):
             pass
@@ -932,11 +1035,13 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
 
     if not active_only:
         for resolved_id, resolved_at in _alert_history.items():
-            alerts.append({
-                "id": resolved_id,
-                "severity": "RESOLVED",
-                "message": f"Previously active alert resolved at {resolved_at}",
-            })
+            alerts.append(
+                {
+                    "id": resolved_id,
+                    "severity": "RESOLVED",
+                    "message": f"Previously active alert resolved at {resolved_at}",
+                }
+            )
 
     health_mcp_mod._alert_history = {aid: now for aid in current_ids}
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1079,6 +1079,37 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        async def _run_ledger_grader() -> None:
+            # WS-2 P2: mechanically grade open predictions past their deadline.
+            # Reads evidence straight off state tables (outreach_history,
+            # task_states, job_run_events, build_candidates, ego_proposals) —
+            # ZERO LLM calls. A second daily pass keeps same-day (24h) task
+            # deadlines from waiting overnight; cheap when nothing is due.
+            if rt._db is None:
+                return
+            import os
+
+            if os.environ.get("GENESIS_LEDGER_GRADER_DISABLED"):
+                return
+            try:
+                from genesis.ledger.grader import grade_due_predictions
+
+                report = await grade_due_predictions(rt._db)
+                rt.record_job_success("ledger_grader")
+                if report.scanned:
+                    logger.info("Ledger grader: %s", report.summary())
+            except Exception as exc:
+                rt.record_job_failure("ledger_grader", str(exc))
+                logger.exception("Ledger grader failed")
+
+        rt._learning_scheduler.add_job(
+            _run_ledger_grader,
+            CronTrigger(hour="6,18", minute=15, timezone=user_timezone()),
+            id="ledger_grader",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         async def _reap_activity_log() -> None:
             if rt._activity_tracker is None:
                 return

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1089,7 +1089,7 @@ async def init(rt: GenesisRuntime) -> None:
                 return
             import os
 
-            if os.environ.get("GENESIS_LEDGER_GRADER_DISABLED"):
+            if os.environ.get("GENESIS_LEDGER_GRADER_DISABLED") == "1":
                 return
             try:
                 from genesis.ledger.grader import grade_due_predictions

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -230,6 +230,16 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "level observability signal for the developer/ego to fix at the "
         "source; waking the Sentinel would achieve nothing."
     ),
+    "ledger:metric_vanished:": (
+        "A cognitive-ledger prediction references a metric no longer in the "
+        "code registry (WS-2 P2 grader) — schema-vs-code drift for a developer "
+        "to fix at the source, not an infra fault. WARNING-level observability."
+    ),
+    "ledger:grade_failed:": (
+        "A cognitive-ledger resolver raised during grading (WS-2 P2) — a code "
+        "bug or malformed evidence for the developer/ego to fix, not something "
+        "the firefighter can auto-heal. WARNING-level observability."
+    ),
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,19 +71,24 @@ def _isolate_circuit_breaker_state(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _isolate_ledger_write_failures():
-    """Reset the ledger writer-failure counter around every test (WS-2 P1b).
+    """Reset the ledger writer + grader failure counters around every test.
 
-    ``genesis.ledger.writers._write_failures`` is a process-global Counter —
-    correct for production (it accumulates failures since process start, read
-    by ``_compute_alerts``), but it leaks across tests: a hook-failure test
-    would otherwise make an unrelated health-alert test see a stray
-    ``ledger:write_failed`` alert. Clear it before and after each test.
+    ``genesis.ledger.writers._write_failures`` (P1b) and the P2 grader's
+    ``_metric_vanished`` / ``_grade_failed`` are process-global Counters —
+    correct for production (they accumulate since process start, read by
+    ``_compute_alerts``), but they leak across tests: a hook/grader-failure
+    test would otherwise make an unrelated health-alert test see a stray
+    ``ledger:write_failed`` / ``ledger:grade_failed`` alert. Clear before and
+    after each test.
     """
+    from genesis.ledger import grader as _ledger_grader
     from genesis.ledger import writers as _ledger_writers
 
     _ledger_writers._write_failures.clear()
+    _ledger_grader._reset_grade_failure_counts_for_tests()
     yield
     _ledger_writers._write_failures.clear()
+    _ledger_grader._reset_grade_failure_counts_for_tests()
 
 
 @pytest.fixture

--- a/tests/test_ledger/test_grader.py
+++ b/tests/test_ledger/test_grader.py
@@ -280,6 +280,36 @@ async def test_double_grade_is_noop(db):
     assert row["status"] == "resolved" and row["outcome_value"] == 1
 
 
+async def test_default_now_grades_absence_rows(db):
+    """The production call site passes no ``now`` — the grader must default it,
+    or every absence-path row TypeErrors into grade_failed (regression: the
+    resolvers' _past_deadline does ``now >= deadline`` with no fallback).
+
+    Deterministic without wall-clock coupling: the row is born with a fixed
+    deadline (2026-07-16T13:00) that is monotonically in the past for any real
+    run, so the defaulted real ``now`` always sees it as due + past-deadline.
+    """
+    await _seed_outreach(db, "o-def")  # exists, silent → absence path
+    await lp.create(
+        db,
+        action_class="outreach_send",
+        subject_ref_type="outreach",
+        subject_ref_id="o-def",
+        domain="outreach.insight",
+        metric="reply_received",
+        confidence=0.5,
+        deadline_at=(BASE + timedelta(hours=1)).isoformat(),
+        provenance="policy_prior",
+        predictor="test",
+        now=BASE,
+    )
+    report = await grade_due_predictions(db)  # NO now= — the production path
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-def"))[0]
+    assert row["status"] == "resolved" and row["resolver"] == "mechanical_absence"
+    assert report.absence == 1
+    assert grader.grade_failure_counts()["grade_failed"] == {}  # no TypeError swallowed
+
+
 async def test_empty_state_clean_noop(db):
     report = await grade_due_predictions(db, now=AFTER)
     assert report.scanned == 0 and report.resolved == 0

--- a/tests/test_ledger/test_grader.py
+++ b/tests/test_ledger/test_grader.py
@@ -1,0 +1,323 @@
+"""WS-2 P2 grader tests: the lane→status mapping matrix (keyed on
+outcome_value), registry-vanish + resolver-exception alarms, idempotent
+double-grade, and the no-LLM import lock.
+
+Rows are created via the real CRUD (which rejects past deadlines), so each
+prediction is born with a near-future deadline relative to ``BASE`` and graded
+with an injected ``now`` past it — one frozen clock drives list_due_open and
+every resolver, zero wall-clock dependence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.db.crud import ledger_predictions as lp
+from genesis.ledger import grader
+from genesis.ledger.grader import grade_due_predictions
+from genesis.ledger.metrics import REGISTRY
+
+BASE = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+AFTER = BASE + timedelta(hours=2)  # past a BASE+1h deadline
+DAY = "2026-07-16"
+
+
+async def _predict(db, *, action_class, subject_type, subject, metric, domain, confidence=0.5):
+    return await lp.create(
+        db,
+        action_class=action_class,
+        subject_ref_type=subject_type,
+        subject_ref_id=subject,
+        domain=domain,
+        metric=metric,
+        confidence=confidence,
+        deadline_at=(BASE + timedelta(hours=1)).isoformat(),
+        provenance="policy_prior",
+        predictor="test",
+        now=BASE,
+    )
+
+
+async def _seed_outreach(db, oid, *, signal=None, outcome=None, user_response=None):
+    await db.execute(
+        "INSERT INTO outreach_history (id, signal_type, topic, category, salience_score,"
+        " channel, message_content, created_at, engagement_signal, engagement_outcome,"
+        " user_response) VALUES (?, 't', 't', 'insight', 0.5, 'telegram', 'm',"
+        " '2026-07-14T00:00:00+00:00', ?, ?, ?)",
+        (oid, signal, outcome, user_response),
+    )
+    await db.commit()
+
+
+async def _seed_task(db, task_id, phase):
+    from genesis.db.crud import task_states
+    from genesis.db.crud.task_states import create_intake_token
+
+    token = await create_intake_token(db)
+    await task_states.create(
+        db, task_id=task_id, description="d", current_phase=phase, intake_token=token
+    )
+
+
+# ── the outcome_value-keyed mapping matrix ───────────────────────────────────
+
+
+async def test_affirmative_mechanical_resolves_1(db):
+    await _seed_outreach(db, "o-yes", signal="user_reply")
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-yes",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    report = await grade_due_predictions(db, now=AFTER)
+    row = await lp.get_by_id(
+        db,
+        (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-yes"))[0][
+            "id"
+        ],
+    )
+    assert row["status"] == "resolved"
+    assert row["outcome_value"] == 1
+    assert row["resolver"] == "mechanical"
+    assert row["evidence_ref"] == "outreach_history:o-yes"
+    assert row["brier"] == pytest.approx((0.5 - 1) ** 2)
+    assert report.resolved == 1 and report.mechanical == 1 and report.absence == 0
+
+
+async def test_mechanical_absence_resolves_0(db):
+    await _seed_outreach(db, "o-silent")  # exists, no signal/outcome
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-silent",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    report = await grade_due_predictions(db, now=AFTER)
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-silent"))[0]
+    assert row["status"] == "resolved"
+    assert row["outcome_value"] == 0
+    assert row["resolver"] == "mechanical_absence"
+    assert report.absence == 1 and report.mechanical == 0
+
+
+async def test_negative_mechanical_resolves_0(db):
+    await _seed_outreach(db, "o-to", signal="timeout")
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-to",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    await grade_due_predictions(db, now=AFTER)
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-to"))[0]
+    assert row["status"] == "resolved" and row["outcome_value"] == 0
+    assert row["resolver"] == "mechanical"  # a real signal fired, not absence
+
+
+async def test_void_lane(db):
+    # scheduled_job with no job_run_events that day → void:no_runs.
+    await _predict(
+        db,
+        action_class="scheduled_job",
+        subject_type="job_day",
+        subject=f"somejob:{DAY}",
+        metric="runs_clean_day",
+        domain="job.somejob",
+    )
+    report = await grade_due_predictions(db, now=AFTER)
+    row = (
+        await lp.list_by_subject(db, action_class="scheduled_job", subject_ref_id=f"somejob:{DAY}")
+    )[0]
+    assert row["status"] == "void"
+    assert row["outcome_value"] is None
+    assert report.void == 1 and report.resolved == 0
+
+
+async def test_unresolvable_subject_missing(db):
+    # No outreach_history row for the subject → unresolvable:subject_missing.
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-ghost",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    report = await grade_due_predictions(db, now=AFTER)
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-ghost"))[0]
+    assert row["status"] == "unresolvable" and row["outcome_value"] is None
+    assert report.unresolvable == 1
+    # subject_missing is a data condition, NOT a code fault → no alarm.
+    assert grader.grade_failure_counts()["metric_vanished"] == {}
+
+
+async def test_fuzzy_pending_parked(db):
+    await _seed_task(db, "t-fuzzy", "completed")
+    await _predict(
+        db,
+        action_class="task_execution",
+        subject_type="task",
+        subject="t-fuzzy",
+        metric="acceptance_pass",
+        domain="task.x",
+    )
+    report = await grade_due_predictions(db, now=AFTER)
+    row = (await lp.list_by_subject(db, action_class="task_execution", subject_ref_id="t-fuzzy"))[0]
+    assert row["status"] == "fuzzy_pending" and row["outcome_value"] is None
+    assert report.fuzzy_pending == 1
+
+
+# ── alarm sensors ────────────────────────────────────────────────────────────
+
+
+async def test_registry_vanished_alarms(db, monkeypatch):
+    await _seed_outreach(db, "o-v", signal="user_reply")
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-v",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    # Simulate a code rollback: the metric is gone from the registry at grade
+    # time. The grader must mark the row unresolvable and alarm, never skip.
+    monkeypatch.setattr(grader, "REGISTRY", {})
+    report = await grade_due_predictions(db, now=AFTER)
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-v"))[0]
+    assert row["status"] == "unresolvable"
+    assert report.unresolvable == 1
+    assert grader.grade_failure_counts()["metric_vanished"] == {"outreach_send": 1}
+
+
+async def test_resolver_exception_isolated_and_counted(db, monkeypatch):
+    await _seed_outreach(db, "o-boom", signal="user_reply")
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-boom",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+
+    async def _boom(*a, **k):
+        raise RuntimeError("resolver blew up")
+
+    bad = replace(REGISTRY["reply_received"], resolver_fn=_boom)
+    monkeypatch.setattr(grader, "REGISTRY", {"reply_received": bad})
+    # Must NOT raise — the batch swallows the resolver error.
+    report = await grade_due_predictions(db, now=AFTER)
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-boom"))[0]
+    assert row["status"] == "open"  # left open, not graded
+    assert report.left_open == 1
+    assert grader.grade_failure_counts()["grade_failed"] == {"outreach_send": 1}
+
+
+async def test_batch_continues_past_one_bad_resolver(db, monkeypatch):
+    await _seed_outreach(db, "o-good", signal="user_reply")
+    await _seed_task(db, "t-good", "completed")
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-good",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    await _predict(
+        db,
+        action_class="task_execution",
+        subject_type="task",
+        subject="t-good",
+        metric="completed",
+        domain="task.x",
+    )
+
+    async def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    reg = dict(REGISTRY)
+    reg["reply_received"] = replace(REGISTRY["reply_received"], resolver_fn=_boom)
+    monkeypatch.setattr(grader, "REGISTRY", reg)
+    report = await grade_due_predictions(db, now=AFTER)
+    # The good task row still graded despite the bad outreach resolver.
+    task_row = (
+        await lp.list_by_subject(db, action_class="task_execution", subject_ref_id="t-good")
+    )[0]
+    assert task_row["status"] == "resolved" and task_row["outcome_value"] == 1
+    assert report.mechanical == 1 and report.left_open == 1
+
+
+# ── idempotence + empty state ────────────────────────────────────────────────
+
+
+async def test_double_grade_is_noop(db):
+    await _seed_outreach(db, "o-idem", signal="user_reply")
+    await _predict(
+        db,
+        action_class="outreach_send",
+        subject_type="outreach",
+        subject="o-idem",
+        metric="reply_received",
+        domain="outreach.insight",
+    )
+    first = await grade_due_predictions(db, now=AFTER)
+    second = await grade_due_predictions(db, now=AFTER)
+    assert first.resolved == 1
+    assert second.scanned == 0  # resolved row no longer open → not re-listed
+    row = (await lp.list_by_subject(db, action_class="outreach_send", subject_ref_id="o-idem"))[0]
+    assert row["status"] == "resolved" and row["outcome_value"] == 1
+
+
+async def test_empty_state_clean_noop(db):
+    report = await grade_due_predictions(db, now=AFTER)
+    assert report.scanned == 0 and report.resolved == 0
+    assert report.mechanical_share() is None
+
+
+async def test_grade_report_summary_and_share(db):
+    await _seed_outreach(db, "o-a", signal="user_reply")
+    await _seed_outreach(db, "o-b")  # silent → absence
+    for oid in ("o-a", "o-b"):
+        await _predict(
+            db,
+            action_class="outreach_send",
+            subject_type="outreach",
+            subject=oid,
+            metric="reply_received",
+            domain="outreach.insight",
+        )
+    report = await grade_due_predictions(db, now=AFTER)
+    assert report.resolved == 2
+    assert report.mechanical_share() == 1.0  # both graded mechanically
+    assert "mechanical_share=1.00" in report.summary()
+
+
+# ── the no-LLM import lock (the P2 grader's core invariant) ───────────────────
+
+
+def test_no_llm_import_path():
+    """Importing the grader must not pull ``genesis.routing`` — the mechanical
+    path makes ZERO LLM calls. Checked in a fresh interpreter (this test
+    process imported routing via other suites long ago)."""
+    import subprocess
+    import sys
+
+    code = (
+        "import sys; import genesis.ledger.grader; "
+        "bad = sorted(n for n in sys.modules if n.startswith('genesis.routing')); "
+        "print('pulled:', bad); sys.exit(1 if bad else 0)"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"


### PR DESCRIPTION
## What

WS-2 **P2a**: the mechanical grader that finally settles the falsifiable predictions P1a/P1b started writing. The proto-ledger never graded a single row; this closes the loop.

`src/genesis/ledger/grader.py` — `grade_due_predictions(db, *, now)`:
- reads open predictions past their deadline (`list_due_open`, rides the partial index),
- runs each metric's registered pure-SQL resolver,
- maps **keyed on `outcome_value`** (the verified invariant: non-None ⟺ `resolved`; None → `void:*`/`unresolvable:*`/`fuzzy_pending`/`open`), writing outcome + Brier through the CRUD's idempotent `resolve()`,
- **zero LLM calls** — own no-`genesis.routing` import lock (`test_no_llm_import_path`).

Scheduled twice daily (`ledger_grader` 6:15/18:15) with env kill-switch `GENESIS_LEDGER_GRADER_DISABLED`. Registry drift (a prediction's metric vanished from code) and resolver exceptions bump per-process counters surfaced as `ledger:metric_vanished:<class>` / `ledger:grade_failed:<class>` via `_compute_alerts` → the M10 awareness-tick alert writer — the same pattern as the P1b `ledger:write_failed`. Both added to the Sentinel `UNMAPPED_BY_DESIGN` map (developer/ego fixes, not firefighter work).

## Deliberately deferred (kept out to hold the mechanical/no-LLM invariant)
- **Fuzzy LLM-fallback drain job** — no writer emits the only fuzzy metric (`acceptance_pass`) in v1, so there's nothing to drain. Rows are parked `fuzzy_pending`; the drain lands when `acceptance_pass` gets a writer.
- **Pipeline demotions + autonomy-evidence rewire** — PR-2b (touches the autonomy Trap; shipped shadow-first).

## Verification
- 13 new grader tests (lane→status matrix, registry-vanish + resolver-exception alarms, batch-continues-past-bad-resolver, idempotent double-grade, empty-state, no-LLM lock); full `test_ledger/` + `test_sentinel/` + alert-persistence + learning job-registration suites green; `ruff --no-cache` clean.
- **E2E on a copy of the live DB**: all 6 real open outreach predictions graded mechanically (`mechanical_absence`, outcome 0, Brier 0.0004 = (0.02−0)²), zero alarms, `mechanical_share=1.00`. No prod mutation.

## Deploy
Runtime code + a new scheduled job — `git pull` + server restart. Existing installs pick up the job at restart; fresh clones get it at boot. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)