### PR TITLE
fix(memory): size the proactive-recall budget to the measured production engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Per-prompt memory recall no longer silently degrades on busy installs.**
+  The server-side recall budget behind the proactive memory hook was sized
+  against a dev install that (unnoticed) ran no reranker and a half-size
+  corpus; on a loaded production install the real pipeline routinely exceeded
+  it, so most prompts fell back to keyword-only recall with a
+  `[Memory·degraded]` banner. The budget now matches the measured production
+  cold path (4.5s server / 4.75s client, still inside the hook's 10s ceiling),
+  the cross-encoder rerank stage is timeboxed at 1s (degrading to fusion order
+  rather than eating the whole budget), recall responses report whether
+  reranking actually **executed** (not merely was requested — the
+  requested-vs-executed confusion is how the old budget got validated), and
+  slow recalls log a per-stage timing breakdown to the journal.
+
 ### Added
 
 - **Genesis's tunable cognition knobs now live in one auditable file.** Three

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -71,10 +71,16 @@ Easy-to-forget mechanisms:
 - **`drift_recall`** (`memory/drift.py`) is the degraded-mode fallback; its
   FTS drilldown searches every collection in `source_collections`,
   rank-merged across collections.
-- The proactive per-prompt path is `scripts/proactive_memory_hook.py` — an
-  **independent reimplementation** (own FTS5→Qdrant→RRF pipeline), not a
-  `HybridRetriever` caller. The `memory_proactive` MCP tool is registered but
-  has zero internal callers — the hook is the live path.
+- The proactive per-prompt path is `scripts/proactive_memory_hook.py` — since
+  #1169 a **thin HTTP client** of `POST /api/genesis/hook/recall`
+  (`dashboard/routes/proactive.py` → `memory/proactive.py::proactive_context`
+  → the shared `_proactive_impl` engine), with a keyword-only FTS5 fallback
+  when the server can't answer. Latency budget: 4.5s server / 4.75s client
+  (sized to the production engine's measured cold path — embed + a 1.0s
+  rerank timebox + retrieval under load; see the #1169 timeout
+  investigation), inside the hook wrapper's 10s ceiling. The
+  `memory_proactive` MCP tool shares the engine but stays unfiltered/
+  un-reranked.
 - `procedure_recall` deliberately uses Jaccard tag-overlap
   (`learning/procedural/matcher.py find_relevant`), not hybrid retrieval.
 - External-world recall results are provenance-wrapped (`wrap_external_recall`)

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -69,10 +69,14 @@ _SERVER_BASE = os.environ.get(
     "http://127.0.0.1:5000",
 ).rstrip("/")
 _RECALL_ENDPOINT = f"{_SERVER_BASE}/api/genesis/hook/recall"
-# Client budget slightly ABOVE the server's 2.0s _async_route timeout so the
+# Client budget slightly ABOVE the server's 4.5s _async_route timeout so the
 # server times out first and returns a clean 503 (→ fallback), rather than the
 # client aborting mid-flight; the short connect timeout catches a down server fast.
-_SERVER_TIMEOUT_S = 2.2
+# 4.5s is sized to the production engine's measured cold path (embed + rerank
+# timebox + retrieval under load) — the original 2.0s degraded ~70% of real
+# prompts to keyword-only recall (#1169 investigation, 2026-07-21). Total stays
+# well inside the hook wrapper's 10s ceiling (.claude/settings.json).
+_SERVER_TIMEOUT_S = 4.75
 _SERVER_CONNECT_TIMEOUT_S = 0.25
 
 # Kill-switch flag consumed by _compute_suppress_ids (H-1 shadow suppression set).

--- a/src/genesis/dashboard/routes/proactive.py
+++ b/src/genesis/dashboard/routes/proactive.py
@@ -9,9 +9,15 @@ every prompt and falls back to a degraded FTS5-only local path on any non-200.
 Open (no bearer token) — same posture as ``/api/genesis/memory/search`` and
 the guardian health probe (user decision 2026-07-19); loopback bind + the
 memory system already being reachable via ``/api/genesis/memory/search`` mean
-a token would add friction without closing a new surface. Bounded at 2.0s (the
-per-prompt latency budget) — on expiry the worker returns 503 and the hook
-falls back rather than blocking the prompt.
+a token would add friction without closing a new surface. Bounded at 4.5s —
+on expiry the worker returns 503 and the hook falls back rather than blocking
+the prompt. The bound is sized to the MEASURED cold-path p99 of the production
+engine (2026-07-21: DeepInfra embed ~0.4-1.0s + Voyage rerank ≤1.0s timebox +
+retrieval/enrichment ~0.2-2.0s under load on a 60k-row corpus), with headroom
+left inside the hook wrapper's 10s ceiling for the hook's own session-local
+work. The original 2.0s value was validated on an install that silently ran
+no reranker (missing API key), shadow graph expansion, and half the corpus —
+see the #1169 timeout investigation.
 """
 
 from __future__ import annotations
@@ -26,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 @blueprint.route("/api/genesis/hook/recall", methods=["POST"])
-@_async_route(timeout=2.0)
+@_async_route(timeout=4.5)
 async def proactive_recall():
     """Build proactive injection context for one prompt (hook backend)."""
     from genesis.runtime import GenesisRuntime

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -818,6 +818,8 @@ async def _proactive_impl(
     extra_fts_terms: list[str] | None = None,
     filter_noise: bool = False,
     kb_slots: int | None = None,
+    rerank_timeout_s: float | None = None,
+    stats: dict | None = None,
 ) -> list[dict]:
     """Cross-session context injection for prompts — shared engine.
 
@@ -830,7 +832,9 @@ async def _proactive_impl(
 
     Backs both the ``memory_proactive`` MCP tool (rerank off, no extra terms,
     no noise filter, no KB cap) and the genesis-server proactive recall endpoint
-    (rerank + file-context terms + ``filter_noise`` + ``kb_slots`` per config).
+    (rerank + file-context terms + ``filter_noise`` + ``kb_slots`` per config,
+    plus ``rerank_timeout_s``/``stats`` — the per-prompt latency timebox and
+    stage-telemetry sink; both ``None`` on the MCP path, byte-for-byte no-op).
     The shared security stages (memory_operation filter, injection-defense wrap,
     gate-4 enforce-drop, graph expansion, immunity emit) run for both callers.
     The endpoint is DELIBERATELY stricter on injection QUALITY: ``filter_noise``
@@ -864,6 +868,8 @@ async def _proactive_impl(
         limit=limit * 2,
         min_activation=0.0,
         rerank=rerank,
+        rerank_timeout_s=rerank_timeout_s,
+        stats=stats,
         extra_fts_terms=extra_fts_terms,
         skip_writeback=lambda r: (
             immunity_shadow.should_enforce_drop(

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -55,6 +55,18 @@ _DEFAULT_BUDGETS: dict[str, int] = {
     "max": 8,
 }
 
+# Timebox on the cross-encoder rerank stage for THIS (per-prompt, latency-
+# budgeted) path only — deep-search callers (memory_recall MCP) are unbounded.
+# Measured 2026-07-21 on the production install: Voyage rerank ≈ 400ms typical,
+# but its client allows 10s and a slow call alone can eat the route budget. On
+# expiry the engine keeps RRF order (identical contract to an API failure).
+# User-set value (2026-07-21): 1.0s.
+_RERANK_TIMEOUT_S = 1.0
+
+# Emit one INFO journal line with the stage breakdown when a call exceeds this
+# — slow calls become diagnosable from the journal without live probing.
+_SLOW_RECALL_LOG_MS = 2000.0
+
 
 def _proactive_config() -> dict[str, Any]:
     """The ``proactive`` section of the merged memory_recall config (live)."""
@@ -582,6 +594,8 @@ async def proactive_context(
     # retrieved_count write-backs (Codex on #1169). memory_proactive (the MCP
     # tool) passes neither, so it is byte-for-byte unchanged.
     kb_slots = max(1, budget // 3)
+    engine_stats: dict[str, Any] = {}
+    t_recall = time.monotonic()
     dicts = await _core._proactive_impl(
         prompt,
         limit=budget,
@@ -589,13 +603,19 @@ async def proactive_context(
         extra_fts_terms=[k for k in (file_keywords or []) if k] or None,
         filter_noise=True,
         kb_slots=kb_slots,
+        rerank_timeout_s=_RERANK_TIMEOUT_S,
+        stats=engine_stats,
     )
+    recall_ms = (time.monotonic() - t_recall) * 1000
 
+    t_enrich = time.monotonic()
     await _enrich(db, dicts)
     await _breadcrumbs(db, dicts)
+    enrich_ms = (time.monotonic() - t_enrich) * 1000
 
     lines = prof.renderer(dicts)
 
+    t_proc = time.monotonic()
     procedure = None
     if vector:
         procedure = await _surface_procedure(db, vector)
@@ -609,7 +629,8 @@ async def proactive_context(
             # SEMANTIC: counts "the engine included this procedure in a RETURNED
             # recall response." Under the split client/server model this can
             # marginally over-count vs "the user saw it": if this response is slow
-            # enough that the client times out (>2.2s under heavy concurrency) and
+            # enough that the client times out (past its budget, see the hook's
+            # _SERVER_TIMEOUT_S) and
             # falls back to the degraded path, the bump already committed but the
             # line was never injected. Accepted — surfaced_count is advisory (never
             # feeds promotion) and the window is a narrow race; a perfect fix would
@@ -624,10 +645,26 @@ async def proactive_context(
             except Exception:
                 logger.debug("surfaced_count bump failed", exc_info=True)
 
+    procedure_ms = (time.monotonic() - t_proc) * 1000
+
     shadow = _shadow_projection(dicts, suppress)
     results = [_result_row(d) for d in dicts]
 
     total_ms = (time.monotonic() - t0) * 1000
+    timings = {
+        "embed": round(embed_ms, 1),
+        "recall": round(recall_ms, 1),
+        "enrich": round(enrich_ms, 1),
+        "procedure": round(procedure_ms, 1),
+        "total": round(total_ms, 1),
+    }
+    if "rerank_ms" in engine_stats:
+        timings["rerank"] = engine_stats["rerank_ms"]
+    if total_ms > _SLOW_RECALL_LOG_MS:
+        # One INFO line per slow call so a latency regression is diagnosable
+        # from the journal alone (the 503 path discards timings_ms entirely —
+        # this was the observability gap behind the #1169 timeout hunt).
+        logger.info("proactive recall slow: %s", timings)
     return {
         "status": "ok",
         "lines": lines,
@@ -636,9 +673,15 @@ async def proactive_context(
         "shadow": shadow,
         "budget": {"stance": stance, "limit": budget, "kb_slots": kb_slots, "cap": cap},
         "embedding": vector,
-        "timings_ms": {"embed": round(embed_ms, 1), "total": round(total_ms, 1)},
+        "timings_ms": timings,
         "engine": {
-            "reranked": rerank_live,
+            # EXECUTED, not requested — a missing Voyage key, API failure, or
+            # timebox expiry leaves results in RRF order even when the profile
+            # asked to rerank. (The requested-not-executed reading of this flag
+            # is how the 2.0s budget got validated against a no-rerank install.)
+            "reranked": bool(engine_stats.get("rerank_executed", False)),
+            "rerank_requested": rerank_live,
+            "rerank_timed_out": bool(engine_stats.get("rerank_timed_out", False)),
             "graph_expansion": graph_expansion.expansion_mode(),
             "intent": classify_intent(prompt).category,
             "profile": profile,

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import logging
 import math
@@ -631,8 +632,22 @@ class HybridRetriever:
         event_id_sink: list[str] | None = None,
         skip_writeback: Callable[[RetrievalResult], bool] | None = None,
         extra_fts_terms: list[str] | None = None,
+        rerank_timeout_s: float | None = None,
+        stats: dict | None = None,
     ) -> list[RetrievalResult]:
         """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF.
+
+        ``rerank_timeout_s``: optional wall-clock bound on the cross-encoder
+        rerank stage ONLY (latency-budgeted callers, e.g. the per-prompt
+        proactive path). On expiry the stage degrades to RRF order — the
+        same contract as a reranker API failure. ``None`` (default, all
+        deep-search callers) keeps the reranker's own HTTP timeout as the
+        only bound.
+
+        ``stats``: optional caller-owned dict populated with rerank stage
+        telemetry (``rerank_executed``, ``rerank_ms``, ``rerank_timed_out``).
+        Caller-owned so concurrent recalls on the shared retriever can never
+        race each other's numbers.
 
         Source selection:
             - ``source=None`` (default): classify the query's intent and
@@ -812,6 +827,8 @@ class HybridRetriever:
             fts_by_id=fts_by_id,
             limit=limit,
             rerank=rerank,
+            timeout_s=rerank_timeout_s,
+            stats=stats,
         )
 
         # 7b. Graph boost: backlink + adjacency (floor-gated); mutates
@@ -1283,6 +1300,8 @@ class HybridRetriever:
         fts_by_id: dict[str, dict],
         limit: int,
         rerank: bool,
+        timeout_s: float | None = None,
+        stats: dict | None = None,
     ) -> dict[str, float]:
         """Stage 7.5: cross-encoder reranking (optional, off by default).
 
@@ -1293,9 +1312,18 @@ class HybridRetriever:
         didn't score are dropped — if they lacked content or fell below
         top_k, they weren't strong enough to keep.
 
+        ``timeout_s`` bounds the reranker call for latency-budgeted callers;
+        on expiry the stage keeps RRF order (identical to an API failure,
+        which already returns ``[]``). ``stats`` (caller-owned) records
+        whether reranking actually EXECUTED — distinct from "was requested":
+        a missing API key, empty candidate set, API failure, or timebox
+        expiry all leave results in RRF order while ``rerank=True``.
+
         Returns the SAME ``fused`` object when reranking is skipped, or a
         replacement positional-score dict when it ran.
         """
+        if stats is not None:
+            stats.setdefault("rerank_executed", False)
         if rerank and self._reranker and self._reranker.enabled and fused:
             rerank_candidates = sorted(
                 fused,
@@ -1313,12 +1341,31 @@ class HybridRetriever:
                 if content:
                     rerank_docs.append({"id": mid, "text": content})
             if rerank_docs:
-                reranked = await self._reranker.rerank(
+                t0 = time.monotonic()
+                coro = self._reranker.rerank(
                     query,
                     rerank_docs,
                     top_k=limit * 2,
                 )
+                try:
+                    if timeout_s is not None:
+                        reranked = await asyncio.wait_for(coro, timeout=timeout_s)
+                    else:
+                        reranked = await coro
+                except TimeoutError:
+                    logger.warning(
+                        "Rerank exceeded %.1fs timebox — keeping RRF order",
+                        timeout_s,
+                    )
+                    if stats is not None:
+                        stats["rerank_timed_out"] = True
+                        stats["rerank_ms"] = round((time.monotonic() - t0) * 1000, 1)
+                    return fused
+                if stats is not None:
+                    stats["rerank_ms"] = round((time.monotonic() - t0) * 1000, 1)
                 if reranked:
+                    if stats is not None:
+                        stats["rerank_executed"] = True
                     # Rebuild fused with only reranked candidates, using
                     # positional scores so graph boost floor-gating works.
                     fused = {item["id"]: 1.0 / (1 + rank) for rank, item in enumerate(reranked)}

--- a/tests/test_memory/test_proactive_engine.py
+++ b/tests/test_memory/test_proactive_engine.py
@@ -269,18 +269,35 @@ async def test_proactive_context_end_to_end_faked():
     # embedding returned for the hook's ambient fold
     assert resp["embedding"] == [0.1] * 8
     assert resp["engine"]["profile"] == "cc_hook"
-    assert resp["engine"]["reranked"] is True
+    # ``reranked`` reports EXECUTED, not requested — the faked impl never
+    # populates the stats sink, so this is honestly False even though the
+    # cc_hook profile requested reranking.
+    assert resp["engine"]["reranked"] is False
+    assert resp["engine"]["rerank_requested"] is True
+    assert resp["engine"]["rerank_timed_out"] is False
+    # Per-stage timings present (values are wall-clock, just assert shape).
+    for key in ("embed", "recall", "enrich", "procedure", "total"):
+        assert key in resp["timings_ms"]
 
 
 async def test_proactive_context_passes_file_keywords_as_extra_fts_terms():
     captured = {}
 
     async def _fake_impl(
-        prompt, limit=5, *, rerank=False, extra_fts_terms=None, filter_noise=False, kb_slots=None
+        prompt,
+        limit=5,
+        *,
+        rerank=False,
+        extra_fts_terms=None,
+        filter_noise=False,
+        kb_slots=None,
+        rerank_timeout_s=None,
+        stats=None,
     ):
         captured["extra"] = extra_fts_terms
         captured["rerank"] = rerank
         captured["limit"] = limit
+        captured["rerank_timeout_s"] = rerank_timeout_s
         return []
 
     with (
@@ -295,6 +312,7 @@ async def test_proactive_context_passes_file_keywords_as_extra_fts_terms():
     assert captured["extra"] == ["memory", "retrieval"]  # falsy dropped
     assert captured["rerank"] is True  # cc_hook default
     assert captured["limit"] == 1  # command budget
+    assert captured["rerank_timeout_s"] == P._RERANK_TIMEOUT_S  # hot-path timebox threaded
 
 
 async def test_proactive_context_bumps_surfaced_count_not_invocation():
@@ -399,7 +417,15 @@ async def test_proactive_context_requests_noise_filter():
     captured = {}
 
     async def _fake_impl(
-        prompt, limit=5, *, rerank=False, extra_fts_terms=None, filter_noise=False, kb_slots=None
+        prompt,
+        limit=5,
+        *,
+        rerank=False,
+        extra_fts_terms=None,
+        filter_noise=False,
+        kb_slots=None,
+        rerank_timeout_s=None,
+        stats=None,
     ):
         captured["filter_noise"] = filter_noise
         return []
@@ -411,6 +437,65 @@ async def test_proactive_context_requests_noise_filter():
         await P.proactive_context(prompt="what did we decide about the recall reranker")
 
     assert captured["filter_noise"] is True
+
+
+async def test_proactive_context_surfaces_engine_stats():
+    """Rerank telemetry flows from the engine's stats sink into the response:
+    ``engine.reranked`` mirrors EXECUTED (not requested), ``timings_ms.rerank``
+    carries the stage latency, and a timebox expiry is flagged."""
+
+    async def _fake_impl(
+        prompt,
+        limit=5,
+        *,
+        rerank=False,
+        extra_fts_terms=None,
+        filter_noise=False,
+        kb_slots=None,
+        rerank_timeout_s=None,
+        stats=None,
+    ):
+        if stats is not None:
+            stats["rerank_executed"] = True
+            stats["rerank_ms"] = 123.4
+        return []
+
+    with (
+        patch("genesis.mcp.memory.core._memory_mod", return_value=_FakeMod()),
+        patch("genesis.mcp.memory.core._proactive_impl", new=_fake_impl),
+    ):
+        resp = await P.proactive_context(prompt="what did we decide about voice STT")
+
+    assert resp["engine"]["reranked"] is True
+    assert resp["engine"]["rerank_timed_out"] is False
+    assert resp["timings_ms"]["rerank"] == 123.4
+
+    async def _timed_out_impl(
+        prompt,
+        limit=5,
+        *,
+        rerank=False,
+        extra_fts_terms=None,
+        filter_noise=False,
+        kb_slots=None,
+        rerank_timeout_s=None,
+        stats=None,
+    ):
+        if stats is not None:
+            stats["rerank_executed"] = False
+            stats["rerank_timed_out"] = True
+            stats["rerank_ms"] = 1000.2
+        return []
+
+    with (
+        patch("genesis.mcp.memory.core._memory_mod", return_value=_FakeMod()),
+        patch("genesis.mcp.memory.core._proactive_impl", new=_timed_out_impl),
+    ):
+        resp = await P.proactive_context(prompt="what did we decide about voice STT")
+
+    assert resp["engine"]["reranked"] is False
+    assert resp["engine"]["rerank_timed_out"] is True
+    assert resp["timings_ms"]["rerank"] == 1000.2
 
 
 def test_is_proactive_noise_predicate():

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -940,6 +941,110 @@ async def test_recall_reranker_replaces_fused_with_positional_scores(
     assert [r.memory_id for r in results] == ["mem-2", "mem-1"]
     assert results[0].score == pytest.approx(1.0)   # 1/(1+0)
     assert results[1].score == pytest.approx(0.5)   # 1/(1+1)
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_rerank_timebox_expiry_keeps_rrf_order(
+    mock_qdrant,
+    mock_crud,
+    mock_links,
+    _mock_expand,
+):
+    """A rerank call slower than ``rerank_timeout_s`` degrades to RRF order —
+    identical contract to an API failure — and the stats sink records the
+    expiry instead of claiming a rerank executed."""
+    embed_provider = MagicMock()
+    embed_provider.embed = AsyncMock(return_value=[0.1] * 1024)
+    reranker = MagicMock()
+    reranker.enabled = True
+
+    async def _slow_rerank(*args, **kwargs):
+        await asyncio.sleep(5)
+        return [{"id": "mem-2"}]
+
+    reranker.rerank = _slow_rerank
+    retriever = HybridRetriever(
+        embedding_provider=embed_provider,
+        qdrant_client=MagicMock(),
+        db=MagicMock(spec_set=["execute", "commit"]),
+        reranker=reranker,
+    )
+
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("mem-1", 0.95),
+        _make_qdrant_hit("mem-2", 0.80),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _setup_link_mocks(mock_links)
+
+    stats: dict = {}
+    results = await retriever.recall(
+        "test query",
+        limit=5,
+        rerank=True,
+        rerank_timeout_s=0.05,
+        stats=stats,
+    )
+
+    # RRF order preserved; nothing dropped by the (aborted) reranker.
+    assert [r.memory_id for r in results] == ["mem-1", "mem-2"]
+    assert stats["rerank_executed"] is False
+    assert stats["rerank_timed_out"] is True
+    assert stats["rerank_ms"] >= 50.0
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_stats_report_rerank_executed_vs_api_failure(
+    mock_qdrant,
+    mock_crud,
+    mock_links,
+    _mock_expand,
+):
+    """``stats['rerank_executed']`` is True only when the reranker actually
+    returned an ordering; an API failure (empty return) reports False — the
+    requested-vs-executed distinction the #1169 budget validation missed."""
+    embed_provider = MagicMock()
+    embed_provider.embed = AsyncMock(return_value=[0.1] * 1024)
+    reranker = MagicMock()
+    reranker.enabled = True
+    reranker.rerank = AsyncMock(return_value=[{"id": "mem-2"}, {"id": "mem-1"}])
+    retriever = HybridRetriever(
+        embedding_provider=embed_provider,
+        qdrant_client=MagicMock(),
+        db=MagicMock(spec_set=["execute", "commit"]),
+        reranker=reranker,
+    )
+
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("mem-1", 0.95),
+        _make_qdrant_hit("mem-2", 0.80),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    _setup_link_mocks(mock_links)
+
+    stats: dict = {}
+    results = await retriever.recall("test query", limit=5, rerank=True, stats=stats)
+    assert [r.memory_id for r in results] == ["mem-2", "mem-1"]
+    assert stats["rerank_executed"] is True
+    assert stats["rerank_ms"] >= 0.0
+    assert "rerank_timed_out" not in stats
+
+    # API failure path: reranker returns [] (its own degrade contract).
+    reranker.rerank = AsyncMock(return_value=[])
+    stats2: dict = {}
+    results = await retriever.recall("test query", limit=5, rerank=True, stats=stats2)
+    assert [r.memory_id for r in results] == ["mem-1", "mem-2"]
+    assert stats2["rerank_executed"] is False
 
 
 # --- mem-007: diversity penalty must not contaminate J9-logged scores ---


### PR DESCRIPTION
## What & why

The thin-client flip (#1169) put the per-prompt recall engine behind a 2.0s server / 2.2s client budget. That budget was validated with a latency proof measured on an install where the pipeline's two most expensive stages were silently absent: no reranker API key (the engine's `reranked: true` meant *requested*, not *executed*), graph expansion in `shadow`, half the memory corpus, and no production load. On a loaded production install the real cold path — network embed (~0.4–1.0s) + cross-encoder rerank (~0.4s) + retrieval/enrichment over a 60k-row corpus — is ~1.5–2.5s, so **~70% of real prompts got a 503 and silently degraded to keyword-only recall**, undoing most of the engine-quality win the flip shipped.

## Changes

- **Budget sized to measurement:** server route timeout 2.0s → 4.5s; hook client budget 2.2s → 4.75s. Still well inside the hook wrapper's 10s ceiling, and no slower than the pre-flip in-process hook ever was — the work always took this long; only the cap changed at the flip.
- **Rerank timeboxed at 1.0s on the per-prompt path only** (`rerank_timeout_s` threaded `proactive_context → _proactive_impl → recall → _maybe_rerank`; expiry degrades to RRF order — the same contract as an API failure). Deep-search callers pass `None` and are byte-for-byte unchanged.
- **Honest rerank telemetry:** `engine.reranked` now reports EXECUTED; `rerank_requested` and `rerank_timed_out` added. The requested-vs-executed conflation is exactly how the original budget got validated against a no-rerank install.
- **Per-stage `timings_ms`** (recall / enrich / procedure / rerank) + one INFO journal line per slow call (>2s), so the next latency regression is diagnosable from the journal — the 503 path used to discard all timing evidence.
- **CURRENT.md**: the proactive-hook bullet still described the pre-#1169 independent-reimplementation architecture; updated to the thin-client reality.

## Verification

- 145 targeted tests green (retrieval, proactive engine, endpoint, async-route, hook subprocess, recall-inject coverage guard); ruff clean.
- New tests: rerank timebox expiry keeps RRF order + flags stats; executed-vs-requested semantics incl. API-failure path; stats flow into `engine`/`timings_ms`; timebox threading asserted at the `proactive_context` boundary.
- Live latency decomposition measured on the production install (probe session, 2026-07-21): cold 8/8 novel prompts exceeded 2.0s; warm 587–1533ms; embed ~490ms fresh-connection / ~215–330ms reused; Voyage rerank ~400ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)