### PR TITLE
feat(voice): graduation door + provenance schema + fail-closed voice API (W0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **Voice graduation door (W0).** The core now exposes an authenticated
+  `POST /v1/voice/graduate` endpoint where a voice edge machine can land
+  typed "graduation" events (synthesized claims from ambient/meeting
+  capture — never raw transcripts). Events are quarantined verbatim in a
+  new `graduation_events` table with idempotent delivery (safe edge
+  retries), and nothing consumes them yet — the policy drainer that routes
+  them into memory arrives in a later phase. Dispositioned events are
+  pruned after 90 days; pending events are never pruned. The memory
+  metadata schema also gains dormant provenance/trust columns
+  (`provenance_class`, `trust_level`, `attribution`, `origin_ref`,
+  `capture_clarity`) for that later phase.
+
+### Changed
+
+- **The voice API is now fail-closed.** Previously, leaving
+  `GENESIS_MCP_HTTP_TOKEN` unset left every `/v1/voice/*` route open to the
+  network. Now an unset token disables the voice API (503 + a boot-time
+  warning in the server log). **Upgrade note:** if you use the voice API,
+  set `GENESIS_MCP_HTTP_TOKEN` in `secrets.env` and make sure your Home
+  Assistant / voice-addon configs send it as a Bearer token — token-less
+  setups stop working on this upgrade.
+
 ### Fixed
 
 - **Dashboard health cards stop crying wolf.** The API Keys and Queues cards

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -231,9 +231,10 @@ WHISPER_MODEL=whisper-large-v3
 DAY_BOUNDARY_HOUR=0
 
 # HTTP API auth
-# Used by: MCP HTTP transport, Voice API endpoint (/v1/voice/chat/completions)
-# When empty, HTTP endpoints allow unauthenticated access (Tailscale-only network).
-# Set to a strong random token for production use.
+# Used by: MCP HTTP transport, Voice API (/v1/voice/* incl. the graduation
+# write endpoint). Fail-closed everywhere: when empty, all /v1/voice/* routes
+# answer 503 (a boot-time warning is logged) and the HTTP MCP transport
+# refuses to start. Set to a strong random token to enable them.
 GENESIS_MCP_HTTP_TOKEN=
 
 # Home Assistant (outbound voice TTS + Voice PE hardware vitals)

--- a/src/genesis/channels/voice/graduation.py
+++ b/src/genesis/channels/voice/graduation.py
@@ -1,0 +1,80 @@
+"""Graduation-event envelope contract for the voice edge→core boundary (W0).
+
+Shared vocabulary for the ``POST /v1/voice/graduate`` endpoint (and, later,
+the W2 policy drainer). Flask-free and stdlib-only on purpose: unit-testable
+without an app fixture, importable from both the dashboard route and the
+drainer.
+
+Validation is deliberately shallow at this boundary: the quarantine table
+lands envelopes verbatim, and per-type payload policy (spec §6.4) belongs to
+the drainer. What IS enforced here is the envelope shape itself — the parts
+the transport contract (dedup key, type dispatch, provenance class) depends
+on. ``schema_version`` is exact-match: a core that doesn't know a version
+must reject it (the edge outbox holds the event until the core upgrades),
+never quarantine something it can't later interpret.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+SCHEMA_VERSION = 1
+
+EVENT_TYPES = ("perk_up", "memory_candidate", "meeting_summary")
+
+PROVENANCE_CLASSES = ("ambient_overheard", "meeting_capture")
+
+# event_id is an edge-generated UUID; anything longer is malformed input, not
+# a UUID variant we should store as a dedup key.
+_MAX_EVENT_ID_LEN = 128
+
+
+def _parseable_iso(value: str) -> bool:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
+def validate_envelope(data: dict) -> list[str]:
+    """Validate a graduation-event envelope. Returns [] if valid.
+
+    Manual dict validation (house pattern — no pydantic in the dashboard
+    surfaces). Each failure appends one human-readable string; the route
+    returns them all at once so the edge can log a complete rejection reason.
+    """
+    errors: list[str] = []
+
+    event_id = data.get("event_id")
+    if not isinstance(event_id, str) or not event_id.strip():
+        errors.append("event_id must be a non-empty string")
+    elif len(event_id) > _MAX_EVENT_ID_LEN:
+        errors.append(f"event_id exceeds {_MAX_EVENT_ID_LEN} chars")
+
+    if data.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be {SCHEMA_VERSION} (got {data.get('schema_version')!r})"
+        )
+
+    if data.get("type") not in EVENT_TYPES:
+        errors.append(f"type must be one of {', '.join(EVENT_TYPES)}")
+
+    source = data.get("source")
+    if not isinstance(source, str) or not source.strip():
+        errors.append("source must be a non-empty string")
+
+    occurred_at = data.get("occurred_at")
+    if not isinstance(occurred_at, str) or not _parseable_iso(occurred_at):
+        errors.append("occurred_at must be an ISO8601 timestamp string")
+
+    if not isinstance(data.get("payload"), dict):
+        errors.append("payload must be an object")
+
+    provenance = data.get("provenance")
+    if not isinstance(provenance, dict):
+        errors.append("provenance must be an object")
+    elif provenance.get("class") not in PROVENANCE_CLASSES:
+        errors.append(f"provenance.class must be one of {', '.join(PROVENANCE_CLASSES)}")
+
+    return errors

--- a/src/genesis/dashboard/routes/voice_api.py
+++ b/src/genesis/dashboard/routes/voice_api.py
@@ -362,12 +362,19 @@ def voice_graduate():
         msg, status = auth
         return jsonify({"error": msg}), status
 
-    if (request.content_length or 0) > _MAX_GRADUATE_BYTES:
+    # Measure the actual body, not the Content-Length header — a chunked
+    # request has no header and would bypass a content_length check; get_json
+    # below reuses this cached read.
+    if len(request.get_data(cache=True)) > _MAX_GRADUATE_BYTES:
         return jsonify(
             {"status": "rejected", "errors": ["envelope exceeds 64KB"]}
         ), 400
 
-    data = request.get_json(force=True, silent=True) or {}
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return jsonify(
+            {"status": "rejected", "errors": ["body must be a JSON object"]}
+        ), 400
     errors = validate_envelope(data)
     if errors:
         return jsonify({"status": "rejected", "errors": errors}), 400

--- a/src/genesis/dashboard/routes/voice_api.py
+++ b/src/genesis/dashboard/routes/voice_api.py
@@ -26,7 +26,6 @@ from datetime import UTC, datetime
 from flask import Blueprint, current_app, jsonify, request
 
 from genesis.channels.voice.graduation import validate_envelope
-from genesis.dashboard._blueprint import _async_route
 
 logger = logging.getLogger("genesis.dashboard.voice_api")
 
@@ -317,9 +316,35 @@ _GRADUATE_TIMEOUT_SECONDS = 10.0
 _MAX_GRADUATE_BYTES = 64 * 1024
 
 
+async def _land_graduation_event(data: dict) -> bool:
+    """Insert the validated envelope into quarantine (runs on the runtime loop).
+
+    Returns True if inserted, False on an event_id replay. Raises
+    LookupError when the runtime/DB isn't ready — the route maps it to 503
+    so the edge outbox retries.
+    """
+    from genesis.db.crud import graduation_events
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        raise LookupError("Genesis runtime not ready")
+
+    return await graduation_events.insert_event(
+        rt.db,
+        event_id=data["event_id"],
+        schema_version=data["schema_version"],
+        type=data["type"],
+        source=data["source"],
+        occurred_at=data["occurred_at"],
+        received_at=datetime.now(UTC).isoformat(),
+        payload=data["payload"],
+        provenance=data["provenance"],
+    )
+
+
 @voice_api_bp.route("/v1/voice/graduate", methods=["POST"])
-@_async_route(timeout=_GRADUATE_TIMEOUT_SECONDS)
-async def voice_graduate():
+def voice_graduate():
     """Land a graduation event from the voice edge (W0 quarantine landing).
 
     Responses (spec §4.9): 200 ``{"status": "accepted"}`` only after the
@@ -327,6 +352,10 @@ async def voice_graduate():
     (edge treats both as delivered); 400 ``{"status": "rejected", "errors":
     [...]}`` on envelope validation failure. One-way boundary — no core data
     ever returns.
+
+    Auth + validation run synchronously (same pattern as the sibling voice
+    routes) so fail-closed answers correctly even while the runtime loop is
+    still starting; only the DB insert dispatches to the runtime loop.
     """
     auth = _check_voice_token()
     if auth is not None:
@@ -343,25 +372,31 @@ async def voice_graduate():
     if errors:
         return jsonify({"status": "rejected", "errors": errors}), 400
 
-    from genesis.runtime import GenesisRuntime
+    event_loop = current_app.config.get("GENESIS_EVENT_LOOP")
+    if event_loop is None or not event_loop.is_running():
+        return jsonify({"error": "Event loop not available"}), 503
 
-    rt = GenesisRuntime.instance()
-    if not rt.is_bootstrapped or rt.db is None:
-        return jsonify({"error": "Genesis runtime not ready"}), 503
-
-    from genesis.db.crud import graduation_events
-
-    inserted = await graduation_events.insert_event(
-        rt.db,
-        event_id=data["event_id"],
-        schema_version=data["schema_version"],
-        type=data["type"],
-        source=data["source"],
-        occurred_at=data["occurred_at"],
-        received_at=datetime.now(UTC).isoformat(),
-        payload=data["payload"],
-        provenance=data["provenance"],
+    future = asyncio.run_coroutine_threadsafe(
+        _land_graduation_event(data), event_loop
     )
+    try:
+        inserted = future.result(timeout=_GRADUATE_TIMEOUT_SECONDS)
+    except TimeoutError:
+        future.cancel()
+        logger.error(
+            "Voice graduate timed out after %.0fs for event %s",
+            _GRADUATE_TIMEOUT_SECONDS, data["event_id"][:16],
+        )
+        return jsonify({"error": "graduate landing timed out"}), 503
+    except LookupError:
+        return jsonify({"error": "Genesis runtime not ready"}), 503
+    except Exception:
+        logger.error(
+            "Voice graduate failed for event %s", data["event_id"][:16],
+            exc_info=True,
+        )
+        return jsonify({"error": "graduate landing failed"}), 500
+
     status = "accepted" if inserted else "duplicate"
     logger.info(
         "Voice graduate: %s event %s from %s",

--- a/src/genesis/dashboard/routes/voice_api.py
+++ b/src/genesis/dashboard/routes/voice_api.py
@@ -21,8 +21,12 @@ import logging
 import os
 import time
 import uuid
+from datetime import UTC, datetime
 
 from flask import Blueprint, current_app, jsonify, request
+
+from genesis.channels.voice.graduation import validate_envelope
+from genesis.dashboard._blueprint import _async_route
 
 logger = logging.getLogger("genesis.dashboard.voice_api")
 
@@ -32,25 +36,26 @@ voice_api_bp = Blueprint("voice_api", __name__)
 _FUTURE_TIMEOUT_SECONDS = 8.0
 
 
-def _check_voice_token() -> str | None:
-    """Validate Bearer token. Returns error message or None if OK.
+def _check_voice_token() -> tuple[str, int] | None:
+    """Validate Bearer token. Returns (error message, http status) or None if OK.
 
-    When ``GENESIS_MCP_HTTP_TOKEN`` is not set, requests are allowed
-    through without auth (Tailscale-only network, local dev).  Set
-    the token in ``secrets.env`` to enforce auth in production.
+    Fail-closed: when ``GENESIS_MCP_HTTP_TOKEN`` is not set, every
+    ``/v1/voice/*`` route answers 503 — a write surface (``/v1/voice/graduate``)
+    shares this token model, so open-by-default is not acceptable even on a
+    trusted network. Set the token in ``secrets.env`` to enable the voice API
+    (the standalone host logs a boot-time warning when it is missing).
     """
     token = os.environ.get("GENESIS_MCP_HTTP_TOKEN", "")
     if not token:
-        # No token configured — allow through (Tailscale-only network)
-        return None
+        return ("voice API disabled: GENESIS_MCP_HTTP_TOKEN not configured", 503)
 
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
-        return "Missing or invalid Authorization header"
+        return ("Missing or invalid Authorization header", 401)
 
     request_token = auth_header[7:]
     if not hmac.compare_digest(request_token, token):
-        return "Invalid bearer token"
+        return ("Invalid bearer token", 401)
 
     return None
 
@@ -64,9 +69,10 @@ def voice_chat_completions():
     the response in OpenAI format.
     """
     # Auth check
-    auth_error = _check_voice_token()
-    if auth_error:
-        return jsonify({"error": auth_error}), 401
+    auth = _check_voice_token()
+    if auth is not None:
+        msg, status = auth
+        return jsonify({"error": msg}), status
 
     # Get handler and event loop from app config
     voice_handler = current_app.config.get("VOICE_HANDLER")
@@ -205,9 +211,10 @@ def voice_tool_call():
     Expects JSON: ``{"tool_name": "ask_genesis", "arguments": {"query": "..."}}``.
     Returns the tool result as JSON.
     """
-    auth_error = _check_voice_token()
-    if auth_error:
-        return jsonify({"error": auth_error}), 401
+    auth = _check_voice_token()
+    if auth is not None:
+        msg, status = auth
+        return jsonify({"error": msg}), status
 
     bridge = current_app.config.get("GENESIS_BRIDGE")
     event_loop = current_app.config.get("GENESIS_EVENT_LOOP")
@@ -259,9 +266,10 @@ def voice_system_prompt():
     Called by the voice addon at session start to configure the
     OpenAI Realtime model with Genesis persona + context.
     """
-    auth_error = _check_voice_token()
-    if auth_error:
-        return jsonify({"error": auth_error}), 401
+    auth = _check_voice_token()
+    if auth is not None:
+        msg, status = auth
+        return jsonify({"error": msg}), status
 
     bridge = current_app.config.get("GENESIS_BRIDGE")
     if bridge is None:
@@ -281,9 +289,82 @@ def voice_tool_declarations():
     Called by the voice addon at session start to register Genesis
     tools with the OpenAI Realtime API.
     """
-    auth_error = _check_voice_token()
-    if auth_error:
-        return jsonify({"error": auth_error}), 401
+    auth = _check_voice_token()
+    if auth is not None:
+        msg, status = auth
+        return jsonify({"error": msg}), status
 
     from genesis.channels.voice.genesis_bridge import TOOL_DECLARATIONS
     return jsonify({"tools": TOOL_DECLARATIONS})
+
+
+# ── Graduation landing (W0 — DARK: quarantine insert only, no consumer) ──
+# The voice edge pushes typed graduation events (synthesized claims, never raw
+# transcripts) here; they land verbatim in the graduation_events quarantine
+# table with disposition='pending'. The W2 policy drainer (separate PR) is the
+# only consumer. Bearer auth is REQUIRED — _check_voice_token is fail-closed,
+# so an unset token disables this write surface entirely.
+
+# 10s: a single INSERT. The realistic hang is SQLite write-lock contention,
+# bounded by busy_timeout=5000 (db/connection.py); 10s = that + runtime-loop
+# scheduling headroom. Fast-fail is safe: the edge outbox retries on 503, and
+# a timed-out-but-committed insert resolves as 'duplicate' on retry (event_id
+# dedup) — effectively-once either way.
+_GRADUATE_TIMEOUT_SECONDS = 10.0
+
+# Envelope sanity cap — graduation events are small JSON (claims + metadata);
+# app-level MAX_CONTENT_LENGTH is sized for uploads, not this route.
+_MAX_GRADUATE_BYTES = 64 * 1024
+
+
+@voice_api_bp.route("/v1/voice/graduate", methods=["POST"])
+@_async_route(timeout=_GRADUATE_TIMEOUT_SECONDS)
+async def voice_graduate():
+    """Land a graduation event from the voice edge (W0 quarantine landing).
+
+    Responses (spec §4.9): 200 ``{"status": "accepted"}`` only after the
+    INSERT commits; 200 ``{"status": "duplicate"}`` on an event_id replay
+    (edge treats both as delivered); 400 ``{"status": "rejected", "errors":
+    [...]}`` on envelope validation failure. One-way boundary — no core data
+    ever returns.
+    """
+    auth = _check_voice_token()
+    if auth is not None:
+        msg, status = auth
+        return jsonify({"error": msg}), status
+
+    if (request.content_length or 0) > _MAX_GRADUATE_BYTES:
+        return jsonify(
+            {"status": "rejected", "errors": ["envelope exceeds 64KB"]}
+        ), 400
+
+    data = request.get_json(force=True, silent=True) or {}
+    errors = validate_envelope(data)
+    if errors:
+        return jsonify({"status": "rejected", "errors": errors}), 400
+
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Genesis runtime not ready"}), 503
+
+    from genesis.db.crud import graduation_events
+
+    inserted = await graduation_events.insert_event(
+        rt.db,
+        event_id=data["event_id"],
+        schema_version=data["schema_version"],
+        type=data["type"],
+        source=data["source"],
+        occurred_at=data["occurred_at"],
+        received_at=datetime.now(UTC).isoformat(),
+        payload=data["payload"],
+        provenance=data["provenance"],
+    )
+    status = "accepted" if inserted else "duplicate"
+    logger.info(
+        "Voice graduate: %s event %s from %s",
+        status, data["event_id"][:16], data["source"][:32],
+    )
+    return jsonify({"status": status})

--- a/src/genesis/db/crud/graduation_events.py
+++ b/src/genesis/db/crud/graduation_events.py
@@ -1,0 +1,89 @@
+"""CRUD for ``graduation_events`` — voice graduation quarantine (W0).
+
+Landing store for ``POST /v1/voice/graduate``: typed events synthesized on the
+voice edge (claims, never raw transcripts) land here verbatim with
+``disposition='pending'``. The W2 policy drainer (separate PR) is the only
+thing that moves a row out of ``pending`` — this module deliberately ships no
+disposition-update helper until that PR exists.
+
+Dedup is by construction: ``event_id`` UNIQUE + ``INSERT OR IGNORE`` turns the
+edge outbox's at-least-once delivery into effectively-once landing. The
+transport contract is 2xx only after the row is durable, so
+:func:`insert_event` commits before returning.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import aiosqlite
+
+
+async def insert_event(
+    db: aiosqlite.Connection,
+    *,
+    event_id: str,
+    schema_version: int,
+    type: str,
+    source: str,
+    occurred_at: str,
+    received_at: str,
+    payload: dict,
+    provenance: dict,
+) -> bool:
+    """Land a graduation event in quarantine (``disposition='pending'``).
+
+    Returns True if the row was inserted, False on an ``event_id`` replay
+    (caller answers ``duplicate``). Commits before returning — the transport
+    contract is 2xx only after the INSERT is durable.
+    """
+    cursor = await db.execute(
+        """INSERT OR IGNORE INTO graduation_events
+           (id, event_id, schema_version, type, source,
+            occurred_at, received_at, payload, provenance)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            uuid.uuid4().hex,
+            event_id,
+            schema_version,
+            type,
+            source,
+            occurred_at,
+            received_at,
+            json.dumps(payload),
+            json.dumps(provenance),
+        ),
+    )
+    inserted = (cursor.rowcount or 0) == 1
+    await db.commit()
+    return inserted
+
+
+async def get_by_event_id(db: aiosqlite.Connection, *, event_id: str) -> dict | None:
+    """Fetch one event by its edge-assigned ``event_id`` (tests / ops / drainer)."""
+    cursor = await db.execute(
+        "SELECT id, event_id, schema_version, type, source, occurred_at, "
+        "received_at, payload, provenance, disposition, memory_id, "
+        "disposition_reason, disposed_at "
+        "FROM graduation_events WHERE event_id = ?",
+        (event_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row is not None else None
+
+
+async def prune_older_than(db: aiosqlite.Connection, *, days: int = 90) -> int:
+    """Delete DISPOSITIONED rows older than ``days`` (by ``disposed_at``).
+
+    NEVER deletes a pending row — pending is the drainer's inbox and the
+    audit obligation. Signature matches the drip-retention prune contract.
+    """
+    cursor = await db.execute(
+        "DELETE FROM graduation_events "
+        "WHERE disposition != 'pending' AND disposed_at IS NOT NULL "
+        "AND disposed_at < datetime('now', ?)",
+        (f"-{int(days)} days",),
+    )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount is not None else 0

--- a/src/genesis/db/crud/graduation_events.py
+++ b/src/genesis/db/crud/graduation_events.py
@@ -56,6 +56,21 @@ async def insert_event(
         ),
     )
     inserted = (cursor.rowcount or 0) == 1
+    if not inserted:
+        # OR IGNORE swallows ANY conflict (CHECK/NOT NULL too, not just the
+        # event_id UNIQUE). Only a genuine replay may answer "duplicate" —
+        # anything else ignored here is silent data loss (e.g. a future
+        # EVENT_TYPES addition missing from an old DB's frozen CHECK list)
+        # and must surface as an error so the edge retries and logs show it.
+        check = await db.execute(
+            "SELECT 1 FROM graduation_events WHERE event_id = ?", (event_id,)
+        )
+        if await check.fetchone() is None:
+            await db.rollback()
+            raise aiosqlite.IntegrityError(
+                f"graduation_events insert ignored for non-duplicate {event_id!r} "
+                "(constraint violation — schema/validator drift?)"
+            )
     await db.commit()
     return inserted
 
@@ -78,6 +93,10 @@ async def prune_older_than(db: aiosqlite.Connection, *, days: int = 90) -> int:
 
     NEVER deletes a pending row — pending is the drainer's inbox and the
     audit obligation. Signature matches the drip-retention prune contract.
+
+    Contract for the W2 drainer: ``disposed_at`` MUST be written as UTC
+    ISO8601 — the cutoff compares lexically against SQLite's UTC
+    ``datetime('now')`` (house pattern, cf. ``alert_events``).
     """
     cursor = await db.execute(
         "DELETE FROM graduation_events "

--- a/src/genesis/db/migrations/0068_voice_graduation.py
+++ b/src/genesis/db/migrations/0068_voice_graduation.py
@@ -1,0 +1,85 @@
+"""Voice graduation W0 — quarantine table + memory_metadata provenance columns.
+
+The edge→core "graduation" boundary lands typed, synthesized events (never raw
+transcripts) in a quarantine table; a policy drainer (W2, separate PR) later
+routes them into memory stores. This migration ships the substrate DARK:
+
+- ``graduation_events`` — verbatim quarantine landing for
+  ``POST /v1/voice/graduate``. ``event_id`` UNIQUE is the transport dedup key
+  (edge outbox is at-least-once; INSERT OR IGNORE in CRUD makes delivery
+  effectively-once). ``disposition`` starts ``'pending'``; only the W2 drainer
+  moves it. Retention: dispositioned rows pruned after 90d
+  (``crud.graduation_events.prune_older_than``); pending rows are NEVER pruned.
+- ``memory_metadata`` gains 5 NULLable columns (``provenance_class``,
+  ``trust_level``, ``attribution``, ``origin_ref``, ``capture_clarity``) —
+  GROUNDWORK(voice-graduation-w2), written by the drainer. NULLable keeps the
+  ADD COLUMN O(1) metadata-only; non-overheard rows stay NULL by design (the
+  trust ladder is overheard-only).
+
+Additive + idempotent; DDL mirrored in ``db/schema/_tables.py`` AND the
+``memory_metadata`` columns mirrored in ``_migrate_add_columns``
+(schema_both_build_paths — the #1123/#1127 class). No backfill (nothing
+overheard exists yet). Individual ``db.execute()`` calls, no commit — the
+runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_MEMORY_METADATA_COLUMNS = (
+    ("provenance_class", "TEXT"),
+    ("trust_level", "TEXT"),
+    ("attribution", "TEXT"),
+    ("origin_ref", "TEXT"),
+    ("capture_clarity", "REAL"),
+)
+
+
+async def _has_table(db: aiosqlite.Connection, name: str) -> bool:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    )
+    return await cursor.fetchone() is not None
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS graduation_events (
+            id                 TEXT PRIMARY KEY,
+            event_id           TEXT NOT NULL UNIQUE,
+            schema_version     INTEGER NOT NULL,
+            type               TEXT NOT NULL
+                               CHECK (type IN ('perk_up','memory_candidate','meeting_summary')),
+            source             TEXT NOT NULL,
+            occurred_at        TEXT NOT NULL,
+            received_at        TEXT NOT NULL,
+            payload            TEXT NOT NULL,
+            provenance         TEXT NOT NULL,
+            disposition        TEXT NOT NULL DEFAULT 'pending'
+                               CHECK (disposition IN ('pending','landed','rejected','merged')),
+            memory_id          TEXT,
+            disposition_reason TEXT,
+            disposed_at        TEXT
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_graduation_events_disposition "
+        "ON graduation_events(disposition, received_at)"
+    )
+
+    if await _has_table(db, "memory_metadata"):
+        col_cursor = await db.execute("PRAGMA table_info(memory_metadata)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        for name, sql_type in _MEMORY_METADATA_COLUMNS:
+            if name not in cols:
+                await db.execute(
+                    f"ALTER TABLE memory_metadata ADD COLUMN {name} {sql_type}"  # noqa: S608 - fixed identifiers from this module only
+                )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS graduation_events")
+    # memory_metadata columns stay — additive-only policy (0054 precedent).

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1672,6 +1672,37 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ego_directives.last_reaffirmed_at",
     )
 
+    # Voice graduation W0 (2026-07-18): provenance/trust columns for graduated
+    # overheard content. GROUNDWORK(voice-graduation-w2) — written by the W2
+    # policy drainer, dark until then. Mirrored in migration 0068 for the
+    # standalone runner; added here too so an existing DB gets them on the
+    # base create_all_tables path (schema_both_build_paths).
+    await _try_alter(
+        db,
+        "ALTER TABLE memory_metadata ADD COLUMN provenance_class TEXT",
+        "memory_metadata.provenance_class",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE memory_metadata ADD COLUMN trust_level TEXT",
+        "memory_metadata.trust_level",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE memory_metadata ADD COLUMN attribution TEXT",
+        "memory_metadata.attribution",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE memory_metadata ADD COLUMN origin_ref TEXT",
+        "memory_metadata.origin_ref",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE memory_metadata ADD COLUMN capture_clarity REAL",
+        "memory_metadata.capture_clarity",
+    )
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1169,7 +1169,35 @@ TABLES = {
             source_subsystem TEXT,
             deprecated       INTEGER NOT NULL DEFAULT 0,
             dream_cycle_run_id TEXT,
-            origin_class     TEXT
+            origin_class     TEXT,
+            -- GROUNDWORK(voice-graduation-w2): provenance/trust columns for
+            -- graduated overheard content — written by the W2 policy drainer,
+            -- dark until then. trust_level ladder is overheard-only (NULL
+            -- for non-overheard rows).
+            provenance_class TEXT,
+            trust_level      TEXT,
+            attribution      TEXT,
+            origin_ref       TEXT,
+            capture_clarity  REAL
+        )
+    """,
+    "graduation_events": """
+        CREATE TABLE IF NOT EXISTS graduation_events (
+            id                 TEXT PRIMARY KEY,
+            event_id           TEXT NOT NULL UNIQUE,
+            schema_version     INTEGER NOT NULL,
+            type               TEXT NOT NULL
+                               CHECK (type IN ('perk_up','memory_candidate','meeting_summary')),
+            source             TEXT NOT NULL,
+            occurred_at        TEXT NOT NULL,
+            received_at        TEXT NOT NULL,
+            payload            TEXT NOT NULL,
+            provenance         TEXT NOT NULL,
+            disposition        TEXT NOT NULL DEFAULT 'pending'
+                               CHECK (disposition IN ('pending','landed','rejected','merged')),
+            memory_id          TEXT,
+            disposition_reason TEXT,
+            disposed_at        TEXT
         )
     """,
     "code_modules": """
@@ -2245,6 +2273,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_lp_domain ON ledger_predictions(domain, action_class, metric)",
     "CREATE INDEX IF NOT EXISTS idx_lp_status ON ledger_predictions(status)",
     "CREATE INDEX IF NOT EXISTS idx_lp_subject ON ledger_predictions(subject_ref_type, subject_ref_id)",
+    # Voice graduation quarantine (W0) — serves the W2 drainer's pending scan
+    # and the dispositioned-only prune
+    "CREATE INDEX IF NOT EXISTS idx_graduation_events_disposition ON graduation_events(disposition, received_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -494,6 +494,12 @@ class StandaloneAdapter:
             if "voice_api" not in app.blueprints:
                 app.register_blueprint(voice_api_bp)
                 logger.info("Voice API blueprint registered")
+            if not os.environ.get("GENESIS_MCP_HTTP_TOKEN"):
+                logger.warning(
+                    "voice API disabled: GENESIS_MCP_HTTP_TOKEN not configured "
+                    "— all /v1/voice/* routes answer 503 (fail-closed; set the "
+                    "token in secrets.env to enable the voice API)"
+                )
         except Exception:
             logger.exception("Failed to register voice API blueprint")
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -165,6 +165,31 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
         misfire_grace_time=3600,
     )
 
+    async def _prune_graduation_events() -> None:
+        if rt._db is None:
+            return
+        try:
+            from genesis.db.crud import graduation_events as _ge
+
+            removed = await _ge.prune_older_than(rt._db, days=90)
+            rt.record_job_success("graduation_events_prune")
+            if removed:
+                logger.info(
+                    "graduation_events prune: removed %d dispositioned rows (>90d)",
+                    removed,
+                )
+        except Exception as exc:
+            rt.record_job_failure("graduation_events_prune", str(exc))
+            logger.exception("graduation_events prune failed")
+
+    scheduler.add_job(
+        _prune_graduation_events,
+        CronTrigger(hour=5, minute=40, timezone=user_timezone()),
+        id="graduation_events_prune",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
 
 async def init(rt: GenesisRuntime) -> None:
     """Initialize learning pipeline, triage, calibration, harvest, and all scheduled jobs."""

--- a/tests/test_channels/test_voice.py
+++ b/tests/test_channels/test_voice.py
@@ -467,12 +467,13 @@ class TestVoiceAPI:
         t.start()
         try:
             with (
-                patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+                patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
                 app.test_client() as client,
             ):
                 resp = client.post(
                     "/v1/voice/chat/completions",
                     json={"messages": [{"role": "system", "content": "you are helpful"}]},
+                    headers={"Authorization": "Bearer secret"},
                 )
                 assert resp.status_code == 400
         finally:
@@ -482,18 +483,19 @@ class TestVoiceAPI:
     def test_handler_not_initialized(self, app):
         app.config["VOICE_HANDLER"] = None
         with (
-            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
             app.test_client() as client,
         ):
             resp = client.post(
                 "/v1/voice/chat/completions",
                 json={"messages": [{"role": "user", "content": "hello"}]},
+                headers={"Authorization": "Bearer secret"},
             )
             assert resp.status_code == 503
 
     def test_successful_response_format(self, app):
         """Verify OpenAI-compatible response structure."""
-        with patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False):
+        with patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False):
             loop = app.config["GENESIS_EVENT_LOOP"]
 
             # Override to use synchronous mock
@@ -514,6 +516,7 @@ class TestVoiceAPI:
                             "messages": [{"role": "user", "content": "what happened yesterday"}],
                             "user": "ha-voice-test",
                         },
+                        headers={"Authorization": "Bearer secret"},
                     )
                     assert resp.status_code == 200
                     data = resp.get_json()
@@ -531,12 +534,13 @@ class TestVoiceAPI:
     def test_tool_call_no_bridge(self, app):
         """Returns 503 when bridge is not initialized."""
         with (
-            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
             app.test_client() as client,
         ):
             resp = client.post(
                 "/v1/voice/tool_call",
                 json={"tool_name": "ask_genesis", "arguments": {"query": "test"}},
+                headers={"Authorization": "Bearer secret"},
             )
             assert resp.status_code == 503
 
@@ -559,12 +563,13 @@ class TestVoiceAPI:
         t.start()
         try:
             with (
-                patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+                patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
                 app.test_client() as client,
             ):
                 resp = client.post(
                     "/v1/voice/tool_call",
                     json={"arguments": {"query": "test"}},
+                    headers={"Authorization": "Bearer secret"},
                 )
                 assert resp.status_code == 400
         finally:
@@ -592,12 +597,13 @@ class TestVoiceAPI:
         t.start()
         try:
             with (
-                patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+                patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
                 app.test_client() as client,
             ):
                 resp = client.post(
                     "/v1/voice/tool_call",
                     json={"tool_name": "ask_genesis", "arguments": {"query": "what did we work on"}},
+                    headers={"Authorization": "Bearer secret"},
                 )
                 assert resp.status_code == 200
                 data = resp.get_json()
@@ -627,10 +633,13 @@ class TestVoiceAPI:
         app.config["GENESIS_BRIDGE"] = bridge
 
         with (
-            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
             app.test_client() as client,
         ):
-            resp = client.get("/v1/voice/system_prompt")
+            resp = client.get(
+                "/v1/voice/system_prompt",
+                headers={"Authorization": "Bearer secret"},
+            )
             assert resp.status_code == 200
             data = resp.get_json()
             assert "prompt" in data
@@ -640,10 +649,13 @@ class TestVoiceAPI:
         """Tool declarations endpoint returns the advertised voice tools
         (ask_genesis disabled until the memory refactor)."""
         with (
-            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": "secret"}, clear=False),
             app.test_client() as client,
         ):
-            resp = client.get("/v1/voice/tool_declarations")
+            resp = client.get(
+                "/v1/voice/tool_declarations",
+                headers={"Authorization": "Bearer secret"},
+            )
             assert resp.status_code == 200
             data = resp.get_json()
             assert "tools" in data
@@ -651,6 +663,31 @@ class TestVoiceAPI:
             assert "ask_genesis" not in tool_names  # disabled until the memory refactor
             assert "web_search" in tool_names
             assert "approve_pending" in tool_names
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("post", "/v1/voice/chat/completions"),
+            ("post", "/v1/voice/tool_call"),
+            ("get", "/v1/voice/system_prompt"),
+            ("get", "/v1/voice/tool_declarations"),
+            ("post", "/v1/voice/graduate"),
+        ],
+    )
+    def test_fail_closed_when_token_unset(self, app, method, path):
+        """Unset GENESIS_MCP_HTTP_TOKEN disables the whole voice API (503).
+
+        This is the fail-closed flip (spec §3.4-1): no token ⇒ no open door,
+        even on a trusted network — /v1/voice/graduate is a write surface on
+        the same token model.
+        """
+        with (
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            app.test_client() as client,
+        ):
+            resp = getattr(client, method)(path, json={})
+            assert resp.status_code == 503
+            assert "GENESIS_MCP_HTTP_TOKEN" in resp.get_json()["error"]
 
 
 # ── Standalone shutdown chime ────────────────────────────────────────

--- a/tests/test_channels/test_voice_graduate.py
+++ b/tests/test_channels/test_voice_graduate.py
@@ -1,0 +1,240 @@
+"""Tests for the W0 graduation door: envelope validator + /v1/voice/graduate.
+
+The route tests use the same minimal-Flask-app + daemon-thread-loop fixture
+shape as ``TestVoiceAPI`` (test_voice.py); the DB layer is mocked at the crud
+seam (``graduation_events.insert_event``) and the runtime at
+``GenesisRuntime.instance`` — CRUD behavior itself is covered in
+``tests/test_db/test_crud_graduation_events.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.channels.voice.graduation import (
+    EVENT_TYPES,
+    PROVENANCE_CLASSES,
+    SCHEMA_VERSION,
+    validate_envelope,
+)
+
+
+def _envelope(**overrides) -> dict:
+    data = {
+        "event_id": "3f2a9c1e0b4d4e8f9a1b2c3d4e5f6a7b",
+        "schema_version": SCHEMA_VERSION,
+        "type": "memory_candidate",
+        "source": "pe-livingroom",
+        "occurred_at": "2026-07-17T21:00:00Z",
+        "payload": {"claim": "someone mentioned a trip"},
+        "provenance": {"class": "ambient_overheard"},
+    }
+    data.update(overrides)
+    return data
+
+
+# ── Envelope validator (pure) ────────────────────────────────────────
+
+
+class TestValidateEnvelope:
+    def test_valid_envelope_passes(self):
+        assert validate_envelope(_envelope()) == []
+
+    def test_all_event_types_and_classes_accepted(self):
+        for etype in EVENT_TYPES:
+            for pclass in PROVENANCE_CLASSES:
+                env = _envelope(type=etype, provenance={"class": pclass})
+                assert validate_envelope(env) == []
+
+    @pytest.mark.parametrize(
+        ("overrides", "fragment"),
+        [
+            ({"event_id": ""}, "event_id"),
+            ({"event_id": 42}, "event_id"),
+            ({"event_id": "x" * 200}, "128"),
+            ({"schema_version": 2}, "schema_version"),
+            ({"schema_version": None}, "schema_version"),
+            ({"type": "unknown"}, "type"),
+            ({"source": ""}, "source"),
+            ({"occurred_at": "not-a-date"}, "occurred_at"),
+            ({"occurred_at": None}, "occurred_at"),
+            ({"payload": "text"}, "payload"),
+            ({"provenance": None}, "provenance"),
+            ({"provenance": {"class": "first_party"}}, "provenance.class"),
+        ],
+    )
+    def test_each_violation_yields_its_error(self, overrides, fragment):
+        errors = validate_envelope(_envelope(**overrides))
+        assert errors, f"expected errors for {overrides}"
+        assert any(fragment in e for e in errors)
+
+    def test_empty_envelope_reports_all_fields(self):
+        errors = validate_envelope({})
+        assert len(errors) >= 6
+
+
+# ── /v1/voice/graduate route ─────────────────────────────────────────
+
+
+class TestVoiceGraduate:
+    @pytest.fixture
+    def app(self):
+        from flask import Flask
+
+        from genesis.dashboard.routes.voice_api import voice_api_bp
+
+        app = Flask(__name__)
+        app.register_blueprint(voice_api_bp)
+        loop = asyncio.new_event_loop()
+        app.config["GENESIS_EVENT_LOOP"] = loop
+        yield app
+        loop.close()
+
+    @contextmanager
+    def _running_loop(self, app):
+        loop = app.config["GENESIS_EVENT_LOOP"]
+
+        def run_loop():
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        t = threading.Thread(target=run_loop, daemon=True)
+        t.start()
+        try:
+            yield
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            t.join(timeout=2)
+
+    @contextmanager
+    def _ready_runtime(self, insert_result=True):
+        rt = MagicMock()
+        rt.is_bootstrapped = True
+        rt.db = object()
+        insert = AsyncMock(return_value=insert_result)
+        with (
+            patch("genesis.runtime.GenesisRuntime") as runtime_cls,
+            patch("genesis.db.crud.graduation_events.insert_event", insert),
+        ):
+            runtime_cls.instance.return_value = rt
+            yield rt, insert
+
+    _AUTH = {"Authorization": "Bearer secret"}
+    _ENV = {"GENESIS_MCP_HTTP_TOKEN": "secret"}
+
+    def test_accepted_and_insert_kwargs(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            self._ready_runtime() as (rt, insert),
+            self._running_loop(app),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/graduate", json=_envelope(), headers=self._AUTH)
+            assert resp.status_code == 200
+            assert resp.get_json() == {"status": "accepted"}
+
+            insert.assert_awaited_once()
+            kwargs = insert.await_args.kwargs
+            assert insert.await_args.args == (rt.db,)
+            env = _envelope()
+            for field in (
+                "event_id",
+                "schema_version",
+                "type",
+                "source",
+                "occurred_at",
+            ):
+                assert kwargs[field] == env[field]
+            assert kwargs["payload"] == env["payload"]
+            assert kwargs["provenance"] == env["provenance"]
+            assert kwargs["received_at"]  # core-stamped, ISO string
+
+    def test_replay_answers_duplicate(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            self._ready_runtime(insert_result=False),
+            self._running_loop(app),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/graduate", json=_envelope(), headers=self._AUTH)
+            assert resp.status_code == 200
+            assert resp.get_json() == {"status": "duplicate"}
+
+    def test_invalid_envelope_rejected_before_any_dispatch(self, app):
+        # No running loop on purpose — validation must answer without it.
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            self._ready_runtime() as (_rt, insert),
+            app.test_client() as client,
+        ):
+            resp = client.post(
+                "/v1/voice/graduate",
+                json=_envelope(schema_version=99, type="nope"),
+                headers=self._AUTH,
+            )
+            assert resp.status_code == 400
+            body = resp.get_json()
+            assert body["status"] == "rejected"
+            assert len(body["errors"]) == 2
+            insert.assert_not_awaited()
+
+    def test_oversized_envelope_rejected(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            big = _envelope(payload={"claim": "x" * (70 * 1024)})
+            resp = client.post("/v1/voice/graduate", json=big, headers=self._AUTH)
+            assert resp.status_code == 400
+            assert "64KB" in resp.get_json()["errors"][0]
+
+    def test_auth_required_bad_bearer(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post(
+                "/v1/voice/graduate",
+                json=_envelope(),
+                headers={"Authorization": "Bearer wrong"},
+            )
+            assert resp.status_code == 401
+
+    def test_no_open_door_when_token_unset(self, app):
+        """Unlike the pre-flip read routes, the write surface NEVER rides
+        network trust — unset token means 503, not open access."""
+        with (
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/graduate", json=_envelope())
+            assert resp.status_code == 503
+
+    def test_runtime_not_ready_is_503(self, app):
+        rt = MagicMock()
+        rt.is_bootstrapped = False
+        rt.db = None
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            patch("genesis.runtime.GenesisRuntime") as runtime_cls,
+            self._running_loop(app),
+            app.test_client() as client,
+        ):
+            runtime_cls.instance.return_value = rt
+            resp = client.post("/v1/voice/graduate", json=_envelope(), headers=self._AUTH)
+            assert resp.status_code == 503
+            assert "not ready" in resp.get_json()["error"]
+
+    def test_loop_not_running_is_503(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/graduate", json=_envelope(), headers=self._AUTH)
+            assert resp.status_code == 503
+            assert "loop" in resp.get_json()["error"].lower()

--- a/tests/test_channels/test_voice_graduate.py
+++ b/tests/test_channels/test_voice_graduate.py
@@ -183,6 +183,23 @@ class TestVoiceGraduate:
             assert len(body["errors"]) == 2
             insert.assert_not_awaited()
 
+    @pytest.mark.parametrize("body", ['[1, 2, 3]', '"hello"', "42"])
+    def test_non_object_json_body_rejected(self, app, body):
+        """A top-level JSON array/string/number is a 400 rejection, never a 500
+        (the edge outbox would retry a 500 forever on a permanently-bad body)."""
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post(
+                "/v1/voice/graduate",
+                data=body,
+                content_type="application/json",
+                headers=self._AUTH,
+            )
+            assert resp.status_code == 400
+            assert resp.get_json()["status"] == "rejected"
+
     def test_oversized_envelope_rejected(self, app):
         with (
             patch.dict("os.environ", self._ENV, clear=False),

--- a/tests/test_db/test_crud_graduation_events.py
+++ b/tests/test_db/test_crud_graduation_events.py
@@ -90,3 +90,17 @@ async def test_prune_removes_old_dispositioned_keeps_recent(db):
     assert removed == 1
     assert await graduation_events.get_by_event_id(db, event_id="evt-landed-old") is None
     assert await graduation_events.get_by_event_id(db, event_id="evt-landed-recent") is not None
+
+
+async def test_constraint_violation_raises_not_duplicate(db):
+    """OR IGNORE swallows CHECK violations too — insert_event must surface a
+    non-duplicate ignore as an error, never a silent 'duplicate' (silent data
+    loss if a future event type is missing from an old DB's frozen CHECK)."""
+    import aiosqlite
+
+    with pytest.raises(aiosqlite.IntegrityError, match="non-duplicate"):
+        await _insert(db, event_id="evt-bogus-type", type="not_a_real_type")
+
+    assert (
+        await graduation_events.get_by_event_id(db, event_id="evt-bogus-type") is None
+    )

--- a/tests/test_db/test_crud_graduation_events.py
+++ b/tests/test_db/test_crud_graduation_events.py
@@ -1,0 +1,92 @@
+"""CRUD tests for ``graduation_events`` — voice graduation quarantine (W0).
+
+Covers the transport contract half the endpoint relies on: INSERT OR IGNORE
+dedup on ``event_id`` (at-least-once delivery → effectively-once landing),
+JSON round-trip of payload/provenance, and the prune invariant — dispositioned
+rows age out at 90d, pending rows are NEVER pruned (they are the W2 drainer's
+inbox).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.db.crud import graduation_events
+
+pytestmark = pytest.mark.asyncio
+
+_ENVELOPE = {
+    "event_id": "evt-0001",
+    "schema_version": 1,
+    "type": "memory_candidate",
+    "source": "pe-livingroom",
+    "occurred_at": "2026-07-17T21:00:00+00:00",
+    "received_at": "2026-07-18T02:00:00+00:00",
+    "payload": {"claim": "someone mentioned a trip", "content_class": "user_world"},
+    "provenance": {"class": "ambient_overheard", "attribution": {"is_user": False}},
+}
+
+
+async def _insert(db, **overrides) -> bool:
+    kwargs = {**_ENVELOPE, **overrides}
+    return await graduation_events.insert_event(db, **kwargs)
+
+
+async def test_insert_lands_pending_row(db):
+    assert await _insert(db) is True
+
+    row = await graduation_events.get_by_event_id(db, event_id="evt-0001")
+    assert row is not None
+    assert row["disposition"] == "pending"
+    assert row["memory_id"] is None
+    assert row["disposed_at"] is None
+    assert json.loads(row["payload"]) == _ENVELOPE["payload"]
+    assert json.loads(row["provenance"]) == _ENVELOPE["provenance"]
+
+
+async def test_replay_is_duplicate_and_row_unchanged(db):
+    assert await _insert(db) is True
+    first = await graduation_events.get_by_event_id(db, event_id="evt-0001")
+
+    # Replay with different content — the original row must win untouched.
+    assert await _insert(db, source="pe-kitchen") is False
+    row = await graduation_events.get_by_event_id(db, event_id="evt-0001")
+    assert row == first
+
+    cursor = await db.execute("SELECT COUNT(*) FROM graduation_events WHERE event_id = 'evt-0001'")
+    assert (await cursor.fetchone())[0] == 1
+
+
+async def test_prune_never_touches_pending(db):
+    # A pending row far older than any retention window.
+    assert await _insert(
+        db,
+        event_id="evt-old-pending",
+        occurred_at="2020-01-01T00:00:00+00:00",
+        received_at="2020-01-01T00:00:00+00:00",
+    )
+
+    removed = await graduation_events.prune_older_than(db, days=1)
+    assert removed == 0
+    assert await graduation_events.get_by_event_id(db, event_id="evt-old-pending") is not None
+
+
+async def test_prune_removes_old_dispositioned_keeps_recent(db):
+    for event_id, disposed_at in (
+        ("evt-landed-old", "2020-01-01T00:00:00+00:00"),
+        ("evt-landed-recent", "2100-01-01T00:00:00+00:00"),
+    ):
+        assert await _insert(db, event_id=event_id)
+        await db.execute(
+            "UPDATE graduation_events SET disposition = 'landed', disposed_at = ? "
+            "WHERE event_id = ?",
+            (disposed_at, event_id),
+        )
+    await db.commit()
+
+    removed = await graduation_events.prune_older_than(db, days=90)
+    assert removed == 1
+    assert await graduation_events.get_by_event_id(db, event_id="evt-landed-old") is None
+    assert await graduation_events.get_by_event_id(db, event_id="evt-landed-recent") is not None

--- a/tests/test_db/test_migration_0068_voice_graduation.py
+++ b/tests/test_db/test_migration_0068_voice_graduation.py
@@ -1,0 +1,153 @@
+"""Migration 0068 — graduation_events table + memory_metadata provenance columns.
+
+Simulates a PRE-0068 database: legacy ``memory_metadata`` DDL copied from
+``db/schema/_tables.py`` minus the five W0 columns, and no
+``graduation_events`` table. Asserts ``up()`` creates the table + index and
+adds the columns, is idempotent (second run leaves everything identical), and
+that the CHECK / UNIQUE constraints actually enforce.
+
+Also proves base-path parity (the #1123/#1127 ``schema_both_build_paths``
+class): ``create_all_tables`` on the same legacy DB must produce the same
+columns via ``_migrate_add_columns`` — an existing install that boots without
+ever running the numbered-migration runner still gets the schema.
+
+The migration does NOT commit (the runner owns the transaction); these tests
+read back on the same aiosqlite connection.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M68 = importlib.import_module("genesis.db.migrations.0068_voice_graduation")
+
+pytestmark = pytest.mark.asyncio
+
+_W0_COLUMNS = {
+    "provenance_class",
+    "trust_level",
+    "attribution",
+    "origin_ref",
+    "capture_clarity",
+}
+
+# Current memory_metadata DDL from _tables.py WITHOUT the five W0 columns.
+_LEGACY_MEMORY_METADATA = """
+    CREATE TABLE memory_metadata (
+        memory_id        TEXT PRIMARY KEY,
+        created_at       TEXT NOT NULL,
+        collection       TEXT NOT NULL DEFAULT 'episodic_memory',
+        confidence       REAL,
+        embedding_status TEXT NOT NULL DEFAULT 'embedded',
+        memory_class     TEXT DEFAULT 'fact',
+        wing             TEXT,
+        room             TEXT,
+        valid_at         TEXT,
+        invalid_at       TEXT,
+        source_subsystem TEXT,
+        deprecated       INTEGER NOT NULL DEFAULT 0,
+        dream_cycle_run_id TEXT,
+        origin_class     TEXT
+    )
+"""
+
+
+async def _legacy_db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await conn.execute(_LEGACY_MEMORY_METADATA)
+    await conn.execute(
+        "INSERT INTO memory_metadata (memory_id, created_at) VALUES ('m1', '2026-01-01')"
+    )
+    return conn
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cursor = await db.execute(f"PRAGMA table_info({table})")  # noqa: S608 - fixed test identifiers
+    return {row[1] for row in await cursor.fetchall()}
+
+
+async def test_up_creates_table_index_and_columns():
+    db = await _legacy_db()
+    try:
+        await M68.up(db)
+
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='graduation_events'"
+        )
+        assert await cursor.fetchone() is not None
+
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name='idx_graduation_events_disposition'"
+        )
+        assert await cursor.fetchone() is not None
+
+        assert await _columns(db, "memory_metadata") >= _W0_COLUMNS
+        # Existing data preserved, new columns NULL
+        row = await (
+            await db.execute("SELECT * FROM memory_metadata WHERE memory_id='m1'")
+        ).fetchone()
+        assert row["created_at"] == "2026-01-01"
+        assert row["provenance_class"] is None
+    finally:
+        await db.close()
+
+
+async def test_up_is_idempotent():
+    db = await _legacy_db()
+    try:
+        await M68.up(db)
+        await M68.up(db)  # must not raise (duplicate table/column/index)
+        assert await _columns(db, "memory_metadata") >= _W0_COLUMNS
+    finally:
+        await db.close()
+
+
+async def test_constraints_enforce():
+    db = await _legacy_db()
+    try:
+        await M68.up(db)
+
+        base = (
+            "INSERT INTO graduation_events "
+            "(id, event_id, schema_version, type, source, occurred_at, "
+            " received_at, payload, provenance) "
+            "VALUES (?, ?, 1, ?, 's', 't', 't', '{}', '{}')"
+        )
+        await db.execute(base, ("r1", "e1", "perk_up"))
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(base, ("r2", "e2", "bogus_type"))
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute("UPDATE graduation_events SET disposition = 'bogus' WHERE id = 'r1'")
+        # UNIQUE(event_id): a plain INSERT (no OR IGNORE) must raise
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(base, ("r3", "e1", "perk_up"))
+    finally:
+        await db.close()
+
+
+async def test_base_path_parity_on_legacy_db():
+    """create_all_tables on a legacy DB yields the same schema (both build paths)."""
+    from genesis.db.schema import create_all_tables
+
+    db = await _legacy_db()
+    try:
+        await create_all_tables(db)
+
+        assert await _columns(db, "memory_metadata") >= _W0_COLUMNS
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='graduation_events'"
+        )
+        assert await cursor.fetchone() is not None
+        # Legacy data survives the base path too
+        row = await (
+            await db.execute("SELECT created_at FROM memory_metadata WHERE memory_id='m1'")
+        ).fetchone()
+        assert row[0] == "2026-01-01"
+    finally:
+        await db.close()

--- a/tests/test_db/test_migration_0068_voice_graduation.py
+++ b/tests/test_db/test_migration_0068_voice_graduation.py
@@ -18,6 +18,7 @@ read back on the same aiosqlite connection.
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 
 import aiosqlite
 import pytest
@@ -151,3 +152,30 @@ async def test_base_path_parity_on_legacy_db():
         assert row[0] == "2026-01-01"
     finally:
         await db.close()
+
+
+def test_event_types_match_ddl_check_lists():
+    """EVENT_TYPES (validator) must equal the CHECK list in BOTH DDL copies.
+
+    SQLite cannot ALTER a CHECK constraint — existing installs keep the W0
+    list forever. If a future PR extends EVENT_TYPES without a migration
+    strategy for the frozen CHECK, validated events of the new type would be
+    OR-IGNOREd on old DBs. insert_event now raises on that case; this test
+    catches the drift at CI time instead.
+    """
+    import re
+
+    from genesis.channels.voice.graduation import EVENT_TYPES
+    from genesis.db.schema._tables import TABLES
+
+    def check_list(ddl: str) -> tuple[str, ...]:
+        m = re.search(r"type\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(type IN \(([^)]+)\)", ddl)
+        assert m, "type CHECK not found in DDL"
+        return tuple(v.strip().strip("'") for v in m.group(1).split(","))
+
+    canonical = check_list(TABLES["graduation_events"])
+    migration_src = Path(M68.__file__).read_text()
+    migration = check_list(migration_src)
+
+    assert canonical == EVENT_TYPES
+    assert migration == EVENT_TYPES

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -75,6 +75,7 @@ EXPECTED_TABLES = [
     "ledger_predictions",  # WS-2 P1a: cognitive-ledger falsifiable prediction rows
     "entity_adjudications",  # entity-node merge-vs-distinct decision ledger (drainer)
     "autonomy_events",  # append-only success/correction ledger for windowed earn-back
+    "graduation_events",  # voice graduation quarantine (W0; drained in W2)
 ]
 
 
@@ -448,6 +449,8 @@ async def test_key_indexes_exist(db):
         # dead letter
         "idx_dead_letter_status",
         "idx_dead_letter_provider",
+        # voice graduation quarantine
+        "idx_graduation_events_disposition",
     }
     for idx in expected:
         assert idx in indexes, f"Missing index: {idx}"

--- a/tests/test_runtime/test_learning_retention_jobs.py
+++ b/tests/test_runtime/test_learning_retention_jobs.py
@@ -19,6 +19,7 @@ _EXPECTED = (
     "file_modifications_prune",
     "job_run_events_prune",
     "alert_events_prune",
+    "graduation_events_prune",
 )
 
 


### PR DESCRIPTION
## Summary

W0 of the voice⇄core interface: the **graduation door** — the boundary through which typed, synthesized voice events (claims — never raw transcripts) enter the core. Ships **dark**: events land in a quarantine table with no consumer; the policy drainer that routes them into memory is a later phase (W2).

### Added
- **`graduation_events` quarantine table** — events land verbatim with `disposition='pending'`. `event_id UNIQUE` + `INSERT OR IGNORE` turns the edge outbox's at-least-once delivery into effectively-once landing. Schema lands on all three build paths (canonical `TABLES` DDL, `_migrate_add_columns` base path, numbered migration `0068`) per the base-path-parity invariant.
- **`POST /v1/voice/graduate`** — bearer-authenticated write endpoint. Validates the versioned envelope (`schema_version`, `type`, `source`, `occurred_at`, `payload`, `provenance.class`), answers `accepted` / `duplicate` / 400 `rejected`, and commits before returning 2xx (durable-before-ack transport contract). 64KB body cap measured on the actual body (chunked-encoding safe).
- **`memory_metadata` provenance columns** (`provenance_class`, `trust_level`, `attribution`, `origin_ref`, `capture_clarity`) — nullable, GROUNDWORK-tagged; written by the W2 drainer, dark until then.
- **90d retention job** (`graduation_events_prune`, CronTrigger) — prunes dispositioned rows only; pending rows are never pruned (they are the drainer's inbox).
- Envelope validator module (`channels/voice/graduation.py`) — Flask-free so the W2 drainer reuses the same vocabulary; a CI parity test pins `EVENT_TYPES` to both DDL CHECK lists (SQLite CHECKs are frozen at CREATE time).

### Changed
- **Voice API auth is now fail-closed.** Previously an unset `GENESIS_MCP_HTTP_TOKEN` left all `/v1/voice/*` routes open to the network; now they answer 503 until the token is configured, with a boot-time warning. This makes the token story uniform with the HTTP MCP transport, which already refused to start without one.

### Hardening (from review)
- `INSERT OR IGNORE` conflation guard: a non-duplicate ignore (e.g. a CHECK violation from validator/DDL drift) raises instead of silently answering `duplicate`.
- Non-object JSON bodies (array/string/number) are a 400 rejection, never a 500 — a permanently-bad body must not put the edge outbox into an infinite retry loop.

## Deploy note

⚠️ **The fail-closed flip requires `GENESIS_MCP_HTTP_TOKEN` in `secrets.env` on any install using the voice API.** Installs that already set the token (required for the HTTP MCP transport) see no behavior change. Installs without a voice pipeline are unaffected — the 503s are inert. After deploying, watch voice-caller logs for 503s (a missing bearer in a caller config shows up on the first voice interaction).

## Testing

- 122 targeted tests green across: envelope validator + route (auth, fail-closed, dedup, oversized/chunked, non-object body, runtime-not-ready), CRUD (dedup, prune invariants, constraint-violation guard), migration 0068 (idempotency, constraint enforcement, base-path parity on a legacy DB, EVENT_TYPES↔DDL parity), schema census, retention-job registry.
- Migration drill on a 255MB copy of a real database: 0068 applied in 27ms, rerun no-op, all columns/table/index present.
- E2E HTTP drill against a real Flask server + real SQLite connection: 8/8 scenarios correct (accepted, duplicate, bad-schema 400, no-auth 401, bad-bearer 401, array-body 400, chunked-oversized 400, read-route 401), exactly one `pending` row landed.

Ledger: 4b6b67e9113e4ef681198b7d5532c606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
