### PR TITLE
feat(reflex): PR1.5 — observability surface + bare-task sweep

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1078,14 +1078,14 @@ verified: 9037d45b 2026-07-07
 
 The afferent nerve for Genesis's own screaming bugs: detect `task.failed`
 exceptions, fingerprint/dedup them, and (later phases) diagnose → card →
-fix under a human-gated tier model. **PR1 only (dark)** — ingestion
-scaffolding, no cards/sessions/LLM yet. Spec:
-`docs/superpowers/specs/2026-07-21-reflex-arc-design.md`.
+fix under a human-gated tier model. **PR1 (dark) + PR1.5 (observability)**
+— ingestion scaffolding and its watch surface; no cards/sessions/LLM yet.
+Spec: `docs/superpowers/specs/2026-07-21-reflex-arc-design.md`.
 
 ```yaml subsystem-map
 entry: reflex-arc
 modules: [reflex]
-verified: bbe3a440 2026-07-21
+verified: 6fd98675 2026-07-21
 ```
 
 - **reflex/**: `fingerprint.py` (pure: normalize task name, line-number-free
@@ -1106,6 +1106,20 @@ verified: bbe3a440 2026-07-21
   (`runtime/init/ego._is_reflex_owned_event`) — reflex owns that class; the
   ego's message-keyed dedup can't absorb variable-payload failure bursts
   (a documented storm mode in `ego/cadence.py`).
+- **Observability (PR1.5)**: aggregates on `db/crud/reflex_signals`
+  (`count_by_status` / `top_class_keys` / `list_recent`) feed four surfaces —
+  the `reflex_status` MCP tool (process-portable: config + DB only), the
+  in-server health snapshot (`observability/snapshots/reflex.py`, reads live
+  ingestor counters via `GenesisRuntime.peek()`, degrades to DB-only),
+  a `reflex` block in `status.json` (isinstance-guarded; consumed by the
+  standalone health MCP), and a dashboard overview card (`reflexSemantic()` —
+  deliberately NOT in `overallHealthSemantic()`: a detected signal is the
+  subsystem working, not the system degrading).
+- **A4 sweep**: remaining fire-and-forget bare `create_task` sites wrapped in
+  `tracked_task` (`cc_fallback_probe`, `escalation` ×2); awaited-elsewhere
+  sites (`knowledge/orchestrator` tree_task, `health_data` single-flight,
+  `events._db_writer`) stay bare with in-code comments — wrapping would
+  double-report exceptions their callers already handle.
 - GROUNDWORK: diagnose lane (PR2), fix lane (PR3) — `reflex_diagnoses` /
   `reflex_verdicts` writers and the card/gate/dispatch flow are NOT yet
   built; the tables are inert scaffolding in PR1.

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -346,6 +346,53 @@
             <div class="health-card-reason" x-text="$store.genesisDashboard.queuesSemantic().reason"></div>
           </div>
 
+          <!-- Reflex arc -->
+          <div class="health-card" title="Reflex arc: fingerprint-deduped record of Genesis's own background-task crashes.">
+            <div class="health-card-header">
+              <div class="health-card-title">Reflex</div>
+              <span class="status-chip"
+                    :class="$store.genesisDashboard.semanticChipClass($store.genesisDashboard.reflexSemantic().state)"
+                    x-text="`${$store.genesisDashboard.semanticChipGlyph($store.genesisDashboard.reflexSemantic().state)} ${$store.genesisDashboard.reflexSemantic().state}`"></span>
+            </div>
+            <div class="health-card-value">
+              <template x-if="$store.genesisDashboard.health.reflex">
+                <div>
+                  <div style="font-size: 0.82rem; cursor: default;"
+                       title="Distinct failure fingerprints awaiting the diagnose lane">
+                    New Signals:
+                    <span x-text="$store.genesisDashboard.health.reflex.counts?.new ?? 0"
+                          :style="($store.genesisDashboard.health.reflex.counts?.new || 0) > 0 ? 'color: #f0ad4e; font-weight: 700' : 'color: #4caf50'"></span>
+                    <span style="font-size: 0.68rem; color: var(--color-text-secondary);"
+                          x-text="'(' + ($store.genesisDashboard.health.reflex.total_signals ?? 0) + ' total)'"></span>
+                  </div>
+                  <template x-if="$store.genesisDashboard.health.reflex.ingestor">
+                    <div style="font-size: 0.82rem; cursor: default;"
+                         title="Live ingestor counters (this server process)">
+                      Ingested:
+                      <span x-text="$store.genesisDashboard.health.reflex.ingestor.processed ?? 0" style="color: #4caf50"></span>
+                      <template x-if="($store.genesisDashboard.health.reflex.ingestor.dropped || 0) > 0">
+                        <span style="color: #d9534f; font-weight: 700;"
+                              x-text="'(' + $store.genesisDashboard.health.reflex.ingestor.dropped + ' dropped)'"></span>
+                      </template>
+                    </div>
+                  </template>
+                  <template x-if="($store.genesisDashboard.health.reflex.top_classes?.length || 0) > 0">
+                    <div style="margin-top: 0.3rem; font-size: 0.68rem;">
+                      <template x-for="cls in $store.genesisDashboard.health.reflex.top_classes.slice(0, 3)" :key="cls.class_key">
+                        <div style="color: var(--color-text-secondary); margin: 0.1rem 0;">
+                          <span x-text="cls.class_key"></span>
+                          (<span x-text="cls.signals + ' signal' + (cls.signals === 1 ? '' : 's')"></span>,
+                          <span x-text="cls.occurrences + '×'"></span>)
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </template>
+            </div>
+            <div class="health-card-reason" x-text="$store.genesisDashboard.reflexSemantic().reason"></div>
+          </div>
+
           <!-- Surplus -->
           <div class="health-card" title="Surplus compute: opportunistic background tasks during idle time."
                style="cursor: pointer;" @click="$store.genesisDashboard.surplusModal.open = true; $store.genesisDashboard.fetchSurplusDetail()">

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3350,6 +3350,32 @@
           return { state: "healthy", reason: worklist > 0 ? `queues clear — ${worklist} worklist item(s) in flight` : "queues are clear" };
         },
 
+        reflexSemantic() {
+          // Deliberately NOT part of overallHealthSemantic(): a new reflex
+          // signal means a bug was DETECTED — the subsystem working, not the
+          // system degrading. Only ingestion-pipeline problems (drops) mark
+          // this card degraded.
+          const reflex = this.health.reflex;
+          if (!reflex) return { state: "unknown", reason: "reflex data unavailable" };
+          const ing = reflex.ingestor;
+          if (!ing) {
+            const total = reflex.total_signals || 0;
+            return { state: "unknown", reason: `ingestor not running — ${total} stored signal(s)` };
+          }
+          if (ing.enabled === false) {
+            return { state: "unknown", reason: "ingestion disabled (nerve dark by config)" };
+          }
+          if ((ing.dropped || 0) > 0) {
+            return { state: "degraded", reason: `${ing.dropped} event(s) dropped (ingest queue overflow)` };
+          }
+          const newCount = (reflex.counts || {}).new || 0;
+          const total = reflex.total_signals || 0;
+          if (newCount > 0) {
+            return { state: "healthy", reason: `nerve live — ${newCount} new signal(s) awaiting the diagnose lane` };
+          }
+          return { state: "healthy", reason: total > 0 ? `nerve live — ${total} signal(s), none new` : "nerve live — no failures detected" };
+        },
+
         surplusSemantic() {
           const surplus = this.health.surplus;
           if (!surplus || surplus.status === "unknown") return { state: "unknown", reason: "surplus scheduler data unavailable" };

--- a/src/genesis/db/crud/reflex_signals.py
+++ b/src/genesis/db/crud/reflex_signals.py
@@ -178,6 +178,7 @@ async def list_by_status(db: aiosqlite.Connection, status: str, *, limit: int = 
 
 
 async def list_recent(db: aiosqlite.Connection, *, limit: int = 10) -> list[dict]:
+    """Most-recently-seen signals across all statuses, newest first."""
     cursor = await db.execute(f"{_SELECT} ORDER BY last_seen_at DESC LIMIT ?", (limit,))
     rows = await cursor.fetchall()
     return [_row_to_dict(tuple(r)) for r in rows]
@@ -188,6 +189,7 @@ async def list_recent(db: aiosqlite.Connection, *, limit: int = 10) -> list[dict
 
 
 async def count_by_status(db: aiosqlite.Connection) -> dict[str, int]:
+    """Signal counts keyed by lifecycle status (statuses with zero rows omitted)."""
     cursor = await db.execute("SELECT status, COUNT(*) FROM reflex_signals GROUP BY status")
     rows = await cursor.fetchall()
     return {row[0]: row[1] for row in rows}

--- a/src/genesis/db/crud/reflex_signals.py
+++ b/src/genesis/db/crud/reflex_signals.py
@@ -175,3 +175,37 @@ async def list_by_status(db: aiosqlite.Connection, status: str, *, limit: int = 
     )
     rows = await cursor.fetchall()
     return [_row_to_dict(tuple(r)) for r in rows]
+
+
+async def list_recent(db: aiosqlite.Connection, *, limit: int = 10) -> list[dict]:
+    cursor = await db.execute(f"{_SELECT} ORDER BY last_seen_at DESC LIMIT ?", (limit,))
+    rows = await cursor.fetchall()
+    return [_row_to_dict(tuple(r)) for r in rows]
+
+
+# ── observability aggregates (PR1.5) — shared by the reflex_status MCP tool
+#    and the in-server health snapshot; read-only ────────────────────────────
+
+
+async def count_by_status(db: aiosqlite.Connection) -> dict[str, int]:
+    cursor = await db.execute("SELECT status, COUNT(*) FROM reflex_signals GROUP BY status")
+    rows = await cursor.fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+async def top_class_keys(db: aiosqlite.Connection, *, limit: int = 8) -> list[dict]:
+    """Class keys ranked by distinct-signal count, occurrence volume as tiebreak.
+
+    Signal count leads (how many distinct bugs in this class), occurrence sum
+    breaks ties (how loud they are) — the ordering the §7.2 taxonomy work reads.
+    """
+    cursor = await db.execute(
+        """SELECT class_key, COUNT(*) AS signals, SUM(occurrence_count) AS occurrences
+           FROM reflex_signals
+           GROUP BY class_key
+           ORDER BY signals DESC, occurrences DESC
+           LIMIT ?""",
+        (limit,),
+    )
+    rows = await cursor.fetchall()
+    return [{"class_key": row[0], "signals": row[1], "occurrences": row[2]} for row in rows]

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -96,7 +96,8 @@ class KnowledgeOrchestrator:
             if self._manifest.has_source(source):
                 logger.warning(
                     "Re-ingest of %s failed extraction (%s) — serving cached units",
-                    source, exc,
+                    source,
+                    exc,
                 )
                 return IngestResult(
                     source=source,
@@ -150,7 +151,8 @@ class KnowledgeOrchestrator:
         except Exception:
             logger.warning(
                 "Injection scan failed for %s (fail-open, ingest continues)",
-                source, exc_info=True,
+                source,
+                exc_info=True,
             )
 
         # 3b. Kick off tree indexing in parallel (if applicable)
@@ -170,6 +172,10 @@ class KnowledgeOrchestrator:
             and source_resolved.exists()
         )
         if should_tree_index:
+            # Bare create_task BY DESIGN (reflex A4 sweep, 2026-07-21): this
+            # task is awaited downstream (_collect_tree_result) and
+            # cancelled+awaited on every error path, so exceptions propagate
+            # to the caller — tracked_task would double-report them.
             tree_task = asyncio.create_task(
                 self._tree_index_source(source),
                 name=f"tree-index-{Path(source).name}",
@@ -193,7 +199,9 @@ class KnowledgeOrchestrator:
 
             # 6. Distill
             units = await self._distillation.distill(
-                content, project_type=project_type, domain=domain,
+                content,
+                project_type=project_type,
+                domain=domain,
                 user_context=user_context,
                 on_chunk_done=on_chunk_done,
                 content_source=content_source,
@@ -232,8 +240,11 @@ class KnowledgeOrchestrator:
         try:
             async with self._store_lock:
                 unit_ids = await self._store_units(
-                    units, project_type=project_type, source=source,
-                    content=content, purpose=purpose,
+                    units,
+                    project_type=project_type,
+                    source=source,
+                    content=content,
+                    purpose=purpose,
                 )
         except Exception as exc:
             logger.error("Storage failed for %s: %s", source, exc)
@@ -268,7 +279,9 @@ class KnowledgeOrchestrator:
             )
             logger.warning(
                 "Injection patterns in ingested source %s: %s (risk=%.3f)",
-                source, scan_result.detected_patterns, scan_result.risk_score,
+                source,
+                scan_result.detected_patterns,
+                scan_result.risk_score,
             )
 
         low_conf = [u for u in units if u.confidence < 0.5]
@@ -306,10 +319,14 @@ class KnowledgeOrchestrator:
         """Batch-ingest all supported files from a directory."""
         dir_path = Path(directory)
         if not dir_path.is_dir():
-            return [IngestResult(
-                source=directory, source_type="error", units_created=0,
-                error=f"Not a directory: {directory}",
-            )]
+            return [
+                IngestResult(
+                    source=directory,
+                    source_type="error",
+                    units_created=0,
+                    error=f"Not a directory: {directory}",
+                )
+            ]
 
         results: list[IngestResult] = []
         supported = set(extensions) if extensions else set(self._registry.supported_extensions())
@@ -352,7 +369,8 @@ class KnowledgeOrchestrator:
         except Exception as exc:
             logger.warning(
                 "Tree indexing failed for %s (non-blocking): %s",
-                source, exc,
+                source,
+                exc,
             )
             return None
 
@@ -400,9 +418,7 @@ class KnowledgeOrchestrator:
         qdrant_ids: list[str] = []  # Track for compensation on failure
         purpose_json = json.dumps(purpose) if purpose else None
         now_iso = datetime.now(UTC).isoformat()
-        embedding_model = getattr(
-            memory_mod._store._embeddings, "model_name", "unknown"
-        )
+        embedding_model = getattr(memory_mod._store._embeddings, "model_name", "unknown")
 
         try:
             for unit in units:
@@ -422,7 +438,8 @@ class KnowledgeOrchestrator:
                 from genesis.memory.provenance import derive_origin_class
 
                 resolved_origin = derive_origin_class(
-                    source_pipeline="curated", collection="knowledge_base",
+                    source_pipeline="curated",
+                    collection="knowledge_base",
                 )
                 qdrant_id = await memory_mod._store.store(
                     unit.body,
@@ -484,7 +501,10 @@ class KnowledgeOrchestrator:
         except Exception:
             logger.error(
                 "Batch storage failed after %d/%d units (%d qdrant vectors) from %s — rolling back",
-                len(unit_ids), len(units), len(qdrant_ids), source,
+                len(unit_ids),
+                len(units),
+                len(qdrant_ids),
+                source,
                 exc_info=True,
             )
             # Roll back SQLite to release the write lock immediately

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -84,6 +84,7 @@ from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
 from genesis.mcp.health import provider as _provider  # noqa: E402
+from genesis.mcp.health import reflex_status as _reflex_status  # noqa: E402, F401
 from genesis.mcp.health import session_charter_tools as _session_charter_tools  # noqa: E402
 from genesis.mcp.health import session_control as _session_control  # noqa: E402
 from genesis.mcp.health import settings as _settings  # noqa: E402

--- a/src/genesis/mcp/health/reflex_status.py
+++ b/src/genesis/mcp/health/reflex_status.py
@@ -1,0 +1,85 @@
+"""reflex_status MCP tool — the reflex-arc nerve surface.
+
+One read-only view of what the nerve has ingested: signal counts by
+lifecycle status, the loudest error classes, and the most recent signals.
+
+Process-portable by design: the standalone health MCP child has no
+bootstrapped runtime, so ``enabled`` comes from the config loader (not the
+live ingestor) and everything else from the shared DB. Live in-memory
+counters (queue depth, processed, dropped) belong to the in-server health
+snapshot / status.json, not this tool.
+
+Read-only. Reuses existing CRUD; no new schema; does NOT change behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+async def _impl_reflex_status() -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+    from genesis.db.crud import reflex_signals as signals_crud
+    from genesis.reflex.config import load_reflex_config
+
+    try:
+        enabled = load_reflex_config().ingest_enabled
+    except Exception:
+        logger.warning("Reflex config load failed in reflex_status", exc_info=True)
+        enabled = None
+
+    counts = await signals_crud.count_by_status(db)
+    top_classes = await signals_crud.top_class_keys(db, limit=8)
+    recent = await signals_crud.list_recent(db, limit=10)
+
+    return {
+        "status": "ok",
+        "ingest_enabled": enabled,
+        "total_signals": sum(counts.values()),
+        "counts_by_status": counts,
+        "top_classes": top_classes,
+        "recent_signals": [
+            {
+                "fingerprint": r.get("fingerprint"),
+                "class_key": r.get("class_key"),
+                "task_name": r.get("task_name"),
+                "error_type": r.get("error_type"),
+                "status": r.get("status"),
+                "occurrence_count": r.get("occurrence_count"),
+                "first_seen_at": r.get("first_seen_at"),
+                "last_seen_at": r.get("last_seen_at"),
+                "last_error_message": r.get("last_error_message"),
+            }
+            for r in recent
+        ],
+        "note": (
+            "Reflex arc afferent nerve. Signals are fingerprint-deduped "
+            "task.failed exceptions (a burst of N identical crashes = one "
+            "signal, occurrence_count N). ingest_enabled reflects the config "
+            "loader in THIS process (shipped default is false; installs "
+            "enable via ~/.genesis/config/reflex.local.yaml); None = config "
+            "unreadable. Live queue/drop counters live in health_status "
+            ".reflex.ingestor. Read-only — does NOT change behaviour."
+        ),
+    }
+
+
+@mcp.tool()
+async def reflex_status() -> dict:
+    """What has the reflex nerve ingested — Genesis's fingerprint-deduped
+    record of its own background-task crashes?
+
+    Signal counts by lifecycle status, the loudest error classes, and the
+    most recent signals. Read-only; does NOT change behaviour.
+    """
+    return await _impl_reflex_status()

--- a/src/genesis/mcp/health/status.py
+++ b/src/genesis/mcp/health/status.py
@@ -38,6 +38,7 @@ async def _impl_health_status() -> dict:
         "services": snap.get("services", {}),
         "provider_activity": provider_activity,
         "vcr": snap.get("vcr", {}),
+        "reflex": snap.get("reflex", {}),
     }
 
 

--- a/src/genesis/mcp/standalone_health.py
+++ b/src/genesis/mcp/standalone_health.py
@@ -77,6 +77,9 @@ class StandaloneHealthDataService:
             "surplus": {},
             "awareness": {},
             "outreach_stats": {},
+            # Reflex ingestor counters written by StatusFileWriter (live in
+            # the server process; slightly stale here by design).
+            "reflex": {"ingestor": data.get("reflex")} if data.get("reflex") else {},
         }
 
         # Enrich from DB where possible (capped at 5s to avoid stalling CC)

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -137,7 +137,10 @@ class HealthDataService:
         if inflight is not None and not inflight.done():
             return await asyncio.shield(inflight)
         # No await between the done() check and the assignment below → race-free
-        # on the single-threaded loop.
+        # on the single-threaded loop. Bare create_task BY DESIGN (reflex A4
+        # sweep, 2026-07-21): every caller awaits via asyncio.shield and the
+        # orphan case retrieves the exception in _release_inflight —
+        # tracked_task would double-report handled snapshot failures.
         task = asyncio.create_task(self._compute_snapshot())
         self._inflight = task
         task.add_done_callback(self._release_inflight)

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -175,7 +175,8 @@ class HealthDataService:
 
             since = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
             return await events_crud.recent_provider_fallback_counts(
-                self._db, since=since,
+                self._db,
+                since=since,
             )
         except Exception:
             logger.debug("recent provider-fallback counts query failed", exc_info=True)
@@ -199,6 +200,7 @@ class HealthDataService:
             proactive_memory_metrics,
             provider_activity,
             queues,
+            reflex,
             services_async,
             surplus_status,
         )
@@ -223,8 +225,11 @@ class HealthDataService:
         # mcp_status) overlap with them and each other.
         results = await asyncio.gather(
             call_sites(
-                self._db, self._routing_config, self._breakers,
-                probe_results=probe_results, state_machine=self._state_machine,
+                self._db,
+                self._routing_config,
+                self._breakers,
+                probe_results=probe_results,
+                state_machine=self._state_machine,
             ),
             cc_sessions(self._db, self._cc_budget, self._state_machine),
             infrastructure(
@@ -253,17 +258,33 @@ class HealthDataService:
             # Deploy staleness — merged-vs-deployed drift (update.sh age, commits
             # behind, missing units, host guardian). Does its own to_thread.
             deploy_health(self._db),
+            # Reflex-arc nerve state (ingestor counters + signal aggregates).
+            reflex(self._db),
             return_exceptions=True,
         )
         # Isolate any failed section uniformly: one raising sub-snapshot degrades
         # to {"status": "error"} instead of taking down the whole snapshot.
         results = [_or_error(r) for r in results]
         (
-            r_call_sites, r_cc_sessions, r_infrastructure, r_queues, r_surplus,
-            r_cost, r_awareness, r_outreach, r_mcp, r_provider_activity,
-            r_memory_health, r_eval_staleness, r_vcr,
-            r_services, r_conversation, r_proactive, r_provider_fallbacks,
+            r_call_sites,
+            r_cc_sessions,
+            r_infrastructure,
+            r_queues,
+            r_surplus,
+            r_cost,
+            r_awareness,
+            r_outreach,
+            r_mcp,
+            r_provider_activity,
+            r_memory_health,
+            r_eval_staleness,
+            r_vcr,
+            r_services,
+            r_conversation,
+            r_proactive,
+            r_provider_fallbacks,
             r_deploy_health,
+            r_reflex,
         ) = results
 
         # Surface infra probe healthy<->unhealthy transitions to the activity
@@ -276,9 +297,7 @@ class HealthDataService:
         # Fallback counts feed the API-keys card. _recent_provider_fallbacks
         # self-isolates its errors to {}, so this is always a provider map; the
         # isinstance keeps the attach loop safe if that contract ever changes.
-        recent_fallbacks = (
-            r_provider_fallbacks if isinstance(r_provider_fallbacks, dict) else {}
-        )
+        recent_fallbacks = r_provider_fallbacks if isinstance(r_provider_fallbacks, dict) else {}
 
         return {
             "timestamp": now,
@@ -293,7 +312,8 @@ class HealthDataService:
             "outreach_stats": r_outreach,
             "services": r_services,
             "api_keys": api_key_health(
-                self._routing_config, breakers=self._breakers,
+                self._routing_config,
+                breakers=self._breakers,
                 recent_fallbacks=recent_fallbacks,
             ),
             "mcp_servers": r_mcp,
@@ -305,6 +325,7 @@ class HealthDataService:
             "eval_staleness": r_eval_staleness,
             "deploy_health": r_deploy_health,
             "vcr": r_vcr,
+            "reflex": r_reflex,
         }
 
     async def _emit_probe_transitions(self, infra: object) -> None:
@@ -375,6 +396,7 @@ class HealthDataService:
             return {}
         try:
             from genesis.db.crud.ego import compute_vcr
+
             return await compute_vcr(self._db, days=30)
         except Exception:
             logger.debug("VCR snapshot failed", exc_info=True)

--- a/src/genesis/observability/snapshots/__init__.py
+++ b/src/genesis/observability/snapshots/__init__.py
@@ -24,6 +24,7 @@ from genesis.observability.snapshots.outreach import outreach_stats
 from genesis.observability.snapshots.proactive_memory import proactive_memory_metrics
 from genesis.observability.snapshots.provider_activity import provider_activity
 from genesis.observability.snapshots.queues import queues
+from genesis.observability.snapshots.reflex import reflex
 from genesis.observability.snapshots.services import mcp_status, services, services_async
 from genesis.observability.snapshots.surplus import surplus_status
 
@@ -43,6 +44,7 @@ __all__ = [
     "proactive_memory_metrics",
     "provider_activity",
     "queues",
+    "reflex",
     "resilience_state",
     "resilience_state_detail",
     "services",

--- a/src/genesis/observability/snapshots/reflex.py
+++ b/src/genesis/observability/snapshots/reflex.py
@@ -1,0 +1,59 @@
+"""Reflex snapshot — nerve ingestion state + signal-store aggregates.
+
+Two data planes, degrading independently:
+
+- ``ingestor``: live in-memory counters from the running ``ReflexIngestor``
+  (queue depth, processed, dropped). Read via ``GenesisRuntime.peek()`` —
+  the sanctioned no-construct read — so a process without a bootstrapped
+  runtime (the standalone health MCP child, early bootstrap, tests) gets
+  ``None`` here instead of a lazily-constructed blank singleton.
+- ``counts`` / ``top_classes`` / ``total_signals``: DB aggregates from
+  ``reflex_signals`` — portable to any process holding the shared DB.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+def _ingestor_stats() -> dict | None:
+    """Live ingestor counters, or None when no runtime/ingestor exists."""
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        rt = GenesisRuntime.peek()
+        ingestor = getattr(rt, "_reflex_ingestor", None) if rt is not None else None
+        if ingestor is None:
+            return None
+        return dict(ingestor.stats)
+    except Exception:
+        logger.debug("Reflex ingestor stats read failed", exc_info=True)
+        return None
+
+
+async def reflex(db: aiosqlite.Connection | None) -> dict:
+    """Reflex-arc section of the health snapshot (never raises)."""
+    result: dict = {
+        "ingestor": _ingestor_stats(),
+        "counts": {},
+        "top_classes": [],
+        "total_signals": 0,
+    }
+    if db is None:
+        return result
+    try:
+        from genesis.db.crud import reflex_signals as signals_crud
+
+        counts = await signals_crud.count_by_status(db)
+        result["counts"] = counts
+        result["total_signals"] = sum(counts.values())
+        result["top_classes"] = await signals_crud.top_class_keys(db, limit=8)
+    except Exception:
+        logger.debug("Reflex signal aggregates query failed", exc_info=True)
+    return result

--- a/src/genesis/resilience/cc_fallback_probe.py
+++ b/src/genesis/resilience/cc_fallback_probe.py
@@ -18,6 +18,7 @@ fallback far sooner in an active system, so this is purely the idle backstop. A
 probe during an outage just fails fast with a rate-limit error (cheap); it only
 costs a real (minimal) Claude call on the cycle where recovery is detected.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -42,9 +43,14 @@ class CCFallbackProbeWorker:
     def start(self) -> None:
         """Start the probe loop (idempotent — no-op if a task is already running)."""
         if self._task is None or self._task.done():
-            self._task = asyncio.create_task(self._loop())
+            from genesis.util.tasks import tracked_task
+
+            # tracked_task (not bare create_task): only stop() ever awaits this
+            # loop, so an unexpected loop death would otherwise be silent.
+            self._task = tracked_task(self._loop(), name="cc-fallback-probe")
             logger.info(
-                "CC fallback probe worker started (interval=%ds)", self._interval_s,
+                "CC fallback probe worker started (interval=%ds)",
+                self._interval_s,
             )
 
     async def stop(self) -> None:
@@ -115,5 +121,6 @@ class CCFallbackProbeWorker:
 
             if await note_home_recovery():
                 logger.info(
-                    "CC fallback probe: home model %r recovered — fallback cleared", home,
+                    "CC fallback probe: home model %r recovered — fallback cleared",
+                    home,
                 )

--- a/src/genesis/resilience/status_writer.py
+++ b/src/genesis/resilience/status_writer.py
@@ -54,6 +54,7 @@ class StatusFileWriter:
         embedding_count = 0
         if self._pending_embeddings_db is not None:
             from genesis.db.crud import pending_embeddings
+
             embedding_count = await pending_embeddings.count_pending(self._pending_embeddings_db)
 
         total_queued = deferred_count + dead_letter_count + embedding_count
@@ -86,6 +87,7 @@ class StatusFileWriter:
         # Pause state and workload info (if runtime available)
         try:
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             data["paused_state"] = {
                 "is_paused": rt.paused,
@@ -96,9 +98,7 @@ class StatusFileWriter:
             data["heavy_workload"] = rt.heavy_workload
             # Uptime since bootstrap — read by watchdog for stabilization
             if rt._bootstrap_completed_at is not None:
-                data["uptime_s"] = (
-                    datetime.now(UTC) - rt._bootstrap_completed_at
-                ).total_seconds()
+                data["uptime_s"] = (datetime.now(UTC) - rt._bootstrap_completed_at).total_seconds()
         except Exception:
             pass
 
@@ -122,6 +122,19 @@ class StatusFileWriter:
         if scheduler_heartbeats:
             data["scheduler_heartbeats"] = scheduler_heartbeats
 
+        # Reflex-arc ingestor counters — lets the standalone health MCP (a
+        # separate process reading this file) surface live nerve state. The
+        # isinstance guard is load-bearing: a non-dict (absent ingestor, mock
+        # runtime in tests) must never reach json.dumps and break the whole
+        # status write.
+        try:
+            ingestor = getattr(self._runtime, "_reflex_ingestor", None)
+            stats = getattr(ingestor, "stats", None)
+            if isinstance(stats, dict):
+                data["reflex"] = stats
+        except Exception:
+            pass
+
         # Merge bridge/adapter health if provided
         if self._extra_data:
             data.update(self._extra_data)
@@ -135,7 +148,8 @@ class StatusFileWriter:
 
             content = json.dumps(data, indent=2)
             fd, tmp_path = tempfile.mkstemp(
-                dir=str(self._path.parent), suffix=".tmp",
+                dir=str(self._path.parent),
+                suffix=".tmp",
             )
             fd_closed = False
             try:
@@ -153,7 +167,8 @@ class StatusFileWriter:
         except Exception:
             logger.error(
                 "Status file write FAILED at %s — external monitoring will see stale data",
-                self._path, exc_info=True,
+                self._path,
+                exc_info=True,
             )
 
     def _get_failing_jobs(self) -> list[str]:
@@ -165,12 +180,14 @@ class StatusFileWriter:
         except Exception:
             return []
         return [
-            name for name, entry in job_health.items()
-            if entry.get("consecutive_failures", 0) >= 2
+            name for name, entry in job_health.items() if entry.get("consecutive_failures", 0) >= 2
         ]
 
     def _build_summary(
-        self, state, total_queued: int, failing_jobs: list[str] | None = None,
+        self,
+        state,
+        total_queued: int,
+        failing_jobs: list[str] | None = None,
     ) -> str:
         """Describe the worst conditions concisely."""
         parts = []

--- a/src/genesis/routing/escalation.py
+++ b/src/genesis/routing/escalation.py
@@ -5,7 +5,8 @@ trips its circuit breaker N times without recovery, creates a high-priority
 observation so the ego picks it up in its next cycle.
 
 The listener MUST be fast (event bus awaits listeners sequentially).
-Observation creation is deferred via asyncio.create_task().
+Observation creation is deferred via tracked_task (failures land on the
+event bus as task.failed — the reflex nerve — as well as in the log).
 """
 
 from __future__ import annotations
@@ -17,7 +18,8 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
-from genesis.observability.types import GenesisEvent, Severity
+from genesis.observability.types import GenesisEvent, Severity, Subsystem
+from genesis.util.tasks import tracked_task
 
 logger = logging.getLogger(__name__)
 
@@ -48,23 +50,27 @@ class ProviderEscalation:
             return
 
         provider = event.details.get("provider", "unknown")
-        state = self._state.setdefault(provider, {
-            "trip_count": 0,
-            "first_trip_at": None,
-            "escalated": False,
-        })
+        state = self._state.setdefault(
+            provider,
+            {
+                "trip_count": 0,
+                "first_trip_at": None,
+                "escalated": False,
+            },
+        )
         state["trip_count"] += 1
         if state["first_trip_at"] is None:
             state["first_trip_at"] = self._clock().isoformat()
 
         if state["trip_count"] >= _TRIP_THRESHOLD and not state["escalated"]:
             state["escalated"] = True
-            # Defer DB write to a background task — don't block emit()
-            task = asyncio.create_task(
+            # Defer DB write to a tracked background task — don't block emit()
+            tracked_task(
                 self._create_observation(provider, state),
                 name=f"escalation-obs-{provider}",
+                event_bus=self._event_bus,
+                subsystem=Subsystem.ROUTING,
             )
-            task.add_done_callback(self._on_task_done)
 
     def record_recovery(self, provider: str) -> None:
         """Called when a provider recovers (breaker → CLOSED).
@@ -90,33 +96,36 @@ class ProviderEscalation:
         # present); a sync caller (e.g. a unit test) may have none — guard so we
         # never raise there, and defer the DB resolve like _create_observation does.
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
             logger.debug(
                 "record_recovery('%s'): no running loop; skipping observation resolve",
                 provider,
             )
             return
-        task = loop.create_task(
+        tracked_task(
             self._resolve_observation(provider),
             name=f"escalation-resolve-{provider}",
+            event_bus=self._event_bus,
+            subsystem=Subsystem.ROUTING,
         )
-        task.add_done_callback(self._on_task_done)
 
     async def _create_observation(self, provider: str, state: dict) -> None:
         """Create a high-priority observation for a persistently failing provider."""
         from genesis.db.crud import observations
 
-        content = json.dumps({
-            "provider": provider,
-            "trip_count": state["trip_count"],
-            "first_trip_at": state["first_trip_at"],
-            "message": (
-                f"Provider '{provider}' has tripped its circuit breaker "
-                f"{state['trip_count']} times since {state['first_trip_at']} "
-                f"without recovery. All calls are falling back to other providers."
-            ),
-        })
+        content = json.dumps(
+            {
+                "provider": provider,
+                "trip_count": state["trip_count"],
+                "first_trip_at": state["first_trip_at"],
+                "message": (
+                    f"Provider '{provider}' has tripped its circuit breaker "
+                    f"{state['trip_count']} times since {state['first_trip_at']} "
+                    f"without recovery. All calls are falling back to other providers."
+                ),
+            }
+        )
         # Hash on provider name — one unresolved observation per provider.
         # Shared helper so the resolve-on-recovery path computes the SAME hash.
         content_hash = self._provider_content_hash(provider)
@@ -136,8 +145,7 @@ class ProviderEscalation:
             )
             if obs_id:
                 logger.warning(
-                    "Created observation %s for provider '%s' failure "
-                    "(%d trips since %s)",
+                    "Created observation %s for provider '%s' failure (%d trips since %s)",
                     obs_id,
                     provider,
                     state["trip_count"],
@@ -172,14 +180,12 @@ class ProviderEscalation:
                 content_hash=content_hash,
                 resolved_at=self._clock().isoformat(),
                 resolution_notes=(
-                    f"auto-resolved: provider '{provider}' recovered "
-                    f"(circuit breaker closed)"
+                    f"auto-resolved: provider '{provider}' recovered (circuit breaker closed)"
                 ),
             )
             if resolved:
                 logger.info(
-                    "Auto-resolved %d provider_failure observation(s) for "
-                    "recovered provider '%s'",
+                    "Auto-resolved %d provider_failure observation(s) for recovered provider '%s'",
                     resolved,
                     provider,
                 )
@@ -194,16 +200,3 @@ class ProviderEscalation:
     def _provider_content_hash(provider: str) -> str:
         """Deterministic per-provider hash — MUST match between create + resolve."""
         return hashlib.sha256(f"provider_failure:{provider}".encode()).hexdigest()
-
-    @staticmethod
-    def _on_task_done(task: asyncio.Task) -> None:
-        """Log exceptions from background observation tasks."""
-        if task.cancelled():
-            return
-        exc = task.exception()
-        if exc:
-            logger.error(
-                "Escalation observation task failed: %s",
-                exc,
-                exc_info=exc,
-            )

--- a/tests/test_mcp/test_health_mcp.py
+++ b/tests/test_mcp/test_health_mcp.py
@@ -674,18 +674,28 @@ class TestBackupsEnabledHelper:
         assert _backups_enabled() is True
 
     def test_unset_everywhere(self, monkeypatch, tmp_path):
+        from pathlib import Path
+
         from genesis.mcp.health.errors import _backups_enabled
 
         monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        # Signal #3 (an existing backup clone under the real home) must not
+        # leak install state into the test — pin home to tmp_path.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr(
             "genesis.env.secrets_path", lambda: tmp_path / "secrets.env",
         )
         assert _backups_enabled() is False
 
     def test_secrets_file_fallback(self, monkeypatch, tmp_path):
+        from pathlib import Path
+
         from genesis.mcp.health.errors import _backups_enabled
 
         monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        # Signal #3 (an existing backup clone under the real home) must not
+        # leak install state into the test — pin home to tmp_path.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         secrets = tmp_path / "secrets.env"
         secrets.write_text(
             "API_KEY_DEEPINFRA=abc\n"
@@ -695,9 +705,14 @@ class TestBackupsEnabledHelper:
         assert _backups_enabled() is True
 
     def test_secrets_file_empty_value(self, monkeypatch, tmp_path):
+        from pathlib import Path
+
         from genesis.mcp.health.errors import _backups_enabled
 
         monkeypatch.delenv("GENESIS_BACKUP_REPO", raising=False)
+        # Signal #3 (an existing backup clone under the real home) must not
+        # leak install state into the test — pin home to tmp_path.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
         secrets = tmp_path / "secrets.env"
         secrets.write_text("GENESIS_BACKUP_REPO=\n")
         monkeypatch.setattr("genesis.env.secrets_path", lambda: secrets)

--- a/tests/test_mcp/test_reflex_status.py
+++ b/tests/test_mcp/test_reflex_status.py
@@ -1,0 +1,100 @@
+"""Tests for the reflex_status MCP tool (read-only nerve surface)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import reflex_signals as crud
+from genesis.db.schema import create_all_tables
+from genesis.reflex.config import ReflexConfig
+
+T0 = "2026-07-21T00:00:00+00:00"
+T1 = "2026-07-21T01:00:00+00:00"
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _seed(db, fingerprint, *, class_key="KeyErrorxmemory", now=T0):
+    return await crud.upsert_occurrence(
+        db,
+        fingerprint=fingerprint,
+        class_key=class_key,
+        task_name="mem-sync",
+        subsystem="memory",
+        error_type="KeyError",
+        error_message="KeyError: 'x'",
+        traceback_tail="memory/sync.py:_apply",
+        now=now,
+    )
+
+
+async def _run(db):
+    svc = MagicMock()
+    svc._db = db
+    with patch("genesis.mcp.health_mcp._service", svc):
+        from genesis.mcp.health.reflex_status import _impl_reflex_status
+
+        return await _impl_reflex_status()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_without_db():
+    svc = MagicMock()
+    svc._db = None
+    with patch("genesis.mcp.health_mcp._service", svc):
+        from genesis.mcp.health.reflex_status import _impl_reflex_status
+
+        result = await _impl_reflex_status()
+    assert result["status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_reports_counts_classes_and_recents(db):
+    await _seed(db, "fp00000000000001", now=T0)
+    await _seed(db, "fp00000000000002", class_key="ValueErrorxrouting", now=T1)
+    row = await crud.get_by_fingerprint(db, "fp00000000000001")
+    await crud.set_status(db, signal_id=row["id"], expected_from="new", to="diagnosing", now=T1)
+
+    with patch(
+        "genesis.reflex.config.load_reflex_config",
+        return_value=ReflexConfig(ingest_enabled=True),
+    ):
+        result = await _run(db)
+
+    assert result["status"] == "ok"
+    assert result["ingest_enabled"] is True
+    assert result["total_signals"] == 2
+    assert result["counts_by_status"] == {"new": 1, "diagnosing": 1}
+    assert {c["class_key"] for c in result["top_classes"]} == {
+        "KeyErrorxmemory",
+        "ValueErrorxrouting",
+    }
+    # most-recently-seen first
+    assert [r["fingerprint"] for r in result["recent_signals"]] == [
+        "fp00000000000002",
+        "fp00000000000001",
+    ]
+    assert result["recent_signals"][0]["occurrence_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_config_failure_degrades_enabled_to_none(db):
+    await _seed(db, "fp00000000000001")
+    with patch(
+        "genesis.reflex.config.load_reflex_config",
+        side_effect=RuntimeError("bad yaml"),
+    ):
+        result = await _run(db)
+    assert result["status"] == "ok"
+    assert result["ingest_enabled"] is None
+    assert result["total_signals"] == 1

--- a/tests/test_mcp/test_standalone_health.py
+++ b/tests/test_mcp/test_standalone_health.py
@@ -309,6 +309,14 @@ class TestHealthBootstrapLifespan:
             patch("scripts.genesis_mcp_server._DEFAULT_DB", fake_db),
             patch("scripts.genesis_mcp_server._DEFAULT_STATUS", tmp_path / "status.json"),
             patch("genesis.mcp.health_mcp.mcp", mock_mcp),
+            # _bootstrap_health -> init_health_mcp sets these module globals;
+            # patching them here makes the mutation revert on exit instead of
+            # leaking a tmp-path service into later tests (their health_status
+            # then returns the normal-path dict and KeyErrors on "status").
+            patch("genesis.mcp.health_mcp._service", None),
+            patch("genesis.mcp.health_mcp._activity_tracker", None),
+            patch("genesis.mcp.health_mcp._event_bus", None),
+            patch("genesis.mcp.health_mcp._job_retry_registry", None),
         ):
             from scripts.genesis_mcp_server import _bootstrap_health
 
@@ -331,6 +339,14 @@ class TestHealthBootstrapLifespan:
             patch("scripts.genesis_mcp_server._DEFAULT_DB", tmp_path / "nonexistent.db"),
             patch("scripts.genesis_mcp_server._DEFAULT_STATUS", tmp_path / "status.json"),
             patch("genesis.mcp.health_mcp.mcp", mock_mcp),
+            # _bootstrap_health -> init_health_mcp sets these module globals;
+            # patching them here makes the mutation revert on exit instead of
+            # leaking a tmp-path service into later tests (their health_status
+            # then returns the normal-path dict and KeyErrors on "status").
+            patch("genesis.mcp.health_mcp._service", None),
+            patch("genesis.mcp.health_mcp._activity_tracker", None),
+            patch("genesis.mcp.health_mcp._event_bus", None),
+            patch("genesis.mcp.health_mcp._job_retry_registry", None),
         ):
             from scripts.genesis_mcp_server import _bootstrap_health
 
@@ -362,6 +378,14 @@ class TestHealthBootstrapLifespan:
             patch("scripts.genesis_mcp_server._DEFAULT_DB", fake_db),
             patch("scripts.genesis_mcp_server._DEFAULT_STATUS", tmp_path / "status.json"),
             patch("genesis.mcp.health_mcp.mcp", mock_mcp),
+            # _bootstrap_health -> init_health_mcp sets these module globals;
+            # patching them here makes the mutation revert on exit instead of
+            # leaking a tmp-path service into later tests (their health_status
+            # then returns the normal-path dict and KeyErrors on "status").
+            patch("genesis.mcp.health_mcp._service", None),
+            patch("genesis.mcp.health_mcp._activity_tracker", None),
+            patch("genesis.mcp.health_mcp._event_bus", None),
+            patch("genesis.mcp.health_mcp._job_retry_registry", None),
         ):
             from scripts.genesis_mcp_server import _bootstrap_health
 

--- a/tests/test_mcp/test_standalone_health.py
+++ b/tests/test_mcp/test_standalone_health.py
@@ -84,11 +84,39 @@ class TestStandaloneHealthDataService:
         assert snap["resilience_state"]["embedding"] == "FALLBACK"
         assert snap["queue_depths"]["deferred_work"] == 5
 
+    async def test_snapshot_maps_reflex_block(self, tmp_path: Path) -> None:
+        """A reflex block in status.json surfaces under the same .reflex.ingestor
+        shape the in-server snapshot uses."""
+        from genesis.mcp.standalone_health import StandaloneHealthDataService
+
+        data = {
+            "timestamp": "2026-07-21T00:00:00+00:00",
+            "resilience_state": {},
+            "queue_depths": {},
+            "human_summary": "ok",
+            "reflex": {"enabled": True, "queued": 0, "processed": 4, "dropped": 0},
+        }
+        path = tmp_path / "status.json"
+        path.write_text(json.dumps(data))
+        svc = StandaloneHealthDataService(status_path=path, db=None)
+        snap = await svc.snapshot()
+        assert snap["reflex"] == {
+            "ingestor": {"enabled": True, "queued": 0, "processed": 4, "dropped": 0}
+        }
+
+    async def test_snapshot_without_reflex_block_is_empty_dict(self, status_json: Path) -> None:
+        from genesis.mcp.standalone_health import StandaloneHealthDataService
+
+        svc = StandaloneHealthDataService(status_path=status_json, db=None)
+        snap = await svc.snapshot()
+        assert snap["reflex"] == {}
+
     async def test_snapshot_missing_file(self, tmp_path: Path) -> None:
         from genesis.mcp.standalone_health import StandaloneHealthDataService
 
         svc = StandaloneHealthDataService(
-            status_path=tmp_path / "nonexistent.json", db=None,
+            status_path=tmp_path / "nonexistent.json",
+            db=None,
         )
         snap = await svc.snapshot()
 
@@ -108,7 +136,8 @@ class TestStandaloneHealthDataService:
         assert "parse" in snap["message"].lower() or "json" in snap["message"].lower()
 
     async def test_health_status_uses_standalone_snapshot(
-        self, status_json: Path,
+        self,
+        status_json: Path,
     ) -> None:
         """When wired with StandaloneHealthDataService, health_status returns file data."""
         import genesis.mcp.health_mcp as health_mcp_mod
@@ -144,12 +173,19 @@ class TestStandaloneBootstrapAndJobHealth:
         from genesis.mcp.health import manifest as manifest_mod
 
         mf = tmp_path / "bootstrap_manifest.json"
-        mf.write_text(json.dumps({
-            "bootstrapped": True,
-            "manifest": {"db": "ok", "outreach": "degraded: no token",
-                         "voice": "failed: no api key"},
-            "persisted_at": "2026-07-06T01:00:00+00:00",
-        }))
+        mf.write_text(
+            json.dumps(
+                {
+                    "bootstrapped": True,
+                    "manifest": {
+                        "db": "ok",
+                        "outreach": "degraded: no token",
+                        "voice": "failed: no api key",
+                    },
+                    "persisted_at": "2026-07-06T01:00:00+00:00",
+                }
+            )
+        )
         monkeypatch.setattr(manifest_mod, "_MANIFEST_FILE", mf)
 
         result = manifest_mod._read_persisted_manifest()
@@ -172,9 +208,7 @@ class TestStandaloneBootstrapAndJobHealth:
         """No persisted file → reader declines (caller reports empty manifest)."""
         from genesis.mcp.health import manifest as manifest_mod
 
-        monkeypatch.setattr(
-            manifest_mod, "_MANIFEST_FILE", tmp_path / "nope.json"
-        )
+        monkeypatch.setattr(manifest_mod, "_MANIFEST_FILE", tmp_path / "nope.json")
         assert manifest_mod._read_persisted_manifest() is None
 
     async def test_bootstrap_manifest_corrupt_file_returns_none(
@@ -258,7 +292,8 @@ class TestHealthBootstrapLifespan:
     """Test that health bootstrap opens and closes DB via lifespan."""
 
     async def test_bootstrap_uses_lifespan_when_db_exists(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """When DB file exists, _bootstrap_health sets mcp._lifespan."""
         from unittest.mock import MagicMock, patch
@@ -284,7 +319,8 @@ class TestHealthBootstrapLifespan:
         mock_mcp.run.assert_called_once_with(transport="stdio")
 
     async def test_bootstrap_no_lifespan_when_db_missing(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """When DB file is missing, falls back to db=None (no lifespan)."""
         from unittest.mock import MagicMock, patch
@@ -304,7 +340,8 @@ class TestHealthBootstrapLifespan:
         mock_mcp.run.assert_called_once_with(transport="stdio")
 
     async def test_lifespan_opens_and_closes_db(
-        self, tmp_path: Path,
+        self,
+        tmp_path: Path,
     ) -> None:
         """The lifespan context manager opens DB on enter and closes on exit."""
         from unittest.mock import AsyncMock, MagicMock, patch
@@ -383,7 +420,8 @@ class TestStandaloneServiceDetection:
         assert snap["services"]["watchdog_timer"]["active_state"] == "active"
 
     async def test_snapshot_services_degrades_gracefully(
-        self, status_json: Path,
+        self,
+        status_json: Path,
     ) -> None:
         """If collect_service_status raises, services should be empty dict."""
         from unittest.mock import patch
@@ -426,7 +464,8 @@ class TestHeartbeatQueriesWithDB:
         )
 
         svc = StandaloneHealthDataService(
-            status_path="/tmp/nonexistent.json", db=db,
+            status_path="/tmp/nonexistent.json",
+            db=db,
         )
 
         old_service = health_mcp_mod._service
@@ -450,7 +489,8 @@ class TestHeartbeatQueriesWithDB:
         from genesis.mcp.standalone_health import StandaloneHealthDataService
 
         svc = StandaloneHealthDataService(
-            status_path="/tmp/nonexistent.json", db=None,
+            status_path="/tmp/nonexistent.json",
+            db=None,
         )
 
         old_service = health_mcp_mod._service
@@ -488,7 +528,8 @@ class TestHeartbeatQueriesWithDB:
         )
 
         svc = StandaloneHealthDataService(
-            status_path="/tmp/nonexistent.json", db=db,
+            status_path="/tmp/nonexistent.json",
+            db=db,
         )
 
         old_service = health_mcp_mod._service
@@ -610,8 +651,15 @@ class TestEnrichFromDB:
             "(call_site_id, last_run_at, provider_used, model_id, "
             "input_tokens, output_tokens, updated_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("test_site", "2026-03-27T04:00:00+00:00", "openrouter", "gpt-4",
-             100, 50, "2026-03-27T04:00:00+00:00"),
+            (
+                "test_site",
+                "2026-03-27T04:00:00+00:00",
+                "openrouter",
+                "gpt-4",
+                100,
+                50,
+                "2026-03-27T04:00:00+00:00",
+            ),
         )
         await db.commit()
 
@@ -629,7 +677,8 @@ class TestEnrichFromDB:
         assert site["last_tokens"] == 150
 
     async def test_enrich_failure_does_not_corrupt_snapshot(
-        self, status_json: Path,
+        self,
+        status_json: Path,
     ) -> None:
         """If enrichment fails, the snapshot should still return valid data."""
         from unittest.mock import AsyncMock, patch
@@ -654,7 +703,9 @@ class TestEnrichFromDB:
         assert isinstance(snap["cost"], dict)
 
     async def test_enrich_cost_uses_real_cost_events_not_shadow(
-        self, db, status_json: Path,
+        self,
+        db,
+        status_json: Path,
     ) -> None:
         """The cost field must report REAL spend from cost_events with a real
         budget_status — NOT the shadow 'if-CC-were-API-billed' figure from
@@ -742,8 +793,10 @@ class TestReflectionHeartbeatEmission:
         # A critical signal is required to trigger the LLM reflection path
         # (PR #404: silent micro ticks unless critical signals are present)
         critical_signal = SignalReading(
-            name="software_error_spike", value=1.0,
-            source="test", collected_at="2026-01-01T00:00:00Z",
+            name="software_error_spike",
+            value=1.0,
+            source="test",
+            collected_at="2026-01-01T00:00:00Z",
         )
         tick = MagicMock(spec=TickResult)
         tick.classified_depth = Depth.MICRO
@@ -753,8 +806,10 @@ class TestReflectionHeartbeatEmission:
         await loop._dispatch_reflection(tick)
 
         mock_bus.emit.assert_awaited_once_with(
-            Subsystem.REFLECTION, Severity.DEBUG,
-            "heartbeat", "micro-reflection completed",
+            Subsystem.REFLECTION,
+            Severity.DEBUG,
+            "heartbeat",
+            "micro-reflection completed",
         )
 
     async def test_heartbeat_not_emitted_on_failure(self) -> None:
@@ -781,8 +836,10 @@ class TestReflectionHeartbeatEmission:
         # Provide a critical signal so we enter the reflect path,
         # but reflect returns success=False → no heartbeat
         critical_signal = SignalReading(
-            name="software_error_spike", value=1.0,
-            source="test", collected_at="2026-01-01T00:00:00Z",
+            name="software_error_spike",
+            value=1.0,
+            source="test",
+            collected_at="2026-01-01T00:00:00Z",
         )
         tick = MagicMock(spec=TickResult)
         tick.classified_depth = Depth.MICRO
@@ -822,8 +879,10 @@ class TestReflectionHeartbeatEmission:
         # and NO LLM reflection runs. value=0.0 keeps it structurally non-critical
         # even if its name is ever added to _MICRO_CRITICAL_SIGNALS.
         routine_signal = SignalReading(
-            name="container_memory_pct", value=0.0,
-            source="test", collected_at="2026-01-01T00:00:00Z",
+            name="container_memory_pct",
+            value=0.0,
+            source="test",
+            collected_at="2026-01-01T00:00:00Z",
         )
         tick = MagicMock(spec=TickResult)
         tick.classified_depth = Depth.MICRO
@@ -834,8 +893,10 @@ class TestReflectionHeartbeatEmission:
 
         mock_engine.reflect.assert_not_awaited()
         mock_bus.emit.assert_awaited_once_with(
-            Subsystem.REFLECTION, Severity.DEBUG,
-            "heartbeat", "reflection idle (no critical signals)",
+            Subsystem.REFLECTION,
+            Severity.DEBUG,
+            "heartbeat",
+            "reflection idle (no critical signals)",
         )
 
 
@@ -858,8 +919,15 @@ class TestReflectionHeartbeatThreshold:
         await db.execute(
             "INSERT INTO events (id, timestamp, subsystem, severity, event_type, "
             "message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("ev-refl-hb", ts, "reflection", "DEBUG", "heartbeat",
-             "reflection idle (no critical signals)", ts),
+            (
+                "ev-refl-hb",
+                ts,
+                "reflection",
+                "DEBUG",
+                "heartbeat",
+                "reflection idle (no critical signals)",
+                ts,
+            ),
         )
         await db.commit()
 

--- a/tests/test_observability/test_reflex_snapshot.py
+++ b/tests/test_observability/test_reflex_snapshot.py
@@ -12,9 +12,9 @@ from unittest.mock import MagicMock, patch
 
 import aiosqlite
 import pytest
-from genesis.observability.snapshots.reflex import reflex
 
 from genesis.db.crud import reflex_signals as crud
+from genesis.observability.snapshots.reflex import reflex
 
 M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
 

--- a/tests/test_observability/test_reflex_snapshot.py
+++ b/tests/test_observability/test_reflex_snapshot.py
@@ -1,0 +1,99 @@
+"""Tests for the reflex health-snapshot section.
+
+The section must degrade to DB-only facts when no runtime/ingestor exists
+(MCP child process, early bootstrap) and to an empty-but-shaped dict when
+even the DB is absent — it can never poison the gathered snapshot.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import aiosqlite
+import pytest
+from genesis.observability.snapshots.reflex import reflex
+
+from genesis.db.crud import reflex_signals as crud
+
+M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+T0 = "2026-07-21T00:00:00+00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        await M70.up(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _seed(db):
+    await crud.upsert_occurrence(
+        db,
+        fingerprint="fp00000000000001",
+        class_key="KeyErrorxmemory",
+        task_name="mem-sync",
+        subsystem="memory",
+        error_type="KeyError",
+        error_message="KeyError: 'x'",
+        traceback_tail="memory/sync.py:_apply",
+        now=T0,
+    )
+
+
+class TestReflexSnapshot:
+    async def test_db_only_when_no_runtime(self, db):
+        await _seed(db)
+        with patch("genesis.runtime.GenesisRuntime.peek", return_value=None):
+            snap = await reflex(db)
+        assert snap["ingestor"] is None
+        assert snap["counts"] == {"new": 1}
+        assert snap["total_signals"] == 1
+        assert snap["top_classes"][0]["class_key"] == "KeyErrorxmemory"
+
+    async def test_ingestor_stats_included_when_present(self, db):
+        await _seed(db)
+        rt = MagicMock()
+        rt._reflex_ingestor.stats = {
+            "enabled": True,
+            "queued": 0,
+            "processed": 3,
+            "dropped": 0,
+        }
+        with patch("genesis.runtime.GenesisRuntime.peek", return_value=rt):
+            snap = await reflex(db)
+        assert snap["ingestor"] == {
+            "enabled": True,
+            "queued": 0,
+            "processed": 3,
+            "dropped": 0,
+        }
+        assert snap["counts"] == {"new": 1}
+
+    async def test_runtime_without_ingestor_degrades(self, db):
+        rt = MagicMock()
+        rt._reflex_ingestor = None
+        with patch("genesis.runtime.GenesisRuntime.peek", return_value=rt):
+            snap = await reflex(db)
+        assert snap["ingestor"] is None
+        assert snap["counts"] == {}
+        assert snap["total_signals"] == 0
+
+    async def test_no_db_returns_shaped_empty(self):
+        snap = await reflex(None)
+        assert snap == {
+            "ingestor": None,
+            "counts": {},
+            "top_classes": [],
+            "total_signals": 0,
+        }
+
+    async def test_db_error_degrades_not_raises(self):
+        bad_db = MagicMock()
+        bad_db.execute.side_effect = RuntimeError("boom")
+        with patch("genesis.runtime.GenesisRuntime.peek", return_value=None):
+            snap = await reflex(bad_db)
+        assert snap["counts"] == {}
+        assert snap["total_signals"] == 0

--- a/tests/test_reflex/conftest.py
+++ b/tests/test_reflex/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for reflex tests.
+
+Install isolation: ``load_reflex_config`` merges the install-local overlay
+(``~/.genesis/config/reflex.local.yaml``) resolved by file STEM — so on any
+install that has enabled ingestion via the overlay, tmp-file config tests
+would silently load ``ingest_enabled: true`` and fail. Point the overlay
+resolver at a path that never exists so these tests see only the file they
+wrote. (CI has no overlay; this bit only real installs.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_local_overlay(monkeypatch, tmp_path):
+    import genesis._config_overlay as overlay_mod
+
+    monkeypatch.setattr(
+        overlay_mod,
+        "_resolve_overlay_path",
+        lambda base_path: tmp_path / "no-overlay" / "never.local.yaml",
+    )

--- a/tests/test_reflex/test_signals_crud.py
+++ b/tests/test_reflex/test_signals_crud.py
@@ -181,3 +181,47 @@ class TestListByStatus:
         )
         rows = await crud.list_by_status(db, "new")
         assert [r["fingerprint"] for r in rows] == ["fp00000000000001"]
+
+
+class TestAggregates:
+    """PR1.5 observability aggregates — shared by the MCP tool and the snapshot."""
+
+    async def test_count_by_status(self, db):
+        await _upsert(db, fingerprint="fp00000000000001")
+        await _upsert(db, fingerprint="fp00000000000002")
+        row2 = await crud.get_by_fingerprint(db, "fp00000000000002")
+        await crud.set_status(
+            db, signal_id=row2["id"], expected_from="new", to="diagnosing", now=T1
+        )
+        counts = await crud.count_by_status(db)
+        assert counts == {"new": 1, "diagnosing": 1}
+
+    async def test_count_by_status_empty(self, db):
+        assert await crud.count_by_status(db) == {}
+
+    async def test_top_class_keys_orders_by_signal_count_then_occurrences(self, db):
+        # 2 distinct signals in KeyErrorxmemory; 1 signal (3 occurrences) in ValueErrorxrouting
+        await _upsert(db, fingerprint="fp00000000000001")
+        await _upsert(db, fingerprint="fp00000000000002")
+        for now in (T0, T1, T2):
+            await _upsert(
+                db, fingerprint="fp00000000000003", class_key="ValueErrorxrouting", now=now
+            )
+        top = await crud.top_class_keys(db, limit=8)
+        assert top[0] == {"class_key": "KeyErrorxmemory", "signals": 2, "occurrences": 2}
+        assert top[1] == {"class_key": "ValueErrorxrouting", "signals": 1, "occurrences": 3}
+
+    async def test_top_class_keys_respects_limit(self, db):
+        await _upsert(db, fingerprint="fp00000000000001", class_key="A")
+        await _upsert(db, fingerprint="fp00000000000002", class_key="B")
+        assert len(await crud.top_class_keys(db, limit=1)) == 1
+
+    async def test_list_recent_orders_by_last_seen_desc(self, db):
+        await _upsert(db, fingerprint="fp00000000000001", now=T0)
+        await _upsert(db, fingerprint="fp00000000000002", now=T2)
+        await _upsert(db, fingerprint="fp00000000000003", now=T1)
+        rows = await crud.list_recent(db, limit=2)
+        assert [r["fingerprint"] for r in rows] == [
+            "fp00000000000002",
+            "fp00000000000003",
+        ]

--- a/tests/test_resilience/test_status_writer.py
+++ b/tests/test_resilience/test_status_writer.py
@@ -131,3 +131,48 @@ class TestStatusFileWriter:
         # pending_embeddings comes from actual db (should be 0 in empty db)
         assert data["queue_depths"]["pending_embeddings"] == 0
         assert "15 items queued" in data["human_summary"]
+
+
+class TestReflexBlock:
+    """The reflex block only appears when a real dict of stats exists —
+    a mock runtime / absent ingestor must never poison the JSON write."""
+
+    async def test_real_stats_dict_included(self, sm, tmp_path):
+        from unittest.mock import MagicMock
+
+        rt = MagicMock()
+        rt.job_health = {}
+        rt._reflex_ingestor.stats = {
+            "enabled": True,
+            "queued": 2,
+            "processed": 7,
+            "dropped": 0,
+        }
+        path = tmp_path / "status.json"
+        writer = StatusFileWriter(state_machine=sm, runtime=rt, path=str(path))
+        await writer.write()
+        data = json.loads(path.read_text())
+        assert data["reflex"] == {
+            "enabled": True,
+            "queued": 2,
+            "processed": 7,
+            "dropped": 0,
+        }
+
+    async def test_mock_runtime_without_real_stats_omits_block(self, sm, tmp_path):
+        from unittest.mock import MagicMock
+
+        rt = MagicMock()  # .stats resolves to a MagicMock, not a dict
+        rt.job_health = {}
+        path = tmp_path / "status.json"
+        writer = StatusFileWriter(state_machine=sm, runtime=rt, path=str(path))
+        await writer.write()
+        data = json.loads(path.read_text())
+        assert "reflex" not in data
+
+    async def test_no_runtime_omits_block(self, sm, tmp_path):
+        path = tmp_path / "status.json"
+        writer = StatusFileWriter(state_machine=sm, path=str(path))
+        await writer.write()
+        data = json.loads(path.read_text())
+        assert "reflex" not in data

--- a/tests/test_routing/test_escalation.py
+++ b/tests/test_routing/test_escalation.py
@@ -101,8 +101,7 @@ class TestRecovery:
             "INSERT INTO observations "
             "(id, source, type, content, priority, resolved, content_hash, created_at) "
             "VALUES (?, 'routing', 'provider_failure', ?, 'high', 0, ?, datetime('now'))",
-            (oid, f"{provider} failing",
-             escalation._provider_content_hash(provider)),
+            (oid, f"{provider} failing", escalation._provider_content_hash(provider)),
         )
         await empty_db.commit()
 
@@ -110,7 +109,8 @@ class TestRecovery:
         # Raw read of (resolved, resolution_notes) — independent of obs_crud so the
         # assertion can't be defeated by a leaked CRUD mock elsewhere in the suite.
         cur = await empty_db.execute(
-            "SELECT resolved, resolution_notes FROM observations WHERE id = ?", (oid,),
+            "SELECT resolved, resolution_notes FROM observations WHERE id = ?",
+            (oid,),
         )
         return await cur.fetchone()
 
@@ -136,10 +136,7 @@ class TestRecovery:
 
         await self._make_pf(escalation, empty_db, "prov-y", "pf-y")
         escalation.record_recovery("prov-y")
-        pending = [
-            t for t in asyncio.all_tasks()
-            if t.get_name() == "escalation-resolve-prov-y"
-        ]
+        pending = [t for t in asyncio.all_tasks() if t.get_name() == "escalation-resolve-prov-y"]
         assert pending, "record_recovery did not schedule the resolve task"
         await asyncio.gather(*pending)
         assert (await self._pf_state(empty_db, "pf-y"))["resolved"] == 1
@@ -173,6 +170,79 @@ class TestEventBusIntegration:
         initial_count = len(event_bus._listeners)
         escalation.attach()
         assert len(event_bus._listeners) == initial_count + 1
+
+
+class TestTaskFailureReporting:
+    """The tracked_task swap (reflex A4): a crash in a deferred escalation
+    task must land on the event bus as task.failed — the log-only
+    _on_task_done callback it replaced reported to nobody. The inner DB
+    helpers swallow their own errors, so these tests inject the failure at
+    the coroutine boundary (the escape path the wrapper exists for)."""
+
+    async def _settle(self):
+        import asyncio
+
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+    def _capture(self, event_bus):
+        captured: list = []
+
+        async def listener(event):
+            captured.append(event)
+
+        event_bus.subscribe(listener, min_severity=Severity.ERROR)
+        return captured
+
+    async def test_create_observation_crash_emits_task_failed(
+        self, escalation, event_bus, monkeypatch
+    ):
+        captured = self._capture(event_bus)
+
+        async def _boom(provider, state):
+            raise RuntimeError("obs write exploded")
+
+        monkeypatch.setattr(escalation, "_create_observation", _boom)
+        for _ in range(_TRIP_THRESHOLD):
+            await escalation._on_event(_make_event())
+        await self._settle()
+
+        failed = [e for e in captured if e.event_type == "task.failed"]
+        assert len(failed) == 1
+        assert failed[0].details["task_name"] == "escalation-obs-test-provider"
+        assert failed[0].details["error_type"] == "RuntimeError"
+        assert failed[0].subsystem == Subsystem.ROUTING
+
+    async def test_resolve_observation_crash_emits_task_failed(
+        self, escalation, event_bus, monkeypatch
+    ):
+        captured = self._capture(event_bus)
+
+        async def _boom(provider):
+            raise RuntimeError("resolve exploded")
+
+        monkeypatch.setattr(escalation, "_resolve_observation", _boom)
+        # Seed state so record_recovery has something to clear, then recover.
+        for _ in range(_TRIP_THRESHOLD):
+            await escalation._on_event(_make_event())
+        escalation.record_recovery("test-provider")
+        await self._settle()
+
+        failed = [
+            e
+            for e in captured
+            if e.event_type == "task.failed"
+            and e.details.get("task_name") == "escalation-resolve-test-provider"
+        ]
+        assert len(failed) == 1
+        assert failed[0].details["error_type"] == "RuntimeError"
+
+    async def test_successful_task_emits_nothing(self, escalation, event_bus):
+        captured = self._capture(event_bus)
+        for _ in range(_TRIP_THRESHOLD):
+            await escalation._on_event(_make_event())
+        await self._settle()
+        assert [e for e in captured if e.event_type == "task.failed"] == []
 
 
 class TestCircuitBreakerRecoveryCallback:


### PR DESCRIPTION
## What

Makes the reflex nerve (PR1, #1177) watchable during its bake, and finishes the nerve by wrapping the remaining safe bare `asyncio.create_task` sites.

**Four read surfaces, one CRUD layer** (`count_by_status` / `top_class_keys` / `list_recent`):
- **`reflex_status` MCP tool** — process-portable (config loader + DB only; the health MCP is a CC child with no runtime). Pattern-copies `build_lane_status`.
- **In-server health snapshot** (`observability/snapshots/reflex.py`) — live ingestor counters via `GenesisRuntime.peek()` (no-construct read), degrades to DB-only when no runtime/ingestor exists; appended LAST in the `health_data.py` gather so existing unpack positions are untouched.
- **`status.json` block** — `StatusFileWriter` writes `rt._reflex_ingestor.stats`, `isinstance(dict)`-guarded so absent ingestors / mock runtimes can never poison the JSON write; the standalone health service maps it through under the same `.reflex.ingestor` shape.
- **Dashboard Reflex card** (`reflexSemantic()`), deliberately NOT in `overallHealthSemantic()`: a detected signal is the subsystem *working*, not the system degrading — only ingest-queue drops mark the card degraded.

**A4 sweep** (every bare `create_task` in `src/genesis` enumerated, each site read in full):
- Wrapped: `cc_fallback_probe._loop` (fire-and-forget; unexpected loop death was silent), `escalation` create/resolve tasks (explicit `event_bus` + `Subsystem.ROUTING`; dead `_on_task_done` removed).
- Stay bare with documenting comments: orchestrator `tree_task` and `health_data` single-flight (awaited by callers — wrapping would double-report), `events._db_writer` (bus can't observe itself), `provider_activity:106` (already the ImportError fallback of a tracked_task call).

**Test-isolation fixes** — three pre-existing install-state leaks (passed on CI, failed on configured installs): reflex config tests picked up the stem-resolved `~/.genesis` overlay; standalone lifespan tests leaked `_bootstrap_health`'s module-global `_service`; backups tests hit the real backup clone via `Path.home()`.

## Why

Jay's point closing PR1: the bake needs eyes. This instruments the nerve while it soaks (24h bake gates PR2) without touching any ingest behavior — the live nerve on the baking install is read, never written.

## Verification

- 314 targeted tests pass (reflex, mcp, observability, resilience, routing, cc, knowledge).
- Inline code review: DONE, zero findings ≥80% confidence; gather/unpack positions verified by direct count; tracked_task cancellation semantics verified identical on the probe/escalation paths.
- Subsystem-map guard CLEAN; `node --check` on dashboard.js.
- Post-merge E2E planned: `curl /api/genesis/health | jq .reflex`, `jq .reflex ~/.genesis/status.json`, dashboard card, `reflex_status` in a fresh CC session.

Ledger: abb7911a5ea24ab6892d739ecdd1fc37

🤖 Generated with [Claude Code](https://claude.com/claude-code)