### PR TITLE
fix(net): network-watchdog self-heals a disabled timer on re-run (P8b — NR1)

### DIFF
--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -127,10 +127,19 @@ _netres_install_watchdog() {
     _netres_put_file "$dst" "$(cat "$NETRES_WATCHDOG_SRC")" "0755"
     _netres_put_file "$NETRES_ETC_ROOT/systemd/system/genesis-network-watchdog.service" "$(_netres_service_content "$dst")" "0644"
     _netres_put_file "$NETRES_ETC_ROOT/systemd/system/genesis-network-watchdog.timer" "$_NETRES_WATCHDOG_TIMER" "0644"
+    # Reload only when a unit file actually changed this run.
     if ((_NETRES_WROTE > before)); then
         sudo systemctl daemon-reload 2>/dev/null || true
+    fi
+    # ALWAYS ensure the timer is active (self-heal), decoupled from whether a file
+    # changed: a re-run must re-enable a timer that was disabled/stopped/masked
+    # externally since install — not skip just because the units are unchanged.
+    # The probe is a read (no sudo) and silent, so a healthy timer causes ZERO
+    # churn; only a genuinely-down timer triggers enable/start. NR1.
+    if ! systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1; then
         sudo systemctl enable genesis-network-watchdog.timer 2>/dev/null || true
         sudo systemctl start genesis-network-watchdog.timer 2>/dev/null || true
+        _NETRES_HEALED=1
     fi
 }
 
@@ -166,6 +175,7 @@ network_resilience_apply() {
 
     _NETRES_WROTE=0
     _NETRES_FAILED=""
+    _NETRES_HEALED=""
     _netres_apply_keepconfig
     _netres_install_watchdog
 
@@ -173,6 +183,8 @@ network_resilience_apply() {
         echo "  Network resilience NOT fully applied — see warnings above."
     elif ((_NETRES_WROTE > 0)); then
         echo "  Network resilience applied (KeepConfiguration + watchdog timer active)."
+    elif [[ -n "$_NETRES_HEALED" ]]; then
+        echo "  Network resilience: re-enabled a stopped/disabled watchdog timer."
     else
         echo "  Network resilience already in place."
     fi

--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -123,12 +123,17 @@ _netres_install_watchdog() {
         return 0
     fi
     local dst="$NETRES_LIBEXEC_DIR/network-watchdog.sh"
-    # If the timer unit is MASKED, its unit path is a symlink to /dev/null — the
-    # writes below use `tee`, which follows the symlink and would write to
-    # /dev/null (the real unit file is never created, and a later unmask then
-    # leaves nothing to enable). Unmask FIRST, and only when actually masked, so
-    # the rewrite recreates a real unit file and healthy runs stay churn-free. NR1.
-    if [ "$(systemctl is-enabled genesis-network-watchdog.timer 2>/dev/null)" = "masked" ]; then
+    # If the timer unit is MASKED, unmask FIRST (only when actually masked, so
+    # healthy runs stay churn-free). Two variants, both handled:
+    #  • "masked" (persistent): the /etc unit path is a symlink to /dev/null, and
+    #    the writes below use `tee` (follows symlinks) → they'd hit /dev/null and
+    #    never create the real unit; unmasking first lets the rewrite recreate it.
+    #  • "masked-runtime" (`mask --runtime`): a /run symlink shadows the unit so
+    #    enable/start fail until it's removed.
+    # `is-enabled` reports "masked" or "masked-runtime"; match both. NR1.
+    local _wd_state
+    _wd_state="$(systemctl is-enabled genesis-network-watchdog.timer 2>/dev/null || true)"
+    if [[ "$_wd_state" == masked* ]]; then
         sudo systemctl unmask genesis-network-watchdog.timer 2>/dev/null || true
     fi
     local before=$_NETRES_WROTE

--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -123,6 +123,14 @@ _netres_install_watchdog() {
         return 0
     fi
     local dst="$NETRES_LIBEXEC_DIR/network-watchdog.sh"
+    # If the timer unit is MASKED, its unit path is a symlink to /dev/null — the
+    # writes below use `tee`, which follows the symlink and would write to
+    # /dev/null (the real unit file is never created, and a later unmask then
+    # leaves nothing to enable). Unmask FIRST, and only when actually masked, so
+    # the rewrite recreates a real unit file and healthy runs stay churn-free. NR1.
+    if [ "$(systemctl is-enabled genesis-network-watchdog.timer 2>/dev/null)" = "masked" ]; then
+        sudo systemctl unmask genesis-network-watchdog.timer 2>/dev/null || true
+    fi
     local before=$_NETRES_WROTE
     _netres_put_file "$dst" "$(cat "$NETRES_WATCHDOG_SRC")" "0755"
     _netres_put_file "$NETRES_ETC_ROOT/systemd/system/genesis-network-watchdog.service" "$(_netres_service_content "$dst")" "0644"
@@ -140,11 +148,10 @@ _netres_install_watchdog() {
     # healthy timer causes ZERO churn; only a down/unpersisted timer heals. NR1.
     if ! systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1 \
         || ! systemctl is-enabled genesis-network-watchdog.timer >/dev/null 2>&1; then
-        # A masked timer can't be enabled/started until unmasked, and systemd never
-        # auto-unmasks — so unmask first, then enable+start, then VERIFY. Never claim
-        # a heal that didn't take: a still-down/unpersisted timer surfaces as a
-        # failure (WARNING + _NETRES_FAILED), not a false "re-enabled" success.
-        sudo systemctl unmask genesis-network-watchdog.timer 2>/dev/null || true
+        # (A masked timer was already unmasked + its unit rewritten above, before
+        # these writes, so enable now has a real unit file to act on.) enable+start,
+        # then VERIFY — never claim a heal that didn't take: a still-down/unpersisted
+        # timer surfaces as WARNING + _NETRES_FAILED, not a false "re-enabled" success.
         sudo systemctl enable genesis-network-watchdog.timer 2>/dev/null || true
         sudo systemctl start genesis-network-watchdog.timer 2>/dev/null || true
         if systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1 \

--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -146,16 +146,23 @@ _netres_install_watchdog() {
     # timer (e.g. `systemctl disable` without --now), which would silently fail to
     # persist across a reboot. Both probes are reads (no sudo) and silent, so a
     # healthy timer causes ZERO churn; only a down/unpersisted timer heals. NR1.
+    # Heal unless the timer is active AND *persistently* enabled. `is-enabled`
+    # exits 0 for BOTH "enabled" and "enabled-runtime" — but the latter is
+    # transient (stored under /run, gone on reboot), exactly what persistence must
+    # prevent — so key on stdout being EXACTLY "enabled" (matching the posture
+    # collector's network_watchdog_enabled signal), not the exit status.
+    local _wd_enabled
+    _wd_enabled="$(systemctl is-enabled genesis-network-watchdog.timer 2>/dev/null || true)"
     if ! systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1 \
-        || ! systemctl is-enabled genesis-network-watchdog.timer >/dev/null 2>&1; then
+        || [ "$_wd_enabled" != "enabled" ]; then
         # (A masked timer was already unmasked + its unit rewritten above, before
         # these writes, so enable now has a real unit file to act on.) enable+start,
-        # then VERIFY — never claim a heal that didn't take: a still-down/unpersisted
-        # timer surfaces as WARNING + _NETRES_FAILED, not a false "re-enabled" success.
+        # then VERIFY — never claim a heal that didn't take: a still-down or
+        # not-persistently-enabled timer surfaces as WARNING + _NETRES_FAILED.
         sudo systemctl enable genesis-network-watchdog.timer 2>/dev/null || true
         sudo systemctl start genesis-network-watchdog.timer 2>/dev/null || true
         if systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1 \
-            && systemctl is-enabled genesis-network-watchdog.timer >/dev/null 2>&1; then
+            && [ "$(systemctl is-enabled genesis-network-watchdog.timer 2>/dev/null || true)" = "enabled" ]; then
             _NETRES_HEALED=1
         else
             echo "  WARNING: watchdog timer could not be re-enabled (may be masked or broken)."

--- a/scripts/lib/network_resilience.sh
+++ b/scripts/lib/network_resilience.sh
@@ -131,15 +131,29 @@ _netres_install_watchdog() {
     if ((_NETRES_WROTE > before)); then
         sudo systemctl daemon-reload 2>/dev/null || true
     fi
-    # ALWAYS ensure the timer is active (self-heal), decoupled from whether a file
-    # changed: a re-run must re-enable a timer that was disabled/stopped/masked
-    # externally since install — not skip just because the units are unchanged.
-    # The probe is a read (no sudo) and silent, so a healthy timer causes ZERO
-    # churn; only a genuinely-down timer triggers enable/start. NR1.
-    if ! systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1; then
+    # ALWAYS ensure the timer is active AND enabled (self-heal), decoupled from
+    # whether a file changed: a re-run must re-establish a timer that was disabled/
+    # stopped/masked externally since install — not skip just because the units are
+    # unchanged. Both states matter: `is-active` alone misses an active-but-DISABLED
+    # timer (e.g. `systemctl disable` without --now), which would silently fail to
+    # persist across a reboot. Both probes are reads (no sudo) and silent, so a
+    # healthy timer causes ZERO churn; only a down/unpersisted timer heals. NR1.
+    if ! systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1 \
+        || ! systemctl is-enabled genesis-network-watchdog.timer >/dev/null 2>&1; then
+        # A masked timer can't be enabled/started until unmasked, and systemd never
+        # auto-unmasks — so unmask first, then enable+start, then VERIFY. Never claim
+        # a heal that didn't take: a still-down/unpersisted timer surfaces as a
+        # failure (WARNING + _NETRES_FAILED), not a false "re-enabled" success.
+        sudo systemctl unmask genesis-network-watchdog.timer 2>/dev/null || true
         sudo systemctl enable genesis-network-watchdog.timer 2>/dev/null || true
         sudo systemctl start genesis-network-watchdog.timer 2>/dev/null || true
-        _NETRES_HEALED=1
+        if systemctl is-active genesis-network-watchdog.timer >/dev/null 2>&1 \
+            && systemctl is-enabled genesis-network-watchdog.timer >/dev/null 2>&1; then
+            _NETRES_HEALED=1
+        else
+            echo "  WARNING: watchdog timer could not be re-enabled (may be masked or broken)."
+            _NETRES_FAILED=1
+        fi
     fi
 }
 

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -30,11 +30,12 @@ exec "$@"
 
 _SYSTEMCTL_STUB = """#!/bin/bash
 # Stateful stub for genesis-network-watchdog.timer, modelling real systemd:
-# `enable`->enabled, `start`->active, `mask`->(enable/start fail until `unmask`).
-# is-active / is-enabled are keyed on the UNIT ($2) and SILENT (never log — a
-# probe must not churn); tests can force states via WATCHDOG_TIMER_ACTIVE_RC /
-# WATCHDOG_TIMER_ENABLED_RC (or by deleting the .timer{started,enabled} state
-# files). systemd-networkd keeps the shared NETWORKD_* vars.
+# `enable`->enabled, `start`->active, mask (unit path = /dev/null symlink) ->
+# enable/start fail until `unmask`. is-enabled echoes the real state string
+# (enabled / enabled-runtime / disabled / masked); is-active/is-enabled are
+# keyed on the UNIT ($2) and SILENT (never log — a probe must not churn). Tests
+# drive state via the .timer{started,enabled,enabledruntime} files, the /dev/null
+# symlink, or WATCHDOG_TIMER_ACTIVE_RC. systemd-networkd keeps the NETWORKD_* vars.
 _b="${SYSTEMCTL_LOG%.log}"
 _T=genesis-network-watchdog.timer
 _TU="${NETRES_ETC_ROOT:-/nonexistent}/systemd/system/$_T"
@@ -48,9 +49,10 @@ if [ "$1" = "is-active" ]; then
 fi
 if [ "$1" = "is-enabled" ]; then
     if [ "$2" = "$_T" ]; then
-        [ -n "${WATCHDOG_TIMER_ENABLED_RC:-}" ] && exit "$WATCHDOG_TIMER_ENABLED_RC"
         _masked && { printf 'masked'; exit 1; }
-        [ -f "$_b.timerenabled" ] && exit 0 || exit 1
+        [ -f "$_b.timerenabled" ] && { printf 'enabled'; exit 0; }
+        [ -f "$_b.timerenabledruntime" ] && { printf 'enabled-runtime'; exit 0; }
+        printf 'disabled'; exit 1
     fi
     printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0
 fi
@@ -213,6 +215,26 @@ def test_masked_timer_unit_is_recreated_before_enable(tmp_path):
     assert "unmask genesis-network-watchdog.timer" in calls
     assert calls.index("unmask") < calls.index("enable genesis-network-watchdog.timer")
     assert "could not be re-enabled" not in result.stdout  # genuinely healed
+
+
+def test_runtime_enabled_timer_is_re_enabled_persistently(tmp_path):
+    """Codex P2: `enabled-runtime` (systemctl enable --runtime) is transient — it
+    lives under /run and vanishes on reboot, yet `is-enabled` exits 0 for it. An
+    exit-code check would wrongly treat it as persistent and skip enable; the heal
+    keys on stdout == exactly 'enabled', so a runtime-only enablement re-enables
+    persistently."""
+    env = _stage(tmp_path)
+    _run_apply(env)  # fresh: persistently enabled + active
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    base = env["SYSTEMCTL_LOG"][:-4]
+    Path(base + ".timerenabled").unlink(missing_ok=True)  # not persistently enabled …
+    Path(base + ".timerenabledruntime").write_text("")  # … only transiently enabled
+    result = _run_apply(env)
+    assert result.returncode == 0, result.stderr
+    calls = Path(env["SYSTEMCTL_LOG"]).read_text()
+    assert "enable genesis-network-watchdog.timer" in calls  # re-enabled persistently
+    assert "could not be re-enabled" not in result.stdout  # and it took
 
 
 def test_unhealable_timer_reports_failure_not_false_heal(tmp_path):

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -39,30 +39,32 @@ _SYSTEMCTL_STUB = """#!/bin/bash
 _b="${SYSTEMCTL_LOG%.log}"
 _T=genesis-network-watchdog.timer
 _TU="${NETRES_ETC_ROOT:-/nonexistent}/systemd/system/$_T"
-_masked() { [ -L "$_TU" ]; }   # real systemd: a masked unit path is a symlink to /dev/null
+_masked() { [ -L "$_TU" ]; }                   # persistent mask: /etc unit path is a /dev/null symlink
+_rmasked() { [ -f "$_b.timermaskruntime" ]; }  # runtime mask (`mask --runtime`): /run shadow, modeled as a flag
 if [ "$1" = "is-active" ]; then
     if [ "$2" = "$_T" ]; then
         [ -n "${WATCHDOG_TIMER_ACTIVE_RC:-}" ] && exit "$WATCHDOG_TIMER_ACTIVE_RC"
-        { _masked || [ ! -f "$_b.timerstarted" ]; } && exit 3 || exit 0
+        { _masked || _rmasked || [ ! -f "$_b.timerstarted" ]; } && exit 3 || exit 0
     fi
     exit "${NETWORKD_ACTIVE_RC:-0}"
 fi
 if [ "$1" = "is-enabled" ]; then
     if [ "$2" = "$_T" ]; then
         _masked && { printf 'masked'; exit 1; }
+        _rmasked && { printf 'masked-runtime'; exit 1; }
         [ -f "$_b.timerenabled" ] && { printf 'enabled'; exit 0; }
         [ -f "$_b.timerenabledruntime" ] && { printf 'enabled-runtime'; exit 0; }
         printf 'disabled'; exit 1
     fi
     printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0
 fi
-[ "$1" = "unmask" ] && _masked && rm -f "$_TU"   # real unmask removes the /dev/null symlink
+if [ "$1" = "unmask" ]; then _masked && rm -f "$_TU"; rm -f "$_b.timermaskruntime"; fi  # clears both variants
 if [ "$1" = "enable" ] && [ "$2" = "$_T" ]; then
-    _masked && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
+    { _masked || _rmasked; } && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
     : > "$_b.timerenabled"
 fi
 if [ "$1" = "start" ] && [ "$2" = "$_T" ]; then
-    _masked && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
+    { _masked || _rmasked; } && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
     : > "$_b.timerstarted"
 fi
 echo "$@" >> "$SYSTEMCTL_LOG"
@@ -235,6 +237,27 @@ def test_runtime_enabled_timer_is_re_enabled_persistently(tmp_path):
     calls = Path(env["SYSTEMCTL_LOG"]).read_text()
     assert "enable genesis-network-watchdog.timer" in calls  # re-enabled persistently
     assert "could not be re-enabled" not in result.stdout  # and it took
+
+
+def test_runtime_masked_timer_is_unmasked_and_healed(tmp_path):
+    """Codex P2: `mask --runtime` reports is-enabled 'masked-runtime' (a /run
+    shadow), not 'masked'. The unmask guard must match BOTH variants, else a
+    runtime-masked timer is never unmasked and the heal fails until reboot."""
+    env = _stage(tmp_path)
+    _run_apply(env)
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    base = env["SYSTEMCTL_LOG"][:-4]
+    Path(base + ".timermaskruntime").write_text("")  # `systemctl mask --runtime`
+    Path(base + ".timerstarted").unlink(missing_ok=True)
+    Path(base + ".timerenabled").unlink(missing_ok=True)
+    result = _run_apply(env)
+    assert result.returncode == 0, result.stderr
+    calls = Path(env["SYSTEMCTL_LOG"]).read_text()
+    assert "unmask genesis-network-watchdog.timer" in calls  # runtime mask detected + cleared
+    assert "enable genesis-network-watchdog.timer" in calls
+    assert calls.index("unmask") < calls.index("enable genesis-network-watchdog.timer")
+    assert "could not be re-enabled" not in result.stdout  # genuinely healed
 
 
 def test_unhealable_timer_reports_failure_not_false_heal(tmp_path):

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -37,7 +37,8 @@ _SYSTEMCTL_STUB = """#!/bin/bash
 # files). systemd-networkd keeps the shared NETWORKD_* vars.
 _b="${SYSTEMCTL_LOG%.log}"
 _T=genesis-network-watchdog.timer
-_masked() { [ -f "$_b.timermasked" ]; }
+_TU="${NETRES_ETC_ROOT:-/nonexistent}/systemd/system/$_T"
+_masked() { [ -L "$_TU" ]; }   # real systemd: a masked unit path is a symlink to /dev/null
 if [ "$1" = "is-active" ]; then
     if [ "$2" = "$_T" ]; then
         [ -n "${WATCHDOG_TIMER_ACTIVE_RC:-}" ] && exit "$WATCHDOG_TIMER_ACTIVE_RC"
@@ -48,12 +49,12 @@ fi
 if [ "$1" = "is-enabled" ]; then
     if [ "$2" = "$_T" ]; then
         [ -n "${WATCHDOG_TIMER_ENABLED_RC:-}" ] && exit "$WATCHDOG_TIMER_ENABLED_RC"
-        { _masked || [ ! -f "$_b.timerenabled" ]; } && exit 1 || exit 0
+        _masked && { printf 'masked'; exit 1; }
+        [ -f "$_b.timerenabled" ] && exit 0 || exit 1
     fi
     printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0
 fi
-[ "$1" = "mask" ] && [ "$2" = "$_T" ] && : > "$_b.timermasked"
-[ "$1" = "unmask" ] && rm -f "$_b.timermasked"
+[ "$1" = "unmask" ] && _masked && rm -f "$_TU"   # real unmask removes the /dev/null symlink
 if [ "$1" = "enable" ] && [ "$2" = "$_T" ]; then
     _masked && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
     : > "$_b.timerenabled"
@@ -182,20 +183,36 @@ def test_second_run_heals_disabled_timer(tmp_path):
     assert "re-enabled a stopped/disabled watchdog timer" in result.stdout
 
 
-def test_second_run_unmasks_and_heals_masked_timer(tmp_path):
-    """A masked timer can't be enabled/started until unmasked; the self-heal
-    unmasks first, then re-enables — and genuinely heals (code-reviewer)."""
+def test_masked_timer_unit_is_recreated_before_enable(tmp_path):
+    """Codex P2: a masked timer's unit path is a symlink to /dev/null, and the
+    unit writes use `tee` (which follows the symlink). The self-heal must UNMASK
+    (remove the symlink) BEFORE rewriting the unit — else the write goes to
+    /dev/null and enable has no unit file. After apply the unit must be a REAL
+    file (not the symlink), unmask must precede enable, and the heal must NOT
+    report failure."""
     env = _stage(tmp_path)
-    _run_apply(env)
+    _run_apply(env)  # fresh: real unit files + active/enabled
+    timer = _paths(env)["timer"]
+    assert not timer.is_symlink()  # sanity: fresh install wrote a real file
+
+    # Simulate `systemctl mask`: the unit path becomes a /dev/null symlink, and
+    # the unit is thereby stopped + disabled.
+    timer.unlink()
+    timer.symlink_to("/dev/null")
+    base = env["SYSTEMCTL_LOG"][:-4]
+    Path(base + ".timerstarted").unlink(missing_ok=True)
+    Path(base + ".timerenabled").unlink(missing_ok=True)
     Path(env["SYSTEMCTL_LOG"]).write_text("")
 
-    Path(env["SYSTEMCTL_LOG"][:-4] + ".timermasked").write_text("")  # externally masked
     result = _run_apply(env)
     assert result.returncode == 0, result.stderr
+    # Unmasked + rewritten as a real file (the write did NOT go to /dev/null).
+    assert not timer.is_symlink(), "masked unit must be unmasked+rewritten as a real file"
+    assert "[Timer]" in timer.read_text()
     calls = Path(env["SYSTEMCTL_LOG"]).read_text()
-    assert "unmask genesis-network-watchdog.timer" in calls  # unmasked first …
-    assert "enable genesis-network-watchdog.timer" in calls  # … then re-enabled
-    assert "re-enabled a stopped/disabled watchdog timer" in result.stdout
+    assert "unmask genesis-network-watchdog.timer" in calls
+    assert calls.index("unmask") < calls.index("enable genesis-network-watchdog.timer")
+    assert "could not be re-enabled" not in result.stdout  # genuinely healed
 
 
 def test_unhealable_timer_reports_failure_not_false_heal(tmp_path):

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -29,22 +29,39 @@ exec "$@"
 """
 
 _SYSTEMCTL_STUB = """#!/bin/bash
-# is-active is keyed on the UNIT ($2) so the watchdog timer's state is
-# independently controllable. The timer is "active" iff a prior `start` ran this
-# test (models real start->active), UNLESS a test forces WATCHDOG_TIMER_ACTIVE_RC
-# to simulate an externally-stopped timer. systemd-networkd keeps the shared
-# NETWORKD_ACTIVE_RC. is-active never logs (a silent probe must not churn).
-_tstate="${SYSTEMCTL_LOG%.log}.timerstate"
+# Stateful stub for genesis-network-watchdog.timer, modelling real systemd:
+# `enable`->enabled, `start`->active, `mask`->(enable/start fail until `unmask`).
+# is-active / is-enabled are keyed on the UNIT ($2) and SILENT (never log — a
+# probe must not churn); tests can force states via WATCHDOG_TIMER_ACTIVE_RC /
+# WATCHDOG_TIMER_ENABLED_RC (or by deleting the .timer{started,enabled} state
+# files). systemd-networkd keeps the shared NETWORKD_* vars.
+_b="${SYSTEMCTL_LOG%.log}"
+_T=genesis-network-watchdog.timer
+_masked() { [ -f "$_b.timermasked" ]; }
 if [ "$1" = "is-active" ]; then
-    case "$2" in
-        genesis-network-watchdog.timer)
-            [ -n "${WATCHDOG_TIMER_ACTIVE_RC:-}" ] && exit "$WATCHDOG_TIMER_ACTIVE_RC"
-            [ -f "$_tstate" ] && exit 0 || exit 3 ;;
-        *) exit "${NETWORKD_ACTIVE_RC:-0}" ;;
-    esac
+    if [ "$2" = "$_T" ]; then
+        [ -n "${WATCHDOG_TIMER_ACTIVE_RC:-}" ] && exit "$WATCHDOG_TIMER_ACTIVE_RC"
+        { _masked || [ ! -f "$_b.timerstarted" ]; } && exit 3 || exit 0
+    fi
+    exit "${NETWORKD_ACTIVE_RC:-0}"
 fi
-if [ "$1" = "is-enabled" ]; then printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0; fi
-[ "$1" = "start" ] && : > "$_tstate"
+if [ "$1" = "is-enabled" ]; then
+    if [ "$2" = "$_T" ]; then
+        [ -n "${WATCHDOG_TIMER_ENABLED_RC:-}" ] && exit "$WATCHDOG_TIMER_ENABLED_RC"
+        { _masked || [ ! -f "$_b.timerenabled" ]; } && exit 1 || exit 0
+    fi
+    printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0
+fi
+[ "$1" = "mask" ] && [ "$2" = "$_T" ] && : > "$_b.timermasked"
+[ "$1" = "unmask" ] && rm -f "$_b.timermasked"
+if [ "$1" = "enable" ] && [ "$2" = "$_T" ]; then
+    _masked && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
+    : > "$_b.timerenabled"
+fi
+if [ "$1" = "start" ] && [ "$2" = "$_T" ]; then
+    _masked && { echo "$@" >> "$SYSTEMCTL_LOG"; exit 1; }
+    : > "$_b.timerstarted"
+fi
 echo "$@" >> "$SYSTEMCTL_LOG"
 exit 0
 """
@@ -149,22 +166,52 @@ def test_second_run_is_a_noop(tmp_path):
     assert Path(env["SYSTEMCTL_LOG"]).read_text() == ""
 
 
-def test_second_run_heals_externally_disabled_timer(tmp_path):
-    """NR1: a re-run must RE-ENABLE a watchdog timer that was disabled/stopped/
-    masked externally since install — not skip just because the unit files are
-    unchanged this run. This is the gap the old `_NETRES_WROTE`-gated enable had."""
+def test_second_run_heals_disabled_timer(tmp_path):
+    """NR1 + Codex P2: an active-but-DISABLED timer (e.g. `systemctl disable`
+    without --now — won't persist across reboot) must heal, even though
+    `is-active` alone would report it fine. The self-heal probes enablement too."""
     env = _stage(tmp_path)
-    _run_apply(env)  # fresh install: timer active
+    _run_apply(env)  # fresh install: active + enabled
     Path(env["SYSTEMCTL_LOG"]).write_text("")
 
-    # Simulate the timer going down between runs (external disable/stop/mask).
-    env["WATCHDOG_TIMER_ACTIVE_RC"] = "3"
+    Path(env["SYSTEMCTL_LOG"][:-4] + ".timerenabled").unlink()  # externally disabled
     result = _run_apply(env)
     assert result.returncode == 0, result.stderr
     calls = Path(env["SYSTEMCTL_LOG"]).read_text()
-    assert "enable genesis-network-watchdog.timer" in calls  # re-enabled …
-    assert "start genesis-network-watchdog.timer" in calls  # … and restarted
+    assert "enable genesis-network-watchdog.timer" in calls  # re-enabled for persistence
     assert "re-enabled a stopped/disabled watchdog timer" in result.stdout
+
+
+def test_second_run_unmasks_and_heals_masked_timer(tmp_path):
+    """A masked timer can't be enabled/started until unmasked; the self-heal
+    unmasks first, then re-enables — and genuinely heals (code-reviewer)."""
+    env = _stage(tmp_path)
+    _run_apply(env)
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    Path(env["SYSTEMCTL_LOG"][:-4] + ".timermasked").write_text("")  # externally masked
+    result = _run_apply(env)
+    assert result.returncode == 0, result.stderr
+    calls = Path(env["SYSTEMCTL_LOG"]).read_text()
+    assert "unmask genesis-network-watchdog.timer" in calls  # unmasked first …
+    assert "enable genesis-network-watchdog.timer" in calls  # … then re-enabled
+    assert "re-enabled a stopped/disabled watchdog timer" in result.stdout
+
+
+def test_unhealable_timer_reports_failure_not_false_heal(tmp_path):
+    """code-reviewer SHOULD-FIX: if enable/start don't take (broken/permanently
+    down unit), the heal must VERIFY and report failure — never a false
+    're-enabled' success on a state that's still broken."""
+    env = _stage(tmp_path)
+    _run_apply(env)
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    env["WATCHDOG_TIMER_ACTIVE_RC"] = "3"  # stays down through the post-heal verify
+    result = _run_apply(env)
+    assert result.returncode == 0, result.stderr
+    assert "could not be re-enabled" in result.stdout  # honest WARNING
+    assert "re-enabled a stopped/disabled watchdog timer" not in result.stdout
+    assert "NOT fully applied" in result.stdout  # routed to the _NETRES_FAILED path
 
 
 def test_no_systemd_skips_cleanly(tmp_path):

--- a/tests/test_scripts/test_network_resilience.py
+++ b/tests/test_scripts/test_network_resilience.py
@@ -29,8 +29,22 @@ exec "$@"
 """
 
 _SYSTEMCTL_STUB = """#!/bin/bash
-if [ "$1" = "is-active" ]; then exit "${NETWORKD_ACTIVE_RC:-0}"; fi
+# is-active is keyed on the UNIT ($2) so the watchdog timer's state is
+# independently controllable. The timer is "active" iff a prior `start` ran this
+# test (models real start->active), UNLESS a test forces WATCHDOG_TIMER_ACTIVE_RC
+# to simulate an externally-stopped timer. systemd-networkd keeps the shared
+# NETWORKD_ACTIVE_RC. is-active never logs (a silent probe must not churn).
+_tstate="${SYSTEMCTL_LOG%.log}.timerstate"
+if [ "$1" = "is-active" ]; then
+    case "$2" in
+        genesis-network-watchdog.timer)
+            [ -n "${WATCHDOG_TIMER_ACTIVE_RC:-}" ] && exit "$WATCHDOG_TIMER_ACTIVE_RC"
+            [ -f "$_tstate" ] && exit 0 || exit 3 ;;
+        *) exit "${NETWORKD_ACTIVE_RC:-0}" ;;
+    esac
+fi
 if [ "$1" = "is-enabled" ]; then printf '%s' "${NETWORKD_ENABLED-enabled}"; exit 0; fi
+[ "$1" = "start" ] && : > "$_tstate"
 echo "$@" >> "$SYSTEMCTL_LOG"
 exit 0
 """
@@ -121,14 +135,36 @@ def test_fresh_apply_writes_dropin_units_and_reloads(tmp_path):
 
 
 def test_second_run_is_a_noop(tmp_path):
+    """A re-run with a HEALTHY (active) timer stays churn-free: the self-heal
+    probe (`is-active`) is silent, so no reload/enable/start is logged. NR1's
+    self-heal must not turn a healthy re-run into churn."""
     env = _stage(tmp_path)
-    _run_apply(env)
+    _run_apply(env)  # fresh install: timer written + started → now active
     Path(env["SYSTEMCTL_LOG"]).write_text("")
 
     result = _run_apply(env)
     assert result.returncode == 0
     assert "already in place" in result.stdout
-    assert Path(env["SYSTEMCTL_LOG"]).read_text() == ""  # no reload/daemon churn
+    # The silent is-active probe finds the timer active → no reload/enable/start.
+    assert Path(env["SYSTEMCTL_LOG"]).read_text() == ""
+
+
+def test_second_run_heals_externally_disabled_timer(tmp_path):
+    """NR1: a re-run must RE-ENABLE a watchdog timer that was disabled/stopped/
+    masked externally since install — not skip just because the unit files are
+    unchanged this run. This is the gap the old `_NETRES_WROTE`-gated enable had."""
+    env = _stage(tmp_path)
+    _run_apply(env)  # fresh install: timer active
+    Path(env["SYSTEMCTL_LOG"]).write_text("")
+
+    # Simulate the timer going down between runs (external disable/stop/mask).
+    env["WATCHDOG_TIMER_ACTIVE_RC"] = "3"
+    result = _run_apply(env)
+    assert result.returncode == 0, result.stderr
+    calls = Path(env["SYSTEMCTL_LOG"]).read_text()
+    assert "enable genesis-network-watchdog.timer" in calls  # re-enabled …
+    assert "start genesis-network-watchdog.timer" in calls  # … and restarted
+    assert "re-enabled a stopped/disabled watchdog timer" in result.stdout
 
 
 def test_no_systemd_skips_cleanly(tmp_path):


### PR DESCRIPTION
Deploy-audit **NR1**. The network-watchdog enable/start was gated on `_NETRES_WROTE` — it only ran when a unit file was newly written that run. A re-run with unchanged unit files never re-verified the timer, so a timer disabled/stopped/masked externally since install was **never healed**.

## Fix
Decouple "ensure the timer is active" from "did I write a file": on every apply, silently probe `systemctl is-active genesis-network-watchdog.timer` (a read — no sudo, no output) and only `enable`/`start` when it is actually down.
- Healthy re-run → just the silent probe → **zero** systemctl churn.
- Down timer → re-enabled + restarted; new "re-enabled a stopped/disabled watchdog timer" summary line.
- `daemon-reload` still runs only when a unit file changed.

## Testing
- `test_second_run_is_a_noop` **preserved** (a healthy re-run stays churn-free — the probe doesn't log), NOT flipped: the earlier "must flip the green test" assumption was design-dependent and a silent-probe design keeps it valid.
- The systemctl stub is made **stateful** (`start`→active) and **unit-keyed** so the timer's active-state is independently controllable.
- New `test_second_run_heals_externally_disabled_timer` covers the heal path. 25/25 pass; `bash -n` clean.

## Deploy
No host gate — `scripts/lib/network_resilience.sh` deploys in-container via `git pull` at next `update.sh`.