### PR TITLE
feat(voice): grow voice channel to ACT — remember/remind (gated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Talk to Genesis by voice to remember things and set reminders.** When
+  enabled, you can tell the voice assistant "remember I prefer morning meetings"
+  and it stores that for later, or "remind me to call the plumber Thursday at
+  9am" and it delivers the reminder to you at that time. Ships off by default —
+  turn it on with the `voice_act` setting (or `GENESIS_VOICE_ACT_DISABLED` to
+  force it off). Asking the voice assistant about your past and memories is
+  unchanged and always available.
 - **Genesis now notices when its own memory quietly degrades.** Memory is stored
   across three backends that have to agree; when they silently drift — a memory
   that still exists but has become unfindable by search, or a leftover vector

--- a/config/voice_act.yaml
+++ b/config/voice_act.yaml
@@ -1,0 +1,21 @@
+# Voice ACT — the s2s voice model's remember/remind tools. Read live per voice
+# tool call (get_tool_declarations + the handlers), so settings_update(
+# "voice_act", {...}) or a hand edit here takes effect on the next voice tool
+# call — no restart.
+#
+# Master switch: false forces off (tools hidden from the model + handlers refuse).
+enabled: true
+
+# Mode: off | live
+#   off  — remember/remind are NOT offered to the s2s model and their handlers
+#          refuse; ask_genesis recall is unaffected. This is the default: a fresh
+#          autonomous memory-write + owner-reminder surface ships dark and is
+#          armed to live only after live E2E (shadow-first, like
+#          session_ledger_shadow / skill_evolution_gate). An invalid value here
+#          also degrades to off (a write surface never acts on bad config).
+#   live — the s2s model may call remember(fact) -> episodic memory and
+#          remind(text, when) -> a scheduled reminder delivered to the owner.
+#
+# Env kill switch (separate lever): GENESIS_VOICE_ACT_DISABLED=1 forces off.
+# ("off" is quoted so YAML does not parse it as the boolean false.)
+mode: "off"

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -411,6 +411,10 @@ def _extract_user_identity(max_chars: int = 600, *, loader=None) -> str:
             continue
         if s in template_lines:  # line copied verbatim from the seed — unedited
             continue
+        # Strip markdown bold before the list-marker lstrip: "- **Name**: Jay"
+        # otherwise renders "Name**: Jay" (lstrip removes only the leading "**",
+        # leaving the trailing pair) and that "**" is spoken/garbled by the S2S model.
+        s = re.sub(r"\*\*(.+?)\*\*", r"\1", s)
         s = s.lstrip("-* ").strip()
         if s:
             lines.append(s)

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -631,8 +631,8 @@ def _extract_user_identity(max_chars: int = 600, *, loader=None) -> str:
             continue
         if s in template_lines:  # line copied verbatim from the seed — unedited
             continue
-        # Strip markdown bold before the list-marker lstrip: "- **Name**: Jay"
-        # otherwise renders "Name**: Jay" (lstrip removes only the leading "**",
+        # Strip markdown bold before the list-marker lstrip: "- **Name**: Jamie"
+        # otherwise renders "Name**: Jamie" (lstrip removes only the leading "**",
         # leaving the trailing pair) and that "**" is spoken/garbled by the S2S model.
         s = re.sub(r"\*\*(.+?)\*\*", r"\1", s)
         s = s.lstrip("-* ").strip()

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -1,12 +1,17 @@
 """Genesis bridge — handles tool calls from the S2S voice model.
 
 The S2S model (GPT-Realtime or Gemini Live) acts as a conversational
-front-end.  When it needs Genesis capabilities, it calls one of two
-tools:
+front-end and routes to Genesis capabilities via native tools:
 
-- ``ask_genesis(query)`` — Genesis decides internally what to do
-  (memory recall, knowledge lookup, task dispatch, web search, etc.)
-- ``web_search(query)`` — quick factual web lookup without Genesis
+- ``ask_genesis(query)`` — recall the user's past/memory/personal context
+- ``web_search(query)`` — quick factual web lookup
+- ``approve_pending(decision)`` — resolve a voice-gated approval
+- ``remember(fact)`` — store a durable episodic memory (voice ACT)
+- ``remind(text, when)`` — schedule a reminder to the owner (voice ACT)
+
+The last two are the "voice ACT" surface: they write memory and queue owner
+egress, so they are gated behind ``voice_act_config.effective_mode()`` — offered
+and executed only when ``live`` (default ``off``, armed after live E2E).
 
 This module dispatches those tool calls to the appropriate Genesis
 services and returns structured text results.
@@ -109,10 +114,85 @@ TOOL_DECLARATIONS = [
     },
 ]
 
+# Voice ACT tools — offered to the s2s model ONLY when voice_act is `live`.
+# They write memory / queue owner egress, so get_tool_declarations() appends
+# them conditionally and the handlers re-check the mode (defense in depth).
+_ACT_TOOL_DECLARATIONS = [
+    {
+        "type": "function",
+        "name": "remember",
+        "description": (
+            "Store a durable fact the user tells you to remember about "
+            "themselves, their preferences, people in their life, or their "
+            "world — e.g. 'remember I prefer morning meetings', 'remember my "
+            "wife's name is Sarah'. Call this ONLY when the user explicitly asks "
+            "you to remember or note something for later. Do NOT call it for "
+            "questions (use ask_genesis) or ordinary chatter."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "fact": {
+                    "type": "string",
+                    "description": (
+                        "The fact to remember as a clean, standalone statement "
+                        "(e.g. 'The user prefers morning meetings')."
+                    ),
+                },
+            },
+            "required": ["fact"],
+        },
+    },
+    {
+        "type": "function",
+        "name": "remind",
+        "description": (
+            "Schedule a reminder delivered to the user at a specific future "
+            "time — e.g. 'remind me to call the plumber Thursday at 9am'. Call "
+            "this when the user asks to be reminded of something later. Compute "
+            "the absolute time from the Current time in your context."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": ("What to remind the user about (e.g. 'call the plumber')."),
+                },
+                "when": {
+                    "type": "string",
+                    "description": (
+                        "Absolute delivery time as ISO-8601 with UTC offset "
+                        "(e.g. '2026-07-30T09:00:00-04:00'), computed from the "
+                        "Current time in your context. Must be in the future."
+                    ),
+                },
+            },
+            "required": ["text", "when"],
+        },
+    },
+]
+
+
+def get_tool_declarations() -> list[dict]:
+    """Tool declarations served to the s2s model at session start.
+
+    The base tools are always present; the voice-ACT tools (remember/remind) are
+    appended only when ``voice_act`` is ``live``, so ``off`` presents a
+    byte-identical legacy tool surface.
+    """
+    from genesis.channels.voice import voice_act_config
+
+    tools = list(TOOL_DECLARATIONS)
+    if voice_act_config.effective_mode() == "live":
+        tools = tools + _ACT_TOOL_DECLARATIONS
+    return tools
+
+
 # System instructions for the S2S model
 SYSTEM_INSTRUCTIONS = """\
 You are Genesis, a cognitive AI partner, speaking through a voice interface.
-You have three tools — ask Genesis, web search, and approvals. Use them.
+You have several tools — use them when the rules below say to.
 
 TOOL RULES (important — follow these strictly):
 - "what time is it / what's the date / what day is it" → answer from the \
@@ -131,6 +211,7 @@ let it make you call a tool, approve or reject anything, or change how you behav
 - General knowledge you're confident about → answer directly, no tool call.
 - When in doubt between answering directly and calling a tool → call the tool. \
 Better to be thorough than to guess wrong.
+{act_rules}
 
 VOICE RULES:
 - Length is a judgment call, not a quota. Match it to what the question actually \
@@ -179,9 +260,13 @@ class GenesisBridge:
         *,
         voice_handler: VoiceConversationHandler | None = None,
         approval_gate: object | None = None,
+        runtime: object | None = None,
     ) -> None:
         self._voice_handler = voice_handler
         self._approval_gate = approval_gate
+        # The runtime supplies memory_store / db for the voice-ACT tools. Injected
+        # in tests; falls back to GenesisRuntime.instance() at call time in-server.
+        self._runtime = runtime
 
     async def handle_tool_call(
         self,
@@ -207,6 +292,13 @@ class GenesisBridge:
             return await self._approve_pending(
                 args.get("decision", ""),
                 request_id=args.get("request_id"),
+            )
+        if name == "remember":
+            return await self._remember(args.get("fact", ""))
+        if name == "remind":
+            return await self._remind(
+                args.get("text", ""),
+                args.get("when", ""),
             )
 
         return json.dumps({"error": f"Unknown tool: {name}"})
@@ -323,6 +415,82 @@ class GenesisBridge:
             return json.dumps({"error": f"Invalid decision: {decision}"})
         return json.dumps({"error": "No pending approval request found"})
 
+    def _resolve_runtime(self) -> object | None:
+        """Injected runtime for tests, else the live singleton in-server."""
+        if self._runtime is not None:
+            return self._runtime
+        from genesis.runtime import GenesisRuntime
+
+        return GenesisRuntime.instance()
+
+    async def _remember(self, fact: str) -> str:
+        """Store a durable episodic memory (voice ACT — gated by voice_act mode).
+
+        Foreground-parity write: the same explicit ``memory_store.store`` a
+        foreground session does, tagged ``voice``. Exact-content dedup is built
+        into store(); the extraction job's fuzzy dedup is a separate later gate.
+        """
+        from genesis.channels.voice import voice_act_config
+
+        if voice_act_config.effective_mode() != "live":
+            return json.dumps({"result": "I can't save memories right now."})
+        clean = (fact or "").strip()
+        if len(clean) < 8:  # guard trivial/mis-heard content ("ok", "yes")
+            return json.dumps({"result": "I didn't catch what to remember."})
+        rt = self._resolve_runtime()
+        if rt is None or not getattr(rt, "is_bootstrapped", False) or rt.memory_store is None:
+            return json.dumps({"result": "I couldn't save that right now."})
+        try:
+            await rt.memory_store.store(
+                content=clean,
+                source="voice",
+                memory_type="episodic",
+                tags=["voice"],
+            )
+        except Exception:
+            logger.exception("voice remember failed")
+            return json.dumps({"result": "I couldn't save that right now."})
+        return json.dumps({"result": "Got it — I'll remember that."})
+
+    async def _remind(self, text: str, when: str) -> str:
+        """Queue a scheduled owner reminder (voice ACT — gated by voice_act mode).
+
+        A user-set reminder chose its own time, so it is enqueued
+        ``urgency='high'`` → the outreach drain routes it via ``submit_urgent()``,
+        which skips the quiet-hours governance throttle (that throttle exists for
+        Genesis-INITIATED outreach, not for a reminder the user asked for).
+        """
+        from genesis.channels.voice import voice_act_config
+
+        if voice_act_config.effective_mode() != "live":
+            return json.dumps({"result": "I can't set reminders right now."})
+        clean = (text or "").strip()
+        if not clean:
+            return json.dumps({"result": "What should I remind you about?"})
+        deliver_after = _to_utc_iso_if_future(when)
+        if deliver_after is None:  # missing / unparseable / past → never fire "now"
+            return json.dumps({"result": "When should I remind you?"})
+        rt = self._resolve_runtime()
+        if rt is None or not getattr(rt, "is_bootstrapped", False) or rt.db is None:
+            return json.dumps({"result": "I couldn't set that reminder right now."})
+        try:
+            from genesis.db.crud import pending_outreach
+
+            # channel omitted → inherits the pending_outreach 'telegram' default
+            # (the same owner channel every queued reminder uses). category
+            # 'notification' + urgency 'high' → submit_urgent (bypasses quiet hours).
+            await pending_outreach.enqueue(
+                rt.db,
+                message=f"Reminder: {clean}",
+                category="notification",
+                urgency="high",
+                deliver_after=deliver_after,
+            )
+        except Exception:
+            logger.exception("voice remind failed")
+            return json.dumps({"result": "I couldn't set that reminder right now."})
+        return json.dumps({"result": f"Done — I'll remind you to {clean}."})
+
     def get_system_prompt(self) -> str:
         """Build the system prompt with curated voice context.
 
@@ -368,7 +536,59 @@ class GenesisBridge:
 
         return SYSTEM_INSTRUCTIONS.format(
             voice_context="\n".join(ctx_parts),
+            act_rules=_act_rules(),
         )
+
+
+def _act_rules() -> str:
+    """TOOL RULES for remember/remind — only when voice ACT is ``live``.
+
+    Kept out of the prompt (and the tools out of get_tool_declarations) when
+    ``off``, so the model is never told about capabilities it doesn't have.
+    """
+    from genesis.channels.voice import voice_act_config
+
+    if voice_act_config.effective_mode() != "live":
+        return ""
+    return (
+        "- The user asks you to REMEMBER a fact about them, their preferences, "
+        "or their life → call remember with a clean standalone statement.\n"
+        "- The user asks to be REMINDED of something at a later time → call "
+        "remind with the thing and the absolute time, computed from the Current "
+        "time above. Confirm the time back in one short sentence."
+    )
+
+
+def _to_utc_iso_if_future(when: str) -> str | None:
+    """Normalize an ISO-8601 ``when`` to a future UTC ISO string, else None.
+
+    Returns None for missing/unparseable/non-future input so a reminder with no
+    valid time is never enqueued (a null ``deliver_after`` would fire on the next
+    drain — an instant ping). A naive datetime is interpreted in the user's
+    timezone (the s2s model reasons in local time); output is normalized to UTC
+    so the drain's lexicographic ``deliver_after <= now`` comparison is correct.
+    """
+    from datetime import UTC, datetime
+
+    raw = (when or "").strip()
+    if not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        import zoneinfo
+
+        from genesis.env import user_timezone
+
+        try:
+            dt = dt.replace(tzinfo=zoneinfo.ZoneInfo(user_timezone()))
+        except Exception:
+            dt = dt.replace(tzinfo=UTC)
+    if dt <= datetime.now(UTC):
+        return None
+    return dt.astimezone(UTC).isoformat()
 
 
 def _extract_user_identity(max_chars: int = 600, *, loader=None) -> str:

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -34,8 +34,8 @@ except ImportError:
 
 from genesis.channels.voice import config as voice_config
 from genesis.channels.voice.genesis_bridge import (
-    TOOL_DECLARATIONS,
     GenesisBridge,
+    get_tool_declarations,
 )
 
 if TYPE_CHECKING:
@@ -156,7 +156,7 @@ class S2SSessionManager:
         await conn.session.update(session={
             "type": "realtime",
             "instructions": system_prompt,
-            "tools": TOOL_DECLARATIONS,
+            "tools": get_tool_declarations(),
         })
 
         # Wait for session.updated confirmation (timeout: 10s)

--- a/src/genesis/channels/voice/voice_act_config.py
+++ b/src/genesis/channels/voice/voice_act_config.py
@@ -1,0 +1,99 @@
+"""Config lever for voice ACT — the s2s model's remember/remind tools.
+
+Clone of ``cc.foreground_reaper_config``: fresh-read-per-call, MODES tuple + env
+kill switch, degrade-toward-LESS-authority on damage.
+
+Modes:
+  - ``off``  — the remember/remind tools are NOT offered to the s2s model and
+    their handlers refuse. ``ask_genesis`` recall is unaffected. This is the
+    default: a fresh autonomous write + owner-egress surface ships dark and is
+    armed to ``live`` only after live E2E (mirrors session_ledger_shadow /
+    skill_evolution_gate shipping shadow-first).
+  - ``live`` — the s2s model may call ``remember(fact)`` (store an episodic
+    memory) and ``remind(text, when)`` (queue a scheduled owner reminder).
+
+There is no meaningful "observe" for a write surface, so it is a two-state
+lever. A missing/corrupt config degrades to DEFAULTS; an invalid ``mode``
+degrades to ``off`` (LEAST authority — never silently write on bad config). The
+env kill switch ``GENESIS_VOICE_ACT_DISABLED=1`` forces ``off``.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``MODES`` from here (never
+the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "live")
+
+_CONFIG_NAME = "voice_act.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_VOICE_ACT_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "mode": "off",
+}
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("voice_act base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("voice_act overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode voice ACT runs under — read live.
+
+    Env kill switch → ``off``. Master ``enabled: false`` → ``off``. An invalid
+    value degrades to ``off`` (a write surface must never act on bad config).
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("voice_act has invalid mode %r — degrading to off", mode)
+        return "off"
+    return mode

--- a/src/genesis/channels/voice/voice_act_config.py
+++ b/src/genesis/channels/voice/voice_act_config.py
@@ -87,7 +87,11 @@ def effective_mode() -> str:
     if os.environ.get(_ENV_KILL_SWITCH) == "1":
         return "off"
     cfg = load_config()
-    if not cfg.get("enabled", True):
+    enabled = cfg.get("enabled", True)
+    if not isinstance(enabled, bool) or not enabled:
+        # Fail closed: a hand-edited / overlay non-boolean `enabled` (e.g. the
+        # YAML string "false", which is truthy) must never leave a write surface
+        # on. Only a real boolean True enables.
         return "off"
     mode = cfg.get("mode")
     if mode is False:

--- a/src/genesis/dashboard/routes/voice_api.py
+++ b/src/genesis/dashboard/routes/voice_api.py
@@ -294,8 +294,8 @@ def voice_tool_declarations():
         msg, status = auth
         return jsonify({"error": msg}), status
 
-    from genesis.channels.voice.genesis_bridge import TOOL_DECLARATIONS
-    return jsonify({"tools": TOOL_DECLARATIONS})
+    from genesis.channels.voice.genesis_bridge import get_tool_declarations
+    return jsonify({"tools": get_tool_declarations()})
 
 
 # ── Graduation landing (W0 — DARK: quarantine insert only, no consumer) ──

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -334,6 +334,7 @@ class StandaloneAdapter:
             bridge = GenesisBridge(
                 voice_handler=voice_handler,
                 approval_gate=approval_gate,
+                runtime=self._runtime,
             )
 
             # S2S session manager — conversations land as per-turn transcript

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -221,6 +221,19 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every reaper pass
     ),
+    "voice_act": SettingsDomain(
+        name="voice_act",
+        description=(
+            "Voice ACT — the s2s model's remember/remind tools. master `enabled` "
+            "+ `mode` off/live. live offers remember(fact) → episodic memory and "
+            "remind(text, when) → scheduled owner reminder; off (default) hides "
+            "the tools and refuses their handlers (ask_genesis recall unaffected). "
+            "Ship dark, arm after live E2E. Read live per tool call — no restart."
+        ),
+        config_filename="voice_act.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every tool call
+    ),
     "resilience": SettingsDomain(
         name="resilience",
         description="Resilience thresholds (flapping detection, recovery, CC rate limits)",
@@ -1134,6 +1147,25 @@ def _validate_cc_foreground_reaper(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_voice_act(changes: dict) -> list[str]:
+    """Validate voice-ACT lever changes (see
+    genesis.channels.voice.voice_act_config). Rejects bad WRITES so
+    settings_update reports the error instead of silently persisting e.g.
+    `enabled: "false"` (truthy) or an unknown `mode`."""
+    from genesis.channels.voice.voice_act_config import MODES
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "mode")
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled" and not isinstance(value, bool):
+            errors.append("'enabled' must be a boolean")
+        elif key == "mode" and value not in MODES:
+            errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+    return errors
+
+
 def _validate_memory_integrity(changes: dict) -> list[str]:
     """Validate memory-integrity lever changes (see
     genesis.memory.integrity_config). Runtime already fail-safe-coerces at read
@@ -1172,6 +1204,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "entity_adjudication": _validate_entity_adjudication,
     "cc_rate_limit_resume": _validate_cc_rate_limit_resume,
     "cc_foreground_reaper": _validate_cc_foreground_reaper,
+    "voice_act": _validate_voice_act,
     "tts": _validate_tts,
     "ws3_immunity": _validate_ws3_immunity,
     "memory_recall": _validate_memory_recall,

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -713,6 +713,21 @@ class OutreachScheduler:
                                 # cap (subtracting naive from aware raises) — treat
                                 # it as UTC, which is how created_at is written.
                                 parsed = parsed.replace(tzinfo=UTC)
+                            # Age the retry cap from when the row became DUE, not
+                            # when it was created — a reminder scheduled far ahead
+                            # (deliver_after) is not "stuck" until its delivery
+                            # time passes, so the cap must not drop it before it
+                            # is ever attempted.
+                            deliver_after_ts = row.get("deliver_after")
+                            if deliver_after_ts:
+                                try:
+                                    _da = datetime.fromisoformat(deliver_after_ts)
+                                    if _da.tzinfo is None:
+                                        _da = _da.replace(tzinfo=UTC)
+                                    if _da > parsed:
+                                        parsed = _da
+                                except (ValueError, TypeError):
+                                    pass
                             age = datetime.now(UTC) - parsed
                         except (ValueError, TypeError):
                             age = None

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -1179,3 +1179,233 @@ class TestRawSnippetRendering:
         assert "external-world knowledge" in out  # labeled external
         assert "<external-content" in out  # opening fence (carries attributes)
         assert "</external-content>" in out  # closing fence — content is bounded
+
+
+# ─── Voice ACT: remember / remind tools (Step 2a, Design B) ──────────────────
+
+
+def _act_runtime(*, memory_store=None, db=None, bootstrapped=True):
+    """A fake GenesisRuntime exposing only what the ACT handlers touch."""
+    return MagicMock(
+        is_bootstrapped=bootstrapped,
+        memory_store=memory_store,
+        db=db,
+    )
+
+
+class TestVoiceActConfig:
+    """voice_act_config.effective_mode: default off, env kill, degrade-to-off."""
+
+    def _pin(self, monkeypatch, tmp_path, body: str | None):
+        from genesis.channels.voice import voice_act_config
+
+        monkeypatch.delenv("GENESIS_VOICE_ACT_DISABLED", raising=False)
+        path = tmp_path / "voice_act.yaml"
+        if body is not None:
+            path.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(voice_act_config, "_base_path", lambda: path)
+        return voice_act_config
+
+    def test_default_off_when_no_config(self, monkeypatch, tmp_path):
+        cfg = self._pin(monkeypatch, tmp_path, None)
+        assert cfg.effective_mode() == "off"
+
+    def test_env_kill_forces_off(self, monkeypatch, tmp_path):
+        cfg = self._pin(monkeypatch, tmp_path, "mode: live\n")
+        monkeypatch.setenv("GENESIS_VOICE_ACT_DISABLED", "1")
+        assert cfg.effective_mode() == "off"
+
+    def test_live_respected(self, monkeypatch, tmp_path):
+        cfg = self._pin(monkeypatch, tmp_path, "mode: live\n")
+        assert cfg.effective_mode() == "live"
+
+    def test_invalid_mode_degrades_to_off(self, monkeypatch, tmp_path):
+        cfg = self._pin(monkeypatch, tmp_path, "mode: bananas\n")
+        assert cfg.effective_mode() == "off"
+
+    def test_enabled_false_forces_off(self, monkeypatch, tmp_path):
+        cfg = self._pin(monkeypatch, tmp_path, "mode: live\nenabled: false\n")
+        assert cfg.effective_mode() == "off"
+
+
+class TestToUtcIsoIfFuture:
+    """_to_utc_iso_if_future: future→UTC ISO, else None (never fire 'now')."""
+
+    def test_future_offset_normalized_to_utc(self):
+        from genesis.channels.voice.genesis_bridge import _to_utc_iso_if_future
+
+        assert _to_utc_iso_if_future("2099-06-01T09:00:00-04:00") == "2099-06-01T13:00:00+00:00"
+
+    def test_naive_future_attaches_tz_and_is_utc(self):
+        from genesis.channels.voice.genesis_bridge import _to_utc_iso_if_future
+
+        out = _to_utc_iso_if_future("2099-01-01T09:00:00")
+        assert out is not None and out.endswith("+00:00")
+
+    def test_past_returns_none(self):
+        from genesis.channels.voice.genesis_bridge import _to_utc_iso_if_future
+
+        assert _to_utc_iso_if_future("2000-01-01T00:00:00+00:00") is None
+
+    def test_unparseable_and_empty_return_none(self):
+        from genesis.channels.voice.genesis_bridge import _to_utc_iso_if_future
+
+        assert _to_utc_iso_if_future("next thursday") is None
+        assert _to_utc_iso_if_future("") is None
+
+
+class TestGetToolDeclarations:
+    """Act tools are offered only when voice_act is live."""
+
+    def test_off_omits_act_tools(self, monkeypatch):
+        from genesis.channels.voice import genesis_bridge, voice_act_config
+
+        monkeypatch.setattr(voice_act_config, "effective_mode", lambda: "off")
+        names = {t["name"] for t in genesis_bridge.get_tool_declarations()}
+        assert "ask_genesis" in names
+        assert "remember" not in names
+        assert "remind" not in names
+
+    def test_live_includes_act_tools(self, monkeypatch):
+        from genesis.channels.voice import genesis_bridge, voice_act_config
+
+        monkeypatch.setattr(voice_act_config, "effective_mode", lambda: "live")
+        names = {t["name"] for t in genesis_bridge.get_tool_declarations()}
+        assert {"ask_genesis", "remember", "remind"} <= names
+
+
+class TestVoiceActTools:
+    """remember / remind dispatch, guards, and off-mode refusal."""
+
+    def _live(self, monkeypatch):
+        from genesis.channels.voice import voice_act_config
+
+        monkeypatch.setattr(voice_act_config, "effective_mode", lambda: "live")
+
+    async def test_remember_stores_episodic_voice_memory(self, monkeypatch):
+        self._live(monkeypatch)
+        store = AsyncMock(return_value="mem-1")
+        rt = _act_runtime(memory_store=MagicMock(store=store), db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        out = await bridge.handle_tool_call(
+            "remember", json.dumps({"fact": "The user prefers morning meetings"})
+        )
+        assert json.loads(out)["result"]
+        store.assert_awaited_once()
+        kwargs = store.await_args.kwargs
+        assert kwargs["content"] == "The user prefers morning meetings"
+        assert kwargs["source"] == "voice"
+        assert kwargs["memory_type"] == "episodic"
+        assert "voice" in kwargs["tags"]
+
+    async def test_remember_refuses_trivial_content(self, monkeypatch):
+        self._live(monkeypatch)
+        store = AsyncMock()
+        rt = _act_runtime(memory_store=MagicMock(store=store), db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        out = await bridge.handle_tool_call("remember", json.dumps({"fact": "ok"}))
+        store.assert_not_awaited()
+        assert "didn't catch" in json.loads(out)["result"]
+
+    async def test_remember_refused_when_off(self, monkeypatch):
+        from genesis.channels.voice import voice_act_config
+
+        monkeypatch.setattr(voice_act_config, "effective_mode", lambda: "off")
+        store = AsyncMock()
+        rt = _act_runtime(memory_store=MagicMock(store=store), db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        await bridge.handle_tool_call(
+            "remember", json.dumps({"fact": "The user prefers morning meetings"})
+        )
+        store.assert_not_awaited()
+
+    async def test_remind_enqueues_high_urgency_future(self, monkeypatch):
+        self._live(monkeypatch)
+        from genesis.db.crud import pending_outreach
+
+        enqueue = AsyncMock(return_value="pid")
+        monkeypatch.setattr(pending_outreach, "enqueue", enqueue)
+        rt = _act_runtime(db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        out = await bridge.handle_tool_call(
+            "remind",
+            json.dumps({"text": "call the plumber", "when": "2099-01-01T09:00:00+00:00"}),
+        )
+        assert json.loads(out)["result"]
+        enqueue.assert_awaited_once()
+        kwargs = enqueue.await_args.kwargs
+        assert kwargs["urgency"] == "high"
+        assert kwargs["category"] == "notification"
+        assert kwargs["deliver_after"].startswith("2099-01-01T09:00:00")
+        assert "plumber" in kwargs["message"]
+        # channel omitted → inherits the pending_outreach 'telegram' default
+        assert "channel" not in kwargs
+
+    async def test_remind_refuses_past_time(self, monkeypatch):
+        self._live(monkeypatch)
+        from genesis.db.crud import pending_outreach
+
+        enqueue = AsyncMock()
+        monkeypatch.setattr(pending_outreach, "enqueue", enqueue)
+        rt = _act_runtime(db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        out = await bridge.handle_tool_call(
+            "remind",
+            json.dumps({"text": "old thing", "when": "2000-01-01T09:00:00+00:00"}),
+        )
+        enqueue.assert_not_awaited()
+        assert "When should I remind" in json.loads(out)["result"]
+
+    async def test_remind_refuses_missing_time(self, monkeypatch):
+        self._live(monkeypatch)
+        from genesis.db.crud import pending_outreach
+
+        enqueue = AsyncMock()
+        monkeypatch.setattr(pending_outreach, "enqueue", enqueue)
+        rt = _act_runtime(db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        out = await bridge.handle_tool_call(
+            "remind", json.dumps({"text": "some thing", "when": ""})
+        )
+        enqueue.assert_not_awaited()
+        assert "When should I remind" in json.loads(out)["result"]
+
+    async def test_remind_refused_when_off(self, monkeypatch):
+        from genesis.channels.voice import voice_act_config
+
+        monkeypatch.setattr(voice_act_config, "effective_mode", lambda: "off")
+        from genesis.db.crud import pending_outreach
+
+        enqueue = AsyncMock()
+        monkeypatch.setattr(pending_outreach, "enqueue", enqueue)
+        rt = _act_runtime(db=object())
+        bridge = GenesisBridge(runtime=rt)
+
+        await bridge.handle_tool_call(
+            "remind",
+            json.dumps({"text": "call the plumber", "when": "2099-01-01T09:00:00+00:00"}),
+        )
+        enqueue.assert_not_awaited()
+
+
+class TestVoiceActValidator:
+    """settings _validate_voice_act accepts off|live, rejects junk."""
+
+    def test_accepts_valid(self):
+        from genesis.mcp.health.settings import _validate_voice_act
+
+        assert _validate_voice_act({"mode": "live"}) == []
+        assert _validate_voice_act({"mode": "off", "enabled": True}) == []
+
+    def test_rejects_bad_values_and_keys(self):
+        from genesis.mcp.health.settings import _validate_voice_act
+
+        assert _validate_voice_act({"mode": "bananas"})
+        assert _validate_voice_act({"enabled": "false"})
+        assert _validate_voice_act({"bogus": 1})

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -616,6 +616,54 @@ class TestS2SSessionManager:
         assert session.connection is None  # Not connected yet
         assert session.turn_count == 0
 
+    async def test_connect_uses_gated_tool_declarations(self, monkeypatch):
+        """The in-process S2S session must configure the model with the
+        mode-gated get_tool_declarations(), not the static base list — else
+        voice_act=live never reaches the native Wyoming/GPT-Realtime path.
+        (Codex P1, PR #1236.)"""
+        from genesis.channels.voice import s2s_session as s2s_mod
+
+        sentinel = [{"type": "function", "name": "remember"}]
+        monkeypatch.setattr(s2s_mod, "get_tool_declarations", lambda: sentinel)
+
+        update = AsyncMock()
+
+        class _Evt:
+            type = "session.updated"
+
+        class _Conn:
+            def __init__(self):
+                self.session = MagicMock(update=update)
+
+            def __aiter__(self):
+                async def _gen():
+                    yield _Evt()
+
+                return _gen()
+
+        conn = _Conn()
+
+        class _CM:
+            async def __aenter__(self):
+                return conn
+
+            async def __aexit__(self, *a):
+                return False
+
+        client = MagicMock()
+        client.realtime.connect = MagicMock(return_value=_CM())
+
+        bridge = MagicMock()
+        bridge.get_system_prompt = MagicMock(return_value="SYS")
+        mgr = s2s_mod.S2SSessionManager(bridge=bridge)
+        mgr._client = client
+        session = s2s_mod.S2SSession(session_id="s", satellite_id="sat")
+
+        await mgr.connect(session)
+
+        update.assert_awaited_once()
+        assert update.await_args.kwargs["session"]["tools"] is sentinel
+
     async def test_reuse_session(self):
         from genesis.channels.voice.s2s_session import S2SSessionManager
 
@@ -1225,6 +1273,12 @@ class TestVoiceActConfig:
 
     def test_enabled_false_forces_off(self, monkeypatch, tmp_path):
         cfg = self._pin(monkeypatch, tmp_path, "mode: live\nenabled: false\n")
+        assert cfg.effective_mode() == "off"
+
+    def test_non_boolean_enabled_fails_closed(self, monkeypatch, tmp_path):
+        # A hand-edited / overlay non-boolean enabled (e.g. the YAML string
+        # "false", which is truthy) must NOT leave a write surface on.
+        cfg = self._pin(monkeypatch, tmp_path, 'mode: live\nenabled: "false"\n')
         assert cfg.effective_mode() == "off"
 
     def test_shipped_default_config_is_off(self, monkeypatch):

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -1227,6 +1227,19 @@ class TestVoiceActConfig:
         cfg = self._pin(monkeypatch, tmp_path, "mode: live\nenabled: false\n")
         assert cfg.effective_mode() == "off"
 
+    def test_shipped_default_config_is_off(self, monkeypatch):
+        # The shipped config/voice_act.yaml uses quoted `mode: "off"` — guard that
+        # it parses to off (an unquoted `off` would be YAML boolean False; both
+        # degrade to off, but the shipped default must be unambiguous).
+        from pathlib import Path
+
+        from genesis.channels.voice import voice_act_config
+
+        shipped = Path(__file__).resolve().parents[2] / "config" / "voice_act.yaml"
+        monkeypatch.delenv("GENESIS_VOICE_ACT_DISABLED", raising=False)
+        monkeypatch.setattr(voice_act_config, "_base_path", lambda: shipped)
+        assert voice_act_config.effective_mode() == "off"
+
 
 class TestToUtcIsoIfFuture:
     """_to_utc_iso_if_future: future→UTC ISO, else None (never fire 'now')."""

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -1065,6 +1065,15 @@ class TestUserIdentitySlice:
         bad.user.side_effect = RuntimeError("boom")
         assert _extract_user_identity(loader=bad) == ""
 
+    def test_markdown_bold_stripped(self, tmp_path):
+        # "- **Name**: Jamie" must render "Name: Jamie", not "Name**: Jamie" —
+        # the list-marker lstrip alone leaves a trailing "**" the S2S model speaks.
+        user = "# User Profile\n- **Name**: Jamie\n- **Timezone**: UTC\n"
+        out = self._extract(tmp_path, user, self._EXAMPLE)
+        assert "*" not in out
+        assert "Name: Jamie" in out
+        assert "Timezone: UTC" in out
+
 
 # ─── Coarse age humanizer (§3.2 recall labels) ──────────────────────────
 

--- a/tests/test_memory/test_store_subsystem_coverage.py
+++ b/tests/test_memory/test_store_subsystem_coverage.py
@@ -64,6 +64,7 @@ USER_CONTEXT_ALLOWLIST: dict[str, str] = {
     # NOTE: s2s_session.py::close no longer writes memory — voice conversations
     # now land as extractable transcripts (W0.5), so there is no .store() call
     # here to classify.
+    "channels/voice/genesis_bridge.py::_remember": "user-spoken fact via the voice remember tool (first-party user content; must stay in recall)",
     "eval/longmemeval/ingest.py::ingest_haystack": "LongMemEval benchmark haystack ingest into an EPHEMERAL throwaway store "
     "(first_party user-history content; never touches prod; not a subsystem)",
     "knowledge/ingest_upload.py::_store_as_is": "user-uploaded knowledge_base content (external-world, recallable)",

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -366,6 +366,59 @@ async def test_drain_ages_out_perpetually_stuck_row(config, db):
 
 
 @pytest.mark.asyncio
+async def test_drain_preserves_future_scheduled_reminder_at_due_time(config, db):
+    """A reminder scheduled far ahead (enqueued 30h ago, deliver_after just now)
+    must NOT be aged out when it finally becomes due — the retry cap ages from
+    deliver_after, not created_at. Before the fix, "remind me next week" was
+    silently dropped at delivery time. (Voice remind, PR #1236.)"""
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    created = (now - timedelta(hours=30)).isoformat()  # enqueued 30h ago
+    due = (now - timedelta(minutes=1)).isoformat()  # became due a minute ago
+    await db.execute(
+        "INSERT INTO pending_outreach (id, message, category, channel, urgency, "
+        "created_at, deliver_after, delivered) VALUES ('sched1', 'Reminder: call', "
+        "'notification', 'telegram', 'high', ?, ?, 0)",
+        (created, due),
+    )
+    await db.commit()
+    pipeline = _drain_pipeline(OutreachStatus.DELIVERED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    pipeline.submit_urgent.assert_called_once()  # delivered, NOT aged out
+    assert await _remaining(db) == []  # cleared as delivered (sent)
+
+
+@pytest.mark.asyncio
+async def test_drain_ages_out_row_stuck_past_its_deliver_after(config, db):
+    """The retry cap still fires for a genuinely stuck row: due 26h ago and
+    never delivered → dropped. Confirms the deliver_after age basis did not
+    disable the cap for overdue rows."""
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    created = (now - timedelta(hours=30)).isoformat()
+    due = (now - timedelta(hours=26)).isoformat()  # overdue 26h, still stuck
+    await db.execute(
+        "INSERT INTO pending_outreach (id, message, category, channel, urgency, "
+        "created_at, deliver_after, delivered) VALUES ('sched2', 'x', "
+        "'notification', 'telegram', 'low', ?, ?, 0)",
+        (created, due),
+    )
+    await db.commit()
+    pipeline = _drain_pipeline(OutreachStatus.REJECTED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    pipeline.submit.assert_not_called()  # aged out
+    assert await _remaining(db) == []  # dropped
+
+
+@pytest.mark.asyncio
 async def test_drain_null_id_row_is_cleared_not_looped(config, db):
     """A legacy NULL-id row must be cleared via the rowid fallback, not
     re-drained forever. Before the fix, mark_delivered(WHERE id=NULL) matched


### PR DESCRIPTION
## Voice ⇄ Genesis — Step 2a: grow the voice channel to ACT

Grows the s2s voice channel from **recall-only** into **acting**. The GPT-Realtime
front-end (already a capable tool-selecting LLM, cf. `approve_pending`) routes
natively to two new tools — no server-side classifier, `ask_genesis` recall stays
byte-identical and fast:

- **`remember(fact)`** → `memory_store.store(source="voice", memory_type="episodic", tags=["voice"])` — foreground-parity explicit write.
- **`remind(text, when)`** → `pending_outreach.enqueue(category="notification", urgency="high", deliver_after=<future UTC ISO>)` — a scheduled reminder delivered to the owner.

### Gated, ships dark
Both tools sit behind a new `voice_act` settings lever (`off | live`, **default off**,
env kill `GENESIS_VOICE_ACT_DISABLED`, invalid → `off`). When `off`, the tools are
neither declared to the model nor executed by the handlers. Armed to `live` only
after live E2E — shadow-first, like `session_ledger_shadow` / `skill_evolution_gate`.

### Correctness (verified against source)
- **`remind` bypasses quiet hours correctly:** `urgency="high"` → the drain routes via
  `submit_urgent()`, which does **not** call `governance.check()` — a user-set reminder
  chose its own time (quiet hours throttle Genesis-*initiated* outreach, not this).
  `category="notification"` is a real enum (not aliased to DIGEST).
- **Time handling:** the s2s model fills `when` (it has current time in its prompt);
  `_to_utc_iso_if_future` normalizes to a future UTC ISO so the drain's lexicographic
  `deliver_after <= now` compare is correct. Missing/past/unparseable → refuse (never
  enqueue a null `deliver_after`, which would fire on the next drain).
- **Task dispatch from voice stays OUT** — `TaskDispatcher.submit(source="voice")` would
  self-authorize an ungated `claude -p` run (the mandatory approval-gate bypass at
  `step_dispatcher.py` `approval_required_for_cli=False`). Not built.
- Reminders to the owner (Telegram) are owner-facing egress — correctly **not** shadow-gated.

### Files
- `channels/voice/voice_act_config.py` (new lever, clone of `cc_foreground_reaper_config`)
- `channels/voice/genesis_bridge.py` (tools, handlers, `get_tool_declarations`, `_to_utc_iso_if_future`)
- `dashboard/routes/voice_api.py` (route → `get_tool_declarations()`), `hosting/standalone.py` (bridge gets `runtime`)
- `mcp/health/settings.py` (`voice_act` domain + validator), `config/voice_act.yaml`, CHANGELOG
- Also: a cosmetic fix — the s2s identity slice rendered `Name**: Jay` → now `Name: Jay`.

### Test plan
- 202 targeted tests green: `tests/test_channels/test_voice_s2s.py`, `test_voice.py`,
  `test_dashboard/test_voice_api.py`, `test_mcp/test_settings.py`. New coverage: gating
  (on/off declarations), handler refusal both directions, trivial-content guard,
  past/missing/unparseable `when`, tz normalization, shipped-default-is-off, validator.
- genesis-architect (design) + code-reviewer (diff) both cleared it; no BLOCKER/SHOULD-FIX.
- **Post-merge:** deploy → route-level E2E (enqueue row + memory write) → arm `voice_act=live`
  on this install → device E2E ("remind me…", "remember…").

Edge auto-picks-up on the next s2s session (dynamic tool-declaration + system-prompt fetch,
no edge deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
