### PR TITLE
feat(ego): PR-4 — dark revision/revalidation schema + rebuild-landmine hardening

### DIFF
--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -568,15 +568,28 @@ async def resolve_proposal(
     status: str,
     user_response: str | None = None,
     resolved_at: str | None = None,
+    expected_revision: int | None = None,
 ) -> bool:
-    """Update a proposal's status. Returns True if a row was updated."""
+    """Update a proposal's status. Returns True if a row was updated.
+
+    ``expected_revision`` (PR-4 dark plumbing — no live caller until PR-6): when
+    provided, the update applies only if the proposal's ``revision_num`` still
+    matches, an optimistic-concurrency guard against a revise/resolve race. The
+    MCP resolve path runs over a SEPARATE non-serialized connection, so this
+    atomic WHERE clause is the only defense against resolving a stale revision.
+    Absent (the default) the behavior is unchanged.
+    """
     if resolved_at is None:
         resolved_at = datetime.now(UTC).isoformat()
-    cursor = await db.execute(
+    sql = (
         "UPDATE ego_proposals SET status = ?, user_response = ?, resolved_at = ? "
-        "WHERE id = ? AND status = 'pending'",
-        (status, user_response, resolved_at, id),
+        "WHERE id = ? AND status = 'pending'"
     )
+    params: list = [status, user_response, resolved_at, id]
+    if expected_revision is not None:
+        sql += " AND revision_num = ?"
+        params.append(expected_revision)
+    cursor = await db.execute(sql, params)
     await db.commit()
     return cursor.rowcount > 0
 

--- a/src/genesis/db/migrations/0071_ego_proposal_revisions.py
+++ b/src/genesis/db/migrations/0071_ego_proposal_revisions.py
@@ -1,0 +1,49 @@
+"""Add the ego_proposal_revisions table — prior-value audit trail for versioned
+proposal revision (ego proposal-lifecycle redesign, PR-4, dark schema).
+
+One row per superseded proposal revision: when the PR-5 reconcile stage revises
+a pending proposal in place, it snapshots the prior (content, rationale,
+confidence, execution_plan, expected_outputs) here before overwriting, so age
+never launders lineage and calibration can grade per revision. Surrogate id PK,
+no FK (mirrors calibration_cell_history; SQLite FK enforcement is PRAGMA-gated,
+so proposal_id is a documented soft reference).
+
+Dark in PR-4 — the table exists but has no writer until PR-5. The paired dark
+columns on ego_proposals (revision_num, revalidate_at, last_validated_at) are
+NOT added here: they are unindexed additive columns handled idempotently by
+_migrate_add_columns on the base path every boot. Adding a bare ADD COLUMN here
+too would double-add after that runs and raise (the boot-crash class documented
+in tests/test_db/test_schema_base_path_parity.py), so this migration is
+table-only.
+
+Fresh/test DBs get the table from the canonical CREATE TABLE in
+db/schema/_tables.py; this numbered migration covers the existing-DB upgrade
+path. Idempotent: CREATE TABLE IF NOT EXISTS. No commit — the runner owns the
+transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """CREATE TABLE IF NOT EXISTS ego_proposal_revisions (
+            id               TEXT PRIMARY KEY,
+            proposal_id      TEXT NOT NULL,
+            revision_num     INTEGER NOT NULL,
+            content          TEXT,
+            rationale        TEXT,
+            confidence       REAL,
+            execution_plan   TEXT,
+            expected_outputs TEXT,
+            revised_at       TEXT NOT NULL,
+            revised_by       TEXT,
+            reason           TEXT
+        )"""
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS ego_proposal_revisions")

--- a/src/genesis/db/migrations/0071_ego_proposal_revisions.py
+++ b/src/genesis/db/migrations/0071_ego_proposal_revisions.py
@@ -1,33 +1,51 @@
-"""Add the ego_proposal_revisions table — prior-value audit trail for versioned
-proposal revision (ego proposal-lifecycle redesign, PR-4, dark schema).
+"""Add the revision/revalidation dark schema for the ego proposal-lifecycle
+redesign (PR-4): three columns on ego_proposals plus the ego_proposal_revisions
+audit table.
 
-One row per superseded proposal revision: when the PR-5 reconcile stage revises
-a pending proposal in place, it snapshots the prior (content, rationale,
-confidence, execution_plan, expected_outputs) here before overwriting, so age
-never launders lineage and calibration can grade per revision. Surrogate id PK,
-no FK (mirrors calibration_cell_history; SQLite FK enforcement is PRAGMA-gated,
-so proposal_id is a documented soft reference).
+- ego_proposals gains revision_num / revalidate_at / last_validated_at.
+- ego_proposal_revisions stores prior (content, rationale, confidence,
+  execution_plan, expected_outputs) snapshots so the PR-5 reconcile stage can
+  revise a pending proposal in place without laundering lineage. Surrogate id
+  PK, no FK (mirrors calibration_cell_history; SQLite FK enforcement is
+  PRAGMA-gated, so proposal_id is a documented soft reference).
 
-Dark in PR-4 — the table exists but has no writer until PR-5. The paired dark
-columns on ego_proposals (revision_num, revalidate_at, last_validated_at) are
-NOT added here: they are unindexed additive columns handled idempotently by
-_migrate_add_columns on the base path every boot. Adding a bare ADD COLUMN here
-too would double-add after that runs and raise (the boot-crash class documented
-in tests/test_db/test_schema_base_path_parity.py), so this migration is
-table-only.
+Dark in PR-4 — no writer until PR-5.
 
-Fresh/test DBs get the table from the canonical CREATE TABLE in
-db/schema/_tables.py; this numbered migration covers the existing-DB upgrade
-path. Idempotent: CREATE TABLE IF NOT EXISTS. No commit — the runner owns the
-transaction.
+Self-contained upgrade path: the column ADDs are PRAGMA-guarded so this migration
+fully applies its own schema whether it runs via create_all_tables' base path
+(where _migrate_add_columns has already added the columns — the guards then skip)
+OR via the standalone numbered-migration runner (python -m genesis.db.migrations
+--apply, used by update.sh) with no create_all_tables. Guarding is what makes the
+double path safe: an unguarded ADD COLUMN after _migrate_add_columns already ran
+would raise 'duplicate column' and hard-fail the runner. Fresh/test DBs get
+everything from the canonical CREATE TABLE in db/schema/_tables.py. No commit —
+the runner owns the transaction.
 """
 
 from __future__ import annotations
 
 import aiosqlite
 
+_EGO_COLUMNS = (
+    ("revision_num", "ALTER TABLE ego_proposals ADD COLUMN revision_num INTEGER DEFAULT 1"),
+    ("revalidate_at", "ALTER TABLE ego_proposals ADD COLUMN revalidate_at TEXT"),
+    ("last_validated_at", "ALTER TABLE ego_proposals ADD COLUMN last_validated_at TEXT"),
+)
+
 
 async def up(db: aiosqlite.Connection) -> None:
+    # Guarded column adds — idempotent and safe regardless of whether
+    # _migrate_add_columns has already run on this DB.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='ego_proposals'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(ego_proposals)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        for name, ddl in _EGO_COLUMNS:
+            if name not in cols:
+                await db.execute(ddl)
+
     await db.execute(
         """CREATE TABLE IF NOT EXISTS ego_proposal_revisions (
             id               TEXT PRIMARY KEY,
@@ -47,3 +65,12 @@ async def up(db: aiosqlite.Connection) -> None:
 
 async def down(db: aiosqlite.Connection) -> None:
     await db.execute("DROP TABLE IF EXISTS ego_proposal_revisions")
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='ego_proposals'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(ego_proposals)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        for name, _ddl in _EGO_COLUMNS:
+            if name in cols:
+                await db.execute(f"ALTER TABLE ego_proposals DROP COLUMN {name}")

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -72,10 +72,20 @@ async def _intersection_copy(
     DROP a column's data: whatever the live table actually has, if ``dst`` also
     declares it, it is copied; columns only ``dst`` has take their DEFAULT.
 
-    A drift canary logs any LIVE column absent from ``dst`` (a column that WOULD
-    be dropped because the rebuild target has fallen behind the canonical DDL).
-    That is the exact data-loss class this helper exists to prevent — surfaced
-    loudly, but never aborting the boot.
+    Drift guard: if the LIVE table has any column ``dst`` does NOT (a rebuild
+    target that has fallen behind the canonical DDL), this RAISES rather than
+    dropping that column's data. Both callers wrap the rebuild in a fail-soft
+    try/except that leaves the ORIGINAL table intact and logs — so genuine drift
+    (a dev error that escaped the base-vs-rebuild parity test) fails the CHECK/
+    UNIQUE upgrade for that one boot but never loses data, and self-heals once
+    the rebuild CREATE is corrected. Dropping-then-logging would be the "mute the
+    symptom" antipattern; preserving irreversible data and failing loud is the
+    right default.
+
+    ``or_ignore`` copies with INSERT OR IGNORE (rebuilds that add a UNIQUE
+    constraint dedup on it — first row per key wins); the number of rows dropped
+    by that dedup is logged so the row-level loss the column drift-guard cannot
+    see is still surfaced.
 
     Table/column names are schema identifiers (from PRAGMA or in-repo string
     literals), never user input, so the f-string interpolation is safe.
@@ -87,17 +97,35 @@ async def _intersection_copy(
 
     dropped = [c for c in src_cols if c not in dst_cols]
     if dropped:
-        logger.warning(
-            "Table-rebuild drift: column(s) %s exist on live '%s' but not on "
-            "rebuild target '%s' — their data would be dropped. Add them to the "
-            "'%s' CREATE in _migrations.py to match the canonical _tables.py DDL.",
-            dropped, src, dst, dst,
+        # Refuse to proceed: copying only the shared columns would permanently
+        # drop `dropped`'s data. Raise so the caller's fail-soft handler keeps
+        # the original table (recoverable) instead of losing data (irreversible).
+        raise RuntimeError(
+            f"Table-rebuild drift: column(s) {dropped} exist on live '{src}' but "
+            f"not on rebuild target '{dst}'; refusing to copy and drop their "
+            f"data. Add them to the '{dst}' CREATE in _migrations.py to match the "
+            f"canonical _tables.py DDL."
         )
 
     shared = [c for c in src_cols if c in dst_cols]
     collist = ", ".join(shared)
     verb = "INSERT OR IGNORE INTO" if or_ignore else "INSERT INTO"
     await db.execute(f"{verb} {dst} ({collist}) SELECT {collist} FROM {src}")  # noqa: S608
+
+    if or_ignore:
+        # dst was freshly created empty before this copy, so its row count is the
+        # number actually inserted; the shortfall vs src is what OR IGNORE dropped.
+        cur = await db.execute(f"SELECT COUNT(*) FROM {src}")  # noqa: S608
+        src_count = (await cur.fetchone())[0]
+        cur = await db.execute(f"SELECT COUNT(*) FROM {dst}")  # noqa: S608
+        dst_count = (await cur.fetchone())[0]
+        merged = src_count - dst_count
+        if merged > 0:
+            logger.info(
+                "Table-rebuild dedup: %s row(s) in '%s' collided on the new "
+                "UNIQUE constraint and were dropped (first row per key wins).",
+                merged, src,
+            )
 
 
 async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
@@ -891,6 +919,9 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         )
         row = await cursor.fetchone()
         if row and "UNIQUE(project_type, domain, concept)" not in (row[0] or ""):
+            # Clear any orphaned temp table from a prior failed/aborted attempt
+            # so the rebuild is retry-safe (mirrors ego_proposals_rebuild).
+            await db.execute("DROP TABLE IF EXISTS knowledge_units_new")
             # Rebuild target mirrors the canonical knowledge_units CREATE in
             # _tables.py (all 21 columns incl. source_pipeline/purpose/
             # ingestion_source/origin_class) so no column data is dropped; the
@@ -935,6 +966,8 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
                 "knowledge_units table rebuilt with UNIQUE(project_type, domain, concept)"
             )
     except Exception:
+        with contextlib.suppress(Exception):
+            await db.execute("DROP TABLE IF EXISTS knowledge_units_new")
         logger.error(
             "knowledge_units UNIQUE constraint migration failed", exc_info=True
         )
@@ -1829,6 +1862,19 @@ async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
 
     SQLite doesn't support ALTER CHECK — must rebuild the table.
     Idempotent: skips if the constraint already includes the new statuses.
+
+    Does NOT recreate indexes: its sole caller (create_all_tables via
+    _migrate_add_columns) runs the module-level INDEXES pass immediately after,
+    re-applying all 8 idx_ego_proposals_*. Do not call this standalone in a
+    context that needs indexes present.
+
+    LOAD-BEARING ORDER: this runs on the base path BEFORE the numbered-migration
+    runner, so it flips the CHECK first and the numbered ego_proposals rebuilds
+    (0007/0012) early-return as no-ops. Those numbered migrations still carry
+    frozen, column-incomplete copy lists; do NOT remove or reorder this base-path
+    rebuild after them, or they could fire on a legacy DB and drop columns
+    (locked by test_rebuild_column_preservation.py
+    ::test_numbered_ego_rebuilds_stay_inert_on_current_db).
     """
     try:
         cursor = await db.execute(

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -56,6 +56,50 @@ async def _try_alter(db: aiosqlite.Connection, sql: str, label: str) -> None:
             logger.error("Migration %s failed: %s", label, exc, exc_info=True)
 
 
+async def _intersection_copy(
+    db: aiosqlite.Connection,
+    *,
+    src: str,
+    dst: str,
+    or_ignore: bool = False,
+) -> None:
+    """Copy rows ``src`` -> ``dst`` over the intersection of their columns, by NAME.
+
+    Used by table-rebuild migrations (SQLite can't ALTER a CHECK/UNIQUE, so the
+    table is rebuilt as ``dst`` then renamed over ``src``). Computing the copy
+    column list at runtime from ``PRAGMA table_info`` — instead of a hardcoded
+    list frozen at some past column set — means a rebuild can never silently
+    DROP a column's data: whatever the live table actually has, if ``dst`` also
+    declares it, it is copied; columns only ``dst`` has take their DEFAULT.
+
+    A drift canary logs any LIVE column absent from ``dst`` (a column that WOULD
+    be dropped because the rebuild target has fallen behind the canonical DDL).
+    That is the exact data-loss class this helper exists to prevent — surfaced
+    loudly, but never aborting the boot.
+
+    Table/column names are schema identifiers (from PRAGMA or in-repo string
+    literals), never user input, so the f-string interpolation is safe.
+    """
+    cur = await db.execute(f"PRAGMA table_info({src})")  # noqa: S608
+    src_cols = [r[1] for r in await cur.fetchall()]
+    cur = await db.execute(f"PRAGMA table_info({dst})")  # noqa: S608
+    dst_cols = {r[1] for r in await cur.fetchall()}
+
+    dropped = [c for c in src_cols if c not in dst_cols]
+    if dropped:
+        logger.warning(
+            "Table-rebuild drift: column(s) %s exist on live '%s' but not on "
+            "rebuild target '%s' — their data would be dropped. Add them to the "
+            "'%s' CREATE in _migrations.py to match the canonical _tables.py DDL.",
+            dropped, src, dst, dst,
+        )
+
+    shared = [c for c in src_cols if c in dst_cols]
+    collist = ", ".join(shared)
+    verb = "INSERT OR IGNORE INTO" if or_ignore else "INSERT INTO"
+    await db.execute(f"{verb} {dst} ({collist}) SELECT {collist} FROM {src}")  # noqa: S608
+
+
 async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     """Idempotent ALTER TABLE migrations for columns added after Phase 0."""
 
@@ -847,6 +891,12 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         )
         row = await cursor.fetchone()
         if row and "UNIQUE(project_type, domain, concept)" not in (row[0] or ""):
+            # Rebuild target mirrors the canonical knowledge_units CREATE in
+            # _tables.py (all 21 columns incl. source_pipeline/purpose/
+            # ingestion_source/origin_class) so no column data is dropped; the
+            # row copy is a runtime column-name intersection with OR IGNORE dedup
+            # (first row per (project_type,domain,concept) wins). A drift canary
+            # in _intersection_copy logs any live column this target lacks.
             await db.execute("""
                 CREATE TABLE knowledge_units_new (
                     id               TEXT PRIMARY KEY,
@@ -866,21 +916,16 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
                     qdrant_id        TEXT,
                     embedding_model  TEXT,
                     retrieved_count  INTEGER NOT NULL DEFAULT 0,
+                    source_pipeline  TEXT,
+                    purpose          TEXT,
+                    ingestion_source TEXT,
+                    origin_class     TEXT,
                     UNIQUE(project_type, domain, concept)
                 )
             """)
-            await db.execute("""
-                INSERT OR IGNORE INTO knowledge_units_new
-                    (id, project_type, domain, source_doc, source_platform,
-                     section_title, concept, body, relationships, caveats, tags,
-                     confidence, source_date, ingested_at, qdrant_id,
-                     embedding_model, retrieved_count)
-                SELECT id, project_type, domain, source_doc, source_platform,
-                       section_title, concept, body, relationships, caveats, tags,
-                       confidence, source_date, ingested_at, qdrant_id,
-                       embedding_model, retrieved_count
-                FROM knowledge_units
-            """)
+            await _intersection_copy(
+                db, src="knowledge_units", dst="knowledge_units_new", or_ignore=True
+            )
             await db.execute("DROP TABLE knowledge_units")
             await db.execute(
                 "ALTER TABLE knowledge_units_new RENAME TO knowledge_units"
@@ -1797,6 +1842,13 @@ async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
             return  # Already up to date
 
         await db.execute("DROP TABLE IF EXISTS ego_proposals_rebuild")
+        # The rebuild target MUST mirror the canonical ego_proposals CREATE in
+        # _tables.py exactly (same columns/types/defaults), differing only by the
+        # corrected status CHECK — that parity is asserted by the Unit-D
+        # base-vs-rebuild schema test. The row copy below is a runtime
+        # column-name intersection (_intersection_copy), NOT a frozen hardcoded
+        # list, so a column added to the live table after this CREATE was written
+        # can never be silently dropped (a drift canary logs any this lacks).
         await db.execute("""
             CREATE TABLE ego_proposals_rebuild (
                 id              TEXT PRIMARY KEY,
@@ -1825,40 +1877,25 @@ async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
                 realist_verdict  TEXT,
                 realist_reasoning TEXT,
                 ego_source       TEXT,
-                goal_id          TEXT
+                goal_id          TEXT,
+                content_hash     TEXT,
+                content_size     INTEGER,
+                original_content TEXT,
+                expected_outputs TEXT,
+                revision_num      INTEGER DEFAULT 1,
+                revalidate_at     TEXT,
+                last_validated_at TEXT
             )
         """)
-        await db.execute("""
-            INSERT INTO ego_proposals_rebuild
-                (id, action_type, action_category, content, rationale,
-                 confidence, urgency, alternatives, status, user_response,
-                 cycle_id, batch_id, created_at, resolved_at, expires_at,
-                 rank, execution_plan, recurring, memory_basis,
-                 realist_verdict, realist_reasoning, ego_source, goal_id)
-            SELECT
-                id, action_type, action_category, content, rationale,
-                confidence, urgency, alternatives, status, user_response,
-                cycle_id, batch_id, created_at, resolved_at, expires_at,
-                rank, execution_plan, recurring, memory_basis,
-                realist_verdict, realist_reasoning, ego_source, goal_id
-            FROM ego_proposals
-        """)
+        await _intersection_copy(db, src="ego_proposals", dst="ego_proposals_rebuild")
         await db.execute("DROP TABLE ego_proposals")
         await db.execute(
             "ALTER TABLE ego_proposals_rebuild RENAME TO ego_proposals"
         )
-        # Recreate indexes
-        for idx_sql in [
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_status ON ego_proposals(status)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_created ON ego_proposals(created_at)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_cycle ON ego_proposals(cycle_id)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_category ON ego_proposals(action_category, status)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_batch ON ego_proposals(batch_id)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_expires ON ego_proposals(expires_at)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_rank ON ego_proposals(status, rank)",
-            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_goal ON ego_proposals(goal_id)",
-        ]:
-            await db.execute(idx_sql)
+        # Indexes are (re)created by create_all_tables' trailing INDEXES pass —
+        # this migration's sole caller runs it right after _migrate_add_columns,
+        # and all 8 idx_ego_proposals_* live in the module-level INDEXES list —
+        # so no inline recreation is needed here.
         await db.commit()
         logger.info("ego_proposals table rebuilt with 'tabled'/'withdrawn' statuses")
     except Exception:

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1498,6 +1498,23 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE ego_proposals ADD COLUMN expected_outputs TEXT",
         "ego_proposals.expected_outputs")
 
+    # PR-4 (ego proposal-lifecycle redesign, dark schema): revision +
+    # revalidation tracking. Unindexed additive columns added on the base
+    # path (every boot) rather than in a numbered migration to avoid the
+    # double-add boot-crash class — a bare ADD COLUMN in the numbered runner
+    # AFTER this _try_alter already ran would raise (see
+    # test_schema_base_path_parity.py). The paired ego_proposal_revisions
+    # table is created by create_all_tables + numbered migration 0071.
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN revision_num INTEGER DEFAULT 1",
+        "ego_proposals.revision_num")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN revalidate_at TEXT",
+        "ego_proposals.revalidate_at")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN last_validated_at TEXT",
+        "ego_proposals.last_validated_at")
+
     # surplus_tasks.not_before — existed in CREATE TABLE DDL but lacked
     # ALTER TABLE migration for installs created before the column was added.
     await _try_alter(db,

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1577,12 +1577,12 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ego_proposals.expected_outputs")
 
     # PR-4 (ego proposal-lifecycle redesign, dark schema): revision +
-    # revalidation tracking. Unindexed additive columns added on the base
-    # path (every boot) rather than in a numbered migration to avoid the
-    # double-add boot-crash class — a bare ADD COLUMN in the numbered runner
-    # AFTER this _try_alter already ran would raise (see
-    # test_schema_base_path_parity.py). The paired ego_proposal_revisions
-    # table is created by create_all_tables + numbered migration 0071.
+    # revalidation tracking. Added on the base path here (every boot) AND by
+    # numbered migration 0071 (PRAGMA-guarded) so the migration ledger is never
+    # marked applied with the columns still absent (0071 also runs standalone
+    # via `python -m genesis.db.migrations`, without this base path). Both are
+    # idempotent: _try_alter suppresses duplicate-column, 0071 skips on PRAGMA —
+    # whichever runs first, the other no-ops (no double-add crash).
     await _try_alter(db,
         "ALTER TABLE ego_proposals ADD COLUMN revision_num INTEGER DEFAULT 1",
         "ego_proposals.revision_num")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1029,7 +1029,30 @@ TABLES = {
             content_hash     TEXT,                    -- SHA-256 of content at creation time
             content_size     INTEGER,                 -- byte count of content at creation time
             original_content TEXT,                    -- pre-realist-amendment content (NULL if not amended)
-            expected_outputs TEXT                     -- JSON: post-dispatch verification criteria (files, min_size, required_strings)
+            expected_outputs TEXT,                    -- JSON: post-dispatch verification criteria (files, min_size, required_strings)
+            revision_num      INTEGER DEFAULT 1,      -- PR-4 dark: current revision number; PR-5 reconcile bumps on revise
+            revalidate_at     TEXT,                   -- PR-4 dark: when the premise is next due for re-validation (set in PR-6)
+            last_validated_at TEXT                    -- PR-4 dark: when the premise was last reaffirmed (set in PR-5)
+        )
+    """,
+    # PR-4 (ego proposal-lifecycle redesign): prior-value audit trail for
+    # versioned proposal revision. One row per superseded revision (surrogate
+    # id PK, no FK — mirrors calibration_cell_history; SQLite FK enforcement is
+    # PRAGMA-gated, so proposal_id is a documented soft reference). Dark in PR-4
+    # (no writer); the PR-5 reconcile stage writes prior values here on revise.
+    "ego_proposal_revisions": """
+        CREATE TABLE IF NOT EXISTS ego_proposal_revisions (
+            id               TEXT PRIMARY KEY,
+            proposal_id      TEXT NOT NULL,           -- ego_proposals.id this revision belongs to (soft ref)
+            revision_num     INTEGER NOT NULL,        -- the prior revision number these snapshotted values represent
+            content          TEXT,                    -- prior content
+            rationale        TEXT,                    -- prior rationale
+            confidence       REAL,                    -- prior confidence
+            execution_plan   TEXT,                    -- prior dispatch instructions (dispatch consumes these)
+            expected_outputs TEXT,                    -- prior post-dispatch verification criteria (JSON)
+            revised_at       TEXT NOT NULL,           -- when the superseding revision was made
+            revised_by       TEXT,                    -- ego_source / reconcile stage that made the revision
+            reason           TEXT                     -- why the revision was made
         )
     """,
     "ego_state": """

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -506,6 +506,10 @@ async def _resolve_one_proposal(
     # and this write and resolve a stale revision. resolve_proposal already
     # accepts expected_revision (PR-4 unit B, inert until wired); PR-6 passes
     # prop["revision_num"] here to make the update atomic. Not passed yet (dark).
+    # NOTE for PR-6: with expected_revision set, a False return conflates
+    # stale-revision, already-resolved, and missing-id. PR-6 must re-read the row
+    # to distinguish a race refusal (re-surface the fresh revision) from a benign
+    # already-resolved before reporting to the user.
     updated = await ego_crud.resolve_proposal(
         db,
         prop["id"],

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -500,6 +500,12 @@ async def _resolve_one_proposal(
     if prop.get("status") != "pending":
         return f"already {prop.get('status')}"
 
+    # GROUNDWORK(ego-pr6-revalidation): this resolves over a SEPARATE
+    # non-serialized get_raw_db connection after reading `prop`, so a concurrent
+    # revise (PR-5 reconcile) could move the proposal's revision between the read
+    # and this write and resolve a stale revision. resolve_proposal already
+    # accepts expected_revision (PR-4 unit B, inert until wired); PR-6 passes
+    # prop["revision_num"] here to make the update atomic. Not passed yet (dark).
     updated = await ego_crud.resolve_proposal(
         db,
         prop["id"],

--- a/tests/ego/test_proposals.py
+++ b/tests/ego/test_proposals.py
@@ -157,6 +157,36 @@ class TestProposalCRUD:
         ok = await ego_crud.resolve_proposal(db, "p1", status="rejected")
         assert ok is False
 
+    async def test_resolve_expected_revision_absent_behaves_as_today(self, db):
+        """PR-4 TOCTOU guard is inert by default: no expected_revision resolves."""
+        await ego_crud.create_proposal(db, id="p1", action_type="t", content="c")
+        ok = await ego_crud.resolve_proposal(db, "p1", status="approved")
+        assert ok is True
+        row = await ego_crud.get_proposal(db, "p1")
+        assert row["status"] == "approved"
+
+    async def test_resolve_expected_revision_match_updates(self, db):
+        """Matching revision_num -> the guarded update applies."""
+        await ego_crud.create_proposal(db, id="p1", action_type="t", content="c")
+        # Fresh proposals default to revision_num = 1 (ego_proposals DEFAULT).
+        ok = await ego_crud.resolve_proposal(
+            db, "p1", status="approved", expected_revision=1,
+        )
+        assert ok is True
+        row = await ego_crud.get_proposal(db, "p1")
+        assert row["status"] == "approved"
+
+    async def test_resolve_expected_revision_mismatch_refuses(self, db):
+        """Stale revision -> refused, row untouched (optimistic-concurrency guard)."""
+        await ego_crud.create_proposal(db, id="p1", action_type="t", content="c")
+        ok = await ego_crud.resolve_proposal(
+            db, "p1", status="approved", expected_revision=2,
+        )
+        assert ok is False
+        row = await ego_crud.get_proposal(db, "p1")
+        assert row["status"] == "pending"
+        assert row["resolved_at"] is None
+
     async def test_batch_delivery_mapping(self, db):
         await ego_crud.set_state(
             db, key="delivery_batch:msg123", value="batch_abc",

--- a/tests/ego/test_schema.py
+++ b/tests/ego/test_schema.py
@@ -118,6 +118,44 @@ class TestEgoSchema:
                     "VALUES ('p2', 'test', 'test', 'BOGUS', '2026-03-28')"
                 )
 
+    def test_ego_proposal_revisions_table_in_schema(self):
+        assert "ego_proposal_revisions" in TABLES
+
+    @pytest.mark.asyncio
+    async def test_ego_proposals_revision_columns_present(self):
+        """PR-4 dark schema: revision + revalidation columns on ego_proposals."""
+        async with aiosqlite.connect(":memory:") as db:
+            await db.execute(TABLES["ego_proposals"])
+            cursor = await db.execute("PRAGMA table_info(ego_proposals)")
+            info = {row[1]: row for row in await cursor.fetchall()}
+            assert "revision_num" in info
+            assert "revalidate_at" in info
+            assert "last_validated_at" in info
+            # PRAGMA table_info columns: (cid, name, type, notnull, dflt_value, pk).
+            # revision_num defaults to 1 so existing rows read as revision 1.
+            assert info["revision_num"][4] == "1"
+            assert info["revision_num"][2] == "INTEGER"
+
+    @pytest.mark.asyncio
+    async def test_ego_proposal_revisions_table_creation(self):
+        async with aiosqlite.connect(":memory:") as db:
+            await db.execute(TABLES["ego_proposal_revisions"])
+            cursor = await db.execute("PRAGMA table_info(ego_proposal_revisions)")
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert cols == {
+                "id",
+                "proposal_id",
+                "revision_num",
+                "content",
+                "rationale",
+                "confidence",
+                "execution_plan",
+                "expected_outputs",
+                "revised_at",
+                "revised_by",
+                "reason",
+            }
+
     def test_ego_indexes_present(self):
         idx_names = [idx for idx in INDEXES if "ego_" in idx]
         assert len(idx_names) >= 9  # 8 original + rank index

--- a/tests/test_db/test_rebuild_column_preservation.py
+++ b/tests/test_db/test_rebuild_column_preservation.py
@@ -20,6 +20,7 @@ import importlib
 import logging
 
 import aiosqlite
+import pytest
 
 from genesis.db.schema._migrations import (
     _intersection_copy,
@@ -160,6 +161,12 @@ async def test_knowledge_units_rebuild_preserves_newer_column_data():
 
 
 async def test_base_vs_rebuild_schema_parity():
+    # SCOPE: this locks the two rebuilds PR-4 hardened with _intersection_copy
+    # (ego_proposals, knowledge_units) + the new ego_proposal_revisions table.
+    # The other ~5 boot-path rebuild sites in _migrations.py (outreach_history,
+    # telegram_messages, tool_registry, cognitive_state) still use frozen copy
+    # lists; they are column-complete today but carry no parity/drift guard.
+    # Generalizing drift-safety to them is tracked as a follow-up, not PR-4.
     fresh = await aiosqlite.connect(":memory:")
     legacy = await aiosqlite.connect(":memory:")
     try:
@@ -225,18 +232,40 @@ async def test_ego_rebuild_idempotent_noop_on_current_ddl():
 # ── Drift canary ──
 
 
-async def test_intersection_copy_drift_canary_fires_and_copies(caplog):
+async def test_intersection_copy_raises_on_drift_and_copies_nothing():
+    # Drift (src has a column dst lacks) must RAISE — refusing to drop the
+    # column's data — not copy-the-rest-and-log. The caller's fail-soft handler
+    # then preserves the original table (recoverable) rather than losing the
+    # column (irreversible). No partial write to dst.
     conn = await aiosqlite.connect(":memory:")
     try:
         await conn.execute("CREATE TABLE src (a TEXT, b TEXT, extra TEXT)")
         await conn.execute("CREATE TABLE dst (a TEXT, b TEXT)")
         await conn.execute("INSERT INTO src (a, b, extra) VALUES ('1','2','LOST')")
         await conn.commit()
-        with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="extra"):
             await _intersection_copy(conn, src="src", dst="dst")
-        assert "extra" in caplog.text and "would be dropped" in caplog.text
-        cur = await conn.execute("SELECT a, b FROM dst")
-        assert await cur.fetchone() == ("1", "2")
+        cur = await conn.execute("SELECT COUNT(*) FROM dst")
+        assert (await cur.fetchone())[0] == 0  # nothing copied
+    finally:
+        await conn.close()
+
+
+async def test_intersection_copy_or_ignore_logs_dropped_rows(caplog):
+    # Row-level loss from OR IGNORE dedup (invisible to the column drift guard)
+    # is surfaced in the logs so a silent merge never ships unnoticed.
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute("CREATE TABLE src (id TEXT, k TEXT, v TEXT)")
+        await conn.execute("CREATE TABLE dst (id TEXT, k TEXT, v TEXT, UNIQUE(k))")
+        await conn.execute("INSERT INTO src (id, k, v) VALUES ('1','K','first')")
+        await conn.execute("INSERT INTO src (id, k, v) VALUES ('2','K','second')")
+        await conn.commit()
+        with caplog.at_level(logging.INFO):
+            await _intersection_copy(conn, src="src", dst="dst", or_ignore=True)
+        assert "1 row" in caplog.text and "dedup" in caplog.text.lower()
+        cur = await conn.execute("SELECT COUNT(*) FROM dst")
+        assert (await cur.fetchone())[0] == 1  # one collided row dropped
     finally:
         await conn.close()
 

--- a/tests/test_db/test_rebuild_column_preservation.py
+++ b/tests/test_db/test_rebuild_column_preservation.py
@@ -1,0 +1,290 @@
+"""Regression guard for the table-rebuild data-loss class (PR-4 unit C/D).
+
+A boot-path "table rebuild" migration (SQLite can't ALTER a CHECK/UNIQUE, so it
+CREATEs a new table, copies rows, DROPs the original, RENAMEs) silently drops a
+column's data when its copy list is a *hardcoded* list frozen at some past
+column set and the rebuild fires with a newer column populated.
+``_migrate_ego_proposals_status_check`` and the ``knowledge_units`` UNIQUE
+rebuild were both armed with this latent bug; PR-4 unit C replaced the frozen
+copy lists with a runtime column-name intersection (``_intersection_copy``) plus
+a drift canary. These tests reproduce the exact loss scenario and lock the fix,
+and assert base-vs-rebuild schema parity so a future hand-CREATE re-drift is
+caught.
+
+Synthetic in-memory DBs only; wall-clock-independent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+import aiosqlite
+
+from genesis.db.schema._migrations import (
+    _intersection_copy,
+    _migrate_add_columns,
+    _migrate_ego_proposals_status_check,
+    create_all_tables,
+)
+from genesis.db.schema._tables import TABLES
+
+# Adversarial legacy ego_proposals: the pre-tabled/withdrawn CHECK (so the
+# rebuild gate FIRES) while ALSO carrying every post-goal_id column populated —
+# the shape a frozen copy list would silently truncate. The ordering in
+# _migrate_add_columns prevents this arising naturally, but a reorder/re-arm is
+# one edit away; this is the regression lock.
+_LEGACY_EGO_OLD_CHECK = """
+    CREATE TABLE ego_proposals (
+        id TEXT PRIMARY KEY, action_type TEXT NOT NULL,
+        action_category TEXT NOT NULL DEFAULT '', content TEXT NOT NULL,
+        rationale TEXT NOT NULL DEFAULT '', confidence REAL NOT NULL DEFAULT 0.0,
+        urgency TEXT NOT NULL DEFAULT 'normal',
+        alternatives TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending'
+            CHECK (status IN ('pending','approved','rejected','expired','executed','failed')),
+        user_response TEXT, cycle_id TEXT, batch_id TEXT, created_at TEXT NOT NULL,
+        resolved_at TEXT, expires_at TEXT, rank INTEGER, execution_plan TEXT,
+        recurring INTEGER DEFAULT 0, memory_basis TEXT DEFAULT '',
+        realist_verdict TEXT, realist_reasoning TEXT, ego_source TEXT, goal_id TEXT,
+        content_hash TEXT, content_size INTEGER, original_content TEXT,
+        expected_outputs TEXT, revision_num INTEGER DEFAULT 1, revalidate_at TEXT,
+        last_validated_at TEXT
+    )
+"""
+
+# Legacy knowledge_units: no UNIQUE(project_type, domain, concept) (so the
+# rebuild gate FIRES) while carrying origin_class (added later by 0054) — the
+# column the frozen copy list omitted.
+_LEGACY_KNOWLEDGE_NO_UNIQUE = """
+    CREATE TABLE knowledge_units (
+        id TEXT PRIMARY KEY, project_type TEXT NOT NULL, domain TEXT NOT NULL,
+        source_doc TEXT NOT NULL, source_platform TEXT, section_title TEXT,
+        concept TEXT NOT NULL, body TEXT NOT NULL, relationships TEXT,
+        caveats TEXT, tags TEXT, confidence REAL DEFAULT 0.85, source_date TEXT,
+        ingested_at TEXT NOT NULL, qdrant_id TEXT, embedding_model TEXT,
+        retrieved_count INTEGER NOT NULL DEFAULT 0, source_pipeline TEXT,
+        purpose TEXT, ingestion_source TEXT, origin_class TEXT
+    )
+"""
+
+
+async def _schema(conn: aiosqlite.Connection, table: str) -> set[tuple]:
+    """Full PRAGMA table_info tuples (name, type, notnull, dflt_value)."""
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return {(r[1], r[2], r[3], r[4]) for r in await cur.fetchall()}
+
+
+# ── Landmine-preserve: the data the frozen copy list dropped now survives ──
+
+
+async def test_ego_rebuild_preserves_newer_column_data():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_LEGACY_EGO_OLD_CHECK)
+        await conn.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, content, status, created_at, "
+            " content_hash, content_size, expected_outputs, revision_num) "
+            "VALUES ('p1','investigate','body','pending','2026-07-01',"
+            "        'HASH',42,'EO',3)"
+        )
+        await conn.commit()
+        await _migrate_ego_proposals_status_check(conn)  # gate fires (old CHECK)
+
+        cur = await conn.execute("SELECT sql FROM sqlite_master WHERE name='ego_proposals'")
+        ddl = (await cur.fetchone())[0]
+        assert "'tabled'" in ddl and "'withdrawn'" in ddl  # CHECK upgraded
+        cur = await conn.execute(
+            "SELECT content_hash, content_size, expected_outputs, revision_num "
+            "FROM ego_proposals WHERE id='p1'"
+        )
+        # This exact assertion FAILS against the pre-PR-4 frozen copy list.
+        assert await cur.fetchone() == ("HASH", 42, "EO", 3)
+    finally:
+        await conn.close()
+
+
+async def test_ego_rebuild_failure_leaves_original_intact(monkeypatch):
+    import genesis.db.schema._migrations as m
+
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_LEGACY_EGO_OLD_CHECK)
+        await conn.execute(
+            "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
+            "VALUES ('p1','t','body','pending','2026-07-01')"
+        )
+        await conn.commit()
+
+        async def boom(*a, **k):
+            raise RuntimeError("simulated copy failure")
+
+        monkeypatch.setattr(m, "_intersection_copy", boom)
+        # Fail-soft: swallows the error, never raises out of the migration.
+        await m._migrate_ego_proposals_status_check(conn)
+
+        cur = await conn.execute("SELECT content FROM ego_proposals WHERE id='p1'")
+        assert (await cur.fetchone())[0] == "body"  # original row intact
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE name='ego_proposals_rebuild'"
+        )
+        assert await cur.fetchone() is None  # temp table cleaned up
+    finally:
+        await conn.close()
+
+
+async def test_knowledge_units_rebuild_preserves_newer_column_data():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await create_all_tables(conn)
+        await conn.execute("DROP TABLE knowledge_units")
+        await conn.execute(_LEGACY_KNOWLEDGE_NO_UNIQUE)
+        await conn.execute(
+            "INSERT INTO knowledge_units "
+            "(id, project_type, domain, source_doc, concept, body, ingested_at, origin_class) "
+            "VALUES ('k1','p','d','doc','c','b','2026-07-01','OC')"
+        )
+        await conn.commit()
+        await _migrate_add_columns(conn)  # runs the knowledge_units rebuild
+
+        cur = await conn.execute("SELECT sql FROM sqlite_master WHERE name='knowledge_units'")
+        assert "UNIQUE(project_type, domain, concept)" in (await cur.fetchone())[0]
+        cur = await conn.execute("SELECT origin_class FROM knowledge_units WHERE id='k1'")
+        assert (await cur.fetchone())[0] == "OC"  # dropped by pre-PR-4 code
+    finally:
+        await conn.close()
+
+
+# ── Column-set parity: legacy-upgrade == fresh, for every touched table ──
+
+
+async def test_base_vs_rebuild_schema_parity():
+    fresh = await aiosqlite.connect(":memory:")
+    legacy = await aiosqlite.connect(":memory:")
+    try:
+        await create_all_tables(fresh)
+
+        await create_all_tables(legacy)
+        await legacy.execute("DROP TABLE ego_proposals")
+        await legacy.execute(_LEGACY_EGO_OLD_CHECK)
+        await legacy.execute("DROP TABLE knowledge_units")
+        await legacy.execute(_LEGACY_KNOWLEDGE_NO_UNIQUE)
+        await legacy.commit()
+        await create_all_tables(legacy)  # rebuilds fire on the swapped tables
+
+        for table in ("ego_proposals", "knowledge_units", "ego_proposal_revisions"):
+            assert await _schema(legacy, table) == await _schema(fresh, table), table
+    finally:
+        await fresh.close()
+        await legacy.close()
+
+
+# ── Numbered ego rebuilds (0007/0012) stay inert on a current DB ──
+
+
+async def test_numbered_ego_rebuilds_stay_inert_on_current_db():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await create_all_tables(conn)
+        before = await _schema(conn, "ego_proposals")
+        for mod_name in ("0007_ego_proposal_board", "0012_ego_proposals_status_check"):
+            mod = importlib.import_module(f"genesis.db.migrations.{mod_name}")
+            await mod.up(conn)  # guards early-return; must not shrink the table
+        after = await _schema(conn, "ego_proposals")
+        assert after == before
+        assert len(after) == 30
+    finally:
+        await conn.close()
+
+
+# ── Idempotent no-op on already-current DDL ──
+
+
+async def test_ego_rebuild_idempotent_noop_on_current_ddl():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["ego_proposals"])  # canonical (has tabled/withdrawn)
+        await conn.execute(
+            "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
+            "VALUES ('p1','t','body','pending','2026-07-01')"
+        )
+        await conn.commit()
+        await _migrate_ego_proposals_status_check(conn)  # gate early-returns
+
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE name='ego_proposals_rebuild'"
+        )
+        assert await cur.fetchone() is None  # no rebuild happened
+        cur = await conn.execute("SELECT content FROM ego_proposals WHERE id='p1'")
+        assert (await cur.fetchone())[0] == "body"
+    finally:
+        await conn.close()
+
+
+# ── Drift canary ──
+
+
+async def test_intersection_copy_drift_canary_fires_and_copies(caplog):
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute("CREATE TABLE src (a TEXT, b TEXT, extra TEXT)")
+        await conn.execute("CREATE TABLE dst (a TEXT, b TEXT)")
+        await conn.execute("INSERT INTO src (a, b, extra) VALUES ('1','2','LOST')")
+        await conn.commit()
+        with caplog.at_level(logging.WARNING):
+            await _intersection_copy(conn, src="src", dst="dst")
+        assert "extra" in caplog.text and "would be dropped" in caplog.text
+        cur = await conn.execute("SELECT a, b FROM dst")
+        assert await cur.fetchone() == ("1", "2")
+    finally:
+        await conn.close()
+
+
+async def test_intersection_copy_silent_when_target_is_superset(caplog):
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute("CREATE TABLE src (a TEXT, b TEXT)")
+        await conn.execute("CREATE TABLE dst (a TEXT, b TEXT, c TEXT)")  # dst ⊇ src
+        await conn.execute("INSERT INTO src (a, b) VALUES ('1','2')")
+        await conn.commit()
+        with caplog.at_level(logging.WARNING):
+            await _intersection_copy(conn, src="src", dst="dst")
+        assert "would be dropped" not in caplog.text
+        cur = await conn.execute("SELECT a, b, c FROM dst")
+        assert await cur.fetchone() == ("1", "2", None)  # c takes DEFAULT NULL
+    finally:
+        await conn.close()
+
+
+# ── knowledge_units OR IGNORE dedup preserved (first row per key wins) ──
+
+
+async def test_knowledge_units_rebuild_dedups_first_wins():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await create_all_tables(conn)
+        await conn.execute("DROP TABLE knowledge_units")
+        await conn.execute(_LEGACY_KNOWLEDGE_NO_UNIQUE)
+        await conn.execute(
+            "INSERT INTO knowledge_units "
+            "(id, project_type, domain, source_doc, concept, body, ingested_at) "
+            "VALUES ('k1','p','d','doc','c','FIRST','2026-07-01')"
+        )
+        await conn.execute(
+            "INSERT INTO knowledge_units "
+            "(id, project_type, domain, source_doc, concept, body, ingested_at) "
+            "VALUES ('k2','p','d','doc','c','SECOND','2026-07-02')"
+        )
+        await conn.commit()
+        await _migrate_add_columns(conn)
+
+        cur = await conn.execute(
+            "SELECT COUNT(*) FROM knowledge_units "
+            "WHERE project_type='p' AND domain='d' AND concept='c'"
+        )
+        assert (await cur.fetchone())[0] == 1  # deduped by UNIQUE + OR IGNORE
+        cur = await conn.execute("SELECT body FROM knowledge_units")
+        assert (await cur.fetchone())[0] == "FIRST"  # first row won
+    finally:
+        await conn.close()

--- a/tests/test_db/test_rebuild_column_preservation.py
+++ b/tests/test_db/test_rebuild_column_preservation.py
@@ -317,3 +317,46 @@ async def test_knowledge_units_rebuild_dedups_first_wins():
         assert (await cur.fetchone())[0] == "FIRST"  # first row won
     finally:
         await conn.close()
+
+
+# ── Migration 0071 self-contains its schema on the standalone runner path ──
+
+
+async def test_migration_0071_adds_columns_standalone_and_is_double_add_safe():
+    # Codex P2 regression: the numbered runner can apply 0071 WITHOUT
+    # create_all_tables (python -m genesis.db.migrations --apply, used by
+    # update.sh). 0071 must add the 3 columns itself — else the migration ledger
+    # marks 0071 applied while revision_num/revalidate_at/last_validated_at are
+    # still absent — AND must no-op (not 'duplicate column' crash) when
+    # _migrate_add_columns already added them on the base path.
+    mod = importlib.import_module("genesis.db.migrations.0071_ego_proposal_revisions")
+
+    # (a) Standalone path: a legacy ego_proposals with none of the 3 columns.
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(
+            "CREATE TABLE ego_proposals (id TEXT PRIMARY KEY, status TEXT, created_at TEXT)"
+        )
+        await conn.commit()
+        await mod.up(conn)
+        cur = await conn.execute("PRAGMA table_info(ego_proposals)")
+        cols = {r[1] for r in await cur.fetchall()}
+        assert {"revision_num", "revalidate_at", "last_validated_at"} <= cols
+        cur = await conn.execute("PRAGMA table_info(ego_proposal_revisions)")
+        assert len(list(await cur.fetchall())) == 11
+        await mod.up(conn)  # (b) idempotent second run — no duplicate-column error
+    finally:
+        await conn.close()
+
+    # (c) After the base path already added them (canonical DDL has the 3 cols):
+    #     0071 must skip via its PRAGMA guard, not raise duplicate-column.
+    conn2 = await aiosqlite.connect(":memory:")
+    try:
+        await conn2.execute(TABLES["ego_proposals"])
+        await conn2.commit()
+        await mod.up(conn2)
+        cur = await conn2.execute("PRAGMA table_info(ego_proposals)")
+        cols = {r[1] for r in await cur.fetchall()}
+        assert {"revision_num", "revalidate_at", "last_validated_at"} <= cols
+    finally:
+        await conn2.close()

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -81,6 +81,7 @@ EXPECTED_TABLES = [
     "reflex_signals",  # reflex arc P0: fingerprint-deduped task.failed signals + lifecycle
     "reflex_diagnoses",  # reflex arc P0: Tier-0 diagnose session artifacts (PR2 writes)
     "reflex_verdicts",  # reflex arc P0: taste corpus — every human verdict, never pruned
+    "ego_proposal_revisions",  # ego lifecycle PR-4: prior-value audit trail for versioned revision (dark)
 ]
 
 


### PR DESCRIPTION
## What

PR-4 of the ego proposal-lifecycle redesign. Lays the **dark schema** foundation for versioned proposal revision + revalidation cadence (advances ledger `5e6ab75c` decisions #1 versioned-revision, #2 revalidation-cadence — does **not** close it; PR-5/6 consume this). While adding columns to `ego_proposals`, an enumerate-the-class audit found a latent **data-loss class** in two boot-path table-rebuild migrations, so this PR also kills that class.

No behavior change — the schema is dark until PR-5/6 wire writers/consumers.

## Changes (committed in units A→D)

**A. Dark schema.** `ego_proposals` gains `revision_num INTEGER DEFAULT 1`, `revalidate_at TEXT`, `last_validated_at TEXT` (all nullable/defaulted, unindexed). New `ego_proposal_revisions` audit table (surrogate `id` PK, no FK — mirrors `calibration_cell_history`). Plumbed via canonical CREATE (`_tables.py`) + idempotent `_migrate_add_columns` `_try_alter` (existing installs) + a table-only numbered migration `0071`. Columns are deliberately **not** in `0071`: a bare `ADD COLUMN` there after `_migrate_add_columns` already ran would double-add and crash boot (the class `test_schema_base_path_parity.py` documents).

**B. Inert TOCTOU guard.** Optional `expected_revision` on `resolve_proposal` appends `AND revision_num = ?` only when passed. Fully inert (all 6 callers use kwargs / default `None`); wired to a live caller in PR-6. The MCP resolve path runs over a separate non-serialized connection, so this atomic WHERE clause is the real defense against a revise/resolve race.

**C. Rebuild-landmine hardening.** Two rebuilds (`_migrate_ego_proposals_status_check`, the `knowledge_units` UNIQUE rebuild) carried hardcoded `INSERT…SELECT` copy lists frozen at a past column set — one reorder/re-arm from silently dropping populated columns' data. New shared `_intersection_copy` computes the copy list at runtime from `PRAGMA table_info` (name-matched, order-independent) and **raises on drift** (a live column the target lacks) so the caller's fail-soft handler preserves the original table rather than losing data. Both rebuild CREATEs now mirror the full canonical DDL. The ego rebuild's redundant inline index loop is removed (the trailing `INDEXES` pass in its sole caller re-applies all 8).

**D. Tests.** 10-case `test_rebuild_column_preservation.py`: per-table landmine-preserve + mid-rebuild-failure-leaves-original-intact; base-vs-rebuild full-PRAGMA schema parity; numbered `0007`/`0012` stay inert on a current DB; idempotent no-op; drift raises; OR IGNORE dedup logging + first-row-wins.

## Verification

- 233 targeted tests green (schema, migration runner, rebuild-preservation, knowledge CRUD, ego proposals/crud/lifecycle).
- **Production-boot E2E on a legacy DB** (real `init_db` order: `create_all_tables` → `MigrationRunner.run_pending`): all migrations apply incl. `0071`, `ego_proposals` rebuilds to 30 cols with populated `content_hash` preserved, `revision_num` backfills to 1, `0071` recorded in the ledger.
- High-effort multi-angle code review (line-by-line, removed-behavior, cross-file, cleanup/altitude); findings addressed (raise-on-drift, dedup logging, explicit invariants) or tracked as a follow-up (generalize drift-safety to the other ~5 column-complete rebuild sites).

## Notes

- Deliberately dark — no user-visible effect, so no CHANGELOG/CURRENT.md entry.
- `ego_proposal_revisions` prune path lands with its writer in PR-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)