### PR TITLE
fix(dr): DR hygiene — restore-nothing guards, private decrypt, alert/cleanup on abort (SF6/SF7/N-notes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Restore fails loudly instead of silently doing nothing, and decrypted
+  secrets are never briefly world-readable.** Disaster-recovery hygiene fixes:
+  an unattended restore with no terminal (and no `--force`) now aborts with a
+  clear message instead of declining every prompt and reporting success; a
+  restore pointed at an empty or wrong backup fails instead of exiting "success"
+  having restored nothing; a failed pull of the two largest payloads (vectors,
+  transcripts) is now reported rather than silently skipped; decrypted
+  secrets/transcripts/memory are written private-by-default (no world-readable
+  window); the backup-failed alert now fires even when a backup aborts early;
+  and the plaintext database dump is cleaned up even if a backup dies mid-run.
+
 - **Backups now verify the database archive is restorable, can't collide with a
   restore, and never re-badge stale data as fresh.** Three disaster-recovery
   integrity fixes: the 6-hourly backup now decrypt-verifies the SQLite archive

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -88,6 +88,7 @@ _SQL_RESTORABLE=false   # AND round-trip-verified → eligible for off-site COMP
 _SQL_ESCROW_DRIFT=false # env-decryptable but escrow stale → off-site DR degraded
 _QDRANT_FRESH=""    # space-separated collections snapshotted+encrypted this run
 _QDRANT_FAILED=""   # collections that EXIST (HTTP 200) but failed to snapshot this run
+_SQL_TMP=""         # plaintext ~269MB dump temp — trap-cleaned (N2, credential-bearing)
 # Tier-1 replication: true once the local repo is in sync with the GitHub remote.
 _TIER1_PUSHED=false
 # Off-site snapshot bookkeeping. _T2_SNAPSHOT_COUNT / _T2_PRUNED stay UNSET until
@@ -110,7 +111,33 @@ _write_status() {
 {"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"eval_files":${_EVAL_COUNT:-0},"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}","offsite_confirmed":$_offsite_confirmed,"tier2_backend":"${_T2_BACKEND:-none}","snapshot_id":"${_T2_STAMP:-}","snapshot_count":${_T2_SNAPSHOT_COUNT:-null},"pruned_count":${_T2_PRUNED:-null},"tier1_pushed":$_TIER1_PUSHED}
 STATUSEOF
 }
-trap '_write_status; backend_cleanup' EXIT
+
+# BK-N1: fire the backup-FAILED Telegram alert from the EXIT trap, not inline at
+# the end — so an abort OUTSIDE the handled git block (mktemp, git add, clone,
+# an unexpected `set -e` death) still alerts instead of only writing
+# success:false to the status file. Fires exactly once (the inline 🚨 block was
+# removed); the off-site ⚠️ alert stays inline (only reachable on a completed
+# run, and its dedup must read the prior status before _write_status rewrites it).
+_alert_backup_failed() {
+    [ "$_SUCCESS" = "true" ] && return 0
+    _send_telegram "🚨 *Backup failed*
+
+Reason: ${_FAILURE_REASON:-unknown (aborted before completion)}
+Time: $(date -Is)
+SQLite lines: $_SQLITE_LINES
+Duration: $(( $(date +%s) - _STARTED_AT ))s"
+}
+
+_on_exit() {
+    _alert_backup_failed
+    _write_status
+    backend_cleanup
+    # N2: the credential-bearing plaintext SQL dump must not outlive the script
+    # if it died mid-section (before its inline rm).
+    [ -n "${_SQL_TMP:-}" ] && rm -f "$_SQL_TMP"
+    return 0
+}
+trap _on_exit EXIT
 
 GENESIS_DIR="${GENESIS_DIR:-$HOME/genesis}"
 BACKUP_DIR="$HOME/backups/genesis-backups"
@@ -365,8 +392,12 @@ for collection in episodic_memory knowledge_base; do
     # as "may not exist" and every backup reported success with zero fresh
     # Qdrant payloads, forever (the audit's exact hole). --max-time 10: a
     # localhost liveness GET, not a transfer.
+    # curl -w already prints "000" on a connection failure AND exits non-zero,
+    # so `|| echo 000` would double-append → "000000"; swallow the exit with
+    # `|| true` and default only a genuinely-empty capture (curl absent).
     _probe_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
-        "$QDRANT_URL/collections/$collection" 2>/dev/null || echo 000)
+        "$QDRANT_URL/collections/$collection" 2>/dev/null || true)
+    _probe_code=${_probe_code:-000}
     if [ "$_probe_code" = "404" ]; then
         log "Qdrant: collection $collection does not exist — skipping"
         continue
@@ -921,15 +952,8 @@ else
     log "WARNING: Backup incomplete — marking as failure (reason: $_FAILURE_REASON)"
 fi
 
-# --- Alert on failure via Telegram ---
-if [ "$_SUCCESS" != "true" ]; then
-    _send_telegram "🚨 *Backup failed*
-
-Reason: ${_FAILURE_REASON:-unknown}
-Time: $(date -Is)
-SQLite lines: $_SQLITE_LINES
-Duration: $(( $(date +%s) - _STARTED_AT ))s"
-fi
+# The backup-FAILED alert now fires from the EXIT trap (_alert_backup_failed),
+# so it covers early aborts too (BK-N1) and fires exactly once here.
 
 # --- Alert on off-site replication failure (local backup still OK) ---
 # Distinct from a backup failure: the local + Tier-1 backup succeeded, but the

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -120,21 +120,34 @@ STATUSEOF
 # run, and its dedup must read the prior status before _write_status rewrites it).
 _alert_backup_failed() {
     [ "$_SUCCESS" = "true" ] && return 0
-    _send_telegram "🚨 *Backup failed*
+    # `set -e` stays active inside the EXIT trap, and this is the FIRST step of
+    # _on_exit — so it must never abort _on_exit (which would skip _write_status
+    # + the plaintext cleanup below). Two ways it could: (a) an abort in the
+    # narrow window before _send_telegram is defined (a 0-byte secrets.env
+    # failing load_secrets_file) → `declare -F` guard skips the call, and
+    # _write_status still records success:false for the health-alert path;
+    # (b) _send_telegram → queue_alert returning non-zero → `|| true`. Always
+    # returns 0.
+    if declare -F _send_telegram >/dev/null 2>&1; then
+        _send_telegram "🚨 *Backup failed*
 
 Reason: ${_FAILURE_REASON:-unknown (aborted before completion)}
 Time: $(date -Is)
 SQLite lines: $_SQLITE_LINES
-Duration: $(( $(date +%s) - _STARTED_AT ))s"
+Duration: $(( $(date +%s) - _STARTED_AT ))s" || true
+    fi
+    return 0
 }
 
 _on_exit() {
-    _alert_backup_failed
-    _write_status
-    backend_cleanup
+    # Exit handler: every step best-effort so a failure in one never skips the
+    # rest (status write + plaintext cleanup must always run).
+    _alert_backup_failed || true
+    _write_status || true
+    backend_cleanup || true
     # N2: the credential-bearing plaintext SQL dump must not outlive the script
     # if it died mid-section (before its inline rm).
-    [ -n "${_SQL_TMP:-}" ] && rm -f "$_SQL_TMP"
+    rm -f "${_SQL_TMP:-}" 2>/dev/null || true
     return 0
 }
 trap _on_exit EXIT

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -115,7 +115,13 @@ _release_deploy_marker() {
         rm -f "$_UPDATE_PID_FILE"
     fi
 }
-trap '_write_status; _release_deploy_marker; backend_cleanup' EXIT
+# N2: the credential-bearing plaintext SQL dump and decrypted Qdrant snapshot
+# temps are `rm`'d inline, but a mid-section death would leave them in ~/tmp —
+# trap-protect them. (Empty-string default → no-op before they're assigned.)
+_SQL_TMP=""
+_QDRANT_TMP=""
+_cleanup_plaintext() { rm -f "${_SQL_TMP:-}" "${_QDRANT_TMP:-}" 2>/dev/null || true; }
+trap '_write_status; _release_deploy_marker; backend_cleanup; _cleanup_plaintext' EXIT
 
 # ── Setup ────────────────────────────────────────────────────────────
 GENESIS_DIR="${GENESIS_DIR:-$HOME/genesis}"
@@ -151,6 +157,16 @@ if ! flock -w "$_LOCK_WAIT" "$DR_LOCK_FD"; then
     die "backup-restore lock still held by ${_holder:-unknown} after ${_LOCK_WAIT}s — a backup is likely running; wait for it to finish and re-run (or set GENESIS_RESTORE_LOCK_WAIT higher)"
 fi
 dr_lock_stamp restore
+
+# Private-by-default for every plaintext this restore writes (SF7): gpg -d and
+# cp otherwise honor the inherited umask (typically 0022 → world-readable), so a
+# decrypted secrets.env / transcript / memory file (all PII-bearing) would be
+# briefly readable by other users on a multi-user host between write and any
+# chmod. Set once here — before the first write — so no section carries that
+# window. (§8 creds still sets its own umask 077 for defence in depth.) The
+# restored DB and config overlays become 0600 too, which is strictly correct;
+# genesis-server reads them as the same user.
+umask 077
 
 # Large intermediate files (the ~269MB decrypted SQLite .dump, decrypted Qdrant snapshots)
 # must NOT land in the inherited TMPDIR (cc-tmp = the watchgod "oxygen" folder for a CC run;
@@ -247,10 +263,16 @@ resolve_payload() {
 
 # Confirm prompt (skipped with --force or --dry-run).
 confirm() {
-    local prompt="$1"
+    local prompt="$1" reply
     $FORCE && return 0
     $DRY_RUN && return 0
-    read -r -p "$prompt [y/N] " reply
+    # `read` returning non-zero means EOF (no TTY to answer), NOT a decline —
+    # without this, an unattended run (e.g. `python -m genesis restore` with no
+    # --force) has EVERY confirm silently return false, skips every section, and
+    # exits 0 "success" having restored nothing. Refuse loudly instead. (N4)
+    if ! read -r -p "$prompt [y/N] " reply; then
+        die "no TTY to confirm '$prompt' — re-run with --force for an unattended restore"
+    fi
     [[ "$reply" =~ ^[yY]([eE][sS])?$ ]]
 }
 
@@ -344,21 +366,26 @@ _pull_from_offsite() {
     else
         warn "off-site: failed to pull genesis.sql.gpg from snapshot $latest — the database will not be restored from off-site"
     fi
-    # Qdrant snapshots + transcripts: list the subdir, then get each *.gpg. The
-    # staging dir is created only when there's actually something to pull, so an
-    # empty set doesn't make the restore sections below run (and e.g. warn that
-    # Qdrant isn't reachable yet → spurious failure).
+    # Qdrant snapshots + transcripts: list the subdir, then get each *.gpg.
+    # Process substitution (not `list | grep | while`): a failed backend_get of
+    # these — the two LARGEST DR payloads (vectors + the "permanent archive"
+    # transcripts) — must `warn` (→ _FAILURES → non-zero restore), matching the
+    # memory/config/secrets pulls below. A pipe-into-while runs the body in a
+    # SUBSHELL where the _FAILURES append is lost, and its `|| true` masked the
+    # failure entirely — the silent-DR-footgun this converts away from. The
+    # `|| true` on the process-substitution input still absorbs an empty-subdir
+    # grep-miss (staging dir created only when something is actually pulled).
     for sub in qdrant transcripts; do
         dst="$BACKUP_DIR/data/qdrant"
         [ "$sub" = transcripts ] && dst="$BACKUP_DIR/transcripts"
-        # `|| true`: an empty subdir makes `grep` exit non-zero → pipefail would
-        # otherwise abort the whole restore.
-        backend_list "$snap/$sub" | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u | while read -r fname; do
+        while read -r fname; do
             mkdir -p "$dst"
             if backend_get "$snap/$sub/$fname" "$dst/$fname"; then
                 log "  off-site: pulled $sub/$fname"
+            else
+                warn "off-site: failed to pull $sub/$fname from snapshot $latest"
             fi
-        done || true
+        done < <(backend_list "$snap/$sub" | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u || true)
     done
 
     # memory / config overlays / secrets — previously only in the Tier-1 git clone. Pull
@@ -426,6 +453,26 @@ _pull_from_offsite() {
 }
 _pull_from_offsite
 
+# N5: a restore that finds NO payloads at all (empty/wrong BACKUP_DIR, no
+# off-site) used to log "no payload" per section and exit 0 "success" having
+# restored nothing — dangerous for an unattended DR run pointed at the wrong
+# place. Fail loudly up front instead. (A backup that IS present but whose
+# destinations are all newer legitimately no-ops later — that's found-but-
+# skipped, not this empty case, so it still succeeds.)
+_backup_has_payload() {
+    local d="$BACKUP_DIR"
+    [ -f "$d/data/genesis.sql.gpg" ] || [ -f "$d/data/genesis.sql" ] && return 0
+    [ -f "$d/secrets/secrets.env.gpg" ] && return 0
+    find "$d/data/qdrant" "$d/transcripts" "$d/memory" "$d/eval" "$d/creds" \
+        -type f \( -name '*.gpg' -o -name '*.snapshot' -o -name '*.jsonl' \) \
+        -print -quit 2>/dev/null | grep -q . && return 0
+    find "$d/config_overrides" -type f -name '*.local.yaml' -print -quit 2>/dev/null | grep -q . && return 0
+    return 1
+}
+if ! $DRY_RUN && ! _backup_has_payload; then
+    die "no restorable payloads found under $BACKUP_DIR (empty or wrong backup source, and no off-site snapshot pulled) — nothing to restore"
+fi
+
 # Check encrypted payloads exist without passphrase → fail fast.
 _has_encrypted=false
 for candidate in "$BACKUP_DIR"/data/genesis.sql.gpg "$BACKUP_DIR"/secrets/secrets.env.gpg; do
@@ -490,7 +537,12 @@ if resolve_payload "$BACKUP_DIR/data/genesis.sql"; then
                         log "SQLite: restored → $DB_FILE"
                         # Verify the restored DB is structurally sound — loud on failure.
                         # 2>&1 so a sqlite3 error (can't open, etc.) surfaces in the warn.
-                        _ic=$(sqlite3 "$DB_FILE" "PRAGMA integrity_check;" 2>&1 | head -1)
+                        # `|| true`: a HARD sqlite3 error (can't reopen the DB)
+                        # fails the pipeline; under set -e the assignment would
+                        # abort the script BEFORE the warn below, skipping the
+                        # rest of the restore. Capture the error text (2>&1) as
+                        # _ic and let the not-"ok" branch surface it. (N6)
+                        _ic=$(sqlite3 "$DB_FILE" "PRAGMA integrity_check;" 2>&1 | head -1) || true
                         if [ "$_ic" = "ok" ]; then
                             log "SQLite: integrity_check ok"
                         else

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -459,14 +459,30 @@ _pull_from_offsite
 # place. Fail loudly up front instead. (A backup that IS present but whose
 # destinations are all newer legitimately no-ops later — that's found-but-
 # skipped, not this empty case, so it still succeeds.)
+# Any-file (not just *.gpg): §4/§4b restore memory/eval with `find -type f`, so a
+# legacy plaintext memory file (arbitrary extension) IS restorable and must count
+# here — matching what the sections actually accept, or the guard false-fails a
+# valid legacy backup.
+_dir_has_file() { [ -d "$1" ] && find "$1" -type f -print -quit 2>/dev/null | grep -q .; }
 _backup_has_payload() {
-    local d="$BACKUP_DIR"
-    [ -f "$d/data/genesis.sql.gpg" ] || [ -f "$d/data/genesis.sql" ] && return 0
+    local d="$BACKUP_DIR" _m
+    { [ -f "$d/data/genesis.sql.gpg" ] || [ -f "$d/data/genesis.sql" ]; } && return 0
+    _dir_has_file "$d/data/qdrant" && return 0
+    _dir_has_file "$d/transcripts" && return 0
+    _dir_has_file "$d/memory" && return 0
+    _dir_has_file "$d/eval" && return 0
+    _dir_has_file "$d/creds" && return 0
     [ -f "$d/secrets/secrets.env.gpg" ] && return 0
-    find "$d/data/qdrant" "$d/transcripts" "$d/memory" "$d/eval" "$d/creds" \
-        -type f \( -name '*.gpg' -o -name '*.snapshot' -o -name '*.jsonl' \) \
-        -print -quit 2>/dev/null | grep -q . && return 0
     find "$d/config_overrides" -type f -name '*.local.yaml' -print -quit 2>/dev/null | grep -q . && return 0
+    # §7/§8 also restore secrets/creds from the host-side credential MIRROR when
+    # BACKUP_DIR lacks them (a no-git DR box whose only surviving copy is the
+    # guardian mirror) — so a mirror payload counts too, or the guard would
+    # wrongly refuse that recovery path.
+    while IFS= read -r _m; do
+        [ -n "$_m" ] || continue
+        [ -f "$_m/secrets/secrets.env.gpg" ] && return 0
+        _dir_has_file "$_m/creds" && return 0
+    done < <(_cred_fallback_sources)
     return 1
 }
 if ! $DRY_RUN && ! _backup_has_payload; then

--- a/tests/test_scripts/test_dr_hygiene.py
+++ b/tests/test_scripts/test_dr_hygiene.py
@@ -59,6 +59,12 @@ def test_backup_alert_fires_from_exit_trap():
     assert on_exit.index("_alert_backup_failed") < on_exit.index("_write_status")
     # No second, inline '🚨 *Backup failed*' emission outside the alert function.
     assert text.count("🚨 *Backup failed*") == 1
+    # Robustness (review fix): the trap must not abort mid-way under set -e —
+    # the alert is guarded against an undefined _send_telegram (early abort) and
+    # every step is `|| true` so _write_status + cleanup always run.
+    alert = text.split("_alert_backup_failed()", 1)[1].split("_on_exit()", 1)[0]
+    assert "declare -F _send_telegram" in alert
+    assert on_exit.count("|| true") >= 3  # alert / write_status / backend_cleanup
 
 
 def test_backup_sql_tmp_trap_cleaned():
@@ -66,7 +72,7 @@ def test_backup_sql_tmp_trap_cleaned():
     the not-yet-assigned case."""
     text = _BACKUP.read_text()
     on_exit = text.split("_on_exit()", 1)[1].split("trap _on_exit", 1)[0]
-    assert 'rm -f "$_SQL_TMP"' in on_exit
+    assert 'rm -f "${_SQL_TMP:-}"' in on_exit
     assert '_SQL_TMP=""' in text  # initialized before the trap can fire
 
 
@@ -170,6 +176,47 @@ def test_n5_empty_backup_fails(restore_sandbox):
     assert "no restorable payloads found" in proc.stdout, proc.stdout
     status = json.loads((sb["home"] / ".genesis" / "restore_status.json").read_text())
     assert status["success"] is False, status
+
+
+def test_n5_legacy_plaintext_memory_counts(restore_sandbox):
+    """Review fix: the N5 guard must count a legacy plaintext memory file (§4
+    restores any file, not just .gpg) — else it false-fails a valid legacy
+    backup. Presence of the payload → the guard passes (no 'nothing to restore'
+    die); the run proceeds (and legitimately finds nothing NEW to do)."""
+    sb = restore_sandbox
+    (sb["backup"] / "memory").mkdir()
+    (sb["backup"] / "memory" / "note.md").write_text("plaintext-legacy\n")  # no .gpg
+    proc = subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(sb["backup"]), "--force"],
+        env=sb["env"],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    assert "no restorable payloads found" not in proc.stdout, proc.stdout
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_n5_credential_mirror_counts(restore_sandbox):
+    """Review fix: with an empty BACKUP_DIR but a host-side credential mirror
+    holding secrets (§7 restores from it), the N5 guard must NOT die — that
+    mirror-only recovery is a real DR path."""
+    sb = restore_sandbox
+    mirror = sb["home"] / ".genesis" / "shared" / "guardian" / "creds-mirror"
+    (mirror / "secrets").mkdir(parents=True)
+    (mirror / "secrets" / "secrets.env.gpg").write_bytes(b"encrypted-blob")
+    proc = subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(sb["backup"]), "--force"],
+        env={
+            **sb["env"],
+            "GENESIS_BACKUP_PASSPHRASE": _TEST_PASSPHRASE,
+            "GNUPGHOME": str(sb["home"] / ".gnupg"),
+        },
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    assert "no restorable payloads found" not in proc.stdout, proc.stdout
 
 
 def test_n4_no_tty_no_force_fails(restore_sandbox):

--- a/tests/test_scripts/test_dr_hygiene.py
+++ b/tests/test_scripts/test_dr_hygiene.py
@@ -1,0 +1,218 @@
+"""DR hygiene tests (audit SF6/SF7 + notes BK-N1/N2/N4/N5/N6) for the
+backup/restore pair — the smaller, lower-severity correctness fixes that sit on
+top of the DR-integrity core.
+
+* **SF6** restore off-site pull of qdrant/transcripts warns on a failed get
+  (→ non-zero restore) instead of the old silent `… | while | done || true`.
+* **SF7** restore sets `umask 077` before any plaintext is written, so a
+  decrypted secrets.env / transcript / memory file is never world-readable.
+* **BK-N1** the backup-FAILED Telegram alert fires from the EXIT trap, so an
+  early abort still alerts.
+* **N2** the plaintext SQL dump temp is trap-cleaned (not left in ~/tmp on a
+  mid-section death).
+* **N4** an unattended restore (no TTY, no --force) fails loudly instead of
+  declining every confirm and exiting 0.
+* **N5** a restore with no restorable payloads fails instead of reporting
+  success:true.
+* **N6** a hard sqlite3 integrity-check error doesn't abort the script before
+  its warn.
+
+Sandboxed: HOME/GENESIS_DIR in tmp; real sqlite3/gpg/git/flock. Several checks
+are extraction-style (assert on the shipped script text) where behavior is
+awkward to trigger live.
+"""
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_BACKUP = _SCRIPTS / "backup.sh"
+_RESTORE = _SCRIPTS / "restore.sh"
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+# ── extraction-style (assert on the shipped script) ──────────────────
+
+
+def test_backup_alert_fires_from_exit_trap():
+    """BK-N1: the 🚨 backup-failed alert is invoked from the EXIT trap
+    (_alert_backup_failed in _on_exit), and the old inline copy is gone so it
+    fires exactly once — including on an early abort."""
+    text = _BACKUP.read_text()
+    assert "_alert_backup_failed()" in text
+    assert "_on_exit()" in text and "trap _on_exit EXIT" in text
+    # _on_exit runs the alert before writing status.
+    on_exit = text.split("_on_exit()", 1)[1].split("trap _on_exit", 1)[0]
+    assert on_exit.index("_alert_backup_failed") < on_exit.index("_write_status")
+    # No second, inline '🚨 *Backup failed*' emission outside the alert function.
+    assert text.count("🚨 *Backup failed*") == 1
+
+
+def test_backup_sql_tmp_trap_cleaned():
+    """N2: the plaintext SQL dump temp is removed in the EXIT trap, guarded for
+    the not-yet-assigned case."""
+    text = _BACKUP.read_text()
+    on_exit = text.split("_on_exit()", 1)[1].split("trap _on_exit", 1)[0]
+    assert 'rm -f "$_SQL_TMP"' in on_exit
+    assert '_SQL_TMP=""' in text  # initialized before the trap can fire
+
+
+def test_restore_offsite_pull_warns_on_failure():
+    """SF6: the qdrant/transcripts pull uses process-substitution + warn (not the
+    silent `list | while | done || true`)."""
+    text = _RESTORE.read_text()
+    seg = text.split("for sub in qdrant transcripts", 1)[1].split("_pull_from_offsite", 1)[0]
+    assert 'warn "off-site: failed to pull $sub/$fname' in seg
+    assert "done < <(backend_list" in seg  # process substitution, runs in THIS shell
+    assert "| while read -r fname; do" not in seg  # the old subshell form is gone
+
+
+def test_restore_sets_umask_before_writes():
+    """SF7: umask 077 is set before the first section writes any plaintext."""
+    text = _RESTORE.read_text()
+    assert "\numask 077" in text
+    assert text.index("umask 077") < text.index("# ── 1. SQLite")
+
+
+def test_restore_confirm_eof_dies():
+    """N4: confirm() dies on read-EOF (no TTY) rather than treating it as a
+    silent decline."""
+    text = _RESTORE.read_text()
+    conf = text.split("confirm() {", 1)[1].split("}", 1)[0]
+    assert "if ! read -r" in conf and "die " in conf
+
+
+def test_restore_integrity_check_guarded():
+    """N6: the integrity_check command-substitution is `|| true`-guarded so a
+    hard sqlite3 error can't abort before the warn."""
+    text = _RESTORE.read_text()
+    assert 'PRAGMA integrity_check;" 2>&1 | head -1) || true' in text
+
+
+# ── live behavior ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def restore_sandbox(tmp_path):
+    home = tmp_path / "home"
+    gd = home / "genesis" / "data"
+    gd.mkdir(parents=True)
+    (home / ".genesis").mkdir(parents=True)
+    (home / "tmp").mkdir()
+    (home / ".gnupg").mkdir(mode=0o700)
+    backup = tmp_path / "backup"
+    backup.mkdir()
+    env = dict(os.environ)
+    env.update(
+        HOME=str(home),
+        GENESIS_DIR=str(home / "genesis"),
+        GENESIS_BACKUP_TMPDIR=str(home / "tmp"),
+        GENESIS_BACKUP_TIER2_BACKEND="none",
+        QDRANT_URL="http://127.0.0.1:1",
+    )
+    return {"home": home, "gd": gd, "backup": backup, "env": env, "tmp": tmp_path}
+
+
+_TEST_PASSPHRASE = "testpass"  # noqa: S105 — test fixture, not a real secret
+
+
+def _seed_secret_payload(sb, passphrase=_TEST_PASSPHRASE):
+    """Put one encrypted secrets.env payload in the backup so a restore has
+    something to do (passes the N5 empty-guard)."""
+    (sb["backup"] / "secrets").mkdir()
+    plain = sb["tmp"] / "secrets.plain"
+    plain.write_text("SECRET=value\n")
+    subprocess.run(
+        [
+            "gpg",
+            "--batch",
+            "--yes",
+            "--passphrase",
+            passphrase,
+            "--symmetric",
+            "--cipher-algo",
+            "AES256",
+            "-o",
+            str(sb["backup"] / "secrets" / "secrets.env.gpg"),
+            str(plain),
+        ],
+        env={**sb["env"], "GNUPGHOME": str(sb["home"] / ".gnupg")},
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_n5_empty_backup_fails(restore_sandbox):
+    """N5: a --force restore against a backup with zero payloads fails loudly
+    (was: exit 0 'success' having restored nothing)."""
+    sb = restore_sandbox
+    proc = subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(sb["backup"]), "--force"],
+        env=sb["env"],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    assert proc.returncode != 0, proc.stdout
+    assert "no restorable payloads found" in proc.stdout, proc.stdout
+    status = json.loads((sb["home"] / ".genesis" / "restore_status.json").read_text())
+    assert status["success"] is False, status
+
+
+def test_n4_no_tty_no_force_fails(restore_sandbox):
+    """N4: no TTY + no --force → the first confirm dies instead of silently
+    declining every section and exiting 0. (A payload is present so we reach a
+    confirm rather than the N5 empty-guard.)"""
+    sb = restore_sandbox
+    _seed_secret_payload(sb)
+    proc = subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(sb["backup"])],  # no --force
+        env={
+            **sb["env"],
+            "GENESIS_BACKUP_PASSPHRASE": _TEST_PASSPHRASE,
+            "GNUPGHOME": str(sb["home"] / ".gnupg"),
+        },
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    assert proc.returncode != 0, proc.stdout
+    assert "no TTY to confirm" in proc.stdout, proc.stdout
+
+
+def test_n5_force_with_payload_succeeds(restore_sandbox):
+    """Control: a --force restore that HAS a payload passes the N5 guard and
+    restores it (0600 via the umask)."""
+    sb = restore_sandbox
+    _seed_secret_payload(sb)
+    proc = subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(sb["backup"]), "--force"],
+        env={
+            **sb["env"],
+            "GENESIS_BACKUP_PASSPHRASE": "testpass",
+            "GNUPGHOME": str(sb["home"] / ".gnupg"),
+            "SECRETS_PATH": str(sb["home"] / "genesis" / "secrets.env"),
+        },
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    secrets_out = sb["home"] / "genesis" / "secrets.env"
+    assert secrets_out.is_file(), proc.stdout
+    # SF7: decrypted secrets are 0600 (no world/group bits), written under umask 077.
+    mode = stat.S_IMODE(secrets_out.stat().st_mode)
+    assert mode & 0o077 == 0, oct(mode)

--- a/tests/test_scripts/test_restore_offsite_pull.py
+++ b/tests/test_scripts/test_restore_offsite_pull.py
@@ -137,11 +137,13 @@ def test_skips_incomplete_latest_snapshot(sandbox):
 
 
 def test_no_complete_snapshot_skips_pull(sandbox):
-    """No COMPLETE snapshot anywhere → pull skipped, no crash."""
+    """No COMPLETE snapshot anywhere → pull skipped; then the empty backup
+    correctly fails the N5 guard (nothing to restore) rather than exiting 0."""
     _snapshot(sandbox, "sourcebox", _NEW, complete=False)
     proc = _run(sandbox, host_override="sourcebox")
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert "no COMPLETE dated snapshot" in proc.stdout, proc.stdout
+    assert proc.returncode != 0, proc.stdout
+    assert "no restorable payloads found" in proc.stdout, proc.stdout
 
 
 def test_explicit_host_override(sandbox):
@@ -178,12 +180,13 @@ def test_autodetect_ignores_stray_file_under_genesis(sandbox):
 
 
 def test_no_backend_configured_skips_pull(sandbox):
-    """backend=none → no off-site pull, no payload, no crash."""
+    """backend=none → no off-site pull attempted; with an otherwise-empty local
+    backup dir that leaves nothing to restore, so the N5 guard fails loudly
+    (rather than the old silent exit-0 'success')."""
     _snapshot(sandbox, "sourcebox", _NEW)
     proc = _run(sandbox, backend="none", host_override="sourcebox")
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    # nothing pulled → restore finds no SQL payload
-    assert "no backup payload" in proc.stdout.lower() or _db_value(sandbox) != "99"
+    assert proc.returncode != 0, proc.stdout
+    assert "no restorable payloads found" in proc.stdout, proc.stdout
 
 
 def test_pulls_and_rehydrates_memory_config_secrets(sandbox):


### PR DESCRIPTION
## Summary

P1b of the deploy-script-audit remediation (report 04 `backup/restore`), the smaller correctness fixes layered on the DR-integrity core (#1173). Standard review (findings are one-liners mirroring adjacent, already-established patterns).

| Finding | Fix |
|---|---|
| **SF6** | restore's off-site pull of qdrant/transcripts (the two largest DR payloads) warns on a failed `backend_get` via process-substitution — the old `list \| while \| done \|\| true` swallowed the failure in a subshell and masked it (the memory/config pulls right below already used the warn form). |
| **SF7** | restore sets `umask 077` before the first plaintext write, so decrypted secrets/transcripts/memory are never briefly world-readable. Verified live: restored `secrets.env` is `0600`. |
| **BK-N1** | the backup-FAILED Telegram alert moved into the EXIT trap, so an abort outside the git block (mktemp/git add/clone/early `set -e`) still alerts. Fires exactly once (inline copy removed). |
| **N2** | the credential-bearing plaintext SQL dump temp is trap-cleaned in both scripts (was inline-only → left in `~/tmp` on a mid-section death). |
| **N4** | an unattended restore (no TTY, no `--force`) dies at the first confirm instead of silently declining every section and exiting 0 "success". |
| **N5** | a restore with no restorable payloads (empty/wrong backup, no off-site) fails loudly up front instead of reporting success having restored nothing. |
| **N6** | the `integrity_check` command-substitution is `\|\| true`-guarded so a hard sqlite3 open error can't abort before its warn. |

**Drive-by (found via live E2E):** the SF3 Qdrant probe logged `HTTP 000000` on a connection failure — `curl -w` prints `000` *and* exits non-zero, so the `|| echo 000` double-appended. Now `|| true` + `${_probe_code:-000}`. Logic was already correct (`000` ≠ 200/404 → skip); this fixes the log and the curl-absent edge.

## Verification

- New `tests/test_scripts/test_dr_hygiene.py` (9): extraction anchors for the trap/umask/warn/guard changes + live N4 (no-TTY dies), N5 (empty-backup fails / payload-present succeeds), SF7 (restored secrets are `0600`). Two offsite-pull tests updated for the N5 behavior.
- **Full DR surface: 77/77** across 8 files.
- **Live E2E** (real gpg/sqlite/git/local-backend): backup → off-site snapshot → fresh-box wipe (live DB + backup clone removed) → restore → **data recovered (42), integrity_check ok, secrets `0600`**, reindex NOTE fired for the Qdrant-less snapshot.

## Deploy path

Existing installs: next `update.sh` pull (scripts re-read per run). Fresh clones: nothing extra. No Host-Deploy Gate (backup/restore only). Builds on #1173 (merged).

Audit source: `deploy-audit-2026-07-13/04-backup-restore.md` · Plan: calm-honking-meadow §P1b

🤖 Generated with [Claude Code](https://claude.com/claude-code)