### PR TITLE
fix(memory): degraded-recall banner names the real cause, not always "unreachable"

### DIFF
--- a/.claude/docs/proactive-memory-hook.md
+++ b/.claude/docs/proactive-memory-hook.md
@@ -54,7 +54,14 @@ local genesis-server; override it if you run the server on a non-default port.
 
 On any server failure (connection refused, timeout, non-200, bad JSON) the hook
 falls back to a **keyword-only FTS5 search** of `episodic_memory` and prints a
-visible banner + `[Memory·degraded | …]` tags. The fallback does **no**
+visible banner + `[Memory·degraded | …]` tags. The banner **names the actual
+cause** rather than always saying "unreachable": a genuinely down/restarting
+server (connection refused / connect timeout) reads `genesis-server unreachable`,
+while a *reachable* server that returned a 503 (recall over its 4.5s budget or
+still booting), timed out, or errored reads `server returned HTTP 503
+(reachable …)` / `recall timed out … (server reachable …)`. This stops a slow-or-
+busy recall from being mislabeled as a dead server (and from masking the latency
+signal). The fallback does **no**
 write-backs, but it still re-applies the external-world provenance label
 (`Memory·external`) and emits the gate-4 injection-shadow record for any
 blockable content it injects locally — the same injection-defense invariant the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,8 +209,10 @@ index. If this answers "what are we working on," don't burn a recall.
 The UserPromptSubmit hook delegates recall to the genesis-server engine
 (`POST /api/genesis/hook/recall` — FTS5 + vector + reranker + graph expansion +
 injection defense) and injects `[Memory | age | wing | id:xxx]` tags. If the
-server is unreachable it degrades to a clearly-labelled keyword-only FTS5 search
-(`[Memory·degraded …]`) and self-heals next prompt; `GENESIS_PROACTIVE_HOOK_MODE`
+server is unavailable (unreachable, over its 4.5s budget/503, timed out, or
+erroring) it degrades to a clearly-labelled keyword-only FTS5 search whose banner
+names the actual cause (`[Memory·degraded …]`) and self-heals next prompt;
+`GENESIS_PROACTIVE_HOOK_MODE`
 (`server`/`local`/`off`) gates it. See `.claude/docs/proactive-memory-hook.md`.
 Check these first before doing explicit recall. Ranking comes from the server
 engine (reranker + fusion + intent-aware budget); the fork's old wing 1.5× boost

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -983,18 +983,50 @@ def _ensure_knowledge_retrieved_count(db_path: Path) -> None:
         pass  # Never block
 
 
+def _server_failure_reason(
+    *, status: int | None = None, detail: str = "", exc: BaseException | None = None
+) -> str:
+    """Human-readable cause for the degraded banner.
+
+    Distinguishes a genuinely unreachable server (connection refused / connect
+    timeout — e.g. mid-restart) from a server that IS reachable but whose recall
+    call failed or ran past its 4.5s budget (a 503 / read-timeout). Calling the
+    latter "unreachable" both misleads and masks the real latency story, so the
+    banner names the actual cause instead.
+    """
+    import httpx
+
+    if exc is not None:
+        # ConnectTimeout is ALSO a TimeoutException, so the connect cases must be
+        # tested before the generic timeout branch or a failed connect would be
+        # mislabeled as a slow-but-reachable recall.
+        if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout)):
+            return "genesis-server unreachable (connection refused — likely restarting or down)"
+        if isinstance(exc, httpx.TimeoutException):
+            return f"recall timed out after {_SERVER_TIMEOUT_S:g}s (server reachable, under load)"
+        return "recall call failed (server reachable)"
+    if status is not None and status != 200:
+        base = f"server returned HTTP {status} (reachable"
+        if status == 503:
+            base += ", over budget or still booting"
+        base += ")"
+        return f"{base}: {detail}" if detail else base
+    return "genesis-server unavailable"
+
+
 async def _call_server(
     prompt: str,
     session_id: str,
     file_keywords: list[str],
     suppress_ids: frozenset[str],
-) -> dict | None:
+) -> tuple[dict | None, str | None]:
     """POST the prompt to the genesis-server proactive recall endpoint.
 
-    Returns the parsed JSON dict on a 200 (status ``ok`` or ``disabled``), or
-    None on ANY failure (connection refused, timeout, non-200, bad JSON) so the
-    caller falls back to the degraded FTS5 path. Never raises — a down or slow
-    server must never block the user's prompt.
+    Returns ``(data, None)`` with the parsed JSON dict on a 200 (status ``ok`` or
+    ``disabled``), or ``(None, reason)`` on ANY failure — where ``reason`` is a
+    short human-readable cause (see :func:`_server_failure_reason`) used for the
+    degraded banner. The caller falls back to the degraded FTS5 path either way.
+    Never raises — a down or slow server must never block the user's prompt.
     """
     import httpx
 
@@ -1015,32 +1047,45 @@ async def _call_server(
         async with httpx.AsyncClient(timeout=timeout, trust_env=False) as client:
             resp = await client.post(_RECALL_ENDPOINT, json=payload)
         if resp.status_code != 200:
-            return None
+            detail = ""
+            try:
+                body = resp.json()
+                if isinstance(body, dict) and isinstance(body.get("error"), str):
+                    detail = body["error"]
+            except Exception:
+                pass
+            return None, _server_failure_reason(status=resp.status_code, detail=detail)
         data = resp.json()
-        return data if isinstance(data, dict) else None
-    except Exception:
-        return None
+        if isinstance(data, dict):
+            return data, None
+        return None, "server returned an unexpected (non-dict) response"
+    except Exception as exc:
+        return None, _server_failure_reason(exc=exc)
 
 
-def _format_degraded(results: list[dict], *, forced_local: bool = False) -> str:
+def _format_degraded(
+    results: list[dict], *, forced_local: bool = False, reason: str | None = None
+) -> str:
     """Render FTS5/code fallback hits with a visible degraded marker.
 
     Used ONLY when the server recall path is unavailable (server down/slow) or
     deliberately bypassed (``GENESIS_PROACTIVE_HOOK_MODE=local``). Reuses the
     offline SQLite enrichment (_enrich_with_metadata) + age formatting, but tags
     every line ``[Memory·degraded | …]`` so the model knows this is keyword-only
-    recall, not the full engine. No write-backs happen on this path.
+    recall, not the full engine. ``reason`` names the actual server-path failure
+    (unreachable vs reachable-but-slow/errored) so the banner never mislabels a
+    503/timeout as "unreachable". No write-backs happen on this path.
     """
     if not results:
         return ""
     _enrich_with_metadata(results)
     from genesis.security.sanitizer import strip_boundary_markers
 
-    banner = (
-        "[Memory recall in local keyword-only mode (GENESIS_PROACTIVE_HOOK_MODE=local)]"
-        if forced_local
-        else "[Memory recall degraded — genesis-server unreachable; keyword-only results]"
-    )
+    if forced_local:
+        banner = "[Memory recall in local keyword-only mode (GENESIS_PROACTIVE_HOOK_MODE=local)]"
+    else:
+        cause = reason or "genesis-server unavailable"
+        banner = f"[Memory recall degraded — {cause}; keyword-only results]"
     lines = [banner]
     for rank, r in enumerate(results):
         max_len = 300 if rank == 0 else 200
@@ -1384,9 +1429,12 @@ async def _run(prompt: str, session_id: str = "") -> None:
     # ── Delegated recall: server engine (default) with FTS5 fallback ─
     server_data: dict | None = None
     server_ms: float | None = None
+    server_reason: str | None = None
     if _HOOK_MODE != "local":
         _t_srv = time.monotonic()
-        server_data = await _call_server(prompt, session_id, file_keywords, suppress_ids)
+        server_data, server_reason = await _call_server(
+            prompt, session_id, file_keywords, suppress_ids
+        )
         server_ms = (time.monotonic() - _t_srv) * 1000
 
     if server_data is not None:
@@ -1486,7 +1534,9 @@ async def _run(prompt: str, session_id: str = "") -> None:
         fused += code_results[: _MAX_RESULTS - len(fused)]
 
     if fused:
-        output = _format_degraded(fused, forced_local=(fallback_mode == "local"))
+        output = _format_degraded(
+            fused, forced_local=(fallback_mode == "local"), reason=server_reason
+        )
         if output:
             print(output)
             sys.stdout.flush()

--- a/tests/test_learning/test_proactive_hook_degraded_banner.py
+++ b/tests/test_learning/test_proactive_hook_degraded_banner.py
@@ -1,0 +1,102 @@
+"""Unit tests for the degraded-banner cause attribution in the proactive hook.
+
+Regression guard for the "genesis-server unreachable" mislabel: the hook used to
+print *unreachable* for every server-path failure, including a reachable server
+that merely returned a 503 (recall over its 4.5s budget) or was slow. These pin
+that ``_server_failure_reason`` distinguishes a truly unreachable server
+(connection refused / connect timeout) from a reachable-but-failing one, and that
+``_format_degraded`` surfaces that cause in the banner instead of a blanket
+"unreachable".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_REPO_DIR = Path(__file__).resolve().parent.parent.parent
+_SCRIPTS_DIR = _REPO_DIR / "scripts"
+_SRC_DIR = _REPO_DIR / "src"
+for _p in (_SCRIPTS_DIR, _SRC_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import proactive_memory_hook as hook  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [httpx.ConnectError("connection refused"), httpx.ConnectTimeout("connect timed out")],
+)
+def test_reason_connect_failures_are_unreachable(exc: Exception):
+    """Connection refused / connect-timeout are the ONLY truly-unreachable cases.
+
+    ConnectTimeout is also an httpx.TimeoutException, so this pins that it is
+    classified as unreachable (connect branch checked first), not as a slow recall.
+    """
+    reason = hook._server_failure_reason(exc=exc)
+    assert "unreachable" in reason
+    assert "connection refused" in reason
+
+
+def test_reason_read_timeout_is_reachable_not_unreachable():
+    reason = hook._server_failure_reason(exc=httpx.ReadTimeout("read timed out"))
+    assert "unreachable" not in reason
+    assert "timed out" in reason and "reachable" in reason
+
+
+def test_reason_503_is_reachable_over_budget():
+    reason = hook._server_failure_reason(status=503, detail="recall over budget")
+    assert "unreachable" not in reason
+    assert "503" in reason and "reachable" in reason
+    assert "recall over budget" in reason  # server-provided detail is surfaced
+
+
+def test_reason_500_is_reachable():
+    reason = hook._server_failure_reason(status=500)
+    assert "unreachable" not in reason
+    assert "500" in reason and "reachable" in reason
+
+
+def test_reason_generic_exception_is_reachable():
+    reason = hook._server_failure_reason(exc=ValueError("boom"))
+    assert "unreachable" not in reason
+    assert "reachable" in reason
+
+
+def test_banner_503_says_reachable_not_unreachable():
+    """The core fix: a reachable-but-503 recall must NOT print 'unreachable'."""
+    results = [{"memory_id": "abc12345", "content": "a recalled fact"}]
+    reason = hook._server_failure_reason(status=503, detail="recall over budget")
+    out = hook._format_degraded(results, reason=reason)
+    banner = out.splitlines()[0]
+    assert banner.startswith("[Memory recall degraded — ")
+    assert "unreachable" not in banner
+    assert "503" in banner and "reachable" in banner
+
+
+def test_banner_unreachable_reason_preserved():
+    """A genuinely unreachable server still reads 'unreachable' (unchanged path)."""
+    results = [{"memory_id": "abc12345", "content": "a recalled fact"}]
+    reason = hook._server_failure_reason(exc=httpx.ConnectError("refused"))
+    banner = hook._format_degraded(results, reason=reason).splitlines()[0]
+    assert "unreachable" in banner
+
+
+def test_banner_forced_local_is_unchanged():
+    """GENESIS_PROACTIVE_HOOK_MODE=local uses its own banner, ignoring reason."""
+    results = [{"memory_id": "abc12345", "content": "a recalled fact"}]
+    banner = hook._format_degraded(results, forced_local=True, reason="ignored").splitlines()[0]
+    assert "local keyword-only mode" in banner
+    assert "degraded" not in banner
+
+
+def test_banner_none_reason_falls_back_safely():
+    """A missing reason (defensive) still yields a coherent, non-crashing banner."""
+    results = [{"memory_id": "abc12345", "content": "a recalled fact"}]
+    banner = hook._format_degraded(results, reason=None).splitlines()[0]
+    assert banner.startswith("[Memory recall degraded — ")
+    assert "genesis-server unavailable" in banner

--- a/tests/test_learning/test_proactive_hook_subprocess.py
+++ b/tests/test_learning/test_proactive_hook_subprocess.py
@@ -321,6 +321,34 @@ def test_server_down_falls_back_to_fts5(fts_db: Path, tmp_path: Path):
     assert m["fts_only_fallback"] is True
 
 
+def test_server_503_banner_says_reachable_not_unreachable(fts_db: Path, tmp_path: Path):
+    """A REACHABLE server returning 503 (recall over its 4.5s budget) must fall back
+    with a banner that names the real cause — HTTP 503, server reachable — and must
+    NOT mislabel it 'unreachable'. Regression guard for the blanket-'unreachable' bug.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    with _stub_server({"error": "recall over budget"}, status=503) as base_url:
+        result = _run_hook(
+            _PROMPT,
+            _SESSION,
+            {
+                "GENESIS_DB_PATH": str(fts_db),
+                "GENESIS_PROACTIVE_HOOK_URL": base_url,
+                "GENESIS_PROACTIVE_HOOK_MODE": "server",
+            },
+            home,
+        )
+    assert result.returncode == 0, result.stderr[:2000]
+    out = result.stdout
+    assert "Memory recall degraded" in out
+    assert "unreachable" not in out  # the fix: a reachable 503 is not "unreachable"
+    assert "503" in out and "reachable" in out
+    assert f"id:{_FTS_ID[:8]}" in out  # FTS5 fallback still surfaced
+    m = _metrics(home)
+    assert m["mode"] == "degraded"
+
+
 def test_mode_off_no_recall(fts_db: Path, tmp_path: Path):
     """GENESIS_PROACTIVE_HOOK_MODE=off → no memory recall (no server, no FTS5)."""
     home = tmp_path / "home"


### PR DESCRIPTION
## Problem
The proactive-memory hook (`scripts/proactive_memory_hook.py`) POSTs each prompt to the server recall endpoint and, on any failure, prints a degraded FTS5 banner. That banner **always** said *"genesis-server unreachable"* — even when the server was up and merely returned a **503** (recall exceeded its 4.5s budget or was still booting) or timed out. This mislabels a slow/busy-but-reachable server as *down*, and masks the real latency signal (the very 503s the recall-latency series targets). The endpoint (`dashboard/routes/proactive.py`, `@_async_route(timeout=4.5)`) returns 503 on budget-expiry/booting and 500 on error, so "server up but recall failed" is the common case — and it was the one being mislabeled.

## Fix
`_call_server` now returns the **failure cause** alongside the (absent) data, and the banner names it:

| Cause | Banner |
|---|---|
| connection refused / connect timeout | `genesis-server unreachable (connection refused — likely restarting or down)` |
| HTTP 503 | `server returned HTTP 503 (reachable, over budget or still booting)` |
| read timeout | `recall timed out after 4.75s (server reachable, under load)` |
| other 5xx / exception | `recall … failed (server reachable)` |

Failure→degraded **control flow is unchanged** — only the message differs. The forced-local banner and the per-line `[Memory·degraded | …]` tags are untouched.

## Changes
- New pure `_server_failure_reason(*, status, detail, exc)` classifier (httpx exc / HTTP status → phrase). `ConnectTimeout` is grouped with `ConnectError` **before** the generic `TimeoutException` branch (it subclasses both).
- `_call_server`: `dict | None` → `tuple[dict | None, str | None]`; on a non-200 it best-effort surfaces the server's `error` detail. Sole caller (`_run`) updated.
- `_format_degraded` gains a `reason` param.
- Tests: a pure-function unit file covering every branch (`test_proactive_hook_degraded_banner.py`) + a subprocess test driving a **real HTTP 503** through the wiring (must read *reachable*, not *unreachable*). All pre-existing subprocess tests unchanged and green (19/19).
- Docs: `.claude/docs/proactive-memory-hook.md` degraded section + `CLAUDE.md` L2 wording.

## Verification
- `pytest tests/test_learning/test_proactive_hook_degraded_banner.py tests/test_learning/test_proactive_hook_subprocess.py` → 19 passed.
- Live happy-path: edited hook vs the running server → `mode: server`, real memory lines, **no banner** (success path intact).
- Independent code-review pass: DONE, no high-confidence issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)