### PR TITLE
fix(deploy): update.sh traps — errtrace, subshell guard, SIGTERM/INT rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **An interrupted update no longer leaves the server down.** If a self-update
+  is interrupted after it has stopped the server (a Ctrl-C, a system shutdown,
+  or an unexpected failure inside an internal step), it now rolls back to the
+  previous version and restarts the server instead of exiting with the service
+  stopped. An interrupt *before* the server is stopped simply cleans up and
+  exits, leaving the running system untouched.
 - **Background sessions no longer get silently cut off after 10 minutes.** A
   long background task (for example deep research running as a background
   session) used to be killed at about 10 minutes with only a partial result and

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -81,7 +81,22 @@ _on_signal_prestop() {
     local sig="$1"
     trap - INT TERM
     echo "" >&2
-    echo "  Update interrupted by SIG$sig before services were stopped — nothing merged; cleaning up." >&2
+    echo "  Update interrupted by SIG$sig before the merge — restoring any stopped services and cleaning up." >&2
+    # The interrupt may have landed mid-stop (the stop polls up to ~10s), so a
+    # service may already be down. Restart exactly what was detected running —
+    # WERE_RUNNING is populated BEFORE the physical stop — so the server is never
+    # left down; `systemctl start` is a no-op if it never actually stopped. No
+    # rollback is needed here: nothing has been merged yet.
+    local _svc
+    for _svc in "${WERE_RUNNING[@]:-}"; do
+        [ -n "$_svc" ] || continue
+        if [ "$_svc" = "genesis-server" ]; then
+            _start_genesis_server 2>/dev/null \
+                || systemctl --user restart genesis-server.service 2>/dev/null || true
+        else
+            systemctl --user start "$_svc.service" 2>/dev/null || true
+        fi
+    done
     rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid" 2>/dev/null || true
     exit 1
 }
@@ -645,11 +660,24 @@ fi
 
 # ── Stop services for update ──────────────────────────────
 echo "--- Stopping services for update ---"
+# Detect what is running BEFORE stopping anything, so the pre-stop signal handler
+# can restart exactly what was running if an interrupt lands mid-stop (the stop
+# polls up to ~10s) — otherwise a Ctrl-C / shutdown during the stop would leave
+# the server down, the very thing the trap exists to prevent.
 WERE_RUNNING=()
-
-# Check genesis-server
 if systemctl --user is-active --quiet genesis-server.service 2>/dev/null || \
    pgrep -f "python -m genesis serve" >/dev/null 2>&1; then
+    WERE_RUNNING+=("genesis-server")
+fi
+for svc in genesis-bridge; do
+    if systemctl --user is-active --quiet "$svc.service" 2>/dev/null; then
+        WERE_RUNNING+=("$svc")
+    fi
+done
+
+# Now stop them. From here a SIG* runs _on_signal_prestop, which restarts
+# WERE_RUNNING (populated above) — so an interrupt mid-stop restores the server.
+if [[ " ${WERE_RUNNING[*]} " == *" genesis-server "* ]]; then
     _stop_genesis_server
     # Disarm systemd's on-failure auto-restart so a stale-code instance can't come
     # back during the merge/migration window. The ERR-trap rollback is not armed
@@ -658,17 +686,15 @@ if systemctl --user is-active --quiet genesis-server.service 2>/dev/null || \
         echo "  Aborting update — could not stop genesis-server; refusing to merge over a live process."
         echo "  genesis-server has been stopped and was NOT restarted. Bring it back with:"
         echo "    systemctl --user restart genesis-server.service"
+        # Deliberate: disarm the signal handler so it does NOT "restore" a server
+        # we are intentionally leaving stopped (we could not cleanly stop it).
+        trap - INT TERM
         exit 1
     fi
-    WERE_RUNNING+=("genesis-server")
 fi
-
-# Check genesis-bridge
-for svc in genesis-bridge; do
-    if systemctl --user is-active --quiet "$svc.service" 2>/dev/null; then
-        systemctl --user stop "$svc.service" || true
-        WERE_RUNNING+=("$svc")
-    fi
+for svc in "${WERE_RUNNING[@]}"; do
+    [ "$svc" = "genesis-server" ] && continue
+    systemctl --user stop "$svc.service" || true
 done
 
 [[ ${#WERE_RUNNING[@]} -gt 0 ]] && echo "  Stopped: ${WERE_RUNNING[*]}" || echo "  No services were running"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -85,8 +85,11 @@ _on_signal_prestop() {
     # The interrupt may have landed mid-stop (the stop polls up to ~10s), so a
     # service may already be down. Restart exactly what was detected running —
     # WERE_RUNNING is populated BEFORE the physical stop — so the server is never
-    # left down; `systemctl start` is a no-op if it never actually stopped. No
-    # rollback is needed here: nothing has been merged yet.
+    # left down. For genesis-server, `_start_genesis_server` runs `systemctl
+    # restart`: it cleanly bounces the server if it never stopped, or starts it
+    # if the interrupt already took it down — either way it ends up running. The
+    # bridge uses `start`, a no-op when still running. No rollback is needed
+    # here: nothing has been merged yet.
     local _svc
     for _svc in "${WERE_RUNNING[@]:-}"; do
         [ -n "$_svc" ] || continue

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -16,7 +16,8 @@
 #   --post-merge  Skip fetch/merge (code already merged by CC conflict resolution);
 #                 run only bootstrap, migrations, health check, and service restart.
 
-set -euo pipefail
+set -Eeuo pipefail  # -E: the ERR trap is inherited by functions AND subshells
+                    # (see _on_err's BASH_SUBSHELL guard for the subshell case)
 
 # ── Copy-to-temp guard ──────────────────────────────────
 # The update script may update itself during git merge, which would corrupt
@@ -70,6 +71,19 @@ _write_state() {
     "timestamp": "$(date -Iseconds)"
 }
 SEOF
+}
+
+# Signal handler for the PRE-STOP window: an interrupt before services are
+# stopped has nothing to roll back (no merge, server still running), so just
+# clear this run's state/marker and exit. Swapped for _on_signal (rollback)
+# once the ERR trap arms. Defined here so it exists before its trap install.
+_on_signal_prestop() {
+    local sig="$1"
+    trap - INT TERM
+    echo "" >&2
+    echo "  Update interrupted by SIG$sig before services were stopped — nothing merged; cleaning up." >&2
+    rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid" 2>/dev/null || true
+    exit 1
 }
 
 # Refuse to run from a worktree — pip install -e in bootstrap.sh would
@@ -523,6 +537,11 @@ fi
 
 _write_state "fetching"
 
+# Catch an interrupt during the pre-stop window (fetch done, services still up).
+# Replaced by the rollback-capable _on_signal once the ERR trap arms post-stop.
+trap '_on_signal_prestop INT' INT
+trap '_on_signal_prestop TERM' TERM
+
 # ── Service stop/start helpers ───────────────────────────
 # Works with both systemd and bare-process environments.
 _stop_genesis_server() {
@@ -750,7 +769,7 @@ _do_rollback() {
     local degraded="${2:-}"
 
     # Disarm the ERR trap to prevent recursive rollback
-    trap - ERR
+    trap - ERR INT TERM
 
     echo ""
     echo "  UPDATE FAILED — $reason"
@@ -851,10 +870,32 @@ with open(sys.argv[11], 'w') as f:
 # Uses $BASH_COMMAND to report which command failed.
 _on_err() {
     local exit_code=$?
+    # Under `set -E` the ERR trap is inherited by command substitutions and
+    # subshells. Rollback must run ONLY at the top level: a failing `$(...)`
+    # would otherwise run _do_rollback (force-stop server + git reset) from
+    # INSIDE the subshell while the parent keeps executing. In a subshell just
+    # propagate the failure — the parent's own ERR trap handles it at depth 0.
+    if [ "${BASH_SUBSHELL:-0}" -ne 0 ]; then
+        exit "$exit_code"
+    fi
     _do_rollback "command failed (exit $exit_code): $BASH_COMMAND"
     exit 1
 }
+# Signal handler for the ARMED window (services stopped, mid-merge/migration):
+# an interrupt here must roll back, exactly like an unhandled error — otherwise
+# the server is left down. Disarm all traps first so a second signal can't
+# re-enter _do_rollback. Installed alongside the ERR trap below.
+_on_signal() {
+    local sig="$1"
+    trap - ERR INT TERM
+    echo "" >&2
+    echo "  Update interrupted by SIG$sig after services were stopped — rolling back." >&2
+    _do_rollback "update interrupted by SIG$sig"
+    exit 1
+}
 trap _on_err ERR
+trap '_on_signal INT' INT
+trap '_on_signal TERM' TERM
 
 if [[ "$POST_MERGE" == "false" ]]; then
 _write_state "merging"
@@ -993,13 +1034,13 @@ PYEOF
         echo "  A CC session will resolve conflicts in a worktree."
         _record_update_history "conflicts_pending" \
             "merge conflicts in: $(echo "$CONFLICTED_FILES" | tr '\n' ', ' | sed 's/, $//')" ""
-        trap - ERR
+        trap - ERR INT TERM
         exit 2
     else
         # Not a conflict — some other merge error. Call rollback directly so the
         # DB gets a meaningful reason instead of "command failed (exit 1): false".
         echo "  Merge failed: $MERGE_OUTPUT"
-        trap - ERR
+        trap - ERR INT TERM
         _do_rollback "git merge failed: $(echo "$MERGE_OUTPUT" | head -3 | tr '\n' ' ')"
         exit 1
     fi
@@ -1052,7 +1093,7 @@ if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]] && _tier2_pending_since_baseline; then
 elif [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
     echo "  Already up to date ($NEW_COMMIT)."
     # Clean up unnecessary rollback tag and disarm trap
-    trap - ERR
+    trap - ERR INT TERM
     git -C "$GENESIS_ROOT" tag -d "$ROLLBACK_TAG" 2>/dev/null || true
     # Restart services that we stopped (if any)
     for svc in "${WERE_RUNNING[@]}"; do
@@ -1354,7 +1395,7 @@ except Exception:
 fi
 
 # ── Success: disarm trap ──────────────────────────────────
-trap - ERR
+trap - ERR INT TERM
 
 _sync_deploy_targets
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1314,6 +1314,16 @@ fi
 _write_state "health_check"
 
 # ── Restart services ──────────────────────────────────────
+# P5 GUARDRAIL: this final restart runs while the armed `_on_signal TERM` trap is
+# STILL live (disarmed only at the success `trap - ERR INT TERM` below). That is
+# safe TODAY only because the completing update path (the dashboard orchestrator)
+# is cgroup-isolated via `systemd-run --scope`, so `_start_genesis_server`'s
+# internal `systemctl stop`/`restart` does NOT signal this process. The
+# `_apply_direct` path (dashboard, supervised=False) does NOT scope-isolate and
+# stays in genesis-server.service's cgroup — a pre-existing bug. When P5 fixes
+# `_apply_direct`, the fix MUST be scope isolation (systemd-run --scope), NOT a
+# handler tweak: otherwise this restart's stop-phase would self-SIGTERM →
+# _on_signal → a SPURIOUS rollback of a healthy, fully-migrated deploy.
 if [[ ${#WERE_RUNNING[@]} -gt 0 ]]; then
     echo "--- Restarting services ---"
 

--- a/tests/test_scripts/test_update_traps.py
+++ b/tests/test_scripts/test_update_traps.py
@@ -100,6 +100,10 @@ def _harness(text: str, scenario: str) -> str:
 set -Eeuo pipefail
 STATE_FILE="$STATE_FILE"
 _do_rollback() {{ echo "depth=$BASH_SUBSHELL reason=$1" >> "$RB_LOG"; }}
+# Stub the service-restart calls the real _on_signal_prestop makes, so the test
+# records intent without touching real systemd.
+_start_genesis_server() {{ echo "start:genesis-server" >> "$RESTART_LOG"; return 0; }}
+systemctl() {{ echo "systemctl $*" >> "$RESTART_LOG"; return 0; }}
 {on_err}
 {on_signal}
 {on_prestop}
@@ -124,6 +128,14 @@ case "{scenario}" in
     sleep 30 & wait $!         # `wait` is interruptible so the trap fires now
     ;;
   prestop_sig)
+    WERE_RUNNING=()            # nothing was running → nothing to restart
+    trap '_on_signal_prestop INT' INT
+    trap '_on_signal_prestop TERM' TERM
+    echo READY > "$READY"
+    sleep 30 & wait $!
+    ;;
+  prestop_running)
+    WERE_RUNNING=("genesis-server")   # server was running + (about to be) stopped
     trap '_on_signal_prestop INT' INT
     trap '_on_signal_prestop TERM' TERM
     echo READY > "$READY"
@@ -134,21 +146,32 @@ esac
 
 
 def _run(tmp_path: Path, text: str, scenario: str, *, signal_it: bool = False):
+    """Returns (rollback_log, state_path, restart_log)."""
     script = tmp_path / "harness.sh"
     script.write_text(_harness(text, scenario))
     rb_log = tmp_path / "rollback.log"
+    restart_log = tmp_path / "restart.log"
     state = tmp_path / "state.json"
     state.write_text("{}")
     ready = tmp_path / "ready"
     env = {
         **os.environ,
         "RB_LOG": str(rb_log),
+        "RESTART_LOG": str(restart_log),
         "STATE_FILE": str(state),
         "READY": str(ready),
     }
+
+    def _reads():
+        return (
+            rb_log.read_text() if rb_log.exists() else "",
+            state,
+            restart_log.read_text() if restart_log.exists() else "",
+        )
+
     if not signal_it:
         subprocess.run(["bash", str(script)], env=env, capture_output=True, timeout=15)
-        return rb_log.read_text() if rb_log.exists() else "", state
+        return _reads()
     proc = subprocess.Popen(
         ["bash", str(script)], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     )
@@ -158,11 +181,11 @@ def _run(tmp_path: Path, text: str, scenario: str, *, signal_it: bool = False):
         time.sleep(0.05)
     proc.send_signal(signal.SIGTERM)
     proc.wait(timeout=15)
-    return (rb_log.read_text() if rb_log.exists() else ""), state
+    return _reads()
 
 
 def test_armed_function_failure_rolls_back(tmp_path: Path, text: str) -> None:
-    log, _ = _run(tmp_path, text, "armed_fn")
+    log, _, _ = _run(tmp_path, text, "armed_fn")
     assert "reason=" in log and "PARENT_CONTINUED" not in log
     assert log.count("depth=") == 1 and "depth=0" in log
 
@@ -170,22 +193,44 @@ def test_armed_function_failure_rolls_back(tmp_path: Path, text: str) -> None:
 def test_subshell_failure_does_not_rollback_in_subshell(tmp_path: Path, text: str) -> None:
     """The whole point of the -E guard: rollback runs ONCE, at depth 0, never
     from the subshell that actually failed."""
-    log, _ = _run(tmp_path, text, "subshell")
+    log, _, _ = _run(tmp_path, text, "subshell")
     assert "PARENT_CONTINUED" not in log, "parent must not continue past a subshell failure"
     depths = re.findall(r"depth=(\d+)", log)
     assert depths == ["0"], f"rollback must run exactly once at depth 0, got {depths}"
 
 
 def test_armed_sigterm_rolls_back(tmp_path: Path, text: str) -> None:
-    log, _ = _run(tmp_path, text, "armed_sig", signal_it=True)
+    log, _, _ = _run(tmp_path, text, "armed_sig", signal_it=True)
     assert "reason=update interrupted by SIGTERM" in log
     assert "depth=0" in log
 
 
 def test_prestop_sigterm_cleans_up_without_rollback(tmp_path: Path, text: str) -> None:
-    log, state = _run(tmp_path, text, "prestop_sig", signal_it=True)
+    """Interrupt BEFORE anything was running/stopped: no rollback, no restart,
+    state cleaned."""
+    log, state, restart = _run(tmp_path, text, "prestop_sig", signal_it=True)
     assert log == "", "pre-stop interrupt must NOT roll back (nothing merged yet)"
+    assert restart == "", "nothing was running → nothing to restart"
     assert not state.exists(), "pre-stop handler should remove the state file"
+
+
+def test_prestop_sigterm_restarts_stopped_services(tmp_path: Path, text: str) -> None:
+    """Codex P1: an interrupt mid-stop (server was running, WERE_RUNNING set) must
+    RESTART it, not leave it down — and still without a rollback (nothing merged)."""
+    log, state, restart = _run(tmp_path, text, "prestop_running", signal_it=True)
+    assert "start:genesis-server" in restart, "the stopped server must be restarted"
+    assert log == "", "still no rollback in the pre-merge window"
+    assert not state.exists()
+
+
+def test_services_detected_before_stop(text: str) -> None:
+    """WERE_RUNNING must be populated BEFORE the physical stop, so the pre-stop
+    handler knows what to restore."""
+    detect = text.find('WERE_RUNNING+=("genesis-server")')
+    stop_call = text.find("_stop_genesis_server\n")
+    assert -1 < detect < stop_call, (
+        "genesis-server must be added to WERE_RUNNING before it is stopped"
+    )
 
 
 if sys.platform.startswith("win"):  # pragma: no cover

--- a/tests/test_scripts/test_update_traps.py
+++ b/tests/test_scripts/test_update_traps.py
@@ -1,0 +1,192 @@
+"""Trap-semantics locks for scripts/update.sh (deploy-audit P4b).
+
+`set -Eeuo pipefail` extends the ERR trap into functions AND subshells, and a
+SIGTERM/SIGINT handler now rolls back an interrupted deploy. Both are safety-
+critical: a trap that fires from a subshell, or a signal handler that leaves the
+server stopped, is worse than the bug it replaces. So this file has two layers:
+
+  1. Extraction asserts against the REAL script text (structure/anchors).
+  2. A FUNCTIONAL harness that sources the ACTUAL shipped `_on_err`,
+     `_on_signal`, and `_on_signal_prestop` functions (extracted from
+     update.sh) with a stubbed `_do_rollback`, and drives the four behaviors
+     that matter:
+       (a) an armed-window function failure rolls back,
+       (b) a failing `$(...)` does NOT roll back from inside the subshell
+           (rollback runs once, at BASH_SUBSHELL==0),
+       (c) SIGTERM in the armed window rolls back,
+       (d) SIGTERM in the pre-stop window cleans up WITHOUT rolling back.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return UPDATE_SH.read_text()
+
+
+def _extract_func(text: str, name: str) -> str:
+    """Extract a `name() { ... }` definition (brace at column 0 closes it)."""
+    m = re.search(rf"^{re.escape(name)}\(\) \{{\n(.*?)\n\}}$", text, re.DOTALL | re.MULTILINE)
+    assert m, f"function {name} not found in update.sh"
+    return f"{name}() {{\n{m.group(1)}\n}}"
+
+
+# ── Extraction locks ───────────────────────────────────────────────────────
+def test_errtrace_enabled(text: str) -> None:
+    assert re.search(r"^set -Eeuo pipefail", text, re.MULTILINE), "need set -E (errtrace)"
+
+
+def test_on_err_guards_subshell(text: str) -> None:
+    body = _extract_func(text, "_on_err")
+    assert "BASH_SUBSHELL" in body and 'exit "$exit_code"' in body, (
+        "_on_err must short-circuit in a subshell so rollback never runs at depth>0"
+    )
+
+
+def test_signal_handlers_defined(text: str) -> None:
+    assert "_on_signal() {" in text
+    assert "_on_signal_prestop() {" in text
+
+
+def test_prestop_trap_installed_before_stop(text: str) -> None:
+    prestop = text.find("trap '_on_signal_prestop TERM' TERM")
+    stop = text.find("--- Stopping services for update ---")
+    armed = text.find("trap '_on_signal TERM' TERM")
+    assert -1 < prestop < stop < armed, (
+        "prestop signal trap must arm before the stop, armed one after"
+    )
+
+
+def test_armed_signal_trap_installed_with_err(text: str) -> None:
+    err = text.find("trap _on_err ERR")
+    sig = text.find("trap '_on_signal TERM' TERM")
+    assert -1 < err < sig, "armed signal trap installs alongside the ERR trap"
+
+
+def test_all_disarm_sites_clear_signals(text: str) -> None:
+    # Every standalone ERR disarm must also drop INT/TERM so a post-disarm signal
+    # doesn't fire a now-inappropriate handler. No bare `trap - ERR` may remain
+    # (except inside a comment/backticks).
+    for m in re.finditer(r"^\s*trap - ERR(.*)$", text, re.MULTILINE):
+        tail = m.group(1)
+        assert "INT TERM" in tail, (
+            f"bare `trap - ERR` must become `trap - ERR INT TERM`: {m.group(0)!r}"
+        )
+
+
+# ── Functional harness (sources the real shipped functions) ────────────────
+def _harness(text: str, scenario: str) -> str:
+    """A self-contained script that reuses the SHIPPED trap functions with a
+    stubbed _do_rollback (records BASH_SUBSHELL depth + reason to $RB_LOG) and
+    stub state, then runs one scenario."""
+    on_err = _extract_func(text, "_on_err")
+    on_signal = _extract_func(text, "_on_signal")
+    on_prestop = _extract_func(text, "_on_signal_prestop")
+    return f"""#!/bin/bash
+set -Eeuo pipefail
+STATE_FILE="$STATE_FILE"
+_do_rollback() {{ echo "depth=$BASH_SUBSHELL reason=$1" >> "$RB_LOG"; }}
+{on_err}
+{on_signal}
+{on_prestop}
+
+case "{scenario}" in
+  subshell)
+    trap _on_err ERR
+    x=$(false)                 # failing command-sub under -E
+    echo "PARENT_CONTINUED" >> "$RB_LOG"   # must NOT be reached
+    ;;
+  armed_fn)
+    trap _on_err ERR
+    _boom() {{ return 3; }}
+    _boom                      # function failure in armed window
+    echo "PARENT_CONTINUED" >> "$RB_LOG"
+    ;;
+  armed_sig)
+    trap _on_err ERR
+    trap '_on_signal INT' INT
+    trap '_on_signal TERM' TERM
+    echo READY > "$READY"
+    sleep 30 & wait $!         # `wait` is interruptible so the trap fires now
+    ;;
+  prestop_sig)
+    trap '_on_signal_prestop INT' INT
+    trap '_on_signal_prestop TERM' TERM
+    echo READY > "$READY"
+    sleep 30 & wait $!
+    ;;
+esac
+"""
+
+
+def _run(tmp_path: Path, text: str, scenario: str, *, signal_it: bool = False):
+    script = tmp_path / "harness.sh"
+    script.write_text(_harness(text, scenario))
+    rb_log = tmp_path / "rollback.log"
+    state = tmp_path / "state.json"
+    state.write_text("{}")
+    ready = tmp_path / "ready"
+    env = {
+        **os.environ,
+        "RB_LOG": str(rb_log),
+        "STATE_FILE": str(state),
+        "READY": str(ready),
+    }
+    if not signal_it:
+        subprocess.run(["bash", str(script)], env=env, capture_output=True, timeout=15)
+        return rb_log.read_text() if rb_log.exists() else "", state
+    proc = subprocess.Popen(
+        ["bash", str(script)], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    for _ in range(100):  # wait for READY (trap installed, in sleep)
+        if ready.exists():
+            break
+        time.sleep(0.05)
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=15)
+    return (rb_log.read_text() if rb_log.exists() else ""), state
+
+
+def test_armed_function_failure_rolls_back(tmp_path: Path, text: str) -> None:
+    log, _ = _run(tmp_path, text, "armed_fn")
+    assert "reason=" in log and "PARENT_CONTINUED" not in log
+    assert log.count("depth=") == 1 and "depth=0" in log
+
+
+def test_subshell_failure_does_not_rollback_in_subshell(tmp_path: Path, text: str) -> None:
+    """The whole point of the -E guard: rollback runs ONCE, at depth 0, never
+    from the subshell that actually failed."""
+    log, _ = _run(tmp_path, text, "subshell")
+    assert "PARENT_CONTINUED" not in log, "parent must not continue past a subshell failure"
+    depths = re.findall(r"depth=(\d+)", log)
+    assert depths == ["0"], f"rollback must run exactly once at depth 0, got {depths}"
+
+
+def test_armed_sigterm_rolls_back(tmp_path: Path, text: str) -> None:
+    log, _ = _run(tmp_path, text, "armed_sig", signal_it=True)
+    assert "reason=update interrupted by SIGTERM" in log
+    assert "depth=0" in log
+
+
+def test_prestop_sigterm_cleans_up_without_rollback(tmp_path: Path, text: str) -> None:
+    log, state = _run(tmp_path, text, "prestop_sig", signal_it=True)
+    assert log == "", "pre-stop interrupt must NOT roll back (nothing merged yet)"
+    assert not state.exists(), "pre-stop handler should remove the state file"
+
+
+if sys.platform.startswith("win"):  # pragma: no cover
+    pytest.skip("bash trap semantics are POSIX-only", allow_module_level=True)


### PR DESCRIPTION
## Deploy-audit P4b — `scripts/update.sh` trap semantics

Two safety-critical trap fixes to the self-update path. Stacks on P4a (#1188, merged). `update.sh` cannot run in CI, so coverage is extraction locks **plus a functional harness that sources the actual shipped handlers** and drives the behaviors that matter.

### #1 — errtrace + subshell guard
- `set -euo pipefail` → `set -Eeuo pipefail`. This closes a real latent gap the architect confirmed empirically: a failure inside a bare helper called in the services-down window (`_write_state`, `memory_resilience_apply`, `network_resilience_apply`) previously did a plain `exit` that **never ran the ERR trap** — leaving the server stopped with no rollback. Under `-E` those now roll back correctly.
- `-E` also makes command substitutions/subshells inherit the ERR trap, so `_on_err` now short-circuits when `BASH_SUBSHELL != 0`: otherwise a failing `$(...)` would force-stop the server and `git reset` from *inside a subshell* while the parent kept running. Rollback now runs exactly once, at top level. (This guard is load-bearing: `_record_update_history`'s expected `rc=2` table-missing case fires the trap inside a `$(…)` — without the guard, that would false-rollback.)

### #14 — SIGTERM/SIGINT rollback
An interrupted deploy (Ctrl-C, systemd shutdown) previously left the server stopped with no rollback. A phase-aware signal trap now mirrors the ERR-trap lifecycle: a **pre-stop** interrupt cleans up state and exits (nothing merged, server still up); an interrupt in the **armed** window (post-stop, mid-merge/migration) rolls back like an unhandled error. All `trap - ERR` disarm sites also clear `INT`/`TERM`.

### Review
- **genesis-architect: DONE_WITH_CONCERNS — no BLOCKER, no SHOULD-FIX.** Verified bash semantics empirically; traced every armed-window call site, both spawn paths, and the cgroup interaction. NOTE-1 (a forward guardrail for P5) is landed as a code comment at the restart site: the `_apply_direct` cgroup-self-SIGTERM fix in P5 **must** be scope isolation (`systemd-run --scope`), not a handler tweak, or the armed restart would self-SIGTERM into a spurious rollback of a healthy deploy.
- Tests: `tests/test_scripts/test_update_traps.py` — 10 cases. The functional harness proves: armed function-failure rolls back; a subshell failure rolls back once at depth 0 (never from the subshell); armed SIGTERM rolls back; pre-stop SIGTERM cleans up without rollback. Full `test_scripts` suite (848) green; zero new shellcheck warnings.

> Host-Deploy Gate: touches `scripts/update.sh` → an `update.sh` run is required after merge (self-deploy lag: the shipping run executes old bytes; `-E` governs the NEXT run — I'll do a post-merge no-op run to exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)