### PR TITLE
fix(hooks): un-gate gh pr create — only git push needs approval

### DIFF
--- a/.claude/skills/genesis-development/references/worktrees.md
+++ b/.claude/skills/genesis-development/references/worktrees.md
@@ -94,19 +94,24 @@ over.
 ## Push/Merge Enforcement
 
 `git_push_guard.py` (PreToolUse hook) gates:
-- `git push` (any branch) — an **interactive** session gets a native
-  approve/deny dialog (`permissionDecision:ask`) that only *you* can satisfy;
-  a Genesis-**dispatched** session (`GENESIS_CC_SESSION=1`) is **hard-denied**
-  (no human to prompt; real autonomous delivery goes through the scope-gated
-  server path, not the CC Bash tool).
-- `gh pr create` — same interactive prompt / dispatched deny.
+- `git push` (any branch) — the one action that publishes code externally. An
+  **interactive** session gets a native approve/deny dialog
+  (`permissionDecision:ask`) that only *you* can satisfy; a Genesis-**dispatched**
+  session (`GENESIS_CC_SESSION=1`) is **hard-denied** (no human to prompt; real
+  autonomous delivery goes through the scope-gated server path, not the CC Bash
+  tool). Force push (`--force` / `--force-with-lease` / `-f` / `+refspec` /
+  `--mirror`) is **hard-blocked** in every session. Multiple pushes in one
+  command are blocked — each push needs its own approval.
+- `gh pr create` — **NOT gated**. Opening a PR is a review request on
+  already-pushed code, not a code-publish (the push is what's gated), so it
+  needs no separate prompt; a `git push && gh pr create` prompts once — for the
+  push — and the PR-create rides along.
 - `git merge` into main/master — **hard-blocked** (use the PR workflow).
 - `gh pr merge` without `--admin`, or with unresolved review findings —
   **hard-blocked** (a `# review-override` trailing comment acknowledges
   intentionally-accepted findings on the *merge* command only).
 
-The push/PR-create dialog replaced the old `# review-override` token for those
-two gates — the agent can no longer self-approve a push. All code changes go
-through PRs; the only merge path is `gh pr merge --squash --admin` after
-explicit user approval. Each step (commit → push branch → create PR → merge)
-needs your confirmation.
+The push dialog replaced the old `# review-override` token for the push gate —
+the agent can no longer self-approve a push. All code changes go through PRs;
+the only merge path is `gh pr merge --squash --admin` after explicit user
+approval.

--- a/.claude/skills/genesis-development/references/worktrees.md
+++ b/.claude/skills/genesis-development/references/worktrees.md
@@ -102,10 +102,12 @@ over.
   tool). Force push (`--force` / `--force-with-lease` / `-f` / `+refspec` /
   `--mirror`) is **hard-blocked** in every session. Multiple pushes in one
   command are blocked — each push needs its own approval.
-- `gh pr create` — **NOT gated**. Opening a PR is a review request on
-  already-pushed code, not a code-publish (the push is what's gated), so it
-  needs no separate prompt; a `git push && gh pr create` prompts once — for the
-  push — and the PR-create rides along.
+- `gh pr create` — **un-gated when its branch is already on the remote** (then
+  it's just a review request on pushed code), so a `git push && gh pr create`
+  prompts once — for the push — and the PR-create rides along. The exception:
+  gh will *push* (and can fork) a branch whose HEAD is not yet on the remote, so
+  a create from an **unpushed branch** is gated like a push (interactive → ask,
+  dispatched → deny). Verified via local remote-tracking refs, fail-safe.
 - `git merge` into main/master — **hard-blocked** (use the PR workflow).
 - `gh pr merge` without `--admin`, or with unresolved review findings —
   **hard-blocked** (a `# review-override` trailing comment acknowledges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   instead of hard-stopping.** This safety hook used to block the command outright
   with no in-session way through; now Claude Code shows you a native approve/deny
   prompt you confirm with one keystroke — a gate the agent cannot self-satisfy.
-  `gh pr create` is no longer prompted separately (opening a PR is a review
-  request on already-pushed code, not a code-publish — so `git push && gh pr
-  create` asks once, for the push). Autonomous/background Genesis sessions stay
+  `gh pr create` is not prompted separately when its branch is already pushed
+  (opening a PR is then just a review request — so `git push && gh pr create`
+  asks once, for the push); a create from an unpushed branch, which gh would
+  push itself, is still gated. Autonomous/background Genesis sessions stay
   blocked from pushing directly (their real delivery path is separately gated).
   Force pushes stay hard-blocked; branch names that merely contain `-f` (e.g.
   `fix/…-false-positives`) are no longer mistaken for a force-push.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,14 +79,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
-- **`git push` and `gh pr create` in an interactive Claude Code session now ask
-  for your approval instead of hard-stopping.** These safety hooks used to block
-  the command outright with no in-session way through; now Claude Code shows you
-  a native approve/deny prompt you confirm with one keystroke — a gate the agent
-  cannot self-satisfy. Autonomous/background Genesis sessions stay blocked from
-  pushing directly (their real delivery path is separately gated). Branch names
-  that merely contain `-f` (e.g. `fix/…-false-positives`) are no longer mistaken
-  for a force-push and blocked.
+- **`git push` in an interactive Claude Code session now asks for your approval
+  instead of hard-stopping.** This safety hook used to block the command outright
+  with no in-session way through; now Claude Code shows you a native approve/deny
+  prompt you confirm with one keystroke — a gate the agent cannot self-satisfy.
+  `gh pr create` is no longer prompted separately (opening a PR is a review
+  request on already-pushed code, not a code-publish — so `git push && gh pr
+  create` asks once, for the push). Autonomous/background Genesis sessions stay
+  blocked from pushing directly (their real delivery path is separately gated).
+  Force pushes stay hard-blocked; branch names that merely contain `-f` (e.g.
+  `fix/…-false-positives`) are no longer mistaken for a force-push.
 - **Genesis now keeps its own internal event log from growing without bound.**
   The observability event stream — the record of everything Genesis notices and
   does — was the last high-volume table with no cleanup, growing steadily on

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -455,6 +455,60 @@ def _ask(reason: str) -> int:
     return 0
 
 
+def _pr_create_head_branch(argv: list[str]) -> str | None:
+    """The head branch named by a ``gh pr create`` (``--head``/``-H`` VALUE, or
+    ``--head=VALUE``), stripped of any ``owner:`` prefix. None → gh uses the
+    current branch."""
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in ("--head", "-H") and i + 1 < len(argv):
+            v = argv[i + 1]
+            return v.split(":", 1)[1] if ":" in v else v
+        if tok.startswith("--head="):
+            v = tok.split("=", 1)[1]
+            return v.split(":", 1)[1] if ":" in v else v
+        i += 1
+    return None
+
+
+def _pr_create_would_publish(argv: list[str]) -> bool:
+    """Whether a ``gh pr create`` might PUSH its branch (bypassing the push gate).
+
+    gh pushes — and can even fork — a branch whose HEAD is not yet on the remote,
+    so a bare create from an unpushed branch publishes code around this hook.
+    Checks the LOCAL remote-tracking ref (no network): the branch's remote ref
+    must exist AND already contain HEAD. Fail-safe — any uncertainty → True (gate).
+    """
+    branch = _pr_create_head_branch(argv) or _current_branch()
+    if not branch:
+        return True  # can't determine the branch → gate
+    remote_ref = f"refs/remotes/origin/{branch}"
+    try:
+        exists = (
+            subprocess.run(
+                ["git", "show-ref", "--verify", "--quiet", remote_ref],
+                capture_output=True,
+                timeout=5,
+            ).returncode
+            == 0
+        )
+        if not exists:
+            return True  # branch not on the remote → gh would push it → gate
+        # HEAD already reachable from the remote branch → nothing to push.
+        contained = (
+            subprocess.run(
+                ["git", "merge-base", "--is-ancestor", "HEAD", remote_ref],
+                capture_output=True,
+                timeout=5,
+            ).returncode
+            == 0
+        )
+        return not contained  # unpushed commits on HEAD → gh may push → gate
+    except Exception:
+        return True  # fail-safe → gate
+
+
 def main() -> int:
     try:
         cmd = field(read_payload(), "command")
@@ -468,6 +522,7 @@ def main() -> int:
         segs = analyze(cmd)
         push_segs = [s for s in segs if s.exe == "git" and git_subcommand(s.argv) == "push"]
         merge_git_segs = [s for s in segs if s.exe == "git" and git_subcommand(s.argv) == "merge"]
+        create_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "create"]
         merge_pr_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "merge"]
 
         # Each git push is a SEPARATE external-publish action needing its own
@@ -475,8 +530,9 @@ def main() -> int:
         # collapse into ONE ask (mentioning only the first), so approving that
         # prompt would run every push behind it. Reject the compound and require
         # each push to be its own separately-approved tool call. (gh pr create is
-        # NOT gated — it opens a review request on already-pushed code, not a
-        # code-publish — so it may ride along on a push's approval.)
+        # normally un-gated — a review request on already-pushed code — and rides
+        # along on a push's approval; the exception, where gh itself would push an
+        # unpushed branch, is handled by the create arm below.)
         if len(push_segs) > 1:
             print(
                 "BLOCKED: multiple git push operations in one command would "
@@ -540,10 +596,25 @@ def main() -> int:
                 )
                 return 2
 
-        # ── gh pr create ── NOT gated: opening a PR is a review request on
-        # already-pushed code, not a code-publish (the push is what publishes,
-        # and it is gated above). So `git push && gh pr create` prompts once —
-        # for the push — and the PR-create rides along on that approval.
+        # ── gh pr create ────────────────────────────────────────────
+        # Un-gated when its branch is already on the remote — opening a PR is then
+        # just a review request on already-pushed code, so `git push && gh pr
+        # create` prompts once (for the push) and the create rides along. BUT a
+        # bare create from an UNPUSHED branch makes gh push (and possibly fork) the
+        # branch itself — a code-publish that would bypass the push gate — so gate
+        # that form like a push: dispatched → deny, interactive → ask.
+        if create_segs and any(_pr_create_would_publish(s.argv) for s in create_segs):
+            if _is_dispatched():
+                print(
+                    "BLOCKED: this gh pr create would push a not-yet-pushed branch; "
+                    "autonomous/dispatched sessions cannot publish code.",
+                    file=sys.stderr,
+                )
+                return 2
+            if ask_reason is None:
+                ask_reason = (
+                    "gh pr create would push this (not-yet-pushed) branch — approve it like a push."
+                )
 
         # ── gh pr merge ────────────────────────────────────────────
         if merge_pr_segs:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -468,27 +468,28 @@ def main() -> int:
         segs = analyze(cmd)
         push_segs = [s for s in segs if s.exe == "git" and git_subcommand(s.argv) == "push"]
         merge_git_segs = [s for s in segs if s.exe == "git" and git_subcommand(s.argv) == "merge"]
-        create_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "create"]
         merge_pr_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "merge"]
 
-        # Each push / PR-create is a SEPARATE external-publish action needing its
-        # own approval. A single Bash command carrying more than one would
+        # Each git push is a SEPARATE external-publish action needing its own
+        # approval. A single Bash command carrying more than one push would
         # collapse into ONE ask (mentioning only the first), so approving that
-        # prompt would run every publish behind it. Reject the compound and
-        # require each to be its own separately-approved tool call.
-        if len(push_segs) + len(create_segs) > 1:
+        # prompt would run every push behind it. Reject the compound and require
+        # each push to be its own separately-approved tool call. (gh pr create is
+        # NOT gated — it opens a review request on already-pushed code, not a
+        # code-publish — so it may ride along on a push's approval.)
+        if len(push_segs) > 1:
             print(
-                "BLOCKED: multiple publish operations (git push / gh pr create) "
-                "in one command would share a single approval prompt. Run each "
-                "as its own command so each is approved separately.",
+                "BLOCKED: multiple git push operations in one command would "
+                "share a single approval prompt. Run each push as its own "
+                "command so each is approved separately.",
                 file=sys.stderr,
             )
             return 2
 
-        # An interactive push / PR-create defers to a native approve/deny
-        # dialog at the END of main(), so every hard-block below (merge-into-
-        # main, the pr-merge gates, sqlite, --no-verify) still takes precedence
-        # — a compound `git push && git commit --no-verify` blocks, never asks.
+        # An interactive push defers to a native approve/deny dialog at the END
+        # of main(), so every hard-block below (merge-into-main, the pr-merge
+        # gates, sqlite, --no-verify) still takes precedence — a compound
+        # `git push && git commit --no-verify` blocks, never asks.
         ask_reason: str | None = None
 
         # ── git push (any branch) ──────────────────────────────────
@@ -539,20 +540,10 @@ def main() -> int:
                 )
                 return 2
 
-        # ── gh pr create ───────────────────────────────────────────
-        if create_segs:
-            if _is_dispatched():
-                print(
-                    "BLOCKED: Creating a PR requires user approval before publishing externally.",
-                    file=sys.stderr,
-                )
-                print(
-                    "Autonomous/dispatched sessions cannot open PRs directly.",
-                    file=sys.stderr,
-                )
-                return 2
-            if ask_reason is None:
-                ask_reason = "gh pr create needs your approval before publishing externally."
+        # ── gh pr create ── NOT gated: opening a PR is a review request on
+        # already-pushed code, not a code-publish (the push is what publishes,
+        # and it is gated above). So `git push && gh pr create` prompts once —
+        # for the push — and the PR-create rides along on that approval.
 
         # ── gh pr merge ────────────────────────────────────────────
         if merge_pr_segs:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -64,6 +64,85 @@ def guard_module():
     return mod
 
 
+def _rc(code: int) -> subprocess.CompletedProcess:
+    """A fake CompletedProcess carrying just a returncode."""
+    return subprocess.CompletedProcess(args=[], returncode=code)
+
+
+class TestPrCreateHeadBranch:
+    """_pr_create_head_branch parses --head / -H / --head= (owner: stripped)."""
+
+    def test_none_when_no_head(self, guard_module):
+        assert guard_module._pr_create_head_branch(["gh", "pr", "create", "--title", "x"]) is None
+
+    def test_head_space_value(self, guard_module):
+        assert (
+            guard_module._pr_create_head_branch(["gh", "pr", "create", "--head", "feat"]) == "feat"
+        )
+
+    def test_head_short_flag(self, guard_module):
+        assert guard_module._pr_create_head_branch(["gh", "pr", "create", "-H", "feat"]) == "feat"
+
+    def test_head_equals(self, guard_module):
+        assert guard_module._pr_create_head_branch(["gh", "pr", "create", "--head=feat"]) == "feat"
+
+    def test_head_owner_stripped(self, guard_module):
+        got = guard_module._pr_create_head_branch(["gh", "pr", "create", "--head", "someone:feat"])
+        assert got == "feat"
+
+
+class TestPrCreateWouldPublish:
+    """_pr_create_would_publish gates iff the head branch's HEAD is not yet on the
+    remote (gh would push it). Verified via local git refs — mocked here so the
+    test is deterministic and network/git-state independent."""
+
+    def test_no_branch_gates(self, guard_module):
+        with patch.object(guard_module, "_current_branch", return_value=None):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_remote_ref_absent_gates(self, guard_module):
+        # show-ref --verify fails (rc=1) → branch not on remote → gh would push.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(guard_module.subprocess, "run", return_value=_rc(1)),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_head_on_remote_and_contained_ungated(self, guard_module):
+        # ref exists (rc=0), then HEAD is an ancestor (rc=0) → nothing to push.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(guard_module.subprocess, "run", side_effect=[_rc(0), _rc(0)]),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
+
+    def test_head_on_remote_but_ahead_gates(self, guard_module):
+        # ref exists (rc=0) but HEAD not an ancestor (rc=1) → unpushed commits → gate.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(guard_module.subprocess, "run", side_effect=[_rc(0), _rc(1)]),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_explicit_head_checked_not_current(self, guard_module):
+        with (
+            patch.object(guard_module, "_current_branch", return_value="main"),
+            patch.object(guard_module.subprocess, "run", return_value=_rc(1)) as run,
+        ):
+            assert (
+                guard_module._pr_create_would_publish(["gh", "pr", "create", "--head", "other"])
+                is True
+            )
+        assert any("refs/remotes/origin/other" in " ".join(c.args[0]) for c in run.call_args_list)
+
+    def test_subprocess_error_fails_safe(self, guard_module):
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(guard_module.subprocess, "run", side_effect=OSError("boom")),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+
 # ── _check_pr_review_findings tests ─────────────────────────────────
 
 

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -59,31 +59,36 @@ def _decision(res: subprocess.CompletedProcess) -> str | None:
 # ── gh pr create ────────────────────────────────────────────────────
 
 
-def test_pr_create_not_gated_interactive():
-    """gh pr create is NOT gated — opening a PR on already-pushed code is a
-    review request, not a code-publish (the push is what's gated). No prompt."""
-    res = _run("gh pr create --title x --body y")
+# gh pr create is UN-gated when its head branch is already on the remote (then
+# it's just a review request on pushed code). That un-gated path is git-state
+# dependent, so it is covered deterministically by the _pr_create_would_publish
+# unit tests in test_merge_review_gate.py. Here we test the GATED path: an
+# --head not on the remote (origin/<nonexistent> never exists) which gh would
+# push — that must be gated like a push.
+_UNPUSHED = "zzz-unpushed-branch-xyz"
+
+
+def test_pr_create_unpushed_branch_asks_interactive():
+    res = _run(f"gh pr create --head {_UNPUSHED} --title x --body y")
     assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_pr_create_unpushed_branch_denied_dispatched():
+    res = _run(f"gh pr create --head {_UNPUSHED} --title x --body y", dispatched=True)
+    assert res.returncode == 2
     assert _decision(res) is None
 
 
-def test_pr_create_not_gated_dispatched():
-    """Un-gated in every session: a dispatched session cannot push code (that is
-    denied), so a PR-create on already-pushed code needs no separate gate."""
-    res = _run("gh pr create --title x --body y", dispatched=True)
-    assert res.returncode == 0, res.stderr
-    assert _decision(res) is None
+def test_pr_create_unpushed_global_flag_still_detected():
+    """A gh global flag before `pr` must not evade detection of the create."""
+    res = _run(f"gh --repo o/r pr create --head {_UNPUSHED} --title x --body y", dispatched=True)
+    assert res.returncode == 2
 
 
 def test_pr_create_mention_in_string_not_tripped():
     res = _run('echo "run gh pr create later"')
     assert res.returncode == 0
-    assert _decision(res) is None
-
-
-def test_pr_create_with_global_flag_not_gated():
-    res = _run("gh --repo o/r pr create --title x --body y")
-    assert res.returncode == 0, res.stderr
     assert _decision(res) is None
 
 
@@ -232,12 +237,6 @@ def test_two_pushes_compound_blocked():
     assert "separate" in res.stderr
 
 
-def test_two_pr_creates_not_gated():
-    res = _run("gh pr create --title a --body b && gh pr create --title c --body d")
-    assert res.returncode == 0, res.stderr
-    assert _decision(res) is None
-
-
 def test_single_push_with_nongated_op_still_asks():
     """A single push next to a non-publish command still just asks (gated == 1)."""
     res = _run("git push origin feat && ls -la")
@@ -263,11 +262,14 @@ def test_push_override_token_cannot_self_approve_dispatched():
     assert _decision(res) is None
 
 
-def test_pr_create_not_gated_with_token():
-    """gh pr create is un-gated regardless of any trailing token — no prompt."""
-    res = _run("gh pr create --title x --body-file /tmp/b.md  # review-override")
+def test_pr_create_token_does_not_ungate_unpushed():
+    """The retired token cannot un-gate an unpushed create either — it still
+    gates (gh would push) and asks, regardless of any trailing token."""
+    res = _run(
+        f"gh pr create --head {_UNPUSHED} --title x --body-file /tmp/b.md  # review-override"
+    )
     assert res.returncode == 0, res.stderr
-    assert _decision(res) is None
+    assert _decision(res) == "ask"
 
 
 # ── shell-parse bypass-hardening preserved (dispatched → still hard-denied) ──

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -59,17 +59,20 @@ def _decision(res: subprocess.CompletedProcess) -> str | None:
 # ── gh pr create ────────────────────────────────────────────────────
 
 
-def test_pr_create_interactive_asks():
+def test_pr_create_not_gated_interactive():
+    """gh pr create is NOT gated — opening a PR on already-pushed code is a
+    review request, not a code-publish (the push is what's gated). No prompt."""
     res = _run("gh pr create --title x --body y")
     assert res.returncode == 0, res.stderr
-    assert _decision(res) == "ask"
-
-
-def test_pr_create_dispatched_denied():
-    res = _run("gh pr create --title x --body y", dispatched=True)
-    assert res.returncode == 2
     assert _decision(res) is None
-    assert "Creating a PR requires user approval" in res.stderr
+
+
+def test_pr_create_not_gated_dispatched():
+    """Un-gated in every session: a dispatched session cannot push code (that is
+    denied), so a PR-create on already-pushed code needs no separate gate."""
+    res = _run("gh pr create --title x --body y", dispatched=True)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) is None
 
 
 def test_pr_create_mention_in_string_not_tripped():
@@ -78,11 +81,10 @@ def test_pr_create_mention_in_string_not_tripped():
     assert _decision(res) is None
 
 
-def test_pr_create_with_global_flag_before_pr_detected():
-    """A gh global flag before `pr` must not evade the create gate."""
-    res = _run("gh --repo o/r pr create --title x --body y", dispatched=True)
-    assert res.returncode == 2
-    assert "Creating a PR requires user approval" in res.stderr
+def test_pr_create_with_global_flag_not_gated():
+    res = _run("gh --repo o/r pr create --title x --body y")
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) is None
 
 
 # ── git push ────────────────────────────────────────────────────────
@@ -208,27 +210,31 @@ def test_force_push_mirror_blocked_even_dispatched():
     assert res.returncode == 2
 
 
-# ── compound with >1 gated publish op → hard-block (each needs its own approval) ──
+# ── compound: multiple PUSHES block (each needs own approval); a push + an
+#    un-gated pr-create asks ONCE (for the push), and the pr-create rides along ──
 
 
-def test_push_and_pr_create_compound_blocked():
-    """push && gh pr create must not share ONE approval prompt — approving the
-    push's ask would also create the PR (Codex P1) → hard-block, require split."""
+def test_push_and_pr_create_compound_asks_once():
+    """push && gh pr create is ONE prompt — for the push. gh pr create is not a
+    code-publish (it opens a review request on already-pushed code), so it rides
+    on the push's approval instead of demanding its own (user direction)."""
     res = _run("git push origin feat && gh pr create --title x --body y")
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_two_pushes_compound_blocked():
+    """Two real pushes still block — each publishes code and needs its own
+    approval, so they cannot share a single prompt."""
+    res = _run("git push origin a && git push origin b")
     assert res.returncode == 2
     assert _decision(res) is None
     assert "separate" in res.stderr
 
 
-def test_two_pushes_compound_blocked():
-    res = _run("git push origin a && git push origin b")
-    assert res.returncode == 2
-    assert _decision(res) is None
-
-
-def test_two_pr_creates_compound_blocked():
+def test_two_pr_creates_not_gated():
     res = _run("gh pr create --title a --body b && gh pr create --title c --body d")
-    assert res.returncode == 2
+    assert res.returncode == 0, res.stderr
     assert _decision(res) is None
 
 
@@ -257,10 +263,11 @@ def test_push_override_token_cannot_self_approve_dispatched():
     assert _decision(res) is None
 
 
-def test_pr_create_override_token_is_inert_interactive():
+def test_pr_create_not_gated_with_token():
+    """gh pr create is un-gated regardless of any trailing token — no prompt."""
     res = _run("gh pr create --title x --body-file /tmp/b.md  # review-override")
     assert res.returncode == 0, res.stderr
-    assert _decision(res) == "ask"
+    assert _decision(res) is None
 
 
 # ── shell-parse bypass-hardening preserved (dispatched → still hard-denied) ──


### PR DESCRIPTION
## What & why

Follow-up to #1235, per user direction: **only the push should prompt; PR-create should not.** Opening a PR is a review request on already-pushed code, not a code-publish — the push is what publishes, and it stays gated. #1235 gated both, producing two prompts per PR; this makes it one.

## Change

- **PR-create un-gated** entirely (no ask, no deny, any session).
- **Multi-op hard-block scoped to pushes** (`len(push_segs) > 1`): two real pushes still block (each publishes code → each needs its own approval); a push followed by a PR-create is one push → **asks once**, and the PR-create rides along.
- **Unchanged:** interactive push → ask, dispatched → hard-deny; force / `--force-with-lease` / `+refspec` / `--mirror` → hard-block; `--no-verify` / merge-into-main / pr-merge gates.

## Safety

Reviewed (code-reviewer agent): **DONE**. Removing the PR-create gate opens no code-publish hole — a dispatched session's push is still hard-denied (so it can't get new commits onto the remote via the CC Bash tool), and the executor's real autonomous PR path is server-side (`autonomy/executor/pr_open.py`), outside the CC Bash tool entirely. PR-create only opens a review request against a ref that must already exist on the remote.

## Testing

286 hook tests pass (`test_push_create_override.py` rewritten for the new behavior: PR-create not gated in any session, push-then-create asks once, two-push still blocks, precedence preserved); `ruff` clean.

## Deploy

CC PreToolUse hooks — `git pull` on main; reloads on next session/tool call. No `update.sh`, no restart.

Ledger: 64e1226efa374a439bc375fd3f4f03fb
