### PR TITLE
perf(memory): defer proactive-recall side effects off the hot path (ac27b693, PR-1)

### DIFF
--- a/.claude/docs/proactive-memory-hook.md
+++ b/.claude/docs/proactive-memory-hook.md
@@ -66,6 +66,30 @@ server path enforces. It self-heals on the next prompt once the server is back.
 `mode` (`server`/`degraded`/`local`/`off`) and `server_ms`, so the server-path
 fallback rate is directly observable. The health dashboard reads this file.
 
+The server response carries `timings_ms` with a per-stage breakdown —
+`embed`, `recall`, and (since ac27b693) the recall sub-stages `vector`,
+`expand`, `fts`, `activation`, plus `rerank`, `enrich`, `procedure`, `total`.
+When a call exceeds the slow-log threshold the server writes one
+`proactive recall slow: {…}` INFO line, so a latency regression is attributable
+to a stage from the journal alone without live probing.
+
+## Latency: work off the hot path
+
+The per-prompt path is latency-budgeted (the route's 4.5s bound), so the server
+does the least work needed to build the response and defers the rest:
+
+- **Write-backs and eval emits are deferred.** The `retrieved_count` bumps, the
+  J-9 `recall_fired` + diagnostics events, the entity-lane shadow probe, the
+  injection-gate immunity emit, and the procedure `surfaced_count` bump all run
+  on background tasks AFTER the response returns — they never affect what is
+  injected. A fixed in-flight backstop makes recall fall back to running them
+  inline (rather than piling up) if they ever drain slower than prompts arrive.
+  Deep-search recall (`memory_recall` MCP) keeps them inline.
+- **The tag co-occurrence index refreshes in the background** (stale-while-
+  revalidate): a stale index never blocks a prompt on a full-corpus scroll; the
+  current prompt uses whatever the index holds and a single background task
+  rebuilds it.
+
 ## Related
 
 - Endpoint + engine: `src/genesis/dashboard/routes/proactive.py`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **Proactive memory recall holds up better when several sessions are active at
+  once.** When multiple Claude Code sessions run side by side, each prompt's
+  memory recall used to spend much of its time-budget on bookkeeping (usage
+  counters, quality metrics) that has nothing to do with the answer — and under
+  that load it would sometimes time out and fall back to the weaker keyword-only
+  memory (`[Memory·degraded]`). That bookkeeping now runs in the background after
+  the results are returned, and the internal tag index refreshes in the
+  background instead of stalling the first prompt after a restart. Recall quality
+  is unchanged; it just stops dropping to the degraded path under concurrency.
+
 ### Fixed
 
 - **Host setup no longer force-deletes a container it wrongly thinks is

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -820,6 +820,7 @@ async def _proactive_impl(
     kb_slots: int | None = None,
     rerank_timeout_s: float | None = None,
     stats: dict | None = None,
+    defer_side_effects: bool = False,
 ) -> list[dict]:
     """Cross-session context injection for prompts — shared engine.
 
@@ -841,6 +842,12 @@ async def _proactive_impl(
     drops garbage + non-intentional knowledge_base and ``kb_slots`` caps KB — so
     the two callers do NOT get identical injected results; the MCP tool is
     intentionally left unfiltered. No duplicated orchestration.
+
+    ``defer_side_effects``: proactive-endpoint only (the MCP tool leaves it
+    False → byte-for-byte unchanged). Moves recall's write-backs/emits AND this
+    function's ``record_would_block`` immunity emit off the request's latency
+    path into background tasks, so the per-prompt path returns without waiting
+    on those DB writes (follow-up ac27b693). All best-effort.
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
@@ -871,6 +878,7 @@ async def _proactive_impl(
         rerank_timeout_s=rerank_timeout_s,
         stats=stats,
         extra_fts_terms=extra_fts_terms,
+        defer_side_effects=defer_side_effects,
         skip_writeback=lambda r: (
             immunity_shadow.should_enforce_drop(
                 gate="injection",
@@ -1002,13 +1010,16 @@ async def _proactive_impl(
         out.append(nd)
         if nr.collection == "knowledge_base":
             kb_count += 1
+
     # WS-3 B1 gate 4 (injection): shadow-record external content reaching this
     # proactive-recall prompt (observe-only). db=memory_mod._db when set, else
     # the emit self-resolves a short-lived connection. `enforced_drops` in the
     # detail is the auto-demote signal — wrap-only observations must never
     # count toward demotion (Codex round-6: a normal explicit-recall session
     # would otherwise flip the gate back to shadow).
-    await immunity_shadow.record_would_block(
+    # Build the emit coroutine HERE (call stays lexically in _proactive_impl so
+    # the injection-gate coverage guard still sees this function emit gate 4).
+    _would_block = immunity_shadow.record_would_block(
         gate="injection",
         source_kind="recall_inject",
         source_ref="mcp/memory/core.py::_proactive_impl",
@@ -1017,6 +1028,15 @@ async def _proactive_impl(
         db=memory_mod._db,
         detail={"enforced_drops": dropped} if dropped else None,
     )
+    # Latency-budgeted proactive path defers this DB write off the hot path
+    # (follow-up ac27b693); the MCP tool (defer_side_effects=False) keeps it
+    # inline — byte-for-byte unchanged. Best-effort either way.
+    if defer_side_effects:
+        from genesis.util.tasks import tracked_task
+
+        tracked_task(_would_block, name="proactive_would_block")
+    else:
+        await _would_block
     return out
 
 

--- a/src/genesis/memory/intent.py
+++ b/src/genesis/memory/intent.py
@@ -11,6 +11,7 @@ OpenClaw QMD query expansion. See:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import time
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Intent classification
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class QueryIntent:
@@ -67,31 +69,55 @@ class IntentProfile:
 # Priority order matters: more specific intents first.
 # WHY before WHAT because "what was the reason" should match WHY.
 _INTENT_PATTERNS: list[tuple[str, re.Pattern[str], float]] = [
-    ("WHY", re.compile(
-        r"^(why\b|what.{0,20}reason|rationale\b|motivation\b|justification\b)",
-        re.IGNORECASE,
-    ), 0.85),
-    ("HOW", re.compile(
-        r"^(how\b|steps?\s+to\b|procedure\b|process\s+for\b|instructions?\b)",
-        re.IGNORECASE,
-    ), 0.85),
-    ("WHEN", re.compile(
-        r"^(when\b|timeline\b|history\s+of\b|last\s+time\b|first\s+time\b)",
-        re.IGNORECASE,
-    ), 0.85),
-    ("WHERE", re.compile(
-        r"^(where\b|location\s+of\b|which\s+file\b|find\s+the\b)",
-        re.IGNORECASE,
-    ), 0.85),
+    (
+        "WHY",
+        re.compile(
+            r"^(why\b|what.{0,20}reason|rationale\b|motivation\b|justification\b)",
+            re.IGNORECASE,
+        ),
+        0.85,
+    ),
+    (
+        "HOW",
+        re.compile(
+            r"^(how\b|steps?\s+to\b|procedure\b|process\s+for\b|instructions?\b)",
+            re.IGNORECASE,
+        ),
+        0.85,
+    ),
+    (
+        "WHEN",
+        re.compile(
+            r"^(when\b|timeline\b|history\s+of\b|last\s+time\b|first\s+time\b)",
+            re.IGNORECASE,
+        ),
+        0.85,
+    ),
+    (
+        "WHERE",
+        re.compile(
+            r"^(where\b|location\s+of\b|which\s+file\b|find\s+the\b)",
+            re.IGNORECASE,
+        ),
+        0.85,
+    ),
     # STATUS is not anchored — often appears mid-query
-    ("STATUS", re.compile(
-        r"(status\s+of\b|progress\s+on\b|current\s+state\b|update\s+on\b|is\s+it\s+done\b)",
-        re.IGNORECASE,
-    ), 0.80),
-    ("WHAT", re.compile(
-        r"^(what\b|define\b|describe\b|explain\s+what\b|tell\s+me\s+about\b)",
-        re.IGNORECASE,
-    ), 0.80),
+    (
+        "STATUS",
+        re.compile(
+            r"(status\s+of\b|progress\s+on\b|current\s+state\b|update\s+on\b|is\s+it\s+done\b)",
+            re.IGNORECASE,
+        ),
+        0.80,
+    ),
+    (
+        "WHAT",
+        re.compile(
+            r"^(what\b|define\b|describe\b|explain\s+what\b|tell\s+me\s+about\b)",
+            re.IGNORECASE,
+        ),
+        0.80,
+    ),
 ]
 
 INTENT_PROFILES: dict[str, IntentProfile] = {
@@ -140,7 +166,9 @@ def classify_intent(query: str) -> QueryIntent:
     cleaned = query.strip()
     if not cleaned:
         return QueryIntent(
-            category="GENERAL", confidence=0.0, matched_pattern="",
+            category="GENERAL",
+            confidence=0.0,
+            matched_pattern="",
             recommended_source=_INTENT_TO_SOURCE["GENERAL"],
         )
 
@@ -155,7 +183,9 @@ def classify_intent(query: str) -> QueryIntent:
             )
 
     return QueryIntent(
-        category="GENERAL", confidence=0.0, matched_pattern="",
+        category="GENERAL",
+        confidence=0.0,
+        matched_pattern="",
         recommended_source=_INTENT_TO_SOURCE["GENERAL"],
     )
 
@@ -176,14 +206,56 @@ STANCES: tuple[str, ...] = ("command", "chatter", "general", "question_decision"
 
 # Imperative verbs that, when they lead a non-interrogative prompt, mark it a
 # command (act-on-the-system, minimal recall). Kept broad but action-oriented.
-_COMMAND_VERBS = frozenset({
-    "restart", "run", "rerun", "deploy", "redeploy", "stop", "start", "commit",
-    "push", "pull", "fix", "install", "uninstall", "delete", "remove", "drop",
-    "add", "create", "update", "upgrade", "rebuild", "build", "revert", "merge",
-    "rebase", "kill", "enable", "disable", "set", "unset", "clear", "checkout",
-    "retry", "execute", "launch", "apply", "reset", "rollback", "bump",
-    "regenerate", "reload", "restore", "sync", "cancel", "abort", "purge",
-})
+_COMMAND_VERBS = frozenset(
+    {
+        "restart",
+        "run",
+        "rerun",
+        "deploy",
+        "redeploy",
+        "stop",
+        "start",
+        "commit",
+        "push",
+        "pull",
+        "fix",
+        "install",
+        "uninstall",
+        "delete",
+        "remove",
+        "drop",
+        "add",
+        "create",
+        "update",
+        "upgrade",
+        "rebuild",
+        "build",
+        "revert",
+        "merge",
+        "rebase",
+        "kill",
+        "enable",
+        "disable",
+        "set",
+        "unset",
+        "clear",
+        "checkout",
+        "retry",
+        "execute",
+        "launch",
+        "apply",
+        "reset",
+        "rollback",
+        "bump",
+        "regenerate",
+        "reload",
+        "restore",
+        "sync",
+        "cancel",
+        "abort",
+        "purge",
+    }
+)
 
 # "what did we decide/agree/choose …" and kin — history-recall questions that
 # deserve a wider budget even when ``classify_intent`` returns GENERAL.
@@ -373,14 +445,13 @@ class TagCooccurrenceIndex:
             # Normalize and deduplicate, excluding non-semantic prefixes
             # (obs: event tags + structural taxonomy tags that co-occur with
             # everything — see _INDEX_EXCLUDED_TAG_PREFIXES / MEM-001).
-            normalized = list({
-                t.lower() for t in tags
-                if t and not t.startswith(_INDEX_EXCLUDED_TAG_PREFIXES)
-            })
+            normalized = list(
+                {t.lower() for t in tags if t and not t.startswith(_INDEX_EXCLUDED_TAG_PREFIXES)}
+            )
             for i, tag_a in enumerate(normalized):
                 if tag_a not in cooc:
                     cooc[tag_a] = {}
-                for tag_b in normalized[i + 1:]:
+                for tag_b in normalized[i + 1 :]:
                     cooc[tag_a][tag_b] = cooc[tag_a].get(tag_b, 0) + 1
                     if tag_b not in cooc:
                         cooc[tag_b] = {}
@@ -391,7 +462,8 @@ class TagCooccurrenceIndex:
         self._built_at = time.monotonic()
         logger.info(
             "Tag co-occurrence index built: %d unique tags, %d memories",
-            len(cooc), memory_count,
+            len(cooc),
+            memory_count,
         )
 
     def expand(self, keywords: list[str], max_expansions: int = 5) -> list[str]:
@@ -420,22 +492,160 @@ class TagCooccurrenceIndex:
         return [tag for tag, _ in ranked[:max_expansions]]
 
 
-# Module-level singleton — rebuilt lazily when stale
+# Module-level singleton — refreshed in the BACKGROUND when stale (SWR).
 _tag_index = TagCooccurrenceIndex()
+
+# Stale-while-revalidate state for expand_query (proactive-recall latency,
+# follow-up ac27b693). The pre-SWR code rebuilt the index INLINE on the first
+# recall after every restart (and after >10% corpus growth) — a synchronous
+# scroll of the entire corpus (hundreds of sync HTTP pages) that ran on the
+# request's own event loop and could stall a single prompt for multiple
+# seconds. SWR fixes that: the count-check is time-gated, and a stale index is
+# refreshed by ONE background task (single-flight) while the current prompt
+# proceeds with whatever the index currently holds (worst case: one prompt's
+# FTS query is unexpanded — a marginal recall dip, not a multi-second stall).
+_COUNT_CHECK_INTERVAL_S = 300.0  # re-poll Qdrant point counts at most this often
+_last_count_check: float = 0.0  # monotonic ts of the last get_collection poll
+_cached_total_count: int = 0  # last observed corpus size (drives is_stale)
+_rebuild_in_flight: bool = False  # single-flight guard for the bg rebuild
+
+
+def _reset_tag_index_state() -> None:
+    """Test seam: reset the module-level SWR state to a cold start."""
+    global _last_count_check, _cached_total_count, _rebuild_in_flight  # noqa: PLW0603
+    _last_count_check = 0.0
+    _cached_total_count = 0
+    _rebuild_in_flight = False
+    _tag_index.__init__()  # type: ignore[misc]
+
+
+def _scan_tag_lists(qdrant_client: object, collections: list[str]) -> list[list[str]]:
+    """Scroll every point's tags for a co-occurrence rebuild (SYNC Qdrant).
+
+    Runs off the request path — invoked only inside the background rebuild task
+    (wrapped in a thread), never inline on a recall.
+    """
+    tag_lists: list[list[str]] = []
+    for coll in collections:
+        try:
+            offset = None
+            while True:
+                result = qdrant_client.scroll(  # type: ignore[union-attr]
+                    collection_name=coll,
+                    limit=500,
+                    offset=offset,
+                    with_payload=["tags"],
+                    with_vectors=False,
+                )
+                points, next_offset = result
+                for point in points:
+                    tags = (point.payload or {}).get("tags") or []
+                    if tags:
+                        tag_lists.append(tags)
+                if next_offset is None:
+                    break
+                offset = next_offset
+        except Exception:
+            logger.warning(
+                "Failed to scan tags from %s for co-occurrence index",
+                coll,
+                exc_info=True,
+            )
+    return tag_lists
+
+
+async def _rebuild_tag_index(
+    qdrant_client: object,
+    collections: list[str],
+    total_count: int,
+) -> None:
+    """Background SWR rebuild: scan tags in a thread, rebuild, clear the flag.
+
+    Single-flight — the caller sets ``_rebuild_in_flight`` before scheduling
+    this, and this clears it in a ``finally`` so a scan failure can't wedge the
+    index stale forever.
+    """
+    global _rebuild_in_flight  # noqa: PLW0603
+    try:
+        # The scroll is synchronous Qdrant I/O; keep it off the event loop so a
+        # large-corpus rebuild never blocks concurrent recalls.
+        tag_lists = await asyncio.to_thread(_scan_tag_lists, qdrant_client, collections)
+        _tag_index.build(tag_lists, total_count)
+        logger.info(
+            "Tag co-occurrence index rebuilt in background (%d tag-lists, corpus=%d)",
+            len(tag_lists),
+            total_count,
+        )
+    finally:
+        _rebuild_in_flight = False
 
 
 def _tokenize_query(query: str) -> list[str]:
     """Extract meaningful keywords from a query string."""
     # Remove common stop words and short tokens
     stop_words = {
-        "a", "an", "the", "is", "are", "was", "were", "be", "been",
-        "do", "does", "did", "have", "has", "had", "will", "would",
-        "can", "could", "should", "may", "might", "shall",
-        "in", "on", "at", "to", "for", "of", "with", "by", "from",
-        "it", "its", "this", "that", "these", "those",
-        "i", "we", "you", "he", "she", "they", "me", "us", "my",
-        "what", "why", "how", "when", "where", "which", "who",
-        "about", "and", "or", "not", "but", "so", "if", "then",
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "do",
+        "does",
+        "did",
+        "have",
+        "has",
+        "had",
+        "will",
+        "would",
+        "can",
+        "could",
+        "should",
+        "may",
+        "might",
+        "shall",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "from",
+        "it",
+        "its",
+        "this",
+        "that",
+        "these",
+        "those",
+        "i",
+        "we",
+        "you",
+        "he",
+        "she",
+        "they",
+        "me",
+        "us",
+        "my",
+        "what",
+        "why",
+        "how",
+        "when",
+        "where",
+        "which",
+        "who",
+        "about",
+        "and",
+        "or",
+        "not",
+        "but",
+        "so",
+        "if",
+        "then",
     }
     tokens = re.findall(r"\w+", query.lower())
     return [t for t in tokens if t not in stop_words and len(t) > 1]
@@ -450,53 +660,47 @@ async def expand_query(
 ) -> str:
     """Expand a query with co-occurring tags for improved FTS5 recall.
 
-    Builds/refreshes the tag co-occurrence index lazily from Qdrant,
-    then appends related terms to the query string.
+    Refreshes the tag co-occurrence index in the BACKGROUND when stale
+    (stale-while-revalidate — see the SWR state block above), then appends
+    related terms to the query string. NEVER rebuilds inline: this runs on the
+    per-prompt recall path, so a stale index triggers a single-flight background
+    rebuild and this call proceeds with the current index (follow-up ac27b693).
 
     Returns the original query if expansion produces no results or
     if Qdrant is unavailable.
     """
-    global _tag_index  # noqa: PLW0603
+    global _last_count_check, _cached_total_count, _rebuild_in_flight  # noqa: PLW0603
 
     try:
-        # Check if index needs rebuilding
-        total_count = 0
-        for coll in collections:
-            try:
-                info = qdrant_client.get_collection(coll)  # type: ignore[union-attr]
-                total_count += info.points_count or 0
-            except Exception:
-                continue
-
-        if _tag_index.is_stale(total_count) and total_count > 0:
-            # Rebuild index by scanning tag metadata
-            tag_lists: list[list[str]] = []
+        # Time-gate the Qdrant point-count poll: the pre-SWR code hit
+        # get_collection on EVERY recall (2 sync HTTP calls/prompt). Re-poll at
+        # most every _COUNT_CHECK_INTERVAL_S; reuse the cached count otherwise.
+        now = time.monotonic()
+        if _last_count_check == 0.0 or (now - _last_count_check) >= _COUNT_CHECK_INTERVAL_S:
+            total_count = 0
             for coll in collections:
                 try:
-                    offset = None
-                    while True:
-                        result = qdrant_client.scroll(  # type: ignore[union-attr]
-                            collection_name=coll,
-                            limit=500,
-                            offset=offset,
-                            with_payload=["tags"],
-                            with_vectors=False,
-                        )
-                        points, next_offset = result
-                        for point in points:
-                            tags = (point.payload or {}).get("tags") or []
-                            if tags:
-                                tag_lists.append(tags)
-                        if next_offset is None:
-                            break
-                        offset = next_offset
+                    info = qdrant_client.get_collection(coll)  # type: ignore[union-attr]
+                    total_count += info.points_count or 0
                 except Exception:
-                    logger.warning(
-                        "Failed to scan tags from %s for co-occurrence index",
-                        coll, exc_info=True,
-                    )
+                    continue
+            _cached_total_count = total_count
+            _last_count_check = now
+        else:
+            total_count = _cached_total_count
 
-            _tag_index.build(tag_lists, total_count)
+        # Stale index → kick ONE background rebuild (single-flight) and proceed
+        # with whatever the index currently holds. Worst case for THIS prompt:
+        # an unexpanded FTS query (a marginal recall dip) instead of a
+        # multi-second inline scroll stall.
+        if total_count > 0 and _tag_index.is_stale(total_count) and not _rebuild_in_flight:
+            _rebuild_in_flight = True
+            from genesis.util.tasks import tracked_task
+
+            tracked_task(
+                _rebuild_tag_index(qdrant_client, list(collections), total_count),
+                name="tag_index_rebuild",
+            )
 
         # Expand query
         keywords = _tokenize_query(query)

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -605,6 +605,10 @@ async def proactive_context(
         kb_slots=kb_slots,
         rerank_timeout_s=_RERANK_TIMEOUT_S,
         stats=engine_stats,
+        # This is THE latency-budgeted per-prompt path: push recall's
+        # write-backs/emits + the immunity emit off the request path so the
+        # 4.5s route budget isn't spent on post-result DB writes (ac27b693).
+        defer_side_effects=True,
     )
     recall_ms = (time.monotonic() - t_recall) * 1000
 
@@ -635,15 +639,24 @@ async def proactive_context(
             # line was never injected. Accepted — surfaced_count is advisory (never
             # feeds promotion) and the window is a narrow race; a perfect fix would
             # need the client to report surfaced-shown back (tracked follow-up).
-            # Best-effort: a bump failure must never fail recall.
-            try:
-                await db.execute(
-                    "UPDATE procedural_memory SET surfaced_count = surfaced_count + 1 WHERE id = ?",
-                    (procedure["id"],),
-                )
-                await db.commit()
-            except Exception:
-                logger.debug("surfaced_count bump failed", exc_info=True)
+            # Best-effort: a bump failure must never fail recall. Deferred off
+            # the latency path (ac27b693) — this is an advisory funnel counter,
+            # never read synchronously, so a background write is strictly safe.
+            _proc_id = procedure["id"]
+
+            async def _bump_surfaced(proc_id: str = _proc_id) -> None:
+                try:
+                    await db.execute(
+                        "UPDATE procedural_memory SET surfaced_count = surfaced_count + 1 WHERE id = ?",
+                        (proc_id,),
+                    )
+                    await db.commit()
+                except Exception:
+                    logger.debug("surfaced_count bump failed", exc_info=True)
+
+            from genesis.util.tasks import tracked_task
+
+            tracked_task(_bump_surfaced(), name="proactive_surfaced_count")
 
     procedure_ms = (time.monotonic() - t_proc) * 1000
 
@@ -660,6 +673,12 @@ async def proactive_context(
     }
     if "rerank_ms" in engine_stats:
         timings["rerank"] = engine_stats["rerank_ms"]
+    # Sub-stage breakdown of the `recall` bucket (ac27b693): surfaced so a slow
+    # recall can be attributed to vector/FTS/expand/activation from the journal
+    # alone, instead of guessed. Present only when recall populated them.
+    for _k in ("vector_ms", "expand_ms", "fts_ms", "activation_ms"):
+        if _k in engine_stats:
+            timings[_k.removesuffix("_ms")] = engine_stats[_k]
     if total_ms > _SLOW_RECALL_LOG_MS:
         # One INFO line per slow call so a latency regression is diagnosable
         # from the journal alone (the 503 path discards timings_ms entirely —

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -43,13 +43,22 @@ _deferred_side_effects_count = 0
 
 
 def _deferred_side_effects_inflight() -> int:
-    """Number of recall side-effect tasks currently pending/running."""
+    """Number of recall side-effect tasks reserved (scheduled or running)."""
     return _deferred_side_effects_count
 
 
-async def _deferred_side_effects(coro: Coroutine[Any, Any, None]) -> None:
-    """Run a deferred side-effect coroutine while accounting it against the
-    in-flight backstop (increment on entry, decrement in ``finally``)."""
+def _schedule_deferred_side_effects(coro: Coroutine[Any, Any, None], *, name: str) -> None:
+    """Reserve a backstop slot SYNCHRONOUSLY, then schedule ``coro`` as a
+    tracked task that releases the slot when it finishes.
+
+    Reserving before ``tracked_task`` (not inside the task body) is what makes
+    the cap real under a burst: several recalls resuming in the same event-loop
+    tick each increment the counter before yielding, so the (N+1)th correctly
+    sees the cap and runs inline instead of queueing an unbounded pile of
+    scheduled-but-not-yet-started tasks (Codex P2). A shutdown cancellation
+    before the task starts would skip the release, but that only leaks an
+    in-memory counter on a process that is already exiting — immaterial.
+    """
     global _deferred_side_effects_count  # noqa: PLW0603
     _deferred_side_effects_count += 1
     if _deferred_side_effects_count == _DEFERRED_SIDE_EFFECT_CAP:
@@ -58,10 +67,15 @@ async def _deferred_side_effects(coro: Coroutine[Any, Any, None]) -> None:
             "further recalls run write-backs inline until it drains",
             _DEFERRED_SIDE_EFFECT_CAP,
         )
-    try:
-        await coro
-    finally:
-        _deferred_side_effects_count -= 1
+
+    async def _runner() -> None:
+        global _deferred_side_effects_count  # noqa: PLW0603
+        try:
+            await coro
+        finally:
+            _deferred_side_effects_count -= 1
+
+    tracked_task(_runner(), name=name)
 
 
 def _has_temporal_markers(query: str) -> bool:
@@ -839,10 +853,7 @@ class HybridRetriever:
                 and event_id_sink is None
                 and _deferred_side_effects_inflight() < _DEFERRED_SIDE_EFFECT_CAP
             ):
-                tracked_task(
-                    _deferred_side_effects(_zero_hit_shadow),
-                    name="recall_zero_hit_shadow",
-                )
+                _schedule_deferred_side_effects(_zero_hit_shadow, name="recall_zero_hit_shadow")
             else:
                 await _zero_hit_shadow
             return []
@@ -1109,7 +1120,7 @@ class HybridRetriever:
             and event_id_sink is None
             and _deferred_side_effects_inflight() < _DEFERRED_SIDE_EFFECT_CAP
         ):
-            tracked_task(_deferred_side_effects(_run_side_effects()), name="recall_side_effects")
+            _schedule_deferred_side_effects(_run_side_effects(), name="recall_side_effects")
         else:
             await _run_side_effects()
 
@@ -1551,10 +1562,20 @@ class HybridRetriever:
 
         if memory_writebacks_off():
             return
-        # 11. Increment retrieved_count + stamp last_retrieved_at
-        for mid in top:
-            qdrant_hit = qdrant_by_id.get(mid)
-            if qdrant_hit:
+
+        # 11. Increment retrieved_count + stamp last_retrieved_at. The Qdrant
+        # client is SYNCHRONOUS, so run the whole per-item write-back loop in a
+        # worker thread: otherwise these blocking HTTP calls stall the shared
+        # event loop when the deferred task runs, stealing time from concurrent
+        # recalls and from the request's own remaining work — which would leave
+        # Qdrant-backed prompts still paying the write-back cost on the loop even
+        # though the work is "deferred" (Codex P2 on the ac27b693 deferral). Each
+        # write stays individually swallowed.
+        def _write_qdrant_counts() -> None:
+            for mid in top:
+                qdrant_hit = qdrant_by_id.get(mid)
+                if not qdrant_hit:
+                    continue
                 coll = qdrant_hit.get("_collection", "episodic_memory")
                 old_count = qdrant_hit.get("payload", {}).get("retrieved_count", 0)
                 try:
@@ -1574,6 +1595,8 @@ class HybridRetriever:
                         coll,
                         exc_info=True,
                     )
+
+        await asyncio.to_thread(_write_qdrant_counts)
 
         # 11b. Sync observation retrieved_count in SQLite
         #       Extract obs:<uuid> tags from Qdrant payloads to find linked observations

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -821,7 +821,7 @@ class HybridRetriever:
             # whether the entity lane would surface something — its highest-value
             # case (Codex #1121 P2: don't skip the zero-hit path). No ranked
             # lists exist here, so lane novelty = its valid candidates.
-            await self._maybe_entity_lane_shadow(
+            _zero_hit_shadow = self._maybe_entity_lane_shadow(
                 query=query,
                 ranked_lists=[],
                 all_ids=set(),
@@ -829,6 +829,22 @@ class HybridRetriever:
                 embedding_available=embedding_available,
                 recall_event_id=None,
             )
+            # Same deferral contract as the has-results path (ac27b693): the
+            # shadow probe is pure observation, so on the latency-budgeted
+            # proactive path it must not run inline here either. Inert today
+            # (entity_lane.mode: off), but keeps the zero-candidate prompt off
+            # the shared connection if that mode is ever flipped to shadow.
+            if (
+                defer_side_effects
+                and event_id_sink is None
+                and _deferred_side_effects_inflight() < _DEFERRED_SIDE_EFFECT_CAP
+            ):
+                tracked_task(
+                    _deferred_side_effects(_zero_hit_shadow),
+                    name="recall_zero_hit_shadow",
+                )
+            else:
+                await _zero_hit_shadow
             return []
 
         now_str = datetime.now(UTC).isoformat()

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -5,8 +5,9 @@ import dataclasses
 import logging
 import math
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
+from typing import Any
 
 import aiosqlite
 from qdrant_client import QdrantClient
@@ -26,8 +27,41 @@ from genesis.memory.types import RetrievalResult
 from genesis.observability.call_site_recorder import record_last_run
 from genesis.observability.provider_activity import track_operation
 from genesis.qdrant import collections as qdrant_ops
+from genesis.util.tasks import tracked_task
 
 logger = logging.getLogger(__name__)
+
+# Backstop for deferred recall side effects (follow-up ac27b693). Each deferred
+# task pins its recall's ``results`` + candidate maps until it drains, so an
+# unbounded pending set would leak memory under a sustained burst. This is a
+# task-COUNT backstop (not a hardware-scaled resource), so a fixed ceiling is
+# install-agnostic: past it, the defer path runs INLINE instead — never dropping
+# a write, only trading latency back. A steady state that regularly hits this
+# means the write-back path itself is too slow (surface, don't silently cap).
+_DEFERRED_SIDE_EFFECT_CAP = 256
+_deferred_side_effects_count = 0
+
+
+def _deferred_side_effects_inflight() -> int:
+    """Number of recall side-effect tasks currently pending/running."""
+    return _deferred_side_effects_count
+
+
+async def _deferred_side_effects(coro: Coroutine[Any, Any, None]) -> None:
+    """Run a deferred side-effect coroutine while accounting it against the
+    in-flight backstop (increment on entry, decrement in ``finally``)."""
+    global _deferred_side_effects_count  # noqa: PLW0603
+    _deferred_side_effects_count += 1
+    if _deferred_side_effects_count == _DEFERRED_SIDE_EFFECT_CAP:
+        logger.warning(
+            "recall deferred-side-effect backstop reached (%d in flight) — "
+            "further recalls run write-backs inline until it drains",
+            _DEFERRED_SIDE_EFFECT_CAP,
+        )
+    try:
+        await coro
+    finally:
+        _deferred_side_effects_count -= 1
 
 
 def _has_temporal_markers(query: str) -> bool:
@@ -634,6 +668,7 @@ class HybridRetriever:
         extra_fts_terms: list[str] | None = None,
         rerank_timeout_s: float | None = None,
         stats: dict | None = None,
+        defer_side_effects: bool = False,
     ) -> list[RetrievalResult]:
         """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF.
 
@@ -645,9 +680,21 @@ class HybridRetriever:
         only bound.
 
         ``stats``: optional caller-owned dict populated with rerank stage
-        telemetry (``rerank_executed``, ``rerank_ms``, ``rerank_timed_out``).
-        Caller-owned so concurrent recalls on the shared retriever can never
-        race each other's numbers.
+        telemetry (``rerank_executed``, ``rerank_ms``, ``rerank_timed_out``)
+        plus per-stage read timings (``vector_ms``, ``expand_ms``, ``fts_ms``,
+        ``activation_ms``). Caller-owned so concurrent recalls on the shared
+        retriever can never race each other's numbers.
+
+        ``defer_side_effects``: when True, the post-result WRITE-BACKS and
+        eval/telemetry emits (retrieved_count bumps, ``recall_fired`` +
+        diagnostics, entity-lane shadow) are moved OFF the caller's latency
+        path into one background ``tracked_task`` — the results return
+        immediately. For the per-prompt proactive path (follow-up ac27b693),
+        where those writes were the dominant serialized cost under concurrent
+        sessions. Mutually exclusive with ``event_id_sink`` (which needs the
+        emitted id synchronously): a caller passing a sink keeps inline emits.
+        All deferred writes are already individually best-effort, so a shutdown
+        cancellation loses at most one prompt's usage bumps.
 
         Source selection:
             - ``source=None`` (default): classify the query's intent and
@@ -707,6 +754,7 @@ class HybridRetriever:
         qdrant_results: list[dict] = []
         qdrant_by_id: dict[str, dict] = {}
         if embedding_available and vector is not None:
+            _ts = time.monotonic()
             qdrant_results, qdrant_by_id = await self._gather_vector_candidates(
                 vector=vector,
                 collections=collections,
@@ -719,6 +767,8 @@ class HybridRetriever:
                 include_only_subsystems=include_only_subsystems,
                 include_deprecated=include_deprecated,
             )
+            if stats is not None:
+                stats["vector_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 2b. Event-calendar search (temporal queries)
         event_memory_ids = await self._gather_event_candidates(
@@ -727,15 +777,20 @@ class HybridRetriever:
             candidate_limit,
         )
 
-        # 2c. Expand query via tag co-occurrence (opt-in, expensive index rebuild)
+        # 2c. Expand query via tag co-occurrence (SWR — stale index rebuilds in
+        # the background, never inline on this path; see intent.expand_query)
+        _ts = time.monotonic()
         fts_query = await self._expand_fts_query(
             query,
             collections,
             expand_query_terms=expand_query_terms,
             extra_fts_terms=extra_fts_terms,
         )
+        if stats is not None:
+            stats["expand_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 3. FTS5 text search (using expanded query)
+        _ts = time.monotonic()
         fts_results, fts_by_id = await self._gather_fts_candidates(
             query=query,
             fts_query=fts_query,
@@ -745,6 +800,8 @@ class HybridRetriever:
             include_only_subsystems=include_only_subsystems,
             include_deprecated=include_deprecated,
         )
+        if stats is not None:
+            stats["fts_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 4. Union of all candidate memory_ids
         all_ids = set(qdrant_by_id) | set(fts_by_id) | set(event_memory_ids)
@@ -777,12 +834,15 @@ class HybridRetriever:
         now_str = datetime.now(UTC).isoformat()
 
         # 5/5b. Batch-fetch link counts + compute activation scores
+        _ts = time.monotonic()
         (
             activation_by_id,
             inbound_by_id,
             retrieved_count_by_id,
             created_at_by_id,
         ) = await self._compute_activations(all_ids, qdrant_by_id, now_str)
+        if stats is not None:
+            stats["activation_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 6. Build ranked lists for RRF (or FTS5-only if no embedding)
         vector_ranked_dedup: list[str] = []
@@ -925,83 +985,117 @@ class HybridRetriever:
             except Exception:
                 logger.debug("skip_writeback predicate failed open", exc_info=True)
                 _wb_ids = top
-        await self._record_retrievals(_wb_ids, qdrant_by_id, fts_by_id, now_str)
 
-        # J-9 eval: log recall event for memory retrieval quality measurement
-        from genesis.eval.j9_hooks import (
-            emit_recall_diagnostics,
-            emit_recall_fired,
-        )
+        # Snapshot the recall latency NOW: when the side effects are deferred,
+        # the ``recall_fired`` emit runs later on a background task, so
+        # recomputing (now - _t0) there would record the deferral delay, not the
+        # actual recall time. Capture it here and pass the fixed value in.
+        _recall_latency_ms = (time.monotonic() - _t0) * 1000
 
-        # J-9 logs the PRE-diversity-penalty scores. ``score`` is an
-        # ordering value (echo penalty applied); logging it understated the
-        # quality of penalized results in top_scores/mean_score/score_spread
-        # and skewed the entrenchment correlation.
-        _scores = [r.retrieval_score for r in results]
-        # MEM-005: entrenchment signal (monitor-only) — see _entrenchment_metrics.
-        _entrenchment, _mean_retrieved, _mean_age_days = _entrenchment_metrics(
-            results,
-            _scores,
-            retrieved_count_by_id,
-            created_at_by_id,
-            now_str,
-        )
+        async def _run_side_effects() -> None:
+            """Post-result write-backs + J-9 emits + entity-lane shadow.
 
-        recall_event_id = await emit_recall_fired(
-            self._db,
-            query=query,
-            result_count=len(results),
-            top_scores=[r.retrieval_score for r in results[:5]],
-            memory_ids=[r.memory_id for r in results[:10]],
-            latency_ms=(time.monotonic() - _t0) * 1000,
-            source=source,
-            intent_category=intent.category,
-            graph_boost_applied=graph_boost_applied,
-            mean_score=sum(_scores) / len(_scores) if _scores else None,
-            wing=wing,
-            entrenchment_corr=_entrenchment,
-            mean_retrieved_count=_mean_retrieved,
-            mean_age_days=_mean_age_days,
-        )
+            Runs inline for deep-search callers (byte-for-byte the pre-change
+            behavior) or as ONE background ``tracked_task`` for the latency-
+            budgeted proactive path (``defer_side_effects``). Every step is
+            already individually best-effort — a failure never blocks results.
+            """
+            # 11/11b/11c. Retrieval write-backs (Qdrant counts, observation +
+            # knowledge_units sync). Runs AFTER assembly + the 12b origin
+            # backfill so `skip_writeback` saw the STORED origin (Codex #1048).
+            await self._record_retrievals(_wb_ids, qdrant_by_id, fts_by_id, now_str)
 
-        # MEM-003: hand the emitted event id back to an MCP caller so it can
-        # enrich THIS event (mode / pipeline_used / post-filter counts) instead
-        # of emitting a second recall_fired that double-counts in the J-9
-        # aggregator and batch judge.
-        if event_id_sink is not None and recall_event_id is not None:
-            event_id_sink.append(recall_event_id)
+            # J-9 eval: log recall event for memory retrieval quality measurement
+            from genesis.eval.j9_hooks import (
+                emit_recall_diagnostics,
+                emit_recall_fired,
+            )
 
-        # Recall diagnostics: capture intermediate pipeline metrics
-        _overlap = len(set(qdrant_by_id) & set(fts_by_id))
-        await emit_recall_diagnostics(
-            self._db,
-            recall_event_id=recall_event_id,
-            qdrant_pool_size=len(qdrant_by_id),
-            fts_pool_size=len(fts_by_id),
-            event_pool_size=len(event_memory_ids),
-            total_candidates=len(all_ids),
-            overlap_count=_overlap,
-            score_spread=round(max(_scores) - min(_scores), 4) if _scores else None,
-            embedding_available=embedding_available,
-            intent_category=intent.category,
-            intent_confidence=intent.confidence,
-            query_expanded=fts_query != query,
-        )
+            # J-9 logs the PRE-diversity-penalty scores. ``score`` is an
+            # ordering value (echo penalty applied); logging it understated the
+            # quality of penalized results in top_scores/mean_score/score_spread
+            # and skewed the entrenchment correlation.
+            _scores = [r.retrieval_score for r in results]
+            # MEM-005: entrenchment signal (monitor-only) — see _entrenchment_metrics.
+            _entrenchment, _mean_retrieved, _mean_age_days = _entrenchment_metrics(
+                results,
+                _scores,
+                retrieved_count_by_id,
+                created_at_by_id,
+                now_str,
+            )
 
-        # Entity-lane SHADOW probe (off by default; entity_lane.mode: shadow).
-        # Measures whether resolving the query to entity nodes + walking the
-        # entity graph would surface novel valid candidates the vector/FTS lanes
-        # miss — pure observation that appends one eval_event and NEVER touches
-        # ``results``. Placed after the write-backs so its insert_event commit
-        # can't flush partial recall state. See also the zero-hit call above.
-        await self._maybe_entity_lane_shadow(
-            query=query,
-            ranked_lists=ranked_lists,
-            all_ids=all_ids,
-            limit=limit,
-            embedding_available=embedding_available,
-            recall_event_id=recall_event_id,
-        )
+            recall_event_id = await emit_recall_fired(
+                self._db,
+                query=query,
+                result_count=len(results),
+                top_scores=[r.retrieval_score for r in results[:5]],
+                memory_ids=[r.memory_id for r in results[:10]],
+                latency_ms=_recall_latency_ms,
+                source=source,
+                intent_category=intent.category,
+                graph_boost_applied=graph_boost_applied,
+                mean_score=sum(_scores) / len(_scores) if _scores else None,
+                wing=wing,
+                entrenchment_corr=_entrenchment,
+                mean_retrieved_count=_mean_retrieved,
+                mean_age_days=_mean_age_days,
+            )
+
+            # MEM-003: hand the emitted event id back to an MCP caller so it can
+            # enrich THIS event instead of emitting a second recall_fired. Only
+            # the inline path carries a sink — a deferred caller passes None
+            # (guaranteed by the defer guard below), so no id is lost.
+            if event_id_sink is not None and recall_event_id is not None:
+                event_id_sink.append(recall_event_id)
+
+            # Recall diagnostics: capture intermediate pipeline metrics
+            _overlap = len(set(qdrant_by_id) & set(fts_by_id))
+            await emit_recall_diagnostics(
+                self._db,
+                recall_event_id=recall_event_id,
+                qdrant_pool_size=len(qdrant_by_id),
+                fts_pool_size=len(fts_by_id),
+                event_pool_size=len(event_memory_ids),
+                total_candidates=len(all_ids),
+                overlap_count=_overlap,
+                score_spread=round(max(_scores) - min(_scores), 4) if _scores else None,
+                embedding_available=embedding_available,
+                intent_category=intent.category,
+                intent_confidence=intent.confidence,
+                query_expanded=fts_query != query,
+            )
+
+            # Entity-lane SHADOW probe (off by default; entity_lane.mode: shadow).
+            # Pure observation that appends one eval_event and NEVER touches
+            # ``results``. Placed after the write-backs so its insert_event
+            # commit can't flush partial recall state.
+            await self._maybe_entity_lane_shadow(
+                query=query,
+                ranked_lists=ranked_lists,
+                all_ids=all_ids,
+                limit=limit,
+                embedding_available=embedding_available,
+                recall_event_id=recall_event_id,
+            )
+
+        # Defer only when the caller opted in AND isn't waiting on the emitted
+        # event id (``event_id_sink`` needs it synchronously). Otherwise run
+        # inline — byte-for-byte the pre-change behavior for deep-search callers.
+        # Defer only when the caller opted in, isn't waiting on the emitted id,
+        # AND we're under the in-flight backstop. The backstop bounds memory:
+        # each deferred task pins ``results``/candidate maps until it drains, so
+        # a sustained burst that outruns the drain rate falls back to inline
+        # (graceful degradation to the pre-change behavior — a write is NEVER
+        # dropped, and the pending-task set can't grow without bound).
+        if (
+            defer_side_effects
+            and event_id_sink is None
+            and _deferred_side_effects_inflight() < _DEFERRED_SIDE_EFFECT_CAP
+        ):
+            tracked_task(_deferred_side_effects(_run_side_effects()), name="recall_side_effects")
+        else:
+            await _run_side_effects()
 
         return results
 

--- a/tests/test_memory/test_proactive_engine.py
+++ b/tests/test_memory/test_proactive_engine.py
@@ -293,6 +293,7 @@ async def test_proactive_context_passes_file_keywords_as_extra_fts_terms():
         kb_slots=None,
         rerank_timeout_s=None,
         stats=None,
+        defer_side_effects=False,
     ):
         captured["extra"] = extra_fts_terms
         captured["rerank"] = rerank
@@ -352,6 +353,15 @@ async def test_proactive_context_bumps_surfaced_count_not_invocation():
         patch("genesis.memory.proactive._surface_procedure", new=AsyncMock(return_value=proc)),
     ):
         resp = await P.proactive_context(prompt="deploy the latest build", session_id="s")
+
+        # The surfaced_count bump is deferred off the latency path (ac27b693) —
+        # drain the background task before asserting it landed.
+        import asyncio
+
+        for _ in range(20):
+            if any("surfaced_count" in s.lower() for s, _ in mod._db.executed):
+                break
+            await asyncio.sleep(0.02)
 
     assert resp["procedure"] == {"id": "proc-abc", "tier": "CORE"}
     bumps = [(sql, params) for sql, params in mod._db.executed if "surfaced_count" in sql.lower()]
@@ -426,6 +436,7 @@ async def test_proactive_context_requests_noise_filter():
         kb_slots=None,
         rerank_timeout_s=None,
         stats=None,
+        defer_side_effects=False,
     ):
         captured["filter_noise"] = filter_noise
         return []
@@ -454,6 +465,7 @@ async def test_proactive_context_surfaces_engine_stats():
         kb_slots=None,
         rerank_timeout_s=None,
         stats=None,
+        defer_side_effects=False,
     ):
         if stats is not None:
             stats["rerank_executed"] = True
@@ -480,6 +492,7 @@ async def test_proactive_context_surfaces_engine_stats():
         kb_slots=None,
         rerank_timeout_s=None,
         stats=None,
+        defer_side_effects=False,
     ):
         if stats is not None:
             stats["rerank_executed"] = False

--- a/tests/test_memory/test_proactive_engine.py
+++ b/tests/test_memory/test_proactive_engine.py
@@ -299,6 +299,7 @@ async def test_proactive_context_passes_file_keywords_as_extra_fts_terms():
         captured["rerank"] = rerank
         captured["limit"] = limit
         captured["rerank_timeout_s"] = rerank_timeout_s
+        captured["defer_side_effects"] = defer_side_effects
         return []
 
     with (
@@ -314,6 +315,10 @@ async def test_proactive_context_passes_file_keywords_as_extra_fts_terms():
     assert captured["rerank"] is True  # cc_hook default
     assert captured["limit"] == 1  # command budget
     assert captured["rerank_timeout_s"] == P._RERANK_TIMEOUT_S  # hot-path timebox threaded
+    # Regression guard (ac27b693): the proactive path MUST defer side effects —
+    # a silent flip back to False reintroduces the concurrent-session latency
+    # regression this PR fixes.
+    assert captured["defer_side_effects"] is True
 
 
 async def test_proactive_context_bumps_surfaced_count_not_invocation():

--- a/tests/test_memory/test_recall_deferral.py
+++ b/tests/test_memory/test_recall_deferral.py
@@ -1,0 +1,144 @@
+"""Recall side-effect deferral + sub-stage telemetry (follow-up ac27b693).
+
+The proactive per-prompt path passes ``defer_side_effects=True`` so recall's
+write-backs and eval emits run on a background task AFTER results return — off
+the 4.5s route budget. Deep-search callers (default False) keep them inline.
+These tests pin both halves of that contract plus the new per-stage timings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.memory.retrieval import HybridRetriever
+
+
+def _qdrant_hit(mid: str, score: float) -> dict:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "id": mid,
+        "score": score,
+        "payload": {
+            "content": f"content for {mid}",
+            "source": "test",
+            "memory_type": "episodic",
+            "tags": [],
+            "confidence": 0.8,
+            "created_at": now,
+            "retrieved_count": 5,
+            "source_type": "memory",
+        },
+    }
+
+
+def _build_retriever():
+    embed = MagicMock()
+    embed.embed = AsyncMock(return_value=[0.1] * 1024)
+    db = MagicMock(spec_set=["execute", "commit"])
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    return HybridRetriever(
+        embedding_provider=embed,
+        qdrant_client=MagicMock(),
+        db=db,
+    )
+
+
+def _wire(mock_qdrant, mock_crud, mock_links):
+    mock_qdrant.search.return_value = [_qdrant_hit("mem-1", 0.95)]
+    mock_qdrant.update_payload = MagicMock()
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_crud.batch_created_at = AsyncMock(return_value={})
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_deferred_writeback_runs_after_return(mock_qdrant, mock_crud, mock_links, _exp):
+    """defer_side_effects=True: results return BEFORE the Qdrant write-back fires;
+    the write-back then runs on the background task."""
+    retriever = _build_retriever()
+    _wire(mock_qdrant, mock_crud, mock_links)
+
+    results = await retriever.recall("test", limit=5, defer_side_effects=True)
+    assert results  # got results synchronously
+    # The retrieved_count write-back has NOT fired yet — it's deferred.
+    assert mock_qdrant.update_payload.call_count == 0
+
+    # Let the background task run.
+    for _ in range(20):
+        if mock_qdrant.update_payload.call_count > 0:
+            break
+        await asyncio.sleep(0.02)
+    assert mock_qdrant.update_payload.call_count >= 1
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_inline_writeback_is_synchronous(mock_qdrant, mock_crud, mock_links, _exp):
+    """Default path (deep search): the write-back fires INLINE before recall
+    returns — byte-for-byte the pre-change behavior."""
+    retriever = _build_retriever()
+    _wire(mock_qdrant, mock_crud, mock_links)
+
+    await retriever.recall("test", limit=5)  # defer_side_effects defaults False
+    # Already fired by the time recall returned — no background wait needed.
+    assert mock_qdrant.update_payload.call_count >= 1
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_backstop_falls_back_to_inline_at_cap(mock_qdrant, mock_crud, mock_links, _exp):
+    """When the in-flight backstop is saturated, defer_side_effects=True runs the
+    write-back INLINE (synchronously) rather than piling up another task — a
+    write is never dropped, memory can't grow unbounded."""
+    from genesis.memory import retrieval
+
+    retriever = _build_retriever()
+    _wire(mock_qdrant, mock_crud, mock_links)
+
+    saved = retrieval._deferred_side_effects_count
+    retrieval._deferred_side_effects_count = retrieval._DEFERRED_SIDE_EFFECT_CAP
+    try:
+        await retriever.recall("test", limit=5, defer_side_effects=True)
+        # At cap → inline: the write-back already fired, no background wait.
+        assert mock_qdrant.update_payload.call_count >= 1
+    finally:
+        retrieval._deferred_side_effects_count = saved
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_stats_carries_substage_timings(mock_qdrant, mock_crud, mock_links, _exp):
+    """A caller-owned stats dict is populated with per-stage read timings."""
+    retriever = _build_retriever()
+    _wire(mock_qdrant, mock_crud, mock_links)
+
+    stats: dict = {}
+    await retriever.recall("test", limit=5, stats=stats, defer_side_effects=True)
+    for key in ("vector_ms", "expand_ms", "fts_ms", "activation_ms"):
+        assert key in stats, f"missing {key} in {stats}"
+        assert isinstance(stats[key], float)
+
+    # Drain the deferred task so it doesn't outlive the test.
+    for _ in range(20):
+        if mock_qdrant.update_payload.call_count > 0:
+            break
+        await asyncio.sleep(0.02)

--- a/tests/test_memory/test_recall_deferral.py
+++ b/tests/test_memory/test_recall_deferral.py
@@ -126,6 +126,37 @@ async def test_backstop_falls_back_to_inline_at_cap(mock_qdrant, mock_crud, mock
 @patch("genesis.memory.retrieval.memory_links")
 @patch("genesis.memory.retrieval.memory_crud")
 @patch("genesis.memory.retrieval.qdrant_ops")
+async def test_backstop_slot_reserved_synchronously(mock_qdrant, mock_crud, mock_links, _exp):
+    """The in-flight slot is reserved when the task is SCHEDULED (before it
+    runs), not when its body starts — so a same-tick burst can't queue past the
+    cap. After recall returns the count is already >=1; it drains back to the
+    starting value once the task completes."""
+    from genesis.memory import retrieval
+
+    retriever = _build_retriever()
+    _wire(mock_qdrant, mock_crud, mock_links)
+
+    start = retrieval._deferred_side_effects_count
+    await retriever.recall("test", limit=5, defer_side_effects=True)
+    # Reserved synchronously at schedule time — the task has not been awaited yet.
+    assert retrieval._deferred_side_effects_count == start + 1
+    # Write-back also hasn't run yet (task not started).
+    assert mock_qdrant.update_payload.call_count == 0
+
+    # Drain: the task runs, does the write-back, and releases the slot.
+    for _ in range(20):
+        if retrieval._deferred_side_effects_count == start:
+            break
+        await asyncio.sleep(0.02)
+    assert retrieval._deferred_side_effects_count == start
+    assert mock_qdrant.update_payload.call_count >= 1
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
 async def test_stats_carries_substage_timings(mock_qdrant, mock_crud, mock_links, _exp):
     """A caller-owned stats dict is populated with per-stage read timings."""
     retriever = _build_retriever()

--- a/tests/test_memory/test_tag_index_swr.py
+++ b/tests/test_memory/test_tag_index_swr.py
@@ -1,0 +1,104 @@
+"""Stale-while-revalidate for the tag co-occurrence index (follow-up ac27b693).
+
+expand_query must NEVER rebuild the index inline on the recall path: a stale
+index kicks a single-flight BACKGROUND rebuild and the current call proceeds
+with whatever the index holds. These tests pin that contract so a future edit
+can't silently restore the multi-second inline scroll on the hot path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from genesis.memory import intent
+
+
+class _FakeInfo:
+    def __init__(self, count: int) -> None:
+        self.points_count = count
+
+
+def _fake_qdrant(count: int, tag_lists: list[list[str]]):
+    """A sync QdrantClient double: get_collection returns a count; scroll yields
+    one page of points whose payloads carry the given tag lists."""
+    client = MagicMock()
+    client.get_collection.return_value = _FakeInfo(count)
+    points = [MagicMock(payload={"tags": tags}) for tags in tag_lists]
+    # scroll returns (points, next_offset); next_offset=None ends pagination.
+    client.scroll.return_value = (points, None)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    intent._reset_tag_index_state()
+    yield
+    intent._reset_tag_index_state()
+
+
+@pytest.mark.asyncio
+async def test_stale_index_does_not_rebuild_inline():
+    """A stale index must NOT scroll inline — expand returns immediately with the
+    (still-empty) index, and a background rebuild is scheduled."""
+    client = _fake_qdrant(count=1000, tag_lists=[["alpha", "beta"], ["alpha", "gamma"]])
+
+    # Cold index is stale; the call must return without an inline scroll.
+    result = await intent.expand_query("alpha", client, ["episodic_memory"])
+
+    # No inline scroll happened during the call itself.
+    assert client.scroll.call_count == 0
+    # Unexpanded this call (index still empty) — original query preserved.
+    assert result == "alpha"
+    # A single-flight rebuild is in flight.
+    assert intent._rebuild_in_flight is True
+
+    # Let the background rebuild task run; it scrolls off the hot path.
+    await asyncio.sleep(0)
+    for _ in range(20):
+        if not intent._rebuild_in_flight:
+            break
+        await asyncio.sleep(0.02)
+    assert intent._rebuild_in_flight is False
+    assert client.scroll.call_count >= 1
+    # Index is now populated — a subsequent expand can enrich.
+    assert not intent._tag_index.is_stale(1000)
+
+
+@pytest.mark.asyncio
+async def test_single_flight_no_stampede():
+    """Concurrent stale recalls must schedule at most ONE rebuild."""
+    client = _fake_qdrant(count=500, tag_lists=[["x", "y"]])
+
+    results = await asyncio.gather(
+        *[intent.expand_query("x", client, ["episodic_memory"]) for _ in range(5)]
+    )
+    assert all(r == "x" for r in results)  # all unexpanded (cold index)
+    # Only one rebuild claimed the flag; drain it.
+    for _ in range(20):
+        if not intent._rebuild_in_flight:
+            break
+        await asyncio.sleep(0.02)
+    # Exactly one scroll pass over the single collection (one rebuild ran).
+    assert client.scroll.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_count_check_is_time_gated():
+    """get_collection must be polled at most once per interval, not per call."""
+    client = _fake_qdrant(count=800, tag_lists=[["a", "b"]])
+
+    await intent.expand_query("a", client, ["episodic_memory"])
+    first = client.get_collection.call_count
+    assert first >= 1
+    # Drain the rebuild so the index is warm.
+    for _ in range(20):
+        if not intent._rebuild_in_flight:
+            break
+        await asyncio.sleep(0.02)
+
+    # Immediate second call: within the interval → no new get_collection poll.
+    await intent.expand_query("a", client, ["episodic_memory"])
+    assert client.get_collection.call_count == first

--- a/tests/test_security/test_recall_inject_coverage.py
+++ b/tests/test_security/test_recall_inject_coverage.py
@@ -375,7 +375,7 @@ KNOWN_QDRANT_READ_SITES: dict[str, tuple[str, str]] = {
         "infra",
         "duplicate-detection metric; content hashed, never prompted",
     ),
-    "memory/intent.py::expand_query": ("infra", "tag-index rebuild; with_payload=[tags] only"),
+    "memory/intent.py::_scan_tag_lists": ("infra", "tag-index rebuild; with_payload=[tags] only"),
     "qdrant/collections.py::batch_retrieve_vectors": (
         "library",
         "shared helper; callers classified individually",


### PR DESCRIPTION
## What & why

Follow-up **ac27b693**: under 5–7 concurrent Claude Code sessions the proactive-recall endpoint (`POST /api/genesis/hook/recall`, 4.5s budget from #1174) intermittently exceeded budget → 503 → keyword-only degrade. Live diagnosis showed the recall STAGE's variance is **shared-resource contention**, not a slow query: post-result bookkeeping serialized on the one shared SQLite connection + the sync Qdrant client on the event loop.

This is **PR-1 of a series**. It removes that bookkeeping from the latency path; PR-2 (Qdrant `to_thread`), PR-3 (RerankProvider), and PR-4 (read-connection split) follow.

## Changes

- **`recall(defer_side_effects=…)`** — proactive path only. `retrieved_count` write-backs, J-9 `recall_fired`+diagnostics, entity-lane shadow, the immunity gate emit, and the procedure `surfaced_count` bump run on background `tracked_task`s AFTER results return. Deep-search / `memory_proactive` MCP callers keep them inline (default `False`) — **byte-for-byte unchanged**, and mutually exclusive with `event_id_sink` so the MEM-003 id contract holds.
- **In-flight backstop** — past a fixed ceiling, deferral falls back to inline so a write is never dropped and the pending-task set can't grow unbounded (surfaced via a WARNING, not a silent cap).
- **Latency snapshot before deferral** — the deferred `recall_fired` records the real recall time, not the background-run time.
- **Tag co-occurrence index → stale-while-revalidate** — never rebuilt inline; a stale index kicks one single-flight background rebuild (scroll wrapped in a thread) and the current prompt proceeds with what it holds. Kills the multi-second first-prompt-after-restart stall.
- **Per-stage telemetry** — `vector`/`expand`/`fts`/`activation` ms in `timings_ms`, so a slow recall is attributable from the journal.

## Safety / correctness

- All deferred writes were already individually best-effort; deferral weakens no guarantee. `SerializedConnection` releases its lock per-method, so a shutdown cancellation between deferred writes can't poison the connection — worst case is one prompt's usage bumps.
- Injection-gate coverage guard preserved: `record_would_block` stays lexically in `_proactive_impl` (coroutine-object pattern, not a nested def).
- New Qdrant scroll site `_scan_tag_lists` reclassified in `KNOWN_QDRANT_READ_SITES` (infra; tags-only).

## Tests

- New `test_recall_deferral.py` (deferred-vs-inline write-back timing, backstop inline-fallback, sub-stage timings) and `test_tag_index_swr.py` (no inline rebuild, single-flight, time-gated count check).
- Full `tests/test_memory/` (1033), security injection-coverage, working-set hook, and recall integration smokes green locally.

## Verification plan (post-merge)

Deploy via `update.sh`, then replay the solo + 7-way concurrent probe battery and compare `timings_ms` distributions + the `proactive recall slow` journal lines before/after; watch the hook degrade-rate for 48h. Regression markers: J-9 `recall_fired`:recall ratio ~1:1, retrieved_count growth unchanged, no "Task was destroyed" at shutdown, MCP `memory_recall` latency unchanged.

Ledger: 477dc3570dc947c3ade5edcce6746151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
