### PR TITLE
feat(code-intel): managed genesis-code-intel-freeze kill-switch unit

### DIFF
--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -113,10 +113,27 @@ working I/O throttle here) under load and kills a run that can't make headway. A
 guardrail test (`tests/test_scripts/test_code_intel_index.py`) fails the build on
 any new raw spawn site. `CODE_INTEL_INDEX_DISABLE=1` skips indexing entirely.
 
+**Emergency kill-switch — `genesis-code-intel-freeze`.** A managed systemd USER
+unit (`scripts/code_intel_freeze.sh`) that holds BOTH single-flight locks (the
+main-repo lock and the runner self-lock), so while armed nothing indexes at all:
+the idle runner exits each tick untouched and a manual/hook entrypoint run exits
+75 ("host-frozen — keep the marker"). Rendered by bootstrap but **not** enabled —
+it is an on-demand lever. Arming stops any in-flight index scope first
+(kill-then-seal), so it engages in ~a second even mid-storm:
+
+```
+systemctl --user start   genesis-code-intel-freeze    # arm now
+systemctl --user enable  genesis-code-intel-freeze    # arm across reboots too
+systemctl --user stop    genesis-code-intel-freeze    # disarm
+```
+
+For a single index run, `CODE_INTEL_INDEX_DISABLE=1` or stopping
+`genesis-code-intel.timer` are lighter alternatives.
+
 **Do NOT call CBM's `index_repository` MCP tool for a fresh full index of
-`~/genesis`.** It runs in-process and bypasses the lock, the caps, AND the host
-kill-switch — a from-scratch full index that way is exactly what read-saturated
-the container. Queue a marker instead and let the idle runner do it:
+`~/genesis`.** It runs in-process and bypasses the lock, the caps, AND the
+freeze kill-switch — a from-scratch full index that way is exactly what
+read-saturated the container. Queue a marker instead and let the idle runner do it:
 `python3 scripts/lib/index_marker.py write --repo ~/genesis --tools both --mode fast`.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,12 @@ pollers split updates and break approval buttons),
 prune, and label-aware attention-snapshot GC; see `scripts/disk_hygiene.sh`),
 `genesis-cc-align.timer` (nightly host CC/Node pin alignment via the guardian
 gateway, so the host recovery brain never lags a pin bump between updates; see
-`scripts/cc_align_host.sh`). MCP servers are CC child processes
+`scripts/cc_align_host.sh`), `genesis-code-intel.timer` (idle-gated code-intel
+index-request consumer; see `scripts/code_intel_runner.sh`) with
+`genesis-code-intel-freeze.service` as its on-demand kill-switch (rendered but
+NOT auto-enabled — `systemctl --user start/stop genesis-code-intel-freeze` to
+arm/disarm; holds both index locks so nothing indexes while armed; see
+`scripts/code_intel_freeze.sh`). MCP servers are CC child processes
 (not systemd) — code changes take effect on next CC session start.
 
 ## Common Commands

--- a/scripts/code_intel_freeze.sh
+++ b/scripts/code_intel_freeze.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# code_intel_freeze.sh — the managed code-intelligence KILL-SWITCH.
+#
+#   Usage: code_intel_freeze.sh [repo_path]   (default: the repo this script lives in)
+#
+# Holds BOTH single-flight locks that gate all code-intel indexing, so while it
+# runs NOTHING indexes:
+#   1. the main repo's per-repo lock (same path code_intel_index.sh takes) — a
+#      manual/hook entrypoint run for that repo hits the held lock and exits
+#      CODE_INTEL_INDEX_LOCK_SKIP_RC (the idle runner sets 75 → "host-frozen,
+#      keep the marker", never a false success);
+#   2. the runner's self-lock — the idle runner (code_intel_runner.sh) exits its
+#      tick immediately without processing ANY marker (any repo), so even a
+#      second checkout can't sneak an index in.
+#
+# This is the repo-shipped replacement for the hand-armed `systemd-run` freeze
+# transient that the 2026-07-13 load-spike postmortem flagged (rec #3): a
+# kill-switch worth having is worth a unit file with arm/disarm + boot
+# persistence. Arm/disarm as a systemd USER unit:
+#
+#   systemctl --user start   genesis-code-intel-freeze     # arm (this session)
+#   systemctl --user enable  genesis-code-intel-freeze     # arm across reboots
+#   systemctl --user stop    genesis-code-intel-freeze     # disarm
+#   systemctl --user disable genesis-code-intel-freeze     # stop arming on boot
+#
+# The unit's ExecStartPre stops any in-flight index scope FIRST (kill-then-seal),
+# so arming during a storm seals in ~a second instead of politely waiting out a
+# 17-min full index. cbm 0.9 can't resume a killed full — acceptable for an
+# emergency lever; the runner's full-backoff (index_marker.py) absorbs the
+# aftermath and retries cheap fast passes until disarmed.
+#
+# The lock ACQUISITION recipe below is byte-for-byte the one in
+# code_intel_index.sh / code_intel_runner.sh; the freeze E2E test
+# (test_code_intel_freeze.py) drives the real entrypoint against a live armed
+# freeze, so any drift in the recipe fails CI rather than silently no-op'ing.
+
+set -u
+
+REPO_PATH="${1:-}"
+if [ -z "$REPO_PATH" ]; then
+    # Default to the repo this script ships in (scripts/ -> repo root).
+    REPO_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+fi
+if [ ! -d "$REPO_PATH" ]; then
+    printf '[code-intel-freeze] ERROR: repo path not a directory: %s\n' "$REPO_PATH" >&2
+    exit 1
+fi
+# Physical path — the per-repo lock is keyed on it (must match the entrypoint's
+# `cd && pwd -P`, so a symlinked spelling maps to the same lock).
+REPO_PATH="$(cd "$REPO_PATH" && pwd -P)"
+
+GENESIS_HOME="${GENESIS_HOME:-$HOME/.genesis}"
+LOCK_DIR="$GENESIS_HOME/locks"
+mkdir -p "$LOCK_DIR" 2>/dev/null || LOCK_DIR="${TMPDIR:-/tmp}"
+
+# Same derivation as code_intel_index.sh (16-hex sha1 of the physical repo path)
+# and code_intel_runner.sh (fixed runner self-lock name).
+REPO_LOCK="$LOCK_DIR/code-intel-$(printf '%s' "$REPO_PATH" | sha1sum | cut -c1-16).lock"
+RUNNER_LOCK="$LOCK_DIR/code-intel-runner.lock"
+
+_log() { printf '%s [code-intel-freeze] %s\n' "$(date -Iseconds 2>/dev/null || date)" "$*"; }
+
+if ! command -v flock >/dev/null 2>&1; then
+    _log "ERROR: flock not available — cannot arm the freeze"
+    exit 1
+fi
+
+# Acquire a lock on fd $1 for file $2, describing it as $3. Try non-blocking
+# first (the common case: nothing indexing) so we can log a loud "waiting" line
+# before we block — otherwise a mid-index arm looks like a silent hang.
+_hold() {
+    local fd="$1" file="$2" label="$3"
+    eval "exec $fd>\"\$file\"" || { _log "ERROR: cannot open $label lock ($file)"; exit 1; }
+    if ! flock -n "$fd"; then
+        _log "waiting for in-flight indexing to release the $label lock…"
+        flock "$fd"   # blocking — we WILL seize it (ExecStartPre already killed the scope)
+    fi
+    _log "held $label lock ($file)"
+}
+
+_hold 9 "$REPO_LOCK" "repo"
+_hold 8 "$RUNNER_LOCK" "runner"
+
+_log "ARMED — all code-intel indexing is frozen (repo=$REPO_PATH). Stop this unit to disarm."
+
+# Hold the locks open until systemd stops us. The backgrounded `sleep` INHERITS
+# lock fds 8/9, so it must be killed on the way out or an orphaned sleep keeps
+# the locks held after we exit (systemd's cgroup SIGKILL would reap it, but the
+# trap makes release deterministic for a plain SIGTERM too). Closing fds 8/9 in
+# THIS shell releases the locks.
+_sleep_pid=""
+_disarm() { _log "disarming — releasing code-intel locks"; [ -n "$_sleep_pid" ] && kill "$_sleep_pid" 2>/dev/null; exit 0; }
+trap _disarm TERM INT
+sleep infinity &
+_sleep_pid=$!
+wait "$_sleep_pid"

--- a/scripts/lib/code_intel_index.sh
+++ b/scripts/lib/code_intel_index.sh
@@ -123,11 +123,12 @@ LOCK_FILE="$LOCK_DIR/code-intel-$(printf '%s' "$REPO_PATH" | sha1sum | cut -c1-1
 # `flock -n 9` failure is indistinguishable from "lock held" otherwise).
 if command -v flock >/dev/null 2>&1 && { exec 9>"$LOCK_FILE"; } 2>/dev/null; then
     if ! flock -n 9; then
-        # Lock held: either a concurrent index, or the host's genesis-code-intel-freeze
-        # unit holding THIS flock as a kill-switch. Default rc 0 (back-compat); the
-        # runner sets CODE_INTEL_INDEX_LOCK_SKIP_RC=75 so it can tell "frozen — keep
-        # the marker" apart from a real success. The lock ACQUISITION above is
-        # byte-unchanged, so the freeze keeps neutralizing every trigger regardless.
+        # Lock held: either a concurrent index, or the managed genesis-code-intel-freeze
+        # user unit (scripts/code_intel_freeze.sh) holding THIS flock as a kill-switch.
+        # Default rc 0 (back-compat); the runner sets CODE_INTEL_INDEX_LOCK_SKIP_RC=75
+        # so it can tell "frozen — keep the marker" apart from a real success. The lock
+        # ACQUISITION above is byte-unchanged, so the freeze keeps neutralizing every
+        # trigger regardless.
         _log "skip: an index for $REPO_PATH is already running (lock held)"
         exit "${CODE_INTEL_INDEX_LOCK_SKIP_RC:-0}"
     fi

--- a/scripts/systemd/genesis-code-intel-freeze.service.template
+++ b/scripts/systemd/genesis-code-intel-freeze.service.template
@@ -1,0 +1,32 @@
+[Unit]
+Description=Genesis Code-Intelligence Freeze — managed indexing kill-switch
+# Repo-shipped replacement for the hand-armed systemd-run freeze the 2026-07-13
+# load-spike postmortem flagged (an unmanaged transient nobody re-armed is how
+# that incident got its false premise). NOT auto-enabled by bootstrap — it is an
+# on-demand emergency lever. Arm/disarm:
+#   systemctl --user start   genesis-code-intel-freeze    # arm now
+#   systemctl --user enable  genesis-code-intel-freeze    # arm on boot too
+#   systemctl --user stop/disable genesis-code-intel-freeze   # disarm
+
+[Service]
+Type=simple
+WorkingDirectory=__REPO_DIR__
+# Kill-then-seal: stop any in-flight transient index scope FIRST so ExecStart's
+# blocking flock seals in ~a second instead of waiting out a 17-min full index.
+# The '-' prefix ignores a non-zero exit (nothing running / no match); systemctl
+# itself expands the glob against currently-loaded units. Killing the scope makes
+# the entrypoint release its per-repo lock, which ExecStart then seizes.
+ExecStartPre=-/usr/bin/systemctl --user stop code-intel-*.scope
+ExecStart=/bin/bash __REPO_DIR__/scripts/code_intel_freeze.sh __REPO_DIR__
+# Needs systemctl (ExecStartPre glob-stop), flock, sha1sum, date. No venv/tool
+# PATH required — this holds locks, it never indexes.
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Restart=no
+StandardOutput=journal
+StandardError=journal
+# Writes only the lock files under ~/.genesis/locks.
+ProtectSystem=strict
+ReadWritePaths=%h
+
+[Install]
+WantedBy=default.target

--- a/tests/test_scripts/test_code_intel_freeze.py
+++ b/tests/test_scripts/test_code_intel_freeze.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/code_intel_freeze.sh — the managed indexing kill-switch.
+
+The freeze holds BOTH single-flight locks that gate code-intel indexing:
+  1. the main repo's per-repo lock (same path code_intel_index.sh derives), so a
+     manual/hook entrypoint run for that repo exits CODE_INTEL_INDEX_LOCK_SKIP_RC
+     (the runner's 75 → "host-frozen, keep the marker") instead of indexing;
+  2. the runner's self-lock (code_intel_runner.sh), so an idle tick can't process
+     ANY marker while armed.
+
+The headline test arms the REAL freeze and runs the REAL entrypoint against it,
+so any drift between the two scripts' lock-path recipes fails CI here rather than
+silently turning the kill-switch into a no-op. Everything is binary-independent
+(fake indexer via PATH injection) so it runs in a toolless CI runner.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FREEZE = _REPO_ROOT / "scripts" / "code_intel_freeze.sh"
+_ENTRYPOINT = _REPO_ROOT / "scripts" / "lib" / "code_intel_index.sh"
+_TEMPLATE = _REPO_ROOT / "scripts" / "systemd" / "genesis-code-intel-freeze.service.template"
+
+_SYSTEM_PATH = "/usr/bin:/bin"
+
+
+def _write_exec(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = Path(os.path.realpath(tmp_path / "repo"))
+    repo.mkdir(exist_ok=True)
+    (repo / ".git").mkdir(exist_ok=True)
+    return repo
+
+
+def _lock_dir(tmp_path: Path) -> Path:
+    return tmp_path / ".genesis" / "locks"
+
+
+def _repo_lock_path(tmp_path: Path, repo: Path) -> Path:
+    """Recompute the repo lock path the SAME way the shell does (shell out to
+    sha1sum so this test can't drift from the scripts by reimplementing it)."""
+    digest = subprocess.run(
+        ["bash", "-c", 'printf "%s" "$1" | sha1sum | cut -c1-16', "_", str(repo)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return _lock_dir(tmp_path) / f"code-intel-{digest}.lock"
+
+
+def _arm_freeze(tmp_path: Path, repo: Path, logfile: Path) -> subprocess.Popen:
+    """Start the freeze in the background; return once it has logged ARMED."""
+    env = {
+        "PATH": _SYSTEM_PATH,
+        "HOME": str(tmp_path),
+        "GENESIS_HOME": str(tmp_path / ".genesis"),
+    }
+    fh = logfile.open("w")
+    proc = subprocess.Popen(
+        ["bash", str(_FREEZE), str(repo)],
+        env=env,
+        stdout=fh,
+        stderr=subprocess.STDOUT,
+    )
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        if "ARMED" in logfile.read_text():
+            return proc
+        if proc.poll() is not None:
+            raise AssertionError(f"freeze exited early: {logfile.read_text()}")
+        time.sleep(0.1)
+    proc.kill()
+    raise AssertionError(f"freeze never armed within 20s: {logfile.read_text()}")
+
+
+def _disarm(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.terminate()  # SIGTERM → trap → releases locks
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_armed_freeze_makes_entrypoint_exit_skip_rc(tmp_path):
+    """Armed freeze holds the repo lock → the real entrypoint exits 75."""
+    repo = _make_repo(tmp_path)
+    logfile = tmp_path / "freeze.log"
+    proc = _arm_freeze(tmp_path, repo, logfile)
+    try:
+        env = {
+            "PATH": _SYSTEM_PATH,
+            "HOME": str(tmp_path),
+            "GENESIS_HOME": str(tmp_path / ".genesis"),
+            "CODE_INTEL_INDEX_LOCK_SKIP_RC": "75",
+        }
+        res = subprocess.run(
+            ["bash", str(_ENTRYPOINT), str(repo), "cbm", "fast"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert res.returncode == 75, (
+            f"expected 75 (frozen), got {res.returncode}: {res.stdout}{res.stderr}"
+        )
+        assert "lock held" in res.stdout, res.stdout
+    finally:
+        _disarm(proc)
+
+
+def test_armed_freeze_holds_runner_self_lock(tmp_path):
+    """Armed freeze also holds the runner self-lock → an idle tick can't run.
+
+    Verified directly: a non-blocking flock on the runner lock must fail while
+    armed (the freeze holds it), and succeed once disarmed.
+    """
+    repo = _make_repo(tmp_path)
+    logfile = tmp_path / "freeze.log"
+    runner_lock = _lock_dir(tmp_path) / "code-intel-runner.lock"
+    proc = _arm_freeze(tmp_path, repo, logfile)
+    try:
+        assert runner_lock.exists(), "freeze did not create the runner lock"
+        with runner_lock.open("w") as fh:
+            try:
+                fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                raise AssertionError("runner lock was NOT held while armed")
+            except BlockingIOError:
+                pass  # expected: the freeze holds it
+    finally:
+        _disarm(proc)
+    # After disarm the runner lock is free again.
+    with runner_lock.open("w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)  # must not raise
+        fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+def test_entrypoint_proceeds_after_disarm(tmp_path):
+    """Once the freeze is stopped, the entrypoint indexes normally (rc=0)."""
+    repo = _make_repo(tmp_path)
+    logfile = tmp_path / "freeze.log"
+    # Fake cbm so a real index "runs" without systemd or the real binary.
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    toollog = tmp_path / "tool.log"
+    _write_exec(
+        fakebin / "codebase-memory-mcp", f'#!/usr/bin/env bash\necho "ran:$*" >> "{toollog}"\n'
+    )
+    # Minimal PATH (no systemd-run) → rlimit fallback path actually invokes the tool.
+    minbin = tmp_path / "minbin"
+    minbin.mkdir()
+    for tool in (
+        "bash",
+        "sh",
+        "env",
+        "mkdir",
+        "sha1sum",
+        "cut",
+        "flock",
+        "nice",
+        "date",
+        "dirname",
+    ):
+        src = Path("/usr/bin") / tool
+        if not src.exists():
+            src = Path("/bin") / tool
+        if src.exists() and not (minbin / tool).exists():
+            (minbin / tool).symlink_to(src)
+    path = f"{fakebin}:{minbin}"
+
+    proc = _arm_freeze(tmp_path, repo, logfile)
+    _disarm(proc)  # disarm immediately, then the entrypoint should proceed
+
+    env = {
+        "PATH": path,
+        "HOME": str(tmp_path),
+        "GENESIS_HOME": str(tmp_path / ".genesis"),
+        "CODE_INTEL_INDEX_LOCK_SKIP_RC": "75",
+        "CODE_INTEL_WATCHDOG_INTERVAL": "1",
+        "CODE_INTEL_WATCHDOG_WARMUP_S": "0",
+        "CODE_INTEL_FAKE_LOADAVG": "0",
+        "CODE_INTEL_FAKE_IOWAIT": "0",
+    }
+    res = subprocess.run(
+        ["bash", str(_ENTRYPOINT), str(repo), "cbm", "fast"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert res.returncode == 0, f"{res.returncode}: {res.stdout}{res.stderr}"
+    assert "ran:" in toollog.read_text(), "fake cbm did not run after disarm"
+
+
+# ── template sanity ────────────────────────────────────────────────────────
+
+
+def test_template_kill_then_seal_and_install():
+    text = _TEMPLATE.read_text(encoding="utf-8")
+    # ExecStartPre stops in-flight scopes (kill-then-seal), ExecStart runs the script.
+    assert "ExecStartPre=" in text and "stop code-intel-*.scope" in text
+    assert "scripts/code_intel_freeze.sh" in text
+    # Boot-persistence install section present (enable → arm on reboot).
+    assert "WantedBy=default.target" in text
+    # Only the known sed placeholders appear.
+    import re
+
+    placeholders = set(re.findall(r"__[A-Z_]+__", text))
+    assert placeholders <= {"__HOME__", "__VENV__", "__REPO_DIR__", "__CC_BIN_DIR__"}, placeholders


### PR DESCRIPTION
## Problem

The 2026-07-13 load-spike postmortem (`incident-20260713-load-spike-rootcause.md`, rec #3) found the code-intel "freeze" kill-switch was an **unmanaged, hand-armed `systemd-run` transient with zero repo references** — which is precisely why *no freeze was active* going into the incident (nobody re-armed it after the prior storm). The idle runner already ships the `rc=75` "host-frozen — keep the marker" plumbing *expecting* such a switch, but nothing in the repo implemented one.

## Fix

Ship it as a managed systemd **user** unit.

**`scripts/code_intel_freeze.sh`** holds BOTH single-flight locks that gate all code-intel indexing:
- the **main-repo per-repo lock** — same 16-hex sha1-of-physical-path recipe as `code_intel_index.sh` — so a manual/hook entrypoint run for `~/genesis` exits `CODE_INTEL_INDEX_LOCK_SKIP_RC` (the runner's 75), never a false success;
- the **runner self-lock** — so an idle `genesis-code-intel.timer` tick exits immediately without processing *any* repo's marker.

Total freeze: while armed, nothing indexes and every pending marker is preserved untouched.

**`genesis-code-intel-freeze.service.template`** uses **kill-then-seal**: `ExecStartPre` stops any in-flight `code-intel-*.scope` first, so the blocking flock seals in ~a second instead of waiting out a 17-min full index (the exact emergency scenario — 07-13's freeze was armed mid-storm). Rendered by the existing bootstrap template glob but **NOT auto-enabled** (only timers are), with `[Install] WantedBy=default.target` for opt-in boot persistence.

```
systemctl --user start   genesis-code-intel-freeze    # arm now
systemctl --user enable  genesis-code-intel-freeze    # arm across reboots
systemctl --user stop    genesis-code-intel-freeze    # disarm
```

## Verification — live E2E drill on this install

Rendered the unit via the exact bootstrap `sed`, then drilled every advertised behavior against the **deployed** entrypoint (proving cross-script lock parity — the freeze locked `code-intel-4408aa696643ed00.lock`, the same file `~/genesis/scripts/lib/code_intel_index.sh` checks):

- **arm → deployed entrypoint exits `rc=75`** ("lock held"); journal shows both locks held + `ARMED`.
- **runner tick while armed → "another runner tick is in progress — exiting"**, indexed nothing.
- **disarm → both locks FREE** (non-blocking flock succeeds) — confirms the SIGTERM release path.
- **kill-then-seal → a live dummy `code-intel-drilltest.scope` went `active`→`inactive` on arm**, freeze sealed.
- **enable → boot-persistence symlink created; disable → removed.**

The pytest suite (`test_code_intel_freeze.py`, 4 tests) drives the **real** entrypoint against a live-armed freeze, so any drift in the lock-path recipe fails CI rather than silently no-op'ing the switch. It also **caught a real bug pre-merge**: the backgrounded `sleep infinity` inherits the lock fds, so a plain SIGTERM left an orphan holding the locks — now killed in the disarm trap for deterministic release. Existing guardrail suite (`test_code_intel_index.py`, 29 tests) green with the new template in-tree.

## Deploy path

Runtime script + unit-template change. Existing installs: `git pull` + `update.sh` re-renders the unit (daemon-reload); **not** enabled — an on-demand lever, docs give the arm command. Fresh clones: bootstrap. Generalizable — no install-specific values (paths via `__REPO_DIR__`/`__HOME__` placeholders; lock dir via `${GENESIS_HOME:-$HOME/.genesis}`).

## Docs

`.claude/docs/code-intelligence.md` (kill-switch section + arm/disarm), `CLAUDE.md` "Other units", and corrected the stale "host's unit" comment in `code_intel_index.sh` to point at the managed script.

Closes Cluster A sub-item (2) of follow-up `3cad9b57`. Sub-item (1) (the 2G cap) is closed separately as disproven-with-evidence (a cold full+semantic cbm index peaked 564M under the 2G cap — ~3.6x headroom).

Ledger: 4ecdb559e2804791bc3f30a0e7b5fcd8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
