### PR TITLE
fix(deploy): update.sh flock — refuse concurrent updates (P5-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   needlessly repeated. (Slow per-record checks were also moved out of the locked
   window.)
 
+- **Two updates can no longer run at the same time.** If an update is already in
+  progress, a second `update.sh` (from another session, or the dashboard) now
+  refuses immediately instead of running concurrently — previously two updates
+  could overlap, each stopping the server and merging, and corrupt the deploy.
 - **An interrupted update no longer leaves the server down.** If a self-update
   is interrupted after it has stopped the server (a Ctrl-C, a system shutdown,
   or an unexpected failure inside an internal step), it now rolls back to the

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -114,6 +114,23 @@ if [[ "$GENESIS_ROOT" == *"/.claude/worktrees/"* ]] || \
     exit 1
 fi
 
+# ── Mutual exclusion: only one update.sh at a time ────────
+# CLI runs, the dashboard direct path, and the orchestrator all reach this
+# script; without a shared lock two could overlap (both stop the server, both
+# merge) and corrupt the deploy — observed live via a concurrent session. Held
+# whole-run on a dedicated FD (auto-released on any exit). `flock -n`: a second
+# run refuses immediately rather than queuing. Placed AFTER the worktree refusal
+# (worktree runs never take it) and BEFORE the rollback tag / backup and the
+# ERR/signal traps — a contention exit leaves the running server untouched.
+UPDATE_LOCK_FILE="$HOME/.genesis/locks/update.lock"
+mkdir -p "$(dirname "$UPDATE_LOCK_FILE")"
+exec {_UPDATE_LOCK_FD}>"$UPDATE_LOCK_FILE"
+if ! flock -n "$_UPDATE_LOCK_FD"; then
+    echo "ERROR: another Genesis update is already in progress ($UPDATE_LOCK_FILE)."
+    echo "       Refusing to run a second update concurrently."
+    exit 1
+fi
+
 echo ""
 echo "  Genesis Update"
 echo "  ──────────────────────────────────────"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -651,8 +651,12 @@ _start_genesis_server() {
     # This bypasses systemd monitoring, so health dashboard will show red.
     echo "  WARNING: systemctl --user restart failed — falling back to direct start (degraded)"
     echo "  Health monitoring will not work correctly. Run: systemctl --user restart genesis-server.service"
+    # Close the update-lock FD in this long-lived child: nohup'd, it OUTLIVES
+    # update.sh, and an inherited lock FD would keep the advisory lock held after
+    # we exit — deadlocking every future update until this degraded server dies.
+    # (systemd-started servers don't inherit our FDs; only this nohup path does.)
     nohup "$VENV_DIR/bin/python" -m genesis serve --host 0.0.0.0 --port 5000 \
-        >> "$HOME/.genesis/logs/genesis-server.log" 2>&1 &
+        {_UPDATE_LOCK_FD}>&- >> "$HOME/.genesis/logs/genesis-server.log" 2>&1 &
     echo "  Started genesis-server in degraded mode (pid $!)"
     # Write marker so dashboard can detect degraded mode
     echo "nohup" > "$HOME/.genesis/server-start-mode"

--- a/tests/test_scripts/test_update_mutex.py
+++ b/tests/test_scripts/test_update_mutex.py
@@ -32,6 +32,16 @@ def test_flock_guard_present(text: str) -> None:
     assert 'flock -n "$_UPDATE_LOCK_FD"' in text
 
 
+def test_nohup_fallback_closes_lock_fd(text: str) -> None:
+    """The degraded nohup server OUTLIVES update.sh; it must not inherit the lock
+    FD, or the advisory lock stays held after exit and deadlocks every future
+    update. The nohup fallback closes the lock FD for that child."""
+    nohup = text.find('nohup "$VENV_DIR/bin/python" -m genesis serve')
+    assert nohup != -1, "nohup fallback not found"
+    block = text[nohup : nohup + 200]
+    assert "{_UPDATE_LOCK_FD}>&-" in block, "nohup fallback must close the lock FD for the child"
+
+
 def test_flock_after_worktree_refusal_before_backup(text: str) -> None:
     """Placement: after the worktree refusal (so worktree runs never take the
     lock) and before the rollback tag / pre-update backup (so the whole mutating

--- a/tests/test_scripts/test_update_mutex.py
+++ b/tests/test_scripts/test_update_mutex.py
@@ -1,0 +1,97 @@
+"""Deploy-mutex lock for scripts/update.sh (deploy-audit P5-A, finding #5).
+
+Two update.sh runs (a CLI run + a dashboard-triggered run, or two dashboard
+runs) could previously overlap — both stop the server, both merge — and corrupt
+the deploy. This was observed LIVE (a concurrent session deployed mid-session).
+A whole-run `flock -n` now makes a second run refuse immediately.
+
+Extraction locks assert the shipped guard + its placement; a functional test
+proves the flock mechanism actually excludes a second holder.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return UPDATE_SH.read_text()
+
+
+def test_flock_guard_present(text: str) -> None:
+    assert 'UPDATE_LOCK_FILE="$HOME/.genesis/locks/update.lock"' in text
+    assert 'exec {_UPDATE_LOCK_FD}>"$UPDATE_LOCK_FILE"' in text
+    assert 'flock -n "$_UPDATE_LOCK_FD"' in text
+
+
+def test_flock_after_worktree_refusal_before_backup(text: str) -> None:
+    """Placement: after the worktree refusal (so worktree runs never take the
+    lock) and before the rollback tag / pre-update backup (so the whole mutating
+    run is protected) — and thus before the ERR/signal traps arm."""
+    worktree = text.find("update.sh must not run from a worktree")
+    lock = text.find('exec {_UPDATE_LOCK_FD}>"$UPDATE_LOCK_FILE"')
+    rollback_tag = text.find('ROLLBACK_TAG="pre-update-')
+    trap_arm = text.find("trap _on_err ERR")
+    assert -1 < worktree < lock < rollback_tag, (
+        "flock must sit after worktree refusal, before the rollback tag"
+    )
+    assert lock < trap_arm, (
+        "flock must acquire before the ERR trap arms (contention exit is server-safe)"
+    )
+
+
+def test_flock_functionally_excludes_second_run(tmp_path: Path) -> None:
+    """The shipped flock pattern must let exactly one holder in; a second
+    non-blocking attempt fails fast with exit 1."""
+    lockfile = tmp_path / "update.lock"
+    ready = tmp_path / "ready"
+    # Holder: acquires the lock exactly like update.sh, signals READY, holds it.
+    holder_sh = f"""#!/bin/bash
+set -euo pipefail
+exec {{FD}}>"{lockfile}"
+flock -n "$FD" || {{ echo "HOLDER_FAILED"; exit 9; }}
+touch "{ready}"
+sleep 5
+"""
+    # Contender: same non-blocking acquire — must fail while the holder holds it.
+    contender_sh = f"""#!/bin/bash
+set -euo pipefail
+exec {{FD}}>"{lockfile}"
+if ! flock -n "$FD"; then echo "LOCKED"; exit 1; fi
+echo "ACQUIRED"
+"""
+    (tmp_path / "holder.sh").write_text(holder_sh)
+    (tmp_path / "contender.sh").write_text(contender_sh)
+
+    holder = subprocess.Popen(["bash", str(tmp_path / "holder.sh")])
+    try:
+        for _ in range(100):
+            if ready.exists():
+                break
+            time.sleep(0.05)
+        assert ready.exists(), "holder never acquired the lock"
+        result = subprocess.run(
+            ["bash", str(tmp_path / "contender.sh")],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 1, f"contender should be refused, got rc={result.returncode}"
+        assert "LOCKED" in result.stdout
+        assert "ACQUIRED" not in result.stdout
+    finally:
+        holder.wait(timeout=10)
+
+    # After the holder exits, the lock is free again — a fresh acquire succeeds.
+    free = subprocess.run(
+        ["bash", str(tmp_path / "contender.sh")], capture_output=True, text=True, timeout=10
+    )
+    assert free.returncode == 0 and "ACQUIRED" in free.stdout


### PR DESCRIPTION
## Deploy-audit P5-A — mutual exclusion for `update.sh` (finding #5)

Two `update.sh` runs could previously overlap — a CLI run plus a dashboard-triggered run, or two dashboard runs — each stopping the server and merging, corrupting the deploy. **Observed live this session** (a concurrent session ran `update.sh` mid-work; `update_history` shows the overlap window).

Fix: a whole-run **`flock -n`** on `~/.genesis/locks/update.lock`. A second run refuses immediately (exit 1) rather than queuing. Placed **after** the worktree refusal (so worktree runs never take the lock) and **before** the rollback tag / pre-update backup and the ERR/signal traps — so a contention exit leaves the running server completely untouched. The lock FD is held for the whole run and auto-released on every exit path.

This is **PR-A of a 2-PR split** the architect recommended: the flock is the highest-value, lowest-risk piece and ships first. PR-B (dashboard cgroup isolation + guard/GC honoring CLI runs + owner-checked marker deletes, with the Part-1↔Part-4 marker-leak fix) follows.

### Review
Architect **design review: GO** on the flock (placement, FD survival across the merge/subshells, auto-release on all exit paths, contention-exit-is-server-safe all validated).

### Tests
`tests/test_scripts/test_update_mutex.py` — extraction locks (guard present + correct placement) plus a functional test proving the flock excludes a second holder and frees on release. 34 update.sh tests green; zero new shellcheck warnings.

> Host-Deploy Gate: touches `scripts/update.sh` → an `update.sh` run required after merge (self-deploy lag; the flock governs the next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)