### PR TITLE
feat(memory): integrity Phase 0 — make silent recall degradation loud

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -149,6 +149,17 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
 
 ### Common Traps
 
+- **Fail-closed data access.** A data-access boundary must RAISE (or return a
+  clearly-typed "unknown/unavailable") on missing scope or an unavailable
+  dependency — it must NEVER silently return the wrong data, the singleton's
+  data, or an empty result that reads as "all clear". A monitoring/consistency
+  check whose dependency (Qdrant, FTS, a remote) is down reports `unknown`, never
+  `healthy`/`degraded` — a dependency outage that masquerades as data
+  corruption (or as cleanliness) is worse than a loud error. Prefer a helper
+  that raises over one that swallows (the `batch_retrieve_point_ids`-raises vs
+  `batch_retrieve_vectors`-swallows split exists for exactly this). Origin: the
+  home-anchored-DB reads that silently returned no data from an empty worktree
+  path, and the memory-integrity checker (2026-07).
 - **Ego sessions are ACTIVE.** `src/genesis/ego/` is live (v3.0a11).
   Two egos: user ego (CEO, Opus) and Genesis ego (COO, Sonnet). Both
   run on adaptive cadence via the awareness loop. Changes here are
@@ -334,6 +345,17 @@ Verify before any commit:
 - `git status --short` — check untracked files (should be staged or ignored)
 - Review level applied matches the adaptive protocol above
 - Staged files do not include secrets (`secrets.env`, `.env`, credentials)
+- **New-Store Gate (anti-proliferation).** A new persistent store — a DB table, a
+  Qdrant collection, a file-plane under `~/.genesis/` — needs a written
+  justification for why an existing store cannot hold it, plus a note on how it
+  stays consistent with related stores (and its retention + backup path). The
+  memory subsystem already sprawls across ~9 logical systems / 3 physical planes
+  because this gate did not exist; a table that "felt cleaner" is how store #10
+  is born. Reuse an existing store or an existing convention (e.g. the
+  `~/.genesis/eval/golden/` install-local golden-set convention, #1143) unless
+  the justification is real. Prefer NOT reusing a store whose SEMANTICS differ
+  (don't shoehorn a store-health row into the model-eval `eval_runs` table just
+  because it is "a table that exists").
 - **Private-data scan before every push (public repo).** Grep the ENTIRE diff
   (`git diff origin/main...HEAD`) for private/identifying data — real names,
   company/product names, emails, IPs, private career/project specifics, verbatim
@@ -393,6 +415,17 @@ defaults, or tests. Resolve repo paths via `genesis.env.repo_root()` /
 (`gh repo view --json nameWithOwner`) — a configured slug can name a
 real-but-wrong repo and return plausible stale data. Shipped config defaults
 must work on a fresh install with ZERO overlay.
+
+**Tenant-neutral, not tenant-shaped.** Genesis is a single-user sovereign
+system. Build clean single-user code; do NOT pre-genericise for multi-tenancy —
+no `tenant_id` columns, ACL tables, or context objects that always resolve to
+one identity — absent a committed multi-tenant requirement. Premature
+genericisation taxes every change with abstraction for a customer that may never
+exist, and the reliability work that WOULD precede multi-tenancy (a fail-closed
+data boundary, consolidated stores, provenance) is worth doing on its own
+single-user merits and makes the eventual retrofit easier as a side effect.
+When that requirement lands, tenancy is a well-understood retrofit — not
+insurance to carry now.
 
 **Deploy-path answer required — "how does this reach other installs?"**
 Every PR must have an answer for both an EXISTING install and a FRESH clone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now notices when its own memory quietly degrades.** Memory is stored
+  across three backends that have to agree; when they silently drift — a memory
+  that still exists but has become unfindable by search, or a leftover vector
+  with no memory behind it — recall just gets quietly worse, with no error and
+  no signal. Genesis now runs two nightly read-only checks: one verifies the
+  three stores still agree, the other replays a set of known good recalls and
+  watches whether their quality slips over time. If either degrades, it raises a
+  standing alert and shows the state on a new Memory Integrity tile in the
+  dashboard, instead of the rot staying invisible. Detection-only for now
+  (it reports; it does not yet repair), read-only, and off-peak. Controlled by
+  the `memory_integrity` setting (`off` / `passive` / `active`, default
+  `passive`); the recall check stays quiet until you seed it a few known
+  query→memory pairs (`scripts/seed_recall_golden_set.py`).
 - **When a background job fails, Genesis now records what actually broke.** The
   scheduled jobs that quietly keep Genesis healthy — pruning, sweeps, harvests,
   reconnaissance — used to log a failure with the details thrown away, leaving a

--- a/config/memory_integrity.yaml
+++ b/config/memory_integrity.yaml
@@ -1,0 +1,46 @@
+# Memory integrity Phase 0 — "make silence loud".
+#
+# Two scheduled read-only jobs consult this file (merged with
+# ~/.genesis/config/memory_integrity.local.yaml) on EVERY run, so a
+# settings_update("memory_integrity", {...}) or hand edit takes effect at the
+# next scheduled run — no restart:
+#   - memory_consistency_check (03:50 local) — verifies memory_metadata <-> Qdrant
+#     <-> memory_fts agree.
+#   - recall_health_probe (03:20 local) — runs an install-local golden query set
+#     through the real recall pipeline and tracks hit-rate / rank drift.
+#
+# Master switch: false stops both jobs before any work.
+enabled: true
+
+# Mode: off | passive | active
+#   off     — jobs do not run.
+#   passive — (default) run the read-only checks and surface findings (persist +
+#             posture alert + dashboard tile). NEVER repairs. All of Phase 0.
+#   active  — RESERVED for Phase 1 (write-path/reconcile repair). Not yet
+#             implemented; coerced to passive with a warning.
+# An invalid value degrades to passive (still observing) — never a silent off.
+mode: passive
+
+# ── consistency checker ──────────────────────────────────────────────────
+sample_fraction: 1.0        # 1.0 = exact full scan (a few seconds at ~30k memories)
+max_points: 500000          # Qdrant scroll budget; exceeding it sets truncated=1
+severe_min_count: 5         # lying_mirror + fts_invisible >= this → degraded
+pollution_min_count: 50     # ghost/unexpected/deprecated floor
+pollution_fraction: 0.01    # ...or this fraction of the corpus, whichever is higher
+max_offender_sample: 25     # capped offending ids per class stored in the report
+
+# ── recall-health probe ──────────────────────────────────────────────────
+# Golden set is an install-local FILE: ~/.genesis/eval/golden/memory_integrity_recall.jsonl
+# (seed it with `python scripts/seed_recall_golden_set.py --suggest N`).
+probe_limit: 10             # results retrieved per golden query
+max_probes_per_run: 25      # cap golden cases exercised per run
+rerank: true                # exercise the real cross-encoder rerank stage
+rerank_timeout_s: 10.0      # wall-clock bound on rerank per query
+min_golden_for_status: 5    # below this the run is 'unknown' (needs setup), not alarmed
+baseline_window_runs: 7     # trailing non-unknown runs averaged for the drift baseline
+baseline_min_runs: 3        # below this: observation period, no drift verdict yet
+drift_band: 0.2             # degraded if baseline_hit_rate - hit_rate > this
+
+# ── shared ───────────────────────────────────────────────────────────────
+stale_report_days: 3        # no non-unknown consistency report within → staleness alert
+retention_days: 90          # prune reports / probe runs older than this

--- a/scripts/run_memory_integrity_check.py
+++ b/scripts/run_memory_integrity_check.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run the memory consistency check on demand and print the report.
+
+Operator tool for the Phase-0 "make silence loud" spine. Runs the READ-ONLY
+cross-backend consistency check (memory_metadata <-> Qdrant <-> memory_fts)
+against the live DB and prints the classification. Persistence is opt-in
+(``--persist``) — by default this touches nothing.
+
+The recall-health probe is NOT run here: it needs the in-process HybridRetriever
+(server context). This standalone runner covers the consistency half, which is
+enough to eyeball the store-integrity state and time the scan.
+
+Usage:
+    python scripts/run_memory_integrity_check.py                 # print report
+    python scripts/run_memory_integrity_check.py --db /path.db   # a copy
+    python scripts/run_memory_integrity_check.py --persist       # also store a row
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _live_db_path() -> str:
+    """The live genesis.db, home-anchored (GENESIS_DB_PATH override honored).
+
+    NOT genesis_db_path() — that is repo-root-anchored and resolves to an empty
+    <worktree>/data/genesis.db when run from a worktree.
+    """
+    return os.environ.get("GENESIS_DB_PATH") or str(Path.home() / "genesis" / "data" / "genesis.db")
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", default=None, help="DB path (default: the live genesis.db)")
+    parser.add_argument(
+        "--persist",
+        action="store_true",
+        help="also write the report to memory_consistency_reports (default: read-only)",
+    )
+    args = parser.parse_args()
+
+    from genesis.memory import integrity_config
+    from genesis.memory.integrity import run_consistency_check
+    from genesis.qdrant.collections import get_client
+
+    # Home-anchor the live-DB default (env-override aware). NOT the repo-anchored
+    # genesis_db_path(): run from a worktree that resolves to an empty
+    # <worktree>/data/genesis.db and the scan reads no data (a documented trap).
+    db_path = args.db or _live_db_path()
+
+    cfg = integrity_config.load_config()
+    report = await run_consistency_check(
+        db_path=db_path,
+        qdrant_client=get_client(),
+        sample_fraction=integrity_config.knob_float01(cfg, "sample_fraction"),
+        max_points=integrity_config.knob_int(cfg, "max_points"),
+        severe_min_count=integrity_config.knob_int(cfg, "severe_min_count"),
+        pollution_min_count=integrity_config.knob_int(cfg, "pollution_min_count"),
+        pollution_fraction=integrity_config.knob_float01(cfg, "pollution_fraction"),
+        max_offender_sample=integrity_config.knob_int(cfg, "max_offender_sample"),
+    )
+    print(json.dumps(dataclasses.asdict(report), indent=2, default=str))
+
+    if args.persist:
+        import aiosqlite
+
+        from genesis.db.crud import memory_integrity as mi_crud
+
+        conn = await aiosqlite.connect(db_path)
+        try:
+            rid = await mi_crud.insert_consistency_report(
+                conn,
+                status=report.status,
+                counts=report.counts,
+                total_rows=report.total_rows,
+                sampled_rows=report.sampled_rows,
+                sample_fraction=report.sample_fraction,
+                truncated=report.truncated,
+                offender_sample=report.offender_sample,
+                unknown_reason=report.unknown_reason,
+                duration_ms=report.duration_ms,
+            )
+            print(f"\npersisted report id: {rid}", file=sys.stderr)
+        finally:
+            await conn.close()
+
+    # Non-zero exit on degraded so the runner is scriptable in a check.
+    return 1 if report.status == "degraded" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/seed_recall_golden_set.py
+++ b/scripts/seed_recall_golden_set.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Seed / manage the memory-integrity recall golden set.
+
+Curates the install-local golden set the recall-health probe runs against:
+  ~/.genesis/eval/golden/memory_integrity_recall.jsonl
+(committed template lives in the repo; real cases are user data, never committed
+— #1143 convention).
+
+``--suggest`` MINES real recall telemetry (``eval_events`` recall_fired rows) for
+STABLE query->memory pairs: the same top-1 memory was returned across >= 2
+recalls with a healthy score, the memory still exists, and probe-sourced recalls
+are excluded so the set never feeds on itself. Curation is a deliberate human
+act — ``--suggest`` only prints; ``--accept-all`` / ``--add-line`` write.
+
+Usage:
+    python scripts/seed_recall_golden_set.py --suggest 20      # print candidates
+    python scripts/seed_recall_golden_set.py --accept-all --suggest 20   # add them
+    python scripts/seed_recall_golden_set.py --add-line '{"id":"x","query":"...","expected_memory_ids":["mid"]}'
+    python scripts/seed_recall_golden_set.py --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+_GOLDEN = Path.home() / ".genesis" / "eval" / "golden" / "memory_integrity_recall.jsonl"
+# Real recall queries are near-unique prompts, so requiring an exact-query repeat
+# finds almost nothing → accept singles too. And top_scores are RRF FUSION scores
+# (tiny, ~0.03-0.07, NOT 0-1 similarity), so there is no meaningful absolute score
+# gate — the top-1 per query is simply "what the pipeline ranked first," a valid
+# drift anchor. Multi-recall pairs still rank first. Curation is the human's job.
+_MIN_RECALLS = 1
+_MIN_SCORE = 0.0
+
+
+def _live_db_path() -> str:
+    """Live genesis.db, home-anchored (GENESIS_DB_PATH override honored) — NOT
+    the repo-anchored default that resolves to an empty worktree DB."""
+    return os.environ.get("GENESIS_DB_PATH") or str(Path.home() / "genesis" / "data" / "genesis.db")
+
+
+async def _suggest(n: int) -> list[dict]:
+    """Mine eval_events for stable query->top-memory pairs (read-only)."""
+    from genesis.db.connection import open_ro_connection
+
+    # Exclude queries already in the golden set so the probe (which re-runs those
+    # exact queries daily and emits recall_fired for them) can never feed the set
+    # back into itself. This is the real self-feeding guard — `source` is a
+    # collection selector, not a probe tag, so it can't distinguish probe events.
+    _, existing_pairs = _load_existing()
+    existing_queries = {q for (q, _mid) in existing_pairs}
+
+    conn = await open_ro_connection(_live_db_path())
+    try:
+        rows = await conn.execute_fetchall(
+            "SELECT metrics_json FROM eval_events "
+            "WHERE dimension='memory' AND event_type='recall_fired' "
+            "ORDER BY timestamp DESC LIMIT 5000"
+        )
+        # query -> {top1_id: (count, best_score)}
+        agg: dict[str, dict[str, list]] = {}
+        for (mj,) in rows:
+            try:
+                m = json.loads(mj)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            q = (m.get("query") or "").strip()
+            if q in existing_queries:
+                continue  # already a golden query — never re-mine (anti-feedback)
+            ids = m.get("memory_ids") or []
+            scores = m.get("top_scores") or []
+            if not q or not ids or not scores:
+                continue
+            top_id, top_score = str(ids[0]), float(scores[0])
+            if top_score < _MIN_SCORE:
+                continue
+            bucket = agg.setdefault(q, {})
+            entry = bucket.setdefault(top_id, [0, 0.0])
+            entry[0] += 1
+            entry[1] = max(entry[1], top_score)
+
+        # keep queries with a single dominant stable top-1
+        candidates: list[dict] = []
+        for q, bucket in agg.items():
+            top_id, (count, best) = max(bucket.items(), key=lambda kv: kv[1][0])
+            if count < _MIN_RECALLS:
+                continue
+            candidates.append({"query": q, "top_id": top_id, "count": count, "score": best})
+        candidates.sort(key=lambda c: (c["count"], c["score"]), reverse=True)
+
+        # verify the memory still exists
+        verified: list[dict] = []
+        for c in candidates:
+            r = await conn.execute_fetchall(
+                "SELECT 1 FROM memory_metadata WHERE memory_id = ? LIMIT 1", (c["top_id"],)
+            )
+            if r:
+                verified.append(c)
+            if len(verified) >= n:
+                break
+        return verified
+    finally:
+        await conn.close()
+
+
+def _load_existing() -> tuple[list[dict], set[tuple[str, str]]]:
+    if not _GOLDEN.exists():
+        return [], set()
+    cases, seen = [], set()
+    for line in _GOLDEN.read_text().splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        try:
+            c = json.loads(s)
+        except json.JSONDecodeError:
+            continue
+        cases.append(c)
+        for e in c.get("expected_memory_ids") or []:
+            seen.add((c.get("query", ""), str(e)))
+    return cases, seen
+
+
+def _append(cases: list[dict]) -> int:
+    _GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+    _, seen = _load_existing()
+    added = 0
+    with _GOLDEN.open("a") as fh:
+        for c in cases:
+            key = (c.get("query", ""), str((c.get("expected_memory_ids") or [""])[0]))
+            if key in seen:
+                continue
+            fh.write(json.dumps(c) + "\n")
+            seen.add(key)
+            added += 1
+    return added
+
+
+async def _main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--suggest", type=int, metavar="N", help="mine + print N candidate pairs")
+    ap.add_argument("--accept-all", action="store_true", help="append the suggested candidates")
+    ap.add_argument("--add-line", metavar="JSON", help="append one hand-written case")
+    ap.add_argument("--list", action="store_true", help="print the current golden set")
+    args = ap.parse_args()
+
+    if args.list:
+        cases, _ = _load_existing()
+        print(f"{len(cases)} case(s) in {_GOLDEN}")
+        for c in cases:
+            print(
+                f"  {c.get('id', '')}: {c.get('query', '')[:60]} -> {c.get('expected_memory_ids')}"
+            )
+        return 0
+
+    if args.add_line:
+        c = json.loads(args.add_line)
+        if not c.get("query") or not c.get("expected_memory_ids"):
+            print("ERROR: case needs query + expected_memory_ids", file=sys.stderr)
+            return 2
+        c.setdefault("id", f"manual-{abs(hash(c['query'])) % 10**8}")
+        print(f"added {_append([c])} case(s)")
+        return 0
+
+    if args.suggest:
+        cands = await _suggest(args.suggest)
+        cases = [
+            {
+                "id": f"mined-{i}",
+                "query": c["query"],
+                "expected_memory_ids": [c["top_id"]],
+                "notes": f"stable: top-1 across {c['count']} recalls, best score {c['score']:.2f}",
+            }
+            for i, c in enumerate(cands)
+        ]
+        if args.accept_all:
+            print(f"added {_append(cases)} case(s) to {_GOLDEN}")
+        else:
+            for case in cases:
+                print(json.dumps(case))
+            print(
+                f"\n# {len(cases)} candidate(s). Re-run with --accept-all to add, "
+                f"or copy the good lines into {_GOLDEN}",
+                file=sys.stderr,
+            )
+        return 0
+
+    ap.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -802,12 +802,11 @@ async def _check_memory_integrity_posture(db) -> None:
                 )
             )
 
-        # Stale/stuck checker: no non-unknown report within the window AND the
-        # checker has been running LONGER than the window (its earliest report
-        # predates the window) — so this is a genuinely dead or unknown-stuck
-        # job, not a fresh install whose first run happened to be 'unknown'.
-        # Only when mode != off.
-        if latest_consistency is not None and integrity_config.effective_mode() != "off":
+        # Stale/stuck detection: a signal that has run LONGER than the window
+        # (earliest row predates it) yet produced no conclusive run within it is
+        # dead or wedged-on-unknown — NOT a fresh install. Applies to both the
+        # consistency checker AND the recall probe. Only when mode != off.
+        if integrity_config.effective_mode() != "off":
             cfg = integrity_config.load_config()
             stale_days = integrity_config.knob_int(cfg, "stale_report_days")
             # Match the stored `datetime('now')` format (space-separated, no tz)
@@ -817,22 +816,60 @@ async def _check_memory_integrity_posture(db) -> None:
             since_iso = (datetime.now(UTC) - timedelta(days=stale_days)).strftime(
                 "%Y-%m-%d %H:%M:%S"
             )
-            earliest = await mi_crud.earliest_report_at(db)
-            checker_older_than_window = earliest is not None and earliest < since_iso
-            if checker_older_than_window and not await mi_crud.has_recent_non_unknown_report(
-                db, since_iso=since_iso
-            ):
-                findings.append(
-                    (
-                        "reports_stale",
-                        f"the consistency checker has produced no conclusive "
-                        f"(non-unknown) report in {stale_days}d — the job is dead or "
-                        f"stuck reporting 'unknown' (e.g. Qdrant persistently "
-                        f"unreachable); memory integrity is currently UNVERIFIED",
+            # Consistency checker staleness.
+            if latest_consistency is not None:
+                earliest = await mi_crud.earliest_report_at(db)
+                if (
+                    earliest is not None
+                    and earliest < since_iso
+                    and not await mi_crud.has_recent_non_unknown_report(db, since_iso=since_iso)
+                ):
+                    findings.append(
+                        (
+                            "reports_stale",
+                            f"the consistency checker has produced no conclusive "
+                            f"(non-unknown) report in {stale_days}d — the job is dead or "
+                            f"stuck reporting 'unknown' (e.g. Qdrant persistently "
+                            f"unreachable); memory integrity is currently UNVERIFIED",
+                        )
                     )
-                )
+            # Recall-probe staleness — EXEMPT a never-configured/unseeded golden
+            # set (latest unknown='golden_set_too_small' is needs-setup, not a
+            # failure); only a real measurement failure (retriever error) escalates.
+            if latest_probe is not None and not (
+                latest_probe.get("status") == "unknown"
+                and latest_probe.get("unknown_reason") == "golden_set_too_small"
+            ):
+                earliest_p = await mi_crud.earliest_probe_run_at(db)
+                if (
+                    earliest_p is not None
+                    and earliest_p < since_iso
+                    and not await mi_crud.has_recent_conclusive_probe(db, since_iso=since_iso)
+                ):
+                    findings.append(
+                        (
+                            "recall_stale",
+                            f"the recall-health probe has produced no conclusive run in "
+                            f"{stale_days}d — the retriever is failing or the probe is "
+                            f"wedged; recall health is currently UNVERIFIED",
+                        )
+                    )
 
         if not findings:
+            # Do NOT treat an inconclusive measurement as recovery. If the latest
+            # consistency report is 'unknown' (Qdrant down), or the latest probe
+            # is 'unknown' for a real reason (not needs-setup), a prior degraded
+            # posture must PERSIST until a conclusive healthy run demonstrates it.
+            consistency_inconclusive = (
+                latest_consistency is not None and latest_consistency.get("status") == "unknown"
+            )
+            probe_inconclusive = (
+                latest_probe is not None
+                and latest_probe.get("status") == "unknown"
+                and latest_probe.get("unknown_reason") != "golden_set_too_small"
+            )
+            if consistency_inconclusive or probe_inconclusive:
+                return  # hold the current posture — recovery not demonstrated
             await _resolve_memory_integrity_posture(db)
             return
 

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -450,6 +450,21 @@ _INFRA_POSTURE_SUPERSEDED_NOTE = "superseded: protection posture changed"
 _last_infra_posture_alert_at: float = 0.0
 _last_infra_posture_key: str = ""
 
+# Memory integrity posture (Phase 0 "make silence loud"): reads the LATEST
+# persisted consistency-report / recall-probe rows (the jobs never alert
+# themselves — decoupled surfacing) and raises ONE standing 'high'
+# infrastructure_alert describing the current state. Fires on: a degraded
+# consistency report, a degraded recall probe, OR a stale/stuck checker (the
+# checker has run before but produced no non-unknown report within the window —
+# a checker stuck on 'unknown' is itself a silent failure and must escalate).
+# 'unknown' single runs never alert; pre-migration / no-run-yet is silent.
+_MEMORY_INTEGRITY_SOURCE = "memory_integrity_posture_monitor"
+_MEMORY_INTEGRITY_COOLDOWN_S = 86400.0
+_MEMORY_INTEGRITY_SUPERSEDED_NOTE = "superseded: memory integrity posture changed"
+_last_memory_integrity_alert_at: float = 0.0
+_last_memory_integrity_key: str = ""
+
+
 # Human-readable defect + remediation per rule slug (alert content).
 _INFRA_POSTURE_DETAIL = {
     "container_swap_disabled": (
@@ -729,6 +744,163 @@ async def _resolve_infra_protection_posture(db) -> None:
             logger.info("Auto-resolved %d infra protection posture alert(s)", resolved)
     except Exception:
         logger.debug("Failed to resolve infra posture alerts", exc_info=True)
+
+
+async def _check_memory_integrity_posture(db) -> None:
+    """Alert when memory storage consistency or recall health has degraded.
+
+    Reads the LATEST persisted memory_consistency_reports / recall_probe_runs
+    rows (the jobs self-persist; this is the decoupled alerting layer, matching
+    infra posture). One 'high' infrastructure_alert = the current state; a
+    posture change supersedes the prior row. Fires on: a degraded consistency
+    report, a degraded recall probe, or a stale/stuck checker (has run before
+    but no non-unknown consistency report within stale_report_days — a checker
+    frozen on 'unknown' is itself a silent failure). 'unknown' single runs never
+    alert; pre-migration / no-run-yet is silent. Auto-resolves when clear.
+    Best-effort; never raises into the tick."""
+    global _last_memory_integrity_alert_at, _last_memory_integrity_key
+    if db is None:
+        return
+    try:
+        from genesis.db.crud import memory_integrity as mi_crud
+        from genesis.memory import integrity_config
+
+        latest_consistency = await mi_crud.latest_consistency_report(db)
+        latest_probe = await mi_crud.latest_recall_probe_run(db)
+        # Pre-migration or no run yet → nothing to assert (silent, not "healthy").
+        if latest_consistency is None and latest_probe is None:
+            return
+
+        findings: list[tuple[str, str]] = []
+
+        if latest_consistency is not None and latest_consistency.get("status") == "degraded":
+            try:
+                counts = json.loads(latest_consistency.get("counts_json") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                counts = {}
+            nonzero = ", ".join(
+                f"{k}={v}" for k, v in sorted(counts.items()) if isinstance(v, int) and v > 0
+            )
+            findings.append(
+                (
+                    "consistency_degraded",
+                    f"cross-backend consistency DEGRADED ({nonzero or 'see report'}) — "
+                    f"memories exist that are silently unreachable via a retrieval lane "
+                    f"or points with no owning row",
+                )
+            )
+
+        if latest_probe is not None and latest_probe.get("status") == "degraded":
+            hr = latest_probe.get("hit_rate")
+            base = latest_probe.get("baseline_hit_rate")
+            findings.append(
+                (
+                    "recall_degraded",
+                    f"recall-health DEGRADED (hit_rate={hr}, baseline={base}) — golden "
+                    f"queries are returning their expected memories less often than the "
+                    f"trailing baseline",
+                )
+            )
+
+        # Stale/stuck checker: no non-unknown report within the window AND the
+        # checker has been running LONGER than the window (its earliest report
+        # predates the window) — so this is a genuinely dead or unknown-stuck
+        # job, not a fresh install whose first run happened to be 'unknown'.
+        # Only when mode != off.
+        if latest_consistency is not None and integrity_config.effective_mode() != "off":
+            cfg = integrity_config.load_config()
+            stale_days = integrity_config.knob_int(cfg, "stale_report_days")
+            # Match the stored `datetime('now')` format (space-separated, no tz)
+            # so BOTH the SQL `created_at >= ?` and the Python `earliest < since`
+            # comparisons sort lexically = chronologically. isoformat()'s 'T' +
+            # offset would break same-date lexical ordering.
+            since_iso = (datetime.now(UTC) - timedelta(days=stale_days)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            earliest = await mi_crud.earliest_report_at(db)
+            checker_older_than_window = earliest is not None and earliest < since_iso
+            if checker_older_than_window and not await mi_crud.has_recent_non_unknown_report(
+                db, since_iso=since_iso
+            ):
+                findings.append(
+                    (
+                        "reports_stale",
+                        f"the consistency checker has produced no conclusive "
+                        f"(non-unknown) report in {stale_days}d — the job is dead or "
+                        f"stuck reporting 'unknown' (e.g. Qdrant persistently "
+                        f"unreachable); memory integrity is currently UNVERIFIED",
+                    )
+                )
+
+        if not findings:
+            await _resolve_memory_integrity_posture(db)
+            return
+
+        key = ",".join(slug for slug, _ in findings)
+        now = time.monotonic()
+        if (
+            _last_memory_integrity_alert_at
+            and now - _last_memory_integrity_alert_at < _MEMORY_INTEGRITY_COOLDOWN_S
+            and key == _last_memory_integrity_key
+        ):
+            return
+        details = "; ".join(detail for _, detail in findings)
+        content = (
+            f"Memory integrity posture: {details}. Recall silently degrades when "
+            f"these drift — this is the 'make silence loud' signal (Phase 0 is "
+            f"detect-only; repair is a separate lane)."
+        )
+        content_hash = hashlib.sha256(f"memory_integrity:{key}".encode()).hexdigest()
+        await observations.supersede_except_hash(
+            db,
+            source=_MEMORY_INTEGRITY_SOURCE,
+            type="infrastructure_alert",
+            keep_content_hash=content_hash,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=_MEMORY_INTEGRITY_SUPERSEDED_NOTE,
+        )
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source=_MEMORY_INTEGRITY_SOURCE,
+            type="infrastructure_alert",
+            content=content,
+            priority="high",
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        _last_memory_integrity_alert_at = now
+        _last_memory_integrity_key = key
+        if created is not None:
+            logger.warning("Memory integrity posture alert: %s", key)
+    except Exception:
+        logger.debug("Failed memory integrity posture check", exc_info=True)
+
+
+async def _resolve_memory_integrity_posture(db) -> None:
+    """Resolve standing memory-integrity alerts once posture is clear.
+
+    Unconditional (survives restart); a cheap no-op when nothing matches."""
+    global _last_memory_integrity_alert_at, _last_memory_integrity_key
+    if db is None:
+        return
+    try:
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source=_MEMORY_INTEGRITY_SOURCE,
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="auto-resolved: memory consistency and recall health nominal",
+        )
+        if resolved:
+            _last_memory_integrity_alert_at = 0.0
+            _last_memory_integrity_key = ""
+            logger.info("Auto-resolved %d memory integrity posture alert(s)", resolved)
+    except Exception:
+        logger.debug("Failed to resolve memory integrity posture alerts", exc_info=True)
+
+
 
 
 # Deploy staleness (WS-B): merged ≠ deployed. A bare git-merge between
@@ -2075,6 +2247,10 @@ class AwarenessLoop:
                     # 'high' infrastructure_alert; self-resolves on recovery.
                     # Facts change at most ~daily (profile refresh) → hourly.
                     await _check_infra_protection_posture(self._db)
+                    # Memory integrity posture: reads the latest persisted
+                    # consistency/recall-probe rows; slow-moving (daily jobs) →
+                    # hourly is ample.
+                    await _check_memory_integrity_posture(self._db)
                 await _check_wal_health(self._db)
                 # WS-2 M10: persist the alert/incident open-set to alert_events.
                 # Every tick (5 min), not hourly — a short-lived alert that fires

--- a/src/genesis/dashboard/routes/memory.py
+++ b/src/genesis/dashboard/routes/memory.py
@@ -159,6 +159,68 @@ async def memory_delete(memory_id: str):
         return jsonify({"error": "Delete failed"}), 500
 
 
+@blueprint.route("/api/genesis/memory/integrity")
+@_async_route
+async def memory_integrity_status():
+    """Phase 0 memory-integrity tile: latest consistency report + recall probe.
+
+    A static route — registered ahead of the ``/<memory_id>`` converter in
+    Werkzeug's specificity ordering, so ``integrity`` is never read as an id.
+    """
+    import json as _json
+
+    from genesis.db.crud import memory_integrity as mi_crud
+    from genesis.memory import integrity_config
+    from genesis.memory.recall_probe import load_golden_set
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Not bootstrapped"}), 503
+
+    report = await mi_crud.latest_consistency_report(rt.db)
+    probe = await mi_crud.latest_recall_probe_run(rt.db)
+    try:
+        golden_count = len(load_golden_set())
+    except Exception:
+        golden_count = 0
+
+    result: dict = {
+        # configured=False means no run has produced a row yet (pre-migration or
+        # awaiting the first nightly run) — the tile shows an explicit
+        # needs-setup state, never a fake "healthy".
+        "configured": report is not None or probe is not None,
+        "mode": integrity_config.effective_mode(),
+        "golden_count": golden_count,
+        "consistency": None,
+        "recall": None,
+    }
+    if report is not None:
+        try:
+            counts = _json.loads(report.get("counts_json") or "{}")
+        except (_json.JSONDecodeError, TypeError):
+            counts = {}
+        result["consistency"] = {
+            "status": report["status"],
+            "counts": counts,
+            "total_rows": report["total_rows"],
+            "truncated": bool(report["truncated"]),
+            "unknown_reason": report["unknown_reason"],
+            "created_at": report["created_at"],
+        }
+    if probe is not None:
+        result["recall"] = {
+            "status": probe["status"],
+            "hit_rate": probe["hit_rate"],
+            "mean_rr": probe["mean_rr"],
+            "baseline_hit_rate": probe["baseline_hit_rate"],
+            "drift": probe["drift"],
+            "unknown_reason": probe["unknown_reason"],
+            "created_at": probe["created_at"],
+        }
+    return jsonify(result)
+
+
 @blueprint.route("/api/genesis/memory/stats")
 @_async_route
 async def memory_stats():

--- a/src/genesis/dashboard/templates/partials/tabs/memory.html
+++ b/src/genesis/dashboard/templates/partials/tabs/memory.html
@@ -9,6 +9,54 @@
         Memory Browser
       </div>
       <div class="panel-body">
+        <!-- Memory integrity tile (Phase 0 "make silence loud") -->
+        <div style="margin-bottom:1rem; padding:0.75rem 1rem; border:1px solid var(--border, #2a2a2a); border-radius:6px;" x-data
+             x-show="$store.genesisDashboard.memoryIntegrity && Object.keys($store.genesisDashboard.memoryIntegrity).length">
+          <div style="display:flex; align-items:center; gap:0.5rem; margin-bottom:0.5rem;">
+            <span class="material-symbols-outlined" style="font-size:1.1rem;">frame_inspect</span>
+            <strong>Memory Integrity</strong>
+            <span style="font-size:0.75rem; opacity:0.6;" x-text="'mode: ' + ($store.genesisDashboard.memoryIntegrity.mode || '?')"></span>
+          </div>
+          <!-- not-configured / awaiting first run -->
+          <template x-if="!$store.genesisDashboard.memoryIntegrity.configured">
+            <div style="font-size:0.85rem; opacity:0.7;">
+              No integrity report yet — the read-only checks run nightly (or seed the
+              recall golden set via <code>scripts/seed_recall_golden_set.py</code>).
+            </div>
+          </template>
+          <div style="display:flex; gap:1.5rem; flex-wrap:wrap;">
+            <!-- consistency -->
+            <template x-if="$store.genesisDashboard.memoryIntegrity.consistency">
+              <div>
+                <div style="font-size:0.7rem; text-transform:uppercase; opacity:0.6;">Storage consistency</div>
+                <div style="font-weight:600;"
+                     :style="{color: $store.genesisDashboard.memoryIntegrity.consistency.status==='degraded' ? '#e5534b' : ($store.genesisDashboard.memoryIntegrity.consistency.status==='unknown' ? '#c9a227' : '#3fb950')}"
+                     x-text="$store.genesisDashboard.memoryIntegrity.consistency.status + ($store.genesisDashboard.memoryIntegrity.consistency.truncated ? ' (sampled)' : '')"></div>
+                <div style="font-size:0.8rem; opacity:0.8;"
+                     x-text="Object.entries($store.genesisDashboard.memoryIntegrity.consistency.counts || {}).filter(([k,v]) => v > 0).map(([k,v]) => k+'='+v).join(', ') || 'no findings'"></div>
+                <template x-if="$store.genesisDashboard.memoryIntegrity.consistency.unknown_reason">
+                  <div style="font-size:0.75rem; color:#c9a227;" x-text="'reason: ' + $store.genesisDashboard.memoryIntegrity.consistency.unknown_reason"></div>
+                </template>
+              </div>
+            </template>
+            <!-- recall health -->
+            <template x-if="$store.genesisDashboard.memoryIntegrity.recall">
+              <div>
+                <div style="font-size:0.7rem; text-transform:uppercase; opacity:0.6;">Recall health</div>
+                <div style="font-weight:600;"
+                     :style="{color: $store.genesisDashboard.memoryIntegrity.recall.status==='degraded' ? '#e5534b' : ($store.genesisDashboard.memoryIntegrity.recall.status==='unknown' ? '#c9a227' : '#3fb950')}"
+                     x-text="$store.genesisDashboard.memoryIntegrity.recall.status"></div>
+                <template x-if="$store.genesisDashboard.memoryIntegrity.recall.hit_rate != null">
+                  <div style="font-size:0.8rem; opacity:0.8;"
+                       x-text="'hit-rate ' + (100*$store.genesisDashboard.memoryIntegrity.recall.hit_rate).toFixed(0) + '%' + ($store.genesisDashboard.memoryIntegrity.recall.drift != null ? ' (drift ' + (100*$store.genesisDashboard.memoryIntegrity.recall.drift).toFixed(0) + '%)' : '')"></div>
+                </template>
+                <template x-if="$store.genesisDashboard.memoryIntegrity.recall.unknown_reason">
+                  <div style="font-size:0.75rem; color:#c9a227;" x-text="$store.genesisDashboard.memoryIntegrity.recall.unknown_reason + ' (golden: ' + ($store.genesisDashboard.memoryIntegrity.golden_count||0) + ')'"></div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </div>
         <!-- Stats row -->
         <div style="display:flex; gap:1rem; margin-bottom:1rem; flex-wrap:wrap;" x-data>
           <template x-if="$store.genesisDashboard.memoryStats.total != null">

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -204,6 +204,7 @@
         memorySearch: { query: "", results: [], loading: false },
         memoryRecent: { items: [], total: 0, loading: false },
         memoryStats: {},
+        memoryIntegrity: {},
         memoryDetail: null,
         knowledgeQuery: "",
         knowledgeSearchResults: [],
@@ -550,7 +551,7 @@
               this._autonomyInterval = setInterval(() => { this.fetchAutonomyGrants(); this.fetchAutonomySends(); }, 30000);
               break;
             case "memory":
-              if (first) { this.fetchMemoryRecent(); this.fetchMemoryStats(); }
+              if (first) { this.fetchMemoryRecent(); this.fetchMemoryStats(); this.fetchMemoryIntegrity(); }
               break;
             case "knowledge":
               if (first) { this.fetchKnowledgeRecent(); this.fetchKnowledgeStats(); this.fetchKnowledgeUploads(); this.fetchKnowledgeTaxonomy(); this.fetchWatchlist(); }
@@ -1478,6 +1479,12 @@
             const resp = await fetchApi("/api/genesis/memory/stats");
             if (resp && resp.ok) { this.memoryStats = await resp.json(); }
           } catch (e) { console.warn("Memory stats failed:", e); }
+        },
+        async fetchMemoryIntegrity() {
+          try {
+            const resp = await fetchApi("/api/genesis/memory/integrity");
+            if (resp && resp.ok) { this.memoryIntegrity = await resp.json(); }
+          } catch (e) { console.warn("Memory integrity failed:", e); }
         },
         async searchMemory() {
           if (!this.memorySearch.query.trim()) return;

--- a/src/genesis/db/crud/memory_integrity.py
+++ b/src/genesis/db/crud/memory_integrity.py
@@ -193,13 +193,16 @@ async def trailing_hit_rate(
     window: int,
     exclude_current_id: str | None = None,
 ) -> tuple[float | None, int]:
-    """Return ``(mean_hit_rate, n_runs)`` over the last *window* non-unknown runs.
+    """Return ``(mean_hit_rate, n_runs)`` over the last *window* HEALTHY runs.
 
-    Only ``status != 'unknown'`` rows with a non-NULL ``hit_rate`` count toward
-    the baseline (an unknown run measured nothing). ``exclude_current_id`` omits
-    the just-inserted row so a run never baselines against itself. Returns
-    ``(None, n)`` when no qualifying runs exist — the caller treats that as the
-    observation period (no drift verdict yet).
+    Baseline = KNOWN-GOOD only: ``status = 'healthy'`` with a non-NULL
+    ``hit_rate``. Deliberately NOT ``status != 'unknown'`` — including degraded
+    runs would let a sustained hit-rate fall gradually normalize itself into the
+    rolling baseline (drift → 0 → false 'healthy'). Because this selects the last
+    N *healthy* runs (not the healthy runs among the last N), a run of degraded
+    results never displaces the known-good baseline; the bar stays put until a
+    genuinely healthy run replaces it. ``exclude_current_id`` omits the
+    just-inserted row. ``(None, n)`` = observation period (no verdict yet).
     """
     if not await _tables_available(db):
         return None, 0
@@ -211,7 +214,7 @@ async def trailing_hit_rate(
     params.append(window)
     cursor = await db.execute(
         "SELECT hit_rate FROM recall_probe_runs "
-        "WHERE status != 'unknown' AND hit_rate IS NOT NULL "  # noqa: S608 - static fragment
+        "WHERE status = 'healthy' AND hit_rate IS NOT NULL "  # noqa: S608 - static fragment
         f"{exclude_clause}"
         "ORDER BY created_at DESC, rowid DESC LIMIT ?",
         params,
@@ -221,6 +224,43 @@ async def trailing_hit_rate(
     if not rates:
         return None, 0
     return sum(rates) / len(rates), len(rates)
+
+
+async def earliest_probe_run_at(db: aiosqlite.Connection) -> str | None:
+    """Oldest recall-probe ``created_at`` (or None). Staleness uses it to tell a
+    fresh install from a genuinely dead/stuck probe (same as earliest_report_at)."""
+    if not await _tables_available(db):
+        return None
+    cursor = await db.execute("SELECT MIN(created_at) FROM recall_probe_runs")
+    row = await cursor.fetchone()
+    return row[0] if row and row[0] else None
+
+
+async def has_recent_conclusive_probe(db: aiosqlite.Connection, *, since_iso: str) -> bool:
+    """True if a probe run with status in (healthy, degraded) exists at/after
+    *since_iso*. A probe frozen on 'unknown' (retriever error) is inconclusive;
+    'golden_set_too_small' is needs-setup, not a failure — both are excluded so
+    the staleness check can distinguish a wedged probe from an unseeded one.
+    Pre-migration -> True (nothing to alert on yet)."""
+    if not await _tables_available(db):
+        return True
+    cursor = await db.execute(
+        "SELECT 1 FROM recall_probe_runs "
+        "WHERE status IN ('healthy', 'degraded') AND created_at >= ? "
+        "LIMIT 1",
+        (since_iso,),
+    )
+    return await cursor.fetchone() is not None
+
+
+async def fetch_consistency_metadata(db: aiosqlite.Connection) -> list:
+    """Return all ``memory_metadata`` rows the consistency checker needs
+    (memory_id, collection, embedding_status, deprecated). Centralizes the
+    full-corpus read so the checker doesn't inline SQL (crud convention); the
+    checker passes its own read-only ``mode=ro`` connection."""
+    return await db.execute_fetchall(
+        "SELECT memory_id, collection, embedding_status, deprecated FROM memory_metadata"
+    )
 
 
 async def has_recent_non_unknown_report(

--- a/src/genesis/db/crud/memory_integrity.py
+++ b/src/genesis/db/crud/memory_integrity.py
@@ -1,0 +1,267 @@
+"""CRUD for memory_consistency_reports + recall_probe_runs — Phase 0 integrity.
+
+Persistence for the "make silence loud" observability spine (migration 0073).
+The consistency checker and recall-health probe write one row per run here; the
+awareness posture check and the dashboard tile read the latest row per table;
+``trailing_hit_rate`` supplies the recall-drift baseline.
+
+Writers guard on table existence and no-op pre-migration (the repo_pulse
+pattern) so a job scheduled before its migration lands never raises. Migration
+0073 is the sole schema authority; nothing here creates tables. Timestamps are
+injected (``now``) for deterministic, testable retention.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import aiosqlite
+
+# Per-process cache: only the TRUE result is cached — a missing table
+# (pre-migration window) is re-checked every call so a job self-heals the
+# moment the server migration lands.
+_tables_verified = False
+
+
+async def _tables_available(db: aiosqlite.Connection) -> bool:
+    global _tables_verified
+    if _tables_verified:
+        return True
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN "
+        "('memory_consistency_reports', 'recall_probe_runs')"
+    )
+    row = await cursor.fetchone()
+    exists = bool(row and row[0] == 2)
+    if exists:
+        _tables_verified = True
+    return exists
+
+
+def _row_to_dict(cursor, row) -> dict:
+    """Map a fetched row to a dict by cursor.description (connection-agnostic)."""
+    return {col[0]: row[i] for i, col in enumerate(cursor.description)}
+
+
+# ── memory_consistency_reports ───────────────────────────────────────────
+
+
+async def insert_consistency_report(
+    db: aiosqlite.Connection,
+    *,
+    status: str,
+    counts: dict[str, int],
+    total_rows: int,
+    sampled_rows: int,
+    sample_fraction: float,
+    truncated: bool,
+    offender_sample: dict[str, list[str]] | None = None,
+    unknown_reason: str | None = None,
+    duration_ms: int | None = None,
+    created_at: str | None = None,
+) -> str | None:
+    """Insert one consistency-check row. Returns the row id, or None pre-migration."""
+    if not await _tables_available(db):
+        return None
+    report_id = uuid.uuid4().hex
+    cols = [
+        "id",
+        "status",
+        "sample_fraction",
+        "sampled_rows",
+        "total_rows",
+        "truncated",
+        "counts_json",
+        "offender_sample_json",
+        "unknown_reason",
+        "duration_ms",
+    ]
+    vals = [
+        report_id,
+        status,
+        sample_fraction,
+        sampled_rows,
+        total_rows,
+        1 if truncated else 0,
+        json.dumps(counts, sort_keys=True),
+        json.dumps(offender_sample or {}, sort_keys=True),
+        unknown_reason,
+        duration_ms,
+    ]
+    if created_at is not None:
+        cols.append("created_at")
+        vals.append(created_at)
+    placeholders = ", ".join("?" for _ in cols)
+    await db.execute(
+        f"INSERT INTO memory_consistency_reports ({', '.join(cols)}) VALUES ({placeholders})",  # noqa: S608 - column names are literals above, values bound
+        vals,
+    )
+    await db.commit()
+    return report_id
+
+
+async def latest_consistency_report(db: aiosqlite.Connection) -> dict | None:
+    """Return the most recent consistency report row as a dict, or None."""
+    if not await _tables_available(db):
+        return None
+    cursor = await db.execute(
+        "SELECT * FROM memory_consistency_reports ORDER BY created_at DESC, id DESC LIMIT 1"
+    )
+    row = await cursor.fetchone()
+    return _row_to_dict(cursor, row) if row else None
+
+
+# ── recall_probe_runs ────────────────────────────────────────────────────
+
+
+async def insert_recall_probe_run(
+    db: aiosqlite.Connection,
+    *,
+    status: str,
+    probes_total: int,
+    probes_hit: int,
+    hit_rate: float | None,
+    mean_rr: float | None,
+    baseline_hit_rate: float | None = None,
+    drift: float | None = None,
+    details: list[dict] | None = None,
+    unknown_reason: str | None = None,
+    duration_ms: int | None = None,
+    created_at: str | None = None,
+) -> str | None:
+    """Insert one recall-probe row. Returns the row id, or None pre-migration."""
+    if not await _tables_available(db):
+        return None
+    run_id = uuid.uuid4().hex
+    cols = [
+        "id",
+        "status",
+        "probes_total",
+        "probes_hit",
+        "hit_rate",
+        "mean_rr",
+        "baseline_hit_rate",
+        "drift",
+        "details_json",
+        "unknown_reason",
+        "duration_ms",
+    ]
+    vals = [
+        run_id,
+        status,
+        probes_total,
+        probes_hit,
+        hit_rate,
+        mean_rr,
+        baseline_hit_rate,
+        drift,
+        json.dumps(details or []),
+        unknown_reason,
+        duration_ms,
+    ]
+    if created_at is not None:
+        cols.append("created_at")
+        vals.append(created_at)
+    placeholders = ", ".join("?" for _ in cols)
+    await db.execute(
+        f"INSERT INTO recall_probe_runs ({', '.join(cols)}) VALUES ({placeholders})",  # noqa: S608 - column names are literals above, values bound
+        vals,
+    )
+    await db.commit()
+    return run_id
+
+
+async def latest_recall_probe_run(db: aiosqlite.Connection) -> dict | None:
+    """Return the most recent recall-probe row as a dict, or None."""
+    if not await _tables_available(db):
+        return None
+    cursor = await db.execute(
+        "SELECT * FROM recall_probe_runs ORDER BY created_at DESC, id DESC LIMIT 1"
+    )
+    row = await cursor.fetchone()
+    return _row_to_dict(cursor, row) if row else None
+
+
+async def trailing_hit_rate(
+    db: aiosqlite.Connection,
+    *,
+    window: int,
+    exclude_current_id: str | None = None,
+) -> tuple[float | None, int]:
+    """Return ``(mean_hit_rate, n_runs)`` over the last *window* non-unknown runs.
+
+    Only ``status != 'unknown'`` rows with a non-NULL ``hit_rate`` count toward
+    the baseline (an unknown run measured nothing). ``exclude_current_id`` omits
+    the just-inserted row so a run never baselines against itself. Returns
+    ``(None, n)`` when no qualifying runs exist — the caller treats that as the
+    observation period (no drift verdict yet).
+    """
+    if not await _tables_available(db):
+        return None, 0
+    params: list = []
+    exclude_clause = ""
+    if exclude_current_id is not None:
+        exclude_clause = "AND id != ? "
+        params.append(exclude_current_id)
+    params.append(window)
+    cursor = await db.execute(
+        "SELECT hit_rate FROM recall_probe_runs "
+        "WHERE status != 'unknown' AND hit_rate IS NOT NULL "  # noqa: S608 - static fragment
+        f"{exclude_clause}"
+        "ORDER BY created_at DESC, id DESC LIMIT ?",
+        params,
+    )
+    rows = await cursor.fetchall()
+    rates = [float(r[0]) for r in rows]
+    if not rates:
+        return None, 0
+    return sum(rates) / len(rates), len(rates)
+
+
+async def has_recent_non_unknown_report(
+    db: aiosqlite.Connection,
+    *,
+    since_iso: str,
+) -> bool:
+    """True if a consistency report with status in (healthy, degraded) exists at
+    or after *since_iso*. Drives the staleness posture: a checker that has
+    produced only ``unknown`` (or nothing) within the window is itself a silent
+    failure and must escalate. Pre-migration → True (nothing to alert on yet).
+    """
+    if not await _tables_available(db):
+        return True
+    cursor = await db.execute(
+        "SELECT 1 FROM memory_consistency_reports "
+        "WHERE status IN ('healthy', 'degraded') AND created_at >= ? "
+        "LIMIT 1",
+        (since_iso,),
+    )
+    return await cursor.fetchone() is not None
+
+
+async def prune_memory_integrity(
+    db: aiosqlite.Connection,
+    *,
+    older_than_days: int = 90,
+    now: str,
+) -> int:
+    """Delete report/probe rows older than *older_than_days* relative to ISO ``now``.
+
+    Retention for the two unbounded integrity stores (wired into the
+    _wire_drip_retention_jobs family). ``now`` is injected (never wall-clock
+    here) so the cutover is deterministic and testable. No-ops before migration
+    0073; never creates tables. Returns total rows deleted.
+    """
+    if not await _tables_available(db):
+        return 0
+    cutoff = f"datetime(?, '-{int(older_than_days)} days')"
+    deleted = 0
+    for table in ("memory_consistency_reports", "recall_probe_runs"):
+        cursor = await db.execute(
+            f"DELETE FROM {table} WHERE created_at < {cutoff}",  # noqa: S608 - table names are literals; now bound
+            (now,),
+        )
+        deleted += cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
+    await db.commit()
+    return deleted

--- a/src/genesis/db/crud/memory_integrity.py
+++ b/src/genesis/db/crud/memory_integrity.py
@@ -105,8 +105,11 @@ async def latest_consistency_report(db: aiosqlite.Connection) -> dict | None:
     """Return the most recent consistency report row as a dict, or None."""
     if not await _tables_available(db):
         return None
+    # Tiebreak on rowid (monotonic insertion order), NOT id: ids are random
+    # uuids, so two reports written in the same second would order
+    # nondeterministically and "latest" could return the older row.
     cursor = await db.execute(
-        "SELECT * FROM memory_consistency_reports ORDER BY created_at DESC, id DESC LIMIT 1"
+        "SELECT * FROM memory_consistency_reports ORDER BY created_at DESC, rowid DESC LIMIT 1"
     )
     row = await cursor.fetchone()
     return _row_to_dict(cursor, row) if row else None
@@ -176,8 +179,9 @@ async def latest_recall_probe_run(db: aiosqlite.Connection) -> dict | None:
     """Return the most recent recall-probe row as a dict, or None."""
     if not await _tables_available(db):
         return None
+    # rowid tiebreak (see latest_consistency_report) — deterministic "latest".
     cursor = await db.execute(
-        "SELECT * FROM recall_probe_runs ORDER BY created_at DESC, id DESC LIMIT 1"
+        "SELECT * FROM recall_probe_runs ORDER BY created_at DESC, rowid DESC LIMIT 1"
     )
     row = await cursor.fetchone()
     return _row_to_dict(cursor, row) if row else None
@@ -209,7 +213,7 @@ async def trailing_hit_rate(
         "SELECT hit_rate FROM recall_probe_runs "
         "WHERE status != 'unknown' AND hit_rate IS NOT NULL "  # noqa: S608 - static fragment
         f"{exclude_clause}"
-        "ORDER BY created_at DESC, id DESC LIMIT ?",
+        "ORDER BY created_at DESC, rowid DESC LIMIT ?",
         params,
     )
     rows = await cursor.fetchall()
@@ -238,6 +242,18 @@ async def has_recent_non_unknown_report(
         (since_iso,),
     )
     return await cursor.fetchone() is not None
+
+
+async def earliest_report_at(db: aiosqlite.Connection) -> str | None:
+    """Return the oldest consistency-report ``created_at``, or None if there are
+    no reports. Used by the staleness posture to distinguish a fresh install
+    (checker younger than the stale window → silent) from a genuinely
+    dead/stuck checker (running longer than the window with no good report)."""
+    if not await _tables_available(db):
+        return None
+    cursor = await db.execute("SELECT MIN(created_at) FROM memory_consistency_reports")
+    row = await cursor.fetchone()
+    return row[0] if row and row[0] else None
 
 
 async def prune_memory_integrity(

--- a/src/genesis/db/migrations/0073_memory_integrity.py
+++ b/src/genesis/db/migrations/0073_memory_integrity.py
@@ -1,0 +1,88 @@
+"""Add memory_consistency_reports + recall_probe_runs — Phase 0 memory integrity.
+
+The "make silence loud" observability spine. Memory recall degrades silently:
+the episodic write path fans out to three backends (Qdrant ``episodic_memory``,
+``memory_metadata``, ``memory_fts``) with no cross-store transaction, and
+nothing verifies they agree. These two tables persist the periodic read-only
+checks so drift becomes a standing signal instead of an invisible quality loss.
+
+- ``memory_consistency_reports``: one row per consistency-check run. Records the
+  cross-backend classification counts (lying_mirror / ghost_points /
+  fts_ghosts / fts_invisible / unexpected_vector / deprecated_divergence), the
+  sample fraction used, and a capped offender-id sample. ``status`` is
+  ``unknown`` when a dependency (Qdrant/FTS) was unavailable — a dependency
+  failure must never masquerade as data corruption.
+
+- ``recall_probe_runs``: one row per recall-health probe run. Records hit-rate
+  and mean-reciprocal-rank of an install-local golden query->expected-memory
+  set run through the REAL recall pipeline, plus drift vs a trailing baseline.
+  ``status`` is ``unknown`` when the golden set is too small to judge.
+
+Why two purpose-built tables rather than reusing ``eval_runs``: that table is
+model-evaluation-semantic (``model_id`` / ``dataset`` / ``task_category`` are
+NOT NULL and rows surface in ``genesis eval results/compare`` model-comparison
+views). Store-integrity snapshots and recall-health probes are neither model
+evals nor bench A/Bs; forcing them there would require lying field values and
+pollute the model-eval views. The golden set itself is NOT a table — it is an
+install-local file under ``~/.genesis/eval/golden/`` per the #1143 convention.
+
+Additive + idempotent; DDL mirrored in ``db/schema/_tables.py``. Individual
+``db.execute()`` calls, no commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_consistency_reports (
+            id                   TEXT PRIMARY KEY,          -- uuid4 hex
+            created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+            status               TEXT NOT NULL CHECK (status IN ('healthy', 'degraded', 'unknown')),
+            sample_fraction      REAL,                      -- 0..1 fraction of rows scanned
+            sampled_rows         INTEGER,                   -- metadata rows actually checked
+            total_rows           INTEGER,                   -- total memory_metadata rows
+            truncated            INTEGER NOT NULL DEFAULT 0, -- 1 = a scan hit its budget cap
+            counts_json          TEXT NOT NULL,             -- {class: count} for all classes
+            offender_sample_json TEXT,                      -- {class: [ids...]} capped sample
+            unknown_reason       TEXT,                      -- set iff status='unknown'
+            duration_ms          INTEGER
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS recall_probe_runs (
+            id                TEXT PRIMARY KEY,             -- uuid4 hex
+            created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            status            TEXT NOT NULL CHECK (status IN ('healthy', 'degraded', 'unknown')),
+            probes_total      INTEGER,                      -- golden cases attempted
+            probes_hit        INTEGER,                      -- cases where an expected id was retrieved
+            hit_rate          REAL,                         -- probes_hit / probes_total
+            mean_rr           REAL,                         -- mean reciprocal rank of first expected hit
+            baseline_hit_rate REAL,                         -- trailing-window mean, NULL during observation
+            drift             REAL,                         -- baseline_hit_rate - hit_rate, NULL if no baseline
+            details_json      TEXT,                         -- per-case {id, hit, rank}
+            unknown_reason    TEXT,                         -- set iff status='unknown'
+            duration_ms       INTEGER
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcr_created ON memory_consistency_reports(created_at)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcr_status ON memory_consistency_reports(status, created_at)"
+    )
+    await db.execute("CREATE INDEX IF NOT EXISTS idx_rpr_created ON recall_probe_runs(created_at)")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_rpr_status ON recall_probe_runs(status, created_at)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS memory_consistency_reports")
+    await db.execute("DROP TABLE IF EXISTS recall_probe_runs")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -2126,6 +2126,49 @@ TABLES = {
             created_at          TEXT NOT NULL
         )
     """,
+    # ── Memory integrity Phase 0 — "make silence loud" ───────────────────
+    # One row per read-only cross-backend consistency check. The episodic
+    # write path fans out to Qdrant + memory_metadata + memory_fts with no
+    # cross-store transaction; these snapshots turn silent drift (a memory
+    # marked embedded whose vector is gone, a ghost point, FTS drift) into a
+    # standing signal. status='unknown' when a dependency was unavailable — a
+    # dependency failure must never look like data corruption. 90-day prune.
+    "memory_consistency_reports": """
+        CREATE TABLE IF NOT EXISTS memory_consistency_reports (
+            id                   TEXT PRIMARY KEY,          -- uuid4 hex
+            created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+            status               TEXT NOT NULL CHECK (status IN ('healthy', 'degraded', 'unknown')),
+            sample_fraction      REAL,                      -- 0..1 fraction of rows scanned
+            sampled_rows         INTEGER,                   -- metadata rows actually checked
+            total_rows           INTEGER,                   -- total memory_metadata rows
+            truncated            INTEGER NOT NULL DEFAULT 0, -- 1 = a scan hit its budget cap
+            counts_json          TEXT NOT NULL,             -- {class: count} for all classes
+            offender_sample_json TEXT,                      -- {class: [ids...]} capped sample
+            unknown_reason       TEXT,                      -- set iff status='unknown'
+            duration_ms          INTEGER
+        )
+    """,
+    # One row per recall-health probe: an install-local golden query->expected
+    # -memory set run through the REAL recall pipeline. Records hit-rate + mean
+    # reciprocal rank + drift vs a trailing baseline. status='unknown' when the
+    # golden set is too small to judge. Golden set is a FILE (~/.genesis/eval/
+    # golden/), not a table (#1143 convention). 90-day prune.
+    "recall_probe_runs": """
+        CREATE TABLE IF NOT EXISTS recall_probe_runs (
+            id                TEXT PRIMARY KEY,             -- uuid4 hex
+            created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            status            TEXT NOT NULL CHECK (status IN ('healthy', 'degraded', 'unknown')),
+            probes_total      INTEGER,                      -- golden cases attempted
+            probes_hit        INTEGER,                      -- cases where an expected id was retrieved
+            hit_rate          REAL,                         -- probes_hit / probes_total
+            mean_rr           REAL,                         -- mean reciprocal rank of first expected hit
+            baseline_hit_rate REAL,                         -- trailing-window mean, NULL during observation
+            drift             REAL,                         -- baseline_hit_rate - hit_rate, NULL if no baseline
+            details_json      TEXT,                         -- per-case {id, hit, rank}
+            unknown_reason    TEXT,                         -- set iff status='unknown'
+            duration_ms       INTEGER
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -2463,6 +2506,11 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_reflex_signals_class ON reflex_signals(class_key)",
     "CREATE INDEX IF NOT EXISTS idx_reflex_diagnoses_signal ON reflex_diagnoses(signal_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_reflex_verdicts_signal ON reflex_verdicts(signal_id, created_at)",
+    # Memory integrity Phase 0 — latest-row-by-time and status filters
+    "CREATE INDEX IF NOT EXISTS idx_mcr_created ON memory_consistency_reports(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_mcr_status ON memory_consistency_reports(status, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_rpr_created ON recall_probe_runs(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_rpr_status ON recall_probe_runs(status, created_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -1134,7 +1134,41 @@ def _validate_cc_foreground_reaper(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_memory_integrity(changes: dict) -> list[str]:
+    """Validate memory-integrity lever changes (see
+    genesis.memory.integrity_config). Runtime already fail-safe-coerces at read
+    time; this rejects bad WRITES so settings_update reports the error instead of
+    silently persisting e.g. `enabled: "false"` (truthy) or `rerank: "false"`."""
+    from genesis.memory.integrity_config import _FLOAT01_KNOBS, _INT_KNOBS, MODES
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "mode", "rerank", "rerank_timeout_s", *_INT_KNOBS, *_FLOAT01_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key in ("enabled", "rerank"):
+            if not isinstance(value, bool):
+                errors.append(f"'{key}' must be a boolean")
+        elif key == "mode":
+            if value not in MODES:
+                errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif key == "rerank_timeout_s":
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+                errors.append("'rerank_timeout_s' must be a positive number")
+        elif key in _FLOAT01_KNOBS:
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not 0 <= value <= 1
+            ):
+                errors.append(f"'{key}' must be a number in 0..1")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
+    "memory_integrity": _validate_memory_integrity,
     "entity_adjudication": _validate_entity_adjudication,
     "cc_rate_limit_resume": _validate_cc_rate_limit_resume,
     "cc_foreground_reaper": _validate_cc_foreground_reaper,

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -132,6 +132,23 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # each worker run is a fresh process
     ),
+    "memory_integrity": SettingsDomain(
+        name="memory_integrity",
+        description=(
+            "Memory integrity Phase 0 (make silence loud) — master `enabled` "
+            "+ `mode` off/passive/active plus checker/probe knobs. Passive "
+            "(default) runs two read-only jobs: a cross-backend consistency "
+            "check (memory_metadata <-> Qdrant <-> memory_fts) and a recall-"
+            "health probe over an install-local golden set, surfacing findings "
+            "via a posture alert + dashboard tile. `active` is reserved for "
+            "Phase 1 repair (coerced to passive). Read live per run — takes "
+            "effect next scheduled run. Kill switch: "
+            "GENESIS_MEMORY_INTEGRITY_DISABLED=1."
+        ),
+        config_filename="memory_integrity.yaml",
+        readonly=False,
+        needs_restart=False,  # read live per scheduled run
+    ),
     "pr_watch": SettingsDomain(
         name="pr_watch",
         description=(

--- a/src/genesis/memory/integrity.py
+++ b/src/genesis/memory/integrity.py
@@ -151,20 +151,18 @@ async def run_consistency_check(
     start = time.monotonic()
     conn = await open_ro_connection(db_path) if db_path else await open_ro_connection()
     try:
-        rows = await conn.execute_fetchall(
-            "SELECT memory_id, collection, embedding_status, deprecated FROM memory_metadata"
-        )
+        from genesis.db.crud import memory_integrity as _mi_crud
+
+        rows = await _mi_crud.fetch_consistency_metadata(conn)
         total_rows = len(rows)
-        if total_rows == 0:
-            # Empty install / fresh state: nothing to be inconsistent about.
-            return MemoryConsistencyReport(
-                status="healthy",
-                counts={c: 0 for c in _CLASSES},
-                total_rows=0,
-                sampled_rows=0,
-                sample_fraction=sample_fraction,
-                duration_ms=int((time.monotonic() - start) * 1000),
-            )
+        # NOTE: do NOT early-return 'healthy' on total_rows == 0. Empty metadata
+        # does not mean "nothing to check" — if metadata was wiped/restored from
+        # an older backup while Qdrant or FTS retained data, the orphaned points
+        # (ghost_points) and FTS rows (fts_ghosts) are exactly what we must
+        # surface. The full scan below yields all-zero counts (→ healthy) for a
+        # genuinely empty install, and flags orphans otherwise. It also lets a
+        # Qdrant outage during an empty-metadata run report 'unknown', not
+        # 'healthy'.
 
         meta_ids: set[str] = set()
         embedded_ids: set[str] = set()

--- a/src/genesis/memory/integrity.py
+++ b/src/genesis/memory/integrity.py
@@ -1,0 +1,299 @@
+"""Cross-backend memory consistency checker — Phase 0 "make silence loud".
+
+Read-only. Verifies that the three episodic backends agree: a memory's
+``memory_metadata`` row, its Qdrant vector, and its ``memory_fts`` entry. The
+episodic write path fans out to all three with no cross-store transaction
+(Qdrant and SQLite cannot share one), so a partial write or a half-completed
+delete leaves a silent inconsistency that degrades recall without any error.
+
+Classification (six classes):
+
+- ``lying_mirror``    — ``embedding_status='embedded'`` but NO Qdrant point in
+  either collection. The memory believes it is vector-searchable; it is not.
+  (The #918/#921 bug class.)
+- ``ghost_points``    — a Qdrant point with no ``memory_metadata`` row at all.
+  Can surface as an unattributable recall hit.
+- ``fts_ghosts``      — ``memory_fts`` rows with no metadata row.
+- ``fts_invisible``   — metadata rows with no ``memory_fts`` row (invisible to
+  keyword/hybrid search).
+- ``unexpected_vector`` — ``embedding_status='fts5_only'`` (deliberately
+  keyword-only) yet a Qdrant point exists.
+- ``deprecated_divergence`` — the ``deprecated`` flag disagrees between the
+  SQLite row and the Qdrant payload.
+
+Existence is checked **collection-agnostically**: a memory's point may live in a
+different Qdrant collection than its ``memory_metadata.collection`` column
+claims (that column is documented-unreliable, and the delete path probes both
+collections). Checking "does a point exist in EITHER collection" avoids
+false lying-mirror reports.
+
+Fail-closed in the correct direction: if Qdrant is unreachable, the report is
+``status='unknown'`` with a reason — a dependency outage must NEVER be reported
+as data corruption. Reads go through ``open_ro_connection`` (WAL-aware
+``mode=ro``), never the runtime write lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import time
+from dataclasses import dataclass, field
+
+from genesis.db.connection import open_ro_connection
+from genesis.db.crud.memory import count_fts_metadata_drift
+from genesis.qdrant import collections as qdrant_ops
+
+logger = logging.getLogger(__name__)
+
+_CLASSES = (
+    "lying_mirror",
+    "ghost_points",
+    "fts_ghosts",
+    "fts_invisible",
+    "unexpected_vector",
+    "deprecated_divergence",
+)
+
+
+@dataclass
+class MemoryConsistencyReport:
+    """One consistency-check result. ``status`` is the headline verdict."""
+
+    status: str  # healthy | degraded | unknown
+    counts: dict[str, int] = field(default_factory=dict)
+    offender_sample: dict[str, list[str]] = field(default_factory=dict)
+    total_rows: int = 0
+    sampled_rows: int = 0
+    sample_fraction: float = 1.0
+    truncated: bool = False
+    unknown_reason: str | None = None
+    duration_ms: int = 0
+
+    @property
+    def total_findings(self) -> int:
+        # A -1 count is the "not computed under truncation" sentinel, never a
+        # finding — clamp it out so the total is honest.
+        return sum(max(self.counts.get(c, 0), 0) for c in _CLASSES)
+
+
+async def _scroll_all_points(
+    qdrant_client,
+    *,
+    collection: str,
+    max_points: int,
+) -> tuple[set[str], set[str], bool]:
+    """Enumerate a collection's point ids (sync client → to_thread).
+
+    Returns ``(present_ids, deprecated_payload_ids, truncated)``. ``truncated``
+    is True if the *max_points* budget was hit before exhausting the collection.
+    """
+    present: set[str] = set()
+    deprecated_ids: set[str] = set()
+    offset: str | None = None
+    truncated = False
+    page_limit = max(1, min(1000, max_points))
+    while True:
+        points, offset = await asyncio.to_thread(
+            qdrant_ops.scroll_points,
+            qdrant_client,
+            collection=collection,
+            limit=page_limit,
+            offset=offset,
+        )
+        for p in points:
+            pid = str(p["id"])
+            present.add(pid)
+            payload = p.get("payload") or {}
+            if payload.get("deprecated"):
+                deprecated_ids.add(pid)
+        if offset is None:
+            break  # collection exhausted — results are COMPLETE
+        if len(present) >= max_points:
+            truncated = True  # budget hit with more points remaining
+            break
+    return present, deprecated_ids, truncated
+
+
+# Severe classes are search-path ABSENCES: a memory that exists but cannot be
+# found via a retrieval lane (missing vector, or missing FTS row). These are the
+# silent-recall-degradation the system exists to surface, so they trip 'degraded'
+# at a small absolute floor. The remaining classes are pollution/attribution
+# issues (extra points, stale flags) — real but lower-severity, so they use a
+# looser corpus-fraction threshold to avoid a permanently-red tile over churn.
+_SEVERE_CLASSES = ("lying_mirror", "fts_invisible")
+_POLLUTION_CLASSES = ("ghost_points", "unexpected_vector", "deprecated_divergence", "fts_ghosts")
+
+
+async def run_consistency_check(
+    *,
+    db_path: str | None = None,
+    qdrant_client,
+    sample_fraction: float = 1.0,
+    max_points: int = 500_000,
+    severe_min_count: int = 5,
+    pollution_min_count: int = 50,
+    pollution_fraction: float = 0.01,
+    max_offender_sample: int = 25,
+) -> MemoryConsistencyReport:
+    """Run the read-only cross-backend consistency check.
+
+    ``sample_fraction`` is recorded for provenance; the scan is exact unless the
+    ``max_points`` budget is hit (then ``truncated=True`` and ``lying_mirror`` is
+    reported as ``-1`` = not-computed, since absence cannot be proven from a
+    partial point set). At single-user scale a full exact scan is cheap.
+
+    Status (severity-aware, Option A): ``degraded`` when the severe search-path-
+    absence classes reach ``severe_min_count`` OR the pollution classes reach
+    ``max(pollution_min_count, ceil(pollution_fraction * total))``.
+    """
+    start = time.monotonic()
+    conn = await open_ro_connection(db_path) if db_path else await open_ro_connection()
+    try:
+        rows = await conn.execute_fetchall(
+            "SELECT memory_id, collection, embedding_status, deprecated FROM memory_metadata"
+        )
+        total_rows = len(rows)
+        if total_rows == 0:
+            # Empty install / fresh state: nothing to be inconsistent about.
+            return MemoryConsistencyReport(
+                status="healthy",
+                counts={c: 0 for c in _CLASSES},
+                total_rows=0,
+                sampled_rows=0,
+                sample_fraction=sample_fraction,
+                duration_ms=int((time.monotonic() - start) * 1000),
+            )
+
+        meta_ids: set[str] = set()
+        embedded_ids: set[str] = set()
+        fts5_only_ids: set[str] = set()
+        deprecated_meta_ids: set[str] = set()
+        for mid, _collection, status, deprecated in rows:
+            mid = str(mid)
+            meta_ids.add(mid)
+            if status == "embedded":
+                embedded_ids.add(mid)
+            elif status == "fts5_only":
+                fts5_only_ids.add(mid)
+            if deprecated:
+                deprecated_meta_ids.add(mid)
+
+        # FTS <-> metadata drift (reuse the existing set-difference helper).
+        # NOTE: count_fts_metadata_drift is a whole-table distinct-id set
+        # difference — NOT scoped by embedding_status/deprecated and count-only
+        # (no offender ids). Safe today: store.store() writes an FTS row for
+        # EVERY memory regardless of status, and mark_superseded sets
+        # deprecated=1 without deleting the FTS row, so no legitimate row trips
+        # fts_invisible. fts_invisible is treated as SEVERE; if a future path can
+        # leave a metadata row without an FTS row, revisit the severity/scoping.
+        # Offender-id extraction for the FTS classes is a Phase-1 triage add.
+        try:
+            fts_ghosts, fts_invisible = await count_fts_metadata_drift(conn)
+        except Exception:
+            logger.warning("consistency: FTS drift query failed", exc_info=True)
+            return MemoryConsistencyReport(
+                status="unknown",
+                counts={c: 0 for c in _CLASSES},
+                total_rows=total_rows,
+                sample_fraction=sample_fraction,
+                unknown_reason="fts_unavailable",
+                duration_ms=int((time.monotonic() - start) * 1000),
+            )
+
+        # Qdrant enumeration across BOTH collections (collection-agnostic
+        # existence). Any transport failure → 'unknown', never a false finding.
+        present_ids: set[str] = set()
+        deprecated_qdrant_ids: set[str] = set()
+        truncated = False
+        try:
+            for collection in qdrant_ops.COLLECTIONS:
+                p, dep, trunc = await _scroll_all_points(
+                    qdrant_client, collection=collection, max_points=max_points
+                )
+                present_ids |= p
+                deprecated_qdrant_ids |= dep
+                truncated = truncated or trunc
+        except Exception as exc:
+            # Fail-closed in the correct direction: ANY failure enumerating
+            # Qdrant (enumerated transport errors, an exotic client exception, a
+            # None client) yields 'unknown' — never a 'degraded'/'healthy' that
+            # would report a dependency outage as data corruption. The set-
+            # algebra below is deliberately OUTSIDE this try, so it only runs on
+            # a fully-enumerated point set.
+            logger.warning(
+                "consistency: Qdrant enumeration failed — reporting unknown", exc_info=True
+            )
+            return MemoryConsistencyReport(
+                status="unknown",
+                counts={c: 0 for c in _CLASSES},
+                total_rows=total_rows,
+                sample_fraction=sample_fraction,
+                unknown_reason=f"qdrant_unavailable: {type(exc).__name__}",
+                duration_ms=int((time.monotonic() - start) * 1000),
+            )
+
+        # Classify via set algebra (collection-agnostic existence).
+        # INVARIANT (ghost_points): both Qdrant collections are populated
+        # EXCLUSIVELY via memory.store.store() -> create_metadata (episodic
+        # writes, knowledge_ingest, and the KB orchestrator all route through
+        # it; embedding_recovery only re-embeds existing metadata). So every
+        # legitimate point owns a metadata row, and present-minus-meta is a true
+        # orphan set. A future DIRECT upsert into either collection that bypasses
+        # create_metadata would manufacture false ghosts — update this if that
+        # ever happens.
+        ghost_points = present_ids - meta_ids
+        unexpected_vector = fts5_only_ids & present_ids
+        # deprecated divergence only for embedded rows that HAVE a point.
+        embedded_present = embedded_ids & present_ids
+        deprecated_divergence = {
+            mid
+            for mid in embedded_present
+            if (mid in deprecated_meta_ids) != (mid in deprecated_qdrant_ids)
+        }
+        if truncated:
+            # Cannot prove a vector's ABSENCE from a partial point set.
+            lying_mirror: set[str] | None = None
+        else:
+            lying_mirror = embedded_ids - present_ids
+
+        counts = {
+            "lying_mirror": (-1 if lying_mirror is None else len(lying_mirror)),
+            "ghost_points": len(ghost_points),
+            "fts_ghosts": int(fts_ghosts),
+            "fts_invisible": int(fts_invisible),
+            "unexpected_vector": len(unexpected_vector),
+            "deprecated_divergence": len(deprecated_divergence),
+        }
+        offender_sample = {
+            "lying_mirror": sorted(lying_mirror)[:max_offender_sample] if lying_mirror else [],
+            "ghost_points": sorted(ghost_points)[:max_offender_sample],
+            "unexpected_vector": sorted(unexpected_vector)[:max_offender_sample],
+            "deprecated_divergence": sorted(deprecated_divergence)[:max_offender_sample],
+        }
+
+        # Severity-aware status (Option A). Severe = search-path absences;
+        # pollution = extra/stale artifacts. A -1 (not-computed under truncation)
+        # never counts toward a threshold.
+        severe_total = sum(counts[c] for c in _SEVERE_CLASSES if counts[c] >= 0)
+        pollution_total = sum(counts[c] for c in _POLLUTION_CLASSES if counts[c] >= 0)
+        pollution_threshold = max(pollution_min_count, math.ceil(pollution_fraction * total_rows))
+        status = (
+            "degraded"
+            if severe_total >= severe_min_count or pollution_total >= pollution_threshold
+            else "healthy"
+        )
+
+        return MemoryConsistencyReport(
+            status=status,
+            counts=counts,
+            offender_sample=offender_sample,
+            total_rows=total_rows,
+            sampled_rows=total_rows,
+            sample_fraction=sample_fraction,
+            truncated=truncated,
+            duration_ms=int((time.monotonic() - start) * 1000),
+        )
+    finally:
+        await conn.close()

--- a/src/genesis/memory/integrity_config.py
+++ b/src/genesis/memory/integrity_config.py
@@ -1,0 +1,176 @@
+"""Memory-integrity control surface — mode lever + checker/probe knobs.
+
+The ONE place the memory-integrity jobs consult for policy (the
+repo_pulse_config lineage). Re-reads the merged YAML
+(``config/memory_integrity.yaml`` + user overlay
+``~/.genesis/config/memory_integrity.local.yaml``) on EVERY call — no boot
+cache, so an operator edit takes effect on the next scheduled run.
+
+Modes (``off | passive | active``):
+
+- ``passive`` (DEFAULT) — run the read-only checks and surface findings
+  (persist + posture alert + dashboard). Never repairs. This is the whole of
+  Phase 0.
+- ``active`` — RESERVED for Phase 1 (write-path/reconcile repair). Not yet
+  implemented, so it is coerced to ``passive`` with a warning: the system
+  should not silently believe repair is on when it is not.
+- ``off`` — do not run at all.
+
+Failure posture: an INVALID mode degrades to ``passive`` (still observing, no
+repair) — never to ``off``, because a silently-not-running integrity checker is
+itself the blind spot this subsystem exists to remove. Missing/corrupt config
+degrades layer-by-layer to DEFAULTS. The scheduler-level kill switch is
+separate: ``GENESIS_MEMORY_INTEGRITY_DISABLED=1`` skips job registration
+entirely.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports MODES from here, never the reverse.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "passive", "active")
+
+_CONFIG_NAME = "memory_integrity.yaml"
+_ENV_KILL_SWITCH = "GENESIS_MEMORY_INTEGRITY_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "mode": "passive",
+    # ── consistency checker ──
+    "sample_fraction": 1.0,  # 1.0 = exact full scan (cheap at single-user scale)
+    "max_points": 500_000,  # Qdrant scroll budget; exceeding it sets truncated
+    "severe_min_count": 5,  # lying_mirror + fts_invisible floor → degraded
+    "pollution_min_count": 50,  # ghost/unexpected/deprecated floor
+    "pollution_fraction": 0.01,  # or this fraction of the corpus, whichever higher
+    "max_offender_sample": 25,  # capped offender ids per class in the report
+    # ── recall-health probe ──
+    "probe_limit": 10,  # results retrieved per golden query
+    "max_probes_per_run": 25,  # cap golden cases exercised per run
+    "rerank": True,  # exercise the real rerank stage
+    "rerank_timeout_s": 10.0,  # wall-clock bound on rerank per query
+    "min_golden_for_status": 5,  # below this the run is 'unknown' (needs setup)
+    "baseline_window_runs": 7,  # trailing runs averaged for the drift baseline
+    "baseline_min_runs": 3,  # below this: observation period, no drift verdict
+    "drift_band": 0.2,  # degraded if baseline_hit_rate - hit_rate > this
+    # ── shared ──
+    "stale_report_days": 3,  # no non-unknown report within → staleness alert
+    "retention_days": 90,  # prune reports/probe runs older than this
+}
+
+_INT_KNOBS = (
+    "max_points",
+    "severe_min_count",
+    "pollution_min_count",
+    "max_offender_sample",
+    "probe_limit",
+    "max_probes_per_run",
+    "min_golden_for_status",
+    "baseline_window_runs",
+    "baseline_min_runs",
+    "stale_report_days",
+    "retention_days",
+)
+
+_FLOAT01_KNOBS = ("sample_fraction", "pollution_fraction", "drift_band")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("memory_integrity base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("memory_integrity overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def env_disabled() -> bool:
+    """True if the scheduler-level kill switch is set."""
+    return os.environ.get(_ENV_KILL_SWITCH, "").strip().lower() in ("1", "true", "yes")
+
+
+def effective_mode() -> str:
+    """The mode the jobs must run under — read live.
+
+    Env kill switch or master ``enabled: false`` → ``off``. ``active`` is
+    coerced to ``passive`` in Phase 0 (repair not yet implemented). An invalid
+    value degrades to ``passive`` — still observing, never a silent ``off``.
+    """
+    if env_disabled():
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # YAML-1.1 unquoted `mode: off` → boolean False. Honor the intent.
+        return "off"
+    if mode == "active":
+        logger.warning(
+            "memory_integrity mode 'active' is reserved for Phase 1 (repair not "
+            "implemented) — running 'passive'"
+        )
+        return "passive"
+    if mode not in MODES:
+        logger.warning("memory_integrity has invalid mode %r — degrading to passive", mode)
+        return "passive"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never crashes a
+    job or zeroes a limit."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def knob_float01(cfg: dict[str, Any], key: str) -> float:
+    """[0,1] float knob with DEFAULTS fallback."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not 0 <= value <= 1:
+        return float(DEFAULTS[key])
+    return float(value)
+
+
+def knob_float(cfg: dict[str, Any], key: str) -> float:
+    """Positive-float knob with DEFAULTS fallback (for unbounded values like
+    ``rerank_timeout_s``)."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        return float(DEFAULTS[key])
+    return float(value)

--- a/src/genesis/memory/recall_probe.py
+++ b/src/genesis/memory/recall_probe.py
@@ -1,0 +1,198 @@
+"""Recall-health golden-set probe — Phase 0 "make silence loud".
+
+Runs an install-local golden set of ``query -> expected_memory_id(s)`` cases
+through the REAL recall pipeline (``HybridRetriever.recall``) and measures
+hit-rate + mean reciprocal rank, tracking drift against a trailing baseline.
+This is the recall-quality half of the integrity spine: the consistency checker
+proves a memory is *stored* correctly; the probe proves a memory is still
+*findable*.
+
+Golden set is an install-local FILE (``~/.genesis/eval/golden/
+memory_integrity_recall.jsonl``) per the #1143 convention — real cases carry
+recalled-memory ids (PII-adjacent) and never live in the repo; a committed
+template documents the schema. Seed it with
+``scripts/seed_recall_golden_set.py --suggest N``.
+
+Probe guardrails (all real ``recall`` params):
+- ``skip_writeback=lambda _r: True`` — recall() normally bumps activation on hits
+  (read-MOSTLY). A daily probe that entrenched its golden memories would distort
+  the very ranking it measures, so write-back is disabled for probe recalls.
+- ``source="both"`` — the collection selector; the whole recall pipeline. NOTE:
+  probe recalls still emit a ``recall_fired`` eval event (skip_writeback does not
+  gate the emit, and ``source`` is not a free attribution tag), so ~one event
+  per golden case per run lands in ``eval_events`` tagged ``both`` — a small,
+  monitor-only footprint. The seeder therefore excludes queries ALREADY in the
+  golden set (not by source) so the set can never feed on itself.
+- ``rerank_timeout_s`` bounds the cross-encoder stage; ``max_probes`` caps work.
+
+Fail-closed: an empty/too-small golden set → ``unknown`` (needs setup, not
+alarmed); a retriever that is absent or raises → ``unknown`` (a measurement
+failure must not read as recall degradation).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_GOLDEN = Path.home() / ".genesis" / "eval" / "golden" / "memory_integrity_recall.jsonl"
+
+
+@dataclass
+class RecallProbeResult:
+    status: str  # healthy | degraded | unknown
+    probes_total: int = 0
+    probes_hit: int = 0
+    hit_rate: float | None = None
+    mean_rr: float | None = None
+    baseline_hit_rate: float | None = None
+    drift: float | None = None
+    details: list[dict] = field(default_factory=list)
+    unknown_reason: str | None = None
+    duration_ms: int = 0
+
+
+def load_golden_set(path: Path | str | None = None) -> list[dict]:
+    """Load golden cases from the install-local JSONL file.
+
+    Skips blank lines and ``#`` comments (the template convention). Each case
+    must carry a ``query`` and a non-empty ``expected_memory_ids`` list; malformed
+    lines are skipped with a warning rather than crashing the probe. Returns
+    ``[]`` when the file is absent (fresh install) — the caller maps that to
+    ``unknown``.
+    """
+    p = Path(path) if path else _DEFAULT_GOLDEN
+    if not p.exists():
+        return []
+    cases: list[dict] = []
+    for raw in p.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            case = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("recall_probe: skipping malformed golden line", exc_info=True)
+            continue
+        query = case.get("query")
+        expected = case.get("expected_memory_ids") or []
+        if not query or not isinstance(expected, list) or not expected:
+            logger.warning("recall_probe: skipping golden case missing query/expected_memory_ids")
+            continue
+        cases.append(
+            {"id": case.get("id", ""), "query": query, "expected": [str(e) for e in expected]}
+        )
+    return cases
+
+
+async def run_recall_probe(
+    *,
+    db,
+    retriever,
+    golden_path: Path | str | None = None,
+    probe_limit: int = 10,
+    max_probes: int = 25,
+    rerank: bool = True,
+    rerank_timeout_s: float = 10.0,
+    min_golden_for_status: int = 5,
+    baseline_window_runs: int = 7,
+    baseline_min_runs: int = 3,
+    drift_band: float = 0.2,
+) -> RecallProbeResult:
+    """Run the recall-health probe. ``db`` is used only to read the trailing
+    baseline (persistence is the caller's job)."""
+    start = time.monotonic()
+
+    def _elapsed() -> int:
+        return int((time.monotonic() - start) * 1000)
+
+    if retriever is None:
+        return RecallProbeResult(
+            status="unknown", unknown_reason="retriever_unavailable", duration_ms=_elapsed()
+        )
+
+    golden = load_golden_set(golden_path)
+    if len(golden) < min_golden_for_status:
+        return RecallProbeResult(
+            status="unknown",
+            probes_total=len(golden),
+            unknown_reason="golden_set_too_small",
+            duration_ms=_elapsed(),
+        )
+
+    cases = golden[:max_probes]
+    details: list[dict] = []
+    hits = 0
+    rr_sum = 0.0
+    for case in cases:
+        try:
+            results = await retriever.recall(
+                case["query"],
+                limit=probe_limit,
+                rerank=rerank,
+                rerank_timeout_s=rerank_timeout_s,
+                # `source` is the COLLECTION selector (episodic|knowledge|both),
+                # NOT an attribution tag — an invalid value raises ValueError.
+                # 'both' exercises the whole recall pipeline the probe measures.
+                source="both",
+                # skip activation write-back so a daily probe never entrenches
+                # its own golden memories and distorts the ranking it measures.
+                skip_writeback=lambda _r: True,
+            )
+        except Exception as exc:
+            # A measurement failure (provider/rerank/DB outage) must NOT be
+            # scored as a recall miss — that would fabricate degradation. Abort
+            # the whole run to 'unknown', consistent with the checker's stance.
+            logger.warning("recall_probe: recall() failed — reporting unknown", exc_info=True)
+            return RecallProbeResult(
+                status="unknown",
+                probes_total=len(cases),
+                unknown_reason=f"recall_error: {type(exc).__name__}",
+                duration_ms=_elapsed(),
+            )
+        retrieved = [str(r.memory_id) for r in results]
+        expected = set(case["expected"])
+        rank: int | None = None
+        for i, mid in enumerate(retrieved):
+            if mid in expected:
+                rank = i + 1
+                break
+        hit = rank is not None
+        if hit:
+            hits += 1
+            rr_sum += 1.0 / rank
+        details.append({"id": case["id"], "hit": hit, "rank": rank})
+
+    total = len(cases)
+    hit_rate = hits / total if total else 0.0
+    mean_rr = rr_sum / total if total else 0.0
+
+    # Trailing baseline over PRIOR non-unknown runs (current run not yet stored).
+    from genesis.db.crud import memory_integrity as mi_crud
+
+    baseline, n_runs = await mi_crud.trailing_hit_rate(db, window=baseline_window_runs)
+    if baseline is None or n_runs < baseline_min_runs:
+        # Observation period — not enough history to call drift yet.
+        status = "healthy"
+        baseline = None
+        drift = None
+    else:
+        drift = baseline - hit_rate
+        status = "degraded" if drift > drift_band else "healthy"
+
+    return RecallProbeResult(
+        status=status,
+        probes_total=total,
+        probes_hit=hits,
+        hit_rate=hit_rate,
+        mean_rr=mean_rr,
+        baseline_hit_rate=baseline,
+        drift=drift,
+        details=details,
+        duration_ms=_elapsed(),
+    )

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -89,9 +89,7 @@ def ensure_payload_indexes(client: QdrantClient) -> None:
                 )
             except Exception:
                 logger.warning(
-                    "payload index %s.%s not created",
-                    collection,
-                    field,
+                    "payload index %s.%s not created", collection, field,
                     exc_info=True,
                 )
 
@@ -188,18 +186,30 @@ def search(
     # must_not only excludes points where the field exists AND matches.
     # Pass include_deprecated=True for audit/history queries.
     if not include_deprecated:
-        must_not_conditions.append(FieldCondition(key="deprecated", match=MatchValue(value=True)))
+        must_not_conditions.append(
+            FieldCondition(key="deprecated", match=MatchValue(value=True))
+        )
 
     if source_type:
-        conditions.append(FieldCondition(key="source_type", match=MatchValue(value=source_type)))
+        conditions.append(
+            FieldCondition(key="source_type", match=MatchValue(value=source_type))
+        )
     if wing:
-        conditions.append(FieldCondition(key="wing", match=MatchValue(value=wing)))
+        conditions.append(
+            FieldCondition(key="wing", match=MatchValue(value=wing))
+        )
     if room:
-        conditions.append(FieldCondition(key="room", match=MatchValue(value=room)))
+        conditions.append(
+            FieldCondition(key="room", match=MatchValue(value=room))
+        )
     if life_domain:
-        conditions.append(FieldCondition(key="life_domain", match=MatchValue(value=life_domain)))
+        conditions.append(
+            FieldCondition(key="life_domain", match=MatchValue(value=life_domain))
+        )
     if project_type:
-        conditions.append(FieldCondition(key="project_type", match=MatchValue(value=project_type)))
+        conditions.append(
+            FieldCondition(key="project_type", match=MatchValue(value=project_type))
+        )
     if include_only_subsystems:
         conditions.append(
             FieldCondition(
@@ -215,14 +225,15 @@ def search(
             )
         )
     if tags_any:
-        conditions.append(FieldCondition(key="tags", match=MatchAny(any=list(tags_any))))
+        conditions.append(
+            FieldCondition(key="tags", match=MatchAny(any=list(tags_any)))
+        )
     if created_before:
         from qdrant_client.models import DatetimeRange
 
         conditions.append(
             FieldCondition(
-                key="created_at",
-                range=DatetimeRange(lte=created_before),
+                key="created_at", range=DatetimeRange(lte=created_before),
             )
         )
     query_filter = Filter(
@@ -242,11 +253,14 @@ def search(
         search_params=search_params,
     )
     return [
-        {"id": str(hit.id), "score": hit.score, "payload": hit.payload} for hit in results.points
+        {"id": str(hit.id), "score": hit.score, "payload": hit.payload}
+        for hit in results.points
     ]
 
 
-def delete_point(client: QdrantClient, *, collection: str, point_id: str) -> None:
+def delete_point(
+    client: QdrantClient, *, collection: str, point_id: str
+) -> None:
     """Delete a point by ID."""
     from qdrant_client.models import PointIdsList
 
@@ -359,7 +373,8 @@ def scroll_points(
         from qdrant_client.models import FieldCondition, Filter, MatchValue
 
         conditions = [
-            FieldCondition(key=k, match=MatchValue(value=v)) for k, v in payload_filter.items()
+            FieldCondition(key=k, match=MatchValue(value=v))
+            for k, v in payload_filter.items()
         ]
         scroll_filter = Filter(must=conditions)
 
@@ -371,11 +386,16 @@ def scroll_points(
         with_payload=True,
         with_vectors=False,
     )
-    points = [{"id": str(point.id), "payload": point.payload} for point in results]
+    points = [
+        {"id": str(point.id), "payload": point.payload}
+        for point in results
+    ]
     return points, str(next_offset) if next_offset else None
 
 
-def delete_collection(client: QdrantClient, collection: str, *, force: bool = False) -> bool:
+def delete_collection(
+    client: QdrantClient, collection: str, *, force: bool = False
+) -> bool:
     """Delete a Qdrant collection.
 
     Refuses to delete production collections (episodic_memory, knowledge_base)
@@ -384,7 +404,8 @@ def delete_collection(client: QdrantClient, collection: str, *, force: bool = Fa
     """
     if collection in _PROTECTED_COLLECTIONS and not force:
         raise ValueError(
-            f"Refusing to delete protected collection '{collection}'. Pass force=True to override."
+            f"Refusing to delete protected collection '{collection}'. "
+            f"Pass force=True to override."
         )
     return client.delete_collection(collection)
 

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -89,7 +89,9 @@ def ensure_payload_indexes(client: QdrantClient) -> None:
                 )
             except Exception:
                 logger.warning(
-                    "payload index %s.%s not created", collection, field,
+                    "payload index %s.%s not created",
+                    collection,
+                    field,
                     exc_info=True,
                 )
 
@@ -186,30 +188,18 @@ def search(
     # must_not only excludes points where the field exists AND matches.
     # Pass include_deprecated=True for audit/history queries.
     if not include_deprecated:
-        must_not_conditions.append(
-            FieldCondition(key="deprecated", match=MatchValue(value=True))
-        )
+        must_not_conditions.append(FieldCondition(key="deprecated", match=MatchValue(value=True)))
 
     if source_type:
-        conditions.append(
-            FieldCondition(key="source_type", match=MatchValue(value=source_type))
-        )
+        conditions.append(FieldCondition(key="source_type", match=MatchValue(value=source_type)))
     if wing:
-        conditions.append(
-            FieldCondition(key="wing", match=MatchValue(value=wing))
-        )
+        conditions.append(FieldCondition(key="wing", match=MatchValue(value=wing)))
     if room:
-        conditions.append(
-            FieldCondition(key="room", match=MatchValue(value=room))
-        )
+        conditions.append(FieldCondition(key="room", match=MatchValue(value=room)))
     if life_domain:
-        conditions.append(
-            FieldCondition(key="life_domain", match=MatchValue(value=life_domain))
-        )
+        conditions.append(FieldCondition(key="life_domain", match=MatchValue(value=life_domain)))
     if project_type:
-        conditions.append(
-            FieldCondition(key="project_type", match=MatchValue(value=project_type))
-        )
+        conditions.append(FieldCondition(key="project_type", match=MatchValue(value=project_type)))
     if include_only_subsystems:
         conditions.append(
             FieldCondition(
@@ -225,15 +215,14 @@ def search(
             )
         )
     if tags_any:
-        conditions.append(
-            FieldCondition(key="tags", match=MatchAny(any=list(tags_any)))
-        )
+        conditions.append(FieldCondition(key="tags", match=MatchAny(any=list(tags_any))))
     if created_before:
         from qdrant_client.models import DatetimeRange
 
         conditions.append(
             FieldCondition(
-                key="created_at", range=DatetimeRange(lte=created_before),
+                key="created_at",
+                range=DatetimeRange(lte=created_before),
             )
         )
     query_filter = Filter(
@@ -253,14 +242,11 @@ def search(
         search_params=search_params,
     )
     return [
-        {"id": str(hit.id), "score": hit.score, "payload": hit.payload}
-        for hit in results.points
+        {"id": str(hit.id), "score": hit.score, "payload": hit.payload} for hit in results.points
     ]
 
 
-def delete_point(
-    client: QdrantClient, *, collection: str, point_id: str
-) -> None:
+def delete_point(client: QdrantClient, *, collection: str, point_id: str) -> None:
     """Delete a point by ID."""
     from qdrant_client.models import PointIdsList
 
@@ -324,6 +310,38 @@ def batch_retrieve_vectors(
     return vector_map
 
 
+def batch_retrieve_point_ids(
+    client: QdrantClient,
+    point_ids: list[str],
+    *,
+    collection: str,
+    batch_size: int = 100,
+) -> set[str]:
+    """Return the SUBSET of *point_ids* that EXIST in *collection*.
+
+    Unlike :func:`batch_retrieve_vectors`, this RAISES on any transport/protocol
+    failure instead of swallowing it. The distinction is load-bearing for the
+    consistency checker: a swallowed error makes "Qdrant is unreachable" look
+    identical to "every vector is missing" — a false data-corruption alarm. The
+    checker must be able to tell those apart (unreachable → status 'unknown';
+    genuinely-absent → a real finding), so it needs a helper that fails loud.
+
+    Existence-only: requests neither payload nor vectors (cheapest retrieve).
+    """
+    present: set[str] = set()
+    for i in range(0, len(point_ids), batch_size):
+        batch = point_ids[i : i + batch_size]
+        results = client.retrieve(
+            collection_name=collection,
+            ids=batch,
+            with_payload=False,
+            with_vectors=False,
+        )
+        for r in results:
+            present.add(str(r.id))
+    return present
+
+
 def scroll_points(
     client: QdrantClient,
     *,
@@ -341,8 +359,7 @@ def scroll_points(
         from qdrant_client.models import FieldCondition, Filter, MatchValue
 
         conditions = [
-            FieldCondition(key=k, match=MatchValue(value=v))
-            for k, v in payload_filter.items()
+            FieldCondition(key=k, match=MatchValue(value=v)) for k, v in payload_filter.items()
         ]
         scroll_filter = Filter(must=conditions)
 
@@ -354,16 +371,11 @@ def scroll_points(
         with_payload=True,
         with_vectors=False,
     )
-    points = [
-        {"id": str(point.id), "payload": point.payload}
-        for point in results
-    ]
+    points = [{"id": str(point.id), "payload": point.payload} for point in results]
     return points, str(next_offset) if next_offset else None
 
 
-def delete_collection(
-    client: QdrantClient, collection: str, *, force: bool = False
-) -> bool:
+def delete_collection(client: QdrantClient, collection: str, *, force: bool = False) -> bool:
     """Delete a Qdrant collection.
 
     Refuses to delete production collections (episodic_memory, knowledge_base)
@@ -372,8 +384,7 @@ def delete_collection(
     """
     if collection in _PROTECTED_COLLECTIONS and not force:
         raise ValueError(
-            f"Refusing to delete protected collection '{collection}'. "
-            f"Pass force=True to override."
+            f"Refusing to delete protected collection '{collection}'. Pass force=True to override."
         )
     return client.delete_collection(collection)
 

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -324,38 +324,6 @@ def batch_retrieve_vectors(
     return vector_map
 
 
-def batch_retrieve_point_ids(
-    client: QdrantClient,
-    point_ids: list[str],
-    *,
-    collection: str,
-    batch_size: int = 100,
-) -> set[str]:
-    """Return the SUBSET of *point_ids* that EXIST in *collection*.
-
-    Unlike :func:`batch_retrieve_vectors`, this RAISES on any transport/protocol
-    failure instead of swallowing it. The distinction is load-bearing for the
-    consistency checker: a swallowed error makes "Qdrant is unreachable" look
-    identical to "every vector is missing" — a false data-corruption alarm. The
-    checker must be able to tell those apart (unreachable → status 'unknown';
-    genuinely-absent → a real finding), so it needs a helper that fails loud.
-
-    Existence-only: requests neither payload nor vectors (cheapest retrieve).
-    """
-    present: set[str] = set()
-    for i in range(0, len(point_ids), batch_size):
-        batch = point_ids[i : i + batch_size]
-        results = client.retrieve(
-            collection_name=collection,
-            ids=batch,
-            with_payload=False,
-            with_vectors=False,
-        )
-        for r in results:
-            present.add(str(r.id))
-    return present
-
-
 def scroll_points(
     client: QdrantClient,
     *,

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1333,6 +1333,12 @@ async def init(rt: GenesisRuntime) -> None:
         # testable seam so the registration is covered, not just the crud prunes).
         _wire_drip_retention_jobs(rt._learning_scheduler, rt)
 
+        # Memory integrity Phase 0 — read-only consistency check + recall-health
+        # probe (off-peak CronTrigger; mode-gated, self-persisting).
+        from genesis.runtime.init.memory_integrity import _wire_memory_integrity_jobs
+
+        _wire_memory_integrity_jobs(rt._learning_scheduler, rt)
+
         # NOTE: the daily deep `git fsck --full` (F.1) is NOT wired here. It runs
         # from the awareness loop (`_check_git_health_deep`) on a ~daily guard so
         # it survives a router-degraded startup that skips this learning init.

--- a/src/genesis/runtime/init/memory_integrity.py
+++ b/src/genesis/runtime/init/memory_integrity.py
@@ -1,0 +1,166 @@
+"""Scheduled memory-integrity jobs — Phase 0 "make silence loud".
+
+Two restart-safe off-peak jobs, registered on the learning scheduler via a
+testable seam (the ``_wire_drip_retention_jobs`` precedent):
+
+- ``memory_consistency_check`` (03:50 local) — the read-only cross-backend
+  consistency scan (memory_metadata <-> Qdrant <-> memory_fts).
+- ``recall_health_probe`` (03:20 local) — the golden-set recall-health probe
+  through the real retriever.
+
+Both no-op when ``effective_mode() == 'off'`` (recording success so the job
+looks healthy, not stuck), read all knobs live from the config, and persist one
+row per run. The persisted rows are the fact store the awareness posture check
+and the dashboard tile read — the jobs never raise alerts themselves (decoupled
+surfacing).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.env import user_timezone
+from genesis.memory import integrity_config
+
+logger = logging.getLogger(__name__)
+
+
+def _wire_memory_integrity_jobs(scheduler, rt) -> None:
+    """Register the two Phase-0 integrity jobs on *scheduler*."""
+    from apscheduler.triggers.cron import CronTrigger
+
+    async def _run_recall_probe() -> None:
+        if rt._db is None:
+            return
+        if integrity_config.effective_mode() == "off":
+            rt.record_job_success("recall_health_probe")
+            return
+        try:
+            from genesis.db.crud import memory_integrity as mi_crud
+            from genesis.memory.recall_probe import run_recall_probe
+
+            cfg = integrity_config.load_config()
+            result = await run_recall_probe(
+                db=rt._db,
+                retriever=rt._hybrid_retriever,
+                probe_limit=integrity_config.knob_int(cfg, "probe_limit"),
+                max_probes=integrity_config.knob_int(cfg, "max_probes_per_run"),
+                rerank=bool(cfg.get("rerank", True)),
+                rerank_timeout_s=integrity_config.knob_float(cfg, "rerank_timeout_s"),
+                min_golden_for_status=integrity_config.knob_int(cfg, "min_golden_for_status"),
+                baseline_window_runs=integrity_config.knob_int(cfg, "baseline_window_runs"),
+                baseline_min_runs=integrity_config.knob_int(cfg, "baseline_min_runs"),
+                drift_band=integrity_config.knob_float01(cfg, "drift_band"),
+            )
+            await mi_crud.insert_recall_probe_run(
+                rt._db,
+                status=result.status,
+                probes_total=result.probes_total,
+                probes_hit=result.probes_hit,
+                hit_rate=result.hit_rate,
+                mean_rr=result.mean_rr,
+                baseline_hit_rate=result.baseline_hit_rate,
+                drift=result.drift,
+                details=result.details,
+                unknown_reason=result.unknown_reason,
+                duration_ms=result.duration_ms,
+            )
+            rt.record_job_success("recall_health_probe")
+            logger.info(
+                "recall health probe: status=%s hit_rate=%s drift=%s",
+                result.status,
+                result.hit_rate,
+                result.drift,
+            )
+        except Exception as exc:
+            rt.record_job_failure("recall_health_probe", exc=exc)
+            logger.exception("recall health probe failed")
+
+    scheduler.add_job(
+        _run_recall_probe,
+        CronTrigger(hour=3, minute=20, timezone=user_timezone()),
+        id="recall_health_probe",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
+    async def _run_consistency_check() -> None:
+        if rt._db is None:
+            return
+        if integrity_config.effective_mode() == "off":
+            rt.record_job_success("memory_consistency_check")
+            return
+        try:
+            from genesis.db.crud import memory_integrity as mi_crud
+            from genesis.memory.integrity import run_consistency_check
+            from genesis.qdrant.collections import get_client
+
+            cfg = integrity_config.load_config()
+            report = await run_consistency_check(
+                qdrant_client=get_client(),
+                sample_fraction=integrity_config.knob_float01(cfg, "sample_fraction"),
+                max_points=integrity_config.knob_int(cfg, "max_points"),
+                severe_min_count=integrity_config.knob_int(cfg, "severe_min_count"),
+                pollution_min_count=integrity_config.knob_int(cfg, "pollution_min_count"),
+                pollution_fraction=integrity_config.knob_float01(cfg, "pollution_fraction"),
+                max_offender_sample=integrity_config.knob_int(cfg, "max_offender_sample"),
+            )
+            await mi_crud.insert_consistency_report(
+                rt._db,
+                status=report.status,
+                counts=report.counts,
+                total_rows=report.total_rows,
+                sampled_rows=report.sampled_rows,
+                sample_fraction=report.sample_fraction,
+                truncated=report.truncated,
+                offender_sample=report.offender_sample,
+                unknown_reason=report.unknown_reason,
+                duration_ms=report.duration_ms,
+            )
+            rt.record_job_success("memory_consistency_check")
+            logger.info(
+                "memory consistency check: status=%s findings=%d",
+                report.status,
+                report.total_findings,
+            )
+        except Exception as exc:
+            rt.record_job_failure("memory_consistency_check", exc=exc)
+            logger.exception("memory consistency check failed")
+
+    scheduler.add_job(
+        _run_consistency_check,
+        CronTrigger(hour=3, minute=50, timezone=user_timezone()),
+        id="memory_consistency_check",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )
+
+    async def _prune_memory_integrity() -> None:
+        if rt._db is None:
+            return
+        try:
+            from datetime import UTC, datetime
+
+            from genesis.db.crud import memory_integrity as mi_crud
+
+            cfg = integrity_config.load_config()
+            now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+            removed = await mi_crud.prune_memory_integrity(
+                rt._db,
+                older_than_days=integrity_config.knob_int(cfg, "retention_days"),
+                now=now,
+            )
+            rt.record_job_success("memory_integrity_prune")
+            if removed:
+                logger.info("memory_integrity prune: removed %d rows", removed)
+        except Exception as exc:
+            rt.record_job_failure("memory_integrity_prune", exc=exc)
+            logger.exception("memory_integrity prune failed")
+
+    scheduler.add_job(
+        _prune_memory_integrity,
+        CronTrigger(hour=4, minute=15, timezone=user_timezone()),
+        id="memory_integrity_prune",
+        max_instances=1,
+        misfire_grace_time=3600,
+    )

--- a/tests/eval/golden/memory_integrity_recall.jsonl
+++ b/tests/eval/golden/memory_integrity_recall.jsonl
@@ -1,0 +1,20 @@
+# Golden set TEMPLATE for the memory-integrity recall-health probe.
+#
+# This committed file is a TEMPLATE ONLY — it carries ZERO real cases. Real
+# cases reference recalled-memory ids (PII-adjacent) and live install-local at
+#   ~/.genesis/eval/golden/memory_integrity_recall.jsonl
+# (encrypted-backed-up via scripts/backup.sh per the #1143 convention; never in
+# the repo). Seed the real file with:
+#   python scripts/seed_recall_golden_set.py --suggest 20
+#
+# One case per line. Lines starting with "#" and blank lines are skipped.
+# Schema:
+#   {"id": "<stable case id>",
+#    "query": "<the query text to run through the real recall pipeline>",
+#    "expected_memory_ids": ["<memory_id that SHOULD be retrieved>", ...],
+#    "notes": "<optional: why this pair is a good stable probe>"}
+#
+# A case "hits" if ANY expected_memory_id appears in the top-N recall results;
+# rank is the 1-based position of the first expected id (drives mean reciprocal
+# rank). The probe reports 'unknown' (needs setup) until at least
+# min_golden_for_status (default 5) real cases exist.

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -165,6 +165,8 @@ async def test_no_unexpected_tables(db):
         "entity_links",  # entity layer (WS-H P2)
         "job_run_events",
         "alert_events",  # WS-2 sensor fabric (M9/M10)
+        "memory_consistency_reports",
+        "recall_probe_runs",  # memory integrity Phase 0 ("make silence loud")
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_memory_integrity/conftest.py
+++ b/tests/test_memory_integrity/conftest.py
@@ -1,0 +1,115 @@
+"""Shared fixtures for memory-integrity tests.
+
+Install-agnostic: a real file-backed SQLite schema in ``tmp_path`` (the checker
+opens its own ``mode=ro`` connection to a path, so it needs a file, not
+``:memory:``) and a ``FakeQdrantClient`` with just the ``scroll``/``retrieve``
+surface the checker uses — no network, no live Qdrant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiosqlite
+
+
+@dataclass
+class _Point:
+    id: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+class FakeQdrantClient:
+    """Minimal in-memory stand-in for QdrantClient.
+
+    ``points``: ``{collection: {point_id: payload_dict}}``. Set ``raise_on`` to
+    a method name (``"scroll"``/``"retrieve"``) to simulate an unreachable
+    Qdrant — the method raises ``ConnectionError`` (caught by the checker's
+    ``_QDRANT_ERRORS`` and mapped to status='unknown').
+    """
+
+    def __init__(
+        self,
+        points: dict[str, dict[str, dict]] | None = None,
+        *,
+        raise_on: str | None = None,
+    ) -> None:
+        self.points = points or {}
+        self.raise_on = raise_on
+
+    def scroll(
+        self,
+        *,
+        collection_name: str,
+        limit: int = 1000,
+        offset: str | None = None,
+        scroll_filter=None,
+        with_payload: bool = True,
+        with_vectors: bool = False,
+    ):
+        if self.raise_on == "scroll":
+            raise ConnectionError("fake qdrant down")
+        coll = self.points.get(collection_name, {})
+        ids = sorted(coll.keys())
+        start = 0
+        if offset is not None:
+            # offset is the id to resume *at* (Qdrant returns the offset point as
+            # the first of the next page); find its index.
+            start = ids.index(offset) if offset in ids else len(ids)
+        page = ids[start : start + limit]
+        pts = [_Point(pid, coll[pid]) for pid in page]
+        next_offset = None
+        end = start + limit
+        if end < len(ids):
+            next_offset = ids[end]
+        return pts, next_offset
+
+    def retrieve(
+        self,
+        *,
+        collection_name: str,
+        ids: list[str],
+        with_payload: bool = False,
+        with_vectors: bool = False,
+    ):
+        if self.raise_on == "retrieve":
+            raise ConnectionError("fake qdrant down")
+        coll = self.points.get(collection_name, {})
+        return [_Point(pid, coll[pid]) for pid in ids if pid in coll]
+
+
+async def build_db(path: str) -> None:
+    """Create a full-schema file DB at *path* (fresh-install tables)."""
+    from genesis.db.schema import create_all_tables
+
+    conn = await aiosqlite.connect(path)
+    await create_all_tables(conn)
+    await conn.commit()
+    await conn.close()
+
+
+async def insert_memory(
+    path: str,
+    memory_id: str,
+    *,
+    status: str = "embedded",
+    collection: str = "episodic_memory",
+    deprecated: int = 0,
+    in_fts: bool = True,
+) -> None:
+    """Insert one memory into memory_metadata (+ optionally memory_fts)."""
+    conn = await aiosqlite.connect(path)
+    await conn.execute(
+        "INSERT INTO memory_metadata (memory_id, created_at, collection, embedding_status, deprecated) "
+        "VALUES (?, datetime('now'), ?, ?, ?)",
+        (memory_id, collection, status, deprecated),
+    )
+    if in_fts:
+        await conn.execute(
+            "INSERT INTO memory_fts (memory_id, content, source_type, tags, collection) "
+            "VALUES (?, ?, 'test', '', ?)",
+            (memory_id, f"content for {memory_id}", collection),
+        )
+    await conn.commit()
+    await conn.close()

--- a/tests/test_memory_integrity/conftest.py
+++ b/tests/test_memory_integrity/conftest.py
@@ -12,6 +12,19 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import aiosqlite
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_mi_table_cache():
+    """The crud module caches table-existence in a process global; a bare-DB
+    (pre-migration) test can leave it False and bleed into a later test under
+    CI's randomized order. Reset around every integrity test."""
+    from genesis.db.crud import memory_integrity as _mi
+
+    _mi._tables_verified = False
+    yield
+    _mi._tables_verified = False
 
 
 @dataclass

--- a/tests/test_memory_integrity/test_crud_and_config.py
+++ b/tests/test_memory_integrity/test_crud_and_config.py
@@ -78,6 +78,37 @@ async def test_trailing_hit_rate_excludes_unknown(tmp_path):
     await conn.close()
 
 
+async def test_latest_is_deterministic_same_second(tmp_path):
+    """Two reports written in the same second must resolve 'latest' by insertion
+    order (rowid), not by random uuid id — regression for a resolve flake."""
+    conn = await _conn(tmp_path)
+    for _ in range(20):
+        await mi.insert_consistency_report(
+            conn,
+            status="degraded",
+            counts={"lying_mirror": 9},
+            total_rows=100,
+            sampled_rows=100,
+            sample_fraction=1.0,
+            truncated=False,
+        )
+        await mi.insert_consistency_report(
+            conn,
+            status="healthy",
+            counts={},
+            total_rows=100,
+            sampled_rows=100,
+            sample_fraction=1.0,
+            truncated=False,
+        )
+        latest = await mi.latest_consistency_report(conn)
+        # healthy was inserted last → must always be latest
+        assert latest["status"] == "healthy"
+        await conn.execute("DELETE FROM memory_consistency_reports")
+        await conn.commit()
+    await conn.close()
+
+
 async def test_trailing_hit_rate_no_runs_is_none(tmp_path):
     conn = await _conn(tmp_path)
     mean, n = await mi.trailing_hit_rate(conn, window=7)

--- a/tests/test_memory_integrity/test_crud_and_config.py
+++ b/tests/test_memory_integrity/test_crud_and_config.py
@@ -109,6 +109,36 @@ async def test_latest_is_deterministic_same_second(tmp_path):
     await conn.close()
 
 
+async def test_trailing_hit_rate_excludes_degraded(tmp_path):
+    """Baseline is KNOWN-GOOD only — degraded runs must not lower the bar and
+    normalize a sustained drop (P2)."""
+    conn = await _conn(tmp_path)
+    for i in range(3):
+        await mi.insert_recall_probe_run(
+            conn,
+            status="healthy",
+            probes_total=10,
+            probes_hit=9,
+            hit_rate=0.9,
+            mean_rr=0.9,
+            created_at=f"2026-07-2{i} 03:00:00",
+        )
+    for i in range(3):
+        await mi.insert_recall_probe_run(
+            conn,
+            status="degraded",
+            probes_total=10,
+            probes_hit=5,
+            hit_rate=0.5,
+            mean_rr=0.5,
+            created_at=f"2026-07-2{i + 3} 03:00:00",
+        )
+    mean, n = await mi.trailing_hit_rate(conn, window=7)
+    assert n == 3  # only the healthy runs
+    assert abs(mean - 0.9) < 1e-9  # degraded 0.5s excluded → baseline stays 0.9
+    await conn.close()
+
+
 async def test_trailing_hit_rate_no_runs_is_none(tmp_path):
     conn = await _conn(tmp_path)
     mean, n = await mi.trailing_hit_rate(conn, window=7)

--- a/tests/test_memory_integrity/test_crud_and_config.py
+++ b/tests/test_memory_integrity/test_crud_and_config.py
@@ -1,0 +1,166 @@
+"""CRUD round-trip / prune / baseline tests."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import memory_integrity as mi
+
+from .conftest import build_db
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _conn(tmp_path):
+    path = str(tmp_path / "t.db")
+    await build_db(path)
+    conn = await aiosqlite.connect(path)
+    return conn
+
+
+# ── crud ──────────────────────────────────────────────────────────────────
+
+
+async def test_consistency_report_round_trip(tmp_path):
+    conn = await _conn(tmp_path)
+    rid = await mi.insert_consistency_report(
+        conn,
+        status="degraded",
+        counts={"lying_mirror": 3, "ghost_points": 7},
+        total_rows=100,
+        sampled_rows=100,
+        sample_fraction=1.0,
+        truncated=False,
+        offender_sample={"lying_mirror": ["a"]},
+        duration_ms=42,
+    )
+    assert rid
+    latest = await mi.latest_consistency_report(conn)
+    assert latest["status"] == "degraded"
+    assert '"lying_mirror": 3' in latest["counts_json"]
+    await conn.close()
+
+
+async def test_trailing_hit_rate_excludes_unknown(tmp_path):
+    conn = await _conn(tmp_path)
+    await mi.insert_recall_probe_run(
+        conn,
+        status="healthy",
+        probes_total=10,
+        probes_hit=9,
+        hit_rate=0.9,
+        mean_rr=0.8,
+        created_at="2026-07-20 03:00:00",
+    )
+    await mi.insert_recall_probe_run(
+        conn,
+        status="unknown",
+        probes_total=0,
+        probes_hit=0,
+        hit_rate=None,
+        mean_rr=None,
+        unknown_reason="golden_set_too_small",
+        created_at="2026-07-21 03:00:00",
+    )
+    await mi.insert_recall_probe_run(
+        conn,
+        status="healthy",
+        probes_total=10,
+        probes_hit=7,
+        hit_rate=0.7,
+        mean_rr=0.6,
+        created_at="2026-07-22 03:00:00",
+    )
+    mean, n = await mi.trailing_hit_rate(conn, window=7)
+    assert n == 2
+    assert abs(mean - 0.8) < 1e-9
+    await conn.close()
+
+
+async def test_trailing_hit_rate_no_runs_is_none(tmp_path):
+    conn = await _conn(tmp_path)
+    mean, n = await mi.trailing_hit_rate(conn, window=7)
+    assert mean is None and n == 0
+    await conn.close()
+
+
+async def test_has_recent_non_unknown_report(tmp_path):
+    conn = await _conn(tmp_path)
+    await mi.insert_consistency_report(
+        conn,
+        status="unknown",
+        counts={},
+        total_rows=0,
+        sampled_rows=0,
+        sample_fraction=1.0,
+        truncated=False,
+        unknown_reason="qdrant_unavailable",
+        created_at="2026-07-22 03:00:00",
+    )
+    # only an unknown row exists → not "recent non-unknown"
+    assert await mi.has_recent_non_unknown_report(conn, since_iso="2026-07-01") is False
+    await mi.insert_consistency_report(
+        conn,
+        status="healthy",
+        counts={},
+        total_rows=5,
+        sampled_rows=5,
+        sample_fraction=1.0,
+        truncated=False,
+        created_at="2026-07-23 03:00:00",
+    )
+    assert await mi.has_recent_non_unknown_report(conn, since_iso="2026-07-01") is True
+    await conn.close()
+
+
+async def test_prune_spares_nothing_but_reports(tmp_path):
+    conn = await _conn(tmp_path)
+    await mi.insert_consistency_report(
+        conn,
+        status="healthy",
+        counts={},
+        total_rows=1,
+        sampled_rows=1,
+        sample_fraction=1.0,
+        truncated=False,
+        created_at="2020-01-01 00:00:00",
+    )
+    await mi.insert_recall_probe_run(
+        conn,
+        status="healthy",
+        probes_total=1,
+        probes_hit=1,
+        hit_rate=1.0,
+        mean_rr=1.0,
+        created_at="2020-01-01 00:00:00",
+    )
+    deleted = await mi.prune_memory_integrity(conn, older_than_days=90, now="2030-01-01 00:00:00")
+    assert deleted == 2
+    assert await mi.latest_consistency_report(conn) is None
+    await conn.close()
+
+
+async def test_crud_noop_before_migration(tmp_path):
+    """Tables absent → writers no-op, readers return None/empty (self-heal)."""
+    # Reset the per-process table cache so this test isn't masked by a prior one.
+    mi._tables_verified = False
+    path = str(tmp_path / "bare.db")
+    conn = await aiosqlite.connect(path)
+    # no schema created
+    assert (
+        await mi.insert_consistency_report(
+            conn,
+            status="healthy",
+            counts={},
+            total_rows=0,
+            sampled_rows=0,
+            sample_fraction=1.0,
+            truncated=False,
+        )
+        is None
+    )
+    assert await mi.latest_consistency_report(conn) is None
+    assert await mi.has_recent_non_unknown_report(conn, since_iso="2000-01-01") is True
+    assert await mi.prune_memory_integrity(conn, older_than_days=90, now="2030-01-01") == 0
+    await conn.close()

--- a/tests/test_memory_integrity/test_integrity_checker.py
+++ b/tests/test_memory_integrity/test_integrity_checker.py
@@ -1,0 +1,156 @@
+"""Consistency-checker classification + fail-closed + status tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.memory.integrity import run_consistency_check
+
+from .conftest import FakeQdrantClient, build_db, insert_memory
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _db(tmp_path) -> str:
+    path = str(tmp_path / "t.db")
+    await build_db(path)
+    return path
+
+
+async def _run(path, qdrant, **kw):
+    return await run_consistency_check(db_path=path, qdrant_client=qdrant, **kw)
+
+
+async def test_empty_state_is_healthy(tmp_path):
+    path = await _db(tmp_path)
+    rep = await _run(path, FakeQdrantClient())
+    assert rep.status == "healthy"
+    assert rep.total_rows == 0
+    assert rep.total_findings == 0
+
+
+async def test_all_consistent_is_healthy(tmp_path):
+    path = await _db(tmp_path)
+    pts = {"episodic_memory": {}, "knowledge_base": {}}
+    for i in range(10):
+        mid = f"m{i}"
+        await insert_memory(path, mid)
+        pts["episodic_memory"][mid] = {}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.status == "healthy"
+    assert rep.total_findings == 0
+
+
+async def test_lying_mirror_detected(tmp_path):
+    """embedded rows with NO Qdrant point → lying_mirror, and >=5 → degraded."""
+    path = await _db(tmp_path)
+    pts = {"episodic_memory": {}, "knowledge_base": {}}
+    for i in range(6):  # 6 embedded rows, none present in Qdrant
+        await insert_memory(path, f"m{i}")
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["lying_mirror"] == 6
+    assert rep.status == "degraded"  # severe floor = 5
+    assert set(rep.offender_sample["lying_mirror"]) == {f"m{i}" for i in range(6)}
+
+
+async def test_lying_mirror_below_floor_is_healthy(tmp_path):
+    path = await _db(tmp_path)
+    pts = {"episodic_memory": {}, "knowledge_base": {}}
+    for i in range(3):  # only 3 < severe floor 5
+        await insert_memory(path, f"m{i}")
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["lying_mirror"] == 3
+    assert rep.status == "healthy"
+
+
+async def test_collection_agnostic_existence(tmp_path):
+    """A point living in a DIFFERENT collection than metadata claims is still a
+    match (the collection column is documented-unreliable)."""
+    path = await _db(tmp_path)
+    await insert_memory(path, "m1", collection="episodic_memory")
+    # point actually stored under knowledge_base
+    pts = {"episodic_memory": {}, "knowledge_base": {"m1": {}}}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["lying_mirror"] == 0  # found in the other collection
+
+
+async def test_ghost_points_detected(tmp_path):
+    path = await _db(tmp_path)
+    await insert_memory(path, "m1")
+    pts = {"episodic_memory": {"m1": {}, "ghost1": {}, "ghost2": {}}, "knowledge_base": {}}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["ghost_points"] == 2
+    assert set(rep.offender_sample["ghost_points"]) == {"ghost1", "ghost2"}
+
+
+async def test_unexpected_vector_detected(tmp_path):
+    """fts5_only rows must NOT have a Qdrant point."""
+    path = await _db(tmp_path)
+    await insert_memory(path, "m1", status="fts5_only")
+    pts = {"episodic_memory": {"m1": {}}, "knowledge_base": {}}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["unexpected_vector"] == 1
+    assert rep.counts["lying_mirror"] == 0  # fts5_only is NOT expected to have a vector
+
+
+async def test_deprecated_divergence_detected(tmp_path):
+    path = await _db(tmp_path)
+    await insert_memory(path, "m1", deprecated=1)  # SQLite says deprecated
+    pts = {"episodic_memory": {"m1": {}}, "knowledge_base": {}}  # payload says not
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["deprecated_divergence"] == 1
+
+
+async def test_fts_invisible_is_severe(tmp_path):
+    """metadata rows with no FTS entry are a severe search-path absence."""
+    path = await _db(tmp_path)
+    pts = {"episodic_memory": {}, "knowledge_base": {}}
+    for i in range(5):
+        mid = f"m{i}"
+        await insert_memory(path, mid, in_fts=False)  # no FTS row
+        pts["episodic_memory"][mid] = {}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["fts_invisible"] == 5
+    assert rep.status == "degraded"
+
+
+async def test_qdrant_unreachable_is_unknown_not_degraded(tmp_path):
+    """A dependency outage must NEVER be reported as data corruption."""
+    path = await _db(tmp_path)
+    for i in range(10):
+        await insert_memory(path, f"m{i}")
+    rep = await _run(path, FakeQdrantClient(raise_on="scroll"))
+    assert rep.status == "unknown"
+    assert rep.unknown_reason and "qdrant_unavailable" in rep.unknown_reason
+    # FTS-side counts are computed; vector-side never fabricated as findings
+    assert rep.total_findings == 0
+
+
+async def test_pollution_threshold_uses_fraction(tmp_path):
+    """Ghosts below max(pollution_min_count, fraction*total) stay healthy."""
+    path = await _db(tmp_path)
+    pts = {"episodic_memory": {}, "knowledge_base": {}}
+    for i in range(100):
+        mid = f"m{i}"
+        await insert_memory(path, mid)
+        pts["episodic_memory"][mid] = {}
+    # 10 ghosts; pollution floor is 50 → healthy
+    for g in range(10):
+        pts["episodic_memory"][f"ghost{g}"] = {}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["ghost_points"] == 10
+    assert rep.status == "healthy"
+
+
+async def test_truncation_marks_lying_mirror_not_computed(tmp_path):
+    """When the point budget is hit, lying_mirror is -1 (not computed), never a
+    wrong count, and truncated is flagged."""
+    path = await _db(tmp_path)
+    pts = {"episodic_memory": {}, "knowledge_base": {}}
+    for i in range(20):
+        mid = f"m{i}"
+        await insert_memory(path, mid)
+        pts["episodic_memory"][mid] = {}
+    rep = await _run(path, FakeQdrantClient(pts), max_points=5)
+    assert rep.truncated is True
+    assert rep.counts["lying_mirror"] == -1

--- a/tests/test_memory_integrity/test_integrity_checker.py
+++ b/tests/test_memory_integrity/test_integrity_checker.py
@@ -29,6 +29,33 @@ async def test_empty_state_is_healthy(tmp_path):
     assert rep.total_findings == 0
 
 
+async def test_empty_metadata_with_orphan_points_not_healthy(tmp_path):
+    """Metadata wiped/restored-stale but Qdrant still holds points → ghost_points
+    surfaced, NOT a false 'healthy' early return (P1: don't skip the scan on an
+    empty corpus)."""
+    path = await _db(tmp_path)  # zero memory rows
+    pts = {"episodic_memory": {f"orphan{i}": {} for i in range(60)}, "knowledge_base": {}}
+    rep = await _run(path, FakeQdrantClient(pts))
+    assert rep.counts["ghost_points"] == 60
+    assert rep.total_rows == 0
+    assert rep.status == "degraded"  # 60 >= pollution floor (50)
+
+
+async def test_empty_everything_is_healthy(tmp_path):
+    """Genuinely empty install (no metadata, no points) → healthy, no alarm."""
+    path = await _db(tmp_path)
+    rep = await _run(path, FakeQdrantClient({"episodic_memory": {}, "knowledge_base": {}}))
+    assert rep.status == "healthy"
+    assert rep.total_findings == 0
+
+
+async def test_empty_metadata_qdrant_down_is_unknown(tmp_path):
+    """Empty metadata + Qdrant unreachable must be 'unknown', never 'healthy'."""
+    path = await _db(tmp_path)
+    rep = await _run(path, FakeQdrantClient(raise_on="scroll"))
+    assert rep.status == "unknown"
+
+
 async def test_all_consistent_is_healthy(tmp_path):
     path = await _db(tmp_path)
     pts = {"episodic_memory": {}, "knowledge_base": {}}

--- a/tests/test_memory_integrity/test_integrity_config.py
+++ b/tests/test_memory_integrity/test_integrity_config.py
@@ -47,6 +47,30 @@ def test_knob_coercion_on_damaged_values():
     assert ic.knob_float(cfg, "rerank_timeout_s") == ic.DEFAULTS["rerank_timeout_s"]
 
 
+def test_settings_validator_rejects_invalid():
+    """settings_update must reject bad writes instead of silently persisting them
+    (P2) — e.g. a string 'false' that is truthy at runtime."""
+    from genesis.mcp.health.settings import _validate_memory_integrity
+
+    assert _validate_memory_integrity({"mode": "bogus"})  # bad enum
+    assert _validate_memory_integrity({"enabled": "false"})  # string, not bool
+    assert _validate_memory_integrity({"rerank": "false"})  # string, not bool
+    assert _validate_memory_integrity({"unknown_key": 1})  # unknown key
+    assert _validate_memory_integrity({"drift_band": 5.0})  # out of 0..1
+    assert _validate_memory_integrity({"severe_min_count": -1})  # not positive
+    # a fully-valid change set passes
+    assert not _validate_memory_integrity(
+        {
+            "enabled": True,
+            "mode": "passive",
+            "rerank": False,
+            "drift_band": 0.2,
+            "severe_min_count": 5,
+            "rerank_timeout_s": 10.0,
+        }
+    )
+
+
 def test_defaults_are_fresh_install_safe():
     # A fresh clone with no overlay must resolve to passive + sane knobs.
     cfg = ic.load_config()

--- a/tests/test_memory_integrity/test_integrity_config.py
+++ b/tests/test_memory_integrity/test_integrity_config.py
@@ -1,0 +1,55 @@
+"""memory_integrity_config mode-lever + knob-coercion tests (sync)."""
+
+from __future__ import annotations
+
+from genesis.memory import integrity_config as ic
+
+
+def test_default_mode_is_passive(monkeypatch):
+    monkeypatch.delenv(ic._ENV_KILL_SWITCH, raising=False)
+    assert ic.effective_mode() == "passive"
+
+
+def test_active_coerced_to_passive(monkeypatch):
+    monkeypatch.delenv(ic._ENV_KILL_SWITCH, raising=False)
+    monkeypatch.setattr(ic, "load_config", lambda: {**ic.DEFAULTS, "mode": "active"})
+    assert ic.effective_mode() == "passive"
+
+
+def test_invalid_mode_degrades_to_passive(monkeypatch):
+    monkeypatch.delenv(ic._ENV_KILL_SWITCH, raising=False)
+    monkeypatch.setattr(ic, "load_config", lambda: {**ic.DEFAULTS, "mode": "bogus"})
+    assert ic.effective_mode() == "passive"
+
+
+def test_env_kill_switch_forces_off(monkeypatch):
+    monkeypatch.setenv(ic._ENV_KILL_SWITCH, "1")
+    assert ic.effective_mode() == "off"
+
+
+def test_enabled_false_is_off(monkeypatch):
+    monkeypatch.delenv(ic._ENV_KILL_SWITCH, raising=False)
+    monkeypatch.setattr(ic, "load_config", lambda: {**ic.DEFAULTS, "enabled": False})
+    assert ic.effective_mode() == "off"
+
+
+def test_yaml_off_boolean_honored(monkeypatch):
+    monkeypatch.delenv(ic._ENV_KILL_SWITCH, raising=False)
+    # unquoted `mode: off` parses to boolean False under YAML 1.1
+    monkeypatch.setattr(ic, "load_config", lambda: {**ic.DEFAULTS, "mode": False})
+    assert ic.effective_mode() == "off"
+
+
+def test_knob_coercion_on_damaged_values():
+    cfg = {"severe_min_count": -3, "drift_band": 5.0, "rerank_timeout_s": 0}
+    assert ic.knob_int(cfg, "severe_min_count") == ic.DEFAULTS["severe_min_count"]
+    assert ic.knob_float01(cfg, "drift_band") == ic.DEFAULTS["drift_band"]
+    assert ic.knob_float(cfg, "rerank_timeout_s") == ic.DEFAULTS["rerank_timeout_s"]
+
+
+def test_defaults_are_fresh_install_safe():
+    # A fresh clone with no overlay must resolve to passive + sane knobs.
+    cfg = ic.load_config()
+    assert cfg["enabled"] is True
+    assert cfg["mode"] == "passive"
+    assert cfg["sample_fraction"] == 1.0

--- a/tests/test_memory_integrity/test_posture_and_jobs.py
+++ b/tests/test_memory_integrity/test_posture_and_jobs.py
@@ -1,0 +1,194 @@
+"""Awareness posture check + job-wiring seam tests."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import memory_integrity as mi
+from genesis.db.schema._tables import TABLES
+
+pytestmark = pytest.mark.asyncio
+
+_SOURCE = "memory_integrity_posture_monitor"
+
+
+@pytest.fixture(autouse=True)
+def _reset_posture_globals():
+    """The posture cooldown state is module-global; reset it between tests so a
+    same-key alert in one test doesn't suppress the next. (The crud table-cache
+    is reset by the package conftest autouse fixture.)"""
+    from genesis.awareness import loop
+
+    loop._last_memory_integrity_alert_at = 0.0
+    loop._last_memory_integrity_key = ""
+    yield
+
+
+async def _setup() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(TABLES["observations"])
+    await db.execute(TABLES["memory_consistency_reports"])
+    await db.execute(TABLES["recall_probe_runs"])
+    await db.commit()
+    mi._tables_verified = False
+    return db
+
+
+async def _alerts(db) -> list[dict]:
+    async with db.execute(
+        "SELECT id, priority, resolved, content FROM observations "
+        "WHERE source = ? AND type = 'infrastructure_alert'",
+        (_SOURCE,),
+    ) as cur:
+        return [dict(r) for r in await cur.fetchall()]
+
+
+def _open(alerts):
+    return [a for a in alerts if a["resolved"] == 0]
+
+
+# ── posture ──
+
+
+async def test_no_rows_is_silent(monkeypatch):
+    from genesis.awareness import loop
+
+    db = await _setup()
+    await loop._check_memory_integrity_posture(db)
+    assert _open(await _alerts(db)) == []
+    await db.close()
+
+
+async def test_degraded_consistency_raises_alert(monkeypatch):
+    from genesis.awareness import loop
+
+    db = await _setup()
+    await mi.insert_consistency_report(
+        db,
+        status="degraded",
+        counts={
+            "lying_mirror": 21,
+            "ghost_points": 274,
+            "fts_ghosts": 0,
+            "fts_invisible": 0,
+            "unexpected_vector": 0,
+            "deprecated_divergence": 0,
+        },
+        total_rows=29699,
+        sampled_rows=29699,
+        sample_fraction=1.0,
+        truncated=False,
+    )
+    await loop._check_memory_integrity_posture(db)
+    opn = _open(await _alerts(db))
+    assert len(opn) == 1
+    assert "lying_mirror=21" in opn[0]["content"]
+    await db.close()
+
+
+async def test_healthy_resolves(monkeypatch):
+    from genesis.awareness import loop
+
+    db = await _setup()
+    # first a degraded row → alert
+    await mi.insert_consistency_report(
+        db,
+        status="degraded",
+        counts={"lying_mirror": 9},
+        total_rows=100,
+        sampled_rows=100,
+        sample_fraction=1.0,
+        truncated=False,
+    )
+    await loop._check_memory_integrity_posture(db)
+    assert len(_open(await _alerts(db))) == 1
+    # now a healthy row supersedes → resolved
+    await mi.insert_consistency_report(
+        db,
+        status="healthy",
+        counts={"lying_mirror": 0},
+        total_rows=100,
+        sampled_rows=100,
+        sample_fraction=1.0,
+        truncated=False,
+    )
+    await loop._check_memory_integrity_posture(db)
+    assert _open(await _alerts(db)) == []
+    await db.close()
+
+
+async def test_single_unknown_run_does_not_alert(monkeypatch):
+    from genesis.awareness import loop
+
+    db = await _setup()
+    await mi.insert_consistency_report(
+        db,
+        status="unknown",
+        counts={},
+        total_rows=100,
+        sampled_rows=0,
+        sample_fraction=1.0,
+        truncated=False,
+        unknown_reason="qdrant_unavailable",
+    )
+    await loop._check_memory_integrity_posture(db)
+    assert _open(await _alerts(db)) == []
+    await db.close()
+
+
+async def test_stuck_unknown_streak_alerts(monkeypatch):
+    """A checker running LONGER than the window with only unknown reports fires
+    the staleness finding; a fresh install with one unknown does not."""
+    from genesis.awareness import loop
+
+    db = await _setup()
+    # earliest report is 10 days old, all unknown → stuck
+    await mi.insert_consistency_report(
+        db,
+        status="unknown",
+        counts={},
+        total_rows=100,
+        sampled_rows=0,
+        sample_fraction=1.0,
+        truncated=False,
+        unknown_reason="qdrant_unavailable",
+        created_at="2026-07-15 03:50:00",
+    )
+    await mi.insert_consistency_report(
+        db,
+        status="unknown",
+        counts={},
+        total_rows=100,
+        sampled_rows=0,
+        sample_fraction=1.0,
+        truncated=False,
+        unknown_reason="qdrant_unavailable",
+        created_at="2026-07-25 03:50:00",
+    )
+    await loop._check_memory_integrity_posture(db)
+    opn = _open(await _alerts(db))
+    assert len(opn) == 1
+    assert "no conclusive" in opn[0]["content"]
+    await db.close()
+
+
+# ── job wiring ──
+
+
+async def test_jobs_registered_on_scheduler():
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+    from genesis.runtime.init.memory_integrity import _wire_memory_integrity_jobs
+
+    class _RT:
+        _db = object()
+        _hybrid_retriever = None
+
+    sched = AsyncIOScheduler()
+    _wire_memory_integrity_jobs(sched, _RT())
+    ids = {j.id for j in sched.get_jobs()}
+    assert {"recall_health_probe", "memory_consistency_check", "memory_integrity_prune"} <= ids
+    for j in sched.get_jobs():
+        assert j.max_instances == 1

--- a/tests/test_memory_integrity/test_posture_and_jobs.py
+++ b/tests/test_memory_integrity/test_posture_and_jobs.py
@@ -174,6 +174,95 @@ async def test_stuck_unknown_streak_alerts(monkeypatch):
     await db.close()
 
 
+async def test_unknown_after_degraded_holds_alert(monkeypatch):
+    """A degraded report followed by an inconclusive 'unknown' run must NOT
+    resolve the alert — recovery was never demonstrated (P1)."""
+    from genesis.awareness import loop
+
+    db = await _setup()
+    await mi.insert_consistency_report(
+        db,
+        status="degraded",
+        counts={"lying_mirror": 9},
+        total_rows=100,
+        sampled_rows=100,
+        sample_fraction=1.0,
+        truncated=False,
+        created_at="2026-07-25 03:50:00",
+    )
+    await loop._check_memory_integrity_posture(db)
+    assert len(_open(await _alerts(db))) == 1
+    # Qdrant goes down → next run is unknown. Alert must persist.
+    await mi.insert_consistency_report(
+        db,
+        status="unknown",
+        counts={},
+        total_rows=100,
+        sampled_rows=0,
+        sample_fraction=1.0,
+        truncated=False,
+        unknown_reason="qdrant_unavailable",
+        created_at="2026-07-25 03:55:00",
+    )
+    await loop._check_memory_integrity_posture(db)
+    assert len(_open(await _alerts(db))) == 1  # held, not resolved
+    # A genuinely healthy run DOES resolve it.
+    await mi.insert_consistency_report(
+        db,
+        status="healthy",
+        counts={},
+        total_rows=100,
+        sampled_rows=100,
+        sample_fraction=1.0,
+        truncated=False,
+        created_at="2026-07-25 04:00:00",
+    )
+    await loop._check_memory_integrity_posture(db)
+    assert _open(await _alerts(db)) == []
+    await db.close()
+
+
+async def test_stuck_recall_probe_alerts_but_unseeded_does_not(monkeypatch):
+    """A recall probe wedged on retriever errors past the window escalates; an
+    unseeded golden set (golden_set_too_small) never does (P1 + exemption)."""
+    from genesis.awareness import loop
+
+    db = await _setup()
+    # probe running 10d, all unknown due to a real retriever error → stale
+    for ts in ("2026-07-15 03:20:00", "2026-07-25 03:20:00"):
+        await mi.insert_recall_probe_run(
+            db,
+            status="unknown",
+            probes_total=5,
+            probes_hit=0,
+            hit_rate=None,
+            mean_rr=None,
+            unknown_reason="recall_error: ConnectionError",
+            created_at=ts,
+        )
+    await loop._check_memory_integrity_posture(db)
+    opn = _open(await _alerts(db))
+    assert len(opn) == 1 and "recall-health probe" in opn[0]["content"]
+    await db.close()
+
+    # Contrast: an unseeded golden set (golden_set_too_small) must NOT alert.
+    db2 = await _setup()
+    for ts in ("2026-07-15 03:20:00", "2026-07-25 03:20:00"):
+        await mi.insert_recall_probe_run(
+            db2,
+            status="unknown",
+            probes_total=0,
+            probes_hit=0,
+            hit_rate=None,
+            mean_rr=None,
+            unknown_reason="golden_set_too_small",
+            created_at=ts,
+        )
+    await loop._check_memory_integrity_posture(db2)
+    assert _open(await _alerts(db2)) == []
+    await db2.close()
+
+
 # ── job wiring ──
 
 

--- a/tests/test_memory_integrity/test_recall_probe.py
+++ b/tests/test_memory_integrity/test_recall_probe.py
@@ -1,0 +1,193 @@
+"""Recall-health probe tests — hit/rank, fail-closed, drift, skip_writeback."""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import memory_integrity as mi
+from genesis.memory.recall_probe import load_golden_set, run_recall_probe
+
+from .conftest import build_db
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Result:
+    def __init__(self, memory_id: str) -> None:
+        self.memory_id = memory_id
+
+
+class FakeRetriever:
+    """Returns a canned id list per query; records recall kwargs for assertions;
+    can raise to simulate a provider outage."""
+
+    def __init__(self, responses: dict[str, list[str]], *, raise_exc: Exception | None = None):
+        self.responses = responses
+        self.raise_exc = raise_exc
+        self.calls: list[dict] = []
+
+    async def recall(self, query, **kwargs):
+        # Mirror the REAL HybridRetriever.recall contract: `source` is the
+        # collection selector, validated against a fixed set. Enforcing it here
+        # is what makes the fake honest — an invalid source (the bug the probe
+        # shipped with) must fail the test, not pass silently.
+        source = kwargs.get("source")
+        if source not in ("episodic", "knowledge", "both", None):
+            raise ValueError(f"source must be episodic|knowledge|both, got {source!r}")
+        self.calls.append({"query": query, **kwargs})
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return [_Result(mid) for mid in self.responses.get(query, [])]
+
+
+def _write_golden(tmp_path, cases: list[dict]) -> str:
+    p = tmp_path / "golden.jsonl"
+    lines = ["# header comment", ""]
+    lines += [json.dumps(c) for c in cases]
+    p.write_text("\n".join(lines))
+    return str(p)
+
+
+async def _db(tmp_path):
+    path = str(tmp_path / "t.db")
+    await build_db(path)
+    return await aiosqlite.connect(path)
+
+
+# ── golden loader ──
+
+
+async def test_load_golden_skips_comments_and_bad(tmp_path):
+    p = tmp_path / "g.jsonl"
+    p.write_text(
+        "# comment\n\n"
+        '{"id":"a","query":"q1","expected_memory_ids":["m1"]}\n'
+        '{"id":"b","query":"","expected_memory_ids":["m2"]}\n'  # bad: empty query
+        '{"id":"c","query":"q3","expected_memory_ids":[]}\n'  # bad: empty expected
+        "not json\n"
+        '{"id":"d","query":"q4","expected_memory_ids":["m4","m5"]}\n'
+    )
+    cases = load_golden_set(p)
+    assert [c["id"] for c in cases] == ["a", "d"]
+    assert cases[1]["expected"] == ["m4", "m5"]
+
+
+async def test_load_golden_absent_file_is_empty(tmp_path):
+    assert load_golden_set(tmp_path / "nope.jsonl") == []
+
+
+# ── probe status ──
+
+
+async def test_too_small_golden_is_unknown(tmp_path):
+    conn = await _db(tmp_path)
+    gp = _write_golden(tmp_path, [{"id": "a", "query": "q", "expected_memory_ids": ["m"]}])
+    res = await run_recall_probe(
+        db=conn, retriever=FakeRetriever({}), golden_path=gp, min_golden_for_status=5
+    )
+    assert res.status == "unknown"
+    assert res.unknown_reason == "golden_set_too_small"
+    await conn.close()
+
+
+async def test_retriever_none_is_unknown(tmp_path):
+    conn = await _db(tmp_path)
+    res = await run_recall_probe(db=conn, retriever=None, min_golden_for_status=1)
+    assert res.status == "unknown"
+    assert res.unknown_reason == "retriever_unavailable"
+    await conn.close()
+
+
+async def test_recall_error_is_unknown_not_miss(tmp_path):
+    """A provider outage must not be scored as a recall miss."""
+    conn = await _db(tmp_path)
+    cases = [{"id": str(i), "query": f"q{i}", "expected_memory_ids": ["m"]} for i in range(5)]
+    gp = _write_golden(tmp_path, cases)
+    retr = FakeRetriever({}, raise_exc=ConnectionError("provider down"))
+    res = await run_recall_probe(db=conn, retriever=retr, golden_path=gp, min_golden_for_status=5)
+    assert res.status == "unknown"
+    assert "recall_error" in res.unknown_reason
+    await conn.close()
+
+
+async def test_hit_rate_and_mrr(tmp_path):
+    conn = await _db(tmp_path)
+    cases = [
+        {"id": "a", "query": "qa", "expected_memory_ids": ["ma"]},  # hit at rank 1
+        {"id": "b", "query": "qb", "expected_memory_ids": ["mb"]},  # hit at rank 3
+        {"id": "c", "query": "qc", "expected_memory_ids": ["mc"]},  # miss
+        {"id": "d", "query": "qd", "expected_memory_ids": ["md"]},  # miss
+        {"id": "e", "query": "qe", "expected_memory_ids": ["me"]},  # hit at rank 1
+    ]
+    gp = _write_golden(tmp_path, cases)
+    retr = FakeRetriever(
+        {
+            "qa": ["ma", "x"],
+            "qb": ["y", "z", "mb"],
+            "qc": ["n"],
+            "qd": [],
+            "qe": ["me"],
+        }
+    )
+    res = await run_recall_probe(
+        db=conn, retriever=retr, golden_path=gp, min_golden_for_status=5, baseline_min_runs=3
+    )
+    assert res.probes_total == 5
+    assert res.probes_hit == 3
+    assert abs(res.hit_rate - 0.6) < 1e-9
+    # MRR = (1 + 1/3 + 0 + 0 + 1) / 5
+    assert abs(res.mean_rr - (1 + 1 / 3 + 1) / 5) < 1e-9
+    # no baseline history yet → observation period, healthy, no drift
+    assert res.status == "healthy"
+    assert res.baseline_hit_rate is None and res.drift is None
+    await conn.close()
+
+
+async def test_probe_passes_skip_writeback(tmp_path):
+    conn = await _db(tmp_path)
+    cases = [{"id": str(i), "query": f"q{i}", "expected_memory_ids": ["m"]} for i in range(5)]
+    gp = _write_golden(tmp_path, cases)
+    retr = FakeRetriever({f"q{i}": ["m"] for i in range(5)})
+    await run_recall_probe(db=conn, retriever=retr, golden_path=gp, min_golden_for_status=5)
+    # every recall must disable activation write-back (probe must not entrench)
+    # and pass a VALID collection source (regression for the ValueError bug).
+    for call in retr.calls:
+        assert callable(call["skip_writeback"])
+        assert call["skip_writeback"]("anything") is True
+        assert call["source"] == "both"
+    await conn.close()
+
+
+async def test_drift_degraded_vs_baseline(tmp_path):
+    conn = await _db(tmp_path)
+    # seed 3 prior healthy runs at hit_rate 0.9 → baseline 0.9
+    for i in range(3):
+        await mi.insert_recall_probe_run(
+            conn,
+            status="healthy",
+            probes_total=10,
+            probes_hit=9,
+            hit_rate=0.9,
+            mean_rr=0.9,
+            created_at=f"2026-07-2{i} 03:00:00",
+        )
+    # current run hits 0.5 → drift 0.4 > band 0.2 → degraded
+    cases = [{"id": str(i), "query": f"q{i}", "expected_memory_ids": ["m"]} for i in range(5)]
+    gp = _write_golden(tmp_path, cases)
+    retr = FakeRetriever({"q0": ["m"], "q1": ["m"], "q2": ["m"], "q3": ["x"], "q4": ["x"]})
+    res = await run_recall_probe(
+        db=conn,
+        retriever=retr,
+        golden_path=gp,
+        min_golden_for_status=5,
+        baseline_min_runs=3,
+        drift_band=0.2,
+    )
+    assert abs(res.hit_rate - 0.6) < 1e-9
+    assert res.baseline_hit_rate == 0.9
+    assert abs(res.drift - 0.3) < 1e-9  # 0.9 - 0.6
+    assert res.status == "degraded"  # drift 0.3 > band 0.2
+    await conn.close()

--- a/tests/test_security/test_recall_inject_coverage.py
+++ b/tests/test_security/test_recall_inject_coverage.py
@@ -109,6 +109,13 @@ KNOWN_RECALL_SITES: dict[str, tuple[str, str]] = {
         "the result is discarded (never rendered, reaches no prompt) and "
         "skip_writeback drops all write-backs — no injection sink",
     ),
+    "memory/recall_probe.py::run_recall_probe": (
+        "pipeline-internal",
+        "memory-integrity recall-health probe: reads ONLY result memory_ids to "
+        "compute hit-rate/rank against a curated install-local golden set; result "
+        "CONTENT never reaches a prompt, and skip_writeback drops all "
+        "write-backs — no injection sink",
+    ),
 }
 
 # NOTE: memory_expand and memory_core_facts (mcp/memory/core.py) are ALSO


### PR DESCRIPTION
## What & why

Memory recall degrades **silently** in Genesis: the episodic write path fans out to three backends (Qdrant `episodic_memory` + `memory_metadata` + `memory_fts`) with no cross-store transaction, and nothing verified they agree. When they drift — a memory that still exists but became unfindable by search, or a leftover vector with no memory behind it — recall just gets quietly worse, with no error and no signal.

This is **Phase 0 ("make silence loud"): detect-only, read-only.** It turns silent degradation into a standing signal. Repair (write-path hardening + reconcile) is a deliberately separate later phase.

**On this install, the checker immediately found real drift:** 21 memories marked `embedded` with no Qdrant vector (silently missing from vector search) + 274 ghost points — pre-existing, previously invisible.

## What's added

- **Cross-backend consistency checker** (`memory/integrity.py`) — read-only, verifies metadata ↔ Qdrant ↔ FTS5 agree; classifies `lying_mirror` / `ghost_points` / `fts_ghosts` / `fts_invisible` / `unexpected_vector` / `deprecated_divergence`. Collection-agnostic existence (the `collection` column is documented-unreliable). **Fail-closed**: any Qdrant/FTS failure -> `unknown`, never a false `degraded`.
- **Recall-health probe** (`memory/recall_probe.py`) — replays an install-local golden set through the **real** retriever; hit-rate + mean-reciprocal-rank + drift vs a trailing baseline. Golden set is a file (`~/.genesis/eval/golden/`, the #1143 convention), not a table.
- **Wiring** — 3 off-peak `CronTrigger` jobs (probe 03:20, consistency 03:50, retention 04:15; mode-gated, self-persisting); an awareness **posture alert** (`_check_memory_integrity_posture`, mirrors the infra-posture trio); a **Memory Integrity dashboard tile** + `/api/genesis/memory/integrity` route.
- **Operator scripts** — `run_memory_integrity_check.py` (manual, read-only), `seed_recall_golden_set.py` (mines recall telemetry).
- **Control** — `memory_integrity` settings domain (`off | passive | active`, default `passive`; `active` reserved for Phase 1) + `GENESIS_MEMORY_INTEGRITY_DISABLED` kill switch. Retention wired; 2 new tables via additive migration 0073.
- **3 genesis-development SKILL rules** — anti-proliferation gate, fail-closed data access, tenant-neutral.

## Verification

- **41 install-agnostic tests** (synthetic fixtures, fake Qdrant/retriever, no live services).
- **Live read-only** run on the real DB: `degraded`, 21 lying-mirrors + 274 ghosts, 4.6s.
- **Full path E2E on a DB copy**: migrate -> check -> persist -> posture alert -> dashboard payload.
- **Recall probe verified live** against the running retriever (`source="both"` returns results; a mined golden query returns its expected memory).
- Two adversarial review rounds; a blocking bug (probe `source=` -> `ValueError`) was caught and fixed + live-verified.

## Deploy path & post-merge verification

Existing install: `git pull` + restart (migration applies at restart; jobs register in learning init; config ships in-repo). Fresh install: `_tables.py` DDL + empty-state-safe defaults.

**Needs post-merge/deploy verification** (can't be done pre-merge): the jobs firing on the live scheduler, the migration applying at restart, and the tile rendering. The recall probe reports `unknown` (needs-setup) until the golden set is seeded — a deliberate first-curation step.

## Notes

- Detection-only; nothing repairs or writes to the memory stores.
- Formatter churn on hot files (loop.py etc.) was reconstructed away — net diff is additions-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
