### PR TITLE
fix(hooks): per-worktree review markers so concurrent sessions don't clobber

### DIFF
--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -132,9 +132,9 @@ def main() -> None:
     if stages_in_same_command:
         # Can't check diff hash (staging hasn't happened yet) — require the
         # marker file to exist and not be expired.
-        rule2_blocks = not has_valid_review_marker()
+        rule2_blocks = not has_valid_review_marker(cwd=cwd)
     else:
-        rule2_blocks = has_code_changes(cwd=cwd) and not is_review_current()
+        rule2_blocks = has_code_changes(cwd=cwd) and not is_review_current(cwd=cwd)
 
     if rule2_blocks:
         # A trailing '# review-override' comment (outside quotes) acknowledges

--- a/scripts/review_invalidate_on_commit.py
+++ b/scripts/review_invalidate_on_commit.py
@@ -23,8 +23,23 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent / "hooks"))
 from hook_input import field, read_payload, tool_response  # noqa: E402
 
+# review_state lives in scripts/ (this file's own dir).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from review_state import clear_marker  # noqa: E402
+
 _COMMIT_PATTERN = re.compile(r"\bgit\s+commit\b")
-_STATE_FILE = Path.home() / ".genesis" / "review_state.json"
+
+
+def _extract_working_dir(command: str) -> str | None:
+    """Extract the worktree cwd from a leading ``cd <path> && ...`` so the marker
+    cleared matches the per-worktree marker that authorized this commit."""
+    import os
+
+    m = re.match(r"^cd\s+([^\s&|;]+)", command)
+    if not m:
+        return None
+    path = os.path.expanduser(m.group(1))
+    return path if os.path.isdir(path) else None
 
 
 def main() -> None:
@@ -48,11 +63,9 @@ def main() -> None:
     except (json.JSONDecodeError, AttributeError):
         pass  # Can't parse result — be conservative, invalidate anyway
 
-    # Clear the review marker
-    import contextlib
-
-    with contextlib.suppress(OSError):
-        _STATE_FILE.unlink(missing_ok=True)
+    # Clear the per-worktree review marker (matching the cwd that authorized
+    # this commit) so the next commit requires a fresh review.
+    clear_marker(cwd=_extract_working_dir(command))
 
     sys.exit(0)
 

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -33,9 +33,41 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-_STATE_FILE = Path.home() / ".genesis" / "review_state.json"
+_MARKER_DIR = Path.home() / ".genesis" / "review_markers"
+# Legacy single-file marker (pre per-worktree scoping). Only read as a fallback
+# so an in-flight review from before an upgrade isn't lost mid-session.
+_LEGACY_STATE_FILE = Path.home() / ".genesis" / "review_state.json"
 _MAX_EVIDENCE_AGE_SECONDS = 1800  # 30 minutes
 _GSTACK_ANALYTICS = Path.home() / ".gstack" / "analytics" / "skill-usage.jsonl"
+
+
+def _worktree_key(cwd: str | None = None) -> str:
+    """Stable per-worktree key from the git worktree root.
+
+    Concurrent CC sessions each work in their own git worktree; a single global
+    marker file let them clobber each other's review state (session B's commit
+    reset session A's marker mid-workflow). Keying the marker by worktree root
+    isolates them. Falls back to "default" outside a git repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+        root = result.stdout.strip()
+        if root:
+            return hashlib.sha256(root.encode()).hexdigest()[:12]
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return "default"
+
+
+def _state_file(cwd: str | None = None) -> Path:
+    """Per-worktree marker path (see ``_worktree_key``)."""
+    return _MARKER_DIR / f"{_worktree_key(cwd)}.json"
 
 
 def get_current_diff_hash(cwd: str | None = None) -> str:
@@ -70,38 +102,44 @@ def has_code_changes(cwd: str | None = None) -> bool:
     return get_current_diff_hash(cwd=cwd) not in ("clean", "unknown")
 
 
-def is_review_current() -> bool:
-    """Check if the stored review marker matches current diff state."""
-    current = get_current_diff_hash()
+def _load_marker(cwd: str | None = None) -> dict | None:
+    """Read the per-worktree marker, falling back to the legacy global file."""
+    for path in (_state_file(cwd), _LEGACY_STATE_FILE):
+        try:
+            if path.exists():
+                return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+    return None
+
+
+def is_review_current(cwd: str | None = None) -> bool:
+    """Check if the stored (per-worktree) marker matches current diff state."""
+    current = get_current_diff_hash(cwd=cwd)
     if current in ("clean", "unknown"):
         return True  # No changes = no review needed
-    if not _STATE_FILE.exists():
-        return False
-    try:
-        state = json.loads(_STATE_FILE.read_text())
-        return state.get("diff_hash") == current
-    except (json.JSONDecodeError, OSError):
-        return False
+    state = _load_marker(cwd)
+    return bool(state) and state.get("diff_hash") == current
 
 
-def has_valid_review_marker() -> bool:
-    """Check if a review marker file exists and is not expired.
+def has_valid_review_marker(cwd: str | None = None) -> bool:
+    """Check if a (per-worktree) review marker exists and is not expired.
 
     Unlike is_review_current(), this does NOT short-circuit on clean staged
     area. Used when the caller knows changes are about to be staged (e.g.
     git add && git commit in the same command).
     """
-    if not _STATE_FILE.exists():
+    state = _load_marker(cwd)
+    if not state:
         return False
     try:
-        state = json.loads(_STATE_FILE.read_text())
         reviewed_at = state.get("reviewed_at", "")
         if not reviewed_at:
             return False
         ts = datetime.fromisoformat(reviewed_at)
         age = (datetime.now(UTC) - ts).total_seconds()
         return age <= _MAX_EVIDENCE_AGE_SECONDS
-    except (json.JSONDecodeError, OSError, ValueError):
+    except (ValueError, TypeError):
         return False
 
 
@@ -149,8 +187,8 @@ def _verify_agent_output(path: str) -> tuple[bool, str]:
     return True, f"Agent output valid ({int(age)}s old, {p.stat().st_size} bytes)"
 
 
-def mark_reviewed(agent_output_path: str | None = None) -> bool:
-    """Write review marker after verifying evidence.
+def mark_reviewed(agent_output_path: str | None = None, cwd: str | None = None) -> bool:
+    """Write the per-worktree review marker after verifying evidence.
 
     The authoritative gate is Check 2 (code-reviewer agent output). Check 1
     (gstack telemetry) is advisory — it annotates the marker but never refuses,
@@ -170,17 +208,33 @@ def mark_reviewed(agent_output_path: str | None = None) -> bool:
         print("Dispatch the superpowers:code-reviewer agent first.", file=sys.stderr)
         return False
 
-    # Authoritative evidence present — write marker.
-    _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    # Authoritative evidence present — write the per-worktree marker.
+    state_file = _state_file(cwd)
+    state_file.parent.mkdir(parents=True, exist_ok=True)
     state = {
-        "diff_hash": get_current_diff_hash(),
+        "diff_hash": get_current_diff_hash(cwd=cwd),
         "reviewed_at": datetime.now(UTC).isoformat(),
         "review_evidence": review_msg,  # advisory annotation (gstack corroboration)
         "agent_evidence": agent_msg,
     }
-    _STATE_FILE.write_text(json.dumps(state, indent=2))
+    state_file.write_text(json.dumps(state, indent=2))
     print(f"Review marker written: {state['diff_hash']}")
     return True
+
+
+def clear_marker(cwd: str | None = None) -> None:
+    """Delete the per-worktree review marker (and the legacy global file).
+
+    Called by the post-commit invalidation hook so the next commit requires a
+    fresh review. MUST target the same per-worktree path ``mark_reviewed`` wrote
+    — deleting only the legacy file would leave the real marker in place and
+    silently authorize every subsequent commit for the marker's TTL. Never raises.
+    """
+    import contextlib
+
+    for path in (_state_file(cwd), _LEGACY_STATE_FILE):
+        with contextlib.suppress(OSError):
+            path.unlink(missing_ok=True)
 
 
 def get_current_branch(cwd: str | None = None) -> str:
@@ -212,8 +266,8 @@ def main() -> None:
         print(f"diff_hash: {diff_hash}")
         print(f"has_changes: {changes}")
         print(f"review_current: {current}")
-        if _STATE_FILE.exists():
-            state = json.loads(_STATE_FILE.read_text())
+        state = _load_marker()
+        if state:
             print(f"last_reviewed: {state.get('reviewed_at', 'unknown')}")
             print(f"stored_hash: {state.get('diff_hash', 'none')}")
 

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -9,7 +9,7 @@ Focus (post-#1227 hardening):
   when buried in the commit message (where it would leak into public history).
 
 Install-agnostic: builds a throwaway git repo under ``tmp_path`` and points
-``HOME`` at another temp dir, so the real ``~/.genesis/review_state.json`` and
+``HOME`` at another temp dir, so the real per-worktree markers under ``~/.genesis/review_markers/`` and
 any concurrent session's markers are never touched. No network, no live server.
 """
 
@@ -26,6 +26,7 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _HOOK = _REPO_ROOT / "scripts" / "review_enforcement_commit.py"
 _REVIEW_STATE = _REPO_ROOT / "scripts" / "review_state.py"
+_INVALIDATE = _REPO_ROOT / "scripts" / "review_invalidate_on_commit.py"
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -235,7 +236,10 @@ def test_mark_succeeds_without_gstack(repo: Path, home: Path) -> None:
     res = _mark(repo, home)
     assert res.returncode == 0, res.stderr
     assert "Review marker written" in res.stdout
-    marker = json.loads((home / ".genesis" / "review_state.json").read_text())
+    # Marker is per-worktree under review_markers/<key>.json (exactly one here).
+    markers = list((home / ".genesis" / "review_markers").glob("*.json"))
+    assert len(markers) == 1
+    marker = json.loads(markers[0].read_text())
     assert "authoritative" in marker["review_evidence"]  # advisory annotation
 
 
@@ -265,3 +269,100 @@ def test_commit_allowed_after_marking(repo: Path, home: Path) -> None:
     assert _mark(repo, home).returncode == 0
     res = _run_hook('git commit -m "wip"', repo, home)
     assert res.returncode == 0, res.stderr
+
+
+# ── Per-worktree marker isolation (concurrent-session clobber fix) ────────
+
+
+def _second_repo(tmp_path: Path, name: str) -> Path:
+    """A distinct git worktree root on its own feature branch, staged."""
+    r = tmp_path / name
+    r.mkdir()
+    _git(r, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(r, "config", "user.email", "t@e.st")
+    _git(r, "config", "user.name", "tester")
+    (r / "g.txt").write_text("base\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "feature/y")
+    (r / "g.txt").write_text("changed\n")
+    _git(r, "add", "-A")
+    return r
+
+
+def test_reviewed_commit_allowed(repo: Path, home: Path) -> None:
+    """Baseline: after marking, the commit passes the gate (no override)."""
+    assert _mark(repo, home).returncode == 0
+    res = _run_hook('git commit -m "reviewed"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_marker_not_clobbered_by_concurrent_worktree(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """A concurrent session marking a DIFFERENT worktree (same shared HOME)
+    must not reset this worktree's marker — the global-file clobber bug."""
+    repo_b = _second_repo(tmp_path, "repo_b")
+    assert _mark(repo, home).returncode == 0  # our worktree reviewed
+    assert _mark(repo_b, home).returncode == 0  # concurrent session marks its own
+    # Our commit must STILL be allowed — B's mark did not touch A's marker.
+    res = _run_hook('git commit -m "reviewed"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_distinct_worktrees_get_distinct_markers(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    repo_b = _second_repo(tmp_path, "repo_b2")
+    assert _mark(repo, home).returncode == 0
+    assert _mark(repo_b, home).returncode == 0
+    markers = list((home / ".genesis" / "review_markers").glob("*.json"))
+    assert len(markers) == 2, [m.name for m in markers]
+
+
+def _run_invalidate(command: str, repo: Path, home: Path) -> subprocess.CompletedProcess:
+    """Run the PostToolUse invalidation hook for a successful commit."""
+    payload = json.dumps(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "[feature/x abc1234] msg", "stderr": ""},
+            "session_id": "test",
+        }
+    )
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(_INVALIDATE)],
+        input=payload, cwd=str(repo), env=env,
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def _markers(home: Path) -> list[Path]:
+    return list((home / ".genesis" / "review_markers").glob("*.json"))
+
+
+def test_commit_invalidates_per_worktree_marker(repo: Path, home: Path) -> None:
+    """After a commit, the per-worktree marker is cleared so the NEXT commit
+    needs a fresh review. Regression for the BLOCKER: the invalidation hook must
+    delete the per-worktree marker, not the retired global file (else one review
+    silently authorizes every subsequent git-add+commit for the marker's TTL)."""
+    assert _mark(repo, home).returncode == 0
+    assert len(_markers(home)) == 1  # marker written
+
+    # Simulate CC firing the PostToolUse invalidation hook after the commit.
+    _run_invalidate("git commit -m done", repo, home)
+    assert _markers(home) == [], "per-worktree marker was not cleared after commit"
+
+    # The next commit must be blocked again (no valid marker).
+    res = _run_hook('git commit -m "again"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_invalidate_ignores_non_commit(repo: Path, home: Path) -> None:
+    """A non-commit command must NOT clear the marker."""
+    assert _mark(repo, home).returncode == 0
+    _run_invalidate("echo not a commit", repo, home)
+    assert len(_markers(home)) == 1  # marker survives


### PR DESCRIPTION
## Problem

The commit review-gate (`review_state.py` + the enforcement hooks) stored its
state in a **single global file** `~/.genesis/review_state.json` (+ evidence
`last_code_review.txt`). Concurrent Claude Code sessions each work in their own
git worktree but share one `~/.genesis`, so:

- Session B's `mark`/commit **reset session A's marker** mid-workflow — A's
  already-reviewed commit then got blocked. (Hit repeatedly while landing the
  inbox-evaluator stack this session.)
- The commit hook called `is_review_current()` with **no cwd**, so it hashed the
  *process* cwd's staged diff, not the worktree being committed — a latent bug.

## Fix

- **Per-worktree marker**: `~/.genesis/review_markers/<sha12(git-worktree-root)>.json`
  via `_worktree_key(cwd)` / `_state_file(cwd)`, with a **read-only** fallback to
  the legacy global file so an in-flight pre-upgrade review isn't lost.
- **Thread `cwd`** through `is_review_current`, `has_valid_review_marker`,
  `mark_reviewed`; the commit hook now passes the worktree cwd (also fixing the
  no-cwd bug).
- **Post-commit invalidation** (`review_invalidate_on_commit.py`): new
  `clear_marker(cwd)` deletes the **per-worktree** marker. Without this, the hook
  would keep deleting only the retired global file — silently disabling
  invalidation and letting one review authorize every subsequent `git add &&
  git commit` for the marker's 30-minute TTL. *(Caught as a BLOCKER in review.)*

Advisory nudge hooks (`review_enforcement_prompt.py`, `genesis_stop_hook.py`)
correctly stay at `cwd=None` — they key on the live session's own cwd and parse
no command.

## Tests

`tests/test_hooks/test_review_enforcement_commit.py` (25 pass): per-worktree
isolation (a concurrent worktree's mark can't clobber this one), distinct marker
files per worktree, a reviewed commit is allowed, and **commit → per-worktree
marker cleared → next commit re-blocked**. Install-agnostic (throwaway git repos,
`HOME` redirected).

## Deploy

Pure hooks/scripts — takes effect at next CC session start (no runtime restart).
The threat model is a self-discipline gate, not a security boundary; the
fail-open `"default"` key for non-git contexts is acceptable and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
