### PR TITLE
feat(ego): advisory capability-improvement orchestrator

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -66,3 +66,15 @@ calibration_injection_enabled: true
 # NOTE: settings_update marks the whole ego domain "restart required"; that is
 # not true for THIS field — the refresh job re-reads the config each run.
 outcome_bus_capability_feed: false
+
+# Capability-improvement scanner (ADVISORY; Genesis ego / COO only). A twice-
+# daily cadence job reads the weakest domains from the capability map and pushes
+# a priority=low capability_improvement signal for the ego to CONSIDER. It never
+# throttles, gates, or auto-dispatches a loop, and never asks the ego to propose
+# less — surfacing a deficiency is the whole job. Set enabled=false to silence
+# the scanner (takes effect on next server restart — job registration is at
+# cadence start()).
+capability_improvement_enabled: true
+capability_weakness_threshold: 0.5        # domains scoring below this are "weak"
+capability_improvement_min_sample_size: 3  # ignore low-n flukes
+capability_improvement_max_signals: 3      # cap advisory signals per scan

--- a/src/genesis/db/crud/capability_map.py
+++ b/src/genesis/db/crud/capability_map.py
@@ -84,6 +84,33 @@ async def get_all(db: aiosqlite.Connection) -> list[dict]:
     return [dict(zip(cols, r, strict=False)) for r in rows]
 
 
+async def get_weakest(
+    db: aiosqlite.Connection,
+    *,
+    max_confidence: float = 0.5,
+    min_sample_size: int = 3,
+    limit: int = 3,
+) -> list[dict]:
+    """Return the weakest capability domains (lowest confidence first).
+
+    Filters to domains scoring below *max_confidence* with at least
+    *min_sample_size* aggregated data points — so a single low-n fluke never
+    surfaces as a deficiency. Ordered by confidence ascending and capped at
+    *limit*. Feeds the advisory capability-improvement scanner in the ego
+    cadence manager; read-only, never mutates the map.
+    """
+    cur = await db.execute(
+        "SELECT domain, confidence, sample_size, trend, evidence_summary, updated_at "
+        "FROM capability_map "
+        "WHERE confidence < ? AND sample_size >= ? "
+        "ORDER BY confidence ASC LIMIT ?",
+        (max_confidence, min_sample_size, limit),
+    )
+    rows = await cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
 async def get_by_domain(db: aiosqlite.Connection, domain: str) -> dict | None:
     """Fetch a single domain's capability entry."""
     cur = await db.execute(

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -5,6 +5,7 @@ Owns an APScheduler with jobs:
 2. CronTrigger for the mandatory morning report
 3. IntervalTrigger for the 30-min mechanical sweep (proposal expiry/dispatch)
 4. CronTrigger for goal staleness scanning (user ego only, twice daily)
+5. CronTrigger for the advisory capability-improvement scan (genesis ego only)
 
 All cycle types (proactive, morning report, reactive, escalation) flow
 through the unified signal consumer loop: signal sources push EgoSignal
@@ -264,6 +265,24 @@ class EgoCadenceManager:
                 self._check_stale_goals,
                 CronTrigger(hour="10,16", timezone=user_timezone()),
                 id="ego_goal_staleness",
+                max_instances=1,
+                misfire_grace_time=600,
+            )
+        # Capability-improvement scanner (advisory): read the weakest domains
+        # from the capability map and push priority=low capability_improvement
+        # signals for the ego to CONSIDER. Genesis ego only — the COO owns
+        # operational self-improvement, and gating to one ego stops both from
+        # pushing duplicate deficiency signals for the shared self-model. Cron
+        # (not Interval) per the >1h reset trap; phased just after the twice-
+        # daily capability_map refresh (09:15/21:15) so it reads fresh scores.
+        if (
+            self._session._source_tag == "genesis_ego_cycle"
+            and self._config.capability_improvement_enabled
+        ):
+            self._scheduler.add_job(
+                self._check_weak_capabilities,
+                CronTrigger(hour="10,22", timezone=user_timezone()),
+                id="ego_capability_improvement",
                 max_instances=1,
                 misfire_grace_time=600,
             )
@@ -586,6 +605,80 @@ class EgoCadenceManager:
                 )
         except Exception:
             logger.debug("Goal staleness scanner failed", exc_info=True)
+
+    # -- Capability improvement scanner (advisory) -------------------------
+
+    async def _check_weak_capabilities(self) -> None:
+        """Push advisory capability_improvement signals for the weakest domains.
+
+        Reads the capability map (Genesis's self-model, refreshed twice daily by
+        the learning scheduler) and surfaces domains whose composite confidence
+        is below ``capability_weakness_threshold`` — so the ego can CONSIDER
+        proposing an improvement. ADVISORY ONLY: the signal is priority=low, it
+        never throttles, gates, or auto-dispatches a loop, and it never asks the
+        ego to propose less (hard quality-over-cost rule). Genesis ego only —
+        registration is gated in start(), but we re-check source_tag here as
+        defense-in-depth. Best-effort — a query failure logs and no-ops.
+        """
+        if self._session._source_tag != "genesis_ego_cycle":
+            return
+        if not self._config.capability_improvement_enabled:
+            return
+        if not self._should_run(skip_idle_check=True):
+            return
+
+        try:
+            from genesis.db.crud import capability_map as cap_crud
+
+            weak = await cap_crud.get_weakest(
+                self._session._db,
+                max_confidence=self._config.capability_weakness_threshold,
+                min_sample_size=self._config.capability_improvement_min_sample_size,
+                limit=self._config.capability_improvement_max_signals,
+            )
+            if not weak:
+                return
+
+            pushed = 0
+            for entry in weak:
+                domain = entry.get("domain")
+                if not domain:
+                    continue
+                confidence = entry.get("confidence") or 0.0
+                trend = entry.get("trend") or "stable"
+                sample = entry.get("sample_size") or 0
+                sig_summary = (
+                    f"Capability deficiency: {domain} at {confidence:.0%} "
+                    f"confidence ({trend}, n={sample})"
+                )
+                signal = EgoSignal(
+                    signal_type="timer",
+                    focus_category="capability_improvement",
+                    summary=sig_summary,
+                    priority="low",
+                    focus_id=domain,
+                    metadata={
+                        # Advisory marker — a consumer must never read this as a
+                        # directive to throttle or auto-act.
+                        "advisory": True,
+                        "confidence": confidence,
+                        "trend": trend,
+                        "sample_size": sample,
+                        "evidence": entry.get("evidence_summary", ""),
+                    },
+                    # 24h: the next capability scan re-detects anything still weak.
+                    expires_at=_expires_in(24 * 60),
+                )
+                if self._signal_queue.push(signal):
+                    pushed += 1
+
+            if pushed:
+                logger.info(
+                    "Capability improvement scanner: %d advisory signal(s) pushed",
+                    pushed,
+                )
+        except Exception:
+            logger.debug("Capability improvement scanner failed", exc_info=True)
 
     # -- Autonomy earn-back ------------------------------------------------
 

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -176,4 +176,25 @@ def validate_ego_config(changes: dict) -> list[str]:
         "suppress",
     ):
         errors.append("quiet_hours_mode must be 'floor' or 'suppress'")
+    # Capability-improvement scanner: invalid values must degrade toward LESS
+    # write authority, so reject the whole change rather than silently uncap.
+    # A negative LIMIT is "no limit" in SQLite and a negative min-sample defeats
+    # the fluke guard — both would widen advisory output, which is exactly what
+    # validation must prevent.
+    if "capability_improvement_enabled" in changes and not isinstance(
+        changes["capability_improvement_enabled"], bool
+    ):
+        errors.append("capability_improvement_enabled must be a boolean")
+    if "capability_weakness_threshold" in changes:
+        v = changes["capability_weakness_threshold"]
+        if not isinstance(v, (int, float)) or isinstance(v, bool) or not (0.0 <= v <= 1.0):
+            errors.append("capability_weakness_threshold must be a number in [0.0, 1.0]")
+    if "capability_improvement_min_sample_size" in changes:
+        v = changes["capability_improvement_min_sample_size"]
+        if not isinstance(v, int) or isinstance(v, bool) or v < 1:
+            errors.append("capability_improvement_min_sample_size must be integer >= 1")
+    if "capability_improvement_max_signals" in changes:
+        v = changes["capability_improvement_max_signals"]
+        if not isinstance(v, int) or isinstance(v, bool) or v < 1:
+            errors.append("capability_improvement_max_signals must be integer >= 1")
     return errors

--- a/src/genesis/ego/focus.py
+++ b/src/genesis/ego/focus.py
@@ -177,6 +177,26 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "recurring_patterns": "skip",
     }),
 
+    # Capability improvement (advisory): self-model performance sections deep so
+    # the ego can reason about the weak domain, everything else light/skip.
+    "capability_improvement": _make_weights({
+        "capability_performance": "deep",
+        "capabilities": "deep",
+        "execution_outcomes": "deep",
+        "recurring_patterns": "deep",
+        "proposal_history": "light",
+        "proposal_board": "light",
+        "follow_ups": "light",
+        "goals": "light",
+        "goal_progress": "light",
+        "goal_deep_dive": "skip",
+        "world_snapshot": "light",
+        "activity_pulse": "light",
+        "recent_conversations": "light",
+        "backlog_summary": "light",
+        "escalations": "light",
+    }),
+
     # Escalation: escalations deep, system context deep, others light
     "escalation": _make_weights({
         "escalations": "deep",

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -56,7 +56,9 @@ class GenesisEgoContextBuilder:
             Keys that match genesis section names are applied; unknown
             keys are ignored (default to "deep").
         focus_id:
-            Accepted for API compatibility. Not used by Genesis ego.
+            The focused target for this cycle. On a capability_improvement
+            cycle it is the weak domain name, surfaced as a "Focused
+            deficiency" row in the capability performance section.
         """
         import asyncio
 
@@ -67,6 +69,13 @@ class GenesisEgoContextBuilder:
         for section in _ALWAYS_SECTIONS:
             if weights.get(section) in ("skip", "light"):
                 weights[section] = "deep"
+
+        # Capability-improvement cycles target a specific weak domain, carried
+        # as focus_id. Stash it for _capability_performance_section so the
+        # focused (low-confidence, hence off the top-N table) domain's row is
+        # always surfaced. Reset each build — a stale value would mislabel a
+        # later cycle's context.
+        self._focus_id = focus_id
 
         sections: list[str] = []
         sections.append("# GENESIS_EGO_CONTEXT — Operations Briefing\n")
@@ -690,6 +699,27 @@ class GenesisEgoContextBuilder:
             return "\n".join(lines)
 
         _TREND_ICONS = {"improving": "+", "declining": "-", "stable": "="}
+
+        # Focused deficiency: a capability_improvement cycle targets a specific
+        # weak domain (self._focus_id). get_all is confidence-DESC and only the
+        # top 15 render below, so a low-confidence target is otherwise absent —
+        # surface its full row explicitly so the advisory names a deficiency the
+        # ego can actually see.
+        focus_id = getattr(self, "_focus_id", None)
+        focused = (
+            next((e for e in entries if e.get("domain") == focus_id), None)
+            if focus_id
+            else None
+        )
+        if focused is not None:
+            _fc = focused.get("confidence", 0.0)
+            _ft = focused.get("trend", "stable")
+            _fs = focused.get("sample_size", 0)
+            _fe = (focused.get("evidence_summary") or "")[:120].replace("|", "/")
+            lines.append(
+                f"**Focused deficiency — {focus_id}**: {_fc:.0%} confidence "
+                f"({_ft}, {_fs} samples). {_fe}\n"
+            )
 
         lines.append("| Domain | Confidence | Trend | Samples | Evidence |")
         lines.append("|--------|-----------|-------|---------|----------|")

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1284,6 +1284,17 @@ class EgoSession:
                 "\n\nThis is an ESCALATION cycle. Assess the health issue "
                 "or system alert and propose remediation actions."
             )
+        elif focus.focus_type == "capability_improvement":
+            directive += (
+                "\n\nThis is a CAPABILITY IMPROVEMENT cycle (ADVISORY). A "
+                "capability domain is scoring low in your self-model. You MAY "
+                "consider — but are not required to propose — a concrete "
+                "improvement for that domain: a better procedure, a skill "
+                "refinement, or a targeted experiment. This is a nudge to "
+                "reflect on a deficiency, never a mandate to act, and NEVER a "
+                "reason to do less, lower your standards, or propose fewer "
+                "actions elsewhere."
+            )
 
         return f"{directive}\n\n---\n\n{dynamic_context}"
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1285,15 +1285,21 @@ class EgoSession:
                 "or system alert and propose remediation actions."
             )
         elif focus.focus_type == "capability_improvement":
+            # Name the exact weak domain (focus.focus_id) — the capability map
+            # renders only the top rows BY CONFIDENCE, so the weakest (target)
+            # domain is otherwise absent from the context. The genesis context
+            # builder also surfaces its row via the "Focused deficiency" line.
+            target = focus.focus_id or "one of your capabilities"
             directive += (
-                "\n\nThis is a CAPABILITY IMPROVEMENT cycle (ADVISORY). A "
-                "capability domain is scoring low in your self-model. You MAY "
-                "consider — but are not required to propose — a concrete "
-                "improvement for that domain: a better procedure, a skill "
-                "refinement, or a targeted experiment. This is a nudge to "
-                "reflect on a deficiency, never a mandate to act, and NEVER a "
-                "reason to do less, lower your standards, or propose fewer "
-                "actions elsewhere."
+                "\n\nThis is a CAPABILITY IMPROVEMENT cycle (ADVISORY). Your "
+                f"**{target}** capability is scoring low in your self-model "
+                "(see the Focused deficiency line under Capability Performance "
+                "for its confidence, trend, and evidence). You MAY consider — "
+                "but are not required to propose — a concrete improvement for "
+                f"{target}: a better procedure, a skill refinement, or a "
+                "targeted experiment. This is a nudge to reflect on a "
+                "deficiency, never a mandate to act, and NEVER a reason to do "
+                "less, lower your standards, or propose fewer actions elsewhere."
             )
 
         return f"{directive}\n\n---\n\n{dynamic_context}"

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -21,6 +21,10 @@ class FocusCategory(StrEnum):
     GOAL_REVIEW = "goal_review"
     DISPATCH_OUTCOME = "dispatch_outcome"
     ESCALATION = "escalation"
+    # Advisory self-improvement: a scanned capability deficiency surfaced for
+    # the ego to CONSIDER. Never throttles/gates/auto-dispatches a loop, and
+    # never a mandate to "propose less" (hard quality-over-cost rule).
+    CAPABILITY_IMPROVEMENT = "capability_improvement"
 
 
 class ProposalStatus(StrEnum):
@@ -199,6 +203,15 @@ class EgoConfig:
     # display-only (rendered into ego-context sections, no code gate), so even ON
     # only nudges the numbers the ego sees about itself. Live-read each refresh.
     outcome_bus_capability_feed: bool = False
+    # Capability-improvement scanner (advisory; genesis ego only). A twice-daily
+    # job reads the weakest domains from the capability map and pushes a
+    # priority=low FocusCategory.CAPABILITY_IMPROVEMENT signal for the ego to
+    # CONSIDER. ADVISORY ONLY — it never throttles, gates, or auto-dispatches a
+    # loop, and never proposes doing less. Set enabled=False to silence it.
+    capability_improvement_enabled: bool = True
+    capability_weakness_threshold: float = 0.5  # domains below this confidence are "weak"
+    capability_improvement_min_sample_size: int = 3  # ignore low-n flukes
+    capability_improvement_max_signals: int = 3  # cap advisory signals per scan
     # Quiet-hours floor (circadian model): during the overnight window, throttle
     # PROACTIVE ticks to at most one per quiet_hours_min_interval_minutes. Morning
     # report, reactive, and escalation paths are never gated by this. Local time

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1419,6 +1419,154 @@ class TestGoalStaleness:
         assert goal_cadence._signal_queue.empty()
 
 
+class TestCapabilityImprovement:
+    """Tests for _check_weak_capabilities() — advisory capability_improvement scanner."""
+
+    @pytest.fixture
+    async def cap_db(self):
+        """DB with the capability_map table."""
+        async with aiosqlite.connect(":memory:") as conn:
+            conn.row_factory = aiosqlite.Row
+            for table in ("ego_cycles", "ego_state", "cc_sessions", "capability_map"):
+                await conn.execute(TABLES[table])
+            await conn.commit()
+            yield conn
+
+    @pytest.fixture
+    def cap_cadence(self, mock_session, config, mock_idle_detector, cap_db):
+        # Genesis ego owns the capability-improvement scanner.
+        mock_session._source_tag = "genesis_ego_cycle"
+        mock_session._db = cap_db
+        return EgoCadenceManager(
+            session=mock_session,
+            config=config,
+            idle_detector=mock_idle_detector,
+            db=cap_db,
+        )
+
+    @staticmethod
+    async def _insert_domain(db, domain, confidence, sample_size=5, trend="stable"):
+        from datetime import datetime as _dt
+
+        await db.execute(
+            "INSERT INTO capability_map "
+            "(id, domain, confidence, sample_size, trend, evidence_summary, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                domain,  # id doubles as a unique key for the test
+                domain,
+                confidence,
+                sample_size,
+                trend,
+                f"{domain} evidence",
+                _dt.now(UTC).isoformat(),
+            ),
+        )
+        await db.commit()
+
+    async def test_weak_domain_pushes_advisory_signal(self, cap_cadence, cap_db):
+        """A weak domain surfaces a priority=low advisory capability_improvement signal."""
+        await self._insert_domain(cap_db, "outreach", 0.30, sample_size=8)
+
+        await cap_cadence._check_weak_capabilities()
+
+        assert not cap_cadence._signal_queue.empty()
+        signals = cap_cadence._signal_queue.drain()
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.focus_category == "capability_improvement"
+        assert sig.priority == "low"
+        assert sig.focus_id == "outreach"
+        assert sig.metadata.get("advisory") is True
+        assert "outreach" in sig.summary
+
+    async def test_strong_domain_no_signal(self, cap_cadence, cap_db):
+        """A domain above the weakness threshold does NOT surface a signal."""
+        await self._insert_domain(cap_db, "investigate", 0.90, sample_size=8)
+
+        await cap_cadence._check_weak_capabilities()
+        assert cap_cadence._signal_queue.empty()
+
+    async def test_low_sample_domain_skipped(self, cap_cadence, cap_db):
+        """A weak-but-low-n domain is ignored as a fluke (min_sample_size gate)."""
+        await self._insert_domain(cap_db, "flaky", 0.10, sample_size=1)
+
+        await cap_cadence._check_weak_capabilities()
+        assert cap_cadence._signal_queue.empty()
+
+    async def test_weakest_first_and_capped(self, cap_cadence, cap_db):
+        """Signals come from the weakest domains, capped at max_signals."""
+        cap_cadence._config.capability_improvement_max_signals = 2
+        await self._insert_domain(cap_db, "d1", 0.10)
+        await self._insert_domain(cap_db, "d2", 0.20)
+        await self._insert_domain(cap_db, "d3", 0.40)
+        await self._insert_domain(cap_db, "d4", 0.95)  # strong — excluded
+
+        await cap_cadence._check_weak_capabilities()
+
+        signals = cap_cadence._signal_queue.drain()
+        assert len(signals) == 2
+        focus_ids = {s.focus_id for s in signals}
+        assert focus_ids == {"d1", "d2"}  # two weakest, d4 excluded
+
+    async def test_user_ego_skipped(self, cap_cadence, cap_db):
+        """The user ego does NOT run the capability scanner (genesis ego only)."""
+        cap_cadence._session._source_tag = "user_ego_cycle"
+        await self._insert_domain(cap_db, "outreach", 0.30, sample_size=8)
+
+        await cap_cadence._check_weak_capabilities()
+        assert cap_cadence._signal_queue.empty()
+
+    async def test_disabled_config_skips(self, cap_cadence, cap_db):
+        """capability_improvement_enabled=False silences the scanner."""
+        cap_cadence._config.capability_improvement_enabled = False
+        await self._insert_domain(cap_db, "outreach", 0.30, sample_size=8)
+
+        await cap_cadence._check_weak_capabilities()
+        assert cap_cadence._signal_queue.empty()
+
+    async def test_empty_map_no_signal(self, cap_cadence, cap_db):
+        """Empty capability map (fresh install) is a clean no-op."""
+        await cap_cadence._check_weak_capabilities()
+        assert cap_cadence._signal_queue.empty()
+
+    async def test_job_registered_for_genesis_ego(
+        self, mock_session, config, mock_idle_detector, cap_db,
+    ):
+        """start() registers the ego_capability_improvement job for the genesis ego."""
+        mock_session._source_tag = "genesis_ego_cycle"
+        mock_session._db = cap_db
+        mgr = EgoCadenceManager(
+            session=mock_session,
+            config=config,
+            idle_detector=mock_idle_detector,
+            db=cap_db,
+        )
+        try:
+            await mgr.start()
+            assert mgr._scheduler.get_job("ego_capability_improvement") is not None
+        finally:
+            await mgr.stop()
+
+    async def test_job_not_registered_for_user_ego(
+        self, mock_session, config, mock_idle_detector, cap_db,
+    ):
+        """The user ego cadence does NOT register the capability scanner job."""
+        mock_session._source_tag = "user_ego_cycle"
+        mock_session._db = cap_db
+        mgr = EgoCadenceManager(
+            session=mock_session,
+            config=config,
+            idle_detector=mock_idle_detector,
+            db=cap_db,
+        )
+        try:
+            await mgr.start()
+            assert mgr._scheduler.get_job("ego_capability_improvement") is None
+        finally:
+            await mgr.stop()
+
+
 class TestJobHealthKeyPerEgo:
     """Each ego records job health under its OWN key, never a shared 'ego_cycle'.
 

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -169,6 +169,40 @@ class TestValidateEgoConfig:
         assert cfg.quiet_hours_end == 7
         assert cfg.quiet_hours_min_interval_minutes == 240
 
+    def test_capability_improvement_enabled_rejects_non_bool(self):
+        errors = validate_ego_config({"capability_improvement_enabled": "on"})
+        assert len(errors) == 1
+        assert "capability_improvement_enabled must be a boolean" in errors[0]
+
+    def test_capability_weakness_threshold_bounds(self):
+        assert validate_ego_config({"capability_weakness_threshold": 0.5}) == []
+        assert validate_ego_config({"capability_weakness_threshold": 0.0}) == []
+        assert validate_ego_config({"capability_weakness_threshold": 1.0}) == []
+        assert len(validate_ego_config({"capability_weakness_threshold": 1.5})) == 1
+        assert len(validate_ego_config({"capability_weakness_threshold": -0.1})) == 1
+        # bool must not sneak through the numeric check
+        assert len(validate_ego_config({"capability_weakness_threshold": True})) == 1
+
+    def test_capability_min_sample_size_rejects_bad(self):
+        assert validate_ego_config({"capability_improvement_min_sample_size": 3}) == []
+        # negative would defeat the fluke guard (sample_size >= -1 is always true)
+        assert len(validate_ego_config({"capability_improvement_min_sample_size": 0})) == 1
+        assert len(validate_ego_config({"capability_improvement_min_sample_size": -1})) == 1
+        assert len(validate_ego_config({"capability_improvement_min_sample_size": 2.5})) == 1
+
+    def test_capability_max_signals_rejects_bad(self):
+        assert validate_ego_config({"capability_improvement_max_signals": 3}) == []
+        # negative LIMIT means "no limit" in SQLite — must be rejected
+        assert len(validate_ego_config({"capability_improvement_max_signals": 0})) == 1
+        assert len(validate_ego_config({"capability_improvement_max_signals": -1})) == 1
+
+    def test_capability_improvement_defaults(self):
+        cfg = EgoConfig()
+        assert cfg.capability_improvement_enabled is True
+        assert cfg.capability_weakness_threshold == 0.5
+        assert cfg.capability_improvement_min_sample_size == 3
+        assert cfg.capability_improvement_max_signals == 3
+
 
 class TestMaxActiveEgoGoalsValidation:
     def test_valid(self):

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -204,6 +204,37 @@ class TestValidateEgoConfig:
         assert cfg.capability_improvement_max_signals == 3
 
 
+class TestCapabilityImprovementSettingsWiring:
+    """The capability_improvement validators are reached by settings_update.
+
+    Proves the settings_update('ego', {...}) path dispatches to
+    validate_ego_config so an invalid capability field is rejected before it
+    can reach ego.yaml (where e.g. a negative max_signals would uncap the
+    SQLite LIMIT and silently disable the feature).
+    """
+
+    def test_ego_domain_dispatches_to_validate_ego_config(self):
+        from genesis.mcp.health.settings import _DOMAIN_VALIDATORS
+
+        assert "ego" in _DOMAIN_VALIDATORS
+        validator = _DOMAIN_VALIDATORS["ego"]
+        # Rejects a non-int max_signals (Codex's "many" case).
+        assert validator({"capability_improvement_max_signals": "many"})
+        # Rejects a negative max_signals (SQLite negative LIMIT = no limit).
+        assert validator({"capability_improvement_max_signals": -1})
+        # Rejects the truthy string "false" for the bool flag.
+        assert validator({"capability_improvement_enabled": "false"})
+        # Rejects an out-of-range threshold.
+        assert validator({"capability_weakness_threshold": 2.0})
+        # A fully-valid change set passes.
+        assert validator({
+            "capability_improvement_enabled": True,
+            "capability_weakness_threshold": 0.4,
+            "capability_improvement_min_sample_size": 5,
+            "capability_improvement_max_signals": 2,
+        }) == []
+
+
 class TestMaxActiveEgoGoalsValidation:
     def test_valid(self):
         assert validate_ego_config({"max_active_ego_goals": 3}) == []

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -775,3 +775,54 @@ class TestOwnGoalsSection:
         assert "## Your Own Goals" in context
         assert "own_goal_creations" in context   # output contract
         assert "own_goal_reviews" in context
+
+
+class TestCapabilityPerformanceFocusedDeficiency:
+    """The focused weak domain is surfaced even when it's off the top-N table."""
+
+    @pytest.fixture
+    async def cap_db(self):
+        from genesis.db.schema import TABLES
+
+        async with aiosqlite.connect(":memory:") as conn:
+            conn.row_factory = aiosqlite.Row
+            await conn.execute(TABLES["capability_map"])
+            await conn.commit()
+            yield conn
+
+    @staticmethod
+    async def _insert(db, domain, confidence):
+        from datetime import UTC, datetime
+
+        await db.execute(
+            "INSERT INTO capability_map "
+            "(id, domain, confidence, sample_size, trend, evidence_summary, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (domain, domain, confidence, 8, "declining",
+             f"{domain}-evidence", datetime.now(UTC).isoformat()),
+        )
+        await db.commit()
+
+    async def test_weak_focus_row_surfaced_when_off_top15(self, cap_db):
+        # 20 strong domains crowd out the weakest one from the top-15 table.
+        for i in range(20):
+            await self._insert(cap_db, f"strong{i:02d}", 0.90)
+        await self._insert(cap_db, "weakling", 0.12)
+
+        builder = GenesisEgoContextBuilder(db=cap_db)
+        builder._focus_id = "weakling"
+        section = await builder._capability_performance_section()
+
+        # Weakest domain is absent from the confidence-DESC top-15 table...
+        assert "| weakling |" not in section
+        # ...but its Focused deficiency line names it with its evidence.
+        assert "Focused deficiency — weakling" in section
+        assert "12%" in section
+        assert "weakling-evidence" in section
+
+    async def test_no_focus_id_no_deficiency_line(self, cap_db):
+        await self._insert(cap_db, "outreach", 0.30)
+        builder = GenesisEgoContextBuilder(db=cap_db)
+        builder._focus_id = None
+        section = await builder._capability_performance_section()
+        assert "Focused deficiency" not in section

--- a/tests/test_db/test_capability_map.py
+++ b/tests/test_db/test_capability_map.py
@@ -89,3 +89,39 @@ class TestGetByDomain:
     async def test_not_found(self, db):
         entry = await cap_crud.get_by_domain(db, "nonexistent")
         assert entry is None
+
+
+
+class TestGetWeakest:
+    @pytest.mark.asyncio
+    async def test_weakest_first_below_threshold(self, db):
+        await cap_crud.upsert(db, domain="strong", confidence=0.9, sample_size=10)
+        await cap_crud.upsert(db, domain="weak1", confidence=0.2, sample_size=8)
+        await cap_crud.upsert(db, domain="weak2", confidence=0.35, sample_size=8)
+
+        weak = await cap_crud.get_weakest(db, max_confidence=0.5)
+        assert [e["domain"] for e in weak] == ["weak1", "weak2"]
+
+    @pytest.mark.asyncio
+    async def test_min_sample_size_filters_flukes(self, db):
+        await cap_crud.upsert(db, domain="fluke", confidence=0.1, sample_size=1)
+        await cap_crud.upsert(db, domain="real", confidence=0.3, sample_size=5)
+
+        weak = await cap_crud.get_weakest(db, max_confidence=0.5, min_sample_size=3)
+        assert [e["domain"] for e in weak] == ["real"]
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_results(self, db):
+        for i in range(5):
+            await cap_crud.upsert(
+                db, domain=f"d{i}", confidence=0.1 + i * 0.05, sample_size=5,
+            )
+        weak = await cap_crud.get_weakest(db, max_confidence=0.5, limit=2)
+        assert len(weak) == 2
+        assert weak[0]["domain"] == "d0"  # lowest confidence first
+
+    @pytest.mark.asyncio
+    async def test_empty_when_all_strong(self, db):
+        await cap_crud.upsert(db, domain="strong", confidence=0.95, sample_size=10)
+        weak = await cap_crud.get_weakest(db, max_confidence=0.5)
+        assert weak == []

--- a/tests/test_ego/test_focus.py
+++ b/tests/test_ego/test_focus.py
@@ -236,6 +236,21 @@ def test_goal_review_weights_have_deep_goals():
     assert weights["execution_outcomes"] == "deep"
 
 
+def test_capability_improvement_category_has_weights():
+    """The advisory capability_improvement focus is fully wired with weights."""
+    from genesis.ego.types import FocusCategory
+
+    assert FocusCategory.CAPABILITY_IMPROVEMENT == "capability_improvement"
+    assert "capability_improvement" in FOCUS_CONTEXT_WEIGHTS
+    weights = FocusSelector.get_context_weights("capability_improvement")
+    # Self-model performance sections are deep so the ego can reason on the gap.
+    assert weights["capability_performance"] == "deep"
+    assert weights["capabilities"] == "deep"
+    assert weights["execution_outcomes"] == "deep"
+    # Always sections are still always.
+    assert weights["user_model"] == "always"
+
+
 # ── FocusResult dataclass ─────────────────────────────────────────────────
 
 

--- a/tests/test_ego/test_unified_cycle.py
+++ b/tests/test_ego/test_unified_cycle.py
@@ -215,6 +215,54 @@ def test_build_focused_prompt_reactive():
     assert "event(s)" in prompt
 
 
+def test_build_focused_prompt_capability_improvement_names_domain():
+    """Capability-improvement directive must NAME the specific weak domain.
+
+    The weak domain rides in focus_id; the capability table renders only the
+    top rows by confidence, so a generic "a capability" directive would leave
+    the ego unable to tell WHICH domain to consider. The directive interpolates
+    focus.focus_id so the target is always explicit.
+    """
+    from genesis.ego.focus import FocusResult
+    from genesis.ego.session import EgoSession
+
+    focus = FocusResult(
+        focus_type="capability_improvement",
+        focus_id="outreach",
+        rationale="advisory: weakest domain",
+    )
+    prompt = EgoSession._build_focused_prompt(
+        None,
+        dynamic_context="## Context",
+        focus=focus,
+    )
+    assert "CAPABILITY IMPROVEMENT" in prompt
+    assert "ADVISORY" in prompt
+    # The specific weak domain name must appear in the directive.
+    assert "outreach" in prompt
+    # Advisory invariant: never asks the ego to do less.
+    assert "propose fewer actions" in prompt
+
+
+def test_build_focused_prompt_capability_improvement_no_domain_fallback():
+    """A missing focus_id falls back to a generic phrase, never a crash."""
+    from genesis.ego.focus import FocusResult
+    from genesis.ego.session import EgoSession
+
+    focus = FocusResult(
+        focus_type="capability_improvement",
+        focus_id=None,
+        rationale="advisory",
+    )
+    prompt = EgoSession._build_focused_prompt(
+        None,
+        dynamic_context="## Context",
+        focus=focus,
+    )
+    assert "CAPABILITY IMPROVEMENT" in prompt
+    assert "one of your capabilities" in prompt
+
+
 # ── FocusCategory enum ────────────────────────────────────────────────────
 
 
@@ -228,6 +276,7 @@ def test_focus_category_values():
     assert FocusCategory.GOAL_REVIEW == "goal_review"
     assert FocusCategory.DISPATCH_OUTCOME == "dispatch_outcome"
     assert FocusCategory.ESCALATION == "escalation"
+    assert FocusCategory.CAPABILITY_IMPROVEMENT == "capability_improvement"
 
 
 # ── EgoConfig goal_review_staleness_days ──────────────────────────────────


### PR DESCRIPTION
## What

Builds the Phase-3 capability-improvement orchestrator — the first consumer of the capability-map deficiency view. An **advisory** scanner that surfaces the ego's weakest capability domains for it to *consider*. It never auto-acts, throttles, gates, or dispatches a loop, and it never asks the ego to "propose less" (the hard quality-over-cost rule).

## How it wires together

- **`FocusCategory.CAPABILITY_IMPROVEMENT`** (`ego/types.py`) + **focus context weights** (`ego/focus.py`) — self-model performance sections deep, everything else light/skip — so the category is *fully wired*, not just defined.
- **`capability_map.get_weakest()`** CRUD — confidence-ascending, `sample_size`-gated so a single low-n fluke never surfaces as a deficiency.
- **`_check_weak_capabilities`** cadence job (`ego/cadence.py`) — reuses the existing `_check_stale_goals` pattern. Reads the weakest domains and pushes a `priority=low` `EgoSignal` onto the reactive `SignalQueue`; the `FocusSelector` arbitrates it among real work (lowest priority → never preempts). `CronTrigger` (interval >1h, per the reset trap), phased just after the twice-daily `capability_map` refresh (09:15/21:15) so it reads fresh scores.
- **Genesis-ego only.** The COO owns operational self-improvement, and gating to one ego stops both from pushing duplicate deficiency signals for the shared self-model (mirrors `_check_stale_goals` being user-ego only).
- **`session.py` focus directive** frames the cycle as advisory: *consider* (not required) a concrete improvement — a better procedure, skill refinement, or targeted experiment — and NEVER do less or lower standards.
- **Settings lever** in `config/ego.yaml` (`capability_improvement_enabled` + thresholds). Dataclass defaults keep a fresh install correct with zero overlay.

## Advisory invariant

The signal is `priority=low`, carries an `advisory: True` metadata marker, and only feeds the perceive phase. There is no code path where it throttles a loop, gates a decision, or triggers autonomous action — it is a nudge for the ego to reflect on a deficiency.

## Tests

- `_check_weak_capabilities` emits the advisory signal from weak domains; skips strong domains, low-n flukes, the user ego, and a disabled config; empty-map no-op; weakest-first + capped; job registration present for genesis ego / absent for user ego.
- `get_weakest` filtering (threshold, min-sample, limit ordering).
- `CAPABILITY_IMPROVEMENT` focus category has weights and resolves through `get_context_weights`.

All targeted test files pass (149) and `ruff check` is clean on changed files.

## Deploy path

Runtime code — `git pull` + server restart (the cadence job registers at ego start). No schema change (uses the existing `capability_map` table).

Ledger: 6a46181b

🤖 Generated with [Claude Code](https://claude.com/claude-code)