### PR TITLE
fix(bootstrap): robustness guards for bootstrap + local-config (P8a)

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -334,8 +334,19 @@ echo "--- Installing code intelligence tools ---"
 # in ~/.claude/.mcp.json, bypassing our 2G-capped launcher. We register the
 # capped wrapper below via _register_mcp, so the installer must NOT self-register.
 echo "  codebase-memory-mcp: installing/upgrading..."
-curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui --skip-config \
-    || echo "  WARNING: codebase-memory-mcp install/upgrade failed (non-critical)"
+# Download-to-temp before executing: `curl … | bash` runs bytes as they stream,
+# so a mid-transfer connection drop executes a truncated script. -f fails the
+# download on a partial transfer; running from a file executes only a fully
+# downloaded installer. B9.
+_cbm_installer=$(mktemp 2>/dev/null) || _cbm_installer=""
+if [[ -n "$_cbm_installer" ]] \
+    && curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh -o "$_cbm_installer" 2>/dev/null; then
+    bash "$_cbm_installer" --ui --skip-config \
+        || echo "  WARNING: codebase-memory-mcp install/upgrade failed (non-critical)"
+else
+    echo "  WARNING: codebase-memory-mcp installer download failed (non-critical)"
+fi
+[[ -n "$_cbm_installer" ]] && rm -f "$_cbm_installer"
 if command -v codebase-memory-mcp &>/dev/null; then
     echo "  codebase-memory-mcp: $(codebase-memory-mcp --version 2>/dev/null || echo 'installed')"
 fi
@@ -360,8 +371,16 @@ fi
 # Serena (Python LSP — symbols, references, rename)
 if ! command -v uv &>/dev/null; then
     echo "  uv not found — installing..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null \
-        || echo "  WARNING: uv install failed (non-critical)"
+    # Download-to-temp before executing (see B9 note above): avoids running a
+    # truncated installer if the transfer drops mid-stream.
+    _uv_installer=$(mktemp 2>/dev/null) || _uv_installer=""
+    if [[ -n "$_uv_installer" ]] \
+        && curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>/dev/null; then
+        sh "$_uv_installer" 2>/dev/null || echo "  WARNING: uv install failed (non-critical)"
+    else
+        echo "  WARNING: uv installer download failed (non-critical)"
+    fi
+    [[ -n "$_uv_installer" ]] && rm -f "$_uv_installer"
     export PATH="$HOME/.local/bin:$PATH"
 fi
 if command -v uv &>/dev/null; then
@@ -383,13 +402,17 @@ SKILLSPECTOR_DIR="$HOME/.genesis/deps/skillspector"
 if [[ ! -x "$SKILLSPECTOR_DIR/.venv/bin/skillspector" ]]; then
     echo "  SkillSpector not found — installing..."
     mkdir -p "$HOME/.genesis/deps"
+    # timeout guards a hung TCP connection (else bootstrap stalls indefinitely on
+    # this OPTIONAL dep); one retry rides out a transient blip. 300s ≈ 5x a normal
+    # --depth 1 clone / small pip install; on failure bootstrap continues. B8.
+    _ss_clone() { timeout 300 git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git "$SKILLSPECTOR_DIR" 2>/dev/null; }
     if [[ ! -d "$SKILLSPECTOR_DIR/.git" ]]; then
-        git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git "$SKILLSPECTOR_DIR" 2>/dev/null \
+        _ss_clone || { sleep 2; _ss_clone; } \
             || echo "  WARNING: SkillSpector clone failed (skill-security scan will no-op until installed)"
     fi
     if [[ -d "$SKILLSPECTOR_DIR" ]]; then
         "$PYTHON_BIN" -m venv "$SKILLSPECTOR_DIR/.venv" 2>/dev/null \
-            && "$SKILLSPECTOR_DIR/.venv/bin/pip" install -q "$SKILLSPECTOR_DIR" 2>/dev/null \
+            && timeout 300 "$SKILLSPECTOR_DIR/.venv/bin/pip" install -q "$SKILLSPECTOR_DIR" 2>/dev/null \
             || echo "  WARNING: SkillSpector install failed (non-critical)"
     fi
 fi
@@ -563,7 +586,10 @@ if command -v codebase-memory-mcp &>/dev/null; then
     _register_mcp "codebase-memory-mcp" "user" "$GENESIS_ROOT/.claude/mcp/run-codebase-memory"
 fi
 if command -v serena &>/dev/null; then
-    _register_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$GENESIS_ROOT"
+    # `-s project` writes .mcp.json keyed to the git-root of the CURRENT dir (no
+    # flag overrides this), so register from the repo root regardless of the
+    # caller's cwd — else bootstrap run from elsewhere writes to the wrong repo. B5.
+    ( cd "$GENESIS_ROOT" && _register_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$GENESIS_ROOT" )
 fi
 echo
 
@@ -598,6 +624,16 @@ if [[ -z "$GENESIS_TIMEZONE" ]]; then
         echo "  Using timezone: $GENESIS_TIMEZONE (non-interactive)"
     fi
 fi
+# Validate the resolved timezone against the system's known zones — but only when
+# timedatectl can enumerate them (a minimal image may not), so we never force UTC
+# on a box we simply couldn't validate against. B6.
+if command -v timedatectl &>/dev/null; then
+    _tz_list=$(timedatectl list-timezones 2>/dev/null || true)
+    if [[ -n "$_tz_list" ]] && ! grep -qxF "$GENESIS_TIMEZONE" <<<"$_tz_list"; then
+        echo "  WARNING: '$GENESIS_TIMEZONE' is not a recognized timezone — falling back to UTC"
+        GENESIS_TIMEZONE="UTC"
+    fi
+fi
 if command -v timedatectl &>/dev/null; then
     sudo timedatectl set-timezone "$GENESIS_TIMEZONE" 2>/dev/null && \
         echo "  System timezone set to $GENESIS_TIMEZONE" || \
@@ -607,6 +643,9 @@ else
 fi
 # Persist to secrets.env for future runs
 if [[ -f "$SECRETS_FILE" ]] && ! grep -q "^GENESIS_TIMEZONE=" "$SECRETS_FILE" 2>/dev/null; then
+    # Ensure a trailing newline before appending, else a secrets.env that doesn't
+    # end in \n concatenates the new key onto the last existing line. B7.
+    [[ -s "$SECRETS_FILE" && -n "$(tail -c1 "$SECRETS_FILE")" ]] && printf '\n' >> "$SECRETS_FILE"
     echo "GENESIS_TIMEZONE=$GENESIS_TIMEZONE" >> "$SECRETS_FILE"
     echo "  Saved to secrets.env"
 fi
@@ -615,7 +654,10 @@ echo
 # --- Runtime state ---
 echo "--- Initializing runtime state ---"
 mkdir -p "$HOME/.genesis"
-touch "$HOME/.genesis/setup-complete"
+# The setup-complete marker is written at the VERY END (after "Bootstrap
+# complete"), NOT here: it gates the fresh-install onboarding prompt
+# (genesis_session_context.py) and ego cadence, so a bootstrap that crashes
+# mid-run must not leave the box looking fully onboarded. B1.
 
 # SQLite data dir — set nodatacow (chattr +C) at creation. On btrfs, CoW +
 # SQLite WAL means write-amplification and chronic fragmentation; the flag only
@@ -898,9 +940,12 @@ if [[ -d "$SYSTEMD_TEMPLATE_DIR" ]]; then
             SERVICES_UPDATED=1
         fi
     done
+    # Always reload before enabling — cheap + idempotent, and covers a prior run
+    # that wrote a unit then crashed before reloading (files unchanged this run,
+    # but systemd's in-memory view stale). B3.
+    systemctl --user daemon-reload 2>/dev/null || true
     if [[ "$SERVICES_UPDATED" = "1" ]]; then
-        systemctl --user daemon-reload 2>/dev/null || true
-        echo "  systemd daemon reloaded"
+        echo "  systemd daemon reloaded (units changed)"
     fi
 
     # Enable + start every rendered timer (idempotent), EXCEPT timers that are a
@@ -1054,6 +1099,11 @@ if [[ -z "$MISSING_CRITICAL" && -z "$MISSING_HELPFUL" ]]; then
     echo "  All recommended plugins installed."
 fi
 echo
+
+# setup-complete written only now that all bootstrap work has finished (B1) — the
+# marker gates the fresh-install onboarding prompt + ego cadence, so an interrupted
+# bootstrap must not have written it early.
+touch "$HOME/.genesis/setup-complete"
 
 echo "=== Bootstrap complete ==="
 echo "Start Claude Code: claude"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -405,12 +405,16 @@ if [[ ! -x "$SKILLSPECTOR_DIR/.venv/bin/skillspector" ]]; then
     # timeout guards a hung TCP connection (else bootstrap stalls indefinitely on
     # this OPTIONAL dep); one retry rides out a transient blip. 300s ≈ 5x a normal
     # --depth 1 clone / small pip install; on failure bootstrap continues. B8.
-    _ss_clone() { timeout 300 git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git "$SKILLSPECTOR_DIR" 2>/dev/null; }
-    if [[ ! -d "$SKILLSPECTOR_DIR/.git" ]]; then
+    # A clone that dies mid-transfer leaves a PARTIAL .git, so clear the dir before
+    # each attempt and gate on a completion marker (pyproject.toml/setup.py — a
+    # populated worktree), NOT bare .git, else a partial clone wedges every future
+    # run (skip-because-.git-exists → pip against an incomplete tree, forever).
+    _ss_clone() { rm -rf "$SKILLSPECTOR_DIR"; timeout 300 git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git "$SKILLSPECTOR_DIR" 2>/dev/null; }
+    if [[ ! -f "$SKILLSPECTOR_DIR/pyproject.toml" && ! -f "$SKILLSPECTOR_DIR/setup.py" ]]; then
         _ss_clone || { sleep 2; _ss_clone; } \
             || echo "  WARNING: SkillSpector clone failed (skill-security scan will no-op until installed)"
     fi
-    if [[ -d "$SKILLSPECTOR_DIR" ]]; then
+    if [[ -f "$SKILLSPECTOR_DIR/pyproject.toml" || -f "$SKILLSPECTOR_DIR/setup.py" ]]; then
         "$PYTHON_BIN" -m venv "$SKILLSPECTOR_DIR/.venv" 2>/dev/null \
             && timeout 300 "$SKILLSPECTOR_DIR/.venv/bin/pip" install -q "$SKILLSPECTOR_DIR" 2>/dev/null \
             || echo "  WARNING: SkillSpector install failed (non-critical)"

--- a/scripts/setup-local-config.sh
+++ b/scripts/setup-local-config.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 GENESIS_HOME="${HOME}/.genesis"
 CONFIG_DIR="${GENESIS_HOME}/config"
 LOCAL_CONFIG="${CONFIG_DIR}/genesis.yaml"
-REPO_EXAMPLE="$(dirname "$(readlink -f "$0")")/../config/genesis.yaml.example"
 
 NON_INTERACTIVE=false
 if [[ "${1:-}" == "--non-interactive" ]]; then
@@ -83,7 +82,7 @@ echo "  settings (timezone, service URLs, GitHub identity)."
 echo "  The file is NEVER committed to git."
 echo ""
 
-# ── Migrate from repo YAML if this is an existing install ────────────────────
+# ── Reuse existing config values as prompt defaults (no migration happens) ───
 
 if [[ -f "$LOCAL_CONFIG" ]]; then
     _ok "Existing config found at $LOCAL_CONFIG — showing current values as defaults."

--- a/tests/test_scripts/test_bootstrap_guards.py
+++ b/tests/test_scripts/test_bootstrap_guards.py
@@ -117,6 +117,12 @@ def test_b8_skillspector_install_is_bounded():
     assert "timeout 300 git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git" in code
     assert "_ss_clone || { sleep 2; _ss_clone; }" in code  # one retry rides out a blip
     assert 'timeout 300 "$SKILLSPECTOR_DIR/.venv/bin/pip" install' in code
+    # A partial clone (mid-transfer failure leaves a stub .git) must be cleared
+    # before each attempt and must not wedge future runs: rm -rf before cloning,
+    # and gate on a completion marker (pyproject.toml/setup.py), not bare .git.
+    assert 'rm -rf "$SKILLSPECTOR_DIR"; timeout 300 git clone' in code
+    assert '! -f "$SKILLSPECTOR_DIR/pyproject.toml"' in code
+    assert '"$SKILLSPECTOR_DIR/.git"' not in code  # the wedge-prone bare-.git gate is gone
 
 
 # ── B9: remote installers download-to-temp, never pipe to a shell ───

--- a/tests/test_scripts/test_bootstrap_guards.py
+++ b/tests/test_scripts/test_bootstrap_guards.py
@@ -1,0 +1,147 @@
+"""Bootstrap robustness guards (deploy-audit P8a — B1/B3/B5/B6/B7/B8/B9/S3).
+
+These harden scripts/bootstrap.sh and scripts/setup-local-config.sh against
+premature completion signalling, skipped reloads, cwd-dependent MCP scope,
+unvalidated timezones, newline-less secret appends, hung dependency installs,
+pipe-to-shell truncation, and dead config. bootstrap.sh runs the full install
+(services, VNC, memory restore) and cannot be exercised in CI, so most locks are
+extraction assertions on the shipped text; B7's subtle newline logic gets a
+functional bash test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap.sh"
+SETUP_LOCAL = REPO_ROOT / "scripts" / "setup-local-config.sh"
+
+
+def _code(path: Path) -> str:
+    """Script text minus comment-only lines (so assertions match real code)."""
+    return "\n".join(ln for ln in path.read_text().splitlines() if not ln.lstrip().startswith("#"))
+
+
+# ── B1: setup-complete marker written only at the END ────────────────
+
+
+def test_b1_setup_complete_marker_written_at_end():
+    text = BOOTSTRAP.read_text()
+    marker = 'touch "$HOME/.genesis/setup-complete"'
+    assert text.count(marker) == 1, "the marker must be written exactly once"
+    touch_at = text.index(marker)
+    init_at = text.index("Initializing runtime state")
+    complete_at = text.index("=== Bootstrap complete ===")
+    # No longer written in the early runtime-state block …
+    assert touch_at > init_at, "marker must not be written in the early runtime-state block"
+    # … it sits right before the completion banner (so a crashed bootstrap leaves
+    # the box looking un-onboarded — the marker gates the onboarding prompt).
+    assert 0 < complete_at - touch_at < 300, "marker must be written immediately before completion"
+
+
+# ── B3: daemon-reload runs unconditionally before the enable loop ────
+
+
+def test_b3_daemon_reload_not_gated_on_services_updated():
+    text = BOOTSTRAP.read_text()
+    echo = 'echo "  systemd daemon reloaded (units changed)"'
+    echo_at = text.index(echo)
+    window = text[max(0, echo_at - 300) : echo_at]
+    # The reload itself is unconditional now …
+    assert "systemctl --user daemon-reload 2>/dev/null || true" in window
+    # … and precedes the SERVICES_UPDATED gate (which now guards only the echo).
+    assert 'if [[ "$SERVICES_UPDATED" = "1" ]]; then' in window
+    assert window.index("daemon-reload") < window.index('if [[ "$SERVICES_UPDATED"')
+
+
+# ── B5: serena project-scope register runs from the repo root ────────
+
+
+def test_b5_serena_register_runs_from_repo_root():
+    code = _code(BOOTSTRAP)
+    # `-s project` is cwd-keyed; the register must be wrapped in a cd-subshell so
+    # it always writes .mcp.json to the repo, never the caller's cwd.
+    assert '( cd "$GENESIS_ROOT" && _register_mcp "serena" "project"' in code
+
+
+# ── B6: timezone validated, but only when enumerable ────────────────
+
+
+def test_b6_timezone_validated_when_enumerable():
+    code = _code(BOOTSTRAP)
+    assert "_tz_list=$(timedatectl list-timezones 2>/dev/null || true)" in code
+    assert 'grep -qxF "$GENESIS_TIMEZONE"' in code
+    # Validation is GUARDED on a non-empty list, so an image that can't enumerate
+    # timezones is never force-reset to UTC.
+    assert 'if [[ -n "$_tz_list" ]] &&' in code
+    assert 'GENESIS_TIMEZONE="UTC"' in code  # the fallback on a genuinely invalid tz
+
+
+# ── B7: trailing-newline guard before the secrets append ────────────
+
+
+def test_b7_newline_guard_present():
+    code = _code(BOOTSTRAP)
+    assert '-n "$(tail -c1 "$SECRETS_FILE")"' in code
+
+
+def test_b7_newline_guard_functional(tmp_path):
+    """A newline is inserted ONLY when the file lacks a trailing one — so the new
+    key always lands on its own line and never concatenates onto the last one.
+    Runs under `set -euo pipefail` to prove the `[[ … ]] &&` guard is set-e-safe."""
+    guard = (
+        "set -euo pipefail; "
+        '[[ -s "$SECRETS_FILE" && -n "$(tail -c1 "$SECRETS_FILE")" ]] && printf \'\\n\' >> "$SECRETS_FILE"; '
+        "printf 'GENESIS_TIMEZONE=UTC\\n' >> \"$SECRETS_FILE\""
+    )
+    # No trailing newline → guard inserts one.
+    f1 = tmp_path / "no_nl.env"
+    f1.write_text("EXISTING=1")
+    subprocess.run(["bash", "-c", guard], env={**os.environ, "SECRETS_FILE": str(f1)}, check=True)
+    assert f1.read_text() == "EXISTING=1\nGENESIS_TIMEZONE=UTC\n"
+    # Already has a trailing newline → no extra blank line.
+    f2 = tmp_path / "with_nl.env"
+    f2.write_text("EXISTING=1\n")
+    subprocess.run(["bash", "-c", guard], env={**os.environ, "SECRETS_FILE": str(f2)}, check=True)
+    assert f2.read_text() == "EXISTING=1\nGENESIS_TIMEZONE=UTC\n"
+
+
+# ── B8: dependency installs are timeout-bounded + retried ───────────
+
+
+def test_b8_skillspector_install_is_bounded():
+    code = _code(BOOTSTRAP)
+    assert "timeout 300 git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git" in code
+    assert "_ss_clone || { sleep 2; _ss_clone; }" in code  # one retry rides out a blip
+    assert 'timeout 300 "$SKILLSPECTOR_DIR/.venv/bin/pip" install' in code
+
+
+# ── B9: remote installers download-to-temp, never pipe to a shell ───
+
+
+def test_b9_no_pipe_to_shell():
+    code = _code(BOOTSTRAP)
+    # The truncation-prone pipe-to-shell forms are gone …
+    assert "install.sh | bash" not in code
+    assert "uv/install.sh | sh" not in code
+    # … replaced by download-to-file then execute-from-file (full download first).
+    assert (
+        'curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh -o "$_cbm_installer"'
+        in code
+    )
+    assert 'bash "$_cbm_installer" --ui --skip-config' in code
+    assert 'curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer"' in code
+    assert 'sh "$_uv_installer"' in code
+
+
+# ── S3: dead REPO_EXAMPLE var + phantom migration comment removed ───
+
+
+def test_s3_dead_repo_example_removed():
+    cfg = SETUP_LOCAL.read_text()
+    assert "REPO_EXAMPLE" not in cfg
+    assert "genesis.yaml.example" not in cfg
+    assert "Migrate from repo YAML" not in cfg  # the misleading comment is corrected


### PR DESCRIPTION
Deploy-audit **P8a** — robustness guards over `scripts/bootstrap.sh` and `scripts/setup-local-config.sh`.

## Findings fixed
- **B1** — `setup-complete` marker written at the VERY END (after "Bootstrap complete"), not the early runtime-state block. The marker gates the fresh-install onboarding prompt (`genesis_session_context.py`) + ego cadence, so a bootstrap that crashes mid-run must not leave the box looking onboarded. Verified no consumer reads it mid-bootstrap; `touch` is idempotent so re-runs keep their marker.
- **B3** — `daemon-reload` runs unconditionally before the enable loop (was gated on `SERVICES_UPDATED`), covering a prior run that wrote a unit then crashed before reloading.
- **B5** — serena `-s project` register wrapped in `( cd "$GENESIS_ROOT" && … )`; project scope is cwd-keyed, so bootstrap run from elsewhere would write `.mcp.json` to the wrong repo.
- **B6** — resolved timezone validated against `timedatectl list-timezones`, but ONLY when it returns a non-empty list (never force-resets to UTC on an image that can't enumerate).
- **B7** — trailing-newline guard before the secrets.env append.
- **B8** — SkillSpector clone + pip `timeout 300`-bounded with one clone retry (a hung TCP connection can't stall bootstrap on an optional dep).
- **B9** — codebase-memory-mcp + uv installers download-to-temp then execute-from-file instead of `curl … | bash` (no truncated-installer execution).
- **S3** — removed dead `REPO_EXAMPLE` var + corrected the phantom "Migrate from repo YAML" comment.

## Testing
- New `test_bootstrap_guards.py` (extraction locks + a functional B7 newline test under `set -euo pipefail`); 9/9 pass.
- `bash -n` clean on both scripts.

## Deploy
No host gate — deploys in-container via `git pull` at next `update.sh`.