### PR TITLE
fix(test): register inbox eval_memory writer in store coverage guard (unbreak main)

### DIFF
--- a/tests/test_memory/test_store_subsystem_coverage.py
+++ b/tests/test_memory/test_store_subsystem_coverage.py
@@ -73,6 +73,7 @@ USER_CONTEXT_ALLOWLIST: dict[str, str] = {
     "mcp/memory/core.py::memory_extract": "user-invoked MCP extraction",
     "mcp/memory/core.py::memory_synthesize": "user-invoked MCP synthesis",
     "memory/dream_cycle.py::_synthesize_and_deprecate": "consolidated memory meant FOR recall (tagging would break update_payload)",
+    "inbox/eval_memory.py::extract_and_store_eval_memories": "inbox-eval insights (user_signal / architecture_insight distilled from the curated .genesis.md output; user-context knowledge that must stay in default recall, not internal decisional output)",
     "memory/knowledge_ingest.py::ingest_knowledge_unit": "knowledge_base ingest (external-world, recallable)",
     "memory/session_observer.py::process_pending_observations": "conversation-derived observations (~48% of recall pool; must stay)",
     "recon/cc_update_analyzer.py::_ingest_to_knowledge": "external-world CC-update knowledge (recallable)",


### PR DESCRIPTION
Hotfix: PR #1240 added inbox/eval_memory.py's store writer without registering it in the WS-3 coverage guard (test_store_subsystem_coverage), turning main red. Registers it in USER_CONTEXT_ALLOWLIST (user-context inbox insights that must stay recallable). The separately-failing test_unknown_after_degraded_holds_alert is a pre-existing flake (fails on #1244 which predates #1240) — tracked apart. 🤖 Generated with [Claude Code](https://claude.com/claude-code)