### PR TITLE
fix(memory): route post-recall enrich/breadcrumbs onto the read pool (ac27b693, PR-4b)

### DIFF
--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -613,8 +613,16 @@ async def proactive_context(
     recall_ms = (time.monotonic() - t_recall) * 1000
 
     t_enrich = time.monotonic()
-    await _enrich(db, dicts)
-    await _breadcrumbs(db, dicts)
+    # PR-4b (ac27b693): route these post-recall reads off the shared write lock
+    # onto recall's read-only pool — the same _ro_read seam recall's own reads
+    # use. Both are pure indexed SELECTs (memory_metadata PK / memory_links
+    # source_id), so under concurrency they were queuing behind server writes,
+    # not query cost. _ro_read runs fn(pooled_conn, *args) and falls back to the
+    # shared connection on any pool miss/error, so this is never worse than the
+    # pre-pool path. retriever is genesis.mcp.memory._retriever (see CC memory
+    # two_retriever_wiring) — the same instance the pool was wired into in PR-4.
+    await retriever._ro_read(_enrich, dicts)
+    await retriever._ro_read(_breadcrumbs, dicts)
     enrich_ms = (time.monotonic() - t_enrich) * 1000
 
     lines = prof.renderer(dicts)

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -401,7 +401,14 @@ def _render_procedure_line(proc: dict) -> str:
 
 
 async def _enrich(db: Any, dicts: list[dict]) -> None:
-    """Backfill ``_created_at`` + ``_wing`` from memory_metadata (in place)."""
+    """Backfill ``_created_at`` + ``_wing`` from memory_metadata (in place).
+
+    Lets a DB read error PROPAGATE — the caller routes this through
+    ``HybridRetriever._ro_read``, whose fallback retries on the shared connection,
+    and guards the whole enrichment step best-effort. Swallowing here would defeat
+    that fallback on a transient pooled-read failure (Codex #1197 P2). Idempotent,
+    so a fallback re-run is safe.
+    """
     ids = [
         d["memory_id"]
         for d in dicts
@@ -409,46 +416,44 @@ async def _enrich(db: Any, dicts: list[dict]) -> None:
     ]
     if not ids:
         return
-    try:
-        placeholders = ",".join("?" for _ in ids)
-        rows = await db.execute_fetchall(
-            f"SELECT memory_id, created_at, wing FROM memory_metadata "  # noqa: S608
-            f"WHERE memory_id IN ({placeholders})",
-            ids,
-        )
-        meta = {row[0]: (row[1], row[2]) for row in rows}
-        for d in dicts:
-            created_at, wing = meta.get(d.get("memory_id"), (None, None))
-            d["_created_at"] = created_at
-            # Prefer a wing already on the recall payload; fall back to metadata.
-            payload_wing = (d.get("payload") or {}).get("wing")
-            d["_wing"] = payload_wing or wing
-    except Exception:
-        logger.debug("proactive metadata enrichment failed", exc_info=True)
+    placeholders = ",".join("?" for _ in ids)
+    rows = await db.execute_fetchall(
+        f"SELECT memory_id, created_at, wing FROM memory_metadata "  # noqa: S608
+        f"WHERE memory_id IN ({placeholders})",
+        ids,
+    )
+    meta = {row[0]: (row[1], row[2]) for row in rows}
+    for d in dicts:
+        created_at, wing = meta.get(d.get("memory_id"), (None, None))
+        d["_created_at"] = created_at
+        # Prefer a wing already on the recall payload; fall back to metadata.
+        payload_wing = (d.get("payload") or {}).get("wing")
+        d["_wing"] = payload_wing or wing
 
 
 async def _breadcrumbs(db: Any, dicts: list[dict]) -> None:
     """Attach up to 2 strongly-linked neighbor id-prefixes to the top 3
-    delivered memories (``related_ids``), for memory_expand follow-up."""
+    delivered memories (``related_ids``), for memory_expand follow-up.
+
+    Lets a DB read error PROPAGATE (see :func:`_enrich`): the caller's ``_ro_read``
+    fallback + best-effort guard handle it, and the writes are idempotent.
+    """
     if not dicts:
         return
     seen = {d.get("memory_id") for d in dicts}
-    try:
-        for d in dicts[:3]:
-            mid = d.get("memory_id")
-            if not mid:
-                continue
-            rows = await db.execute_fetchall(
-                "SELECT target_id FROM memory_links "
-                "WHERE source_id = ? AND strength >= 0.5 "
-                "ORDER BY strength DESC LIMIT 2",
-                (mid,),
-            )
-            related = [row[0][:8] for row in rows if row[0] not in seen]
-            if related:
-                d["related_ids"] = related
-    except Exception:
-        logger.debug("proactive breadcrumbs failed", exc_info=True)
+    for d in dicts[:3]:
+        mid = d.get("memory_id")
+        if not mid:
+            continue
+        rows = await db.execute_fetchall(
+            "SELECT target_id FROM memory_links "
+            "WHERE source_id = ? AND strength >= 0.5 "
+            "ORDER BY strength DESC LIMIT 2",
+            (mid,),
+        )
+        related = [row[0][:8] for row in rows if row[0] not in seen]
+        if related:
+            d["related_ids"] = related
 
 
 # ---------------------------------------------------------------------------
@@ -614,15 +619,22 @@ async def proactive_context(
 
     t_enrich = time.monotonic()
     # PR-4b (ac27b693): route these post-recall reads off the shared write lock
-    # onto recall's read-only pool — the same _ro_read seam recall's own reads
+    # onto recall's read-only pool via the same _ro_read seam recall's own reads
     # use. Both are pure indexed SELECTs (memory_metadata PK / memory_links
     # source_id), so under concurrency they were queuing behind server writes,
-    # not query cost. _ro_read runs fn(pooled_conn, *args) and falls back to the
-    # shared connection on any pool miss/error, so this is never worse than the
-    # pre-pool path. retriever is genesis.mcp.memory._retriever (see CC memory
-    # two_retriever_wiring) — the same instance the pool was wired into in PR-4.
-    await retriever._ro_read(_enrich, dicts)
-    await retriever._ro_read(_breadcrumbs, dicts)
+    # not query cost. _ro_read runs fn(pooled_conn, *args) and, on any pool
+    # miss/error, retries on the shared connection — so the helpers deliberately
+    # do NOT swallow their own DB errors (that would hide a transient pooled-read
+    # failure from the fallback; Codex #1197 P2). The best-effort catch lives HERE
+    # so that if BOTH the pooled and shared reads fail, enrichment degrades to
+    # nothing rather than failing recall (the pre-pool best-effort contract).
+    # retriever is genesis.mcp.memory._retriever (see CC memory two_retriever_wiring)
+    # — the same instance the pool was wired into in PR-4.
+    try:
+        await retriever._ro_read(_enrich, dicts)
+        await retriever._ro_read(_breadcrumbs, dicts)
+    except Exception:
+        logger.debug("post-recall enrichment/breadcrumbs failed", exc_info=True)
     enrich_ms = (time.monotonic() - t_enrich) * 1000
 
     lines = prof.renderer(dicts)

--- a/tests/test_memory/test_proactive_engine.py
+++ b/tests/test_memory/test_proactive_engine.py
@@ -190,11 +190,6 @@ def test_render_procedure_line_dormant_labeled_unproven():
 # --- full engine wiring (faked deps) ----------------------------------------
 
 
-class _FakeRetriever:
-    async def _embed_query(self, _q):
-        return ([0.1] * 8, True)
-
-
 class _FakeDB:
     async def execute_fetchall(self, sql, params=()):
         s = sql.lower()
@@ -203,9 +198,27 @@ class _FakeDB:
         return []  # memory_links + procedural_memory → nothing
 
 
+# In production retriever._db IS memory_mod._db (same connection object); the fake
+# shares one instance so the invariant holds and _ro_read's no-pool fallback path
+# reads the same rows the engine's own db reads (procedure/bump).
+_FAKE_DB = _FakeDB()
+
+
+class _FakeRetriever:
+    _db = _FAKE_DB
+
+    async def _embed_query(self, _q):
+        return ([0.1] * 8, True)
+
+    async def _ro_read(self, fn, *args, **kwargs):
+        # Mirror HybridRetriever._ro_read's no-pool path (PR-4b): with no pool the
+        # read runs on the shared db, byte-identical to the pre-pool call.
+        return await fn(self._db, *args, **kwargs)
+
+
 class _FakeMod:
     _retriever = _FakeRetriever()
-    _db = _FakeDB()
+    _db = _FAKE_DB
 
     @staticmethod
     def _require_init():
@@ -278,6 +291,51 @@ async def test_proactive_context_end_to_end_faked():
     # Per-stage timings present (values are wall-clock, just assert shape).
     for key in ("embed", "recall", "enrich", "procedure", "total"):
         assert key in resp["timings_ms"]
+
+
+async def test_proactive_context_routes_enrich_breadcrumbs_through_ro_read():
+    """PR-4b: the post-recall ``_enrich`` + ``_breadcrumbs`` reads must run through
+    the retriever's ``_ro_read`` pool seam, not straight on the shared write
+    connection — otherwise they keep queuing behind server writes (the residual
+    PR-4b targets). Regression guard against reverting to bare ``_enrich(db, …)``.
+    """
+    routed: list[str] = []
+
+    class _SpyRetriever(_FakeRetriever):
+        async def _ro_read(self, fn, *args, **kwargs):
+            routed.append(fn.__name__)
+            return await fn(self._db, *args, **kwargs)
+
+    class _SpyMod:
+        _retriever = _SpyRetriever()
+        _db = _FAKE_DB
+
+        @staticmethod
+        def _require_init():
+            return None
+
+    delivered = [
+        {
+            "memory_id": "aaaaaaaa1111",
+            "content": "a delivered memory",
+            "collection": "episodic_memory",
+            "memory_class": "fact",
+            "origin_class": None,
+            "source_pipeline": None,
+            "score": 0.1,
+            "payload": {"wing": "voice"},
+            "via_graph": False,
+        }
+    ]
+    with (
+        patch("genesis.mcp.memory.core._memory_mod", return_value=_SpyMod()),
+        patch("genesis.mcp.memory.core._proactive_impl", new=AsyncMock(return_value=delivered)),
+    ):
+        resp = await P.proactive_context(prompt="what did we decide", session_id="s")
+
+    assert resp["status"] == "ok"
+    # BOTH post-recall reads went through the pool seam (order: enrich then breadcrumbs).
+    assert routed == ["_enrich", "_breadcrumbs"], routed
 
 
 async def test_proactive_context_passes_file_keywords_as_extra_fts_terms():

--- a/tests/test_memory/test_recall_read_pool.py
+++ b/tests/test_memory/test_recall_read_pool.py
@@ -140,3 +140,34 @@ async def test_enrich_and_breadcrumbs_run_through_pool(tmp_path):
         assert dicts[0]["related_ids"] == ["aaaaaaaa", "bbbbbbbb"]
     finally:
         await pool.close()
+
+
+async def test_enrich_read_error_on_pool_falls_back_to_shared_db():
+    """Codex #1197 P2: when the pool hands out a connection but its SELECT fails
+    (stale/closed conn, SQLITE_BUSY after the read timeout), the read must fall
+    back to the shared connection and STILL enrich — _enrich no longer swallows
+    the error internally, so _ro_read's fallback fires. Under the old
+    swallow-inside behavior enrichment would silently vanish on a transient pool
+    read failure; this guards against regressing to that.
+    """
+
+    class _BadConn:
+        async def execute_fetchall(self, sql, params=()):
+            raise sqlite3.OperationalError("database is locked")
+
+    class _GoodConn:
+        async def execute_fetchall(self, sql, params=()):
+            if "memory_metadata" in sql.lower():
+                return [("mem1", "2024-01-01T00:00:00+00:00", "routing")]
+            return []
+
+    # Pool yields a connection whose SELECT raises; the shared _db is healthy.
+    retriever = _retriever(read_pool=_FakePool(_BadConn()))
+    retriever._db = _GoodConn()
+    dicts = [{"memory_id": "mem1", "payload": {}}]
+
+    await retriever._ro_read(_enrich, dicts)
+
+    # Fell back to the shared DB and enriched, rather than silently losing it.
+    assert dicts[0]["_wing"] == "routing"
+    assert dicts[0]["_created_at"] == "2024-01-01T00:00:00+00:00"

--- a/tests/test_memory/test_recall_read_pool.py
+++ b/tests/test_memory/test_recall_read_pool.py
@@ -10,10 +10,12 @@ pool error re-reads real data instead of fail-open ``None``.
 
 from __future__ import annotations
 
+import sqlite3
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 
-from genesis.db.connection import ReadPoolClosed
+from genesis.db.connection import ReadConnectionPool, ReadPoolClosed
+from genesis.memory.proactive import _breadcrumbs, _enrich
 from genesis.memory.retrieval import HybridRetriever
 
 
@@ -97,3 +99,44 @@ async def test_ro_read_falls_back_on_readpoolclosed():
 
     assert await retriever._ro_read(fn, 1) == 1
     assert seen["conn"] is retriever._db
+
+
+async def test_enrich_and_breadcrumbs_run_through_pool(tmp_path):
+    """PR-4b functional: the proactive engine's post-recall reads (``_enrich`` +
+    ``_breadcrumbs``) execute correctly on a POOLED ``mode=ro`` connection via
+    ``_ro_read`` — backfilling ``_created_at``/``_wing`` and attaching
+    ``related_ids`` off the shared write lock, exactly as the engine now calls
+    them. Both queries are indexed seeks; this pins that they read real rows
+    through the pool, not just that ``_ro_read`` forwards a connection.
+    """
+    db_path = tmp_path / "engine.db"
+    con = sqlite3.connect(str(db_path))
+    con.executescript(
+        "CREATE TABLE memory_metadata (memory_id TEXT PRIMARY KEY, created_at TEXT, wing TEXT);"
+        "CREATE TABLE memory_links (source_id TEXT, target_id TEXT, strength REAL);"
+    )
+    con.execute(
+        "INSERT INTO memory_metadata VALUES ('mem1', '2024-01-01T00:00:00+00:00', 'routing')"
+    )
+    con.executemany(
+        "INSERT INTO memory_links (source_id, target_id, strength) VALUES (?, ?, ?)",
+        [("mem1", "aaaaaaaa01", 0.9), ("mem1", "bbbbbbbb02", 0.7), ("mem1", "cccccccc03", 0.3)],
+    )
+    con.commit()
+    con.close()
+
+    pool = ReadConnectionPool(db_path, size=2)
+    await pool.open()
+    retriever = _retriever(read_pool=pool)
+    try:
+        dicts = [{"memory_id": "mem1", "payload": {}}]
+
+        await retriever._ro_read(_enrich, dicts)
+        assert dicts[0]["_created_at"] == "2024-01-01T00:00:00+00:00"
+        assert dicts[0]["_wing"] == "routing"  # payload wing empty → metadata wing
+
+        await retriever._ro_read(_breadcrumbs, dicts)
+        # top-2 neighbors with strength >= 0.5, DESC; the 0.3 link is excluded.
+        assert dicts[0]["related_ids"] == ["aaaaaaaa", "bbbbbbbb"]
+    finally:
+        await pool.close()


### PR DESCRIPTION
## Problem
PR-4 (#1189) gave recall's **internal** read stages a dedicated `mode=ro` connection pool, and the live 7× probe confirmed they flattened (`activation` ~1055ms → 15ms). But the proactive engine runs two more reads **on the shared write connection AFTER `recall()` returns** — `_enrich` (backfills `_created_at`/`_wing` from `memory_metadata`) and `_breadcrumbs` (neighbor ids from `memory_links`). They were never inside `recall()`, so PR-4 didn't reach them. With recall's reads relieved, that post-recall pair became the **dominant residual** under load (enrich median ~1s, p95 ~1.7s).

`EXPLAIN QUERY PLAN` shows both are **indexed seeks** (`memory_metadata` PK / `idx_memory_links_source`), so the ~1s under concurrency is **lock-wait queuing behind server writes**, not query cost — the exact class PR-4 fixed for `activation`.

## Fix
Route both through PR-4's existing, tested `HybridRetriever._ro_read` seam (2 call sites in `memory/proactive.py::proactive_context`):

```python
await retriever._ro_read(_enrich, dicts)
await retriever._ro_read(_breadcrumbs, dicts)
```

`retriever` is `genesis.mcp.memory._retriever` — the MCP-module instance the proactive path uses and the one the pool was wired into in PR-4. `_ro_read` runs the read on a pooled `mode=ro` connection and **falls back to the shared connection on any pool miss/error**, so this is never worse than the pre-pool path. `mode=ro` sees committed state; no post-recall read depends on an uncommitted same-request write (`_bump_surfaced` runs after and is deferred).

**Deliberately out of scope:** `_surface_procedure` stays on the shared connection — its DB reads are a rare TTL-gated cache rebuild + a tiny PK verify (marginal contention), and wrapping it would hold a pooled slot across `cosine_similarity_batch` CPU. Revisit only if E2E shows procedure is a live residual.

## Tests
- **Functional** (`test_recall_read_pool.py`): a real `ReadConnectionPool` over a seeded temp db → asserts `_ro_read(_enrich, …)` backfills `_created_at`/`_wing` and `_ro_read(_breadcrumbs, …)` attaches the right `related_ids` off a pooled RO connection.
- **Wiring guard** (`test_proactive_engine.py`): drives `proactive_context` and asserts both `_enrich` and `_breadcrumbs` route through `_ro_read` — regression guard against reverting to bare `_enrich(db, …)`.
- The engine test's `_FakeRetriever` was taught the no-pool `_ro_read` seam so all pre-existing engine tests stay green. `pytest` → **40 passed**, ruff clean.

## Verification plan
Post-deploy: re-run the solo/4×/**7×** concurrent probe and compare `timings_ms.enrich` before/after — expect it to flatten like `activation` did, 0 503s maintained. **Falsifiable:** if enrich stays >500ms at 7×, first suspect pool-queue-wait (4 slots vs 7×) → bump `GENESIS_RECALL_READ_POOL_SIZE` (env, no code); only if a larger pool doesn't help is the lock-wait theory wrong.

Follow-up: f8a99778 (filed for this work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)