### PR TITLE
feat(resilience): isolate cc-tmp onto a dedicated incus storage volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   longer starve cc-tmp below the watchdog's floor. Applied automatically on
   fresh installs (host-setup) and on existing installs (guardian redeploy, when
   no CC session is live so a running session is never disturbed); size defaults
-  to 2 GiB, override with `CCTMPVOL_SIZE_GIB`. A new infrastructure-posture
-  check raises a standing alert on any container install where cc-tmp is not yet
-  isolated, and `scripts/lib/cc_tmp_volume.sh`'s `cc_tmp_volume_remove` reverts
-  it.
+  to 2 GiB, override with `CCTMPVOL_SIZE_GIB`. Requires a block/CoW-backed
+  storage pool (lvm/zfs/btrfs/ceph — what the default install uses); a dir-backed
+  pool can't enforce the cap on its own device, so it's skipped rather than
+  giving a cosmetic guarantee. A new infrastructure-posture check raises a
+  standing alert on any container install where cc-tmp is not yet isolated, and
+  `scripts/lib/cc_tmp_volume.sh`'s `cc_tmp_volume_remove` reverts it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **A runaway Claude Code temp write can no longer fill the container's root
+  disk.** `~/.genesis/cc-tmp` — the scratch space every CC session (and
+  genesis-server) writes to — now lives on its own size-capped incus storage
+  volume. A runaway temp write fills only that volume; the container root
+  filesystem is never touched (a full rootfs would otherwise kill every CC
+  session). It also guards the reverse case: unrelated rootfs growth can no
+  longer starve cc-tmp below the watchdog's floor. Applied automatically on
+  fresh installs (host-setup) and on existing installs (guardian redeploy, when
+  no CC session is live so a running session is never disturbed); size defaults
+  to 2 GiB, override with `CCTMPVOL_SIZE_GIB`. A new infrastructure-posture
+  check raises a standing alert on any container install where cc-tmp is not yet
+  isolated, and `scripts/lib/cc_tmp_volume.sh`'s `cc_tmp_volume_remove` reverts
+  it.
+
 ### Fixed
 
 - **Dashboard health cards stop crying wolf.** The API Keys and Queues cards

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -266,6 +266,13 @@ growth can starve cc-tmp below the watchdog's ~150 MiB sacred-ground floor. The
 split moves cc-tmp onto a dedicated, size-capped incus custom storage volume so
 neither can happen.
 
+**Pool requirement.** The isolation and the size cap only hold on a
+block/CoW-backed pool (lvm/zfs/btrfs/ceph) — the default install uses LVM-thin.
+On a `dir`-backed pool the custom volume shares the container root's filesystem
+and `size=` is not enforced without fs-level project quotas, so the guarantee
+would be cosmetic; `cc_tmp_volume_apply` detects this and skips with a note
+rather than reporting a false isolation.
+
 **Topology.** A thin custom volume in the container's own pool
 (`<container>-cc-tmp`), attached as a disk device named `cc-tmp` mounted at
 `~/.genesis/cc-tmp`, made writable by the container user via a `chown` from

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -256,3 +256,51 @@ git remote set-url origin <your public GENesis-AGI URL>
 
 The clone checks out the exact `HEAD` the bundle captured (`--all` records HEAD +
 every branch/tag), so the working tree matches the container at publish time.
+
+## cc-tmp Blast-Radius Volume (`scripts/lib/cc_tmp_volume.sh`)
+
+`~/.genesis/cc-tmp` is the TMPDIR for every Claude Code session and for
+genesis-server. On a shared rootfs it is a two-way hazard: a runaway temp write
+can fill the container root (killing every CC session), and unrelated rootfs
+growth can starve cc-tmp below the watchdog's ~150 MiB sacred-ground floor. The
+split moves cc-tmp onto a dedicated, size-capped incus custom storage volume so
+neither can happen.
+
+**Topology.** A thin custom volume in the container's own pool
+(`<container>-cc-tmp`), attached as a disk device named `cc-tmp` mounted at
+`~/.genesis/cc-tmp`, made writable by the container user via a `chown` from
+container-root (no `security.shifted` — a fresh volume mounts owned by
+container-root, and chown maps to the correct unprivileged host uid). Root's
+`limits.read`/`limits.write` IO caps are mirrored onto the device. Size defaults
+to 2 GiB (`CCTMPVOL_SIZE_GIB`).
+
+**How installs get it.** Fresh installs: `scripts/host-setup.sh` applies it at
+container creation. Existing installs: the guardian gateway `redeploy` verb runs
+`cc_tmp_volume_apply` on every update — but it **skips while a CC session is
+live** (attaching over cc-tmp would shadow that session's open temp files), so
+an always-busy install converges on a later quiet window. To apply immediately,
+during a quiet moment (no `claude` processes) run on the host:
+`bash -c '. <install-dir>/scripts/lib/cc_tmp_volume.sh && cc_tmp_volume_apply'`,
+then inside the container `systemctl --user restart genesis-server` to drop any
+shadowed temp fds.
+
+**Monitoring.** The infra-profile `storage` section carries an effective-state
+`cc_tmp_isolated` fact; the awareness posture check raises a standing
+`cc_tmp_shared_fs` alert on any lxc install where it is still `false` (gated on
+`virt.container == "lxc"` — never nags a non-container topology). The watchgod
+state file gains `fs_free_mb`/`fs_total_mb` describing the volume's headroom.
+Pool-level exhaustion is already covered by the guardian's `measure_storage_pool`
+tiers (a thin volume counts toward the pool's `data%`).
+
+**Snapshots.** incus container snapshots do NOT include custom volumes — so the
+guardian healthy-snapshot rollback lifeline never churns scratch data (desirable
+for temp). The volume is disposable: `cc_tmp_volume_remove` (host-side, during a
+quiet window) detaches and deletes it, reverting cc-tmp to the rootfs.
+
+**Rollback.** `bash -c '. <install-dir>/scripts/lib/cc_tmp_volume.sh && cc_tmp_volume_remove'`.
+
+**Seams** (defaults work on any single-container install; override only for
+non-standard topologies): `CCTMPVOL_SIZE_GIB` (2), `CCTMPVOL_CONTAINER` (resolved
+from guardian.yaml, else `genesis`), `CCTMPVOL_POOL` (root device's pool),
+`CCTMPVOL_VOLUME_NAME` (`<container>-cc-tmp`), `CCTMPVOL_USER` (`ubuntu`),
+`CCTMPVOL_DISABLE` (opt out).

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -634,6 +634,20 @@ PYEOF
                 1>&2 || true
         fi
 
+        # cc-tmp blast-radius isolation: put the container's CC scratch dir on
+        # its own size-capped storage volume. Same retrofit rationale as the
+        # zram block above (installer steps never re-run — existing installs get
+        # it here). Same best-effort/stderr-only/[ -f ]-guarded contract; 120s
+        # because a volume create + several incus execs run. The lib resolves
+        # the container from guardian.yaml and SKIPS when a CC session is live
+        # (it will not attach over a running session, so this never disrupts an
+        # in-flight session), converging on a later quiet apply.
+        if [ -f "$INSTALL_DIR/scripts/lib/cc_tmp_volume.sh" ]; then
+            timeout 120 bash -c \
+                ". '$INSTALL_DIR/scripts/lib/cc_tmp_volume.sh' && cc_tmp_volume_apply" \
+                1>&2 || true
+        fi
+
         # Clean up backup on success
         rm -rf "$BACKUP_DIR"
         ;;

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -601,6 +601,20 @@ if [ "$root_dev" != "$home_dev" ] && [ "${home_avail_kb:-0}" -gt "${root_avail_k
     fi
 fi
 
+# ── cc-tmp blast-radius isolation ────────────────────────────────────────────
+# Put the Claude Code scratch dir (~/.genesis/cc-tmp) on its own size-capped
+# incus storage volume so a runaway temp write can never fill the container root
+# filesystem (which would kill every CC session), and nothing else on the rootfs
+# can starve it. Applied outside the creation block AND after any homedisk
+# attach/restart above, so re-running host-setup retrofits existing containers
+# and the mount is never shadowed by a later bind. A fresh container has no CC
+# session, so it applies immediately; on a busy retrofit the lib skips (it won't
+# attach over a live session) and a later apply converges.
+# shellcheck source=lib/cc_tmp_volume.sh
+. "$(cd "$(dirname "$0")" && pwd)/lib/cc_tmp_volume.sh"
+CCTMPVOL_CONTAINER="$CONTAINER_NAME"
+cc_tmp_volume_apply
+
 # ── Verify container networking ──────────────────────────────
 # DHCP can be slow, especially on first boot or after UFW rules are freshly added.
 # Actively kick the DHCP client if needed rather than just waiting and hoping.

--- a/scripts/lib/cc_tmp_volume.sh
+++ b/scripts/lib/cc_tmp_volume.sh
@@ -1,0 +1,243 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# cc_tmp_volume_apply — isolate the container's Claude Code scratch dir
+# (~/.genesis/cc-tmp) onto a DEDICATED incus custom storage volume.
+#
+# WHY: cc-tmp is the TMPDIR for every CC session and for genesis-server. Today
+# it shares the container root filesystem with everything else, which is a
+# two-way hazard: a runaway temp write can fill the root disk (killing every CC
+# session), and any other rootfs writer can starve cc-tmp below the watchgod's
+# ~150 MiB "sacred ground" and kill sessions from the other direction. Moving
+# cc-tmp onto its own size-capped volume closes both: a runaway fills only its
+# own volume (the rootfs never moves), and nothing else can crowd it out.
+#
+# Spike-proven on the real host (2026-07-18, incus 6.0): a fresh custom volume
+# mounts owned by container-root; a `chown` from container-root makes it
+# writable by the container user with the correct unprivileged host mapping —
+# so `security.shifted` (privesc advisory GHSA-56mx-8g9f-5crf) is NOT needed.
+# The disk device hot-plugs onto a running container with no restart, and
+# filling the volume to ENOSPC left the container rootfs `df` byte-identical.
+#
+# Headroom: the volume is THIN (an empty create costs ~zero physical pool
+# space) and its SIZE caps the worst case (a full runaway adds at most
+# CCTMPVOL_SIZE_GIB to the pool). Physical pool exhaustion is already tiered-
+# alerted by the guardian's measure_storage_pool — so no create-time headroom
+# guard is needed here (an over-commit reading from `incus storage info` would
+# be the wrong signal on a thin pool anyway).
+#
+# Degrades gracefully to a one-line skip (rc=0, never aborts the caller under
+# `set -e`): no incus, container not running, a live CC session (attaching over
+# cc-tmp would shadow that session's open temp files — converges on a later
+# apply when quiet), already attached (idempotent), or a write-verify failure
+# (rolls the device back — an attached-but-UNWRITABLE cc-tmp would brick every
+# session, strictly worse than not-yet-isolated). We deliberately do NOT delete
+# the pre-split contents: they get harmlessly shadowed under the mount (tiny,
+# one-time) rather than risk yanking an in-flight genesis-server temp file.
+#
+# Sourced by scripts/host-setup.sh (fresh installs + retrofit on re-run) and by
+# the guardian-gateway.sh `redeploy` verb (existing installs retrofit on their
+# next update, when no CC session is live).
+#
+# Test seams (defaults are the real system; pytest overrides these and stubs
+# `incus` on PATH):
+CCTMPVOL_DISABLE="${CCTMPVOL_DISABLE:-0}"
+CCTMPVOL_SIZE_GIB="${CCTMPVOL_SIZE_GIB:-2}"      # floor 1; 4x the 500 MiB watchgod du-budget
+CCTMPVOL_CONTAINER="${CCTMPVOL_CONTAINER:-}"     # "" → guardian.yaml container_name, then "genesis"
+CCTMPVOL_USER="${CCTMPVOL_USER:-ubuntu}"         # in-container owner of cc-tmp
+CCTMPVOL_DEVICE_NAME="${CCTMPVOL_DEVICE_NAME:-cc-tmp}"
+CCTMPVOL_VOLUME_NAME="${CCTMPVOL_VOLUME_NAME:-}" # "" → <container>-cc-tmp (collision-safe per host)
+CCTMPVOL_POOL="${CCTMPVOL_POOL:-}"               # "" → the root device's pool
+CCTMPVOL_MOUNT_PATH="${CCTMPVOL_MOUNT_PATH:-}"   # "" → <container home>/.genesis/cc-tmp
+CCTMPVOL_GUARDIAN_YAML="${CCTMPVOL_GUARDIAN_YAML:-$HOME/.local/state/genesis-guardian/guardian.yaml}"
+
+# _cctmpvol_container — resolve the target container: explicit seam, else the
+# container_name from guardian.yaml, else the universal "genesis" default
+# (matches install_guardian.sh / guardian config).
+_cctmpvol_container() {
+    if [[ -n "$CCTMPVOL_CONTAINER" ]]; then
+        echo "$CCTMPVOL_CONTAINER"
+        return 0
+    fi
+    local name=""
+    if [[ -f "$CCTMPVOL_GUARDIAN_YAML" ]]; then
+        name="$(awk -F':' '/^container_name:/ {sub(/^[^:]*:/,""); gsub(/[" '"'"']/,""); print; exit}' \
+            "$CCTMPVOL_GUARDIAN_YAML" 2>/dev/null)" || name=""
+    fi
+    echo "${name:-genesis}"
+}
+
+# _cctmpvol_pool <container> — the pool backing the container's root device
+# (so the cc-tmp volume lives in the same pool), else the first storage pool.
+_cctmpvol_pool() {
+    local c="$1" pool=""
+    if [[ -n "$CCTMPVOL_POOL" ]]; then
+        echo "$CCTMPVOL_POOL"
+        return 0
+    fi
+    pool="$(incus config device get "$c" root pool 2>/dev/null)" || pool=""
+    if [[ -z "$pool" ]]; then
+        pool="$(incus storage list -f csv 2>/dev/null | head -1 | cut -d, -f1)" || pool=""
+    fi
+    echo "$pool"
+}
+
+# _cctmpvol_volume_name <container> — <container>-cc-tmp unless overridden.
+_cctmpvol_volume_name() {
+    if [[ -n "$CCTMPVOL_VOLUME_NAME" ]]; then
+        echo "$CCTMPVOL_VOLUME_NAME"
+    else
+        echo "${1}-cc-tmp"
+    fi
+}
+
+# _cctmpvol_size_gib — integer >= 1 (a bad value floors to the 2 GiB default).
+_cctmpvol_size_gib() {
+    local n="$CCTMPVOL_SIZE_GIB"
+    if [[ ! "$n" =~ ^[0-9]+$ || "$n" -lt 1 ]]; then
+        n=2
+    fi
+    echo "$n"
+}
+
+# _cctmpvol_mount_path <container> — the in-container cc-tmp path. Resolves the
+# container user's home via getent (config-overridable via the seam).
+_cctmpvol_mount_path() {
+    local c="$1" home=""
+    if [[ -n "$CCTMPVOL_MOUNT_PATH" ]]; then
+        echo "$CCTMPVOL_MOUNT_PATH"
+        return 0
+    fi
+    home="$(incus exec "$c" -- getent passwd "$CCTMPVOL_USER" 2>/dev/null | cut -d: -f6)" || home=""
+    echo "${home:-/home/$CCTMPVOL_USER}/.genesis/cc-tmp"
+}
+
+# cc_tmp_volume_apply — the entrypoint. Always returns 0.
+cc_tmp_volume_apply() {
+    echo "--- cc-tmp dedicated volume (blast-radius isolation) ---"
+
+    if [[ "$CCTMPVOL_DISABLE" == "1" ]]; then
+        echo "  Skipped: CCTMPVOL_DISABLE=1."
+        return 0
+    fi
+    if ! command -v incus >/dev/null 2>&1; then
+        echo "  Skipped: incus not available (not a guardian host vantage)."
+        return 0
+    fi
+
+    local c dev pool vol size path
+    c="$(_cctmpvol_container)"
+    dev="$CCTMPVOL_DEVICE_NAME"
+
+    if ! incus info "$c" >/dev/null 2>&1; then
+        echo "  Skipped: container '$c' not found."
+        return 0
+    fi
+    if [[ "$(incus info "$c" 2>/dev/null | awk -F': *' '/^Status:/ {print tolower($2); exit}')" != "running" ]]; then
+        echo "  Skipped: container '$c' is not running."
+        return 0
+    fi
+
+    # Idempotency: the device already exists → cc-tmp is already isolated.
+    if incus config device get "$c" "$dev" source >/dev/null 2>&1; then
+        echo "  cc-tmp already on a dedicated volume (device '$dev' on '$c')."
+        return 0
+    fi
+
+    # Live-CC guard: attaching over cc-tmp shadows a running session's open
+    # temp files. Skip; a later apply (redeploy, or a deliberate quiet-moment
+    # run) converges. Do NOT broaden to genesis-server — that would make the
+    # apply permanently unreachable on a live install; its cc-tmp temp files
+    # are short-lived and the pre-split contents are shadowed, not deleted.
+    if incus exec "$c" -- pgrep -x claude >/dev/null 2>&1; then
+        echo "  Skipped: a Claude Code session is live in '$c' — attach would shadow its"
+        echo "           open temp files. Converges on a later apply during a quiet window."
+        return 0
+    fi
+
+    pool="$(_cctmpvol_pool "$c")"
+    if [[ -z "$pool" ]]; then
+        echo "  Skipped: could not resolve a storage pool for '$c'."
+        return 0
+    fi
+    vol="$(_cctmpvol_volume_name "$c")"
+    size="$(_cctmpvol_size_gib)"
+    path="$(_cctmpvol_mount_path "$c")"
+
+    # Create the volume if absent (thin — an empty create costs ~zero pool).
+    if ! incus storage volume show "$pool" "$vol" >/dev/null 2>&1; then
+        if ! incus storage volume create "$pool" "$vol" "size=${size}GiB" >/dev/null 2>&1; then
+            echo "  WARNING: could not create storage volume '$pool/$vol' — cc-tmp NOT isolated."
+            return 0
+        fi
+        echo "  + created storage volume '$pool/$vol' (${size}GiB)."
+    fi
+
+    # Attach (hot-plug, no restart — spike-proven). Leave the volume on failure
+    # so a later apply can retry without re-creating it.
+    if ! incus config device add "$c" "$dev" disk \
+        pool="$pool" source="$vol" path="$path" >/dev/null 2>&1; then
+        echo "  WARNING: could not attach volume at '$path' — cc-tmp NOT isolated (volume kept for retry)."
+        return 0
+    fi
+
+    # IO-limit parity: a temp storm on cc-tmp must not bypass the host IO caps
+    # the root device carries. Mirror root's limits (each key set separately —
+    # the two-pair form errors 'Invalid key=value configuration', spike 2026-07-18).
+    local rlim wlim
+    rlim="$(incus config device get "$c" root limits.read 2>/dev/null)" || rlim=""
+    wlim="$(incus config device get "$c" root limits.write 2>/dev/null)" || wlim=""
+    [[ -n "$rlim" ]] && incus config device set "$c" "$dev" limits.read "$rlim" 2>/dev/null || true
+    [[ -n "$wlim" ]] && incus config device set "$c" "$dev" limits.write "$wlim" 2>/dev/null || true
+
+    # Make it writable by the container user (spike: fresh volume mounts owned
+    # by container-root; chown from container-root maps to the correct
+    # unprivileged host uid). Then VERIFY a real uid write, and ROLL BACK the
+    # device on failure — an attached-but-unwritable cc-tmp bricks every CC
+    # session, which is worse than staying un-isolated.
+    incus exec "$c" -- chown "$CCTMPVOL_USER:$CCTMPVOL_USER" "$path" 2>/dev/null || true
+    incus exec "$c" -- chmod 700 "$path" 2>/dev/null || true
+    local uid gid
+    uid="$(incus exec "$c" -- id -u "$CCTMPVOL_USER" 2>/dev/null)" || uid=""
+    gid="$(incus exec "$c" -- id -g "$CCTMPVOL_USER" 2>/dev/null)" || gid=""
+    if [[ -n "$uid" && -n "$gid" ]] \
+        && incus exec "$c" --user "$uid" --group "$gid" -- \
+            sh -c "touch '$path/.cctmpvol-verify' && rm -f '$path/.cctmpvol-verify'" 2>/dev/null; then
+        echo "  + cc-tmp now on dedicated volume '$pool/$vol' (${size}GiB) at $path on '$c'."
+    else
+        incus config device remove "$c" "$dev" >/dev/null 2>&1 || true
+        echo "  WARNING: volume attached but not writable by $CCTMPVOL_USER — rolled back the device."
+        echo "           cc-tmp stays on the rootfs (un-isolated). Check container idmap:"
+        echo "           incus config device add $c $dev disk pool=$pool source=$vol path=$path (then chown)."
+    fi
+    return 0
+}
+
+# cc_tmp_volume_remove — operator rollback / clean opt-out. Detaches the device
+# and deletes the volume (cc-tmp reverts to the rootfs). Always returns 0.
+cc_tmp_volume_remove() {
+    echo "--- Removing cc-tmp dedicated volume ---"
+    if ! command -v incus >/dev/null 2>&1; then
+        echo "  Skipped: incus not available."
+        return 0
+    fi
+    local c dev pool vol
+    c="$(_cctmpvol_container)"
+    dev="$CCTMPVOL_DEVICE_NAME"
+    if ! incus info "$c" >/dev/null 2>&1; then
+        echo "  Skipped: container '$c' not found."
+        return 0
+    fi
+    # Removing the device yanks the filesystem from under any open fd — refuse
+    # while a CC session is live.
+    if incus exec "$c" -- pgrep -x claude >/dev/null 2>&1; then
+        echo "  Skipped: a Claude Code session is live in '$c' — remove during a quiet window."
+        return 0
+    fi
+    pool="$(_cctmpvol_pool "$c")"
+    vol="$(_cctmpvol_volume_name "$c")"
+    incus config device remove "$c" "$dev" >/dev/null 2>&1 || true
+    incus storage volume delete "$pool" "$vol" >/dev/null 2>&1 || true
+    echo "  + cc-tmp reverted to the container rootfs (device + volume removed)."
+    return 0
+}

--- a/scripts/lib/cc_tmp_volume.sh
+++ b/scripts/lib/cc_tmp_volume.sh
@@ -160,6 +160,24 @@ cc_tmp_volume_apply() {
         echo "  Skipped: could not resolve a storage pool for '$c'."
         return 0
     fi
+
+    # The isolation AND the size cap only hold on a backend that both puts the
+    # volume on its own device/dataset and enforces a per-volume quota. A `dir`
+    # pool places the custom volume on the SAME host filesystem as the container
+    # root and only quotas with fs-level project quotas — so a runaway fill
+    # could still reach the rootfs and the cap would be cosmetic. Only apply on
+    # block/CoW backends where the guarantee is real; skip (honestly) otherwise.
+    local driver
+    driver="$(incus storage show "$pool" 2>/dev/null | awk -F': *' '/^driver:/ {print $2; exit}')"
+    case "$driver" in
+        lvm | zfs | btrfs | ceph) : ;;
+        *)
+            echo "  Skipped: pool '$pool' (driver='${driver:-unknown}') does not enforce a"
+            echo "           per-volume size cap on its own device — cc-tmp isolation would be"
+            echo "           cosmetic. A block/CoW-backed pool (lvm/zfs/btrfs/ceph) is required."
+            return 0 ;;
+    esac
+
     vol="$(_cctmpvol_volume_name "$c")"
     size="$(_cctmpvol_size_gib)"
     path="$(_cctmpvol_mount_path "$c")"

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -87,16 +87,32 @@ fs_free_mb() {
     echo "${result:-999999}"
 }
 
+fs_total_mb() {
+    # Total size of the filesystem containing the given path, in MB. After the
+    # cc-tmp blast-radius split this reports the dedicated volume's size, so the
+    # state file (and dashboard) can show the volume's capacity/headroom, not
+    # the rootfs's.
+    local result
+    result=$(df -BM --output=size "$1" 2>/dev/null | tail -1 | tr -d ' M') || true
+    echo "${result:-0}"
+}
+
 write_state() {
     local cc_tier="$1" cc_used="$2" sys_tier="$3" sys_pct="$4"
     local is_tmpfs="false"
     if df -T /tmp 2>/dev/null | grep -q tmpfs; then
         is_tmpfs="true"
     fi
+    # Filesystem headroom for cc-tmp's mount. Post-split these describe the
+    # dedicated volume; pre-split they describe the rootfs. Consumers read them
+    # via .get(..) so an older state file (without these keys) stays valid.
+    local cc_fs_free cc_fs_total
+    cc_fs_free=$(fs_free_mb "$CC_TMP_DIR")
+    cc_fs_total=$(fs_total_mb "$CC_TMP_DIR")
     local tmp="${STATE_FILE}.tmp"
     cat > "$tmp" <<EOF
 {
-  "cc_tmp": {"tier": "$cc_tier", "used_mb": $cc_used, "budget_mb": $CC_TMP_BUDGET_MB, "sacred_mb": $SACRED_GROUND_MB},
+  "cc_tmp": {"tier": "$cc_tier", "used_mb": $cc_used, "budget_mb": $CC_TMP_BUDGET_MB, "sacred_mb": $SACRED_GROUND_MB, "fs_free_mb": $cc_fs_free, "fs_total_mb": $cc_fs_total},
   "system_tmp": {"tier": "$sys_tier", "used_pct": $sys_pct, "is_tmpfs": $is_tmpfs},
   "poll_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
@@ -239,6 +255,10 @@ check_cc_tmp() {
 
     local tier="green"
 
+    # After the cc-tmp blast-radius split, free_mb measures the DEDICATED
+    # volume, so this sacred-ground trigger guards that volume (not the rootfs).
+    # On a 2 GiB volume it is a pure backstop behind the 450 MiB budget-red
+    # above; rootfs free-space monitoring lives in Zone B (/tmp) below.
     if (( used_mb > threshold_red )) || (( free_mb < SACRED_GROUND_MB )); then
         tier="red"
         _log_cc_pressure red "$used_mb" "$free_mb"   # capture BEFORE the nuclear cleanup erases it

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -195,7 +195,7 @@ _sync_deploy_targets() {
             # TimeoutStartSec) registers as drift and triggers a redeploy — the
             # archive below ships those units and the gateway's redeploy verb
             # copies them, but none of that fires unless the drift gate sees them.
-            GUARDIAN_PATHS="src/genesis/guardian src/genesis/util src/genesis/env.py src/genesis/observability src/genesis/db config/guardian-claude.md config/genesis-guardian.service config/genesis-guardian.timer config/genesis-guardian-watchman.service config/genesis-guardian-watchman.timer pyproject.toml scripts/install_guardian.sh scripts/guardian-gateway.sh scripts/lib/host_swap.sh"
+            GUARDIAN_PATHS="src/genesis/guardian src/genesis/util src/genesis/env.py src/genesis/observability src/genesis/db config/guardian-claude.md config/genesis-guardian.service config/genesis-guardian.timer config/genesis-guardian-watchman.service config/genesis-guardian-watchman.timer pyproject.toml scripts/install_guardian.sh scripts/guardian-gateway.sh scripts/lib/host_swap.sh scripts/lib/cc_tmp_volume.sh"
             DEPLOY_HASH=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 
             # ── Read host state ONCE: deployed_commit + node/cc versions ──

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -488,6 +488,15 @@ _INFRA_POSTURE_DETAIL = {
         "scripts/bootstrap.sh (installs + enables the watchdog timer via "
         "lib/network_resilience.sh)"
     ),
+    "cc_tmp_shared_fs": (
+        "the Claude Code scratch dir (~/.genesis/cc-tmp) shares a filesystem "
+        "with the container root — a runaway temp write can fill the root disk "
+        "and take every CC session down (the watchgod can only mitigate, not "
+        "prevent). On the host: re-run scripts/host-setup.sh, or the guardian "
+        "gateway redeploy applies scripts/lib/cc_tmp_volume.sh automatically "
+        "when no CC session is live (moves cc-tmp onto a dedicated storage "
+        "volume, size-capped so a runaway can never reach the rootfs)"
+    ),
 }
 
 
@@ -506,7 +515,7 @@ def _infra_profile_age_days(profile: dict) -> float | None:
 
 
 def _infra_missing_protections(profile: dict) -> list[str]:
-    """Evaluate the memory- and network-plane protection rules against profile facts.
+    """Evaluate the memory-, network-, and storage-plane protection rules against profile facts.
 
     Only an EXPLICIT defect value counts — absent/None facts stay silent.
     Tri-state contract for cgroup_memory_swap_max (collectors/container.py):
@@ -561,10 +570,20 @@ def _infra_missing_protections(profile: dict) -> list[str]:
             missing.append("networkd_keepconfig_missing")
         if network.get("network_watchdog_enabled") is False:
             missing.append("network_watchdog_absent")
+    # Storage plane: cc-tmp blast-radius isolation (EFFECTIVE-state fact from
+    # collectors/container.py::collect_storage). Gated on an lxc container —
+    # the remedy is a dedicated incus volume, which only exists on a container
+    # install; a bare-metal/other topology where the fact reads False is not
+    # actionable, so stay silent there.
+    if (
+        _facts("virt").get("container") == "lxc"
+        and _facts("storage").get("cc_tmp_isolated") is False
+    ):
+        missing.append("cc_tmp_shared_fs")
     return sorted(missing)
 
 
-_POSTURE_PLANES = ("memory", "host_system", "host_virt", "network")
+_POSTURE_PLANES = ("memory", "host_system", "host_virt", "network", "storage")
 
 
 def _infra_unverifiable_planes(profile: dict) -> list[str]:
@@ -588,7 +607,7 @@ def _infra_unverifiable_planes(profile: dict) -> list[str]:
 
 
 async def _check_infra_protection_posture(db) -> None:
-    """Alert when a memory- or network-plane protection is missing or the profile is stale.
+    """Alert when a memory-, network-, or storage-plane protection is missing or the profile is stale.
 
     One 'high' infrastructure_alert (dashboard + morning report; the WS-2 M10
     reconciler absorbs it into the durable open-set) describing the CURRENT

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -495,7 +495,8 @@ _INFRA_POSTURE_DETAIL = {
         "prevent). On the host: re-run scripts/host-setup.sh, or the guardian "
         "gateway redeploy applies scripts/lib/cc_tmp_volume.sh automatically "
         "when no CC session is live (moves cc-tmp onto a dedicated storage "
-        "volume, size-capped so a runaway can never reach the rootfs)"
+        "volume, size-capped so a runaway can never reach the rootfs; requires "
+        "a block/CoW-backed storage pool — lvm/zfs/btrfs/ceph)"
     ),
 }
 

--- a/src/genesis/guardian/collector.py
+++ b/src/genesis/guardian/collector.py
@@ -313,7 +313,11 @@ async def _collect_cpu(config: GuardianConfig) -> CPUInfo:
 async def _collect_disk(config: GuardianConfig) -> list[DiskInfo]:
     """Collect disk usage for key mount points."""
     disks = []
-    for mount in ["/", "/tmp", "/home"]:  # noqa: S108 - monitoring host mounts, not creating temp files
+    seen: set[str] = set()
+    # cc-tmp: after the blast-radius split it is its own mount; pre-split df
+    # resolves it to "/" (deduped below so it does not double-count).
+    cc_tmp = f"/home/{config.container_user}/.genesis/cc-tmp"
+    for mount in ["/", "/tmp", "/home", cc_tmp]:  # noqa: S108 - monitoring host mounts, not creating temp files
         try:
             rc, out = await _incus_exec(
                 config.container_name,
@@ -326,6 +330,9 @@ async def _collect_disk(config: GuardianConfig) -> list[DiskInfo]:
                 continue
             parts = lines[-1].split()
             if len(parts) >= 5:
+                if parts[0] in seen:
+                    continue  # cc-tmp resolved to an already-probed mount
+                seen.add(parts[0])
                 disks.append(DiskInfo(
                     mount=parts[0],
                     total_mb=int(parts[1]),

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -45,7 +45,7 @@ class GuardianWatchdog:
         "src/genesis/observability", "src/genesis/db",
         "config/guardian-claude.md", "pyproject.toml",
         "scripts/install_guardian.sh", "scripts/guardian-gateway.sh",
-        "scripts/lib/host_swap.sh",
+        "scripts/lib/host_swap.sh", "scripts/lib/cc_tmp_volume.sh",
     ]
     DRIFT_ALERT_THRESHOLD = 3   # Consecutive drifted ticks before alerting
     CC_TOKEN_WARN_AGE_DAYS = 335  # warn ~30d before a 1-year setup-token expires

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -443,7 +443,8 @@ async def collect_storage(
 
     # /tmp is a MEASUREMENT TARGET here (small tmpfs = known incident class),
     # not a temp-file location.
-    for label, path in (("root", "/"), ("home", str(Path.home())), ("tmp", "/tmp")):  # noqa: S108
+    cc_tmp_path = Path.home() / ".genesis" / "cc-tmp"
+    for label, path in (("root", "/"), ("home", str(Path.home())), ("tmp", "/tmp"), ("cc_tmp", str(cc_tmp_path))):  # noqa: S108
         try:
             st = os.statvfs(path)
             total = st.f_blocks * st.f_frsize
@@ -456,6 +457,21 @@ async def collect_storage(
             }
         except OSError:
             continue
+
+    # cc-tmp isolation — EFFECTIVE-state fact (measures the live filesystem,
+    # not on-disk config). True when ~/.genesis/cc-tmp sits on its own device
+    # (the dedicated blast-radius volume); False when it shares a device with
+    # its parent ~/.genesis (the rootfs — a runaway temp fill can fill root and
+    # kill every CC session). Absent when cc-tmp does not exist yet (pre-
+    # bootstrap). The posture rule that nags on False is gated on
+    # virt.container == "lxc", since the remedy (a dedicated incus volume) only
+    # applies on a container install.
+    try:
+        _cc_dev = os.stat(cc_tmp_path).st_dev
+        _parent_dev = os.stat(cc_tmp_path.parent).st_dev
+        facts["cc_tmp_isolated"] = _cc_dev != _parent_dev
+    except OSError:
+        pass
 
     return SectionResult(name="storage", facts=facts, metrics=metrics)
 

--- a/src/genesis/observability/service_status.py
+++ b/src/genesis/observability/service_status.py
@@ -298,6 +298,8 @@ def collect_cc_tmp_usage() -> dict:
             "cc_used_mb": cc.get("used_mb", 0),
             "cc_budget_mb": cc.get("budget_mb", 500),
             "cc_sacred_mb": cc.get("sacred_mb", 150),
+            "cc_fs_free_mb": cc.get("fs_free_mb", None),
+            "cc_fs_total_mb": cc.get("fs_total_mb", None),
             "sys_tier": sys_tmp.get("tier", "unknown"),
             "sys_used_pct": sys_tmp.get("used_pct", 0),
             "poll_at": data.get("poll_at", ""),

--- a/src/genesis/observability/snapshots/deploy_health.py
+++ b/src/genesis/observability/snapshots/deploy_health.py
@@ -71,6 +71,7 @@ GUARDIAN_HOST_PATHS = (
     "scripts/install_guardian.sh",
     "scripts/guardian-gateway.sh",
     "scripts/lib/host_swap.sh",
+    "scripts/lib/cc_tmp_volume.sh",
 )
 
 _HOST_STATE_FILE = "host_gateway_state.json"

--- a/tests/test_awareness/test_infra_protection_posture.py
+++ b/tests/test_awareness/test_infra_protection_posture.py
@@ -59,6 +59,8 @@ def _profile(
     networkd_route: object = True,
     keepconfig: object = True,
     watchdog: object = True,
+    cc_tmp_isolated: object = True,
+    container: object = "lxc",
     age_days: float = 0.0,
     collected_at: object = "auto",
 ) -> dict:
@@ -91,6 +93,8 @@ def _profile(
                     "network_watchdog_enabled": watchdog,
                 },
             },
+            "virt": {"status": "ok", "facts": {"container": container}},
+            "storage": {"status": "ok", "facts": {"cc_tmp_isolated": cc_tmp_isolated}},
         }
     }
     if collected_at is not None:
@@ -122,11 +126,13 @@ _ALL_DEFECTS = dict(
     networkd_route=True,  # networkd owns the route, so the network rules apply
     keepconfig=False,
     watchdog=False,
+    cc_tmp_isolated=False,
 )
 
 
 def test_all_defects_detected():
     assert _infra_missing_protections(_profile(**_ALL_DEFECTS)) == [
+        "cc_tmp_shared_fs",
         "container_swap_disabled",
         "container_swap_knob_off",
         "host_swap_absent",
@@ -138,6 +144,33 @@ def test_all_defects_detected():
 
 def test_healthy_profile_no_defects():
     assert _infra_missing_protections(_profile()) == []
+
+
+def test_cc_tmp_shared_fs_detected_in_lxc():
+    # cc-tmp NOT isolated on an lxc container → the nag fires.
+    assert "cc_tmp_shared_fs" in _infra_missing_protections(
+        _profile(cc_tmp_isolated=False, container="lxc")
+    )
+
+
+def test_cc_tmp_isolated_is_silent():
+    # cc-tmp on its own volume → no nag.
+    assert "cc_tmp_shared_fs" not in _infra_missing_protections(_profile(cc_tmp_isolated=True))
+
+
+def test_cc_tmp_not_nagged_off_lxc():
+    # Non-container topology: the remedy (a dedicated incus volume) is not
+    # actionable, so a False fact must stay silent.
+    assert "cc_tmp_shared_fs" not in _infra_missing_protections(
+        _profile(cc_tmp_isolated=False, container="none")
+    )
+
+
+def test_cc_tmp_fact_absent_is_silent():
+    # Fact not yet collected (pre-bootstrap) → silent.
+    prof = _profile(container="lxc")
+    del prof["sections"]["storage"]["facts"]["cc_tmp_isolated"]
+    assert "cc_tmp_shared_fs" not in _infra_missing_protections(prof)
 
 
 def test_absent_facts_are_silent():
@@ -487,6 +520,7 @@ def test_resilience_facts_are_covered():
         "networkd_manages_default_route",
         "networkd_default_route_keepconfig",
         "network_watchdog_enabled",
+        "cc_tmp_isolated",
     ):
         assert fact in src, f"posture rules no longer read {fact!r}"
 

--- a/tests/test_guardian/test_collector.py
+++ b/tests/test_guardian/test_collector.py
@@ -143,3 +143,35 @@ class TestCollectDiagnostics:
         # Container info should be default since it raised
         assert snap.container_status == ""
         assert snap.collected_at != ""
+
+
+async def test_collect_disk_probes_and_dedupes_cc_tmp(config, monkeypatch):
+    import genesis.guardian.collector as gc
+
+    cc_tmp = f"/home/{config.container_user}/.genesis/cc-tmp"
+    calls = []
+
+    async def fake_exec(container, *args):
+        mount = args[-1]
+        calls.append(mount)
+        target = "/" if mount in ("/", cc_tmp) else mount  # cc-tmp shares rootfs pre-split
+        return (0, "Mounted 1M Used Avail Use%\n" + f"{target} 1000 500 500 50%\n")
+
+    monkeypatch.setattr(gc, "_incus_exec", fake_exec)
+    disks = await gc._collect_disk(config)
+    assert cc_tmp in calls  # cc-tmp is probed
+    assert [d.mount for d in disks].count("/") == 1  # root+cc-tmp deduped to one row
+
+
+async def test_collect_disk_isolated_cc_tmp_is_own_row(config, monkeypatch):
+    import genesis.guardian.collector as gc
+
+    cc_tmp = f"/home/{config.container_user}/.genesis/cc-tmp"
+
+    async def fake_exec(container, *args):
+        mount = args[-1]  # each path is its own mount (cc-tmp isolated)
+        return (0, "Mounted 1M Used Avail Use%\n" + f"{mount} 2048 100 1948 5%\n")
+
+    monkeypatch.setattr(gc, "_incus_exec", fake_exec)
+    disks = await gc._collect_disk(config)
+    assert cc_tmp in [d.mount for d in disks]  # isolated cc-tmp surfaces as its own row

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -407,3 +407,40 @@ async def test_collect_network_suppresses_when_networkmanager(tmp_path, monkeypa
     result = await collect_network(etc_root=tmp_path)
     assert result.facts["networkd_manages_default_route"] is False
     assert result.facts["networkd_default_route_keepconfig"] is False
+
+
+# ── cc-tmp isolation (blast-radius split) ──────────────────────────────────
+
+
+async def test_storage_cc_tmp_not_isolated_same_fs(proc_root, sys_root, tmp_path, monkeypatch):
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert result.facts["cc_tmp_isolated"] is False  # shares a device with its parent
+    assert "cc_tmp" in result.metrics  # df headroom label present
+
+
+async def test_storage_cc_tmp_isolated_own_device(proc_root, sys_root, tmp_path, monkeypatch):
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+
+    class _S:
+        def __init__(self, dev):
+            self.st_dev = dev
+
+    def fake_stat(path, *a, **k):
+        return _S(1 if str(path).endswith("cc-tmp") else 2)
+
+    monkeypatch.setattr(_container.os, "stat", fake_stat)
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert result.facts["cc_tmp_isolated"] is True
+
+
+async def test_storage_cc_tmp_fact_absent_when_missing(proc_root, sys_root, tmp_path, monkeypatch):
+    home = tmp_path / "h"
+    (home / ".genesis").mkdir(parents=True)  # cc-tmp does not exist
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert "cc_tmp_isolated" not in result.facts

--- a/tests/test_scripts/test_cc_tmp_volume_sh.py
+++ b/tests/test_scripts/test_cc_tmp_volume_sh.py
@@ -1,0 +1,296 @@
+"""Behavioral tests for cc_tmp_volume_apply / cc_tmp_volume_remove
+(scripts/lib/cc_tmp_volume.sh).
+
+The functions are sourced from the REAL lib and driven under the callers'
+``set -euo pipefail`` (host-setup.sh and the gateway redeploy verb both run that
+way), with a stubbed ``incus`` on PATH that logs every invocation to
+``$INCUS_LOG`` and answers from ``INCUS_*`` env vars. A ``__DONE__`` sentinel
+printed after the call proves the function returned instead of tripping errexit
+— every guard/degrade path must never abort an install or a redeploy.
+
+Design facts encoded here were spike-proven on the real host (2026-07-18):
+attach hot-plugs live; a fresh volume needs ``chown`` from container-root (no
+security.shifted); IO limits are set one key per call; a full volume leaves the
+rootfs untouched.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts" / "lib" / "cc_tmp_volume.sh"
+HOST_SETUP = REPO_ROOT / "scripts" / "host-setup.sh"
+GATEWAY = REPO_ROOT / "scripts" / "guardian-gateway.sh"
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+WATCHDOG = REPO_ROOT / "src" / "genesis" / "guardian" / "watchdog.py"
+DEPLOY_HEALTH = REPO_ROOT / "src" / "genesis" / "observability" / "snapshots" / "deploy_health.py"
+
+# A single stub `incus` covering every subcommand the lib calls. Behavior is
+# driven by INCUS_* env vars; every invocation is appended to $INCUS_LOG so
+# tests can assert ordering AND absence ("no create when a session is live").
+_INCUS_STUB = r"""#!/bin/bash
+echo "$*" >> "$INCUS_LOG"
+case "$1" in
+  info)
+    [ "${INCUS_INFO_MISSING:-0}" = "1" ] && exit 1
+    echo "Status: ${INCUS_INFO_STATUS:-Running}"
+    exit 0 ;;
+  config)
+    if [ "$2 $3" = "device get" ]; then
+      dev="$5"; key="$6"
+      if [ "$dev" = "root" ]; then
+        case "$key" in
+          pool) echo "${INCUS_POOL:-default}" ;;
+          limits.read) echo "${INCUS_LIMIT_READ-190MB}" ;;
+          limits.write) echo "${INCUS_LIMIT_WRITE-90MB}" ;;
+        esac
+        exit 0
+      fi
+      if [ "$key" = "source" ]; then
+        [ "${INCUS_DEVICE_ATTACHED:-0}" = "1" ] && { echo "${INCUS_VOL:-vol}"; exit 0; }
+        exit 1
+      fi
+      exit 0
+    fi
+    [ "$2 $3" = "device add" ] && exit "${INCUS_ATTACH_RC:-0}"
+    exit 0 ;;
+  storage)
+    if [ "$2" = "list" ]; then echo "default,lvm,vg0,,1,CREATED"; exit 0; fi
+    if [ "$2 $3" = "volume show" ]; then exit "${INCUS_VOLUME_EXISTS:-1}"; fi
+    if [ "$2 $3" = "volume create" ]; then exit "${INCUS_CREATE_RC:-0}"; fi
+    exit 0 ;;
+  exec)
+    inner=""; seen=0
+    for a in "$@"; do
+      if [ "$seen" = "1" ]; then inner="$a"; break; fi
+      [ "$a" = "--" ] && seen=1
+    done
+    case "$inner" in
+      pgrep) [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ] && exit 0 || exit 1 ;;
+      getent) echo "ubuntu:x:1000:1000::/home/ubuntu:/bin/bash"; exit 0 ;;
+      id)
+        for a in "$@"; do
+          [ "$a" = "-u" ] && { echo "${INCUS_UID:-1000}"; exit 0; }
+          [ "$a" = "-g" ] && { echo "${INCUS_GID:-1000}"; exit 0; }
+        done
+        echo 1000; exit 0 ;;
+      sh) exit "${INCUS_VERIFY_RC:-0}" ;;
+      *) exit 0 ;;
+    esac ;;
+esac
+exit 0
+"""
+
+
+def _sandbox(tmp_path, **incus_env):
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    p = bindir / "incus"
+    p.write_text(_INCUS_STUB)
+    p.chmod(0o755)
+    (tmp_path / "incus.log").touch()
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "INCUS_LOG": str(tmp_path / "incus.log"),
+        "HOME": str(tmp_path),  # so a stray guardian.yaml lookup can't leak
+    }
+    env.update({k: str(v) for k, v in incus_env.items()})
+    return env
+
+
+def _run(env, fn="cc_tmp_volume_apply", extra_env=None):
+    if extra_env:
+        env = {**env, **extra_env}
+    script = f'set -euo pipefail; source "{LIB}"; {fn}; echo __DONE__'
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+
+
+def _log(tmp_path) -> str:
+    return (tmp_path / "incus.log").read_text()
+
+
+# ── guards / degrade paths (must return 0, never abort the caller) ───────────
+
+
+def test_lib_parses_clean():
+    res = subprocess.run(["bash", "-n", str(LIB)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_disable_seam_skips(tmp_path):
+    env = _sandbox(tmp_path, CCTMPVOL_DISABLE=1)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    assert _log(tmp_path).strip() == ""  # never even called incus
+
+
+def test_no_incus_skips(tmp_path):
+    env = _sandbox(tmp_path)
+    onlybash = tmp_path / "onlybash"
+    onlybash.mkdir()
+    os.symlink(shutil.which("bash"), onlybash / "bash")  # bash resolvable, incus absent
+    env["PATH"] = str(onlybash)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+
+
+def test_container_missing_skips(tmp_path):
+    env = _sandbox(tmp_path, INCUS_INFO_MISSING=1)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    assert "storage volume create" not in _log(tmp_path)
+
+
+def test_container_not_running_skips(tmp_path):
+    env = _sandbox(tmp_path, INCUS_INFO_STATUS="Stopped")
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    assert "storage volume create" not in _log(tmp_path)
+
+
+def test_already_attached_is_idempotent(tmp_path):
+    env = _sandbox(tmp_path, INCUS_DEVICE_ATTACHED=1)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    assert "storage volume create" not in log  # no mutation on a re-run
+    assert "config device add" not in log
+
+
+def test_live_claude_session_skips_without_mutating(tmp_path):
+    env = _sandbox(tmp_path, INCUS_CLAUDE_RUNNING=1)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    # The whole point: a live session must NOT be disturbed.
+    assert "storage volume create" not in log
+    assert "config device add" not in log
+
+
+# ── happy path: correct ordering + writability ──────────────────────────────
+
+
+def test_happy_path_creates_attaches_and_verifies(tmp_path):
+    env = _sandbox(tmp_path)  # fresh: volume absent, no claude, running
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    i_create = log.index("storage volume create")
+    i_add = log.index("config device add")
+    i_chown = log.index("chown")
+    assert i_create < i_add < i_chown  # create → attach → chown ordering
+    assert "config device add genesis-cc-tmp" in log or "config device add" in log
+    assert "size=2GiB" in log  # default size
+    assert "config device remove" not in log  # no rollback on success
+    assert "dedicated volume" in res.stdout  # success line
+
+
+def test_io_limits_mirrored_one_key_each(tmp_path):
+    env = _sandbox(tmp_path, INCUS_LIMIT_READ="190MB", INCUS_LIMIT_WRITE="90MB")
+    res = _run(env)
+    assert res.returncode == 0
+    log = _log(tmp_path)
+    assert "config device set genesis cc-tmp limits.read 190MB" in log
+    assert "config device set genesis cc-tmp limits.write 90MB" in log
+
+
+def test_empty_root_limits_sets_nothing(tmp_path):
+    env = _sandbox(tmp_path, INCUS_LIMIT_READ="", INCUS_LIMIT_WRITE="")
+    res = _run(env)
+    assert res.returncode == 0
+    assert "config device set" not in _log(tmp_path)  # nothing to mirror → no set
+
+
+def test_volume_already_exists_skips_create_but_attaches(tmp_path):
+    env = _sandbox(tmp_path, INCUS_VOLUME_EXISTS=0)  # show rc 0 = exists
+    res = _run(env)
+    assert res.returncode == 0
+    log = _log(tmp_path)
+    assert "storage volume create" not in log
+    assert "config device add" in log  # still attaches the existing volume
+
+
+# ── failure handling: unwritable volume must roll back ──────────────────────
+
+
+def test_verify_failure_rolls_back_the_device(tmp_path):
+    env = _sandbox(tmp_path, INCUS_VERIFY_RC=1)  # uid-1000 write fails
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    assert "config device add" in log
+    assert "config device remove" in log  # rolled back
+    assert "not writable" in res.stdout
+
+
+def test_attach_failure_keeps_volume_for_retry(tmp_path):
+    env = _sandbox(tmp_path, INCUS_ATTACH_RC=1)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    assert "could not attach" in res.stdout
+    assert "config device remove" not in _log(tmp_path)  # nothing to roll back
+
+
+# ── size + name resolution ──────────────────────────────────────────────────
+
+
+def test_size_env_override(tmp_path):
+    env = _sandbox(tmp_path, CCTMPVOL_SIZE_GIB=8)
+    assert _run(env).returncode == 0
+    assert "size=8GiB" in _log(tmp_path)
+
+
+def test_bad_size_floors_to_default(tmp_path):
+    env = _sandbox(tmp_path, CCTMPVOL_SIZE_GIB="abc")
+    assert _run(env).returncode == 0
+    assert "size=2GiB" in _log(tmp_path)
+
+
+# ── remove path ─────────────────────────────────────────────────────────────
+
+
+def test_remove_detaches_then_deletes(tmp_path):
+    env = _sandbox(tmp_path)
+    res = _run(env, fn="cc_tmp_volume_remove")
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    assert log.index("config device remove") < log.index("storage volume delete")
+
+
+def test_remove_skips_while_session_live(tmp_path):
+    env = _sandbox(tmp_path, INCUS_CLAUDE_RUNNING=1)
+    res = _run(env, fn="cc_tmp_volume_remove")
+    assert res.returncode == 0
+    assert "storage volume delete" not in _log(tmp_path)
+
+
+# ── parse + wiring ──────────────────────────────────────────────────────────
+
+
+def test_host_setup_wires_the_lib():
+    """Fresh installs + retrofit: host-setup.sh must source AND call the lib."""
+    text = HOST_SETUP.read_text()
+    assert "lib/cc_tmp_volume.sh" in text
+    assert "cc_tmp_volume_apply" in text
+
+
+def test_gateway_redeploy_wires_the_lib():
+    """Existing installs receive code only via the redeploy verb — it must
+    invoke the lib to stderr (stdout is a parsed JSON contract)."""
+    text = GATEWAY.read_text()
+    assert "cc_tmp_volume.sh" in text
+    idx = text.index("cc_tmp_volume_apply")
+    window = text[idx : idx + 200]
+    assert "1>&2" in window or ">&2" in window
+
+
+def test_guardian_paths_include_the_lib_everywhere():
+    """A cc_tmp_volume.sh-only change must trigger a guardian redeploy: the
+    trigger list and both Python mirrors stay in lockstep."""
+    assert "scripts/lib/cc_tmp_volume.sh" in UPDATE_SH.read_text()
+    assert "scripts/lib/cc_tmp_volume.sh" in WATCHDOG.read_text()
+    assert "scripts/lib/cc_tmp_volume.sh" in DEPLOY_HEALTH.read_text()

--- a/tests/test_scripts/test_cc_tmp_volume_sh.py
+++ b/tests/test_scripts/test_cc_tmp_volume_sh.py
@@ -60,6 +60,7 @@ case "$1" in
     exit 0 ;;
   storage)
     if [ "$2" = "list" ]; then echo "default,lvm,vg0,,1,CREATED"; exit 0; fi
+    if [ "$2" = "show" ]; then echo "driver: ${INCUS_DRIVER:-lvm}"; exit 0; fi
     if [ "$2 $3" = "volume show" ]; then exit "${INCUS_VOLUME_EXISTS:-1}"; fi
     if [ "$2 $3" = "volume create" ]; then exit "${INCUS_CREATE_RC:-0}"; fi
     exit 0 ;;
@@ -169,6 +170,19 @@ def test_live_claude_session_skips_without_mutating(tmp_path):
     # The whole point: a live session must NOT be disturbed.
     assert "storage volume create" not in log
     assert "config device add" not in log
+
+
+def test_dir_pool_skips_cosmetic_isolation(tmp_path):
+    # A dir-backed pool can't enforce the size cap on its own device — applying
+    # would be cosmetic (a runaway could still reach the rootfs), so the lib
+    # must skip honestly rather than report a false isolation.
+    env = _sandbox(tmp_path, INCUS_DRIVER="dir")
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    assert "storage volume create" not in log
+    assert "config device add" not in log
+    assert "cosmetic" in res.stdout
 
 
 # ── happy path: correct ordering + writability ──────────────────────────────

--- a/tests/test_scripts/test_watchgod_instrumentation.py
+++ b/tests/test_scripts/test_watchgod_instrumentation.py
@@ -84,3 +84,22 @@ def test_pressure_snapshots_are_bounded(tmp_path):
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     remaining = list(logs.glob("cc_tmp_top_*.txt"))
     assert len(remaining) <= 20, f"snapshots not bounded: {len(remaining)} remain"
+
+
+def test_write_state_includes_fs_headroom(tmp_path):
+    import json
+
+    home, cctmp, bind = _sandbox(tmp_path)
+    out = _run(home, bind, "write_state green 100 green 5")
+    assert out.returncode == 0, f"{out.stdout}\n{out.stderr}"
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    cc = state["cc_tmp"]
+    assert "fs_free_mb" in cc and "fs_total_mb" in cc  # post-split volume headroom
+    assert cc["fs_total_mb"] > 0  # the cc-tmp dir exists in the sandbox
+
+
+def test_fs_total_mb_reports_positive(tmp_path):
+    home, cctmp, bind = _sandbox(tmp_path)
+    out = _run(home, bind, f"fs_total_mb '{cctmp}'")
+    assert out.returncode == 0, out.stderr
+    assert int(out.stdout.strip()) > 0


### PR DESCRIPTION
## Problem

`~/.genesis/cc-tmp` — the `TMPDIR` for every Claude Code session and for
genesis-server — shares the container root filesystem with everything else.
That is a two-way hazard: a runaway temp write can fill the container root
(and a full rootfs kills **every** CC session, since the watchdog can only
mitigate), and unrelated rootfs growth can starve cc-tmp below the watchdog's
~150 MiB sacred-ground floor and kill sessions from the other direction. It is
the one shared-rootfs blast-radius the storage-resiliency sprint didn't close.

## Fix

Move cc-tmp onto its **own size-capped incus custom storage volume**, mounted
at the same path (so zero TMPDIR/unit churn). A runaway fill is then capped at
the volume; the container root filesystem is never touched, and nothing else
can crowd cc-tmp out.

Spike-proven live (incus 6.0): a fresh custom volume mounts owned by
container-root; a `chown` from container-root makes it writable by the
container user with the correct unprivileged host-uid mapping — so
`security.shifted` (privesc advisory GHSA-56mx-8g9f-5crf) is **not** used. The
disk device hot-plugs onto a running container with no restart, and filling the
volume to ENOSPC leaves the container rootfs `df` byte-identical.

## What's in it

- **`scripts/lib/cc_tmp_volume.sh`** — `cc_tmp_volume_apply` / `_remove`,
  modeled on `host_swap.sh` (every path returns 0; degrade-to-skip; never
  aborts a caller under `set -e`). Guard ladder: disable / no-incus /
  container-down / **already-attached (idempotent)** / **live CC session**
  (won't attach over a running session — converges on a later quiet apply).
  Creates a thin volume, hot-plug attaches it, mirrors root's `limits.read/write`
  IO caps, chowns to the container user and **verifies a uid write — rolling the
  device back on failure** (an attached-but-unwritable cc-tmp is worse than
  none). Pre-split contents are shadowed under the mount, not deleted (never
  yanks an in-flight genesis-server temp file).
- **Pool-driver gate** (from review): only applies on a block/CoW backend
  (lvm/zfs/btrfs/ceph) where the isolation and size cap actually hold. On a
  `dir` pool the volume shares the rootfs and `size=` isn't enforced without
  fs-level project quotas, so it skips honestly rather than giving a cosmetic
  guarantee.
- **Rollout:** `host-setup.sh` (fresh installs + retrofit) and the guardian
  gateway `redeploy` verb (existing installs, best-effort, stderr-only, skips
  while a session is live). Lib added to `GUARDIAN_PATHS` ×3 (update.sh,
  watchdog, deploy_health).
- **Monitoring / provision-or-surface:** infra-profile `storage.cc_tmp_isolated`
  effective-state fact + an awareness posture `cc_tmp_shared_fs` alert (gated on
  `virt.container == "lxc"`, so a non-container topology is never nagged);
  guardian `_collect_disk` probes the cc-tmp mount (deduped); watchgod state
  gains `fs_free_mb`/`fs_total_mb` describing the volume.
- Docs (recovery-and-portability-workflow) + CHANGELOG; targeted tests for the
  lib, collector, posture rule, and watchgod fields.

## Generalization

No machine constants: container name resolves from `guardian.yaml` (else
`genesis`), pool from the root device, size defaults to 2 GiB
(`CCTMPVOL_SIZE_GIB`), user seam `CCTMPVOL_USER`. Requires a block/CoW pool
(the default LVM-thin setup); dir pools are detected and skipped.

## Test / E2E

100 targeted tests (lib guard/ordering/rollback/dir-gate, collector dedupe,
posture rule matrix, watchgod fields), ruff clean. **Live E2E on the real
host:** full lib lifecycle on a scratch container (attach→chown→uid-verify→
shadow→idempotent→remove); a full-volume ENOSPC left the container rootfs `df`
byte-identical; the safety guard skipped the real genesis container (live CC
session, no mutation); the dir-pool gate skipped cosmetically; and the new
collector reports `cc_tmp_isolated: False` on the box today.

## Deploy

Touches `guardian/` + gateway + a new lib in `GUARDIAN_PATHS`, so it reaches
both sides via `scripts/update.sh` (guardian redeploy). Existing installs
retrofit on the next redeploy during a CC-quiet window; this install applies via
a deliberate ~2-minute quiet-window run (close CC sessions → `cc_tmp_volume_apply`
host-side → restart genesis-server).

Ledger: 9da51d2571a54a74a98f50dc9fb67334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
