### PR TITLE
fix(voice-master): resolve first-person contradiction (drop opens_with_I gate)

### DIFF
--- a/src/genesis/content/antislop.py
+++ b/src/genesis/content/antislop.py
@@ -155,9 +155,6 @@ def detect(text: str) -> dict[str, object]:
         findings["contrast_structures"] = contrasts
 
     sents = _sentences(prose)
-    if sents and sents[0].lstrip().startswith("I "):
-        findings["opens_with_I"] = sents[0][:60]
-
     lengths = [len(s.split()) for s in sents]
     if len(lengths) > 3 and (max(lengths) - min(lengths) < 4):
         findings["uniform_sentence_length"] = len(lengths)
@@ -194,7 +191,7 @@ def scrub(text: str, *, is_voiced: bool = True) -> ScrubResult:
         findings = detect(cleaned)
         for key in (
             "spaced_ambiguous_dash", "banned_words", "banned_phrases",
-            "filler_openers", "contrast_structures", "opens_with_I",
+            "filler_openers", "contrast_structures",
             "uniform_sentence_length",
         ):
             if key in findings:

--- a/src/genesis/skills/voice-master/references/anti-slop.md
+++ b/src/genesis/skills/voice-master/references/anti-slop.md
@@ -128,7 +128,6 @@ not per paragraph. Stacking them is an AI fingerprint.
 
 ### Structural tells
 
-- Opening the first sentence with "I".
 - Three-part lists whose items share the exact same grammatical structure.
 - Uniform sentence length — vary it. Favor sentences under ~16 words but keep
   the user's natural longer reasoning chains; don't flatten everything to one

--- a/src/genesis/skills/voice-master/references/style-guide.md
+++ b/src/genesis/skills/voice-master/references/style-guide.md
@@ -30,9 +30,9 @@ Real humans have mixed feelings. "This is impressive but also kind of unsettling
 
 **Human:** It's clever, but it makes me nervous. The failure modes aren't well understood.
 
-## Use first person when it fits
+## First person is encouraged
 
-"I" isn't unprofessional — it's honest.
+"I" is a good word; use it. First person isn't unprofessional, it's honest. Don't contort a sentence to avoid it.
 
 - "I keep coming back to..."
 - "Here's what gets me..."

--- a/tests/test_content/test_antislop.py
+++ b/tests/test_content/test_antislop.py
@@ -150,3 +150,21 @@ class TestRealisticSlopRoundTrip:
         assert f" {EM} " not in r.cleaned_text
         assert f"here{EM}not" in r.cleaned_text
         assert r.fixes_applied == ["spaced_em_dash:1"]
+
+
+class TestFirstPersonOpenerAllowed:
+    """First person is encouraged by the voice-master style-guide, so an opener
+    starting with "I" is NOT an anti-slop tell (the old opens_with_I gate was
+    removed to stop it contradicting the guidance)."""
+
+    def test_detect_does_not_flag_first_person_opener(self):
+        assert "opens_with_I" not in detect(
+            "I keep coming back to the same failure mode."
+        )
+
+    def test_scrub_does_not_flag_first_person_opener(self):
+        r = scrub(
+            "I keep coming back to it. The failure bites every time, in new ways.",
+            is_voiced=True,
+        )
+        assert not any("opens_with_I" in f for f in r.flags)


### PR DESCRIPTION
## What

The voice-master content skill's guidance **encourages first person** ("I" is a good word — `style-guide.md`, plus the gen-guidance #1200 added), but two gates still **penalized** it, so content that follows the guidance failed the anti-slop check:

- `references/anti-slop.md` listed *"opening the first sentence with I"* as a structural tell.
- the deterministic scrubber `src/genesis/content/antislop.py:158` emitted an `opens_with_I` finding (and listed it in `scrub()`'s flag set), so `"I keep coming back to…"` failed in the CLI + egress logs.

Flagged as a **Codex P2** on PR #1204 (now closed — its doc-level-tells + markdown-as-tell bulk was superseded by #1200; this is the remaining, uncovered residual).

## Change
- Remove the `opens_with_I` detection + its flag-key entry from `antislop.py`. The genuine assistant-opener tell (`"I'd be happy to…"`) is still caught as a banned phrase, so nothing regresses.
- Remove the `"opening with I"` bullet from `anti-slop.md`.
- Strengthen `style-guide.md` first-person from "use first person when it fits" to "first person is encouraged, 'I' is a good word" (also drops a stray spaced em-dash from that line).
- Add a regression test: a first-person opener is not flagged by `detect()` or `scrub()`.

## Tests
`test_content/test_antislop.py` — 24 passed (incl. 2 new). `ruff check` clean.

## Scope
Public-repo skill + its deterministic scrubber; no user voice data (that lives in the private overlay). No in-flight voice-master PRs at branch time (checked).

---
Completes the first-person residual of follow-up `93a4265b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
