### PR TITLE
feat(eval): install-local golden sets — conventions + encrypted backup

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -72,7 +72,7 @@ _write_status() {
     if [ "${_T2_STATUS:-}" = "ok" ]; then _offsite_confirmed=true; fi
     mkdir -p "$(dirname "$_STATUS_FILE")"
     cat > "$_STATUS_FILE" <<STATUSEOF
-{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}","offsite_confirmed":$_offsite_confirmed,"tier2_backend":"${_T2_BACKEND:-none}","snapshot_id":"${_T2_STAMP:-}","snapshot_count":${_T2_SNAPSHOT_COUNT:-null},"pruned_count":${_T2_PRUNED:-null},"tier1_pushed":$_TIER1_PUSHED}
+{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"eval_files":${_EVAL_COUNT:-0},"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}","offsite_confirmed":$_offsite_confirmed,"tier2_backend":"${_T2_BACKEND:-none}","snapshot_id":"${_T2_STAMP:-}","snapshot_count":${_T2_SNAPSHOT_COUNT:-null},"pruned_count":${_T2_PRUNED:-null},"tier1_pushed":$_TIER1_PUSHED}
 STATUSEOF
 }
 trap '_write_status; backend_cleanup' EXIT
@@ -341,6 +341,32 @@ if [ -d "$HOME/.genesis/infrastructure" ]; then
     for _f in profile.json annotations.json INFRASTRUCTURE.md; do
         [ -f "$HOME/.genesis/infrastructure/$_f" ] && cp "$HOME/.genesis/infrastructure/$_f" infrastructure/
     done
+fi
+
+# --- 6c. Eval golden sets (encrypted — hand-graded rubric calibration data
+# holding recalled memory content: PII-bearing like section 4, and expensive
+# to recreate. Install-local (~/.genesis/eval), absent on a fresh install. ---
+_EVAL_DIR="$HOME/.genesis/eval"
+if [ -d "$_EVAL_DIR" ]; then
+    log "Backing up eval golden sets..."
+    mkdir -p eval
+    # Purge any pre-encryption plaintext.
+    find eval -type f ! -name '*.gpg' -delete 2>/dev/null || true
+    if ! $_ENCRYPT_READY; then
+        log "WARNING: GENESIS_BACKUP_PASSPHRASE not set — skipping eval (refusing plaintext)"
+    else
+        while IFS= read -r -d '' src; do
+            rel="${src#"$_EVAL_DIR"/}"
+            dst="eval/${rel}.gpg"
+            mkdir -p "$(dirname "$dst")"
+            if [ -f "$dst" ] && [ "$dst" -nt "$src" ]; then
+                continue
+            fi
+            encrypt_file "$src" "$dst" || log "WARNING: failed to encrypt eval/$rel"
+        done < <(find "$_EVAL_DIR" -type f -print0)
+        _EVAL_COUNT=$(find eval -type f -name '*.gpg' 2>/dev/null | wc -l)
+        log "Eval golden sets: $_EVAL_COUNT files (encrypted)"
+    fi
 fi
 
 # --- 7. Secrets (encrypted with GPG symmetric) ---

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -526,6 +526,26 @@ else
         fi
     done < <(find memory -maxdepth 1 -type f -name '*.gpg' -print0 2>/dev/null)
 
+    # Upload eval golden sets (§6c) into the COMPLETE off-site snapshot so a
+    # no-git fresh-box DR rehydrates them (restore §4b) — without this they were
+    # Tier-1-git-only. Encrypted; nests under eval/golden/, so mirror the
+    # relative path (backend_mkdir is idempotent). A failed upload of a present
+    # file flips _T2_OK, same contract as the payloads above.
+    if [ -d eval ]; then
+        backend_mkdir "${_T2_DIR}/eval"
+        while IFS= read -r -d '' f; do
+            rel="${f#eval/}"
+            _sub="$(dirname "$rel")"
+            [ "$_sub" != "." ] && backend_mkdir "${_T2_DIR}/eval/${_sub}"
+            if backend_put "$f" "${_T2_DIR}/eval/${rel}"; then
+                log "  off-site: uploaded eval/${rel}"
+            else
+                log "WARNING: off-site upload failed for eval/${rel}"
+                _T2_OK=false
+            fi
+        done < <(find eval -type f -name '*.gpg' -print0 2>/dev/null)
+    fi
+
     backend_mkdir "${_T2_DIR}/config_overrides"
     while IFS= read -r -d '' f; do
         fname=$(basename "$f")

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -382,6 +382,20 @@ _pull_from_offsite() {
             warn "off-site: failed to pull secrets.env.gpg from snapshot $latest — secrets will not be restored"
         fi
     fi
+    # eval golden sets — a no-git fresh box needs them from the snapshot too
+    # (restore §4b reads $BACKUP_DIR/eval). backend_list is single-level, so
+    # iterate eval/ and eval/golden/ separately; the .gpg filter drops the
+    # `golden` subdir entry so it is not mis-fetched as a flat file.
+    for _sub in eval eval/golden; do
+        while read -r fname; do
+            mkdir -p "$BACKUP_DIR/$_sub"
+            if backend_get "$snap/$_sub/$fname" "$BACKUP_DIR/$_sub/$fname"; then
+                log "  off-site: pulled $_sub/$fname"
+            else
+                warn "off-site: failed to pull $_sub/$fname from snapshot $latest"
+            fi
+        done < <(backend_list "$snap/$_sub" 2>/dev/null | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u)
+    done
     # creds — Tier-1 git normally carries these; a no-git box needs them from the
     # snapshot too (restore §8 reads $BACKUP_DIR/creds). backend_list is
     # single-level, so iterate creds/ and creds/ssh/ separately; the .gpg filter

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -64,6 +64,7 @@ _SQLITE_RESTORED=false
 _QDRANT_RESTORED=0
 _TRANSCRIPT_RESTORED=0
 _MEMORY_RESTORED=0
+_EVAL_RESTORED=0
 _CCMEM_RESTORED=false
 _OVERLAYS_RESTORED=0
 _SECRETS_RESTORED=false
@@ -78,7 +79,7 @@ _write_status() {
     _failures_json=$(printf '%s\n' "${_FAILURES[@]:-}" | python3 -c "import json,sys; print(json.dumps([l for l in sys.stdin.read().splitlines() if l]))")
     mkdir -p "$(dirname "$_STATUS_FILE")"
     cat > "$_STATUS_FILE" <<STATUSEOF
-{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"dry_run":$DRY_RUN,"sqlite_restored":$_SQLITE_RESTORED,"qdrant_restored":$_QDRANT_RESTORED,"transcripts_restored":$_TRANSCRIPT_RESTORED,"memory_restored":$_MEMORY_RESTORED,"cc_memory_restored":$_CCMEM_RESTORED,"overlays_restored":$_OVERLAYS_RESTORED,"secrets_restored":$_SECRETS_RESTORED,"duration_s":$_duration,"failures":$_failures_json}
+{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"dry_run":$DRY_RUN,"sqlite_restored":$_SQLITE_RESTORED,"qdrant_restored":$_QDRANT_RESTORED,"transcripts_restored":$_TRANSCRIPT_RESTORED,"memory_restored":$_MEMORY_RESTORED,"eval_restored":$_EVAL_RESTORED,"cc_memory_restored":$_CCMEM_RESTORED,"overlays_restored":$_OVERLAYS_RESTORED,"secrets_restored":$_SECRETS_RESTORED,"duration_s":$_duration,"failures":$_failures_json}
 STATUSEOF
 }
 # ── Deploy-in-progress marker ────────────────────────────────────────
@@ -628,6 +629,36 @@ if [ -d "$BACKUP_DIR/memory" ]; then
     log "Memory: $_MEMORY_RESTORED restored"
 else
     log "Memory: no backup directory"
+fi
+
+# ── 4b. Eval golden sets ─────────────────────────────────────────────
+log "--- Eval golden sets ---"
+if [ -d "$BACKUP_DIR/eval" ]; then
+    _EVAL_TARGET="$HOME/.genesis/eval"
+    mkdir -p "$_EVAL_TARGET"
+    while IFS= read -r -d '' src; do
+        rel="${src#"$BACKUP_DIR"/eval/}"
+        dst_rel="${rel%.gpg}"
+        dst="$_EVAL_TARGET/$dst_rel"
+        if [ -f "$dst" ] && [ "$dst" -nt "$src" ] && ! $FORCE; then
+            continue
+        fi
+        if $DRY_RUN; then
+            log "Eval: would restore $rel → $dst"
+            _EVAL_RESTORED=$(( _EVAL_RESTORED + 1 ))
+            continue
+        fi
+        mkdir -p "$(dirname "$dst")"
+        if [[ "$src" == *.gpg ]]; then
+            decrypt_file "$src" "$dst" || { warn "eval decrypt failed: $rel"; continue; }
+        else
+            cp "$src" "$dst"
+        fi
+        _EVAL_RESTORED=$(( _EVAL_RESTORED + 1 ))
+    done < <(find "$BACKUP_DIR/eval" -type f -print0 2>/dev/null)
+    log "Eval golden sets: $_EVAL_RESTORED restored"
+else
+    log "Eval golden sets: no backup directory"
 fi
 
 # ── 5. In-repo CC memory backup ──────────────────────────────────────

--- a/tests/eval/golden/memory_recall_grounding.jsonl
+++ b/tests/eval/golden/memory_recall_grounding.jsonl
@@ -8,8 +8,23 @@
 #    "expected": "<reference label, e.g. 'relevant' or 'not_relevant'>",
 #    "user_passed": <true if you'd judge this memory as relevant for
 #                    the query, false otherwise>,
+#    "fail_reason": "<OPTIONAL, only on user_passed=false — one of
+#                     answer-doesnt-exist | partial-topic-mismatch |
+#                     truly-off-topic>",
 #    "scorer_config": {"rubric_name": "memory_recall_grounding",
 #                      "query": "<the original query the user asked>"}}
+#
+# fail_reason separates a COVERAGE miss (answer-doesnt-exist: the store
+# held no answer, so recall returned a topical best-effort — not a recall
+# bug) from a RECALL-QUALITY miss (partial-topic-mismatch / truly-off-topic).
+# Compute the coverage-controlled effective rate by dropping
+# answer-doesnt-exist rows before comparing against the ship gate — a raw
+# rate can look sub-gate purely because the tested queries have no answers
+# in the store yet.
+#
+# This committed file is a TEMPLATE (no cases). An install's real golden
+# set contains recalled memory content and lives OUTSIDE the repo at
+# ~/.genesis/eval/golden/<rubric>.jsonl; pass it to run_calibration.
 #
 # Aim for 30-50 hand-graded cases before running calibration. Mix:
 #   - clear-positives: query and memory line up tightly


### PR DESCRIPTION
## What

Rubric calibration golden sets contain recalled memory content (PII-bearing), so an install's real set belongs **outside** the repo. This makes that a first-class, documented, durable pattern and closes a backup gap.

## Changes

- **Backup coverage** — `~/.genesis/eval` was uncovered, so hand-graded golden sets (expensive to recreate) had no durable copy. Adds an encrypted Tier-1 block that mirrors the auto-memory section (GPG per-file, refuses plaintext without a passphrase, skip-if-newer), a matching restore section, and status-JSON counts. Guarded on a fresh install where the dir is absent; round-trip verified byte-for-byte.
- **Template doc** — the committed `memory_recall_grounding.jsonl` stays a template and now documents the optional `fail_reason` field (`answer-doesnt-exist | partial-topic-mismatch | truly-off-topic`), which separates coverage misses from recall-quality misses when computing the effective calibration rate, and notes that real sets live install-local at `~/.genesis/eval/golden/`.

## Verification

- Backup/restore of the eval dir round-trips byte-for-byte (encrypt → restore → decrypt → diff).
- Existing backup + restore test suites pass (27 tests).
- `bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)