### PR TITLE
fix(voice): strip markdown emphasis from USER.md identity slice for S2S

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -411,12 +411,14 @@ def _extract_user_identity(max_chars: int = 600, *, loader=None) -> str:
             continue
         if s in template_lines:  # line copied verbatim from the seed — unedited
             continue
+        # Strip markdown emphasis SPANS (matched **bold** / __bold__ pairs) BEFORE
+        # removing the leading list marker, so a "- **Name**: Jay" line collapses
+        # to "Name: Jay" without the S2S provider speaking the asterisks — and
+        # without deleting a legitimate double underscore inside a value (a handle
+        # like "jay__smith" has no closing pair, so it is preserved).
+        s = re.sub(r"\*\*(.+?)\*\*", r"\1", s)
+        s = re.sub(r"__(.+?)__", r"\1", s)
         s = s.lstrip("-* ").strip()
-        # Strip markdown emphasis PAIRS (** / __) that lstrip leaves behind on a
-        # line like "- **Name**: Jay" (lstrip removes the leading "- **" but not
-        # the trailing "**"), so the S2S provider doesn't speak the asterisks.
-        # Scoped to pairs so a lone underscore in an identifier survives.
-        s = re.sub(r"\*\*|__", "", s).strip()
         if s:
             lines.append(s)
     return "\n".join(lines)[:max_chars]

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -412,6 +412,11 @@ def _extract_user_identity(max_chars: int = 600, *, loader=None) -> str:
         if s in template_lines:  # line copied verbatim from the seed — unedited
             continue
         s = s.lstrip("-* ").strip()
+        # Strip markdown emphasis PAIRS (** / __) that lstrip leaves behind on a
+        # line like "- **Name**: Jay" (lstrip removes the leading "- **" but not
+        # the trailing "**"), so the S2S provider doesn't speak the asterisks.
+        # Scoped to pairs so a lone underscore in an identifier survives.
+        s = re.sub(r"\*\*|__", "", s).strip()
         if s:
             lines.append(s)
     return "\n".join(lines)[:max_chars]

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -1031,6 +1031,25 @@ class TestUserIdentitySlice:
         assert "Systems engineer" in out
         assert "#" not in out  # markdown headers stripped
         assert "guidance" not in out  # HTML comments stripped
+        assert "*" not in out  # markdown emphasis stripped — no asterisks to S2S
+
+    def test_markdown_emphasis_pairs_stripped(self, tmp_path):
+        # "- **Name**: Jamie": lstrip removes the leading "- **" but the trailing
+        # "**" used to survive, so the S2S provider spoke the asterisks. Both the
+        # ** pair and any __ pair must be gone.
+        user = "# User Profile\n- **Name**: Jamie\n- __Role__: Engineer\n"
+        out = self._extract(tmp_path, user, self._EXAMPLE)
+        assert "Name: Jamie" in out  # emphasis pair removed, not just the leading
+        assert "Role: Engineer" in out
+        assert "*" not in out
+        assert "__" not in out
+
+    def test_single_underscore_identifier_preserved(self, tmp_path):
+        # Only PAIRS are stripped — a lone underscore in an identifier survives.
+        user = "# User Profile\n- **Handle**: user_name_42\n"
+        out = self._extract(tmp_path, user, self._EXAMPLE)
+        assert "user_name_42" in out
+        assert "*" not in out
 
     def test_partial_fill_drops_unedited_template_lines(self, tmp_path):
         # Name/Timezone edited; Background/Communication left as the seed — those

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -1045,10 +1045,17 @@ class TestUserIdentitySlice:
         assert "__" not in out
 
     def test_single_underscore_identifier_preserved(self, tmp_path):
-        # Only PAIRS are stripped — a lone underscore in an identifier survives.
+        # Only matched pairs are stripped — a lone underscore in an identifier survives.
         user = "# User Profile\n- **Handle**: user_name_42\n"
         out = self._extract(tmp_path, user, self._EXAMPLE)
         assert "user_name_42" in out
+
+    def test_double_underscore_in_value_preserved(self, tmp_path):
+        # A double underscore inside a VALUE with no closing pair is NOT a markdown
+        # emphasis span → preserved (jay__smith must not become jaysmith). Codex P2.
+        user = "# User Profile\n- **Handle**: jay__smith\n"
+        out = self._extract(tmp_path, user, self._EXAMPLE)
+        assert "Handle: jay__smith" in out
         assert "*" not in out
 
     def test_partial_fill_drops_unedited_template_lines(self, tmp_path):


### PR DESCRIPTION
## What & why

`_extract_user_identity()` (the USER.md slice injected into the S2S / voice system prompt) ran `s.lstrip("-* ")` on a line like `- **Name**: Jay`. `lstrip` removes the *leading* `- **` but leaves the *trailing* `**`, so the speech provider received `Name**: Jay` and **spoke the asterisks**.

## Change

Strip `**`/`__` emphasis **pairs** after the lstrip, scoped to pairs so a lone underscore in an identifier (e.g. `user_name`) survives:

```python
s = s.lstrip("-* ").strip()
s = re.sub(r"\*\*|__", "", s).strip()
```

The sole caller is `get_system_prompt` (the S2S prompt). All other guarantees are preserved — fail-closed on a missing `USER.md.example`, placeholder-line dropping, HTML-comment stripping, the 600-char cap.

## Testing

`TestUserIdentitySlice`: emphasis pairs stripped (`- **Name**: Jay` → `Name: Jay`), single-underscore identifier preserved, plus a `"*" not in out` regression assertion on the existing clean-profile test. 8 identity-slice tests pass; `ruff` clean. Reviewed (code-reviewer agent): DONE, no findings.

## Deploy

Genesis runtime code → `git pull` + `systemctl --user restart genesis-server`.
