### PR TITLE
feat(cc): rate-limit durability — park exhausted CC work (PR-2a)

### DIFF
--- a/config/cc_rate_limit_resume.yaml
+++ b/config/cc_rate_limit_resume.yaml
@@ -1,0 +1,58 @@
+# Rate-limit park + auto-resume — writable, DORMANT (off) by default until the
+# resume engine lands.
+#
+# When a CC session hits a rate/usage limit, the work is PARKED durably
+# (cc_rate_limit_parks) and a CronTrigger job re-dispatches the actual parked
+# work at the error's reset time, delivering the result back to its origin
+# conversation. The engine re-reads this merged config (this file +
+# ~/.genesis/config/cc_rate_limit_resume.local.yaml) every tick, so a
+# settings_update("cc_rate_limit_resume", {...}) or hand edit takes effect on
+# the next tick — no restart.
+#
+# Master switch: false stops both parking-copy mode-awareness and the resumer.
+enabled: true
+
+# Mode: off | propose_only | live
+#   off          — never auto-resume (parks still recorded; copy says "try later")
+#   propose_only — park the work and PING the user ("ready — reply 'resume'");
+#                  the user's reply is the dispatch approval. Not hands-off.
+#   live         — (default) auto-resume: re-dispatch the parked work at reset
+#                  and deliver to origin. A resume only completes work whose
+#                  initiation was ALREADY approved (a foreground turn's typed
+#                  prompt, or a direct_session's already-gated original dispatch),
+#                  so it is not new autonomous initiative and does not re-enter
+#                  the autonomous-CLI approval gate.
+#
+# Hook/env kill switch (separate lever): GENESIS_RATE_LIMIT_RESUME_DISABLED=1
+# forces the resumer to no-op regardless of this file.
+#
+# DORMANT until the resume engine is wired (PR-2b): with no resumer, `live`/
+# `propose_only` would promise a resume nothing delivers. PR-2b flips this to
+# `live`. Until then `off` parks nothing and shows an honest "try again later".
+mode: off
+
+# Retry cadence (minutes) when the reset time could not be parsed (e.g. a
+# day-ambiguous weekly limit) — the park is retried on this floor instead.
+cadence_floor_minutes: 30
+
+# Re-limit backoff: a resumed retry that hits the limit AGAIN backs off
+# exponentially from base toward the cap before the next attempt.
+backoff_base_minutes: 30
+backoff_cap_minutes: 240
+
+# Jitter (seconds) added to each next-attempt time to avoid a thundering herd
+# when many parks share one reset window.
+jitter_seconds: 60
+
+# Parks resumed per engine tick (the account-wide limit means they clear in
+# order; this bounds per-tick dispatch).
+max_due_per_tick: 50
+
+# Give up after this many attempts → escalate to needs_user (one alert, no more
+# auto-retries). At ~worst-case 4h backoff this is roughly a week of retries.
+needs_user_attempts: 40
+
+# Capability pinning: a resumed conversation-origin turn runs under this bounded
+# background profile (a subset of the foreground tool surface). Direct-session
+# parks re-run under their own original profile, unchanged.
+conversation_resume_profile: research

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -182,6 +182,26 @@ verified: 3c5e1f24 2026-07-22
   honored in `_deliver` before category routing — DM or forum topic). Legacy callers
   (all 8) derive `SILENT`/`FAILURE_ONLY` from their notify bools → unchanged. Fixes the
   latent bug where a successful background result was saved but never sent.
+- **Rate-limit park + auto-resume** (`cc/rate_limit_park.py`, `cc/rate_limit_reset.py`,
+  `crud/cc_rate_limit_parks.py`, config `cc_rate_limit_resume`): the durability half of
+  the same 2026-07-20 incident. When a CC call hits a rate/usage limit, the work is
+  PARKED (a `cc_rate_limit_parks` row — the durable lineage object) instead of dying —
+  foreground turns (after failover+contingency both fail) and background `direct_session`s
+  (a new catch before the generic `except`). The park stores a parsed `reset_at`
+  (`rate_limit_reset.parse_reset` off the annotated `CCRateLimitError.raw_event`/`raw_text`,
+  previously discarded); `cc_sessions.rate_limit_resumes_at` finally gets a producer, and
+  the foreground copy is mode-aware (no longer promises resume nothing backed). A
+  `CronTrigger` engine (PR-2b) re-dispatches the actual parked work at reset via the
+  delivery model (`delivery_mode=result` + `origin_session_id`); a still-limited retry
+  re-limits its OWN park in place (attempts+1, backoff) — resolved by `park_id` threaded
+  in `caller_context="rate_limit_resume:<id>"` — so the `needs_user` escalation stays
+  reachable. Gate posture: a resume completes already-approved work (a foreground prompt,
+  or an already-gated dispatch), so it is not new autonomous initiative. Reflection-bridge
+  and the task executor deliberately do NOT park (periodic self-retry / already durable via
+  `task_states`). Lever `cc_rate_limit_resume` (off|propose_only|live) +
+  `GENESIS_RATE_LIMIT_RESUME_DISABLED`; **default `off` (dormant) until PR-2b
+  wires the resume engine, then flipped to `live`** — shipping the park substrate
+  inert avoids promising a resume nothing yet delivers.
 
 ## 3. Autonomy & egress gating
 

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -10,7 +10,7 @@ from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from genesis.cc import roster
+from genesis.cc import rate_limit_park, roster
 from genesis.cc.context_injector import ContextInjector
 from genesis.cc.exceptions import (
     CCError,
@@ -271,10 +271,19 @@ class ConversationLoop:
                     "Contingency fallback failed after rate limit: %s", e,
                     exc_info=True,
                 )
-                return (
-                    "[Rate limit reached — Genesis is temporarily running in reduced mode. "
-                    "Background tasks are queued and will resume automatically.]"
+                # Both fallbacks failed → the user got no answer. Park the turn
+                # durably so it auto-resumes when capacity returns (rate_limit_park
+                # owns the reset parse, the cc_sessions resume-time write, and the
+                # mode-aware copy — replacing the old sentence nothing backed).
+                outcome = await rate_limit_park.park_conversation(
+                    self._db,
+                    prompt=prompt_text,
+                    origin_session_id=session["id"],
+                    exc=e,
+                    model=model,
+                    effort=effort,
                 )
+                return outcome.copy
             except CCMCPError as e:
                 self._fire_failure_detection("mcp_error")
                 server = f" ({e.server_name})" if e.server_name else ""
@@ -578,10 +587,19 @@ class ConversationLoop:
                     "Contingency fallback failed after rate limit: %s", e,
                     exc_info=True,
                 )
-                return (
-                    "[Rate limit reached — Genesis is temporarily running in reduced mode. "
-                    "Background tasks are queued and will resume automatically.]"
+                # Both fallbacks failed → the user got no answer. Park the turn
+                # durably so it auto-resumes when capacity returns (rate_limit_park
+                # owns the reset parse, the cc_sessions resume-time write, and the
+                # mode-aware copy — replacing the old sentence nothing backed).
+                outcome = await rate_limit_park.park_conversation(
+                    self._db,
+                    prompt=prompt_text,
+                    origin_session_id=session["id"],
+                    exc=e,
+                    model=model,
+                    effort=effort,
                 )
+                return outcome.copy
             except CCMCPError as e:
                 self._fire_failure_detection("mcp_error")
                 server = f" ({e.server_name})" if e.server_name else ""

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -30,7 +30,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from genesis.cc import roster
+from genesis.cc import rate_limit_park, roster
+from genesis.cc.exceptions import CCQuotaExhaustedError, CCRateLimitError
 from genesis.cc.types import (
     CCInvocation,
     CCModel,
@@ -920,6 +921,12 @@ class DirectSessionRunner:
             if request.delivery_mode == DeliveryMode.RESULT:
                 await self._deliver_result_to_origin(request, result)
 
+            # If this session was a rate-limit resume, close its park now that the
+            # result is delivered (no-op unless caller_context carries a park id).
+            _db = getattr(self._rt, "_db", None)
+            if _db is not None:
+                await rate_limit_park.mark_resumed_if_lineage(_db, request.caller_context)
+
             logger.info(
                 "Direct session %s completed: %.1fs, $%.4f, %d tools",
                 session_id[:8],
@@ -969,60 +976,117 @@ class DirectSessionRunner:
             )
             raise
 
-        except Exception as exc:
-            elapsed = time.monotonic() - start
-            error_result = DirectSessionResult(
-                session_id=session_id,
-                success=False,
-                error=f"{type(exc).__name__}: {exc}",
-                duration_s=round(elapsed, 1),
-                tools_called=telemetry,
-            )
-
-            # Best-effort: persist failure and notify
-            try:
-                await self._store_result(session_id, request, error_result)
-                await self._record_proposal_outcome(request, error_result)
-                await self._session_manager.fail(
-                    session_id,
-                    reason=str(exc)[:500],
+        except (CCRateLimitError, CCQuotaExhaustedError) as exc:
+            # A rate/quota limit is NOT a real failure — park the work durably so
+            # it auto-resumes when capacity returns, instead of the misleading
+            # "FAILED" alert the generic handler emits. If this session was itself
+            # a resume, park_direct_session re-limits its own park in place
+            # (preserving the attempts/escalation lineage). mode=off or no db →
+            # fall through to the generic failure path (current behavior).
+            db = getattr(self._rt, "_db", None)
+            park_id = None
+            if db is not None:
+                park_id = await rate_limit_park.park_direct_session(db, request=request, exc=exc)
+            if park_id is not None:
+                elapsed = time.monotonic() - start
+                parked_result = DirectSessionResult(
+                    session_id=session_id,
+                    success=False,
+                    error=f"rate_limited: parked for resume ({park_id})",
+                    duration_s=round(elapsed, 1),
+                    tools_called=telemetry,
                 )
-            except Exception:
-                logger.error(
-                    "Failed to record session %s failure",
-                    session_id[:8],
-                    exc_info=True,
-                )
-
-            # RESULT-mode delivers the failure to the origin thread (a promised
-            # report that failed is still owed to the requester); otherwise the
-            # legacy broadcast failure alert fires. _deliver_result_to_origin
-            # swallows its own errors, so no extra guard is needed here.
-            if request.delivery_mode == DeliveryMode.RESULT:
-                await self._deliver_result_to_origin(request, error_result)
-            elif request.notify:
                 try:
-                    await self._notify(request, error_result, success=False)
+                    await self._store_result(session_id, request, parked_result)
+                    await self._session_manager.fail(
+                        session_id,
+                        reason="rate_limited_parked",
+                    )
                 except Exception:
                     logger.error(
-                        "Failed to send failure notification for %s",
+                        "Failed to record parked session %s",
                         session_id[:8],
                         exc_info=True,
                     )
+                logger.info(
+                    "Direct session %s rate-limited → parked %s for resume",
+                    session_id[:8],
+                    park_id,
+                )
+                return parked_result
+            # Parking disabled/failed — treat as a normal failure (re-raises).
+            await self._finalize_failure(session_id, request, exc, telemetry, start)
 
-            logger.error(
-                "Direct session %s failed after %.1fs: %s",
-                session_id[:8],
-                elapsed,
-                exc,
-            )
-            raise
+        except Exception as exc:
+            await self._finalize_failure(session_id, request, exc, telemetry, start)
 
         finally:
             # Remove this session's isolated CC sandbox (created off cc-tmp just
             # before the run above). Best-effort; the disk-hygiene reaper catches
             # any orphans left by a hard SIGKILL that skips this finally.
             shutil.rmtree(_bg_session_root(session_id), ignore_errors=True)
+
+    async def _finalize_failure(
+        self,
+        session_id: str,
+        request: DirectSessionRequest,
+        exc: BaseException,
+        telemetry: list[dict],
+        start: float,
+    ) -> None:
+        """Record + deliver a genuine session failure, then re-raise.
+
+        Extracted from the generic ``except`` so the rate-limit catch can reuse
+        the exact same path when parking is disabled (mode=off). Ends with
+        ``raise`` to preserve the original propagate-after-record contract.
+        """
+        elapsed = time.monotonic() - start
+        error_result = DirectSessionResult(
+            session_id=session_id,
+            success=False,
+            error=f"{type(exc).__name__}: {exc}",
+            duration_s=round(elapsed, 1),
+            tools_called=telemetry,
+        )
+
+        # Best-effort: persist failure and notify
+        try:
+            await self._store_result(session_id, request, error_result)
+            await self._record_proposal_outcome(request, error_result)
+            await self._session_manager.fail(
+                session_id,
+                reason=str(exc)[:500],
+            )
+        except Exception:
+            logger.error(
+                "Failed to record session %s failure",
+                session_id[:8],
+                exc_info=True,
+            )
+
+        # RESULT-mode delivers the failure to the origin thread (a promised
+        # report that failed is still owed to the requester); otherwise the
+        # legacy broadcast failure alert fires. _deliver_result_to_origin
+        # swallows its own errors, so no extra guard is needed here.
+        if request.delivery_mode == DeliveryMode.RESULT:
+            await self._deliver_result_to_origin(request, error_result)
+        elif request.notify:
+            try:
+                await self._notify(request, error_result, success=False)
+            except Exception:
+                logger.error(
+                    "Failed to send failure notification for %s",
+                    session_id[:8],
+                    exc_info=True,
+                )
+
+        logger.error(
+            "Direct session %s failed after %.1fs: %s",
+            session_id[:8],
+            elapsed,
+            exc,
+        )
+        raise
 
     async def _record_proposal_outcome(
         self,

--- a/src/genesis/cc/exceptions.py
+++ b/src/genesis/cc/exceptions.py
@@ -35,11 +35,34 @@ class CCMCPError(CCError):
         self.server_name = server_name
 
 
-class CCRateLimitError(CCError):
+class _CCLimitError(CCError):
+    """Shared base for rate-limit / quota errors — carries the reset signal.
+
+    The CC CLI surfaces a reset hint ("resets Xpm") in the error prose and, on
+    the streaming path, a structured ``rate_limit_event`` payload. Both were
+    historically discarded at every detection point. Capturing them here lets
+    the durability layer (``cc_rate_limit_parks``) schedule a resume off the
+    real reset time instead of a blind backoff. Both fields are optional so all
+    existing single-arg raises (``CCRateLimitError(text)``) stay valid.
+    """
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        raw_event: dict | None = None,
+        raw_text: str | None = None,
+    ):
+        super().__init__(message)
+        self.raw_event = raw_event
+        self.raw_text = raw_text
+
+
+class CCRateLimitError(_CCLimitError):
     """CC hit transient rate limit (recovers in minutes)."""
 
 
-class CCQuotaExhaustedError(CCError):
+class CCQuotaExhaustedError(_CCLimitError):
     """CC usage quota exhausted — hard ceiling lasting hours.
 
     Distinct from CCRateLimitError: quota exhaustion means the Max subscription

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -535,7 +535,7 @@ class CCInvoker:
             "token limit exceeded",
         )
         if any(p in lower for p in _QUOTA_PATTERNS):
-            return CCQuotaExhaustedError(stderr_text or stdout_text)
+            return CCQuotaExhaustedError(stderr_text or stdout_text, raw_text=combined)
         # Transient rate limit (429, recovers in minutes)
         # CC CLI says "You've hit your limit · resets Xpm" — not "rate limit"
         _RATE_LIMIT_PATTERNS = (
@@ -546,7 +546,7 @@ class CCInvoker:
             "hit the limit",
         )
         if any(p in lower for p in _RATE_LIMIT_PATTERNS):
-            return CCRateLimitError(stderr_text or stdout_text)
+            return CCRateLimitError(stderr_text or stdout_text, raw_text=combined)
         # MCP server error
         source = stderr_text or stdout_text
         if "mcp" in lower or "mcp server" in lower:
@@ -904,6 +904,7 @@ class CCInvoker:
         result_data: dict | None = None
         collected_text: list[str] = []
         event_types: list[str] = []
+        rate_limit_raw: dict | None = None
         timed_out = False
         terminated_after_result = False
         line_count = 0
@@ -923,6 +924,10 @@ class CCInvoker:
 
                     etype = event_raw.get("type", "?")
                     event_types.append(etype)
+                    if etype == "rate_limit_event":
+                        # Retain the raw payload (otherwise discarded) so the
+                        # durability layer can parse a reset time off it.
+                        rate_limit_raw = event_raw
                     logger.debug("CC stream event #%d: type=%s", line_count, etype)
 
                     event = StreamEvent.from_raw(event_raw)
@@ -1060,12 +1065,17 @@ class CCInvoker:
                         "CC rate-limited but response has content (%d chars) — delivering",
                         len(output.text),
                     )
-                    err = CCRateLimitError("CC rate limited (stream event)")
+                    err = CCRateLimitError(
+                        "CC rate limited (stream event)", raw_event=rate_limit_raw
+                    )
                     await self._notify_status_change(err)
                     await self._fire_downgrade_callback(output)
                     return output
                 # Empty/no response — rate limit prevented a real answer
-                err = CCRateLimitError(output.text or "CC rate limited (stream event)")
+                err = CCRateLimitError(
+                    output.text or "CC rate limited (stream event)",
+                    raw_event=rate_limit_raw,
+                )
                 await self._notify_status_change(err)
                 raise err
 

--- a/src/genesis/cc/rate_limit_park.py
+++ b/src/genesis/cc/rate_limit_park.py
@@ -1,0 +1,274 @@
+"""Rate-limit park orchestration — the thin layer the CC call sites delegate to.
+
+Keeps `conversation.py` / `direct_session.py` (both already over the file-size
+cap) free of park logic. Responsibilities:
+
+- ``park_conversation`` — a foreground turn exhausted failover+contingency: park
+  the user's prompt, write the display resume time, return mode-aware copy.
+- ``park_direct_session`` — a background session hit the limit: park the full
+  request (fresh), OR — if this session was itself a resume (caller_context
+  carries a park id) — re-limit the SAME park in place (attempts+1, backoff),
+  preserving the lineage the escalation counter depends on.
+- ``mark_resumed_if_lineage`` — a resumed session delivered successfully: close
+  its park.
+
+All writes are best-effort and mode-gated (``off`` → no park, current behavior).
+``now`` is injectable for deterministic tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from genesis.cc import rate_limit_resume_config as cfg_mod
+from genesis.cc.rate_limit_reset import parse_reset
+from genesis.db.crud import cc_rate_limit_parks as parks
+from genesis.db.crud import cc_sessions
+
+logger = logging.getLogger("genesis.cc.rate_limit_park")
+
+_RESUME_PREFIX = "rate_limit_resume:"
+
+
+@dataclass
+class ParkOutcome:
+    """Result of a foreground park — what the handler returns to the user."""
+
+    parked: bool
+    park_id: str | None
+    reset_at: datetime | None
+    mode: str
+    copy: str
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+def dedup_key(kind: str, origin_session_id: str | None, prompt: str) -> str:
+    """Stable per-logical-work key: same (kind, origin, prompt) → same open park."""
+    raw = f"{kind}\x00{origin_session_id or ''}\x00{prompt}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def parse_park_id(caller_context: str | None) -> str | None:
+    """Extract a park id from a ``rate_limit_resume:<id>`` caller_context."""
+    if caller_context and caller_context.startswith(_RESUME_PREFIX):
+        return caller_context[len(_RESUME_PREFIX) :] or None
+    return None
+
+
+def _enum_str(value: object, default: str) -> str:
+    """Normalise a CCModel/EffortLevel enum-or-string to its wire string."""
+    if value is None:
+        return default
+    return str(getattr(value, "value", value))
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def next_attempt_at(reset_at: datetime | None, now: datetime, cfg: dict) -> str:
+    """First re-attempt time: the reset (if known) else a cadence floor, both
+    with jitter. Jitter is deterministic (derived from now) so tests are stable."""
+    jitter = timedelta(seconds=cfg_mod.knob_int(cfg, "jitter_seconds") * (now.second % 2 + 1) / 2)
+    if reset_at is not None:
+        base = reset_at if reset_at > now else now
+    else:
+        base = now + timedelta(minutes=cfg_mod.knob_int(cfg, "cadence_floor_minutes"))
+    return _iso(base + jitter)
+
+
+def backoff_next_attempt(attempts: int, now: datetime, cfg: dict) -> str:
+    """Exponential backoff for a re-limited retry: base·2^attempts capped."""
+    base = cfg_mod.knob_int(cfg, "backoff_base_minutes")
+    cap = cfg_mod.knob_int(cfg, "backoff_cap_minutes")
+    minutes = min(base * (2 ** max(0, attempts)), cap)
+    return _iso(now + timedelta(minutes=minutes))
+
+
+def _fmt_reset(reset_at: datetime | None) -> str:
+    if reset_at is None:
+        return ""
+    try:
+        return f" around {reset_at.strftime('%-I:%M %p %Z').strip()}"
+    except ValueError:
+        return ""
+
+
+def resume_copy(mode: str, reset_at: datetime | None) -> str:
+    """Mode-aware foreground message. Replaces the old sentence that promised
+    automatic resume unconditionally (nothing backed it)."""
+    if mode == "live":
+        return (
+            "[Rate limit reached — your request is parked and will auto-resume "
+            f"and deliver here{_fmt_reset(reset_at)}.]"
+        )
+    if mode == "propose_only":
+        return (
+            "[Rate limit reached — your request is parked. Reply 'resume' when "
+            "capacity returns and I'll pick it back up.]"
+        )
+    # off
+    return (
+        "[Rate limit reached — Genesis is temporarily running in reduced mode. "
+        "Please try again later.]"
+    )
+
+
+# ── foreground ───────────────────────────────────────────────────────────
+async def park_conversation(
+    db: aiosqlite.Connection,
+    *,
+    prompt: str,
+    origin_session_id: str,
+    exc: Exception,
+    model: object = None,
+    effort: object = None,
+    timeout_s: int = 3600,
+    now: datetime | None = None,
+    mode: str | None = None,
+) -> ParkOutcome:
+    """Park an exhausted foreground turn and return the user-facing copy."""
+    now = now or datetime.now(UTC)
+    mode = mode if mode is not None else cfg_mod.effective_mode()
+    cfg = cfg_mod.load_config()
+
+    raw_event = getattr(exc, "raw_event", None)
+    raw_text = getattr(exc, "raw_text", None)
+    limit_kind, reset_at = parse_reset(raw_event=raw_event, raw_text=raw_text, now=now)
+
+    if mode == "off":
+        return ParkOutcome(False, None, reset_at, mode, resume_copy(mode, reset_at))
+
+    payload = {
+        "prompt": prompt,
+        "profile": cfg_mod.resume_profile(cfg),
+        "model": _enum_str(model, "sonnet"),
+        "effort": _enum_str(effort, "high"),
+        "timeout_s": int(timeout_s),
+        "roster_model": None,
+    }
+    park_id: str | None = None
+    try:
+        park_id = await parks.upsert_open_park(
+            db,
+            kind="conversation",
+            dedup_key=dedup_key("conversation", origin_session_id, prompt),
+            payload=payload,
+            origin_session_id=origin_session_id,
+            limit_kind=limit_kind,
+            raw_signal=(raw_text or (json.dumps(raw_event) if raw_event else None)),
+            reset_at=_iso(reset_at) if reset_at else None,
+            next_attempt_at=next_attempt_at(reset_at, now, cfg),
+        )
+        # Single source of truth: the display resumes_at mirrors the park's reset.
+        await cc_sessions.update_rate_limit(
+            db,
+            origin_session_id,
+            rate_limited_at=_iso(now),
+            rate_limit_resumes_at=_iso(reset_at) if reset_at else None,
+        )
+    except Exception:
+        logger.error("Failed to park conversation turn %s", origin_session_id[:8], exc_info=True)
+        return ParkOutcome(False, None, reset_at, mode, resume_copy(mode, reset_at))
+
+    return ParkOutcome(True, park_id, reset_at, mode, resume_copy(mode, reset_at))
+
+
+# ── background ───────────────────────────────────────────────────────────
+async def park_direct_session(
+    db: aiosqlite.Connection,
+    *,
+    request: object,
+    exc: Exception,
+    now: datetime | None = None,
+    mode: str | None = None,
+) -> str | None:
+    """Park (or re-limit) a background session that hit a rate limit.
+
+    Returns the park id if the work was parked/re-parked, or None when parking
+    is disabled (mode=off) or failed — the caller then keeps current behavior.
+    """
+    now = now or datetime.now(UTC)
+    mode = mode if mode is not None else cfg_mod.effective_mode()
+    if mode == "off":
+        return None
+    cfg = cfg_mod.load_config()
+
+    raw_event = getattr(exc, "raw_event", None)
+    raw_text = getattr(exc, "raw_text", None)
+    limit_kind, reset_at = parse_reset(raw_event=raw_event, raw_text=raw_text, now=now)
+
+    caller_context = getattr(request, "caller_context", None)
+    lineage_id = parse_park_id(caller_context)
+
+    try:
+        # A resumed session re-limited → update its own park in place so the
+        # attempts counter (and the needs_user escalation) survives (architect #1).
+        if lineage_id is not None:
+            park = await parks.get_by_id(db, lineage_id)
+            attempts = (park["attempts"] if park else 0) + 1
+            reset_iso = _iso(reset_at) if reset_at else None
+            na = (
+                _iso(reset_at)
+                if (reset_at and reset_at > now)
+                else backoff_next_attempt(attempts, now, cfg)
+            )
+            status = await parks.relimit(
+                db,
+                lineage_id,
+                reset_at=reset_iso,
+                next_attempt_at=na,
+                needs_user_at_attempts=cfg_mod.knob_int(cfg, "needs_user_attempts"),
+            )
+            if status:
+                return lineage_id
+            # Lineage row gone/terminal (pruned, or a race with
+            # recover_stale_resuming) — fall through to a FRESH park so the work
+            # is never dropped, rather than returning None → generic failure.
+            logger.warning(
+                "Resume park %s not resolvable (relimit no-op) — re-parking fresh",
+                lineage_id,
+            )
+
+        # Fresh background park — serialize enough to re-dispatch verbatim.
+        prompt = getattr(request, "prompt", "")
+        origin = getattr(request, "origin_session_id", None)
+        payload = {
+            "prompt": prompt,
+            "profile": getattr(request, "profile", "observe"),
+            "model": _enum_str(getattr(request, "model", None), "sonnet"),
+            "effort": _enum_str(getattr(request, "effort", None), "high"),
+            "timeout_s": int(getattr(request, "timeout_s", 3600)),
+            "roster_model": getattr(request, "roster_model", None),
+        }
+        return await parks.upsert_open_park(
+            db,
+            kind="direct_session",
+            dedup_key=dedup_key("direct_session", origin, prompt),
+            payload=payload,
+            origin_session_id=origin,
+            limit_kind=limit_kind,
+            raw_signal=(raw_text or (json.dumps(raw_event) if raw_event else None)),
+            reset_at=_iso(reset_at) if reset_at else None,
+            next_attempt_at=next_attempt_at(reset_at, now, cfg),
+        )
+    except Exception:
+        logger.error("Failed to park direct session", exc_info=True)
+        return None
+
+
+async def mark_resumed_if_lineage(db: aiosqlite.Connection, caller_context: str | None) -> None:
+    """Close the park of a resumed session that just delivered successfully."""
+    park_id = parse_park_id(caller_context)
+    if park_id is None:
+        return
+    try:
+        await parks.mark_resumed(db, park_id)
+    except Exception:
+        logger.error("Failed to mark park %s resumed", park_id, exc_info=True)

--- a/src/genesis/cc/rate_limit_reset.py
+++ b/src/genesis/cc/rate_limit_reset.py
@@ -1,0 +1,213 @@
+"""Best-effort parse of a CC rate-limit signal into a resume schedule.
+
+Pure + injected clock. Cascades: structured ``raw_event`` → prose ``raw_text``
+→ ``None``. The reset time is a *floor* for the resume scheduler, never a
+promise — resume is self-validating (a still-limited re-run re-parks), so an
+imprecise or missing reset only changes WHEN the first re-attempt fires, not
+whether the parked work survives.
+
+CRITICAL UNKNOWN — verify against the first real captured event: the exact
+field layout of a CC ``rate_limit_event`` payload is not documented, and the
+prose form ("resets Xpm") is only known from a code comment. This parser
+therefore searches defensively for common reset-time keys and falls back to
+prose; on any miss it returns ``None`` and the scheduler uses its cadence
+floor. A weekly limit with only a wall-clock time is day-ambiguous → ``None``
+(never guess "next 5pm").
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+
+# limit_kind vocabulary — kept tiny; only used to size backoff and to decide
+# whether a bare wall-clock prose time is day-ambiguous.
+SESSION = "session"
+WEEKLY = "weekly"
+UNKNOWN = "unknown"
+
+# A parsed absolute reset further than this from ``now`` is treated as
+# implausible (bad parse) and dropped to None — the cadence floor is safer than
+# a wild timestamp.
+_MAX_HORIZON = timedelta(days=14)
+
+# Candidate keys (normalised: lowercased, non-alphanumerics stripped) that may
+# carry a reset time in a structured payload. Duration-style keys (retry-after,
+# *_in, *_seconds) are interpreted relative to ``now``; the rest as absolute.
+_ABSOLUTE_KEYS = frozenset(
+    {"resetsat", "resetat", "reset", "resettime", "resettimestamp", "windowresetsat"}
+)
+_DURATION_KEYS = frozenset(
+    {"retryafter", "retryafterseconds", "resetin", "resetinseconds", "secondsuntilreset"}
+)
+
+
+def _norm_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", key.lower())
+
+
+def _blob(raw_event: dict | None, raw_text: str | None) -> str:
+    """Lowercased text blob for keyword detection (event stringified + prose)."""
+    parts: list[str] = []
+    if raw_event is not None:
+        parts.append(str(raw_event))
+    if raw_text:
+        parts.append(raw_text)
+    return " ".join(parts).lower()
+
+
+def detect_limit_kind(raw_event: dict | None, raw_text: str | None) -> str:
+    """Best-effort {session|weekly|unknown} from the signal's text."""
+    blob = _blob(raw_event, raw_text)
+    if not blob:
+        return UNKNOWN
+    if "week" in blob:
+        return WEEKLY
+    if "session" in blob or "5-hour" in blob or "5 hour" in blob or "five hour" in blob:
+        return SESSION
+    return UNKNOWN
+
+
+def _coerce_number(value: float, now: datetime, *, is_duration: bool) -> datetime | None:
+    """Turn a numeric reset value into an absolute UTC datetime, or None."""
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if v <= 0:
+        return None
+    if is_duration:
+        return now + timedelta(seconds=v)
+    # Absolute epoch: seconds (~1e9–1e11) or milliseconds (>=1e12).
+    if v >= 1e12:
+        v /= 1000.0
+    if v >= 1e9:
+        try:
+            return datetime.fromtimestamp(v, tz=now.tzinfo)
+        except (OSError, OverflowError, ValueError):
+            return None
+    # Small bare number with an absolute key is ambiguous — treat as seconds
+    # from now (retry-after leakage) rather than an epoch near 1970.
+    return now + timedelta(seconds=v)
+
+
+def _parse_iso(text: str, now: datetime) -> datetime | None:
+    s = text.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=now.tzinfo)
+    return dt
+
+
+def _reset_from_event(
+    raw_event: dict | None, now: datetime, limit_kind: str = UNKNOWN
+) -> datetime | None:
+    """Recursively hunt for a reset-time key in a structured payload.
+
+    ``limit_kind`` is threaded so a wall-clock string value under an absolute
+    key honors the same weekly day-ambiguity guard as the prose path (a weekly
+    "5pm" is unknowable → None, never a guessed concrete time)."""
+    if not isinstance(raw_event, dict):
+        return None
+    for key, value in raw_event.items():
+        nk = _norm_key(str(key))
+        if nk in _DURATION_KEYS and isinstance(value, (int, float)) and not isinstance(value, bool):
+            dt = _coerce_number(value, now, is_duration=True)
+            if dt is not None:
+                return dt
+        if nk in _ABSOLUTE_KEYS:
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, (int, float)):
+                dt = _coerce_number(value, now, is_duration=False)
+                if dt is not None:
+                    return dt
+            if isinstance(value, str):
+                dt = _parse_iso(value, now) or _reset_from_prose(value, now, limit_kind)
+                if dt is not None:
+                    return dt
+    # Recurse into nested dicts/lists (payload shape unknown).
+    for value in raw_event.values():
+        if isinstance(value, dict):
+            dt = _reset_from_event(value, now, limit_kind)
+            if dt is not None:
+                return dt
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    dt = _reset_from_event(item, now, limit_kind)
+                    if dt is not None:
+                        return dt
+    return None
+
+
+_DURATION_RE = re.compile(
+    r"reset[a-z ]*?in[:\s]*"
+    r"(?:(?P<h>\d+)\s*(?:h|hour|hours|hr))?\s*"
+    r"(?:(?P<m>\d+)\s*(?:m|min|minute|minutes))?",
+    re.IGNORECASE,
+)
+_CLOCK_RE = re.compile(
+    r"reset[a-z ]*?(?:at\s*)?(?P<h>\d{1,2})(?::(?P<min>\d{2}))?\s*(?P<ap>am|pm)",
+    re.IGNORECASE,
+)
+
+
+def _reset_from_prose(text: str, now: datetime, limit_kind: str) -> datetime | None:
+    """Parse a reset time from CC's prose. Relative durations are unambiguous;
+    a bare wall-clock time is day-ambiguous for a WEEKLY limit → None."""
+    if not text:
+        return None
+    low = text.lower()
+
+    # Relative duration: "resets in 2h 30m" / "Resets in: 45 minutes".
+    m = _DURATION_RE.search(low)
+    if m and (m.group("h") or m.group("m")):
+        hours = int(m.group("h") or 0)
+        mins = int(m.group("m") or 0)
+        if hours or mins:
+            return now + timedelta(hours=hours, minutes=mins)
+
+    # Wall-clock: "resets 5pm" / "resets at 11:30 am".
+    c = _CLOCK_RE.search(low)
+    if c:
+        if limit_kind == WEEKLY:
+            # Which day? Unknowable from a bare clock time — don't guess.
+            return None
+        hour = int(c.group("h")) % 12
+        if c.group("ap").lower() == "pm":
+            hour += 12
+        minute = int(c.group("min") or 0)
+        candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate <= now:
+            candidate += timedelta(days=1)
+        return candidate
+    return None
+
+
+def parse_reset(
+    *,
+    raw_event: dict | None = None,
+    raw_text: str | None = None,
+    now: datetime,
+) -> tuple[str, datetime | None]:
+    """Return ``(limit_kind, reset_at)``.
+
+    ``limit_kind`` ∈ {session, weekly, unknown}. ``reset_at`` is a tz-aware
+    datetime (in ``now``'s tz) or ``None`` when unknown/ambiguous. Never raises
+    — a totally unparseable signal yields ``(unknown, None)`` and the scheduler
+    falls back to its cadence floor.
+    """
+    limit_kind = detect_limit_kind(raw_event, raw_text)
+    reset_at = _reset_from_event(raw_event, now, limit_kind)
+    if reset_at is None and raw_text:
+        reset_at = _reset_from_prose(raw_text, now, limit_kind)
+    # Sanity clamp: an absurdly-distant parse is an artifact — drop it so the
+    # scheduler uses its cadence floor. A past/near reset is fine (the scheduler
+    # treats <= now as "due now").
+    if reset_at is not None and (reset_at - now) > _MAX_HORIZON:
+        reset_at = None
+    return limit_kind, reset_at

--- a/src/genesis/cc/rate_limit_resume_config.py
+++ b/src/genesis/cc/rate_limit_resume_config.py
@@ -1,0 +1,142 @@
+"""Config lever for rate-limit park + auto-resume.
+
+Cloned from ``memory.entity_adjudication_config``: fresh-read-per-call, MODES
+tuple + env kill switch, degrade-toward-less-authority on damage.
+
+Failure posture: a missing/corrupt config degrades to DEFAULTS; an invalid
+``mode`` degrades to ``propose_only`` (never a silent ``live``). The env kill
+switch ``GENESIS_RATE_LIMIT_RESUME_DISABLED=1`` forces ``off`` regardless of the
+file — an operator's emergency brake against unattended re-dispatch.
+
+Default mode is ``off`` (DORMANT) until the resume engine lands (PR-2b): with no
+resumer wired, a parked request would sit ``status='parked'`` forever while the
+foreground copy promised auto-resume — recreating the very silent-death this
+fixes. Shipping the park substrate off-by-default (like the reaper's dry-run /
+entity-adjudication's shadow) keeps PR-2a inert-but-observable; PR-2b flips the
+default to ``live``. Once ``live``: a resume only completes work whose initiation
+was already user-approved (a foreground turn's typed prompt) or already
+gate-approved (a direct_session's original dispatch), so it is not new autonomous
+initiative — see ``rate_limit_resume`` module docstring.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``MODES`` and ``INT_KNOBS``
+from here (never the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "propose_only", "live")
+
+_CONFIG_NAME = "cc_rate_limit_resume.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_RATE_LIMIT_RESUME_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # DORMANT until PR-2b wires the resume engine — see module docstring. PR-2b
+    # flips this to "live". off → parks nothing, honest "try again later" copy.
+    "mode": "off",
+    # Scheduling
+    "cadence_floor_minutes": 30,  # retry cadence when the reset time is unknown
+    "backoff_base_minutes": 30,  # re-limit backoff base
+    "backoff_cap_minutes": 240,  # re-limit backoff ceiling (4h)
+    "jitter_seconds": 60,  # spread on next_attempt to avoid thundering herd
+    "max_due_per_tick": 50,  # parks resumed per engine tick
+    # Give-up threshold — escalate to needs_user once attempts reaches this.
+    "needs_user_attempts": 40,
+    # Capability pinning: a resumed conversation-origin turn runs under this
+    # bounded background profile (⊆ the foreground surface). Direct-session
+    # parks re-run under their own original profile.
+    "conversation_resume_profile": "research",
+}
+
+# Public: the settings-domain validator imports these to check knobs.
+INT_KNOBS = (
+    "cadence_floor_minutes",
+    "backoff_base_minutes",
+    "backoff_cap_minutes",
+    "jitter_seconds",
+    "max_due_per_tick",
+    "needs_user_attempts",
+)
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("cc_rate_limit_resume base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("cc_rate_limit_resume overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode auto-resume runs under — read live.
+
+    Env kill switch → ``off``. Master ``enabled: false`` → ``off``. An invalid
+    value degrades to ``propose_only`` (observable, no dispatch authority — never
+    a silent ``off`` that hides the feature, never a silent ``live``).
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("cc_rate_limit_resume has invalid mode %r — degrading to propose_only", mode)
+        return "propose_only"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
+    limit or crashes the engine."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def resume_profile(cfg: dict[str, Any]) -> str:
+    """Bounded background profile for a resumed conversation-origin turn."""
+    value = cfg.get("conversation_resume_profile")
+    if isinstance(value, str) and value.strip():
+        return value
+    return str(DEFAULTS["conversation_resume_profile"])

--- a/src/genesis/db/crud/cc_rate_limit_parks.py
+++ b/src/genesis/db/crud/cc_rate_limit_parks.py
@@ -1,0 +1,233 @@
+"""CRUD for cc_rate_limit_parks — durable rate-limit park + resume lineage.
+
+A park row is the durable lineage object for one logical unit of work that hit a
+CC rate limit. It survives restarts (DB-backed) and is resolved by ``id`` across
+an async re-dispatch cycle: the resume engine claims ``parked→resuming`` and
+re-runs the work; the retry's outcome resolves THIS row — ``resumed`` on success,
+or ``relimit`` (attempts+1, fresh reset, backoff) on a re-limit. Marking a park
+terminal at dispatch would sever that lineage (attempts never accumulate, the
+``needs_user`` escalation becomes unreachable) — so the row stays ``resuming``
+between dispatch and outcome, reclaimed by ``recover_stale_resuming`` if the
+process dies mid-flight.
+
+Mirrors ``direct_session_queue`` (single-statement claim via UPDATE…RETURNING).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+# Open states hold the partial-unique dedup index — one open park per dedup_key.
+_OPEN = ("parked", "resuming")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def upsert_open_park(
+    db: aiosqlite.Connection,
+    *,
+    kind: str,
+    dedup_key: str,
+    payload: dict,
+    origin_session_id: str | None,
+    limit_kind: str,
+    raw_signal: str | None,
+    reset_at: str | None,
+    next_attempt_at: str,
+) -> str:
+    """Insert a fresh park, or bump the existing OPEN park with the same
+    dedup_key (idempotent concurrent parks). Returns the park id.
+
+    Used for FRESH parks (foreground turn, first background rate-limit) that
+    carry no lineage. A re-limit of an already-resumed job is resolved by id via
+    ``relimit`` instead — never through this path.
+    """
+    park_id = f"rlp-{uuid.uuid4().hex[:12]}"
+    now = _now()
+    cursor = await db.execute(
+        """INSERT INTO cc_rate_limit_parks
+               (id, kind, dedup_key, payload_json, origin_session_id, limit_kind,
+                raw_signal, reset_at, status, attempts, next_attempt_at,
+                created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'parked', 0, ?, ?, ?)
+           ON CONFLICT(dedup_key) WHERE status IN ('parked', 'resuming')
+           DO UPDATE SET
+               attempts        = attempts + 1,
+               reset_at        = excluded.reset_at,
+               next_attempt_at = excluded.next_attempt_at,
+               raw_signal      = excluded.raw_signal,
+               limit_kind      = excluded.limit_kind,
+               updated_at      = excluded.updated_at
+           RETURNING id""",
+        (
+            park_id,
+            kind,
+            dedup_key,
+            json.dumps(payload),
+            origin_session_id,
+            limit_kind,
+            raw_signal,
+            reset_at,
+            next_attempt_at,
+            now,
+            now,
+        ),
+    )
+    row = await cursor.fetchone()
+    await db.commit()
+    return row[0] if row else park_id
+
+
+async def list_due(
+    db: aiosqlite.Connection,
+    *,
+    now: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Open parks whose next_attempt_at is due (<= now). Oldest first."""
+    now = now or _now()
+    cursor = await db.execute(
+        """SELECT * FROM cc_rate_limit_parks
+           WHERE status = 'parked'
+             AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+           ORDER BY created_at
+           LIMIT ?""",
+        (now, limit),
+    )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def claim(db: aiosqlite.Connection, park_id: str) -> bool:
+    """Atomically claim a due park (parked→resuming). True iff this caller won."""
+    now = _now()
+    cursor = await db.execute(
+        """UPDATE cc_rate_limit_parks
+           SET status = 'resuming', claimed_at = ?, updated_at = ?
+           WHERE id = ? AND status = 'parked'""",
+        (now, now, park_id),
+    )
+    await db.commit()
+    return cursor.rowcount == 1
+
+
+async def mark_resumed(db: aiosqlite.Connection, park_id: str) -> bool:
+    """Terminal success: resuming→resumed. Called from the retry's completion
+    hook AFTER the result is delivered. True iff the row was resuming."""
+    now = _now()
+    cursor = await db.execute(
+        """UPDATE cc_rate_limit_parks
+           SET status = 'resumed', claimed_at = NULL, updated_at = ?
+           WHERE id = ? AND status = 'resuming'""",
+        (now, park_id),
+    )
+    await db.commit()
+    return cursor.rowcount == 1
+
+
+async def relimit(
+    db: aiosqlite.Connection,
+    park_id: str,
+    *,
+    reset_at: str | None,
+    next_attempt_at: str,
+    needs_user_at_attempts: int,
+) -> str:
+    """A resumed retry hit the limit again — update THIS row in place (attempts+1,
+    fresh reset, backoff). Escalates to ``needs_user`` once attempts reaches the
+    threshold. Returns the resulting status ('parked' | 'needs_user' | '' if the
+    row was not resolvable). Increments regardless of the prior status so a
+    re-limit is never lost, but only re-opens (→parked) from an in-flight row.
+    """
+    now = _now()
+    cursor = await db.execute(
+        """UPDATE cc_rate_limit_parks
+           SET attempts        = attempts + 1,
+               reset_at        = ?,
+               next_attempt_at = ?,
+               claimed_at      = NULL,
+               status          = CASE
+                   WHEN attempts + 1 >= ? THEN 'needs_user'
+                   ELSE 'parked'
+               END,
+               updated_at      = ?
+           WHERE id = ? AND status IN ('resuming', 'parked')
+           RETURNING status""",
+        (reset_at, next_attempt_at, needs_user_at_attempts, now, park_id),
+    )
+    row = await cursor.fetchone()
+    await db.commit()
+    return row[0] if row else ""
+
+
+async def recover_stale_resuming(
+    db: aiosqlite.Connection,
+    *,
+    max_age_s: int = 7200,
+) -> int:
+    """Reclaim parks stuck in 'resuming' longer than max_age_s (retry lost to a
+    crash/restart between claim and outcome) back to 'parked' for another try.
+
+    max_age_s defaults to 2h — comfortably longer than a direct_session timeout
+    (1h) so an in-flight resume is never yanked out from under a live retry.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(seconds=max_age_s)).isoformat()
+    now = _now()
+    cursor = await db.execute(
+        """UPDATE cc_rate_limit_parks
+           SET status = 'parked', claimed_at = NULL, updated_at = ?
+           WHERE status = 'resuming'
+             AND (claimed_at IS NULL OR claimed_at < ?)""",
+        (now, cutoff),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def mark_terminal(db: aiosqlite.Connection, park_id: str, status: str) -> None:
+    """Force a terminal status (cancelled/expired) — e.g. a cancel-path absorb."""
+    now = _now()
+    await db.execute(
+        """UPDATE cc_rate_limit_parks
+           SET status = ?, claimed_at = NULL, updated_at = ?
+           WHERE id = ?""",
+        (status, now, park_id),
+    )
+    await db.commit()
+
+
+async def get_by_id(db: aiosqlite.Connection, park_id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM cc_rate_limit_parks WHERE id = ?",
+        (park_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def count_open(db: aiosqlite.Connection) -> int:
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM cc_rate_limit_parks WHERE status IN ('parked', 'resuming')",
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def prune_terminal(db: aiosqlite.Connection, *, older_than_days: int = 45) -> int:
+    """Delete finished parks (resumed/cancelled/expired) past the retention
+    window. ``needs_user`` is NEVER pruned — it awaits the user."""
+    cutoff = (datetime.now(UTC) - timedelta(days=older_than_days)).isoformat()
+    cursor = await db.execute(
+        """DELETE FROM cc_rate_limit_parks
+           WHERE status IN ('resumed', 'cancelled', 'expired')
+             AND updated_at < ?""",
+        (cutoff,),
+    )
+    await db.commit()
+    return cursor.rowcount

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1322,6 +1322,28 @@ TABLES = {
             dispatched_at   TEXT
         )
     """,
+    "cc_rate_limit_parks": """
+        CREATE TABLE IF NOT EXISTS cc_rate_limit_parks (
+            id                TEXT PRIMARY KEY,
+            kind              TEXT NOT NULL
+                              CHECK (kind IN ('conversation', 'direct_session')),
+            dedup_key         TEXT NOT NULL,
+            payload_json      TEXT NOT NULL,
+            origin_session_id TEXT,
+            limit_kind        TEXT NOT NULL DEFAULT 'unknown'
+                              CHECK (limit_kind IN ('session', 'weekly', 'unknown')),
+            raw_signal        TEXT,
+            reset_at          TEXT,
+            status            TEXT NOT NULL DEFAULT 'parked'
+                              CHECK (status IN ('parked', 'resuming', 'resumed',
+                                                'needs_user', 'cancelled', 'expired')),
+            attempts          INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at   TEXT,
+            claimed_at        TEXT,
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL
+        )
+    """,
     "eval_events": """
         CREATE TABLE IF NOT EXISTS eval_events (
             id           TEXT PRIMARY KEY,
@@ -2340,6 +2362,10 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_status ON cognitive_file_modifications(status)",
     # direct session queue
     "CREATE INDEX IF NOT EXISTS idx_dsq_status_created ON direct_session_queue(status, created_at)",
+    # cc rate-limit parks (durable park + reset-time resume) — partial-unique on
+    # OPEN parks makes concurrent same-work parks idempotent (upsert target).
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_rlp_open_dedup ON cc_rate_limit_parks(dedup_key) WHERE status IN ('parked', 'resuming')",
+    "CREATE INDEX IF NOT EXISTS idx_rlp_status_next ON cc_rate_limit_parks(status, next_attempt_at)",
     # J-9 eval infrastructure
     "CREATE INDEX IF NOT EXISTS idx_eval_events_dimension ON eval_events(dimension, timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_eval_events_type ON eval_events(event_type, timestamp)",

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -177,6 +177,19 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every drain run
     ),
+    "cc_rate_limit_resume": SettingsDomain(
+        name="cc_rate_limit_resume",
+        description=(
+            "Rate-limit park + auto-resume — master `enabled` + `mode` "
+            "off/propose_only/live, plus cadence/backoff/escalation knobs. "
+            "live (default) auto-resumes parked work at its reset time and "
+            "delivers to origin; propose_only pings to resume; off records only. "
+            "Read live each engine tick — takes effect next tick, no restart."
+        ),
+        config_filename="cc_rate_limit_resume.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every resume tick
+    ),
     "resilience": SettingsDomain(
         name="resilience",
         description="Resilience thresholds (flapping detection, recovery, CC rate limits)",
@@ -1045,8 +1058,33 @@ def _validate_entity_adjudication(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_cc_rate_limit_resume(changes: dict) -> list[str]:
+    """Validate rate-limit resume lever changes (see
+    genesis.cc.rate_limit_resume_config)."""
+    from genesis.cc.rate_limit_resume_config import INT_KNOBS, MODES
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "mode", "conversation_resume_profile", *INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key == "mode":
+            if value not in MODES:
+                errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif key == "conversation_resume_profile":
+            if not isinstance(value, str) or not value.strip():
+                errors.append("'conversation_resume_profile' must be a non-empty string")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "entity_adjudication": _validate_entity_adjudication,
+    "cc_rate_limit_resume": _validate_cc_rate_limit_resume,
     "tts": _validate_tts,
     "ws3_immunity": _validate_ws3_immunity,
     "memory_recall": _validate_memory_recall,

--- a/tests/test_cc/test_rate_limit_park.py
+++ b/tests/test_cc/test_rate_limit_park.py
@@ -1,0 +1,248 @@
+"""Tests for rate_limit_park — park orchestration the CC call sites delegate to.
+
+Covers dedup-key stability, caller_context lineage parsing, mode-gated foreground
+parking + copy, fresh background parking, the re-limit-in-place lineage (the
+architect-#1 fix), resumed-close, and backoff math. Uses the real in-memory db.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.cc import rate_limit_park as rlp
+from genesis.cc.direct_session import DirectSessionRequest, DirectSessionRunner
+from genesis.cc.exceptions import CCQuotaExhaustedError, CCRateLimitError
+from genesis.cc.rate_limit_resume_config import load_config
+from genesis.cc.types import DeliveryMode
+from genesis.db.crud import cc_rate_limit_parks as parks
+
+NOW = datetime(2026, 7, 22, 14, 0, 0, tzinfo=UTC)
+
+
+def test_dedup_key_stable_and_scoped():
+    a = rlp.dedup_key("conversation", "s1", "hello")
+    assert a == rlp.dedup_key("conversation", "s1", "hello")
+    assert a != rlp.dedup_key("conversation", "s2", "hello")  # origin-scoped
+    assert a != rlp.dedup_key("direct_session", "s1", "hello")  # kind-scoped
+    assert a != rlp.dedup_key("conversation", "s1", "world")  # prompt-scoped
+
+
+def test_parse_park_id():
+    assert rlp.parse_park_id("rate_limit_resume:rlp-abc") == "rlp-abc"
+    assert rlp.parse_park_id("ego_proposal:x") is None
+    assert rlp.parse_park_id(None) is None
+    assert rlp.parse_park_id("rate_limit_resume:") is None
+
+
+def test_backoff_is_exponential_and_capped():
+    cfg = load_config()
+    a0 = rlp.backoff_next_attempt(0, NOW, cfg)
+    a1 = rlp.backoff_next_attempt(1, NOW, cfg)
+    a_big = rlp.backoff_next_attempt(20, NOW, cfg)
+    assert a0 == (NOW + timedelta(minutes=30)).isoformat()
+    assert a1 == (NOW + timedelta(minutes=60)).isoformat()
+    assert a_big == (NOW + timedelta(minutes=240)).isoformat()  # capped at 4h
+
+
+async def test_park_conversation_off_mode_does_not_park(db):
+    exc = CCRateLimitError("limit", raw_text="resets 5pm")
+    outcome = await rlp.park_conversation(
+        db,
+        prompt="hi",
+        origin_session_id="s1",
+        exc=exc,
+        now=NOW,
+        mode="off",
+    )
+    assert outcome.parked is False
+    assert "try again later" in outcome.copy
+    assert await parks.count_open(db) == 0
+
+
+async def test_park_conversation_live_parks_with_reset(db):
+    exc = CCRateLimitError("limit", raw_text="Session limit — resets 5pm")
+    outcome = await rlp.park_conversation(
+        db,
+        prompt="deep research please",
+        origin_session_id="s1",
+        exc=exc,
+        now=NOW,
+        mode="live",
+    )
+    assert outcome.parked is True
+    assert outcome.park_id is not None
+    assert "auto-resume" in outcome.copy
+    row = await parks.get_by_id(db, outcome.park_id)
+    assert row["kind"] == "conversation"
+    assert row["origin_session_id"] == "s1"
+    assert row["limit_kind"] == "session"
+    assert row["reset_at"] == NOW.replace(hour=17, minute=0).isoformat()
+    # payload carries a bounded resume profile + the prompt
+    import json
+
+    payload = json.loads(row["payload_json"])
+    assert payload["prompt"] == "deep research please"
+    assert payload["profile"] == "research"
+
+
+async def test_park_conversation_quota_error_also_parks(db):
+    exc = CCQuotaExhaustedError("usage limit", raw_text="resets in 1h")
+    outcome = await rlp.park_conversation(
+        db,
+        prompt="x",
+        origin_session_id="s2",
+        exc=exc,
+        now=NOW,
+        mode="live",
+    )
+    assert outcome.parked is True
+
+
+def _bg_request(caller_context=None, prompt="bg work"):
+    return SimpleNamespace(
+        prompt=prompt,
+        profile="research",
+        model="sonnet",
+        effort="high",
+        timeout_s=3600,
+        roster_model=None,
+        origin_session_id="orig1",
+        caller_context=caller_context,
+    )
+
+
+async def test_park_direct_session_fresh(db):
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=_bg_request(), exc=exc, now=NOW, mode="live")
+    assert pid is not None
+    row = await parks.get_by_id(db, pid)
+    assert row["kind"] == "direct_session"
+    assert row["attempts"] == 0
+
+
+async def test_park_direct_session_off_returns_none(db):
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=_bg_request(), exc=exc, now=NOW, mode="off")
+    assert pid is None
+    assert await parks.count_open(db) == 0
+
+
+async def test_relimit_updates_same_park_not_a_new_one(db):
+    """A resumed session that re-limits must update its OWN park (attempts+1),
+    not mint a fresh one — the architect-#1 lineage fix."""
+    # Seed a park + claim it (as the resume engine would).
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=_bg_request(), exc=exc, now=NOW, mode="live")
+    await parks.claim(db, pid)
+    assert await parks.count_open(db) == 1
+    # The resumed retry re-limits: caller_context carries the park id.
+    resumed_req = _bg_request(caller_context=f"rate_limit_resume:{pid}")
+    exc2 = CCRateLimitError("limit", raw_text="resets in 1h")
+    returned = await rlp.park_direct_session(
+        db,
+        request=resumed_req,
+        exc=exc2,
+        now=NOW,
+        mode="live",
+    )
+    assert returned == pid  # same park, not a new one
+    assert await parks.count_open(db) == 1  # NOT 2
+    row = await parks.get_by_id(db, pid)
+    assert row["attempts"] == 1
+    assert row["status"] == "parked"  # re-opened for another attempt
+
+
+async def test_relimit_escalates_to_needs_user(db):
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=_bg_request(), exc=exc, now=NOW, mode="live")
+    # Force attempts near threshold by direct writes, then re-limit once.
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET attempts = 39, status = 'resuming' WHERE id = ?",
+        (pid,),
+    )
+    await db.commit()
+    resumed = _bg_request(caller_context=f"rate_limit_resume:{pid}")
+    await rlp.park_direct_session(db, request=resumed, exc=exc, now=NOW, mode="live")
+    row = await parks.get_by_id(db, pid)
+    assert row["attempts"] == 40
+    assert row["status"] == "needs_user"
+
+
+async def test_relimit_missing_lineage_reparks_fresh_not_dropped(db):
+    """A resumed request whose park row is gone/terminal must re-park fresh, not
+    return None → generic failure (reviewer NOTE #2)."""
+    resumed = _bg_request(caller_context="rate_limit_resume:rlp-doesnotexist")
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=resumed, exc=exc, now=NOW, mode="live")
+    assert pid is not None
+    assert pid != "rlp-doesnotexist"
+    assert await parks.count_open(db) == 1
+
+
+async def test_mark_resumed_if_lineage(db):
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=_bg_request(), exc=exc, now=NOW, mode="live")
+    await parks.claim(db, pid)
+    await rlp.mark_resumed_if_lineage(db, f"rate_limit_resume:{pid}")
+    assert (await parks.get_by_id(db, pid))["status"] == "resumed"
+    # No-op for a non-resume caller_context.
+    await rlp.mark_resumed_if_lineage(db, "ego_proposal:x")  # must not raise
+
+
+def _park_runner(db):
+    """A DirectSessionRunner whose runtime exposes the real in-memory db."""
+    rt = MagicMock()
+    rt._db = db
+    runner = DirectSessionRunner(
+        invoker=AsyncMock(),
+        session_manager=AsyncMock(),
+        config_builder=AsyncMock(),
+        runtime=rt,
+    )
+    runner._build_invocation = MagicMock(return_value=MagicMock(claude_code_tmpdir=None))
+    runner._store_result = AsyncMock()
+    runner._record_proposal_outcome = AsyncMock()
+    runner._session_manager.fail = AsyncMock()
+    runner._deliver_result_to_origin = AsyncMock()
+    runner._notify = AsyncMock()
+    return runner
+
+
+class TestRunSessionParkWiring:
+    async def test_rate_limit_parks_instead_of_failing(self, db, monkeypatch):
+        # Default mode is off (dormant until PR-2b) — force live to exercise the
+        # park path.
+        monkeypatch.setattr("genesis.cc.rate_limit_resume_config.effective_mode", lambda: "live")
+        runner = _park_runner(db)
+        runner._invoker.run_streaming = AsyncMock(
+            side_effect=CCRateLimitError("limit", raw_text="resets in 30m")
+        )
+        req = DirectSessionRequest(
+            prompt="bg", delivery_mode=DeliveryMode.RESULT, origin_session_id="o1"
+        )
+        # Parks gracefully — does NOT raise and does NOT deliver a failure.
+        result = await runner._run_session(req, "sess-park")
+        assert result.success is False
+        assert "parked for resume" in (result.error or "")
+        runner._deliver_result_to_origin.assert_not_awaited()
+        runner._session_manager.fail.assert_awaited_with("sess-park", reason="rate_limited_parked")
+        assert await parks.count_open(db) == 1
+
+    async def test_disabled_falls_through_to_failure(self, db, monkeypatch):
+        monkeypatch.setenv("GENESIS_RATE_LIMIT_RESUME_DISABLED", "1")
+        runner = _park_runner(db)
+        runner._invoker.run_streaming = AsyncMock(
+            side_effect=CCRateLimitError("limit", raw_text="resets in 30m")
+        )
+        req = DirectSessionRequest(
+            prompt="bg", delivery_mode=DeliveryMode.RESULT, origin_session_id="o1"
+        )
+        # mode=off → current behavior: re-raises AND delivers the failure to origin.
+        with pytest.raises(CCRateLimitError):
+            await runner._run_session(req, "sess-fail")
+        runner._deliver_result_to_origin.assert_awaited_once()
+        assert await parks.count_open(db) == 0

--- a/tests/test_cc/test_rate_limit_reset.py
+++ b/tests/test_cc/test_rate_limit_reset.py
@@ -1,0 +1,119 @@
+"""Tests for the rate-limit reset parser (pure, injected clock).
+
+The parser is best-effort by design: it never raises, degrades to None on any
+miss, and treats a day-ambiguous weekly wall-clock time as unknown.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.cc.rate_limit_reset import (
+    SESSION,
+    UNKNOWN,
+    WEEKLY,
+    detect_limit_kind,
+    parse_reset,
+)
+
+NOW = datetime(2026, 7, 22, 14, 0, 0, tzinfo=UTC)
+
+
+def test_prose_relative_duration_is_unambiguous():
+    kind, reset = parse_reset(raw_text="You've hit your limit · resets in 2h 30m", now=NOW)
+    assert reset == NOW + timedelta(hours=2, minutes=30)
+
+
+def test_prose_wallclock_session_next_occurrence():
+    kind, reset = parse_reset(raw_text="Session limit — resets 5pm", now=NOW)
+    assert kind == SESSION
+    assert reset == NOW.replace(hour=17, minute=0)
+
+
+def test_prose_wallclock_weekly_is_ambiguous_none():
+    kind, reset = parse_reset(raw_text="Weekly usage limit reached, resets 5pm", now=NOW)
+    assert kind == WEEKLY
+    assert reset is None
+
+
+def test_wallclock_already_passed_rolls_to_tomorrow():
+    kind, reset = parse_reset(raw_text="resets 9am", now=NOW)  # 9am < 2pm now
+    assert reset == (NOW + timedelta(days=1)).replace(hour=9, minute=0)
+
+
+def test_event_epoch_seconds():
+    ts = int((NOW + timedelta(hours=3)).timestamp())
+    _, reset = parse_reset(raw_event={"type": "rate_limit_event", "resetsAt": ts}, now=NOW)
+    assert reset == NOW + timedelta(hours=3)
+
+
+def test_event_epoch_milliseconds():
+    ts_ms = int((NOW + timedelta(hours=1)).timestamp() * 1000)
+    _, reset = parse_reset(raw_event={"resetAt": ts_ms}, now=NOW)
+    assert reset == NOW + timedelta(hours=1)
+
+
+def test_event_retry_after_duration():
+    _, reset = parse_reset(raw_event={"retryAfter": 900}, now=NOW)
+    assert reset == NOW + timedelta(seconds=900)
+
+
+def test_event_nested_payload_and_weekly_keyword():
+    ts = int((NOW + timedelta(hours=2)).timestamp())
+    kind, reset = parse_reset(
+        raw_event={"error": {"rate_limit": {"reset": ts}}, "note": "weekly limit"}, now=NOW
+    )
+    assert kind == WEEKLY
+    assert reset == NOW + timedelta(hours=2)
+
+
+def test_event_iso_string():
+    iso = (NOW + timedelta(hours=4)).isoformat()
+    _, reset = parse_reset(raw_event={"resetsAt": iso}, now=NOW)
+    assert reset == NOW + timedelta(hours=4)
+
+
+def test_empty_signal_is_unknown_none():
+    assert parse_reset(now=NOW) == (UNKNOWN, None)
+
+
+def test_absurd_future_epoch_is_clamped_to_none():
+    ts = int((NOW + timedelta(days=40)).timestamp())
+    _, reset = parse_reset(raw_event={"resetsAt": ts}, now=NOW)
+    assert reset is None
+
+
+def test_detect_limit_kind_variants():
+    assert detect_limit_kind(None, "5-hour session limit") == SESSION
+    assert detect_limit_kind(None, "weekly cap reached") == WEEKLY
+    assert detect_limit_kind({"scope": "five hour"}, None) == SESSION
+    assert detect_limit_kind(None, "some other error") == UNKNOWN
+
+
+def test_event_weekly_string_value_is_ambiguous_none():
+    # A STRUCTURED weekly payload with a wall-clock reset string must not guess a
+    # concrete time (the day-ambiguity guard applies to raw_event strings too —
+    # without the fix, _reset_from_event would parse "resets 5pm" to a concrete
+    # time despite the weekly kind).
+    kind, reset = parse_reset(raw_event={"limit_type": "weekly", "reset": "resets 5pm"}, now=NOW)
+    assert kind == WEEKLY
+    assert reset is None
+
+
+def test_event_session_string_value_resolves():
+    kind, reset = parse_reset(raw_event={"limit_type": "session", "reset": "resets 5pm"}, now=NOW)
+    assert kind == SESSION
+    assert reset == NOW.replace(hour=17, minute=0)
+
+
+def test_event_preferred_over_prose_when_both_present():
+    # Structured event wins; prose weekly-ambiguity does not suppress it.
+    ts = int((NOW + timedelta(hours=1)).timestamp())
+    _, reset = parse_reset(raw_event={"resetsAt": ts}, raw_text="weekly limit resets 5pm", now=NOW)
+    assert reset == NOW + timedelta(hours=1)
+
+
+def test_never_raises_on_garbage():
+    # Bad types must degrade, not crash.
+    kind, reset = parse_reset(raw_event={"resetsAt": object()}, raw_text=None, now=NOW)
+    assert reset is None

--- a/tests/test_db/test_cc_rate_limit_parks.py
+++ b/tests/test_db/test_cc_rate_limit_parks.py
@@ -1,0 +1,250 @@
+"""Tests for cc_rate_limit_parks CRUD — the durable rate-limit park lineage.
+
+Covers idempotent upsert (partial-unique open dedup), due-selection, claim race,
+in-place re-limit + needs_user escalation, stale-resuming recovery, terminal
+prune, and the dedup-slot release on escalation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import cc_rate_limit_parks as parks
+
+
+def _payload(prompt: str = "hi") -> dict:
+    return {"prompt": prompt, "profile": "research"}
+
+
+async def test_upsert_inserts_then_bumps_same_dedup_key(db):
+    pid = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k1",
+        payload=_payload(),
+        origin_session_id="sess1",
+        limit_kind="session",
+        raw_signal="resets 5pm",
+        reset_at="2026-07-22T17:00:00+00:00",
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    # Same open dedup_key → same row, attempts bumped, reset refreshed.
+    pid2 = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k1",
+        payload=_payload(),
+        origin_session_id="sess1",
+        limit_kind="session",
+        raw_signal="resets 6pm",
+        reset_at="2026-07-22T18:00:00+00:00",
+        next_attempt_at="2026-07-22T18:00:00+00:00",
+    )
+    assert pid == pid2
+    row = await parks.get_by_id(db, pid)
+    assert row["attempts"] == 1
+    assert row["reset_at"] == "2026-07-22T18:00:00+00:00"
+    assert await parks.count_open(db) == 1
+
+
+async def test_distinct_dedup_keys_coexist(db):
+    await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="a",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="unknown",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    await parks.upsert_open_park(
+        db,
+        kind="direct_session",
+        dedup_key="b",
+        payload=_payload("x"),
+        origin_session_id="s2",
+        limit_kind="weekly",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    assert await parks.count_open(db) == 2
+
+
+async def test_list_due_respects_next_attempt_at(db):
+    await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at="2026-07-22T18:00:00+00:00",
+        next_attempt_at="2026-07-22T18:00:00+00:00",
+    )
+    assert len(await parks.list_due(db, now="2026-07-22T17:30:00+00:00")) == 0
+    assert len(await parks.list_due(db, now="2026-07-22T19:00:00+00:00")) == 1
+
+
+async def test_claim_is_single_winner(db):
+    pid = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    assert await parks.claim(db, pid) is True
+    assert await parks.claim(db, pid) is False  # already resuming
+    assert (await parks.get_by_id(db, pid))["status"] == "resuming"
+
+
+async def test_mark_resumed_only_from_resuming(db):
+    pid = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    assert await parks.mark_resumed(db, pid) is False  # still parked
+    await parks.claim(db, pid)
+    assert await parks.mark_resumed(db, pid) is True
+    assert (await parks.get_by_id(db, pid))["status"] == "resumed"
+
+
+async def test_relimit_increments_in_place_then_escalates(db):
+    pid = await parks.upsert_open_park(
+        db,
+        kind="direct_session",
+        dedup_key="k",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    await parks.claim(db, pid)
+    # First re-limit: back to parked, attempts=1.
+    st = await parks.relimit(
+        db,
+        pid,
+        reset_at="2026-07-22T20:00:00+00:00",
+        next_attempt_at="2026-07-22T20:00:00+00:00",
+        needs_user_at_attempts=3,
+    )
+    assert st == "parked"
+    assert (await parks.get_by_id(db, pid))["attempts"] == 1
+    # Drive to the escalation threshold.
+    await parks.claim(db, pid)
+    await parks.relimit(db, pid, reset_at=None, next_attempt_at="x", needs_user_at_attempts=3)
+    await parks.claim(db, pid)
+    st_final = await parks.relimit(
+        db, pid, reset_at=None, next_attempt_at="x", needs_user_at_attempts=3
+    )
+    assert st_final == "needs_user"
+    assert (await parks.get_by_id(db, pid))["status"] == "needs_user"
+    # needs_user is not due and not pruned.
+    assert len(await parks.list_due(db, now="2099-01-01T00:00:00+00:00")) == 0
+
+
+async def test_escalation_frees_dedup_slot(db):
+    """A park escalated to needs_user releases its dedup_key so a fresh identical
+    request can re-park (needs_user is not an OPEN state)."""
+    pid = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="same",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    await parks.claim(db, pid)
+    await parks.relimit(db, pid, reset_at=None, next_attempt_at="x", needs_user_at_attempts=1)
+    assert (await parks.get_by_id(db, pid))["status"] == "needs_user"
+    pid_new = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="same",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    assert pid_new != pid
+    assert await parks.count_open(db) == 1  # only the new one
+
+
+async def test_recover_stale_resuming(db):
+    pid = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    await parks.claim(db, pid)
+    # max_age_s=0 → any claimed_at is stale → reclaimed.
+    assert await parks.recover_stale_resuming(db, max_age_s=0) >= 1
+    assert (await parks.get_by_id(db, pid))["status"] == "parked"
+
+
+async def test_prune_terminal_keeps_needs_user(db):
+    # A resumed park older than the window is pruned; needs_user is never pruned.
+    pid = await parks.upsert_open_park(
+        db,
+        kind="conversation",
+        dedup_key="k",
+        payload=_payload(),
+        origin_session_id="s",
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at="2026-07-22T17:00:00+00:00",
+    )
+    await parks.claim(db, pid)
+    await parks.mark_resumed(db, pid)
+    # Force updated_at into the deep past so the prune window catches it.
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET updated_at = '2000-01-01T00:00:00+00:00' WHERE id = ?",
+        (pid,),
+    )
+    await db.commit()
+    assert await parks.prune_terminal(db, older_than_days=45) == 1
+    assert await parks.get_by_id(db, pid) is None
+
+
+@pytest.mark.parametrize("bad_status", ["bogus", "PARKED", ""])
+async def test_status_check_constraint(db, bad_status):
+    import sqlite3
+
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            """INSERT INTO cc_rate_limit_parks
+                   (id, kind, dedup_key, payload_json, status, attempts,
+                    created_at, updated_at)
+               VALUES ('x', 'conversation', 'k', '{}', ?, 0, 'n', 'n')""",
+            (bad_status,),
+        )
+        await db.commit()

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -139,6 +139,7 @@ async def test_no_unexpected_tables(db):
         "knowledge_uploads",
         "file_modifications",
         "direct_session_queue",
+        "cc_rate_limit_parks",
         "eval_events",
         "eval_snapshots",
         "memory_events",


### PR DESCRIPTION
## What & why

The durability half of the 2026-07-20 silent-death incident (a Telegram deep-research request died on a rate limit and never came back). PR-1 (#1192, delivery model) fixed result delivery; this fixes the **rate-limit** half.

Today, when a CC call hits a rate/usage limit, the work is dropped — and the foreground handler even tells the user *"Background tasks are queued and will resume automatically"*, a promise nothing backs (`rate_limit_resumes_at` had a full read/schema/CRUD path but **zero producers** — always NULL). PR-2a makes the work durable and the copy honest. Reset-time-driven **auto-resume + delivery** follows in **PR-2b**.

## What's in this PR

- **`cc_rate_limit_parks` table + CRUD** — the durable lineage object for one logical unit of rate-limited work: upsert-idempotent on a partial-unique open-park dedup key (`sha256(kind+origin+prompt)`), `claim`, `relimit`-in-place (attempts+1 + backoff), `needs_user` escalation, stale-resuming recovery, terminal prune.
- **Reset-signal capture** — annotate `CCRateLimitError`/`CCQuotaExhaustedError` with the `raw_event`/`raw_text` reset hint that was discarded at every detection point; `rate_limit_reset.parse_reset` best-effort-parses it (structured event → prose `"resets Xpm"` → None). A **weekly wall-clock time is day-ambiguous → None** (never guesses "next 5pm").
- **Park writers** (`cc/rate_limit_park.py`, a thin-delegate module so the two >1000-line call sites stay thin): foreground `conversation.py` (both sites, after failover+contingency both fail) and background `direct_session._run_session` (new catch **before** the generic `except`; `_finalize_failure` extracted so `mode=off` preserves exact current behavior). `cc_sessions.rate_limit_resumes_at` finally gets a producer.
- **Settings lever** `cc_rate_limit_resume` (off | propose_only | **live**) + `GENESIS_RATE_LIMIT_RESUME_DISABLED` kill switch; mode-aware honest foreground copy.

## Design decisions (from a pre-build architecture review)

- **Reset-time re-run, not a probe.** Subscription budgets are per-model-tier, so a cheap Haiku probe can't gate an Opus resume — the resumed work is its own probe (re-run at reset; re-limit → re-park). No cross-tier soundness problem.
- **Park lineage is durable.** The park row is resolved by `park_id` (threaded via `caller_context`) across the async re-dispatch, so attempts/backoff/`needs_user` escalation survive a re-limit (not reset per cycle).
- **Gate posture — resume is gate-covered by origin.** A resume only completes work whose initiation was already approved (a foreground prompt, or a `direct_session` already gated at its original dispatch), so it is **not** new autonomous initiative. (Wired in PR-2b.)
- **Deliberately NOT parked:** reflection-bridge (periodic self-retry) and the task executor (already durable via `task_states`).

## Testing

- Parser (16), parks CRUD lineage (11), park helpers + `_run_session` background-catch wiring (15) — all green; 232-test regression sweep across `test_cc`/`test_db` green; 0 lint errors.
- Code-reviewed; both findings fixed in-PR (structured-event weekly day-ambiguity guard; re-park-fresh fallback when a lineage row is gone).

## Follow-ups (tabled)

- Verify the autonomy task-recovery orchestrator treats `CCRateLimitError` as retryable (not permanent-FAILED).
- Spawn-time non-CC dispatch failure in the enqueue poll drops silently (pre-existing; resume makes it user-visible).
- `cc_fallback_probe.py` `bare=True` probes the API-key lane, not the subscription (latent false-recovery bug; separate prober).

Part of ledger ee391fbd (rate-limit park+resume remainder; **completed by PR-2b**, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)