### PR TITLE
fix(follow-ups): stop notes-only follow_up_update reverting concurrent status

### DIFF
--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -262,6 +262,41 @@ async def update_status(
     return cursor.rowcount > 0
 
 
+async def update_notes(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    resolution_notes: str | None = None,
+    blocked_reason: str | None = None,
+) -> bool:
+    """Update resolution_notes/blocked_reason WITHOUT touching status.
+
+    A targeted partial UPDATE of only the note columns the caller supplied.
+    The notes-only update path uses this instead of re-writing status: the
+    prior code re-asserted the status it had READ at entry, so a concurrent
+    (cross-process) status transition landing in that gap was silently
+    reverted -- a lost update. Touching neither status nor completed_at closes
+    that window. Returns True if a row was modified, False on a no-op (no note
+    fields supplied)."""
+    parts: list[str] = []
+    params: list[str | None] = []
+    if resolution_notes is not None:
+        parts.append("resolution_notes = ?")
+        params.append(resolution_notes)
+    if blocked_reason is not None:
+        parts.append("blocked_reason = ?")
+        params.append(blocked_reason)
+    if not parts:
+        return False
+    params.append(id)
+    cursor = await db.execute(
+        f"UPDATE follow_ups SET {', '.join(parts)} WHERE id = ?",
+        params,
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
 async def link_task(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -217,10 +217,13 @@ async def _impl_follow_up_update(
             if not updated:
                 return {"error": "Update failed — row not modified"}
         elif resolution_notes or blocked_reason:
-            await follow_ups.update_status(
+            # Notes-only update: write ONLY the note columns. Do NOT re-assert
+            # existing["status"] (read at entry) -- a concurrent status
+            # transition landing between that read and this write would be
+            # reverted (lost update). See crud.follow_ups.update_notes.
+            await follow_ups.update_notes(
                 db,
                 follow_up_id,
-                existing["status"],
                 resolution_notes=resolution_notes,
                 blocked_reason=blocked_reason,
             )

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -284,6 +284,40 @@ async def test_batch_notes_only_rewrite_preserves_completed_at(db):
         assert row["resolution_notes"] == "bulk note"
 
 
+# --- update_notes: targeted note write that never touches status ------------
+# The notes-only handler path (follow_up_update with resolution_notes but no
+# status) uses update_notes so it can no longer re-assert a stale status read
+# and revert a concurrent transition (lost update).
+
+
+async def test_update_notes_writes_notes_without_touching_status(db):
+    """update_notes sets notes but leaves status untouched."""
+    fid = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_status(db, fid, "in_progress")
+    assert await follow_ups.update_notes(db, fid, resolution_notes="progress")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "in_progress"  # NOT reverted to pending
+    assert row["resolution_notes"] == "progress"
+
+
+async def test_update_notes_preserves_completed_at(db):
+    """A notes-only write on a completed row disturbs neither status nor completed_at."""
+    fid = await follow_ups.create(db, **_BASE)
+    await _force_terminal(db, fid, "completed")
+    await follow_ups.update_notes(db, fid, resolution_notes="post-hoc note")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"
+    assert row["completed_at"] == _OLD
+    assert row["resolution_notes"] == "post-hoc note"
+
+
+async def test_update_notes_no_fields_is_noop(db):
+    """No note fields supplied -> no-op returning False, nothing changed."""
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.update_notes(db, fid) is False
+    assert (await follow_ups.get_by_id(db, fid))["status"] == "pending"
+
+
 async def test_batch_failed_to_completed_stamps_fresh(db):
     """update_status_batch: genuine failed→completed transition stamps fresh."""
     ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -127,3 +127,34 @@ async def test_list_status_filter_excludes_tabled(db):
             status_filter="pending", include_tabled=True,
         )
     assert sorted(f["kind"] for f in res_incl["follow_ups"]) == ["follow_up", "tabled"]
+
+
+async def test_notes_only_update_does_not_revert_concurrent_status(db):
+    """Regression: a notes-only follow_up_update must NOT re-assert the status it
+    read at entry. A concurrent (cross-process) status transition landing between
+    that read and the notes write was previously reverted (lost update)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="race target", reason="r", strategy="ego_judgment",
+        )
+        fid = created["id"]
+
+        # Flip status to in_progress in the gap between the handler's initial
+        # get_by_id (its status read) and its notes write, by hooking the FIRST
+        # get_by_id call to transition the row right after it returns the stale row.
+        real_get = follow_ups.get_by_id
+        seen = {"n": 0}
+
+        async def racing_get(conn, id_):
+            row = await real_get(conn, id_)
+            if seen["n"] == 0:
+                seen["n"] += 1
+                await follow_ups.update_status(conn, id_, "in_progress")
+            return row
+
+        with patch.object(follow_ups, "get_by_id", racing_get):
+            await follow_up_tools._impl_follow_up_update(fid, resolution_notes="a note")
+
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "in_progress"  # NOT reverted to the stale 'pending' read
+    assert row["resolution_notes"] == "a note"


### PR DESCRIPTION
## What

The notes-only branch of `_impl_follow_up_update` (the `follow_up_update` MCP tool) re-asserted the `status` it read at handler entry, so a concurrent cross-process `status` transition landing between that read and the notes write was silently reverted — a lost update.

**Fix:** add `crud.follow_ups.update_notes()` — a targeted partial `UPDATE` of only the note columns the caller supplied, touching neither `status` nor `completed_at` — and route the notes-only path through it. The `if status:` branch and the priority/pinned/kind writes are unchanged.

## Diagnosis correction

This item (`d67c83c7`) was originally filed as a **`pinned` field-clobber** (fields flipping under sequential, non-overlapping calls). That is **refuted**: `set_pinned` is the only writer of the `pinned` column, and the handler calls it *only* when `pinned` is explicitly passed, so an omitted-`pinned` update cannot change it. The `pinned:true` reads observed during a ledger audit were pre-existing pins misread as self-inflicted clobber. The genuine defect is the narrow status re-assert above.

## Tests

- `test_notes_only_update_does_not_revert_concurrent_status` — handler regression, **proven RED without the fix** (a status transition interleaved between the handler's read and write gets reverted), GREEN with it.
- `test_update_notes_*` — unit coverage: status untouched, `completed_at` preserved on a terminal row, no-op returning `False` on empty input.
- Full run of both files: 57 passed, ruff clean.

## Deploy path

- `crud/follow_ups.py` (runtime callers — dispatcher, ego): `git pull` + server restart.
- `follow_up_tools.py` (MCP tool): takes effect on next CC session start.
- No schema change, no migration; `update_notes` is purely additive (no existing caller affected).

Ledger: 4764332657754650b5992fbb47d17a65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
