### PR TITLE
feat(cc): rate-limit auto-resume engine + flip to live (PR-2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   vanished). Long results arrive as a short summary plus a saved file rather than
   a wall of messages. Failures are reported in the same thread instead of
   disappearing.
+- **When Genesis hits a usage/rate limit, your request comes back on its own.**
+  Previously, hitting the limit dropped the work — and the message you got even
+  claimed "background tasks will resume automatically" when nothing would. Now
+  the request is saved the moment the limit is hit, and Genesis automatically
+  picks it back up once the limit resets and delivers the answer to the same
+  conversation. If capacity keeps being exhausted it backs off and eventually
+  tells you it needs a hand rather than retrying forever. (This closes the
+  other half of the 2026-07-20 disappearance.)
 
 ### Changed
 

--- a/config/cc_rate_limit_resume.yaml
+++ b/config/cc_rate_limit_resume.yaml
@@ -1,5 +1,4 @@
-# Rate-limit park + auto-resume — writable, DORMANT (off) by default until the
-# resume engine lands.
+# Rate-limit park + auto-resume — writable, LIVE by default.
 #
 # When a CC session hits a rate/usage limit, the work is PARKED durably
 # (cc_rate_limit_parks) and a CronTrigger job re-dispatches the actual parked
@@ -25,11 +24,7 @@ enabled: true
 #
 # Hook/env kill switch (separate lever): GENESIS_RATE_LIMIT_RESUME_DISABLED=1
 # forces the resumer to no-op regardless of this file.
-#
-# DORMANT until the resume engine is wired (PR-2b): with no resumer, `live`/
-# `propose_only` would promise a resume nothing delivers. PR-2b flips this to
-# `live`. Until then `off` parks nothing and shows an honest "try again later".
-mode: off
+mode: live
 
 # Retry cadence (minutes) when the reset time could not be parsed (e.g. a
 # day-ambiguous weekly limit) — the park is retried on this floor instead.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -198,10 +198,13 @@ verified: 3c5e1f24 2026-07-22
   reachable. Gate posture: a resume completes already-approved work (a foreground prompt,
   or an already-gated dispatch), so it is not new autonomous initiative. Reflection-bridge
   and the task executor deliberately do NOT park (periodic self-retry / already durable via
-  `task_states`). Lever `cc_rate_limit_resume` (off|propose_only|live) +
-  `GENESIS_RATE_LIMIT_RESUME_DISABLED`; **default `off` (dormant) until PR-2b
-  wires the resume engine, then flipped to `live`** — shipping the park substrate
-  inert avoids promising a resume nothing yet delivers.
+  `task_states`). Resume engine (`cc/rate_limit_resume.py`, `_wire_rate_limit_resume`
+  on the learning scheduler, `CronTrigger */10`): reclaims stale claims → lists due
+  parks → claims + re-dispatches each via the queue (`delivery_mode=result`); the
+  re-run self-validates (re-limit → its own catch re-parks with backoff); exhausted
+  parks escalate to `needs_user` with a governed (`rate_limit_park` signal) alert.
+  Lever `cc_rate_limit_resume` (off|propose_only|**live**, default live) +
+  `GENESIS_RATE_LIMIT_RESUME_DISABLED`.
 
 ## 3. Autonomy & egress gating
 

--- a/src/genesis/cc/rate_limit_resume.py
+++ b/src/genesis/cc/rate_limit_resume.py
@@ -1,0 +1,188 @@
+"""Rate-limit resume engine — re-dispatch parked CC work at its reset time.
+
+The PR-2b consumer of the ``cc_rate_limit_parks`` substrate. On a CronTrigger
+tick it reclaims stale claims, finds due parks, and (in ``live`` mode) claims and
+re-dispatches each one's actual work through the direct-session queue with
+``delivery_mode="result"`` — so the finished answer is delivered back to its
+origin conversation via the shipped #1192 delivery path.
+
+**No probe.** Subscription budgets are per-model-tier, so a cheap probe can't
+gate an expensive resume — the re-run IS the probe. A still-limited retry hits
+the same rate limit, and its background catch (``rate_limit_park``) re-limits the
+SAME park in place (attempts+1, backoff), so the ``needs_user`` escalation stays
+reachable. The park row is resolved by id via ``caller_context`` — the engine
+never marks a park ``resumed`` itself; the retry's own outcome does.
+
+**Gate posture.** A resume only completes work whose initiation was ALREADY
+approved: a foreground turn (the user's typed prompt) or a direct_session that
+already passed the autonomous-CLI approval gate at its original dispatch. It
+creates no new ungated work, so it does not re-enter ``AutonomousCliApprovalGate``.
+The resumed session runs under a bounded profile (never exceeding the origin
+turn's surface). Master gate: ``cc_rate_limit_resume`` mode + the
+``GENESIS_RATE_LIMIT_RESUME_DISABLED`` kill switch.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from genesis.cc import rate_limit_park as park_helpers
+from genesis.cc import rate_limit_resume_config as cfg_mod
+from genesis.db.crud import cc_rate_limit_parks as parks
+from genesis.db.crud import direct_session_queue
+
+logger = logging.getLogger("genesis.cc.rate_limit_resume")
+
+# Reclaim a park stuck 'resuming' longer than this (retry lost to a crash/restart
+# between claim and outcome). 2h > the 1h direct_session timeout, so a live retry
+# is never yanked out from under itself.
+_STALE_RESUMING_S = 7200
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+async def _redispatch(db, park: dict) -> None:
+    """Re-enqueue a parked unit of work as a RESULT-delivering direct session."""
+    payload = json.loads(park["payload_json"])
+    await direct_session_queue.enqueue(
+        db,
+        prompt=payload.get("prompt", ""),
+        profile=payload.get("profile", "research"),
+        model=payload.get("model", "sonnet"),
+        effort=payload.get("effort", "high"),
+        timeout_s=int(payload.get("timeout_s", 3600)),
+        roster_model=payload.get("roster_model"),
+        notify=False,
+        notify_on_failure_only=False,
+        delivery_mode="result",
+        origin_session_id=park["origin_session_id"],
+        caller_context=f"{park_helpers._RESUME_PREFIX}{park['id']}",
+    )
+
+
+async def _alert(rt, *, topic: str, context: str) -> None:
+    """Governed (deduped) owner alert — best-effort, never breaks a tick."""
+    pipeline = getattr(rt, "_outreach_pipeline", None)
+    if pipeline is None:
+        return
+    try:
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        await pipeline.submit(
+            OutreachRequest(
+                category=OutreachCategory.ALERT,
+                topic=topic,
+                context=context,
+                salience_score=0.85,
+                signal_type="rate_limit_park",
+                channel="telegram",
+                verbatim=True,
+            )
+        )
+    except Exception:
+        logger.warning("rate_limit_resume alert failed", exc_info=True)
+
+
+def _safe_prompt(payload_json: str) -> str:
+    """Best-effort prompt from a park payload — never raises (a corrupt row must
+    not sink the whole tick)."""
+    try:
+        return str(json.loads(payload_json).get("prompt", ""))[:200]
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return ""
+
+
+async def _escalate_needs_user(rt, db) -> None:
+    """One deduped alert per park that has exhausted auto-resume attempts.
+
+    Each park is isolated: a single corrupt row (bad payload_json, alert failure)
+    must not abort the tick before the due-park loop runs (that would recur every
+    10 min and block ALL resumes)."""
+    stuck = await parks.list_by_status(db, status="needs_user", limit=50)
+    for park in stuck:
+        try:
+            await _alert(
+                rt,
+                topic=f"Rate limit park {park['id']}",
+                context=(
+                    "A rate-limited request could not be auto-resumed after "
+                    f"{park['attempts']} attempts and needs you. Original prompt: "
+                    f"{_safe_prompt(park['payload_json'])}"
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "needs_user escalation failed for park %s", park.get("id"), exc_info=True
+            )
+
+
+async def run_resume_tick(rt, *, now: datetime | None = None) -> None:
+    """One resume pass. Injectable ``now`` for deterministic tests."""
+    now = now or datetime.now(UTC)
+    db = getattr(rt, "_db", None)
+    if db is None:
+        return
+    try:
+        # Always reclaim stale claims first — even in off/propose_only, a park
+        # stranded 'resuming' by a restart must return to 'parked'.
+        await parks.recover_stale_resuming(db, max_age_s=_STALE_RESUMING_S)
+
+        mode = cfg_mod.effective_mode()
+        if mode == "off":
+            rt.record_job_success("rate_limit_resume")
+            return
+
+        # Surface parks that gave up, regardless of live/propose_only.
+        await _escalate_needs_user(rt, db)
+
+        cfg = cfg_mod.load_config()
+        due = await parks.list_due(
+            db, now=_iso(now), limit=cfg_mod.knob_int(cfg, "max_due_per_tick")
+        )
+        if not due:
+            rt.record_job_success("rate_limit_resume")
+            return
+
+        if mode == "propose_only":
+            await _alert(
+                rt,
+                topic="Rate limit parks ready",
+                context=(
+                    f"{len(due)} rate-limited request(s) are parked and ready to "
+                    "resume. Set cc_rate_limit_resume mode to 'live' to auto-resume "
+                    "and deliver them."
+                ),
+            )
+            rt.record_job_success("rate_limit_resume")
+            return
+
+        # live: claim + re-dispatch each due park.
+        dispatched = 0
+        for park in due:
+            if not await parks.claim(db, park["id"]):
+                continue  # another tick/instance won the claim
+            try:
+                await _redispatch(db, park)
+                dispatched += 1
+            except Exception:
+                # Dispatch failed (queue/db) — re-open with backoff so it retries
+                # rather than stranding in 'resuming'.
+                logger.error("Re-dispatch failed for park %s", park["id"], exc_info=True)
+                attempts = park["attempts"] + 1
+                await parks.relimit(
+                    db,
+                    park["id"],
+                    reset_at=park["reset_at"],
+                    next_attempt_at=park_helpers.backoff_next_attempt(attempts, now, cfg),
+                    needs_user_at_attempts=cfg_mod.knob_int(cfg, "needs_user_attempts"),
+                )
+        if dispatched:
+            logger.info("rate_limit_resume: re-dispatched %d/%d due park(s)", dispatched, len(due))
+        rt.record_job_success("rate_limit_resume")
+    except Exception as exc:  # noqa: BLE001 — job boundary
+        rt.record_job_failure("rate_limit_resume", str(exc))
+        logger.exception("rate_limit_resume tick failed")

--- a/src/genesis/cc/rate_limit_resume_config.py
+++ b/src/genesis/cc/rate_limit_resume_config.py
@@ -8,15 +8,14 @@ Failure posture: a missing/corrupt config degrades to DEFAULTS; an invalid
 switch ``GENESIS_RATE_LIMIT_RESUME_DISABLED=1`` forces ``off`` regardless of the
 file — an operator's emergency brake against unattended re-dispatch.
 
-Default mode is ``off`` (DORMANT) until the resume engine lands (PR-2b): with no
-resumer wired, a parked request would sit ``status='parked'`` forever while the
-foreground copy promised auto-resume — recreating the very silent-death this
-fixes. Shipping the park substrate off-by-default (like the reaper's dry-run /
-entity-adjudication's shadow) keeps PR-2a inert-but-observable; PR-2b flips the
-default to ``live``. Once ``live``: a resume only completes work whose initiation
-was already user-approved (a foreground turn's typed prompt) or already
-gate-approved (a direct_session's original dispatch), so it is not new autonomous
-initiative — see ``rate_limit_resume`` module docstring.
+Default mode is ``live`` (auto-resume): the resume engine (``rate_limit_resume``)
+re-dispatches parked work at its reset time and delivers the result to origin. A
+resume only completes work whose initiation was already user-approved (a
+foreground turn's typed prompt) or already gate-approved (a direct_session's
+original dispatch), so it is not new autonomous initiative and does not re-enter
+``AutonomousCliApprovalGate`` — see the ``rate_limit_resume`` module docstring.
+(PR-2a shipped this off-by-default while the resumer did not yet exist; PR-2b
+wires it and flips the default here.)
 
 Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
 ``genesis.mcp.health.settings`` imports the public ``MODES`` and ``INT_KNOBS``
@@ -46,9 +45,7 @@ _ENV_KILL_SWITCH = "GENESIS_RATE_LIMIT_RESUME_DISABLED"
 
 DEFAULTS: dict[str, Any] = {
     "enabled": True,
-    # DORMANT until PR-2b wires the resume engine — see module docstring. PR-2b
-    # flips this to "live". off → parks nothing, honest "try again later" copy.
-    "mode": "off",
+    "mode": "live",
     # Scheduling
     "cadence_floor_minutes": 30,  # retry cadence when the reset time is unknown
     "backoff_base_minutes": 30,  # re-limit backoff base

--- a/src/genesis/db/crud/cc_rate_limit_parks.py
+++ b/src/genesis/db/crud/cc_rate_limit_parks.py
@@ -104,6 +104,24 @@ async def list_due(
     return [dict(r) for r in rows]
 
 
+async def list_by_status(
+    db: aiosqlite.Connection,
+    *,
+    status: str,
+    limit: int = 50,
+) -> list[dict]:
+    """Parks in a given status. Oldest first."""
+    cursor = await db.execute(
+        """SELECT * FROM cc_rate_limit_parks
+           WHERE status = ?
+           ORDER BY created_at
+           LIMIT ?""",
+        (status, limit),
+    )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
 async def claim(db: aiosqlite.Connection, park_id: str) -> bool:
     """Atomically claim a due park (parked→resuming). True iff this caller won."""
     now = _now()

--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -67,6 +67,9 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "mail_follow_up": 24,  # Follow-up emails — one per day max per topic
     "discord_poll": 168,  # Discord polls — 7 days (matches default poll duration)
     "j9_regression_alert": 168,  # Weekly eval regressions — one alert/week max
+    # Rate-limit park alerts (needs_user escalation per park-topic; propose_only
+    # "ready" ping on a fixed topic) — re-remind at most twice a day.
+    "rate_limit_park": 12,
 }
 _DEFAULT_DEDUP_HOURS = 24
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from genesis.env import cc_project_dir, user_timezone
 from genesis.runtime.init.process_reaper import _wire_process_reaper
+from genesis.runtime.init.rate_limit_resume import _wire_rate_limit_resume
 
 if TYPE_CHECKING:
     from genesis.runtime._core import GenesisRuntime
@@ -1282,6 +1283,10 @@ async def init(rt: GenesisRuntime) -> None:
         # policy — activity markers + live-terminal gate, dry-run→auto-arm).
         # Extracted to a testable seam; see process_reaper.py.
         _wire_process_reaper(rt._learning_scheduler, rt)
+
+        # Rate-limit resume engine (re-dispatch parked CC work at reset; gated
+        # per-tick by cc_rate_limit_resume mode). Testable seam; CronTrigger */10.
+        _wire_rate_limit_resume(rt._learning_scheduler, rt)
 
         # ── Skill evolution pipeline (weekly backup trigger) ────────────────
         async def _run_skill_evolution() -> None:

--- a/src/genesis/runtime/init/rate_limit_resume.py
+++ b/src/genesis/runtime/init/rate_limit_resume.py
@@ -1,0 +1,25 @@
+"""Wire the rate-limit resume engine onto the learning scheduler.
+
+CronTrigger (not IntervalTrigger): IntervalTrigger resets on server restart, so
+a frequently-restarting server would never fire it. Every 10 minutes, gated per
+tick by ``cc_rate_limit_resume`` mode (off/propose_only/live).
+"""
+
+from __future__ import annotations
+
+from genesis.cc.rate_limit_resume import run_resume_tick
+
+
+def _wire_rate_limit_resume(scheduler, rt) -> None:
+    from apscheduler.triggers.cron import CronTrigger
+
+    async def _tick() -> None:
+        await run_resume_tick(rt)
+
+    scheduler.add_job(
+        _tick,
+        CronTrigger(minute="*/10"),
+        id="rate_limit_resume",
+        max_instances=1,
+        misfire_grace_time=600,
+    )

--- a/tests/test_cc/test_rate_limit_resume.py
+++ b/tests/test_cc/test_rate_limit_resume.py
@@ -1,0 +1,201 @@
+"""Tests for the rate-limit resume engine (rate_limit_resume.run_resume_tick).
+
+Covers mode gating (off/propose_only/live), due-park claim + re-dispatch with the
+RESULT+origin+caller_context contract, dispatch-failure re-park, needs_user
+escalation alert, stale-resuming recovery, and empty-state no-op. Real in-memory
+db; fake runtime with a mocked outreach pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from genesis.cc.rate_limit_resume import run_resume_tick
+from genesis.db.crud import cc_rate_limit_parks as parks
+from genesis.db.crud import direct_session_queue as dsq
+
+NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=UTC)
+PAST = "2026-07-22T10:00:00+00:00"
+
+
+def _rt(db):
+    rt = MagicMock()
+    rt._db = db
+    rt._outreach_pipeline = MagicMock()
+    rt._outreach_pipeline.submit = AsyncMock()
+    rt.record_job_success = MagicMock()
+    rt.record_job_failure = MagicMock()
+    return rt
+
+
+async def _seed_due(db, *, prompt="do the thing", origin="orig1", dedup="k"):
+    return await parks.upsert_open_park(
+        db,
+        kind="direct_session",
+        dedup_key=dedup,
+        payload={
+            "prompt": prompt,
+            "profile": "research",
+            "model": "sonnet",
+            "effort": "high",
+            "timeout_s": 3600,
+            "roster_model": None,
+        },
+        origin_session_id=origin,
+        limit_kind="session",
+        raw_signal=None,
+        reset_at=None,
+        next_attempt_at=PAST,
+    )
+
+
+def _force(monkeypatch, mode):
+    monkeypatch.setattr("genesis.cc.rate_limit_resume_config.effective_mode", lambda: mode)
+
+
+async def test_live_redispatches_due_park_with_result_contract(db, monkeypatch):
+    _force(monkeypatch, "live")
+    rt = _rt(db)
+    pid = await _seed_due(db)
+    await run_resume_tick(rt, now=NOW)
+    # park is claimed (resuming) — engine does NOT mark resumed; the retry does.
+    assert (await parks.get_by_id(db, pid))["status"] == "resuming"
+    # exactly one queue row, carrying the delivery contract.
+    q = await dsq.claim_next(db)
+    assert q is not None
+    payload = json.loads(q["payload_json"])
+    assert payload["delivery_mode"] == "result"
+    assert payload["origin_session_id"] == "orig1"
+    assert payload["caller_context"] == f"rate_limit_resume:{pid}"
+    assert payload["prompt"] == "do the thing"
+    assert payload["profile"] == "research"
+    rt.record_job_success.assert_called_with("rate_limit_resume")
+
+
+async def test_off_mode_does_not_dispatch(db, monkeypatch):
+    _force(monkeypatch, "off")
+    rt = _rt(db)
+    pid = await _seed_due(db)
+    await run_resume_tick(rt, now=NOW)
+    assert (await parks.get_by_id(db, pid))["status"] == "parked"
+    assert await dsq.count_pending(db) == 0
+    rt.record_job_success.assert_called_with("rate_limit_resume")
+
+
+async def test_propose_only_alerts_without_dispatch(db, monkeypatch):
+    _force(monkeypatch, "propose_only")
+    rt = _rt(db)
+    pid = await _seed_due(db)
+    await run_resume_tick(rt, now=NOW)
+    assert (await parks.get_by_id(db, pid))["status"] == "parked"
+    assert await dsq.count_pending(db) == 0
+    rt._outreach_pipeline.submit.assert_awaited()  # "ready to resume" ping
+
+
+async def test_empty_state_no_op(db, monkeypatch):
+    _force(monkeypatch, "live")
+    rt = _rt(db)
+    await run_resume_tick(rt, now=NOW)
+    assert await dsq.count_pending(db) == 0
+    rt.record_job_success.assert_called_with("rate_limit_resume")
+
+
+async def test_dispatch_failure_reparks_not_stranded(db, monkeypatch):
+    _force(monkeypatch, "live")
+    monkeypatch.setattr(
+        "genesis.cc.rate_limit_resume.direct_session_queue.enqueue",
+        AsyncMock(side_effect=RuntimeError("queue down")),
+    )
+    rt = _rt(db)
+    pid = await _seed_due(db)
+    await run_resume_tick(rt, now=NOW)
+    row = await parks.get_by_id(db, pid)
+    # Re-opened for retry (not stranded in 'resuming'), attempts incremented.
+    assert row["status"] == "parked"
+    assert row["attempts"] == 1
+    rt.record_job_success.assert_called_with("rate_limit_resume")
+
+
+async def test_needs_user_parks_escalate_alert(db, monkeypatch):
+    _force(monkeypatch, "live")
+    rt = _rt(db)
+    pid = await _seed_due(db)
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET status='needs_user' WHERE id=?",
+        (pid,),
+    )
+    await db.commit()
+    await run_resume_tick(rt, now=NOW)
+    # An alert fired referencing the stuck park.
+    rt._outreach_pipeline.submit.assert_awaited()
+    call = rt._outreach_pipeline.submit.call_args[0][0]
+    assert call.signal_type == "rate_limit_park"
+
+
+async def test_stale_resuming_reclaimed_each_tick(db, monkeypatch):
+    _force(monkeypatch, "off")  # off so we isolate the recovery step
+    rt = _rt(db)
+    pid = await _seed_due(db)
+    await parks.claim(db, pid)
+    # Backdate the claim so it's stale.
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET claimed_at='2000-01-01T00:00:00+00:00' WHERE id=?",
+        (pid,),
+    )
+    await db.commit()
+    await run_resume_tick(rt, now=NOW)
+    assert (await parks.get_by_id(db, pid))["status"] == "parked"
+
+
+async def test_tick_failure_records_job_failure(db, monkeypatch):
+    _force(monkeypatch, "live")
+    monkeypatch.setattr(
+        "genesis.cc.rate_limit_resume.parks.list_due",
+        AsyncMock(side_effect=RuntimeError("db exploded")),
+    )
+    rt = _rt(db)
+    await _seed_due(db)
+    await run_resume_tick(rt, now=NOW)  # must not raise
+    rt.record_job_failure.assert_called()
+
+
+async def test_corrupt_needs_user_park_does_not_block_tick(db, monkeypatch):
+    """A needs_user park with malformed payload_json must not abort the tick
+    before the due-park loop runs (else it recurs every 10 min forever)."""
+    _force(monkeypatch, "live")
+    rt = _rt(db)
+    # A corrupt needs_user park (bad JSON payload).
+    bad = await _seed_due(db, dedup="bad", origin="o-bad")
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET status='needs_user', payload_json='{not json' WHERE id=?",
+        (bad,),
+    )
+    await db.commit()
+    # A healthy due park that must still be resumed this tick.
+    good = await _seed_due(db, dedup="good", origin="o-good", prompt="run me")
+    await run_resume_tick(rt, now=NOW)  # must not raise
+    # The healthy park was claimed + dispatched despite the corrupt one.
+    assert (await parks.get_by_id(db, good))["status"] == "resuming"
+    assert await dsq.count_pending(db) == 1
+    rt.record_job_success.assert_called_with("rate_limit_resume")
+    rt.record_job_failure.assert_not_called()
+
+
+async def test_wire_rate_limit_resume_registers_job():
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from apscheduler.triggers.cron import CronTrigger
+
+    from genesis.runtime.init.rate_limit_resume import _wire_rate_limit_resume
+
+    sched = AsyncIOScheduler()
+    _wire_rate_limit_resume(sched, MagicMock())
+    sched.start(paused=True)
+    try:
+        job = sched.get_job("rate_limit_resume")
+        assert job is not None
+        assert isinstance(job.trigger, CronTrigger)
+        assert job.max_instances == 1
+    finally:
+        sched.shutdown(wait=False)


### PR DESCRIPTION
## What & why

Stacked on **#1210** (PR-2a, the park substrate). PR-2a parks rate-limited CC work durably but ships **dormant** (`mode: off`) because no resumer existed. PR-2b adds the resumer and **flips the default to `live`**, closing the rate-limit half of the 2026-07-20 silent-death: a rate-limited request is now parked, automatically re-dispatched at reset, and delivered back to its origin conversation.

## What's in this PR

- **`cc/rate_limit_resume.py`** — a `CronTrigger */10` engine (registered on the learning scheduler, `max_instances=1`, `misfire_grace_time=600`). Per tick, gated by `cc_rate_limit_resume` mode: reclaim stale `resuming` claims → list due parks → **(live)** claim + re-dispatch the *actual* parked work via `direct_session_queue.enqueue(delivery_mode="result", origin_session_id=…, caller_context="rate_limit_resume:<park_id>")`.
- **No probe.** Subscription budgets are per-model-tier, so a cheap probe can't gate an expensive resume — the re-run *is* the probe. A still-limited retry re-limits its **own** park in place (attempts+1, backoff) via PR-2a's background catch, so the `needs_user` escalation stays reachable. The engine never marks a park `resumed` — the retry's outcome does (success → `mark_resumed_if_lineage`; re-limit → `relimit`). A dispatch failure re-opens the park with backoff (never stranded in `resuming`).
- **Notifications:** `needs_user` (auto-resume gave up) → governed, deduped owner alert (`rate_limit_park` signal + new `_DEDUP_WINDOWS` entry). `propose_only` → deduped "ready to resume" ping, no auto-dispatch.
- **Gate posture:** a resume only completes work whose initiation was already approved (a foreground prompt, or a `direct_session` already gated at original dispatch) — not new autonomous initiative, so it does **not** re-enter `AutonomousCliApprovalGate` (documented in the engine docstring).
- Flips `cc_rate_limit_resume` default **off→live** (config + yaml); restores the user-facing CHANGELOG entry.

## Testing

- 9 engine/registration tests (mode-gating; claim + RESULT/origin/caller_context re-dispatch; dispatch-failure re-park; `needs_user` escalation; stale recovery; empty no-op; job-failure recording; CronTrigger registration). 76-test sweep across the rate-limit + governance suites green; 0 lint errors.
- Full **park → resume → deliver E2E** to run post-deploy.

`Ledger: ee391fbd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)