### PR TITLE
fix(ego): make ego_directive + ego_proposal_resolve user-only (provenance)

### DIFF
--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -102,6 +102,12 @@ _EGO_CYCLE_DISALLOWED_TOOLS = (
     # class as the goal tools above). Capture happens in user-facing
     # sessions (conversation, resolution paths), never inside a cycle.
     "mcp__genesis-health__ego_decision",
+    # Directives and proposal resolution are USER authority — both stamp
+    # source="user" on what they create (a directive; a withdrawn -> re-validation
+    # directive). The ego cycle must never forge either. Belt to the per-tool
+    # is_dispatched_session_env() gate's suspenders.
+    "mcp__genesis-health__ego_directive",
+    "mcp__genesis-health__ego_proposal_resolve",
 )
 
 # Per-cycle cap on autonomous own-goal creations (genesis ego). One per cycle

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -117,6 +117,11 @@ async def ego_directive(
     to its reasoning but decides what to propose. Use this when you want
     the ego to pay attention to something specific.
 
+    **User-only.** Directives are recorded as user instructions
+    (source="user"). This tool is REFUSED from autonomous/dispatched sessions
+    — an autonomous session must surface intent through a proposal, observation,
+    or report, never by writing a directive to itself.
+
     Args:
         content: What you want the ego to consider (e.g., "Retry the
             Medium article publish — VNC bypass is fixed now")
@@ -127,6 +132,25 @@ async def ego_directive(
         return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_DIRECTIVE_PRIORITIES)}"}
     if ego_target not in _VALID_EGO_TARGETS:
         return {"status": "error", "reason": f"Invalid ego_target: {ego_target!r}. Must be one of: {sorted(_VALID_EGO_TARGETS)}"}
+
+    # User-only: this tool stamps source="user", so an autonomous/dispatched
+    # session calling it would forge a user directive (the exact mechanism
+    # behind a mis-attributed directive, 2026-07). Refuse unless the caller is
+    # a foreground human terminal (no dispatch marker) or an owner-attended
+    # conversation (supervised). Fail direction is safe: env absent = human
+    # terminal = allowed.
+    from genesis.security.immunity_shadow import is_dispatched_session_env
+
+    if is_dispatched_session_env():
+        return {
+            "status": "refused",
+            "reason": (
+                "ego_directive is user-only — it records a directive as a user "
+                "instruction (source='user'). An autonomous/dispatched session "
+                "must not call it; surface this through your session's normal "
+                "output (a proposal, observation, or report) instead."
+            ),
+        }
 
     from genesis.db.connection import get_raw_db
     from genesis.db.crud import ego as ego_crud
@@ -591,6 +615,24 @@ async def ego_proposal_resolve(
         return {
             "status": "error",
             "reason": f"action must be 'approve' or 'reject', got {action!r}",
+        }
+
+    # User-only authority: approving/rejecting a proposal is a user action,
+    # and the withdrawn-proposal path creates a source="user" re-validation
+    # directive — an autonomous/dispatched session must not resolve the board
+    # or forge such a directive. Refuse unless foreground/supervised (same
+    # provenance class as ego_directive).
+    from genesis.security.immunity_shadow import is_dispatched_session_env
+
+    if is_dispatched_session_env():
+        return {
+            "status": "refused",
+            "reason": (
+                "ego_proposal_resolve is user-only — approving or rejecting "
+                "proposals is a user authority. An autonomous/dispatched session "
+                "must not resolve proposals; surface your assessment as an "
+                "observation or report instead."
+            ),
         }
 
     from genesis.db.connection import get_raw_db

--- a/tests/test_mcp/test_ego_tools.py
+++ b/tests/test_mcp/test_ego_tools.py
@@ -82,3 +82,122 @@ class TestEgoFocusReset:
         assert "genesis_ego_focus_summary" in details
         assert details["ego_focus_summary"]["new"] == "general system awareness"
         assert details["genesis_ego_focus_summary"]["new"] == "general system awareness"
+
+
+# -- Thread 2: ego_directive + ego_proposal_resolve are user-only --
+
+
+@pytest.fixture
+async def directive_db(tmp_path):
+    """A file DB carrying only the ego_directives table (for the create path)."""
+    db_path = tmp_path / "dir.db"
+    async with aiosqlite.connect(str(db_path)) as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_directives"])
+        await conn.commit()
+        yield conn, db_path
+
+
+class TestEgoDirectiveUserOnly:
+    """ego_directive stamps source="user", so it must be refused from an
+    autonomous/dispatched session and allowed only from a foreground/supervised
+    one (is_dispatched_session_env gate)."""
+
+    async def test_refused_when_dispatched(self, directive_db, monkeypatch):
+        conn, db_path = directive_db
+        monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+        monkeypatch.delenv("GENESIS_SESSION_SUPERVISED", raising=False)
+
+        from genesis.mcp.health.ego_tools import ego_directive
+
+        with patch(
+            "genesis.mcp.health.ego_tools._get_db_path", return_value=db_path
+        ):
+            result = await ego_directive.fn(
+                "test directive", priority="high", ego_target="genesis_ego"
+            )
+        assert result["status"] == "refused"
+        row = await (
+            await conn.execute("SELECT COUNT(*) AS c FROM ego_directives")
+        ).fetchone()
+        assert row["c"] == 0  # nothing written
+
+    async def test_allowed_when_supervised(self, directive_db, monkeypatch):
+        _conn, db_path = directive_db
+        monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+        monkeypatch.setenv("GENESIS_SESSION_SUPERVISED", "1")
+
+        from genesis.mcp.health.ego_tools import ego_directive
+
+        with patch(
+            "genesis.mcp.health.ego_tools._get_db_path", return_value=db_path
+        ):
+            result = await ego_directive.fn(
+                "test directive", priority="high", ego_target="user_ego"
+            )
+        assert result["status"] == "created"
+
+    async def test_allowed_when_no_cc_session(self, directive_db, monkeypatch):
+        _conn, db_path = directive_db
+        monkeypatch.delenv("GENESIS_CC_SESSION", raising=False)
+        monkeypatch.delenv("GENESIS_SESSION_SUPERVISED", raising=False)
+
+        from genesis.mcp.health.ego_tools import ego_directive
+
+        with patch(
+            "genesis.mcp.health.ego_tools._get_db_path", return_value=db_path
+        ):
+            result = await ego_directive.fn(
+                "test directive", priority="normal", ego_target="user_ego"
+            )
+        assert result["status"] == "created"
+
+
+class TestEgoProposalResolveUserOnly:
+    """ego_proposal_resolve is a user authority (and its withdrawn-proposal path
+    forges a source="user" directive) — refused from dispatched sessions."""
+
+    async def test_refused_when_dispatched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+        monkeypatch.delenv("GENESIS_SESSION_SUPERVISED", raising=False)
+
+        from genesis.mcp.health.ego_tools import ego_proposal_resolve
+
+        # Patch the db path to an empty tmp file so that even if the gate
+        # FAILED to fire, the call could never touch the real database.
+        with patch(
+            "genesis.mcp.health.ego_tools._get_db_path",
+            return_value=tmp_path / "empty.db",
+        ):
+            result = await ego_proposal_resolve.fn("reject", proposal_ids="whatever")
+        assert result["status"] == "refused"
+
+    async def test_allowed_when_no_cc_session_reaches_logic(self, tmp_path, monkeypatch):
+        """A non-dispatched caller passes the gate (reaches normal handling)."""
+        monkeypatch.delenv("GENESIS_CC_SESSION", raising=False)
+        monkeypatch.delenv("GENESIS_SESSION_SUPERVISED", raising=False)
+
+        db_path = tmp_path / "res.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            conn.row_factory = aiosqlite.Row
+            await conn.execute(TABLES["ego_proposals"])
+            await conn.commit()
+
+        from genesis.mcp.health.ego_tools import ego_proposal_resolve
+
+        with patch(
+            "genesis.mcp.health.ego_tools._get_db_path", return_value=db_path
+        ):
+            result = await ego_proposal_resolve.fn("reject", proposal_ids="none-such")
+        # Passed the gate -> normal handling (no such proposal), NOT "refused".
+        assert result["status"] != "refused"
+
+
+class TestUserAuthorityToolsDisallowedInCycle:
+    def test_directive_and_resolve_disallowed(self):
+        from genesis.ego.session import _EGO_CYCLE_DISALLOWED_TOOLS
+
+        assert "mcp__genesis-health__ego_directive" in _EGO_CYCLE_DISALLOWED_TOOLS
+        assert (
+            "mcp__genesis-health__ego_proposal_resolve" in _EGO_CYCLE_DISALLOWED_TOOLS
+        )


### PR DESCRIPTION
## Problem

An autonomous background session called the `ego_directive` MCP tool, which hardcodes `source="user"` on the directive it writes — so a directive the user never issued was recorded as a user instruction. Root cause proven via `cc_sessions`: only autonomous sessions were alive when the mis-attributed directive was created; zero foreground. The same provenance hole exists via `ego_proposal_resolve`, whose withdrawn-proposal re-validation path also writes `source="user"` directives, and neither tool was blocked from the autonomous ego cycle.

## Fix

Invariant enforced: **no autonomous/dispatched session may create a `source="user"` directive or resolve proposals** — both are user authority. Two thin layers, no schema change:

1. **Hard gate** at the top of `ego_directive` and `ego_proposal_resolve` on `is_dispatched_session_env()` (`GENESIS_CC_SESSION` set AND `GENESIS_SESSION_SUPERVISED` unset) → return a `refused` status before any DB work. Fail direction is safe: env absent = human terminal = allowed; an owner-attended conversation (`SUPERVISED=1`) is allowed.
2. **Defense-in-depth**: both tool names added to `_EGO_CYCLE_DISALLOWED_TOOLS`, so the ego cycle can't call them regardless.

The dashboard and Telegram resolution paths call the CRUD/resolution layer directly (not the MCP tool), so they are unaffected.

## Tests

6 new tests: refuse-when-dispatched (incl. a zero-write assertion proving the gate fires before DB access), allow-when-supervised, allow-when-no-CC-session, resolve refuse/allow, and disallow-list membership. 137 tests green across `test_ego_tools` / `test_ego_proposal_resolve_targeting` / `test_session` / `test_redteam_enforce`.

## Review

Code-reviewer: DONE, no BLOCKER/SHOULD-FIX/NOTE. Independently verified gate placement (inert for legitimate callers), the fail direction, no circular import, the dashboard path being unaffected, correct tool-name format, and that all four `source="user"` writers are accounted for (three gated here; the fourth is the genuine Telegram user-conversation flow, correctly out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
