### PR TITLE
fix(voice): serialize transcript writer appends to close double-fire race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Voice conversation delivery no longer double-writes turns under a burst.**
+  The `POST /v1/voice/conversation` landing did a read-then-append (count the
+  transcript's lines, then write the new turns) with an `await` in the middle.
+  Because the dashboard serves requests on threads that all feed one event
+  loop, two near-simultaneous deliveries of the same conversation (a voice
+  edge can fire the same disconnect twice within a second) could both read the
+  same line count and both append the same turns, duplicating them in the
+  transcript. Deliveries now hold a lock across the read-and-append so the
+  turns land exactly once.
 - **Legacy voice conversation blobs are swept from episodic memory.** The old
   one-blob landing left duplicated, ever-growing "Voice conversation [...]"
   memories polluting recall (and their vector embeddings polluting semantic

--- a/src/genesis/channels/voice/transcript_writer.py
+++ b/src/genesis/channels/voice/transcript_writer.py
@@ -17,12 +17,16 @@ Two producers share this component:
 Idempotency: session ids are deterministic (uuid5 of the external session
 id) and ``sync_cumulative`` appends only turns beyond the file's current
 line count — replays, double-fires and cumulative re-sends land exactly
-once. All methods MUST be called on the runtime event loop (single-writer;
-no file locking needed).
+once. Appends run under an ``asyncio.Lock``: the ``/v1/voice/conversation``
+route dispatches each request on its own WSGI thread onto the shared runtime
+loop, so without the lock two same-session cumulative syncs could both read
+line count N (across the ``await`` in the critical section) and both append
+the same delta — duplicating turns. All methods MUST be called on that loop.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -115,6 +119,10 @@ class VoiceTranscriptWriter:
         self._db = db
         self._dir = transcript_dir or voice_transcript_dir()
         self._registered: set[str] = set()
+        # Serializes the read-modify-write in append_message / sync_cumulative
+        # so concurrent same-session requests on the shared loop cannot
+        # interleave a line-count read with another append (double-write).
+        self._lock = asyncio.Lock()
 
     async def heal_orphans(self) -> int:
         """Complete 'active' voice rows idle >1h (boot + daily self-heal).
@@ -127,7 +135,8 @@ class VoiceTranscriptWriter:
 
         cutoff = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
         healed = await sessions_crud.complete_orphaned_voice_sessions(
-            self._db, idle_before=cutoff,
+            self._db,
+            idle_before=cutoff,
         )
         if healed:
             logger.info("Completed %d orphaned voice session row(s)", healed)
@@ -143,9 +152,10 @@ class VoiceTranscriptWriter:
         if role not in _ROLES or not text.strip():
             return
         sid = transcript_session_id(external_session_id)
-        await self._ensure_registered(sid)
-        self._append_lines(sid, [(role, text)])
-        await self._touch_activity(sid)
+        async with self._lock:
+            await self._ensure_registered(sid)
+            self._append_lines(sid, [(role, text)])
+            await self._touch_activity(sid)
 
     async def sync_cumulative(
         self,
@@ -162,24 +172,28 @@ class VoiceTranscriptWriter:
         """
         sid = transcript_session_id(external_session_id)
 
-        existing = self._line_count(sid)
-        if len(turns) < existing:
-            logger.warning(
-                "Voice cumulative sync for %s sent %d turns but transcript "
-                "already has %d — producer turn cache reset without a new "
-                "session id; appending nothing",
-                external_session_id[:32],
-                len(turns),
-                existing,
-            )
-            return 0
+        # The read (line count) and the append MUST be atomic w.r.t. other
+        # coroutines: concurrent same-session syncs on the shared loop would
+        # otherwise both read N and both append turns[N:] (double-write).
+        async with self._lock:
+            existing = self._line_count(sid)
+            if len(turns) < existing:
+                logger.warning(
+                    "Voice cumulative sync for %s sent %d turns but transcript "
+                    "already has %d — producer turn cache reset without a new "
+                    "session id; appending nothing",
+                    external_session_id[:32],
+                    len(turns),
+                    existing,
+                )
+                return 0
 
-        new_turns = [(t["role"], t["text"]) for t in turns[existing:]]
-        if new_turns:
-            await self._ensure_registered(sid)
-            self._append_lines(sid, new_turns)
-            await self._touch_activity(sid)
-        return len(new_turns)
+            new_turns = [(t["role"], t["text"]) for t in turns[existing:]]
+            if new_turns:
+                await self._ensure_registered(sid)
+                self._append_lines(sid, new_turns)
+                await self._touch_activity(sid)
+            return len(new_turns)
 
     async def close_session(self, external_session_id: str) -> None:
         """Mark a session's row completed (transcript stays for extraction)."""
@@ -201,7 +215,9 @@ class VoiceTranscriptWriter:
 
     async def _touch_activity(self, sid: str) -> None:
         await sessions_crud.update_activity(
-            self._db, sid, last_activity_at=datetime.now(UTC).isoformat(),
+            self._db,
+            sid,
+            last_activity_at=datetime.now(UTC).isoformat(),
         )
 
     def _path(self, sid: str) -> Path:

--- a/tests/test_channels/test_voice_transcript_writer.py
+++ b/tests/test_channels/test_voice_transcript_writer.py
@@ -7,6 +7,8 @@ transcripts the extraction job can mine, so the real parser is the oracle.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from genesis.channels.voice.transcript_writer import (
@@ -197,3 +199,33 @@ class TestVoiceTranscriptWriter:
         await writer.append_message("edge-1", "user", "   ")
         sid = transcript_session_id("edge-1")
         assert not (tmp_path / "voice" / f"{sid}.jsonl").exists()
+
+    async def test_concurrent_same_session_syncs_append_delta_once(self, writer, tmp_path):
+        """The route dispatches each POST on its own WSGI thread onto the shared
+        loop, so a double-fire (same cumulative list, near-simultaneous) runs
+        two sync_cumulative coroutines concurrently. Without the lock, both read
+        line-count N across the await in the critical section and both append
+        turns[N:] — duplicating the whole conversation. The lock serializes the
+        read-modify-write so the delta lands exactly once.
+
+        A yield is injected into _ensure_registered to force the interleave that
+        the lock must defeat; without the lock this test appends 2N lines.
+        """
+        orig_register = writer._ensure_registered
+
+        async def _slow_register(sid: str) -> None:
+            await asyncio.sleep(0)  # force a yield at the critical point
+            await orig_register(sid)
+
+        writer._ensure_registered = _slow_register
+
+        results = await asyncio.gather(
+            writer.sync_cumulative("edge-race", _turns(4)),
+            writer.sync_cumulative("edge-race", _turns(4)),
+        )
+
+        # One coroutine appends all 4, the other sees them already there.
+        assert sorted(results) == [0, 4]
+        sid = transcript_session_id("edge-race")
+        messages = read_transcript_messages(tmp_path / "voice" / f"{sid}.jsonl")
+        assert len(messages) == 4


### PR DESCRIPTION
## Summary

Closes a double-write race in the W0.5 voice conversation landing (`POST /v1/voice/conversation`, #1155).

`VoiceTranscriptWriter.sync_cumulative` did a read-modify-write — count the transcript's lines, then append `turns[N:]` — with an `await` (`_ensure_registered`) **inside** the critical section. The dashboard Flask serves requests `threaded=True`, and every voice request dispatches onto the one shared runtime loop via `run_coroutine_threadsafe`. So two near-simultaneous deliveries of the same conversation (a voice edge fires the same disconnect twice within a second — observed live) could both read line-count N and both append the same delta, duplicating the whole conversation in the transcript.

## Fix

A writer-level `asyncio.Lock` held across the read-modify-write in both `sync_cumulative` and `append_message`, so the read and the append are atomic with respect to other coroutines on the shared loop.

## Testing

- New regression test drives two concurrent same-session `sync_cumulative` calls with a yield injected into `_ensure_registered`; the delta lands exactly once. **Proven discriminating** — with the lock neutralized the same scenario writes 2N lines.
- Full voice writer / route / hygiene / s2s / extraction + store-coverage guardrail suites green (85 tests).

## Context

Prerequisite for the follow-on GENesis-Voice change that switches the edge s2s bridge from the legacy blob endpoint to `POST /v1/voice/conversation` — where the double-fire actually reaches this path. Ships ahead of it so the core is protected before the edge starts delivering cumulative turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
