### PR TITLE
feat(ego): quiet_hours_mode toggle + render true next-fire on cadence card

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -46,6 +46,7 @@ quiet_hours_enabled: true
 quiet_hours_start: 23          # local hour [0-23], inclusive
 quiet_hours_end: 7             # local hour [0-23], exclusive
 quiet_hours_min_interval_minutes: 240   # min gap between overnight proactive ticks
+quiet_hours_mode: floor        # "floor" = throttle to 1/interval | "suppress" = full silence
 
 # Circuit breaker
 consecutive_failure_limit: 3

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -412,7 +412,7 @@
                       })()"></div>
                     </div>
                     <span style="font-size: 0.6rem; color: var(--color-text-secondary); min-width: 2.2rem; text-align: right;"
-                          x-text="ue?.cadence?.gated ? 'gated — awaiting approval' : ((ue?.cadence?.current_interval_minutes || ue?.cadence_minutes || '?') + 'm')"></span>
+                          x-text="ue?.cadence?.gated ? 'gated — awaiting approval' : (ue?.cadence?.next_fire_at ? ('next ' + new Date(ue.cadence.next_fire_at).toLocaleTimeString([], {hour: 'numeric', minute: '2-digit'})) : ((ue?.cadence?.current_interval_minutes || ue?.cadence_minutes || '?') + 'm'))"></span>
                   </div>
                 </div>
                 <!-- Genesis Ego (COO) row -->
@@ -439,7 +439,7 @@
                       })()"></div>
                     </div>
                     <span style="font-size: 0.6rem; color: var(--color-text-secondary); min-width: 2.2rem; text-align: right;"
-                          x-text="ge?.cadence?.gated ? 'gated — awaiting approval' : ((ge?.cadence?.current_interval_minutes || ge?.cadence_minutes || '?') + 'm')"></span>
+                          x-text="ge?.cadence?.gated ? 'gated — awaiting approval' : (ge?.cadence?.next_fire_at ? ('next ' + new Date(ge.cadence.next_fire_at).toLocaleTimeString([], {hour: 'numeric', minute: '2-digit'})) : ((ge?.cadence?.current_interval_minutes || ge?.cadence_minutes || '?') + 'm'))"></span>
                   </div>
                 </div>
                 <!-- Cost footer -->

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -818,6 +818,12 @@ class EgoCadenceManager:
         # counter slot. Morning report / reactive / escalation are unaffected.
         if self._quiet_hours_suppresses_tick():
             logger.debug("Ego proactive tick suppressed — quiet hours")
+            # In suppress mode, advance the next fire to the window end so a
+            # large (24h-multiple) interval phased inside the window cannot
+            # starve the ego indefinitely. Floor mode self-corrects — it lets
+            # one tick through once quiet_hours_min_interval_minutes elapses.
+            if getattr(self._config, "quiet_hours_mode", "floor") == "suppress":
+                self._reschedule_past_quiet_hours()
             return
 
         # Deep-think: every Nth proactive cycle upgrades to Opus.
@@ -1245,6 +1251,34 @@ class EgoCadenceManager:
             return False
         floor = timedelta(minutes=self._config.quiet_hours_min_interval_minutes)
         return (_now_utc() - last) < floor
+
+    def _reschedule_past_quiet_hours(self) -> None:
+        """Move the next ego_cycle fire to the next quiet-hours-end boundary.
+
+        Guards suppress mode against starvation: if the adaptive interval has
+        backed off to a 24h multiple whose phase lands inside the quiet
+        window, every fire would be suppressed and proactive cycles would
+        never resume. Best-effort — a failure leaves the schedule untouched.
+        """
+        try:
+            now_local = _local_now(user_timezone())
+            end_local = now_local.replace(
+                hour=self._config.quiet_hours_end,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+            if end_local <= now_local:
+                end_local = end_local + timedelta(days=1)
+            self._scheduler.modify_job(
+                "ego_cycle", next_run_time=end_local.astimezone(UTC),
+            )
+            logger.info(
+                "Quiet-hours suppress: next ego tick moved to %s (window end)",
+                end_local.isoformat(),
+            )
+        except Exception:
+            logger.debug("Quiet-hours reschedule failed", exc_info=True)
 
     async def _restore_interval(self) -> None:
         """Load the persisted adaptive interval, clamped to current config

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -1225,15 +1225,21 @@ class EgoCadenceManager:
     def _quiet_hours_suppresses_tick(self) -> bool:
         """Whether the current proactive tick should be skipped for quiet hours.
 
-        Suppresses only when quiet hours are enabled, the local clock is inside
-        the window, AND the last proactive fire was less than
-        quiet_hours_min_interval_minutes ago. A first tick with no recorded
-        prior fire is allowed (never block on unknown boot state).
+        Only ever suppresses when quiet hours are enabled and the local clock is
+        inside the window. Within the window, behaviour depends on
+        quiet_hours_mode:
+        - "suppress": skip every proactive tick until the window ends.
+        - "floor" (default): allow at most one proactive tick per
+          quiet_hours_min_interval_minutes; a first tick with no recorded prior
+          fire is allowed (never block on unknown boot state).
+        Morning report / reactive / escalation paths are never gated here.
         """
         if not getattr(self._config, "quiet_hours_enabled", False):
             return False
         if not self._in_quiet_hours(_local_now(user_timezone())):
             return False
+        if getattr(self._config, "quiet_hours_mode", "floor") == "suppress":
+            return True
         last = self._last_proactive_fire_at
         if last is None:
             return False

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -171,4 +171,9 @@ def validate_ego_config(changes: dict) -> list[str]:
         v = changes["quiet_hours_min_interval_minutes"]
         if not isinstance(v, (int, float)) or v < 1:
             errors.append("quiet_hours_min_interval_minutes must be >= 1")
+    if "quiet_hours_mode" in changes and changes["quiet_hours_mode"] not in (
+        "floor",
+        "suppress",
+    ):
+        errors.append("quiet_hours_mode must be 'floor' or 'suppress'")
     return errors

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -169,5 +169,6 @@ class EgoConfig:
     quiet_hours_start: int = 23  # local hour [0-23], inclusive
     quiet_hours_end: int = 7  # local hour [0-23], exclusive
     quiet_hours_min_interval_minutes: int = 240  # min gap between overnight ticks
+    quiet_hours_mode: str = "floor"  # "floor" (throttle) | "suppress" (silence window)
 
 

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1541,6 +1541,34 @@ class TestQuietHours:
         import datetime as _dt
         return _dt.datetime(2026, 1, 1, hour, 0, tzinfo=_dt.UTC)
 
+    def test_suppress_mode_skips_entire_window(
+        self, db, mock_session, mock_idle_detector, monkeypatch,
+    ):
+        mgr = self._mgr(
+            db, mock_session, mock_idle_detector, quiet_hours_mode="suppress",
+        )
+        now = self._at(2)
+        monkeypatch.setattr("genesis.ego.cadence._local_now", lambda tz: now)
+        monkeypatch.setattr("genesis.ego.cadence._now_utc", lambda: now)
+        # No prior fire AND a very recent fire both suppress in suppress mode.
+        mgr._last_proactive_fire_at = None
+        assert mgr._quiet_hours_suppresses_tick() is True
+        mgr._last_proactive_fire_at = now - timedelta(minutes=1)
+        assert mgr._quiet_hours_suppresses_tick() is True
+
+    def test_floor_mode_is_default_and_throttles(
+        self, db, mock_session, mock_idle_detector, monkeypatch,
+    ):
+        mgr = self._mgr(db, mock_session, mock_idle_detector)  # default mode
+        assert mgr._config.quiet_hours_mode == "floor"
+        now = self._at(2)
+        monkeypatch.setattr("genesis.ego.cadence._local_now", lambda tz: now)
+        monkeypatch.setattr("genesis.ego.cadence._now_utc", lambda: now)
+        mgr._last_proactive_fire_at = now - timedelta(minutes=1)  # recent → throttled
+        assert mgr._quiet_hours_suppresses_tick() is True
+        mgr._last_proactive_fire_at = None  # no prior fire → allowed
+        assert mgr._quiet_hours_suppresses_tick() is False
+
     def test_in_quiet_hours_crosses_midnight(self, db, mock_session, mock_idle_detector):
         mgr = self._mgr(db, mock_session, mock_idle_detector)  # 23 → 7
         assert mgr._in_quiet_hours(self._at(23)) is True

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1569,6 +1569,23 @@ class TestQuietHours:
         mgr._last_proactive_fire_at = None  # no prior fire → allowed
         assert mgr._quiet_hours_suppresses_tick() is False
 
+    def test_suppress_mode_reschedules_past_window(
+        self, db, mock_session, mock_idle_detector, monkeypatch,
+    ):
+        from unittest.mock import MagicMock
+
+        mgr = self._mgr(
+            db, mock_session, mock_idle_detector, quiet_hours_mode="suppress",
+        )
+        now = self._at(2)  # inside the 23→7 window
+        monkeypatch.setattr("genesis.ego.cadence._local_now", lambda tz: now)
+        mgr._scheduler = MagicMock()
+        mgr._reschedule_past_quiet_hours()
+        assert mgr._scheduler.modify_job.called
+        _, kwargs = mgr._scheduler.modify_job.call_args
+        # Next fire advanced to the window end (07:00), not left in-window.
+        assert kwargs["next_run_time"].hour == 7
+
     def test_in_quiet_hours_crosses_midnight(self, db, mock_session, mock_idle_detector):
         mgr = self._mgr(db, mock_session, mock_idle_detector)  # 23 → 7
         assert mgr._in_quiet_hours(self._at(23)) is True

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -155,6 +155,13 @@ class TestValidateEgoConfig:
         assert len(errors) == 1
         assert "quiet_hours_min_interval_minutes must be >= 1" in errors[0]
 
+    def test_quiet_hours_mode(self):
+        assert validate_ego_config({"quiet_hours_mode": "floor"}) == []
+        assert validate_ego_config({"quiet_hours_mode": "suppress"}) == []
+        errors = validate_ego_config({"quiet_hours_mode": "loud"})
+        assert len(errors) == 1
+        assert "quiet_hours_mode must be" in errors[0]
+
     def test_quiet_hours_defaults(self):
         cfg = EgoConfig()
         assert cfg.quiet_hours_enabled is True


### PR DESCRIPTION
Two small cadence/dashboard-honesty finishes identified by an independent
retroactive review of the ego cadence work (gaps left by #1145).

## Changes
- **`quiet_hours_mode` (`floor` | `suppress`), default `floor`.** `floor` keeps
  the delivered overnight behavior (≤1 proactive cycle per
  `quiet_hours_min_interval_minutes` — winds down but still thinks); `suppress`
  skips every proactive tick until the window ends. Morning-report / reactive /
  escalation paths are unaffected in both modes. Adds the config field,
  validator, and `ego.yaml` default.
- **Render the true next-fire time on the cadence card.** `_cadence_snapshot`
  already exposed `next_fire_at` (via `mgr.next_fire_at`) but the card never
  displayed it — it showed only interval minutes. The label now shows the real
  next-fire clock time; the interval stays in the tooltip; gated state still
  renders "gated — awaiting approval".

## Tests
- `TestQuietHours`: `suppress` skips the whole window regardless of last-fire;
  `floor` is the default and throttles to the min interval.
- `test_config`: `quiet_hours_mode` validation (accepts floor/suppress, rejects
  other).
- Existing dashboard route + quiet-hours tests still green.

Gate integrity unchanged — this only paces proactive ticks and surfaces an
existing payload field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)