### PR TITLE
perf(memory): run recall's Qdrant vector search off the event loop (ac27b693, PR-2)

### DIFF
--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -1243,8 +1243,18 @@ class HybridRetriever:
         qdrant_results: list[dict] = []
         qdrant_by_id: dict[str, dict] = {}
         for coll in collections:
+            # Qdrant's client is SYNCHRONOUS (no AsyncQdrantClient exists in
+            # Genesis), so offload each blocking search to a worker thread — it
+            # must never block the shared event loop while other coroutines (other
+            # recalls, the rest of the server) are waiting, which matters under
+            # Jay's 5-7 concurrent-session norm (ac27b693, PR-2). track_operation
+            # stays ON the event loop wrapping the await, so per-collection
+            # "qdrant.search" telemetry (the provider:qdrant_unreachable signal in
+            # mcp/health/errors.py) is byte-identical to the inline version, and
+            # asyncio.to_thread re-raises so a Qdrant error propagates unchanged.
             with track_operation(self._embeddings.tracker, "qdrant.search"):
-                hits = qdrant_ops.search(
+                hits = await asyncio.to_thread(
+                    qdrant_ops.search,
                     self._qdrant,
                     collection=coll,
                     query_vector=vector,

--- a/tests/test_memory/test_vector_offload.py
+++ b/tests/test_memory/test_vector_offload.py
@@ -1,0 +1,93 @@
+"""Qdrant vector search runs off the event loop (follow-up ac27b693, PR-2).
+
+Qdrant's client is synchronous; `_gather_vector_candidates` now runs the whole
+per-collection search loop in a worker thread via `asyncio.to_thread` so it never
+blocks the shared event loop under concurrent recalls. These tests pin (a) that
+the blocking search actually executes off the main thread and (b) that the
+score-sort / `_collection`-tag / first-hit-wins dedup behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.memory.retrieval import HybridRetriever
+
+
+def _retriever() -> HybridRetriever:
+    embed = MagicMock()
+    embed.embed = AsyncMock(return_value=[0.1] * 1024)
+    return HybridRetriever(
+        embedding_provider=embed,
+        qdrant_client=MagicMock(),
+        db=MagicMock(),
+    )
+
+
+def _hit(mid: str, score: float) -> dict:
+    return {"id": mid, "score": score, "payload": {"content": mid}}
+
+
+async def _gather(retriever: HybridRetriever, collections: list[str]):
+    return await retriever._gather_vector_candidates(
+        vector=[0.1] * 1024,
+        collections=collections,
+        candidate_limit=10,
+        wing=None,
+        room=None,
+        life_domain=None,
+        project_type=None,
+        exclude_subsystems=None,
+        include_only_subsystems=None,
+        include_deprecated=False,
+    )
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_search_runs_off_event_loop(mock_qdrant):
+    """The synchronous qdrant_ops.search executes in a worker thread, not on the
+    event-loop thread (that is the whole point of the to_thread offload)."""
+    main_ident = threading.get_ident()
+    seen: dict = {}
+
+    def _search(_client, *, collection, **_kw):
+        seen["ident"] = threading.get_ident()
+        return [_hit("m1", 0.9)]
+
+    mock_qdrant.search.side_effect = _search
+
+    results, by_id = await _gather(_retriever(), ["c1"])
+
+    assert "ident" in seen, "search was never called"
+    assert seen["ident"] != main_ident, "search ran on the event-loop thread (not offloaded)"
+    assert [h["id"] for h in results] == ["m1"]
+    assert by_id["m1"]["_collection"] == "c1"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_sort_tag_dedup_parity(mock_qdrant):
+    """Across collections: results stay score-sorted desc, every hit is
+    `_collection`-tagged, and the dedup map keeps the first hit in score order
+    (so the higher-scoring duplicate wins) — identical to the pre-offload loop."""
+
+    def _search(_client, *, collection, **_kw):
+        if collection == "c1":
+            return [_hit("dup", 0.5), _hit("m1", 0.9)]
+        return [_hit("dup", 0.8), _hit("m2", 0.7)]
+
+    mock_qdrant.search.side_effect = _search
+
+    results, by_id = await _gather(_retriever(), ["c1", "c2"])
+
+    scores = [h["score"] for h in results]
+    assert scores == sorted(scores, reverse=True)
+    assert all("_collection" in h for h in results)
+    # first-hit-wins after the score sort → dup's 0.8 (from c2) beats its 0.5
+    assert by_id["dup"]["score"] == 0.8
+    assert by_id["dup"]["_collection"] == "c2"
+    assert set(by_id) == {"dup", "m1", "m2"}


### PR DESCRIPTION
## What & why

`_gather_vector_candidates` looped the **synchronous** `qdrant_ops.search` (→ `client.query_points`) directly on the asyncio event loop, once per collection — blocking every other coroutine (other recalls, the whole server) for each Qdrant round-trip. Under Jay's 5–7 concurrent-session norm that's shared-loop head-of-line blocking. It was the **only** remaining sync-Qdrant-on-loop call on the read path (`_expand_fts_query`'s scroll and the PR-1 write-back are already offloaded).

This is **PR-2** of the ac27b693 recall-latency series (after PR-1 side-effect deferral, PR-4 recall-read RO pool, PR-4b enrich/breadcrumbs pool).

## Change

Offload **each per-collection search** via `asyncio.to_thread(qdrant_ops.search, …)`. Deliberately per-collection (not one batched closure) so `track_operation("qdrant.search")` stays exactly where it was — on the event loop, one span per collection, wrapping the await:

- **Telemetry byte-identical** — span count, success/failure, and sample volume unchanged, so the `provider:qdrant_unreachable` alert (`mcp/health/errors.py`, CRITICAL at error_rate≥0.5) is unaffected. (A first pass collapsed N spans→1; a local code review flagged the alert-sensitivity change and it was reworked to per-collection offload.)
- **Exception semantics unchanged** — `asyncio.to_thread` re-raises, so a Qdrant error propagates identically.
- **Behavior parity** — score-sort / `_collection` tagging / first-hit-wins dedup untouched.
- **Thread-safety** — the Qdrant client is remote REST/httpx (thread-safe); this extends the already-shipped worker-thread pattern from PR-1's write-back offload.

## Value (honest)

The happy-path vector stage is small (~32ms); the win is **not blocking the shared event loop** under concurrency so other coroutines progress. The live 7× event-loop-responsiveness measurement is **deploy-gated** (deploy currently held).

## Tests

New `tests/test_memory/test_vector_offload.py`: (a) the search runs in a **worker thread** (proves the offload), (b) sort/tag/dedup parity across collections. Full recall regression suite green locally (57 tests incl. `test_recall_deferral`, `test_retrieval`).

Follow-up: ac27b693

🤖 Generated with [Claude Code](https://claude.com/claude-code)