### PR TITLE
fix(browser): interstitial-only Turnstile detection with short grace (PR-E2)

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -124,15 +124,24 @@ _vnc_verified = False
 
 # Cloudflare challenge detection constants (FlareSolverr-proven)
 _CHALLENGE_TITLES = ["just a moment", "ddos-guard"]
-_CHALLENGE_SELECTORS = [
-    'iframe[src*="challenges.cloudflare.com"]',
-    'input[name="cf-turnstile-response"]',
+# Interstitial (blocking full-page challenge) markers. A Cloudflare interstitial
+# INTERCEPTS the request and replaces the page; these appear only on the challenge
+# chrome, never on an embedded widget. The strongest signal is the cf-mitigated
+# response header (checked in _detect_interstitial).
+# NOTE: .ray_id excluded — appears on non-challenge CF error pages (403/502/520).
+_INTERSTITIAL_SELECTORS = [
     "#cf-challenge-running",
     "#challenge-spinner",
-    "#turnstile-wrapper",
     "#cf-please-wait",
-    # NOTE: .ray_id excluded — appears on non-challenge Cloudflare error
-    # pages (403, 502, 520) and would cause false-positive blocking.
+]
+# Embedded Turnstile widget markers. These appear on ordinary, already-loaded
+# pages (login/signup forms) that merely EMBED a widget — NOT a blocking
+# challenge. Detected separately (short-grace path), never escalated to VNC/alert.
+_WIDGET_SELECTORS = [
+    'iframe[src*="challenges.cloudflare.com"]',
+    'input[name="cf-turnstile-response"]',
+    "#turnstile-wrapper",
+    ".cf-turnstile",
 ]
 
 
@@ -1668,24 +1677,43 @@ async def _vnc_click_turnstile(page) -> bool:
         return False
 
 
-async def _detect_challenge(page) -> bool:
-    """Detect any Cloudflare challenge (iframe, managed, interstitial).
+async def _detect_interstitial(page, response=None) -> bool:
+    """Detect a BLOCKING Cloudflare interstitial (not an embedded widget).
 
-    Uses FlareSolverr-proven selectors plus page title check.
-    Returns True if a challenge is detected.
+    True only on interstitial evidence: the ``cf-mitigated`` response header
+    (Cloudflare's canonical challenge-response marker, language-independent),
+    full-page challenge chrome (``#cf-challenge-running`` etc.), or a "just a
+    moment" / "ddos-guard" title. A page that merely embeds a Turnstile widget
+    on already-loaded content is NOT an interstitial — see _detect_widget.
     """
-    # Check DOM selectors (fastest)
-    for selector in _CHALLENGE_SELECTORS:
-        el = await page.query_selector(selector)
-        if el is not None:
+    # Strongest signal: CF tags challenge responses with cf-mitigated. Best-effort
+    # (Camoufox proxying could hide it — the DOM/title checks below are the backstop).
+    if response is not None:
+        try:
+            if response.headers.get("cf-mitigated"):
+                return True
+        except Exception:
+            pass  # header access is best-effort
+
+    # Full-page challenge chrome (fastest DOM signal).
+    for selector in _INTERSTITIAL_SELECTORS:
+        if await page.query_selector(selector) is not None:
             return True
 
-    # Title-based detection for very early interstitials
+    # Interstitial title (English / DDoS-Guard; cf-mitigated is the i18n backstop).
     title = (await page.title()).lower()
     return any(ct in title for ct in _CHALLENGE_TITLES)
 
 
-async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
+async def _detect_widget(page) -> bool:
+    """Detect an embedded Cloudflare Turnstile widget (non-blocking)."""
+    for selector in _WIDGET_SELECTORS:
+        if await page.query_selector(selector) is not None:
+            return True
+    return False
+
+
+async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> dict | None:
     """Detect and handle Cloudflare challenge (Turnstile or managed).
 
     Phase 1 (auto-resolve): Polls for ``timeout_ms`` for automatic resolution.
@@ -1708,8 +1736,19 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
         _ts_log.info("_wait_for_turnstile called — checking for challenge")
         _ts_log.info("Page URL: %s | Title: %s", page.url, await page.title())
 
-        if not await _detect_challenge(page):
-            _ts_log.info("_detect_challenge returned False — no challenge found")
+        if not await _detect_interstitial(page, response):
+            # No blocking interstitial. A page that merely EMBEDS a Turnstile
+            # widget (login/signup forms) is not a challenge: give it only a
+            # brief auto-resolve grace poll (in case it is a fast auto-solving
+            # variant), then return WITHOUT the VNC ladder or Telegram alert.
+            if await _detect_widget(page):
+                _ts_log.info("Widget present, no interstitial — short grace poll")
+                if await _poll_turnstile_token(page, timeout_ms / 1000, 1.0):
+                    _ts_log.info("RESOLVED: auto (embedded widget)")
+                    return {"status": "resolved", "method": "auto"}
+                _ts_log.info("Embedded widget only — not a blocking challenge")
+                return {"status": "embedded", "method": "widget_no_interstitial"}
+            _ts_log.info("No interstitial and no widget — no challenge found")
             return None
 
         _ts_log.info("=== CHALLENGE DETECTED — starting resolution ===")
@@ -1735,7 +1774,7 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
                     _ts_log.info("RESOLVED: widget_click (attempt %d)", click_attempt)
                     logger.info("Challenge resolved via widget click (attempt %d)", click_attempt)
                     return {"status": "resolved", "method": "iframe_click"}
-                if not await _detect_challenge(page):
+                if not await _detect_interstitial(page):
                     _ts_log.info("RESOLVED: widget_click (challenge gone)")
                     return {"status": "resolved", "method": "iframe_click"}
                 _ts_log.info("Widget click %d: sent but not resolved", click_attempt)
@@ -1753,7 +1792,7 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
                 _ts_log.info("RESOLVED: playwright_captcha")
                 logger.info("Challenge resolved via playwright-captcha")
                 return {"status": "resolved", "method": "playwright_captcha"}
-            if not await _detect_challenge(page):
+            if not await _detect_interstitial(page):
                 _ts_log.info("RESOLVED: playwright_captcha (challenge gone)")
                 return {"status": "resolved", "method": "playwright_captcha"}
 
@@ -1773,7 +1812,7 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
                     await asyncio.sleep(random.uniform(1.0, 3.0))
                     return {"status": "resolved", "method": "auto_delayed"}
 
-                if not await _detect_challenge(page):
+                if not await _detect_interstitial(page):
                     logger.info("Challenge page gone — resolved")
                     return {"status": "resolved", "method": "external"}
 
@@ -1884,9 +1923,10 @@ async def _impl_browser_navigate(
         # Skip goto only when TinyFish session was JUST created with this URL
         # (it already navigated on creation). Subsequent navigations must goto.
         skip_goto = is_new_tinyfish and url
+        response = None
         if not skip_goto:
             _ts_log.info("page.goto starting: %s", url)
-            await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+            response = await page.goto(url, wait_until="domcontentloaded", timeout=30000)
             _ts_log.info("page.goto completed — title: %s", await page.title())
 
         # Challenge detection for local browsers (Camoufox + Chromium).
@@ -1895,7 +1935,7 @@ async def _impl_browser_navigate(
         turnstile_result = None
         if not tinyfish and not remote:
             _ts_log.info("calling _wait_for_turnstile")
-            turnstile_result = await _wait_for_turnstile(page)
+            turnstile_result = await _wait_for_turnstile(page, response=response)
             _ts_log.info("_wait_for_turnstile returned: %s", turnstile_result)
 
         # Track URL for drift detection on remote sessions

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -1775,6 +1775,21 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
         _ts_log.info("Page URL: %s", page.url)
         logger.info("Cloudflare challenge detected — waiting for auto-resolve")
 
+        # Track whether we ever actually observed the challenge in the DOM. A
+        # header-only detection (cf-mitigated with no chrome/widget that never
+        # renders) must NOT be treated as "gone" by the DOM-based gates below —
+        # that would falsely report resolved; it runs the ladder to a blocked
+        # result instead. A challenge we DID see and then watched disappear
+        # (e.g. a redirect interstitial) is a genuine resolution.
+        saw_challenge_dom = await _challenge_present(page)
+
+        async def _challenge_gone() -> bool:
+            nonlocal saw_challenge_dom
+            if await _challenge_present(page):
+                saw_challenge_dom = True
+                return False
+            return saw_challenge_dom
+
         # Phase 1: auto-resolve (3-5s for trusted browsers, 15s max)
         _ts_log.info("PHASE 1: auto-resolve (%.0fs)", timeout_ms / 1000)
         if await _poll_turnstile_token(page, timeout_ms / 1000, 1.0):
@@ -1793,7 +1808,7 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
                     _ts_log.info("RESOLVED: widget_click (attempt %d)", click_attempt)
                     logger.info("Challenge resolved via widget click (attempt %d)", click_attempt)
                     return {"status": "resolved", "method": "iframe_click"}
-                if not await _challenge_present(page):
+                if await _challenge_gone():
                     _ts_log.info("RESOLVED: widget_click (challenge gone)")
                     return {"status": "resolved", "method": "iframe_click"}
                 _ts_log.info("Widget click %d: sent but not resolved", click_attempt)
@@ -1811,7 +1826,7 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
                 _ts_log.info("RESOLVED: playwright_captcha")
                 logger.info("Challenge resolved via playwright-captcha")
                 return {"status": "resolved", "method": "playwright_captcha"}
-            if not await _challenge_present(page):
+            if await _challenge_gone():
                 _ts_log.info("RESOLVED: playwright_captcha (challenge gone)")
                 return {"status": "resolved", "method": "playwright_captcha"}
 
@@ -1831,7 +1846,7 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
                     await asyncio.sleep(random.uniform(1.0, 3.0))
                     return {"status": "resolved", "method": "auto_delayed"}
 
-                if not await _challenge_present(page):
+                if await _challenge_gone():
                     logger.info("Challenge page gone — resolved")
                     return {"status": "resolved", "method": "external"}
 

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -1713,6 +1713,18 @@ async def _detect_widget(page) -> bool:
     return False
 
 
+async def _challenge_present(page) -> bool:
+    """Secondary "is a challenge still on the page?" check.
+
+    True if a blocking interstitial OR an embedded Turnstile widget is still
+    present. Used by the in-ladder "challenge gone?" gates so a still-unsolved
+    widget (chrome dismissed, non-English title, no token yet) is NOT mistaken
+    for a resolved challenge. The token poll remains the primary success signal;
+    this only guards the DOM-based early-exit.
+    """
+    return await _detect_interstitial(page) or await _detect_widget(page)
+
+
 async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> dict | None:
     """Detect and handle Cloudflare challenge (Turnstile or managed).
 
@@ -1774,7 +1786,7 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
                     _ts_log.info("RESOLVED: widget_click (attempt %d)", click_attempt)
                     logger.info("Challenge resolved via widget click (attempt %d)", click_attempt)
                     return {"status": "resolved", "method": "iframe_click"}
-                if not await _detect_interstitial(page):
+                if not await _challenge_present(page):
                     _ts_log.info("RESOLVED: widget_click (challenge gone)")
                     return {"status": "resolved", "method": "iframe_click"}
                 _ts_log.info("Widget click %d: sent but not resolved", click_attempt)
@@ -1792,7 +1804,7 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
                 _ts_log.info("RESOLVED: playwright_captcha")
                 logger.info("Challenge resolved via playwright-captcha")
                 return {"status": "resolved", "method": "playwright_captcha"}
-            if not await _detect_interstitial(page):
+            if not await _challenge_present(page):
                 _ts_log.info("RESOLVED: playwright_captcha (challenge gone)")
                 return {"status": "resolved", "method": "playwright_captcha"}
 
@@ -1812,7 +1824,7 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
                     await asyncio.sleep(random.uniform(1.0, 3.0))
                     return {"status": "resolved", "method": "auto_delayed"}
 
-                if not await _detect_interstitial(page):
+                if not await _challenge_present(page):
                     logger.info("Challenge page gone — resolved")
                     return {"status": "resolved", "method": "external"}
 

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -1726,7 +1726,13 @@ async def _challenge_present(page) -> bool:
 
 
 async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> dict | None:
-    """Detect and handle Cloudflare challenge (Turnstile or managed).
+    """Detect and handle a Cloudflare challenge (Turnstile or managed).
+
+    ``response`` is the ``page.goto`` Response when available; its ``cf-mitigated``
+    header is the strongest (language-independent) interstitial signal. Only a
+    real interstitial runs the full ladder below. A page that merely EMBEDS a
+    Turnstile widget (no interstitial) gets a short auto-resolve grace poll and
+    returns ``{"status": "embedded"}`` with no VNC/Telegram escalation.
 
     Phase 1 (auto-resolve): Polls for ``timeout_ms`` for automatic resolution.
 
@@ -1739,7 +1745,8 @@ async def _wait_for_turnstile(page, response=None, timeout_ms: int = 15000) -> d
 
     No human escalation — Genesis handles this itself.
 
-    Returns None if no challenge detected, or a status dict.
+    Returns None if neither an interstitial nor a widget is present, else a
+    status dict (``resolved`` / ``embedded`` / ``blocked``).
     """
     try:
         # Brief delay for SPA-injected widgets to load

--- a/src/genesis/skills/stealth-browser/SKILL.md
+++ b/src/genesis/skills/stealth-browser/SKILL.md
@@ -141,8 +141,10 @@ resolved. The resolution cascade runs without any manual intervention:
 - Escalate to the user
 
 Simply call `browser_navigate(url)` and check the response. If
-`turnstile.status == "resolved"`, the page is ready. If `"blocked"`,
-a Telegram alert was already sent.
+`turnstile.status == "resolved"`, the page is ready. If `"embedded"`,
+the page merely embeds a Turnstile widget (no blocking interstitial —
+the page is already loaded; solve the widget only if a later form submit
+needs it). If `"blocked"`, a Telegram alert was already sent.
 
 ---
 

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -1188,3 +1188,121 @@ class TestReclaimVncPort:
         with patch("subprocess.run", side_effect=run), patch("os.kill") as kill:
             browser._reclaim_vnc_port()
         kill.assert_not_called()
+
+
+def _ts_page(*, selectors_present=(), title="Example Domain", url="https://example.com/"):
+    """Fake page for turnstile detection tests."""
+    present = set(selectors_present)
+
+    async def _qs(sel):
+        return MagicMock() if sel in present else None
+
+    page = MagicMock()
+    page.query_selector = AsyncMock(side_effect=_qs)
+    page.title = AsyncMock(return_value=title)
+    page.reload = AsyncMock()
+    page.url = url
+    return page
+
+
+def _ts_response(headers=None):
+    resp = MagicMock()
+    resp.headers = headers if headers is not None else {}
+    return resp
+
+
+_WIDGET_INPUT = 'input[name="cf-turnstile-response"]'
+_WIDGET_IFRAME = 'iframe[src*="challenges.cloudflare.com"]'
+
+
+class TestInterstitialDetection:
+    """FIX 1 (idx 38): _detect_interstitial fires only on interstitial evidence."""
+
+    @pytest.mark.asyncio
+    async def test_cf_mitigated_header_is_interstitial(self):
+        page = _ts_page(title="Example Domain")
+        resp = _ts_response({"cf-mitigated": "challenge"})
+        assert await browser._detect_interstitial(page, resp) is True
+
+    @pytest.mark.asyncio
+    async def test_challenge_title_is_interstitial(self):
+        page = _ts_page(title="Just a moment...")
+        assert await browser._detect_interstitial(page, None) is True
+
+    @pytest.mark.asyncio
+    async def test_challenge_chrome_is_interstitial(self):
+        page = _ts_page(selectors_present={"#cf-challenge-running"}, title="x")
+        assert await browser._detect_interstitial(page, None) is True
+
+    @pytest.mark.asyncio
+    async def test_embedded_widget_only_is_not_interstitial(self):
+        # Widget markers present, but NO interstitial evidence -> NOT blocking.
+        page = _ts_page(selectors_present={_WIDGET_INPUT, _WIDGET_IFRAME}, title="Sign in")
+        assert await browser._detect_interstitial(page, None) is False
+
+    @pytest.mark.asyncio
+    async def test_response_none_is_safe(self):
+        page = _ts_page(title="Home")
+        assert await browser._detect_interstitial(page, None) is False
+
+
+class TestWidgetDetection:
+    @pytest.mark.asyncio
+    async def test_widget_input_present(self):
+        page = _ts_page(selectors_present={_WIDGET_INPUT})
+        assert await browser._detect_widget(page) is True
+
+    @pytest.mark.asyncio
+    async def test_no_widget(self):
+        page = _ts_page()
+        assert await browser._detect_widget(page) is False
+
+
+class TestTurnstileShortGrace:
+    """FIX 1: widget-only -> short grace (no VNC/Telegram); interstitial -> full ladder."""
+
+    @pytest.mark.asyncio
+    async def test_embedded_widget_short_grace_no_escalation(self):
+        page = _ts_page(selectors_present={_WIDGET_INPUT}, title="Sign in")
+        with patch.object(browser, "_poll_turnstile_token", new=AsyncMock(return_value=False)) as poll, \
+             patch.object(browser, "_click_turnstile_widget", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_vnc_click_turnstile", new=AsyncMock(return_value=False)) as vnc, \
+             patch.object(browser, "_send_turnstile_alert", new=AsyncMock()) as alert, \
+             patch("asyncio.sleep", new=AsyncMock()):
+            result = await browser._wait_for_turnstile(page, response=None)
+        assert result == {"status": "embedded", "method": "widget_no_interstitial"}
+        poll.assert_awaited()          # grace poll ran
+        vnc.assert_not_called()        # NO VNC escalation
+        alert.assert_not_called()      # NO Telegram alert
+
+    @pytest.mark.asyncio
+    async def test_embedded_widget_grace_resolves(self):
+        page = _ts_page(selectors_present={_WIDGET_INPUT}, title="Sign in")
+        with patch.object(browser, "_poll_turnstile_token", new=AsyncMock(return_value=True)), \
+             patch.object(browser, "_send_turnstile_alert", new=AsyncMock()) as alert, \
+             patch("asyncio.sleep", new=AsyncMock()):
+            result = await browser._wait_for_turnstile(page, response=None)
+        assert result["status"] == "resolved"
+        alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_challenge_returns_none(self):
+        page = _ts_page(title="Home")
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await browser._wait_for_turnstile(page, response=None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_interstitial_runs_full_ladder_to_alert(self):
+        page = _ts_page(selectors_present={"#cf-challenge-running"}, title="Just a moment...")
+        resp = _ts_response({"cf-mitigated": "challenge"})
+        with patch.object(browser, "_poll_turnstile_token", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_click_turnstile_widget", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_solve_with_playwright_captcha", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_vnc_click_turnstile", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_ensure_vnc", new=AsyncMock()), \
+             patch.object(browser, "_send_turnstile_alert", new=AsyncMock()) as alert, \
+             patch("asyncio.sleep", new=AsyncMock()):
+            result = await browser._wait_for_turnstile(page, response=resp)
+        assert result == {"status": "blocked", "method": "timeout"}
+        alert.assert_awaited()         # ladder ran to exhaustion

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -1293,6 +1293,26 @@ class TestTurnstileShortGrace:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_interstitial_widget_still_present_not_falsely_resolved(self):
+        # Real interstitial (cf-mitigated) that shows a bare widget with a
+        # non-English title and no chrome. A widget-click yields no token; the
+        # secondary "gone?" gate must NOT declare resolved while a widget remains.
+        page = _ts_page(selectors_present={_WIDGET_INPUT}, title="verificando")
+        resp = _ts_response({"cf-mitigated": "challenge"})
+        with patch.object(browser, "_poll_turnstile_token", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_click_turnstile_widget", new=AsyncMock(return_value=True)), \
+             patch.object(browser, "_solve_with_playwright_captcha", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_vnc_click_turnstile", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_ensure_vnc", new=AsyncMock()), \
+             patch.object(browser, "_send_turnstile_alert", new=AsyncMock()) as alert, \
+             patch("asyncio.sleep", new=AsyncMock()):
+            result = await browser._wait_for_turnstile(page, response=resp)
+        assert result != {"status": "resolved", "method": "iframe_click"}, \
+            "falsely reported resolved while a widget was still present"
+        assert result == {"status": "blocked", "method": "timeout"}
+        alert.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_interstitial_runs_full_ladder_to_alert(self):
         page = _ts_page(selectors_present={"#cf-challenge-running"}, title="Just a moment...")
         resp = _ts_response({"cf-mitigated": "challenge"})

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -1313,6 +1313,24 @@ class TestTurnstileShortGrace:
         alert.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_header_only_interstitial_not_falsely_resolved(self):
+        # cf-mitigated header but NO DOM chrome/widget and a non-English title.
+        # The DOM-based "gone?" gates must NOT report resolved (the challenge was
+        # never observed in the DOM) — it must run to a blocked result instead.
+        page = _ts_page(selectors_present=set(), title="verificando")
+        resp = _ts_response({"cf-mitigated": "challenge"})
+        with patch.object(browser, "_poll_turnstile_token", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_click_turnstile_widget", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_solve_with_playwright_captcha", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_vnc_click_turnstile", new=AsyncMock(return_value=False)), \
+             patch.object(browser, "_ensure_vnc", new=AsyncMock()), \
+             patch.object(browser, "_send_turnstile_alert", new=AsyncMock()) as alert, \
+             patch("asyncio.sleep", new=AsyncMock()):
+            result = await browser._wait_for_turnstile(page, response=resp)
+        assert result == {"status": "blocked", "method": "timeout"}, result
+        alert.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_interstitial_runs_full_ladder_to_alert(self):
         page = _ts_page(selectors_present={"#cf-challenge-running"}, title="Just a moment...")
         resp = _ts_response({"cf-mitigated": "challenge"})


### PR DESCRIPTION
Final fix in the Codex-remediation campaign (audit idx 38). Detection change for Cloudflare Turnstile, split out from PR-E1 (#1165) so the delicate under-detection surface got its own review + live E2E.

## The bug
`_detect_challenge` returned True on the mere DOM presence of ANY selector in a flat list — including embedded-widget markers (`input[name="cf-turnstile-response"]`, the CF iframe, `#turnstile-wrapper`) that appear on ordinary login/signup pages. So a normal page that merely *embeds* a Turnstile widget was misclassified as a blocking challenge → the full solver ladder (up to ~300s) + a Telegram alert + a `blocked` result.

## The fix (short-grace model)
Split detection into two signals:
- **`_detect_interstitial(page, response)`** — True only on interstitial evidence: the `cf-mitigated` response header (Cloudflare's canonical, language-independent challenge marker — `page.goto`'s Response is now captured and threaded in), full-page challenge chrome (`#cf-challenge-running` / `#challenge-spinner` / `#cf-please-wait`), or a "just a moment" / "ddos-guard" title.
- **`_detect_widget(page)`** — embedded widget markers.

`_wait_for_turnstile`: an interstitial runs the full ladder **unchanged**; a widget-only page (no interstitial evidence) gets **only** the ~15s auto-resolve grace poll, then returns `{"status": "embedded"}` with **no VNC and no Telegram** — killing the false 300s burn while still solving a fast auto-resolving variant if one is ever misclassified. The in-ladder "challenge gone?" gates use `_challenge_present` (interstitial **or** widget), so a still-unsolved widget is never mistaken for resolved.

## Verification
- 12 RED→GREEN tests (interstitial/widget detection, short-grace vs full-ladder, cf-mitigated header, response=None safety, and the mid-ladder false-resolve guard). Full browser test file: **98 passed**. Ruff clean.
- **Live E2E on-box:** example.com → `turnstile: None`; the Cloudflare Turnstile **demo page** (embedded widget) → resolved in **~3s with no warning** (under the old code this page ran the ~300s ladder + alert); cloudflare.com → `response.headers` readable under Camoufox (`server: cloudflare`, `cf-ray` present) confirming the `cf-mitigated` path's plumbing works.
- Code review: no BLOCKER/SHOULD-FIX; one informational NOTE (mid-ladder widget backstop) fixed here (`_challenge_present`) + RED→GREEN test.
- SKILL.md documents the new `embedded` status. Only consumer of the turnstile status is the `== "blocked"` check in `_impl_browser_navigate`, so `embedded`/`resolved` produce no warning.

Known residual (bounded, non-silent): a real interstitial with a stripped `cf-mitigated` header AND no challenge chrome AND a non-English title would fall to the 15s grace path (degraded, not a hang). cf-mitigated + chrome + English title cover the documented variants.

No host-deploy paths (container-side MCP). Runtime effect on next genesis-server restart + local-main sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)