### PR TITLE
docs(voice-master): anti-slop doc-level tells + generation guidance

### DIFF
--- a/src/genesis/skills/voice-master/SKILL.md
+++ b/src/genesis/skills/voice-master/SKILL.md
@@ -112,7 +112,11 @@ curate) × **whose voice** (user's [default] / stealth, see Stealth Mode).
    invent stale-able specifics (elapsed time like "four months building",
    star/line/version counts, adoption stats); if a number isn't given, omit it.
    Register scales with audience (see table); drop profanity at formality 3 and
-   above.
+   above. **First person is fine:** use I/my/me where they fit — "I" reads as
+   honest, not unprofessional; don't sterilize the pronoun out to sound
+   "objective." **Exclamation marks are fine:** use them where they feel natural
+   for energy or genuine enthusiasm; don't overdo it, but don't strip them out of
+   otherwise-human writing either.
 4. **Hand off to medium skill** — if a downstream skill exists for the medium
    (e.g., linkedin-post-writer), hand the voice-loaded content off for
    medium-specific formatting.

--- a/src/genesis/skills/voice-master/references/anti-slop.md
+++ b/src/genesis/skills/voice-master/references/anti-slop.md
@@ -137,6 +137,45 @@ not per paragraph. Stacking them is an AI fingerprint.
   "Absolutely").
 - Hedging openers ("It's worth considering that…", "It's important to note…").
 
+### Deliverable shipped as raw .md
+
+A finished deliverable — a report, proposal, take-home, one-pager, brief —
+handed back as a raw `.md` file with literal `#`/`##` headers, `**bold**`, and
+`-` bullets visible on the page is a tell that a model generated it and nobody
+repackaged it. People send the format the context expects: a `.docx`, a PDF, a
+slide deck, a formatted email. Markdown syntax showing through in the final
+artifact means the deliverable was never actually finished. (Sending markdown
+is native where markdown *is* the medium — a README, a GitHub comment, a chat
+message — so scope this to things going out as a document under someone's name.)
+
+### Document-level structural tells
+
+The sentence- and paragraph-level tells above miss AI slop that only shows at
+the whole-document scale. These apply to any structured deliverable — report,
+essay, proposal, deck — regardless of medium, not just LinkedIn:
+
+- **Meta-narration.** The document narrates its own structure: "This report
+  covers three areas…", "In the following sections we will…", "Having
+  established X, we now turn to Y." Real writers just write the thing.
+- **Exhaustive-coverage-as-virtue.** Every angle covered, every subtopic given
+  its own section, nothing left out — comprehensiveness treated as the goal.
+  Humans prioritize: they omit what doesn't matter and spend the room on what
+  does.
+- **Equal-length sections.** Every section roughly the same size because the
+  outline had N headings and each got filled to the same depth. Real documents
+  are lopsided; the part that matters is longer.
+- **Relentless parallelism.** Every heading the same grammatical shape, every
+  bullet the same length and structure, every section opening the same way.
+  Mechanical symmetry across the whole document reads as generated.
+- **Table overload.** Reaching for a table (or a bulleted matrix) whenever
+  information *could* be a table, rather than when prose would be worse. One
+  well-placed table earns its keep; five in a two-page document is an assistant
+  reflex.
+- **Absent point of view.** The document reports and organizes but never takes
+  a position — never says what matters most, what's weak, or what the writer
+  would actually do. AI defaults to a neutral survey; a real deliverable has a
+  recommendation.
+
 ---
 
 ## Professional / LinkedIn


### PR DESCRIPTION
## What

Three doc-only additions to the `voice-master` skill, hardening its anti-slop coverage and generation guidance. No code touched.

### 1. SKILL.md — Generate step guidance (net-new)
Added the two missing workflow lines to the **Generate** step: first-person pronouns (I/my/me) are fine and read as honest, and exclamation marks are fine where they feel natural. This guidance already lived in `references/style-guide.md` (the human-writing reference) but was never surfaced as generation-workflow instruction, so a fast pass over SKILL.md missed it.

### 2. anti-slop.md — "deliverable shipped as raw .md" tell (net-new)
A finished deliverable handed back with visible markdown syntax (`#` headers, `**bold**`, `-` bullets) is a tell that a model generated it and nobody repackaged it into the format the context expects (.docx, PDF, deck, formatted email). Scoped to explicitly exclude cases where markdown *is* the medium (README, GitHub comment, chat).

### 3. anti-slop.md — document-level structural-tell checklist (generalized)
The existing "Structural tells" were sentence/paragraph-level, and the document-level ones existed only LinkedIn-scoped under "Banned Structural Patterns." Added a medium-agnostic checklist in the Universal section: meta-narration, exhaustive-coverage-as-virtue, equal-length sections, relentless parallelism, table overload, and absent point of view. Reconstructed from the concepts in Wikipedia "Signs of AI Writing" and the structural-fingerprint literature plus the existing banned list — no external guide purchased.

## Verification
- Doc-only; no `.py` changed, no tests to run.
- Diff scanned for private data (IPs, emails, real names, paths) — clean, synthetic examples only.
- Confirmed each addition was genuinely absent before adding (`grep` for "raw .md" = 0 hits; first-person/exclamation existed only in style-guide.md; doc-level tells were LinkedIn-scoped only).

Ledger: 93a4265b

🤖 Generated with [Claude Code](https://claude.com/claude-code)