### PR TITLE
docs(memory): clean up churn artifacts from the #1169 proactive-hook review

### DIFF
--- a/.claude/docs/proactive-memory-hook.md
+++ b/.claude/docs/proactive-memory-hook.md
@@ -31,8 +31,9 @@ The endpoint path also re-applies the two content-quality guards the old fork
 had (they were hook-only, never in the shared `memory_proactive` MCP tool):
 malformed rows (`provenance.is_garbage` — raw JSON observation blobs, YAML
 frontmatter, NULL) and non-intentional `knowledge_base` hits (only
-`extraction_job`/`knowledge_ingest`/`knowledge_ingest_source`/`reference_store`
-survive; the collection is otherwise majority surplus/recon crawl). These run
+`extraction_job`/`knowledge_ingest`/`knowledge_ingest_source`/`reference_store`/
+`curated` — the dashboard file/URL upload pipeline — survive; the collection is
+otherwise majority surplus/recon crawl). These run
 inside `_proactive_impl` (gated by a `filter_noise` flag the endpoint sets and
 the MCP tool leaves off) — in the backfill loop and before external-content
 wrapping, so a dropped noisy hit is replaced by the next safe candidate and the

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -828,12 +828,15 @@ async def _proactive_impl(
     context the ranked top-K missed, so trimming the total to ``limit`` would
     displace the organic results expansion is meant to supplement.
 
-    Backs both the ``memory_proactive`` MCP tool (rerank off, no extra terms)
-    and the genesis-server proactive recall endpoint (rerank + file-context
-    terms per config). ``rerank``/``extra_fts_terms`` are the ONLY behavioral
-    knobs; every security stage (memory_operation filter, injection-defense
-    wrap, gate-4 enforce-drop, graph expansion, immunity emit) is shared, so
-    both callers get identical protection with no duplicated orchestration.
+    Backs both the ``memory_proactive`` MCP tool (rerank off, no extra terms,
+    no noise filter, no KB cap) and the genesis-server proactive recall endpoint
+    (rerank + file-context terms + ``filter_noise`` + ``kb_slots`` per config).
+    The shared security stages (memory_operation filter, injection-defense wrap,
+    gate-4 enforce-drop, graph expansion, immunity emit) run for both callers.
+    The endpoint is DELIBERATELY stricter on injection QUALITY: ``filter_noise``
+    drops garbage + non-intentional knowledge_base and ``kb_slots`` caps KB — so
+    the two callers do NOT get identical injected results; the MCP tool is
+    intentionally left unfiltered. No duplicated orchestration.
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
@@ -847,12 +850,15 @@ async def _proactive_impl(
         """Proactive noise (garbage / non-intentional KB), endpoint-gated."""
         return filter_noise and is_proactive_noise(r.collection, r.source_pipeline, r.content)
 
-    # skip_writeback: an item the loop below will DROP must not gain
-    # retrieved_count/activation credit from this recall — otherwise blocked
-    # external content (enforce-drop) or filtered noise (garbage / non-intentional
-    # KB) farms ranking energy from every session that matches it while never
-    # being delivered (Codex #1048 P2 + Codex #1169). Same predicates as the drop
-    # loop; fail-open (predicate error -> normal write-backs).
+    # skip_writeback: an item the loop below DROPS for a content reason must not
+    # gain retrieved_count/activation credit — otherwise blocked external content
+    # (enforce-drop) or filtered noise (garbage / non-intentional KB) farms
+    # ranking energy from every session that matches it while never being
+    # delivered (Codex #1048 P2 + Codex #1169). Mirrors the enforce-drop + noise
+    # predicates ONLY: a KB-slot-CAP drop below deliberately KEEPS its write-back
+    # credit (it was legitimately retrieved, merely over the display budget —
+    # unlike blocked/garbage content). fail-open (predicate error -> normal
+    # write-backs).
     results = await memory_mod._retriever.recall(
         current_message,
         limit=limit * 2,
@@ -895,6 +901,11 @@ async def _proactive_impl(
         # sees RAW content) and inside THIS backfill loop (so a dropped noisy
         # top-K item is replaced by the next safe candidate, not left as a hole).
         # Restores the pre-flip hook's guards; fixes Codex P2 on #1169.
+        # NOTE: this guard + the KB-slot cap below sit UPSTREAM of the gate-4
+        # enforce accounting, so items they drop are intentionally NOT counted in
+        # the immunity block-ledger — a dedicated quality filter already removed
+        # them before they could reach the prompt; the ledger measures enforce-
+        # gate activity (delivered-blockable + enforce-dropped), not quality drops.
         if _is_noise(r):
             continue
         # KB slot cap IN the backfill loop (endpoint sets kb_slots; the MCP tool

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -443,8 +443,6 @@ async def _breadcrumbs(db: Any, dicts: list[dict]) -> None:
 # H-1 working-set shadow projection (post-selection, degraded).
 # ---------------------------------------------------------------------------
 
-_SERENDIPITY_BOOST = 1.3  # documented for parity; not applied post-selection
-
 
 def _shadow_projection(dicts: list[dict], suppress_ids: frozenset[str]) -> dict:
     """Project the PR2b novelty gate over the DELIVERED set (H-1 measurement).


### PR DESCRIPTION
Post-merge self-review cleanup of #1169 (the proactive-hook thin-client flip).

A proper `code-review` pass on the merged code — the one I should have run before
merging rather than letting the 6-round bot cycle drive — found **no correctness
bugs** (both loops symmetric, filters/backfill/skip-writeback correct, all hook
paths sound, backed by live E2E) but real **doc/comment cruft** left by the
reactive churn. **No behavior change** — comments, one doc line, one dead constant:

- `_proactive_impl` docstring falsely claimed rerank/extra_fts_terms were "the
  ONLY behavioral knobs" and both callers get "identical protection" (both false
  after `filter_noise` + `kb_slots`; the endpoint is deliberately stricter).
- `skip_writeback` "Same predicates as the drop loop" over-promised — it mirrors
  enforce-drop + noise only; a KB-slot-cap drop intentionally keeps write-back
  credit. Clarified.
- Noted that noise + KB-cap drops sit upstream of the gate-4 enforce accounting
  and are intentionally not in the immunity block-ledger.
- Removed the dead `_SERENDIPITY_BOOST` constant (unused since the in-hook
  `_shadow_gate` was deleted).
- `.claude/docs/proactive-memory-hook.md`: added `curated` to the intentional-KB
  allowlist list (code has 5 pipelines, the doc listed 4).

54 targeted tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)