### PR TITLE
feat(observability): wire 90-day retention for the events bus table (PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Genesis now keeps its own internal event log from growing without bound.**
+  The observability event stream — the record of everything Genesis notices and
+  does — was the last high-volume table with no cleanup, growing steadily on
+  disk. A daily maintenance pass now trims events older than 90 days, matching
+  the retention already applied to Genesis's other internal logs. No visible
+  change to day-to-day use; it just stops a slow disk leak.
 - **Proactive memory recall holds up better when several sessions are active at
   once.** When multiple Claude Code sessions run side by side, each prompt's
   memory recall used to spend much of its time-budget on bookkeeping (usage

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -538,7 +538,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 302066ad 2026-07-23
+verified: ca875c4b 2026-07-24
 ```
 
 - **PR-watch inline surface (2026-07-21)**: a SessionStart hook

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -614,7 +614,11 @@ verified: 302066ad 2026-07-23
   failure on streak onset + hourly heartbeat — so a stuck sub-hourly poll costs
   ~24 rows/day. `duration_ms` is honest-or-NULL (only from an explicit
   `record_job_start` marker; never derived from `last_run`). 90-day prune via
-  `_wire_drip_retention_jobs`. **Failure payloads (2026-07-23):** the three
+  `_wire_drip_retention_jobs` — which (2026-07-24) also prunes the observability
+  `events` bus table itself (`events_prune`, the last high-volume table with no
+  retention: 45k+ rows / ~108d). `crud.events.prune` takes an ISO cutoff, not
+  `days=`; the DELETE's lexical `timestamp < cutoff` is chronological because
+  every `events.timestamp` is a UTC isoformat. **Failure payloads (2026-07-23):** the three
   scheduler emitters (reflection, outreach, surplus) thread the exception into
   `observability/failure_details.py`, which sets `error_type` **IFF** a real
   exception caused the failure — a semantic failure (external blocker, e.g. a

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -191,6 +191,38 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
         misfire_grace_time=3600,
     )
 
+    async def _prune_events() -> None:
+        # The observability event bus is the ONLY high-volume table with no
+        # retention (45k+ rows / ~108d, growing ~12x month-over-month). Unlike
+        # the sibling prunes, crud.events.prune takes an ISO cutoff, not days=;
+        # every events.timestamp is stored as UTC isoformat (…+00:00), so the
+        # DELETE's lexical `timestamp < cutoff` is a correct chronological
+        # comparison. Consumers only ever read recent rows (ORDER BY timestamp
+        # DESC LIMIT), so a 90-day window breaks nothing.
+        if rt._db is None:
+            return
+        try:
+            from datetime import timedelta
+
+            from genesis.db.crud import events as _ev
+
+            cutoff = (datetime.now(UTC) - timedelta(days=90)).isoformat()
+            removed = await _ev.prune(rt._db, older_than=cutoff)
+            rt.record_job_success("events_prune")
+            if removed:
+                logger.info("events prune: removed %d rows (>90d)", removed)
+        except Exception as exc:
+            rt.record_job_failure("events_prune", exc=exc)
+            logger.exception("events prune failed")
+
+    scheduler.add_job(
+        _prune_events,
+        CronTrigger(hour=5, minute=50, timezone=user_timezone()),
+        id="events_prune",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
     async def _voice_hygiene() -> None:
         # Three observable-state duties (channels/voice/hygiene.py):
         # transcript files past the 1-year retention, legacy one-blob voice

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -217,7 +217,9 @@ def _wire_drip_retention_jobs(scheduler, rt) -> None:
 
     scheduler.add_job(
         _prune_events,
-        CronTrigger(hour=5, minute=50, timezone=user_timezone()),
+        # 06:00 — the drip slots 05:00–05:50 are taken (…graduation 05:40,
+        # voice_hygiene 05:50); a fresh slot avoids two DB-writing jobs at once.
+        CronTrigger(hour=6, minute=0, timezone=user_timezone()),
         id="events_prune",
         max_instances=1,
         misfire_grace_time=3600,

--- a/tests/test_db/test_events_prune.py
+++ b/tests/test_db/test_events_prune.py
@@ -1,0 +1,100 @@
+"""Retention for the observability ``events`` table (crud.events.prune).
+
+The event bus is the one high-volume table with no retention until the
+``events_prune`` drip job (runtime/init/learning.py) was wired. These lock the
+crud it calls: an ISO ``older_than`` cutoff deletes strictly-older rows and
+leaves recent ones, and (with ``event_type``) can scope to one type.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import events
+from genesis.db.schema import create_all_tables
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _db() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await create_all_tables(db)  # canonical events schema — drift-proof
+    return db
+
+
+def _iso(days_ago: float) -> str:
+    return (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+
+
+async def _insert(db, *, days_ago: float, event_type: str = "test.event") -> str:
+    return await events.insert(
+        db,
+        subsystem="health",
+        severity="error",
+        event_type=event_type,
+        message=f"event {days_ago}d ago",
+        timestamp=_iso(days_ago),
+    )
+
+
+async def test_prune_removes_only_older_than_cutoff():
+    db = await _db()
+    try:
+        old = await _insert(db, days_ago=100)
+        recent = await _insert(db, days_ago=10)
+        cutoff = _iso(90)
+
+        removed = await events.prune(db, older_than=cutoff)
+
+        assert removed == 1
+        rows = await events.query(db)
+        ids = {r["id"] for r in rows}
+        assert old not in ids and recent in ids
+    finally:
+        await db.close()
+
+
+async def test_prune_empty_table_is_noop():
+    db = await _db()
+    try:
+        assert await events.prune(db, older_than=_iso(90)) == 0
+    finally:
+        await db.close()
+
+
+async def test_prune_boundary_is_strict_less_than():
+    """A row exactly at the cutoff is NOT pruned (DELETE uses `timestamp < ?`)."""
+    db = await _db()
+    try:
+        cutoff = _iso(90)
+        await events.insert(
+            db,
+            subsystem="health",
+            severity="error",
+            event_type="boundary",
+            message="at cutoff",
+            timestamp=cutoff,
+        )
+        assert await events.prune(db, older_than=cutoff) == 0
+    finally:
+        await db.close()
+
+
+async def test_prune_scoped_to_event_type():
+    db = await _db()
+    try:
+        await _insert(db, days_ago=100, event_type="keep.me")
+        await _insert(db, days_ago=100, event_type="prune.me")
+        cutoff = _iso(90)
+
+        removed = await events.prune(db, older_than=cutoff, event_type="prune.me")
+
+        assert removed == 1
+        remaining = {r["event_type"] for r in await events.query(db)}
+        assert remaining == {"keep.me"}
+    finally:
+        await db.close()

--- a/tests/test_runtime/test_learning_retention_jobs.py
+++ b/tests/test_runtime/test_learning_retention_jobs.py
@@ -1,6 +1,6 @@
 """Registration coverage for the genesis.db drip-table retention jobs (D3).
 
-Locks that ``_wire_drip_retention_jobs`` actually registers all three prune jobs — if an
+Locks that ``_wire_drip_retention_jobs`` actually registers every prune job — if an
 ``add_job`` call were dropped or a job id changed, this fails (the crud prunes themselves
 are covered separately). Uses a real AsyncIOScheduler + a stub runtime; no full runtime init.
 """
@@ -21,6 +21,7 @@ _EXPECTED = (
     "alert_events_prune",
     "deferred_work_prune",
     "graduation_events_prune",
+    "events_prune",
     "voice_hygiene",
 )
 


### PR DESCRIPTION
## Summary

The observability `events` table — the record of everything Genesis notices and
does — was the last high-volume table with **no retention**. `crud.events.prune`
existed with **zero callers**, and the table had grown to 45k+ rows over ~108
days (~12× month-over-month). This wires a bounded 90-day retention.

## What changed

- **`events_prune` drip job** added to `_wire_drip_retention_jobs`
  (`runtime/init/learning.py`) — the in-process retention pattern, mirroring its
  six sibling prunes (execution_traces, cost_events, …). This is DB-table
  retention, so it belongs with its siblings, not in `disk_hygiene.sh`
  (filesystem hygiene).
- `crud.events.prune` takes an **ISO `older_than` cutoff**, not a `days=` arg
  like the siblings; computed from `datetime.now(UTC) - 90d`. Every
  `events.timestamp` is stored as a UTC isoformat (verified: 45,627/45,627 rows
  end in `+00:00`), so the DELETE's lexical `timestamp < cutoff` is a correct
  chronological comparison. Consumers only ever read recent rows (`ORDER BY
  timestamp DESC LIMIT`), so a 90-day window breaks nothing.
- The job records failures via `record_job_failure(exc=exc)`, so the retention
  job's own failures are diagnosable through the failure funnel.

## Verification

- **Tests:** crud prune coverage (strict `<` boundary, `event_type` scope, empty
  no-op) via canonical `create_all_tables()`; `events_prune` added to the
  registration test's expected set.
- **Wired-job E2E:** invoked the actual job closure against a seeded DB — a
  100-day-old event pruned, a 5-day-old event kept, success recorded.
- Registered at 06:00 (the 05:00–05:50 drip slots are taken; `voice_hygiene`
  owns 05:50) so two DB-writing jobs don't fire concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
