### PR TITLE
feat(observability): alert when ambient auto-recovery can't restore a dark device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Ambient capture now alerts when auto-recovery can't bring a wedged device
+  back.** For installs running the optional voice/ambient edge with device
+  auto-recovery armed, Genesis now raises a capture-health alert when the device
+  has been dark for hours *and* the automatic reboots failed to restore it — the
+  one case that means a real fault rather than a device simply being switched off.
+  Installs without auto-recovery are unchanged: a merely-absent device still never
+  alerts (nothing on the network distinguishes "unplugged" from "crashed", so the
+  signal fires only where arming recovery already asserts the device should be up).
+  The alert names how long it's been dark and how many reboot attempts failed, with
+  no device address or key ever included.
+
 - **When Genesis hands a long task off to run in the background and says "I'll
   report back," it now actually does.** Ask for something heavy from Telegram — a
   deep research run, a long analysis — and Genesis can dispatch it to a background

--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -171,12 +171,18 @@ def evaluate_ambient_health(
       (the bridge process is dead/hung — it stopped writing the health file).
     - ``diar_worker_alive`` False while ``diar_enabled`` -> ``degraded`` (the
       diarization worker crashed).
+    - ``recovery_failing`` True -> ``degraded`` (the edge auto-recovery is armed,
+      engaged, and STILL could not restore the device). This is the ONE darkness
+      signal we act on, and only because it is self-selecting: it is emitted solely
+      when the operator ARMED auto-recovery (asserting the device is expected up).
     - otherwise -> ``ok`` — INCLUDING when the device is offline
       (``active_connections == 0``): an absent device is not a software bug.
 
-    Deliberately does NOT consider ``active_connections`` or ``last_ts``: a device
-    that is unplugged/idle, or a quiet room with no recent utterance, is normal —
-    not a fault to alert on.
+    Deliberately does NOT consider ``active_connections`` or ``last_ts`` on their own:
+    a device that is unplugged/idle, or a quiet room with no recent utterance, is
+    normal — not a fault to alert on. Sustained darkness alone is NOT alerted (no
+    network signal distinguishes "unplugged" from "crashed"); only ``recovery_failing``
+    (which encodes the operator's always-on intent) crosses that line.
     """
     if data is None:
         return AmbientVerdict(
@@ -225,6 +231,33 @@ def evaluate_ambient_health(
             causes.append(cause)
             if status == "ok":
                 status = "degraded"
+
+    # Recovery-failing: the edge auto-recovery is armed, engaged, and the device is
+    # STILL dark long after recovery gave up (past recovery_seen_window). This is the
+    # ONE ambient-darkness signal that distinguishes a real fault from a merely-absent
+    # device — it fires ONLY when someone ARMED auto-recovery (asserting the device is
+    # expected up) and recovery could not restore it. On installs without recovery armed
+    # the field is never emitted, so an absent/off device stays silent (the "never alert
+    # on an absent device" invariant, docstring above, is preserved). Only upgrades
+    # ok -> degraded (bridge alive, capture impaired); a dead bridge stays "down" with
+    # the reason still appended.
+    if data.get("recovery_failing") is True:
+        count = data.get("failed_reboot_count")
+        since = data.get("device_dark_since")
+        err = data.get("last_reboot_error")
+        detail = (
+            f"{count} reboot attempt(s) failed"
+            if isinstance(count, int)
+            else "reboot attempts failed"
+        )
+        if since:
+            detail += f", dark since {since}"
+        if err:
+            detail += f" (last error: {err})"
+        reasons.append(f"auto-recovery exhausted — {detail}")
+        causes.append("recovery-failing")
+        if status == "ok":
+            status = "degraded"
 
     if status == "ok":
         reasons.append("healthy")

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -603,11 +603,18 @@ class OutreachScheduler:
     def _ambient_remedy_hint(causes: tuple[str, ...]) -> str:
         """Cause-aware remediation line for the ambient alert (worst cause wins).
 
-        "degraded" is a multi-cause bucket (dead diar worker, RSS regression) —
-        a fixed "process down/hung" suffix misdiagnoses a live-but-leaking bridge.
+        "degraded" is a multi-cause bucket (dead diar worker, RSS regression,
+        auto-recovery exhausted) — a fixed "process down/hung" suffix misdiagnoses a
+        live-but-leaking bridge. Precedence: bridge-dead > recovery-failing > diar >
+        rss (most-specific/actionable wins).
         """
         if "bridge-dead" in causes:
             return "(ambient bridge process down/hung — check/restart ambient-bridge.service)"
+        if "recovery-failing" in causes:
+            return (
+                "(auto-recovery exhausted — the device is dark and reboot attempts failed; "
+                "check the device's power/network or the ESPHome API on the Voice PE)"
+            )
         if "diar-worker" in causes:
             return "(diarization worker crashed — a bridge restart respawns it: systemctl --user restart ambient-bridge)"
         if "rss-total" in causes or "rss-diar-child" in causes:

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -4,6 +4,7 @@ Covers the alert-decision logic (the testable core) and ``bridge_snapshot``'s
 composition/contract; the SSH read + scheduler wiring are verified on-device
 (they need the edge + a running scheduler).
 """
+
 import asyncio
 from datetime import UTC, datetime, timedelta
 
@@ -61,7 +62,8 @@ def test_device_offline_does_not_mask_software_failure():
     # A real software failure (dead diar worker) still fires even if the device
     # happens to be offline at the same time.
     verdict = evaluate_ambient_health(
-        _snapshot(active_connections=0, diar_worker_alive=False), now=NOW,
+        _snapshot(active_connections=0, diar_worker_alive=False),
+        now=NOW,
     )
     assert verdict.status == "degraded"
 
@@ -256,7 +258,8 @@ def test_rss_breach_does_not_mask_down():
     # the RSS reason is still appended for the operator.
     stale = (NOW - timedelta(minutes=10)).isoformat()
     verdict = evaluate_ambient_health(
-        _snapshot(ts=stale, rss_total_mb=1200.0), now=NOW,
+        _snapshot(ts=stale, rss_total_mb=1200.0),
+        now=NOW,
     )
     assert verdict.status == "down"
     assert any("RSS" in r for r in verdict.reasons)
@@ -271,10 +274,12 @@ def test_causes_are_stable_machine_keys():
     stale = (NOW - timedelta(minutes=10)).isoformat()
     assert evaluate_ambient_health(_snapshot(ts=stale), now=NOW).causes == ("bridge-dead",)
     assert evaluate_ambient_health(
-        _snapshot(diar_worker_alive=False), now=NOW,
+        _snapshot(diar_worker_alive=False),
+        now=NOW,
     ).causes == ("diar-worker",)
     verdict = evaluate_ambient_health(
-        _snapshot(rss_total_mb=1200.0, rss_diar_child_mb=600.0), now=NOW,
+        _snapshot(rss_total_mb=1200.0, rss_diar_child_mb=600.0),
+        now=NOW,
     )
     assert verdict.causes == ("rss-total", "rss-diar-child")
 
@@ -289,3 +294,80 @@ def test_bridge_snapshot_carries_causes(monkeypatch):
     monkeypatch.setattr(ambient_health, "read_edge_health", _data)
     out = asyncio.run(ambient_health.bridge_snapshot(now=NOW))
     assert out["causes"] == ["rss-total"]
+
+
+# --- recovery_failing: the ONE darkness signal we act on (armed auto-recovery could
+# not restore the device). Fires ONLY when the edge emits recovery_failing=True, which
+# only happens on a recovery-armed install — so an unarmed/off device stays silent. ---
+
+
+def test_recovery_failing_is_degraded_with_cause():
+    verdict = evaluate_ambient_health(
+        _snapshot(
+            active_connections=0,
+            recovery_failing=True,
+            failed_reboot_count=3,
+            device_dark_since="2026-06-18T06:00:00+00:00",
+            last_reboot_error="TimeoutError",
+        ),
+        now=NOW,
+    )
+    assert verdict.status == "degraded"
+    assert verdict.causes == ("recovery-failing",)
+    reason = " ".join(verdict.reasons)
+    assert "auto-recovery exhausted" in reason
+    assert "3 reboot attempt" in reason
+    assert "2026-06-18T06:00:00+00:00" in reason
+    assert "TimeoutError" in reason
+
+
+def test_recovery_failing_false_is_ok():
+    # Recovery armed but not failing (device present, or dark but within the recovery
+    # window) must NOT alert — same as today.
+    assert evaluate_ambient_health(_snapshot(recovery_failing=False), now=NOW).status == "ok"
+
+
+def test_recovery_failing_absent_is_ok():
+    # An edge build without recovery armed never emits the field → unchanged (the
+    # "never alert on an absent device" invariant holds by default).
+    assert evaluate_ambient_health(_snapshot(active_connections=0), now=NOW).status == "ok"
+
+
+def test_recovery_failing_with_missing_detail_fields_still_degrades():
+    # recovery_failing=True with no count/since/error still degrades with a bare reason
+    # (defensive: an older/partial edge payload must not crash the evaluator).
+    verdict = evaluate_ambient_health(_snapshot(recovery_failing=True), now=NOW)
+    assert verdict.status == "degraded"
+    assert verdict.causes == ("recovery-failing",)
+    assert any("auto-recovery exhausted" in r for r in verdict.reasons)
+
+
+def test_recovery_failing_does_not_mask_dead_bridge():
+    # A dead bridge (stale heartbeat) stays "down" even when recovery is also failing;
+    # the recovery reason is still appended for the operator.
+    stale = (NOW - timedelta(minutes=10)).isoformat()
+    verdict = evaluate_ambient_health(
+        _snapshot(ts=stale, recovery_failing=True, failed_reboot_count=1),
+        now=NOW,
+    )
+    assert verdict.status == "down"
+    assert "bridge-dead" in verdict.causes
+    assert "recovery-failing" in verdict.causes
+    assert any("auto-recovery exhausted" in r for r in verdict.reasons)
+
+
+def test_recovery_failing_coexists_with_diar_worker():
+    # Two independent degraded causes both surface (the scheduler re-alerts on a NEW
+    # cause via the value-free cause keys).
+    verdict = evaluate_ambient_health(
+        _snapshot(active_connections=0, diar_worker_alive=False, recovery_failing=True),
+        now=NOW,
+    )
+    assert verdict.status == "degraded"
+    assert set(verdict.causes) == {"diar-worker", "recovery-failing"}
+
+
+def test_recovery_failing_truthy_non_true_does_not_fire():
+    # Strict `is True` gate: a truthy-but-not-True value (e.g. 1) must NOT trip it,
+    # matching the diar/RSS guards' explicitness.
+    assert evaluate_ambient_health(_snapshot(recovery_failing=1), now=NOW).status == "ok"

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -524,3 +524,49 @@ async def test_ambient_rss_alert_text_names_leak_not_down(config, db):
     text = scheduler._pipeline.submit_raw.call_args[0][0]
     assert "down/hung" not in text  # the bridge is alive — don't misdiagnose
     assert "RSS" in text
+
+
+@pytest.mark.parametrize(
+    ("causes", "expected"),
+    [
+        (("bridge-dead",), "ambient-bridge.service"),
+        (("recovery-failing",), "auto-recovery exhausted"),
+        (("diar-worker",), "diarization worker"),
+        (("rss-total",), "leak regression"),
+        (("rss-diar-child",), "leak regression"),
+        ((), "journalctl"),  # default fallback when no known cause
+    ],
+)
+def test_ambient_remedy_hint_per_cause(causes, expected):
+    assert expected in OutreachScheduler._ambient_remedy_hint(causes)
+
+
+def test_ambient_remedy_hint_precedence():
+    # bridge-dead outranks recovery-failing; recovery-failing outranks diar/rss.
+    assert "ambient-bridge.service" in OutreachScheduler._ambient_remedy_hint(
+        ("bridge-dead", "recovery-failing")
+    )
+    assert "auto-recovery exhausted" in OutreachScheduler._ambient_remedy_hint(
+        ("recovery-failing", "diar-worker", "rss-total")
+    )
+
+
+@pytest.mark.asyncio
+async def test_ambient_recovery_failing_alerts_with_remedy(config, db):
+    # End-to-end job path: a recovery_failing snapshot degrades and alerts, and the
+    # alert text carries both the reason and the recovery-failing remedy hint.
+    scheduler = _make_scheduler(config, db)
+    await _ambient_tick(
+        scheduler,
+        _ambient_snapshot(
+            active_connections=0,
+            recovery_failing=True,
+            failed_reboot_count=2,
+            device_dark_since="2026-06-18T06:00:00+00:00",
+            last_reboot_error="ConnectionError",
+        ),
+    )
+    scheduler._pipeline.submit_raw.assert_called_once()
+    text = scheduler._pipeline.submit_raw.call_args[0][0]
+    assert "auto-recovery exhausted" in text
+    assert "ESPHome API" in text  # the recovery-failing remedy hint


### PR DESCRIPTION
## What

The ambient-capture health monitor now raises a `degraded` alert when the edge
bridge reports `recovery_failing` — i.e. auto-recovery is armed, has engaged, and
still could not bring a wedged capture device back after it has been dark past the
escalation threshold.

This is deliberately the **only** darkness signal the evaluator acts on. There is
no network signal that distinguishes a device that was *unplugged* from one that
*crashed*, so alerting on raw absence would nag any device that's ever powered off.
`recovery_failing` sidesteps that: it is emitted **only** where the operator armed
auto-recovery, which already asserts the device is expected to stay up — so an
absent or intentionally-off device on an install without recovery stays silent, and
the long-standing "never alert on an absent device" invariant is preserved.

## Details

- `evaluate_ambient_health` gains an additive `recovery_failing` check → new
  `recovery-failing` cause; only upgrades `ok → degraded` (a dead bridge stays
  `down`). Absent/false leaves behavior unchanged.
- `_ambient_remedy_hint` gains a cause-aware line (precedence: bridge-dead >
  recovery-failing > diar > rss).
- The alert names the dark-since time and the failed-reboot count; it never
  contains a device address or key (the edge sanitizes those before emitting).

The edge side that produces this signal is a companion change in the voice/edge
repo; both are additive and back-compatible, so they merge independently.

## Tests

New pure-function coverage in `test_ambient_health.py` (degraded+cause on true;
unchanged on false/absent; strict `is True` gate; does-not-mask a dead bridge;
coexists with the diar-worker cause). Full suite green; ruff clean.

Ledger: 54ec6212ef514b45b09a088ff6d829ac

🤖 Generated with [Claude Code](https://claude.com/claude-code)
