### PR TITLE
fix(ci): triage 4 new litellm proxy CVEs in dependency-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,18 @@ jobs:
         run: |
           # Triaged --ignore-vuln IDs (rationale of record: pyproject.toml pins).
           # A NEW / untriaged advisory is NOT in this list and so fails the job.
-          #   litellm 1.78.7 — every ID is a proxy-server / JWT / OIDC / UI vuln;
-          #     Genesis uses acompletion/completion_cost only (no proxy server),
-          #     so none are reachable. Pinned <1.83 also dodges 1.82.x malware.
+          #   litellm 1.78.7 — every ID is a proxy-server / JWT / OIDC / UI /
+          #     MCP-gateway vuln; Genesis uses acompletion/completion_cost only
+          #     (no proxy server), so none are reachable. Pinned <1.83 also dodges
+          #     1.82.x malware. The 2026-11 batch is the same class, each gated on
+          #     running the proxy Genesis never starts (advisory-verified):
+          #       CVE-2026-59819 — /health/test_connection OIDC file-read (proxy).
+          #       CVE-2026-59820 — /v1/skills archive path-traversal (proxy route).
+          #       CVE-2026-59821 — Guardrails create/update code-exec (proxy).
+          #       CVE-2026-59822 — MCP Streamable-HTTP OAuth2 auth bypass (proxy MCP
+          #         gateway; Genesis's own MCP servers are fastmcp, not litellm's).
+          #     grep-verified: only litellm.acompletion / completion_cost /
+          #     model_cost + exception types are imported — no proxy surface.
           #   diskcache 5.6.3 (CVE-2025-69872) — pickle-by-default RCE, no fixed
           #     release. Genesis's only diskcache use (memory/embeddings.py) is a
           #     JSON-only _SafeDisk subclass, so the vulnerable pickle path is unused.
@@ -72,6 +81,10 @@ jobs:
             --ignore-vuln CVE-2026-42271 \
             --ignore-vuln CVE-2026-47102 \
             --ignore-vuln CVE-2026-47101 \
+            --ignore-vuln CVE-2026-59819 \
+            --ignore-vuln CVE-2026-59820 \
+            --ignore-vuln CVE-2026-59821 \
+            --ignore-vuln CVE-2026-59822 \
             --ignore-vuln CVE-2025-69872 \
             --ignore-vuln PYSEC-2026-2475 \
             --ignore-vuln PYSEC-2026-2476


### PR DESCRIPTION
## What

`dependency-audit` started failing repo-wide on 4 new litellm advisories published against the pinned `litellm==1.78.7`. This adds them to the `--ignore-vuln` triage list with per-CVE rationale.

## Why they're not reachable

All 4 require running the **litellm proxy server**, which Genesis never starts — it uses litellm purely as a library:

| CVE | GHSA | Sev | Surface (proxy-only) |
|---|---|---|---|
| CVE-2026-59819 | GHSA-4g5m-c9r5-49xf | low | `/health/test_connection` OIDC file-read |
| CVE-2026-59820 | GHSA-5jmr-gcrj-2c9q | med | `/v1/skills` archive path-traversal |
| CVE-2026-59821 | GHSA-72m8-9m7m-h278 | low | Guardrails create/update code-exec |
| CVE-2026-59822 | GHSA-7488-6r32-c95q | high | MCP Streamable-HTTP OAuth2 auth bypass (proxy MCP gateway) |

**grep-verified** Genesis imports only `litellm.acompletion` / `completion_cost` / `model_cost` + exception types — no `proxy_server`, `/v1/skills`, Guardrails, `test_connection`, or litellm MCP-gateway usage anywhere. Genesis's own MCP servers are fastmcp, not litellm's. Same class as the 7 litellm advisories already triaged in this list.

Verified locally: with these 4 added, `pip-audit` no longer flags any litellm CVE.

## Scope

CI-only (comments + 4 static `--ignore-vuln` lines). No dependency version change (the pin stays `<1.83` to also avoid the 1.82.x malware). Revisit if Genesis ever runs the litellm proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)