### PR TITLE
feat(cc): background-session delivery model — handed-off work reports back to origin thread

### DIFF
--- a/.claude/docs/background-sessions.md
+++ b/.claude/docs/background-sessions.md
@@ -16,12 +16,19 @@ Read this guide any time you're considering a background session or sub-agent.
 outlive this conversation → background session. If you just need an answer in
 the next few minutes → sub-agent.
 
-> **Note:** the background lane now owns a longer CC background-wait ceiling (set
-> to its full `timeout_s`), so a dispatched `Workflow` inside a background session
-> runs to completion instead of the CLI's default 600s truncation. Automatically
-> routing long research *from a channel turn* into this lane — with the result
-> delivered back to the requester — is a follow-up (needs the delivery model wired;
-> a background session's success output is not yet sent to the owner).
+> **Note:** the background lane owns a longer CC background-wait ceiling (set to its
+> full `timeout_s`), so a dispatched `Workflow` inside a background session runs to
+> completion instead of the CLI's default 600s truncation.
+>
+> **Origin delivery:** pass `deliver_to_origin=True` to `direct_session_run` (from a
+> channel/foreground turn) and the session's terminal outcome — success *or* failure
+> — is delivered back to the exact conversation it was dispatched from (the DM or
+> forum topic). This is how you hand off long work from a channel and actually
+> "report back." Without it, a successful background run is silent (only failures
+> raise a Telegram alert); poll `direct_session_status` for the output. Delivery is
+> framework-owned (the session need not — and for `observe`/`research` cannot — send
+> its own report); oversized output is saved under `~/.genesis/output/` and delivered
+> as a summary + file pointer.
 
 ## Profiles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **When Genesis hands a long task off to run in the background and says "I'll
+  report back," it now actually does.** Ask for something heavy from Telegram — a
+  deep research run, a long analysis — and Genesis can dispatch it to a background
+  session and deliver the finished result straight back into the same
+  conversation (your DM or the same forum topic) when it's done, success or
+  failure. Previously a background task's successful result went nowhere: it was
+  saved to the database but never sent, so a promised "I'll get back to you"
+  silently never arrived (the cause behind a research request on 2026-07-20 that
+  vanished). Long results arrive as a short summary plus a saved file rather than
+  a wall of messages. Failures are reported in the same thread instead of
+  disappearing.
+
 ### Changed
 
 - **Proactive memory recall holds up better when several sessions are active at

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -137,7 +137,7 @@ any task bigger than an LLM call.
 ```yaml subsystem-map
 entry: execution-cc
 modules: [cc]
-verified: 8cb9e8dc 2026-07-21
+verified: 3c5e1f24 2026-07-22
 ```
 
 - `cc/direct_session.py` + `cc/conversation.py` (both >1000 LOC; split

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -170,9 +170,18 @@ verified: 8cb9e8dc 2026-07-21
   kill; the background lane (direct_session) sets it to the full budget so long work
   (deep-research) runs to completion. A hit sets `CCOutput.bg_truncated` → a visible
   user notice + a `cc.bg_truncated` event. Foreground turns keep the 600s default so a
-  conversational turn never lingers holding the per-session lock; routing long research
-  from a channel to the durable background lane (with result delivery) is a follow-up.
+  conversational turn never lingers holding the per-session lock.
   Origin: the 2026-07-20 silent-death of a Telegram deep-research run.
+- **Background-session delivery model** (`DeliveryMode`, direct_session.py): a
+  handed-off task can deliver its terminal outcome (success AND failure) back to the
+  conversation it was dispatched from. `direct_session_run(deliver_to_origin=True)`
+  captures the foreground origin via `GENESIS_SESSION_ID` (the foreground `cc_sessions`
+  row id the health-MCP child inherits), threaded through the queue onto the request;
+  `DirectSessionRunner._deliver_result_to_origin` resolves the origin's channel+thread
+  and delivers a targeted send (`OutreachRequest.target_chat_id`/`target_thread_id`,
+  honored in `_deliver` before category routing — DM or forum topic). Legacy callers
+  (all 8) derive `SILENT`/`FAILURE_ONLY` from their notify bools → unchanged. Fixes the
+  latent bug where a successful background result was saved but never sent.
 
 ## 3. Autonomy & egress gating
 

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -116,6 +116,7 @@ class ConversationLoop:
         user_id: str,
         channel: ChannelType,
         thread_id: str | None = None,
+        chat_id: str | None = None,
     ) -> str:
         """Process a user message and return the response text."""
         try:
@@ -172,7 +173,7 @@ class ConversationLoop:
         # Get or create session, persist any model/effort changes
         session = await self._session_mgr.get_or_create_foreground(
             user_id=user_id, channel=channel, model=model, effort=effort,
-            thread_id=thread_id,
+            thread_id=thread_id, chat_id=chat_id,
         )
 
         # Set session context so downstream code (CCInvoker, eval hooks)
@@ -351,6 +352,7 @@ class ConversationLoop:
         on_event: Callable[[StreamEvent], Awaitable[None]] | None = None,
         thread_id: str | None = None,
         session_key: str | None = None,
+        chat_id: str | None = None,
     ) -> str:
         """Like handle_message but uses streaming for live progress.
 
@@ -410,7 +412,7 @@ class ConversationLoop:
 
         session = await self._session_mgr.get_or_create_foreground(
             user_id=user_id, channel=channel, model=model, effort=effort,
-            thread_id=thread_id,
+            thread_id=thread_id, chat_id=chat_id,
         )
 
         # Set session context for eval attribution (same as handle_message).

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1450,6 +1450,7 @@ class DirectSessionRunner:
     @staticmethod
     def _resolve_origin_target(
         channel: str | None,
+        chat_id: str | None,
         user_id: str,
         thread_id_raw: object,
         forum_chat_id: str | None,
@@ -1457,25 +1458,31 @@ class DirectSessionRunner:
         """Resolve a Telegram ``(chat_id, message_thread_id)`` delivery target
         from an origin ``cc_sessions`` row.
 
-        Returns ``(None, None)`` when the origin cannot be addressed: a
-        non-telegram channel, a forum-topic origin with no forum chat
-        configured, or a DM whose numeric chat id isn't recoverable.
+        Prefers the persisted origin ``chat_id`` (captured at intake) — correct
+        for a DM, a group, AND a forum topic uniformly (a forum topic's
+        ``chat.id`` *is* the supergroup). Falls back to best-effort
+        reconstruction for legacy rows written before ``chat_id`` was captured.
+        Returns ``(None, None)`` when the origin cannot be addressed.
         """
         if channel != "telegram":
             return None, None
-        # Forum-topic origin: the chat is the forum supergroup and the thread is
-        # the persisted topic id (which provably exists — the origin message came
-        # from it). Requires forum_chat_id to be configured.
+        tid: int | None = None
         if thread_id_raw:
             try:
                 tid = int(thread_id_raw)  # type: ignore[arg-type]
             except (TypeError, ValueError):
                 return None, None
-            if forum_chat_id:
-                return str(forum_chat_id), tid
-            return None, None
-        # DM origin (no forum thread): the chat id equals the Telegram user id,
-        # stored on the row as ``tg-<id>``.
+        # Preferred: the real origin chat id. Handles DM / group / forum topic.
+        if chat_id:
+            return str(chat_id), tid
+        # --- Legacy fallback (rows predating chat_id capture) ---
+        # Forum-topic origin without a persisted chat: the supergroup, if set.
+        if tid is not None:
+            return (str(forum_chat_id), tid) if forum_chat_id else (None, None)
+        # DM origin: the chat id equals the Telegram user id (``tg-<id>``).
+        # NOTE: a legacy no-thread GROUP origin is indistinguishable from a DM
+        # here and would resolve to the user's DM — the exact gap the persisted
+        # chat_id closes for all new sessions.
         if user_id.startswith("tg-"):
             num = user_id[3:]
             if num.lstrip("-").isdigit():
@@ -1525,6 +1532,7 @@ class DirectSessionRunner:
 
             chat_id, thread_id = self._resolve_origin_target(
                 origin.get("channel"),
+                origin.get("chat_id"),
                 origin.get("user_id") or "",
                 origin.get("thread_id"),
                 getattr(pipeline, "_forum_chat_id", None),

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -35,6 +35,7 @@ from genesis.cc.types import (
     CCInvocation,
     CCModel,
     CCOutput,
+    DeliveryMode,
     EffortLevel,
     SessionType,
     StreamEvent,
@@ -60,6 +61,32 @@ _BG_TRUNCATION_NOTICE = (
     "\n\n⚠️ Note: this run reached its time budget and some background work was "
     "cut off before finishing, so the results below may be incomplete."
 )
+
+# Soft cap for a single Telegram delivery of a RESULT-mode outcome. Below the
+# 4096-char hard limit, leaving room for the header + HTML entity expansion.
+# Larger output is written to a file and delivered as a head + pointer.
+_TG_MSG_CAP = 3500
+
+
+def _write_result_artifact(session_id: str, raw: str) -> str | None:
+    """Write a background session's full result to ``~/.genesis/output`` so an
+    oversized outcome can be delivered as a head + file pointer instead of a
+    wall of Telegram messages. Returns the path, or None if the write failed
+    (delivery still proceeds with just the truncated head).
+    """
+    try:
+        out_dir = Path.home() / ".genesis" / "output"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        path = out_dir / f"bg-session-{session_id}.md"
+        path.write_text(raw, encoding="utf-8")
+        return str(path)
+    except Exception:
+        logger.error(
+            "Failed to write result artifact for %s",
+            session_id[:8],
+            exc_info=True,
+        )
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -559,12 +586,30 @@ class DirectSessionRequest:
     # (e.g. "glm-5.2") to run this background session on instead of the global
     # default. None → the chokepoint applies the active default as usual.
     roster_model: str | None = None
+    # Delivery of the terminal outcome. None → derived from the legacy
+    # notify/notify_on_failure_only bools in __post_init__ (SILENT/FAILURE_ONLY),
+    # so existing callers are unchanged. RESULT is set only by the
+    # deliver_to_origin dispatch path and requires origin_session_id.
+    delivery_mode: DeliveryMode | None = None
+    # The foreground cc_sessions row id this session was dispatched from, used
+    # to route a RESULT delivery back to that conversation. Captured from
+    # GENESIS_SESSION_ID at dispatch (see direct_session_run). None otherwise.
+    origin_session_id: str | None = None
 
     def __post_init__(self) -> None:
         if self.profile not in VALID_PROFILES:
             raise ValueError(
                 f"Invalid profile {self.profile!r}. "
                 f"Must be one of: {', '.join(sorted(VALID_PROFILES))}"
+            )
+        # Frozen dataclass: derive the delivery mode from the legacy bools when
+        # not explicitly set, so every existing constructor keeps its behavior
+        # without an edit. object.__setattr__ is required under frozen=True.
+        if self.delivery_mode is None:
+            object.__setattr__(
+                self,
+                "delivery_mode",
+                DeliveryMode.from_legacy(self.notify, self.notify_on_failure_only),
             )
 
 
@@ -870,6 +915,11 @@ class DirectSessionRunner:
                 output_tokens=output.output_tokens,
             )
 
+            # RESULT-mode: deliver the finished outcome back to the origin
+            # conversation. Best-effort (own try/except) — never fails the run.
+            if request.delivery_mode == DeliveryMode.RESULT:
+                await self._deliver_result_to_origin(request, result)
+
             logger.info(
                 "Direct session %s completed: %.1fs, $%.4f, %d tools",
                 session_id[:8],
@@ -944,7 +994,13 @@ class DirectSessionRunner:
                     exc_info=True,
                 )
 
-            if request.notify:
+            # RESULT-mode delivers the failure to the origin thread (a promised
+            # report that failed is still owed to the requester); otherwise the
+            # legacy broadcast failure alert fires. _deliver_result_to_origin
+            # swallows its own errors, so no extra guard is needed here.
+            if request.delivery_mode == DeliveryMode.RESULT:
+                await self._deliver_result_to_origin(request, error_result)
+            elif request.notify:
                 try:
                     await self._notify(request, error_result, success=False)
                 except Exception:
@@ -1385,3 +1441,132 @@ class DirectSessionRunner:
             )
         except Exception:
             logger.error("Outreach submit failed", exc_info=True)
+
+    @staticmethod
+    def _resolve_origin_target(
+        channel: str | None,
+        user_id: str,
+        thread_id_raw: object,
+        forum_chat_id: str | None,
+    ) -> tuple[str | None, int | None]:
+        """Resolve a Telegram ``(chat_id, message_thread_id)`` delivery target
+        from an origin ``cc_sessions`` row.
+
+        Returns ``(None, None)`` when the origin cannot be addressed: a
+        non-telegram channel, a forum-topic origin with no forum chat
+        configured, or a DM whose numeric chat id isn't recoverable.
+        """
+        if channel != "telegram":
+            return None, None
+        # Forum-topic origin: the chat is the forum supergroup and the thread is
+        # the persisted topic id (which provably exists — the origin message came
+        # from it). Requires forum_chat_id to be configured.
+        if thread_id_raw:
+            try:
+                tid = int(thread_id_raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None, None
+            if forum_chat_id:
+                return str(forum_chat_id), tid
+            return None, None
+        # DM origin (no forum thread): the chat id equals the Telegram user id,
+        # stored on the row as ``tg-<id>``.
+        if user_id.startswith("tg-"):
+            num = user_id[3:]
+            if num.lstrip("-").isdigit():
+                return num, None
+        return None, None
+
+    async def _deliver_result_to_origin(
+        self,
+        request: DirectSessionRequest,
+        result: DirectSessionResult,
+    ) -> None:
+        """Deliver a RESULT-mode session's terminal outcome to its origin thread.
+
+        Routes the finished output (success) or the error (failure/truncation)
+        back to the exact conversation the session was dispatched from — the
+        channel + thread on the origin foreground ``cc_sessions`` row
+        (``request.origin_session_id``). Best-effort: any failure is logged, never
+        raised, so a delivery problem cannot fail the session handler. Oversized
+        output is written to ``~/.genesis/output`` and delivered as a head +
+        pointer. Delivered via ``submit_urgent(verbatim=True)`` so a promised
+        result is never suppressed by governance/dedup or reworded by the drafter.
+        """
+        origin_id = request.origin_session_id
+        if not origin_id:
+            logger.warning(
+                "RESULT delivery for session %s has no origin_session_id — skipping",
+                result.session_id[:8],
+            )
+            return
+        try:
+            import html as html_mod
+
+            pipeline = getattr(self._rt, "_outreach_pipeline", None)
+            db = getattr(self._rt, "_db", None)
+            if pipeline is None or db is None:
+                logger.warning("RESULT delivery: outreach pipeline or DB unavailable")
+                return
+
+            from genesis.db.crud import cc_sessions as cs_crud
+
+            origin = await cs_crud.get_by_id(db, origin_id) or {}
+            if not origin:
+                logger.warning(
+                    "RESULT delivery: origin session %s not found — using fallback surface",
+                    origin_id[:8],
+                )
+
+            chat_id, thread_id = self._resolve_origin_target(
+                origin.get("channel"),
+                origin.get("user_id") or "",
+                origin.get("thread_id"),
+                getattr(pipeline, "_forum_chat_id", None),
+            )
+
+            status = "✓" if result.success else "✗"
+            raw = (
+                (result.output_text or "(no output)")
+                if result.success
+                else f"Task did not complete: {result.error or 'unknown error'}"
+            )
+            header = f"<b>{status} Background task complete</b>\n\n"
+            text = header + html_mod.escape(raw)
+            if len(text) > _TG_MSG_CAP:
+                path = _write_result_artifact(result.session_id, raw)
+                head = html_mod.escape(raw[: _TG_MSG_CAP - 400])
+                pointer = html_mod.escape(str(path)) if path else "(disk write failed)"
+                text = header + head + f"\n\n… (truncated) — full result saved to {pointer}"
+
+            if not chat_id:
+                # Origin unaddressable (non-telegram, or a chat we don't persist):
+                # deliver to the default owner surface rather than drop the
+                # promised result silently.
+                text += (
+                    "\n\n<i>(origin conversation could not be addressed — "
+                    "delivered to the default surface)</i>"
+                )
+
+            from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+            await pipeline.submit_urgent(
+                OutreachRequest(
+                    category=OutreachCategory.ALERT,
+                    # Unique per session so governance dedup never collides with
+                    # another delivery.
+                    topic=f"bg_result:{result.session_id}",
+                    context=text,
+                    salience_score=0.9,
+                    channel="telegram" if chat_id else None,
+                    verbatim=True,
+                    target_chat_id=chat_id,
+                    target_thread_id=thread_id,
+                )
+            )
+        except Exception:
+            logger.error(
+                "Failed to deliver RESULT to origin for session %s",
+                result.session_id[:8],
+                exc_info=True,
+            )

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1243,6 +1243,11 @@ class DirectSessionRunner:
         # narrow file-write or shell access (e.g., models.md weekly synthesis).
         if request.tool_exceptions:
             exceptions = set(request.tool_exceptions)
+            # Never let a background session re-enable recursive spawn via a
+            # tool_exception: the delivery model's foreground-origin-only
+            # invariant (GENESIS_SESSION_ID is always a foreground row) depends
+            # on direct_session_run staying unreachable from background sessions.
+            exceptions.discard("mcp__genesis-health__direct_session_run")
             disallowed = [t for t in disallowed if t not in exceptions]
 
         # Give background sessions access to Genesis MCP servers. Profile
@@ -1532,10 +1537,16 @@ class DirectSessionRunner:
                 else f"Task did not complete: {result.error or 'unknown error'}"
             )
             header = f"<b>{status} Background task complete</b>\n\n"
-            text = header + html_mod.escape(raw)
+            escaped = html_mod.escape(raw)
+            text = header + escaped
             if len(text) > _TG_MSG_CAP:
                 path = _write_result_artifact(result.session_id, raw)
-                head = html_mod.escape(raw[: _TG_MSG_CAP - 400])
+                # Budget on the ESCAPED length (entities expand up to ~4×), then
+                # trim any dangling partial entity at the cut so Telegram's HTML
+                # parser doesn't choke on a truncated "&amp;"-style sequence.
+                head = escaped[: _TG_MSG_CAP - 400]
+                if "&" in head[-6:]:
+                    head = head.rsplit("&", 1)[0]
                 pointer = html_mod.escape(str(path)) if path else "(disk write failed)"
                 text = header + head + f"\n\n… (truncated) — full result saved to {pointer}"
 

--- a/src/genesis/cc/session_manager.py
+++ b/src/genesis/cc/session_manager.py
@@ -46,6 +46,7 @@ class SessionManager:
         model: CCModel = CCModel.SONNET,
         effort: EffortLevel = EffortLevel.MEDIUM,
         thread_id: str | None = None,
+        chat_id: str | None = None,
     ) -> dict:
         ch = str(channel)
         existing = await cc_sessions.get_active_foreground(
@@ -74,6 +75,7 @@ class SessionManager:
             last_activity_at=now,
             source_tag="foreground",
             thread_id=thread_id,
+            chat_id=chat_id,
         )
         return await cc_sessions.get_by_id(self._db, sess_id)
 

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -84,6 +84,40 @@ class EffortLevel(StrEnum):
     MAX = "max"
 
 
+class DeliveryMode(StrEnum):
+    """How a background (direct) session's terminal outcome is delivered.
+
+    - ``SILENT`` — no notification; the DB row is the only record.
+    - ``FAILURE_ONLY`` — failures are broadcast-alerted; success is silent.
+      The legacy default (success notifications were retired as noise).
+    - ``RESULT`` — the terminal outcome (success AND failure/truncation) is
+      delivered back to the ORIGIN conversation the session was dispatched
+      from. Requires ``DirectSessionRequest.origin_session_id`` (the foreground
+      ``cc_sessions`` row id captured at dispatch); falls back to the default
+      owner surface when the origin cannot be addressed.
+    """
+
+    SILENT = "silent"
+    FAILURE_ONLY = "failure_only"
+    RESULT = "result"
+
+    @classmethod
+    def from_legacy(cls, notify: bool, notify_on_failure_only: bool = False) -> DeliveryMode:
+        """Map the legacy ``notify`` / ``notify_on_failure_only`` bools to a mode.
+
+        Preserves today's behavior exactly: ``notify=False`` → SILENT; any
+        ``notify=True`` → FAILURE_ONLY (success has never notified — the runner
+        only sends on failure). ``notify_on_failure_only`` is accepted for
+        signature completeness but does not change the result: nothing in the
+        runner reads it today, so both ``notify=True`` combinations collapse to
+        FAILURE_ONLY. No legacy caller maps to RESULT — that mode is opt-in via
+        the ``deliver_to_origin`` dispatch path only.
+        """
+        if not notify:
+            return cls.SILENT
+        return cls.FAILURE_ONLY
+
+
 # Ordered list used for ceiling comparisons (low → max).
 _EFFORT_RANK: list[EffortLevel] = [
     EffortLevel.LOW,

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -238,6 +238,7 @@ async def _handle_text_inner(ctx: HandlerContext, msg, user, tid):
             on_event=on_event,
             thread_id=tid,
             session_key=interrupt_key(*ikey),
+            chat_id=str(msg.chat.id),
         )
         log.info("Response to %s (%d chars)", user.id, len(response or ""))
 
@@ -421,6 +422,7 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
             on_event=on_event,
             thread_id=tid,
             session_key=interrupt_key(*ikey),
+            chat_id=str(msg.chat.id),
         )
         log.info("Voice response to %s (%d chars)", user.id, len(response or ""))
 
@@ -609,6 +611,7 @@ async def _handle_media_inner(
             on_event=on_event,
             thread_id=tid,
             session_key=interrupt_key(*ikey),
+            chat_id=str(msg.chat.id),
         )
         log.info("Media response to %s (%d chars)", user.id, len(response or ""))
 

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -25,13 +25,14 @@ async def create(
     metadata: str | None = None,
     thread_id: str | None = None,
     origin_class: str | None = None,
+    chat_id: str | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO cc_sessions
            (id, session_type, user_id, channel, model, effort, status,
             pid, started_at, last_activity_at, source_tag, metadata, thread_id,
-            origin_class)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            origin_class, chat_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             id,
             session_type,
@@ -47,6 +48,7 @@ async def create(
             metadata,
             thread_id,
             origin_class,
+            chat_id,
         ),
     )
     await db.commit()

--- a/src/genesis/db/crud/direct_session_queue.py
+++ b/src/genesis/db/crud/direct_session_queue.py
@@ -25,6 +25,8 @@ async def enqueue(
     notify_on_failure_only: bool = False,
     caller_context: str | None = None,
     roster_model: str | None = None,
+    origin_session_id: str | None = None,
+    delivery_mode: str | None = None,
 ) -> str:
     """Insert a new queue item. Returns the queue_id."""
     queue_id = f"dsq-{uuid.uuid4().hex[:12]}"
@@ -38,6 +40,8 @@ async def enqueue(
         "notify_on_failure_only": notify_on_failure_only,
         "caller_context": caller_context,
         "roster_model": roster_model,
+        "origin_session_id": origin_session_id,
+        "delivery_mode": delivery_mode,
     }
     await db.execute(
         """INSERT INTO direct_session_queue

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -105,6 +105,13 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     await _try_alter(db,
         "ALTER TABLE cc_sessions ADD COLUMN thread_id TEXT",
         "cc_sessions.thread_id")
+    # Origin chat id (2026-07-22): the real Telegram chat.id at intake, so a
+    # background RESULT delivery reaches the exact origin (DM, group, or forum
+    # topic) instead of assuming every no-thread origin is a DM.
+    await _try_alter(
+        db,
+        "ALTER TABLE cc_sessions ADD COLUMN chat_id TEXT",
+        "cc_sessions.chat_id")
 
     # Phase 9: rate limit tracking on cc_sessions
     await _try_alter(db,

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -500,7 +500,8 @@ TABLES = {
             thread_id        TEXT,
             rate_limited_at  TEXT,
             rate_limit_resumes_at TEXT,
-            origin_class     TEXT
+            origin_class     TEXT,
+            chat_id          TEXT
         )
     """,
     "inbox_items": """

--- a/src/genesis/identity/CONVERSATION.md
+++ b/src/genesis/identity/CONVERSATION.md
@@ -20,9 +20,12 @@ deploy — anything likely to take more than a couple of minutes):
 - **Break it into small steps** and make visible progress rather than attempting
   one massive action in a single turn.
 - **For genuinely long work, hand it off:** dispatch a background session with the
-  `direct_session_run` MCP tool (`notify=True`) and **acknowledge immediately** —
-  tell the user you've started it and will report back — instead of blocking the
-  conversation and going silent.
+  `direct_session_run` MCP tool and **acknowledge immediately** — tell the user
+  you've started it and will report back — instead of blocking the conversation and
+  going silent. When you make that promise, pass **`deliver_to_origin=True`** so the
+  finished outcome (success *or* failure) is delivered back to **this exact
+  conversation** when it completes. Without it, a successful background run is silent
+  (only failures alert), and your "I'll report back" goes unkept.
 - A quick, honest "here's the plan" or "I've kicked this off in the background,
   I'll report back" always beats a long silent wait.
 

--- a/src/genesis/mcp/health/direct_session_tools.py
+++ b/src/genesis/mcp/health/direct_session_tools.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 
 from genesis.mcp.health import mcp
 
@@ -57,6 +58,7 @@ async def _impl_direct_session_run(
     timeout_minutes: int = 15,
     notify: bool = True,
     roster_model: str | None = None,
+    deliver_to_origin: bool = False,
 ) -> dict:
     """Enqueue a directed background CC session for dispatch."""
     if _db is None:
@@ -95,6 +97,25 @@ async def _impl_direct_session_run(
             known = ", ".join((_roster.load_roster().get("models") or {}).keys())
             return {"error": f"Unknown roster_model '{roster_model}'. Known: {known}"}
 
+    # deliver_to_origin: capture the foreground origin so the server can route
+    # the result back to the calling conversation. GENESIS_SESSION_ID is the
+    # foreground cc_sessions row id, set by the CCInvoker and inherited into this
+    # MCP child process. Only foreground/interactive sessions can reach this tool
+    # (it is in the background disallow list), so this id is always a foreground
+    # origin — never a background session (which would be circular).
+    origin_session_id = None
+    delivery_mode = None
+    if deliver_to_origin:
+        origin_session_id = os.environ.get("GENESIS_SESSION_ID") or None
+        if origin_session_id:
+            delivery_mode = "result"
+        else:
+            logger.warning(
+                "direct_session_run(deliver_to_origin=True) with no "
+                "GENESIS_SESSION_ID in env — falling back to default notification "
+                "(no origin delivery)"
+            )
+
     try:
         from genesis.db.crud import direct_session_queue as dsq
 
@@ -108,6 +129,8 @@ async def _impl_direct_session_run(
             notify=notify,
             caller_context="mcp_tool",
             roster_model=roster_model,
+            origin_session_id=origin_session_id,
+            delivery_mode=delivery_mode,
         )
         return {
             "queue_id": queue_id,
@@ -116,7 +139,13 @@ async def _impl_direct_session_run(
             "message": (
                 f"Session queued with '{profile}' profile. "
                 "The Genesis server will dispatch it within seconds. "
-                "You'll be notified via Telegram when it completes."
+                + (
+                    "The result will be delivered back to this conversation "
+                    "when it completes."
+                    if delivery_mode == "result"
+                    else "You'll get a Telegram alert if it fails (successful "
+                    "runs are silent — poll direct_session_status for output)."
+                )
             ),
         }
     except Exception as exc:
@@ -287,11 +316,17 @@ async def direct_session_run(
     timeout_minutes: int = 15,
     notify: bool = True,
     roster_model: str | None = None,
+    deliver_to_origin: bool = False,
 ) -> dict:
     """Spawn a directed background CC session with profile-based tool restrictions.
 
     The session is queued and dispatched by the Genesis server, so it
-    outlives this MCP session. Results are reported via Telegram.
+    outlives this MCP session. By default the session is FIRE-AND-FORGET:
+    successful runs are silent (poll ``direct_session_status`` for output) and
+    only failures raise a Telegram alert. Set ``deliver_to_origin=True`` to have
+    the terminal outcome (success AND failure) delivered back to THIS
+    conversation when it finishes — use this whenever you hand off long work from
+    a channel and tell the user you'll report back.
 
     Profiles control what the session can do:
     - observe: Read everything, change nothing. Browser viewing, memory reads, web search.
@@ -307,14 +342,26 @@ async def direct_session_run(
         model: LLM model (sonnet, opus, haiku, fable)
         effort: Effort level (low, medium, high, xhigh, max)
         timeout_minutes: Max runtime in minutes (default 15, max 60)
-        notify: Send Telegram notification on completion/failure
+        notify: Send a Telegram alert if the session FAILS (successful runs are
+            silent unless deliver_to_origin is set). Has no effect when
+            deliver_to_origin=True.
+        deliver_to_origin: Deliver the terminal outcome (success and failure)
+            back to the conversation this tool was called from. Requires a
+            foreground channel session as the caller.
         roster_model: Optionally run this session on a specific roster model
             (e.g. "glm-5.2") instead of the default — intentional model
             selection. Omit/None to use the active default. Fails the session
             if the named model is unknown or its API key is not configured.
     """
     return await _impl_direct_session_run(
-        prompt, profile, model, effort, timeout_minutes, notify, roster_model,
+        prompt,
+        profile,
+        model,
+        effort,
+        timeout_minutes,
+        notify,
+        roster_model,
+        deliver_to_origin,
     )
 
 

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -892,6 +892,11 @@ class OutreachPipeline:
                     "content": content,
                     "category": request.category.value,
                     "topic": request.topic,
+                    # Origin-targeted delivery must survive a transient-failure
+                    # retry, or a result that failed once lands in the default
+                    # surface instead of the exact origin thread it promised.
+                    "target_chat_id": request.target_chat_id,
+                    "target_thread_id": request.target_thread_id,
                 }),
                 reason=reason,
                 staleness_policy="drain",

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -483,7 +483,11 @@ class OutreachPipeline:
         gate_cleared: bool = False,
     ) -> OutreachResult:
         adapter = self._channels.get(channel)
-        recipient = request.validated_recipient or self._recipients.get(channel, "")
+        recipient = (
+            request.validated_recipient
+            or request.target_chat_id
+            or self._recipients.get(channel, "")
+        )
 
         # Email self-send / no-recipient terminal skip (WS-8 spam-loop fix). A
         # send to the agent's OWN address, or an email with no resolved
@@ -580,7 +584,14 @@ class OutreachPipeline:
         thread_id = None
         topic_cat: str | None = None
         delivery_recipient = recipient
-        if channel == "telegram":
+        # Origin-targeted telegram delivery (a background result routed back to
+        # the exact conversation it was requested in): the caller already
+        # resolved the chat + topic, so bypass the category->forum-topic routing
+        # entirely and deliver straight to that chat/thread.
+        if channel == "telegram" and request.target_chat_id:
+            delivery_recipient = request.target_chat_id
+            thread_id = request.target_thread_id
+        elif channel == "telegram":
             if routing in ("supergroup", "both") and self._topic_manager is not None:
                 topic_cat = self._topic_manager.resolve_outreach_category(
                     request.category.value,

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -119,6 +119,14 @@ class OutreachRequest:
     # at delivery; None → the prediction rides the policy_prior lane (a
     # measured base-rate seed, NOT 0.5 — see ledger/writers.py).
     stated_confidence: float | None = None
+    # Origin-targeted TELEGRAM delivery: when set, ``_deliver`` sends this
+    # message to THIS chat + forum topic instead of the category→topic routing.
+    # Used to deliver a background session's result back to the exact
+    # conversation it was requested in. ``target_chat_id`` is a numeric chat id
+    # as a string (a DM user id, or the forum supergroup id); ``target_thread_id``
+    # is the forum topic id (None for a DM). Ignored for non-telegram channels.
+    target_chat_id: str | None = None
+    target_thread_id: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/genesis/resilience/outreach_recovery.py
+++ b/src/genesis/resilience/outreach_recovery.py
@@ -139,6 +139,10 @@ class OutreachRecoveryWorker:
                 salience_score=0.9,
                 signal_type="deferred_retry",
                 channel=payload.get("channel"),
+                # Preserve origin-targeted telegram delivery across the retry so a
+                # once-failed background result still reaches its exact origin thread.
+                target_chat_id=payload.get("target_chat_id"),
+                target_thread_id=payload.get("target_thread_id"),
             )
             content = payload.get("content", "")
             if not content:

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -52,7 +52,7 @@ async def _recover_stale_claims(db) -> None:
 async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
     """Poll direct_session_queue for pending items, dispatch to runner."""
     from genesis.cc.direct_session import DirectSessionRequest
-    from genesis.cc.types import CCModel, EffortLevel
+    from genesis.cc.types import CCModel, DeliveryMode, EffortLevel
     from genesis.db.crud import direct_session_queue as dsq
 
     # Crash recovery on boot: reset claims orphaned before a crash/restart.
@@ -83,6 +83,7 @@ async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
             queue_id = row["id"]
             try:
                 payload = json.loads(row["payload_json"])
+                delivery_mode_raw = payload.get("delivery_mode")
                 request = DirectSessionRequest(
                     prompt=payload["prompt"],
                     profile=payload.get("profile", "observe"),
@@ -93,6 +94,10 @@ async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
                     notify_on_failure_only=payload.get("notify_on_failure_only", False),
                     caller_context=payload.get("caller_context"),
                     roster_model=payload.get("roster_model"),
+                    # Origin-delivery (added by the deliver_to_origin dispatch path);
+                    # absent on legacy rows → None → derived legacy behavior.
+                    origin_session_id=payload.get("origin_session_id"),
+                    delivery_mode=(DeliveryMode(delivery_mode_raw) if delivery_mode_raw else None),
                 )
                 session_id = await runner.spawn(request)
                 await dsq.mark_dispatched(db, queue_id, session_id)

--- a/tests/test_cc/test_direct_session_delivery.py
+++ b/tests/test_cc/test_direct_session_delivery.py
@@ -55,26 +55,46 @@ class TestDeliveryModeDerivation:
 class TestResolveOriginTarget:
     f = staticmethod(DirectSessionRunner._resolve_origin_target)
 
-    def test_dm_origin(self):
-        # No forum thread → DM; chat id == the numeric telegram user id.
-        assert self.f("telegram", "tg-12345678", None, "-100999") == ("12345678", None)
+    # --- Preferred path: persisted chat_id (all new sessions) ---
+    def test_dm_uses_persisted_chat_id(self):
+        assert self.f("telegram", "12345678", "tg-12345678", None, "-100999") == (
+            "12345678",
+            None,
+        )
 
-    def test_forum_topic_origin(self):
-        # Forum thread → the supergroup chat + the topic id.
-        assert self.f("telegram", "tg-12345678", "110", "-100999") == ("-100999", 110)
+    def test_group_uses_persisted_chat_id(self):
+        # A group chat (chat.id != user.id, no thread) delivers to the GROUP, not
+        # the user's DM — the exact misroute the persisted chat_id closes.
+        assert self.f("telegram", "-100555", "tg-12345678", None, "-100999") == (
+            "-100555",
+            None,
+        )
 
-    def test_forum_without_configured_chat_unaddressable(self):
-        assert self.f("telegram", "tg-12345678", "110", None) == (None, None)
+    def test_forum_uses_persisted_chat_id_and_thread(self):
+        assert self.f("telegram", "-100999", "tg-12345678", "110", "-100999") == (
+            "-100999",
+            110,
+        )
 
-    def test_non_numeric_user_unaddressable(self):
-        assert self.f("telegram", "tg-notanumber", None, "-100999") == (None, None)
-
-    def test_non_telegram_channel_unaddressable(self):
-        assert self.f("terminal", "tg-1", None, "-100999") == (None, None)
-        assert self.f(None, "tg-1", None, "-100999") == (None, None)
+    def test_non_telegram_unaddressable(self):
+        assert self.f("terminal", "999", "tg-1", None, "-100999") == (None, None)
+        assert self.f(None, "999", "tg-1", None, "-100999") == (None, None)
 
     def test_bad_thread_id_unaddressable(self):
-        assert self.f("telegram", "tg-1", "not-an-int", "-100999") == (None, None)
+        assert self.f("telegram", "999", "tg-1", "not-an-int", "-100999") == (None, None)
+
+    # --- Legacy fallback: chat_id absent (rows predating capture) ---
+    def test_legacy_dm_reconstructs_from_user_id(self):
+        assert self.f("telegram", None, "tg-12345678", None, "-100999") == ("12345678", None)
+
+    def test_legacy_forum_uses_forum_chat_id(self):
+        assert self.f("telegram", None, "tg-1", "110", "-100999") == ("-100999", 110)
+
+    def test_legacy_forum_without_chat_unaddressable(self):
+        assert self.f("telegram", None, "tg-1", "110", None) == (None, None)
+
+    def test_legacy_non_numeric_user_unaddressable(self):
+        assert self.f("telegram", None, "tg-notanumber", None, "-100999") == (None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +119,7 @@ def _runner_with_pipeline(db):
     return runner, pipeline
 
 
-async def _make_origin(db, *, session_id, channel, user_id, thread_id=None):
+async def _make_origin(db, *, session_id, channel, user_id, thread_id=None, chat_id=None):
     await cc_sessions.create(
         db,
         id=session_id,
@@ -110,6 +130,7 @@ async def _make_origin(db, *, session_id, channel, user_id, thread_id=None):
         user_id=user_id,
         channel=channel,
         thread_id=thread_id,
+        chat_id=chat_id,
     )
 
 
@@ -146,6 +167,27 @@ class TestDeliverResultToOrigin:
         sent = pipeline.submit_urgent.call_args.args[0]
         assert sent.target_chat_id == "-1002000"  # the forum supergroup
         assert sent.target_thread_id == 110
+
+    async def test_group_chat_delivery_uses_persisted_chat_id(self, db):
+        # A group-chat origin (chat.id != user.id, no thread) must deliver to the
+        # GROUP, not the requesting user's DM. Regression guard for the Codex P2.
+        await _make_origin(
+            db,
+            session_id="o-grp",
+            channel="telegram",
+            user_id="tg-12345678",
+            chat_id="-100555",
+        )
+        runner, pipeline = _runner_with_pipeline(db)
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-grp"
+        )
+        res = DirectSessionResult(session_id="sg", success=True, output_text="group report")
+        await runner._deliver_result_to_origin(req, res)
+
+        sent = pipeline.submit_urgent.call_args.args[0]
+        assert sent.target_chat_id == "-100555"  # the group, NOT tg-12345678's DM
+        assert sent.target_thread_id is None
 
     async def test_failure_delivered_to_origin(self, db):
         await _make_origin(db, session_id="o-f", channel="telegram", user_id="tg-1")

--- a/tests/test_cc/test_direct_session_delivery.py
+++ b/tests/test_cc/test_direct_session_delivery.py
@@ -1,0 +1,291 @@
+"""Tests for the background-session delivery model.
+
+Covers DeliveryMode derivation, origin-target resolution, the framework
+delivery helper (_deliver_result_to_origin), and the _run_session wiring that
+routes a RESULT-mode outcome (success AND failure) back to its origin thread.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.cc.direct_session import (
+    DirectSessionRequest,
+    DirectSessionResult,
+    DirectSessionRunner,
+)
+from genesis.cc.types import CCOutput, DeliveryMode
+from genesis.db.crud import cc_sessions
+
+# ---------------------------------------------------------------------------
+# DeliveryMode derivation — legacy callers must be behaviorally unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestDeliveryModeDerivation:
+    def test_from_legacy_maps_bools(self):
+        assert DeliveryMode.from_legacy(False, False) is DeliveryMode.SILENT
+        assert DeliveryMode.from_legacy(True, False) is DeliveryMode.FAILURE_ONLY
+        # notify_on_failure_only is a no-op today; both notify=True combos collapse.
+        assert DeliveryMode.from_legacy(True, True) is DeliveryMode.FAILURE_ONLY
+
+    def test_request_derives_mode_from_notify(self):
+        assert DirectSessionRequest(prompt="x", notify=True).delivery_mode is (
+            DeliveryMode.FAILURE_ONLY
+        )
+        assert DirectSessionRequest(prompt="x", notify=False).delivery_mode is (DeliveryMode.SILENT)
+
+    def test_explicit_result_mode_preserved(self):
+        r = DirectSessionRequest(
+            prompt="x",
+            delivery_mode=DeliveryMode.RESULT,
+            origin_session_id="sess-abc",
+        )
+        assert r.delivery_mode is DeliveryMode.RESULT
+        assert r.origin_session_id == "sess-abc"
+
+
+# ---------------------------------------------------------------------------
+# Origin-target resolution (pure static method)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOriginTarget:
+    f = staticmethod(DirectSessionRunner._resolve_origin_target)
+
+    def test_dm_origin(self):
+        # No forum thread → DM; chat id == the numeric telegram user id.
+        assert self.f("telegram", "tg-831453901", None, "-100999") == ("831453901", None)
+
+    def test_forum_topic_origin(self):
+        # Forum thread → the supergroup chat + the topic id.
+        assert self.f("telegram", "tg-831453901", "110", "-100999") == ("-100999", 110)
+
+    def test_forum_without_configured_chat_unaddressable(self):
+        assert self.f("telegram", "tg-831453901", "110", None) == (None, None)
+
+    def test_non_numeric_user_unaddressable(self):
+        assert self.f("telegram", "tg-notanumber", None, "-100999") == (None, None)
+
+    def test_non_telegram_channel_unaddressable(self):
+        assert self.f("terminal", "tg-1", None, "-100999") == (None, None)
+        assert self.f(None, "tg-1", None, "-100999") == (None, None)
+
+    def test_bad_thread_id_unaddressable(self):
+        assert self.f("telegram", "tg-1", "not-an-int", "-100999") == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _deliver_result_to_origin — framework delivery helper
+# ---------------------------------------------------------------------------
+
+
+def _runner_with_pipeline(db):
+    """A runner whose runtime exposes a capturing outreach pipeline + the db."""
+    pipeline = MagicMock()
+    pipeline.submit_urgent = AsyncMock(return_value=None)
+    pipeline._forum_chat_id = "-1002000"
+    rt = MagicMock()
+    rt._outreach_pipeline = pipeline
+    rt._db = db
+    runner = DirectSessionRunner(
+        invoker=AsyncMock(),
+        session_manager=AsyncMock(),
+        config_builder=AsyncMock(),
+        runtime=rt,
+    )
+    return runner, pipeline
+
+
+async def _make_origin(db, *, session_id, channel, user_id, thread_id=None):
+    await cc_sessions.create(
+        db,
+        id=session_id,
+        session_type="foreground",
+        model="opus",
+        started_at="2026-07-22T00:00:00+00:00",
+        last_activity_at="2026-07-22T00:00:00+00:00",
+        user_id=user_id,
+        channel=channel,
+        thread_id=thread_id,
+    )
+
+
+class TestDeliverResultToOrigin:
+    async def test_dm_delivery(self, db):
+        await _make_origin(db, session_id="o-dm", channel="telegram", user_id="tg-831453901")
+        runner, pipeline = _runner_with_pipeline(db)
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-dm"
+        )
+        res = DirectSessionResult(session_id="s1", success=True, output_text="the findings")
+        await runner._deliver_result_to_origin(req, res)
+
+        pipeline.submit_urgent.assert_awaited_once()
+        sent = pipeline.submit_urgent.call_args.args[0]
+        assert sent.target_chat_id == "831453901"
+        assert sent.target_thread_id is None
+        assert sent.channel == "telegram"
+        assert sent.verbatim is True
+        assert "the findings" in sent.context
+        assert sent.topic == "bg_result:s1"
+
+    async def test_forum_delivery(self, db):
+        await _make_origin(
+            db, session_id="o-fx", channel="telegram", user_id="tg-1", thread_id="110"
+        )
+        runner, pipeline = _runner_with_pipeline(db)
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-fx"
+        )
+        res = DirectSessionResult(session_id="s2", success=True, output_text="report")
+        await runner._deliver_result_to_origin(req, res)
+
+        sent = pipeline.submit_urgent.call_args.args[0]
+        assert sent.target_chat_id == "-1002000"  # the forum supergroup
+        assert sent.target_thread_id == 110
+
+    async def test_failure_delivered_to_origin(self, db):
+        await _make_origin(db, session_id="o-f", channel="telegram", user_id="tg-1")
+        runner, pipeline = _runner_with_pipeline(db)
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-f"
+        )
+        res = DirectSessionResult(session_id="s3", success=False, error="boom")
+        await runner._deliver_result_to_origin(req, res)
+
+        sent = pipeline.submit_urgent.call_args.args[0]
+        assert "boom" in sent.context
+        assert "✗" in sent.context
+
+    async def test_oversized_output_writes_file_and_pointers(self, db, tmp_path, monkeypatch):
+        # Redirect the artifact dir to a temp path.
+        import genesis.cc.direct_session as ds
+
+        monkeypatch.setattr(ds.Path, "home", lambda: tmp_path)
+        await _make_origin(db, session_id="o-big", channel="telegram", user_id="tg-1")
+        runner, pipeline = _runner_with_pipeline(db)
+        big = "A" * 9000
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-big"
+        )
+        res = DirectSessionResult(session_id="s4", success=True, output_text=big)
+        await runner._deliver_result_to_origin(req, res)
+
+        sent = pipeline.submit_urgent.call_args.args[0]
+        assert len(sent.context) < 9000  # truncated for delivery
+        assert "truncated" in sent.context
+        artifact = tmp_path / ".genesis" / "output" / "bg-session-s4.md"
+        assert artifact.exists()
+        assert artifact.read_text() == big  # full raw content saved
+
+    async def test_unaddressable_origin_falls_back_not_dropped(self, db):
+        # A non-telegram origin can't be targeted → deliver to the default surface.
+        await _make_origin(db, session_id="o-term", channel="terminal", user_id="tg-1")
+        runner, pipeline = _runner_with_pipeline(db)
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-term"
+        )
+        res = DirectSessionResult(session_id="s5", success=True, output_text="done")
+        await runner._deliver_result_to_origin(req, res)
+
+        pipeline.submit_urgent.assert_awaited_once()
+        sent = pipeline.submit_urgent.call_args.args[0]
+        assert sent.target_chat_id is None
+        assert sent.channel is None  # default channel selection
+        assert "could not be addressed" in sent.context
+
+    async def test_no_origin_id_skips_without_error(self, db):
+        runner, pipeline = _runner_with_pipeline(db)
+        req = DirectSessionRequest(prompt="x", delivery_mode=DeliveryMode.RESULT)
+        res = DirectSessionResult(session_id="s6", success=True, output_text="x")
+        await runner._deliver_result_to_origin(req, res)
+        pipeline.submit_urgent.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _run_session wiring — RESULT routes both terminal states to origin delivery
+# ---------------------------------------------------------------------------
+
+
+def _cc_output(*, is_error=False, text="hi"):
+    return CCOutput(
+        session_id="cc-1",
+        text=text,
+        model_used="sonnet",
+        cost_usd=0.0,
+        input_tokens=1,
+        output_tokens=1,
+        duration_ms=10,
+        exit_code=0,
+        is_error=is_error,
+    )
+
+
+class TestRunSessionDeliveryWiring:
+    async def test_success_result_mode_delivers(self):
+        runner = DirectSessionRunner(
+            invoker=AsyncMock(),
+            session_manager=AsyncMock(),
+            config_builder=AsyncMock(),
+            runtime=MagicMock(),
+        )
+        runner._build_invocation = MagicMock(return_value=MagicMock(claude_code_tmpdir=None))
+        runner._invoker.run_streaming = AsyncMock(return_value=_cc_output())
+        runner._store_result = AsyncMock()
+        runner._record_proposal_outcome = AsyncMock()
+        runner._session_manager.complete = AsyncMock()
+        runner._deliver_result_to_origin = AsyncMock()
+
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o1"
+        )
+        await runner._run_session(req, "sess-1")
+        runner._deliver_result_to_origin.assert_awaited_once()
+
+    async def test_failure_result_mode_delivers_not_broadcast(self):
+        runner = DirectSessionRunner(
+            invoker=AsyncMock(),
+            session_manager=AsyncMock(),
+            config_builder=AsyncMock(),
+            runtime=MagicMock(),
+        )
+        runner._build_invocation = MagicMock(return_value=MagicMock(claude_code_tmpdir=None))
+        runner._invoker.run_streaming = AsyncMock(side_effect=RuntimeError("kaboom"))
+        runner._store_result = AsyncMock()
+        runner._record_proposal_outcome = AsyncMock()
+        runner._session_manager.fail = AsyncMock()
+        runner._deliver_result_to_origin = AsyncMock()
+        runner._notify = AsyncMock()
+
+        req = DirectSessionRequest(
+            prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o1"
+        )
+        with pytest.raises(RuntimeError):
+            await runner._run_session(req, "sess-2")
+        runner._deliver_result_to_origin.assert_awaited_once()
+        runner._notify.assert_not_awaited()  # RESULT replaces the broadcast alert
+
+    async def test_failure_legacy_mode_broadcasts_not_origin(self):
+        runner = DirectSessionRunner(
+            invoker=AsyncMock(),
+            session_manager=AsyncMock(),
+            config_builder=AsyncMock(),
+            runtime=MagicMock(),
+        )
+        runner._build_invocation = MagicMock(return_value=MagicMock(claude_code_tmpdir=None))
+        runner._invoker.run_streaming = AsyncMock(side_effect=RuntimeError("kaboom"))
+        runner._store_result = AsyncMock()
+        runner._record_proposal_outcome = AsyncMock()
+        runner._session_manager.fail = AsyncMock()
+        runner._deliver_result_to_origin = AsyncMock()
+        runner._notify = AsyncMock()
+
+        # Legacy caller (notify=True → FAILURE_ONLY): broadcast, not origin.
+        req = DirectSessionRequest(prompt="x", notify=True)
+        with pytest.raises(RuntimeError):
+            await runner._run_session(req, "sess-3")
+        runner._notify.assert_awaited_once()
+        runner._deliver_result_to_origin.assert_not_awaited()

--- a/tests/test_cc/test_direct_session_delivery.py
+++ b/tests/test_cc/test_direct_session_delivery.py
@@ -57,14 +57,14 @@ class TestResolveOriginTarget:
 
     def test_dm_origin(self):
         # No forum thread → DM; chat id == the numeric telegram user id.
-        assert self.f("telegram", "tg-831453901", None, "-100999") == ("831453901", None)
+        assert self.f("telegram", "tg-12345678", None, "-100999") == ("12345678", None)
 
     def test_forum_topic_origin(self):
         # Forum thread → the supergroup chat + the topic id.
-        assert self.f("telegram", "tg-831453901", "110", "-100999") == ("-100999", 110)
+        assert self.f("telegram", "tg-12345678", "110", "-100999") == ("-100999", 110)
 
     def test_forum_without_configured_chat_unaddressable(self):
-        assert self.f("telegram", "tg-831453901", "110", None) == (None, None)
+        assert self.f("telegram", "tg-12345678", "110", None) == (None, None)
 
     def test_non_numeric_user_unaddressable(self):
         assert self.f("telegram", "tg-notanumber", None, "-100999") == (None, None)
@@ -115,7 +115,7 @@ async def _make_origin(db, *, session_id, channel, user_id, thread_id=None):
 
 class TestDeliverResultToOrigin:
     async def test_dm_delivery(self, db):
-        await _make_origin(db, session_id="o-dm", channel="telegram", user_id="tg-831453901")
+        await _make_origin(db, session_id="o-dm", channel="telegram", user_id="tg-12345678")
         runner, pipeline = _runner_with_pipeline(db)
         req = DirectSessionRequest(
             prompt="x", delivery_mode=DeliveryMode.RESULT, origin_session_id="o-dm"
@@ -125,7 +125,7 @@ class TestDeliverResultToOrigin:
 
         pipeline.submit_urgent.assert_awaited_once()
         sent = pipeline.submit_urgent.call_args.args[0]
-        assert sent.target_chat_id == "831453901"
+        assert sent.target_chat_id == "12345678"
         assert sent.target_thread_id is None
         assert sent.channel == "telegram"
         assert sent.verbatim is True

--- a/tests/test_outreach/test_deliver_origin_target.py
+++ b/tests/test_outreach/test_deliver_origin_target.py
@@ -1,0 +1,144 @@
+"""Tests for origin-targeted Telegram delivery in the outreach chokepoint.
+
+The delivery model routes a background session's result back to the exact
+conversation it was requested in by pinning target_chat_id + target_thread_id on
+the OutreachRequest. _deliver must honor that BEFORE the category->forum-topic
+routing, and must not regress the existing (untargeted) category path.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.content.types import FormatTarget, FormattedContent
+from genesis.db.schema import create_all_tables
+from genesis.outreach.config import OutreachConfig, QuietHours
+from genesis.outreach.governance import GovernanceGate
+from genesis.outreach.pipeline import OutreachPipeline
+from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+
+
+@pytest.fixture
+def config():
+    return OutreachConfig(
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
+        channel_preferences={"default": "telegram"},
+        thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
+        max_daily=50,
+        surplus_daily=10,
+        content_daily=30,
+        notification_daily=100,
+        morning_report_time="07:00",
+        engagement_timeout_hours=24,
+        engagement_poll_minutes=60,
+    )
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def mock_formatter():
+    formatter = MagicMock()
+    formatter.format.side_effect = lambda text, target: FormattedContent(
+        text=text,
+        target=FormatTarget.TELEGRAM,
+        truncated=False,
+        original_length=len(text),
+    )
+    return formatter
+
+
+@pytest.fixture
+def mock_channel():
+    adapter = AsyncMock()
+    adapter.send_message.return_value = "delivery-abc"
+    return adapter
+
+
+def _pipeline(config, db, mock_formatter, mock_channel, *, recipients):
+    return OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=AsyncMock(),
+        formatter=mock_formatter,
+        channels={"telegram": mock_channel},
+        db=db,
+        config=config,
+        recipients=recipients,
+    )
+
+
+def _targeted_req(*, chat_id, thread_id):
+    return OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="bg_result:s1",
+        context="the delivered result",
+        salience_score=0.9,
+        channel="telegram",
+        verbatim=True,
+        target_chat_id=chat_id,
+        target_thread_id=thread_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_targeted_dm_delivery(config, db, mock_formatter, mock_channel):
+    pipeline = _pipeline(config, db, mock_formatter, mock_channel, recipients={"telegram": "999"})
+    result = await pipeline.submit_urgent(_targeted_req(chat_id="831453901", thread_id=None))
+
+    assert result.status == OutreachStatus.DELIVERED
+    args, kwargs = mock_channel.send_message.call_args
+    assert args[0] == "831453901"  # delivered to the target chat, NOT the default "999"
+    assert kwargs["message_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_targeted_forum_topic_delivery(config, db, mock_formatter, mock_channel):
+    pipeline = _pipeline(config, db, mock_formatter, mock_channel, recipients={"telegram": "999"})
+    pipeline.set_forum_chat_id(-1002000)
+    result = await pipeline.submit_urgent(_targeted_req(chat_id="-1002000", thread_id=110))
+
+    assert result.status == OutreachStatus.DELIVERED
+    args, kwargs = mock_channel.send_message.call_args
+    assert args[0] == "-1002000"
+    assert kwargs["message_thread_id"] == 110
+
+
+@pytest.mark.asyncio
+async def test_targeted_survives_empty_default_recipient(config, db, mock_formatter, mock_channel):
+    # No default telegram recipient configured — a targeted send must still
+    # deliver (the target chat satisfies the non-empty recipient guard).
+    pipeline = _pipeline(config, db, mock_formatter, mock_channel, recipients={})
+    result = await pipeline.submit_urgent(_targeted_req(chat_id="555", thread_id=None))
+
+    assert result.status == OutreachStatus.DELIVERED
+    args, _ = mock_channel.send_message.call_args
+    assert args[0] == "555"
+
+
+@pytest.mark.asyncio
+async def test_untargeted_category_path_unchanged(config, db, mock_formatter, mock_channel):
+    # No target → existing behavior: DM fallback to the default recipient
+    # (topic_manager is None, so no forum topic resolves).
+    pipeline = _pipeline(config, db, mock_formatter, mock_channel, recipients={"telegram": "12345"})
+    req = OutreachRequest(
+        category=OutreachCategory.ALERT,
+        topic="ordinary alert",
+        context="hello",
+        salience_score=0.9,
+        channel="telegram",
+        verbatim=True,
+    )
+    result = await pipeline.submit_urgent(req)
+
+    assert result.status == OutreachStatus.DELIVERED
+    args, kwargs = mock_channel.send_message.call_args
+    assert args[0] == "12345"
+    assert kwargs["message_thread_id"] is None

--- a/tests/test_outreach/test_deliver_origin_target.py
+++ b/tests/test_outreach/test_deliver_origin_target.py
@@ -142,3 +142,45 @@ async def test_untargeted_category_path_unchanged(config, db, mock_formatter, mo
     args, kwargs = mock_channel.send_message.call_args
     assert args[0] == "12345"
     assert kwargs["message_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_defer_carries_target_fields_for_retry(config, db, mock_formatter):
+    # A transient send failure defers the send; the origin-target fields MUST be
+    # serialized so a retry still reaches the exact origin thread (SHOULD-FIX 1).
+    import json
+
+    failing_adapter = AsyncMock()
+    failing_adapter.send_message.side_effect = RuntimeError("transient telegram error")
+    deferred_queue = AsyncMock()
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=AsyncMock(),
+        formatter=mock_formatter,
+        channels={"telegram": failing_adapter},
+        db=db,
+        config=config,
+        recipients={"telegram": "999"},
+        deferred_queue=deferred_queue,
+    )
+    await pipeline.submit_urgent(_targeted_req(chat_id="831453901", thread_id=None))
+
+    deferred_queue.enqueue.assert_awaited_once()
+    payload = json.loads(deferred_queue.enqueue.call_args.kwargs["payload"])
+    assert payload["target_chat_id"] == "831453901"
+    assert payload["target_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_raw_retry_path_honors_target(config, db, mock_formatter, mock_channel):
+    # The recovery worker retries via submit_raw(content, request); a request
+    # carrying the restored target fields must still deliver to the origin thread.
+    pipeline = _pipeline(config, db, mock_formatter, mock_channel, recipients={"telegram": "999"})
+    pipeline.set_forum_chat_id(-1002000)
+    req = _targeted_req(chat_id="-1002000", thread_id=110)
+    result = await pipeline.submit_raw("pre-formatted result", req)
+
+    assert result.status == OutreachStatus.DELIVERED
+    args, kwargs = mock_channel.send_message.call_args
+    assert args[0] == "-1002000"
+    assert kwargs["message_thread_id"] == 110

--- a/tests/test_outreach/test_deliver_origin_target.py
+++ b/tests/test_outreach/test_deliver_origin_target.py
@@ -91,11 +91,11 @@ def _targeted_req(*, chat_id, thread_id):
 @pytest.mark.asyncio
 async def test_targeted_dm_delivery(config, db, mock_formatter, mock_channel):
     pipeline = _pipeline(config, db, mock_formatter, mock_channel, recipients={"telegram": "999"})
-    result = await pipeline.submit_urgent(_targeted_req(chat_id="831453901", thread_id=None))
+    result = await pipeline.submit_urgent(_targeted_req(chat_id="12345678", thread_id=None))
 
     assert result.status == OutreachStatus.DELIVERED
     args, kwargs = mock_channel.send_message.call_args
-    assert args[0] == "831453901"  # delivered to the target chat, NOT the default "999"
+    assert args[0] == "12345678"  # delivered to the target chat, NOT the default "999"
     assert kwargs["message_thread_id"] is None
 
 
@@ -163,11 +163,11 @@ async def test_defer_carries_target_fields_for_retry(config, db, mock_formatter)
         recipients={"telegram": "999"},
         deferred_queue=deferred_queue,
     )
-    await pipeline.submit_urgent(_targeted_req(chat_id="831453901", thread_id=None))
+    await pipeline.submit_urgent(_targeted_req(chat_id="12345678", thread_id=None))
 
     deferred_queue.enqueue.assert_awaited_once()
     payload = json.loads(deferred_queue.enqueue.call_args.kwargs["payload"])
-    assert payload["target_chat_id"] == "831453901"
+    assert payload["target_chat_id"] == "12345678"
     assert payload["target_thread_id"] is None
 
 


### PR DESCRIPTION
## What & why

When Genesis hands a long task off to a background session and says "I'll report back," it now actually does. Previously a background task's **successful** result was saved to the DB but **never delivered** — `DirectSessionRunner._notify` hard-returns on success — so a promised "I'll get back to you" silently never arrived. This was the second half of the 2026-07-20 incident (a Telegram deep-research request that vanished): PR #1186 stopped the work from *dying*; this stops the result from *disappearing*.

It's a **general** mechanism, not research-specific: any handed-off background task can deliver its terminal outcome back to the exact conversation it came from.

## How

- **`DeliveryMode`** enum (`SILENT`/`FAILURE_ONLY`/`RESULT`) with `from_legacy()` deriving mode from the existing `notify` bools — all 8 existing `DirectSessionRequest` callers are behaviorally unchanged (none map to `RESULT`).
- **Origin capture:** `direct_session_run(deliver_to_origin=True)` reads `GENESIS_SESSION_ID` (the foreground `cc_sessions` row id the health-MCP child provably inherits) and threads it, with `delivery_mode=result`, through the queue payload onto the request. The tool is foreground-only (background disallow list + a `tool_exceptions` guard), so the origin is never a background session.
- **Framework delivery (Option B):** on a `RESULT` run, `DirectSessionRunner._deliver_result_to_origin` resolves the origin's channel+thread and delivers via the outreach chokepoint — `OutreachRequest.target_chat_id`/`target_thread_id`, honored in `pipeline._deliver` *before* the category→topic routing. DM (`chat==user id`) and forum-topic (`forum_chat_id`+thread) both work; unaddressable origins fall back to the owner surface (never a silent drop). Delivered `submit_urgent(verbatim=True)` + unique per-session topic so a promised result is never governance/dedup-suppressed or reworded. Target survives the transient-failure defer→retry.
- **Size-driven:** oversized output is saved under `~/.genesis/output/` and delivered as a summary + file pointer.
- Honest `direct_session_run` docstring/message + `CONVERSATION.md`/`background-sessions.md` guidance (was: "Results are reported via Telegram" — false for success).

## Tests

24 new tests: `DeliveryMode` derivation, `_resolve_origin_target` (DM/forum/unaddressable), `_deliver_result_to_origin` (DM/forum/failure/oversized→file/fallback/no-origin), `_run_session` wiring (RESULT delivers both terminal states; legacy stays broadcast), Option-B `_deliver` targeting (DM/forum/empty-recipient/untargeted-unchanged), and the defer→retry target round-trip. 140 existing direct-session + pipeline tests still green. genesis-architect review: DONE_WITH_CONCERNS → SHOULD-FIX + NOTES addressed in `837de464`.

## Scope / follow-up

- **Cancel-path delivery is out of scope** (a `RESULT` session cancelled by a restart records failure but doesn't deliver) — that's PR-2 (rate-limit park + auto-resume) territory, tracked under ledger `ee391fbd`.
- Live E2E (a real targeted Telegram delivery) runs post-deploy.

Ledger: d82f5101c3c149cbb76fea4dae1143ef

🤖 Generated with [Claude Code](https://claude.com/claude-code)
