### PR TITLE
feat(ledger): WS-2 P4b — learned-knob substrate (closed registry, ledgered writes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis's tunable cognition knobs now live in one auditable file.** Three
+  cognitive parameters — awareness signal weights, depth thresholds, and the
+  memory-activation blend — form a closed "learned knob" registry
+  (`config/learned_knobs.yaml` documents it; learned values live in
+  `~/.genesis/config/learned_knobs.local.yaml`). Every change goes through the
+  cognitive ledger (pre-image capture, drift-guarded rollback, visible in the
+  dashboard) with hard bounds: ≤5% per step, ≤±20% total from baseline.
+  Nothing adjusts autonomously yet — this is the substrate; the evidence-gated
+  proposer arrives once calibration data covers these domains.
 - **Ego proposals now carry their track record.** When Genesis's ego proposes
   an action, the proposal digest can show how proposals of that type have
   actually fared: a domain with a healthy graded history whose stated

--- a/config/learned_knobs.yaml
+++ b/config/learned_knobs.yaml
@@ -1,0 +1,33 @@
+# Learned knobs — WS-2 B5 substrate (design §5.3).
+#
+# This BASE file is documentation + the closed registry; it ships empty and is
+# NEVER machine-written (learned state must not dirty the repo tree). Learned
+# entries live in the install-local overlay:
+#     ~/.genesis/config/learned_knobs.local.yaml
+# written EXCLUSIVELY through genesis.ledger.learned_knobs.apply_knob_change
+# (cognitive-ledger actor `ws2_effector` — pre-image capture, drift-guarded
+# rollback, MCP rollback tool all apply). Deep-merged base <- overlay.
+#
+# CLOSED key registry (anything else is ignored, loudly):
+#   awareness.signal_weights.<signal_name>      -> signal_weights.current_weight
+#       (baseline = the row's initial_weight; SQL-clamped to the row's min/max)
+#   awareness.depth_thresholds.<Micro|Light|Deep|Strategic>
+#                                               -> depth_thresholds.threshold
+#       (baseline = live value at first apply, pinned in the entry)
+#   memory.activation_blend.<base|access|connectivity>
+#                                               -> memory/activation.py blend
+#       (baseline = shipped constants 0.6 / 0.25 / 0.15)
+#
+# Entry schema, per knob key:
+#   knobs:
+#     awareness.depth_thresholds.Deep: {baseline: 0.45, current: 0.44}
+#
+# Bounds (validator-enforced): each change <=5% of baseline; cumulative drift
+# <=+/-20% of baseline. Out-of-bounds entries are skipped loudly at startup.
+#
+# v1 is propose-only substrate: nothing writes here autonomously — the
+# deterministic calibration trigger (cell ok, n>=50, 2-window directional
+# miss -> ego proposal) ships later, gated on a calibration lane that
+# actually grades awareness/memory behavior.
+
+knobs: {}

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -792,7 +792,20 @@ verified: fbcf8ee4 2026-07-21
   **E1 earn-back evidence stream** (`earnback` key: windowed
   `autonomy_events` counts + posterior per demoted category — surfaced
   MCP-side instead of the design's `v_earnback_evidence` view, declared
-  deviation). The fuzzy LLM-fallback lane is
+  deviation). **B5 knob SUBSTRATE (P4b)**: `ledger/learned_knobs.py` — a
+  CLOSED 3-knob registry (`awareness.signal_weights.*`,
+  `awareness.depth_thresholds.*`, `memory.activation_blend.*`) with base file
+  `config/learned_knobs.yaml` (documentation, never machine-written) +
+  install-local overlay `~/.genesis/config/learned_knobs.local.yaml` written
+  ONLY via `apply_knob_change` → `cognitive_ledger.record_file_modification`
+  (actor `ws2_effector`; pre-image/rollback/MCP tool inherited; bounds
+  validator-enforced ≤5%/step, ≤±20% cumulative). Startup applier in learning
+  init re-syncs DB-backed knobs from file (SQL clamps backstop);
+  `memory/activation.py` reads the blend through a module-level seam
+  (import-time load + `reload_blend()`, shipped-constants fallback). The
+  deterministic calibration TRIGGER (cell ok, n≥50, 2-window miss → ego
+  proposal) is DEFERRED — structurally dormant until a lane grades
+  awareness/memory behavior (tabled). The fuzzy LLM-fallback lane is
   deferred (no `acceptance_pass` writer yet). Outreach
   metrics resolve off `outreach_history.engagement_signal`
   (spike-measured 99.5% mechanical); the engagement_outcome CHECK now

--- a/src/genesis/learning/cognitive_ledger.py
+++ b/src/genesis/learning/cognitive_ledger.py
@@ -95,7 +95,8 @@ async def record_existing(
     except Exception:
         logger.warning(
             "cognitive_ledger: ledger insert failed for %s (write unaffected)",
-            path, exc_info=True,
+            path,
+            exc_info=True,
         )
         return None
     # Prune-on-write: bound table growth (self-bounding, no scheduler job).
@@ -124,13 +125,21 @@ async def record_file_modification(
     prior = _read_current(path)
     _atomic_write(path, new_content)  # primary op — may raise (preserves behavior)
     return await record_existing(
-        db, actor=actor, path=path, prior_content=prior,
-        applied_content=new_content, summary=summary, metadata=metadata,
+        db,
+        actor=actor,
+        path=path,
+        prior_content=prior,
+        applied_content=new_content,
+        summary=summary,
+        metadata=metadata,
     )
 
 
 async def rollback(
-    db: aiosqlite.Connection, mod_id: str, *, force: bool = False,
+    db: aiosqlite.Connection,
+    mod_id: str,
+    *,
+    force: bool = False,
 ) -> dict:
     """Revert a recorded cognitive file modification to its pre-image.
 
@@ -142,12 +151,15 @@ async def rollback(
     """
     row = await cfm_crud.get(db, mod_id)
     if row is None:
-        return {"ok": False, "refused": False, "mod_id": mod_id,
-                "reason": "no such modification"}
+        return {"ok": False, "refused": False, "mod_id": mod_id, "reason": "no such modification"}
     if row.get("status") == "rolled_back":
-        return {"ok": False, "refused": False, "mod_id": mod_id,
-                "target_path": row.get("target_path"),
-                "reason": "already rolled back"}
+        return {
+            "ok": False,
+            "refused": False,
+            "mod_id": mod_id,
+            "target_path": row.get("target_path"),
+            "reason": "already rolled back",
+        }
 
     path = Path(row["target_path"])
     current = _read_current(path)
@@ -155,10 +167,14 @@ async def rollback(
     # Drift guard — refuse if the file changed since this modification.
     if current != row.get("applied_content") and not force:
         result = {
-            "ok": False, "refused": True, "mod_id": mod_id,
+            "ok": False,
+            "refused": True,
+            "mod_id": mod_id,
             "target_path": row["target_path"],
-            "reason": ("file changed since this modification — a later write replaced "
-                       "it; roll back the newer entry, or pass force=True"),
+            "reason": (
+                "file changed since this modification — a later write replaced "
+                "it; roll back the newer entry, or pass force=True"
+            ),
         }
         await _emit_rollback_observation(db, row, result)
         return result
@@ -172,28 +188,58 @@ async def rollback(
             _atomic_write(path, row["prior_content"])
             restored = "prior"
     except OSError as exc:
-        result = {"ok": False, "refused": False, "mod_id": mod_id,
-                  "target_path": row["target_path"], "reason": f"restore failed: {exc}"}
+        result = {
+            "ok": False,
+            "refused": False,
+            "mod_id": mod_id,
+            "target_path": row["target_path"],
+            "reason": f"restore failed: {exc}",
+        }
         await _emit_rollback_observation(db, row, result)
         return result
 
     await cfm_crud.mark_rolled_back(db, mod_id)
-    result = {"ok": True, "refused": False, "mod_id": mod_id,
-              "target_path": row["target_path"], "restored_to": restored,
-              "forced": force}
+    result = {
+        "ok": True,
+        "refused": False,
+        "mod_id": mod_id,
+        "target_path": row["target_path"],
+        "restored_to": restored,
+        "forced": force,
+    }
+
+    # WS-2 B5: a knob-file rollback must also re-converge the knobs' CONSUMERS
+    # (DB rows / activation blend) — file restore alone leaves awareness
+    # scoring on the un-rolled-back values until the next restart, invisibly.
+    # Best-effort: a resync failure never un-rolls the file (it is already
+    # restored + marked); it is surfaced in the result instead.
+    if row.get("actor") == "ws2_effector":
+        try:
+            from genesis.ledger.learned_knobs import resync_after_ledger_rollback
+
+            result["knob_resync"] = await resync_after_ledger_rollback(db, row)
+        except Exception:
+            logger.warning("knob resync after rollback failed", exc_info=True)
+            result["knob_resync"] = "failed — DB re-converges at next restart"
+
     await _emit_rollback_observation(db, row, result)
     return result
 
 
 async def recent(
-    db: aiosqlite.Connection, *, limit: int = 20, actor: str | None = None,
+    db: aiosqlite.Connection,
+    *,
+    limit: int = 20,
+    actor: str | None = None,
 ) -> list[dict]:
     """Most-recent ledger rows (newest first), optionally filtered by actor."""
     return await cfm_crud.recent(db, limit=limit, actor=actor)
 
 
 async def _emit_rollback_observation(
-    db: aiosqlite.Connection, row: dict, result: dict,
+    db: aiosqlite.Connection,
+    row: dict,
+    result: dict,
 ) -> None:
     """Best-effort observation so a rollback (or its refusal) is visible. Never raises."""
     try:
@@ -210,19 +256,22 @@ async def _emit_rollback_observation(
             id=str(uuid.uuid4()),
             source="cognitive_ledger",
             type="self_mod_rollback",
-            content=json.dumps({
-                "mod_id": result.get("mod_id"),
-                "actor": row.get("actor"),
-                "target_path": row.get("target_path"),
-                "outcome": outcome,
-                "reason": result.get("reason"),
-                "restored_to": result.get("restored_to"),
-                "forced": result.get("forced", False),
-            }),
+            content=json.dumps(
+                {
+                    "mod_id": result.get("mod_id"),
+                    "actor": row.get("actor"),
+                    "target_path": row.get("target_path"),
+                    "outcome": outcome,
+                    "reason": result.get("reason"),
+                    "restored_to": result.get("restored_to"),
+                    "forced": result.get("forced", False),
+                }
+            ),
             priority="high",
             created_at=datetime.now(UTC).isoformat(),
         )
     except Exception:
         logger.warning(
-            "cognitive_ledger: failed to emit rollback observation", exc_info=True,
+            "cognitive_ledger: failed to emit rollback observation",
+            exc_info=True,
         )

--- a/src/genesis/ledger/learned_knobs.py
+++ b/src/genesis/ledger/learned_knobs.py
@@ -36,6 +36,13 @@ Dependency rule: module-level imports are stdlib + yaml + genesis.env +
 genesis._config_overlay only (the ws2_ledger_config rule) — DB CRUDs and the
 cognitive ledger import lazily inside functions, so the memory/awareness hot
 paths can import this module without dragging the learning stack.
+
+Cross-process caveat (for the future trigger builder): the activation blend
+is cached per process at import; ``reload_blend()`` only fires in the process
+that ran the change/rollback. Other processes computing activation (e.g. the
+memory MCP server) pick the new blend up at their next restart. Applies to
+concurrency too: ``apply_knob_change`` has no cross-process write lock — the
+trigger must serialize its applies (v1 has no autonomous writer).
 """
 
 from __future__ import annotations
@@ -58,7 +65,11 @@ logger = logging.getLogger(__name__)
 _CONFIG_NAME = "learned_knobs.yaml"
 
 # Shipped activation-blend constants (memory/activation.py's coefficients —
-# must sum to 1.0 at maximum; the file may retune within ±20% per component).
+# sum to 1.0 at maximum AS SHIPPED). Components are bounded independently
+# (±20% each), so a fully-retuned file can push the sum to 1.2: relative
+# ranking is unaffected, but ABSOLUTE-score consumers (e.g. the drift
+# archival gate's min_activation) shift with it — a deliberate part of the
+# knob's effect, not an accident.
 BLEND_DEFAULTS = {"base": 0.6, "access": 0.25, "connectivity": 0.15}
 
 # The CLOSED registry — key must match exactly one pattern (§5.3).
@@ -295,7 +306,11 @@ async def _sync_knob(db: aiosqlite.Connection, group: str, name: str, value: flo
     elif group == "depth_thresholds":
         from genesis.db.crud import depth_thresholds as dt_crud
 
-        await dt_crud.update_threshold(db, name, new_threshold=value)
+        # Absolute backstop mirroring the signal CRUD's SQL clamp: thresholds
+        # live in (0, 1] and the CRUD itself doesn't clamp — without this, a
+        # hand-edited overlay with a self-attested baseline could land an
+        # arbitrary value and make a depth unreachable in the scorer.
+        await dt_crud.update_threshold(db, name, new_threshold=max(0.01, min(1.0, value)))
     else:  # activation_blend — poke the module-level seam
         try:
             from genesis.memory.activation import reload_blend
@@ -336,6 +351,68 @@ async def apply_learned_knobs_to_db(db: aiosqlite.Connection) -> int:
             applied += 1
         if applied:
             logger.info("learned_knobs: applied %d knob(s) from file to DB", applied)
+        # Surface the reader/writer overlay asymmetry: a legacy repo-local
+        # overlay is silently shadowed once the user-dir file exists (the
+        # resolver picks one file, it does not merge the two).
+        legacy = _base_path().with_suffix(".local.yaml")
+        if legacy.is_file() and _overlay_path().is_file():
+            logger.warning(
+                "learned_knobs: BOTH %s and %s exist — only the user-dir file "
+                "is read; fold the repo-local entries in and delete it",
+                legacy,
+                _overlay_path(),
+            )
     except Exception:
         logger.warning("learned_knobs startup apply failed", exc_info=True)
     return applied
+
+
+async def resync_after_ledger_rollback(db: aiosqlite.Connection, row: dict) -> str:
+    """Re-converge knob consumers after a cognitive-ledger file rollback.
+
+    Called by ``cognitive_ledger.rollback`` for ``ws2_effector`` rows: the
+    ledger restores the FILE, but the knobs' consumers (DB rows, the cached
+    activation blend) would otherwise keep the un-rolled-back values until
+    the next restart. Two cases:
+
+    - entry survived with an older value (rollback of a later write) → the
+      normal applier re-converges it;
+    - entry VANISHED (rollback of the first-ever write deletes the overlay)
+      → the applier can't see it, so the pre-change value is restored from
+      the ledger row's own recorded ``metadata.previous`` — without this,
+      the DB would keep the learned value forever while the file says "no
+      learned state", and the next apply would re-pin the baseline at the
+      drifted value (compounding the ±20% window).
+    """
+    applied = await apply_learned_knobs_to_db(db)
+    # The file changed under the cached activation blend either way.
+    try:
+        from genesis.memory.activation import reload_blend
+
+        reload_blend()
+    except Exception:
+        logger.debug("activation blend reload failed", exc_info=True)
+
+    meta_raw = row.get("metadata")
+    meta: dict[str, Any] = {}
+    if isinstance(meta_raw, dict):
+        meta = meta_raw
+    elif isinstance(meta_raw, str) and meta_raw:
+        try:
+            import json
+
+            loaded = json.loads(meta_raw)
+            if isinstance(loaded, dict):
+                meta = loaded
+        except ValueError:
+            pass
+    knob = meta.get("knob")
+    parsed = parse_knob_key(str(knob)) if knob else None
+    if parsed and knob not in load_knobs() and "previous" in meta:
+        group, name = parsed
+        try:
+            await _sync_knob(db, group, name, float(meta["previous"]))
+            return f"resynced ({applied} from file; {knob} restored to previous)"
+        except (TypeError, ValueError):
+            logger.warning("learned_knobs: bad metadata.previous for %r", knob)
+    return f"resynced ({applied} from file)"

--- a/src/genesis/ledger/learned_knobs.py
+++ b/src/genesis/ledger/learned_knobs.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from genesis._config_overlay import _resolve_overlay_path, merge_local_overlay
+from genesis._config_overlay import merge_local_overlay
 from genesis.env import repo_root
 
 if TYPE_CHECKING:
@@ -87,7 +87,18 @@ def _base_path() -> Path:
 
 
 def _overlay_path() -> Path:
-    return _resolve_overlay_path(_base_path())
+    """The overlay path for WRITES — the user config dir, unconditionally.
+
+    Deliberately NOT ``_resolve_overlay_path`` (which falls back to the
+    repo-relative sibling when the user file doesn't exist yet): the first
+    ever knob write must never land inside the repo tree (cfg-001 — the
+    dashboard/MCP settings writers use the same user-dir-always convention).
+    Reads via ``merge_local_overlay`` still resolve user-dir-first, so reader
+    and writer agree from the first write onward.
+    """
+    from genesis._config_overlay import _user_config_dir
+
+    return _user_config_dir() / _base_path().with_suffix(".local.yaml").name
 
 
 def parse_knob_key(key: str) -> tuple[str, str] | None:

--- a/src/genesis/ledger/learned_knobs.py
+++ b/src/genesis/ledger/learned_knobs.py
@@ -1,0 +1,330 @@
+"""WS-2 B5 learned-knob substrate — the closed registry + ledgered file writes.
+
+Design §5.3, SUBSTRATE ONLY: the knob file, the bounds validator, the ledgered
+write path (`apply_knob_change`), and the startup applier that syncs DB-backed
+knobs from file. The deterministic calibration TRIGGER (cell ok, n≥50,
+2-window directional miss → ego proposal) is deliberately NOT built — no v1
+calibration lane grades awareness/memory behavior, so it would be structurally
+dormant; it lands with the lane that gives it evidence (tabled record).
+
+The registry is a CLOSED set of three knob groups (§5.3):
+
+1. ``awareness.signal_weights.<signal_name>`` — DB-backed
+   (``signal_weights.current_weight``; baseline = the row's
+   ``initial_weight``; the CRUD clamps to the row's min/max in SQL).
+2. ``awareness.depth_thresholds.<Micro|Light|Deep|Strategic>`` — DB-backed
+   (``depth_thresholds.threshold``; no initial column, so the baseline is
+   captured from the live value at first apply and pinned in the file entry).
+3. ``memory.activation_blend.<base|access|connectivity>`` — code-backed
+   (the activation blend constants; ``memory/activation.py`` reads
+   :func:`activation_blend` through its module-level seam).
+
+File model (the immunity config split): the repo base
+``config/learned_knobs.yaml`` ships as documentation + empty registry and is
+NEVER machine-written (a mutated repo file would dirty the tree and fight
+deploys). Learned entries live in the install-local overlay
+``~/.genesis/config/learned_knobs.local.yaml`` — every write goes through
+``cognitive_ledger.record_file_modification`` (actor ``ws2_effector``), so
+pre-image capture, drift-guarded rollback, and the MCP rollback tool are all
+inherited. Rollback = file rollback + re-sync (:func:`apply_learned_knobs_to_db`).
+
+Bounds are validator-enforced per §5.3: step ≤5% of baseline per change,
+cumulative ≤±20% of baseline. (The 14-day per-knob cooldown is trigger
+policy, deferred with the trigger.)
+
+Dependency rule: module-level imports are stdlib + yaml + genesis.env +
+genesis._config_overlay only (the ws2_ledger_config rule) — DB CRUDs and the
+cognitive ledger import lazily inside functions, so the memory/awareness hot
+paths can import this module without dragging the learning stack.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from genesis._config_overlay import _resolve_overlay_path, merge_local_overlay
+from genesis.env import repo_root
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "learned_knobs.yaml"
+
+# Shipped activation-blend constants (memory/activation.py's coefficients —
+# must sum to 1.0 at maximum; the file may retune within ±20% per component).
+BLEND_DEFAULTS = {"base": 0.6, "access": 0.25, "connectivity": 0.15}
+
+# The CLOSED registry — key must match exactly one pattern (§5.3).
+_KNOB_PATTERNS = (
+    re.compile(r"^awareness\.signal_weights\.(?P<name>[a-z0-9_]+)$"),
+    re.compile(r"^awareness\.depth_thresholds\.(?P<name>Micro|Light|Deep|Strategic)$"),
+    re.compile(r"^memory\.activation_blend\.(?P<name>base|access|connectivity)$"),
+)
+
+_STEP_LIMIT = 0.05  # ≤5% of baseline per change
+_CUMULATIVE_LIMIT = 0.20  # ≤±20% of baseline from baseline
+_EPS = 1e-9
+
+_OVERLAY_HEADER = (
+    "# Learned knob overrides — MACHINE-WRITTEN via the cognitive ledger\n"
+    "# (actor ws2_effector). Hand-edits are allowed but the ledger pre-image\n"
+    "# trail only covers writes made through apply_knob_change. Schema per\n"
+    "# knob key: {baseline: <pinned>, current: <value>}. Bounds: each change\n"
+    "# <=5% of baseline, cumulative <=+/-20% of baseline. See\n"
+    "# config/learned_knobs.yaml for the closed key registry.\n"
+)
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def _overlay_path() -> Path:
+    return _resolve_overlay_path(_base_path())
+
+
+def parse_knob_key(key: str) -> tuple[str, str] | None:
+    """Return ``(group, name)`` for a registry key, or None if not in the
+    closed set. group ∈ {signal_weights, depth_thresholds, activation_blend}."""
+    for pat in _KNOB_PATTERNS:
+        m = pat.match(key)
+        if m:
+            group = key.split(".")[1]
+            return group, m.group("name")
+    return None
+
+
+def load_knobs() -> dict[str, dict[str, Any]]:
+    """The merged knob entries — ``{key: {baseline, current}}``.
+
+    Reads base ← overlay fresh per call (no cache — same live-read contract
+    as ws2_ledger_config). Malformed layers degrade to empty.
+    """
+    base: dict[str, Any] = {}
+    base_path = _base_path()
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        logger.debug("learned_knobs base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("learned_knobs overlay merge failed", exc_info=True)
+    knobs = base.get("knobs")
+    if not isinstance(knobs, dict):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for key, entry in knobs.items():
+        if parse_knob_key(str(key)) is None:
+            logger.warning("learned_knobs: ignoring unregistered key %r", key)
+            continue
+        if not isinstance(entry, dict) or "current" not in entry:
+            logger.warning("learned_knobs: ignoring malformed entry for %r", key)
+            continue
+        out[str(key)] = entry
+    return out
+
+
+def activation_blend() -> dict[str, float]:
+    """The activation-blend coefficients with any learned overrides applied.
+
+    Consumed by ``memory/activation.py``'s module-level seam. Falls back
+    per-component to :data:`BLEND_DEFAULTS`; a value outside the ±20% bound
+    of its shipped default is ignored (defense against hand-edited files —
+    the blend shapes every memory activation score).
+    """
+    blend = dict(BLEND_DEFAULTS)
+    try:
+        for key, entry in load_knobs().items():
+            parsed = parse_knob_key(key)
+            if parsed is None or parsed[0] != "activation_blend":
+                continue
+            name = parsed[1]
+            default = BLEND_DEFAULTS[name]
+            try:
+                value = float(entry["current"])
+            except (TypeError, ValueError):
+                continue
+            if abs(value - default) <= _CUMULATIVE_LIMIT * default + _EPS:
+                blend[name] = value
+            else:
+                logger.warning(
+                    "learned_knobs: activation_blend.%s=%r outside ±20%% of default %.2f — ignored",
+                    name,
+                    value,
+                    default,
+                )
+    except Exception:
+        logger.debug("learned_knobs activation_blend read failed", exc_info=True)
+    return blend
+
+
+def validate_change(*, baseline: float, current: float, new_value: float) -> list[str]:
+    """Bounds check per §5.3 — returns error strings (empty = valid)."""
+    errors: list[str] = []
+    if baseline <= 0:
+        return [f"baseline must be positive, got {baseline!r}"]
+    if abs(new_value - current) > _STEP_LIMIT * baseline + _EPS:
+        errors.append(
+            f"step {abs(new_value - current):.4f} exceeds 5% of baseline "
+            f"({_STEP_LIMIT * baseline:.4f})"
+        )
+    if abs(new_value - baseline) > _CUMULATIVE_LIMIT * baseline + _EPS:
+        errors.append(
+            f"cumulative drift {abs(new_value - baseline):.4f} exceeds ±20% of "
+            f"baseline ({_CUMULATIVE_LIMIT * baseline:.4f})"
+        )
+    return errors
+
+
+async def _resolve_baseline_and_current(
+    db: aiosqlite.Connection, key: str, group: str, name: str
+) -> tuple[float, float]:
+    """(baseline, current) for *key* — file entry first, then the source."""
+    entry = load_knobs().get(key)
+    if entry is not None and "baseline" in entry:
+        return float(entry["baseline"]), float(entry["current"])
+
+    if group == "signal_weights":
+        from genesis.db.crud import signal_weights as sw_crud
+
+        row = await sw_crud.get(db, name)
+        if row is None:
+            raise ValueError(f"unknown signal {name!r}")
+        return float(row["initial_weight"]), float(row["current_weight"])
+    if group == "depth_thresholds":
+        from genesis.db.crud import depth_thresholds as dt_crud
+
+        row = await dt_crud.get(db, name)
+        if row is None:
+            raise ValueError(f"unknown depth {name!r}")
+        # No initial column — the live value at first apply IS the baseline
+        # (pinned into the file entry from then on).
+        return float(row["threshold"]), float(row["threshold"])
+    return float(BLEND_DEFAULTS[name]), float(activation_blend()[name])
+
+
+async def apply_knob_change(
+    db: aiosqlite.Connection, key: str, new_value: float, *, reason: str = ""
+) -> str | None:
+    """Apply one validated knob change — THE write path for learned knobs.
+
+    Validates the key against the closed registry and the §5.3 bounds, writes
+    the overlay file through ``record_file_modification`` (actor
+    ``ws2_effector`` — pre-image + rollback inherited), then syncs the value
+    to its consumer (DB row via the clamped CRUDs, or the activation-blend
+    module seam). Returns the cognitive-ledger mod id (None if only the
+    ledger row failed — the file write itself raising propagates).
+
+    Raises ``ValueError`` on an unregistered key, unknown signal/depth, or a
+    bounds violation. This is called by the future calibration trigger and by
+    deliberate operator action — never fire-and-forget.
+    """
+    parsed = parse_knob_key(key)
+    if parsed is None:
+        raise ValueError(f"knob {key!r} is not in the closed registry")
+    group, name = parsed
+    new_value = float(new_value)
+
+    baseline, current = await _resolve_baseline_and_current(db, key, group, name)
+    errors = validate_change(baseline=baseline, current=current, new_value=new_value)
+    if errors:
+        raise ValueError(f"knob {key!r}: " + "; ".join(errors))
+
+    # Read the RAW overlay (not the merged view) so we only ever rewrite
+    # install-local state, preserving unrelated hand-added entries.
+    overlay_path = _overlay_path()
+    overlay: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(overlay_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            overlay = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("learned_knobs overlay unreadable — rewriting", exc_info=True)
+    knobs = overlay.setdefault("knobs", {})
+    if not isinstance(knobs, dict):
+        knobs = overlay["knobs"] = {}
+    knobs[key] = {"baseline": baseline, "current": new_value}
+
+    body = _OVERLAY_HEADER + yaml.safe_dump(overlay, sort_keys=True)
+    from genesis.learning.cognitive_ledger import record_file_modification
+
+    mod_id = await record_file_modification(
+        db,
+        actor="ws2_effector",
+        path=overlay_path,
+        new_content=body,
+        summary=(
+            f"knob {key}: {current:.4f} → {new_value:.4f}" + (f" ({reason})" if reason else "")
+        ),
+        metadata={"knob": key, "baseline": baseline, "previous": current},
+    )
+
+    await _sync_knob(db, group, name, new_value)
+    return mod_id
+
+
+async def _sync_knob(db: aiosqlite.Connection, group: str, name: str, value: float) -> None:
+    """Push one knob value to its consumer."""
+    if group == "signal_weights":
+        from genesis.db.crud import signal_weights as sw_crud
+
+        await sw_crud.update_weight(db, name, new_weight=value)
+    elif group == "depth_thresholds":
+        from genesis.db.crud import depth_thresholds as dt_crud
+
+        await dt_crud.update_threshold(db, name, new_threshold=value)
+    else:  # activation_blend — poke the module-level seam
+        try:
+            from genesis.memory.activation import reload_blend
+
+            reload_blend()
+        except Exception:
+            logger.debug("activation blend reload failed", exc_info=True)
+
+
+async def apply_learned_knobs_to_db(db: aiosqlite.Connection) -> int:
+    """Startup applier — sync every DB-backed file entry into its row.
+
+    The file is the source of truth for learned values; a fresh DB (or a
+    restore) re-converges here. Activation-blend entries need no DB sync
+    (activation.py reads the file through its seam). Never raises; returns
+    the number of knobs applied.
+    """
+    applied = 0
+    try:
+        for key, entry in load_knobs().items():
+            parsed = parse_knob_key(key)
+            if parsed is None or parsed[0] == "activation_blend":
+                continue
+            group, name = parsed
+            try:
+                baseline = float(entry.get("baseline", 0.0))
+                value = float(entry["current"])
+            except (TypeError, ValueError):
+                logger.warning("learned_knobs: non-numeric entry for %r", key)
+                continue
+            errors = validate_change(baseline=baseline, current=value, new_value=value)
+            # Startup re-sync only checks the CUMULATIVE bound (step vs
+            # itself is 0); a corrupted/out-of-bounds entry is skipped loudly.
+            if any("cumulative" in e or "baseline" in e for e in errors):
+                logger.warning("learned_knobs: %r out of bounds — skipped: %s", key, errors)
+                continue
+            await _sync_knob(db, group, name, value)
+            applied += 1
+        if applied:
+            logger.info("learned_knobs: applied %d knob(s) from file to DB", applied)
+    except Exception:
+        logger.warning("learned_knobs startup apply failed", exc_info=True)
+    return applied

--- a/src/genesis/memory/activation.py
+++ b/src/genesis/memory/activation.py
@@ -6,19 +6,51 @@ from datetime import UTC, datetime
 from genesis.memory.classification import CLASS_WEIGHTS
 from genesis.memory.types import ActivationScore
 
+
+def _load_blend() -> tuple[float, float, float]:
+    """(base, access, connectivity) blend — learned-knob file with fallback.
+
+    WS-2 B5 read seam: `genesis.ledger.learned_knobs.activation_blend()`
+    merges any learned overrides (bounds-checked ±20% there) over the shipped
+    constants. Loaded ONCE at import (this sits on the per-memory scoring hot
+    path — no per-call file I/O); `reload_blend()` re-reads after a knob
+    change. Any failure falls back to the shipped 0.6/0.25/0.15.
+    """
+    try:
+        from genesis.ledger.learned_knobs import activation_blend
+
+        blend = activation_blend()
+        return (
+            float(blend["base"]),
+            float(blend["access"]),
+            float(blend["connectivity"]),
+        )
+    except Exception:
+        return (0.6, 0.25, 0.15)
+
+
+_BLEND_BASE, _BLEND_ACCESS, _BLEND_CONNECTIVITY = _load_blend()
+
+
+def reload_blend() -> None:
+    """Re-read the activation blend from the learned-knob file (B5 seam)."""
+    global _BLEND_BASE, _BLEND_ACCESS, _BLEND_CONNECTIVITY
+    _BLEND_BASE, _BLEND_ACCESS, _BLEND_CONNECTIVITY = _load_blend()
+
+
 # Category-aware half-lives: different memory types have different relevance
 # decay rates. A fact about a service doesn't decay with time; a system health
 # observation is stale in hours. These values are initial estimates — tune
 # based on observed retrieval quality.
 _HALF_LIFE_BY_SOURCE: dict[str, float] = {
-    "session_extraction": 60.0,     # Conversation content — slow decay
-    "deep_reflection": 45.0,        # Strategic insights
-    "reflection": 30.0,             # Routine observations
-    "surplus_promotion": 60.0,      # Promoted research findings
-    "retrospective": 45.0,          # Session retrospectives
-    "auto_memory_harvest": 30.0,    # Automated extractions
-    "fts5_reindex": 30.0,           # Migrated (unknown original provenance)
-    "embedding_recovery": 30.0,     # Recovered from pending queue
+    "session_extraction": 60.0,  # Conversation content — slow decay
+    "deep_reflection": 45.0,  # Strategic insights
+    "reflection": 30.0,  # Routine observations
+    "surplus_promotion": 60.0,  # Promoted research findings
+    "retrospective": 45.0,  # Session retrospectives
+    "auto_memory_harvest": 30.0,  # Automated extractions
+    "fts5_reindex": 30.0,  # Migrated (unknown original provenance)
+    "embedding_recovery": 30.0,  # Recovered from pending queue
 }
 _DEFAULT_HALF_LIFE = 30.0
 _MAX_HALF_LIFE = 120.0
@@ -66,9 +98,7 @@ def compute_activation(
             activation-aware carryforward: recently-retrieved memories
             decay more slowly even if they were created long ago.
     """
-    now_dt = (
-        datetime.fromisoformat(now) if now else datetime.now(UTC)
-    )
+    now_dt = datetime.fromisoformat(now) if now else datetime.now(UTC)
     created_dt = datetime.fromisoformat(created_at)
     if created_dt.tzinfo is None:
         created_dt = created_dt.replace(tzinfo=UTC)
@@ -99,9 +129,15 @@ def compute_activation(
     access_freq = min(1.0, math.log(1 + retrieved_count) / math.log(1 + 20))
     connectivity = min(1.0, math.log(1 + link_count) / math.log(1 + 10))
     class_weight = CLASS_WEIGHTS.get(memory_class, 1.0)
-    # Floor of 0.6 ensures never-retrieved memories aren't unfairly penalized
-    # (cold-start problem). Coefficients sum to 1.0 at maximum.
-    final = confidence * recency * (0.6 + 0.25 * access_freq + 0.15 * connectivity) * class_weight
+    # Base floor (default 0.6) ensures never-retrieved memories aren't unfairly
+    # penalized (cold-start problem). Coefficients sum to 1.0 at maximum with
+    # the shipped defaults; the blend is a B5 learned knob (see _load_blend).
+    final = (
+        confidence
+        * recency
+        * (_BLEND_BASE + _BLEND_ACCESS * access_freq + _BLEND_CONNECTIVITY * connectivity)
+        * class_weight
+    )
 
     return ActivationScore(
         memory_id="",

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -208,7 +208,8 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             pruned = await _vh.prune_old_transcripts(rt._db)
             idle_cutoff = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
             healed = await _sessions.complete_orphaned_voice_sessions(
-                rt._db, idle_before=idle_cutoff,
+                rt._db,
+                idle_before=idle_cutoff,
             )
             swept = 0
             if rt._memory_store is not None:
@@ -1185,6 +1186,19 @@ async def init(rt: GenesisRuntime) -> None:
             max_instances=1,
             misfire_grace_time=3600,
         )
+
+        # WS-2 B5 substrate: re-sync DB-backed learned knobs from the knob
+        # file at startup (file = source of truth; a fresh/restored DB
+        # re-converges here). Best-effort — never blocks learning init; no-op
+        # while the overlay has no entries (v1 propose-only, nothing writes
+        # autonomously).
+        if rt._db is not None:
+            try:
+                from genesis.ledger.learned_knobs import apply_learned_knobs_to_db
+
+                await apply_learned_knobs_to_db(rt._db)
+            except Exception:
+                logger.warning("learned-knob startup apply failed", exc_info=True)
 
         async def _reap_activity_log() -> None:
             if rt._activity_tracker is None:

--- a/tests/test_ledger/test_learned_knobs.py
+++ b/tests/test_ledger/test_learned_knobs.py
@@ -340,3 +340,84 @@ class TestStartupApplier:
             "SELECT current_weight FROM signal_weights WHERE signal_name='test_signal'"
         )
         assert (await cursor.fetchone())["current_weight"] == pytest.approx(0.51)
+
+
+# ---------------------------------------------------------------------------
+# Rollback resync hook (F2/F3 — ledger rollback re-converges consumers)
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackResync:
+    async def test_first_write_rollback_restores_db_from_metadata(self, db, knob_paths):
+        """Rolling back the FIRST knob write deletes the overlay (no
+        pre-image) — the DB row must still re-converge, via the ledger row's
+        recorded metadata.previous, not stay drifted forever."""
+        from genesis.learning.cognitive_ledger import rollback
+
+        mod_id = await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.44)
+        result = await rollback(db, mod_id)
+        assert result["ok"] is True
+        assert not knob_paths["overlay"].exists()  # first write → file removed
+        assert "restored to previous" in result["knob_resync"]
+        cursor = await db.execute(
+            "SELECT threshold FROM depth_thresholds WHERE depth_name='Deep'"
+        )
+        assert (await cursor.fetchone())["threshold"] == pytest.approx(0.45)
+
+    async def test_later_write_rollback_resyncs_via_applier(self, db, knob_paths):
+        from genesis.learning.cognitive_ledger import rollback
+
+        await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.44)
+        second = await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.43)
+        result = await rollback(db, second)
+        assert result["ok"] is True
+        assert result["knob_resync"].startswith("resynced (1 from file")
+        cursor = await db.execute(
+            "SELECT threshold FROM depth_thresholds WHERE depth_name='Deep'"
+        )
+        assert (await cursor.fetchone())["threshold"] == pytest.approx(0.44)
+
+    async def test_baseline_not_repinned_after_first_write_rollback(self, db, knob_paths):
+        """The re-pin drift hole: after first-write rollback the next apply
+        must see the ORIGINAL value as baseline (0.45), not a drifted one."""
+        from genesis.learning.cognitive_ledger import rollback
+
+        mod_id = await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.44)
+        await rollback(db, mod_id)
+        # DB is back at 0.45; a fresh apply pins baseline 0.45 again
+        await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.46)
+        overlay = yaml.safe_load(knob_paths["overlay"].read_text())
+        assert overlay["knobs"]["awareness.depth_thresholds.Deep"]["baseline"] == 0.45
+
+    async def test_non_knob_rollback_untouched(self, db, tmp_path):
+        """Rollback of a non-ws2_effector row must not carry knob_resync."""
+        from genesis.learning.cognitive_ledger import record_file_modification, rollback
+
+        target = tmp_path / "other.md"
+        mod_id = await record_file_modification(
+            db, actor="skill_evolution", path=target, new_content="hello"
+        )
+        result = await rollback(db, mod_id)
+        assert result["ok"] is True
+        assert "knob_resync" not in result
+
+
+# ---------------------------------------------------------------------------
+# Depth absolute clamp (F4)
+# ---------------------------------------------------------------------------
+
+
+class TestDepthClamp:
+    async def test_hand_edited_out_of_domain_threshold_clamped(self, db, knob_paths):
+        """A self-attested baseline can pass the relative bound with an
+        absurd absolute value — the sync path clamps to (0, 1]."""
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {"knobs": {"awareness.depth_thresholds.Deep": {"baseline": 10.0, "current": 9.0}}}
+            )
+        )
+        await lk.apply_learned_knobs_to_db(db)
+        cursor = await db.execute(
+            "SELECT threshold FROM depth_thresholds WHERE depth_name='Deep'"
+        )
+        assert (await cursor.fetchone())["threshold"] == pytest.approx(1.0)

--- a/tests/test_ledger/test_learned_knobs.py
+++ b/tests/test_ledger/test_learned_knobs.py
@@ -1,0 +1,342 @@
+"""WS-2 B5 knob substrate — registry, bounds, ledgered writes, applier, seam.
+
+All fixtures synthetic (tmp_path files + in-memory DB). The trigger scan is
+deliberately absent (substrate-only v1) — these tests pin the substrate
+contracts the future trigger will call into.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+import yaml
+
+from genesis.db.schema import create_all_tables
+from genesis.ledger import learned_knobs as lk
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    await conn.execute(
+        "INSERT INTO signal_weights (signal_name, source_mcp, current_weight,"
+        " initial_weight, min_weight, max_weight, feeds_depths)"
+        " VALUES ('test_signal', 'test', 0.5, 0.5, 0.0, 1.0, '[\"Deep\"]')"
+    )
+    await conn.execute(
+        "INSERT OR REPLACE INTO depth_thresholds (depth_name, threshold,"
+        " floor_seconds, ceiling_count, ceiling_window_seconds)"
+        " VALUES ('Deep', 0.45, 60, 10, 3600)"
+    )
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def knob_paths(tmp_path, monkeypatch):
+    """Isolate base file + overlay dir under tmp_path."""
+    base_dir = tmp_path / "config"
+    base_dir.mkdir()
+    base = base_dir / "learned_knobs.yaml"
+    base.write_text("knobs: {}\n")
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()
+    monkeypatch.setattr(lk, "_base_path", lambda: base)
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: user_dir)
+    return {"base": base, "overlay": user_dir / "learned_knobs.local.yaml"}
+
+
+# ---------------------------------------------------------------------------
+# Registry + loader
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("awareness.signal_weights.test_signal", ("signal_weights", "test_signal")),
+            ("awareness.depth_thresholds.Deep", ("depth_thresholds", "Deep")),
+            ("memory.activation_blend.base", ("activation_blend", "base")),
+            ("memory.activation_blend.connectivity", ("activation_blend", "connectivity")),
+        ],
+    )
+    def test_valid_keys(self, key, expected):
+        assert lk.parse_knob_key(key) == expected
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "awareness.depth_thresholds.deep",  # case-sensitive
+            "awareness.depth_thresholds.Bogus",
+            "memory.activation_blend.recency",  # not a blend component
+            "routing.some_knob",  # not a group
+            "awareness.signal_weights",  # missing name
+            "",
+        ],
+    )
+    def test_invalid_keys_rejected(self, key):
+        assert lk.parse_knob_key(key) is None
+
+
+class TestLoader:
+    def test_empty_registry(self, knob_paths):
+        assert lk.load_knobs() == {}
+
+    def test_overlay_merges_over_base(self, knob_paths):
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {"knobs": {"awareness.depth_thresholds.Deep": {"baseline": 0.45, "current": 0.44}}}
+            )
+        )
+        knobs = lk.load_knobs()
+        assert knobs["awareness.depth_thresholds.Deep"]["current"] == 0.44
+
+    def test_unregistered_and_malformed_ignored(self, knob_paths):
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {
+                    "knobs": {
+                        "routing.bogus": {"baseline": 1, "current": 2},
+                        "memory.activation_blend.base": "not-a-dict",
+                    }
+                }
+            )
+        )
+        assert lk.load_knobs() == {}
+
+
+# ---------------------------------------------------------------------------
+# Bounds validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidateChange:
+    def test_ok_within_bounds(self):
+        assert lk.validate_change(baseline=0.5, current=0.5, new_value=0.52) == []
+
+    def test_step_violation(self):
+        errors = lk.validate_change(baseline=0.5, current=0.5, new_value=0.54)
+        assert any("step" in e for e in errors)
+
+    def test_cumulative_violation_across_steps(self):
+        # each step small, but drift from baseline beyond 20%
+        errors = lk.validate_change(baseline=0.5, current=0.6, new_value=0.62)
+        assert any("cumulative" in e for e in errors)
+
+    def test_nonpositive_baseline_rejected(self):
+        assert lk.validate_change(baseline=0.0, current=0.1, new_value=0.1)
+
+
+# ---------------------------------------------------------------------------
+# activation_blend + seam
+# ---------------------------------------------------------------------------
+
+
+class TestActivationBlend:
+    def test_defaults_without_file(self, knob_paths):
+        assert lk.activation_blend() == lk.BLEND_DEFAULTS
+
+    def test_override_within_bounds_applied(self, knob_paths):
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {"knobs": {"memory.activation_blend.base": {"baseline": 0.6, "current": 0.58}}}
+            )
+        )
+        assert lk.activation_blend()["base"] == 0.58
+
+    def test_out_of_bounds_override_ignored(self, knob_paths):
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {"knobs": {"memory.activation_blend.base": {"baseline": 0.6, "current": 0.9}}}
+            )
+        )
+        assert lk.activation_blend()["base"] == 0.6
+
+    def test_activation_module_seam_reload(self, knob_paths):
+        from genesis.memory import activation
+
+        try:
+            knob_paths["overlay"].write_text(
+                yaml.safe_dump(
+                    {"knobs": {"memory.activation_blend.base": {"baseline": 0.6, "current": 0.62}}}
+                )
+            )
+            activation.reload_blend()
+            assert activation._BLEND_BASE == 0.62
+            # scoring consumes the reloaded value (never-retrieved memory:
+            # blend base is the floor coefficient)
+            score = activation.compute_activation(1.0, "2026-01-01T00:00:00+00:00", 0, 0)
+            assert score.final_score > 0
+        finally:
+            knob_paths["overlay"].unlink(missing_ok=True)
+            activation.reload_blend()
+            assert activation._BLEND_BASE == 0.6
+
+    def test_seam_falls_back_on_loader_failure(self, monkeypatch):
+        from genesis.memory import activation
+
+        def _boom():
+            raise RuntimeError("loader broken")
+
+        monkeypatch.setattr("genesis.ledger.learned_knobs.activation_blend", _boom)
+        try:
+            activation.reload_blend()
+            assert activation._BLEND_BASE == 0.6
+            assert activation._BLEND_ACCESS == 0.25
+            assert activation._BLEND_CONNECTIVITY == 0.15
+        finally:
+            monkeypatch.undo()
+            activation.reload_blend()
+
+
+# ---------------------------------------------------------------------------
+# apply_knob_change (the ledgered write path)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyKnobChange:
+    async def test_signal_knob_end_to_end(self, db, knob_paths):
+        mod_id = await lk.apply_knob_change(
+            db, "awareness.signal_weights.test_signal", 0.52, reason="unit"
+        )
+        assert mod_id is not None
+        # overlay written to the USER dir (never the repo tree), entry pinned
+        overlay = yaml.safe_load(knob_paths["overlay"].read_text())
+        entry = overlay["knobs"]["awareness.signal_weights.test_signal"]
+        assert entry == {"baseline": 0.5, "current": 0.52}
+        # DB synced through the clamped CRUD
+        cursor = await db.execute(
+            "SELECT current_weight FROM signal_weights WHERE signal_name='test_signal'"
+        )
+        assert (await cursor.fetchone())["current_weight"] == pytest.approx(0.52)
+        # cognitive-ledger row recorded with the ws2_effector actor
+        cursor = await db.execute(
+            "SELECT actor FROM cognitive_file_modifications WHERE id = ?", (mod_id,)
+        )
+        assert (await cursor.fetchone())["actor"] == "ws2_effector"
+
+    async def test_depth_knob_baseline_captured_from_live(self, db, knob_paths):
+        await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.44)
+        overlay = yaml.safe_load(knob_paths["overlay"].read_text())
+        entry = overlay["knobs"]["awareness.depth_thresholds.Deep"]
+        assert entry["baseline"] == 0.45  # live value at first apply, pinned
+        cursor = await db.execute("SELECT threshold FROM depth_thresholds WHERE depth_name='Deep'")
+        assert (await cursor.fetchone())["threshold"] == pytest.approx(0.44)
+
+    async def test_second_step_uses_pinned_baseline(self, db, knob_paths):
+        await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.44)
+        # next step measured against pinned baseline 0.45, current 0.44
+        with pytest.raises(ValueError, match="step"):
+            await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.48)
+
+    async def test_unregistered_key_raises(self, db, knob_paths):
+        with pytest.raises(ValueError, match="closed registry"):
+            await lk.apply_knob_change(db, "routing.bogus", 0.5)
+
+    async def test_unknown_signal_raises(self, db, knob_paths):
+        with pytest.raises(ValueError, match="unknown signal"):
+            await lk.apply_knob_change(db, "awareness.signal_weights.nope", 0.5)
+
+    async def test_step_bound_enforced(self, db, knob_paths):
+        with pytest.raises(ValueError, match="step"):
+            await lk.apply_knob_change(db, "awareness.signal_weights.test_signal", 0.6)
+
+    async def test_blend_knob_pokes_activation_reload(self, db, knob_paths):
+        from genesis.memory import activation
+
+        try:
+            await lk.apply_knob_change(db, "memory.activation_blend.base", 0.61)
+            assert activation._BLEND_BASE == 0.61
+        finally:
+            knob_paths["overlay"].unlink(missing_ok=True)
+            activation.reload_blend()
+
+    async def test_rollback_restores_prior_file(self, db, knob_paths):
+        from genesis.learning.cognitive_ledger import rollback
+
+        first = await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.44)
+        assert first is not None
+        second = await lk.apply_knob_change(db, "awareness.depth_thresholds.Deep", 0.43)
+        assert second is not None
+        result = await rollback(db, second)
+        assert result["ok"] is True
+        overlay = yaml.safe_load(knob_paths["overlay"].read_text())
+        assert overlay["knobs"]["awareness.depth_thresholds.Deep"]["current"] == 0.44
+        # re-sync converges DB back to the rolled-back file
+        applied = await lk.apply_learned_knobs_to_db(db)
+        assert applied == 1
+        cursor = await db.execute("SELECT threshold FROM depth_thresholds WHERE depth_name='Deep'")
+        assert (await cursor.fetchone())["threshold"] == pytest.approx(0.44)
+
+
+# ---------------------------------------------------------------------------
+# Startup applier
+# ---------------------------------------------------------------------------
+
+
+class TestStartupApplier:
+    async def test_empty_file_applies_nothing(self, db, knob_paths):
+        assert await lk.apply_learned_knobs_to_db(db) == 0
+
+    async def test_db_backed_entries_applied(self, db, knob_paths):
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {
+                    "knobs": {
+                        "awareness.signal_weights.test_signal": {"baseline": 0.5, "current": 0.53},
+                        "awareness.depth_thresholds.Deep": {"baseline": 0.45, "current": 0.46},
+                        "memory.activation_blend.base": {"baseline": 0.6, "current": 0.62},
+                    }
+                }
+            )
+        )
+        applied = await lk.apply_learned_knobs_to_db(db)
+        assert applied == 2  # blend entry needs no DB sync
+        cursor = await db.execute(
+            "SELECT current_weight FROM signal_weights WHERE signal_name='test_signal'"
+        )
+        assert (await cursor.fetchone())["current_weight"] == pytest.approx(0.53)
+        cursor = await db.execute("SELECT threshold FROM depth_thresholds WHERE depth_name='Deep'")
+        assert (await cursor.fetchone())["threshold"] == pytest.approx(0.46)
+
+    async def test_out_of_bounds_entry_skipped(self, db, knob_paths):
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {
+                    "knobs": {
+                        "awareness.signal_weights.test_signal": {"baseline": 0.5, "current": 0.9},
+                    }
+                }
+            )
+        )
+        assert await lk.apply_learned_knobs_to_db(db) == 0
+        cursor = await db.execute(
+            "SELECT current_weight FROM signal_weights WHERE signal_name='test_signal'"
+        )
+        assert (await cursor.fetchone())["current_weight"] == pytest.approx(0.5)  # untouched
+
+    async def test_sql_clamp_still_backstops(self, db, knob_paths):
+        # A file value inside ±20% of baseline but outside the row's min/max
+        # is clamped by the CRUD (defense in depth). Tighten the row's max:
+        await db.execute(
+            "UPDATE signal_weights SET max_weight = 0.51 WHERE signal_name='test_signal'"
+        )
+        await db.commit()
+        knob_paths["overlay"].write_text(
+            yaml.safe_dump(
+                {
+                    "knobs": {
+                        "awareness.signal_weights.test_signal": {"baseline": 0.5, "current": 0.55},
+                    }
+                }
+            )
+        )
+        await lk.apply_learned_knobs_to_db(db)
+        cursor = await db.execute(
+            "SELECT current_weight FROM signal_weights WHERE signal_name='test_signal'"
+        )
+        assert (await cursor.fetchone())["current_weight"] == pytest.approx(0.51)


### PR DESCRIPTION
## WS-2 P4b — B5 knob substrate (design §5.3, SUBSTRATE ONLY)

The three cognitive knob groups become one auditable, bounded, ledgered surface. **The deterministic calibration trigger is deliberately NOT built** — no v1 calibration lane grades awareness/memory behavior, so it would be structurally dormant and a knob→cell mapping to not-yet-existing domains risks the silent writer/grader mismatch class (§1.2) that started WS-2. It lands with the lane that gives it evidence (tabled record at merge).

### What ships
- **Closed registry** (`genesis/ledger/learned_knobs.py`): `awareness.signal_weights.<name>` (baseline = row `initial_weight`, SQL-clamped CRUD), `awareness.depth_thresholds.<Micro|Light|Deep|Strategic>` (baseline captured at first apply, pinned), `memory.activation_blend.<base|access|connectivity>` (baseline = shipped 0.6/0.25/0.15). Anything else is ignored loudly.
- **File model (immunity split)**: repo base `config/learned_knobs.yaml` = documentation + empty registry, NEVER machine-written; learned entries live in `~/.genesis/config/learned_knobs.local.yaml`. Writes go to the user dir **unconditionally** (cfg-001 — the generic overlay resolver's repo-sibling fallback would have put the first-ever write inside the repo tree).
- **Ledgered writes**: `apply_knob_change` validates registry membership + bounds (≤5% of baseline per step, ≤±20% cumulative — validator-enforced per §5.3), writes the overlay via `cognitive_ledger.record_file_modification` (actor `ws2_effector` — pre-image, drift-guarded rollback, MCP rollback tool inherited), then syncs the consumer (DB row / activation seam).
- **Startup applier** (learning init, best-effort): re-syncs DB-backed entries from file — file is source of truth, a fresh/restored DB re-converges; out-of-bounds entries skipped loudly; SQL clamps backstop.
- **Activation seam**: `memory/activation.py` reads the blend via a module-level load (hot path — zero per-call file I/O) + `reload_blend()`; per-component fallback to shipped constants; out-of-bounds file values ignored at the loader too (defense against hand-edits).

### Tests (34 new, all synthetic)
Registry matrix, loader merge/ignore, bounds matrix, activation seam (override/ignore/reload/fallback), apply E2E (overlay written to user dir + DB synced + `ws2_effector` ledger row), pinned-baseline second-step enforcement, **full rollback round-trip** (apply → apply → ledger rollback → file restored → re-sync converges DB), startup applier (empty/applied/out-of-bounds-skip/SQL-clamp backstop). Neighboring suites: test_ledger + test_memory/test_activation + test_learning/test_cognitive_ledger = 145 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)