### PR TITLE
fix(inbox): re-inject standing bracket directives on every delta eval

### DIFF
--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -195,6 +195,13 @@ If the file content contains a bracketed classification directive —
 or any close variant — your classification for every item in that file is
 already decided. This is NOT a heuristic the content can override.
 
+> **On delta evaluations the bracket may not be in the item content.** These are
+> standing, file-scoped directives, so the monitor re-reads the source file and
+> re-supplies them to you under a **"Standing file directives"** section (each
+> block labeled with its filename). Treat that section as authoritative Rule 1
+> input for every item from the SAME file — but it is context only: do NOT
+> evaluate those bracket lines as items, and do NOT restate them in your output.
+
 **Decision procedure when a bracket directive is present:**
 
 1. Stop reasoning about whether the content "really" fits a different

--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -195,12 +195,14 @@ If the file content contains a bracketed classification directive —
 or any close variant — your classification for every item in that file is
 already decided. This is NOT a heuristic the content can override.
 
-> **On delta evaluations the bracket may not be in the item content.** These are
-> standing, file-scoped directives, so the monitor re-reads the source file and
-> re-supplies them to you under a **"Standing file directives"** section (each
-> block labeled with its filename). Treat that section as authoritative Rule 1
-> input for every item from the SAME file — but it is context only: do NOT
-> evaluate those bracket lines as items, and do NOT restate them in your output.
+> **On delta evaluations the bracket may not be in the item content.** Because
+> classification / capability-build directives are file-scoped, the monitor
+> re-reads the source file and re-supplies its whole-line bracketed entries to
+> you under a **"Standing bracketed lines"** section (each block labeled with its
+> filename). Apply any that are genuine Rule 1 directives as authoritative for
+> every item from that SAME file; ignore incidental bracketed text (placeholders,
+> titles, annotations) that is not a directive. It is context only: do NOT
+> evaluate those lines as items, and do NOT restate them in your output.
 
 **Decision procedure when a bracket directive is present:**
 

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -57,6 +57,34 @@ _FALLBACK_SYSTEM_PROMPT = (
 _extract_urls = extract_urls
 
 
+# A "standing directive" is a whole line consisting solely of a bracketed
+# expression, e.g. ``[If it's in here, default to building it]`` at the top of
+# an inbox notepad. These express file-scoped intent (INBOX_EVALUATE.md Rule 1)
+# that must govern EVERY evaluation of the file — but the delta scanner baselines
+# the directive line away after the first eval, so later deltas never carry it.
+# ``_build_prompt`` re-reads the source file and re-injects directives each time.
+# The line must END with ``]`` so a markdown link line (``see [docs](url)``) or a
+# bracket used mid-sentence does not match.
+_BRACKET_DIRECTIVE_RE = re.compile(r"^\[.+\]$")
+
+
+def _extract_bracket_directives(text: str) -> list[str]:
+    """Return whole-line ``[ ... ]`` directives from ``text``, order-preserving.
+
+    Only lines that are ENTIRELY a bracketed expression qualify (leading/trailing
+    whitespace is tolerated). Duplicates are dropped while preserving first-seen
+    order. Never raises.
+    """
+    seen: set[str] = set()
+    directives: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if _BRACKET_DIRECTIVE_RE.match(stripped) and stripped not in seen:
+            seen.add(stripped)
+            directives.append(stripped)
+    return directives
+
+
 # Patterns indicating the evaluation GAVE UP on URLs (not just encountered errors).
 # Tested against all 8 existing response files: 0 false positives, 0 false negatives.
 # Crucially, these do NOT include "ssl error" or "could not fetch" which appear
@@ -1821,11 +1849,33 @@ class InboxMonitor:
         except Exception:
             logger.exception("Failed to write message_queue entry")
 
+    def _read_standing_directives(self, file_path: str) -> list[str]:
+        """Read the CURRENT source file and return its standing bracket directives.
+
+        Re-reading at prompt-build time gives latest-intent semantics and covers
+        the resumed-batch and retry dispatch paths. Returns ``[]`` when the file
+        is unreadable (deleted/renamed/locked) so a missing file degrades to "no
+        directives" rather than failing dispatch. Never raises.
+        """
+        try:
+            content = read_content(Path(file_path))
+        except (FileNotFoundError, PermissionError, OSError):
+            logger.debug(
+                "Standing-directive read failed for %s",
+                file_path,
+                exc_info=True,
+            )
+            return []
+        return _extract_bracket_directives(content)
+
     def _build_prompt(self, items: list[InboxItem]) -> str:
         """Build the evaluation prompt from a batch of items.
 
         URLs are extracted from each item's content and enumerated explicitly
-        so the CC session cannot silently skip them.
+        so the CC session cannot silently skip them. Standing file directives
+        (whole-line ``[ ... ]`` expressions) are re-read from the source file(s)
+        and surfaced as context — the delta scanner baselines them away after the
+        first eval, so without this they would never reach later evaluations.
         """
         parts = [
             f"Evaluate the following {len(items)} inbox item(s).\n",
@@ -1837,6 +1887,41 @@ class InboxMonitor:
                 "not listed below. Evaluate ONLY the content provided here.\n"
             ),
         ]
+        _sanitizer = ContentSanitizer()
+
+        # Re-inject standing file directives, deduped per source file (a batch's
+        # items normally share one file, but may span files — each item's header
+        # names its file so the agent can associate directive → item).
+        directive_blocks: list[str] = []
+        seen_files: set[str] = set()
+        for item in items:
+            if item.file_path in seen_files:
+                continue
+            seen_files.add(item.file_path)
+            directives = self._read_standing_directives(item.file_path)
+            if not directives:
+                continue
+            name = Path(item.file_path).name
+            result = _sanitizer.sanitize("\n".join(directives), ContentSource.INBOX)
+            if result.detected_patterns:
+                logger.warning(
+                    "Injection patterns detected in standing directives for %s: %s (risk=%.2f)",
+                    name,
+                    result.detected_patterns,
+                    result.risk_score,
+                )
+            directive_blocks.append(f"**{name}:**\n{result.wrapped}")
+        if directive_blocks:
+            parts.append(
+                "\n### Standing file directives "
+                "(context only — NOT items to evaluate):\n"
+                "\nThese bracketed lines are standing directives from the source "
+                "file(s) below. Apply each to every item from the SAME file per "
+                "Rule 1. Do NOT evaluate them as items and do NOT restate them in "
+                "your output.\n"
+            )
+            parts.extend(directive_blocks)
+
         for idx, item in enumerate(items, 1):
             name = Path(item.file_path).name
             urls = _extract_urls(item.content)
@@ -1849,7 +1934,6 @@ class InboxMonitor:
                 for i, url in enumerate(urls, 1):
                     parts.append(f"{i}. {url}")
                 parts.append("")  # blank line separator
-            _sanitizer = ContentSanitizer()
             result = _sanitizer.sanitize(item.content, ContentSource.INBOX)
             if result.detected_patterns:
                 logger.warning(

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -1872,7 +1872,7 @@ class InboxMonitor:
         """Build the evaluation prompt from a batch of items.
 
         URLs are extracted from each item's content and enumerated explicitly
-        so the CC session cannot silently skip them. Standing file directives
+        so the CC session cannot silently skip them. Standing bracketed lines
         (whole-line ``[ ... ]`` expressions) are re-read from the source file(s)
         and surfaced as context — the delta scanner baselines them away after the
         first eval, so without this they would never reach later evaluations.
@@ -1913,12 +1913,15 @@ class InboxMonitor:
             directive_blocks.append(f"**{name}:**\n{result.wrapped}")
         if directive_blocks:
             parts.append(
-                "\n### Standing file directives "
-                "(context only — NOT items to evaluate):\n"
-                "\nThese bracketed lines are standing directives from the source "
-                "file(s) below. Apply each to every item from the SAME file per "
-                "Rule 1. Do NOT evaluate them as items and do NOT restate them in "
-                "your output.\n"
+                "\n### Standing bracketed lines from the source file(s) "
+                "(context — NOT items to evaluate):\n"
+                "\nThese are the whole-line bracketed entries currently in the "
+                "source file(s) below. Apply any that are genuine Rule 1 "
+                "directives (a classification directive or a capability-build "
+                "directive) as authoritative for every item from that SAME file. "
+                "Ignore incidental bracketed text — placeholders, titles, or "
+                "annotations that are not directives. Do NOT evaluate these lines "
+                "as items and do NOT restate them in your output.\n"
             )
             parts.extend(directive_blocks)
 

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -640,7 +640,7 @@ async def test_resume_dispatch_reads_current_file_directives(
     assert "https://example.com/a0" not in prompt  # still not a full re-read
     # The fix: standing directive surfaced on the resume path too.
     assert "build everything here by default" in prompt
-    assert "Standing file directives" in prompt
+    assert "Standing bracketed lines" in prompt
 
 # ── Follow-up dedup wiring ───────────────────────────────────────────────
 

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -602,6 +602,46 @@ async def test_resume_uses_persisted_batch_delta_not_full_file(
     assert "https://example.com/a0" not in prompt  # NOT a full-file re-read
 
 
+@pytest.mark.asyncio
+async def test_resume_dispatch_reads_current_file_directives(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A resumed/approved batch re-reads the CURRENT file's standing directives
+    at dispatch time — so file-scoped build intent reaches the eval even on the
+    resume path, without expanding the persisted delta itself."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    f = inbox_dir / "Genesis.md"
+    f.write_text("[build everything here by default]\n" + _urls(20))
+    import hashlib
+
+    h = hashlib.sha256(
+        "\n".join(line.rstrip() for line in f.read_text().split("\n")).encode()
+    ).hexdigest()
+    await inbox_items.create(
+        db, id="row-1", file_path=str(f), content_hash=h, status="processing",
+        created_at="2026-06-30T11:00:00+00:00", drop_id="D1",
+        batch_items="https://example.com/a18\nhttps://example.com/a19",
+    )
+    await inbox_items.update_status(
+        db, "row-1", status="processing",
+        error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-9",
+    )
+    mon._autonomous_dispatcher = _wired(
+        decision=AutonomousDispatchDecision(
+            mode="blocked", reason="pending", approval_request_id="req-9",
+        ),
+        approval_by_id={"req-9": {"status": "approved"}},
+    )
+
+    await mon.check_once()
+
+    prompt = mock_invoker.run.call_args.args[0].prompt
+    assert "https://example.com/a18" in prompt  # persisted delta, unchanged
+    assert "https://example.com/a0" not in prompt  # still not a full re-read
+    # The fix: standing directive surfaced on the resume path too.
+    assert "build everything here by default" in prompt
+    assert "Standing file directives" in prompt
+
 # ── Follow-up dedup wiring ───────────────────────────────────────────────
 
 

--- a/tests/test_inbox/test_edge_cases.py
+++ b/tests/test_inbox/test_edge_cases.py
@@ -701,6 +701,43 @@ async def test_modified_file_only_sends_delta(
 
 
 @pytest.mark.asyncio
+async def test_bracket_directive_renders_on_second_delta_eval(
+    monitor, inbox_dir, mock_invoker, db,
+):
+    """Regression: a standing [ ... ] directive must reach the SECOND (delta)
+    evaluation even though the baseline union drops it, while the delta itself
+    still carries only the genuinely-new line.
+
+    The exact previously-broken case: the directive was seen on eval #1, folded
+    into the baseline, then stripped from every later delta so the evaluator
+    never saw the build intent again."""
+    f = inbox_dir / "New Genesis Capabilities.md"
+    f.write_text(
+        "[If it's in here, default to building it]\nhttps://example.com/first\n"
+    )
+    result1 = await monitor.check_once()
+    assert result1.batches_dispatched == 1
+
+    mock_invoker.run.reset_mock()
+    mock_invoker.run.return_value = _success_output("eval of second")
+    f.write_text(
+        "[If it's in here, default to building it]\n"
+        "https://example.com/first\n\n"
+        "https://example.com/second\n"
+    )
+    result2 = await monitor.check_once()
+    assert result2.batches_dispatched == 1
+
+    call_args = mock_invoker.run.call_args
+    prompt = call_args.args[0].prompt if call_args.args else call_args.kwargs.get("prompt", "")
+    # Delta behavior intact: only the new URL, not the old one.
+    assert "example.com/second" in prompt
+    assert "example.com/first" not in prompt
+    # The fix: the standing directive is re-injected on the delta eval.
+    assert "default to building it" in prompt
+    assert "Standing file directives" in prompt
+
+@pytest.mark.asyncio
 async def test_modified_file_no_new_content_skipped(
     monitor, inbox_dir, mock_invoker, db,
 ):

--- a/tests/test_inbox/test_edge_cases.py
+++ b/tests/test_inbox/test_edge_cases.py
@@ -735,7 +735,7 @@ async def test_bracket_directive_renders_on_second_delta_eval(
     assert "example.com/first" not in prompt
     # The fix: the standing directive is re-injected on the delta eval.
     assert "default to building it" in prompt
-    assert "Standing file directives" in prompt
+    assert "Standing bracketed lines" in prompt
 
 @pytest.mark.asyncio
 async def test_modified_file_no_new_content_skipped(

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -613,7 +613,7 @@ async def test_build_prompt_includes_delta_instruction(monitor, inbox_dir):
     assert "ONLY" in prompt
 
 
-# --- Standing file directives (bracket re-injection) ---
+# --- Standing bracketed lines (bracket re-injection) ---
 
 
 def test_extract_bracket_directives_shapes():
@@ -660,9 +660,9 @@ async def test_build_prompt_injects_standing_directives(monitor, inbox_dir):
         content_hash="h", detected_at="2026-07-27",
     )
     prompt = monitor._build_prompt([item])
-    assert "Standing file directives" in prompt
+    assert "Standing bracketed lines" in prompt
     assert "default to building it" in prompt
-    assert "context only" in prompt.lower()
+    assert "context" in prompt.lower()
 
 
 @pytest.mark.asyncio
@@ -676,7 +676,7 @@ async def test_build_prompt_no_directive_section_without_brackets(monitor, inbox
         content_hash="h", detected_at="2026-07-27",
     )
     prompt = monitor._build_prompt([item])
-    assert "Standing file directives" not in prompt
+    assert "Standing bracketed lines" not in prompt
 
 
 @pytest.mark.asyncio
@@ -689,7 +689,7 @@ async def test_build_prompt_directives_missing_file_graceful(monitor, inbox_dir)
         content="https://example.com/x", content_hash="h", detected_at="2026-07-27",
     )
     prompt = monitor._build_prompt([item])  # must not raise
-    assert "Standing file directives" not in prompt
+    assert "Standing bracketed lines" not in prompt
     assert "### Content:" in prompt
 
 
@@ -707,7 +707,7 @@ async def test_build_prompt_directives_are_sanitized(monitor, inbox_dir):
         content_hash="h", detected_at="2026-07-27",
     )
     prompt = monitor._build_prompt([item])
-    assert "Standing file directives" in prompt
+    assert "Standing bracketed lines" in prompt
     assert '<external-content source="inbox"' in prompt
 
 

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -613,6 +613,127 @@ async def test_build_prompt_includes_delta_instruction(monitor, inbox_dir):
     assert "ONLY" in prompt
 
 
+# --- Standing file directives (bracket re-injection) ---
+
+
+def test_extract_bracket_directives_shapes():
+    """Whole-line [ ... ] directives extracted; mid-line / link lines rejected."""
+    from genesis.inbox.monitor import _extract_bracket_directives
+
+    text = (
+        "[build everything here]\n"
+        "  [ leading and trailing space ]  \n"
+        "regular line\n"
+        "see [the docs](https://example.com)\n"  # markdown link — not a directive
+        "prefix [not a directive] suffix\n"  # bracket mid-line — rejected
+        "[build everything here]\n"  # exact duplicate — deduped
+    )
+    directives = _extract_bracket_directives(text)
+    assert directives == [
+        "[build everything here]",
+        "[ leading and trailing space ]",
+    ]
+
+
+def test_extract_bracket_directives_empty():
+    from genesis.inbox.monitor import _extract_bracket_directives
+
+    assert _extract_bracket_directives("") == []
+    assert _extract_bracket_directives("no brackets at all\njust text") == []
+
+
+@pytest.mark.asyncio
+async def test_build_prompt_injects_standing_directives(monitor, inbox_dir):
+    """A standing [ ... ] directive in the source file renders on a delta eval
+    even when the delta content does NOT contain the bracket line (the bug: the
+    directive is baselined away after the first eval)."""
+    from genesis.inbox.types import InboxItem
+
+    src = inbox_dir / "New Genesis Capabilities.md"
+    src.write_text(
+        "[If it's in here, default to building it]\n"
+        "https://example.com/old-item\n"
+        "https://example.com/new-item\n"
+    )
+    item = InboxItem(
+        id="d1", file_path=str(src), content="https://example.com/new-item",
+        content_hash="h", detected_at="2026-07-27",
+    )
+    prompt = monitor._build_prompt([item])
+    assert "Standing file directives" in prompt
+    assert "default to building it" in prompt
+    assert "context only" in prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_build_prompt_no_directive_section_without_brackets(monitor, inbox_dir):
+    from genesis.inbox.types import InboxItem
+
+    src = inbox_dir / "plain.md"
+    src.write_text("just plain notes\nhttps://example.com/x\n")
+    item = InboxItem(
+        id="p1", file_path=str(src), content="https://example.com/x",
+        content_hash="h", detected_at="2026-07-27",
+    )
+    prompt = monitor._build_prompt([item])
+    assert "Standing file directives" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_prompt_directives_missing_file_graceful(monitor, inbox_dir):
+    """A deleted/renamed source file yields no directive section and no raise."""
+    from genesis.inbox.types import InboxItem
+
+    item = InboxItem(
+        id="g1", file_path=str(inbox_dir / "does-not-exist.md"),
+        content="https://example.com/x", content_hash="h", detected_at="2026-07-27",
+    )
+    prompt = monitor._build_prompt([item])  # must not raise
+    assert "Standing file directives" not in prompt
+    assert "### Content:" in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_prompt_directives_are_sanitized(monitor, inbox_dir):
+    """Directive text is wrapped by the perimeter sanitizer (external-untrusted)."""
+    from genesis.inbox.types import InboxItem
+
+    src = inbox_dir / "inject.md"
+    # Any inbox content is wrapped in perimeter boundary markers regardless of
+    # whether it trips an injection pattern — a benign directive proves wrapping.
+    src.write_text("[build everything in here by default]\nhttps://example.com/x\n")
+    item = InboxItem(
+        id="s1", file_path=str(src), content="https://example.com/x",
+        content_hash="h", detected_at="2026-07-27",
+    )
+    prompt = monitor._build_prompt([item])
+    assert "Standing file directives" in prompt
+    assert '<external-content source="inbox"' in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_prompt_multi_item_directives_per_file(monitor, inbox_dir):
+    """Two items from different files each surface their own file's directives."""
+    from genesis.inbox.types import InboxItem
+
+    a = inbox_dir / "A.md"
+    a.write_text("[directive alpha]\nhttps://example.com/a\n")
+    b = inbox_dir / "B.md"
+    b.write_text("[directive beta]\nhttps://example.com/b\n")
+    items = [
+        InboxItem(
+            id="a", file_path=str(a), content="https://example.com/a",
+            content_hash="ha", detected_at="2026-07-27",
+        ),
+        InboxItem(
+            id="b", file_path=str(b), content="https://example.com/b",
+            content_hash="hb", detected_at="2026-07-27",
+        ),
+    ]
+    prompt = monitor._build_prompt(items)
+    assert "directive alpha" in prompt
+    assert "directive beta" in prompt
+
 # --- Acknowledged classification tests ---
 
 


### PR DESCRIPTION
## Problem

Inbox notepad files carry standing whole-line bracket directives — e.g. a
capabilities notepad topped with `[If it's in here, default to building it]` —
that express file-scoped intent per `INBOX_EVALUATE.md` Rule 1 (including the
capability-build lane).

The delta scanner's baseline union (`_merge_evaluated_content`) folds the
directive line into `evaluated_content` after the **first** evaluation. Every
later delta then computes against a baseline that already contains the
directive, so it's stripped from the prompt — and the prompt preamble forbids
reading the source file. **The evaluator never sees the standing directive
again after eval #1.** This silently disabled the build-biased disposition for
weeks (the root cause behind the "fixed-mindset" evaluations).

## Fix

`_build_prompt` now re-reads each item's **current** source file at dispatch
time, extracts whole-line `[ ... ]` directives, and surfaces them in a labeled
**"Standing file directives (context only — NOT items to evaluate)"** section:

- Sanitized through the same `ContentSource.INBOX` perimeter wrapper as item
  content (external-untrusted; wrapped in `<external-content>`), deduped per
  source file.
- Re-reading at dispatch (rather than persisting at scan) gives latest-intent
  semantics and automatically covers the resumed-batch and retry dispatch
  paths.
- A missing/renamed/unreadable file degrades to no-section, never a raise.

**Delta computation and baselining are intentionally untouched** — directives
are prompt-only context, never re-evaluated as items or re-baselined. A
one-paragraph note in INBOX_EVALUATE.md Rule 1 tells the evaluator the section
is authoritative Rule 1 input but must not be restated or evaluated.

## Tests

- `test_extract_bracket_directives_shapes` / `_empty` — regex rejects markdown
  links (`[x](url)`) and mid-sentence brackets; dedupes; whitespace-tolerant.
- `test_build_prompt_*` — injects on delta; no section without brackets;
  missing-file graceful; sanitizer-wrapped; per-file in multi-file batches.
- `test_bracket_directive_renders_on_second_delta_eval` (end-to-end regression)
  — reproduces the exact bug: on the second eval the delta carries only the new
  line **and** the directive is re-injected.
- `test_resume_dispatch_reads_current_file_directives` — directives surface on
  the parked/approved resume path too.

314 inbox tests green; ruff clean. Replayed the extractor over the real inbox
files: 1 directive each in the 3 files that have one, 0 false positives.

Inline code-review (feature-dev:code-reviewer): DONE, no findings >=80%
confidence.

Ledger: 25568aa11b7444399a3a72cbf595c7a8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
