### PR TITLE
feat(voice-master): anti-slop hardening (markdown-as-tell, doc-level tells, first-person)

### DIFF
--- a/src/genesis/skills/voice-master/references/ai-vocabulary.md
+++ b/src/genesis/skills/voice-master/references/ai-vocabulary.md
@@ -169,3 +169,21 @@ Vague upbeat endings.
 - "the possibilities are endless"
 - "poised for growth"
 - "watch this space"
+
+## Significance & structure inflation
+
+High-signal words and phrases that inflate importance or fake structure. Treat
+these like the Significance and Promotional lists above (added alongside the
+document-level structural tells in `anti-slop.md`).
+
+- "stands as" / "stands as a testament": inflated copula; prefer "is".
+- "at the forefront of" / "on the cutting edge of": press-release framing.
+- "sits at the intersection of": fake-profound positioning.
+- "a hallmark of" / "the epitome of" / "quintessential": significance puffery.
+- "a wealth of" / "a plethora of" / "a treasure trove of": quantity inflation; give the number or drop it.
+- "ever-evolving" / "ever-changing" / "rapidly evolving": filler dynamism.
+- "profound" / "profoundly": usually removable inflation.
+- "resonates with": vague emotional claim; say what actually lands.
+- "underpins" / "a cornerstone of": abstract structural filler.
+- "stark reminder" / "stark contrast": cliché intensifier; be concrete.
+- "rich history" / "rich tradition" / "rich tapestry": tourism-brochure filler.

--- a/src/genesis/skills/voice-master/references/anti-slop.md
+++ b/src/genesis/skills/voice-master/references/anti-slop.md
@@ -128,7 +128,6 @@ not per paragraph. Stacking them is an AI fingerprint.
 
 ### Structural tells
 
-- Opening the first sentence with "I".
 - Three-part lists whose items share the exact same grammatical structure.
 - Uniform sentence length — vary it. Favor sentences under ~16 words but keep
   the user's natural longer reasoning chains; don't flatten everything to one
@@ -136,6 +135,45 @@ not per paragraph. Stacking them is an AI fingerprint.
 - Sycophantic acknowledgments before answering ("Great question", "Certainly",
   "Absolutely").
 - Hedging openers ("It's worth considering that…", "It's important to note…").
+
+### Raw markdown as a delivery format
+
+Shipping a *work deliverable* as a raw `.md` file is the single loudest "AI wrote
+this" signal: the format itself gives it away before a word is read. A person
+sends a PDF, a DOCX, a slide deck, or a spreadsheet; only an AI hands over raw
+markdown as the finished artifact. **Fail** any external or under-the-user's-name
+deliverable that ships as raw `.md`, and convert it to the format the audience
+expects (PDF / DOCX / XLSX / deck). **Exempt:** contexts where markdown is
+genuinely native: a repo, a README, a wiki, a blog or CMS draft, a chat reply.
+The tell is markdown *as the delivery envelope for finished work*, not markdown
+as an authoring or repo format.
+
+### Document-level structural tells
+
+These operate at the altitude of the whole document, not the sentence. A piece
+can pass every line-level check above and still read as machine-made because its
+*shape* is an AI reflex. Scan the finished document for:
+
+- **Meta-narration.** The document narrating its own structure: "In this section
+  we'll explore…", "This report is organized as follows…", "Having covered X, we
+  now turn to Y." A human just writes the section.
+- **Exhaustive-coverage-as-virtue.** Treating "I covered every possible angle" as
+  the goal. Humans pick the load-bearing points and cut the rest; AI enumerates.
+  Completeness is not insight.
+- **Equal-length sections.** Every section roughly the same size. Real documents
+  are lopsided: the part that mattered got three times the room.
+- **Relentless parallelism.** Every heading the same grammatical shape, every
+  bullet the same length and rhythm. Mechanical symmetry reads as generated.
+- **Table overload.** Reaching for a table (or a bulleted list) where prose would
+  carry the point better. Some ideas are paragraphs; AI over-structures.
+- **Absent point of view.** The "balanced overview" with no thesis and no stance.
+  A person writing about something they care about takes a position; a survey
+  that refuses to is itself a tell.
+
+Sources: Wikipedia *Signs of AI Writing*, the arXiv structural-fingerprint work,
+and the tells above (the Long-form section applies several of these to essays
+specifically). On a fail, don't just reformat: re-decide what the document is
+*for*, lead with that, and cut what exists only for coverage.
 
 ---
 

--- a/src/genesis/skills/voice-master/references/style-guide.md
+++ b/src/genesis/skills/voice-master/references/style-guide.md
@@ -30,9 +30,9 @@ Real humans have mixed feelings. "This is impressive but also kind of unsettling
 
 **Human:** It's clever, but it makes me nervous. The failure modes aren't well understood.
 
-## Use first person when it fits
+## First person is encouraged
 
-"I" isn't unprofessional — it's honest.
+"I" is a good word; use it. First person isn't unprofessional, it's honest. Don't contort a sentence to avoid it.
 
 - "I keep coming back to..."
 - "Here's what gets me..."


### PR DESCRIPTION
## What

Lands the deferred **voice-master hardening** (follow-up `93a4265b`) onto the post-#621 canonical skill — the content-voice / AI-humanizer skill's anti-slop guidance. Source: the "voice-master Hardening Workstream" of the deliverable-forge design spec.

### Changes (references only)
1. **`anti-slop.md` — markdown-as-tell**: shipping a *work deliverable* as raw `.md` is the single loudest "AI wrote this" signal for external work. Flagged as a tell, with an explicit exemption where markdown is native (repo / wiki / blog / chat).
2. **`anti-slop.md` — document-level structural-tell checklist**: meta-narration, exhaustive-coverage-as-virtue, equal-length sections, relentless parallelism, table overload, absent point of view. Reconstructed from Wikipedia *Signs of AI Writing* + the arXiv structural-fingerprint work (not the paid guide the spec explicitly warned against).
3. **First-person reconciliation**: removed the stale `anti-slop.md` "don't open a sentence with I" ban that contradicted the style-guide's own first-person guidance (the spec assumed #621 removed it; it hadn't, so first-person openers were still flagged), and strengthened `style-guide.md` from "use first person when it fits" to "first person is encouraged, 'I' is a good word." Exclamation guidance already shipped in #661 and is untouched.
4. **`ai-vocabulary.md`**: a curated significance / structure-inflation word list.

## Scope & safety
- **Guidance-only** (`references/*.md`). The deterministic code scrubber `genesis.content.antislop` keeps its own ported word subset and does **not** read these files, so there is no runtime coupling. No `SKILL.md` change (skill-validator line cap untouched).
- Public-repo skill: only generic machinery touched; no user voice data (that lives in the private `~/.claude/skills/voice-master/` overlay).
- Dogfood: zero new spaced em-dashes introduced into the file that bans them.

## Tests
`test_content/test_antislop.py` + `test_mcp/test_skill_replay_run.py` — 30 passed. No test reads these `.md` files directly.

---
Completes follow-up `93a4265b`; part of session-ledger row `316fa049` (unblocked-items execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
