### PR TITLE
fix(observability): exclude batch worklists from deferred-review sample

### DIFF
--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -384,11 +384,24 @@ async def queues(
     deferred_items: list[dict] = []
     if db:
         try:
+            # Exclude scheduled batch worklists (dream-synthesis, entity
+            # adjudication) from the review sample — they are drained on a daily
+            # budget by design and sit pending for days, so surfacing them as
+            # "Deferred review" items is a false alarm. They stay counted in the
+            # separate `deferred_worklist` gauge. Same segmentation the
+            # recovery-depth alarm applies (see BATCH_WORK_TYPES).
+            from genesis.resilience.deferred_work import BATCH_WORK_TYPES
+
             now_dt = datetime.now(UTC)
+            placeholders = ",".join("?" * len(BATCH_WORK_TYPES))
+            # NOT-IN values are bound parameters; only the placeholder count is
+            # interpolated (from an internal constant), so no injection surface.
             cur = await db.execute(
-                """SELECT work_type, call_site_id, deferred_reason, attempts, created_at
-                   FROM deferred_work_queue WHERE status='pending'
-                   ORDER BY priority, created_at LIMIT 5"""
+                f"""SELECT work_type, call_site_id, deferred_reason, attempts, created_at
+                   FROM deferred_work_queue
+                   WHERE status='pending' AND work_type NOT IN ({placeholders})
+                   ORDER BY priority, created_at LIMIT 5""",  # noqa: S608
+                tuple(BATCH_WORK_TYPES),
             )
             for row in await cur.fetchall():
                 age = (now_dt - datetime.fromisoformat(row["created_at"])).total_seconds()

--- a/tests/test_observability/test_deferred_work_segmentation.py
+++ b/tests/test_observability/test_deferred_work_segmentation.py
@@ -122,6 +122,27 @@ class TestSnapshotSplit:
         assert result["deferred_recovery"] == 2  # alarm-eligible
 
     @pytest.mark.asyncio
+    async def test_deferred_items_sample_excludes_batch_worklists(self, db):
+        # The "Deferred review" card renders `deferred_items`. Batch worklists
+        # drain on a daily budget and sit pending for days by design, so they
+        # must not crowd the sample or surface as items "needing review" — even
+        # when they dominate the pending set (400 dream slices was the live
+        # trigger). Only genuine recovery items belong here.
+        import importlib
+
+        qmod = importlib.import_module("genesis.observability.snapshots.queues")
+
+        await _seed_recovery(db, 2)
+        await _seed_worklist(db, 50, age_days=0.0)  # batch flood
+
+        result = await qmod.queues(db, _queue(db), None)
+
+        sampled_types = {item["type"] for item in result["deferred_items"]}
+        assert WORKLIST_TYPE not in sampled_types
+        assert sampled_types == {"reflection"}
+        assert len(result["deferred_items"]) == 2
+
+    @pytest.mark.asyncio
     async def test_queues_snapshot_no_queue_is_zero(self, db):
         import importlib
 


### PR DESCRIPTION
## What

The dashboard **Deferred review** card renders the health snapshot's `deferred_items` sample, which selected the top-5 pending `deferred_work_queue` rows regardless of type. Scheduled batch worklists — dream-synthesis (`dream_synthesis_slice`) and entity-adjudication — drain on a daily budget and sit pending for days *by design*, so they flooded the sample and surfaced as items "needing review." The live trigger was 400 dream-synthesis slices enqueued by the weekly dream cycle showing up as `unknown • dream_synthesis_slice` in the review card.

## Fix

Exclude `BATCH_WORK_TYPES` from the `deferred_items` sample query — the same segmentation the recovery-depth alarm already applies (`resilience/deferred_work.py`). Batch items stay counted in the separate `deferred_worklist` gauge and the raw `deferred_work` total, so the `(+N worklist)` display is unaffected.

## Verification

- New test `test_deferred_items_sample_excludes_batch_worklists` seeds a 50-item batch flood + 2 recovery items and asserts the sample contains only recovery items. Confirmed RED on unfixed code, GREEN with the fix.
- All 10 tests in `test_deferred_work_segmentation.py` pass; ruff clean.
- **Live E2E** (worktree code vs. the real prod DB, read-only): with 400 dream slices pending, `deferred_items` sample went from 5 dream-slice entries → `[]`, while `deferred_work=400`, `deferred_worklist=400`, `deferred_recovery=0` stayed correct.

## Deploy path

Runtime code — `git pull` + server restart (update.sh). No schema/data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)