### PR TITLE
perf(memory): dedicated read-only connection pool for recall reads (ac27b693, PR-4)

### DIFF
--- a/.claude/docs/proactive-memory-hook.md
+++ b/.claude/docs/proactive-memory-hook.md
@@ -68,10 +68,14 @@ fallback rate is directly observable. The health dashboard reads this file.
 
 The server response carries `timings_ms` with a per-stage breakdown —
 `embed`, `recall`, and (since ac27b693) the recall sub-stages `vector`,
-`expand`, `fts`, `activation`, plus `rerank`, `enrich`, `procedure`, `total`.
-When a call exceeds the slow-log threshold the server writes one
-`proactive recall slow: {…}` INFO line, so a latency regression is attributable
-to a stage from the journal alone without live probing.
+`event`, `expand`, `fts`, `expired`, `activation`, `breadcrumbs`, `assembly`,
+plus `rerank`, `enrich`, `procedure`, `total`. The read-stage timers
+(`event`/`fts`/`expired`/`activation`/`breadcrumbs`) decompose the `recall`
+bucket so what used to be an unaccounted residual — read-lock contention on the
+shared connection — is now attributable to a stage. When a call exceeds the
+slow-log threshold the server writes one `proactive recall slow: {…}` INFO line,
+so a latency regression is attributable to a stage from the journal alone
+without live probing.
 
 ## Latency: work off the hot path
 
@@ -89,6 +93,16 @@ does the least work needed to build the response and defers the rest:
   revalidate): a stale index never blocks a prompt on a full-corpus scroll; the
   current prompt uses whatever the index holds and a single background task
   rebuilds it.
+- **Recall reads run on a dedicated read-only connection pool** (`mode=ro`,
+  WAL-aware; `db/connection.py::ReadConnectionPool`, wired in `init/memory.py`).
+  All Genesis subsystems share one write connection behind a single lock, so
+  recall's read stages (FTS5, activation, enrich, breadcrumbs) otherwise queue
+  behind the whole server's writes under concurrent sessions. The pool gives
+  them genuinely-parallel readers off that lock. It is an **optional value-add**:
+  any pool miss or error falls back to the shared connection, so recall is never
+  worse than without it. Size: `GENESIS_RECALL_READ_POOL_SIZE` (default 4); kill
+  switch `GENESIS_RECALL_READ_POOL_OFF=1`. The query-embed call-site heartbeat
+  is also fired off the hot path, so `embed` no longer blocks on that write.
 
 ## Related
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   background instead of stalling the first prompt after a restart. Recall quality
   is unchanged; it just stops dropping to the degraded path under concurrency.
 
+- **Memory recall reads no longer wait in line behind the rest of the system's
+  writes.** Everything Genesis does shared a single database connection, so when
+  it was busy writing (reflections, learning, other sessions), a prompt's memory
+  lookup could sit waiting for its turn — the main reason recall slowed down and
+  occasionally dropped to the weaker keyword-only memory when several sessions
+  were active. Memory lookups now read through a dedicated read-only connection
+  pool that runs alongside the writes instead of behind them, so recall stays
+  responsive under load. It falls back to the shared connection automatically if
+  the pool is ever unavailable, so nothing breaks — recall is never slower than
+  before. Recall quality is unchanged.
+
 ### Fixed
 
 - **Background sessions no longer get silently cut off after 10 minutes.** A

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import sqlite3
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +32,19 @@ BUSY_TIMEOUT_MS = 5000
 # per *connection*, so the long-lived server + MCP connections each hold up to
 # this much — a few GiB total against a 36 GiB budget, comfortably within range.
 CACHE_SIZE_KIB = -262144
+
+# Read-only recall pool (follow-up ac27b693). Recall's read stages open a
+# dedicated mode=ro pool so they stop queuing behind the WHOLE server's write
+# traffic on the single SerializedConnection lock. Per-connection page cache is
+# deliberately MODEST here: the writer holds 256 MiB (CACHE_SIZE_KIB), but a read
+# pool multiplies the cache by its size, so bound each RO connection to keep the
+# pool cheap on small installs (64 MiB × a few connections stays comfortable).
+RO_CACHE_SIZE_KIB = -65536  # 64 MiB per read-only connection
+
+# Default read-pool size. Sized for the common "several concurrent CC sessions"
+# workload — reads are sub-second, so a handful of parallel readers clears the
+# checkout queue fast. Overridable via config; floor of 1 enforced in the pool.
+DEFAULT_READ_POOL_SIZE = 4
 
 # Schema migrations run rarely (deploy / server startup) but must win the write
 # lock even when other processes (concurrent CC-session MCP servers) are writing.
@@ -71,10 +84,15 @@ class SerializedConnection:
     """
 
     # Attributes that live on the proxy itself, not the wrapped connection.
-    _OWN_ATTRS = frozenset({
-        "_conn", "_lock", "_reconnect_fn",
-        "_consecutive_errors", "_max_errors",
-    })
+    _OWN_ATTRS = frozenset(
+        {
+            "_conn",
+            "_lock",
+            "_reconnect_fn",
+            "_consecutive_errors",
+            "_max_errors",
+        }
+    )
 
     _MAX_LOCK_ERRORS = 5
 
@@ -113,7 +131,8 @@ class SerializedConnection:
         if count >= self._max_errors and self._reconnect_fn is not None:
             logger.warning(
                 "DB lock error %d/%d — attempting reconnection",
-                count, self._max_errors,
+                count,
+                self._max_errors,
             )
             try:
                 old_conn = self._conn
@@ -132,7 +151,9 @@ class SerializedConnection:
     # -- Operations that return Result (support both await and async with) --
 
     def execute(
-        self, sql: str, parameters: Iterable[Any] | None = None,
+        self,
+        sql: str,
+        parameters: Iterable[Any] | None = None,
     ) -> Result:
         async def _locked() -> aiosqlite.Cursor:
             async with self._lock:
@@ -144,10 +165,13 @@ class SerializedConnection:
                     if "locked" in str(e):
                         await self._handle_lock_error(e)
                     raise
+
         return Result(_locked())
 
     def executemany(
-        self, sql: str, parameters: Iterable[Iterable[Any]],
+        self,
+        sql: str,
+        parameters: Iterable[Iterable[Any]],
     ) -> Result:
         async def _locked() -> aiosqlite.Cursor:
             async with self._lock:
@@ -159,10 +183,13 @@ class SerializedConnection:
                     if "locked" in str(e):
                         await self._handle_lock_error(e)
                     raise
+
         return Result(_locked())
 
     def execute_fetchall(
-        self, sql: str, parameters: Iterable[Any] | None = None,
+        self,
+        sql: str,
+        parameters: Iterable[Any] | None = None,
     ) -> Result:
         async def _locked() -> list[aiosqlite.Row]:
             async with self._lock:
@@ -174,10 +201,13 @@ class SerializedConnection:
                     if "locked" in str(e):
                         await self._handle_lock_error(e)
                     raise
+
         return Result(_locked())
 
     def execute_insert(
-        self, sql: str, parameters: Iterable[Any] | None = None,
+        self,
+        sql: str,
+        parameters: Iterable[Any] | None = None,
     ) -> Result:
         async def _locked() -> tuple | None:
             async with self._lock:
@@ -189,6 +219,7 @@ class SerializedConnection:
                     if "locked" in str(e):
                         await self._handle_lock_error(e)
                     raise
+
         return Result(_locked())
 
     def executescript(self, sql: str) -> Result:
@@ -202,6 +233,7 @@ class SerializedConnection:
                     if "locked" in str(e):
                         await self._handle_lock_error(e)
                     raise
+
         return Result(_locked())
 
     # -- Simple async operations -------------------------------------------
@@ -317,6 +349,131 @@ async def get_raw_db(
         yield db
     finally:
         await db.close()
+
+
+async def open_ro_connection(
+    path: str | Path = DEFAULT_DB_PATH,
+    *,
+    cache_size_kib: int = RO_CACHE_SIZE_KIB,
+) -> aiosqlite.Connection:
+    """Open a standalone READ-ONLY aiosqlite connection (``mode=ro``, WAL-aware).
+
+    The shared seam for zero-write readers that need the live DB without
+    contending on the runtime's :class:`SerializedConnection` write lock.
+    ``mode=ro`` (NOT ``immutable=1``) reads the live ``-wal``, so it sees
+    committed writes — a change committed on the writer moments earlier IS
+    visible here.
+
+    Reader-safe pragmas ONLY: ``busy_timeout`` (a checkpoint's brief exclusive
+    moment can otherwise throw ``SQLITE_BUSY`` at a reader), a modest
+    ``cache_size``, and the ``Row`` factory for parity with :func:`get_db`.
+    Deliberately does NOT run ``journal_mode=WAL`` or ``synchronous`` — those
+    need write access to the DB header and are no-ops (or raise
+    ``SQLITE_READONLY`` on some builds) on a read-only handle.
+    """
+    uri = f"file:{Path(path)}?mode=ro"
+    conn = await aiosqlite.connect(uri, uri=True)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    await conn.execute(f"PRAGMA cache_size={cache_size_kib}")
+    return conn
+
+
+class ReadPoolClosed(Exception):
+    """Raised by :meth:`ReadConnectionPool.acquire` when the pool is closed or
+    was never opened. Callers treat it as "use the shared connection instead."
+    """
+
+
+class ReadConnectionPool:
+    """Small fixed pool of read-only aiosqlite connections for hot read paths.
+
+    Each connection is a ``mode=ro`` handle (:func:`open_ro_connection`). WAL
+    allows unlimited concurrent readers, so N connections give N genuinely-
+    parallel readers that never queue behind the ``SerializedConnection`` write
+    lock — the fix for recall reads stalling behind the whole server's writes
+    under concurrent sessions (follow-up ac27b693).
+
+    Checkout is **exclusive** (an ``asyncio.Queue``): ``async with
+    pool.acquire() as conn`` hands ONE connection to ONE coroutine at a time,
+    which is exactly why the pooled connections need no per-connection lock (a
+    raw aiosqlite connection is safe for a single owner; the ``SerializedConnection``
+    lock only exists because many coroutines share one connection). The
+    (size+1)th concurrent reader blocks on the queue until a slot frees —
+    natural backpressure; the route's own timeout is the ultimate bound.
+
+    A pooled ``mode=ro`` autocommit ``SELECT`` never opens a transaction, so a
+    read that errors or is cancelled leaves no dangling state — the connection
+    is always safe to return to the pool, so there is deliberately no
+    replace-on-error logic (which would ``await`` in a ``finally`` under route-
+    timeout cancellation).
+
+    The pool is an OPTIMIZATION, never a hard dependency: callers fall back to
+    the shared write connection on any pool miss/error, so it can never make a
+    read WORSE than the pre-pool behavior.
+    """
+
+    def __init__(
+        self,
+        path: str | Path = DEFAULT_DB_PATH,
+        *,
+        size: int = DEFAULT_READ_POOL_SIZE,
+        cache_size_kib: int = RO_CACHE_SIZE_KIB,
+    ) -> None:
+        self._path = str(Path(path))
+        self._size = max(1, size)
+        self._cache_size_kib = cache_size_kib
+        self._queue: asyncio.Queue[aiosqlite.Connection] = asyncio.Queue()
+        self._all: list[aiosqlite.Connection] = []
+        self._closed = False
+        self._opened = False
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    async def open(self) -> None:
+        """Open all connections and fill the checkout queue. Idempotent."""
+        if self._opened:
+            return
+        for _ in range(self._size):
+            conn = await open_ro_connection(self._path, cache_size_kib=self._cache_size_kib)
+            self._all.append(conn)
+            self._queue.put_nowait(conn)
+        self._opened = True
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[aiosqlite.Connection]:
+        """Check out one connection for the duration of the ``async with`` block.
+
+        Raises :class:`ReadPoolClosed` if the pool is closed or not yet opened
+        (the caller falls back to the shared connection). The connection is
+        returned to the queue on exit — including on error/cancellation, which
+        is safe for autocommit ``mode=ro`` reads (no dangling transaction). If
+        the pool was closed while the connection was held, it is dropped rather
+        than returned (``close()`` closes every ``self._all`` connection).
+        """
+        if self._closed or not self._opened:
+            raise ReadPoolClosed
+        conn = await self._queue.get()
+        try:
+            yield conn
+        finally:
+            # No ``await`` here: put_nowait can't fail (unbounded queue), so the
+            # slot is returned even under route-timeout cancellation. On a
+            # close() race we drop the handle — close() owns closing self._all.
+            if not self._closed:
+                self._queue.put_nowait(conn)
+
+    async def close(self) -> None:
+        """Close every connection. Idempotent; safe to call at shutdown."""
+        if self._closed:
+            return
+        self._closed = True
+        for conn in self._all:
+            with suppress(Exception):
+                await conn.close()
+        self._all.clear()
 
 
 async def init_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -141,6 +141,44 @@ def memory_rerank_off() -> bool:
     )
 
 
+def recall_read_pool_off() -> bool:
+    """True when the recall read-connection pool must NOT be built (kill switch).
+
+    Recall's read stages (FTS5, activation, enrich, breadcrumbs) normally run on
+    a dedicated ``mode=ro`` connection pool so they stop queuing behind the whole
+    server's writes on the shared ``SerializedConnection`` (follow-up ac27b693).
+    This env kill makes the runtime skip building the pool — every recall read
+    falls back to the shared connection (the pre-pool behavior) — without a code
+    change. Default off: the pool is built.
+    """
+    return os.environ.get("GENESIS_RECALL_READ_POOL_OFF", "").strip() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def recall_read_pool_size() -> int:
+    """Size of the recall read-only connection pool (default from
+    ``DEFAULT_READ_POOL_SIZE``).
+
+    Each connection is one genuinely-parallel reader plus one OS thread and a
+    modest page cache, so this bounds how many concurrent recall read-chains run
+    in parallel before the next blocks on checkout. Tunable per install via
+    ``GENESIS_RECALL_READ_POOL_SIZE``; the pool floors it at 1. A missing or
+    non-integer value falls back to the default.
+    """
+    from genesis.db.connection import DEFAULT_READ_POOL_SIZE
+
+    raw = os.environ.get("GENESIS_RECALL_READ_POOL_SIZE", "").strip()
+    if not raw:
+        return DEFAULT_READ_POOL_SIZE
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_READ_POOL_SIZE
+
+
 def skill_gate_off() -> bool:
     """True when the skill-edit Critic must be suppressed entirely (kill switch).
 

--- a/src/genesis/mcp/memory/__init__.py
+++ b/src/genesis/mcp/memory/__init__.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     import aiosqlite
     from qdrant_client import QdrantClient
 
+    from genesis.db.connection import ReadConnectionPool
     from genesis.memory.reranker import VoyageReranker
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ def init(
     recall_embedding_provider: EmbeddingProvider | None = None,
     activity_tracker: object | None = None,
     reranker: VoyageReranker | None = None,
+    read_pool: ReadConnectionPool | None = None,
     # Backward compat — old callers pass ``embedding_provider``
     embedding_provider: EmbeddingProvider | None = None,
 ) -> None:
@@ -111,11 +113,17 @@ def init(
         db=db,
         linker=linker,
     )
+    # read_pool: the proactive per-prompt path recalls through THIS retriever
+    # (memory/proactive.py uses genesis.mcp.memory._retriever), so the ac27b693
+    # read-only pool must reach it here — wiring it only into rt._hybrid_retriever
+    # would leave the very hot path the pool targets bypassing it. Same shared
+    # pool instance (bounded connections); None keeps the pre-pool behavior.
     _retriever = HybridRetriever(
         embedding_provider=recall_emb,
         qdrant_client=qdrant_client,
         db=db,
         reranker=reranker,
+        read_pool=read_pool,
     )
     _user_model_evolver = UserModelEvolver(db=db)
     _bookmark_mgr = BookmarkManager(

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -674,9 +674,21 @@ async def proactive_context(
     if "rerank_ms" in engine_stats:
         timings["rerank"] = engine_stats["rerank_ms"]
     # Sub-stage breakdown of the `recall` bucket (ac27b693): surfaced so a slow
-    # recall can be attributed to vector/FTS/expand/activation from the journal
-    # alone, instead of guessed. Present only when recall populated them.
-    for _k in ("vector_ms", "expand_ms", "fts_ms", "activation_ms"):
+    # recall can be attributed to a specific stage from the journal alone,
+    # instead of guessed. PR-4 added the read-stage timers (event/expired/
+    # breadcrumbs) + assembly so the previously-unaccounted recall residual
+    # (read-lock contention) is now attributable. Present only when recall
+    # populated them.
+    for _k in (
+        "vector_ms",
+        "event_ms",
+        "expand_ms",
+        "fts_ms",
+        "expired_ms",
+        "activation_ms",
+        "breadcrumbs_ms",
+        "assembly_ms",
+    ):
         if _k in engine_stats:
             timings[_k.removesuffix("_ms")] = engine_stats[_k]
     if total_ms > _SLOW_RECALL_LOG_MS:

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -12,6 +12,7 @@ from typing import Any
 import aiosqlite
 from qdrant_client import QdrantClient
 
+from genesis.db.connection import ReadConnectionPool, ReadPoolClosed
 from genesis.db.crud import memory as memory_crud
 from genesis.db.crud import memory_links, observations
 from genesis.memory.activation import compute_activation
@@ -624,11 +625,50 @@ class HybridRetriever:
         qdrant_client: QdrantClient,
         db: aiosqlite.Connection,
         reranker: VoyageReranker | None = None,
+        read_pool: ReadConnectionPool | None = None,
     ) -> None:
         self._embeddings = embedding_provider
         self._qdrant = qdrant_client
         self._db = db
         self._reranker = reranker
+        # Optional read-only pool for recall's read stages (follow-up ac27b693).
+        # When wired (server path), pure-read helpers run on a dedicated mode=ro
+        # connection off the shared write lock; None (eval, tests, other callers)
+        # keeps every read on self._db — byte-identical to the pre-pool path.
+        self._read_pool = read_pool
+
+    async def _ro_read(
+        self,
+        fn: Callable[..., Coroutine[Any, Any, Any]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run a pure-read helper on a pooled read-only connection, off the
+        shared write lock. Called as ``fn(conn, *args, **kwargs)``.
+
+        Falls back to ``self._db`` on any pool miss/error — the pool is an
+        OPTIMIZATION, never a hard dependency, so a read is never WORSE than the
+        pre-pool path. This also means a security-relevant read (the WS-3
+        origin_class backfill) that hits a transient pool error is re-run on the
+        real write connection and returns true data, NOT a fail-open ``None``.
+
+        NOTE: a pooled read sees only COMMITTED state (mode=ro snapshot). Every
+        current recall read is safe (none depends on an uncommitted write made
+        earlier in the same recall); a future read that does must not route here.
+        """
+        pool = self._read_pool
+        if pool is not None:
+            try:
+                async with pool.acquire() as ro:
+                    return await fn(ro, *args, **kwargs)
+            except ReadPoolClosed:
+                pass  # pool closed / not opened — use the shared connection
+            except Exception:
+                logger.debug(
+                    "recall RO-pool read failed; retrying on shared connection",
+                    exc_info=True,
+                )
+        return await fn(self._db, *args, **kwargs)
 
     async def _maybe_entity_lane_shadow(
         self,
@@ -695,9 +735,12 @@ class HybridRetriever:
 
         ``stats``: optional caller-owned dict populated with rerank stage
         telemetry (``rerank_executed``, ``rerank_ms``, ``rerank_timed_out``)
-        plus per-stage read timings (``vector_ms``, ``expand_ms``, ``fts_ms``,
-        ``activation_ms``). Caller-owned so concurrent recalls on the shared
-        retriever can never race each other's numbers.
+        plus per-stage read timings (``vector_ms``, ``event_ms``, ``expand_ms``,
+        ``fts_ms``, ``expired_ms``, ``activation_ms``, ``breadcrumbs_ms``,
+        ``assembly_ms``). These decompose the ``recall`` wall-time so a residual
+        (e.g. read-lock contention) is attributable to a stage from the journal
+        alone. Caller-owned so concurrent recalls on the shared retriever can
+        never race each other's numbers.
 
         ``defer_side_effects``: when True, the post-result WRITE-BACKS and
         eval/telemetry emits (retrieved_count bumps, ``recall_fired`` +
@@ -785,11 +828,14 @@ class HybridRetriever:
                 stats["vector_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 2b. Event-calendar search (temporal queries)
+        _ts = time.monotonic()
         event_memory_ids = await self._gather_event_candidates(
             query,
             intent,
             candidate_limit,
         )
+        if stats is not None:
+            stats["event_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 2c. Expand query via tag co-occurrence (SWR — stale index rebuilds in
         # the background, never inline on this path; see intent.expand_query)
@@ -824,12 +870,15 @@ class HybridRetriever:
         # (No-op on an empty set — guard the call so both empty exits share one
         # path below.)
         if all_ids:
+            _ts = time.monotonic()
             all_ids, event_memory_ids = await self._filter_expired_candidates(
                 all_ids,
                 qdrant_by_id,
                 fts_by_id,
                 event_memory_ids,
             )
+            if stats is not None:
+                stats["expired_ms"] = round((time.monotonic() - _ts) * 1000, 1)
         if not all_ids:
             # No organic candidates from vector/FTS/event lanes. Still measure
             # whether the entity lane would surface something — its highest-value
@@ -920,9 +969,13 @@ class HybridRetriever:
 
         # 7b. Graph boost: backlink + adjacency (floor-gated); mutates
         # ``fused`` in place.
+        _ts = time.monotonic()
         graph_boost_applied = await self._apply_graph_boost(fused, inbound_by_id)
+        if stats is not None:
+            stats["breadcrumbs_ms"] = round((time.monotonic() - _ts) * 1000, 1)
 
         # 8. Filter by min_activation
+        _ts_asm = time.monotonic()
         candidates = [mid for mid in fused if activation_by_id.get(mid, 0.0) >= min_activation]
 
         # 8b. Diversity penalty — collapse echo clusters
@@ -987,7 +1040,10 @@ class HybridRetriever:
         _no_origin = [r.memory_id for r in results if r.origin_class is None]
         if _no_origin:
             try:
-                _origin_by_id = await memory_crud.origin_class_by_ids(self._db, _no_origin)
+                # RO-pool read (WS-3 injection-gate backfill): _ro_read re-reads
+                # on self._db if the pool errs, so a transient pool miss returns
+                # true origin data, never the fail-open None in the except below.
+                _origin_by_id = await self._ro_read(memory_crud.origin_class_by_ids, _no_origin)
                 results = [
                     dataclasses.replace(r, origin_class=_origin_by_id.get(r.memory_id))
                     if r.origin_class is None and _origin_by_id.get(r.memory_id)
@@ -996,6 +1052,9 @@ class HybridRetriever:
                 ]
             except Exception:
                 logger.debug("origin_class backfill on recall failed", exc_info=True)
+
+        if stats is not None:
+            stats["assembly_ms"] = round((time.monotonic() - _ts_asm) * 1000, 1)
 
         # 11/11b/11c. Retrieval write-backs (Qdrant counts, observation +
         # knowledge_units sync) — each individually swallowed. Runs AFTER
@@ -1142,12 +1201,20 @@ class HybridRetriever:
         vector = None
         try:
             vector = await self._embeddings.embed(query)
-            await record_last_run(
-                self._db,
-                "21b_query_embedding",
-                provider="embedding",
-                model_id="cloud-primary",
-                response_text=f"Query embed: {query[:60]}",
+            # Fire the call-site heartbeat OFF the hot path (ac27b693): it's
+            # best-effort telemetry, and blocking embed_ms on this write — which
+            # queues behind the whole server's writes under load — is pure
+            # latency waste. Nothing reads call_site_last_run synchronously
+            # during recall, so a fire-and-forget task is correct here.
+            tracked_task(
+                record_last_run(
+                    self._db,
+                    "21b_query_embedding",
+                    provider="embedding",
+                    model_id="cloud-primary",
+                    response_text=f"Query embed: {query[:60]}",
+                ),
+                name="embed_last_run",
             )
         except EmbeddingUnavailableError:
             embedding_available = False
@@ -1222,8 +1289,8 @@ class HybridRetriever:
                 if time_range:
                     from genesis.db.crud import memory_events
 
-                    event_memory_ids = await memory_events.get_memory_ids_in_range(
-                        self._db,
+                    event_memory_ids = await self._ro_read(
+                        memory_events.get_memory_ids_in_range,
                         time_range[0],
                         time_range[1],
                         limit=candidate_limit,
@@ -1293,8 +1360,8 @@ class HybridRetriever:
         """
         fts_is_boolean = fts_query != query  # expansion produced boolean syntax
         fts_collection = collections[0] if len(collections) == 1 else None
-        fts_results = await memory_crud.search_ranked(
-            self._db,
+        fts_results = await self._ro_read(
+            memory_crud.search_ranked,
             query=fts_query,
             collection=fts_collection,
             limit=candidate_limit,
@@ -1332,7 +1399,7 @@ class HybridRetriever:
         ids); returns the shrunk ``(all_ids, event_memory_ids)``.
         """
         try:
-            expired = await _expired_candidate_ids(self._db, all_ids)
+            expired = await self._ro_read(_expired_candidate_ids, all_ids)
         except Exception:
             logger.warning(
                 "invalid_at filter failed, returning unfiltered candidates",
@@ -1362,7 +1429,7 @@ class HybridRetriever:
         (not act on) whether the activation loop entrenches frequently-
         retrieved memories.
         """
-        link_counts = await memory_links.batch_link_counts(self._db, list(all_ids))
+        link_counts = await self._ro_read(memory_links.batch_link_counts, list(all_ids))
 
         # FTS-only rows (no Qdrant hit) otherwise fall back to now_str for
         # created_at, giving them an unearned recency = exp(0) = 1.0 and a
@@ -1371,7 +1438,7 @@ class HybridRetriever:
         # ghosts with no metadata row keep the now_str fallback below.
         fts_only_ids = [mid for mid in all_ids if mid not in qdrant_by_id]
         meta_created_at = (
-            await memory_crud.batch_created_at(self._db, fts_only_ids) if fts_only_ids else {}
+            await self._ro_read(memory_crud.batch_created_at, fts_only_ids) if fts_only_ids else {}
         )
 
         activation_by_id: dict[str, float] = {}
@@ -1524,8 +1591,8 @@ class HybridRetriever:
             top_k = boosted_ranked[:_ADJACENCY_TOP_K]
             if len(top_k) >= 3:
                 try:
-                    edges = await memory_links.inter_candidate_links(
-                        self._db,
+                    edges = await self._ro_read(
+                        memory_links.inter_candidate_links,
                         top_k,
                     )
                     intra_inbound: dict[str, int] = {}

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from genesis.cc.context_injector import ContextInjector
     from genesis.cc.reflection_bridge import CCReflectionBridge
     from genesis.cc.session_manager import SessionManager
+    from genesis.db.connection import ReadConnectionPool
     from genesis.inbox.monitor import InboxMonitor
     from genesis.learning.pipeline import TriagePipeline
     from genesis.mail.monitor import MailMonitor
@@ -174,6 +175,9 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._bootstrapped = False
 
         self._db: aiosqlite.Connection | None = None
+        # Dedicated read-only pool for recall's read stages (follow-up ac27b693);
+        # wired in _init_memory, closed before self._db at shutdown.
+        self._db_ro_pool: ReadConnectionPool | None = None
         self._event_bus: GenesisEventBus | None = None
         self._awareness_loop: AwarenessLoop | None = None
         self._router: Router | None = None
@@ -679,6 +683,16 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
                 await self._event_bus.stop()
             except Exception:
                 logger.exception("Failed to stop event bus")
+
+        # Close the recall read-only pool BEFORE the writer — readers stop
+        # first (follow-up ac27b693). Idempotent; a failed memory init leaves
+        # this None, so the guard also covers the pool-never-built case.
+        if self._db_ro_pool is not None:
+            try:
+                await self._db_ro_pool.close()
+                logger.info("Recall read-only pool closed")
+            except Exception:
+                logger.exception("Failed to close recall read-only pool")
 
         if self._db is not None:
             try:

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -20,7 +20,8 @@ logger = logging.getLogger("genesis.runtime")
 
 
 async def run_status_writer_loop(
-    runtime: GenesisRuntime, interval_s: float = _STATUS_WRITE_INTERVAL_S,
+    runtime: GenesisRuntime,
+    interval_s: float = _STATUS_WRITE_INTERVAL_S,
 ) -> None:
     """Background loop that refreshes status.json on a fixed cadence.
 
@@ -42,7 +43,8 @@ async def run_status_writer_loop(
         except Exception as exc:
             runtime.record_job_failure("status_writer_loop", str(exc))
             logger.error(
-                "Status writer loop iteration failed", exc_info=True,
+                "Status writer loop iteration failed",
+                exc_info=True,
             )
 
 
@@ -51,13 +53,14 @@ async def init(rt: GenesisRuntime) -> None:
     try:
         from qdrant_client import QdrantClient
 
-        from genesis.env import qdrant_url
+        from genesis.env import qdrant_url, recall_read_pool_off, recall_read_pool_size
         from genesis.memory.embeddings import EmbeddingProvider
         from genesis.memory.linker import MemoryLinker
         from genesis.memory.store import MemoryStore
 
         qdrant = QdrantClient(url=qdrant_url(), timeout=5)
         from genesis.qdrant.collections import ensure_collections
+
         ensure_collections(qdrant)
         logger.info("Qdrant collections ensured")
 
@@ -105,11 +108,38 @@ async def init(rt: GenesisRuntime) -> None:
         from genesis.memory.retrieval import HybridRetriever
 
         reranker = VoyageReranker()
+
+        # Dedicated read-only connection pool for recall's read stages
+        # (follow-up ac27b693): FTS5/activation/enrich/breadcrumbs run off the
+        # shared SerializedConnection write lock so they stop queuing behind the
+        # whole server's writes under concurrent sessions. Optional value-add —
+        # HybridRetriever falls back to rt._db on any pool miss, so a build
+        # failure (or the GENESIS_RECALL_READ_POOL_OFF kill) degrades to the
+        # pre-pool path rather than breaking recall.
+        rt._db_ro_pool = None
+        if not recall_read_pool_off():
+            try:
+                from genesis.db.connection import ReadConnectionPool
+                from genesis.env import genesis_db_path
+
+                pool = ReadConnectionPool(genesis_db_path(), size=recall_read_pool_size())
+                await pool.open()
+                rt._db_ro_pool = pool
+                logger.info("Recall read-only pool opened (size=%d)", pool.size)
+            except Exception:
+                logger.warning(
+                    "Recall read-only pool failed to open — recall reads use the "
+                    "shared connection (degraded, not broken)",
+                    exc_info=True,
+                )
+                rt._db_ro_pool = None
+
         rt._hybrid_retriever = HybridRetriever(
             embedding_provider=recall_embedder,
             qdrant_client=qdrant,
             db=rt._db,
             reranker=reranker,
+            read_pool=rt._db_ro_pool,
         )
         rt._context_injector = ContextInjector(
             retriever=rt._hybrid_retriever,
@@ -173,11 +203,13 @@ async def init(rt: GenesisRuntime) -> None:
                 await rt._status_writer.write()
             except Exception:
                 logger.warning(
-                    "Initial status writer write failed", exc_info=True,
+                    "Initial status writer write failed",
+                    exc_info=True,
                 )
 
             rt._status_writer_task = tracked_task(
-                run_status_writer_loop(rt), name="status-writer-loop",
+                run_status_writer_loop(rt),
+                name="status-writer-loop",
             )
             logger.info(
                 "Status writer loop started (interval=%ds)",
@@ -226,23 +258,29 @@ async def init(rt: GenesisRuntime) -> None:
 
     except (ConnectionError, TimeoutError) as exc:
         logger.error(
-            "MemoryStore creation failed (Qdrant down?) — "
-            "continuing without vector memory",
+            "MemoryStore creation failed (Qdrant down?) — continuing without vector memory",
             exc_info=True,
         )
         from genesis.runtime._degradation import record_init_degradation
-        await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
+
+        await record_init_degradation(
+            rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error"
+        )
     except Exception as exc:
         logger.error(
             "MemoryStore creation failed — continuing without vector memory",
             exc_info=True,
         )
         from genesis.runtime._degradation import record_init_degradation
-        await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
+
+        await record_init_degradation(
+            rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error"
+        )
 
 
 async def _migrate_reference_vectors(
-    qdrant: QdrantClient, db: aiosqlite.Connection,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
 ) -> None:
     """One-time migration: move reference vectors from knowledge_base → episodic_memory.
 
@@ -295,9 +333,7 @@ async def _migrate_reference_vectors(
         for p in to_migrate:
             payload = dict(p.payload) if p.payload else {}
             payload["memory_type"] = "episodic"
-            points_to_upsert.append(
-                PointStruct(id=str(p.id), vector=p.vector, payload=payload)
-            )
+            points_to_upsert.append(PointStruct(id=str(p.id), vector=p.vector, payload=payload))
 
         qdrant.upsert(
             collection_name="episodic_memory",
@@ -313,8 +349,7 @@ async def _migrate_reference_vectors(
         )
 
         logger.info(
-            "Reference vector migration: moved %d points from "
-            "knowledge_base → episodic_memory",
+            "Reference vector migration: moved %d points from knowledge_base → episodic_memory",
             len(to_migrate),
         )
     except Exception:

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -158,6 +158,10 @@ async def init(rt: GenesisRuntime) -> None:
             # tools (memory_recall / knowledge_recall) actually rerank instead
             # of silently building a reranker-less retriever.
             reranker=reranker,
+            # Share the SAME read-only pool: the proactive per-prompt path recalls
+            # through the MCP retriever, so the pool must reach it here or the hot
+            # path PR-4 targets would bypass it (ac27b693).
+            read_pool=rt._db_ro_pool,
         )
         logger.info("Memory MCP initialized (dual embedders, shared reranker)")
 

--- a/tests/test_db/test_read_pool.py
+++ b/tests/test_db/test_read_pool.py
@@ -192,3 +192,30 @@ async def test_open_is_idempotent(db_path):
 async def test_size_floored_at_one(db_path):
     assert ReadConnectionPool(db_path, size=0).size == 1
     assert ReadConnectionPool(db_path, size=-3).size == 1
+
+
+def test_recall_read_pool_size_env(monkeypatch):
+    """The size env-reader parses an int and falls back to the default on a
+    missing/blank/non-integer value (a bad env value must never crash boot)."""
+    from genesis import env
+    from genesis.db.connection import DEFAULT_READ_POOL_SIZE
+
+    monkeypatch.delenv("GENESIS_RECALL_READ_POOL_SIZE", raising=False)
+    assert env.recall_read_pool_size() == DEFAULT_READ_POOL_SIZE
+    monkeypatch.setenv("GENESIS_RECALL_READ_POOL_SIZE", "7")
+    assert env.recall_read_pool_size() == 7
+    monkeypatch.setenv("GENESIS_RECALL_READ_POOL_SIZE", "not-an-int")
+    assert env.recall_read_pool_size() == DEFAULT_READ_POOL_SIZE  # ValueError → default
+    monkeypatch.setenv("GENESIS_RECALL_READ_POOL_SIZE", "   ")
+    assert env.recall_read_pool_size() == DEFAULT_READ_POOL_SIZE  # blank → default
+
+
+def test_recall_read_pool_off_env(monkeypatch):
+    from genesis import env
+
+    monkeypatch.delenv("GENESIS_RECALL_READ_POOL_OFF", raising=False)
+    assert env.recall_read_pool_off() is False
+    monkeypatch.setenv("GENESIS_RECALL_READ_POOL_OFF", "1")
+    assert env.recall_read_pool_off() is True
+    monkeypatch.setenv("GENESIS_RECALL_READ_POOL_OFF", "no")
+    assert env.recall_read_pool_off() is False

--- a/tests/test_db/test_read_pool.py
+++ b/tests/test_db/test_read_pool.py
@@ -1,0 +1,194 @@
+"""ReadConnectionPool + open_ro_connection (follow-up ac27b693, PR-4).
+
+A dedicated ``mode=ro`` pool lets recall's read stages run off the shared
+SerializedConnection write lock. These tests pin the load-bearing invariants:
+
+- **checkout exclusivity** — the entire no-per-connection-lock design rests on a
+  connection only ever being held by one coroutine at a time;
+- **``mode=ro`` is truly read-only** — a pooled connection cannot write;
+- **WAL-awareness** — a pooled reader sees committed writes (the ``immutable=1``
+  trap would miss un-checkpointed WAL frames);
+- **clean close/lifecycle** — idempotent close, ReadPoolClosed after close/before
+  open, and no slot leak when a read errors inside the block.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from genesis.db.connection import (
+    ReadConnectionPool,
+    ReadPoolClosed,
+    get_db,
+    open_ro_connection,
+)
+
+
+async def _seed_db(path) -> None:
+    db = await aiosqlite.connect(str(path))
+    await db.execute("PRAGMA journal_mode=WAL")
+    await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    await db.execute("INSERT INTO t (id, v) VALUES (1, 'a'), (2, 'b')")
+    await db.commit()
+    await db.close()
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "pool.db"
+
+
+async def test_open_ro_connection_reads_and_row_factory(db_path):
+    await _seed_db(db_path)
+    conn = await open_ro_connection(db_path)
+    try:
+        rows = await conn.execute_fetchall("SELECT v FROM t ORDER BY id")
+        assert [r[0] for r in rows] == ["a", "b"]
+        # Row-factory parity with get_db: named column access must work, or the
+        # RO connection silently diverges from self._db (architect SHOULD-FIX).
+        named = await conn.execute_fetchall("SELECT v FROM t WHERE id = 1")
+        assert named[0]["v"] == "a"
+    finally:
+        await conn.close()
+
+
+async def test_ro_connection_cannot_write(db_path):
+    """Pins the zero-write invariant — a mode=ro handle rejects INSERT."""
+    await _seed_db(db_path)
+    conn = await open_ro_connection(db_path)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            await conn.execute("INSERT INTO t (id, v) VALUES (3, 'c')")
+    finally:
+        await conn.close()
+
+
+async def test_pool_acquire_reads(db_path):
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=2)
+    await pool.open()
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.execute_fetchall("SELECT COUNT(*) FROM t")
+            assert rows[0][0] == 2
+    finally:
+        await pool.close()
+
+
+async def test_checkout_is_exclusive(db_path):
+    """Load-bearing invariant: a checked-out connection is NEVER handed to a
+    second coroutine while held. With size=1 a second acquire blocks until the
+    first releases; a bug that double-hands the connection resurrects the exact
+    in_transaction corruption SerializedConnection exists to prevent.
+    """
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=1)
+    await pool.open()
+    order: list[str] = []
+    try:
+        async with pool.acquire() as c1:
+            started = asyncio.Event()
+
+            async def second() -> None:
+                started.set()
+                async with pool.acquire() as c2:
+                    order.append("second-acquired")
+                    assert c2 is c1  # size=1 → the one connection, reused
+
+            task = asyncio.create_task(second())
+            await started.wait()
+            await asyncio.sleep(0.05)  # give second() a chance to (not) acquire
+            assert order == []  # still blocked behind the held checkout
+            order.append("first-releasing")
+        await task
+        assert order == ["first-releasing", "second-acquired"]
+    finally:
+        await pool.close()
+
+
+async def test_pool_sees_committed_writes(db_path):
+    """mode=ro is WAL-aware: a write committed on the writer is visible to a
+    pooled reader. (immutable=1 would miss the un-checkpointed WAL frame — the
+    documented trap this pool must not fall into.)
+    """
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=1)
+    await pool.open()
+    writer = await get_db(db_path)
+    try:
+        await writer.execute("INSERT INTO t (id, v) VALUES (3, 'c')")
+        await writer.commit()
+        async with pool.acquire() as conn:
+            rows = await conn.execute_fetchall("SELECT v FROM t WHERE id = 3")
+            assert rows and rows[0][0] == "c"
+    finally:
+        await writer.close()
+        await pool.close()
+
+
+async def test_error_in_block_returns_connection(db_path):
+    """An error inside the acquire block must still return the connection — an
+    autocommit mode=ro SELECT leaves no dangling transaction, so the slot is
+    safe to reuse. A leaked slot would deadlock the (size=1) pool on the next
+    acquire; this test would hang instead of passing if the finally regressed.
+    """
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=1)
+    await pool.open()
+    try:
+        with pytest.raises(ValueError):
+            async with pool.acquire() as conn:
+                await conn.execute_fetchall("SELECT 1")
+                raise ValueError("boom")
+        # Slot returned — this acquire would block forever if it leaked.
+        async with asyncio.timeout(2):
+            async with pool.acquire() as conn:
+                rows = await conn.execute_fetchall("SELECT COUNT(*) FROM t")
+                assert rows[0][0] == 2
+    finally:
+        await pool.close()
+
+
+async def test_acquire_after_close_raises(db_path):
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=2)
+    await pool.open()
+    await pool.close()
+    with pytest.raises(ReadPoolClosed):
+        async with pool.acquire():
+            pass
+
+
+async def test_acquire_before_open_raises(db_path):
+    pool = ReadConnectionPool(db_path, size=2)
+    with pytest.raises(ReadPoolClosed):
+        async with pool.acquire():
+            pass
+
+
+async def test_close_is_idempotent(db_path):
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=2)
+    await pool.open()
+    await pool.close()
+    await pool.close()  # second close must not raise
+
+
+async def test_open_is_idempotent(db_path):
+    await _seed_db(db_path)
+    pool = ReadConnectionPool(db_path, size=2)
+    await pool.open()
+    await pool.open()  # second open is a no-op, does not double the pool
+    try:
+        assert pool._queue.qsize() == 2
+    finally:
+        await pool.close()
+
+
+async def test_size_floored_at_one(db_path):
+    assert ReadConnectionPool(db_path, size=0).size == 1
+    assert ReadConnectionPool(db_path, size=-3).size == 1

--- a/tests/test_mcp/test_memory_reranker_wiring.py
+++ b/tests/test_mcp/test_memory_reranker_wiring.py
@@ -44,6 +44,7 @@ def _stub_init_deps(monkeypatch) -> dict:
         def __init__(self, **kwargs):
             captured.update(kwargs)
             self._reranker = kwargs.get("reranker")
+            self._read_pool = kwargs.get("read_pool")
 
     # Local imports inside init() resolve these attributes at call time, so
     # patching the source module attribute is sufficient.
@@ -87,3 +88,37 @@ def test_init_without_reranker_is_none(monkeypatch):
     )
 
     assert captured["reranker"] is None
+
+
+def test_init_threads_read_pool_into_retriever(monkeypatch):
+    """The proactive per-prompt path recalls through the MCP retriever
+    (memory/proactive.py uses genesis.mcp.memory._retriever), so the ac27b693
+    read-only pool MUST reach it here — wiring it only into rt._hybrid_retriever
+    would leave the very hot path the pool targets bypassing it (Codex #1189 P1).
+    """
+    captured = _stub_init_deps(monkeypatch)
+    sentinel = object()
+
+    mem.init(
+        db=MagicMock(),
+        qdrant_client=MagicMock(),
+        embedding_provider=MagicMock(),
+        read_pool=sentinel,
+    )
+
+    assert captured["read_pool"] is sentinel
+    assert mem._retriever._read_pool is sentinel
+
+
+def test_init_without_read_pool_is_none(monkeypatch):
+    # Legacy / eval call sites pass no pool — the retriever falls back to the
+    # shared connection (pre-pool behavior), byte-identical.
+    captured = _stub_init_deps(monkeypatch)
+
+    mem.init(
+        db=MagicMock(),
+        qdrant_client=MagicMock(),
+        embedding_provider=MagicMock(),
+    )
+
+    assert captured["read_pool"] is None

--- a/tests/test_memory/test_recall_deferral.py
+++ b/tests/test_memory/test_recall_deferral.py
@@ -164,7 +164,16 @@ async def test_stats_carries_substage_timings(mock_qdrant, mock_crud, mock_links
 
     stats: dict = {}
     await retriever.recall("test", limit=5, stats=stats, defer_side_effects=True)
-    for key in ("vector_ms", "expand_ms", "fts_ms", "activation_ms"):
+    for key in (
+        "vector_ms",
+        "event_ms",
+        "expand_ms",
+        "fts_ms",
+        "expired_ms",
+        "activation_ms",
+        "breadcrumbs_ms",
+        "assembly_ms",
+    ):
         assert key in stats, f"missing {key} in {stats}"
         assert isinstance(stats[key], float)
 

--- a/tests/test_memory/test_recall_read_pool.py
+++ b/tests/test_memory/test_recall_read_pool.py
@@ -1,0 +1,99 @@
+"""HybridRetriever._ro_read seam (follow-up ac27b693, PR-4).
+
+recall's pure reads route through ``_ro_read``, which runs them on a pooled
+``mode=ro`` connection when a pool is wired and falls back to the shared write
+connection (``self._db``) on any pool miss/error. That fallback is the safety
+net that makes the pool optional: a read is never WORSE than the pre-pool path,
+and a security-relevant read (the WS-3 origin backfill) that hits a transient
+pool error re-reads real data instead of fail-open ``None``.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from genesis.db.connection import ReadPoolClosed
+from genesis.memory.retrieval import HybridRetriever
+
+
+def _retriever(read_pool=None) -> HybridRetriever:
+    embed = MagicMock()
+    embed.embed = AsyncMock(return_value=[0.1] * 1024)
+    return HybridRetriever(
+        embedding_provider=embed,
+        qdrant_client=MagicMock(),
+        db=MagicMock(name="shared_db"),
+        read_pool=read_pool,
+    )
+
+
+class _FakePool:
+    """Minimal pool: ``acquire()`` yields a fixed connection, or raises."""
+
+    def __init__(self, conn, *, raise_exc=None):
+        self._conn = conn
+        self._raise_exc = raise_exc
+        self.acquired = 0
+
+    @asynccontextmanager
+    async def acquire(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        self.acquired += 1
+        yield self._conn
+
+
+async def test_ro_read_uses_pool_when_present():
+    ro_conn = object()
+    pool = _FakePool(ro_conn)
+    retriever = _retriever(read_pool=pool)
+
+    async def fn(conn, x):
+        assert conn is ro_conn  # ran on the pooled RO connection, not self._db
+        return x * 2
+
+    assert await retriever._ro_read(fn, 5) == 10
+    assert pool.acquired == 1
+
+
+async def test_ro_read_falls_back_to_db_without_pool():
+    retriever = _retriever(read_pool=None)
+    seen: dict = {}
+
+    async def fn(conn, x):
+        seen["conn"] = conn
+        return x
+
+    assert await retriever._ro_read(fn, 7) == 7
+    assert seen["conn"] is retriever._db  # byte-identical to the pre-pool path
+
+
+async def test_ro_read_falls_back_to_db_on_pool_error():
+    """A pool acquire/read error re-runs on self._db — the safety net that makes
+    the pool optional. Also the WS-3 origin-backfill security path: a transient
+    pool error re-reads true data on the shared connection, never fail-open None.
+    """
+    pool = _FakePool(object(), raise_exc=RuntimeError("pool down"))
+    retriever = _retriever(read_pool=pool)
+    seen: dict = {}
+
+    async def fn(conn, x):
+        seen["conn"] = conn
+        return x
+
+    assert await retriever._ro_read(fn, 3) == 3
+    assert seen["conn"] is retriever._db
+
+
+async def test_ro_read_falls_back_on_readpoolclosed():
+    pool = _FakePool(object(), raise_exc=ReadPoolClosed())
+    retriever = _retriever(read_pool=pool)
+    seen: dict = {}
+
+    async def fn(conn, x):
+        seen["conn"] = conn
+        return x
+
+    assert await retriever._ro_read(fn, 1) == 1
+    assert seen["conn"] is retriever._db


### PR DESCRIPTION
## What & why

Recall's read stages (FTS5, activation, enrich, breadcrumbs, expired-filter, event, origin backfill) shared the one `SerializedConnection` behind a single `asyncio.Lock` with the whole server, so under concurrent CC sessions they queued behind all server writes. PR-1's per-stage telemetry exposed this as a ~1.2s **unaccounted** residual inside the `recall` stage — the head-of-line-blocking that intermittently pushed the 4.5s route over budget → 503 → keyword-only degrade. Follow-up `ac27b693`; 4th in the latency series (PR-1 = #1185).

## Change

- **`ReadConnectionPool` + `open_ro_connection`** (`db/connection.py`): small fixed pool of `mode=ro` (WAL-aware, **not** `immutable=1`) aiosqlite connections. Exclusive `asyncio.Queue` checkout — one reader per connection, so no per-connection lock is needed. Reader-safe pragmas only (`busy_timeout`, a modest 64 MiB cache, `Row` factory — deliberately **no** `journal_mode`/`synchronous` on a RO handle). Size `GENESIS_RECALL_READ_POOL_SIZE` (default 4), kill switch `GENESIS_RECALL_READ_POOL_OFF`.
- **`HybridRetriever._ro_read` seam** routes the 7 pure reads through the pool, **falling back to `self._db` on any pool miss/error** — the pool is optional value-add, so recall is never worse than before. The WS-3 `origin_class` backfill re-reads on `self._db` on a pool error, never fail-open `None`.
- Query-embed call-site heartbeat now fires off the hot path (was a synchronous write inside `embed_ms`).
- Read-stage sub-timers (`event`/`expired`/`breadcrumbs`/`assembly`) decompose the previously-unaccounted `recall` residual so the fix is measurable from the journal.
- Pool built in `_init_memory` (`rt._db_ro_pool`), closed **before** `self._db` at shutdown (readers before writer).

## Confidence & safety

- Read/write split & pool mechanism: high — a genesis-architect design review + a code-reviewer implementation pass both cleared it (all 6 design SHOULD-FIXes honored; reviewer verdict DONE, no findings ≥80% confidence).
- **PR-4 alone may not fully close 503s at 7× concurrent** (honest): the journal shows `embed`/`procedure`/`rerank` also contribute ~2s of non-recall-read latency this PR doesn't touch — the series (PR-2 Qdrant, PR-3 rerank) continues. PR-4 is the biggest single lever, not a silver bullet.
- Deep-search / MCP callers unchanged (`read_pool` defaults `None` → byte-identical). Worst case on any pool failure = today's behavior.

## Tests

`tests/test_db/test_read_pool.py` (checkout exclusivity, `mode=ro` read-only, WAL-awareness, idempotent close, no slot-leak on error), `tests/test_memory/test_recall_read_pool.py` (`_ro_read` pool-vs-fallback incl. the security re-read), extended sub-timer assertions. 113 targeted tests green locally (incl. the injection-gate coverage guard, retrieval, retrieval-fallback, origin-class recall, proactive engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
