### PR TITLE
feat(voice): s2s extraction parity — conversations feed memory extraction (W0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
-<<<<<<< HEAD
+- **Voice conversations now feed real memory extraction (W0.5).** S2S voice
+  conversations used to land in episodic memory as one growing raw blob per
+  session close — duplicated on replays, never mined for facts. They now
+  land as per-conversation transcripts (CC-transcript format, under
+  `~/.genesis/voice-transcripts/`, outside the Claude Code resume picker)
+  that the existing memory extraction job mines incrementally like every
+  other channel: facts, references, and a topic index instead of raw dumps.
+  A new authenticated `POST /v1/voice/conversation` endpoint lets a voice
+  edge machine deliver its conversation turns with replay-safe, idempotent
+  append semantics (double-fires and cumulative re-sends land exactly once,
+  and turns are durable before the endpoint acknowledges). Voice transcripts
+  are kept for 1 year (daily prune; an in-progress conversation is never
+  touched), and voice conversation rows are excluded from the Claude Code
+  session budget and the ego's capability self-model — they are
+  conversations, not work sessions.
 - **Genesis now keeps an honest, mechanical scorecard of its own confidence.**
   The cognitive ledger's graded predictions roll up into a unified calibration
   table (`calibration_cells`, migration 0069), recomputed after every grading
@@ -25,7 +39,6 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   mechanical-vs-LLM grading shares), and Deep/Strategic reflections now read
   their "when you report ~80% you're right ~60%" advisory from this real
   graded record instead of the legacy proto-calibration table.
-=======
 - **Voice graduation door (W0).** The core now exposes an authenticated
   `POST /v1/voice/graduate` endpoint where a voice edge machine can land
   typed "graduation" events (synthesized claims from ambient/meeting
@@ -37,7 +50,6 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   metadata schema also gains dormant provenance/trust columns
   (`provenance_class`, `trust_level`, `attribution`, `origin_ref`,
   `capture_clarity`) for that later phase.
->>>>>>> origin/main
 - **A runaway Claude Code temp write can no longer fill the container's root
   disk.** `~/.genesis/cc-tmp` — the scratch space every CC session (and
   genesis-server) writes to — now lives on its own size-capped incus storage
@@ -66,6 +78,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Legacy voice conversation blobs are swept from episodic memory.** The old
+  one-blob landing left duplicated, ever-growing "Voice conversation [...]"
+  memories polluting recall (and their vector embeddings polluting semantic
+  search). A daily voice-hygiene job now removes them across all storage
+  layers; it runs as a standing sweep (not a one-shot migration) so blobs
+  written by a voice edge that hasn't been updated yet are cleaned up too,
+  and it logs loudly when it finds any — a nonzero sweep after your edge is
+  current means a stale producer is back.
 - **`update.sh` no longer aborts on Serena's config churn.** `.serena/project.yml`
   is now install-local (untracked): Serena rewrites the file's comment block on
   its own version bumps, so any install running the Serena MCP went permanently

--- a/src/genesis/channels/voice/hygiene.py
+++ b/src/genesis/channels/voice/hygiene.py
@@ -1,0 +1,150 @@
+"""Daily voice hygiene — transcript aging + stale-producer blob sweep.
+
+Two duties, both keyed on observable state, wired as the ``voice_hygiene``
+retention job (``runtime/init/learning.py``):
+
+1. ``prune_old_transcripts`` — delete voice transcript files older than the
+   retention window (default 1 year, user decision 2026-07-19). The
+   ``cc_sessions`` rows stay: they are the tiny topic/keyword index, matching
+   how CC session rows outlive interest in their transcripts.
+
+2. ``sweep_blob_memories`` — remove legacy "one-blob" voice conversation
+   memories. Before the transcript-writer landing existed, both the core S2S
+   manager and the edge s2s bridge stored each conversation as a single
+   growing ``"Voice conversation [...]"`` blob in episodic memory (duplicated
+   per client disconnect, cumulative across weeks). After this release
+   nothing legitimate writes that signature, so any hit is a stale producer
+   (an edge bridge that has not yet been updated) — swept daily and logged
+   loudly. A one-shot data migration cannot do this job: the migration runner
+   never re-runs completed migrations, so blobs written after the first purge
+   would survive forever.
+
+No-voice installs no-op for pennies: candidate discovery is an index-backed
+FTS MATCH, not a content scan.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import aiosqlite
+
+from genesis.db.crud import cc_sessions as sessions_crud
+from genesis.env import voice_transcript_dir
+
+if TYPE_CHECKING:
+    from genesis.memory.store import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+TRANSCRIPT_RETENTION_DAYS = 365
+
+# Signature of the legacy blob landing. The tags MATCH narrows to a handful
+# of candidates via the FTS index; the exact content prefix (checked in
+# Python) is what makes a hit definitive — legitimate voice-tagged memories
+# without the prefix survive. Live-verified against the polluted cohort
+# 2026-07-19: FTS source_type is the generic 'memory' for these rows, so
+# tags+prefix is the only reliable discriminator.
+_BLOB_CANDIDATE_MATCH = "tags:voice AND tags:s2s AND tags:conversation"
+_BLOB_CONTENT_PREFIX = "Voice conversation ["
+
+
+async def prune_old_transcripts(
+    db: aiosqlite.Connection,
+    *,
+    days: int = TRANSCRIPT_RETENTION_DAYS,
+    transcript_dir: Path | None = None,
+) -> int:
+    """Delete voice transcript files past retention. Returns files removed.
+
+    Age comes from the session row's ``started_at`` when one exists (file
+    mtime as fallback for rowless files). A file whose session is still
+    ``active`` is never deleted, regardless of age.
+    """
+    directory = transcript_dir or voice_transcript_dir()
+    if not directory.is_dir():
+        return 0
+
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    removed = 0
+    for path in directory.glob("*.jsonl"):
+        row = await sessions_crud.get_by_id(db, path.stem)
+        if row is not None:
+            if row.get("status") == "active":
+                continue
+            started_raw = row.get("started_at") or ""
+            try:
+                age_marker = datetime.fromisoformat(started_raw)
+                if age_marker.tzinfo is None:
+                    age_marker = age_marker.replace(tzinfo=UTC)
+            except ValueError:
+                age_marker = None
+        else:
+            age_marker = None
+
+        if age_marker is None:
+            try:
+                age_marker = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+            except OSError:
+                continue
+
+        if age_marker < cutoff:
+            try:
+                path.unlink()
+                removed += 1
+            except OSError:
+                logger.warning("Could not prune voice transcript %s", path, exc_info=True)
+
+    if removed:
+        logger.info(
+            "Pruned %d voice transcript(s) older than %d days",
+            removed,
+            days,
+        )
+    return removed
+
+
+async def sweep_blob_memories(
+    db: aiosqlite.Connection,
+    store: MemoryStore,
+) -> int:
+    """Cascade-delete legacy one-blob voice memories. Returns memories swept.
+
+    Uses ``MemoryStore.delete`` (the real cascade: FTS, metadata, Qdrant both
+    collections, links, pending embeddings, entity mentions) plus a
+    ``memory_events`` delete — the one layer keyed by memory_id that
+    ``store.delete`` does not cover.
+    """
+    cursor = await db.execute(
+        "SELECT memory_id, content FROM memory_fts WHERE memory_fts MATCH ?",
+        (_BLOB_CANDIDATE_MATCH,),
+    )
+    rows = await cursor.fetchall()
+
+    swept = 0
+    for row in rows:
+        content = row["content"] or ""
+        if not content.startswith(_BLOB_CONTENT_PREFIX):
+            continue
+        memory_id = row["memory_id"]
+        await store.delete(memory_id)
+        await db.execute(
+            "DELETE FROM memory_events WHERE memory_id = ?",
+            (memory_id,),
+        )
+        swept += 1
+
+    if swept:
+        await db.commit()
+        # Loud by design: a nonzero sweep after the edge bridge is updated
+        # means a blob producer is back — investigate, don't just clean up.
+        logger.warning(
+            "Voice hygiene swept %d legacy blob memor%s from episodic memory "
+            "(stale producer still writing? edge bridge update pending?)",
+            swept,
+            "y" if swept == 1 else "ies",
+        )
+    return swept

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -98,10 +98,8 @@ class S2SSessionManager:
     async def start_reaper(self) -> None:
         """Start the idle session reaper (runs every 15s)."""
         from genesis.util.tasks import tracked_task
-
         self._reaper_task = tracked_task(
-            self._reap_loop(),
-            name="s2s-session-reaper",
+            self._reap_loop(), name="s2s-session-reaper",
         )
 
     async def _reap_loop(self) -> None:
@@ -110,8 +108,7 @@ class S2SSessionManager:
             await asyncio.sleep(15)
             now = datetime.now(UTC)
             stale = [
-                sat_id
-                for sat_id, s in self._sessions.items()
+                sat_id for sat_id, s in self._sessions.items()
                 if (now - s.last_activity).total_seconds() > self._max_idle_seconds
                 and not s._closed
             ]
@@ -130,7 +127,10 @@ class S2SSessionManager:
         if self._client is None:
             self._client = openai.AsyncOpenAI()
 
-        session_id = f"s2s-{satellite_id}-{datetime.now(UTC).strftime('%H%M%S')}"
+        # Date included: this id is now a durable identity key (uuid5 →
+        # transcript file + cc_sessions row) — HHMMSS alone collides across
+        # days and would merge two conversations into one transcript.
+        session_id = f"s2s-{satellite_id}-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}"
         session = S2SSession(session_id=session_id, satellite_id=satellite_id)
         self._sessions[satellite_id] = session
         logger.info("S2S session created: %s for satellite %s", session_id, satellite_id)
@@ -153,13 +153,11 @@ class S2SSessionManager:
         # server VAD, 24kHz PCM. We use conversation.item.create for audio
         # input so VAD doesn't interfere with bulk utterances from Wyoming.
         system_prompt = self._bridge.get_system_prompt()
-        await conn.session.update(
-            session={
-                "type": "realtime",
-                "instructions": system_prompt,
-                "tools": TOOL_DECLARATIONS,
-            }
-        )
+        await conn.session.update(session={
+            "type": "realtime",
+            "instructions": system_prompt,
+            "tools": TOOL_DECLARATIONS,
+        })
 
         # Wait for session.updated confirmation (timeout: 10s)
         try:
@@ -179,11 +177,7 @@ class S2SSessionManager:
             raise RuntimeError("S2S session config timed out") from None
 
     async def send_turn(
-        self,
-        session: S2SSession,
-        audio: bytes,
-        *,
-        input_rate: int = 16000,
+        self, session: S2SSession, audio: bytes, *, input_rate: int = 16000,
     ) -> None:
         """Send a complete utterance as a conversation item and trigger a response.
 
@@ -197,19 +191,16 @@ class S2SSessionManager:
         # Resample 16kHz → 24kHz (Realtime API requires 24kHz PCM)
         if input_rate != 24000:
             from genesis.channels.voice.wyoming_tts import _resample_pcm
-
             audio = _resample_pcm(audio, input_rate, 24000)
 
         encoded = base64.b64encode(audio).decode()
 
         # Send as a conversation item (bypasses input_audio_buffer entirely)
-        await session.connection.conversation.item.create(
-            item={
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_audio", "audio": encoded}],
-            }
-        )
+        await session.connection.conversation.item.create(item={
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_audio", "audio": encoded}],
+        })
 
         # Brief pause to let the model ingest the audio before we request
         # a response.  Without this, response.create() can fire before
@@ -224,8 +215,7 @@ class S2SSessionManager:
         await session.connection.response.create()
 
     async def receive_response(
-        self,
-        session: S2SSession,
+        self, session: S2SSession,
     ) -> AsyncIterator[S2SResponseEvent]:
         """Yield response events from the S2S model.
 
@@ -271,7 +261,8 @@ class S2SSessionManager:
 
                 # Check for function calls in this response
                 func_calls = [
-                    item for item in output_items if getattr(item, "type", None) == "function_call"
+                    item for item in output_items
+                    if getattr(item, "type", None) == "function_call"
                 ]
 
                 if func_calls:
@@ -290,19 +281,15 @@ class S2SSessionManager:
 
                         # Dispatch the tool call (pass satellite for session scoping)
                         result = await self._bridge.handle_tool_call(
-                            name,
-                            args,
-                            satellite_id=session.satellite_id,
+                            name, args, satellite_id=session.satellite_id,
                         )
 
                         # Send result back to model
-                        await conn.conversation.item.create(
-                            item={
-                                "type": "function_call_output",
-                                "call_id": call_id,
-                                "output": result,
-                            }
-                        )
+                        await conn.conversation.item.create(item={
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": result,
+                        })
 
                     # Trigger the follow-up audio response
                     await conn.response.create()
@@ -329,6 +316,10 @@ class S2SSessionManager:
                     continue
 
                 logger.error("S2S error: %s", msg)
+                # Flush the partial turn (its audio was already streaming to
+                # the user) so it can't leak into the NEXT turn's record.
+                await self._record_turn(session, "assistant", session._turn_output)
+                session._turn_output = ""
                 yield S2SResponseEvent(type="error", text=msg)
                 break
 
@@ -343,15 +334,12 @@ class S2SSessionManager:
             return
         try:
             await self._transcript_writer.append_message(
-                session.session_id,
-                role,
-                text,
+                session.session_id, role, text,
             )
         except Exception:
             logger.warning(
                 "Failed to record voice turn for %s",
-                session.session_id,
-                exc_info=True,
+                session.session_id, exc_info=True,
             )
 
     async def close(self, satellite_id: str) -> tuple[str, str]:
@@ -361,6 +349,9 @@ class S2SSessionManager:
             return "", ""
 
         session._closed = True
+        # Flush any partial turn abandoned mid-stream (client disconnect).
+        await self._record_turn(session, "assistant", session._turn_output)
+        session._turn_output = ""
         transcripts = (session.input_transcript, session.output_transcript)
 
         if session.connection:
@@ -379,14 +370,12 @@ class S2SSessionManager:
             except Exception:
                 logger.warning(
                     "Failed to finalize voice transcript for %s",
-                    session.session_id,
-                    exc_info=True,
+                    session.session_id, exc_info=True,
                 )
 
         logger.info(
             "S2S session closed: %s (turns=%d)",
-            session.session_id,
-            session.turn_count,
+            session.session_id, session.turn_count,
         )
         return transcripts
 

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -39,7 +39,7 @@ from genesis.channels.voice.genesis_bridge import (
 )
 
 if TYPE_CHECKING:
-    from genesis.memory.store import MemoryStore
+    from genesis.channels.voice.transcript_writer import VoiceTranscriptWriter
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +68,7 @@ class S2SSession:
     _conn_mgr: object | None = field(default=None, repr=False)
     input_transcript: str = ""
     output_transcript: str = ""
+    _turn_output: str = ""  # current turn's assistant text (reset per turn)
     turn_count: int = 0
     _closed: bool = False
 
@@ -84,11 +85,11 @@ class S2SSessionManager:
         self,
         *,
         bridge: GenesisBridge,
-        memory_store: MemoryStore | None = None,
+        transcript_writer: VoiceTranscriptWriter | None = None,
         max_idle_seconds: int = 300,
     ) -> None:
         self._bridge = bridge
-        self._memory_store = memory_store
+        self._transcript_writer = transcript_writer
         self._max_idle_seconds = max_idle_seconds
         self._sessions: dict[str, S2SSession] = {}
         self._client: openai.AsyncOpenAI | None = None
@@ -97,8 +98,10 @@ class S2SSessionManager:
     async def start_reaper(self) -> None:
         """Start the idle session reaper (runs every 15s)."""
         from genesis.util.tasks import tracked_task
+
         self._reaper_task = tracked_task(
-            self._reap_loop(), name="s2s-session-reaper",
+            self._reap_loop(),
+            name="s2s-session-reaper",
         )
 
     async def _reap_loop(self) -> None:
@@ -107,7 +110,8 @@ class S2SSessionManager:
             await asyncio.sleep(15)
             now = datetime.now(UTC)
             stale = [
-                sat_id for sat_id, s in self._sessions.items()
+                sat_id
+                for sat_id, s in self._sessions.items()
                 if (now - s.last_activity).total_seconds() > self._max_idle_seconds
                 and not s._closed
             ]
@@ -149,11 +153,13 @@ class S2SSessionManager:
         # server VAD, 24kHz PCM. We use conversation.item.create for audio
         # input so VAD doesn't interfere with bulk utterances from Wyoming.
         system_prompt = self._bridge.get_system_prompt()
-        await conn.session.update(session={
-            "type": "realtime",
-            "instructions": system_prompt,
-            "tools": TOOL_DECLARATIONS,
-        })
+        await conn.session.update(
+            session={
+                "type": "realtime",
+                "instructions": system_prompt,
+                "tools": TOOL_DECLARATIONS,
+            }
+        )
 
         # Wait for session.updated confirmation (timeout: 10s)
         try:
@@ -173,7 +179,11 @@ class S2SSessionManager:
             raise RuntimeError("S2S session config timed out") from None
 
     async def send_turn(
-        self, session: S2SSession, audio: bytes, *, input_rate: int = 16000,
+        self,
+        session: S2SSession,
+        audio: bytes,
+        *,
+        input_rate: int = 16000,
     ) -> None:
         """Send a complete utterance as a conversation item and trigger a response.
 
@@ -187,16 +197,19 @@ class S2SSessionManager:
         # Resample 16kHz → 24kHz (Realtime API requires 24kHz PCM)
         if input_rate != 24000:
             from genesis.channels.voice.wyoming_tts import _resample_pcm
+
             audio = _resample_pcm(audio, input_rate, 24000)
 
         encoded = base64.b64encode(audio).decode()
 
         # Send as a conversation item (bypasses input_audio_buffer entirely)
-        await session.connection.conversation.item.create(item={
-            "type": "message",
-            "role": "user",
-            "content": [{"type": "input_audio", "audio": encoded}],
-        })
+        await session.connection.conversation.item.create(
+            item={
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_audio", "audio": encoded}],
+            }
+        )
 
         # Brief pause to let the model ingest the audio before we request
         # a response.  Without this, response.create() can fire before
@@ -211,7 +224,8 @@ class S2SSessionManager:
         await session.connection.response.create()
 
     async def receive_response(
-        self, session: S2SSession,
+        self,
+        session: S2SSession,
     ) -> AsyncIterator[S2SResponseEvent]:
         """Yield response events from the S2S model.
 
@@ -241,12 +255,14 @@ class S2SSessionManager:
             # Audio transcript (text of what the model is saying)
             elif etype == "response.output_audio_transcript.delta":
                 session.output_transcript += event.delta
+                session._turn_output += event.delta
                 yield S2SResponseEvent(type="transcript", text=event.delta)
 
             # Input transcript (what the user said — async via Whisper)
             elif etype == "conversation.item.input_audio_transcription.completed":
                 if hasattr(event, "transcript") and event.transcript:
                     session.input_transcript += event.transcript
+                    await self._record_turn(session, "user", event.transcript)
 
             # Response complete — check if it's a function call or final audio
             elif etype == "response.done":
@@ -255,8 +271,7 @@ class S2SSessionManager:
 
                 # Check for function calls in this response
                 func_calls = [
-                    item for item in output_items
-                    if getattr(item, "type", None) == "function_call"
+                    item for item in output_items if getattr(item, "type", None) == "function_call"
                 ]
 
                 if func_calls:
@@ -275,15 +290,19 @@ class S2SSessionManager:
 
                         # Dispatch the tool call (pass satellite for session scoping)
                         result = await self._bridge.handle_tool_call(
-                            name, args, satellite_id=session.satellite_id,
+                            name,
+                            args,
+                            satellite_id=session.satellite_id,
                         )
 
                         # Send result back to model
-                        await conn.conversation.item.create(item={
-                            "type": "function_call_output",
-                            "call_id": call_id,
-                            "output": result,
-                        })
+                        await conn.conversation.item.create(
+                            item={
+                                "type": "function_call_output",
+                                "call_id": call_id,
+                                "output": result,
+                            }
+                        )
 
                     # Trigger the follow-up audio response
                     await conn.response.create()
@@ -293,6 +312,8 @@ class S2SSessionManager:
                     session.turn_count += 1
                     session.last_activity = datetime.now(UTC)
                     session.output_transcript += "\n"
+                    await self._record_turn(session, "assistant", session._turn_output)
+                    session._turn_output = ""
                     yield S2SResponseEvent(type="done")
                     break
 
@@ -311,8 +332,30 @@ class S2SSessionManager:
                 yield S2SResponseEvent(type="error", text=msg)
                 break
 
+    async def _record_turn(self, session: S2SSession, role: str, text: str) -> None:
+        """Append one turn to the session's transcript (best-effort, durable).
+
+        Per-turn writes replace the legacy store-one-blob-at-close landing:
+        a crash loses nothing already spoken, and the extraction job mines
+        the transcript like any other channel's conversation.
+        """
+        if self._transcript_writer is None or not text.strip():
+            return
+        try:
+            await self._transcript_writer.append_message(
+                session.session_id,
+                role,
+                text,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to record voice turn for %s",
+                session.session_id,
+                exc_info=True,
+            )
+
     async def close(self, satellite_id: str) -> tuple[str, str]:
-        """Close a session, store transcripts, return (input, output)."""
+        """Close a session, finalize its transcript, return (input, output)."""
         session = self._sessions.pop(satellite_id, None)
         if not session:
             return "", ""
@@ -328,35 +371,22 @@ class S2SSessionManager:
             except Exception:
                 logger.exception("Error closing S2S session %s", session.session_id)
 
-        # Store conversation transcripts to episodic memory (best-effort)
-        if self._memory_store and (transcripts[0] or transcripts[1]):
+        # Mark the transcript session completed (turns were written as they
+        # happened via _record_turn — nothing is stored at close anymore).
+        if self._transcript_writer and (transcripts[0] or transcripts[1]):
             try:
-                content = (
-                    f"Voice conversation [{satellite_id}]:\n"
-                    f"User: {transcripts[0]}\n"
-                    f"Genesis: {transcripts[1]}"
-                )
-                await self._memory_store.store(
-                    content,
-                    source="voice_s2s",
-                    memory_type="episodic",
-                    tags=["voice", "s2s", "conversation"],
-                    wing="channels",
-                    room="voice",
-                )
-                logger.info(
-                    "Voice transcript stored for session %s (%d turns)",
-                    session.session_id, session.turn_count,
-                )
+                await self._transcript_writer.close_session(session.session_id)
             except Exception:
                 logger.warning(
-                    "Failed to store voice transcript for %s",
-                    session.session_id, exc_info=True,
+                    "Failed to finalize voice transcript for %s",
+                    session.session_id,
+                    exc_info=True,
                 )
 
         logger.info(
             "S2S session closed: %s (turns=%d)",
-            session.session_id, session.turn_count,
+            session.session_id,
+            session.turn_count,
         )
         return transcripts
 

--- a/src/genesis/channels/voice/transcript_writer.py
+++ b/src/genesis/channels/voice/transcript_writer.py
@@ -117,8 +117,18 @@ class VoiceTranscriptWriter:
         self._registered: set[str] = set()
 
     async def heal_orphans(self) -> int:
-        """Complete stale 'active' voice rows (boot-time self-heal)."""
-        healed = await sessions_crud.complete_orphaned_voice_sessions(self._db)
+        """Complete 'active' voice rows idle >1h (boot + daily self-heal).
+
+        The idle gate keeps a conversation that is live RIGHT NOW (writer
+        constructed lazily mid-uptime, or the daily hygiene tick) from having
+        its row flipped mid-call; appends refresh last_activity_at.
+        """
+        from datetime import timedelta
+
+        cutoff = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        healed = await sessions_crud.complete_orphaned_voice_sessions(
+            self._db, idle_before=cutoff,
+        )
         if healed:
             logger.info("Completed %d orphaned voice session row(s)", healed)
         return healed
@@ -135,6 +145,7 @@ class VoiceTranscriptWriter:
         sid = transcript_session_id(external_session_id)
         await self._ensure_registered(sid)
         self._append_lines(sid, [(role, text)])
+        await self._touch_activity(sid)
 
     async def sync_cumulative(
         self,
@@ -150,7 +161,6 @@ class VoiceTranscriptWriter:
         appended. Returns the number of messages appended.
         """
         sid = transcript_session_id(external_session_id)
-        await self._ensure_registered(sid)
 
         existing = self._line_count(sid)
         if len(turns) < existing:
@@ -166,7 +176,9 @@ class VoiceTranscriptWriter:
 
         new_turns = [(t["role"], t["text"]) for t in turns[existing:]]
         if new_turns:
+            await self._ensure_registered(sid)
             self._append_lines(sid, new_turns)
+            await self._touch_activity(sid)
         return len(new_turns)
 
     async def close_session(self, external_session_id: str) -> None:
@@ -187,6 +199,11 @@ class VoiceTranscriptWriter:
         )
         self._registered.add(sid)
 
+    async def _touch_activity(self, sid: str) -> None:
+        await sessions_crud.update_activity(
+            self._db, sid, last_activity_at=datetime.now(UTC).isoformat(),
+        )
+
     def _path(self, sid: str) -> Path:
         return self._dir / f"{sid}.jsonl"
 
@@ -194,12 +211,11 @@ class VoiceTranscriptWriter:
         path = self._path(sid)
         if not path.exists():
             return 0
-        try:
-            with open(path, encoding="utf-8") as f:
-                return sum(1 for _ in f)
-        except OSError:
-            logger.warning("Could not count transcript lines: %s", path, exc_info=True)
-            return 0
+        # An unreadable file must NOT read as "0 lines" — that would make
+        # the next cumulative sync re-append the whole conversation. Let the
+        # OSError propagate (route answers 500; the producer retries).
+        with open(path, encoding="utf-8") as f:
+            return sum(1 for _ in f)
 
     def _append_lines(self, sid: str, turns: list[tuple[str, str]]) -> None:
         """Append CC-transcript-format JSONL lines (the shape
@@ -218,8 +234,17 @@ class VoiceTranscriptWriter:
                     {"type": role, "message": message, "timestamp": now},
                 )
             )
-        try:
-            with open(self._path(sid), "a", encoding="utf-8") as f:
-                f.write("\n".join(lines) + "\n")
-        except OSError:
-            logger.error("Voice transcript append failed: %s", sid, exc_info=True)
+        # Durable-before-ack: an append failure must RAISE so the route
+        # answers 5xx and the producer retries — a swallowed OSError here
+        # would return 200 to a caller that then discards its turn cache.
+        path = self._path(sid)
+        prefix = ""
+        if path.exists() and path.stat().st_size > 0:
+            # Crash-guard: a torn final line without a trailing newline must
+            # not have the next message concatenated onto it.
+            with open(path, "rb") as f:
+                f.seek(-1, 2)
+                if f.read(1) != b"\n":
+                    prefix = "\n"
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(prefix + "\n".join(lines) + "\n")

--- a/src/genesis/channels/voice/transcript_writer.py
+++ b/src/genesis/channels/voice/transcript_writer.py
@@ -1,0 +1,225 @@
+"""Voice conversation transcript writer — the extraction-parity landing.
+
+S2S voice conversations used to land in episodic memory as one growing blob
+per session close, bypassing the extraction pipeline every other channel goes
+through. This writer replaces that landing: each conversation becomes a
+per-session JSONL transcript in ``voice_transcript_dir()`` (CC-transcript
+format, the exact shape ``genesis.util.jsonl.read_transcript_messages``
+parses) plus a ``cc_sessions`` row (``source_tag='voice'``), so the memory
+extraction job mines voice conversations incrementally by watermark — facts,
+references and topics instead of raw dumps.
+
+Two producers share this component:
+- the core ``S2SSessionManager`` (per-turn ``append_message`` calls), and
+- the ``POST /v1/voice/conversation`` route, targeted by the edge s2s bridge
+  (``sync_cumulative`` with the bridge's full cached turn list).
+
+Idempotency: session ids are deterministic (uuid5 of the external session
+id) and ``sync_cumulative`` appends only turns beyond the file's current
+line count — replays, double-fires and cumulative re-sends land exactly
+once. All methods MUST be called on the runtime event loop (single-writer;
+no file locking needed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+
+from genesis.db.crud import cc_sessions as sessions_crud
+from genesis.env import voice_transcript_dir
+
+logger = logging.getLogger(__name__)
+
+# Deterministic namespace for external-session-id → transcript-session-id.
+_VOICE_SESSION_NS = uuid.uuid5(uuid.NAMESPACE_URL, "genesis://voice/transcripts")
+
+_ROLES = ("user", "assistant")
+_MAX_SESSION_ID_LEN = 128
+_MAX_TURNS = 5000
+
+
+def validate_conversation(data: dict) -> list[str]:
+    """Validate a /v1/voice/conversation body. Returns error strings ([] = valid)."""
+    errors: list[str] = []
+
+    session_id = data.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        errors.append("session_id: required non-empty string")
+    elif len(session_id) > _MAX_SESSION_ID_LEN:
+        errors.append(f"session_id: exceeds {_MAX_SESSION_ID_LEN} chars")
+
+    satellite_id = data.get("satellite_id")
+    if satellite_id is not None and not isinstance(satellite_id, str):
+        errors.append("satellite_id: must be a string when present")
+
+    turns = data.get("turns")
+    if not isinstance(turns, list):
+        errors.append("turns: required list")
+        return errors
+    if len(turns) > _MAX_TURNS:
+        errors.append(f"turns: exceeds {_MAX_TURNS} entries")
+        return errors
+    for i, turn in enumerate(turns):
+        if not isinstance(turn, dict):
+            errors.append(f"turns[{i}]: must be an object")
+            continue
+        if turn.get("role") not in _ROLES:
+            errors.append(f"turns[{i}].role: must be one of {_ROLES}")
+        text = turn.get("text")
+        if not isinstance(text, str) or not text.strip():
+            errors.append(f"turns[{i}].text: required non-empty string")
+
+    return errors
+
+
+def transcript_session_id(external_session_id: str) -> str:
+    """Deterministic transcript/cc_sessions id for an external session id."""
+    return str(uuid.uuid5(_VOICE_SESSION_NS, external_session_id))
+
+
+_shared_writer: VoiceTranscriptWriter | None = None
+
+
+async def get_shared_writer(db: aiosqlite.Connection) -> VoiceTranscriptWriter:
+    """Process-wide writer for the runtime DB (route + S2S manager share it).
+
+    Lazy so the ``/v1/voice/conversation`` route works even on installs where
+    the core S2S pipeline never initializes (the edge bridge posts over HTTP
+    regardless). Heals orphaned 'active' voice rows on first construction;
+    the daily voice hygiene job repeats the heal, so a boot with no voice
+    activity still converges. Must be called on the runtime event loop.
+    """
+    global _shared_writer
+    if _shared_writer is None or _shared_writer._db is not db:
+        writer = VoiceTranscriptWriter(db)
+        await writer.heal_orphans()
+        _shared_writer = writer
+    return _shared_writer
+
+
+class VoiceTranscriptWriter:
+    """Writes voice conversations as extractable CC-format transcripts."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        *,
+        transcript_dir: Path | None = None,
+    ) -> None:
+        self._db = db
+        self._dir = transcript_dir or voice_transcript_dir()
+        self._registered: set[str] = set()
+
+    async def heal_orphans(self) -> int:
+        """Complete stale 'active' voice rows (boot-time self-heal)."""
+        healed = await sessions_crud.complete_orphaned_voice_sessions(self._db)
+        if healed:
+            logger.info("Completed %d orphaned voice session row(s)", healed)
+        return healed
+
+    async def append_message(
+        self,
+        external_session_id: str,
+        role: str,
+        text: str,
+    ) -> None:
+        """Append one message to a session's transcript (core per-turn path)."""
+        if role not in _ROLES or not text.strip():
+            return
+        sid = transcript_session_id(external_session_id)
+        await self._ensure_registered(sid)
+        self._append_lines(sid, [(role, text)])
+
+    async def sync_cumulative(
+        self,
+        external_session_id: str,
+        turns: list[dict],
+    ) -> int:
+        """Reconcile a full cumulative turn list against the transcript.
+
+        Appends only turns beyond the file's current message count, making
+        replays and double-fires idempotent. A list SHORTER than the file
+        violates the producer contract (the caller must regenerate its
+        session id whenever its turn cache resets) — logged loudly, nothing
+        appended. Returns the number of messages appended.
+        """
+        sid = transcript_session_id(external_session_id)
+        await self._ensure_registered(sid)
+
+        existing = self._line_count(sid)
+        if len(turns) < existing:
+            logger.warning(
+                "Voice cumulative sync for %s sent %d turns but transcript "
+                "already has %d — producer turn cache reset without a new "
+                "session id; appending nothing",
+                external_session_id[:32],
+                len(turns),
+                existing,
+            )
+            return 0
+
+        new_turns = [(t["role"], t["text"]) for t in turns[existing:]]
+        if new_turns:
+            self._append_lines(sid, new_turns)
+        return len(new_turns)
+
+    async def close_session(self, external_session_id: str) -> None:
+        """Mark a session's row completed (transcript stays for extraction)."""
+        sid = transcript_session_id(external_session_id)
+        await sessions_crud.update_status(self._db, sid, status="completed")
+
+    # ── internals ────────────────────────────────────────────────────
+
+    async def _ensure_registered(self, sid: str) -> None:
+        if sid in self._registered:
+            return
+        now = datetime.now(UTC).isoformat()
+        await sessions_crud.register_voice_session(
+            self._db,
+            id=sid,
+            started_at=now,
+        )
+        self._registered.add(sid)
+
+    def _path(self, sid: str) -> Path:
+        return self._dir / f"{sid}.jsonl"
+
+    def _line_count(self, sid: str) -> int:
+        path = self._path(sid)
+        if not path.exists():
+            return 0
+        try:
+            with open(path, encoding="utf-8") as f:
+                return sum(1 for _ in f)
+        except OSError:
+            logger.warning("Could not count transcript lines: %s", path, exc_info=True)
+            return 0
+
+    def _append_lines(self, sid: str, turns: list[tuple[str, str]]) -> None:
+        """Append CC-transcript-format JSONL lines (the shape
+        ``read_transcript_messages`` parses: user content is a plain string,
+        assistant content is a list of text blocks)."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(UTC).isoformat()
+        lines = []
+        for role, text in turns:
+            if role == "user":
+                message: dict = {"content": text}
+            else:
+                message = {"content": [{"type": "text", "text": text}]}
+            lines.append(
+                json.dumps(
+                    {"type": role, "message": message, "timestamp": now},
+                )
+            )
+        try:
+            with open(self._path(sid), "a", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+        except OSError:
+            logger.error("Voice transcript append failed: %s", sid, exc_info=True)

--- a/src/genesis/dashboard/routes/voice_api.py
+++ b/src/genesis/dashboard/routes/voice_api.py
@@ -26,6 +26,7 @@ from datetime import UTC, datetime
 from flask import Blueprint, current_app, jsonify, request
 
 from genesis.channels.voice.graduation import validate_envelope
+from genesis.channels.voice.transcript_writer import validate_conversation
 
 logger = logging.getLogger("genesis.dashboard.voice_api")
 
@@ -78,20 +79,25 @@ def voice_chat_completions():
     event_loop = current_app.config.get("GENESIS_EVENT_LOOP")
 
     if voice_handler is None:
-        return jsonify({
-            "error": {"message": "Voice handler not initialized", "type": "server_error"},
-        }), 503
+        return jsonify(
+            {
+                "error": {"message": "Voice handler not initialized", "type": "server_error"},
+            }
+        ), 503
 
     if event_loop is None or not event_loop.is_running():
-        return jsonify({
-            "error": {"message": "Event loop not available", "type": "server_error"},
-        }), 503
+        return jsonify(
+            {
+                "error": {"message": "Event loop not available", "type": "server_error"},
+            }
+        ), 503
 
     # S2S short-circuit: if the S2S model already handled this request
     # (audio response queued on Wyoming TTS server), return the transcript
     # as-is without making another LLM call.  HA's pipeline still requires
     # a conversation agent response — we give it one, but cheaply.
     from genesis.channels.voice import config as voice_config
+
     if voice_config.s2s_enabled():
         data = request.get_json(force=True, silent=True) or {}
         messages = data.get("messages", [])
@@ -105,16 +111,20 @@ def voice_chat_completions():
         # text — HA will send it to Wyoming TTS, which will serve the S2S
         # audio instead of synthesizing from this text.
         logger.info("S2S mode: passing through transcript (%d chars)", len(transcript))
-        return jsonify({
-            "id": "chatcmpl-s2s-passthrough",
-            "object": "chat.completion",
-            "model": "genesis-voice-s2s",
-            "choices": [{
-                "index": 0,
-                "message": {"role": "assistant", "content": transcript or "..."},
-                "finish_reason": "stop",
-            }],
-        })
+        return jsonify(
+            {
+                "id": "chatcmpl-s2s-passthrough",
+                "object": "chat.completion",
+                "model": "genesis-voice-s2s",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": transcript or "..."},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        )
 
     # Parse request
     data = request.get_json(force=True, silent=True) or {}
@@ -128,9 +138,11 @@ def voice_chat_completions():
             break
 
     if not transcript:
-        return jsonify({
-            "error": {"message": "No user message in request", "type": "invalid_request_error"},
-        }), 400
+        return jsonify(
+            {
+                "error": {"message": "No user message in request", "type": "invalid_request_error"},
+            }
+        ), 400
 
     # Cap transcript length — voice transcripts are typically 1-100 words
     _MAX_TRANSCRIPT_CHARS = 2000
@@ -155,42 +167,50 @@ def voice_chat_completions():
         elapsed = time.monotonic() - start
         logger.error(
             "Voice handler timed out after %.1fs for session %s",
-            elapsed, session_id[:12],
+            elapsed,
+            session_id[:12],
         )
         response_text = "I'm taking too long to respond. Try a simpler question."
     except Exception:
         logger.error(
             "Voice handler failed for session %s",
-            session_id[:12], exc_info=True,
+            session_id[:12],
+            exc_info=True,
         )
         response_text = "Something went wrong. Try again."
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
     logger.info(
         "Voice response: %dms, %d chars, session=%s",
-        elapsed_ms, len(response_text), session_id[:12],
+        elapsed_ms,
+        len(response_text),
+        session_id[:12],
     )
 
     # Return OpenAI-compatible response
-    return jsonify({
-        "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
-        "object": "chat.completion",
-        "created": int(time.time()),
-        "model": "genesis-voice",
-        "choices": [{
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": response_text,
+    return jsonify(
+        {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": "genesis-voice",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": response_text,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
             },
-            "finish_reason": "stop",
-        }],
-        "usage": {
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "total_tokens": 0,
-        },
-    })
+        }
+    )
 
 
 # ── S2S Bridge Tool Dispatch ────────────────────────────────────────
@@ -294,6 +314,7 @@ def voice_tool_declarations():
         return jsonify({"error": msg}), status
 
     from genesis.channels.voice.genesis_bridge import TOOL_DECLARATIONS
+
     return jsonify({"tools": TOOL_DECLARATIONS})
 
 
@@ -366,15 +387,11 @@ def voice_graduate():
     # request has no header and would bypass a content_length check; get_json
     # below reuses this cached read.
     if len(request.get_data(cache=True)) > _MAX_GRADUATE_BYTES:
-        return jsonify(
-            {"status": "rejected", "errors": ["envelope exceeds 64KB"]}
-        ), 400
+        return jsonify({"status": "rejected", "errors": ["envelope exceeds 64KB"]}), 400
 
     data = request.get_json(force=True, silent=True)
     if not isinstance(data, dict):
-        return jsonify(
-            {"status": "rejected", "errors": ["body must be a JSON object"]}
-        ), 400
+        return jsonify({"status": "rejected", "errors": ["body must be a JSON object"]}), 400
     errors = validate_envelope(data)
     if errors:
         return jsonify({"status": "rejected", "errors": errors}), 400
@@ -383,23 +400,23 @@ def voice_graduate():
     if event_loop is None or not event_loop.is_running():
         return jsonify({"error": "Event loop not available"}), 503
 
-    future = asyncio.run_coroutine_threadsafe(
-        _land_graduation_event(data), event_loop
-    )
+    future = asyncio.run_coroutine_threadsafe(_land_graduation_event(data), event_loop)
     try:
         inserted = future.result(timeout=_GRADUATE_TIMEOUT_SECONDS)
     except TimeoutError:
         future.cancel()
         logger.error(
             "Voice graduate timed out after %.0fs for event %s",
-            _GRADUATE_TIMEOUT_SECONDS, data["event_id"][:16],
+            _GRADUATE_TIMEOUT_SECONDS,
+            data["event_id"][:16],
         )
         return jsonify({"error": "graduate landing timed out"}), 503
     except LookupError:
         return jsonify({"error": "Genesis runtime not ready"}), 503
     except Exception:
         logger.error(
-            "Voice graduate failed for event %s", data["event_id"][:16],
+            "Voice graduate failed for event %s",
+            data["event_id"][:16],
             exc_info=True,
         )
         return jsonify({"error": "graduate landing failed"}), 500
@@ -407,6 +424,108 @@ def voice_graduate():
     status = "accepted" if inserted else "duplicate"
     logger.info(
         "Voice graduate: %s event %s from %s",
-        status, data["event_id"][:16], data["source"][:32],
+        status,
+        data["event_id"][:16],
+        data["source"][:32],
     )
     return jsonify({"status": status})
+
+
+# ── Conversation transcript landing (W0.5 — s2s extraction parity) ──
+# The edge s2s bridge posts its FULL cumulative turn list here on client
+# disconnect (and may re-post on replays/double-fires). The transcript writer
+# appends only new turns to a per-session CC-format JSONL that the memory
+# extraction job mines like any other channel — replacing the legacy
+# "one-blob memory_store" landing entirely.
+
+# 10s: a bounded file append + at most two SQLite writes — the same bound
+# class as /v1/voice/graduate (busy_timeout=5000 + loop scheduling headroom).
+# Fast-fail is safe: the edge re-posts its cumulative list, and the
+# line-count reconciliation makes any replay idempotent.
+_CONVERSATION_TIMEOUT_SECONDS = 10.0
+
+# Cumulative turn lists are bigger than graduation envelopes (largest blob
+# observed in the wild: ~25KB after weeks of accumulation) — 256KB is ~10x
+# headroom while still refusing pathological bodies.
+_MAX_CONVERSATION_BYTES = 256 * 1024
+
+
+async def _land_conversation(data: dict) -> int:
+    """Reconcile the cumulative turn list (runs on the runtime loop).
+
+    Returns the number of newly appended messages. Raises LookupError when
+    the runtime/DB isn't ready — mapped to 503 so the edge retries.
+    """
+    from genesis.channels.voice.transcript_writer import get_shared_writer
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        raise LookupError("Genesis runtime not ready")
+
+    writer = await get_shared_writer(rt.db)
+    return await writer.sync_cumulative(data["session_id"], data["turns"])
+
+
+@voice_api_bp.route("/v1/voice/conversation", methods=["POST"])
+def voice_conversation():
+    """Land a voice conversation's cumulative turn list from the edge bridge.
+
+    Body: ``{"session_id": str, "satellite_id": str?, "turns": [{"role":
+    "user"|"assistant", "text": str}, ...]}`` where ``turns`` is the full
+    cumulative list for the session. Contract: the producer must regenerate
+    ``session_id`` whenever its turn cache resets (a shorter-than-known list
+    appends nothing and logs a warning server-side).
+
+    Responses: 200 ``{"status": "ok", "appended": N}`` after the transcript
+    append is durable; 400 ``{"status": "rejected", "errors": [...]}`` on
+    validation failure; 503 while the runtime is not ready (edge retries).
+    """
+    auth = _check_voice_token()
+    if auth is not None:
+        msg, status = auth
+        return jsonify({"error": msg}), status
+
+    # Measure the actual body, not the Content-Length header (chunked-safe);
+    # get_json below reuses this cached read.
+    if len(request.get_data(cache=True)) > _MAX_CONVERSATION_BYTES:
+        return jsonify({"status": "rejected", "errors": ["body exceeds 256KB"]}), 400
+
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"status": "rejected", "errors": ["body must be a JSON object"]}), 400
+    errors = validate_conversation(data)
+    if errors:
+        return jsonify({"status": "rejected", "errors": errors}), 400
+
+    event_loop = current_app.config.get("GENESIS_EVENT_LOOP")
+    if event_loop is None or not event_loop.is_running():
+        return jsonify({"error": "Event loop not available"}), 503
+
+    future = asyncio.run_coroutine_threadsafe(_land_conversation(data), event_loop)
+    try:
+        appended = future.result(timeout=_CONVERSATION_TIMEOUT_SECONDS)
+    except TimeoutError:
+        future.cancel()
+        logger.error(
+            "Voice conversation landing timed out after %.0fs for session %s",
+            _CONVERSATION_TIMEOUT_SECONDS,
+            data["session_id"][:32],
+        )
+        return jsonify({"error": "conversation landing timed out"}), 503
+    except LookupError:
+        return jsonify({"error": "Genesis runtime not ready"}), 503
+    except Exception:
+        logger.error(
+            "Voice conversation landing failed for session %s",
+            data["session_id"][:32],
+            exc_info=True,
+        )
+        return jsonify({"error": "conversation landing failed"}), 500
+
+    logger.info(
+        "Voice conversation: %d message(s) appended for session %s",
+        appended,
+        data["session_id"][:32],
+    )
+    return jsonify({"status": "ok", "appended": appended})

--- a/src/genesis/dashboard/routes/voice_api.py
+++ b/src/genesis/dashboard/routes/voice_api.py
@@ -79,25 +79,20 @@ def voice_chat_completions():
     event_loop = current_app.config.get("GENESIS_EVENT_LOOP")
 
     if voice_handler is None:
-        return jsonify(
-            {
-                "error": {"message": "Voice handler not initialized", "type": "server_error"},
-            }
-        ), 503
+        return jsonify({
+            "error": {"message": "Voice handler not initialized", "type": "server_error"},
+        }), 503
 
     if event_loop is None or not event_loop.is_running():
-        return jsonify(
-            {
-                "error": {"message": "Event loop not available", "type": "server_error"},
-            }
-        ), 503
+        return jsonify({
+            "error": {"message": "Event loop not available", "type": "server_error"},
+        }), 503
 
     # S2S short-circuit: if the S2S model already handled this request
     # (audio response queued on Wyoming TTS server), return the transcript
     # as-is without making another LLM call.  HA's pipeline still requires
     # a conversation agent response — we give it one, but cheaply.
     from genesis.channels.voice import config as voice_config
-
     if voice_config.s2s_enabled():
         data = request.get_json(force=True, silent=True) or {}
         messages = data.get("messages", [])
@@ -111,20 +106,16 @@ def voice_chat_completions():
         # text — HA will send it to Wyoming TTS, which will serve the S2S
         # audio instead of synthesizing from this text.
         logger.info("S2S mode: passing through transcript (%d chars)", len(transcript))
-        return jsonify(
-            {
-                "id": "chatcmpl-s2s-passthrough",
-                "object": "chat.completion",
-                "model": "genesis-voice-s2s",
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {"role": "assistant", "content": transcript or "..."},
-                        "finish_reason": "stop",
-                    }
-                ],
-            }
-        )
+        return jsonify({
+            "id": "chatcmpl-s2s-passthrough",
+            "object": "chat.completion",
+            "model": "genesis-voice-s2s",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": transcript or "..."},
+                "finish_reason": "stop",
+            }],
+        })
 
     # Parse request
     data = request.get_json(force=True, silent=True) or {}
@@ -138,11 +129,9 @@ def voice_chat_completions():
             break
 
     if not transcript:
-        return jsonify(
-            {
-                "error": {"message": "No user message in request", "type": "invalid_request_error"},
-            }
-        ), 400
+        return jsonify({
+            "error": {"message": "No user message in request", "type": "invalid_request_error"},
+        }), 400
 
     # Cap transcript length — voice transcripts are typically 1-100 words
     _MAX_TRANSCRIPT_CHARS = 2000
@@ -167,50 +156,42 @@ def voice_chat_completions():
         elapsed = time.monotonic() - start
         logger.error(
             "Voice handler timed out after %.1fs for session %s",
-            elapsed,
-            session_id[:12],
+            elapsed, session_id[:12],
         )
         response_text = "I'm taking too long to respond. Try a simpler question."
     except Exception:
         logger.error(
             "Voice handler failed for session %s",
-            session_id[:12],
-            exc_info=True,
+            session_id[:12], exc_info=True,
         )
         response_text = "Something went wrong. Try again."
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
     logger.info(
         "Voice response: %dms, %d chars, session=%s",
-        elapsed_ms,
-        len(response_text),
-        session_id[:12],
+        elapsed_ms, len(response_text), session_id[:12],
     )
 
     # Return OpenAI-compatible response
-    return jsonify(
-        {
-            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
-            "object": "chat.completion",
-            "created": int(time.time()),
-            "model": "genesis-voice",
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": response_text,
-                    },
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {
-                "prompt_tokens": 0,
-                "completion_tokens": 0,
-                "total_tokens": 0,
+    return jsonify({
+        "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "genesis-voice",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": response_text,
             },
-        }
-    )
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    })
 
 
 # ── S2S Bridge Tool Dispatch ────────────────────────────────────────
@@ -314,7 +295,6 @@ def voice_tool_declarations():
         return jsonify({"error": msg}), status
 
     from genesis.channels.voice.genesis_bridge import TOOL_DECLARATIONS
-
     return jsonify({"tools": TOOL_DECLARATIONS})
 
 
@@ -387,11 +367,15 @@ def voice_graduate():
     # request has no header and would bypass a content_length check; get_json
     # below reuses this cached read.
     if len(request.get_data(cache=True)) > _MAX_GRADUATE_BYTES:
-        return jsonify({"status": "rejected", "errors": ["envelope exceeds 64KB"]}), 400
+        return jsonify(
+            {"status": "rejected", "errors": ["envelope exceeds 64KB"]}
+        ), 400
 
     data = request.get_json(force=True, silent=True)
     if not isinstance(data, dict):
-        return jsonify({"status": "rejected", "errors": ["body must be a JSON object"]}), 400
+        return jsonify(
+            {"status": "rejected", "errors": ["body must be a JSON object"]}
+        ), 400
     errors = validate_envelope(data)
     if errors:
         return jsonify({"status": "rejected", "errors": errors}), 400
@@ -400,23 +384,23 @@ def voice_graduate():
     if event_loop is None or not event_loop.is_running():
         return jsonify({"error": "Event loop not available"}), 503
 
-    future = asyncio.run_coroutine_threadsafe(_land_graduation_event(data), event_loop)
+    future = asyncio.run_coroutine_threadsafe(
+        _land_graduation_event(data), event_loop
+    )
     try:
         inserted = future.result(timeout=_GRADUATE_TIMEOUT_SECONDS)
     except TimeoutError:
         future.cancel()
         logger.error(
             "Voice graduate timed out after %.0fs for event %s",
-            _GRADUATE_TIMEOUT_SECONDS,
-            data["event_id"][:16],
+            _GRADUATE_TIMEOUT_SECONDS, data["event_id"][:16],
         )
         return jsonify({"error": "graduate landing timed out"}), 503
     except LookupError:
         return jsonify({"error": "Genesis runtime not ready"}), 503
     except Exception:
         logger.error(
-            "Voice graduate failed for event %s",
-            data["event_id"][:16],
+            "Voice graduate failed for event %s", data["event_id"][:16],
             exc_info=True,
         )
         return jsonify({"error": "graduate landing failed"}), 500
@@ -424,9 +408,7 @@ def voice_graduate():
     status = "accepted" if inserted else "duplicate"
     logger.info(
         "Voice graduate: %s event %s from %s",
-        status,
-        data["event_id"][:16],
-        data["source"][:32],
+        status, data["event_id"][:16], data["source"][:32],
     )
     return jsonify({"status": status})
 

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -389,6 +389,53 @@ async def register_from_filesystem(
     return cursor.rowcount > 0
 
 
+async def register_voice_session(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    started_at: str,
+    channel: str = "voice_s2s",
+) -> bool:
+    """Register a voice conversation session for memory extraction.
+
+    Voice sessions are not CC invocations: they carry ``source_tag='voice'``
+    so extraction picks them up while the CC-budget counter and ego
+    capability aggregator exclude them. ``session_type='foreground'`` is the
+    closest CHECK-constraint member (user-facing conversation).
+
+    INSERT OR IGNORE + deterministic ids (uuid5 of the external session id)
+    make re-registration idempotent across restarts and replays.
+    Returns True if a new row was inserted.
+    """
+    cursor = await db.execute(
+        "INSERT OR IGNORE INTO cc_sessions "
+        "(id, cc_session_id, session_type, channel, model, source_tag, "
+        " status, started_at, last_activity_at) "
+        "VALUES (?, ?, 'foreground', ?, 'voice', 'voice', "
+        " 'active', ?, ?)",
+        (id, id, channel, started_at, started_at),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def complete_orphaned_voice_sessions(db: aiosqlite.Connection) -> int:
+    """Mark stale ``active`` voice sessions as completed.
+
+    Voice sessions never survive a server restart, but the foreground
+    session_type exempts them from ``cleanup_stale`` — without this, a crash
+    between conversation start and close leaves an ``active`` row forever.
+    Called on transcript-writer construction (boot); keyed on observable
+    state, so it is safe to run any time.
+    """
+    cursor = await db.execute(
+        "UPDATE cc_sessions SET status = 'completed' "
+        "WHERE source_tag = 'voice' AND status = 'active'",
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def get_extractable(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -419,18 +419,23 @@ async def register_voice_session(
     return cursor.rowcount > 0
 
 
-async def complete_orphaned_voice_sessions(db: aiosqlite.Connection) -> int:
-    """Mark stale ``active`` voice sessions as completed.
+async def complete_orphaned_voice_sessions(
+    db: aiosqlite.Connection, *, idle_before: str,
+) -> int:
+    """Mark ``active`` voice sessions idle since before ``idle_before`` completed.
 
     Voice sessions never survive a server restart, but the foreground
     session_type exempts them from ``cleanup_stale`` — without this, a crash
     between conversation start and close leaves an ``active`` row forever.
-    Called on transcript-writer construction (boot); keyed on observable
-    state, so it is safe to run any time.
+    The idle gate (appends refresh last_activity_at) protects a conversation
+    that is live at heal time, so this is safe at boot AND from the daily
+    hygiene job.
     """
     cursor = await db.execute(
         "UPDATE cc_sessions SET status = 'completed' "
-        "WHERE source_tag = 'voice' AND status = 'active'",
+        "WHERE source_tag = 'voice' AND status = 'active' "
+        "  AND last_activity_at < ?",
+        (idle_before,),
     )
     await db.commit()
     return cursor.rowcount

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -32,7 +32,6 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
     # events, not user decisions on proposal quality.
     try:
         from genesis.db.crud import intervention_journal as journal_crud
-
         aggs = await journal_crud.aggregate_by_type(db)
         for row in aggs:
             domain = row["action_type"]
@@ -138,7 +137,9 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
         cfg = load_ego_config()
         # Default OFF: enable ONLY on an explicit True (a YAML null / missing key
         # / falsey value all keep it off, so it can't be silently enabled).
-        outcome_bus_enabled = getattr(cfg, "outcome_bus_capability_feed", False) is True
+        outcome_bus_enabled = (
+            getattr(cfg, "outcome_bus_capability_feed", False) is True
+        )
     except Exception:
         logger.debug("Capability aggregation: ego config unreadable; outcome bus OFF")
 
@@ -146,7 +147,9 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
         try:
             from genesis.db.crud import outcome_events as oe_crud
 
-            rows = await oe_crud.aggregate_by_domain(db, tier=1, source="surplus", days=30)
+            rows = await oe_crud.aggregate_by_domain(
+                db, tier=1, source="surplus", days=30
+            )
             for row in rows:
                 n = row.get("n") or 0
                 # Noise gate — mirrors cc_sessions' HAVING total >= 3.
@@ -228,7 +231,9 @@ class _DomainAccumulator:
         field_scores = {source: rate for source, rate, _ in self.signals}
         # Arithmetic mean as fallback if rates are out-of-range (shouldn't
         # happen, but DB values could be corrupted)
-        arithmetic_mean = round(sum(rate * n for _, rate, n in self.signals) / total_weight, 3)
+        arithmetic_mean = round(
+            sum(rate * n for _, rate, n in self.signals) / total_weight, 3
+        )
         try:
             confidence = round(inverse_confidence_weight(field_scores), 3)
         except ValueError:

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -32,6 +32,7 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
     # events, not user decisions on proposal quality.
     try:
         from genesis.db.crud import intervention_journal as journal_crud
+
         aggs = await journal_crud.aggregate_by_type(db)
         for row in aggs:
             domain = row["action_type"]
@@ -101,7 +102,9 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
     except Exception:
         logger.debug("Capability aggregation: procedural_memory unavailable")
 
-    # 5. CC sessions — completion rate by source_tag (30d)
+    # 5. CC sessions — completion rate by source_tag (30d). 'voice' rows are
+    # conversation transcript indexes, not CC work sessions — including them
+    # would fabricate an always-100%-complete "voice" capability domain.
     try:
         cur = await db.execute(
             """SELECT source_tag,
@@ -109,7 +112,7 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
                       SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed
                FROM cc_sessions
                WHERE started_at >= datetime('now', '-30 days')
-                 AND source_tag != 'foreground'
+                 AND source_tag NOT IN ('foreground', 'voice')
                GROUP BY source_tag
                HAVING total >= 3"""
         )
@@ -135,9 +138,7 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
         cfg = load_ego_config()
         # Default OFF: enable ONLY on an explicit True (a YAML null / missing key
         # / falsey value all keep it off, so it can't be silently enabled).
-        outcome_bus_enabled = (
-            getattr(cfg, "outcome_bus_capability_feed", False) is True
-        )
+        outcome_bus_enabled = getattr(cfg, "outcome_bus_capability_feed", False) is True
     except Exception:
         logger.debug("Capability aggregation: ego config unreadable; outcome bus OFF")
 
@@ -145,9 +146,7 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
         try:
             from genesis.db.crud import outcome_events as oe_crud
 
-            rows = await oe_crud.aggregate_by_domain(
-                db, tier=1, source="surplus", days=30
-            )
+            rows = await oe_crud.aggregate_by_domain(db, tier=1, source="surplus", days=30)
             for row in rows:
                 n = row.get("n") or 0
                 # Noise gate — mirrors cc_sessions' HAVING total >= 3.
@@ -229,9 +228,7 @@ class _DomainAccumulator:
         field_scores = {source: rate for source, rate, _ in self.signals}
         # Arithmetic mean as fallback if rates are out-of-range (shouldn't
         # happen, but DB values could be corrupted)
-        arithmetic_mean = round(
-            sum(rate * n for _, rate, n in self.signals) / total_weight, 3
-        )
+        arithmetic_mean = round(sum(rate * n for _, rate, n in self.signals) / total_weight, 3)
         try:
             confidence = round(inverse_confidence_weight(field_scores), 3)
         except ValueError:

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -254,6 +254,18 @@ def output_dir() -> Path:
     return Path(value).expanduser() if value else genesis_home() / "output"
 
 
+def voice_transcript_dir() -> Path:
+    """Voice conversation transcripts (~/.genesis/voice-transcripts).
+
+    Per-session CC-format JSONL written by the voice transcript writer and
+    read incrementally by the memory extraction job. Deliberately outside
+    both the repo tree and Claude Code's projects directory (so the CC
+    resume picker never lists voice sessions).
+    """
+    value = os.environ.get("GENESIS_VOICE_TRANSCRIPT_DIR")
+    return Path(value).expanduser() if value else genesis_home() / "voice-transcripts"
+
+
 def cc_project_dir() -> str:
     """Claude Code project directory name, derived from repo root path.
 

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -108,9 +108,7 @@ class StandaloneAdapter:
         )
         flask_thread.start()
         logger.info(
-            "Dashboard at http://%s:%d/genesis",
-            self._host,
-            self._port,
+            "Dashboard at http://%s:%d/genesis", self._host, self._port,
         )
 
         # Telegram if configured
@@ -124,21 +122,16 @@ class StandaloneAdapter:
             while not self._shutdown_event.is_set():
                 # Update status_writer so dashboard health panel has fresh data
                 if self._runtime and self._runtime.status_writer:
-                    self._runtime.status_writer.set_extra_data(
-                        "standalone",
-                        {
-                            "flask_running": self._app is not None,
-                            "telegram_active": self._telegram_adapter is not None,
-                            "uptime_h": round(
-                                (time.monotonic() - start_time) / 3600,
-                                2,
-                            ),
-                        },
-                    )
+                    self._runtime.status_writer.set_extra_data("standalone", {
+                        "flask_running": self._app is not None,
+                        "telegram_active": self._telegram_adapter is not None,
+                        "uptime_h": round(
+                            (time.monotonic() - start_time) / 3600, 2,
+                        ),
+                    })
                 try:
                     await asyncio.wait_for(
-                        self._shutdown_event.wait(),
-                        timeout=1800,
+                        self._shutdown_event.wait(), timeout=1800,
                     )
                     break
                 except TimeoutError:
@@ -289,8 +282,7 @@ class StandaloneAdapter:
             ha_token = os.environ.get("HA_LONG_LIVED_TOKEN", "")
             if ha_url and ha_token:
                 voice_adapter = VoiceChannelAdapter(
-                    ha_url=ha_url,
-                    ha_token=ha_token,
+                    ha_url=ha_url, ha_token=ha_token,
                 )
                 self._app.config["VOICE_ADAPTER"] = voice_adapter
                 logger.info("Voice adapter initialized (outbound TTS via HA)")
@@ -312,7 +304,8 @@ class StandaloneAdapter:
 
         if not voice_config.s2s_enabled():
             logger.info(
-                "S2S voice disabled — no API key for provider '%s'. Wyoming servers not started.",
+                "S2S voice disabled — no API key for provider '%s'. "
+                "Wyoming servers not started.",
                 voice_config.s2s_provider(),
             )
             return
@@ -327,7 +320,10 @@ class StandaloneAdapter:
             # Genesis bridge for tool calls — delegates ask_genesis to
             # the existing VoiceConversationHandler (no DRY violation)
             voice_handler = self._app.config.get("VOICE_HANDLER") if self._app else None
-            approval_gate = self._runtime.autonomous_cli_approval_gate if self._runtime else None
+            approval_gate = (
+                self._runtime.autonomous_cli_approval_gate
+                if self._runtime else None
+            )
             bridge = GenesisBridge(
                 voice_handler=voice_handler,
                 approval_gate=approval_gate,
@@ -591,8 +587,7 @@ class StandaloneAdapter:
 
             tts_provider = None
             tts_enabled = os.environ.get(
-                "TTS_ENABLED",
-                "true",
+                "TTS_ENABLED", "true",
             ).lower() not in ("false", "0", "no")
             if tts_enabled and rt.provider_registry:
                 from genesis.providers.types import ProviderCategory
@@ -632,7 +627,9 @@ class StandaloneAdapter:
 
             # Register channel
             recipient = (
-                str(next(iter(config["allowed_users"]), "")) if config["allowed_users"] else ""
+                str(next(iter(config["allowed_users"]), ""))
+                if config["allowed_users"]
+                else ""
             )
             rt.register_channel("telegram", adapter, recipient=recipient)
 
@@ -656,16 +653,10 @@ class StandaloneAdapter:
                 # startup, not just after the first approval is delivered).
                 # Mirrors channels/bridge.py:236-241.
                 for cat in (
-                    "conversation",
-                    "morning_report",
-                    "alert",
-                    "reflection_micro",
-                    "reflection_light",
-                    "reflection_deep",
-                    "reflection_strategic",
-                    "surplus",
-                    "recon",
-                    "approvals",
+                    "conversation", "morning_report", "alert",
+                    "reflection_micro", "reflection_light",
+                    "reflection_deep", "reflection_strategic",
+                    "surplus", "recon", "approvals",
                     "ego_proposals",
                 ):
                     await topic_manager.get_or_create_persistent(cat)

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -108,7 +108,9 @@ class StandaloneAdapter:
         )
         flask_thread.start()
         logger.info(
-            "Dashboard at http://%s:%d/genesis", self._host, self._port,
+            "Dashboard at http://%s:%d/genesis",
+            self._host,
+            self._port,
         )
 
         # Telegram if configured
@@ -122,16 +124,21 @@ class StandaloneAdapter:
             while not self._shutdown_event.is_set():
                 # Update status_writer so dashboard health panel has fresh data
                 if self._runtime and self._runtime.status_writer:
-                    self._runtime.status_writer.set_extra_data("standalone", {
-                        "flask_running": self._app is not None,
-                        "telegram_active": self._telegram_adapter is not None,
-                        "uptime_h": round(
-                            (time.monotonic() - start_time) / 3600, 2,
-                        ),
-                    })
+                    self._runtime.status_writer.set_extra_data(
+                        "standalone",
+                        {
+                            "flask_running": self._app is not None,
+                            "telegram_active": self._telegram_adapter is not None,
+                            "uptime_h": round(
+                                (time.monotonic() - start_time) / 3600,
+                                2,
+                            ),
+                        },
+                    )
                 try:
                     await asyncio.wait_for(
-                        self._shutdown_event.wait(), timeout=1800,
+                        self._shutdown_event.wait(),
+                        timeout=1800,
                     )
                     break
                 except TimeoutError:
@@ -282,7 +289,8 @@ class StandaloneAdapter:
             ha_token = os.environ.get("HA_LONG_LIVED_TOKEN", "")
             if ha_url and ha_token:
                 voice_adapter = VoiceChannelAdapter(
-                    ha_url=ha_url, ha_token=ha_token,
+                    ha_url=ha_url,
+                    ha_token=ha_token,
                 )
                 self._app.config["VOICE_ADAPTER"] = voice_adapter
                 logger.info("Voice adapter initialized (outbound TTS via HA)")
@@ -304,8 +312,7 @@ class StandaloneAdapter:
 
         if not voice_config.s2s_enabled():
             logger.info(
-                "S2S voice disabled — no API key for provider '%s'. "
-                "Wyoming servers not started.",
+                "S2S voice disabled — no API key for provider '%s'. Wyoming servers not started.",
                 voice_config.s2s_provider(),
             )
             return
@@ -313,25 +320,30 @@ class StandaloneAdapter:
         try:
             from genesis.channels.voice.genesis_bridge import GenesisBridge
             from genesis.channels.voice.s2s_session import S2SSessionManager
+            from genesis.channels.voice.transcript_writer import get_shared_writer
             from genesis.channels.voice.wyoming_stt import WyomingSTTServer
             from genesis.channels.voice.wyoming_tts import WyomingTTSServer
 
             # Genesis bridge for tool calls — delegates ask_genesis to
             # the existing VoiceConversationHandler (no DRY violation)
             voice_handler = self._app.config.get("VOICE_HANDLER") if self._app else None
-            approval_gate = (
-                self._runtime.autonomous_cli_approval_gate
-                if self._runtime else None
-            )
+            approval_gate = self._runtime.autonomous_cli_approval_gate if self._runtime else None
             bridge = GenesisBridge(
                 voice_handler=voice_handler,
                 approval_gate=approval_gate,
             )
 
-            # S2S session manager (memory_store for transcript persistence)
+            # S2S session manager — conversations land as per-turn transcript
+            # files that the extraction job mines (W0.5 parity), not as
+            # one-blob memories at close.
+            transcript_writer = (
+                await get_shared_writer(self._runtime.db)
+                if self._runtime and self._runtime.db is not None
+                else None
+            )
             s2s_manager = S2SSessionManager(
                 bridge=bridge,
-                memory_store=self._runtime.memory_store if self._runtime else None,
+                transcript_writer=transcript_writer,
             )
             await s2s_manager.start_reaper()
             logger.info(
@@ -579,7 +591,8 @@ class StandaloneAdapter:
 
             tts_provider = None
             tts_enabled = os.environ.get(
-                "TTS_ENABLED", "true",
+                "TTS_ENABLED",
+                "true",
             ).lower() not in ("false", "0", "no")
             if tts_enabled and rt.provider_registry:
                 from genesis.providers.types import ProviderCategory
@@ -619,9 +632,7 @@ class StandaloneAdapter:
 
             # Register channel
             recipient = (
-                str(next(iter(config["allowed_users"]), ""))
-                if config["allowed_users"]
-                else ""
+                str(next(iter(config["allowed_users"]), "")) if config["allowed_users"] else ""
             )
             rt.register_channel("telegram", adapter, recipient=recipient)
 
@@ -645,10 +656,16 @@ class StandaloneAdapter:
                 # startup, not just after the first approval is delivered).
                 # Mirrors channels/bridge.py:236-241.
                 for cat in (
-                    "conversation", "morning_report", "alert",
-                    "reflection_micro", "reflection_light",
-                    "reflection_deep", "reflection_strategic",
-                    "surplus", "recon", "approvals",
+                    "conversation",
+                    "morning_report",
+                    "alert",
+                    "reflection_micro",
+                    "reflection_light",
+                    "reflection_deep",
+                    "reflection_strategic",
+                    "surplus",
+                    "recon",
+                    "approvals",
                     "ego_proposals",
                 ):
                     await topic_manager.get_or_create_persistent(cat)

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
-from genesis.env import cc_project_dir
+from genesis.env import cc_project_dir, voice_transcript_dir
 from genesis.learning.procedural.judge import ProcedureBuilderUnavailable
 from genesis.memory.extraction import (
     RETRY_PROMPT,
@@ -45,8 +45,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Session types eligible for extraction
-_EXTRACTABLE_SOURCE_TAGS = {"foreground", "inbox"}
+# Session types eligible for extraction. 'voice' rows are written by the
+# voice transcript writer (channels/voice/transcript_writer.py) — their
+# transcripts live in voice_transcript_dir(), not the CC projects dir.
+_EXTRACTABLE_SOURCE_TAGS = {"foreground", "inbox", "voice"}
 
 # Transcript directory
 _TRANSCRIPT_DIR = Path.home() / ".claude" / "projects" / cc_project_dir()
@@ -76,6 +78,7 @@ async def _check_claim_duplicate(
     to confirm. Deduplicates across all sessions.
     """
     import re
+
     # Use a simple alphanumeric tokenizer inline rather than importing
     # the private _extract_terms. Avoids cross-module private API coupling.
     words = re.findall(r"[a-z0-9]+", content.lower())
@@ -90,8 +93,7 @@ async def _check_claim_duplicate(
 
     try:
         cursor = await db.execute(
-            "SELECT memory_id, content FROM memory_fts "
-            "WHERE memory_fts MATCH ? LIMIT ?",
+            "SELECT memory_id, content FROM memory_fts WHERE memory_fts MATCH ? LIMIT ?",
             (fts_query, fts5_limit),
         )
         rows = await cursor.fetchall()
@@ -160,11 +162,7 @@ async def run_extraction_cycle(
     # (``if not messages: continue``) — this drain is the only path that recovers
     # them. Skipped for the history-mining / filtered invocations, which don't
     # own production extraction state.
-    if (
-        not reference_only_mode
-        and start_line_override is None
-        and session_filter is None
-    ):
+    if not reference_only_mode and start_line_override is None and session_filter is None:
         try:
             await _drain_procedure_rebuilds(
                 db=db,
@@ -189,6 +187,11 @@ async def run_extraction_cycle(
         else:
             last_line = session.get("last_extracted_line") or 0
         transcript_path = _find_transcript(transcript_dir, cc_session_id)
+        if not transcript_path and session.get("source_tag") == "voice":
+            # Voice sessions keep their transcripts outside the CC projects
+            # dir (same CC-JSONL format, written by the voice transcript
+            # writer) so the CC resume picker never lists them.
+            transcript_path = _find_transcript(voice_transcript_dir(), cc_session_id)
 
         if not transcript_path:
             continue
@@ -228,7 +231,10 @@ async def run_extraction_cycle(
                 summary["errors"] += 1
                 logger.error(
                     "Extraction parse error for session %s chunk %d-%d: %s",
-                    session_id, chunk_start, chunk_end, result.parse_error,
+                    session_id,
+                    chunk_start,
+                    chunk_end,
+                    result.parse_error,
                 )
                 continue
 
@@ -243,7 +249,9 @@ async def run_extraction_cycle(
                 logger.warning(
                     "Zero entities extracted from session %s chunk %d-%d "
                     "(possible extraction quality issue)",
-                    session_id, chunk_start, chunk_end,
+                    session_id,
+                    chunk_start,
+                    chunk_end,
                 )
                 continue
 
@@ -256,9 +264,7 @@ async def run_extraction_cycle(
                 # Gate reference auto-capture to the USER's own words — the
                 # classifier must not mine Genesis's analysis prose (the
                 # dominant source of junk refs) for credentials/IPs/URLs.
-                chunk_user_text = "\n".join(
-                    m.text for m in chunk if m.role == "user"
-                )
+                chunk_user_text = "\n".join(m.text for m in chunk if m.role == "user")
                 ref_count = await extract_references_from_chunk(
                     result.extractions,
                     store=store,
@@ -275,7 +281,10 @@ async def run_extraction_cycle(
                 # pipeline — log and continue.
                 logger.warning(
                     "Reference extractor failed on session %s chunk %d-%d",
-                    session_id, chunk_start, chunk_end, exc_info=True,
+                    session_id,
+                    chunk_start,
+                    chunk_end,
+                    exc_info=True,
                 )
 
             # Stream 2: procedure candidate flagging (C2b — flag-only). The SLM
@@ -291,13 +300,14 @@ async def run_extraction_cycle(
                         extract_procedures_from_chunk,
                     )
 
-                    session_candidates.extend(
-                        extract_procedures_from_chunk(result.extractions)
-                    )
+                    session_candidates.extend(extract_procedures_from_chunk(result.extractions))
                 except Exception:
                     logger.warning(
                         "Procedure candidate flagging failed on session %s chunk %d-%d",
-                        session_id, chunk_start, chunk_end, exc_info=True,
+                        session_id,
+                        chunk_start,
+                        chunk_end,
+                        exc_info=True,
                     )
 
             if reference_only_mode:
@@ -321,17 +331,21 @@ async def run_extraction_cycle(
                 # source transcript chunk. Demote confidence for ungrounded
                 # extractions. See memory-immune-system-design.md §1.1.
                 overlap_result = verify_source_overlap(
-                    extraction.content, source_text,
+                    extraction.content,
+                    source_text,
                 )
                 if not overlap_result.verified:
                     extraction.confidence = max(
-                        extraction.confidence - 0.3, 0.1,
+                        extraction.confidence - 0.3,
+                        0.1,
                     )
                     logger.info(
                         "Source-overlap FAIL for extraction in session %s "
                         "(overlap=%.2f, confidence demoted to %.2f): %.80s",
-                        session_id, overlap_result.overlap,
-                        extraction.confidence, extraction.content,
+                        session_id,
+                        overlap_result.overlap,
+                        extraction.confidence,
+                        extraction.content,
                     )
 
                 # ── Cross-session claim dedup ──
@@ -340,7 +354,8 @@ async def run_extraction_cycle(
                 # See memory-immune-system-design.md §1.2.
                 try:
                     is_dup = await _check_claim_duplicate(
-                        db, extraction.content,
+                        db,
+                        extraction.content,
                     )
                     if is_dup:
                         summary.setdefault("claims_deduped", 0)
@@ -348,7 +363,8 @@ async def run_extraction_cycle(
                         logger.info(
                             "Cross-session dedup: skipping extraction in "
                             "session %s (duplicate of existing memory): %.80s",
-                            session_id, extraction.content,
+                            session_id,
+                            extraction.content,
                         )
                         continue  # Skip this extraction entirely
                 except Exception:
@@ -370,7 +386,8 @@ async def run_extraction_cycle(
                     # extraction cycle from hammering the embedding backend
                     # with hundreds of sequential calls.
                     memory_id = await store.store(
-                        **kwargs, force_fts5_only=True,
+                        **kwargs,
+                        force_fts5_only=True,
                     )
                     summary["entities_extracted"] += 1
                     # Count source-unverified only for stored extractions
@@ -378,14 +395,13 @@ async def run_extraction_cycle(
                         summary.setdefault("source_unverified", 0)
                         summary["source_unverified"] += 1
                     session_extraction_count += 1
-                    _newly_stored.append(
-                        (memory_id, extraction.content, cc_session_id)
-                    )
+                    _newly_stored.append((memory_id, extraction.content, cc_session_id))
 
                     # Store SVO event if temporal + verb present
                     if extraction.event_verb and extraction.temporal:
                         try:
                             from genesis.db.crud import memory_events
+
                             await memory_events.insert(
                                 db,
                                 memory_id=memory_id,
@@ -402,19 +418,22 @@ async def run_extraction_cycle(
                             summary["events_failed"] += 1
                             logger.warning(
                                 "Failed to store SVO event for %s",
-                                memory_id, exc_info=True,
+                                memory_id,
+                                exc_info=True,
                             )
 
                     # Create typed links from extraction relationships
                     if linker and extraction.relationships:
                         try:
                             await linker.create_typed_links(
-                                memory_id, extraction.relationships,
+                                memory_id,
+                                extraction.relationships,
                             )
                         except Exception:
                             logger.error(
                                 "Failed to create typed links for %s",
-                                memory_id, exc_info=True,
+                                memory_id,
+                                exc_info=True,
                             )
 
                     # Entity layer (E3): give extracted entities and
@@ -428,7 +447,9 @@ async def run_extraction_cycle(
                             )
 
                             entity_counts = await record_extraction(
-                                db, memory_id, extraction,
+                                db,
+                                memory_id,
+                                extraction,
                             )
                             summary.setdefault("entity_mentions", 0)
                             summary.setdefault("entity_links", 0)
@@ -437,7 +458,8 @@ async def run_extraction_cycle(
                         except Exception:
                             logger.warning(
                                 "Entity-layer recording failed for %s",
-                                memory_id, exc_info=True,
+                                memory_id,
+                                exc_info=True,
                             )
 
                     # Goal signal detection — DISABLED: keyword matcher
@@ -452,29 +474,33 @@ async def run_extraction_cycle(
                         from genesis.memory.contact_tracker import (
                             process_extraction as _track_contact,
                         )
+
                         n = await _track_contact(
-                            db, extraction,
+                            db,
+                            extraction,
                             source_session_id=cc_session_id,
                         )
                         summary["contacts_detected"] += n
                     except Exception:
                         logger.debug(
                             "Contact tracker failed for %s",
-                            memory_id, exc_info=True,
+                            memory_id,
+                            exc_info=True,
                         )
                 except Exception:
                     summary["errors"] += 1
                     logger.error(
                         "Failed to store extraction from session %s",
-                        session_id, exc_info=True,
+                        session_id,
+                        exc_info=True,
                     )
 
             # Check per-session cap after storing this chunk's extractions
             if session_extraction_count >= max_extractions_per_session:
                 logger.info(
-                    "Hit per-session extraction cap (%d) for session %s, "
-                    "skipping remaining chunks",
-                    max_extractions_per_session, session_id,
+                    "Hit per-session extraction cap (%d) for session %s, skipping remaining chunks",
+                    max_extractions_per_session,
+                    session_id,
                 )
                 break
 
@@ -486,8 +512,10 @@ async def run_extraction_cycle(
             await _update_watermark(db, session_id, max_line)
             if all_keywords or latest_topic:
                 await _update_session_index(
-                    db, session_id,
-                    keywords=all_keywords, topic=latest_topic,
+                    db,
+                    session_id,
+                    keywords=all_keywords,
+                    topic=latest_topic,
                 )
 
             # Stream 1: the whole-session procedure BUILDER (runs once per
@@ -509,9 +537,8 @@ async def run_extraction_cycle(
                 struggle_score = score_struggle(spine)
                 struggle_triggered = struggle_score >= STRUGGLE_THRESHOLD
                 if (
-                    (struggle_triggered or session_candidates)
-                    and session_procs < max_procedures_per_session
-                ):
+                    struggle_triggered or session_candidates
+                ) and session_procs < max_procedures_per_session:
                     from genesis.learning.procedural.judge import (
                         JUDGE_TIMEOUT_SECS,
                         judge_multi_procedure,
@@ -519,7 +546,11 @@ async def run_extraction_cycle(
 
                     stored_ids = await asyncio.wait_for(
                         judge_multi_procedure(
-                            db, spine, haystack, struggle_score, router,
+                            db,
+                            spine,
+                            haystack,
+                            struggle_score,
+                            router,
                             source_session_id=cc_session_id,
                             max_new=max_procedures_per_session - session_procs,
                         ),
@@ -527,21 +558,25 @@ async def run_extraction_cycle(
                     )
                     session_procs += len(stored_ids)
                     if stored_ids:
-                        summary["struggle_procedures"] = (
-                            summary.get("struggle_procedures", 0) + len(stored_ids)
-                        )
+                        summary["struggle_procedures"] = summary.get(
+                            "struggle_procedures", 0
+                        ) + len(stored_ids)
                     # Measure SLM over-flagging: the builder fired on chunk
                     # candidates alone, with no struggle signal.
                     if session_candidates and not struggle_triggered:
                         logger.info(
                             "Procedure builder fired on candidates-only for %s "
                             "(%d candidates, score=%.2f): stored=%d",
-                            session_id, len(session_candidates), struggle_score,
+                            session_id,
+                            len(session_candidates),
+                            struggle_score,
                             len(stored_ids),
                         )
                     logger.info(
                         "Procedure builder for %s: score=%.2f, candidates=%d, stored=%d",
-                        session_id, struggle_score, len(session_candidates),
+                        session_id,
+                        struggle_score,
+                        len(session_candidates),
                         len(stored_ids),
                     )
             except (ProcedureBuilderUnavailable, TimeoutError) as exc:
@@ -556,8 +591,9 @@ async def run_extraction_cycle(
                 # self-commit and the deferred memory_events was committed by the
                 # watermark update above.
                 logger.warning(
-                    "Procedure builder unavailable for session %s (%s) — "
-                    "re-queuing for rebuild", session_id, type(exc).__name__,
+                    "Procedure builder unavailable for session %s (%s) — re-queuing for rebuild",
+                    session_id,
+                    type(exc).__name__,
                 )
                 await _enqueue_procedure_rebuild(db, session_id, cc_session_id)
             except Exception:
@@ -566,7 +602,8 @@ async def run_extraction_cycle(
                 # connection — see above).
                 logger.warning(
                     "Procedure builder failed for session %s",
-                    session_id, exc_info=True,
+                    session_id,
+                    exc_info=True,
                 )
 
         summary["sessions_processed"] += 1
@@ -590,7 +627,9 @@ async def run_extraction_cycle(
 
 
 async def _enqueue_procedure_rebuild(
-    db: aiosqlite.Connection, session_id: str, cc_session_id: str,
+    db: aiosqlite.Connection,
+    session_id: str,
+    cc_session_id: str,
 ) -> None:
     """Re-queue a session whose procedure build died on provider exhaustion.
 
@@ -611,16 +650,15 @@ async def _enqueue_procedure_rebuild(
             work_type=_PROCEDURE_REBUILD_WORK,
             call_site_id="38_procedure_extraction",
             priority=MEMORY_OPS,
-            payload=json.dumps(
-                {"session_id": session_id, "cc_session_id": cc_session_id}
-            ),
+            payload=json.dumps({"session_id": session_id, "cc_session_id": cc_session_id}),
             reason="procedure builder provider-exhausted; watermark already advanced",
             staleness_policy=DRAIN,
         )
     except Exception:
         logger.error(
             "Failed to enqueue procedure rebuild for session %s",
-            session_id, exc_info=True,
+            session_id,
+            exc_info=True,
         )
 
 
@@ -656,7 +694,9 @@ async def _drain_procedure_rebuilds(
 
     queue = DeferredWorkQueue(db)
     items = await dw_crud.query_pending(
-        db, work_type=_PROCEDURE_REBUILD_WORK, limit=20,
+        db,
+        work_type=_PROCEDURE_REBUILD_WORK,
+        limit=20,
     )
     for item in items:
         item_id = item["id"]
@@ -673,9 +713,7 @@ async def _drain_procedure_rebuilds(
             continue
 
         cc_session_id = payload.get("cc_session_id") or payload.get("session_id")
-        transcript_path = (
-            _find_transcript(transcript_dir, cc_session_id) if cc_session_id else None
-        )
+        transcript_path = _find_transcript(transcript_dir, cc_session_id) if cc_session_id else None
         if not transcript_path:
             # Transcript rotated/gone — nothing to rebuild from.
             await queue.mark_discarded(item_id, "transcript not found")
@@ -687,20 +725,24 @@ async def _drain_procedure_rebuilds(
             score = score_struggle(spine)
             stored_ids = await asyncio.wait_for(
                 judge_multi_procedure(
-                    db, spine, haystack, score, router,
+                    db,
+                    spine,
+                    haystack,
+                    score,
+                    router,
                     source_session_id=cc_session_id,
                     max_new=max_procedures_per_session,
                 ),
                 timeout=JUDGE_TIMEOUT_SECS,
             )
             await queue.mark_completed(item_id)
-            summary["procedures_rebuilt"] = (
-                summary.get("procedures_rebuilt", 0) + len(stored_ids)
-            )
+            summary["procedures_rebuilt"] = summary.get("procedures_rebuilt", 0) + len(stored_ids)
             if stored_ids:
                 logger.info(
                     "Rebuilt %d procedure(s) for session %s (attempt %d)",
-                    len(stored_ids), cc_session_id, attempts + 1,
+                    len(stored_ids),
+                    cc_session_id,
+                    attempts + 1,
                 )
         except (ProcedureBuilderUnavailable, TimeoutError):
             # Providers still down — keep it pending for a later cycle. No
@@ -712,7 +754,8 @@ async def _drain_procedure_rebuilds(
             # Deterministic failure (bad transcript / parse) — don't loop forever.
             logger.warning(
                 "Procedure rebuild failed permanently for session %s",
-                cc_session_id, exc_info=True,
+                cc_session_id,
+                exc_info=True,
             )
             await queue.mark_discarded(item_id, "rebuild raised non-retryable error")
 
@@ -752,7 +795,8 @@ async def _exhaust_procedure_rebuild(db: aiosqlite.Connection, queue, item: dict
         )
     logger.warning(
         "Procedure rebuild EXHAUSTED for session %s after %d attempts",
-        cc_session_id, _MAX_PROCEDURE_REBUILD_ATTEMPTS,
+        cc_session_id,
+        _MAX_PROCEDURE_REBUILD_ATTEMPTS,
     )
 
 
@@ -784,6 +828,7 @@ async def _find_extractable_sessions(
                     continue
                 # Auto-register as foreground session
                 import uuid as _uuid
+
                 try:
                     _uuid.UUID(session_id)  # validate UUID format
                 except ValueError:
@@ -791,7 +836,8 @@ async def _find_extractable_sessions(
 
                 # Get file mtime as approximate start time
                 mtime = datetime.fromtimestamp(
-                    jsonl_file.stat().st_mtime, tz=UTC,
+                    jsonl_file.stat().st_mtime,
+                    tz=UTC,
                 )
                 mtime_iso = mtime.isoformat()
                 await sessions_crud.register_from_filesystem(
@@ -808,7 +854,8 @@ async def _find_extractable_sessions(
 
     # Phase 2: Query all extractable sessions (including newly registered ones)
     return await sessions_crud.get_extractable(
-        db, source_tags=_EXTRACTABLE_SOURCE_TAGS,
+        db,
+        source_tags=_EXTRACTABLE_SOURCE_TAGS,
     )
 
 
@@ -822,7 +869,8 @@ async def _update_watermark(
 
     now_iso = datetime.now(UTC).isoformat()
     await sessions_crud.update_extraction_watermark(
-        db, session_id,
+        db,
+        session_id,
         last_extracted_line=line_number,
         last_extracted_at=now_iso,
     )
@@ -853,11 +901,16 @@ async def _update_session_index(
     keywords_str = ", ".join(merged)
 
     await sessions_crud.update_topic_and_keywords(
-        db, session_id, topic=topic, keywords=keywords_str,
+        db,
+        session_id,
+        topic=topic,
+        keywords=keywords_str,
     )
     logger.info(
         "Session %s indexed: topic=%r, keywords=%d",
-        session_id[:8], topic[:60], len(merged),
+        session_id[:8],
+        topic[:60],
+        len(merged),
     )
 
 
@@ -913,7 +966,10 @@ async def _extract_chunk(
             else:
                 messages = [
                     {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": "(previous attempt failed to produce valid JSON)"},
+                    {
+                        "role": "assistant",
+                        "content": "(previous attempt failed to produce valid JSON)",
+                    },
                     {"role": "user", "content": RETRY_PROMPT},
                 ]
 
@@ -950,7 +1006,9 @@ async def _extract_chunk(
             if attempt < max_retries - 1:
                 logger.warning(
                     "Extraction parse failed (attempt %d/%d): %s",
-                    attempt + 1, max_retries, exc,
+                    attempt + 1,
+                    max_retries,
+                    exc,
                 )
                 continue
             return ExtractionResult(
@@ -962,7 +1020,9 @@ async def _extract_chunk(
             )
         except Exception as exc:
             logger.error(
-                "Extraction LLM call failed: %s", exc, exc_info=True,
+                "Extraction LLM call failed: %s",
+                exc,
+                exc_info=True,
             )
             return ExtractionResult(
                 extractions=[],

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -78,7 +78,6 @@ async def _check_claim_duplicate(
     to confirm. Deduplicates across all sessions.
     """
     import re
-
     # Use a simple alphanumeric tokenizer inline rather than importing
     # the private _extract_terms. Avoids cross-module private API coupling.
     words = re.findall(r"[a-z0-9]+", content.lower())
@@ -93,7 +92,8 @@ async def _check_claim_duplicate(
 
     try:
         cursor = await db.execute(
-            "SELECT memory_id, content FROM memory_fts WHERE memory_fts MATCH ? LIMIT ?",
+            "SELECT memory_id, content FROM memory_fts "
+            "WHERE memory_fts MATCH ? LIMIT ?",
             (fts_query, fts5_limit),
         )
         rows = await cursor.fetchall()
@@ -162,7 +162,11 @@ async def run_extraction_cycle(
     # (``if not messages: continue``) — this drain is the only path that recovers
     # them. Skipped for the history-mining / filtered invocations, which don't
     # own production extraction state.
-    if not reference_only_mode and start_line_override is None and session_filter is None:
+    if (
+        not reference_only_mode
+        and start_line_override is None
+        and session_filter is None
+    ):
         try:
             await _drain_procedure_rebuilds(
                 db=db,
@@ -231,10 +235,7 @@ async def run_extraction_cycle(
                 summary["errors"] += 1
                 logger.error(
                     "Extraction parse error for session %s chunk %d-%d: %s",
-                    session_id,
-                    chunk_start,
-                    chunk_end,
-                    result.parse_error,
+                    session_id, chunk_start, chunk_end, result.parse_error,
                 )
                 continue
 
@@ -249,9 +250,7 @@ async def run_extraction_cycle(
                 logger.warning(
                     "Zero entities extracted from session %s chunk %d-%d "
                     "(possible extraction quality issue)",
-                    session_id,
-                    chunk_start,
-                    chunk_end,
+                    session_id, chunk_start, chunk_end,
                 )
                 continue
 
@@ -264,7 +263,9 @@ async def run_extraction_cycle(
                 # Gate reference auto-capture to the USER's own words — the
                 # classifier must not mine Genesis's analysis prose (the
                 # dominant source of junk refs) for credentials/IPs/URLs.
-                chunk_user_text = "\n".join(m.text for m in chunk if m.role == "user")
+                chunk_user_text = "\n".join(
+                    m.text for m in chunk if m.role == "user"
+                )
                 ref_count = await extract_references_from_chunk(
                     result.extractions,
                     store=store,
@@ -281,10 +282,7 @@ async def run_extraction_cycle(
                 # pipeline — log and continue.
                 logger.warning(
                     "Reference extractor failed on session %s chunk %d-%d",
-                    session_id,
-                    chunk_start,
-                    chunk_end,
-                    exc_info=True,
+                    session_id, chunk_start, chunk_end, exc_info=True,
                 )
 
             # Stream 2: procedure candidate flagging (C2b — flag-only). The SLM
@@ -300,14 +298,13 @@ async def run_extraction_cycle(
                         extract_procedures_from_chunk,
                     )
 
-                    session_candidates.extend(extract_procedures_from_chunk(result.extractions))
+                    session_candidates.extend(
+                        extract_procedures_from_chunk(result.extractions)
+                    )
                 except Exception:
                     logger.warning(
                         "Procedure candidate flagging failed on session %s chunk %d-%d",
-                        session_id,
-                        chunk_start,
-                        chunk_end,
-                        exc_info=True,
+                        session_id, chunk_start, chunk_end, exc_info=True,
                     )
 
             if reference_only_mode:
@@ -331,21 +328,17 @@ async def run_extraction_cycle(
                 # source transcript chunk. Demote confidence for ungrounded
                 # extractions. See memory-immune-system-design.md §1.1.
                 overlap_result = verify_source_overlap(
-                    extraction.content,
-                    source_text,
+                    extraction.content, source_text,
                 )
                 if not overlap_result.verified:
                     extraction.confidence = max(
-                        extraction.confidence - 0.3,
-                        0.1,
+                        extraction.confidence - 0.3, 0.1,
                     )
                     logger.info(
                         "Source-overlap FAIL for extraction in session %s "
                         "(overlap=%.2f, confidence demoted to %.2f): %.80s",
-                        session_id,
-                        overlap_result.overlap,
-                        extraction.confidence,
-                        extraction.content,
+                        session_id, overlap_result.overlap,
+                        extraction.confidence, extraction.content,
                     )
 
                 # ── Cross-session claim dedup ──
@@ -354,8 +347,7 @@ async def run_extraction_cycle(
                 # See memory-immune-system-design.md §1.2.
                 try:
                     is_dup = await _check_claim_duplicate(
-                        db,
-                        extraction.content,
+                        db, extraction.content,
                     )
                     if is_dup:
                         summary.setdefault("claims_deduped", 0)
@@ -363,8 +355,7 @@ async def run_extraction_cycle(
                         logger.info(
                             "Cross-session dedup: skipping extraction in "
                             "session %s (duplicate of existing memory): %.80s",
-                            session_id,
-                            extraction.content,
+                            session_id, extraction.content,
                         )
                         continue  # Skip this extraction entirely
                 except Exception:
@@ -386,8 +377,7 @@ async def run_extraction_cycle(
                     # extraction cycle from hammering the embedding backend
                     # with hundreds of sequential calls.
                     memory_id = await store.store(
-                        **kwargs,
-                        force_fts5_only=True,
+                        **kwargs, force_fts5_only=True,
                     )
                     summary["entities_extracted"] += 1
                     # Count source-unverified only for stored extractions
@@ -395,13 +385,14 @@ async def run_extraction_cycle(
                         summary.setdefault("source_unverified", 0)
                         summary["source_unverified"] += 1
                     session_extraction_count += 1
-                    _newly_stored.append((memory_id, extraction.content, cc_session_id))
+                    _newly_stored.append(
+                        (memory_id, extraction.content, cc_session_id)
+                    )
 
                     # Store SVO event if temporal + verb present
                     if extraction.event_verb and extraction.temporal:
                         try:
                             from genesis.db.crud import memory_events
-
                             await memory_events.insert(
                                 db,
                                 memory_id=memory_id,
@@ -418,22 +409,19 @@ async def run_extraction_cycle(
                             summary["events_failed"] += 1
                             logger.warning(
                                 "Failed to store SVO event for %s",
-                                memory_id,
-                                exc_info=True,
+                                memory_id, exc_info=True,
                             )
 
                     # Create typed links from extraction relationships
                     if linker and extraction.relationships:
                         try:
                             await linker.create_typed_links(
-                                memory_id,
-                                extraction.relationships,
+                                memory_id, extraction.relationships,
                             )
                         except Exception:
                             logger.error(
                                 "Failed to create typed links for %s",
-                                memory_id,
-                                exc_info=True,
+                                memory_id, exc_info=True,
                             )
 
                     # Entity layer (E3): give extracted entities and
@@ -447,9 +435,7 @@ async def run_extraction_cycle(
                             )
 
                             entity_counts = await record_extraction(
-                                db,
-                                memory_id,
-                                extraction,
+                                db, memory_id, extraction,
                             )
                             summary.setdefault("entity_mentions", 0)
                             summary.setdefault("entity_links", 0)
@@ -458,8 +444,7 @@ async def run_extraction_cycle(
                         except Exception:
                             logger.warning(
                                 "Entity-layer recording failed for %s",
-                                memory_id,
-                                exc_info=True,
+                                memory_id, exc_info=True,
                             )
 
                     # Goal signal detection — DISABLED: keyword matcher
@@ -474,33 +459,29 @@ async def run_extraction_cycle(
                         from genesis.memory.contact_tracker import (
                             process_extraction as _track_contact,
                         )
-
                         n = await _track_contact(
-                            db,
-                            extraction,
+                            db, extraction,
                             source_session_id=cc_session_id,
                         )
                         summary["contacts_detected"] += n
                     except Exception:
                         logger.debug(
                             "Contact tracker failed for %s",
-                            memory_id,
-                            exc_info=True,
+                            memory_id, exc_info=True,
                         )
                 except Exception:
                     summary["errors"] += 1
                     logger.error(
                         "Failed to store extraction from session %s",
-                        session_id,
-                        exc_info=True,
+                        session_id, exc_info=True,
                     )
 
             # Check per-session cap after storing this chunk's extractions
             if session_extraction_count >= max_extractions_per_session:
                 logger.info(
-                    "Hit per-session extraction cap (%d) for session %s, skipping remaining chunks",
-                    max_extractions_per_session,
-                    session_id,
+                    "Hit per-session extraction cap (%d) for session %s, "
+                    "skipping remaining chunks",
+                    max_extractions_per_session, session_id,
                 )
                 break
 
@@ -512,10 +493,8 @@ async def run_extraction_cycle(
             await _update_watermark(db, session_id, max_line)
             if all_keywords or latest_topic:
                 await _update_session_index(
-                    db,
-                    session_id,
-                    keywords=all_keywords,
-                    topic=latest_topic,
+                    db, session_id,
+                    keywords=all_keywords, topic=latest_topic,
                 )
 
             # Stream 1: the whole-session procedure BUILDER (runs once per
@@ -537,8 +516,9 @@ async def run_extraction_cycle(
                 struggle_score = score_struggle(spine)
                 struggle_triggered = struggle_score >= STRUGGLE_THRESHOLD
                 if (
-                    struggle_triggered or session_candidates
-                ) and session_procs < max_procedures_per_session:
+                    (struggle_triggered or session_candidates)
+                    and session_procs < max_procedures_per_session
+                ):
                     from genesis.learning.procedural.judge import (
                         JUDGE_TIMEOUT_SECS,
                         judge_multi_procedure,
@@ -546,11 +526,7 @@ async def run_extraction_cycle(
 
                     stored_ids = await asyncio.wait_for(
                         judge_multi_procedure(
-                            db,
-                            spine,
-                            haystack,
-                            struggle_score,
-                            router,
+                            db, spine, haystack, struggle_score, router,
                             source_session_id=cc_session_id,
                             max_new=max_procedures_per_session - session_procs,
                         ),
@@ -558,25 +534,21 @@ async def run_extraction_cycle(
                     )
                     session_procs += len(stored_ids)
                     if stored_ids:
-                        summary["struggle_procedures"] = summary.get(
-                            "struggle_procedures", 0
-                        ) + len(stored_ids)
+                        summary["struggle_procedures"] = (
+                            summary.get("struggle_procedures", 0) + len(stored_ids)
+                        )
                     # Measure SLM over-flagging: the builder fired on chunk
                     # candidates alone, with no struggle signal.
                     if session_candidates and not struggle_triggered:
                         logger.info(
                             "Procedure builder fired on candidates-only for %s "
                             "(%d candidates, score=%.2f): stored=%d",
-                            session_id,
-                            len(session_candidates),
-                            struggle_score,
+                            session_id, len(session_candidates), struggle_score,
                             len(stored_ids),
                         )
                     logger.info(
                         "Procedure builder for %s: score=%.2f, candidates=%d, stored=%d",
-                        session_id,
-                        struggle_score,
-                        len(session_candidates),
+                        session_id, struggle_score, len(session_candidates),
                         len(stored_ids),
                     )
             except (ProcedureBuilderUnavailable, TimeoutError) as exc:
@@ -591,9 +563,8 @@ async def run_extraction_cycle(
                 # self-commit and the deferred memory_events was committed by the
                 # watermark update above.
                 logger.warning(
-                    "Procedure builder unavailable for session %s (%s) — re-queuing for rebuild",
-                    session_id,
-                    type(exc).__name__,
+                    "Procedure builder unavailable for session %s (%s) — "
+                    "re-queuing for rebuild", session_id, type(exc).__name__,
                 )
                 await _enqueue_procedure_rebuild(db, session_id, cc_session_id)
             except Exception:
@@ -602,8 +573,7 @@ async def run_extraction_cycle(
                 # connection — see above).
                 logger.warning(
                     "Procedure builder failed for session %s",
-                    session_id,
-                    exc_info=True,
+                    session_id, exc_info=True,
                 )
 
         summary["sessions_processed"] += 1
@@ -627,9 +597,7 @@ async def run_extraction_cycle(
 
 
 async def _enqueue_procedure_rebuild(
-    db: aiosqlite.Connection,
-    session_id: str,
-    cc_session_id: str,
+    db: aiosqlite.Connection, session_id: str, cc_session_id: str,
 ) -> None:
     """Re-queue a session whose procedure build died on provider exhaustion.
 
@@ -650,15 +618,16 @@ async def _enqueue_procedure_rebuild(
             work_type=_PROCEDURE_REBUILD_WORK,
             call_site_id="38_procedure_extraction",
             priority=MEMORY_OPS,
-            payload=json.dumps({"session_id": session_id, "cc_session_id": cc_session_id}),
+            payload=json.dumps(
+                {"session_id": session_id, "cc_session_id": cc_session_id}
+            ),
             reason="procedure builder provider-exhausted; watermark already advanced",
             staleness_policy=DRAIN,
         )
     except Exception:
         logger.error(
             "Failed to enqueue procedure rebuild for session %s",
-            session_id,
-            exc_info=True,
+            session_id, exc_info=True,
         )
 
 
@@ -694,9 +663,7 @@ async def _drain_procedure_rebuilds(
 
     queue = DeferredWorkQueue(db)
     items = await dw_crud.query_pending(
-        db,
-        work_type=_PROCEDURE_REBUILD_WORK,
-        limit=20,
+        db, work_type=_PROCEDURE_REBUILD_WORK, limit=20,
     )
     for item in items:
         item_id = item["id"]
@@ -713,7 +680,9 @@ async def _drain_procedure_rebuilds(
             continue
 
         cc_session_id = payload.get("cc_session_id") or payload.get("session_id")
-        transcript_path = _find_transcript(transcript_dir, cc_session_id) if cc_session_id else None
+        transcript_path = (
+            _find_transcript(transcript_dir, cc_session_id) if cc_session_id else None
+        )
         if not transcript_path:
             # Transcript rotated/gone — nothing to rebuild from.
             await queue.mark_discarded(item_id, "transcript not found")
@@ -725,24 +694,20 @@ async def _drain_procedure_rebuilds(
             score = score_struggle(spine)
             stored_ids = await asyncio.wait_for(
                 judge_multi_procedure(
-                    db,
-                    spine,
-                    haystack,
-                    score,
-                    router,
+                    db, spine, haystack, score, router,
                     source_session_id=cc_session_id,
                     max_new=max_procedures_per_session,
                 ),
                 timeout=JUDGE_TIMEOUT_SECS,
             )
             await queue.mark_completed(item_id)
-            summary["procedures_rebuilt"] = summary.get("procedures_rebuilt", 0) + len(stored_ids)
+            summary["procedures_rebuilt"] = (
+                summary.get("procedures_rebuilt", 0) + len(stored_ids)
+            )
             if stored_ids:
                 logger.info(
                     "Rebuilt %d procedure(s) for session %s (attempt %d)",
-                    len(stored_ids),
-                    cc_session_id,
-                    attempts + 1,
+                    len(stored_ids), cc_session_id, attempts + 1,
                 )
         except (ProcedureBuilderUnavailable, TimeoutError):
             # Providers still down — keep it pending for a later cycle. No
@@ -754,8 +719,7 @@ async def _drain_procedure_rebuilds(
             # Deterministic failure (bad transcript / parse) — don't loop forever.
             logger.warning(
                 "Procedure rebuild failed permanently for session %s",
-                cc_session_id,
-                exc_info=True,
+                cc_session_id, exc_info=True,
             )
             await queue.mark_discarded(item_id, "rebuild raised non-retryable error")
 
@@ -795,8 +759,7 @@ async def _exhaust_procedure_rebuild(db: aiosqlite.Connection, queue, item: dict
         )
     logger.warning(
         "Procedure rebuild EXHAUSTED for session %s after %d attempts",
-        cc_session_id,
-        _MAX_PROCEDURE_REBUILD_ATTEMPTS,
+        cc_session_id, _MAX_PROCEDURE_REBUILD_ATTEMPTS,
     )
 
 
@@ -828,7 +791,6 @@ async def _find_extractable_sessions(
                     continue
                 # Auto-register as foreground session
                 import uuid as _uuid
-
                 try:
                     _uuid.UUID(session_id)  # validate UUID format
                 except ValueError:
@@ -836,8 +798,7 @@ async def _find_extractable_sessions(
 
                 # Get file mtime as approximate start time
                 mtime = datetime.fromtimestamp(
-                    jsonl_file.stat().st_mtime,
-                    tz=UTC,
+                    jsonl_file.stat().st_mtime, tz=UTC,
                 )
                 mtime_iso = mtime.isoformat()
                 await sessions_crud.register_from_filesystem(
@@ -854,8 +815,7 @@ async def _find_extractable_sessions(
 
     # Phase 2: Query all extractable sessions (including newly registered ones)
     return await sessions_crud.get_extractable(
-        db,
-        source_tags=_EXTRACTABLE_SOURCE_TAGS,
+        db, source_tags=_EXTRACTABLE_SOURCE_TAGS,
     )
 
 
@@ -869,8 +829,7 @@ async def _update_watermark(
 
     now_iso = datetime.now(UTC).isoformat()
     await sessions_crud.update_extraction_watermark(
-        db,
-        session_id,
+        db, session_id,
         last_extracted_line=line_number,
         last_extracted_at=now_iso,
     )
@@ -901,16 +860,11 @@ async def _update_session_index(
     keywords_str = ", ".join(merged)
 
     await sessions_crud.update_topic_and_keywords(
-        db,
-        session_id,
-        topic=topic,
-        keywords=keywords_str,
+        db, session_id, topic=topic, keywords=keywords_str,
     )
     logger.info(
         "Session %s indexed: topic=%r, keywords=%d",
-        session_id[:8],
-        topic[:60],
-        len(merged),
+        session_id[:8], topic[:60], len(merged),
     )
 
 
@@ -966,10 +920,7 @@ async def _extract_chunk(
             else:
                 messages = [
                     {"role": "user", "content": prompt},
-                    {
-                        "role": "assistant",
-                        "content": "(previous attempt failed to produce valid JSON)",
-                    },
+                    {"role": "assistant", "content": "(previous attempt failed to produce valid JSON)"},
                     {"role": "user", "content": RETRY_PROMPT},
                 ]
 
@@ -1006,9 +957,7 @@ async def _extract_chunk(
             if attempt < max_retries - 1:
                 logger.warning(
                     "Extraction parse failed (attempt %d/%d): %s",
-                    attempt + 1,
-                    max_retries,
-                    exc,
+                    attempt + 1, max_retries, exc,
                 )
                 continue
             return ExtractionResult(
@@ -1020,9 +969,7 @@ async def _extract_chunk(
             )
         except Exception as exc:
             logger.error(
-                "Extraction LLM call failed: %s",
-                exc,
-                exc_info=True,
+                "Extraction LLM call failed: %s", exc, exc_info=True,
             )
             return ExtractionResult(
                 extractions=[],

--- a/src/genesis/resilience/cc_budget.py
+++ b/src/genesis/resilience/cc_budget.py
@@ -47,21 +47,37 @@ class CCBudgetTracker:
                 """INSERT INTO cc_sessions
                    (id, session_type, model, started_at, last_activity_at, status, source_tag)
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (str(uuid.uuid4()), session_type, "sonnet", now, now, "active", f"priority_{priority}"),
+                (
+                    str(uuid.uuid4()),
+                    session_type,
+                    "sonnet",
+                    now,
+                    now,
+                    "active",
+                    f"priority_{priority}",
+                ),
             )
             await self._db.commit()
         except Exception:
             logger.error(
                 "CC budget record FAILED: session_type=%s priority=%d",
-                session_type, priority, exc_info=True,
+                session_type,
+                priority,
+                exc_info=True,
             )
 
     async def _count_recent_sessions(self) -> int:
-        """Count sessions started in the last hour (active or completed)."""
+        """Count sessions started in the last hour (active or completed).
+
+        Voice conversation rows (source_tag='voice') are transcript-index
+        entries, not CC invocations — they must not consume the budget or
+        trigger throttling.
+        """
         cutoff = (self._clock() - timedelta(hours=1)).isoformat()
         cursor = await self._db.execute(
             """SELECT COUNT(*) FROM cc_sessions
-               WHERE started_at > ? AND status IN ('active', 'completed', 'expired')""",
+               WHERE started_at > ? AND status IN ('active', 'completed', 'expired')
+                 AND source_tag != 'voice'""",
             (cutoff,),
         )
         row = await cursor.fetchone()

--- a/src/genesis/resilience/cc_budget.py
+++ b/src/genesis/resilience/cc_budget.py
@@ -47,23 +47,13 @@ class CCBudgetTracker:
                 """INSERT INTO cc_sessions
                    (id, session_type, model, started_at, last_activity_at, status, source_tag)
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    str(uuid.uuid4()),
-                    session_type,
-                    "sonnet",
-                    now,
-                    now,
-                    "active",
-                    f"priority_{priority}",
-                ),
+                (str(uuid.uuid4()), session_type, "sonnet", now, now, "active", f"priority_{priority}"),
             )
             await self._db.commit()
         except Exception:
             logger.error(
                 "CC budget record FAILED: session_type=%s priority=%d",
-                session_type,
-                priority,
-                exc_info=True,
+                session_type, priority, exc_info=True,
             )
 
     async def _count_recent_sessions(self) -> int:

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -190,6 +190,45 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
         misfire_grace_time=3600,
     )
 
+    async def _voice_hygiene() -> None:
+        # Three observable-state duties (channels/voice/hygiene.py):
+        # transcript files past the 1-year retention, legacy one-blob voice
+        # memories from stale producers (a job, not a data migration — the
+        # migration runner never re-runs, so it couldn't sweep blobs written
+        # by a not-yet-updated edge bridge), and orphaned 'active' voice
+        # session rows (crash between conversation start and close).
+        if rt._db is None:
+            return
+        try:
+            from genesis.channels.voice import hygiene as _vh
+            from genesis.db.crud import cc_sessions as _sessions
+
+            pruned = await _vh.prune_old_transcripts(rt._db)
+            healed = await _sessions.complete_orphaned_voice_sessions(rt._db)
+            swept = 0
+            if rt._memory_store is not None:
+                swept = await _vh.sweep_blob_memories(rt._db, rt._memory_store)
+            rt.record_job_success("voice_hygiene")
+            if pruned or swept or healed:
+                logger.info(
+                    "voice hygiene: pruned %d transcript(s), swept %d blob "
+                    "memor(ies), healed %d orphan row(s)",
+                    pruned,
+                    swept,
+                    healed,
+                )
+        except Exception as exc:
+            rt.record_job_failure("voice_hygiene", str(exc))
+            logger.exception("voice hygiene failed")
+
+    scheduler.add_job(
+        _voice_hygiene,
+        CronTrigger(hour=5, minute=50, timezone=user_timezone()),
+        id="voice_hygiene",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
 
 async def init(rt: GenesisRuntime) -> None:
     """Initialize learning pipeline, triage, calibration, harvest, and all scheduled jobs."""

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -200,11 +200,16 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
         if rt._db is None:
             return
         try:
+            from datetime import timedelta
+
             from genesis.channels.voice import hygiene as _vh
             from genesis.db.crud import cc_sessions as _sessions
 
             pruned = await _vh.prune_old_transcripts(rt._db)
-            healed = await _sessions.complete_orphaned_voice_sessions(rt._db)
+            idle_cutoff = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+            healed = await _sessions.complete_orphaned_voice_sessions(
+                rt._db, idle_before=idle_cutoff,
+            )
             swept = 0
             if rt._memory_store is not None:
                 swept = await _vh.sweep_blob_memories(rt._db, rt._memory_store)

--- a/tests/test_channels/test_voice_conversation_route.py
+++ b/tests/test_channels/test_voice_conversation_route.py
@@ -1,0 +1,192 @@
+"""Tests for POST /v1/voice/conversation (W0.5 extraction parity landing).
+
+Same minimal-Flask-app + daemon-thread-loop fixture shape as
+``TestVoiceGraduate``; the writer is mocked at the ``get_shared_writer``
+seam — writer behavior itself is covered in
+``tests/test_channels/test_voice_transcript_writer.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _body(n_turns: int = 2, **overrides) -> dict:
+    data = {
+        "session_id": "edge-cache-0001",
+        "satellite_id": "pe-livingroom",
+        "turns": [
+            {"role": "user" if i % 2 == 0 else "assistant", "text": f"turn {i}"}
+            for i in range(n_turns)
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+class TestVoiceConversation:
+    @pytest.fixture
+    def app(self):
+        from flask import Flask
+
+        from genesis.dashboard.routes.voice_api import voice_api_bp
+
+        app = Flask(__name__)
+        app.register_blueprint(voice_api_bp)
+        loop = asyncio.new_event_loop()
+        app.config["GENESIS_EVENT_LOOP"] = loop
+        yield app
+        loop.close()
+
+    @contextmanager
+    def _running_loop(self, app):
+        loop = app.config["GENESIS_EVENT_LOOP"]
+
+        def run_loop():
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        t = threading.Thread(target=run_loop, daemon=True)
+        t.start()
+        try:
+            yield
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            t.join(timeout=2)
+
+    @contextmanager
+    def _ready_runtime(self, appended=2):
+        rt = MagicMock()
+        rt.is_bootstrapped = True
+        rt.db = object()
+        writer = MagicMock()
+        writer.sync_cumulative = AsyncMock(return_value=appended)
+        get_writer = AsyncMock(return_value=writer)
+        with (
+            patch("genesis.runtime.GenesisRuntime") as runtime_cls,
+            patch(
+                "genesis.channels.voice.transcript_writer.get_shared_writer",
+                get_writer,
+            ),
+        ):
+            runtime_cls.instance.return_value = rt
+            yield rt, writer
+
+    _AUTH = {"Authorization": "Bearer secret"}
+    _ENV = {"GENESIS_MCP_HTTP_TOKEN": "secret"}
+
+    def test_ok_and_writer_args(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            self._ready_runtime() as (_rt, writer),
+            self._running_loop(app),
+            app.test_client() as client,
+        ):
+            body = _body(4)
+            resp = client.post("/v1/voice/conversation", json=body, headers=self._AUTH)
+            assert resp.status_code == 200
+            assert resp.get_json() == {"status": "ok", "appended": 2}
+            writer.sync_cumulative.assert_awaited_once_with(
+                body["session_id"],
+                body["turns"],
+            )
+
+    def test_replay_returns_zero_appended(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            self._ready_runtime(appended=0),
+            self._running_loop(app),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/conversation", json=_body(), headers=self._AUTH)
+            assert resp.status_code == 200
+            assert resp.get_json() == {"status": "ok", "appended": 0}
+
+    def test_invalid_body_rejected_before_any_dispatch(self, app):
+        # No running loop on purpose — validation must answer without it.
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            self._ready_runtime() as (_rt, writer),
+            app.test_client() as client,
+        ):
+            resp = client.post(
+                "/v1/voice/conversation",
+                json=_body(turns=[{"role": "narrator", "text": "hi"}]),
+                headers=self._AUTH,
+            )
+            assert resp.status_code == 400
+            assert resp.get_json()["status"] == "rejected"
+            writer.sync_cumulative.assert_not_awaited()
+
+    @pytest.mark.parametrize("body", ["[1, 2, 3]", '"hello"', "42"])
+    def test_non_object_json_body_rejected(self, app, body):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post(
+                "/v1/voice/conversation",
+                data=body,
+                content_type="application/json",
+                headers=self._AUTH,
+            )
+            assert resp.status_code == 400
+            assert resp.get_json()["status"] == "rejected"
+
+    def test_oversized_body_rejected(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            big = _body(turns=[{"role": "user", "text": "x" * (270 * 1024)}])
+            resp = client.post("/v1/voice/conversation", json=big, headers=self._AUTH)
+            assert resp.status_code == 400
+            assert "256KB" in resp.get_json()["errors"][0]
+
+    def test_auth_required_bad_bearer(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post(
+                "/v1/voice/conversation",
+                json=_body(),
+                headers={"Authorization": "Bearer wrong"},
+            )
+            assert resp.status_code == 401
+
+    def test_fail_closed_when_token_unset(self, app):
+        with (
+            patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/conversation", json=_body())
+            assert resp.status_code == 503
+
+    def test_runtime_not_ready_is_503(self, app):
+        rt = MagicMock()
+        rt.is_bootstrapped = False
+        rt.db = None
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            patch("genesis.runtime.GenesisRuntime") as runtime_cls,
+            self._running_loop(app),
+            app.test_client() as client,
+        ):
+            runtime_cls.instance.return_value = rt
+            resp = client.post("/v1/voice/conversation", json=_body(), headers=self._AUTH)
+            assert resp.status_code == 503
+            assert "not ready" in resp.get_json()["error"]
+
+    def test_loop_not_running_is_503(self, app):
+        with (
+            patch.dict("os.environ", self._ENV, clear=False),
+            app.test_client() as client,
+        ):
+            resp = client.post("/v1/voice/conversation", json=_body(), headers=self._AUTH)
+            assert resp.status_code == 503

--- a/tests/test_channels/test_voice_hygiene.py
+++ b/tests/test_channels/test_voice_hygiene.py
@@ -1,0 +1,145 @@
+"""Tests for daily voice hygiene: transcript aging + stale-producer blob sweep."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.channels.voice.hygiene import (
+    prune_old_transcripts,
+    sweep_blob_memories,
+)
+from genesis.db.crud import cc_sessions as sessions_crud
+
+pytestmark = pytest.mark.asyncio
+
+_BLOB_TAGS = "voice s2s conversation class:fact wing:channels"
+
+
+def _iso_days_ago(days: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+
+# ── transcript prune ─────────────────────────────────────────────────
+
+
+class TestPruneOldTranscripts:
+    async def _seed(self, db, tmp_path, name: str, *, started_days_ago: int, status: str):
+        await sessions_crud.register_voice_session(
+            db,
+            id=name,
+            started_at=_iso_days_ago(started_days_ago),
+        )
+        if status != "active":
+            await sessions_crud.update_status(db, name, status=status)
+        path = tmp_path / f"{name}.jsonl"
+        path.write_text('{"type":"user","message":{"content":"hi"}}\n')
+        return path
+
+    async def test_prunes_only_old_completed(self, db, tmp_path):
+        old = await self._seed(db, tmp_path, "old-done", started_days_ago=400, status="completed")
+        recent = await self._seed(db, tmp_path, "recent", started_days_ago=30, status="completed")
+        removed = await prune_old_transcripts(db, transcript_dir=tmp_path)
+        assert removed == 1
+        assert not old.exists()
+        assert recent.exists()
+
+    async def test_never_prunes_active_session(self, db, tmp_path):
+        path = await self._seed(db, tmp_path, "old-active", started_days_ago=400, status="active")
+        assert await prune_old_transcripts(db, transcript_dir=tmp_path) == 0
+        assert path.exists()
+
+    async def test_rowless_file_falls_back_to_mtime(self, db, tmp_path):
+        old = tmp_path / "rowless-old.jsonl"
+        old.write_text("{}\n")
+        stamp = (datetime.now(UTC) - timedelta(days=400)).timestamp()
+        os.utime(old, (stamp, stamp))
+        fresh = tmp_path / "rowless-fresh.jsonl"
+        fresh.write_text("{}\n")
+        assert await prune_old_transcripts(db, transcript_dir=tmp_path) == 1
+        assert not old.exists()
+        assert fresh.exists()
+
+    async def test_missing_dir_noops(self, db, tmp_path):
+        assert await prune_old_transcripts(db, transcript_dir=tmp_path / "nope") == 0
+
+
+# ── blob sweep ───────────────────────────────────────────────────────
+
+
+class TestSweepBlobMemories:
+    async def _seed_fts(self, db, memory_id: str, content: str, tags: str):
+        await db.execute(
+            "INSERT INTO memory_fts (memory_id, content, source_type, tags, collection) "
+            "VALUES (?, ?, 'memory', ?, 'episodic_memory')",
+            (memory_id, content, tags),
+        )
+        await db.commit()
+
+    def _store(self) -> MagicMock:
+        store = MagicMock()
+        store.delete = AsyncMock(return_value={"fts5": True})
+        return store
+
+    async def test_sweeps_exactly_the_blob_cohort(self, db):
+        # The cohort: voice-tagged AND the legacy blob content prefix
+        await self._seed_fts(
+            db,
+            "blob-1",
+            "Voice conversation [s2s-default]:\nUser: hi",
+            _BLOB_TAGS,
+        )
+        await self._seed_fts(
+            db,
+            "blob-2",
+            "Voice conversation [pe]:\nUser: yo\nGenesis: hey",
+            _BLOB_TAGS,
+        )
+        # Voice-tagged but NOT the blob signature — must survive
+        await self._seed_fts(
+            db,
+            "legit-voice",
+            "User asked about ice cream via voice",
+            _BLOB_TAGS,
+        )
+        # Unrelated memory — must survive
+        await self._seed_fts(
+            db,
+            "unrelated",
+            "Voice conversation preferences discussion",
+            "notes wing:memory",
+        )
+        # Dangling SVO event for a blob (store.delete does not cover this table)
+        await db.execute(
+            "INSERT INTO memory_events (id, memory_id, subject, verb) "
+            "VALUES ('ev1', 'blob-1', 's', 'v')",
+        )
+        await db.commit()
+
+        store = self._store()
+        assert await sweep_blob_memories(db, store) == 2
+        deleted = {c.args[0] for c in store.delete.await_args_list}
+        assert deleted == {"blob-1", "blob-2"}
+
+        cur = await db.execute("SELECT COUNT(*) FROM memory_events WHERE memory_id='blob-1'")
+        assert (await cur.fetchone())[0] == 0
+
+    async def test_no_candidates_noops(self, db):
+        await self._seed_fts(db, "other", "unrelated content", "notes wing:memory")
+        store = self._store()
+        assert await sweep_blob_memories(db, store) == 0
+        store.delete.assert_not_awaited()
+
+    async def test_sweep_logs_loudly(self, db, caplog):
+        await self._seed_fts(
+            db,
+            "blob-1",
+            "Voice conversation [s2s-default]:\nUser: hi",
+            _BLOB_TAGS,
+        )
+        with caplog.at_level("WARNING"):
+            await sweep_blob_memories(db, self._store())
+        assert any("stale producer" in r.message for r in caplog.records)

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -51,10 +51,13 @@ class TestVoiceConfig:
             assert not s2s_enabled()
 
     def test_s2s_enabled_gemini(self):
-        with patch.dict("os.environ", {
-            "VOICE_S2S_PROVIDER": "gemini",
-            "GOOGLE_API_KEY": "test",
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "VOICE_S2S_PROVIDER": "gemini",
+                "GOOGLE_API_KEY": "test",
+            },
+        ):
             assert s2s_enabled()
 
 
@@ -90,7 +93,8 @@ class TestGenesisBridge:
     async def test_ask_genesis_no_handler(self):
         bridge = GenesisBridge()
         result = await bridge.handle_tool_call(
-            "ask_genesis", json.dumps({"query": "test"}),
+            "ask_genesis",
+            json.dumps({"query": "test"}),
         )
         data = json.loads(result)
         assert "answer" in data  # Returns "handler not available"
@@ -101,7 +105,8 @@ class TestGenesisBridge:
 
         bridge = GenesisBridge(voice_handler=handler)
         result = await bridge.handle_tool_call(
-            "ask_genesis", json.dumps({"query": "what did we do yesterday?"}),
+            "ask_genesis",
+            json.dumps({"query": "what did we do yesterday?"}),
         )
         data = json.loads(result)
         assert "answer" in data
@@ -140,7 +145,8 @@ class TestGenesisBridge:
 
         bridge = GenesisBridge(voice_handler=handler)
         result = await bridge.handle_tool_call(
-            "ask_genesis", json.dumps({"query": "test"}),
+            "ask_genesis",
+            json.dumps({"query": "test"}),
         )
         data = json.loads(result)
         assert "answer" in data
@@ -150,7 +156,8 @@ class TestGenesisBridge:
     async def test_web_search_import_failure(self):
         bridge = GenesisBridge()
         result = await bridge.handle_tool_call(
-            "web_search", json.dumps({"query": "weather"}),
+            "web_search",
+            json.dumps({"query": "weather"}),
         )
         data = json.loads(result)
         assert isinstance(data, dict)
@@ -165,7 +172,8 @@ class TestGenesisBridge:
     async def test_approve_pending_no_gate(self):
         bridge = GenesisBridge()
         result = await bridge.handle_tool_call(
-            "approve_pending", json.dumps({"decision": "approved"}),
+            "approve_pending",
+            json.dumps({"decision": "approved"}),
         )
         data = json.loads(result)
         assert "error" in data
@@ -173,27 +181,38 @@ class TestGenesisBridge:
 
     async def test_approve_pending_success(self):
         gate = AsyncMock()
-        gate.resolve_pending_voice = AsyncMock(return_value={
-            "status": "resolved", "request_id": "abc12345", "label": "run tests",
-        })
+        gate.resolve_pending_voice = AsyncMock(
+            return_value={
+                "status": "resolved",
+                "request_id": "abc12345",
+                "label": "run tests",
+            }
+        )
 
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
-            "approve_pending", json.dumps({"decision": "approved"}),
+            "approve_pending",
+            json.dumps({"decision": "approved"}),
         )
         data = json.loads(result)
         assert "result" in data
         assert "approved" in data["result"]
         assert data["action"] == "run tests"
         gate.resolve_pending_voice.assert_awaited_once_with(
-            decision="approved", resolved_by="voice:s2s", request_id=None,
+            decision="approved",
+            resolved_by="voice:s2s",
+            request_id=None,
         )
 
     async def test_approve_pending_by_id(self):
         gate = AsyncMock()
-        gate.resolve_pending_voice = AsyncMock(return_value={
-            "status": "resolved", "request_id": "id-2", "label": "send email",
-        })
+        gate.resolve_pending_voice = AsyncMock(
+            return_value={
+                "status": "resolved",
+                "request_id": "id-2",
+                "label": "send email",
+            }
+        )
 
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
@@ -203,22 +222,27 @@ class TestGenesisBridge:
         data = json.loads(result)
         assert "result" in data
         gate.resolve_pending_voice.assert_awaited_once_with(
-            decision="approved", resolved_by="voice:s2s", request_id="id-2",
+            decision="approved",
+            resolved_by="voice:s2s",
+            request_id="id-2",
         )
 
     async def test_approve_pending_ambiguous_asks_which(self):
         gate = AsyncMock()
-        gate.resolve_pending_voice = AsyncMock(return_value={
-            "status": "ambiguous",
-            "candidates": [
-                {"id": "id-1", "label": "run tests"},
-                {"id": "id-2", "label": "send email"},
-            ],
-        })
+        gate.resolve_pending_voice = AsyncMock(
+            return_value={
+                "status": "ambiguous",
+                "candidates": [
+                    {"id": "id-1", "label": "run tests"},
+                    {"id": "id-2", "label": "send email"},
+                ],
+            }
+        )
 
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
-            "approve_pending", json.dumps({"decision": "approved"}),
+            "approve_pending",
+            json.dumps({"decision": "approved"}),
         )
         data = json.loads(result)
         assert "needs_clarification" in data
@@ -243,7 +267,8 @@ class TestGenesisBridge:
 
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
-            "approve_pending", json.dumps({"decision": "rejected"}),
+            "approve_pending",
+            json.dumps({"decision": "rejected"}),
         )
         data = json.loads(result)
         assert "error" in data
@@ -253,7 +278,8 @@ class TestGenesisBridge:
         gate = AsyncMock()
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
-            "approve_pending", json.dumps({"decision": "maybe"}),
+            "approve_pending",
+            json.dumps({"decision": "maybe"}),
         )
         data = json.loads(result)
         assert "error" in data
@@ -292,41 +318,52 @@ class TestGenesisBridge:
         try:
             mgr = ApprovalManager(db=conn)
             rid1 = await mgr.request_approval(
-                action_type="sentinel_dispatch", action_class="reversible",
+                action_type="sentinel_dispatch",
+                action_class="reversible",
                 description="investigate the disk alert",
             )
             rid2 = await mgr.request_approval(
-                action_type="autonomous_cli_fallback", action_class="reversible",
+                action_type="autonomous_cli_fallback",
+                action_class="reversible",
                 description="run the deploy script",
             )
             gate = AutonomousCliApprovalGate(
-                runtime=MagicMock(), approval_manager=mgr,
+                runtime=MagicMock(),
+                approval_manager=mgr,
             )
             bridge = GenesisBridge(approval_gate=gate)
 
             # Two pending -> bare "approve" refuses to guess.
-            amb = json.loads(await bridge.handle_tool_call(
-                "approve_pending", json.dumps({"decision": "approved"}),
-            ))
+            amb = json.loads(
+                await bridge.handle_tool_call(
+                    "approve_pending",
+                    json.dumps({"decision": "approved"}),
+                )
+            )
             assert "needs_clarification" in amb
             assert {p["request_id"] for p in amb["pending"]} == {rid1, rid2}
             assert (await mgr.get_by_id(rid1))["status"] == "pending"
             assert (await mgr.get_by_id(rid2))["status"] == "pending"
 
             # Resolve the specific one by id.
-            ok = json.loads(await bridge.handle_tool_call(
-                "approve_pending",
-                json.dumps({"decision": "approved", "request_id": rid2}),
-            ))
+            ok = json.loads(
+                await bridge.handle_tool_call(
+                    "approve_pending",
+                    json.dumps({"decision": "approved", "request_id": rid2}),
+                )
+            )
             assert ok["result"] == "Request approved"
             assert ok["action"] == "run the deploy script"
             assert (await mgr.get_by_id(rid2))["status"] == "approved"
             assert (await mgr.get_by_id(rid1))["status"] == "pending"
 
             # Now only one pending -> unambiguous resolution.
-            ok2 = json.loads(await bridge.handle_tool_call(
-                "approve_pending", json.dumps({"decision": "rejected"}),
-            ))
+            ok2 = json.loads(
+                await bridge.handle_tool_call(
+                    "approve_pending",
+                    json.dumps({"decision": "rejected"}),
+                )
+            )
             assert ok2["result"] == "Request rejected"
             assert (await mgr.get_by_id(rid1))["status"] == "rejected"
         finally:
@@ -601,59 +638,103 @@ class TestS2SSessionManager:
         assert out == "hi there"
         assert "sat-1" not in mgr._sessions
 
-    async def test_close_stores_transcript(self):
+    async def test_close_finalizes_transcript_session_not_a_blob_store(self):
+        """W0.5: close() marks the transcript session completed — the legacy
+        one-blob memory_store landing is gone (turns are written per-turn
+        via _record_turn as the conversation happens)."""
         from genesis.channels.voice.s2s_session import S2SSessionManager
 
-        store = AsyncMock()
-        store.store = AsyncMock(return_value="mem-123")
+        writer = MagicMock()
+        writer.close_session = AsyncMock()
+        writer.append_message = AsyncMock()
 
         bridge = GenesisBridge()
-        mgr = S2SSessionManager(bridge=bridge, memory_store=store)
+        mgr = S2SSessionManager(bridge=bridge, transcript_writer=writer)
         session = await mgr.get_or_create("sat-1")
         session.input_transcript = "What did we work on?"
         session.output_transcript = "We worked on voice pipeline."
 
         await mgr.close("sat-1")
 
-        store.store.assert_awaited_once()
-        call_kwargs = store.store.call_args
-        content = call_kwargs[0][0]  # first positional arg
-        assert "What did we work on?" in content
-        assert "We worked on voice pipeline." in content
-        assert call_kwargs[1]["source"] == "voice_s2s"
-        assert call_kwargs[1]["wing"] == "channels"
-        assert call_kwargs[1]["room"] == "voice"
+        writer.close_session.assert_awaited_once_with(session.session_id)
+        assert not hasattr(mgr, "_memory_store")
 
-    async def test_close_skips_store_when_empty(self):
+    async def test_close_skips_finalize_when_empty(self):
         from genesis.channels.voice.s2s_session import S2SSessionManager
 
-        store = AsyncMock()
-        store.store = AsyncMock()
+        writer = MagicMock()
+        writer.close_session = AsyncMock()
 
         bridge = GenesisBridge()
-        mgr = S2SSessionManager(bridge=bridge, memory_store=store)
+        mgr = S2SSessionManager(bridge=bridge, transcript_writer=writer)
         await mgr.get_or_create("sat-1")
         # No transcripts set
 
         await mgr.close("sat-1")
-        store.store.assert_not_awaited()
+        writer.close_session.assert_not_awaited()
 
-    async def test_close_handles_store_failure(self):
+    async def test_close_handles_writer_failure(self):
         from genesis.channels.voice.s2s_session import S2SSessionManager
 
-        store = AsyncMock()
-        store.store = AsyncMock(side_effect=Exception("DB error"))
+        writer = MagicMock()
+        writer.close_session = AsyncMock(side_effect=Exception("DB error"))
 
         bridge = GenesisBridge()
-        mgr = S2SSessionManager(bridge=bridge, memory_store=store)
+        mgr = S2SSessionManager(bridge=bridge, transcript_writer=writer)
         session = await mgr.get_or_create("sat-1")
         session.input_transcript = "hello"
         session.output_transcript = "hi"
 
-        # Should not raise — store failure is best-effort
+        # Should not raise — transcript finalize is best-effort
         inp, out = await mgr.close("sat-1")
         assert inp == "hello"
         assert out == "hi"
+
+    async def test_record_turn_writes_through_writer(self):
+        from genesis.channels.voice.s2s_session import S2SSessionManager
+
+        writer = MagicMock()
+        writer.append_message = AsyncMock()
+
+        bridge = GenesisBridge()
+        mgr = S2SSessionManager(bridge=bridge, transcript_writer=writer)
+        session = await mgr.get_or_create("sat-1")
+
+        await mgr._record_turn(session, "user", "what time is it")
+        await mgr._record_turn(session, "assistant", "half past three")
+        assert writer.append_message.await_args_list[0].args == (
+            session.session_id,
+            "user",
+            "what time is it",
+        )
+        assert writer.append_message.await_args_list[1].args == (
+            session.session_id,
+            "assistant",
+            "half past three",
+        )
+
+    async def test_record_turn_skips_blank_and_survives_writer_error(self):
+        from genesis.channels.voice.s2s_session import S2SSessionManager
+
+        writer = MagicMock()
+        writer.append_message = AsyncMock(side_effect=Exception("disk full"))
+
+        bridge = GenesisBridge()
+        mgr = S2SSessionManager(bridge=bridge, transcript_writer=writer)
+        session = await mgr.get_or_create("sat-1")
+
+        await mgr._record_turn(session, "user", "   ")
+        writer.append_message.assert_not_awaited()
+        # Error path must not raise (best-effort recording)
+        await mgr._record_turn(session, "user", "hello")
+
+    async def test_record_turn_noop_without_writer(self):
+        from genesis.channels.voice.s2s_session import S2SSessionManager
+
+        bridge = GenesisBridge()
+        mgr = S2SSessionManager(bridge=bridge)
+        session = await mgr.get_or_create("sat-1")
+        await mgr._record_turn(session, "user", "hello")  # must not raise
 
 
 # ─── Voice hours + _should_voice tests ─────────────────────────────────
@@ -736,7 +817,9 @@ class TestVoiceHours:
         pipe = self._make_pipeline(has_voice=False)
         req = OutreachRequest(
             category=OutreachCategory.ALERT,
-            topic="test", context="test", salience_score=1.0,
+            topic="test",
+            context="test",
+            salience_score=1.0,
             source_id="infra:disk_low",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=True):
@@ -756,7 +839,10 @@ class TestVoiceHours:
             OutreachCategory.APPROVAL,
         ):
             req = OutreachRequest(
-                category=cat, topic="t", context="t", salience_score=1.0,
+                category=cat,
+                topic="t",
+                context="t",
+                salience_score=1.0,
             )
             with patch.object(pipe, "_in_voice_hours", return_value=True):
                 assert not pipe._should_voice(req), f"category={cat}"
@@ -768,8 +854,11 @@ class TestVoiceHours:
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
-            signal_type="health_alert", source_id="infra:disk_low",
+            topic="t",
+            context="t",
+            salience_score=1.0,
+            signal_type="health_alert",
+            source_id="infra:disk_low",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=True):
             assert pipe._should_voice(req)
@@ -781,7 +870,9 @@ class TestVoiceHours:
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
+            topic="t",
+            context="t",
+            salience_score=1.0,
             signal_type="health_alert",
             source_id="queue:stale_dead_letters,infra:disk_low",
         )
@@ -795,7 +886,9 @@ class TestVoiceHours:
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
+            topic="t",
+            context="t",
+            salience_score=1.0,
             signal_type="sentinel_escalation",
             source_id="sentinel-escalation:mem:123",
         )
@@ -816,8 +909,11 @@ class TestVoiceHours:
         ):
             req = OutreachRequest(
                 category=OutreachCategory.ALERT,
-                topic="t", context="t", salience_score=1.0,
-                signal_type=signal, source_id="task:abc123",
+                topic="t",
+                context="t",
+                salience_score=1.0,
+                signal_type=signal,
+                source_id="task:abc123",
             )
             with patch.object(pipe, "_in_voice_hours", return_value=True):
                 assert pipe._should_voice(req) is expected, f"signal={signal}"
@@ -829,7 +925,9 @@ class TestVoiceHours:
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
+            topic="t",
+            context="t",
+            salience_score=1.0,
             signal_type="critical_observation",
             source_id="obs-uuid-1,obs-uuid-2",
         )
@@ -843,8 +941,11 @@ class TestVoiceHours:
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.APPROVAL,
-            topic="t", context="t", salience_score=1.0,
-            signal_type="cli_approval", source_id="cli-approval:42",
+            topic="t",
+            context="t",
+            salience_score=1.0,
+            signal_type="cli_approval",
+            source_id="cli-approval:42",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=True):
             assert not pipe._should_voice(req)
@@ -856,7 +957,9 @@ class TestVoiceHours:
         pipe = self._make_pipeline(voice_alert_ids=("provider:credit_exhaustion",))
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
+            topic="t",
+            context="t",
+            salience_score=1.0,
             source_id="provider:credit_exhaustion:deepinfra",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=True):
@@ -869,7 +972,9 @@ class TestVoiceHours:
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="t", context="t", salience_score=1.0,
+            topic="t",
+            context="t",
+            salience_score=1.0,
             source_id="infra:disk_low",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=False):

--- a/tests/test_channels/test_voice_transcript_writer.py
+++ b/tests/test_channels/test_voice_transcript_writer.py
@@ -146,11 +146,20 @@ class TestVoiceTranscriptWriter:
         assert await w2.sync_cumulative("edge-1", _turns(3)) == 0
         assert await w2.sync_cumulative("edge-1", _turns(4)) == 1
 
-    async def test_heal_orphans_completes_only_voice_actives(self, db, tmp_path):
+    async def test_heal_orphans_completes_only_idle_voice_actives(self, db, tmp_path):
+        from datetime import UTC, datetime
+
         await sessions_crud.register_voice_session(
             db,
             id="voice-orphan",
             started_at="2026-07-01T00:00:00+00:00",
+        )
+        # A voice session active RIGHT NOW (fresh last_activity_at) must
+        # never be healed mid-call — the idle gate protects it.
+        await sessions_crud.register_voice_session(
+            db,
+            id="voice-live",
+            started_at=datetime.now(UTC).isoformat(),
         )
         await sessions_crud.create(
             db,
@@ -164,7 +173,24 @@ class TestVoiceTranscriptWriter:
         writer = VoiceTranscriptWriter(db, transcript_dir=tmp_path / "voice")
         assert await writer.heal_orphans() == 1
         assert (await sessions_crud.get_by_id(db, "voice-orphan"))["status"] == "completed"
+        assert (await sessions_crud.get_by_id(db, "voice-live"))["status"] == "active"
         assert (await sessions_crud.get_by_id(db, "cc-foreground"))["status"] == "active"
+
+    async def test_empty_cumulative_sync_registers_nothing(self, writer, db, tmp_path):
+        assert await writer.sync_cumulative("edge-empty", []) == 0
+        sid = transcript_session_id("edge-empty")
+        assert await sessions_crud.get_by_id(db, sid) is None
+        assert not (tmp_path / "voice" / f"{sid}.jsonl").exists()
+
+    async def test_append_failure_raises_not_swallows(self, db, tmp_path):
+        """Durable-before-ack: an unwritable transcript dir must RAISE (the
+        route answers 5xx and the producer retries) — a swallowed error
+        would ack turns that were never written."""
+        blocked = tmp_path / "blocked"
+        blocked.write_text("a file, not a dir")
+        writer = VoiceTranscriptWriter(db, transcript_dir=blocked)
+        with pytest.raises(OSError):
+            await writer.sync_cumulative("edge-1", _turns(2))
 
     async def test_append_ignores_invalid_role_and_blank_text(self, writer, tmp_path):
         await writer.append_message("edge-1", "system", "nope")

--- a/tests/test_channels/test_voice_transcript_writer.py
+++ b/tests/test_channels/test_voice_transcript_writer.py
@@ -1,0 +1,173 @@
+"""Tests for the voice transcript writer (W0.5 extraction parity).
+
+The round-trip tests parse writer output with the REAL
+``read_transcript_messages`` — the writer's whole contract is producing
+transcripts the extraction job can mine, so the real parser is the oracle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.channels.voice.transcript_writer import (
+    VoiceTranscriptWriter,
+    transcript_session_id,
+    validate_conversation,
+)
+from genesis.db.crud import cc_sessions as sessions_crud
+from genesis.util.jsonl import read_transcript_messages
+
+
+def _turns(n: int) -> list[dict]:
+    out = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        out.append({"role": role, "text": f"turn {i}"})
+    return out
+
+
+# ── validate_conversation (pure) ─────────────────────────────────────
+
+
+class TestValidateConversation:
+    def test_valid_body_passes(self):
+        body = {"session_id": "edge-1", "satellite_id": "pe", "turns": _turns(4)}
+        assert validate_conversation(body) == []
+
+    def test_empty_turns_list_is_valid(self):
+        assert validate_conversation({"session_id": "s", "turns": []}) == []
+
+    @pytest.mark.parametrize(
+        ("overrides", "fragment"),
+        [
+            ({"session_id": ""}, "session_id"),
+            ({"session_id": 42}, "session_id"),
+            ({"session_id": "x" * 200}, "128"),
+            ({"satellite_id": 7}, "satellite_id"),
+            ({"turns": "nope"}, "turns"),
+            ({"turns": [{"role": "system", "text": "hi"}]}, "role"),
+            ({"turns": [{"role": "user", "text": ""}]}, "text"),
+            ({"turns": [{"role": "user"}]}, "text"),
+            ({"turns": ["not-a-dict"]}, "object"),
+        ],
+    )
+    def test_each_violation_yields_its_error(self, overrides, fragment):
+        body = {"session_id": "edge-1", "turns": _turns(2)}
+        body.update(overrides)
+        errors = validate_conversation(body)
+        assert errors, f"expected errors for {overrides}"
+        assert any(fragment in e for e in errors)
+
+
+# ── deterministic session identity ───────────────────────────────────
+
+
+def test_transcript_session_id_deterministic_and_distinct():
+    assert transcript_session_id("a") == transcript_session_id("a")
+    assert transcript_session_id("a") != transcript_session_id("b")
+    # Valid UUID shape (used as filename + cc_sessions primary key)
+    import uuid
+
+    uuid.UUID(transcript_session_id("a"))
+
+
+# ── writer behavior (real DB + real parser) ──────────────────────────
+
+
+@pytest.mark.asyncio
+class TestVoiceTranscriptWriter:
+    @pytest.fixture
+    def writer(self, db, tmp_path):
+        return VoiceTranscriptWriter(db, transcript_dir=tmp_path / "voice")
+
+    async def test_append_round_trips_through_real_parser(self, writer, tmp_path):
+        await writer.append_message("s2s-pe-1", "user", "what time is it")
+        await writer.append_message("s2s-pe-1", "assistant", "half past three")
+        await writer.append_message("s2s-pe-1", "user", "thanks")
+
+        sid = transcript_session_id("s2s-pe-1")
+        messages = read_transcript_messages(tmp_path / "voice" / f"{sid}.jsonl")
+        assert [(m.role, m.text) for m in messages] == [
+            ("user", "what time is it"),
+            ("assistant", "half past three"),
+            ("user", "thanks"),
+        ]
+        assert all(m.timestamp for m in messages)
+
+    async def test_registers_voice_session_row_once(self, writer, db):
+        await writer.append_message("s2s-pe-1", "user", "hello")
+        await writer.append_message("s2s-pe-1", "assistant", "hi")
+
+        sid = transcript_session_id("s2s-pe-1")
+        row = await sessions_crud.get_by_id(db, sid)
+        assert row is not None
+        assert row["source_tag"] == "voice"
+        assert row["channel"] == "voice_s2s"
+        assert row["session_type"] == "foreground"
+        assert row["status"] == "active"
+        assert row["cc_session_id"] == sid
+
+    async def test_close_session_completes_row(self, writer, db):
+        await writer.append_message("s2s-pe-1", "user", "hello")
+        await writer.close_session("s2s-pe-1")
+        row = await sessions_crud.get_by_id(db, transcript_session_id("s2s-pe-1"))
+        assert row["status"] == "completed"
+
+    async def test_sync_cumulative_is_idempotent(self, writer):
+        assert await writer.sync_cumulative("edge-1", _turns(3)) == 3
+        # Exact replay (edge double-fire) appends nothing
+        assert await writer.sync_cumulative("edge-1", _turns(3)) == 0
+        # Superset appends only the delta
+        assert await writer.sync_cumulative("edge-1", _turns(5)) == 2
+
+    async def test_sync_cumulative_replay_leaves_file_identical(self, writer, tmp_path):
+        await writer.sync_cumulative("edge-1", _turns(4))
+        sid = transcript_session_id("edge-1")
+        path = tmp_path / "voice" / f"{sid}.jsonl"
+        first = path.read_text()
+        await writer.sync_cumulative("edge-1", _turns(4))
+        assert path.read_text() == first
+
+    async def test_shorter_list_appends_nothing_and_warns(self, writer, tmp_path, caplog):
+        await writer.sync_cumulative("edge-1", _turns(5))
+        with caplog.at_level("WARNING"):
+            assert await writer.sync_cumulative("edge-1", _turns(2)) == 0
+        assert any("cache reset" in r.message for r in caplog.records)
+        sid = transcript_session_id("edge-1")
+        messages = read_transcript_messages(tmp_path / "voice" / f"{sid}.jsonl")
+        assert len(messages) == 5
+
+    async def test_new_writer_instance_continues_same_transcript(self, db, tmp_path):
+        """Restart survival: the deterministic id + on-disk line count carry
+        the reconciliation state — no in-memory state required."""
+        w1 = VoiceTranscriptWriter(db, transcript_dir=tmp_path / "voice")
+        await w1.sync_cumulative("edge-1", _turns(3))
+        w2 = VoiceTranscriptWriter(db, transcript_dir=tmp_path / "voice")
+        assert await w2.sync_cumulative("edge-1", _turns(3)) == 0
+        assert await w2.sync_cumulative("edge-1", _turns(4)) == 1
+
+    async def test_heal_orphans_completes_only_voice_actives(self, db, tmp_path):
+        await sessions_crud.register_voice_session(
+            db,
+            id="voice-orphan",
+            started_at="2026-07-01T00:00:00+00:00",
+        )
+        await sessions_crud.create(
+            db,
+            id="cc-foreground",
+            session_type="foreground",
+            model="opus",
+            started_at="2026-07-01T00:00:00+00:00",
+            last_activity_at="2026-07-01T00:00:00+00:00",
+            status="active",
+        )
+        writer = VoiceTranscriptWriter(db, transcript_dir=tmp_path / "voice")
+        assert await writer.heal_orphans() == 1
+        assert (await sessions_crud.get_by_id(db, "voice-orphan"))["status"] == "completed"
+        assert (await sessions_crud.get_by_id(db, "cc-foreground"))["status"] == "active"
+
+    async def test_append_ignores_invalid_role_and_blank_text(self, writer, tmp_path):
+        await writer.append_message("edge-1", "system", "nope")
+        await writer.append_message("edge-1", "user", "   ")
+        sid = transcript_session_id("edge-1")
+        assert not (tmp_path / "voice" / f"{sid}.jsonl").exists()

--- a/tests/test_ego/test_capability_aggregator.py
+++ b/tests/test_ego/test_capability_aggregator.py
@@ -304,3 +304,33 @@ class TestOutcomeBusSource:
         assert inv is not None
         assert "proposals:" in inv["evidence"]
         assert "outcomes:" in inv["evidence"]
+
+
+class TestVoiceRowExclusion:
+    @pytest.mark.asyncio
+    async def test_voice_rows_never_form_a_domain(self, db):
+        """Voice conversation rows (source_tag='voice') are transcript-index
+        entries, always 'completed' — including them would fabricate a
+        100%-complete phantom capability domain."""
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC).isoformat()
+        for i in range(5):
+            await db.execute(
+                "INSERT INTO cc_sessions (id, session_type, model, status, "
+                "source_tag, started_at) "
+                "VALUES (?, 'foreground', 'voice', 'completed', 'voice', ?)",
+                (f"v{i}", now),
+            )
+        for i in range(4):
+            await db.execute(
+                "INSERT INTO cc_sessions (id, session_type, model, status, "
+                "source_tag, started_at) "
+                "VALUES (?, 'background_task', 'sonnet', 'completed', 'sentinel', ?)",
+                (f"s{i}", now),
+            )
+        await db.commit()
+
+        results = await compute_capability_map(db)
+        assert not any(r["domain"] == "voice" for r in results)
+        assert any(r["domain"] == "sentinel" for r in results)

--- a/tests/test_memory/test_extraction_voice_sessions.py
+++ b/tests/test_memory/test_extraction_voice_sessions.py
@@ -1,0 +1,132 @@
+"""E2E-in-test: voice transcripts flow through the real extraction cycle.
+
+Producer and consumer are both REAL: the transcript comes from the actual
+``VoiceTranscriptWriter`` and the cycle is the actual ``run_extraction_cycle``
+against a full-schema DB — only the LLM router and the vector store are
+mocked. This is the load-bearing W0.5 parity proof: a voice conversation is
+discovered via the voice-dir fallback, mined, and watermarked exactly like
+any other channel's session.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.channels.voice.transcript_writer import (
+    VoiceTranscriptWriter,
+    transcript_session_id,
+)
+from genesis.db.schema import create_all_tables
+from genesis.memory.extraction_job import run_extraction_cycle
+
+_EXTRACTION_JSON = (
+    '```json\n{"extractions": [{"content": "User prefers oat milk in coffee", '
+    '"type": "preference", "confidence": 0.8, "entities": ["oat milk"]}], '
+    '"session_topic": "coffee preferences", '
+    '"session_keywords": ["coffee", "oat milk"]}\n```'
+)
+
+
+@pytest.mark.asyncio
+async def test_voice_session_extracted_via_voice_dir_fallback(tmp_path, monkeypatch):
+    cc_dir = tmp_path / "cc-projects"
+    cc_dir.mkdir()
+    voice_dir = tmp_path / "voice-transcripts"
+    monkeypatch.setenv("GENESIS_VOICE_TRANSCRIPT_DIR", str(voice_dir))
+
+    async with aiosqlite.connect(":memory:") as db:
+        db.row_factory = aiosqlite.Row
+        await create_all_tables(db)
+
+        # REAL producer: writer registers the session + writes the transcript
+        writer = VoiceTranscriptWriter(db, transcript_dir=voice_dir)
+        await writer.append_message("s2s-pe-042", "user", "remember I take oat milk")
+        await writer.append_message("s2s-pe-042", "assistant", "noted — oat milk it is")
+        await writer.close_session("s2s-pe-042")
+        sid = transcript_session_id("s2s-pe-042")
+
+        router = AsyncMock()
+        router.route_call = AsyncMock(
+            return_value=AsyncMock(
+                success=True,
+                content=_EXTRACTION_JSON,
+                call_site_id="9_fact_extraction",
+                error=None,
+            )
+        )
+        store = AsyncMock()
+        store.store = AsyncMock(return_value="mem-1")
+        store._embeddings = MagicMock()
+        store._embeddings.model_name = "m"
+
+        summary = await run_extraction_cycle(
+            db=db,
+            store=store,
+            router=router,
+            transcript_dir=cc_dir,
+        )
+
+        assert summary["sessions_processed"] == 1
+        assert summary["entities_extracted"] >= 1
+        store.store.assert_awaited()
+
+        cursor = await db.execute(
+            "SELECT last_extracted_line, topic FROM cc_sessions WHERE id = ?",
+            (sid,),
+        )
+        row = await cursor.fetchone()
+        assert row["last_extracted_line"] > 0, "watermark must advance"
+        assert row["topic"] == "coffee preferences"
+
+
+@pytest.mark.asyncio
+async def test_voice_watermark_makes_replay_a_noop(tmp_path, monkeypatch):
+    """Second cycle over an unchanged transcript extracts nothing — the
+    structural guarantee the legacy blob landing lacked."""
+    cc_dir = tmp_path / "cc-projects"
+    cc_dir.mkdir()
+    voice_dir = tmp_path / "voice-transcripts"
+    monkeypatch.setenv("GENESIS_VOICE_TRANSCRIPT_DIR", str(voice_dir))
+
+    async with aiosqlite.connect(":memory:") as db:
+        db.row_factory = aiosqlite.Row
+        await create_all_tables(db)
+
+        writer = VoiceTranscriptWriter(db, transcript_dir=voice_dir)
+        await writer.append_message("s2s-pe-042", "user", "hello there")
+        await writer.append_message("s2s-pe-042", "assistant", "hi")
+
+        router = AsyncMock()
+        router.route_call = AsyncMock(
+            return_value=AsyncMock(
+                success=True,
+                content=_EXTRACTION_JSON,
+                call_site_id="9_fact_extraction",
+                error=None,
+            )
+        )
+        store = AsyncMock()
+        store.store = AsyncMock(return_value="mem-1")
+        store._embeddings = MagicMock()
+        store._embeddings.model_name = "m"
+
+        first = await run_extraction_cycle(
+            db=db,
+            store=store,
+            router=router,
+            transcript_dir=cc_dir,
+        )
+        assert first["sessions_processed"] == 1
+
+        second = await run_extraction_cycle(
+            db=db,
+            store=store,
+            router=router,
+            transcript_dir=cc_dir,
+        )
+        assert second["chunks_processed"] == 0, (
+            "replay must not re-extract already-watermarked lines"
+        )

--- a/tests/test_memory/test_store_subsystem_coverage.py
+++ b/tests/test_memory/test_store_subsystem_coverage.py
@@ -37,10 +37,19 @@ _SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "genesis"
 # Distinctive MemoryStore.store(...) keyword parameters. A ``.store(...)`` call
 # passing any of these is treated as a memory write (filters out unrelated
 # ``.store()`` APIs like ``conn.store``).
-_MEMORY_KWARGS = frozenset({
-    "memory_type", "source_pipeline", "source_subsystem", "wing", "room",
-    "auto_link", "source_session_id", "invalid_at", "memory_class",
-})
+_MEMORY_KWARGS = frozenset(
+    {
+        "memory_type",
+        "source_pipeline",
+        "source_subsystem",
+        "wing",
+        "room",
+        "auto_link",
+        "source_session_id",
+        "invalid_at",
+        "memory_class",
+    }
+)
 
 # file (relative to src/genesis) :: enclosing function  ->  why it is NULL.
 # These writers deliberately leave source_subsystem NULL: the content is
@@ -51,28 +60,21 @@ USER_CONTEXT_ALLOWLIST: dict[str, str] = {
     "bookmark/manager.py::create_micro": "user-saved bookmark (user content)",
     "bookmark/manager.py::create_topic": "user-saved bookmark (user content)",
     "bookmark/manager.py::enrich": "user-saved bookmark enrichment (user content)",
-    "channels/telegram/_handler_messages.py::_try_ego_correction_store":
-        "user-authored ego correction (user content; ego must recall it)",
-    "channels/voice/s2s_session.py::close":
-        "voice conversation memory (user content)",
-    "eval/longmemeval/ingest.py::ingest_haystack":
-        "LongMemEval benchmark haystack ingest into an EPHEMERAL throwaway store "
-        "(first_party user-history content; never touches prod; not a subsystem)",
-    "knowledge/ingest_upload.py::_store_as_is":
-        "user-uploaded knowledge_base content (external-world, recallable)",
-    "knowledge/orchestrator.py::_store_units":
-        "ingested knowledge units (external-world, recallable)",
+    "channels/telegram/_handler_messages.py::_try_ego_correction_store": "user-authored ego correction (user content; ego must recall it)",
+    # NOTE: s2s_session.py::close no longer writes memory — voice conversations
+    # now land as extractable transcripts (W0.5), so there is no .store() call
+    # here to classify.
+    "eval/longmemeval/ingest.py::ingest_haystack": "LongMemEval benchmark haystack ingest into an EPHEMERAL throwaway store "
+    "(first_party user-history content; never touches prod; not a subsystem)",
+    "knowledge/ingest_upload.py::_store_as_is": "user-uploaded knowledge_base content (external-world, recallable)",
+    "knowledge/orchestrator.py::_store_units": "ingested knowledge units (external-world, recallable)",
     "mcp/memory/core.py::memory_store": "user-invoked MCP store",
     "mcp/memory/core.py::memory_extract": "user-invoked MCP extraction",
     "mcp/memory/core.py::memory_synthesize": "user-invoked MCP synthesis",
-    "memory/dream_cycle.py::_synthesize_and_deprecate":
-        "consolidated memory meant FOR recall (tagging would break update_payload)",
-    "memory/knowledge_ingest.py::ingest_knowledge_unit":
-        "knowledge_base ingest (external-world, recallable)",
-    "memory/session_observer.py::process_pending_observations":
-        "conversation-derived observations (~48% of recall pool; must stay)",
-    "recon/cc_update_analyzer.py::_ingest_to_knowledge":
-        "external-world CC-update knowledge (recallable)",
+    "memory/dream_cycle.py::_synthesize_and_deprecate": "consolidated memory meant FOR recall (tagging would break update_payload)",
+    "memory/knowledge_ingest.py::ingest_knowledge_unit": "knowledge_base ingest (external-world, recallable)",
+    "memory/session_observer.py::process_pending_observations": "conversation-derived observations (~48% of recall pool; must stay)",
+    "recon/cc_update_analyzer.py::_ingest_to_knowledge": "external-world CC-update knowledge (recallable)",
 }
 
 
@@ -139,7 +141,8 @@ def test_every_untagged_writer_is_classified():
     unclassified = untagged - allow
     assert not unclassified, (
         "New memory writer(s) that do NOT pass source_subsystem= and are not "
-        "classified:\n  " + "\n  ".join(sorted(unclassified))
+        "classified:\n  "
+        + "\n  ".join(sorted(unclassified))
         + "\n\nIf this is an internal-subsystem writer (ego/triage/reflection/"
         "autonomy), add source_subsystem=. If it is user-sourced / knowledge / "
         "consolidated content that must stay recallable, register it in "
@@ -149,8 +152,7 @@ def test_every_untagged_writer_is_classified():
     stale = allow - untagged
     assert not stale, (
         "Allowlisted writer(s) no longer found untagged (now tagged, renamed, "
-        "or removed) — update USER_CONTEXT_ALLOWLIST:\n  "
-        + "\n  ".join(sorted(stale))
+        "or removed) — update USER_CONTEXT_ALLOWLIST:\n  " + "\n  ".join(sorted(stale))
     )
 
 
@@ -160,6 +162,5 @@ def test_no_module_sets_source_subsystem():
     assert not tagged_module, (
         "module .store() call(s) set source_subsystem — modules are external "
         "capabilities ('hands, not brain', see modules/base.py), NEVER Genesis "
-        "subsystems, and must never tag a memory write:\n  "
-        + "\n  ".join(sorted(tagged_module))
+        "subsystems, and must never tag a memory write:\n  " + "\n  ".join(sorted(tagged_module))
     )

--- a/tests/test_resilience/test_cc_budget.py
+++ b/tests/test_resilience/test_cc_budget.py
@@ -64,6 +64,25 @@ class TestUsageAndStatus:
         assert await tracker.get_usage_pct() == pytest.approx(0.0)
         assert await tracker.get_status() == CCStatus.NORMAL
 
+    async def test_ignores_voice_conversation_rows(self, tracker, db):
+        # Voice conversation rows (source_tag='voice') are transcript-index
+        # entries, not CC invocations — a chatty voice day must not throttle
+        # background CC sessions.
+        recent = (datetime(2026, 3, 11, 11, 30, 0, tzinfo=UTC)).isoformat()
+        for _ in range(25):
+            sid = str(uuid.uuid4())
+            await db.execute(
+                """INSERT INTO cc_sessions
+                   (id, session_type, channel, model, started_at,
+                    last_activity_at, status, source_tag)
+                   VALUES (?, 'foreground', 'voice_s2s', 'voice', ?, ?,
+                           'completed', 'voice')""",
+                (sid, recent, recent),
+            )
+        await db.commit()
+        assert await tracker.get_usage_pct() == pytest.approx(0.0)
+        assert await tracker.get_status() == CCStatus.NORMAL
+
 
 class TestThrottling:
     async def test_normal_nothing_throttled(self, tracker, db):

--- a/tests/test_runtime/test_learning_retention_jobs.py
+++ b/tests/test_runtime/test_learning_retention_jobs.py
@@ -19,7 +19,9 @@ _EXPECTED = (
     "file_modifications_prune",
     "job_run_events_prune",
     "alert_events_prune",
+    "deferred_work_prune",
     "graduation_events_prune",
+    "voice_hygiene",
 )
 
 


### PR DESCRIPTION
## Summary

W0.5 of the voice⇄core interface: **s2s conversations now feed the memory extraction pipeline** like every other channel, replacing the one-blob `memory_store` landing.

Previously an s2s voice conversation was stored as a single growing `"Voice conversation [...]"` blob in episodic memory at session close — duplicated on every replay, never mined for facts, and (from the edge bridge) re-posted cumulatively so the same conversation grew for weeks. Now each conversation lands as a per-session CC-format JSONL transcript that the existing extraction job mines incrementally by watermark: entities, references, and a topic index instead of a raw dump.

### Added
- **`VoiceTranscriptWriter`** (`channels/voice/transcript_writer.py`) — writes conversations as CC-transcript JSONL under `voice_transcript_dir()` (`~/.genesis/voice-transcripts/`, outside the repo AND outside the CC projects dir so the resume picker never lists them) plus a `cc_sessions` row (`source_tag='voice'`). Deterministic `uuid5` session ids + line-count reconciliation make replays, double-fires, and cumulative re-sends land **exactly once**. Appends are **durable before the caller is acked** (an append failure raises → route 5xx → producer retries; a swallowed error would ack turns that never landed).
- **`POST /v1/voice/conversation`** — bearer-authenticated (fail-closed via the W0 token model), accepts a cumulative `turns` list, returns `{"status":"ok","appended":N}`. 256KB body cap measured on the actual body (chunked-safe). This is the endpoint the GENesis-Voice edge bridge will target (follow-on PR).
- **Extraction eligibility** — `source_tag='voice'` added to the extractable set; the session loop falls back to `voice_transcript_dir()` for voice rows. Watermark, chunking, reference user-gating, and topic indexing all apply unchanged.
- **Daily `voice_hygiene` job** — (a) prunes voice transcripts older than **1 year** (a still-`active` conversation is never touched; rowless files fall back to mtime), (b) heals orphaned `active` voice rows idle >1h (appends refresh `last_activity_at`, so a live conversation is never flipped mid-call), (c) sweeps legacy blob memories (below).

### Changed
- **Core `S2SSessionManager`** records turns per-turn through the writer (durable; a crash loses nothing already spoken) and finalizes the transcript session at close — the one-blob `memory_store.store` landing is deleted. Its `memory_store` param becomes `transcript_writer`.
- **Voice conversation rows are excluded** from the CC-session budget (`resilience/cc_budget.py`) and the ego's capability self-model (`ego/capability_aggregator.py`) — they are conversations, not CC work sessions, and would otherwise throttle background CC or fabricate an always-100% "voice" capability domain.

### Fixed
- **Legacy voice blobs are swept from episodic memory.** A standing daily sweep (not a one-shot data migration — the migration runner never re-runs, so it couldn't catch blobs written by a not-yet-updated edge) removes memories matching the exact `"Voice conversation ["` prefix **and** the `voice`+`s2s`+`conversation` tag set, across all storage layers (`MemoryStore.delete` cascade + `memory_events`). It logs loudly on any nonzero sweep — after the edge PR lands, a hit means a stale producer is back. Legitimate voice-tagged memories without the blob prefix are spared (verified against the live cohort).
- Repaired committed `<<<<<<< / >>>>>>>` conflict markers in `CHANGELOG.md` (landed via #1153's merge) and added the missing `deferred_work_prune` case to the retention-jobs registration test.

## Deploy notes

⚠️ **Schema-migration-free** (no new tables/columns; the blob sweep is a runtime job). Existing installs: `git pull` + restart. On the primary, the first `voice_hygiene` tick (05:50) purges the historical blob cohort and the extraction cron begins mining new voice conversations within ~2h.

**Follow-on GENesis-Voice PR** switches the edge s2s bridge from `POST /api/t/memory_store` (blob) to `POST /v1/voice/conversation` (cumulative `turns`, session_id regenerated whenever its turn cache resets, existing bearer token). Until it lands, the daily sweep keeps clearing any interim blobs.

**Scope boundary:** ambient/overheard capture is untouched — it stays edge-side (48h TTL); only s2s conversations are in scope here. The fast-path `VoiceConversationHandler` remains in-memory-only (it persisted nothing before either — no regression).

## Testing

- 213 targeted tests green: transcript writer (CC round-trip through the **real** `read_transcript_messages`, cumulative idempotency, durable-ack-on-failure, idle-gated heal), `/v1/voice/conversation` route (auth/fail-closed/400/cap/append/replay/503), s2s rewire (no-blob-store, per-turn record, partial-turn flush), hygiene (prune active-safety + mtime fallback, blob-cohort sweep with cascade + false-positive survival), extraction E2E (real writer → **real `run_extraction_cycle`** via the voice-dir fallback; watermark advance + replay no-op), and the budget/capability exclusions.
- Live E2E drill (real Flask + real SQLite): append 4 → replay 0 → superset +2 → shorter 0 (warn) → 401/400 correct; transcript file 6 lines with correct alternating roles; real extraction cycle mined it (watermark 6, topic indexed) and the replay cycle reprocessed 0 chunks.

Adversarial review (Claude reviewer; Codex auth-blocked on this repo) found one real BLOCKER — the append swallowed `OSError` and still acked 200 — now fixed with a test, plus the idle-gated heal, date-in-session-id (HHMMSS alone collided across days), and partial-turn flush hardening.

Ledger: 9db340a3d255469ea5acf81bc617831e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
