### PR TITLE
fix(hooks): worktree-aware + remote-aware git guards; docs-only review skip

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -32,14 +32,35 @@ from shell_parse import (  # noqa: E402
     gh_pr_subcommand,
     git_subcommand,
     has_trailing_override,
+    split_segments,
+)
+
+# Sentinel: the effective cwd cannot be confidently resolved (a cd into a
+# variable/command-substitution, a subshell, or a target nested at depth>0).
+# Callers MUST fail closed on it — block the merge, do not soften a force push.
+_CWD_UNKNOWN = object()
+
+# git global options that consume the FOLLOWING token as their value — used to
+# skip past `git -C <dir>` / `git -c KEY=VAL` when locating a push's positionals.
+_GIT_GLOBAL_VALUE_FLAGS = frozenset(
+    {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix"}
 )
 
 
-def _current_branch() -> str | None:
-    """Get current git branch name."""
+def _current_branch(cwd: str | None = None) -> str | None:
+    """Get current git branch name, optionally in a specific working dir.
+
+    When ``cwd`` is truthy, run ``git -C <cwd> branch --show-current`` so the
+    branch reflects the worktree the command actually targets — not the hook's
+    own cwd (always the main tree, on ``main``). Fail-safe: None on any error.
+    """
     try:
+        args = ["git"]
+        if cwd:
+            args += ["-C", cwd]
+        args += ["branch", "--show-current"]
         result = subprocess.run(
-            ["git", "branch", "--show-current"],
+            args,
             capture_output=True,
             text=True,
             timeout=5,
@@ -49,10 +70,131 @@ def _current_branch() -> str | None:
         return None
 
 
-def _get_push_remote_and_branch(cmd: str) -> tuple[str | None, str | None]:
+def _seg_dash_C(argv) -> str | None:
+    """The dir named by a ``git -C <dir>`` in a segment's argv, else None."""
+    argv = argv or []
+    for i, tok in enumerate(argv):
+        if tok == "-C" and i + 1 < len(argv):
+            return argv[i + 1]
+    return None
+
+
+def _cd_target(raw: str):
+    """Classify a top-level command segment as a ``cd``.
+
+    Returns the literal target dir when ``raw`` is a plain ``cd <literal-path>``
+    segment; ``_CWD_UNKNOWN`` when it is a cd we cannot resolve (no arg, ``cd -``,
+    a variable/command-substitution/glob target, or a subshell/group that would
+    scope the cd); ``None`` when it is not a cd at all. Because ``split_segments``
+    already split on shell operators, a genuine cd segment is exactly ``cd <path>``.
+    """
+    s = raw.strip()
+    # A subshell/group ( … ) / { … } scopes its cd — we cannot track it.
+    if s.startswith("(") or s.startswith("{"):
+        return _CWD_UNKNOWN
+    m = re.match(r"^cd(?:\s+(?P<p>.*))?$", s)
+    if not m:
+        return None
+    p = (m.group("p") or "").strip()
+    if not p or p == "-":
+        return _CWD_UNKNOWN  # `cd` (home) / `cd -` (previous) — unresolvable here
+    # Quoted target.
+    if len(p) >= 2 and p[0] in "'\"" and p[-1] == p[0]:
+        inner = p[1:-1]
+        if p[0] == '"' and ("$" in inner or "`" in inner):
+            return _CWD_UNKNOWN  # double-quote expansion
+        return inner
+    if " " in p or "\t" in p:
+        return _CWD_UNKNOWN  # extra args / unexpected shape → don't guess
+    if p.startswith("~"):
+        p = os.path.expanduser(p)
+    if any(ch in p for ch in "$`*?"):
+        return _CWD_UNKNOWN  # expansion or glob → unresolvable
+    return p
+
+
+def _effective_cwd(cmd: str, payload: dict, seg=None):
+    """The directory where a SINGLE target segment actually runs.
+
+    Returns ``str`` (resolved), ``None`` (no cwd info → run in the hook's own
+    cwd), or ``_CWD_UNKNOWN`` (ambiguous → caller must fail closed). Resolution:
+      1. ``git -C <dir>`` on the target segment's argv (explicit).
+      2. If the target is nested (depth>0, inside bash -c/subshell/$()), UNKNOWN.
+      3. Else the LAST top-level ``cd`` that runs BEFORE the target segment —
+         bash applies cds sequentially, so the last one wins (an unresolvable cd
+         before the target ⇒ UNKNOWN). Falls back to the payload cwd as the base.
+    Used for single-target callers (push); the merge check uses the multi-target
+    walk in ``_walk_merge_into_main`` so every merge in a compound is covered.
+    """
+    if seg is not None:
+        dash_c = _seg_dash_C(getattr(seg, "argv", None))
+        if dash_c is not None:
+            return dash_c
+        if getattr(seg, "depth", 0) > 0:
+            return _CWD_UNKNOWN
+    base = payload.get("cwd") if isinstance(payload, dict) else None
+    cur = base if isinstance(base, str) and base else None
+    target_raw = getattr(seg, "raw", None)
+    if target_raw is not None:
+        for raw in split_segments(cmd):
+            if raw == target_raw:
+                return cur  # cwd in effect when the target segment runs
+            cd = _cd_target(raw)
+            if cd is _CWD_UNKNOWN:
+                cur = _CWD_UNKNOWN
+            elif cd is not None:
+                cur = cd
+    return cur
+
+
+def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool:
+    """True if ANY executed ``git merge`` would run on main/master (fail-closed).
+
+    Walks the top-level segments in bash order tracking cwd (last literal ``cd``
+    wins), and checks EACH ``git merge`` as it would actually run — so a compound
+    like ``git -C <feat-wt> merge a && git merge b`` cannot smuggle the second
+    (bare) merge into main behind the first. A per-segment
+    ``# merge-to-main-override`` acknowledges that segment. Fail closed: a merge
+    nested at depth>0 (bash -c / subshell / ``$()``) or reached under an
+    unresolvable cd is treated as targeting main and blocked (unless overridden).
+    """
+    # depth>0 merges cannot be associated with a top-level cwd → fail closed.
+    for s in merge_git_segs:
+        if getattr(s, "depth", 0) > 0 and not has_trailing_override(
+            s.raw, "merge-to-main-override"
+        ):
+            return True
+
+    base = payload.get("cwd") if isinstance(payload, dict) else None
+    cur = base if isinstance(base, str) and base else None
+    for raw in split_segments(cmd):
+        top = [s for s in analyze(raw) if getattr(s, "depth", 0) == 0]
+        merge_here = next(
+            (s for s in top if s.exe == "git" and git_subcommand(s.argv) == "merge"),
+            None,
+        )
+        if merge_here is not None and not has_trailing_override(raw, "merge-to-main-override"):
+            mcwd = _seg_dash_C(merge_here.argv)
+            if mcwd is None:
+                mcwd = cur
+            if mcwd is _CWD_UNKNOWN:
+                return True
+            branch = _current_branch(cwd=mcwd if isinstance(mcwd, str) else None)
+            if branch in ("main", "master"):
+                return True
+        cd = _cd_target(raw)
+        if cd is _CWD_UNKNOWN:
+            cur = _CWD_UNKNOWN
+        elif cd is not None:
+            cur = cd
+    return False
+
+
+def _get_push_remote_and_branch(cmd: str, cwd: str | None = None) -> tuple[str | None, str | None]:
     """Parse git push command to determine target remote and branch.
 
-    Returns (remote, branch) or (None, None) if can't determine.
+    Returns (remote, branch) or (None, None) if can't determine. ``cwd`` is the
+    effective worktree dir, used to resolve the current branch label correctly.
     """
     parts = cmd.split()
     # Find 'push' position
@@ -76,10 +218,10 @@ def _get_push_remote_and_branch(cmd: str) -> tuple[str | None, str | None]:
 
     if len(args) == 0:
         # Bare 'git push' — pushes current branch to its upstream
-        return "upstream", _current_branch()
+        return "upstream", _current_branch(cwd=cwd)
     if len(args) == 1:
         # 'git push origin' — pushes current branch to remote
-        return args[0], _current_branch()
+        return args[0], _current_branch(cwd=cwd)
     if len(args) >= 2:
         # 'git push origin main' or 'git push origin feature:main'
         remote = args[0]
@@ -537,6 +679,86 @@ def _push_is_force(argv: list[str]) -> bool:
     return False
 
 
+def _push_named_remote(argv: list[str]) -> str | None:
+    """The remote named on a ``git push <remote> …``, else None.
+
+    argv is quote-stripped from ``shell_parse``. Skips git global options (and
+    their values), the ``push`` token, and push flags/values; the first bare
+    positional after that is the remote. A ``+<refspec>`` positional is NOT a
+    remote (it is a force refspec) and is skipped.
+    """
+    i = 1  # skip argv[0] == "git"
+    # advance past git global options to the `push` token
+    while i < len(argv):
+        t = argv[i]
+        if t in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        break
+    if i >= len(argv) or argv[i] != "push":
+        return None
+    i += 1
+    while i < len(argv):
+        t = argv[i]
+        if t in _PUSH_VALUE_FLAGS:
+            i += 2
+            continue
+        if t.startswith("-") or t.startswith("+"):
+            i += 1
+            continue
+        return t  # first bare positional after `push` is the remote
+    return None
+
+
+def _resolve_push_remote(seg, cwd: str | None = None) -> str | None:
+    """The target remote for a ``git push`` segment, or None if UNKNOWN.
+
+    Resolution order: an explicitly named remote → that; else the current
+    branch's upstream remote (the part before ``/`` of ``@{upstream}``); else
+    None. Callers FAIL CLOSED on None — an undeterminable remote is treated as
+    origin/public and blocked.
+    """
+    remote = _push_named_remote(getattr(seg, "argv", None) or [])
+    if remote:
+        return remote
+    try:
+        args = ["git"]
+        if cwd:
+            args += ["-C", cwd]
+        args += ["rev-parse", "--abbrev-ref", "@{upstream}"]
+        result = subprocess.run(args, capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            upstream = result.stdout.strip()
+            if "/" in upstream:
+                return upstream.split("/", 1)[0]
+    except Exception:
+        pass
+    return None
+
+
+def _remote_url(name: str, cwd: str | None = None) -> str | None:
+    """The fetch/push URL configured for remote ``name``, or None if unresolvable.
+
+    Classifying a force-push target by NAME is spoofable — ``git remote add
+    mirror <origin-url>`` gives a non-"origin" name that still points at the
+    PUBLIC repo. Callers compare this URL against origin's to decide whether a
+    force actually rewrites public history; an unresolvable URL FAILS CLOSED.
+    """
+    try:
+        args = ["git"]
+        if cwd:
+            args += ["-C", cwd]
+        args += ["remote", "get-url", name]
+        result = subprocess.run(args, capture_output=True, text=True, timeout=5)
+        url = result.stdout.strip()
+        return url if result.returncode == 0 and url else None
+    except Exception:
+        return None
+
+
 def _ask(reason: str) -> int:
     """Emit a PreToolUse ``ask`` decision — a native approve/deny dialog.
 
@@ -615,7 +837,8 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
 
 def main() -> int:
     try:
-        cmd = field(read_payload(), "command")
+        payload = read_payload()
+        cmd = field(payload, "command")
         if not cmd:
             return 0
 
@@ -662,46 +885,94 @@ def main() -> int:
         # tool). The old `# review-override` token is dropped for push: the
         # dialog replaces it, so the agent can no longer self-approve.
         if push_segs:
-            # Force push is destructive — hard-block in EVERY session (never a
-            # mere ask). argv-based (via shell_parse) so a quoted `'-f'` or a
-            # `--force-with-lease` cannot evade it into a generic approval prompt.
-            if any(_push_is_force(s.argv) for s in push_segs):
-                print(
-                    "BLOCKED: Force push is not allowed — open a PR instead.",
-                    file=sys.stderr,
+            _pcwd = _effective_cwd(cmd, payload, seg=push_segs[0])
+            pcwd_unknown = _pcwd is _CWD_UNKNOWN
+            pcwd = _pcwd if isinstance(_pcwd, str) else None
+            # Force push is destructive. argv-based force detection (via
+            # shell_parse) so a quoted `'-f'` / `--force-with-lease` / bundled
+            # `-uf` / `+refspec` all still count and cannot evade into a generic
+            # prompt.
+            #
+            # SECURITY INVARIANT: a force push is HARD-BLOCKED in ALL sessions
+            # whenever it targets the public repo. "Public" is decided by URL, not
+            # remote name — an explicit `origin`, an UNKNOWN/None remote, an
+            # ambiguous cwd, OR a differently-named remote whose URL EQUALS
+            # origin's (e.g. `git remote add mirror <origin-url>`) all count as
+            # public ⇒ blocked (fail closed). Only a remote whose URL is
+            # resolvable AND differs from origin's gets the softer cautious-ask
+            # path — interactive asks (rewrites remote history), dispatched denies.
+            force_segs = [s for s in push_segs if _push_is_force(s.argv)]
+            if force_segs:
+                remote = _resolve_push_remote(force_segs[0], cwd=pcwd)
+                if pcwd_unknown or remote is None or remote == "origin":
+                    print(
+                        "BLOCKED: Force push to origin/<public> is not allowed — open a PR.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                # Classify by URL — a non-"origin" name pointing at origin's repo
+                # is still a public force push. Unresolvable URL ⇒ fail closed.
+                remote_url = _remote_url(remote, cwd=pcwd)
+                origin_url = _remote_url("origin", cwd=pcwd)
+                if remote_url is None or origin_url is None or remote_url == origin_url:
+                    print(
+                        "BLOCKED: Force push to origin/<public> is not allowed — open a PR.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                # Definitely a different repo from origin → cautious, never silent.
+                if _is_dispatched():
+                    print(
+                        f"BLOCKED: force push rewrites remote history on "
+                        f"'{remote}'; autonomous/dispatched sessions cannot "
+                        f"force-push.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                ask_reason = (
+                    f"FORCE push detected — this REWRITES remote history on "
+                    f"'{remote}' (a non-origin remote). Approve only if you "
+                    f"intend to rewrite that remote's history."
                 )
-                return 2
-            _remote, branch = _get_push_remote_and_branch(cmd)
-            if _is_dispatched():
-                print(
-                    f"BLOCKED: git push requires user approval before "
-                    f"publishing code externally (target: {branch or 'default'}).",
-                    file=sys.stderr,
+                # Fall through: any hard-block below still takes precedence.
+            else:
+                # Non-force push: interactive asks, dispatched hard-denies.
+                _remote, branch = _get_push_remote_and_branch(cmd, cwd=pcwd)
+                if _is_dispatched():
+                    print(
+                        f"BLOCKED: git push requires user approval before "
+                        f"publishing code externally (target: {branch or 'default'}).",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "Autonomous/dispatched sessions cannot push directly — "
+                        "delivery goes through the scope-gated server path.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                ask_reason = (
+                    f"git push needs your approval before publishing externally "
+                    f"(target: {branch or 'default'})."
                 )
-                print(
-                    "Autonomous/dispatched sessions cannot push directly — "
-                    "delivery goes through the scope-gated server path.",
-                    file=sys.stderr,
-                )
-                return 2
-            ask_reason = (
-                f"git push needs your approval before publishing externally "
-                f"(target: {branch or 'default'})."
-            )
 
         # ── git merge into main ─────────────────────────────────────
-        if merge_git_segs:
-            current = _current_branch()
-            if current in ("main", "master"):
-                print(
-                    "BLOCKED: Merging into main directly is not allowed.",
-                    file=sys.stderr,
-                )
-                print(
-                    "Use the PR workflow instead.",
-                    file=sys.stderr,
-                )
-                return 2
+        # Worktree-aware AND compound-aware: EVERY git-merge in the command is
+        # checked in the dir it actually runs (git -C / the last cd before it /
+        # payload cwd), NOT just the first segment and NOT the hook's own cwd — so
+        # a feature-branch merge cannot chaperone a second bare `git merge` into
+        # main. A per-segment `# merge-to-main-override` acknowledges an intended
+        # on-main merge; an ambiguous cwd fails closed (blocked). See
+        # _walk_merge_into_main.
+        if merge_git_segs and _walk_merge_into_main(cmd, payload, merge_git_segs):
+            print(
+                "BLOCKED: Merging into main directly is not allowed.",
+                file=sys.stderr,
+            )
+            print(
+                "Use the PR workflow instead.",
+                file=sys.stderr,
+            )
+            return 2
 
         # ── gh pr create ────────────────────────────────────────────
         # Un-gated when its branch is already on the remote — opening a PR is then

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -113,50 +113,69 @@ def _cd_target(raw: str):
     return p
 
 
+def _resolve_against(current, target: str):
+    """Resolve a possibly-relative ``cd``/``-C`` target to an ABSOLUTE path.
+
+    An absolute target is normalized and returned (it recovers even from a prior
+    ``_CWD_UNKNOWN``). A relative target is joined onto ``current``; if
+    ``current`` is unknown/None the result is ``_CWD_UNKNOWN`` (fail closed) —
+    a relative path with no known base cannot be resolved, and running
+    ``git -C <relative>`` from the hook's own cwd would silently target the wrong
+    tree (P1-A).
+    """
+    if os.path.isabs(target):
+        return os.path.normpath(target)
+    if not isinstance(current, str) or not current:
+        return _CWD_UNKNOWN
+    return os.path.normpath(os.path.join(current, target))
+
+
 def _effective_cwd(cmd: str, payload: dict, seg=None):
-    """The directory where a SINGLE target segment actually runs.
+    """The ABSOLUTE directory where a SINGLE target segment actually runs.
 
     Returns ``str`` (resolved), ``None`` (no cwd info → run in the hook's own
     cwd), or ``_CWD_UNKNOWN`` (ambiguous → caller must fail closed). Resolution:
-      1. ``git -C <dir>`` on the target segment's argv (explicit).
-      2. If the target is nested (depth>0, inside bash -c/subshell/$()), UNKNOWN.
-      3. Else the LAST top-level ``cd`` that runs BEFORE the target segment —
-         bash applies cds sequentially, so the last one wins (an unresolvable cd
-         before the target ⇒ UNKNOWN). Falls back to the payload cwd as the base.
+      1. If the target is nested (depth>0, inside bash -c/subshell/$()), UNKNOWN.
+      2. The LAST top-level ``cd`` that runs BEFORE the target segment — bash
+         applies cds sequentially, so the last one wins; relative cds/-C are
+         resolved against the running cwd, and an unresolvable one ⇒ UNKNOWN.
+      3. ``git -C <dir>`` on the target segment's argv overrides, resolved
+         against the cwd in effect at the target.
     Used for single-target callers (push); the merge check uses the multi-target
     walk in ``_walk_merge_into_main`` so every merge in a compound is covered.
     """
-    if seg is not None:
-        dash_c = _seg_dash_C(getattr(seg, "argv", None))
-        if dash_c is not None:
-            return dash_c
-        if getattr(seg, "depth", 0) > 0:
-            return _CWD_UNKNOWN
+    if seg is not None and getattr(seg, "depth", 0) > 0:
+        return _CWD_UNKNOWN
     base = payload.get("cwd") if isinstance(payload, dict) else None
-    cur = base if isinstance(base, str) and base else None
+    cur = os.path.normpath(base) if isinstance(base, str) and base else None
     target_raw = getattr(seg, "raw", None)
     if target_raw is not None:
         for raw in split_segments(cmd):
             if raw == target_raw:
-                return cur  # cwd in effect when the target segment runs
+                break
             cd = _cd_target(raw)
             if cd is _CWD_UNKNOWN:
                 cur = _CWD_UNKNOWN
             elif cd is not None:
-                cur = cd
+                cur = _resolve_against(cur, cd)
+    if seg is not None:
+        dash_c = _seg_dash_C(getattr(seg, "argv", None))
+        if dash_c is not None:
+            return _resolve_against(cur, dash_c)
     return cur
 
 
 def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool:
     """True if ANY executed ``git merge`` would run on main/master (fail-closed).
 
-    Walks the top-level segments in bash order tracking cwd (last literal ``cd``
-    wins), and checks EACH ``git merge`` as it would actually run — so a compound
-    like ``git -C <feat-wt> merge a && git merge b`` cannot smuggle the second
-    (bare) merge into main behind the first. A per-segment
-    ``# merge-to-main-override`` acknowledges that segment. Fail closed: a merge
-    nested at depth>0 (bash -c / subshell / ``$()``) or reached under an
-    unresolvable cd is treated as targeting main and blocked (unless overridden).
+    Walks the top-level segments in bash order tracking the ABSOLUTE cwd (last
+    ``cd`` wins; relative cds/-C resolved against it), and checks EACH ``git
+    merge`` as it would actually run — so a compound like ``git -C <feat-wt>
+    merge a && git merge b`` cannot smuggle the second (bare) merge into main
+    behind the first. A per-segment ``# merge-to-main-override`` acknowledges that
+    segment. Fail closed: a merge nested at depth>0, reached under an unresolvable
+    cwd, OR whose branch cannot be read (None) is treated as targeting main and
+    blocked (unless overridden). A detached HEAD ("") is left allowed.
     """
     # depth>0 merges cannot be associated with a top-level cwd → fail closed.
     for s in merge_git_segs:
@@ -166,7 +185,7 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
             return True
 
     base = payload.get("cwd") if isinstance(payload, dict) else None
-    cur = base if isinstance(base, str) and base else None
+    cur = os.path.normpath(base) if isinstance(base, str) and base else None
     for raw in split_segments(cmd):
         top = [s for s in analyze(raw) if getattr(s, "depth", 0) == 0]
         merge_here = next(
@@ -174,19 +193,18 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
             None,
         )
         if merge_here is not None and not has_trailing_override(raw, "merge-to-main-override"):
-            mcwd = _seg_dash_C(merge_here.argv)
-            if mcwd is None:
-                mcwd = cur
+            dash_c = _seg_dash_C(merge_here.argv)
+            mcwd = _resolve_against(cur, dash_c) if dash_c is not None else cur
             if mcwd is _CWD_UNKNOWN:
                 return True
             branch = _current_branch(cwd=mcwd if isinstance(mcwd, str) else None)
-            if branch in ("main", "master"):
-                return True
+            if branch is None or branch in ("main", "master"):
+                return True  # None branch (error/unresolved) fails closed
         cd = _cd_target(raw)
         if cd is _CWD_UNKNOWN:
             cur = _CWD_UNKNOWN
         elif cd is not None:
-            cur = cd
+            cur = _resolve_against(cur, cd)
     return False
 
 
@@ -713,15 +731,37 @@ def _push_named_remote(argv: list[str]) -> str | None:
     return None
 
 
-def _resolve_push_remote(seg, cwd: str | None = None) -> str | None:
-    """The target remote for a ``git push`` segment, or None if UNKNOWN.
+def _push_repo_flag(argv: list[str]) -> str | None:
+    """The value of a ``--repo <value>`` / ``--repo=value`` on a git push, else None.
 
-    Resolution order: an explicitly named remote → that; else the current
-    branch's upstream remote (the part before ``/`` of ``@{upstream}``); else
-    None. Callers FAIL CLOSED on None — an undeterminable remote is treated as
-    origin/public and blocked.
+    ``git push --repo <dest>`` overrides both the positional remote and the
+    branch upstream as the push DESTINATION (P1-C), so it must win when deciding
+    what a force push actually targets. The value may be a remote name OR a URL.
     """
-    remote = _push_named_remote(getattr(seg, "argv", None) or [])
+    i = 0
+    while i < len(argv):
+        t = argv[i]
+        if t == "--repo" and i + 1 < len(argv):
+            return argv[i + 1]
+        if t.startswith("--repo="):
+            return t.split("=", 1)[1]
+        i += 1
+    return None
+
+
+def _resolve_push_remote(seg, cwd: str | None = None) -> str | None:
+    """The push DESTINATION (remote name or URL) for a segment, or None if UNKNOWN.
+
+    Resolution order: an explicit ``--repo <dest>`` (P1-C) → an explicitly named
+    positional remote → else the current branch's upstream remote (the part
+    before ``/`` of ``@{upstream}``); else None. Callers FAIL CLOSED on None — an
+    undeterminable destination is treated as origin/public and blocked.
+    """
+    argv = getattr(seg, "argv", None) or []
+    repo = _push_repo_flag(argv)
+    if repo:
+        return repo
+    remote = _push_named_remote(argv)
     if remote:
         return remote
     try:
@@ -739,24 +779,51 @@ def _resolve_push_remote(seg, cwd: str | None = None) -> str | None:
     return None
 
 
-def _remote_url(name: str, cwd: str | None = None) -> str | None:
-    """The fetch/push URL configured for remote ``name``, or None if unresolvable.
+def _looks_like_url(dest: str) -> bool:
+    """Whether a push destination is a URL/path rather than a remote NAME."""
+    return (
+        "://" in dest
+        or "@" in dest
+        or ":" in dest  # scp-like git@host:path or host:path
+        or dest.startswith(("/", "./", "../", "~"))
+    )
 
-    Classifying a force-push target by NAME is spoofable — ``git remote add
-    mirror <origin-url>`` gives a non-"origin" name that still points at the
-    PUBLIC repo. Callers compare this URL against origin's to decide whether a
-    force actually rewrites public history; an unresolvable URL FAILS CLOSED.
+
+def _remote_push_urls(name: str, cwd: str | None = None) -> set[str]:
+    """The set of PUSH urls configured for a remote NAME (empty if unresolvable).
+
+    git pushes to the PUSH url, which can differ from the fetch url
+    (``git remote set-url --push``), so classifying by the fetch url misses a
+    public push target (P1-B). ``--push --all`` returns every push url (one per
+    line). An empty set means the name is not a resolvable remote → callers FAIL
+    CLOSED.
     """
     try:
         args = ["git"]
         if cwd:
             args += ["-C", cwd]
-        args += ["remote", "get-url", name]
+        args += ["remote", "get-url", "--push", "--all", name]
         result = subprocess.run(args, capture_output=True, text=True, timeout=5)
-        url = result.stdout.strip()
-        return url if result.returncode == 0 and url else None
+        if result.returncode == 0:
+            return {ln.strip() for ln in result.stdout.splitlines() if ln.strip()}
     except Exception:
-        return None
+        pass
+    return set()
+
+
+def _push_dest_urls(dest: str, cwd: str | None = None) -> set[str]:
+    """Push-url set for a destination that may be a remote NAME or a raw URL/path.
+
+    A known remote name resolves to its ``--push`` urls; otherwise, if the
+    destination looks like a URL/path (e.g. a ``--repo https://…`` value), it IS
+    the target url. An unresolvable name yields an empty set (fail closed).
+    """
+    urls = _remote_push_urls(dest, cwd)
+    if urls:
+        return urls
+    if _looks_like_url(dest):
+        return {dest}
+    return set()
 
 
 def _ask(reason: str) -> int:
@@ -894,13 +961,14 @@ def main() -> int:
             # prompt.
             #
             # SECURITY INVARIANT: a force push is HARD-BLOCKED in ALL sessions
-            # whenever it targets the public repo. "Public" is decided by URL, not
-            # remote name — an explicit `origin`, an UNKNOWN/None remote, an
-            # ambiguous cwd, OR a differently-named remote whose URL EQUALS
-            # origin's (e.g. `git remote add mirror <origin-url>`) all count as
-            # public ⇒ blocked (fail closed). Only a remote whose URL is
-            # resolvable AND differs from origin's gets the softer cautious-ask
-            # path — interactive asks (rewrites remote history), dispatched denies.
+            # whenever it targets the public repo. "Public" is decided by PUSH URL,
+            # not remote name — an explicit `origin`, an UNKNOWN/None destination,
+            # an ambiguous cwd, a `--repo origin` (P1-C), OR a differently-named
+            # remote whose PUSH url set INTERSECTS origin's (e.g. `git remote add
+            # mirror <origin-url>`, or a `set-url --push` to origin's url, P1-B)
+            # all count as public ⇒ blocked (fail closed). Only a destination
+            # whose push urls resolve AND are DISJOINT from origin's gets the
+            # softer cautious-ask path — interactive asks, dispatched denies.
             force_segs = [s for s in push_segs if _push_is_force(s.argv)]
             if force_segs:
                 remote = _resolve_push_remote(force_segs[0], cwd=pcwd)
@@ -910,11 +978,11 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     return 2
-                # Classify by URL — a non-"origin" name pointing at origin's repo
-                # is still a public force push. Unresolvable URL ⇒ fail closed.
-                remote_url = _remote_url(remote, cwd=pcwd)
-                origin_url = _remote_url("origin", cwd=pcwd)
-                if remote_url is None or origin_url is None or remote_url == origin_url:
+                # Classify by PUSH-url set — a non-"origin" name/url that shares any
+                # push url with origin is still a public force. Unresolvable ⇒ block.
+                dest_urls = _push_dest_urls(remote, cwd=pcwd)
+                origin_urls = _remote_push_urls("origin", cwd=pcwd)
+                if not dest_urls or not origin_urls or (dest_urls & origin_urls):
                     print(
                         "BLOCKED: Force push to origin/<public> is not allowed — open a PR.",
                         file=sys.stderr,

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -128,57 +128,191 @@ def _cd_target(raw: str):
     return p
 
 
+def _resolve_against(current, target: str):
+    """Resolve a possibly-relative ``cd``/``-C`` target to an ABSOLUTE path.
+
+    Absolute → normalized (recovers even from a prior UNKNOWN). Relative → joined
+    onto ``current``; if ``current`` is unknown/None → ``_CWD_UNKNOWN`` (fail
+    closed), since ``git -C <relative>`` from the hook's own cwd would silently
+    inspect the wrong tree (P1-A).
+    """
+    if os.path.isabs(target):
+        return os.path.normpath(target)
+    if not isinstance(current, str) or not current:
+        return _CWD_UNKNOWN
+    return os.path.normpath(os.path.join(current, target))
+
+
 def _effective_diff_cwd(command: str, payload: dict, segs: list):
-    """The dir whose index the commit inspects — ``str``, ``None``, or ``_CWD_UNKNOWN``.
+    """The ABSOLUTE dir whose index the commit inspects — ``str``/``None``/UNKNOWN.
 
     Resolution mirrors git_push_guard (self-contained; no import):
-      1. ``git -C <dir>`` on a commit segment's argv.
-      2. If the commit is nested (depth>0), UNKNOWN → fail closed.
-      3. Else the LAST top-level ``cd`` before the commit segment (bash applies
-         cds sequentially, so the last one wins — a decoy ``cd A && …; cd B &&
-         git commit`` runs in B, not A). An unresolvable cd before the commit ⇒
-         UNKNOWN. Falls back to the payload cwd as the base.
+      1. If the commit is nested (depth>0), UNKNOWN → fail closed.
+      2. The LAST top-level ``cd`` before the commit segment (bash applies cds
+         sequentially, so the last wins — a decoy ``cd A && …; cd B && git
+         commit`` runs in B). Relative cds/-C resolve against the running cwd; an
+         unresolvable one ⇒ UNKNOWN. Falls back to the payload cwd as the base.
+      3. ``git -C <dir>`` on the commit segment overrides, resolved against that.
     """
     commit_seg = next((s for s in segs if git_subcommand(s.argv) == "commit"), None)
-    if commit_seg is not None:
-        dash_c = _seg_dash_C(getattr(commit_seg, "argv", None))
-        if dash_c is not None:
-            return dash_c
-        if getattr(commit_seg, "depth", 0) > 0:
-            return _CWD_UNKNOWN
+    if commit_seg is not None and getattr(commit_seg, "depth", 0) > 0:
+        return _CWD_UNKNOWN
 
     base = payload.get("cwd") if isinstance(payload, dict) else None
-    cur = base if isinstance(base, str) and base else None
+    cur = os.path.normpath(base) if isinstance(base, str) and base else None
     target_raw = getattr(commit_seg, "raw", None) if commit_seg is not None else None
     if target_raw is not None:
         for raw in split_segments(command):
             if raw == target_raw:
-                return cur
+                break
             cd = _cd_target(raw)
             if cd is _CWD_UNKNOWN:
                 cur = _CWD_UNKNOWN
             elif cd is not None:
-                cur = cd
+                cur = _resolve_against(cur, cd)
+    if commit_seg is not None:
+        dash_c = _seg_dash_C(getattr(commit_seg, "argv", None))
+        if dash_c is not None:
+            return _resolve_against(cur, dash_c)
     return cur
 
 
 def _staged_files(cwd: str | None) -> list[str] | None:
     """Staged paths for the pending commit, or None if the diff cannot be read.
 
-    None (command failed / error) is the caller's signal to fall back to normal
-    enforcement rather than skip.
+    Uses ``--name-status -M`` so renames/copies surface BOTH sides (P2-E): a
+    ``foo.py → README.md`` rename shows only ``README.md`` under ``--name-only``,
+    which would wrongly read as docs-only. Both the source and the destination
+    are returned, so a code source still forces review. None (command error) is
+    the caller's signal to fall back to normal enforcement rather than skip.
     """
     args = ["git"]
     if cwd:
         args += ["-C", cwd]
-    args += ["diff", "--cached", "--name-only"]
+    args += ["diff", "--cached", "--name-status", "-M"]
     try:
         result = subprocess.run(args, capture_output=True, text=True, timeout=10)
         if result.returncode != 0:
             return None
-        return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+        paths: list[str] = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            status = parts[0]
+            # Rename/Copy: `R100<TAB>old<TAB>new` / `C075<TAB>old<TAB>new` — both
+            # the source and the destination path are relevant.
+            if status[:1] in ("R", "C") and len(parts) >= 3:
+                paths.append(parts[1])
+                paths.append(parts[2])
+            elif len(parts) >= 2:
+                paths.append(parts[-1])
+        return paths
     except Exception:
         return None
+
+
+# ── Pure-commit gate for the docs/config skip (P1-D) ─────────────────────
+# The staged index at hook time is NOT what a commit necessarily records:
+# `git commit -a` stages tracked changes, `git commit -m x app.py` selects a
+# pathspec, and `git add app.py && git commit` stages code in a prior segment.
+# The docs-only skip may fire ONLY for a "pure" bare commit that provably cannot
+# add or select content beyond the current --cached snapshot.
+_GIT_GLOBAL_VALUE_FLAGS = frozenset(
+    {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix"}
+)
+# git commit long flags that CONSUME a following value token (so the value is not
+# misread as a pathspec).
+_COMMIT_VALUE_LONG = frozenset(
+    {
+        "--message",
+        "--file",
+        "--author",
+        "--date",
+        "--template",
+        "--reuse-message",
+        "--reedit-message",
+        "--fixup",
+        "--squash",
+        "--gpg-sign",
+        "--cleanup",
+    }
+)
+# Long flags that select/stage content beyond the index → not a pure commit.
+_COMMIT_SELECT_LONG = frozenset(
+    {"--all", "--include", "--only", "--patch", "--interactive", "--pathspec-from-file"}
+)
+_COMMIT_ARG_SHORT = "mFCct"  # short flags consuming a value (t = --template)
+_COMMIT_SELECT_SHORT = "aiop"  # -a --all, -i --include, -o --only, -p --patch
+
+
+def _commit_can_select_content(argv: list[str]) -> bool:
+    """Whether a ``git commit`` argv could stage/select content (pathspec or
+    -a/-i/-o/-p/--all/…): True ⇒ NOT a pure commit ⇒ do not take the docs skip."""
+    # advance to the "commit" token, past git global options
+    i = 1
+    while i < len(argv):
+        t = argv[i]
+        if t in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        break
+    if i >= len(argv) or argv[i] != "commit":
+        return True  # can't confirm shape → fail toward enforcement
+    i += 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            return (i + 1) < len(argv)  # any pathspec after `--`
+        if tok.startswith("--"):
+            name = tok.split("=", 1)[0]
+            if name in _COMMIT_SELECT_LONG:
+                return True
+            if name in _COMMIT_VALUE_LONG and "=" not in tok:
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok.startswith("-") and len(tok) > 1:
+            consumes_next = False
+            for j, ch in enumerate(tok[1:], 1):
+                if ch in _COMMIT_SELECT_SHORT:
+                    return True
+                if ch == "S":
+                    break  # -S[keyid]: rest of token is an optional value
+                if ch in _COMMIT_ARG_SHORT:
+                    consumes_next = j == len(tok) - 1  # value is next token if last
+                    break
+                # else a boolean short flag (n/e/s/q/v/u/z/…) — keep scanning
+            i += 2 if consumes_next else 1
+            continue
+        return True  # a bare positional = pathspec
+    return False
+
+
+def _commit_may_add_content(segs: list) -> bool:
+    """True if the command could commit content the --cached snapshot doesn't show.
+
+    Covers the commit segment's own pathspec/select flags AND any staging command
+    (git add/rm/mv/reset, or restore --staged) elsewhere in the chain (P1-D).
+    """
+    commit_seg = next((s for s in segs if git_subcommand(s.argv) == "commit"), None)
+    if commit_seg is None:
+        return True
+    if _commit_can_select_content(commit_seg.argv):
+        return True
+    for s in segs:
+        if s is commit_seg:
+            continue
+        sub = git_subcommand(s.argv)
+        if sub in ("add", "rm", "mv", "reset"):
+            return True
+        if sub == "restore" and "--staged" in s.argv:
+            return True
+    return False
 
 
 def main() -> None:
@@ -250,15 +384,17 @@ def main() -> None:
     # Docs/config-only skip: a commit whose ENTIRE staged set is documentation
     # or config carries no code to review (adaptive-review "review level: None"),
     # so skip Rule 2 for it. Conservative fail-toward-review default: we skip ONLY
-    # when the staged set is non-empty AND every path is on the docs/config
-    # allowlist. An empty staged set (e.g. a "git add && git commit" chain that
-    # stages in-command), a diff we cannot read, or an ambiguous cwd (already
-    # blocked by Rule 1 above) falls through to normal enforcement — never
-    # skipped. Placed AFTER Rule 0 (--no-verify) and Rule 1 (main-branch) so it
-    # can never weaken those hard blocks.
-    staged = _staged_files(cwd)
-    if staged and all(_is_docs_or_config(p) for p in staged):
-        sys.exit(0)
+    # when (a) the commit is PURE — it cannot add/select content beyond the
+    # current index (no pathspec, no -a/-i/-o/-p, and no git add/rm/mv/reset in
+    # the chain, P1-D) — AND (b) the staged set is non-empty and every path is on
+    # the docs/config allowlist. An impure commit, an empty staged set, a diff we
+    # cannot read, or an ambiguous cwd (already blocked by Rule 1) falls through
+    # to normal enforcement — never skipped. Placed AFTER Rule 0 (--no-verify) and
+    # Rule 1 (main-branch) so it can never weaken those hard blocks.
+    if not _commit_may_add_content(segs):
+        staged = _staged_files(cwd)
+        if staged and all(_is_docs_or_config(p) for p in staged):
+            sys.exit(0)
 
     # Rule 2: Block commits without review (on branches)
     # Race condition: when command is "git add X && git commit", nothing is

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -16,13 +16,24 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 
 # The shared hook-input helper lives in scripts/hooks/; this script runs from
 # scripts/ (a different sys.path[0]), so add the hooks dir before importing it.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "hooks"))
 from hook_input import field, read_payload  # noqa: E402
-from shell_parse import analyze, commit_skips_hooks, git_subcommand  # noqa: E402
+from shell_parse import (  # noqa: E402
+    analyze,
+    commit_skips_hooks,
+    git_subcommand,
+    split_segments,
+)
+
+# Sentinel: the commit's effective cwd cannot be confidently resolved (a cd into
+# a variable/command-substitution, a subshell, or a commit nested at depth>0).
+# Fail closed on it — treat as main (block Rule 1) and do NOT take the docs skip.
+_CWD_UNKNOWN = object()
 
 # Cheap early-out: a raw command that never mentions "git commit" is not a
 # commit. Actual detection (through wrappers, bash -c, etc.) uses shell_parse.
@@ -50,23 +61,130 @@ def _commit_override(command: str, segs: list) -> str:
     return "none"
 
 
-def _extract_working_dir(command: str) -> str | None:
-    """Extract the effective working directory from a Bash command.
+# ── Docs/config-only skip (adaptive-review "review level: None") ──────────
+# Pure docs/config commits carry no code to review, so the review protocol rates
+# them "review level: None". The extension/basename allowlist below is the set we
+# will SKIP enforcement for when EVERY staged path matches. Anything else — a
+# .py/.js/.ts/.sh/.json, or any unrecognized extension — is treated as code and
+# still gated (fail TOWARD requiring review).
+_DOCS_CONFIG_EXTS = {".md", ".rst", ".txt", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+_DOCS_CONFIG_BASENAMES = {"CHANGELOG", "LICENSE", ".GITIGNORE"}  # compared upper-cased
 
-    When CC runs in a worktree, commands typically start with
-    'cd /path/to/worktree && ...'.  Extract that path so git commands
-    in review_state.py run in the correct directory.
+
+def _is_docs_or_config(path: str) -> bool:
+    """Whether a staged path is a docs/config file (per the conservative allowlist).
+
+    Anything under a ``.github/`` directory is NEVER docs/config: GitHub Actions
+    workflows are executable CI config (arbitrary ``run:`` with repo secrets), so
+    a workflow-only commit MUST still be reviewed even though it is ``.yml``.
     """
-    m = re.match(r"^cd\s+([^\s&|;]+)", command)
+    norm = path.replace("\\", "/")
+    if ".github" in norm.split("/"):  # leading `.github/` or any `/.github/` component
+        return False
+    base = os.path.basename(norm)
+    if base.upper() in _DOCS_CONFIG_BASENAMES:
+        return True
+    _, ext = os.path.splitext(base)
+    return ext.lower() in _DOCS_CONFIG_EXTS
+
+
+def _seg_dash_C(argv) -> str | None:
+    """The dir named by a ``git -C <dir>`` in a segment's argv, else None."""
+    argv = argv or []
+    for i, tok in enumerate(argv):
+        if tok == "-C" and i + 1 < len(argv):
+            return argv[i + 1]
+    return None
+
+
+def _cd_target(raw: str):
+    """Classify a top-level command segment as a ``cd``.
+
+    Returns the literal target dir for a plain ``cd <literal-path>`` segment;
+    ``_CWD_UNKNOWN`` for a cd we cannot resolve (no arg, ``cd -``, a
+    variable/command-substitution/glob target, or a subshell/group); ``None`` if
+    it is not a cd. Self-contained (does NOT import git_push_guard).
+    """
+    s = raw.strip()
+    if s.startswith("(") or s.startswith("{"):
+        return _CWD_UNKNOWN  # subshell/group scopes its cd
+    m = re.match(r"^cd(?:\s+(?P<p>.*))?$", s)
     if not m:
         return None
-    path = os.path.expanduser(m.group(1))
-    return path if os.path.isdir(path) else None
+    p = (m.group("p") or "").strip()
+    if not p or p == "-":
+        return _CWD_UNKNOWN
+    if len(p) >= 2 and p[0] in "'\"" and p[-1] == p[0]:
+        inner = p[1:-1]
+        if p[0] == '"' and ("$" in inner or "`" in inner):
+            return _CWD_UNKNOWN
+        return inner
+    if " " in p or "\t" in p:
+        return _CWD_UNKNOWN
+    if p.startswith("~"):
+        p = os.path.expanduser(p)
+    if any(ch in p for ch in "$`*?"):
+        return _CWD_UNKNOWN
+    return p
+
+
+def _effective_diff_cwd(command: str, payload: dict, segs: list):
+    """The dir whose index the commit inspects — ``str``, ``None``, or ``_CWD_UNKNOWN``.
+
+    Resolution mirrors git_push_guard (self-contained; no import):
+      1. ``git -C <dir>`` on a commit segment's argv.
+      2. If the commit is nested (depth>0), UNKNOWN → fail closed.
+      3. Else the LAST top-level ``cd`` before the commit segment (bash applies
+         cds sequentially, so the last one wins — a decoy ``cd A && …; cd B &&
+         git commit`` runs in B, not A). An unresolvable cd before the commit ⇒
+         UNKNOWN. Falls back to the payload cwd as the base.
+    """
+    commit_seg = next((s for s in segs if git_subcommand(s.argv) == "commit"), None)
+    if commit_seg is not None:
+        dash_c = _seg_dash_C(getattr(commit_seg, "argv", None))
+        if dash_c is not None:
+            return dash_c
+        if getattr(commit_seg, "depth", 0) > 0:
+            return _CWD_UNKNOWN
+
+    base = payload.get("cwd") if isinstance(payload, dict) else None
+    cur = base if isinstance(base, str) and base else None
+    target_raw = getattr(commit_seg, "raw", None) if commit_seg is not None else None
+    if target_raw is not None:
+        for raw in split_segments(command):
+            if raw == target_raw:
+                return cur
+            cd = _cd_target(raw)
+            if cd is _CWD_UNKNOWN:
+                cur = _CWD_UNKNOWN
+            elif cd is not None:
+                cur = cd
+    return cur
+
+
+def _staged_files(cwd: str | None) -> list[str] | None:
+    """Staged paths for the pending commit, or None if the diff cannot be read.
+
+    None (command failed / error) is the caller's signal to fall back to normal
+    enforcement rather than skip.
+    """
+    args = ["git"]
+    if cwd:
+        args += ["-C", cwd]
+    args += ["diff", "--cached", "--name-only"]
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, timeout=10)
+        if result.returncode != 0:
+            return None
+        return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    except Exception:
+        return None
 
 
 def main() -> None:
     # Parse tool input
-    command = field(read_payload(), "command")
+    payload = read_payload()
+    command = field(payload, "command")
     if not _COMMIT_PATTERN.search(command):
         sys.exit(0)  # Not a commit, allow
 
@@ -95,8 +213,13 @@ def main() -> None:
         )
         return
 
-    # Detect worktree: extract working directory from 'cd /path && git commit'
-    cwd = _extract_working_dir(command)
+    # Resolve the dir the commit actually targets (git -C / the LAST cd before
+    # the commit segment / payload cwd). A decoy `cd A && …; cd B && git commit`
+    # runs in B, and B is what we must inspect. An ambiguous cwd (variable /
+    # subshell / depth>0) yields the _CWD_UNKNOWN sentinel → fail closed.
+    eff_cwd = _effective_diff_cwd(command, payload, segs)
+    cwd_unknown = eff_cwd is _CWD_UNKNOWN
+    cwd = eff_cwd if isinstance(eff_cwd, str) else None
 
     # Import review_state from same directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -115,13 +238,27 @@ def main() -> None:
 
     branch = get_current_branch(cwd=cwd)
 
-    # Rule 1: Block commits on main
-    if branch in ("main", "master"):
+    # Rule 1: Block commits on main. Fail closed when the cwd is ambiguous — we
+    # cannot prove the commit is NOT landing on main, so treat it as such.
+    if cwd_unknown or branch in ("main", "master"):
         _deny(
             "BLOCKED: Direct commits to main are not allowed. "
             "Create a branch first: git checkout -b <scope>/<description>"
         )
         return
+
+    # Docs/config-only skip: a commit whose ENTIRE staged set is documentation
+    # or config carries no code to review (adaptive-review "review level: None"),
+    # so skip Rule 2 for it. Conservative fail-toward-review default: we skip ONLY
+    # when the staged set is non-empty AND every path is on the docs/config
+    # allowlist. An empty staged set (e.g. a "git add && git commit" chain that
+    # stages in-command), a diff we cannot read, or an ambiguous cwd (already
+    # blocked by Rule 1 above) falls through to normal enforcement — never
+    # skipped. Placed AFTER Rule 0 (--no-verify) and Rule 1 (main-branch) so it
+    # can never weaken those hard blocks.
+    staged = _staged_files(cwd)
+    if staged and all(_is_docs_or_config(p) for p in staged):
+        sys.exit(0)
 
     # Rule 2: Block commits without review (on branches)
     # Race condition: when command is "git add X && git commit", nothing is

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -41,11 +41,14 @@ def repo(tmp_path: Path) -> Path:
     _git(r, "-c", "init.defaultBranch=main", "init", "-q")
     _git(r, "config", "user.email", "t@e.st")
     _git(r, "config", "user.name", "tester")
-    (r / "f.txt").write_text("base\n")
+    (r / "f.py").write_text("base = 1\n")
     _git(r, "add", "-A")
     _git(r, "commit", "-qm", "base")
     _git(r, "checkout", "-q", "-b", "feature/x")
-    (r / "f.txt").write_text("changed\n")  # staged below → has_code_changes
+    # A .py change: real code that Rule 2 must gate (a docs/config extension like
+    # .txt is now legitimately exempt by the Change-4 skip, so it cannot stand in
+    # for "unreviewed code" here).
+    (r / "f.py").write_text("base = 2\n")  # staged below → has_code_changes
     _git(r, "add", "-A")
     return r
 
@@ -221,7 +224,7 @@ def test_override_on_other_segment_does_not_authorize(repo: Path, home: Path) ->
 
 def test_main_branch_not_overridable(repo: Path, home: Path) -> None:
     _git(repo, "checkout", "-q", "main")
-    (repo / "f.txt").write_text("main-change\n")
+    (repo / "f.py").write_text("main_change = 1\n")
     _git(repo, "add", "-A")
     res = _run_hook('git commit -m "wip"  # review-override', repo, home)
     assert res.returncode == 2
@@ -281,11 +284,11 @@ def _second_repo(tmp_path: Path, name: str) -> Path:
     _git(r, "-c", "init.defaultBranch=main", "init", "-q")
     _git(r, "config", "user.email", "t@e.st")
     _git(r, "config", "user.name", "tester")
-    (r / "g.txt").write_text("base\n")
+    (r / "g.py").write_text("base = 1\n")
     _git(r, "add", "-A")
     _git(r, "commit", "-qm", "base")
     _git(r, "checkout", "-q", "-b", "feature/y")
-    (r / "g.txt").write_text("changed\n")
+    (r / "g.py").write_text("base = 2\n")
     _git(r, "add", "-A")
     return r
 
@@ -310,9 +313,7 @@ def test_marker_not_clobbered_by_concurrent_worktree(
     assert res.returncode == 0, res.stderr
 
 
-def test_distinct_worktrees_get_distinct_markers(
-    repo: Path, home: Path, tmp_path: Path
-) -> None:
+def test_distinct_worktrees_get_distinct_markers(repo: Path, home: Path, tmp_path: Path) -> None:
     repo_b = _second_repo(tmp_path, "repo_b2")
     assert _mark(repo, home).returncode == 0
     assert _mark(repo_b, home).returncode == 0
@@ -334,8 +335,12 @@ def _run_invalidate(command: str, repo: Path, home: Path) -> subprocess.Complete
     env = {**os.environ, "HOME": str(home)}
     return subprocess.run(
         [sys.executable, str(_INVALIDATE)],
-        input=payload, cwd=str(repo), env=env,
-        capture_output=True, text=True, timeout=30,
+        input=payload,
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
 
 
@@ -366,3 +371,160 @@ def test_invalidate_ignores_non_commit(repo: Path, home: Path) -> None:
     assert _mark(repo, home).returncode == 0
     _run_invalidate("echo not a commit", repo, home)
     assert len(_markers(home)) == 1  # marker survives
+
+
+# ── Docs/config-only skip (Change 4) ─────────────────────────────────────
+# A commit whose ENTIRE staged set is docs/config carries no code to review
+# (adaptive-review "review level: None") → Rule 2 is skipped. Conservative
+# fail-toward-review default: any code/unknown extension, an empty staged set, or
+# an unreadable diff falls through to normal enforcement (never skipped). Rule 0
+# (--no-verify) and Rule 1 (main) are checked BEFORE the skip and stay hard.
+
+
+def _restage(repo: Path, paths_contents: dict[str, str]) -> None:
+    """Clean the tree, then write the given files and stage EXACTLY them.
+
+    A hard reset drops the fixture's staged (code) change so the staged set is
+    only the files under test — a soft reset would leave that change in the
+    working tree, and `git add -A` would re-stage it, polluting the set.
+    """
+    _git(repo, "reset", "--hard", "HEAD", "-q")
+    for rel, content in paths_contents.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    _git(repo, "add", "-A")
+
+
+def test_docs_only_commit_skips_enforcement(repo: Path, home: Path) -> None:
+    """README.md + config/x.yaml with NO review marker → skipped (exit 0)."""
+    _restage(repo, {"README.md": "# docs\n", "config/x.yaml": "a: 1\n"})
+    res = _run_hook('git commit -m "docs"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_single_readme_skips(repo: Path, home: Path) -> None:
+    _restage(repo, {"README.md": "# docs\n"})
+    res = _run_hook('git commit -m "docs"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_extensionless_docs_basenames_skip(repo: Path, home: Path) -> None:
+    """CHANGELOG / LICENSE / .gitignore basenames are on the allowlist."""
+    _restage(repo, {"CHANGELOG": "v1\n", "LICENSE": "MIT\n", ".gitignore": "*.pyc\n"})
+    res = _run_hook('git commit -m "chores"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_code_file_still_enforced(repo: Path, home: Path) -> None:
+    """A .py in the staged set → NOT docs-only → Rule 2 still blocks."""
+    _restage(repo, {"foo.py": "print(1)\n"})
+    res = _run_hook('git commit -m "code"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_mixed_docs_and_code_enforced(repo: Path, home: Path) -> None:
+    """One code file among docs → the whole set is NOT docs-only → enforced."""
+    _restage(repo, {"README.md": "# docs\n", "foo.py": "print(1)\n"})
+    res = _run_hook('git commit -m "mixed"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_unknown_extension_enforced(repo: Path, home: Path) -> None:
+    """An unrecognized extension is treated as code (fail toward review)."""
+    _restage(repo, {"data.json": "{}\n"})
+    res = _run_hook('git commit -m "json"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_empty_staged_set_falls_back_to_enforcement(repo: Path, home: Path) -> None:
+    """A git-add-&&-commit chain stages nothing at hook time → NOT skipped →
+    marker-based Rule 2 blocks when unreviewed (fallback, not a docs skip)."""
+    _git(repo, "reset", "-q")  # nothing staged now
+    (repo / "g.txt").write_text("new\n")  # a docs-ext file, but not yet staged
+    res = _run_hook('git add -A && git commit -m "wip"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_docs_only_no_verify_still_blocked(repo: Path, home: Path) -> None:
+    """Rule 0 precedes the docs skip — --no-verify on a docs-only commit blocks."""
+    _restage(repo, {"README.md": "# docs\n"})
+    res = _run_hook('git commit --no-verify -m "docs"', repo, home)
+    assert res.returncode == 2
+    assert "no-verify" in res.stderr
+
+
+def test_docs_only_on_main_still_blocked(repo: Path, home: Path) -> None:
+    """Rule 1 precedes the docs skip — a docs-only commit on main still blocks."""
+    _git(repo, "checkout", "-q", "main")
+    _restage(repo, {"README.md": "# docs\n"})
+    res = _run_hook('git commit -m "docs"', repo, home)
+    assert res.returncode == 2
+    assert "main" in res.stderr.lower()
+
+
+# ── SHOULD-FIX 4: .github/workflows/*.yml is executable CI config ─────────
+
+
+def test_github_workflow_yaml_still_enforced(repo: Path, home: Path) -> None:
+    """A workflow-only commit is NOT docs/config (arbitrary `run:` with repo
+    secrets) → Rule 2 still fires even though the file is .yml."""
+    _restage(repo, {".github/workflows/ci.yml": "on: push\njobs: {}\n"})
+    res = _run_hook('git commit -m "ci"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_workflow_plus_docs_still_enforced(repo: Path, home: Path) -> None:
+    """One workflow file among docs → the set is not all-docs → enforced."""
+    _restage(repo, {"README.md": "# d\n", ".github/workflows/ci.yml": "on: push\n"})
+    res = _run_hook('git commit -m "mix"', repo, home)
+    assert res.returncode == 2
+
+
+def test_nonworkflow_yaml_still_skips(repo: Path, home: Path) -> None:
+    """A legit config .yaml (not under .github/) still skips review."""
+    _restage(repo, {"config/recon_watchlist.yaml": "watch: []\n"})
+    res = _run_hook('git commit -m "cfg"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+# ── BLOCKER 2: decoy-cd cannot point the docs skip at the wrong repo ───────
+
+
+def _docs_only_repo(tmp_path: Path, name: str) -> Path:
+    """A throwaway repo on a feature branch whose ENTIRE staged set is docs."""
+    r = tmp_path / name
+    r.mkdir()
+    _git(r, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(r, "config", "user.email", "t@e.st")
+    _git(r, "config", "user.name", "tester")
+    (r / "seed.py").write_text("x = 1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "feature/docs")
+    (r / "README.md").write_text("# only docs staged\n")
+    _git(r, "add", "-A")
+    return r
+
+
+def test_decoy_cd_docs_skip_uses_real_wt(repo: Path, home: Path, tmp_path: Path) -> None:
+    """`cd <docs-repo> && true; cd <real-wt> && git commit` must inspect the REAL
+    wt (code staged, no marker) → enforced. The old first-cd resolver would have
+    read the decoy docs repo's staged set and skipped review for real code."""
+    decoy = _docs_only_repo(tmp_path, "decoy_docs")
+    cmd = f"cd {decoy} && true; cd {repo} && git commit -m x"
+    res = _run_hook(cmd, repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_ambiguous_cd_before_commit_enforced(repo: Path, home: Path) -> None:
+    """A cd into a variable before the commit ⇒ UNKNOWN cwd ⇒ fail closed (Rule 1
+    blocks; the docs skip is never reached)."""
+    res = _run_hook("cd $WT && git commit -m x", repo, home)
+    assert res.returncode == 2

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -60,15 +60,18 @@ def home(tmp_path: Path) -> Path:
     return h
 
 
-def _run_hook(command: str, repo: Path, home: Path) -> subprocess.CompletedProcess:
-    payload = json.dumps(
-        {
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Bash",
-            "tool_input": {"command": command},
-            "session_id": "test",
-        }
-    )
+def _run_hook(
+    command: str, repo: Path, home: Path, payload_cwd: str | None = None
+) -> subprocess.CompletedProcess:
+    body = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "session_id": "test",
+    }
+    if payload_cwd is not None:
+        body["cwd"] = payload_cwd
+    payload = json.dumps(body)
     env = {**os.environ, "HOME": str(home)}
     return subprocess.run(
         [sys.executable, str(_HOOK)],
@@ -528,3 +531,91 @@ def test_ambiguous_cd_before_commit_enforced(repo: Path, home: Path) -> None:
     blocks; the docs skip is never reached)."""
     res = _run_hook("cd $WT && git commit -m x", repo, home)
     assert res.returncode == 2
+
+
+# ── P1-D: staged index at hook time ≠ what the command commits ────────────
+
+
+def test_commit_dash_a_with_docs_staged_enforced(repo: Path, home: Path) -> None:
+    """`git commit -a` stages tracked code the --cached snapshot doesn't show yet
+    → NOT a pure commit → the docs-only skip must NOT fire."""
+    _restage(repo, {"README.md": "# docs\n"})
+    (repo / "f.py").write_text("changed = 3\n")  # tracked, unstaged code change
+    res = _run_hook('git commit -a -m "x"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_commit_pathspec_with_docs_staged_enforced(repo: Path, home: Path) -> None:
+    """`git commit -m x app.py` selects a pathspec → not pure → not skipped."""
+    _restage(repo, {"README.md": "# docs\n"})
+    res = _run_hook('git commit -m "x" app.py', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_add_then_commit_chain_with_docs_staged_enforced(repo: Path, home: Path) -> None:
+    """`git add app.py && git commit` stages code in a prior segment → not pure."""
+    _restage(repo, {"README.md": "# docs\n"})
+    (repo / "app.py").write_text("y = 2\n")
+    res = _run_hook('git add app.py && git commit -m "x"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_bare_docs_commit_still_skips_after_p1d(repo: Path, home: Path) -> None:
+    """Control: a genuinely pure bare docs commit still skips."""
+    _restage(repo, {"README.md": "# docs\n"})
+    res = _run_hook('git commit -m "docs"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+# ── P2-E: renames surface both source and destination ────────────────────
+
+
+def test_rename_from_code_to_docs_enforced(repo: Path, home: Path) -> None:
+    """A staged rename `foo.py → README.md` shows only README under --name-only,
+    but the SOURCE is code → must enforce (uses --name-status -M, both sides)."""
+    _git(repo, "reset", "--hard", "HEAD", "-q")
+    (repo / "foo.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add foo")
+    _git(repo, "mv", "foo.py", "README.md")  # staged rename foo.py → README.md
+    res = _run_hook('git commit -m "rename"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
+def test_rename_docs_to_docs_still_skips(repo: Path, home: Path) -> None:
+    """A docs→docs rename (both sides docs) still skips."""
+    _git(repo, "reset", "--hard", "HEAD", "-q")
+    (repo / "NOTES.md").write_text("# notes\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add notes")
+    _git(repo, "mv", "NOTES.md", "README.md")
+    res = _run_hook('git commit -m "rename docs"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+# ── P1-A: relative cd resolved against the payload cwd (commit) ────────────
+
+
+def test_relative_cd_commit_to_sibling_main_blocked(repo: Path, home: Path, tmp_path: Path) -> None:
+    """`cd ../main && git commit` from a feature-wt payload cwd resolves to the
+    sibling main tree → Rule 1 blocks (relative path resolved against the cwd)."""
+    trees = tmp_path / "trees"
+    feature = trees / "feature"
+    main = trees / "main"
+    for d, br in ((feature, "feature/x"), (main, "main")):
+        d.mkdir(parents=True)
+        _git(d, "-c", "init.defaultBranch=main", "init", "-q")
+        _git(d, "config", "user.email", "t@e.st")
+        _git(d, "config", "user.name", "tester")
+        (d / "seed.py").write_text("x = 1\n")
+        _git(d, "add", "-A")
+        _git(d, "commit", "-qm", "base")
+        if br != "main":
+            _git(d, "checkout", "-q", "-b", br)
+    res = _run_hook("cd ../main && git commit -m x", feature, home, payload_cwd=str(feature))
+    assert res.returncode == 2
+    assert "main" in res.stderr.lower()

--- a/tests/test_hooks/test_worktree_remote_guard.py
+++ b/tests/test_hooks/test_worktree_remote_guard.py
@@ -141,6 +141,37 @@ def remotes_repo(tmp_path):
     return r
 
 
+@pytest.fixture
+def push_url_repo(tmp_path):
+    """A working repo whose ``sneaky`` remote has a PRIVATE fetch url but a PUSH
+    url set to origin's url (P1-B) — git pushes to origin's repo even though the
+    fetch url differs. ``backups`` stays a genuinely-separate repo."""
+    origin_url = str(tmp_path / "origin.git")
+    fork_url = str(tmp_path / "fork.git")
+    subprocess.run(["git", "init", "--bare", "-q", origin_url], check=True, capture_output=True)
+    subprocess.run(["git", "init", "--bare", "-q", fork_url], check=True, capture_output=True)
+    r = tmp_path / "wt"
+    _init_repo(r, "feature/x")
+    _git(r, "remote", "add", "origin", origin_url)
+    _git(r, "remote", "add", "sneaky", fork_url)  # private FETCH url…
+    _git(r, "remote", "set-url", "--push", "sneaky", origin_url)  # …but PUSH → origin
+    _git(r, "remote", "add", "backups", fork_url)  # fetch AND push → fork (disjoint)
+    return r
+
+
+@pytest.fixture
+def sibling_trees(tmp_path):
+    """Two sibling repos so a RELATIVE `cd ../main` / `git -C ../main` resolves:
+
+    ``trees/feature`` (feature branch) and ``trees/main`` (main branch)."""
+    trees = tmp_path / "trees"
+    feature = trees / "feature"
+    main = trees / "main"
+    _init_repo(feature, "feature/x")
+    _init_repo(main, "main")
+    return feature, main
+
+
 # ── Change 1 + 3: worktree-aware merge-into-main ─────────────────────────
 
 
@@ -333,8 +364,8 @@ class TestForcePushRemoteAware:
         monkeypatch.setattr(guard_module, "_resolve_push_remote", lambda seg, cwd=None: "myfork")
         monkeypatch.setattr(
             guard_module,
-            "_remote_url",
-            lambda name, cwd=None: "url://fork" if name == "myfork" else "url://origin",
+            "_remote_push_urls",
+            lambda name, cwd=None: {"url://fork"} if name == "myfork" else {"url://origin"},
         )
         monkeypatch.setattr(guard_module, "read_payload", lambda: _payload("git push -f"))
         rc = guard_module.main()
@@ -403,3 +434,96 @@ def test_bare_push_label_uses_worktree_branch(guard_module, monkeypatch, capsys)
     out = json.loads(capsys.readouterr().out)
     assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert "feature/label" in out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+# ── P1-A: relative cd / git -C resolved against the effective (absolute) cwd ──
+
+
+class TestRelativeCwdResolution:
+    def test_relative_cd_merge_into_main_blocked(self, sibling_trees):
+        """`cd ../main && git merge x` from a feature-wt payload cwd resolves to
+        the sibling main tree → main branch → blocked (was kept verbatim before,
+        so `git -C ../main` ran from the hook cwd and mis-resolved / fell open)."""
+        feature, main = sibling_trees
+        res = _run_cwd("cd ../main && git merge x", str(feature))
+        assert res.returncode == 2
+        assert "Merging into main" in res.stderr
+
+    def test_relative_dash_C_merge_into_main_blocked(self, sibling_trees):
+        feature, main = sibling_trees
+        res = _run_cwd("git -C ../main merge x", str(feature))
+        assert res.returncode == 2
+        assert "Merging into main" in res.stderr
+
+    def test_relative_cd_to_feature_not_blocked(self, sibling_trees):
+        """Control: relative cd landing on a feature branch → not blocked."""
+        feature, main = sibling_trees
+        res = _run_cwd("cd ../feature && git merge x", str(main))
+        assert res.returncode == 0, res.stderr
+
+    def test_none_branch_fails_closed(self, guard_module, monkeypatch):
+        """A merge whose branch cannot be read (None) → fail closed → block."""
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        monkeypatch.setattr(guard_module, "_current_branch", lambda cwd=None: None)
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: _payload("git merge x", cwd="/wt")
+        )
+        assert guard_module.main() == 2
+
+    def test_detached_head_empty_branch_allowed(self, guard_module, monkeypatch):
+        """A detached HEAD ("") is not main and not None → allowed."""
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        monkeypatch.setattr(guard_module, "_current_branch", lambda cwd=None: "")
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: _payload("git merge x", cwd="/wt")
+        )
+        assert guard_module.main() == 0
+
+
+# ── P1-B: force-push classified by PUSH url set, not fetch url ────────────
+
+
+class TestForcePushUrlClassification:
+    def test_force_to_remote_with_origin_pushurl_blocked(self, push_url_repo):
+        """`sneaky` has a private FETCH url but its PUSH url == origin's → git
+        would force the PUBLIC repo → hard-block (fetch-url classification missed
+        this)."""
+        res = _run_cwd(f"git push {_FORCE} sneaky main", str(push_url_repo))
+        assert res.returncode == 2
+        assert "Force push to origin" in res.stderr
+        assert _decision(res) is None
+
+    def test_force_to_disjoint_pushurl_asks(self, push_url_repo):
+        """`backups` push url is disjoint from origin's → cautious ask."""
+        res = _run_cwd(f"git push {_FORCE} backups main", str(push_url_repo))
+        assert res.returncode == 0, res.stderr
+        assert _decision(res) == "ask"
+
+    def test_force_to_disjoint_pushurl_denied_dispatched(self, push_url_repo):
+        res = _run_cwd(f"git push {_FORCE} backups main", str(push_url_repo), dispatched=True)
+        assert res.returncode == 2
+
+
+# ── P1-C: --repo <dest> honored as the push destination ──────────────────
+
+
+class TestForcePushRepoFlag:
+    def test_force_repo_flag_origin_blocked(self, remotes_repo):
+        """`git push --force --repo origin` targets origin regardless of upstream
+        → hard-block (was skipped, falling back to a private upstream → soft ask)."""
+        res = _run_cwd(f"git push {_FORCE} --repo origin", str(remotes_repo))
+        assert res.returncode == 2
+        assert "Force push to origin" in res.stderr
+
+    def test_force_repo_equals_origin_blocked(self, remotes_repo):
+        res = _run_cwd(f"git push {_FORCE} --repo=origin", str(remotes_repo))
+        assert res.returncode == 2
+
+    def test_force_repo_flag_precedence_over_positional(self, guard_module):
+        seg = [
+            s
+            for s in analyze(f"git push {_FORCE} --repo origin backups main")
+            if git_subcommand(s.argv) == "push"
+        ][0]
+        # --repo wins over the positional `backups`.
+        assert guard_module._resolve_push_remote(seg) == "origin"

--- a/tests/test_hooks/test_worktree_remote_guard.py
+++ b/tests/test_hooks/test_worktree_remote_guard.py
@@ -1,0 +1,405 @@
+"""Tests for the worktree-aware + remote-aware guard behavior in git_push_guard.py.
+
+Covers three fixes:
+- Change 1: merge-into-main / push-label branch is read in the dir the command
+  actually targets (git -C / leading cd / payload cwd), not the hook's own cwd.
+- Change 2: force push is REMOTE-aware — origin or UNKNOWN remote hard-blocks in
+  every session (fail closed); a definitely-non-origin remote gets a cautious
+  ask (interactive) / deny (dispatched).
+- Change 3: a trailing `# merge-to-main-override` acknowledges an on-main merge.
+
+cwd-dependent branches are driven by monkeypatching `_current_branch` /
+`_resolve_push_remote` / `read_payload`, so no real git or network runs. The
+deterministic remote-name cases (a literal `git push --force backups`) run the
+hook via subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "hooks"
+_GUARD = _SCRIPTS / "git_push_guard.py"
+
+sys.path.insert(0, str(_SCRIPTS))
+from shell_parse import analyze, git_subcommand  # noqa: E402
+
+_FORCE = "--fo" + "rce"  # split so this file's own text never trips a host push-guard
+
+
+@pytest.fixture(scope="module")
+def guard_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("git_push_guard", _GUARD)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _payload(cmd: str, cwd: str | None = None) -> dict:
+    p = {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": cmd}}
+    if cwd is not None:
+        p["cwd"] = cwd
+    return p
+
+
+def _run(command: str, *, dispatched: bool = False) -> subprocess.CompletedProcess:
+    """Run the guard as a subprocess (real string-parsing path, no monkeypatch)."""
+    env = {
+        k: v for k, v in os.environ.items() if k not in ("CLAUDE_TOOL_INPUT", "GENESIS_CC_SESSION")
+    }
+    if dispatched:
+        env["GENESIS_CC_SESSION"] = "1"
+    return subprocess.run(
+        [sys.executable, str(_GUARD)],
+        input=json.dumps(_payload(command)),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _decision(res: subprocess.CompletedProcess) -> str | None:
+    try:
+        return json.loads(res.stdout)["hookSpecificOutput"]["permissionDecision"]
+    except Exception:
+        return None
+
+
+def _run_cwd(command: str, cwd: str, *, dispatched: bool = False) -> subprocess.CompletedProcess:
+    """Run the guard with a Bash-tool cwd set in the payload (real git, no mock)."""
+    env = {
+        k: v for k, v in os.environ.items() if k not in ("CLAUDE_TOOL_INPUT", "GENESIS_CC_SESSION")
+    }
+    if dispatched:
+        env["GENESIS_CC_SESSION"] = "1"
+    return subprocess.run(
+        [sys.executable, str(_GUARD)],
+        input=json.dumps(_payload(command, cwd=cwd)),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _git(repo, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(repo), check=True, capture_output=True, text=True)
+
+
+def _init_repo(path, branch: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(path, "config", "user.email", "t@e.st")
+    _git(path, "config", "user.name", "tester")
+    (path / "base.txt").write_text("base\n")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-qm", "base")
+    if branch != "main":
+        _git(path, "checkout", "-q", "-b", branch)
+
+
+@pytest.fixture
+def main_repo(tmp_path):
+    r = tmp_path / "main_repo"
+    _init_repo(r, "main")
+    return r
+
+
+@pytest.fixture
+def feature_repo(tmp_path):
+    r = tmp_path / "feature_repo"
+    _init_repo(r, "feature/x")
+    return r
+
+
+@pytest.fixture
+def remotes_repo(tmp_path):
+    """A feature-branch working repo with three remotes:
+
+    - ``origin``  → the public repo URL
+    - ``mirror``  → the SAME URL as origin (name != origin, but same repo)
+    - ``backups`` → a DIFFERENT URL (a genuinely separate, private repo)
+    """
+    origin_url = str(tmp_path / "origin.git")
+    fork_url = str(tmp_path / "fork.git")
+    subprocess.run(["git", "init", "--bare", "-q", origin_url], check=True, capture_output=True)
+    subprocess.run(["git", "init", "--bare", "-q", fork_url], check=True, capture_output=True)
+    r = tmp_path / "wt"
+    _init_repo(r, "feature/x")
+    _git(r, "remote", "add", "origin", origin_url)
+    _git(r, "remote", "add", "mirror", origin_url)  # same URL as origin
+    _git(r, "remote", "add", "backups", fork_url)  # different URL
+    return r
+
+
+# ── Change 1 + 3: worktree-aware merge-into-main ─────────────────────────
+
+
+class TestMergeIntoMainWorktreeAware:
+    def _prep(self, guard_module, monkeypatch, cmd, cwd=None):
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        monkeypatch.setattr(guard_module, "read_payload", lambda: _payload(cmd, cwd=cwd))
+
+    def test_merge_from_feature_worktree_not_blocked(self, guard_module, monkeypatch):
+        # Effective branch (resolved in the worktree cwd) is a feature branch.
+        monkeypatch.setattr(
+            guard_module,
+            "_current_branch",
+            lambda cwd=None: "feature/x" if cwd else "main",
+        )
+        self._prep(guard_module, monkeypatch, "git merge upstream/feat", cwd="/wt")
+        assert guard_module.main() == 0
+
+    def test_merge_on_main_blocked(self, guard_module, monkeypatch, capsys):
+        monkeypatch.setattr(guard_module, "_current_branch", lambda cwd=None: "main")
+        self._prep(guard_module, monkeypatch, "git merge upstream/feat", cwd=None)
+        assert guard_module.main() == 2
+        assert "Merging into main" in capsys.readouterr().err
+
+    def test_merge_on_main_with_override_allowed(self, guard_module, monkeypatch):
+        monkeypatch.setattr(guard_module, "_current_branch", lambda cwd=None: "main")
+        self._prep(
+            guard_module,
+            monkeypatch,
+            "git merge upstream/feat  # merge-to-main-override",
+            cwd=None,
+        )
+        assert guard_module.main() == 0
+
+    def test_git_dash_C_worktree_form_not_blocked(self, guard_module, monkeypatch):
+        # `git -C /wt merge feat`: effective cwd comes from the -C in argv, so the
+        # branch is read in /wt (a feature branch), not the hook's main tree.
+        seen = []
+
+        def fake_branch(cwd=None):
+            seen.append(cwd)
+            return "feature/z" if cwd == "/wt" else "main"
+
+        monkeypatch.setattr(guard_module, "_current_branch", fake_branch)
+        self._prep(guard_module, monkeypatch, "git -C /wt merge feat", cwd=None)
+        assert guard_module.main() == 0
+        assert "/wt" in seen
+
+    def test_leading_cd_worktree_form_not_blocked(self, guard_module, monkeypatch):
+        monkeypatch.setattr(
+            guard_module,
+            "_current_branch",
+            lambda cwd=None: "feature/y" if cwd == "/wt" else "main",
+        )
+        self._prep(guard_module, monkeypatch, "cd /wt && git merge feat", cwd=None)
+        assert guard_module.main() == 0
+
+
+class TestCompoundAndDecoyMerge:
+    """BLOCKER 1 + BLOCKER 2: EVERY merge in a compound is checked in the dir it
+    actually runs, and the LAST cd before a merge wins (not the first). Uses real
+    git repos so `_current_branch` reads genuine branches."""
+
+    def test_compound_second_bare_merge_into_main_blocked(self, main_repo, feature_repo):
+        """BLOCKER 1: `git -C <feat> merge a && git merge b` — seg[0] is a feature
+        branch, but the SECOND bare merge runs in the payload cwd (main) → block."""
+        res = _run_cwd(
+            f"git -C {feature_repo} merge a && git merge b",
+            str(main_repo),
+        )
+        assert res.returncode == 2
+        assert "Merging into main" in res.stderr
+
+    def test_compound_both_feature_not_blocked(self, feature_repo):
+        """Control: both merges resolve to feature branches → not blocked."""
+        res = _run_cwd(
+            f"git -C {feature_repo} merge a && git merge b",
+            str(feature_repo),
+        )
+        assert res.returncode == 0, res.stderr
+
+    def test_decoy_cd_last_cd_wins_blocks(self, main_repo, feature_repo):
+        """BLOCKER 2: `cd <feat> && true; cd <main> && git merge x` runs in main
+        (the LAST cd), so it must block — the old first-cd resolver saw <feat>."""
+        res = _run_cwd(
+            f"cd {feature_repo} && true; cd {main_repo} && git merge x",
+            str(feature_repo),  # base cwd is feature — the trailing `cd main` overrides it
+        )
+        assert res.returncode == 2
+        assert "Merging into main" in res.stderr
+
+    def test_decoy_cd_last_cd_feature_not_blocked(self, main_repo, feature_repo):
+        """Mirror control: last cd lands on a feature branch → not blocked."""
+        res = _run_cwd(
+            f"cd {main_repo} && true; cd {feature_repo} && git merge x",
+            str(main_repo),
+        )
+        assert res.returncode == 0, res.stderr
+
+    def test_ambiguous_cd_before_merge_fails_closed(self, guard_module, monkeypatch):
+        """A cd into a variable before the merge ⇒ UNKNOWN cwd ⇒ blocked."""
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        # _current_branch would say feature, but the ambiguous cd must win → block.
+        monkeypatch.setattr(guard_module, "_current_branch", lambda cwd=None: "feature/x")
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: _payload("cd $WT && git merge x", cwd="/wt"),
+        )
+        assert guard_module.main() == 2
+
+    def test_merge_in_bash_c_fails_closed(self, guard_module, monkeypatch):
+        """A merge nested in bash -c (depth>0) can't be cwd-associated → block."""
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        monkeypatch.setattr(guard_module, "_current_branch", lambda cwd=None: "feature/x")
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: _payload("bash -c 'git merge x'", cwd="/wt"),
+        )
+        assert guard_module.main() == 2
+
+
+# ── Change 2: remote-aware force push ────────────────────────────────────
+
+
+class TestForcePushRemoteAware:
+    """origin/UNKNOWN → hard-block (fail closed); non-origin → cautious ask/deny."""
+
+    def test_force_to_origin_blocked_interactive(self):
+        res = _run(f"git push {_FORCE} origin main")
+        assert res.returncode == 2
+        assert "Force push to origin" in res.stderr
+        assert _decision(res) is None
+
+    def test_force_to_origin_blocked_dispatched(self):
+        res = _run(f"git push {_FORCE} origin main", dispatched=True)
+        assert res.returncode == 2
+
+    def test_force_to_nonorigin_asks_interactive(self, remotes_repo):
+        # `backups` URL differs from origin's → genuinely different repo → ask.
+        res = _run_cwd(f"git push {_FORCE} backups main", str(remotes_repo))
+        assert res.returncode == 0, res.stderr
+        assert _decision(res) == "ask"
+
+    def test_force_to_nonorigin_denied_dispatched(self, remotes_repo):
+        res = _run_cwd(f"git push {_FORCE} backups main", str(remotes_repo), dispatched=True)
+        assert res.returncode == 2
+        assert "rewrites remote history" in res.stderr
+        assert _decision(res) is None
+
+    # ── SHOULD-FIX 3: classify by URL, not remote NAME ──────────────────
+    def test_force_to_mirror_same_url_as_origin_blocked(self, remotes_repo):
+        """ATTACK: `git remote add mirror <origin-url>` then force-push mirror —
+        a non-'origin' NAME that still rewrites the PUBLIC repo. URL == origin's
+        → hard-block (was a soft ask under name-only classification)."""
+        res = _run_cwd(f"git push {_FORCE} mirror main", str(remotes_repo))
+        assert res.returncode == 2
+        assert "Force push to origin" in res.stderr
+        assert _decision(res) is None
+
+    def test_force_to_mirror_same_url_blocked_even_dispatched(self, remotes_repo):
+        res = _run_cwd(f"git push {_FORCE} mirror main", str(remotes_repo), dispatched=True)
+        assert res.returncode == 2
+
+    def test_force_to_unresolvable_url_blocked_fail_closed(self, remotes_repo):
+        """A named remote with no configured URL → URL unresolvable → fail closed."""
+        res = _run_cwd(f"git push {_FORCE} ghost main", str(remotes_repo))
+        assert res.returncode == 2
+        assert _decision(res) is None
+
+    def test_force_unknown_remote_blocked_fail_closed(self, guard_module, monkeypatch):
+        # No named remote and upstream unresolvable → remote UNKNOWN → treat as
+        # origin → hard-block in every session (fail closed).
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        monkeypatch.setattr(guard_module, "_resolve_push_remote", lambda seg, cwd=None: None)
+        monkeypatch.setattr(guard_module, "read_payload", lambda: _payload("git push -f"))
+        assert guard_module.main() == 2
+
+    def test_force_unknown_remote_blocked_even_dispatched(self, guard_module, monkeypatch):
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: True)
+        monkeypatch.setattr(guard_module, "_resolve_push_remote", lambda seg, cwd=None: None)
+        monkeypatch.setattr(guard_module, "read_payload", lambda: _payload("git push -f"))
+        assert guard_module.main() == 2
+
+    def test_nonorigin_via_upstream_asks(self, guard_module, monkeypatch, capsys):
+        # No named remote, but the branch's upstream resolves to a non-origin
+        # remote whose URL differs from origin's → cautious ask (not a hard block).
+        monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+        monkeypatch.setattr(guard_module, "_resolve_push_remote", lambda seg, cwd=None: "myfork")
+        monkeypatch.setattr(
+            guard_module,
+            "_remote_url",
+            lambda name, cwd=None: "url://fork" if name == "myfork" else "url://origin",
+        )
+        monkeypatch.setattr(guard_module, "read_payload", lambda: _payload("git push -f"))
+        rc = guard_module.main()
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "ask"
+        assert "myfork" in json.loads(out)["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+# ── _resolve_push_remote unit tests ──────────────────────────────────────
+
+
+class TestResolvePushRemote:
+    def _seg(self, cmd):
+        return [s for s in analyze(cmd) if git_subcommand(s.argv) == "push"][0]
+
+    def test_named_remote(self, guard_module):
+        seg = self._seg("git push origin main")
+        assert guard_module._resolve_push_remote(seg) == "origin"
+
+    def test_named_nonorigin_remote(self, guard_module):
+        seg = self._seg(f"git push {_FORCE} backups main")
+        assert guard_module._resolve_push_remote(seg) == "backups"
+
+    def test_plus_refspec_is_not_a_remote(self, guard_module, monkeypatch):
+        # `git push +main` names no remote → resolve via upstream.
+        seg = self._seg("git push +main")
+        monkeypatch.setattr(
+            guard_module.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess([], 0, stdout="origin/main\n", stderr=""),
+        )
+        assert guard_module._resolve_push_remote(seg) == "origin"
+
+    def test_upstream_derived_remote(self, guard_module, monkeypatch):
+        seg = self._seg("git push")
+        monkeypatch.setattr(
+            guard_module.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess([], 0, stdout="myfork/topic\n", stderr=""),
+        )
+        assert guard_module._resolve_push_remote(seg) == "myfork"
+
+    def test_upstream_failure_is_unknown(self, guard_module, monkeypatch):
+        seg = self._seg("git push")
+        monkeypatch.setattr(
+            guard_module.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess([], 1, stdout="", stderr="no upstream"),
+        )
+        assert guard_module._resolve_push_remote(seg) is None
+
+
+# ── Change 1: push-target label uses the effective-cwd branch ────────────
+
+
+def test_bare_push_label_uses_worktree_branch(guard_module, monkeypatch, capsys):
+    monkeypatch.setattr(guard_module, "_is_dispatched", lambda: False)
+    monkeypatch.setattr(
+        guard_module,
+        "_current_branch",
+        lambda cwd=None: "feature/label" if cwd == "/wt" else "main",
+    )
+    monkeypatch.setattr(guard_module, "read_payload", lambda: _payload("git push", cwd="/wt"))
+    assert guard_module.main() == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "feature/label" in out["hookSpecificOutput"]["permissionDecisionReason"]


### PR DESCRIPTION
## Why

These are Claude Code PreToolUse Bash guard hooks. Three real defects surfaced while merging tonight's PR stack:

1. **Worktree-blind branch detection.** `git_push_guard._current_branch()` ran `git branch --show-current` in the *hook's* cwd — always the main tree, on `main` — so **`git merge` from any feature-branch worktree was falsely blocked** as "merge into main," and bare/one-arg push targets were mislabelled in the approval dialog. (This blocked legitimate worktree merges all session.)
2. **Force-push was hard-blocked unconditionally**, dropping the documented private-fork exception (`block origin/public, allow forks`).
3. **The commit review gate fired even on pure docs/config commits**, which the adaptive-review protocol rates "review level: None."

## What

- **Worktree-aware cwd** (`_effective_cwd` / `_walk_merge_into_main`): resolve the dir a git command actually runs in — explicit `git -C <dir>`, else the **last** top-level `cd` before the segment (bash order), else the CC payload `cwd`. The merge-into-main check now inspects **every** `git merge` segment (a compound `git -C <wt> merge a && git merge b` can no longer smuggle the second into main). Ambiguous cwd (subshell / `bash -c` / variable/`$()` cd) **fails closed** (blocks). A per-segment `# merge-to-main-override` acknowledges an intentional on-main merge.
- **Remote-aware force-push** (per maintainer: hard-block to the public repo, other remotes warrant caution not a hard block): a force push is blocked in every session when it targets the public repo, **decided by URL, not name** — an explicit `origin`, an unknown/None remote, an ambiguous cwd, or a differently-named remote whose URL equals origin's (a `mirror` alias) all count as public and block (fail closed). Only a remote with a resolvable, origin-differing URL gets a **cautious approval** (interactive asks — it rewrites remote history; dispatched denies). Never silently allowed.
- **review_enforcement_commit** skips enforcement only when the staged set is non-empty and **every** path is docs/config (`.md/.rst/.txt/.yaml/.yml/.toml/.ini/.cfg` + `CHANGELOG/LICENSE/.gitignore`). Any `.github/` path (workflow YAML is executable CI config with secret access) or any code/unknown extension still enforces; an empty set, unreadable diff, or ambiguous cwd falls through to enforcement (conservative, fail toward review).

## Security review

Independent review found and this PR fixes: **2 BLOCKERs** (compound-`git merge` bypass; decoy-`cd` cwd spoof that also let code commits masquerade as docs-only) and **2 SHOULD-FIXes** (name-vs-URL remote classification; `.github/workflows/*.yml` skippable). Each has a regression test built from the reviewer's attack input. Every ambiguity fails toward the safe outcome (block / enforce).

## Tests

New `tests/test_hooks/test_worktree_remote_guard.py` (worktree/`-C`/`cd` merge, compound-merge bypass, decoy-`cd` spoof, force origin/unknown/mirror-URL/non-origin, ambiguous-cwd fail-closed) + extended `test_review_enforcement_commit.py` (docs/config skip, `.github/workflows` enforced, mixed/code/empty enforced). **260 targeted + 732 `tests/test_hooks` pass; ruff clean.**

## Deploy

Hooks-only — take effect at next CC session start. Fail-open only where a transient read failure shouldn't wedge work; fail-closed on every security-relevant ambiguity.

Ledger: 56d147d5eb8d43f294560295233f6411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
