### PR TITLE
feat(ledger): WS-2 P4a — arbitration discount (shadow) + earn-back evidence surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Ego proposals now carry their track record.** When Genesis's ego proposes
+  an action, the proposal digest can show how proposals of that type have
+  actually fared: a domain with a healthy graded history whose stated
+  confidence runs >15 points hot gets a badge ("⚖ stated 0.90 → track record
+  0.62 (n=41)"), and a domain with too little graded history gets an explicit
+  "escalate — track record not yet trustworthy" note instead of a number.
+  Annotation-only by default (`ws2_ledger.arbitration: shadow`); an optional
+  `enforce` mode lets the track record drive the digest ordering. A proposal
+  is never hidden — annotations inform, the user decides.
+- **The `calibration_status` view now includes earn-back evidence.** For any
+  autonomy category running below its earned level, the tool surfaces the
+  recent graded evidence (windowed successes/corrections + Bayesian posterior)
+  so "has it re-earned that level?" is answerable from mechanically graded
+  data instead of judgment.
 - **Genesis now screens its own skill self-edits for degradation.** When the
   skill-evolution loop rewrites one of Genesis's own skill files, a new Critic
   reads the change and flags the classic self-modification failure modes —

--- a/config/ws2_ledger.yaml
+++ b/config/ws2_ledger.yaml
@@ -15,3 +15,14 @@ enabled: true
 #   off: no autonomy side-effect (the grader still grades predictions).
 # Autonomy is a Trap subsystem — this stays shadow until the operator flips it.
 autonomy_feed: shadow
+
+# ego-proposal arbitration discount (WS-2 P4, design §5.1). off | shadow | enforce.
+#   shadow (default): proposals whose domain has a healthy (ok) stated
+#     calibration cell with an overconfidence gap >0.15 get a digest badge
+#     ("⚖ stated 0.85 → track record 0.62 (n=41)"); thin/unknown cells get an
+#     escalation note. Sort order NEVER moves in shadow.
+#   enforce: the calibrated confidence (track record) additionally drives the
+#     digest sort order. Annotation-only otherwise — a proposal is never
+#     suppressed from the digest (sovereignty invariant).
+#   off: no calibration lookup at all.
+arbitration: shadow

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -779,7 +779,20 @@ verified: fbcf8ee4 2026-07-21
   (`/api/genesis/calibration` — cells + mechanical/fallback shares), and
   perception's advisory text repointed from legacy `calibration_curves` to
   ok stated cells (90d-preferred, ego.* excluded, byte-stable sentence
-  contract). The fuzzy LLM-fallback lane is
+  contract). **Consumers LIVE (P4a)**: the ego-proposal **arbitration
+  discount** (`ego/proposals.py::annotate_calibration`, gated by
+  `ws2_ledger.arbitration` off/shadow/enforce, default shadow) reads each
+  proposal's stated-lane 90d cell (`ego.<action_type>` /
+  `approved_and_executes`) — thin/unknown → escalation note only (never a
+  discount on ignorance), ok with overconfidence gap >0.15 →
+  `_calibrated_confidence` + a digest badge; the calibrated value drives
+  digest sort ONLY in enforce; a proposal is never suppressed (sovereignty
+  invariant). Lookup failures count into the standing
+  `ledger:arbitration_failed` WARNING. `calibration_status` also carries the
+  **E1 earn-back evidence stream** (`earnback` key: windowed
+  `autonomy_events` counts + posterior per demoted category — surfaced
+  MCP-side instead of the design's `v_earnback_evidence` view, declared
+  deviation). The fuzzy LLM-fallback lane is
   deferred (no `acceptance_pass` writer yet). Outreach
   metrics resolve off `outreach_history.engagement_signal`
   (spike-measured 99.5% mechanical); the engagement_outcome CHECK now

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -69,13 +69,25 @@ _EGO_LABELS = {
 }
 
 
-def _sort_proposals(proposals: list[dict]) -> list[dict]:
-    """Sort proposals by urgency (critical first) then confidence (desc)."""
+def _sort_proposals(proposals: list[dict], *, enforce_calibration: bool = False) -> list[dict]:
+    """Sort proposals by urgency (critical first) then confidence (desc).
+
+    With ``enforce_calibration`` the arbitration discount's
+    ``_calibrated_confidence`` (domain track record) outranks the stated
+    confidence — WS-2 P4 ``arbitration: enforce`` only. In shadow the stated
+    value always drives the sort (annotate-only).
+    """
+
+    def _conf(p: dict) -> float:
+        if enforce_calibration and p.get("_calibrated_confidence") is not None:
+            return float(p["_calibrated_confidence"])
+        return float(p.get("confidence", 0))
+
     return sorted(
         proposals,
         key=lambda p: (
             _URGENCY_ORDER.get(p.get("urgency", "normal"), 2),
-            -float(p.get("confidence", 0)),
+            -_conf(p),
         ),
     )
 
@@ -94,8 +106,17 @@ def _format_digest(
 
     Proposals are sorted by urgency x confidence before numbering.
     Fields map to: content → WHAT, rationale → WHY, execution_plan → HOW.
+
+    The calibrated track-record confidence drives the sort only under
+    ``arbitration: enforce`` (see :func:`annotate_calibration`).
     """
-    sorted_proposals = _sort_proposals(proposals)
+    try:
+        from genesis.ledger.ws2_ledger_config import arbitration_mode
+
+        enforce = arbitration_mode() == "enforce"
+    except Exception:  # noqa: BLE001 — formatting must never fail on config
+        enforce = False
+    sorted_proposals = _sort_proposals(proposals, enforce_calibration=enforce)
     label = _EGO_LABELS.get(ego_source or "", "Ego")
     lines = [f"<b>{_ESC(label)}</b> \u2014 {_ESC(batch_id[:8])}\n"]
 
@@ -105,9 +126,7 @@ def _format_digest(
         action_type = p.get("action_type", "?")
 
         # Header: number + urgency + action type
-        lines.append(
-            f"<b>{i}.</b> {_ESC(urgency_tag)}{_ESC(action_type)}"
-        )
+        lines.append(f"<b>{i}.</b> {_ESC(urgency_tag)}{_ESC(action_type)}")
 
         # WHAT (content)
         content = _truncate(p.get("content", ""), 400)
@@ -128,13 +147,101 @@ def _format_digest(
         # Confidence badge
         confidence = p.get("confidence", 0.0)
         lines.append(f"\n[{confidence:.2f} confidence]")
+
+        # WS-2 P4 arbitration annotations (annotate-only; never suppresses).
+        badge = p.get("_calibration_badge")
+        if badge:
+            lines.append(_ESC(badge))
+        note = p.get("_calibration_note")
+        if note:
+            lines.append(f"<i>{_ESC(note)}</i>")
         lines.append("")
 
     # Separator + compact reply instructions
-    lines.append(
-        "<i>ok \u2022 no \u2022 \"approve 1, reject 2\" \u2022 or talk</i>"
-    )
+    lines.append('<i>ok \u2022 no \u2022 "approve 1, reject 2" \u2022 or talk</i>')
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# WS-2 P4 arbitration discount (design \u00a75.1)
+# ---------------------------------------------------------------------------
+
+# Confidence-vs-track-record gap on ok stated cells that triggers the
+# discount (same floor as the calibration_status MCP ranking).
+_CALIBRATION_GAP_FLOOR = 0.15
+
+# Process-global count of calibration-lookup failures \u2014 surfaced as the
+# `ledger:arbitration_failed` WARNING by mcp/health/errors.py while nonzero
+# (writers.py counter idiom). A lookup failure never blocks proposal creation.
+_arbitration_failures: dict[str, int] = {}
+
+
+def arbitration_failure_counts() -> dict[str, int]:
+    """Snapshot of arbitration-lookup failure counts (read by health alerts)."""
+    return dict(_arbitration_failures)
+
+
+def _reset_arbitration_failures_for_tests() -> None:
+    _arbitration_failures.clear()
+
+
+async def annotate_calibration(db: aiosqlite.Connection, proposal: dict) -> None:
+    """Annotate ONE proposal dict (in place) with its domain's calibration.
+
+    Reads the stated-lane 90d ``calibration_cells`` row for
+    ``(ego.<action_type>, ego_proposal, approved_and_executes)`` \u2014 the exact
+    cell the ledger grades this proposal class into (writers.py stamps
+    ``domain=f"ego.{action_type}"``):
+
+    - no cell \u2192 nothing (no-data ego domains are the norm until rows grade);
+    - ``thin``/``unknown`` \u2192 ``_calibration_note`` escalation phrasing ONLY \u2014
+      never a discount on ignorance, never a bare percentage (design \u00a73.4);
+    - ``ok`` with overconfidence gap > 0.15 (cell mean stated \u2212 track record)
+      \u2192 ``_calibrated_confidence`` = shrunk track record + a digest badge
+      showing THIS proposal's stated confidence vs the domain track record.
+
+    Annotate-only: sort consumes ``_calibrated_confidence`` exclusively under
+    ``arbitration: enforce`` (see ``_sort_proposals``); delivery is never
+    gated. Raises never escape \u2014 failures count into
+    ``_arbitration_failures`` and the proposal ships un-annotated.
+    """
+    action_type = proposal.get("action_type", "unknown")
+    try:
+        from genesis.db.crud import calibration_cells as cc_crud
+
+        domain = f"ego.{action_type}"
+        cells = await cc_crud.list_cells(db, domain=domain, provenance="stated", window_days=90)
+        cell = next(
+            (
+                c
+                for c in cells
+                if c["domain"] == domain
+                and c["action_class"] == "ego_proposal"
+                and c["metric"] == "approved_and_executes"
+            ),
+            None,
+        )
+        if cell is None:
+            return
+        if cell["status"] in ("thin", "unknown"):
+            proposal["_calibration_note"] = (
+                f"calibration: {cell['status']} (n={cell['n']}) \u2014 escalate; "
+                "track record not yet trustworthy"
+            )
+            return
+        mean_conf = cell["mean_confidence"]
+        shrunk = cell["shrunk_estimate"]
+        if mean_conf is None or shrunk is None:
+            return
+        if (mean_conf - shrunk) > _CALIBRATION_GAP_FLOOR:
+            proposal["_calibrated_confidence"] = float(shrunk)
+            stated = float(proposal.get("confidence", 0.0))
+            proposal["_calibration_badge"] = (
+                f"\u2696 stated {stated:.2f} \u2192 track record {float(shrunk):.2f} (n={cell['n']})"
+            )
+    except Exception:  # noqa: BLE001 \u2014 annotation is best-effort, never blocking
+        _arbitration_failures[action_type] = _arbitration_failures.get(action_type, 0) + 1
+        logger.debug("arbitration calibration lookup failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -196,6 +303,16 @@ class ProposalWorkflow:
         batch_id = uuid.uuid4().hex[:16]
         created_at = datetime.now(UTC).isoformat()
 
+        # WS-2 P4 arbitration mode — read live once per batch. `off` skips the
+        # calibration lookup entirely; shadow/enforce both annotate (the sort
+        # distinction lives in _sort_proposals). Fail-safe toward shadow.
+        try:
+            from genesis.ledger.ws2_ledger_config import arbitration_mode
+
+            annotate = arbitration_mode() != "off"
+        except Exception:  # noqa: BLE001 — config must never break the batch
+            annotate = True
+
         # Pre-fetch valid goal IDs for validation (cheap SELECT, prevents
         # hallucinated goal_ids from persisting).
         valid_goal_ids: set[str] | None = None
@@ -241,7 +358,8 @@ class ProposalWorkflow:
                 if not goal_id:
                     logger.warning(
                         "Proposal %s: dropping invalid goal_id %r",
-                        pid, raw_goal_id,
+                        pid,
+                        raw_goal_id,
                     )
             else:
                 goal_id = raw_goal_id
@@ -255,7 +373,8 @@ class ProposalWorkflow:
             if hash_val:
                 try:
                     if await ego_crud.has_pending_proposal_with_hash(
-                        self._db, hash_val,
+                        self._db,
+                        hash_val,
                     ):
                         logger.info(
                             "Proposal dedup: skipping exact duplicate (hash=%s)",
@@ -310,6 +429,10 @@ class ProposalWorkflow:
                 )
             except Exception:  # noqa: BLE001 — ledger is best-effort
                 logger.debug("ledger prediction hook failed", exc_info=True)
+
+            # WS-2 P4: calibration annotation (never raises, never blocks).
+            if annotate:
+                await annotate_calibration(self._db, p)
 
         logger.info(
             "Created ego proposal batch %s with %d proposals",
@@ -399,7 +522,8 @@ class ProposalWorkflow:
                     if last_dt > cutoff:
                         logger.info(
                             "Digest rate-limited for %s (last: %s, next eligible: %s)",
-                            ego_source, last_ts,
+                            ego_source,
+                            last_ts,
                             (last_dt + timedelta(hours=self._DIGEST_RATE_LIMIT_HOURS)).isoformat(),
                         )
                         return None
@@ -421,12 +545,10 @@ class ProposalWorkflow:
         # Show pending backlog from other batches (same ego only)
         try:
             all_pending = await ego_crud.list_pending_proposals(
-                self._db, ego_source=ego_source,
+                self._db,
+                ego_source=ego_source,
             )
-            other_pending = [
-                p for p in all_pending
-                if p.get("batch_id") != batch_id
-            ]
+            other_pending = [p for p in all_pending if p.get("batch_id") != batch_id]
             if other_pending:
                 summary_lines = []
                 for op in other_pending[:5]:
@@ -439,8 +561,7 @@ class ProposalWorkflow:
                 digest_html = (
                     f"<i>\U0001f4cb {len(other_pending)} older proposal(s) still "
                     f"awaiting response:</i>\n{backlog_text}\n"
-                    f"<i>Reply 'approve all pending' to resolve all.</i>\n\n"
-                    + digest_html
+                    f"<i>Reply 'approve all pending' to resolve all.</i>\n\n" + digest_html
                 )
         except Exception:
             pass  # Non-critical; skip header on error
@@ -472,6 +593,7 @@ class ProposalWorkflow:
         try:
             if ego_source:
                 from datetime import UTC, datetime
+
                 await ego_crud.set_state(
                     self._db,
                     key=f"last_digest_delivery:{ego_source}",
@@ -530,7 +652,9 @@ class ProposalWorkflow:
                 from genesis.ego.resolution import handle_proposal_resolution
 
                 await handle_proposal_resolution(
-                    self._db, prop, status,
+                    self._db,
+                    prop,
+                    status,
                     reason=reason,
                     source="telegram",
                     memory_store=self._memory_store,
@@ -659,12 +783,20 @@ _CANCEL_WORDS = {"cancel", "cancelled", "revoke", "revoked", "stop", "undo"}
 # shared normalize() strips trailing punctuation before matching, but this
 # parser's caller only lowercases/strips), so the historical dotted
 # variants are added back locally for byte-compatible matching.
-_BARE_APPROVE = _SHARED_BARE_APPROVE | frozenset({
-    "ok.", "okay.", "yes.", "yep.", "sure.",
-})
-_BARE_REJECT = _SHARED_BARE_REJECT | frozenset({
-    "no.",
-})
+_BARE_APPROVE = _SHARED_BARE_APPROVE | frozenset(
+    {
+        "ok.",
+        "okay.",
+        "yes.",
+        "yep.",
+        "sure.",
+    }
+)
+_BARE_REJECT = _SHARED_BARE_REJECT | frozenset(
+    {
+        "no.",
+    }
+)
 
 # Pattern: "1 approve" or "approve 1" or "1 yes" or "reject 2: reason"
 _NUMBERED_PATTERN = re.compile(

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -240,7 +240,12 @@ async def annotate_calibration(db: aiosqlite.Connection, proposal: dict) -> None
                 f"\u2696 stated {stated:.2f} \u2192 track record {float(shrunk):.2f} (n={cell['n']})"
             )
     except Exception:  # noqa: BLE001 \u2014 annotation is best-effort, never blocking
-        _arbitration_failures[action_type] = _arbitration_failures.get(action_type, 0) + 1
+        # Sanitize before keying: action_type is free-form ego-LLM text and
+        # this key flows into the durable alert-id namespace
+        # (ledger:arbitration_failed:<key>) \u2014 unlike the schema-CHECKed
+        # action_class of the sibling alarms.
+        key = re.sub(r"[^a-z0-9_.-]", "_", str(action_type).lower())[:48] or "unknown"
+        _arbitration_failures[key] = _arbitration_failures.get(key, 0) + 1
         logger.debug("arbitration calibration lookup failed", exc_info=True)
 
 
@@ -302,16 +307,6 @@ class ProposalWorkflow:
         """
         batch_id = uuid.uuid4().hex[:16]
         created_at = datetime.now(UTC).isoformat()
-
-        # WS-2 P4 arbitration mode — read live once per batch. `off` skips the
-        # calibration lookup entirely; shadow/enforce both annotate (the sort
-        # distinction lives in _sort_proposals). Fail-safe toward shadow.
-        try:
-            from genesis.ledger.ws2_ledger_config import arbitration_mode
-
-            annotate = arbitration_mode() != "off"
-        except Exception:  # noqa: BLE001 — config must never break the batch
-            annotate = True
 
         # Pre-fetch valid goal IDs for validation (cheap SELECT, prevents
         # hallucinated goal_ids from persisting).
@@ -430,10 +425,6 @@ class ProposalWorkflow:
             except Exception:  # noqa: BLE001 — ledger is best-effort
                 logger.debug("ledger prediction hook failed", exc_info=True)
 
-            # WS-2 P4: calibration annotation (never raises, never blocks).
-            if annotate:
-                await annotate_calibration(self._db, p)
-
         logger.info(
             "Created ego proposal batch %s with %d proposals",
             batch_id,
@@ -534,6 +525,20 @@ class ProposalWorkflow:
         if not proposals:
             logger.warning("No proposals found for batch %s", batch_id)
             return None
+
+        # WS-2 P4: annotate at the RENDER boundary — the reload above returns
+        # bare DB rows (the transient _calibration_* keys are never persisted),
+        # so annotating any earlier could not reach the delivered digest.
+        # Delivery-time annotation also renders the freshest twice-daily cells.
+        try:
+            from genesis.ledger.ws2_ledger_config import arbitration_mode
+
+            annotate = arbitration_mode() != "off"
+        except Exception:  # noqa: BLE001 — config must never block delivery
+            annotate = True
+        if annotate:
+            for p in proposals:
+                await annotate_calibration(self._db, p)
 
         digest_html = self.format_digest(proposals, batch_id, ego_source=ego_source)
 

--- a/src/genesis/ledger/ws2_ledger_config.py
+++ b/src/genesis/ledger/ws2_ledger_config.py
@@ -1,13 +1,20 @@
 """WS-2 cognitive-ledger control surface — live-read consumer levers.
 
 The ONE place ledger consumers consult for policy (repo_pulse_config /
-ledger_shadow_config lineage). v1 exposes a single lever:
+ledger_shadow_config lineage). Levers:
 
 - :func:`autonomy_feed_mode` — ``off | shadow | live`` for the P2b grader→
   autonomy earn-back feed, re-read from the merged YAML
   (``config/ws2_ledger.yaml`` + the user overlay
   ``~/.genesis/config/ws2_ledger.local.yaml``) on EVERY grading pass. No boot
   cache — the operator flips shadow→live without a restart.
+- :func:`arbitration_mode` — ``off | shadow | enforce`` for the P4 ego-proposal
+  arbitration discount (design §5.1). ``shadow`` annotates proposals with
+  calibration badges/escalation notes in the digest but never changes sort
+  order; ``enforce`` additionally lets the calibrated confidence drive the
+  digest sort. The discount only ever annotates — it NEVER suppresses a
+  proposal from the digest (owner-facing delivery is not gated; sovereignty
+  invariant, design §5).
 
 Shadow is the DEFAULT and an INVALID value degrades to shadow — toward LESS
 write authority (the same fail-safe as ledger_shadow_config). The grader feeds
@@ -16,9 +23,9 @@ logs what it WOULD fire so the operator can watch the real pattern before it
 moves any autonomy math. ``off`` disables the feed entirely (the grader still
 grades predictions — only the autonomy side-effect is gated).
 
-P4 grows the SAME domain with the other consumer levers (arbitration discount,
-B5 knob effector) as sibling keys — forward-compatible, so this file and the
-settings domain stay the single source of truth.
+Remaining P4 lever (B5 knob effector) lands as a sibling key when the trigger
+scan ships — forward-compatible, so this file and the settings domain stay the
+single source of truth.
 
 Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
 ``genesis.mcp.health.settings`` imports MODES from here, never the reverse
@@ -41,12 +48,14 @@ from genesis.env import repo_root
 logger = logging.getLogger(__name__)
 
 MODES = ("off", "shadow", "live")
+ARBITRATION_MODES = ("off", "shadow", "enforce")
 
 _CONFIG_NAME = "ws2_ledger.yaml"
 
 DEFAULTS: dict[str, Any] = {
     "enabled": True,
     "autonomy_feed": "shadow",  # grader→autonomy earn-back feed; shadow-first
+    "arbitration": "shadow",  # ego-proposal calibration discount; shadow-first
 }
 
 
@@ -94,5 +103,25 @@ def autonomy_feed_mode() -> str:
         return "off"
     if mode not in MODES:
         logger.warning("ws2_ledger has invalid autonomy_feed %r — degrading to shadow", mode)
+        return "shadow"
+    return mode
+
+
+def arbitration_mode() -> str:
+    """The ego-proposal arbitration-discount mode — read live.
+
+    Master ``enabled: false`` → ``off``. An invalid value degrades to
+    ``shadow`` (annotate-only — badges/escalation notes render but sort order
+    never moves; the same less-authority fail-safe as ``autonomy_feed_mode``).
+    """
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("arbitration")
+    if mode is False:
+        # Unquoted `arbitration: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in ARBITRATION_MODES:
+        logger.warning("ws2_ledger has invalid arbitration %r — degrading to shadow", mode)
         return "shadow"
     return mode

--- a/src/genesis/mcp/health/calibration_status.py
+++ b/src/genesis/mcp/health/calibration_status.py
@@ -118,6 +118,7 @@ async def _impl_calibration_status(domain: str = "", include_history: bool = Fal
         "cells_readable": [_readable(c) for c in cells],
         "overconfident_domains": overconfident,
         "underconfident_domains": underconfident,
+        "earnback": await _earnback_evidence(db),
         "note": (
             "Read-only. thin/unknown cells carry escalation phrasing by design "
             "— never treat them as a usable percentage. Rankings use the "
@@ -133,6 +134,55 @@ async def _impl_calibration_status(domain: str = "", include_history: bool = Fal
     return result
 
 
+# Default evidence window — mirrors AutonomyManager._earnback_window_days
+# (autonomy config `earnback.window_days`, default 45). This surface is
+# read-only observability; the AUTHORITATIVE earn-back proposal path is the
+# ego cadence, which reads the live config.
+_EARNBACK_WINDOW_DAYS = 45
+
+
+async def _earnback_evidence(db) -> dict:
+    """E1 earn-back evidence stream (WS-2 P4, design §5.2 — surfaced here
+    instead of a ``v_earnback_evidence`` SQL view; declared deviation).
+
+    For every DEMOTED autonomy category (current_level < earned_level):
+    windowed success/correction counts from the append-only ``autonomy_events``
+    ledger, the windowed Bayesian posterior, and ``evidence_supports_earned``
+    (whether recent evidence alone re-reaches the earned level — the same
+    predicate ``detect_earnback_candidates`` gates on). Empty list = nothing
+    demoted. Never raises — degrades to an ``unavailable`` marker.
+    """
+    try:
+        from genesis.db.crud import autonomy as autonomy_crud
+
+        demoted = []
+        for row in await autonomy_crud.list_all(db):
+            if row["current_level"] >= row["earned_level"]:
+                continue
+            successes, corrections = await autonomy_crud.windowed_counts(
+                db, row["category"], window_days=_EARNBACK_WINDOW_DAYS
+            )
+            demoted.append(
+                {
+                    "category": row["category"],
+                    "current_level": row["current_level"],
+                    "earned_level": row["earned_level"],
+                    "window_days": _EARNBACK_WINDOW_DAYS,
+                    "window_successes": successes,
+                    "window_corrections": corrections,
+                    "posterior": round(autonomy_crud.bayesian_posterior(successes, corrections), 4),
+                    "evidence_supports_earned": (
+                        autonomy_crud.bayesian_level(successes, corrections) >= row["earned_level"]
+                    ),
+                    "last_regression_at": row["last_regression_at"],
+                }
+            )
+        return {"demoted_categories": demoted}
+    except Exception:  # noqa: BLE001 — observability add-on, never breaks the tool
+        logger.debug("earnback evidence read failed", exc_info=True)
+        return {"demoted_categories": [], "unavailable": True}
+
+
 @mcp.tool()
 async def calibration_status(domain: str = "", include_history: bool = False) -> dict:
     """Genesis's mechanically-graded calibration record, per cell.
@@ -143,7 +193,9 @@ async def calibration_status(domain: str = "", include_history: bool = False) ->
     by dotted prefix (e.g. ``outreach``); ``include_history`` adds trend
     snapshots (requires a domain). Cells labelled thin/unknown render
     escalation phrasing instead of percentages — that is the cold-start
-    honesty contract, not missing data. Distinct from ``ego_calibration_status``
+    honesty contract, not missing data. The ``earnback`` key surfaces the
+    E1 evidence stream: windowed graded evidence for every demoted autonomy
+    category. Distinct from ``ego_calibration_status``
     (the ego's snapshot ECE surface).
     """
     return await _impl_calibration_status(domain, include_history)

--- a/src/genesis/mcp/health/calibration_status.py
+++ b/src/genesis/mcp/health/calibration_status.py
@@ -168,6 +168,11 @@ async def _earnback_evidence(db) -> dict:
                     "current_level": row["current_level"],
                     "earned_level": row["earned_level"],
                     "window_days": _EARNBACK_WINDOW_DAYS,
+                    # This surface uses the DEFAULT window; the authoritative
+                    # gate (ego cadence → detect_earnback_candidates) reads
+                    # the live autonomy config and may differ if the operator
+                    # changed earnback.window_days.
+                    "window_source": "default",
                     "window_successes": successes,
                     "window_corrections": corrections,
                     "posterior": round(autonomy_crud.bayesian_posterior(successes, corrections), 4),

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -292,6 +292,30 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     except Exception:
         logger.debug("cell recompute alert check failed", exc_info=True)
 
+    # WS-2 P4: ego-proposal arbitration lookup failures — proposals still ship
+    # (annotation is best-effort) but calibration badges/escalation notes are
+    # silently absent. Same per-process counter contract.
+    try:
+        from genesis.ego.proposals import arbitration_failure_counts
+
+        for action_type, count in sorted(arbitration_failure_counts().items()):
+            if count > 0:
+                alert_id = f"ledger:arbitration_failed:{action_type}"
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"{count} arbitration calibration lookup(s) failed for "
+                            f"ego action_type {action_type} — proposals shipped "
+                            "without calibration annotations"
+                        ),
+                    }
+                )
+                current_ids.add(alert_id)
+    except Exception:
+        logger.debug("arbitration alert check failed", exc_info=True)
+
     if _service is None:
         alerts.append(
             {

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -108,9 +108,11 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         description=(
             "WS-2 cognitive-ledger consumer levers — master `enabled` + "
             "`autonomy_feed` off/shadow/live (P2b grader→autonomy earn-back "
-            "feed). Shadow (default) logs what it WOULD fire without writing "
-            "the autonomy Trap; an invalid value degrades to shadow. Read live "
-            "per grading pass by genesis.ledger.ws2_ledger_config (no restart)."
+            "feed) + `arbitration` off/shadow/enforce (P4 ego-proposal "
+            "calibration discount: shadow annotates digest badges only, "
+            "enforce lets calibrated confidence drive digest sort; never "
+            "suppresses a proposal). Invalid values degrade to shadow. Read "
+            "live per use by genesis.ledger.ws2_ledger_config (no restart)."
         ),
         config_filename="ws2_ledger.yaml",
         readonly=False,
@@ -845,15 +847,20 @@ def _validate_session_ledger_shadow(changes: dict) -> list[str]:
 def _validate_ws2_ledger(changes: dict) -> list[str]:
     """Validate ws2_ledger consumer-lever changes (see
     genesis.ledger.ws2_ledger_config)."""
-    from genesis.ledger.ws2_ledger_config import MODES
+    from genesis.ledger.ws2_ledger_config import ARBITRATION_MODES, MODES
 
     errors: list[str] = []
     for key, value in changes.items():
-        if key not in ("enabled", "autonomy_feed"):
-            errors.append(f"Unknown key '{key}'. Valid: enabled, autonomy_feed")
+        if key not in ("enabled", "autonomy_feed", "arbitration"):
+            errors.append(f"Unknown key '{key}'. Valid: enabled, autonomy_feed, arbitration")
         elif key == "enabled":
             if not isinstance(value, bool):
                 errors.append("'enabled' must be a boolean")
+        elif key == "arbitration":
+            if value not in ARBITRATION_MODES:
+                errors.append(
+                    f"'arbitration' must be one of {', '.join(ARBITRATION_MODES)}; got {value!r}"
+                )
         elif value not in MODES:
             errors.append(f"'autonomy_feed' must be one of {', '.join(MODES)}; got {value!r}")
     return errors

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -247,6 +247,13 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "the source (same posture as the other ledger alarms); the next "
         "successful pass self-heals the staleness. WARNING-level observability."
     ),
+    "ledger:arbitration_failed:": (
+        "An ego-proposal arbitration calibration lookup raised (WS-2 P4) — "
+        "the proposal still shipped, just without its calibration badge/"
+        "escalation note. A code bug for the developer/ego to fix at the "
+        "source (same posture as the other ledger alarms). WARNING-level "
+        "observability."
+    ),
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ def _isolate_ledger_write_failures():
     ``ledger:write_failed`` / ``ledger:grade_failed`` alert. Clear before and
     after each test.
     """
+    from genesis.ego import proposals as _ego_proposals
     from genesis.ledger import cells as _ledger_cells
     from genesis.ledger import grader as _ledger_grader
     from genesis.ledger import writers as _ledger_writers
@@ -88,10 +89,12 @@ def _isolate_ledger_write_failures():
     _ledger_writers._write_failures.clear()
     _ledger_grader._reset_grade_failure_counts_for_tests()
     _ledger_cells._reset_cell_counters_for_tests()
+    _ego_proposals._reset_arbitration_failures_for_tests()
     yield
     _ledger_writers._write_failures.clear()
     _ledger_grader._reset_grade_failure_counts_for_tests()
     _ledger_cells._reset_cell_counters_for_tests()
+    _ego_proposals._reset_arbitration_failures_for_tests()
 
 
 @pytest.fixture

--- a/tests/ego/test_arbitration.py
+++ b/tests/ego/test_arbitration.py
@@ -8,6 +8,7 @@ suppressed (sovereignty invariant, design §5).
 
 from __future__ import annotations
 
+import re
 from unittest.mock import AsyncMock
 
 import aiosqlite
@@ -41,7 +42,9 @@ async def db():
 
 @pytest.fixture
 def workflow(db):
-    return ProposalWorkflow(db=db, topic_manager=AsyncMock(), memory_store=AsyncMock())
+    tm = AsyncMock()
+    tm.send_to_category.return_value = "msg12345"
+    return ProposalWorkflow(db=db, topic_manager=tm, memory_store=AsyncMock())
 
 
 async def _insert_cell(
@@ -166,17 +169,33 @@ class TestAnnotateCalibration:
 
 
 # ---------------------------------------------------------------------------
-# create_batch wiring
+# Delivery wiring (annotation happens at the RENDER boundary in send_digest —
+# the reload from DB returns bare rows, so any earlier annotation is invisible)
 # ---------------------------------------------------------------------------
 
 
-class TestCreateBatchWiring:
-    async def test_shadow_annotates_created_proposals(self, db, workflow, monkeypatch):
+class TestDeliveryWiring:
+    async def test_send_digest_renders_badge_from_db_state_e2e(self, db, workflow, monkeypatch):
+        """Regression for the built≠wired gap: cell in DB + create_batch +
+        send_digest must produce the badge in the DELIVERED HTML — no
+        in-memory dict handoff anywhere."""
         monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
         await _insert_cell(db, domain="ego.dispatch", mean_confidence=0.85, shrunk_estimate=0.62)
-        _, ids, created = await workflow.create_batch([_proposal("dispatch", 0.9)])
+        batch_id, ids, _ = await workflow.create_batch([_proposal("dispatch", 0.9)])
         assert len(ids) == 1
-        assert created[0]["_calibrated_confidence"] == pytest.approx(0.62)
+        delivery_id = await workflow.send_digest(batch_id)
+        assert delivery_id is not None
+        html = workflow._topic_manager.send_to_category.call_args.args[1]
+        assert "⚖ stated 0.90 → track record 0.62 (n=41)" in html
+
+    async def test_send_digest_renders_escalation_note_e2e(self, db, workflow, monkeypatch):
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
+        await _insert_cell(db, domain="ego.dispatch", status="thin", n=7)
+        batch_id, _, _ = await workflow.create_batch([_proposal("dispatch")])
+        await workflow.send_digest(batch_id)
+        html = workflow._topic_manager.send_to_category.call_args.args[1]
+        assert "escalate" in html
+        assert "thin" in html
 
     async def test_off_skips_lookup_entirely(self, db, workflow, monkeypatch):
         monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "off")
@@ -188,21 +207,45 @@ class TestCreateBatchWiring:
             return []
 
         monkeypatch.setattr("genesis.db.crud.calibration_cells.list_cells", _spy)
-        _, ids, created = await workflow.create_batch([_proposal("dispatch")])
+        batch_id, ids, _ = await workflow.create_batch([_proposal("dispatch")])
+        delivery_id = await workflow.send_digest(batch_id)
         assert len(ids) == 1
+        assert delivery_id is not None
         assert called is False
-        assert "_calibrated_confidence" not in created[0]
 
-    async def test_annotation_failure_never_blocks_batch(self, db, workflow, monkeypatch):
+    async def test_annotation_failure_never_blocks_delivery(self, db, workflow, monkeypatch):
         monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
 
         async def _boom(*a, **k):
             raise RuntimeError("synthetic lookup failure")
 
         monkeypatch.setattr("genesis.db.crud.calibration_cells.list_cells", _boom)
-        _, ids, _created = await workflow.create_batch([_proposal("dispatch")])
-        assert len(ids) == 1
+        batch_id, _, _ = await workflow.create_batch([_proposal("dispatch")])
+        delivery_id = await workflow.send_digest(batch_id)
+        assert delivery_id is not None  # proposal shipped un-annotated
         assert arbitration_failure_counts().get("dispatch") == 1
+
+    async def test_create_batch_no_longer_annotates(self, db, workflow, monkeypatch):
+        """Annotation lives ONLY at the render boundary — create_batch must
+        not do calibration lookups (they would be invisible + stale)."""
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
+        await _insert_cell(db, domain="ego.dispatch", mean_confidence=0.85, shrunk_estimate=0.62)
+        _, _, created = await workflow.create_batch([_proposal("dispatch", 0.9)])
+        assert "_calibrated_confidence" not in created[0]
+
+    async def test_counter_key_sanitized_for_llm_action_type(self, db, workflow, monkeypatch):
+        """Free-form LLM action_type is sanitized before entering the
+        counter / durable alert-id namespace."""
+
+        async def _boom(*a, **k):
+            raise RuntimeError("synthetic lookup failure")
+
+        monkeypatch.setattr("genesis.db.crud.calibration_cells.list_cells", _boom)
+        p = _proposal("Dispatch a Session <b>now</b>\nplease " + "x" * 100)
+        await annotate_calibration(db, p)
+        (key,) = arbitration_failure_counts()
+        assert re.fullmatch(r"[a-z0-9_.-]{1,48}", key)
+        assert key.startswith("dispatch_a_session")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ego/test_arbitration.py
+++ b/tests/ego/test_arbitration.py
@@ -1,0 +1,310 @@
+"""WS-2 P4 arbitration discount — annotation, sort, digest, isolation.
+
+All fixtures synthetic. The discount is annotate-only: shadow renders
+badges/escalation notes without touching sort order; enforce lets the
+calibrated track record drive the digest sort; a proposal is never
+suppressed (sovereignty invariant, design §5).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import TABLES
+from genesis.ego import proposals as proposals_mod
+from genesis.ego.proposals import (
+    ProposalWorkflow,
+    _format_digest,
+    _sort_proposals,
+    annotate_calibration,
+    arbitration_failure_counts,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db():
+    """In-memory DB with ego + calibration tables."""
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_proposals"])
+        await conn.execute(TABLES["ego_state"])
+        await conn.execute(TABLES["calibration_cells"])
+        yield conn
+
+
+@pytest.fixture
+def workflow(db):
+    return ProposalWorkflow(db=db, topic_manager=AsyncMock(), memory_store=AsyncMock())
+
+
+async def _insert_cell(
+    db,
+    *,
+    domain: str,
+    status: str = "ok",
+    n: int = 41,
+    mean_confidence: float | None = 0.85,
+    shrunk_estimate: float | None = 0.62,
+    provenance: str = "stated",
+    window_days: int = 90,
+    action_class: str = "ego_proposal",
+    metric: str = "approved_and_executes",
+) -> None:
+    await db.execute(
+        "INSERT INTO calibration_cells (domain, action_class, metric, provenance,"
+        " window_days, n, n_mechanical, base_rate, mean_confidence, brier,"
+        " reliability, resolution, uncertainty, ece, shrunk_estimate, status,"
+        " computed_at) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, NULL,"
+        " NULL, NULL, ?, ?, '2026-01-01T00:00:00+00:00')",
+        (
+            domain,
+            action_class,
+            metric,
+            provenance,
+            window_days,
+            n,
+            n,
+            mean_confidence,
+            shrunk_estimate,
+            status,
+        ),
+    )
+    await db.commit()
+
+
+def _proposal(action_type: str = "dispatch", confidence: float = 0.9, **extra) -> dict:
+    return {
+        "action_type": action_type,
+        "content": f"do the {action_type} thing",
+        "rationale": "because the synthetic fixture says so",
+        "confidence": confidence,
+        "urgency": "normal",
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# annotate_calibration
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotateCalibration:
+    async def test_no_cell_no_annotation(self, db):
+        p = _proposal()
+        await annotate_calibration(db, p)
+        assert "_calibration_note" not in p
+        assert "_calibrated_confidence" not in p
+        assert "_calibration_badge" not in p
+
+    @pytest.mark.parametrize("status", ["thin", "unknown"])
+    async def test_thin_unknown_escalation_note_only(self, db, status):
+        await _insert_cell(db, domain="ego.dispatch", status=status, n=7)
+        p = _proposal("dispatch")
+        await annotate_calibration(db, p)
+        assert "escalate" in p["_calibration_note"]
+        assert status in p["_calibration_note"]
+        assert "(n=7)" in p["_calibration_note"]
+        # Never a discount on ignorance, never a bare percentage.
+        assert "_calibrated_confidence" not in p
+        assert "_calibration_badge" not in p
+        assert "%" not in p["_calibration_note"]
+
+    async def test_ok_gap_discounts_and_badges(self, db):
+        await _insert_cell(
+            db, domain="ego.dispatch", mean_confidence=0.85, shrunk_estimate=0.62, n=41
+        )
+        p = _proposal("dispatch", confidence=0.9)
+        await annotate_calibration(db, p)
+        assert p["_calibrated_confidence"] == pytest.approx(0.62)
+        assert p["_calibration_badge"] == "⚖ stated 0.90 → track record 0.62 (n=41)"
+        assert "_calibration_note" not in p
+
+    async def test_ok_no_gap_untouched(self, db):
+        await _insert_cell(db, domain="ego.dispatch", mean_confidence=0.70, shrunk_estimate=0.65)
+        p = _proposal("dispatch")
+        await annotate_calibration(db, p)
+        assert "_calibrated_confidence" not in p
+        assert "_calibration_badge" not in p
+
+    async def test_ok_null_scoring_untouched(self, db):
+        # A base-rate-style ok cell with NULL mean_confidence must never
+        # produce a discount (the tool-lane shape).
+        await _insert_cell(db, domain="ego.dispatch", mean_confidence=None, shrunk_estimate=None)
+        p = _proposal("dispatch")
+        await annotate_calibration(db, p)
+        assert "_calibrated_confidence" not in p
+
+    async def test_wrong_domain_metric_ignored(self, db):
+        # A gap cell for a DIFFERENT action_type or metric never annotates.
+        await _insert_cell(db, domain="ego.other")
+        await _insert_cell(db, domain="ego.dispatch", metric="something_else")
+        p = _proposal("dispatch")
+        await annotate_calibration(db, p)
+        assert "_calibrated_confidence" not in p
+
+    async def test_policy_prior_lane_never_consulted(self, db):
+        # A prior can never launder into the stated discount (design §4.2).
+        await _insert_cell(db, domain="ego.dispatch", provenance="policy_prior")
+        p = _proposal("dispatch")
+        await annotate_calibration(db, p)
+        assert "_calibrated_confidence" not in p
+
+    async def test_lookup_failure_isolated_and_counted(self, db):
+        await db.execute("DROP TABLE calibration_cells")
+        await db.commit()
+        p = _proposal("dispatch")
+        await annotate_calibration(db, p)  # must not raise
+        assert "_calibrated_confidence" not in p
+        assert arbitration_failure_counts().get("dispatch") == 1
+
+
+# ---------------------------------------------------------------------------
+# create_batch wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBatchWiring:
+    async def test_shadow_annotates_created_proposals(self, db, workflow, monkeypatch):
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
+        await _insert_cell(db, domain="ego.dispatch", mean_confidence=0.85, shrunk_estimate=0.62)
+        _, ids, created = await workflow.create_batch([_proposal("dispatch", 0.9)])
+        assert len(ids) == 1
+        assert created[0]["_calibrated_confidence"] == pytest.approx(0.62)
+
+    async def test_off_skips_lookup_entirely(self, db, workflow, monkeypatch):
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "off")
+        called = False
+
+        async def _spy(*a, **k):
+            nonlocal called
+            called = True
+            return []
+
+        monkeypatch.setattr("genesis.db.crud.calibration_cells.list_cells", _spy)
+        _, ids, created = await workflow.create_batch([_proposal("dispatch")])
+        assert len(ids) == 1
+        assert called is False
+        assert "_calibrated_confidence" not in created[0]
+
+    async def test_annotation_failure_never_blocks_batch(self, db, workflow, monkeypatch):
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
+
+        async def _boom(*a, **k):
+            raise RuntimeError("synthetic lookup failure")
+
+        monkeypatch.setattr("genesis.db.crud.calibration_cells.list_cells", _boom)
+        _, ids, _created = await workflow.create_batch([_proposal("dispatch")])
+        assert len(ids) == 1
+        assert arbitration_failure_counts().get("dispatch") == 1
+
+
+# ---------------------------------------------------------------------------
+# Sort + digest
+# ---------------------------------------------------------------------------
+
+
+class TestSortAndDigest:
+    def test_shadow_sort_uses_stated(self):
+        a = _proposal("a", confidence=0.9, _calibrated_confidence=0.1)
+        b = _proposal("b", confidence=0.5)
+        assert _sort_proposals([b, a])[0] is a  # stated 0.9 still wins
+
+    def test_enforce_sort_uses_calibrated(self):
+        a = _proposal("a", confidence=0.9, _calibrated_confidence=0.1)
+        b = _proposal("b", confidence=0.5)
+        assert _sort_proposals([a, b], enforce_calibration=True)[0] is b
+
+    def test_enforce_without_calibration_falls_back_to_stated(self):
+        a = _proposal("a", confidence=0.9)
+        b = _proposal("b", confidence=0.5)
+        assert _sort_proposals([b, a], enforce_calibration=True)[0] is a
+
+    def test_digest_renders_badge_and_note(self, monkeypatch):
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "shadow")
+        digest = _format_digest(
+            [
+                _proposal(
+                    "dispatch",
+                    confidence=0.9,
+                    _calibration_badge="⚖ stated 0.90 → track record 0.62 (n=41)",
+                ),
+                _proposal(
+                    "research",
+                    confidence=0.4,
+                    _calibration_note="calibration: thin (n=7) — escalate; track record not yet trustworthy",
+                ),
+            ],
+            "batch123",
+        )
+        assert "⚖ stated 0.90 → track record 0.62 (n=41)" in digest
+        assert "escalate" in digest
+        # Sort untouched in shadow: dispatch (0.9) numbered before research.
+        assert digest.index("dispatch") < digest.index("research")
+
+    def test_digest_enforce_reorders(self, monkeypatch):
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", lambda: "enforce")
+        digest = _format_digest(
+            [
+                _proposal("overconf", confidence=0.9, _calibrated_confidence=0.2),
+                _proposal("modest", confidence=0.5),
+            ],
+            "batch123",
+        )
+        assert digest.index("modest") < digest.index("overconf")
+
+    def test_digest_mode_read_failure_degrades_to_shadow(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("genesis.ledger.ws2_ledger_config.arbitration_mode", _boom)
+        digest = _format_digest(
+            [
+                _proposal("overconf", confidence=0.9, _calibrated_confidence=0.1),
+                _proposal("modest", confidence=0.5),
+            ],
+            "batch123",
+        )
+        # Fail-safe = shadow: stated order preserved, digest still renders.
+        assert digest.index("overconf") < digest.index("modest")
+
+
+# ---------------------------------------------------------------------------
+# Failure-counter surface
+# ---------------------------------------------------------------------------
+
+
+class TestFailureCounter:
+    def test_counts_snapshot_and_reset(self):
+        proposals_mod._arbitration_failures["dispatch"] = 2
+        assert arbitration_failure_counts() == {"dispatch": 2}
+        proposals_mod._reset_arbitration_failures_for_tests()
+        assert arbitration_failure_counts() == {}
+
+
+# ---------------------------------------------------------------------------
+# Health surfacing
+# ---------------------------------------------------------------------------
+
+
+async def test_compute_alerts_surfaces_arbitration_failures():
+    """_compute_alerts emits ledger:arbitration_failed while the counter is
+    nonzero — silently missing calibration annotations must not be silent."""
+    from genesis.mcp.health import errors as health_errors
+
+    proposals_mod._arbitration_failures["dispatch"] = 3
+    alerts, current_ids = await health_errors._compute_alerts()
+    assert "ledger:arbitration_failed:dispatch" in current_ids
+    (alert,) = [a for a in alerts if a["id"] == "ledger:arbitration_failed:dispatch"]
+    assert alert["severity"] == "WARNING"
+    assert "without calibration annotations" in alert["message"]
+
+    proposals_mod._reset_arbitration_failures_for_tests()
+    _alerts, current_ids = await health_errors._compute_alerts()
+    assert not any(i.startswith("ledger:arbitration_failed") for i in current_ids)

--- a/tests/test_mcp/test_calibration_status.py
+++ b/tests/test_mcp/test_calibration_status.py
@@ -182,3 +182,76 @@ async def test_tool_lane_cells_render_observed_base_rate(db):
     result = await _run(db)
     (line,) = result["cells_readable"]
     assert "base rate 90%" in line and "observed only" in line
+
+
+# ── WS-2 P4: earn-back evidence stream ──────────────────────────────────────
+
+
+async def _seed_autonomy(db, *, category="direct_session", current=2, earned=4):
+    await db.execute(
+        "INSERT INTO autonomy_state (id, category, current_level, earned_level,"
+        " updated_at) VALUES (?, ?, ?, ?, ?)",
+        (f"as-{category}", category, current, earned, NOW.isoformat()),
+    )
+    await db.commit()
+
+
+async def _seed_events(db, category, *, successes=0, corrections=0):
+    for i in range(successes):
+        await db.execute(
+            "INSERT INTO autonomy_events (id, category, kind, occurred_at)"
+            " VALUES (?, ?, 'success', ?)",
+            (f"ev-s-{category}-{i}", category, NOW.isoformat()),
+        )
+    for i in range(corrections):
+        await db.execute(
+            "INSERT INTO autonomy_events (id, category, kind, occurred_at)"
+            " VALUES (?, ?, 'correction', ?)",
+            (f"ev-c-{category}-{i}", category, NOW.isoformat()),
+        )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_earnback_empty_when_nothing_demoted(db):
+    await cc_crud.replace_cells(db, [_cell()], now=NOW)
+    await _seed_autonomy(db, current=4, earned=4)  # not demoted
+    result = await _run(db)
+    assert result["earnback"] == {"demoted_categories": []}
+
+
+@pytest.mark.asyncio
+async def test_earnback_surfaces_demoted_category_with_windowed_evidence(db):
+    await cc_crud.replace_cells(db, [_cell()], now=NOW)
+    await _seed_autonomy(db, current=2, earned=4)
+    await _seed_events(db, "direct_session", successes=30, corrections=1)
+    result = await _run(db)
+    (entry,) = result["earnback"]["demoted_categories"]
+    assert entry["category"] == "direct_session"
+    assert entry["current_level"] == 2
+    assert entry["earned_level"] == 4
+    assert entry["window_successes"] == 30
+    assert entry["window_corrections"] == 1
+    assert 0.0 < entry["posterior"] <= 1.0
+    assert isinstance(entry["evidence_supports_earned"], bool)
+
+
+@pytest.mark.asyncio
+async def test_earnback_no_evidence_reads_zero_counts(db):
+    await cc_crud.replace_cells(db, [_cell()], now=NOW)
+    await _seed_autonomy(db, current=1, earned=3)
+    result = await _run(db)
+    (entry,) = result["earnback"]["demoted_categories"]
+    assert entry["window_successes"] == 0
+    assert entry["window_corrections"] == 0
+    assert entry["evidence_supports_earned"] is False
+
+
+@pytest.mark.asyncio
+async def test_earnback_failure_degrades_to_unavailable(db):
+    await cc_crud.replace_cells(db, [_cell()], now=NOW)
+    await db.execute("DROP TABLE autonomy_state")
+    await db.commit()
+    result = await _run(db)
+    assert result["earnback"]["demoted_categories"] == []
+    assert result["earnback"]["unavailable"] is True

--- a/tests/test_mcp/test_settings_ws2_ledger.py
+++ b/tests/test_mcp/test_settings_ws2_ledger.py
@@ -1,0 +1,70 @@
+"""ws2_ledger settings validator + arbitration_mode reader (WS-2 P2b/P4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.ledger import ws2_ledger_config as cfg_mod
+from genesis.mcp.health.settings import _DOMAIN_VALIDATORS
+
+_validate = _DOMAIN_VALIDATORS["ws2_ledger"]
+
+
+class TestValidator:
+    def test_valid_changes_pass(self):
+        assert _validate({"enabled": True, "autonomy_feed": "shadow"}) == []
+        assert _validate({"arbitration": "off"}) == []
+        assert _validate({"arbitration": "shadow"}) == []
+        assert _validate({"arbitration": "enforce"}) == []
+
+    def test_unknown_key_rejected_and_lists_arbitration(self):
+        (err,) = _validate({"bogus": 1})
+        assert "arbitration" in err and "Unknown key" in err
+
+    def test_arbitration_rejects_non_modes(self):
+        (err,) = _validate({"arbitration": "live"})  # live is autonomy_feed-only
+        assert "arbitration" in err
+        assert _validate({"arbitration": True}) != []
+
+    def test_autonomy_feed_rejects_enforce(self):
+        (err,) = _validate({"autonomy_feed": "enforce"})  # enforce is arbitration-only
+        assert "autonomy_feed" in err
+
+    def test_enabled_must_be_bool(self):
+        (err,) = _validate({"enabled": "yes"})
+        assert "boolean" in err
+
+
+class TestArbitrationModeReader:
+    @pytest.mark.parametrize("mode", ["off", "shadow", "enforce"])
+    def test_valid_modes_pass_through(self, monkeypatch, mode):
+        monkeypatch.setattr(
+            cfg_mod, "load_config", lambda: {"enabled": True, "arbitration": mode}
+        )
+        assert cfg_mod.arbitration_mode() == mode
+
+    def test_master_disabled_forces_off(self, monkeypatch):
+        monkeypatch.setattr(
+            cfg_mod, "load_config", lambda: {"enabled": False, "arbitration": "enforce"}
+        )
+        assert cfg_mod.arbitration_mode() == "off"
+
+    def test_invalid_degrades_to_shadow(self, monkeypatch):
+        monkeypatch.setattr(
+            cfg_mod, "load_config", lambda: {"enabled": True, "arbitration": "banana"}
+        )
+        assert cfg_mod.arbitration_mode() == "shadow"
+
+    def test_missing_key_degrades_to_shadow(self, monkeypatch):
+        monkeypatch.setattr(cfg_mod, "load_config", lambda: {"enabled": True})
+        assert cfg_mod.arbitration_mode() == "shadow"
+
+    def test_yaml_false_means_off(self, monkeypatch):
+        # Unquoted `arbitration: off` parses as YAML-1.1 boolean False.
+        monkeypatch.setattr(
+            cfg_mod, "load_config", lambda: {"enabled": True, "arbitration": False}
+        )
+        assert cfg_mod.arbitration_mode() == "off"
+
+    def test_shipped_default_is_shadow(self):
+        assert cfg_mod.DEFAULTS["arbitration"] == "shadow"


### PR DESCRIPTION
## WS-2 P4a — the first calibration consumers

The graded calibration record (P3) gains its first two consumers, both read-only against the cells and shadow-first.

### Arbitration discount (design §5.1)
- `ego/proposals.py::annotate_calibration`: each created proposal is annotated from its domain's **stated-lane 90d cell** (`ego.<action_type>` / `ego_proposal` / `approved_and_executes` — the exact cell the ledger writer stamps).
- **thin/unknown** cells → an escalation note only ("track record not yet trustworthy") — never a discount on ignorance, never a bare percentage (§3.4).
- **ok** cells with an overconfidence gap >0.15 (cell mean stated − shrunk track record) → `_calibrated_confidence` + a digest badge ("⚖ stated 0.90 → track record 0.62 (n=41)").
- Gated by the new `ws2_ledger.arbitration` lever (**off/shadow/enforce, default shadow**, read live, fail-safe to shadow). Sort consumes the calibrated value ONLY in enforce; shadow is annotate-only. A proposal is **never suppressed** (sovereignty invariant, §5).
- Lookup failures are isolated (a failure ships the proposal un-annotated), counted, and surfaced as the standing `ledger:arbitration_failed` WARNING (same counter→`_compute_alerts` contract as the other ledger alarms; registered in the Sentinel remediation map as unmapped-by-design).

### Earn-back evidence stream (design §5.2)
- `calibration_status` MCP gains an `earnback` key: for every demoted autonomy category (current < earned), the windowed `autonomy_events` counts, Bayesian posterior, and `evidence_supports_earned` (the same predicate `detect_earnback_candidates` gates on). Read-only, MCP-side (no runtime instance), degrades to an `unavailable` marker.

### Declared deviations
- §5.2's named `v_earnback_evidence` SQL view was **not** built — migration 0067's `windowed_counts` machinery already computes it; the evidence is surfaced via the MCP instead (a view would duplicate).
- The earn-back window on this surface uses the 45d default rather than re-reading the autonomy config — the AUTHORITATIVE proposal path stays the ego cadence (which does read config); this key is observability.
- `ego/proposals.py` carries minor formatter-only churn in untouched lines (worktree formatter; zero semantic change).

### Tests (all synthetic fixtures)
33 new: annotation matrix (no-cell / thin / unknown / ok+gap / ok-no-gap / NULL-scoring / wrong-domain / policy_prior-never-consulted / failure-isolated), create_batch wiring (off skips lookup; failures never block the batch), sort shadow-vs-enforce (+fail-safe), digest badge/note rendering, alert emission, validator matrix, arbitration_mode reader, earn-back evidence (demoted/empty/unavailable). Targeted net: tests/ego + test_mcp settings/calibration_status + test_ledger = **1019 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)