### PR TITLE
fix(ego): dispatch verification — string/size checks advisory, not pass/fail

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from genesis.cc import AgentProvider
     from genesis.cc.session_config import SessionConfigBuilder
     from genesis.cc.session_manager import SessionManager
+    from genesis.ego.verification import VerificationResult
 
 logger = logging.getLogger(__name__)
 
@@ -965,6 +966,7 @@ class DirectSessionRunner:
         if not request.caller_context or not request.caller_context.startswith("ego_proposal:"):
             return
         proposal_id = request.caller_context.split(":", 1)[1]
+        advisories: list[str] = []
         try:
             from genesis.db.crud.ego import (
                 mark_proposal_verification_failed,
@@ -976,19 +978,19 @@ class DirectSessionRunner:
                 return
 
             # Post-dispatch verification: if the session succeeded and the
-            # proposal defines expected_outputs, verify deliverables before
-            # recording the outcome.
+            # proposal defines expected_outputs, check deliverables. Missing or
+            # empty files are hard failures; size/content misses are advisories
+            # that KEEP the proposal executed — a real deliverable was produced,
+            # and a string/size miss is a failure of the proxy, not the work.
             if result.success:
-                verification_failed = await self._verify_proposal_outputs(
-                    db,
-                    proposal_id,
-                )
-                if verification_failed:
-                    # Mark as failed + store observation; skip normal outcome
+                vres = await self._verify_proposal_outputs(db, proposal_id)
+                if vres is not None and vres.missing_files:
+                    # Deliverable not produced → hard fail + observation.
+                    fail_summary = "; ".join(vres.missing_files)
                     await mark_proposal_verification_failed(
                         db,
                         proposal_id,
-                        summary=verification_failed,
+                        summary=fail_summary,
                     )
                     try:
                         store = getattr(self._rt, "_memory_store", None)
@@ -996,7 +998,7 @@ class DirectSessionRunner:
                             await store.store(
                                 content=(
                                     f"Ego dispatch VERIFICATION FAILED for "
-                                    f"proposal {proposal_id}: {verification_failed}"
+                                    f"proposal {proposal_id}: {fail_summary}"
                                 ),
                                 source="ego_dispatch_verification",
                                 tags=["ego", "verification_failure"],
@@ -1016,8 +1018,15 @@ class DirectSessionRunner:
                         result,
                     )
                     return
+                if vres is not None:
+                    advisories = list(vres.advisories)
 
             summary = (result.output_text or result.error or "")[:1000]
+            if advisories:
+                # Informational only — never changes the |completed: polarity
+                # the feedback harvester reads from this suffix.
+                note = "; ".join(advisories)
+                summary = f"{summary}\n[verification advisories: {note}]"[:1000]
             await update_proposal_outcome(
                 db,
                 proposal_id,
@@ -1047,17 +1056,19 @@ class DirectSessionRunner:
                 exc_info=True,
             )
         # Debrief is best-effort, fully self-contained (own try/except)
-        await self._notify_dispatch_debrief(proposal_id, request, result)
+        await self._notify_dispatch_debrief(proposal_id, request, result, advisories=advisories)
 
     async def _verify_proposal_outputs(
         self,
         db: object,
         proposal_id: str,
-    ) -> str | None:
-        """Check expected outputs for a completed proposal.
+    ) -> VerificationResult | None:
+        """Run post-dispatch verification for a completed proposal.
 
-        Returns a failure summary string if verification fails,
-        or ``None`` if verification passes or is not configured.
+        Returns the :class:`~genesis.ego.verification.VerificationResult`
+        (inspect ``missing_files`` for hard failures and ``advisories`` for
+        non-fatal size/content notes), or ``None`` if the proposal has no
+        ``expected_outputs`` or verification could not run.
         """
         try:
             from genesis.db.crud.ego import get_proposal
@@ -1069,24 +1080,28 @@ class DirectSessionRunner:
             expected = parse_expected_outputs(proposal.get("expected_outputs"))
             if expected is None:
                 return None  # no verification configured
-            result = verify_outputs(expected)
-            if not result.passed:
-                return "; ".join(result.failures)
+            return verify_outputs(expected)
         except Exception:
             logger.warning(
                 "Post-dispatch verification error for %s (skipping)",
                 proposal_id,
                 exc_info=True,
             )
-        return None
+            return None
 
     async def _notify_dispatch_debrief(
         self,
         proposal_id: str,
         request: DirectSessionRequest,
         result: DirectSessionResult,
+        advisories: list[str] | None = None,
     ) -> None:
-        """Send after-action report to ego_dispatches Telegram topic."""
+        """Send after-action report to ego_dispatches Telegram topic.
+
+        ``advisories`` are non-fatal verification notes (a content/size proxy
+        that didn't match a still-accepted deliverable); surfaced as an FYI,
+        never as a failure.
+        """
         try:
             import html as html_mod
 
@@ -1108,6 +1123,9 @@ class DirectSessionRunner:
                 f"<i>Duration:</i> {dur_str} | <i>Cost:</i> {cost_str}\n\n"
                 f"<b>Outcome:</b>\n{outcome_escaped}"
             )
+            if advisories:
+                adv_escaped = html_mod.escape("; ".join(advisories))
+                msg += f"\n\n<i>Advisory (deliverable accepted):</i>\n{adv_escaped}"
             await tm.send_to_category("ego_dispatches", msg)
         except Exception:
             logger.debug("Failed to send dispatch debrief", exc_info=True)

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1021,12 +1021,16 @@ class DirectSessionRunner:
                 if vres is not None:
                     advisories = list(vres.advisories)
 
-            summary = (result.output_text or result.error or "")[:1000]
+            base = result.output_text or result.error or ""
             if advisories:
                 # Informational only — never changes the |completed: polarity
-                # the feedback harvester reads from this suffix.
-                note = "; ".join(advisories)
-                summary = f"{summary}\n[verification advisories: {note}]"[:1000]
+                # the feedback harvester reads from this suffix. Budget the note
+                # into the 1000-char cap so a long output_text can't truncate
+                # the advisory away entirely (the whole point of surfacing it).
+                note = f"\n[verification advisories: {'; '.join(advisories)}]"[:500]
+                summary = base[: max(0, 1000 - len(note))] + note
+            else:
+                summary = base[:1000]
             await update_proposal_outcome(
                 db,
                 proposal_id,

--- a/src/genesis/db/data_migrations/d0005_reverify_false_dispatch_failures.py
+++ b/src/genesis/db/data_migrations/d0005_reverify_false_dispatch_failures.py
@@ -71,6 +71,7 @@ def _exact_pass(expected_outputs: str | None) -> bool:
 
 
 def migrate() -> dict:
+    """Flip each exact-pass false-failure to 'executed'; return counts."""
     db = sqlite3.connect(genesis_db_path(), timeout=30.0)
     try:
         rows = db.execute(_SELECT).fetchall()

--- a/src/genesis/db/data_migrations/d0005_reverify_false_dispatch_failures.py
+++ b/src/genesis/db/data_migrations/d0005_reverify_false_dispatch_failures.py
@@ -1,0 +1,101 @@
+"""d0005 — un-bury dispatch proposals false-failed by the old string/size gate.
+
+Post-dispatch verification used to hard-fail a proposal (status → 'failed')
+when a ``required_strings`` entry was absent, a file was under
+``min_size_bytes``, or a ``~``/``$VAR`` path was left unexpanded. This
+false-failed complete deliverables and fed a NEGATIVE learning signal into the
+feedback harvester for work that actually succeeded. The mechanism is fixed
+going forward (``ego/verification.py``: existence-only hard signal, string/size
+advisory, path expansion). This migration repairs the rows already stranded as
+'failed' on existing installs.
+
+Re-verify every proposal sitting at status='failed' with a
+``|verification_failed:`` marker using the fixed logic. Flip to 'executed'
+(appending a ``|completed:`` suffix so the outcome reads as the success it was)
+ONLY when the deliverable now passes AND every expected file exists at its
+EXACT resolved path — never on a fuzzy-name match, which no heuristic can
+reliably tell from an unrelated similarly-named file (a wrong file scored higher
+name-similarity than two legit renames in the observed data). Fuzzy-only and
+genuinely-missing rows are left 'failed' — conservative by design.
+
+KNOWN LIMITATION (tracked as a follow-up, not fixed here): the negative
+``ln`` (Outcome Bus) EXECUTION_OUTCOME already harvested for these proposals is
+keyed on a unique (source, ref_type, ref_id, signal_type) and will not be
+overwritten by a re-harvest. This migration corrects proposal STATUS (dashboard
+visibility + ``capability_aggregator`` counts), not the already-recorded
+learning signal.
+
+migrate()/verify() are SYNC (framework contract, cf. d0001/d0002/d0004); own
+connections only — never the runtime's async ``rt._db``. Idempotent: once a row
+is 'executed' it no longer matches the status='failed' filter, and a fresh
+install has no such rows.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from genesis.ego.verification import (
+    _resolve_path,
+    parse_expected_outputs,
+    verify_outputs,
+)
+from genesis.env import genesis_db_path
+
+requires_operator = False
+
+_SELECT = (
+    "SELECT id, user_response, expected_outputs FROM ego_proposals "
+    "WHERE status = 'failed' AND user_response LIKE '%verification_failed%'"
+)
+
+_NOTE = (
+    "|completed:re-verified under fixed advisory logic (d0005 data-migration); "
+    "deliverable present at the exact expected path"
+)
+
+
+def _exact_pass(expected_outputs: str | None) -> bool:
+    """True iff the deliverable now passes AND every file exists at its exact
+    resolved path (no fuzzy substitution). Conservative: any parse/IO problem
+    or fuzzy-only match returns False (leave the row 'failed')."""
+    expected = parse_expected_outputs(expected_outputs)
+    if expected is None:
+        return False
+    try:
+        if not all(_resolve_path(f).exists() for f in expected.files):
+            return False
+        return verify_outputs(expected).passed
+    except OSError:
+        return False
+
+
+def migrate() -> dict:
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    try:
+        rows = db.execute(_SELECT).fetchall()
+        flipped = 0
+        for pid, _user_response, expected_outputs in rows:
+            if not _exact_pass(expected_outputs):
+                continue
+            db.execute(
+                "UPDATE ego_proposals SET status = 'executed', "
+                "user_response = COALESCE(user_response, '') || ? "
+                "WHERE id = ? AND status = 'failed'",
+                (_NOTE, pid),
+            )
+            flipped += 1
+        db.commit()
+        return {"flipped": flipped, "scanned": len(rows)}
+    finally:
+        db.close()
+
+
+def verify() -> bool:
+    """Complete when no exact-pass proposal remains stranded at 'failed'."""
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        rows = db.execute(_SELECT).fetchall()
+    finally:
+        db.close()
+    return not any(_exact_pass(eo) for _pid, _ur, eo in rows)

--- a/src/genesis/ego/verification.py
+++ b/src/genesis/ego/verification.py
@@ -169,7 +169,9 @@ def verify_outputs(expected: ExpectedOutputs) -> VerificationResult:
     for filepath in expected.files:
         path = _resolve_path(filepath)
         fuzzy = False
-        if not path.exists():
+        # is_file() (not exists()) so a directory at the expected path is not
+        # mistaken for a deliverable (a dir's st_size reads as non-zero).
+        if not path.is_file():
             # Fuzzy fallback: search parent directory for similar files
             similar = _find_similar(path)
             if similar is not None:

--- a/src/genesis/ego/verification.py
+++ b/src/genesis/ego/verification.py
@@ -181,6 +181,18 @@ def verify_outputs(expected: ExpectedOutputs) -> VerificationResult:
         # Use the resolved path in messages so operators can find the file
         label = f"{path} (fuzzy match for {filepath})" if fuzzy else filepath
 
+        # A fuzzy match means the EXACT expected path was absent. No heuristic
+        # (name-similarity OR content) reliably tells a rename from an unrelated
+        # similarly-named file, so we still count it as produced (never a
+        # false-fail on a real rename) but flag it LOUDLY — a possibly-wrong
+        # file must never pass silently. The LLM semantic verifier is the real
+        # disambiguation.
+        if fuzzy:
+            advisories.append(
+                f"Fuzzy filename match — expected {filepath!r}, used "
+                f"{path.name!r}; verify this is the intended deliverable"
+            )
+
         try:
             size = path.stat().st_size
         except OSError as exc:

--- a/src/genesis/ego/verification.py
+++ b/src/genesis/ego/verification.py
@@ -1,20 +1,33 @@
 """Post-dispatch output verification for ego proposals.
 
-After an ego-dispatched session completes, this module checks whether
-the expected deliverables actually exist and meet minimum criteria.
-Verification is opt-in: proposals without ``expected_outputs`` metadata
-skip verification entirely.
+After an ego-dispatched session completes, this module checks whether the
+expected deliverables were produced. Verification is opt-in: proposals without
+``expected_outputs`` metadata skip verification entirely.
 
-When an expected file is missing, a fuzzy-match fallback searches the
-parent directory for similarly-named files (using SequenceMatcher).
-This catches common dispatch mismatches (added suffixes, version numbers,
-slight name variations) without false-positiving on unrelated files.
+**Success model — file existence is the only hard signal.** The trustworthy
+"a real deliverable was produced" signal is: the expected file exists (after
+``~``/env expansion and a fuzzy-name fallback) and is non-empty. Everything
+else — ``min_size_bytes`` shortfalls and ``required_strings`` misses — is a
+*weak proxy* and is recorded as an **advisory** only. A content/size check can
+raise a note for the human, but it NEVER fails the proposal and never feeds a
+negative learning signal: an expected string absent from a real deliverable is
+a failure of the string matcher, not of the deliverable.
+
+Hard failures (``missing_files``): the file is absent (no exact path, no fuzzy
+match) or exists but is empty (0 bytes → not produced). Advisories: a non-empty
+file under ``min_size_bytes``, or a ``required_strings`` entry not found
+(matched case-insensitively and whitespace-normalized).
+
+When an expected file is missing, a fuzzy-match fallback searches the parent
+directory for similarly-named files (added suffixes, version numbers, slight
+name variations) without false-positiving on unrelated files.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from pathlib import Path
@@ -33,10 +46,16 @@ class ExpectedOutputs:
 
 @dataclass
 class VerificationResult:
-    """Outcome of a post-dispatch verification check."""
+    """Outcome of a post-dispatch verification check.
+
+    ``missing_files`` are hard failures (deliverable not produced) and drive
+    ``passed``. ``advisories`` are non-fatal notes (size/content proxies) that
+    are surfaced to the human but never fail the proposal.
+    """
 
     passed: bool
-    failures: list[str] = field(default_factory=list)
+    missing_files: list[str] = field(default_factory=list)
+    advisories: list[str] = field(default_factory=list)
 
 
 def parse_expected_outputs(raw: str | None) -> ExpectedOutputs | None:
@@ -62,6 +81,31 @@ def parse_expected_outputs(raw: str | None) -> ExpectedOutputs | None:
         min_size_bytes=int(data.get("min_size_bytes", 0)),
         required_strings=list(data.get("required_strings") or []),
     )
+
+
+def _resolve_path(filepath: str) -> Path:
+    """Expand ``~`` and ``$VARS`` before building a Path.
+
+    ``Path("~/x.md").exists()`` is always False (Python does not expand ``~``),
+    which used to produce spurious 'Missing file' hard-fails on deliverables
+    written to the expanded home path. Expand env vars first, then ``~``.
+    """
+    return Path(os.path.expanduser(os.path.expandvars(filepath)))
+
+
+def _normalize(text: str) -> str:
+    """Collapse all whitespace runs to single spaces and casefold.
+
+    Makes required-string matching forgiving of casing and incidental
+    whitespace/newline differences — the common ways a real deliverable states
+    the same content without the exact literal.
+    """
+    return " ".join(text.split()).casefold()
+
+
+def _content_has(content: str, required: str) -> bool:
+    """True if *required* appears in *content*, ignoring case and whitespace."""
+    return _normalize(required) in _normalize(content)
 
 
 def _find_similar(expected: Path, *, min_ratio: float = 0.6) -> Path | None:
@@ -106,22 +150,24 @@ def _find_similar(expected: Path, *, min_ratio: float = 0.6) -> Path | None:
 
 
 def verify_outputs(expected: ExpectedOutputs) -> VerificationResult:
-    """Check file existence, size, and required content strings.
+    """Check deliverable existence (hard) plus size/content (advisory).
 
-    When an expected file is missing, attempts a fuzzy match against
-    similarly-named files in the same directory.  If a match is found,
-    verification continues against that file (size + content checks)
-    and the result is treated as a pass with a logged warning.
+    A file that is absent (no exact path after ``~``/env expansion, no fuzzy
+    match) or empty (0 bytes) is a hard failure recorded in ``missing_files``
+    and fails the result. A non-empty file under ``min_size_bytes`` and any
+    unmatched ``required_strings`` are recorded in ``advisories`` and do NOT
+    fail the result — string/size are weak proxies for "did it satisfy intent",
+    so they inform but never gate.
 
     This is synchronous filesystem I/O — callers in async contexts should
-    wrap in ``asyncio.to_thread`` if latency is a concern. In practice
-    this runs after a multi-minute CC session, so the overhead is
-    negligible.
+    wrap in ``asyncio.to_thread`` if latency is a concern. In practice this
+    runs after a multi-minute CC session, so the overhead is negligible.
     """
-    failures: list[str] = []
+    missing_files: list[str] = []
+    advisories: list[str] = []
 
     for filepath in expected.files:
-        path = Path(filepath)
+        path = _resolve_path(filepath)
         fuzzy = False
         if not path.exists():
             # Fuzzy fallback: search parent directory for similar files
@@ -130,24 +176,43 @@ def verify_outputs(expected: ExpectedOutputs) -> VerificationResult:
                 path = similar
                 fuzzy = True
             else:
-                failures.append(f"Missing file: {filepath}")
+                missing_files.append(f"Missing file: {filepath}")
                 continue
-        # Use the resolved path in failure messages so operators can find the file
+        # Use the resolved path in messages so operators can find the file
         label = f"{path} (fuzzy match for {filepath})" if fuzzy else filepath
-        size = path.stat().st_size
+
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            missing_files.append(f"Cannot stat {label}: {exc}")
+            continue
+
+        # A 0-byte file is "not produced" — a hard failure.
+        if size == 0:
+            missing_files.append(f"Empty file (0 bytes): {label}")
+            continue
+
+        # Size shortfall is a weak proxy → advisory only.
         if size < expected.min_size_bytes:
-            failures.append(
-                f"File too small: {label} ({size}B < {expected.min_size_bytes}B)"
+            advisories.append(
+                f"File smaller than expected: {label} ({size}B < {expected.min_size_bytes}B)"
             )
+
         if expected.required_strings:
             try:
                 content = path.read_text(errors="replace")
-                for req in expected.required_strings:
-                    if req not in content:
-                        failures.append(
-                            f"Missing required string in {label}: {req!r}"
-                        )
             except OSError as exc:
-                failures.append(f"Cannot read {label}: {exc}")
+                advisories.append(f"Cannot read {label}: {exc}")
+                continue
+            for req in expected.required_strings:
+                if not _content_has(content, req):
+                    advisories.append(
+                        f"Content hint not found verbatim in {label}: "
+                        f"{req!r} — deliverable accepted"
+                    )
 
-    return VerificationResult(passed=len(failures) == 0, failures=failures)
+    return VerificationResult(
+        passed=len(missing_files) == 0,
+        missing_files=missing_files,
+        advisories=advisories,
+    )

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -80,9 +80,14 @@ Every cycle:
    `rank` to each board proposal (1 = highest priority).
 2. **Include an `execution_plan`** for each board proposal — how it would
    be executed, estimated cost, and time. Optionally include
-   `expected_outputs` — a dict with `files` (paths that must exist after
-   dispatch), `min_size_bytes`, and `required_strings`. Auto-verified
-   after completion; failed verification marks the proposal as failed.
+   `expected_outputs` — a dict with `files` (deliverable paths that must
+   exist after dispatch) and, optionally, `min_size_bytes` and
+   `required_strings` (short, distinctive literal anchors you expect
+   verbatim, e.g. a required heading). After completion the system checks
+   these: a **missing or empty file fails** the proposal; `min_size_bytes`
+   and `required_strings` are **advisory only** — a miss is surfaced as a
+   note but keeps the proposal executed (a string is a weak proxy and never
+   fails a real deliverable).
 3. **Mark `recurring: true`** for ongoing operational tasks.
 4. **Unboard** items you no longer need to focus on — output their IDs
    in the `unboarded` array. They stay pending for user decision.
@@ -319,7 +324,7 @@ Use MCP tools first, then output valid JSON:
       "urgency": "low|normal|high|critical",
       "alternatives": "What else you considered",
       "execution_plan": "health check via MCP tools, ~$0.10, ~2 min",
-      "expected_outputs": {"files": ["/path/to/output.md"], "min_size_bytes": 200},
+      "expected_outputs": {"files": ["/path/to/output.md"], "min_size_bytes": 200, "required_strings": ["## Summary"]},
       "rank": 1,
       "recurring": false
     }

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -194,10 +194,14 @@ Every brainstorming cycle:
    to each board proposal (1 = highest priority).
 2. **Include an `execution_plan`** for each board proposal — brief
    description of how it would be executed, estimated cost, and time.
-   Optionally include `expected_outputs` — a dict with `files` (paths
-   that must exist after dispatch), `min_size_bytes`, and
-   `required_strings`. The system auto-verifies these after completion;
-   failed verification marks the proposal as failed and resurfaces it.
+   Optionally include `expected_outputs` — a dict with `files` (deliverable
+   paths that must exist after dispatch) and, optionally, `min_size_bytes`
+   and `required_strings` (short, distinctive literal anchors you expect
+   verbatim, e.g. a required heading). After completion the system checks
+   these: a **missing or empty file fails** the proposal (and resurfaces
+   it); `min_size_bytes` and `required_strings` are **advisory only** — a
+   miss is surfaced as a note but keeps the proposal executed (a string is a
+   weak proxy and never fails a real deliverable).
 3. **Mark `recurring: true`** for proposals that imply ongoing work.
 4. **Unboard** items you no longer want to focus on — output their IDs
    in the `unboarded` array. Unboarded proposals stay pending in the

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from genesis.cc.direct_session import DirectSessionRequest, DirectSessionRunner
+from genesis.cc.direct_session import (
+    DirectSessionRequest,
+    DirectSessionResult,
+    DirectSessionRunner,
+)
 from genesis.cc.session_manager import SessionManager
 from genesis.db.crud import cc_sessions
 
@@ -115,10 +119,14 @@ class TestSpawnRecordsSkillSignal:
             skill_tags=["voice-master"],
         )
         req = DirectSessionRequest(
-            prompt="x", profile="research", skills=["voice-master"],
+            prompt="x",
+            profile="research",
+            skills=["voice-master"],
         )
         result = DirectSessionResult(
-            session_id=sess["id"], success=True, output_text="done",
+            session_id=sess["id"],
+            success=True,
+            output_text="done",
         )
         await runner._store_result(sess["id"], req, result)
 
@@ -191,19 +199,31 @@ class TestBackgroundFallbackRecovery:
 
         sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
         invoker = AsyncMock()
-        invoker.run_streaming = AsyncMock(return_value=CCOutput(
-            session_id="cc-bg", text="done", model_used=roster_model or "claude",
-            cost_usd=0.0, input_tokens=1, output_tokens=1, duration_ms=1, exit_code=0,
-            is_error=False, roster_model=roster_model,
-        ))
+        invoker.run_streaming = AsyncMock(
+            return_value=CCOutput(
+                session_id="cc-bg",
+                text="done",
+                model_used=roster_model or "claude",
+                cost_usd=0.0,
+                input_tokens=1,
+                output_tokens=1,
+                duration_ms=1,
+                exit_code=0,
+                is_error=False,
+                roster_model=roster_model,
+            )
+        )
         runner = DirectSessionRunner(
-            invoker=invoker, session_manager=sm, config_builder=AsyncMock(),
+            invoker=invoker,
+            session_manager=sm,
+            config_builder=AsyncMock(),
             runtime=SimpleNamespace(_db=db),
         )
         runner._build_invocation = lambda _req, _sid: CCInvocation(prompt="x")
         sess = await sm.create_background(
             session_type=SessionType.BACKGROUND_TASK,
-            model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+            model=CCModel.SONNET,
+            effort=EffortLevel.MEDIUM,
         )
         result = await runner._run_session(DirectSessionRequest(prompt="t"), sess["id"])
         assert result.success is True
@@ -228,7 +248,9 @@ class TestBackgroundFallbackRecovery:
         assert state.is_fallback is False
 
     @pytest.mark.asyncio
-    async def test_native_claude_success_with_peer_home_does_not_clear(self, db, tmp_path, monkeypatch):
+    async def test_native_claude_success_with_peer_home_does_not_clear(
+        self, db, tmp_path, monkeypatch
+    ):
         # The bug case: home is glm-5.2 (down); an intentional native-Claude run
         # succeeds but must NOT clear the glm fallback (Claude is ~always up).
         state = await self._run(db, tmp_path, monkeypatch, home="glm-5.2", roster_model="claude")
@@ -257,25 +279,36 @@ async def test_run_session_isolates_and_cleans_sandbox(db, tmp_path, monkeypatch
         captured["existed_at_run"] = p.exists()
         captured["path"] = str(p)
         return CCOutput(
-            session_id="cc-bg", text="done", model_used="sonnet",
-            cost_usd=0.0, input_tokens=1, output_tokens=1, duration_ms=1,
-            exit_code=0, is_error=False, roster_model=None,
+            session_id="cc-bg",
+            text="done",
+            model_used="sonnet",
+            cost_usd=0.0,
+            input_tokens=1,
+            output_tokens=1,
+            duration_ms=1,
+            exit_code=0,
+            is_error=False,
+            roster_model=None,
         )
 
     sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
     invoker = AsyncMock()
     invoker.run_streaming = _check_sandbox_live
     runner = DirectSessionRunner(
-        invoker=invoker, session_manager=sm, config_builder=AsyncMock(),
+        invoker=invoker,
+        session_manager=sm,
+        config_builder=AsyncMock(),
         runtime=SimpleNamespace(_db=db),
     )
     # Mirror the real _build_invocation: wire the per-session sandbox tmpdir.
     runner._build_invocation = lambda _req, sid: CCInvocation(
-        prompt="x", claude_code_tmpdir=_bg_session_sandbox(sid),
+        prompt="x",
+        claude_code_tmpdir=_bg_session_sandbox(sid),
     )
     sess = await sm.create_background(
         session_type=SessionType.BACKGROUND_TASK,
-        model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+        model=CCModel.SONNET,
+        effort=EffortLevel.MEDIUM,
     )
     result = await runner._run_session(DirectSessionRequest(prompt="t"), sess["id"])
 
@@ -403,3 +436,83 @@ async def test_run_session_cancelled_records_proposal_outcome(db):
     runner._record_proposal_outcome.assert_awaited_once()
     result = runner._record_proposal_outcome.await_args.args[1]
     assert result.success is False
+
+
+# --- post-dispatch verification routing (advisory vs hard-fail) ---
+
+
+def _verif_runner(db):
+    from types import SimpleNamespace
+
+    return DirectSessionRunner(
+        invoker=AsyncMock(),
+        session_manager=AsyncMock(),
+        config_builder=AsyncMock(),
+        runtime=SimpleNamespace(_db=db, _memory_store=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_proposal_outputs_content_miss_is_advisory(db, tmp_path):
+    """A file that exists but misses a required string → advisory, not missing."""
+    from genesis.db.crud.ego import create_proposal
+
+    f = tmp_path / "deliverable.md"
+    f.write_text("A real report body that addresses the ask.\n")
+    await create_proposal(
+        db,
+        id="prop-adv",
+        action_type="dispatch",
+        content="x",
+        status="executed",
+        expected_outputs=json.dumps({"files": [str(f)], "required_strings": ["## Summary"]}),
+    )
+    vres = await _verif_runner(db)._verify_proposal_outputs(db, "prop-adv")
+    assert vres is not None
+    assert vres.missing_files == []
+    assert vres.advisories  # a note, but not a failure
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_advisory_keeps_executed(db, tmp_path):
+    """A content-only miss keeps the proposal 'executed' (positive learning
+    signal via |completed:), NOT flipped to 'failed'."""
+    from genesis.db.crud.ego import create_proposal, get_proposal
+
+    f = tmp_path / "deliverable.md"
+    f.write_text("A real report body.\n")
+    await create_proposal(
+        db,
+        id="prop-exec",
+        action_type="dispatch",
+        content="x",
+        status="executed",
+        expected_outputs=json.dumps({"files": [str(f)], "required_strings": ["## Summary"]}),
+    )
+    req = DirectSessionRequest(prompt="t", caller_context="ego_proposal:prop-exec")
+    res = DirectSessionResult(session_id="s1", success=True, output_text="done")
+    await _verif_runner(db)._record_proposal_outcome(req, res)
+    prop = await get_proposal(db, "prop-exec")
+    assert prop["status"] == "executed"
+    assert "|completed:" in (prop["user_response"] or "")
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_missing_file_marks_failed(db, tmp_path):
+    """A genuinely missing deliverable still hard-fails (regression guard)."""
+    from genesis.db.crud.ego import create_proposal, get_proposal
+
+    await create_proposal(
+        db,
+        id="prop-miss",
+        action_type="dispatch",
+        content="x",
+        status="executed",
+        expected_outputs=json.dumps({"files": [str(tmp_path / "never-written.md")]}),
+    )
+    req = DirectSessionRequest(prompt="t", caller_context="ego_proposal:prop-miss")
+    res = DirectSessionResult(session_id="s2", success=True, output_text="claims done")
+    await _verif_runner(db)._record_proposal_outcome(req, res)
+    prop = await get_proposal(db, "prop-miss")
+    assert prop["status"] == "failed"
+    assert "verification_failed" in (prop["user_response"] or "")

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -498,6 +498,32 @@ async def test_record_outcome_advisory_keeps_executed(db, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_record_outcome_long_output_preserves_advisory(db, tmp_path):
+    """A long output_text must not truncate the advisory note off the summary —
+    the advisory is budgeted into the 1000-char cap."""
+    from genesis.db.crud.ego import create_proposal, get_proposal
+
+    f = tmp_path / "deliverable.md"
+    f.write_text("A real report body.\n")
+    await create_proposal(
+        db,
+        id="prop-long",
+        action_type="dispatch",
+        content="x",
+        status="executed",
+        expected_outputs=json.dumps({"files": [str(f)], "required_strings": ["## Not Present"]}),
+    )
+    req = DirectSessionRequest(prompt="t", caller_context="ego_proposal:prop-long")
+    res = DirectSessionResult(session_id="s3", success=True, output_text="x" * 1500)
+    await _verif_runner(db)._record_proposal_outcome(req, res)
+    prop = await get_proposal(db, "prop-long")
+    ur = prop["user_response"] or ""
+    assert prop["status"] == "executed"
+    assert "|completed:" in ur  # polarity preserved
+    assert "verification advisories" in ur  # advisory survived the truncation
+
+
+@pytest.mark.asyncio
 async def test_record_outcome_missing_file_marks_failed(db, tmp_path):
     """A genuinely missing deliverable still hard-fails (regression guard)."""
     from genesis.db.crud.ego import create_proposal, get_proposal

--- a/tests/test_db/test_d0005_reverify_false_dispatch_failures.py
+++ b/tests/test_db/test_d0005_reverify_false_dispatch_failures.py
@@ -1,0 +1,94 @@
+"""d0005 — re-verify dispatch proposals false-failed by the old string/size gate.
+
+Flips status='failed' verification rows to 'executed' when the deliverable now
+passes AND every file exists at its EXACT resolved path. Fuzzy-only and
+genuinely-missing rows stay 'failed'. Idempotent; no-op on a fresh install.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import genesis.db.data_migrations.d0005_reverify_false_dispatch_failures as d0005
+
+
+def _seed(path, rows) -> None:
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE ego_proposals (id TEXT PRIMARY KEY, status TEXT, "
+        "user_response TEXT, expected_outputs TEXT)"
+    )
+    db.executemany(
+        "INSERT INTO ego_proposals (id, status, user_response, expected_outputs) "
+        "VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    db.commit()
+    db.close()
+
+
+def test_flips_exact_pass_leaves_missing_failed(tmp_path, monkeypatch):
+    f = tmp_path / "deliverable.md"
+    f.write_text("## Summary\nA real, complete deliverable body.\n")
+    # A content-miss (advisory-only under the fixed logic) must still flip.
+    flip_eo = json.dumps({"files": [str(f)], "required_strings": ["## Not Present Heading"]})
+    missing_eo = json.dumps({"files": [str(tmp_path / "never-written.md")]})
+    _seed(
+        tmp_path / "genesis.db",
+        [
+            ("p-flip", "failed", "session:x|verification_failed:Missing string", flip_eo),
+            ("p-missing", "failed", "session:y|verification_failed:Missing file", missing_eo),
+        ],
+    )
+    monkeypatch.setattr(d0005, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+
+    assert d0005.verify() is False
+    assert d0005.migrate() == {"flipped": 1, "scanned": 2}
+    assert d0005.verify() is True
+
+    db = sqlite3.connect(tmp_path / "genesis.db")
+    status = dict(db.execute("SELECT id, status FROM ego_proposals").fetchall())
+    ur = db.execute("SELECT user_response FROM ego_proposals WHERE id = 'p-flip'").fetchone()[0]
+    db.close()
+    assert status["p-flip"] == "executed"
+    assert "|completed:" in ur  # reads as a positive outcome for the harvester
+    assert status["p-missing"] == "failed"  # genuinely absent → stays failed
+
+
+def test_fuzzy_only_match_is_not_flipped(tmp_path, monkeypatch):
+    """A similarly-named file (exact path absent) must NOT flip — no heuristic
+    reliably tells a rename from an unrelated file, so the migration is
+    exact-match only."""
+    (tmp_path / "report-v2.md").write_text("## Summary\nbody\n")
+    eo = json.dumps({"files": [str(tmp_path / "report.md")], "required_strings": ["## Summary"]})
+    _seed(tmp_path / "genesis.db", [("p-fuzzy", "failed", "z|verification_failed:x", eo)])
+    monkeypatch.setattr(d0005, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+
+    assert d0005.migrate()["flipped"] == 0
+    db = sqlite3.connect(tmp_path / "genesis.db")
+    got = db.execute("SELECT status FROM ego_proposals WHERE id = 'p-fuzzy'").fetchone()
+    db.close()
+    assert got[0] == "failed"
+
+
+def test_migrate_is_idempotent(tmp_path, monkeypatch):
+    f = tmp_path / "d.md"
+    f.write_text("a real deliverable body\n")
+    _seed(
+        tmp_path / "genesis.db",
+        [("p1", "failed", "q|verification_failed:x", json.dumps({"files": [str(f)]}))],
+    )
+    monkeypatch.setattr(d0005, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+
+    assert d0005.migrate()["flipped"] == 1
+    assert d0005.migrate()["flipped"] == 0
+    assert d0005.verify() is True
+
+
+def test_fresh_install_is_noop(tmp_path, monkeypatch):
+    _seed(tmp_path / "genesis.db", [])
+    monkeypatch.setattr(d0005, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+
+    assert d0005.verify() is True
+    assert d0005.migrate() == {"flipped": 0, "scanned": 0}

--- a/tests/test_ego/test_verification.py
+++ b/tests/test_ego/test_verification.py
@@ -233,8 +233,10 @@ def test_find_similar_nonexistent_parent():
 # --- verify_outputs with fuzzy matching ---
 
 
-def test_verify_fuzzy_match_passes(tmp_path: Path):
-    """Missing exact file but fuzzy match found — should pass cleanly."""
+def test_verify_fuzzy_match_passes_but_flagged(tmp_path: Path):
+    """Missing exact file but fuzzy match found — passes (never false-fails a
+    real rename), but the fuzzy substitution is flagged as an advisory so a
+    possibly-wrong file never passes silently."""
     actual = tmp_path / "arxiv-related-work-draft-v1.md"
     actual.write_text("## Related Work\nGenesis is a cognitive architecture.")
     expected = ExpectedOutputs(
@@ -245,23 +247,44 @@ def test_verify_fuzzy_match_passes(tmp_path: Path):
     result = verify_outputs(expected)
     assert result.passed is True
     assert result.missing_files == []
-    assert result.advisories == []
+    # Content matched, but the fuzzy substitution itself is still surfaced.
+    assert any("fuzzy filename match" in a.lower() for a in result.advisories)
 
 
-def test_verify_fuzzy_match_content_miss_is_advisory(tmp_path: Path):
-    """A fuzzy-matched file that misses a content string → advisory, not fail."""
+def test_verify_fuzzy_match_never_silent(tmp_path: Path):
+    """Any fuzzy substitution is surfaced as an advisory, even when the content
+    check also passes — a possibly-wrong similarly-named file must never mark a
+    proposal produced silently. No heuristic (name OR content) reliably
+    separates a rename from an unrelated file, so we flag rather than gate.
+    """
     actual = tmp_path / "report-v2.md"
-    actual.write_text("Some content without the required heading.")
+    actual.write_text("Some reworded content without the exact heading.")
     expected = ExpectedOutputs(
         files=[str(tmp_path / "report.md")],
         required_strings=["## Summary"],
     )
     result = verify_outputs(expected)
+    # Still passes (never a false-fail on a possible rename)...
     assert result.passed is True
     assert result.missing_files == []
-    assert any("## Summary" in a for a in result.advisories)
-    # Advisory should reference the fuzzy-matched path for debugging
-    assert any("fuzzy match" in a for a in result.advisories)
+    # ...but the fuzzy substitution is loudly flagged for verification.
+    assert any("fuzzy filename match" in a.lower() for a in result.advisories)
+    assert any("report-v2.md" in a for a in result.advisories)
+
+
+def test_verify_fuzzy_partial_string_match_accepted(tmp_path: Path):
+    """A fuzzy rename that shares AT LEAST ONE anchor is accepted; the missing
+    anchors are advisory only (it is the deliverable, just partially reworded)."""
+    actual = tmp_path / "report-v2.md"
+    actual.write_text("## Summary\nReal reworded body.\n")
+    expected = ExpectedOutputs(
+        files=[str(tmp_path / "report.md")],
+        required_strings=["## Summary", "## Appendix"],  # one present, one absent
+    )
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.missing_files == []
+    assert any("## Appendix" in a for a in result.advisories)
 
 
 def test_verify_no_fuzzy_for_exact_match(tmp_path: Path):

--- a/tests/test_ego/test_verification.py
+++ b/tests/test_ego/test_verification.py
@@ -54,11 +54,13 @@ def test_parse_valid_minimal():
 
 def test_parse_valid_full():
     """Full expected_outputs with all fields."""
-    raw = json.dumps({
-        "files": ["/tmp/a.md", "/tmp/b.md"],
-        "min_size_bytes": 500,
-        "required_strings": ["## Summary", "## Conclusion"],
-    })
+    raw = json.dumps(
+        {
+            "files": ["/tmp/a.md", "/tmp/b.md"],
+            "min_size_bytes": 500,
+            "required_strings": ["## Summary", "## Conclusion"],
+        }
+    )
     result = parse_expected_outputs(raw)
     assert result is not None
     assert result.files == ["/tmp/a.md", "/tmp/b.md"]
@@ -80,30 +82,51 @@ def test_verify_all_pass(tmp_path: Path):
     )
     result = verify_outputs(expected)
     assert result.passed is True
-    assert result.failures == []
+    assert result.missing_files == []
+    assert result.advisories == []
 
 
 def test_verify_missing_file(tmp_path: Path):
-    """Missing file produces a failure."""
+    """Missing file is a hard failure (the deliverable was not produced)."""
     expected = ExpectedOutputs(files=[str(tmp_path / "nonexistent.md")])
     result = verify_outputs(expected)
     assert result.passed is False
-    assert len(result.failures) == 1
-    assert "Missing file" in result.failures[0]
+    assert len(result.missing_files) == 1
+    assert "Missing file" in result.missing_files[0]
 
 
-def test_verify_file_too_small(tmp_path: Path):
-    """File exists but under min_size_bytes."""
+def test_verify_file_too_small_is_advisory(tmp_path: Path):
+    """A non-empty file under min_size_bytes is an advisory, NOT a hard fail.
+
+    Size is a weak proxy — a shorter-than-expected but real deliverable still
+    succeeded; we surface a note but never fail on it.
+    """
     f = tmp_path / "small.md"
-    f.write_text("hi")
+    f.write_text("hi")  # non-empty, but tiny
     expected = ExpectedOutputs(files=[str(f)], min_size_bytes=1000)
     result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.missing_files == []
+    assert any("small" in a.lower() for a in result.advisories)
+
+
+def test_verify_empty_file_is_hard_fail(tmp_path: Path):
+    """A 0-byte file counts as 'not produced' — a hard failure."""
+    f = tmp_path / "empty.md"
+    f.write_text("")
+    expected = ExpectedOutputs(files=[str(f)])
+    result = verify_outputs(expected)
     assert result.passed is False
-    assert "too small" in result.failures[0].lower()
+    assert len(result.missing_files) == 1
+    assert "empty" in result.missing_files[0].lower()
 
 
-def test_verify_missing_required_string(tmp_path: Path):
-    """File exists, right size, but missing a required string."""
+def test_verify_missing_required_string_is_advisory(tmp_path: Path):
+    """A missing required string is advisory only — the deliverable exists.
+
+    This is the core regression lock: a string miss is a failure of the
+    matcher, NOT of the deliverable, and must NEVER hard-fail the proposal.
+    """
     f = tmp_path / "output.md"
     f.write_text("## Introduction\nSome content here.\n")
     expected = ExpectedOutputs(
@@ -112,12 +135,13 @@ def test_verify_missing_required_string(tmp_path: Path):
         required_strings=["## Summary"],
     )
     result = verify_outputs(expected)
-    assert result.passed is False
-    assert "Missing required string" in result.failures[0]
+    assert result.passed is True
+    assert result.missing_files == []
+    assert any("## Summary" in a for a in result.advisories)
 
 
 def test_verify_multiple_files(tmp_path: Path):
-    """Multiple files: one exists, one doesn't."""
+    """Multiple files: one exists, one doesn't → hard fail on the missing one."""
     good = tmp_path / "good.md"
     good.write_text("content")
     expected = ExpectedOutputs(
@@ -125,8 +149,8 @@ def test_verify_multiple_files(tmp_path: Path):
     )
     result = verify_outputs(expected)
     assert result.passed is False
-    assert len(result.failures) == 1
-    assert "missing.md" in result.failures[0]
+    assert len(result.missing_files) == 1
+    assert "missing.md" in result.missing_files[0]
 
 
 def test_verify_no_files():
@@ -210,7 +234,7 @@ def test_find_similar_nonexistent_parent():
 
 
 def test_verify_fuzzy_match_passes(tmp_path: Path):
-    """Missing exact file but fuzzy match found — should pass."""
+    """Missing exact file but fuzzy match found — should pass cleanly."""
     actual = tmp_path / "arxiv-related-work-draft-v1.md"
     actual.write_text("## Related Work\nGenesis is a cognitive architecture.")
     expected = ExpectedOutputs(
@@ -220,11 +244,12 @@ def test_verify_fuzzy_match_passes(tmp_path: Path):
     )
     result = verify_outputs(expected)
     assert result.passed is True
-    assert result.failures == []
+    assert result.missing_files == []
+    assert result.advisories == []
 
 
-def test_verify_fuzzy_match_checks_content(tmp_path: Path):
-    """Fuzzy-matched file still must pass content checks."""
+def test_verify_fuzzy_match_content_miss_is_advisory(tmp_path: Path):
+    """A fuzzy-matched file that misses a content string → advisory, not fail."""
     actual = tmp_path / "report-v2.md"
     actual.write_text("Some content without the required heading.")
     expected = ExpectedOutputs(
@@ -232,10 +257,11 @@ def test_verify_fuzzy_match_checks_content(tmp_path: Path):
         required_strings=["## Summary"],
     )
     result = verify_outputs(expected)
-    assert result.passed is False
-    assert any("Missing required string" in f for f in result.failures)
-    # Failure message should reference the fuzzy-matched path for debugging
-    assert any("fuzzy match" in f for f in result.failures)
+    assert result.passed is True
+    assert result.missing_files == []
+    assert any("## Summary" in a for a in result.advisories)
+    # Advisory should reference the fuzzy-matched path for debugging
+    assert any("fuzzy match" in a for a in result.advisories)
 
 
 def test_verify_no_fuzzy_for_exact_match(tmp_path: Path):
@@ -248,3 +274,79 @@ def test_verify_no_fuzzy_for_exact_match(tmp_path: Path):
     expected = ExpectedOutputs(files=[str(exact)])
     result = verify_outputs(expected)
     assert result.passed is True
+
+
+# --- path expansion (Class B: ~ and $VARS were never expanded) ---
+
+
+def test_verify_expands_tilde_path(tmp_path: Path, monkeypatch):
+    """A ``~/...`` file path must be expanded before the existence check.
+
+    Regression lock: ``Path("~/x.md").exists()`` is ALWAYS False (Python does
+    not expand ``~``), which produced spurious 'Missing file' hard-fails on
+    real deliverables written to the expanded home path.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "report.md").write_text("## Summary\nReal deliverable.\n")
+    expected = ExpectedOutputs(
+        files=["~/report.md"],
+        min_size_bytes=5,
+        required_strings=["## Summary"],
+    )
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.missing_files == []
+    assert result.advisories == []
+
+
+def test_verify_expands_env_var_path(tmp_path: Path, monkeypatch):
+    """A ``$VAR/...`` file path must be expanded before the existence check."""
+    monkeypatch.setenv("GENESIS_OUT", str(tmp_path))
+    (tmp_path / "report.md").write_text("content here")
+    expected = ExpectedOutputs(files=["$GENESIS_OUT/report.md"])
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.missing_files == []
+
+
+# --- forgiving (advisory-only) string matching (Class A) ---
+
+
+def test_verify_required_string_case_insensitive(tmp_path: Path):
+    """Required-string match is case-insensitive — no advisory on casing diff."""
+    f = tmp_path / "output.md"
+    f.write_text("## confirm with ram before building\n")
+    expected = ExpectedOutputs(files=[str(f)], required_strings=["Confirm With Ram"])
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.advisories == []
+
+
+def test_verify_required_string_whitespace_normalized(tmp_path: Path):
+    """Internal whitespace differences don't trip the matcher."""
+    f = tmp_path / "output.md"
+    f.write_text("##   Summary\nbody\n")  # extra spaces
+    expected = ExpectedOutputs(files=[str(f)], required_strings=["## Summary"])
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.advisories == []
+
+
+def test_verify_content_miss_never_hard_fails(tmp_path: Path):
+    """SOC-blueprint class: a deliverable that addressed intent via different
+    phrasing (e.g. '[CONFIRM-RAM]' + a question list, not the literal
+    'Confirm with Ram') gets an advisory but NEVER a hard fail."""
+    f = tmp_path / "wf-blueprint.md"
+    f.write_text(
+        "## 7. Confirm-before-building — the question list for Ram\n"
+        "Every [CONFIRM-RAM] guess above is resolved by answering these.\n"
+    )
+    expected = ExpectedOutputs(
+        files=[str(f)],
+        min_size_bytes=10,
+        required_strings=["Confirm with Ram"],
+    )
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.missing_files == []
+    assert any("Confirm with Ram" in a for a in result.advisories)

--- a/tests/test_ego/test_verification.py
+++ b/tests/test_ego/test_verification.py
@@ -110,6 +110,18 @@ def test_verify_file_too_small_is_advisory(tmp_path: Path):
     assert any("small" in a.lower() for a in result.advisories)
 
 
+def test_verify_directory_is_not_a_deliverable(tmp_path: Path):
+    """A directory at the expected path is not a produced file → hard fail
+    (guards against st_size on a dir reading as a non-empty 'file')."""
+    d = tmp_path / "output.md"  # a directory sitting where a file was expected
+    d.mkdir()
+    (d / "child.txt").write_text("x")  # non-empty dir → st_size != 0 (exposes the bug)
+    expected = ExpectedOutputs(files=[str(d)])
+    result = verify_outputs(expected)
+    assert result.passed is False
+    assert result.missing_files
+
+
 def test_verify_empty_file_is_hard_fail(tmp_path: Path):
     """A 0-byte file counts as 'not produced' — a hard failure."""
     f = tmp_path / "empty.md"


### PR DESCRIPTION
## Problem

Post-dispatch deliverable verification hard-failed an ego proposal (status → `failed`) whenever a `required_strings` entry was absent or a file fell under `min_size_bytes`. On real data this false-failed **complete deliverables** (a writer that addressed the intent via different phrasing) — and, worse, fed a **negative learning signal** into the feedback harvester (`feedback/harvest.py` reads the `user_response` suffix: `|completed:`→positive, and a `failed` status → negative `EXECUTION_OUTCOME`). Enumerating the install's 6 `verification_failed` proposals, **4 of 6 were false negatives**.

Two compounding mechanism bugs:
- `~`/`$VAR` file paths were never expanded — `Path("~/x").exists()` is always `False`, guaranteeing a spurious "Missing file" **and** a dead fuzzy fallback.
- `required_strings` matched exact, case-sensitive substrings only.

## Change

**File existence is the only trustworthy "a real deliverable was produced" signal.** A missing OR empty (0-byte) file hard-fails; `min_size_bytes` and `required_strings` become **advisory only** — surfaced as a note in the dispatch debrief and the `|completed:` outcome, never failing the proposal and never poisoning the learning signal. A string miss is a failure of the matcher, not of the work.

- `ego/verification.py`: `VerificationResult` splits into `missing_files` (hard) + `advisories` (soft); path expansion; case-insensitive + whitespace-normalized matching.
- Fuzzy filename matches (exact path absent) still pass — no heuristic (name-similarity *or* content) reliably separates a rename from an unrelated similar file — but are **loudly flagged** as an advisory so a possibly-wrong file never passes silently.
- `cc/direct_session.py`: routing — `missing_files` → hard-fail (unchanged); advisories-only → stays `executed` (positive `|completed:` learning signal), advisories folded into the summary + debrief.
- Ego identity prompts updated to describe the advisory model (corrects the now-false "failed verification marks the proposal as failed").
- **`d0005` data-migration**: re-verifies proposals stranded at `failed` and flips those that now pass at their **exact** path. Generalizable (every install), idempotent, no-op on a fresh clone.

## Tests

TDD throughout: `tests/test_ego/test_verification.py` (advisory vs hard-fail, path expansion, empty-file, fuzzy-flag), `tests/test_cc/test_direct_session.py` (end-to-end routing: advisory keeps `executed`, missing file → `failed`), `tests/test_db/test_d0005_*` (exact-flip, fuzzy-skip, idempotent, fresh-install). Behavior-diff on the live proposal that prompted this confirms it now passes with an advisory.

## Follow-ups (separate)
- **LLM semantic verifier** — the real "did it satisfy intent / is this the right file" tool; retires the string/fuzzy heuristics.
- Verification runs before a late file write (a race observed once); re-verify at a later checkpoint.
- The `d0005` flip corrects proposal status but not the already-harvested negative `ln` outcome (unique-key won't overwrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)