### PR TITLE
feat(ego): informational eval lane — j9/gauntlet off the approval queue (PR-1)

### DIFF
--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1075,9 +1075,17 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
                 is_approve = any(s == "approved" for s, _ in decisions.values())
                 if is_approve:
                     try:
+                        from genesis.ego.types import is_informational
+
                         recent_withdrawn = await ego_crud.list_proposals(
-                            ctx.db, status="withdrawn", limit=1,
+                            ctx.db, status="withdrawn", limit=5,
                         )
+                        # Skip auto-cleared informational eval rows (j9/gauntlet)
+                        # — they were never user-facing approvals to re-propose.
+                        recent_withdrawn = [
+                            w for w in recent_withdrawn
+                            if not is_informational(w.get("action_type"))
+                        ]
                         if recent_withdrawn:
                             top = recent_withdrawn[0]
                             await ego_crud.create_directive(

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -109,21 +109,36 @@ async def unified_comms():
         counts["outreach_total"] = 0
 
     # --- Ego proposals ---
+    informational: list[dict] = []
     try:
         from genesis.db.crud import ego
+        from genesis.ego.types import (
+            INFORMATIONAL_ACTION_TYPES,
+            partition_informational,
+        )
 
         if view == "pending":
-            proposals = await ego.list_pending_proposals(rt.db)
+            raw = await ego.list_pending_proposals(rt.db)
+            # Acknowledge-only eval rows (j9/gauntlet) are notifications, not
+            # approval items — split them into a separate informational lane.
+            proposals, informational = partition_informational(raw)
         else:
             proposals = await ego.list_proposals(rt.db, limit=limit)
 
         # Enrich executed proposals with session outcome data
         proposals = await _enrich_proposals_with_outcomes(rt.db, proposals)
 
+        # Pending APPROVAL count excludes informational rows (they carry no
+        # approve/reject decision). Built from the shared constant so it can
+        # never drift from the lane split above.
+        _info_placeholders = ",".join("?" for _ in INFORMATIONAL_ACTION_TYPES)
         pending_count_cursor = await rt.db.execute(
-            "SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending'"
+            "SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending' "
+            f"AND action_type NOT IN ({_info_placeholders})",
+            tuple(INFORMATIONAL_ACTION_TYPES),
         )
         counts["proposals_pending"] = (await pending_count_cursor.fetchone())[0]
+        counts["proposals_informational"] = len(informational)
 
         total_count_cursor = await rt.db.execute(
             "SELECT COUNT(*) FROM ego_proposals"
@@ -154,6 +169,7 @@ async def unified_comms():
     return jsonify({
         "outreach": outreach,
         "proposals": proposals,
+        "informational": informational,
         "pending_approvals": pending_approvals,
         "counts": counts,
     })

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -77,8 +77,8 @@ async def unified_comms():
     rt = GenesisRuntime.instance()
     if not rt.is_bootstrapped or rt.db is None:
         return jsonify({
-            "outreach": [], "proposals": [], "pending_approvals": [],
-            "counts": {},
+            "outreach": [], "proposals": [], "informational": [],
+            "pending_approvals": [], "counts": {},
         })
 
     view = request.args.get("view", "pending")
@@ -109,35 +109,52 @@ async def unified_comms():
         counts["outreach_total"] = 0
 
     # --- Ego proposals ---
+    # Acknowledge-only eval rows (j9/gauntlet) are notifications, not approval
+    # items — they never render with approve/reject and never count as pending
+    # approvals, in EITHER view. In the pending view the approval count is just
+    # the approval-lane length; in the history view the page is limited, so the
+    # full pending-approval count comes from a COUNT query (built from the shared
+    # constant so it can't drift from the split).
     informational: list[dict] = []
     try:
         from genesis.db.crud import ego
         from genesis.ego.types import (
             INFORMATIONAL_ACTION_TYPES,
+            is_informational,
             partition_informational,
         )
 
         if view == "pending":
             raw = await ego.list_pending_proposals(rt.db)
-            # Acknowledge-only eval rows (j9/gauntlet) are notifications, not
-            # approval items — split them into a separate informational lane.
             proposals, informational = partition_informational(raw)
+            counts["proposals_pending"] = len(proposals)
         else:
-            proposals = await ego.list_proposals(rt.db, limit=limit)
+            raw = await ego.list_proposals(rt.db, limit=limit)
+            # Keep resolved rows (incl. resolved informational) in history, but
+            # pull still-PENDING informational rows into the informational lane so
+            # they never render as approvable in the history view.
+            proposals = [
+                p for p in raw
+                if not (
+                    p.get("status") == "pending"
+                    and is_informational(p.get("action_type"))
+                )
+            ]
+            informational = [
+                p for p in raw
+                if p.get("status") == "pending"
+                and is_informational(p.get("action_type"))
+            ]
+            _info_placeholders = ",".join("?" for _ in INFORMATIONAL_ACTION_TYPES)
+            pending_count_cursor = await rt.db.execute(
+                "SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending' "
+                f"AND action_type NOT IN ({_info_placeholders})",
+                tuple(INFORMATIONAL_ACTION_TYPES),
+            )
+            counts["proposals_pending"] = (await pending_count_cursor.fetchone())[0]
 
         # Enrich executed proposals with session outcome data
         proposals = await _enrich_proposals_with_outcomes(rt.db, proposals)
-
-        # Pending APPROVAL count excludes informational rows (they carry no
-        # approve/reject decision). Built from the shared constant so it can
-        # never drift from the lane split above.
-        _info_placeholders = ",".join("?" for _ in INFORMATIONAL_ACTION_TYPES)
-        pending_count_cursor = await rt.db.execute(
-            "SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending' "
-            f"AND action_type NOT IN ({_info_placeholders})",
-            tuple(INFORMATIONAL_ACTION_TYPES),
-        )
-        counts["proposals_pending"] = (await pending_count_cursor.fetchone())[0]
         counts["proposals_informational"] = len(informational)
 
         total_count_cursor = await rt.db.execute(
@@ -148,6 +165,7 @@ async def unified_comms():
         # Ego tables may be empty if ego hasn't run — that's fine
         logger.debug("Ego proposals unavailable for comms view", exc_info=True)
         counts["proposals_pending"] = 0
+        counts["proposals_informational"] = 0
         counts["proposals_total"] = 0
 
     # --- Pending approvals ---

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -19,6 +19,7 @@ async def ego_status():
 
     from genesis.db.crud import ego as ego_crud
     from genesis.ego.config import load_ego_config
+    from genesis.ego.types import partition_informational
     from genesis.runtime import GenesisRuntime
 
     rt = GenesisRuntime.instance()
@@ -29,7 +30,10 @@ async def ego_status():
     daily_cost = await ego_crud.daily_ego_cost(rt._db)
     focus = await ego_crud.get_state(rt._db, "ego_focus_summary")
     recent = await ego_crud.list_recent_cycles(rt._db, limit=1)
-    pending = await ego_crud.list_pending_proposals(rt._db)
+    # Approval-queue counts exclude acknowledge-only eval rows (j9/gauntlet) —
+    # they are surfaced separately as informational, never as pending approvals.
+    all_pending = await ego_crud.list_pending_proposals(rt._db)
+    pending, informational = partition_informational(all_pending)
     uncompacted = await ego_crud.count_uncompacted(rt._db)
 
     last_cycle = None
@@ -137,6 +141,7 @@ async def ego_status():
             "focus_summary": focus,
             "last_cycle": last_cycle,
             "pending_proposals": len(pending),
+            "informational_count": len(informational),
             "uncompacted_cycles": uncompacted,
             "shadow_morning_report": config.shadow_morning_report,
             "board_size": config.board_size,
@@ -216,15 +221,21 @@ async def ego_cycles():
 @blueprint.route("/api/genesis/ego/proposals")
 @_async_route
 async def ego_proposals():
-    """Return pending ego proposals."""
+    """Return pending ego proposals (approval items only).
+
+    Acknowledge-only eval rows (j9/gauntlet) are excluded here and served by
+    :func:`ego_informational` — they carry no approve/reject decision.
+    """
     from genesis.db.crud import ego as ego_crud
+    from genesis.ego.types import partition_informational
     from genesis.runtime import GenesisRuntime
 
     rt = GenesisRuntime.instance()
     if not rt.is_bootstrapped or rt._db is None:
         return jsonify([])
 
-    pending = await ego_crud.list_pending_proposals(rt._db)
+    all_pending = await ego_crud.list_pending_proposals(rt._db)
+    pending, _informational = partition_informational(all_pending)
     return jsonify(
         [
             {
@@ -244,6 +255,42 @@ async def ego_proposals():
                 "realist_verdict": p.get("realist_verdict"),
             }
             for p in pending
+        ]
+    )
+
+
+@blueprint.route("/api/genesis/ego/informational")
+@_async_route
+async def ego_informational():
+    """Return pending acknowledge-only eval rows (j9/gauntlet).
+
+    These are notifications, not approval items: they render in a distinct
+    informational strip with no approve/reject controls.
+    """
+    from genesis.db.crud import ego as ego_crud
+    from genesis.ego.types import partition_informational
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt._db is None:
+        return jsonify([])
+
+    all_pending = await ego_crud.list_pending_proposals(rt._db)
+    _pending, informational = partition_informational(all_pending)
+    return jsonify(
+        [
+            {
+                "id": p["id"],
+                "action_type": p["action_type"],
+                "content": p["content"],
+                "rationale": p.get("rationale"),
+                "confidence": p["confidence"],
+                "urgency": p["urgency"],
+                "status": p["status"],
+                "created_at": p["created_at"],
+                "ego_source": p.get("ego_source"),
+            }
+            for p in informational
         ]
     )
 

--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -259,6 +259,9 @@
                       <span style="font-size: 0.68rem; padding: 1px 6px; border-radius: 3px; font-weight: 600;"
                             :style="`background: rgba(192,132,252,0.15); color: #c084fc;`"
                             x-text="p.action_type"></span>
+                      <span x-show="p.ego_source" style="font-size: 0.68rem; padding: 1px 6px; border-radius: 3px; font-weight: 600; text-transform: uppercase;"
+                            :style="p.ego_source === 'genesis_ego_cycle' ? 'background: rgba(156,39,176,0.2); color: #e1bee7;' : 'background: rgba(33,150,243,0.2); color: #90caf9;'"
+                            x-text="$store.genesisDashboard.egoSourceLabel(p.ego_source)"></span>
                       <span style="font-size: 0.68rem; padding: 1px 6px; border-radius: 3px;"
                             :style="`background: ${p.urgency === 'critical' ? 'rgba(217,83,79,0.15)' : p.urgency === 'high' ? 'rgba(240,173,78,0.15)' : p.urgency === 'normal' ? 'rgba(33,150,243,0.15)' : 'rgba(136,136,136,0.15)'}; color: ${p.urgency === 'critical' ? '#d9534f' : p.urgency === 'high' ? '#f0ad4e' : p.urgency === 'normal' ? '#2196F3' : '#888'}`"
                             x-text="p.urgency"></span>

--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -300,8 +300,8 @@
                         <span style="font-weight: 600;">Response:</span> <span x-text="p.user_response"></span>
                       </div>
                     </template>
-                    <!-- Approve/Reject buttons (pending only) -->
-                    <template x-if="p.status === 'pending'">
+                    <!-- Approve/Reject buttons (pending, non-informational only) -->
+                    <template x-if="p.status === 'pending' && !$store.genesisDashboard.isInformationalProposal(p)">
                       <div style="margin-top: 0.5rem; display: flex; gap: 0.4rem; align-items: center;">
                         <button style="font-size: 0.72rem; padding: 0.25rem 0.8rem; border-radius: 4px; border: 1px solid #4caf50; background: rgba(76,175,80,0.1); color: #4caf50; cursor: pointer;"
                                 @click="$store.genesisDashboard.resolveEgoProposal(p.id, 'approved', '')">Approve</button>

--- a/src/genesis/dashboard/templates/partials/tabs/chat.html
+++ b/src/genesis/dashboard/templates/partials/tabs/chat.html
@@ -204,7 +204,7 @@
                         x-text="p.status"></span>
                   <span x-show="p.ego_source" style="font-size:0.65rem; padding:0.1rem 0.4rem; border-radius:3px; font-weight:600; text-transform:uppercase;"
                         :style="p.ego_source === 'genesis_ego_cycle' ? 'background:rgba(156,39,176,0.25); color:#e1bee7;' : 'background:rgba(33,150,243,0.25); color:#90caf9;'"
-                        x-text="p.ego_source === 'genesis_ego_cycle' ? 'Genesis' : p.ego_source === 'user_ego_cycle' ? 'User' : 'Ego'"></span>
+                        x-text="$store.genesisDashboard.egoSourceLabel(p.ego_source)"></span>
                   <span x-show="p.action_type" style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px; background:rgba(33,150,243,0.1); color:#64b5f6;"
                         x-text="p.action_type"></span>
                   <span x-show="p.urgency && p.urgency !== 'normal'" style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px;"
@@ -284,6 +284,31 @@
                               @click="$store.genesisDashboard.commsRejectingId = null; $store.genesisDashboard.commsRejectReason = ''">Cancel</button>
                     </div>
                   </template>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <!-- ── Informational (eval notifications, no approval) ── -->
+          <template x-if="$store.genesisDashboard.commsInformational.length > 0">
+            <div style="margin-top:1rem;">
+              <div style="font-size:0.68rem; text-transform:uppercase; letter-spacing:0.04em; color:var(--color-text-secondary); margin-bottom:0.4rem; display:flex; align-items:center; gap:0.35rem;">
+                <span>Informational</span>
+                <span style="font-size:0.6rem; color:var(--color-text-secondary); font-weight:400; text-transform:none;">— eval notifications, no approval needed</span>
+              </div>
+              <template x-for="p in $store.genesisDashboard.commsInformational" :key="p.id">
+                <div style="border:1px dashed var(--color-border); border-radius:6px; padding:0.6rem; margin-bottom:0.5rem; opacity:0.92;">
+                  <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.3rem;">
+                    <div style="display:flex; gap:0.3rem; align-items:center;">
+                      <span style="font-size:0.65rem; padding:0.1rem 0.4rem; border-radius:3px; font-weight:600; text-transform:uppercase; background:rgba(158,158,158,0.2); color:#bdbdbd;"
+                            x-text="$store.genesisDashboard.egoSourceLabel(p.ego_source)"></span>
+                      <span x-show="p.action_type" style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px; background:rgba(33,150,243,0.1); color:#64b5f6;"
+                            x-text="p.action_type"></span>
+                    </div>
+                    <span style="font-size:0.65rem; color:var(--color-text-secondary);"
+                          x-text="$store.genesisDashboard.formatDateTime(p.created_at)"></span>
+                  </div>
+                  <div style="font-size:0.78rem; line-height:1.4;" x-text="p.content"></div>
                 </div>
               </template>
             </div>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3794,6 +3794,14 @@
           })[src] || "Ego";
         },
 
+        // Acknowledge-only eval rows (j9/gauntlet) — never approvable. Kept in
+        // sync with ego/types.py::INFORMATIONAL_ACTION_TYPES.
+        isInformationalProposal(p) {
+          return ["j9_regression", "gauntlet_regression"].includes(
+            p && p.action_type,
+          );
+        },
+
         // 5-state chip helpers over the shared status semantics (spec §3.3).
         // Layered onto the existing .status-chip pill: chip--* supplies the
         // canonical color + background tint; the glyph is color-blind support.

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -184,6 +184,7 @@
         // ── Comms state (on Chat tab) ────────────────────────────
         commsOutreach: [],
         commsProposals: [],
+        commsInformational: [],
         commsPendingApprovals: [],
         commsCounts: {},
         commsView: 'pending',
@@ -1424,6 +1425,7 @@
               const data = await resp.json();
               this.commsOutreach = data.outreach || [];
               this.commsProposals = data.proposals || [];
+              this.commsInformational = data.informational || [];
               this.commsPendingApprovals = data.pending_approvals || [];
               this.commsCounts = data.counts || {};
               this.finishFetch("comms");
@@ -3778,6 +3780,18 @@
           // Delegates to the shared fmtAge contract (spec §3.4):
           // just now (<90s) / Nm / Nh / Nd — no "ago" suffix, one format everywhere.
           return fmtAge(value);
+        },
+
+        // Map an ego proposal's ego_source to a display label. Eval sources
+        // (j9_eval, gauntlet) get real names so they never render as a bare
+        // "Ego". Kept in sync with ego/proposals.py::_EGO_LABELS.
+        egoSourceLabel(src) {
+          return ({
+            genesis_ego_cycle: "Genesis",
+            user_ego_cycle: "User",
+            j9_eval: "Eval",
+            gauntlet: "Gauntlet",
+          })[src] || "Ego";
         },
 
         // 5-state chip helpers over the shared status semantics (spec §3.3).

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -696,6 +696,12 @@ class ProposalWorkflow:
         indexes into list_proposals_by_batch (ALL proposals, not just pending).
         """
         pending = await ego_crud.list_pending_proposals(self._db)
+        # Informational eval rows (j9/gauntlet) are acknowledge-only — a bulk
+        # "approve all pending" must never sweep them into a resolution. (Today
+        # they also carry a NULL batch_id and would fall out of the per-batch
+        # grouping below, but that is incidental; this makes the exclusion
+        # explicit so the no-approval invariant can't regress.)
+        pending, _informational = partition_informational(pending)
         if not pending:
             return {}
 

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from genesis.db.crud import ego as ego_crud
+from genesis.ego.types import partition_informational
 from genesis.util.approval_words import (
     APPROVE_PHRASES as _SHARED_BARE_APPROVE,
 )
@@ -66,6 +67,9 @@ _URGENCY_TAGS = {"critical": "[CRITICAL] ", "high": "[HIGH] "}
 _EGO_LABELS = {
     "user_ego_cycle": "User Ego",
     "genesis_ego_cycle": "Genesis Ego",
+    # Informational eval sources — named so they never render as a bare "Ego".
+    "j9_eval": "Eval",
+    "gauntlet": "Gauntlet",
 }
 
 
@@ -547,13 +551,16 @@ class ProposalWorkflow:
             warn_lines = "\n".join(f"  - {w}" for w in validation_warnings)
             digest_html = f"\u26a0\ufe0f <b>Validation:</b>\n{warn_lines}\n\n{digest_html}"
 
-        # Show pending backlog from other batches (same ego only)
+        # Show pending backlog from other batches (same ego only). Exclude
+        # acknowledge-only eval rows (j9/gauntlet) — they are notifications, not
+        # approval work, and "approve all pending" never touches them.
         try:
             all_pending = await ego_crud.list_pending_proposals(
                 self._db,
                 ego_source=ego_source,
             )
-            other_pending = [p for p in all_pending if p.get("batch_id") != batch_id]
+            approval_pending, _informational = partition_informational(all_pending)
+            other_pending = [p for p in approval_pending if p.get("batch_id") != batch_id]
             if other_pending:
                 summary_lines = []
                 for op in other_pending[:5]:

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -33,9 +33,11 @@ from genesis.cc.types import (
 )
 from genesis.db.crud import ego as ego_crud
 from genesis.ego.types import (
+    INFORMATIONAL_ACTION_TYPES,
     NEUTRAL_STATUS,
     EgoConfig,
     EgoCycle,
+    partition_informational,
 )
 from genesis.observability.session_context import set_session_id as _set_obs_session
 from genesis.observability.spans import SpanKind, start_span
@@ -75,12 +77,11 @@ _NEVER_DISPATCH_ACTION_TYPES = (
     "goal_status_change",
     "cell_promotion",
     "cognitive_variant_promotion",
-    # j9_regression is informational (NOTIFY_USER); its handler marks it executed
-    # on approval. Blocklisted so it can never be dispatched as a session.
-    "j9_regression",
-    # gauntlet_regression: same informational contract — the model-roster gauntlet
-    # flagged a PASS→FAIL; advisory only, never auto-acts. Blocklisted from dispatch.
-    "gauntlet_regression",
+    # The informational eval types (j9_regression, gauntlet_regression) are
+    # acknowledge-only — their handlers mark them 'executed' on approval with no
+    # side-effect. Sourced from the single INFORMATIONAL_ACTION_TYPES constant so
+    # the dispatch blocklist and the approval-queue exclusion never drift apart.
+    *INFORMATIONAL_ACTION_TYPES,
 )
 
 # MCP tools the ego CYCLE session must never call directly. In-cycle goal
@@ -1569,9 +1570,13 @@ class EgoSession:
             # Auto-table oldest unranked proposals when queue exceeds cap.
             # Respects the 24h guard — proposals < 24h old are not tabled.
             try:
-                pending = await ego_crud.list_pending_proposals(
+                all_pending = await ego_crud.list_pending_proposals(
                     self._db, ego_source=self._source_tag,
                 )
+                # Informational eval rows (j9/gauntlet) are acknowledge-only and
+                # must not consume the approval-queue cap — otherwise a burst of
+                # eval regressions could auto-table real, actionable proposals.
+                pending, _informational = partition_informational(all_pending)
                 max_pending = getattr(self._config, "max_pending_proposals", 15)
                 if len(pending) + len(proposals) > max_pending:
                     unranked = [

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -60,6 +60,44 @@ class ProposalUrgency(StrEnum):
     CRITICAL = "critical"
 
 
+# Informational proposal action_types: acknowledge-only rows filed by eval
+# subsystems (J-9 subsystem-grade regressions, the model-roster gauntlet).
+# They are notifications wearing a proposal's clothes — the ego_proposals row
+# exists ONLY as the per-period idempotency marker; approving one merely
+# acknowledges (its resolution handler marks it 'executed', no side-effect) and
+# it is never dispatched as a session. They must NOT be counted or surfaced as
+# pending-APPROVAL work: no approve/reject decision changes system state, so
+# presenting them on the approval queue is a category error (and inflating the
+# ego's pending-cap with them can auto-table real proposals). Single source of
+# truth; ``session._NEVER_DISPATCH_ACTION_TYPES`` is a strict superset (it also
+# blocks decision-carrying inline-applied types like cell_promotion, which DO
+# belong on the approval queue).
+INFORMATIONAL_ACTION_TYPES: tuple[str, ...] = ("j9_regression", "gauntlet_regression")
+
+
+def is_informational(action_type: str | None) -> bool:
+    """True if *action_type* is an acknowledge-only eval notification."""
+    return action_type in INFORMATIONAL_ACTION_TYPES
+
+
+def partition_informational(
+    proposals: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Split proposals into (approval_items, informational_items).
+
+    Order-preserving. A row is informational iff its ``action_type`` is in
+    :data:`INFORMATIONAL_ACTION_TYPES`.
+    """
+    approval: list[dict] = []
+    informational: list[dict] = []
+    for p in proposals:
+        if is_informational(p.get("action_type")):
+            informational.append(p)
+        else:
+            approval.append(p)
+    return approval, informational
+
+
 @dataclass(frozen=True)
 class EgoProposal:
     """A single action the ego wants to take, pending user approval."""

--- a/src/genesis/eval/gauntlet_regression.py
+++ b/src/genesis/eval/gauntlet_regression.py
@@ -45,6 +45,43 @@ def _proposal_id(model_id: str, run_id: str) -> str:
     return hashlib.sha256(f"{_ACTION_TYPE}:{model_id}:{run_id}".encode()).hexdigest()[:16]
 
 
+async def _clear_recovered_gauntlet(db: aiosqlite.Connection, model_id: str) -> int:
+    """Withdraw pending ``gauntlet_regression`` rows for a recovered model.
+
+    Called when a model logs a genuine PASS: the pending row's premise
+    ("previously PASSED, now FAILED") is now false, so it must not keep sitting
+    as an informational item. Best-effort — never raises into the caller.
+    """
+    from genesis.db.crud import ego as ego_crud
+
+    cleared = 0
+    try:
+        pending = await ego_crud.list_proposals(db, status="pending", limit=200)
+    except Exception:
+        logger.warning("gauntlet auto-clear: pending read failed", exc_info=True)
+        return 0
+    for p in pending:
+        if p.get("action_type") != _ACTION_TYPE:
+            continue
+        # Match the load-bearing content format written in check_gauntlet_regression.
+        if f"gauntlet regression — {model_id}:" not in p.get("content", ""):
+            continue
+        try:
+            ok = await ego_crud.resolve_proposal(
+                db,
+                p["id"],
+                status="withdrawn",
+                user_response=f"auto-cleared: {model_id} gauntlet passed again",
+            )
+            if ok:
+                cleared += 1
+        except Exception:
+            logger.warning(
+                "gauntlet auto-clear: withdraw failed for %s", p.get("id"), exc_info=True
+            )
+    return cleared
+
+
 async def check_gauntlet_regression(
     db: aiosqlite.Connection,
     summary: EvalRunSummary,
@@ -60,8 +97,13 @@ async def check_gauntlet_regression(
         passed = summary.passed_cases
         failed = summary.failed_cases
 
-        # Not a genuine failure (all green, or all skipped/inconclusive) → no signal.
+        # Not a genuine failure (all green, or all skipped/inconclusive) → no
+        # regression signal. A genuine PASS (green, not all-skipped) is a
+        # RECOVERY: clear any pending gauntlet row for this model. An
+        # inconclusive/all-skipped run clears nothing.
         if failed <= 0:
+            if _is_pass(passed, failed):
+                await _clear_recovered_gauntlet(db, summary.model_id)
             return None
 
         # Cold-start guard: require a prior PASS so a never-trusted model does not

--- a/src/genesis/eval/gauntlet_regression.py
+++ b/src/genesis/eval/gauntlet_regression.py
@@ -45,43 +45,6 @@ def _proposal_id(model_id: str, run_id: str) -> str:
     return hashlib.sha256(f"{_ACTION_TYPE}:{model_id}:{run_id}".encode()).hexdigest()[:16]
 
 
-async def _clear_recovered_gauntlet(db: aiosqlite.Connection, model_id: str) -> int:
-    """Withdraw pending ``gauntlet_regression`` rows for a recovered model.
-
-    Called when a model logs a genuine PASS: the pending row's premise
-    ("previously PASSED, now FAILED") is now false, so it must not keep sitting
-    as an informational item. Best-effort — never raises into the caller.
-    """
-    from genesis.db.crud import ego as ego_crud
-
-    cleared = 0
-    try:
-        pending = await ego_crud.list_proposals(db, status="pending", limit=200)
-    except Exception:
-        logger.warning("gauntlet auto-clear: pending read failed", exc_info=True)
-        return 0
-    for p in pending:
-        if p.get("action_type") != _ACTION_TYPE:
-            continue
-        # Match the load-bearing content format written in check_gauntlet_regression.
-        if f"gauntlet regression — {model_id}:" not in p.get("content", ""):
-            continue
-        try:
-            ok = await ego_crud.resolve_proposal(
-                db,
-                p["id"],
-                status="withdrawn",
-                user_response=f"auto-cleared: {model_id} gauntlet passed again",
-            )
-            if ok:
-                cleared += 1
-        except Exception:
-            logger.warning(
-                "gauntlet auto-clear: withdraw failed for %s", p.get("id"), exc_info=True
-            )
-    return cleared
-
-
 async def check_gauntlet_regression(
     db: aiosqlite.Connection,
     summary: EvalRunSummary,
@@ -103,7 +66,16 @@ async def check_gauntlet_regression(
         # inconclusive/all-skipped run clears nothing.
         if failed <= 0:
             if _is_pass(passed, failed):
-                await _clear_recovered_gauntlet(db, summary.model_id)
+                from genesis.eval.regression_common import (
+                    withdraw_recovered_proposals,
+                )
+
+                await withdraw_recovered_proposals(
+                    db,
+                    action_type=_ACTION_TYPE,
+                    recovered_subjects={summary.model_id},
+                    reason="gauntlet passed again",
+                )
             return None
 
         # Cold-start guard: require a prior PASS so a never-trusted model does not
@@ -177,6 +149,7 @@ async def check_gauntlet_regression(
                 db,
                 id=pid,
                 action_type=_ACTION_TYPE,
+                action_category=summary.model_id,
                 content=text,
                 rationale=(
                     "The model-roster gauntlet flagged a PASS→FAIL regression. "

--- a/src/genesis/eval/regression_alert.py
+++ b/src/genesis/eval/regression_alert.py
@@ -39,6 +39,10 @@ _J9_REGRESSION_ACTION_TYPE = "j9_regression"
 # score drop regardless of grade. Tunable down toward D once variance is known.
 _ABSOLUTE_FLOOR_GRADE = "F"
 _DELTA_DROP_POINTS = 15.0
+# Auto-clear a standing regression row only on AFFIRMATIVE health — never on
+# mere "no fresh regression" (a subsystem that dropped and holds at a degraded
+# grade, or a no-data week, is still regressed).
+_HEALTHY_GRADES = {"A", "B"}
 
 
 def _proposal_id(subsystem: str, period_end: str) -> str:
@@ -116,7 +120,11 @@ async def check_and_alert_regressions(
 
         reason = _regression_reason(latest, prior)
         if not reason:
-            clean_subs.add(sub)
+            # Recovery = affirmatively healthy grade, NOT merely "no fresh
+            # regression": a subsystem holding at a degraded grade after a drop
+            # (or a no-data week, grade None) is still regressed.
+            if latest.get("grade") in _HEALTHY_GRADES:
+                clean_subs.add(sub)
             continue
 
         pid = _proposal_id(sub, period_end)
@@ -131,10 +139,8 @@ async def check_and_alert_regressions(
             )
             continue
 
-        # NOTE: the "Cognitive subsystem regression — {sub}:" prefix is a
-        # load-bearing format — the auto-clear pass below matches pending rows by
-        # it. No prescriptive remedy: the confidence framework forbids naming a
-        # fix before any investigation. The remedy is the user's call.
+        # No prescriptive remedy: the confidence framework forbids naming a fix
+        # before any investigation. The remedy is the user's call.
         text = (
             f"Cognitive subsystem regression — {sub}: {reason} "
             f"(week ending {period_end[:10]}). Investigate the {sub} pipeline."
@@ -165,6 +171,7 @@ async def check_and_alert_regressions(
                 db,
                 id=pid,
                 action_type=_J9_REGRESSION_ACTION_TYPE,
+                action_category=sub,
                 content=text,
                 rationale=(
                     "J-9 weekly eval flagged a cognitive-subsystem quality "
@@ -187,39 +194,16 @@ async def check_and_alert_regressions(
         )
 
     # Auto-clear: withdraw pending j9_regression rows for subsystems that have
-    # since recovered (latest grade no longer a regression). The row's premise —
-    # "this subsystem is regressed" — is now false, so it must not keep sitting
-    # as an informational item. Best-effort; a failure never blocks the check.
-    cleared = 0
-    if clean_subs:
-        try:
-            pending = await ego_crud.list_proposals(db, status="pending", limit=200)
-        except Exception:
-            logger.warning("j9 auto-clear: pending read failed", exc_info=True)
-            pending = []
-        for p in pending:
-            if p.get("action_type") != _J9_REGRESSION_ACTION_TYPE:
-                continue
-            content = p.get("content", "")
-            # Match the load-bearing content prefix written above.
-            matched = next(
-                (s for s in clean_subs if f"regression — {s}:" in content), None
-            )
-            if not matched:
-                continue
-            try:
-                ok = await ego_crud.resolve_proposal(
-                    db,
-                    p["id"],
-                    status="withdrawn",
-                    user_response=f"auto-cleared: {matched} grade recovered",
-                )
-                if ok:
-                    cleared += 1
-            except Exception:
-                logger.warning(
-                    "j9 auto-clear: withdraw failed for %s", p.get("id"), exc_info=True
-                )
+    # affirmatively recovered (healthy latest grade — see the _HEALTHY_GRADES
+    # gate above). Matched by the queryable action_category subject, not text.
+    from genesis.eval.regression_common import withdraw_recovered_proposals
+
+    cleared = await withdraw_recovered_proposals(
+        db,
+        action_type=_J9_REGRESSION_ACTION_TYPE,
+        recovered_subjects=clean_subs,
+        reason="grade recovered",
+    )
 
     if handled or cleared:
         logger.info(

--- a/src/genesis/eval/regression_alert.py
+++ b/src/genesis/eval/regression_alert.py
@@ -86,6 +86,9 @@ async def check_and_alert_regressions(
     the caller; per-subsystem failures are logged and skipped.
     """
     handled: list[dict] = []
+    # Subsystems whose latest weekly grade is NOT a regression → any pending
+    # j9_regression row for them is stale and gets auto-cleared below.
+    clean_subs: set[str] = set()
     try:
         grades = await j9_eval.get_latest_subsystem_grades(db, period_type="weekly")
     except Exception:
@@ -113,6 +116,7 @@ async def check_and_alert_regressions(
 
         reason = _regression_reason(latest, prior)
         if not reason:
+            clean_subs.add(sub)
             continue
 
         pid = _proposal_id(sub, period_end)
@@ -127,10 +131,13 @@ async def check_and_alert_regressions(
             )
             continue
 
+        # NOTE: the "Cognitive subsystem regression — {sub}:" prefix is a
+        # load-bearing format — the auto-clear pass below matches pending rows by
+        # it. No prescriptive remedy: the confidence framework forbids naming a
+        # fix before any investigation. The remedy is the user's call.
         text = (
             f"Cognitive subsystem regression — {sub}: {reason} "
-            f"(week ending {period_end[:10]}). Investigate the {sub} pipeline; "
-            f"candidate remedy: an Evo experiment on the {sub} config."
+            f"(week ending {period_end[:10]}). Investigate the {sub} pipeline."
         )
 
         # 1. BLOCKER alert (best-effort; governance dedups within 168h).
@@ -179,8 +186,45 @@ async def check_and_alert_regressions(
             {"subsystem": sub, "period_end": period_end, "reason": reason, "proposal_id": pid},
         )
 
-    if handled:
+    # Auto-clear: withdraw pending j9_regression rows for subsystems that have
+    # since recovered (latest grade no longer a regression). The row's premise —
+    # "this subsystem is regressed" — is now false, so it must not keep sitting
+    # as an informational item. Best-effort; a failure never blocks the check.
+    cleared = 0
+    if clean_subs:
+        try:
+            pending = await ego_crud.list_proposals(db, status="pending", limit=200)
+        except Exception:
+            logger.warning("j9 auto-clear: pending read failed", exc_info=True)
+            pending = []
+        for p in pending:
+            if p.get("action_type") != _J9_REGRESSION_ACTION_TYPE:
+                continue
+            content = p.get("content", "")
+            # Match the load-bearing content prefix written above.
+            matched = next(
+                (s for s in clean_subs if f"regression — {s}:" in content), None
+            )
+            if not matched:
+                continue
+            try:
+                ok = await ego_crud.resolve_proposal(
+                    db,
+                    p["id"],
+                    status="withdrawn",
+                    user_response=f"auto-cleared: {matched} grade recovered",
+                )
+                if ok:
+                    cleared += 1
+            except Exception:
+                logger.warning(
+                    "j9 auto-clear: withdraw failed for %s", p.get("id"), exc_info=True
+                )
+
+    if handled or cleared:
         logger.info(
-            "J9 regression check: %d subsystem regression(s) surfaced", len(handled),
+            "J9 regression check: %d regression(s) surfaced, %d stale row(s) cleared",
+            len(handled),
+            cleared,
         )
     return handled

--- a/src/genesis/eval/regression_common.py
+++ b/src/genesis/eval/regression_common.py
@@ -1,0 +1,79 @@
+"""Shared helpers for eval-sourced informational proposals (j9 / gauntlet).
+
+Both J-9 subsystem-grade regressions and model-roster gauntlet regressions file
+acknowledge-only ``ego_proposals`` rows and later auto-clear them when the
+subject recovers. This module owns the single clear implementation so the two
+writers cannot drift (their sibling alert+propose halves already did — see the
+``gauntlet_regression`` module docstring).
+
+Subject identity is the queryable ``action_category`` column (set at file time),
+NOT free-text ``content`` — a reword of the alert copy can never silently break
+recovery-clearing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from genesis.db.crud import ego as ego_crud
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def withdraw_recovered_proposals(
+    db: aiosqlite.Connection,
+    *,
+    action_type: str,
+    recovered_subjects: set[str],
+    reason: str,
+) -> int:
+    """Withdraw pending *action_type* rows whose subject has recovered.
+
+    A row's subject is its ``action_category`` (e.g. the subsystem name for j9,
+    the model id for gauntlet). Rows whose subject is in *recovered_subjects* are
+    moved to ``withdrawn`` with ``user_response = "auto-cleared: <subject>
+    <reason>"``. Iterates the UNBOUNDED, oldest-first ``list_pending_proposals``
+    (stale rows awaiting clear are the oldest — a capped newest-first scan would
+    drop exactly them). Best-effort: never raises into the caller.
+
+    Legacy rows filed before this column was populated have an empty
+    ``action_category`` and are intentionally left for the 14-day auto-table —
+    never matched by free-text content here.
+
+    Returns the number of rows withdrawn.
+    """
+    if not recovered_subjects:
+        return 0
+    try:
+        pending = await ego_crud.list_pending_proposals(db)
+    except Exception:
+        logger.warning("%s auto-clear: pending read failed", action_type, exc_info=True)
+        return 0
+    cleared = 0
+    for p in pending:
+        if p.get("action_type") != action_type:
+            continue
+        subject = p.get("action_category") or ""
+        if subject not in recovered_subjects:
+            continue
+        try:
+            ok = await ego_crud.resolve_proposal(
+                db,
+                p["id"],
+                status="withdrawn",
+                user_response=f"auto-cleared: {subject} {reason}",
+            )
+            if ok:
+                cleared += 1
+        except Exception:
+            logger.warning(
+                "%s auto-clear: withdraw failed for %s",
+                action_type,
+                p.get("id"),
+                exc_info=True,
+            )
+    return cleared

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -401,7 +401,11 @@ class MorningReportGenerator:
             logger.warning("Ground truth: follow-up counts failed", exc_info=True)
 
         try:
-            proposals = await ego_crud.list_pending_proposals(self._db)
+            from genesis.ego.types import partition_informational
+
+            raw_props = await ego_crud.list_pending_proposals(self._db)
+            # Informational eval rows (j9/gauntlet) aren't approval work.
+            proposals, _informational = partition_informational(raw_props)
             lines.append(f"- Pending ego proposals: {len(proposals)}")
         except Exception:
             logger.warning("Ground truth: proposal count failed", exc_info=True)
@@ -716,7 +720,11 @@ class MorningReportGenerator:
 
         # Pending ego proposals (user needs to approve/reject on dashboard)
         try:
-            proposals = await ego_crud.list_pending_proposals(self._db)
+            from genesis.ego.types import partition_informational
+
+            raw_props = await ego_crud.list_pending_proposals(self._db)
+            # Informational eval rows (j9/gauntlet) aren't approve/reject work.
+            proposals, _informational = partition_informational(raw_props)
             total_proposals = len(proposals)
             proposals = proposals[:5]
             if proposals:

--- a/tests/ego/test_informational_lane.py
+++ b/tests/ego/test_informational_lane.py
@@ -55,3 +55,43 @@ def test_partition_missing_action_type_is_approval():
     approval, informational = partition_informational([{"id": "x"}])
     assert [p["id"] for p in approval] == ["x"]
     assert informational == []
+
+
+async def test_bulk_approve_all_pending_skips_informational():
+    """`approve all pending` (cross-batch resolve) must not sweep acknowledge-only
+    eval rows into a resolution."""
+    import aiosqlite
+
+    from genesis.db.crud import ego as ego_crud
+    from genesis.db.schema import create_all_tables
+    from genesis.ego.proposals import ProposalWorkflow
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    await ego_crud.create_proposal(
+        conn,
+        id="real1",
+        action_type="investigate",
+        content="real proposal",
+        batch_id="batch_a",
+    )
+    await ego_crud.create_proposal(
+        conn,
+        id="j9a",
+        action_type="j9_regression",
+        action_category="memory",
+        content="eval notice",
+        ego_source="j9_eval",
+    )
+    try:
+        results = await ProposalWorkflow(db=conn).resolve_all_pending_proposals(
+            "approved",
+        )
+        assert "real1" in results
+        assert "j9a" not in results
+        assert (await ego_crud.get_proposal(conn, "real1"))["status"] == "approved"
+        # Informational row untouched — still pending, never acknowledged.
+        assert (await ego_crud.get_proposal(conn, "j9a"))["status"] == "pending"
+    finally:
+        await conn.close()

--- a/tests/ego/test_informational_lane.py
+++ b/tests/ego/test_informational_lane.py
@@ -1,0 +1,57 @@
+"""Informational proposal lane — acknowledge-only eval rows are not approvals.
+
+Covers the shared taxonomy (INFORMATIONAL_ACTION_TYPES / is_informational /
+partition_informational) and its invariants against the dispatch blocklist.
+"""
+
+from genesis.ego.session import _NEVER_DISPATCH_ACTION_TYPES
+from genesis.ego.types import (
+    INFORMATIONAL_ACTION_TYPES,
+    is_informational,
+    partition_informational,
+)
+
+
+def test_informational_set_contents():
+    assert set(INFORMATIONAL_ACTION_TYPES) == {"j9_regression", "gauntlet_regression"}
+
+
+def test_is_informational():
+    assert is_informational("j9_regression") is True
+    assert is_informational("gauntlet_regression") is True
+    assert is_informational("investigate") is False
+    assert is_informational("cell_promotion") is False  # decision-carrying
+    assert is_informational(None) is False
+
+
+def test_informational_is_strict_subset_of_never_dispatch():
+    """Every informational type is never-dispatch, but not vice-versa —
+    decision-carrying types (cell_promotion, autonomy_earnback, …) are
+    never-dispatch yet still belong on the approval queue."""
+    info = set(INFORMATIONAL_ACTION_TYPES)
+    never = set(_NEVER_DISPATCH_ACTION_TYPES)
+    assert info < never  # strict subset
+    assert {"cell_promotion", "autonomy_earnback"} <= (never - info)
+
+
+def test_partition_preserves_order_and_splits():
+    proposals = [
+        {"id": "a", "action_type": "investigate"},
+        {"id": "b", "action_type": "j9_regression"},
+        {"id": "c", "action_type": "maintenance"},
+        {"id": "d", "action_type": "gauntlet_regression"},
+    ]
+    approval, informational = partition_informational(proposals)
+    assert [p["id"] for p in approval] == ["a", "c"]
+    assert [p["id"] for p in informational] == ["b", "d"]
+
+
+def test_partition_empty():
+    assert partition_informational([]) == ([], [])
+
+
+def test_partition_missing_action_type_is_approval():
+    # A row with no action_type is not informational → stays an approval item.
+    approval, informational = partition_informational([{"id": "x"}])
+    assert [p["id"] for p in approval] == ["x"]
+    assert informational == []

--- a/tests/test_dashboard/test_informational_lane_routes.py
+++ b/tests/test_dashboard/test_informational_lane_routes.py
@@ -1,0 +1,144 @@
+"""E2E (HTTP-layer) tests for the informational-proposal lane on the ego routes.
+
+Drives the real Flask route handlers with the DB layer patched to return a mix
+of approval + acknowledge-only (j9/gauntlet) pending rows, and asserts the split.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _rt():
+    rt = MagicMock()
+    rt.is_bootstrapped = True
+    rt._db = MagicMock()
+    return rt
+
+
+def _row(id_, action_type, ego_source, status="pending"):
+    return {
+        "id": id_,
+        "action_type": action_type,
+        "action_category": "",
+        "content": f"content-{id_}",
+        "rationale": "why",
+        "confidence": 0.8,
+        "urgency": "normal",
+        "status": status,
+        "created_at": "2026-07-22T10:00:00Z",
+        "expires_at": None,
+        "rank": None,
+        "execution_plan": None,
+        "recurring": 0,
+        "ego_source": ego_source,
+        "realist_verdict": None,
+    }
+
+
+# One real approval proposal + two acknowledge-only eval rows.
+_MIXED = [
+    _row("real1", "investigate", "genesis_ego_cycle"),
+    _row("j9a", "j9_regression", "j9_eval"),
+    _row("gaunt", "gauntlet_regression", "gauntlet"),
+]
+
+
+class TestEgoProposalsExcludesInformational:
+    def test_proposals_endpoint_hides_informational(self, client):
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.ego.list_pending_proposals",
+                new_callable=AsyncMock,
+                return_value=list(_MIXED),
+            ),
+        ):
+            MockRT.instance.return_value = _rt()
+            resp = client.get("/api/genesis/ego/proposals")
+            data = resp.get_json()
+            ids = [p["id"] for p in data]
+            assert ids == ["real1"]  # eval rows excluded from approval list
+
+
+class TestEgoInformationalEndpoint:
+    def test_informational_endpoint_returns_only_eval(self, client):
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.ego.list_pending_proposals",
+                new_callable=AsyncMock,
+                return_value=list(_MIXED),
+            ),
+        ):
+            MockRT.instance.return_value = _rt()
+            resp = client.get("/api/genesis/ego/informational")
+            data = resp.get_json()
+            ids = sorted(p["id"] for p in data)
+            assert ids == ["gaunt", "j9a"]
+
+    def test_informational_empty_when_not_bootstrapped(self, client):
+        rt = _rt()
+        rt.is_bootstrapped = False
+        with patch("genesis.runtime.GenesisRuntime") as MockRT:
+            MockRT.instance.return_value = rt
+            resp = client.get("/api/genesis/ego/informational")
+            assert resp.get_json() == []
+
+
+class TestEgoStatusCounts:
+    def test_pending_count_excludes_informational(self, client):
+        rt = _rt()
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.ego.list_pending_proposals",
+                new_callable=AsyncMock,
+                return_value=list(_MIXED),
+            ),
+            patch("genesis.db.crud.ego.daily_ego_cost", new_callable=AsyncMock, return_value=0.0),
+            patch("genesis.db.crud.ego.get_state", new_callable=AsyncMock, return_value=""),
+            patch(
+                "genesis.db.crud.ego.list_recent_cycles", new_callable=AsyncMock, return_value=[]
+            ),
+            patch("genesis.db.crud.ego.count_uncompacted", new_callable=AsyncMock, return_value=0),
+            patch(
+                "genesis.db.crud.ego.daily_dispatch_cost", new_callable=AsyncMock, return_value=0.0
+            ),
+            patch(
+                "genesis.db.crud.ego.rolling_daily_ego_cost",
+                new_callable=AsyncMock,
+                return_value=0.0,
+            ),
+            patch(
+                "genesis.db.crud.ego.has_pending_cli_approval",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            rt._ego_cadence_manager = None
+            rt._genesis_ego_cadence_manager = None
+            MockRT.instance.return_value = rt
+            resp = client.get("/api/genesis/ego/status")
+            data = resp.get_json()
+            # 3 pending rows in, but only the 1 approval item counts as pending.
+            assert data["pending_proposals"] == 1
+            assert data["informational_count"] == 2

--- a/tests/test_eval/test_gauntlet.py
+++ b/tests/test_eval/test_gauntlet.py
@@ -345,6 +345,7 @@ async def _db_with_pending_gauntlet(model: str):
         conn,
         id="p1",
         action_type="gauntlet_regression",
+        action_category=model,
         content=(
             f"Model-roster gauntlet regression — {model}: previously PASSED, "
             f"now FAILED 1/2 fixtures."

--- a/tests/test_eval/test_gauntlet.py
+++ b/tests/test_eval/test_gauntlet.py
@@ -326,3 +326,89 @@ async def test_regression_idempotent_when_proposal_exists(monkeypatch):
     assert reg is None
     assert create_calls == []
     assert pipe.alerts == []
+
+
+# ---- PR-1: auto-clear a pending gauntlet row when the model recovers ----
+
+
+async def _db_with_pending_gauntlet(model: str):
+    """In-memory DB seeded with one pending gauntlet_regression row for *model*."""
+    import aiosqlite
+
+    from genesis.db.crud import ego as ego_crud
+    from genesis.db.schema import create_all_tables
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    await ego_crud.create_proposal(
+        conn,
+        id="p1",
+        action_type="gauntlet_regression",
+        content=(
+            f"Model-roster gauntlet regression — {model}: previously PASSED, "
+            f"now FAILED 1/2 fixtures."
+        ),
+        rationale="advisory",
+        confidence=1.0,
+        urgency="high",
+        status="pending",
+        ego_source="gauntlet",
+    )
+    return conn
+
+
+async def test_genuine_pass_auto_clears_pending_gauntlet():
+    from genesis.db.crud import ego as ego_crud
+
+    model = "glm-5.2"
+    conn = await _db_with_pending_gauntlet(model)
+    try:
+        # A genuine PASS (green, not all-skipped) is a recovery.
+        reg = await GR.check_gauntlet_regression(
+            db=conn,
+            summary=_summary(model, "run2", passed=3, failed=0),
+            outreach_pipeline=None,
+        )
+        assert reg is None
+        prop = await ego_crud.get_proposal(conn, "p1")
+        assert prop["status"] == "withdrawn"
+        assert "auto-cleared" in (prop["user_response"] or "")
+    finally:
+        await conn.close()
+
+
+async def test_all_skipped_does_not_clear_pending_gauntlet():
+    from genesis.db.crud import ego as ego_crud
+
+    model = "glm-5.2"
+    conn = await _db_with_pending_gauntlet(model)
+    try:
+        # Inconclusive (all skipped) → NOT a recovery, must not clear.
+        reg = await GR.check_gauntlet_regression(
+            db=conn,
+            summary=_summary(model, "run2", passed=0, failed=0, skipped=3),
+            outreach_pipeline=None,
+        )
+        assert reg is None
+        prop = await ego_crud.get_proposal(conn, "p1")
+        assert prop["status"] == "pending"  # untouched
+    finally:
+        await conn.close()
+
+
+async def test_pass_only_clears_matching_model():
+    from genesis.db.crud import ego as ego_crud
+
+    conn = await _db_with_pending_gauntlet("glm-5.2")
+    try:
+        # A different model passing must not clear glm-5.2's row.
+        await GR.check_gauntlet_regression(
+            db=conn,
+            summary=_summary("other-model", "run2", passed=3, failed=0),
+            outreach_pipeline=None,
+        )
+        prop = await ego_crud.get_proposal(conn, "p1")
+        assert prop["status"] == "pending"
+    finally:
+        await conn.close()

--- a/tests/test_eval/test_regression_alert.py
+++ b/tests/test_eval/test_regression_alert.py
@@ -148,3 +148,56 @@ async def test_week_over_week_drop_surfaces(db):
 
     assert len(handled) == 1
     assert "dropped" in handled[0]["reason"]
+
+
+# ── PR-1: no prescriptive remedy + auto-clear on recovery ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_proposal_text_has_no_prescriptive_remedy(db):
+    """The confidence framework forbids naming a fix before investigation —
+    the surfaced text must not prescribe an Evo experiment."""
+    await _grade(db, "memory", "F", 55.0, "2026-06-22T00:00:00Z")
+
+    await check_and_alert_regressions(db, None)
+
+    pid = _proposal_id("memory", "2026-06-22T00:00:00Z")
+    prop = await ego_crud.get_proposal(db, pid)
+    assert "Evo experiment" not in prop["content"]
+    assert "candidate remedy" not in prop["content"]
+    assert "Investigate the memory pipeline" in prop["content"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_auto_clears_stale_pending(db):
+    """A subsystem that regressed then recovered → its stale pending row is
+    auto-withdrawn (its premise is now false)."""
+    # Week 1: memory F → proposal filed, pending.
+    await _grade(db, "memory", "F", 55.0, "2026-06-15T00:00:00Z")
+    handled = await check_and_alert_regressions(db, None)
+    assert len(handled) == 1
+    pid = _proposal_id("memory", "2026-06-15T00:00:00Z")
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"
+
+    # Week 2: memory recovers to B → stale week-1 row auto-clears.
+    await _grade(db, "memory", "B", 84.0, "2026-06-22T00:00:00Z")
+    handled2 = await check_and_alert_regressions(db, None)
+    assert handled2 == []  # no new regression
+
+    prop = await ego_crud.get_proposal(db, pid)
+    assert prop["status"] == "withdrawn"
+    assert "auto-cleared" in (prop["user_response"] or "")
+
+
+@pytest.mark.asyncio
+async def test_still_regressed_does_not_auto_clear(db):
+    """A subsystem still at F does NOT get its pending row cleared."""
+    await _grade(db, "memory", "F", 55.0, "2026-06-15T00:00:00Z")
+    await check_and_alert_regressions(db, None)
+    pid = _proposal_id("memory", "2026-06-15T00:00:00Z")
+
+    # Week 2: still F (new period) → new row filed, old stays pending (not cleared).
+    await _grade(db, "memory", "F", 52.0, "2026-06-22T00:00:00Z")
+    await check_and_alert_regressions(db, None)
+
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"

--- a/tests/test_eval/test_regression_alert.py
+++ b/tests/test_eval/test_regression_alert.py
@@ -201,3 +201,48 @@ async def test_still_regressed_does_not_auto_clear(db):
     await check_and_alert_regressions(db, None)
 
     assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_no_data_week_does_not_clear(db):
+    """An insufficient-data week (grade None) is unknown, not recovered — the
+    standing row must NOT be auto-cleared."""
+    await _grade(db, "memory", "F", 55.0, "2026-06-15T00:00:00Z")
+    await check_and_alert_regressions(db, None)
+    pid = _proposal_id("memory", "2026-06-15T00:00:00Z")
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"
+
+    # Next week: grade None (too few samples) — premise unknown, not disproven.
+    await _grade(db, "memory", None, None, "2026-06-22T00:00:00Z")
+    await check_and_alert_regressions(db, None)
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_dropped_then_stable_does_not_clear(db):
+    """A delta-drop row must NOT auto-clear just because there's no FRESH drop —
+    a subsystem holding at a degraded grade is still regressed."""
+    # A(90) → C(70) is a >=15pt drop → files a delta-drop row.
+    await _grade(db, "memory", "A", 90.0, "2026-06-08T00:00:00Z")
+    await _grade(db, "memory", "C", 70.0, "2026-06-15T00:00:00Z")
+    handled = await check_and_alert_regressions(db, None)
+    assert len(handled) == 1
+    pid = _proposal_id("memory", "2026-06-15T00:00:00Z")
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"
+
+    # Next week holds at C — no fresh drop, but grade C is NOT healthy → the row
+    # stays standing (the bug was clearing it here as "recovered").
+    await _grade(db, "memory", "C", 70.0, "2026-06-22T00:00:00Z")
+    await check_and_alert_regressions(db, None)
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_filed_row_carries_subsystem_in_action_category(db):
+    """The subject key that auto-clear matches on is the queryable
+    action_category column, not free-text content."""
+    await _grade(db, "memory", "F", 55.0, "2026-06-22T00:00:00Z")
+    await check_and_alert_regressions(db, None)
+    pid = _proposal_id("memory", "2026-06-22T00:00:00Z")
+    prop = await ego_crud.get_proposal(db, pid)
+    assert prop["action_category"] == "memory"


### PR DESCRIPTION
## Summary

First PR in the ego proposal-lifecycle redesign. J-9 subsystem-grade and model-roster gauntlet regressions file **acknowledge-only** `ego_proposals` rows (idempotency markers) — but they were rendered as approvable, mislabeled a bare "Ego", counted toward the ego's pending-proposal cap (where a burst could auto-table real proposals), and surfaced as approve/reject work in the morning report. This PR gives them a proper informational lane.

## What changed

- **Single source of truth** — `INFORMATIONAL_ACTION_TYPES` + `is_informational` / `partition_informational` in `ego/types.py`. `session._NEVER_DISPATCH_ACTION_TYPES` derives its two informational members from it (strict superset — decision-carrying never-dispatch types stay on the approval queue).
- **Dashboard** — informational rows excluded from pending-approval counts/lists and the needs-action banner, in both the pending and history views; rendered in a read-only "Informational" strip on the comms tab; new `/api/genesis/ego/informational` endpoint. Source badge maps `j9_eval`→"Eval", `gauntlet`→"Gauntlet" (shared `egoSourceLabel`) — never a bare "Ego".
- **Other approval surfaces** — the ego pending-cap, Telegram digest backlog, morning report (×2), and the Telegram bare-approval re-propose path all exclude informational rows.
- **Auto-clear on recovery** — a j9 subsystem whose latest weekly grade is **affirmatively healthy** (A/B — not merely "no fresh regression"), or a gauntlet model that passes again, has its stale pending row withdrawn. Subject identity is the queryable `action_category` column (set at file time) matched by equality via one shared helper (`eval/regression_common.py`), on the unbounded oldest-first `list_pending_proposals` — no fragile content parsing, no silent cap.
- **Confidence framework** — dropped the pre-baked "candidate remedy: an Evo experiment" from the j9 text (no prescribing a fix before investigation).

## Review

High-effort multi-agent review (3 finder angles → verify) surfaced 7 findings — all fixed in the second commit: j9 false-recovery on no-data/stable weeks, a silent 200-row newest-first cap that dropped exactly the stale rows, the content-substring fragility (→ `action_category` equality), the comms 'all'-view leak, and two missed approval surfaces (morning report, Telegram re-propose).

## Verification

- 82 targeted tests green: informational-lane taxonomy + invariants; j9 remedy-removal, healthy-grade recovery, no-data/dropped-then-stable no-clear, `action_category` subject key; gauntlet genuine-pass clears / all-skipped doesn't / only-matching-model; **HTTP-layer E2E** driving the real Flask handlers (`/ego/proposals`, `/ego/informational`, `/ego/status`) for the split + counts.
- Browser rendering of the new strip is deferred to post-deploy (git pull + server restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)