### PR TITLE
test(memory-integrity): make posture staleness tests clock-independent

### DIFF
--- a/tests/test_memory_integrity/test_posture_and_jobs.py
+++ b/tests/test_memory_integrity/test_posture_and_jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import aiosqlite
 import pytest
 
@@ -47,6 +49,17 @@ async def _alerts(db) -> list[dict]:
 
 def _open(alerts):
     return [a for a in alerts if a["resolved"] == 0]
+
+
+def _ago(*, days: int = 0, hours: int = 0, minutes: int = 0) -> str:
+    """A timestamp ``now - offset`` in the stored ``YYYY-MM-DD HH:MM:SS`` format
+    (space-separated, no tz) so it sorts lexically = chronologically against the
+    posture check's ``since_iso`` window. Relative to real ``now`` so these
+    tests never drift across the staleness threshold as the calendar advances
+    (no wall-clock-dependent tests)."""
+    return (
+        datetime.now(UTC) - timedelta(days=days, hours=hours, minutes=minutes)
+    ).strftime("%Y-%m-%d %H:%M:%S")
 
 
 # ── posture ──
@@ -154,7 +167,7 @@ async def test_stuck_unknown_streak_alerts(monkeypatch):
         sample_fraction=1.0,
         truncated=False,
         unknown_reason="qdrant_unavailable",
-        created_at="2026-07-15 03:50:00",
+        created_at=_ago(days=10),
     )
     await mi.insert_consistency_report(
         db,
@@ -165,7 +178,7 @@ async def test_stuck_unknown_streak_alerts(monkeypatch):
         sample_fraction=1.0,
         truncated=False,
         unknown_reason="qdrant_unavailable",
-        created_at="2026-07-25 03:50:00",
+        created_at=_ago(hours=1),
     )
     await loop._check_memory_integrity_posture(db)
     opn = _open(await _alerts(db))
@@ -188,7 +201,7 @@ async def test_unknown_after_degraded_holds_alert(monkeypatch):
         sampled_rows=100,
         sample_fraction=1.0,
         truncated=False,
-        created_at="2026-07-25 03:50:00",
+        created_at=_ago(hours=3),
     )
     await loop._check_memory_integrity_posture(db)
     assert len(_open(await _alerts(db))) == 1
@@ -202,7 +215,7 @@ async def test_unknown_after_degraded_holds_alert(monkeypatch):
         sample_fraction=1.0,
         truncated=False,
         unknown_reason="qdrant_unavailable",
-        created_at="2026-07-25 03:55:00",
+        created_at=_ago(hours=2),
     )
     await loop._check_memory_integrity_posture(db)
     assert len(_open(await _alerts(db))) == 1  # held, not resolved
@@ -215,7 +228,7 @@ async def test_unknown_after_degraded_holds_alert(monkeypatch):
         sampled_rows=100,
         sample_fraction=1.0,
         truncated=False,
-        created_at="2026-07-25 04:00:00",
+        created_at=_ago(hours=1),
     )
     await loop._check_memory_integrity_posture(db)
     assert _open(await _alerts(db)) == []
@@ -229,7 +242,7 @@ async def test_stuck_recall_probe_alerts_but_unseeded_does_not(monkeypatch):
 
     db = await _setup()
     # probe running 10d, all unknown due to a real retriever error → stale
-    for ts in ("2026-07-15 03:20:00", "2026-07-25 03:20:00"):
+    for ts in (_ago(days=10), _ago(hours=1)):
         await mi.insert_recall_probe_run(
             db,
             status="unknown",
@@ -247,7 +260,7 @@ async def test_stuck_recall_probe_alerts_but_unseeded_does_not(monkeypatch):
 
     # Contrast: an unseeded golden set (golden_set_too_small) must NOT alert.
     db2 = await _setup()
-    for ts in ("2026-07-15 03:20:00", "2026-07-25 03:20:00"):
+    for ts in (_ago(days=10), _ago(hours=1)):
         await mi.insert_recall_probe_run(
             db2,
             status="unknown",


### PR DESCRIPTION
## Problem

`_check_memory_integrity_posture` (awareness/loop.py) fires a `reports_stale` / "no conclusive report in Nd" alert when the earliest report predates a **now-relative** window (`datetime.now(UTC) - stale_report_days`, default 3d) with no recent conclusive report. Three posture tests seeded **hardcoded `2026-07-xx`** timestamps, so they drift across that window as the real calendar advances.

`test_unknown_after_degraded_holds_alert` began failing on **2026-07-28** when its `2026-07-25` "healthy" report crossed the 3-day boundary: the staleness alert fired, so the test asserted `[]` but got one open alert. This blocks CI `test` on every PR opened today. (The two "stuck/stale" tests happen to pass now but are equally fragile — they'd fail if run before their hardcoded dates aged past the window.)

## Fix

Test-only. Add an `_ago(days/hours/minutes)` helper returning `now - offset` in the stored `%Y-%m-%d %H:%M:%S` format (so it sorts lexically = chronologically against the check's `since_iso`), and seed the three fragile tests relative to `now`:
- **hold/resolve test**: all three reports recent (within the window) → the healthy report resolves the alert and staleness never fires.
- **two stuck/stale tests**: a 10-day-old earliest + a recent still-unknown report → the staleness/stuck finding fires deterministically.

Wide margins (3h vs 72h; 10d vs 3d) hold for any real `now` — no time-of-day / month-boundary / DST dependence.

## Scope

Only `test_posture_and_jobs.py` needed this — the code-reviewer verified the other hardcoded-date files in the dir (`test_crud_and_config.py`, `test_recall_probe.py`) compare against fixed `since_iso`/injected `now` values, not `datetime.now`, so they don't drift.

## Verify

`pytest tests/test_memory_integrity/test_posture_and_jobs.py` → 8 passed (incl. the previously-failing test). Code-reviewer: DONE, no BLOCKER/SHOULD-FIX — traced each rewrite through the real posture logic, confirmed intent preserved, format match, no vacuous assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
