### PR TITLE
fix(hooks): resolve the commit review gate's worktree from the payload cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The commit review gate no longer false-blocks commits made from a second
+  worktree.** When one Claude Code session worked in a git worktree other than
+  the one it launched from, the hook that requires a code review before a commit
+  looked for the review record in the wrong worktree and blocked the commit even
+  though the review had been done. It now reads the Bash tool's actual working
+  directory from the hook payload, so a plain `git commit` resolves its own
+  worktree's review record — no `cd`-prefix workaround needed. The gate is not
+  weakened: an unreviewed commit still blocks, verified by a test that marks the
+  wrong worktree and confirms the real target is still gated.
 - **Genesis's safety guardrails work again.** The hooks that block dangerous
   actions in Claude Code sessions — force-pushing, `rm -rf` on your data
   directories or database, committing to `main` without a review, writing to

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -64,9 +64,26 @@ def _extract_working_dir(command: str) -> str | None:
     return path if os.path.isdir(path) else None
 
 
+def _payload_cwd(payload: dict) -> str | None:
+    """The Bash tool's actual working directory, from the PreToolUse payload.
+
+    CC reports ``cwd`` = the shell's current directory at hook time, and it
+    TRACKS the Bash tool's persisted ``cd`` across separate calls (verified live
+    2026-07-29). So a bare ``git commit`` with no leading ``cd`` still resolves
+    to the right worktree via this, where the command-string parse can't see it.
+    ``CLAUDE_PROJECT_DIR`` is NOT usable here — it is the static session root, so
+    it points at the wrong worktree when this session drives a secondary one.
+    """
+    cwd = payload.get("cwd") if isinstance(payload, dict) else None
+    if isinstance(cwd, str) and cwd and os.path.isabs(cwd) and os.path.isdir(cwd):
+        return cwd  # absolute (CC always supplies absolute) + real dir
+    return None
+
+
 def main() -> None:
     # Parse tool input
-    command = field(read_payload(), "command")
+    payload = read_payload()
+    command = field(payload, "command")
     if not _COMMIT_PATTERN.search(command):
         sys.exit(0)  # Not a commit, allow
 
@@ -95,8 +112,12 @@ def main() -> None:
         )
         return
 
-    # Detect worktree: extract working directory from 'cd /path && git commit'
-    cwd = _extract_working_dir(command)
+    # Detect worktree, in precedence order: an explicit 'cd /path && git commit'
+    # (the command targets THAT dir) → the Bash tool's actual cwd from the payload
+    # (a bare commit runs there; tracks cd-drift across calls) → None (the hook's
+    # own cwd / project root). This is what lets a bare `git commit` from a
+    # secondary worktree find its own review marker instead of false-blocking.
+    cwd = _extract_working_dir(command) or _payload_cwd(payload)
 
     # Import review_state from same directory
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/scripts/review_invalidate_on_commit.py
+++ b/scripts/review_invalidate_on_commit.py
@@ -14,6 +14,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -33,13 +34,25 @@ _COMMIT_PATTERN = re.compile(r"\bgit\s+commit\b")
 def _extract_working_dir(command: str) -> str | None:
     """Extract the worktree cwd from a leading ``cd <path> && ...`` so the marker
     cleared matches the per-worktree marker that authorized this commit."""
-    import os
-
     m = re.match(r"^cd\s+([^\s&|;]+)", command)
     if not m:
         return None
     path = os.path.expanduser(m.group(1))
     return path if os.path.isdir(path) else None
+
+
+def _payload_cwd(payload: dict) -> str | None:
+    """The Bash tool's actual working directory, from the PostToolUse payload.
+
+    MUST mirror ``review_enforcement_commit._payload_cwd`` exactly: the PreToolUse
+    checker resolves a bare ``git commit`` (no leading ``cd``) via this payload
+    ``cwd``, so the PostToolUse invalidator has to clear the SAME per-worktree
+    marker — else the checked marker survives the commit and a later add+commit
+    chain in that worktree passes the existence-only gate on a stale review."""
+    cwd = payload.get("cwd") if isinstance(payload, dict) else None
+    if isinstance(cwd, str) and cwd and os.path.isabs(cwd) and os.path.isdir(cwd):
+        return cwd  # absolute (CC always supplies absolute) + real dir
+    return None
 
 
 def main() -> None:
@@ -64,8 +77,11 @@ def main() -> None:
         pass  # Can't parse result — be conservative, invalidate anyway
 
     # Clear the per-worktree review marker (matching the cwd that authorized
-    # this commit) so the next commit requires a fresh review.
-    clear_marker(cwd=_extract_working_dir(command))
+    # this commit) so the next commit requires a fresh review. Same precedence as
+    # the PreToolUse checker — explicit `cd X && …` → payload cwd → None — so the
+    # marker CLEARED is the same one that was CHECKED (a bare commit resolves via
+    # payload cwd on both sides; a mismatch would leave a stale marker valid).
+    clear_marker(cwd=_extract_working_dir(command) or _payload_cwd(payload))
 
     sys.exit(0)
 

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -310,14 +310,69 @@ def test_marker_not_clobbered_by_concurrent_worktree(
     assert res.returncode == 0, res.stderr
 
 
-def test_distinct_worktrees_get_distinct_markers(
-    repo: Path, home: Path, tmp_path: Path
-) -> None:
+def test_distinct_worktrees_get_distinct_markers(repo: Path, home: Path, tmp_path: Path) -> None:
     repo_b = _second_repo(tmp_path, "repo_b2")
     assert _mark(repo, home).returncode == 0
     assert _mark(repo_b, home).returncode == 0
     markers = list((home / ".genesis" / "review_markers").glob("*.json"))
     assert len(markers) == 2, [m.name for m in markers]
+
+
+# ── Worktree resolved from the payload cwd (bare commit, no `cd` prefix) ──
+
+
+def _run_hook_at(
+    command: str, *, run_from: Path, payload_cwd: Path, home: Path
+) -> subprocess.CompletedProcess:
+    """Run the hook with the process cwd and the payload `cwd` set independently.
+
+    Mirrors the real case where CC's hook process runs at the static project
+    root (run_from) while the Bash tool's actual dir — carried in the payload
+    `cwd` — is a different worktree the session cd'd into."""
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "session_id": "test",
+            "cwd": str(payload_cwd),
+        }
+    )
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=payload,
+        cwd=str(run_from),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_bare_commit_resolves_reviewed_worktree_via_payload_cwd(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """A bare `git commit` (no `cd` prefix) resolves its worktree from the
+    payload `cwd`, so a reviewed commit is allowed even when the hook's own
+    process cwd is a DIFFERENT worktree — the CLAUDE_PROJECT_DIR != actual
+    worktree case that used to false-block."""
+    repo_b = _second_repo(tmp_path, "repo_b_neutral")  # process cwd; unreviewed
+    assert _mark(repo, home).returncode == 0  # reviewed worktree = repo (payload cwd)
+    res = _run_hook_at('git commit -m "reviewed"', run_from=repo_b, payload_cwd=repo, home=home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_payload_cwd_wins_over_process_cwd_and_still_enforces(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """The payload `cwd` (the real commit target) wins over the hook's process
+    cwd, and does NOT weaken the gate: marking the WRONG worktree (repo_b, where
+    the hook process runs) leaves the real target (repo) unreviewed → blocked."""
+    repo_b = _second_repo(tmp_path, "repo_b_marked")
+    assert _mark(repo_b, home).returncode == 0  # the WRONG worktree is reviewed
+    res = _run_hook_at('git commit -m "wip"', run_from=repo_b, payload_cwd=repo, home=home)
+    assert res.returncode == 2, res.stderr
 
 
 def _run_invalidate(command: str, repo: Path, home: Path) -> subprocess.CompletedProcess:
@@ -334,8 +389,12 @@ def _run_invalidate(command: str, repo: Path, home: Path) -> subprocess.Complete
     env = {**os.environ, "HOME": str(home)}
     return subprocess.run(
         [sys.executable, str(_INVALIDATE)],
-        input=payload, cwd=str(repo), env=env,
-        capture_output=True, text=True, timeout=30,
+        input=payload,
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
 
 
@@ -366,3 +425,57 @@ def test_invalidate_ignores_non_commit(repo: Path, home: Path) -> None:
     assert _mark(repo, home).returncode == 0
     _run_invalidate("echo not a commit", repo, home)
     assert len(_markers(home)) == 1  # marker survives
+
+
+def _run_invalidate_at(
+    command: str, *, run_from: Path, payload_cwd: Path, home: Path
+) -> subprocess.CompletedProcess:
+    """PostToolUse invalidation hook with process cwd and payload cwd set apart."""
+    payload = json.dumps(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "[feature/x abc1234] msg", "stderr": ""},
+            "session_id": "test",
+            "cwd": str(payload_cwd),
+        }
+    )
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(_INVALIDATE)],
+        input=payload,
+        cwd=str(run_from),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_bare_commit_invalidates_via_payload_cwd_no_stale_bypass(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """End-to-end BLOCKER regression (both hooks together): a bare commit is
+    CHECKED against repo's marker via payload cwd (PreToolUse), so the PostToolUse
+    invalidator MUST clear that SAME marker via payload cwd. If it doesn't (the
+    asymmetry where only the checker learned payload-cwd), repo's marker survives
+    and a later add+commit chain in repo sails through the existence-only gate on
+    a stale review — the exact unreviewed-commit bypass this guards."""
+    repo_b = _second_repo(tmp_path, "repo_b_e2e")  # hook PROCESS cwd (wrong worktree)
+    assert _mark(repo, home).returncode == 0  # review recorded for repo (real target)
+    # PreToolUse allows the bare commit — resolves repo via payload cwd.
+    assert (
+        _run_hook_at(
+            'git commit -m "reviewed"', run_from=repo_b, payload_cwd=repo, home=home
+        ).returncode
+        == 0
+    )
+    # PostToolUse must clear repo's marker (same payload cwd), not the process-cwd key.
+    _run_invalidate_at('git commit -m "reviewed"', run_from=repo_b, payload_cwd=repo, home=home)
+    assert _markers(home) == [], "invalidator did not clear the payload-cwd-resolved marker"
+    # A NEW unreviewed add+commit chain in repo must now BLOCK (no stale marker).
+    res = _run_hook_at(
+        'git add -A && git commit -m "unreviewed"', run_from=repo_b, payload_cwd=repo, home=home
+    )
+    assert res.returncode == 2, res.stderr


### PR DESCRIPTION
## What

Stops the commit review gate from false-blocking a `git commit` made from a **second worktree** (one that isn't the session's launch dir).

The gate figured out which worktree's review marker to check by parsing a leading `cd X && git commit` from the command string only. A **bare** `git commit` (no `cd` prefix) from a secondary worktree therefore resolved the marker against the wrong worktree and blocked the commit even though the review had been recorded — a real papercut hit repeatedly this session (10+ times).

## How

Both hooks of the pair fall back to the **PreToolUse/PostToolUse payload `cwd`** — the Bash tool's actual working directory, which tracks its persisted `cd` across separate calls (verified live: it reports the drifted shell dir, not the static `CLAUDE_PROJECT_DIR`). Precedence: explicit `cd X && …` (the command targets that dir; payload `cwd` would be the stale *pre-cd* dir) → payload `cwd` → `None`.

**Both** the checker (`review_enforcement_commit.py`) and the invalidator (`review_invalidate_on_commit.py`) get the **identical** resolution, so the marker cleared after a commit is the same one that was checked. Patching only the checker would desync the pair and reopen a stale-marker bypass — caught by review, fixed here, and guarded by an end-to-end regression test that drives both hooks (mark → PreToolUse allow → PostToolUse invalidate → a new unreviewed `add && commit` must still block).

`_payload_cwd` requires an absolute, existing directory; anything else (non-str, empty, relative, non-dir) falls through to prior behavior — over-strict, never permissive.

## Not weakened

A test marks the **wrong** worktree and confirms the real target still blocks; Rule 0 (`--no-verify`) is checked before `cwd` is computed; Rule 1 (main) keys on the same resolved `cwd` as the commit's real location.

## Review

Codex + two Claude adversarial passes. The whole-repo Claude pass found a **BLOCKER** — the PostToolUse invalidator hadn't been updated, desyncing the pair — now fixed and regression-tested (verified RED without the invalidator fix). Optional `os.path.isabs()` hardening applied to both copies. 41 hook tests pass; ruff clean; private-data scan clean. A pre-existing decoy-`cd` / `git -C` evasion surface of the gate is tracked separately (tabled `d21db5ea`).

## Deploy

CC-session hooks — merge then `git pull` on main; reload on next Bash call. No restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
