### PR TITLE
feat(ego): dashboard Directives & Goals visibility + retire (PR-2)

### DIFF
--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -570,11 +570,14 @@ async def ego_goals():
     if not rt.is_bootstrapped or rt._db is None:
         return jsonify({"user": [], "genesis_ego": []})
 
-    goals = await goals_crud.list_active(rt._db, limit=50, origin=None)
+    # Query each lane separately so a busy user-goal lane can't starve the
+    # own-goal lane under a shared LIMIT, and only the two known origins render.
+    user_goals = await goals_crud.list_active(rt._db, limit=50, origin="user")
+    own_goals = await goals_crud.list_active(rt._db, limit=50, origin="genesis_ego")
     return jsonify(
         {
-            "user": [_goal_view(g) for g in goals if g.get("origin") == "user"],
-            "genesis_ego": [_goal_view(g) for g in goals if g.get("origin") == "genesis_ego"],
+            "user": [_goal_view(g) for g in user_goals],
+            "genesis_ego": [_goal_view(g) for g in own_goals],
         }
     )
 

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -488,3 +488,131 @@ async def ego_vcr():
 
     data = await compute_vcr(rt._db, days=30)
     return jsonify(data)
+
+
+# ── Directives & goals visibility (read + user-driven retire) ──────────
+
+
+def _directive_view(d: dict) -> dict:
+    """Project a directive row to the dashboard payload."""
+    return {
+        "id": d["id"],
+        "content": d["content"],
+        "priority": d["priority"],
+        "source": d["source"],
+        "ego_target": d["ego_target"],
+        "status": d["status"],
+        "created_at": d["created_at"],
+        "resolved_at": d.get("resolved_at"),
+        "resolution": d.get("resolution"),
+        "reaffirm_count": d.get("reaffirm_count", 0),
+        "last_reaffirmed_at": d.get("last_reaffirmed_at"),
+    }
+
+
+def _goal_view(g: dict) -> dict:
+    """Project a goal row to the dashboard payload."""
+    return {
+        "id": g["id"],
+        "title": g["title"],
+        "description": g.get("description"),
+        "category": g["category"],
+        "priority": g["priority"],
+        "status": g["status"],
+        "timeline": g.get("timeline"),
+        "confidence": g.get("confidence"),
+        "goal_type": g.get("goal_type"),
+        "origin": g.get("origin"),
+        "created_at": g["created_at"],
+        "updated_at": g.get("updated_at"),
+    }
+
+
+@blueprint.route("/api/genesis/ego/directives")
+@_async_route
+async def ego_directives():
+    """Active directives (both egos) + recently-resolved history.
+
+    Visibility surface so the user can see — and via the resolve endpoint,
+    retire — the standing directives driving each ego. Decision rows
+    (kind='decision') are excluded; they have their own lifecycle.
+    """
+    from genesis.db.crud import ego as ego_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt._db is None:
+        return jsonify({"active": [], "resolved": []})
+
+    active = await ego_crud.list_directives(rt._db, statuses=("active",), limit=50)
+    resolved = await ego_crud.list_directives(rt._db, statuses=("completed", "cancelled"), limit=5)
+    return jsonify(
+        {
+            "active": [_directive_view(d) for d in active],
+            "resolved": [_directive_view(d) for d in resolved],
+        }
+    )
+
+
+@blueprint.route("/api/genesis/ego/goals")
+@_async_route
+async def ego_goals():
+    """Active goals split by provenance — user directives vs ego own-goals.
+
+    Read-only visibility (no goal mutation here). ``genesis_ego`` is the ego's
+    own-goal lane; ``user`` are the user's goals. Either list may be empty on a
+    fresh install.
+    """
+    from genesis.db.crud import user_goals as goals_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt._db is None:
+        return jsonify({"user": [], "genesis_ego": []})
+
+    goals = await goals_crud.list_active(rt._db, limit=50, origin=None)
+    return jsonify(
+        {
+            "user": [_goal_view(g) for g in goals if g.get("origin") == "user"],
+            "genesis_ego": [_goal_view(g) for g in goals if g.get("origin") == "genesis_ego"],
+        }
+    )
+
+
+@blueprint.route("/api/genesis/ego/directives/<directive_id>/resolve", methods=["POST"])
+@_async_route
+async def ego_directive_resolve(directive_id: str):
+    """Retire a standing directive from the dashboard (a user action).
+
+    Default is a 'cancelled' retire (no longer relevant); pass
+    status='completed' to mark it done instead. Decision rows are structurally
+    refused by ``resolve_directive`` (kind != 'decision').
+    """
+    from genesis.db.crud import ego as ego_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt._db is None:
+        return jsonify({"ok": False, "error": "not bootstrapped"}), 503
+
+    body = request.get_json(silent=True) or {}
+    status = body.get("status", "cancelled")
+    if status not in ("completed", "cancelled"):
+        return jsonify({"ok": False, "error": "status must be 'completed' or 'cancelled'"}), 400
+    resolution = body.get("resolution") or "Retired via dashboard"
+
+    updated = await ego_crud.resolve_directive(
+        rt._db,
+        directive_id,
+        status=status,
+        resolution=resolution,
+    )
+    if not updated:
+        return jsonify(
+            {
+                "ok": False,
+                "error": "directive not found, already resolved, or a decision row",
+            }
+        ), 404
+
+    return jsonify({"ok": True, "id": directive_id, "status": status})

--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -227,6 +227,29 @@
                   </div>
                 </div>
               </template>
+              <!-- Directives & Goals (read-only glance — act on the Chat tab) -->
+              <div style="margin-top: 1rem; padding: 0.6rem 0.8rem; background: rgba(255,255,255,0.03); border: 1px solid var(--color-border); border-radius: 6px;">
+                <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.35rem;">
+                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600;">Directives &amp; Goals</div>
+                  <button style="font-size:0.62rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:transparent; color:var(--color-text-secondary); border:1px solid var(--color-border);"
+                          @click="$store.genesisDashboard.egoModal.open = false; location.hash = 'chat'; $store.genesisDashboard.commsTab = 'proposals'">Manage in Chat</button>
+                </div>
+                <template x-if="$store.genesisDashboard.egoDirectives.active.length === 0">
+                  <div style="font-size:0.7rem; color:var(--color-text-secondary); font-style:italic;">No active directives.</div>
+                </template>
+                <template x-for="d in $store.genesisDashboard.egoDirectives.active" :key="d.id">
+                  <div style="display:flex; gap:0.35rem; align-items:baseline; margin-bottom:0.25rem;">
+                    <span style="font-size:0.6rem; padding:0.05rem 0.35rem; border-radius:3px; text-transform:uppercase; background:rgba(192,132,252,0.2); color:#e1bee7; white-space:nowrap;"
+                          x-text="$store.genesisDashboard.egoTargetLabel(d.ego_target)"></span>
+                    <span style="font-size:0.74rem; line-height:1.3; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="d.content"></span>
+                  </div>
+                </template>
+                <div style="font-size:0.66rem; color:var(--color-text-secondary); margin-top:0.4rem; padding-top:0.35rem; border-top:1px solid var(--color-border);">
+                  <span x-text="$store.genesisDashboard.egoGoals.user.length + ' user goal' + ($store.genesisDashboard.egoGoals.user.length === 1 ? '' : 's')"></span>
+                  ·
+                  <span x-text="$store.genesisDashboard.egoGoals.genesis_ego.length + ' own-goal' + ($store.genesisDashboard.egoGoals.genesis_ego.length === 1 ? '' : 's')"></span>
+                </div>
+              </div>
               <!-- Quick navigation links -->
               <div style="margin-top:1rem; display:flex; gap:0.5rem;">
                 <button style="font-size:0.72rem; padding:0.3rem 0.8rem; border-radius:4px; cursor:pointer; background:rgba(192,132,252,0.1); color:#c084fc; border:1px solid rgba(192,132,252,0.2);"

--- a/src/genesis/dashboard/templates/partials/tabs/chat.html
+++ b/src/genesis/dashboard/templates/partials/tabs/chat.html
@@ -313,6 +313,83 @@
               </template>
             </div>
           </template>
+
+          <!-- ── Directives (steering the ego — user may retire) ── -->
+          <template x-if="$store.genesisDashboard.egoDirectives.active.length > 0 || $store.genesisDashboard.egoDirectives.resolved.length > 0">
+            <div style="margin-top:1rem;">
+              <div style="font-size:0.68rem; text-transform:uppercase; letter-spacing:0.04em; color:var(--color-text-secondary); margin-bottom:0.4rem; display:flex; align-items:center; gap:0.35rem;">
+                <span style="color:#c084fc;">Directives</span>
+                <span style="font-size:0.6rem; color:var(--color-text-secondary); font-weight:400; text-transform:none;">— standing instructions steering each ego</span>
+              </div>
+              <!-- Active directives -->
+              <template x-for="d in $store.genesisDashboard.egoDirectives.active" :key="d.id">
+                <div style="border:1px solid var(--color-border); border-left:3px solid #c084fc; border-radius:6px; padding:0.6rem; margin-bottom:0.5rem;">
+                  <div style="display:flex; justify-content:space-between; align-items:center; gap:0.5rem; margin-bottom:0.3rem;">
+                    <div style="display:flex; gap:0.3rem; align-items:center; flex-wrap:wrap;">
+                      <span style="font-size:0.65rem; padding:0.1rem 0.4rem; border-radius:3px; font-weight:600; text-transform:uppercase; background:rgba(192,132,252,0.2); color:#e1bee7;"
+                            x-text="$store.genesisDashboard.egoTargetLabel(d.ego_target)"></span>
+                      <span style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px; text-transform:uppercase;"
+                            :style="(d.priority === 'critical' || d.priority === 'high') ? 'background:rgba(244,67,54,0.15); color:#ef9a9a;' : 'background:rgba(158,158,158,0.15); color:#bdbdbd;'"
+                            x-text="d.priority"></span>
+                      <span x-show="d.reaffirm_count > 0" style="font-size:0.6rem; color:var(--color-text-secondary);"
+                            x-text="'reaffirmed ×' + d.reaffirm_count"></span>
+                    </div>
+                    <button @click="$store.genesisDashboard.retireDirective(d.id)"
+                            :disabled="$store.genesisDashboard.retiringDirectiveId === d.id"
+                            style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; border:1px solid var(--color-border); background:transparent; color:var(--color-text-secondary); cursor:pointer; white-space:nowrap;"
+                            x-text="$store.genesisDashboard.retiringDirectiveId === d.id ? 'Retiring…' : 'Retire'"></button>
+                  </div>
+                  <div style="font-size:0.78rem; line-height:1.4;" x-text="d.content"></div>
+                  <div style="font-size:0.6rem; color:var(--color-text-secondary); margin-top:0.25rem;"
+                       x-text="'since ' + $store.genesisDashboard.formatDateTime(d.created_at)"></div>
+                </div>
+              </template>
+              <!-- Recently resolved (de-emphasized) -->
+              <template x-for="d in $store.genesisDashboard.egoDirectives.resolved" :key="d.id">
+                <div style="border:1px dashed var(--color-border); border-radius:6px; padding:0.5rem 0.6rem; margin-bottom:0.4rem; opacity:0.6;">
+                  <div style="display:flex; justify-content:space-between; align-items:center; gap:0.5rem;">
+                    <span style="font-size:0.72rem; line-height:1.35;" x-text="d.content"></span>
+                    <span style="font-size:0.6rem; color:var(--color-text-secondary); white-space:nowrap;"
+                          x-text="d.status + (d.resolved_at ? ' ' + $store.genesisDashboard.formatDateTime(d.resolved_at) : '')"></span>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <!-- ── Goals (read-only — user goals + ego own-goals) ── -->
+          <template x-if="$store.genesisDashboard.egoGoals.user.length > 0 || $store.genesisDashboard.egoGoals.genesis_ego.length > 0">
+            <div style="margin-top:1rem;">
+              <div style="font-size:0.68rem; text-transform:uppercase; letter-spacing:0.04em; color:var(--color-text-secondary); margin-bottom:0.4rem;">
+                <span style="color:#c084fc;">Goals</span>
+              </div>
+              <template x-for="g in $store.genesisDashboard.egoGoals.user" :key="g.id">
+                <div style="border:1px solid var(--color-border); border-radius:6px; padding:0.5rem 0.6rem; margin-bottom:0.4rem;">
+                  <div style="display:flex; gap:0.3rem; align-items:center; flex-wrap:wrap; margin-bottom:0.2rem;">
+                    <span style="font-size:0.62rem; padding:0.08rem 0.35rem; border-radius:3px; text-transform:uppercase; background:rgba(33,150,243,0.15); color:#90caf9;"
+                          x-text="$store.genesisDashboard.goalOriginLabel(g.origin)"></span>
+                    <span style="font-size:0.62rem; color:var(--color-text-secondary); text-transform:uppercase;" x-text="g.priority"></span>
+                  </div>
+                  <div style="font-size:0.78rem; line-height:1.35;" x-text="g.title"></div>
+                </div>
+              </template>
+              <!-- Ego own-goals (may be empty on a fresh install) -->
+              <div style="font-size:0.6rem; color:var(--color-text-secondary); margin:0.35rem 0 0.3rem;">Genesis own-goals</div>
+              <template x-if="$store.genesisDashboard.egoGoals.genesis_ego.length === 0">
+                <div style="font-size:0.7rem; color:var(--color-text-secondary); font-style:italic; padding:0.3rem 0.1rem;">No autonomous goals yet.</div>
+              </template>
+              <template x-for="g in $store.genesisDashboard.egoGoals.genesis_ego" :key="g.id">
+                <div style="border:1px solid var(--color-border); border-left:3px solid #e1bee7; border-radius:6px; padding:0.5rem 0.6rem; margin-bottom:0.4rem;">
+                  <div style="display:flex; gap:0.3rem; align-items:center; flex-wrap:wrap; margin-bottom:0.2rem;">
+                    <span style="font-size:0.62rem; padding:0.08rem 0.35rem; border-radius:3px; text-transform:uppercase; background:rgba(192,132,252,0.2); color:#e1bee7;"
+                          x-text="$store.genesisDashboard.goalOriginLabel(g.origin)"></span>
+                    <span style="font-size:0.62rem; color:var(--color-text-secondary); text-transform:uppercase;" x-text="g.priority"></span>
+                  </div>
+                  <div style="font-size:0.78rem; line-height:1.35;" x-text="g.title"></div>
+                </div>
+              </template>
+            </div>
+          </template>
         </div>
 
         <!-- ── Approvals ────────────────────────────────── -->

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -4215,19 +4215,21 @@
               fetchApi("/api/genesis/ego/directives"),
               fetchApi("/api/genesis/ego/goals"),
             ]);
-            if (dR?.ok) this.egoDirectives = await dR.json();
-            if (gR?.ok) this.egoGoals = await gR.json();
+            // Normalize to the guaranteed {active,resolved} / {user,genesis_ego}
+            // shape so a drifted payload can never break the panel templates.
+            if (dR?.ok) { const d = await dR.json(); this.egoDirectives = { active: d.active || [], resolved: d.resolved || [] }; }
+            if (gR?.ok) { const g = await gR.json(); this.egoGoals = { user: g.user || [], genesis_ego: g.genesis_ego || [] }; }
           } catch { /* silent — panels show empty */ }
         },
 
-        // User-driven retire of a standing directive (default: cancelled).
-        async retireDirective(id, status) {
+        // User-driven retire of a standing directive (marks it cancelled).
+        async retireDirective(id) {
           this.retiringDirectiveId = id;
           try {
             const resp = await fetchApi("/api/genesis/ego/directives/" + id + "/resolve", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ status: status || "cancelled" }),
+              body: JSON.stringify({ status: "cancelled" }),
             });
             if (resp?.ok) { await this.fetchEgoDirectivesGoals(); }
           } catch (e) {

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -194,6 +194,12 @@
         commsRejectingId: null,
         commsRejectReason: '',
 
+        // ── Directives & goals (ego visibility — read + user retire) ──
+        // Shared by the Chat-tab strips and the ego-modal Overview card.
+        egoDirectives: { active: [], resolved: [] },
+        egoGoals: { user: [], genesis_ego: [] },
+        retiringDirectiveId: null,
+
         // ── Memory tab state ──────────────────────────────────────
         memorySearch: { query: "", results: [], loading: false },
         memoryRecent: { items: [], total: 0, loading: false },
@@ -510,7 +516,7 @@
             case "chat":
               // Re-fit terminal on tab re-entry
               if (!first && this._xterm && this._fitAddon) { this._fitAddon.fit(); }
-              if (first) { this.fetchComms(); this.fetchApprovals(); }
+              if (first) { this.fetchComms(); this.fetchApprovals(); this.fetchEgoDirectivesGoals(); }
               this._commsInterval = setInterval(() => this.fetchComms(), 15000);
               this._approvalsInterval = setInterval(() => this.fetchApprovals(), 15000);
               break;
@@ -3820,6 +3826,15 @@
           })[src] || "Ego";
         },
 
+        // Provenance labels for the directives/goals visibility panels.
+        // ego_target = which ego a directive steers; origin = who owns a goal.
+        egoTargetLabel(t) {
+          return ({ genesis_ego: "Genesis", user_ego: "User" })[t] || t || "?";
+        },
+        goalOriginLabel(o) {
+          return ({ genesis_ego: "Genesis", user: "User" })[o] || o || "?";
+        },
+
         // Acknowledge-only eval rows (j9/gauntlet) — never approvable. Kept in
         // sync with ego/types.py::INFORMATIONAL_ACTION_TYPES.
         isInformationalProposal(p) {
@@ -4153,6 +4168,8 @@
 
         async fetchEgoDetail() {
           this.startModalFetch("egoModal");
+          // Refresh the shared directives/goals panels alongside the modal open.
+          this.fetchEgoDirectivesGoals();
           try {
             const [statusR, cadenceR, cyclesR, proposalsR, followUpsR, vcrR] = await Promise.all([
               fetchApi("/api/genesis/ego/status"),
@@ -4187,6 +4204,37 @@
               await this.fetchEgoDetail();
             }
           } catch (e) { console.warn("Proposal resolve failed:", e); }
+        },
+
+        // Directives + own/user goals — populated on Chat-tab entry, on ego-modal
+        // open, and after a retire. Not polled: these change rarely, so a 15s
+        // loop would be wasted work.
+        async fetchEgoDirectivesGoals() {
+          try {
+            const [dR, gR] = await Promise.all([
+              fetchApi("/api/genesis/ego/directives"),
+              fetchApi("/api/genesis/ego/goals"),
+            ]);
+            if (dR?.ok) this.egoDirectives = await dR.json();
+            if (gR?.ok) this.egoGoals = await gR.json();
+          } catch { /* silent — panels show empty */ }
+        },
+
+        // User-driven retire of a standing directive (default: cancelled).
+        async retireDirective(id, status) {
+          this.retiringDirectiveId = id;
+          try {
+            const resp = await fetchApi("/api/genesis/ego/directives/" + id + "/resolve", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ status: status || "cancelled" }),
+            });
+            if (resp?.ok) { await this.fetchEgoDirectivesGoals(); }
+          } catch (e) {
+            console.warn("Directive retire failed:", e);
+          } finally {
+            this.retiringDirectiveId = null;
+          }
         },
 
         async fetchOutreachMessages() {

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -516,7 +516,11 @@
             case "chat":
               // Re-fit terminal on tab re-entry
               if (!first && this._xterm && this._fitAddon) { this._fitAddon.fit(); }
-              if (first) { this.fetchComms(); this.fetchApprovals(); this.fetchEgoDirectivesGoals(); }
+              if (first) { this.fetchComms(); this.fetchApprovals(); }
+              // Refresh directives/goals on every Chat activation (not just first)
+              // so re-entry can't show standing state that changed elsewhere while
+              // the dashboard stayed open. Rarely changes → refreshed here, not polled.
+              this.fetchEgoDirectivesGoals();
               this._commsInterval = setInterval(() => this.fetchComms(), 15000);
               this._approvalsInterval = setInterval(() => this.fetchApprovals(), 15000);
               break;

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -1105,13 +1105,9 @@ async def list_active_directives(
     ``kind`` defaults to plain directives so pre-decision callers are
     unchanged; decision rows have their own accessors below.
     """
-    cursor = await db.execute(
-        "SELECT * FROM ego_directives "
-        "WHERE status = 'active' AND ego_target = ? AND kind = ? "
-        "ORDER BY created_at DESC LIMIT ?",
-        (ego_target, kind, limit),
+    return await list_directives(
+        db, ego_target=ego_target, statuses=("active",), kind=kind, limit=limit
     )
-    return [dict(r) for r in await cursor.fetchall()]
 
 
 async def resolve_directive(

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -1137,6 +1137,43 @@ async def resolve_directive(
     return cursor.rowcount > 0
 
 
+async def list_directives(
+    db: aiosqlite.Connection,
+    *,
+    ego_target: str | None = None,
+    statuses: tuple[str, ...] = ("active",),
+    kind: str = "directive",
+    limit: int = 20,
+) -> list[dict]:
+    """Directives filtered by status (and optionally ego_target).
+
+    Generalizes :func:`list_active_directives` for the dashboard, which needs a
+    cross-target active view plus recently-resolved history. Ordered by
+    ``COALESCE(resolved_at, created_at) DESC`` so a homogeneous call sorts
+    correctly either way — active rows (resolved_at NULL) by creation, resolved
+    rows by resolution time. ``kind`` defaults to plain directives; decision
+    rows are excluded (they have their own accessors).
+    """
+    if not statuses:
+        return []
+    placeholders = ",".join("?" for _ in statuses)
+    params: list[object] = [kind, *statuses]
+    target_clause = ""
+    if ego_target is not None:
+        target_clause = "AND ego_target = ? "
+        params.append(ego_target)
+    params.append(limit)
+    cursor = await db.execute(
+        f"""SELECT * FROM ego_directives
+           WHERE kind = ? AND status IN ({placeholders})
+           {target_clause}
+           ORDER BY COALESCE(resolved_at, created_at) DESC
+           LIMIT ?""",  # noqa: S608 — placeholders count-derived, all values bound
+        params,
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
 # ── Decision rows (kind='decision') — durable user rulings ──────────────
 
 

--- a/tests/test_dashboard/test_directives_goals_routes.py
+++ b/tests/test_dashboard/test_directives_goals_routes.py
@@ -98,15 +98,29 @@ class TestEgoDirectives:
             assert data == {"active": [], "resolved": []}
 
 
+def _goals_by_origin(by_origin):
+    """Build a list_active side_effect returning per-origin rows (the route
+    now queries each lane separately, so a busy lane can't starve the other)."""
+
+    def _side_effect(db, *, limit=20, origin=None):
+        return list(by_origin.get(origin, []))
+
+    return _side_effect
+
+
 class TestEgoGoals:
     def test_split_by_origin(self, client):
-        goals = [_grow("g1", "user"), _grow("g2", "genesis_ego"), _grow("g3", "user")]
+        side = _goals_by_origin(
+            {
+                "user": [_grow("g1", "user"), _grow("g3", "user")],
+                "genesis_ego": [_grow("g2", "genesis_ego")],
+            }
+        )
         with (
             patch("genesis.runtime.GenesisRuntime") as MockRT,
             patch(
                 "genesis.db.crud.user_goals.list_active",
-                new_callable=AsyncMock,
-                return_value=goals,
+                new=AsyncMock(side_effect=side),
             ),
         ):
             MockRT.instance.return_value = _rt()
@@ -116,13 +130,10 @@ class TestEgoGoals:
 
     def test_empty_own_goal_lane_renders(self, client):
         # fresh-install state: only user goals, empty own-goal lane
+        side = _goals_by_origin({"user": [_grow("g1", "user")], "genesis_ego": []})
         with (
             patch("genesis.runtime.GenesisRuntime") as MockRT,
-            patch(
-                "genesis.db.crud.user_goals.list_active",
-                new_callable=AsyncMock,
-                return_value=[_grow("g1", "user")],
-            ),
+            patch("genesis.db.crud.user_goals.list_active", new=AsyncMock(side_effect=side)),
         ):
             MockRT.instance.return_value = _rt()
             data = client.get("/api/genesis/ego/goals").get_json()

--- a/tests/test_dashboard/test_directives_goals_routes.py
+++ b/tests/test_dashboard/test_directives_goals_routes.py
@@ -1,0 +1,198 @@
+"""E2E (HTTP-layer) tests for the ego Directives & Goals visibility routes.
+
+Drives the real Flask route handlers with the DB/CRUD layer patched, asserting
+the payload shape (active/resolved split, user/own-goal split), the
+not-bootstrapped guards, and the retire (resolve) contract incl. 400/404/503.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _rt(bootstrapped=True):
+    rt = MagicMock()
+    rt.is_bootstrapped = bootstrapped
+    rt._db = MagicMock() if bootstrapped else None
+    return rt
+
+
+def _drow(id_, ego_target, status, resolved_at=None):
+    return {
+        "id": id_,
+        "content": f"directive {id_}",
+        "priority": "high",
+        "source": "user",
+        "ego_target": ego_target,
+        "status": status,
+        "created_at": "2026-06-08T00:00:00+00:00",
+        "resolved_at": resolved_at,
+        "resolution": None,
+        "reaffirm_count": 0,
+        "last_reaffirmed_at": None,
+    }
+
+
+def _grow(id_, origin):
+    return {
+        "id": id_,
+        "title": f"goal {id_}",
+        "description": "d",
+        "category": "project",
+        "priority": "high",
+        "status": "active",
+        "timeline": None,
+        "confidence": 0.5,
+        "goal_type": "milestone",
+        "origin": origin,
+        "created_at": "2026-07-01T00:00:00+00:00",
+        "updated_at": "2026-07-01T00:00:00+00:00",
+    }
+
+
+def _list_directives_side_effect(db, *, statuses=("active",), limit=20, **_kw):
+    if "active" in statuses:
+        return [_drow("c60", "genesis_ego", "active"), _drow("u1", "user_ego", "active")]
+    return [_drow("old", "user_ego", "completed", resolved_at="2026-07-19T00:00:00+00:00")]
+
+
+class TestEgoDirectives:
+    def test_active_and_resolved_split(self, client):
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.ego.list_directives",
+                new=AsyncMock(side_effect=_list_directives_side_effect),
+            ),
+        ):
+            MockRT.instance.return_value = _rt()
+            data = client.get("/api/genesis/ego/directives").get_json()
+            assert [d["id"] for d in data["active"]] == ["c60", "u1"]
+            assert [d["id"] for d in data["resolved"]] == ["old"]
+            # payload projection carries priority/target/reaffirm for the panel
+            assert data["active"][0]["ego_target"] == "genesis_ego"
+            assert data["active"][0]["reaffirm_count"] == 0
+
+    def test_empty_when_not_bootstrapped(self, client):
+        with patch("genesis.runtime.GenesisRuntime") as MockRT:
+            MockRT.instance.return_value = _rt(bootstrapped=False)
+            data = client.get("/api/genesis/ego/directives").get_json()
+            assert data == {"active": [], "resolved": []}
+
+
+class TestEgoGoals:
+    def test_split_by_origin(self, client):
+        goals = [_grow("g1", "user"), _grow("g2", "genesis_ego"), _grow("g3", "user")]
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.user_goals.list_active",
+                new_callable=AsyncMock,
+                return_value=goals,
+            ),
+        ):
+            MockRT.instance.return_value = _rt()
+            data = client.get("/api/genesis/ego/goals").get_json()
+            assert [g["id"] for g in data["user"]] == ["g1", "g3"]
+            assert [g["id"] for g in data["genesis_ego"]] == ["g2"]
+
+    def test_empty_own_goal_lane_renders(self, client):
+        # fresh-install state: only user goals, empty own-goal lane
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.user_goals.list_active",
+                new_callable=AsyncMock,
+                return_value=[_grow("g1", "user")],
+            ),
+        ):
+            MockRT.instance.return_value = _rt()
+            data = client.get("/api/genesis/ego/goals").get_json()
+            assert data["genesis_ego"] == []
+            assert len(data["user"]) == 1
+
+    def test_empty_when_not_bootstrapped(self, client):
+        with patch("genesis.runtime.GenesisRuntime") as MockRT:
+            MockRT.instance.return_value = _rt(bootstrapped=False)
+            data = client.get("/api/genesis/ego/goals").get_json()
+            assert data == {"user": [], "genesis_ego": []}
+
+
+class TestEgoDirectiveResolve:
+    def test_retire_happy_path(self, client):
+        resolve = AsyncMock(return_value=True)
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch("genesis.db.crud.ego.resolve_directive", new=resolve),
+        ):
+            MockRT.instance.return_value = _rt()
+            resp = client.post("/api/genesis/ego/directives/c60/resolve", json={})
+            assert resp.status_code == 200
+            assert resp.get_json() == {"ok": True, "id": "c60", "status": "cancelled"}
+            # default retire uses status='cancelled' + a resolution note
+            _args, kwargs = resolve.call_args
+            assert kwargs["status"] == "cancelled"
+            assert kwargs["resolution"] == "Retired via dashboard"
+
+    def test_completed_status_passthrough(self, client):
+        resolve = AsyncMock(return_value=True)
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch("genesis.db.crud.ego.resolve_directive", new=resolve),
+        ):
+            MockRT.instance.return_value = _rt()
+            resp = client.post(
+                "/api/genesis/ego/directives/c60/resolve",
+                json={"status": "completed", "resolution": "done"},
+            )
+            assert resp.status_code == 200
+            _args, kwargs = resolve.call_args
+            assert kwargs["status"] == "completed"
+            assert kwargs["resolution"] == "done"
+
+    def test_not_found_or_decision_row_is_404(self, client):
+        # resolve_directive returns False for a missing/already-resolved/decision row
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch(
+                "genesis.db.crud.ego.resolve_directive",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            MockRT.instance.return_value = _rt()
+            resp = client.post("/api/genesis/ego/directives/nope/resolve", json={})
+            assert resp.status_code == 404
+            assert resp.get_json()["ok"] is False
+
+    def test_bad_status_is_400(self, client):
+        with patch("genesis.runtime.GenesisRuntime") as MockRT:
+            MockRT.instance.return_value = _rt()
+            resp = client.post(
+                "/api/genesis/ego/directives/c60/resolve",
+                json={"status": "approved"},
+            )
+            assert resp.status_code == 400
+
+    def test_not_bootstrapped_is_503(self, client):
+        with patch("genesis.runtime.GenesisRuntime") as MockRT:
+            MockRT.instance.return_value = _rt(bootstrapped=False)
+            resp = client.post("/api/genesis/ego/directives/c60/resolve", json={})
+            assert resp.status_code == 503

--- a/tests/test_db/test_list_directives.py
+++ b/tests/test_db/test_list_directives.py
@@ -1,0 +1,107 @@
+"""Unit tests for ``ego_crud.list_directives`` — the status-filtered directive
+list the dashboard's Directives panel reads.
+
+Covers: status filtering, optional ``ego_target`` scoping, the ``kind='directive'``
+default that structurally excludes decision rows, and the
+``COALESCE(resolved_at, created_at) DESC`` ordering (verified per homogeneous
+call). Timestamps are inserted explicitly so ordering never depends on the wall
+clock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _mk_directive(
+    db,
+    *,
+    id,
+    ego_target="user_ego",
+    status="active",
+    created_at,
+    resolved_at=None,
+    kind="directive",
+    priority="high",
+):
+    await db.execute(
+        """INSERT INTO ego_directives
+           (id, content, priority, source, ego_target, status, created_at,
+            resolved_at, kind)
+           VALUES (?, ?, ?, 'user', ?, ?, ?, ?, ?)""",
+        (id, f"directive {id}", priority, ego_target, status, created_at, resolved_at, kind),
+    )
+    await db.commit()
+
+
+async def test_active_only_both_targets(db):
+    await _mk_directive(db, id="ua", ego_target="user_ego", created_at="2026-07-01T00:00:00+00:00")
+    await _mk_directive(
+        db, id="ga", ego_target="genesis_ego", created_at="2026-07-02T00:00:00+00:00"
+    )
+    await _mk_directive(
+        db,
+        id="done",
+        status="completed",
+        created_at="2026-06-01T00:00:00+00:00",
+        resolved_at="2026-06-02T00:00:00+00:00",
+    )
+
+    rows = await ego_crud.list_directives(db, statuses=("active",))
+    ids = [r["id"] for r in rows]
+    assert ids == ["ga", "ua"]  # active only, newest created_at first (COALESCE)
+
+
+async def test_ego_target_filter(db):
+    await _mk_directive(db, id="ua", ego_target="user_ego", created_at="2026-07-01T00:00:00+00:00")
+    await _mk_directive(
+        db, id="ga", ego_target="genesis_ego", created_at="2026-07-02T00:00:00+00:00"
+    )
+
+    rows = await ego_crud.list_directives(db, ego_target="genesis_ego", statuses=("active",))
+    assert [r["id"] for r in rows] == ["ga"]
+
+
+async def test_default_kind_excludes_decisions(db):
+    await _mk_directive(db, id="dir", created_at="2026-07-01T00:00:00+00:00")
+    await _mk_directive(db, id="dec", kind="decision", created_at="2026-07-02T00:00:00+00:00")
+
+    rows = await ego_crud.list_directives(db, statuses=("active",))
+    assert [r["id"] for r in rows] == ["dir"]  # decision row excluded by default kind
+
+
+async def test_resolved_ordering_newest_resolved_first(db):
+    await _mk_directive(
+        db,
+        id="r_old",
+        status="completed",
+        created_at="2026-06-01T00:00:00+00:00",
+        resolved_at="2026-06-05T00:00:00+00:00",
+    )
+    await _mk_directive(
+        db,
+        id="r_new",
+        status="cancelled",
+        created_at="2026-05-01T00:00:00+00:00",
+        resolved_at="2026-07-10T00:00:00+00:00",
+    )
+    rows = await ego_crud.list_directives(db, statuses=("completed", "cancelled"))
+    # ordered by resolved_at DESC even though r_new was created earlier
+    assert [r["id"] for r in rows] == ["r_new", "r_old"]
+
+
+async def test_limit_is_respected(db):
+    for i in range(5):
+        await _mk_directive(db, id=f"d{i}", created_at=f"2026-07-0{i + 1}T00:00:00+00:00")
+    rows = await ego_crud.list_directives(db, statuses=("active",), limit=2)
+    assert len(rows) == 2
+    assert rows[0]["id"] == "d4"  # newest first, capped at 2
+
+
+async def test_empty_statuses_returns_empty(db):
+    await _mk_directive(db, id="a", created_at="2026-07-01T00:00:00+00:00")
+    assert await ego_crud.list_directives(db, statuses=()) == []


### PR DESCRIPTION
## PR-2 — Dashboard: Directives & Goals visibility

Second PR of the ego-lifecycle redesign. Gives the user eyes on what's actually **driving** each ego — standing directives and goals — on the same surface as proposals, with a manual **Retire** control for directives. Visibility + user-driven retire only; **no autonomous behavior** added (locked decision 4).

### Why
The proposal board accumulated stale work driven by a directive the user could not see anywhere in the UI (write/read asymmetry). This PR surfaces active directives (both egos) and goals so standing state is visible and retirable by eye.

### Backend
- `list_directives` CRUD — status-filtered directive list (generalizes `list_active_directives`, which now delegates to it). `kind='directive'` excludes decision rows. No schema change.
- `GET /api/genesis/ego/directives` — active (both egos) + recently-resolved.
- `GET /api/genesis/ego/goals` — active goals, per-lane queries (user vs own-goal), so neither lane starves the other.
- `POST /api/genesis/ego/directives/<id>/resolve` — user-driven retire (default cancelled; decision rows structurally refused).

### Frontend
- **Chat tab** (where proposals render): Directives strip (active with Retire, resolved de-emphasized) + Goals strip (user goals + ego own-goal lane with empty-state).
- **Ego modal Overview**: compact read-only glance card linking to the Chat tab to act.
- Shared store fields populated on chat entry, modal open, and post-retire; not polled (change rarely).

### Verification
- Unit test for `list_directives` (status filter, ego_target scope, decision exclusion, ordering, limit) — wall-clock-independent.
- HTTP-layer E2E for all three routes: payload split, empty-state, not-bootstrapped guards, retire happy/400/404/503, `completed` passthrough.
- Multi-angle review (backend/frontend/altitude+conventions) + fixes: per-lane goal query (anti-starvation), delegation dedup, client-side payload shape guard, dropped a UI-unreachable param.

### Deploy
Runtime code + templates + static JS: `git pull` + server restart. No migration.

Ledger: 36d4b7667d3644ae9d265e5fee4b9f5d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
