### PR TITLE
fix(follow-ups): stop follow_up_update clobbering status + orphaning completed_at

### DIFF
--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -72,16 +72,30 @@ async def create(
             scheduled_at, status, priority, pinned, kind, domain, goal_id,
             dedup_key, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?)""",
-        (fid, source, source_session, content, reason, strategy,
-         _normalize_scheduled_at(scheduled_at), priority, int(pinned),
-         kind, domain, goal_id, dedup_key, _now_iso()),
+        (
+            fid,
+            source,
+            source_session,
+            content,
+            reason,
+            strategy,
+            _normalize_scheduled_at(scheduled_at),
+            priority,
+            int(pinned),
+            kind,
+            domain,
+            goal_id,
+            dedup_key,
+            _now_iso(),
+        ),
     )
     await db.commit()
     return fid
 
 
 async def exists_by_dedup_key(
-    db: aiosqlite.Connection, dedup_key: str,
+    db: aiosqlite.Connection,
+    dedup_key: str,
 ) -> bool:
     """Return True if any follow-up already exists with *dedup_key*.
 
@@ -150,15 +164,17 @@ async def get_by_status(
     dom_clause, dom_params = _domain_eq(domain)
     kind_and = "" if include_tabled else "AND kind = 'follow_up' "
     cursor = await db.execute(
-        f"SELECT * FROM follow_ups WHERE status = ?{dom_clause} {kind_and}"
-        "ORDER BY created_at ASC",
+        f"SELECT * FROM follow_ups WHERE status = ?{dom_clause} {kind_and}ORDER BY created_at ASC",
         (status, *dom_params),
     )
     return [dict(row) for row in await cursor.fetchall()]
 
 
 async def get_actionable(
-    db: aiosqlite.Connection, *, limit: int = 50, include_tabled: bool = False,
+    db: aiosqlite.Connection,
+    *,
+    limit: int = 50,
+    include_tabled: bool = False,
     domain: str | None = None,
 ) -> list[dict]:
     """Get follow-ups needing attention: pending, failed, blocked.
@@ -183,7 +199,9 @@ async def get_actionable(
 
 
 async def get_scheduled_due(
-    db: aiosqlite.Connection, *, include_tabled: bool = False,
+    db: aiosqlite.Connection,
+    *,
+    include_tabled: bool = False,
 ) -> list[dict]:
     """Get scheduled follow-ups whose time has arrived.
 
@@ -202,7 +220,9 @@ async def get_scheduled_due(
 
 
 async def get_linked_active(
-    db: aiosqlite.Connection, *, include_tabled: bool = False,
+    db: aiosqlite.Connection,
+    *,
+    include_tabled: bool = False,
 ) -> list[dict]:
     """Get follow-ups linked to surplus tasks that are in flight.
 
@@ -241,6 +261,13 @@ async def update_status(
         parts.append("completed_at = CASE WHEN status = ? THEN completed_at ELSE ? END")
         params.append(status)
         params.append(_now_iso())
+    else:
+        # Non-terminal status: clear any completed_at left orphaned by a prior
+        # terminal→non-terminal transition (a row wrongly flipped to completed,
+        # then corrected back). completed_at means "reached terminal"; a
+        # non-terminal row must not carry one, or GC/report windows keyed off it
+        # mis-key the row (follow-up d67c83c7). No-op when already NULL.
+        parts.append("completed_at = NULL")
     if resolution_notes is not None:
         parts.append("resolution_notes = ?")
         params.append(resolution_notes)
@@ -253,6 +280,41 @@ async def update_status(
     if verification_notes is not None:
         parts.append("verification_notes = ?")
         params.append(verification_notes)
+    params.append(id)
+    cursor = await db.execute(
+        f"UPDATE follow_ups SET {', '.join(parts)} WHERE id = ?",
+        params,
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def update_notes(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    resolution_notes: str | None = None,
+    blocked_reason: str | None = None,
+) -> bool:
+    """Write resolution_notes / blocked_reason WITHOUT touching status.
+
+    A notes-only update must never re-write ``status``. The MCP follow_up_update
+    previously re-applied the status it had read moments earlier; against
+    Genesis's own live background writers (ego resolve_follow_ups, concurrent
+    sessions) racing the same row, that silently reverts a status change made in
+    between — a lost update (follow-up d67c83c7). This writes only the columns
+    actually provided, leaving status (and completed_at) untouched.
+    """
+    parts: list[str] = []
+    params: list[str | None] = []
+    if resolution_notes is not None:
+        parts.append("resolution_notes = ?")
+        params.append(resolution_notes)
+    if blocked_reason is not None:
+        parts.append("blocked_reason = ?")
+        params.append(blocked_reason)
+    if not parts:
+        return False
     params.append(id)
     cursor = await db.execute(
         f"UPDATE follow_ups SET {', '.join(parts)} WHERE id = ?",
@@ -305,7 +367,9 @@ async def set_pinned(
 
 
 async def get_summary_counts(
-    db: aiosqlite.Connection, *, include_tabled: bool = True,
+    db: aiosqlite.Connection,
+    *,
+    include_tabled: bool = True,
 ) -> dict[str, int]:
     """Get counts by status for dashboard badges.
 
@@ -540,7 +604,12 @@ _VALID_KIND = {"follow_up", "tabled"}
 _VALID_DOMAIN = {"internal", "user_world"}
 _VALID_PRIORITY = {"low", "medium", "high", "critical"}
 _VALID_STATUS = {
-    "pending", "scheduled", "in_progress", "completed", "failed", "blocked",
+    "pending",
+    "scheduled",
+    "in_progress",
+    "completed",
+    "failed",
+    "blocked",
 }
 
 # Allowlisted sort keys → ORDER BY fragment (never interpolate caller input).
@@ -579,7 +648,8 @@ async def set_kind(db: aiosqlite.Connection, id: str, kind: str) -> bool:
     if kind not in _VALID_KIND:
         raise ValueError(f"invalid kind {kind!r}; must be one of {sorted(_VALID_KIND)}")
     cursor = await db.execute(
-        "UPDATE follow_ups SET kind = ? WHERE id = ?", (kind, id),
+        "UPDATE follow_ups SET kind = ? WHERE id = ?",
+        (kind, id),
     )
     await db.commit()
     return cursor.rowcount > 0
@@ -592,7 +662,8 @@ async def set_domain(db: aiosqlite.Connection, id: str, domain: str | None) -> b
             f"invalid domain {domain!r}; must be one of {sorted(_VALID_DOMAIN)} or None"
         )
     cursor = await db.execute(
-        "UPDATE follow_ups SET domain = ? WHERE id = ?", (domain, id),
+        "UPDATE follow_ups SET domain = ? WHERE id = ?",
+        (domain, id),
     )
     await db.commit()
     return cursor.rowcount > 0
@@ -601,11 +672,10 @@ async def set_domain(db: aiosqlite.Connection, id: str, domain: str | None) -> b
 async def set_priority(db: aiosqlite.Connection, id: str, priority: str) -> bool:
     """Set a follow-up's priority (validated against the schema CHECK set)."""
     if priority not in _VALID_PRIORITY:
-        raise ValueError(
-            f"invalid priority {priority!r}; must be one of {sorted(_VALID_PRIORITY)}"
-        )
+        raise ValueError(f"invalid priority {priority!r}; must be one of {sorted(_VALID_PRIORITY)}")
     cursor = await db.execute(
-        "UPDATE follow_ups SET priority = ? WHERE id = ?", (priority, id),
+        "UPDATE follow_ups SET priority = ? WHERE id = ?",
+        (priority, id),
     )
     await db.commit()
     return cursor.rowcount > 0
@@ -619,7 +689,8 @@ async def delete_batch(db: aiosqlite.Connection, ids: list[str]) -> int:
         return 0
     placeholders = ",".join("?" for _ in ids)
     cursor = await db.execute(
-        f"DELETE FROM follow_ups WHERE id IN ({placeholders})", ids,
+        f"DELETE FROM follow_ups WHERE id IN ({placeholders})",
+        ids,
     )
     await db.commit()
     return cursor.rowcount
@@ -652,9 +723,7 @@ async def update_status_batch(
     Mirrors update_status: stamps completed_at on terminal states.
     """
     if status not in _VALID_STATUS:
-        raise ValueError(
-            f"invalid status {status!r}; must be one of {sorted(_VALID_STATUS)}"
-        )
+        raise ValueError(f"invalid status {status!r}; must be one of {sorted(_VALID_STATUS)}")
     if not ids:
         return 0
     parts = ["status = ?"]
@@ -668,6 +737,10 @@ async def update_status_batch(
         parts.append("completed_at = CASE WHEN status = ? THEN completed_at ELSE ? END")
         params.append(status)
         params.append(_now_iso())
+    else:
+        # Mirror update_status: clear completed_at on a non-terminal transition
+        # so a bulk reopen never leaves orphaned terminal timestamps (d67c83c7).
+        parts.append("completed_at = NULL")
     if resolution_notes is not None:
         parts.append("resolution_notes = ?")
         params.append(resolution_notes)
@@ -682,9 +755,7 @@ async def update_status_batch(
 
 async def get_distinct_sources(db: aiosqlite.Connection) -> list[str]:
     """Distinct source values present, for cockpit filter dropdowns."""
-    cursor = await db.execute(
-        "SELECT DISTINCT source FROM follow_ups ORDER BY source"
-    )
+    cursor = await db.execute("SELECT DISTINCT source FROM follow_ups ORDER BY source")
     return [row[0] for row in await cursor.fetchall()]
 
 
@@ -746,7 +817,11 @@ async def count_filtered(
 ) -> int:
     """Count follow-ups matching the cockpit filters."""
     where, params = _build_filter_where(
-        kind=kind, domain=domain, status=status, source=source, search=search,
+        kind=kind,
+        domain=domain,
+        status=status,
+        source=source,
+        search=search,
         status_exclude=status_exclude,
     )
     cursor = await db.execute(f"SELECT COUNT(*) FROM follow_ups{where}", params)
@@ -774,7 +849,11 @@ async def query_page(
     ``status_exclude`` hides terminal states (ignored when ``status`` is set).
     """
     where, params = _build_filter_where(
-        kind=kind, domain=domain, status=status, source=source, search=search,
+        kind=kind,
+        domain=domain,
+        status=status,
+        source=source,
+        search=search,
         status_exclude=status_exclude,
     )
     order = _SORT_MAP.get(sort, _SORT_MAP["priority"])

--- a/src/genesis/db/data_migrations/d0007_clear_orphaned_completed_at.py
+++ b/src/genesis/db/data_migrations/d0007_clear_orphaned_completed_at.py
@@ -1,0 +1,73 @@
+"""d0007 — clear completed_at orphaned on non-terminal follow_ups rows.
+
+``follow_ups.update_status`` stamped ``completed_at`` on a transition INTO a
+terminal state but never cleared it on the way back OUT. So a row wrongly
+flipped to ``completed`` (e.g. by a concurrent writer — the ego's
+``resolve_follow_ups`` or another live session — during a bulk audit) and then
+corrected back to ``in_progress``/``pending`` kept a stale ``completed_at``: a
+timestamp that lies about a row that never actually completed, mis-keying any
+GC/report window that reads ``completed_at`` directly (follow-up d67c83c7).
+
+The code fix (``update_status`` now NULLs ``completed_at`` on every non-terminal
+transition) stops NEW orphans; this migration heals the historical rows on
+EVERY install (idempotent, post-boot) — the bug shipped in the code, so peer
+installs carry orphans too, no per-install hand-fix.
+
+Deterministic + tightly scoped: only rows where ``completed_at IS NOT NULL AND
+status NOT IN ('completed','failed')``. A correctly-terminal row is never
+touched, and a fresh install (no such rows) is a clean no-op. One bounded
+UPDATE (orphans are a handful) — no per-row loop, so no batched commit needed.
+
+``migrate()``/``verify()`` are SYNC (framework contract, cf. d0005/d0006) on
+their own connections — never the runtime's async ``rt._db``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from genesis.env import genesis_db_path
+
+logger = logging.getLogger(__name__)
+
+requires_operator = False
+
+# A completed_at on a non-terminal row is the orphan signature. Terminal
+# (completed/failed) rows legitimately carry completed_at and are left alone.
+# The WHERE predicate is a fixed literal (identical in migrate/verify below).
+
+
+def migrate() -> dict:
+    """NULL completed_at on every non-terminal row that carries one."""
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    try:
+        cur = db.execute(
+            "UPDATE follow_ups SET completed_at = NULL "
+            "WHERE completed_at IS NOT NULL "
+            "AND status NOT IN ('completed', 'failed')"
+        )
+        db.commit()
+        cleared = cur.rowcount
+    finally:
+        db.close()
+    logger.info("d0007: cleared completed_at on %d orphaned non-terminal follow_ups", cleared)
+    return {"cleared": cleared}
+
+
+def verify() -> bool:
+    """Complete only when NO non-terminal row carries a completed_at.
+
+    Read via ``mode=ro`` (WAL-aware) so it sees migrate()'s just-committed write
+    — an ``immutable=1`` read would miss WAL-resident rows.
+    """
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        (n,) = db.execute(
+            "SELECT COUNT(*) FROM follow_ups "
+            "WHERE completed_at IS NOT NULL "
+            "AND status NOT IN ('completed', 'failed')"
+        ).fetchone()
+        return n == 0
+    finally:
+        db.close()

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -47,15 +47,21 @@ async def _impl_follow_up_create(
 
     valid_strategies = {"scheduled_task", "surplus_task", "ego_judgment", "user_input_needed"}
     if strategy not in valid_strategies:
-        return {"error": f"Invalid strategy '{strategy}'. Must be one of: {', '.join(sorted(valid_strategies))}"}
+        return {
+            "error": f"Invalid strategy '{strategy}'. Must be one of: {', '.join(sorted(valid_strategies))}"
+        }
 
     valid_priorities = {"low", "medium", "high", "critical"}
     if priority not in valid_priorities:
-        return {"error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"}
+        return {
+            "error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"
+        }
 
     valid_domains = {"internal", "user_world"}
     if domain is not None and domain not in valid_domains:
-        return {"error": f"Invalid domain '{domain}'. Must be one of: {', '.join(sorted(valid_domains))}"}
+        return {
+            "error": f"Invalid domain '{domain}'. Must be one of: {', '.join(sorted(valid_domains))}"
+        }
 
     valid_kinds = {"follow_up", "tabled"}
     if kind not in valid_kinds:
@@ -136,11 +142,15 @@ async def _impl_follow_up_list(
 
         if status_filter:
             items = await follow_ups.get_by_status(
-                db, status_filter, include_tabled=include_tabled,
+                db,
+                status_filter,
+                include_tabled=include_tabled,
             )
         else:
             items = await follow_ups.get_recent(
-                db, limit=limit, include_tabled=include_tabled,
+                db,
+                limit=limit,
+                include_tabled=include_tabled,
             )
 
         counts = await follow_ups.get_summary_counts(db, include_tabled=include_tabled)
@@ -176,11 +186,15 @@ async def _impl_follow_up_update(
 
     valid_statuses = {"pending", "scheduled", "in_progress", "completed", "failed", "blocked"}
     if status and status not in valid_statuses:
-        return {"error": f"Invalid status '{status}'. Must be one of: {', '.join(sorted(valid_statuses))}"}
+        return {
+            "error": f"Invalid status '{status}'. Must be one of: {', '.join(sorted(valid_statuses))}"
+        }
 
     valid_priorities = {"low", "medium", "high", "critical"}
     if priority and priority not in valid_priorities:
-        return {"error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"}
+        return {
+            "error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"
+        }
 
     valid_kinds = {"follow_up", "tabled"}
     if kind and kind not in valid_kinds:
@@ -216,13 +230,26 @@ async def _impl_follow_up_update(
             )
             if not updated:
                 return {"error": "Update failed — row not modified"}
-        elif resolution_notes or blocked_reason:
+        elif blocked_reason is not None:
+            # blocked_reason without an explicit status means "block this" — honor
+            # the documented contract (it previously silently kept the existing
+            # status). Any notes ride along on the same targeted status write.
             await follow_ups.update_status(
                 db,
                 follow_up_id,
-                existing["status"],
+                "blocked",
                 resolution_notes=resolution_notes,
                 blocked_reason=blocked_reason,
+            )
+        elif resolution_notes is not None:
+            # Notes-only update: write ONLY resolution_notes, never re-touch
+            # status. Re-applying the status read at the top of this call races
+            # Genesis's own live writers and silently reverts their change
+            # (lost update, follow-up d67c83c7).
+            await follow_ups.update_notes(
+                db,
+                follow_up_id,
+                resolution_notes=resolution_notes,
             )
 
         refreshed = await follow_ups.get_by_id(db, follow_up_id)

--- a/tests/test_db/test_d0007_clear_orphaned_completed_at.py
+++ b/tests/test_db/test_d0007_clear_orphaned_completed_at.py
@@ -1,0 +1,65 @@
+"""d0007 — clear completed_at orphaned on non-terminal follow_ups rows.
+
+The bug: update_status stamped completed_at on entry to a terminal state but
+never cleared it on the way back out, so a wrongly-completed-then-corrected row
+kept a lying terminal timestamp (follow-up d67c83c7). This migration heals the
+historical rows; the code fix stops new ones.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import genesis.db.data_migrations.d0007_clear_orphaned_completed_at as d0007
+
+
+def _seed(path, rows) -> None:
+    db = sqlite3.connect(path)
+    db.execute("CREATE TABLE follow_ups (id TEXT PRIMARY KEY, status TEXT, completed_at TEXT)")
+    db.executemany(
+        "INSERT INTO follow_ups (id, status, completed_at) VALUES (?, ?, ?)",
+        rows,
+    )
+    db.commit()
+    db.close()
+
+
+def test_clears_orphans_leaves_terminal_and_clean(tmp_path, monkeypatch):
+    _seed(
+        tmp_path / "genesis.db",
+        [
+            # orphans: completed_at set on a non-terminal row
+            ("orphan-ip", "in_progress", "2026-07-22T14:46:00+00:00"),
+            ("orphan-pend", "pending", "2026-07-22T14:46:00+00:00"),
+            ("orphan-blocked", "blocked", "2026-07-22T14:46:00+00:00"),
+            # legit terminal rows: completed_at is correct, must be untouched
+            ("legit-done", "completed", "2026-07-20T00:00:00+00:00"),
+            ("legit-fail", "failed", "2026-07-20T00:00:00+00:00"),
+            # already-clean non-terminal row
+            ("clean-pend", "pending", None),
+        ],
+    )
+    monkeypatch.setattr(d0007, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+
+    assert d0007.verify() is False
+    assert d0007.migrate() == {"cleared": 3}
+    assert d0007.verify() is True
+
+    db = sqlite3.connect(tmp_path / "genesis.db")
+    rows = dict(db.execute("SELECT id, completed_at FROM follow_ups").fetchall())
+    db.close()
+    assert rows["orphan-ip"] is None
+    assert rows["orphan-pend"] is None
+    assert rows["orphan-blocked"] is None
+    assert rows["legit-done"] == "2026-07-20T00:00:00+00:00"  # untouched
+    assert rows["legit-fail"] == "2026-07-20T00:00:00+00:00"  # untouched
+    assert rows["clean-pend"] is None
+
+
+def test_noop_on_fresh_install(tmp_path, monkeypatch):
+    """No orphans → verify() already True, migrate() a clean no-op."""
+    _seed(tmp_path / "genesis.db", [("clean", "pending", None)])
+    monkeypatch.setattr(d0007, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+    assert d0007.verify() is True
+    assert d0007.migrate() == {"cleared": 0}
+    assert d0007.verify() is True

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -33,8 +33,7 @@ async def test_purge_completed_deletes_old(db):
 async def test_purge_completed_keeps_recent(db):
     """Recently completed follow-ups survive."""
     fid = await follow_ups.create(db, **_BASE)
-    await follow_ups.update_status(db, fid, status="completed",
-                                   resolution_notes="done")
+    await follow_ups.update_status(db, fid, status="completed", resolution_notes="done")
 
     count = await follow_ups.purge_completed(db)
     assert count == 0
@@ -89,7 +88,11 @@ async def test_purge_failed_old(db):
 async def test_create_with_kind_and_domain(db):
     """create() persists kind, domain, and goal_id."""
     fid = await follow_ups.create(
-        db, **_BASE, kind="tabled", domain="internal", goal_id="g1",
+        db,
+        **_BASE,
+        kind="tabled",
+        domain="internal",
+        goal_id="g1",
     )
     row = await follow_ups.get_by_id(db, fid)
     assert row["kind"] == "tabled"
@@ -155,10 +158,14 @@ async def test_delete_removes_row(db):
 
 async def test_query_page_filters_search_and_null_domain(db):
     await follow_ups.create(
-        db, **{**_BASE, "content": "alpha internal item"}, domain="internal",
+        db,
+        **{**_BASE, "content": "alpha internal item"},
+        domain="internal",
     )
     await follow_ups.create(
-        db, **{**_BASE, "content": "beta user item"}, domain="user_world",
+        db,
+        **{**_BASE, "content": "beta user item"},
+        domain="user_world",
     )
     await follow_ups.create(db, **{**_BASE, "content": "gamma unclassified"})
 
@@ -222,9 +229,10 @@ async def test_set_kind_batch_rejects_invalid(db):
 
 async def test_update_status_batch_stamps_completed_at(db):
     ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]
-    assert await follow_ups.update_status_batch(
-        db, ids, "completed", resolution_notes="bulk done"
-    ) == 2
+    assert (
+        await follow_ups.update_status_batch(db, ids, "completed", resolution_notes="bulk done")
+        == 2
+    )
     for fid in ids:
         row = await follow_ups.get_by_id(db, fid)
         assert row["status"] == "completed"
@@ -312,13 +320,18 @@ async def _seed_pending_domains(db):
     """One pending follow-up per domain. Returns {domain_key: id}."""
     return {
         "internal": await follow_ups.create(
-            db, **{**_BASE, "content": "internal item"}, domain="internal",
+            db,
+            **{**_BASE, "content": "internal item"},
+            domain="internal",
         ),
         "user_world": await follow_ups.create(
-            db, **{**_BASE, "content": "user item"}, domain="user_world",
+            db,
+            **{**_BASE, "content": "user item"},
+            domain="user_world",
         ),
         "null": await follow_ups.create(
-            db, **{**_BASE, "content": "unclassified item"},
+            db,
+            **{**_BASE, "content": "unclassified item"},
         ),
     }
 
@@ -338,9 +351,7 @@ async def test_get_pending_domain_none_is_noop(db):
 
 async def test_get_by_status_domain_exact_match(db):
     ids = await _seed_pending_domains(db)
-    scoped = {
-        r["id"] for r in await follow_ups.get_by_status(db, "pending", domain="user_world")
-    }
+    scoped = {r["id"] for r in await follow_ups.get_by_status(db, "pending", domain="user_world")}
     assert scoped == {ids["user_world"]}
     unscoped = {r["id"] for r in await follow_ups.get_by_status(db, "pending")}
     assert unscoped == set(ids.values())  # backward-compat no-op
@@ -356,17 +367,23 @@ async def test_get_actionable_domain_exact_match(db):
 
 async def test_get_recently_completed_domain_exact_match(db):
     int_id = await follow_ups.create(
-        db, **{**_BASE, "content": "int done"}, domain="internal",
+        db,
+        **{**_BASE, "content": "int done"},
+        domain="internal",
     )
     uw_id = await follow_ups.create(
-        db, **{**_BASE, "content": "uw done"}, domain="user_world",
+        db,
+        **{**_BASE, "content": "uw done"},
+        domain="user_world",
     )
     null_id = await follow_ups.create(db, **{**_BASE, "content": "null done"})
     await follow_ups.update_status(db, int_id, "completed")
     await follow_ups.update_status(db, uw_id, "completed")
     await follow_ups.update_status(db, null_id, "completed")
 
-    scoped = [r["content"] for r in await follow_ups.get_recently_completed(db, domain="user_world")]
+    scoped = [
+        r["content"] for r in await follow_ups.get_recently_completed(db, domain="user_world")
+    ]
     assert scoped == ["uw done"]  # internal + NULL excluded (NB: result has no domain col)
     unscoped = {r["content"] for r in await follow_ups.get_recently_completed(db)}
     assert unscoped == {"int done", "uw done", "null done"}  # NULL survives unscoped no-op
@@ -377,10 +394,15 @@ async def test_get_actionable_domain_excludes_pinned_internal(db):
     PR3 decision that pinned/high-priority cross-domain items re-home to the
     cockpit, NOT the user (CEO) ego."""
     uw = await follow_ups.create(
-        db, **{**_BASE, "content": "user item"}, domain="user_world",
+        db,
+        **{**_BASE, "content": "user item"},
+        domain="user_world",
     )
     pinned_internal = await follow_ups.create(
-        db, **{**_BASE, "content": "pinned internal"}, domain="internal", pinned=True,
+        db,
+        **{**_BASE, "content": "pinned internal"},
+        domain="internal",
+        pinned=True,
     )
     ids = {r["id"] for r in await follow_ups.get_actionable(db, domain="user_world")}
     assert ids == {uw}
@@ -399,9 +421,7 @@ async def test_query_page_status_exclude_hides_terminal(db):
     rows = await follow_ups.query_page(db, status_exclude=["completed", "failed"])
     ids = {r["id"] for r in rows}
     assert keep in ids and done not in ids
-    assert await follow_ups.count_filtered(
-        db, status_exclude=["completed", "failed"]
-    ) == 1
+    assert await follow_ups.count_filtered(db, status_exclude=["completed", "failed"]) == 1
 
 
 async def test_query_page_explicit_status_overrides_exclude(db):
@@ -410,7 +430,9 @@ async def test_query_page_explicit_status_overrides_exclude(db):
     await follow_ups.update_status(db, done, status="completed")
 
     rows = await follow_ups.query_page(
-        db, status="completed", status_exclude=["completed"],
+        db,
+        status="completed",
+        status_exclude=["completed"],
     )
     assert {r["id"] for r in rows} == {done}
 
@@ -421,8 +443,7 @@ async def test_query_page_pinned_floats_to_top(db):
     await follow_ups.create(db, **{**_BASE, "content": "newer unpinned"})
     # Make the pinned row OLDER so a plain recency/priority sort would bury it.
     await db.execute(
-        "UPDATE follow_ups SET pinned = 1, "
-        "created_at = '2025-01-01T00:00:00+00:00' WHERE id = ?",
+        "UPDATE follow_ups SET pinned = 1, created_at = '2025-01-01T00:00:00+00:00' WHERE id = ?",
         (pinned_old,),
     )
     await db.commit()
@@ -448,13 +469,24 @@ async def test_query_page_status_sort_ranks_by_actionability(db):
 # ─── Inbox attention-marker decay (WATCH/BOOKMARK tabled lane) ────────────────
 
 
-async def _make_marker(db, *, age_days: int, kind="tabled",
-                       source="inbox_evaluation", content="[WATCH] x",
-                       status="pending"):
+async def _make_marker(
+    db,
+    *,
+    age_days: int,
+    kind="tabled",
+    source="inbox_evaluation",
+    content="[WATCH] x",
+    status="pending",
+):
     """Create a follow-up, backdate created_at by *age_days*, set *status*."""
     fid = await follow_ups.create(
-        db, source=source, content=content, reason="r",
-        strategy="ego_judgment", priority="low", kind=kind,
+        db,
+        source=source,
+        content=content,
+        reason="r",
+        strategy="ego_judgment",
+        priority="low",
+        kind=kind,
     )
     from datetime import UTC, datetime, timedelta
 
@@ -519,7 +551,10 @@ async def test_decay_keeps_recent_marker(db):
 async def test_decay_ignores_actionable_follow_up_lane(db):
     """An old ADOPT/ADAPT/EXPLORE follow_up (not tabled) is never decayed."""
     fid = await _make_marker(
-        db, age_days=200, kind="follow_up", content="[ADAPT] x",
+        db,
+        age_days=200,
+        kind="follow_up",
+        content="[ADAPT] x",
     )
 
     count = await follow_ups.decay_stale_inbox_markers(db, older_than_days=60)
@@ -549,10 +584,7 @@ async def test_get_recently_resolved_excludes_tabled(db):
     assert fu in ids
     assert marker not in ids
 
-    ids_all = {
-        r["id"]
-        for r in await follow_ups.get_recently_resolved(db, include_tabled=True)
-    }
+    ids_all = {r["id"] for r in await follow_ups.get_recently_resolved(db, include_tabled=True)}
     assert marker in ids_all
 
 
@@ -566,7 +598,9 @@ async def test_get_recently_completed_excludes_tabled(db):
     fu = (await follow_ups.get_pending(db))[0]["id"]
     await follow_ups.update_status(db, fu, status="completed")
     marker = await follow_ups.create(
-        db, **{**_BASE, "content": "[BOOKMARK] decayed"}, kind="tabled",
+        db,
+        **{**_BASE, "content": "[BOOKMARK] decayed"},
+        kind="tabled",
     )
     await follow_ups.update_status(db, marker, status="completed")
 
@@ -575,7 +609,63 @@ async def test_get_recently_completed_excludes_tabled(db):
     assert "[BOOKMARK] decayed" not in contents
 
     contents_all = {
-        r["content"]
-        for r in await follow_ups.get_recently_completed(db, include_tabled=True)
+        r["content"] for r in await follow_ups.get_recently_completed(db, include_tabled=True)
     }
     assert "[BOOKMARK] decayed" in contents_all
+
+
+# ─── d67c83c7: notes-only never touches status; reopen clears completed_at ────
+# Two hazards fixed together: (1) update_notes writes ONLY notes/blocked cols —
+# it must not re-apply a (possibly stale) status, which under Genesis's live
+# concurrent writers silently reverts their status change (lost update); and
+# (2) update_status clears completed_at on a transition BACK to a non-terminal
+# state, so a row wrongly completed then corrected doesn't keep a lying stamp.
+
+
+async def test_update_notes_leaves_status_and_completed_at_untouched(db):
+    """update_notes writes only resolution_notes — status/completed_at unchanged."""
+    fid = await follow_ups.create(db, **_BASE)
+    await db.execute("UPDATE follow_ups SET status = 'in_progress' WHERE id = ?", (fid,))
+    await db.commit()
+    assert await follow_ups.update_notes(db, fid, resolution_notes="progress note")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "in_progress"  # NOT reverted/clobbered
+    assert row["resolution_notes"] == "progress note"
+    assert row["completed_at"] is None
+
+
+async def test_update_notes_blocked_reason_only(db):
+    """update_notes can set blocked_reason alone, still not touching status."""
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.update_notes(db, fid, blocked_reason="waiting on X")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "pending"
+    assert row["blocked_reason"] == "waiting on X"
+
+
+async def test_update_notes_noop_when_nothing_given(db):
+    """No notes and no blocked_reason → no write, returns False."""
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.update_notes(db, fid) is False
+
+
+async def test_update_status_reopen_clears_orphaned_completed_at(db):
+    """completed→in_progress must NULL completed_at (the d67c83c7 orphan)."""
+    fid = await follow_ups.create(db, **_BASE)
+    await _force_terminal(db, fid, "completed")  # completed_at = _OLD
+    await follow_ups.update_status(db, fid, "in_progress")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "in_progress"
+    assert row["completed_at"] is None  # orphan cleared
+
+
+async def test_update_status_batch_reopen_clears_completed_at(db):
+    """Batch reopen mirrors: a non-terminal batch transition clears completed_at."""
+    ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]
+    for fid in ids:
+        await _force_terminal(db, fid, "completed")
+    await follow_ups.update_status_batch(db, ids, "pending")
+    for fid in ids:
+        row = await follow_ups.get_by_id(db, fid)
+        assert row["status"] == "pending"
+        assert row["completed_at"] is None

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -16,7 +16,9 @@ async def test_create_default_kind_is_follow_up(db):
     """Without an explicit kind, a create lands in the actionable follow_up lane."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res = await follow_up_tools._impl_follow_up_create(
-            content="do the thing", reason="because", strategy="ego_judgment",
+            content="do the thing",
+            reason="because",
+            strategy="ego_judgment",
         )
     assert "id" in res, res
     assert res["kind"] == "follow_up"
@@ -28,8 +30,10 @@ async def test_create_kind_tabled(db):
     """kind='tabled' routes a someday/maybe into the tabled lane, off the actionable queue."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res = await follow_up_tools._impl_follow_up_create(
-            content="maybe explore idea Y someday", reason="interesting",
-            strategy="ego_judgment", kind="tabled",
+            content="maybe explore idea Y someday",
+            reason="interesting",
+            strategy="ego_judgment",
+            kind="tabled",
         )
     assert "id" in res, res
     assert res["kind"] == "tabled"
@@ -44,7 +48,10 @@ async def test_create_kind_tabled(db):
 async def test_create_invalid_kind_errors(db):
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res = await follow_up_tools._impl_follow_up_create(
-            content="x", reason="y", strategy="ego_judgment", kind="bogus",
+            content="x",
+            reason="y",
+            strategy="ego_judgment",
+            kind="bogus",
         )
     assert "error" in res
     assert "kind" in res["error"].lower()
@@ -54,7 +61,9 @@ async def test_update_relanes_follow_up_to_tabled(db):
     """follow_up_update kind='tabled' demotes an actionable item into the tabled lane."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         created = await follow_up_tools._impl_follow_up_create(
-            content="reconsider later", reason="low priority", strategy="ego_judgment",
+            content="reconsider later",
+            reason="low priority",
+            strategy="ego_judgment",
         )
         fid = created["id"]
         res = await follow_up_tools._impl_follow_up_update(fid, kind="tabled")
@@ -66,7 +75,9 @@ async def test_update_relanes_follow_up_to_tabled(db):
 async def test_update_invalid_kind_errors(db):
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         created = await follow_up_tools._impl_follow_up_create(
-            content="z", reason="z", strategy="ego_judgment",
+            content="z",
+            reason="z",
+            strategy="ego_judgment",
         )
         res = await follow_up_tools._impl_follow_up_update(created["id"], kind="nope")
     assert "error" in res
@@ -77,10 +88,15 @@ async def test_list_excludes_tabled_by_default(db):
     """follow_up_list hides tabled items from the agent view and reports them separately."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         await follow_up_tools._impl_follow_up_create(
-            content="actionable thing", reason="r", strategy="ego_judgment",
+            content="actionable thing",
+            reason="r",
+            strategy="ego_judgment",
         )
         await follow_up_tools._impl_follow_up_create(
-            content="someday idea", reason="r", strategy="ego_judgment", kind="tabled",
+            content="someday idea",
+            reason="r",
+            strategy="ego_judgment",
+            kind="tabled",
         )
         res = await follow_up_tools._impl_follow_up_list()
 
@@ -95,10 +111,15 @@ async def test_list_include_tabled_shows_them(db):
     """Opting in surfaces tabled items alongside actionable ones."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         await follow_up_tools._impl_follow_up_create(
-            content="actionable thing", reason="r", strategy="ego_judgment",
+            content="actionable thing",
+            reason="r",
+            strategy="ego_judgment",
         )
         await follow_up_tools._impl_follow_up_create(
-            content="someday idea", reason="r", strategy="ego_judgment", kind="tabled",
+            content="someday idea",
+            reason="r",
+            strategy="ego_judgment",
+            kind="tabled",
         )
         res = await follow_up_tools._impl_follow_up_list(include_tabled=True)
 
@@ -110,12 +131,17 @@ async def test_list_status_filter_excludes_tabled(db):
     """The status_filter path (get_by_status) also excludes tabled by default."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         await follow_up_tools._impl_follow_up_create(
-            content="actionable pending", reason="r", strategy="ego_judgment",
+            content="actionable pending",
+            reason="r",
+            strategy="ego_judgment",
         )
         # tabled items keep their status ('pending' by default), so a naive
         # status filter would surface them without the kind exclusion.
         await follow_up_tools._impl_follow_up_create(
-            content="tabled pending", reason="r", strategy="ego_judgment", kind="tabled",
+            content="tabled pending",
+            reason="r",
+            strategy="ego_judgment",
+            kind="tabled",
         )
         res = await follow_up_tools._impl_follow_up_list(status_filter="pending")
     kinds = [f["kind"] for f in res["follow_ups"]]
@@ -124,6 +150,76 @@ async def test_list_status_filter_excludes_tabled(db):
     # ...unless the caller opts in.
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res_incl = await follow_up_tools._impl_follow_up_list(
-            status_filter="pending", include_tabled=True,
+            status_filter="pending",
+            include_tabled=True,
         )
     assert sorted(f["kind"] for f in res_incl["follow_ups"]) == ["follow_up", "tabled"]
+
+
+# ─── d67c83c7: notes-only preserves status; blocked_reason blocks; no revert ──
+
+
+async def test_update_notes_only_preserves_status(db):
+    """A notes-only follow_up_update must NOT change status (routes to update_notes)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="active work",
+            reason="r",
+            strategy="ego_judgment",
+        )
+        fid = created["id"]
+        await follow_up_tools._impl_follow_up_update(fid, status="in_progress")
+        res = await follow_up_tools._impl_follow_up_update(
+            fid,
+            resolution_notes="a progress note, no status",
+        )
+    assert res["status"] == "in_progress"  # preserved, not flipped
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "in_progress"
+    assert row["resolution_notes"] == "a progress note, no status"
+
+
+async def test_update_blocked_reason_sets_blocked(db):
+    """blocked_reason without an explicit status sets status='blocked' (documented contract)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="thing",
+            reason="r",
+            strategy="ego_judgment",
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(
+            fid,
+            blocked_reason="waiting on upstream PR",
+        )
+    assert res["status"] == "blocked"
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "blocked"
+    assert row["blocked_reason"] == "waiting on upstream PR"
+
+
+async def test_notes_only_does_not_write_stale_status(db):
+    """Lost-update regression (d67c83c7): with a STALE in_progress read but the DB
+    row already completed by a concurrent writer, a notes-only update must write
+    ONLY notes — never the stale status back. RED on the old elif branch (which
+    re-wrote existing['status'])."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="racy",
+            reason="r",
+            strategy="ego_judgment",
+        )
+        fid = created["id"]
+        # Concurrent writer (e.g. ego resolve_follow_ups) completes it.
+        await follow_ups.update_status(db, fid, "completed", resolution_notes="ego done")
+
+        # This call's reads all return a STALE in_progress snapshot.
+        async def _stale_get(_db, _id):
+            return {"id": fid, "status": "in_progress", "priority": "medium"}
+
+        with patch.object(follow_ups, "get_by_id", _stale_get):
+            await follow_up_tools._impl_follow_up_update(fid, resolution_notes="fg note")
+
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"  # stale in_progress NOT written back
+    assert row["resolution_notes"] == "fg note"


### PR DESCRIPTION
## Problem (follow-up `d67c83c7`)

A follow-up audit reported `follow_up_update` intermittently flipping `status`→completed and `pinned`→true on calls that omitted those params, theorizing a **full-row read-modify-write** race.

Investigation disproved that theory: **every CRUD writer is already a targeted column `UPDATE`** — there is no full-row rewrite. The two reported symptoms were:
- **`pinned`→true**: a measurement artifact. The only `pinned` writers are the explicit MCP param and the dashboard toggle (no autonomous pinner exists); the affected rows were *already pinned*, and the tool's refreshed-return surfaced the true state, misread as a flip.
- **`status`→completed**: a concurrent writer (the ego's `resolve_follow_ups`, or another live session) legitimately completing the row mid-audit — not a `follow_up_update` clobber.

But the investigation surfaced **two real data-integrity bugs** (plus a doc/behavior mismatch):

### 1. Notes-only updates re-wrote `status` (lost update)
The MCP notes-only branch called `update_status(existing["status"], …)`, re-applying a status read ~30 lines earlier. Against Genesis's own live writers racing the same row, that **silently reverts** a status change made in between.
**Fix:** new `follow_ups.update_notes()` writes only the notes/blocked columns; the MCP branch routes to it and never touches `status`.

### 2. Orphaned `completed_at` on non-terminal rows
`update_status` stamped `completed_at` entering a terminal state but **never cleared it** on the way back out. A row wrongly completed then corrected to `in_progress`/`pending` kept a lying terminal timestamp that mis-keys GC/report windows. Verified live: 3+ rows carried `completed_at` while non-terminal.
**Fix:** `update_status` (+ `_batch`) NULLs `completed_at` on any non-terminal transition; **data migration `d0007`** heals historical orphans on every install (idempotent, post-boot).

### 3. `blocked_reason` didn't block
`blocked_reason` without an explicit `status` kept the old status, contradicting the documented contract ("sets status to blocked if status not provided"). Now sets `status='blocked'`.

## Tests
- **CRUD**: `update_notes` leaves status/`completed_at` untouched; notes-only regression; reopen clears `completed_at`; batch mirror.
- **MCP**: notes-only preserves status; `blocked_reason` blocks; **stale-read lost-update regression** (patches `get_by_id` stale → proves the old `elif` reverted, new path does not).
- **d0007**: clears orphans, spares terminal rows, no-op on fresh install.
- Adjacent consumers (`test_dispatch`, cockpit API) green.

## Notes
- Diff includes formatter churn from the repo's ruff-format PostToolUse hook (whole-file reflow; semantically identical, `ruff check` clean). Logical change is ~90 lines.
- RED-on-old-code verified by logic, not `git stash` (stash is repo-global; other worktrees active).

Ledger: d67c83c777f9494aa4db726834d1f8a5

🤖 Generated with [Claude Code](https://claude.com/claude-code)