### PR TITLE
feat(memory): rate-gate + timeout-only breaker for recall's Voyage rerank (ac27b693, PR-3)

### DIFF
--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -179,6 +179,41 @@ def recall_read_pool_size() -> int:
         return DEFAULT_READ_POOL_SIZE
 
 
+def recall_rerank_gate_off() -> bool:
+    """True when the recall rerank rate-gate + circuit-breaker must NOT be built
+    (kill switch).
+
+    Recall's Voyage rerank normally runs behind a shared rate gate (skip to the
+    RRF+graph floor instead of burning a 429 when over Voyage's RPM) and a
+    timeout-only circuit breaker (skip during a Voyage hang) — follow-up
+    ac27b693, PR-3. This env kill makes the runtime skip building them, so the
+    rerank call is unguarded exactly as before the change — no code change.
+    Default off: the gate+breaker are built.
+    """
+    return os.environ.get("GENESIS_RECALL_RERANK_GATE_OFF", "").strip() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def recall_rerank_rpm() -> int:
+    """Requests-per-minute the recall rerank rate gate paces Voyage to.
+
+    Voyage's free tier (no payment method) is 3 RPM; paid usage tiers are higher,
+    so this is tunable per install via ``GENESIS_RECALL_RERANK_RPM`` rather than
+    hardcoded (generalizability). Floored at 1; a missing/non-integer value falls
+    back to the free-tier default of 3.
+    """
+    raw = os.environ.get("GENESIS_RECALL_RERANK_RPM", "").strip()
+    if not raw:
+        return 3
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 3
+
+
 def skill_gate_off() -> bool:
     """True when the skill-edit Critic must be suppressed entirely (kill switch).
 

--- a/src/genesis/mcp/memory/__init__.py
+++ b/src/genesis/mcp/memory/__init__.py
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
 
     from genesis.db.connection import ReadConnectionPool
     from genesis.memory.reranker import VoyageReranker
+    from genesis.routing.circuit_breaker import CircuitBreaker
+    from genesis.routing.rate_gate import ProviderRateGate
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +74,8 @@ def init(
     activity_tracker: object | None = None,
     reranker: VoyageReranker | None = None,
     read_pool: ReadConnectionPool | None = None,
+    rerank_gate: ProviderRateGate | None = None,
+    rerank_breaker: CircuitBreaker | None = None,
     # Backward compat — old callers pass ``embedding_provider``
     embedding_provider: EmbeddingProvider | None = None,
 ) -> None:
@@ -118,12 +122,18 @@ def init(
     # read-only pool must reach it here — wiring it only into rt._hybrid_retriever
     # would leave the very hot path the pool targets bypassing it. Same shared
     # pool instance (bounded connections); None keeps the pre-pool behavior.
+    # rerank_gate/rerank_breaker: same rationale as read_pool — the proactive hot
+    # path reranks through THIS retriever, so the shared gate+breaker must reach it
+    # here (same instances as rt._hybrid_retriever) or Voyage's RPM would be
+    # enforced twice-over (ac27b693, PR-3). None keeps the unguarded behavior.
     _retriever = HybridRetriever(
         embedding_provider=recall_emb,
         qdrant_client=qdrant_client,
         db=db,
         reranker=reranker,
         read_pool=read_pool,
+        rerank_gate=rerank_gate,
+        rerank_breaker=rerank_breaker,
     )
     _user_model_evolver = UserModelEvolver(db=db)
     _bookmark_mgr = BookmarkManager(

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -7,7 +7,7 @@ import math
 import time
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 from qdrant_client import QdrantClient
@@ -29,6 +29,10 @@ from genesis.observability.call_site_recorder import record_last_run
 from genesis.observability.provider_activity import track_operation
 from genesis.qdrant import collections as qdrant_ops
 from genesis.util.tasks import tracked_task
+
+if TYPE_CHECKING:
+    from genesis.routing.circuit_breaker import CircuitBreaker
+    from genesis.routing.rate_gate import ProviderRateGate
 
 logger = logging.getLogger(__name__)
 
@@ -626,6 +630,8 @@ class HybridRetriever:
         db: aiosqlite.Connection,
         reranker: VoyageReranker | None = None,
         read_pool: ReadConnectionPool | None = None,
+        rerank_gate: ProviderRateGate | None = None,
+        rerank_breaker: CircuitBreaker | None = None,
     ) -> None:
         self._embeddings = embedding_provider
         self._qdrant = qdrant_client
@@ -636,6 +642,15 @@ class HybridRetriever:
         # connection off the shared write lock; None (eval, tests, other callers)
         # keeps every read on self._db — byte-identical to the pre-pool path.
         self._read_pool = read_pool
+        # Optional rate-gate + circuit-breaker guarding the Voyage rerank call
+        # (follow-up ac27b693, PR-3). Shared instances (one per process) enforce
+        # Voyage's account-global RPM across all concurrent recalls: gate-denied
+        # skips the rerank INSTANTLY to the RRF+graph floor instead of burning a
+        # 429, and the breaker skips after repeated hangs. None (eval, tests,
+        # other callers, or the GENESIS_RECALL_RERANK_GATE_OFF kill) = today's
+        # unguarded behavior.
+        self._rerank_gate = rerank_gate
+        self._rerank_breaker = rerank_breaker
 
     async def _ro_read(
         self,
@@ -1529,6 +1544,21 @@ class HybridRetriever:
                 if content:
                     rerank_docs.append({"id": mid, "text": content})
             if rerank_docs:
+                # Rerank resilience (ac27b693, PR-3): skip straight to the
+                # RRF+graph floor rather than pay a doomed Voyage call. Breaker
+                # (open only after repeated genuine hangs) first, then the
+                # account-global rate gate — a denied gate means we'd exceed
+                # Voyage's RPM (free tier = 3 RPM), so skipping INSTANTLY beats
+                # burning a 429 round-trip. Both are optional; unset (eval/tests/
+                # kill switch) = today's unguarded behavior.
+                if self._rerank_breaker is not None and not self._rerank_breaker.is_available():
+                    if stats is not None:
+                        stats["rerank_skipped_breaker_open"] = True
+                    return fused
+                if self._rerank_gate is not None and not await self._rerank_gate.try_acquire():
+                    if stats is not None:
+                        stats["rerank_skipped_ratelimited"] = True
+                    return fused
                 t0 = time.monotonic()
                 coro = self._reranker.rerank(
                     query,
@@ -1545,6 +1575,14 @@ class HybridRetriever:
                         "Rerank exceeded %.1fs timebox — keeping RRF order",
                         timeout_s,
                     )
+                    # A timebox expiry is a genuine hang (NOT a 429) → feed the
+                    # breaker so a persistently-slow Voyage trips it OPEN and we
+                    # skip instantly during the cooldown. 429/empty returns never
+                    # reach here and never trip it — the rate gate is the RPM brake.
+                    if self._rerank_breaker is not None:
+                        from genesis.routing.types import ErrorCategory
+
+                        self._rerank_breaker.record_failure(ErrorCategory.TIMEOUT)
                     if stats is not None:
                         stats["rerank_timed_out"] = True
                         stats["rerank_ms"] = round((time.monotonic() - t0) * 1000, 1)
@@ -1552,6 +1590,11 @@ class HybridRetriever:
                 if stats is not None:
                     stats["rerank_ms"] = round((time.monotonic() - t0) * 1000, 1)
                 if reranked:
+                    # A real result set proves Voyage responsive → heal the breaker
+                    # (resets consecutive failures / closes a HALF_OPEN). An empty
+                    # return (429/5xx) is left as no-signal: RRF floor, no trip.
+                    if self._rerank_breaker is not None:
+                        self._rerank_breaker.record_success()
                     if stats is not None:
                         stats["rerank_executed"] = True
                     # Rebuild fused with only reranked candidates, using

--- a/src/genesis/routing/rate_gate.py
+++ b/src/genesis/routing/rate_gate.py
@@ -42,6 +42,23 @@ class ProviderRateGate:
             self._last_request = time.monotonic()
             return max(wait, 0.0)
 
+    async def try_acquire(self) -> bool:
+        """Non-blocking variant of :meth:`acquire`.
+
+        Returns True and reserves the slot if the interval has elapsed; returns
+        False immediately (NO sleep) if a request would be too soon. Use this on
+        latency-critical paths where blocking up to ``interval`` (e.g. 20s at
+        3 RPM) is unacceptable — the caller skips the rate-limited work instead
+        of waiting. Slot accounting is identical to ``acquire`` (same lock, same
+        ``_last_request`` update), so the two may be mixed on one gate.
+        """
+        async with self._lock:
+            now = time.monotonic()
+            if now - self._last_request < self._interval:
+                return False
+            self._last_request = now
+            return True
+
     @property
     def interval(self) -> float:
         return self._interval
@@ -58,7 +75,9 @@ class RateGateRegistry:
         self._gates[provider] = ProviderRateGate(provider, rpm)
         logger.debug(
             "Rate gate registered for %s: %d RPM (%.1fs interval)",
-            provider, rpm, 60.0 / rpm,
+            provider,
+            rpm,
+            60.0 / rpm,
         )
 
     async def acquire(self, provider: str) -> float:

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -53,7 +53,13 @@ async def init(rt: GenesisRuntime) -> None:
     try:
         from qdrant_client import QdrantClient
 
-        from genesis.env import qdrant_url, recall_read_pool_off, recall_read_pool_size
+        from genesis.env import (
+            qdrant_url,
+            recall_read_pool_off,
+            recall_read_pool_size,
+            recall_rerank_gate_off,
+            recall_rerank_rpm,
+        )
         from genesis.memory.embeddings import EmbeddingProvider
         from genesis.memory.linker import MemoryLinker
         from genesis.memory.store import MemoryStore
@@ -134,12 +140,53 @@ async def init(rt: GenesisRuntime) -> None:
                 )
                 rt._db_ro_pool = None
 
+        # Shared rate gate + timeout-only circuit breaker guarding recall's Voyage
+        # rerank (follow-up ac27b693, PR-3). ONE gate + ONE breaker per process,
+        # shared by BOTH retrievers below, so Voyage's account-global RPM (free
+        # tier = 3) is enforced across every concurrent recall — two instances
+        # would each permit the full RPM. A gate-denied rerank skips instantly to
+        # the RRF+graph floor instead of burning a 429; the breaker trips only on
+        # a genuine rerank hang (timebox expiry), never on a 429. The
+        # GENESIS_RECALL_RERANK_GATE_OFF kill (or a build failure) leaves both None
+        # → recall reranks unguarded exactly as before the change.
+        rt._rerank_gate = None
+        rt._rerank_breaker = None
+        if not recall_rerank_gate_off():
+            try:
+                from genesis.routing.circuit_breaker import CircuitBreaker
+                from genesis.routing.rate_gate import ProviderRateGate
+                from genesis.routing.types import ProviderConfig
+
+                rerank_rpm = recall_rerank_rpm()
+                rt._rerank_gate = ProviderRateGate("voyage", rpm=rerank_rpm)
+                rt._rerank_breaker = CircuitBreaker(
+                    ProviderConfig(
+                        name="voyage",
+                        provider_type="rerank",
+                        model_id="rerank-2.5",
+                        is_free=True,
+                        rpm_limit=rerank_rpm,
+                        open_duration_s=120,
+                    )
+                )
+                logger.info("Recall rerank gate+breaker built (voyage, %d RPM)", rerank_rpm)
+            except Exception:
+                logger.warning(
+                    "Recall rerank gate/breaker failed to build — rerank runs "
+                    "unguarded (degraded, not broken)",
+                    exc_info=True,
+                )
+                rt._rerank_gate = None
+                rt._rerank_breaker = None
+
         rt._hybrid_retriever = HybridRetriever(
             embedding_provider=recall_embedder,
             qdrant_client=qdrant,
             db=rt._db,
             reranker=reranker,
             read_pool=rt._db_ro_pool,
+            rerank_gate=rt._rerank_gate,
+            rerank_breaker=rt._rerank_breaker,
         )
         rt._context_injector = ContextInjector(
             retriever=rt._hybrid_retriever,
@@ -162,6 +209,12 @@ async def init(rt: GenesisRuntime) -> None:
             # through the MCP retriever, so the pool must reach it here or the hot
             # path PR-4 targets would bypass it (ac27b693).
             read_pool=rt._db_ro_pool,
+            # Share the SAME rerank gate+breaker: the proactive per-prompt path is
+            # the dominant Voyage consumer and recalls through THIS retriever, so
+            # the gate must reach it here — and it must be the same instance as the
+            # runtime stack's, or each would permit the full RPM (ac27b693, PR-3).
+            rerank_gate=rt._rerank_gate,
+            rerank_breaker=rt._rerank_breaker,
         )
         logger.info("Memory MCP initialized (dual embedders, shared reranker)")
 

--- a/tests/test_mcp/test_memory_reranker_wiring.py
+++ b/tests/test_mcp/test_memory_reranker_wiring.py
@@ -45,6 +45,8 @@ def _stub_init_deps(monkeypatch) -> dict:
             captured.update(kwargs)
             self._reranker = kwargs.get("reranker")
             self._read_pool = kwargs.get("read_pool")
+            self._rerank_gate = kwargs.get("rerank_gate")
+            self._rerank_breaker = kwargs.get("rerank_breaker")
 
     # Local imports inside init() resolve these attributes at call time, so
     # patching the source module attribute is sufficient.
@@ -108,6 +110,31 @@ def test_init_threads_read_pool_into_retriever(monkeypatch):
 
     assert captured["read_pool"] is sentinel
     assert mem._retriever._read_pool is sentinel
+
+
+def test_init_threads_rerank_gate_and_breaker_into_retriever(monkeypatch):
+    """The proactive hot path is the dominant Voyage consumer and reranks through
+    the MCP retriever, so the shared rate gate + circuit breaker MUST reach it
+    here — and be the SAME instances as rt._hybrid_retriever's, or each retriever
+    would permit the full RPM (ac27b693, PR-3). Same two_retriever_wiring surface
+    as the reranker + read_pool guards above.
+    """
+    captured = _stub_init_deps(monkeypatch)
+    gate = object()
+    breaker = object()
+
+    mem.init(
+        db=MagicMock(),
+        qdrant_client=MagicMock(),
+        embedding_provider=MagicMock(),
+        rerank_gate=gate,
+        rerank_breaker=breaker,
+    )
+
+    assert captured["rerank_gate"] is gate
+    assert captured["rerank_breaker"] is breaker
+    assert mem._retriever._rerank_gate is gate
+    assert mem._retriever._rerank_breaker is breaker
 
 
 def test_init_without_read_pool_is_none(monkeypatch):

--- a/tests/test_memory/test_rerank_gate.py
+++ b/tests/test_memory/test_rerank_gate.py
@@ -1,0 +1,246 @@
+"""Recall rerank resilience: rate-gate + timeout-only circuit breaker
+(follow-up ac27b693, PR-3).
+
+`_maybe_rerank` now consults an optional shared rate gate and circuit breaker
+before calling Voyage, so under free-tier RPM pressure it skips straight to the
+RRF+graph floor instead of burning a 429, and skips during a genuine Voyage
+hang. Only a timebox expiry (a real hang) feeds the breaker — a 429/empty return
+never trips it (the gate is the RPM brake). These tests pin every branch plus
+the kill-switch byte-parity (gate/breaker None → today's unguarded behavior).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.memory.retrieval import HybridRetriever
+from genesis.routing.circuit_breaker import CircuitBreaker
+from genesis.routing.rate_gate import ProviderRateGate
+from genesis.routing.types import ErrorCategory, ProviderConfig
+
+
+def _real_gate(rpm: int = 3) -> ProviderRateGate:
+    return ProviderRateGate("voyage", rpm=rpm)
+
+
+def _real_breaker() -> CircuitBreaker:
+    return CircuitBreaker(
+        ProviderConfig(
+            name="voyage",
+            provider_type="rerank",
+            model_id="rerank-2.5",
+            is_free=True,
+            rpm_limit=3,
+            open_duration_s=120,
+        )
+    )
+
+
+_FUSED = {"m1": 0.05, "m2": 0.03}
+_QBI = {
+    "m1": {"payload": {"content": "text one"}},
+    "m2": {"payload": {"content": "text two"}},
+}
+
+
+def _reranker(rerank_fn) -> MagicMock:
+    rr = MagicMock()
+    rr.enabled = True
+    rr.rerank = rerank_fn
+    return rr
+
+
+def _breaker(*, available: bool = True) -> MagicMock:
+    cb = MagicMock()
+    cb.is_available.return_value = available
+    cb.record_success = MagicMock()
+    cb.record_failure = MagicMock()
+    return cb
+
+
+def _gate(*, granted: bool = True) -> MagicMock:
+    g = MagicMock()
+    g.try_acquire = AsyncMock(return_value=granted)
+    return g
+
+
+def _retriever(*, reranker=None, gate=None, breaker=None) -> HybridRetriever:
+    embed = MagicMock()
+    embed.embed = AsyncMock(return_value=[0.1] * 1024)
+    return HybridRetriever(
+        embedding_provider=embed,
+        qdrant_client=MagicMock(),
+        db=MagicMock(),
+        reranker=reranker,
+        rerank_gate=gate,
+        rerank_breaker=breaker,
+    )
+
+
+async def _run(retriever, *, timeout_s=None):
+    fused = dict(_FUSED)
+    stats: dict = {}
+    result = await retriever._maybe_rerank(
+        query="q",
+        fused=fused,
+        qdrant_by_id=_QBI,
+        fts_by_id={},
+        limit=5,
+        rerank=True,
+        timeout_s=timeout_s,
+        stats=stats,
+    )
+    return result, fused, stats
+
+
+@pytest.mark.asyncio
+async def test_breaker_open_skips_without_calling_voyage():
+    rr = _reranker(AsyncMock(return_value=[{"id": "m1", "score": 0.9}]))
+    gate = _gate(granted=True)
+    breaker = _breaker(available=False)
+    r = _retriever(reranker=rr, gate=gate, breaker=breaker)
+
+    result, fused, stats = await _run(r)
+
+    assert result is fused  # unchanged → RRF+graph floor
+    assert stats["rerank_skipped_breaker_open"] is True
+    rr.rerank.assert_not_called()
+    gate.try_acquire.assert_not_called()  # breaker checked first, short-circuits
+    breaker.record_failure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gate_denied_skips_instantly_to_rrf():
+    rr = _reranker(AsyncMock(return_value=[{"id": "m1", "score": 0.9}]))
+    gate = _gate(granted=False)
+    breaker = _breaker(available=True)
+    r = _retriever(reranker=rr, gate=gate, breaker=breaker)
+
+    result, fused, stats = await _run(r)
+
+    assert result is fused
+    assert stats["rerank_skipped_ratelimited"] is True
+    rr.rerank.assert_not_called()  # no 429 burned — never called Voyage
+    breaker.record_failure.assert_not_called()
+    breaker.record_success.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_success_records_success_and_applies_rerank():
+    rr = _reranker(AsyncMock(return_value=[{"id": "m1", "score": 0.9}]))
+    gate = _gate(granted=True)
+    breaker = _breaker(available=True)
+    r = _retriever(reranker=rr, gate=gate, breaker=breaker)
+
+    result, fused, stats = await _run(r)
+
+    assert result is not fused  # rebuilt from reranker order
+    assert result == {"m1": 1.0}
+    assert stats["rerank_executed"] is True
+    breaker.record_success.assert_called_once()
+    breaker.record_failure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_timeout_records_failure_only():
+    async def _hang(*_a, **_k):
+        await asyncio.sleep(1)
+
+    rr = _reranker(_hang)
+    gate = _gate(granted=True)
+    breaker = _breaker(available=True)
+    r = _retriever(reranker=rr, gate=gate, breaker=breaker)
+
+    result, fused, stats = await _run(r, timeout_s=0.01)
+
+    assert result is fused  # kept RRF+graph
+    assert stats["rerank_timed_out"] is True
+    breaker.record_failure.assert_called_once_with(ErrorCategory.TIMEOUT)
+    breaker.record_success.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_return_gives_no_breaker_signal():
+    """A 429/5xx surfaces as an empty list from VoyageReranker; it must fall back
+    to RRF WITHOUT touching the breaker (the gate, not the breaker, brakes 429s)."""
+    rr = _reranker(AsyncMock(return_value=[]))
+    gate = _gate(granted=True)
+    breaker = _breaker(available=True)
+    r = _retriever(reranker=rr, gate=gate, breaker=breaker)
+
+    result, fused, stats = await _run(r)
+
+    assert result is fused
+    assert stats.get("rerank_executed") is False
+    breaker.record_failure.assert_not_called()
+    breaker.record_success.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_none_is_byte_parity():
+    """gate=None and breaker=None (kill switch / legacy callers): the rerank runs
+    exactly as before — no gate/breaker interaction, reranker applied."""
+    rr = _reranker(AsyncMock(return_value=[{"id": "m1", "score": 0.9}]))
+    r = _retriever(reranker=rr, gate=None, breaker=None)
+
+    result, fused, stats = await _run(r)
+
+    assert result == {"m1": 1.0}
+    assert stats["rerank_executed"] is True
+    rr.rerank.assert_awaited_once()
+
+
+# --- Integration: REAL ProviderRateGate + CircuitBreaker through the call site ---
+
+
+@pytest.mark.asyncio
+async def test_integration_real_gate_denies_second_call_within_interval():
+    """End-to-end with the REAL gate + breaker (no mocks): the first rerank is
+    granted and applied; a second within the 20s interval is gate-denied and
+    skips to the RRF floor — the exact behavior under concurrent recalls at 3
+    RPM. The window is then rewound (no real sleep) to prove a later call grants."""
+    gate = _real_gate(rpm=3)
+    breaker = _real_breaker()
+    rr = _reranker(AsyncMock(return_value=[{"id": "m1", "score": 0.9}]))
+    r = _retriever(reranker=rr, gate=gate, breaker=breaker)
+
+    _, _, s1 = await _run(r)
+    assert s1["rerank_executed"] is True
+    assert "rerank_skipped_ratelimited" not in s1
+
+    r2, f2, s2 = await _run(r)
+    assert r2 is f2
+    assert s2["rerank_skipped_ratelimited"] is True
+
+    gate._last_request = time.monotonic() - gate.interval - 0.01
+    _, _, s3 = await _run(r)
+    assert s3["rerank_executed"] is True
+
+
+@pytest.mark.asyncio
+async def test_integration_real_breaker_trips_after_consecutive_timeouts():
+    """REAL CircuitBreaker: 3 consecutive rerank timeouts (failure_threshold) trip
+    it OPEN, after which reranks skip with rerank_skipped_breaker_open and Voyage
+    is never called. gate=None isolates the breaker."""
+
+    async def _hang(*_a, **_k):
+        await asyncio.sleep(1)
+
+    breaker = _real_breaker()
+    r = _retriever(reranker=_reranker(_hang), gate=None, breaker=breaker)
+
+    for _ in range(3):
+        _, _, stats = await _run(r, timeout_s=0.01)
+        assert stats["rerank_timed_out"] is True
+    assert breaker.is_available() is False  # tripped OPEN by the 3rd timeout
+
+    # Breaker now open → next rerank skips without calling Voyage.
+    healthy = _reranker(AsyncMock(return_value=[{"id": "m1", "score": 0.9}]))
+    r._reranker = healthy
+    _, fused, stats = await _run(r)
+    assert stats["rerank_skipped_breaker_open"] is True
+    healthy.rerank.assert_not_called()

--- a/tests/test_routing/test_rate_gate.py
+++ b/tests/test_routing/test_rate_gate.py
@@ -109,3 +109,45 @@ def test_rate_gate_interval():
 
     gate2 = ProviderRateGate("test", rpm=15)
     assert gate2.interval == 4.0
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_first_call_true_no_block():
+    """try_acquire grants the first request and never blocks."""
+    gate = ProviderRateGate("test", rpm=3)  # 20s interval
+    t0 = time.monotonic()
+    assert await gate.try_acquire() is True
+    assert time.monotonic() - t0 < 0.1
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_denies_within_interval_instantly():
+    """A second try_acquire inside the interval returns False IMMEDIATELY —
+    unlike acquire(), it must not sleep ~20s at 3 RPM."""
+    gate = ProviderRateGate("test", rpm=3)
+    assert await gate.try_acquire() is True
+    t0 = time.monotonic()
+    assert await gate.try_acquire() is False
+    assert time.monotonic() - t0 < 0.1  # returned instantly, did NOT block
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_grants_after_interval():
+    """Once the interval has elapsed, try_acquire grants again. Driven by
+    rewinding _last_request so the test is wall-clock-independent (no real sleep)."""
+    gate = ProviderRateGate("test", rpm=3)
+    assert await gate.try_acquire() is True
+    assert await gate.try_acquire() is False
+    gate._last_request = time.monotonic() - gate.interval - 0.01
+    assert await gate.try_acquire() is True
+
+
+@pytest.mark.asyncio
+async def test_try_acquire_denial_does_not_advance_window():
+    """A denied try_acquire must NOT reserve the slot — otherwise repeated denials
+    would push _last_request forward and could starve the caller indefinitely."""
+    gate = ProviderRateGate("test", rpm=3)
+    assert await gate.try_acquire() is True
+    last = gate._last_request
+    assert await gate.try_acquire() is False
+    assert gate._last_request == last


### PR DESCRIPTION
## What & why

Recall's Voyage rerank had **no rate limiting**. Under the free tier (**3 RPM + 10K TPM**) with Jay's 5–7 concurrent sessions the account is saturated — the server logs show **65 `Voyage rerank HTTP 429 — degrading to RRF order` in the last 7 days**, each paying a wasted round-trip before falling back. Zero genuine-outage lines in the window: rate-limiting is the whole problem.

This is **PR-3** of the ac27b693 recall-latency series.

## Design (Option B — gate kills 429s, breaker guards only hangs)

Shared, process-wide rate gate + **timeout-only** circuit breaker, consulted at the `_maybe_rerank` call site (mirrors `router.py` wrapping providers rather than baking resilience into `VoyageReranker`, which `corrective.py` also uses and is left untouched):

- **`ProviderRateGate.try_acquire()`** — new non-blocking variant of `acquire()` (which *sleeps* up to the interval = 20s at 3 RPM, unusable on the hot path). Gate denied → skip **instantly** to the RRF+graph floor (`rerank_skipped_ratelimited`), no 429 burned.
- **Breaker trips ONLY on an `asyncio.wait_for` `TimeoutError`** (a genuine hang) → `record_failure(ErrorCategory.TIMEOUT)`. A 429/empty return gives **no breaker signal** — respecting the routing rule that a 429 must not trip a breaker (the gate is the RPM brake). Open → skip (`rerank_skipped_breaker_open`); a real result → `record_success()` heals it.
- **One gate + one breaker shared by BOTH retrievers** (`runtime/init/memory.py` builds them once, passes the *same instances* to `HybridRetriever(...)` and `init_memory_mcp(...)` → MCP retriever) so Voyage's account-global RPM is enforced across all concurrent recalls — two instances would each permit the full RPM. Guarded by the `two_retriever_wiring` regression test.
- **Kill-switch** `GENESIS_RECALL_RERANK_GATE_OFF` + config `GENESIS_RECALL_RERANK_RPM` (default 3, tunable for paid tiers). `None`/`None` → byte-parity with today (verified).

RRF+graph stays the guaranteed floor on every skip — **no result-quality change**, only removes wasted/doomed Voyage calls. Does **not** speed successful reranks (~450–550ms Voyage latency is real).

## Tests

- `try_acquire` (grant / deny-within-interval-instantly / grant-after-window / denial-doesn't-advance-window) — deterministic, no real sleeps.
- `_maybe_rerank` branches: breaker-open short-circuits before the gate, gate-denied never calls Voyage, success → `record_success`, timeout → `record_failure(TIMEOUT)` only, empty-return → no breaker signal, kill-switch None/None → byte-parity.
- **Integration with REAL `ProviderRateGate` + `CircuitBreaker`** (not mocks): the real gate denies the 2nd call within the interval; the real breaker trips OPEN after 3 consecutive timeouts and then skips without calling Voyage.
- Extended the two-retriever wiring guard to pin the MCP retriever receives the gate + breaker.

Full recall + routing regression green locally (387 tests). The live 7× probe (expect `rerank_skipped_ratelimited` to climb and the 429 WARN rate to drop toward zero) is **deploy-gated** — deploy currently held.

Follow-up: ac27b693

🤖 Generated with [Claude Code](https://claude.com/claude-code)