### PR TITLE
fix(telegram): self-heal shutdown-closed send client + stop senders before close

### DIFF
--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -280,6 +280,7 @@ async def main():
             adapter._app.bot,
             config["forum_chat_id"],
             db=runtime.db,
+            stopping=lambda: getattr(adapter, "_stopping", False),
         )
         await topic_manager.load_persisted()
 

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -176,6 +176,7 @@ async def _make_streamer(ctx: HandlerContext, msg, user, tid) -> DraftStreamer |
         draft_id=generate_draft_id(),
         message_thread_id=msg.message_thread_id,
         prefix=prefix,
+        stopping=lambda: getattr(ctx.adapter, "_stopping", False),
     )
 
     # Flush immediately — user sees prefix before inference starts

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -38,6 +38,7 @@ from genesis.channels.telegram.transport.send import (
     safe_send_document,
     safe_send_message,
     safe_send_voice,
+    send_with_client_heal,
 )
 from genesis.channels.telegram.transport.typing_breaker import TypingCircuitBreaker
 from genesis.channels.telegram.transport.update_dedupe import TelegramUpdateDedupe
@@ -76,6 +77,10 @@ class TelegramAdapterV2(ChannelAdapter):
         self._autonomous_cli_gate = autonomous_cli_gate
         self._proposal_workflow = proposal_workflow
         self._app = None
+        # Set True at the top of stop() so background senders healing a
+        # shutdown-closed httpx client don't resurrect a client the process
+        # is deliberately tearing down (send_with_client_heal reads this).
+        self._stopping = False
 
         # Transport layer components
         self._dedupe = TelegramUpdateDedupe()
@@ -234,6 +239,10 @@ class TelegramAdapterV2(ChannelAdapter):
         self._watchdog.start()
 
     async def stop(self) -> None:
+        # Signal in-flight/background senders to stop healing the client we are
+        # about to close — a heal during shutdown would just leak a client the
+        # process is discarding.
+        self._stopping = True
         if self._watchdog:
             await self._watchdog.stop()
         if self._app:
@@ -259,13 +268,17 @@ class TelegramAdapterV2(ChannelAdapter):
         if not self._app:
             raise RuntimeError("Adapter not started")
 
-        msg = await safe_send_message(
+        msg = await send_with_client_heal(
             self._app.bot,
-            int(channel_id),
-            text,
-            parse_mode=parse_mode or "HTML",
-            message_thread_id=message_thread_id,
-            reply_markup=reply_markup,
+            lambda: safe_send_message(
+                self._app.bot,
+                int(channel_id),
+                text,
+                parse_mode=parse_mode or "HTML",
+                message_thread_id=message_thread_id,
+                reply_markup=reply_markup,
+            ),
+            stopping=lambda: self._stopping,
         )
         if msg is None:
             raise RuntimeError("Failed to send message after retries")
@@ -319,11 +332,15 @@ class TelegramAdapterV2(ChannelAdapter):
     ) -> str:
         if not self._app:
             raise RuntimeError("Adapter not started")
-        msg = await safe_send_voice(
+        msg = await send_with_client_heal(
             self._app.bot,
-            int(channel_id),
-            io.BytesIO(audio_bytes),
-            reply_to_message_id=int(reply_to_message_id) if reply_to_message_id else None,
+            lambda: safe_send_voice(
+                self._app.bot,
+                int(channel_id),
+                io.BytesIO(audio_bytes),
+                reply_to_message_id=int(reply_to_message_id) if reply_to_message_id else None,
+            ),
+            stopping=lambda: self._stopping,
         )
         if msg is None:
             raise RuntimeError("Failed to send voice after retries")
@@ -342,19 +359,29 @@ class TelegramAdapterV2(ChannelAdapter):
         if not self._app:
             raise RuntimeError("Adapter not started")
 
-        if isinstance(document, bytes):
-            doc_input = io.BytesIO(document)
-            if filename:
-                doc_input.name = filename
-        else:
-            doc_input = document  # file_id or URL
+        # Build a FRESH stream per send attempt. PTB's InputFile reads a
+        # file-like document to EOF at construction — which happens before the
+        # closed-client error is raised — so reusing one BytesIO across a
+        # heal-retry would silently upload zero bytes. String file_id/URL docs
+        # are stateless, so the factory just returns them.
+        def _doc_input() -> io.BytesIO | str:
+            if isinstance(document, bytes):
+                stream = io.BytesIO(document)
+                if filename:
+                    stream.name = filename
+                return stream
+            return document  # file_id or URL
 
-        msg = await safe_send_document(
+        msg = await send_with_client_heal(
             self._app.bot,
-            int(channel_id),
-            doc_input,
-            caption=caption,
-            message_thread_id=message_thread_id,
+            lambda: safe_send_document(
+                self._app.bot,
+                int(channel_id),
+                _doc_input(),
+                caption=caption,
+                message_thread_id=message_thread_id,
+            ),
+            stopping=lambda: self._stopping,
         )
         if msg is None:
             raise RuntimeError("Failed to send document after retries")

--- a/src/genesis/channels/telegram/topics.py
+++ b/src/genesis/channels/telegram/topics.py
@@ -18,7 +18,11 @@ from typing import TYPE_CHECKING
 
 from telegram.error import BadRequest
 
+from genesis.channels.telegram.transport.send import send_with_client_heal
+
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import aiosqlite
     from telegram import Bot
 
@@ -57,6 +61,7 @@ class TopicManager:
         *,
         db: aiosqlite.Connection | None = None,
         categories: dict[str, str] | None = None,
+        stopping: Callable[[], bool] | None = None,
     ) -> None:
         self._bot = bot
         self._chat_id = forum_chat_id
@@ -64,6 +69,10 @@ class TopicManager:
         self._categories = categories or DEFAULT_CATEGORIES
         self._persistent_topics: dict[str, int] = {}  # category → thread_id
         self._create_lock = asyncio.Lock()
+        # Heal a shutdown-closed send client on outbound topic messages. The
+        # host wires this to the Telegram adapter's stopping flag so we never
+        # resurrect a client mid-shutdown; default = never stopping.
+        self._stopping = stopping or (lambda: False)
 
     async def load_persisted(self) -> None:
         """Load persisted topic mappings from DB. Call once after construction."""
@@ -185,6 +194,19 @@ class TopicManager:
 
         return first_msg_id
 
+    async def _send_message_healed(self, **kwargs):
+        """Send via the bot, self-healing a shutdown-closed httpx client once.
+
+        Wraps the raw ``bot.send_message`` (TopicManager holds the bot directly,
+        bypassing the adapter's send methods) so a closed send client is rebuilt
+        and retried instead of failing permanently.
+        """
+        return await send_with_client_heal(
+            self._bot,
+            lambda: self._bot.send_message(**kwargs),
+            stopping=self._stopping,
+        )
+
     async def _send_single(
         self,
         text: str,
@@ -204,7 +226,7 @@ class TopicManager:
             if parse_mode:
                 kwargs["parse_mode"] = parse_mode
             try:
-                msg = await self._bot.send_message(**kwargs)
+                msg = await self._send_message_healed(**kwargs)
             except BadRequest as exc:
                 err_msg = str(exc).lower()
                 if "thread not found" in err_msg:
@@ -215,14 +237,14 @@ class TopicManager:
                     if thread_id is None:
                         return None
                     kwargs["message_thread_id"] = thread_id
-                    msg = await self._bot.send_message(**kwargs)
+                    msg = await self._send_message_healed(**kwargs)
                 elif parse_mode and ("can't parse" in err_msg or "parse entities" in err_msg):
                     logger.warning(
                         "Topic send with %s failed, retrying plain",
                         parse_mode, exc_info=True,
                     )
                     kwargs.pop("parse_mode", None)
-                    msg = await self._bot.send_message(**kwargs)
+                    msg = await self._send_message_healed(**kwargs)
                 else:
                     raise
             # Persist outbound message for audit trail + reply resolution

--- a/src/genesis/channels/telegram/transport/send.py
+++ b/src/genesis/channels/telegram/transport/send.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from telegram import Bot
@@ -28,6 +29,65 @@ logger = logging.getLogger(__name__)
 
 _MAX_RETRIES = 3
 _TG_MAX_LEN = 4096
+
+
+def _is_closed_client_error(exc: BaseException) -> bool:
+    """True if ``exc`` signals PTB's httpx send-client was closed (shut down).
+
+    PTB's ``HTTPXRequest.do_request`` raises
+    ``RuntimeError("This HTTPXRequest is not initialized!")`` when the client
+    is closed, which ``_request_wrapper`` rewraps as
+    ``NetworkError("Unknown error in HTTP implementation: RuntimeError('This
+    HTTPXRequest is not initialized!')") from exc``. The ``not initialized``
+    signature therefore appears both on the outer ``NetworkError`` message and
+    on its ``__cause__``/``__context__`` chain, so we walk the chain and match
+    either — precise enough that ordinary network blips never trigger a rebuild,
+    and resilient if a future PTB tweaks the wrapper text.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    depth = 0
+    while cur is not None and depth < 10 and id(cur) not in seen:
+        seen.add(id(cur))
+        if "not initialized" in str(cur).lower():
+            return True
+        cur = cur.__cause__ or cur.__context__
+        depth += 1
+    return False
+
+
+async def send_with_client_heal(
+    bot: Bot,
+    send: Callable[[], Awaitable[Any]],
+    *,
+    stopping: Callable[[], bool],
+) -> Any:
+    """Run a Telegram send, self-healing a shutdown-closed httpx client once.
+
+    ``send`` is a zero-arg coroutine factory that performs the actual bot call
+    (so it can be re-run cleanly on retry). On a closed-client error, if we are
+    NOT shutting down (``stopping()`` is ``False``), rebuild the send client via
+    ``bot.request.initialize()`` — idempotent, since ``HTTPXRequest.initialize``
+    only rebuilds when the client ``is_closed`` — and retry the send exactly
+    once. During shutdown we re-raise instead of resurrecting a client the
+    process is deliberately tearing down.
+
+    Background: on 2026-07-15 the send client was closed while background senders
+    kept firing; every send raised the closed-client error, the outreach recovery
+    worker exhausted its 5 retries against the dead client, and two Sentinel
+    approval requests were permanently discarded (the owner never saw them). This
+    recovers the client instead of failing permanently — whatever closed it.
+    """
+    try:
+        return await send()
+    except Exception as exc:
+        if not _is_closed_client_error(exc) or stopping():
+            raise
+        logger.warning(
+            "Telegram send client was closed; reinitializing and retrying once",
+        )
+        await bot.request.initialize()
+        return await send()
 
 
 async def safe_send_message(

--- a/src/genesis/channels/telegram/transport/streaming.py
+++ b/src/genesis/channels/telegram/transport/streaming.py
@@ -18,8 +18,14 @@ from __future__ import annotations
 import logging
 import secrets
 import time
+from typing import TYPE_CHECKING
 
 import telegram
+
+from genesis.channels.telegram.transport.send import send_with_client_heal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +75,7 @@ class DraftStreamer:
         message_thread_id: int | None = None,
         throttle_s: float = _DEFAULT_THROTTLE_S,
         prefix: str = "",
+        stopping: Callable[[], bool] | None = None,
     ) -> None:
         self.bot = bot
         self.chat_id = chat_id
@@ -76,6 +83,9 @@ class DraftStreamer:
         self.message_thread_id = message_thread_id
         self.throttle_s = throttle_s
         self._prefix = prefix
+        # Heal a shutdown-closed send client on draft sends; wired to the
+        # adapter's stopping flag by the caller (default: never stopping).
+        self._stopping = stopping or (lambda: False)
 
         self._tool_lines: list[str] = []
         self._text = ""
@@ -193,7 +203,11 @@ class DraftStreamer:
             }
             if self.message_thread_id is not None:
                 kwargs["message_thread_id"] = self.message_thread_id
-            await self.bot.send_message_draft(**kwargs)
+            await send_with_client_heal(
+                self.bot,
+                lambda: self.bot.send_message_draft(**kwargs),
+                stopping=self._stopping,
+            )
             self._last_send_time = time.monotonic()
             self._last_draft_text = draft_text
             self._any_draft_sent = True

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -182,6 +182,13 @@ class StandaloneAdapter:
         # Stop Wyoming servers
         await self._shutdown_wyoming_servers()
 
+        # Stop background senders (outreach recovery worker) BEFORE closing the
+        # Telegram client below, so no late retry fires through a torn-down
+        # client and exhausts into a permanent discard — the failure that
+        # silently dropped two Sentinel approval requests on 2026-07-15.
+        if self._runtime is not None:
+            await self._runtime.stop_outbound_senders()
+
         if self._telegram_adapter is not None:
             try:
                 await self._telegram_adapter.stop()
@@ -637,6 +644,7 @@ class StandaloneAdapter:
                     adapter._app.bot,
                     config["forum_chat_id"],
                     db=rt.db,
+                    stopping=lambda: adapter._stopping,
                 )
                 await topic_manager.load_persisted()
 

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -562,6 +562,28 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
 
         write_capabilities_file(self)
 
+    async def stop_outbound_senders(self) -> None:
+        """Stop the outreach recovery worker before the Telegram client closes.
+
+        The recovery worker is the one background sender with the
+        retry-exhaust-then-permanent-discard pathology: it polls every 60s and
+        burns its 5-retry budget against whatever client it's given. The host
+        calls this BEFORE ``adapter.stop()`` closes the httpx client, so a late
+        retry can't fire through a torn-down client and discard the payload —
+        the failure that silently dropped two Sentinel approval requests on
+        2026-07-15. Other outbound senders (schedulers, awareness) are stopped
+        later in ``shutdown()``; a send from one in the small post-close window
+        just re-raises (heal is disabled during shutdown) rather than
+        exhaust-discarding. Idempotent and exception-guarded so it never blocks
+        shutdown; ``shutdown()`` also stops the worker as a belt.
+        """
+        worker = getattr(self, "_outreach_recovery_worker", None)
+        if worker is not None:
+            try:
+                await worker.stop()
+            except Exception:
+                logger.exception("Failed to stop outreach recovery worker")
+
     async def shutdown(self) -> None:
         if not self._bootstrapped:
             return
@@ -599,6 +621,8 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             ("user_ego_cadence", self._ego_cadence_manager),
             ("genesis_ego_cadence", self._genesis_ego_cadence_manager),
             ("outreach_scheduler", self._outreach_scheduler),
+            # getattr: only set when outreach init succeeded (init/outreach.py).
+            ("outreach_recovery", getattr(self, "_outreach_recovery_worker", None)),
             ("user_job_scheduler", self._user_job_scheduler),
             ("reflection_scheduler", self._reflection_scheduler),
             ("inbox_monitor", self._inbox_monitor),

--- a/tests/test_channels/test_transport.py
+++ b/tests/test_channels/test_transport.py
@@ -1,13 +1,14 @@
 """Tests for Telegram V2 transport layer."""
+
 from __future__ import annotations
 
 import asyncio
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from telegram.error import NetworkError
+from telegram.error import NetworkError, TimedOut
 
 from genesis.channels.telegram.transport.offset_store import (
     delete_offset,
@@ -29,6 +30,7 @@ from genesis.channels.telegram.transport.update_dedupe import (
 )
 
 # ---- UpdateDedupe ----
+
 
 class TestUpdateDedupe:
     def test_first_seen_not_duplicate(self):
@@ -68,6 +70,7 @@ class TestUpdateDedupe:
 
 # ---- OffsetStore ----
 
+
 class TestOffsetStore:
     def test_read_nonexistent(self, tmp_path):
         with patch(
@@ -95,6 +98,7 @@ class TestOffsetStore:
 
 
 # ---- SendSafety ----
+
 
 class TestSendSafety:
     def test_connect_error_is_safe(self):
@@ -141,6 +145,7 @@ class TestSendSafety:
 
 # ---- TypingCircuitBreaker ----
 
+
 class TestTypingBreaker:
     def test_initially_should_send(self):
         cb = TypingCircuitBreaker()
@@ -174,6 +179,7 @@ class TestTypingBreaker:
 
 # ---- PollingWatchdog ----
 
+
 class TestPollingWatchdog:
     @pytest.mark.asyncio
     async def test_stall_triggers_callback(self):
@@ -205,6 +211,7 @@ class TestPollingWatchdog:
 
 
 # ---- DraftStreamer ----
+
 
 class TestDraftStreamer:
     @pytest.mark.asyncio
@@ -264,17 +271,20 @@ class TestDraftStreamer:
 
 # ---- FTS5 Escape Fix ----
 
+
 class TestFTS5Prepare:
     """Tests for _prepare_fts5 — the FTS5 query sanitizer."""
 
     def test_commas_escaped(self):
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5("hello, world, test")
         assert "," not in result
         assert result is not None
 
     def test_natural_language(self):
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5("What's the weather like today?")
         assert result is not None
         assert "?" not in result
@@ -282,6 +292,7 @@ class TestFTS5Prepare:
 
     def test_parentheses_escaped(self):
         from genesis.db.crud.knowledge import _prepare_fts5
+
         result = _prepare_fts5("function(arg1, arg2)")
         assert "(" not in result
         assert ")" not in result
@@ -289,11 +300,13 @@ class TestFTS5Prepare:
 
     def test_empty_after_escape_returns_none(self):
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5("!!!")
         assert result is None
 
     def test_unicode_preserved(self):
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5("café résumé naïve")
         assert result is not None
         assert "café" in result
@@ -301,6 +314,7 @@ class TestFTS5Prepare:
     def test_uppercase_or_and_neutralized(self):
         """Uppercase OR/AND in user queries must not become FTS5 operators."""
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5("FTS5 boolean OR AND query")
         assert result is not None
         # Lowercased — or/and are plain search terms, not FTS5 operators
@@ -312,8 +326,10 @@ class TestFTS5Prepare:
     def test_boolean_mode_preserves_operators(self):
         """Boolean mode preserves OR/AND/parens for expand_query output."""
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5(
-            "(configure AND routing) OR setup OR deploy", boolean=True,
+            "(configure AND routing) OR setup OR deploy",
+            boolean=True,
         )
         assert result is not None
         assert "OR" in result
@@ -324,6 +340,7 @@ class TestFTS5Prepare:
     def test_boolean_mode_unbalanced_parens_stripped(self):
         """Unbalanced parentheses in boolean mode are safely stripped."""
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5("(test AND query", boolean=True)
         assert result is not None
         assert "(" not in result  # parens stripped due to imbalance
@@ -332,8 +349,10 @@ class TestFTS5Prepare:
     def test_boolean_mode_strips_special_chars(self):
         """Boolean mode still strips non-operator special chars."""
         from genesis.db.crud.memory import _prepare_fts5
+
         result = _prepare_fts5(
-            '(test AND "query") OR setup*', boolean=True,
+            '(test AND "query") OR setup*',
+            boolean=True,
         )
         assert '"' not in result
         assert "*" not in result
@@ -354,6 +373,7 @@ class TestAdapterOffsetDebounce:
 
     def _make_adapter(self):
         from genesis.channels.telegram.adapter_v2 import TelegramAdapterV2
+
         return TelegramAdapterV2(token="t", conversation_loop=AsyncMock())
 
     def test_sentinel_initialized_to_none(self):
@@ -450,7 +470,8 @@ class TestLivenessHTTPXRequest:
 
         calls = []
         req = LivenessHTTPXRequest(
-            connection_pool_size=1, on_success=lambda: calls.append(1),
+            connection_pool_size=1,
+            on_success=lambda: calls.append(1),
         )
         parent = AsyncMock()
         if do_request_exc is not None:
@@ -458,7 +479,8 @@ class TestLivenessHTTPXRequest:
         else:
             parent.return_value = do_request_result
         patcher = patch(
-            "telegram.request.HTTPXRequest.do_request", parent,
+            "telegram.request.HTTPXRequest.do_request",
+            parent,
         )
         return req, calls, patcher
 
@@ -494,3 +516,207 @@ class TestLivenessHTTPXRequest:
         req = LivenessHTTPXRequest(connection_pool_size=1)
         with patch("telegram.request.HTTPXRequest.do_request", AsyncMock(return_value=(200, b""))):
             await req.do_request(url="u", method="post")  # must not raise
+
+
+# ---- send_with_client_heal / _is_closed_client_error ----
+
+
+def _closed_client_error() -> NetworkError:
+    """Build the exact exception PTB raises when the send client is closed.
+
+    ``HTTPXRequest.do_request`` raises RuntimeError("This HTTPXRequest is not
+    initialized!"); ``_request_wrapper`` rewraps it as NetworkError(...) from exc.
+    """
+    inner = RuntimeError("This HTTPXRequest is not initialized!")
+    wrapped = NetworkError(f"Unknown error in HTTP implementation: {inner!r}")
+    wrapped.__cause__ = inner
+    return wrapped
+
+
+class TestClosedClientMatcher:
+    def test_matches_wrapped_error_on_message(self):
+        from genesis.channels.telegram.transport.send import _is_closed_client_error
+
+        assert _is_closed_client_error(_closed_client_error())
+
+    def test_matches_cause_chain_only(self):
+        # Outer message clean, signature only on the __cause__.
+        from genesis.channels.telegram.transport.send import _is_closed_client_error
+
+        e = NetworkError("Unknown error in HTTP implementation")
+        e.__cause__ = RuntimeError("This HTTPXRequest is not initialized!")
+        assert _is_closed_client_error(e)
+
+    def test_rejects_ordinary_network_errors(self):
+        from genesis.channels.telegram.transport.send import _is_closed_client_error
+
+        assert not _is_closed_client_error(TimedOut("Timed out"))
+        assert not _is_closed_client_error(NetworkError("Connection reset by peer"))
+
+    def test_no_infinite_loop_on_cyclic_cause(self):
+        from genesis.channels.telegram.transport.send import _is_closed_client_error
+
+        a = NetworkError("a")
+        b = NetworkError("b")
+        a.__cause__ = b
+        b.__cause__ = a  # cycle
+        assert _is_closed_client_error(a) is False  # terminates, no hang
+
+
+class TestSendWithClientHeal:
+    @pytest.mark.asyncio
+    async def test_heals_and_retries_once_then_succeeds(self):
+        from genesis.channels.telegram.transport.send import send_with_client_heal
+
+        bot = MagicMock()
+        bot.request.initialize = AsyncMock()
+        calls = {"n": 0}
+
+        async def send():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _closed_client_error()
+            return "delivered"
+
+        result = await send_with_client_heal(bot, send, stopping=lambda: False)
+        assert result == "delivered"
+        assert calls["n"] == 2  # first fails, heal, second succeeds
+        bot.request.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stopping_reraises_without_heal(self):
+        from genesis.channels.telegram.transport.send import send_with_client_heal
+
+        bot = MagicMock()
+        bot.request.initialize = AsyncMock()
+
+        async def send():
+            raise _closed_client_error()
+
+        with pytest.raises(NetworkError):
+            await send_with_client_heal(bot, send, stopping=lambda: True)
+        bot.request.initialize.assert_not_awaited()  # never resurrect on shutdown
+
+    @pytest.mark.asyncio
+    async def test_non_closed_error_reraises_without_heal(self):
+        from genesis.channels.telegram.transport.send import send_with_client_heal
+
+        bot = MagicMock()
+        bot.request.initialize = AsyncMock()
+
+        async def send():
+            raise TimedOut("Timed out")
+
+        with pytest.raises(TimedOut):
+            await send_with_client_heal(bot, send, stopping=lambda: False)
+        bot.request.initialize.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_heal_retry_still_failing_reraises_bounded(self):
+        # Client stays dead: heal once, retry, still fails -> raise (no loop).
+        from genesis.channels.telegram.transport.send import send_with_client_heal
+
+        bot = MagicMock()
+        bot.request.initialize = AsyncMock()
+
+        async def send():
+            raise _closed_client_error()
+
+        with pytest.raises(NetworkError):
+            await send_with_client_heal(bot, send, stopping=lambda: False)
+        bot.request.initialize.assert_awaited_once()  # exactly one heal attempt
+
+
+class TestAdapterDocumentHeal:
+    @pytest.mark.asyncio
+    async def test_document_heal_retry_uses_fresh_stream(self):
+        """Regression: on a heal-retry the document must re-stream from the
+        start. PTB's InputFile consumes the BytesIO to EOF on the first
+        (failing) attempt; a reused stream would upload zero bytes silently."""
+        from genesis.channels.telegram.adapter_v2 import TelegramAdapterV2
+
+        adapter = TelegramAdapterV2(token="123:ABC", conversation_loop=MagicMock())
+        adapter._app = MagicMock()
+        adapter._app.bot.request.initialize = AsyncMock()
+
+        seen: list[bytes] = []
+        calls = {"n": 0}
+
+        async def fake_send_document(bot, chat_id, document, **kwargs):
+            calls["n"] += 1
+            data = document.read()  # PTB consumes the stream at InputFile build
+            if calls["n"] == 1:
+                raise _closed_client_error()
+            seen.append(data)
+            return MagicMock(message_id=99)
+
+        with patch(
+            "genesis.channels.telegram.adapter_v2.safe_send_document",
+            side_effect=fake_send_document,
+        ):
+            msg_id = await adapter.send_document("123", b"PAYLOAD-BYTES", filename="f.txt")
+
+        assert msg_id == "99"
+        assert seen == [b"PAYLOAD-BYTES"]  # retry got the FULL payload, not b""
+        adapter._app.bot.request.initialize.assert_awaited_once()
+
+
+class TestClientHealE2E:
+    @pytest.mark.asyncio
+    async def test_real_ptb_closed_client_heals_and_delivers(self, caplog):
+        """End-to-end through REAL PTB: a shutdown-closed httpx send-client is
+        rebuilt by the heal and the message is delivered. Network is mocked via
+        httpx.MockTransport, but do_request, initialize(), and the NetworkError
+        wrap are all real PTB — this guards against a PTB upgrade changing
+        HTTPXRequest.initialize() rebuild semantics (the load-bearing mechanism).
+        """
+        import logging
+
+        from telegram import Bot
+        from telegram.request import HTTPXRequest
+
+        from genesis.channels.telegram.adapter_v2 import TelegramAdapterV2
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "message_id": 555,
+                        "date": 0,
+                        "chat": {"id": 123, "type": "private"},
+                        "text": "x",
+                    },
+                },
+            )
+
+        req = HTTPXRequest(httpx_kwargs={"transport": httpx.MockTransport(handler)})
+        bot = Bot(token="123:ABC", request=req)
+        conv = MagicMock()
+        conv._db = None  # skip DB persistence path
+        adapter = TelegramAdapterV2(token="123:ABC", conversation_loop=conv)
+        app = MagicMock()
+        app.bot = bot
+        adapter._app = app
+
+        try:
+            # Reproduce the 2026-07-15 state: the real send client is closed.
+            await bot.request.shutdown()
+            assert bot.request._client.is_closed
+
+            # Real adapter path: raises the real closed-client error, heals via
+            # real bot.request.initialize(), retries, delivers.
+            with caplog.at_level(logging.ERROR):
+                mid = await adapter.send_message("123", "after client closed")
+            assert mid == "555"
+            assert not bot.request._client.is_closed  # rebuilt
+
+            # During shutdown, the heal must NOT resurrect the client.
+            adapter._stopping = True
+            await bot.request.shutdown()
+            with pytest.raises(NetworkError):
+                await adapter.send_message("123", "during shutdown")
+            assert bot.request._client.is_closed
+        finally:
+            await req.shutdown()

--- a/tests/test_hosting/test_standalone_shutdown_ordering.py
+++ b/tests/test_hosting/test_standalone_shutdown_ordering.py
@@ -1,0 +1,65 @@
+"""StandaloneAdapter.shutdown ordering guard.
+
+Background senders that push through the Telegram send client (the outreach
+recovery worker) must be stopped BEFORE the Telegram adapter closes its httpx
+client. Otherwise a late retry fires through a torn-down client, raises the
+closed-client error, and after exhausting its retries gets permanently
+discarded — the failure that silently dropped two Sentinel approval requests
+on 2026-07-15. The runtime is only torn down AFTER the adapter, so the required
+order is: stop_outbound_senders -> adapter.stop -> runtime.shutdown.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.hosting.standalone import StandaloneAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_outbound_senders_stopped_before_telegram_client_closes():
+    adapter = StandaloneAdapter()
+
+    order: list[str] = []
+
+    runtime = MagicMock()
+    runtime.awareness_loop = None  # skip the soft-stop branch
+    runtime.stop_outbound_senders = AsyncMock(side_effect=lambda: order.append("stop_senders"))
+    runtime.shutdown = AsyncMock(side_effect=lambda: order.append("runtime_shutdown"))
+
+    telegram_adapter = MagicMock()
+    telegram_adapter.stop = AsyncMock(side_effect=lambda: order.append("adapter_stop"))
+
+    adapter._runtime = runtime
+    adapter._telegram_adapter = telegram_adapter
+    # Neutralize the unrelated shutdown steps so the test isolates ordering.
+    adapter._voice_last_breath = AsyncMock()
+    adapter._shutdown_wyoming_servers = AsyncMock()
+
+    await adapter.shutdown()
+
+    assert order == ["stop_senders", "adapter_stop", "runtime_shutdown"], (
+        "outbound senders must stop before the Telegram client closes, and the "
+        "runtime tears down last"
+    )
+
+
+async def test_shutdown_survives_absent_telegram_adapter():
+    # No Telegram configured: still stop senders, still shut the runtime down.
+    adapter = StandaloneAdapter()
+    order: list[str] = []
+
+    runtime = MagicMock()
+    runtime.awareness_loop = None
+    runtime.stop_outbound_senders = AsyncMock(side_effect=lambda: order.append("stop_senders"))
+    runtime.shutdown = AsyncMock(side_effect=lambda: order.append("runtime_shutdown"))
+
+    adapter._runtime = runtime
+    adapter._telegram_adapter = None
+    adapter._voice_last_breath = AsyncMock()
+    adapter._shutdown_wyoming_servers = AsyncMock()
+
+    await adapter.shutdown()
+
+    assert order == ["stop_senders", "runtime_shutdown"]

--- a/tests/test_runtime/test_runtime_shutdown.py
+++ b/tests/test_runtime/test_runtime_shutdown.py
@@ -214,3 +214,52 @@ async def test_shutdown_stops_direct_session_runner_before_db_close() -> None:
     assert db_was_usable == [True], (
         "runner.shutdown() must run BEFORE the DB closes"
     )
+
+
+@pytest.mark.asyncio
+async def test_stop_outbound_senders_stops_worker() -> None:
+    """stop_outbound_senders() must stop the outreach recovery worker so a late
+    retry can't fire through a Telegram send client the host is about to close
+    (the 2026-07-15 Sentinel-approval discard)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    GenesisRuntime.reset()
+    rt = GenesisRuntime.instance()
+    worker = MagicMock()
+    worker.stop = AsyncMock()
+    rt._outreach_recovery_worker = worker
+
+    await rt.stop_outbound_senders()
+
+    worker.stop.assert_awaited_once()
+    GenesisRuntime.reset()
+
+
+@pytest.mark.asyncio
+async def test_stop_outbound_senders_noop_when_worker_absent() -> None:
+    """When outreach init never ran, the attribute is unset — getattr(None)
+    must make this a safe no-op, never an AttributeError."""
+    GenesisRuntime.reset()
+    rt = GenesisRuntime.instance()
+    # Ensure the attribute is genuinely absent.
+    if hasattr(rt, "_outreach_recovery_worker"):
+        delattr(rt, "_outreach_recovery_worker")
+
+    await rt.stop_outbound_senders()  # must not raise
+    GenesisRuntime.reset()
+
+
+@pytest.mark.asyncio
+async def test_stop_outbound_senders_swallows_worker_error() -> None:
+    """A failing worker.stop() must never block or crash shutdown."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    GenesisRuntime.reset()
+    rt = GenesisRuntime.instance()
+    worker = MagicMock()
+    worker.stop = AsyncMock(side_effect=RuntimeError("boom"))
+    rt._outreach_recovery_worker = worker
+
+    await rt.stop_outbound_senders()  # must not raise
+    worker.stop.assert_awaited_once()
+    GenesisRuntime.reset()


### PR DESCRIPTION
## Problem

On 2026-07-15 the Telegram httpx **send**-client was closed while background senders kept firing, so every send raised PTB's closed-client error — `NetworkError` wrapping `RuntimeError("This HTTPXRequest is not initialized!")`. `is_safe_to_retry_send()` returns `False` for it, so the outreach recovery worker burned all 5 retries against the dead client and **permanently discarded two Sentinel approval requests** — the owner never saw them. This surfaced as the "Discarded review" card on the dashboard.

## Fix — two prongs

**BELT (self-heal).** New `send_with_client_heal(bot, send, *, stopping)` in `transport/send.py`: on a closed-client error, rebuild the send client via `bot.request.initialize()` (idempotent — `HTTPXRequest.initialize()` rebuilds only when `is_closed`, and has no skip-guard, unlike `Bot.initialize()`) and retry once — **unless** we're shutting down. Routed through every background/outbound send surface:
- `adapter_v2` `send_message` / `send_voice` / `send_document`
- `TopicManager._send_single` (all 3 direct `bot.send_message` calls)
- `DraftStreamer` draft sends

The adapter sets `_stopping` at the top of `stop()`; TopicManager/DraftStreamer take a `stopping` callable wired to it (default: never stopping). `send_document` builds a **fresh** `BytesIO` per attempt — PTB's `InputFile` drains the stream before the closed-client error is raised, so reusing one would upload zero bytes silently on the heal-retry.

**ROOT (shutdown ordering).** The outreach recovery worker was **never stopped** — absent from the runtime shutdown component list (a real latent bug). Added it there, and added `runtime.stop_outbound_senders()` which `standalone.shutdown()` now calls **before** `adapter.stop()` closes the client, so a late retry can't fire through a torn-down client. Idempotent + exception-guarded.

## Verification

- **124 targeted tests pass**; ruff clean.
- **Code review** caught a `send_document` BytesIO-reuse bug (fixed here + regression test).
- **E2E through real PTB 22.7** (`httpx.MockTransport`, no network): real `adapter.send_message` → real closed client → real closed-client error → real `initialize()` rebuild → **delivered**; shutdown path re-raises without resurrecting. Committed as `TestClientHealE2E`.

## Scope notes

- Only **background/outbound** senders are wrapped. `reply_text`/command handlers are inbound-reactive (they require a live polling client anyway) — a different failure class, not implicated in the 07-15 incident.
- Concurrent heals could momentarily build two clients (one orphaned, GC'd) — benign; not worth a lock on a rare shutdown-adjacent path.

Deploy: code-only (editable reinstall + `systemctl --user restart genesis-server`). No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
