### PR TITLE
fix(host): abort/honesty guards for host + guardian scripts (P7)

### DIFF
--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -288,7 +288,7 @@ except Exception:
         INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
         if [ -d "$INSTALL_DIR/.git" ]; then
             cd "$INSTALL_DIR"
-            OLD=$(git rev-parse --short HEAD 2>/dev/null)
+            OLD=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
             # Discard CLAUDE.md before pull — it's a generated file that the
             # repo's version would overwrite with the wrong content (container
             # dev instructions vs Guardian diagnostic instructions). We
@@ -361,6 +361,10 @@ except Exception:
                     if [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
                         sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/ 2>/dev/null || true
                         sudo udevadm control --reload-rules 2>/dev/null || true
+                        # reload alone only refreshes the rules DB; trigger re-applies
+                        # the scheduler rule to already-present block devices (scoped to
+                        # block so a live host's network/other udev isn't re-triggered).
+                        sudo udevadm trigger --subsystem-match=block 2>/dev/null || true
                     fi
                     # Regenerate I/O sysctl from canonical values
                     sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null 2>&1 << 'IOSYSCTL' || true

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -578,10 +578,11 @@ if ! incus info "$CONTAINER_NAME" &>/dev/null; then
     # On LVM-backed pools, the default thin volume is only 10GB.
     # "device override" resizes the underlying LV + filesystem.
     incus config device override "$CONTAINER_NAME" root size="$DISK" 2>/dev/null || true
-    # I/O limits (idempotent sets). The override above errors benignly when the
-    # device is already overridden on a re-run, so only the IOPS sets — which ARE
-    # idempotent — gate the success message; the echo must not claim limits that
-    # a pool without device-limit support silently rejected.
+    # I/O limits. Gate the success message on the IOPS sets, NOT the override: a
+    # storage pool that doesn't support device I/O limits rejects limits.read/write
+    # while the container is still created fine, so the echo must not claim limits
+    # that didn't apply. The override stays `|| true` — its failure is a
+    # pool-capability signal, not something the IOPS message should reflect.
     _io_limits_ok=true
     incus config device set "$CONTAINER_NAME" root limits.read 190MB 2>/dev/null || _io_limits_ok=false
     incus config device set "$CONTAINER_NAME" root limits.write 90MB 2>/dev/null || _io_limits_ok=false

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -381,13 +381,16 @@ vm.min_free_kbytes = $_min_free_kb
 vm.watermark_scale_factor = 50
 vm.oom_kill_allocating_task = 1
 SYSCTL
-    sudo sysctl --system > /dev/null 2>&1
-    echo "  + OOM tuning applied (min_free=${_min_free_mb}MB for ${host_mem_gb}GB host)"
+    if sudo sysctl --system > /dev/null 2>&1; then
+        echo "  + OOM tuning applied (min_free=${_min_free_mb}MB for ${host_mem_gb}GB host)"
+    else
+        echo "  WARNING: OOM sysctl apply failed (non-fatal) — verify with 'sudo sysctl --system'"
+    fi
 fi
 
 # Find the managed bridge (not the host NIC). Column order: NAME,TYPE,MANAGED,...
 # Filter for MANAGED=YES to avoid trying to modify physical interfaces like ens4.
-_INCUS_BRIDGE=$(incus network list --format csv 2>/dev/null | grep ",YES," | head -1 | cut -d, -f1)
+_INCUS_BRIDGE=$(incus network list --format csv 2>/dev/null | grep ",YES," | head -1 | cut -d, -f1 || true)
 if [ -n "$_INCUS_BRIDGE" ]; then
     _NAT_STATUS=$(incus network get "$_INCUS_BRIDGE" ipv4.nat 2>/dev/null || echo "")
     if [ "$_NAT_STATUS" != "true" ]; then
@@ -405,7 +408,7 @@ fi
 # Rather than trying to detect which firewall is active and failing
 # silently, just run ALL commands unconditionally. They're idempotent
 # and fail harmlessly when the tool isn't installed.
-_INCUS_BRIDGE=$(incus network list --format csv 2>/dev/null | grep ",YES," | head -1 | cut -d, -f1)
+_INCUS_BRIDGE=$(incus network list --format csv 2>/dev/null | grep ",YES," | head -1 | cut -d, -f1 || true)
 if [ -n "$_INCUS_BRIDGE" ]; then
     echo "  Configuring firewall for container traffic on $_INCUS_BRIDGE..."
 
@@ -575,10 +578,18 @@ if ! incus info "$CONTAINER_NAME" &>/dev/null; then
     # On LVM-backed pools, the default thin volume is only 10GB.
     # "device override" resizes the underlying LV + filesystem.
     incus config device override "$CONTAINER_NAME" root size="$DISK" 2>/dev/null || true
-    # I/O limits
-    incus config device set "$CONTAINER_NAME" root limits.read 190MB 2>/dev/null || true
-    incus config device set "$CONTAINER_NAME" root limits.write 90MB 2>/dev/null || true
-    echo "  + Disk: $DISK, IOPS limits applied"
+    # I/O limits (idempotent sets). The override above errors benignly when the
+    # device is already overridden on a re-run, so only the IOPS sets — which ARE
+    # idempotent — gate the success message; the echo must not claim limits that
+    # a pool without device-limit support silently rejected.
+    _io_limits_ok=true
+    incus config device set "$CONTAINER_NAME" root limits.read 190MB 2>/dev/null || _io_limits_ok=false
+    incus config device set "$CONTAINER_NAME" root limits.write 90MB 2>/dev/null || _io_limits_ok=false
+    if [ "$_io_limits_ok" = true ]; then
+        echo "  + Disk: $DISK, IOPS limits applied"
+    else
+        echo "  + Disk: $DISK (WARNING: IOPS limits not applied — pool may not support device limits)"
+    fi
 
     # Wait for container to be ready
     echo "  Waiting for container to initialize..."
@@ -729,7 +740,7 @@ _final_tz="UTC"
 
 # Try IP geolocation (the install requires internet, so this should work)
 _detected_tz=$(curl -sf --max-time 5 "http://ip-api.com/json?fields=timezone" 2>/dev/null | \
-    grep -o '"timezone":"[^"]*"' | cut -d'"' -f4)
+    grep -o '"timezone":"[^"]*"' | cut -d'"' -f4) || _detected_tz=""
 
 # Fallback: host system timezone (may be UTC on fresh cloud VMs)
 if [ -z "$_detected_tz" ]; then

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -419,8 +419,11 @@ echo "[3/14] Creating virtual environment..."
 
 if [ ! -x "$VENV_DIR/bin/python" ]; then
     # Gate on the interpreter, not the directory: a partial/broken venv dir
-    # (interrupted create, missing bin/python) must be re-created, not skipped.
-    $PYTHON -m venv "$VENV_DIR"
+    # (interrupted create, missing OR dangling bin/python) must be rebuilt, not
+    # skipped. --clear wipes a partial dir so even a dangling symlink is repaired
+    # (a plain re-run of venv skips an existing-but-dangling bin/python link).
+    # Only reached when bin/python is already unusable, so nothing good is lost.
+    $PYTHON -m venv --clear "$VENV_DIR"
 fi
 
 # Debian creates venvs without pip even when ensurepip imports (ensurepip

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -417,7 +417,9 @@ fi
 echo ""
 echo "[3/14] Creating virtual environment..."
 
-if [ ! -d "$VENV_DIR" ]; then
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+    # Gate on the interpreter, not the directory: a partial/broken venv dir
+    # (interrupted create, missing bin/python) must be re-created, not skipped.
     $PYTHON -m venv "$VENV_DIR"
 fi
 
@@ -677,6 +679,10 @@ SYSCTL
     if [ -d "$INSTALL_DIR/config" ] && [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
         sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/ || true
         sudo udevadm control --reload-rules 2>/dev/null || true
+        # trigger re-applies the scheduler rule to existing block devices
+        # (reload only refreshes the rules DB); scoped to block to avoid
+        # re-triggering unrelated subsystems on the host.
+        sudo udevadm trigger --subsystem-match=block 2>/dev/null || true
         echo "  + BFQ I/O scheduler rule installed"
     fi
 else

--- a/tests/test_scripts/test_host_destructive_guards.py
+++ b/tests/test_scripts/test_host_destructive_guards.py
@@ -227,3 +227,5 @@ def test_i5_venv_gate_checks_interpreter_not_dir():
     assert 'if [ ! -x "$VENV_DIR/bin/python" ]; then' in code
     # The dir-existence gate (which skipped recreating a broken venv) is gone.
     assert 'if [ ! -d "$VENV_DIR" ]; then' not in code
+    # --clear so a dangling bin/python symlink is rebuilt, not skipped by venv.
+    assert '-m venv --clear "$VENV_DIR"' in code

--- a/tests/test_scripts/test_host_destructive_guards.py
+++ b/tests/test_scripts/test_host_destructive_guards.py
@@ -1,7 +1,29 @@
-"""Host destructive-path guards (deploy-audit H4/H5/H7/I2/I3/H8).
+"""Host destructive-path guards (deploy-audit H4/H5/H7/I2/I3/H8) plus the
+P7 robustness/abort guards (H1/H2/H3/H6/G2/I4/I5).
 
-These fixes harden host-side operations in scripts/host-setup.sh and
-scripts/install_guardian.sh that can destroy data or strip a working config:
+These fixes harden host-side operations in scripts/host-setup.sh,
+scripts/install_guardian.sh, and scripts/guardian-gateway.sh that can destroy
+data, strip a working config, abort the whole script under `set -euo pipefail`,
+or claim success that didn't happen:
+
+* **H1** IP-geolocation TZ pipeline aborted host-setup on a curl failure / grep
+  no-match (pipefail) before its own fallback could run — now `|| _detected_tz=""`.
+* **H2** the managed-bridge detect (`incus … | grep ",YES," | …`) aborted on a
+  no-match host (grep→1 under pipefail) before the `[ -n ]` skip — now `|| true`.
+* **H3** the OOM `sudo sysctl --system` aborted on failure and lied about success —
+  now an `if … then/else` that neither aborts nor over-claims.
+* **H6** the "IOPS limits applied" echo was unconditional after `|| true` device
+  commands — now gated on the idempotent IOPS sets (NOT the override, which errors
+  benignly on a re-run).
+* **G2** the guardian `update` verb's `OLD=$(git rev-parse …)` had no fallback —
+  now `|| echo "unknown"` matching its siblings.
+* **I4** udev rules were reloaded but never `trigger`ed, so the BFQ scheduler rule
+  never reached existing block devices — now `udevadm trigger --subsystem-match=block`
+  at BOTH sites (install_guardian.sh + guardian-gateway.sh's update mirror).
+* **I5** the venv gate tested `-d "$VENV_DIR"` so a partial/broken venv was skipped —
+  now `-x "$VENV_DIR/bin/python"`.
+
+The original destructive-path guards:
 
 * **H4** a "damaged" container was force-DELETED (unrecoverable — DB, memory,
   transcripts gone), and a single transient `incus exec` failure could
@@ -30,6 +52,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOST_SETUP = REPO_ROOT / "scripts" / "host-setup.sh"
 INSTALL_GUARDIAN = REPO_ROOT / "scripts" / "install_guardian.sh"
+GUARDIAN_GATEWAY = REPO_ROOT / "scripts" / "guardian-gateway.sh"
 
 
 def _code(path: Path) -> str:
@@ -123,3 +146,84 @@ def test_h8_reexec_quotes_args():
     code = _code(HOST_SETUP)
     assert 'for _a in "$@"; do _ORIG_ARGS+="$(printf \'%q \' "$_a")"; done' in code
     assert '_ORIG_ARGS="$*"' not in code  # the flattening form is gone
+
+
+# ── P7: robustness / abort / honesty guards (H1/H2/H3/H6/G2/I4/I5) ────
+
+
+def test_p7_host_setup_runs_under_pipefail():
+    """The abort-guards (H1/H2/H3) only matter under pipefail — lock that the
+    script still declares it, so a future `set -e`→`set +o pipefail` change can't
+    silently make these guards dead weight."""
+    assert "set -euo pipefail" in HOST_SETUP.read_text()
+
+
+def test_h1_timezone_pipeline_has_fallback():
+    code = _code(HOST_SETUP)
+    # curl-fail / grep-no-match must fall through to the timedatectl fallback,
+    # not abort at the assignment under pipefail.
+    assert '|| _detected_tz=""' in code
+    # The fallback block that the guard protects must still be reachable.
+    assert 'if [ -z "$_detected_tz" ]; then' in code
+
+
+def test_h2_bridge_detect_no_match_is_survivable():
+    code = _code(HOST_SETUP)
+    # BOTH detect sites (NAT + firewall) guard the grep-no-match abort …
+    assert code.count("cut -d, -f1 || true)") == 2
+    # … and the unguarded form is gone entirely.
+    assert "cut -d, -f1)" not in code
+    # The "no managed bridge" skip path is now reachable.
+    assert "No managed Incus bridge found" in HOST_SETUP.read_text()
+
+
+def test_h3_oom_sysctl_neither_aborts_nor_lies():
+    code = _code(HOST_SETUP)
+    assert "if sudo sysctl --system > /dev/null 2>&1; then" in code
+    # The bare, abort-prone form is gone.
+    assert "\n    sudo sysctl --system > /dev/null 2>&1\n" not in "\n" + code + "\n"
+    assert "OOM sysctl apply failed" in HOST_SETUP.read_text()  # honest failure branch
+
+
+def test_h6_iops_message_gated_on_idempotent_sets():
+    code = _code(HOST_SETUP)
+    # The success echo is now conditional on the two idempotent IOPS sets …
+    assert "_io_limits_ok=true" in code
+    assert code.count("_io_limits_ok=false") == 2  # one per limits.read / limits.write set
+    assert 'if [ "$_io_limits_ok" = true ]; then' in code
+    # … NOT on the override, which errors benignly on a re-run (must stay `|| true`).
+    assert (
+        'incus config device override "$CONTAINER_NAME" root size="$DISK" 2>/dev/null || true'
+        in code
+    )
+    assert "IOPS limits not applied" in HOST_SETUP.read_text()  # honest else branch
+
+
+def test_g2_guardian_update_rev_parse_has_fallback():
+    code = _code(GUARDIAN_GATEWAY)
+    assert 'OLD=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")' in code
+    # The unguarded form is gone (would abort a corrupt-repo update under set -e).
+    assert "OLD=$(git rev-parse --short HEAD 2>/dev/null)" not in code
+
+
+def test_i4_udev_reload_is_followed_by_trigger():
+    """reload alone refreshes the rules DB but never re-applies to existing
+    block devices; the scheduler rule needs a `trigger`. Scoped to `block` so a
+    live host's other subsystems aren't re-triggered. Both sites must have it."""
+    trigger = "sudo udevadm trigger --subsystem-match=block 2>/dev/null || true"
+    assert trigger in _code(INSTALL_GUARDIAN)
+    assert trigger in _code(GUARDIAN_GATEWAY)
+    # A reload with NO following trigger is the bug — assert the trigger count
+    # matches the reload count at each site.
+    for path in (INSTALL_GUARDIAN, GUARDIAN_GATEWAY):
+        c = _code(path)
+        assert c.count("udevadm control --reload-rules") == c.count(
+            "udevadm trigger --subsystem-match=block"
+        )
+
+
+def test_i5_venv_gate_checks_interpreter_not_dir():
+    code = _code(INSTALL_GUARDIAN)
+    assert 'if [ ! -x "$VENV_DIR/bin/python" ]; then' in code
+    # The dir-existence gate (which skipped recreating a broken venv) is gone.
+    assert 'if [ ! -d "$VENV_DIR" ]; then' not in code


### PR DESCRIPTION
Deploy-audit **P7** — robustness guards for host/guardian shell scripts that run under `set -euo pipefail`.

## Findings fixed
| id | file | fix |
|----|------|-----|
| H1 | host-setup.sh | IP-geolocation TZ pipeline `\|\| _detected_tz=""` — a curl-fail/grep-no-match falls through to the timedatectl fallback instead of aborting |
| H2 (×2) | host-setup.sh | managed-bridge detect tolerates a grep no-match (`\|\| true`), reaching the "no bridge" skip on a non-incus host |
| H3 | host-setup.sh | OOM `sudo sysctl --system` wrapped in if/else — neither aborts nor claims success it didn't achieve |
| H6 | host-setup.sh | "IOPS limits applied" echo gated on the idempotent IOPS sets (a pool without device-limit support rejects them while the container still creates) |
| G2 | guardian-gateway.sh | `OLD=$(git rev-parse …)` gets `\|\| echo "unknown"` matching its siblings |
| I4 (×2) | install_guardian.sh, guardian-gateway.sh | `udevadm trigger --subsystem-match=block` after the rules reload, so the BFQ scheduler rule reaches existing block devices |
| I5 | install_guardian.sh | venv gate tests `-x "$VENV_DIR/bin/python"` (+`--clear`) not `-d`, so a partial/dangling venv is rebuilt, not skipped |

## Testing
- Extraction/regression-lock tests in `test_host_destructive_guards.py` (adds a `GUARDIAN_GATEWAY` constant); 16/16 pass.
- `bash -n` clean on all three scripts.
- code-reviewer: no ≥80-confidence findings; two sub-threshold accuracy items (H6 comment, I5 dangling-symlink) fixed in the review-fix commit.

## Deploy
**Host-Deploy Gate applies** (touches host-setup.sh / guardian-gateway.sh / install_guardian.sh) — `scripts/update.sh` + guardian redeploy verification after merge.