### PR TITLE
feat(eval): held-out replay gate for skill edits (WS1, shadow)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,10 @@ data/genesis.sql
 # repo — the bench test suite loads them. The REAL task set stays private
 # under ~/.genesis/eval/ and is refused by the loader if found in-repo.
 !tests/test_eval/bench_fixtures/*.jsonl
+# Synthetic skill-replay golden fixtures (fake voice tasks) MUST be in the repo —
+# the skill-replay test suite loads them. Real per-skill golden suites stay
+# private under ~/.genesis/eval/skill_golden/ and are refused if found in-repo.
+!tests/test_eval/skill_golden_fixtures/*.jsonl
 .config/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   before the screen is ever given veto power. Tunable via the new
   `skill_evolution_gate` setting (`off` | `shadow`) with a
   `GENESIS_SKILL_EVOLUTION_GATE_OFF` kill switch.
+- **Genesis can now regression-test a skill edit by actually re-running it.**
+  Beyond reading the diff, Genesis can replay a frozen set of real tasks against
+  both the old and the new version of a skill and compare how well each does —
+  promoting the change only when it shows zero regressions and a real
+  improvement. Like the diff screen it starts in shadow: it records a
+  `net_positive` / `regression` / `inconclusive` verdict (surfaced when it finds
+  a regression) and never blocks or applies an edit. It runs on demand via the
+  new `skill_replay_run` tool against a per-skill task suite you author with
+  `python -m genesis.eval.skill_golden_set`, and shares the
+  `skill_evolution_gate` setting (a new `replay` section) and kill switch.
 - **Voice conversations now feed real memory extraction (W0.5).** S2S voice
   conversations used to land in episodic memory as one growing raw blob per
   session close — duplicated on replays, never mined for facts. They now

--- a/config/skill_evolution_gate.yaml
+++ b/config/skill_evolution_gate.yaml
@@ -21,3 +21,20 @@ enabled: true
 # There is no "enforce" mode yet — the gate never blocks an edit while it bakes.
 # An invalid value degrades to shadow (observe-only, the safe baseline).
 mode: shadow
+
+# Held-out REPLAY gate (WS1). A second, complementary screen: instead of a
+# static diff, it REPLAYS a frozen per-skill golden task suite against the OLD
+# vs NEW SKILL.md content (control=OLD, treatment=NEW) and logs a recommend-only
+# verdict (net_positive / regression / inconclusive). It only fires where a
+# golden suite exists and is HEAVY (spawns CC sessions), so it runs out-of-band
+# (the skill_replay MCP tool / CLI), never in the auto-apply hot path.
+replay:
+  # off | shadow. shadow (default): run the replay and log the verdict
+  #   (source="skill_evolution_gate", type="skill_replay_verdict"); the edit is
+  #   never blocked. off: never run the replay. No "enforce" yet. Invalid → shadow.
+  mode: shadow
+  # Per-task judge-score margin a win must exceed (paired win-rate).
+  epsilon: 0.05
+  # Minimum complete (non-skipped) task pairs before the verdict is anything but
+  # "inconclusive" — below it the run has no statistical power.
+  min_pairs: 5

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -652,7 +652,7 @@ Self-improvement loops and the instrumentation that keeps them honest.
 ```yaml subsystem-map
 entry: learning-evaluation
 modules: [learning, eval, experimentation, feedback, calibration, ledger]
-verified: 06c22c68 2026-07-20
+verified: fbcf8ee4 2026-07-21
 ```
 
 - **learning/** is the de-facto cron host: `rt._learning_scheduler` registers
@@ -666,8 +666,14 @@ verified: 06c22c68 2026-07-20
   (`skills/skill_edit_critic.py` + `eval/rubrics/skill_edit_regression.py`)
   now screens each auto-applied edit for self-modification pathologies via the
   `judge` call site and LOGS a verdict (`skill_evolution_gate` observations) —
-  it never blocks the edit (WS1 shadow). Levers: `skill_evolution_gate`
-  settings domain (off|shadow) + `GENESIS_SKILL_EVOLUTION_GATE_OFF`.
+  it never blocks the edit (WS1 shadow). A complementary **held-out replay
+  gate** (`eval/skill_replay/`, tool `skill_replay_run`) goes further — it
+  REPLAYS a frozen per-skill golden suite (`~/.genesis/eval/skill_golden/`,
+  authored via `eval/skill_golden_set.py`) against OLD vs NEW content in
+  bare-Claude isolation and logs a recommend-only zero-regression verdict
+  (`skill_replay_verdict` observations); also shadow, out-of-band, mutates
+  nothing. Levers: `skill_evolution_gate` settings domain (off|shadow for the
+  Critic + a `replay` off|shadow sub-config) + `GENESIS_SKILL_EVOLUTION_GATE_OFF`.
   `tool_discovery.py` static maps are deprecated (GROUNDWORK
   provider-migration) — use ProviderRegistry.
 - **eval/**: J9 = fire-and-forget emit hooks on live cognitive paths (the

--- a/src/genesis/db/crud/cognitive_file_modifications.py
+++ b/src/genesis/db/crud/cognitive_file_modifications.py
@@ -66,8 +66,14 @@ async def record(
                 change_summary, metadata, status, created_at, rolled_back_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, 'applied', ?, NULL)""",
         (
-            mod_id, actor, target_path, prior_content, applied_content,
-            change_summary, meta_json, created_at,
+            mod_id,
+            actor,
+            target_path,
+            prior_content,
+            applied_content,
+            change_summary,
+            meta_json,
+            created_at,
         ),
     )
     await db.commit()
@@ -77,14 +83,43 @@ async def record(
 async def get(db: aiosqlite.Connection, mod_id: str) -> dict | None:
     """Fetch one ledger row by id (metadata parsed to a dict)."""
     cur = await db.execute(
-        "SELECT * FROM cognitive_file_modifications WHERE id = ?", (mod_id,),
+        "SELECT * FROM cognitive_file_modifications WHERE id = ?",
+        (mod_id,),
     )
     row = await cur.fetchone()
     return _row_to_dict(cur, row) if row else None
 
 
+async def latest_for_target(
+    db: aiosqlite.Connection,
+    target_path: str,
+    *,
+    actor: str | None = None,
+) -> dict | None:
+    """The most-recent ledger row for a specific ``target_path`` (optionally
+    filtered by ``actor``), or None. Bounded by the path index — never scans a
+    global recency window that could miss an older per-target edit."""
+    if actor:
+        cur = await db.execute(
+            "SELECT * FROM cognitive_file_modifications WHERE target_path = ? AND actor = ? "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (target_path, actor),
+        )
+    else:
+        cur = await db.execute(
+            "SELECT * FROM cognitive_file_modifications WHERE target_path = ? "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (target_path,),
+        )
+    row = await cur.fetchone()
+    return _row_to_dict(cur, row) if row else None
+
+
 async def recent(
-    db: aiosqlite.Connection, *, limit: int = 20, actor: str | None = None,
+    db: aiosqlite.Connection,
+    *,
+    limit: int = 20,
+    actor: str | None = None,
 ) -> list[dict]:
     """Most-recent ledger rows, newest first, optionally filtered by actor."""
     if actor:
@@ -95,8 +130,7 @@ async def recent(
         )
     else:
         cur = await db.execute(
-            "SELECT * FROM cognitive_file_modifications "
-            "ORDER BY created_at DESC, id DESC LIMIT ?",
+            "SELECT * FROM cognitive_file_modifications ORDER BY created_at DESC, id DESC LIMIT ?",
             (limit,),
         )
     rows = await cur.fetchall()
@@ -115,7 +149,10 @@ async def counts_by_target(db: aiosqlite.Connection) -> list[dict]:
 
 
 async def mark_rolled_back(
-    db: aiosqlite.Connection, mod_id: str, *, rolled_back_at: str | None = None,
+    db: aiosqlite.Connection,
+    mod_id: str,
+    *,
+    rolled_back_at: str | None = None,
 ) -> bool:
     """Mark a row rolled back. Returns True iff a row was updated."""
     rolled_back_at = rolled_back_at or datetime.now(UTC).isoformat()
@@ -129,7 +166,10 @@ async def mark_rolled_back(
 
 
 async def prune_keep_per_target(
-    db: aiosqlite.Connection, target_path: str, *, keep: int,
+    db: aiosqlite.Connection,
+    target_path: str,
+    *,
+    keep: int,
 ) -> int:
     """Delete all but the most-recent ``keep`` rows for ``target_path``.
 

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -162,6 +162,10 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     # adjudication window survives. NOT in INTERNAL_OBS_TYPES: flagged
     # (high-priority) verdicts stay visible during the bake.
     "skill_edit_critic": timedelta(days=30),
+    # skill-replay held-out gate verdicts (WS1) — same 30d shadow-bake window
+    # as the diff-screen critic; a regression verdict is high-priority so it
+    # stays visible for adjudication.
+    "skill_replay_verdict": timedelta(days=30),
     # ── 60-day (action-required, real issues) ──────────────────────────
     "bug_identified": timedelta(days=60),
     "tech_debt": timedelta(days=60),

--- a/src/genesis/eval/bench/runner.py
+++ b/src/genesis/eval/bench/runner.py
@@ -87,37 +87,53 @@ def _release_lock(fh) -> None:
         fh.close()
 
 
-async def _run_arm(
+async def run_arm(
     invoker,
     inv,
     task: BenchTask,
     arm: str,
 ) -> BenchArmOutcome:
-    """Execute one arm; infra failures become skipped outcomes."""
+    """Execute one arm; infra failures become skipped outcomes.
+
+    Public + arm-agnostic: reused by the skill-replay gate (WS1) whose arms are
+    OLD/NEW pinned-skill invocations. Takes any CCInvocation-shaped ``inv`` and
+    an arbitrary ``arm`` label; the skip semantics (CC error/timeout, empty
+    output, model downgrade) are harness-independent.
+    """
     try:
         output = await invoker.run(inv)
     except CCError as e:
         return BenchArmOutcome(
-            task_id=task.id, arm=arm, output_text="",
-            skipped=True, skip_reason=f"infra: {type(e).__name__}: {e}",
+            task_id=task.id,
+            arm=arm,
+            output_text="",
+            skipped=True,
+            skip_reason=f"infra: {type(e).__name__}: {e}",
         )
     if output.is_error:
         return BenchArmOutcome(
-            task_id=task.id, arm=arm, output_text="",
+            task_id=task.id,
+            arm=arm,
+            output_text="",
             skipped=True,
             skip_reason=f"infra: cc error: {output.error_message or 'unknown'}",
         )
     if not (output.text or "").strip():
         # Silent-cap signature: successful-looking empty completion.
         return BenchArmOutcome(
-            task_id=task.id, arm=arm, output_text="",
-            skipped=True, skip_reason="infra: empty output",
+            task_id=task.id,
+            arm=arm,
+            output_text="",
+            skipped=True,
+            skip_reason="infra: empty output",
         )
     if getattr(output, "downgraded", False):
         # Fairness violation: this arm ran a lower tier than requested (e.g.
         # a quota downgrade). The pair can't be compared — infra skip.
         return BenchArmOutcome(
-            task_id=task.id, arm=arm, output_text="",
+            task_id=task.id,
+            arm=arm,
+            output_text="",
             model_used=output.model_used,
             skipped=True,
             skip_reason=(
@@ -137,8 +153,13 @@ async def _run_arm(
     )
 
 
-async def _judge_arm(scorer, task: BenchTask, outcome: BenchArmOutcome) -> BenchArmOutcome:
-    """Judge one arm's output. Judge infra failures skip the outcome."""
+async def judge_arm(scorer, task: BenchTask, outcome: BenchArmOutcome) -> BenchArmOutcome:
+    """Judge one arm's output against the task's ex-ante criteria.
+
+    Public + harness-agnostic (reused by the skill-replay gate, WS1): grades the
+    arm's final text via ``scorer.score_async`` against the ``bench_task_success``
+    rubric; a judge call/parse failure skips the outcome (infra ≠ quality).
+    """
     if outcome.skipped:
         return outcome
     passed, score, detail = await scorer.score_async(
@@ -152,18 +173,29 @@ async def _judge_arm(scorer, task: BenchTask, outcome: BenchArmOutcome) -> Bench
         detail_obj = {}
     if detail_obj.get("error"):
         return BenchArmOutcome(
-            task_id=outcome.task_id, arm=outcome.arm,
-            output_text=outcome.output_text, model_used=outcome.model_used,
-            duration_s=outcome.duration_s, cost_usd=outcome.cost_usd,
-            input_tokens=outcome.input_tokens, output_tokens=outcome.output_tokens,
-            skipped=True, skip_reason=f"judge: {detail_obj['error']}",
+            task_id=outcome.task_id,
+            arm=outcome.arm,
+            output_text=outcome.output_text,
+            model_used=outcome.model_used,
+            duration_s=outcome.duration_s,
+            cost_usd=outcome.cost_usd,
+            input_tokens=outcome.input_tokens,
+            output_tokens=outcome.output_tokens,
+            skipped=True,
+            skip_reason=f"judge: {detail_obj['error']}",
         )
     return BenchArmOutcome(
-        task_id=outcome.task_id, arm=outcome.arm,
-        output_text=outcome.output_text, model_used=outcome.model_used,
-        duration_s=outcome.duration_s, cost_usd=outcome.cost_usd,
-        input_tokens=outcome.input_tokens, output_tokens=outcome.output_tokens,
-        judge_passed=passed, judge_score=score, judge_detail=detail,
+        task_id=outcome.task_id,
+        arm=outcome.arm,
+        output_text=outcome.output_text,
+        model_used=outcome.model_used,
+        duration_s=outcome.duration_s,
+        cost_usd=outcome.cost_usd,
+        input_tokens=outcome.input_tokens,
+        output_tokens=outcome.output_tokens,
+        judge_passed=passed,
+        judge_score=score,
+        judge_detail=detail,
     )
 
 
@@ -174,9 +206,7 @@ def _arm_summary(
     duration_s: float,
     extra_metadata: dict,
 ) -> EvalRunSummary:
-    outcomes = [
-        (p.bare if arm == ARM_BARE else p.genesis) for p in report.pairs
-    ]
+    outcomes = [(p.bare if arm == ARM_BARE else p.genesis) for p in report.pairs]
     results = [
         ScoredOutput(
             case_id=o.task_id,
@@ -257,7 +287,8 @@ async def run_bench(
         logger.info("bench: scrubbed nested-CC env vars: %s", ", ".join(sorted(removed)))
 
     tasks, task_set_version, sha256 = load_tasks(
-        tasks_path or DEFAULT_TASKS_PATH, allow_repo_path=allow_repo_tasks,
+        tasks_path or DEFAULT_TASKS_PATH,
+        allow_repo_path=allow_repo_tasks,
     )
     if task_id:
         tasks = [t for t in tasks if t.id == task_id]
@@ -325,7 +356,8 @@ async def run_bench(
             if judge_provider:
                 chain = [judge_provider, *[p for p in chain if p != judge_provider]]
             router = StandaloneLiteLLMRouter(
-                chain[0], fallback_providers=tuple(chain[1:]),
+                chain[0],
+                fallback_providers=tuple(chain[1:]),
             )
         scorer = LLMJudgeScorer(router=router)
 
@@ -333,25 +365,34 @@ async def run_bench(
         for i, task in enumerate(tasks, start=1):
             logger.info("bench: task %d/%d %s (%s)", i, len(tasks), task.id, task.category)
             bare_inv = build_bare_arm_invocation(
-                task, run_dir, model, effort, bare_cfg, run_id,
+                task,
+                run_dir,
+                model,
+                effort,
+                bare_cfg,
+                run_id,
             )
             genesis_inv = build_genesis_arm_invocation(
-                task, run_dir, model, effort, mcp_config_path, run_id,
+                task,
+                run_dir,
+                model,
+                effort,
+                mcp_config_path,
+                run_id,
             )
             bare_out, genesis_out = await asyncio.gather(
-                _run_arm(invoker, bare_inv, task, ARM_BARE),
-                _run_arm(invoker, genesis_inv, task, ARM_GENESIS),
+                run_arm(invoker, bare_inv, task, ARM_BARE),
+                run_arm(invoker, genesis_inv, task, ARM_GENESIS),
             )
             # Captured BEFORE judging — a judge failure must not mask the
             # arm-degradation positive control below.
             genesis_ran = genesis_ran or not genesis_out.skipped
-            bare_out = await _judge_arm(scorer, task, bare_out)
-            genesis_out = await _judge_arm(scorer, task, genesis_out)
+            bare_out = await judge_arm(scorer, task, bare_out)
+            genesis_out = await judge_arm(scorer, task, genesis_out)
             pair = BenchPair(task=task, bare=bare_out, genesis=genesis_out)
             if pair.skipped:
                 reasons = "; ".join(
-                    f"{o.arm}: {o.skip_reason}"
-                    for o in (bare_out, genesis_out) if o.skipped
+                    f"{o.arm}: {o.skip_reason}" for o in (bare_out, genesis_out) if o.skipped
                 )
                 logger.warning("bench: pair %s SKIPPED (%s)", task.id, reasons)
             report.pairs.append(pair)
@@ -392,7 +433,9 @@ async def run_bench(
             bare_scores = [p.bare.judge_score for p in complete]
             genesis_scores = [p.genesis.judge_score for p in complete]
             report.score_winrate = compute_score_winrate(
-                bare_scores, genesis_scores, epsilon=epsilon,
+                bare_scores,
+                genesis_scores,
+                epsilon=epsilon,
             )
             report.pass_winrate = compute_winrate(
                 [p.bare.judge_passed for p in complete],
@@ -430,7 +473,10 @@ async def run_bench(
                 treatment_id = await insert_run(
                     db,
                     _arm_summary(
-                        report, ARM_GENESIS, f"{run_id}-genesis", duration_s,
+                        report,
+                        ARM_GENESIS,
+                        f"{run_id}-genesis",
+                        duration_s,
                         {**extra, "paired_run_id": control_id},
                     ),
                 )
@@ -443,7 +489,8 @@ async def run_bench(
                 # persistence from it rather than wasting the whole run.
                 logger.exception(
                     "bench: persisting to eval_runs failed — report at %s "
-                    "is the source of truth for replay", report_path,
+                    "is the source of truth for replay",
+                    report_path,
                 )
                 report.notes.append("PERSISTENCE FAILED — see log; report on disk")
 

--- a/src/genesis/eval/skill_golden_set.py
+++ b/src/genesis/eval/skill_golden_set.py
@@ -1,0 +1,92 @@
+"""Author a per-skill golden task suite for the held-out replay gate (WS1).
+
+Writes a starter suite to ``~/.genesis/eval/skill_golden/<skill>.jsonl`` — OUTSIDE
+the repo, because per-skill suites derive from how YOU use the skill and stay
+private (like the bench task set). The ``expected`` field is EX-ANTE frozen
+success criteria you edit by hand: the replay judge grades an arm's output
+against exactly these, and the loader records the file's sha256 so a post-hoc
+edit is visible rather than silent.
+
+Author suites for the behavior the SKILL.md BODY controls (process / structure /
+what the output must or must not do) — NOT criteria that need files or exemplars
+the isolated replay can't reach.
+
+Usage::
+
+    python -m genesis.eval.skill_golden_set --skill voice-master        # scaffold
+    python -m genesis.eval.skill_golden_set --validate <path/to/suite.jsonl>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from genesis.env import genesis_home
+
+
+def default_suite_path(skill_name: str) -> Path:
+    return genesis_home() / "eval" / "skill_golden" / f"{skill_name}.jsonl"
+
+
+# A minimal starter the author replaces with real tasks. Valid JSON (loads
+# cleanly) but every field is a placeholder flagged by --validate until edited.
+_SCAFFOLD_TASKS = [
+    {
+        "id": "example_1",
+        "category": "drafting",
+        "prompt": "<REPLACE: a real task you would give this skill>",
+        "expected": (
+            "<REPLACE: frozen, checkable criteria for the SKILL.md BODY behavior — "
+            "what the output must and must not do; avoid anything needing external files>"
+        ),
+    },
+]
+
+
+def write_scaffold(skill_name: str, path: Path, *, force: bool) -> None:
+    if path.exists() and not force:
+        raise SystemExit(f"{path} already exists — use --force to overwrite")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps({"_meta": {"task_set_version": f"{skill_name}_v1"}})]
+    lines += [json.dumps(t) for t in _SCAFFOLD_TASKS]
+    path.write_text("\n".join(lines) + "\n")
+    print(f"wrote scaffold: {path}")
+    print("Edit each task's prompt + expected (8-15 tasks recommended), then --validate.")
+
+
+def validate(path: Path) -> int:
+    from genesis.eval.bench.tasks import TaskFileError, load_tasks
+
+    try:
+        tasks, version, sha = load_tasks(path)
+    except TaskFileError as exc:
+        print(f"INVALID: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {len(tasks)} task(s), version={version}, sha256={sha[:12]}…")
+    placeholders = [t.id for t in tasks if "<REPLACE" in t.expected or "<REPLACE" in t.prompt]
+    if placeholders:
+        print(f"  WARNING: unedited placeholder task(s): {', '.join(placeholders)}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Author a per-skill golden suite (WS1).")
+    ap.add_argument("--skill", help="skill name to scaffold a suite for")
+    ap.add_argument("--output", type=Path, help="override the output path")
+    ap.add_argument("--force", action="store_true", help="overwrite an existing suite")
+    ap.add_argument("--validate", type=Path, help="validate an existing suite file")
+    args = ap.parse_args(argv)
+
+    if args.validate:
+        return validate(args.validate)
+    if not args.skill:
+        ap.error("--skill (to scaffold) or --validate is required")
+    write_scaffold(args.skill, args.output or default_suite_path(args.skill), force=args.force)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genesis/eval/skill_replay/__init__.py
+++ b/src/genesis/eval/skill_replay/__init__.py
@@ -1,0 +1,27 @@
+"""Skill-replay held-out regression gate (WS1) — SHADOW / recommend-only.
+
+Replays a frozen golden task suite against the OLD vs NEW SKILL.md content and
+logs a ``net_positive | regression | inconclusive`` verdict. It never blocks an
+edit and mutates no cognition — the execution complement to the static
+``skill_edit_critic`` diff-screen.
+"""
+
+from __future__ import annotations
+
+from genesis.eval.skill_replay.types import (
+    VERDICT_INCONCLUSIVE,
+    VERDICT_NET_POSITIVE,
+    VERDICT_REGRESSION,
+    SkillReplayConfig,
+    SkillReplayVerdict,
+)
+from genesis.eval.skill_replay.verdict import compute_verdict
+
+__all__ = [
+    "VERDICT_INCONCLUSIVE",
+    "VERDICT_NET_POSITIVE",
+    "VERDICT_REGRESSION",
+    "SkillReplayConfig",
+    "SkillReplayVerdict",
+    "compute_verdict",
+]

--- a/src/genesis/eval/skill_replay/arms.py
+++ b/src/genesis/eval/skill_replay/arms.py
@@ -1,0 +1,72 @@
+"""The two skill-replay arms — OLD vs NEW SKILL.md content, file-free pinning.
+
+Both arms use the eval bench's BARE-arm recipe (``safe_mode`` + strict empty MCP
++ neutral per-arm cwd + cleanroom ``CLAUDE_CONFIG_DIR``) — the strongest
+customization suppression available. ``safe_mode`` is the only OAuth-compatible
+way to suppress CC's native, passwd-home skill discovery (``CLAUDE_CONFIG_DIR``
+does NOT relocate it), so the live on-disk SKILL.md cannot leak in alongside the
+pinned copy. The ONLY delta between the two arms is the pinned skill content in
+the system prompt: control = OLD (current), treatment = NEW (proposed).
+
+``--system-prompt`` is honored under ``--safe-mode`` (probe-verified 2026-07-20:
+a pinned system prompt was obeyed with safe-mode active).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from genesis.cc.types import CCInvocation, CCModel, EffortLevel
+from genesis.env import repo_root
+from genesis.eval.bench.arms import TASK_ENVELOPE
+from genesis.eval.bench.types import BenchTask
+from genesis.eval.skill_replay.types import ARM_NEW, ARM_OLD
+
+
+def _task_workdir(run_dir: Path, task: BenchTask, arm_label: str) -> Path:
+    """Neutral, empty, per-task-per-arm cwd — outside any git repo, so no project
+    CLAUDE.md or ``.claude/skills`` directory is discoverable from it."""
+    workdir = run_dir / "work" / task.id / arm_label
+    workdir.mkdir(parents=True, exist_ok=True)
+    return workdir
+
+
+def build_skill_arm_invocation(
+    task: BenchTask,
+    run_dir: Path,
+    model: CCModel,
+    effort: EffortLevel,
+    *,
+    skill_name: str,
+    skill_content: str,
+    bare_config_dir: Path,
+    run_id: str,
+    arm_label: str,
+) -> CCInvocation:
+    """Build one replay arm: bare-Claude isolation + the skill pinned in the
+    system prompt.
+
+    ``arm_label`` is :data:`ARM_OLD` (control, current/pre-edit content) or
+    :data:`ARM_NEW` (treatment, proposed content). The system prompt mirrors how
+    Genesis injects a skill in production (``direct_session`` concatenates
+    ``"## Skill: <name>\\n<body>"`` into the system prompt), so the arm reads the
+    pinned body exactly as a live session would — and nothing else.
+    """
+    if arm_label not in (ARM_OLD, ARM_NEW):
+        raise ValueError(f"arm_label must be {ARM_OLD!r} or {ARM_NEW!r}, got {arm_label!r}")
+    system_prompt = f"## Skill: {skill_name}\n{skill_content}"
+    return CCInvocation(
+        prompt=task.rendered_prompt() + TASK_ENVELOPE,
+        model=model,
+        effort=effort,
+        system_prompt=system_prompt,
+        working_dir=str(_task_workdir(run_dir, task, arm_label)),
+        timeout_s=task.timeout_s,
+        skip_permissions=True,
+        mcp_config=str(repo_root().resolve() / "config" / "no_mcp.json"),
+        strict_mcp_config=True,
+        safe_mode=True,
+        claude_code_tmpdir=str(run_dir / "cc-sandbox"),
+        env_overrides={"CLAUDE_CONFIG_DIR": str(bare_config_dir)},
+        session_key=f"skill_replay:{run_id}:{task.id}:{arm_label}",
+    )

--- a/src/genesis/eval/skill_replay/persist.py
+++ b/src/genesis/eval/skill_replay/persist.py
@@ -1,0 +1,173 @@
+"""Persistence + observation logging for a skill-replay run.
+
+Two additive, reversible sinks:
+
+  * :func:`persist_skill_replay_summary` — two paired ``eval_runs`` rows (OLD
+    control, NEW treatment) via ``EvalTrigger.EXPERIMENT`` +
+    ``metadata.kind='skill_replay_verdict'`` (NO migration — reuses the
+    experiment trigger, like ``persist_evo_summary``), linked with
+    ``set_comparison_run``.
+  * :func:`log_replay_observation` — one observation
+    (``source='skill_evolution_gate'``, ``type='skill_replay_verdict'``)
+    carrying the recommend-only verdict, sibling to the static
+    ``skill_edit_critic`` verdict. ``priority='high'`` for a regression so it
+    surfaces during the shadow bake, ``'low'`` otherwise.
+
+Depends only on the pure ``types`` module (no CC), so it stays DB-only.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from statistics import fmean
+
+from genesis.eval.skill_replay.types import (
+    ARM_NEW,
+    ARM_OLD,
+    VERDICT_INCONCLUSIVE,
+    VERDICT_REGRESSION,
+    SkillReplayReport,
+)
+from genesis.eval.types import (
+    EvalRunSummary,
+    EvalTrigger,
+    ScoredOutput,
+    ScorerType,
+    TaskCategory,
+)
+
+_DATASET_PREFIX = "skill_replay"
+# eval_results.actual_output cap — bounded against a runaway transcript output.
+_OUTPUT_PERSIST_CAP = 20_000
+
+
+def _verdict_metadata(report: SkillReplayReport) -> dict:
+    v = report.verdict
+    return {
+        "kind": "skill_replay_verdict",
+        "skill_name": report.skill_name,
+        "verdict": v.verdict if v else None,
+        "n_complete": v.n_complete if v else 0,
+        "n_regressions": v.n_regressions if v else 0,
+        "n_improvements": v.n_improvements if v else 0,
+        "score_winrate": v.score_winrate if v else {},
+        "pass_winrate": v.pass_winrate if v else {},
+        "note": v.note if v else "",
+        "task_set_version": report.task_set_version,
+        "task_file_sha256": report.task_file_sha256,
+        "rubric": report.rubric_name,
+        "rubric_version": report.rubric_version,
+        "effort": report.effort,
+        "notes": report.notes,
+        "prod_delta_clean": report.prod_delta.get("clean"),
+    }
+
+
+def _arm_summary(
+    report: SkillReplayReport,
+    arm: str,
+    run_id: str,
+    duration_s: float,
+    extra_metadata: dict,
+) -> EvalRunSummary:
+    outcomes = [(p.old if arm == ARM_OLD else p.new) for p in report.pairs]
+    results = [
+        ScoredOutput(
+            case_id=o.task_id,
+            passed=o.judge_passed,
+            score=o.judge_score,
+            actual_output=(o.output_text or o.skip_reason)[:_OUTPUT_PERSIST_CAP],
+            scorer_type=ScorerType.LLM_JUDGE,
+            scorer_detail=o.judge_detail or o.skip_reason,
+            latency_ms=o.duration_s * 1000.0,
+            input_tokens=o.input_tokens,
+            output_tokens=o.output_tokens,
+            cost_usd=o.cost_usd,
+            skipped=o.skipped,
+        )
+        for o in outcomes
+    ]
+    live = [o for o in outcomes if not o.skipped]
+    scores = [o.judge_score for o in live]
+    return EvalRunSummary(
+        run_id=run_id,
+        model_id=report.model,
+        model_profile=f"{_DATASET_PREFIX}:{arm}",
+        dataset=f"{_DATASET_PREFIX}:{report.skill_name}",
+        trigger=EvalTrigger.EXPERIMENT,
+        task_category=TaskCategory.AGENTIC,
+        total_cases=len(outcomes),
+        passed_cases=sum(1 for o in live if o.judge_passed),
+        failed_cases=sum(1 for o in live if not o.judge_passed),
+        skipped_cases=sum(1 for o in outcomes if o.skipped),
+        aggregate_score=fmean(scores) if scores else 0.0,
+        scores={"mean_judge_score": fmean(scores)} if scores else {},
+        metadata={"arm": arm, **extra_metadata},
+        duration_s=duration_s,
+        results=results,
+    )
+
+
+async def persist_skill_replay_summary(
+    db,
+    report: SkillReplayReport,
+    *,
+    duration_s: float = 0.0,
+) -> tuple[str, str]:
+    """Write the paired OLD/NEW ``eval_runs`` rows; returns (control_id, treatment_id).
+
+    Mutates ``report.control_run_id`` / ``report.treatment_run_id`` in place.
+    """
+    from genesis.eval.db import insert_run, set_comparison_run
+
+    extra = _verdict_metadata(report)
+    control_id = await insert_run(
+        db, _arm_summary(report, ARM_OLD, f"{report.run_id}-old", duration_s, extra)
+    )
+    treatment_id = await insert_run(
+        db,
+        _arm_summary(
+            report,
+            ARM_NEW,
+            f"{report.run_id}-new",
+            duration_s,
+            {**extra, "paired_run_id": control_id},
+        ),
+    )
+    await set_comparison_run(db, treatment_id, control_id)  # commits
+    report.control_run_id = control_id
+    report.treatment_run_id = treatment_id
+    return control_id, treatment_id
+
+
+async def log_replay_observation(db, report: SkillReplayReport, *, now: str) -> str:
+    """Log the recommend-only verdict as an observation. Returns the obs id."""
+    from genesis.db.crud import observations
+
+    v = report.verdict
+    verdict_label = v.verdict if v else VERDICT_INCONCLUSIVE
+    content = {
+        "skill_name": report.skill_name,
+        "verdict": verdict_label,
+        "n_complete": v.n_complete if v else 0,
+        "n_regressions": v.n_regressions if v else 0,
+        "n_improvements": v.n_improvements if v else 0,
+        "note": v.note if v else "",
+        "run_id": report.run_id,
+        "control_run_id": report.control_run_id,
+        "treatment_run_id": report.treatment_run_id,
+        "task_set_version": report.task_set_version,
+        "rubric_version": report.rubric_version,
+    }
+    obs_id = str(uuid.uuid4())
+    await observations.create(
+        db,
+        id=obs_id,
+        source="skill_evolution_gate",
+        type="skill_replay_verdict",
+        content=json.dumps(content),
+        priority="high" if verdict_label == VERDICT_REGRESSION else "low",
+        created_at=now,
+    )
+    return obs_id

--- a/src/genesis/eval/skill_replay/runner.py
+++ b/src/genesis/eval/skill_replay/runner.py
@@ -1,0 +1,223 @@
+"""Paired OLD-vs-NEW replay orchestration for the skill-edit regression gate.
+
+Per golden task, both arms (OLD content vs NEW content, pinned into the system
+prompt) run CONCURRENTLY in the bench's bare-Claude isolation; tasks run
+sequentially. Each arm's final text is judged per-arm-absolute against the
+task's ex-ante criteria (shared ``bench_task_success`` rubric); the verdict is
+computed here, downstream of the judge. Recommend-only — this runner mutates no
+cognition and touches no DB (persistence + observation logging are the caller's
+job).
+
+Simpler than the A/B bench: neither arm uses memory MCP (a writing task is not a
+recall task), so there is NO prod-DB snapshot, NO redirected MCP server, and NO
+eval_events positive control — just a ProdDeltaProbe bracket as cheap
+falsifiability. Reuses the bench's ``run_arm``/``judge_arm`` (harness-agnostic)
+and its arm-isolation helpers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import fcntl
+import logging
+import shutil
+import uuid
+from pathlib import Path
+
+from genesis.cc.types import CCModel, EffortLevel
+from genesis.eval.bench.arms import prepare_bare_config_dir, scrub_nested_cc_env
+from genesis.eval.bench.isolation import ProdDeltaProbe
+from genesis.eval.bench.runner import judge_arm, run_arm
+from genesis.eval.skill_replay.arms import build_skill_arm_invocation
+from genesis.eval.skill_replay.types import (
+    ARM_NEW,
+    ARM_OLD,
+    SkillReplayConfig,
+    SkillReplayPair,
+    SkillReplayReport,
+)
+from genesis.eval.skill_replay.verdict import compute_verdict
+
+logger = logging.getLogger(__name__)
+
+# v1 reuses the bench rubric — generic "does the output meet the ex-ante
+# criteria" grading. A dedicated skill_replay_success rubric is a later refinement.
+_RUBRIC_NAME = "bench_task_success"
+
+
+class SkillReplayBusyError(RuntimeError):
+    """Another skill-replay run holds the lock."""
+
+
+def _acquire_lock():
+    """Non-blocking skill-replay lock — separate from the bench lock so a replay
+    and a bench run never starve each other."""
+    lock_path = Path.home() / "tmp" / ".skill_replay.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fh = open(lock_path, "w")  # noqa: SIM115 — held for the run
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as e:
+        fh.close()
+        raise SkillReplayBusyError("another skill-replay run is already in progress") from e
+    return fh
+
+
+def _release_lock(fh) -> None:
+    with contextlib.suppress(Exception):
+        fcntl.flock(fh, fcntl.LOCK_UN)
+        fh.close()
+
+
+def _build_judge_router(judge_provider: str | None):
+    """The runtime `judge` call site's free-first chain (mirrors run_bench)."""
+    from genesis.experimentation.standalone_router import (
+        DEFAULT_JUDGE_PROVIDER,
+        StandaloneLiteLLMRouter,
+    )
+
+    chain = [
+        DEFAULT_JUDGE_PROVIDER,
+        "openrouter-deepseek-v4",
+        "openrouter-deepseek-v4-flash",
+    ]
+    if judge_provider:
+        chain = [judge_provider, *[p for p in chain if p != judge_provider]]
+    return StandaloneLiteLLMRouter(chain[0], fallback_providers=tuple(chain[1:]))
+
+
+async def run_skill_replay(
+    *,
+    skill_name: str,
+    old_content: str,
+    new_content: str,
+    tasks_path: Path | str,
+    model: CCModel = CCModel.SONNET,
+    effort: EffortLevel = EffortLevel.MEDIUM,
+    config: SkillReplayConfig | None = None,
+    limit: int | None = None,
+    verify_prod: bool = True,
+    invoker=None,
+    scorer=None,
+    router=None,
+    run_root: Path | None = None,
+    allow_repo_tasks: bool = False,
+    judge_provider: str | None = None,
+    keep_workdir: bool = False,
+) -> SkillReplayReport:
+    """Replay ``tasks_path`` against OLD vs NEW ``skill_name`` content.
+
+    Returns a :class:`SkillReplayReport` with a recommend-only verdict.
+    Persistence and observation logging are the CALLER's job (the MCP tool /
+    CLI) — this runner touches no DB. Test seams: ``invoker`` (CCInvoker-shaped),
+    ``scorer`` (LLMJudgeScorer-shaped), ``router`` (judge, only used to build a
+    scorer when ``scorer`` is None), ``run_root``, ``allow_repo_tasks``.
+    """
+    from genesis.eval.bench.tasks import load_tasks
+    from genesis.eval.rubrics import get_rubric
+
+    config = config or SkillReplayConfig()
+
+    removed = scrub_nested_cc_env()
+    if removed:
+        logger.info("skill_replay: scrubbed nested-CC env vars: %s", ", ".join(sorted(removed)))
+
+    tasks, task_set_version, sha256 = load_tasks(tasks_path, allow_repo_path=allow_repo_tasks)
+    if limit:
+        tasks = tasks[:limit]
+
+    run_id = uuid.uuid4().hex[:12]
+    rubric = get_rubric(_RUBRIC_NAME)
+    report = SkillReplayReport(
+        run_id=run_id,
+        skill_name=skill_name,
+        model=str(model),
+        effort=str(effort),
+        task_set_version=task_set_version,
+        task_file_sha256=sha256,
+        rubric_name=rubric.name,
+        rubric_version=rubric.version,
+    )
+
+    lock = _acquire_lock()
+    run_dir = (run_root or Path.home() / "tmp" / "skill_replay") / run_id
+    try:
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        probe = ProdDeltaProbe() if verify_prod else None
+        if probe:
+            probe.start()
+
+        bare_cfg = prepare_bare_config_dir(run_dir)
+
+        if invoker is None:
+            from genesis.cc.invoker import CCInvoker
+
+            invoker = CCInvoker()  # fresh, no callbacks → side-effect-free
+        if scorer is None:
+            from genesis.eval.scorers import LLMJudgeScorer
+
+            scorer = LLMJudgeScorer(router=router or _build_judge_router(judge_provider))
+
+        for i, task in enumerate(tasks, start=1):
+            logger.info("skill_replay: task %d/%d %s (%s)", i, len(tasks), task.id, task.category)
+            old_inv = build_skill_arm_invocation(
+                task,
+                run_dir,
+                model,
+                effort,
+                skill_name=skill_name,
+                skill_content=old_content,
+                bare_config_dir=bare_cfg,
+                run_id=run_id,
+                arm_label=ARM_OLD,
+            )
+            new_inv = build_skill_arm_invocation(
+                task,
+                run_dir,
+                model,
+                effort,
+                skill_name=skill_name,
+                skill_content=new_content,
+                bare_config_dir=bare_cfg,
+                run_id=run_id,
+                arm_label=ARM_NEW,
+            )
+            old_out, new_out = await asyncio.gather(
+                run_arm(invoker, old_inv, task, ARM_OLD),
+                run_arm(invoker, new_inv, task, ARM_NEW),
+            )
+            old_out = await judge_arm(scorer, task, old_out)
+            new_out = await judge_arm(scorer, task, new_out)
+            pair = SkillReplayPair(task=task, old=old_out, new=new_out)
+            if pair.skipped:
+                reasons = "; ".join(
+                    f"{o.arm}: {o.skip_reason}" for o in (old_out, new_out) if o.skipped
+                )
+                logger.warning("skill_replay: pair %s SKIPPED (%s)", task.id, reasons)
+            report.pairs.append(pair)
+
+        if probe:
+            report.prod_delta = probe.finish()
+            if not report.prod_delta.get("clean", False):
+                report.notes.append(
+                    "PROD DELTA observed — attribute against concurrent server "
+                    "activity before calling it a breach (the arms make zero writes)."
+                )
+
+        complete = [p for p in report.pairs if not p.skipped]
+        report.verdict = compute_verdict(
+            old_scores=[p.old.judge_score for p in complete],
+            new_scores=[p.new.judge_score for p in complete],
+            old_pass=[p.old.judge_passed for p in complete],
+            new_pass=[p.new.judge_passed for p in complete],
+            config=config,
+        )
+        if not complete:
+            report.notes.append("no complete pairs — every task hit an infra skip")
+        return report
+    finally:
+        _release_lock(lock)
+        if not keep_workdir:
+            shutil.rmtree(run_dir, ignore_errors=True)

--- a/src/genesis/eval/skill_replay/types.py
+++ b/src/genesis/eval/skill_replay/types.py
@@ -16,6 +16,12 @@ VERDICT_NET_POSITIVE = "net_positive"  # zero regression AND at least one improv
 VERDICT_REGRESSION = "regression"  # NEW lost on >=1 task, or pass-rate favours OLD
 VERDICT_INCONCLUSIVE = "inconclusive"  # all ties, or too few complete pairs to judge
 
+# Arm identifiers for the paired replay — control = OLD (current) skill content,
+# treatment = NEW (proposed). Plain strings so the dependency-light modules
+# (runner, persist) can label without importing the CC arm builder.
+ARM_OLD = "old"
+ARM_NEW = "new"
+
 
 @dataclass(frozen=True)
 class SkillReplayConfig:

--- a/src/genesis/eval/skill_replay/types.py
+++ b/src/genesis/eval/skill_replay/types.py
@@ -5,11 +5,17 @@ against the OLD vs NEW skill content and comparing per-task judge scores —
 control = OLD, treatment = NEW. The verdict is recommend-only (it is logged as
 an observation and NEVER blocks an edit); the promotion posture it encodes is
 the spec's "promote only on zero-regression + net-positive". See ``verdict.py``.
+
+Reuses the bench's pure task/outcome dataclasses (``BenchTask``,
+``BenchArmOutcome`` — no CC, no DB) so the golden-suite format and the arm
+skip-semantics are shared across eval harnesses.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
+from genesis.eval.bench.types import BenchArmOutcome, BenchTask
 
 # Verdict labels — the three outcomes of a replay comparison.
 VERDICT_NET_POSITIVE = "net_positive"  # zero regression AND at least one improvement
@@ -48,3 +54,36 @@ class SkillReplayVerdict:
     score_winrate: dict = field(default_factory=dict)  # compute_score_winrate output
     pass_winrate: dict = field(default_factory=dict)  # compute_winrate output
     note: str = ""
+
+
+@dataclass(frozen=True)
+class SkillReplayPair:
+    """Both arms' outcomes on one golden task. control = OLD, treatment = NEW."""
+
+    task: BenchTask
+    old: BenchArmOutcome
+    new: BenchArmOutcome
+
+    @property
+    def skipped(self) -> bool:
+        return self.old.skipped or self.new.skipped
+
+
+@dataclass
+class SkillReplayReport:
+    """Aggregate result of one skill-replay run (the runner's return value)."""
+
+    run_id: str
+    skill_name: str
+    model: str
+    effort: str
+    task_set_version: str
+    task_file_sha256: str
+    rubric_name: str
+    rubric_version: str
+    pairs: list[SkillReplayPair] = field(default_factory=list)
+    verdict: SkillReplayVerdict | None = None
+    prod_delta: dict = field(default_factory=dict)
+    notes: list[str] = field(default_factory=list)
+    control_run_id: str = ""
+    treatment_run_id: str = ""

--- a/src/genesis/eval/skill_replay/types.py
+++ b/src/genesis/eval/skill_replay/types.py
@@ -1,0 +1,44 @@
+"""Types for the skill-replay held-out regression gate (WS1).
+
+A proposed SKILL.md edit is screened by REPLAYING a frozen golden task suite
+against the OLD vs NEW skill content and comparing per-task judge scores —
+control = OLD, treatment = NEW. The verdict is recommend-only (it is logged as
+an observation and NEVER blocks an edit); the promotion posture it encodes is
+the spec's "promote only on zero-regression + net-positive". See ``verdict.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Verdict labels — the three outcomes of a replay comparison.
+VERDICT_NET_POSITIVE = "net_positive"  # zero regression AND at least one improvement
+VERDICT_REGRESSION = "regression"  # NEW lost on >=1 task, or pass-rate favours OLD
+VERDICT_INCONCLUSIVE = "inconclusive"  # all ties, or too few complete pairs to judge
+
+
+@dataclass(frozen=True)
+class SkillReplayConfig:
+    """Statistical knobs for the verdict (operator-tunable via skill_gate_config).
+
+    ``epsilon`` is the per-task judge-score margin a win must exceed
+    (``compute_score_winrate``); ``min_pairs`` is the minimum number of complete
+    (non-skipped) task pairs required before a verdict is anything but
+    ``inconclusive`` — below it the run has no power and says so honestly.
+    """
+
+    epsilon: float = 0.05
+    min_pairs: int = 5
+
+
+@dataclass(frozen=True)
+class SkillReplayVerdict:
+    """The recommend-only outcome of one OLD-vs-NEW replay comparison."""
+
+    verdict: str  # one of VERDICT_*
+    n_complete: int  # complete (non-skipped) pairs graded
+    n_regressions: int  # tasks where OLD beat NEW by > epsilon
+    n_improvements: int  # tasks where NEW beat OLD by > epsilon
+    score_winrate: dict = field(default_factory=dict)  # compute_score_winrate output
+    pass_winrate: dict = field(default_factory=dict)  # compute_winrate output
+    note: str = ""

--- a/src/genesis/eval/skill_replay/verdict.py
+++ b/src/genesis/eval/skill_replay/verdict.py
@@ -1,0 +1,97 @@
+"""The skill-replay verdict — pure statistics over per-task judge results.
+
+Given the COMPLETE (non-skipped) task pairs of an OLD-vs-NEW replay, decide
+``net_positive`` / ``regression`` / ``inconclusive``. control = OLD, treatment =
+NEW. The bar is the spec's "promote only on zero-regression + net-positive":
+
+  * REGRESSION  — NEW scored worse than OLD on >=1 task (by more than epsilon),
+    OR the binary pass-rate favours OLD. This is the safety signal.
+  * NET_POSITIVE — zero regressions AND NEW strictly improved on >=1 task.
+  * INCONCLUSIVE — everything else (all ties, or fewer than ``min_pairs``
+    complete pairs to judge).
+
+Significance (McNemar exact, carried in the winrate dicts) is ADVISORY at
+shadow scale, NOT a gate: at 8-15 tasks a clean 5-0 improvement only reaches
+p=0.0625, so requiring significance would perversely reject genuine
+improvements. The verdict rests on zero-regression + strict-improvement; a
+future ENFORCE flip may add a significance floor once suites grow past ~30.
+
+Pure and CC-free — the runner extracts the per-case lists and calls this.
+"""
+
+from __future__ import annotations
+
+from genesis.eval.skill_replay.types import (
+    VERDICT_INCONCLUSIVE,
+    VERDICT_NET_POSITIVE,
+    VERDICT_REGRESSION,
+    SkillReplayConfig,
+    SkillReplayVerdict,
+)
+from genesis.eval.stats import compute_score_winrate, compute_winrate
+
+
+def compute_verdict(
+    *,
+    old_scores: list[float],
+    new_scores: list[float],
+    old_pass: list[bool],
+    new_pass: list[bool],
+    config: SkillReplayConfig,
+) -> SkillReplayVerdict:
+    """Decide the replay verdict from the complete task pairs.
+
+    All four lists are the COMPLETE (non-skipped) pairs in the SAME task order
+    and MUST be equal length (the runner drops any pair where either arm was
+    skipped for infra reasons). ``old_*`` is control, ``new_*`` is treatment.
+    """
+    n = len(new_scores)
+    if not (len(old_scores) == len(old_pass) == len(new_pass) == n):
+        msg = (
+            f"per-case lists must be equal length: old_scores={len(old_scores)}, "
+            f"new_scores={len(new_scores)}, old_pass={len(old_pass)}, new_pass={len(new_pass)}"
+        )
+        raise ValueError(msg)
+
+    if n < config.min_pairs:
+        return SkillReplayVerdict(
+            verdict=VERDICT_INCONCLUSIVE,
+            n_complete=n,
+            n_regressions=0,
+            n_improvements=0,
+            note=(
+                f"only {n} complete pair(s) (< min_pairs={config.min_pairs}) — "
+                "not enough signal to judge the edit"
+            ),
+        )
+
+    score_wr = compute_score_winrate(old_scores, new_scores, epsilon=config.epsilon)
+    pass_wr = compute_winrate(old_pass, new_pass)
+    n_reg = score_wr["n_control_wins"]  # OLD scored > NEW by > epsilon
+    n_imp = score_wr["n_treatment_wins"]  # NEW scored > OLD by > epsilon
+    pass_favours_old = pass_wr["recommendation"] == "control_wins"
+
+    if n_reg >= 1 or pass_favours_old:
+        verdict = VERDICT_REGRESSION
+        parts = []
+        if n_reg >= 1:
+            parts.append(f"{n_reg} task(s) regressed (OLD scored >epsilon higher)")
+        if pass_favours_old:
+            parts.append("binary pass-rate favours OLD")
+        note = "; ".join(parts)
+    elif n_imp >= 1:
+        verdict = VERDICT_NET_POSITIVE
+        note = f"zero regressions, {n_imp} task(s) improved (mean_delta={score_wr['mean_delta']})"
+    else:
+        verdict = VERDICT_INCONCLUSIVE
+        note = "no per-task differences beyond epsilon (all ties)"
+
+    return SkillReplayVerdict(
+        verdict=verdict,
+        n_complete=n,
+        n_regressions=n_reg,
+        n_improvements=n_imp,
+        score_winrate=score_wr,
+        pass_winrate=pass_wr,
+        note=note,
+    )

--- a/src/genesis/eval/skill_replay/verdict.py
+++ b/src/genesis/eval/skill_replay/verdict.py
@@ -5,16 +5,21 @@ Given the COMPLETE (non-skipped) task pairs of an OLD-vs-NEW replay, decide
 NEW. The bar is the spec's "promote only on zero-regression + net-positive":
 
   * REGRESSION  — NEW scored worse than OLD on >=1 task (by more than epsilon),
-    OR the binary pass-rate favours OLD. This is the safety signal.
+    OR the binary pass-rate net-favours OLD (more pass->fail flips than
+    fail->pass). This is the safety signal.
   * NET_POSITIVE — zero regressions AND NEW strictly improved on >=1 task.
   * INCONCLUSIVE — everything else (all ties, or fewer than ``min_pairs``
     complete pairs to judge).
 
 Significance (McNemar exact, carried in the winrate dicts) is ADVISORY at
-shadow scale, NOT a gate: at 8-15 tasks a clean 5-0 improvement only reaches
-p=0.0625, so requiring significance would perversely reject genuine
-improvements. The verdict rests on zero-regression + strict-improvement; a
-future ENFORCE flip may add a significance floor once suites grow past ~30.
+shadow scale, NOT a gate — applied symmetrically to BOTH signals: at 8-15 tasks
+a clean 5-0 improvement only reaches p=0.0625, so requiring significance would
+perversely reject genuine improvements AND (on the pass side) silently mask a
+real pass->fail regression. The verdict rests on zero-regression +
+strict-improvement. CAVEAT: per-task binary pass/fail is noisy at small N (judge
+variance can flip a task on identical content) — a pass-rate-only regression is
+a weak signal to adjudicate, not trust. A future ENFORCE flip needs larger
+suites / repetition before either signal is trusted to gate.
 
 Pure and CC-free — the runner extracts the per-case lists and calls this.
 """
@@ -69,7 +74,18 @@ def compute_verdict(
     pass_wr = compute_winrate(old_pass, new_pass)
     n_reg = score_wr["n_control_wins"]  # OLD scored > NEW by > epsilon
     n_imp = score_wr["n_treatment_wins"]  # NEW scored > OLD by > epsilon
-    pass_favours_old = pass_wr["recommendation"] == "control_wins"
+    # Binary pass-rate backstop for a score change that straddles the pass/fail
+    # line within epsilon (a graded near-tie the score check treats as a tie).
+    # Flag it on NET pass->fail flips favouring OLD, significance-INDEPENDENT
+    # (McNemar's `recommendation` needs ~6 unanimous discordant pairs to reach
+    # p<0.05, so a small suite would silently mask a real pass->fail; and the
+    # module treats significance as advisory, not a gate). Using the NET count
+    # (control_wins > treatment_wins) tolerates one stray pass<->fail flip from
+    # judge noise cancelling against its opposite — but a lone pass->fail on a
+    # small, noisy suite still flags: sensitive-by-design for a shadow bake that
+    # feeds human adjudication (see the small-N caveat in the module docstring).
+    n_pass_reg = pass_wr["n_control_wins"]  # tasks OLD passed but NEW failed
+    pass_favours_old = n_pass_reg > pass_wr["n_treatment_wins"]
 
     if n_reg >= 1 or pass_favours_old:
         verdict = VERDICT_REGRESSION
@@ -77,7 +93,10 @@ def compute_verdict(
         if n_reg >= 1:
             parts.append(f"{n_reg} task(s) regressed (OLD scored >epsilon higher)")
         if pass_favours_old:
-            parts.append("binary pass-rate favours OLD")
+            parts.append(
+                f"net pass->fail flips favour OLD ({n_pass_reg} vs "
+                f"{pass_wr['n_treatment_wins']}) — noisy at small N, adjudicate"
+            )
         note = "; ".join(parts)
     elif n_imp >= 1:
         verdict = VERDICT_NET_POSITIVE

--- a/src/genesis/learning/skills/skill_gate_config.py
+++ b/src/genesis/learning/skills/skill_gate_config.py
@@ -1,26 +1,30 @@
-"""Skill-edit Critic control surface — live-read gate lever.
+"""Skill-edit gate control surface — live-read levers.
 
-The ONE place the skill-edit Critic consults for policy (ws2_ledger_config /
-ledger_shadow_config lineage). Exposes a single lever:
+The ONE place the skill-evolution gates consult for policy (ws2_ledger_config /
+ledger_shadow_config lineage). Two levers, both re-read from the merged YAML
+(``config/skill_evolution_gate.yaml`` + the user overlay
+``~/.genesis/config/skill_evolution_gate.local.yaml``) on EVERY skill-evolution
+pass — no boot cache, flip without a restart:
 
-- :func:`skill_gate_mode` — ``off | shadow`` for the Critic that screens
-  self-proposed SKILL.md edits, re-read from the merged YAML
-  (``config/skill_evolution_gate.yaml`` + the user overlay
-  ``~/.genesis/config/skill_evolution_gate.local.yaml``) on EVERY skill-
-  evolution pass. No boot cache — the operator flips off/shadow without a
-  restart.
+- :func:`skill_gate_mode` — ``off | shadow`` for the static diff-screen Critic
+  that screens a proposed SKILL.md edit for self-modification pathologies.
+- :func:`skill_replay_mode` / :func:`skill_replay_config` — ``off | shadow`` +
+  statistical knobs for the held-out REPLAY gate (WS1), which screens an edit by
+  replaying a frozen golden task suite against OLD vs NEW content.
 
-Shadow is the DEFAULT and an INVALID value degrades to shadow — the gate is
-log-only (it never blocks an edit), so shadow is the safe, observable baseline
-(the same fail-safe posture as ledger_shadow_config). ``off`` disables the
-Critic entirely (no LLM call, no observation). There is no ``enforce`` mode yet.
+Shadow is the DEFAULT everywhere and an INVALID value degrades to shadow — the
+gates are log-only (they never block an edit), so shadow is the safe, observable
+baseline (the same fail-safe posture as ledger_shadow_config). ``off`` disables
+a gate entirely. There is no ``enforce`` mode yet.
 
 The env kill ``GENESIS_SKILL_EVOLUTION_GATE_OFF`` (genesis.env.skill_gate_off)
-is a separate hard override checked first by the Critic — it forces off without
-touching this config.
+is a separate hard override checked first by the gates — it forces off without
+touching this config, and covers BOTH gates.
 
 Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
-``genesis.mcp.health.settings`` imports MODES from here, never the reverse.
+``genesis.mcp.health.settings`` imports MODES/REPLAY_MODES from here, never the
+reverse. Accessors return plain values (no eval/skill_replay import) so this
+module stays dependency-light.
 """
 
 from __future__ import annotations
@@ -38,12 +42,18 @@ from genesis.env import repo_root
 logger = logging.getLogger(__name__)
 
 MODES = ("off", "shadow")
+REPLAY_MODES = ("off", "shadow")
 
 _CONFIG_NAME = "skill_evolution_gate.yaml"
 
 DEFAULTS: dict[str, Any] = {
     "enabled": True,
-    "mode": "shadow",  # log-only Critic; shadow-first
+    "mode": "shadow",  # the static diff-screen Critic; shadow-first
+    # Held-out replay gate (WS1). Screens an edit by REPLAYING a per-skill golden
+    # suite against OLD vs NEW content and logging a recommend-only verdict. Only
+    # fires where a suite exists; heavy (spawns CC sessions), so it runs
+    # out-of-band, never in the auto-apply hot path.
+    "replay": {"mode": "shadow", "epsilon": 0.05, "min_pairs": 5},
 }
 
 
@@ -75,7 +85,7 @@ def load_config() -> dict[str, Any]:
 
 
 def skill_gate_mode() -> str:
-    """The skill-edit Critic mode — read live.
+    """The static diff-screen Critic mode — read live.
 
     Master ``enabled: false`` → ``off``. An invalid value degrades to
     ``shadow`` (observe-only; the gate never blocks an edit, so shadow is the
@@ -93,3 +103,48 @@ def skill_gate_mode() -> str:
         logger.warning("skill_evolution_gate has invalid mode %r — degrading to shadow", mode)
         return "shadow"
     return mode
+
+
+def skill_replay_mode() -> str:
+    """The held-out replay gate mode — ``off | shadow``, read live.
+
+    Master ``enabled: false`` → ``off`` (covers both gates). A missing or
+    invalid ``replay.mode`` degrades to ``shadow`` (the log-only safe baseline).
+    """
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    replay = cfg.get("replay")
+    if not isinstance(replay, dict):
+        return "shadow"
+    mode = replay.get("mode")
+    if mode is False:  # YAML-1.1 `mode: off` → boolean False; honor the intent.
+        return "off"
+    if mode not in REPLAY_MODES:
+        logger.warning("skill_evolution_gate.replay invalid mode %r — degrading to shadow", mode)
+        return "shadow"
+    return mode
+
+
+def skill_replay_config() -> dict[str, Any]:
+    """Replay-gate knobs (mode + statistical thresholds), read live.
+
+    Returns a plain dict — the caller builds the ``SkillReplayConfig`` (keeps
+    this module free of an eval/skill_replay import). Malformed numeric knobs
+    degrade to defaults; ``min_pairs`` is clamped to >= 1 so a bad value can
+    never let a verdict fire on an empty comparison.
+    """
+    cfg = load_config()
+    replay = cfg.get("replay") if isinstance(cfg.get("replay"), dict) else {}
+
+    def _num(key: str, default: float, cast):
+        try:
+            return cast(replay.get(key, default))
+        except (TypeError, ValueError):
+            return default
+
+    return {
+        "mode": skill_replay_mode(),
+        "epsilon": _num("epsilon", 0.05, float),
+        "min_pairs": max(1, _num("min_pairs", 5, int)),
+    }

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -87,6 +87,7 @@ from genesis.mcp.health import provider as _provider  # noqa: E402
 from genesis.mcp.health import session_charter_tools as _session_charter_tools  # noqa: E402
 from genesis.mcp.health import session_control as _session_control  # noqa: E402
 from genesis.mcp.health import settings as _settings  # noqa: E402
+from genesis.mcp.health import skill_replay_run as _skill_replay_run  # noqa: E402, F401
 from genesis.mcp.health import status as _status  # noqa: E402
 from genesis.mcp.health import task_tools as _task_tools  # noqa: E402
 from genesis.mcp.health import update_history as _update_history  # noqa: E402

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -133,13 +133,15 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
     "skill_evolution_gate": SettingsDomain(
         name="skill_evolution_gate",
         description=(
-            "Skill-edit Critic (WS1) — master `enabled` + `mode` off/shadow. "
-            "Shadow (default) screens self-proposed SKILL.md edits for "
-            "self-modification pathologies and LOGS a verdict observation "
-            "without blocking the auto-apply; off skips the Critic entirely. "
-            "No `enforce` mode yet. Read live per skill-evolution pass by "
-            "genesis.learning.skills.skill_gate_config (no restart); kill via "
-            "GENESIS_SKILL_EVOLUTION_GATE_OFF."
+            "Skill-evolution gates (WS1) — master `enabled`, the static Critic "
+            "`mode` off/shadow, and the held-out `replay` gate "
+            "(replay.mode off/shadow + epsilon/min_pairs). Shadow (default) "
+            "screens self-proposed SKILL.md edits — the Critic by static diff, "
+            "the replay by re-running a golden suite against OLD vs NEW — and "
+            "LOGS a verdict observation without blocking the auto-apply; off "
+            "skips a gate. No `enforce` mode yet. Read live per pass by "
+            "genesis.learning.skills.skill_gate_config (no restart); kill both "
+            "via GENESIS_SKILL_EVOLUTION_GATE_OFF."
         ),
         config_filename="skill_evolution_gate.yaml",
         readonly=False,
@@ -857,20 +859,45 @@ def _validate_ws2_ledger(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_skill_replay_subconfig(value, replay_modes) -> list[str]:
+    """Validate the ``replay`` sub-config of the skill-evolution gate."""
+    if not isinstance(value, dict):
+        return ["'replay' must be a mapping (mode/epsilon/min_pairs)"]
+    errors: list[str] = []
+    for k, v in value.items():
+        if k == "mode":
+            if v not in replay_modes:
+                errors.append(f"'replay.mode' must be one of {', '.join(replay_modes)}; got {v!r}")
+        elif k == "epsilon":
+            # bool is a subclass of int — reject it explicitly.
+            if isinstance(v, bool) or not isinstance(v, (int, float)) or not (0.0 <= v < 1.0):
+                errors.append("'replay.epsilon' must be a number in [0.0, 1.0)")
+        elif k == "min_pairs":
+            if isinstance(v, bool) or not isinstance(v, int) or v < 1:
+                errors.append("'replay.min_pairs' must be an integer >= 1")
+        else:
+            errors.append(f"Unknown key 'replay.{k}'. Valid: mode, epsilon, min_pairs")
+    return errors
+
+
 def _validate_skill_evolution_gate(changes: dict) -> list[str]:
-    """Validate skill-edit Critic lever changes (see
-    genesis.learning.skills.skill_gate_config)."""
-    from genesis.learning.skills.skill_gate_config import MODES
+    """Validate skill-evolution gate lever changes — the static Critic (mode)
+    and the held-out replay gate (replay.*). See
+    genesis.learning.skills.skill_gate_config."""
+    from genesis.learning.skills.skill_gate_config import MODES, REPLAY_MODES
 
     errors: list[str] = []
     for key, value in changes.items():
-        if key not in ("enabled", "mode"):
-            errors.append(f"Unknown key '{key}'. Valid: enabled, mode")
-        elif key == "enabled":
+        if key == "enabled":
             if not isinstance(value, bool):
                 errors.append("'enabled' must be a boolean")
-        elif value not in MODES:
-            errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif key == "mode":
+            if value not in MODES:
+                errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif key == "replay":
+            errors.extend(_validate_skill_replay_subconfig(value, REPLAY_MODES))
+        else:
+            errors.append(f"Unknown key '{key}'. Valid: enabled, mode, replay")
     return errors
 
 

--- a/src/genesis/mcp/health/skill_replay_run.py
+++ b/src/genesis/mcp/health/skill_replay_run.py
@@ -88,7 +88,13 @@ async def _impl_skill_replay_run(
         return _err(f"skill not found: {skill_name}")
 
     if new_content is None:
-        new_content = load_skill(skill_name)
+        try:
+            new_content = load_skill(skill_name)
+        except Exception:  # noqa: BLE001 — never crash the tool (bad encoding / TOCTOU)
+            logger.warning(
+                "skill_replay_run: reading SKILL.md for %s failed", skill_name, exc_info=True
+            )
+            return _err(f"could not read current SKILL.md for {skill_name}")
     if not new_content:
         return _err(f"no NEW content resolved for {skill_name}")
 

--- a/src/genesis/mcp/health/skill_replay_run.py
+++ b/src/genesis/mcp/health/skill_replay_run.py
@@ -1,0 +1,205 @@
+"""skill_replay_run MCP tool — replay a skill edit against its golden suite (WS1).
+
+Runs the held-out regression gate for ONE skill: replays the frozen golden task
+suite against the OLD vs NEW SKILL.md content (control=OLD, treatment=NEW) and
+RETURNS + LOGS a recommend-only verdict (net_positive / regression /
+inconclusive). It NEVER blocks or applies an edit — ``autonomous_action`` is
+always False. Gated by the ``skill_evolution_gate.replay`` lever and the
+``GENESIS_SKILL_EVOLUTION_GATE_OFF`` hard kill.
+
+OLD content resolves from the cognitive-ledger pre-image of the last
+``skill_evolution`` edit (the applicator captures it via record_file_modification)
+unless passed explicitly; NEW defaults to the on-disk SKILL.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+def _default_suite_path(skill_name: str) -> Path:
+    from genesis.env import genesis_home
+
+    return genesis_home() / "eval" / "skill_golden" / f"{skill_name}.jsonl"
+
+
+async def _resolve_ledger_old_content(db, target_path: str) -> str | None:
+    """OLD content = ``prior_content`` of the most-recent ``skill_evolution`` edit
+    to ``target_path`` (the pre-image the applicator captured before overwriting)."""
+    if db is None:
+        return None
+    try:
+        from genesis.db.crud import cognitive_file_modifications as cfm
+
+        rows = await cfm.recent(db, limit=50, actor="skill_evolution")
+    except Exception:  # noqa: BLE001 — best-effort; caller falls back to explicit arg
+        logger.warning("skill_replay_run: ledger pre-image lookup failed", exc_info=True)
+        return None
+    for row in rows:
+        if row.get("target_path") == target_path:
+            return row.get("prior_content")
+    return None
+
+
+def _err(message: str) -> dict:
+    return {"status": "error", "autonomous_action": False, "message": message}
+
+
+async def _impl_skill_replay_run(
+    *,
+    skill_name: str,
+    old_content: str | None = None,
+    new_content: str | None = None,
+    suite_path: str | None = None,
+    model: str = "sonnet",
+    effort: str = "medium",
+    limit: int | None = None,
+) -> dict:
+    from genesis.env import skill_gate_off
+    from genesis.learning.skills.skill_gate_config import (
+        skill_replay_config,
+        skill_replay_mode,
+    )
+
+    if skill_gate_off() or skill_replay_mode() == "off":
+        return {
+            "status": "skipped",
+            "reason": "replay gate off (skill_evolution_gate.replay=off or env kill)",
+            "autonomous_action": False,
+            "recommend_only": True,
+        }
+
+    from genesis.cc.types import VALID_EFFORT_NAMES, VALID_MODEL_NAMES, CCModel, EffortLevel
+    from genesis.learning.skills.wiring import get_skill_path, load_skill
+
+    if model not in VALID_MODEL_NAMES:
+        return _err(f"invalid model {model!r}; valid: {', '.join(sorted(VALID_MODEL_NAMES))}")
+    if effort not in VALID_EFFORT_NAMES:
+        return _err(f"invalid effort {effort!r}; valid: {', '.join(sorted(VALID_EFFORT_NAMES))}")
+
+    path = get_skill_path(skill_name)
+    if path is None:
+        return _err(f"skill not found: {skill_name}")
+
+    if new_content is None:
+        new_content = load_skill(skill_name)
+    if not new_content:
+        return _err(f"no NEW content resolved for {skill_name}")
+
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = getattr(health_mcp_mod, "_service", None)
+    db = getattr(_service, "_db", None) if _service is not None else None
+
+    if old_content is None:
+        old_content = await _resolve_ledger_old_content(db, str(path))
+    if not old_content:
+        return _err(
+            "no OLD content — pass old_content explicitly, or ensure a "
+            "skill_evolution ledger pre-image exists for this skill's SKILL.md"
+        )
+
+    suite = Path(suite_path) if suite_path else _default_suite_path(skill_name)
+    if not suite.exists():
+        return _err(
+            f"golden suite not found: {suite}. Author it with "
+            f"`python -m genesis.eval.skill_golden_set --skill {skill_name}`"
+        )
+
+    from genesis.eval.skill_replay.persist import (
+        log_replay_observation,
+        persist_skill_replay_summary,
+    )
+    from genesis.eval.skill_replay.runner import run_skill_replay
+    from genesis.eval.skill_replay.types import SkillReplayConfig
+
+    knobs = skill_replay_config()
+    cfg = SkillReplayConfig(epsilon=knobs["epsilon"], min_pairs=knobs["min_pairs"])
+
+    started = datetime.now(UTC)
+    try:
+        report = await run_skill_replay(
+            skill_name=skill_name,
+            old_content=old_content,
+            new_content=new_content,
+            tasks_path=suite,
+            model=CCModel(model),
+            effort=EffortLevel(effort),
+            config=cfg,
+            limit=limit,
+        )
+    except Exception as exc:  # noqa: BLE001 — never crash the tool
+        logger.warning("skill_replay_run failed", exc_info=True)
+        return _err(f"{type(exc).__name__}: {exc}")
+
+    duration_s = (datetime.now(UTC) - started).total_seconds()
+    if db is not None:
+        try:
+            await persist_skill_replay_summary(db, report, duration_s=duration_s)
+            await log_replay_observation(db, report, now=datetime.now(UTC).isoformat())
+        except Exception:  # noqa: BLE001 — persistence is non-fatal to the measurement
+            logger.warning("skill_replay_run: persistence failed", exc_info=True)
+
+    v = report.verdict
+    return {
+        "status": "ok",
+        "autonomous_action": False,
+        "recommend_only": True,
+        "skill_name": skill_name,
+        "verdict": v.verdict if v else None,
+        "n_complete": v.n_complete if v else 0,
+        "n_regressions": v.n_regressions if v else 0,
+        "n_improvements": v.n_improvements if v else 0,
+        "note": v.note if v else "",
+        "score_winrate": v.score_winrate if v else {},
+        "control_run_id": report.control_run_id,
+        "treatment_run_id": report.treatment_run_id,
+        "task_set_version": report.task_set_version,
+        "prod_delta_clean": report.prod_delta.get("clean"),
+        "notes": report.notes,
+    }
+
+
+@mcp.tool()
+async def skill_replay_run(
+    skill_name: str,
+    old_content: str = "",
+    new_content: str = "",
+    suite_path: str = "",
+    model: str = "sonnet",
+    effort: str = "medium",
+    limit: int = 0,
+) -> dict:
+    """Replay a skill edit (WS1 held-out gate): run the skill's frozen golden
+    suite against OLD vs NEW SKILL.md content and RETURN + LOG a recommend-only
+    verdict (net_positive / regression / inconclusive).
+
+    RECOMMEND-ONLY — it never blocks or applies an edit (autonomous_action
+    False); it logs the verdict as a ``skill_replay_verdict`` observation. Heavy
+    (spawns CC sessions), so run it out-of-band. Gated by
+    ``skill_evolution_gate.replay`` + ``GENESIS_SKILL_EVOLUTION_GATE_OFF``.
+
+    Args:
+        skill_name: the skill whose edit to screen (e.g. "voice-master").
+        old_content: pre-edit SKILL.md body; default = the cognitive-ledger
+            pre-image of the last skill_evolution edit.
+        new_content: proposed SKILL.md body; default = the on-disk current file.
+        suite_path: golden JSONL; default ~/.genesis/eval/skill_golden/<skill>.jsonl.
+        model / effort: CC arm model tier / effort (default sonnet / medium).
+        limit: cap the number of golden tasks (0 = all).
+    """
+    return await _impl_skill_replay_run(
+        skill_name=skill_name,
+        old_content=old_content or None,
+        new_content=new_content or None,
+        suite_path=suite_path or None,
+        model=model,
+        effort=effort,
+        limit=limit or None,
+    )

--- a/src/genesis/mcp/health/skill_replay_run.py
+++ b/src/genesis/mcp/health/skill_replay_run.py
@@ -37,14 +37,13 @@ async def _resolve_ledger_old_content(db, target_path: str) -> str | None:
     try:
         from genesis.db.crud import cognitive_file_modifications as cfm
 
-        rows = await cfm.recent(db, limit=50, actor="skill_evolution")
+        # Bounded by target_path (not a global recency window) so an older
+        # per-skill edit is never missed behind a burst of other skills' edits.
+        row = await cfm.latest_for_target(db, target_path, actor="skill_evolution")
     except Exception:  # noqa: BLE001 — best-effort; caller falls back to explicit arg
         logger.warning("skill_replay_run: ledger pre-image lookup failed", exc_info=True)
         return None
-    for row in rows:
-        if row.get("target_path") == target_path:
-            return row.get("prior_content")
-    return None
+    return row.get("prior_content") if row else None
 
 
 def _err(message: str) -> dict:

--- a/tests/test_db/test_cognitive_file_modifications.py
+++ b/tests/test_db/test_cognitive_file_modifications.py
@@ -203,3 +203,34 @@ class TestPrune:
         kept_p = [r["applied_content"] for r in rows if r["target_path"] == "/p"]
         assert kept_p == ["4", "3"]  # the two most recent
         assert any(r["target_path"] == "/other" for r in rows)
+
+
+class TestLatestForTarget:
+    @pytest.mark.asyncio
+    async def test_returns_newest_for_path(self, db):
+        await cfm.record(
+            db, actor="skill_evolution", target_path="/p", prior_content="v1",
+            applied_content="v2", created_at="2026-01-01T00:00:00",
+        )
+        await cfm.record(
+            db, actor="skill_evolution", target_path="/p", prior_content="v2",
+            applied_content="v3", created_at="2026-01-02T00:00:00",
+        )
+        # A newer edit to a DIFFERENT path must not shadow /p's latest.
+        await cfm.record(
+            db, actor="skill_evolution", target_path="/other", prior_content="x",
+            applied_content="y", created_at="2026-01-03T00:00:00",
+        )
+        row = await cfm.latest_for_target(db, "/p", actor="skill_evolution")
+        assert row is not None
+        assert row["prior_content"] == "v2"  # pre-image of the newest /p edit
+
+    @pytest.mark.asyncio
+    async def test_actor_filter(self, db):
+        await cfm.record(db, actor="other", target_path="/p", applied_content="a")
+        assert await cfm.latest_for_target(db, "/p", actor="skill_evolution") is None
+        assert await cfm.latest_for_target(db, "/p") is not None  # unfiltered finds it
+
+    @pytest.mark.asyncio
+    async def test_unknown_path_returns_none(self, db):
+        assert await cfm.latest_for_target(db, "/nope") is None

--- a/tests/test_eval/skill_golden_fixtures/voice_master_fixture.jsonl
+++ b/tests/test_eval/skill_golden_fixtures/voice_master_fixture.jsonl
@@ -1,0 +1,6 @@
+{"_meta": {"task_set_version": "fixture_v1"}}
+{"id": "t1", "category": "drafting", "prompt": "Task 1: write a one-line greeting in the user's voice.", "expected": "First person, warm, no AI cliches."}
+{"id": "t2", "category": "drafting", "prompt": "Task 2: rewrite a sentence to remove AI tells.", "expected": "No em-dash pileups, no 'it's not just X it's Y' construction."}
+{"id": "t3", "category": "drafting", "prompt": "Task 3: draft a short reply.", "expected": "Concise and direct."}
+{"id": "t4", "category": "drafting", "prompt": "Task 4: humanize a stiff paragraph.", "expected": "Varied rhythm, plain words."}
+{"id": "t5", "category": "drafting", "prompt": "Task 5: write a two-sentence intro.", "expected": "Specific, first person."}

--- a/tests/test_eval/test_skill_golden_set.py
+++ b/tests/test_eval/test_skill_golden_set.py
@@ -1,0 +1,33 @@
+"""Tests for the skill-golden-set authoring helper — scaffold + validate."""
+
+from __future__ import annotations
+
+from genesis.eval.skill_golden_set import validate, write_scaffold
+
+
+def test_scaffold_writes_loadable_suite(tmp_path):
+    path = tmp_path / "myskill.jsonl"
+    write_scaffold("myskill", path, force=False)
+    assert path.exists()
+    # It loads cleanly through the bench task loader (tmp_path is outside the repo).
+    assert validate(path) == 0
+
+
+def test_scaffold_refuses_overwrite_without_force(tmp_path):
+    path = tmp_path / "s.jsonl"
+    write_scaffold("s", path, force=False)
+    with __import__("pytest").raises(SystemExit):
+        write_scaffold("s", path, force=False)
+    # force overwrites.
+    write_scaffold("s", path, force=True)
+
+
+def test_validate_missing_file_returns_error(tmp_path):
+    assert validate(tmp_path / "nope.jsonl") == 1
+
+
+def test_validate_flags_placeholders(tmp_path, capsys):
+    path = tmp_path / "ph.jsonl"
+    write_scaffold("ph", path, force=False)
+    assert validate(path) == 0
+    assert "placeholder" in capsys.readouterr().out.lower()

--- a/tests/test_eval/test_skill_replay_arms.py
+++ b/tests/test_eval/test_skill_replay_arms.py
@@ -1,0 +1,75 @@
+"""Structural tests for the skill-replay arm builder.
+
+No live CC — assert the built CCInvocation carries the bare-arm isolation
+recipe and that the ONLY delta between arms is the pinned skill content.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.cc.types import CCModel, EffortLevel
+from genesis.eval.bench.types import BenchTask
+from genesis.eval.skill_replay.arms import build_skill_arm_invocation
+from genesis.eval.skill_replay.types import ARM_NEW, ARM_OLD
+
+_TASK = BenchTask(
+    id="t1",
+    category="drafting",
+    prompt="Write a two-sentence intro in the user's voice.",
+    expected="First person; no AI-tell constructions.",
+)
+
+
+def _arm(tmp_path, arm_label, content):
+    return build_skill_arm_invocation(
+        _TASK,
+        tmp_path,
+        CCModel.SONNET,
+        EffortLevel.MEDIUM,
+        skill_name="voice-master",
+        skill_content=content,
+        bare_config_dir=tmp_path / "bare-config",
+        run_id="run1",
+        arm_label=arm_label,
+    )
+
+
+def test_arm_carries_bare_isolation_recipe(tmp_path):
+    inv = _arm(tmp_path, ARM_OLD, "OLD BODY")
+    assert inv.safe_mode is True
+    assert inv.strict_mcp_config is True
+    assert inv.mcp_config.endswith("no_mcp.json")
+    assert inv.skip_permissions is True
+    assert inv.env_overrides["CLAUDE_CONFIG_DIR"].endswith("bare-config")
+    # Neutral per-arm cwd, outside any repo checkout.
+    assert inv.working_dir.endswith(f"work/{_TASK.id}/{ARM_OLD}")
+
+
+def test_pinned_content_is_the_system_prompt(tmp_path):
+    inv = _arm(tmp_path, ARM_NEW, "NEW BODY HERE")
+    assert inv.system_prompt == "## Skill: voice-master\nNEW BODY HERE"
+    # Prompt is the task + shared fairness envelope (out-of-bounds rule etc.).
+    assert inv.prompt.startswith(_TASK.rendered_prompt())
+
+
+def test_only_delta_between_arms_is_pinned_content(tmp_path):
+    old = _arm(tmp_path, ARM_OLD, "OLD BODY")
+    new = _arm(tmp_path, ARM_NEW, "NEW BODY")
+    # Identical fairness surface.
+    assert old.prompt == new.prompt
+    assert old.model == new.model
+    assert old.effort == new.effort
+    assert old.timeout_s == new.timeout_s
+    assert old.safe_mode == new.safe_mode
+    # The intended deltas.
+    assert old.system_prompt != new.system_prompt
+    assert old.working_dir != new.working_dir
+    assert old.session_key != new.session_key
+    assert old.session_key.endswith(ARM_OLD)
+    assert new.session_key.endswith(ARM_NEW)
+
+
+def test_invalid_arm_label_raises(tmp_path):
+    with pytest.raises(ValueError, match="arm_label must be"):
+        _arm(tmp_path, "treatment", "body")

--- a/tests/test_eval/test_skill_replay_persist.py
+++ b/tests/test_eval/test_skill_replay_persist.py
@@ -1,0 +1,132 @@
+"""Persistence + observation tests for the skill-replay gate.
+
+In-memory aiosqlite; assert exactly the paired eval_runs rows + one observation,
+with priority keyed to the verdict. Fixed timestamps, no live clock.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.eval.bench.types import BenchArmOutcome, BenchTask
+from genesis.eval.skill_replay.persist import (
+    log_replay_observation,
+    persist_skill_replay_summary,
+)
+from genesis.eval.skill_replay.types import (
+    VERDICT_NET_POSITIVE,
+    VERDICT_REGRESSION,
+    SkillReplayPair,
+    SkillReplayReport,
+    SkillReplayVerdict,
+)
+
+_NOW = "2026-07-20T00:00:00+00:00"
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    from importlib import import_module
+
+    from genesis.db.schema import create_all_tables, seed_data
+
+    await create_all_tables(conn)
+    await seed_data(conn)
+    # eval_runs / eval_results are migration-only (not in create_all_tables);
+    # apply the eval-table migrations in order (0003 adds .skipped, 0014
+    # adds .metadata_json — both written by insert_run).
+    for mig in (
+        "0002_add_eval_tables",
+        "0003_eval_results_skipped",
+        "0014_eval_results_metadata",
+    ):
+        await import_module(f"genesis.db.migrations.{mig}").up(conn)
+    yield conn
+    await conn.close()
+
+
+def _outcome(arm: str, score: float, passed: bool) -> BenchArmOutcome:
+    return BenchArmOutcome(
+        task_id="t1",
+        arm=arm,
+        output_text=f"{arm}-output",
+        judge_passed=passed,
+        judge_score=score,
+        judge_detail="{}",
+    )
+
+
+def _report(verdict_label: str, n_reg: int, n_imp: int) -> SkillReplayReport:
+    task = BenchTask(id="t1", category="drafting", prompt="p", expected="e")
+    pair = SkillReplayPair(
+        task=task,
+        old=_outcome("old", 0.5, False),
+        new=_outcome("new", 0.9, True),
+    )
+    return SkillReplayReport(
+        run_id="run1",
+        skill_name="voice-master",
+        model="sonnet",
+        effort="medium",
+        task_set_version="v1",
+        task_file_sha256="abc123",
+        rubric_name="bench_task_success",
+        rubric_version="1.0",
+        pairs=[pair],
+        verdict=SkillReplayVerdict(
+            verdict=verdict_label,
+            n_complete=1,
+            n_regressions=n_reg,
+            n_improvements=n_imp,
+            note="x",
+        ),
+    )
+
+
+async def test_persist_writes_paired_eval_runs(db):
+    report = _report(VERDICT_NET_POSITIVE, 0, 1)
+    control_id, treatment_id = await persist_skill_replay_summary(db, report)
+
+    cur = await db.execute(
+        "SELECT id, model_profile, comparison_run_id FROM eval_runs ORDER BY model_profile"
+    )
+    rows = await cur.fetchall()
+    assert len(rows) == 2
+    profiles = {r["model_profile"] for r in rows}
+    assert profiles == {"skill_replay:old", "skill_replay:new"}
+    # Treatment (new) links back to control (old).
+    treatment = next(r for r in rows if r["model_profile"] == "skill_replay:new")
+    assert treatment["comparison_run_id"] == control_id
+    assert report.control_run_id == control_id
+    assert report.treatment_run_id == treatment_id
+    # Two arms x one case = two eval_results.
+    cur = await db.execute("SELECT COUNT(*) AS n FROM eval_results")
+    assert (await cur.fetchone())["n"] == 2
+
+
+async def test_observation_regression_is_high_priority(db):
+    report = _report(VERDICT_REGRESSION, 1, 0)
+    obs_id = await log_replay_observation(db, report, now=_NOW)
+
+    cur = await db.execute(
+        "SELECT source, type, priority, content FROM observations WHERE id = ?",
+        (obs_id,),
+    )
+    row = await cur.fetchone()
+    assert row["source"] == "skill_evolution_gate"
+    assert row["type"] == "skill_replay_verdict"
+    assert row["priority"] == "high"
+    assert "regression" in row["content"]
+
+
+async def test_observation_net_positive_is_low_priority(db):
+    report = _report(VERDICT_NET_POSITIVE, 0, 1)
+    await log_replay_observation(db, report, now=_NOW)
+
+    cur = await db.execute("SELECT priority FROM observations WHERE type = 'skill_replay_verdict'")
+    rows = await cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "low"

--- a/tests/test_eval/test_skill_replay_runner.py
+++ b/tests/test_eval/test_skill_replay_runner.py
@@ -1,0 +1,132 @@
+"""Runner tests for the skill-replay gate — fake invoker + fake scorer, no CC.
+
+The runner reuses the bench's run_arm/judge_arm skip-semantics and its own
+verdict. These tests drive the whole paired loop deterministically and assert
+the verdict, that an infra skip shrinks N, and that nothing mutates.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import genesis.eval.skill_replay.runner as runner_mod
+from genesis.eval.skill_replay.runner import run_skill_replay
+from genesis.eval.skill_replay.types import (
+    VERDICT_INCONCLUSIVE,
+    VERDICT_NET_POSITIVE,
+    VERDICT_REGRESSION,
+    SkillReplayConfig,
+)
+
+_FIXTURE = Path(__file__).parent / "skill_golden_fixtures" / "voice_master_fixture.jsonl"
+_CFG = SkillReplayConfig(epsilon=0.05, min_pairs=3)
+
+
+@dataclass
+class _FakeOutput:
+    text: str
+    is_error: bool = False
+    error_message: str = ""
+    model_used: str = "fake-model"
+    duration_ms: float = 10.0
+    cost_usd: float = 0.0
+    input_tokens: int = 1
+    output_tokens: int = 1
+
+
+class _FakeInvoker:
+    """Returns 'OLD'/'NEW' by which content is pinned; can error the OLD arm of
+    named tasks to exercise the infra-skip path."""
+
+    def __init__(self, error_old_for: frozenset[str] = frozenset()):
+        self._error_old_for = error_old_for
+
+    async def run(self, inv):
+        is_new = "NEWBODY" in (inv.system_prompt or "")
+        if not is_new and any(s in inv.prompt for s in self._error_old_for):
+            return _FakeOutput(text="", is_error=True, error_message="infra boom")
+        return _FakeOutput(text="NEW" if is_new else "OLD")
+
+
+class _FakeScorer:
+    """Scores by (task-prompt substring, arm). Default 0.5 (a failing tie)."""
+
+    def __init__(self, scores: dict[tuple[str, str], float]):
+        self._scores = scores
+
+    async def score_async(self, *, actual, expected, config):
+        arm = "new" if actual == "NEW" else "old"
+        task_prompt = config.get("task_prompt", "")
+        score = 0.5
+        for (substr, a), val in self._scores.items():
+            if a == arm and substr in task_prompt:
+                score = val
+                break
+        detail = json.dumps({"judge_score": score, "rubric_version": "1.0"})
+        return score >= 0.6, score, detail
+
+
+@pytest.fixture(autouse=True)
+def _hermetic(monkeypatch, tmp_path):
+    # Don't require real CC credentials, and don't mutate the process env.
+    monkeypatch.setattr(runner_mod, "prepare_bare_config_dir", lambda run_dir: run_dir / "cfg")
+    monkeypatch.setattr(runner_mod, "scrub_nested_cc_env", lambda: [])
+
+
+async def _run(invoker, scorer, tmp_path):
+    return await run_skill_replay(
+        skill_name="voice-master",
+        old_content="OLDBODY",
+        new_content="NEWBODY",
+        tasks_path=_FIXTURE,
+        config=_CFG,
+        invoker=invoker,
+        scorer=scorer,
+        verify_prod=False,
+        allow_repo_tasks=True,
+        run_root=tmp_path,
+    )
+
+
+async def test_net_positive_when_new_improves_with_zero_regressions(tmp_path):
+    scorer = _FakeScorer({("Task 1", "new"): 0.9, ("Task 2", "new"): 0.9})
+    report = await _run(_FakeInvoker(), scorer, tmp_path)
+    assert report.verdict.verdict == VERDICT_NET_POSITIVE
+    assert report.verdict.n_regressions == 0
+    assert report.verdict.n_improvements == 2
+    assert report.verdict.n_complete == 5
+    assert len(report.pairs) == 5
+
+
+async def test_regression_when_new_loses_a_task(tmp_path):
+    scorer = _FakeScorer({("Task 1", "old"): 0.9})  # OLD beats NEW on t1
+    report = await _run(_FakeInvoker(), scorer, tmp_path)
+    assert report.verdict.verdict == VERDICT_REGRESSION
+    assert report.verdict.n_regressions == 1
+
+
+async def test_all_ties_is_inconclusive(tmp_path):
+    report = await _run(_FakeInvoker(), _FakeScorer({}), tmp_path)
+    assert report.verdict.verdict == VERDICT_INCONCLUSIVE
+    assert report.verdict.n_complete == 5
+
+
+async def test_infra_skip_shrinks_n(tmp_path):
+    # OLD arm of Task 1 errors → that pair is skipped; the other 4 still judge.
+    invoker = _FakeInvoker(error_old_for=frozenset({"Task 1"}))
+    report = await _run(invoker, _FakeScorer({}), tmp_path)
+    assert len(report.pairs) == 5
+    assert report.pairs[0].skipped is True
+    assert report.verdict.n_complete == 4
+
+
+async def test_report_carries_provenance(tmp_path):
+    report = await _run(_FakeInvoker(), _FakeScorer({}), tmp_path)
+    assert report.skill_name == "voice-master"
+    assert report.task_set_version == "fixture_v1"
+    assert report.rubric_name == "bench_task_success"
+    assert report.task_file_sha256  # sha256 recorded for frozen-set provenance

--- a/tests/test_eval/test_skill_replay_verdict.py
+++ b/tests/test_eval/test_skill_replay_verdict.py
@@ -1,0 +1,131 @@
+"""Tests for the skill-replay verdict — pure statistics, no CC, no clock.
+
+control = OLD, treatment = NEW. The gate promotes only on zero-regression +
+strict-improvement; regression is any per-task loss beyond epsilon (or a
+pass-rate that favours OLD).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.eval.skill_replay.types import (
+    VERDICT_INCONCLUSIVE,
+    VERDICT_NET_POSITIVE,
+    VERDICT_REGRESSION,
+    SkillReplayConfig,
+)
+from genesis.eval.skill_replay.verdict import compute_verdict
+
+_CFG = SkillReplayConfig(epsilon=0.05, min_pairs=5)
+
+
+def test_net_positive_zero_regression_with_improvements():
+    # 5 pairs: NEW clearly better on 3, ties on 2 → zero regressions, improved.
+    v = compute_verdict(
+        old_scores=[0.5, 0.5, 0.5, 0.5, 0.5],
+        new_scores=[0.9, 0.9, 0.9, 0.5, 0.5],
+        old_pass=[False, False, False, False, False],
+        new_pass=[True, True, True, False, False],
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_NET_POSITIVE
+    assert v.n_regressions == 0
+    assert v.n_improvements == 3
+    assert v.n_complete == 5
+
+
+def test_regression_on_single_task_score_loss():
+    # OLD beats NEW on task 0 (0.9 vs 0.5) → regression even amid ties.
+    v = compute_verdict(
+        old_scores=[0.9, 0.5, 0.5, 0.5, 0.5],
+        new_scores=[0.5, 0.5, 0.5, 0.5, 0.5],
+        old_pass=[True, False, False, False, False],
+        new_pass=[False, False, False, False, False],
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_REGRESSION
+    assert v.n_regressions == 1
+
+
+def test_regression_when_pass_rate_favours_old_despite_score_ties():
+    # Scores all tie (no per-task score win either way), but OLD passes 6 tasks
+    # NEW fails → significant McNemar control_wins → regression via pass-rate.
+    old_pass = [True, True, True, True, True, True, False]
+    new_pass = [False, False, False, False, False, False, False]
+    scores = [0.5] * 7
+    v = compute_verdict(
+        old_scores=scores,
+        new_scores=list(scores),
+        old_pass=old_pass,
+        new_pass=new_pass,
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_REGRESSION
+    assert v.n_regressions == 0  # no per-task SCORE regression...
+    assert v.pass_winrate["recommendation"] == "control_wins"  # ...pass-rate is why
+
+
+def test_inconclusive_all_ties():
+    v = compute_verdict(
+        old_scores=[0.5] * 5,
+        new_scores=[0.5] * 5,
+        old_pass=[True] * 5,
+        new_pass=[True] * 5,
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_INCONCLUSIVE
+    assert v.n_regressions == 0
+    assert v.n_improvements == 0
+
+
+def test_inconclusive_below_min_pairs():
+    # Clear improvement, but only 2 complete pairs (< min_pairs=5) → no power.
+    v = compute_verdict(
+        old_scores=[0.5, 0.5],
+        new_scores=[0.9, 0.9],
+        old_pass=[False, False],
+        new_pass=[True, True],
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_INCONCLUSIVE
+    assert v.n_complete == 2
+    assert "min_pairs" in v.note
+
+
+def test_regression_takes_precedence_over_improvement():
+    # NEW improves task 0 but regresses task 1 → any regression wins the verdict.
+    v = compute_verdict(
+        old_scores=[0.5, 0.9, 0.5, 0.5, 0.5],
+        new_scores=[0.9, 0.5, 0.5, 0.5, 0.5],
+        old_pass=[False, True, False, False, False],
+        new_pass=[True, False, False, False, False],
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_REGRESSION
+    assert v.n_regressions == 1
+    assert v.n_improvements == 1
+
+
+def test_epsilon_treats_small_differences_as_ties():
+    # NEW is higher but only by 0.03 (< epsilon 0.05) everywhere → all ties.
+    v = compute_verdict(
+        old_scores=[0.50] * 5,
+        new_scores=[0.53] * 5,
+        old_pass=[True] * 5,
+        new_pass=[True] * 5,
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_INCONCLUSIVE
+    assert v.n_improvements == 0
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(ValueError, match="equal length"):
+        compute_verdict(
+            old_scores=[0.5, 0.5],
+            new_scores=[0.5],
+            old_pass=[True, True],
+            new_pass=[True],
+            config=_CFG,
+        )

--- a/tests/test_eval/test_skill_replay_verdict.py
+++ b/tests/test_eval/test_skill_replay_verdict.py
@@ -51,19 +51,35 @@ def test_regression_on_single_task_score_loss():
 def test_regression_when_pass_rate_favours_old_despite_score_ties():
     # Scores all tie (no per-task score win either way), but OLD passes 6 tasks
     # NEW fails → significant McNemar control_wins → regression via pass-rate.
-    old_pass = [True, True, True, True, True, True, False]
-    new_pass = [False, False, False, False, False, False, False]
-    scores = [0.5] * 7
+    # A single pass->fail flip with NO score regression (scores tie) — this is
+    # significance-independent now, so even 1 net flip flags it (previously the
+    # McNemar-gated check masked it into inconclusive).
     v = compute_verdict(
-        old_scores=scores,
-        new_scores=list(scores),
-        old_pass=old_pass,
-        new_pass=new_pass,
+        old_scores=[0.6] * 5,
+        new_scores=[0.6] * 5,
+        old_pass=[True, True, True, True, True],
+        new_pass=[False, True, True, True, True],
         config=_CFG,
     )
     assert v.verdict == VERDICT_REGRESSION
     assert v.n_regressions == 0  # no per-task SCORE regression...
-    assert v.pass_winrate["recommendation"] == "control_wins"  # ...pass-rate is why
+    assert v.pass_winrate["n_control_wins"] > v.pass_winrate["n_treatment_wins"]  # ...pass is why
+
+
+def test_pass_to_fail_not_masked_into_net_positive():
+    # Reviewer scenario: task1 crosses the pass/fail line within epsilon
+    # (0.62->0.58, a score tie) while 4 other tasks improve but STAY passing.
+    # Must be REGRESSION, not net_positive — the pass->fail flip is real.
+    v = compute_verdict(
+        old_scores=[0.62, 0.70, 0.70, 0.70, 0.70],
+        new_scores=[0.58, 0.90, 0.90, 0.90, 0.90],
+        old_pass=[True, True, True, True, True],
+        new_pass=[False, True, True, True, True],
+        config=_CFG,
+    )
+    assert v.verdict == VERDICT_REGRESSION
+    assert v.n_regressions == 0  # score deltas are ties (task1) or improvements
+    assert v.n_improvements == 4
 
 
 def test_inconclusive_all_ties():

--- a/tests/test_learning/test_skill_replay_gate_config.py
+++ b/tests/test_learning/test_skill_replay_gate_config.py
@@ -1,0 +1,102 @@
+"""Tests for the held-out replay gate lever (skill_gate_config.replay) + its
+settings validator. load_config is monkeypatched for hermeticity."""
+
+from __future__ import annotations
+
+from genesis.learning.skills import skill_gate_config as sgc
+from genesis.mcp.health.settings import _validate_skill_evolution_gate
+
+
+def _cfg(monkeypatch, cfg):
+    monkeypatch.setattr(sgc, "load_config", lambda: cfg)
+
+
+def test_default_replay_mode_is_shadow():
+    # The shipped DEFAULTS must be safe/observable on a fresh clone.
+    assert sgc.DEFAULTS["replay"]["mode"] == "shadow"
+
+
+def test_replay_mode_shadow(monkeypatch):
+    _cfg(monkeypatch, {"enabled": True, "replay": {"mode": "shadow"}})
+    assert sgc.skill_replay_mode() == "shadow"
+
+
+def test_master_disabled_forces_off(monkeypatch):
+    _cfg(monkeypatch, {"enabled": False, "replay": {"mode": "shadow"}})
+    assert sgc.skill_replay_mode() == "off"
+
+
+def test_replay_mode_off(monkeypatch):
+    _cfg(monkeypatch, {"enabled": True, "replay": {"mode": "off"}})
+    assert sgc.skill_replay_mode() == "off"
+
+
+def test_yaml_boolean_off_honored(monkeypatch):
+    # Unquoted `mode: off` parses as YAML-1.1 boolean False.
+    _cfg(monkeypatch, {"enabled": True, "replay": {"mode": False}})
+    assert sgc.skill_replay_mode() == "off"
+
+
+def test_invalid_replay_mode_degrades_to_shadow(monkeypatch):
+    _cfg(monkeypatch, {"enabled": True, "replay": {"mode": "enforce"}})
+    assert sgc.skill_replay_mode() == "shadow"
+
+
+def test_missing_replay_block_degrades_to_shadow(monkeypatch):
+    _cfg(monkeypatch, {"enabled": True})
+    assert sgc.skill_replay_mode() == "shadow"
+
+
+def test_replay_config_reads_knobs(monkeypatch):
+    _cfg(
+        monkeypatch, {"enabled": True, "replay": {"mode": "shadow", "epsilon": 0.1, "min_pairs": 8}}
+    )
+    cfg = sgc.skill_replay_config()
+    assert cfg == {"mode": "shadow", "epsilon": 0.1, "min_pairs": 8}
+
+
+def test_replay_config_clamps_and_defaults(monkeypatch):
+    # min_pairs 0 clamps to 1; a non-numeric epsilon falls back to the default.
+    _cfg(monkeypatch, {"enabled": True, "replay": {"epsilon": "nope", "min_pairs": 0}})
+    cfg = sgc.skill_replay_config()
+    assert cfg["min_pairs"] == 1
+    assert cfg["epsilon"] == 0.05
+
+
+# ── settings validator ──────────────────────────────────────────────────
+
+
+def test_validator_accepts_valid_replay():
+    errs = _validate_skill_evolution_gate(
+        {"replay": {"mode": "shadow", "epsilon": 0.05, "min_pairs": 5}}
+    )
+    assert errs == []
+
+
+def test_validator_rejects_bad_replay_mode():
+    errs = _validate_skill_evolution_gate({"replay": {"mode": "enforce"}})
+    assert any("replay.mode" in e for e in errs)
+
+
+def test_validator_rejects_epsilon_out_of_range():
+    errs = _validate_skill_evolution_gate({"replay": {"epsilon": 1.5}})
+    assert any("replay.epsilon" in e for e in errs)
+
+
+def test_validator_rejects_min_pairs_zero():
+    errs = _validate_skill_evolution_gate({"replay": {"min_pairs": 0}})
+    assert any("replay.min_pairs" in e for e in errs)
+
+
+def test_validator_rejects_unknown_replay_key():
+    errs = _validate_skill_evolution_gate({"replay": {"bogus": 1}})
+    assert any("replay.bogus" in e for e in errs)
+
+
+def test_validator_rejects_non_mapping_replay():
+    errs = _validate_skill_evolution_gate({"replay": "shadow"})
+    assert any("must be a mapping" in e for e in errs)
+
+
+def test_validator_still_accepts_critic_mode():
+    assert _validate_skill_evolution_gate({"enabled": True, "mode": "shadow"}) == []

--- a/tests/test_mcp/test_skill_replay_run.py
+++ b/tests/test_mcp/test_skill_replay_run.py
@@ -1,0 +1,106 @@
+"""Tests for the skill_replay_run MCP tool (_impl) — gate/validation branches +
+happy path with the heavy runner patched. Asserts recommend-only, never mutates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genesis.eval.skill_replay.types import SkillReplayReport, SkillReplayVerdict
+from genesis.mcp.health.skill_replay_run import _impl_skill_replay_run
+
+_FIXTURE = (
+    Path(__file__).parent.parent
+    / "test_eval"
+    / "skill_golden_fixtures"
+    / "voice_master_fixture.jsonl"
+)
+
+
+@pytest.fixture(autouse=True)
+def _gate_on(monkeypatch):
+    # Default: env kill off, replay mode shadow (the gate permits a run).
+    monkeypatch.setattr("genesis.env.skill_gate_off", lambda: False)
+    monkeypatch.setattr(
+        "genesis.learning.skills.skill_gate_config.skill_replay_mode", lambda: "shadow"
+    )
+
+
+async def test_gate_off_returns_skipped(monkeypatch):
+    monkeypatch.setattr(
+        "genesis.learning.skills.skill_gate_config.skill_replay_mode", lambda: "off"
+    )
+    res = await _impl_skill_replay_run(skill_name="voice-master")
+    assert res["status"] == "skipped"
+    assert res["autonomous_action"] is False
+
+
+async def test_env_kill_returns_skipped(monkeypatch):
+    monkeypatch.setattr("genesis.env.skill_gate_off", lambda: True)
+    res = await _impl_skill_replay_run(skill_name="voice-master")
+    assert res["status"] == "skipped"
+
+
+async def test_invalid_model_errors():
+    res = await _impl_skill_replay_run(skill_name="voice-master", model="bogus")
+    assert res["status"] == "error"
+    assert "invalid model" in res["message"]
+    assert res["autonomous_action"] is False
+
+
+async def test_unknown_skill_errors():
+    res = await _impl_skill_replay_run(skill_name="no-such-skill-xyz", old_content="x")
+    assert res["status"] == "error"
+    assert "skill not found" in res["message"]
+
+
+async def test_missing_old_content_errors(monkeypatch):
+    # No explicit old_content and no runtime db → no ledger pre-image → error.
+    res = await _impl_skill_replay_run(skill_name="voice-master", new_content="NEW")
+    assert res["status"] == "error"
+    assert "OLD content" in res["message"]
+
+
+async def test_missing_suite_errors():
+    res = await _impl_skill_replay_run(
+        skill_name="voice-master",
+        old_content="OLD",
+        new_content="NEW",
+        suite_path="/nonexistent/suite.jsonl",
+    )
+    assert res["status"] == "error"
+    assert "golden suite not found" in res["message"]
+
+
+async def test_happy_path_returns_recommend_only_verdict(monkeypatch):
+    fake_report = SkillReplayReport(
+        run_id="r1",
+        skill_name="voice-master",
+        model="sonnet",
+        effort="medium",
+        task_set_version="fixture_v1",
+        task_file_sha256="sha",
+        rubric_name="bench_task_success",
+        rubric_version="1.0",
+        verdict=SkillReplayVerdict(
+            verdict="net_positive", n_complete=5, n_regressions=0, n_improvements=2, note="ok"
+        ),
+    )
+
+    async def fake_run(**kwargs):
+        return fake_report
+
+    monkeypatch.setattr("genesis.eval.skill_replay.runner.run_skill_replay", fake_run)
+
+    res = await _impl_skill_replay_run(
+        skill_name="voice-master",
+        old_content="OLD",
+        new_content="NEW",
+        suite_path=str(_FIXTURE),
+    )
+    assert res["status"] == "ok"
+    assert res["verdict"] == "net_positive"
+    assert res["n_improvements"] == 2
+    assert res["autonomous_action"] is False
+    assert res["recommend_only"] is True

--- a/tests/test_mcp/test_skill_replay_run.py
+++ b/tests/test_mcp/test_skill_replay_run.py
@@ -62,6 +62,18 @@ async def test_missing_old_content_errors(monkeypatch):
     assert "OLD content" in res["message"]
 
 
+async def test_load_skill_raising_returns_error_not_crash(monkeypatch):
+    # SHOULD-FIX 2: an unreadable SKILL.md (bad encoding / TOCTOU) must become a
+    # structured error, not an exception out of the tool.
+    def boom(_name):
+        raise UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
+
+    monkeypatch.setattr("genesis.learning.skills.wiring.load_skill", boom)
+    res = await _impl_skill_replay_run(skill_name="voice-master")
+    assert res["status"] == "error"
+    assert "could not read current SKILL.md" in res["message"]
+
+
 async def test_missing_suite_errors():
     res = await _impl_skill_replay_run(
         skill_name="voice-master",


### PR DESCRIPTION
## What

The **execution complement** to the shadow skill-edit Critic (#1166). Where the Critic reads the *diff* of a self-proposed `SKILL.md` edit, this **replays** a frozen per-skill golden task suite against the OLD vs NEW content (control=OLD, treatment=NEW) in bare-Claude isolation and logs a recommend-only verdict — `net_positive` / `regression` / `inconclusive` — promoting nothing and blocking nothing. This is the "the Bench" mechanism from the WS1 spec, scoped to a **skills-first vertical slice**.

## How it composes (mostly reuse)

- **`eval/skill_replay/`** — verdict logic over the existing `eval/stats` win-rate machinery (zero-regression + strict-improvement; McNemar significance advisory at shadow-scale); a file-free arm builder that pins OLD/NEW content into the system prompt (no file mutation); a paired runner reusing the bench's `run_arm`/`judge_arm` (promoted from private — harness-agnostic, zero external callers) + bare-Claude isolation; persistence (paired `eval_runs` via `EvalTrigger.EXPERIMENT`, no migration) + a `skill_replay_verdict` observation (30d TTL).
- **`skill_replay_run` MCP tool** — out-of-band invocation (the replay is heavy: spawns CC sessions), resolves NEW from disk + OLD from the cognitive-ledger pre-image, gated by a new `replay` sub-config on the existing `skill_evolution_gate` domain (`off|shadow`) + the `GENESIS_SKILL_EVOLUTION_GATE_OFF` kill. `autonomous_action` is always False.
- **`eval/skill_golden_set.py`** — authors per-skill suites under `~/.genesis/eval/skill_golden/` (outside the repo, like the bench task set).

The skill-evolution **auto-apply hot path is byte-identical** — the replay never runs inline.

## Verification

74 targeted tests; ruff clean; subsystem-map guard clean; privacy scan clean.

**Live E2E (real `claude -p` arms):**
- OLD (full voice-master) vs NEW (anti-slop rules **stripped**) → verdict **`regression`** (de-slop task OLD=0.40 vs NEW=0.00). This simultaneously proves the pinning discriminates **and that the on-disk skill does not leak in** — a leaked on-disk copy (which has the anti-slop rules) would have made NEW follow them and hide the regression.
- OLD vs OLD → **zero false regressions** (the safety-critical direction). Note: at small-N + low effort the `net_positive`/`inconclusive` boundary is noisy (coarse judge scoring) — which is exactly why this ships **shadow / recommend-only + human-adjudicated**; epsilon/effort/suite-size are the calibration knobs for the bake.

## Scope / not-yet

Delivers the held-out replay **mechanism** for `SKILL.md`-body edits, one skill, log-only. Does **not** deliver the ENFORCE flip (blocking a bad edit), procedures, or multi-skill — so WS1 (row `2139de1a`) stays open; this is the load-bearing core that makes those incremental. Context, not a completion marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)