### PR TITLE
fix(surplus): stop knowledge-base pollution by operational telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   overwrites a newer local file with an older backup copy (a `cp` quirk on newer
   systems used to); and local-config setup fails with a clear "install PyYAML"
   message up front instead of a raw traceback after you've answered every prompt.
+- **The knowledge base no longer fills with Genesis's own operational
+  telemetry.** Background maintenance and eval tasks (DB maintenance, disk
+  cleanup, model/J9 evals, backup verification, research/prompt-review
+  intermediates) were routing their point-in-time status reports into the
+  knowledge base as if they were durable, recallable knowledge — growing it to
+  ~71% operational noise and crowding out real ingested content. Those tasks no
+  longer write to the knowledge base, a one-time cleanup removes the historical
+  telemetry rows on the next restart, and crawled external intelligence
+  (model/GitHub/web scans) is now correctly labelled as external-world content
+  rather than Genesis's own memory.
 
 - **Per-prompt memory recall no longer silently degrades on busy installs.**
   The server-side recall budget behind the proactive memory hook was sized

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -215,7 +215,7 @@ Note: the *learning* package hosts the other big scheduler (see entry 10).
 ```yaml subsystem-map
 entry: scheduling-background
 modules: [surplus, scheduler, follow_ups]
-verified: 3403599d 2026-07-16
+verified: 0e65071c 2026-07-21
 ```
 
 - **Surplus generators are deliberately BLIND to `infrastructure_alert`
@@ -246,7 +246,14 @@ verified: 3403599d 2026-07-16
 - **`surplus/intake.py`** (intelligence intake: atomize → score → route)
   auto-ingests curated sources into the knowledge base with NO manifest gate —
   an INTENTIONAL bypass of the conversational confirm-first path; don't "fix"
-  it.
+  it. BUT only tasks in `types.KB_ROUTING_TASK_TYPES` (insight-producing +
+  bookmark-enrichment) route to the KB; action/maintenance/monitor/pipeline-
+  intermediate output is point-in-time OPERATIONAL TELEMETRY, gated OUT at
+  `dispatch._route_insights` (before the gate it filled the KB with db-
+  maintenance/eval reports — 71% surplus; d0005 purged the historical rows).
+  `source_pipeline` is per-source (`intake._pipeline_for_source`): Genesis-
+  authored → `surplus`/first-party; crawled recon/model/github/web →
+  distinct labels classified `external_untrusted` (wrapped on recall).
 - **`scheduler/` (top-level package) is the UserJobScheduler** — user-authored
   cron jobs (via MCP) that dispatch background DirectSessions. Distinct from
   `surplus/scheduler.py`.

--- a/src/genesis/db/data_migrations/d0005_purge_surplus_ops_telemetry.py
+++ b/src/genesis/db/data_migrations/d0005_purge_surplus_ops_telemetry.py
@@ -12,12 +12,14 @@ code since 2026-06-10, so peer installs carry it too; no per-install hand-fix.
 
 Match is deterministic + tightly scoped (near-zero false-delete): a
 ``knowledge_unit`` whose ``source_pipeline='surplus'`` AND
-``domain='intelligence.surplus'`` AND whose body's FIRST LINE equals a
-non-KB-routing task's ``single_item`` title (``task_type.replace("_"," ").title()``,
-e.g. "Db Maintenance", "Research Query Gen"). Insight-producing tasks kept in the
-KB (brainstorm/audit/anticipatory/self_unblock/prompt_effectiveness_review) have
-DISTINCT titles or real LLM-authored titles, so they are never matched (the
-title sets are disjoint — asserted by test_d0005_purge_surplus_ops_telemetry).
+``domain='intelligence.surplus'`` AND whose body is ``"<title>\n\n<prefix>…"`` for
+an entry in ``_OPS_SIGNATURES`` — the exact non-KB-routing ``single_item`` title
+AND the deterministic machine-report opener the executor writes (e.g.
+"Db Maintenance" + "Database maintenance report:"). The body-prefix guard is what
+makes it safe against a legitimate insight an LLM happened to title "Model Eval"
+in the same scope (Codex P2, #1179) — an insight's prose body lacks the machine
+prefix. Insight-producing tasks are never matched (their titles are disjoint from
+the signatures — asserted by test_d0005_purge_surplus_ops_telemetry).
 
 Cross-store: a KB unit lives in Qdrant + memory_metadata + memory_fts +
 knowledge_units + knowledge_fts (+ memory_links / pending_embeddings /
@@ -50,38 +52,41 @@ logger = logging.getLogger(__name__)
 
 requires_operator = False
 
-# First-line title signatures of the single_item ops-telemetry rows to purge =
-# ``task_type.replace("_"," ").title()`` for every TaskType NOT in
-# ``surplus.types.KB_ROUTING_TASK_TYPES`` (action/maintenance/monitor/pipeline-
-# intermediate). Snapshotted here as an explicit, auditable list for a DESTRUCTIVE
-# migration; test_d0005_purge_surplus_ops_telemetry asserts this equals the live
-# enum derivation, so it cannot silently drift from the gate.
-_OPS_TELEMETRY_TITLES = frozenset(
-    {
-        "Backup Verification",
-        "Cc Memory Staleness",
-        "Code Index",
-        "Db Maintenance",
-        "Dead Letter Replay",
-        "Disk Cleanup",
-        "Fresh Session Test",
-        "Infrastructure Monitor",
-        "J9 Eval Batch",
-        "Model Eval",
-        "Prompt Review Catalog",
-        "Prompt Review Sample",
-        "Research Query Gen",
-    }
-)
+# Purge signatures: ``{first-line title -> required body prefix}``. A row is
+# telemetry only if its body is ``"<title>\n\n<prefix>…"`` — i.e. the exact
+# single_item title AND the deterministic machine-report opener the executor
+# writes. Every title here is a non-KB-routing task's ``task_type.title()``
+# (asserted by test) so it can never name an insight-producing task.
+#
+# The body-prefix guard exists because title-alone is unsafe for GENERIC
+# operational names: an insight-producing task could produce a finding an LLM
+# titled "Model Eval" or "Db Maintenance" in the same surplus/intelligence.surplus
+# scope, and a title-only match would false-delete it (Codex P2, PR #1179). The
+# machine-report prefix an LLM insight would never reproduce makes the match safe.
+# Pipeline-intermediate titles (RESEARCH_QUERY_GEN / PROMPT_REVIEW_*) are SPECIFIC
+# internal step-names no insight would ever carry, and their bodies are free-form
+# LLM prose with no stable prefix, so they use ``""`` (title-only — still safe).
+_OPS_SIGNATURES: dict[str, str] = {
+    "Backup Verification": "Backup verification:",
+    "Cc Memory Staleness": "CC Memory Staleness Scan:",
+    "Db Maintenance": "Database maintenance report:",
+    "Disk Cleanup": "Disk cleanup scan",
+    "Fresh Session Test": "Fresh Session Test completed",
+    "J9 Eval Batch": "J9 eval batch:",
+    "Model Eval": "Model evaluation:",
+    "Research Query Gen": "",  # specific pipeline-step name — title-only is safe
+    "Prompt Review Sample": "",  # specific pipeline-step name — title-only is safe
+    "Prompt Review Catalog": "",  # specific pipeline-step name — title-only is safe
+}
 
 
 def _candidate_ids(db: sqlite3.Connection) -> list[tuple[str, str]]:
     """Return ``(unit_id, qdrant_id)`` for every surplus ops-telemetry KB unit.
 
     Scoped to ``source_pipeline='surplus' AND domain='intelligence.surplus'``,
-    then filtered in Python to units whose body first line is an exact ops-title
-    match — the deterministic signature that separates telemetry from the
-    real-titled insights sharing the same pipeline/domain.
+    then filtered in Python to units whose body is ``"<title>\\n\\n<prefix>…"`` for
+    an entry in ``_OPS_SIGNATURES`` — the deterministic title+machine-report
+    signature that separates telemetry from real insights in the same scope.
     """
     rows = db.execute(
         "SELECT id, qdrant_id, body FROM knowledge_units "
@@ -89,9 +94,11 @@ def _candidate_ids(db: sqlite3.Connection) -> list[tuple[str, str]]:
     ).fetchall()
     out: list[tuple[str, str]] = []
     for unit_id, qdrant_id, body in rows:
-        first_line = (body or "").split("\n", 1)[0].strip()
-        if first_line in _OPS_TELEMETRY_TITLES:
-            out.append((unit_id, qdrant_id or ""))
+        b = body or ""
+        for title, prefix in _OPS_SIGNATURES.items():
+            if b.startswith(f"{title}\n\n{prefix}"):
+                out.append((unit_id, qdrant_id or ""))
+                break
     return out
 
 

--- a/src/genesis/db/data_migrations/d0005_purge_surplus_ops_telemetry.py
+++ b/src/genesis/db/data_migrations/d0005_purge_surplus_ops_telemetry.py
@@ -1,0 +1,169 @@
+"""d0005 — purge operational-telemetry rows that polluted the knowledge base.
+
+Non-KB-routing surplus tasks (action/maintenance/monitor/pipeline-intermediate:
+db_maintenance, disk_cleanup, model_eval, j9_eval_batch, backup_verification,
+research_query_gen, prompt_review_*, cc_memory_staleness, …) routed their
+point-in-time output through ``run_intake`` as curated knowledge before the
+``KB_ROUTING_TASK_TYPES`` gate landed (fix(surplus): stop operational-telemetry
+pollution). Result: the knowledge_base grew to ~71% ``source_pipeline=surplus``
+ops telemetry. The gate stops NEW writes; this migration removes the historical
+rows on EVERY install (idempotent, post-boot) — the pollution shipped in the
+code since 2026-06-10, so peer installs carry it too; no per-install hand-fix.
+
+Match is deterministic + tightly scoped (near-zero false-delete): a
+``knowledge_unit`` whose ``source_pipeline='surplus'`` AND
+``domain='intelligence.surplus'`` AND whose body's FIRST LINE equals a
+non-KB-routing task's ``single_item`` title (``task_type.replace("_"," ").title()``,
+e.g. "Db Maintenance", "Research Query Gen"). Insight-producing tasks kept in the
+KB (brainstorm/audit/anticipatory/self_unblock/prompt_effectiveness_review) have
+DISTINCT titles or real LLM-authored titles, so they are never matched (the
+title sets are disjoint — asserted by test_d0005_purge_surplus_ops_telemetry).
+
+Cross-store: a KB unit lives in Qdrant + memory_metadata + memory_fts +
+knowledge_units + knowledge_fts (+ memory_links / pending_embeddings /
+entity_mentions cascades) — the same fan-out ``MemoryStore.delete()`` performs.
+Deleting only the Qdrant point + knowledge_units would leave the junk
+RESURFACING via degraded FTS5 recall (``memory_fts`` is cross-collection), so we
+reproduce the full cascade in raw SQL (``migrate()``/``verify()`` are SYNC with
+their own connections — they cannot call the async store).
+
+Ordering: the Qdrant point is deleted BEFORE the SQLite rows for that unit; if
+the Qdrant delete fails (transient), the unit's SQLite rows are LEFT intact so
+``verify()`` still sees it as a candidate → the migration is marked failed and
+retries next boot (no half-deleted orphan vector). ``get_client()`` failing
+entirely raises → same retry. Idempotent: a missing point deletes as a no-op,
+and the DELETEs are no-ops once purged / on a fresh install (no such rows).
+
+migrate()/verify() are SYNC (framework contract, cf. d0003/d0004). Own
+connections only — never the runtime's async ``rt._db``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from genesis.env import genesis_db_path
+from genesis.qdrant.collections import delete_point, get_client
+
+logger = logging.getLogger(__name__)
+
+requires_operator = False
+
+# First-line title signatures of the single_item ops-telemetry rows to purge =
+# ``task_type.replace("_"," ").title()`` for every TaskType NOT in
+# ``surplus.types.KB_ROUTING_TASK_TYPES`` (action/maintenance/monitor/pipeline-
+# intermediate). Snapshotted here as an explicit, auditable list for a DESTRUCTIVE
+# migration; test_d0005_purge_surplus_ops_telemetry asserts this equals the live
+# enum derivation, so it cannot silently drift from the gate.
+_OPS_TELEMETRY_TITLES = frozenset(
+    {
+        "Backup Verification",
+        "Cc Memory Staleness",
+        "Code Index",
+        "Db Maintenance",
+        "Dead Letter Replay",
+        "Disk Cleanup",
+        "Fresh Session Test",
+        "Infrastructure Monitor",
+        "J9 Eval Batch",
+        "Model Eval",
+        "Prompt Review Catalog",
+        "Prompt Review Sample",
+        "Research Query Gen",
+    }
+)
+
+
+def _candidate_ids(db: sqlite3.Connection) -> list[tuple[str, str]]:
+    """Return ``(unit_id, qdrant_id)`` for every surplus ops-telemetry KB unit.
+
+    Scoped to ``source_pipeline='surplus' AND domain='intelligence.surplus'``,
+    then filtered in Python to units whose body first line is an exact ops-title
+    match — the deterministic signature that separates telemetry from the
+    real-titled insights sharing the same pipeline/domain.
+    """
+    rows = db.execute(
+        "SELECT id, qdrant_id, body FROM knowledge_units "
+        "WHERE source_pipeline = 'surplus' AND domain = 'intelligence.surplus'"
+    ).fetchall()
+    out: list[tuple[str, str]] = []
+    for unit_id, qdrant_id, body in rows:
+        first_line = (body or "").split("\n", 1)[0].strip()
+        if first_line in _OPS_TELEMETRY_TITLES:
+            out.append((unit_id, qdrant_id or ""))
+    return out
+
+
+def migrate() -> dict:
+    """Purge surplus ops-telemetry KB units across all stores. Return counts."""
+    # Read candidates first (read-only conn) so a no-op run never touches Qdrant.
+    ro = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        targets = _candidate_ids(ro)
+    finally:
+        ro.close()
+    if not targets:
+        return {"purged": 0, "qdrant_deleted": 0}
+
+    # Raises if Qdrant is unreachable → migration stays pending, retries next boot.
+    client = get_client()
+
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    purged = 0
+    qdrant_deleted = 0
+    qdrant_failed = 0
+    try:
+        for unit_id, qdrant_id in targets:
+            if qdrant_id:
+                try:
+                    delete_point(client, collection="knowledge_base", point_id=qdrant_id)
+                    qdrant_deleted += 1
+                except Exception:
+                    # Leave this unit's SQLite rows intact so verify() still sees
+                    # it and the migration retries — never a half-deleted orphan.
+                    logger.warning(
+                        "d0005: Qdrant delete failed for %s — skipping SQLite purge",
+                        qdrant_id,
+                        exc_info=True,
+                    )
+                    qdrant_failed += 1
+                    continue
+            # Full MemoryStore.delete() cascade, in raw SQL.
+            db.execute("DELETE FROM knowledge_fts WHERE unit_id = ?", (unit_id,))
+            db.execute("DELETE FROM knowledge_units WHERE id = ?", (unit_id,))
+            if qdrant_id:
+                db.execute("DELETE FROM memory_fts WHERE memory_id = ?", (qdrant_id,))
+                db.execute("DELETE FROM memory_metadata WHERE memory_id = ?", (qdrant_id,))
+                db.execute(
+                    "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?",
+                    (qdrant_id, qdrant_id),
+                )
+                db.execute("DELETE FROM pending_embeddings WHERE memory_id = ?", (qdrant_id,))
+                db.execute("DELETE FROM entity_mentions WHERE memory_id = ?", (qdrant_id,))
+            purged += 1
+        db.commit()
+    finally:
+        db.close()
+
+    logger.info(
+        "d0005: purged %d surplus ops-telemetry KB units (%d Qdrant points, "
+        "%d Qdrant-delete failures left for retry)",
+        purged,
+        qdrant_deleted,
+        qdrant_failed,
+    )
+    return {"purged": purged, "qdrant_deleted": qdrant_deleted, "qdrant_failed": qdrant_failed}
+
+
+def verify() -> bool:
+    """Complete only when NO surplus ops-telemetry knowledge_unit remains.
+
+    A unit whose Qdrant delete failed keeps its SQLite rows, so it stays a
+    candidate here → verify() returns False → the migration retries next boot.
+    """
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        return not _candidate_ids(db)
+    finally:
+        db.close()

--- a/src/genesis/memory/provenance.py
+++ b/src/genesis/memory/provenance.py
@@ -42,6 +42,11 @@ _PIPELINE_FRIENDLY: dict[str, str] = {
     "extraction_job": "auto-extracted",
     "crag_web": "web",  # CRAG web-fallback augmentation — live internet content
     "recon": "recon/web",
+    "model_intelligence": "model intel",
+    "github_landscape": "github",
+    "web_monitoring": "web monitor",
+    "source_discovery": "source scan",
+    "email_recon": "email recon",
     "surplus": "surplus insight",
 }
 
@@ -54,6 +59,11 @@ _PIPELINE_SHORT: dict[str, str] = {
     "extraction_job": "extracted",
     "crag_web": "web",
     "recon": "recon",
+    "model_intelligence": "modelint",
+    "github_landscape": "github",
+    "web_monitoring": "webmon",
+    "source_discovery": "srcscan",
+    "email_recon": "emailrecon",
     "surplus": "surplus",
 }
 
@@ -105,10 +115,19 @@ def is_garbage(content: str | None) -> bool:
 # knowledge_base rows representing INTENTIONAL ingestions (user-requested docs,
 # references, structured extractions, dashboard file/URL uploads). Everything else
 # in knowledge_base is noisy pipeline output (surplus insights, recon/web crawl)
-# that must not surface into a proactive prompt. (Live: knowledge_base is ~71%
-# surplus.) ``curated`` is the dashboard upload / orchestrator ingestion pipeline
-# (genesis.knowledge.ingest_upload) — intentional user content, so it belongs here
-# even though it is external_untrusted (it still surfaces, labelled external).
+# that must not surface into a proactive prompt. ``curated`` is the dashboard
+# upload / orchestrator ingestion pipeline (genesis.knowledge.ingest_upload) —
+# intentional user content, so it belongs here even though it is
+# external_untrusted (it still surfaces, labelled external).
+#
+# TWO AXES — do NOT "reconcile" this set with _FIRST_PARTY_PIPELINES /
+# _EXTERNAL_PIPELINES above. This set = "proactive-WORTHY" (surface it unprompted).
+# Those sets = "provenance" (first-party vs external-world, for injection defense).
+# They are orthogonal: ``surplus`` is deliberately FIRST-PARTY (Genesis authored
+# it) yet NOT proactive-worthy (auto-generated insight, lower-trust than a
+# user-ingested doc), so it is absent HERE but present in _FIRST_PARTY_PIPELINES.
+# The crawled labels (model_intelligence/github_landscape/…) are external AND not
+# proactive-worthy → absent from both this set and _FIRST_PARTY_PIPELINES.
 _KB_INTENTIONAL_PIPELINES = frozenset(
     {
         "extraction_job",
@@ -190,6 +209,16 @@ _EXTERNAL_PIPELINES = frozenset(
         "inbox",
         "web_search",
         "web_fetch",
+        # Surplus/recon intake crawlers — external-world intelligence pulled off
+        # model registries, GitHub, the web, and email. Labelled by
+        # surplus/intake.py::_PIPELINE_FOR_SOURCE (keep the two in lockstep).
+        # Genesis-AUTHORED surplus insight tasks keep the "surplus" label and
+        # stay first-party below — only the crawled sources are external.
+        "model_intelligence",
+        "github_landscape",
+        "web_monitoring",
+        "source_discovery",
+        "email_recon",
     }
 )
 

--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -26,7 +26,11 @@ from typing import TYPE_CHECKING, Protocol
 
 from genesis.db.crud import surplus as surplus_crud
 from genesis.observability.types import Severity, Subsystem
-from genesis.surplus.types import INSIGHT_PRODUCING_TASK_TYPES, TaskType
+from genesis.surplus.types import (
+    INSIGHT_PRODUCING_TASK_TYPES,
+    KB_ROUTING_TASK_TYPES,
+    TaskType,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -77,7 +81,11 @@ def _select_executor(sched: DispatchContext, task) -> SurplusExecutor:
 
 
 async def _handle_failure(
-    sched: DispatchContext, task, reason: str, *, emit_event: bool,
+    sched: DispatchContext,
+    task,
+    reason: str,
+    *,
+    emit_event: bool,
 ) -> None:
     """Shared failure path: mark failed, optionally emit, signal autonomy,
     maybe observe.
@@ -89,18 +97,22 @@ async def _handle_failure(
     await sched._queue.mark_failed(task.id, reason=reason)
     if emit_event and sched._event_bus:
         await sched._event_bus.emit(
-            Subsystem.SURPLUS, Severity.WARNING,
+            Subsystem.SURPLUS,
+            Severity.WARNING,
             "task.failed",
             f"Surplus task {task.id} failed with exception",
-            task_id=task.id, task_type=str(task.task_type),
+            task_id=task.id,
+            task_type=str(task.task_type),
         )
     # Signal autonomy correction for background cognitive failure
     try:
         from genesis.runtime import GenesisRuntime
+
         rt = GenesisRuntime.instance()
         mgr = getattr(rt, "_autonomy_manager", None)
         if mgr is not None:
             from datetime import UTC, datetime
+
             await mgr.record_correction(
                 "background_cognitive",
                 corrected_at=datetime.now(UTC).isoformat(),
@@ -111,7 +123,9 @@ async def _handle_failure(
 
 
 async def _route_insights(
-    sched: DispatchContext, task, result,
+    sched: DispatchContext,
+    task,
+    result,
 ) -> tuple[str | None, str | None, float | None, str | None]:
     """Step 6 — route through intake pipeline (atomize → score → route to
     knowledge) and run the measurement-only quality judge.
@@ -136,7 +150,8 @@ async def _route_insights(
         if len(content.strip()) < 50:
             logger.warning(
                 "Surplus insight too short, skipping (%d chars, task=%s)",
-                len(content.strip()), task.id[:8],
+                len(content.strip()),
+                task.id[:8],
             )
         else:
             if task.task_type == TaskType.CODE_AUDIT:
@@ -148,12 +163,30 @@ async def _route_insights(
                 # for tracking; the quality judge below still runs.
                 content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
                 staging_id = f"{task.task_type.value}-{content_hash}"
+            elif task.task_type not in KB_ROUTING_TASK_TYPES:
+                # Non-KB-routing task (action/maintenance/monitor/pipeline-
+                # intermediate — e.g. DB_MAINTENANCE, DISK_CLEANUP, MODEL_EVAL,
+                # J9_EVAL_BATCH): its output is point-in-time OPERATIONAL
+                # TELEMETRY (a maintenance report, an eval-batch summary), NOT
+                # durable knowledge. Never ingest it into the knowledge base —
+                # doing so is what polluted the KB to 71% surplus. The task's
+                # outcome is still recorded via the normal outcome-bus path; we
+                # keep a synthetic staging_id for tracking only. The quality
+                # judge below stays gated on INSIGHT_PRODUCING and no-ops here.
+                content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+                staging_id = f"{task.task_type.value}-{content_hash}"
+                logger.debug(
+                    "Skipping KB intake for non-KB-routing task %s (%s)",
+                    task.task_type.value,
+                    task.id[:8],
+                )
             else:
                 try:
                     from genesis.surplus.intake import (
                         run_intake,
                         source_for_task_type,
                     )
+
                     source = source_for_task_type(str(task.task_type))
                     intake_stats = await run_intake(
                         content=content,
@@ -205,10 +238,11 @@ async def _route_insights(
             # a judge outage yields a NULL verdict, never a false 'hollow'.
             if task.task_type in INSIGHT_PRODUCING_TASK_TYPES:
                 from genesis.surplus.quality_judge import run_quality_judge
-                outcome_quality, judge_score, judge_detail = (
-                    await run_quality_judge(
-                        content, task.task_type, sched._judge_router,
-                    )
+
+                outcome_quality, judge_score, judge_detail = await run_quality_judge(
+                    content,
+                    task.task_type,
+                    sched._judge_router,
                 )
     return staging_id, outcome_quality, judge_score, judge_detail
 
@@ -229,6 +263,7 @@ async def _chain_pipeline(sched: DispatchContext, task, result) -> None:
             is_pipeline_task,
             parse_pipeline_payload,
         )
+
         if is_pipeline_task(task.payload):
             try:
                 meta = parse_pipeline_payload(task.payload)
@@ -240,7 +275,8 @@ async def _chain_pipeline(sched: DispatchContext, task, result) -> None:
                     if defn and step < len(defn.steps):
                         next_step = defn.steps[step]  # 0-indexed, step is 1-based
                         next_payload = build_next_step_payload(
-                            meta, result.content or "",
+                            meta,
+                            result.content or "",
                         )
                         await sched._queue.enqueue(
                             next_step.task_type,
@@ -251,17 +287,23 @@ async def _chain_pipeline(sched: DispatchContext, task, result) -> None:
                         )
                         logger.info(
                             "Pipeline %s: step %d/%d complete, enqueued step %d",
-                            pipeline_name, step, total, step + 1,
+                            pipeline_name,
+                            step,
+                            total,
+                            step + 1,
                         )
                     else:
                         logger.warning(
                             "Pipeline %s: step %d references missing definition",
-                            pipeline_name, step + 1,
+                            pipeline_name,
+                            step + 1,
                         )
                 else:
                     logger.info(
                         "Pipeline %s: final step %d/%d complete",
-                        pipeline_name, step, total,
+                        pipeline_name,
+                        step,
+                        total,
                     )
             except Exception:
                 logger.error("Pipeline chaining failed", exc_info=True)
@@ -272,8 +314,9 @@ async def _bridge_code_audit_findings(task, result) -> None:
     if task.task_type == TaskType.CODE_AUDIT and result.insights:
         try:
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
-            if hasattr(rt, '_findings_bridge') and rt._findings_bridge is not None:
+            if hasattr(rt, "_findings_bridge") and rt._findings_bridge is not None:
                 bridged = await rt._findings_bridge.bridge_findings(result.insights)
                 logger.info("Bridged %d code audit findings to observations", bridged)
         except Exception:
@@ -281,7 +324,10 @@ async def _bridge_code_audit_findings(task, result) -> None:
 
 
 async def _log_brainstorm(
-    sched: DispatchContext, task, result, staging_id: str | None,
+    sched: DispatchContext,
+    task,
+    result,
+    staging_id: str | None,
 ) -> None:
     """Write to brainstorm_log for brainstorm-type tasks."""
     if task.task_type in (TaskType.BRAINSTORM_USER, TaskType.BRAINSTORM_SELF):
@@ -314,6 +360,7 @@ async def _signal_autonomy_success() -> None:
     """Signal autonomy calibration for background cognitive work."""
     try:
         from genesis.runtime import GenesisRuntime
+
         rt = GenesisRuntime.instance()
         mgr = getattr(rt, "_autonomy_manager", None)
         if mgr is not None:
@@ -365,12 +412,17 @@ async def dispatch_once(sched: DispatchContext) -> bool:
 
     # 6. Route through intake pipeline (atomize → score → route to knowledge)
     staging_id, outcome_quality, judge_score, judge_detail = await _route_insights(
-        sched, task, result,
+        sched,
+        task,
+        result,
     )
 
     await sched._queue.mark_completed(
-        task.id, staging_id=staging_id, outcome_quality=outcome_quality,
-        judge_score=judge_score, judge_detail=judge_detail,
+        task.id,
+        staging_id=staging_id,
+        outcome_quality=outcome_quality,
+        judge_score=judge_score,
+        judge_detail=judge_detail,
     )
 
     await _chain_pipeline(sched, task, result)
@@ -388,7 +440,8 @@ async def maybe_observe_failure(sched: DispatchContext, task, reason: str) -> No
         from genesis.db.crud import observations, surplus_tasks
 
         count = await surplus_tasks.consecutive_failures(
-            sched._db, str(task.task_type),
+            sched._db,
+            str(task.task_type),
         )
         if count >= 3:
             obs_id = f"surplus_failing_{task.task_type}"
@@ -407,7 +460,8 @@ async def maybe_observe_failure(sched: DispatchContext, task, reason: str) -> No
             )
             logger.warning(
                 "Surplus task %s: %d consecutive failures, observation created",
-                task.task_type, count,
+                task.task_type,
+                count,
             )
     except Exception:
         logger.debug("Failed to create failure observation", exc_info=True)

--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -81,11 +81,7 @@ def _select_executor(sched: DispatchContext, task) -> SurplusExecutor:
 
 
 async def _handle_failure(
-    sched: DispatchContext,
-    task,
-    reason: str,
-    *,
-    emit_event: bool,
+    sched: DispatchContext, task, reason: str, *, emit_event: bool,
 ) -> None:
     """Shared failure path: mark failed, optionally emit, signal autonomy,
     maybe observe.
@@ -97,22 +93,18 @@ async def _handle_failure(
     await sched._queue.mark_failed(task.id, reason=reason)
     if emit_event and sched._event_bus:
         await sched._event_bus.emit(
-            Subsystem.SURPLUS,
-            Severity.WARNING,
+            Subsystem.SURPLUS, Severity.WARNING,
             "task.failed",
             f"Surplus task {task.id} failed with exception",
-            task_id=task.id,
-            task_type=str(task.task_type),
+            task_id=task.id, task_type=str(task.task_type),
         )
     # Signal autonomy correction for background cognitive failure
     try:
         from genesis.runtime import GenesisRuntime
-
         rt = GenesisRuntime.instance()
         mgr = getattr(rt, "_autonomy_manager", None)
         if mgr is not None:
             from datetime import UTC, datetime
-
             await mgr.record_correction(
                 "background_cognitive",
                 corrected_at=datetime.now(UTC).isoformat(),
@@ -123,9 +115,7 @@ async def _handle_failure(
 
 
 async def _route_insights(
-    sched: DispatchContext,
-    task,
-    result,
+    sched: DispatchContext, task, result,
 ) -> tuple[str | None, str | None, float | None, str | None]:
     """Step 6 — route through intake pipeline (atomize → score → route to
     knowledge) and run the measurement-only quality judge.
@@ -150,8 +140,7 @@ async def _route_insights(
         if len(content.strip()) < 50:
             logger.warning(
                 "Surplus insight too short, skipping (%d chars, task=%s)",
-                len(content.strip()),
-                task.id[:8],
+                len(content.strip()), task.id[:8],
             )
         else:
             if task.task_type == TaskType.CODE_AUDIT:
@@ -177,8 +166,7 @@ async def _route_insights(
                 staging_id = f"{task.task_type.value}-{content_hash}"
                 logger.debug(
                     "Skipping KB intake for non-KB-routing task %s (%s)",
-                    task.task_type.value,
-                    task.id[:8],
+                    task.task_type.value, task.id[:8],
                 )
             else:
                 try:
@@ -186,7 +174,6 @@ async def _route_insights(
                         run_intake,
                         source_for_task_type,
                     )
-
                     source = source_for_task_type(str(task.task_type))
                     intake_stats = await run_intake(
                         content=content,
@@ -238,11 +225,10 @@ async def _route_insights(
             # a judge outage yields a NULL verdict, never a false 'hollow'.
             if task.task_type in INSIGHT_PRODUCING_TASK_TYPES:
                 from genesis.surplus.quality_judge import run_quality_judge
-
-                outcome_quality, judge_score, judge_detail = await run_quality_judge(
-                    content,
-                    task.task_type,
-                    sched._judge_router,
+                outcome_quality, judge_score, judge_detail = (
+                    await run_quality_judge(
+                        content, task.task_type, sched._judge_router,
+                    )
                 )
     return staging_id, outcome_quality, judge_score, judge_detail
 
@@ -263,7 +249,6 @@ async def _chain_pipeline(sched: DispatchContext, task, result) -> None:
             is_pipeline_task,
             parse_pipeline_payload,
         )
-
         if is_pipeline_task(task.payload):
             try:
                 meta = parse_pipeline_payload(task.payload)
@@ -275,8 +260,7 @@ async def _chain_pipeline(sched: DispatchContext, task, result) -> None:
                     if defn and step < len(defn.steps):
                         next_step = defn.steps[step]  # 0-indexed, step is 1-based
                         next_payload = build_next_step_payload(
-                            meta,
-                            result.content or "",
+                            meta, result.content or "",
                         )
                         await sched._queue.enqueue(
                             next_step.task_type,
@@ -287,23 +271,17 @@ async def _chain_pipeline(sched: DispatchContext, task, result) -> None:
                         )
                         logger.info(
                             "Pipeline %s: step %d/%d complete, enqueued step %d",
-                            pipeline_name,
-                            step,
-                            total,
-                            step + 1,
+                            pipeline_name, step, total, step + 1,
                         )
                     else:
                         logger.warning(
                             "Pipeline %s: step %d references missing definition",
-                            pipeline_name,
-                            step + 1,
+                            pipeline_name, step + 1,
                         )
                 else:
                     logger.info(
                         "Pipeline %s: final step %d/%d complete",
-                        pipeline_name,
-                        step,
-                        total,
+                        pipeline_name, step, total,
                     )
             except Exception:
                 logger.error("Pipeline chaining failed", exc_info=True)
@@ -314,9 +292,8 @@ async def _bridge_code_audit_findings(task, result) -> None:
     if task.task_type == TaskType.CODE_AUDIT and result.insights:
         try:
             from genesis.runtime import GenesisRuntime
-
             rt = GenesisRuntime.instance()
-            if hasattr(rt, "_findings_bridge") and rt._findings_bridge is not None:
+            if hasattr(rt, '_findings_bridge') and rt._findings_bridge is not None:
                 bridged = await rt._findings_bridge.bridge_findings(result.insights)
                 logger.info("Bridged %d code audit findings to observations", bridged)
         except Exception:
@@ -324,10 +301,7 @@ async def _bridge_code_audit_findings(task, result) -> None:
 
 
 async def _log_brainstorm(
-    sched: DispatchContext,
-    task,
-    result,
-    staging_id: str | None,
+    sched: DispatchContext, task, result, staging_id: str | None,
 ) -> None:
     """Write to brainstorm_log for brainstorm-type tasks."""
     if task.task_type in (TaskType.BRAINSTORM_USER, TaskType.BRAINSTORM_SELF):
@@ -360,7 +334,6 @@ async def _signal_autonomy_success() -> None:
     """Signal autonomy calibration for background cognitive work."""
     try:
         from genesis.runtime import GenesisRuntime
-
         rt = GenesisRuntime.instance()
         mgr = getattr(rt, "_autonomy_manager", None)
         if mgr is not None:
@@ -412,17 +385,12 @@ async def dispatch_once(sched: DispatchContext) -> bool:
 
     # 6. Route through intake pipeline (atomize → score → route to knowledge)
     staging_id, outcome_quality, judge_score, judge_detail = await _route_insights(
-        sched,
-        task,
-        result,
+        sched, task, result,
     )
 
     await sched._queue.mark_completed(
-        task.id,
-        staging_id=staging_id,
-        outcome_quality=outcome_quality,
-        judge_score=judge_score,
-        judge_detail=judge_detail,
+        task.id, staging_id=staging_id, outcome_quality=outcome_quality,
+        judge_score=judge_score, judge_detail=judge_detail,
     )
 
     await _chain_pipeline(sched, task, result)
@@ -440,8 +408,7 @@ async def maybe_observe_failure(sched: DispatchContext, task, reason: str) -> No
         from genesis.db.crud import observations, surplus_tasks
 
         count = await surplus_tasks.consecutive_failures(
-            sched._db,
-            str(task.task_type),
+            sched._db, str(task.task_type),
         )
         if count >= 3:
             obs_id = f"surplus_failing_{task.task_type}"
@@ -460,8 +427,7 @@ async def maybe_observe_failure(sched: DispatchContext, task, reason: str) -> No
             )
             logger.warning(
                 "Surplus task %s: %d consecutive failures, observation created",
-                task.task_type,
-                count,
+                task.task_type, count,
             )
     except Exception:
         logger.debug("Failed to create failure observation", exc_info=True)

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -36,16 +36,16 @@ logger = logging.getLogger(__name__)
 class IntakeSource(StrEnum):
     """Source categories with pre-assigned confidence tiers."""
 
-    USER_DIRECTED = "user_directed"  # 0.9
-    FOREGROUND_WEB = "foreground_web"  # 0.75
-    BACKGROUND_TASK = "background_task"  # 0.7
-    EMAIL_RECON = "email_recon"  # 0.65
+    USER_DIRECTED = "user_directed"              # 0.9
+    FOREGROUND_WEB = "foreground_web"            # 0.75
+    BACKGROUND_TASK = "background_task"          # 0.7
+    EMAIL_RECON = "email_recon"                  # 0.65
     ANTICIPATORY_RESEARCH = "anticipatory_research"  # 0.6
-    MODEL_INTELLIGENCE = "model_intelligence"  # 0.6
-    GITHUB_LANDSCAPE = "github_landscape"  # 0.5 — needs LLM scoring
-    WEB_MONITORING = "web_monitoring"  # 0.5 — needs LLM scoring
+    MODEL_INTELLIGENCE = "model_intelligence"    # 0.6
+    GITHUB_LANDSCAPE = "github_landscape"        # 0.5 — needs LLM scoring
+    WEB_MONITORING = "web_monitoring"            # 0.5 — needs LLM scoring
     FREE_MODEL_INVENTORY = "free_model_inventory"  # 0.5 — needs LLM scoring
-    SOURCE_DISCOVERY = "source_discovery"  # 0.4 — needs LLM scoring
+    SOURCE_DISCOVERY = "source_discovery"        # 0.4 — needs LLM scoring
 
 
 # Sources that skip LLM scoring — already curated by an LLM upstream.
@@ -81,16 +81,14 @@ _TASK_TYPE_TO_SOURCE: dict[str, IntakeSource] = {
 }
 
 # Task types that typically produce multiple findings and should be atomized.
-MULTI_FINDING_TASK_TYPES = frozenset(
-    {
-        "anticipatory_research",
-        "code_audit",
-        "gap_clustering",
-        "brainstorm_user",
-        "brainstorm_self",
-        "wing_audit",
-    }
-)
+MULTI_FINDING_TASK_TYPES = frozenset({
+    "anticipatory_research",
+    "code_audit",
+    "gap_clustering",
+    "brainstorm_user",
+    "brainstorm_self",
+    "wing_audit",
+})
 
 
 @dataclass(frozen=True)
@@ -149,8 +147,8 @@ class IntakeStats:
 FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
 
 
-# Dict fields to pull, in priority order, when a findings item / bare JSON object
-# has no plain ``content`` field. Human-meaningful prose beats a raw JSON dump.
+# Dict fields to pull, in priority order, when a bare JSON object has no plain
+# ``content`` field. Human-meaningful prose beats a raw JSON dump.
 _FINDING_BODY_FIELDS = ("content", "summary", "description", "body", "text", "detail")
 # Keys that are structural metadata, not part of the readable body.
 _FINDING_META_KEYS = frozenset({"title", "file", "name", "sources", "relevance"})
@@ -161,10 +159,10 @@ def _render_finding_body(data: dict) -> str:
 
     Used by the ``atomize`` ``json_single`` path — a MULTI_FINDING task that
     returned a bare JSON OBJECT (no ``findings`` key). Instead of storing a raw
-    ``json.dumps`` blob (unreadable in the KB and a proactive-recall noise
-    source — the ``{...}`` bodies that motivated this fix), pull the
-    human-meaningful field in priority order, else fall back to a compact
-    ``key: value`` render of the remaining fields. Never returns a raw JSON dump.
+    ``json.dumps`` blob (unreadable in the KB and a proactive-recall noise source
+    — the ``{...}`` bodies that motivated this fix), pull the human-meaningful
+    field in priority order, else fall back to a compact ``key: value`` render of
+    the remaining fields. Never returns a raw JSON dump.
 
     Deliberately NOT used for structured findings-array items (``_finding_from_item``
     keeps every field via json.dumps — code_audit's severity must survive) nor for
@@ -193,10 +191,8 @@ def _finding_from_item(item: object, index: int, default_title: str) -> AtomicFi
     Handles both the ``{"findings": [...]}`` envelope item shape
     (title/content/sources/relevance) and bare-array shapes from task-specific
     prompts (e.g. code_audit's ``{"file", "severity", "description", ...}``) —
-    unknown dict shapes keep a title from their identity keys and the full item
-    as pretty-printed JSON content (STRUCTURED findings preserve every field —
-    e.g. code_audit's severity; do NOT prose-render here). Non-str scalars are
-    unusable.
+    unknown dict shapes keep a title from their identity keys and the full
+    item as pretty-printed JSON content. Scalars other than str are unusable.
     """
     if isinstance(item, dict):
         title = str(item.get("title") or item.get("file") or item.get("name") or "").strip()
@@ -240,12 +236,10 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
 
     # Single-output task types skip atomization entirely.
     if source_task_type not in MULTI_FINDING_TASK_TYPES:
-        return [
-            AtomicFinding(
-                title=source_task_type.replace("_", " ").title(),
-                content=content.strip(),
-            )
-        ], "single_item"
+        return [AtomicFinding(
+            title=source_task_type.replace("_", " ").title(),
+            content=content.strip(),
+        )], "single_item"
 
     # Attempt 1: Parse as JSON with findings array. Models routinely wrap the
     # payload in a ```json fence despite instructions — unwrap a whole-message
@@ -287,12 +281,10 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
         # Valid JSON but no findings key — treat as single item, rendering the
         # dict as readable prose rather than a raw json.dumps blob.
         if isinstance(data, dict):
-            return [
-                AtomicFinding(
-                    title=str(data.get("title", source_task_type.replace("_", " ").title()))[:200],
-                    content=_render_finding_body(data),
-                )
-            ], "json_single"
+            return [AtomicFinding(
+                title=str(data.get("title", source_task_type.replace("_", " ").title()))[:200],
+                content=_render_finding_body(data),
+            )], "json_single"
     except (json.JSONDecodeError, ValueError, TypeError):
         pass
 
@@ -302,12 +294,10 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
         return findings, "markdown_split"
 
     # Attempt 3: Fall back to single item.
-    return [
-        AtomicFinding(
-            title=source_task_type.replace("_", " ").title(),
-            content=content.strip(),
-        )
-    ], "single_item"
+    return [AtomicFinding(
+        title=source_task_type.replace("_", " ").title(),
+        content=content.strip(),
+    )], "single_item"
 
 
 # Markdown heading pattern: ## Title or ### Title
@@ -442,10 +432,8 @@ async def score_batch_llm(
             logger.warning("Intake LLM scoring returned empty — using defaults")
             return [
                 ScoredFinding(
-                    finding=f,
-                    confidence=default_confidence,
-                    source=source,
-                    source_task_type=source_task_type,
+                    finding=f, confidence=default_confidence,
+                    source=source, source_task_type=source_task_type,
                     generating_model=generating_model,
                 )
                 for f in findings
@@ -456,26 +444,22 @@ async def score_batch_llm(
         scored = []
         for i, f in enumerate(findings):
             score_data = scores.get(i, {})
-            scored.append(
-                ScoredFinding(
-                    finding=f,
-                    confidence=float(score_data.get("score", default_confidence)),
-                    source=source,
-                    source_task_type=source_task_type,
-                    generating_model=generating_model,
-                    is_pattern_insight=bool(score_data.get("is_pattern", False)),
-                )
-            )
+            scored.append(ScoredFinding(
+                finding=f,
+                confidence=float(score_data.get("score", default_confidence)),
+                source=source,
+                source_task_type=source_task_type,
+                generating_model=generating_model,
+                is_pattern_insight=bool(score_data.get("is_pattern", False)),
+            ))
         return scored
 
     except Exception:
         logger.warning("Intake LLM scoring failed — using default confidence", exc_info=True)
         return [
             ScoredFinding(
-                finding=f,
-                confidence=default_confidence,
-                source=source,
-                source_task_type=source_task_type,
+                finding=f, confidence=default_confidence,
+                source=source, source_task_type=source_task_type,
                 generating_model=generating_model,
             )
             for f in findings
@@ -492,7 +476,9 @@ def _parse_score_response(content: str) -> dict[int, dict]:
         data = json.loads(content)
         if isinstance(data, list):
             return {
-                item.get("index", i): item for i, item in enumerate(data) if isinstance(item, dict)
+                item.get("index", i): item
+                for i, item in enumerate(data)
+                if isinstance(item, dict)
             }
     except (json.JSONDecodeError, ValueError):
         pass
@@ -565,9 +551,7 @@ async def run_intake(
     if needs_llm_scoring(source):
         if router is not None:
             scored_findings = await score_batch_llm(
-                findings,
-                source,
-                router,
+                findings, source, router,
                 source_task_type=source_task_type,
                 generating_model=generating_model,
             )
@@ -575,12 +559,14 @@ async def run_intake(
         else:
             logger.warning("No router available for LLM scoring — using defaults")
             scored_findings = [
-                score_finding(f, source, source_task_type, generating_model) for f in findings
+                score_finding(f, source, source_task_type, generating_model)
+                for f in findings
             ]
             stats.scoring_skipped = True
     else:
         scored_findings = [
-            score_finding(f, source, source_task_type, generating_model) for f in findings
+            score_finding(f, source, source_task_type, generating_model)
+            for f in findings
         ]
         stats.scoring_skipped = True
 
@@ -601,9 +587,7 @@ async def run_intake(
         except Exception as exc:
             logger.error(
                 "Intake routing failed for finding '%s': %s",
-                scored.finding.title[:50],
-                exc,
-                exc_info=True,
+                scored.finding.title[:50], exc, exc_info=True,
             )
             stats.errors.append(f"{scored.finding.title[:50]}: {exc}")
 
@@ -611,13 +595,9 @@ async def run_intake(
     logger.info(
         "Intake: source=%s, atomization=%s, findings=%d, "
         "knowledge=%d, observation=%d, discard=%d, scoring_skipped=%s",
-        stats.source,
-        stats.atomization_path,
-        stats.findings_count,
-        stats.routed_knowledge,
-        stats.routed_observation,
-        stats.routed_discard,
-        stats.scoring_skipped,
+        stats.source, stats.atomization_path, stats.findings_count,
+        stats.routed_knowledge, stats.routed_observation,
+        stats.routed_discard, stats.scoring_skipped,
     )
 
     # If ALL non-discard findings failed routing, raise so caller can fall back.
@@ -625,7 +605,8 @@ async def run_intake(
     actual_routes = stats.routed_knowledge + stats.routed_observation
     if expected_routes > 0 and actual_routes == 0 and stats.errors:
         raise RuntimeError(
-            f"Intake routing failed for all {expected_routes} findings: {stats.errors[0]}"
+            f"Intake routing failed for all {expected_routes} findings: "
+            f"{stats.errors[0]}"
         )
 
     return stats
@@ -657,7 +638,6 @@ async def _route_to_knowledge(
     if store is None:
         try:
             from genesis.runtime import GenesisRuntime
-
             rt = GenesisRuntime.instance()
             store = rt._memory_store
         except Exception:
@@ -708,7 +688,10 @@ async def _route_to_observation(
 
     obs_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
-    content = f"{scored.finding.title}\n\n{scored.finding.content}"
+    content = (
+        f"{scored.finding.title}\n\n"
+        f"{scored.finding.content}"
+    )
     if scored.finding.relevance:
         content += f"\n\nRelevance: {scored.finding.relevance}"
 
@@ -746,11 +729,11 @@ def _domain_for_source(source: IntakeSource, task_type: str) -> str:
 
 # Provenance ``source_pipeline`` label per IntakeSource. Two classes:
 #  - Genesis-AUTHORED intake (surplus insight tasks, background/user-directed
-#    research, user-mediated web capture) → "surplus" — first-party
+#    research, user-mediated web capture) -> "surplus" — first-party
 #    (provenance._FIRST_PARTY_PIPELINES), so recall treats it as Genesis's own.
 #  - CRAWLED external-world intelligence (model registries, GitHub landscape, web
-#    monitoring, email/source recon) → its own label, registered in
-#    provenance._EXTERNAL_PIPELINES → classified external_untrusted, so recall
+#    monitoring, email/source recon) -> its own label, registered in
+#    provenance._EXTERNAL_PIPELINES -> classified external_untrusted, so recall
 #    wraps it in <external-content> markers (the correct injection-defense posture
 #    for content pulled from outside; it is NOT Genesis's own memory).
 # This map — NOT ``source.value`` — is the authority for the label, because
@@ -809,7 +792,11 @@ async def capture_web_result(
     }
     source = source_map.get(session_type, IntakeSource.FOREGROUND_WEB)
 
-    content = f"Web result: {url}\n\nQuery: {query_context}\n\n{content_summary}"
+    content = (
+        f"Web result: {url}\n\n"
+        f"Query: {query_context}\n\n"
+        f"{content_summary}"
+    )
 
     return await run_intake(
         content=content,

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -36,16 +36,16 @@ logger = logging.getLogger(__name__)
 class IntakeSource(StrEnum):
     """Source categories with pre-assigned confidence tiers."""
 
-    USER_DIRECTED = "user_directed"              # 0.9
-    FOREGROUND_WEB = "foreground_web"            # 0.75
-    BACKGROUND_TASK = "background_task"          # 0.7
-    EMAIL_RECON = "email_recon"                  # 0.65
+    USER_DIRECTED = "user_directed"  # 0.9
+    FOREGROUND_WEB = "foreground_web"  # 0.75
+    BACKGROUND_TASK = "background_task"  # 0.7
+    EMAIL_RECON = "email_recon"  # 0.65
     ANTICIPATORY_RESEARCH = "anticipatory_research"  # 0.6
-    MODEL_INTELLIGENCE = "model_intelligence"    # 0.6
-    GITHUB_LANDSCAPE = "github_landscape"        # 0.5 — needs LLM scoring
-    WEB_MONITORING = "web_monitoring"            # 0.5 — needs LLM scoring
+    MODEL_INTELLIGENCE = "model_intelligence"  # 0.6
+    GITHUB_LANDSCAPE = "github_landscape"  # 0.5 — needs LLM scoring
+    WEB_MONITORING = "web_monitoring"  # 0.5 — needs LLM scoring
     FREE_MODEL_INVENTORY = "free_model_inventory"  # 0.5 — needs LLM scoring
-    SOURCE_DISCOVERY = "source_discovery"        # 0.4 — needs LLM scoring
+    SOURCE_DISCOVERY = "source_discovery"  # 0.4 — needs LLM scoring
 
 
 # Sources that skip LLM scoring — already curated by an LLM upstream.
@@ -81,14 +81,16 @@ _TASK_TYPE_TO_SOURCE: dict[str, IntakeSource] = {
 }
 
 # Task types that typically produce multiple findings and should be atomized.
-MULTI_FINDING_TASK_TYPES = frozenset({
-    "anticipatory_research",
-    "code_audit",
-    "gap_clustering",
-    "brainstorm_user",
-    "brainstorm_self",
-    "wing_audit",
-})
+MULTI_FINDING_TASK_TYPES = frozenset(
+    {
+        "anticipatory_research",
+        "code_audit",
+        "gap_clustering",
+        "brainstorm_user",
+        "brainstorm_self",
+        "wing_audit",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -147,14 +149,54 @@ class IntakeStats:
 FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
 
 
+# Dict fields to pull, in priority order, when a findings item / bare JSON object
+# has no plain ``content`` field. Human-meaningful prose beats a raw JSON dump.
+_FINDING_BODY_FIELDS = ("content", "summary", "description", "body", "text", "detail")
+# Keys that are structural metadata, not part of the readable body.
+_FINDING_META_KEYS = frozenset({"title", "file", "name", "sources", "relevance"})
+
+
+def _render_finding_body(data: dict) -> str:
+    """Render a bare-object finding as readable prose for the knowledge-base body.
+
+    Used by the ``atomize`` ``json_single`` path — a MULTI_FINDING task that
+    returned a bare JSON OBJECT (no ``findings`` key). Instead of storing a raw
+    ``json.dumps`` blob (unreadable in the KB and a proactive-recall noise
+    source — the ``{...}`` bodies that motivated this fix), pull the
+    human-meaningful field in priority order, else fall back to a compact
+    ``key: value`` render of the remaining fields. Never returns a raw JSON dump.
+
+    Deliberately NOT used for structured findings-array items (``_finding_from_item``
+    keeps every field via json.dumps — code_audit's severity must survive) nor for
+    the ``single_item`` path (which stores model-intelligence's intentional
+    ``prefix + JSON`` body, parsed downstream by models_md_synthesis).
+    """
+    for key in _FINDING_BODY_FIELDS:
+        val = data.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    parts = [
+        f"{k}: {v}"
+        for k, v in data.items()
+        if k not in _FINDING_META_KEYS and v not in (None, "", [], {})
+    ]
+    if parts:
+        return "\n".join(parts)
+    # Degenerate: nothing renderable beyond a title/identity key. Fall back to the
+    # title so the unit is at least labelled, never a raw JSON dump.
+    return str(data.get("title") or data.get("file") or data.get("name") or "").strip()
+
+
 def _finding_from_item(item: object, index: int, default_title: str) -> AtomicFinding | None:
     """Build a finding from one entry of a findings array.
 
     Handles both the ``{"findings": [...]}`` envelope item shape
     (title/content/sources/relevance) and bare-array shapes from task-specific
     prompts (e.g. code_audit's ``{"file", "severity", "description", ...}``) —
-    unknown dict shapes keep a title from their identity keys and the full
-    item as pretty-printed JSON content. Scalars other than str are unusable.
+    unknown dict shapes keep a title from their identity keys and the full item
+    as pretty-printed JSON content (STRUCTURED findings preserve every field —
+    e.g. code_audit's severity; do NOT prose-render here). Non-str scalars are
+    unusable.
     """
     if isinstance(item, dict):
         title = str(item.get("title") or item.get("file") or item.get("name") or "").strip()
@@ -198,10 +240,12 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
 
     # Single-output task types skip atomization entirely.
     if source_task_type not in MULTI_FINDING_TASK_TYPES:
-        return [AtomicFinding(
-            title=source_task_type.replace("_", " ").title(),
-            content=content.strip(),
-        )], "single_item"
+        return [
+            AtomicFinding(
+                title=source_task_type.replace("_", " ").title(),
+                content=content.strip(),
+            )
+        ], "single_item"
 
     # Attempt 1: Parse as JSON with findings array. Models routinely wrap the
     # payload in a ```json fence despite instructions — unwrap a whole-message
@@ -240,12 +284,15 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
             # unusable entry shapes) is a no-op result — never store the
             # raw envelope as a single unit.
             return [], "empty_findings"
-        # Valid JSON but no findings key — treat as single item.
+        # Valid JSON but no findings key — treat as single item, rendering the
+        # dict as readable prose rather than a raw json.dumps blob.
         if isinstance(data, dict):
-            return [AtomicFinding(
-                title=str(data.get("title", source_task_type.replace("_", " ").title()))[:200],
-                content=json.dumps(data, indent=2) if not isinstance(data, str) else data,
-            )], "json_single"
+            return [
+                AtomicFinding(
+                    title=str(data.get("title", source_task_type.replace("_", " ").title()))[:200],
+                    content=_render_finding_body(data),
+                )
+            ], "json_single"
     except (json.JSONDecodeError, ValueError, TypeError):
         pass
 
@@ -255,10 +302,12 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
         return findings, "markdown_split"
 
     # Attempt 3: Fall back to single item.
-    return [AtomicFinding(
-        title=source_task_type.replace("_", " ").title(),
-        content=content.strip(),
-    )], "single_item"
+    return [
+        AtomicFinding(
+            title=source_task_type.replace("_", " ").title(),
+            content=content.strip(),
+        )
+    ], "single_item"
 
 
 # Markdown heading pattern: ## Title or ### Title
@@ -393,8 +442,10 @@ async def score_batch_llm(
             logger.warning("Intake LLM scoring returned empty — using defaults")
             return [
                 ScoredFinding(
-                    finding=f, confidence=default_confidence,
-                    source=source, source_task_type=source_task_type,
+                    finding=f,
+                    confidence=default_confidence,
+                    source=source,
+                    source_task_type=source_task_type,
                     generating_model=generating_model,
                 )
                 for f in findings
@@ -405,22 +456,26 @@ async def score_batch_llm(
         scored = []
         for i, f in enumerate(findings):
             score_data = scores.get(i, {})
-            scored.append(ScoredFinding(
-                finding=f,
-                confidence=float(score_data.get("score", default_confidence)),
-                source=source,
-                source_task_type=source_task_type,
-                generating_model=generating_model,
-                is_pattern_insight=bool(score_data.get("is_pattern", False)),
-            ))
+            scored.append(
+                ScoredFinding(
+                    finding=f,
+                    confidence=float(score_data.get("score", default_confidence)),
+                    source=source,
+                    source_task_type=source_task_type,
+                    generating_model=generating_model,
+                    is_pattern_insight=bool(score_data.get("is_pattern", False)),
+                )
+            )
         return scored
 
     except Exception:
         logger.warning("Intake LLM scoring failed — using default confidence", exc_info=True)
         return [
             ScoredFinding(
-                finding=f, confidence=default_confidence,
-                source=source, source_task_type=source_task_type,
+                finding=f,
+                confidence=default_confidence,
+                source=source,
+                source_task_type=source_task_type,
                 generating_model=generating_model,
             )
             for f in findings
@@ -437,9 +492,7 @@ def _parse_score_response(content: str) -> dict[int, dict]:
         data = json.loads(content)
         if isinstance(data, list):
             return {
-                item.get("index", i): item
-                for i, item in enumerate(data)
-                if isinstance(item, dict)
+                item.get("index", i): item for i, item in enumerate(data) if isinstance(item, dict)
             }
     except (json.JSONDecodeError, ValueError):
         pass
@@ -512,7 +565,9 @@ async def run_intake(
     if needs_llm_scoring(source):
         if router is not None:
             scored_findings = await score_batch_llm(
-                findings, source, router,
+                findings,
+                source,
+                router,
                 source_task_type=source_task_type,
                 generating_model=generating_model,
             )
@@ -520,14 +575,12 @@ async def run_intake(
         else:
             logger.warning("No router available for LLM scoring — using defaults")
             scored_findings = [
-                score_finding(f, source, source_task_type, generating_model)
-                for f in findings
+                score_finding(f, source, source_task_type, generating_model) for f in findings
             ]
             stats.scoring_skipped = True
     else:
         scored_findings = [
-            score_finding(f, source, source_task_type, generating_model)
-            for f in findings
+            score_finding(f, source, source_task_type, generating_model) for f in findings
         ]
         stats.scoring_skipped = True
 
@@ -548,7 +601,9 @@ async def run_intake(
         except Exception as exc:
             logger.error(
                 "Intake routing failed for finding '%s': %s",
-                scored.finding.title[:50], exc, exc_info=True,
+                scored.finding.title[:50],
+                exc,
+                exc_info=True,
             )
             stats.errors.append(f"{scored.finding.title[:50]}: {exc}")
 
@@ -556,9 +611,13 @@ async def run_intake(
     logger.info(
         "Intake: source=%s, atomization=%s, findings=%d, "
         "knowledge=%d, observation=%d, discard=%d, scoring_skipped=%s",
-        stats.source, stats.atomization_path, stats.findings_count,
-        stats.routed_knowledge, stats.routed_observation,
-        stats.routed_discard, stats.scoring_skipped,
+        stats.source,
+        stats.atomization_path,
+        stats.findings_count,
+        stats.routed_knowledge,
+        stats.routed_observation,
+        stats.routed_discard,
+        stats.scoring_skipped,
     )
 
     # If ALL non-discard findings failed routing, raise so caller can fall back.
@@ -566,8 +625,7 @@ async def run_intake(
     actual_routes = stats.routed_knowledge + stats.routed_observation
     if expected_routes > 0 and actual_routes == 0 and stats.errors:
         raise RuntimeError(
-            f"Intake routing failed for all {expected_routes} findings: "
-            f"{stats.errors[0]}"
+            f"Intake routing failed for all {expected_routes} findings: {stats.errors[0]}"
         )
 
     return stats
@@ -599,6 +657,7 @@ async def _route_to_knowledge(
     if store is None:
         try:
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             store = rt._memory_store
         except Exception:
@@ -610,10 +669,13 @@ async def _route_to_knowledge(
 
     from genesis.memory.knowledge_ingest import ingest_knowledge_unit
 
-    # Build provenance.
+    # Build provenance. source_pipeline is derived from the real IntakeSource
+    # (NOT hardcoded "surplus") so crawled external-world intelligence
+    # (model/github/web/recon) carries an honest label + external classification,
+    # while Genesis-authored insight tasks stay "surplus"/first-party.
     provenance = {
         "source_doc": f"intake:{scored.source.value}",
-        "source_pipeline": "surplus",
+        "source_pipeline": _pipeline_for_source(scored.source),
         "ingested_at": datetime.now(UTC).isoformat(),
     }
     if scored.generating_model:
@@ -646,10 +708,7 @@ async def _route_to_observation(
 
     obs_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
-    content = (
-        f"{scored.finding.title}\n\n"
-        f"{scored.finding.content}"
-    )
+    content = f"{scored.finding.title}\n\n{scored.finding.content}"
     if scored.finding.relevance:
         content += f"\n\nRelevance: {scored.finding.relevance}"
 
@@ -685,6 +744,45 @@ def _domain_for_source(source: IntakeSource, task_type: str) -> str:
     return "intelligence.surplus"
 
 
+# Provenance ``source_pipeline`` label per IntakeSource. Two classes:
+#  - Genesis-AUTHORED intake (surplus insight tasks, background/user-directed
+#    research, user-mediated web capture) → "surplus" — first-party
+#    (provenance._FIRST_PARTY_PIPELINES), so recall treats it as Genesis's own.
+#  - CRAWLED external-world intelligence (model registries, GitHub landscape, web
+#    monitoring, email/source recon) → its own label, registered in
+#    provenance._EXTERNAL_PIPELINES → classified external_untrusted, so recall
+#    wraps it in <external-content> markers (the correct injection-defense posture
+#    for content pulled from outside; it is NOT Genesis's own memory).
+# This map — NOT ``source.value`` — is the authority for the label, because
+# ``source_for_task_type`` collapses ALL surplus insight task types onto
+# ANTICIPATORY_RESEARCH; a naive ``.value`` would mislabel every Genesis insight
+# "anticipatory_research" and (being in no first-party set) flip it to
+# external_untrusted. Keep the crawled labels in lockstep with
+# provenance._EXTERNAL_PIPELINES.
+_PIPELINE_FOR_SOURCE: dict[IntakeSource, str] = {
+    IntakeSource.USER_DIRECTED: "surplus",
+    IntakeSource.FOREGROUND_WEB: "surplus",
+    IntakeSource.BACKGROUND_TASK: "surplus",
+    IntakeSource.ANTICIPATORY_RESEARCH: "surplus",
+    IntakeSource.EMAIL_RECON: "email_recon",
+    IntakeSource.MODEL_INTELLIGENCE: "model_intelligence",
+    IntakeSource.FREE_MODEL_INVENTORY: "model_intelligence",
+    IntakeSource.GITHUB_LANDSCAPE: "github_landscape",
+    IntakeSource.WEB_MONITORING: "web_monitoring",
+    IntakeSource.SOURCE_DISCOVERY: "source_discovery",
+}
+
+
+def _pipeline_for_source(source: IntakeSource) -> str:
+    """``source_pipeline`` provenance label for a KB unit ingested from ``source``.
+
+    Defaults to "surplus" (first-party) for any unmapped source — the safe,
+    backward-compatible choice; a NEW crawled source added later must be mapped
+    here AND registered in provenance._EXTERNAL_PIPELINES to classify correctly.
+    """
+    return _PIPELINE_FOR_SOURCE.get(source, "surplus")
+
+
 # ── Web search capture ───────────────────────────────────────────────────
 
 
@@ -711,11 +809,7 @@ async def capture_web_result(
     }
     source = source_map.get(session_type, IntakeSource.FOREGROUND_WEB)
 
-    content = (
-        f"Web result: {url}\n\n"
-        f"Query: {query_context}\n\n"
-        f"{content_summary}"
-    )
+    content = f"Web result: {url}\n\nQuery: {query_context}\n\n{content_summary}"
 
     return await run_intake(
         content=content,

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -71,21 +71,19 @@ class TaskType(StrEnum):
 #   - BOOKMARK_ENRICHMENT: uses a dedicated executor whose intake routing is not
 #     yet validated (no live volume). Excluded NULL-on-uncertainty (matches the
 #     codebase's conservative-classification norm); add once its routing is proven.
-INSIGHT_PRODUCING_TASK_TYPES: frozenset[TaskType] = frozenset(
-    {
-        TaskType.BRAINSTORM_USER,
-        TaskType.BRAINSTORM_SELF,
-        TaskType.META_BRAINSTORM,
-        TaskType.MEMORY_AUDIT,
-        TaskType.PROCEDURE_AUDIT,
-        TaskType.GAP_CLUSTERING,
-        TaskType.SELF_UNBLOCK,
-        TaskType.ANTICIPATORY_RESEARCH,
-        TaskType.PROMPT_EFFECTIVENESS_REVIEW,
-        TaskType.CODE_AUDIT,
-        TaskType.WING_AUDIT,
-    }
-)
+INSIGHT_PRODUCING_TASK_TYPES: frozenset[TaskType] = frozenset({
+    TaskType.BRAINSTORM_USER,
+    TaskType.BRAINSTORM_SELF,
+    TaskType.META_BRAINSTORM,
+    TaskType.MEMORY_AUDIT,
+    TaskType.PROCEDURE_AUDIT,
+    TaskType.GAP_CLUSTERING,
+    TaskType.SELF_UNBLOCK,
+    TaskType.ANTICIPATORY_RESEARCH,
+    TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+    TaskType.CODE_AUDIT,
+    TaskType.WING_AUDIT,
+})
 
 
 # Task types whose completed output should be routed to the KNOWLEDGE BASE via

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -71,19 +71,44 @@ class TaskType(StrEnum):
 #   - BOOKMARK_ENRICHMENT: uses a dedicated executor whose intake routing is not
 #     yet validated (no live volume). Excluded NULL-on-uncertainty (matches the
 #     codebase's conservative-classification norm); add once its routing is proven.
-INSIGHT_PRODUCING_TASK_TYPES: frozenset[TaskType] = frozenset({
-    TaskType.BRAINSTORM_USER,
-    TaskType.BRAINSTORM_SELF,
-    TaskType.META_BRAINSTORM,
-    TaskType.MEMORY_AUDIT,
-    TaskType.PROCEDURE_AUDIT,
-    TaskType.GAP_CLUSTERING,
-    TaskType.SELF_UNBLOCK,
-    TaskType.ANTICIPATORY_RESEARCH,
-    TaskType.PROMPT_EFFECTIVENESS_REVIEW,
-    TaskType.CODE_AUDIT,
-    TaskType.WING_AUDIT,
-})
+INSIGHT_PRODUCING_TASK_TYPES: frozenset[TaskType] = frozenset(
+    {
+        TaskType.BRAINSTORM_USER,
+        TaskType.BRAINSTORM_SELF,
+        TaskType.META_BRAINSTORM,
+        TaskType.MEMORY_AUDIT,
+        TaskType.PROCEDURE_AUDIT,
+        TaskType.GAP_CLUSTERING,
+        TaskType.SELF_UNBLOCK,
+        TaskType.ANTICIPATORY_RESEARCH,
+        TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+        TaskType.CODE_AUDIT,
+        TaskType.WING_AUDIT,
+    }
+)
+
+
+# Task types whose completed output should be routed to the KNOWLEDGE BASE via
+# the intake pipeline (surplus/dispatch.py::_route_insights). This is a DISTINCT
+# concern from INSIGHT_PRODUCING_TASK_TYPES above (the measurement-JUDGE set):
+# KB-routing asks "does this task produce durable knowledge worth ingesting?",
+# whereas the judge set asks "can this task's output be graded for verified
+# correctness?". They mostly overlap, but BOOKMARK_ENRICHMENT is deliberately
+# EXCLUDED from the judge set (no live volume to validate its routing — see the
+# note above) while it DOES produce KB-bound content (enriched user bookmarks), so
+# it belongs here. Keeping the two sets separate avoids silently dropping
+# bookmark-enrichment KB writes when the judge set changes.
+#
+# Everything NOT in this set — action/maintenance tasks (MODEL_EVAL, DISK_CLEANUP,
+# DB_MAINTENANCE, DEAD_LETTER_REPLAY, BACKUP_VERIFICATION, J9_EVAL_BATCH,
+# FRESH_SESSION_TEST), monitors (INFRASTRUCTURE_MONITOR, CC_MEMORY_STALENESS), and
+# pipeline intermediates (RESEARCH_QUERY_GEN, PROMPT_REVIEW_*) — produces
+# point-in-time OPERATIONAL TELEMETRY, not durable knowledge: its output must NOT
+# be ingested into the knowledge base (it polluted the KB to 71% surplus before
+# this gate; the types' own docstring already says they "don't target the KB").
+KB_ROUTING_TASK_TYPES: frozenset[TaskType] = INSIGHT_PRODUCING_TASK_TYPES | {
+    TaskType.BOOKMARK_ENRICHMENT,
+}
 
 
 class ComputeTier(StrEnum):

--- a/tests/test_db/test_d0005_purge_surplus_ops_telemetry.py
+++ b/tests/test_db/test_d0005_purge_surplus_ops_telemetry.py
@@ -1,0 +1,157 @@
+"""d0005 — purge surplus operational-telemetry rows from the knowledge base.
+
+Non-KB-routing surplus tasks (action/maintenance/monitor/pipeline-intermediate)
+wrote single_item ops-telemetry KB units before the KB_ROUTING gate. This purges
+them across the full MemoryStore.delete() cross-store cascade, while leaving
+genuine insight units (real titles) and non-surplus-domain rows intact.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import genesis.db.data_migrations.d0005_purge_surplus_ops_telemetry as d0005
+
+# Minimal slices of the tables the migration touches (columns it reads/deletes).
+_SCHEMA = """
+CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, qdrant_id TEXT,
+    source_pipeline TEXT, domain TEXT, body TEXT);
+CREATE TABLE knowledge_fts (unit_id TEXT, body TEXT);
+CREATE TABLE memory_fts (memory_id TEXT, content TEXT, collection TEXT);
+CREATE TABLE memory_metadata (memory_id TEXT PRIMARY KEY, collection TEXT);
+CREATE TABLE memory_links (source_id TEXT, target_id TEXT, link_type TEXT);
+CREATE TABLE pending_embeddings (id TEXT, memory_id TEXT);
+CREATE TABLE entity_mentions (memory_id TEXT, entity_id TEXT);
+"""
+
+
+def _seed(path) -> None:
+    db = sqlite3.connect(path)
+    db.executescript(_SCHEMA)
+    units = [
+        # (unit_id, qdrant_id, source_pipeline, domain, body) — first line = title
+        # PURGE: action-task telemetry
+        ("u1", "q1", "surplus", "intelligence.surplus", "Db Maintenance\n\nDB size 266MB"),
+        # PURGE: pipeline-intermediate telemetry
+        ("u3", "q3", "surplus", "intelligence.surplus", "Research Query Gen\n\nq1; q2; q3"),
+        # KEEP: genuine insight (real LLM title, same pipeline/domain)
+        ("u2", "q2", "surplus", "intelligence.surplus", "Optimize Memory and Process\n\n…"),
+        # KEEP: crawled external intelligence (different domain — not matched)
+        ("u4", "q4", "model_intelligence", "intelligence.models", "Model Intelligence\n\n{...}"),
+        # KEEP: a title collision guard — "Model Eval" is an ops title, but this
+        # row is in a different domain, so the domain scope must protect it.
+        ("u5", "q5", "surplus", "intelligence.models", "Model Eval\n\nnot telemetry here"),
+    ]
+    db.executemany(
+        "INSERT INTO knowledge_units (id, qdrant_id, source_pipeline, domain, body) "
+        "VALUES (?, ?, ?, ?, ?)",
+        units,
+    )
+    # Mirror rows keyed by qdrant_id for every unit, plus the knowledge_fts pair.
+    for uid, qid, *_ in units:
+        db.execute("INSERT INTO knowledge_fts (unit_id, body) VALUES (?, ?)", (uid, "b"))
+        db.execute(
+            "INSERT INTO memory_fts (memory_id, content, collection) VALUES (?, ?, 'knowledge_base')",
+            (qid, "c"),
+        )
+        db.execute(
+            "INSERT INTO memory_metadata (memory_id, collection) VALUES (?, 'knowledge_base')",
+            (qid,),
+        )
+        db.execute(
+            "INSERT INTO memory_links (source_id, target_id, link_type) VALUES (?, 'x', 'rel')",
+            (qid,),
+        )
+        db.execute(
+            "INSERT INTO pending_embeddings (id, memory_id) VALUES (?, ?)", (f"p-{qid}", qid)
+        )
+        db.execute("INSERT INTO entity_mentions (memory_id, entity_id) VALUES (?, 'e1')", (qid,))
+    db.commit()
+    db.close()
+
+
+def _patch(monkeypatch, path, *, deleted=None, qdrant_fail_ids=()):
+    monkeypatch.setattr(d0005, "genesis_db_path", lambda: str(path))
+    monkeypatch.setattr(d0005, "get_client", lambda: "FAKE_CLIENT")
+
+    def _fake_delete(client, *, collection, point_id):
+        if point_id in qdrant_fail_ids:
+            raise RuntimeError("qdrant down")
+        if deleted is not None:
+            deleted.append((collection, point_id))
+
+    monkeypatch.setattr(d0005, "delete_point", _fake_delete)
+
+
+def test_purges_only_ops_telemetry_in_surplus_domain(tmp_path, monkeypatch):
+    path = tmp_path / "genesis.db"
+    _seed(path)
+    deleted: list = []
+    _patch(monkeypatch, path, deleted=deleted)
+
+    assert d0005.verify() is False
+    summary = d0005.migrate()
+    assert summary["purged"] == 2  # u1 (Db Maintenance) + u3 (Research Query Gen)
+    assert d0005.verify() is True
+
+    db = sqlite3.connect(path)
+    units = {r[0] for r in db.execute("SELECT id FROM knowledge_units").fetchall()}
+    # Cross-store: no orphaned mirror rows for the purged points.
+    fts = {r[0] for r in db.execute("SELECT memory_id FROM memory_fts").fetchall()}
+    meta = {r[0] for r in db.execute("SELECT memory_id FROM memory_metadata").fetchall()}
+    kfts = {r[0] for r in db.execute("SELECT unit_id FROM knowledge_fts").fetchall()}
+    db.close()
+
+    assert units == {"u2", "u4", "u5"}  # insight + crawled + domain-guarded kept
+    assert fts == {"q2", "q4", "q5"}  # memory_fts cascade removed q1/q3
+    assert meta == {"q2", "q4", "q5"}  # memory_metadata cascade removed q1/q3
+    assert kfts == {"u2", "u4", "u5"}
+    assert set(deleted) == {("knowledge_base", "q1"), ("knowledge_base", "q3")}
+
+
+def test_migrate_is_idempotent(tmp_path, monkeypatch):
+    path = tmp_path / "genesis.db"
+    _seed(path)
+    _patch(monkeypatch, path)
+    assert d0005.migrate()["purged"] == 2
+    assert d0005.migrate()["purged"] == 0
+    assert d0005.verify() is True
+
+
+def test_qdrant_failure_leaves_unit_for_retry(tmp_path, monkeypatch):
+    # A failed Qdrant delete must NOT delete the SQLite rows (no orphan vector);
+    # the unit stays a candidate so verify() is False and the migration retries.
+    path = tmp_path / "genesis.db"
+    _seed(path)
+    _patch(monkeypatch, path, qdrant_fail_ids={"q1"})
+    summary = d0005.migrate()
+    assert summary["purged"] == 1  # only u3 (q3) purged; u1 (q1) failed
+    assert summary["qdrant_failed"] == 1
+    assert d0005.verify() is False  # u1 still present → will retry next boot
+
+    db = sqlite3.connect(path)
+    units = {r[0] for r in db.execute("SELECT id FROM knowledge_units").fetchall()}
+    db.close()
+    assert "u1" in units  # left intact for retry
+
+
+def test_empty_db_verifies_clean(tmp_path, monkeypatch):
+    path = tmp_path / "genesis.db"
+    db = sqlite3.connect(path)
+    db.executescript(_SCHEMA)
+    db.commit()
+    db.close()
+    _patch(monkeypatch, path)
+    assert d0005.verify() is True
+    assert d0005.migrate() == {"purged": 0, "qdrant_deleted": 0}
+
+
+def test_purge_titles_match_live_enum_derivation():
+    # The hardcoded signature list must equal the non-KB-routing task titles, so
+    # it can't silently drift from the dispatch gate.
+    from genesis.surplus.types import KB_ROUTING_TASK_TYPES, TaskType
+
+    derived = {
+        tt.value.replace("_", " ").title() for tt in TaskType if tt not in KB_ROUTING_TASK_TYPES
+    }
+    assert derived == d0005._OPS_TELEMETRY_TITLES

--- a/tests/test_db/test_d0005_purge_surplus_ops_telemetry.py
+++ b/tests/test_db/test_d0005_purge_surplus_ops_telemetry.py
@@ -29,18 +29,34 @@ def _seed(path) -> None:
     db = sqlite3.connect(path)
     db.executescript(_SCHEMA)
     units = [
-        # (unit_id, qdrant_id, source_pipeline, domain, body) — first line = title
-        # PURGE: action-task telemetry
-        ("u1", "q1", "surplus", "intelligence.surplus", "Db Maintenance\n\nDB size 266MB"),
-        # PURGE: pipeline-intermediate telemetry
+        # (unit_id, qdrant_id, source_pipeline, domain, body) — first line = title,
+        # then the machine-report body prefix the signature requires.
+        # PURGE: action-task telemetry (title + machine prefix)
+        (
+            "u1",
+            "q1",
+            "surplus",
+            "intelligence.surplus",
+            "Db Maintenance\n\nDatabase maintenance report:   DB file size 266MB",
+        ),
+        # PURGE: pipeline-intermediate telemetry (specific title, no prefix guard)
         ("u3", "q3", "surplus", "intelligence.surplus", "Research Query Gen\n\nq1; q2; q3"),
         # KEEP: genuine insight (real LLM title, same pipeline/domain)
         ("u2", "q2", "surplus", "intelligence.surplus", "Optimize Memory and Process\n\n…"),
         # KEEP: crawled external intelligence (different domain — not matched)
         ("u4", "q4", "model_intelligence", "intelligence.models", "Model Intelligence\n\n{...}"),
-        # KEEP: a title collision guard — "Model Eval" is an ops title, but this
-        # row is in a different domain, so the domain scope must protect it.
+        # KEEP: domain-scope guard — "Model Eval" title but in intelligence.models.
         ("u5", "q5", "surplus", "intelligence.models", "Model Eval\n\nnot telemetry here"),
+        # KEEP: Codex-P2 false-delete guard — an INSIGHT finding an LLM titled
+        # "Model Eval" in the SAME surplus/intelligence.surplus scope, but with a
+        # prose body (no "Model evaluation:" machine prefix) → must survive.
+        (
+            "u6",
+            "q6",
+            "surplus",
+            "intelligence.surplus",
+            "Model Eval\n\nA brainstorm on how we should evaluate candidate models next quarter.",
+        ),
     ]
     db.executemany(
         "INSERT INTO knowledge_units (id, qdrant_id, source_pipeline, domain, body) "
@@ -102,10 +118,12 @@ def test_purges_only_ops_telemetry_in_surplus_domain(tmp_path, monkeypatch):
     kfts = {r[0] for r in db.execute("SELECT unit_id FROM knowledge_fts").fetchall()}
     db.close()
 
-    assert units == {"u2", "u4", "u5"}  # insight + crawled + domain-guarded kept
-    assert fts == {"q2", "q4", "q5"}  # memory_fts cascade removed q1/q3
-    assert meta == {"q2", "q4", "q5"}  # memory_metadata cascade removed q1/q3
-    assert kfts == {"u2", "u4", "u5"}
+    # Kept: insight (u2) + crawled (u4) + domain-guarded (u5) + the prose-body
+    # "Model Eval" insight (u6, the Codex-P2 false-delete guard).
+    assert units == {"u2", "u4", "u5", "u6"}
+    assert fts == {"q2", "q4", "q5", "q6"}  # memory_fts cascade removed q1/q3
+    assert meta == {"q2", "q4", "q5", "q6"}  # memory_metadata cascade removed q1/q3
+    assert kfts == {"u2", "u4", "u5", "u6"}
     assert set(deleted) == {("knowledge_base", "q1"), ("knowledge_base", "q3")}
 
 
@@ -146,12 +164,31 @@ def test_empty_db_verifies_clean(tmp_path, monkeypatch):
     assert d0005.migrate() == {"purged": 0, "qdrant_deleted": 0}
 
 
-def test_purge_titles_match_live_enum_derivation():
-    # The hardcoded signature list must equal the non-KB-routing task titles, so
-    # it can't silently drift from the dispatch gate.
+def test_signature_titles_are_all_non_kb_routing():
+    # Every purge signature title must be a non-KB-routing task's title() — so the
+    # migration can NEVER match an insight-producing task's title. Guards against a
+    # future edit adding an insight title to the signature map.
     from genesis.surplus.types import KB_ROUTING_TASK_TYPES, TaskType
 
-    derived = {
+    non_kb_titles = {
         tt.value.replace("_", " ").title() for tt in TaskType if tt not in KB_ROUTING_TASK_TYPES
     }
-    assert derived == d0005._OPS_TELEMETRY_TITLES
+    assert set(d0005._OPS_SIGNATURES) <= non_kb_titles
+
+
+def test_generic_title_with_prose_body_is_not_purged(tmp_path, monkeypatch):
+    # Codex-P2 guard: a generic ops title ("Model Eval") on a real insight with a
+    # prose body (no machine-report prefix) must NOT be purged.
+    path = tmp_path / "genesis.db"
+    db = sqlite3.connect(path)
+    db.executescript(_SCHEMA)
+    db.execute(
+        "INSERT INTO knowledge_units (id, qdrant_id, source_pipeline, domain, body) "
+        "VALUES ('x', 'qx', 'surplus', 'intelligence.surplus', "
+        "'Model Eval\n\nMy analysis of which models to evaluate.')"
+    )
+    db.commit()
+    db.close()
+    _patch(monkeypatch, path)
+    assert d0005.migrate()["purged"] == 0
+    assert d0005.verify() is True

--- a/tests/test_memory/test_provenance.py
+++ b/tests/test_memory/test_provenance.py
@@ -314,3 +314,36 @@ def test_provenance_descriptor_corrupt_origin_labels_external():
     assert provenance_descriptor(collection="episodic_memory", origin_class="garbage").startswith(
         "external-world knowledge"
     )
+
+
+# ── surplus-KB honest-label origin classification ───────────────────────
+# Genesis-authored surplus insight tasks stay first-party; crawled external
+# intelligence (model/github/web/recon) is classified external_untrusted so
+# recall wraps it as external content (correct injection-defense posture).
+
+from genesis.memory.provenance import derive_origin_class  # noqa: E402
+
+
+def test_surplus_label_is_first_party():
+    assert (
+        derive_origin_class(
+            collection="knowledge_base", source_pipeline="surplus", source_subsystem=None
+        )
+        == "first_party"
+    )
+
+
+def test_crawled_labels_are_external_untrusted():
+    for label in (
+        "model_intelligence",
+        "github_landscape",
+        "web_monitoring",
+        "source_discovery",
+        "email_recon",
+    ):
+        assert (
+            derive_origin_class(
+                collection="knowledge_base", source_pipeline=label, source_subsystem=None
+            )
+            == "external_untrusted"
+        ), label

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -175,3 +175,62 @@ async def test_maybe_observe_failure_silent_below_threshold(monkeypatch):
     await dispatch.maybe_observe_failure(ctx, _Task(), "some reason")
 
     upsert_spy.assert_not_awaited()
+
+
+# ── KB-routing gate (_route_insights) ───────────────────────────────────
+# Non-KB-routing tasks (action/maintenance/monitor/pipeline-intermediate) must
+# NOT ingest their operational-telemetry output into the knowledge base; only
+# KB_ROUTING_TASK_TYPES (insight-producing + bookmark-enrichment) do.
+
+import types as _types  # noqa: E402
+
+from genesis.surplus import intake as _intake_mod  # noqa: E402
+from genesis.surplus import quality_judge as _judge_mod  # noqa: E402
+
+_LONG = "x" * 60  # clears the 50-char intake gate
+
+
+def _intake_ctx():
+    ctx = _make_ctx()
+    ctx._judge_router = None
+    return ctx
+
+
+async def _run_route(task_type, monkeypatch):
+    run_intake_spy = AsyncMock(
+        return_value=_types.SimpleNamespace(
+            findings_count=1, routed_knowledge=1, routed_observation=0, routed_discard=0
+        )
+    )
+    monkeypatch.setattr(_intake_mod, "run_intake", run_intake_spy)
+    monkeypatch.setattr(
+        _judge_mod, "run_quality_judge", AsyncMock(return_value=(None, None, None))
+    )
+    ctx = _intake_ctx()
+    result = _Result(insights=[{"generating_model": "m", "confidence": 0.6}], content=_LONG)
+    staging_id, *_ = await dispatch._route_insights(ctx, _Task(task_type), result)
+    return run_intake_spy, staging_id
+
+
+async def test_route_insights_skips_kb_intake_for_action_task(monkeypatch):
+    # DB_MAINTENANCE is operational telemetry — must NOT reach run_intake.
+    spy, staging_id = await _run_route(TaskType.DB_MAINTENANCE, monkeypatch)
+    spy.assert_not_awaited()
+    assert staging_id is not None  # still tracked
+
+
+async def test_route_insights_skips_kb_intake_for_pipeline_intermediate(monkeypatch):
+    spy, _ = await _run_route(TaskType.RESEARCH_QUERY_GEN, monkeypatch)
+    spy.assert_not_awaited()
+
+
+async def test_route_insights_ingests_insight_task(monkeypatch):
+    # BRAINSTORM_SELF produces durable knowledge — must reach run_intake.
+    spy, _ = await _run_route(TaskType.BRAINSTORM_SELF, monkeypatch)
+    spy.assert_awaited_once()
+
+
+async def test_route_insights_ingests_bookmark_enrichment(monkeypatch):
+    # In KB_ROUTING (enriched bookmarks are durable) though NOT judge-eligible.
+    spy, _ = await _run_route(TaskType.BOOKMARK_ENRICHMENT, monkeypatch)
+    spy.assert_awaited_once()

--- a/tests/test_surplus/test_intake.py
+++ b/tests/test_surplus/test_intake.py
@@ -107,8 +107,7 @@ class TestItemRobustness:
         assert findings[0].sources == []
 
     def test_string_sources_wrapped_not_char_iterated(self):
-        payload = ('{"findings": [{"title": "A", "content": "x",'
-                   ' "sources": "http://example.test"}]}')
+        payload = '{"findings": [{"title": "A", "content": "x", "sources": "http://example.test"}]}'
         findings, path = atomize(payload, "anticipatory_research")
         assert path == "json_findings"
         assert findings[0].sources == ["http://example.test"]
@@ -149,12 +148,24 @@ class TestFenceVariants:
 class TestBareArrayPayload:
     """code_audit-style prompts return a bare top-level array, not an envelope."""
 
-    _AUDIT_JSON = json.dumps([
-        {"file": "src/x.py", "line": 3, "severity": "high",
-         "description": "desc one", "confidence": 0.8},
-        {"file": "src/y.py", "line": None, "severity": "low",
-         "description": "desc two", "confidence": 0.6},
-    ])
+    _AUDIT_JSON = json.dumps(
+        [
+            {
+                "file": "src/x.py",
+                "line": 3,
+                "severity": "high",
+                "description": "desc one",
+                "confidence": 0.8,
+            },
+            {
+                "file": "src/y.py",
+                "line": None,
+                "severity": "low",
+                "description": "desc two",
+                "confidence": 0.6,
+            },
+        ]
+    )
 
     def test_fenced_bare_array_atomized(self):
         findings, path = atomize(f"```json\n{self._AUDIT_JSON}\n```", "code_audit")
@@ -223,3 +234,50 @@ class TestKbContent:
     def test_minimal_shape(self):
         f = AtomicFinding(title="T", content="C")
         assert kb_content_for_finding(f) == "T\n\nC"
+
+
+# ── source_pipeline honest labels + json_single prose render ─────────────
+
+from genesis.surplus.intake import (  # noqa: E402
+    _pipeline_for_source,
+    _render_finding_body,
+)
+
+
+class TestPipelineForSource:
+    def test_genesis_authored_is_surplus(self):
+        for src in (
+            IntakeSource.ANTICIPATORY_RESEARCH,
+            IntakeSource.BACKGROUND_TASK,
+            IntakeSource.USER_DIRECTED,
+            IntakeSource.FOREGROUND_WEB,
+        ):
+            assert _pipeline_for_source(src) == "surplus"
+
+    def test_crawled_sources_get_distinct_labels(self):
+        assert _pipeline_for_source(IntakeSource.MODEL_INTELLIGENCE) == "model_intelligence"
+        assert _pipeline_for_source(IntakeSource.FREE_MODEL_INVENTORY) == "model_intelligence"
+        assert _pipeline_for_source(IntakeSource.GITHUB_LANDSCAPE) == "github_landscape"
+        assert _pipeline_for_source(IntakeSource.WEB_MONITORING) == "web_monitoring"
+        assert _pipeline_for_source(IntakeSource.SOURCE_DISCOVERY) == "source_discovery"
+        assert _pipeline_for_source(IntakeSource.EMAIL_RECON) == "email_recon"
+
+
+class TestJsonSingleProseRender:
+    def test_bare_object_renders_summary_not_raw_json(self):
+        # A MULTI_FINDING task returning a bare object (no findings key) →
+        # json_single. The body must be readable prose, never a JSON dump.
+        findings, path = atomize(
+            '{"title": "Idea", "summary": "a readable summary line"}', "brainstorm_self"
+        )
+        assert path == "json_single"
+        assert findings[0].content == "a readable summary line"
+        assert "{" not in findings[0].content
+
+    def test_render_finding_body_falls_back_to_key_values(self):
+        body = _render_finding_body({"analysis": "x found", "recommendation": "do y"})
+        assert body == "analysis: x found\nrecommendation: do y"
+
+    def test_render_finding_body_skips_meta_keys(self):
+        # title/file/sources/relevance are structural, not body.
+        assert _render_finding_body({"title": "T", "detail": "the detail"}) == "the detail"


### PR DESCRIPTION
## Problem

The `knowledge_base` Qdrant collection was **71% `source_pipeline=surplus`** (1157/1699 units, live-growing since 2026-06-10) — and that "surplus" content was **Genesis's own operational telemetry**: DB-maintenance reports, disk-cleanup scans, model/J9 eval batches, backup verifications, plus research/prompt-review pipeline intermediates. It crowded out real ingested knowledge and (before the PR-B proactive filter) leaked into proactive recall.

**Root cause:** `surplus/dispatch.py::_route_insights` routed *every* non-`CODE_AUDIT` surplus task's output through `run_intake` as curated knowledge. Because surplus is a curated `IntakeSource`, intake skips scoring and writes straight to the KB. But `surplus/types.py`'s own docstring already says those action/maintenance/monitor/intermediate tasks "don't target the KB" — the intake routing simply never had that gate (the quality judge 40 lines below already did).

## Fix

- **Gate** — new `KB_ROUTING_TASK_TYPES` (insight-producing + `BOOKMARK_ENRICHMENT`, deliberately decoupled from the measurement-judge set); `_route_insights` no longer ingests non-KB-routing task output.
- **Honest provenance** — `intake.py` stopped hardcoding `source_pipeline="surplus"` for all intake. New `_pipeline_for_source` map: Genesis-authored insight tasks stay `surplus`/first-party; crawled external intelligence (`model_intelligence`/`github_landscape`/`web_monitoring`/`source_discovery`/`email_recon`) gets its own label, registered in `provenance._EXTERNAL_PIPELINES` → classified `external_untrusted` so recall wraps it as external-world content (the correct injection-defense posture; verified safe — the one structural consumer `models_md_synthesis` reads raw SQL, bypassing recall-wrapping).
- **Atomizer** — `atomize` `json_single` now renders a bare JSON object as readable prose instead of a raw `json.dumps` blob. **Scoped to `json_single` only**: the `single_item` path (model-intelligence's intentionally-JSON, machine-parsed body) and structured findings-array items (code-audit severity) are untouched.
- **Purge** — `db/data_migrations/d0005` removes the historical telemetry rows on every install (post-boot, idempotent). Deterministic match: `source_pipeline=surplus AND domain=intelligence.surplus AND` body first-line == a non-KB-routing task's exact `single_item` title (disjoint from the kept insight titles — asserted vs the live enum). Reproduces the full `MemoryStore.delete()` cross-store cascade in raw SQL (Qdrant + `memory_metadata`/`memory_fts`/`knowledge_units`/`knowledge_fts` + `memory_links`/`pending_embeddings`/`entity_mentions`) so purged junk can't resurface via degraded FTS5 recall.

## Verification

- 120 targeted unit tests (gate, honest labels, atomizer prose, migration cross-store cascade + idempotency + Qdrant-failure-retry + domain-guard + enum-sync).
- **E2E against a WAL-consistent copy of the live DB** (Qdrant mocked): 256 ops-telemetry units purged, `intelligence.models` **401→401 preserved**, **0 cross-store orphans**, idempotent 2nd run.

## Deploy

On merge + `git pull` + genesis-server restart, the post-boot data-migration runner executes d0005 automatically — no manual step. Forward writes are gated immediately.

Ledger: eea08356ce094370ad14b5a786f16e1f

🤖 Generated with [Claude Code](https://claude.com/claude-code)