### PR TITLE
fix(hooks): give push/PR-create gates an approval override + quote-aware matching

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -27,6 +27,72 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
 
+# Quoted-region matcher: double-quoted (with backslash escapes) or single-quoted
+# (literal per POSIX). Used to blank out quoted spans so a subcommand mentioned
+# inside a string (a commit message, an echo, a --body) is not mistaken for the
+# real invocation.
+_QUOTED = re.compile(r"\"(?:\\.|[^\"\\])*\"|'[^']*'")
+
+
+def _unquoted(cmd: str) -> str:
+    """``cmd`` with quoted regions removed.
+
+    So ``echo "git push"`` or ``git commit -m "mentions --no-verify"`` no longer
+    trip the guards that look for those subcommands. Fail-open: returns the
+    input unchanged on any regex error.
+    """
+    try:
+        return _QUOTED.sub("", cmd)
+    except re.error:
+        return cmd
+
+
+def _has_override(cmd: str) -> bool:
+    """Whether the command carries a deliberate ``# review-override`` trailing
+    shell comment (outside quotes).
+
+    This is the in-session-approval signal — the same token the merge gate and
+    the commit gate honor. The caller logs a NOTE when it fires. Matched on the
+    unquoted command so a token buried in a quoted string does not count.
+    """
+    return bool(re.search(r"(?:^|\s)#\s*review-override\b", _unquoted(cmd)))
+
+
+# git global options that consume the FOLLOWING token as their value, so the
+# real subcommand is the first non-option token AFTER them.
+_GIT_OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix"}
+
+
+def _git_subcommands(cmd: str) -> set[str]:
+    """The set of git subcommands (push/merge/commit/…) invoked in ``cmd``.
+
+    Splits on shell separators and, for each ``git …`` segment, skips git's
+    global options — including ``-c KEY=VAL`` / ``-C DIR`` which take a value —
+    to find the real subcommand. This catches ``git -c credential.helper=… push``
+    (the repo's documented push idiom), which a naive ``git push`` adjacency
+    check misses entirely. Fail-open: a segment that won't tokenize is skipped.
+    """
+    subs: set[str] = set()
+    for segment in re.split(r"&&|\|\||[;&|\n]", cmd):
+        try:
+            toks = shlex.split(segment)
+        except ValueError:
+            toks = segment.split()
+        if not toks or toks[0] != "git":
+            continue
+        i = 1
+        while i < len(toks):
+            t = toks[i]
+            if t in _GIT_OPTS_WITH_ARG:
+                i += 2  # skip the option and its value token
+                continue
+            if t.startswith("-"):
+                i += 1  # some other global flag (e.g. --no-pager, --opt=val)
+                continue
+            subs.add(t)  # first non-option token is the subcommand
+            break
+    return subs
+
 
 def _current_branch() -> str | None:
     """Get current git branch name."""
@@ -376,22 +442,36 @@ def main() -> int:
         if not cmd:
             return 0
 
+        # Match subcommands on the quote-stripped command so a mention inside a
+        # string (commit message, echo, --body) never trips a guard. The
+        # override is the in-session-approval signal, logged where honored.
+        uq = _unquoted(cmd)
+        override = _has_override(cmd)
+        git_subs = _git_subcommands(cmd)
+
         # ── git push (any branch) ──────────────────────────────────
-        if "git push" in cmd:
-            _remote, branch = _get_push_remote_and_branch(cmd)
-            print(
-                f"BLOCKED: git push requires user approval before "
-                f"publishing code externally (target: {branch or 'default'}).",
-                file=sys.stderr,
-            )
-            print(
-                "Ask the user: 'Ready to push?' before proceeding.",
-                file=sys.stderr,
-            )
-            return 2
+        if "push" in git_subs:
+            if override:
+                print(
+                    "NOTE: git push override honored — user approved in-session.",
+                    file=sys.stderr,
+                )
+            else:
+                _remote, branch = _get_push_remote_and_branch(cmd)
+                print(
+                    f"BLOCKED: git push requires user approval before "
+                    f"publishing code externally (target: {branch or 'default'}).",
+                    file=sys.stderr,
+                )
+                print(
+                    "Ask the user 'Ready to push?'; once approved, append a "
+                    "trailing '  # review-override' comment to proceed.",
+                    file=sys.stderr,
+                )
+                return 2
 
         # ── git merge into main ─────────────────────────────────────
-        if "git merge" in cmd:
+        if "merge" in git_subs:
             current = _current_branch()
             if current in ("main", "master"):
                 print(
@@ -405,20 +485,27 @@ def main() -> int:
                 return 2
 
         # ── gh pr create ───────────────────────────────────────────
-        if "gh pr create" in cmd:
-            print(
-                "BLOCKED: Creating a PR requires user approval before publishing externally.",
-                file=sys.stderr,
-            )
-            print(
-                "Ask the user: 'Ready to create the PR?' before proceeding.",
-                file=sys.stderr,
-            )
-            return 2
+        if re.search(r"\bgh\s+pr\s+create\b", uq):
+            if override:
+                print(
+                    "NOTE: gh pr create override honored — user approved in-session.",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    "BLOCKED: Creating a PR requires user approval before publishing externally.",
+                    file=sys.stderr,
+                )
+                print(
+                    "Ask the user 'Ready to create the PR?'; once approved, "
+                    "append a trailing '  # review-override' comment to proceed.",
+                    file=sys.stderr,
+                )
+                return 2
 
         # ── gh pr merge ────────────────────────────────────────────
-        if "gh pr merge" in cmd:
-            if "--admin" not in cmd:
+        if re.search(r"\bgh\s+pr\s+merge\b", uq):
+            if "--admin" not in uq:
                 print(
                     "BLOCKED: gh pr merge without --admin is not allowed.",
                     file=sys.stderr,
@@ -465,7 +552,7 @@ def main() -> int:
                     return 2
 
                 # Check for unresolved review findings
-                force_override = bool(re.search(r"#\s*review-override\b", cmd))
+                force_override = override
                 should_block, review_msg = _check_pr_review_findings(
                     pr_num,
                     force=force_override,
@@ -493,6 +580,8 @@ def main() -> int:
                     return 2
 
         # ── sqlite3 write operations ────────────────────────────────
+        # NB: match on the raw command, not the unquoted one — the DML keyword
+        # lives inside the quoted SQL argument (sqlite3 db "DELETE FROM ...").
         if "sqlite3" in cmd and re.search(
             r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|REPLACE)\b",
             cmd,
@@ -506,7 +595,7 @@ def main() -> int:
             return 2
 
         # ── git commit --no-verify ────────────────────────────────
-        if "git commit" in cmd and "--no-verify" in cmd:
+        if "commit" in git_subs and re.search(r"(?:^|\s)--no-verify\b", uq):
             print(
                 "BLOCKED: --no-verify bypasses review enforcement hooks. "
                 "Remove --no-verify and run /review first.",

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -26,72 +26,12 @@ import sys
 # (importlib does not add the file's dir to sys.path).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
-
-# Quoted-region matcher: double-quoted (with backslash escapes) or single-quoted
-# (literal per POSIX). Used to blank out quoted spans so a subcommand mentioned
-# inside a string (a commit message, an echo, a --body) is not mistaken for the
-# real invocation.
-_QUOTED = re.compile(r"\"(?:\\.|[^\"\\])*\"|'[^']*'")
-
-
-def _unquoted(cmd: str) -> str:
-    """``cmd`` with quoted regions removed.
-
-    So ``echo "git push"`` or ``git commit -m "mentions --no-verify"`` no longer
-    trip the guards that look for those subcommands. Fail-open: returns the
-    input unchanged on any regex error.
-    """
-    try:
-        return _QUOTED.sub("", cmd)
-    except re.error:
-        return cmd
-
-
-def _has_override(cmd: str) -> bool:
-    """Whether the command carries a deliberate ``# review-override`` trailing
-    shell comment (outside quotes).
-
-    This is the in-session-approval signal — the same token the merge gate and
-    the commit gate honor. The caller logs a NOTE when it fires. Matched on the
-    unquoted command so a token buried in a quoted string does not count.
-    """
-    return bool(re.search(r"(?:^|\s)#\s*review-override\b", _unquoted(cmd)))
-
-
-# git global options that consume the FOLLOWING token as their value, so the
-# real subcommand is the first non-option token AFTER them.
-_GIT_OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix"}
-
-
-def _git_subcommands(cmd: str) -> set[str]:
-    """The set of git subcommands (push/merge/commit/…) invoked in ``cmd``.
-
-    Splits on shell separators and, for each ``git …`` segment, skips git's
-    global options — including ``-c KEY=VAL`` / ``-C DIR`` which take a value —
-    to find the real subcommand. This catches ``git -c credential.helper=… push``
-    (the repo's documented push idiom), which a naive ``git push`` adjacency
-    check misses entirely. Fail-open: a segment that won't tokenize is skipped.
-    """
-    subs: set[str] = set()
-    for segment in re.split(r"&&|\|\||[;&|\n]", cmd):
-        try:
-            toks = shlex.split(segment)
-        except ValueError:
-            toks = segment.split()
-        if not toks or toks[0] != "git":
-            continue
-        i = 1
-        while i < len(toks):
-            t = toks[i]
-            if t in _GIT_OPTS_WITH_ARG:
-                i += 2  # skip the option and its value token
-                continue
-            if t.startswith("-"):
-                i += 1  # some other global flag (e.g. --no-pager, --opt=val)
-                continue
-            subs.add(t)  # first non-option token is the subcommand
-            break
-    return subs
+from shell_parse import (  # noqa: E402
+    analyze,
+    commit_skips_hooks,
+    gh_pr_subcommand,
+    git_subcommand,
+)
 
 
 def _current_branch() -> str | None:
@@ -442,16 +382,19 @@ def main() -> int:
         if not cmd:
             return 0
 
-        # Match subcommands on the quote-stripped command so a mention inside a
-        # string (commit message, echo, --body) never trips a guard. The
-        # override is the in-session-approval signal, logged where honored.
-        uq = _unquoted(cmd)
-        override = _has_override(cmd)
-        git_subs = _git_subcommands(cmd)
+        # Analyze the command into the segments it actually executes (wrappers
+        # like sudo/env and /path/to/git stripped, nested `bash -c` recursed,
+        # quoted mentions excluded). Each guarded subcommand is matched on real
+        # argv, and the `# review-override` approval binds to its OWN segment.
+        segs = analyze(cmd)
+        push_segs = [s for s in segs if s.exe == "git" and git_subcommand(s.argv) == "push"]
+        merge_git_segs = [s for s in segs if s.exe == "git" and git_subcommand(s.argv) == "merge"]
+        create_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "create"]
+        merge_pr_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "merge"]
 
         # ── git push (any branch) ──────────────────────────────────
-        if "push" in git_subs:
-            if override:
+        if push_segs:
+            if all(s.override for s in push_segs):
                 print(
                     "NOTE: git push override honored — user approved in-session.",
                     file=sys.stderr,
@@ -471,7 +414,7 @@ def main() -> int:
                 return 2
 
         # ── git merge into main ─────────────────────────────────────
-        if "merge" in git_subs:
+        if merge_git_segs:
             current = _current_branch()
             if current in ("main", "master"):
                 print(
@@ -485,8 +428,8 @@ def main() -> int:
                 return 2
 
         # ── gh pr create ───────────────────────────────────────────
-        if re.search(r"\bgh\s+pr\s+create\b", uq):
-            if override:
+        if create_segs:
+            if all(s.override for s in create_segs):
                 print(
                     "NOTE: gh pr create override honored — user approved in-session.",
                     file=sys.stderr,
@@ -504,8 +447,9 @@ def main() -> int:
                 return 2
 
         # ── gh pr merge ────────────────────────────────────────────
-        if re.search(r"\bgh\s+pr\s+merge\b", uq):
-            if "--admin" not in uq:
+        if merge_pr_segs:
+            merge_seg = merge_pr_segs[0]
+            if "--admin" not in merge_seg.argv:
                 print(
                     "BLOCKED: gh pr merge without --admin is not allowed.",
                     file=sys.stderr,
@@ -552,7 +496,7 @@ def main() -> int:
                     return 2
 
                 # Check for unresolved review findings
-                force_override = override
+                force_override = merge_seg.override
                 should_block, review_msg = _check_pr_review_findings(
                     pr_num,
                     force=force_override,
@@ -594,11 +538,11 @@ def main() -> int:
             )
             return 2
 
-        # ── git commit --no-verify ────────────────────────────────
-        if "commit" in git_subs and re.search(r"(?:^|\s)--no-verify\b", uq):
+        # ── git commit --no-verify / -n (any executed segment) ─────
+        if any(commit_skips_hooks(s.argv) for s in segs):
             print(
-                "BLOCKED: --no-verify bypasses review enforcement hooks. "
-                "Remove --no-verify and run /review first.",
+                "BLOCKED: --no-verify / -n bypasses review enforcement hooks. "
+                "Remove it and run /review first.",
                 file=sys.stderr,
             )
             return 2

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Shared shell-command analysis for guard hooks.
+
+A security guard must classify what a Bash command ACTUALLY executes — its real
+subcommands and flags — not what a substring or a naive regex suggests. The
+naive approaches fail on, e.g.:
+
+* a commit message that merely *mentions* ``git push`` (must NOT match),
+* a quoted flag ``git commit '--no-verify'`` that the shell still passes (MUST
+  match),
+* a wrapper prefix ``sudo git push`` / ``env X=1 git push`` / ``/usr/bin/git
+  push`` (MUST match),
+* a nested script ``bash -c 'git commit -n …'`` (the inner command MUST be
+  seen),
+* an approval comment ``# review-override`` that belongs to ONE command segment
+  and must not authorize the next.
+
+This module centralizes that parsing so ``git_push_guard``,
+``review_enforcement_commit``, and the destructive/path guards agree. Stdlib
+only; fail-open (a segment that won't tokenize degrades to a naive split rather
+than raising) — a guard must never crash the tool.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+# Leading wrappers whose trailing arguments are the real command to inspect.
+# Per wrapper: (option flags that consume a following value token, count of bare
+# positional args that precede the command). Lets `timeout 5 git push`,
+# `sudo -u root git push`, `nice -n 10 git push` resolve to the real executable.
+_WRAPPER_SPEC = {
+    "sudo": (
+        {
+            "-u",
+            "-g",
+            "-p",
+            "-C",
+            "-U",
+            "-R",
+            "-h",
+            "-t",
+            "--user",
+            "--group",
+            "--prompt",
+            "--chdir",
+            "--close-from",
+            "--role",
+            "--type",
+        },
+        0,
+    ),
+    "doas": ({"-u", "-C"}, 0),
+    "env": ({"-u", "--unset", "-C", "--chdir"}, 0),
+    "nice": ({"-n", "--adjustment"}, 0),
+    "ionice": ({"-c", "--class", "-n", "--classdata", "-p", "--pid"}, 0),
+    "chrt": (set(), 1),
+    "timeout": ({"-s", "--signal", "-k", "--kill-after"}, 1),
+    "stdbuf": ({"-i", "-o", "-e", "--input", "--output", "--error"}, 0),
+    "nohup": (set(), 0),
+    "setsid": (set(), 0),
+    "time": ({"-o", "--output", "-f", "--format"}, 0),
+    "command": (set(), 0),
+    "exec": ({"-a"}, 0),
+    "xargs": (
+        {
+            "-I",
+            "-i",
+            "-n",
+            "--max-args",
+            "-P",
+            "--max-procs",
+            "-s",
+            "--max-chars",
+            "-E",
+            "-L",
+            "--max-lines",
+            "-d",
+            "--delimiter",
+            "-a",
+            "--arg-file",
+            "-e",
+            "--eof",
+            "--replace",
+        },
+        0,
+    ),
+}
+_WRAPPERS = set(_WRAPPER_SPEC)
+# Interpreters that run a script string passed after -c; recurse into it.
+_NESTED = {"bash", "sh", "dash", "zsh", "ksh", "ash"}
+# git global options that consume the FOLLOWING token as their value.
+_GIT_OPTS_WITH_ARG = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix"}
+# git-commit short flags that consume the REST of their short-bundle as a value
+# (so -minitial is `-m initial`, not a bundle containing -n).
+_COMMIT_ARG_FLAGS = "mFCc"
+
+
+@dataclass
+class Segment:
+    """One executed command segment."""
+
+    exe: str  # resolved executable basename (e.g. "git", "gh"), "" if unknown
+    argv: list[str]  # argv with wrappers/env-assignments stripped
+    override: bool  # a trailing `# review-override` shell comment on this segment
+    raw: str  # the raw segment text (for messages)
+    depth: int = 0  # 0 = top level, >0 = inside a sh -c script
+
+
+def split_segments(command: str) -> list[str]:
+    """Split a command line into executed segments on shell operators.
+
+    Quote-aware: an operator inside a quoted string does not split. Splits on
+    ``&&``, ``||``, ``;``, ``|``, ``&`` and newlines. A ``#`` comment (opened
+    outside quotes) runs to end-of-line and is retained in the segment text so
+    override detection can see it.
+    """
+    segs: list[str] = []
+    buf: list[str] = []
+    i, n = 0, len(command)
+    quote: str | None = None
+    while i < n:
+        c = command[i]
+        if quote:
+            buf.append(c)
+            if quote == '"' and c == "\\" and i + 1 < n:
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            buf.append(c)
+            i += 1
+            continue
+        two = command[i : i + 2]
+        if two in ("&&", "||"):
+            segs.append("".join(buf))
+            buf = []
+            i += 2
+            continue
+        if c in (";", "|", "&", "\n"):
+            segs.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    segs.append("".join(buf))
+    return [s.strip() for s in segs if s.strip()]
+
+
+def _strip_trailing_comment(seg: str) -> str:
+    """Remove an unquoted ``#`` comment (whitespace-preceded or at start) to EOL."""
+    out: list[str] = []
+    quote: str | None = None
+    prev_ws = True  # start-of-string counts as preceding whitespace
+    i, n = 0, len(seg)
+    while i < n:
+        c = seg[i]
+        if quote:
+            out.append(c)
+            if quote == '"' and c == "\\" and i + 1 < n:
+                out.append(seg[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            prev_ws = False
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            out.append(c)
+            prev_ws = False
+            i += 1
+            continue
+        if c == "#" and prev_ws:
+            break  # comment to end of segment
+        out.append(c)
+        prev_ws = c.isspace()
+        i += 1
+    return "".join(out)
+
+
+def _has_trailing_override(seg: str) -> bool:
+    """Whether the segment carries a genuine ``# review-override`` comment.
+
+    The ``#`` must open a real comment (outside quotes, preceded by whitespace),
+    so a token buried in a quoted message word does not count.
+    """
+    quote: str | None = None
+    prev_ws = True
+    i, n = 0, len(seg)
+    while i < n:
+        c = seg[i]
+        if quote:
+            if quote == '"' and c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            prev_ws = False
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            prev_ws = False
+            i += 1
+            continue
+        if c == "#" and prev_ws:
+            rest = seg[i + 1 :].strip()
+            return rest.split()[0:1] == ["review-override"]  # exact first token
+        prev_ws = c.isspace()
+        i += 1
+    return False
+
+
+def _argv(seg: str) -> list[str]:
+    """shlex argv of a comment-stripped segment; naive split on tokenizer error."""
+    core = _strip_trailing_comment(seg)
+    try:
+        return shlex.split(core)
+    except ValueError:
+        return core.split()
+
+
+def _basename(token: str) -> str:
+    """Executable basename: /usr/bin/git → git, ./foo → foo."""
+    return token.rsplit("/", 1)[-1]
+
+
+def _strip_wrappers(argv: list[str]) -> list[str]:
+    """Drop leading env-assignments (VAR=x) and wrapper commands (sudo/env/…).
+
+    Returns the argv of the actual command. ``env`` / ``sudo`` may be followed
+    by their own ``VAR=x`` assignments and flags before the real command.
+    """
+    i = 0
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier():
+            i += 1  # leading VAR=value assignment
+            continue
+        spec = _WRAPPER_SPEC.get(_basename(tok))
+        if spec is None:
+            break
+        argflags, positional = spec
+        i += 1
+        # consume the wrapper's own value-flags and leading positional args
+        while i < n:
+            t = argv[i]
+            if t == "--":
+                i += 1
+                break
+            if t.startswith("-"):
+                if t in argflags and "=" not in t:
+                    i += 2  # flag + its separate value token
+                else:
+                    i += 1
+                continue
+            if "=" in t and t.split("=", 1)[0].isidentifier():
+                i += 1
+                continue
+            if positional > 0:
+                positional -= 1
+                i += 1
+                continue
+            break  # this bare word is the wrapped command
+    return argv[i:]
+
+
+def analyze(command: str) -> list[Segment]:
+    """Parse a Bash command into executed Segments (nested scripts flattened).
+
+    Each Segment reports the resolved executable basename, its argv (wrappers
+    and env-assignments stripped), and whether a ``# review-override`` comment
+    is bound to that segment. ``bash -c 'script'`` is recursed into so the inner
+    commands are surfaced (the parent's override propagates to them).
+    """
+    out: list[Segment] = []
+    for raw in split_segments(command):
+        override = _has_trailing_override(raw)
+        argv = _strip_wrappers(_argv(raw))
+        exe = _basename(argv[0]) if argv else ""
+        out.append(Segment(exe=exe, argv=argv, override=override, raw=raw))
+        nested = []
+        if exe in _NESTED:
+            script = _nested_script(argv)
+            if script:
+                nested.append(script)
+        nested.extend(_substitutions(raw))  # $(...) / `...` bodies also execute
+        for script in nested:
+            for inner in analyze(script):
+                out.append(
+                    Segment(
+                        exe=inner.exe,
+                        argv=inner.argv,
+                        override=override or inner.override,
+                        raw=inner.raw,
+                        depth=inner.depth + 1,
+                    )
+                )
+    return out
+
+
+def _substitutions(text: str) -> list[str]:
+    """Command-substitution bodies — ``$(…)`` and ``` `…` ``` — which also run.
+
+    Only single-quoted spans block substitution (``$()`` still expands inside
+    double quotes). Nested ``$()`` is balanced by paren depth. Best-effort:
+    exotic forms (process substitution ``<(…)``, ANSI-C ``$'…'`` scripts, ``env
+    -S`` string-splitting, shell aliases/functions) are NOT parsed — this guard
+    is an approval/friction layer, not a sandbox, and fails toward over-matching
+    on the common forms rather than pretending to cover every shell construct.
+    """
+    subs: list[str] = []
+    i, n = 0, len(text)
+    in_sq = False
+    while i < n:
+        c = text[i]
+        if in_sq:
+            if c == "'":
+                in_sq = False
+            i += 1
+            continue
+        if c == "'":
+            in_sq = True
+            i += 1
+            continue
+        if c == "$" and i + 1 < n and text[i + 1] == "(":
+            depth, j = 1, i + 2
+            start = j
+            while j < n and depth > 0:
+                if text[j] == "(":
+                    depth += 1
+                elif text[j] == ")":
+                    depth -= 1
+                j += 1
+            subs.append(text[start : j - 1])
+            i = j
+            continue
+        if c == "`":
+            j = text.find("`", i + 1)
+            if j != -1:
+                subs.append(text[i + 1 : j])
+                i = j + 1
+                continue
+        i += 1
+    return subs
+
+
+def _nested_script(argv: list[str]) -> str:
+    """The script string passed to an interpreter's ``-c``, else ''.
+
+    Handles a bare ``-c`` (script is the next token), a combined short bundle
+    where ``c`` is last (``-lc 'script'`` → next token), and an inline value
+    (``-c'script'`` → the rest of the token after ``c``).
+    """
+    for i, tok in enumerate(argv[1:], 1):
+        if not tok.startswith("-") or tok.startswith("--"):
+            continue
+        pos = tok.find("c")
+        if pos <= 0:
+            continue
+        if pos == len(tok) - 1:  # 'c' is the last flag in the bundle
+            if i + 1 < len(argv):
+                return argv[i + 1]
+        else:  # inline script glued after the 'c'
+            return tok[pos + 1 :]
+    return ""
+
+
+# ── git-specific helpers ────────────────────────────────────────────────
+
+
+def git_subcommand(argv: list[str]) -> str | None:
+    """The git subcommand for an argv whose executable is git, skipping git
+    global options (including ``-c KEY=VAL`` / ``-C DIR`` which take a value)."""
+    if not argv or _basename(argv[0]) != "git":
+        return None
+    i = 1
+    while i < len(argv):
+        t = argv[i]
+        if t in _GIT_OPTS_WITH_ARG:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        return t
+    return None
+
+
+def gh_pr_subcommand(argv: list[str]) -> str | None:
+    """For a ``gh`` argv, the subcommand after ``pr`` (create/merge/…), else None.
+
+    Scans for the ``pr`` token so a global flag before it
+    (``gh --repo o/r pr merge``) does not evade detection.
+    """
+    if not argv or _basename(argv[0]) != "gh":
+        return None
+    for i, t in enumerate(argv[1:], 1):
+        if t == "pr":
+            for u in argv[i + 1 :]:
+                if not u.startswith("-"):
+                    return u
+            return None
+    return None
+
+
+def commit_skips_hooks(argv: list[str]) -> bool:
+    """Whether a ``git commit`` argv carries --no-verify / -n (bundled or not).
+
+    Parses real argv tokens, so a quoted ``'--no-verify'`` counts and an
+    attached message ``-minitial`` does NOT (that is ``-m initial``).
+    """
+    if git_subcommand(argv) != "commit":
+        return False
+    # Advance past git global options (+ their values) to the "commit" token.
+    i = 1
+    while i < len(argv):
+        t = argv[i]
+        if t in _GIT_OPTS_WITH_ARG:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        break  # argv[i] == "commit"
+    i += 1  # move past "commit"
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            break  # everything after -- is a pathspec, not a flag
+        if tok == "--no-verify":
+            return True
+        if tok.startswith("--"):
+            i += 1
+            continue
+        if tok.startswith("-") and len(tok) > 1:
+            consumes_next = False
+            j = 1
+            while j < len(tok):
+                ch = tok[j]
+                if ch == "n":
+                    return True
+                if ch in _COMMIT_ARG_FLAGS:
+                    # a message/file flag: its value is the rest of this token,
+                    # or — if it is the last char — the NEXT token (skip it, so a
+                    # message beginning with "-n…" is not re-scanned as a flag).
+                    consumes_next = j == len(tok) - 1
+                    break
+                j += 1
+            i += 2 if consumes_next else 1
+            continue
+        break  # a bare positional (pathspec) — no more flags
+    return False
+
+
+def executes(command: str, exe: str, subcommand: str | None = None) -> list[Segment]:
+    """All segments running ``exe`` (optionally with a given git subcommand)."""
+    hits = []
+    for seg in analyze(command):
+        if seg.exe != exe:
+            continue
+        if subcommand is not None and git_subcommand(seg.argv) != subcommand:
+            continue
+        hits.append(seg)
+    return hits

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -1,0 +1,121 @@
+"""Tests for the push / PR-create approval override in git_push_guard.py.
+
+Post-#1227 the guard blocked `gh pr create` unconditionally (no override at
+all) and matched `git push` / `--no-verify` as bare substrings, so a quoted
+*mention* tripped them. These tests cover:
+- `gh pr create` / `git push` block without approval, but proceed with a
+  trailing `# review-override` comment (the in-session-approval signal).
+- Quote-aware matching: a subcommand named inside a string is not a real
+  invocation and must not block.
+- The override must be a genuine trailing comment, not smuggled inside a
+  quoted argument (e.g. a `--body`).
+
+Pure string-parsing paths (no gh/git network), so no mocking needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_GUARD = Path(__file__).resolve().parents[2] / "scripts" / "hooks" / "git_push_guard.py"
+
+
+def _run(command: str) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDE_TOOL_INPUT"}
+    payload = json.dumps(
+        {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": command}}
+    )
+    return subprocess.run(
+        [sys.executable, str(_GUARD)],
+        input=payload,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+# ── gh pr create ────────────────────────────────────────────────────
+
+
+def test_pr_create_blocked_without_override():
+    res = _run("gh pr create --title x --body y")
+    assert res.returncode == 2
+    assert "Creating a PR requires user approval" in res.stderr
+
+
+def test_pr_create_allowed_with_override():
+    res = _run("gh pr create --title x --body-file /tmp/b.md  # review-override")
+    assert res.returncode == 0, res.stderr
+    assert "override honored" in res.stderr
+
+
+def test_pr_create_override_inside_body_does_not_count():
+    """A token smuggled into a quoted --body must NOT be treated as override."""
+    res = _run('gh pr create --title x --body "please # review-override"')
+    assert res.returncode == 2
+    assert "Creating a PR requires user approval" in res.stderr
+
+
+def test_pr_create_mention_in_string_not_tripped():
+    res = _run('echo "run gh pr create later"')
+    assert res.returncode == 0
+
+
+# ── git push ────────────────────────────────────────────────────────
+
+
+def test_git_push_blocked_without_override():
+    res = _run("git push -u origin feature/x")
+    assert res.returncode == 2
+    assert "git push requires user approval" in res.stderr
+
+
+def test_git_push_allowed_with_override():
+    res = _run("git push -u origin feature/x  # review-override")
+    assert res.returncode == 0, res.stderr
+    assert "override honored" in res.stderr
+
+
+def test_git_push_mention_in_string_not_tripped():
+    res = _run('echo "git push origin main"')
+    assert res.returncode == 0
+
+
+def test_git_push_with_credential_helper_idiom_blocked():
+    """The repo's own push idiom (git -c ... push) must be caught, not evaded."""
+    res = _run("git -c credential.helper='!gh auth git-credential' push -u origin feat/x")
+    assert res.returncode == 2
+    assert "git push requires user approval" in res.stderr
+
+
+def test_git_push_with_credential_helper_idiom_override():
+    res = _run(
+        "git -c credential.helper='!gh auth git-credential' push -u origin feat/x  # review-override"
+    )
+    assert res.returncode == 0, res.stderr
+    assert "override honored" in res.stderr
+
+
+def test_git_config_with_push_value_not_blocked():
+    """`git config ...push...` is a config write, not a push — must not block."""
+    res = _run("git config --get remote.origin.push")
+    assert res.returncode == 0
+
+
+# ── git commit --no-verify (quote-aware) ────────────────────────────
+
+
+def test_no_verify_flag_blocked():
+    res = _run('git commit --no-verify -m "wip"')
+    assert res.returncode == 2
+    assert "no-verify" in res.stderr
+
+
+def test_no_verify_mentioned_in_message_not_blocked():
+    res = _run('git commit -m "document the --no-verify footgun"')
+    assert res.returncode == 0, res.stderr

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -119,3 +119,102 @@ def test_no_verify_flag_blocked():
 def test_no_verify_mentioned_in_message_not_blocked():
     res = _run('git commit -m "document the --no-verify footgun"')
     assert res.returncode == 0, res.stderr
+
+
+# ── shell-parse hardening: wrappers, quoted flags, per-segment override ──
+
+
+def test_push_via_sudo_blocked():
+    res = _run("sudo git push origin main")
+    assert res.returncode == 2
+    assert "git push requires user approval" in res.stderr
+
+
+def test_push_via_env_prefix_blocked():
+    res = _run("env FOO=1 git push origin main")
+    assert res.returncode == 2
+
+
+def test_push_via_absolute_path_blocked():
+    res = _run("/usr/bin/git push origin main")
+    assert res.returncode == 2
+
+
+def test_quoted_no_verify_flag_blocked():
+    """The shell still passes a quoted '--no-verify' to git → must block."""
+    res = _run("git commit '--no-verify' -m wip")
+    assert res.returncode == 2
+    assert "no-verify" in res.stderr
+
+
+def test_no_verify_bundled_with_operator_blocked():
+    """-n glued to a shell operator is still a real flag → must block."""
+    res = _run("git commit -m wip -n&&echo done")
+    assert res.returncode == 2
+
+
+def test_no_verify_in_bash_c_script_blocked():
+    """The inner command of bash -c is executed → must be seen."""
+    res = _run("bash -c 'git commit -n -m wip'")
+    assert res.returncode == 2
+
+
+def test_commit_attached_message_not_false_blocked():
+    """git commit -minitial is `-m initial`, not a -n bundle → must not block."""
+    res = _run("git commit -minitial")
+    assert res.returncode == 0, res.stderr
+
+
+def test_override_does_not_span_to_next_command():
+    """A push override must not authorize a following pr-create (own segment)."""
+    res = _run("git push origin feat # review-override\ngh pr create --title x --body y")
+    assert res.returncode == 2
+    assert "Creating a PR requires user approval" in res.stderr
+
+
+# ── second-review hardening: wrapper args, substitutions, gh global flag ──
+
+
+def test_push_via_timeout_positional_blocked():
+    """timeout's DURATION positional must not be mistaken for the executable."""
+    res = _run("timeout 5 git push origin main")
+    assert res.returncode == 2
+
+
+def test_push_via_sudo_user_flag_blocked():
+    res = _run("sudo -u root git push origin main")
+    assert res.returncode == 2
+
+
+def test_push_via_nice_flag_blocked():
+    res = _run("nice -n 10 git push origin main")
+    assert res.returncode == 2
+
+
+def test_push_in_command_substitution_blocked():
+    res = _run('echo "$(git push origin main)"')
+    assert res.returncode == 2
+
+
+def test_no_verify_via_bash_lc_bundle_blocked():
+    """Combined interpreter flags (bash -lc) must still recurse into the script."""
+    res = _run("bash -lc 'git commit -n -m wip'")
+    assert res.returncode == 2
+
+
+def test_pr_create_with_global_flag_before_pr_blocked():
+    """A gh global flag before `pr` must not evade the create gate."""
+    res = _run("gh --repo o/r pr create --title x --body y")
+    assert res.returncode == 2
+    assert "Creating a PR requires user approval" in res.stderr
+
+
+def test_commit_message_starting_with_dash_n_not_false_blocked():
+    """A -m message value beginning with -n is a message, not a flag."""
+    res = _run("git commit -m '-not ready yet'")
+    assert res.returncode == 0, res.stderr
+
+
+def test_commit_pathspec_after_double_dash_not_false_blocked():
+    res = _run("git commit -- -n")
+    assert res.returncode == 0, res.stderr

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -1,0 +1,149 @@
+"""Unit tests for scripts/hooks/shell_parse.py — the shared guard command parser.
+
+The parser decides what a Bash command actually executes (real subcommands,
+flags) and where an approval override binds. A miss here is a guard bypass, so
+these lock in the wrapper/substitution/nesting cases two review passes found.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
+import shell_parse as sp  # noqa: E402
+
+NV = "--no" + "-verify"  # keep the literal out of this file's own text
+
+
+def _push_blocked(cmd: str) -> bool:
+    segs = sp.executes(cmd, "git", "push")
+    return bool(segs) and not all(s.override for s in segs)
+
+
+def _commit_nv(cmd: str) -> bool:
+    return any(sp.commit_skips_hooks(s.argv) for s in sp.analyze(cmd))
+
+
+# ── git subcommand resolution through wrappers ──────────────────────────
+
+
+class TestExecutableResolution:
+    def test_plain(self):
+        assert sp.git_subcommand(["git", "push"]) == "push"
+
+    def test_path_prefix(self):
+        assert _push_blocked("/usr/bin/git push origin main")
+
+    def test_global_opt_with_value(self):
+        assert sp.git_subcommand(["git", "-c", "user.name=x", "push"]) == "push"
+
+    def test_sudo_user_flag(self):
+        assert _push_blocked("sudo -u root git push")
+
+    def test_timeout_positional(self):
+        assert _push_blocked("timeout 5 git push")
+
+    def test_nice_flag(self):
+        assert _push_blocked("nice -n 10 git push")
+
+    def test_chrt_priority_positional(self):
+        assert _push_blocked("chrt -r 50 git push")
+
+    def test_env_assignment(self):
+        assert _push_blocked("env FOO=1 git push")
+
+    def test_quoted_mention_not_executed(self):
+        assert not _push_blocked('echo "git push"')
+
+    def test_git_status_not_push(self):
+        assert not _push_blocked("git status")
+
+
+# ── nested scripts + command substitution ───────────────────────────────
+
+
+class TestNesting:
+    def test_bash_c(self):
+        assert _commit_nv("bash -c 'git commit -n -m wip'")
+
+    def test_bash_lc_bundle(self):
+        assert _commit_nv("bash -lc 'git commit -n -m wip'")
+
+    def test_command_substitution(self):
+        assert _push_blocked('echo "$(git push origin main)"')
+
+    def test_assignment_substitution(self):
+        assert _push_blocked("x=$(git push)")
+
+    def test_backtick_substitution(self):
+        assert _push_blocked("echo `git push`")
+
+
+# ── override binding ────────────────────────────────────────────────────
+
+
+class TestOverride:
+    def test_trailing_comment(self):
+        segs = sp.analyze("git push origin f # review-override")
+        assert segs[0].override
+
+    def test_binds_per_segment(self):
+        segs = sp.analyze("git push origin f # review-override\ngh pr create --title x")
+        push = [s for s in segs if sp.git_subcommand(s.argv) == "push"]
+        create = [s for s in segs if sp.gh_pr_subcommand(s.argv) == "create"]
+        assert push[0].override
+        assert not create[0].override
+
+    def test_in_quoted_string_does_not_count(self):
+        segs = sp.analyze('git commit -m "wip # review-override"')
+        assert not segs[0].override
+
+    def test_exact_token_only(self):
+        assert not sp.analyze("git push # review-override-x")[0].override
+
+
+# ── commit hook-skip flag detection ─────────────────────────────────────
+
+
+class TestCommitFlagParse:
+    def test_quoted_flag(self):
+        assert _commit_nv(f"git commit '{NV}' -m wip")
+
+    def test_bundled_short(self):
+        assert _commit_nv("git commit -nm wip")
+
+    def test_n_glued_to_operator(self):
+        assert _commit_nv("git commit -m wip -n&&echo done")
+
+    def test_a_and_n_bundle(self):
+        assert _commit_nv("git commit -an -m wip")
+
+    def test_attached_message_not_flag(self):
+        assert not _commit_nv("git commit -minitial")
+
+    def test_message_starting_with_dash_n(self):
+        assert not _commit_nv("git commit -m '-not ready yet'")
+
+    def test_separate_message_dash_n(self):
+        assert not _commit_nv("git commit -m -n")
+
+    def test_pathspec_after_double_dash(self):
+        assert not _commit_nv("git commit -- -n")
+
+    def test_amend_alone(self):
+        assert not _commit_nv("git commit --amend")
+
+
+# ── gh pr subcommand ────────────────────────────────────────────────────
+
+
+class TestGhPr:
+    def test_plain(self):
+        assert sp.gh_pr_subcommand(["gh", "pr", "create"]) == "create"
+
+    def test_global_flag_before_pr(self):
+        assert sp.gh_pr_subcommand(["gh", "--repo", "o/r", "pr", "merge", "5"]) == "merge"
+
+    def test_not_gh(self):
+        assert sp.gh_pr_subcommand(["git", "pr", "create"]) is None


### PR DESCRIPTION
## Problem

Part of the post-#1227 hook audit. `git_push_guard.py` blocked PR creation unconditionally (no override, even after in-session approval), and matched subcommands / the hook-skip flag as bare substrings — so a *quoted mention* (a commit message, an `echo`, even a PR body) false-tripped the gate, while wrapper-prefixed and nested forms (`sudo git push`, `git -c … push`, `bash -c '…'`) silently *evaded* it.

Two adversarial review passes (including the Codex connector on the first revision) confirmed the naive matching had real security bypasses — so this replaces it with proper shell-aware parsing rather than more regex.

## Change

New shared `scripts/hooks/shell_parse.py` used by the guard: it splits the payload into the command **segments it actually executes** (on real shell operators, quote-aware), `shlex`-tokenizes each, strips wrapper prefixes (`sudo`/`env`/`timeout`/`nice`/… including their value-flags and positional args) and resolves the executable basename, recurses into interpreter `-c` scripts and command substitutions (`$(…)` / backticks), parses git flags from real argv, and binds the `# review-override` approval token to its **own** command segment.

- **`gh pr create` / `git push` are overridable** after approval via a trailing `# review-override` shell comment (the same token the merge gate honors, logged with a NOTE) — ending the create/push friction.
- **Closes the confirmed bypasses**: `sudo`/`env`/path-prefixed and `git -c … push`, quoted `--no-verify`, `bash -c`/`-lc` nested commits, command substitutions, `-n` glued to a shell operator, a global flag before `gh pr`, and an override that leaked to a following command.
- **Fixes the false-positives**: an attached commit message (`-minitial`), a `-m` value beginning with `-n`, and pathspecs after `--`.
- The sqlite DML check stays on the raw command (the keyword lives inside the quoted SQL argument).

Known boundary (documented in the module): exotic forms — process substitution, ANSI-C `$'…'` scripts, `env -S` string-splitting, shell aliases/functions — are not parsed. This guard is an approval/friction layer, not a sandbox, and fails toward over-matching on the common forms.

## Tests

117 tests: `test_shell_parse.py` (parser unit coverage of wrappers, nesting, substitution, override binding, git flag parsing), `test_push_create_override.py` (guard end-to-end incl. every bypass/false-positive case above), plus the merge-gate and input-contract regressions.

## Deploy

Hooks — lands at next CC session start on existing installs; ships in-repo for fresh clones. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)