### PR TITLE
feat(reflex): PR1 — afferent nerve, fingerprinted task.failed ingestion (dark)

### DIFF
--- a/config/reflex.yaml
+++ b/config/reflex.yaml
@@ -1,0 +1,11 @@
+# Reflex arc — autonomous self-bug detection.
+# Spec: docs/superpowers/specs/2026-07-21-reflex-arc-design.md
+#
+# PR1 ships the afferent nerve DARK. `ingest_enabled` gates BOTH the
+# default-event-bus wiring for tracked_task failures AND reflex signal-store
+# ingestion (store-only — no cards, no sessions, no LLM calls in P0/PR1).
+#
+# Turning ON requires a server restart (the subscriber registers at init).
+# Turning OFF is honored live within ~30s. Env kill switch:
+# GENESIS_REFLEX_INGEST_OFF=1 wins over any value here.
+ingest_enabled: false

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1073,6 +1073,42 @@ verified: 9037d45b 2026-07-07
 - **workflows/**: YAML DAG executor — GROUNDWORK(workflow-engine), built with
   NO runtime caller. Not live; do not treat as a capability.
 
+## 14. Reflex arc — self-bug detection & repair
+
+The afferent nerve for Genesis's own screaming bugs: detect `task.failed`
+exceptions, fingerprint/dedup them, and (later phases) diagnose → card →
+fix under a human-gated tier model. **PR1 only (dark)** — ingestion
+scaffolding, no cards/sessions/LLM yet. Spec:
+`docs/superpowers/specs/2026-07-21-reflex-arc-design.md`.
+
+```yaml subsystem-map
+entry: reflex-arc
+modules: [reflex]
+verified: bbe3a440 2026-07-21
+```
+
+- **reflex/**: `fingerprint.py` (pure: normalize task name, line-number-free
+  frame tail → stable sha, `class_key = ErrorType×subsystem` from the deepest
+  genesis frame), `config.py` (`ingest_enabled` gate, default OFF +
+  `GENESIS_REFLEX_INGEST_OFF` env kill), `ingest.py` (`ReflexIngestor` —
+  bus subscriber ENQUEUES only to a bounded queue; a `tracked_task` worker
+  drains + upserts off the event-bus dispatch path). Wired at
+  `runtime/init/reflex.py` (after `tasks`), which installs the **default
+  event bus** for `tracked_task` (`util/tasks.set_default_event_bus`) ONLY
+  when ingestion is enabled — before this, ~63 of 66 `tracked_task` sites
+  emitted no failure event.
+- **Tables** (`reflex_signals` upsert-deduped by `fingerprint`;
+  `reflex_diagnoses`; `reflex_verdicts` = the taste corpus, never pruned).
+  Later-phase columns/statuses ship now so the lifecycle CHECK never needs a
+  rebuild migration.
+- **Trap**: `task.failed` is carved out of the ego reactive path
+  (`runtime/init/ego._is_reflex_owned_event`) — reflex owns that class; the
+  ego's message-keyed dedup can't absorb variable-payload failure bursts
+  (a documented storm mode in `ego/cadence.py`).
+- GROUNDWORK: diagnose lane (PR2), fix lane (PR3) — `reflex_diagnoses` /
+  `reflex_verdicts` writers and the card/gate/dispatch flow are NOT yet
+  built; the tables are inert scaffolding in PR1.
+
 ---
 
 *Maintenance: run `python scripts/check_subsystem_map.py` from the repo root;

--- a/src/genesis/db/crud/reflex_signals.py
+++ b/src/genesis/db/crud/reflex_signals.py
@@ -1,0 +1,177 @@
+"""CRUD for reflex_signals — fingerprint-deduped task.failed signals.
+
+One row per failure fingerprint; recurrences increment ``occurrence_count``
+via ``ON CONFLICT(fingerprint) DO UPDATE`` (a burst of N identical crashes
+is one signal, not N). ``maybe_reopen`` is the caller-side policy step: a
+recurrence of a terminal signal (merged / dismissed / expired / failed)
+past its mute window flips it back to ``new`` — for a ``merged`` signal
+that recurrence is evidence the fix did not hold.
+
+Callers pass the shared SerializedConnection: commit on every write, never
+rollback. All timestamps are injected ISO-UTC strings (lexicographic
+comparison is used for the mute window) — no wall clock in this module.
+Reads build dicts from an explicit column list rather than relying on
+``row_factory`` (the shared connection's factory is not guaranteed).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import aiosqlite
+
+_COLS = (
+    "id",
+    "fingerprint",
+    "class_key",
+    "task_name",
+    "subsystem",
+    "error_type",
+    "last_error_message",
+    "traceback_tail",
+    "status",
+    "occurrence_count",
+    "first_seen_at",
+    "last_seen_at",
+    "reopen_count",
+    "reopened_at",
+    "muted_until",
+    "active_diagnosis_id",
+    "diagnose_request_id",
+    "fix_request_id",
+    "task_id",
+    "pr_url",
+    "outcome_label",
+    "created_at",
+    "updated_at",
+)
+
+_SELECT = f"SELECT {', '.join(_COLS)} FROM reflex_signals"  # noqa: S608 — static column list
+
+# Statuses a recurrence may reopen from. Everything else is an ACTIVE
+# lifecycle stage (carded / diagnosing / fixing / in PR) where the
+# recurrence is expected — the occurrence counter still climbs.
+_REOPENABLE = (
+    "merged",
+    "resolved",
+    "dismissed_notbug",
+    "dismissed_wontfix",
+    "card_expired",
+    "diagnose_failed",
+    "fix_failed",
+)
+
+
+def _row_to_dict(row: tuple) -> dict:
+    return dict(zip(_COLS, row, strict=True))
+
+
+async def upsert_occurrence(
+    db: aiosqlite.Connection,
+    *,
+    fingerprint: str,
+    class_key: str,
+    task_name: str,
+    subsystem: str,
+    error_type: str,
+    error_message: str | None,
+    traceback_tail: str | None,
+    now: str,
+) -> dict:
+    """Insert a new signal or record one more occurrence of a known one.
+
+    The conflict path deliberately touches only occurrence bookkeeping
+    (count, last_seen, latest message) — never ``status``: lifecycle
+    transitions belong to ``set_status``/``maybe_reopen``. Returns the row
+    after the write.
+    """
+    await db.execute(
+        """INSERT INTO reflex_signals
+           (id, fingerprint, class_key, task_name, subsystem, error_type,
+            last_error_message, traceback_tail, status, occurrence_count,
+            first_seen_at, last_seen_at, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'new', 1, ?, ?, ?, ?)
+           ON CONFLICT(fingerprint) DO UPDATE SET
+             occurrence_count = occurrence_count + 1,
+             last_seen_at = excluded.last_seen_at,
+             last_error_message = excluded.last_error_message,
+             task_name = excluded.task_name,
+             updated_at = excluded.updated_at""",
+        (
+            uuid.uuid4().hex[:16],
+            fingerprint,
+            class_key,
+            task_name,
+            subsystem,
+            error_type,
+            error_message,
+            traceback_tail,
+            now,
+            now,
+            now,
+            now,
+        ),
+    )
+    await db.commit()
+    row = await get_by_fingerprint(db, fingerprint)
+    if row is None:  # pragma: no cover — row was just upserted above
+        raise RuntimeError(f"reflex_signals upsert vanished for fingerprint {fingerprint}")
+    return row
+
+
+async def maybe_reopen(db: aiosqlite.Connection, *, fingerprint: str, now: str) -> bool:
+    """Reopen a terminal signal whose mute window has passed.
+
+    Guarded single UPDATE: only fires when status is reopenable AND
+    ``muted_until`` is NULL or in the past. Clears the per-round lifecycle
+    references so the next card round starts clean. Returns True iff the
+    signal was reopened.
+    """
+    placeholders = ", ".join("?" * len(_REOPENABLE))
+    cursor = await db.execute(
+        f"""UPDATE reflex_signals SET
+              status = 'new',
+              reopen_count = reopen_count + 1,
+              reopened_at = ?,
+              diagnose_request_id = NULL,
+              fix_request_id = NULL,
+              task_id = NULL,
+              updated_at = ?
+            WHERE fingerprint = ?
+              AND status IN ({placeholders})
+              AND (muted_until IS NULL OR muted_until <= ?)""",  # noqa: S608 — static placeholders
+        (now, now, fingerprint, *_REOPENABLE, now),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def set_status(
+    db: aiosqlite.Connection,
+    *,
+    signal_id: str,
+    expected_from: str,
+    to: str,
+    now: str,
+) -> bool:
+    """Guarded lifecycle transition — no-op unless status == expected_from."""
+    cursor = await db.execute(
+        "UPDATE reflex_signals SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+        (to, now, signal_id, expected_from),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def get_by_fingerprint(db: aiosqlite.Connection, fingerprint: str) -> dict | None:
+    cursor = await db.execute(f"{_SELECT} WHERE fingerprint = ?", (fingerprint,))
+    row = await cursor.fetchone()
+    return _row_to_dict(tuple(row)) if row is not None else None
+
+
+async def list_by_status(db: aiosqlite.Connection, status: str, *, limit: int = 100) -> list[dict]:
+    cursor = await db.execute(
+        f"{_SELECT} WHERE status = ? ORDER BY last_seen_at DESC LIMIT ?", (status, limit)
+    )
+    rows = await cursor.fetchall()
+    return [_row_to_dict(tuple(r)) for r in rows]

--- a/src/genesis/db/migrations/0070_reflex_arc.py
+++ b/src/genesis/db/migrations/0070_reflex_arc.py
@@ -1,0 +1,117 @@
+"""Add reflex-arc P0 tables — signals, diagnoses, verdicts (taste corpus).
+
+The reflex arc's afferent store (spec:
+``docs/superpowers/specs/2026-07-21-reflex-arc-design.md``):
+
+- ``reflex_signals`` — one row per failure fingerprint (task.failed events,
+  upsert-deduped with an occurrence count), carrying the full Tier-0
+  lifecycle in ``status``. Later-phase columns (fix ids, outcome_label)
+  ship now so the lifecycle CHECK never needs a rebuild migration.
+- ``reflex_diagnoses`` — one row per Tier-0 diagnose session round
+  (written from PR2 onward).
+- ``reflex_verdicts`` — the taste corpus: every human verdict as a
+  self-contained (context, judgment) example. Never pruned by design
+  (spec §9); non-human rows (timeout expiry) filter via ``resolved_by``.
+
+Fresh/test DBs get the tables from the canonical CREATE TABLE in
+``db/schema/_tables.py``; this numbered migration covers the existing-DB
+upgrade path. Idempotent: CREATE TABLE/INDEX IF NOT EXISTS. No commit — the
+runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """CREATE TABLE IF NOT EXISTS reflex_signals (
+            id                  TEXT PRIMARY KEY,
+            fingerprint         TEXT NOT NULL UNIQUE,
+            class_key           TEXT NOT NULL,
+            task_name           TEXT NOT NULL,
+            subsystem           TEXT NOT NULL,
+            error_type          TEXT NOT NULL,
+            last_error_message  TEXT,
+            traceback_tail      TEXT,
+            status              TEXT NOT NULL DEFAULT 'new'
+                                  CHECK (status IN (
+                                    'new','carded_diagnose','diagnosing','diagnose_failed',
+                                    'diagnosed','carded_fix','fix_dispatched','fix_failed',
+                                    'pr_open','merged','resolved',
+                                    'dismissed_notbug','dismissed_wontfix','card_expired')),
+            occurrence_count    INTEGER NOT NULL DEFAULT 1,
+            first_seen_at       TEXT NOT NULL,
+            last_seen_at        TEXT NOT NULL,
+            reopen_count        INTEGER NOT NULL DEFAULT 0,
+            reopened_at         TEXT,
+            muted_until         TEXT,
+            active_diagnosis_id TEXT,
+            diagnose_request_id TEXT,
+            fix_request_id      TEXT,
+            task_id             TEXT,
+            pr_url              TEXT,
+            outcome_label       TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL
+        )"""
+    )
+    await db.execute(
+        """CREATE TABLE IF NOT EXISTS reflex_diagnoses (
+            id                  TEXT PRIMARY KEY,
+            signal_id           TEXT NOT NULL,
+            session_id          TEXT,
+            status              TEXT NOT NULL DEFAULT 'running'
+                                  CHECK (status IN ('running','completed','failed','unparseable')),
+            artifact_json       TEXT,
+            artifact_text       TEXT,
+            root_cause          TEXT,
+            fix_plan_summary    TEXT,
+            blast_radius        TEXT,
+            stated_confidence   REAL,
+            predicted_success_p REAL,
+            prediction_features TEXT,
+            model_used          TEXT,
+            created_at          TEXT NOT NULL,
+            completed_at        TEXT
+        )"""
+    )
+    await db.execute(
+        """CREATE TABLE IF NOT EXISTS reflex_verdicts (
+            id                  TEXT PRIMARY KEY,
+            signal_id           TEXT NOT NULL,
+            diagnosis_id        TEXT,
+            verdict_point       TEXT NOT NULL
+                                  CHECK (verdict_point IN
+                                    ('diagnose_card','fix_card','pr_merge','promotion')),
+            verdict             TEXT NOT NULL
+                                  CHECK (verdict IN (
+                                    'execute','dismiss_notbug','dismiss_wontfix',
+                                    'expired','merged','closed_unmerged')),
+            resolved_by         TEXT NOT NULL,
+            approval_request_id TEXT,
+            context_snapshot    TEXT NOT NULL,
+            created_at          TEXT NOT NULL
+        )"""
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflex_signals_status ON reflex_signals(status)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflex_signals_class ON reflex_signals(class_key)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflex_diagnoses_signal "
+        "ON reflex_diagnoses(signal_id, created_at)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflex_verdicts_signal "
+        "ON reflex_verdicts(signal_id, created_at)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS reflex_verdicts")
+    await db.execute("DROP TABLE IF EXISTS reflex_diagnoses")
+    await db.execute("DROP TABLE IF EXISTS reflex_signals")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -2000,6 +2000,86 @@ TABLES = {
             snapshot_at  TEXT NOT NULL
         )
     """,
+    # Reflex arc P0 (spec: docs/superpowers/specs/2026-07-21-reflex-arc-design.md).
+    # reflex_signals: one row per failure fingerprint, upsert-deduped
+    # (occurrence_count), full Tier-0 lifecycle in `status`. Later-phase
+    # statuses/columns (outcome_label, fix ids) ship now so the lifecycle
+    # CHECK never needs a rebuild migration.
+    "reflex_signals": """
+        CREATE TABLE IF NOT EXISTS reflex_signals (
+            id                  TEXT PRIMARY KEY,
+            fingerprint         TEXT NOT NULL UNIQUE,
+            class_key           TEXT NOT NULL,
+            task_name           TEXT NOT NULL,
+            subsystem           TEXT NOT NULL,
+            error_type          TEXT NOT NULL,
+            last_error_message  TEXT,
+            traceback_tail      TEXT,
+            status              TEXT NOT NULL DEFAULT 'new'
+                                  CHECK (status IN (
+                                    'new','carded_diagnose','diagnosing','diagnose_failed',
+                                    'diagnosed','carded_fix','fix_dispatched','fix_failed',
+                                    'pr_open','merged','resolved',
+                                    'dismissed_notbug','dismissed_wontfix','card_expired')),
+            occurrence_count    INTEGER NOT NULL DEFAULT 1,
+            first_seen_at       TEXT NOT NULL,
+            last_seen_at        TEXT NOT NULL,
+            reopen_count        INTEGER NOT NULL DEFAULT 0,
+            reopened_at         TEXT,
+            muted_until         TEXT,
+            active_diagnosis_id TEXT,
+            diagnose_request_id TEXT,
+            fix_request_id      TEXT,
+            task_id             TEXT,
+            pr_url              TEXT,
+            outcome_label       TEXT,
+            created_at          TEXT NOT NULL,
+            updated_at          TEXT NOT NULL
+        )
+    """,
+    # reflex_diagnoses: one row per Tier-0 diagnose session round (PR2 writes).
+    "reflex_diagnoses": """
+        CREATE TABLE IF NOT EXISTS reflex_diagnoses (
+            id                  TEXT PRIMARY KEY,
+            signal_id           TEXT NOT NULL,
+            session_id          TEXT,
+            status              TEXT NOT NULL DEFAULT 'running'
+                                  CHECK (status IN ('running','completed','failed','unparseable')),
+            artifact_json       TEXT,
+            artifact_text       TEXT,
+            root_cause          TEXT,
+            fix_plan_summary    TEXT,
+            blast_radius        TEXT,
+            stated_confidence   REAL,
+            predicted_success_p REAL,
+            prediction_features TEXT,
+            model_used          TEXT,
+            created_at          TEXT NOT NULL,
+            completed_at        TEXT
+        )
+    """,
+    # reflex_verdicts: the taste corpus — every human verdict in the arc as a
+    # self-contained (context, judgment) example. Never pruned by design
+    # (spec §9: "never throw away a verdict"); non-human rows (expiry) are
+    # filterable via resolved_by.
+    "reflex_verdicts": """
+        CREATE TABLE IF NOT EXISTS reflex_verdicts (
+            id                  TEXT PRIMARY KEY,
+            signal_id           TEXT NOT NULL,
+            diagnosis_id        TEXT,
+            verdict_point       TEXT NOT NULL
+                                  CHECK (verdict_point IN
+                                    ('diagnose_card','fix_card','pr_merge','promotion')),
+            verdict             TEXT NOT NULL
+                                  CHECK (verdict IN (
+                                    'execute','dismiss_notbug','dismiss_wontfix',
+                                    'expired','merged','closed_unmerged')),
+            resolved_by         TEXT NOT NULL,
+            approval_request_id TEXT,
+            context_snapshot    TEXT NOT NULL,
+            created_at          TEXT NOT NULL
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -2328,6 +2408,11 @@ INDEXES = [
     # Voice graduation quarantine (W0) — serves the W2 drainer's pending scan
     # and the dispositioned-only prune
     "CREATE INDEX IF NOT EXISTS idx_graduation_events_disposition ON graduation_events(disposition, received_at)",
+    # Reflex arc P0 — lane polling scans by status; class analytics by class_key
+    "CREATE INDEX IF NOT EXISTS idx_reflex_signals_status ON reflex_signals(status)",
+    "CREATE INDEX IF NOT EXISTS idx_reflex_signals_class ON reflex_signals(class_key)",
+    "CREATE INDEX IF NOT EXISTS idx_reflex_diagnoses_signal ON reflex_diagnoses(signal_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_reflex_verdicts_signal ON reflex_verdicts(signal_id, created_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/reflex/__init__.py
+++ b/src/genesis/reflex/__init__.py
@@ -1,0 +1,7 @@
+"""Reflex arc — autonomous self-bug detection & repair.
+
+The afferent nerve for Genesis's own screaming bugs: ``task.failed`` events
+are fingerprinted and deduplicated into ``reflex_signals``; later phases add
+the diagnose/fix card lanes. Design spec:
+``docs/superpowers/specs/2026-07-21-reflex-arc-design.md``.
+"""

--- a/src/genesis/reflex/config.py
+++ b/src/genesis/reflex/config.py
@@ -1,0 +1,65 @@
+"""Reflex-arc config — loader for ``config/reflex.yaml``.
+
+PR1 surface: ``ingest_enabled`` gates the whole afferent nerve (the
+default-event-bus wiring for tracked_task failures AND signal-store
+ingestion). Ships OFF; turning it ON requires a server restart (the
+subscriber registers at init), turning it OFF is honored live within the
+ingestor's refresh interval. ``GENESIS_REFLEX_INGEST_OFF=1`` is the env
+kill switch — it wins over any config value (fail toward less activity).
+
+Later phases (cards, dispatch) add their keys here; model/effort choices
+stay config, never constants.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "reflex.yaml"
+
+
+@dataclass(frozen=True)
+class ReflexConfig:
+    ingest_enabled: bool = False
+    source: str = "defaults"
+
+
+def _env_killed() -> bool:
+    return os.environ.get("GENESIS_REFLEX_INGEST_OFF", "").strip() in ("1", "true", "yes")
+
+
+def load_reflex_config(path: Path | None = None) -> ReflexConfig:
+    """Load reflex config; missing/malformed file → safe defaults (OFF)."""
+    if _env_killed():
+        return ReflexConfig(ingest_enabled=False, source="env_kill")
+
+    cfg_path = path or _CONFIG_PATH
+    if not cfg_path.exists():
+        return ReflexConfig()
+
+    try:
+        from genesis._config_overlay import merge_local_overlay
+
+        raw = yaml.safe_load(cfg_path.read_text()) or {}
+        raw = merge_local_overlay(raw, cfg_path)
+    except Exception:
+        logger.warning(
+            "Failed to load reflex config from %s; using defaults", cfg_path, exc_info=True
+        )
+        return ReflexConfig()
+
+    if not isinstance(raw, dict):
+        logger.warning("Reflex config at %s is not a mapping; using defaults", cfg_path)
+        return ReflexConfig()
+
+    return ReflexConfig(
+        ingest_enabled=bool(raw.get("ingest_enabled", False)),
+        source=str(cfg_path),
+    )

--- a/src/genesis/reflex/fingerprint.py
+++ b/src/genesis/reflex/fingerprint.py
@@ -1,0 +1,64 @@
+"""Signal fingerprinting — pure functions, no I/O.
+
+A fingerprint identifies "which exact way did which exact thing break" so
+recurrences of one bug upsert into one ``reflex_signals`` row instead of N.
+
+Inputs and exclusions:
+
+- normalized task name — dynamic id fragments (uuid hex, counters) are
+  scrubbed so occurrence 2 of ``obs-<uuid>`` matches occurrence 1
+- exception type name
+- normalized frame tail (rendered by ``genesis.util.tasks`` as
+  ``relpath:funcname`` with NO line numbers — line numbers shift on every
+  unrelated commit and would split fingerprints across deploys)
+- the exception MESSAGE is deliberately excluded: it carries per-occurrence
+  variable data (ids, values, timestamps)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+
+_HEX_RUN = re.compile(r"[0-9a-f]{8,}")
+_DIGIT_RUN = re.compile(r"\d{4,}")
+
+
+def normalize_task_name(name: str) -> str:
+    """Scrub dynamic fragments from a task name so recurrences collapse."""
+    norm = name.lower()
+    norm = _HEX_RUN.sub("#", norm)
+    return _DIGIT_RUN.sub("#", norm)
+
+
+def fingerprint(task_name: str, error_type: str, frames: Sequence[str]) -> str:
+    """Stable 16-hex-char identity for one failure mode of one task.
+
+    Empty ``frames`` (event from a pre-upgrade process, or a traceback with
+    no extractable frames) degrades to a coarser but still stable key.
+    """
+    key = f"{normalize_task_name(task_name)}|{error_type}|{'>'.join(frames)}"
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def derive_subsystem(frames: Sequence[str], fallback: str) -> str:
+    """Failing subsystem = top-level package of the DEEPEST frame.
+
+    Most ``tracked_task`` sites do not pass ``subsystem`` and default to
+    HEALTH, which would collapse the ``class_key`` taxonomy axis; the frame
+    path recovers it mechanically. Frames are outermost→innermost, so the
+    last one is closest to the raise. A basename-only frame (no package
+    path) yields ``fallback``.
+    """
+    if not frames:
+        return fallback
+    path = frames[-1].split(":", 1)[0]
+    if "/" not in path:
+        return fallback
+    return path.split("/", 1)[0]
+
+
+def class_key(error_type: str, subsystem: str) -> str:
+    """Bug-class key, spec §7.2 sketch: ``<ErrorType>x<subsystem>``."""
+    return f"{error_type}x{subsystem}"

--- a/src/genesis/reflex/ingest.py
+++ b/src/genesis/reflex/ingest.py
@@ -17,6 +17,7 @@ queue then fills and drops — no recursion, no loop.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from datetime import UTC, datetime
@@ -50,13 +51,15 @@ class ReflexIngestor:
         self,
         db: aiosqlite.Connection,
         *,
-        config_loader: Callable[[], ReflexConfig] = load_reflex_config,
+        config_loader: Callable[[], ReflexConfig] | None = None,
         queue_size: int = _QUEUE_SIZE,
         refresh_interval_s: float = _REFRESH_INTERVAL_S,
         clock: Callable[[], datetime] | None = None,
     ) -> None:
         self._db = db
-        self._config_loader = config_loader
+        # Resolve the loader at call time (not a def-time default) so it stays
+        # patchable and never freezes an import-time reference.
+        self._config_loader = config_loader or load_reflex_config
         self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=queue_size)
         self._refresh_interval_s = refresh_interval_s
         self._clock = clock or (lambda: datetime.now(UTC))
@@ -65,6 +68,7 @@ class ReflexIngestor:
         self._dropped = 0
         self._processed = 0
         self._worker_task: asyncio.Task | None = None
+        self._event_bus: Any = None
 
     # ── bus side (runs inside emit() — fast, never raises) ──────────────
 
@@ -95,11 +99,12 @@ class ReflexIngestor:
     # ── worker side (off the dispatch path) ─────────────────────────────
 
     def start(self, event_bus: Any) -> None:
-        """Subscribe to the bus and start the drain worker."""
+        """Subscribe to the bus, start the drain worker, own the default bus."""
         from genesis.observability.types import Severity
         from genesis.util.tasks import tracked_task
 
-        self.refresh_enabled()
+        self._event_bus = event_bus
+        self.refresh_enabled()  # sets _enabled AND installs/clears the default bus
         event_bus.subscribe(self.handle_event, min_severity=Severity.ERROR)
         self._worker_task = tracked_task(
             self._worker(),
@@ -112,15 +117,39 @@ class ReflexIngestor:
             self._queue.maxsize,
         )
 
+    async def stop(self) -> None:
+        """Cancel the drain worker and unwire the default bus (runtime shutdown)."""
+        self._set_default_bus(None)
+        if self._worker_task is not None and not self._worker_task.done():
+            self._worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._worker_task
+        logger.info("Reflex ingestion stopped")
+
     def refresh_enabled(self) -> None:
-        """Re-read config (incl. env kill). OFF takes effect without restart."""
+        """Re-read config (incl. env kill) and (un)install the default bus.
+
+        This is what makes the kill switch fully effective live: when
+        ingestion flips OFF, the default event bus is cleared so tracked_task
+        stops emitting task.failed at the source (not just dropped at the
+        handler) — no wasted bus/DB traffic. On (re-)enable it is reinstalled.
+        """
         try:
             self._enabled = self._config_loader().ingest_enabled
         except Exception:
             logger.warning(
                 "Reflex config refresh failed — keeping enabled=%s", self._enabled, exc_info=True
             )
+        self._set_default_bus(self._event_bus if self._enabled else None)
         self._last_refresh = time.monotonic()
+
+    def _set_default_bus(self, bus: Any) -> None:
+        """Install/clear the process-wide tracked_task default bus (idempotent)."""
+        if self._event_bus is None:
+            return  # not started yet — nothing to install
+        from genesis.util.tasks import set_default_event_bus
+
+        set_default_event_bus(bus)
 
     async def _worker(self) -> None:
         while True:

--- a/src/genesis/reflex/ingest.py
+++ b/src/genesis/reflex/ingest.py
@@ -1,0 +1,173 @@
+"""Reflex ingestion — task.failed events → fingerprinted signal rows.
+
+Two-stage by design (mirrors the event bus's own persistence path): the
+bus subscriber only ENQUEUES — the event bus dispatches listeners inline
+inside ``emit()``, so a DB commit there would serialize every ERROR+
+event behind SQLite contention and compound a failure burst instead of
+absorbing it. A dedicated worker (itself a ``tracked_task``) drains the
+bounded queue and upserts. Overflow drops are counted, never silent.
+
+Failure containment: the subscriber body and the worker's per-item
+processing are each fully guarded — reflex ingestion must never break the
+bus or die to one poison item. If the worker task itself crashes, that IS
+a ``task.failed`` signal (emitted via its own tracked_task wrapper); the
+queue then fills and drops — no recursion, no loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from genesis.db.crud import reflex_signals as signals_crud
+from genesis.reflex.config import load_reflex_config
+from genesis.reflex.fingerprint import class_key, derive_subsystem, fingerprint
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import aiosqlite
+
+    from genesis.observability.types import GenesisEvent
+    from genesis.reflex.config import ReflexConfig
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_SIZE = 1000
+# Config re-read cadence: turning ingestion OFF (config or env kill) takes
+# effect within this window without a restart — the runtime brake.
+_REFRESH_INTERVAL_S = 30.0
+_DROP_WARN_EVERY = 100
+
+
+class ReflexIngestor:
+    """Subscribe-enqueue-drain pipeline from the event bus into reflex_signals."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        *,
+        config_loader: Callable[[], ReflexConfig] = load_reflex_config,
+        queue_size: int = _QUEUE_SIZE,
+        refresh_interval_s: float = _REFRESH_INTERVAL_S,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._db = db
+        self._config_loader = config_loader
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=queue_size)
+        self._refresh_interval_s = refresh_interval_s
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._enabled = False
+        self._last_refresh = 0.0
+        self._dropped = 0
+        self._processed = 0
+        self._worker_task: asyncio.Task | None = None
+
+    # ── bus side (runs inside emit() — fast, never raises) ──────────────
+
+    async def handle_event(self, event: GenesisEvent) -> None:
+        try:
+            if event.event_type != "task.failed" or not self._enabled:
+                return
+            details = getattr(event, "details", None) or {}
+            payload = {
+                "task_name": str(details.get("task_name") or "unnamed"),
+                "error": str(details.get("error") or ""),
+                "error_type": str(details.get("error_type") or "UnknownError"),
+                "error_frames": [str(f) for f in (details.get("error_frames") or [])],
+                "subsystem": str(getattr(event, "subsystem", "") or "health"),
+            }
+            try:
+                self._queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                self._dropped += 1
+                if self._dropped % _DROP_WARN_EVERY == 1:
+                    logger.warning(
+                        "Reflex ingest queue full — dropped %d task.failed events so far",
+                        self._dropped,
+                    )
+        except Exception:  # never break the bus — reflex is an observer
+            logger.warning("Reflex ingest handler error (event dropped)", exc_info=True)
+
+    # ── worker side (off the dispatch path) ─────────────────────────────
+
+    def start(self, event_bus: Any) -> None:
+        """Subscribe to the bus and start the drain worker."""
+        from genesis.observability.types import Severity
+        from genesis.util.tasks import tracked_task
+
+        self.refresh_enabled()
+        event_bus.subscribe(self.handle_event, min_severity=Severity.ERROR)
+        self._worker_task = tracked_task(
+            self._worker(),
+            name="reflex-ingest-worker",
+            event_bus=event_bus,
+        )
+        logger.info(
+            "Reflex ingestion started (enabled=%s, queue=%d)",
+            self._enabled,
+            self._queue.maxsize,
+        )
+
+    def refresh_enabled(self) -> None:
+        """Re-read config (incl. env kill). OFF takes effect without restart."""
+        try:
+            self._enabled = self._config_loader().ingest_enabled
+        except Exception:
+            logger.warning(
+                "Reflex config refresh failed — keeping enabled=%s", self._enabled, exc_info=True
+            )
+        self._last_refresh = time.monotonic()
+
+    async def _worker(self) -> None:
+        while True:
+            try:
+                item = await asyncio.wait_for(self._queue.get(), timeout=self._refresh_interval_s)
+            except TimeoutError:
+                self.refresh_enabled()
+                continue
+            try:
+                await self.process(item)
+                self._processed += 1
+            except Exception:  # one poison item must not kill the drain
+                logger.error("Reflex ingest failed to process item: %s", item, exc_info=True)
+            if time.monotonic() - self._last_refresh > self._refresh_interval_s:
+                self.refresh_enabled()
+
+    async def process(self, item: dict[str, Any]) -> dict:
+        """Fingerprint + upsert one task.failed payload; apply reopen policy."""
+        frames = item["error_frames"]
+        error_type = item["error_type"]
+        task_name = item["task_name"]
+        subsystem = derive_subsystem(frames, item["subsystem"])
+        fp = fingerprint(task_name, error_type, frames)
+        now = self._clock().isoformat()
+        row = await signals_crud.upsert_occurrence(
+            self._db,
+            fingerprint=fp,
+            class_key=class_key(error_type, subsystem),
+            task_name=task_name,
+            subsystem=subsystem,
+            error_type=error_type,
+            error_message=item["error"][:500] or None,
+            traceback_tail=">".join(frames) or None,
+            now=now,
+        )
+        # Recurrence of a terminal signal past its mute window → back to
+        # 'new' (for a merged signal: evidence the fix did not hold).
+        # Self-guarded — a no-op for active or muted signals.
+        if await signals_crud.maybe_reopen(self._db, fingerprint=fp, now=now):
+            row = await signals_crud.get_by_fingerprint(self._db, fp) or row
+        return row
+
+    @property
+    def stats(self) -> dict[str, int | bool]:
+        return {
+            "enabled": self._enabled,
+            "queued": self._queue.qsize(),
+            "processed": self._processed,
+            "dropped": self._dropped,
+        }

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -637,6 +637,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             ("campaign_runner", self._campaign_runner),
             ("awareness_loop", self._awareness_loop),
             ("cc_fallback_probe", self._cc_fallback_probe_worker),
+            ("reflex_ingestor", self._reflex_ingestor),
         ]:
             if component is None:
                 continue

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -237,6 +237,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._task_dispatch_poll: asyncio.Task | None = None
         self._build_lane: object | None = None
         self._build_lane_poll: asyncio.Task | None = None
+        self._reflex_ingestor: object | None = None
         self._direct_session_runner: object | None = None
         self._direct_session_poll: asyncio.Task | None = None
         self._ego_session: object | None = None  # User ego (primary)
@@ -457,6 +458,9 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
 
         if _full:
             await self._run_init_step_async("tasks", self._init_tasks)
+
+        if _full:
+            await self._run_init_step_async("reflex", self._init_reflex)
         self._run_init_step("guardian", self._probe_guardian_status)
 
         if _full:
@@ -469,7 +473,8 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         # host plane; non-blocking (spawns a delayed background refresh).
         if _full:
             await self._run_init_step_async(
-                "infra_profile", self._init_infra_profile,
+                "infra_profile",
+                self._init_infra_profile,
             )
 
         if _full:

--- a/src/genesis/runtime/_init_delegates.py
+++ b/src/genesis/runtime/_init_delegates.py
@@ -45,6 +45,7 @@ from genesis.runtime.init import (
     pipeline,
     providers,
     reflection,
+    reflex,
     router,
     secrets,
     surplus,
@@ -136,28 +137,37 @@ class _InitDelegatesMixin:
     async def _init_tasks(self) -> None:
         await tasks.init(self)
 
+    async def _init_reflex(self) -> None:
+        await reflex.init(self)
+
     def _selfheal_credentials_startup(self) -> None:
         from genesis.runtime.init.cred_integrity import selfheal_startup
+
         selfheal_startup(self)
 
     def _init_cred_integrity(self) -> None:
         from genesis.runtime.init.cred_integrity import wire
+
         wire(self)
 
     def _init_alert_drain(self) -> None:
         from genesis.runtime.init.alert_drain import wire
+
         wire(self)
 
     async def _init_guardian_monitoring(self) -> None:
         from genesis.runtime.init.guardian import init_guardian_monitoring
+
         await init_guardian_monitoring(self)
 
     async def _init_sentinel(self) -> None:
         from genesis.runtime.init.sentinel import init_sentinel
+
         await init_sentinel(self)
 
     async def _init_infra_profile(self) -> None:
         from genesis.runtime.init.infra_profile import init_infra_profile
+
         await init_infra_profile(self)
 
     def _probe_guardian_status(self) -> None:
@@ -171,6 +181,7 @@ class _InitDelegatesMixin:
         """
         import json
         from datetime import UTC, datetime
+
         heartbeat_path = Path.home() / ".genesis" / "guardian_heartbeat.json"
         try:
             data = json.loads(heartbeat_path.read_text())

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -42,6 +42,24 @@ def _is_non_actionable_infra_event(subsystem: str, event_type: str) -> bool:
     return subsystem in ("routing", "providers") and event_type == "all_exhausted"
 
 
+_REFLEX_OWNED_EVENT_TYPES = frozenset({"task.failed"})
+
+
+def _is_reflex_owned_event(event_type: str) -> bool:
+    """True for failure classes the reflex arc ingests, dedups, and cards.
+
+    ``task.failed`` was dark until the reflex arc installed the default event
+    bus (util/tasks.py) — the ego never reacted to it historically because
+    the events were never emitted. Reflex is the designed consumer: it
+    fingerprints recurrences into one signal and cards the user. A reactive
+    ego cycle per failure would re-run the event-burst storm mode (see the
+    push_reactive_event note in ego/cadence.py) with a message-keyed dedup
+    that variable exception payloads bypass. Module-level so it is
+    unit-testable.
+    """
+    return event_type in _REFLEX_OWNED_EVENT_TYPES
+
+
 async def init(rt: GenesisRuntime) -> None:
     """Initialize both egos: user ego + genesis ego."""
     # Hard dependencies — skip if unavailable
@@ -330,16 +348,16 @@ async def init(rt: GenesisRuntime) -> None:
                                         f"{_outcome} (session:{session_id[:8]})"
                                     )
                                 else:
-                                    _note = (
-                                        f"[{status}] {_content} "
-                                        f"(session:{session_id[:8]})"
-                                    )
+                                    _note = f"[{status}] {_content} (session:{session_id[:8]})"
                                 await user_goals.add_progress_note(
-                                    rt._db, _gid, _note,
+                                    rt._db,
+                                    _gid,
+                                    _note,
                                 )
                                 logger.info(
                                     "Recorded goal progress for %s via %s",
-                                    _gid[:12], _pid[:8],
+                                    _gid[:12],
+                                    _pid[:8],
                                 )
                         except Exception:
                             logger.debug(
@@ -364,13 +382,25 @@ async def init(rt: GenesisRuntime) -> None:
             # Route by subsystem — reliable field on every GenesisEvent.
             # User-facing subsystems trigger user ego; system subsystems
             # trigger Genesis ego.
-            _USER_SUBSYSTEMS = frozenset({
-                "outreach", "inbox", "mail", "recon",
-            })
-            _SYSTEM_SUBSYSTEMS = frozenset({
-                "health", "routing", "providers", "guardian",
-                "awareness", "surplus", "learning",
-            })
+            _USER_SUBSYSTEMS = frozenset(
+                {
+                    "outreach",
+                    "inbox",
+                    "mail",
+                    "recon",
+                }
+            )
+            _SYSTEM_SUBSYSTEMS = frozenset(
+                {
+                    "health",
+                    "routing",
+                    "providers",
+                    "guardian",
+                    "awareness",
+                    "surplus",
+                    "learning",
+                }
+            )
 
             async def _on_high_severity_event(event) -> None:
                 """Route high-severity events to the appropriate ego's signal queue.
@@ -385,6 +415,12 @@ async def init(rt: GenesisRuntime) -> None:
                 """
                 # Only react to ERROR+ events with actionable types
                 if event.event_type in ("heartbeat", "metric"):
+                    return
+
+                # REFLEX GATE: task.failed belongs to the reflex arc (signal
+                # store → dedup → user card) — never a per-failure reactive
+                # ego cycle. See _is_reflex_owned_event.
+                if _is_reflex_owned_event(event.event_type):
                     return
 
                 subsystem = str(getattr(event, "subsystem", ""))
@@ -413,10 +449,7 @@ async def init(rt: GenesisRuntime) -> None:
                     target = genesis_ego_cadence
 
                 # CRITICAL → escalation signal, ERROR → reactive signal
-                is_critical = (
-                    hasattr(event, "severity")
-                    and event.severity.name == "CRITICAL"
-                )
+                is_critical = hasattr(event, "severity") and event.severity.name == "CRITICAL"
                 if is_critical:
                     target.push_escalation_event(event_dict)
                 else:

--- a/src/genesis/runtime/init/reflex.py
+++ b/src/genesis/runtime/init/reflex.py
@@ -43,10 +43,11 @@ async def init(rt: GenesisRuntime) -> None:
         return
 
     from genesis.reflex.ingest import ReflexIngestor
-    from genesis.util.tasks import set_default_event_bus
 
     ingestor = ReflexIngestor(rt._db)
     rt._reflex_ingestor = ingestor
+    # start() subscribes, launches the drain worker, AND installs the default
+    # event bus for tracked_task (it owns that lifecycle so a live disable can
+    # unwind it). Cancelled + unwired via ingestor.stop() in runtime shutdown.
     ingestor.start(rt._event_bus)
-    set_default_event_bus(rt._event_bus)
     logger.info("Reflex ingestion ACTIVE — default event bus installed for tracked_task")

--- a/src/genesis/runtime/init/reflex.py
+++ b/src/genesis/runtime/init/reflex.py
@@ -1,0 +1,52 @@
+"""Init function: _init_reflex — the reflex arc's afferent nerve.
+
+When reflex ingestion is enabled (``config/reflex.yaml`` ``ingest_enabled``,
+env kill ``GENESIS_REFLEX_INGEST_OFF``), this step:
+
+1. starts the ``ReflexIngestor`` (bus subscriber + drain worker), and
+2. installs the process-wide default event bus for ``tracked_task`` so all
+   background-task failures emit ``task.failed`` — the nerve was dark
+   before this (only ~3 of 66 call sites passed a bus explicitly).
+
+Both are gated together: with ingestion off, the default bus stays unset,
+so other ERROR+ bus consumers (e.g. the AZ notification bridge on installs
+that wire it) see no new event class either. The ego reactive path carves
+``task.failed`` out unconditionally (``runtime/init/ego.py``) — reflex owns
+that class.
+
+Runs after the ``tasks`` init step; the late-binding default bus covers
+tasks created earlier in bootstrap the moment it is installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from genesis.runtime._core import GenesisRuntime
+
+logger = logging.getLogger("genesis.runtime")
+
+
+async def init(rt: GenesisRuntime) -> None:
+    """Initialize reflex signal ingestion (dark unless explicitly enabled)."""
+    if rt._db is None or rt._event_bus is None:
+        logger.info("Reflex ingestion skipped — db/event bus unavailable")
+        return
+
+    from genesis.reflex.config import load_reflex_config
+
+    cfg = load_reflex_config()
+    if not cfg.ingest_enabled:
+        logger.info("Reflex ingestion disabled (ingest_enabled=false) — nerve stays dark")
+        return
+
+    from genesis.reflex.ingest import ReflexIngestor
+    from genesis.util.tasks import set_default_event_bus
+
+    ingestor = ReflexIngestor(rt._db)
+    rt._reflex_ingestor = ingestor
+    ingestor.start(rt._event_bus)
+    set_default_event_bus(rt._event_bus)
+    logger.info("Reflex ingestion ACTIVE — default event bus installed for tracked_task")

--- a/src/genesis/util/tasks.py
+++ b/src/genesis/util/tasks.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import traceback
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -21,6 +22,48 @@ if TYPE_CHECKING:
     from genesis.observability.types import Subsystem
 
 _default_logger = logging.getLogger("genesis.tasks")
+
+# Process-wide fallback bus (reflex arc PR1). Most tracked_task call sites
+# never passed event_bus=, so their failures died in the logger — zero
+# task.failed events in 36 days of history. The default bus makes every
+# site (current and future) emit without per-call-site plumbing. Installed
+# by runtime init, gated on reflex ingestion config; an explicit event_bus
+# argument always wins.
+_default_event_bus: GenesisEventBus | None = None
+
+# Frames deeper than this carry diminishing identity and bloat the payload.
+_FRAME_TAIL_LEN = 3
+
+
+def set_default_event_bus(bus: GenesisEventBus | None) -> None:
+    """Install (or clear, with ``None``) the process-wide fallback bus."""
+    global _default_event_bus
+    _default_event_bus = bus
+
+
+def _normalized_frames(exc: BaseException) -> list[str]:
+    """Render the traceback tail as stable ``relpath:funcname`` strings.
+
+    - keeps only frames inside the genesis package (``/genesis/`` path
+      segment — package-relative, so it works on any install/CI checkout);
+      if none match, keeps the whole traceback with basename paths
+    - takes the deepest ``_FRAME_TAIL_LEN`` frames (closest to the raise)
+    - carries NO line numbers: they shift on every unrelated commit and
+      would split one bug into many fingerprints across deploys
+    """
+    tb = exc.__traceback__
+    if tb is None:
+        return []
+    frames = traceback.extract_tb(tb)
+    genesis_frames = [f for f in frames if "/genesis/" in f.filename]
+    selected = (genesis_frames or list(frames))[-_FRAME_TAIL_LEN:]
+    rendered = []
+    for frame in selected:
+        filename = frame.filename
+        idx = filename.rfind("/genesis/")
+        rel = filename[idx + len("/genesis/") :] if idx != -1 else filename.rsplit("/", 1)[-1]
+        rendered.append(f"{rel}:{frame.name}")
+    return rendered
 
 
 def tracked_task(
@@ -82,15 +125,21 @@ def _make_done_callback(
             exc_info=exc,
         )
 
-        if event_bus is not None:
+        # Explicit per-call bus wins; the module default covers the ~60
+        # call sites that never passed one. Read at fire time (not closure
+        # creation) so tasks started before runtime init still emit.
+        bus = event_bus if event_bus is not None else _default_event_bus
+        if bus is not None:
             emit_sync(
-                event_bus,
+                bus,
                 subsystem=subsystem,
                 severity_str="ERROR",
                 event_type="task.failed",
                 message=f"Background task {task_name!r} failed: {exc}",
                 task_name=task_name,
                 error=str(exc),
+                error_type=type(exc).__name__,
+                error_frames=_normalized_frames(exc),
             )
 
     return _on_done
@@ -127,5 +176,7 @@ def emit_sync(
     except RuntimeError:
         _default_logger.warning(
             "Cannot emit event (no loop): %s/%s: %s",
-            sub, event_type, message,
+            sub,
+            event_type,
+            message,
         )

--- a/tests/ego/test_init.py
+++ b/tests/ego/test_init.py
@@ -228,6 +228,7 @@ class TestReactiveDomainGate:
             patch("genesis.ego.dispatch.EgoDispatcher"),
         ):
             from genesis.ego.types import EgoConfig
+
             mock_config = EgoConfig(enabled=True)
             mock_load.return_value = mock_config
             mock_cadence = AsyncMock()
@@ -250,3 +251,56 @@ class TestReactiveDomainGate:
 
             await callback(_evt("routing", "budget.exceeded"))
             mock_cadence.push_reactive_event.assert_called_once()
+
+
+class TestReflexOwnedGate:
+    """task.failed belongs to the reflex arc — never a per-failure reactive
+    ego cycle. The ego's reactive dedup keys on the message (which embeds the
+    variable exception payload), so a fail-in-a-loop would bypass it and
+    re-run the event-burst storm mode (see ego/cadence.py)."""
+
+    def test_task_failed_is_reflex_owned(self):
+        assert ego._is_reflex_owned_event("task.failed") is True
+
+    def test_other_events_not_reflex_owned(self):
+        assert ego._is_reflex_owned_event("all_exhausted") is False
+        assert ego._is_reflex_owned_event("guardian.code_drift") is False
+
+    @pytest.mark.asyncio
+    async def test_wiring_gates_task_failed_any_subsystem_and_severity(self):
+        """Through the subscriber closure: task.failed never reaches the
+        reactive OR escalation path, regardless of subsystem or severity."""
+        rt = _make_runtime()
+        with (
+            patch("genesis.ego.config.load_ego_config") as mock_load,
+            patch("genesis.ego.session.EgoSession"),
+            patch("genesis.ego.cadence.EgoCadenceManager") as mock_cadence_cls,
+            patch("genesis.ego.compaction.CompactionEngine"),
+            patch("genesis.ego.context.EgoContextBuilder"),
+            patch("genesis.ego.proposals.ProposalWorkflow"),
+            patch("genesis.ego.dispatch.EgoDispatcher"),
+        ):
+            from genesis.ego.types import EgoConfig
+
+            mock_load.return_value = EgoConfig(enabled=True)
+            mock_cadence = AsyncMock()
+            mock_cadence.push_reactive_event = MagicMock()
+            mock_cadence.push_escalation_event = MagicMock()
+            mock_cadence_cls.return_value = mock_cadence
+
+            await ego.init(rt)
+            callback = rt._event_bus.subscribe.call_args.args[0]
+
+            def _evt(subsystem, severity):
+                e = MagicMock()
+                e.subsystem = subsystem
+                e.event_type = "task.failed"
+                e.severity.name = severity
+                e.message = f"Background task failed in {subsystem}"
+                return e
+
+            await callback(_evt("health", "ERROR"))
+            await callback(_evt("memory", "ERROR"))
+            await callback(_evt("awareness", "CRITICAL"))
+            mock_cadence.push_reactive_event.assert_not_called()
+            mock_cadence.push_escalation_event.assert_not_called()

--- a/tests/test_db/test_migration_0070_reflex_arc.py
+++ b/tests/test_db/test_migration_0070_reflex_arc.py
@@ -1,0 +1,245 @@
+"""Migration 0070 — create the reflex-arc P0 tables.
+
+Verifies full column sets of all three tables, the indexes, idempotency,
+the lifecycle/verdict CHECK matrices, the fingerprint UNIQUE constraint,
+fresh-canonical parity with ``_tables.py``, and ``down``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+_EXPECTED_SIGNAL_COLUMNS = {
+    "id",
+    "fingerprint",
+    "class_key",
+    "task_name",
+    "subsystem",
+    "error_type",
+    "last_error_message",
+    "traceback_tail",
+    "status",
+    "occurrence_count",
+    "first_seen_at",
+    "last_seen_at",
+    "reopen_count",
+    "reopened_at",
+    "muted_until",
+    "active_diagnosis_id",
+    "diagnose_request_id",
+    "fix_request_id",
+    "task_id",
+    "pr_url",
+    "outcome_label",
+    "created_at",
+    "updated_at",
+}
+
+_EXPECTED_DIAGNOSIS_COLUMNS = {
+    "id",
+    "signal_id",
+    "session_id",
+    "status",
+    "artifact_json",
+    "artifact_text",
+    "root_cause",
+    "fix_plan_summary",
+    "blast_radius",
+    "stated_confidence",
+    "predicted_success_p",
+    "prediction_features",
+    "model_used",
+    "created_at",
+    "completed_at",
+}
+
+_EXPECTED_VERDICT_COLUMNS = {
+    "id",
+    "signal_id",
+    "diagnosis_id",
+    "verdict_point",
+    "verdict",
+    "resolved_by",
+    "approval_request_id",
+    "context_snapshot",
+    "created_at",
+}
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _insert_signal(db: aiosqlite.Connection, **overrides) -> None:
+    row = {
+        "id": "sig1",
+        "fingerprint": "abcd1234abcd1234",
+        "class_key": "KeyErrorxmemory",
+        "task_name": "mem-sync",
+        "subsystem": "memory",
+        "error_type": "KeyError",
+        "status": "new",
+        "first_seen_at": "2026-07-21T00:00:00+00:00",
+        "last_seen_at": "2026-07-21T00:00:00+00:00",
+        "created_at": "2026-07-21T00:00:00+00:00",
+        "updated_at": "2026-07-21T00:00:00+00:00",
+    }
+    row.update(overrides)
+    cols = ", ".join(row)
+    marks = ", ".join("?" * len(row))
+    await db.execute(f"INSERT INTO reflex_signals ({cols}) VALUES ({marks})", list(row.values()))
+
+
+async def _insert_verdict(db: aiosqlite.Connection, **overrides) -> None:
+    row = {
+        "id": "v1",
+        "signal_id": "sig1",
+        "verdict_point": "diagnose_card",
+        "verdict": "execute",
+        "resolved_by": "telegram:button:1",
+        "context_snapshot": "{}",
+        "created_at": "2026-07-21T00:00:00+00:00",
+    }
+    row.update(overrides)
+    cols = ", ".join(row)
+    marks = ", ".join("?" * len(row))
+    await db.execute(f"INSERT INTO reflex_verdicts ({cols}) VALUES ({marks})", list(row.values()))
+
+
+@pytest.mark.asyncio
+async def test_up_creates_all_tables_with_full_column_sets(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        assert await _columns(db, "reflex_signals") == _EXPECTED_SIGNAL_COLUMNS
+        assert await _columns(db, "reflex_diagnoses") == _EXPECTED_DIAGNOSIS_COLUMNS
+        assert await _columns(db, "reflex_verdicts") == _EXPECTED_VERDICT_COLUMNS
+
+
+@pytest.mark.asyncio
+async def test_up_creates_indexes(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_reflex%'"
+        )
+        names = {row[0] for row in await cur.fetchall()}
+    assert names == {
+        "idx_reflex_signals_status",
+        "idx_reflex_signals_class",
+        "idx_reflex_diagnoses_signal",
+        "idx_reflex_verdicts_signal",
+    }
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        await M70.up(db)  # second run must not raise
+        await _insert_signal(db)
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unique(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        await _insert_signal(db)
+        with pytest.raises(aiosqlite.IntegrityError):
+            await _insert_signal(db, id="sig2")  # same fingerprint
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"status": "bogus"},
+    ],
+)
+async def test_signal_check_rejects(tmp_path, overrides):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        with pytest.raises(aiosqlite.IntegrityError):
+            await _insert_signal(db, **overrides)
+
+
+@pytest.mark.asyncio
+async def test_signal_lifecycle_statuses_accepted(tmp_path):
+    statuses = [
+        "new",
+        "carded_diagnose",
+        "diagnosing",
+        "diagnose_failed",
+        "diagnosed",
+        "carded_fix",
+        "fix_dispatched",
+        "fix_failed",
+        "pr_open",
+        "merged",
+        "resolved",
+        "dismissed_notbug",
+        "dismissed_wontfix",
+        "card_expired",
+    ]
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        for i, status in enumerate(statuses):
+            await _insert_signal(db, id=f"s{i}", fingerprint=f"fp{i:014d}", status=status)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"verdict_point": "bogus"},
+        {"verdict": "bogus"},
+    ],
+)
+async def test_verdict_check_rejects(tmp_path, overrides):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        await _insert_signal(db)
+        with pytest.raises(aiosqlite.IntegrityError):
+            await _insert_verdict(db, **overrides)
+
+
+@pytest.mark.asyncio
+async def test_fresh_canonical_parity(tmp_path):
+    """_tables.py and the migration must build identical column sets."""
+    from genesis.db.schema import TABLES
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(TABLES["reflex_signals"])
+        await db.execute(TABLES["reflex_diagnoses"])
+        await db.execute(TABLES["reflex_verdicts"])
+        fresh = {
+            t: await _columns(db, t)
+            for t in ("reflex_signals", "reflex_diagnoses", "reflex_verdicts")
+        }
+    async with aiosqlite.connect(str(tmp_path / "m.db")) as db:
+        await M70.up(db)
+        migrated = {
+            t: await _columns(db, t)
+            for t in ("reflex_signals", "reflex_diagnoses", "reflex_verdicts")
+        }
+    assert fresh == migrated
+    assert fresh["reflex_signals"] == _EXPECTED_SIGNAL_COLUMNS
+    assert fresh["reflex_diagnoses"] == _EXPECTED_DIAGNOSIS_COLUMNS
+    assert fresh["reflex_verdicts"] == _EXPECTED_VERDICT_COLUMNS
+
+
+@pytest.mark.asyncio
+async def test_down_drops_all_tables(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M70.up(db)
+        await M70.down(db)
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('reflex_signals','reflex_diagnoses','reflex_verdicts')"
+        )
+        assert await cur.fetchall() == []

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -78,6 +78,9 @@ EXPECTED_TABLES = [
     "graduation_events",  # voice graduation quarantine (W0; drained in W2)
     "calibration_cells",  # WS-2 P3: per-(domain,class,metric,lane,window) calibration aggregates
     "calibration_cell_history",  # WS-2 P3: per-recompute snapshots (180d retention)
+    "reflex_signals",  # reflex arc P0: fingerprint-deduped task.failed signals + lifecycle
+    "reflex_diagnoses",  # reflex arc P0: Tier-0 diagnose session artifacts (PR2 writes)
+    "reflex_verdicts",  # reflex arc P0: taste corpus — every human verdict, never pruned
 ]
 
 

--- a/tests/test_reflex/test_config.py
+++ b/tests/test_reflex/test_config.py
@@ -1,0 +1,69 @@
+"""Tests for reflex config loading — defaults, malformed input, env kill."""
+
+from __future__ import annotations
+
+from genesis.reflex.config import ReflexConfig, load_reflex_config
+
+
+class TestDefaults:
+    def test_missing_file_defaults_off(self, tmp_path):
+        cfg = load_reflex_config(tmp_path / "nope.yaml")
+        assert cfg.ingest_enabled is False
+
+    def test_dataclass_default_off(self):
+        assert ReflexConfig().ingest_enabled is False
+
+
+class TestFileLoading:
+    def test_enabled_true_loads(self, tmp_path):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("ingest_enabled: true\n")
+        assert load_reflex_config(p).ingest_enabled is True
+
+    def test_malformed_yaml_defaults_off(self, tmp_path):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("ingest_enabled: [unclosed\n")
+        assert load_reflex_config(p).ingest_enabled is False
+
+    def test_non_mapping_defaults_off(self, tmp_path):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("- just\n- a list\n")
+        assert load_reflex_config(p).ingest_enabled is False
+
+    def test_missing_key_defaults_off(self, tmp_path):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("some_future_key: 1\n")
+        assert load_reflex_config(p).ingest_enabled is False
+
+
+class TestEnvKill:
+    def test_env_kill_wins_over_enabled_config(self, tmp_path, monkeypatch):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("ingest_enabled: true\n")
+        monkeypatch.setenv("GENESIS_REFLEX_INGEST_OFF", "1")
+        cfg = load_reflex_config(p)
+        assert cfg.ingest_enabled is False
+        assert cfg.source == "env_kill"
+
+    def test_env_kill_accepts_true_spelling(self, tmp_path, monkeypatch):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("ingest_enabled: true\n")
+        monkeypatch.setenv("GENESIS_REFLEX_INGEST_OFF", "true")
+        assert load_reflex_config(p).ingest_enabled is False
+
+    def test_env_zero_does_not_kill(self, tmp_path, monkeypatch):
+        p = tmp_path / "reflex.yaml"
+        p.write_text("ingest_enabled: true\n")
+        monkeypatch.setenv("GENESIS_REFLEX_INGEST_OFF", "0")
+        assert load_reflex_config(p).ingest_enabled is True
+
+    def test_shipped_repo_config_is_off(self):
+        # the committed config/reflex.yaml must ship dark on every install —
+        # read the shipped file directly (a local overlay or env kill on the
+        # running install must not affect this assertion)
+        import yaml
+
+        from genesis.reflex.config import _CONFIG_PATH
+
+        raw = yaml.safe_load(_CONFIG_PATH.read_text())
+        assert raw["ingest_enabled"] is False

--- a/tests/test_reflex/test_fingerprint.py
+++ b/tests/test_reflex/test_fingerprint.py
@@ -1,0 +1,97 @@
+"""Tests for reflex fingerprinting — pure functions, no I/O.
+
+Fingerprint contract (reflex-arc spec §4.1 + plan):
+- keyed on (normalized task name, error type, normalized frame tail)
+- the exception MESSAGE is deliberately NOT an input (varies per occurrence)
+- stable across deploys (frames carry no line numbers — emit side guarantees)
+"""
+
+from __future__ import annotations
+
+from genesis.reflex.fingerprint import (
+    class_key,
+    derive_subsystem,
+    fingerprint,
+    normalize_task_name,
+)
+
+FRAMES = ["memory/sync.py:_apply_delta", "memory/store.py:get_entity"]
+
+
+class TestNormalizeTaskName:
+    def test_lowercases(self):
+        assert normalize_task_name("Memory-Sync-Loop") == "memory-sync-loop"
+
+    def test_scrubs_long_hex_runs(self):
+        # uuid4-hex fragments embedded in dynamic task names must not split
+        # fingerprints across occurrences
+        assert normalize_task_name("obs-a1b2c3d4e5f6a7b8") == "obs-#"
+
+    def test_scrubs_long_digit_runs(self):
+        assert normalize_task_name("job-123456") == "job-#"
+
+    def test_keeps_short_digits(self):
+        # version-ish suffixes are identity, not noise
+        assert normalize_task_name("phase2-tick") == "phase2-tick"
+
+    def test_two_dynamic_names_collapse(self):
+        a = normalize_task_name("session-0a1b2c3d4e5f6789-poll")
+        b = normalize_task_name("session-ffee00112233ddcc-poll")
+        assert a == b == "session-#-poll"
+
+
+class TestFingerprint:
+    def test_deterministic(self):
+        assert fingerprint("t", "KeyError", FRAMES) == fingerprint("t", "KeyError", FRAMES)
+
+    def test_hex16(self):
+        fp = fingerprint("t", "KeyError", FRAMES)
+        assert len(fp) == 16
+        int(fp, 16)  # raises if not hex
+
+    def test_task_name_distinguishes_shared_deep_frames(self):
+        # Anti-over-collapse: two different tasks failing through the same
+        # shared utility frames must NOT merge into one signal
+        assert fingerprint("memory-sync", "TimeoutError", FRAMES) != fingerprint(
+            "outreach-poll", "TimeoutError", FRAMES
+        )
+
+    def test_error_type_distinguishes(self):
+        assert fingerprint("t", "KeyError", FRAMES) != fingerprint("t", "ValueError", FRAMES)
+
+    def test_frames_distinguish(self):
+        other = ["routing/router.py:route_call"]
+        assert fingerprint("t", "KeyError", FRAMES) != fingerprint("t", "KeyError", other)
+
+    def test_dynamic_task_name_does_not_split(self):
+        # occurrence 1 and 2 of the same failing dynamic task → one fingerprint
+        a = fingerprint("obs-a1b2c3d4e5f6a7b8", "KeyError", FRAMES)
+        b = fingerprint("obs-ffee00112233ddcc", "KeyError", FRAMES)
+        assert a == b
+
+    def test_empty_frames_fallback_stable(self):
+        # rolling deploy: old-process events carry no frames — coarser but stable
+        assert fingerprint("t", "KeyError", []) == fingerprint("t", "KeyError", [])
+        assert fingerprint("t", "KeyError", []) != fingerprint("t", "ValueError", [])
+
+
+class TestDeriveSubsystem:
+    def test_deepest_frame_top_package(self):
+        # frames are outermost→innermost (emit side keeps extract_tb order);
+        # the DEEPEST (last) frame names the failing subsystem
+        assert (
+            derive_subsystem(["awareness/loop.py:_tick", "memory/store.py:get"], "health")
+            == "memory"
+        )
+
+    def test_basename_frame_falls_back(self):
+        # emit side falls back to basename when no genesis/ segment — no package info
+        assert derive_subsystem(["tasks.py:foo"], "health") == "health"
+
+    def test_empty_frames_falls_back(self):
+        assert derive_subsystem([], "health") == "health"
+
+
+class TestClassKey:
+    def test_format(self):
+        assert class_key("KeyError", "memory") == "KeyErrorxmemory"

--- a/tests/test_reflex/test_ingest.py
+++ b/tests/test_reflex/test_ingest.py
@@ -1,0 +1,209 @@
+"""Tests for ReflexIngestor — filtering, enqueue gating, drain, containment."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import reflex_signals as crud
+from genesis.reflex.config import ReflexConfig
+from genesis.reflex.ingest import ReflexIngestor
+
+M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+FIXED_NOW = datetime(2026, 7, 21, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        await M70.up(conn)
+        await conn.commit()
+        yield conn
+
+
+def _ingestor(db, *, enabled=True, **kwargs):
+    ing = ReflexIngestor(
+        db,
+        config_loader=lambda: ReflexConfig(ingest_enabled=enabled),
+        clock=lambda: FIXED_NOW,
+        **kwargs,
+    )
+    ing.refresh_enabled()
+    return ing
+
+
+def _event(event_type="task.failed", subsystem="health", **details):
+    base = {
+        "task_name": "mem-sync",
+        "error": "KeyError: 'x'",
+        "error_type": "KeyError",
+        "error_frames": ["memory/sync.py:_apply", "memory/store.py:get"],
+    }
+    base.update(details)
+    return SimpleNamespace(event_type=event_type, subsystem=subsystem, details=base)
+
+
+class TestHandler:
+    async def test_enqueues_task_failed(self, db):
+        ing = _ingestor(db)
+        await ing.handle_event(_event())
+        assert ing.stats["queued"] == 1
+
+    async def test_ignores_other_event_types(self, db):
+        ing = _ingestor(db)
+        await ing.handle_event(_event(event_type="breaker.tripped"))
+        await ing.handle_event(_event(event_type="heartbeat"))
+        assert ing.stats["queued"] == 0
+
+    async def test_disabled_does_not_enqueue(self, db):
+        ing = _ingestor(db, enabled=False)
+        await ing.handle_event(_event())
+        assert ing.stats["queued"] == 0
+
+    async def test_queue_full_drops_counted_no_raise(self, db):
+        ing = _ingestor(db, queue_size=2)
+        for _ in range(5):
+            await ing.handle_event(_event())
+        assert ing.stats["queued"] == 2
+        assert ing.stats["dropped"] == 3
+
+    async def test_malformed_event_never_raises(self, db):
+        ing = _ingestor(db)
+        await ing.handle_event(SimpleNamespace(event_type="task.failed", details=None))
+        await ing.handle_event(SimpleNamespace(event_type="task.failed"))  # no details attr
+        # handler swallowed everything; the well-formed-enough ones enqueued
+        assert ing.stats["dropped"] == 0
+
+
+class TestProcess:
+    async def test_process_upserts_row(self, db):
+        ing = _ingestor(db)
+        row = await ing.process(
+            {
+                "task_name": "mem-sync",
+                "error": "KeyError: 'x'",
+                "error_type": "KeyError",
+                "error_frames": ["memory/sync.py:_apply", "memory/store.py:get"],
+                "subsystem": "health",
+            }
+        )
+        assert row["status"] == "new"
+        assert row["occurrence_count"] == 1
+        # subsystem derived from deepest frame, NOT the event's HEALTH default
+        assert row["subsystem"] == "memory"
+        assert row["class_key"] == "KeyErrorxmemory"
+        assert row["traceback_tail"] == "memory/sync.py:_apply>memory/store.py:get"
+
+    async def test_burst_collapses_to_one_row(self, db):
+        ing = _ingestor(db)
+        item = {
+            "task_name": "mem-sync",
+            "error": "KeyError: 'x'",
+            "error_type": "KeyError",
+            "error_frames": ["memory/sync.py:_apply"],
+            "subsystem": "health",
+        }
+        for _ in range(7):
+            row = await ing.process(item)
+        assert row["occurrence_count"] == 7
+        cur = await db.execute("SELECT COUNT(*) FROM reflex_signals")
+        assert (await cur.fetchone())[0] == 1
+
+    async def test_empty_frames_falls_back_to_event_subsystem(self, db):
+        ing = _ingestor(db)
+        row = await ing.process(
+            {
+                "task_name": "old-proc-task",
+                "error": "boom",
+                "error_type": "ValueError",
+                "error_frames": [],
+                "subsystem": "awareness",
+            }
+        )
+        assert row["subsystem"] == "awareness"
+        assert row["traceback_tail"] is None
+
+    async def test_recurrence_of_terminal_signal_reopens(self, db):
+        ing = _ingestor(db)
+        item = {
+            "task_name": "mem-sync",
+            "error": "KeyError: 'x'",
+            "error_type": "KeyError",
+            "error_frames": ["memory/sync.py:_apply"],
+            "subsystem": "health",
+        }
+        row = await ing.process(item)
+        await crud.set_status(
+            db,
+            signal_id=row["id"],
+            expected_from="new",
+            to="merged",
+            now=FIXED_NOW.isoformat(),
+        )
+        row = await ing.process(item)
+        assert row["status"] == "new"
+        assert row["reopen_count"] == 1
+        assert row["occurrence_count"] == 2
+
+
+class TestWorker:
+    async def test_worker_drains_queue_end_to_end(self, db):
+        ing = _ingestor(db, refresh_interval_s=0.05)
+        await ing.handle_event(_event())
+        await ing.handle_event(_event(task_name="other-task"))
+        worker = asyncio.create_task(ing._worker())
+        try:
+            for _ in range(100):
+                if ing.stats["processed"] >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            assert ing.stats["processed"] == 2
+            cur = await db.execute("SELECT COUNT(*) FROM reflex_signals")
+            assert (await cur.fetchone())[0] == 2
+        finally:
+            worker.cancel()
+
+    async def test_worker_survives_poison_item(self, db):
+        ing = _ingestor(db, refresh_interval_s=0.05)
+        ing._queue.put_nowait({"bad": "payload"})  # missing required keys
+        await ing.handle_event(_event())
+        worker = asyncio.create_task(ing._worker())
+        try:
+            for _ in range(100):
+                if ing.stats["processed"] >= 1:
+                    break
+                await asyncio.sleep(0.01)
+            # the good item after the poison one still processed
+            assert ing.stats["processed"] == 1
+        finally:
+            worker.cancel()
+
+    async def test_worker_refresh_disables_live(self, db):
+        flag = {"enabled": True}
+        ing = ReflexIngestor(
+            db,
+            config_loader=lambda: ReflexConfig(ingest_enabled=flag["enabled"]),
+            clock=lambda: FIXED_NOW,
+            refresh_interval_s=0.02,
+        )
+        ing.refresh_enabled()
+        assert ing.stats["enabled"] is True
+        flag["enabled"] = False
+        worker = asyncio.create_task(ing._worker())
+        try:
+            for _ in range(100):
+                if ing.stats["enabled"] is False:
+                    break
+                await asyncio.sleep(0.01)
+            assert ing.stats["enabled"] is False
+            # and the handler now refuses new events
+            await ing.handle_event(_event())
+            assert ing.stats["queued"] == 0
+        finally:
+            worker.cancel()

--- a/tests/test_reflex/test_ingest.py
+++ b/tests/test_reflex/test_ingest.py
@@ -10,11 +10,30 @@ from types import SimpleNamespace
 import aiosqlite
 import pytest
 
+import genesis.util.tasks as tasks_mod
 from genesis.db.crud import reflex_signals as crud
 from genesis.reflex.config import ReflexConfig
 from genesis.reflex.ingest import ReflexIngestor
 
 M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+
+class _FakeBus:
+    """Minimal bus: records the subscribe call, satisfies tracked_task."""
+
+    def __init__(self):
+        self.subscribed = None
+
+    def subscribe(self, listener, *, min_severity=None):
+        self.subscribed = listener
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_bus():
+    tasks_mod.set_default_event_bus(None)
+    yield
+    tasks_mod.set_default_event_bus(None)
+
 
 FIXED_NOW = datetime(2026, 7, 21, 12, 0, 0, tzinfo=UTC)
 
@@ -207,3 +226,71 @@ class TestWorker:
             assert ing.stats["queued"] == 0
         finally:
             worker.cancel()
+
+
+class TestDefaultBusLifecycle:
+    """start() installs the default bus when enabled; live-disable and stop()
+    unwind it so tracked_task stops emitting at the source."""
+
+    async def test_start_enabled_installs_default_bus(self, db):
+        bus = _FakeBus()
+        ing = ReflexIngestor(
+            db, config_loader=lambda: ReflexConfig(ingest_enabled=True), clock=lambda: FIXED_NOW
+        )
+        ing.start(bus)
+        try:
+            assert tasks_mod._default_event_bus is bus
+        finally:
+            ing._worker_task.cancel()
+
+    async def test_start_disabled_leaves_default_bus_clear(self, db):
+        bus = _FakeBus()
+        ing = ReflexIngestor(
+            db, config_loader=lambda: ReflexConfig(ingest_enabled=False), clock=lambda: FIXED_NOW
+        )
+        ing.start(bus)
+        try:
+            assert tasks_mod._default_event_bus is None
+        finally:
+            ing._worker_task.cancel()
+
+    async def test_live_disable_clears_default_bus(self, db):
+        flag = {"enabled": True}
+        bus = _FakeBus()
+        ing = ReflexIngestor(
+            db,
+            config_loader=lambda: ReflexConfig(ingest_enabled=flag["enabled"]),
+            clock=lambda: FIXED_NOW,
+            refresh_interval_s=0.02,
+        )
+        ing.start(bus)
+        try:
+            assert tasks_mod._default_event_bus is bus
+            flag["enabled"] = False
+            for _ in range(100):
+                if tasks_mod._default_event_bus is None:
+                    break
+                await asyncio.sleep(0.01)
+            # kill switch fully unwound: emission stops at the source
+            assert tasks_mod._default_event_bus is None
+        finally:
+            ing._worker_task.cancel()
+
+    async def test_stop_cancels_worker_and_clears_bus(self, db):
+        bus = _FakeBus()
+        ing = ReflexIngestor(
+            db, config_loader=lambda: ReflexConfig(ingest_enabled=True), clock=lambda: FIXED_NOW
+        )
+        ing.start(bus)
+        assert tasks_mod._default_event_bus is bus
+        await ing.stop()
+        assert tasks_mod._default_event_bus is None
+        assert ing._worker_task.cancelled() or ing._worker_task.done()
+
+    async def test_unit_ingestor_without_start_does_not_touch_global(self, db):
+        # tests that drive process()/handle_event directly must never mutate
+        # the process-global default bus (isolation guard)
+        ing = _ingestor(db, enabled=True)
+        assert tasks_mod._default_event_bus is None
+        await ing.handle_event(_event())
+        assert tasks_mod._default_event_bus is None

--- a/tests/test_reflex/test_integration.py
+++ b/tests/test_reflex/test_integration.py
@@ -1,0 +1,140 @@
+"""Full-chain integration — real tracked_task → real bus → real ingestor → DB.
+
+This is the E2E-at-code-level check the server dark-bake will later confirm
+at runtime: no mocks on the path. It wires the genuine GenesisEventBus, the
+genuine ReflexIngestor, and the genuine default-bus tracked_task fallback,
+then lets a real background coroutine raise — and asserts a fingerprinted
+row lands in reflex_signals with the right subsystem/class/count.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.observability.events import GenesisEventBus
+from genesis.reflex.config import ReflexConfig
+from genesis.reflex.ingest import ReflexIngestor
+from genesis.util.tasks import set_default_event_bus, tracked_task
+
+M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_bus():
+    set_default_event_bus(None)
+    yield
+    set_default_event_bus(None)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        await M70.up(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _drain_until(ingestor, target, *, timeout=3.0):
+    async def _poll():
+        while ingestor.stats["processed"] < target:
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+class TestFullChain:
+    async def test_real_task_failure_lands_a_signal(self, db):
+        bus = GenesisEventBus()
+        ingestor = ReflexIngestor(
+            db,
+            config_loader=lambda: ReflexConfig(ingest_enabled=True),
+            refresh_interval_s=0.05,
+        )
+        ingestor.start(bus)  # subscribes + starts worker; installs nothing global
+        set_default_event_bus(bus)  # what runtime init does when enabled
+
+        # A real background task with NO explicit event_bus — exactly the ~63
+        # call sites that were dark before PR1. It must still emit via the
+        # default bus and reach the ingestor.
+        async def _boom():
+            raise KeyError("integration-xyz")
+
+        task = tracked_task(_boom(), name="integration-loop")
+        with pytest.raises(KeyError):
+            await task
+
+        await _drain_until(ingestor, 1)
+
+        cur = await db.execute(
+            "SELECT fingerprint, error_type, class_key, occurrence_count, status "
+            "FROM reflex_signals"
+        )
+        rows = await cur.fetchall()
+        assert len(rows) == 1
+        fingerprint, error_type, class_key, count, status = rows[0]
+        assert error_type == "KeyError"
+        assert count == 1
+        assert status == "new"
+        # class_key subsystem derived from the deepest genesis frame — this
+        # test file lives under a /genesis/ path in the worktree, so the
+        # frame resolves to a package; assert the error-type half regardless
+        assert class_key.startswith("KeyErrorx")
+
+        ingestor._worker_task.cancel()
+
+    async def test_burst_of_real_failures_is_one_row(self, db):
+        bus = GenesisEventBus()
+        ingestor = ReflexIngestor(
+            db,
+            config_loader=lambda: ReflexConfig(ingest_enabled=True),
+            refresh_interval_s=0.05,
+        )
+        ingestor.start(bus)
+        set_default_event_bus(bus)
+
+        async def _boom(i):
+            raise ValueError(f"rotating-payload-{i}")  # varying message
+
+        for i in range(5):
+            task = tracked_task(_boom(i), name="burst-loop")
+            with pytest.raises(ValueError):
+                await task
+
+        await _drain_until(ingestor, 5)
+
+        cur = await db.execute("SELECT COUNT(*), MAX(occurrence_count) FROM reflex_signals")
+        n_rows, max_count = await cur.fetchone()
+        # variable message must NOT split the fingerprint — one row, count 5
+        assert n_rows == 1
+        assert max_count == 5
+
+        ingestor._worker_task.cancel()
+
+    async def test_disabled_ingestor_stores_nothing(self, db):
+        bus = GenesisEventBus()
+        ingestor = ReflexIngestor(
+            db,
+            config_loader=lambda: ReflexConfig(ingest_enabled=False),
+            refresh_interval_s=0.05,
+        )
+        ingestor.start(bus)
+        set_default_event_bus(bus)
+
+        async def _boom():
+            raise KeyError("should-be-ignored")
+
+        task = tracked_task(_boom(), name="dark-loop")
+        with pytest.raises(KeyError):
+            await task
+        # give the (idle) worker a few cycles — nothing should enqueue
+        await asyncio.sleep(0.2)
+
+        cur = await db.execute("SELECT COUNT(*) FROM reflex_signals")
+        assert (await cur.fetchone())[0] == 0
+        assert ingestor.stats["queued"] == 0
+
+        ingestor._worker_task.cancel()

--- a/tests/test_reflex/test_runtime_init.py
+++ b/tests/test_reflex/test_runtime_init.py
@@ -54,9 +54,17 @@ class TestGating:
     @pytest.mark.asyncio
     async def test_enabled_wires_everything(self):
         rt = _rt()
-        with patch(
-            "genesis.reflex.config.load_reflex_config",
-            return_value=ReflexConfig(ingest_enabled=True),
+        # patch BOTH the init-path read and the ingestor's own bound reference
+        # (the ingestor re-reads config for live toggling) so both see enabled
+        with (
+            patch(
+                "genesis.reflex.config.load_reflex_config",
+                return_value=ReflexConfig(ingest_enabled=True),
+            ),
+            patch(
+                "genesis.reflex.ingest.load_reflex_config",
+                return_value=ReflexConfig(ingest_enabled=True),
+            ),
         ):
             await reflex_init.init(rt)
         # subscriber registered at ERROR floor

--- a/tests/test_reflex/test_runtime_init.py
+++ b/tests/test_reflex/test_runtime_init.py
@@ -1,0 +1,70 @@
+"""Tests for runtime/init/reflex.py — gating, wiring, default-bus install."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import genesis.util.tasks as tasks_mod
+from genesis.reflex.config import ReflexConfig
+from genesis.runtime.init import reflex as reflex_init
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_bus():
+    tasks_mod.set_default_event_bus(None)
+    yield
+    tasks_mod.set_default_event_bus(None)
+
+
+def _rt():
+    rt = MagicMock()
+    rt._db = MagicMock()
+    rt._event_bus = MagicMock()
+    rt._reflex_ingestor = None
+    return rt
+
+
+class TestGating:
+    @pytest.mark.asyncio
+    async def test_disabled_config_stays_fully_dark(self):
+        rt = _rt()
+        with patch(
+            "genesis.reflex.config.load_reflex_config",
+            return_value=ReflexConfig(ingest_enabled=False),
+        ):
+            await reflex_init.init(rt)
+        rt._event_bus.subscribe.assert_not_called()
+        assert rt._reflex_ingestor is None
+        assert tasks_mod._default_event_bus is None  # nerve NOT wired
+
+    @pytest.mark.asyncio
+    async def test_missing_db_skips(self):
+        rt = _rt()
+        rt._db = None
+        with patch(
+            "genesis.reflex.config.load_reflex_config",
+            return_value=ReflexConfig(ingest_enabled=True),
+        ):
+            await reflex_init.init(rt)
+        rt._event_bus.subscribe.assert_not_called()
+        assert tasks_mod._default_event_bus is None
+
+    @pytest.mark.asyncio
+    async def test_enabled_wires_everything(self):
+        rt = _rt()
+        with patch(
+            "genesis.reflex.config.load_reflex_config",
+            return_value=ReflexConfig(ingest_enabled=True),
+        ):
+            await reflex_init.init(rt)
+        # subscriber registered at ERROR floor
+        rt._event_bus.subscribe.assert_called_once()
+        assert rt._event_bus.subscribe.call_args.kwargs["min_severity"].name == "ERROR"
+        # ingestor stashed on the runtime, worker started
+        assert rt._reflex_ingestor is not None
+        assert rt._reflex_ingestor._worker_task is not None
+        # THE nerve wiring: default bus installed for all tracked_task sites
+        assert tasks_mod._default_event_bus is rt._event_bus
+        rt._reflex_ingestor._worker_task.cancel()

--- a/tests/test_reflex/test_signals_crud.py
+++ b/tests/test_reflex/test_signals_crud.py
@@ -1,0 +1,183 @@
+"""Tests for reflex_signals CRUD — fingerprint upsert, reopen, transitions.
+
+All timestamps are injected (no wall clock). ISO-UTC strings compare
+lexicographically, which the mute-window check relies on.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import reflex_signals as crud
+
+M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+T0 = "2026-07-21T00:00:00+00:00"
+T1 = "2026-07-21T01:00:00+00:00"
+T2 = "2026-07-21T02:00:00+00:00"
+FUTURE = "2026-08-01T00:00:00+00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        await M70.up(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _upsert(db, *, fingerprint="fp00000000000001", now=T0, **overrides):
+    kwargs = {
+        "fingerprint": fingerprint,
+        "class_key": "KeyErrorxmemory",
+        "task_name": "mem-sync",
+        "subsystem": "memory",
+        "error_type": "KeyError",
+        "error_message": "KeyError: 'x'",
+        "traceback_tail": "memory/sync.py:_apply>memory/store.py:get",
+        "now": now,
+    }
+    kwargs.update(overrides)
+    return await crud.upsert_occurrence(db, **kwargs)
+
+
+class TestUpsert:
+    async def test_insert_creates_new_row(self, db):
+        row = await _upsert(db)
+        assert row["status"] == "new"
+        assert row["occurrence_count"] == 1
+        assert row["first_seen_at"] == T0
+        assert row["last_seen_at"] == T0
+        assert row["fingerprint"] == "fp00000000000001"
+        assert row["class_key"] == "KeyErrorxmemory"
+
+    async def test_conflict_increments_and_advances_last_seen(self, db):
+        await _upsert(db, now=T0)
+        row = await _upsert(db, now=T1, error_message="KeyError: 'y'")
+        assert row["occurrence_count"] == 2
+        assert row["first_seen_at"] == T0  # preserved
+        assert row["last_seen_at"] == T1
+        assert row["last_error_message"] == "KeyError: 'y'"  # latest wins
+
+    async def test_burst_of_n_is_one_row(self, db):
+        for i in range(10):
+            await _upsert(db, now=f"2026-07-21T00:00:{i:02d}+00:00")
+        cur = await db.execute("SELECT COUNT(*) FROM reflex_signals")
+        assert (await cur.fetchone())[0] == 1
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert row["occurrence_count"] == 10
+
+    async def test_distinct_fingerprints_distinct_rows(self, db):
+        await _upsert(db, fingerprint="fp00000000000001")
+        await _upsert(db, fingerprint="fp00000000000002")
+        cur = await db.execute("SELECT COUNT(*) FROM reflex_signals")
+        assert (await cur.fetchone())[0] == 2
+
+    async def test_conflict_does_not_touch_status(self, db):
+        await _upsert(db, now=T0)
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert await crud.set_status(
+            db, signal_id=row["id"], expected_from="new", to="carded_diagnose", now=T1
+        )
+        row = await _upsert(db, now=T2)
+        assert row["status"] == "carded_diagnose"
+        assert row["occurrence_count"] == 2
+
+
+_TERMINAL = [
+    "merged",
+    "resolved",
+    "dismissed_notbug",
+    "dismissed_wontfix",
+    "card_expired",
+    "diagnose_failed",
+    "fix_failed",
+]
+
+
+class TestReopen:
+    @pytest.mark.parametrize("terminal", _TERMINAL)
+    async def test_reopens_from_each_terminal_status(self, db, terminal):
+        row = await _upsert(db, now=T0)
+        await crud.set_status(db, signal_id=row["id"], expected_from="new", to=terminal, now=T1)
+        assert await crud.maybe_reopen(db, fingerprint="fp00000000000001", now=T2) is True
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert row["status"] == "new"
+        assert row["reopen_count"] == 1
+        assert row["reopened_at"] == T2
+        assert row["diagnose_request_id"] is None
+        assert row["fix_request_id"] is None
+        assert row["task_id"] is None
+
+    async def test_no_reopen_from_active_status(self, db):
+        row = await _upsert(db, now=T0)
+        await crud.set_status(db, signal_id=row["id"], expected_from="new", to="diagnosing", now=T1)
+        assert await crud.maybe_reopen(db, fingerprint="fp00000000000001", now=T2) is False
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert row["status"] == "diagnosing"
+        assert row["reopen_count"] == 0
+
+    async def test_muted_until_blocks_reopen(self, db):
+        row = await _upsert(db, now=T0)
+        await crud.set_status(
+            db, signal_id=row["id"], expected_from="new", to="dismissed_wontfix", now=T1
+        )
+        await db.execute(
+            "UPDATE reflex_signals SET muted_until = ? WHERE id = ?", (FUTURE, row["id"])
+        )
+        await db.commit()
+        assert await crud.maybe_reopen(db, fingerprint="fp00000000000001", now=T2) is False
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert row["status"] == "dismissed_wontfix"
+
+    async def test_expired_mute_allows_reopen(self, db):
+        row = await _upsert(db, now=T0)
+        await crud.set_status(
+            db, signal_id=row["id"], expected_from="new", to="dismissed_wontfix", now=T0
+        )
+        await db.execute("UPDATE reflex_signals SET muted_until = ? WHERE id = ?", (T1, row["id"]))
+        await db.commit()
+        assert await crud.maybe_reopen(db, fingerprint="fp00000000000001", now=T2) is True
+
+    async def test_missing_fingerprint_returns_false(self, db):
+        assert await crud.maybe_reopen(db, fingerprint="nope", now=T0) is False
+
+
+class TestSetStatus:
+    async def test_guarded_transition_succeeds(self, db):
+        row = await _upsert(db)
+        assert (
+            await crud.set_status(
+                db, signal_id=row["id"], expected_from="new", to="carded_diagnose", now=T1
+            )
+            is True
+        )
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert row["status"] == "carded_diagnose"
+        assert row["updated_at"] == T1
+
+    async def test_wrong_expected_from_is_noop(self, db):
+        row = await _upsert(db)
+        assert (
+            await crud.set_status(
+                db, signal_id=row["id"], expected_from="diagnosing", to="diagnosed", now=T1
+            )
+            is False
+        )
+        row = await crud.get_by_fingerprint(db, "fp00000000000001")
+        assert row["status"] == "new"
+
+
+class TestListByStatus:
+    async def test_lists_matching_only(self, db):
+        await _upsert(db, fingerprint="fp00000000000001")
+        await _upsert(db, fingerprint="fp00000000000002")
+        row2 = await crud.get_by_fingerprint(db, "fp00000000000002")
+        await crud.set_status(
+            db, signal_id=row2["id"], expected_from="new", to="diagnosing", now=T1
+        )
+        rows = await crud.list_by_status(db, "new")
+        assert [r["fingerprint"] for r in rows] == ["fp00000000000001"]

--- a/tests/test_util/test_tasks.py
+++ b/tests/test_util/test_tasks.py
@@ -1,0 +1,238 @@
+"""Tests for tracked_task failure observation — emit payload + default bus.
+
+The reflex arc (PR1) extended ``tracked_task``:
+
+- ``task.failed`` events now carry ``error_type`` and ``error_frames``
+  (normalized, line-number-free traceback tail) alongside the legacy
+  ``task_name``/``error`` fields
+- a module-level default event bus makes ALL tracked_task sites emit
+  without per-call-site ``event_bus=`` plumbing (explicit arg still wins)
+
+Frame tests use synthetic tracebacks with controlled filenames — the test
+file's own path must never be an input (repo dir names differ per install).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from genesis.util.tasks import (
+    _normalized_frames,
+    set_default_event_bus,
+    tracked_task,
+)
+
+
+class FakeBus:
+    def __init__(self):
+        self.events: list[dict] = []
+
+    async def emit(self, subsystem, severity, event_type, message, **details):
+        self.events.append(
+            {
+                "subsystem": subsystem,
+                "severity": severity,
+                "event_type": event_type,
+                "message": message,
+                "details": details,
+            }
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_bus():
+    """The default bus is process-global — never leak it across tests."""
+    set_default_event_bus(None)
+    yield
+    set_default_event_bus(None)
+
+
+def _raise_at(filename: str, funcname: str, exc_type: type[Exception] = KeyError) -> Exception:
+    """Raise inside a function compiled at a controlled fake filename.
+
+    The helper's own frame is stripped from the traceback so assertions see
+    ONLY the synthetic frames — this test file's path is install-specific
+    (contains ``/genesis/`` here, not on CI) and must never be an input.
+    """
+    src = f"def {funcname}():\n    raise __EXC__('boom-4217')\n"
+    ns: dict = {"__EXC__": exc_type}
+    exec(compile(src, filename, "exec"), ns)  # noqa: S102 — test-only synthetic frames
+    try:
+        ns[funcname]()
+    except Exception as exc:  # noqa: BLE001
+        assert exc.__traceback__ is not None
+        return exc.with_traceback(exc.__traceback__.tb_next)
+    raise AssertionError("did not raise")
+
+
+class TestNormalizedFrames:
+    def test_relpath_from_genesis_segment(self):
+        exc = _raise_at("/install/src/genesis/memory/sync.py", "_apply_delta")
+        assert _normalized_frames(exc) == ["memory/sync.py:_apply_delta"]
+
+    def test_no_line_numbers_anywhere(self):
+        exc = _raise_at("/install/src/genesis/memory/sync.py", "_apply_delta")
+        for frame in _normalized_frames(exc):
+            assert frame.count(":") == 1  # exactly relpath:funcname, no :lineno
+
+    def test_non_genesis_frames_dropped_when_genesis_present(self):
+        # outer frame in stdlib-ish path, inner in genesis → only genesis kept
+        def outer():
+            ns: dict = {}
+            src = "def inner():\n    raise ValueError('x')\n"
+            exec(compile(src, "/install/src/genesis/routing/router.py", "exec"), ns)  # noqa: S102
+            ns["inner"]()
+
+        try:
+            outer()
+        except ValueError as exc:
+            frames = _normalized_frames(exc)
+        # this test function's own frame (repo path, install-specific) may or
+        # may not carry a /genesis/ segment; the synthetic genesis frame must
+        # be the LAST (deepest) either way
+        assert frames[-1] == "routing/router.py:inner"
+
+    def test_all_foreign_frames_kept_as_basenames(self):
+        exc = _raise_at("/usr/lib/python3.12/threading.py", "run")
+        assert _normalized_frames(exc) == ["threading.py:run"]
+
+    def test_last_three_only(self):
+        src = (
+            "def f1():\n    raise KeyError('k')\n"
+            "def f2():\n    f1()\n"
+            "def f3():\n    f2()\n"
+            "def f4():\n    f3()\n"
+        )
+        ns: dict = {}
+        exec(compile(src, "/install/src/genesis/ego/session.py", "exec"), ns)  # noqa: S102
+        try:
+            ns["f4"]()
+        except KeyError as exc:
+            frames = _normalized_frames(exc)
+        # call chain f4→f3→f2→f1 = 4 genesis frames; keep the DEEPEST three
+        assert frames == [
+            "ego/session.py:f3",
+            "ego/session.py:f2",
+            "ego/session.py:f1",
+        ]
+
+    def test_no_traceback_yields_empty(self):
+        assert _normalized_frames(KeyError("bare")) == []
+
+
+async def _fail(exc: Exception):
+    raise exc
+
+
+async def _settle():
+    # done-callback runs via call_soon; emit_sync relays via create_task —
+    # two scheduling hops need real loop turns
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+async def _fail_at(filename: str, funcname: str):
+    """Coroutine raising inside a function compiled at a fake filename."""
+    src = f"def {funcname}():\n    raise KeyError('boom-4217')\n"
+    ns: dict = {}
+    exec(compile(src, filename, "exec"), ns)  # noqa: S102 — test-only synthetic frames
+    ns[funcname]()
+
+
+class TestEmitPayload:
+    async def test_explicit_bus_emits_extended_payload(self):
+        bus = FakeBus()
+        task = tracked_task(
+            _fail_at("/install/src/genesis/memory/sync.py", "_apply_delta"),
+            name="mem-sync",
+            event_bus=bus,
+        )
+        with pytest.raises(KeyError):
+            await task
+        await _settle()
+
+        assert len(bus.events) == 1
+        ev = bus.events[0]
+        assert ev["event_type"] == "task.failed"
+        d = ev["details"]
+        assert d["task_name"] == "mem-sync"  # legacy field intact
+        assert "boom-4217" in d["error"]  # legacy field intact
+        assert d["error_type"] == "KeyError"
+        # deepest frame = the synthetic raise site; earlier frames (this test
+        # file, the coroutine) may or may not survive the genesis-path filter
+        # depending on where the repo lives per install — assert the invariant
+        assert d["error_frames"][-1] == "memory/sync.py:_apply_delta"
+
+    async def test_default_bus_fallback(self):
+        bus = FakeBus()
+        set_default_event_bus(bus)
+        task = tracked_task(_fail(ValueError("v")), name="no-arg-site")
+        with pytest.raises(ValueError):
+            await task
+        await _settle()
+        assert len(bus.events) == 1
+        assert bus.events[0]["details"]["task_name"] == "no-arg-site"
+
+    async def test_explicit_arg_wins_over_default(self):
+        default = FakeBus()
+        explicit = FakeBus()
+        set_default_event_bus(default)
+        task = tracked_task(_fail(ValueError("v")), name="t", event_bus=explicit)
+        with pytest.raises(ValueError):
+            await task
+        await _settle()
+        assert len(explicit.events) == 1
+        assert default.events == []
+
+    async def test_no_bus_anywhere_no_crash(self):
+        task = tracked_task(_fail(ValueError("v")), name="t")
+        with pytest.raises(ValueError):
+            await task
+        await _settle()  # nothing to assert — absence of exception is the test
+
+    async def test_default_bus_late_binding(self):
+        # a task CREATED before the default bus is wired still emits if it
+        # FAILS after wiring — the callback reads the global at fire time
+        bus = FakeBus()
+        gate: asyncio.Event = asyncio.Event()
+
+        async def fail_after_gate():
+            await gate.wait()
+            raise ValueError("late")
+
+        task = tracked_task(fail_after_gate(), name="early-task")
+        set_default_event_bus(bus)
+        gate.set()
+        with pytest.raises(ValueError):
+            await task
+        await _settle()
+        assert len(bus.events) == 1
+
+    async def test_success_emits_nothing(self):
+        bus = FakeBus()
+        set_default_event_bus(bus)
+
+        async def ok():
+            return 42
+
+        task = tracked_task(ok(), name="fine")
+        assert await task == 42
+        await _settle()
+        assert bus.events == []
+
+    async def test_cancelled_emits_nothing(self):
+        bus = FakeBus()
+        set_default_event_bus(bus)
+
+        async def forever():
+            await asyncio.sleep(3600)
+
+        task = tracked_task(forever(), name="cancel-me")
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await _settle()
+        assert bus.events == []


### PR DESCRIPTION
## Reflex Arc — PR1: the afferent nerve (ships dark)

First slice of the reflex arc (autonomous self-bug detection & repair). Spec: `docs/superpowers/specs/2026-07-21-reflex-arc-design.md`. This PR ingests background-task failures into a fingerprint-deduped signal store. **No cards, no sessions, no LLM calls, no dispatch** — pure observation, gated OFF by default.

### What it does
- **Wires the dark nerve.** `tracked_task` had ~66 call sites but only ~3 passed an `event_bus`, so background-task failures died in the logger — **zero `task.failed` events in 36 days** of retained history. A process-wide default event bus (`set_default_event_bus`, installed at runtime init) makes every site emit, current and future. An explicit `event_bus=` argument still wins.
- **Richer failure payload.** `task.failed` now carries `error_type` and a normalized, line-number-free traceback tail (`memory/sync.py:_apply_delta`) so fingerprints stay stable across unrelated commits.
- **Fingerprints + dedups** into `reflex_signals` (`ON CONFLICT(fingerprint)` → occurrence count). A burst of N identical crashes is one row, not N. `reflex_diagnoses` and `reflex_verdicts` (the taste corpus) ship now so later phases add no rebuild migrations.
- **Off-dispatch-path ingestion.** The bus subscriber only enqueues to a bounded queue (counted drops); a dedicated worker drains and upserts — so a failure burst never serializes the event bus behind SQLite.

### Safety (from the pre-implementation architect review)
The default-bus wiring is not passive — `task.failed` reaches every ERROR+ bus subscriber. Folded in before merge:
- **Ego carve-out.** The ego reactive loop subscribes at ERROR and would spin a cognition cycle per failure, with a message-keyed dedup that variable exception payloads bypass (a documented event-burst storm mode, `ego/cadence.py`). `task.failed` is now dropped from the ego reactive path — reflex is the designed consumer. The carve-out is unconditional; in the dark state the ~3 already-wired sites lose their ego reaction, but those sites have zero failure history and the ERROR log still fires.
- **Kill switch + default OFF.** `config/reflex.yaml` `ingest_enabled: false` gates both the default-bus wiring and ingestion; `GENESIS_REFLEX_INGEST_OFF=1` env kill wins over config. Turning OFF is honored live (~30s); turning ON needs a restart.
- **Frame-derived subsystem.** `class_key`'s subsystem comes from the deepest genesis frame, not the event's (mostly-HEALTH) field, so the taxonomy axis isn't near-constant.

### Deploy path
Runtime code + additive migration `0070` — `git pull` + restart. Fresh clones get the tables from the canonical schema. Ships dark on every install; enabling is a deliberate per-install flip.

### Tests
New: `tests/test_reflex/` (fingerprint, config, CRUD, ingest concurrency, runtime wiring), `tests/test_db/test_migration_0070_reflex_arc.py`, extended `tests/test_util/test_tasks.py` and `tests/ego/test_init.py`. Full regression sweep of ego + util + observability + db + runtime: ~2700 tests green, no regressions.

### Next (separate PRs)
PR2 = diagnose lane (card #1, gate integration, taste-corpus writes). PR3 = fix lane (card #2, executor dispatch, PR reconcile). Then a dark bake measures real post-wiring `task.failed` volume before anything user-facing enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
