### PR TITLE
fix(hooks): privacy & no-mutate hardening (re-audit)

### DIFF
--- a/scripts/hooks/credential_surface_hook.py
+++ b/scripts/hooks/credential_surface_hook.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: surface credentials for auth-related Bash commands.
+"""PreToolUse hook: surface stored credentials for auth-related Bash commands.
 
-When a Bash command involves SSH, SCP, Incus, or other auth-related
-operations, check the reference store and network topology for matching
-credentials and inject them so the model doesn't guess.
+When a Bash command involves SSH, SCP, Incus, or other auth-related operations,
+check the reference store and network topology for matching entries and point
+the model at them so it doesn't guess.
 
-Reads hook input from stdin as JSON:
-  {"tool_name": "Bash", "tool_input": {"command": "..."}, ...}
-
-Output (stdout): credential hints injected into conversation.
-Exit 0 always — this is advisory, never blocks.
+Privacy contract: this hook POINTS at credentials, it does not reveal them. It
+surfaces reference-store matches by their CONCEPT (label) name only — never the
+body, which holds the raw ``Value:`` secret — and tells the model to retrieve
+them via the ``reference_lookup`` MCP tool (masked, audited). Network-topology
+hints are scrubbed of any inline secret shapes. Output travels on the documented
+PreToolUse ``hookSpecificOutput.additionalContext`` JSON channel (plain stdout
+does not reach the model on PreToolUse). Exit 0 always — advisory, never blocks.
 """
 
 from __future__ import annotations
@@ -45,9 +47,15 @@ SRC_DIR = REPO_DIR / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
+# Self-locate the hooks dir so the shared helpers resolve as a script.
+_HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+from hook_input import field, read_payload  # noqa: E402
+from secret_scrub import scrub  # noqa: E402
+
 _NETWORK_TOPOLOGY = (
-    Path.home()
-    / ".claude/projects/-home-ubuntu-genesis/memory/reference_network_topology.md"
+    Path.home() / ".claude/projects/-home-ubuntu-genesis/memory/reference_network_topology.md"
 )
 
 
@@ -55,6 +63,7 @@ def _genesis_db_path() -> Path:
     """Resolve DB path via genesis.env (works in worktrees)."""
     try:
         import importlib
+
         return importlib.import_module("genesis.env").genesis_db_path()
     except Exception:
         return REPO_DIR / "data" / "genesis.db"  # fallback
@@ -73,45 +82,46 @@ def _extract_targets(command: str) -> list[str]:
     return targets
 
 
-def _search_reference_store(targets: list[str]) -> list[str]:
-    """Query knowledge_units for reference entries matching targets."""
+def _reference_concept_hits(targets: list[str]) -> list[str]:
+    """CONCEPT (label) names of reference entries matching any target.
+
+    Never returns bodies — a reference body holds the raw ``Value:`` secret.
+    The model is pointed at the ``reference_lookup`` MCP tool (masked, audited)
+    instead of having the secret injected into the transcript.
+    """
     db_path = _genesis_db_path()
     if not db_path.exists():
         return []
 
-    hints = []
+    concepts: list[str] = []
     try:
-        conn = sqlite3.connect(str(db_path), timeout=2)
-        conn.execute("PRAGMA query_only = ON")
-        conn.row_factory = sqlite3.Row
+        # mode=ro is WAL-aware read-only (immutable=1 would miss un-checkpointed
+        # writes); query_only is belt-and-suspenders against any write.
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2)
         try:
+            conn.execute("PRAGMA query_only = ON")
+            conn.row_factory = sqlite3.Row
             for target in targets:
                 rows = conn.execute(
-                    "SELECT concept, body FROM knowledge_units "
+                    "SELECT DISTINCT concept FROM knowledge_units "
                     "WHERE project_type = 'reference' "
                     "AND (body LIKE ? OR concept LIKE ?) "
                     "LIMIT 3",
                     (f"%{target}%", f"%{target}%"),
                 ).fetchall()
                 for row in rows:
-                    body = row["body"] or ""
-                    # Extract the most useful line (the one with the target)
-                    for line in body.split("\n"):
-                        if target in line and len(line.strip()) > 10:
-                            hints.append(line.strip()[:200])
-                            break
-                    else:
-                        if body:
-                            hints.append(body[:200])
+                    concept = (row["concept"] or "").strip()
+                    if concept:
+                        concepts.append(concept)
         finally:
             conn.close()
     except Exception:
         pass
-    return hints
+    return concepts
 
 
 def _search_network_topology(targets: list[str]) -> list[str]:
-    """Search the network topology reference for target info."""
+    """Search the network topology reference for target info (secret-scrubbed)."""
     if not _NETWORK_TOPOLOGY.exists():
         return []
 
@@ -121,10 +131,21 @@ def _search_network_topology(targets: list[str]) -> list[str]:
         for target in targets:
             for line in content.split("\n"):
                 if target in line and len(line.strip()) > 5:
-                    hints.append(line.strip()[:200])
+                    hints.append(scrub(line.strip()[:200]))
     except Exception:
         pass
     return hints
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        norm = item.strip()
+        if norm and norm not in seen:
+            seen.add(norm)
+            out.append(norm)
+    return out
 
 
 def main() -> None:
@@ -132,14 +153,8 @@ def main() -> None:
     if os.environ.get("GENESIS_CC_SESSION") == "1":
         return
 
-    try:
-        raw = sys.stdin.read()
-        hook_input = json.loads(raw) if raw.strip() else {}
-    except (json.JSONDecodeError, OSError):
-        return
-
-    tool_input = hook_input.get("tool_input", {})
-    command = tool_input.get("command", "")
+    payload = read_payload()
+    command = field(payload, "command")
 
     if not command or not _is_auth_command(command):
         return
@@ -148,23 +163,34 @@ def main() -> None:
     if not targets:
         return
 
-    # Check both sources
-    ref_hints = _search_reference_store(targets)
-    topo_hints = _search_network_topology(targets)
+    concept_hits = _dedupe(_reference_concept_hits(targets))
+    topo_hints = _dedupe(_search_network_topology(targets))
 
-    all_hints = []
-    seen = set()
-    for hint in ref_hints + topo_hints:
-        normalized = hint.strip()
-        if normalized and normalized not in seen:
-            seen.add(normalized)
-            all_hints.append(normalized)
+    lines: list[str] = []
+    if concept_hits:
+        lines.append(
+            "Stored credentials/access info exist in the reference store for: "
+            + ", ".join(concept_hits[:5])
+            + ". Retrieve them with the reference_lookup MCP tool — do NOT guess "
+            "or reuse values from history."
+        )
+    if topo_hints:
+        lines.append("Network topology notes for the target(s):")
+        lines.extend(f"  {hint}" for hint in topo_hints[:5])
 
-    if all_hints:
-        print("[Credential] Found stored access info for target:")
-        for hint in all_hints[:5]:
-            print(f"  {hint}")
-        sys.stdout.flush()
+    if not lines:
+        return
+
+    context = "[Credential surface] " + "\n".join(lines)
+    json.dump(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": context,
+            }
+        },
+        sys.stdout,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/edit_verify_advisory.py
+++ b/scripts/hooks/edit_verify_advisory.py
@@ -75,12 +75,14 @@ def _git_baseline(path: Path) -> tuple[str | None, bool]:
     """Committed (HEAD) contents of ``path``, as ``(baseline, git_ok)``.
 
     - ``(text, True)`` — the file has a committed blob.
-    - ``(None, True)`` — git RAN and the file has no committed baseline to
-      disturb: a new/untracked file, or a path outside any git repo (both exit
-      non-zero without erroring).
-    - ``(None, False)`` — git itself FAILED (timeout / missing binary). The
-      caller must NOT assume "no baseline" here — the file might be a dirty
-      tracked file — so it fails conservative.
+    - ``(None, True)`` — git RAN and there is genuinely no committed baseline to
+      disturb: a new/untracked file, a path outside any git repo, or a repo with
+      no commits yet. Recognised by git's benign "not in HEAD" / "not a git
+      repository" / "unknown revision" messages.
+    - ``(None, False)`` — git FAILED (timeout / missing binary) OR exited
+      non-zero for any OTHER reason (a corrupt/locked repo, permission error).
+      The caller must NOT assume "no baseline" — the file might be a dirty
+      tracked file we simply couldn't read — so it fails conservative.
 
     ``git show HEAD:./<name>`` resolves the blob relative to the file's own
     directory, so it works in worktrees and subdirectories alike."""
@@ -95,7 +97,19 @@ def _git_baseline(path: Path) -> tuple[str | None, bool]:
         return (None, False)
     if proc.returncode == 0:
         return (proc.stdout, True)
-    return (None, True)
+    # Non-zero: only treat as "no baseline (safe to format)" for the benign
+    # cases git reports explicitly. Any other fatal exit (corrupt/locked repo,
+    # permissions) is UNSAFE — a tracked file may exist but be unreadable.
+    stderr = (proc.stderr or "").lower()
+    benign = (
+        "does not exist in" in stderr  # new path, not in HEAD
+        or "exists on disk, but not in" in stderr  # untracked file
+        or "not a git repository" in stderr  # outside a repo
+        or "unknown revision" in stderr  # no commits yet
+        or "ambiguous argument" in stderr  # HEAD unborn
+        or "bad revision" in stderr
+    )
+    return (None, True) if benign else (None, False)
 
 
 def _baseline_status(ruff: Path, path: Path) -> tuple[bool, bool]:

--- a/scripts/hooks/edit_verify_advisory.py
+++ b/scripts/hooks/edit_verify_advisory.py
@@ -61,6 +61,75 @@ def _run(ruff: Path, *args: str) -> subprocess.CompletedProcess:
     )
 
 
+def _run_stdin(ruff: Path, args: list[str], stdin_text: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603 - fixed venv binary, no shell
+        [str(ruff), *args],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=_RUFF_TIMEOUT_S,
+    )
+
+
+def _git_baseline(path: Path) -> tuple[str | None, bool]:
+    """Committed (HEAD) contents of ``path``, as ``(baseline, git_ok)``.
+
+    - ``(text, True)`` — the file has a committed blob.
+    - ``(None, True)`` — git RAN and the file has no committed baseline to
+      disturb: a new/untracked file, or a path outside any git repo (both exit
+      non-zero without erroring).
+    - ``(None, False)`` — git itself FAILED (timeout / missing binary). The
+      caller must NOT assume "no baseline" here — the file might be a dirty
+      tracked file — so it fails conservative.
+
+    ``git show HEAD:./<name>`` resolves the blob relative to the file's own
+    directory, so it works in worktrees and subdirectories alike."""
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", "-C", str(path.parent), "show", f"HEAD:./{path.name}"],
+            capture_output=True,
+            text=True,
+            timeout=_RUFF_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (None, False)
+    if proc.returncode == 0:
+        return (proc.stdout, True)
+    return (None, True)
+
+
+def _baseline_status(ruff: Path, path: Path) -> tuple[bool, bool]:
+    """Whether each whole-file mutation is safe to run without reflowing
+    unrelated legacy lines, decided from the COMMITTED baseline.
+
+    Returns ``(safe_format, safe_fix)``:
+
+    - git failed (couldn't read a baseline that might exist) → ``(False, False)``:
+      conservative — never reflow a possibly-dirty tracked file on a transient
+      git error.
+    - No committed baseline (new / untracked / outside a repo) → ``(True, True)``:
+      nothing legacy to disturb.
+    - Otherwise ``ruff format`` is safe only if the baseline is already
+      format-clean, and ``ruff check --fix`` only if the baseline is already
+      lint-clean — then the mutation can touch only the region THIS edit
+      changed. (The repo enforces ``ruff check`` in CI but not ``ruff format``,
+      so the common case is lint-clean-but-format-dirty: the autofix still runs,
+      the whole-file reflow does not.)
+    - ruff-stdin error → ``(False, False)`` (skip mutation; advisory still runs).
+    """
+    baseline, git_ok = _git_baseline(path)
+    if not git_ok:
+        return (False, False)
+    if baseline is None:
+        return (True, True)
+    try:
+        fmt = _run_stdin(ruff, ["format", "--check", "--stdin-filename", str(path), "-"], baseline)
+        chk = _run_stdin(ruff, ["check", "--stdin-filename", str(path), "-"], baseline)
+    except (OSError, subprocess.SubprocessError):
+        return (False, False)
+    return (fmt.returncode == 0, chk.returncode == 0)
+
+
 def _process(data: dict) -> None:
     if data.get("tool_name") not in ("Edit", "Write"):
         return
@@ -77,9 +146,18 @@ def _process(data: dict) -> None:
     if ruff is None:
         return
 
-    # Same mutations the old inline hook performed, in the same order.
-    _run(ruff, "format", "--quiet", str(path))
-    _run(ruff, "check", "--fix", "--quiet", str(path))
+    # Whole-file ``ruff format`` / ``check --fix`` reflow the ENTIRE file, so on
+    # a file whose committed baseline is not already ruff-clean they rewrite
+    # unrelated legacy lines — inflating the PR diff and colliding with a
+    # concurrent worktree editing the same file. Gate each mutation on the
+    # baseline being clean for THAT tool, so a mutation can only touch the
+    # region this edit changed. New / non-repo files have no baseline to disturb
+    # and are formatted freely. The advisory below always runs regardless.
+    safe_format, safe_fix = _baseline_status(ruff, path)
+    if safe_format:
+        _run(ruff, "format", "--quiet", str(path))
+    if safe_fix:
+        _run(ruff, "check", "--fix", "--quiet", str(path))
 
     # What remains after autofix is what the model should hear about.
     result = _run(ruff, "check", "--output-format", "concise", str(path))
@@ -87,10 +165,7 @@ def _process(data: dict) -> None:
         return
     diagnostics = [ln for ln in result.stdout.splitlines() if ln.strip()]
     # Drop ruff's "Found N errors" / fix-hint summary lines.
-    diagnostics = [
-        ln for ln in diagnostics
-        if not ln.startswith(("Found ", "[*]", "No fixes"))
-    ]
+    diagnostics = [ln for ln in diagnostics if not ln.startswith(("Found ", "[*]", "No fixes"))]
     if not diagnostics:
         return
 

--- a/scripts/hooks/secret_scrub.py
+++ b/scripts/hooks/secret_scrub.py
@@ -67,10 +67,12 @@ _CREDENTIAL_TOKEN_PATTERN = re.compile(
 )
 
 # password/passphrase/pin values — keep the label, redact the value. A quoted
-# value is captured whole (quotes let a password contain spaces, e.g.
-# `password: "hunter 2 pw"`); an unquoted value stops at whitespace/separator.
+# value is captured whole (the quote alternatives let the value contain spaces);
+# an unquoted value stops at whitespace/separator. The left anchor is
+# ``(?<![A-Za-z])`` (not ``\b``) so an underscore-joined label still matches —
+# e.g. the ``DB_PASSWORD`` form has no word boundary between ``_`` and ``P``.
 _SINGLE_CREDENTIAL_PATTERN = re.compile(
-    r"\b(?:password|pass(?:word)?|pwd|passphrase|passcode|pin)"
+    r"(?<![A-Za-z])(?:password|pass(?:word)?|pwd|passphrase|passcode|pin)"
     r"\s*(?:is\s+|[:=]\s*)"
     r"(?P<value>\"[^\"]*\"|'[^']*'|[^\s,;]{4,})",
     re.IGNORECASE,
@@ -84,11 +86,14 @@ _URL_CREDENTIAL_PATTERN = re.compile(
 )
 
 # .env-style UPPER_SNAKE=value. The bare pattern over-redacts (PYTHONPATH=…,
-# EDITOR=…), so it is gated to keys whose NAME signals a secret.
+# EDITOR=…), so it is gated to keys whose NAME signals a secret. A quoted value
+# is captured whole (so a multi-word secret like KEY='a b c' is not left with
+# its tail exposed after the first space); an unquoted value is a 6+ run of
+# non-space so short non-secret values aren't touched.
 _ENV_ASSIGNMENT_PATTERN = re.compile(
     r"(?P<key>[A-Z][A-Z0-9_]{2,})"
     r"(?P<sep>\s*=\s*)"
-    r"(?P<val>[^\s]{6,})",
+    r"(?P<val>\"[^\"]*\"|'[^']*'|[^\s]{6,})",
 )
 _SECRET_KEY_HINT = re.compile(
     r"KEY|SECRET|TOKEN|PASSWORD|PASSWD|PASS|AUTH|API|CRED|PRIVATE", re.IGNORECASE

--- a/scripts/hooks/secret_scrub.py
+++ b/scripts/hooks/secret_scrub.py
@@ -66,16 +66,19 @@ _CREDENTIAL_TOKEN_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# password/passphrase/pin values — keep the label, redact the value.
+# password/passphrase/pin values — keep the label, redact the value. A quoted
+# value is captured whole (quotes let a password contain spaces, e.g.
+# `password: "hunter 2 pw"`); an unquoted value stops at whitespace/separator.
 _SINGLE_CREDENTIAL_PATTERN = re.compile(
     r"\b(?:password|pass(?:word)?|pwd|passphrase|passcode|pin)"
     r"\s*(?:is\s+|[:=]\s*)"
-    r"(?P<value>[^\s,;]{4,})",
+    r"(?P<value>\"[^\"]*\"|'[^']*'|[^\s,;]{4,})",
     re.IGNORECASE,
 )
 
-# Credentials embedded in a URL userinfo: scheme://user:PASSWORD@host.
-# Only fires when an ``@`` follows, so ``host:port/path`` URLs never match.
+# Credentials embedded in a URL's userinfo section (the user/password pair that
+# can precede an "@" host separator). Only fires when an "@" follows, so a plain
+# host-and-port URL never matches.
 _URL_CREDENTIAL_PATTERN = re.compile(
     r"(?P<pre>[a-zA-Z][a-zA-Z0-9+.\-]*://[^:/@\s]+:)(?P<pw>[^@/\s]+)(?P<at>@)",
 )

--- a/scripts/hooks/secret_scrub.py
+++ b/scripts/hooks/secret_scrub.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Stdlib-only credential/secret scrubber for CC hooks.
+
+Hooks that persist tool activity (session telemetry, audit trails) can
+incidentally capture secrets — a ``cat secrets.env``, an ``export API_KEY=…``,
+a token echoed in command output. Once such text lands in a per-session JSONL
+or the DB it flows into memory extraction and proactive recall, i.e. it leaks
+into places with a much longer life than the transcript. This module redacts
+the high-confidence secret shapes BEFORE any such capture.
+
+Design constraints:
+- **Stdlib only, import-light.** Hooks run on a <50ms budget and must not
+  import ``genesis`` (heavy) or touch the network. So the detection patterns
+  are copied from ``src/genesis/memory/reference_extraction.py`` rather than
+  imported. Keep the two in rough sync — this file favors RECALL (redact a
+  little too eagerly) because a missed secret is worse than a redacted
+  non-secret in low-stakes telemetry, whereas the extraction classifier favors
+  precision (it fabricates references on false positives).
+- **Fail-safe, never crash.** ``scrub`` returns a fully-withheld placeholder if
+  its own regex work raises, never the raw input; ``is_secret_path`` /
+  ``command_touches_secret`` return conservative booleans.
+- **One secret-filename vocabulary.** ``is_secret_path`` is the single source of
+  truth; ``command_touches_secret`` reuses it (tokenizes the command and asks
+  ``is_secret_path`` per token) so the two can never drift apart.
+
+Two layers callers combine:
+1. ``is_secret_path`` / ``command_touches_secret`` — flag inputs whose *bodies*
+   are secret by nature (``.env``, ``*.pem``, ``id_ed25519``, ``cat secrets``),
+   so the caller can skip capturing the body entirely.
+2. ``scrub`` — redact inline secret shapes from whatever text IS captured.
+"""
+
+from __future__ import annotations
+
+import re
+
+_REDACTED = "[REDACTED]"
+
+# ── Detection patterns (mirror of reference_extraction.py) ───────────────────
+
+# Known key prefixes — format-only, near-certain real credentials. The whole
+# match is the secret, so it is redacted wholesale.
+_KNOWN_KEY_PREFIX_PATTERN = re.compile(
+    r"(?:"
+    r"ghp_[A-Za-z0-9]{30,}"  # GitHub personal access token
+    r"|gho_[A-Za-z0-9]{30,}"  # GitHub OAuth token
+    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI / Anthropic
+    r"|xoxb-[A-Za-z0-9\-]{20,}"  # Slack bot token
+    r"|xoxp-[A-Za-z0-9\-]{20,}"  # Slack user token
+    r"|AKIA[A-Z0-9]{12,}"  # AWS access key id
+    r"|AIza[A-Za-z0-9_\-]{30,}"  # Google API key
+    r"|di-[A-Za-z0-9]{20,}"  # DeepInfra
+    r")",
+)
+
+# Labeled API/access/secret tokens — keep the label, redact the value.
+# ``secret[_\s-]?access[_\s-]?key`` is listed explicitly (before the shorter
+# ``secret[_\s-]?key``) so the AWS secret-key label is caught.
+_CREDENTIAL_TOKEN_PATTERN = re.compile(
+    # (?<![A-Za-z]) (not \b) so an underscore-joined prefix still matches, e.g.
+    # the ``aws_secret_access_key`` form used in ~/.aws/credentials.
+    r"(?<![A-Za-z])(?:api[_\s-]?key|access[_\s-]?token|bearer[_\s-]?token|"
+    r"secret[_\s-]?access[_\s-]?key|secret[_\s-]?key|auth[_\s-]?token|"
+    r"refresh[_\s-]?token|api[_\s-]?secret|private[_\s-]?key)"
+    r"\s*(?:is\s+|[:=]\s*)(?P<token>[A-Za-z0-9_\-\./+]{16,})",
+    re.IGNORECASE,
+)
+
+# password/passphrase/pin values — keep the label, redact the value.
+_SINGLE_CREDENTIAL_PATTERN = re.compile(
+    r"\b(?:password|pass(?:word)?|pwd|passphrase|passcode|pin)"
+    r"\s*(?:is\s+|[:=]\s*)"
+    r"(?P<value>[^\s,;]{4,})",
+    re.IGNORECASE,
+)
+
+# Credentials embedded in a URL userinfo: scheme://user:PASSWORD@host.
+# Only fires when an ``@`` follows, so ``host:port/path`` URLs never match.
+_URL_CREDENTIAL_PATTERN = re.compile(
+    r"(?P<pre>[a-zA-Z][a-zA-Z0-9+.\-]*://[^:/@\s]+:)(?P<pw>[^@/\s]+)(?P<at>@)",
+)
+
+# .env-style UPPER_SNAKE=value. The bare pattern over-redacts (PYTHONPATH=…,
+# EDITOR=…), so it is gated to keys whose NAME signals a secret.
+_ENV_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<key>[A-Z][A-Z0-9_]{2,})"
+    r"(?P<sep>\s*=\s*)"
+    r"(?P<val>[^\s]{6,})",
+)
+_SECRET_KEY_HINT = re.compile(
+    r"KEY|SECRET|TOKEN|PASSWORD|PASSWD|PASS|AUTH|API|CRED|PRIVATE", re.IGNORECASE
+)
+
+# Files whose CONTENTS are secret by nature. ONE vocabulary, anchored per path
+# segment; reused by command_touches_secret via tokenisation.
+_SECRET_FILENAME_CORE = (
+    r"\.env(?:\.[\w.-]+)?"  # noqa: S105 - a regex of secret FILENAMES, not a password
+    r"|secrets?\.env"
+    r"|[\w.-]*\.pem"
+    r"|[\w.-]*\.key"
+    r"|[\w.-]*\.(?:p12|pfx|jks)"
+    r"|[\w.-]*\.token"
+    r"|id_(?:rsa|ed25519|ecdsa|dsa)"
+    r"|\.netrc|\.pgpass|\.htpasswd|\.npmrc|\.pypirc|\.git-credentials"
+    r"|\.kube/config"
+    r"|credentials(?:\.json)?"
+)
+_SECRET_FILE_RE = re.compile(rf"(?:^|/)(?:{_SECRET_FILENAME_CORE})$", re.IGNORECASE)
+# Non-secret templates that share a secret-ish name.
+_TEMPLATE_SUFFIX_RE = re.compile(r"\.(?:example|sample|template|dist)$", re.IGNORECASE)
+# Shell metacharacters that separate command tokens.
+_CMD_TOKEN_SPLIT = re.compile(r"[\s;|&()<>'\"=]+")
+
+
+def _redact_value_group(pattern: re.Pattern, text: str, group: str) -> str:
+    """Replace only the captured ``group`` (the secret value) within each match,
+    by SPAN — never a substring search, which could redact a label that happens
+    to equal the value (``password: password``)."""
+
+    def _repl(m: re.Match) -> str:
+        start, end = m.span(group)
+        base = m.start()
+        return m.group(0)[: start - base] + _REDACTED + m.group(0)[end - base :]
+
+    return pattern.sub(_repl, text)
+
+
+def _redact_env(text: str) -> str:
+    def _repl(m: re.Match) -> str:
+        if _SECRET_KEY_HINT.search(m.group("key")):
+            return f"{m.group('key')}{m.group('sep')}{_REDACTED}"
+        return m.group(0)
+
+    return _ENV_ASSIGNMENT_PATTERN.sub(_repl, text)
+
+
+def scrub(text: str) -> str:
+    """Redact high-confidence secret shapes from ``text``.
+
+    Fail-safe: on any internal error returns a placeholder, never the raw input.
+    """
+    if not text:
+        return text
+    try:
+        text = _KNOWN_KEY_PREFIX_PATTERN.sub(_REDACTED, text)
+        text = _redact_value_group(_CREDENTIAL_TOKEN_PATTERN, text, "token")
+        text = _redact_value_group(_SINGLE_CREDENTIAL_PATTERN, text, "value")
+        text = _redact_value_group(_URL_CREDENTIAL_PATTERN, text, "pw")
+        text = _redact_env(text)
+        return text
+    except Exception:  # noqa: BLE001 - never leak raw text on a scrub failure
+        return "[scrub-error: content withheld]"
+
+
+def is_secret_path(path: str) -> bool:
+    """True if ``path`` names a file whose contents are secret by nature."""
+    if not path:
+        return False
+    base = path.rsplit("/", 1)[-1]
+    if _TEMPLATE_SUFFIX_RE.search(base):
+        return False
+    if _SECRET_FILE_RE.search(path):
+        return True
+    low = base.lower()
+    return "secret" in low or "credential" in low
+
+
+def command_touches_secret(command: str) -> bool:
+    """True if any token of a shell command names a secret-bearing file — its
+    output or edit body is likely to contain secrets, so the caller should not
+    capture it. Tokenises on shell metacharacters and reuses ``is_secret_path``
+    so the two never diverge."""
+    if not command:
+        return False
+    return any(tok and is_secret_path(tok) for tok in _CMD_TOKEN_SPLIT.split(command))
+
+
+def scrub_info(info: dict) -> dict:
+    """Scrub every string value in a flat dict (in place) and return it."""
+    for k, v in list(info.items()):
+        if isinstance(v, str):
+            info[k] = scrub(v)
+    return info

--- a/scripts/hooks/session_observer_hook.py
+++ b/scripts/hooks/session_observer_hook.py
@@ -22,6 +22,15 @@ from pathlib import Path
 if os.environ.get("GENESIS_CC_SESSION") == "1":
     sys.exit(0)
 
+# Self-locate so secret_scrub resolves whether run as a script or imported.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from secret_scrub import (  # noqa: E402
+    command_touches_secret,
+    is_secret_path,
+    scrub,
+    scrub_info,
+)
+
 # Tools that produce low-signal observations — not worth capturing
 _SKIP_TOOLS = frozenset(
     {
@@ -56,17 +65,26 @@ _MAX_FILE_BYTES = 500_000  # ~500KB, roughly 200-300 observations
 def _extract_key_info(tool_name: str, tool_input: dict) -> dict:
     """Extract the most useful information from tool input by tool type."""
     info: dict = {}
+    if _is_credential_tool(tool_name):
+        # reference_store args ARE the credential — never capture them.
+        return {"note": "[redacted: credential-store tool]"}
     if tool_name in ("Read", "Write"):
         info["file_path"] = tool_input.get("file_path", "")
     elif tool_name == "Edit":
-        info["file_path"] = tool_input.get("file_path", "")
-        # Capture what changed for richer LLM context
+        fp = tool_input.get("file_path", "")
+        info["file_path"] = fp
+        # Capture what changed for richer LLM context — but the before/after
+        # bodies of a secret-bearing file ARE secrets, so never persist them.
         old = tool_input.get("old_string", "")
         new = tool_input.get("new_string", "")
-        if old:
-            info["old_string"] = old[:150]
-        if new:
-            info["new_string"] = new[:150]
+        if is_secret_path(fp):
+            if old or new:
+                info["edit"] = "[redacted: secret-bearing file]"
+        else:
+            if old:
+                info["old_string"] = old[:150]
+            if new:
+                info["new_string"] = new[:150]
     elif tool_name == "Bash":
         cmd = tool_input.get("command", "")
         info["command"] = cmd[:500] if cmd else ""
@@ -88,7 +106,8 @@ def _extract_key_info(tool_name: str, tool_input: dict) -> dict:
                 info[key] = val[:200]
             elif isinstance(val, (int, float, bool)):
                 info[key] = val
-    return info
+    # Redact inline secret shapes from every captured string value.
+    return scrub_info(info)
 
 
 def _truncate_output(output_raw: str) -> str:
@@ -96,6 +115,34 @@ def _truncate_output(output_raw: str) -> str:
     if not output_raw or len(output_raw) <= _OUTPUT_CAP:
         return output_raw or ""
     return output_raw[:_OUTPUT_CAP] + f"\n... [truncated, {len(output_raw)} total chars]"
+
+
+def _is_credential_tool(tool_name: str) -> bool:
+    """Reference-store MCP tools carry credentials by design — their args and
+    results should not be captured into telemetry at all."""
+    return tool_name.lower().endswith(("reference_store", "reference_lookup", "reference_export"))
+
+
+def _summarize_output(tool_name: str, tool_input: dict, output_raw: str) -> str:
+    """Capture tool output for note-taking without persisting secret bodies.
+
+    Reading/editing/searching a secret-bearing path, a Bash command that reads
+    one, or a reference-store tool puts raw secrets in the result — skip
+    capturing it. Whatever IS captured is still scrubbed for inline secret
+    shapes (a token echoed in output, an ``export API_KEY=…``), since this text
+    flows on into memory extraction and proactive recall."""
+    if not output_raw:
+        return ""
+    ti = tool_input if isinstance(tool_input, dict) else {}
+    path = ti.get("file_path", "") or ti.get("path", "")
+    cmd = ti.get("command", "")
+    if tool_name in ("Read", "Edit", "Write", "Grep", "Glob") and is_secret_path(path):
+        return "[skipped: secret-bearing path]"
+    if tool_name == "Bash" and command_touches_secret(cmd):
+        return "[skipped: command reads a secret-bearing file]"
+    if _is_credential_tool(tool_name):
+        return "[skipped: credential-store tool]"
+    return scrub(_truncate_output(output_raw))
 
 
 def main() -> None:
@@ -139,7 +186,7 @@ def _process(data: dict) -> None:
         "session_id": session_id,
         "tool_name": tool_name,
         "key_info": _extract_key_info(tool_name, tool_input),
-        "output_summary": _truncate_output(output_raw),
+        "output_summary": _summarize_output(tool_name, tool_input, output_raw),
     }
 
     # Append to per-session JSONL file

--- a/tests/test_hooks/test_credential_surface_hook.py
+++ b/tests/test_hooks/test_credential_surface_hook.py
@@ -1,0 +1,106 @@
+"""Tests for scripts/hooks/credential_surface_hook.py (PreToolUse Bash).
+
+The hook's job is to POINT at stored credentials, never reveal them. These lock
+in the privacy contract post-fix: reference matches surface by CONCEPT name only
+(never the body's raw ``Value:`` secret), the model is directed to
+``reference_lookup``, and output travels on the PreToolUse
+``hookSpecificOutput.additionalContext`` channel (not plain stdout, which CC
+drops on PreToolUse).
+
+A throwaway SQLite DB (pointed at via ``GENESIS_DB_PATH``) stands in for the
+reference store, so the live store is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent.parent
+HOOK = REPO_DIR / "scripts" / "hooks" / "credential_surface_hook.py"
+
+_SECRET_BODY = "Value: supersecretpassword123\nHost: 192.0.2.10"
+_CONCEPT = "example-service SSH access"
+
+
+def _make_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE knowledge_units (concept TEXT, body TEXT, project_type TEXT)")
+    conn.execute(
+        "INSERT INTO knowledge_units (concept, body, project_type) VALUES (?, ?, 'reference')",
+        (_CONCEPT, _SECRET_BODY),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _run(command: str, db: Path | None) -> subprocess.CompletedProcess:
+    env = {**os.environ}
+    env.pop("GENESIS_CC_SESSION", None)
+    if db is not None:
+        env["GENESIS_DB_PATH"] = str(db)
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}, "session_id": "t"}
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _context(proc: subprocess.CompletedProcess) -> str | None:
+    if not proc.stdout.strip():
+        return None
+    return json.loads(proc.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+def test_points_at_concept_never_body(tmp_path: Path):
+    db = tmp_path / "ref.db"
+    _make_db(db)
+    proc = _run("ssh deploy@192.0.2.10", db)
+    ctx = _context(proc)
+    assert ctx is not None
+    assert _CONCEPT in ctx  # the label surfaces
+    assert "reference_lookup" in ctx  # points at the masked retrieval tool
+    assert "supersecretpassword123" not in ctx  # the body secret NEVER surfaces
+    assert "Value:" not in ctx
+
+
+def test_output_uses_additionalcontext_channel(tmp_path: Path):
+    db = tmp_path / "ref.db"
+    _make_db(db)
+    proc = _run("scp file deploy@192.0.2.10:/tmp", db)
+    assert proc.returncode == 0
+    out = json.loads(proc.stdout)
+    assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert "additionalContext" in out["hookSpecificOutput"]
+
+
+def test_no_match_no_output(tmp_path: Path):
+    db = tmp_path / "ref.db"
+    _make_db(db)
+    proc = _run("ssh nobody@10.10.10.10", db)  # no stored target
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_non_auth_command_ignored(tmp_path: Path):
+    db = tmp_path / "ref.db"
+    _make_db(db)
+    proc = _run("ls -la /home", db)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_missing_db_fails_open(tmp_path: Path):
+    proc = _run("ssh deploy@192.0.2.10", tmp_path / "does_not_exist.db")
+    assert proc.returncode == 0
+    # No reference store → no reference pointer (topology file may or may not
+    # exist on the box; either way, never a crash and never a raw secret).
+    assert "supersecretpassword123" not in (proc.stdout or "")

--- a/tests/test_hooks/test_edit_verify_advisory.py
+++ b/tests/test_hooks/test_edit_verify_advisory.py
@@ -10,6 +10,7 @@ on every malformed or out-of-scope input.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -193,7 +194,6 @@ def test_git_unavailable_fails_safe(tmp_path: Path):
     payload = {"tool_name": "Edit", "tool_input": {"file_path": str(f)}, "session_id": "t"}
     # A PATH with no `git` on it → subprocess FileNotFoundError inside the hook.
     # ruff is resolved via sys.executable's dir (absolute), so it still runs.
-    import os
 
     env = {**os.environ, "PATH": "/nonexistent-dir"}
     proc = subprocess.run(

--- a/tests/test_hooks/test_edit_verify_advisory.py
+++ b/tests/test_hooks/test_edit_verify_advisory.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_DIR = Path(__file__).resolve().parent.parent.parent
 HOOK = REPO_DIR / "scripts" / "hooks" / "edit_verify_advisory.py"
 
@@ -116,13 +118,118 @@ def test_malformed_stdin_fails_open():
         assert proc.stdout.strip() == ""
 
 
+# ── Baseline-gated mutation: no whole-file reflow of legacy lines ─────────
+#
+# The mutation (ruff format / check --fix) rewrites the WHOLE file, so on a
+# file whose committed baseline is not already ruff-clean it reflows unrelated
+# legacy lines — inflating the PR diff and colliding with concurrent worktrees.
+# These lock in that each mutation runs ONLY when the committed baseline is
+# already clean for that tool (so it can touch only the just-edited region),
+# while new / non-repo files still format freely.
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def gitrepo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(r, "config", "user.email", "t@e.st")
+    _git(r, "config", "user.name", "tester")
+    (r / "seed.py").write_text("seed = 1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "seed")
+    return r
+
+
+def test_format_dirty_baseline_not_reflowed(gitrepo: Path):
+    """Committed file is format-dirty (but lint-clean). An edit must NOT trigger
+    a whole-file `ruff format` — the messy legacy lines stay byte-for-byte."""
+    f = gitrepo / "legacy.py"
+    messy = "x = {'a':1,'b':2}\ny = [1,2,  3]\n"  # ruff format WOULD rewrite this
+    f.write_text(messy)
+    _git(gitrepo, "add", "-A")
+    _git(gitrepo, "commit", "-qm", "legacy")
+    f.write_text(messy + "\n\ndef added():\n    return 1\n")  # the edit
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    after = f.read_text()
+    assert "{'a':1,'b':2}" in after  # legacy dict untouched (no reflow)
+    assert "[1,2,  3]" in after
+
+
+def test_clean_baseline_edit_region_formatted(gitrepo: Path):
+    """Committed file is fully clean → formatting only touches the just-added
+    line, which is safe (no legacy to disturb) → mutation runs."""
+    f = gitrepo / "clean.py"
+    f.write_text("x = 1\n")
+    _git(gitrepo, "add", "-A")
+    _git(gitrepo, "commit", "-qm", "clean")
+    f.write_text("x = 1\ny = {'a':1}\n")  # add a format-dirty line
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    assert '{"a": 1}' in f.read_text()  # clean baseline → formatted
+
+
+def test_new_untracked_file_formatted(gitrepo: Path):
+    """A file with no committed baseline has nothing legacy to disturb → format."""
+    f = gitrepo / "brand_new.py"
+    f.write_text("y = {'a':1}\n")  # never committed
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    assert '{"a": 1}' in f.read_text()
+
+
+def test_git_unavailable_fails_safe(tmp_path: Path):
+    """S2: if `git` cannot run (missing binary) the baseline is UNKNOWN — a
+    tracked file might be dirty — so the mutation must NOT fire (fail-safe),
+    rather than treating it as a new file and reflowing it."""
+    f = tmp_path / "messy.py"
+    original = "y = {'a':1}\n"  # ruff format WOULD normalize this
+    f.write_text(original)
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": str(f)}, "session_id": "t"}
+    # A PATH with no `git` on it → subprocess FileNotFoundError inside the hook.
+    # ruff is resolved via sys.executable's dir (absolute), so it still runs.
+    import os
+
+    env = {**os.environ, "PATH": "/nonexistent-dir"}
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    assert f.read_text() == original  # NOT reflowed — fail-safe on git error
+
+
+def test_lint_dirty_baseline_autofix_skipped(gitrepo: Path):
+    """Committed file is lint-dirty (unused import) but format-clean → the
+    localized `check --fix` is skipped, so the legacy unused import is NOT
+    auto-removed (that would be an unrelated diff on someone's edit)."""
+    f = gitrepo / "lintbad.py"
+    f.write_text("import os\nx = 1\n")  # F401 unused — lint-dirty, format-clean
+    _git(gitrepo, "add", "-A")
+    _git(gitrepo, "commit", "-qm", "lintbad")
+    f.write_text("import os\nx = 1\ny = 2\n")  # the edit
+    proc = _invoke(str(f))
+    assert proc.returncode == 0
+    assert "import os" in f.read_text()  # autofix skipped → import preserved
+
+
 def test_registered_in_settings_json():
     """The Edit|Write PostToolUse matcher runs THIS script (replacing the old
     inline silent fixer) — one hook, because parallel hooks on the same
     matcher would race the autofix."""
     settings = json.loads((REPO_DIR / ".claude" / "settings.json").read_text())
     entries = [
-        e for e in settings["hooks"]["PostToolUse"]
+        e
+        for e in settings["hooks"]["PostToolUse"]
         if e.get("matcher") in ("Edit|Write", "Write|Edit")
     ]
     commands = [h["command"] for e in entries for h in e["hooks"]]

--- a/tests/test_hooks/test_edit_verify_baseline.py
+++ b/tests/test_hooks/test_edit_verify_baseline.py
@@ -1,0 +1,74 @@
+"""Unit tests for edit_verify_advisory's baseline gating — the git-error branches.
+
+The black-box subprocess tests in test_edit_verify_advisory.py cover the happy
+paths; these monkeypatch subprocess.run to exercise branches that are hard to
+trigger for real: a benign "no committed baseline" exit (safe to format), and a
+FATAL git exit — corrupt/locked repo — which must be treated as UNSAFE (never
+reflow a tracked file we merely failed to read). Codex P2 (#1249).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HOOKS = Path(__file__).resolve().parents[2] / "scripts" / "hooks"
+sys.path.insert(0, str(_HOOKS))
+import edit_verify_advisory as eva  # noqa: E402
+
+_DUMMY_RUFF = Path("/nonexistent/ruff")
+
+
+class _Proc:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _patch_run(monkeypatch, result) -> None:
+    def fake_run(*_a, **_k):
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(eva.subprocess, "run", fake_run)
+
+
+def test_committed_baseline_returns_text(monkeypatch):
+    _patch_run(monkeypatch, _Proc(0, stdout="x = 1\n"))
+    baseline, ok = eva._git_baseline(Path("/repo/f.py"))
+    assert ok is True and baseline == "x = 1\n"
+
+
+def test_benign_new_file_is_safe(monkeypatch):
+    _patch_run(monkeypatch, _Proc(128, stderr="fatal: path 'f.py' does not exist in 'HEAD'"))
+    assert eva._git_baseline(Path("/repo/f.py")) == (None, True)
+    assert eva._baseline_status(_DUMMY_RUFF, Path("/repo/f.py")) == (True, True)
+
+
+def test_not_a_repo_is_safe(monkeypatch):
+    _patch_run(
+        monkeypatch,
+        _Proc(128, stderr="fatal: not a git repository (or any of the parent directories): .git"),
+    )
+    assert eva._git_baseline(Path("/tmp/f.py")) == (None, True)
+
+
+def test_unborn_head_is_safe(monkeypatch):
+    _patch_run(monkeypatch, _Proc(128, stderr="fatal: bad revision 'HEAD'"))
+    assert eva._git_baseline(Path("/repo/f.py")) == (None, True)
+
+
+def test_fatal_repo_error_is_unsafe(monkeypatch):
+    """A corrupt/locked repo exits non-zero with an UNrecognised fatal message —
+    a tracked file may exist but be unreadable, so do NOT reflow."""
+    _patch_run(monkeypatch, _Proc(128, stderr="error: object file .git/objects/ab/cd is empty"))
+    assert eva._git_baseline(Path("/repo/f.py")) == (None, False)
+    assert eva._baseline_status(_DUMMY_RUFF, Path("/repo/f.py")) == (False, False)
+
+
+def test_git_binary_missing_is_unsafe(monkeypatch):
+    _patch_run(monkeypatch, FileNotFoundError("git not found"))
+    assert eva._git_baseline(Path("/repo/f.py")) == (None, False)
+    assert eva._baseline_status(_DUMMY_RUFF, Path("/repo/f.py")) == (False, False)

--- a/tests/test_hooks/test_secret_scrub.py
+++ b/tests/test_hooks/test_secret_scrub.py
@@ -178,3 +178,12 @@ class TestReviewFixes:
     def test_value_equal_to_label_not_mangled(self):
         # N1: span redaction, not first-occurrence substring replace.
         assert s.scrub("password: password") == "password: [REDACTED]"
+
+    def test_quoted_password_with_spaces_fully_redacted(self):
+        # Codex P1: a quoted password/passphrase containing whitespace must be
+        # redacted WHOLE, not just up to the first space.
+        out = s.scrub('password: "hunter 2 correct horse"')
+        assert "hunter" not in out and "horse" not in out and R in out
+        # value words chosen NOT to be substrings of the label ("passphrase").
+        out2 = s.scrub("passphrase = 'zebra quux mango token'")
+        assert "zebra" not in out2 and "mango" not in out2 and R in out2

--- a/tests/test_hooks/test_secret_scrub.py
+++ b/tests/test_hooks/test_secret_scrub.py
@@ -187,3 +187,29 @@ class TestReviewFixes:
         # value words chosen NOT to be substrings of the label ("passphrase").
         out2 = s.scrub("passphrase = 'zebra quux mango token'")
         assert "zebra" not in out2 and "mango" not in out2 and R in out2
+
+    def test_env_quoted_multiword_secret_fully_redacted(self):
+        # Codex P1 (round 2): the env-assignment path must ALSO redact a quoted
+        # multi-word value whole — for secret-hinted keys the password-label
+        # pattern does NOT catch, the env pattern is the only line of defence,
+        # and its value group used to stop at the first space (tail leaked).
+        for line in (
+            "MY_SECRET='correct horse battery'",
+            "AWS_SECRET_ACCESS_KEY='correct horse battery'",
+            "DB_PASSWORD='correct horse battery'",  # no \b between '_' and 'P'
+            'API_TOKEN="alpha bravo charlie"',
+        ):
+            out = s.scrub(line)
+            assert R in out, line
+            assert "horse" not in out and "battery" not in out and "charlie" not in out, line
+
+    def test_underscore_prefixed_password_label_caught(self):
+        # (?<![A-Za-z]) anchor: DB_PASSWORD: <value> free-text form is redacted
+        # even though \b would not match inside the underscore-joined label.
+        out = s.scrub("DB_PASSWORD: hunter2secretvalue")
+        assert R in out and "hunter2secretvalue" not in out
+
+    def test_env_quoted_value_without_secret_hint_preserved(self):
+        # The secret-key-name gate still applies: a quoted value under a benign
+        # key (no KEY/SECRET/TOKEN/… in the name) must NOT be redacted.
+        assert s.scrub("MESSAGE='hello world foo'") == "MESSAGE='hello world foo'"

--- a/tests/test_hooks/test_secret_scrub.py
+++ b/tests/test_hooks/test_secret_scrub.py
@@ -1,0 +1,180 @@
+"""Unit tests for scripts/hooks/secret_scrub.py — the stdlib secret scrubber.
+
+The scrubber protects hook-captured telemetry (session observations, audit
+trails) from persisting secrets, so these lock in BOTH directions: real secret
+shapes are redacted, and benign look-alikes are left intact (over-redaction in
+telemetry is cheap, but redacting normal env vars / paths would gut the notes).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
+import secret_scrub as s  # noqa: E402
+
+R = "[REDACTED]"
+
+
+# ── scrub: real secrets redacted ─────────────────────────────────────────
+
+
+class TestScrubRedacts:
+    def test_github_pat(self):
+        assert R in s.scrub("token=ghp_" + "a" * 36)
+
+    def test_openai_key(self):
+        assert R in s.scrub("key sk-" + "b" * 30)
+
+    def test_aws_akia(self):
+        assert R in s.scrub("AKIA" + "A" * 16)
+
+    def test_google_key(self):
+        assert R in s.scrub("AIza" + "c" * 35)
+
+    def test_slack_token(self):
+        assert R in s.scrub("xoxb-" + "1" * 25)
+
+    def test_labeled_api_key(self):
+        out = s.scrub("api_key: " + "Z" * 20)
+        assert R in out and "api_key" in out.lower()
+
+    def test_password_value(self):
+        out = s.scrub("password: hunter2secret")
+        assert R in out and "hunter2secret" not in out
+
+    def test_passphrase(self):
+        assert "correcthorse" not in s.scrub("passphrase = correcthorsebattery")
+
+    def test_env_secret_assignment(self):
+        out = s.scrub("export API_KEY=sk-" + "d" * 25)
+        assert R in out and "API_KEY" in out
+
+    def test_env_various_secret_keys(self):
+        for key in ("AWS_SECRET_ACCESS_KEY", "DB_PASSWORD", "AUTH_TOKEN", "MY_API_SECRET"):
+            out = s.scrub(f"{key}=verysecretvalue123")
+            assert R in out, f"{key} not redacted"
+
+    def test_token_survives_surrounding_text(self):
+        out = s.scrub("before ghp_" + "a" * 36 + " after")
+        assert "before" in out and "after" in out and R in out
+
+
+# ── scrub: benign look-alikes preserved ──────────────────────────────────
+
+
+class TestScrubPreserves:
+    def test_pythonpath(self):
+        assert s.scrub("PYTHONPATH=/home/x/src") == "PYTHONPATH=/home/x/src"
+
+    def test_editor_env(self):
+        assert s.scrub("EDITOR=/usr/bin/vim") == "EDITOR=/usr/bin/vim"
+
+    def test_ssh_userhost_kept(self):
+        # ssh target is a connection detail, not a secret — the hook needs it.
+        assert s.scrub("ssh deploy@192.0.2.10") == "ssh deploy@192.0.2.10"
+
+    def test_plain_prose(self):
+        txt = "Refactored the retrieval pipeline and fixed the reranker."
+        assert s.scrub(txt) == txt
+
+    def test_empty(self):
+        assert s.scrub("") == ""
+
+
+# ── is_secret_path ───────────────────────────────────────────────────────
+
+
+class TestIsSecretPath:
+    def test_dotenv(self):
+        assert s.is_secret_path("/app/.env")
+
+    def test_secrets_env(self):
+        assert s.is_secret_path("/home/u/.genesis/secrets.env")
+
+    def test_pem(self):
+        assert s.is_secret_path("/certs/server.pem")
+
+    def test_ssh_key(self):
+        assert s.is_secret_path("/home/u/.ssh/id_ed25519")
+
+    def test_credentials_json(self):
+        assert s.is_secret_path("/x/credentials.json")
+
+    def test_name_contains_secret(self):
+        assert s.is_secret_path("/x/my_secret_notes.txt")
+
+    def test_python_file_not_secret(self):
+        assert not s.is_secret_path("/x/module.py")
+
+    def test_env_example_not_secret(self):
+        assert not s.is_secret_path("/x/.env.example")
+        assert not s.is_secret_path("/x/secrets.env.sample")
+
+    def test_empty_not_secret(self):
+        assert not s.is_secret_path("")
+
+
+# ── command_touches_secret ───────────────────────────────────────────────
+
+
+class TestCommandTouchesSecret:
+    def test_cat_secrets(self):
+        assert s.command_touches_secret("cat ~/.genesis/secrets.env")
+
+    def test_source_dotenv(self):
+        assert s.command_touches_secret("source .env && run")
+
+    def test_read_pem(self):
+        assert s.command_touches_secret("openssl x509 -in /certs/key.pem")
+
+    def test_plain_ls_not(self):
+        assert not s.command_touches_secret("ls -la /home")
+
+    def test_git_status_not(self):
+        assert not s.command_touches_secret("git status --short")
+
+
+# ── Round-2: gaps the adversarial review found ───────────────────────────
+
+
+class TestReviewFixes:
+    def test_aws_credentials_file_and_command_agree(self):
+        # S1: the file check and the command check must not diverge.
+        assert s.is_secret_path("/home/u/.aws/credentials")
+        assert s.command_touches_secret("cat ~/.aws/credentials")
+
+    def test_pipe_to_secret_read(self):
+        # N4: a pipe must not hide a secret-file read.
+        assert s.command_touches_secret("grep pw .env|cat")
+
+    def test_extra_secret_file_types(self):
+        # N3: keystores, npm/pypi rc, kube config, generic .token.
+        for p in (
+            "/certs/store.p12",
+            "/certs/store.pfx",
+            "/app/keystore.jks",
+            "/home/u/.npmrc",
+            "/home/u/.pypirc",
+            "/home/u/.kube/config",
+            "/run/session.token",
+        ):
+            assert s.is_secret_path(p), p
+
+    def test_url_embedded_credential_redacted(self):
+        # N2: scheme://user:PASSWORD@host
+        out = s.scrub("DATABASE_URL=postgres://user:s3cr3tpw@db.host/app")
+        assert "s3cr3tpw" not in out and R in out
+
+    def test_host_port_url_not_redacted(self):
+        # No userinfo '@' → not a credential URL, leave intact.
+        assert s.scrub("http://example.com:8080/path") == "http://example.com:8080/path"
+
+    def test_aws_secret_access_key_label(self):
+        out = s.scrub("aws_secret_access_key = wJalrXUtnFEMIK7MDENGbPxRfiCYKEY")
+        assert "wJalrXUtnFEMIK7MDENGbPxRfiCYKEY" not in out and R in out
+
+    def test_value_equal_to_label_not_mangled(self):
+        # N1: span redaction, not first-occurrence substring replace.
+        assert s.scrub("password: password") == "password: [REDACTED]"

--- a/tests/test_hooks/test_session_observer_scrub.py
+++ b/tests/test_hooks/test_session_observer_scrub.py
@@ -1,0 +1,152 @@
+"""Integration tests for scripts/hooks/session_observer_hook.py secret hygiene.
+
+The observer appends tool activity to a per-session JSONL that feeds memory
+extraction + proactive recall — a long-lived sink. These run the hook as a real
+subprocess (the CC contract) with HOME pointed at a temp dir, and assert that
+secret bodies never land in the JSONL: secret-bearing file reads/edits are
+skipped, secret-reading commands are skipped, and inline secret shapes in any
+captured text are redacted. Non-secret activity is still captured in full.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent.parent
+HOOK = REPO_DIR / "scripts" / "hooks" / "session_observer_hook.py"
+
+_SID = "test-scrub-session"
+_TOKEN = "ghp_" + "a" * 36  # a realistic GitHub PAT shape
+
+
+def _run(payload: dict, home: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "HOME": str(home)}
+    env.pop("GENESIS_CC_SESSION", None)  # must not short-circuit
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _observations(home: Path) -> list[dict]:
+    f = home / ".genesis" / "sessions" / _SID / "tool_observations.jsonl"
+    if not f.exists():
+        return []
+    return [json.loads(ln) for ln in f.read_text().splitlines() if ln.strip()]
+
+
+def _raw_jsonl(home: Path) -> str:
+    f = home / ".genesis" / "sessions" / _SID / "tool_observations.jsonl"
+    return f.read_text() if f.exists() else ""
+
+
+def _payload(tool_name: str, tool_input: dict, tool_response) -> dict:
+    return {
+        "tool_name": tool_name,
+        "session_id": _SID,
+        "tool_input": tool_input,
+        "tool_response": tool_response,
+    }
+
+
+def test_read_secret_file_body_not_captured(tmp_path: Path):
+    home = tmp_path
+    body = f"API_KEY=sk-{'x' * 30}\nDB_PASSWORD=hunter2secret"
+    _run(_payload("Read", {"file_path": "/etc/genesis/secrets.env"}, {"content": body}), home)
+    obs = _observations(home)
+    assert obs and obs[-1]["output_summary"] == "[skipped: secret-bearing path]"
+    assert "sk-" + "x" * 30 not in _raw_jsonl(home)
+    assert "hunter2secret" not in _raw_jsonl(home)
+
+
+def test_bash_reading_secret_file_output_skipped(tmp_path: Path):
+    home = tmp_path
+    _run(_payload("Bash", {"command": "cat ~/.genesis/secrets.env"}, f"TOKEN={_TOKEN}"), home)
+    obs = _observations(home)
+    assert obs[-1]["output_summary"] == "[skipped: command reads a secret-bearing file]"
+    assert _TOKEN not in _raw_jsonl(home)
+
+
+def test_inline_token_in_output_redacted(tmp_path: Path):
+    home = tmp_path
+    _run(_payload("Bash", {"command": "echo done"}, f"here is {_TOKEN} in output"), home)
+    obs = _observations(home)
+    assert "[REDACTED]" in obs[-1]["output_summary"]
+    assert _TOKEN not in _raw_jsonl(home)
+
+
+def test_secret_in_command_redacted(tmp_path: Path):
+    home = tmp_path
+    _run(_payload("Bash", {"command": f"export API_KEY=sk-{'z' * 25}"}, "ok"), home)
+    obs = _observations(home)
+    assert "[REDACTED]" in obs[-1]["key_info"]["command"]
+    assert "sk-" + "z" * 25 not in _raw_jsonl(home)
+
+
+def test_edit_secret_file_bodies_not_captured(tmp_path: Path):
+    home = tmp_path
+    _run(
+        _payload(
+            "Edit",
+            {
+                "file_path": "/app/.env",
+                "old_string": "API_KEY=oldsecretvalue",
+                "new_string": "API_KEY=newsecretvalue",
+            },
+            {"success": True},
+        ),
+        home,
+    )
+    ki = _observations(home)[-1]["key_info"]
+    assert ki.get("edit") == "[redacted: secret-bearing file]"
+    assert "old_string" not in ki and "new_string" not in ki
+    assert "oldsecretvalue" not in _raw_jsonl(home)
+
+
+def test_normal_activity_still_captured(tmp_path: Path):
+    home = tmp_path
+    _run(_payload("Bash", {"command": "ls -la"}, "total 8\ndrwxr-xr-x file.py"), home)
+    obs = _observations(home)
+    assert obs[-1]["key_info"]["command"] == "ls -la"
+    assert "file.py" in obs[-1]["output_summary"]
+
+
+def test_grep_over_secret_path_skipped(tmp_path: Path):
+    """N5: Grep results over a secret-bearing path are not captured."""
+    home = tmp_path
+    _run(
+        _payload(
+            "Grep",
+            {"pattern": "KEY", "path": "/home/u/.aws/credentials"},
+            {"matches": [f"KEY={_TOKEN}"]},
+        ),
+        home,
+    )
+    obs = _observations(home)
+    assert obs[-1]["output_summary"] == "[skipped: secret-bearing path]"
+    assert _TOKEN not in _raw_jsonl(home)
+
+
+def test_reference_store_tool_not_captured(tmp_path: Path):
+    """N5: the reference store carries credentials by design — skip args+result."""
+    home = tmp_path
+    _run(
+        _payload(
+            "mcp__genesis-memory__reference_store",
+            {"concept": "prod db", "body": f"password: {_TOKEN}"},
+            {"stored": True, "value": _TOKEN},
+        ),
+        home,
+    )
+    obs = _observations(home)
+    assert obs[-1]["key_info"] == {"note": "[redacted: credential-store tool]"}
+    assert obs[-1]["output_summary"] == "[skipped: credential-store tool]"
+    assert _TOKEN not in _raw_jsonl(home)


### PR DESCRIPTION
## Summary

A re-audit of the Claude Code hook set surfaced a class of issues the original
(block-only) audit missed — hooks that *mutate*, *leak*, or *misfire* rather
than wrongly block. This is the privacy/mutation cluster.

## Changes

- **`edit_verify_advisory` — stop whole-file reflow.** The PostToolUse ruff hook
  ran `ruff format` + `ruff check --fix` over the *entire* file after every edit,
  rewriting unrelated legacy lines (noisy diffs, collisions between concurrent
  worktrees). Each mutation is now gated on the committed HEAD baseline already
  being clean for that tool, so it can only touch the just-edited region.
  New/untracked files still format; a git error fails conservative (never
  reflows a possibly-dirty file).
- **`session_observer` — never persist secrets.** It captured tool outputs and
  command/edit strings verbatim into a per-session log that feeds downstream
  memory. It now skips secret-bearing file reads/edits, secret-reading commands,
  and reference-store tool I/O, and scrubs inline secret shapes from whatever it
  does capture.
- **`credential_surface` — point, don't reveal.** It emitted plain stdout
  (dropped by CC on PreToolUse) and injected raw stored-credential bodies into
  the transcript. It now emits `hookSpecificOutput.additionalContext`, surfaces
  matches by label only, and directs retrieval through the proper masked path.
- **New `secret_scrub.py`** — a small stdlib-only scrubber shared by the above
  (one secret-filename vocabulary; redacts key prefixes, labeled tokens,
  passwords, URL-embedded creds, secret env assignments; leaves benign env vars
  and connection targets intact).

## Testing

- New/extended: `secret_scrub`, `session_observer` scrub, `credential_surface`,
  `edit_verify` baseline-gate.
- Adversarially reviewed; every finding fixed with a regression fixture.
- ruff clean; full `tests/test_hooks/` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
