### PR TITLE
refactor(session-awareness): live entity_candidates count replaces dead entity_shadow

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -555,9 +555,10 @@ verified: b662f3e3 2026-07-17
   retrieves+ranks candidates over four lanes — vector, decisions
   (`tags~decision`, the OMI-incident class), entity-keyword drift, and
   the **entity lane** (ledger keywords → entity nodes → ≤2 typed hops →
-  mentions; `ranking.ENTITY_LANE_MODE`, SHADOW — entity-only hits ride
-  `entity_shadow` telemetry, never candidates, until the OMI-replay-
-  gated flip) — all Qdrant lanes EXACT search (filtered HNSW without
+  mentions; `ranking.ENTITY_LANE_MODE`, LIVE since the E4b flip (#993) —
+  entity hits rank normally with a reserved floor of 2, and the verdict's
+  `entity_candidates` count reports the live lane's contribution) — all
+  Qdrant lanes EXACT search (filtered HNSW without
   payload indexes drops valid results; found 2026-07-09). Headless-
   Haiku arbiter judges candidates per fire (fail-closed parse, group-
   kill on timeout). Verdicts → `ambient_verdict.json`, tuning →

--- a/src/genesis/session_awareness/worker.py
+++ b/src/genesis/session_awareness/worker.py
@@ -161,14 +161,12 @@ async def run_worker(
             qdrant = QdrantClient(url=url, timeout=10)
             provider = EmbeddingProvider()
             entity_query = " ".join(top_entities(state, ENTITY_QUERY_TERMS))
-            entity_shadow: list[dict] = []
             candidates = await rank_candidates(
                 ema=state["ema"],
                 entity_query=entity_query,
                 db=db,
                 qdrant_client=qdrant,
                 embedding_provider=provider,
-                entity_shadow_out=entity_shadow,
                 # Keys verbatim — alias-normalized ledger keys can be
                 # multi-word ("claude code") and must not be re-split.
                 entity_terms=top_entities(state, ENTITY_RESOLVE_TERMS),
@@ -182,14 +180,17 @@ async def run_worker(
             "fired_count": state.get("fired_count", 0),
             "outlier_skips": state.get("outlier_skips", 0),
         }
+        # E4 live-lane telemetry: how many surfaced candidates carry the
+        # entity lane. 0 is a real signal here — a dead live entity lane,
+        # indistinguishable from a healthy one under the old shadow-only
+        # ``entity_shadow`` field (always [] since the E4b live flip, #993).
+        entity_candidates = sum(1 for c in candidates if "entity" in (c.get("lanes") or []))
         verdict: dict = {
             "status": "no_arbiter" if no_arbiter else "judged",
             "theme": theme_stats,
             "entity_query": entity_query,
             "candidates": candidates,
-            # E4 shadow telemetry: what the entity lane would have added
-            # (empty once the lane goes live — hits then ride candidates).
-            "entity_shadow": entity_shadow,
+            "entity_candidates": entity_candidates,
         }
         if not no_arbiter:
             # Deferred: --no-arbiter runs never load the subprocess

--- a/tests/test_session_awareness/test_worker.py
+++ b/tests/test_session_awareness/test_worker.py
@@ -172,3 +172,58 @@ async def test_arbiter_path_records_picks(tmp_path):
     judge.assert_awaited_once()
     v = _verdict(sessions)
     assert v["picked_memory_ids"] == ["m2"]
+
+
+@pytest.mark.asyncio
+async def test_entity_candidates_count_replaces_dead_shadow_field(tmp_path):
+    """Live-mode entity-lane observability: the verdict reports how many
+    surfaced candidates carry the entity lane. 0 is a real signal (a dead
+    live entity lane), distinct from a healthy one — the old shadow-only
+    ``entity_shadow`` field was always [] post-E4b flip, so a broken and a
+    healthy live lane looked identical. That field is gone; ``entity_candidates``
+    replaces it."""
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    _seed_theme(sessions)
+    fake = [
+        {"memory_id": "m1", "score": 0.9, "lanes": ["vector"]},
+        {"memory_id": "m2", "score": 0.8, "lanes": ["entity"]},
+        {"memory_id": "m3", "score": 0.7, "lanes": ["decision", "entity"]},
+    ]
+    with patch.object(
+        worker_mod, "rank_candidates", new=AsyncMock(return_value=fake),
+    ):
+        result = await run_worker(
+            SID,
+            no_arbiter=True,
+            sessions_root=sessions,
+            state_root=state,
+            db_path=_tmp_db(tmp_path),
+            qdrant_url="http://127.0.0.1:1",
+        )
+    # Two of the three surfaced candidates carry the entity lane.
+    assert result["entity_candidates"] == 2
+    assert "entity_shadow" not in result
+    v = _verdict(sessions)
+    assert v["entity_candidates"] == 2
+    assert "entity_shadow" not in v
+
+
+@pytest.mark.asyncio
+async def test_entity_candidates_zero_when_no_entity_lane(tmp_path):
+    """A candidate set with no entity-tagged rows reports 0 — the dead-lane
+    signal the old always-[] field could never surface."""
+    sessions, state = tmp_path / "s", tmp_path / "sa"
+    _seed_theme(sessions)
+    fake = [{"memory_id": "m1", "score": 0.9, "lanes": ["vector"]}]
+    with patch.object(
+        worker_mod, "rank_candidates", new=AsyncMock(return_value=fake),
+    ):
+        result = await run_worker(
+            SID,
+            no_arbiter=True,
+            sessions_root=sessions,
+            state_root=state,
+            db_path=_tmp_db(tmp_path),
+            qdrant_url="http://127.0.0.1:1",
+        )
+    assert result["entity_candidates"] == 0


### PR DESCRIPTION
## What

The ambient session-awareness worker wrote an `entity_shadow` field into every verdict (`ambient_verdict.json` + `shadow_log.jsonl`), but that field only populates in **shadow** mode (`ranking.py` gates it on `mode == "shadow"`). The entity lane went **live** at E4b (#993) minutes after it shipped, so `entity_shadow` has been `[]` in every production record for 12 days — a broken live entity lane and a healthy one were **indistinguishable** (both `[]`), and no code path reads the field.

This replaces it with `entity_candidates`: a count of surfaced candidates carrying the entity lane (`"entity" in c["lanes"]`), computed from the returned candidate set. **`0` is now a real dead-lane signal.**

## Scope

- **`ranking.py` untouched** — its `entity_shadow_out` plumbing is still used by `scripts/ambient_replay.py` for offline shadow-mode replay + `test_ranking_entity_lane.py`. Only the live worker path drops the (already no-op) `entity_shadow_out=` kwarg.
- Verdict-schema change (drop `entity_shadow`, add `entity_candidates`) has **zero readers** of the removed key (grep-verified across src/scripts/tests/dashboard).
- Doc fix: `docs/architecture/CURRENT.md` still called the entity lane "SHADOW" riding `entity_shadow` telemetry — corrected to LIVE (E4b) + `entity_candidates`.

## Testing

- TDD RED→GREEN: 2 new tests (populated count == 2; zero-signal case == 0), assert `entity_shadow` gone from the verdict.
- Green: `test_worker.py`, `test_worker_telemetry.py`, `test_ranking_entity_lane.py`, `test_arbiter.py`; ruff clean.
- Code-reviewer: DONE, no BLOCKER/SHOULD-FIX — count expression safe against the real `rank_candidates` return contract; exception path returns an error verdict before the count line.

No CHANGELOG entry — internal telemetry, no user-visible effect.

Ledger: c1fa85c45c994fc3bbfa0583f835d44c

🤖 Generated with [Claude Code](https://claude.com/claude-code)