### PR TITLE
fix(dr): DR integrity core — round-trip verify, backup/restore mutex, freshness gate (SF3/SF4/SF5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,19 +140,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
-- **Backups now prove they're restorable, can't collide with a restore, and
-  never re-badge stale data as fresh.** Three disaster-recovery integrity fixes
-  (deploy-script audit SF3/SF4/SF5): the 6-hourly backup now decrypt-verifies
-  the SQL archive with the passphrase a recovery box would actually use (a
-  rotated-but-not-escrowed passphrase pages immediately instead of surfacing at
-  disaster time); backup and restore share a lock so the timer can never
-  snapshot a half-restored database (a backup skips quietly, a restore waits
-  then says who's holding the lock); and the off-site dated snapshot only ever
-  contains payloads regenerated that run — a Qdrant outage now fails the backup
-  loudly (previously it read as "collection may not exist" and reported success
-  forever) instead of silently shipping the previous run's files under a fresh
-  timestamp. All off-site operations are also time-bounded, so a hung NAS mount
-  degrades to a partial-backup alert instead of wedging backups indefinitely.
+- **Backups now verify the database archive is restorable, can't collide with a
+  restore, and never re-badge stale data as fresh.** Three disaster-recovery
+  integrity fixes: the 6-hourly backup now decrypt-verifies the SQLite archive
+  with the passphrase a recovery box would actually use, so a
+  rotated-but-not-re-escrowed passphrase is caught immediately (and the fresh
+  copy is held out of the off-site snapshot until re-escrowed) instead of
+  surfacing at disaster time; backup and restore share a lock so the timer can
+  never snapshot a half-restored database (a backup skips quietly, a restore
+  waits then says who's holding the lock); and the off-site snapshot only ever
+  contains payloads regenerated that run — a reachable collection that fails to
+  snapshot now fails the backup loudly instead of silently shipping the previous
+  run's copy under a fresh timestamp (a genuinely absent or unreachable vector
+  store degrades gracefully, since it rebuilds from the database). All off-site
+  operations are time-bounded, so a hung network mount degrades to a
+  partial-backup alert instead of wedging backups indefinitely.
 
 - **The dashboard no longer shows a false "degraded / sentinel stale" during an
   update.** While `update.sh` restarts the server, the freshly booted server's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Backups now prove they're restorable, can't collide with a restore, and
+  never re-badge stale data as fresh.** Three disaster-recovery integrity fixes
+  (deploy-script audit SF3/SF4/SF5): the 6-hourly backup now decrypt-verifies
+  the SQL archive with the passphrase a recovery box would actually use (a
+  rotated-but-not-escrowed passphrase pages immediately instead of surfacing at
+  disaster time); backup and restore share a lock so the timer can never
+  snapshot a half-restored database (a backup skips quietly, a restore waits
+  then says who's holding the lock); and the off-site dated snapshot only ever
+  contains payloads regenerated that run — a Qdrant outage now fails the backup
+  loudly (previously it read as "collection may not exist" and reported success
+  forever) instead of silently shipping the previous run's files under a fresh
+  timestamp. All off-site operations are also time-bounded, so a hung NAS mount
+  degrades to a partial-backup alert instead of wedging backups indefinitely.
+
 - **The dashboard no longer shows a false "degraded / sentinel stale" during an
   update.** While `update.sh` restarts the server, the freshly booted server's
   sentinel heartbeat is briefly empty, which used to paint the Services card

--- a/SETUP.md
+++ b/SETUP.md
@@ -156,6 +156,24 @@ use crontab.
 > crontab -l | grep -v 'scripts/backup.sh' | crontab -
 > ```
 
+### Backup ↔ restore mutual exclusion
+
+`backup.sh` and `restore.sh` coordinate through a single lock
+(`~/.genesis/locks/backup-restore.lock`) so the 6-hourly timer can never
+snapshot a database that a restore is mid-way through rebuilding:
+
+- A **backup** that finds the lock held (a restore is running) **skips** that
+  run — it logs `SKIPPED: backup-restore lock held …` to the journal and exits
+  cleanly. The next scheduled run backs up normally. (The dashboard's Backup
+  status keeps showing the prior run until then.)
+- A **restore** that finds the lock held (a backup is running) **waits** up to
+  `GENESIS_RESTORE_LOCK_WAIT` seconds (default **300**), then aborts naming the
+  holder. A first full off-site backup can take longer than 300s, so for an
+  unattended disaster-recovery restore during a backup window, raise it:
+  ```bash
+  GENESIS_RESTORE_LOCK_WAIT=1800 scripts/restore.sh …
+  ```
+
 ## Verify Installation
 
 ```bash

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -59,16 +59,15 @@ fi
 # update.sh invokes this script AS its pre-update backup while the dashboard
 # orchestrator holds that marker; honoring it would silently skip every
 # pre-deploy backup while update.sh prints "Backup complete".
-_LOCK_DIR="$HOME/.genesis/locks"
-_LOCK_FILE="$_LOCK_DIR/backup-restore.lock"
-mkdir -p "$_LOCK_DIR"
-exec 200>>"$_LOCK_FILE"
-if ! flock -n 200; then
-    _holder="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
+# shellcheck source=scripts/lib/dr_lock.sh
+source "$_SCRIPT_DIR/lib/dr_lock.sh"
+dr_lock_open
+if ! flock -n "$DR_LOCK_FD"; then
+    _holder="$(cat "$DR_LOCK_FILE" 2>/dev/null || true)"
     echo "[genesis-backup] $(date -Iseconds) SKIPPED: backup-restore lock held by ${_holder:-unknown} — backup not run"
     exit 0
 fi
-printf '%s backup %s\n' "$$" "$(date -Iseconds)" > "$_LOCK_FILE"
+dr_lock_stamp backup
 
 # ── Status tracking ──────────────────────────────────────────────────
 _STATUS_FILE="$HOME/.genesis/backup_status.json"
@@ -84,9 +83,11 @@ _FAILURE_REASON=""
 # off-site dated snapshot — a leftover .gpg from a prior run must never be
 # re-badged under a fresh COMPLETE stamp (it silently misrepresents recency,
 # and GFS retention then ages out the snapshots holding genuinely-fresh data).
-_SQL_FRESH=false
+_SQL_FRESH=false        # SQL dump regenerated (encrypted) this run
+_SQL_RESTORABLE=false   # AND round-trip-verified → eligible for off-site COMPLETE
+_SQL_ESCROW_DRIFT=false # env-decryptable but escrow stale → off-site DR degraded
 _QDRANT_FRESH=""    # space-separated collections snapshotted+encrypted this run
-_QDRANT_FAILED=""   # collections that EXIST but failed to snapshot this run
+_QDRANT_FAILED=""   # collections that EXIST (HTTP 200) but failed to snapshot this run
 # Tier-1 replication: true once the local repo is in sync with the GitHub remote.
 _TIER1_PUSHED=false
 # Off-site snapshot bookkeeping. _T2_SNAPSHOT_COUNT / _T2_PRUNED stay UNSET until
@@ -193,6 +194,78 @@ encrypt_file() {
         --symmetric --cipher-algo AES256 -o "$dst" "$src" 2>/dev/null
 }
 
+# Git network ops run while the backup↔restore lock is held for the whole run,
+# so an unbounded stall (half-open TCP to the remote — kernel retransmit can
+# hang 10-15min) would block a concurrent DR restore past its wait. Bound them
+# (named failure: stalled push/pull/clone holding the DR lock). GENESIS-
+# overridable for slow links; -k SIGKILLs a SIGTERM-ignoring git.
+_GIT_NET_TIMEOUT="${GENESIS_BACKUP_GIT_TIMEOUT:-300}"
+_git_net() { timeout -k 10 "$_GIT_NET_TIMEOUT" git "$@"; }
+
+# _roundtrip_ok <passphrase> <artifact.gpg> [stderr_file] — decrypt-verify that
+# <artifact.gpg> decrypts with <passphrase> AND ends with the sqlite `.dump`
+# success marker `COMMIT;` (a mid-dump failure ends `ROLLBACK; -- due to
+# errors`). Returns 0 on verified, 1 otherwise. Streams (no plaintext temp).
+# Captures the decrypt tail into a var FIRST so `grep -q` matching early can't
+# SIGPIPE `tail` and flip the pipeline non-zero under pipefail on a good dump.
+_roundtrip_ok() {
+    local _pass="$1" _art="$2" _errf="${3:-/dev/null}" _tailf _rc _grc
+    _tailf=$(mktemp -p "$GENESIS_BIG_TMP")
+    # Real pipeline (NOT inside $()) so PIPESTATUS reflects gpg's own exit; tail
+    # buffers to a file (not piped into grep) so nothing can SIGPIPE gpg/tail and
+    # flip the result under pipefail. tail -5 reads to EOF, so gpg always runs
+    # fully and its exit at PIPESTATUS[1] (printf=0, gpg=1, tail=2) is authoritative.
+    printf '%s' "$_pass" | gpg --batch --passphrase-fd 0 -d "$_art" 2>"$_errf" | tail -5 > "$_tailf"
+    _rc=${PIPESTATUS[1]}
+    if [ "$_rc" -ne 0 ]; then rm -f "$_tailf"; return 1; fi
+    grep -q '^COMMIT;' "$_tailf"; _grc=$?
+    rm -f "$_tailf"
+    return "$_grc"
+}
+
+# _verify_sql_roundtrip <artifact.gpg> — classify the freshly-encrypted SQL
+# archive's restorability and echo one verdict word:
+#   RESTORABLE — decrypts with the passphrase a DR box would use (escrow if
+#                present, else env). Ships off-site, normal success.
+#   DRIFT      — decrypts with the ENV passphrase but NOT the escrowed one
+#                (secrets.env rotated, escrow stale). The LOCAL backup is fine
+#                (env-decryptable, and secrets.env is itself backed up), so this
+#                is NOT a backup failure — but a real DR box (env gone) decrypts
+#                with escrow and would fail, so the artifact is withheld from the
+#                off-site COMPLETE snapshot and the caller surfaces "re-escrow".
+#   CORRUPT    — does not decrypt with the ENV passphrase it was encrypted with
+#                → the archive is damaged (bad GPG MDC / truncation). Hard fail.
+# Happy path is ONE decrypt (escrow present & matches, or env-only & good); the
+# second decrypt runs only to classify a first-decrypt failure.
+_verify_sql_roundtrip() {
+    local _art="$1" _errf
+    _errf=$(mktemp -p "$GENESIS_BIG_TMP")
+    passphrase_escrow_lookup
+    local _primary="$_BACKUP_PASSPHRASE" _have_escrow=false
+    if [ -n "$ESCROW_PASSPHRASE" ]; then _primary="$ESCROW_PASSPHRASE"; _have_escrow=true; fi
+    if _roundtrip_ok "$_primary" "$_art" "$_errf"; then
+        rm -f "$_errf"
+        echo RESTORABLE
+        return 0
+    fi
+    # Primary failed. If the primary WAS escrow, an env-passphrase success means
+    # drift (artifact good, escrow stale); env failure means genuine corruption.
+    if $_have_escrow && _roundtrip_ok "$_BACKUP_PASSPHRASE" "$_art" /dev/null; then
+        rm -f "$_errf"
+        echo DRIFT
+        return 0
+    fi
+    # Surface the gpg error, sanitized to printable ASCII: _write_status only
+    # escapes quotes/backslashes, so a raw tab/CR/UTF-8 gpg message would make
+    # backup_status.json invalid — and the health consumer's read_text()+
+    # json.loads would then throw UnicodeDecodeError (uncaught → crashes health)
+    # or JSONDecodeError (swallowed → suppresses the very CRITICAL this raises).
+    ROUNDTRIP_DETAIL=$(LC_ALL=C tr -cd '[:print:]' < "$_errf" | cut -c1-200)
+    rm -f "$_errf"
+    echo CORRUPT
+    return 0
+}
+
 # --- Clone or pull backup repo ---
 if [ ! -d "$BACKUP_DIR/.git" ]; then
     # Determine backup repo URL: env var → auto-detect from existing clone → fail
@@ -204,7 +277,7 @@ if [ ! -d "$BACKUP_DIR/.git" ]; then
     fi
     log "Cloning backup repo..."
     mkdir -p "$(dirname "$BACKUP_DIR")"
-    git clone "$BACKUP_REPO" "$BACKUP_DIR"
+    _git_net clone "$BACKUP_REPO" "$BACKUP_DIR"
 fi
 
 cd "$BACKUP_DIR"
@@ -216,7 +289,7 @@ git config user.email "backup@genesis.local" 2>/dev/null || true
 # held backup-restore lock fd and would hold the DR lock past script exit.
 git config gc.autoDetach false 2>/dev/null || true
 
-git pull --rebase --quiet 2>/dev/null || log "WARNING: git pull failed, continuing with local state"
+_git_net pull --rebase --quiet 2>/dev/null || log "WARNING: git pull failed, continuing with local state"
 
 # --- 1. SQLite dump (encrypted — may hold memory-stored credentials/PII) ---
 log "Backing up SQLite database..."
@@ -235,36 +308,36 @@ if [ -f "$DB_FILE" ]; then
             if encrypt_file "$_SQL_TMP" data/genesis.sql.gpg; then
                 _SQL_FRESH=true
                 log "SQLite: $_SQLITE_LINES lines (encrypted)"
-                # SF4 round-trip: prove the artifact DECRYPTS with the
-                # passphrase a DR box would actually use. Prefer the escrowed
-                # copy — env-encrypt + escrow-decrypt is the drift detector
-                # (passphrase rotated in secrets.env with a stale escrow is
-                # undecryptable exactly when secrets.env is lost). No escrow →
-                # verify with the env passphrase (catches archive corruption).
-                # `tail -5 | grep COMMIT;` also catches a bad dump: sqlite3
-                # .dump ends `COMMIT;` on success, `ROLLBACK; -- due to errors`
-                # on a mid-dump failure. Under pipefail any stage failing
-                # (incl. gpg MDC integrity errors) fails the check. gpg stderr
-                # is kept (not discarded) so the alert names the real error.
-                passphrase_escrow_lookup
-                _rt_pass="$_BACKUP_PASSPHRASE"
-                _rt_src="env"
-                if [ -n "$ESCROW_PASSPHRASE" ]; then
-                    _rt_pass="$ESCROW_PASSPHRASE"
-                    _rt_src="escrow ($ESCROW_SOURCE)"
-                fi
-                _rt_err=$(mktemp)
-                if printf '%s' "$_rt_pass" \
-                    | gpg --batch --passphrase-fd 0 -d data/genesis.sql.gpg 2>"$_rt_err" \
-                    | tail -5 | grep -q '^COMMIT;'; then
-                    log "SQLite: round-trip decrypt verified (passphrase source: $_rt_src)"
-                else
-                    _rt_detail=$(head -c 300 "$_rt_err" | tr '\n' ' ')
-                    _FAILURE_REASON="${_FAILURE_REASON:+$_FAILURE_REASON; }SQL round-trip decrypt failed with $_rt_src passphrase (${_rt_detail:-no gpg output}) — backup may be UNRESTORABLE (passphrase drift or corrupt archive)"
-                    log "WARNING: $_FAILURE_REASON"
-                    _SQLITE_LINES=0
-                fi
-                rm -f "$_rt_err"
+                # SF4 round-trip: classify the fresh artifact's restorability
+                # (see _verify_sql_roundtrip). ROUNDTRIP_DETAIL is set (sanitized)
+                # only on CORRUPT. _SQL_RESTORABLE gates the OFF-SITE upload so a
+                # DR box never auto-selects a COMPLETE snapshot it can't decrypt.
+                ROUNDTRIP_DETAIL=""
+                case "$(_verify_sql_roundtrip data/genesis.sql.gpg)" in
+                    RESTORABLE)
+                        _SQL_RESTORABLE=true
+                        log "SQLite: round-trip decrypt verified"
+                        ;;
+                    DRIFT)
+                        # Local backup is fine (env-decryptable + secrets.env is
+                        # itself backed up), so NOT a backup failure — but a real
+                        # DR box decrypts with the stale escrow and would fail, so
+                        # withhold this dump from the off-site COMPLETE snapshot
+                        # (the last-good off-site copy, encrypted under the
+                        # pre-rotation passphrase == the escrow, stays restorable)
+                        # and surface a distinct re-escrow alert via the off-site
+                        # path (never CRITICAL "backup failed").
+                        _SQL_RESTORABLE=false
+                        _SQL_ESCROW_DRIFT=true
+                        log "WARNING: SQL round-trip failed with the ESCROWED passphrase but SUCCEEDED with the env one — escrow is stale (secrets.env rotated?). Local backup OK; off-site DR degraded until re-escrow."
+                        ;;
+                    *)  # CORRUPT
+                        _SQL_RESTORABLE=false
+                        _FAILURE_REASON="${_FAILURE_REASON:+$_FAILURE_REASON; }SQL archive failed round-trip decrypt with its own env passphrase (${ROUNDTRIP_DETAIL:-no gpg output}) — corrupt/unrestorable, withheld from off-site"
+                        log "WARNING: $_FAILURE_REASON"
+                        _SQLITE_LINES=0
+                        ;;
+                esac
             else
                 log "WARNING: SQLite encryption failed"
                 _SQLITE_LINES=0
@@ -298,8 +371,15 @@ for collection in episodic_memory knowledge_base; do
         log "Qdrant: collection $collection does not exist — skipping"
         continue
     elif [ "$_probe_code" != "200" ]; then
-        log "WARNING: Qdrant unreachable probing $collection (HTTP $_probe_code)"
-        _QDRANT_FAILED="$_QDRANT_FAILED $collection(probe:$_probe_code)"
+        # Server unreachable/erroring (000/timeout/5xx) — we CANNOT confirm the
+        # collection exists, so this is NOT the audit's "collections exist but
+        # weren't captured" failure. Qdrant is rebuildable from the (round-trip-
+        # verified) SQLite dump, and restore.sh likewise treats an unreachable
+        # Qdrant as a skip — so degrade gracefully (WARNING, backup still
+        # succeeds) instead of paging CRITICAL every 6h forever on a host where
+        # Qdrant is optional, still booting, or briefly down. Only a REACHABLE
+        # collection (HTTP 200) that then fails to snapshot is a hard failure.
+        log "WARNING: Qdrant unreachable probing $collection (HTTP $_probe_code) — skipping (rebuildable from SQL)"
         continue
     fi
     # Create snapshot via Qdrant API. --max-time 600: snapshot creation is a
@@ -341,7 +421,10 @@ for collection in episodic_memory knowledge_base; do
         rm -f "data/qdrant/${collection}.snapshot"
     fi
 
-    # Clean up snapshot from Qdrant server
+    # Clean up snapshot from Qdrant server. --max-time 60: a local best-effort
+    # DELETE (failure mode: a wedged Qdrant leaves the server-side snapshot to
+    # its own retention — non-fatal, `|| true`); bounded only so a hung server
+    # can't stall the backup here.
     curl -sf --max-time 60 -X DELETE "$QDRANT_URL/collections/$collection/snapshots/$snapshot_name" >/dev/null 2>&1 || true
 done
 # A collection that EXISTS but produced no fresh payload is a backup failure
@@ -599,20 +682,28 @@ else
         fi
     done
 
-    # Upload SQL dump — same freshness gate (SF3, SQL variant). A regenerated
-    # dump whose round-trip FAILED still uploads (_SQL_FRESH is set at encrypt
-    # time): it is the best artifact available — in the escrow-drift case it
-    # decrypts with the env passphrase — and the backup already fails loudly.
-    # Only a NOT-regenerated leftover is excluded.
-    if [ -f data/genesis.sql.gpg ] && $_SQL_FRESH; then
+    # Upload SQL dump — freshness AND restorability gated (SF3 + SF4). The
+    # off-site snapshot is what a fresh DR box auto-selects, so it must only
+    # ever carry a dump that box can actually decrypt: _SQL_RESTORABLE is true
+    # only when the round-trip verified with the DR passphrase (escrow if
+    # present). A stale (not-regenerated) OR round-trip-failed (corrupt, or
+    # escrow-drift → DR box can't decrypt) dump is withheld, forcing NO COMPLETE
+    # this run so restore keeps falling back to the last verified-good snapshot.
+    if [ -f data/genesis.sql.gpg ] && $_SQL_FRESH && $_SQL_RESTORABLE; then
         if backend_put "data/genesis.sql.gpg" "${_T2_DIR}/data/genesis.sql.gpg"; then
             log "  off-site: uploaded genesis.sql.gpg"
         else
             log "WARNING: off-site upload failed for genesis.sql.gpg"
             _T2_OK=false
         fi
+    elif [ -f data/genesis.sql.gpg ] && $_SQL_FRESH; then
+        # Regenerated but not restorable with the DR passphrase — do NOT stamp a
+        # COMPLETE snapshot around an undecryptable/corrupt dump.
+        log "WARNING: genesis.sql.gpg failed round-trip verify — withheld from off-site (no COMPLETE this run; last-good retained)"
+        _T2_OK=false
     elif [ -f data/genesis.sql.gpg ]; then
         log "WARNING: genesis.sql.gpg is stale (not regenerated this run) — excluded from off-site snapshot"
+        _T2_OK=false
     fi
 
     # Upload transcripts (part of the off-site snapshot)
@@ -851,12 +942,25 @@ if [ "${_T2_BACKEND:-none}" != "none" ] && [ "$_T2_STATUS" != "ok" ]; then
     # once off-site recovers (offsite_confirmed flips true) and then fails again.
     _prev_offsite=$(python3 -c "import json; print(json.load(open('$_STATUS_FILE')).get('offsite_confirmed', True))" 2>/dev/null || echo "True")
     if [ "$_prev_offsite" != "False" ]; then
-        _send_telegram "⚠️ *Off-site replication failed*
+        # Escrow drift withheld the SQL dump from the off-site snapshot (the
+        # target is fine — the escrowed passphrase is stale), so name the real
+        # cause + fix instead of pointing at the off-site target.
+        if [ "$_SQL_ESCROW_DRIFT" = true ]; then
+            _send_telegram "⚠️ *Off-site DR degraded — backup passphrase escrow drift*
+
+The local backup is OK (decrypts with the env passphrase), but the ESCROWED
+passphrase a disaster-recovery box would use no longer matches — so the fresh
+SQL dump was withheld from the off-site snapshot (last-good retained).
+Re-escrow the current GENESIS_BACKUP_PASSPHRASE to restore off-site DR.
+Time: $(date -Is)"
+        else
+            _send_telegram "⚠️ *Off-site replication failed*
 
 The local backup is OK, but it was NOT replicated off-site.
 Tier-2 status: ${_T2_STATUS}
 Time: $(date -Is)
 Off-site copies are missing — check the off-site target."
+        fi
     fi
 fi
 log "Backup complete (success=$_SUCCESS)"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -43,6 +43,33 @@ else
     queue_alert() { :; }
 fi
 
+# ── Mutual exclusion (SF5): backup↔restore share one whole-run lock ──
+# Non-blocking: a 6h timer run SKIPS (exit 0) when a restore — or another
+# backup — holds the lock; it must never queue behind a multi-minute DR
+# restore. The skip deliberately does NOT touch backup_status.json: writing
+# success:false would page a false CRITICAL (health `backup:last_failed`)
+# during a legitimate restore, so the prior run's status stays put and the
+# existing `backup:overdue` staleness alert (>8h) detects a wedged holder
+# honestly. That is why this block sits BEFORE the EXIT trap below — a skip
+# must write nothing (log() isn't defined yet either; the echo is inline).
+# The lock fd is held for the script's lifetime and released at exit; the
+# open is APPEND mode so a losing contender never truncates the holder line
+# (only the winner rewrites it, by path, after acquiring).
+# NOTE deliberately NOT checked here: ~/.genesis/update_in_progress.pid —
+# update.sh invokes this script AS its pre-update backup while the dashboard
+# orchestrator holds that marker; honoring it would silently skip every
+# pre-deploy backup while update.sh prints "Backup complete".
+_LOCK_DIR="$HOME/.genesis/locks"
+_LOCK_FILE="$_LOCK_DIR/backup-restore.lock"
+mkdir -p "$_LOCK_DIR"
+exec 200>>"$_LOCK_FILE"
+if ! flock -n 200; then
+    _holder="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
+    echo "[genesis-backup] $(date -Iseconds) SKIPPED: backup-restore lock held by ${_holder:-unknown} — backup not run"
+    exit 0
+fi
+printf '%s backup %s\n' "$$" "$(date -Iseconds)" > "$_LOCK_FILE"
+
 # ── Status tracking ──────────────────────────────────────────────────
 _STATUS_FILE="$HOME/.genesis/backup_status.json"
 _STARTED_AT=$(date +%s)
@@ -53,6 +80,13 @@ _MEMORY_COUNT=0
 _SECRETS_OK=false
 _SUCCESS=false
 _FAILURE_REASON=""
+# SF3 freshness tracking: only payloads regenerated THIS run may enter the
+# off-site dated snapshot — a leftover .gpg from a prior run must never be
+# re-badged under a fresh COMPLETE stamp (it silently misrepresents recency,
+# and GFS retention then ages out the snapshots holding genuinely-fresh data).
+_SQL_FRESH=false
+_QDRANT_FRESH=""    # space-separated collections snapshotted+encrypted this run
+_QDRANT_FAILED=""   # collections that EXIST but failed to snapshot this run
 # Tier-1 replication: true once the local repo is in sync with the GitHub remote.
 _TIER1_PUSHED=false
 # Off-site snapshot bookkeeping. _T2_SNAPSHOT_COUNT / _T2_PRUNED stay UNSET until
@@ -93,6 +127,10 @@ LOG_PREFIX="[genesis-backup]"
 # shellcheck source=scripts/lib/load_secrets.sh
 source "$_SCRIPT_DIR/lib/load_secrets.sh"
 load_secrets_file "$SECRETS_FILE"
+
+# Escrow lookup for the SF4 round-trip (shared with restore.sh).
+# shellcheck source=scripts/lib/passphrase_escrow.sh
+source "$_SCRIPT_DIR/lib/passphrase_escrow.sh"
 
 log() { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 
@@ -174,6 +212,9 @@ cd "$BACKUP_DIR"
 # Ensure git identity is configured (per-repo, not global)
 git config user.name "Genesis Backup" 2>/dev/null || true
 git config user.email "backup@genesis.local" 2>/dev/null || true
+# Keep gc in-process: a detached auto-gc (gc.autoDetach default) inherits the
+# held backup-restore lock fd and would hold the DR lock past script exit.
+git config gc.autoDetach false 2>/dev/null || true
 
 git pull --rebase --quiet 2>/dev/null || log "WARNING: git pull failed, continuing with local state"
 
@@ -192,7 +233,38 @@ if [ -f "$DB_FILE" ]; then
         if sqlite3 "$DB_FILE" .dump > "$_SQL_TMP" 2>/dev/null; then
             _SQLITE_LINES=$(wc -l < "$_SQL_TMP")
             if encrypt_file "$_SQL_TMP" data/genesis.sql.gpg; then
+                _SQL_FRESH=true
                 log "SQLite: $_SQLITE_LINES lines (encrypted)"
+                # SF4 round-trip: prove the artifact DECRYPTS with the
+                # passphrase a DR box would actually use. Prefer the escrowed
+                # copy — env-encrypt + escrow-decrypt is the drift detector
+                # (passphrase rotated in secrets.env with a stale escrow is
+                # undecryptable exactly when secrets.env is lost). No escrow →
+                # verify with the env passphrase (catches archive corruption).
+                # `tail -5 | grep COMMIT;` also catches a bad dump: sqlite3
+                # .dump ends `COMMIT;` on success, `ROLLBACK; -- due to errors`
+                # on a mid-dump failure. Under pipefail any stage failing
+                # (incl. gpg MDC integrity errors) fails the check. gpg stderr
+                # is kept (not discarded) so the alert names the real error.
+                passphrase_escrow_lookup
+                _rt_pass="$_BACKUP_PASSPHRASE"
+                _rt_src="env"
+                if [ -n "$ESCROW_PASSPHRASE" ]; then
+                    _rt_pass="$ESCROW_PASSPHRASE"
+                    _rt_src="escrow ($ESCROW_SOURCE)"
+                fi
+                _rt_err=$(mktemp)
+                if printf '%s' "$_rt_pass" \
+                    | gpg --batch --passphrase-fd 0 -d data/genesis.sql.gpg 2>"$_rt_err" \
+                    | tail -5 | grep -q '^COMMIT;'; then
+                    log "SQLite: round-trip decrypt verified (passphrase source: $_rt_src)"
+                else
+                    _rt_detail=$(head -c 300 "$_rt_err" | tr '\n' ' ')
+                    _FAILURE_REASON="${_FAILURE_REASON:+$_FAILURE_REASON; }SQL round-trip decrypt failed with $_rt_src passphrase (${_rt_detail:-no gpg output}) — backup may be UNRESTORABLE (passphrase drift or corrupt archive)"
+                    log "WARNING: $_FAILURE_REASON"
+                    _SQLITE_LINES=0
+                fi
+                rm -f "$_rt_err"
             else
                 log "WARNING: SQLite encryption failed"
                 _SQLITE_LINES=0
@@ -214,19 +286,42 @@ mkdir -p data/qdrant
 # alongside the new encrypted form.
 find data/qdrant -maxdepth 1 -name '*.snapshot' -type f -delete 2>/dev/null || true
 for collection in episodic_memory knowledge_base; do
-    # Create snapshot via Qdrant API
-    snapshot_resp=$(curl -sf -X POST "$QDRANT_URL/collections/$collection/snapshots" 2>/dev/null) || {
-        log "WARNING: Qdrant snapshot failed for $collection (collection may not exist)"
+    # SF3 existence probe, branched on the HTTP code: only a real 404 is the
+    # benign "collection absent" skip. Connection-refused/timeout/5xx mean the
+    # SERVER is unreachable — with the old `curl -sf || continue` those read
+    # as "may not exist" and every backup reported success with zero fresh
+    # Qdrant payloads, forever (the audit's exact hole). --max-time 10: a
+    # localhost liveness GET, not a transfer.
+    _probe_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+        "$QDRANT_URL/collections/$collection" 2>/dev/null || echo 000)
+    if [ "$_probe_code" = "404" ]; then
+        log "Qdrant: collection $collection does not exist — skipping"
+        continue
+    elif [ "$_probe_code" != "200" ]; then
+        log "WARNING: Qdrant unreachable probing $collection (HTTP $_probe_code)"
+        _QDRANT_FAILED="$_QDRANT_FAILED $collection(probe:$_probe_code)"
+        continue
+    fi
+    # Create snapshot via Qdrant API. --max-time 600: snapshot creation is a
+    # server-side write of the full collection (~282MB and growing); bounded
+    # so a wedged Qdrant can't hold the DR lock forever, sized ~10x a healthy
+    # local snapshot write.
+    snapshot_resp=$(curl -sf --max-time 600 -X POST "$QDRANT_URL/collections/$collection/snapshots" 2>/dev/null) || {
+        log "WARNING: Qdrant snapshot creation failed for $collection"
+        _QDRANT_FAILED="$_QDRANT_FAILED $collection(create)"
         continue
     }
     snapshot_name=$(echo "$snapshot_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['name'])" 2>/dev/null) || {
         log "WARNING: Could not parse snapshot response for $collection"
+        _QDRANT_FAILED="$_QDRANT_FAILED $collection(parse)"
         continue
     }
-    # Download snapshot
-    curl -sf "$QDRANT_URL/collections/$collection/snapshots/$snapshot_name" \
+    # Download snapshot. --max-time 900: a localhost transfer of the full
+    # collection; bounded against a hung server, generous for a healthy one.
+    curl -sf --max-time 900 "$QDRANT_URL/collections/$collection/snapshots/$snapshot_name" \
         -o "data/qdrant/${collection}.snapshot" 2>/dev/null || {
         log "WARNING: Could not download snapshot for $collection"
+        _QDRANT_FAILED="$_QDRANT_FAILED $collection(download)"
         continue
     }
 
@@ -238,15 +333,24 @@ for collection in episodic_memory knowledge_base; do
     elif encrypt_file "data/qdrant/${collection}.snapshot" "data/qdrant/${collection}.snapshot.gpg"; then
         rm -f "data/qdrant/${collection}.snapshot"
         _QDRANT_COUNT=$(( _QDRANT_COUNT + 1 ))
+        _QDRANT_FRESH="$_QDRANT_FRESH $collection"
         log "Qdrant: $collection ($(du -sh "data/qdrant/${collection}.snapshot.gpg" | cut -f1), encrypted)"
     else
         log "WARNING: Qdrant encryption failed for $collection"
+        _QDRANT_FAILED="$_QDRANT_FAILED $collection(encrypt)"
         rm -f "data/qdrant/${collection}.snapshot"
     fi
 
     # Clean up snapshot from Qdrant server
-    curl -sf -X DELETE "$QDRANT_URL/collections/$collection/snapshots/$snapshot_name" >/dev/null 2>&1 || true
+    curl -sf --max-time 60 -X DELETE "$QDRANT_URL/collections/$collection/snapshots/$snapshot_name" >/dev/null 2>&1 || true
 done
+# A collection that EXISTS but produced no fresh payload is a backup failure
+# (success:false → CRITICAL + Telegram), not a quiet gap: restore auto-selects
+# the newest COMPLETE snapshot, so silence here would let stale-or-missing
+# vectors masquerade as current until a disaster surfaces it.
+if [ -n "$_QDRANT_FAILED" ]; then
+    _FAILURE_REASON="${_FAILURE_REASON:+$_FAILURE_REASON; }Qdrant backup failed for:${_QDRANT_FAILED}"
+fi
 
 # --- 3. CC session transcripts (encrypted — contain conversation PII) ---
 #
@@ -470,10 +574,23 @@ else
 
     _T2_OK=true
 
-    # Upload Qdrant snapshots
+    # Upload Qdrant snapshots — FRESH ones only (SF3). A .gpg left on disk by
+    # a prior run (this run's snapshot failed) must not be stamped into a new
+    # dated snapshot: it would misrepresent recency, and GFS retention would
+    # age out the snapshots holding the genuinely-fresh copy. The stale local
+    # file is kept (last-good copy); the failure already pages via
+    # _QDRANT_FAILED above.
     for f in data/qdrant/*.gpg; do
         [ -f "$f" ] || continue
         fname=$(basename "$f")
+        _coll="${fname%.snapshot.gpg}"
+        case " $_QDRANT_FRESH " in
+            *" $_coll "*) ;;
+            *)
+                log "WARNING: $fname is stale (not regenerated this run) — excluded from off-site snapshot"
+                continue
+                ;;
+        esac
         if backend_put "$f" "${_T2_DIR}/qdrant/$fname"; then
             log "  off-site: uploaded $fname"
         else
@@ -482,14 +599,20 @@ else
         fi
     done
 
-    # Upload SQL dump
-    if [ -f data/genesis.sql.gpg ]; then
+    # Upload SQL dump — same freshness gate (SF3, SQL variant). A regenerated
+    # dump whose round-trip FAILED still uploads (_SQL_FRESH is set at encrypt
+    # time): it is the best artifact available — in the escrow-drift case it
+    # decrypts with the env passphrase — and the backup already fails loudly.
+    # Only a NOT-regenerated leftover is excluded.
+    if [ -f data/genesis.sql.gpg ] && $_SQL_FRESH; then
         if backend_put "data/genesis.sql.gpg" "${_T2_DIR}/data/genesis.sql.gpg"; then
             log "  off-site: uploaded genesis.sql.gpg"
         else
             log "WARNING: off-site upload failed for genesis.sql.gpg"
             _T2_OK=false
         fi
+    elif [ -f data/genesis.sql.gpg ]; then
+        log "WARNING: genesis.sql.gpg is stale (not regenerated this run) — excluded from off-site snapshot"
     fi
 
     # Upload transcripts (part of the off-site snapshot)
@@ -684,14 +807,16 @@ else
     # (as happened 2026-05-08 through 2026-05-25: 17 days unnoticed).
     if git commit -m "backup: $(date -Iseconds)" --quiet 2>&1; then
         if ! git push --quiet 2>&1; then
-            _FAILURE_REASON="git push failed — backup exists locally only (not replicated to remote)"
-            log "ERROR: $_FAILURE_REASON"
+            # Append, never overwrite — an earlier SF3/SF4 failure reason must
+            # survive into the status file alongside the push failure.
+            _FAILURE_REASON="${_FAILURE_REASON:+$_FAILURE_REASON; }git push failed — backup exists locally only (not replicated to remote)"
+            log "ERROR: git push failed — backup exists locally only (not replicated to remote)"
         else
             _TIER1_PUSHED=true
             log "Backup committed and pushed"
         fi
     else
-        _FAILURE_REASON="git commit failed (corrupt repo or index error)"
+        _FAILURE_REASON="${_FAILURE_REASON:+$_FAILURE_REASON; }git commit failed (corrupt repo or index error)"
         log "ERROR: git commit failed — repository may need re-clone from remote"
     fi
 fi

--- a/scripts/lib/backup_backends.sh
+++ b/scripts/lib/backup_backends.sh
@@ -68,9 +68,13 @@ _BACKEND_LOCAL_ROOT=""  # local: root directory
 _BACKEND_CTL_TIMEOUT="${GENESIS_BACKUP_CTL_TIMEOUT:-60}"
 _BACKEND_XFER_TIMEOUT="${GENESIS_BACKUP_XFER_TIMEOUT:-1800}"
 _BACKEND_DEL_TIMEOUT="${GENESIS_BACKUP_DEL_TIMEOUT:-600}"
-_t_ctl()  { timeout "$_BACKEND_CTL_TIMEOUT"  "$@"; }
-_t_xfer() { timeout "$_BACKEND_XFER_TIMEOUT" "$@"; }
-_t_del()  { timeout "$_BACKEND_DEL_TIMEOUT"  "$@"; }
+# `-k 10`: if the op ignores/blocks SIGTERM at the deadline, SIGKILL it 10s
+# later. (A truly uninterruptible D-state mount wait survives even SIGKILL
+# until the kernel IO returns — no userland timeout can escape that; the -k
+# just bounds the SIGTERM-ignoring case.)
+_t_ctl()  { timeout -k 10 "$_BACKEND_CTL_TIMEOUT"  "$@"; }
+_t_xfer() { timeout -k 10 "$_BACKEND_XFER_TIMEOUT" "$@"; }
+_t_del()  { timeout -k 10 "$_BACKEND_DEL_TIMEOUT"  "$@"; }
 
 _backend_resolve() {
     local b="${GENESIS_BACKUP_TIER2_BACKEND:-}"

--- a/scripts/lib/backup_backends.sh
+++ b/scripts/lib/backup_backends.sh
@@ -48,6 +48,30 @@ _BACKEND_CREDS=""       # smb: temp creds file (cleaned by backend_cleanup)
 _BACKEND_NAS=""         # smb: //host/share
 _BACKEND_LOCAL_ROOT=""  # local: root directory
 
+# ── Operation timeouts ───────────────────────────────────────────────
+# Named failure mode: a hung SMB/NFS mount (or dead smbclient TCP session)
+# blocks forever inside a backend op. Since SF5 both scripts hold the shared
+# backup-restore flock for their whole run, an unbounded hang here would hold
+# the DR lock indefinitely — blocking a real disaster-recovery restore. Every
+# backend op is therefore bounded, in three tiers sized to the work:
+#   ctl  (60s):   mkdir/list/exists — session setup + one dir op; seconds on
+#                 any live link, 60s is 10-20x headroom.
+#   xfer (1800s): put/get — the largest real payload is the episodic_memory
+#                 Qdrant snapshot (~282MB and growing); at a worst-case
+#                 0.3MB/s that is ~940s, so 900 would kill a slow-but-alive
+#                 link. 1800 bounds a hung mount at 30min without capping a
+#                 healthy slow transfer.
+#   del  (600s):  recursive delete — O(files) server-side (a dated snapshot
+#                 holds 1000+ transcript files); per-file SMB round trips can
+#                 legitimately exceed the ctl tier.
+# Env-overridable for unusual links (levers, not hardcoded policy).
+_BACKEND_CTL_TIMEOUT="${GENESIS_BACKUP_CTL_TIMEOUT:-60}"
+_BACKEND_XFER_TIMEOUT="${GENESIS_BACKUP_XFER_TIMEOUT:-1800}"
+_BACKEND_DEL_TIMEOUT="${GENESIS_BACKUP_DEL_TIMEOUT:-600}"
+_t_ctl()  { timeout "$_BACKEND_CTL_TIMEOUT"  "$@"; }
+_t_xfer() { timeout "$_BACKEND_XFER_TIMEOUT" "$@"; }
+_t_del()  { timeout "$_BACKEND_DEL_TIMEOUT"  "$@"; }
+
 _backend_resolve() {
     local b="${GENESIS_BACKUP_TIER2_BACKEND:-}"
     # Backward-compat: a configured NAS with no explicit selector means smb.
@@ -83,16 +107,21 @@ backend_cleanup() {
 backend_name() { printf '%s' "$_BACKEND"; }
 
 # 0 if the backend's tool + config are usable; non-zero otherwise.
+# The local arm's dir probe is external `test` under timeout, NOT the `[ -d ]`
+# builtin: a hung NFS/CIFS mount hangs the stat() inside the builtin with no
+# way to bound it — and this probe runs FIRST, while the DR lock is held.
 backend_available() {
     case "$_BACKEND" in
         smb)   [ -n "$_BACKEND_NAS" ] && command -v smbclient >/dev/null 2>&1 ;;
-        local) [ -n "$_BACKEND_LOCAL_ROOT" ] && [ -d "$_BACKEND_LOCAL_ROOT" ] ;;
+        local) [ -n "$_BACKEND_LOCAL_ROOT" ] && _t_ctl test -d "$_BACKEND_LOCAL_ROOT" ;;
         *)     return 1 ;;
     esac
 }
 
 # ── smb backend ──────────────────────────────────────────────────────
-_smb_run() { smbclient "$_BACKEND_NAS" -A "$_BACKEND_CREDS" "$@"; }
+# _SMB_OP_TIMEOUT is dynamically scoped: put/get/delete override it per-call
+# (bash `local` in the caller is visible here); everything else gets ctl.
+_smb_run() { timeout "${_SMB_OP_TIMEOUT:-$_BACKEND_CTL_TIMEOUT}" smbclient "$_BACKEND_NAS" -A "$_BACKEND_CREDS" "$@"; }
 
 _smb_mkdir() {
     # smbclient mkdir is non-recursive — create each ancestor in one -c batch.
@@ -109,12 +138,12 @@ _smb_mkdir() {
 }
 
 _smb_put() {
-    local src="$1" dst="$2"
+    local src="$1" dst="$2" _SMB_OP_TIMEOUT="$_BACKEND_XFER_TIMEOUT"
     _smb_run -c "cd \"$(dirname "$dst")\"; put \"$src\" \"$(basename "$dst")\"" >/dev/null 2>&1
 }
 
 _smb_get() {
-    local rem="$1" dst="$2"
+    local rem="$1" dst="$2" _SMB_OP_TIMEOUT="$_BACKEND_XFER_TIMEOUT"
     _smb_run -c "cd \"$(dirname "$rem")\"; get \"$(basename "$rem")\" \"$dst\"" >/dev/null 2>&1
 }
 
@@ -142,17 +171,20 @@ _smb_exists() {
         | awk -v n="$b" '$1==n && $2 ~ /^[DAHSRN]+$/ {f=1} END{exit !f}'
 }
 
-_smb_delete() { _smb_run -c "deltree \"$1\"" >/dev/null 2>&1; }
+_smb_delete() { local _SMB_OP_TIMEOUT="$_BACKEND_DEL_TIMEOUT"; _smb_run -c "deltree \"$1\"" >/dev/null 2>&1; }
 
 # ── local backend (cp/ls/test/rm to a mounted path) ──────────────────
 # Also the real-filesystem regression anchor for tests (no binary stub needed).
-_local_mkdir()  { mkdir -p "$_BACKEND_LOCAL_ROOT/$1" 2>/dev/null; }
-_local_put()    { mkdir -p "$(dirname "$_BACKEND_LOCAL_ROOT/$2")" 2>/dev/null && cp "$1" "$_BACKEND_LOCAL_ROOT/$2"; }
-_local_get()    { cp "$_BACKEND_LOCAL_ROOT/$1" "$2"; }
-_local_list()   { ls -1A "$_BACKEND_LOCAL_ROOT/$1" 2>/dev/null || true; }
-_local_list_dirs() { find "$_BACKEND_LOCAL_ROOT/$1" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null || true; }
-_local_exists() { [ -e "$_BACKEND_LOCAL_ROOT/$1" ]; }
-_local_delete() { rm -rf "${_BACKEND_LOCAL_ROOT:?}/$1"; }
+# Every op runs under a tiered timeout: "local" here usually means a MOUNTED
+# path (NFS/CIFS), where a dead server hangs mkdir/cp/ls/stat forever — and
+# builtins (`[ -e ]`) can't be bounded, hence external `test`.
+_local_mkdir()  { _t_ctl mkdir -p "$_BACKEND_LOCAL_ROOT/$1" 2>/dev/null; }
+_local_put()    { _t_ctl mkdir -p "$(dirname "$_BACKEND_LOCAL_ROOT/$2")" 2>/dev/null && _t_xfer cp "$1" "$_BACKEND_LOCAL_ROOT/$2"; }
+_local_get()    { _t_xfer cp "$_BACKEND_LOCAL_ROOT/$1" "$2"; }
+_local_list()   { _t_ctl ls -1A "$_BACKEND_LOCAL_ROOT/$1" 2>/dev/null || true; }
+_local_list_dirs() { _t_ctl find "$_BACKEND_LOCAL_ROOT/$1" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null || true; }
+_local_exists() { _t_ctl test -e "$_BACKEND_LOCAL_ROOT/$1"; }
+_local_delete() { _t_del rm -rf "${_BACKEND_LOCAL_ROOT:?}/$1"; }
 
 # ── dispatch ─────────────────────────────────────────────────────────
 backend_mkdir() {

--- a/scripts/lib/dr_lock.sh
+++ b/scripts/lib/dr_lock.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# Shared backup↔restore mutual-exclusion lock constants + open helper (SF5).
+# Single-sourced by scripts/backup.sh and scripts/restore.sh so the lock PATH
+# and fd can never drift between them — if they named different files or fds,
+# both would acquire "successfully" and run concurrently, silently
+# reintroducing the exact hole SF5 closes (a 6h backup snapshotting a
+# half-restored DB as the newest COMPLETE).
+#
+#   dr_lock_open   — mkdir the lock dir and open the lock file on DR_LOCK_FD in
+#                    APPEND mode (never O_TRUNC: a losing contender must not
+#                    truncate the winner's holder line). Does NOT acquire —
+#                    the caller runs `flock -n`/`flock -w` per its own policy
+#                    (backup skips, restore waits).
+#   dr_lock_stamp <role> — after acquiring, record "<pid> <role> <iso8601>" so
+#                    the other side's timeout/skip message can name the holder.
+
+DR_LOCK_DIR="${GENESIS_HOME:-$HOME/.genesis}/locks"
+DR_LOCK_FILE="$DR_LOCK_DIR/backup-restore.lock"
+DR_LOCK_FD=200
+
+dr_lock_open() {
+    mkdir -p "$DR_LOCK_DIR"
+    # Open on the fixed fd in append mode (no truncate-on-open).
+    eval "exec ${DR_LOCK_FD}>>\"\$DR_LOCK_FILE\""
+}
+
+dr_lock_stamp() {
+    printf '%s %s %s\n' "$$" "$1" "$(date -Iseconds)" > "$DR_LOCK_FILE"
+}

--- a/scripts/lib/passphrase_escrow.sh
+++ b/scripts/lib/passphrase_escrow.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2034  # ESCROW_* are caller-visible outputs (backup/restore), not locals
 # (sourced fragment, not an executable script — no shebang)
 #
 # Host-side backup-passphrase escrow lookup — shared by scripts/restore.sh
@@ -20,6 +21,8 @@
 # quote-stripped — the passphrase may legitimately contain quotes.
 
 passphrase_escrow_lookup() {
+    # ESCROW_PASSPHRASE / ESCROW_SOURCE are the caller-visible outputs
+    # (consumed by backup.sh / restore.sh), not locals.
     ESCROW_PASSPHRASE=""
     ESCROW_SOURCE=""
     local _escrow _val

--- a/scripts/lib/passphrase_escrow.sh
+++ b/scripts/lib/passphrase_escrow.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
+#
+# Host-side backup-passphrase escrow lookup — shared by scripts/restore.sh
+# (circular-trap fallback: decrypt a backup when secrets.env itself was lost)
+# and scripts/backup.sh (SF4 round-trip: verify the freshly-encrypted SQL dump
+# decrypts with the passphrase a DR box would actually use, so env-vs-escrow
+# drift pages at backup time instead of surfacing at disaster time).
+#
+# Contract:
+#   passphrase_escrow_lookup
+#     Sets ESCROW_PASSPHRASE / ESCROW_SOURCE to the first candidate file that
+#     yields a non-empty value (both empty when no escrow found). ALWAYS
+#     returns 0 (set -e safe). No logging — callers own their log() idiom.
+#
+# Candidate order is load-bearing (explicit override, then shared mount, then
+# host-side guardian state) and must stay in sync with the credential bridge's
+# write locations. The bridge writes exactly `GENESIS_BACKUP_PASSPHRASE=<value>`
+# (no quotes); an optional `export ` prefix is tolerated. Values are NOT
+# quote-stripped — the passphrase may legitimately contain quotes.
+
+passphrase_escrow_lookup() {
+    ESCROW_PASSPHRASE=""
+    ESCROW_SOURCE=""
+    local _escrow _val
+    for _escrow in \
+        "${GENESIS_PASSPHRASE_ESCROW:-}" \
+        "$HOME/.genesis/shared/guardian/backup_passphrase.env" \
+        "$HOME/.local/state/genesis-guardian/shared/guardian/backup_passphrase.env" \
+        "$HOME/.local/state/genesis-guardian/creds-archive/backup_passphrase.env"; do
+        [ -n "$_escrow" ] && [ -f "$_escrow" ] || continue
+        _val="$(sed -n 's/^\(export \)\{0,1\}GENESIS_BACKUP_PASSPHRASE=//p' "$_escrow" | head -n1)"
+        if [ -n "$_val" ]; then
+            ESCROW_PASSPHRASE="$_val"
+            ESCROW_SOURCE="$_escrow"
+            break
+        fi
+    done
+    return 0
+}

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -142,16 +142,15 @@ die()  { log "FATAL: $*"; _FAILURES+=("$*"); exit 1; }
 # run — dying with the holder named is the right behavior for an operator
 # script (wait for the backup, re-run); override for unattended DR flows.
 # Append-mode open: a losing contender must never truncate the holder line.
-_LOCK_DIR="$HOME/.genesis/locks"
-_LOCK_FILE="$_LOCK_DIR/backup-restore.lock"
+# shellcheck source=scripts/lib/dr_lock.sh
+source "$_SCRIPT_DIR/lib/dr_lock.sh"
 _LOCK_WAIT="${GENESIS_RESTORE_LOCK_WAIT:-300}"
-mkdir -p "$_LOCK_DIR"
-exec 200>>"$_LOCK_FILE"
-if ! flock -w "$_LOCK_WAIT" 200; then
-    _holder="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
+dr_lock_open
+if ! flock -w "$_LOCK_WAIT" "$DR_LOCK_FD"; then
+    _holder="$(cat "$DR_LOCK_FILE" 2>/dev/null || true)"
     die "backup-restore lock still held by ${_holder:-unknown} after ${_LOCK_WAIT}s — a backup is likely running; wait for it to finish and re-run (or set GENESIS_RESTORE_LOCK_WAIT higher)"
 fi
-printf '%s restore %s\n' "$$" "$(date -Iseconds)" > "$_LOCK_FILE"
+dr_lock_stamp restore
 
 # Large intermediate files (the ~269MB decrypted SQLite .dump, decrypted Qdrant snapshots)
 # must NOT land in the inherited TMPDIR (cc-tmp = the watchgod "oxygen" folder for a CC run;
@@ -820,6 +819,15 @@ else
 fi
 
 # ── Done ─────────────────────────────────────────────────────────────
+# A COMPLETE off-site snapshot can legitimately lack a Qdrant collection (the
+# backup gates each collection on its being reachable+fresh that run — Qdrant is
+# rebuildable from SQLite, so fresh-SQL-without-vectors beats no-snapshot). Warn
+# loudly when we restored the DB but no vectors, so the operator rebuilds them
+# instead of running on a silently-empty vector store.
+if ! $DRY_RUN && $_SQLITE_RESTORED && [ "$_QDRANT_RESTORED" -eq 0 ]; then
+    log "NOTE: SQLite restored but 0 Qdrant collections were in this snapshot."
+    log "      Rebuild the vector store from the DB: python -m genesis reindex (or scripts/reindex_fts_to_qdrant.py)."
+fi
 if $_SERVER_WAS_STOPPED; then
     log "NOTE: genesis-server was stopped for the restore and left stopped."
     log "      Verify the restored DB, then: systemctl --user start genesis-server"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -131,6 +131,28 @@ log()  { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 warn() { log "WARNING: $*"; _FAILURES+=("$*"); }
 die()  { log "FATAL: $*"; _FAILURES+=("$*"); exit 1; }
 
+# ── Mutual exclusion (SF5): backup↔restore share one whole-run lock ──
+# Counterpart of backup.sh's non-blocking skip. A restore is operator-driven,
+# so it WAITS (bounded) rather than skipping — the 6h backup timer firing
+# mid-restore would otherwise snapshot the half-built DB as the newest
+# COMPLETE backup. Acquired AFTER the EXIT trap above so a lock timeout is
+# recorded in restore_status.json as a real failure, and BEFORE the
+# repo-obtain below (backup.sh commits into the same clone this git-pulls).
+# The default 300s wait is deliberately shorter than a full off-site backup
+# run — dying with the holder named is the right behavior for an operator
+# script (wait for the backup, re-run); override for unattended DR flows.
+# Append-mode open: a losing contender must never truncate the holder line.
+_LOCK_DIR="$HOME/.genesis/locks"
+_LOCK_FILE="$_LOCK_DIR/backup-restore.lock"
+_LOCK_WAIT="${GENESIS_RESTORE_LOCK_WAIT:-300}"
+mkdir -p "$_LOCK_DIR"
+exec 200>>"$_LOCK_FILE"
+if ! flock -w "$_LOCK_WAIT" 200; then
+    _holder="$(cat "$_LOCK_FILE" 2>/dev/null || true)"
+    die "backup-restore lock still held by ${_holder:-unknown} after ${_LOCK_WAIT}s — a backup is likely running; wait for it to finish and re-run (or set GENESIS_RESTORE_LOCK_WAIT higher)"
+fi
+printf '%s restore %s\n' "$$" "$(date -Iseconds)" > "$_LOCK_FILE"
+
 # Large intermediate files (the ~269MB decrypted SQLite .dump, decrypted Qdrant snapshots)
 # must NOT land in the inherited TMPDIR (cc-tmp = the watchgod "oxygen" folder for a CC run;
 # /tmp tmpfs/RAM otherwise). Route them to a dedicated on-disk dir per the tmp_filesystem_limit
@@ -172,24 +194,16 @@ _BACKUP_PASSPHRASE="${GENESIS_BACKUP_PASSPHRASE:-}"
 # Circular-trap fallback: if the passphrase is not in the environment (e.g.
 # secrets.env was lost — the exact disaster this backup exists for), read it
 # from the host-side escrow the credential bridge writes. Without this, an
-# encrypted backup of a lost secrets.env would be undecryptable.
+# encrypted backup of a lost secrets.env would be undecryptable. Lookup logic
+# lives in lib/passphrase_escrow.sh (shared with backup.sh's SF4 round-trip).
+# shellcheck source=scripts/lib/passphrase_escrow.sh
+source "$_SCRIPT_DIR/lib/passphrase_escrow.sh"
 if [ -z "$_BACKUP_PASSPHRASE" ]; then
-    for _escrow in \
-        "${GENESIS_PASSPHRASE_ESCROW:-}" \
-        "$HOME/.genesis/shared/guardian/backup_passphrase.env" \
-        "$HOME/.local/state/genesis-guardian/shared/guardian/backup_passphrase.env" \
-        "$HOME/.local/state/genesis-guardian/creds-archive/backup_passphrase.env"; do
-        [ -n "$_escrow" ] && [ -f "$_escrow" ] || continue
-        # Bridge writes exactly `GENESIS_BACKUP_PASSPHRASE=<value>` (no quotes);
-        # tolerate an optional `export ` prefix. Do NOT strip quotes — the
-        # passphrase may legitimately contain them.
-        _escrowed="$(sed -n 's/^\(export \)\{0,1\}GENESIS_BACKUP_PASSPHRASE=//p' "$_escrow" | head -n1)"
-        if [ -n "$_escrowed" ]; then
-            _BACKUP_PASSPHRASE="$_escrowed"
-            log "Using escrowed backup passphrase from $_escrow (env passphrase absent)"
-            break
-        fi
-    done
+    passphrase_escrow_lookup
+    if [ -n "$ESCROW_PASSPHRASE" ]; then
+        _BACKUP_PASSPHRASE="$ESCROW_PASSPHRASE"
+        log "Using escrowed backup passphrase from $ESCROW_SOURCE (env passphrase absent)"
+    fi
 fi
 
 # G.4 host-side credential mirror fallback. If the Tier-1 backup clone lacks the

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -37,9 +37,11 @@ def backup_env(tmp_path):
     (gd / "data").mkdir(parents=True)
     (home / ".genesis").mkdir(parents=True)
     (home / ".gnupg").mkdir(mode=0o700)
-    subprocess.run(["sqlite3", str(gd / "data" / "genesis.db"),
-                    "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
-                   check=True, capture_output=True)
+    subprocess.run(
+        ["sqlite3", str(gd / "data" / "genesis.db"), "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
+        check=True,
+        capture_output=True,
+    )
     # A2a inputs: auto-memory (flat), a config overlay, and a secrets file — so the
     # off-site snapshot can include them alongside data/qdrant/transcripts.
     cc_id = str(gd).replace("/", "-")
@@ -73,32 +75,43 @@ def backup_env(tmp_path):
     # smbclient stub: log the -c command (the arg after -c), succeed.
     _make_stub(
         bind / "smbclient",
-        '#!/usr/bin/env bash\n'
+        "#!/usr/bin/env bash\n"
         'prev=""\n'
         'for a in "$@"; do\n'
         f'  [ "$prev" = "-c" ] && printf "%s\\n" "$a" >> "{smb_log}"\n'
         '  prev="$a"\n'
-        'done\n'
-        'exit 0\n',
+        "done\n"
+        "exit 0\n",
     )
-    # curl stub: Telegram captured (unused here), everything else fails (Qdrant skipped).
-    _make_stub(bind / "curl", '#!/usr/bin/env bash\nexit 1\n')
+    # curl stub: SF3 existence probe answers 404 (collections genuinely absent
+    # → benign skip; a bare connection failure now FAILS the backup);
+    # everything else fails (no Telegram asserted here).
+    _make_stub(
+        bind / "curl",
+        "#!/usr/bin/env bash\n"
+        'for a in "$@"; do [ "$a" = "-w" ] && { printf "404"; exit 0; }; done\n'
+        "exit 1\n",
+    )
     return {"home": home, "gd": gd, "bind": bind, "smb_log": smb_log, "tmp": tmp_path}
 
 
 def _run(backup_env):
     env = dict(os.environ)
     env.update(
-        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
-        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
-        GENESIS_BACKUP_NAS="//nas/share", GENESIS_BACKUP_NAS_USER="u",
+        HOME=str(backup_env["home"]),
+        GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass",
+        QDRANT_URL="http://127.0.0.1:1",
+        GENESIS_BACKUP_NAS="//nas/share",
+        GENESIS_BACKUP_NAS_USER="u",
         GENESIS_BACKUP_NAS_PASS="p",
-        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+        PATH=f"{backup_env['bind']}:{os.environ['PATH']}",
     )
     for k in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_FORUM_CHAT_ID"):
         env.pop(k, None)
-    proc = subprocess.run(["bash", str(_BACKUP)], env=env,
-                          capture_output=True, text=True, stdin=subprocess.DEVNULL)
+    proc = subprocess.run(
+        ["bash", str(_BACKUP)], env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL
+    )
     cmds = backup_env["smb_log"].read_text() if backup_env["smb_log"].exists() else ""
     return proc, cmds
 
@@ -110,8 +123,9 @@ def test_sqlite_uploaded_under_dated_snapshot_dir(backup_env):
     put_sql = [ln for ln in cmds.splitlines() if "put" in ln and "genesis.sql.gpg" in ln]
     assert put_sql, f"no SQL upload command logged:\n{cmds}"
     # The cd target for the SQL put must include a dated snapshot dir + /data.
-    assert any(_STAMP_RE.search(ln) for ln in put_sql), \
+    assert any(_STAMP_RE.search(ln) for ln in put_sql), (
         f"SQL upload not under a dated snapshot dir:\n{put_sql}"
+    )
     assert any("/data" in ln for ln in put_sql), f"SQL upload not under .../data:\n{put_sql}"
 
 
@@ -132,17 +146,25 @@ def _run_local(backup_env, offsite_root: Path):
     """Run backup.sh through the `local` Tier-2 backend (no smbclient stub)."""
     env = dict(os.environ)
     env.update(
-        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
-        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
+        HOME=str(backup_env["home"]),
+        GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass",
+        QDRANT_URL="http://127.0.0.1:1",
         GENESIS_BACKUP_TIER2_BACKEND="local",
         GENESIS_BACKUP_LOCAL_PATH=str(offsite_root),
-        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+        PATH=f"{backup_env['bind']}:{os.environ['PATH']}",
     )
-    for k in ("GENESIS_BACKUP_NAS", "GENESIS_BACKUP_NAS_USER", "GENESIS_BACKUP_NAS_PASS",
-              "TELEGRAM_BOT_TOKEN", "TELEGRAM_FORUM_CHAT_ID"):
+    for k in (
+        "GENESIS_BACKUP_NAS",
+        "GENESIS_BACKUP_NAS_USER",
+        "GENESIS_BACKUP_NAS_PASS",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_FORUM_CHAT_ID",
+    ):
         env.pop(k, None)
-    return subprocess.run(["bash", str(_BACKUP)], env=env,
-                          capture_output=True, text=True, stdin=subprocess.DEVNULL)
+    return subprocess.run(
+        ["bash", str(_BACKUP)], env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL
+    )
 
 
 def test_local_backend_writes_dated_snapshot_to_real_fs(backup_env, tmp_path):
@@ -190,11 +212,13 @@ def test_local_backend_snapshot_includes_memory_config_secrets(backup_env, tmp_p
     mem_gpgs = list((snap / "memory").glob("*.gpg")) if (snap / "memory").is_dir() else []
     assert mem_gpgs, f"no memory/*.gpg in the off-site snapshot: {[d.name for d in snap.iterdir()]}"
     # config_overrides: the overlay shipped as-is (plaintext, mirrors Tier-1).
-    assert (snap / "config_overrides" / "sample.local.yaml").is_file(), \
+    assert (snap / "config_overrides" / "sample.local.yaml").is_file(), (
         f"config overlay missing from off-site snapshot: {[d.name for d in snap.iterdir()]}"
+    )
     # secrets: the encrypted secrets payload.
-    assert (snap / "secrets" / "secrets.env.gpg").is_file(), \
+    assert (snap / "secrets" / "secrets.env.gpg").is_file(), (
         f"secrets payload missing from off-site snapshot: {[d.name for d in snap.iterdir()]}"
+    )
     # COMPLETE still written (and only because all three landed too).
     assert (snap / "COMPLETE").is_file(), "COMPLETE marker not written"
 
@@ -211,8 +235,9 @@ def test_offsite_memory_includes_dotfiles(backup_env, tmp_path):
     snaps = [d for d in host.iterdir() if _STAMP_RE.fullmatch(d.name)]
     assert len(snaps) == 1, [d.name for d in snaps]
     mem = snaps[0] / "memory"
-    assert (mem / ".consolidate-lock.gpg").is_file(), \
+    assert (mem / ".consolidate-lock.gpg").is_file(), (
         f"dotfile dropped from off-site memory mirror: {sorted(p.name for p in mem.iterdir())}"
+    )
     assert (mem / "note.md.gpg").is_file()  # regular file still mirrored (no regression)
 
 
@@ -224,33 +249,44 @@ def test_large_temp_goes_to_dedicated_dir_not_inherited_tmpdir(backup_env, tmp_p
     The seeded `tmp_filesystem_limit` procedure already mandates ~/tmp for large temp."""
     offsite = tmp_path / "offsite"
     offsite.mkdir()
-    cctmp = tmp_path / "cc-tmp-sentinel"   # stand-in for the watchgod "oxygen" folder
+    cctmp = tmp_path / "cc-tmp-sentinel"  # stand-in for the watchgod "oxygen" folder
     cctmp.mkdir()
     bigtmp = tmp_path / "dedicated-big-tmp"
     bigtmp.mkdir()
     env = dict(os.environ)
     env.update(
-        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
-        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
-        GENESIS_BACKUP_TIER2_BACKEND="local", GENESIS_BACKUP_LOCAL_PATH=str(offsite),
-        TMPDIR=str(cctmp),                  # inherited — MUST NOT be used for the big dump
+        HOME=str(backup_env["home"]),
+        GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass",
+        QDRANT_URL="http://127.0.0.1:1",
+        GENESIS_BACKUP_TIER2_BACKEND="local",
+        GENESIS_BACKUP_LOCAL_PATH=str(offsite),
+        TMPDIR=str(cctmp),  # inherited — MUST NOT be used for the big dump
         GENESIS_BACKUP_TMPDIR=str(bigtmp),  # the dedicated dir the dump MUST use
-        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+        PATH=f"{backup_env['bind']}:{os.environ['PATH']}",
     )
-    for k in ("GENESIS_BACKUP_NAS", "GENESIS_BACKUP_NAS_USER", "GENESIS_BACKUP_NAS_PASS",
-              "TELEGRAM_BOT_TOKEN", "TELEGRAM_FORUM_CHAT_ID"):
+    for k in (
+        "GENESIS_BACKUP_NAS",
+        "GENESIS_BACKUP_NAS_USER",
+        "GENESIS_BACKUP_NAS_PASS",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_FORUM_CHAT_ID",
+    ):
         env.pop(k, None)
-    proc = subprocess.run(["bash", str(_BACKUP)], env=env, capture_output=True,
-                          text=True, stdin=subprocess.DEVNULL)
+    proc = subprocess.run(
+        ["bash", str(_BACKUP)], env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL
+    )
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     # The script announces where large temp goes; it must be the dedicated dir, not cc-tmp.
     assert f"big-temp dir: {bigtmp}" in proc.stdout, (
-        f"backup did not route large temp to the dedicated dir (expected {bigtmp}):\n{proc.stdout}")
+        f"backup did not route large temp to the dedicated dir (expected {bigtmp}):\n{proc.stdout}"
+    )
 
 
 # --------------------------------------------------------------------------- #
 # GFS retention prune (D4) — off-site dated snapshots
 # --------------------------------------------------------------------------- #
+
 
 def _seed_offsite_snapshot(host_dir: Path, stamp: str, *, complete: bool) -> None:
     snap = host_dir / stamp

--- a/tests/test_scripts/test_backup_dr_signal.py
+++ b/tests/test_scripts/test_backup_dr_signal.py
@@ -37,9 +37,11 @@ def backup_env(tmp_path):
     (gd / "data").mkdir(parents=True)
     (home / ".genesis").mkdir(parents=True)
     (home / ".gnupg").mkdir(mode=0o700)
-    subprocess.run(["sqlite3", str(gd / "data" / "genesis.db"),
-                    "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
-                   check=True, capture_output=True)
+    subprocess.run(
+        ["sqlite3", str(gd / "data" / "genesis.db"), "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
+        check=True,
+        capture_output=True,
+    )
 
     # Backup repo: bare remote (main) + a clone at $HOME/backups/genesis-backups
     # so backup.sh skips its clone and `git push` lands on the local remote.
@@ -61,42 +63,60 @@ def backup_env(tmp_path):
     bind = tmp_path / "bin"
     bind.mkdir()
     tg = tmp_path / "telegram_calls.log"
-    # curl stub: capture Telegram sends; fail everything else (Qdrant → skipped).
+    # curl stub: capture Telegram sends; answer the SF3 existence probe with
+    # 404 (collections genuinely absent → benign skip — a bare connection
+    # failure now correctly FAILS the backup); fail everything else.
     _make_stub(
         bind / "curl",
-        '#!/usr/bin/env bash\n'
+        "#!/usr/bin/env bash\n"
         'for a in "$@"; do case "$a" in\n'
         f'  *api.telegram.org*) printf "%s\\n" "$*" >> "{tg}"; exit 0 ;;\n'
-        'esac; done\n'
-        'exit 1\n',
+        "esac; done\n"
+        'for a in "$@"; do [ "$a" = "-w" ] && { printf "404"; exit 0; }; done\n'
+        "exit 1\n",
     )
     return {"home": home, "gd": gd, "bind": bind, "tg": tg, "tmp": tmp_path}
 
 
-def _run(backup_env, *, smb_rc: int = 0, nas: bool = True, remove_db: bool = False,
-         fail_complete: bool = False):
+def _run(
+    backup_env,
+    *,
+    smb_rc: int = 0,
+    nas: bool = True,
+    remove_db: bool = False,
+    fail_complete: bool = False,
+):
     if remove_db:  # force _SUCCESS=false (no SQLite data) for the failure-alert path
         (backup_env["gd"] / "data" / "genesis.db").unlink(missing_ok=True)
     if fail_complete:  # payloads upload OK, only the COMPLETE marker fails
-        _make_stub(backup_env["bind"] / "smbclient",
-                   '#!/usr/bin/env bash\ncase "$*" in *COMPLETE*) exit 1 ;; esac\nexit 0\n')
+        _make_stub(
+            backup_env["bind"] / "smbclient",
+            '#!/usr/bin/env bash\ncase "$*" in *COMPLETE*) exit 1 ;; esac\nexit 0\n',
+        )
     else:
-        _make_stub(backup_env["bind"] / "smbclient", f'#!/usr/bin/env bash\nexit {smb_rc}\n')
+        _make_stub(backup_env["bind"] / "smbclient", f"#!/usr/bin/env bash\nexit {smb_rc}\n")
     env = dict(os.environ)
     env.update(
-        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
-        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
-        TELEGRAM_BOT_TOKEN="bot-x", TELEGRAM_FORUM_CHAT_ID="chat-y",
-        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+        HOME=str(backup_env["home"]),
+        GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass",
+        QDRANT_URL="http://127.0.0.1:1",
+        TELEGRAM_BOT_TOKEN="bot-x",
+        TELEGRAM_FORUM_CHAT_ID="chat-y",
+        PATH=f"{backup_env['bind']}:{os.environ['PATH']}",
     )
     if nas:
-        env.update(GENESIS_BACKUP_NAS="//nas/share",
-                   GENESIS_BACKUP_NAS_USER="u", GENESIS_BACKUP_NAS_PASS="p")
+        env.update(
+            GENESIS_BACKUP_NAS="//nas/share",
+            GENESIS_BACKUP_NAS_USER="u",
+            GENESIS_BACKUP_NAS_PASS="p",
+        )
     else:
         for k in ("GENESIS_BACKUP_NAS", "GENESIS_BACKUP_NAS_USER", "GENESIS_BACKUP_NAS_PASS"):
             env.pop(k, None)
-    proc = subprocess.run(["bash", str(_BACKUP)], env=env,
-                          capture_output=True, text=True, stdin=subprocess.DEVNULL)
+    proc = subprocess.run(
+        ["bash", str(_BACKUP)], env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL
+    )
     status = json.loads((backup_env["home"] / ".genesis" / "backup_status.json").read_text())
     tg = backup_env["tg"].read_text() if backup_env["tg"].exists() else ""
     return proc, status, tg
@@ -117,7 +137,9 @@ def test_offsite_failure_alerts_but_local_succeeds(backup_env):
     """NAS configured but the upload fails → offsite_confirmed:false, the LOCAL
     backup still succeeds, and a distinct off-site alert fires."""
     proc, status, tg = _run(backup_env, smb_rc=1, nas=True)  # NAS upload fails
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"  # off-site miss is not a hard failure
+    assert proc.returncode == 0, (
+        f"{proc.stdout}\n{proc.stderr}"
+    )  # off-site miss is not a hard failure
     assert status["success"] is True, status
     assert status["offsite_confirmed"] is False, status
     assert status["tier2_status"] != "ok", status
@@ -136,7 +158,7 @@ def test_backup_failure_still_alerts(backup_env):
 def test_offsite_alert_deduplicated(backup_env):
     """A persistent off-site outage alerts ONCE (on the transition), not every
     6h run — the second consecutive failure is deduped via the prior status."""
-    _run(backup_env, smb_rc=1, nas=True)              # 1st failure → alert
+    _run(backup_env, smb_rc=1, nas=True)  # 1st failure → alert
     _, status2, tg = _run(backup_env, smb_rc=1, nas=True)  # 2nd failure → deduped
     assert status2["offsite_confirmed"] is False, status2
     n = tg.lower().count("off-site replication failed")
@@ -184,7 +206,7 @@ def test_complete_marker_failure_is_offsite_failure(backup_env):
     """If payloads upload but the COMPLETE marker fails, restore would skip the
     snapshot — so it must report partial + offsite_confirmed:false + alert, not ok."""
     proc, status, tg = _run(backup_env, fail_complete=True, nas=True)
-    assert status["success"] is True, status          # local backup is still fine
+    assert status["success"] is True, status  # local backup is still fine
     assert status["tier2_status"] == "partial", status
     assert status["offsite_confirmed"] is False, status
     assert "replication" in tg.lower() or "off-site" in tg.lower(), tg

--- a/tests/test_scripts/test_dr_integrity_core.py
+++ b/tests/test_scripts/test_dr_integrity_core.py
@@ -81,6 +81,14 @@ case "$*" in *api.telegram.org*) printf '%s\\n' "$*" >> "__TGLOG__"; exit 0 ;; e
 exit 1
 """
 
+_CURL_EXISTS_NOSNAP = """#!/usr/bin/env bash
+# Collection EXISTS (probe 200) but snapshot creation fails — the audit's real
+# "collections exist but weren't captured" case.
+case "$*" in *api.telegram.org*) printf '%s\\n' "$*" >> "__TGLOG__"; exit 0 ;; esac
+for a in "$@"; do [ "$a" = "-w" ] && { printf '200'; exit 0; }; done
+exit 1
+"""
+
 
 @pytest.fixture
 def sandbox(tmp_path):
@@ -251,47 +259,120 @@ def test_roundtrip_env_passphrase_verified(sandbox):
     """No escrow → round-trip runs with the env passphrase and passes."""
     _install_curl(sandbox, _CURL_ABSENT)
     proc, status = _run_backup(sandbox)
-    assert "round-trip decrypt verified (passphrase source: env)" in proc.stdout, proc.stdout
+    assert "round-trip decrypt verified" in proc.stdout, proc.stdout
     assert status["success"] is True, status
 
 
-def test_roundtrip_escrow_drift_fails_backup(sandbox):
-    """Escrowed passphrase differs from the env one (rotation drift) → the
-    round-trip fails, the backup fails loudly, and the alert names it."""
-    _install_curl(sandbox, _CURL_ABSENT)
+def test_escrow_drift_degrades_offsite_not_critical(sandbox):
+    """Escrow stale but env passphrase decrypts (rotation drift): the LOCAL
+    backup still succeeds (not a CRITICAL backup-failure), the fresh SQL dump is
+    WITHHELD from the off-site snapshot (a DR box couldn't decrypt it), and a
+    distinct re-escrow alert fires instead of 'backup failed'."""
+    _install_curl(sandbox, _CURL_HEALTHY)
     escrow = sandbox["home"] / ".genesis" / "shared" / "guardian"
     escrow.mkdir(parents=True)
     (escrow / "backup_passphrase.env").write_text("GENESIS_BACKUP_PASSPHRASE=stale-rotated-away\n")
     proc, status = _run_backup(sandbox)
-    assert status["success"] is False, status
-    assert "round-trip" in status["failure_reason"], status
-    assert status["sqlite_lines"] == 0, status
+    assert status["success"] is True, status  # env-decryptable → local OK
+    assert status["offsite_confirmed"] is False, status
+    files = _offsite_files(sandbox)
+    assert not any(f.endswith("data/genesis.sql.gpg") for f in files), files
+    assert not any(f.endswith("/COMPLETE") for f in files), (
+        files
+    )  # no COMPLETE around a withheld dump
     tg = sandbox["tg"].read_text() if sandbox["tg"].exists() else ""
-    assert "backup failed" in tg.lower(), tg
+    assert "escrow drift" in tg.lower(), tg
+    assert "backup failed" not in tg.lower(), tg
 
 
 def test_roundtrip_escrow_matching_passes(sandbox):
-    """Escrow present and matching → verified against the escrow copy."""
-    _install_curl(sandbox, _CURL_ABSENT)
+    """Escrow present and matching the env passphrase → RESTORABLE via the
+    escrow-preferred branch; backup succeeds and the SQL ships off-site."""
+    _install_curl(sandbox, _CURL_HEALTHY)
     escrow = sandbox["home"] / ".genesis" / "shared" / "guardian"
     escrow.mkdir(parents=True)
     (escrow / "backup_passphrase.env").write_text("GENESIS_BACKUP_PASSPHRASE=testpass\n")
     proc, status = _run_backup(sandbox)
-    assert "passphrase source: escrow" in proc.stdout, proc.stdout
+    assert "round-trip decrypt verified" in proc.stdout, proc.stdout
     assert status["success"] is True, status
+    files = _offsite_files(sandbox)
+    assert any(f.endswith("data/genesis.sql.gpg") for f in files), files
+
+
+def test_corrupt_sql_fails_and_withheld(sandbox):
+    """A dump that won't decrypt with its OWN env passphrase (corruption) fails
+    the backup AND is withheld from the off-site snapshot."""
+    _install_curl(sandbox, _CURL_HEALTHY)
+    # Corrupt the artifact after encryption by making the round-trip gpg see a
+    # truncated file: stub gpg's decrypt to fail. Simplest deterministic route —
+    # wrong env passphrase can't be injected mid-run, so overwrite the encrypted
+    # file via a wrapper is complex; instead assert via a broken cipher: feed a
+    # DB whose dump encrypts fine but we corrupt the .gpg with a post-encrypt
+    # hook is not available. Use the escrow-absent + a gpg stub that fails -d.
+    gpg_stub = sandbox["bind"] / "gpg"
+    real_gpg = subprocess.run(
+        ["bash", "-lc", "command -v gpg"], capture_output=True, text=True
+    ).stdout.strip()
+    _make_stub(
+        gpg_stub,
+        f"#!/usr/bin/env bash\n"
+        f'for a in "$@"; do [ "$a" = "-d" ] && {{ echo "gpg: decryption failed: Bad session key" >&2; exit 2; }}; done\n'
+        f'exec {real_gpg} "$@"\n',
+    )
+    proc, status = _run_backup(sandbox)
+    assert status["success"] is False, status
+    assert "round-trip" in status["failure_reason"], status
+    files = _offsite_files(sandbox)
+    assert not any(f.endswith("data/genesis.sql.gpg") for f in files), files
+
+
+def test_roundtrip_error_detail_sanitized_valid_json(sandbox):
+    """A gpg error containing control chars / non-ASCII must not corrupt
+    backup_status.json (the health consumer's read_text()+json.loads would
+    otherwise crash or swallow the CRITICAL). The status file stays valid JSON
+    and parseable — proven by _run_backup already json.loads-ing it."""
+    _install_curl(sandbox, _CURL_HEALTHY)
+    gpg_stub = sandbox["bind"] / "gpg"
+    real_gpg = subprocess.run(
+        ["bash", "-lc", "command -v gpg"], capture_output=True, text=True
+    ).stdout.strip()
+    # Decrypt fails with a tab + CR + non-ASCII (é, 0xE9) in the message.
+    _make_stub(
+        gpg_stub,
+        f"#!/usr/bin/env bash\n"
+        f'for a in "$@"; do [ "$a" = "-d" ] && {{ printf "gpg:\\tbad\\rk\\xc3\\xa9y\\n" >&2; exit 2; }}; done\n'
+        f'exec {real_gpg} "$@"\n',
+    )
+    proc, status = _run_backup(sandbox)
+    # status is not None ⇒ json.loads succeeded ⇒ valid JSON despite the gpg tab/CR/UTF-8.
+    assert status is not None and status["success"] is False, status
+    assert "\t" not in status["failure_reason"] and "\r" not in status["failure_reason"], repr(
+        status["failure_reason"]
+    )
 
 
 # ── SF3: freshness gate ──────────────────────────────────────────────
 
 
-def test_qdrant_down_fails_backup(sandbox):
-    """Server unreachable is a FAILURE (the audit hole: it used to read as
-    'collection may not exist' and report success forever)."""
+def test_qdrant_unreachable_is_benign(sandbox):
+    """Server unreachable (000) is NOT a failure — a fresh/bootstrapping install
+    or Qdrant-less host would otherwise page CRITICAL every 6h forever. Qdrant is
+    rebuildable from SQL, so the backup succeeds with a WARNING."""
     _install_curl(sandbox, _CURL_DOWN)
+    proc, status = _run_backup(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert status["success"] is True, status
+    assert "Qdrant" not in status["failure_reason"], status
+    assert "unreachable" in proc.stdout.lower(), proc.stdout
+
+
+def test_qdrant_reachable_but_snapshot_fails(sandbox):
+    """A REACHABLE collection (probe 200) that then fails to snapshot IS the
+    audit's real failure — data is present but wasn't captured."""
+    _install_curl(sandbox, _CURL_EXISTS_NOSNAP)
     proc, status = _run_backup(sandbox)
     assert status["success"] is False, status
     assert "Qdrant backup failed" in status["failure_reason"], status
-    assert "probe" in status["failure_reason"], status
 
 
 def test_qdrant_absent_is_benign(sandbox):

--- a/tests/test_scripts/test_dr_integrity_core.py
+++ b/tests/test_scripts/test_dr_integrity_core.py
@@ -1,0 +1,471 @@
+"""DR integrity core (audit SF3/SF4/SF5) tests for backup.sh / restore.sh.
+
+Three properties of the disaster-recovery pair are guarded here:
+
+* **Mutual exclusion (SF5).** backup.sh and restore.sh share one whole-run
+  flock (`~/.genesis/locks/backup-restore.lock`). A timer-fired backup SKIPS
+  (exit 0, and — critically — without touching ``backup_status.json``, which
+  would page a false CRITICAL) when a restore holds the lock; a restore WAITS
+  bounded and dies naming the holder. Backend ops are timeout-bounded so a
+  hung mount can't hold the DR lock forever.
+* **Round-trip verify (SF4).** The freshly-encrypted SQL dump must DECRYPT
+  with the passphrase a DR box would use (escrow preferred — env-encrypt +
+  escrow-decrypt is the drift detector). A failed round-trip fails the backup.
+* **Freshness gate (SF3).** Only payloads regenerated THIS run enter the
+  off-site dated snapshot; a leftover .gpg from a failed prior section is
+  excluded (and kept locally). A collection that EXISTS but fails to snapshot
+  fails the backup; a genuinely absent collection (HTTP 404) stays benign.
+
+Fully sandboxed: ``HOME``/``GENESIS_DIR`` in tmp; real sqlite3/gpg/git/flock;
+``curl`` stubbed per-scenario; the off-site tier uses the REAL `local` backend
+against a tmp dir so upload assertions are actual files.
+"""
+
+import fcntl
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_BACKUP = _SCRIPTS / "backup.sh"
+_RESTORE = _SCRIPTS / "restore.sh"
+_BACKENDS = _SCRIPTS / "lib" / "backup_backends.sh"
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+# curl stub bodies. Every stub logs Telegram sends to TGLOG and handles the
+# Qdrant surface per scenario; anything unrecognized fails (offline).
+_CURL_HEALTHY = """#!/usr/bin/env bash
+# Healthy Qdrant: probe→200, snapshot POST→name, download→bytes, DELETE→ok.
+args=("$@"); url=""; out=""; method="GET"; has_w=0; i=0
+while [ $i -lt ${#args[@]} ]; do
+  a="${args[$i]}"
+  case "$a" in
+    -X) i=$((i+1)); method="${args[$i]}" ;;
+    -o) i=$((i+1)); out="${args[$i]}" ;;
+    -w) i=$((i+1)); has_w=1 ;;
+    --max-time|-H|-d|-F) i=$((i+1)) ;;
+    http*) url="$a" ;;
+  esac
+  i=$((i+1))
+done
+case "$url" in *api.telegram.org*) printf '%s\\n' "$*" >> "__TGLOG__"; exit 0 ;; esac
+[ "$has_w" = 1 ] && { printf '200'; exit 0; }
+[ "$method" = "POST" ] && { printf '{"result":{"name":"s1"}}'; exit 0; }
+[ "$method" = "DELETE" ] && exit 0
+[ -n "$out" ] && { printf 'snapshot-bytes' > "$out"; exit 0; }
+exit 1
+"""
+
+_CURL_ABSENT = """#!/usr/bin/env bash
+# Collections genuinely absent: probe answers 404; everything else fails.
+case "$*" in *api.telegram.org*) printf '%s\\n' "$*" >> "__TGLOG__"; exit 0 ;; esac
+for a in "$@"; do [ "$a" = "-w" ] && { printf '404'; exit 0; }; done
+exit 1
+"""
+
+_CURL_DOWN = """#!/usr/bin/env bash
+# Qdrant down: every call fails with no output (probe reads 000).
+case "$*" in *api.telegram.org*) printf '%s\\n' "$*" >> "__TGLOG__"; exit 0 ;; esac
+exit 1
+"""
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    home = tmp_path / "home"
+    gd = home / "genesis"
+    (gd / "data").mkdir(parents=True)
+    (home / ".genesis").mkdir(parents=True)
+    (home / ".gnupg").mkdir(mode=0o700)
+    (home / "tmp").mkdir()
+    subprocess.run(
+        ["sqlite3", str(gd / "data" / "genesis.db"), "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
+        check=True,
+        capture_output=True,
+    )
+
+    bare = tmp_path / "remote.git"
+    _git("init", "-q", "--bare", str(bare), cwd=tmp_path)
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=bare)
+    seed = tmp_path / "seed"
+    _git("-c", "init.defaultBranch=main", "clone", "-q", str(bare), str(seed), cwd=tmp_path)
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=seed)
+    _git("config", "user.email", "t@t.t", cwd=seed)
+    _git("config", "user.name", "t", cwd=seed)
+    (seed / "README").write_text("seed\n")
+    _git("add", "README", cwd=seed)
+    _git("commit", "-qm", "init", cwd=seed)
+    _git("push", "-q", "origin", "main", cwd=seed)
+    (home / "backups").mkdir(parents=True)
+    clone = home / "backups" / "genesis-backups"
+    _git("clone", "-q", str(bare), str(clone), cwd=tmp_path)
+
+    offsite = tmp_path / "offsite"
+    offsite.mkdir()
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    tg = tmp_path / "telegram_calls.log"
+    return {
+        "home": home,
+        "gd": gd,
+        "bind": bind,
+        "tg": tg,
+        "offsite": offsite,
+        "clone": clone,
+        "tmp": tmp_path,
+    }
+
+
+def _env(sb, **extra):
+    env = dict(os.environ)
+    for k in (
+        "GENESIS_BACKUP_NAS",
+        "GENESIS_BACKUP_NAS_USER",
+        "GENESIS_BACKUP_NAS_PASS",
+        "GENESIS_BACKUP_TIER2_BACKEND",
+        "GENESIS_BACKUP_LOCAL_PATH",
+        "GENESIS_PASSPHRASE_ESCROW",
+    ):
+        env.pop(k, None)
+    env.update(
+        HOME=str(sb["home"]),
+        GENESIS_DIR=str(sb["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass",
+        GENESIS_BACKUP_TMPDIR=str(sb["home"] / "tmp"),
+        QDRANT_URL="http://127.0.0.1:1",
+        TELEGRAM_BOT_TOKEN="bot-x",
+        TELEGRAM_FORUM_CHAT_ID="chat-y",
+        GENESIS_BACKUP_TIER2_BACKEND="local",
+        GENESIS_BACKUP_LOCAL_PATH=str(sb["offsite"]),
+        PATH=f"{sb['bind']}:{os.environ['PATH']}",
+    )
+    env.update(extra)
+    return env
+
+
+def _install_curl(sb, body: str) -> None:
+    _make_stub(sb["bind"] / "curl", body.replace("__TGLOG__", str(sb["tg"])))
+
+
+def _run_backup(sb, **extra):
+    proc = subprocess.run(
+        ["bash", str(_BACKUP)],
+        env=_env(sb, **extra),
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    status_file = sb["home"] / ".genesis" / "backup_status.json"
+    status = json.loads(status_file.read_text()) if status_file.exists() else None
+    return proc, status
+
+
+def _offsite_files(sb):
+    return sorted(
+        str(p.relative_to(sb["offsite"])) for p in sb["offsite"].rglob("*") if p.is_file()
+    )
+
+
+# ── SF5: mutual exclusion ────────────────────────────────────────────
+
+
+def test_backup_skips_when_lock_held(sandbox):
+    """Lock held → backup exits 0, logs SKIPPED, and writes NO status file
+    (success:false would page a false CRITICAL during a legitimate restore)."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    lock_dir = sandbox["home"] / ".genesis" / "locks"
+    lock_dir.mkdir(parents=True)
+    lock_file = lock_dir / "backup-restore.lock"
+    lock_file.write_text("99999 restore 2026-01-01T00:00:00\n")
+    with open(lock_file, "a") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        proc, status = _run_backup(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "SKIPPED" in proc.stdout and "99999 restore" in proc.stdout, proc.stdout
+    assert status is None, f"skip must not write backup_status.json: {status}"
+
+
+def test_backup_holder_line_written(sandbox):
+    """A winning backup records itself in the lock file (holder forensics)."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    proc, status = _run_backup(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    holder = (sandbox["home"] / ".genesis" / "locks" / "backup-restore.lock").read_text()
+    assert " backup " in holder, holder
+
+
+def test_restore_lock_timeout_names_holder(sandbox):
+    """Restore waits bounded, then dies naming the holder — and records the
+    failure in restore_status.json (unlike backup's silent skip)."""
+    lock_dir = sandbox["home"] / ".genesis" / "locks"
+    lock_dir.mkdir(parents=True)
+    lock_file = lock_dir / "backup-restore.lock"
+    lock_file.write_text("4242 backup 2026-01-01T00:00:00\n")
+    with open(lock_file, "a") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        proc = subprocess.run(
+            ["bash", str(_RESTORE), "--dry-run"],
+            env=_env(sandbox, GENESIS_RESTORE_LOCK_WAIT="1"),
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+        )
+    assert proc.returncode != 0, proc.stdout
+    assert "4242 backup" in proc.stdout and "re-run" in proc.stdout, proc.stdout
+    status = json.loads((sandbox["home"] / ".genesis" / "restore_status.json").read_text())
+    assert status["success"] is False, status
+    assert any("lock" in f for f in status["failures"]), status
+
+
+def test_backup_gc_autodetach_disabled(sandbox):
+    """A detached auto-gc would inherit the held lock fd past exit — backup
+    must pin gc.autoDetach false in the clone."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    proc, _ = _run_backup(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    got = subprocess.run(
+        ["git", "config", "gc.autoDetach"],
+        cwd=str(sandbox["clone"]),
+        capture_output=True,
+        text=True,
+    )
+    assert got.stdout.strip() == "false", got.stdout
+
+
+# ── SF4: round-trip verify ───────────────────────────────────────────
+
+
+def test_roundtrip_env_passphrase_verified(sandbox):
+    """No escrow → round-trip runs with the env passphrase and passes."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    proc, status = _run_backup(sandbox)
+    assert "round-trip decrypt verified (passphrase source: env)" in proc.stdout, proc.stdout
+    assert status["success"] is True, status
+
+
+def test_roundtrip_escrow_drift_fails_backup(sandbox):
+    """Escrowed passphrase differs from the env one (rotation drift) → the
+    round-trip fails, the backup fails loudly, and the alert names it."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    escrow = sandbox["home"] / ".genesis" / "shared" / "guardian"
+    escrow.mkdir(parents=True)
+    (escrow / "backup_passphrase.env").write_text("GENESIS_BACKUP_PASSPHRASE=stale-rotated-away\n")
+    proc, status = _run_backup(sandbox)
+    assert status["success"] is False, status
+    assert "round-trip" in status["failure_reason"], status
+    assert status["sqlite_lines"] == 0, status
+    tg = sandbox["tg"].read_text() if sandbox["tg"].exists() else ""
+    assert "backup failed" in tg.lower(), tg
+
+
+def test_roundtrip_escrow_matching_passes(sandbox):
+    """Escrow present and matching → verified against the escrow copy."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    escrow = sandbox["home"] / ".genesis" / "shared" / "guardian"
+    escrow.mkdir(parents=True)
+    (escrow / "backup_passphrase.env").write_text("GENESIS_BACKUP_PASSPHRASE=testpass\n")
+    proc, status = _run_backup(sandbox)
+    assert "passphrase source: escrow" in proc.stdout, proc.stdout
+    assert status["success"] is True, status
+
+
+# ── SF3: freshness gate ──────────────────────────────────────────────
+
+
+def test_qdrant_down_fails_backup(sandbox):
+    """Server unreachable is a FAILURE (the audit hole: it used to read as
+    'collection may not exist' and report success forever)."""
+    _install_curl(sandbox, _CURL_DOWN)
+    proc, status = _run_backup(sandbox)
+    assert status["success"] is False, status
+    assert "Qdrant backup failed" in status["failure_reason"], status
+    assert "probe" in status["failure_reason"], status
+
+
+def test_qdrant_absent_is_benign(sandbox):
+    """A real 404 (collection genuinely absent — fresh install) stays a
+    benign skip: success:true, no Qdrant failure recorded."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    proc, status = _run_backup(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert status["success"] is True, status
+    assert "Qdrant" not in status["failure_reason"], status
+
+
+def test_fresh_qdrant_uploaded_offsite(sandbox):
+    """Healthy Qdrant → both collections snapshot fresh and land in the
+    off-site dated snapshot with a COMPLETE marker."""
+    _install_curl(sandbox, _CURL_HEALTHY)
+    proc, status = _run_backup(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert status["success"] is True, status
+    assert status["qdrant_collections"] == 2, status
+    files = _offsite_files(sandbox)
+    assert any(f.endswith("qdrant/episodic_memory.snapshot.gpg") for f in files), files
+    assert any(f.endswith("qdrant/knowledge_base.snapshot.gpg") for f in files), files
+    assert any(f.endswith("/COMPLETE") for f in files), files
+
+
+def test_stale_qdrant_gpg_excluded_from_offsite(sandbox):
+    """A leftover .gpg from a prior run (this run's snapshot failed with the
+    collection absent) is EXCLUDED from the new dated snapshot but KEPT
+    locally (last-good copy)."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    stale = sandbox["clone"] / "data" / "qdrant"
+    stale.mkdir(parents=True)
+    (stale / "episodic_memory.snapshot.gpg").write_bytes(b"old-bytes")
+    proc, status = _run_backup(sandbox)
+    assert "stale (not regenerated this run)" in proc.stdout, proc.stdout
+    files = _offsite_files(sandbox)
+    assert not any("episodic_memory" in f for f in files), files
+    assert (stale / "episodic_memory.snapshot.gpg").read_bytes() == b"old-bytes"
+
+
+def test_stale_sql_excluded_from_offsite(sandbox):
+    """SQL variant of the freshness gate: no DB this run + a leftover
+    genesis.sql.gpg → excluded from the off-site snapshot (and the backup
+    already fails via no-SQLite-data)."""
+    _install_curl(sandbox, _CURL_ABSENT)
+    (sandbox["gd"] / "data" / "genesis.db").unlink()
+    data_dir = sandbox["clone"] / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "genesis.sql.gpg").write_bytes(b"old-sql")
+    proc, status = _run_backup(sandbox)
+    assert status["success"] is False, status
+    assert "genesis.sql.gpg is stale" in proc.stdout, proc.stdout
+    files = _offsite_files(sandbox)
+    assert not any(f.endswith("data/genesis.sql.gpg") for f in files), files
+
+
+# ── SF5: backend timeouts ────────────────────────────────────────────
+
+
+def _bash_lib(sb, script: str, **envx) -> subprocess.CompletedProcess:
+    env = _env(sb, **envx)
+    return subprocess.run(
+        ["bash", "-c", f'set -uo pipefail; source "{_BACKENDS}"; backend_init; {script}'],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_local_put_bounded_by_xfer_timeout(sandbox):
+    """A hung transfer (stub cp sleeps past the budget) returns 124, not ∞ —
+    the caller's `|| _T2_OK=false` degrades to partial instead of wedging."""
+    _make_stub(sandbox["bind"] / "cp", "#!/usr/bin/env bash\nsleep 5\n")
+    src = sandbox["tmp"] / "payload"
+    src.write_text("x")
+    proc = _bash_lib(
+        sandbox, f'backend_put "{src}" "dst/payload"; echo "rc=$?"', GENESIS_BACKUP_XFER_TIMEOUT="1"
+    )
+    assert "rc=124" in proc.stdout, f"{proc.stdout}\n{proc.stderr}"
+
+
+def test_smb_ops_run_under_timeout(sandbox):
+    """A hung smbclient is BOUNDED by the ctl tier (nonzero within ~1s — the
+    exists pipeline surfaces awk's exit under pipefail, so assert the bound,
+    not the literal 124), and put/get escalate to the xfer tier (dynamic-scope
+    override observed by the sleep surviving 1s ctl but dying at 2s xfer)."""
+    _make_stub(sandbox["bind"] / "smbclient", "#!/usr/bin/env bash\nsleep 10\n")
+    proc = _bash_lib(
+        sandbox,
+        'start=$SECONDS; backend_exists "x"; echo "ctl=$? elapsed=$((SECONDS-start))"',
+        GENESIS_BACKUP_TIER2_BACKEND="smb",
+        GENESIS_BACKUP_NAS="//nas/share",
+        GENESIS_BACKUP_CTL_TIMEOUT="1",
+        GENESIS_BACKUP_XFER_TIMEOUT="2",
+    )
+    assert "ctl=0" not in proc.stdout, f"{proc.stdout}\n{proc.stderr}"
+    ctl_elapsed = int(proc.stdout.split("elapsed=")[1].split()[0])
+    assert ctl_elapsed <= 4, f"exists must be ctl-bounded (~1s), sleep is 10s: {proc.stdout}"
+    src = sandbox["tmp"] / "p2"
+    src.write_text("x")
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'set -uo pipefail; source "{_BACKENDS}"; backend_init; '
+            f'start=$SECONDS; backend_put "{src}" "d/p2"; rc=$?; '
+            'echo "rc=$rc elapsed=$((SECONDS-start))"',
+        ],
+        env=_env(
+            sandbox,
+            GENESIS_BACKUP_TIER2_BACKEND="smb",
+            GENESIS_BACKUP_NAS="//nas/share",
+            GENESIS_BACKUP_CTL_TIMEOUT="1",
+            GENESIS_BACKUP_XFER_TIMEOUT="2",
+        ),
+        capture_output=True,
+        text=True,
+    )
+    assert "rc=124" in proc.stdout, f"{proc.stdout}\n{proc.stderr}"
+    elapsed = int(proc.stdout.split("elapsed=")[1].split()[0])
+    assert elapsed >= 2, f"put must use the xfer tier, not ctl: {proc.stdout}"
+
+
+def test_backend_available_local_bounded(sandbox):
+    """backend_available's local arm runs under timeout (external test, not
+    the unboundable [ -d ] builtin) and still answers correctly."""
+    proc = _bash_lib(sandbox, "backend_available && echo yes || echo no")
+    assert "yes" in proc.stdout, f"{proc.stdout}\n{proc.stderr}"
+    proc = _bash_lib(
+        sandbox,
+        "backend_available && echo yes || echo no",
+        GENESIS_BACKUP_LOCAL_PATH=str(sandbox["tmp"] / "missing"),
+    )
+    assert "no" in proc.stdout, f"{proc.stdout}\n{proc.stderr}"
+
+
+# ── regression: the restore escrow refactor keeps its contract ───────
+
+
+def test_escrow_lib_contract(sandbox):
+    """passphrase_escrow_lookup: candidate order, export-prefix tolerance,
+    no quote-stripping, always-0 return under set -e."""
+    lib = _SCRIPTS / "lib" / "passphrase_escrow.sh"
+    escrow = sandbox["home"] / ".genesis" / "shared" / "guardian"
+    escrow.mkdir(parents=True)
+    (escrow / "backup_passphrase.env").write_text('export GENESIS_BACKUP_PASSPHRASE="quoted"pass\n')
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'set -euo pipefail; source "{lib}"; passphrase_escrow_lookup; '
+            'printf "%s|%s" "$ESCROW_PASSPHRASE" "$ESCROW_SOURCE"',
+        ],
+        env=_env(sandbox),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    val, src = proc.stdout.split("|")
+    assert val == '"quoted"pass', f"quotes must survive: {val!r}"
+    assert src.endswith("backup_passphrase.env"), src
+    # No escrow anywhere → empty result, still exit 0 under set -e.
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'set -euo pipefail; source "{lib}"; passphrase_escrow_lookup; '
+            'printf "[%s]" "$ESCROW_PASSPHRASE"; echo ok',
+        ],
+        env=_env(sandbox, HOME=str(sandbox["tmp"] / "empty-home")),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0 and "[]" in proc.stdout and "ok" in proc.stdout, (
+        f"{proc.stdout}\n{proc.stderr}"
+    )


### PR DESCRIPTION
## Summary

P1a of the deploy-script-audit remediation (report 04 `backup/restore`, findings **SF3/SF4/SF5** — the "silent until disaster" bucket). Architect-reviewed pre-build (DONE_WITH_CONCERNS; all findings folded in, including the BLOCKER below).

### SF5 — mutual exclusion + hang bounds
- `backup.sh` and `restore.sh` share a whole-run flock (`~/.genesis/locks/backup-restore.lock`). Timer backup **skips** non-fatally when a restore holds it; the skip sits **before** the EXIT trap so `backup_status.json` is never rewritten (a `success:false` there pages CRITICAL via `errors.py:backup:last_failed` during a legitimate restore). Wedged-holder detection stays honest via the existing >8h `backup:overdue` alert. Restore **waits** (`GENESIS_RESTORE_LOCK_WAIT`, default 300s) then dies naming the holder (append-mode lock open, so a losing contender can't truncate the holder line).
- **Deliberately NOT honored by backup.sh: `update_in_progress.pid`** — update.sh invokes backup.sh as its pre-update backup while the dashboard orchestrator holds that marker; honoring it would silently skip every pre-deploy backup while update.sh prints "Backup complete" (architect-review BLOCKER, resolved by dropping the check — the flock alone covers the real hazard).
- Every backend op is time-bounded in three env-overridable tiers (`ctl` 60s / `xfer` 1800s / `del` 600s — sized to the ~282MB largest real payload and O(files) snapshot deletes). `backend_available`'s local arm + `_local_exists` use external `test` under `timeout` (builtins can't be bounded on a hung mount). Qdrant curls get `--max-time`. `gc.autoDetach=false` in the backup clone so a detached gc can't inherit the held lock fd.

### SF4 — decrypt round-trip
The freshly encrypted SQL dump is stream-verified (`gpg -d | tail -5 | grep '^COMMIT;'`) with the **escrowed** passphrase when present — env-encrypt + escrow-decrypt is precisely the rotation-drift detector (a rotated-but-not-escrowed passphrase means an undecryptable backup exactly when secrets.env is lost) — else the env passphrase (corruption/bad-dump detector; a failed dump ends `ROLLBACK;`). Failure fails the backup, naming the gpg error. Escrow lookup extracted to `scripts/lib/passphrase_escrow.sh`, shared behavior-preserving with restore.sh (candidate order, `export`-prefix tolerance, no quote-stripping).

### SF3 — freshness gate
Only payloads regenerated **this run** enter the off-site dated snapshot (SQL + Qdrant variants). Stale leftovers from a failed prior section are excluded (kept locally as last-good) instead of re-badged under a fresh COMPLETE stamp — which misrepresented recency and let GFS retention age out the snapshots holding genuinely-fresh data. The Qdrant existence probe now branches on HTTP code: **404 = benign absent; anything else (down/misrouted server) fails the backup** — previously every outage read as "collection may not exist" and backups reported success forever. COMPLETE semantics deliberately kept as "everything in this snapshot uploaded fully": fresh-SQL-with-missing-qdrant beats no-COMPLETE-for-a-week (Qdrant is rebuildable from SQLite; the DB is not).

## Tests

`tests/test_scripts/test_dr_integrity_core.py` — 14 functional sandboxed tests (real `flock`/`gpg`/`git`/`sqlite3`, per-scenario `curl` stubs, real `local` backend so upload assertions are actual files): lock skip writes no status; restore timeout names holder + records failure; round-trip env/escrow-match/escrow-drift; probe 404-benign vs down-fails; fresh-uploaded vs stale-excluded (SQL + Qdrant); timeout tiers incl. the dynamic-scope xfer escalation; escrow-lib contract. Existing backup test stubs taught to answer the probe with 404 (the designed behavior change: connection failure is no longer benign). Full DR surface green: **57/57** across 6 test files.

## Deploy path

Existing installs: next `update.sh` pull (scripts are re-read per run — no service restart needed; the lock dir auto-creates). Fresh clones: nothing extra. No Host-Deploy Gate (no guardian/host paths).

Audit source: `deploy-audit-2026-07-13/04-backup-restore.md` · Plan: calm-honking-meadow §P1a

🤖 Generated with [Claude Code](https://claude.com/claude-code)