### PR TITLE
fix(db): batch bulk data-migration writes to avoid WAL write-lock starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A large one-time data cleanup no longer briefly freezes the running system.**
+  Post-startup data migrations (one-off cleanups/backfills of stored knowledge and
+  history) run alongside the live system, which allows only one writer to the
+  database at a time. A big cleanup used to do all its work in a single long write,
+  briefly blocking every other write for ~10+ seconds — long enough that the system
+  logged "database is locked" errors and, in one case, had to re-run the cleanup
+  after a restart. Bulk cleanups now save their progress in small batches, releasing
+  the database between them, and the bookkeeping that records a migration as "done"
+  now retries briefly if it hits a momentary lock — so a cleanup is never
+  needlessly repeated. (Slow per-record checks were also moved out of the locked
+  window.)
+
 - **Background sessions no longer get silently cut off after 10 minutes.** A
   long background task (for example deep research running as a background
   session) used to be killed at about 10 minutes with only a partial result and

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -260,7 +260,7 @@ verified: 0e65071c 2026-07-21
   bookmark-enrichment) route to the KB; action/maintenance/monitor/pipeline-
   intermediate output is point-in-time OPERATIONAL TELEMETRY, gated OUT at
   `dispatch._route_insights` (before the gate it filled the KB with db-
-  maintenance/eval reports — 71% surplus; d0005 purged the historical rows).
+  maintenance/eval reports — 71% surplus; d0006 purged the historical rows).
   `source_pipeline` is per-source (`intake._pipeline_for_source`): Genesis-
   authored → `surplus`/first-party; crawled recon/model/github/web →
   distinct labels classified `external_untrusted` (wrapped on recall).
@@ -912,7 +912,11 @@ verified: b662f3e3 2026-07-17
   ones sit `operator_pending` and never auto-run. Shared file-discovery with the
   schema runner (`db/_migration_discovery.py`), deliberately NOT the atomic-txn
   proxy. Seed `d0001` mirrors SQLite `origin_class` onto Qdrant — idempotent, so
-  a lagging install self-heals on next pull+restart with no control plane.
+  a lagging install self-heals on next pull+restart with no control plane. Bulk
+  write/delete migrations MUST commit in batches (`_util.commit_in_batches`) so a
+  big backfill never holds the single WAL writer long enough to starve the live
+  server (which waits only 5s for the lock); the runner also retries a
+  lock-contended ledger write (#1179 regression guard).
 - **runtime/**: sequential bootstrap (secrets → db → … → sentinel, ~27 steps);
   each step records ok/degraded/failed in the manifest — only db aborts.
   `~/.genesis/capabilities.json` + `bootstrap_manifest.json` are projected at

--- a/src/genesis/db/data_migrations/__init__.py
+++ b/src/genesis/db/data_migrations/__init__.py
@@ -13,4 +13,14 @@ runs ``migrate()`` then ``verify()`` off the event loop, and records
 completed/failed. Idempotency is each migration's own contract — a re-run on
 an already-migrated install must be a clean no-op (this is how a lagging peer
 install self-heals on its next pull+restart, with no control plane).
+
+Migrations run POST-boot on their own sync connection, CONCURRENTLY with the
+live server. SQLite (WAL) has a single writer, and the server waits only 5s for
+the write lock — so a bulk migration that loops over many rows in ONE
+transaction starves every server write for the loop's duration (regression:
+d0006 held it ~13s, #1179). **A migration that writes more than a handful of
+rows in a loop MUST drive its writes through ``_util.commit_in_batches`` (commits
+per batch, releasing the lock between them) rather than a single trailing
+``commit()``.** Do any slow per-row work (disk/network I/O) BEFORE opening the
+write connection (see d0005/d0006 for the read-first-then-batched-write shape).
 """

--- a/src/genesis/db/data_migrations/_util.py
+++ b/src/genesis/db/data_migrations/_util.py
@@ -1,0 +1,72 @@
+"""Shared helpers for data migrations (WS-C).
+
+The one piece here — :func:`commit_in_batches` — exists to keep bulk write/delete
+migrations from starving the live server's writers.
+
+Data migrations run POST-boot, on their own sync sqlite connection, CONCURRENTLY
+with the running server. SQLite (WAL) allows exactly one writer at a time, and
+the server's shared connection waits only ``BUSY_TIMEOUT_MS`` (5s) for the write
+lock before failing with ``database is locked``. A migration that loops over many
+rows inside a SINGLE transaction holds that lock for the whole loop — so a large
+bulk migration blocks every server write, AND the runner's own ledger bookkeeping
+(``mark_completed`` on the shared connection), for the loop's full duration.
+
+Regression this prevents: d0006 (surplus ops-telemetry purge) deleted 256 units ×
+~7 cross-store rows in one ~13s transaction; the live server logged a burst of
+``database is locked`` and its ``mark_completed`` failed, leaving the ledger row
+``running`` until a restart re-ran the (idempotent) migration.
+
+Committing every ``batch_size`` items releases the write lock between batches so
+concurrent server writes interleave — each batch is far under the 5s ceiling.
+Crash-safety is unchanged for idempotent migrations: a crash mid-run leaves the
+un-applied items for the next idempotent retry (better durability granularity,
+not worse).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Callable, Sequence
+
+from genesis.db.connection import MIGRATION_BUSY_TIMEOUT_MS
+
+logger = logging.getLogger(__name__)
+
+# 100 keeps each committed batch comfortably under the server's 5s busy_timeout
+# even for a fan-out migration (e.g. d0006's ~7 DELETEs/item ⇒ ~700 statements
+# per batch, sub-second), while amortizing commit/fsync overhead across items.
+DEFAULT_BATCH_SIZE = 100
+
+
+def commit_in_batches[T](
+    conn: sqlite3.Connection,
+    items: Sequence[T],
+    apply: Callable[[sqlite3.Connection, T], None],
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> int:
+    """Apply ``apply(conn, item)`` for each item, committing every ``batch_size``.
+
+    Sets a generous ``busy_timeout`` on ``conn`` (``MIGRATION_BUSY_TIMEOUT_MS``)
+    so the migration itself waits out a brief concurrent server write instead of
+    failing, then commits after every ``batch_size`` items (and once more for the
+    final partial batch) so the WAL write lock is never held across the whole
+    loop. Returns the number of items applied.
+
+    ``apply`` must NOT commit — batching owns transaction boundaries. It may skip
+    an item's writes internally (e.g. a pre-step failed); the item still counts
+    toward ``batch_size`` pacing and the return total. ``batch_size`` is clamped
+    to ``>= 1``.
+    """
+    batch_size = max(1, batch_size)
+    conn.execute(f"PRAGMA busy_timeout={MIGRATION_BUSY_TIMEOUT_MS}")
+    applied = 0
+    for item in items:
+        apply(conn, item)
+        applied += 1
+        if applied % batch_size == 0:
+            conn.commit()
+    conn.commit()  # flush the final (possibly partial) batch
+    logger.debug("commit_in_batches applied %d items (batch_size=%d)", applied, batch_size)
+    return applied

--- a/src/genesis/db/data_migrations/d0005_reverify_false_dispatch_failures.py
+++ b/src/genesis/db/data_migrations/d0005_reverify_false_dispatch_failures.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import sqlite3
 
+from genesis.db.data_migrations._util import commit_in_batches
 from genesis.ego.verification import (
     _resolve_path,
     parse_expected_outputs,
@@ -71,25 +72,38 @@ def _exact_pass(expected_outputs: str | None) -> bool:
 
 
 def migrate() -> dict:
-    """Flip each exact-pass false-failure to 'executed'; return counts."""
-    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    """Flip each exact-pass false-failure to 'executed'; return counts.
+
+    Two phases so the slow per-row file-existence checks (``_exact_pass`` does
+    disk I/O) run WITHOUT holding the write lock: gather the exact-pass ids on a
+    read-only connection first, then apply the UPDATEs in committed batches. A
+    single-transaction loop that did the disk checks inline would hold the WAL
+    write lock for the whole scan and starve the live server's writers (see
+    ``_util.commit_in_batches``)."""
+    ro = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
     try:
-        rows = db.execute(_SELECT).fetchall()
-        flipped = 0
-        for pid, _user_response, expected_outputs in rows:
-            if not _exact_pass(expected_outputs):
-                continue
-            db.execute(
-                "UPDATE ego_proposals SET status = 'executed', "
-                "user_response = COALESCE(user_response, '') || ? "
-                "WHERE id = ? AND status = 'failed'",
-                (_NOTE, pid),
-            )
-            flipped += 1
-        db.commit()
-        return {"flipped": flipped, "scanned": len(rows)}
+        rows = ro.execute(_SELECT).fetchall()
+    finally:
+        ro.close()
+    to_flip = [pid for pid, _ur, expected_outputs in rows if _exact_pass(expected_outputs)]
+    if not to_flip:
+        return {"flipped": 0, "scanned": len(rows)}
+
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+
+    def _flip(conn: sqlite3.Connection, pid: object) -> None:
+        conn.execute(
+            "UPDATE ego_proposals SET status = 'executed', "
+            "user_response = COALESCE(user_response, '') || ? "
+            "WHERE id = ? AND status = 'failed'",
+            (_NOTE, pid),
+        )
+
+    try:
+        flipped = commit_in_batches(db, to_flip, _flip)
     finally:
         db.close()
+    return {"flipped": flipped, "scanned": len(rows)}
 
 
 def verify() -> bool:

--- a/src/genesis/db/data_migrations/d0006_purge_surplus_ops_telemetry.py
+++ b/src/genesis/db/data_migrations/d0006_purge_surplus_ops_telemetry.py
@@ -29,12 +29,14 @@ RESURFACING via degraded FTS5 recall (``memory_fts`` is cross-collection), so we
 reproduce the full cascade in raw SQL (``migrate()``/``verify()`` are SYNC with
 their own connections — they cannot call the async store).
 
-Ordering: the Qdrant point is deleted BEFORE the SQLite rows for that unit; if
-the Qdrant delete fails (transient), the unit's SQLite rows are LEFT intact so
-``verify()`` still sees it as a candidate → the migration is marked failed and
+Ordering: Qdrant points are deleted (phase 1) BEFORE any SQLite rows (phase 2),
+never while holding the SQLite write lock. If a unit's Qdrant delete fails
+(transient), that unit is dropped from phase 2 so its SQLite rows are LEFT intact
+— ``verify()`` still sees it as a candidate → the migration is marked failed and
 retries next boot (no half-deleted orphan vector). ``get_client()`` failing
-entirely raises → same retry. Idempotent: a missing point deletes as a no-op,
-and the DELETEs are no-ops once purged / on a fresh install (no such rows).
+entirely raises → same retry. Idempotent: a missing point deletes as a no-op, and
+the SQLite DELETEs are no-ops once purged / on a fresh install (no such rows) —
+so the intermediate "point gone, rows still present" window is simply re-run.
 
 migrate()/verify() are SYNC (framework contract, cf. d0003/d0004). Own
 connections only — never the runtime's async ``rt._db``.
@@ -45,6 +47,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 
+from genesis.db.data_migrations._util import commit_in_batches
 from genesis.env import genesis_db_path
 from genesis.qdrant.collections import delete_point, get_client
 
@@ -103,7 +106,20 @@ def _candidate_ids(db: sqlite3.Connection) -> list[tuple[str, str]]:
 
 
 def migrate() -> dict:
-    """Purge surplus ops-telemetry KB units across all stores. Return counts."""
+    """Purge surplus ops-telemetry KB units across all stores. Return counts.
+
+    Two phases so the WAL write lock is never held during Qdrant network I/O
+    (holding it there is what let the original single-transaction form starve the
+    live server for ~13s, #1179):
+
+    Phase 1 (lock-free — no write connection open): delete each unit's Qdrant
+    point. A unit whose point-delete FAILS is dropped from phase 2, so its SQLite
+    rows stay put, verify() still sees it, and the migration retries — never a
+    half-deleted orphan vector.
+
+    Phase 2 (``commit_in_batches``): the fast raw-SQL cross-store cascade, holding
+    the write lock only for a bounded batch of quick DELETEs at a time.
+    """
     # Read candidates first (read-only conn) so a no-op run never touches Qdrant.
     ro = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
     try:
@@ -116,40 +132,45 @@ def migrate() -> dict:
     # Raises if Qdrant is unreachable → migration stays pending, retries next boot.
     client = get_client()
 
-    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
-    purged = 0
+    # Phase 1 — Qdrant deletes, no SQLite write lock held. Only units whose point
+    # is gone (or that never had one) advance to the SQLite cascade.
+    deletable: list[tuple[str, str]] = []
     qdrant_deleted = 0
     qdrant_failed = 0
-    try:
-        for unit_id, qdrant_id in targets:
-            if qdrant_id:
-                try:
-                    delete_point(client, collection="knowledge_base", point_id=qdrant_id)
-                    qdrant_deleted += 1
-                except Exception:
-                    # Leave this unit's SQLite rows intact so verify() still sees
-                    # it and the migration retries — never a half-deleted orphan.
-                    logger.warning(
-                        "d0006: Qdrant delete failed for %s — skipping SQLite purge",
-                        qdrant_id,
-                        exc_info=True,
-                    )
-                    qdrant_failed += 1
-                    continue
-            # Full MemoryStore.delete() cascade, in raw SQL.
-            db.execute("DELETE FROM knowledge_fts WHERE unit_id = ?", (unit_id,))
-            db.execute("DELETE FROM knowledge_units WHERE id = ?", (unit_id,))
-            if qdrant_id:
-                db.execute("DELETE FROM memory_fts WHERE memory_id = ?", (qdrant_id,))
-                db.execute("DELETE FROM memory_metadata WHERE memory_id = ?", (qdrant_id,))
-                db.execute(
-                    "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?",
-                    (qdrant_id, qdrant_id),
+    for unit_id, qdrant_id in targets:
+        if qdrant_id:
+            try:
+                delete_point(client, collection="knowledge_base", point_id=qdrant_id)
+                qdrant_deleted += 1
+            except Exception:
+                logger.warning(
+                    "d0006: Qdrant delete failed for %s — leaving SQLite rows for retry",
+                    qdrant_id,
+                    exc_info=True,
                 )
-                db.execute("DELETE FROM pending_embeddings WHERE memory_id = ?", (qdrant_id,))
-                db.execute("DELETE FROM entity_mentions WHERE memory_id = ?", (qdrant_id,))
-            purged += 1
-        db.commit()
+                qdrant_failed += 1
+                continue
+        deletable.append((unit_id, qdrant_id))
+
+    # Phase 2 — the full MemoryStore.delete() cascade in raw SQL, batched so the
+    # write lock is released between batches (see _util.commit_in_batches).
+    def _purge_sqlite(conn: sqlite3.Connection, target: tuple[str, str]) -> None:
+        unit_id, qdrant_id = target
+        conn.execute("DELETE FROM knowledge_fts WHERE unit_id = ?", (unit_id,))
+        conn.execute("DELETE FROM knowledge_units WHERE id = ?", (unit_id,))
+        if qdrant_id:
+            conn.execute("DELETE FROM memory_fts WHERE memory_id = ?", (qdrant_id,))
+            conn.execute("DELETE FROM memory_metadata WHERE memory_id = ?", (qdrant_id,))
+            conn.execute(
+                "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?",
+                (qdrant_id, qdrant_id),
+            )
+            conn.execute("DELETE FROM pending_embeddings WHERE memory_id = ?", (qdrant_id,))
+            conn.execute("DELETE FROM entity_mentions WHERE memory_id = ?", (qdrant_id,))
+
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    try:
+        purged = commit_in_batches(db, deletable, _purge_sqlite)
     finally:
         db.close()
 

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -13,6 +13,8 @@ import asyncio
 import importlib
 import logging
 import re
+import sqlite3
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 
 import aiosqlite
@@ -24,6 +26,42 @@ logger = logging.getLogger(__name__)
 
 _DATA_MIGRATIONS_DIR = Path(__file__).parent
 _DATA_MIGRATION_PATTERN = re.compile(r"^(d\d{4})_\w+\.py$")
+
+# The ledger bookkeeping (mark_completed / mark_failed) writes through the shared
+# server connection, which waits only BUSY_TIMEOUT_MS (5s) for the write lock. A
+# bulk migration that briefly holds the WAL write lock can make these fail with
+# "database is locked", leaving the row 'running' — it self-heals via
+# reset_running_to_pending on the next boot, but at the cost of an unnecessary
+# idempotent re-run (observed: d0006, #1179). Batching the migrations
+# (commit_in_batches) is the primary fix; retrying the ledger write is
+# defense-in-depth for the bookkeeping itself.
+_LEDGER_LOCK_RETRIES = 5
+_LEDGER_RETRY_DELAY_S = 0.5
+
+
+async def _ledger_write(make_coro: Callable[[], Awaitable[None]], *, what: str) -> None:
+    """Run a ledger bookkeeping write, retrying briefly on "database is locked".
+
+    Best-effort: never raises. The migrate()/verify() work has already happened by
+    the time we record its outcome, so a lost bookkeeping write only costs an
+    idempotent no-op re-run on the next boot — far better than raising and
+    aborting the runner's batch. ``make_coro`` must build a FRESH coroutine each
+    call (a coroutine can only be awaited once)."""
+    for attempt in range(1, _LEDGER_LOCK_RETRIES + 1):
+        try:
+            await make_coro()
+            return
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() or attempt == _LEDGER_LOCK_RETRIES:
+                logger.error(
+                    "data-migration ledger %s write failed (attempt %d/%d): %s",
+                    what,
+                    attempt,
+                    _LEDGER_LOCK_RETRIES,
+                    exc,
+                )
+                return
+            await asyncio.sleep(_LEDGER_RETRY_DELAY_S * attempt)
 
 
 class DataMigrationRunner:
@@ -91,18 +129,28 @@ class DataMigrationRunner:
             summary = await asyncio.to_thread(mod.migrate)
             verified = await asyncio.to_thread(mod.verify)
             if not verified:
-                await crud.mark_failed(
-                    self._db, mid, error="verify() returned False after migrate()"
+                await _ledger_write(
+                    lambda: crud.mark_failed(
+                        self._db, mid, error="verify() returned False after migrate()"
+                    ),
+                    what="mark_failed",
                 )
                 logger.error("Data migration %s did not verify — marked failed", name)
                 return {"id": mid, "name": name, "success": False, "error": "verify failed"}
 
             summary_str = str(summary) if summary is not None else ""
-            await crud.mark_completed(self._db, mid, summary=summary_str)
+            await _ledger_write(
+                lambda: crud.mark_completed(self._db, mid, summary=summary_str),
+                what="mark_completed",
+            )
             logger.info("Data migration %s completed: %s", name, summary_str)
             return {"id": mid, "name": name, "success": True, "summary": summary}
         except Exception as exc:  # noqa: BLE001 — record + continue; never abort the batch
-            await crud.mark_failed(self._db, mid, error=repr(exc))
+            err = repr(exc)  # bind before the closure (exc is except-scoped, del'd on exit)
+            await _ledger_write(
+                lambda: crud.mark_failed(self._db, mid, error=err),
+                what="mark_failed",
+            )
             logger.error("Data migration %s failed: %s", name, exc, exc_info=True)
             return {"id": mid, "name": name, "success": False, "error": str(exc)}
 

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -39,18 +39,20 @@ _LEDGER_LOCK_RETRIES = 5
 _LEDGER_RETRY_DELAY_S = 0.5
 
 
-async def _ledger_write(make_coro: Callable[[], Awaitable[None]], *, what: str) -> None:
+async def _ledger_write(make_coro: Callable[[], Awaitable[None]], *, what: str) -> bool:
     """Run a ledger bookkeeping write, retrying briefly on "database is locked".
 
-    Best-effort: never raises. The migrate()/verify() work has already happened by
-    the time we record its outcome, so a lost bookkeeping write only costs an
-    idempotent no-op re-run on the next boot — far better than raising and
-    aborting the runner's batch. ``make_coro`` must build a FRESH coroutine each
-    call (a coroutine can only be awaited once)."""
+    Returns ``True`` iff the write actually landed. Best-effort: never raises. The
+    migrate()/verify() work has already happened by the time we record its outcome,
+    so a lost bookkeeping write only costs an idempotent no-op re-run on the next
+    boot — far better than raising and aborting the runner's batch. The caller uses
+    the return so it never reports a durable success the ledger didn't record.
+    ``make_coro`` must build a FRESH coroutine each call (a coroutine can only be
+    awaited once)."""
     for attempt in range(1, _LEDGER_LOCK_RETRIES + 1):
         try:
             await make_coro()
-            return
+            return True
         except sqlite3.OperationalError as exc:
             if "locked" not in str(exc).lower() or attempt == _LEDGER_LOCK_RETRIES:
                 logger.error(
@@ -60,8 +62,9 @@ async def _ledger_write(make_coro: Callable[[], Awaitable[None]], *, what: str) 
                     _LEDGER_LOCK_RETRIES,
                     exc,
                 )
-                return
+                return False
             await asyncio.sleep(_LEDGER_RETRY_DELAY_S * attempt)
+    return False  # unreachable (loop always returns), but keeps the type honest
 
 
 class DataMigrationRunner:
@@ -139,10 +142,25 @@ class DataMigrationRunner:
                 return {"id": mid, "name": name, "success": False, "error": "verify failed"}
 
             summary_str = str(summary) if summary is not None else ""
-            await _ledger_write(
+            recorded = await _ledger_write(
                 lambda: crud.mark_completed(self._db, mid, summary=summary_str),
                 what="mark_completed",
             )
+            if not recorded:
+                # The migration's DATA work applied, but the 'completed' ledger
+                # write did not land (lock/operational error). Do NOT report a
+                # durable success: the row stays 'running' and replays (idempotent)
+                # on the next boot. Report failure honestly so the run is visible.
+                logger.error(
+                    "Data migration %s applied but ledger write failed — will replay next boot",
+                    name,
+                )
+                return {
+                    "id": mid,
+                    "name": name,
+                    "success": False,
+                    "error": "ledger write failed after completion; will replay next boot",
+                }
             logger.info("Data migration %s completed: %s", name, summary_str)
             return {"id": mid, "name": name, "success": True, "summary": summary}
         except Exception as exc:  # noqa: BLE001 — record + continue; never abort the batch

--- a/tests/test_db/test_d0005_reverify_false_dispatch_failures.py
+++ b/tests/test_db/test_d0005_reverify_false_dispatch_failures.py
@@ -92,3 +92,23 @@ def test_fresh_install_is_noop(tmp_path, monkeypatch):
 
     assert d0005.verify() is True
     assert d0005.migrate() == {"flipped": 0, "scanned": 0}
+
+
+def test_flips_many_rows_across_batch_boundaries(tmp_path, monkeypatch):
+    # The read-first-then-batched-write restructure must flip correctly when the
+    # candidate set spans multiple commit batches. _exact_pass is stubbed (the
+    # disk check itself is covered by the real-file tests above) so we can seed
+    # far more rows than one batch cheaply.
+    rows = [(f"p{i}", "failed", "x|verification_failed:z", '{"files": []}') for i in range(250)]
+    _seed(tmp_path / "genesis.db", rows)
+    monkeypatch.setattr(d0005, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+    monkeypatch.setattr(d0005, "_exact_pass", lambda eo: True)
+
+    assert d0005.migrate() == {"flipped": 250, "scanned": 250}
+    db = sqlite3.connect(tmp_path / "genesis.db")
+    remaining = db.execute("SELECT COUNT(*) FROM ego_proposals WHERE status = 'failed'").fetchone()[
+        0
+    ]
+    db.close()
+    assert remaining == 0
+    assert d0005.verify() is True

--- a/tests/test_db/test_data_migration_batching.py
+++ b/tests/test_db/test_data_migration_batching.py
@@ -126,7 +126,7 @@ def test_ledger_write_retries_then_succeeds(monkeypatch):
         if calls["n"] < 3:
             raise sqlite3.OperationalError("database is locked")
 
-    asyncio.run(runner._ledger_write(_flaky, what="mark_completed"))
+    assert asyncio.run(runner._ledger_write(_flaky, what="mark_completed")) is True
     assert calls["n"] == 3  # failed twice on lock, succeeded on the third attempt
 
 
@@ -139,7 +139,8 @@ def test_ledger_write_gives_up_on_persistent_lock_without_raising(monkeypatch, c
         raise sqlite3.OperationalError("database is locked")
 
     with caplog.at_level(logging.ERROR, logger=runner.logger.name):
-        asyncio.run(runner._ledger_write(_always_locked, what="mark_failed"))  # must NOT raise
+        # must NOT raise, and reports it did not record
+        assert asyncio.run(runner._ledger_write(_always_locked, what="mark_failed")) is False
 
     assert calls["n"] == runner._LEDGER_LOCK_RETRIES  # exhausted the retry budget
     assert "ledger mark_failed write failed" in caplog.text
@@ -154,6 +155,35 @@ def test_ledger_write_does_not_retry_non_lock_errors(monkeypatch, caplog):
         raise sqlite3.OperationalError("no such table: data_migrations")
 
     with caplog.at_level(logging.ERROR, logger=runner.logger.name):
-        asyncio.run(runner._ledger_write(_other_error, what="mark_completed"))  # must NOT raise
+        # must NOT raise, reports failure, and does not retry a non-lock error
+        assert asyncio.run(runner._ledger_write(_other_error, what="mark_completed")) is False
 
     assert calls["n"] == 1  # a non-lock error is logged and NOT retried
+
+
+def test_run_one_reports_failure_when_completed_ledger_write_fails(monkeypatch, caplog):
+    # Codex P2 (#1190): when migrate()/verify() succeed but the 'completed' ledger
+    # write can't land (persistent lock), _run_one must NOT report success — the
+    # row stays 'running' and replays, so a false success would hide the failure.
+    from pathlib import Path
+
+    from genesis.db.data_migrations import d0006_purge_surplus_ops_telemetry as d6
+
+    monkeypatch.setattr(d6, "migrate", lambda: {"purged": 0})
+    monkeypatch.setattr(d6, "verify", lambda: True)
+    monkeypatch.setattr(runner, "_LEDGER_RETRY_DELAY_S", 0)
+
+    async def _locked(*_a, **_k) -> None:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(runner.crud, "mark_completed", _locked)
+
+    r = runner.DataMigrationRunner(db=object())  # _db unused (mark_completed stubbed)
+    with caplog.at_level(logging.ERROR, logger=runner.logger.name):
+        outcome = asyncio.run(
+            r._run_one("d0006", "d0006_purge_surplus_ops_telemetry", Path(d6.__file__))
+        )
+
+    assert outcome["success"] is False
+    assert "ledger write failed" in outcome["error"]
+    assert "will replay next boot" in caplog.text

--- a/tests/test_db/test_data_migration_batching.py
+++ b/tests/test_db/test_data_migration_batching.py
@@ -1,0 +1,159 @@
+"""Write-lock hardening for the data-migration framework.
+
+Covers the two mechanisms that keep a bulk migration from starving the live
+server's single WAL writer (regression: d0006 held the write lock ~13s and the
+server + its own ledger write failed with "database is locked", #1179):
+
+1. ``_util.commit_in_batches`` — commits per batch so the write lock is released
+   between batches (proven by a separate reader observing committed batches
+   mid-run).
+2. ``runner._ledger_write`` — retries the ledger bookkeeping write on a transient
+   lock, and is best-effort (never raises) so a lost bookkeeping write only costs
+   an idempotent no-op re-run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+
+import pytest
+
+from genesis.db.data_migrations import runner
+from genesis.db.data_migrations._util import DEFAULT_BATCH_SIZE, commit_in_batches
+
+
+def _wal_db(tmp_path, n: int) -> tuple[str, sqlite3.Connection]:
+    path = str(tmp_path / "b.db")
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")  # match prod; WAL readers don't block the writer
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY)")
+    conn.executemany("INSERT INTO t(id) VALUES (?)", [(i,) for i in range(n)])
+    conn.commit()
+    return path, conn
+
+
+# --- commit_in_batches ------------------------------------------------------
+
+
+def test_commits_incrementally(tmp_path):
+    # A SEPARATE reader connection must observe committed batches WHILE the
+    # migration is still running — proof the write lock is released per batch,
+    # not held for the whole loop.
+    path, conn = _wal_db(tmp_path, 250)
+    peek = sqlite3.connect(path)
+    seen: list[int] = []
+
+    def _apply(c: sqlite3.Connection, i: int) -> None:
+        c.execute("DELETE FROM t WHERE id = ?", (i,))
+        seen.append(peek.execute("SELECT COUNT(*) FROM t").fetchone()[0])
+
+    applied = commit_in_batches(conn, list(range(250)), _apply, batch_size=100)
+    conn.close()
+    peek.close()
+
+    assert applied == 250
+    # After batch 1 commits, the reader sees 150 remaining; after batch 2, 50.
+    assert 150 in seen
+    assert 50 in seen
+
+
+def test_applies_all_including_final_partial_batch(tmp_path):
+    path, conn = _wal_db(tmp_path, 5)
+    applied = commit_in_batches(
+        conn,
+        list(range(5)),
+        lambda c, i: c.execute("DELETE FROM t WHERE id = ?", (i,)),
+        batch_size=2,
+    )
+    remaining = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    conn.close()
+    assert applied == 5
+    assert remaining == 0  # the trailing partial batch (1 leftover) is flushed
+
+
+def test_batch_size_is_clamped_to_at_least_one(tmp_path):
+    path, conn = _wal_db(tmp_path, 3)
+    applied = commit_in_batches(
+        conn,
+        [0, 1, 2],
+        lambda c, i: c.execute("DELETE FROM t WHERE id = ?", (i,)),
+        batch_size=0,
+    )
+    remaining = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    conn.close()
+    assert applied == 3
+    assert remaining == 0
+
+
+def test_empty_items_is_a_noop(tmp_path):
+    path, conn = _wal_db(tmp_path, 0)
+    applied = commit_in_batches(conn, [], lambda c, i: pytest.fail("apply must not be called"))
+    conn.close()
+    assert applied == 0
+
+
+def test_apply_may_skip_writes_but_still_paces(tmp_path):
+    # An item whose apply does no write still counts toward the total (and the
+    # batch cadence) — mirrors d0006 skipping a unit on a Qdrant failure.
+    path, conn = _wal_db(tmp_path, 4)
+
+    def _apply(c: sqlite3.Connection, i: int) -> None:
+        if i % 2 == 0:
+            c.execute("DELETE FROM t WHERE id = ?", (i,))
+
+    applied = commit_in_batches(conn, list(range(4)), _apply, batch_size=2)
+    remaining = {r[0] for r in conn.execute("SELECT id FROM t").fetchall()}
+    conn.close()
+    assert applied == 4
+    assert remaining == {1, 3}  # odd ids skipped, even ids deleted
+
+
+def test_default_batch_size_is_reasonable():
+    assert DEFAULT_BATCH_SIZE == 100
+
+
+# --- runner._ledger_write ---------------------------------------------------
+
+
+def test_ledger_write_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(runner, "_LEDGER_RETRY_DELAY_S", 0)
+    calls = {"n": 0}
+
+    async def _flaky() -> None:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise sqlite3.OperationalError("database is locked")
+
+    asyncio.run(runner._ledger_write(_flaky, what="mark_completed"))
+    assert calls["n"] == 3  # failed twice on lock, succeeded on the third attempt
+
+
+def test_ledger_write_gives_up_on_persistent_lock_without_raising(monkeypatch, caplog):
+    monkeypatch.setattr(runner, "_LEDGER_RETRY_DELAY_S", 0)
+    calls = {"n": 0}
+
+    async def _always_locked() -> None:
+        calls["n"] += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    with caplog.at_level(logging.ERROR, logger=runner.logger.name):
+        asyncio.run(runner._ledger_write(_always_locked, what="mark_failed"))  # must NOT raise
+
+    assert calls["n"] == runner._LEDGER_LOCK_RETRIES  # exhausted the retry budget
+    assert "ledger mark_failed write failed" in caplog.text
+
+
+def test_ledger_write_does_not_retry_non_lock_errors(monkeypatch, caplog):
+    monkeypatch.setattr(runner, "_LEDGER_RETRY_DELAY_S", 0)
+    calls = {"n": 0}
+
+    async def _other_error() -> None:
+        calls["n"] += 1
+        raise sqlite3.OperationalError("no such table: data_migrations")
+
+    with caplog.at_level(logging.ERROR, logger=runner.logger.name):
+        asyncio.run(runner._ledger_write(_other_error, what="mark_completed"))  # must NOT raise
+
+    assert calls["n"] == 1  # a non-lock error is logged and NOT retried


### PR DESCRIPTION
## Problem

Post-boot data migrations run on their own connection concurrently with the live server, which permits a single WAL writer and waits only 5s (`busy_timeout`) for the lock. The `d0006` surplus purge deleted 256 units × cross-store rows — **including 256 Qdrant network calls** — inside one ~13s transaction, starving every server write and its own `mark_completed` (the ledger row stuck `running`, self-healed only on the next restart, #1179).

Verified from the live journal: a ~10s burst of `database is locked`, then a 5-minute-later idempotent re-run of the same migration.

## Fix (whole class, not just d0006)

The at-risk class is **loop-then-single-commit** migrations = {d0005, d0006}; d0002/03/04 are single set-based statements (lock held briefly) and are left as-is.

- **`_util.commit_in_batches`** — reusable helper; commits every N items so the write lock is released between batches, and sets `MIGRATION_BUSY_TIMEOUT_MS` on the migration's connection.
- **d0006 → two-phase.** Delete Qdrant points **first** (with no write connection open — network I/O never holds the write lock), then batch the fast SQLite cross-store cascade. A Qdrant-delete failure still drops the unit from phase 2, so its rows remain for the idempotent retry (no half-deleted orphan) — behaviour unchanged.
- **d0005 → read-first.** Its slow per-row file-existence checks now run on a read-only (`mode=ro`) connection, outside the write lock; the UPDATEs then batch.
- **runner** — retries `mark_completed`/`mark_failed` on a transient lock (best-effort, never raises) so a completed migration is never left `running`.

### Why batching alone wasn't enough
The first E2E showed naive batching still held the lock ~6s, because Qdrant network calls ran *inside* the open transaction. The real fix is moving slow work **out** of the write transaction (phase-separate / read-first); batching then wraps only fast writes.

## Verification

- **E2E on the real `d0006.migrate()`** (mocked 20ms Qdrant + a concurrent-writer probe): server max lock-wait **0.04s**, vs **6.15s** for the old single-transaction form.
- 67 targeted tests pass; ruff clean. Adds a **d0005 test (previously untested)** plus `commit_in_batches` and runner-retry coverage. Existing d0005/d0006 tests are unchanged (behaviour preserved).

## Docs
CHANGELOG (user-facing) + a data-migration framework note in `CURRENT.md`, and a fix to a stale `d0005`→`d0006` purge reference left over from the #1184 rename. CURRENT.md `verified:` stamps intentionally not bumped — these are a factual correction + one additive framework note, not a full-section re-verification (stamps are warn-only).

Follow-up: 2fa0bfee