### PR TITLE
perf(memory): warm-connection reuse for recall embedding backends

### DIFF
--- a/src/genesis/memory/embeddings.py
+++ b/src/genesis/memory/embeddings.py
@@ -39,6 +39,58 @@ _HTTPX_ERRORS = (
     httpx.HTTPStatusError,
 )
 
+# ---------------------------------------------------------------------------
+# Connection reuse tuning for embedding backends
+# ---------------------------------------------------------------------------
+# The recall embedder is a long-lived singleton whose backends each hold one
+# AsyncClient for their lifetime, so the underlying TLS connection *can* be
+# reused across proactive recalls. httpx's default keepalive_expiry is only 5s,
+# though — between the sparse per-prompt recalls that drive proactive memory,
+# the warm connection to DeepInfra/DashScope expires and each cold embed pays a
+# fresh TLS handshake (the ~2357ms embed spikes seen in prod). Extending
+# keepalive_expiry keeps the connection warm across that gap; the connection
+# counts stay small because a single recall issues one embed at a time.
+_EMBED_KEEPALIVE_EXPIRY_S = 60.0
+_EMBED_MAX_KEEPALIVE_CONNECTIONS = 8
+_EMBED_MAX_CONNECTIONS = 16
+
+
+def _embed_limits() -> httpx.Limits:
+    """httpx connection-pool limits tuned for warm-connection reuse."""
+    return httpx.Limits(
+        max_connections=_EMBED_MAX_CONNECTIONS,
+        max_keepalive_connections=_EMBED_MAX_KEEPALIVE_CONNECTIONS,
+        keepalive_expiry=_EMBED_KEEPALIVE_EXPIRY_S,
+    )
+
+
+def _http2_available() -> bool:
+    """True only if the optional ``h2`` package is importable.
+
+    httpx raises if ``http2=True`` is requested without ``h2`` installed, so we
+    gate on import rather than adding a hard dependency.
+    """
+    try:
+        import h2  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _build_embed_client(timeout: float, *, http2: bool = False) -> httpx.AsyncClient:
+    """Build an AsyncClient with warm-reuse limits (and HTTP/2 when available).
+
+    ``http2`` is only honoured for TLS (https) cloud backends where it is
+    negotiated via ALPN and falls back cleanly to HTTP/1.1. It is left off for
+    cleartext local endpoints (Ollama), where enabling it would force h2 with
+    prior knowledge and could break servers that only speak HTTP/1.1.
+    """
+    return httpx.AsyncClient(
+        timeout=timeout,
+        limits=_embed_limits(),
+        http2=http2 and _http2_available(),
+    )
+
 
 class EmbeddingUnavailableError(Exception):
     """Raised when all embedding backends are unavailable."""
@@ -75,7 +127,9 @@ class OllamaBackend:
     ) -> None:
         self._url = url
         self._model = model
-        self._client = client or httpx.AsyncClient(timeout=60.0)
+        # Local cleartext endpoint — warm-reuse limits, but HTTP/2 stays off
+        # (h2 with prior knowledge would break HTTP/1.1-only Ollama servers).
+        self._client = client or _build_embed_client(60.0)
         self._avail_cache: bool | None = None
         self._avail_cache_at: float = 0.0
 
@@ -134,7 +188,7 @@ class DeepInfraBackend:
     ) -> None:
         self._api_key = api_key
         self._model = model
-        self._client = client or httpx.AsyncClient(timeout=30.0)
+        self._client = client or _build_embed_client(30.0, http2=True)
 
     @property
     def name(self) -> str:
@@ -174,7 +228,7 @@ class DashScopeBackend:
         self._api_key = api_key
         self._model = model
         self._dimensions = dimensions
-        self._client = client or httpx.AsyncClient(timeout=30.0)
+        self._client = client or _build_embed_client(30.0, http2=True)
 
     @property
     def name(self) -> str:

--- a/tests/test_memory/test_embeddings.py
+++ b/tests/test_memory/test_embeddings.py
@@ -77,9 +77,7 @@ class TestDeepInfraBackend:
     @pytest.mark.asyncio
     async def test_embed_success(self) -> None:
         client = MagicMock()
-        client.post = AsyncMock(
-            return_value=_ok_response({"data": [{"embedding": VEC_1024}]})
-        )
+        client.post = AsyncMock(return_value=_ok_response({"data": [{"embedding": VEC_1024}]}))
         backend = DeepInfraBackend(api_key="test-key", client=client)
         result = await backend.embed("test")
         assert result == VEC_1024
@@ -89,9 +87,7 @@ class TestDeepInfraBackend:
     @pytest.mark.asyncio
     async def test_auth_header(self) -> None:
         client = MagicMock()
-        client.post = AsyncMock(
-            return_value=_ok_response({"data": [{"embedding": VEC_1024}]})
-        )
+        client.post = AsyncMock(return_value=_ok_response({"data": [{"embedding": VEC_1024}]}))
         backend = DeepInfraBackend(api_key="my-secret", client=client)
         await backend.embed("test")
         headers = client.post.call_args[1]["headers"]
@@ -102,9 +98,7 @@ class TestDashScopeBackend:
     @pytest.mark.asyncio
     async def test_embed_success(self) -> None:
         client = MagicMock()
-        client.post = AsyncMock(
-            return_value=_ok_response({"data": [{"embedding": VEC_1024}]})
-        )
+        client.post = AsyncMock(return_value=_ok_response({"data": [{"embedding": VEC_1024}]}))
         backend = DashScopeBackend(api_key="test-key", client=client)
         result = await backend.embed("test")
         assert result == VEC_1024
@@ -114,9 +108,7 @@ class TestDashScopeBackend:
     @pytest.mark.asyncio
     async def test_dimensions_param(self) -> None:
         client = MagicMock()
-        client.post = AsyncMock(
-            return_value=_ok_response({"data": [{"embedding": VEC_1024}]})
-        )
+        client.post = AsyncMock(return_value=_ok_response({"data": [{"embedding": VEC_1024}]}))
         backend = DashScopeBackend(api_key="key", dimensions=1024, client=client)
         await backend.embed("test")
         body = client.post.call_args[1]["json"]
@@ -272,3 +264,71 @@ class TestOllamaRetry:
         with pytest.raises(httpx.ConnectError):
             await backend.embed("test")
         assert client.post.call_count == 1  # no retry
+
+
+class TestConnectionReuse:
+    """Backends build warm-reuse AsyncClients (kills the 5s-expiry re-handshake).
+
+    Asserts the tuned httpx.Limits / keepalive_expiry are applied and that
+    HTTP/2 is negotiated only for the TLS cloud backends when ``h2`` is
+    importable (never for cleartext Ollama).
+    """
+
+    @staticmethod
+    def _pool(client: httpx.AsyncClient):
+        # httpx AsyncClient -> AsyncHTTPTransport -> httpcore AsyncConnectionPool
+        return client._transport._pool
+
+    def test_embed_limits_are_tuned(self) -> None:
+        from genesis.memory.embeddings import (
+            _EMBED_KEEPALIVE_EXPIRY_S,
+            _EMBED_MAX_KEEPALIVE_CONNECTIONS,
+            _embed_limits,
+        )
+
+        limits = _embed_limits()
+        assert limits.keepalive_expiry == _EMBED_KEEPALIVE_EXPIRY_S
+        assert limits.keepalive_expiry >= 30.0  # survives sparse recall gaps
+        assert limits.max_keepalive_connections == _EMBED_MAX_KEEPALIVE_CONNECTIONS
+        # httpx default keepalive_expiry is 5s; we must beat it decisively.
+        assert limits.keepalive_expiry > 5.0
+
+    def test_deepinfra_client_tuned_and_http2(self) -> None:
+        from genesis.memory.embeddings import (
+            _EMBED_KEEPALIVE_EXPIRY_S,
+            _EMBED_MAX_KEEPALIVE_CONNECTIONS,
+            _http2_available,
+        )
+
+        backend = DeepInfraBackend(api_key="k")
+        pool = self._pool(backend._client)
+        assert pool._keepalive_expiry == _EMBED_KEEPALIVE_EXPIRY_S
+        assert pool._max_keepalive_connections == _EMBED_MAX_KEEPALIVE_CONNECTIONS
+        # HTTP/2 iff the optional h2 package is present in the venv.
+        assert pool._http2 is _http2_available()
+
+    def test_dashscope_client_tuned_and_http2(self) -> None:
+        from genesis.memory.embeddings import (
+            _EMBED_KEEPALIVE_EXPIRY_S,
+            _http2_available,
+        )
+
+        backend = DashScopeBackend(api_key="k")
+        pool = self._pool(backend._client)
+        assert pool._keepalive_expiry == _EMBED_KEEPALIVE_EXPIRY_S
+        assert pool._http2 is _http2_available()
+
+    def test_ollama_client_tuned_but_no_http2(self) -> None:
+        from genesis.memory.embeddings import _EMBED_KEEPALIVE_EXPIRY_S
+
+        backend = OllamaBackend(url="http://fake:11434")
+        pool = self._pool(backend._client)
+        # Warm-reuse limits still apply to the local backend...
+        assert pool._keepalive_expiry == _EMBED_KEEPALIVE_EXPIRY_S
+        # ...but HTTP/2 must never be forced on the cleartext local endpoint.
+        assert pool._http2 is False
+
+    def test_injected_client_is_not_overridden(self) -> None:
+        sentinel = MagicMock()
+        backend = DeepInfraBackend(api_key="k", client=sentinel)
+        assert backend._client is sentinel


### PR DESCRIPTION
## Problem

Follow-up `ac27b693`, PR-2 lever. The proactive-recall `embed` stage swings from ~64ms to ~2357ms in prod. The recall embedder is a long-lived singleton whose backends (`OllamaBackend`, `DeepInfraBackend`, `DashScopeBackend` in `src/genesis/memory/embeddings.py`) each hold one `httpx.AsyncClient` for their lifetime — so the TLS connection to the cloud providers *can* be reused. But each client was built with httpx's **default pool settings**, whose `keepalive_expiry` is only **5s**. Between the sparse per-prompt recalls that drive proactive memory, the warm connection to DeepInfra/DashScope expires and every cold embed re-handshakes TLS — the spike named in the row.

## Fix

- Build each backend's `AsyncClient` via a shared `_build_embed_client()` helper that applies tuned `httpx.Limits`: `keepalive_expiry` raised to **60s** (module constant `_EMBED_KEEPALIVE_EXPIRY_S`, not an inline magic number) so warm connections survive the gap between recalls, plus modest `max_keepalive_connections`/`max_connections`. **This is the primary fix** — it directly kills the 5s-expiry re-handshake.
- Enable `http2=True` **only** for the TLS cloud backends (DeepInfra, DashScope), and **only** when the optional `h2` package is importable (gated through `_http2_available()`). No new dependency — httpx raises if `http2=True` is requested without `h2`, so we import-gate instead. Verified `h2` is present in the venv.
- Ollama keeps HTTP/2 **off**: it is a cleartext local endpoint where forcing h2 with prior knowledge could break HTTP/1.1-only servers. It still gets the warm-reuse `Limits`.

No behavior change beyond connection reuse — timeouts, request bodies, and the fallback chain are untouched. An injected `client` (test seam) still wins over the built default.

## Out of scope (noted for follow-up)

- **Graph-expansion N+1** over entity hops — explicitly out of PR-2 scope per the follow-up.
- **Qdrant client pooling** — no clear, safe reuse win identified here; left for a separate look.
- **PR-4** (#1189, read-only WAL connection pool) already landed and is deliberately untouched.

## Test

`tests/test_memory/test_embeddings.py::TestConnectionReuse` asserts the tuned `Limits`/`keepalive_expiry` are applied to each backend's client and that HTTP/2 is negotiated only for the cloud backends when `h2` is present (never for Ollama). Injected-client passthrough is covered too.

`pytest tests/test_memory/test_embeddings.py` → 25 passed. `ruff check` on changed files → clean.

Ledger: ac27b693

🤖 Generated with [Claude Code](https://claude.com/claude-code)