### PR TITLE
fix(hooks): verify pr-create branch against live remote (close stale-ref fail-open)

### DIFF
--- a/.claude/skills/genesis-development/references/worktrees.md
+++ b/.claude/skills/genesis-development/references/worktrees.md
@@ -102,14 +102,20 @@ over.
   tool). Force push (`--force` / `--force-with-lease` / `-f` / `+refspec` /
   `--mirror`) is **hard-blocked** in every session. Multiple pushes in one
   command are blocked — each push needs its own approval.
-- `gh pr create` — **un-gated when its branch is already on the remote** (then
-  it's just a review request on pushed code), so a `git push && gh pr create`
-  prompts once — for the push — and the PR-create rides along. The exception:
-  gh will *push* (and can fork) a branch whose HEAD is not yet on the remote, so
-  a create from an **unpushed branch** is gated like a push (interactive → ask,
-  dispatched → deny). Verified against the **actual remote** via `git ls-remote`
-  (not the local tracking ref, which goes stale when a merged branch is deleted),
-  fail-safe — any network error / timeout / uncertainty gates.
+- `gh pr create` — a create only publishes code in the **implicit** form (no
+  `--head`), where gh may *push* (and can fork) the current branch when it isn't
+  fully on the remote. So an **explicit `--head`** (local, unpushed, or
+  `owner:fork`) is **un-gated** — `gh pr create --help`: "Use `--head` to
+  explicitly skip any forking or pushing behavior." The implicit form is un-gated
+  **only when the current branch is already on the remote** (then it's just a
+  review request on pushed code); if it isn't, it's gated like a push (interactive
+  → ask, dispatched → deny). The "already pushed?" check hits the **actual remote**
+  via `git ls-remote` (not the local tracking ref, which goes stale when a merged
+  branch is deleted), fail-safe — any network error / timeout / uncertainty gates.
+  On the un-gated path the hook emits an explicit **`allow`** so Claude Code's own
+  permission prompt doesn't re-fire for the (non-allow-listed) command — so a
+  `git push && gh pr create` prompts once (for the push) and the create rides
+  along, and a standalone create on pushed code doesn't prompt at all.
 - `git merge` into main/master — **hard-blocked** (use the PR workflow).
 - `gh pr merge` without `--admin`, or with unresolved review findings —
   **hard-blocked** (a `# review-override` trailing comment acknowledges

--- a/.claude/skills/genesis-development/references/worktrees.md
+++ b/.claude/skills/genesis-development/references/worktrees.md
@@ -107,7 +107,9 @@ over.
   prompts once — for the push — and the PR-create rides along. The exception:
   gh will *push* (and can fork) a branch whose HEAD is not yet on the remote, so
   a create from an **unpushed branch** is gated like a push (interactive → ask,
-  dispatched → deny). Verified via local remote-tracking refs, fail-safe.
+  dispatched → deny). Verified against the **actual remote** via `git ls-remote`
+  (not the local tracking ref, which goes stale when a merged branch is deleted),
+  fail-safe — any network error / timeout / uncertainty gates.
 - `git merge` into main/master — **hard-blocked** (use the PR workflow).
 - `gh pr merge` without `--admin`, or with unresolved review findings —
   **hard-blocked** (a `# review-override` trailing comment acknowledges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,14 +83,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   instead of hard-stopping.** This safety hook used to block the command outright
   with no in-session way through; now Claude Code shows you a native approve/deny
   prompt you confirm with one keystroke — a gate the agent cannot self-satisfy.
-  `gh pr create` is not prompted separately when its branch is already pushed
-  (opening a PR is then just a review request — so `git push && gh pr create`
-  asks once, for the push); a create from an unpushed branch, which gh would
-  push itself, is still gated. That "already pushed?" check queries the live
-  remote, so it isn't fooled by a stale local reference to a since-deleted
-  branch, and any network error just gates. Autonomous/background Genesis
-  sessions stay blocked from pushing directly (their real delivery path is
-  separately gated).
+  `gh pr create` no longer prompts on its own when it can't publish code —
+  opening a PR is then just a review request, so `git push && gh pr create` asks
+  once (for the push) and a standalone create on already-pushed code doesn't
+  prompt at all. Only the one form that can publish — a create with no `--head`
+  from a branch that isn't fully pushed, where gh pushes the branch itself — is
+  gated like a push; any explicit `--head` (which tells gh to skip pushing) is
+  never gated. The "already pushed?" check queries the live remote, so it isn't
+  fooled by a stale local reference to a since-deleted branch, and any network
+  error just gates. Autonomous/background Genesis sessions stay blocked from
+  pushing directly (their real delivery path is separately gated).
   Force pushes stay hard-blocked; branch names that merely contain `-f` (e.g.
   `fix/…-false-positives`) are no longer mistaken for a force-push.
 - **Genesis now keeps its own internal event log from growing without bound.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `gh pr create` is not prompted separately when its branch is already pushed
   (opening a PR is then just a review request — so `git push && gh pr create`
   asks once, for the push); a create from an unpushed branch, which gh would
-  push itself, is still gated. Autonomous/background Genesis sessions stay
-  blocked from pushing directly (their real delivery path is separately gated).
+  push itself, is still gated. That "already pushed?" check queries the live
+  remote, so it isn't fooled by a stale local reference to a since-deleted
+  branch, and any network error just gates. Autonomous/background Genesis
+  sessions stay blocked from pushing directly (their real delivery path is
+  separately gated).
   Force pushes stay hard-blocked; branch names that merely contain `-f` (e.g.
   `fix/…-false-positives`) are no longer mistaken for a force-push.
 - **Genesis now keeps its own internal event log from growing without bound.**

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -455,21 +455,28 @@ def _ask(reason: str) -> int:
     return 0
 
 
-def _pr_create_head_branch(argv: list[str]) -> str | None:
-    """The head branch named by a ``gh pr create`` (``--head``/``-H`` VALUE, or
-    ``--head=VALUE``), stripped of any ``owner:`` prefix. None → gh uses the
-    current branch."""
+def _pr_create_head_raw(argv: list[str]) -> str | None:
+    """The RAW ``--head``/``-H`` value (``owner:`` prefix intact), or None. An
+    ``owner:branch`` head means gh publishes to a FORK, not origin."""
     i = 0
     while i < len(argv):
         tok = argv[i]
         if tok in ("--head", "-H") and i + 1 < len(argv):
-            v = argv[i + 1]
-            return v.split(":", 1)[1] if ":" in v else v
+            return argv[i + 1]
         if tok.startswith("--head="):
-            v = tok.split("=", 1)[1]
-            return v.split(":", 1)[1] if ":" in v else v
+            return tok.split("=", 1)[1]
         i += 1
     return None
+
+
+def _pr_create_head_branch(argv: list[str]) -> str | None:
+    """The head branch named by a ``gh pr create`` (``--head``/``-H`` VALUE, or
+    ``--head=VALUE``), stripped of any ``owner:`` prefix. None → gh uses the
+    current branch."""
+    v = _pr_create_head_raw(argv)
+    if v is None:
+        return None
+    return v.split(":", 1)[1] if ":" in v else v
 
 
 def _pr_create_would_publish(argv: list[str]) -> bool:
@@ -477,34 +484,73 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
 
     gh pushes — and can even fork — a branch whose HEAD is not yet on the remote,
     so a bare create from an unpushed branch publishes code around this hook.
-    Checks the LOCAL remote-tracking ref (no network): the branch's remote ref
-    must exist AND already contain HEAD. Fail-safe — any uncertainty → True (gate).
+
+    Compares the LOCAL tip of the branch gh would publish — the ``--head`` branch
+    if given, else the current branch (NOT necessarily ``HEAD``: ``--head`` can
+    name a branch other than the checkout) — against the ACTUAL remote, queried
+    with ``git ls-remote`` rather than the LOCAL remote-tracking ref (which goes
+    stale the moment the remote branch is deleted — a squash-merge auto-delete
+    leaves ``refs/remotes/origin/<branch>`` pointing at a now-gone branch, so a
+    local-ref check would wrongly report "already pushed"). The branch must exist
+    on the remote AND already contain that local tip. Assumes origin's push and
+    fetch destinations coincide (the standard single-remote setup); an
+    ``owner:branch`` cross-fork head is gated outright since it publishes to a
+    fork this check can't see. Fail-safe — any uncertainty (network error,
+    timeout, missing branch, unpushed commits) → True (gate). Bounded by a 10s
+    ls-remote timeout that fits inside the hook's 60s budget; a hung/slow remote
+    fails closed, never open.
     """
+    raw_head = _pr_create_head_raw(argv)
+    if raw_head and ":" in raw_head:
+        return True  # owner:branch → gh publishes to a fork, not origin → gate
     branch = _pr_create_head_branch(argv) or _current_branch()
     if not branch:
         return True  # can't determine the branch → gate
-    remote_ref = f"refs/remotes/origin/{branch}"
     try:
-        exists = (
-            subprocess.run(
-                ["git", "show-ref", "--verify", "--quiet", remote_ref],
-                capture_output=True,
-                timeout=5,
-            ).returncode
-            == 0
+        # The tip gh would publish is the head BRANCH's local ref, not HEAD —
+        # `--head other` publishes `other` even while another branch is checked out.
+        local_sha = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        if not local_sha:
+            return True  # not a local branch → can't tell what gh would push → gate
+        remote = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", branch],
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
-        if not exists:
+        if remote.returncode != 0:
+            return True  # cannot reach/read the remote → gate (fail-safe)
+        # ls-remote's <pattern> is NOT an exact filter — a bare name tail-matches
+        # namespaced refs (pattern `matrix` also matches `refs/heads/ws8/matrix`),
+        # so a differently-namespaced remote branch could hand back the WRONG sha
+        # and under-gate. Accept only a line whose ref path is EXACTLY this branch.
+        target_ref = f"refs/heads/{branch}"
+        remote_sha = ""
+        for ln in remote.stdout.splitlines():
+            parts = ln.split()
+            if len(parts) >= 2 and parts[1] == target_ref:
+                remote_sha = parts[0]
+                break
+        if not remote_sha:
             return True  # branch not on the remote → gh would push it → gate
-        # HEAD already reachable from the remote branch → nothing to push.
+        if local_sha == remote_sha:
+            return False  # branch tip is exactly the remote tip → nothing to push
+        # Not the tip: un-gate only if the local tip is already contained in the
+        # remote branch (needs the object locally; if absent, is-ancestor → gate).
         contained = (
             subprocess.run(
-                ["git", "merge-base", "--is-ancestor", "HEAD", remote_ref],
+                ["git", "merge-base", "--is-ancestor", local_sha, remote_sha],
                 capture_output=True,
                 timeout=5,
             ).returncode
             == 0
         )
-        return not contained  # unpushed commits on HEAD → gh may push → gate
+        return not contained  # unpushed commits on the branch → gh may push → gate
     except Exception:
         return True  # fail-safe → gate
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -455,68 +455,102 @@ def _ask(reason: str) -> int:
     return 0
 
 
+def _allow(reason: str) -> int:
+    """Emit a PreToolUse ``allow`` decision — auto-approve, no prompt.
+
+    Prints the hook JSON to stdout and returns 0. An ``allow`` decision bypasses
+    Claude Code's own permission prompt, unlike a bare exit-0 (which leaves the
+    command to the normal permission flow — and a non-allow-listed ``gh pr create``
+    would then still prompt). Used ONLY on the verified-safe pr-create path (the
+    branch is already on the remote, or an explicit ``--head`` means gh cannot
+    push), so opening the PR rides on the push's approval instead of demanding its
+    own.
+    """
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    return 0
+
+
 def _pr_create_head_raw(argv: list[str]) -> str | None:
-    """The RAW ``--head``/``-H`` value (``owner:`` prefix intact), or None. An
-    ``owner:branch`` head means gh publishes to a FORK, not origin."""
+    """The RAW ``--head``/``-H`` value (``owner:`` prefix intact), or None.
+
+    Returns the LAST occurrence, mirroring gh's pflag last-value-wins semantics
+    for a repeated string flag — ``--head real --head=`` resolves to ``""`` in gh,
+    so this must too, else a stale earlier value could wrongly look like a real
+    head. ``None`` = no ``--head`` given at all (distinct from an empty value)."""
+    result: str | None = None
     i = 0
     while i < len(argv):
         tok = argv[i]
         if tok in ("--head", "-H") and i + 1 < len(argv):
-            return argv[i + 1]
-        if tok.startswith("--head="):
-            return tok.split("=", 1)[1]
+            result = argv[i + 1]
+        elif tok.startswith("--head="):
+            result = tok.split("=", 1)[1]
         i += 1
-    return None
-
-
-def _pr_create_head_branch(argv: list[str]) -> str | None:
-    """The head branch named by a ``gh pr create`` (``--head``/``-H`` VALUE, or
-    ``--head=VALUE``), stripped of any ``owner:`` prefix. None → gh uses the
-    current branch."""
-    v = _pr_create_head_raw(argv)
-    if v is None:
-        return None
-    return v.split(":", 1)[1] if ":" in v else v
+    return result
 
 
 def _pr_create_would_publish(argv: list[str]) -> bool:
-    """Whether a ``gh pr create`` might PUSH its branch (bypassing the push gate).
+    """Whether a ``gh pr create`` might PUSH/fork its branch (bypassing the push gate).
 
-    gh pushes — and can even fork — a branch whose HEAD is not yet on the remote,
-    so a bare create from an unpushed branch publishes code around this hook.
+    Per the gh manual (``gh pr create --help``): only a create with NO ``--head``
+    can publish — "when the current branch isn't fully pushed to a git remote, a
+    prompt will ask where to push the branch and offer an option to fork ... Use
+    ``--head`` to explicitly skip any forking or pushing behavior." So:
 
-    Compares the LOCAL tip of the branch gh would publish — the ``--head`` branch
-    if given, else the current branch (NOT necessarily ``HEAD``: ``--head`` can
-    name a branch other than the checkout) — against the ACTUAL remote, queried
-    with ``git ls-remote`` rather than the LOCAL remote-tracking ref (which goes
-    stale the moment the remote branch is deleted — a squash-merge auto-delete
-    leaves ``refs/remotes/origin/<branch>`` pointing at a now-gone branch, so a
-    local-ref check would wrongly report "already pushed"). The branch must exist
-    on the remote AND already contain that local tip. Assumes origin's push and
-    fetch destinations coincide (the standard single-remote setup); an
-    ``owner:branch`` cross-fork head is gated outright since it publishes to a
-    fork this check can't see. Fail-safe — any uncertainty (network error,
-    timeout, missing branch, unpushed commits) → True (gate). Bounded by a 10s
-    ls-remote timeout that fits inside the hook's 60s budget; a hung/slow remote
-    fails closed, never open.
+    * A NON-EMPTY, plausibly-LITERAL explicit ``--head`` (local, unpushed, or
+      ``owner:fork``) → gh does NOT push/fork; it references the head ref as-is
+      (erroring if absent) → cannot publish code around this hook → **un-gate**.
+      (gh only takes this skip-push path when its resolved ``HeadBranch != ""``.
+      An EMPTY head — ``--head=`` / ``--head ""``, or a repeated flag whose LAST
+      value is empty — is gh's implicit path, and a value carrying shell-expansion
+      metacharacters (``$VAR`` / ``$(...)`` / backticks) could resolve to empty at
+      runtime and we can't see through it; both are NOT trusted as a real head and
+      fall through to the implicit verification below.)
+    * No ``--head`` (or an empty one) → gh may push the CURRENT branch when it
+      isn't fully on the remote. Verified against the ACTUAL remote with ``git
+      ls-remote`` — not the LOCAL remote-tracking ref, which goes stale the moment
+      a merged branch is deleted (a squash-merge auto-delete leaves
+      refs/remotes/origin/<branch> pointing at a gone branch, so a local-ref check
+      would wrongly report "already pushed"). Accept only the ls-remote line whose
+      ref path is EXACTLY ``refs/heads/<branch>`` (a bare pattern tail-matches
+      namespaced refs).
+
+    Assumes origin's push and fetch destinations coincide (standard single-remote
+    setup). Fail-safe — any uncertainty (network error, timeout, current branch
+    not on the remote, unpushed commits, detached HEAD) → True (gate). The
+    ls-remote call is bounded by a 10s timeout inside the hook's 60s budget; a
+    hung/slow remote fails closed, never open.
     """
     raw_head = _pr_create_head_raw(argv)
-    if raw_head and ":" in raw_head:
-        return True  # owner:branch → gh publishes to a fork, not origin → gate
-    branch = _pr_create_head_branch(argv) or _current_branch()
+    if raw_head and "$" not in raw_head and "`" not in raw_head:
+        # A NON-EMPTY, plausibly-LITERAL --head → gh skips push/fork → un-gate.
+        # An empty head (--head= / --head "") is gh's implicit path; a value with
+        # shell-expansion metacharacters ($VAR / $(...) / `...`) could resolve to
+        # empty (→ implicit push) at runtime and we can't see through it — both
+        # fall through to the live current-branch verification below (fail-safe).
+        return False
+    branch = _current_branch()
     if not branch:
-        return True  # can't determine the branch → gate
+        return True  # detached / unknown current branch → can't verify → gate
     try:
-        # The tip gh would publish is the head BRANCH's local ref, not HEAD —
-        # `--head other` publishes `other` even while another branch is checked out.
-        local_sha = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
             capture_output=True,
             text=True,
             timeout=5,
         ).stdout.strip()
-        if not local_sha:
-            return True  # not a local branch → can't tell what gh would push → gate
+        if not head_sha:
+            return True  # can't resolve HEAD → gate
         remote = subprocess.run(
             ["git", "ls-remote", "--heads", "origin", branch],
             capture_output=True,
@@ -525,10 +559,6 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
         )
         if remote.returncode != 0:
             return True  # cannot reach/read the remote → gate (fail-safe)
-        # ls-remote's <pattern> is NOT an exact filter — a bare name tail-matches
-        # namespaced refs (pattern `matrix` also matches `refs/heads/ws8/matrix`),
-        # so a differently-namespaced remote branch could hand back the WRONG sha
-        # and under-gate. Accept only a line whose ref path is EXACTLY this branch.
         target_ref = f"refs/heads/{branch}"
         remote_sha = ""
         for ln in remote.stdout.splitlines():
@@ -537,20 +567,21 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
                 remote_sha = parts[0]
                 break
         if not remote_sha:
-            return True  # branch not on the remote → gh would push it → gate
-        if local_sha == remote_sha:
-            return False  # branch tip is exactly the remote tip → nothing to push
-        # Not the tip: un-gate only if the local tip is already contained in the
-        # remote branch (needs the object locally; if absent, is-ancestor → gate).
+            return True  # current branch not on the remote → gh would push it → gate
+        if head_sha == remote_sha:
+            return False  # current branch tip is on the remote → nothing to push
+        # HEAD differs from the remote tip: un-gate only if HEAD is already
+        # contained in the remote branch (needs the object locally; if absent,
+        # is-ancestor fails → gate).
         contained = (
             subprocess.run(
-                ["git", "merge-base", "--is-ancestor", local_sha, remote_sha],
+                ["git", "merge-base", "--is-ancestor", "HEAD", remote_sha],
                 capture_output=True,
                 timeout=5,
             ).returncode
             == 0
         )
-        return not contained  # unpushed commits on the branch → gh may push → gate
+        return not contained  # unpushed commits on HEAD → gh may push → gate
     except Exception:
         return True  # fail-safe → gate
 
@@ -788,6 +819,18 @@ def main() -> int:
         # native approve/deny dialog for its push / PR-create.
         if ask_reason is not None:
             return _ask(ask_reason)
+
+        # A standalone, un-gated `gh pr create` (branch already on the remote, or
+        # an explicit --head that gh won't push): reaching here means nothing
+        # needed approval. Emit an explicit `allow` so CC's OWN permission prompt
+        # doesn't fire for this non-allow-listed command — the un-gate is only
+        # meaningful if it actually suppresses the prompt. (A push in the same
+        # command would have set ask_reason above, so this never overrides a push.)
+        if create_segs:
+            return _allow(
+                "gh pr create cannot publish code here (explicit --head, or current "
+                "branch already on the remote) — no push, so no separate approval"
+            )
 
     except Exception:
         pass  # Fail-open on any error — never block legitimate work

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -69,6 +69,11 @@ def _rc(code: int) -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=code)
 
 
+def _proc(code: int, out: str = "") -> subprocess.CompletedProcess:
+    """A fake CompletedProcess carrying a returncode and stdout."""
+    return subprocess.CompletedProcess(args=[], returncode=code, stdout=out)
+
+
 class TestPrCreateHeadBranch:
     """_pr_create_head_branch parses --head / -H / --head= (owner: stripped)."""
 
@@ -92,53 +97,184 @@ class TestPrCreateHeadBranch:
 
 
 class TestPrCreateWouldPublish:
-    """_pr_create_would_publish gates iff the head branch's HEAD is not yet on the
-    remote (gh would push it). Verified via local git refs — mocked here so the
-    test is deterministic and network/git-state independent."""
+    """_pr_create_would_publish gates iff the branch gh would publish is not yet on
+    the remote (gh would push it). It compares the LOCAL tip of that branch — the
+    --head branch, else the current branch (NOT necessarily HEAD) — against the
+    ACTUAL remote via git ls-remote (not the stale-prone local tracking ref).
+    subprocess mocked here for determinism. Call order per branch: rev-parse
+    --verify refs/heads/<branch>, ls-remote --heads origin <branch>, then
+    merge-base --is-ancestor <local_sha> <remote_sha>."""
 
     def test_no_branch_gates(self, guard_module):
         with patch.object(guard_module, "_current_branch", return_value=None):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 
-    def test_remote_ref_absent_gates(self, guard_module):
-        # show-ref --verify fails (rc=1) → branch not on remote → gh would push.
+    def test_cross_fork_owner_head_gates(self, guard_module):
+        # --head owner:branch → gh publishes to a FORK, not origin. We can't verify
+        # a fork's state here, so gate outright — BEFORE any git subprocess runs.
+        with patch.object(guard_module.subprocess, "run", side_effect=AssertionError) as run:
+            assert (
+                guard_module._pr_create_would_publish(
+                    ["gh", "pr", "create", "--head", "alice:feature"]
+                )
+                is True
+            )
+        assert run.call_count == 0  # short-circuits before touching git
+
+    def test_local_branch_missing_gates(self, guard_module):
+        # rev-parse of the head branch fails (not a local branch) → can't tell what
+        # gh would publish → gate.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
-            patch.object(guard_module.subprocess, "run", return_value=_rc(1)),
+            patch.object(guard_module.subprocess, "run", side_effect=[_proc(1, "")]),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 
-    def test_head_on_remote_and_contained_ungated(self, guard_module):
-        # ref exists (rc=0), then HEAD is an ancestor (rc=0) → nothing to push.
+    def test_remote_branch_absent_gates(self, guard_module):
+        # local branch exists; ls-remote returns NO ref line → branch not on remote → gate.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
-            patch.object(guard_module.subprocess, "run", side_effect=[_rc(0), _rc(0)]),
+            patch.object(
+                guard_module.subprocess, "run", side_effect=[_proc(0, "H1"), _proc(0, "")]
+            ),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_stale_local_ref_no_longer_ungates(self, guard_module):
+        # Regression: after a remote branch is deleted (squash-merge auto-delete),
+        # the LOCAL tracking ref lingers but ls-remote returns empty → must GATE,
+        # NOT trust the stale ref. This is the fail-open the local-ref check had.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(
+                guard_module.subprocess, "run", side_effect=[_proc(0, "H1"), _proc(0, "")]
+            ) as run,
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+        # Proves it went to the network (ls-remote), not a local remote-tracking ref.
+        assert any("ls-remote" in " ".join(c.args[0]) for c in run.call_args_list)
+
+    def test_remote_unreachable_gates(self, guard_module):
+        # ls-remote fails (rc!=0: no network / auth) → cannot verify → gate.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(
+                guard_module.subprocess, "run", side_effect=[_proc(0, "H1"), _proc(2, "")]
+            ),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_namespaced_ref_mismatch_gates(self, guard_module):
+        # ls-remote pattern-matches tail components: querying short name "matrix"
+        # can return `refs/heads/ws8/matrix` (a DIFFERENT branch). That line's ref
+        # path != refs/heads/matrix, so it must NOT be accepted → gate (no under-block).
+        with (
+            patch.object(guard_module, "_current_branch", return_value="matrix"),
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=[_proc(0, "L1"), _proc(0, "aaa111\trefs/heads/ws8/matrix")],
+            ),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_exact_ref_among_multiple_lines_used(self, guard_module):
+        # Several lines returned; only the exact refs/heads/<branch> line is used.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="matrix"),
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=[
+                    _proc(0, "bbb222"),
+                    _proc(0, "aaa111\trefs/heads/ws8/matrix\nbbb222\trefs/heads/matrix"),
+                ],
+            ),
+        ):
+            # local tip == the EXACT branch's remote tip (bbb222), not aaa111 → ungate.
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
+
+    def test_head_is_remote_tip_ungated(self, guard_module):
+        # local branch tip == remote tip → nothing to push.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=[_proc(0, "abc123\n"), _proc(0, "abc123\trefs/heads/feat")],
+            ),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
 
-    def test_head_on_remote_but_ahead_gates(self, guard_module):
-        # ref exists (rc=0) but HEAD not an ancestor (rc=1) → unpushed commits → gate.
+    def test_local_tip_contained_but_not_remote_tip_ungated(self, guard_module):
+        # local tip differs from remote tip but is an ancestor of it (rc=0) → nothing to push.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
-            patch.object(guard_module.subprocess, "run", side_effect=[_rc(0), _rc(1)]),
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=[_proc(0, "abc123"), _proc(0, "def456\trefs/heads/feat"), _rc(0)],
+            ),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
+
+    def test_local_tip_ahead_of_remote_gates(self, guard_module):
+        # local tip differs and is NOT an ancestor (rc=1) → unpushed commits → gate.
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=[_proc(0, "abc999"), _proc(0, "def456\trefs/heads/feat"), _rc(1)],
+            ),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 
-    def test_explicit_head_checked_not_current(self, guard_module):
+    def test_head_branch_resolved_not_checkout(self, guard_module):
+        # Regression (Codex F1): --head names `feature` while `main` is checked out.
+        # gh publishes `feature`, so we must resolve refs/heads/FEATURE's tip and
+        # compare THAT to the remote — never the current checkout's HEAD. Here the
+        # local `feature` tip (H1) is ahead of origin/feature (H0) → gate, even
+        # though a HEAD-based check on `main` might have matched and under-gated.
         with (
             patch.object(guard_module, "_current_branch", return_value="main"),
-            patch.object(guard_module.subprocess, "run", return_value=_rc(1)) as run,
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=[_proc(0, "H1"), _proc(0, "H0\trefs/heads/feature"), _rc(1)],
+            ) as run,
         ):
             assert (
-                guard_module._pr_create_would_publish(["gh", "pr", "create", "--head", "other"])
+                guard_module._pr_create_would_publish(["gh", "pr", "create", "--head", "feature"])
                 is True
             )
-        assert any("refs/remotes/origin/other" in " ".join(c.args[0]) for c in run.call_args_list)
+        # The LOCAL tip resolved is refs/heads/feature, not HEAD.
+        assert any(
+            c.args[0][:3] == ["git", "rev-parse", "--verify"]
+            and c.args[0][-1] == "refs/heads/feature"
+            for c in run.call_args_list
+        )
+        # ls-remote is queried for the EXPLICIT head branch, not the current one.
+        assert any(
+            "ls-remote" in " ".join(c.args[0]) and c.args[0][-1] == "feature"
+            for c in run.call_args_list
+        )
 
     def test_subprocess_error_fails_safe(self, guard_module):
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(guard_module.subprocess, "run", side_effect=OSError("boom")),
+        ):
+            assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+    def test_timeout_fails_safe(self, guard_module):
+        with (
+            patch.object(guard_module, "_current_branch", return_value="feat"),
+            patch.object(
+                guard_module.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10),
+            ),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -74,64 +74,95 @@ def _proc(code: int, out: str = "") -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=code, stdout=out)
 
 
-class TestPrCreateHeadBranch:
-    """_pr_create_head_branch parses --head / -H / --head= (owner: stripped)."""
+class TestPrCreateHeadRaw:
+    """_pr_create_head_raw returns the RAW --head / -H / --head= value (owner:
+    prefix intact), or None. Presence of ANY --head means gh skips push/fork."""
 
     def test_none_when_no_head(self, guard_module):
-        assert guard_module._pr_create_head_branch(["gh", "pr", "create", "--title", "x"]) is None
+        assert guard_module._pr_create_head_raw(["gh", "pr", "create", "--title", "x"]) is None
 
     def test_head_space_value(self, guard_module):
-        assert (
-            guard_module._pr_create_head_branch(["gh", "pr", "create", "--head", "feat"]) == "feat"
-        )
+        assert guard_module._pr_create_head_raw(["gh", "pr", "create", "--head", "feat"]) == "feat"
 
     def test_head_short_flag(self, guard_module):
-        assert guard_module._pr_create_head_branch(["gh", "pr", "create", "-H", "feat"]) == "feat"
+        assert guard_module._pr_create_head_raw(["gh", "pr", "create", "-H", "feat"]) == "feat"
 
     def test_head_equals(self, guard_module):
-        assert guard_module._pr_create_head_branch(["gh", "pr", "create", "--head=feat"]) == "feat"
+        assert guard_module._pr_create_head_raw(["gh", "pr", "create", "--head=feat"]) == "feat"
 
-    def test_head_owner_stripped(self, guard_module):
-        got = guard_module._pr_create_head_branch(["gh", "pr", "create", "--head", "someone:feat"])
-        assert got == "feat"
+    def test_head_owner_kept_raw(self, guard_module):
+        got = guard_module._pr_create_head_raw(["gh", "pr", "create", "--head", "someone:feat"])
+        assert got == "someone:feat"
+
+    def test_last_value_wins(self, guard_module):
+        # gh's pflag applies last-value-wins for a repeated string flag, so the
+        # parser must return the LAST occurrence — not the first.
+        assert (
+            guard_module._pr_create_head_raw(["gh", "pr", "create", "--head", "a", "--head=b"])
+            == "b"
+        )
+        assert (
+            guard_module._pr_create_head_raw(["gh", "pr", "create", "--head", "real", "--head="])
+            == ""
+        )
 
 
 class TestPrCreateWouldPublish:
-    """_pr_create_would_publish gates iff the branch gh would publish is not yet on
-    the remote (gh would push it). It compares the LOCAL tip of that branch — the
-    --head branch, else the current branch (NOT necessarily HEAD) — against the
+    """Only a create with NO --head can publish (gh may push the current branch
+    when it isn't fully on the remote). Any explicit --head makes gh skip
+    push/fork → un-gate, no git touched. The implicit case is verified against the
     ACTUAL remote via git ls-remote (not the stale-prone local tracking ref).
-    subprocess mocked here for determinism. Call order per branch: rev-parse
-    --verify refs/heads/<branch>, ls-remote --heads origin <branch>, then
-    merge-base --is-ancestor <local_sha> <remote_sha>."""
+    subprocess mocked for determinism. Implicit call order: rev-parse HEAD,
+    ls-remote --heads origin <current>, merge-base --is-ancestor HEAD <remote_sha>."""
+
+    def test_explicit_head_never_publishes(self, guard_module):
+        # gh --help: "Use --head to explicitly skip any forking or pushing
+        # behavior." So ANY explicit head un-gates WITHOUT touching git — incl. a
+        # cross-fork owner:branch head (gh can't push to a fork we don't control).
+        for argv in (
+            ["gh", "pr", "create", "--head", "feat"],
+            ["gh", "pr", "create", "-H", "feat"],
+            ["gh", "pr", "create", "--head=feat"],
+            ["gh", "pr", "create", "--head", "alice:feat"],
+        ):
+            with patch.object(guard_module.subprocess, "run", side_effect=AssertionError) as run:
+                assert guard_module._pr_create_would_publish(argv) is False
+            assert run.call_count == 0  # short-circuits before any git call
+
+    def test_untrusted_head_falls_through_to_gate(self, guard_module):
+        # Regression (both reviewers): a head that gh would treat as EMPTY, or one
+        # we can't verify statically, must NOT un-gate — it falls through to the
+        # implicit current-branch push path. Covered:
+        #   - literal empty (`--head=` / `--head ""`) → gh's HeadBranch == "";
+        #   - repeated flag, LAST value empty → gh's last-wins → "";
+        #   - shell-expansion value (`$BRANCH` / `$(...)` / backtick) → may resolve
+        #     empty at runtime, unseeable here.
+        # With the current branch unknown, each falls through and GATES (not un-gate).
+        for argv in (
+            ["gh", "pr", "create", "--head="],
+            ["gh", "pr", "create", "--head", ""],
+            ["gh", "pr", "create", "--head", "real", "--head="],  # last-value-wins
+            ["gh", "pr", "create", "--head", "$BRANCH"],  # shell variable
+            ["gh", "pr", "create", "--head", "$(git rev-parse --abbrev-ref HEAD)"],
+            ["gh", "pr", "create", "--head", "`echo x`"],  # backtick substitution
+        ):
+            with patch.object(guard_module, "_current_branch", return_value=None):
+                assert guard_module._pr_create_would_publish(argv) is True, argv
 
     def test_no_branch_gates(self, guard_module):
         with patch.object(guard_module, "_current_branch", return_value=None):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 
-    def test_cross_fork_owner_head_gates(self, guard_module):
-        # --head owner:branch → gh publishes to a FORK, not origin. We can't verify
-        # a fork's state here, so gate outright — BEFORE any git subprocess runs.
-        with patch.object(guard_module.subprocess, "run", side_effect=AssertionError) as run:
-            assert (
-                guard_module._pr_create_would_publish(
-                    ["gh", "pr", "create", "--head", "alice:feature"]
-                )
-                is True
-            )
-        assert run.call_count == 0  # short-circuits before touching git
-
-    def test_local_branch_missing_gates(self, guard_module):
-        # rev-parse of the head branch fails (not a local branch) → can't tell what
-        # gh would publish → gate.
+    def test_empty_head_sha_gates(self, guard_module):
+        # rev-parse HEAD empty (unborn / odd state) → can't resolve → gate.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
-            patch.object(guard_module.subprocess, "run", side_effect=[_proc(1, "")]),
+            patch.object(guard_module.subprocess, "run", side_effect=[_proc(0, "")]),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 
-    def test_remote_branch_absent_gates(self, guard_module):
-        # local branch exists; ls-remote returns NO ref line → branch not on remote → gate.
+    def test_current_branch_absent_on_remote_gates(self, guard_module):
+        # ls-remote returns NO matching ref → current branch not pushed → gate.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(
@@ -165,15 +196,15 @@ class TestPrCreateWouldPublish:
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
 
     def test_namespaced_ref_mismatch_gates(self, guard_module):
-        # ls-remote pattern-matches tail components: querying short name "matrix"
-        # can return `refs/heads/ws8/matrix` (a DIFFERENT branch). That line's ref
-        # path != refs/heads/matrix, so it must NOT be accepted → gate (no under-block).
+        # ls-remote pattern-matches tail components: querying short name "feat"
+        # can return `refs/heads/ws8/feat` (a DIFFERENT branch). That line's ref
+        # path != refs/heads/feat, so it must NOT be accepted → gate (no under-block).
         with (
-            patch.object(guard_module, "_current_branch", return_value="matrix"),
+            patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(
                 guard_module.subprocess,
                 "run",
-                side_effect=[_proc(0, "L1"), _proc(0, "aaa111\trefs/heads/ws8/matrix")],
+                side_effect=[_proc(0, "H1"), _proc(0, "aaa111\trefs/heads/ws8/feat")],
             ),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
@@ -181,21 +212,21 @@ class TestPrCreateWouldPublish:
     def test_exact_ref_among_multiple_lines_used(self, guard_module):
         # Several lines returned; only the exact refs/heads/<branch> line is used.
         with (
-            patch.object(guard_module, "_current_branch", return_value="matrix"),
+            patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(
                 guard_module.subprocess,
                 "run",
                 side_effect=[
-                    _proc(0, "bbb222"),
-                    _proc(0, "aaa111\trefs/heads/ws8/matrix\nbbb222\trefs/heads/matrix"),
+                    _proc(0, "bbb222\n"),
+                    _proc(0, "aaa111\trefs/heads/ws8/feat\nbbb222\trefs/heads/feat"),
                 ],
             ),
         ):
-            # local tip == the EXACT branch's remote tip (bbb222), not aaa111 → ungate.
+            # HEAD == the EXACT branch's remote tip (bbb222), not aaa111 → ungate.
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
 
     def test_head_is_remote_tip_ungated(self, guard_module):
-        # local branch tip == remote tip → nothing to push.
+        # current branch tip (HEAD) == remote tip → nothing to push.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(
@@ -206,8 +237,8 @@ class TestPrCreateWouldPublish:
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
 
-    def test_local_tip_contained_but_not_remote_tip_ungated(self, guard_module):
-        # local tip differs from remote tip but is an ancestor of it (rc=0) → nothing to push.
+    def test_head_contained_but_not_tip_ungated(self, guard_module):
+        # HEAD differs from remote tip but is an ancestor of it (rc=0) → nothing to push.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(
@@ -218,8 +249,8 @@ class TestPrCreateWouldPublish:
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is False
 
-    def test_local_tip_ahead_of_remote_gates(self, guard_module):
-        # local tip differs and is NOT an ancestor (rc=1) → unpushed commits → gate.
+    def test_head_ahead_of_remote_gates(self, guard_module):
+        # HEAD differs and is NOT an ancestor (rc=1) → unpushed commits → gate.
         with (
             patch.object(guard_module, "_current_branch", return_value="feat"),
             patch.object(
@@ -229,36 +260,6 @@ class TestPrCreateWouldPublish:
             ),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
-
-    def test_head_branch_resolved_not_checkout(self, guard_module):
-        # Regression (Codex F1): --head names `feature` while `main` is checked out.
-        # gh publishes `feature`, so we must resolve refs/heads/FEATURE's tip and
-        # compare THAT to the remote — never the current checkout's HEAD. Here the
-        # local `feature` tip (H1) is ahead of origin/feature (H0) → gate, even
-        # though a HEAD-based check on `main` might have matched and under-gated.
-        with (
-            patch.object(guard_module, "_current_branch", return_value="main"),
-            patch.object(
-                guard_module.subprocess,
-                "run",
-                side_effect=[_proc(0, "H1"), _proc(0, "H0\trefs/heads/feature"), _rc(1)],
-            ) as run,
-        ):
-            assert (
-                guard_module._pr_create_would_publish(["gh", "pr", "create", "--head", "feature"])
-                is True
-            )
-        # The LOCAL tip resolved is refs/heads/feature, not HEAD.
-        assert any(
-            c.args[0][:3] == ["git", "rev-parse", "--verify"]
-            and c.args[0][-1] == "refs/heads/feature"
-            for c in run.call_args_list
-        )
-        # ls-remote is queried for the EXPLICIT head branch, not the current one.
-        assert any(
-            "ls-remote" in " ".join(c.args[0]) and c.args[0][-1] == "feature"
-            for c in run.call_args_list
-        )
 
     def test_subprocess_error_fails_safe(self, guard_module):
         with (

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -62,33 +62,36 @@ def _decision(res: subprocess.CompletedProcess) -> str | None:
 # ── gh pr create ────────────────────────────────────────────────────
 
 
-# gh pr create is UN-gated when its head branch is already on the remote (then
-# it's just a review request on pushed code). That un-gated path is git-state
-# dependent, so it is covered deterministically by the _pr_create_would_publish
-# unit tests in test_merge_review_gate.py. Here we test the GATED path: an
-# --head that ls-remote cannot find on origin (this bogus branch never exists,
-# so ls-remote returns empty; if the network is down it fails closed) which gh
-# would push — either way it must be gated like a push, keeping this test
-# deterministic regardless of connectivity.
-_UNPUSHED = "zzz-unpushed-branch-xyz"
+# gh pr create publishes code ONLY in the implicit form (no --head), where gh may
+# push the current branch if it isn't fully on the remote. Per `gh pr create
+# --help`, "Use --head to explicitly skip any forking or pushing behavior" — so
+# ANY explicit --head cannot publish and is un-gated. The un-gated path emits an
+# explicit `allow` so CC's own permission prompt for this non-allow-listed command
+# does not fire (a bare exit-0 would leave it to prompt). The implicit
+# push-or-not decision is git-state dependent, so it's covered deterministically
+# by the _pr_create_would_publish unit tests in test_merge_review_gate.py; here we
+# assert the deterministic explicit-head behavior (allow, no network).
+_HEAD = "zzz-some-branch-xyz"
 
 
-def test_pr_create_unpushed_branch_asks_interactive():
-    res = _run(f"gh pr create --head {_UNPUSHED} --title x --body y")
+def test_pr_create_explicit_head_allowed_interactive():
+    res = _run(f"gh pr create --head {_HEAD} --title x --body y")
     assert res.returncode == 0, res.stderr
-    assert _decision(res) == "ask"
+    assert _decision(res) == "allow"  # gh skips push with --head → no prompt
 
 
-def test_pr_create_unpushed_branch_denied_dispatched():
-    res = _run(f"gh pr create --head {_UNPUSHED} --title x --body y", dispatched=True)
-    assert res.returncode == 2
-    assert _decision(res) is None
+def test_pr_create_explicit_head_allowed_dispatched():
+    res = _run(f"gh pr create --head {_HEAD} --title x --body y", dispatched=True)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
 
 
-def test_pr_create_unpushed_global_flag_still_detected():
-    """A gh global flag before `pr` must not evade detection of the create."""
-    res = _run(f"gh --repo o/r pr create --head {_UNPUSHED} --title x --body y", dispatched=True)
-    assert res.returncode == 2
+def test_pr_create_cross_fork_head_allowed():
+    """An owner:branch cross-fork head also can't push around the gate (gh can't
+    push to a fork we don't control), so it is un-gated too."""
+    res = _run("gh pr create --head someone:feature --title x --body y")
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
 
 
 def test_pr_create_mention_in_string_not_tripped():
@@ -267,14 +270,13 @@ def test_push_override_token_cannot_self_approve_dispatched():
     assert _decision(res) is None
 
 
-def test_pr_create_token_does_not_ungate_unpushed():
-    """The retired token cannot un-gate an unpushed create either — it still
-    gates (gh would push) and asks, regardless of any trailing token."""
-    res = _run(
-        f"gh pr create --head {_UNPUSHED} --title x --body-file /tmp/b.md  # review-override"
-    )
+def test_pr_create_token_irrelevant_to_gate():
+    """The retired `# review-override` token never factored into pr-create gating
+    (it governs the pr-merge findings gate only). An explicit-head create is
+    allowed on its own merits — the trailing token neither helps nor changes it."""
+    res = _run(f"gh pr create --head {_HEAD} --title x --body-file /tmp/b.md  # review-override")
     assert res.returncode == 0, res.stderr
-    assert _decision(res) == "ask"
+    assert _decision(res) == "allow"
 
 
 # ── shell-parse bypass-hardening preserved (dispatched → still hard-denied) ──

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -14,7 +14,10 @@ it still governs the pr-merge review-findings gate (see test_merge_review_gate.p
 All shell-parse bypass-hardening from #1232 is preserved — a push detected through
 a wrapper is still caught, now denied in the dispatched context.
 
-Pure string-parsing paths (no gh/git network), so no mocking needed.
+Mostly pure string-parsing paths, so no mocking needed. The gated pr-create cases
+resolve their branch against the real remote via ``git ls-remote``; they use a
+bogus branch (or tolerate a network failure) so the decision is "gate" either way,
+keeping the assertions deterministic regardless of connectivity.
 """
 
 from __future__ import annotations
@@ -63,8 +66,10 @@ def _decision(res: subprocess.CompletedProcess) -> str | None:
 # it's just a review request on pushed code). That un-gated path is git-state
 # dependent, so it is covered deterministically by the _pr_create_would_publish
 # unit tests in test_merge_review_gate.py. Here we test the GATED path: an
-# --head not on the remote (origin/<nonexistent> never exists) which gh would
-# push — that must be gated like a push.
+# --head that ls-remote cannot find on origin (this bogus branch never exists,
+# so ls-remote returns empty; if the network is down it fails closed) which gh
+# would push — either way it must be gated like a push, keeping this test
+# deterministic regardless of connectivity.
 _UNPUSHED = "zzz-unpushed-branch-xyz"
 
 


### PR DESCRIPTION
## What

Makes the `gh pr create` gate in `git_push_guard.py` correct and quiet, on top of #1241's un-gate. Three related fixes to `_pr_create_would_publish` + the create-arm:

1. **Close a stale-ref fail-open.** #1241 decided "already pushed?" from the LOCAL remote-tracking ref, which goes stale the moment a remote branch is deleted (a squash-merge auto-delete). The check now hits the **live remote** via `git ls-remote` (accepting only the line whose ref path is exactly `refs/heads/<branch>`, so a bare pattern can't tail-match a namespaced ref). Verified live: on the exact stale ref #1241's own merge left behind, the old guard returns `would_publish=False` (fail-open); this returns `True` (gates).

2. **Gate only the form that can publish.** Per `gh pr create --help` ("Use `--head` to explicitly skip any forking or pushing behavior") and gh source (`if opts.HeadBranch != ""`), only an **implicit** create (no `--head`) can push — gh may push the current branch when it isn't fully on the remote. So any non-empty literal `--head` (local, unpushed, or `owner:fork`) is un-gated. Empty (`--head=`/`--head ""`), repeated-flag-last-empty (gh's last-value-wins), and shell-expansion heads (`$VAR`/`$(…)`/backtick, which could resolve empty at runtime) are **not** trusted and fall through to the live verification.

3. **Actually stop the prompt.** The un-gated path now emits `permissionDecision: "allow"` instead of a bare exit-0. A bare exit-0 left the command to Claude Code's own permission flow, which **still prompts** for a non-allow-listed `gh pr create` — the real reason a standalone create on already-pushed code kept prompting after #1241. A push in the same command still asks first (its `ask` is returned before the create `allow`), so `git push && gh pr create` prompts **once**, for the push.

## Net behaviour

- standalone `gh pr create` on a pushed branch → **allow** (no prompt)
- `gh pr create --head <literal>` (incl. `owner:fork`) → allow
- `git push && gh pr create` → one ask (for the push)
- `gh pr create` from an unpushed current branch, or an empty/dynamic `--head` → ask (interactive) / deny (dispatched)
- force-push, merge-into-main, `gh pr merge` w/o `--admin`, `commit --no-verify` → unchanged hard-blocks

Fail-safe throughout: network error, timeout, missing/absent branch, detached HEAD, or any uncertainty → gate. `ls-remote` bounded by 10s inside the hook's 60s budget.

## Review

Two independent adversarial passes (Codex + Claude), both hunting for fail-opens:
- Both caught the empty-`--head` under-gate; Claude additionally caught the dynamic (`--head "$BRANCH"`) and last-value-wins variants. All fixed + regression-tested.
- Both confirmed: non-empty literal `--head` un-gate is gh-source-supported; the implicit `ls-remote` path fails closed on every uncertainty; `allow` bypasses no other guard and never overrides a pending push `ask`.

125 hook tests pass (`test_merge_review_gate` + `test_push_create_override` + `test_hook_input_contract`); ruff clean; private-data scan clean. The exotic `pushurl != fetchurl` edge is tracked separately (tabled `26ff0b2f`).

## Deploy

CC-session hook — merge then `git pull` on main; reloads on next Bash call. No restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
