### PR TITLE
feat(ego): directive plumbing correctness + realist scoped exemption + COO operate-vs-develop (PR-3)

### DIFF
--- a/src/genesis/ego/directives_context.py
+++ b/src/genesis/ego/directives_context.py
@@ -1,0 +1,82 @@
+"""Shared user-directives section builder for both ego context builders.
+
+Renders active directives (from ``ego_directives``) targeted at a given ego as
+a context block. Called by both UserEgoContextBuilder and
+GenesisEgoContextBuilder — only the ``ego_target``, the framing sentence, and
+the error body differ, so the query + age-computation + render loop live here
+once (mirrors the ``build_intentions_section`` shared-helper pattern).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.crud import ego as ego_crud
+
+logger = logging.getLogger(__name__)
+
+_HEADER = "## User Directives"
+
+
+async def build_directives_section(
+    db: aiosqlite.Connection,
+    ego_target: str,
+    *,
+    framing: str,
+    error_body: str,
+) -> str:
+    """Render active directives for ``ego_target`` as a markdown block.
+
+    Returns ``""`` when there are none (no empty header pollutes the context).
+
+    Parameters
+    ----------
+    ego_target:
+        ``"user_ego"`` or ``"genesis_ego"`` — whose directives to render.
+    framing:
+        The intro sentence shown under the header, including its own trailing
+        newline (each ego frames directives slightly differently).
+    error_body:
+        The italic line rendered when the directive query fails.
+    """
+    try:
+        directives = await ego_crud.list_active_directives(
+            db,
+            ego_target=ego_target,
+            limit=5,
+        )
+    except Exception:
+        logger.warning("Failed to query %s directives", ego_target, exc_info=True)
+        return f"{_HEADER}\n\n{error_body}\n"
+
+    if not directives:
+        return ""
+
+    lines = [f"{_HEADER}\n", framing]
+
+    now = datetime.now(UTC)
+    for d in directives:
+        priority = d.get("priority", "normal").upper()
+        content = d.get("content", "?")[:200]
+        directive_id = d.get("id", "?")
+        created_at = d.get("created_at", "")
+        age_str = ""
+        if created_at:
+            try:
+                created = datetime.fromisoformat(created_at)
+                delta = now - created
+                if delta.days > 0:
+                    age_str = f"{delta.days}d ago"
+                else:
+                    hours = int(delta.total_seconds() / 3600)
+                    age_str = f"{hours}h ago" if hours > 0 else "just now"
+            except (ValueError, TypeError):
+                pass
+        age_part = f", {age_str}" if age_str else ""
+        lines.append(f"- [{priority}] {content}\n  (id={directive_id}{age_part})")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/src/genesis/ego/directives_context.py
+++ b/src/genesis/ego/directives_context.py
@@ -46,7 +46,7 @@ async def build_directives_section(
         directives = await ego_crud.list_active_directives(
             db,
             ego_target=ego_target,
-            limit=5,
+            limit=50,
         )
     except Exception:
         logger.warning("Failed to query %s directives", ego_target, exc_info=True)
@@ -54,6 +54,15 @@ async def build_directives_section(
 
     if not directives:
         return ""
+
+    # Priority-first ordering so a high/critical directive is never hidden
+    # behind newer low/normal ones. list_active_directives returns newest-first;
+    # a stable sort by priority rank preserves that recency order within each
+    # priority band. Without this, an old-but-important directive could fall
+    # off the render and — never exposing its id — stay active indefinitely,
+    # the exact immortality this PR removes.
+    _PRIO_RANK = {"critical": 0, "high": 1, "normal": 2, "low": 3}
+    directives = sorted(directives, key=lambda d: _PRIO_RANK.get(d.get("priority", "normal"), 2))
 
     lines = [f"{_HEADER}\n", framing]
 

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -130,63 +130,22 @@ class GenesisEgoContextBuilder:
     async def _directives_section(self, *, depth: str = "deep") -> str:
         """User directives targeted at the Genesis (COO) ego.
 
-        Only rendered if there are active genesis_ego directives. Returns
-        empty string otherwise to avoid polluting context with empty
-        sections. Mirrors the user ego's directive section — the same
-        user-input framing applies to the COO.
+        Renders active genesis_ego directives (empty string when none). The
+        query + render live in the shared build_directives_section helper; the
+        COO differs only in framing.
         """
-        try:
-            from genesis.db.crud import ego as ego_crud
+        from genesis.ego.directives_context import build_directives_section
 
-            directives = await ego_crud.list_active_directives(
-                self._db,
-                ego_target="genesis_ego",
-                limit=5,
-            )
-        except Exception:
-            logger.warning("Failed to query genesis directives", exc_info=True)
-            return (
-                "## User Directives\n\n"
-                "*Directives unavailable (query error — see logs).*\n"
-            )
-
-        if not directives:
-            return ""
-
-        lines = ["## User Directives\n"]
-        lines.append(
-            "*The user flagged these for you (the operations ego). Factor "
-            "them into your thinking, act on or resolve them, or disagree "
-            "with reasoning — but never ignore one silently.*\n"
+        return await build_directives_section(
+            self._db,
+            "genesis_ego",
+            framing=(
+                "*The user flagged these for you (the operations ego). Factor "
+                "them into your thinking, act on or resolve them, or disagree "
+                "with reasoning — but never ignore one silently.*\n"
+            ),
+            error_body="*Directives unavailable (query error — see logs).*",
         )
-
-        from datetime import UTC, datetime
-
-        now = datetime.now(UTC)
-        for d in directives:
-            priority = d.get("priority", "normal").upper()
-            content = d.get("content", "?")[:200]
-            directive_id = d.get("id", "?")
-            created_at = d.get("created_at", "")
-            age_str = ""
-            if created_at:
-                try:
-                    created = datetime.fromisoformat(created_at)
-                    delta = now - created
-                    if delta.days > 0:
-                        age_str = f"{delta.days}d ago"
-                    else:
-                        hours = int(delta.total_seconds() / 3600)
-                        age_str = f"{hours}h ago" if hours > 0 else "just now"
-                except (ValueError, TypeError):
-                    pass
-            age_part = f", {age_str}" if age_str else ""
-            lines.append(
-                f"- [{priority}] {content}\n  (id={directive_id}{age_part})"
-            )
-
-        lines.append("")
-        return "\n".join(lines)
 
     async def _system_health_section(self, *, depth: str = "deep") -> str:
         """Live system health from health_data snapshot."""

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -81,6 +81,7 @@ class GenesisEgoContextBuilder:
         section_map: list[tuple[str, Any]] = [
             ("system_health", self._system_health_section),
             ("intentions", self._intentions_section),
+            ("directives", self._directives_section),
             ("settled_decisions", self._settled_decisions_section),
             ("signals", self._signals_section),
             ("observations", self._observations_section),
@@ -125,6 +126,67 @@ class GenesisEgoContextBuilder:
         """
         from genesis.ego.intentions_context import build_intentions_section
         return await build_intentions_section(self._db, "genesis_ego_cycle")
+
+    async def _directives_section(self, *, depth: str = "deep") -> str:
+        """User directives targeted at the Genesis (COO) ego.
+
+        Only rendered if there are active genesis_ego directives. Returns
+        empty string otherwise to avoid polluting context with empty
+        sections. Mirrors the user ego's directive section — the same
+        user-input framing applies to the COO.
+        """
+        try:
+            from genesis.db.crud import ego as ego_crud
+
+            directives = await ego_crud.list_active_directives(
+                self._db,
+                ego_target="genesis_ego",
+                limit=5,
+            )
+        except Exception:
+            logger.warning("Failed to query genesis directives", exc_info=True)
+            return (
+                "## User Directives\n\n"
+                "*Directives unavailable (query error — see logs).*\n"
+            )
+
+        if not directives:
+            return ""
+
+        lines = ["## User Directives\n"]
+        lines.append(
+            "*The user flagged these for you (the operations ego). Factor "
+            "them into your thinking, act on or resolve them, or disagree "
+            "with reasoning — but never ignore one silently.*\n"
+        )
+
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        for d in directives:
+            priority = d.get("priority", "normal").upper()
+            content = d.get("content", "?")[:200]
+            directive_id = d.get("id", "?")
+            created_at = d.get("created_at", "")
+            age_str = ""
+            if created_at:
+                try:
+                    created = datetime.fromisoformat(created_at)
+                    delta = now - created
+                    if delta.days > 0:
+                        age_str = f"{delta.days}d ago"
+                    else:
+                        hours = int(delta.total_seconds() / 3600)
+                        age_str = f"{hours}h ago" if hours > 0 else "just now"
+                except (ValueError, TypeError):
+                    pass
+            age_part = f", {age_str}" if age_str else ""
+            lines.append(
+                f"- [{priority}] {content}\n  (id={directive_id}{age_part})"
+            )
+
+        lines.append("")
+        return "\n".join(lines)
 
     async def _system_health_section(self, *, depth: str = "deep") -> str:
         """Live system health from health_data snapshot."""

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -998,27 +998,13 @@ class EgoSession:
             # persisted to ego_state. It controls THIS cycle's delivery only.
             comm_decision = parsed.get("communication_decision", "send_digest")
             if proposals:
-                # Bypass realist gate when critical directives are active —
-                # the user explicitly told the ego to propose something.
-                # The realist's zombie detection would incorrectly block
-                # re-proposals that were rejected for fixable reasons.
-                has_critical_directive = False
-                try:
-                    active_dirs = await ego_crud.list_active_directives(
-                        self._db, self._source_tag.replace("_cycle", ""),
-                    )
-                    has_critical_directive = any(
-                        d.get("priority") == "critical"
-                        for d in active_dirs
-                    )
-                except Exception:
-                    pass
-                if has_critical_directive:
-                    logger.info(
-                        "Realist bypassed — active critical directive(s)",
-                    )
-                else:
-                    proposals = await self._filter_proposals(proposals)
+                # Realist ALWAYS runs — no blanket directive bypass. The
+                # directive-scoped exemption is applied INSIDE the realist:
+                # active critical/high directives are shown to it, and it
+                # suspends zombie/duplicate rejection only for drafts that
+                # actually address one (see _filter_proposals). Feasibility,
+                # actionability, and domain-boundary checks always apply.
+                proposals = await self._filter_proposals(proposals)
                 # Log realist cost for observability (cycle dataclass is frozen,
                 # so cost is tracked via logging; negligible vs ego cycle cost)
                 if self._last_realist_cost_usd > 0:
@@ -1377,7 +1363,30 @@ class EgoSession:
             logger.warning("Realist: failed to fetch history, passing through")
             return proposals
 
-        prompt = _build_realist_prompt(proposals, recent, ego_source=self._source_tag)
+        # Directive-scoped exemption: fetch active critical/high directives for
+        # THIS ego so the realist can suspend zombie/duplicate rejection for
+        # drafts that address an explicit user directive. Fail-open to no
+        # exemption on any error.
+        active_directives: list[dict] = []
+        try:
+            dirs = await ego_crud.list_directives(
+                self._db,
+                ego_target=self._source_tag.replace("_cycle", ""),
+                statuses=("active",),
+                limit=10,
+            )
+            active_directives = [
+                d for d in dirs if d.get("priority") in ("critical", "high")
+            ]
+        except Exception:
+            logger.warning("Realist: failed to fetch directives, no exemption")
+
+        prompt = _build_realist_prompt(
+            proposals,
+            recent,
+            ego_source=self._source_tag,
+            active_directives=active_directives,
+        )
 
         try:
             invocation = CCInvocation(
@@ -2515,6 +2524,7 @@ def _build_realist_prompt(
     recent_history: list[dict],
     *,
     ego_source: str = "",
+    active_directives: list[dict] | None = None,
 ) -> str:
     """Build the realist evaluation prompt.
 
@@ -2605,9 +2615,32 @@ monitoring, or internal maintenance.
    purely investigative with no write/action/outreach component, REJECT it:
    "Read operation — do this during your cycle, don't propose it.\""""
 
+    # Directive exemption block — only when active critical/high directives
+    # exist for this ego. The realist itself judges whether a draft addresses
+    # a directive; the ego cannot self-grant an exemption.
+    directive_section = ""
+    _dir_lines = []
+    for d in active_directives or []:
+        _prio = str(d.get("priority", "?")).upper()
+        _content = (d.get("content") or "")[:200].replace("\n", " ").replace("|", "/")
+        _did = d.get("id", "?")
+        _dir_lines.append(f"- [{_prio}] (id={_did}) {_content}")
+    if _dir_lines:
+        directive_section = (
+            "\n## Active User Directives\n"
+            "The user explicitly flagged these as important for this ego:\n"
+            + "\n".join(_dir_lines)
+            + "\n\n**Directive exemption:** If a proposal DIRECTLY ADDRESSES "
+            "one of the directives above, do NOT reject it as a Zombie or "
+            "Duplicate (Rule #2) — the user explicitly wants this work, even if "
+            "a similar proposal was tried before. Judge the match yourself. All "
+            "other rules (feasibility, actionability, domain boundary) still "
+            "apply.\n"
+        )
+
     return f"""You are the Realist — a quality gate for ego proposals. Evaluate each
 proposal and return a JSON array of verdicts.
-{ego_section}
+{ego_section}{directive_section}
 ## Rules
 {rule_1}
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -2595,6 +2595,25 @@ monitoring, or internal maintenance.
    maintenance. Those belong to the Genesis ego (COO).
 """
 
+    # Operate-vs-develop rubric (genesis/operations ego only). Second gate
+    # behind the identity doc's "Operate, Don't Develop" mandate — catches a
+    # develop-class proposal (code/schema/install/config-value change) if one
+    # slips through drafting. Err toward the doc: reject only CLEAR develop
+    # work; remediation of a specific operational defect is operate, not
+    # develop.
+    operate_rule = ""
+    if ego_source == "genesis_ego_cycle":
+        operate_rule = """
+8. **Operate vs develop (operations ego only).** These proposals should
+   OPERATE the running system (diagnose, pull reversible operational levers,
+   dispatch remediation for a specific defect), NOT DEVELOP it. If a proposal
+   would write or refactor code, change a database schema, edit an install
+   script, or alter a configuration *value* (threshold, interval, routing
+   weight, budget cap), REJECT it: "Develop, not operate — escalate the
+   change to the user." A remediation dispatch for a specific operational
+   defect is fine; building a feature or redesigning a subsystem is not.
+"""
+
     # Build Rule #1 based on ego source — genesis ego is allowed to
     # propose investigation dispatches (background sessions for diagnosis),
     # while user ego should do read-only work in-cycle.
@@ -2671,7 +2690,7 @@ proposal and return a JSON array of verdicts.
    patterns in the history. A proposal that failed before may succeed
    now — circumstances change. Judge the proposal on its own merits,
    not on inferred system state.
-{domain_rule}
+{domain_rule}{operate_rule}
 ## Recent Proposal History (48h)
 {chr(10).join(history_lines)}
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1369,11 +1369,16 @@ class EgoSession:
         # exemption on any error.
         active_directives: list[dict] = []
         try:
+            # Generous limit: list_directives orders newest-first and the
+            # critical/high filter runs in Python, so a small limit could drop
+            # an older critical/high directive behind a burst of newer
+            # low/normal ones. Active directives per ego are realistically a
+            # handful; 50 is ample headroom on a tiny indexed table.
             dirs = await ego_crud.list_directives(
                 self._db,
                 ego_target=self._source_tag.replace("_cycle", ""),
                 statuses=("active",),
-                limit=10,
+                limit=50,
             )
             active_directives = [
                 d for d in dirs if d.get("priority") in ("critical", "high")

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -425,59 +425,21 @@ class UserEgoContextBuilder:
     async def _user_directives_section(self, *, depth: str = "deep") -> str:
         """User directives — explicit user instructions for the ego.
 
-        Only rendered if there are active directives. Returns empty string
-        otherwise to avoid polluting context with empty sections.
+        Renders active user_ego directives (empty string when none). The query
+        + age computation + render live in the shared build_directives_section
+        helper.
         """
-        try:
-            from genesis.db.crud import ego as ego_crud
+        from genesis.ego.directives_context import build_directives_section
 
-            directives = await ego_crud.list_active_directives(
-                self._db,
-                ego_target="user_ego",
-                limit=5,
-            )
-        except Exception:
-            logger.warning("Failed to query ego directives", exc_info=True)
-            return (
-                "## User Directives\n\n"
-                "*User directives unavailable (query error — see logs).*\n"
-            )
-
-        if not directives:
-            return ""
-
-        lines = ["## User Directives\n"]
-        lines.append(
-            "*The user flagged these as important. Factor them into your "
-            "thinking — but you decide what to propose.*\n"
+        return await build_directives_section(
+            self._db,
+            "user_ego",
+            framing=(
+                "*The user flagged these as important. Factor them into your "
+                "thinking — but you decide what to propose.*\n"
+            ),
+            error_body="*User directives unavailable (query error — see logs).*",
         )
-
-        from datetime import UTC, datetime
-
-        now = datetime.now(UTC)
-        for d in directives:
-            priority = d.get("priority", "normal").upper()
-            content = d.get("content", "?")[:200]
-            directive_id = d.get("id", "?")
-            created_at = d.get("created_at", "")
-            # Compute age
-            age_str = ""
-            if created_at:
-                try:
-                    created = datetime.fromisoformat(created_at)
-                    delta = now - created
-                    if delta.days > 0:
-                        age_str = f"{delta.days}d ago"
-                    else:
-                        hours = int(delta.total_seconds() / 3600)
-                        age_str = f"{hours}h ago" if hours > 0 else "just now"
-                except (ValueError, TypeError):
-                    pass
-            age_part = f", {age_str}" if age_str else ""
-            lines.append(f"- [{priority}] {content}\n  (id={directive_id}{age_part})")
-
-        lines.append("")
-        return "\n".join(lines)
 
     async def _settled_decisions_section(self, *, depth: str = "deep") -> str:
         """Settled user decisions — durable rulings from proposal rejections

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -237,13 +237,35 @@ If system health is good and you have no proposals to make:
    "all green, no action" cycle is better than a 3000-token cycle that
    says the same thing with more words. Let the cadence manager back off.
 
-### No Autonomous Code or Config Modification
+### Operate, Don't Develop
 
-Do NOT propose dispatching sessions that modify Genesis source code, database
-schemas, or system configuration values (thresholds, intervals, routing weights).
-You may diagnose issues and recommend the user address them in a foreground
-session, but autonomous system modification is a future capability. Your role
-is diagnosis and recommendation. Produce reports, not patches.
+Your mandate is to **operate** the running Genesis system, not to **develop**
+it. Hold the line between the two:
+
+**OPERATE (your job — propose freely, always approval-gated):**
+- Diagnose health, performance, and reliability issues.
+- Pull operational levers: restart a wedged service, clear a stuck queue,
+  flush a cache, re-run a failed job, rotate a log — the reversible knobs
+  that keep the system healthy.
+- Dispatch a remediation session for a *specific* critical operational
+  defect when a fix needs dedicated time beyond your cycle. Frame it as
+  remediation of a named defect, not a feature.
+
+**DEVELOP (never today — a future capability, not a mark of distrust):**
+- Writing or refactoring Genesis source code, changing database schemas,
+  editing install scripts, or altering configuration *values* (thresholds,
+  intervals, routing weights, budget caps — those are user decisions).
+- Building new capabilities or "improving" a subsystem's design. Anything
+  that produces a patch. Autonomous self-modification is a capability
+  Genesis will earn later; for now, diagnose the problem and escalate the
+  code/config change to the user.
+
+**Never duplicate owned work.** Do NOT propose anything already owned by an
+active foreground session or an existing scheduled job. If a job already runs
+the task (e.g. a cron install-test), the correct move is to note it's handled —
+not to propose it again. When your context shows a directive whose work a job
+already covers, **resolve** the directive ("already handled by <job>"), don't
+re-propose it.
 
 ## Persistent Memory
 

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -283,6 +283,30 @@ when its conditions have been met, use the `resolved_follow_ups` array:
 ]
 ```
 
+## User Directives
+
+Your context may include a **"## User Directives"** section — things the
+user explicitly flagged for you, the operations ego. These are input to
+your reasoning, **not orders**. Factor each into your thinking, then do
+one of:
+
+- **Act on it** — if it names infrastructure work within your
+  jurisdiction, address it through your normal gates (propose, dispatch,
+  or escalate) and resolve it in your output.
+- **Resolve it** — when a directive's intent is already satisfied (the
+  work is done, already covered by a scheduled job, or overtaken by
+  events), mark it resolved via `resolved_directives` with a one-line
+  reason. This is the right move for a directive whose work already
+  exists — resolve it, do NOT re-propose work that's already handled.
+- **Disagree with reasoning** — if a directive is outside your
+  jurisdiction or ill-advised, say why (in an escalation to the user ego
+  or your `focus_summary`) and resolve it as declined.
+
+**Never ignore a directive silently.** There is NO must-propose rule: a
+directive is a strong signal, not a mandate to manufacture a proposal. If
+the correct response is to resolve it (e.g. "already handled by cron job
+X"), do that instead of proposing.
+
 ## Your Own Goals (Additive Autonomy)
 
 You may maintain a small set of YOUR OWN goals — Genesis-internal
@@ -370,6 +394,9 @@ Use MCP tools first, then output valid JSON:
   ],
   "resolved_follow_ups": [
     {"id": "follow_up_id", "resolution": "Why it's resolved"}
+  ],
+  "resolved_directives": [
+    {"id": "directive_id", "resolution": "What you decided: acted / already satisfied (how) / declined (why)"}
   ],
   "intentions": {
     "review": [

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -131,7 +131,8 @@ direct user attention that shouldn't go through the user ego filter.
 ### Notifications vs Proposals
 
 - **Proposals**: actions needing user approval (investigations, maintenance,
-  config changes)
+  operational remediation). Config-*value* changes are escalated to the user,
+  not proposed (see "Operate, Don't Develop").
 - **Notifications**: informational messages, no approval needed (status
   updates, "maintenance complete", "issue resolved", health summaries)
 - Rule of thumb: if it costs nothing and needs no decision, use a
@@ -321,8 +322,11 @@ one of:
   reason. This is the right move for a directive whose work already
   exists — resolve it, do NOT re-propose work that's already handled.
 - **Disagree with reasoning** — if a directive is outside your
-  jurisdiction or ill-advised, say why (in an escalation to the user ego
-  or your `focus_summary`) and resolve it as declined.
+  jurisdiction or ill-advised, escalate your reasoning to the user ego and
+  **leave the directive active**. Do NOT self-resolve a directive you merely
+  disagree with — you don't get to cancel the user's instruction;
+  `resolved_directives` is for directives you *acted on* or that are *already
+  satisfied*. The user retires the rest.
 
 **Never ignore a directive silently.** There is NO must-propose rule: a
 directive is a strong signal, not a mandate to manufacture a proposal. If
@@ -418,7 +422,7 @@ Use MCP tools first, then output valid JSON:
     {"id": "follow_up_id", "resolution": "Why it's resolved"}
   ],
   "resolved_directives": [
-    {"id": "directive_id", "resolution": "What you decided: acted / already satisfied (how) / declined (why)"}
+    {"id": "directive_id", "resolution": "acted (what you did) OR already satisfied (how, e.g. covered by cron job X). NOT for disagreements — escalate those and leave the directive active."}
   ],
   "intentions": {
     "review": [

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -147,7 +147,11 @@ async def ego_directive(
         "content": content[:100],
         "priority": priority,
         "ego_target": ego_target,
-        "note": "The ego will see this in its next thinking cycle.",
+        "note": (
+            f"The {ego_target} will see this directive in its next thinking "
+            "cycle (rendered into its context) and can act on it, resolve it, "
+            "or disagree with reasoning."
+        ),
         "timestamp": datetime.now(UTC).isoformat(),
     }
 

--- a/tests/ego/test_directives_context.py
+++ b/tests/ego/test_directives_context.py
@@ -81,3 +81,29 @@ class TestBuildDirectivesSection:
         )
         assert "## User Directives" in out
         assert "*directives unavailable*" in out
+
+    async def test_high_priority_never_hidden_behind_newer_low(self, db):
+        # Codex P2: an old high/critical directive must render before newer
+        # low/normal ones (priority-first), so it is never hidden — a hidden
+        # directive never exposes its id and can't be resolved.
+        await ego_crud.create_directive(
+            db,
+            content="OLD but CRITICAL",
+            priority="critical",
+            ego_target="genesis_ego",
+            source="user",
+        )
+        for n in range(8):
+            await ego_crud.create_directive(
+                db,
+                content=f"newer low {n}",
+                priority="low",
+                ego_target="genesis_ego",
+                source="user",
+            )
+        out = await build_directives_section(
+            db, "genesis_ego", framing=_GEN_FRAMING, error_body="*err*"
+        )
+        assert "OLD but CRITICAL" in out
+        # Critical renders before the low-priority rows.
+        assert out.index("OLD but CRITICAL") < out.index("newer low 0")

--- a/tests/ego/test_directives_context.py
+++ b/tests/ego/test_directives_context.py
@@ -1,0 +1,83 @@
+"""Tests for the shared build_directives_section helper (PR-3 DRY extraction).
+
+Both UserEgoContextBuilder and GenesisEgoContextBuilder delegate their
+directive section to this one function; only ego_target/framing/error_body
+differ. Covers the render, empty, ego-target filtering, and the error-body
+fail-soft path (previously untested in either builder).
+"""
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import TABLES
+from genesis.ego.directives_context import build_directives_section
+
+_USER_FRAMING = "*user framing line.*\n"
+_GEN_FRAMING = "*genesis framing line.*\n"
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_directives"])
+        await conn.commit()
+        yield conn
+
+
+class TestBuildDirectivesSection:
+    async def test_empty_returns_blank(self, db):
+        out = await build_directives_section(
+            db, "user_ego", framing=_USER_FRAMING, error_body="*err*"
+        )
+        assert out == ""
+
+    async def test_renders_with_framing_and_header(self, db):
+        await ego_crud.create_directive(
+            db,
+            content="Do the thing",
+            priority="high",
+            ego_target="user_ego",
+            source="user",
+        )
+        out = await build_directives_section(
+            db, "user_ego", framing=_USER_FRAMING, error_body="*err*"
+        )
+        assert out.startswith("## User Directives")
+        assert "*user framing line.*" in out
+        assert "[HIGH] Do the thing" in out
+
+    async def test_filters_by_ego_target(self, db):
+        await ego_crud.create_directive(
+            db,
+            content="genesis-only",
+            priority="high",
+            ego_target="genesis_ego",
+            source="user",
+        )
+        # Query for user_ego -> the genesis directive must not appear.
+        out = await build_directives_section(
+            db, "user_ego", framing=_USER_FRAMING, error_body="*err*"
+        )
+        assert out == ""
+        # Query for genesis_ego with its own framing -> it appears.
+        out_g = await build_directives_section(
+            db, "genesis_ego", framing=_GEN_FRAMING, error_body="*err*"
+        )
+        assert "genesis-only" in out_g
+        assert "*genesis framing line.*" in out_g
+
+    async def test_error_body_on_query_failure(self):
+        # A closed/invalid connection makes the query raise -> error body,
+        # not a crash (fail-soft).
+        conn = await aiosqlite.connect(":memory:")
+        await conn.close()
+        out = await build_directives_section(
+            conn,
+            "user_ego",
+            framing=_USER_FRAMING,
+            error_body="*directives unavailable*",
+        )
+        assert "## User Directives" in out
+        assert "*directives unavailable*" in out

--- a/tests/ego/test_genesis_directives_section.py
+++ b/tests/ego/test_genesis_directives_section.py
@@ -1,0 +1,100 @@
+"""Tests for the Genesis-ego directives context section (PR-3).
+
+The Genesis (COO) ego previously could not see directives targeted at it —
+`genesis_context` had no directives section, so a `genesis_ego` directive was
+immortal and invisible. This verifies the new section renders active
+`genesis_ego` directives, ignores `user_ego` ones, excludes resolved rows, and
+stays empty (no polluting header) when there are none.
+"""
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import TABLES, create_all_tables
+from genesis.ego.genesis_context import GenesisEgoContextBuilder
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_directives"])
+        await conn.commit()
+        yield conn
+
+
+def _builder(conn):
+    return GenesisEgoContextBuilder(db=conn)
+
+
+class TestGenesisDirectivesSection:
+    async def test_empty_when_no_directives(self, db):
+        assert await _builder(db)._directives_section() == ""
+
+    async def test_renders_active_genesis_directive(self, db):
+        await ego_crud.create_directive(
+            db,
+            content="Weekly install test needs to run.",
+            priority="high",
+            ego_target="genesis_ego",
+            source="user",
+        )
+        out = await _builder(db)._directives_section()
+        assert "## User Directives" in out
+        assert "[HIGH]" in out
+        assert "Weekly install test" in out
+        # Soft framing (no must-propose): invites resolve/disagree, not silence.
+        assert "silently" in out.lower()
+
+    async def test_ignores_user_ego_directives(self, db):
+        # A user_ego directive must NOT bleed into the COO's section.
+        await ego_crud.create_directive(
+            db,
+            content="User-only directive",
+            priority="high",
+            ego_target="user_ego",
+            source="user",
+        )
+        assert await _builder(db)._directives_section() == ""
+
+    async def test_excludes_resolved(self, db):
+        did = await ego_crud.create_directive(
+            db,
+            content="Already handled by cron",
+            priority="high",
+            ego_target="genesis_ego",
+            source="user",
+        )
+        await ego_crud.resolve_directive(db, did, status="completed", resolution="done")
+        assert await _builder(db)._directives_section() == ""
+
+    async def test_shows_id_for_resolution(self, db):
+        # The rendered id is what the ego echoes back in resolved_directives.
+        did = await ego_crud.create_directive(
+            db,
+            content="Resolve me by id",
+            priority="critical",
+            ego_target="genesis_ego",
+            source="user",
+        )
+        out = await _builder(db)._directives_section()
+        assert f"id={did}" in out
+
+    async def test_wired_into_full_build(self):
+        # Proves the ("directives", ...) tuple is actually reached by build()
+        # (it is also in _ALWAYS_SECTIONS, so never weighted to skip). Uses a
+        # full schema so every other section builder has its tables.
+        async with aiosqlite.connect(":memory:") as conn:
+            conn.row_factory = aiosqlite.Row
+            await create_all_tables(conn)
+            await ego_crud.create_directive(
+                conn,
+                content="Render-me directive in full build",
+                priority="critical",
+                ego_target="genesis_ego",
+                source="user",
+            )
+            out = await GenesisEgoContextBuilder(db=conn).build()
+            assert "## User Directives" in out
+            assert "Render-me directive in full build" in out

--- a/tests/ego/test_realist_directive_exemption.py
+++ b/tests/ego/test_realist_directive_exemption.py
@@ -66,9 +66,31 @@ class TestDirectiveExemption:
 
     def test_backward_compatible_without_directives(self):
         # No directives → directive_section is empty → prompt is byte-identical
-        # to the pre-PR-3 form (interpolation is a no-op).
+        # to the pre-PR-3 form for the same ego (interpolation is a no-op).
         base = _build_realist_prompt(_props("X"), [], ego_source="genesis_ego_cycle")
         with_empty = _build_realist_prompt(
             _props("X"), [], ego_source="genesis_ego_cycle", active_directives=[]
         )
         assert base == with_empty
+
+
+class TestOperateVsDevelopRule:
+    """The genesis (COO) ego gets an operate-vs-develop realist rule; other
+    egos do not (it is a COO-specific jurisdiction constraint)."""
+
+    def test_genesis_ego_gets_operate_rule(self):
+        prompt = _build_realist_prompt(
+            _props("Refactor the router"), [], ego_source="genesis_ego_cycle"
+        )
+        assert "Operate vs develop" in prompt
+        assert "Develop, not operate" in prompt
+
+    def test_user_ego_has_no_operate_rule(self):
+        prompt = _build_realist_prompt(
+            _props("Publish an article"), [], ego_source="user_ego_cycle"
+        )
+        assert "Operate vs develop" not in prompt
+
+    def test_no_ego_source_has_no_operate_rule(self):
+        prompt = _build_realist_prompt(_props("Do X"), [])
+        assert "Operate vs develop" not in prompt

--- a/tests/ego/test_realist_directive_exemption.py
+++ b/tests/ego/test_realist_directive_exemption.py
@@ -1,0 +1,74 @@
+"""Tests for the realist's directive-scoped exemption (PR-3, LLM-judgment).
+
+The old design bypassed the whole realist gate when any *critical* directive
+was active. PR-3 replaces that with showing active critical/high directives to
+the realist so IT judges whether a draft addresses one (the ego cannot
+self-grant). These cover the prompt-construction contract: the directives block
++ Rule #2 carve-out render only when directives are present, content is
+sanitized, and — critically — proposal index parity is preserved (index is the
+only binding contract between a proposal and its verdict).
+"""
+
+from genesis.ego.session import _build_realist_prompt
+
+
+def _props(*contents):
+    return [{"action_type": "maintenance", "content": c, "confidence": 0.7} for c in contents]
+
+
+class TestDirectiveExemption:
+    def test_no_directives_no_block(self):
+        prompt = _build_realist_prompt(_props("Do X"), [])
+        assert "Active User Directives" not in prompt
+        assert "Directive exemption" not in prompt
+
+    def test_empty_directives_no_block(self):
+        prompt = _build_realist_prompt(_props("Do X"), [], active_directives=[])
+        assert "Active User Directives" not in prompt
+
+    def test_directives_rendered_with_carveout(self):
+        directives = [
+            {"id": "abc123", "priority": "high", "content": "Weekly install test"},
+        ]
+        prompt = _build_realist_prompt(
+            _props("Run the install test"), [], active_directives=directives
+        )
+        assert "## Active User Directives" in prompt
+        assert "[HIGH]" in prompt
+        assert "id=abc123" in prompt
+        assert "Weekly install test" in prompt
+        # Carve-out suspends Rule #2 (zombie/duplicate) for matching drafts...
+        assert "Directive exemption" in prompt
+        assert "Zombie" in prompt and "Duplicate" in prompt
+        # ...but explicitly keeps the other rules in force.
+        assert "feasibility" in prompt.lower()
+
+    def test_directive_content_sanitized(self):
+        directives = [
+            {
+                "id": "x",
+                "priority": "critical",
+                "content": "line1\nline2 | piped " + "Y" * 300,
+            },
+        ]
+        prompt = _build_realist_prompt(_props("p"), [], active_directives=directives)
+        # Newlines → spaces, pipes → slashes, truncated to 200 chars.
+        assert "line1 line2 / piped" in prompt
+        assert "Y" * 300 not in prompt
+
+    def test_index_parity_preserved_with_directives(self):
+        # Proposals must stay 0-indexed regardless of the directives block —
+        # index alignment is the realist's only proposal↔verdict contract.
+        directives = [{"id": "d1", "priority": "high", "content": "dir"}]
+        prompt = _build_realist_prompt(_props("First", "Second"), [], active_directives=directives)
+        assert "0. [maintenance]" in prompt
+        assert "1. [maintenance]" in prompt
+
+    def test_backward_compatible_without_directives(self):
+        # No directives → directive_section is empty → prompt is byte-identical
+        # to the pre-PR-3 form (interpolation is a no-op).
+        base = _build_realist_prompt(_props("X"), [], ego_source="genesis_ego_cycle")
+        with_empty = _build_realist_prompt(
+            _props("X"), [], ego_source="genesis_ego_cycle", active_directives=[]
+        )
+        assert base == with_empty


### PR DESCRIPTION
## What

PR-3 of the ego proposal-lifecycle redesign. Fixes the **directive write/read asymmetry** and rescopes the COO ego. Delivers locked decisions #3, #8, #9 (ledger `5e6ab75c54f649ba85395e4a647d9c20`; that item covers all 9 decisions, so this advances it, not closes it — the rest are PR-4/5/6).

**The core bug:** the `ego_directive` MCP tool accepts `ego_target=genesis_ego`, but the genesis/COO ego had **no directives section** in its context — a genesis-targeted directive was invisible and immortal (only its *priority* was read, by the old realist bypass), and the tool falsely promised "the ego will see this next cycle". This is the mechanism behind the 6-generation install-test proposal saga.

## Changes (4 commits)

1. **Directive injection + resolution lane** — genesis_context gets a `directives` section (already in `_ALWAYS_SECTIONS`, so it renders every cycle); `GENESIS_EGO_SESSION.md` gets directive-handling guidance + a `resolved_directives` output field (the step-10c processing already existed). `ego_directive` note is now truthful.
2. **Realist directive-scoped exemption (LLM-judgment)** — removes the old blanket bypass (skip the whole realist when any *critical* directive is active) and replaces it with showing active **critical+high** directives to the realist, which judges whether a draft addresses one and suspends only Rule #2 (zombie/duplicate) for it. **Design note:** I rejected the plan's original "id-anchored" exemption — verifying a `directive_id` *exists* doesn't verify the proposal *addresses* it, so a valid id on an unrelated zombie would smuggle it past the gate. LLM-judgment closes that hole, needs no `directive_id` emission (no `USER_EGO_SESSION.md` change), and leaves proposal **index parity** (the realist's only proposal↔verdict contract) untouched.
3. **COO "Operate, Don't Develop" mandate** — replaces "produce reports, not patches" with an operate-vs-develop axis: OPERATE (diagnose, reversible levers, defect remediation — *looser*) vs DEVELOP (code/schema/install/config-value changes — never today) + a "never duplicate owned work" clause (resolve a directive already covered by a job, don't re-propose). Plus a second-gate realist rule. Wording user-reviewed.
4. **Review remediation** — shared `build_directives_section` helper (DRY, byte-identical to prior user-ego rendering); disagreement governance (COO escalates + leaves a directive active, never self-cancels a user instruction); stale "config changes" proposal line fixed; directive fetch limit 10→50 so an older critical/high can't be dropped.

## Review

Two-reviewer pass (architecture + bug). No blockers. All 5 design constraints verified upheld in code (index parity, fail-open ×2, correct per-ego target, resolved_directives fires for genesis, `_ALWAYS_SECTIONS` never-skip). Should-fix findings all addressed above.

## Watch after deploy (from review)

- **Operate-rule false-positives** (~65% first-pass): a routing-weight/config flip for provider failover *is* operational but reads as "config value" → could be rejected as develop. Watch the first genesis cycle's realist verdicts.
- **User-ego bypass delta**: removing the blanket bypass means a user_ego cycle with an active critical directive now runs the full realist (only Rule #2 suspended for matched directives), where it previously skipped the gate. Intended tightening; watch the first user-ego digests for over-rejection.

## Sequencing

Directive `c60d8bdd` (June-8 install test, still active, superseded by cron `user_job:df48828a`) is retired as a labeled data repair **before** this deploys — otherwise the newly-seeing COO ego could re-surface it.

## Tests

New: `test_genesis_directives_section`, `test_realist_directive_exemption`, `test_directives_context`. Full ego suite: **1049 passed, 1 skipped**. All 41 pre-existing realist tests pass unchanged (backward compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)