### PR TITLE
feat(hooks): block gh pr merge on red/pending CI unless # ci-override

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -31,6 +31,7 @@ from shell_parse import (  # noqa: E402
     commit_skips_hooks,
     gh_pr_subcommand,
     git_subcommand,
+    has_trailing_override,
 )
 
 
@@ -165,6 +166,97 @@ def _check_mergeable(pr_num: str) -> str | None:
         return result.stdout.strip() if result.returncode == 0 else None
     except Exception:
         return None  # Fail-open
+
+
+# Check-run conclusions / statuses that mean the CI is NOT green.
+_CI_RED_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+_CI_RED_STATES = {"FAILURE", "ERROR"}  # legacy StatusContext state
+_CI_SKIP_CONCLUSIONS = {"SKIPPED", "NEUTRAL"}
+_CI_GREEN = {"SUCCESS"}
+
+
+def _pr_ci_status(pr_num: str) -> tuple[str, list[str]]:
+    """Classify a PR's CI check-runs.
+
+    Returns ``(state, problem_checks)`` where state is one of:
+      * ``"green"``   — every non-skipped check concluded SUCCESS
+      * ``"red"``     — at least one check failed/cancelled/timed-out
+      * ``"pending"`` — a check is still queued/running (and none are red)
+      * ``"unknown"`` — could not determine (API error, no checks, or an
+                        unrecognized payload shape) → callers FAIL OPEN, because
+                        blocking a merge on our own inability to read CI would be
+                        worse than the gap this gate closes.
+
+    Tests inject via the ``_TEST_GH_CI_ROLLUP`` env var (a JSON array like
+    ``gh pr view --json statusCheckRollup``) so no network is needed.
+    """
+    raw = os.environ.get("_TEST_GH_CI_ROLLUP")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    pr_num,
+                    "--json",
+                    "statusCheckRollup",
+                    "--jq",
+                    ".statusCheckRollup",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                return "unknown", []
+            raw = result.stdout.strip()
+        except Exception:
+            return "unknown", []
+    try:
+        checks = json.loads(raw) if raw else []
+    except Exception:
+        return "unknown", []
+    if not isinstance(checks, list) or not checks:
+        return "unknown", []
+
+    red: list[str] = []
+    pending: list[str] = []
+    saw_recognized = False
+    for c in checks:
+        if not isinstance(c, dict):
+            continue
+        name = c.get("name") or c.get("context") or "check"
+        conclusion = c.get("conclusion")  # CheckRun
+        status = c.get("status")  # CheckRun: QUEUED/IN_PROGRESS/COMPLETED
+        state = c.get("state")  # StatusContext: SUCCESS/FAILURE/PENDING/ERROR
+        if conclusion in _CI_SKIP_CONCLUSIONS:
+            saw_recognized = True
+            continue
+        if conclusion in _CI_RED_CONCLUSIONS or state in _CI_RED_STATES:
+            saw_recognized = True
+            red.append(name)
+        elif status in ("QUEUED", "IN_PROGRESS") or state == "PENDING":
+            saw_recognized = True
+            pending.append(name)
+        elif conclusion in _CI_GREEN or state in _CI_GREEN:
+            saw_recognized = True
+        # else: unrecognized shape — ignore this entry
+
+    if red:
+        return "red", sorted(set(red))
+    if pending:
+        return "pending", sorted(set(pending))
+    if not saw_recognized:
+        return "unknown", []  # payload had no CI-shaped entries
+    return "green", []
+
+
+# The CI-status gate is waived only by a genuine ``# ci-override`` trailing
+# comment on the merge segment itself — detected with the same quote-aware,
+# segment-bound parser as ``# review-override`` (shell_parse.has_trailing_override)
+# so it cannot be spoofed from inside a quoted --body or a different chained
+# command. Distinct from --admin and # review-override; waives ONLY this gate.
 
 
 # ── Review findings detection ──────────────────────────────────────────
@@ -602,6 +694,40 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     return 2
+
+                # CI-status gate. On an unprotected default branch,
+                # mergeStateStatus=CLEAN is NOT a CI verdict (it only means "no
+                # conflict / no REQUIRED check blocking", and nothing is required
+                # when the branch is unprotected). So --admin merges would sail
+                # past a red `test` job — exactly how main was broken on
+                # 2026-07-28. Block red/pending CI unless a conscious, separate
+                # `# ci-override` is appended (never waived by --admin or
+                # # review-override). Fail-OPEN on "unknown" so a transient API
+                # hiccup can't wedge merges.
+                ci_state, ci_bad = _pr_ci_status(pr_num)
+                ci_override = has_trailing_override(merge_seg.raw, "ci-override")
+                if ci_state in ("red", "pending") and not ci_override:
+                    print(
+                        f"BLOCKED: PR #{pr_num} CI is {ci_state.upper()} "
+                        f"({', '.join(ci_bad[:6])}).",
+                        file=sys.stderr,
+                    )
+                    print(
+                        f"Do NOT merge red/pending CI. Wait for green "
+                        f"(gh pr checks {pr_num}). If these checks are a known, "
+                        "documented pre-existing flake you are consciously "
+                        "accepting, append a trailing '# ci-override' to merge "
+                        "anyway (logged).",
+                        file=sys.stderr,
+                    )
+                    return 2
+                if ci_state in ("red", "pending"):
+                    print(
+                        f"NOTE: CI {ci_state.upper()} on #{pr_num} "
+                        f"({', '.join(ci_bad[:6])}) — merging via # ci-override "
+                        "(consciously accepted).",
+                        file=sys.stderr,
+                    )
 
                 # Check for unresolved review findings
                 force_override = merge_seg.override

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -173,6 +173,10 @@ _CI_RED_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "
 _CI_RED_STATES = {"FAILURE", "ERROR"}  # legacy StatusContext state
 _CI_SKIP_CONCLUSIONS = {"SKIPPED", "NEUTRAL"}
 _CI_GREEN = {"SUCCESS"}
+# The only CheckRun.status that means "finished". Everything else
+# (QUEUED/IN_PROGRESS/PENDING/WAITING/REQUESTED/…) is treated as unfinished, so
+# a new/renamed non-terminal state can never be silently mistaken for green.
+_CI_TERMINAL_STATUSES = {"COMPLETED"}
 
 
 def _pr_ci_status(pr_num: str) -> tuple[str, list[str]]:
@@ -228,7 +232,7 @@ def _pr_ci_status(pr_num: str) -> tuple[str, list[str]]:
             continue
         name = c.get("name") or c.get("context") or "check"
         conclusion = c.get("conclusion")  # CheckRun
-        status = c.get("status")  # CheckRun: QUEUED/IN_PROGRESS/COMPLETED
+        status = c.get("status")  # CheckRun: QUEUED/IN_PROGRESS/COMPLETED/PENDING/…
         state = c.get("state")  # StatusContext: SUCCESS/FAILURE/PENDING/ERROR
         if conclusion in _CI_SKIP_CONCLUSIONS:
             saw_recognized = True
@@ -236,12 +240,20 @@ def _pr_ci_status(pr_num: str) -> tuple[str, list[str]]:
         if conclusion in _CI_RED_CONCLUSIONS or state in _CI_RED_STATES:
             saw_recognized = True
             red.append(name)
-        elif status in ("QUEUED", "IN_PROGRESS") or state == "PENDING":
-            saw_recognized = True
-            pending.append(name)
         elif conclusion in _CI_GREEN or state in _CI_GREEN:
             saw_recognized = True
-        # else: unrecognized shape — ignore this entry
+        elif status in _CI_TERMINAL_STATUSES:
+            # COMPLETED with an unrecognized/None conclusion — treat as done,
+            # don't fabricate pending; ignore this entry.
+            saw_recognized = True
+        elif status is not None or state == "PENDING":
+            # ANY non-terminal CheckRun status (QUEUED/IN_PROGRESS/PENDING/
+            # WAITING/REQUESTED/…) or a PENDING StatusContext is unfinished →
+            # block. Enumerating "known pending" states would silently miss new
+            # ones (P1 review finding), so we invert: not-terminal ⇒ pending.
+            saw_recognized = True
+            pending.append(name)
+        # else: no status/state/conclusion at all — unrecognized shape, ignore
 
     if red:
         return "red", sorted(set(red))
@@ -563,16 +575,18 @@ def main() -> int:
         create_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "create"]
         merge_pr_segs = [s for s in segs if gh_pr_subcommand(s.argv) == "merge"]
 
-        # Each push / PR-create is a SEPARATE external-publish action needing its
-        # own approval. A single Bash command carrying more than one would
-        # collapse into ONE ask (mentioning only the first), so approving that
-        # prompt would run every publish behind it. Reject the compound and
-        # require each to be its own separately-approved tool call.
-        if len(push_segs) + len(create_segs) > 1:
+        # Each push / PR-create / PR-merge is a SEPARATE gated action. A single
+        # Bash command carrying more than one would collapse into ONE ask/gate
+        # (evaluated only for the first), so approving it would run every publish
+        # — and every UNCHECKED merge — behind it. Reject the compound and require
+        # each to be its own separately-gated tool call. (Merges are included so
+        # `gh pr merge 1 --admin && gh pr merge 2 --admin` can't smuggle the
+        # second past the CI/review gates, which only inspect the first segment.)
+        if len(push_segs) + len(create_segs) + len(merge_pr_segs) > 1:
             print(
-                "BLOCKED: multiple publish operations (git push / gh pr create) "
-                "in one command would share a single approval prompt. Run each "
-                "as its own command so each is approved separately.",
+                "BLOCKED: multiple publish/merge operations (git push / gh pr "
+                "create / gh pr merge) in one command would share a single gate. "
+                "Run each as its own command so each is gated separately.",
                 file=sys.stderr,
             )
             return 2

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -188,12 +188,15 @@ def _strip_trailing_comment(seg: str) -> str:
     return "".join(out)
 
 
-def _has_trailing_override(seg: str) -> bool:
-    """Whether the segment carries a genuine ``# review-override`` comment.
+def _has_trailing_override(seg: str, sigil: str = "review-override") -> bool:
+    """Whether the segment carries a genuine ``# <sigil>`` comment.
 
     The ``#`` must open a real comment (outside quotes, preceded by whitespace),
-    so a token buried in a quoted message word does not count.
+    so a token buried in a quoted message word does not count. ``sigil`` selects
+    which override token to detect (``review-override`` by default; the CI-status
+    merge gate passes ``ci-override``).
     """
+    token = re.compile(re.escape(sigil) + r"(?![-\w])")
     quote: str | None = None
     prev_ws = True
     i, n = 0, len(seg)
@@ -218,10 +221,15 @@ def _has_trailing_override(seg: str) -> bool:
             # The sigil must be the token, optionally followed by punctuation /
             # comment text (`# review-override: accepted P2s`), but NOT be a
             # prefix of a longer token (`review-override-x`, `review-overridexyz`).
-            return bool(re.match(r"review-override(?![-\w])", rest))
+            return bool(token.match(rest))
         prev_ws = c.isspace()
         i += 1
     return False
+
+
+def has_trailing_override(seg: str, sigil: str = "review-override") -> bool:
+    """Public alias of :func:`_has_trailing_override` for sibling hooks."""
+    return _has_trailing_override(seg, sigil)
 
 
 def _argv(seg: str) -> list[str]:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -799,3 +799,49 @@ class TestCiGateEndToEnd:
             lambda: self._payload("gh pr merge 5 --squash --admin"),
         )
         assert guard_module.main() == 0
+
+
+class TestCiStatusUnfinishedStates:
+    """P1 fix: ANY non-terminal check status counts as pending (not just
+    QUEUED/IN_PROGRESS) — a new/renamed unfinished state can't read as green."""
+
+    @staticmethod
+    def _set(monkeypatch, checks):
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", json.dumps(checks))
+
+    def test_pending_status_is_pending(self, guard_module, monkeypatch):
+        self._set(monkeypatch, [
+            {"name": "test", "status": "PENDING"},
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("pending", ["test"])
+
+    def test_waiting_requested_new_states_are_pending(self, guard_module, monkeypatch):
+        for st in ("WAITING", "REQUESTED", "SOME_NEW_STATE"):
+            self._set(monkeypatch, [{"name": "test", "status": st}])
+            assert guard_module._pr_ci_status("1")[0] == "pending", st
+
+    def test_completed_null_conclusion_not_pending(self, guard_module, monkeypatch):
+        self._set(monkeypatch, [
+            {"name": "test", "status": "COMPLETED", "conclusion": None},
+            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("green", [])
+
+
+class TestMultiMergeBlocked:
+    """P2 fix: multiple merge segments (or merge+push) in one command are blocked
+    — the CI/review gates only inspect the first, so a second could smuggle past."""
+
+    def test_two_merges_blocked(self):
+        res = _run_guard("gh pr merge 1 --squash --admin && gh pr merge 2 --squash --admin")
+        assert res.returncode == 2
+        assert "multiple publish/merge" in res.stderr
+
+    def test_merge_plus_push_blocked(self):
+        res = _run_guard("gh pr merge 1 --squash --admin && git push origin x")
+        assert res.returncode == 2
+
+    def test_single_merge_not_tripped_by_multi_guard(self):
+        res = _run_guard("gh pr merge 1 --squash --admin")
+        assert "multiple publish/merge" not in res.stderr

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -20,6 +20,13 @@ import pytest
 _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "hooks"
 _GUARD = _SCRIPTS / "git_push_guard.py"
 
+sys.path.insert(0, str(_SCRIPTS))
+from shell_parse import (  # noqa: E402
+    analyze,
+    gh_pr_subcommand,
+    has_trailing_override,
+)
+
 
 def _run_guard(
     command: str, *, mock_gh_output: str = "", mock_gh_rc: int = 0
@@ -601,3 +608,194 @@ class TestResolvePrNumber:
             ),
         ):
             assert guard_module._resolve_pr_number("gh pr merge --squash") is None
+
+
+# ── CI-status merge gate (_pr_ci_status / _has_ci_override) ───────────────
+
+
+class TestPrCiStatus:
+    """The CI classifier that blocks red/pending merges (env-injected, no net)."""
+
+    @staticmethod
+    def _set(monkeypatch, checks):
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", json.dumps(checks))
+
+    def test_all_success_is_green(self, guard_module, monkeypatch):
+        self._set(
+            monkeypatch,
+            [
+                {"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        )
+        assert guard_module._pr_ci_status("1") == ("green", [])
+
+    def test_failure_is_red(self, guard_module, monkeypatch):
+        self._set(
+            monkeypatch,
+            [
+                {"name": "test", "status": "COMPLETED", "conclusion": "FAILURE"},
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        )
+        assert guard_module._pr_ci_status("1") == ("red", ["test"])
+
+    def test_in_progress_is_pending(self, guard_module, monkeypatch):
+        self._set(
+            monkeypatch,
+            [
+                {"name": "test", "status": "IN_PROGRESS", "conclusion": None},
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ],
+        )
+        assert guard_module._pr_ci_status("1") == ("pending", ["test"])
+
+    def test_red_beats_pending(self, guard_module, monkeypatch):
+        self._set(
+            monkeypatch,
+            [
+                {"name": "test", "conclusion": "FAILURE"},
+                {"name": "build", "status": "IN_PROGRESS"},
+            ],
+        )
+        assert guard_module._pr_ci_status("1")[0] == "red"
+
+    def test_skipped_and_neutral_ignored(self, guard_module, monkeypatch):
+        self._set(
+            monkeypatch,
+            [
+                {"name": "test", "conclusion": "SUCCESS"},
+                {"name": "opt", "conclusion": "SKIPPED"},
+                {"name": "info", "conclusion": "NEUTRAL"},
+            ],
+        )
+        assert guard_module._pr_ci_status("1") == ("green", [])
+
+    def test_legacy_statuscontext_failure_is_red(self, guard_module, monkeypatch):
+        self._set(monkeypatch, [{"context": "legacy-ci", "state": "FAILURE"}])
+        assert guard_module._pr_ci_status("1") == ("red", ["legacy-ci"])
+
+    def test_empty_is_unknown(self, guard_module, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", "[]")
+        assert guard_module._pr_ci_status("1") == ("unknown", [])
+
+    def test_garbage_is_unknown(self, guard_module, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", "not-json")
+        assert guard_module._pr_ci_status("1") == ("unknown", [])
+
+    def test_non_ci_payload_is_unknown_fail_open(self, guard_module, monkeypatch):
+        # e.g. a review-comment mock other tests inject — must not be read as red.
+        self._set(monkeypatch, [{"login": "codex", "body": "FAILURE somewhere"}])
+        assert guard_module._pr_ci_status("1") == ("unknown", [])
+
+
+class TestCiOverrideSigil:
+    """The `# ci-override` sigil is quote-aware and (at the call site) bound to
+    the merge segment — it cannot be spoofed from a quoted --body or a chained
+    command. This is the BLOCKER the reviewer caught in the first draft."""
+
+    def test_trailing_comment_accepted(self, guard_module):
+        assert has_trailing_override("gh pr merge 5 --squash --admin  # ci-override", "ci-override")
+
+    def test_absent(self, guard_module):
+        assert not has_trailing_override("gh pr merge 5 --squash --admin", "ci-override")
+
+    def test_review_override_is_not_ci_override(self, guard_module):
+        assert not has_trailing_override(
+            "gh pr merge 5 --squash --admin  # review-override", "ci-override"
+        )
+
+    def test_sigil_in_quoted_body_rejected(self, guard_module):
+        # No real '#' comment — sigil is just text inside --body.
+        assert not has_trailing_override(
+            'gh pr merge 5 --admin --body "flaky, see ci-override note"', "ci-override"
+        )
+
+    def test_hash_sigil_inside_quotes_rejected(self, guard_module):
+        # A literal '# ci-override' buried INSIDE quotes must not count.
+        assert not has_trailing_override(
+            'gh pr merge 5 --admin --body "x # ci-override"', "ci-override"
+        )
+
+    def test_not_bound_to_other_segment(self, guard_module):
+        # Sigil on a chained commit segment must not waive the merge segment.
+        segs = analyze("git commit -m wip  # ci-override && gh pr merge 5 --squash --admin")
+        merge = [s for s in segs if gh_pr_subcommand(s.argv) == "merge"][0]
+        assert not has_trailing_override(merge.raw, "ci-override")
+
+    def test_default_sigil_review_override_unchanged(self, guard_module):
+        assert has_trailing_override("gh pr merge 5 --admin  # review-override")
+
+
+class TestCiGateEndToEnd:
+    """The gate actually returns exit 2 through main() on red CI — closes the
+    'mechanism present but not reached' gap the reviewer flagged."""
+
+    def _payload(self, cmd):
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": cmd},
+        }
+
+    def _patch_merge_ok(self, guard_module, monkeypatch):
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n: "MERGEABLE")
+        monkeypatch.setattr(
+            guard_module, "_check_pr_review_findings", lambda n, force=False: (False, "")
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_inline_review_findings",
+            lambda n, force=False: (False, ""),
+        )
+
+    def test_red_ci_blocks_exit_2(self, guard_module, monkeypatch, capsys):
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "FAILURE"}])
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin"),
+        )
+        rc = guard_module.main()
+        assert rc == 2
+        assert "CI is RED" in capsys.readouterr().err
+
+    def test_red_ci_with_override_allowed(self, guard_module, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "FAILURE"}])
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin  # ci-override"),
+        )
+        assert guard_module.main() == 0
+
+    def test_pending_ci_blocks(self, guard_module, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "test", "status": "IN_PROGRESS"}]),
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin"),
+        )
+        assert guard_module.main() == 2
+
+    def test_green_ci_allowed(self, guard_module, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin"),
+        )
+        assert guard_module.main() == 0


### PR DESCRIPTION
## Why

The merge gate in `git_push_guard.py` required `--admin` for **every** merge (so
`--admin` is the normal flag, carrying no CI signal) and checked conflict status
+ Codex review findings — but **never the CI `test`-job conclusion.** With `main`
unprotected (GitHub enforces no required checks), an `--admin` merge sails past a
failing `test` job. That's exactly how main broke this session: a red
coverage-guard PR merged on `mergeStateStatus=CLEAN` (which only means "no
conflict / no *required* check blocking").

## What

A CI-status gate on the `gh pr merge` path:

- **`_pr_ci_status(pr)`** — fetches `gh pr view --json statusCheckRollup` (with a
  `_TEST_GH_CI_ROLLUP` env seam for tests), classifies **green / red / pending /
  unknown** across both CheckRun (`status`+`conclusion`) and legacy StatusContext
  (`state`) shapes. `red > pending > green`; `SKIPPED`/`NEUTRAL` ignored.
- **Blocks red or pending CI** unless a genuine `# ci-override` is present —
  detected with the **same quote-aware, segment-bound** parser as
  `# review-override` (`shell_parse.has_trailing_override`, now parameterized on
  the sigil), bound to the **merge segment's raw text**. So it *cannot* be
  spoofed from a quoted `--body` or a different chained command. It waives
  **only** this gate — never `--admin`, conflict, or review-findings.
- **Fail-OPEN on `unknown`** (API error / empty / non-CI payload) so a transient
  hiccup can't wedge merges.

## Review

An earlier draft used a bare `re.search` over the whole command; the reviewer
correctly flagged that as a **BLOCKER** (spoofable from a quoted `--body` or a
chained segment). Fixed by binding to `merge_seg.raw` + the quote-aware detector,
with explicit spoof-rejection tests. Also added the end-to-end test the reviewer
asked for (gate actually returns exit 2 through `main()` on red CI).

## Tests

65 hook tests green (45 pre-existing unaffected + new): classifier
(green/red/pending/skip/legacy/unknown), override spoof-rejection (quoted-body,
`#`-inside-quotes, wrong-segment, default-sigil-unchanged), and end-to-end
(exit 2 on red, 0 with `# ci-override`, 0 on green, 2 on pending). ruff clean.

## Deploy

Hooks-only — takes effect at next CC session start. The gate is a self-discipline
guard, not a security boundary; the fail-open on `unknown` is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
