### PR TITLE
fix(deploy): dashboard cgroup isolation + honor CLI runs + owner-checked marker (P5-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Two updates can no longer run at the same time.** If an update is already in
+  progress, a second `update.sh` (from another session, or the dashboard) now
+  refuses immediately instead of running concurrently — previously two updates
+  could overlap, each stopping the server and merging, and corrupt the deploy.
 - **An interrupted update no longer leaves the server down.** If a self-update
   is interrupted after it has stopped the server (a Ctrl-C, a system shutdown,
   or an unexpected failure inside an internal step), it now rolls back to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The dashboard now recognizes updates started from the command line.** Its
+  "update in progress" checks previously only saw dashboard-triggered updates,
+  so a command-line `update.sh` run could be interrupted (its state wiped) or a
+  second update launched over it. The dashboard now consults the same
+  deploy-in-progress signal the rest of the system uses, and a dashboard-started
+  update no longer runs in the server's own service group (where the update
+  stopping the server could kill the update itself).
 - **Two updates can no longer run at the same time.** If an update is already in
   progress, a second `update.sh` (from another session, or the dashboard) now
   refuses immediately instead of running concurrently — previously two updates

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -150,6 +150,17 @@ if ! flock -n "$_UPDATE_LOCK_FD"; then
     exit 1
 fi
 
+# Dashboard DIRECT path: the dashboard spawns us via `systemd-run --scope`, whose
+# PID it writes to the marker — and that PID is OUR $PPID. Adopt the marker as our
+# own ($$) so _clear_deploy_state can clean it at exit (its owner-check needs
+# marker==$$); otherwise systemd-run's PID leaks as a stale marker until the next
+# deploy. Gated on $PPID so we NEVER adopt a restore's marker (its own $$) or the
+# supervised orchestrator's marker (held by a CC session's parent, not ours).
+_own_marker="$HOME/.genesis/update_in_progress.pid"
+if [ -f "$_own_marker" ] && [ "$(cat "$_own_marker" 2>/dev/null || true)" = "$PPID" ]; then
+    echo "$$" > "$_own_marker"
+fi
+
 echo ""
 echo "  Genesis Update"
 echo "  ──────────────────────────────────────"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -114,6 +114,23 @@ if [[ "$GENESIS_ROOT" == *"/.claude/worktrees/"* ]] || \
     exit 1
 fi
 
+# ── Mutual exclusion: only one update.sh at a time ────────
+# CLI runs, the dashboard direct path, and the orchestrator all reach this
+# script; without a shared lock two could overlap (both stop the server, both
+# merge) and corrupt the deploy — observed live via a concurrent session. Held
+# whole-run on a dedicated FD (auto-released on any exit). `flock -n`: a second
+# run refuses immediately rather than queuing. Placed AFTER the worktree refusal
+# (worktree runs never take it) and BEFORE the rollback tag / backup and the
+# ERR/signal traps — a contention exit leaves the running server untouched.
+UPDATE_LOCK_FILE="$HOME/.genesis/locks/update.lock"
+mkdir -p "$(dirname "$UPDATE_LOCK_FILE")"
+exec {_UPDATE_LOCK_FD}>"$UPDATE_LOCK_FILE"
+if ! flock -n "$_UPDATE_LOCK_FD"; then
+    echo "ERROR: another Genesis update is already in progress ($UPDATE_LOCK_FILE)."
+    echo "       Refusing to run a second update concurrently."
+    exit 1
+fi
+
 echo ""
 echo "  Genesis Update"
 echo "  ──────────────────────────────────────"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -73,6 +73,25 @@ _write_state() {
 SEOF
 }
 
+# Clear this run's deploy state files. The state file is ours (we wrote it) so
+# always remove it. The PID marker is NOT necessarily ours to delete: only the
+# dashboard DIRECT path makes it our $$; the supervised orchestrator holds it
+# with ITS pid ACROSS tiers, and scripts/restore.sh holds it with its own pid
+# while it rebuilds the DB. So delete the marker ONLY if we own it ($$) OR its
+# holder PID is dead — never strip a LIVE foreign holder's watchdog inhibitor
+# (mirrors restore.sh's owner-check). The "dead" clause also cleans a stale
+# marker left by a prior direct run (its systemd-run parent PID is dead once
+# that run finished); env.update_in_progress() reads such a dead marker as "no
+# deploy", so the window before it is cleaned is harmless.
+_clear_deploy_state() {
+    rm -f "$STATE_FILE" 2>/dev/null || true
+    local _m="$HOME/.genesis/update_in_progress.pid" _pid
+    _pid="$(cat "$_m" 2>/dev/null || true)"
+    if [ "$_pid" = "$$" ] || { [ -n "$_pid" ] && ! kill -0 "$_pid" 2>/dev/null; }; then
+        rm -f "$_m" 2>/dev/null || true
+    fi
+}
+
 # Signal handler for the PRE-STOP window: an interrupt before services are
 # stopped has nothing to roll back (no merge, server still running), so just
 # clear this run's state/marker and exit. Swapped for _on_signal (rollback)
@@ -100,7 +119,7 @@ _on_signal_prestop() {
             systemctl --user start "$_svc.service" 2>/dev/null || true
         fi
     done
-    rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid" 2>/dev/null || true
+    _clear_deploy_state
     exit 1
 }
 
@@ -565,7 +584,7 @@ if [[ "$POST_MERGE" == "false" ]]; then
     if ! timeout 120 git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main; then
         echo "  Fetch failed (network/timeout?) — server NOT stopped, nothing changed."
         git -C "$GENESIS_ROOT" tag -d "$ROLLBACK_TAG" 2>/dev/null || true
-        rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid"
+        _clear_deploy_state
         exit 1
     fi
 fi
@@ -904,7 +923,7 @@ with open(sys.argv[11], 'w') as f:
     # leftover entry can't suppress the watchdog's deploy-restart guard after a
     # rollback. The server is back up (above); once this invocation exits its PID
     # dies anyway, but removing the files closes the PID-reuse window proactively.
-    rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid"
+    _clear_deploy_state
 
     echo ""
     echo "  ──────────────────────────────────────"
@@ -1151,7 +1170,7 @@ elif [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
     done
     # Nothing changed and no --post-merge continuation follows, so clear the
     # in-progress signals (like the success path) — a leftover must never linger.
-    rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid"
+    _clear_deploy_state
     # Transitional: the pre-merge step may have cleared live settings.local.json
     # or .serena/project.yml edits — put them back even though no merge landed.
     if [ -f "$SETTINGS_LOCAL_BAK" ]; then
@@ -1530,7 +1549,7 @@ rm -f "$STATE_FILE"
 rm -f "$HOME/.genesis/update_conflicts.json"
 rm -f "$HOME/.genesis/last_update_summary.txt"
 # Clean up PID file
-rm -f "$HOME/.genesis/update_in_progress.pid"
+_clear_deploy_state
 
 # ── Done ──────────────────────────────────────────────────
 echo "  ──────────────────────────────────────"

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -249,6 +249,24 @@ def update_apply():
     return _apply_direct(_PID_FILE)
 
 
+def _systemd_run_scope_available(env: dict) -> bool:
+    """True only if `systemd-run --user --scope` can actually start a scope here.
+
+    systemd-run can be present but unusable when the user manager / D-Bus is
+    unreachable: `Popen` would succeed yet the child dies with "Failed to connect
+    to bus", silently no-op'ing the update. Probe with a no-op scope so we can
+    fall back deterministically instead of trusting Popen not to raise.
+    """
+    try:
+        r = subprocess.run(
+            ["systemd-run", "--user", "--scope", "--", "true"],
+            capture_output=True, timeout=10, env=env,
+        )
+        return r.returncode == 0
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _apply_direct(pid_file: Path) -> tuple:
     """Run update.sh directly (no CC supervision), in its OWN systemd scope.
 
@@ -263,11 +281,11 @@ def _apply_direct(pid_file: Path) -> tuple:
         log_path = _HOME / ".genesis" / "update_direct.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fh = open(log_path, "w")  # noqa: SIM115
-        try:
-            env = os.environ.copy()
-            uid = os.getuid()
-            env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{uid}")
-            env.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path=/run/user/{uid}/bus")
+        env = os.environ.copy()
+        uid = os.getuid()
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+        env.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path=/run/user/{uid}/bus")
+        if _systemd_run_scope_available(env):
             proc = subprocess.Popen(
                 ["systemd-run", "--user", "--scope", "--", "bash", str(_UPDATE_SCRIPT)],
                 stdout=log_fh,
@@ -275,12 +293,13 @@ def _apply_direct(pid_file: Path) -> tuple:
                 env=env,
             )
             logger.info("Direct update spawned via systemd-run --scope (pid %d)", proc.pid)
-        except (FileNotFoundError, OSError) as exc:
-            # systemd-run unavailable (e.g. container restrictions): fall back to
-            # a new session. update.sh may then be killed if it stops the server
-            # from inside the shared cgroup -- but its P4b prestop/rollback traps
-            # keep the server from being left down.
-            logger.warning("systemd-run failed (%s), falling back to start_new_session", exc)
+        else:
+            # systemd-run absent OR the user manager/D-Bus is unreachable (a scope
+            # can't start -- Popen would succeed but the child dies "Failed to
+            # connect to bus"). Fall back to a new session in the shared cgroup;
+            # update.sh's P4b prestop/rollback traps keep the server from being
+            # left down if it self-SIGTERMs at the server stop.
+            logger.warning("systemd-run --scope unavailable; falling back to start_new_session")
             proc = subprocess.Popen(
                 ["bash", str(_UPDATE_SCRIPT)],
                 stdout=log_fh,

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import blueprint
+from genesis.env import update_in_progress
 
 logger = logging.getLogger(__name__)
 
@@ -230,20 +231,15 @@ def update_apply():
     if not _UPDATE_SCRIPT.is_file():
         return jsonify({"error": "Update script not found"}), 404
 
-    # Check if an update is already in progress (simple PID file guard)
-    if _PID_FILE.is_file():
-        try:
-            old_pid = int(_PID_FILE.read_text().strip())
-            result = subprocess.run(["kill", "-0", str(old_pid)],
-                                    capture_output=True, timeout=2)
-            if result.returncode == 0:
-                return jsonify({
-                    "error": "Update already in progress",
-                    "pid": old_pid,
-                }), 409
-            _PID_FILE.unlink(missing_ok=True)
-        except (ValueError, subprocess.TimeoutExpired, OSError):
-            _PID_FILE.unlink(missing_ok=True)
+    # An update already in progress? Use the canonical liveness check
+    # (env.update_in_progress) so this also catches a CLI `update.sh` run and
+    # restore.sh -- which signal via the state file / marker, not the dashboard's
+    # own PID file -- instead of launching a second run that update.sh's flock
+    # would reject anyway.
+    if update_in_progress():
+        return jsonify({"error": "Update already in progress"}), 409
+    # Not in progress -> any lingering dashboard PID file holds a dead PID; tidy it.
+    _PID_FILE.unlink(missing_ok=True)
 
     use_cc = request.get_json(silent=True) or {}
     supervised = use_cc.get("supervised", True)
@@ -254,19 +250,50 @@ def update_apply():
 
 
 def _apply_direct(pid_file: Path) -> tuple:
-    """Run update.sh directly (no CC supervision)."""
+    """Run update.sh directly (no CC supervision), in its OWN systemd scope.
+
+    Without a scope, update.sh stays in genesis-server.service's cgroup; its own
+    `systemctl stop genesis-server` then SIGTERMs update.sh via the default
+    KillMode=control-group -- aborting the update, or (at the final restart)
+    self-SIGTERMing into a spurious rollback of a healthy deploy. `systemd-run
+    --user --scope` gives it its own cgroup (mirrors the supervised orchestrator
+    spawn); `start_new_session` alone changes only the session, not the cgroup.
+    """
     try:
         log_path = _HOME / ".genesis" / "update_direct.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fh = open(log_path, "w")  # noqa: SIM115
-        proc = subprocess.Popen(
-            ["bash", str(_UPDATE_SCRIPT)],
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
+        try:
+            env = os.environ.copy()
+            uid = os.getuid()
+            env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+            env.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path=/run/user/{uid}/bus")
+            proc = subprocess.Popen(
+                ["systemd-run", "--user", "--scope", "--", "bash", str(_UPDATE_SCRIPT)],
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                env=env,
+            )
+            logger.info("Direct update spawned via systemd-run --scope (pid %d)", proc.pid)
+        except (FileNotFoundError, OSError) as exc:
+            # systemd-run unavailable (e.g. container restrictions): fall back to
+            # a new session. update.sh may then be killed if it stops the server
+            # from inside the shared cgroup -- but its P4b prestop/rollback traps
+            # keep the server from being left down.
+            logger.warning("systemd-run failed (%s), falling back to start_new_session", exc)
+            proc = subprocess.Popen(
+                ["bash", str(_UPDATE_SCRIPT)],
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
         log_fh.close()  # child inherited the fd; parent can close its copy
         pid_file.parent.mkdir(parents=True, exist_ok=True)
+        # NOTE: on the systemd-run path proc.pid is systemd-run's PID (it stays
+        # alive as the scope parent for the run's duration, then exits). update.sh
+        # owner-checks the marker (delete if ==$$ OR holder dead), so it is cleaned
+        # by the next run; env.update_in_progress() reads a dead marker as "no
+        # deploy" in the interim.
         pid_file.write_text(str(proc.pid))
         logger.info("Direct update triggered (pid %d)", proc.pid)
         return jsonify({"status": "triggered", "pid": proc.pid, "supervised": False})
@@ -625,17 +652,10 @@ log.info("Orchestrator finished")
 @blueprint.route("/api/genesis/updates/dismiss", methods=["POST"])
 def update_dismiss():
     """Clear stale update state files so the dashboard returns to normal."""
-    # Don't delete PID file if a process is still alive — prevents
-    # removing the concurrency guard during a slow-but-active update.
-    pid_alive = False
-    if _PID_FILE.is_file():
-        with contextlib.suppress(ValueError, subprocess.TimeoutExpired, OSError):
-            pid = int(_PID_FILE.read_text().strip())
-            result = subprocess.run(["kill", "-0", str(pid)],
-                                    capture_output=True, timeout=2)
-            pid_alive = result.returncode == 0
-
-    if pid_alive:
+    # Refuse while any deploy is live (marker OR CLI state file) -- don't clear a
+    # slow-but-active update's state out from under it. Canonical liveness check
+    # so a CLI `update.sh` run counts too, not just the dashboard's PID file.
+    if update_in_progress():
         return jsonify({"error": "Update still in progress"}), 409
 
     for f in (_SUMMARY_FILE, _ESCALATION_FILE, _CONFLICT_FILE, _STATE_FILE, _PID_FILE):
@@ -654,20 +674,12 @@ def update_resolve():
     if not has_escalation and not has_conflicts:
         return jsonify({"error": "No conflicts pending"}), 404
 
-    # Check if something is already running
-    if _PID_FILE.is_file():
-        try:
-            old_pid = int(_PID_FILE.read_text().strip())
-            result = subprocess.run(["kill", "-0", str(old_pid)],
-                                    capture_output=True, timeout=2)
-            if result.returncode == 0:
-                return jsonify({
-                    "error": "Update session already in progress",
-                    "pid": old_pid,
-                }), 409
-            _PID_FILE.unlink(missing_ok=True)
-        except (ValueError, subprocess.TimeoutExpired, OSError):
-            _PID_FILE.unlink(missing_ok=True)
+    # An update session already running? Canonical liveness (marker + state file)
+    # so a CLI run counts too, not just the dashboard's own PID file.
+    if update_in_progress():
+        return jsonify({"error": "Update session already in progress"}), 409
+    # Not in progress -> any lingering PID file is stale; tidy it.
+    _PID_FILE.unlink(missing_ok=True)
 
     tier3_prompt = _TIER3_PROMPT.format(
         escalation_file=_ESCALATION_FILE,
@@ -732,16 +744,10 @@ def update_progress():
             state_data = json.loads(_STATE_FILE.read_text())
             phase = state_data.get("phase")
 
-    # Check if an update process is still running
-    in_progress = False
-    if _PID_FILE.is_file():
-        try:
-            pid = int(_PID_FILE.read_text().strip())
-            result = subprocess.run(["kill", "-0", str(pid)],
-                                    capture_output=True, timeout=2)
-            in_progress = result.returncode == 0
-        except (ValueError, subprocess.TimeoutExpired, OSError):
-            pass
+    # Is an update process still running? Canonical liveness check (marker AND
+    # state file) so a CLI `update.sh` run counts too -- which also keeps the
+    # state-file GC below from unlinking a live CLI run's crash-recovery state.
+    in_progress = update_in_progress()
 
     # Detect failed/stale states.
     # Guard against false positives during the brief window at update end:

--- a/tests/test_dashboard/test_update_apply_direct.py
+++ b/tests/test_dashboard/test_update_apply_direct.py
@@ -1,0 +1,67 @@
+"""_apply_direct cgroup isolation (deploy-audit P5-B, part 1 / architect NOTE-1).
+
+The direct update path must spawn update.sh in its OWN systemd scope, so
+update.sh's `systemctl stop genesis-server` cannot SIGTERM it via the shared
+cgroup (which aborts the update, or self-SIGTERMs into a spurious rollback at
+the final restart). Falls back to start_new_session if systemd-run is absent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from genesis.dashboard.routes import updates
+
+
+@pytest.fixture
+def _passthrough_jsonify():
+    with patch.object(updates, "jsonify", lambda x: x):
+        yield
+
+
+def test_apply_direct_uses_systemd_run_scope(tmp_path, _passthrough_jsonify):
+    fake_proc = MagicMock(pid=12345)
+    pid_file = tmp_path / ".genesis" / "update_in_progress.pid"
+    with (
+        patch.object(updates.subprocess, "Popen", return_value=fake_proc) as popen,
+        patch.object(updates, "_HOME", tmp_path),
+    ):
+        updates._apply_direct(pid_file)
+    argv = popen.call_args_list[0][0][0]
+    assert argv[0] == "systemd-run"
+    assert "--user" in argv and "--scope" in argv
+    assert "bash" in argv and any(str(updates._UPDATE_SCRIPT) == a for a in argv)
+    assert pid_file.read_text() == "12345"
+
+
+def test_apply_direct_falls_back_when_systemd_run_missing(tmp_path, _passthrough_jsonify):
+    fake_proc = MagicMock(pid=999)
+    pid_file = tmp_path / ".genesis" / "update_in_progress.pid"
+    with (
+        patch.object(
+            updates.subprocess, "Popen", side_effect=[FileNotFoundError(), fake_proc]
+        ) as popen,
+        patch.object(updates, "_HOME", tmp_path),
+    ):
+        updates._apply_direct(pid_file)
+    # Second call is the fallback — a plain bash spawn with start_new_session.
+    fallback_argv = popen.call_args_list[1][0][0]
+    fallback_kwargs = popen.call_args_list[1][1]
+    assert fallback_argv[0] == "bash"
+    assert fallback_kwargs.get("start_new_session") is True
+    assert pid_file.read_text() == "999"
+
+
+def test_apply_guard_and_status_use_update_in_progress():
+    """Part 3 wiring: both the concurrency guard and the status route now consult
+    the canonical env.update_in_progress (marker AND state file), not a PID-file-
+    only check — so a CLI run is seen and its crash-recovery state is not GC'd."""
+    from pathlib import Path
+
+    text = Path(updates.__file__).read_text()
+    # The old PID-file-only liveness gate must be gone from the guard/status.
+    assert 'result = subprocess.run(["kill", "-0", str(old_pid)]' not in text
+    assert "in_progress = update_in_progress()" in text
+    assert text.count("if update_in_progress():") >= 1  # the apply guard

--- a/tests/test_dashboard/test_update_apply_direct.py
+++ b/tests/test_dashboard/test_update_apply_direct.py
@@ -25,6 +25,7 @@ def test_apply_direct_uses_systemd_run_scope(tmp_path, _passthrough_jsonify):
     fake_proc = MagicMock(pid=12345)
     pid_file = tmp_path / ".genesis" / "update_in_progress.pid"
     with (
+        patch.object(updates, "_systemd_run_scope_available", return_value=True),
         patch.object(updates.subprocess, "Popen", return_value=fake_proc) as popen,
         patch.object(updates, "_HOME", tmp_path),
     ):
@@ -36,22 +37,32 @@ def test_apply_direct_uses_systemd_run_scope(tmp_path, _passthrough_jsonify):
     assert pid_file.read_text() == "12345"
 
 
-def test_apply_direct_falls_back_when_systemd_run_missing(tmp_path, _passthrough_jsonify):
+def test_apply_direct_falls_back_when_scope_unavailable(tmp_path, _passthrough_jsonify):
+    """systemd-run absent OR the user manager/D-Bus unreachable (probe False) →
+    plain bash + start_new_session, never a silent no-op."""
     fake_proc = MagicMock(pid=999)
     pid_file = tmp_path / ".genesis" / "update_in_progress.pid"
     with (
-        patch.object(
-            updates.subprocess, "Popen", side_effect=[FileNotFoundError(), fake_proc]
-        ) as popen,
+        patch.object(updates, "_systemd_run_scope_available", return_value=False),
+        patch.object(updates.subprocess, "Popen", return_value=fake_proc) as popen,
         patch.object(updates, "_HOME", tmp_path),
     ):
         updates._apply_direct(pid_file)
-    # Second call is the fallback — a plain bash spawn with start_new_session.
-    fallback_argv = popen.call_args_list[1][0][0]
-    fallback_kwargs = popen.call_args_list[1][1]
-    assert fallback_argv[0] == "bash"
-    assert fallback_kwargs.get("start_new_session") is True
+    argv = popen.call_args_list[0][0][0]
+    kwargs = popen.call_args_list[0][1]
+    assert argv[0] == "bash"
+    assert kwargs.get("start_new_session") is True
     assert pid_file.read_text() == "999"
+
+
+def test_systemd_run_scope_probe():
+    """The viability probe: 0 → True; non-zero (D-Bus down) → False; missing → False."""
+    with patch.object(updates.subprocess, "run", return_value=MagicMock(returncode=0)):
+        assert updates._systemd_run_scope_available({}) is True
+    with patch.object(updates.subprocess, "run", return_value=MagicMock(returncode=1)):
+        assert updates._systemd_run_scope_available({}) is False
+    with patch.object(updates.subprocess, "run", side_effect=FileNotFoundError()):
+        assert updates._systemd_run_scope_available({}) is False
 
 
 def test_apply_guard_and_status_use_update_in_progress():

--- a/tests/test_scripts/test_update_marker_ownership.py
+++ b/tests/test_scripts/test_update_marker_ownership.py
@@ -1,0 +1,116 @@
+"""Owner-checked marker deletes in scripts/update.sh (deploy-audit P5-B, part 4).
+
+update.sh must NOT unconditionally delete ~/.genesis/update_in_progress.pid: on
+the supervised path the orchestrator holds it with ITS pid across tiers, and
+scripts/restore.sh holds it with its own pid while rebuilding the DB — stripping
+a live foreign holder's marker reopens the watchdog-revives-mid-op hazard. The
+`_clear_deploy_state` helper deletes the marker only if WE own it ($$) OR its
+holder is dead. The state file is always removed (update.sh wrote it).
+
+These drive the ACTUAL shipped `_clear_deploy_state` function against each marker
+state.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return UPDATE_SH.read_text()
+
+
+def _extract_func(text: str, name: str) -> str:
+    m = re.search(rf"^{re.escape(name)}\(\) \{{\n(.*?)\n\}}$", text, re.DOTALL | re.MULTILINE)
+    assert m, f"{name} not found"
+    return f"{name}() {{\n{m.group(1)}\n}}"
+
+
+def test_no_unconditional_marker_rm_remains(text: str) -> None:
+    """Every marker delete must go through the owner-checked helper — no raw
+    `rm -f ... update_in_progress.pid` outside `_clear_deploy_state`."""
+    body = _extract_func(text, "_clear_deploy_state")
+    outside = text.replace(body, "")
+    assert "update_in_progress.pid" not in outside, "a raw marker rm survives outside the helper"
+    assert text.count("_clear_deploy_state\n") >= 5, "helper must be called at every cleanup site"
+
+
+def _run_clear(tmp_path: Path, text: str, marker_pid: str | None) -> tuple[bool, bool]:
+    """Run the shipped _clear_deploy_state with a given marker state.
+    Returns (marker_still_exists, state_still_exists)."""
+    home = tmp_path / "home"
+    (home / ".genesis").mkdir(parents=True)
+    marker = home / ".genesis" / "update_in_progress.pid"
+    state = tmp_path / "update_state.json"
+    state.write_text("{}")
+    if marker_pid is not None:
+        marker.write_text(marker_pid)
+    harness = f"""#!/bin/bash
+set -Eeuo pipefail
+STATE_FILE="{state}"
+{_extract_func(text, "_clear_deploy_state")}
+_clear_deploy_state
+"""
+    script = tmp_path / "h.sh"
+    script.write_text(harness)
+    subprocess.run(
+        ["bash", str(script)], env={**os.environ, "HOME": str(home)}, timeout=10, check=True
+    )
+    return marker.exists(), state.exists()
+
+
+def test_deletes_marker_we_own(tmp_path: Path, text: str) -> None:
+    # A helper subshell's $$ differs from any pid we write, so use the harness's
+    # own pid by writing "$$" — emulate ownership by writing the bash pid at run.
+    # Simpler: a marker holding THIS python process's pid is a live FOREIGN pid;
+    # to test "owned", we write the shell's own $$ from inside the harness.
+    home = tmp_path / "home"
+    (home / ".genesis").mkdir(parents=True)
+    state = tmp_path / "s.json"
+    state.write_text("{}")
+    marker = home / ".genesis" / "update_in_progress.pid"
+    harness = f"""#!/bin/bash
+set -Eeuo pipefail
+STATE_FILE="{state}"
+echo "$$" > "{marker}"      # marker holds OUR pid → owned
+{_extract_func(text, "_clear_deploy_state")}
+_clear_deploy_state
+"""
+    (tmp_path / "h.sh").write_text(harness)
+    subprocess.run(
+        ["bash", str(tmp_path / "h.sh")],
+        env={**os.environ, "HOME": str(home)},
+        timeout=10,
+        check=True,
+    )
+    assert not marker.exists(), "an owned marker must be deleted"
+    assert not state.exists(), "the state file is always removed"
+
+
+def test_keeps_live_foreign_marker(tmp_path: Path, text: str) -> None:
+    """A LIVE foreign holder's marker (e.g. a concurrent restore) must survive."""
+    # os.getpid() is this pytest process — alive and NOT the harness's $$.
+    marker_exists, state_exists = _run_clear(tmp_path, text, str(os.getpid()))
+    assert marker_exists, "a live foreign marker must NOT be stripped"
+    assert not state_exists, "the state file is still removed"
+
+
+def test_deletes_dead_marker(tmp_path: Path, text: str) -> None:
+    """A marker whose holder is dead (a stale direct-run systemd-run pid) is cleaned."""
+    # PID 2^31-ish is not a live process.
+    marker_exists, _ = _run_clear(tmp_path, text, "2147480000")
+    assert not marker_exists, "a dead-holder marker must be cleaned"
+
+
+def test_no_marker_is_safe(tmp_path: Path, text: str) -> None:
+    marker_exists, state_exists = _run_clear(tmp_path, text, None)
+    assert not marker_exists and not state_exists

--- a/tests/test_scripts/test_update_marker_ownership.py
+++ b/tests/test_scripts/test_update_marker_ownership.py
@@ -40,8 +40,54 @@ def test_no_unconditional_marker_rm_remains(text: str) -> None:
     `rm -f ... update_in_progress.pid` outside `_clear_deploy_state`."""
     body = _extract_func(text, "_clear_deploy_state")
     outside = text.replace(body, "")
-    assert "update_in_progress.pid" not in outside, "a raw marker rm survives outside the helper"
+    # No raw DELETE of the marker may survive outside the helper (the adoption
+    # block writes it, which is fine — only unconditional rm is the hazard).
+    assert not re.search(r"rm -f[^\n]*update_in_progress\.pid", outside), (
+        "a raw marker rm survives outside the helper"
+    )
     assert text.count("_clear_deploy_state\n") >= 5, "helper must be called at every cleanup site"
+
+
+def test_direct_path_adopts_marker_by_ppid(text: str) -> None:
+    """The direct-dashboard path adopts the marker (systemd-run's PID == our
+    $PPID) as our own $$, so _clear_deploy_state can clean it — gated on $PPID so
+    a restore/orchestrator marker is never adopted."""
+    assert '_own_marker="$HOME/.genesis/update_in_progress.pid"' in text
+    assert '= "$PPID" ]' in text and 'echo "$$" > "$_own_marker"' in text
+
+
+def _extract_adoption(text: str) -> str:
+    m = re.search(
+        r'(_own_marker="\$HOME.*?\n    echo "\$\$" > "\$_own_marker"\nfi)', text, re.DOTALL
+    )
+    assert m, "adoption block not found"
+    return m.group(1)
+
+
+def test_direct_run_marker_cleaned_no_leak(tmp_path: Path, text: str) -> None:
+    """End-to-end: with the marker holding our parent PID (the direct path), after
+    adoption + _clear_deploy_state the marker is GONE — no systemd-run-PID leak."""
+    home = tmp_path / "home"
+    (home / ".genesis").mkdir(parents=True)
+    marker = home / ".genesis" / "update_in_progress.pid"
+    state = tmp_path / "s.json"
+    state.write_text("{}")
+    harness = f"""#!/bin/bash
+set -Eeuo pipefail
+STATE_FILE="{state}"
+echo "$PPID" > "{marker}"          # dashboard wrote our (systemd-run) parent's PID
+{_extract_adoption(text)}
+{_extract_func(text, "_clear_deploy_state")}
+_clear_deploy_state
+"""
+    (tmp_path / "h.sh").write_text(harness)
+    subprocess.run(
+        ["bash", str(tmp_path / "h.sh")],
+        env={**os.environ, "HOME": str(home)},
+        timeout=10,
+        check=True,
+    )
+    assert not marker.exists(), "direct-path marker must be cleaned (adopted then owner-deleted)"
 
 
 def _run_clear(tmp_path: Path, text: str, marker_pid: str | None) -> tuple[bool, bool]:

--- a/tests/test_scripts/test_update_mutex.py
+++ b/tests/test_scripts/test_update_mutex.py
@@ -1,0 +1,97 @@
+"""Deploy-mutex lock for scripts/update.sh (deploy-audit P5-A, finding #5).
+
+Two update.sh runs (a CLI run + a dashboard-triggered run, or two dashboard
+runs) could previously overlap — both stop the server, both merge — and corrupt
+the deploy. This was observed LIVE (a concurrent session deployed mid-session).
+A whole-run `flock -n` now makes a second run refuse immediately.
+
+Extraction locks assert the shipped guard + its placement; a functional test
+proves the flock mechanism actually excludes a second holder.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SH = REPO_ROOT / "scripts" / "update.sh"
+
+
+@pytest.fixture(scope="module")
+def text() -> str:
+    return UPDATE_SH.read_text()
+
+
+def test_flock_guard_present(text: str) -> None:
+    assert 'UPDATE_LOCK_FILE="$HOME/.genesis/locks/update.lock"' in text
+    assert 'exec {_UPDATE_LOCK_FD}>"$UPDATE_LOCK_FILE"' in text
+    assert 'flock -n "$_UPDATE_LOCK_FD"' in text
+
+
+def test_flock_after_worktree_refusal_before_backup(text: str) -> None:
+    """Placement: after the worktree refusal (so worktree runs never take the
+    lock) and before the rollback tag / pre-update backup (so the whole mutating
+    run is protected) — and thus before the ERR/signal traps arm."""
+    worktree = text.find("update.sh must not run from a worktree")
+    lock = text.find('exec {_UPDATE_LOCK_FD}>"$UPDATE_LOCK_FILE"')
+    rollback_tag = text.find('ROLLBACK_TAG="pre-update-')
+    trap_arm = text.find("trap _on_err ERR")
+    assert -1 < worktree < lock < rollback_tag, (
+        "flock must sit after worktree refusal, before the rollback tag"
+    )
+    assert lock < trap_arm, (
+        "flock must acquire before the ERR trap arms (contention exit is server-safe)"
+    )
+
+
+def test_flock_functionally_excludes_second_run(tmp_path: Path) -> None:
+    """The shipped flock pattern must let exactly one holder in; a second
+    non-blocking attempt fails fast with exit 1."""
+    lockfile = tmp_path / "update.lock"
+    ready = tmp_path / "ready"
+    # Holder: acquires the lock exactly like update.sh, signals READY, holds it.
+    holder_sh = f"""#!/bin/bash
+set -euo pipefail
+exec {{FD}}>"{lockfile}"
+flock -n "$FD" || {{ echo "HOLDER_FAILED"; exit 9; }}
+touch "{ready}"
+sleep 5
+"""
+    # Contender: same non-blocking acquire — must fail while the holder holds it.
+    contender_sh = f"""#!/bin/bash
+set -euo pipefail
+exec {{FD}}>"{lockfile}"
+if ! flock -n "$FD"; then echo "LOCKED"; exit 1; fi
+echo "ACQUIRED"
+"""
+    (tmp_path / "holder.sh").write_text(holder_sh)
+    (tmp_path / "contender.sh").write_text(contender_sh)
+
+    holder = subprocess.Popen(["bash", str(tmp_path / "holder.sh")])
+    try:
+        for _ in range(100):
+            if ready.exists():
+                break
+            time.sleep(0.05)
+        assert ready.exists(), "holder never acquired the lock"
+        result = subprocess.run(
+            ["bash", str(tmp_path / "contender.sh")],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 1, f"contender should be refused, got rc={result.returncode}"
+        assert "LOCKED" in result.stdout
+        assert "ACQUIRED" not in result.stdout
+    finally:
+        holder.wait(timeout=10)
+
+    # After the holder exits, the lock is free again — a fresh acquire succeeds.
+    free = subprocess.run(
+        ["bash", str(tmp_path / "contender.sh")], capture_output=True, text=True, timeout=10
+    )
+    assert free.returncode == 0 and "ACQUIRED" in free.stdout

--- a/tests/test_scripts/test_update_phase_order.py
+++ b/tests/test_scripts/test_update_phase_order.py
@@ -103,7 +103,9 @@ def test_fetch_failure_cleans_up_and_exits_without_rollback(text):
     # The fetch block ends at the first standalone `fi` after the fetch.
     block = text[f : text.index("\nfi\n", f)]
     assert 'tag -d "$ROLLBACK_TAG"' in block, "fetch-failure must delete the rollback tag"
-    assert 'rm -f "$STATE_FILE"' in block, "fetch-failure must clear the state file"
+    assert "_clear_deploy_state" in block, (
+        "fetch-failure must clear the state (via _clear_deploy_state)"
+    )
     assert "exit 1" in block, "fetch-failure must exit 1"
     # Check CODE lines only — a comment may legitimately mention _do_rollback.
     code = "\n".join(ln for ln in block.splitlines() if not ln.lstrip().startswith("#"))

--- a/tests/test_scripts/test_update_traps.py
+++ b/tests/test_scripts/test_update_traps.py
@@ -96,6 +96,7 @@ def _harness(text: str, scenario: str) -> str:
     on_err = _extract_func(text, "_on_err")
     on_signal = _extract_func(text, "_on_signal")
     on_prestop = _extract_func(text, "_on_signal_prestop")
+    on_clear = _extract_func(text, "_clear_deploy_state")
     return f"""#!/bin/bash
 set -Eeuo pipefail
 STATE_FILE="$STATE_FILE"
@@ -104,6 +105,7 @@ _do_rollback() {{ echo "depth=$BASH_SUBSHELL reason=$1" >> "$RB_LOG"; }}
 # records intent without touching real systemd.
 _start_genesis_server() {{ echo "start:genesis-server" >> "$RESTART_LOG"; return 0; }}
 systemctl() {{ echo "systemctl $*" >> "$RESTART_LOG"; return 0; }}
+{on_clear}
 {on_err}
 {on_signal}
 {on_prestop}
@@ -154,8 +156,12 @@ def _run(tmp_path: Path, text: str, scenario: str, *, signal_it: bool = False):
     state = tmp_path / "state.json"
     state.write_text("{}")
     ready = tmp_path / "ready"
+    # Isolate HOME so _clear_deploy_state's marker path
+    # ($HOME/.genesis/update_in_progress.pid) is a tmp, never the real marker.
+    (tmp_path / ".genesis").mkdir(exist_ok=True)
     env = {
         **os.environ,
+        "HOME": str(tmp_path),
         "RB_LOG": str(rb_log),
         "RESTART_LOG": str(restart_log),
         "STATE_FILE": str(state),


### PR DESCRIPTION
## Deploy-audit P5-B (parts 1/3/4) — stacks on P5-A (#1195)

Architect **design-reviewed** (validated the 4-part design; BLOCKER-1 addressed, SHOULD-FIX-1 tabled `bc7313b1`). Closes #4 (dashboard state-GC destroying a CLI run's state) and #5's dashboard side, plus NOTE-1 (`_apply_direct` cgroup self-SIGTERM).

- **Part 1 (cgroup / NOTE-1):** `_apply_direct` spawns `update.sh` via `systemd-run --user --scope` (own cgroup, mirrors the supervised orchestrator), so update.sh's own `systemctl stop genesis-server` can't SIGTERM it — which otherwise aborts the update or self-SIGTERMs into a spurious rollback at the final restart. Falls back to `start_new_session` if systemd-run is absent.
- **Part 3 (#4/#5):** all four dashboard "update in progress" checks (apply guard, dismiss, resolve, status/GC) now use the canonical `env.update_in_progress()` (marker AND state file) instead of a PID-file-only probe — so a CLI `update.sh` run is seen (409'd, not double-launched) and its crash-recovery state is not GC'd.
- **Part 4 (marker ownership):** update.sh's 5 marker deletes go through `_clear_deploy_state`, which removes the marker only if we own it (`$$`) OR its holder is dead — never stripping a live foreign holder (the supervised orchestrator across tiers, or a concurrent restore's watchdog inhibitor). The state file is always cleared.

### Build-time finding (worth reviewer attention)
I verified `systemd-run --scope` **stays alive** as the scope parent for the run's duration (the architect's design review assumed it was ephemeral). This refines — doesn't break — the marker cleanup: on the direct path the marker holds a *live* systemd-run PID during the run and a *dead* one after, read correctly by `env.update_in_progress()`, and cleaned by the next run's owner-check dead-clause. I also extended Part 3 to the `dismiss`/`resolve` guards for consistency (same CLI-blindness).

### Tests
Functional marker-ownership (drives the shipped `_clear_deploy_state` across owned/live-foreign/dead/absent), `_apply_direct` systemd-run + fallback, guard-wiring assertions, and updated trap/phase-order tests for the `_clear_deploy_state` refactor. 39 update.sh + dashboard tests green; `updates.py` reconstructed to avoid wholesale format churn (base wasn't ruff-format-clean; CI lints only).

> Host-Deploy Gate: touches `scripts/update.sh` → `update.sh` run required after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)