### PR TITLE
fix(observability): failure emitters carry a diagnosable payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **When a scheduled job fails, Genesis now records what actually went wrong.**
+  Job failures were logged with only the job's name and whatever text the error
+  happened to carry — and for the most common failures that text was *empty*, so
+  the record read "Scheduled job 'memory_extraction' failed:" with nothing after
+  it. Failures now carry the error type and the code location, in both the event
+  log and the job-health view, which is the difference between a failure you can
+  diagnose and one you can only count. Genesis also now distinguishes a bug in
+  its own code from an outside blocker (a provider outage, a rate limit) rather
+  than filing both the same way — so "the API was down" no longer looks like
+  something to go fix in the code.
 - **A failed update that had already run database migrations now rolls the
   database back too.** Previously a rollback restored the code and dependencies
   but left the (newly migrated) database in place, so the rolled-back older code

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -538,7 +538,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 6d79e097 2026-07-21
+verified: 483469d7 2026-07-23
 ```
 
 - **PR-watch inline surface (2026-07-21)**: a SessionStart hook
@@ -614,7 +614,18 @@ verified: 6d79e097 2026-07-21
   failure on streak onset + hourly heartbeat — so a stuck sub-hourly poll costs
   ~24 rows/day. `duration_ms` is honest-or-NULL (only from an explicit
   `record_job_start` marker; never derived from `last_run`). 90-day prune via
-  `_wire_drip_retention_jobs`.
+  `_wire_drip_retention_jobs`. **Failure payloads (2026-07-23):** the three
+  scheduler emitters (reflection, outreach, surplus) thread the exception into
+  `observability/failure_details.py`, which sets `error_type` **IFF** a real
+  exception caused the failure — a semantic failure (external blocker, e.g. a
+  429 quota result) carries `error_reason` and no `error_type`. That presence
+  test is the structural internal-vs-external discriminator; do NOT infer it by
+  pattern-matching the message, because ONE event type carries both kinds
+  (`weekly_assessment.failed` fires for a genuine TypeError *and* for a provider
+  quota block). `job_health.error_type` mirrors it and clears on recovery
+  alongside `last_error`. Frames come only from
+  `util/tasks.normalized_frames` — a second normalizer would split one bug
+  into two fingerprints.
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
   reflection bridge. GROUNDWORK: user-model-synthesis, pre-execution-gate

--- a/src/genesis/db/migrations/0072_job_health_error_type.py
+++ b/src/genesis/db/migrations/0072_job_health_error_type.py
@@ -1,0 +1,55 @@
+"""Add ``job_health.error_type`` — the exception class behind a job failure.
+
+Before this, ``job_health.last_error`` was the only failure detail stored, and it
+was written as a bare ``str(exception)``. APScheduler exceptions routinely render
+as an EMPTY string, so live rows carried ``last_error = ""`` — a failure record
+with no diagnosable content. The exception TYPE is precisely the signal that was
+being dropped.
+
+``error_type`` is NULL when no exception caused the failure (a semantic failure —
+e.g. an external quota block surfaced through a job result's reason). That makes
+the column a structural discriminator between an internal defect and an external
+blocker, not just extra detail.
+
+Cleared on recovery alongside ``last_error`` (``record_job_success`` /
+``clear_stale_job_failures`` both pop it), so a recovered job never keeps a stale
+type.
+
+Self-contained upgrade path: the column ADD is PRAGMA-guarded so this migration
+applies whether it runs via ``create_all_tables``' base path (where
+``_migrate_add_columns`` has already added the column — the guard then skips) OR
+via the standalone numbered-migration runner (``python -m genesis.db.migrations
+--apply``, used by update.sh) with no create_all_tables. Fresh/test DBs get the
+column from the CREATE TABLE in ``db/schema/_migrations.py``. No commit — the
+runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='job_health'"
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — the CREATE TABLE already carries the column
+
+    cursor = await db.execute("PRAGMA table_info(job_health)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "error_type" not in cols:
+        await db.execute("ALTER TABLE job_health ADD COLUMN error_type TEXT")
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='job_health'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    cursor = await db.execute("PRAGMA table_info(job_health)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "error_type" in cols:
+        await db.execute("ALTER TABLE job_health DROP COLUMN error_type")

--- a/src/genesis/db/migrations/__main__.py
+++ b/src/genesis/db/migrations/__main__.py
@@ -12,6 +12,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -20,10 +21,28 @@ import aiosqlite
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
+def _resolve_db_path() -> Path:
+    """Resolve the DB to migrate.
+
+    ``GENESIS_DB_PATH`` wins when set — WITHOUT it, migrating a copy is
+    impossible and the obvious ``GENESIS_DB_PATH=~/tmp/copy.db python -m
+    genesis.db.migrations --apply`` silently rewrites PRODUCTION (this bit us
+    2026-07-23). The fallback stays HOME-anchored (not ``repo_root()/data``) so
+    a run from a worktree checkout still targets the real production DB rather
+    than an empty ``<worktree>/data`` — the trap ``genesis_db_path()`` walks
+    into (see feedback_hook_prod_db_home_anchored). update.sh runs this from
+    ~/genesis, so production behaviour is unchanged.
+    """
+    value = os.environ.get("GENESIS_DB_PATH")
+    if value:
+        return Path(value).expanduser()
+    return Path.home() / "genesis" / "data" / "genesis.db"
+
+
 async def _run(args: argparse.Namespace) -> int:
     from genesis.db.migrations.runner import MigrationRunner
 
-    db_path = Path.home() / "genesis" / "data" / "genesis.db"
+    db_path = _resolve_db_path()
     if not db_path.exists():
         print(f"Database not found: {db_path}", file=sys.stderr)
         return 1

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -325,15 +325,21 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             last_success     TEXT,
             last_failure     TEXT,
             last_error       TEXT,
-            -- Exception class name when an exception caused the failure, else
-            -- NULL (a semantic failure — e.g. an external quota block). Cleared
-            -- on recovery alongside last_error.
-            error_type       TEXT,
             consecutive_failures INTEGER NOT NULL DEFAULT 0,
             total_runs       INTEGER NOT NULL DEFAULT 0,
             total_successes  INTEGER NOT NULL DEFAULT 0,
             total_failures   INTEGER NOT NULL DEFAULT 0,
-            updated_at       TEXT NOT NULL
+            updated_at       TEXT NOT NULL,
+            -- Exception class name when an exception caused the failure, else
+            -- NULL (a semantic failure — e.g. an external quota block). Cleared
+            -- on recovery alongside last_error.
+            --
+            -- LAST on purpose: ALTER TABLE ADD COLUMN appends, so declaring it
+            -- last here keeps a fresh install's column ORDER identical to an
+            -- upgraded one. Both dashboard readers use SELECT * with dict(row)
+            -- (name-based) today, but a positional reader would otherwise
+            -- silently disagree between fresh and migrated installs.
+            error_type       TEXT
         )
     """)
 

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -325,6 +325,10 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             last_success     TEXT,
             last_failure     TEXT,
             last_error       TEXT,
+            -- Exception class name when an exception caused the failure, else
+            -- NULL (a semantic failure — e.g. an external quota block). Cleared
+            -- on recovery alongside last_error.
+            error_type       TEXT,
             consecutive_failures INTEGER NOT NULL DEFAULT 0,
             total_runs       INTEGER NOT NULL DEFAULT 0,
             total_successes  INTEGER NOT NULL DEFAULT 0,
@@ -332,6 +336,12 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             updated_at       TEXT NOT NULL
         )
     """)
+
+    # Failure-emitter payloads: error_type on job_health for DBs created before
+    # the column existed (the CREATE above only applies to fresh installs).
+    await _try_alter(db,
+        "ALTER TABLE job_health ADD COLUMN error_type TEXT",
+        "job_health.error_type")
 
     # Dashboard Phase 4: manual error resolution tracking
     # CREATE TABLE IF NOT EXISTS is inherently idempotent — no suppress needed

--- a/src/genesis/observability/failure_details.py
+++ b/src/genesis/observability/failure_details.py
@@ -1,0 +1,88 @@
+"""Structured failure payloads for ERROR-severity events.
+
+Before this module, ``util/tasks.py`` was the ONLY emitter in the codebase that
+attached ``error_type`` to a failure event. Every other failure event type
+(~25 of them) emitted a bare message, so a recurring failure recorded nothing a
+diagnosis could act on. Worst observed case, live for months::
+
+    event:   scheduler.job_failed
+    details: {"job_id": "memory_extraction"}
+    message: "Scheduled job 'memory_extraction' failed: "   # str(exc) was empty
+
+An empty ``str(exc)`` is exactly when the exception TYPE carries all the signal,
+and that was the one field being dropped.
+
+The structural discriminator
+----------------------------
+``error_type`` is present **if and only if** a real Python exception caused the
+failure. A failure reported as a semantic *result* — an external blocker such as
+an HTTP 429 quota response surfaced through a job result's ``reason`` — carries
+``error_reason`` and **no** ``error_type``.
+
+This distinction is structural on purpose. The same event type can carry either
+kind: ``weekly_assessment.failed`` is emitted both for a genuine ``TypeError``
+in Genesis code (``reflection/scheduler.py`` exception path) and for a provider
+quota block (its ``result.reason`` path). Downstream consumers must therefore
+never infer internal-vs-external by pattern-matching the message — they read the
+presence of ``error_type`` instead.
+
+Frames come from :func:`genesis.util.tasks.normalized_frames`, the single
+identity basis for failure fingerprints. Do not add a second normalizer here or
+anywhere else: two normalizers render one bug two ways and split a single
+recurring failure into two fingerprints.
+"""
+
+from __future__ import annotations
+
+from genesis.util.tasks import normalized_frames
+
+# Mirrors the reflex arc's own cap on stored message length so a payload can
+# never balloon an events row on a pathological exception string.
+_MAX_ERROR_CHARS = 500
+
+
+def failure_details(
+    *,
+    exc: BaseException | None = None,
+    reason: str | None = None,
+) -> dict[str, object]:
+    """Build the ``details`` payload for a failure event.
+
+    Parameters
+    ----------
+    exc:
+        The exception that caused the failure, when one exists. Takes
+        precedence over *reason* — an exception is always the stronger signal.
+    reason:
+        A semantic failure reason with no exception behind it (e.g. a job
+        result's ``reason`` field). Emitted as ``error_reason``.
+
+    Returns
+    -------
+    dict
+        ``{"error_type", "error", "error_frames"}`` for the exception path,
+        ``{"error_reason"}`` for the semantic path, or ``{}`` when neither is
+        supplied (callers must stay emittable — a missing payload degrades the
+        event, it never breaks it).
+    """
+    if exc is not None:
+        return {
+            "error_type": type(exc).__name__,
+            "error": str(exc)[:_MAX_ERROR_CHARS],
+            "error_frames": normalized_frames(exc),
+        }
+    if reason:
+        return {"error_reason": str(reason)[:_MAX_ERROR_CHARS]}
+    return {}
+
+
+def error_summary(exc: BaseException | None, fallback: str | None = None) -> str | None:
+    """Render a failure for a single text column (e.g. ``job_health.last_error``).
+
+    Prefixes the exception type so a blank ``str(exc)`` still records something
+    diagnosable: ``"TypeError: "`` beats ``""``. Falls back to *fallback* when
+    there is no exception.
+    """
+    if exc is not None:
+        return f"{type(exc).__name__}: {exc}"[:_MAX_ERROR_CHARS]
+    return fallback[:_MAX_ERROR_CHARS] if fallback else fallback

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -185,9 +185,13 @@ class OutreachScheduler:
         if error or exc is not None:
             from genesis.observability.failure_details import error_summary, failure_details
 
+            # One detail string for both sinks, so job_health.last_error and the
+            # event message agree — and so passing only *exc* (no *error*) can
+            # never render the message as "failed: None".
+            detail = error_summary(exc, error) or "unknown"
             rt.record_job_failure(
                 name,
-                error_summary(exc, error) or "unknown",
+                detail,
                 error_type=type(exc).__name__ if exc is not None else None,
             )
             if self._event_bus:
@@ -197,7 +201,7 @@ class OutreachScheduler:
                     Subsystem.OUTREACH,
                     Severity.ERROR,
                     f"{name}.failed",
-                    f"Scheduled job {name} failed: {error}",
+                    f"Scheduled job {name} failed: {detail}",
                     **failure_details(exc=exc, reason=None if exc is not None else error),
                 )
         else:

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -169,13 +169,27 @@ class OutreachScheduler:
             self._scheduler.shutdown(wait=False)
             self._scheduler = None
 
-    async def _record_job_result(self, name: str, *, error: str | None = None) -> None:
-        """Record success/failure in runtime + emit event."""
+    async def _record_job_result(
+        self, name: str, *, error: str | None = None, exc: BaseException | None = None
+    ) -> None:
+        """Record success/failure in runtime + emit event.
+
+        Pass *exc* whenever an exception caused the failure — it is what makes
+        the event diagnosable (``error_type`` + frames). A failure reported only
+        as a semantic *error* string carries no ``error_type``, which is how
+        consumers tell an internal defect from an external blocker.
+        """
         from genesis.runtime import GenesisRuntime
 
         rt = GenesisRuntime.instance()
-        if error:
-            rt.record_job_failure(name, error)
+        if error or exc is not None:
+            from genesis.observability.failure_details import error_summary, failure_details
+
+            rt.record_job_failure(
+                name,
+                error_summary(exc, error) or "unknown",
+                error_type=type(exc).__name__ if exc is not None else None,
+            )
             if self._event_bus:
                 from genesis.observability.types import Severity, Subsystem
 
@@ -184,6 +198,7 @@ class OutreachScheduler:
                     Severity.ERROR,
                     f"{name}.failed",
                     f"Scheduled job {name} failed: {error}",
+                    **failure_details(exc=exc, reason=None if exc is not None else error),
                 )
         else:
             rt.record_job_success(name)
@@ -243,7 +258,7 @@ class OutreachScheduler:
             await self._record_job_result("morning_report")
         except Exception as exc:
             logger.exception("Morning report job failed")
-            await self._record_job_result("morning_report", error=str(exc))
+            await self._record_job_result("morning_report", error=str(exc), exc=exc)
 
     async def _surplus_outreach_job(self) -> None:
         if self._is_paused():
@@ -277,7 +292,7 @@ class OutreachScheduler:
             await self._record_job_result("surplus_outreach")
         except Exception as exc:
             logger.exception("Surplus outreach job failed")
-            await self._record_job_result("surplus_outreach", error=str(exc))
+            await self._record_job_result("surplus_outreach", error=str(exc), exc=exc)
 
     async def _engagement_poll_job(self) -> None:
         if self._is_paused():
@@ -291,7 +306,7 @@ class OutreachScheduler:
             await self._record_job_result("engagement_poll")
         except Exception as exc:
             logger.exception("Engagement poll failed")
-            await self._record_job_result("engagement_poll", error=str(exc))
+            await self._record_job_result("engagement_poll", error=str(exc), exc=exc)
 
     async def _health_check_job(self) -> None:
         """Check health alerts and send outreach for critical issues.
@@ -383,7 +398,7 @@ class OutreachScheduler:
             await self._record_job_result("health_check")
         except Exception as exc:
             logger.exception("Health check outreach job failed")
-            await self._record_job_result("health_check", error=str(exc))
+            await self._record_job_result("health_check", error=str(exc), exc=exc)
 
     async def _critical_observations_job(self) -> None:
         """Alert user via Telegram when critical observations are created.
@@ -511,7 +526,7 @@ class OutreachScheduler:
             await self._record_job_result("critical_observations")
         except Exception as exc:
             logger.exception("Critical observations outreach job failed")
-            await self._record_job_result("critical_observations", error=str(exc))
+            await self._record_job_result("critical_observations", error=str(exc), exc=exc)
 
     async def _ambient_health_job(self) -> None:
         """Alert when the edge ambient-capture bridge goes dark or regresses.
@@ -597,7 +612,7 @@ class OutreachScheduler:
             await self._record_job_result("ambient_health")
         except Exception as exc:
             logger.exception("Ambient health monitor job failed")
-            await self._record_job_result("ambient_health", error=str(exc))
+            await self._record_job_result("ambient_health", error=str(exc), exc=exc)
 
     @staticmethod
     def _ambient_remedy_hint(causes: tuple[str, ...]) -> str:
@@ -639,7 +654,7 @@ class OutreachScheduler:
             await self._record_job_result("calibration")
         except Exception as exc:
             logger.exception("Calibration job failed")
-            await self._record_job_result("calibration", error=str(exc))
+            await self._record_job_result("calibration", error=str(exc), exc=exc)
 
     async def _mark_row_delivered(self, row: dict, delivered_at: str) -> None:
         """Mark a drained row delivered, keying on ``id`` or falling back to
@@ -785,7 +800,7 @@ class OutreachScheduler:
             await self._record_job_result("drain_pending")
         except Exception as exc:
             logger.exception("Drain pending outreach job failed")
-            await self._record_job_result("drain_pending", error=str(exc))
+            await self._record_job_result("drain_pending", error=str(exc), exc=exc)
 
     async def _pick_best_insight(self) -> dict | None:
         cursor = await self._db.execute(

--- a/src/genesis/reflection/scheduler.py
+++ b/src/genesis/reflection/scheduler.py
@@ -117,18 +117,35 @@ class ReflectionScheduler:
             self._scheduler = None
             logger.info("Reflection scheduler stopped")
 
-    async def _record_job_result(self, name: str, *, error: str | None = None) -> None:
+    async def _record_job_result(
+        self, name: str, *, error: str | None = None, exc: BaseException | None = None
+    ) -> None:
+        """Record a job outcome.
+
+        Pass *exc* whenever an exception caused the failure — it is what makes
+        the event diagnosable (``error_type`` + frames). A failure reported only
+        as a semantic *error* string (a job result's ``reason``, e.g. a provider
+        quota block) carries no ``error_type``, which is how consumers tell an
+        internal defect from an external blocker.
+        """
         from genesis.runtime import GenesisRuntime
 
         rt = GenesisRuntime.instance()
-        if error:
-            rt.record_job_failure(name, error)
+        if error or exc is not None:
+            from genesis.observability.failure_details import error_summary, failure_details
+
+            rt.record_job_failure(
+                name,
+                error_summary(exc, error) or "unknown",
+                error_type=type(exc).__name__ if exc is not None else None,
+            )
             if self._event_bus:
                 from genesis.observability.types import Severity, Subsystem
 
                 await self._event_bus.emit(
                     Subsystem.REFLECTION, Severity.ERROR,
                     f"{name}.failed", f"Scheduled job {name} failed: {error}",
+                    **failure_details(exc=exc, reason=None if exc is not None else error),
                 )
         else:
             rt.record_job_success(name)
@@ -164,7 +181,7 @@ class ReflectionScheduler:
                 await self._record_job_result("weekly_assessment", error=result.reason or "unknown")
         except Exception as exc:
             logger.exception("Weekly self-assessment error")
-            await self._record_job_result("weekly_assessment", error=str(exc))
+            await self._record_job_result("weekly_assessment", error=str(exc), exc=exc)
 
     async def _run_calibration(self) -> None:
         """Run quality calibration + regression check."""
@@ -202,7 +219,7 @@ class ReflectionScheduler:
                 await self._record_job_result("weekly_calibration", error=result.reason or "unknown")
         except Exception as exc:
             logger.exception("Quality calibration error")
-            await self._record_job_result("weekly_calibration", error=str(exc))
+            await self._record_job_result("weekly_calibration", error=str(exc), exc=exc)
 
     async def _already_ran_this_week(self, *obs_types: str) -> bool:
         """Check if an observation of any of these types exists from this week.

--- a/src/genesis/reflection/scheduler.py
+++ b/src/genesis/reflection/scheduler.py
@@ -134,9 +134,13 @@ class ReflectionScheduler:
         if error or exc is not None:
             from genesis.observability.failure_details import error_summary, failure_details
 
+            # One detail string for both sinks, so job_health.last_error and the
+            # event message agree — and so passing only *exc* (no *error*) can
+            # never render the message as "failed: None".
+            detail = error_summary(exc, error) or "unknown"
             rt.record_job_failure(
                 name,
-                error_summary(exc, error) or "unknown",
+                detail,
                 error_type=type(exc).__name__ if exc is not None else None,
             )
             if self._event_bus:
@@ -144,7 +148,7 @@ class ReflectionScheduler:
 
                 await self._event_bus.emit(
                     Subsystem.REFLECTION, Severity.ERROR,
-                    f"{name}.failed", f"Scheduled job {name} failed: {error}",
+                    f"{name}.failed", f"Scheduled job {name} failed: {detail}",
                     **failure_details(exc=exc, reason=None if exc is not None else error),
                 )
         else:

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -303,8 +303,10 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
     def record_job_success(self, job_name: str) -> None:
         record_job_success(self, job_name)
 
-    def record_job_failure(self, job_name: str, error: str) -> None:
-        record_job_failure(self, job_name, error)
+    def record_job_failure(
+        self, job_name: str, error: str, *, error_type: str | None = None
+    ) -> None:
+        record_job_failure(self, job_name, error, error_type=error_type)
 
     async def _load_persisted_job_health(self) -> None:
         # Thin wrapper: preserves the class-level patch surface for tests

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -119,6 +119,11 @@ async def load_persisted_job_health(rt: GenesisRuntime) -> None:
         import aiosqlite
 
         async with rt._db.execute(
+            # error_type is deliberately NOT selected: it is only read by the
+            # persist path, which re-supplies it on every write (set on failure,
+            # popped on success/clear), so nothing goes stale by omitting it —
+            # and selecting a column added by a later migration would fail this
+            # whole load, not just one field.
             "SELECT job_name, last_run, last_success, last_failure, "
             "last_error, consecutive_failures FROM job_health"
         ) as cur:
@@ -169,6 +174,7 @@ def clear_stale_job_failures(rt: GenesisRuntime) -> int:
         entry["consecutive_failures"] = 0
         entry.pop("last_failure", None)
         entry.pop("last_error", None)
+        entry.pop("error_type", None)
         persist_job_health(rt, job_name, entry, now_iso)
         cleared += 1
 
@@ -199,9 +205,9 @@ def persist_job_health(rt: GenesisRuntime, job_name: str, entry: dict, now: str)
             await rt._db.execute(
                 """INSERT INTO job_health
                    (job_name, last_run, last_success, last_failure, last_error,
-                    consecutive_failures, total_runs, total_successes,
+                    error_type, consecutive_failures, total_runs, total_successes,
                     total_failures, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
                    ON CONFLICT(job_name) DO UPDATE SET
                        last_run = excluded.last_run,
                        last_success = COALESCE(excluded.last_success, last_success),
@@ -210,6 +216,9 @@ def persist_job_health(rt: GenesisRuntime, job_name: str, entry: dict, now: str)
                        -- recovery; the failure path always supplies both (WS-3b).
                        last_failure = excluded.last_failure,
                        last_error = excluded.last_error,
+                       -- Same clear-on-recovery contract as last_error: a stale
+                       -- error_type would mislabel a recovered job.
+                       error_type = excluded.error_type,
                        consecutive_failures = excluded.consecutive_failures,
                        total_runs = total_runs + 1,
                        total_successes = total_successes + CASE WHEN excluded.last_success IS NOT NULL THEN 1 ELSE 0 END,
@@ -222,6 +231,7 @@ def persist_job_health(rt: GenesisRuntime, job_name: str, entry: dict, now: str)
                     snapshot.get("last_success"),
                     snapshot.get("last_failure"),
                     snapshot.get("last_error"),
+                    snapshot.get("error_type"),
                     snapshot.get("consecutive_failures", 0),
                     1 if snapshot.get("last_success") else 0,
                     1 if snapshot.get("last_failure") else 0,
@@ -312,6 +322,7 @@ def record_job_success(rt: GenesisRuntime, job_name: str) -> None:
     # failures in the SQL CASE WHEN excluded.last_failure IS NOT NULL check.
     entry.pop("last_failure", None)
     entry.pop("last_error", None)
+    entry.pop("error_type", None)
     rt._persist_job_health(job_name, entry, now)
 
     # WS-2 M9: debounced success run-event — first success ever, or >= 1h since
@@ -331,11 +342,19 @@ def record_job_success(rt: GenesisRuntime, job_name: str) -> None:
         )
 
 
-def record_job_failure(rt: GenesisRuntime, job_name: str, error: str) -> None:
+def record_job_failure(
+    rt: GenesisRuntime, job_name: str, error: str, *, error_type: str | None = None
+) -> None:
     """Record a failed scheduled job execution (in-memory + DB).
 
     When consecutive failures reach the retry threshold (3), triggers
     an automatic retry via the JobRetryRegistry if one is wired.
+
+    *error_type* is the exception class name when an exception caused the
+    failure, else ``None`` (a semantic failure — e.g. an external quota block
+    surfaced as a result reason). Keyword-only and optional so the ~110 existing
+    call sites keep working untouched; only callers that actually hold the
+    exception need to pass it.
     """
     now = datetime.now(UTC).isoformat()
     entry = rt._job_health.setdefault(job_name, {"consecutive_failures": 0})
@@ -345,6 +364,10 @@ def record_job_failure(rt: GenesisRuntime, job_name: str, error: str) -> None:
     entry["last_run"] = now
     entry["last_failure"] = now
     entry["last_error"] = error
+    # Always assign (even None) so a semantic failure overwrites a previous
+    # exception's type instead of inheriting it — a stale error_type would
+    # mislabel an external blocker as an internal defect.
+    entry["error_type"] = error_type
     entry["consecutive_failures"] = prev_consecutive + 1
     rt._persist_job_health(job_name, entry, now)
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -14,6 +14,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from genesis.env import user_timezone
 from genesis.observability.events import GenesisEventBus
+from genesis.observability.failure_details import error_summary, failure_details
 from genesis.observability.types import Severity, Subsystem
 from genesis.surplus import dispatch as dispatch_engine
 from genesis.surplus.brainstorm import BrainstormRunner
@@ -602,8 +603,6 @@ class SurplusScheduler:
         # exception TYPE — APScheduler exceptions here routinely render as an
         # empty str(), which is exactly when the type carries all the signal
         # (live: last_error was recorded as "" for months).
-        from genesis.observability.failure_details import error_summary, failure_details
-
         try:
             from genesis.runtime import GenesisRuntime
             rt = GenesisRuntime.instance()

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -589,8 +589,16 @@ class SurplusScheduler:
         """Emit observability event for a failed or missed scheduled job."""
         exception = getattr(event, "exception", None)
         is_error = exception is not None
+        # error_summary prefixes the exception TYPE — APScheduler exceptions here
+        # routinely render as an empty str(), which is exactly when the type
+        # carries all the signal (live: last_error was recorded as "" for
+        # months). Build the message from the SAME summary that goes to
+        # job_health so the message-only surfaces — health_errors output and the
+        # grouped-error UI, which key on the event MESSAGE not its details —
+        # are diagnosable too, not just the job_health row.
+        detail = error_summary(exception, "missed") or "missed"
         msg = (
-            f"Scheduled job '{job_id}' failed: {exception}"
+            f"Scheduled job '{job_id}' failed: {detail}"
             if is_error
             else f"Scheduled job '{job_id}' missed (past misfire grace time)"
         )
@@ -599,16 +607,13 @@ class SurplusScheduler:
         else:
             logger.warning(msg)
 
-        # Record failure in job health tracking. error_summary prefixes the
-        # exception TYPE — APScheduler exceptions here routinely render as an
-        # empty str(), which is exactly when the type carries all the signal
-        # (live: last_error was recorded as "" for months).
+        # Record failure in job health tracking.
         try:
             from genesis.runtime import GenesisRuntime
             rt = GenesisRuntime.instance()
             rt.record_job_failure(
                 job_id,
-                error_summary(exception, "missed") or "missed",
+                detail,
                 error_type=type(exception).__name__ if exception is not None else None,
             )
         except Exception:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -598,11 +598,20 @@ class SurplusScheduler:
         else:
             logger.warning(msg)
 
-        # Record failure in job health tracking
+        # Record failure in job health tracking. error_summary prefixes the
+        # exception TYPE — APScheduler exceptions here routinely render as an
+        # empty str(), which is exactly when the type carries all the signal
+        # (live: last_error was recorded as "" for months).
+        from genesis.observability.failure_details import error_summary, failure_details
+
         try:
             from genesis.runtime import GenesisRuntime
             rt = GenesisRuntime.instance()
-            rt.record_job_failure(job_id, str(exception or "missed")[:500])
+            rt.record_job_failure(
+                job_id,
+                error_summary(exception, "missed") or "missed",
+                error_type=type(exception).__name__ if exception is not None else None,
+            )
         except Exception:
             logger.warning("Failed to record job failure for %s", job_id, exc_info=True)
 
@@ -617,6 +626,7 @@ class SurplusScheduler:
                     "scheduler.job_failed" if is_error else "scheduler.job_missed",
                     msg,
                     job_id=job_id,
+                    **failure_details(exc=exception),
                 )
         except Exception:
             logger.warning("Failed to emit scheduler error event", exc_info=True)

--- a/src/genesis/util/tasks.py
+++ b/src/genesis/util/tasks.py
@@ -41,8 +41,14 @@ def set_default_event_bus(bus: GenesisEventBus | None) -> None:
     _default_event_bus = bus
 
 
-def _normalized_frames(exc: BaseException) -> list[str]:
+def normalized_frames(exc: BaseException) -> list[str]:
     """Render the traceback tail as stable ``relpath:funcname`` strings.
+
+    Public because it is the single identity basis for failure fingerprints.
+    Every failure emitter must use THIS function (see
+    ``genesis.observability.failure_details``) — a second normalizer would
+    render the same bug two different ways and split one signal into two
+    fingerprints.
 
     - keeps only frames inside the genesis package (``/genesis/`` path
       segment — package-relative, so it works on any install/CI checkout);
@@ -139,7 +145,7 @@ def _make_done_callback(
                 task_name=task_name,
                 error=str(exc),
                 error_type=type(exc).__name__,
-                error_frames=_normalized_frames(exc),
+                error_frames=normalized_frames(exc),
             )
 
     return _on_done

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -143,12 +143,12 @@ _JOB_HEALTH_DDL = """
         last_success     TEXT,
         last_failure     TEXT,
         last_error       TEXT,
-        error_type       TEXT,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         total_runs       INTEGER NOT NULL DEFAULT 0,
         total_successes  INTEGER NOT NULL DEFAULT 0,
         total_failures   INTEGER NOT NULL DEFAULT 0,
-        updated_at       TEXT NOT NULL
+        updated_at       TEXT NOT NULL,
+        error_type       TEXT
     )
 """
 

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -143,6 +143,7 @@ _JOB_HEALTH_DDL = """
         last_success     TEXT,
         last_failure     TEXT,
         last_error       TEXT,
+        error_type       TEXT,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         total_runs       INTEGER NOT NULL DEFAULT 0,
         total_successes  INTEGER NOT NULL DEFAULT 0,

--- a/tests/test_db/test_migration_0072_job_health_error_type.py
+++ b/tests/test_db/test_migration_0072_job_health_error_type.py
@@ -1,0 +1,106 @@
+"""Migration 0072 — add ``job_health.error_type``.
+
+Covers the legacy upgrade, idempotency, the double-application path
+(``create_all_tables`` then the numbered runner), the no-table no-op, ``down``,
+and — the reason this column is declared last — fresh/migrated column-ORDER
+parity, so a positional reader can never disagree between a fresh clone and an
+upgraded install.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M72 = importlib.import_module("genesis.db.migrations.0072_job_health_error_type")
+
+# job_health as it existed BEFORE this column (pre-0072 installs).
+_LEGACY_DDL = """
+    CREATE TABLE job_health (
+        job_name         TEXT PRIMARY KEY,
+        last_run         TEXT,
+        last_success     TEXT,
+        last_failure     TEXT,
+        last_error       TEXT,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        total_runs       INTEGER NOT NULL DEFAULT 0,
+        total_successes  INTEGER NOT NULL DEFAULT 0,
+        total_failures   INTEGER NOT NULL DEFAULT 0,
+        updated_at       TEXT NOT NULL
+    )
+"""
+
+
+async def _cols(db: aiosqlite.Connection) -> list[str]:
+    cur = await db.execute("PRAGMA table_info(job_health)")
+    return [row[1] for row in await cur.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_up_adds_column_to_legacy_db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        assert "error_type" not in await _cols(db)
+        await M72.up(db)
+        assert "error_type" in await _cols(db)
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        await M72.up(db)
+        await M72.up(db)  # second run must not raise
+        assert (await _cols(db)).count("error_type") == 1
+
+
+@pytest.mark.asyncio
+async def test_double_path_after_create_all_tables(tmp_path):
+    """create_all_tables already adds the column; the runner must then no-op."""
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await create_all_tables(db)
+        assert "error_type" in await _cols(db)
+        await M72.up(db)  # must not raise "duplicate column"
+        assert (await _cols(db)).count("error_type") == 1
+
+
+@pytest.mark.asyncio
+async def test_up_no_ops_when_table_absent(tmp_path):
+    """A DB with no job_health table yet must not raise (fresh-install ordering)."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M72.up(db)  # no-op, no raise
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='job_health'"
+        )
+        assert await cur.fetchone() is None
+
+
+@pytest.mark.asyncio
+async def test_fresh_and_migrated_column_order_identical(tmp_path):
+    """error_type is declared LAST precisely so both paths agree byte-for-byte —
+    ALTER appends, so a mid-table CREATE would diverge from an upgraded DB."""
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(str(tmp_path / "fresh.db")) as db:
+        await create_all_tables(db)
+        fresh = await _cols(db)
+    async with aiosqlite.connect(str(tmp_path / "migrated.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        await M72.up(db)
+        migrated = await _cols(db)
+
+    assert fresh == migrated
+    assert fresh[-1] == "error_type"
+
+
+@pytest.mark.asyncio
+async def test_down_removes_column(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        await M72.up(db)
+        await M72.down(db)
+        assert "error_type" not in await _cols(db)

--- a/tests/test_db/test_migration_runner_db_path.py
+++ b/tests/test_db/test_migration_runner_db_path.py
@@ -1,0 +1,36 @@
+"""The migration CLI must honour GENESIS_DB_PATH.
+
+Without this, `GENESIS_DB_PATH=~/tmp/copy.db python -m genesis.db.migrations
+--apply` — the obvious way to test a migration against a copy — silently
+rewrites the PRODUCTION database instead (it happened, 2026-07-23). The fallback
+must stay HOME-anchored, not repo_root()/data, so a run from a worktree checkout
+still targets the real production DB (feedback_hook_prod_db_home_anchored).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from genesis.db.migrations.__main__ import _resolve_db_path
+
+
+class TestResolveDbPath:
+    def test_env_override_wins(self, monkeypatch, tmp_path):
+        target = tmp_path / "copy.db"
+        monkeypatch.setenv("GENESIS_DB_PATH", str(target))
+        assert _resolve_db_path() == target
+
+    def test_env_override_expands_user(self, monkeypatch):
+        monkeypatch.setenv("GENESIS_DB_PATH", "~/tmp/copy.db")
+        assert _resolve_db_path() == Path.home() / "tmp" / "copy.db"
+
+    def test_fallback_is_home_anchored(self, monkeypatch):
+        """Not repo_root()/data — a worktree run must still hit the real DB."""
+        monkeypatch.delenv("GENESIS_DB_PATH", raising=False)
+        assert _resolve_db_path() == Path.home() / "genesis" / "data" / "genesis.db"
+
+    def test_fallback_ignores_cwd(self, monkeypatch, tmp_path):
+        """CWD (e.g. a worktree) must not change the resolved production path."""
+        monkeypatch.delenv("GENESIS_DB_PATH", raising=False)
+        monkeypatch.chdir(tmp_path)
+        assert _resolve_db_path() == Path.home() / "genesis" / "data" / "genesis.db"

--- a/tests/test_observability/test_failure_details.py
+++ b/tests/test_observability/test_failure_details.py
@@ -1,0 +1,111 @@
+"""Failure-payload contract: the structural internal-vs-external discriminator.
+
+The load-bearing invariant here is that ``error_type`` is present IFF a real
+exception caused the failure. Downstream classification reads that presence
+instead of pattern-matching the message — necessary because one event type
+(``weekly_assessment.failed``) is emitted for BOTH a genuine TypeError in
+Genesis code and a provider quota block.
+"""
+
+from __future__ import annotations
+
+from genesis.observability.failure_details import error_summary, failure_details
+from genesis.util.tasks import normalized_frames
+
+
+def _raise_type_error() -> BaseException:
+    """Return a TypeError carrying a real traceback (mirrors the live defect:
+    ``float() argument must be a string or a real number, not 'NoneType'``)."""
+    try:
+        float(None)  # type: ignore[arg-type]
+    except TypeError as exc:
+        return exc
+    raise AssertionError("expected TypeError")
+
+
+class TestStructuralDiscriminator:
+    def test_exception_path_carries_type_and_frames(self):
+        exc = _raise_type_error()
+        details = failure_details(exc=exc)
+
+        assert details["error_type"] == "TypeError"
+        assert "float()" in str(details["error"])
+        assert details["error_frames"], "an exception with a traceback must yield frames"
+        assert "error_reason" not in details
+
+    def test_semantic_path_carries_no_error_type(self):
+        """An external blocker reported as a result reason must NOT look like an
+        exception — this is the whole discriminator."""
+        details = failure_details(reason='{"api_error_status":429,"result":"weekly limit"}')
+
+        assert "error_type" not in details
+        assert "error_frames" not in details
+        assert "429" in str(details["error_reason"])
+
+    def test_exception_wins_over_reason(self):
+        exc = _raise_type_error()
+        details = failure_details(exc=exc, reason="some reason")
+
+        assert details["error_type"] == "TypeError"
+        assert "error_reason" not in details
+
+    def test_neither_yields_empty_payload(self):
+        """Callers must stay emittable — a missing payload degrades the event,
+        it never breaks it."""
+        assert failure_details() == {}
+        assert failure_details(reason="") == {}
+
+    def test_empty_exception_string_still_diagnosable(self):
+        """The live scheduler.job_failed bug: str(exc) was empty, so the TYPE was
+        the only signal — and it was the field being dropped."""
+        details = failure_details(exc=ValueError())
+
+        assert details["error_type"] == "ValueError"
+        assert details["error"] == ""
+
+    def test_long_error_is_truncated(self):
+        details = failure_details(exc=RuntimeError("x" * 5000))
+        assert len(str(details["error"])) == 500
+
+    def test_long_reason_is_truncated(self):
+        details = failure_details(reason="y" * 5000)
+        assert len(str(details["error_reason"])) == 500
+
+
+class TestSingleIdentityBasis:
+    """A second traceback normalizer would render one bug two ways and split a
+    recurring failure into two fingerprints. Guard that there is exactly one."""
+
+    def test_frames_match_the_canonical_normalizer(self):
+        exc = _raise_type_error()
+        assert failure_details(exc=exc)["error_frames"] == normalized_frames(exc)
+
+    def test_same_exception_fingerprints_identically_from_any_emitter(self):
+        """Two emitters reporting the same failure must produce one fingerprint."""
+        from genesis.reflex.fingerprint import fingerprint
+
+        exc = _raise_type_error()
+        details = failure_details(exc=exc)
+
+        from_emitter_a = fingerprint(
+            "weekly_assessment", str(details["error_type"]), details["error_frames"]
+        )
+        from_emitter_b = fingerprint(
+            "weekly_assessment", type(exc).__name__, normalized_frames(exc)
+        )
+        assert from_emitter_a == from_emitter_b
+
+
+class TestErrorSummary:
+    def test_prefixes_exception_type(self):
+        """job_health.last_error is a single column — the type must survive into
+        it, or a blank str(exc) records nothing (observed live for months)."""
+        assert error_summary(ValueError()) == "ValueError: "
+        assert error_summary(_raise_type_error()).startswith("TypeError: ")
+
+    def test_falls_back_when_no_exception(self):
+        assert error_summary(None, "missed") == "missed"
+        assert error_summary(None, None) is None
+
+    def test_truncates(self):
+        assert len(error_summary(RuntimeError("z" * 5000))) == 500

--- a/tests/test_reflection/test_scheduler_failure_payloads.py
+++ b/tests/test_reflection/test_scheduler_failure_payloads.py
@@ -118,6 +118,22 @@ class TestExceptionPath:
         assert call["error"].startswith("ValueError:"), "blank str(exc) must still be diagnosable"
 
 
+class TestMessageDetail:
+    @pytest.mark.asyncio
+    async def test_exc_only_never_renders_none(self, db, bus, _stub_runtime):
+        """Passing only *exc* (no *error*) must not render "failed: None" — the
+        message and job_health.last_error both come from one detail string."""
+        sched = _scheduler(db, bus, AsyncMock())
+        await sched._record_job_result("weekly_assessment", exc=TypeError("bad float"))
+
+        failures = bus.failures()
+        assert len(failures) == 1
+        assert "None" not in failures[0]["message"]
+        assert "TypeError: bad float" in failures[0]["message"]
+        # Both sinks agree.
+        assert _stub_runtime.calls[0]["error"] == "TypeError: bad float"
+
+
 class TestSemanticPath:
     @pytest.mark.asyncio
     async def test_quota_block_carries_no_error_type(self, db, bus, _stub_runtime):

--- a/tests/test_reflection/test_scheduler_failure_payloads.py
+++ b/tests/test_reflection/test_scheduler_failure_payloads.py
@@ -1,0 +1,170 @@
+"""Emitter-level proof that job failures carry a diagnosable payload.
+
+``tests/test_observability/test_failure_details.py`` covers the pure payload
+builder. This file covers the WIRING: that a real scheduler failure actually
+reaches the event bus with ``error_type`` + frames, and that a semantic failure
+does not — the distinction downstream classification depends on.
+
+``weekly_assessment.failed`` is the motivating case: live data shows it emitted
+for BOTH a genuine ``TypeError`` in Genesis code AND a provider 429 quota block,
+so the two must be distinguishable without parsing the message.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables, seed_data
+from genesis.perception.types import ReflectionResult
+from genesis.reflection.scheduler import ReflectionScheduler
+
+# A real provider quota response, shaped as observed live.
+_QUOTA_REASON = (
+    '{"type":"result","subtype":"success","is_error":true,'
+    '"api_error_status":429,"result":"You\'ve hit your weekly limit"}'
+)
+
+
+class _RecordingBus:
+    """Captures emitted events (the bus dispatches listeners inline)."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def emit(self, subsystem, severity, event_type, message, **details):
+        self.events.append(
+            {
+                "subsystem": subsystem,
+                "severity": severity,
+                "event_type": event_type,
+                "message": message,
+                "details": details,
+            }
+        )
+
+    def failures(self) -> list[dict]:
+        return [e for e in self.events if e["event_type"].endswith(".failed")]
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        await seed_data(conn)
+        yield conn
+
+
+@pytest.fixture
+def bus():
+    return _RecordingBus()
+
+
+def _scheduler(db, bus, bridge):
+    return ReflectionScheduler(bridge=bridge, stability_monitor=None, db=db, event_bus=bus)
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime(monkeypatch):
+    """record_job_failure reaches a real GenesisRuntime singleton; capture instead."""
+    calls: list[dict] = []
+    rt = MagicMock()
+    # MUST be explicitly False — a bare MagicMock attribute is truthy, and
+    # _run_assessment returns early when the runtime reports paused.
+    rt.paused = False
+    rt.record_job_failure = MagicMock(
+        side_effect=lambda name, error, error_type=None: calls.append(
+            {"name": name, "error": error, "error_type": error_type}
+        )
+    )
+    rt.record_job_success = MagicMock()
+
+    import genesis.runtime as runtime_mod
+
+    monkeypatch.setattr(runtime_mod.GenesisRuntime, "instance", classmethod(lambda cls: rt))
+    rt.calls = calls
+    return rt
+
+
+class TestExceptionPath:
+    @pytest.mark.asyncio
+    async def test_exception_failure_carries_type_and_frames(self, db, bus, _stub_runtime):
+        bridge = AsyncMock()
+        bridge.run_weekly_assessment = AsyncMock(
+            side_effect=TypeError("float() argument must be a string or a real number")
+        )
+        await _scheduler(db, bus, bridge)._run_assessment()
+
+        failures = bus.failures()
+        assert len(failures) == 1
+        details = failures[0]["details"]
+        assert failures[0]["event_type"] == "weekly_assessment.failed"
+        assert details["error_type"] == "TypeError"
+        assert details["error_frames"], "an internal defect must carry frames to diagnose"
+        assert "error_reason" not in details
+
+    @pytest.mark.asyncio
+    async def test_exception_type_reaches_job_health(self, db, bus, _stub_runtime):
+        """job_health.last_error recorded "" for months — the type must survive."""
+        bridge = AsyncMock()
+        bridge.run_weekly_assessment = AsyncMock(side_effect=ValueError())
+        await _scheduler(db, bus, bridge)._run_assessment()
+
+        call = _stub_runtime.calls[0]
+        assert call["error_type"] == "ValueError"
+        assert call["error"].startswith("ValueError:"), "blank str(exc) must still be diagnosable"
+
+
+class TestSemanticPath:
+    @pytest.mark.asyncio
+    async def test_quota_block_carries_no_error_type(self, db, bus, _stub_runtime):
+        """An external blocker must not look like an internal defect."""
+        bridge = AsyncMock()
+        bridge.run_weekly_assessment = AsyncMock(
+            return_value=ReflectionResult(success=False, reason=_QUOTA_REASON)
+        )
+        await _scheduler(db, bus, bridge)._run_assessment()
+
+        failures = bus.failures()
+        assert len(failures) == 1
+        details = failures[0]["details"]
+        assert "error_type" not in details
+        assert "error_frames" not in details
+        assert "429" in details["error_reason"]
+        assert _stub_runtime.calls[0]["error_type"] is None
+
+    @pytest.mark.asyncio
+    async def test_same_event_type_both_dispositions(self, db, bus, _stub_runtime):
+        """The core finding: one event_type carries both kinds, so an event-type
+        allowlist cannot classify them — only the payload can."""
+        bridge = AsyncMock()
+        bridge.run_weekly_assessment = AsyncMock(side_effect=TypeError("boom"))
+        await _scheduler(db, bus, bridge)._run_assessment()
+        bridge.run_weekly_assessment = AsyncMock(
+            return_value=ReflectionResult(success=False, reason=_QUOTA_REASON)
+        )
+        await _scheduler(db, bus, bridge)._run_assessment()
+
+        failures = bus.failures()
+        assert [f["event_type"] for f in failures] == [
+            "weekly_assessment.failed",
+            "weekly_assessment.failed",
+        ]
+        assert "error_type" in failures[0]["details"]
+        assert "error_type" not in failures[1]["details"]
+
+
+class TestSuccessPathUnaffected:
+    @pytest.mark.asyncio
+    async def test_success_emits_no_failure_event(self, db, bus, _stub_runtime):
+        bridge = AsyncMock()
+        bridge.run_weekly_assessment = AsyncMock(
+            return_value=ReflectionResult(success=True, reason="done")
+        )
+        await _scheduler(db, bus, bridge)._run_assessment()
+
+        assert bus.failures() == []
+        assert _stub_runtime.calls == []

--- a/tests/test_runtime/test_job_health.py
+++ b/tests/test_runtime/test_job_health.py
@@ -26,6 +26,7 @@ _CREATE_JOB_HEALTH = """
         last_success     TEXT,
         last_failure     TEXT,
         last_error       TEXT,
+        error_type       TEXT,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         total_runs       INTEGER NOT NULL DEFAULT 0,
         total_successes  INTEGER NOT NULL DEFAULT 0,

--- a/tests/test_runtime/test_job_health.py
+++ b/tests/test_runtime/test_job_health.py
@@ -26,12 +26,12 @@ _CREATE_JOB_HEALTH = """
         last_success     TEXT,
         last_failure     TEXT,
         last_error       TEXT,
-        error_type       TEXT,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         total_runs       INTEGER NOT NULL DEFAULT 0,
         total_successes  INTEGER NOT NULL DEFAULT 0,
         total_failures   INTEGER NOT NULL DEFAULT 0,
-        updated_at       TEXT NOT NULL
+        updated_at       TEXT NOT NULL,
+        error_type       TEXT
     )
 """
 

--- a/tests/test_runtime/test_job_run_events.py
+++ b/tests/test_runtime/test_job_run_events.py
@@ -24,6 +24,7 @@ _CREATE_JOB_HEALTH = """
         last_success     TEXT,
         last_failure     TEXT,
         last_error       TEXT,
+        error_type       TEXT,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         total_runs       INTEGER NOT NULL DEFAULT 0,
         total_successes  INTEGER NOT NULL DEFAULT 0,

--- a/tests/test_runtime/test_job_run_events.py
+++ b/tests/test_runtime/test_job_run_events.py
@@ -24,12 +24,12 @@ _CREATE_JOB_HEALTH = """
         last_success     TEXT,
         last_failure     TEXT,
         last_error       TEXT,
-        error_type       TEXT,
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         total_runs       INTEGER NOT NULL DEFAULT 0,
         total_successes  INTEGER NOT NULL DEFAULT 0,
         total_failures   INTEGER NOT NULL DEFAULT 0,
-        updated_at       TEXT NOT NULL
+        updated_at       TEXT NOT NULL,
+        error_type       TEXT
     )
 """
 _CREATE_JOB_RUN_EVENTS = """

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -513,6 +513,46 @@ async def test_alarm_db_integrity_writes_observation_and_emits(db):
     assert call.args[1] == Severity.ERROR
 
 
+class _FailedEvent:
+    """Stand-in for an APScheduler EVENT_JOB_ERROR with an empty-str exception —
+    the live case: the TYPE is the only signal and str(exception) is blank."""
+
+    def __init__(self, exc):
+        self.job_id = "memory_extraction"
+        self.exception = exc
+
+
+async def test_emit_job_error_event_message_carries_type(db):
+    """Codex P2 (#1225): the emitted event MESSAGE — not just job_health — must
+    carry the exception type, because health_errors output and the grouped-error
+    UI key on the message, not the details dict."""
+    from genesis.observability.types import Subsystem
+
+    sched, _ = _make_scheduler(db)
+    sched._event_bus = AsyncMock()
+
+    rt = AsyncMock()
+    rt.event_bus = sched._event_bus
+    captured: dict = {}
+    rt.record_job_failure = lambda job_id, detail, error_type=None: captured.update(
+        job_id=job_id, detail=detail, error_type=error_type
+    )
+
+    with patch("genesis.runtime.GenesisRuntime.instance", return_value=rt):
+        await sched._emit_job_error_event("memory_extraction", _FailedEvent(ValueError()))
+
+    # Event message is diagnosable even though str(ValueError()) is empty.
+    call = sched._event_bus.emit.await_args
+    assert call.args[0] == Subsystem.SURPLUS
+    message = call.args[3]
+    assert "ValueError" in message
+    assert not message.rstrip().endswith("failed:"), "message must not be a bare 'failed:'"
+    # details still carry the structured type, and both sinks agree.
+    assert call.kwargs["error_type"] == "ValueError"
+    assert captured["error_type"] == "ValueError"
+    assert captured["detail"] in message
+
+
 async def test_run_db_integrity_check_healthy_db_no_alarm(db):
     """On a healthy DB the weekly job completes and raises no alarm."""
     sched, _ = _make_scheduler(db)

--- a/tests/test_util/test_tasks.py
+++ b/tests/test_util/test_tasks.py
@@ -19,7 +19,7 @@ import asyncio
 import pytest
 
 from genesis.util.tasks import (
-    _normalized_frames,
+    normalized_frames,
     set_default_event_bus,
     tracked_task,
 )
@@ -70,11 +70,11 @@ def _raise_at(filename: str, funcname: str, exc_type: type[Exception] = KeyError
 class TestNormalizedFrames:
     def test_relpath_from_genesis_segment(self):
         exc = _raise_at("/install/src/genesis/memory/sync.py", "_apply_delta")
-        assert _normalized_frames(exc) == ["memory/sync.py:_apply_delta"]
+        assert normalized_frames(exc) == ["memory/sync.py:_apply_delta"]
 
     def test_no_line_numbers_anywhere(self):
         exc = _raise_at("/install/src/genesis/memory/sync.py", "_apply_delta")
-        for frame in _normalized_frames(exc):
+        for frame in normalized_frames(exc):
             assert frame.count(":") == 1  # exactly relpath:funcname, no :lineno
 
     def test_non_genesis_frames_dropped_when_genesis_present(self):
@@ -88,7 +88,7 @@ class TestNormalizedFrames:
         try:
             outer()
         except ValueError as exc:
-            frames = _normalized_frames(exc)
+            frames = normalized_frames(exc)
         # this test function's own frame (repo path, install-specific) may or
         # may not carry a /genesis/ segment; the synthetic genesis frame must
         # be the LAST (deepest) either way
@@ -96,7 +96,7 @@ class TestNormalizedFrames:
 
     def test_all_foreign_frames_kept_as_basenames(self):
         exc = _raise_at("/usr/lib/python3.12/threading.py", "run")
-        assert _normalized_frames(exc) == ["threading.py:run"]
+        assert normalized_frames(exc) == ["threading.py:run"]
 
     def test_last_three_only(self):
         src = (
@@ -110,7 +110,7 @@ class TestNormalizedFrames:
         try:
             ns["f4"]()
         except KeyError as exc:
-            frames = _normalized_frames(exc)
+            frames = normalized_frames(exc)
         # call chain f4→f3→f2→f1 = 4 genesis frames; keep the DEEPEST three
         assert frames == [
             "ego/session.py:f3",
@@ -119,7 +119,7 @@ class TestNormalizedFrames:
         ]
 
     def test_no_traceback_yields_empty(self):
-        assert _normalized_frames(KeyError("bare")) == []
+        assert normalized_frames(KeyError("bare")) == []
 
 
 async def _fail(exc: Exception):


### PR DESCRIPTION
## What & why

Until now `util/tasks.py` was the **only** emitter in the codebase that attached `error_type` to a failure event. Every other failure event type (~25 of them) emitted a bare message, so a recurring failure recorded nothing a diagnosis could act on. Worst case, live for months:

```
event:   scheduler.job_failed
details: {"job_id": "memory_extraction"}
message: "Scheduled job 'memory_extraction' failed: "   # str(exc) was empty
```

An empty `str(exc)` is exactly when the exception **type** carries all the signal — and that was the field being dropped, into both the event and `job_health.last_error`.

## The design

New `observability/failure_details.py` builds the payload once, with a **structural discriminator**: `error_type` is present **iff** a real exception caused the failure. A failure reported as a semantic result reason (an external blocker — e.g. an HTTP 429 quota response) carries `error_reason` and no `error_type`.

This matters because **one event type carries both kinds**: `weekly_assessment.failed` is emitted for a genuine `TypeError` in Genesis code *and* for a provider quota block. Consumers must read the presence of `error_type`, not pattern-match the message — which is why an event-type allowlist can't classify these. Frames come only from `util/tasks.normalized_frames` (promoted from private); a second normalizer would split one bug into two fingerprints, and a test pins that parity.

This is the prerequisite for the reflex arc's widened intake: an event with no `error_type` is undiagnosable, so a diagnose session handed one cannot succeed.

## Changes

- **`observability/failure_details.py`** — the shared payload builder + `error_summary` for single-column sinks
- **three schedulers** (reflection, outreach, surplus) thread the exception through; one detail string feeds both the event and `job_health` so they agree
- **`record_job_failure`** gains an optional keyword-only `error_type` — all ~111 existing call sites keep working untouched
- **migration 0072** adds `job_health.error_type` (additive, idempotent; declared last so fresh and upgraded installs get a byte-identical schema)
- **migration CLI** now honours `GENESIS_DB_PATH` — it hardcoded the prod path and ignored the override, so the obvious `GENESIS_DB_PATH=~/tmp/copy.db … --apply` silently rewrote production. Fallback stays home-anchored (worktree-safe).

## Verification

- 613 tests pass across the touched surface; new tests cover the discriminator, emitter wiring, the "one detail string" trap, fingerprint parity, migration on all four paths (fresh / legacy / double / no-table), fresh-vs-migrated column-order parity, and the CLI path resolution
- migration proven E2E against a DB copy
- subsystem map (+ stamp) and CHANGELOG updated

## Scope note

This fixes the 3 scheduler emitters. The remaining ~22 blind emitters are tracked as a follow-up (the shared helper + pattern are in place, so each is a small mechanical change).

Ledger: 3da40ff1b6384bdbb4299f36bdf435aa

🤖 Generated with [Claude Code](https://claude.com/claude-code)