### PR TITLE
fix(hooks): behavioral-linter precision — prose warns, code blocks, no self-lint

### DIFF
--- a/config/behavioral_rules/no_hide_problems.yaml
+++ b/config/behavioral_rules/no_hide_problems.yaml
@@ -12,6 +12,14 @@
 
 name: no-hide-problems
 severity: block
+# Doc formats are excluded: a markdown/rst/txt file that merely QUOTES the
+# CSS/Alpine patterns (an audit report, a PR body, a code fence) must not be
+# hard-blocked for describing the anti-pattern. Real markup lives in
+# .css/.html/.js/.vue files, which stay in scope.
+excludes:
+  - "*.md"
+  - "*.rst"
+  - "*.txt"
 description: >
   Never hide, suppress, or work around broken things — fix them.
   This applies to code, UI, plans, and reasoning. When something
@@ -43,15 +51,15 @@ patterns:
     context: Alpine conditional hiding error/unknown states
 
   # Reasoning-level patterns (plans, comments, proposals) — WARN only
-  - regex: '\b(?:hide|skip|remove|suppress|omit)\b.{0,40}\b(?:unknown|error|broken|stale|failed|placeholder|not.configured|not.available)\b'
+  - regex: '\b(?:hide|skip|remove|suppress|omit)\b.{0,40}\b(?:unknown|error|broken|stale|failed|placeholder|not.configured|not.available)'
     severity: warn
     context: Proposing to hide/skip broken or unknown data
-  - regex: '\b(?:unknown|error|broken|stale|failed|placeholder)\b.{0,40}\b(?:hide|skip|remove|suppress|omit)\b'
+  - regex: '\b(?:unknown|error|broken|stale|failed|placeholder).{0,40}\b(?:hide|skip|remove|suppress|omit)\b'
     severity: warn
     context: Proposing to suppress display of broken state
-  - regex: '\b(?:don.?t|do not|never|avoid)\s+(?:show|display|render|expose)\b.{0,40}\b(?:error|unknown|broken|stale|failed)\b'
+  - regex: '\b(?:don.?t|do not|never|avoid)\s+(?:show|display|render|expose)\b.{0,40}\b(?:error|unknown|broken|stale|failed)'
     severity: warn
     context: Proposing to not show error/broken state
-  - regex: '\b(?:only show|skip showing)\b.{0,40}(?:when|if|unless).{0,40}\b(?:available|configured|exists|ready|healthy)\b'
+  - regex: '\b(?:only show|skip showing)\b.{0,40}(?:when|if|unless).{0,40}\b(?:available|configured|exists|ready|healthy)'
     severity: warn
     context: Conditional display that omits broken states instead of showing them honestly

--- a/config/behavioral_rules/no_hide_problems.yaml
+++ b/config/behavioral_rules/no_hide_problems.yaml
@@ -3,6 +3,12 @@
 # Origin: 2026-03-15 — proposed hiding "unknown" resilience state instead
 # of wiring the actual state machine. User correctly identified this as
 # a trust-destroying anti-pattern.
+#
+# behavioral-lint: ignore no-hide-problems
+# ^ This rule-definition file necessarily contains the trigger patterns it
+#   matches, so it is exempt from self-linting (also enforced structurally by
+#   the linter skipping config/behavioral_rules/). The escape leaves an audit
+#   trail per the linter's own convention.
 
 name: no-hide-problems
 severity: block
@@ -18,19 +24,34 @@ suggestion: >
   skip, suppress, or omit broken data. Never propose deferring the
   fix while hiding the symptom.
 
+# Severity model: the code-level patterns (display:none / x-show hiding an
+# error state) are unambiguous and stay `block` (the rule default). The
+# reasoning/prose patterns are inherently fuzzy — they match token adjacency,
+# not intent — so they are `warn`: they surface the concern without hard-
+# blocking legitimate prose (a commit message, a docstring, this audit). The
+# verbs and state-words are \b-anchored so identifier-embedded matches
+# (skip_writeback, _QDRANT_ERRORS) and most punctuation-joined tokens no longer
+# trip the rule.
 patterns:
-  # Code-level patterns
+  # Code-level patterns — hard block (unambiguous; require literal display:none
+  # or an Alpine x-show, which effectively never appear in prose)
   - regex: 'display:\s*none[^;]*(?:unknown|error|broken|stale|failed)'
     context: Hiding element based on error/unknown state
+  - regex: '(?:unknown|error|broken|stale|failed)[^;]{0,40}display:\s*none'
+    context: Hiding an error/unknown element via display:none
   - regex: 'x-show="[^"]*!\s*\S*(?:error|unknown|failed)'
     context: Alpine conditional hiding error/unknown states
 
-  # Reasoning-level patterns (plans, comments, proposals)
-  - regex: '(?:hide|skip|remove|suppress|omit).{0,40}(?:unknown|error|broken|stale|failed|placeholder|not.configured|not.available)'
+  # Reasoning-level patterns (plans, comments, proposals) — WARN only
+  - regex: '\b(?:hide|skip|remove|suppress|omit)\b.{0,40}\b(?:unknown|error|broken|stale|failed|placeholder|not.configured|not.available)\b'
+    severity: warn
     context: Proposing to hide/skip broken or unknown data
-  - regex: '(?:unknown|error|broken|stale|failed|placeholder).{0,40}(?:hide|skip|remove|suppress|omit|display:\s*none|don.?t show|do not show|not show)'
+  - regex: '\b(?:unknown|error|broken|stale|failed|placeholder)\b.{0,40}\b(?:hide|skip|remove|suppress|omit)\b'
+    severity: warn
     context: Proposing to suppress display of broken state
-  - regex: '(?:don.?t|do not|never|avoid)\s+(?:show|display|render|expose).{0,40}(?:error|unknown|broken|stale|failed)'
+  - regex: '\b(?:don.?t|do not|never|avoid)\s+(?:show|display|render|expose)\b.{0,40}\b(?:error|unknown|broken|stale|failed)\b'
+    severity: warn
     context: Proposing to not show error/broken state
-  - regex: '(?:only show|skip showing).{0,40}(?:when|if|unless).{0,40}(?:available|configured|exists|ready|healthy)'
+  - regex: '\b(?:only show|skip showing)\b.{0,40}(?:when|if|unless).{0,40}\b(?:available|configured|exists|ready|healthy)\b'
+    severity: warn
     context: Conditional display that omits broken states instead of showing them honestly

--- a/config/behavioral_rules/no_unguarded_kill.yaml
+++ b/config/behavioral_rules/no_unguarded_kill.yaml
@@ -8,9 +8,25 @@
 # linter checks Edit new_string content, and a guarded killpg (with pgid > 1
 # check on a preceding line) would false-positive. The os.kill(-1) and
 # os.kill(0) patterns are always dangerous regardless of context.
+#
+# behavioral-lint: ignore no-unguarded-kill
+# behavioral-lint: ignore no-hide-problems
+# ^ This rule-definition file necessarily contains the trigger literals it
+#   matches, so it is exempt from self-linting (also enforced structurally by
+#   the linter skipping config/behavioral_rules/). The tokens leave an audit
+#   trail per the linter's own convention.
 
 name: no-unguarded-kill
 severity: block
+# Fires on ALL code — including extensionless CLI scripts (shebang python),
+# notebooks, and templates that carry the real call. Only doc formats are
+# excluded, so a markdown/rst file quoting the literal (this rule's audit, the
+# hook-audit report) is not hard-blocked, while a `.py` allow-list would have
+# silently un-guarded the dangerous call in every extensionless script.
+excludes:
+  - "*.md"
+  - "*.rst"
+  - "*.txt"
 description: >
   Never call os.kill(-1, ...) or os.kill(0, ...) — these kill all processes
   owned by the user or in the process group. Use os.killpg() with a

--- a/scripts/behavioral_linter.py
+++ b/scripts/behavioral_linter.py
@@ -18,6 +18,7 @@ Emits SteerMessage for unified enforcement feedback.
 
 import re
 import sys
+from fnmatch import fnmatch
 from pathlib import Path
 
 import yaml
@@ -45,45 +46,141 @@ def _load_rules() -> list[dict]:
     return rules
 
 
-def _check_content(content: str, rules: list[dict]) -> list[tuple[dict, dict]]:
-    """Check content against all rules. Returns list of (rule, matched_pattern) tuples."""
+def _severity_of(rule: dict, pattern_def: dict) -> str:
+    """Resolve a pattern's severity, falling back to the rule-level default.
+
+    Per-pattern ``severity`` lets one rule mix hard-block code patterns with
+    advisory (warn) prose patterns. Anything other than "block" resolves to
+    "warn" (fail toward the softer decision).
+    """
+    sev = pattern_def.get("severity") or rule.get("severity", "warn")
+    return "block" if sev == "block" else "warn"
+
+
+def _glob_match(file_path: str, globs: list) -> bool:
+    """Whether ``file_path`` matches any glob (full normalized path or basename)."""
+    name = file_path.replace("\\", "/")
+    base = name.rsplit("/", 1)[-1]
+    return any(fnmatch(name, g) or fnmatch(base, g) for g in globs)
+
+
+def _applies_to(rule: dict, file_path: str) -> bool:
+    """Whether a rule applies to the given file path.
+
+    A rule may declare ``applies_to`` (allow-list) and/or ``excludes``
+    (deny-list) as lists of globs:
+    - ``excludes`` wins: a file matching an exclude glob is never checked. Use
+      this for a code rule that should fire everywhere EXCEPT docs (safer than
+      an allow-list, which silently misses extensionless scripts / notebooks /
+      templates that carry real code).
+    - ``applies_to``: when present, the rule fires only for matching files.
+    Absent both → applies to all. An empty/absent file_path keeps the rule
+    active (fail toward checking).
+    """
+    excludes = rule.get("excludes")
+    if excludes and file_path and _glob_match(file_path, excludes):
+        return False
+    globs = rule.get("applies_to")
+    if not globs:
+        return True
+    if not file_path:
+        return True
+    return _glob_match(file_path, globs)
+
+
+def _check_content(
+    content: str, rules: list[dict], file_path: str = ""
+) -> list[tuple[dict, dict, str]]:
+    """Check content against all rules.
+
+    Returns one ``(rule, pattern_def, severity)`` per violated rule, choosing
+    the HIGHEST-severity matching pattern for that rule (so a warn-level pattern
+    can never mask a block-level one — which the old first-match ``break`` did).
+    """
     violations = []
     for rule in rules:
         rule_name = rule.get("name", "unnamed")
 
-        # Check for escape hatch
+        if not _applies_to(rule, file_path):
+            continue
+
+        # Escape hatch: an explicit opt-out comment turns off the whole rule.
         escape = f"behavioral-lint: ignore {rule_name}"
         if escape in content:
             continue
 
+        best: tuple[dict, dict, str] | None = None
+        best_rank = -1
         for pattern_def in rule.get("patterns", []):
             regex = pattern_def.get("regex", "")
             if not regex:
                 continue
             try:
-                if re.search(regex, content, re.IGNORECASE | re.MULTILINE):
-                    violations.append((rule, pattern_def))
-                    break  # One match per rule is enough
+                matched = re.search(regex, content, re.IGNORECASE | re.MULTILINE)
             except re.error:
                 print(f"WARNING: Invalid regex in rule {rule_name}: {regex}", file=sys.stderr)
+                continue
+            if not matched:
+                continue
+            severity = _severity_of(rule, pattern_def)
+            rank = 2 if severity == "block" else 0
+            if rank > best_rank:
+                best = (rule, pattern_def, severity)
+                best_rank = rank
+                if rank == 2:
+                    break  # block is the max — no pattern can outrank it
+        if best is not None:
+            violations.append(best)
     return violations
 
 
-def _to_steer_messages(violations: list[tuple[dict, dict]], file_path: str) -> list:
-    """Convert violations to SteerMessage instances."""
-    from genesis.autonomy.steering import SteerMessage
-    from genesis.autonomy.types import ApprovalDecision, EnforcementLayer
+def _plain_stderr(rule: dict, pattern_def: dict, severity: str, name: str, file_path: str) -> str:
+    """Format a violation without the genesis package (fresh-install fallback).
 
-    messages = []
-    for rule, pattern_def in violations:
-        severity = rule.get("severity", "warn")
+    Mirrors SteerMessage.to_stderr()'s shape so downstream text assertions and
+    the human-readable format stay stable when genesis isn't importable.
+    """
+    label = "BLOCKED" if severity == "block" else "WARNING"
+    lines = [f"\n{label}: Behavioral rule '{name}' violated", f"  Rule: {name}"]
+    if file_path:
+        lines.append(f"  File: {file_path}")
+    if pattern_def.get("context"):
+        lines.append(f"  Issue: {pattern_def['context']}")
+    fix = rule.get("description", "")
+    if rule.get("suggestion"):
+        fix += "\n  " + rule["suggestion"]
+    if fix:
+        lines.append(f"  Fix: {fix}")
+    lines.append(f"  Escape: Add '# behavioral-lint: ignore {name}' if user-approved")
+    return "\n".join(lines) + "\n"
+
+
+def _emit(violations: list[tuple[dict, dict, str]], file_path: str) -> int:
+    """Print each violation to stderr; return the max exit code (2 = block).
+
+    Prefers SteerMessage formatting, but if the genesis package isn't importable
+    (a fresh/partial install), falls back to plain text that STILL returns the
+    correct exit code — so a block never silently degrades to a non-blocking
+    error just because genesis wasn't on the path.
+    """
+    try:
+        from genesis.autonomy.steering import SteerMessage
+        from genesis.autonomy.types import ApprovalDecision, EnforcementLayer
+
+        use_steer = True
+    except Exception:
+        use_steer = False
+
+    exit_code = 0
+    for rule, pattern_def, severity in violations:
         name = rule.get("name", "unnamed")
-        messages.append(
-            SteerMessage(
+        is_block = severity == "block"
+        if use_steer:
+            msg = SteerMessage(
                 layer=EnforcementLayer.HARD_BLOCK,
                 rule_id=name,
-                decision=ApprovalDecision.BLOCK if severity == "block" else ApprovalDecision.ACT,
-                severity="critical" if severity == "block" else "medium",
+                decision=ApprovalDecision.BLOCK if is_block else ApprovalDecision.ACT,
+                severity="critical" if is_block else "medium",
                 title=f"Behavioral rule '{name}' violated",
                 context=pattern_def.get("context", ""),
                 suggestion=rule.get("description", "")
@@ -93,8 +190,14 @@ def _to_steer_messages(violations: list[tuple[dict, dict]], file_path: str) -> l
                 can_suppress=True,
                 suppress_key=f"# behavioral-lint: ignore {name}",
             )
-        )
-    return messages
+            print(msg.to_stderr(), file=sys.stderr)
+            code = msg.to_exit_code()
+        else:
+            print(_plain_stderr(rule, pattern_def, severity, name, file_path), file=sys.stderr)
+            code = 2 if is_block else 0
+        if code > exit_code:
+            exit_code = code
+    return exit_code
 
 
 def main() -> int:
@@ -107,25 +210,29 @@ def main() -> int:
 
     file_path = field(payload, "file_path")
 
+    # Never lint the rule-definition files themselves: they necessarily contain
+    # the very patterns they match (the kill-all call literals, the hide-on-
+    # error CSS), so self-linting hard-blocks every edit to this directory — a
+    # #1227 side effect once the hook gained teeth. Editing the rules is how the
+    # rules get fixed; it must not require the escape hatch in each file. Match
+    # the ACTUAL rules dir by resolved path (not a bare substring, which would
+    # also skip an unrelated */config/behavioral_rules/* path elsewhere).
+    if file_path:
+        try:
+            if _RULES_DIR.resolve() in Path(file_path).resolve().parents:
+                return 0
+        except (OSError, ValueError, RuntimeError):
+            pass
+
     rules = _load_rules()
     if not rules:
         return 0
 
-    violations = _check_content(content, rules)
+    violations = _check_content(content, rules, file_path)
     if not violations:
         return 0
 
-    # Convert to SteerMessages and output
-    messages = _to_steer_messages(violations, file_path)
-
-    exit_code = 0
-    for msg in messages:
-        print(msg.to_stderr(), file=sys.stderr)
-        code = msg.to_exit_code()
-        if code > exit_code:
-            exit_code = code
-
-    return exit_code
+    return _emit(violations, file_path)
 
 
 if __name__ == "__main__":

--- a/scripts/behavioral_linter.py
+++ b/scripts/behavioral_linter.py
@@ -16,6 +16,7 @@ audit trail — the user approved the exception.
 Emits SteerMessage for unified enforcement feedback.
 """
 
+import json
 import re
 import sys
 from fnmatch import fnmatch
@@ -172,6 +173,8 @@ def _emit(violations: list[tuple[dict, dict, str]], file_path: str) -> int:
         use_steer = False
 
     exit_code = 0
+    block_texts: list[str] = []
+    warn_texts: list[str] = []
     for rule, pattern_def, severity in violations:
         name = rule.get("name", "unnamed")
         is_block = severity == "block"
@@ -190,13 +193,34 @@ def _emit(violations: list[tuple[dict, dict, str]], file_path: str) -> int:
                 can_suppress=True,
                 suppress_key=f"# behavioral-lint: ignore {name}",
             )
-            print(msg.to_stderr(), file=sys.stderr)
+            text = msg.to_stderr()
             code = msg.to_exit_code()
         else:
-            print(_plain_stderr(rule, pattern_def, severity, name, file_path), file=sys.stderr)
+            text = _plain_stderr(rule, pattern_def, severity, name, file_path)
             code = 2 if is_block else 0
+        (block_texts if is_block else warn_texts).append(text)
         if code > exit_code:
             exit_code = code
+
+    if exit_code == 2:
+        # A block fired: exit 2 delivers stderr to the model, so surface every
+        # message (blocks and any warns) there.
+        for text in block_texts + warn_texts:
+            print(text, file=sys.stderr)
+    elif warn_texts:
+        # Warn-only: PreToolUse stderr on exit 0 is DISCARDED by Claude Code, so
+        # the advisory must ride hookSpecificOutput.additionalContext (stdout),
+        # which is delivered to the model.
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "additionalContext": "\n".join(warn_texts),
+                    }
+                }
+            )
+        )
     return exit_code
 
 

--- a/tests/test_hooks/test_behavioral_linter.py
+++ b/tests/test_hooks/test_behavioral_linter.py
@@ -98,6 +98,19 @@ class TestNoHideProblemsCodeBlocks:
         assert result.returncode == 2
         assert "no-hide-problems" in result.stderr
 
+    def test_markdown_quoting_css_not_blocked(self):
+        """P2 regression: a .md/.rst doc quoting the CSS must not hard-block.
+
+        A doc merely describing the anti-pattern (an audit report, a PR body, a
+        code fence) is excluded; real markup lives in .css/.html/.js. Fixture is
+        concatenated so this file has no literal trigger.
+        behavioral-lint: ignore no-hide-problems
+        """
+        css = ".err" + "or { display: none; }"
+        content = "The anti-pattern to avoid:\n```css\n" + css + "\n```\n"
+        result = _run_linter({"content": content, "file_path": "docs/hooks-audit.md"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
 
 # ---------------------------------------------------------------------------
 # no-hide-problems — reasoning/prose patterns WARN (exit 0)
@@ -113,14 +126,17 @@ class TestNoHideProblemsProseWarns:
     """
 
     def _assert_warns(self, result):
+        # Warn advisories ride hookSpecificOutput.additionalContext on STDOUT
+        # (exit-0 stderr is discarded by Claude Code), never a hard block.
         assert result.returncode == 0, result.stderr
-        assert "WARNING" in result.stderr
-        assert "no-hide-problems" in result.stderr
-        assert "BLOCKED" not in result.stderr
+        assert "additionalContext" in result.stdout
+        assert "WARNING" in result.stdout
+        assert "no-hide-problems" in result.stdout
+        assert "BLOCKED" not in result.stdout and "BLOCKED" not in result.stderr
 
     def test_propose_hide_broken_data(self):
         content = "# We should hide the broken data for now"
-        self._assert_warns(_run_linter({"content": content, "file_path": "plan.md"}))
+        self._assert_warns(_run_linter({"content": content, "file_path": "plan.py"}))
 
     def test_propose_skip_unknown(self):
         content = "# skip the unknown values until we figure it out"
@@ -509,9 +525,9 @@ class TestMultipleRules:
         content = "# hide the broken dashboard widget"
         result = _run_linter({"content": content, "file_path": "hide_only.py"})
         assert result.returncode == 0, result.stderr
-        assert "WARNING" in result.stderr
-        assert "no-hide-problems" in result.stderr
-        assert "no-unguarded-kill" not in result.stderr
+        assert "WARNING" in result.stdout  # warn rides additionalContext
+        assert "no-hide-problems" in result.stdout
+        assert "no-unguarded-kill" not in result.stdout
 
     def test_prose_warn_and_kill_block(self):
         """Prose hide (warn) + kill (block) → exit 2, both reported.
@@ -551,22 +567,32 @@ class TestViolationMessages:
         assert "Escape:" in stderr
         assert "behavioral-lint: ignore no-unguarded-kill" in stderr
 
-    def test_warn_message_structure(self):
-        """Prose warn messages use WARNING (not BLOCKED) and still carry Fix/Escape."""
+    def test_warn_rides_additional_context(self):
+        """A warn advisory is delivered via additionalContext (stdout), exit 0.
+
+        Regression: exit-0 stderr is discarded by Claude Code, so a warn printed
+        only to stderr would be invisible to the model. It must ride
+        hookSpecificOutput.additionalContext instead.
+        """
         content = "# suppress the failed records"
-        result = _run_linter(
-            {
-                "content": content,
-                "file_path": "src/data.py",
-            }
-        )
+        result = _run_linter({"content": content, "file_path": "src/data.py"})
         assert result.returncode == 0, result.stderr
-        stderr = result.stderr
-        assert "WARNING" in stderr
-        assert "BLOCKED" not in stderr
-        assert "no-hide-problems" in stderr
-        assert "src/data.py" in stderr
-        assert "behavioral-lint: ignore no-hide-problems" in stderr
+        payload = json.loads(result.stdout)
+        ctx = payload["hookSpecificOutput"]["additionalContext"]
+        assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert "WARNING" in ctx
+        assert "no-hide-problems" in ctx
+        assert "src/data.py" in ctx
+        assert "behavioral-lint: ignore no-hide-problems" in ctx
+
+    def test_block_plus_warn_all_on_stderr(self):
+        """When a block co-occurs with a warn, exit 2 and both ride stderr."""
+        kill = "os.kill(-" + "1, signal.SIGKILL)"  # avoid the literal in source
+        content = "# hide the broken data\n" + kill + "\n"
+        result = _run_linter({"content": content, "file_path": "mix.py"})
+        assert result.returncode == 2
+        assert "no-unguarded-kill" in result.stderr
+        assert "no-hide-problems" in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks/test_behavioral_linter.py
+++ b/tests/test_hooks/test_behavioral_linter.py
@@ -4,8 +4,15 @@ Runs the script as a subprocess with piped stdin JSON to test the actual
 invocation pattern used by the CC CLI. Checks exit code and stderr output.
 
 Exit codes:
-  0 — allow (no violations, empty content, parse failure)
-  2 — block (a rule with severity=block matched)
+  0 — allow (no violations, only warnings, empty content, parse failure)
+  2 — block (a pattern with severity=block matched)
+
+behavioral-lint: ignore no-hide-problems
+behavioral-lint: ignore no-unguarded-kill
+^ This is the linter's OWN test suite: its fixtures necessarily contain every
+  trigger pattern the linter matches, so it must be exempt from self-linting.
+  Post-deploy the linter also skips this by directory, but the escape tokens
+  keep the file editable under an older (still-blocking) hook.
 """
 
 import json
@@ -13,9 +20,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_SCRIPT = str(
-    Path(__file__).resolve().parent.parent.parent / "scripts" / "behavioral_linter.py"
-)
+_SCRIPT = str(Path(__file__).resolve().parent.parent.parent / "scripts" / "behavioral_linter.py")
 _PYTHON = sys.executable
 
 
@@ -46,16 +51,20 @@ def _run_linter(
 
 
 # ---------------------------------------------------------------------------
-# no-hide-problems rule — should BLOCK (exit 2)
+# no-hide-problems — code-level patterns BLOCK (exit 2)
 # ---------------------------------------------------------------------------
 
 
-class TestNoHideProblemsBlocks:
-    """Content that violates no-hide-problems must produce exit 2."""
+class TestNoHideProblemsCodeBlocks:
+    """Code-level hiding (display:none / x-show on an error state) → exit 2.
+
+    These patterns require a literal ``display:none`` or an Alpine ``x-show``,
+    which effectively never appear in prose, so they remain hard blocks.
+    """
 
     def test_display_none_with_error_state(self):
-        """CSS display:none targeting an error/unknown element → blocked."""
-        content = '.error-widget { display: none; /* unknown state */ }'
+        """CSS display:none on an error-named element → blocked."""
+        content = ".error-widget { display: none; /* unknown state */ }"
         result = _run_linter({"content": content, "file_path": "dashboard.css"})
         assert result.returncode == 2
         assert "no-hide-problems" in result.stderr
@@ -89,92 +98,94 @@ class TestNoHideProblemsBlocks:
         assert result.returncode == 2
         assert "no-hide-problems" in result.stderr
 
-    def test_propose_hide_broken_data(self):
-        """Comment proposing to hide broken data → blocked."""
-        content = "# We should hide the broken data for now"
-        result = _run_linter({"content": content, "file_path": "plan.md"})
-        assert result.returncode == 2
+
+# ---------------------------------------------------------------------------
+# no-hide-problems — reasoning/prose patterns WARN (exit 0)
+# ---------------------------------------------------------------------------
+
+
+class TestNoHideProblemsProseWarns:
+    """Reasoning/prose proposals → WARN (exit 0), not a hard block.
+
+    The prose patterns match token adjacency, not intent, so they surface the
+    concern without blocking legitimate writing. Each still names the rule on
+    stderr so the nudge is visible.
+    """
+
+    def _assert_warns(self, result):
+        assert result.returncode == 0, result.stderr
+        assert "WARNING" in result.stderr
         assert "no-hide-problems" in result.stderr
+        assert "BLOCKED" not in result.stderr
+
+    def test_propose_hide_broken_data(self):
+        content = "# We should hide the broken data for now"
+        self._assert_warns(_run_linter({"content": content, "file_path": "plan.md"}))
 
     def test_propose_skip_unknown(self):
-        """Comment proposing to skip unknown values → blocked."""
         content = "# skip the unknown values until we figure it out"
-        result = _run_linter({"content": content, "file_path": "notes.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "notes.py"}))
 
     def test_propose_suppress_failed(self):
-        """Comment proposing to suppress failed items → blocked."""
         content = "# suppress the failed items in the output"
-        result = _run_linter({"content": content, "file_path": "renderer.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "renderer.py"}))
 
     def test_propose_omit_stale(self):
-        """Comment proposing to omit stale entries → blocked."""
         content = "# omit any stale entries from the dashboard"
-        result = _run_linter({"content": content, "file_path": "dashboard.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "dashboard.py"}))
 
     def test_reverse_order_error_then_hide(self):
-        """'error' before 'hide' in same sentence → blocked."""
         content = "# error state — hide it from the user"
-        result = _run_linter({"content": content, "file_path": "view.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "view.py"}))
 
     def test_dont_show_error(self):
-        """'don't show the error' → blocked."""
         content = "# don't show the error state to users"
-        result = _run_linter({"content": content, "file_path": "handler.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "handler.py"}))
 
     def test_do_not_display_unknown(self):
-        """'do not display unknown' → blocked."""
         content = "# do not display unknown values in the table"
-        result = _run_linter({"content": content, "file_path": "table.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "table.py"}))
 
     def test_only_show_when_available(self):
-        """'only show when available' pattern → blocked."""
         content = "# only show the metric when the data is available"
-        result = _run_linter({"content": content, "file_path": "metrics.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "metrics.py"}))
 
     def test_only_show_when_healthy(self):
-        """'only show when healthy' → blocked."""
         content = "# only show the panel when the service is healthy"
-        result = _run_linter({"content": content, "file_path": "service.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "service.py"}))
 
     def test_skip_showing_unless_configured(self):
-        """'skip showing unless configured' → blocked."""
         content = "# skip showing the widget unless the source exists"
-        result = _run_linter({"content": content, "file_path": "widget.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "widget.py"}))
 
     def test_unknown_suppress_in_comment(self):
-        """'unknown data, just suppress it' → blocked."""
         content = "# unknown data, just suppress it for now"
-        result = _run_linter({"content": content, "file_path": "processor.py"})
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+        self._assert_warns(_run_linter({"content": content, "file_path": "processor.py"}))
 
-    def test_violation_in_new_string_field(self):
-        """Content in new_string (Edit tool) is also checked."""
-        result = _run_linter({
-            "new_string": "# hide the broken data for now",
-            "old_string": "# show the broken data",
-            "file_path": "editor.py",
-        })
-        assert result.returncode == 2
-        assert "no-hide-problems" in result.stderr
+    def test_warns_in_new_string_field(self):
+        """Prose in new_string (Edit tool) is also checked — warns."""
+        result = _run_linter(
+            {
+                "new_string": "# hide the broken data for now",
+                "old_string": "# show the broken data",
+                "file_path": "editor.py",
+            }
+        )
+        self._assert_warns(result)
+
+    def test_identifier_embedded_not_flagged(self):
+        """Regression: word-boundary anchoring — identifiers must not trip.
+
+        The live false positives that motivated the warn downgrade + \\b anchors:
+        a removed error-tuple identifier and a skip_writeback param near 'drift'.
+        """
+        for content in (
+            "removed the now-dead _QDRANT_ERRORS tuple",
+            "skip_writeback asserted after the too-small-unknown drift",
+        ):
+            result = _run_linter({"content": content, "file_path": "notes.py"})
+            assert result.returncode == 0, f"{content!r} → {result.stderr}"
+            assert "no-hide-problems" not in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -244,13 +255,22 @@ class TestNoUnguardedKillBlocks:
 
     def test_violation_in_new_string_field(self):
         """Kill pattern in new_string (Edit tool) → blocked."""
-        result = _run_linter({
-            "new_string": "os.kill(-1, signal.SIGKILL)",
-            "old_string": "pass",
-            "file_path": "edit.py",
-        })
+        result = _run_linter(
+            {
+                "new_string": "os.kill(-1, signal.SIGKILL)",
+                "old_string": "pass",
+                "file_path": "edit.py",
+            }
+        )
         assert result.returncode == 2
         assert "no-unguarded-kill" in result.stderr
+
+    def test_kill_literal_in_markdown_not_blocked(self):
+        """applies_to: *.py — the kill literal quoted in a .md doc must NOT block."""
+        content = "The audit flagged os.kill(-1, SIGKILL) as the dangerous call."
+        result = _run_linter({"content": content, "file_path": "docs/audit.md"})
+        assert result.returncode == 0, result.stderr
+        assert "no-unguarded-kill" not in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -263,16 +283,13 @@ class TestAllowCleanContent:
 
     def test_normal_python_code(self):
         """Plain Python with no anti-patterns → allowed."""
-        content = (
-            "def process_data(items):\n"
-            "    return [x for x in items if x.is_valid()]\n"
-        )
+        content = "def process_data(items):\n    return [x for x in items if x.is_valid()]\n"
         result = _run_linter({"content": content, "file_path": "processor.py"})
         assert result.returncode == 0
 
     def test_display_none_without_error_keyword(self):
         """CSS display:none without error/unknown keywords → allowed."""
-        content = '.sidebar { display: none; }'
+        content = ".sidebar { display: none; }"
         result = _run_linter({"content": content, "file_path": "style.css"})
         assert result.returncode == 0
 
@@ -284,10 +301,7 @@ class TestAllowCleanContent:
 
     def test_showing_error_state_honestly(self):
         """Code that SHOWS error state (not hiding it) → allowed."""
-        content = (
-            'if status == "error":\n'
-            '    render_error_banner(details)\n'
-        )
+        content = 'if status == "error":\n    render_error_banner(details)\n'
         result = _run_linter({"content": content, "file_path": "view.py"})
         assert result.returncode == 0
 
@@ -299,10 +313,7 @@ class TestAllowCleanContent:
 
     def test_os_killpg_with_guarded_variable(self):
         """os.killpg(pgid, ...) with a variable → allowed."""
-        content = (
-            "if pgid > 1:\n"
-            "    os.killpg(pgid, signal.SIGTERM)\n"
-        )
+        content = "if pgid > 1:\n    os.killpg(pgid, signal.SIGTERM)\n"
         result = _run_linter({"content": content, "file_path": "guard.py"})
         assert result.returncode == 0
 
@@ -347,28 +358,22 @@ class TestEscapeHatch:
 
     def test_escape_unguarded_kill(self):
         """behavioral-lint: ignore no-unguarded-kill → allows kill(-1)."""
-        content = (
-            "# behavioral-lint: ignore no-unguarded-kill\n"
-            "os.kill(-1, signal.SIGTERM)\n"
-        )
+        content = "# behavioral-lint: ignore no-unguarded-kill\nos.kill(-1, signal.SIGTERM)\n"
         result = _run_linter({"content": content, "file_path": "escape.py"})
         assert result.returncode == 0
 
     def test_escape_hide_problems(self):
-        """behavioral-lint: ignore no-hide-problems → allows hide pattern."""
+        """behavioral-lint: ignore no-hide-problems → allows the display:none block."""
         content = (
             "# behavioral-lint: ignore no-hide-problems\n"
-            "# hide the broken data temporarily\n"
+            ".error-box { display: none; /* failed */ }\n"
         )
-        result = _run_linter({"content": content, "file_path": "escape.py"})
+        result = _run_linter({"content": content, "file_path": "escape.css"})
         assert result.returncode == 0
 
     def test_escape_one_rule_still_blocks_other(self):
         """Escaping one rule doesn't escape a different rule."""
-        content = (
-            "# behavioral-lint: ignore no-hide-problems\n"
-            "os.kill(-1, signal.SIGKILL)\n"
-        )
+        content = "# behavioral-lint: ignore no-hide-problems\nos.kill(-1, signal.SIGKILL)\n"
         result = _run_linter({"content": content, "file_path": "partial.py"})
         assert result.returncode == 2
         assert "no-unguarded-kill" in result.stderr
@@ -380,7 +385,7 @@ class TestEscapeHatch:
         content = (
             "# behavioral-lint: ignore no-hide-problems\n"
             "# behavioral-lint: ignore no-unguarded-kill\n"
-            "# hide the broken data\n"
+            ".error-box { display: none; /* failed */ }\n"
             "os.kill(-1, signal.SIGKILL)\n"
         )
         result = _run_linter({"content": content, "file_path": "all_escaped.py"})
@@ -423,30 +428,36 @@ class TestEdgeCases:
 
     def test_content_field_used_for_write_tool(self):
         """Write tool sends content field — violations detected there."""
-        result = _run_linter({
-            "content": "os.kill(-1, signal.SIGKILL)",
-            "file_path": "write.py",
-        })
+        result = _run_linter(
+            {
+                "content": "os.kill(-1, signal.SIGKILL)",
+                "file_path": "write.py",
+            }
+        )
         assert result.returncode == 2
         assert "no-unguarded-kill" in result.stderr
 
     def test_new_string_field_used_for_edit_tool(self):
         """Edit tool sends new_string field — violations detected there."""
-        result = _run_linter({
-            "new_string": "os.killpg(1, signal.SIGTERM)",
-            "old_string": "pass",
-            "file_path": "edit.py",
-        })
+        result = _run_linter(
+            {
+                "new_string": "os.killpg(1, signal.SIGTERM)",
+                "old_string": "pass",
+                "file_path": "edit.py",
+            }
+        )
         assert result.returncode == 2
         assert "no-unguarded-kill" in result.stderr
 
     def test_old_string_not_checked(self):
         """old_string field should NOT be checked (it's existing code)."""
-        result = _run_linter({
-            "old_string": "os.kill(-1, signal.SIGKILL)",
-            "new_string": "os.kill(pid, signal.SIGTERM)",
-            "file_path": "fix.py",
-        })
+        result = _run_linter(
+            {
+                "old_string": "os.kill(-1, signal.SIGKILL)",
+                "new_string": "os.kill(pid, signal.SIGTERM)",
+                "file_path": "fix.py",
+            }
+        )
         assert result.returncode == 0
 
     def test_content_preferred_over_new_string(self):
@@ -455,20 +466,24 @@ class TestEdgeCases:
         The script uses `data.get("content", "") or data.get("new_string", "")`,
         so if content is non-empty it takes precedence.
         """
-        result = _run_linter({
-            "content": "normal safe code",
-            "new_string": "os.kill(-1, signal.SIGKILL)",
-            "file_path": "both.py",
-        })
+        result = _run_linter(
+            {
+                "content": "normal safe code",
+                "new_string": "os.kill(-1, signal.SIGKILL)",
+                "file_path": "both.py",
+            }
+        )
         # content is clean → allowed (new_string not checked)
         assert result.returncode == 0
 
     def test_file_path_in_error_message(self):
         """The file_path appears in the violation message."""
-        result = _run_linter({
-            "content": "os.kill(-1, signal.SIGTERM)",
-            "file_path": "src/genesis/danger_zone.py",
-        })
+        result = _run_linter(
+            {
+                "content": "os.kill(-1, signal.SIGTERM)",
+                "file_path": "src/genesis/danger_zone.py",
+            }
+        )
         assert result.returncode == 2
         assert "src/genesis/danger_zone.py" in result.stderr
 
@@ -489,20 +504,21 @@ class TestMultipleRules:
         assert "no-unguarded-kill" in result.stderr
         assert "no-hide-problems" not in result.stderr
 
-    def test_hide_violation_only(self):
-        """Hide violation without kill violation → only no-hide-problems."""
+    def test_hide_prose_warns_only(self):
+        """Prose hide proposal without kill → warn (exit 0), only no-hide-problems."""
         content = "# hide the broken dashboard widget"
         result = _run_linter({"content": content, "file_path": "hide_only.py"})
-        assert result.returncode == 2
+        assert result.returncode == 0, result.stderr
+        assert "WARNING" in result.stderr
         assert "no-hide-problems" in result.stderr
         assert "no-unguarded-kill" not in result.stderr
 
-    def test_both_violations(self):
-        """Content violating both rules → both reported, exit 2."""
-        content = (
-            "# hide the broken data\n"
-            "os.kill(-1, signal.SIGKILL)\n"
-        )
+    def test_prose_warn_and_kill_block(self):
+        """Prose hide (warn) + kill (block) → exit 2, both reported.
+
+        Verifies the warn pattern does not mask the block pattern (max-severity).
+        """
+        content = "# hide the broken data\nos.kill(-1, signal.SIGKILL)\n"
         result = _run_linter({"content": content, "file_path": "double.py"})
         assert result.returncode == 2
         assert "no-hide-problems" in result.stderr
@@ -518,12 +534,14 @@ class TestViolationMessages:
     """Verify the structure of violation messages on stderr."""
 
     def test_blocked_message_structure(self):
-        """Violation messages include BLOCKED, rule name, file, issue, fix, escape."""
+        """Block messages include BLOCKED, rule name, file, issue, fix, escape."""
         content = "os.killpg(0, signal.SIGTERM)"
-        result = _run_linter({
-            "content": content,
-            "file_path": "src/process.py",
-        })
+        result = _run_linter(
+            {
+                "content": content,
+                "file_path": "src/process.py",
+            }
+        )
         assert result.returncode == 2
         stderr = result.stderr
         assert "BLOCKED" in stderr
@@ -533,17 +551,69 @@ class TestViolationMessages:
         assert "Escape:" in stderr
         assert "behavioral-lint: ignore no-unguarded-kill" in stderr
 
-    def test_hide_problems_message_structure(self):
-        """no-hide-problems violation has proper message structure."""
+    def test_warn_message_structure(self):
+        """Prose warn messages use WARNING (not BLOCKED) and still carry Fix/Escape."""
         content = "# suppress the failed records"
-        result = _run_linter({
-            "content": content,
-            "file_path": "src/data.py",
-        })
-        assert result.returncode == 2
+        result = _run_linter(
+            {
+                "content": content,
+                "file_path": "src/data.py",
+            }
+        )
+        assert result.returncode == 0, result.stderr
         stderr = result.stderr
-        assert "BLOCKED" in stderr
+        assert "WARNING" in stderr
+        assert "BLOCKED" not in stderr
         assert "no-hide-problems" in stderr
         assert "src/data.py" in stderr
-        assert "Fix:" in stderr
         assert "behavioral-lint: ignore no-hide-problems" in stderr
+
+
+# ---------------------------------------------------------------------------
+# applies_to / excludes — the kill rule must fire on ALL code, not just *.py
+# behavioral-lint: ignore no-unguarded-kill
+# ---------------------------------------------------------------------------
+
+
+class TestKillRuleFileScope:
+    """no-unguarded-kill uses a docs exclude-list, not a *.py allow-list.
+
+    Regression for the review finding: a `*.py` allow-list silently un-guarded
+    the catastrophic call in extensionless CLI scripts, notebooks, and
+    templates. The rule must fire on every code file and only skip doc formats.
+    """
+
+    _KILL = "os.kill(-1, signal.SIGKILL)"
+
+    def test_extensionless_shebang_script_blocked(self):
+        """A real target: scripts/gmodel is an extensionless python CLI."""
+        result = _run_linter({"content": self._KILL, "file_path": "scripts/gmodel"})
+        assert result.returncode == 2
+        assert "no-unguarded-kill" in result.stderr
+
+    def test_notebook_blocked(self):
+        result = _run_linter({"content": self._KILL, "file_path": "explore.ipynb"})
+        assert result.returncode == 2
+
+    def test_template_blocked(self):
+        result = _run_linter({"content": self._KILL, "file_path": "unit.service.j2"})
+        assert result.returncode == 2
+
+    def test_markdown_doc_allowed(self):
+        result = _run_linter({"content": self._KILL, "file_path": "docs/audit.md"})
+        assert result.returncode == 0, result.stderr
+        assert "no-unguarded-kill" not in result.stderr
+
+    def test_rst_doc_allowed(self):
+        result = _run_linter({"content": self._KILL, "file_path": "docs/audit.rst"})
+        assert result.returncode == 0, result.stderr
+
+    def test_rules_dir_lookalike_path_still_linted(self):
+        """The rules-dir skip must match the REAL dir, not any path containing
+        the segment — a crafted src/.../config/behavioral_rules/ must still lint.
+        """
+        result = _run_linter(
+            {"content": self._KILL, "file_path": "src/genesis/config/behavioral_rules/evil.py"}
+        )
+        assert result.returncode == 2
+        assert "no-unguarded-kill" in result.stderr


### PR DESCRIPTION
## Problem

Part of the post-#1227 hook audit. The behavioral linter gained teeth and its **prose** patterns began hard-blocking innocent writing — an identifier near a verb (`removed the now-dead _QDRANT_ERRORS tuple`), a docstring's word adjacency (`unknown … suppresses`). Editing the rule-definition files themselves was also blocked (they necessarily contain their own trigger patterns), and on a fresh install a missing `genesis` package made a hard block silently degrade to a non-blocking exit 1.

## Change

- **Prose → warn, code → block.** In `no-hide-problems`, the four reasoning/prose patterns become `severity: warn` (surface the concern, don't hard-block); the code-level CSS/Alpine patterns (hiding an element based on an error state) stay `block`. Verbs and state-words are word-boundary anchored so identifier-embedded matches (`skip_writeback`, `_QDRANT_ERRORS`) no longer trip.
- **Per-pattern `severity`** (falls back to the rule level) and per-rule **`applies_to` / `excludes`** globs. The first-match `break` is removed so a warn pattern can never mask a block pattern (highest severity wins per rule).
- **`no-unguarded-kill` fires on ALL code** via a docs `excludes` list (`*.md/*.rst/*.txt`), not a `*.py` allow-list — a `.py`-only rule silently un-guarded the catastrophic kill-all call in extensionless scripts (e.g. `scripts/gmodel`), notebooks, and templates.
- **Genesis-import shim**: a block still returns exit 2 when the `genesis` package isn't importable (was a fail-open exit 1 on fresh installs).
- The linter no longer lints its own **rule-definition directory** (matched by resolved path), since those files necessarily contain the patterns they define.

## Tests

64 cases in `test_behavioral_linter.py`, including the two live false-positive incidents as regression fixtures, the extensionless-script / notebook / template coverage for the kill rule, the docs-exclusion cases, mixed-severity (warn cannot mask block), and the rules-dir-lookalike precision check.

## Deploy

Hooks/config — lands at next CC session start on existing installs; ships in-repo for fresh clones. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
