### PR TITLE
feat(cc): foreground-session liveness reaper (D3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **An interrupted request no longer vanishes silently.** If a message you sent
+  on Telegram was cut off before Genesis finished answering — a crash, a
+  restart, or the session going dark mid-turn — Genesis now notices the
+  abandoned session on its next hygiene pass and tells you it was interrupted so
+  you can re-send, instead of leaving you waiting on a reply that never comes.
+  Configurable via `cc_foreground_reaper` (`off` / `observe` / `notify`, default
+  `notify`); observability-only — it never silently re-runs the lost work.
 - **Ambient capture now alerts when auto-recovery can't bring a wedged device
   back.** For installs running the optional voice/ambient edge with device
   auto-recovery armed, Genesis now raises a capture-health alert when the device

--- a/config/cc_foreground_reaper.yaml
+++ b/config/cc_foreground_reaper.yaml
@@ -1,0 +1,23 @@
+# Foreground-session liveness reaper (D3).
+# See src/genesis/cc/foreground_reaper_config.py for the full contract.
+#
+# A foreground cc_sessions row stays 'active' by design so the next turn can
+# --resume it, so a crash/OOM/restart mid-turn leaves it 'active' forever. This
+# reaper relabels such dark rows to 'checkpointed' (non-destructive, still
+# resumable), records a dark-session observation, and — on the crisp
+# "unanswered user turn" signal — notifies the origin user that their request
+# was interrupted.
+
+enabled: true
+
+# off | observe | notify
+#   off     — do nothing (dark rows stay 'active', pre-D3 status quo)
+#   observe — reap + observe, but never notify the user
+#   notify  — observe + notify on the crisp unanswered-user signal
+mode: notify
+
+# A foreground row idle at least this long with no live turn is treated as dark.
+idle_hours: 24
+
+# Loud-truncation cap on dark rows processed per reaper pass.
+max_per_tick: 200

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -137,7 +137,7 @@ any task bigger than an LLM call.
 ```yaml subsystem-map
 entry: execution-cc
 modules: [cc]
-verified: 3c5e1f24 2026-07-22
+verified: 0a3fc19d 2026-07-23
 ```
 
 - `cc/direct_session.py` + `cc/conversation.py` (both >1000 LOC; split
@@ -157,6 +157,20 @@ verified: 3c5e1f24 2026-07-22
   .shutdown`, 10s grace) BEFORE closing the DB so that handler can persist
   (2026-07-09; the old crud `reap_stale`, which relabeled orphans
   'completed', is deleted). J-9 counts only `completed` as success.
+- **Foreground liveness (D3)** (`cc/foreground_reaper.py`): foreground rows stay
+  `active` by design so the next turn can `--resume`, so a crash/restart mid-turn
+  leaves one `active` forever — `query_stale` excludes foreground, so nothing
+  reaped them. The `session_reaper` job now ALSO runs `reap_dark_foreground`
+  (its own inner try/except — a notify failure can't abort stale-session
+  cleanup): foreground rows idle >24h → `checkpointed` via `checkpoint_dark`
+  (non-destructive — `get_active_foreground` matches `checkpointed` and
+  `get_or_create_foreground` flips it back to `active` on reuse, so `--resume` is
+  intact). On the CRISP "unanswered user turn" transcript signal (age-guarded to
+  exclude a mid-flight turn, and not already covered by a rate-limit park or
+  dispatch) it notifies the origin user their request was interrupted; the FUZZY
+  "I'll report back" signal is shadow-logged only until its precision is measured.
+  Observability-only (never re-dispatches). Lever: `cc_foreground_reaper`
+  (`off|observe|notify`, default `notify`) + `GENESIS_FOREGROUND_REAPER_DISABLED`.
 - **Perimeter-session hardening:** `_NO_WEB_TOOLS` / `_NO_OUTREACH_EXTRAS`
   blocklists strip risky tools from perimeter profiles — a security edge, not
   configuration convenience.

--- a/src/genesis/cc/foreground_reaper.py
+++ b/src/genesis/cc/foreground_reaper.py
@@ -1,0 +1,405 @@
+"""Foreground CC-session liveness reaper (D3).
+
+A foreground ``cc_sessions`` row stays ``status='active'`` by design after a
+successful turn so the next turn can ``--resume`` it. There is no guaranteed
+terminal write, so a crash / OOM / container restart mid-turn leaves the row
+``active`` forever — indistinguishable from a healthy resumable session (the
+2026-07-20 silent-death: a foreground turn launched background work, said "I'll
+report back", was killed, and its row sat ``active`` 26h+ with the user never
+told). Nothing reaps foreground rows: the ``session_reaper`` job hard-excludes
+them (``query_stale`` filters ``session_type != 'foreground'``).
+
+This reaper closes that gap WITHOUT breaking resume. Each pass:
+  1. Finds foreground rows idle > ``idle_hours`` (``query_stale_foreground``).
+  2. Relabels each ``active`` → ``checkpointed`` (``checkpoint_dark``,
+     rowcount-guarded). Non-destructive: ``get_active_foreground`` matches
+     ``checkpointed`` and ``get_or_create_foreground`` flips it back to ``active``
+     on reuse, so ``--resume`` is untouched.
+  3. Classifies the transcript tail (``dark_signal``) and, on the CRISP
+     "unanswered user turn" signal — gated on the tail turn's OWN age and not
+     already covered by the rate-limit / dispatch machinery — notifies the
+     origin user their request was interrupted. The FUZZY promise-regex signal
+     is shadow-logged only (never notifies) until its precision is measured.
+
+Observability-only: it never re-dispatches or auto-retries the dead work. The
+whole pass is gated by ``cc_foreground_reaper`` (``off | observe | notify``).
+Wired into the existing ``session_reaper`` job in its OWN inner try/except so a
+notify failure can never abort the stale-session / heartbeat cleanup.
+"""
+
+from __future__ import annotations
+
+import html as html_mod
+import json
+import logging
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from genesis.cc.foreground_reaper_config import effective_mode, knob_int, load_config
+from genesis.db.crud import cc_sessions, observations
+from genesis.env import cc_project_dir
+from genesis.session_awareness.transcript import _assistant_text, typed_prompt_text
+
+logger = logging.getLogger(__name__)
+
+# Narrow "promised deferred work" regex — SHADOW ONLY (never notifies) until its
+# precision is measured against real dark rows. Deliberately tight to the
+# report-back shapes Genesis actually emits, not generic sign-offs.
+_PROMISE_RE = re.compile(
+    r"(report back|get back to you|running in the background|"
+    r"in the background and will|i['’]?ll (let you know|update you|follow up)|"
+    r"once (it|this|that) (finishes|completes|is done|wraps up))",
+    re.IGNORECASE,
+)
+
+# Retention for routine (low-priority) dark-session observations.
+_OBS_TTL_DAYS = 45
+_TAIL_MAX_BYTES = 262_144  # read at most the last 256 KB of a transcript
+_TAIL_MAX_ENTRIES = 80  # classify over at most the last 80 parsed entries
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested without I/O or a runtime)
+# ---------------------------------------------------------------------------
+def dark_signal(entries: list[dict]) -> tuple[str, str | None]:
+    """Classify a transcript tail. Returns ``(signal, last_user_ts)``.
+
+    - ``unanswered_user`` — the last typed user prompt has NO assistant text
+      reply after it (a turn that died before answering). CRISP → eligible to
+      notify (subject to the age guard + covered-by check in the reaper).
+    - ``promise`` — the last user turn WAS answered, but the reply promised
+      deferred work ("I'll report back") that may have died. FUZZY → shadow only.
+    - ``clean`` — answered, no deferral promise (a normal walk-away).
+    - ``unknown`` — no typed user turn found (e.g. no transcript / earliest-crash
+      session with no ``cc_session_id``).
+
+    ``last_user_ts`` is the ISO timestamp of the last user turn (for the age
+    guard), or None.
+    """
+    last_user_idx = -1
+    last_user_ts: str | None = None
+    for i, entry in enumerate(entries):
+        if typed_prompt_text(entry) is not None:
+            last_user_idx = i
+            last_user_ts = str(entry.get("timestamp") or "") or None
+    if last_user_idx == -1:
+        return "unknown", None
+    reply: str | None = None
+    for entry in entries[last_user_idx + 1 :]:
+        txt = _assistant_text(entry)
+        if txt:
+            reply = txt
+    if reply is None:
+        return "unanswered_user", last_user_ts
+    if _PROMISE_RE.search(reply):
+        return "promise", last_user_ts
+    return "clean", last_user_ts
+
+
+def _ts_older_than(ts_iso: str | None, cutoff: datetime) -> bool:
+    """True iff ``ts_iso`` parses to a time at/before ``cutoff`` (age guard).
+
+    A missing/unparseable timestamp is treated as NOT-old — we never notify on a
+    turn whose age we cannot establish (conservative against the mid-flight FP).
+    """
+    if not ts_iso:
+        return False
+    try:
+        dt = datetime.fromisoformat(ts_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt <= cutoff
+
+
+def _transcript_path(cc_session_id: str) -> Path:
+    """Path to a foreground session's CC transcript jsonl.
+
+    Foreground sessions run in the repo root, so the project dir is
+    ``cc_project_dir()`` — the same resolver the memory-extraction job uses.
+    """
+    return Path.home() / ".claude" / "projects" / cc_project_dir() / f"{cc_session_id}.jsonl"
+
+
+def _read_tail_entries(
+    path: Path,
+    *,
+    max_bytes: int = _TAIL_MAX_BYTES,
+    max_entries: int = _TAIL_MAX_ENTRIES,
+) -> list[dict]:
+    """Last decoded JSONL entries of a transcript (bounded), oldest-first.
+
+    Reads only the trailing ``max_bytes`` and drops a possibly-torn first line;
+    returns at most ``max_entries`` decoded dict entries. Missing/unreadable →
+    ``[]`` (a session with no transcript simply yields the ``unknown`` signal).
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return []
+    try:
+        with path.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+                fh.readline()  # discard the torn partial line at the seek point
+            raw_lines = fh.read().splitlines()
+    except OSError:
+        return []
+    entries: list[dict] = []
+    for raw in raw_lines:
+        try:
+            entry = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(entry, dict):
+            entries.append(entry)
+    return entries[-max_entries:]
+
+
+# ---------------------------------------------------------------------------
+# Async steps
+# ---------------------------------------------------------------------------
+async def _covered_by_other_subsystem(db: Any, origin_session_id: str) -> bool:
+    """True iff the rate-limit park or dispatch machinery already owns notifying
+    the user about this session's work — so the reaper must not double-notify."""
+    from genesis.db.crud import cc_rate_limit_parks, direct_session_queue
+
+    return await cc_rate_limit_parks.has_open_for_origin(
+        db, origin_session_id
+    ) or await direct_session_queue.has_open_for_origin(db, origin_session_id)
+
+
+async def _notify_origin(rt: Any, row: dict) -> bool:
+    """Tell the origin user their earlier request was interrupted.
+
+    Reuses the shipped delivery path (``_resolve_origin_target`` +
+    ``submit_urgent(verbatim=True)``). Returns True iff a notify was submitted.
+    Best-effort — the caller isolates exceptions. Non-addressable origins
+    (non-Telegram / legacy) get no notify; the observation is the only record.
+    """
+    pipeline = getattr(rt, "_outreach_pipeline", None)
+    if pipeline is None:
+        return False
+    from genesis.cc.direct_session import DirectSessionRunner
+
+    chat_id, thread_id = DirectSessionRunner._resolve_origin_target(
+        row.get("channel"),
+        row.get("chat_id"),
+        row.get("user_id") or "",
+        row.get("thread_id"),
+        getattr(pipeline, "_forum_chat_id", None),
+    )
+    if not chat_id:
+        return False
+    topic_hint = (row.get("topic") or "").strip()
+    hint = f' ("{html_mod.escape(topic_hint[:80])}")' if topic_hint else ""
+    text = (
+        "<b>⚠️ Earlier request interrupted</b>\n\n"
+        f"Your earlier request{hint} looks like it was interrupted before I "
+        "finished, and nothing is still running on it. If you still want it, "
+        "please re-send."
+    )
+    from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+    try:
+        await pipeline.submit_urgent(
+            OutreachRequest(
+                category=OutreachCategory.ALERT,
+                # Unique per session so governance dedup never collides.
+                topic=f"dark_session:{row['id']}",
+                context=text,
+                salience_score=0.85,
+                channel="telegram",
+                verbatim=True,
+                target_chat_id=chat_id,
+                target_thread_id=thread_id,
+            )
+        )
+    except Exception:
+        # Delivery is best-effort and must NOT propagate: the row is already
+        # checkpointed, so a raise would drop the caller's high-priority
+        # observation and the alert would be lost forever (never re-selected).
+        # The eligibility-driven high-priority observation still surfaces it.
+        logger.warning(
+            "foreground reaper: dark-session notify delivery failed for %s",
+            row["id"][:8],
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+async def _observe(
+    db: Any,
+    row: dict,
+    *,
+    signal: str,
+    notify_eligible: bool,
+    notified: bool,
+    shadow: bool,
+    now: datetime,
+) -> None:
+    """Record a dark-session observation.
+
+    Priority is driven by ELIGIBILITY, not delivery success: a crisp dead
+    request (``notify_eligible``) is `high` — so it surfaces in the morning
+    report EVEN IF the direct Telegram delivery raised/failed (the alert is
+    never silently lost). Everything else (shadow promise, mid-flight, covered)
+    is `low` + TTL-bounded.
+    """
+    priority = "high" if notify_eligible else "low"
+    expires_at = None if notify_eligible else (now + timedelta(days=_OBS_TTL_DAYS)).isoformat()
+    marker = "shadow " if shadow else ""
+    if not notify_eligible:
+        disposition = "not eligible"
+    elif notified:
+        disposition = "notified"
+    else:
+        disposition = "delivery failed (surfaced via this observation)"
+    content = (
+        f"Dark foreground session reaped to 'checkpointed': {row['id'][:8]} "
+        f"(channel={row.get('channel')}, last_activity_at={row.get('last_activity_at')}); "
+        f"signal={signal}; {marker}notify {disposition}."
+    )
+    try:
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="foreground_reaper",
+            type="dark_foreground_session",
+            content=content,
+            priority=priority,
+            created_at=now.isoformat(),
+            expires_at=expires_at,
+        )
+    except Exception:
+        logger.warning(
+            "foreground reaper: observation write failed for %s",
+            row["id"][:8],
+            exc_info=True,
+        )
+
+
+async def _process_row(
+    rt: Any,
+    db: Any,
+    row: dict,
+    *,
+    now: datetime,
+    cutoff: datetime,
+    mode: str,
+    result: dict,
+) -> None:
+    """Reap one dark row (checkpoint → classify → observe/notify). Isolated per
+    row by the caller so one bad row cannot abort the pass."""
+    won = await cc_sessions.checkpoint_dark(db, row["id"], checkpointed_at=now.isoformat())
+    if not won:
+        # A concurrent turn revived the row between the query and this write.
+        return
+    result["reaped"] += 1
+
+    signal, tail_ts = "unknown", None
+    cc_sid = row.get("cc_session_id")
+    if cc_sid:
+        signal, tail_ts = dark_signal(_read_tail_entries(_transcript_path(cc_sid)))
+
+    shadow = signal == "promise"
+    if shadow:
+        result["shadow"] += 1
+
+    # Notify-eligible = a CRISP dead request we should tell the user about:
+    # unanswered user turn, in notify mode, the turn itself older than the idle
+    # cutoff (age guard — excludes a mid-flight long turn whose session-level
+    # last_activity is merely stale), and not already owned by the rate-limit
+    # park / dispatch machinery.
+    notify_eligible = (
+        signal == "unanswered_user"
+        and mode == "notify"
+        and _ts_older_than(tail_ts, cutoff)
+        and not await _covered_by_other_subsystem(db, row["id"])
+    )
+    notified = False
+    if notify_eligible:
+        notified = await _notify_origin(rt, row)  # never raises; False on failure
+        if notified:
+            result["notified"] += 1
+
+    # Observe only the noteworthy signals; a routine 'clean'/'unknown' reap is
+    # silent hygiene. Priority is eligibility-driven (see _observe) so a failed
+    # delivery still surfaces the dead request via the morning report.
+    if signal in ("unanswered_user", "promise"):
+        await _observe(
+            db,
+            row,
+            signal=signal,
+            notify_eligible=notify_eligible,
+            notified=notified,
+            shadow=shadow,
+            now=now,
+        )
+
+
+async def reap_dark_foreground(
+    rt: Any,
+    *,
+    now: datetime | None = None,
+    idle_hours: int | None = None,
+    mode: str | None = None,
+) -> dict:
+    """One reaper pass. Returns a summary dict (mode/scanned/reaped/notified/shadow).
+
+    Safe to call from the ``session_reaper`` job. Never raises for a per-row
+    problem (each row is isolated); a catastrophic failure (bad db) surfaces to
+    the caller's try/except.
+    """
+    result = {"mode": None, "scanned": 0, "reaped": 0, "notified": 0, "shadow": 0}
+    db = getattr(rt, "_db", None)
+    if db is None:
+        return result
+
+    mode = mode or effective_mode()
+    result["mode"] = mode
+    if mode == "off":
+        return result
+
+    cfg = load_config()
+    if idle_hours is None:
+        idle_hours = knob_int(cfg, "idle_hours")
+    max_per_tick = knob_int(cfg, "max_per_tick")
+    now = now or datetime.now(UTC)
+    cutoff = now - timedelta(hours=idle_hours)
+
+    rows = await cc_sessions.query_stale_foreground(db, older_than=cutoff.isoformat())
+    result["scanned"] = len(rows)
+    if len(rows) > max_per_tick:
+        logger.warning(
+            "foreground reaper: %d dark rows exceed max_per_tick=%d — capping "
+            "(remainder next pass)",
+            len(rows),
+            max_per_tick,
+        )
+        rows = rows[:max_per_tick]
+
+    for row in rows:
+        try:
+            await _process_row(rt, db, row, now=now, cutoff=cutoff, mode=mode, result=result)
+        except Exception:
+            logger.warning(
+                "foreground reaper: processing failed for %s",
+                row.get("id", "?")[:8],
+                exc_info=True,
+            )
+
+    if result["reaped"]:
+        logger.info(
+            "foreground reaper: checkpointed %d dark session(s) (notified=%d, shadow=%d, mode=%s)",
+            result["reaped"],
+            result["notified"],
+            result["shadow"],
+            mode,
+        )
+    return result

--- a/src/genesis/cc/foreground_reaper_config.py
+++ b/src/genesis/cc/foreground_reaper_config.py
@@ -1,0 +1,123 @@
+"""Config lever for the foreground-session liveness reaper (D3).
+
+Cloned from ``cc.rate_limit_resume_config``: fresh-read-per-call, MODES tuple +
+env kill switch, degrade-toward-less-authority on damage.
+
+Modes (increasing authority):
+  - ``off``     — the reaper does nothing; dark foreground rows stay ``active``
+    (the pre-D3 status quo).
+  - ``observe`` — reap dark rows to ``checkpointed`` + write dark-session
+    observations, but NEVER notify the user (the autonomous-notify kill the
+    architecture review asked for).
+  - ``notify``  — observe + notify the origin user on the crisp "unanswered
+    user turn" signal. The fuzzy promise-regex signal is ALWAYS shadow-logged
+    only (never notified) until its precision is measured, regardless of mode.
+
+Default ``notify``: the 2026-07-20 silent-death's core failure was the user
+never being told their request died. A missing/corrupt config degrades to
+DEFAULTS; an invalid ``mode`` degrades to ``observe`` (reap safely — never a
+silent unattended notify, never a silent ``off`` that hides the feature). The
+env kill switch ``GENESIS_FOREGROUND_REAPER_DISABLED=1`` forces ``off``.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``MODES`` / ``INT_KNOBS``
+from here (never the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "observe", "notify")
+
+_CONFIG_NAME = "cc_foreground_reaper.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_FOREGROUND_REAPER_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "mode": "notify",
+    # A foreground row idle this long with no live turn is treated as dark.
+    # Generous: legitimate turns keep last_activity_at fresh via update_activity,
+    # so 24h of true silence means abandoned, not thinking.
+    "idle_hours": 24,
+    # Loud-truncation cap: dark rows processed per reaper pass.
+    "max_per_tick": 200,
+}
+
+# Public: the settings-domain validator imports these to check knobs.
+INT_KNOBS = (
+    "idle_hours",
+    "max_per_tick",
+)
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("cc_foreground_reaper base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("cc_foreground_reaper overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode the reaper runs under — read live.
+
+    Env kill switch → ``off``. Master ``enabled: false`` → ``off``. An invalid
+    value degrades to ``observe`` (reap safely, no unattended notify — never a
+    silent ``off`` that hides the feature, never a silent ``notify``).
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("cc_foreground_reaper has invalid mode %r — degrading to observe", mode)
+        return "observe"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
+    limit or crashes the reaper."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value

--- a/src/genesis/cc/session_manager.py
+++ b/src/genesis/cc/session_manager.py
@@ -15,7 +15,9 @@ from genesis.db.crud import cc_sessions
 logger = logging.getLogger(__name__)
 
 # Callback signatures for session lifecycle hooks
-OnSessionStart = Callable[[str, str, str], Awaitable[None]]  # (session_id, session_type, source_tag)
+OnSessionStart = Callable[
+    [str, str, str], Awaitable[None]
+]  # (session_id, session_type, source_tag)
 OnSessionEnd = Callable[[str], Awaitable[None]]  # (session_id,)
 
 
@@ -50,9 +52,19 @@ class SessionManager:
     ) -> dict:
         ch = str(channel)
         existing = await cc_sessions.get_active_foreground(
-            self._db, user_id=user_id, channel=ch, thread_id=thread_id,
+            self._db,
+            user_id=user_id,
+            channel=ch,
+            thread_id=thread_id,
         )
         if existing:
+            # A dark foreground session reaped to 'checkpointed' by the
+            # liveness reaper (D3) is still resumable — flip it back to 'active'
+            # on reuse so the turn resumes via --resume exactly as before the
+            # reap (cc_session_id / model / effort are left untouched).
+            if existing.get("status") == "checkpointed":
+                await cc_sessions.update_status(self._db, existing["id"], status="active")
+                existing["status"] = "active"
             return existing
 
         # Process any pending auto-bookmark from the previous session
@@ -175,7 +187,10 @@ class SessionManager:
         """
         now = datetime.now(UTC)
         boundary = now.replace(
-            hour=self._day_boundary_hour, minute=0, second=0, microsecond=0,
+            hour=self._day_boundary_hour,
+            minute=0,
+            second=0,
+            microsecond=0,
         )
         if now < boundary:
             boundary -= timedelta(days=1)
@@ -188,13 +203,20 @@ class SessionManager:
     # Source tags that are safe to auto-expire. Reflection output is persisted
     # in the observations table (not cc_sessions), so expiring session records
     # does NOT lose reflection history or context continuity.
-    _EXPIRABLE_SOURCE_TAGS = frozenset({
-        "reflection_light", "reflection_micro",
-        "reflection_deep", "reflection_strategic",
-        "brainstorm", "weekly_assessment", "quality_calibration",
-        "code_audit", "infrastructure_monitor",
-        "direct_session",
-    })
+    _EXPIRABLE_SOURCE_TAGS = frozenset(
+        {
+            "reflection_light",
+            "reflection_micro",
+            "reflection_deep",
+            "reflection_strategic",
+            "brainstorm",
+            "weekly_assessment",
+            "quality_calibration",
+            "code_audit",
+            "infrastructure_monitor",
+            "direct_session",
+        }
+    )
     # Source tags to NEVER auto-expire — currently empty. Only foreground
     # sessions are preserved (handled by the session_type check below).
     _PRESERVE_SOURCE_TAGS: frozenset[str] = frozenset()
@@ -223,15 +245,19 @@ class SessionManager:
 
             # Expire if source_tag is in the expirable set, OR if it's a
             # background_task type, OR if unrecognised (default: expire)
-            if (source_tag in self._EXPIRABLE_SOURCE_TAGS
-                    or session_type == "background_task"
-                    or session_type != "foreground"):
+            if (
+                source_tag in self._EXPIRABLE_SOURCE_TAGS
+                or session_type == "background_task"
+                or session_type != "foreground"
+            ):
                 await cc_sessions.update_status(self._db, row["id"], status="expired")
                 await self._fire_end_hooks(row["id"])
                 count += 1
 
         if count:
-            logger.info("Expired %d stale background sessions (idle > %d min)", count, max_idle_minutes)
+            logger.info(
+                "Expired %d stale background sessions (idle > %d min)", count, max_idle_minutes
+            )
         return count
 
     async def process_pending_bookmark(self) -> str | None:
@@ -252,6 +278,7 @@ class SessionManager:
         finally:
             # Always clean up the file to avoid reprocessing
             import contextlib
+
             with contextlib.suppress(OSError):
                 self._PENDING_BOOKMARK_FILE.unlink(missing_ok=True)
 
@@ -282,7 +309,8 @@ class SessionManager:
             )
             logger.info(
                 "Auto-created bookmark %s for previous session %s",
-                bookmark_id[:8], session_id[:8],
+                bookmark_id[:8],
+                session_id[:8],
             )
             return bookmark_id
         except Exception:

--- a/src/genesis/db/crud/cc_rate_limit_parks.py
+++ b/src/genesis/db/crud/cc_rate_limit_parks.py
@@ -249,3 +249,20 @@ async def prune_terminal(db: aiosqlite.Connection, *, older_than_days: int = 45)
     )
     await db.commit()
     return cursor.rowcount
+
+
+async def has_open_for_origin(db: aiosqlite.Connection, origin_session_id: str) -> bool:
+    """True iff an OPEN park (parked/resuming/needs_user) exists for this origin.
+
+    An open park means the rate-limit machinery still owns notifying the user
+    about this session's work (auto-resume delivery or a needs_user escalation),
+    so the foreground-liveness reaper (D3) must not ALSO notify. Terminal parks
+    (resumed/cancelled/expired) are done and do not suppress.
+    """
+    cursor = await db.execute(
+        "SELECT 1 FROM cc_rate_limit_parks "
+        "WHERE origin_session_id = ? "
+        "AND status IN ('parked', 'resuming', 'needs_user') LIMIT 1",
+        (origin_session_id,),
+    )
+    return await cursor.fetchone() is not None

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -85,7 +85,7 @@ async def get_active_foreground(
         cursor = await db.execute(
             """SELECT * FROM cc_sessions
                WHERE session_type = 'foreground'
-                 AND status = 'active'
+                 AND status IN ('active', 'checkpointed')
                  AND user_id = ?
                  AND channel = ?
                  AND thread_id = ?
@@ -96,7 +96,7 @@ async def get_active_foreground(
         cursor = await db.execute(
             """SELECT * FROM cc_sessions
                WHERE session_type = 'foreground'
-                 AND status = 'active'
+                 AND status IN ('active', 'checkpointed')
                  AND user_id = ?
                  AND channel = ?
                  AND thread_id IS NULL
@@ -161,6 +161,57 @@ async def query_stale(
         (older_than,),
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def query_stale_foreground(
+    db: aiosqlite.Connection,
+    *,
+    older_than: str,
+) -> list[dict]:
+    """Return active FOREGROUND sessions idle since before *older_than*.
+
+    The inverse of :func:`query_stale` (which excludes foreground). Used by
+    the foreground-liveness reaper (D3): a foreground row stays ``active`` by
+    design so the next turn can ``--resume`` it, so a crash / OOM / restart
+    mid-turn leaves it ``active`` forever — indistinguishable from a healthy
+    resumable session. Voice foreground rows are excluded (they have their own
+    orphan sweep, :func:`complete_orphaned_voice_sessions`); a NULL source_tag
+    is treated as non-voice so legacy foreground rows are still swept.
+    """
+    cursor = await db.execute(
+        """SELECT * FROM cc_sessions
+           WHERE status = 'active'
+             AND session_type = 'foreground'
+             AND COALESCE(source_tag, '') != 'voice'
+             AND last_activity_at < ?
+           ORDER BY last_activity_at ASC""",
+        (older_than,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def checkpoint_dark(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    checkpointed_at: str,
+) -> bool:
+    """Relabel a dark (abandoned) foreground row ``active`` → ``checkpointed``.
+
+    Non-destructive: touches only ``status`` / ``checkpointed_at``, never
+    ``cc_session_id`` / model / effort / metadata, so the row stays resumable
+    (``get_active_foreground`` matches ``checkpointed`` and
+    ``get_or_create_foreground`` flips it back to ``active`` on reuse). The
+    ``status = 'active'`` guard makes this a no-op (rowcount 0) when a
+    concurrent turn revived the row between the reaper's read and this write.
+    """
+    cursor = await db.execute(
+        "UPDATE cc_sessions SET status = 'checkpointed', checkpointed_at = ? "
+        "WHERE id = ? AND status = 'active'",
+        (checkpointed_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
 
 
 # reap_stale (bulk UPDATE → 'completed') was deleted. It relabeled
@@ -422,7 +473,9 @@ async def register_voice_session(
 
 
 async def complete_orphaned_voice_sessions(
-    db: aiosqlite.Connection, *, idle_before: str,
+    db: aiosqlite.Connection,
+    *,
+    idle_before: str,
 ) -> int:
     """Mark ``active`` voice sessions idle since before ``idle_before`` completed.
 

--- a/src/genesis/db/crud/direct_session_queue.py
+++ b/src/genesis/db/crud/direct_session_queue.py
@@ -110,7 +110,8 @@ async def mark_failed(
 async def get_by_id(db: aiosqlite.Connection, queue_id: str) -> dict | None:
     """Fetch a queue item by ID."""
     cursor = await db.execute(
-        "SELECT * FROM direct_session_queue WHERE id = ?", (queue_id,),
+        "SELECT * FROM direct_session_queue WHERE id = ?",
+        (queue_id,),
     )
     row = await cursor.fetchone()
     return dict(row) if row else None
@@ -142,3 +143,23 @@ async def count_pending(db: aiosqlite.Connection) -> int:
     )
     row = await cursor.fetchone()
     return row[0] if row else 0
+
+
+async def has_open_for_origin(db: aiosqlite.Connection, origin_session_id: str) -> bool:
+    """True iff a not-yet-run queued session (pending/claimed) exists for this
+    origin — work that WILL deliver its outcome to the origin (delivery model)
+    but hasn't yet, so the foreground-liveness reaper (D3) must not also notify.
+
+    NOTE: 'dispatched' is deliberately EXCLUDED — a queue row is left in
+    'dispatched' permanently after its background session completes (there is no
+    terminal 'completed' status), so treating it as open would suppress the
+    dark-session notify FOREVER for any origin that ever dispatched work.
+    """
+    # origin_session_id is stored inside payload_json (not a column), so extract it.
+    cursor = await db.execute(
+        "SELECT 1 FROM direct_session_queue "
+        "WHERE json_extract(payload_json, '$.origin_session_id') = ? "
+        "AND status IN ('pending', 'claimed') LIMIT 1",
+        (origin_session_id,),
+    )
+    return await cursor.fetchone() is not None

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -190,6 +190,20 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every resume tick
     ),
+    "cc_foreground_reaper": SettingsDomain(
+        name="cc_foreground_reaper",
+        description=(
+            "Foreground-session liveness reaper (D3) — master `enabled` + `mode` "
+            "off/observe/notify, plus idle_hours/max_per_tick. notify (default) "
+            "reaps abandoned foreground sessions to 'checkpointed' and tells the "
+            "origin user their request was interrupted (crisp unanswered-user "
+            "signal only); observe reaps + records without notifying; off does "
+            "nothing. Read live each reaper pass — takes effect next pass, no restart."
+        ),
+        config_filename="cc_foreground_reaper.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every reaper pass
+    ),
     "resilience": SettingsDomain(
         name="resilience",
         description="Resilience thresholds (flapping detection, recovery, CC rate limits)",
@@ -1082,9 +1096,31 @@ def _validate_cc_rate_limit_resume(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_cc_foreground_reaper(changes: dict) -> list[str]:
+    """Validate foreground-liveness reaper lever changes (see
+    genesis.cc.foreground_reaper_config)."""
+    from genesis.cc.foreground_reaper_config import INT_KNOBS, MODES
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "mode", *INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key == "mode":
+            if value not in MODES:
+                errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "entity_adjudication": _validate_entity_adjudication,
     "cc_rate_limit_resume": _validate_cc_rate_limit_resume,
+    "cc_foreground_reaper": _validate_cc_foreground_reaper,
     "tts": _validate_tts,
     "ws3_immunity": _validate_ws3_immunity,
     "memory_recall": _validate_memory_recall,

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1036,6 +1036,29 @@ async def init(rt: GenesisRuntime) -> None:
                         max_idle_minutes=360,
                     )
                 cleaned = await cleanup_stale_heartbeats(rt._db)
+
+                # D3 — foreground-session liveness reaper. Isolated in its OWN
+                # try/except so a notify/observation failure can NEVER abort the
+                # stale-session / heartbeat cleanup above (which is the job's
+                # primary contract).
+                try:
+                    from genesis.cc.foreground_reaper import reap_dark_foreground
+
+                    fg = await reap_dark_foreground(rt)
+                    if fg.get("reaped"):
+                        logger.info(
+                            "Session reaper: checkpointed %d dark foreground "
+                            "session(s) (notified=%d, shadow=%d)",
+                            fg["reaped"],
+                            fg.get("notified", 0),
+                            fg.get("shadow", 0),
+                        )
+                except Exception:
+                    logger.warning(
+                        "Foreground liveness reaper failed (stale-session cleanup unaffected)",
+                        exc_info=True,
+                    )
+
                 rt.record_job_success("session_reaper")
                 if reaped:
                     logger.info("Session reaper: expired %d stale sessions", reaped)

--- a/tests/test_cc/test_foreground_reaper.py
+++ b/tests/test_cc/test_foreground_reaper.py
@@ -1,0 +1,261 @@
+"""Tests for the foreground-session liveness reaper (D3).
+
+Covers the pure tail classifier (``dark_signal`` + age guard) and the full
+``reap_dark_foreground`` behavior matrix: reap-skips-live, reap-checkpoints-dead,
+notify-only-on-unanswered-user (with the mid-flight age guard), suppressed on
+clean idle / when covered by park or dispatch, promise=shadow, non-telegram
+graceful, mode gating, and the checkpoint race guard. Real in-memory db; fake
+runtime with a mocked outreach pipeline; the transcript read is monkeypatched so
+the classifier's input is controlled without touching disk.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from genesis.cc import foreground_reaper as fr
+from genesis.db.crud import cc_sessions
+from genesis.db.crud import direct_session_queue as dsq
+
+NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=UTC)
+OLD = "2026-07-20T00:00:00+00:00"  # ~60h before NOW → older than the 24h cutoff
+RECENT = "2026-07-22T11:30:00+00:00"  # 30 min before NOW → NEWER than the cutoff
+
+
+# --- transcript entry builders -------------------------------------------------
+def _user(text: str, ts: str) -> dict:
+    return {"type": "user", "promptSource": "typed", "timestamp": ts, "message": {"content": text}}
+
+
+def _assistant(text: str) -> dict:
+    return {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}
+
+
+# --- pure classifier -----------------------------------------------------------
+def test_dark_signal_unanswered_user():
+    sig, ts = fr.dark_signal([_user("do the thing", OLD)])
+    assert sig == "unanswered_user"
+    assert ts == OLD
+
+
+def test_dark_signal_clean_when_answered():
+    sig, _ = fr.dark_signal([_user("do X", OLD), _assistant("here you go")])
+    assert sig == "clean"
+
+
+def test_dark_signal_promise_when_answered_with_deferral():
+    sig, _ = fr.dark_signal(
+        [_user("research X", OLD), _assistant("On it — I'll report back when it finishes.")]
+    )
+    assert sig == "promise"
+
+
+def test_dark_signal_unknown_without_user_turn():
+    sig, ts = fr.dark_signal([_assistant("orphan")])
+    assert sig == "unknown"
+    assert ts is None
+
+
+def test_ts_older_than_guard():
+    cutoff = datetime(2026, 7, 21, 12, 0, 0, tzinfo=UTC)
+    assert fr._ts_older_than(OLD, cutoff) is True
+    assert fr._ts_older_than(RECENT, cutoff) is False
+    assert fr._ts_older_than(None, cutoff) is False
+    assert fr._ts_older_than("not-a-date", cutoff) is False
+
+
+# --- reaper harness ------------------------------------------------------------
+def _rt(db):
+    rt = MagicMock()
+    rt._db = db
+    pipe = MagicMock()
+    pipe.submit_urgent = AsyncMock()
+    pipe._forum_chat_id = None
+    rt._outreach_pipeline = pipe
+    return rt
+
+
+async def _seed(
+    db,
+    *,
+    sid="s1",
+    cc_sid="cc-s1",
+    last_activity=OLD,
+    channel="telegram",
+    chat_id="12345",
+    status="active",
+):
+    await cc_sessions.create(
+        db,
+        id=sid,
+        session_type="foreground",
+        model="sonnet",
+        effort="medium",
+        status=status,
+        user_id="tg-999",
+        channel=channel,
+        started_at=last_activity,
+        last_activity_at=last_activity,
+        source_tag="foreground",
+        chat_id=chat_id,
+    )
+    if cc_sid:
+        await cc_sessions.update_cc_session_id(db, sid, cc_session_id=cc_sid)
+    return sid
+
+
+def _patch_tail(monkeypatch, entries):
+    monkeypatch.setattr(fr, "_read_tail_entries", lambda *a, **k: list(entries))
+
+
+async def _obs_count(db) -> int:
+    cur = await db.execute(
+        "SELECT COUNT(*) FROM observations WHERE type = 'dark_foreground_session'"
+    )
+    return (await cur.fetchone())[0]
+
+
+async def test_skips_live_foreground(db, monkeypatch):
+    await _seed(db, last_activity=RECENT)  # idle < 24h → not stale
+    _patch_tail(monkeypatch, [_user("x", RECENT)])
+    res = await fr.reap_dark_foreground(_rt(db), now=NOW, idle_hours=24, mode="notify")
+    assert res["scanned"] == 0 and res["reaped"] == 0
+
+
+async def test_checkpoints_dead_and_notifies_on_unanswered(db, monkeypatch):
+    sid = await _seed(db)
+    _patch_tail(monkeypatch, [_user("finish my research", OLD)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["notified"] == 1
+    assert (await cc_sessions.get_by_id(db, sid))["status"] == "checkpointed"
+    rt._outreach_pipeline.submit_urgent.assert_awaited_once()
+    req = rt._outreach_pipeline.submit_urgent.call_args[0][0]
+    assert req.target_chat_id == "12345"
+    assert req.topic == f"dark_session:{sid}"
+    assert await _obs_count(db) == 1
+
+
+async def test_age_guard_suppresses_notify_for_midflight_turn(db, monkeypatch):
+    # Session-level last_activity is stale (selected), but the unanswered user
+    # turn itself is RECENT — a long in-flight turn, not a dead one. Must NOT notify.
+    sid = await _seed(db)
+    _patch_tail(monkeypatch, [_user("still working on this", RECENT)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["notified"] == 0
+    rt._outreach_pipeline.submit_urgent.assert_not_awaited()
+    assert (await cc_sessions.get_by_id(db, sid))["status"] == "checkpointed"
+
+
+async def test_suppressed_on_clean_idle(db, monkeypatch):
+    await _seed(db)
+    _patch_tail(monkeypatch, [_user("hi", OLD), _assistant("hello — here's your answer")])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["notified"] == 0
+    rt._outreach_pipeline.submit_urgent.assert_not_awaited()
+    assert await _obs_count(db) == 0  # a clean reap is silent hygiene
+
+
+async def test_promise_is_shadow_only(db, monkeypatch):
+    await _seed(db)
+    _patch_tail(
+        monkeypatch,
+        [_user("dig into X", OLD), _assistant("Running in the background and will report back.")],
+    )
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["shadow"] == 1 and res["notified"] == 0
+    rt._outreach_pipeline.submit_urgent.assert_not_awaited()
+    assert await _obs_count(db) == 1  # shadow observation recorded
+
+
+async def test_suppressed_when_covered_by_dispatch(db, monkeypatch):
+    sid = await _seed(db)
+    await dsq.enqueue(db, prompt="p", profile="research", origin_session_id=sid)
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["notified"] == 0
+    rt._outreach_pipeline.submit_urgent.assert_not_awaited()
+
+
+async def test_non_telegram_origin_graceful(db, monkeypatch):
+    sid = await _seed(db, channel="web", chat_id=None)
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["notified"] == 0  # unaddressable → no notify, no crash
+    assert (await cc_sessions.get_by_id(db, sid))["status"] == "checkpointed"
+    assert await _obs_count(db) == 1  # unanswered still observed
+
+
+async def test_observe_mode_reaps_without_notify(db, monkeypatch):
+    await _seed(db)
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="observe")
+    assert res["reaped"] == 1 and res["notified"] == 0
+    rt._outreach_pipeline.submit_urgent.assert_not_awaited()
+
+
+async def test_off_mode_no_op(db, monkeypatch):
+    sid = await _seed(db)
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    res = await fr.reap_dark_foreground(_rt(db), now=NOW, idle_hours=24, mode="off")
+    assert res["reaped"] == 0
+    assert (await cc_sessions.get_by_id(db, sid))["status"] == "active"
+
+
+async def test_resume_still_works_after_checkpoint(db, monkeypatch):
+    # After a reap, get_active_foreground still returns the row (widened), with
+    # cc_session_id intact — so --resume is preserved.
+    sid = await _seed(db)
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    await fr.reap_dark_foreground(_rt(db), now=NOW, idle_hours=24, mode="observe")
+    row = await cc_sessions.get_active_foreground(db, user_id="tg-999", channel="telegram")
+    assert row is not None and row["id"] == sid
+    assert row["status"] == "checkpointed"
+    assert row["cc_session_id"] == "cc-s1"
+
+
+async def test_dispatched_dsq_does_not_suppress(db, monkeypatch):
+    # A 'dispatched' queue row persists forever after its session completes
+    # (no terminal status), so it must NOT permanently suppress the notify.
+    sid = await _seed(db)
+    qid = await dsq.enqueue(db, prompt="p", profile="research", origin_session_id=sid)
+    await db.execute("UPDATE direct_session_queue SET status='dispatched' WHERE id=?", (qid,))
+    await db.commit()
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["notified"] == 1  # dispatched is not "open" → not suppressed
+    rt._outreach_pipeline.submit_urgent.assert_awaited_once()
+
+
+async def test_pending_dsq_still_suppresses(db, monkeypatch):
+    # A genuinely not-yet-run ('pending') queue row WILL deliver → still suppress.
+    sid = await _seed(db)
+    await dsq.enqueue(db, prompt="p", profile="research", origin_session_id=sid)
+    _patch_tail(monkeypatch, [_user("do it", OLD)])
+    rt = _rt(db)
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["notified"] == 0
+    rt._outreach_pipeline.submit_urgent.assert_not_awaited()
+
+
+async def test_notify_delivery_failure_preserves_alert(db, monkeypatch):
+    # submit_urgent raising after checkpoint must NOT lose the alert: no crash,
+    # and a HIGH-priority observation still surfaces the dead request.
+    sid = await _seed(db)
+    _patch_tail(monkeypatch, [_user("finish it", OLD)])
+    rt = _rt(db)
+    rt._outreach_pipeline.submit_urgent = AsyncMock(side_effect=RuntimeError("tg down"))
+    res = await fr.reap_dark_foreground(rt, now=NOW, idle_hours=24, mode="notify")
+    assert res["reaped"] == 1 and res["notified"] == 0  # delivery failed, no crash
+    assert (await cc_sessions.get_by_id(db, sid))["status"] == "checkpointed"
+    cur = await db.execute("SELECT priority FROM observations WHERE type='dark_foreground_session'")
+    rows = await cur.fetchall()
+    assert len(rows) == 1 and rows[0][0] == "high"  # eligibility-driven, survives failure

--- a/tests/test_cc/test_session_manager.py
+++ b/tests/test_cc/test_session_manager.py
@@ -22,7 +22,8 @@ async def manager(db, mock_invoker):
 
 async def test_create_foreground(db, manager):
     sess = await manager.get_or_create_foreground(
-        user_id="u1", channel=ChannelType.TELEGRAM,
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
     )
     assert sess is not None
     assert sess["session_type"] == "foreground"
@@ -31,12 +32,32 @@ async def test_create_foreground(db, manager):
 
 async def test_get_existing_foreground(db, manager):
     s1 = await manager.get_or_create_foreground(
-        user_id="u1", channel=ChannelType.TELEGRAM,
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
     )
     s2 = await manager.get_or_create_foreground(
-        user_id="u1", channel=ChannelType.TELEGRAM,
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
     )
     assert s1["id"] == s2["id"]
+
+
+async def test_get_or_create_flips_checkpointed_to_active(db, manager):
+    """A reaped (checkpointed) foreground session is revived to 'active' on
+    reuse, preserving its id so --resume continues (D3 resume safety)."""
+    s1 = await manager.get_or_create_foreground(
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
+    )
+    await cc_sessions.checkpoint_dark(db, s1["id"], checkpointed_at="2026-07-22T12:00:00+00:00")
+    assert (await cc_sessions.get_by_id(db, s1["id"]))["status"] == "checkpointed"
+    s2 = await manager.get_or_create_foreground(
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
+    )
+    assert s2["id"] == s1["id"]
+    assert s2["status"] == "active"
+    assert (await cc_sessions.get_by_id(db, s1["id"]))["status"] == "active"
 
 
 async def test_create_background(db, manager):
@@ -109,7 +130,8 @@ async def test_create_background_no_profile(db, manager):
 
 async def test_checkpoint(db, manager):
     sess = await manager.get_or_create_foreground(
-        user_id="u1", channel=ChannelType.TELEGRAM,
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
     )
     await manager.checkpoint(sess["id"])
     row = await cc_sessions.get_by_id(db, sess["id"])
@@ -118,7 +140,8 @@ async def test_checkpoint(db, manager):
 
 async def test_complete(db, manager):
     sess = await manager.get_or_create_foreground(
-        user_id="u1", channel=ChannelType.TELEGRAM,
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
     )
     await manager.complete(sess["id"])
     row = await cc_sessions.get_by_id(db, sess["id"])
@@ -237,7 +260,8 @@ async def test_create_background_origin_defaults_null(db, manager):
 
 async def test_foreground_origin_stays_null(db, manager):
     sess = await manager.get_or_create_foreground(
-        user_id="u1", channel=ChannelType.TELEGRAM,
+        user_id="u1",
+        channel=ChannelType.TELEGRAM,
     )
     row = await cc_sessions.get_by_id(db, sess["id"])
     assert row["origin_class"] is None  # owner-supervised, read first_party

--- a/tests/test_db/test_cc_sessions.py
+++ b/tests/test_db/test_cc_sessions.py
@@ -52,7 +52,9 @@ async def test_update_status(db, sess_fields):
 async def test_update_activity(db, sess_fields):
     await cc_sessions.create(db, **sess_fields)
     ok = await cc_sessions.update_activity(
-        db, "sess-1", last_activity_at="2026-03-07T09:00:00",
+        db,
+        "sess-1",
+        last_activity_at="2026-03-07T09:00:00",
     )
     assert ok
     row = await cc_sessions.get_by_id(db, "sess-1")
@@ -86,7 +88,10 @@ async def test_roster_persist_reconstruct_loop(db, sess_fields, monkeypatch):
 
     # (chokepoint) a pre-stamped routed resume is respected, never rerouted:
     inv = CCInvocation(
-        prompt="x", roster_eligible=True, resume_session_id="cc-x", **overrides,
+        prompt="x",
+        roster_eligible=True,
+        resume_session_id="cc-x",
+        **overrides,
     )
     out_inv, name = roster.apply_active(inv)
     assert out_inv is inv and name == "glm-5.2"
@@ -96,11 +101,14 @@ async def test_merge_metadata_round_trip(db, sess_fields):
     # roster-endpoint persistence: shallow merge into JSON metadata, no migration.
     await cc_sessions.create(db, **{**sess_fields, "metadata": '{"existing": 1}'})
     ok = await cc_sessions.merge_metadata(
-        db, "sess-1", {"roster_endpoint": {"model_id": "glm-5.2"}},
+        db,
+        "sess-1",
+        {"roster_endpoint": {"model_id": "glm-5.2"}},
     )
     assert ok
     row = await cc_sessions.get_by_id(db, "sess-1")
     import json
+
     md = json.loads(row["metadata"])
     assert md["existing"] == 1  # preserved
     assert md["roster_endpoint"] == {"model_id": "glm-5.2"}  # merged
@@ -111,6 +119,7 @@ async def test_merge_metadata_tolerates_corrupt_and_missing(db, sess_fields):
     ok = await cc_sessions.merge_metadata(db, "sess-1", {"k": "v"})
     assert ok
     import json
+
     row = await cc_sessions.get_by_id(db, "sess-1")
     assert json.loads(row["metadata"]) == {"k": "v"}  # corrupt treated as {}
     # missing row → False, no raise
@@ -128,8 +137,11 @@ async def test_query_stale(db, sess_fields):
     # Background sessions should appear in stale results
     await cc_sessions.create(
         db,
-        **{**sess_fields, "session_type": "background_task",
-           "last_activity_at": "2026-03-07T06:00:00"},
+        **{
+            **sess_fields,
+            "session_type": "background_task",
+            "last_activity_at": "2026-03-07T06:00:00",
+        },
     )
     rows = await cc_sessions.query_stale(db, older_than="2026-03-07T07:00:00")
     assert len(rows) == 1
@@ -139,8 +151,7 @@ async def test_query_stale_excludes_foreground(db, sess_fields):
     """Foreground sessions must never appear in stale query results."""
     await cc_sessions.create(
         db,
-        **{**sess_fields, "session_type": "foreground",
-           "last_activity_at": "2026-03-07T06:00:00"},
+        **{**sess_fields, "session_type": "foreground", "last_activity_at": "2026-03-07T06:00:00"},
     )
     rows = await cc_sessions.query_stale(db, older_than="2026-03-07T07:00:00")
     assert len(rows) == 0
@@ -175,8 +186,7 @@ async def test_check_constraint_status(db, sess_fields):
 @pytest.mark.asyncio
 async def test_update_cc_session_id(db, sess_fields):
     await cc_sessions.create(db, **sess_fields)
-    ok = await cc_sessions.update_cc_session_id(
-        db, "sess-1", cc_session_id="cc-cli-uuid-123")
+    ok = await cc_sessions.update_cc_session_id(db, "sess-1", cc_session_id="cc-cli-uuid-123")
     assert ok
     row = await cc_sessions.get_by_id(db, "sess-1")
     assert row["cc_session_id"] == "cc-cli-uuid-123"
@@ -194,15 +204,61 @@ async def test_get_by_session_types(db, sess_fields):
     """Filters to the requested session_types; empty input returns []."""
     await cc_sessions.create(db, **sess_fields)  # foreground
     await cc_sessions.create(
-        db, **{**sess_fields, "id": "sess-2", "session_type": "background_task"})
+        db, **{**sess_fields, "id": "sess-2", "session_type": "background_task"}
+    )
     await cc_sessions.create(
-        db, **{**sess_fields, "id": "sess-3", "session_type": "background_task"})
+        db, **{**sess_fields, "id": "sess-3", "session_type": "background_task"}
+    )
 
     bg = await cc_sessions.get_by_session_types(db, {"background_task"})
     assert {r["id"] for r in bg} == {"sess-2", "sess-3"}
 
-    both = await cc_sessions.get_by_session_types(
-        db, {"background_task", "foreground"})
+    both = await cc_sessions.get_by_session_types(db, {"background_task", "foreground"})
     assert {r["id"] for r in both} == {"sess-1", "sess-2", "sess-3"}
 
     assert await cc_sessions.get_by_session_types(db, set()) == []
+
+
+@pytest.mark.asyncio
+async def test_get_active_foreground_returns_checkpointed(db, sess_fields):
+    """D3: a reaped (checkpointed) foreground row is still resumable — the
+    widened query must return it (not just 'active')."""
+    await cc_sessions.create(db, **{**sess_fields, "status": "checkpointed"})
+    row = await cc_sessions.get_active_foreground(db, user_id="user-1", channel="telegram")
+    assert row is not None and row["id"] == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_query_stale_foreground(db, sess_fields):
+    """Selects idle foreground rows; excludes non-foreground, voice, and fresh."""
+    old = "2020-01-01T00:00:00+00:00"
+    await cc_sessions.create(db, **{**sess_fields, "id": "fg-old", "last_activity_at": old})
+    await cc_sessions.create(
+        db, **{**sess_fields, "id": "fg-fresh", "last_activity_at": "2099-01-01T00:00:00+00:00"}
+    )
+    await cc_sessions.create(
+        db, **{**sess_fields, "id": "voice", "source_tag": "voice", "last_activity_at": old}
+    )
+    await cc_sessions.create(
+        db,
+        **{**sess_fields, "id": "bg", "session_type": "background_task", "last_activity_at": old},
+    )
+    rows = await cc_sessions.query_stale_foreground(db, older_than="2021-01-01T00:00:00+00:00")
+    assert {r["id"] for r in rows} == {"fg-old"}
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_dark_and_race_guard(db, sess_fields):
+    await cc_sessions.create(db, **sess_fields)  # active
+    won = await cc_sessions.checkpoint_dark(
+        db, "sess-1", checkpointed_at="2026-07-22T12:00:00+00:00"
+    )
+    assert won is True
+    row = await cc_sessions.get_by_id(db, "sess-1")
+    assert row["status"] == "checkpointed"
+    assert row["checkpointed_at"] == "2026-07-22T12:00:00+00:00"
+    # Race guard: a second checkpoint on the now-non-active row is a no-op.
+    again = await cc_sessions.checkpoint_dark(
+        db, "sess-1", checkpointed_at="2026-07-22T13:00:00+00:00"
+    )
+    assert again is False

--- a/tests/test_mcp/test_settings.py
+++ b/tests/test_mcp/test_settings.py
@@ -15,6 +15,7 @@ from genesis.mcp.health.settings import (
     _impl_settings_get,
     _impl_settings_list,
     _impl_settings_update,
+    _validate_cc_foreground_reaper,
     _validate_inbox_monitor,
     _validate_resilience,
     _validate_tts,
@@ -78,10 +79,14 @@ async def test_settings_list_outreach_is_writable():
 
 
 async def test_settings_get_tts(config_dir: Path):
-    _write_config(config_dir, "tts.yaml", {
-        "provider": "elevenlabs",
-        "elevenlabs": {"stability": 0.9, "speed": 1.1},
-    })
+    _write_config(
+        config_dir,
+        "tts.yaml",
+        {
+            "provider": "elevenlabs",
+            "elevenlabs": {"stability": 0.9, "speed": 1.1},
+        },
+    )
     result = await _impl_settings_get("tts")
     assert result["domain"] == "tts"
     assert result["config"]["provider"] == "elevenlabs"
@@ -120,13 +125,20 @@ async def test_settings_get_missing_file():
 
 
 async def test_settings_update_tts(config_dir: Path):
-    _write_config(config_dir, "tts.yaml", {
-        "provider": "elevenlabs",
-        "elevenlabs": {"stability": 0.85, "speed": 1.1},
-    })
-    result = await _impl_settings_update("tts", {
-        "elevenlabs": {"stability": 0.9},
-    })
+    _write_config(
+        config_dir,
+        "tts.yaml",
+        {
+            "provider": "elevenlabs",
+            "elevenlabs": {"stability": 0.85, "speed": 1.1},
+        },
+    )
+    result = await _impl_settings_update(
+        "tts",
+        {
+            "elevenlabs": {"stability": 0.9},
+        },
+    )
     assert result["status"] == "applied"
     assert result["needs_restart"] is False
     assert "local_override_file" in result
@@ -140,6 +152,7 @@ async def test_settings_update_tts(config_dir: Path):
 
     # Merged view (via settings_get) should show updated value
     from genesis.mcp.health.settings import _load_yaml_merged
+
     merged = _load_yaml_merged("tts.yaml")
     assert merged["elevenlabs"]["stability"] == 0.9
     assert merged["elevenlabs"]["speed"] == 1.1  # Preserved from base
@@ -148,48 +161,67 @@ async def test_settings_update_tts(config_dir: Path):
 
 async def test_settings_update_tts_validation_error(config_dir: Path):
     _write_config(config_dir, "tts.yaml", {"provider": "elevenlabs"})
-    result = await _impl_settings_update("tts", {
-        "elevenlabs": {"stability": 5.0},
-    })
+    result = await _impl_settings_update(
+        "tts",
+        {
+            "elevenlabs": {"stability": 5.0},
+        },
+    )
     assert result["error"] == "validation failed"
     assert any("stability" in e for e in result["validation_errors"])
 
 
 async def test_settings_update_resilience(config_dir: Path):
-    _write_config(config_dir, "resilience.yaml", {
-        "flapping": {"transition_count": 3, "window_seconds": 900},
-        "cc": {"max_sessions_per_hour": 20},
-    })
-    result = await _impl_settings_update("resilience", {
-        "cc": {"max_sessions_per_hour": 30},
-    })
+    _write_config(
+        config_dir,
+        "resilience.yaml",
+        {
+            "flapping": {"transition_count": 3, "window_seconds": 900},
+            "cc": {"max_sessions_per_hour": 20},
+        },
+    )
+    result = await _impl_settings_update(
+        "resilience",
+        {
+            "cc": {"max_sessions_per_hour": 30},
+        },
+    )
     assert result["status"] == "applied"
     assert result["needs_restart"] is True
     assert "note" in result  # Restart note
 
     # Changes in .local.yaml; merged view has both
     from genesis.mcp.health.settings import _load_yaml_merged
+
     merged = _load_yaml_merged("resilience.yaml")
     assert merged["cc"]["max_sessions_per_hour"] == 30
     assert merged["flapping"]["transition_count"] == 3  # Preserved from base
 
 
 async def test_settings_update_inbox_monitor(config_dir: Path):
-    _write_config(config_dir, "inbox_monitor.yaml", {
-        "inbox_monitor": {
-            "enabled": True,
-            "batch_size": 1,
-            "model": "sonnet",
-            "timezone": "America/New_York",
+    _write_config(
+        config_dir,
+        "inbox_monitor.yaml",
+        {
+            "inbox_monitor": {
+                "enabled": True,
+                "batch_size": 1,
+                "model": "sonnet",
+                "timezone": "America/New_York",
+            },
         },
-    })
-    result = await _impl_settings_update("inbox_monitor", {
-        "inbox_monitor": {"batch_size": 3, "model": "opus"},
-    })
+    )
+    result = await _impl_settings_update(
+        "inbox_monitor",
+        {
+            "inbox_monitor": {"batch_size": 3, "model": "opus"},
+        },
+    )
     assert result["status"] == "applied"
     assert result["needs_restart"] is True
 
     from genesis.mcp.health.settings import _load_yaml_merged
+
     merged = _load_yaml_merged("inbox_monitor.yaml")
     assert merged["inbox_monitor"]["batch_size"] == 3
     assert merged["inbox_monitor"]["model"] == "opus"
@@ -198,12 +230,19 @@ async def test_settings_update_inbox_monitor(config_dir: Path):
 
 async def test_settings_update_inbox_timezone_ignored(config_dir: Path):
     """Timezone field is silently ignored — uses system timezone now."""
-    _write_config(config_dir, "inbox_monitor.yaml", {
-        "inbox_monitor": {"enabled": True},
-    })
-    result = await _impl_settings_update("inbox_monitor", {
-        "inbox_monitor": {"timezone": "Mars/Olympus_Mons"},
-    })
+    _write_config(
+        config_dir,
+        "inbox_monitor.yaml",
+        {
+            "inbox_monitor": {"enabled": True},
+        },
+    )
+    result = await _impl_settings_update(
+        "inbox_monitor",
+        {
+            "inbox_monitor": {"timezone": "Mars/Olympus_Mons"},
+        },
+    )
     # No validation error — timezone key is ignored, passes through as unknown YAML
     assert "error" not in result
 
@@ -229,9 +268,13 @@ async def test_settings_update_unknown_domain():
 
 async def test_settings_update_dry_run(config_dir: Path):
     _write_config(config_dir, "tts.yaml", {"provider": "elevenlabs"})
-    result = await _impl_settings_update("tts", {
-        "elevenlabs": {"stability": 0.9},
-    }, dry_run=True)
+    result = await _impl_settings_update(
+        "tts",
+        {
+            "elevenlabs": {"stability": 0.9},
+        },
+        dry_run=True,
+    )
     assert result["status"] == "dry_run_ok"
     assert result["changes_applied"] == {"elevenlabs": {"stability": 0.9}}
 
@@ -265,13 +308,18 @@ async def test_settings_update_write_failure(config_dir: Path):
 
 async def test_settings_update_inbox_flat_changes_auto_wrapped(config_dir: Path):
     """Flat changes (without inbox_monitor wrapper) are auto-wrapped."""
-    _write_config(config_dir, "inbox_monitor.yaml", {
-        "inbox_monitor": {"enabled": True, "batch_size": 1},
-    })
+    _write_config(
+        config_dir,
+        "inbox_monitor.yaml",
+        {
+            "inbox_monitor": {"enabled": True, "batch_size": 1},
+        },
+    )
     result = await _impl_settings_update("inbox_monitor", {"batch_size": 5})
     assert result["status"] == "applied"
 
     from genesis.mcp.health.settings import _load_yaml_merged
+
     merged = _load_yaml_merged("inbox_monitor.yaml")
     assert merged["inbox_monitor"]["batch_size"] == 5
     assert merged["inbox_monitor"]["enabled"] is True  # Preserved from base
@@ -340,21 +388,25 @@ class TestValidateTTS:
         assert "Unknown key" in errs[0]
 
     def test_multiple_errors(self):
-        errs = _validate_tts({
-            "provider": "bad",
-            "elevenlabs": {"stability": 5.0, "speed": 0.1},
-        })
+        errs = _validate_tts(
+            {
+                "provider": "bad",
+                "elevenlabs": {"stability": 5.0, "speed": 0.1},
+            }
+        )
         assert len(errs) == 3
 
     def test_valid_full_elevenlabs(self):
-        errs = _validate_tts({
-            "elevenlabs": {
-                "stability": 0.85,
-                "similarity_boost": 0.7,
-                "style": 0.3,
-                "speed": 1.1,
-            },
-        })
+        errs = _validate_tts(
+            {
+                "elevenlabs": {
+                    "stability": 0.85,
+                    "similarity_boost": 0.7,
+                    "style": 0.3,
+                    "speed": 1.1,
+                },
+            }
+        )
         assert errs == []
 
 
@@ -432,3 +484,26 @@ async def test_settings_tools_registered():
     tools = await mcp.get_tools()
     for name in ["settings_list", "settings_get", "settings_update"]:
         assert name in tools, f"Missing tool: {name}"
+
+
+class TestValidateCcForegroundReaper:
+    def test_valid_changes(self):
+        assert _validate_cc_foreground_reaper({"mode": "notify", "idle_hours": 12}) == []
+
+    def test_invalid_mode(self):
+        errs = _validate_cc_foreground_reaper({"mode": "notfy"})
+        assert len(errs) == 1 and "mode" in errs[0]
+
+    def test_non_positive_int(self):
+        errs = _validate_cc_foreground_reaper({"idle_hours": 0})
+        assert len(errs) == 1 and "idle_hours" in errs[0]
+
+    def test_unknown_key(self):
+        errs = _validate_cc_foreground_reaper({"nope": 1})
+        assert len(errs) == 1 and "nope" in errs[0]
+
+    def test_registered(self):
+        from genesis.mcp.health.settings import _DOMAIN_REGISTRY, _DOMAIN_VALIDATORS
+
+        assert "cc_foreground_reaper" in _DOMAIN_REGISTRY
+        assert "cc_foreground_reaper" in _DOMAIN_VALIDATORS


### PR DESCRIPTION
## What

The remaining half of the 2026-07-20 silent-death remediation (follow-up `19282498`). A foreground `cc_sessions` row stays `active` by design so the next turn can `--resume` it — so a crash / OOM / container restart mid-turn leaves it `active` **forever**, indistinguishable from a healthy resumable session (the incident row sat `active` 26h+ with the user never told). The `session_reaper` job hard-excludes foreground (`query_stale` filters `session_type != 'foreground'`), so nothing reaped them.

## How

`reap_dark_foreground` (new `cc/foreground_reaper.py`), wired into the **existing** `session_reaper` job in its own inner try/except (a notify/observation failure can never abort stale-session/heartbeat cleanup):

- Foreground rows idle > `idle_hours` (24h) → `checkpointed` via `checkpoint_dark` (rowcount-guarded). **Non-destructive**: `get_active_foreground` now matches `checkpointed`, and `get_or_create_foreground` flips it back to `active` on reuse, preserving `cc_session_id` — so `--resume` is untouched.
- Transcript-tail classifier (`dark_signal`): the **crisp** "unanswered user turn" signal → notify the origin user their request was interrupted (reusing the shipped `#1192` delivery path), **only** when the unanswered turn's own timestamp is older than the cutoff (age guard — excludes a mid-flight long turn) and it isn't already covered by a rate-limit park or dispatched session. The **fuzzy** "I'll report back" promise-regex → shadow-logged only, never notifies, until precision is measured.
- Observability-only — it never re-dispatches or auto-retries the dead work.

## Lever
`cc_foreground_reaper` (`off` / `observe` / `notify`, default `notify`) + `GENESIS_FOREGROUND_REAPER_DISABLED`. `observe` reaps + records without notifying.

## Deviation from the original audit
The audit named a `session.dispatched_work_dead` **event**; there's no event bus / consumer, so this uses `observations.create` (the established awareness surfacing pattern) instead.

## Tests
`test_foreground_reaper.py` (pure `dark_signal` + age guard; full reap matrix: skips-live, checkpoints-dead, notify-only-on-unanswered, age-guard-suppresses-midflight, suppressed-on-clean/covered-by-dispatch, promise=shadow, non-telegram-graceful, observe/off modes, resume-after-checkpoint) + CRUD tests (widening, `query_stale_foreground`, `checkpoint_dark` race guard) + the SessionManager checkpointed→active flip. 16 D3 tests + 95 neighboring green locally.

Reviewed pre-build by genesis-architect (DONE_WITH_CONCERNS; all 4 SHOULD-FIX adopted: age guard, kill lever, shared origin resolver reuse, inner try/except isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)