### PR TITLE
feat(ego): signal-queue resilience — priority eviction, honest dedup, requeue + TTLs

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -52,6 +52,18 @@ _RECENCY_TIERS: list[tuple[timedelta | None, int]] = [
 ]
 
 
+def _expires_in(minutes: float) -> str:
+    """ISO timestamp *minutes* from now — signal TTL helper.
+
+    TTLs keep requeued/parked signals from going stale in the queue:
+    each producer sets a lifetime matching how long its signal stays
+    actionable (a proactive tick is superseded by the next one; a
+    morning briefing is stale by afternoon). Escalations get NO TTL —
+    critical facts don't expire on their own.
+    """
+    return (datetime.now(UTC) + timedelta(minutes=minutes)).isoformat()
+
+
 def _map_priority(severity_or_priority: str) -> str:
     """Map event severity/priority strings to signal priority levels."""
     s = severity_or_priority.lower()
@@ -286,7 +298,7 @@ class EgoCadenceManager:
         """Push an event that may trigger a reactive ego cycle.
 
         Creates an EgoSignal and pushes to the unified signal queue.
-        Content dedup is handled by SignalQueue (6h window on
+        Content dedup is handled by SignalQueue (per-category window on
         ``reactive:{summary}``). Rate limiting happens at the consumer
         (``_process_signals``) to preserve batch semantics.
 
@@ -306,6 +318,9 @@ class EgoCadenceManager:
                 "event_type": event.get("type"),
                 "source": event.get("source"),
             },
+            # 12h: the deadline scanner re-fires and events re-emit; a
+            # half-day-old reactive signal is stale context, not news.
+            expires_at=_expires_in(12 * 60),
         )
         if self._signal_queue.push(signal):
             logger.debug("Reactive signal pushed: %s", event.get("type", "?"))
@@ -335,6 +350,7 @@ class EgoCadenceManager:
                 "event_type": event.get("type"),
                 "source": event.get("source"),
             },
+            # No expires_at: critical facts don't expire on their own.
         )
         if self._signal_queue.push(signal):
             logger.info("Escalation signal pushed: %s", event.get("type", "?"))
@@ -487,6 +503,9 @@ class EgoCadenceManager:
                         "mode": "stuck" if is_stuck else "stale",
                         "executed_proposals": executed,
                     },
+                    # 24h: the next staleness scan re-detects anything
+                    # still stale.
+                    expires_at=_expires_in(24 * 60),
                 )
                 if self._signal_queue.push(signal):
                     pushed += 1
@@ -748,6 +767,9 @@ class EgoCadenceManager:
             summary=f"Idle tick #{self._proactive_cycle_count}",
             priority="medium",
             metadata={"model_override": model_override} if model_override else {},
+            # Self-superseding: the next tick pushes a fresh one, so a
+            # tick parked longer than the current interval is stale.
+            expires_at=_expires_in(self._current_interval),
         )
         if self._signal_queue.push(signal):
             logger.debug("Proactive signal pushed: %s", signal.summary)
@@ -913,6 +935,10 @@ class EgoCadenceManager:
                 # Effort override comes from the dedicated config field.
                 "effort_override": self._config.morning_report_effort,
             },
+            # 6h: a briefing delivered same-morning (e.g. once a pending
+            # approval resolves) is useful; by afternoon it is stale and
+            # tomorrow's cron covers it.
+            expires_at=_expires_in(6 * 60),
         )
         if self._signal_queue.push(signal):
             logger.info("Morning report signal pushed")

--- a/src/genesis/ego/signals.py
+++ b/src/genesis/ego/signals.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
-# Priority ordering for asyncio.PriorityQueue (lower = higher priority).
+# Priority ordering (lower = higher priority). Also drives drain order.
 PRIORITY_ORDER: dict[str, int] = {
     "critical": 0,
     "high": 1,
@@ -31,11 +31,10 @@ class EgoSignal:
     """A structured event that the ego might want to pay attention to.
 
     Uses ``@dataclass(order=True)`` with ``_priority_order`` as the
-    only compared field so that ``asyncio.PriorityQueue`` drains
-    highest-priority signals first.
+    only compared field so sorting drains highest-priority signals first.
     """
 
-    # PriorityQueue ordering — lower number = higher priority.
+    # Ordering — lower number = higher priority.
     _priority_order: int = field(compare=True, repr=False, default=2)
 
     # --- Actual fields (not compared for ordering) ---
@@ -71,22 +70,36 @@ class EgoSignal:
 
 
 class SignalQueue:
-    """Priority queue for ego signals with dedup and expiry.
+    """Priority queue for ego signals with dedup, expiry, and eviction.
 
-    Generalizes the reactive dedup pattern from
-    ``EgoCadenceManager`` (cadence.py:101-105, 209-223).
+    Internally a plain list — async blocking is provided by the
+    ``_notify`` event (as it always was), so no asyncio queue is needed.
+    All mutators run on the event loop with no await points, so no lock
+    is required.
+
+    Admission on a full queue: expired signals are pruned first; if still
+    full, a strictly lower-priority signal is evicted to admit a
+    higher-priority newcomer (oldest victim within the lowest priority
+    class). A newcomer that outranks nothing is rejected.
 
     Parameters
     ----------
     maxsize:
-        Maximum number of signals in the queue. Overflow drops
-        on push (lowest priority first via replacement is not
-        implemented — we simply reject when full, matching the
-        existing ``QueueFull`` pattern from cadence.py:225-229).
+        Maximum number of signals in the queue.
     dedup_hours:
-        Window for summary-based dedup. Same summary within this
-        window is rejected. Default 6h matches cadence.py.
+        Default window for summary-based dedup. Same summary within the
+        window is rejected. Escalation/reactive categories use shorter
+        windows (``_DEDUP_HOURS_BY_CATEGORY``) — a re-firing CRITICAL is
+        a fresh fact, not spam.
     """
+
+    # Per-category dedup windows (hours). Categories absent here use the
+    # constructor's dedup_hours. Escalations re-admit after 1h: suppressing
+    # a recurring CRITICAL for 6h leaves the ego blind to a live incident.
+    _DEDUP_HOURS_BY_CATEGORY: dict[str, float] = {
+        "escalation": 1,
+        "reactive": 2,
+    }
 
     def __init__(
         self,
@@ -94,9 +107,7 @@ class SignalQueue:
         maxsize: int = 20,
         dedup_hours: int = 6,
     ) -> None:
-        self._queue: asyncio.PriorityQueue[EgoSignal] = (
-            asyncio.PriorityQueue(maxsize=maxsize)
-        )
+        self._items: list[EgoSignal] = []
         self._maxsize = maxsize
         self._dedup_hours = dedup_hours
         # summary → last_seen timestamp (same pattern as cadence.py:104)
@@ -104,25 +115,35 @@ class SignalQueue:
         # Blocking notification for consumer loop (set on push, cleared on drain)
         self._notify = asyncio.Event()
 
+    def _dedup_window_hours(self, focus_category: str) -> float:
+        return self._DEDUP_HOURS_BY_CATEGORY.get(
+            focus_category,
+            self._dedup_hours,
+        )
+
+    @staticmethod
+    def _dedup_key(signal: EgoSignal) -> str:
+        # Include focus_category to prevent collision on empty/short summaries.
+        return f"{signal.focus_category}:{signal.summary[:100]}"
+
     def push(self, signal: EgoSignal) -> bool:
         """Add a signal to the queue.
 
         Returns True if the signal was accepted, False if it was
-        rejected (dedup hit, expired, or queue full).
+        rejected (dedup hit, expired, or queue full with nothing
+        evictable).
         """
         # Reject expired signals
         if signal.is_expired:
             logger.debug("Signal rejected (expired): %s", signal.summary[:50])
             return False
 
-        # Content dedup: skip if same summary seen recently.
-        # Include focus_category to prevent collision on empty/short summaries.
-        summary_key = f"{signal.focus_category}:{signal.summary[:100]}"
+        summary_key = self._dedup_key(signal)
         now = datetime.now(UTC)
 
         if summary_key in self._seen:
             age = (now - self._seen[summary_key]).total_seconds()
-            if age < self._dedup_hours * 3600:
+            if age < self._dedup_window_hours(signal.focus_category) * 3600:
                 logger.debug(
                     "Signal deduped (%.0fm old): %s",
                     age / 60,
@@ -130,57 +151,118 @@ class SignalQueue:
                 )
                 return False
 
-        # Prune old entries (keep dict bounded)
-        cutoff = now - timedelta(hours=self._dedup_hours)
+        # Prune old entries (keep dict bounded). Use the max window so a
+        # still-active default-window stamp is never pruned early.
+        max_window = max(
+            [float(self._dedup_hours), *self._DEDUP_HOURS_BY_CATEGORY.values()],
+        )
+        cutoff = now - timedelta(hours=max_window)
         self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
-        self._seen[summary_key] = now
 
-        # Try to enqueue
-        try:
-            self._queue.put_nowait(signal)
-            self._notify.set()
-            logger.debug(
-                "Signal queued [%s]: %s",
-                signal.priority,
-                summary_key[:50],
-            )
-            return True
-        except asyncio.QueueFull:
-            logger.warning("Signal queue full — dropping: %s", summary_key[:50])
+        if not self._admit(signal):
             return False
+
+        # Stamp dedup ONLY after successful admission — a rejected push
+        # must not suppress its own retry for the rest of the window.
+        self._seen[summary_key] = now
+        self._notify.set()
+        logger.debug(
+            "Signal queued [%s]: %s",
+            signal.priority,
+            summary_key[:50],
+        )
+        return True
+
+    def requeue(self, signals: list[EgoSignal]) -> int:
+        """Re-admit previously drained signals (e.g. after a gated cycle).
+
+        Bypasses dedup — these signals were already admitted once and
+        their dedup stamps still stand. Expired signals are dropped.
+        Returns the number of signals re-admitted.
+        """
+        admitted = 0
+        for signal in signals:
+            if signal.is_expired:
+                logger.debug(
+                    "Requeue dropped (expired): %s",
+                    signal.summary[:50],
+                )
+                continue
+            if self._admit(signal):
+                admitted += 1
+            else:
+                logger.warning(
+                    "Requeue dropped (queue full): %s",
+                    signal.summary[:50],
+                )
+        if admitted:
+            self._notify.set()
+        return admitted
+
+    def _admit(self, signal: EgoSignal) -> bool:
+        """Insert *signal*, pruning expired items and evicting a strictly
+        lower-priority victim if the queue is full. Returns False when
+        the queue is full of equal-or-higher-priority signals.
+        """
+        if len(self._items) >= self._maxsize:
+            self._items = [s for s in self._items if not s.is_expired]
+
+        if len(self._items) >= self._maxsize:
+            lowest = max(s._priority_order for s in self._items)
+            if signal._priority_order < lowest:
+                # Victim: oldest signal in the lowest priority class —
+                # staleness loses.
+                victim = min(
+                    (s for s in self._items if s._priority_order == lowest),
+                    key=lambda s: s.created_at,
+                )
+                self._items.remove(victim)
+                logger.warning(
+                    "Signal queue full — evicted [%s] %r to admit [%s] %r",
+                    victim.priority,
+                    victim.summary[:50],
+                    signal.priority,
+                    signal.summary[:50],
+                )
+            else:
+                logger.warning(
+                    "Signal queue full — dropping: %s",
+                    self._dedup_key(signal)[:50],
+                )
+                return False
+
+        self._items.append(signal)
+        return True
 
     def drain(self) -> list[EgoSignal]:
         """Drain all signals from the queue, dropping expired ones.
 
-        Returns signals sorted by priority (highest first — they
-        come out in priority order from the PriorityQueue).
+        Returns signals sorted by priority (highest first), FIFO within
+        the same priority.
 
         Clears the notify event BEFORE draining so that a push()
         during drain re-sets it — the next wait() returns immediately.
         """
         self._notify.clear()
+        items, self._items = self._items, []
         signals: list[EgoSignal] = []
-        while not self._queue.empty():
-            try:
-                sig = self._queue.get_nowait()
-                if not sig.is_expired:
-                    signals.append(sig)
-                else:
-                    logger.debug(
-                        "Signal dropped (expired on drain): %s",
-                        sig.summary[:50],
-                    )
-            except asyncio.QueueEmpty:
-                break
+        for sig in sorted(items, key=lambda s: (s._priority_order, s.created_at)):
+            if not sig.is_expired:
+                signals.append(sig)
+            else:
+                logger.debug(
+                    "Signal dropped (expired on drain): %s",
+                    sig.summary[:50],
+                )
         return signals
 
     def __len__(self) -> int:
         """Number of signals currently in the queue."""
-        return self._queue.qsize()
+        return len(self._items)
 
     def empty(self) -> bool:
         """Whether the queue is empty."""
-        return self._queue.empty()
+        return not self._items
 
     async def wait(self) -> None:
         """Block until at least one signal is pushed."""
@@ -189,9 +271,5 @@ class SignalQueue:
     def clear(self) -> None:
         """Drop all signals and reset dedup state."""
         self._notify.clear()
-        while not self._queue.empty():
-            try:
-                self._queue.get_nowait()
-            except asyncio.QueueEmpty:
-                break
+        self._items.clear()
         self._seen.clear()

--- a/src/genesis/ego/signals.py
+++ b/src/genesis/ego/signals.py
@@ -216,7 +216,15 @@ class SignalQueue:
                     (s for s in self._items if s._priority_order == lowest),
                     key=lambda s: s.created_at,
                 )
-                self._items.remove(victim)
+                # Remove by identity — EgoSignal.__eq__ compares only
+                # _priority_order (every other field is compare=False), so
+                # list.remove() would delete the FIRST same-priority signal
+                # rather than this specific oldest victim.
+                self._items = [s for s in self._items if s is not victim]
+                # Drop the victim's dedup stamp: it never reached a cycle, so
+                # its content must be free to re-enter within the window —
+                # otherwise eviction reintroduces the silent-loss case.
+                self._seen.pop(self._dedup_key(victim), None)
                 logger.warning(
                     "Signal queue full — evicted [%s] %r to admit [%s] %r",
                     victim.priority,

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1342,3 +1342,49 @@ class TestJobHealthKeyPerEgo:
             mgr._record_success()
         assert recorded == ["user_ego_cycle", "genesis_ego_cycle"]
         assert len(set(recorded)) == 2  # no collision
+
+
+# ---------------------------------------------------------------------------
+# Signal TTLs — every producer stamps a lifetime (signal-resilience PR-1)
+# ---------------------------------------------------------------------------
+
+
+class TestSignalTTLs:
+    """Producers stamp expires_at so parked/requeued signals age out
+    instead of going stale in the queue. Escalations carry NO TTL —
+    critical facts don't expire on their own.
+    """
+
+    @staticmethod
+    def _ttl_minutes(sig) -> float:
+        assert sig.expires_at is not None, "producer must stamp expires_at"
+        expires = datetime.fromisoformat(sig.expires_at)
+        return (expires - datetime.now(UTC)).total_seconds() / 60
+
+    async def test_proactive_tick_ttl_matches_current_interval(self, cadence):
+        await cadence._on_tick()
+        [sig] = cadence._signal_queue.drain()
+        ttl = self._ttl_minutes(sig)
+        assert cadence._current_interval - 1 < ttl <= cadence._current_interval
+
+    async def test_morning_report_ttl_six_hours(self, cadence):
+        await cadence._on_morning_report()
+        [sig] = cadence._signal_queue.drain()
+        assert sig.focus_category == "daily_briefing"
+        ttl = self._ttl_minutes(sig)
+        assert 6 * 60 - 1 < ttl <= 6 * 60
+
+    async def test_reactive_ttl_twelve_hours(self, cadence):
+        cadence._running = True
+        cadence.push_reactive_event({"type": "test", "summary": "an error"})
+        [sig] = cadence._signal_queue.drain()
+        assert sig.focus_category == "reactive"
+        ttl = self._ttl_minutes(sig)
+        assert 12 * 60 - 1 < ttl <= 12 * 60
+
+    async def test_escalation_has_no_ttl(self, cadence):
+        cadence._running = True
+        cadence.push_escalation_event({"type": "test", "summary": "critical"})
+        [sig] = cadence._signal_queue.drain()
+        assert sig.focus_category == "escalation"
+        assert sig.expires_at is None

--- a/tests/test_ego/test_signals.py
+++ b/tests/test_ego/test_signals.py
@@ -270,6 +270,38 @@ def test_eviction_victim_is_oldest_of_lowest_class():
     assert "new low" in summaries
 
 
+def test_eviction_removes_selected_victim_by_identity():
+    """The oldest victim is removed even when it is NOT the first same-priority
+    signal in the list. EgoSignal.__eq__ compares only _priority_order, so a
+    list.remove(victim) would wrongly delete the first low-priority signal.
+    """
+    q = SignalQueue(maxsize=2)
+    recent = (datetime.now(UTC)).isoformat()
+    stale = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    # Append RECENT first, STALE second — the oldest victim is appended last.
+    q.push(EgoSignal(priority="low", summary="recent low", created_at=recent))
+    q.push(EgoSignal(priority="low", summary="stale low", created_at=stale))
+    assert q.push(EgoSignal(priority="critical", summary="crit")) is True
+
+    summaries = {s.summary for s in q.drain()}
+    assert "crit" in summaries
+    assert "recent low" in summaries  # first-appended survivor kept
+    assert "stale low" not in summaries  # actual oldest victim removed
+
+
+def test_evicted_signal_can_repush_within_window():
+    """An evicted signal's dedup stamp is cleared so its content can re-enter —
+    otherwise eviction reintroduces silent signal-loss under queue pressure.
+    """
+    q = SignalQueue(maxsize=1)
+    q.push(EgoSignal(priority="low", summary="evict me"))
+    # Critical evicts the low signal.
+    q.push(EgoSignal(priority="critical", summary="urgent"))
+    # The evicted summary must be immediately re-pushable (dedup stamp cleared).
+    q.drain()
+    assert q.push(EgoSignal(priority="low", summary="evict me")) is True
+
+
 def test_expired_pruned_before_eviction():
     """A full queue frees space by pruning expired signals first."""
     import time

--- a/tests/test_ego/test_signals.py
+++ b/tests/test_ego/test_signals.py
@@ -230,3 +230,136 @@ async def test_push_during_drain_resets_notify():
     q.push(EgoSignal(summary="new signal"))
     await asyncio.wait_for(q.wait(), timeout=1.0)
     assert not q.empty()
+
+
+# ── Priority eviction on overflow ────────────────────────────────────────
+
+
+def test_full_queue_evicts_lower_priority_for_higher():
+    """A CRITICAL newcomer evicts a low-priority signal from a full queue."""
+    q = SignalQueue(maxsize=2)
+    assert q.push(EgoSignal(priority="low", summary="low a")) is True
+    assert q.push(EgoSignal(priority="low", summary="low b")) is True
+    assert q.push(EgoSignal(priority="critical", summary="urgent")) is True
+    assert len(q) == 2
+    summaries = [s.summary for s in q.drain()]
+    assert "urgent" in summaries
+
+
+def test_full_queue_rejects_equal_priority():
+    """No eviction among equals — a full queue still rejects same-priority."""
+    q = SignalQueue(maxsize=1)
+    assert q.push(EgoSignal(priority="high", summary="first")) is True
+    assert q.push(EgoSignal(priority="high", summary="second")) is False
+    assert len(q) == 1
+
+
+def test_eviction_victim_is_oldest_of_lowest_class():
+    """Eviction picks the oldest signal in the lowest priority class."""
+    q = SignalQueue(maxsize=3)
+    old = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    new = datetime.now(UTC).isoformat()
+    q.push(EgoSignal(priority="low", summary="old low", created_at=old))
+    q.push(EgoSignal(priority="low", summary="new low", created_at=new))
+    q.push(EgoSignal(priority="medium", summary="med"))
+
+    assert q.push(EgoSignal(priority="critical", summary="crit")) is True
+    summaries = [s.summary for s in q.drain()]
+    assert summaries[0] == "crit"
+    assert "old low" not in summaries
+    assert "new low" in summaries
+
+
+def test_expired_pruned_before_eviction():
+    """A full queue frees space by pruning expired signals first."""
+    import time
+
+    q = SignalQueue(maxsize=1)
+    soon = (datetime.now(UTC) + timedelta(milliseconds=10)).isoformat()
+    q.push(EgoSignal(priority="medium", summary="short lived", expires_at=soon))
+    time.sleep(0.05)
+    # Same priority — only admitted because the occupant expired.
+    assert q.push(EgoSignal(priority="medium", summary="newcomer")) is True
+    assert [s.summary for s in q.drain()] == ["newcomer"]
+
+
+# ── Dedup semantics ──────────────────────────────────────────────────────
+
+
+def test_rejected_push_does_not_poison_dedup():
+    """A push rejected for overflow must not stamp the dedup window."""
+    q = SignalQueue(maxsize=1)
+    q.push(EgoSignal(priority="high", summary="occupied"))
+    assert q.push(EgoSignal(priority="high", summary="try again")) is False
+    q.drain()
+    # Retry after the queue empties: must be admitted, not dedup-blocked.
+    assert q.push(EgoSignal(priority="high", summary="try again")) is True
+
+
+def test_escalation_dedup_window_is_shorter():
+    """Escalations re-admit after 1h — a re-firing CRITICAL is news."""
+    q = SignalQueue(maxsize=10, dedup_hours=6)
+    make = lambda: EgoSignal(  # noqa: E731
+        focus_category="escalation",
+        priority="critical",
+        summary="db down",
+    )
+    assert q.push(make()) is True
+    assert q.push(make()) is False  # inside the 1h escalation window
+
+    # Backdate the stamp past 1h but inside the 6h default window.
+    q._seen["escalation:db down"] = datetime.now(UTC) - timedelta(hours=2)
+    assert q.push(make()) is True
+
+
+def test_default_category_keeps_long_window():
+    """Non-escalation categories keep the constructor's dedup window."""
+    q = SignalQueue(maxsize=10, dedup_hours=6)
+    assert q.push(EgoSignal(summary="routine")) is True
+    q._seen["proactive:routine"] = datetime.now(UTC) - timedelta(hours=2)
+    assert q.push(EgoSignal(summary="routine")) is False  # 2h < 6h
+
+
+# ── requeue() — gated-cycle survival ─────────────────────────────────────
+
+
+def test_requeue_bypasses_dedup():
+    """Drained signals re-enter despite their still-standing dedup stamps."""
+    q = SignalQueue(maxsize=10)
+    q.push(EgoSignal(summary="gated work"))
+    drained = q.drain()
+    assert q.push(EgoSignal(summary="gated work")) is False  # dedup holds
+    assert q.requeue(drained) == 1
+    assert len(q) == 1
+
+
+def test_requeue_drops_expired():
+    q = SignalQueue(maxsize=10)
+    past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+    stale = EgoSignal(summary="stale", expires_at=past)
+    fresh = EgoSignal(summary="fresh")
+    assert q.requeue([stale, fresh]) == 1
+    assert [s.summary for s in q.drain()] == ["fresh"]
+
+
+def test_requeue_applies_priority_eviction():
+    q = SignalQueue(maxsize=1)
+    q.push(EgoSignal(priority="low", summary="filler"))
+    crit = EgoSignal(
+        focus_category="escalation",
+        priority="critical",
+        summary="requeued crit",
+    )
+    assert q.requeue([crit]) == 1
+    assert [s.summary for s in q.drain()] == ["requeued crit"]
+
+
+@pytest.mark.asyncio
+async def test_requeue_sets_notify():
+    """Requeued signals must wake the consumer like a fresh push."""
+    q = SignalQueue(maxsize=10)
+    q.push(EgoSignal(summary="x"))
+    drained = q.drain()  # clears notify
+    q.requeue(drained)
+    await asyncio.wait_for(q.wait(), timeout=1.0)
+    assert not q.empty()


### PR DESCRIPTION
## What

Reworks the ego `SignalQueue` so the signal funnel stops silently losing work, and stamps a TTL on every producer's signals. Workstream 1 of the ego-signal-resilience spec (audit 2026-07-18); the gate-aware consumer that uses `requeue()` lands in the next PR.

## Why

A live audit traced two concrete losses to queue semantics:

- The once-daily ego morning-report signal was drained and discarded while the cycle was blocked on a pending approval — no retry until the next day's cron.
- A recurring CRITICAL error re-firing within 6h was dedup-suppressed after its first (possibly discarded) push, leaving the ego blind to a live incident.
- A full queue (maxsize 20) rejected newcomers regardless of priority, so a burst of low-priority signals could lock out a CRITICAL escalation.
- The dedup stamp was written before enqueue, so a push rejected for overflow still suppressed its own retry for 6h.

## Changes

- **Priority eviction on overflow** — prune expired first; then evict the oldest strictly-lower-priority signal for a higher-priority newcomer; equal-or-lower newcomers still rejected.
- **Dedup stamps only on successful admission.**
- **Per-category dedup windows** — escalation 1h, reactive 2h, default 6h unchanged.
- **`requeue(signals)`** — dedup-bypassing, expiry- and eviction-aware re-admission for gate-blocked cycles (consumer wiring in next PR).
- **Producer TTLs** (`expires_at` existed on `EgoSignal` but was never set): proactive tick = current interval, daily briefing 6h, goal review 24h, reactive 12h, escalation = none (critical facts don't expire).
- Internals: `asyncio.PriorityQueue` → plain list (blocking was already via the notify Event; eviction needs list access). Public API unchanged; only `cadence.py` consumes the queue (verified).

## Tests

- 13 new queue tests: eviction ordering + victim selection, equal-priority rejection, expired-prune-before-evict, dedup stamp-after-admission, per-category windows, requeue (dedup bypass / expiry drop / eviction / notify).
- 4 new producer-TTL tests in the cadence suite.
- Full signal + cadence suites: 118 passed.

## Deploy

Runtime code only — `git pull` + server restart. No schema, no config, no new autonomous behavior (signals age out *sooner*, nothing runs more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)