### PR TITLE
fix(dashboard): deploy-aware Services card — no false stale mid-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The dashboard no longer shows a false "degraded / sentinel stale" during an
+  update.** While `update.sh` restarts the server, the freshly booted server's
+  sentinel heartbeat is briefly empty, which used to paint the Services card
+  amber ("sentinel stale — last heartbeat Nm ago") even though nothing was
+  wrong. The health snapshot now recognizes an in-progress deploy (the same
+  signal the watchdog already uses to defer restarts) and shows a neutral
+  "deploying" state for that window instead — a genuine fault (an escalated
+  sentinel, a down service) still shows through.
 - **Voice conversation delivery no longer double-writes turns under a burst.**
   The `POST /v1/voice/conversation` landing did a read-then-append (count the
   transcript's lines, then write the new turns) with an `await` in the middle.

--- a/src/genesis/dashboard/webui/css/components.css
+++ b/src/genesis/dashboard/webui/css/components.css
@@ -36,8 +36,8 @@
 .chip--ok    { color: var(--ok);    background: color-mix(in srgb, var(--ok-dim) 45%, transparent);    border-color: var(--ok-dim); }
 .chip--warn  { color: var(--warn);  background: color-mix(in srgb, var(--warn-dim) 45%, transparent);  border-color: var(--warn-dim); }
 .chip--err   { color: var(--err);   background: color-mix(in srgb, var(--err-dim) 45%, transparent);   border-color: var(--err-dim); }
-/* chip--info is NOT a health state (chipState never returns it) — it's for
- * informational/neutral chips applied via static class, e.g. count badges. */
+/* chip--info = the transient "deploying" state (chipState returns "info" for it)
+ * plus informational/neutral chips applied via a static class, e.g. count badges. */
 .chip--info  { color: var(--info);  background: color-mix(in srgb, var(--info-dim) 45%, transparent);  border-color: var(--info-dim); }
 .chip--stale { color: var(--stale); background: color-mix(in srgb, var(--stale) 12%, transparent);     border-color: color-mix(in srgb, var(--stale) 35%, transparent); }
 /* chip--action = "needs your action" (e.g. pending approvals). Reuses the

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3209,7 +3209,7 @@
           // chipState() the chips use, so the two surfaces can never disagree
           // about what a state means. Values match the token palette
           // (--ok/--warn/--err); off/idle/unknown keep the historical dot gray.
-          const colors = { ok: "#4caf50", warn: "#f0ad4e", err: "#d9534f", stale: "#9e9e9e", action: "#7c4dff", off: "#888" };
+          const colors = { ok: "#4caf50", warn: "#f0ad4e", err: "#d9534f", stale: "#9e9e9e", action: "#7c4dff", info: "#2196f3", off: "#888" };
           return colors[chipState(state)] || "#888";
         },
 
@@ -3405,13 +3405,27 @@
           const services = this.health.services;
           if (!services || services.status === "unknown") return { state: "unknown", reason: "service status unavailable" };
           const svcLabel = (services?.bridge?.service_label || "Genesis").toLowerCase();
+          // A deploy intentionally stops/restarts the server. Suppress only the
+          // TRANSIENT signals it causes (the server briefly "activating"; the fresh
+          // server's empty sentinel heartbeat reading stale — the latter already
+          // suppressed server-side). GENUINE faults (host-framework down, watchdog
+          // restart-loop, an escalated/investigating sentinel) must still win, so the
+          // neutral "deploying" verdict is returned LAST — only if nothing real is wrong.
+          const deploying = !!services?.deploying;
           // Host framework health
           const hf = services?.host_framework;
           if (hf?.detected && (hf.status === "down" || hf.status === "error")) {
             return { state: "error", reason: `${hf.name} is ${hf.status}` };
           }
-          if (services?.bridge?.active_state && services.bridge.active_state !== "active") {
-            if (services.bridge.active_state === "unknown") {
+          // During a deploy the server is legitimately restarting — suppress ONLY
+          // the transient systemd states (activating/deactivating/reloading). A
+          // genuinely failed/inactive unit still reads red (e.g. update.sh's
+          // direct-serve fallback can leave the systemd unit failed while a bare
+          // process serves the dashboard).
+          const svcState = services?.bridge?.active_state;
+          const svcTransient = deploying && ["activating", "deactivating", "reloading"].includes(svcState);
+          if (svcState && svcState !== "active" && !svcTransient) {
+            if (svcState === "unknown") {
               return { state: "unknown", reason: `${svcLabel} service state is unknown` };
             }
             return { state: "error", reason: `${svcLabel} service is not active` };
@@ -3445,6 +3459,9 @@
               return { state: "degraded", reason: `sentinel ${label}` };
             }
           }
+          // Nothing genuine is wrong — surface the in-progress deploy as neutral
+          // (info) rather than a false "healthy" mid-restart.
+          if (deploying) return { state: "deploying", reason: "deploy in progress" };
           return { state: "healthy", reason: `${svcLabel} and watchdog services are active` };
         },
 

--- a/src/genesis/dashboard/webui/js/ui-utils.js
+++ b/src/genesis/dashboard/webui/js/ui-utils.js
@@ -51,6 +51,9 @@ export function chipState(health, lastRun = null, nowMs = Date.now()) {
   // approvals). Not a fault and not neutral-quiet: its own visible state so it
   // never masquerades as degraded (a fault) or healthy (nothing to do).
   if (["needs action", "action", "attention"].includes(h)) return "action";
+  // "deploying" — an update is in progress (server intentionally down/restarting).
+  // Informational, not a fault: render neutral-blue (chip--info), never amber/red.
+  if (h === "deploying") return "info";
   return "warn"; // genuinely novel health value: surface it, don't hide it
 }
 
@@ -60,8 +63,8 @@ export function chipClass(state) {
 }
 
 /** Shape glyph per state — color-blind support without icon fonts.
- * ("info" is not a health state — chipState never returns it — but chips
- * using .chip--info via static class can still ask for its glyph.) */
+ * ("info" is the transient "deploying" state (chipState) plus chips using
+ * .chip--info via a static class.) */
 export function chipGlyph(state) {
   return { ok: "●", warn: "▲", err: "✕", stale: "◔", info: "ℹ", action: "◆", off: "○" }[state] ?? "●";
 }

--- a/src/genesis/observability/snapshots/services.py
+++ b/src/genesis/observability/snapshots/services.py
@@ -41,6 +41,21 @@ def _finish_services(result: dict) -> dict:
     Host-framework ``detect()`` is near-free (empty detector registry, 30s cache),
     so it stays here too rather than warranting its own offload.
     """
+    # Deploy-aware: update.sh/restore intentionally stop genesis-server during a
+    # deploy. Reuse the SAME signal the watchdog honors (env.update_in_progress —
+    # PID-liveness + phase-gated + 4h-bounded, fail-open to False) so the dashboard
+    # shows "deploying" instead of a false "degraded/stale". The visible window is
+    # the post-restart health_check phase (fresh server, empty sentinel heartbeat →
+    # would read stale); the full server-down window is correctly invisible (no
+    # server to serve /health).
+    try:
+        from genesis.env import update_in_progress
+
+        deploying = bool(update_in_progress())
+    except Exception:
+        deploying = False
+    result["deploying"] = deploying
+
     # Host framework detection (USB mode)
     try:
         status = _get_registry().detect()
@@ -84,10 +99,17 @@ def _finish_services(result: dict) -> dict:
                 age_s = 9999  # No heartbeat recorded yet — treat as stale
             is_stale = age_s > 600  # 10 min = 2x awareness loop interval
 
-            # Only override to "stale" when sentinel reports healthy — active
-            # states (investigating, escalated) are more informative than stale.
+            # Only coerce a HEALTHY sentinel — active states (investigating,
+            # escalated, remediating, awaiting_*) are more informative and must
+            # not be masked by "stale" or "deploying". During a deploy the fresh
+            # server's heartbeat is legitimately empty (not stale): suppress stale
+            # and surface "deploying" so the dashboard reads informational, not red.
             reported_state = state.current_state
-            if is_stale and reported_state == "healthy":
+            if deploying:
+                is_stale = False
+                if reported_state == "healthy":
+                    reported_state = "deploying"
+            elif is_stale and reported_state == "healthy":
                 reported_state = "stale"
 
             result["sentinel"] = {

--- a/tests/test_observability/test_services_snapshot.py
+++ b/tests/test_observability/test_services_snapshot.py
@@ -23,6 +23,7 @@ from genesis.runtime._core import GenesisRuntime
 
 def _fake_sentinel(current_state="healthy", is_active=False, **kw):
     from datetime import UTC, datetime
+
     state = SimpleNamespace(
         current_state=current_state,
         last_trigger_source=kw.get("last_trigger_source", ""),
@@ -57,12 +58,14 @@ def test_services_includes_sentinel_key_when_healthy(runtime_singleton):
 
 
 def test_services_sentinel_investigating_active(runtime_singleton):
-    _install_runtime(_fake_sentinel(
-        current_state="investigating",
-        is_active=True,
-        last_trigger_source="fire_alarm",
-        last_trigger_reason="router.all_exhausted",
-    ))
+    _install_runtime(
+        _fake_sentinel(
+            current_state="investigating",
+            is_active=True,
+            last_trigger_source="fire_alarm",
+            last_trigger_reason="router.all_exhausted",
+        )
+    )
     result = services()
     assert result["sentinel"]["current_state"] == "investigating"
     assert result["sentinel"]["is_active"] is True
@@ -87,7 +90,8 @@ def test_services_sentinel_unavailable_when_sentinel_is_none(runtime_singleton):
 
 
 def test_services_sentinel_unavailable_when_runtime_not_bootstrapped(
-    runtime_singleton, monkeypatch,
+    runtime_singleton,
+    monkeypatch,
 ):
     """The real bootstrap-never-ran path: the snapshot reads the runtime via
     ``peek()`` and reports 'unavailable' without ever constructing one.
@@ -114,3 +118,45 @@ def test_services_sentinel_unavailable_when_runtime_not_bootstrapped(
     # The snapshot must read the runtime via peek() (never instance(), which would
     # construct). If a future change swaps peek() for instance(), this fails.
     peek_spy.assert_called()
+
+
+# ── Deploy-aware display (services.deploying reuses env.update_in_progress) ──
+
+
+def _stale_heartbeat() -> str:
+    """An ISO timestamp old enough to trip the 600s staleness threshold."""
+    from datetime import UTC, datetime, timedelta
+
+    return (datetime.now(UTC) - timedelta(minutes=30)).isoformat()
+
+
+def test_services_deploying_suppresses_stale(runtime_singleton, monkeypatch):
+    """During a deploy, a fresh/stale HEALTHY sentinel reads 'deploying', not
+    'stale' — the post-restart health_check window this fix exists for."""
+    _install_runtime(_fake_sentinel(current_state="healthy", last_heartbeat_at=_stale_heartbeat()))
+    monkeypatch.setattr("genesis.env.update_in_progress", lambda: True)
+    result = services()
+    assert result["deploying"] is True
+    assert result["sentinel"]["is_stale"] is False
+    assert result["sentinel"]["current_state"] == "deploying"
+
+
+def test_services_deploying_preserves_active_sentinel(runtime_singleton, monkeypatch):
+    """A deploy must NOT mask an active/escalated sentinel — a real fault mid-deploy
+    stays visible; only stale is suppressed."""
+    _install_runtime(_fake_sentinel(current_state="escalated", escalated_count=1))
+    monkeypatch.setattr("genesis.env.update_in_progress", lambda: True)
+    result = services()
+    assert result["deploying"] is True
+    assert result["sentinel"]["current_state"] == "escalated"  # preserved, not coerced
+    assert result["sentinel"]["is_stale"] is False
+
+
+def test_services_not_deploying_by_default(runtime_singleton, monkeypatch):
+    """No deploy in progress → deploying False and the stale path is unchanged."""
+    _install_runtime(_fake_sentinel(current_state="healthy", last_heartbeat_at=_stale_heartbeat()))
+    monkeypatch.setattr("genesis.env.update_in_progress", lambda: False)
+    result = services()
+    assert result["deploying"] is False
+    assert result["sentinel"]["is_stale"] is True
+    assert result["sentinel"]["current_state"] == "stale"


### PR DESCRIPTION
## Problem

While `update.sh` restarts the server, the freshly booted server's sentinel heartbeat is briefly empty (`last_heartbeat_at` unset → `age_s=9999`), so the Services card painted amber **"sentinel stale — last heartbeat Nm ago"** for the post-restart `health_check` window even though nothing was wrong. (The full server-down window is correctly invisible — no server to serve `/health`; this is specifically the post-restart settle.)

## Fix

The services snapshot now reads `env.update_in_progress()` — the **same** PID-live / phase-gated / 4h-bounded signal the watchdog already honors to defer restarts (#840) — and exposes `services.deploying`:

- **Backend** (`observability/snapshots/services.py`): when deploying, `is_stale` is suppressed and a **HEALTHY** sentinel reads `"deploying"`. Active states (`escalated`, `investigating`, `remediating`, `awaiting_*`) are **preserved, never masked**.
- **Frontend** (`servicesSemantic`): the deploy suppresses only the **transient** signals it causes (the server briefly `activating`; the empty-heartbeat stale). **Genuine faults still win** (host-framework down, watchdog restart-loop, an escalated/investigating sentinel), and the neutral `"deploying"` verdict is returned **last** — only if nothing real is wrong. This also keeps `overallHealthSemantic` honest (a real escalation still returns `error`).
- **Chip** (`ui-utils.js` `chipState`): `"deploying"` → the `info` (neutral-blue) chip + status dot (`chip--info` already exists).

## Review + verification

- **genesis-architect** (design) + **code-reviewer** (implementation) — both findings applied: reuse the central `chipState` classifier so the chip isn't amber; do not mask genuine faults during the deploy window; corrected a stale CSS comment.
- Backend E2E'd with a **real** `update_state.json` marker via a temp `GENESIS_HOME` (unmocked `update_in_progress()` → `services.deploying`); 8/8 `test_services_snapshot.py` pass; JS syntax-checked as ES modules.
- The visual chip renders at the next deploy after merge (post-restart window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)