### PR TITLE
perf(memory): vectorize + cache procedure surfacing (A1)

### DIFF
--- a/src/genesis/learning/procedural/embedding.py
+++ b/src/genesis/learning/procedural/embedding.py
@@ -16,6 +16,8 @@ import math
 import struct
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     from genesis.memory.embeddings import EmbeddingProvider
 
@@ -97,3 +99,39 @@ def cosine_similarity(a: list[float], b: list[float]) -> float:
     if na == 0.0 or nb == 0.0:
         return 0.0
     return dot / (na * nb)
+
+
+def normalize_rows(matrix: np.ndarray) -> np.ndarray:
+    """L2-normalize each row of an ``(N, D)`` matrix.
+
+    Zero-norm rows are left as zero rows, so their dot with any query is 0.0 —
+    matching :func:`cosine_similarity`'s zero-norm contract. Intended to run
+    ONCE at cache-build time (see ``memory.proactive._load_procedure_cache``),
+    hoisting normalization out of the per-query hot path.
+    """
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return matrix / norms
+
+
+def cosine_similarity_batch(normalized_matrix: np.ndarray, query: list[float]) -> np.ndarray:
+    """Cosine of ``query`` against every row of a PRE-normalized ``(N, D)`` matrix.
+
+    Returns an ``(N,)`` float64 array — the vectorized (single matmul, GIL-
+    releasing) equivalent of calling :func:`cosine_similarity` once per row,
+    without the per-row Python overhead. Rows MUST already be L2-normalized via
+    :func:`normalize_rows`. Edge cases return an all-zeros result to match the
+    scalar contract: empty matrix, zero-norm query, or a query whose length
+    differs from the matrix width (the scalar helper returns 0.0 on length
+    mismatch, never raising).
+    """
+    n = normalized_matrix.shape[0]
+    if normalized_matrix.size == 0:
+        return np.zeros(n, dtype=np.float64)
+    q = np.asarray(query, dtype=np.float64)
+    if q.ndim != 1 or q.shape[0] != normalized_matrix.shape[1]:
+        return np.zeros(n, dtype=np.float64)
+    qn = np.linalg.norm(q)
+    if qn == 0.0:
+        return np.zeros(n, dtype=np.float64)
+    return normalized_matrix @ (q / qn)

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -349,6 +349,25 @@ async def _surface_procedure(db: Any, vector: list[float]) -> dict | None:
     if best_idx < 0:
         return None
     proc_id, task_type, principle, tier = cache.meta[best_idx]
+
+    # The cache is up to TTL stale, so it can still hold a procedure that was
+    # quarantined/deprecated since the build — the exclusion the bulk SQL filter
+    # (deprecated=0 AND quarantined=0) would otherwise re-apply every call. Verify
+    # the single winner live before surfacing: one PK lookup, only on the surface
+    # path (a minority of prompts). Fail-closed — if it is gone, excluded, or the
+    # check errors, surface nothing this turn (self-heals at the next rebuild)
+    # rather than advise a procedure the rest of the system now excludes.
+    try:
+        live = await db.execute_fetchall(
+            "SELECT 1 FROM procedural_memory "
+            "WHERE id = ? AND deprecated = 0 AND quarantined = 0 LIMIT 1",
+            (proc_id,),
+        )
+    except Exception:
+        return None
+    if not live:
+        return None
+
     return {"id": proc_id, "task_type": task_type, "principle": principle[:200], "tier": tier}
 
 

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -237,16 +237,45 @@ DEFAULT_PROFILE = "cc_hook"
 _PROCEDURE_SURFACE_THRESHOLD = 0.7
 _DORMANT_SURFACE_THRESHOLD = 0.78
 
+# TTL for the surfaceable-procedure cache. Procedure principle embeddings change
+# rarely (novelty-gated writes), so a stale-by-≤300s cache on a soft top-1
+# advisory is fine — and it keeps the ~300-row read + BLOB unpack + row
+# normalization off the per-prompt hot path (they run once per TTL, not every
+# call). The pure-Python O(n·d) cosine loop that dominated the old path
+# (~98ms/call — DB read + unpack + scalar cosine over ~300×1024) becomes one
+# cached matmul (~0.25ms). Single event loop → no lock needed (a concurrent
+# rebuild just recomputes identical data, last writer wins).
+_PROCEDURE_CACHE_TTL_S = 300.0
 
-async def _surface_procedure(db: Any, vector: list[float]) -> dict | None:
-    """Return ``{"id", "task_type", "principle", "tier"}`` for the best
-    procedure clearing its tier-dependent cosine bar, else None."""
+
+@dataclass(frozen=True)
+class _ProcedureCache:
+    """Pre-normalized principle-embedding matrix + row-aligned metadata."""
+
+    matrix: Any  # (N, D) L2-normalized float64 ndarray (np.empty((0, 0)) when N=0)
+    meta: list[tuple[str, str, str, str]]  # (id, task_type, principle, tier), row-aligned
+    built_at: float  # time.monotonic() at build
+
+
+_procedure_cache: _ProcedureCache | None = None
+
+
+async def _load_procedure_cache(db: Any) -> _ProcedureCache | None:
+    """Return the cached surfaceable-procedure matrix, rebuilding past the TTL.
+
+    On a DB/read error the prior cache is kept (returns None only when one was
+    never built) — strictly more resilient than the old per-call path, which
+    surfaced nothing on a transient error, and still bounded by the TTL.
+    """
+    global _procedure_cache
+    now = time.monotonic()
+    cache = _procedure_cache
+    if cache is not None and (now - cache.built_at) < _PROCEDURE_CACHE_TTL_S:
+        return cache
+
+    from genesis.learning.procedural.embedding import normalize_rows, unpack_embedding
+
     try:
-        from genesis.learning.procedural.embedding import (
-            cosine_similarity,
-            unpack_embedding,
-        )
-
         rows = await db.execute_fetchall(
             "SELECT id, task_type, principle, principle_embedding, activation_tier "
             "FROM procedural_memory "
@@ -255,26 +284,58 @@ async def _surface_procedure(db: Any, vector: list[float]) -> dict | None:
             "ORDER BY confidence DESC LIMIT 1000"
         )
     except Exception:
-        return None  # table absent / DB error — never block the endpoint
+        logger.debug("procedure cache reload failed — keeping prior cache", exc_info=True)
+        return cache  # table absent / DB error — never block the endpoint
 
-    best: tuple[float, str, str, str, str] | None = None
+    import numpy as np
+
+    vectors: list[list[float]] = []
+    meta: list[tuple[str, str, str, str]] = []
     for row in rows:
-        existing = unpack_embedding(row[3])
-        if existing is None:
+        vec = unpack_embedding(row[3])
+        if vec is None:
             continue
-        sim = cosine_similarity(vector, existing)
-        tier = row[4] or "DORMANT"
+        vectors.append(vec)
+        meta.append((row[0], row[1] or "", row[2] or "", row[4] or "DORMANT"))
+
+    matrix = normalize_rows(np.asarray(vectors, dtype=np.float64)) if vectors else np.empty((0, 0))
+    _procedure_cache = _ProcedureCache(matrix=matrix, meta=meta, built_at=now)
+    return _procedure_cache
+
+
+async def _surface_procedure(db: Any, vector: list[float]) -> dict | None:
+    """Return ``{"id", "task_type", "principle", "tier"}`` for the best
+    procedure clearing its tier-dependent cosine bar, else None.
+
+    Vectorized against the TTL-cached, pre-normalized matrix (see
+    :func:`_load_procedure_cache`) — exact-parity with the old per-row scalar
+    loop: same confidence-DESC row order, same strict ``>`` tie-break (first/
+    highest-confidence wins), same per-tier thresholds.
+    """
+    from genesis.learning.procedural.embedding import cosine_similarity_batch
+
+    cache = await _load_procedure_cache(db)
+    if cache is None or not cache.meta:
+        return None
+
+    sims = cosine_similarity_batch(cache.matrix, vector)
+
+    best_idx = -1
+    best_sim = -1.0
+    for idx, (_pid, _task, _principle, tier) in enumerate(cache.meta):
         threshold = (
             _DORMANT_SURFACE_THRESHOLD if tier == "DORMANT" else _PROCEDURE_SURFACE_THRESHOLD
         )
+        sim = float(sims[idx])
         if sim < threshold:
             continue
-        if best is None or sim > best[0]:
-            best = (sim, row[0], row[1] or "", row[2] or "", tier)
+        if sim > best_sim:
+            best_sim = sim
+            best_idx = idx
 
-    if best is None:
+    if best_idx < 0:
         return None
-    _sim, proc_id, task_type, principle, tier = best
+    proc_id, task_type, principle, tier = cache.meta[best_idx]
     return {"id": proc_id, "task_type": task_type, "principle": principle[:200], "tier": tier}
 
 

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -263,9 +263,14 @@ _procedure_cache: _ProcedureCache | None = None
 async def _load_procedure_cache(db: Any) -> _ProcedureCache | None:
     """Return the cached surfaceable-procedure matrix, rebuilding past the TTL.
 
-    On a DB/read error the prior cache is kept (returns None only when one was
-    never built) — strictly more resilient than the old per-call path, which
-    surfaced nothing on a transient error, and still bounded by the TTL.
+    On a DB/read error the last good cache is served (returns None only when one
+    was never built) — more resilient than the old per-call path, which surfaced
+    nothing on a transient error. Staleness is normally ≤ TTL, but during a
+    *sustained* read outage the last snapshot is served until the DB recovers
+    (acceptable for a soft top-1 advisory; a down DB fails ``recall()`` upstream
+    long before this matters). The cache is process-global and NOT keyed on
+    ``db`` — correct because the runtime passes exactly one process-global
+    connection (``memory_mod._db``) for its whole lifetime.
     """
     global _procedure_cache
     now = time.monotonic()
@@ -296,7 +301,12 @@ async def _load_procedure_cache(db: Any) -> _ProcedureCache | None:
         if vec is None:
             continue
         vectors.append(vec)
-        meta.append((row[0], row[1] or "", row[2] or "", row[4] or "DORMANT"))
+        # Principle is truncated to the returned width here so the cache doesn't
+        # pin full principle text for every row over the TTL (only [:200] is ever
+        # surfaced). float64 matrix is deliberate — the scalar cosine_similarity
+        # computes in Python float; a float32 matmul would diverge ~1e-6 and can
+        # flip a near-threshold surface, so keep float64 for parity.
+        meta.append((row[0], row[1] or "", (row[2] or "")[:200], row[4] or "DORMANT"))
 
     matrix = normalize_rows(np.asarray(vectors, dtype=np.float64)) if vectors else np.empty((0, 0))
     _procedure_cache = _ProcedureCache(matrix=matrix, meta=meta, built_at=now)
@@ -308,9 +318,12 @@ async def _surface_procedure(db: Any, vector: list[float]) -> dict | None:
     procedure clearing its tier-dependent cosine bar, else None.
 
     Vectorized against the TTL-cached, pre-normalized matrix (see
-    :func:`_load_procedure_cache`) — exact-parity with the old per-row scalar
-    loop: same confidence-DESC row order, same strict ``>`` tie-break (first/
-    highest-confidence wins), same per-tier thresholds.
+    :func:`_load_procedure_cache`) — parity with the old per-row scalar loop
+    within floating-point tolerance (measured Δ ~1e-16 vs the scalar cosine):
+    same confidence-DESC row order, same strict ``>`` tie-break (first/highest-
+    confidence wins), same per-tier thresholds. The only conceivable divergence
+    is a cosine sitting within ~machine-ε of a tier bar flipping surface/skip —
+    measure-zero on continuous embeddings and immaterial for a soft advisory.
     """
     from genesis.learning.procedural.embedding import cosine_similarity_batch
 

--- a/tests/test_memory/test_procedure_surface_parity.py
+++ b/tests/test_memory/test_procedure_surface_parity.py
@@ -67,12 +67,17 @@ _Row = tuple[str, str, str, bytes, str | None]
 
 
 class _FakeDB:
-    """Minimal stand-in exposing the one method _load_procedure_cache uses."""
+    """Stand-in for the runtime db. The bulk query (no params) returns the cached
+    rows; the winner recheck (``WHERE id = ?``, one param) returns a truthy row
+    iff that id is still "live" (default: every row is live)."""
 
-    def __init__(self, rows: list[_Row]) -> None:
+    def __init__(self, rows: list[_Row], live_ids: set[str] | None = None) -> None:
         self._rows = rows
+        self._live_ids = {r[0] for r in rows} if live_ids is None else set(live_ids)
 
-    async def execute_fetchall(self, _sql: str, _params: object = None) -> list[_Row]:
+    async def execute_fetchall(self, _sql: str, params: object = None) -> list:
+        if params is not None:  # winner recheck
+            return [(1,)] if params[0] in self._live_ids else []
         return self._rows
 
 
@@ -156,3 +161,19 @@ async def test_surface_procedure_empty_and_bad_rows() -> None:
     proactive._procedure_cache = None
     got = await proactive._surface_procedure(_FakeDB([bad, good]), q)
     assert got is not None and got["id"] == "good"
+
+
+async def test_surface_procedure_rechecks_live_winner() -> None:
+    """A procedure still in the (≤TTL stale) cache but quarantined/deprecated
+    since the build must NOT surface — the winner is re-verified live first."""
+    rng = np.random.default_rng(11)
+    q = _rand_vec(rng)
+    row = ("q1", "task", "p", pack_embedding(q), "CORE")  # self-match clears the bar
+
+    proactive._procedure_cache = None
+    got = await proactive._surface_procedure(_FakeDB([row]), q)
+    assert got is not None and got["id"] == "q1"  # live → surfaces
+
+    proactive._procedure_cache = None
+    got = await proactive._surface_procedure(_FakeDB([row], live_ids=set()), q)
+    assert got is None  # excluded since build → suppressed

--- a/tests/test_memory/test_procedure_surface_parity.py
+++ b/tests/test_memory/test_procedure_surface_parity.py
@@ -1,0 +1,158 @@
+"""Parity guard for the vectorized procedure surfacing (A1).
+
+``memory.proactive._surface_procedure`` was reworked from a per-row pure-Python
+``cosine_similarity`` loop over ~300 principle embeddings (read + unpacked every
+call) into one cached matmul against a TTL-cached, pre-normalized matrix. These
+tests lock the vectorized path to the exact behavior of the old scalar loop —
+same cosines (within float tolerance), same tie-break, same per-tier thresholds.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from genesis.learning.procedural.embedding import (
+    EMBEDDING_DIM,
+    cosine_similarity,
+    cosine_similarity_batch,
+    normalize_rows,
+    pack_embedding,
+)
+from genesis.memory import proactive
+
+
+def _rand_vec(rng: np.random.Generator, dim: int = EMBEDDING_DIM) -> list[float]:
+    return [float(x) for x in rng.standard_normal(dim)]
+
+
+# --------------------------------------------------------------------------- #
+# Helper-level parity: batched cosine == scalar cosine, per row.
+# --------------------------------------------------------------------------- #
+
+
+def test_cosine_batch_matches_scalar_randomized() -> None:
+    rng = np.random.default_rng(1234)
+    for _ in range(100):
+        n = int(rng.integers(1, 40))
+        dim = int(rng.integers(2, 64))
+        vecs = [_rand_vec(rng, dim) for _ in range(n)]
+        if n > 2:  # ensure a zero row is exercised (cosine 0.0)
+            vecs[1] = [0.0] * dim
+        query = _rand_vec(rng, dim)
+
+        matrix = normalize_rows(np.asarray(vecs, dtype=np.float64))
+        batched = cosine_similarity_batch(matrix, query)
+        scalar = [cosine_similarity(query, v) for v in vecs]
+
+        assert np.allclose(batched, scalar, atol=1e-9), (batched.tolist(), scalar)
+
+
+def test_cosine_batch_edge_cases() -> None:
+    matrix = normalize_rows(np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=np.float64))
+    # zero-norm query -> all zeros (matches scalar contract)
+    assert list(cosine_similarity_batch(matrix, [0.0, 0.0])) == [0.0, 0.0]
+    # length mismatch -> all zeros, never raises (scalar returns 0.0)
+    assert list(cosine_similarity_batch(matrix, [1.0, 0.0, 0.0])) == [0.0, 0.0]
+    # empty matrix -> empty result
+    assert cosine_similarity_batch(np.empty((0, 0)), [1.0, 0.0]).shape == (0,)
+
+
+# --------------------------------------------------------------------------- #
+# Function-level parity: _surface_procedure vs a verbatim reference of the
+# pre-refactor scalar algorithm.
+# --------------------------------------------------------------------------- #
+
+_Row = tuple[str, str, str, bytes, str | None]
+
+
+class _FakeDB:
+    """Minimal stand-in exposing the one method _load_procedure_cache uses."""
+
+    def __init__(self, rows: list[_Row]) -> None:
+        self._rows = rows
+
+    async def execute_fetchall(self, _sql: str, _params: object = None) -> list[_Row]:
+        return self._rows
+
+
+def _reference_surface(rows: list[_Row], vector: list[float]) -> dict | None:
+    """The old per-row scalar algorithm, verbatim (the oracle)."""
+    best: tuple[float, str, str, str, str] | None = None
+    for row in rows:
+        from genesis.learning.procedural.embedding import unpack_embedding
+
+        existing = unpack_embedding(row[3])
+        if existing is None:
+            continue
+        sim = cosine_similarity(vector, existing)
+        tier = row[4] or "DORMANT"
+        threshold = 0.78 if tier == "DORMANT" else 0.7
+        if sim < threshold:
+            continue
+        if best is None or sim > best[0]:
+            best = (sim, row[0], row[1] or "", row[2] or "", tier)
+    if best is None:
+        return None
+    _sim, proc_id, task_type, principle, tier = best
+    return {"id": proc_id, "task_type": task_type, "principle": principle[:200], "tier": tier}
+
+
+@pytest.fixture(autouse=True)
+def _reset_procedure_cache():
+    """The TTL cache is module-global — clear it around every case so each fake
+    db is actually read rather than served stale."""
+    proactive._procedure_cache = None
+    yield
+    proactive._procedure_cache = None
+
+
+async def test_surface_procedure_matches_reference_randomized() -> None:
+    rng = np.random.default_rng(42)
+    tiers = ["CORE", "ADVISORY", "LIBRARY", "DORMANT", None]
+    for case in range(120):
+        query = np.asarray(_rand_vec(rng), dtype=np.float64)
+        rows: list[_Row] = []
+        n = int(rng.integers(0, 12))
+        for i in range(n):
+            # Blend the query direction with noise so cosines span both sides of
+            # the 0.7 / 0.78 tier bars (some surface, some don't).
+            w = float(rng.uniform(0.4, 1.0))
+            emb = w * query + (1.0 - w) * np.asarray(_rand_vec(rng), dtype=np.float64)
+            tier = tiers[int(rng.integers(0, len(tiers)))]
+            rows.append(
+                (
+                    f"proc{i:02d}",
+                    f"task_type_{i}",
+                    f"principle text {i} " + "x" * 250,  # > 200 chars → exercises [:200]
+                    pack_embedding([float(x) for x in emb]),
+                    tier,
+                )
+            )
+
+        proactive._procedure_cache = None
+        got = await proactive._surface_procedure(_FakeDB(rows), [float(x) for x in query])
+        want = _reference_surface(rows, [float(x) for x in query])
+        assert got == want, (case, got, want)
+
+
+async def test_surface_procedure_empty_and_bad_rows() -> None:
+    # No rows -> None
+    assert (
+        await proactive._surface_procedure(_FakeDB([]), _rand_vec(np.random.default_rng(1))) is None
+    )
+
+    # A row with a corrupt (wrong-length) embedding blob is skipped, not crashed.
+    rng = np.random.default_rng(7)
+    q = _rand_vec(rng)
+    good = (
+        "good",
+        "task",
+        "p",
+        pack_embedding(q),  # identical to query → cosine 1.0, clears any bar
+        "CORE",
+    )
+    bad = ("bad", "task", "p", b"\x00\x01\x02", "CORE")  # wrong length → unpack None
+    proactive._procedure_cache = None
+    got = await proactive._surface_procedure(_FakeDB([bad, good]), q)
+    assert got is not None and got["id"] == "good"


### PR DESCRIPTION
## What

`_surface_procedure` (the proactive-recall procedure surfacing) ran a
per-call **pure-Python** cosine loop over every surfaceable procedure —
reading ~300 rows, unpacking each 4 KB `principle_embedding` BLOB, and computing
`cosine_similarity` (`sum(x*y ...)`, `math.sqrt`) 1024-dim × ~300 times — on the
**single runtime event loop**, on **every** prompt that hits the endpoint or the
`memory_proactive` MCP tool. Measured ~98 ms/call (DB read 21 + unpack 25 +
scalar cosine 52). This is the same class of loop-blocking hot spot as the
#1161 Jaccard fix, and it stacks under concurrency.

This replaces it with **one numpy matmul against a TTL-cached (300s),
pre-normalized matrix** of the principle embeddings:
- The ~300-row read + BLOB unpack + row normalization run **once per TTL**, not
  every call.
- The cosine becomes a single GIL-releasing matmul: **~0.3 ms/call** warm.

## Parity

Exact within floating-point tolerance — same confidence-DESC row order, same
strict-`>` tie-break, same per-tier thresholds (0.7 / 0.78), same `[:200]`
slice. Measured Δ vs the scalar cosine = **1.5e-16**.

- New `tests/test_memory/test_procedure_surface_parity.py`: randomized oracle
  (120 cases) comparing `_surface_procedure` to a verbatim copy of the old
  scalar algorithm, plus helper-level batch-vs-scalar parity and edge cases
  (empty/bad rows, zero/dim-mismatch query).
- Live-data check against the real 303 procedures: **100/100** parity vs the
  scalar reference; warm-cache **0.342 ms/call** (was ~98 ms).

## Notes

- New helpers `normalize_rows` / `cosine_similarity_batch` in
  `learning/procedural/embedding.py`; scalar `cosine_similarity` kept for the
  extractor novelty gate (unchanged).
- Cache is process-global and TTL-based (not keyed on `db`) — correct because
  the runtime passes one process-global connection; single event loop → no lock.
  On a sustained DB outage the last-good snapshot is served until recovery
  (acceptable for a soft top-1 advisory).
- Matrix kept float64 deliberately (float32 would diverge ~1e-6 and could flip a
  near-threshold surface).

Standalone recall-perf PR — the first of the hook-track work (procedure-cache
prerequisite before the proactive-hook thin-client flip). Part of follow-up
`48aa976c` (not closed by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
