### PR TITLE
feat(ledger): WS-2 P2b — demote self-grade autonomy feed; grader feeds it mechanically (shadow-first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Autonomy stops grading its own homework.** Genesis's autonomy earn-back
+  evidence used to be fed by the LLM classifier's own verdict on each
+  interaction — it decided it "succeeded", and that counted toward earning more
+  autonomy (a system grading itself). That self-grade feed is removed. In its
+  place the mechanical grader feeds earn-back evidence from *actually completed
+  vs. actually failed* autonomous tasks, and only a genuine failure counts
+  against a category — a task that was merely slow or got cancelled never does.
+  Ships in shadow mode by default (it logs what it would record, changes no
+  autonomy levels); an operator flips it to live via the new `ws2_ledger`
+  setting after watching the real pattern.
+
 - **Those predictions now get graded.** A mechanical grader runs twice daily
   and settles every prediction whose deadline has passed — reading the actual
   outcome straight from the system's own records (did the reply arrive, did the

--- a/config/ws2_ledger.yaml
+++ b/config/ws2_ledger.yaml
@@ -1,0 +1,17 @@
+# WS-2 cognitive-ledger consumer levers (read live by genesis.ledger.ws2_ledger_config).
+#
+# Overlay per install at ~/.genesis/config/ws2_ledger.local.yaml (deep-merged
+# over this base). Shipped defaults must be safe on a fresh clone with no overlay.
+
+# Master switch for all ledger consumers. false → every lever below reads "off".
+enabled: true
+
+# grader → autonomy earn-back feed (WS-2 P2b). off | shadow | live.
+#   shadow (default): the grader LOGS the record_success/correction it would
+#     fire for direct_session from mechanically-graded task rows, writes nothing
+#     to the autonomy store. Watch the real firing pattern here first.
+#   live: the grader actually feeds direct_session evidence (failure-only:
+#     completed→success, genuine failure→correction; never on slowness/cancel).
+#   off: no autonomy side-effect (the grader still grades predictions).
+# Autonomy is a Trap subsystem — this stays shadow until the operator flips it.
+autonomy_feed: shadow

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -652,7 +652,7 @@ Self-improvement loops and the instrumentation that keeps them honest.
 ```yaml subsystem-map
 entry: learning-evaluation
 modules: [learning, eval, experimentation, feedback, calibration, ledger]
-verified: 1828ee2f 2026-07-18
+verified: b1163dd5 2026-07-18
 ```
 
 - **learning/** is the de-facto cron host: `rt._learning_scheduler` registers
@@ -740,9 +740,16 @@ verified: 1828ee2f 2026-07-18
   through the CRUD's idempotent `resolve()`; ZERO LLM calls (own no-`routing`
   import lock). Registry drift / resolver faults alarm
   `ledger:metric_vanished:<class>` / `ledger:grade_failed:<class>` via the same
-  counter→`_compute_alerts` path. The autonomy-evidence rewire (demote the LLM
-  self-grade feed) and calibration-cell aggregation are later PRs; the fuzzy
-  LLM-fallback lane is deferred (no `acceptance_pass` writer yet). Outreach
+  counter→`_compute_alerts` path. **Autonomy-evidence rewire LIVE (P2b)**: the
+  `learning/pipeline.py` self-grade feed (autonomy `record_success/correction`
+  off the LLM classifier verdict — the A1 harm) is REMOVED; the grader now feeds
+  `direct_session` earn-back from mechanically-graded `task_execution/completed`
+  rows — FAILURE-ONLY (lane `completed`→success, `phase:failed`→correction,
+  nothing on slowness/cancel) and SHADOW-FIRST behind `ws2_ledger.autonomy_feed`
+  (off/shadow/live, default shadow, read live via `ledger/ws2_ledger_config.py`;
+  live feeds the same seam #1119's `autonomy_events` windowed ledger consumes).
+  Calibration-cell aggregation is a later PR; the fuzzy LLM-fallback lane is
+  deferred (no `acceptance_pass` writer yet). Outreach
   metrics resolve off `outreach_history.engagement_signal`
   (spike-measured 99.5% mechanical); the engagement_outcome CHECK now
   ENFORCES the canonical vocabulary (rebuild #4 in the

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -170,20 +170,11 @@ def build_triage_pipeline(
             else:
                 delta = await delta_assessor.assess(summary)
 
-            # Log prediction for calibration (fire-and-forget)
-            if outcome and runtime is not None:
-                try:
-                    prediction_logger = getattr(runtime, "_prediction_logger", None)
-                    if prediction_logger is not None:
-                        await prediction_logger.log(
-                            action_id=f"triage-{summary.session_id or 'unknown'}",
-                            prediction=f"Outcome classified as {outcome.value}",
-                            confidence=0.7 if outcome.value == "success" else 0.5,
-                            domain="triage",
-                            reasoning=triage.rationale or "pipeline classification",
-                        )
-                except Exception:
-                    logger.debug("Prediction logging failed (non-fatal)", exc_info=True)
+            # Proto-ledger prediction logging REMOVED (WS-2 P2b, Sunset S1). It
+            # wrote unfalsifiable domain='triage' rows (a restatement of the
+            # classifier's own verdict, no deadline, hard-coded confidence) that
+            # nothing ever graded. The real ledger (ledger_predictions + the P2
+            # grader) supersedes it.
 
         # 6. Observation + attribution routing (depth >= FULL_ANALYSIS)
         if triage.depth >= TriageDepth.FULL_ANALYSIS and outcome and delta:
@@ -203,25 +194,15 @@ def build_triage_pipeline(
             except Exception:
                 logger.error("Drive adaptation failed (non-fatal)", exc_info=True)
 
-            # 6.2. Autonomy calibration — wire Bayesian regression to live outcomes
-            if runtime is not None:
-                try:
-                    mgr = getattr(runtime, "_autonomy_manager", None)
-                    if mgr is not None:
-                        from datetime import UTC, datetime
-
-                        if outcome == OutcomeClass.SUCCESS:
-                            await mgr.record_success("direct_session")
-                        elif outcome in (
-                            OutcomeClass.APPROACH_FAILURE,
-                            OutcomeClass.CAPABILITY_GAP,
-                        ):
-                            await mgr.record_correction(
-                                "direct_session",
-                                corrected_at=datetime.now(UTC).isoformat(),
-                            )
-                except Exception:
-                    logger.error("Autonomy calibration failed (non-fatal)", exc_info=True)
+            # 6.2. Autonomy calibration — REMOVED (WS-2 P2b, the A1 harm-removal).
+            # direct_session earn-back evidence no longer eats the LLM
+            # classifier's SUCCESS/APPROACH_FAILURE/CAPABILITY_GAP self-verdict
+            # (Genesis grading its own state — the dominant WS-0 failure class).
+            # The P2 grader now feeds direct_session record_success/correction
+            # from *mechanically graded* task_execution rows (ledger/grader.py:
+            # failure-only — lane 'completed'→success, 'phase:failed'→correction,
+            # nothing on slowness/cancel — behind the shadow-first ws2_ledger
+            # settings gate).
 
         # 6.5. Procedure extraction — DEPRECATED (30-day grace period)
         #

--- a/src/genesis/ledger/grader.py
+++ b/src/genesis/ledger/grader.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from genesis.db.crud import ledger_predictions as lp_crud
 from genesis.ledger.metrics import REGISTRY
+from genesis.ledger.ws2_ledger_config import autonomy_feed_mode
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,11 @@ logger = logging.getLogger(__name__)
 # consistent with the single-designated-writer rule.
 _metric_vanished: Counter[str] = Counter()
 _grade_failed: Counter[str] = Counter()
+# WS-2 P2b: live autonomy-feed side-effect failures (record_success/correction
+# raised). Non-critical — the grade itself landed; only the earn-back evidence
+# didn't propagate — so log+count, no health alert (matches the removed
+# pipeline block's non-fatal posture).
+_autonomy_feed_failures: Counter[str] = Counter()
 
 
 def grade_failure_counts() -> dict[str, dict[str, int]]:
@@ -61,9 +67,15 @@ def grade_failure_counts() -> dict[str, dict[str, int]]:
     }
 
 
+def autonomy_feed_failure_counts() -> dict[str, int]:
+    """Live autonomy-feed side-effect failures since process start (observability)."""
+    return dict(_autonomy_feed_failures)
+
+
 def _reset_grade_failure_counts_for_tests() -> None:
     _metric_vanished.clear()
     _grade_failed.clear()
+    _autonomy_feed_failures.clear()
 
 
 @dataclass
@@ -79,6 +91,9 @@ class GradeReport:
     fuzzy_pending: int = 0
     left_open: int = 0
     per_class: dict[str, Counter[str]] = field(default_factory=dict)
+    # WS-2 P2b autonomy feed, keyed "<mode>:<kind>" (e.g. "shadow:success",
+    # "live:correction") — what the grader fired (live) or would have (shadow).
+    autonomy: Counter[str] = field(default_factory=Counter)
 
     def _bump(self, action_class: str, kind: str) -> None:
         self.per_class.setdefault(action_class, Counter())[kind] += 1
@@ -99,14 +114,80 @@ class GradeReport:
             f"void={self.void} unresolvable={self.unresolvable} "
             f"fuzzy_pending={self.fuzzy_pending} left_open={self.left_open} "
             f"mechanical_share={share_s}"
+            + (f" autonomy={dict(self.autonomy)}" if self.autonomy else "")
         )
 
 
-async def _apply(db: Any, row: dict, res, report: GradeReport, *, now: datetime | None) -> None:
+async def _feed_autonomy(
+    row: dict,
+    res,
+    report: GradeReport,
+    *,
+    autonomy_manager: Any,
+    autonomy_feed: str,
+    now: datetime,
+) -> None:
+    """FAILURE-ONLY autonomy earn-back evidence from a graded task row (P2b).
+
+    Replaces the removed pipeline self-grade feed. Fires ONLY on genuine
+    completion (lane ``completed`` → success) or genuine execution failure
+    (lane ``phase:failed`` → correction). A task that merely missed its
+    deadline while still running (``mechanical_absence``) or was cancelled
+    (``phase:cancelled``) is NOT a competence signal — a correction there would
+    spuriously demote direct_session. SHADOW-FIRST: shadow logs the intent and
+    writes nothing; live fires the manager seam fire-and-forget (a raise never
+    touches the grade, which already landed).
+    """
+    if res.lane == "completed":
+        kind = "success"
+    elif res.lane == "phase:failed":
+        kind = "correction"
+    else:
+        return  # slowness / cancellation / anything else — no autonomy signal
+    if autonomy_feed == "off":
+        return
+    report.autonomy[f"{autonomy_feed}:{kind}"] += 1
+    if autonomy_feed == "shadow":
+        logger.info(
+            "[ledger-autonomy shadow] WOULD record_%s(direct_session) for task %s (lane=%s)",
+            kind,
+            row["subject_ref_id"],
+            res.lane,
+        )
+        return
+    if autonomy_manager is None:  # live but no manager wired — nothing to fire
+        return
+    try:
+        if kind == "success":
+            await autonomy_manager.record_success("direct_session")
+        else:
+            await autonomy_manager.record_correction("direct_session", corrected_at=now.isoformat())
+    except Exception:
+        _autonomy_feed_failures[kind] += 1
+        logger.error(
+            "ledger autonomy feed (%s) failed for task %s — grade unaffected",
+            kind,
+            row["subject_ref_id"],
+            exc_info=True,
+        )
+
+
+async def _apply(
+    db: Any,
+    row: dict,
+    res,
+    report: GradeReport,
+    *,
+    now: datetime,
+    autonomy_manager: Any = None,
+    autonomy_feed: str = "off",
+) -> None:
     """Translate one :class:`Resolution` into a ``resolve()`` call.
 
     Keyed on ``outcome_value`` first (the resolved-iff-non-None invariant),
-    then the lane for the None-outcome dispositions.
+    then the lane for the None-outcome dispositions. A resolved
+    task_execution/completed row additionally feeds autonomy earn-back evidence
+    (failure-only, shadow-first — P2b).
     """
     action_class = row["action_class"]
     if res.outcome_value is not None:
@@ -127,6 +208,18 @@ async def _apply(db: Any, row: dict, res, report: GradeReport, *, now: datetime 
             else:
                 report.mechanical += 1
             report._bump(action_class, f"resolved:{res.lane}")
+            # Exactly-once: only a genuine open→resolved transition (changed)
+            # feeds autonomy — the idempotent resolve() guard makes re-grades
+            # no-ops, so no double-fire across the twice-daily passes.
+            if action_class == "task_execution" and row["metric"] == "completed":
+                await _feed_autonomy(
+                    row,
+                    res,
+                    report,
+                    autonomy_manager=autonomy_manager,
+                    autonomy_feed=autonomy_feed,
+                    now=now,
+                )
         return
 
     lane = res.lane
@@ -152,7 +245,7 @@ async def _apply(db: Any, row: dict, res, report: GradeReport, *, now: datetime 
 
 
 async def grade_due_predictions(
-    db: Any, *, now: datetime | None = None, limit: int = 500
+    db: Any, *, now: datetime | None = None, limit: int = 500, autonomy_manager: Any = None
 ) -> GradeReport:
     """Grade every open prediction whose deadline has passed. Idempotent.
 
@@ -162,8 +255,14 @@ async def grade_due_predictions(
     ``_past_deadline`` check does ``now >= deadline`` with no fallback, so a
     ``None`` would TypeError every absence-path row into ``grade_failed``
     instead of resolving it.
+
+    ``autonomy_manager`` (the runtime ``AutonomyManager``) enables the P2b
+    earn-back feed; the mode (off/shadow/live) is read LIVE once per pass from
+    the ws2_ledger settings domain. Omitting it (tests, or a caller with no
+    runtime) simply skips the feed.
     """
     now = now or datetime.now(UTC)
+    autonomy_feed = autonomy_feed_mode()
     report = GradeReport()
     rows = await lp_crud.list_due_open(db, now=now, limit=limit)
     report.scanned = len(rows)
@@ -197,5 +296,13 @@ async def grade_due_predictions(
             report.left_open += 1
             report._bump(action_class, "grade_failed")
             continue
-        await _apply(db, row, res, report, now=now)
+        await _apply(
+            db,
+            row,
+            res,
+            report,
+            now=now,
+            autonomy_manager=autonomy_manager,
+            autonomy_feed=autonomy_feed,
+        )
     return report

--- a/src/genesis/ledger/grader.py
+++ b/src/genesis/ledger/grader.py
@@ -146,8 +146,8 @@ async def _feed_autonomy(
         return  # slowness / cancellation / anything else — no autonomy signal
     if autonomy_feed == "off":
         return
-    report.autonomy[f"{autonomy_feed}:{kind}"] += 1
     if autonomy_feed == "shadow":
+        report.autonomy[f"shadow:{kind}"] += 1  # what live WOULD fire
         logger.info(
             "[ledger-autonomy shadow] WOULD record_%s(direct_session) for task %s (lane=%s)",
             kind,
@@ -157,6 +157,11 @@ async def _feed_autonomy(
         return
     if autonomy_manager is None:  # live but no manager wired — nothing to fire
         return
+    # Count only once we know a manager exists to fire into — otherwise the
+    # report would claim a live fire that never happened (hiding a wiring
+    # regression). A raise below still counts as fired-then-failed via
+    # _autonomy_feed_failures, which is the honest record.
+    report.autonomy[f"live:{kind}"] += 1
     try:
         if kind == "success":
             await autonomy_manager.record_success("direct_session")

--- a/src/genesis/ledger/ws2_ledger_config.py
+++ b/src/genesis/ledger/ws2_ledger_config.py
@@ -1,0 +1,98 @@
+"""WS-2 cognitive-ledger control surface — live-read consumer levers.
+
+The ONE place ledger consumers consult for policy (repo_pulse_config /
+ledger_shadow_config lineage). v1 exposes a single lever:
+
+- :func:`autonomy_feed_mode` — ``off | shadow | live`` for the P2b grader→
+  autonomy earn-back feed, re-read from the merged YAML
+  (``config/ws2_ledger.yaml`` + the user overlay
+  ``~/.genesis/config/ws2_ledger.local.yaml``) on EVERY grading pass. No boot
+  cache — the operator flips shadow→live without a restart.
+
+Shadow is the DEFAULT and an INVALID value degrades to shadow — toward LESS
+write authority (the same fail-safe as ledger_shadow_config). The grader feeds
+autonomy evidence into a Trap subsystem (earn-back Bayesian posteriors); shadow
+logs what it WOULD fire so the operator can watch the real pattern before it
+moves any autonomy math. ``off`` disables the feed entirely (the grader still
+grades predictions — only the autonomy side-effect is gated).
+
+P4 grows the SAME domain with the other consumer levers (arbitration discount,
+B5 knob effector) as sibling keys — forward-compatible, so this file and the
+settings domain stay the single source of truth.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports MODES from here, never the reverse
+(one-way, the immunity rule). NO import path to ``genesis.routing`` — the
+grader that reads this must keep its no-LLM lock.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "shadow", "live")
+
+_CONFIG_NAME = "ws2_ledger.yaml"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "autonomy_feed": "shadow",  # grader→autonomy earn-back feed; shadow-first
+}
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        logger.warning("ws2_ledger base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("ws2_ledger overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def autonomy_feed_mode() -> str:
+    """The grader→autonomy feed mode — read live.
+
+    Master ``enabled: false`` → ``off``. An invalid value degrades to
+    ``shadow`` (observable, no write authority into the autonomy Trap — never a
+    silent live-fire).
+    """
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("autonomy_feed")
+    if mode is False:
+        # A hand-edited unquoted `autonomy_feed: off` parses as YAML-1.1
+        # boolean False. That intent is unambiguous — honor it.
+        return "off"
+    if mode not in MODES:
+        logger.warning("ws2_ledger has invalid autonomy_feed %r — degrading to shadow", mode)
+        return "shadow"
+    return mode

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -103,6 +103,19 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # each worker run is a fresh process
     ),
+    "ws2_ledger": SettingsDomain(
+        name="ws2_ledger",
+        description=(
+            "WS-2 cognitive-ledger consumer levers — master `enabled` + "
+            "`autonomy_feed` off/shadow/live (P2b grader→autonomy earn-back "
+            "feed). Shadow (default) logs what it WOULD fire without writing "
+            "the autonomy Trap; an invalid value degrades to shadow. Read live "
+            "per grading pass by genesis.ledger.ws2_ledger_config (no restart)."
+        ),
+        config_filename="ws2_ledger.yaml",
+        readonly=False,
+        needs_restart=False,  # read live per grading pass by ws2_ledger_config
+    ),
     "repo_pulse": SettingsDomain(
         name="repo_pulse",
         description=(
@@ -812,6 +825,23 @@ def _validate_session_ledger_shadow(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_ws2_ledger(changes: dict) -> list[str]:
+    """Validate ws2_ledger consumer-lever changes (see
+    genesis.ledger.ws2_ledger_config)."""
+    from genesis.ledger.ws2_ledger_config import MODES
+
+    errors: list[str] = []
+    for key, value in changes.items():
+        if key not in ("enabled", "autonomy_feed"):
+            errors.append(f"Unknown key '{key}'. Valid: enabled, autonomy_feed")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif value not in MODES:
+            errors.append(f"'autonomy_feed' must be one of {', '.join(MODES)}; got {value!r}")
+    return errors
+
+
 def _validate_repo_pulse(changes: dict) -> list[str]:
     """Validate repo-pulse lever changes (see
     genesis.session_awareness.repo_pulse_config)."""
@@ -923,6 +953,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "ws3_immunity": _validate_ws3_immunity,
     "memory_recall": _validate_memory_recall,
     "session_ledger_shadow": _validate_session_ledger_shadow,
+    "ws2_ledger": _validate_ws2_ledger,
     "repo_pulse": _validate_repo_pulse,
     "cc_roster": _validate_cc_roster,
     "resilience": _validate_resilience,

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1094,7 +1094,12 @@ async def init(rt: GenesisRuntime) -> None:
             try:
                 from genesis.ledger.grader import grade_due_predictions
 
-                report = await grade_due_predictions(rt._db)
+                # Pass the autonomy manager for the P2b earn-back feed; its mode
+                # (off/shadow/live, default shadow) is read live per pass from
+                # the ws2_ledger settings domain inside the grader.
+                report = await grade_due_predictions(
+                    rt._db, autonomy_manager=getattr(rt, "_autonomy_manager", None)
+                )
                 rt.record_job_success("ledger_grader")
                 if report.scanned:
                     logger.info("Ledger grader: %s", report.summary())

--- a/tests/test_learning/test_pipeline.py
+++ b/tests/test_learning/test_pipeline.py
@@ -153,9 +153,7 @@ class TestTriagePipeline:
             observation_writer=ow,
             router=router,
         )
-        text_with_learnings = (
-            "response\n## Learnings\n- something\n- else"
-        )
+        text_with_learnings = "response\n## Learnings\n- something\n- else"
         await pipeline(FakeCCOutput(text=text_with_learnings), "q", "terminal")
 
         oc.classify.assert_awaited_once()
@@ -164,9 +162,7 @@ class TestTriagePipeline:
         # Procedure extraction routes through router — must NOT fire
         router.route_call.assert_not_awaited()
         # Debrief parsing is independent — should still write learnings
-        learning_calls = [
-            c for c in ow.write.call_args_list if c[1].get("source") == "cc_debrief"
-        ]
+        learning_calls = [c for c in ow.write.call_args_list if c[1].get("source") == "cc_debrief"]
         assert len(learning_calls) == 2
 
     @pytest.mark.asyncio
@@ -203,9 +199,7 @@ class TestTriagePipeline:
         output = FakeCCOutput(text=text_with_learnings)
         await pipeline(output, "test", "terminal")
         # Should write 2 learnings
-        learning_calls = [
-            c for c in ow.write.call_args_list if c[1].get("source") == "cc_debrief"
-        ]
+        learning_calls = [c for c in ow.write.call_args_list if c[1].get("source") == "cc_debrief"]
         assert len(learning_calls) == 2
 
     @pytest.mark.asyncio
@@ -226,78 +220,12 @@ class TestTriagePipeline:
         assert call_kwargs["event_type"] == "triage.classified"
 
 
-class TestAutonomyCalibration:
-    """Pipeline wires outcome classification to autonomy manager."""
-
-    @pytest.mark.asyncio
-    async def test_success_outcome_records_autonomy_success(self, db):
-        """SUCCESS outcome triggers autonomy_manager.record_success."""
-        mgr = AsyncMock()
-        mgr.record_success = AsyncMock(return_value=(True, False))
-        runtime = MagicMock()
-        runtime._autonomy_manager = mgr
-        runtime.record_job_success = MagicMock()
-        runtime.record_job_failure = MagicMock()
-
-        ow = MagicMock()
-        ow.write = AsyncMock(return_value="obs-1")
-        pipeline = build_triage_pipeline(
-            db=db,
-            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
-            outcome_classifier=_make_outcome_classifier(OutcomeClass.SUCCESS),
-            delta_assessor=_make_delta_assessor(),
-            observation_writer=ow,
-            runtime=runtime,
-        )
-        await pipeline(FakeCCOutput(), "test", "terminal")
-        mgr.record_success.assert_awaited_once_with("direct_session")
-
-    @pytest.mark.asyncio
-    async def test_failure_outcome_records_autonomy_correction(self, db):
-        """APPROACH_FAILURE outcome triggers autonomy_manager.record_correction."""
-        mgr = AsyncMock()
-        mgr.record_correction = AsyncMock(return_value=(True, True))
-        runtime = MagicMock()
-        runtime._autonomy_manager = mgr
-        runtime.record_job_success = MagicMock()
-        runtime.record_job_failure = MagicMock()
-
-        ow = MagicMock()
-        ow.write = AsyncMock(return_value="obs-1")
-        pipeline = build_triage_pipeline(
-            db=db,
-            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
-            outcome_classifier=_make_outcome_classifier(OutcomeClass.APPROACH_FAILURE),
-            delta_assessor=_make_delta_assessor(),
-            observation_writer=ow,
-            runtime=runtime,
-        )
-        await pipeline(FakeCCOutput(), "test", "terminal")
-        mgr.record_correction.assert_awaited_once()
-        # Verify category is direct_session
-        call_args = mgr.record_correction.call_args
-        assert call_args[0][0] == "direct_session"
-
-    @pytest.mark.asyncio
-    async def test_no_autonomy_manager_does_not_crash(self, db):
-        """Pipeline doesn't crash when runtime has no autonomy manager."""
-        runtime = MagicMock()
-        runtime._autonomy_manager = None
-        runtime.record_job_success = MagicMock()
-        runtime.record_job_failure = MagicMock()
-
-        ow = MagicMock()
-        ow.write = AsyncMock(return_value="obs-1")
-        pipeline = build_triage_pipeline(
-            db=db,
-            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
-            outcome_classifier=_make_outcome_classifier(OutcomeClass.SUCCESS),
-            delta_assessor=_make_delta_assessor(),
-            observation_writer=ow,
-            runtime=runtime,
-        )
-        # Should not raise
-        await pipeline(FakeCCOutput(), "test", "terminal")
+# TestAutonomyCalibration REMOVED (WS-2 P2b): the pipeline no longer feeds
+# autonomy record_success/record_correction from the LLM classifier's
+# SUCCESS/APPROACH_FAILURE verdict (the A1 harm-removal — Genesis grading its
+# own state). Autonomy earn-back evidence now flows from the ledger grader over
+# mechanically-graded task rows (failure-only, shadow-first) — covered by
+# tests/test_ledger/test_grader.py::TestAutonomyFeed.
 
 
 class TestSteeringRuleExtraction:
@@ -417,7 +345,8 @@ class TestSuccessExtractionChannelGate:
             return None
 
         monkeypatch.setattr(
-            "genesis.learning.pipeline.extract_procedure", fake_extract,
+            "genesis.learning.pipeline.extract_procedure",
+            fake_extract,
         )
         router = MagicMock()
         router.route_call = AsyncMock()
@@ -442,7 +371,8 @@ class TestSuccessExtractionChannelGate:
             return None
 
         monkeypatch.setattr(
-            "genesis.learning.pipeline.extract_procedure", fake_extract,
+            "genesis.learning.pipeline.extract_procedure",
+            fake_extract,
         )
         router = MagicMock()
         router.route_call = AsyncMock()
@@ -468,7 +398,8 @@ class TestSuccessExtractionChannelGate:
             return None
 
         monkeypatch.setattr(
-            "genesis.learning.pipeline.extract_procedure", fake_extract,
+            "genesis.learning.pipeline.extract_procedure",
+            fake_extract,
         )
         router = MagicMock()
         router.route_call = AsyncMock()

--- a/tests/test_ledger/test_grader.py
+++ b/tests/test_ledger/test_grader.py
@@ -459,6 +459,17 @@ async def test_autonomy_only_completed_metric_not_first_attempt(db, monkeypatch)
     mgr.record_success.assert_not_awaited()
 
 
+async def test_autonomy_live_no_manager_does_not_overcount(db, monkeypatch):
+    # live mode but no manager wired: nothing fires AND report.autonomy must not
+    # claim a fire (else it hides a wiring regression — architect NOTE-1).
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-nomgr", "completed")
+    await _task_pred(db, "t-nomgr")
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=None)
+    assert report.mechanical == 1  # graded fine
+    assert not report.autonomy  # but nothing counted as fired
+
+
 async def test_autonomy_exactly_once_across_regrade(db, monkeypatch):
     monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
     await _seed_task(db, "t-once", "completed")

--- a/tests/test_ledger/test_grader.py
+++ b/tests/test_ledger/test_grader.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -351,3 +352,131 @@ def test_no_llm_import_path():
     )
     proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=60)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+
+# ── P2b autonomy feed: failure-only + shadow-first (into the autonomy Trap) ───
+
+
+async def _task_pred(db, tid, metric="completed"):
+    await lp.create(
+        db,
+        action_class="task_execution",
+        subject_ref_type="task",
+        subject_ref_id=tid,
+        domain="task.x",
+        metric=metric,
+        confidence=0.5,
+        deadline_at=(BASE + timedelta(hours=1)).isoformat(),
+        provenance="policy_prior",
+        predictor="test",
+        now=BASE,
+    )
+
+
+def _mgr():
+    m = AsyncMock()
+    m.record_success = AsyncMock()
+    m.record_correction = AsyncMock()
+    return m
+
+
+async def test_autonomy_shadow_logs_but_fires_nothing(db, monkeypatch):
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "shadow")
+    await _seed_task(db, "t-shadow", "completed")
+    await _task_pred(db, "t-shadow")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert report.autonomy["shadow:success"] == 1
+    mgr.record_success.assert_not_awaited()  # shadow writes nothing to the Trap
+    mgr.record_correction.assert_not_awaited()
+
+
+async def test_autonomy_live_success_on_completion(db, monkeypatch):
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-live", "completed")
+    await _task_pred(db, "t-live")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert report.autonomy["live:success"] == 1
+    mgr.record_success.assert_awaited_once_with("direct_session")
+    mgr.record_correction.assert_not_awaited()
+
+
+async def test_autonomy_live_correction_on_genuine_failure(db, monkeypatch):
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-fail", "failed")
+    await _task_pred(db, "t-fail")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert report.autonomy["live:correction"] == 1
+    mgr.record_correction.assert_awaited_once()
+    assert mgr.record_correction.call_args[0][0] == "direct_session"
+    mgr.record_success.assert_not_awaited()
+
+
+async def test_autonomy_no_fire_on_cancelled(db, monkeypatch):
+    # A cancelled task grades 0 (phase:cancelled) but is NOT a competence signal.
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-cancel", "cancelled")
+    await _task_pred(db, "t-cancel")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert not report.autonomy
+    mgr.record_success.assert_not_awaited()
+    mgr.record_correction.assert_not_awaited()
+
+
+async def test_autonomy_no_fire_on_deadline_miss(db, monkeypatch):
+    # Still running at deadline → mechanical_absence: slowness, not failure.
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-slow", "dispatching")
+    await _task_pred(db, "t-slow")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert report.absence == 1 and not report.autonomy
+    mgr.record_success.assert_not_awaited()
+    mgr.record_correction.assert_not_awaited()
+
+
+async def test_autonomy_off_fires_nothing(db, monkeypatch):
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "off")
+    await _seed_task(db, "t-off", "completed")
+    await _task_pred(db, "t-off")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert not report.autonomy
+    mgr.record_success.assert_not_awaited()
+
+
+async def test_autonomy_only_completed_metric_not_first_attempt(db, monkeypatch):
+    # completed_first_attempt must NOT feed autonomy (one event per task).
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-cfa", "completed")
+    await _task_pred(db, "t-cfa", metric="completed_first_attempt")
+    mgr = _mgr()
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    assert report.resolved == 1 and not report.autonomy  # graded, no autonomy
+    mgr.record_success.assert_not_awaited()
+
+
+async def test_autonomy_exactly_once_across_regrade(db, monkeypatch):
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-once", "completed")
+    await _task_pred(db, "t-once")
+    mgr = _mgr()
+    await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)  # resolved row not re-listed
+    mgr.record_success.assert_awaited_once()  # fired once, not per pass
+
+
+async def test_autonomy_manager_failure_never_touches_grade(db, monkeypatch):
+    monkeypatch.setattr(grader, "autonomy_feed_mode", lambda: "live")
+    await _seed_task(db, "t-boom", "completed")
+    await _task_pred(db, "t-boom")
+    mgr = _mgr()
+    mgr.record_success = AsyncMock(side_effect=RuntimeError("autonomy store down"))
+    report = await grade_due_predictions(db, now=AFTER, autonomy_manager=mgr)
+    row = (await lp.list_by_subject(db, action_class="task_execution", subject_ref_id="t-boom"))[0]
+    assert row["status"] == "resolved" and row["outcome_value"] == 1  # grade still landed
+    assert report.mechanical == 1
+    assert grader.autonomy_feed_failure_counts() == {"success": 1}


### PR DESCRIPTION
## What — the A1 harm-removal + its honest replacement

WS-2 **P2b** (the autonomy-Trap half of P2). Two demotions in `learning/pipeline.py`:
1. The **dead proto-ledger prediction-log** block (unfalsifiable `domain='triage'` rows nothing graded — Sunset S1).
2. The **autonomy self-grade calls** — `record_success/record_correction("direct_session")` fired off the LLM classifier's own SUCCESS/APPROACH_FAILURE verdict. This is the A1 harm: *Genesis grading its own state* fed the earn-back posteriors that gate its autonomy. `direct_session` was fed **only** by this block.

The **P2 grader replaces that feed** with mechanically-graded evidence (`ledger/grader.py::_feed_autonomy`):
- **FAILURE-ONLY** — a graded `task_execution/completed` row fires `record_success` on lane `completed`, `record_correction` on lane `phase:failed`, and **nothing** on `mechanical_absence` (task merely slow) or `phase:cancelled`. Only a *genuine* failure can demote — the LLM path corrected on semantic failure, never slowness/cancellation. (This fixes a spurious-demotion bug the first design draft would have shipped.)
- **SHADOW-FIRST** — new `ws2_ledger` settings domain (`autonomy_feed` off/shadow/live, **default shadow**, fail-safe to shadow), read live per grading pass via `ledger/ws2_ledger_config.py` (the `repo_pulse_config` lineage). Shadow logs + counts what it *would* fire and writes nothing to the Trap; an operator flips to `live` after watching the pattern — no restart.
- **Exactly-once** per task (fires only on the genuine `open→resolved` transition; the idempotent `resolve()` guard makes re-grades no-ops). `grader.py` keeps its no-`genesis.routing` import lock.

`#1119`'s windowed `autonomy_events` earn-back ledger (migration 0067) consumes the *same* manager seam — so `live` automatically feeds both the lifetime counters and the windowed reader. No new table/migration.

## Verification
- Removed the 3 obsolete pipeline autonomy tests; added **9 grader autonomy-feed tests** (shadow/live/off, failure-only on cancel/slowness, completed-only-not-first-attempt, exactly-once across re-grade, manager-failure isolation). 23 grader tests + 15 pipeline + 45 settings + 67 (ledger + learning-init) all green; no-LLM lock explicitly re-verified; `ruff --no-cache` clean.
- **E2E on a copy of the live DB with the real `AutonomyManager`**: `shadow` → **0** `autonomy_events` written; `live` → **1** real `{category: direct_session, kind: success}` event. No prod mutation.
- `skip-when-graded` (§3.3) **tabled** — `InteractionSummary` carries no task/outreach ref, so the narrow join can't be built yet (locked decision #7).

## Deploy
Runtime code — `git pull` + server restart. Autonomy feed is **shadow** on every install until an operator sets `ws2_ledger.autonomy_feed: live`. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)