### PR TITLE
fix(browser): click nav-wait + safe VNC stale-port reclaim (PR-E1)

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -20,6 +20,8 @@ import logging
 import math
 import os
 import random
+import re
+import signal
 import time
 from pathlib import Path
 
@@ -611,6 +613,133 @@ def _start_idle_watcher():
         )
 
 
+def _parse_ss_listeners(ss_output):
+    """Parse `ss -ltnpH` output into a deduped list of (pid, process_name).
+
+    Each listener row ends with e.g. ``users:(("x11vnc",pid=509730,fd=8))``.
+    A process listening on both IPv4 and IPv6 appears on two rows with the
+    same pid, so dedup by pid (the names are identical).
+    """
+    holders = {}
+    for name, pid_str in re.findall(r'\(\("([^"]+)",pid=(\d+),', ss_output):
+        try:
+            holders[int(pid_str)] = name
+        except ValueError:
+            continue
+    return list(holders.items())
+
+
+def _parse_fuser_pids(fuser_output):
+    """Parse `fuser <port>/tcp` stdout (space-separated PIDs) into deduped ints."""
+    pids = []
+    seen = set()
+    for tok in fuser_output.split():
+        try:
+            pid = int(tok)
+        except ValueError:
+            continue
+        if pid not in seen:
+            seen.add(pid)
+            pids.append(pid)
+    return pids
+
+
+def _proc_comm(pid):
+    """Return /proc/<pid>/comm (process name) or None if unreadable/gone."""
+    try:
+        with open(f"/proc/{pid}/comm") as fh:
+            return fh.read().strip()
+    except OSError:
+        return None
+
+
+def _reclaim_vnc_port(port=5999, unit="genesis-vnc"):
+    """Safely reclaim a VNC port held by a stale x11vnc process.
+
+    Only SIGKILLs a *foreign* x11vnc process (pid != the unit's MainPID) that
+    holds the port while the systemd unit is genuinely down.  Never acts when
+    the unit is active/activating (legitimate owner or mid-startup), never
+    touches a non-x11vnc process, never blanket-kills the port, and never
+    kills pid <= 1.  Prefers `ss` (atomic name+pid, no TOCTOU); falls back to
+    `fuser` + /proc/<pid>/comm.  Best-effort: any failure leaves the port as-is.
+    Sync (runs in an executor).
+    """
+    import subprocess as _sp
+
+    # 1. Identify holders (pid + process name when ss is available).
+    holders = None
+    try:
+        r = _sp.run(
+            ["ss", "-ltnpH", f"sport = :{port}"],
+            capture_output=True, text=True, timeout=3,
+        )
+        holders = _parse_ss_listeners(r.stdout)
+    except FileNotFoundError:
+        pass  # ss absent — fall back to fuser
+    except Exception:
+        logger.debug("ss VNC-port probe failed", exc_info=True)
+        return
+    if holders is None:
+        try:
+            r = _sp.run(
+                ["fuser", f"{port}/tcp"],
+                capture_output=True, text=True, timeout=3,
+            )
+            holders = [(pid, None) for pid in _parse_fuser_pids(r.stdout)]
+        except FileNotFoundError:
+            logger.warning(
+                "Neither ss nor fuser available — cannot reclaim VNC port %d", port,
+            )
+            return
+        except Exception:
+            logger.debug("fuser VNC-port probe failed", exc_info=True)
+            return
+    if not holders:
+        return  # nothing holds the port
+
+    # 2. Never disturb a live or starting unit.
+    try:
+        state = _sp.run(
+            ["systemctl", "--user", "show", "-p", "ActiveState", "--value", unit],
+            capture_output=True, text=True, timeout=3,
+        ).stdout.strip()
+    except Exception:
+        state = ""
+    if state in ("active", "activating"):
+        return
+
+    # 3. Never kill the unit's own MainPID.
+    try:
+        main_pid = int(
+            _sp.run(
+                ["systemctl", "--user", "show", "-p", "MainPID", "--value", unit],
+                capture_output=True, text=True, timeout=3,
+            ).stdout.strip()
+            or "0"
+        )
+    except Exception:
+        main_pid = 0
+
+    killed = False
+    for pid, name in holders:
+        # pid > 1 guard: os.kill(1, ...)/(0, ...) would signal init / the whole
+        # process group — catastrophic in a container.
+        if pid <= 1 or pid == main_pid:
+            continue
+        proc_name = name if name is not None else _proc_comm(pid)
+        if proc_name != "x11vnc":
+            continue  # only reclaim from a stale x11vnc — never a bystander
+        try:
+            os.kill(pid, signal.SIGKILL)
+            killed = True
+            logger.info("Killed stale x11vnc pid %d holding VNC port %d", pid, port)
+        except (ProcessLookupError, PermissionError):
+            continue  # already gone or not ours to signal
+
+    if killed:
+        time.sleep(1)  # brief grace so systemd can rebind the freed port
+
+
 async def _ensure_vnc():
     """Verify x11vnc + websockify are running for local browser VNC access.
 
@@ -628,30 +757,10 @@ async def _ensure_vnc():
         nonlocal started
         import subprocess as _sp
 
-        # Kill stale x11vnc processes that hold port 5900 and prevent
-        # the systemd service from starting (common after session restart).
-        try:
-            r = _sp.run(
-                ["fuser", "5999/tcp"],
-                capture_output=True, text=True, timeout=3,
-            )
-            if r.stdout.strip():
-                # Port is held — check if it's the systemd-managed process
-                svc = _sp.run(
-                    ["systemctl", "--user", "is-active", "genesis-vnc"],
-                    capture_output=True, text=True, timeout=3,
-                )
-                if svc.stdout.strip() != "active":
-                    # Stale process — kill it so systemd can bind
-                    _sp.run(
-                        ["fuser", "-k", "5999/tcp"],
-                        capture_output=True, timeout=3,
-                    )
-                    logger.info("Killed stale process holding VNC port 5999")
-                    import time
-                    time.sleep(1)
-        except FileNotFoundError:
-            pass  # fuser not available, proceed anyway
+        # Reclaim a stale VNC port safely: only a foreign x11vnc holder when
+        # the genesis-vnc unit is genuinely down — never the live unit, an
+        # 'activating' (mid-startup) unit, or an unrelated process.
+        _reclaim_vnc_port(5999, "genesis-vnc")
 
         try:
             r = _sp.run(
@@ -1829,6 +1938,13 @@ async def _impl_browser_click(selector: str) -> dict:
     try:
         await _human_delay()
         await _stealth_click(page, selector)
+        # A click may trigger navigation (form submit, link). The stealth mouse
+        # path — unlike page.click() — has no navigation auto-wait, so settle
+        # briefly to let a nav commit, then best-effort wait for the new
+        # document. Fully swallowed: never break a click that already worked.
+        await asyncio.sleep(0.3)
+        with contextlib.suppress(Exception):
+            await page.wait_for_load_state("domcontentloaded", timeout=3000)
         _update_remote_url()  # Click may cause navigation (form submit, link)
         snapshot = await _snapshot_page(page)
         return {"clicked": selector, "url": page.url, "snapshot": snapshot}

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -697,18 +697,23 @@ def _reclaim_vnc_port(port=5999, unit="genesis-vnc"):
     if not holders:
         return  # nothing holds the port
 
-    # 2. Never disturb a live or starting unit.
+    # 2. Never disturb a live or starting unit. If we cannot determine the
+    #    unit state (systemctl/dbus hiccup), fail SAFE: leave the port as-is
+    #    rather than defaulting to a value that would bypass this guard.
     try:
         state = _sp.run(
             ["systemctl", "--user", "show", "-p", "ActiveState", "--value", unit],
             capture_output=True, text=True, timeout=3,
         ).stdout.strip()
     except Exception:
-        state = ""
+        logger.debug("VNC unit ActiveState probe failed — leaving port as-is", exc_info=True)
+        return
     if state in ("active", "activating"):
         return
 
-    # 3. Never kill the unit's own MainPID.
+    # 3. Never kill the unit's own MainPID. Same fail-safe: an unverifiable
+    #    MainPID must NOT default to 0 (which matches no real pid and would
+    #    let the kill loop reach a legitimate holder).
     try:
         main_pid = int(
             _sp.run(
@@ -718,7 +723,8 @@ def _reclaim_vnc_port(port=5999, unit="genesis-vnc"):
             or "0"
         )
     except Exception:
-        main_pid = 0
+        logger.debug("VNC unit MainPID probe failed — leaving port as-is", exc_info=True)
+        return
 
     killed = False
     for pid, name in holders:

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -697,33 +697,51 @@ def _reclaim_vnc_port(port=5999, unit="genesis-vnc"):
     if not holders:
         return  # nothing holds the port
 
-    # 2. Never disturb a live or starting unit. If we cannot determine the
-    #    unit state (systemctl/dbus hiccup), fail SAFE: leave the port as-is
-    #    rather than defaulting to a value that would bypass this guard.
+    # 2. Never disturb a live or starting unit. Treat the state as UNVERIFIABLE
+    #    — and fail SAFE (leave the port as-is) — if the probe raises OR returns
+    #    nonzero/empty. The systemd bus being down is the key case: `systemctl`
+    #    exits 1 with EMPTY stdout and does NOT raise, so an exception-only guard
+    #    would sail past it. A genuinely-down unit returns rc=0 with a real state
+    #    ("inactive"), so this never blocks a legitimate reclaim.
     try:
-        state = _sp.run(
+        probe = _sp.run(
             ["systemctl", "--user", "show", "-p", "ActiveState", "--value", unit],
             capture_output=True, text=True, timeout=3,
-        ).stdout.strip()
+        )
     except Exception:
-        logger.debug("VNC unit ActiveState probe failed — leaving port as-is", exc_info=True)
+        logger.debug("VNC unit ActiveState probe raised — leaving port as-is", exc_info=True)
+        return
+    state = probe.stdout.strip()
+    if probe.returncode != 0 or not state:
+        logger.debug(
+            "VNC unit ActiveState unverifiable (rc=%s) — leaving port as-is",
+            probe.returncode,
+        )
         return
     if state in ("active", "activating"):
         return
 
-    # 3. Never kill the unit's own MainPID. Same fail-safe: an unverifiable
-    #    MainPID must NOT default to 0 (which matches no real pid and would
-    #    let the kill loop reach a legitimate holder).
+    # 3. Never kill the unit's own MainPID. Same fail-safe on raise/nonzero/empty.
+    #    A down unit returns rc=0 stdout="0" (MainPID 0) — valid, so proceed.
     try:
-        main_pid = int(
-            _sp.run(
-                ["systemctl", "--user", "show", "-p", "MainPID", "--value", unit],
-                capture_output=True, text=True, timeout=3,
-            ).stdout.strip()
-            or "0"
+        probe = _sp.run(
+            ["systemctl", "--user", "show", "-p", "MainPID", "--value", unit],
+            capture_output=True, text=True, timeout=3,
         )
     except Exception:
-        logger.debug("VNC unit MainPID probe failed — leaving port as-is", exc_info=True)
+        logger.debug("VNC unit MainPID probe raised — leaving port as-is", exc_info=True)
+        return
+    mp_raw = probe.stdout.strip()
+    if probe.returncode != 0 or not mp_raw:
+        logger.debug(
+            "VNC unit MainPID unverifiable (rc=%s) — leaving port as-is",
+            probe.returncode,
+        )
+        return
+    try:
+        main_pid = int(mp_raw)
+    except ValueError:
+        logger.debug("VNC unit MainPID not an int (%r) — leaving port as-is", mp_raw)
         return
 
     killed = False

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -1042,7 +1042,8 @@ class TestReclaimVncPort:
     @staticmethod
     def _fake_run(*, ss_out=None, ss_missing=False, ss_exc=None, fuser_out=None,
                   fuser_missing=False, fuser_exc=None, active_state="inactive",
-                  active_exc=None, main_pid="0", mainpid_exc=None, calls=None):
+                  active_exc=None, active_rc=0, main_pid="0", mainpid_exc=None,
+                  mainpid_rc=0, calls=None):
         def _run(argv, **kwargs):
             if calls is not None:
                 calls.append(list(argv))
@@ -1064,11 +1065,13 @@ class TestReclaimVncPort:
                 if prop == "ActiveState":
                     if active_exc is not None:
                         raise active_exc
-                    return MagicMock(stdout=active_state + "\n", returncode=0)
+                    out = "" if active_rc != 0 else active_state + "\n"
+                    return MagicMock(stdout=out, returncode=active_rc)
                 if prop == "MainPID":
                     if mainpid_exc is not None:
                         raise mainpid_exc
-                    return MagicMock(stdout=main_pid + "\n", returncode=0)
+                    out = "" if mainpid_rc != 0 else main_pid + "\n"
+                    return MagicMock(stdout=out, returncode=mainpid_rc)
                 return MagicMock(stdout="", returncode=0)
             return MagicMock(stdout="", returncode=0)
         return _run
@@ -1163,6 +1166,19 @@ class TestReclaimVncPort:
 
     def test_fuser_generic_exception_no_kill(self):
         run = self._fake_run(ss_missing=True, fuser_exc=OSError("boom"))
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_activestate_nonzero_rc_no_kill(self):
+        # bus down -> systemctl exits 1 with empty stdout and does NOT raise.
+        run = self._fake_run(ss_out=_ss_line(4242), active_rc=1)
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_mainpid_nonzero_rc_no_kill(self):
+        run = self._fake_run(ss_out=_ss_line(4242), active_state="inactive", mainpid_rc=1)
         with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
             browser._reclaim_vnc_port()
         kill.assert_not_called()

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,6 +29,8 @@ def _clear_all_browser_state():
     browser._remote_page = None
     browser._remote_cdp_url = None
     browser._remote_last_url = None
+    # VNC verification flag — FIX 3 tests toggle it; reset to avoid leak
+    browser._vnc_verified = False
 
 
 @pytest.fixture(autouse=True)
@@ -988,3 +991,149 @@ class TestRemoteHelpers:
         browser._update_remote_url()
 
         assert browser._remote_last_url == "https://old.com"  # unchanged
+
+
+def _ss_line(pid, name="x11vnc", v6=False):
+    """One `ss -ltnpH` listener row for the VNC port."""
+    addr = "[::]:5999" if v6 else "0.0.0.0:5999"
+    peer = "[::]:*" if v6 else "0.0.0.0:*"
+    return f'LISTEN 0      32     {addr} {peer} users:(("{name}",pid={pid},fd=8))\n'
+
+
+class TestClickNavigationWait:
+    """FIX 2 (idx 39): _impl_browser_click waits for click-triggered navigation."""
+
+    @pytest.mark.asyncio
+    async def test_click_waits_for_load_state(self):
+        page = MagicMock()
+        page.url = "https://example.com/after"
+        page.is_closed.return_value = False
+        page.wait_for_load_state = AsyncMock()
+        browser._active_page = page
+        with patch.object(browser, "_stealth_click", new=AsyncMock()), patch.object(
+            browser, "_snapshot_page", new=AsyncMock(return_value="snap")
+        ), patch.object(browser, "_human_delay", new=AsyncMock()):
+            result = await browser._impl_browser_click("#go")
+        page.wait_for_load_state.assert_awaited_once()
+        args, _ = page.wait_for_load_state.call_args
+        assert args and args[0] == "domcontentloaded"
+        assert result["clicked"] == "#go"
+
+    @pytest.mark.asyncio
+    async def test_click_survives_raising_load_state(self):
+        page = MagicMock()
+        page.url = "https://example.com/after"
+        page.is_closed.return_value = False
+        page.wait_for_load_state = AsyncMock(
+            side_effect=Exception("execution context destroyed")
+        )
+        browser._active_page = page
+        with patch.object(browser, "_stealth_click", new=AsyncMock()), patch.object(
+            browser, "_snapshot_page", new=AsyncMock(return_value="snap")
+        ), patch.object(browser, "_human_delay", new=AsyncMock()):
+            result = await browser._impl_browser_click("#go")
+        assert result["clicked"] == "#go"
+        assert "error" not in result
+
+
+class TestReclaimVncPort:
+    """FIX 3 (idx 9): safe VNC stale-port reclaim (ss-primary, MainPID-guarded)."""
+
+    @staticmethod
+    def _fake_run(*, ss_out=None, ss_missing=False, fuser_out=None,
+                  fuser_missing=False, active_state="inactive", main_pid="0",
+                  calls=None):
+        def _run(argv, **kwargs):
+            if calls is not None:
+                calls.append(list(argv))
+            cmd = argv[0]
+            if cmd == "ss":
+                if ss_missing:
+                    raise FileNotFoundError("ss")
+                return MagicMock(stdout=ss_out or "", stderr="", returncode=0)
+            if cmd == "fuser":
+                if fuser_missing:
+                    raise FileNotFoundError("fuser")
+                return MagicMock(stdout=fuser_out or "", stderr="", returncode=0)
+            if cmd == "systemctl":
+                prop = argv[4] if len(argv) > 4 else ""
+                if prop == "ActiveState":
+                    return MagicMock(stdout=active_state + "\n", returncode=0)
+                if prop == "MainPID":
+                    return MagicMock(stdout=main_pid + "\n", returncode=0)
+                return MagicMock(stdout="", returncode=0)
+            return MagicMock(stdout="", returncode=0)
+        return _run
+
+    def test_active_unit_not_killed(self):
+        run = self._fake_run(ss_out=_ss_line(1234), active_state="active", main_pid="1234")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port(5999, "genesis-vnc")
+        kill.assert_not_called()
+
+    def test_activating_unit_not_killed(self):
+        run = self._fake_run(ss_out=_ss_line(1234), active_state="activating", main_pid="0")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_holder_equals_mainpid_not_killed(self):
+        run = self._fake_run(ss_out=_ss_line(509730), active_state="inactive", main_pid="509730")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_foreign_non_x11vnc_not_killed(self):
+        run = self._fake_run(ss_out=_ss_line(4242, name="nginx"), active_state="inactive", main_pid="0")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_foreign_x11vnc_killed_specific_pid(self):
+        run = self._fake_run(ss_out=_ss_line(4242), active_state="inactive", main_pid="0")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill, \
+             patch("time.sleep"):
+            browser._reclaim_vnc_port()
+        kill.assert_called_once_with(4242, signal.SIGKILL)
+
+    def test_pid_le_1_never_killed(self):
+        run = self._fake_run(ss_out=_ss_line(1), active_state="inactive", main_pid="0")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_dual_stack_deduped_single_kill(self):
+        ss_out = _ss_line(4242, v6=False) + _ss_line(4242, v6=True)
+        run = self._fake_run(ss_out=ss_out, active_state="inactive", main_pid="0")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill, \
+             patch("time.sleep"):
+            browser._reclaim_vnc_port()
+        kill.assert_called_once_with(4242, signal.SIGKILL)
+
+    def test_kill_processlookup_swallowed(self):
+        run = self._fake_run(ss_out=_ss_line(4242), active_state="inactive", main_pid="0")
+        with patch("subprocess.run", side_effect=run), \
+             patch("os.kill", side_effect=ProcessLookupError), patch("time.sleep"):
+            browser._reclaim_vnc_port()  # must not raise
+
+    def test_fuser_fallback_never_blanket_kill(self):
+        calls = []
+        run = self._fake_run(ss_missing=True, fuser_out="4242\n",
+                             active_state="inactive", main_pid="0", calls=calls)
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill, \
+             patch.object(browser, "_proc_comm", return_value="x11vnc"), patch("time.sleep"):
+            browser._reclaim_vnc_port()
+        kill.assert_called_once_with(4242, signal.SIGKILL)
+        assert not any(a[0] == "fuser" and "-k" in a for a in calls)
+
+    def test_neither_ss_nor_fuser(self):
+        run = self._fake_run(ss_missing=True, fuser_missing=True)
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_no_holder_no_kill(self):
+        run = self._fake_run(ss_out="", active_state="inactive", main_pid="0")
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -1040,9 +1040,9 @@ class TestReclaimVncPort:
     """FIX 3 (idx 9): safe VNC stale-port reclaim (ss-primary, MainPID-guarded)."""
 
     @staticmethod
-    def _fake_run(*, ss_out=None, ss_missing=False, fuser_out=None,
-                  fuser_missing=False, active_state="inactive", main_pid="0",
-                  calls=None):
+    def _fake_run(*, ss_out=None, ss_missing=False, ss_exc=None, fuser_out=None,
+                  fuser_missing=False, fuser_exc=None, active_state="inactive",
+                  active_exc=None, main_pid="0", mainpid_exc=None, calls=None):
         def _run(argv, **kwargs):
             if calls is not None:
                 calls.append(list(argv))
@@ -1050,16 +1050,24 @@ class TestReclaimVncPort:
             if cmd == "ss":
                 if ss_missing:
                     raise FileNotFoundError("ss")
+                if ss_exc is not None:
+                    raise ss_exc
                 return MagicMock(stdout=ss_out or "", stderr="", returncode=0)
             if cmd == "fuser":
                 if fuser_missing:
                     raise FileNotFoundError("fuser")
+                if fuser_exc is not None:
+                    raise fuser_exc
                 return MagicMock(stdout=fuser_out or "", stderr="", returncode=0)
             if cmd == "systemctl":
                 prop = argv[4] if len(argv) > 4 else ""
                 if prop == "ActiveState":
+                    if active_exc is not None:
+                        raise active_exc
                     return MagicMock(stdout=active_state + "\n", returncode=0)
                 if prop == "MainPID":
+                    if mainpid_exc is not None:
+                        raise mainpid_exc
                     return MagicMock(stdout=main_pid + "\n", returncode=0)
                 return MagicMock(stdout="", returncode=0)
             return MagicMock(stdout="", returncode=0)
@@ -1128,6 +1136,33 @@ class TestReclaimVncPort:
 
     def test_neither_ss_nor_fuser(self):
         run = self._fake_run(ss_missing=True, fuser_missing=True)
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_activestate_probe_raises_no_kill(self):
+        # systemctl ActiveState lookup fails -> can't verify unit is down -> fail-safe.
+        run = self._fake_run(ss_out=_ss_line(4242), active_exc=TimeoutError("dbus"))
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_mainpid_probe_raises_no_kill(self):
+        # systemctl MainPID lookup fails -> can't verify holder != MainPID -> fail-safe.
+        run = self._fake_run(ss_out=_ss_line(4242), active_state="inactive",
+                             mainpid_exc=TimeoutError("dbus"))
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_ss_generic_exception_no_kill(self):
+        run = self._fake_run(ss_exc=OSError("netlink"))
+        with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
+            browser._reclaim_vnc_port()
+        kill.assert_not_called()
+
+    def test_fuser_generic_exception_no_kill(self):
+        run = self._fake_run(ss_missing=True, fuser_exc=OSError("boom"))
         with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
             browser._reclaim_vnc_port()
         kill.assert_not_called()


### PR DESCRIPTION
Two browser-automation robustness fixes from the Codex-remediation campaign (audit idx 39 + 9), both in `src/genesis/mcp/health/browser.py`. Low-risk, well-verified pair; the delicate detection change (idx 38) is split into a separate follow-up PR.

## FIX 2 (idx 39) — wait for click-triggered navigation
The Camoufox stealth-click path ends at `page.mouse.up()` with no navigation auto-wait (unlike `page.click()`), so `_impl_browser_click` snapshotted and read `page.url` immediately, racing any click-triggered navigation and returning the pre-navigation page. Adds a brief settle + best-effort, fully-swallowed `wait_for_load_state("domcontentloaded")` in the caller — covering the mouse, keyboard, and plain-click strategies plus the Medium distribution path. Swallowed, so worst case is today's behavior.

## FIX 3 (idx 9) — safe VNC stale-port reclaim
`_ensure_vnc` reclaimed a held VNC port via blanket `fuser -k` gated only on `is-active != active` — it would SIGKILL an unrelated process (no MainPID/holder check) and kill a legitimately-starting unit (`activating` != `active`). Extracted a module-level `_reclaim_vnc_port()` that:
- prefers `ss` (atomic pid+name, no TOCTOU; falls back to `fuser` + `/proc/<pid>/comm` — and is now functional on `ss`-only hosts, since `fuser` is not universally installed);
- never acts when the unit is `active`/`activating`;
- **fails safe** when unit state is unverifiable (systemctl/dbus hiccup → leave the port as-is, never default to values that bypass the guards);
- skips the unit's own MainPID; verifies the holder is `x11vnc`; kills only that specific pid (never blanket), guarding `pid > 1`.

## Verification
- RED-first: 17 targeted tests (2 click-nav + 15 reclaim branch matrix incl. `activating`/active guard, MainPID skip, non-x11vnc skip, pid<=1, dual-stack v4/v6 dedup, ProcessLookupError swallow, and the fail-safe systemctl/ss/fuser exception branches). Full browser test file: 84 passed. Ruff clean.
- **Live E2E on-box**: FIX 3 — `_reclaim_vnc_port` refused to touch the running active `genesis-vnc` and `ss` parsing matched the live MainPID; FIX 2 — real Camoufox navigate → click a link → returned URL reflected the post-navigation destination.
- Code-reviewer pass caught a real fail-open blocker (systemctl-failure defaults bypassing the guards); fixed + locked with the 4 exception-branch tests.

No host-deploy paths (container-side MCP). Runtime effect on next genesis-server restart + local-main sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)