### PR TITLE
feat(reflex): funnel background-job exceptions onto the bus (PR-2a, dark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **When a background job fails, Genesis now records what actually broke.** The
+  scheduled jobs that quietly keep Genesis healthy — pruning, sweeps, harvests,
+  reconnaissance — used to log a failure with the details thrown away, leaving a
+  blank error behind. They now capture the real exception type and a compact
+  traceback, so a recurring internal bug becomes diagnosable instead of
+  invisible. The same failures are now surfaced onto Genesis's internal event
+  stream, laying the groundwork for it to detect and eventually help fix its own
+  bugs — kept deliberately dormant for now (it observes, it does not act).
 - **An interrupted request no longer vanishes silently.** If a message you sent
   on Telegram was cut off before Genesis finished answering — a crash, a
   restart, or the session going dark mid-turn — Genesis now notices the

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -538,7 +538,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 483469d7 2026-07-23
+verified: 302066ad 2026-07-23
 ```
 
 - **PR-watch inline surface (2026-07-21)**: a SessionStart hook
@@ -625,7 +625,18 @@ verified: 483469d7 2026-07-23
   quota block). `job_health.error_type` mirrors it and clears on recovery
   alongside `last_error`. Frames come only from
   `util/tasks.normalized_frames` — a second normalizer would split one bug
-  into two fingerprints.
+  into two fingerprints. **The funnel (2026-07-23):** `record_job_failure`
+  gained an `exc=` param and, when an exception caused the failure, ALSO emits
+  a throttled `job.failed` event (via `util/tasks.emit_sync`, sharing the
+  run-event throttle -> ~24/day/job). This bridges the ~50 background-job loops
+  that wrote only to `job_health` onto the event bus, where the reflex arc (a
+  bus subscriber) can reach the largest class of internal defects - previously
+  invisible. Semantic/no-exception failures stay off the bus; callers that emit
+  their own domain `.failed` pass `emit_event=False` to avoid double-counting.
+  Fire-and-forget (a broken emit never blocks the `job_health` write), and
+  `job.failed` is in the ego's `_REFLEX_OWNED_EVENT_TYPES` so it never spins a
+  reactive ego cycle. Dark until reflex intake widens (`ingest.py` still drops
+  non-`task.failed`).
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
   reflection bridge. GROUNDWORK: user-model-synthesis, pre-execution-gate
@@ -1183,7 +1194,7 @@ Spec: `docs/superpowers/specs/2026-07-21-reflex-arc-design.md`.
 ```yaml subsystem-map
 entry: reflex-arc
 modules: [reflex]
-verified: 6fd98675 2026-07-21
+verified: 302066ad 2026-07-23
 ```
 
 - **reflex/**: `fingerprint.py` (pure: normalize task name, line-number-free
@@ -1200,10 +1211,19 @@ verified: 6fd98675 2026-07-21
   `reflex_diagnoses`; `reflex_verdicts` = the taste corpus, never pruned).
   Later-phase columns/statuses ship now so the lifecycle CHECK never needs a
   rebuild migration.
-- **Trap**: `task.failed` is carved out of the ego reactive path
-  (`runtime/init/ego._is_reflex_owned_event`) — reflex owns that class; the
-  ego's message-keyed dedup can't absorb variable-payload failure bursts
-  (a documented storm mode in `ego/cadence.py`).
+- **Afferent sources**: `task.failed` (from `tracked_task`) is the original
+  nerve, but it is a near-empty channel — Genesis's background loops catch their
+  own exceptions and never reach the `tracked_task` done-callback (0 events in
+  108d, verified two installs). The **funnel (2026-07-23)** adds the real
+  stream: `runtime/_job_health.record_job_failure` emits a throttled
+  `job.failed` for every exception-driven background-job failure (see the
+  scheduled-job telemetry entry). Emitted now but NOT yet ingested —
+  `ingest.py` still drops non-`task.failed`; widening intake to `job.failed` is
+  the gated PR-2b.
+- **Trap**: BOTH `task.failed` and `job.failed` are carved out of the ego
+  reactive path (`runtime/init/ego._is_reflex_owned_event`) — reflex owns that
+  class; the ego's message-keyed dedup can't absorb variable-payload failure
+  bursts (a documented storm mode in `ego/cadence.py`).
 - **Observability (PR1.5)**: aggregates on `db/crud/reflex_signals`
   (`count_by_status` / `top_class_keys` / `list_recent`) feed four surfaces —
   the `reflex_status` MCP tool (process-portable: config + DB only), the

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1927,7 +1927,7 @@ class AwarenessLoop:
                     )
                 try:
                     from genesis.runtime import GenesisRuntime
-                    GenesisRuntime.instance().record_job_failure("awareness_tick", str(exc))
+                    GenesisRuntime.instance().record_job_failure("awareness_tick", exc=exc)
                 except Exception:
                     pass
                 # Even on unexpected failure, don't leave _last_tick_at stale

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -33,6 +33,7 @@ from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 from genesis.db.crud import awareness_ticks, observations
 from genesis.infra_profile.store import load_profile
 from genesis.observability.events import GenesisEventBus
+from genesis.observability.failure_details import failure_details
 from genesis.observability.types import Severity, Subsystem
 from genesis.resilience.state import CloudStatus
 from genesis.routing.types import DegradationLevel
@@ -1924,10 +1925,11 @@ class AwarenessLoop:
                         Subsystem.AWARENESS, Severity.ERROR,
                         "tick.failed",
                         "Awareness tick failed with exception",
+                        **failure_details(exc=exc),
                     )
                 try:
                     from genesis.runtime import GenesisRuntime
-                    GenesisRuntime.instance().record_job_failure("awareness_tick", exc=exc)
+                    GenesisRuntime.instance().record_job_failure("awareness_tick", exc=exc, emit_event=False)
                 except Exception:
                     pass
                 # Even on unexpected failure, don't leave _last_tick_at stale

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -142,7 +142,7 @@ class CampaignRunner:
         except Exception as exc:
             logger.exception("Campaign tick failed for %s", campaign_id)
             with contextlib.suppress(Exception):
-                GenesisRuntime.instance().record_job_failure(job_id, str(exc)[:500])
+                GenesisRuntime.instance().record_job_failure(job_id, exc=exc)
             return
         with contextlib.suppress(Exception):
             GenesisRuntime.instance().record_job_success(job_id)

--- a/src/genesis/cc/rate_limit_resume.py
+++ b/src/genesis/cc/rate_limit_resume.py
@@ -184,5 +184,5 @@ async def run_resume_tick(rt, *, now: datetime | None = None) -> None:
             logger.info("rate_limit_resume: re-dispatched %d/%d due park(s)", dispatched, len(due))
         rt.record_job_success("rate_limit_resume")
     except Exception as exc:  # noqa: BLE001 — job boundary
-        rt.record_job_failure("rate_limit_resume", str(exc))
+        rt.record_job_failure("rate_limit_resume", exc=exc)
         logger.exception("rate_limit_resume tick failed")

--- a/src/genesis/dashboard/heartbeat.py
+++ b/src/genesis/dashboard/heartbeat.py
@@ -60,13 +60,13 @@ class DashboardHeartbeat:
                     finally:
                         loop.close()
                     rt.record_job_success("dashboard_heartbeat")
-            except Exception:
+            except Exception as exc:
                 logger.error("Dashboard heartbeat failed", exc_info=True)
                 try:
                     from genesis.runtime import GenesisRuntime
 
                     rt = GenesisRuntime.instance()
-                    rt.record_job_failure("dashboard_heartbeat", "heartbeat emission failed")
+                    rt.record_job_failure("dashboard_heartbeat", "heartbeat emission failed", exc=exc)
                 except Exception:
                     pass
             self._stop_event.wait(self._interval)

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -26,6 +26,7 @@ from genesis.inbox.scanner import (
     segment_items,
 )
 from genesis.inbox.types import CheckResult, InboxConfig, InboxItem
+from genesis.observability.failure_details import failure_details
 from genesis.security import ContentSanitizer, ContentSource
 from genesis.util.tz import parse_utc_iso
 
@@ -1912,7 +1913,7 @@ class InboxMonitor:
                     "heartbeat",
                     "inbox_monitor check completed",
                 )
-        except Exception:
+        except Exception as exc:
             logger.exception("Inbox check failed")
             if self._event_bus:
                 from genesis.observability.types import Severity, Subsystem
@@ -1922,6 +1923,7 @@ class InboxMonitor:
                     Severity.ERROR,
                     "check.failed",
                     "Inbox check failed with exception",
+                    **failure_details(exc=exc),
                 )
 
     # ------------------------------------------------------------------

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -116,9 +116,9 @@ def build_triage_pipeline(
             if runtime is not None:
                 runtime.record_job_success("retrospective_triage")
             _record_call_site(triage_depth=None)
-        except Exception:
+        except Exception as exc:
             if runtime is not None:
-                runtime.record_job_failure("retrospective_triage", "pipeline exception")
+                runtime.record_job_failure("retrospective_triage", "pipeline exception", exc=exc, emit_event=False)
             raise
 
     async def _run_pipeline(output: Any, user_text: str, channel: str) -> None:

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -118,7 +118,11 @@ def build_triage_pipeline(
             _record_call_site(triage_depth=None)
         except Exception as exc:
             if runtime is not None:
-                runtime.record_job_failure("retrospective_triage", "pipeline exception", exc=exc, emit_event=False)
+                # _fire_triage (inbox/monitor + cc/conversation) wraps this in a
+                # tracked_task but SWALLOWS the re-raise with a bare except+log,
+                # so no task.failed is ever emitted for this path. Let the funnel
+                # emit job.failed — it is the only bus signal this failure gets.
+                runtime.record_job_failure("retrospective_triage", "pipeline exception", exc=exc)
             raise
 
     async def _run_pipeline(output: Any, user_text: str, channel: str) -> None:

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -304,9 +304,22 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         record_job_success(self, job_name)
 
     def record_job_failure(
-        self, job_name: str, error: str, *, error_type: str | None = None
+        self,
+        job_name: str,
+        error: str | None = None,
+        *,
+        exc: BaseException | None = None,
+        error_type: str | None = None,
+        emit_event: bool = True,
     ) -> None:
-        record_job_failure(self, job_name, error, error_type=error_type)
+        record_job_failure(
+            self,
+            job_name,
+            error,
+            exc=exc,
+            error_type=error_type,
+            emit_event=emit_event,
+        )
 
     async def _load_persisted_job_health(self) -> None:
         # Thin wrapper: preserves the class-level patch surface for tests

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -430,14 +430,17 @@ def record_job_failure(
         # the run-event throttle above → bounded ~24/day/job. Gated on an actual
         # exception (semantic/external failures stay off the bus) and on a live
         # bus. Fully fire-and-forget: a broken emit must NEVER stop the
-        # job_health record above from being written.
-        if exc is not None and emit_event and rt._event_bus is not None:
+        # job_health record above from being written. getattr (not rt._event_bus
+        # directly) so a bare test runtime built via __new__ — with no
+        # _event_bus attribute set — degrades to no-emit instead of raising.
+        bus = getattr(rt, "_event_bus", None)
+        if exc is not None and emit_event and bus is not None:
             try:
                 from genesis.observability.failure_details import failure_details
                 from genesis.util.tasks import emit_sync
 
                 emit_sync(
-                    rt._event_bus,
+                    bus,
                     severity_str="ERROR",
                     event_type="job.failed",
                     message=f"Scheduled job {job_name!r} failed: {error}",

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -169,7 +169,9 @@ def clear_stale_job_failures(rt: GenesisRuntime) -> int:
             continue
         logger.info(
             "Cleared stale failures for job %s (last_failure=%s, was=%d)",
-            job_name, last_failure, entry["consecutive_failures"],
+            job_name,
+            last_failure,
+            entry["consecutive_failures"],
         )
         entry["consecutive_failures"] = 0
         entry.pop("last_failure", None)
@@ -343,19 +345,52 @@ def record_job_success(rt: GenesisRuntime, job_name: str) -> None:
 
 
 def record_job_failure(
-    rt: GenesisRuntime, job_name: str, error: str, *, error_type: str | None = None
+    rt: GenesisRuntime,
+    job_name: str,
+    error: str | None = None,
+    *,
+    exc: BaseException | None = None,
+    error_type: str | None = None,
+    emit_event: bool = True,
 ) -> None:
     """Record a failed scheduled job execution (in-memory + DB).
 
     When consecutive failures reach the retry threshold (3), triggers
     an automatic retry via the JobRetryRegistry if one is wired.
 
+    *exc* is the exception object when one caused the failure. Pass it in
+    preference to a pre-stringified *error*: it is the single richest artifact,
+    and it is what turns a background-job failure into a diagnosable **reflex
+    signal**. When *exc* is given, *error* and *error_type* are derived from it
+    (an explicit *error* still wins for the human message).
+
     *error_type* is the exception class name when an exception caused the
     failure, else ``None`` (a semantic failure — e.g. an external quota block
     surfaced as a result reason). Keyword-only and optional so the ~110 existing
     call sites keep working untouched; only callers that actually hold the
     exception need to pass it.
+
+    The funnel (WS-reflex): when *exc* is present this ALSO emits a throttled
+    ``job.failed`` event onto the bus (see the emit block below) so the reflex
+    arc — which subscribes to the bus, not this table — can see the largest
+    class of internal Genesis defects (background-job exceptions). Semantic /
+    no-exception failures stay off the bus: an external blocker is not a Genesis
+    bug the reflex arc can act on. Set *emit_event=False* to suppress the emit
+    for callers that already emit their own richer domain ``.failed`` event
+    (the reflection/outreach/surplus schedulers), so one failure is not counted
+    twice.
     """
+    # Derive the human/DB fields from the exception when one was supplied, so
+    # every exc-bearing caller records a typed error even when str(exc) is blank
+    # (a bare TypeError renders "" — the type is then the only signal).
+    if exc is not None:
+        from genesis.observability.failure_details import error_summary
+
+        if error is None:
+            error = error_summary(exc)
+        if error_type is None:
+            error_type = type(exc).__name__
+
     now = datetime.now(UTC).isoformat()
     entry = rt._job_health.setdefault(job_name, {"consecutive_failures": 0})
     prev_consecutive = entry.get("consecutive_failures", 0)  # 0 → this is a streak ONSET
@@ -390,6 +425,31 @@ def record_job_failure(
             error=error,
             now=now,
         )
+        # Reflex funnel: surface exception-driven job failures onto the event
+        # bus so the reflex arc (and health/ego consumers) can see them. Shares
+        # the run-event throttle above → bounded ~24/day/job. Gated on an actual
+        # exception (semantic/external failures stay off the bus) and on a live
+        # bus. Fully fire-and-forget: a broken emit must NEVER stop the
+        # job_health record above from being written.
+        if exc is not None and emit_event and rt._event_bus is not None:
+            try:
+                from genesis.observability.failure_details import failure_details
+                from genesis.util.tasks import emit_sync
+
+                emit_sync(
+                    rt._event_bus,
+                    severity_str="ERROR",
+                    event_type="job.failed",
+                    message=f"Scheduled job {job_name!r} failed: {error}",
+                    task_name=job_name,
+                    **failure_details(exc=exc),
+                )
+            except Exception:
+                logger.warning(
+                    "job.failed emit failed for %r (job_health still recorded)",
+                    job_name,
+                    exc_info=True,
+                )
 
     consecutive = entry["consecutive_failures"]
     if consecutive >= 3 and rt._job_retry_registry is not None:
@@ -409,7 +469,6 @@ def register_channel(
         rt._outreach_pipeline._channels[name] = adapter
         if recipient:
             rt._outreach_pipeline._recipients[name] = recipient
-    if (rt._outreach_scheduler is not None
-            and not rt._outreach_scheduler.is_running):
+    if rt._outreach_scheduler is not None and not rt._outreach_scheduler.is_running:
         logger.info("First outreach channel '%s' registered — starting scheduler", name)
         rt._outreach_scheduler.start()

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -172,7 +172,7 @@ async def init(rt: GenesisRuntime) -> None:
                     except asyncio.CancelledError:
                         break
                     except Exception as exc:
-                        rt.record_job_failure("approval_timeout_poll", str(exc))
+                        rt.record_job_failure("approval_timeout_poll", exc=exc)
                         logger.error("Approval timeout polling failed", exc_info=True)
 
             rt._approval_timeout_task = tracked_task(

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -42,7 +42,7 @@ def _is_non_actionable_infra_event(subsystem: str, event_type: str) -> bool:
     return subsystem in ("routing", "providers") and event_type == "all_exhausted"
 
 
-_REFLEX_OWNED_EVENT_TYPES = frozenset({"task.failed"})
+_REFLEX_OWNED_EVENT_TYPES = frozenset({"task.failed", "job.failed"})
 
 
 def _is_reflex_owned_event(event_type: str) -> bool:
@@ -50,12 +50,15 @@ def _is_reflex_owned_event(event_type: str) -> bool:
 
     ``task.failed`` was dark until the reflex arc installed the default event
     bus (util/tasks.py) — the ego never reacted to it historically because
-    the events were never emitted. Reflex is the designed consumer: it
-    fingerprints recurrences into one signal and cards the user. A reactive
-    ego cycle per failure would re-run the event-burst storm mode (see the
-    push_reactive_event note in ego/cadence.py) with a message-keyed dedup
-    that variable exception payloads bypass. Module-level so it is
-    unit-testable.
+    the events were never emitted. ``job.failed`` is the same shape from the
+    other direction: the funnel in ``runtime/_job_health.record_job_failure``
+    now emits it for exception-driven background-job failures (the largest
+    class of internal defects, previously invisible to the bus). Both belong to
+    the reflex arc, which fingerprints recurrences into one signal and cards
+    the user. A reactive ego cycle per failure would re-run the event-burst
+    storm mode (see the push_reactive_event note in ego/cadence.py) with a
+    message-keyed dedup that variable exception payloads bypass. Module-level so
+    it is unit-testable.
     """
     return event_type in _REFLEX_OWNED_EVENT_TYPES
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -42,7 +42,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             if removed:
                 logger.info("execution_traces prune: removed %d rows (>90d)", removed)
         except Exception as exc:
-            rt.record_job_failure("execution_traces_prune", str(exc))
+            rt.record_job_failure("execution_traces_prune", exc=exc)
             logger.exception("execution_traces prune failed")
 
     scheduler.add_job(
@@ -64,7 +64,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             if removed:
                 logger.info("cost_events prune: removed %d rows (>90d)", removed)
         except Exception as exc:
-            rt.record_job_failure("cost_events_prune", str(exc))
+            rt.record_job_failure("cost_events_prune", exc=exc)
             logger.exception("cost_events prune failed")
 
     scheduler.add_job(
@@ -86,7 +86,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             if removed:
                 logger.info("file_modifications prune: removed %d rows (>90d)", removed)
         except Exception as exc:
-            rt.record_job_failure("file_modifications_prune", str(exc))
+            rt.record_job_failure("file_modifications_prune", exc=exc)
             logger.exception("file_modifications prune failed")
 
     scheduler.add_job(
@@ -108,7 +108,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             if removed:
                 logger.info("job_run_events prune: removed %d rows (>90d)", removed)
         except Exception as exc:
-            rt.record_job_failure("job_run_events_prune", str(exc))
+            rt.record_job_failure("job_run_events_prune", exc=exc)
             logger.exception("job_run_events prune failed")
 
     scheduler.add_job(
@@ -130,7 +130,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             if removed:
                 logger.info("alert_events prune: removed %d resolved rows (>90d)", removed)
         except Exception as exc:
-            rt.record_job_failure("alert_events_prune", str(exc))
+            rt.record_job_failure("alert_events_prune", exc=exc)
             logger.exception("alert_events prune failed")
 
     scheduler.add_job(
@@ -155,7 +155,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
             if removed:
                 logger.info("deferred_work prune: removed %d terminal rows (>45d)", removed)
         except Exception as exc:
-            rt.record_job_failure("deferred_work_prune", str(exc))
+            rt.record_job_failure("deferred_work_prune", exc=exc)
             logger.exception("deferred_work prune failed")
 
     scheduler.add_job(
@@ -180,7 +180,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
                     removed,
                 )
         except Exception as exc:
-            rt.record_job_failure("graduation_events_prune", str(exc))
+            rt.record_job_failure("graduation_events_prune", exc=exc)
             logger.exception("graduation_events prune failed")
 
     scheduler.add_job(
@@ -225,7 +225,7 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
                     healed,
                 )
         except Exception as exc:
-            rt.record_job_failure("voice_hygiene", str(exc))
+            rt.record_job_failure("voice_hygiene", exc=exc)
             logger.exception("voice hygiene failed")
 
     scheduler.add_job(
@@ -408,7 +408,7 @@ async def init(rt: GenesisRuntime) -> None:
                 else:
                     rt.record_job_success("triage_calibration_daily")
             except Exception as exc:
-                rt.record_job_failure("triage_calibration_daily", str(exc))
+                rt.record_job_failure("triage_calibration_daily", exc=exc)
                 raise
 
         rt._learning_scheduler.add_job(
@@ -441,7 +441,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if n:
                     logger.info("Email gate drain resolved %d held send(s)", n)
             except Exception as exc:
-                rt.record_job_failure("email_gate_drain", str(exc))
+                rt.record_job_failure("email_gate_drain", exc=exc)
                 raise
 
         rt._learning_scheduler.add_job(
@@ -480,7 +480,7 @@ async def init(rt: GenesisRuntime) -> None:
                         ", ".join(decayed),
                     )
             except Exception as exc:
-                rt.record_job_failure("capability_decay_sweep", str(exc))
+                rt.record_job_failure("capability_decay_sweep", exc=exc)
                 raise
 
         rt._learning_scheduler.add_job(
@@ -547,7 +547,7 @@ async def init(rt: GenesisRuntime) -> None:
                     )
                 rt.record_job_success("auto_memory_harvest")
             except Exception as exc:
-                rt.record_job_failure("auto_memory_harvest", str(exc))
+                rt.record_job_failure("auto_memory_harvest", exc=exc)
                 logger.exception("Auto-memory harvest failed")
 
         rt._learning_scheduler.add_job(
@@ -570,7 +570,7 @@ async def init(rt: GenesisRuntime) -> None:
                         stale,
                     )
             except Exception as exc:
-                rt.record_job_failure("observation_expiry_sweep", str(exc))
+                rt.record_job_failure("observation_expiry_sweep", exc=exc)
                 logger.exception("Observation expiry sweep failed")
 
         rt._learning_scheduler.add_job(
@@ -593,7 +593,7 @@ async def init(rt: GenesisRuntime) -> None:
                         count,
                     )
             except Exception as exc:
-                rt.record_job_failure("follow_up_retention_sweep", str(exc))
+                rt.record_job_failure("follow_up_retention_sweep", exc=exc)
                 logger.exception("Follow-up retention sweep failed")
 
         rt._learning_scheduler.add_job(
@@ -629,7 +629,7 @@ async def init(rt: GenesisRuntime) -> None:
                         decayed,
                     )
             except Exception as exc:
-                rt.record_job_failure("inbox_marker_decay", str(exc))
+                rt.record_job_failure("inbox_marker_decay", exc=exc)
                 logger.exception("Inbox marker decay sweep failed")
 
         rt._learning_scheduler.add_job(
@@ -652,8 +652,8 @@ async def init(rt: GenesisRuntime) -> None:
                             report.embeddings_recovered,
                             report.items_pending,
                         )
-                except Exception:
-                    rt.record_job_failure("recovery_orchestrator", "recovery failed")
+                except Exception as exc:
+                    rt.record_job_failure("recovery_orchestrator", "recovery failed", exc=exc)
                     logger.exception("Recovery orchestrator failed")
 
         rt._learning_scheduler.add_job(
@@ -669,8 +669,8 @@ async def init(rt: GenesisRuntime) -> None:
                 try:
                     await rt._health_data.validate_api_keys()
                     rt.record_job_success("api_key_validation")
-                except Exception:
-                    rt.record_job_failure("api_key_validation", "validation failed")
+                except Exception as exc:
+                    rt.record_job_failure("api_key_validation", "validation failed", exc=exc)
                     logger.exception("API key validation failed")
 
         rt._learning_scheduler.add_job(
@@ -696,8 +696,8 @@ async def init(rt: GenesisRuntime) -> None:
                     rt.record_job_success("dead_letter_expiry")
                     if expired:
                         logger.info("Expired %d dead letter items (>72h)", expired)
-                except Exception:
-                    rt.record_job_failure("dead_letter_expiry", "expiry failed")
+                except Exception as exc:
+                    rt.record_job_failure("dead_letter_expiry", "expiry failed", exc=exc)
                     logger.exception("Dead letter expiry failed")
 
         rt._learning_scheduler.add_job(
@@ -722,7 +722,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if expired:
                     logger.info("Expired %d stale message queue items (>7d)", expired)
             except Exception as exc:
-                rt.record_job_failure("message_queue_expiry", str(exc))
+                rt.record_job_failure("message_queue_expiry", exc=exc)
                 logger.exception("Message queue expiry failed")
 
         rt._learning_scheduler.add_job(
@@ -755,10 +755,11 @@ async def init(rt: GenesisRuntime) -> None:
                             ok,
                             fail,
                         )
-                except Exception:
+                except Exception as exc:
                     rt.record_job_failure(
                         "dead_letter_redispatch",
                         "redispatch failed",
+                        exc=exc,
                     )
                     logger.exception("Dead letter redispatch failed")
 
@@ -811,7 +812,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if counts.get("judged") or counts.get("merged") or counts.get("proposed"):
                     logger.info("entity_adjudication drain (mode=%s): %s", mode, counts)
             except Exception as exc:
-                rt.record_job_failure("entity_adjudication_drain", str(exc))
+                rt.record_job_failure("entity_adjudication_drain", exc=exc)
                 logger.exception("entity_adjudication drain failed")
 
         # CronTrigger (not IntervalTrigger — resets on restart). :25 is a clean
@@ -833,7 +834,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if any(v > 0 for v in result.values()):
                     logger.info("Procedure promotion: %s", result)
             except Exception as exc:
-                rt.record_job_failure("procedure_promotion", str(exc))
+                rt.record_job_failure("procedure_promotion", exc=exc)
                 logger.exception("Procedure promotion failed")
             # Self-healing embedding backfill — independent of promotion so a
             # backfill failure never fails the promotion job. Repairs procedures
@@ -1003,7 +1004,7 @@ async def init(rt: GenesisRuntime) -> None:
                             logger.exception("Failed to synthesize USER_KNOWLEDGE.md")
                 rt.record_job_success("user_model_evolution")
             except Exception as exc:
-                rt.record_job_failure("user_model_evolution", str(exc))
+                rt.record_job_failure("user_model_evolution", exc=exc)
                 logger.exception("User model evolution failed")
 
         rt._learning_scheduler.add_job(
@@ -1065,7 +1066,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if cleaned:
                     logger.info("Session reaper: cleaned %d stale heartbeats", cleaned)
             except Exception as exc:
-                rt.record_job_failure("session_reaper", str(exc))
+                rt.record_job_failure("session_reaper", exc=exc)
                 logger.exception("Session reaper failed")
 
         rt._learning_scheduler.add_job(
@@ -1092,7 +1093,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if count:
                     logger.info("Capability map refreshed: %d domains", count)
             except Exception as exc:
-                rt.record_job_failure("capability_map_refresh", str(exc))
+                rt.record_job_failure("capability_map_refresh", exc=exc)
                 logger.exception("Capability map refresh failed")
 
         rt._learning_scheduler.add_job(
@@ -1125,7 +1126,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if any(incremental.values()):
                     logger.info("Outcome harvest: %s", incremental)
             except Exception as exc:
-                rt.record_job_failure("outcome_harvest", str(exc))
+                rt.record_job_failure("outcome_harvest", exc=exc)
                 logger.exception("Outcome harvest failed")
 
         rt._learning_scheduler.add_job(
@@ -1164,7 +1165,7 @@ async def init(rt: GenesisRuntime) -> None:
                         " (low-confidence)" if snap["low_confidence"] else "",
                     )
             except Exception as exc:
-                rt.record_job_failure("ego_calibration", str(exc))
+                rt.record_job_failure("ego_calibration", exc=exc)
                 logger.exception("Ego calibration failed")
 
         rt._learning_scheduler.add_job(
@@ -1200,7 +1201,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if report.scanned:
                     logger.info("Ledger grader: %s", report.summary())
             except Exception as exc:
-                rt.record_job_failure("ledger_grader", str(exc))
+                rt.record_job_failure("ledger_grader", exc=exc)
                 logger.exception("Ledger grader failed")
 
         rt._learning_scheduler.add_job(
@@ -1233,7 +1234,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if reaped:
                     logger.info("Activity log reaper: deleted %d old records", reaped)
             except Exception as exc:
-                rt.record_job_failure("activity_log_reaper", str(exc))
+                rt.record_job_failure("activity_log_reaper", exc=exc)
                 logger.exception("Activity log reaper failed")
 
         rt._learning_scheduler.add_job(
@@ -1256,7 +1257,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if n:
                     logger.debug("CC span ingest: %d spans", n)
             except Exception as exc:
-                rt.record_job_failure("cc_span_ingest", str(exc))
+                rt.record_job_failure("cc_span_ingest", exc=exc)
                 logger.exception("CC span ingest failed")
 
         # Frequent (every 2 min) so dispatched-session tool spans land in the
@@ -1283,7 +1284,7 @@ async def init(rt: GenesisRuntime) -> None:
                 if removed:
                     logger.info("otel_spans prune: removed %d old spans", removed)
             except Exception as exc:
-                rt.record_job_failure("otel_span_prune", str(exc))
+                rt.record_job_failure("otel_span_prune", exc=exc)
                 logger.exception("otel_spans prune failed")
 
         rt._learning_scheduler.add_job(
@@ -1331,7 +1332,7 @@ async def init(rt: GenesisRuntime) -> None:
                     logger.info("Skill evolution completed: %s", result)
                 rt.record_job_success("skill_evolution")
             except Exception as exc:
-                rt.record_job_failure("skill_evolution", str(exc))
+                rt.record_job_failure("skill_evolution", exc=exc)
                 logger.exception("Skill evolution pipeline failed")
 
         rt._learning_scheduler.add_job(
@@ -1374,7 +1375,7 @@ async def init(rt: GenesisRuntime) -> None:
                     logger.warning("J9 regression check failed", exc_info=True)
                 rt.record_job_success("j9_eval_aggregation")
             except Exception as exc:
-                rt.record_job_failure("j9_eval_aggregation", str(exc))
+                rt.record_job_failure("j9_eval_aggregation", exc=exc)
                 logger.exception("J9 weekly aggregation failed")
 
         rt._learning_scheduler.add_job(
@@ -1410,7 +1411,7 @@ async def init(rt: GenesisRuntime) -> None:
                 )
                 rt.record_job_success("pr_review_harvest")
             except Exception as exc:
-                rt.record_job_failure("pr_review_harvest", str(exc))
+                rt.record_job_failure("pr_review_harvest", exc=exc)
                 logger.exception("PR review harvest failed")
 
         rt._learning_scheduler.add_job(
@@ -1480,7 +1481,7 @@ async def init(rt: GenesisRuntime) -> None:
                 logger.info("Model gauntlet: ran %d/%d roster model(s)", ran, len(models))
                 rt.record_job_success("model_gauntlet")
             except Exception as exc:
-                rt.record_job_failure("model_gauntlet", str(exc))
+                rt.record_job_failure("model_gauntlet", exc=exc)
                 logger.exception("Model gauntlet job failed")
 
         rt._learning_scheduler.add_job(

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -41,7 +41,7 @@ async def run_status_writer_loop(
         except asyncio.CancelledError:
             break
         except Exception as exc:
-            runtime.record_job_failure("status_writer_loop", str(exc))
+            runtime.record_job_failure("status_writer_loop", exc=exc)
             logger.error(
                 "Status writer loop iteration failed",
                 exc_info=True,

--- a/src/genesis/runtime/init/pipeline.py
+++ b/src/genesis/runtime/init/pipeline.py
@@ -34,7 +34,7 @@ async def run_pipeline_cycle(rt: GenesisRuntime, profile_name: str) -> None:
             result.discarded,
         )
     except Exception as exc:
-        rt.record_job_failure(job_name, str(exc))
+        rt.record_job_failure(job_name, exc=exc)
         logger.error("Pipeline cycle %s failed", profile_name, exc_info=True)
 
 

--- a/src/genesis/runtime/init/process_reaper.py
+++ b/src/genesis/runtime/init/process_reaper.py
@@ -472,7 +472,7 @@ async def run_reaper(rt: GenesisRuntime, *, now: float | None = None) -> None:
             )
         rt.record_job_success("process_reaper")
     except Exception as exc:  # noqa: BLE001 — job boundary
-        rt.record_job_failure("process_reaper", str(exc))
+        rt.record_job_failure("process_reaper", exc=exc)
         logger.exception("Process reaper failed")
 
 

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -393,7 +393,7 @@ async def init(rt: GenesisRuntime) -> None:
                     rt.record_job_success("extraction_calibration")
                 except Exception as exc:
                     logger.exception("Extraction calibration failed")
-                    rt.record_job_failure("extraction_calibration", str(exc))
+                    rt.record_job_failure("extraction_calibration", exc=exc)
 
             rt._surplus_scheduler._scheduler.add_job(
                 _calibration_job,

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -63,7 +63,7 @@ def _wire_build_lane(rt: GenesisRuntime, dispatcher: object) -> None:
             except asyncio.CancelledError:
                 break
             except Exception as exc:
-                rt.record_job_failure("build_lane_poll", str(exc))
+                rt.record_job_failure("build_lane_poll", exc=exc)
                 logger.error("Build-lane polling failed", exc_info=True)
 
     rt._build_lane_poll = tracked_task(
@@ -194,7 +194,7 @@ async def init(rt: GenesisRuntime) -> None:
                             logger.info("Reaped %d stale dispatching claims", reaped)
                         rt.record_job_success("task_dispatch_reaper")
                     except Exception as exc:
-                        rt.record_job_failure("task_dispatch_reaper", str(exc))
+                        rt.record_job_failure("task_dispatch_reaper", exc=exc)
                         logger.error("Dispatch reaper failed", exc_info=True)
                     count = await dispatcher.dispatch_cycle()
                     if count:
@@ -203,7 +203,7 @@ async def init(rt: GenesisRuntime) -> None:
                 except asyncio.CancelledError:
                     break
                 except Exception as exc:
-                    rt.record_job_failure("task_dispatch_poll", str(exc))
+                    rt.record_job_failure("task_dispatch_poll", exc=exc)
                     logger.error("Task dispatch polling failed", exc_info=True)
 
         rt._task_dispatch_poll = tracked_task(

--- a/src/genesis/scheduler/user_jobs.py
+++ b/src/genesis/scheduler/user_jobs.py
@@ -222,6 +222,6 @@ class UserJobScheduler:
             with contextlib.suppress(Exception):
                 from genesis.runtime import GenesisRuntime
                 rt = GenesisRuntime.instance()
-                rt.record_job_failure(f"user_job:{job_id[:8]}", str(exc))
+                rt.record_job_failure(f"user_job:{job_id[:8]}", exc=exc)
 
             return None

--- a/src/genesis/surplus/jobs/dream.py
+++ b/src/genesis/surplus/jobs/dream.py
@@ -30,6 +30,7 @@ async def run_dream_cycle() -> None:
     """
     try:
         from genesis.runtime import GenesisRuntime
+
         if GenesisRuntime.instance().paused:
             logger.debug("Dream cycle skipped (Genesis paused)")
             return
@@ -42,6 +43,7 @@ async def run_dream_cycle() -> None:
     # record_job_success nor record_job_failure was reached.
     try:
         from genesis.runtime import GenesisRuntime
+
         GenesisRuntime.instance().record_job_start("dream_cycle")
     except Exception:
         pass  # Don't let health tracking prevent the actual job
@@ -69,6 +71,7 @@ async def run_dream_cycle() -> None:
         # Default dry-run until user enables live mode.
         # Set GENESIS_DREAM_CYCLE_LIVE=1 to enable actual merges.
         import os
+
         dry_run = os.environ.get("GENESIS_DREAM_CYCLE_LIVE", "") not in ("1", "true")
 
         report = await dream_cycle.run(
@@ -84,6 +87,7 @@ async def run_dream_cycle() -> None:
             import uuid as _uuid  # noqa: PLC0415
 
             from genesis.db.crud import observations as obs_crud
+
             await obs_crud.create(
                 rt.db,
                 id=str(_uuid.uuid4()),
@@ -111,14 +115,16 @@ async def run_dream_cycle() -> None:
         logger.exception("Dream cycle failed: %s", exc)
         try:
             from genesis.runtime import GenesisRuntime
+
             GenesisRuntime.instance().record_job_failure(
-                "dream_cycle", str(exc)[:500],
+                "dream_cycle",
+                exc=exc,
             )
         except Exception as rec_err:
             logger.error(
-                "Failed to record dream_cycle failure: %s "
-                "(original error: %s)",
-                rec_err, exc,
+                "Failed to record dream_cycle failure: %s (original error: %s)",
+                rec_err,
+                exc,
             )
     finally:
         # Always clear heavy workload flag, even on failure — but ONLY if
@@ -148,6 +154,7 @@ async def run_dream_synthesis_drain() -> None:
     """
     try:
         from genesis.runtime import GenesisRuntime
+
         rt = GenesisRuntime.instance()
         if rt.paused:
             logger.debug("Dream synthesis drain skipped (Genesis paused)")
@@ -165,15 +172,11 @@ async def run_dream_synthesis_drain() -> None:
         # "started" in job_health (masks real stuck-job detection).
         store = rt.memory_store
         if rt.db is None or store is None or rt.router is None:
-            logger.warning(
-                "Dream synthesis drain skipped — missing runtime dependencies"
-            )
+            logger.warning("Dream synthesis drain skipped — missing runtime dependencies")
             return
         qdrant = store.qdrant_client
         if qdrant is None:
-            logger.warning(
-                "Dream synthesis drain skipped — MemoryStore has no Qdrant client"
-            )
+            logger.warning("Dream synthesis drain skipped — MemoryStore has no Qdrant client")
             return
     except Exception:
         logger.warning(
@@ -193,7 +196,10 @@ async def run_dream_synthesis_drain() -> None:
 
         # SHADOW hardwired: the live flip is a separate user-gated change.
         report = await dream_cycle.run_synthesis_drain(
-            qdrant=qdrant, db=rt.db, router=rt.router, store=store,
+            qdrant=qdrant,
+            db=rt.db,
+            router=rt.router,
+            store=store,
             dry_run=True,
         )
 
@@ -201,6 +207,7 @@ async def run_dream_synthesis_drain() -> None:
             import uuid as _uuid  # noqa: PLC0415
 
             from genesis.db.crud import observations as obs_crud
+
             await obs_crud.create(
                 rt.db,
                 id=str(_uuid.uuid4()),
@@ -227,14 +234,16 @@ async def run_dream_synthesis_drain() -> None:
         logger.exception("Dream synthesis drain failed: %s", exc)
         try:
             from genesis.runtime import GenesisRuntime
+
             GenesisRuntime.instance().record_job_failure(
-                "dream_synthesis_drain", str(exc)[:500],
+                "dream_synthesis_drain",
+                exc=exc,
             )
         except Exception as rec_err:
             logger.error(
-                "Failed to record dream_synthesis_drain failure: %s "
-                "(original error: %s)",
-                rec_err, exc,
+                "Failed to record dream_synthesis_drain failure: %s (original error: %s)",
+                rec_err,
+                exc,
             )
     finally:
         # Clear only if this job set the flag (see run_dream_cycle note).

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.db.crud import surplus as surplus_crud
+from genesis.observability.failure_details import failure_details
 from genesis.observability.types import Severity, Subsystem
 from genesis.surplus.jobs._guard import (
     job_guard,
@@ -38,6 +39,7 @@ async def brainstorm_check(sched: SchedulerContext) -> None:
     """Ensure today's brainstorm sessions are queued."""
     try:
         from genesis.runtime import GenesisRuntime
+
         if GenesisRuntime.instance().paused:
             logger.debug("Brainstorm check skipped (Genesis paused)")
             return
@@ -52,14 +54,18 @@ async def brainstorm_check(sched: SchedulerContext) -> None:
         record_failure("surplus_brainstorm", str(exc))
         if sched._event_bus:
             await sched._event_bus.emit(
-                Subsystem.SURPLUS, Severity.ERROR,
+                Subsystem.SURPLUS,
+                Severity.ERROR,
                 "brainstorm.failed",
                 "Brainstorm check failed with exception",
+                **failure_details(exc=exc),
             )
 
 
 async def recently_completed(
-    sched: SchedulerContext, task_type, cooldown_hours: int | float,
+    sched: SchedulerContext,
+    task_type,
+    cooldown_hours: int | float,
 ) -> bool:
     """Return ``True`` if *task_type* completed within *cooldown_hours*.
 
@@ -86,11 +92,10 @@ async def schedule_code_index(sched: SchedulerContext) -> None:
 
     active = await sched._queue.active_by_type(TaskType.CODE_INDEX)
     if active == 0 and not await sched._recently_completed(
-        TaskType.CODE_INDEX, sched._code_index_hours,
+        TaskType.CODE_INDEX,
+        sched._code_index_hours,
     ):
-        await sched._queue.enqueue(
-            TaskType.CODE_INDEX, ComputeTier.FREE_API, 0.6, "competence"
-        )
+        await sched._queue.enqueue(TaskType.CODE_INDEX, ComputeTier.FREE_API, 0.6, "competence")
 
 
 @job_guard("schedule_j9_eval_batch", "J9 eval batch scheduling failed")
@@ -100,11 +105,10 @@ async def schedule_j9_eval_batch(sched: SchedulerContext) -> None:
 
     active = await sched._queue.active_by_type(TaskType.J9_EVAL_BATCH)
     if active == 0 and not await sched._recently_completed(
-        TaskType.J9_EVAL_BATCH, sched._j9_eval_batch_hours,
+        TaskType.J9_EVAL_BATCH,
+        sched._j9_eval_batch_hours,
     ):
-        await sched._queue.enqueue(
-            TaskType.J9_EVAL_BATCH, ComputeTier.FREE_API, 0.3, "competence"
-        )
+        await sched._queue.enqueue(TaskType.J9_EVAL_BATCH, ComputeTier.FREE_API, 0.3, "competence")
 
 
 @job_guard("schedule_fresh_session_test", "Fresh session test scheduling failed")
@@ -128,11 +132,15 @@ async def schedule_model_eval(sched: SchedulerContext) -> None:
 
     active = await sched._queue.active_by_type(TaskType.MODEL_EVAL)
     if active == 0 and not await sched._recently_completed(
-        TaskType.MODEL_EVAL, sched._model_eval_hours,
+        TaskType.MODEL_EVAL,
+        sched._model_eval_hours,
     ):
         payload = json.dumps({"model_id": "groq-free"})
         await sched._queue.enqueue(
-            TaskType.MODEL_EVAL, ComputeTier.FREE_API, 0.4, "competence",
+            TaskType.MODEL_EVAL,
+            ComputeTier.FREE_API,
+            0.4,
+            "competence",
             payload=payload,
         )
 
@@ -150,6 +158,7 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     # GC: remove completed/failed pending_embeddings older than 30 days
     try:
         from genesis.db.crud import pending_embeddings as pe_crud
+
         pe_purged = await pe_crud.purge_completed(db, older_than_days=30)
         if pe_purged:
             logger.info("Purged %d completed pending_embeddings", pe_purged)
@@ -164,14 +173,17 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     # this is the monitored tripwire that would justify one.)
     try:
         from genesis.db.crud import memory as mem_crud
+
         fts_ghosts, fts_invisible = await mem_crud.count_fts_metadata_drift(db)
         if fts_ghosts or fts_invisible:
             logger.warning(
                 "FTS/metadata drift: %d FTS-ghost rows (no metadata), "
                 "%d metadata rows invisible to FTS",
-                fts_ghosts, fts_invisible,
+                fts_ghosts,
+                fts_invisible,
             )
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             if rt.event_bus:
                 await rt.event_bus.emit(
@@ -186,9 +198,12 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     # GC: rotate heartbeat events older than 7 days
     try:
         from genesis.db.crud import events as events_crud
+
         hb_cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
         hb_purged = await events_crud.prune(
-            db, older_than=hb_cutoff, event_type="heartbeat",
+            db,
+            older_than=hb_cutoff,
+            event_type="heartbeat",
         )
         if hb_purged:
             logger.info("Pruned %d heartbeat events older than 7d", hb_purged)
@@ -198,8 +213,11 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     # GC: prune weak memory links (strength <= 0.3, older than 30d)
     try:
         from genesis.db.crud import memory_links as links_crud
+
         links_pruned = await links_crud.prune_weak(
-            db, max_strength=0.3, min_age_days=30,
+            db,
+            max_strength=0.3,
+            min_age_days=30,
         )
         if links_pruned:
             logger.info("Pruned %d weak memory links", links_pruned)
@@ -209,13 +227,15 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     # GC: archive old transcript files (gzip .jsonl > 90 days)
     try:
         from genesis.surplus.maintenance import archive_old_transcripts
+
         transcripts_archived = await archive_old_transcripts(
             Path.home() / ".genesis" / "background-sessions",
             older_than_days=90,
         )
         if transcripts_archived:
             logger.info(
-                "Archived %d old transcript files", transcripts_archived,
+                "Archived %d old transcript files",
+                transcripts_archived,
             )
     except Exception:
         logger.warning("GC: transcript archival failed", exc_info=True)
@@ -236,14 +256,19 @@ async def schedule_maintenance(sched: SchedulerContext) -> None:
     for task_type, priority, drive in maintenance_tasks:
         active = await sched._queue.active_by_type(task_type)
         if active == 0 and not await sched._recently_completed(
-            task_type, sched._maintenance_hours,
+            task_type,
+            sched._maintenance_hours,
         ):
             await sched._queue.enqueue(
-                task_type, ComputeTier.FREE_API, priority, drive,
+                task_type,
+                ComputeTier.FREE_API,
+                priority,
+                drive,
             )
 
     # ── GC operations ──────────────────────────────────────────
     from genesis.runtime import GenesisRuntime
+
     rt = GenesisRuntime.instance()
     if rt.db is not None:
         await _run_maintenance_gc(rt.db)
@@ -266,10 +291,14 @@ async def schedule_analytical(sched: SchedulerContext) -> None:
     for task_type, priority, drive in analytical_tasks:
         active = await sched._queue.active_by_type(task_type)
         if active == 0 and not await sched._recently_completed(
-            task_type, sched._analytical_hours,
+            task_type,
+            sched._analytical_hours,
         ):
             await sched._queue.enqueue(
-                task_type, ComputeTier.FREE_API, priority, drive,
+                task_type,
+                ComputeTier.FREE_API,
+                priority,
+                drive,
             )
     # prompt_effectiveness runs as a 3-step pipeline.
     await sched.schedule_pipeline("prompt_effectiveness")
@@ -283,9 +312,7 @@ async def schedule_wing_audit(sched: SchedulerContext) -> None:
 
     active = await sched._queue.active_by_type(TaskType.WING_AUDIT)
     if active == 0:
-        await sched._queue.enqueue(
-            TaskType.WING_AUDIT, ComputeTier.FREE_API, 0.4, "competence"
-        )
+        await sched._queue.enqueue(TaskType.WING_AUDIT, ComputeTier.FREE_API, 0.4, "competence")
 
 
 @job_guard("schedule_cc_memory_staleness", "CC memory staleness scheduling failed")
@@ -324,7 +351,8 @@ async def schedule_pipeline(sched: SchedulerContext, pipeline_name: str) -> str 
     # Uses the last step because that's when the full pipeline finished.
     last_step = defn.steps[-1]
     if await sched._recently_completed(
-        last_step.task_type, sched._analytical_hours,
+        last_step.task_type,
+        sched._analytical_hours,
     ):
         return None
 

--- a/src/genesis/surplus/jobs/gitnexus.py
+++ b/src/genesis/surplus/jobs/gitnexus.py
@@ -100,7 +100,7 @@ async def run_gitnexus_reindex() -> None:
         with contextlib.suppress(Exception):
             GenesisRuntime.instance().record_job_failure(
                 "gitnexus_reindex",
-                str(exc),
+                exc=exc,
             )
 
 

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -15,6 +15,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from genesis.observability.failure_details import failure_details
 from genesis.observability.types import Severity, Subsystem
 from genesis.surplus.jobs._guard import record_failure, record_success
 
@@ -82,6 +83,7 @@ async def run_recon_gather(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.ERROR,
                 "recon_gather.failed",
                 "Recon gather failed with exception",
+                **failure_details(exc=exc),
             )
         record_failure("recon_gather", str(exc))
 
@@ -108,6 +110,7 @@ async def run_model_intelligence(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.ERROR,
                 "model_intelligence.failed",
                 "Model intelligence scan failed",
+                **failure_details(exc=exc),
             )
         record_failure("model_intelligence", str(exc))
 
@@ -134,6 +137,7 @@ async def run_skill_security_scan(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.ERROR,
                 "skill_security_scan.failed",
                 "Skill-security scan failed",
+                **failure_details(exc=exc),
             )
         record_failure("skill_security_scan", str(exc))
 
@@ -167,6 +171,7 @@ async def run_github_discovery(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.ERROR,
                 "github_discovery.failed",
                 "GitHub Discovery failed",
+                **failure_details(exc=exc),
             )
         record_failure("github_discovery", str(exc))
 
@@ -212,6 +217,7 @@ async def run_models_md_synthesis(sched: SchedulerContext) -> None:
                 Subsystem.RECON, Severity.ERROR,
                 "models_md_synthesis.failed",
                 "Models.md synthesis failed",
+                **failure_details(exc=exc),
             )
         record_failure("models_md_synthesis", str(exc))
 
@@ -320,5 +326,6 @@ async def run_memory_extraction(sched: SchedulerContext) -> None:
                 Subsystem.SURPLUS, Severity.ERROR,
                 "memory_extraction.failed",
                 "Memory extraction failed with exception",
+                **failure_details(exc=exc),
             )
         record_failure("memory_extraction", str(exc))

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -96,7 +96,10 @@ class SurplusScheduler:
         self._compute = compute_availability
         self._executor = executor or StubExecutor()
         self._brainstorm_runner = brainstorm_runner or BrainstormRunner(
-            db, queue, executor=self._executor, clock=clock,
+            db,
+            queue,
+            executor=self._executor,
+            clock=clock,
         )
         self._dispatch_interval = dispatch_interval_minutes
         self._brainstorm_interval = brainstorm_check_hours
@@ -170,6 +173,7 @@ class SurplusScheduler:
         # Late-registration: if scheduler already started, add the job now
         if self._scheduler.running and not self._scheduler.get_job("schedule_fresh_session_test"):
             from apscheduler.triggers.cron import CronTrigger
+
             self._scheduler.add_job(
                 self._schedule_fresh_session_test,
                 CronTrigger(day_of_week="sat", hour=9, timezone=user_timezone()),
@@ -263,6 +267,7 @@ class SurplusScheduler:
         # restart.  Config param brainstorm_check_hours is unused since this
         # conversion; the fixed schedule replaces the interval cadence.
         from apscheduler.triggers.cron import CronTrigger
+
         self._scheduler.add_job(
             self.brainstorm_check,
             CronTrigger(hour="1,13", minute=0, timezone=user_timezone()),
@@ -351,6 +356,7 @@ class SurplusScheduler:
             )
         # Dream cycle: weekly Sunday 4am — clustering + worklist persist
         from apscheduler.triggers.cron import CronTrigger
+
         self._scheduler.add_job(
             self.run_dream_cycle,
             CronTrigger(day_of_week="sun", hour=4, timezone=user_timezone()),
@@ -450,6 +456,7 @@ class SurplusScheduler:
             # restarts more frequently.  Fixed hour ensures the batch runs
             # daily regardless of restart cadence.
             from apscheduler.triggers.cron import CronTrigger
+
             self._scheduler.add_job(
                 self.schedule_j9_eval_batch,
                 CronTrigger(hour=3, timezone=user_timezone()),  # 3 AM local daily
@@ -493,6 +500,7 @@ class SurplusScheduler:
         # pattern (see genesis.awareness.loop._on_scheduler_job_event).
         try:
             from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_MISSED
+
             self._job_event_loop = asyncio.get_running_loop()
             self._scheduler.add_listener(
                 self._on_scheduler_job_event,
@@ -507,6 +515,7 @@ class SurplusScheduler:
         # timestamps from the previous process and trigger a restart.
         try:
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             rt.record_job_success("surplus_dispatch")
             logger.info("Surplus scheduler: initial heartbeat emitted")
@@ -517,6 +526,7 @@ class SurplusScheduler:
         try:
             from genesis.memory.dream_cycle import check_incomplete_runs
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             if rt.db is not None:
                 await check_incomplete_runs(rt.db)
@@ -529,7 +539,8 @@ class SurplusScheduler:
         # and don't count the restart toward the task's retry budget.
         try:
             requeued, _ = await self._queue.recover_stuck(
-                older_than_hours=0, bump_attempt=False,
+                older_than_hours=0,
+                bump_attempt=False,
             )
             if requeued:
                 logger.info("Boot sweep: reclaimed %d orphaned running task(s)", requeued)
@@ -553,7 +564,8 @@ class SurplusScheduler:
         await self.run_gitnexus_strip()
         logger.info(
             "Surplus scheduler started (dispatch=%dm, brainstorm=%dh)",
-            self._dispatch_interval, self._brainstorm_interval,
+            self._dispatch_interval,
+            self._brainstorm_interval,
         )
 
     async def stop(self) -> None:
@@ -581,7 +593,8 @@ class SurplusScheduler:
             )
         except Exception:
             logger.warning(
-                "Failed to hand off scheduler event for %s", job_id,
+                "Failed to hand off scheduler event for %s",
+                job_id,
                 exc_info=True,
             )
 
@@ -610,6 +623,7 @@ class SurplusScheduler:
         # Record failure in job health tracking.
         try:
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             rt.record_job_failure(
                 job_id,
@@ -622,6 +636,7 @@ class SurplusScheduler:
         # Emit to event bus for dashboard / alerting
         try:
             from genesis.runtime import GenesisRuntime
+
             rt = GenesisRuntime.instance()
             if rt.event_bus:
                 await rt.event_bus.emit(
@@ -647,7 +662,9 @@ class SurplusScheduler:
         await gate_jobs.brainstorm_check(self)
 
     async def _recently_completed(
-        self, task_type, cooldown_hours: int | float,
+        self,
+        task_type,
+        cooldown_hours: int | float,
     ) -> bool:
         """Return ``True`` if *task_type* completed within *cooldown_hours*."""
         return await gate_jobs.recently_completed(self, task_type, cooldown_hours)
@@ -761,6 +778,7 @@ class SurplusScheduler:
         """Scheduled dispatch callback."""
         try:
             from genesis.runtime import GenesisRuntime
+
             if GenesisRuntime.instance().paused:
                 logger.debug("Surplus dispatch skipped (Genesis paused)")
                 return
@@ -772,6 +790,7 @@ class SurplusScheduler:
             # (sequential task execution + intake pipeline overhead).
             try:
                 from genesis.runtime import GenesisRuntime
+
                 GenesisRuntime.instance().record_job_success("surplus_dispatch")
             except Exception:
                 pass
@@ -786,20 +805,26 @@ class SurplusScheduler:
 
             if self._event_bus:
                 await self._event_bus.emit(
-                    Subsystem.SURPLUS, Severity.DEBUG,
-                    "heartbeat", "surplus_scheduler dispatch completed",
+                    Subsystem.SURPLUS,
+                    Severity.DEBUG,
+                    "heartbeat",
+                    "surplus_scheduler dispatch completed",
                 )
         except Exception as exc:
             logger.exception("Surplus dispatch loop failed")
             if self._event_bus:
                 await self._event_bus.emit(
-                    Subsystem.SURPLUS, Severity.ERROR,
+                    Subsystem.SURPLUS,
+                    Severity.ERROR,
                     "dispatch.failed",
                     "Surplus dispatch loop failed with exception",
+                    **failure_details(exc=exc),
                 )
             try:
                 from genesis.runtime import GenesisRuntime
-                GenesisRuntime.instance().record_job_failure("surplus_dispatch", exc=exc)
+
+                GenesisRuntime.instance().record_job_failure(
+                    "surplus_dispatch", exc=exc, emit_event=False
+                )
             except Exception:
                 pass
-

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -799,7 +799,7 @@ class SurplusScheduler:
                 )
             try:
                 from genesis.runtime import GenesisRuntime
-                GenesisRuntime.instance().record_job_failure("surplus_dispatch", str(exc))
+                GenesisRuntime.instance().record_job_failure("surplus_dispatch", exc=exc)
             except Exception:
                 pass
 

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiosqlite
 import pytest
 
-from genesis.db.schema import TABLES
+from genesis.db.schema import TABLES, create_all_tables
 from genesis.ego.cadence import _RECENCY_TIERS, EgoCadenceManager
 from genesis.ego.session import CycleBlockedError
 from genesis.ego.types import EgoConfig, EgoCycle
@@ -136,26 +136,10 @@ class TestCadenceLifecycle:
 # Restart-safe boot first-fire (B1): anchor ego_cycle to job_health.last_success
 # ---------------------------------------------------------------------------
 
-_JOB_HEALTH_DDL = """
-    CREATE TABLE IF NOT EXISTS job_health (
-        job_name         TEXT PRIMARY KEY,
-        last_run         TEXT,
-        last_success     TEXT,
-        last_failure     TEXT,
-        last_error       TEXT,
-        consecutive_failures INTEGER NOT NULL DEFAULT 0,
-        total_runs       INTEGER NOT NULL DEFAULT 0,
-        total_successes  INTEGER NOT NULL DEFAULT 0,
-        total_failures   INTEGER NOT NULL DEFAULT 0,
-        updated_at       TEXT NOT NULL,
-        error_type       TEXT
-    )
-"""
-
 
 async def _seed_last_success(conn, job_name: str, last_success: datetime) -> None:
     """Create job_health (not in TABLES) and seed one ego's last_success row."""
-    await conn.execute(_JOB_HEALTH_DDL)
+    await create_all_tables(conn)
     iso = last_success.isoformat()
     await conn.execute(
         "INSERT INTO job_health "
@@ -195,7 +179,7 @@ class TestBootFirstFire:
 
     async def test_no_row_returns_none(self, cadence, mock_session, db):
         mock_session._source_tag = "genesis_ego_cycle"
-        await db.execute(_JOB_HEALTH_DDL)  # table exists, no row for this ego
+        await create_all_tables(db)  # table exists, no row for this ego
         await db.commit()
         assert await cadence._compute_boot_first_fire() is None
 
@@ -1532,7 +1516,11 @@ class TestCapabilityImprovement:
         assert cap_cadence._signal_queue.empty()
 
     async def test_job_registered_for_genesis_ego(
-        self, mock_session, config, mock_idle_detector, cap_db,
+        self,
+        mock_session,
+        config,
+        mock_idle_detector,
+        cap_db,
     ):
         """start() registers the ego_capability_improvement job for the genesis ego."""
         mock_session._source_tag = "genesis_ego_cycle"
@@ -1550,7 +1538,11 @@ class TestCapabilityImprovement:
             await mgr.stop()
 
     async def test_job_not_registered_for_user_ego(
-        self, mock_session, config, mock_idle_detector, cap_db,
+        self,
+        mock_session,
+        config,
+        mock_idle_detector,
+        cap_db,
     ):
         """The user ego cadence does NOT register the capability scanner job."""
         mock_session._source_tag = "user_ego_cycle"
@@ -1876,10 +1868,17 @@ class TestQuietHours:
         return _dt.datetime(2026, 1, 1, hour, 0, tzinfo=_dt.UTC)
 
     def test_suppress_mode_skips_entire_window(
-        self, db, mock_session, mock_idle_detector, monkeypatch,
+        self,
+        db,
+        mock_session,
+        mock_idle_detector,
+        monkeypatch,
     ):
         mgr = self._mgr(
-            db, mock_session, mock_idle_detector, quiet_hours_mode="suppress",
+            db,
+            mock_session,
+            mock_idle_detector,
+            quiet_hours_mode="suppress",
         )
         now = self._at(2)
         monkeypatch.setattr("genesis.ego.cadence._local_now", lambda tz: now)
@@ -1891,7 +1890,11 @@ class TestQuietHours:
         assert mgr._quiet_hours_suppresses_tick() is True
 
     def test_floor_mode_is_default_and_throttles(
-        self, db, mock_session, mock_idle_detector, monkeypatch,
+        self,
+        db,
+        mock_session,
+        mock_idle_detector,
+        monkeypatch,
     ):
         mgr = self._mgr(db, mock_session, mock_idle_detector)  # default mode
         assert mgr._config.quiet_hours_mode == "floor"
@@ -1904,12 +1907,19 @@ class TestQuietHours:
         assert mgr._quiet_hours_suppresses_tick() is False
 
     def test_suppress_mode_reschedules_past_window(
-        self, db, mock_session, mock_idle_detector, monkeypatch,
+        self,
+        db,
+        mock_session,
+        mock_idle_detector,
+        monkeypatch,
     ):
         from unittest.mock import MagicMock
 
         mgr = self._mgr(
-            db, mock_session, mock_idle_detector, quiet_hours_mode="suppress",
+            db,
+            mock_session,
+            mock_idle_detector,
+            quiet_hours_mode="suppress",
         )
         now = self._at(2)  # inside the 23→7 window
         monkeypatch.setattr("genesis.ego.cadence._local_now", lambda tz: now)

--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -49,13 +49,19 @@ class TestCampaignTick:
 
         # Burn through the budget
         from genesis.db.crud import campaigns as crud
+
         await crud.create_run(
-            db, id="r-budget", campaign_id=campaign_in_db,
+            db,
+            id="r-budget",
+            campaign_id=campaign_in_db,
             started_at=datetime.now(UTC).isoformat(),
             trigger_type="scheduled",
         )
         await crud.complete_run(
-            db, "r-budget", outcome="success", cost_usd=5.0,
+            db,
+            "r-budget",
+            outcome="success",
+            cost_usd=5.0,
             finished_at=datetime.now(UTC).isoformat(),
         )
 
@@ -78,12 +84,14 @@ class TestCampaignTick:
         # Write a minimal strategy doc
         import os
         import tempfile
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
             f.write("# Test Strategy\nPost something useful.\n")
             strategy_path = f.name
 
         try:
             from genesis.db.crud import campaigns as crud
+
             await crud.update_campaign(db, campaign_in_db, strategy_doc_path=strategy_path)
 
             result = await runner.campaign_tick(campaign_in_db)
@@ -110,6 +118,7 @@ class TestCampaignTick:
 
         # Set state to indicate a pending session
         from genesis.db.crud import campaigns as crud
+
         state = {"posts_today": 0, "total_posts": 0, "_pending_session_id": "sess-old"}
         await crud.update_campaign_state(db, campaign_in_db, json.dumps(state))
 
@@ -135,6 +144,7 @@ class TestCampaignTick:
 
         # Set state with a completed pending session
         from genesis.db.crud import campaigns as crud
+
         state = {
             "posts_today": 0,
             "total_posts": 0,
@@ -145,17 +155,22 @@ class TestCampaignTick:
 
         # Create the pending run in DB
         await crud.create_run(
-            db, id="run-done", campaign_id=campaign_in_db,
-            started_at="2026-06-07T00:30:00Z", trigger_type="scheduled",
+            db,
+            id="run-done",
+            campaign_id=campaign_in_db,
+            started_at="2026-06-07T00:30:00Z",
+            trigger_type="scheduled",
         )
 
         # Mock session as completed with structured output
         completed_result = {
             "success": True,
-            "output_text": json.dumps({
-                "state_updates": {"posts_today": 1, "total_posts": 1},
-                "summary": "Posted to #dev-discussion",
-            }),
+            "output_text": json.dumps(
+                {
+                    "state_updates": {"posts_today": 1, "total_posts": 1},
+                    "summary": "Posted to #dev-discussion",
+                }
+            ),
             "cost_usd": 0.03,
         }
 
@@ -164,6 +179,7 @@ class TestCampaignTick:
 
             import os
             import tempfile
+
             with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
                 f.write("# Test\n")
                 strategy_path = f.name
@@ -287,9 +303,10 @@ class TestTickWrapperJobHealth:
             await runner._tick_wrapper("camp-1", "campaign_test")
 
         inst.record_job_failure.assert_called_once()
-        job_id, err = inst.record_job_failure.call_args[0][:2]
-        assert job_id == "campaign_test"
-        assert "boom" in err
+        call = inst.record_job_failure.call_args
+        assert call.args[0] == "campaign_test"
+        # The exception is now threaded through (exc=), not pre-stringified.
+        assert "boom" in str(call.kwargs["exc"])
         inst.record_job_success.assert_not_called()
 
     @pytest.mark.anyio

--- a/tests/test_runtime/test_job_failure_funnel.py
+++ b/tests/test_runtime/test_job_failure_funnel.py
@@ -1,0 +1,136 @@
+"""The reflex funnel — record_job_failure emits a throttled job.failed event.
+
+Background-job exceptions were, for months, written only to the job_health table
+and never to the event bus, so the reflex arc (a bus subscriber) could not see
+the single largest class of internal Genesis defects. record_job_failure now
+emits a job.failed event when — and only when — an exception caused the failure,
+sharing the existing streak-onset/hourly-heartbeat throttle.
+
+These tests pin the four behaviours that keep the funnel safe: it fires on the
+exception path, it stays silent on the semantic path and when a caller opts out,
+it respects the throttle, and it never raises (a broken emit must never stop the
+job_health record).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+import pytest
+
+from genesis.observability.events import GenesisEventBus
+from genesis.observability.types import Severity
+from genesis.runtime._job_health import record_job_failure
+
+
+def _make_rt(bus):
+    """A minimal runtime stand-in with just the attributes the funnel reads."""
+    return types.SimpleNamespace(
+        _job_health={},
+        _event_bus=bus,
+        _job_retry_registry=None,
+        _db=None,  # _append_job_run_event no-ops without a DB
+        _persist_job_health=lambda *a, **k: None,
+    )
+
+
+async def _collect(bus):
+    seen: list = []
+
+    async def _handler(ev):
+        seen.append(ev)
+
+    bus.subscribe(_handler, min_severity=Severity.ERROR)
+    return seen
+
+
+def _boom() -> ValueError:
+    try:
+        raise ValueError("kaboom")
+    except ValueError as exc:
+        return exc
+
+
+@pytest.mark.asyncio
+async def test_exception_path_emits_job_failed_with_type_and_frames():
+    bus = GenesisEventBus()
+    seen = await _collect(bus)
+    rt = _make_rt(bus)
+
+    record_job_failure(rt, "prune_job", exc=_boom())
+    await asyncio.sleep(0.05)  # let emit_sync's scheduled task run
+
+    assert len(seen) == 1
+    ev = seen[0]
+    assert ev.event_type == "job.failed"
+    assert ev.details["task_name"] == "prune_job"
+    assert ev.details["error_type"] == "ValueError"
+    assert ev.details["error_frames"]  # non-empty
+    # job_health carries the typed error too
+    assert rt._job_health["prune_job"]["error_type"] == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_semantic_path_does_not_emit():
+    bus = GenesisEventBus()
+    seen = await _collect(bus)
+    rt = _make_rt(bus)
+
+    record_job_failure(rt, "quota_job", "429 weekly limit")  # no exc
+    await asyncio.sleep(0.05)
+
+    assert seen == []
+    # ...but a semantic failure still records to job_health (no error_type)
+    assert rt._job_health["quota_job"]["error_type"] is None
+
+
+@pytest.mark.asyncio
+async def test_emit_event_false_suppresses_funnel():
+    """Callers that emit their own domain .failed opt out to avoid double-count."""
+    bus = GenesisEventBus()
+    seen = await _collect(bus)
+    rt = _make_rt(bus)
+
+    record_job_failure(rt, "sched_job", exc=_boom(), emit_event=False)
+    await asyncio.sleep(0.05)
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_throttle_suppresses_repeat_within_the_hour():
+    bus = GenesisEventBus()
+    seen = await _collect(bus)
+    rt = _make_rt(bus)
+
+    record_job_failure(rt, "flaky_job", exc=_boom())  # streak onset → emits
+    record_job_failure(rt, "flaky_job", exc=_boom())  # same hour → throttled
+    await asyncio.sleep(0.05)
+
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_bare_runtime_without_event_bus_never_raises():
+    """A runtime built via __new__ has no _event_bus attribute — must not raise."""
+    rt = types.SimpleNamespace(
+        _job_health={},
+        _job_retry_registry=None,
+        _db=None,
+        _persist_job_health=lambda *a, **k: None,
+    )  # note: NO _event_bus attribute at all
+
+    # Must not raise; job_health still recorded.
+    record_job_failure(rt, "bare_job", exc=_boom())
+    assert rt._job_health["bare_job"]["error_type"] == "ValueError"
+
+
+def test_job_failed_is_reflex_owned_so_ego_defers_it():
+    """The ego must NOT spin a reactive cycle per job failure — reflex owns it."""
+    from genesis.runtime.init.ego import _is_reflex_owned_event
+
+    assert _is_reflex_owned_event("job.failed") is True
+    assert _is_reflex_owned_event("task.failed") is True
+    # a normal ERROR event is still routed to the ego
+    assert _is_reflex_owned_event("some.other_error") is False

--- a/tests/test_runtime/test_job_health.py
+++ b/tests/test_runtime/test_job_health.py
@@ -15,25 +15,9 @@ import asyncio
 
 import aiosqlite
 
+from genesis.db.schema import create_all_tables
 from genesis.runtime import GenesisRuntime
 from genesis.runtime._job_health import clear_stale_job_failures
-
-# Mirror of the job_health schema (src/genesis/db/schema/_migrations.py).
-_CREATE_JOB_HEALTH = """
-    CREATE TABLE IF NOT EXISTS job_health (
-        job_name         TEXT PRIMARY KEY,
-        last_run         TEXT,
-        last_success     TEXT,
-        last_failure     TEXT,
-        last_error       TEXT,
-        consecutive_failures INTEGER NOT NULL DEFAULT 0,
-        total_runs       INTEGER NOT NULL DEFAULT 0,
-        total_successes  INTEGER NOT NULL DEFAULT 0,
-        total_failures   INTEGER NOT NULL DEFAULT 0,
-        updated_at       TEXT NOT NULL,
-        error_type       TEXT
-    )
-"""
 
 
 async def _drain_pending() -> None:
@@ -64,7 +48,7 @@ async def _fetch(db: aiosqlite.Connection, job_name: str):
 async def test_success_clears_persisted_failure():
     """A job that fails then succeeds must not retain a stale last_failure/last_error."""
     async with aiosqlite.connect(":memory:") as db:
-        await db.execute(_CREATE_JOB_HEALTH)
+        await create_all_tables(db)
         await db.commit()
         rt = _make_runtime(db)
 
@@ -96,7 +80,7 @@ async def test_failure_path_unbroken_and_success_preserved():
     real failure, while COALESCE on last_success still preserves a prior success.
     """
     async with aiosqlite.connect(":memory:") as db:
-        await db.execute(_CREATE_JOB_HEALTH)
+        await create_all_tables(db)
         await db.commit()
         rt = _make_runtime(db)
 
@@ -120,7 +104,7 @@ async def test_clear_stale_failures_clears_persisted_failure():
     signal recovery; it persists via the same UPSERT and must not retain stale failures.
     """
     async with aiosqlite.connect(":memory:") as db:
-        await db.execute(_CREATE_JOB_HEALTH)
+        await create_all_tables(db)
         await db.commit()
         rt = _make_runtime(db)
 

--- a/tests/test_runtime/test_job_run_events.py
+++ b/tests/test_runtime/test_job_run_events.py
@@ -15,34 +15,8 @@ from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
+from genesis.db.schema import create_all_tables
 from genesis.runtime import GenesisRuntime
-
-_CREATE_JOB_HEALTH = """
-    CREATE TABLE IF NOT EXISTS job_health (
-        job_name         TEXT PRIMARY KEY,
-        last_run         TEXT,
-        last_success     TEXT,
-        last_failure     TEXT,
-        last_error       TEXT,
-        consecutive_failures INTEGER NOT NULL DEFAULT 0,
-        total_runs       INTEGER NOT NULL DEFAULT 0,
-        total_successes  INTEGER NOT NULL DEFAULT 0,
-        total_failures   INTEGER NOT NULL DEFAULT 0,
-        updated_at       TEXT NOT NULL,
-        error_type       TEXT
-    )
-"""
-_CREATE_JOB_RUN_EVENTS = """
-    CREATE TABLE IF NOT EXISTS job_run_events (
-        id             TEXT PRIMARY KEY,
-        job_name       TEXT NOT NULL,
-        status         TEXT NOT NULL CHECK (status IN ('success', 'failed')),
-        run_started_at TEXT,
-        duration_ms    INTEGER,
-        error          TEXT,
-        recorded_at    TEXT NOT NULL DEFAULT (datetime('now'))
-    )
-"""
 
 
 async def _drain_pending() -> None:
@@ -70,8 +44,7 @@ async def _events(db: aiosqlite.Connection, job_name: str) -> list[tuple]:
 
 async def _setup() -> aiosqlite.Connection:
     db = await aiosqlite.connect(":memory:")
-    await db.execute(_CREATE_JOB_HEALTH)
-    await db.execute(_CREATE_JOB_RUN_EVENTS)
+    await create_all_tables(db)
     await db.commit()
     return db
 
@@ -201,7 +174,10 @@ async def test_run_event_write_failure_never_throws():
     """A missing table (write path broken) must not propagate into the ~62 callers."""
     db = await aiosqlite.connect(":memory:")
     try:
-        await db.execute(_CREATE_JOB_HEALTH)  # job_health exists, job_run_events does NOT
+        # job_health exists (full canonical schema), job_run_events does NOT —
+        # the write path is deliberately broken to prove failures are swallowed.
+        await create_all_tables(db)
+        await db.execute("DROP TABLE job_run_events")
         await db.commit()
         rt = _make_runtime(db)
         # Must not raise despite the missing job_run_events table.

--- a/tests/test_runtime/test_learning_retention_jobs.py
+++ b/tests/test_runtime/test_learning_retention_jobs.py
@@ -31,7 +31,7 @@ class _StubRT:
     def record_job_success(self, *_a):
         pass
 
-    def record_job_failure(self, *_a):
+    def record_job_failure(self, *_a, **_kw):
         pass
 
 

--- a/tests/test_runtime/test_process_reaper.py
+++ b/tests/test_runtime/test_process_reaper.py
@@ -141,8 +141,8 @@ class _FakeRT:
     def record_job_success(self, name):
         self.successes.append(name)
 
-    def record_job_failure(self, name, err):
-        self.failures.append((name, err))
+    def record_job_failure(self, name, error=None, *, exc=None, error_type=None, emit_event=True):
+        self.failures.append((name, error if error is not None else (str(exc) if exc else None)))
 
 
 def _patch_io(
@@ -425,7 +425,7 @@ class _StubRT:
     def record_job_success(self, *_a):
         pass
 
-    def record_job_failure(self, *_a):
+    def record_job_failure(self, *_a, **_kw):
         pass
 
 


### PR DESCRIPTION
## Summary

Background-job exceptions were, for months, written only to the `job_health`
table and never to the event bus — so Genesis's self-bug-detection (the reflex
arc, a bus subscriber) could not see the single largest class of its own
internal defects. This PR bridges that gap and makes those failures diagnosable.

**Dark by design:** `job.failed` is emitted now, but reflex intake still drops
non-`task.failed` — widening intake to consume it is a separate, gated follow-up.

## What changed

- **The funnel.** `record_job_failure` gains an `exc=` parameter. When an
  exception caused the failure it derives the typed error/frames from it AND
  emits a throttled `job.failed` event (via the existing `emit_sync` relay,
  sharing the streak-onset/hourly run-event throttle → bounded ~24/day/job).
  Semantic/no-exception failures stay off the bus (an external blocker is not a
  Genesis bug the arc can act on). The emit is fully fire-and-forget — a broken
  emit can never stop the `job_health` write. `job.failed` is added to the ego's
  reflex-owned carve-out so it never spins a reactive ego cycle per failure.

- **Emitter sweep.** 53 background-job failure sites now thread the caught
  exception (`exc=exc`) instead of a stringified/blank message, and 9
  exception-driven domain `.failed` events are enriched with typed
  error+frames. Double-emit is avoided where a site emits its own domain event
  AND records job health (`emit_event=False`). Semantic/infra emitters
  (`guardian.*`, provider exhaustion, LLM output-quality gates) are correctly
  left alone.

- **Test hardening.** The three test fixtures that mirrored the full
  `job_health` schema now build it via the canonical `create_all_tables()`, so a
  future column add can't drift them out of sync again; stale test fakes are
  aligned to the new signature.

## Verification

- New unit tests pin the funnel contract (exception path emits with
  type+frames; semantic path and `emit_event=False` stay silent; the throttle
  suppresses repeats; a bare runtime never raises; `job.failed` is reflex-owned).
- Proven end-to-end against a live event bus.
- `ruff` clean; targeted tests across every changed module green.

Closes the blind-emitter and test-DDL follow-ups. One site (ego cadence job
recording) is deferred — it takes a pre-built string, so threading the
exception needs an internal signature change; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
