### PR TITLE
feat(hooks): guard against the Bash-tool-timeout deploy footgun

### DIFF
--- a/.claude/hooks/cc-deploy-timeout-guard
+++ b/.claude/hooks/cc-deploy-timeout-guard
@@ -28,5 +28,12 @@ esac
 BG=$(printf '%s' "$IN" | jq -r '.tool_input.run_in_background // false' 2>/dev/null)
 [ "$BG" = "true" ] && exit 0
 
-printf '%s\n' "ADVISORY: this looks like a long deploy (update.sh / bootstrap.sh / host-setup.sh) in the FOREGROUND. It aligns the container + redeploys the guardian + syncs the host (update-node up to 600s, update-cc up to 300s, sequential) and routinely exceeds the Bash tool's 120s DEFAULT timeout — an inner 'timeout N' does NOT extend it, and a SIGTERM at 120s makes update.sh roll back mid-deploy. Prefer run_in_background: true (harness-tracked, no timeout ceiling), or set the Bash tool 'timeout' param generously (>=900000ms)." >&2
+# Surface the nudge via PreToolUse structured stdout (additionalContext) — exit 0
+# + stderr is treated as "no objection" and is NOT shown to the model, which would
+# make this guard invisible in the exact path it protects.
+ADVISORY="ADVISORY: this looks like a long deploy (update.sh / bootstrap.sh / host-setup.sh) in the FOREGROUND. It aligns the container + redeploys the guardian + syncs the host (update-node up to 600s, update-cc up to 300s, sequential) and routinely exceeds the Bash tool's 120s DEFAULT timeout — an inner 'timeout N' does NOT extend it, and a SIGTERM at 120s makes update.sh roll back mid-deploy. Prefer run_in_background: true (harness-tracked, no timeout ceiling), or set the Bash tool 'timeout' param generously (>=900000ms)."
+# jq builds valid JSON (escapes the message). If jq somehow fails, fall back to
+# stderr so the nudge is at least not lost, and still exit 0 (never block).
+jq -n --arg c "$ADVISORY" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$c}}' 2>/dev/null \
+    || printf '%s\n' "$ADVISORY" >&2
 exit 0

--- a/.claude/hooks/cc-deploy-timeout-guard
+++ b/.claude/hooks/cc-deploy-timeout-guard
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) ADVISORY — never blocks (always exit 0).
+#
+# Long deploys — scripts/update.sh, bootstrap.sh, host-setup.sh — routinely exceed
+# the Bash TOOL's 120s DEFAULT timeout (container align + guardian redeploy + host
+# update-node/update-cc, run sequentially). An inner `timeout N …` does NOT extend
+# the tool's own timeout, so a FOREGROUND run gets SIGKILLed at 120s (exit 143) and
+# update.sh's SIGTERM traps roll it back mid-deploy. The fix is to run these via
+# `run_in_background: true` (harness-tracked, no timeout ceiling). This hook nudges
+# toward that, only when such a deploy is run in the FOREGROUND.
+#
+# Non-blocking by contract: EVERY path exits 0. Worst case is a spurious one-line
+# note (e.g. on `cat scripts/update.sh`); it can never stop a legitimate command.
+# See the genesis-development skill's Timeout Policy and CC memory
+# feedback-bash-tool-timeout-long-deploys.
+
+IN=$(cat 2>/dev/null)
+CMD=$(printf '%s' "$IN" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && exit 0
+
+# Only the long-deploy scripts.
+case "$CMD" in
+    *update.sh*|*bootstrap.sh*|*host-setup.sh*) : ;;
+    *) exit 0 ;;
+esac
+
+# Already backgrounded (correct usage) → nothing to say.
+BG=$(printf '%s' "$IN" | jq -r '.tool_input.run_in_background // false' 2>/dev/null)
+[ "$BG" = "true" ] && exit 0
+
+printf '%s\n' "ADVISORY: this looks like a long deploy (update.sh / bootstrap.sh / host-setup.sh) in the FOREGROUND. It aligns the container + redeploys the guardian + syncs the host (update-node up to 600s, update-cc up to 300s, sequential) and routinely exceeds the Bash tool's 120s DEFAULT timeout — an inner 'timeout N' does NOT extend it, and a SIGTERM at 120s makes update.sh roll back mid-deploy. Prefer run_in_background: true (harness-tracked, no timeout ceiling), or set the Bash tool 'timeout' param generously (>=900000ms)." >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -222,6 +222,16 @@
                 ]
             },
             {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/cc-deploy-timeout-guard",
+                        "timeout": 5
+                    }
+                ]
+            },
+            {
                 "matcher": "WebFetch",
                 "hooks": [
                     {

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -74,6 +74,21 @@ is raw subprocess calls with no external watchdog (e.g., deterministic
 executor steps), where a hung process blocks shared resources (executor
 semaphore) with no other recovery mechanism.
 
+**The Bash TOOL's own timeout is separate — and defaults to 120s.** An inner
+`timeout N …` INSIDE the command does NOT extend it: the tool wrapper SIGTERMs the
+whole call at its own `timeout` param (default 120000ms → exit 143). To allow
+longer, set the Bash tool's `timeout` PARAMETER explicitly. For long or unbounded
+work — above all deploys (`scripts/update.sh`, `bootstrap.sh`, `host-setup.sh`:
+container align + guardian redeploy + host `update-node`/`update-cc`, run
+sequentially — can exceed even 900s) — run via **`run_in_background: true`**
+(harness-tracked, notifies on completion, no timeout ceiling), NEVER a foreground
+timeout or `nohup … &` (detached but untracked → no completion signal, so you end
+up hand-polling anyway). `update.sh` has SIGTERM/INT rollback traps, so a mid-run
+kill is not a no-op — verify state (server active, no mid-rebase, pin, both CC
+versions) before re-running; it is idempotent. (A non-blocking PreToolUse advisory
+hook, `.claude/hooks/cc-deploy-timeout-guard`, nudges toward this when a deploy is
+run in the foreground.)
+
 ### Verify Outcomes, Not Just Tests
 
 `ruff check . && pytest -v` is the minimum bar, not the finish line.


### PR DESCRIPTION
## Why
During the CC 2.1.218 deploy, `scripts/update.sh` was SIGKILLed at 120s because the Bash **tool's** own timeout defaults to 120s and an inner `timeout 900` does **not** extend it — and `update.sh`'s SIGTERM traps then rolled it back mid-deploy. Avoidable, and worth preventing structurally rather than relying on a per-install CC memory.

## What
- **`genesis-development` skill → Timeout Policy:** documents that the Bash tool timeout is separate + defaults to 120s (inner `timeout N` doesn't extend it), and long deploys (`update.sh` / `bootstrap.sh` / `host-setup.sh` — container align + guardian redeploy + host `update-node`/`update-cc`, sequential, can exceed 900s) must run via **`run_in_background: true`**, never a foreground timeout or `nohup`.
- **New non-blocking PreToolUse(Bash) hook `cc-deploy-timeout-guard`:** nudges toward `run_in_background` when a deploy script is run in the foreground. Silent when `run_in_background: true` or on non-deploy commands. **Always exits 0 — it can never block a command.**

## Verification
Hook tested standalone: foreground `update.sh`/`host-setup.sh` → advisory; `run_in_background:true` → silent; non-deploy → silent; settings.json valid. This is versioned + all-installs (skill + repo hook), unlike the foreground-only CC memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
