### PR TITLE
fix(install): data-loss guards — atomic writes + preserve user config on re-run (B4/S1/S2/B10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Setup and restore scripts no longer risk destroying user data on a re-run
+  or crash.** Three install-surface fixes: re-running local-config setup now
+  preserves your existing `github.private_repo` and any custom keys (it rebuilt
+  the file from scratch before, wiping them) and writes atomically; the shell
+  wrapper that setup installs in `~/.bashrc` is rewritten atomically and, if it
+  finds a half-written block from an earlier interrupted run, leaves the file
+  untouched instead of deleting everything below it; the CC-memory restore never
+  overwrites a newer local file with an older backup copy (a `cp` quirk on newer
+  systems used to); and local-config setup fails with a clear "install PyYAML"
+  message up front instead of a raw traceback after you've answered every prompt.
+
 - **Per-prompt memory recall no longer silently degrades on busy installs.**
   The server-side recall budget behind the proactive memory hook was sized
   against a dev install that (unnoticed) ran no reranker and a half-size

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -737,8 +737,12 @@ claude() {
 WRAPEOF
 touch "$BASHRC"
 if grep -qF "# >>> genesis tmux-wrap >>>" "$BASHRC" 2>/dev/null; then
-    # Replace the existing block in place (idempotent update path).
-    GENESIS_TMUX_WRAP_BLOCK="$TMUX_WRAP_BLOCK" python3 - "$BASHRC" <<'PYEOF'
+    # Replace the existing block in place (idempotent update path). Capture the
+    # python rc (`|| _tw_rc=$?` keeps set -e from aborting): 0 = rewritten,
+    # 2 = damaged block left untouched (do NOT claim it refreshed), other = a
+    # real write error to surface.
+    _tw_rc=0
+    GENESIS_TMUX_WRAP_BLOCK="$TMUX_WRAP_BLOCK" python3 - "$BASHRC" <<'PYEOF' || _tw_rc=$?
 import os
 import sys
 import tempfile
@@ -762,7 +766,7 @@ if b is not None:
         sys.stderr.write(
             "  WARNING: ~/.bashrc has an unterminated genesis tmux-wrap block "
             "(missing end sentinel) — leaving it untouched; fix it manually.\n")
-        sys.exit(0)
+        sys.exit(2)  # distinct rc: the caller must NOT claim it refreshed
     out = lines[:b] + lines[e + 1:]
 else:
     out = lines
@@ -785,7 +789,13 @@ except BaseException:
         pass
     raise
 PYEOF
-    echo "  tmux-wrap block refreshed in ~/.bashrc"
+    if [ "$_tw_rc" -eq 0 ]; then
+        echo "  tmux-wrap block refreshed in ~/.bashrc"
+    elif [ "$_tw_rc" -eq 2 ]; then
+        echo "  tmux-wrap block left untouched — ~/.bashrc has a damaged block; fix it manually (see warning above)"
+    else
+        echo "  WARNING: could not update tmux-wrap block in ~/.bashrc (rc=$_tw_rc)"
+    fi
 else
     printf '\n%s\n' "$TMUX_WRAP_BLOCK" >> "$BASHRC"
     echo "  tmux-wrap block installed in ~/.bashrc"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -741,24 +741,49 @@ if grep -qF "# >>> genesis tmux-wrap >>>" "$BASHRC" 2>/dev/null; then
     GENESIS_TMUX_WRAP_BLOCK="$TMUX_WRAP_BLOCK" python3 - "$BASHRC" <<'PYEOF'
 import os
 import sys
+import tempfile
 
 path = sys.argv[1]
 begin = "# >>> genesis tmux-wrap >>>"
 end = "# <<< genesis tmux-wrap <<<"
 block = os.environ["GENESIS_TMUX_WRAP_BLOCK"]
 lines = open(path).read().splitlines()
-out, skipping = [], False
-for line in lines:
-    if line.strip() == begin:
-        skipping = True
-        continue
-    if line.strip() == end:
-        skipping = False
-        continue
-    if not skipping:
-        out.append(line)
+
+# Locate the FIRST well-formed begin..end pair and replace only that. A BEGIN
+# with NO matching END after it is a damaged/half-written block (e.g. a prior
+# crash mid-append) — the old code set `skipping=True` at BEGIN and cleared it
+# only at END, so a missing END swallowed everything from BEGIN to EOF,
+# DELETING any user content below the block. Refuse that: leave ~/.bashrc
+# untouched and warn.
+b = next((i for i, ln in enumerate(lines) if ln.strip() == begin), None)
+if b is not None:
+    e = next((i for i in range(b + 1, len(lines)) if lines[i].strip() == end), None)
+    if e is None:
+        sys.stderr.write(
+            "  WARNING: ~/.bashrc has an unterminated genesis tmux-wrap block "
+            "(missing end sentinel) — leaving it untouched; fix it manually.\n")
+        sys.exit(0)
+    out = lines[:b] + lines[e + 1:]
+else:
+    out = lines
+
 text = "\n".join(out).rstrip("\n")
-open(path, "w").write(text + "\n\n" + block + "\n")
+new = (text + "\n\n" if text else "") + block + "\n"
+
+# Atomic write: a temp file in the SAME dir + os.replace (atomic rename on
+# POSIX) so a crash between open and write can never leave ~/.bashrc truncated.
+d = os.path.dirname(path) or "."
+fd, tmp = tempfile.mkstemp(dir=d, prefix=".bashrc.genesis-tmp.")
+try:
+    with os.fdopen(fd, "w") as f:
+        f.write(new)
+    os.replace(tmp, path)
+except BaseException:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
 PYEOF
     echo "  tmux-wrap block refreshed in ~/.bashrc"
 else

--- a/scripts/restore_cc_memory.sh
+++ b/scripts/restore_cc_memory.sh
@@ -28,10 +28,20 @@ echo "Backup source:    $BACKUP_DIR"
 
 mkdir -p "$CC_MEMORY_DIR"
 
-# Copy without overwriting newer files (preserve work done on this machine)
-# Using cp -an (no-clobber) to avoid overwriting existing files
-cp -an "$BACKUP_DIR"/. "$CC_MEMORY_DIR/" 2>/dev/null || \
-    cp -a "$BACKUP_DIR"/. "$CC_MEMORY_DIR/"
+# Copy files the machine doesn't already have, NEVER overwriting existing ones
+# (preserve work done on this machine). The old `cp -an … || cp -a …` was a
+# data-loss trap: coreutils 9.1+ makes `cp -an` return NON-ZERO when it SKIPS an
+# existing file (skip-counts-as-failure), so on a normal run the `|| cp -a`
+# fallback fired and CLOBBERED the newer local files `-n` exists to protect.
+# Prefer rsync --ignore-existing (stable, version-independent skip semantics);
+# fall back to `cp -an` best-effort (its skip-as-failure exit is swallowed — a
+# skipped existing file is the intended outcome, not an error to "recover" from
+# by overwriting).
+if command -v rsync >/dev/null 2>&1; then
+    rsync -a --ignore-existing "$BACKUP_DIR"/ "$CC_MEMORY_DIR/"
+else
+    cp -an "$BACKUP_DIR"/. "$CC_MEMORY_DIR/" || true
+fi
 
 FILE_COUNT=$(find "$CC_MEMORY_DIR" -type f | wc -l)
 TOTAL_SIZE=$(du -sh "$CC_MEMORY_DIR" | cut -f1)

--- a/scripts/restore_cc_memory.sh
+++ b/scripts/restore_cc_memory.sh
@@ -37,10 +37,24 @@ mkdir -p "$CC_MEMORY_DIR"
 # fall back to `cp -an` best-effort (its skip-as-failure exit is swallowed — a
 # skipped existing file is the intended outcome, not an error to "recover" from
 # by overwriting).
+# The caller (restore.sh §5) keys _CCMEM_RESTORED on this script's exit status,
+# so the copy must be no-clobber AND propagate a REAL failure (unreadable
+# source, permission, full disk) as a non-zero exit — while NOT failing merely
+# because it skipped an existing file.
 if command -v rsync >/dev/null 2>&1; then
+    # rsync: --ignore-existing is stable no-clobber with proper exit codes.
     rsync -a --ignore-existing "$BACKUP_DIR"/ "$CC_MEMORY_DIR/"
+elif cp --help 2>/dev/null | grep -q -- '--update'; then
+    # coreutils 9.3+: `--update=none` is the stable no-clobber flag (the one
+    # `cp -n`'s own deprecation warning points to). A skip exits 0, a real error
+    # exits non-zero — so let the exit status propagate under `set -e`. (cp -n on
+    # 9.1-9.2 counted a skip as failure and 9.3+ warns about it — both avoided.)
+    cp -a --update=none "$BACKUP_DIR"/. "$CC_MEMORY_DIR/"
 else
-    cp -an "$BACKUP_DIR"/. "$CC_MEMORY_DIR/" || true
+    # Pre-9.3 coreutils without --update=none: cp -an is no-clobber but its exit
+    # code can't distinguish a skip from a real error, so this path is
+    # best-effort only (the two paths above carry clean error propagation).
+    cp -an "$BACKUP_DIR"/. "$CC_MEMORY_DIR/" 2>/dev/null || true
 fi
 
 FILE_COUNT=$(find "$CC_MEMORY_DIR" -type f | wc -l)

--- a/scripts/setup-local-config.sh
+++ b/scripts/setup-local-config.sh
@@ -45,8 +45,9 @@ _read_yaml_value() {
     local key="$1"
     [[ -f "$LOCAL_CONFIG" ]] || { echo ""; return; }
     python3 - "$LOCAL_CONFIG" "$key" <<'PYEOF'
-import sys, yaml
+import sys
 try:
+    import yaml  # inside the try: a missing PyYAML degrades to an empty default
     with open(sys.argv[1]) as f:
         data = yaml.safe_load(f) or {}
     parts = sys.argv[2].split(".")
@@ -60,6 +61,16 @@ except Exception:
     print("")
 PYEOF
 }
+
+# PyYAML is required to WRITE the config below (unlike the read above, the write
+# cannot degrade). On a minimal image it may be absent — fail with a clear,
+# actionable message up front rather than a raw traceback after the operator has
+# answered every prompt.
+if ! python3 -c 'import yaml' 2>/dev/null; then
+    _warn "PyYAML is required but not importable by python3."
+    _warn "Install it first, e.g.:  sudo apt-get install -y python3-yaml   (or: python3 -m pip install pyyaml)"
+    exit 1
+fi
 
 # ── Banner ────────────────────────────────────────────────────────────────────
 
@@ -140,7 +151,11 @@ mkdir -p "$CONFIG_DIR"
 python3 - "$LOCAL_CONFIG" \
     "$OLLAMA_URL" "$OLLAMA_ENABLED" "$LM_STUDIO_URL" \
     "$USER_TIMEZONE" "$GH_USER" "$GH_PUBLIC_REPO" << 'PYEOF'
-import sys, yaml
+import os
+import sys
+import tempfile
+
+import yaml
 
 out_path = sys.argv[1]
 ollama_url, ollama_enabled_str, lm_studio_url = sys.argv[2], sys.argv[3], sys.argv[4]
@@ -149,28 +164,58 @@ timezone, gh_user, gh_public_repo = sys.argv[5], sys.argv[6], sys.argv[7]
 # Parse ollama_enabled: accept "true"/"false"/1/0 strings
 ollama_enabled = ollama_enabled_str.lower() in {"true", "1", "yes"}
 
-data = {
-    "network": {
-        "ollama_url": ollama_url,
-        "ollama_enabled": ollama_enabled,
-        "lm_studio_url": lm_studio_url,
-    },
-    "timezone": timezone,
-    "github": {
-        "user": gh_user,
-        "public_repo": gh_public_repo,
-        "private_repo": "",
-    },
-}
+# Load the existing config FIRST and update only the leaves this script manages,
+# so a re-run preserves github.private_repo (never prompted here) and any key a
+# user or another tool added. The old code built a fresh literal dict and wiped
+# everything it didn't know about.
+data = {}
+if os.path.exists(out_path):
+    try:
+        with open(out_path) as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        data = {}
+if not isinstance(data, dict):
+    data = {}
+
+net = data.get("network")
+if not isinstance(net, dict):
+    net = data["network"] = {}
+net["ollama_url"] = ollama_url
+net["ollama_enabled"] = ollama_enabled
+net["lm_studio_url"] = lm_studio_url
+
+data["timezone"] = timezone
+
+gh = data.get("github")
+if not isinstance(gh, dict):
+    gh = data["github"] = {}
+gh["user"] = gh_user
+gh["public_repo"] = gh_public_repo
+gh.setdefault("private_repo", "")  # keep an existing value; default only if absent
 
 header = (
     "# Genesis local configuration — machine-specific, never committed to git.\n"
     "# Regenerate: ./scripts/setup-local-config.sh\n"
     "# Env var overrides take precedence over values here.\n\n"
 )
-with open(out_path, "w") as f:
-    f.write(header)
-    yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+# Atomic write: temp file in the SAME dir + os.replace, so a mid-write kill can
+# never corrupt genesis.yaml (which would also destroy the values the next run
+# reads back as defaults).
+d = os.path.dirname(out_path) or "."
+fd, tmp = tempfile.mkstemp(dir=d, prefix=".genesis.yaml-tmp.")
+try:
+    with os.fdopen(fd, "w") as f:
+        f.write(header)
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    os.replace(tmp, out_path)
+except BaseException:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
 PYEOF
 
 _ok "Config written to $LOCAL_CONFIG"

--- a/tests/test_scripts/test_install_dataloss.py
+++ b/tests/test_scripts/test_install_dataloss.py
@@ -1,0 +1,215 @@
+"""Install-surface data-loss guards (deploy-audit B4/S1/S2/B10).
+
+Three install/setup scripts could destroy user data on a re-run or a crash:
+
+* **B4** `scripts/bootstrap.sh` rewrites the `~/.bashrc` genesis tmux-wrap block
+  in place, non-atomically, and — when the END sentinel is missing (a
+  half-written block) — deleted everything from BEGIN to EOF, taking any user
+  content below it. Now: atomic temp+rename, and a missing END leaves the file
+  untouched.
+* **S1** `scripts/setup-local-config.sh` rebuilt `genesis.yaml` from a fresh
+  literal dict on every re-run, wiping `github.private_repo` and any unmanaged
+  key, with a non-atomic write. Now: load-merge existing + atomic write.
+* **S2** the same script's `import yaml` aborted with a raw traceback on a
+  minimal image lacking PyYAML. Now: read degrades to empty defaults, and a
+  preflight fails fast with an actionable message before the write.
+* **B10** `scripts/restore_cc_memory.sh` used `cp -an … || cp -a …`; coreutils
+  9.1+ returns non-zero when `cp -an` skips an existing file, so the clobbering
+  `cp -a` fallback overwrote the newer local files `-n` exists to protect. Now:
+  rsync --ignore-existing (or `cp -an` best-effort), never a clobber.
+
+The B4 heredoc is extracted from the shipped script and run directly; S1/B10 run
+the real scripts in a sandbox; S2 is asserted on the shipped text (a missing
+PyYAML is awkward to stage live).
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap.sh"
+SETUP_LOCAL = REPO_ROOT / "scripts" / "setup-local-config.sh"
+RESTORE_CC = REPO_ROOT / "scripts" / "restore_cc_memory.sh"
+
+
+# ── B4: bashrc rewriter ──────────────────────────────────────────────
+
+
+def _extract_bashrc_heredoc() -> str:
+    """Pull the exact python heredoc that rewrites ~/.bashrc out of bootstrap.sh
+    so the test runs the SHIPPED code, not a copy."""
+    text = BOOTSTRAP.read_text()
+    m = re.search(r'python3 - "\$BASHRC" <<\'PYEOF\'\n(.*?)\nPYEOF', text, re.DOTALL)
+    assert m, "could not find the bashrc-rewriter heredoc in bootstrap.sh"
+    return m.group(1)
+
+
+_BLOCK = "# >>> genesis tmux-wrap >>>\nclaude() { :; }\n# <<< genesis tmux-wrap <<<"
+
+
+def _run_bashrc_rewriter(tmp_path, bashrc_text: str):
+    src = tmp_path / "rewriter.py"
+    src.write_text(_extract_bashrc_heredoc())
+    bashrc = tmp_path / ".bashrc"
+    bashrc.write_text(bashrc_text)
+    proc = subprocess.run(
+        [sys.executable, str(src), str(bashrc)],
+        env={**os.environ, "GENESIS_TMUX_WRAP_BLOCK": _BLOCK},
+        capture_output=True,
+        text=True,
+    )
+    return proc, bashrc
+
+
+def test_b4_atomic_and_endmarker_in_text():
+    """Extraction: the rewriter is atomic (temp + os.replace) and refuses the
+    END-missing swallow-to-EOF."""
+    heredoc = _extract_bashrc_heredoc()
+    assert "os.replace(" in heredoc and "mkstemp(" in heredoc
+    assert "unterminated genesis tmux-wrap block" in heredoc
+    assert 'open(path, "w").write' not in heredoc  # the old non-atomic write is gone
+
+
+def test_b4_missing_end_preserves_user_content(tmp_path):
+    """A damaged block (BEGIN, no END) with user content BELOW it must NOT be
+    swallowed to EOF — the file is left untouched and warned about."""
+    bashrc = (
+        "export USER_VAR=1\n"
+        "# >>> genesis tmux-wrap >>>\n"
+        "claude() { partial\n"  # damaged: no END sentinel
+        "export IMPORTANT_USER_LINE=keep-me\n"
+    )
+    proc, out = _run_bashrc_rewriter(tmp_path, bashrc)
+    assert proc.returncode == 0, proc.stderr
+    assert "IMPORTANT_USER_LINE=keep-me" in out.read_text(), "user content was destroyed"
+    assert "unterminated" in proc.stderr
+
+
+def test_b4_wellformed_block_replaced(tmp_path):
+    """A well-formed block is replaced in place; user content around it survives;
+    the new block lands exactly once."""
+    bashrc = (
+        "export BEFORE=1\n"
+        "# >>> genesis tmux-wrap >>>\n"
+        "claude() { OLD; }\n"
+        "# <<< genesis tmux-wrap <<<\n"
+        "export AFTER=2\n"
+    )
+    proc, out = _run_bashrc_rewriter(tmp_path, bashrc)
+    assert proc.returncode == 0, proc.stderr
+    txt = out.read_text()
+    assert "export BEFORE=1" in txt and "export AFTER=2" in txt
+    assert "OLD" not in txt  # old block body replaced
+    assert txt.count("# >>> genesis tmux-wrap >>>") == 1
+
+
+# ── S1 / S2: setup-local-config.sh ───────────────────────────────────
+
+
+def _run_setup_local(tmp_path):
+    home = tmp_path / "home"
+    (home / ".genesis" / "config").mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    # Ensure the script's bare `python3` resolves to an interpreter WITH yaml
+    # (the venv running these tests).
+    env["HOME"] = str(home)
+    env["PATH"] = f"{Path(sys.executable).parent}:{env['PATH']}"
+    proc = subprocess.run(
+        ["bash", str(SETUP_LOCAL), "--non-interactive"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    cfg = home / ".genesis" / "config" / "genesis.yaml"
+    return proc, cfg
+
+
+def test_s1_preserves_private_repo_and_unknown_keys(tmp_path):
+    """A re-run must preserve github.private_repo (never prompted) and any key a
+    user/other tool added — the old code wiped both."""
+    import yaml
+
+    proc0, cfg = _run_setup_local(tmp_path)
+    assert proc0.returncode == 0, f"{proc0.stdout}\n{proc0.stderr}"
+    # Seed values the managed write must not clobber.
+    data = yaml.safe_load(cfg.read_text())
+    data["github"]["private_repo"] = "my-private-backups"
+    data["custom_user_key"] = {"nested": "keepme"}
+    cfg.write_text(yaml.safe_dump(data))
+    # Re-run (non-interactive → managed leaves get defaults, others untouched).
+    proc1, _ = _run_setup_local(tmp_path)
+    assert proc1.returncode == 0, f"{proc1.stdout}\n{proc1.stderr}"
+    after = yaml.safe_load(cfg.read_text())
+    assert after["github"]["private_repo"] == "my-private-backups", after
+    assert after["custom_user_key"] == {"nested": "keepme"}, after
+    assert "github" in after and "network" in after and "timezone" in after
+
+
+def test_s1_atomic_write_in_text():
+    """Extraction: the config write is atomic (temp + os.replace) and load-merges
+    (not a fresh literal dict)."""
+    text = SETUP_LOCAL.read_text()
+    assert "os.replace(" in text and "mkstemp(" in text
+    assert 'gh.setdefault("private_repo"' in text  # preserve, not overwrite
+    assert (
+        "yaml.safe_load(f) or {}" in text.split("# ── Write config", 1)[1]
+    )  # load in the WRITE heredoc
+
+
+def test_s2_yaml_preflight_and_guarded_read():
+    """Extraction: the write path preflights PyYAML with an actionable message,
+    and the read path's `import yaml` is inside the try (degrades to empty)."""
+    text = SETUP_LOCAL.read_text()
+    assert "python3 -c 'import yaml'" in text
+    assert "python3-yaml" in text  # actionable install hint
+    # The read heredoc guards its import inside the try (degrade to empty); the
+    # write heredoc imports yaml at top-level (needs it — preflighted above).
+    # This exact pattern is unique to the guarded read path.
+    assert "try:\n    import yaml" in text
+
+
+# ── B10: restore_cc_memory.sh ────────────────────────────────────────
+
+
+def test_b10_never_clobbers_newer_local(tmp_path):
+    """A newer local memory file must survive the restore — the backup's older
+    copy must NOT overwrite it (the old `|| cp -a` clobbered)."""
+    genesis_root = tmp_path / "genesis"
+    backup = genesis_root / "data" / "cc-memory-backup"
+    backup.mkdir(parents=True)
+    (backup / "note.md").write_text("OLD backup content\n")
+    (backup / "only-in-backup.md").write_text("fresh from backup\n")
+
+    home = tmp_path / "home"
+    cc_id = str(genesis_root).replace("/", "-")
+    mem = home / ".claude" / "projects" / cc_id / "memory"
+    mem.mkdir(parents=True)
+    (mem / "note.md").write_text("NEW local content — keep me\n")  # newer, must survive
+
+    proc = subprocess.run(
+        ["bash", str(RESTORE_CC), str(genesis_root)],
+        env={**os.environ, "HOME": str(home)},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert (mem / "note.md").read_text() == "NEW local content — keep me\n", (
+        "local file was clobbered"
+    )
+    assert (mem / "only-in-backup.md").read_text() == "fresh from backup\n", (
+        "missing file not restored"
+    )
+
+
+def test_b10_no_clobber_fallback_in_text():
+    """Extraction: the clobbering bare `cp -a` fallback is gone from the CODE
+    (comments may still describe it)."""
+    code = "\n".join(
+        ln for ln in RESTORE_CC.read_text().splitlines() if not ln.lstrip().startswith("#")
+    )
+    assert "cp -a " not in code, code  # bare clobbering cp -a (cp -an is fine — trailing 'n')
+    assert "--ignore-existing" in code

--- a/tests/test_scripts/test_install_dataloss.py
+++ b/tests/test_scripts/test_install_dataloss.py
@@ -42,7 +42,7 @@ def _extract_bashrc_heredoc() -> str:
     """Pull the exact python heredoc that rewrites ~/.bashrc out of bootstrap.sh
     so the test runs the SHIPPED code, not a copy."""
     text = BOOTSTRAP.read_text()
-    m = re.search(r'python3 - "\$BASHRC" <<\'PYEOF\'\n(.*?)\nPYEOF', text, re.DOTALL)
+    m = re.search(r"python3 - \"\$BASHRC\" <<'PYEOF'.*?\n(.*?)\nPYEOF", text, re.DOTALL)
     assert m, "could not find the bashrc-rewriter heredoc in bootstrap.sh"
     return m.group(1)
 
@@ -71,11 +71,23 @@ def test_b4_atomic_and_endmarker_in_text():
     assert "os.replace(" in heredoc and "mkstemp(" in heredoc
     assert "unterminated genesis tmux-wrap block" in heredoc
     assert 'open(path, "w").write' not in heredoc  # the old non-atomic write is gone
+    assert "sys.exit(2)" in heredoc  # bail signals a distinct rc to the caller
+
+
+def test_b4_bash_reports_bail_distinctly():
+    """The outer bash must NOT print 'refreshed' on the missing-END bail: it
+    captures the python rc and branches (0=refreshed, 2=left-untouched,
+    other=warning)."""
+    text = BOOTSTRAP.read_text()
+    assert "<<'PYEOF' || _tw_rc=$?" in text  # captures rc without set -e aborting
+    assert '[ "$_tw_rc" -eq 2 ]' in text and "left untouched" in text  # distinct bail message
+    assert "(rc=$_tw_rc)" in text  # a genuine write error surfaces too
 
 
 def test_b4_missing_end_preserves_user_content(tmp_path):
     """A damaged block (BEGIN, no END) with user content BELOW it must NOT be
-    swallowed to EOF — the file is left untouched and warned about."""
+    swallowed to EOF — the file is left untouched, warned about, and the
+    rewriter exits with the distinct bail code (2), not 0."""
     bashrc = (
         "export USER_VAR=1\n"
         "# >>> genesis tmux-wrap >>>\n"
@@ -83,8 +95,9 @@ def test_b4_missing_end_preserves_user_content(tmp_path):
         "export IMPORTANT_USER_LINE=keep-me\n"
     )
     proc, out = _run_bashrc_rewriter(tmp_path, bashrc)
-    assert proc.returncode == 0, proc.stderr
+    assert proc.returncode == 2, proc.stderr
     assert "IMPORTANT_USER_LINE=keep-me" in out.read_text(), "user content was destroyed"
+    assert out.read_text() == bashrc, "file must be byte-identical (untouched) on bail"
     assert "unterminated" in proc.stderr
 
 

--- a/tests/test_scripts/test_install_dataloss.py
+++ b/tests/test_scripts/test_install_dataloss.py
@@ -219,10 +219,14 @@ def test_b10_never_clobbers_newer_local(tmp_path):
 
 
 def test_b10_no_clobber_fallback_in_text():
-    """Extraction: the clobbering bare `cp -a` fallback is gone from the CODE
-    (comments may still describe it)."""
+    """Extraction: the clobbering `cp -an … || cp -a …` fallback is gone, and the
+    two modern paths (rsync, cp --update=none) propagate real errors via exit
+    code (no `|| true` masking) — the caller keys _CCMEM_RESTORED on our status."""
     code = "\n".join(
         ln for ln in RESTORE_CC.read_text().splitlines() if not ln.lstrip().startswith("#")
     )
-    assert "cp -a " not in code, code  # bare clobbering cp -a (cp -an is fine — trailing 'n')
-    assert "--ignore-existing" in code
+    assert "|| cp -a" not in code and "|| \\" not in code  # the old clobber fallback is gone
+    assert "--ignore-existing" in code  # rsync no-clobber
+    assert "--update=none" in code  # coreutils 9.3+ stable no-clobber (proper exit codes)
+    # The only best-effort `|| true` is the pre-9.3 cp -an fallback (last resort).
+    assert code.count("|| true") <= 1


### PR DESCRIPTION
## Summary

P2 of the deploy-script-audit remediation (report 02 `bootstrap/install`). Three setup/restore scripts could destroy user data on a re-run or a crash. Standard review (one-liners + local heredoc rewrites).

| Finding | Fix |
|---|---|
| **B4** `bootstrap.sh` | the `~/.bashrc` genesis tmux-wrap rewriter deleted everything from BEGIN to EOF when the END sentinel was missing (a half-written block), taking user content below it, and wrote non-atomically. Now: replace only a well-formed begin..end pair; a missing END leaves the file **untouched** + warns; write is temp + `os.replace` (atomic). |
| **S1** `setup-local-config.sh` | a re-run rebuilt `genesis.yaml` from a fresh literal dict, wiping `github.private_repo` + any unmanaged key, non-atomically. Now: `yaml.safe_load` existing first, update only managed leaves (private_repo preserved, unknown keys kept), temp + `os.replace`. |
| **S2** `setup-local-config.sh` | `import yaml` aborted with a raw traceback on a minimal image lacking PyYAML, before the first prompt. Now: read path guards the import (degrades to empty defaults); a preflight fails fast with an actionable `install python3-yaml` message before the write. |
| **B10** `restore_cc_memory.sh` | `cp -an … \|\| cp -a …` — coreutils 9.1+ returns non-zero when `cp -an` **skips** an existing file, so the clobbering `cp -a` fallback fired on a normal run and overwrote the newer local files `-n` protects. Now: `rsync --ignore-existing` (stable skip semantics) or `cp -an` best-effort, never a clobber. |

## Verification

`tests/test_scripts/test_install_dataloss.py` (8) — extraction anchors + **live data-loss checks**:
- **B4** extracts the shipped rewriter heredoc and runs it: a damaged block (BEGIN, no END) with user content below it is **preserved** (file untouched + warned); a well-formed block is replaced in place with surrounding content intact.
- **S1** runs the real script **twice** in a sandbox: a seeded `private_repo` + a custom key both **survive** the re-run.
- **B10** runs the real restore: a **newer local file is not clobbered** by the older backup copy; a backup-only file is still restored.

No existing tests covered these 3 scripts; the new file mirrors the `test_network_resilience.py` extraction idiom. Adjacent tests that read `bootstrap.sh` (`test_live_system_guard`, `test_session_doors`) stay green. shellcheck + ruff clean; private-data sweep clean.

## Deploy path

Existing installs: next `update.sh` pull re-renders the bashrc block via bootstrap (the new atomic rewriter). Fresh clones: nothing extra. No Host-Deploy Gate.

Audit source: `deploy-audit-2026-07-13/02-bootstrap-install.md` · Plan: calm-honking-meadow §P2

🤖 Generated with [Claude Code](https://claude.com/claude-code)