### PR TITLE
feat(session-awareness): inline PR-watch nudge — surface steward notifications in-session

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,16 @@
                 ]
             },
             {
+                "matcher": "startup|resume|clear",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook surface_pr_updates.py",
+                        "timeout": 10
+                    }
+                ]
+            },
+            {
                 "matcher": "startup|resume|clear|compact",
                 "hooks": [
                     {

--- a/config/pr_watch.yaml
+++ b/config/pr_watch.yaml
@@ -1,0 +1,27 @@
+# PR-watch inline surface — read live by the surface_pr_updates SessionStart
+# hook (this file + ~/.genesis/config/pr_watch.local.yaml), so a
+# settings_update("pr_watch", {...}) or a hand edit takes effect at the next
+# session start — no restart.
+#
+# What it does: mirrors the upstream-pr-steward campaign's own owner
+# notifications (already in outreach_history) inline, as a one-line nudge, so a
+# tracked-PR status change you missed on Telegram still reaches you next
+# foreground session.
+#
+# Master switch: false stops the hook before any DB/sidecar work.
+# Hook-level kill switch (separate, stdlib-cheap): GENESIS_PR_WATCH_DISABLED=1
+# short-circuits the hook before it imports anything.
+enabled: true
+
+# How far back to scan outreach_history for steward notifications to surface.
+# Also the sidecar-prune horizon (entries for pings older than this fall out of
+# the scan and are dropped from the sidecar automatically).
+lookback_days: 30
+
+# A surfaced update keeps reappearing at session start until it is this many
+# days old, then it stops nagging. "Surface until you notice it, not forever."
+resurface_days: 10
+
+# Max distinct updates rendered on the nudge line; overflow collapses to
+# "+N more".
+max_surface: 5

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -472,9 +472,26 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: b662f3e3 2026-07-17
+verified: 6d79e097 2026-07-21
 ```
 
+- **PR-watch inline surface (2026-07-21)**: a SessionStart hook
+  (`scripts/surface_pr_updates.py` → `session_awareness/pr_watch.py`) mirrors the
+  `upstream-pr-steward` campaign's own owner notifications — the ones it already
+  logs to `outreach_history` (category `notification`, topic `%steward%`) when a
+  tracked EXTERNAL PR changes — into foreground CC sessions as a one-line
+  `[PRs] …` nudge, so a status change missed on Telegram still reaches the user.
+  Read-only, **home-anchored DB** (NOT `genesis_db_path()`/`repo_root()`, which
+  would read an empty `<worktree>/data/` — the same trap `_charter_db_path`
+  avoids). Seen-state is a home-anchored JSON sidecar
+  (`~/.genesis/pr_watch/seen.json`), NOT `outreach_history.opened_at` (that
+  column is unwired, always NULL); a change resurfaces each session for
+  `resurface_days` then stops, and the sidecar self-prunes to the `lookback_days`
+  window (no retention step). Lever: settings domain `pr_watch`
+  (`config/pr_watch.yaml` + `pr_watch_config.py`) + `GENESIS_PR_WATCH_DISABLED`
+  kill switch; skips dispatched sessions (`GENESIS_CC_SESSION=1`) so the human's
+  next foreground session still gets the nudge. The campaign's discovery/notify
+  behavior lives in its install-local strategy doc (campaigns ship zero defaults).
 - **Infra protection posture (2026-07-16; network plane 2026-07-17)**: hourly
   `_check_infra_protection_posture` reads the infra profile's effective facts
   and raises one `high` `infrastructure_alert` when a memory-plane protection

--- a/scripts/surface_pr_updates.py
+++ b/scripts/surface_pr_updates.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surface unseen upstream-PR-steward notifications inline.
+
+The upstream-pr-steward campaign already Telegram-pings the owner when a tracked
+external PR changes, and logs each ping to outreach_history. Those pings are
+easy to miss on Telegram, so this hook mirrors the unseen ones into the CC
+session as a one-line nudge:
+
+    [PRs] 1 external-PR update you may not have seen — PR steward: … (Jul 9).
+    Ask "show PRs" to review.
+
+Its stdout becomes context visible to Claude at session start (same contract as
+scripts/check_stale_pending.py). The whole body is fail-open: any error, missing
+table, or disabled config -> print nothing, never block session start.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime
+
+
+def main() -> None:
+    # Cheapest gates first — before importing genesis modules.
+    if os.environ.get("GENESIS_PR_WATCH_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    # Genesis-dispatched (background) sessions must not consume the human's
+    # unseen pings — leave the sidecar untouched so the next FOREGROUND session
+    # still surfaces them.
+    if os.environ.get("GENESIS_CC_SESSION") == "1":
+        return
+
+    # Make src/ importable when run outside an editable install (mirrors other
+    # hooks; the genesis-hook launcher already selects the right venv).
+    repo_src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+    if repo_src not in sys.path:
+        sys.path.insert(0, repo_src)
+
+    try:
+        from genesis.session_awareness import pr_watch, pr_watch_config
+
+        cfg = pr_watch_config.load_config()
+        if not pr_watch_config.is_enabled(cfg):
+            return
+
+        now = datetime.now(UTC)
+        lookback = pr_watch_config.knob_int(cfg, "lookback_days")
+        resurface = pr_watch_config.knob_int(cfg, "resurface_days")
+        max_surface = pr_watch_config.knob_int(cfg, "max_surface")
+
+        notifs = pr_watch.read_steward_notifications(pr_watch.db_path(), lookback, now)
+        if not notifs:
+            return
+
+        side_path = pr_watch.sidecar_path()
+        surfaced, _existed = pr_watch.load_sidecar(side_path)
+        lines, new_surfaced = pr_watch.select_to_surface(
+            notifs, surfaced, now, resurface, max_surface
+        )
+        # Persist seen-state even if nothing new to show (records baselines).
+        pr_watch.save_sidecar(side_path, new_surfaced)
+
+        text = pr_watch.format_injection(lines)
+        if text:
+            print(text)
+            sys.stdout.flush()
+    except Exception:
+        return  # Never block session start.
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/db/crud/outreach.py
+++ b/src/genesis/db/crud/outreach.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+
 import aiosqlite
 
 from genesis.outreach.types import POSITIVE_ENGAGEMENT_SQL_IN as _POSITIVE_IN
@@ -224,3 +226,41 @@ async def count_recent(
     )
     row = await cursor.fetchone()
     return row[0] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Sync version (for hook context)
+# ---------------------------------------------------------------------------
+
+
+def get_notifications_by_topic_sync(
+    db_path: str,
+    *,
+    topic_like: str,
+    timeout: float = 2.0,
+) -> list[dict]:
+    """Delivered owner-notifications whose topic matches ``topic_like`` (SQL
+    LIKE), newest first. Read-only (``mode=ro``, WAL-safe). Returns [] on any
+    error.
+
+    Sync sibling of the async readers above -- mirrors the session_heartbeats
+    async+sync split: a SessionStart hook needs a fast synchronous read and
+    cannot drive the async runtime connection.
+    """
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=timeout)
+        try:
+            conn.execute("PRAGMA busy_timeout=300")
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT id, topic, delivered_at FROM outreach_history "
+                "WHERE category = 'notification' AND topic LIKE ? "
+                "AND delivered_at IS NOT NULL "
+                "ORDER BY delivered_at DESC",
+                (topic_like,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+    except Exception:
+        return []

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -132,6 +132,20 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # each worker run is a fresh process
     ),
+    "pr_watch": SettingsDomain(
+        name="pr_watch",
+        description=(
+            "PR-watch inline surface — master `enabled` plus lookback/resurface/"
+            "max_surface knobs. Mirrors the upstream-pr-steward campaign's own "
+            "owner notifications into foreground CC sessions as a one-line nudge, "
+            "so a tracked-PR status change missed on Telegram still reaches the "
+            "user next session. Read live by the SessionStart hook — takes effect "
+            "next session start. Hook kill switch: GENESIS_PR_WATCH_DISABLED=1."
+        ),
+        config_filename="pr_watch.yaml",
+        readonly=False,
+        needs_restart=False,  # read fresh by each SessionStart hook invocation
+    ),
     "skill_evolution_gate": SettingsDomain(
         name="skill_evolution_gate",
         description=(
@@ -936,6 +950,24 @@ def _validate_repo_pulse(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_pr_watch(changes: dict) -> list[str]:
+    """Validate pr-watch lever changes (see
+    genesis.session_awareness.pr_watch_config)."""
+    from genesis.session_awareness.pr_watch_config import _INT_KNOBS
+
+    errors: list[str] = []
+    valid_keys = ("enabled", *_INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 def _validate_memory_recall(changes: dict) -> list[str]:
     """Validate memory_recall changes (see genesis.memory.graph_expansion).
 
@@ -1021,6 +1053,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "session_ledger_shadow": _validate_session_ledger_shadow,
     "ws2_ledger": _validate_ws2_ledger,
     "repo_pulse": _validate_repo_pulse,
+    "pr_watch": _validate_pr_watch,
     "skill_evolution_gate": _validate_skill_evolution_gate,
     "cc_roster": _validate_cc_roster,
     "resilience": _validate_resilience,

--- a/src/genesis/session_awareness/pr_watch.py
+++ b/src/genesis/session_awareness/pr_watch.py
@@ -29,12 +29,12 @@ import contextlib
 import json
 import logging
 import os
-import sqlite3
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from genesis.db.crud import outreach as outreach_crud
 from genesis.env import genesis_home
 
 logger = logging.getLogger(__name__)
@@ -84,32 +84,25 @@ def _parse_ts(value: Any) -> datetime | None:
 def read_steward_notifications(
     db_file: Path, lookback_days: int, now: datetime
 ) -> list[dict[str, Any]]:
-    """Recent steward owner-notifications, newest first. Any error -> []."""
-    cutoff = now.timestamp() - lookback_days * 86400
-    try:
-        if not db_file.exists():
-            return []
-        conn = sqlite3.connect(f"file:{db_file}?mode=ro", uri=True, timeout=2)
-        try:
-            conn.execute("PRAGMA busy_timeout=300")
-            rows = conn.execute(
-                "SELECT id, topic, delivered_at FROM outreach_history "
-                "WHERE category = 'notification' AND topic LIKE ? "
-                "AND delivered_at IS NOT NULL "
-                "ORDER BY delivered_at DESC",
-                (_TOPIC_LIKE,),
-            ).fetchall()
-        finally:
-            conn.close()
-    except Exception:
-        return []
+    """Recent steward owner-notifications, newest first. Any error -> [].
 
+    The DB read is delegated to the crud layer
+    (``db.crud.outreach.get_notifications_by_topic_sync`` — a read-only sync
+    reader, the hook-context sibling of the async outreach readers). This
+    function keeps only the lookback windowing (tz-safe via ``_parse_ts``).
+    """
+    if not db_file.exists():
+        return []
+    cutoff = now.timestamp() - lookback_days * 86400
+    rows = outreach_crud.get_notifications_by_topic_sync(str(db_file), topic_like=_TOPIC_LIKE)
     out: list[dict[str, Any]] = []
-    for rid, topic, delivered_at in rows:
-        ts = _parse_ts(delivered_at)
+    for r in rows:
+        ts = _parse_ts(r.get("delivered_at"))
         if ts is None or ts.timestamp() < cutoff:
             continue
-        out.append({"id": rid, "topic": topic or "", "delivered_at": delivered_at})
+        out.append(
+            {"id": r["id"], "topic": r.get("topic") or "", "delivered_at": r["delivered_at"]}
+        )
     return out
 
 

--- a/src/genesis/session_awareness/pr_watch.py
+++ b/src/genesis/session_awareness/pr_watch.py
@@ -1,0 +1,206 @@
+"""PR-watch core — surface the upstream-PR-steward's own owner notifications
+inside foreground CC sessions.
+
+The ``upstream-pr-steward`` campaign already notifies the owner (Telegram) when
+a tracked external PR changes (merged/closed/new maintainer comment/nudge), and
+logs each ping to ``outreach_history`` (category ``notification``). But those
+pings are easy to miss on Telegram. This module lets a SessionStart hook mirror
+the *unseen* ones inline as a one-line nudge.
+
+Design notes:
+- **Read-only** against ``genesis.db`` (``file:...?mode=ro`` — WAL-aware; never
+  ``immutable=1`` which would miss un-checkpointed writes). Every failure path
+  degrades to "surface nothing" — a hook must never block session start.
+- **Seen-state is a home-anchored JSON sidecar**, not the DB: ``opened_at`` in
+  ``outreach_history`` is unwired (never populated), so it cannot be the seen
+  signal. The sidecar records which notification ids this inline surface has
+  already shown, with the timestamp of first surfacing, so a change keeps
+  reappearing for ``resurface_days`` and then stops nagging.
+- The notification volume is tiny (the steward pings only on material change,
+  every ~2 days), so there is no first-run "backlog dump" risk — an empty
+  sidecar simply surfaces the recent unseen pings, capped by ``max_surface``.
+  (This is the deliberate divergence from the discarded pr_status-diff design,
+  whose first run had to baseline the whole roster silently.)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from genesis.env import genesis_home
+
+logger = logging.getLogger(__name__)
+
+_SIDECAR_VERSION = 1
+# Steward campaign is literally named "…steward"; every owner ping it sends
+# carries that in the topic. Case-insensitive LIKE (SQLite default for ASCII).
+_TOPIC_LIKE = "%steward%"
+
+
+def db_path() -> Path:
+    """The PROD DB, home-anchored — NOT repo_root()-anchored.
+
+    ``genesis.env.genesis_db_path()`` resolves ``repo_root()/data/genesis.db``,
+    which in a worktree session points at an EMPTY ``<worktree>/data/`` — a
+    silent-coverage trap (same reason ``genesis_session_context._charter_db_path``
+    is home-anchored). outreach_history only ever lives in the prod DB, so read
+    that directly. ``GENESIS_DB_PATH`` overrides for tests/E2E/relocated installs.
+    """
+    explicit = os.environ.get("GENESIS_DB_PATH")
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / "genesis" / "data" / "genesis.db"
+
+
+def sidecar_path() -> Path:
+    """Home-anchored seen-state file — shared across worktrees (the human's
+    'last seen' is per-human, not per-checkout)."""
+    return genesis_home() / "pr_watch" / "seen.json"
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def read_steward_notifications(
+    db_file: Path, lookback_days: int, now: datetime
+) -> list[dict[str, Any]]:
+    """Recent steward owner-notifications, newest first. Any error -> []."""
+    cutoff = now.timestamp() - lookback_days * 86400
+    try:
+        if not db_file.exists():
+            return []
+        conn = sqlite3.connect(f"file:{db_file}?mode=ro", uri=True, timeout=2)
+        try:
+            conn.execute("PRAGMA busy_timeout=300")
+            rows = conn.execute(
+                "SELECT id, topic, delivered_at FROM outreach_history "
+                "WHERE category = 'notification' AND topic LIKE ? "
+                "AND delivered_at IS NOT NULL "
+                "ORDER BY delivered_at DESC",
+                (_TOPIC_LIKE,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        return []
+
+    out: list[dict[str, Any]] = []
+    for rid, topic, delivered_at in rows:
+        ts = _parse_ts(delivered_at)
+        if ts is None or ts.timestamp() < cutoff:
+            continue
+        out.append({"id": rid, "topic": topic or "", "delivered_at": delivered_at})
+    return out
+
+
+def load_sidecar(path: Path) -> tuple[dict[str, dict[str, Any]], bool]:
+    """Return (surfaced-map, existed). Corrupt/absent -> ({}, False)."""
+    try:
+        if not path.exists():
+            return {}, False
+        data = json.loads(path.read_text())
+        surfaced = data.get("surfaced") if isinstance(data, dict) else None
+        if not isinstance(surfaced, dict):
+            return {}, False
+        # Keep only well-formed entries.
+        clean = {str(k): v for k, v in surfaced.items() if isinstance(v, dict)}
+        return clean, True
+    except Exception:
+        return {}, False
+
+
+def save_sidecar(path: Path, surfaced: dict[str, dict[str, Any]]) -> None:
+    """Atomic write (tmp + rename). Fail-open — never raise."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps({"version": _SIDECAR_VERSION, "surfaced": surfaced})
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".seen-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as fh:
+                fh.write(payload)
+            os.replace(tmp, path)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+    except Exception:
+        logger.debug("pr_watch sidecar write failed", exc_info=True)
+
+
+def render_clause(notif: dict[str, Any]) -> str:
+    """Condense a notification into one short human clause with a date hint."""
+    topic = str(notif.get("topic") or "").strip()
+    first_line = next((ln.strip() for ln in topic.splitlines() if ln.strip()), "")
+    if len(first_line) > 72:
+        first_line = first_line[:71].rstrip() + "…"
+    ts = _parse_ts(notif.get("delivered_at"))
+    if ts is not None:
+        return f"{first_line} ({ts.strftime('%b %-d')})"
+    return first_line or "(update)"
+
+
+def select_to_surface(
+    notifs: list[dict[str, Any]],
+    surfaced: dict[str, dict[str, Any]],
+    now: datetime,
+    resurface_days: int,
+    max_surface: int,
+) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    """Decide which notifications to surface this run and compute the next
+    sidecar.
+
+    Per notification (already lookback-filtered, newest first):
+    - unseen -> surface, record first_ts=now
+    - seen, first surfaced <= resurface_days ago -> resurface
+    - seen, aged past resurface_days -> keep in sidecar, do NOT surface
+
+    The next sidecar is built ONLY from the current notification set, so any id
+    that has fallen outside the lookback window is pruned automatically (no
+    unbounded growth, no retention step).
+    """
+    resurface_cutoff = now.timestamp() - resurface_days * 86400
+    new_surfaced: dict[str, dict[str, Any]] = {}
+    to_show: list[dict[str, Any]] = []
+
+    for n in notifs:
+        nid = str(n["id"])
+        prev = surfaced.get(nid)
+        if prev is None:
+            new_surfaced[nid] = {"first_ts": now.isoformat()}
+            to_show.append(n)
+            continue
+        first_ts = _parse_ts(prev.get("first_ts")) or now
+        new_surfaced[nid] = {"first_ts": prev.get("first_ts") or now.isoformat()}
+        if first_ts.timestamp() >= resurface_cutoff:
+            to_show.append(n)
+
+    lines = [render_clause(n) for n in to_show[: max(max_surface, 0)]]
+    overflow = len(to_show) - len(lines)
+    if overflow > 0:
+        lines.append(f"+{overflow} more")
+    return lines, new_surfaced
+
+
+def format_injection(lines: list[str]) -> str:
+    """The single line injected into the session. Empty -> ''."""
+    if not lines:
+        return ""
+    n = len([ln for ln in lines if not ln.startswith("+")])
+    noun = "update" if n == 1 else "updates"
+    return (
+        f"[PRs] {n} external-PR {noun} you may not have seen — "
+        + " · ".join(lines)
+        + '. Ask "show PRs" to review.'
+    )

--- a/src/genesis/session_awareness/pr_watch.py
+++ b/src/genesis/session_awareness/pr_watch.py
@@ -25,12 +25,13 @@ Design notes:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import sqlite3
 import tempfile
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -69,9 +70,15 @@ def _parse_ts(value: Any) -> datetime | None:
     if not isinstance(value, str):
         return None
     try:
-        return datetime.fromisoformat(value)
+        dt = datetime.fromisoformat(value)
     except (ValueError, TypeError):
         return None
+    # Coerce naive timestamps to UTC so .timestamp() comparisons never skew by
+    # the local offset (mirrors check_stale_pending.py). outreach_history writes
+    # tz-aware ISO today, but a legacy/naive row must not silently mis-window.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
 
 
 def read_steward_notifications(
@@ -194,13 +201,23 @@ def select_to_surface(
 
 
 def format_injection(lines: list[str]) -> str:
-    """The single line injected into the session. Empty -> ''."""
+    """The single line injected into the session. Empty -> ''.
+
+    The header count is the TRUE total (shown clauses + any "+N more"
+    overflow), so a capped list still reports how many updates there are.
+    """
     if not lines:
         return ""
-    n = len([ln for ln in lines if not ln.startswith("+")])
-    noun = "update" if n == 1 else "updates"
+    shown = [ln for ln in lines if not ln.startswith("+")]
+    overflow = 0
+    for ln in lines:
+        if ln.startswith("+") and ln.endswith(" more"):
+            with contextlib.suppress(ValueError):
+                overflow = int(ln[1 : -len(" more")])
+    total = len(shown) + overflow
+    noun = "update" if total == 1 else "updates"
     return (
-        f"[PRs] {n} external-PR {noun} you may not have seen — "
+        f"[PRs] {total} external-PR {noun} you may not have seen — "
         + " · ".join(lines)
         + '. Ask "show PRs" to review.'
     )

--- a/src/genesis/session_awareness/pr_watch_config.py
+++ b/src/genesis/session_awareness/pr_watch_config.py
@@ -1,0 +1,90 @@
+"""PR-watch control surface — live-read enable lever + knobs.
+
+The ONE place the ``surface_pr_updates`` SessionStart hook consults for policy
+(``repo_pulse_config`` lineage). Re-read from the merged YAML
+(``config/pr_watch.yaml`` + the user overlay
+``~/.genesis/config/pr_watch.local.yaml``) on EVERY call — NO boot cache, since
+each SessionStart hook invocation is a fresh short-lived process.
+
+The feature is a pure OUTPUT surface (it injects a nudge; it never acts on the
+outside world), so a single ``enabled`` master switch is the whole policy — no
+off/propose_only/live ladder like the write-capable levers. A missing/corrupt
+config degrades to DEFAULTS. The hook-level kill switch is separate and
+stdlib-cheap: ``GENESIS_PR_WATCH_DISABLED=1`` short-circuits the hook before it
+imports anything (the hook keeps a stdlib-only budget and cannot read YAML).
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports from here, never the reverse (one-way).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "pr_watch.yaml"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # How far back to look for steward notifications to (re)surface. Bounds the
+    # scan; also the sidecar-prune horizon.
+    "lookback_days": 30,
+    # A surfaced update keeps reappearing at session start until it is this many
+    # days old (then it stops nagging). "Surface until you notice it."
+    "resurface_days": 10,
+    # Max distinct updates rendered on one line; overflow collapses to "+N more".
+    "max_surface": 5,
+}
+
+_INT_KNOBS = (
+    "lookback_days",
+    "resurface_days",
+    "max_surface",
+)
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults <- base yaml <- .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = repo_root() / "config" / _CONFIG_NAME
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        logger.warning("pr_watch base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("pr_watch overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def is_enabled(cfg: dict[str, Any] | None = None) -> bool:
+    """Master switch, read live. Anything but an explicit false is enabled."""
+    if cfg is None:
+        cfg = load_config()
+    return cfg.get("enabled", True) is not False
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never crashes
+    the hook or zeroes a window."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value

--- a/tests/test_db/test_outreach.py
+++ b/tests/test_db/test_outreach.py
@@ -108,3 +108,38 @@ async def test_list_by_channel_filters_by_person_id(db):
     rows = await outreach.list_by_channel(db, "discord", person_id="alice")
     assert len(rows) == 1
     assert rows[0]["id"] == "ohpid3"
+
+
+# --- sync reader (hook context) ---------------------------------------------
+
+
+def _seed_notifications(path):
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE outreach_history "
+        "(id TEXT PRIMARY KEY, topic TEXT, category TEXT, delivered_at TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO outreach_history (id, topic, category, delivered_at) VALUES (?,?,?,?)",
+        [
+            ("a", "PR steward: #1 closed", "notification", "2026-07-20T00:00:00+00:00"),
+            ("b", "Billy update", "notification", "2026-07-20T00:00:00+00:00"),  # topic
+            ("c", "PR steward tick", "digest", "2026-07-20T00:00:00+00:00"),  # category
+            ("d", "PR steward: #2", "notification", None),  # null delivered_at
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_get_notifications_by_topic_sync_filters(tmp_path):
+    db = tmp_path / "g.db"
+    _seed_notifications(db)
+    rows = outreach.get_notifications_by_topic_sync(str(db), topic_like="%steward%")
+    assert [r["id"] for r in rows] == ["a"]  # topic+category+non-null delivered_at
+
+
+def test_get_notifications_by_topic_sync_missing_db_returns_empty(tmp_path):
+    assert (
+        outreach.get_notifications_by_topic_sync(str(tmp_path / "nope.db"), topic_like="%x%") == []
+    )

--- a/tests/test_mcp/test_settings_pr_watch.py
+++ b/tests/test_mcp/test_settings_pr_watch.py
@@ -1,0 +1,38 @@
+"""pr_watch settings validator (PR-watch inline surface lever)."""
+
+from __future__ import annotations
+
+from genesis.mcp.health.settings import _DOMAIN_REGISTRY, _DOMAIN_VALIDATORS
+
+_validate = _DOMAIN_VALIDATORS["pr_watch"]
+
+
+def test_domain_registered_with_config_file():
+    dom = _DOMAIN_REGISTRY["pr_watch"]
+    assert dom.config_filename == "pr_watch.yaml"
+    assert dom.readonly is False
+    assert dom.needs_restart is False
+
+
+def test_valid_changes_pass():
+    assert _validate({"enabled": True}) == []
+    assert _validate({"enabled": False, "resurface_days": 5}) == []
+    assert _validate({"lookback_days": 30, "max_surface": 3}) == []
+
+
+def test_unknown_key_rejected_and_lists_valid():
+    (err,) = _validate({"bogus": 1})
+    assert "Unknown key" in err
+    assert "enabled" in err and "resurface_days" in err
+
+
+def test_enabled_must_be_bool():
+    assert _validate({"enabled": "yes"}) != []
+    assert _validate({"enabled": 1}) != []
+
+
+def test_knobs_must_be_positive_int():
+    assert _validate({"max_surface": 0}) != []
+    assert _validate({"lookback_days": -1}) != []
+    assert _validate({"resurface_days": True}) != []  # bool is not a valid int
+    assert _validate({"resurface_days": 1.5}) != []

--- a/tests/test_scripts/test_surface_pr_updates.py
+++ b/tests/test_scripts/test_surface_pr_updates.py
@@ -1,0 +1,114 @@
+"""E2E: the surface_pr_updates SessionStart hook script.
+
+Drives the real script as a subprocess (the actual entrypoint), with a temp DB
+(GENESIS_DB_PATH) and temp home (GENESIS_HOME). Install-agnostic: synthetic
+rows, tmp paths, no network, no live services.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "surface_pr_updates.py"
+_SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _make_db(path: Path, rows: list[tuple]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE outreach_history ("
+        "id TEXT PRIMARY KEY, topic TEXT, category TEXT, delivered_at TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO outreach_history (id, topic, category, delivered_at) VALUES (?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _steward_row(nid: str, days_ago: int = 1) -> tuple:
+    ts = (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+    return (nid, f"PR steward tick: {nid} was closed", "notification", ts)
+
+
+def _run(db: Path | None, home: Path, *, disabled=False, cc_session=False) -> str:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_SRC)
+    env["GENESIS_HOME"] = str(home)
+    env.pop("GENESIS_REPO_ROOT", None)  # use worktree config (enabled: true)
+    if db is not None:
+        env["GENESIS_DB_PATH"] = str(db)
+    else:
+        env["GENESIS_DB_PATH"] = str(home / "does-not-exist.db")
+    if disabled:
+        env["GENESIS_PR_WATCH_DISABLED"] = "1"
+    else:
+        env.pop("GENESIS_PR_WATCH_DISABLED", None)
+    if cc_session:
+        env["GENESIS_CC_SESSION"] = "1"
+    else:
+        env.pop("GENESIS_CC_SESSION", None)
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return proc.stdout
+
+
+def test_surfaces_when_match(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db, [_steward_row("litellm#27447")])
+    out = _run(db, tmp_path / "home")
+    assert "[PRs]" in out
+    assert "litellm#27447" in out
+    # sidecar was written
+    assert (tmp_path / "home" / "pr_watch" / "seen.json").exists()
+
+
+def test_env_kill_switch_silences(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db, [_steward_row("x")])
+    out = _run(db, tmp_path / "home", disabled=True)
+    assert out.strip() == ""
+
+
+def test_dispatched_session_silent_and_leaves_sidecar_untouched(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db, [_steward_row("x")])
+    home = tmp_path / "home"
+    out = _run(db, home, cc_session=True)
+    assert out.strip() == ""
+    assert not (home / "pr_watch" / "seen.json").exists()  # never touched
+
+
+def test_no_matching_rows_silent(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(
+        db, [("b", "Billy brain is live", "notification", datetime.now(UTC).isoformat())]
+    )  # not steward
+    out = _run(db, tmp_path / "home")
+    assert out.strip() == ""
+
+
+def test_missing_db_fail_open(tmp_path):
+    out = _run(None, tmp_path / "home")  # GENESIS_DB_PATH -> nonexistent
+    assert out.strip() == ""
+
+
+def test_resurfaces_on_second_run(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db, [_steward_row("litellm#27447")])
+    home = tmp_path / "home"
+    first = _run(db, home)
+    second = _run(db, home)  # same day -> within resurface window
+    assert "[PRs]" in first
+    assert "[PRs]" in second

--- a/tests/test_session_awareness/test_pr_watch.py
+++ b/tests/test_session_awareness/test_pr_watch.py
@@ -1,0 +1,206 @@
+"""Tests for the PR-watch inline-surface core (pure logic + DB read + sidecar)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from genesis.session_awareness import pr_watch
+
+NOW = datetime(2026, 7, 21, 12, 0, tzinfo=UTC)
+
+
+def _make_db(path: Path, rows: list[tuple]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE outreach_history ("
+        "id TEXT PRIMARY KEY, topic TEXT, category TEXT, delivered_at TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO outreach_history (id, topic, category, delivered_at) VALUES (?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+# --------------------------------------------------------------------------
+# read_steward_notifications
+# --------------------------------------------------------------------------
+
+
+def test_read_filters_category_topic_and_lookback(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(
+        db,
+        [
+            (
+                "a",
+                "PR steward tick: litellm#27447 mergeable",
+                "notification",
+                (NOW - timedelta(days=1)).isoformat(),
+            ),
+            (
+                "b",
+                "Upstream PR Steward baseline",
+                "notification",
+                (NOW - timedelta(days=90)).isoformat(),
+            ),  # outside lookback
+            (
+                "c",
+                "Billy brain is live",
+                "notification",
+                (NOW - timedelta(days=1)).isoformat(),
+            ),  # not steward
+            (
+                "d",
+                "PR steward tick: x",
+                "digest",
+                (NOW - timedelta(days=1)).isoformat(),
+            ),  # wrong category
+        ],
+    )
+    out = pr_watch.read_steward_notifications(db, lookback_days=30, now=NOW)
+    assert [r["id"] for r in out] == ["a"]
+
+
+def test_read_case_insensitive_steward_match(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(
+        db,
+        [
+            (
+                "a",
+                "Upstream PR Steward is live",
+                "notification",
+                (NOW - timedelta(days=2)).isoformat(),
+            )
+        ],
+    )
+    out = pr_watch.read_steward_notifications(db, lookback_days=30, now=NOW)
+    assert len(out) == 1
+
+
+def test_read_missing_db_returns_empty(tmp_path):
+    assert pr_watch.read_steward_notifications(tmp_path / "nope.db", 30, NOW) == []
+
+
+def test_read_missing_table_returns_empty(tmp_path):
+    db = tmp_path / "g.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE unrelated (x INTEGER)")
+    conn.commit()
+    conn.close()
+    assert pr_watch.read_steward_notifications(db, 30, NOW) == []
+
+
+# --------------------------------------------------------------------------
+# sidecar load/save
+# --------------------------------------------------------------------------
+
+
+def test_sidecar_absent(tmp_path):
+    surfaced, existed = pr_watch.load_sidecar(tmp_path / "seen.json")
+    assert surfaced == {} and existed is False
+
+
+def test_sidecar_corrupt(tmp_path):
+    p = tmp_path / "seen.json"
+    p.write_text("{not json")
+    surfaced, existed = pr_watch.load_sidecar(p)
+    assert surfaced == {} and existed is False
+
+
+def test_sidecar_roundtrip(tmp_path):
+    p = tmp_path / "sub" / "seen.json"
+    pr_watch.save_sidecar(p, {"x": {"first_ts": NOW.isoformat()}})
+    surfaced, existed = pr_watch.load_sidecar(p)
+    assert existed is True
+    assert surfaced["x"]["first_ts"] == NOW.isoformat()
+    # File is valid JSON with the version envelope.
+    data = json.loads(p.read_text())
+    assert data["version"] == 1
+
+
+# --------------------------------------------------------------------------
+# select_to_surface
+# --------------------------------------------------------------------------
+
+
+def _notif(nid, days_ago):
+    return {
+        "id": nid,
+        "topic": f"PR steward tick: {nid}",
+        "delivered_at": (NOW - timedelta(days=days_ago)).isoformat(),
+    }
+
+
+def test_select_first_sight_surfaces_and_records(tmp_path):
+    notifs = [_notif("a", 1)]
+    lines, new = pr_watch.select_to_surface(notifs, {}, NOW, 10, 5)
+    assert len(lines) == 1
+    assert new["a"]["first_ts"] == NOW.isoformat()
+
+
+def test_select_resurfaces_within_window():
+    notifs = [_notif("a", 1)]
+    surfaced = {"a": {"first_ts": (NOW - timedelta(days=3)).isoformat()}}
+    lines, new = pr_watch.select_to_surface(notifs, surfaced, NOW, 10, 5)
+    assert len(lines) == 1
+    # first_ts is preserved (not reset), so the window keeps counting down.
+    assert new["a"]["first_ts"] == surfaced["a"]["first_ts"]
+
+
+def test_select_ages_out_beyond_window_but_keeps_record():
+    notifs = [_notif("a", 20)]
+    surfaced = {"a": {"first_ts": (NOW - timedelta(days=15)).isoformat()}}
+    lines, new = pr_watch.select_to_surface(notifs, surfaced, NOW, 10, 5)
+    assert lines == []
+    assert "a" in new  # kept so it does not re-surface as "new"
+
+
+def test_select_prunes_ids_outside_current_notifs():
+    notifs = [_notif("a", 1)]
+    surfaced = {"gone": {"first_ts": (NOW - timedelta(days=2)).isoformat()}}
+    _lines, new = pr_watch.select_to_surface(notifs, surfaced, NOW, 10, 5)
+    assert "gone" not in new  # pruned (self-bounding sidecar)
+
+
+def test_select_caps_at_max_surface_with_overflow():
+    notifs = [_notif(str(i), 1) for i in range(8)]
+    lines, _new = pr_watch.select_to_surface(notifs, {}, NOW, 10, 3)
+    assert len(lines) == 4  # 3 clauses + 1 overflow marker
+    assert lines[-1] == "+5 more"
+
+
+# --------------------------------------------------------------------------
+# render_clause / format_injection
+# --------------------------------------------------------------------------
+
+
+def test_render_clause_takes_first_line_and_dates():
+    clause = pr_watch.render_clause(
+        {"topic": "PR steward: #905 closed\n\nmore detail", "delivered_at": NOW.isoformat()}
+    )
+    assert clause.startswith("PR steward: #905 closed")
+    assert "Jul 21" in clause
+
+
+def test_render_clause_truncates_long_topic():
+    clause = pr_watch.render_clause({"topic": "x" * 200, "delivered_at": None})
+    assert len(clause) <= 73 and clause.endswith("…")
+
+
+def test_format_injection_empty():
+    assert pr_watch.format_injection([]) == ""
+
+
+def test_format_injection_singular_plural_and_overflow():
+    assert "1 external-PR update " in pr_watch.format_injection(["one (Jul 1)"])
+    two = pr_watch.format_injection(["a (Jul 1)", "b (Jul 2)"])
+    assert "2 external-PR updates " in two
+    # Overflow marker does not inflate the count.
+    with_overflow = pr_watch.format_injection(["a (Jul 1)", "+4 more"])
+    assert "1 external-PR update " in with_overflow

--- a/tests/test_session_awareness/test_pr_watch.py
+++ b/tests/test_session_awareness/test_pr_watch.py
@@ -201,6 +201,7 @@ def test_format_injection_singular_plural_and_overflow():
     assert "1 external-PR update " in pr_watch.format_injection(["one (Jul 1)"])
     two = pr_watch.format_injection(["a (Jul 1)", "b (Jul 2)"])
     assert "2 external-PR updates " in two
-    # Overflow marker does not inflate the count.
+    # Header count is the TRUE total: 1 shown + 4 overflow = 5.
     with_overflow = pr_watch.format_injection(["a (Jul 1)", "+4 more"])
-    assert "1 external-PR update " in with_overflow
+    assert "5 external-PR updates " in with_overflow
+    assert "+4 more" in with_overflow

--- a/tests/test_session_awareness/test_pr_watch_config.py
+++ b/tests/test_session_awareness/test_pr_watch_config.py
@@ -1,0 +1,40 @@
+"""Tests for the PR-watch config lever."""
+
+from __future__ import annotations
+
+import genesis.session_awareness.pr_watch_config as cfgmod
+
+
+def test_defaults_when_no_files(monkeypatch, tmp_path):
+    # repo_root has no config/pr_watch.yaml -> pure DEFAULTS.
+    monkeypatch.setattr(cfgmod, "repo_root", lambda: tmp_path)
+    cfg = cfgmod.load_config()
+    assert cfg["enabled"] is True
+    assert cfg["lookback_days"] == 30
+    assert cfg["resurface_days"] == 10
+    assert cfg["max_surface"] == 5
+
+
+def test_base_yaml_overrides_defaults(monkeypatch, tmp_path):
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "pr_watch.yaml").write_text("enabled: false\nresurface_days: 3\n")
+    monkeypatch.setattr(cfgmod, "repo_root", lambda: tmp_path)
+    cfg = cfgmod.load_config()
+    assert cfg["enabled"] is False
+    assert cfg["resurface_days"] == 3
+    assert cfg["lookback_days"] == 30  # untouched default
+
+
+def test_is_enabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(cfgmod, "repo_root", lambda: tmp_path)
+    assert cfgmod.is_enabled({"enabled": True}) is True
+    assert cfgmod.is_enabled({"enabled": False}) is False
+    assert cfgmod.is_enabled({}) is True  # default-on
+
+
+def test_knob_int_rejects_bad_values():
+    assert cfgmod.knob_int({"lookback_days": 0}, "lookback_days") == 30
+    assert cfgmod.knob_int({"lookback_days": -5}, "lookback_days") == 30
+    assert cfgmod.knob_int({"lookback_days": True}, "lookback_days") == 30
+    assert cfgmod.knob_int({"lookback_days": "x"}, "lookback_days") == 30
+    assert cfgmod.knob_int({"max_surface": 7}, "max_surface") == 7


### PR DESCRIPTION
## What

Adds a SessionStart hook that mirrors the `upstream-pr-steward` campaign's own
owner-notifications into foreground Claude Code sessions as a one-line nudge:

```
[PRs] 2 external-PR updates you may not have seen — PR steward: #905 closed (Jul 9) · … . Ask "show PRs" to review.
```

The steward campaign already notifies the owner when a tracked external PR
changes (merged/closed/new maintainer comment) and logs each ping to
`outreach_history`. Those pings are easy to miss on a chat channel, so this
surfaces the **unseen** ones inline — a second delivery surface, not a new
monitor.

## Design

- **Deterministic, read-only.** The hook reads recent steward notifications
  (`outreach_history`, category `notification`) over a read-only, WAL-aware
  connection and renders a one-line nudge. Seen-state is a home-anchored JSON
  sidecar (`~/.genesis/pr_watch/seen.json`) — a change resurfaces each session
  for `resurface_days` then stops, and the sidecar self-prunes to the
  `lookback_days` window (no retention job needed).
- **Home-anchored DB path**, not `repo_root()`-anchored — a worktree session
  would otherwise read an empty `<worktree>/data/` (the same trap the charter
  hook avoids).
- **Fail-open**: any error, missing table (fresh clone), disabled config, or
  dispatched session (`GENESIS_CC_SESSION=1`) → surfaces nothing, never blocks
  session start.
- **Operator levers**: settings domain `pr_watch` (`config/pr_watch.yaml`,
  live-read) + `GENESIS_PR_WATCH_DISABLED=1` kill switch.

## Testing

- 76 tests: core decision-table, config lever, settings validator, and an
  end-to-end subprocess test of the hook.
- Verified end-to-end through the real hook-dispatch path: first-surface →
  resurface → age-out → kill-switch → dispatched-session-skip.

## Deploy

Hook + settings land at next session start after `git pull`; no schema
migration (reads existing `outreach_history`). Fresh clones with no campaign
degrade to a clean no-op. Empty state (no sidecar, no notifications) surfaces
nothing.

Note: the campaign's discovery/notification behavior is configured in its
install-local strategy doc (campaigns ship zero defaults), so it is not part of
this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)