### PR TITLE
fix(resilience): internet-outage class fixes (PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   state — so a memory that was retired or superseded while its vector was still
   pending stays excluded from recall instead of quietly reappearing, and its real
   confidence is preserved rather than reset to a default.
+- **Internet outages no longer leave a mess behind.** A long connectivity loss
+  used to pile up hundreds of duplicate queued alerts, spam the health view with
+  false "delivery exhausted" warnings, and — worst — put Genesis in an endless
+  restart loop (it announced "going offline" over and over because restarting
+  can't fix a dead network). Now: a repeated delivery failure for the same alert
+  is de-duplicated instead of re-queued; a duplicate that was already delivered,
+  or an email held for your approval, is treated as done rather than retried into
+  a false failure; deferred messages actually expire on their 4-hour deadline
+  instead of lingering forever; and the watchdog, after restarting a few times
+  for the same reason, backs off and sends you one warning instead of restarting
+  on a loop.
+- **Genesis now sheds low-priority background work when its providers are
+  struggling.** The degradation system that's meant to skip non-essential work
+  (surplus brainstorms, the morning report) during a provider brownout was wired
+  up but never actually triggered on provider failures — it does now, so a rough
+  patch for the model providers no longer drags every background task down with it.
 
 ### Added
 

--- a/config/autonomy.yaml
+++ b/config/autonomy.yaml
@@ -56,6 +56,15 @@ watchdog:
   backoff_initial_seconds: 10
   backoff_max_seconds: 300               # Cap at 5 minutes
   config_validation: true                # Validate config before restart
+  # Flap damping — a SLOW recurring same-reason restart (spaced beyond the 120s
+  # stabilization window, so consecutive_failures resets each time) would restart
+  # forever; restart cannot fix a persistent external cause (2026-07 outage flapped
+  # zombie_scheduler ~25x/12h). Once >= flap_threshold same-reason restarts land
+  # within flap_window_seconds, escalate backoff (capped) and surface one warning
+  # alert. A BACKOFF, not a refusal — self-heals once the window prunes.
+  flap_window_seconds: 21600             # 6h rolling per-reason window
+  flap_threshold: 3                      # same-reason restarts before damping kicks in
+  flap_backoff_max_seconds: 7200         # cap escalating flap backoff at 2h
 
 # CC rate limit detection patterns
 # These are parsed from CC CLI stderr/stdout when rate limits are hit.

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -796,10 +796,16 @@ retry:
     max_retries: 4
     base_delay_ms: 1000
     max_delay_ms: 60000
-    # Generous safety net only — should never fire in normal operation. Dream /
-    # reflection / ego are exactly where a single completion may legitimately
-    # take a while across failovers; we only stop the pathology, not cognition.
-    max_total_s: 1800
+    # Safety net for background dispatches (dream / reflection / ego / surplus).
+    # MUST stay comfortably under the watchdog's 900s scheduler-heartbeat zombie
+    # threshold (autonomy/watchdog.py _check_scheduler_heartbeats): a background
+    # route_call that outlives it lets the surplus heartbeat go stale and the
+    # watchdog restarts the WHOLE server — which, during the 2026-07 outage,
+    # produced 25+ restart-kills in a day (was 1800s = 2x the threshold, so a
+    # single stalled dispatch always tripped it). 600s still allows ~5 sequential
+    # 120s hard-timeout attempts across the chain; it bounds ONE completion's
+    # retry-multiplier, not cognition. Guarded by test_retry_profiles_under_watchdog_threshold.
+    max_total_s: 600
 surplus:
   idle_threshold_minutes: 15
   dispatch_interval_minutes: 5

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -64,6 +64,9 @@ class WatchdogChecker:
         secrets_path: str | Path | None = None,
         state_file: str | Path = "~/.genesis/watchdog_state.json",
         stabilization_s: int = 120,
+        flap_window_s: int = 21600,
+        flap_threshold: int = 3,
+        flap_backoff_max_s: int = 7200,
         remediation_registry: RemediationRegistry | None = None,
         outreach_fn: OutreachFn | None = None,
     ) -> None:
@@ -78,6 +81,9 @@ class WatchdogChecker:
         self._secrets_path = Path(resolved_secrets).expanduser()
         self._state_path = Path(state_file).expanduser()
         self._stabilization_s = stabilization_s
+        self._flap_window_s = flap_window_s
+        self._flap_threshold = flap_threshold
+        self._flap_backoff_max_s = flap_backoff_max_s
         self._remediation_registry = remediation_registry
         self._outreach_fn = outreach_fn
         self._target_service = self._detect_target_service()
@@ -117,6 +123,9 @@ class WatchdogChecker:
                 backoff_max_s=wd.get("backoff_max_seconds", 300),
                 config_validation=wd.get("config_validation", True),
                 stabilization_s=wd.get("stabilization_seconds", 120),
+                flap_window_s=wd.get("flap_window_seconds", 21600),
+                flap_threshold=wd.get("flap_threshold", 3),
+                flap_backoff_max_s=wd.get("flap_backoff_max_seconds", 7200),
             )
         except (yaml.YAMLError, OSError, AttributeError):
             logger.warning("Failed to load watchdog config — using defaults", exc_info=True)
@@ -213,6 +222,35 @@ class WatchdogChecker:
                 "Deploy in progress — deferring %s restart until it completes", reason,
             )
             return WatchdogAction.SKIP
+
+        # Flap damping: a SLOW recurring same-reason restart (spaced beyond the
+        # 120s stabilization window, so consecutive_failures keeps resetting to
+        # 0) would otherwise restart forever — restart cannot fix a persistent
+        # external cause (the 2026-07 outage flapped zombie_scheduler ~25x/12h).
+        # Once >= flap_threshold same-reason restarts land within flap_window,
+        # apply an escalating (capped) backoff and surface ONE durable warning
+        # instead of silently restarting again. This is a BACKOFF, never a
+        # permanent refusal — it self-heals once the window prunes. Rapid crash
+        # recovery is unaffected (that trips consecutive_failures/backoff below,
+        # within the stabilization window). PR-2 will additionally suppress
+        # zombie restarts outright when the connectivity sentinel reports offline.
+        now = time.time()
+        same_reason = [
+            h for h in state.get("restart_history", [])
+            if h.get("reason") == reason and now - h.get("ts", 0) <= self._flap_window_s
+        ]
+        if len(same_reason) >= self._flap_threshold:
+            over = len(same_reason) - self._flap_threshold + 1
+            flap_backoff = min(self._flap_backoff_max_s, self._backoff_max * (2**over))
+            last_ts = max(h["ts"] for h in same_reason)
+            if now < last_ts + flap_backoff:
+                self._alert_flap(reason, len(same_reason), flap_backoff)
+                logger.warning(
+                    "Flap damping: %d '%s' restarts within %ds — backing off "
+                    "%.0fs (restart cannot fix a recurring same-reason failure)",
+                    len(same_reason), reason, self._flap_window_s, flap_backoff,
+                )
+                return WatchdogAction.BACKOFF
 
         if state["consecutive_failures"] >= self._max_restarts:
             logger.error(
@@ -420,7 +458,7 @@ class WatchdogChecker:
                 return json.loads(self._state_path.read_text())
             except (json.JSONDecodeError, OSError):
                 pass
-        return {"consecutive_failures": 0, "next_attempt_after": None, "last_reason": None, "last_restart_at": None, "last_check_at": None}
+        return {"consecutive_failures": 0, "next_attempt_after": None, "last_reason": None, "last_restart_at": None, "last_check_at": None, "restart_history": []}
 
     def _save_state(self, state: dict) -> None:
         self._state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -430,16 +468,54 @@ class WatchdogChecker:
             logger.error("Failed to save watchdog state to %s", self._state_path, exc_info=True)
 
     def _record_failure(self, state: dict, *, reason: str) -> None:
+        now = time.time()
         state["consecutive_failures"] += 1
         state["last_reason"] = reason
-        state["last_restart_at"] = time.time()
+        state["last_restart_at"] = now
+        # Rolling per-reason restart history for flap damping. Recorded on
+        # every actual restart decision (never on a backoff-skip), pruned to
+        # the flap window. Deliberately survives _reset_state so SLOW
+        # recurrences (spaced beyond the 120s stabilization window, which
+        # resets consecutive_failures to 0) are still counted — the hole that
+        # let the 2026-07 outage flap ~25x/12h.
+        history = [
+            h for h in state.get("restart_history", [])
+            if now - h.get("ts", 0) <= self._flap_window_s
+        ]
+        history.append({"ts": now, "reason": reason})
+        state["restart_history"] = history
         # Exponential backoff: initial * 2^(failures-1), capped
         backoff = min(
             self._backoff_initial * (2 ** (state["consecutive_failures"] - 1)),
             self._backoff_max,
         )
-        state["next_attempt_after"] = time.time() + backoff
+        state["next_attempt_after"] = now + backoff
         self._save_state(state)
+
+    def _alert_flap(self, reason: str, count: int, backoff_s: float) -> None:
+        """Surface ONE durable warning that the watchdog is flap-damping a
+        recurring same-reason restart. Routed through the alert queue (drained
+        to the owner by the awareness tick) because the oneshot watchdog has no
+        outreach pipeline; the dedupe_key collapses repeats to a single live
+        entry per reason. Best-effort — never raises."""
+        try:
+            from genesis.guardian.alert.queue import enqueue_alert
+
+            enqueue_alert(
+                Path.home() / ".genesis" / "alerts" / "queue",
+                severity="warning",
+                source="watchdog",
+                title="Watchdog flap-damping repeated restarts",
+                body=(
+                    f"{count} '{reason}' restarts within {self._flap_window_s}s — "
+                    f"backing off {backoff_s:.0f}s. Restart cannot fix a recurring "
+                    f"same-reason failure; investigate the root cause "
+                    f"(e.g. connectivity loss or a crash loop)."
+                ),
+                dedupe_key=f"watchdog:flap:{reason}",
+            )
+        except Exception:
+            logger.debug("flap alert enqueue failed", exc_info=True)
 
     def _reset_state(self) -> None:
         if not self._state_path.exists():
@@ -471,6 +547,13 @@ class WatchdogChecker:
                     logger.error("Failed to save watchdog state", exc_info=True)
                 return
 
+        # Preserve the rolling restart history (pruned) across a healthy reset
+        # — wiping it here is exactly what let slow recurrences dodge damping.
+        now = time.time()
+        history = [
+            h for h in state.get("restart_history", [])
+            if now - h.get("ts", 0) <= self._flap_window_s
+        ]
         try:
             self._state_path.write_text(
                 json.dumps({
@@ -479,6 +562,7 @@ class WatchdogChecker:
                     "last_reason": None,
                     "last_restart_at": None,
                     "last_check_at": datetime.now(UTC).isoformat(),
+                    "restart_history": history,
                 })
             )
         except OSError:

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1933,6 +1933,7 @@ class AwarenessLoop:
         self._resilience_state_machine = resilience_state_machine
         self._deferred_queue = deferred_queue
         self._circuit_breakers: CircuitBreakerRegistry | None = None
+        self._degradation_tracker = None
         self._tick_event_loop: asyncio.AbstractEventLoop | None = None
         self._topic_manager = None
         self._guardian_watchdog = None
@@ -1973,6 +1974,12 @@ class AwarenessLoop:
     def set_circuit_breakers(self, breakers: CircuitBreakerRegistry) -> None:
         """Inject circuit breaker registry for resilience state updates."""
         self._circuit_breakers = breakers
+
+    def set_degradation_tracker(self, tracker) -> None:
+        """Inject the routing DegradationTracker so the awareness tick can latch
+        composite resilience state into it (see _on_tick). Without this the
+        tracker's cloud degradation level never leaves NORMAL."""
+        self._degradation_tracker = tracker
 
     async def _update_resilience_cognitive_state(self, level: DegradationLevel) -> None:
         """Write or clear cognitive state when resilience level changes."""
@@ -2225,6 +2232,20 @@ class AwarenessLoop:
                         self._resilience_state_machine.update_tmp_pressure(tmp_status)
                 except Exception:
                     logger.debug("tmp_pressure axis update failed", exc_info=True)
+
+            # Latch the composite resilience state into the routing degradation
+            # tracker so cloud/provider degradation actually sheds background
+            # call sites (_L2_SKIP at REDUCED, _L3_KEEP at ESSENTIAL). Without
+            # this per-tick refresh the tracker's cloud level is frozen at
+            # NORMAL and shedding never fires on provider degradation (the
+            # tmp_pressure axis reads live state and was unaffected). Runs after
+            # all axis updates so the freshest composite state is latched.
+            # (ego goal af5c59b8: surplus L0-skip)
+            if self._degradation_tracker is not None:
+                try:
+                    self._degradation_tracker.update_from_resilience()
+                except Exception:
+                    logger.debug("degradation tracker update failed", exc_info=True)
 
             # Per-CC-slot RSS leak check — reads /proc (no DB dependency, so it
             # still runs during a DB hiccup); the observation write is guarded on

--- a/src/genesis/db/crud/deferred_work.py
+++ b/src/genesis/db/crud/deferred_work.py
@@ -153,34 +153,57 @@ async def count_pending_in(
     return int(row[0])
 
 
-async def count_open_by_topic(
+async def count_open_by_identity(
     db: aiosqlite.Connection,
     *,
     work_type: str,
     topic: str,
+    category: str,
+    signal_type: str | None,
 ) -> int:
-    """Count OPEN (pending or processing) rows for a work_type whose payload
-    ``topic`` matches.
+    """Count OPEN (pending or processing) rows for a work_type matching the FULL
+    outreach dedup identity ``(topic, category, signal_type)`` stored in
+    ``payload_json``.
 
-    Dedup-at-defer: repeated delivery failures of the same alert must not each
+    Dedup-at-defer: repeated delivery failures of the SAME message must not each
     enqueue a fresh row. Both the recovery worker's retry (which moves the
     original to 'processing' before re-attempting, then re-defers on failure)
     and the alert-drain re-submit loop go through ``_defer`` — counting
     'processing' as well as 'pending' closes both amplification paths (2026-07
     outage: 690 duplicate rows for one backup-alert topic).
 
-    ``topic`` lives in ``payload_json`` (no dedicated column) — read it with the
-    JSON1 ``json_extract``. A single-writer queue makes the read-then-insert
-    race-free enough here; the ``idx_rlp_open_dedup`` partial-unique-index
-    pattern (``cc_rate_limit_parks``) is the upgrade path if a concurrent
-    producer ever appears.
+    Keys on the SAME ``(signal_type, topic, category)`` identity governance uses
+    (``outreach/governance.py``), NOT topic alone. A topic is reused across
+    message TYPES (e.g. ``autonomy/executor/engine.py`` emits progress, success,
+    alert, and blocker under one ``Task <id>`` topic); a topic-only guard would
+    suppress a later blocker behind an open progress row and permanently drop it.
+    (The alert-drain dupes share one identity so they still collapse to a single
+    row; the recovery worker rewrites signal_type to ``deferred_retry`` on its
+    retries, so that path stabilises at ~2 rows/message — still vs 690 — while
+    distinct message types stay independently deliverable.)
+
+    ``json_valid`` + ``CASE`` guard each extraction so a corrupt ``payload_json``
+    row (external corruption — ``_defer`` always writes valid JSON) is skipped
+    rather than raising ``OperationalError``, which would propagate through
+    ``has_open`` into ``_defer``'s broad handler and silently drop EVERY new
+    delivery until the bad row is cleared. ``COALESCE(..., '')`` makes a
+    missing/NULL signal_type or category match cleanly (SQL ``NULL = ?`` is never
+    true). Single-writer queue → the read-then-insert is race-free enough; the
+    ``idx_rlp_open_dedup`` partial-unique-index pattern (``cc_rate_limit_parks``)
+    is the upgrade path if a concurrent producer ever appears.
     """
     cursor = await db.execute(
         """SELECT COUNT(*) FROM deferred_work_queue
            WHERE work_type = ?
              AND status IN ('pending', 'processing')
-             AND json_extract(payload_json, '$.topic') = ?""",
-        (work_type, topic),
+             AND (CASE WHEN json_valid(payload_json)
+                       THEN json_extract(payload_json, '$.topic') END) = ?
+             AND COALESCE(CASE WHEN json_valid(payload_json)
+                       THEN json_extract(payload_json, '$.category') END, '') = ?
+             AND COALESCE(CASE WHEN json_valid(payload_json)
+                       THEN json_extract(payload_json, '$.signal_type') END, '')
+                 = COALESCE(?, '')""",
+        (work_type, topic, category, signal_type),
     )
     row = await cursor.fetchone()
     return int(row[0])

--- a/src/genesis/db/crud/deferred_work.py
+++ b/src/genesis/db/crud/deferred_work.py
@@ -153,6 +153,39 @@ async def count_pending_in(
     return int(row[0])
 
 
+async def count_open_by_topic(
+    db: aiosqlite.Connection,
+    *,
+    work_type: str,
+    topic: str,
+) -> int:
+    """Count OPEN (pending or processing) rows for a work_type whose payload
+    ``topic`` matches.
+
+    Dedup-at-defer: repeated delivery failures of the same alert must not each
+    enqueue a fresh row. Both the recovery worker's retry (which moves the
+    original to 'processing' before re-attempting, then re-defers on failure)
+    and the alert-drain re-submit loop go through ``_defer`` — counting
+    'processing' as well as 'pending' closes both amplification paths (2026-07
+    outage: 690 duplicate rows for one backup-alert topic).
+
+    ``topic`` lives in ``payload_json`` (no dedicated column) — read it with the
+    JSON1 ``json_extract``. A single-writer queue makes the read-then-insert
+    race-free enough here; the ``idx_rlp_open_dedup`` partial-unique-index
+    pattern (``cc_rate_limit_parks``) is the upgrade path if a concurrent
+    producer ever appears.
+    """
+    cursor = await db.execute(
+        """SELECT COUNT(*) FROM deferred_work_queue
+           WHERE work_type = ?
+             AND status IN ('pending', 'processing')
+             AND json_extract(payload_json, '$.topic') = ?""",
+        (work_type, topic),
+    )
+    row = await cursor.fetchone()
+    return int(row[0])
+
+
 async def count_recovery_pending(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -887,7 +887,10 @@ class OutreachPipeline:
             # (pending/processing) row for this topic already exists. Empty topic
             # → never suppress (can't distinguish distinct sends).
             if request.topic and await self._deferred_queue.has_open(
-                "outreach_delivery", request.topic
+                "outreach_delivery",
+                request.topic,
+                request.category.value,
+                request.signal_type,
             ):
                 logger.info(
                     "Defer suppressed for %s — open deferred outreach for "
@@ -906,6 +909,7 @@ class OutreachPipeline:
                     "channel": channel,
                     "content": content,
                     "category": request.category.value,
+                    "signal_type": request.signal_type,
                     "topic": request.topic,
                     # Origin-targeted delivery must survive a transient-failure
                     # retry, or a result that failed once lands in the default

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -880,6 +880,21 @@ class OutreachPipeline:
         if not self._deferred_queue:
             return
         try:
+            # Dedup-at-defer: a repeated delivery failure of the SAME topic must
+            # not enqueue a fresh row each time (2026-07 outage: 690 duplicate
+            # rows for one backup-alert topic, from the recovery-worker retry
+            # loop AND the alert-drain re-submit loop). Suppress when an open
+            # (pending/processing) row for this topic already exists. Empty topic
+            # → never suppress (can't distinguish distinct sends).
+            if request.topic and await self._deferred_queue.has_open(
+                "outreach_delivery", request.topic
+            ):
+                logger.info(
+                    "Defer suppressed for %s — open deferred outreach for "
+                    "topic %r already queued",
+                    outreach_id, request.topic,
+                )
+                return
             # "outreach_fallback" — deferred-queue work tag (not in model_routing.yaml).
             # No own routing chain; used for cost/event tracking only.
             await self._deferred_queue.enqueue(
@@ -899,8 +914,13 @@ class OutreachPipeline:
                     "target_thread_id": request.target_thread_id,
                 }),
                 reason=reason,
-                staleness_policy="drain",
-                staleness_ttl_s=14400,  # 4h — accommodates 5 retries with backoff
+                # "ttl" (not "drain"): expire_by_policy honors staleness_ttl_s
+                # only for the 'ttl' policy — under 'drain' the row NEVER expired,
+                # so failed-forever items accumulated (2026-07 outage). 4h covers
+                # 5 retries with backoff (sum ≈ 2.35h); RecoveryOrchestrator's
+                # 30-min expire_stale() sweep enforces it.
+                staleness_policy="ttl",
+                staleness_ttl_s=14400,
             )
         except Exception:
             logger.exception("Failed to defer outreach %s", outreach_id)

--- a/src/genesis/resilience/deferred_work.py
+++ b/src/genesis/resilience/deferred_work.py
@@ -197,14 +197,20 @@ class DeferredWorkQueue:
         """Count pending items, optionally filtered by work_type."""
         return await crud.count_pending(self._db, work_type=work_type)
 
-    async def has_open(self, work_type: str, topic: str) -> bool:
-        """True if an OPEN (pending/processing) item already exists for this
-        (work_type, topic). Dedup-at-defer guard — see
-        ``crud.count_open_by_topic``.
+    async def has_open(
+        self, work_type: str, topic: str, category: str, signal_type: str | None
+    ) -> bool:
+        """True if an OPEN (pending/processing) item already exists for this FULL
+        outreach identity (work_type, topic, category, signal_type). Dedup-at-defer
+        guard — see ``crud.count_open_by_identity``.
         """
         return (
-            await crud.count_open_by_topic(
-                self._db, work_type=work_type, topic=topic
+            await crud.count_open_by_identity(
+                self._db,
+                work_type=work_type,
+                topic=topic,
+                category=category,
+                signal_type=signal_type,
             )
             > 0
         )

--- a/src/genesis/resilience/deferred_work.py
+++ b/src/genesis/resilience/deferred_work.py
@@ -197,6 +197,18 @@ class DeferredWorkQueue:
         """Count pending items, optionally filtered by work_type."""
         return await crud.count_pending(self._db, work_type=work_type)
 
+    async def has_open(self, work_type: str, topic: str) -> bool:
+        """True if an OPEN (pending/processing) item already exists for this
+        (work_type, topic). Dedup-at-defer guard — see
+        ``crud.count_open_by_topic``.
+        """
+        return (
+            await crud.count_open_by_topic(
+                self._db, work_type=work_type, topic=topic
+            )
+            > 0
+        )
+
     async def count_worklist_pending(self) -> int:
         """Count pending batch-worklist items (dream synthesis etc.).
 

--- a/src/genesis/resilience/outreach_recovery.py
+++ b/src/genesis/resilience/outreach_recovery.py
@@ -129,7 +129,11 @@ class OutreachRecoveryWorker:
         await self._queue.mark_processing(item_id)
 
         try:
-            from genesis.outreach.types import OutreachCategory, OutreachRequest
+            from genesis.outreach.types import (
+                OutreachCategory,
+                OutreachRequest,
+                OutreachStatus,
+            )
 
             category = OutreachCategory(payload.get("category", "alert"))
             request = OutreachRequest(
@@ -151,14 +155,47 @@ class OutreachRecoveryWorker:
 
             result = await self._pipeline.submit_raw(content, request)
 
-            if result.status.value == "delivered":
+            if result.status == OutreachStatus.DELIVERED:
                 await self._queue.mark_completed(item_id)
                 logger.info(
                     "Outreach recovery: delivered %s on attempt %d",
                     item_id, attempts + 1,
                 )
+            elif result.status in (OutreachStatus.REJECTED, OutreachStatus.HELD):
+                # TERMINAL, not a failure — stop retrying (mirrors alert_drain:
+                # DELIVERED and REJECTED are both terminal).
+                #  - REJECTED = governance dedup: an identical send already
+                #    reached the user; retrying just re-trips the dedup and
+                #    (pre-fix) burned all 5 attempts + filed a junk
+                #    delivery_exhausted observation.
+                #  - HELD = WS-8 email autonomy gate recorded a pending hold and
+                #    owns delivery via its resolution watcher; retrying here
+                #    re-gates and records a NEW hold each cycle.
+                # mark_completed (not discarded) so the row is not surfaced as a
+                # failure by crud.query_failed.
+                await self._queue.mark_completed(item_id)
+                logger.info(
+                    "Outreach recovery: %s terminal for %s (%s) — done, no retry",
+                    result.status.value, item_id,
+                    "duplicate of a delivered send"
+                    if result.status == OutreachStatus.REJECTED
+                    else "held by email autonomy gate",
+                )
+            elif result.status == OutreachStatus.IGNORED:
+                # Permanent non-delivery (self-addressed / unresolved recipient
+                # — pipeline._deliver returns IGNORED), NOT a transient failure.
+                # Discard so it neither retries nor files a junk
+                # delivery_exhausted observation (same class as REJECTED/HELD).
+                await self._queue.mark_discarded(
+                    item_id,
+                    f"outreach ignored (not retriable): {result.error or 'suppressed'}",
+                )
+                logger.info(
+                    "Outreach recovery: ignored (not retriable) for %s: %s",
+                    item_id, result.error or "suppressed",
+                )
             else:
-                # Delivery failed again
+                # Delivery failed again (FAILED/PENDING/…) — retry next cycle.
                 await self._queue.reset_to_pending(item_id)
                 logger.warning(
                     "Outreach recovery: retry %d/%d failed for %s: %s",

--- a/src/genesis/runtime/init/router.py
+++ b/src/genesis/runtime/init/router.py
@@ -88,6 +88,7 @@ def init(rt: GenesisRuntime) -> None:
             rt._awareness_loop.set_resilience_state_machine(rt._resilience_state_machine)
             if rt._circuit_breakers is not None:
                 rt._awareness_loop.set_circuit_breakers(rt._circuit_breakers)
+            rt._awareness_loop.set_degradation_tracker(degradation)
             logger.info("Deferred queue + resilience state machine + circuit breakers injected into awareness loop")
 
     except ImportError:

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -85,6 +85,9 @@ def _make_checker(
         secrets_path=str(secrets_path or tmp_path / "secrets.env"),
         state_file=str(tmp_path / "watchdog_state.json"),
         stabilization_s=kwargs.get("stabilization_s", 600),
+        flap_window_s=kwargs.get("flap_window_s", 21600),
+        flap_threshold=kwargs.get("flap_threshold", 3),
+        flap_backoff_max_s=kwargs.get("flap_backoff_max_s", 7200),
     )
 
 
@@ -126,6 +129,109 @@ class TestDeployInProgress:
         # guard adds zero behavior change outside a deploy window.
         checker = _make_checker(tmp_path, stale_status)
         assert checker.check() is WatchdogAction.RESTART
+
+
+class TestFlapDamping:
+    """Slow recurring same-reason restarts (spaced beyond the stabilization
+    window, so consecutive_failures keeps resetting) must eventually back off and
+    surface a warning, instead of restarting forever (2026-07 outage: 25x/12h)."""
+
+    def _seed(self, count, reason="zombie_scheduler", age_s=5):
+        now = time.time()
+        return {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": [{"ts": now - age_s, "reason": reason} for _ in range(count)],
+        }
+
+    def test_backs_off_after_threshold(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        assert (
+            checker._restart_if_allowed(self._seed(3), reason="zombie_scheduler")
+            is WatchdogAction.BACKOFF
+        )
+
+    def test_below_threshold_still_restarts(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        assert (
+            checker._restart_if_allowed(self._seed(2), reason="zombie_scheduler")
+            is WatchdogAction.RESTART
+        )
+
+    def test_different_reasons_dont_cross_count(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        now = time.time()
+        state = {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": [
+                {"ts": now - 5, "reason": "zombie_scheduler"},
+                {"ts": now - 5, "reason": "zombie_scheduler"},
+                {"ts": now - 5, "reason": "stale_status_restart"},
+            ],
+        }
+        assert (
+            checker._restart_if_allowed(state, reason="zombie_scheduler")
+            is WatchdogAction.RESTART
+        )
+
+    def test_history_pruned_past_window(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(
+            tmp_path, stale_status, flap_threshold=3, flap_window_s=100, backoff_max_s=10
+        )
+        now = time.time()
+        state = {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": [
+                {"ts": now - 500, "reason": "zombie_scheduler"},  # outside 100s window
+                {"ts": now - 5, "reason": "zombie_scheduler"},
+                {"ts": now - 5, "reason": "zombie_scheduler"},
+            ],
+        }
+        assert (
+            checker._restart_if_allowed(state, reason="zombie_scheduler")
+            is WatchdogAction.RESTART
+        )
+
+    def test_alert_enqueued_once_on_flap(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        with patch("genesis.guardian.alert.queue.enqueue_alert") as mock_alert:
+            checker._restart_if_allowed(self._seed(3), reason="zombie_scheduler")
+        mock_alert.assert_called_once()
+        assert mock_alert.call_args.kwargs["dedupe_key"] == "watchdog:flap:zombie_scheduler"
+        assert mock_alert.call_args.kwargs["severity"] == "warning"
+
+    def test_record_failure_appends_history(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status)
+        state = {"consecutive_failures": 0, "restart_history": []}
+        checker._record_failure(state, reason="zombie_scheduler")
+        assert len(state["restart_history"]) == 1
+        assert state["restart_history"][0]["reason"] == "zombie_scheduler"
+
+    def test_reset_state_preserves_history(self, tmp_path: Path, fresh_status: Path):
+        checker = _make_checker(tmp_path, fresh_status, stabilization_s=0)
+        state_file = tmp_path / "watchdog_state.json"
+        now = time.time()
+        state_file.write_text(
+            json.dumps({
+                "consecutive_failures": 3,
+                "last_restart_at": now - 1000,
+                "restart_history": [{"ts": now - 10, "reason": "zombie_scheduler"}],
+            })
+        )
+        checker.check()
+        state = json.loads(state_file.read_text())
+        assert state["consecutive_failures"] == 0  # healthy reset
+        assert len(state["restart_history"]) == 1  # but history preserved
+
+    def test_legacy_state_without_history_ok(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3)
+        action = checker._restart_if_allowed(
+            {"consecutive_failures": 0, "next_attempt_after": None},
+            reason="zombie_scheduler",
+        )
+        assert action is WatchdogAction.RESTART  # no restart_history key → no crash
 
 
 class TestHealthy:

--- a/tests/test_awareness/test_loop_resilience.py
+++ b/tests/test_awareness/test_loop_resilience.py
@@ -63,11 +63,51 @@ async def test_late_binding_setters(db):
     sm = MagicMock()
     dq = AsyncMock()
 
+    tracker = MagicMock()
     loop.set_resilience_state_machine(sm)
     loop.set_deferred_queue(dq)
+    loop.set_degradation_tracker(tracker)
 
     assert loop._resilience_state_machine is sm
     assert loop._deferred_queue is dq
+    assert loop._degradation_tracker is tracker
+
+
+async def test_on_tick_latches_degradation_into_tracker(db, monkeypatch):
+    """Fix E wiring: _on_tick must call update_from_resilience() on the injected
+    DegradationTracker so cloud degradation actually sheds background call sites.
+    With cloud REDUCED and NO circuit breakers (so the tick's cloud-axis update is
+    skipped and the pre-set state stands), the tracker level moves NORMAL -> REDUCED,
+    which only update_from_resilience() does. Guards against the wiring being
+    dropped or moved to a path _on_tick never calls."""
+    from genesis.resilience.state import CloudStatus, ResilienceStateMachine
+    from genesis.routing.degradation import DegradationTracker
+    from genesis.routing.types import DegradationLevel
+
+    def _fake_tracked_task(coro, *, name="", **kw):
+        coro.close()
+        return None
+
+    monkeypatch.setattr("genesis.util.tasks.tracked_task", _fake_tracked_task)
+    # Hermetic: pin tmp pressure to NORMAL so the composite level reflects only
+    # the cloud axis regardless of the host's live watchgod state (a host under
+    # CRITICAL tmp pressure would otherwise push the legacy level to ESSENTIAL).
+    monkeypatch.setattr(
+        "genesis.observability.service_status.collect_cc_tmp_usage",
+        lambda: {"cc_tier": "green"},
+    )
+
+    sm = ResilienceStateMachine()
+    sm.update_cloud(CloudStatus.REDUCED)
+    tracker = DegradationTracker(resilience_state=sm)
+    assert tracker.current_level == DegradationLevel.NORMAL  # not latched yet
+
+    loop = AwarenessLoop(db=db, collectors=[])
+    loop.set_resilience_state_machine(sm)
+    loop.set_degradation_tracker(tracker)
+    await loop._on_tick()
+
+    assert tracker.current_level == DegradationLevel.REDUCED
 
 
 # ── LIGHT → CC Haiku (primary) ───────────────────────────────────────────

--- a/tests/test_outreach/test_deliver_origin_target.py
+++ b/tests/test_outreach/test_deliver_origin_target.py
@@ -153,6 +153,7 @@ async def test_defer_carries_target_fields_for_retry(config, db, mock_formatter)
     failing_adapter = AsyncMock()
     failing_adapter.send_message.side_effect = RuntimeError("transient telegram error")
     deferred_queue = AsyncMock()
+    deferred_queue.has_open = AsyncMock(return_value=False)  # no open dup
     pipeline = OutreachPipeline(
         governance=GovernanceGate(config, db),
         drafter=AsyncMock(),

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -302,6 +302,7 @@ async def test_delivery_failure_defers(config, db, mock_drafter, mock_formatter)
     failing_channel = AsyncMock()
     failing_channel.send_message.side_effect = ConnectionError("Network down")
     mock_deferred = AsyncMock()
+    mock_deferred.has_open = AsyncMock(return_value=False)  # no open dup
 
     gate = GovernanceGate(config, db)
     pipeline = OutreachPipeline(
@@ -324,6 +325,45 @@ async def test_delivery_failure_defers(config, db, mock_drafter, mock_formatter)
     result = await pipeline.submit(req)
     assert result.status == OutreachStatus.FAILED
     mock_deferred.enqueue.assert_called_once()
+    # Fix B: deferred outreach must use the 'ttl' policy so expire_by_policy
+    # actually expires it (the old 'drain' policy never expired → pile-up).
+    assert mock_deferred.enqueue.call_args.kwargs["staleness_policy"] == "ttl"
+    assert mock_deferred.enqueue.call_args.kwargs["staleness_ttl_s"] == 14400
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_suppressed_when_open_duplicate(
+    config, db, mock_drafter, mock_formatter
+):
+    """Fix C: a repeated failure for a topic with an already-open deferred row
+    does NOT enqueue a second row (the 690-duplicate outage signature)."""
+    failing_channel = AsyncMock()
+    failing_channel.send_message.side_effect = ConnectionError("Network down")
+    mock_deferred = AsyncMock()
+    mock_deferred.has_open = AsyncMock(return_value=True)  # dup already queued
+
+    gate = GovernanceGate(config, db)
+    pipeline = OutreachPipeline(
+        governance=gate,
+        drafter=mock_drafter,
+        formatter=mock_formatter,
+        channels={"telegram": failing_channel},
+        deferred_queue=mock_deferred,
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    req = OutreachRequest(
+        category=OutreachCategory.SURPLUS,
+        topic="Defer test",
+        context="Will fail delivery",
+        salience_score=0.9,
+        signal_type="surplus_insight",
+    )
+    result = await pipeline.submit(req)
+    assert result.status == OutreachStatus.FAILED
+    mock_deferred.has_open.assert_awaited_once_with("outreach_delivery", "Defer test")
+    mock_deferred.enqueue.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -362,7 +362,9 @@ async def test_delivery_failure_suppressed_when_open_duplicate(
     )
     result = await pipeline.submit(req)
     assert result.status == OutreachStatus.FAILED
-    mock_deferred.has_open.assert_awaited_once_with("outreach_delivery", "Defer test")
+    mock_deferred.has_open.assert_awaited_once_with(
+        "outreach_delivery", "Defer test", "surplus", "surplus_insight"
+    )
     mock_deferred.enqueue.assert_not_called()
 
 

--- a/tests/test_resilience/test_deferred_work.py
+++ b/tests/test_resilience/test_deferred_work.py
@@ -104,66 +104,115 @@ class TestMarkStatus:
 
 
 class TestHasOpen:
-    """Dedup-at-defer guard — count_open_by_topic / has_open."""
+    """Dedup-at-defer guard — count_open_by_identity / has_open. Identity is the
+    full (topic, category, signal_type) governance uses, NOT topic alone."""
+
+    @staticmethod
+    def _payload(topic="alert:x", category="alert", signal_type="sig"):
+        import json as _json
+
+        return _json.dumps(
+            {"topic": topic, "category": category, "signal_type": signal_type}
+        )
+
+    async def _enqueue(self, queue, **ident):
+        return await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, self._payload(**ident), "r"
+        )
 
     @pytest.mark.asyncio
     async def test_pending_row_is_open(self, queue):
-        await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
-        )
-        assert await queue.has_open("outreach_delivery", "alert:x")
+        await self._enqueue(queue)
+        assert await queue.has_open("outreach_delivery", "alert:x", "alert", "sig")
 
     @pytest.mark.asyncio
     async def test_processing_row_is_open(self, queue):
         # The recovery worker marks the original 'processing' before re-attempting;
         # a re-defer during that window must still see it as open.
-        item_id = await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
-        )
+        item_id = await self._enqueue(queue)
         await queue.mark_processing(item_id)
-        assert await queue.has_open("outreach_delivery", "alert:x")
+        assert await queue.has_open("outreach_delivery", "alert:x", "alert", "sig")
 
     @pytest.mark.asyncio
     async def test_terminal_rows_are_not_open(self, queue):
-        completed_id = await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:c"}', "r"
-        )
+        completed_id = await self._enqueue(queue, topic="alert:c")
         await queue.mark_completed(completed_id)
-        assert not await queue.has_open("outreach_delivery", "alert:c")
+        assert not await queue.has_open("outreach_delivery", "alert:c", "alert", "sig")
 
-        discarded_id = await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:d"}', "r"
-        )
+        discarded_id = await self._enqueue(queue, topic="alert:d")
         await queue.mark_discarded(discarded_id, "gone")
-        assert not await queue.has_open("outreach_delivery", "alert:d")
+        assert not await queue.has_open("outreach_delivery", "alert:d", "alert", "sig")
 
     @pytest.mark.asyncio
     async def test_distinguishes_topics(self, queue):
-        await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
-        )
-        assert not await queue.has_open("outreach_delivery", "alert:y")
+        await self._enqueue(queue)
+        assert not await queue.has_open("outreach_delivery", "alert:y", "alert", "sig")
 
     @pytest.mark.asyncio
     async def test_distinguishes_work_types(self, queue):
-        await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        await self._enqueue(queue)
+        assert not await queue.has_open("reflection", "alert:x", "alert", "sig")
+
+    @pytest.mark.asyncio
+    async def test_same_topic_different_category_not_open(self, queue):
+        # Codex P1: a topic is reused across message types (executor emits
+        # progress/success/alert/blocker under one 'Task <id>' topic). Keying on
+        # category (and signal_type) keeps a later blocker independently
+        # deliverable instead of being dropped behind an open progress row.
+        await self._enqueue(queue, category="notification")
+        assert not await queue.has_open(
+            "outreach_delivery", "alert:x", "blocker", "sig"
         )
-        assert not await queue.has_open("reflection", "alert:x")
+        # ...but the exact same identity IS a dup.
+        assert await queue.has_open(
+            "outreach_delivery", "alert:x", "notification", "sig"
+        )
+
+    @pytest.mark.asyncio
+    async def test_same_topic_different_signal_type_not_open(self, queue):
+        await self._enqueue(queue, signal_type="progress")
+        assert not await queue.has_open(
+            "outreach_delivery", "alert:x", "alert", "blocker_signal"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_payload_row_does_not_raise(self, queue):
+        # Codex P2: a corrupt payload_json must be skipped, not raise
+        # OperationalError (which _defer's broad handler would swallow, silently
+        # dropping EVERY new delivery until the bad row is cleared).
+        await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, "not valid json{", "r"
+        )
+        await self._enqueue(queue)  # a valid dup alongside the corrupt row
+        assert await queue.has_open("outreach_delivery", "alert:x", "alert", "sig")
+        assert not await queue.has_open("outreach_delivery", "nope", "alert", "sig")
+
+    @pytest.mark.asyncio
+    async def test_null_signal_type_matches_cleanly(self, queue):
+        import json as _json
+
+        await queue.enqueue(
+            "outreach_delivery",
+            None,
+            REFLECTION,
+            _json.dumps({"topic": "alert:x", "category": "alert"}),  # no signal_type
+            "r",
+        )
+        assert await queue.has_open("outreach_delivery", "alert:x", "alert", None)
 
     @pytest.mark.asyncio
     async def test_counts_multiple_open(self, queue):
         from genesis.db.crud import deferred_work as crud
 
-        await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
-        )
-        await queue.enqueue(
-            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
-        )
+        await self._enqueue(queue)
+        await self._enqueue(queue)
         assert (
-            await crud.count_open_by_topic(
-                queue._db, work_type="outreach_delivery", topic="alert:x"
+            await crud.count_open_by_identity(
+                queue._db,
+                work_type="outreach_delivery",
+                topic="alert:x",
+                category="alert",
+                signal_type="sig",
             )
             == 2
         )

--- a/tests/test_resilience/test_deferred_work.py
+++ b/tests/test_resilience/test_deferred_work.py
@@ -103,6 +103,72 @@ class TestMarkStatus:
         assert await queue.count_pending() == 0
 
 
+class TestHasOpen:
+    """Dedup-at-defer guard — count_open_by_topic / has_open."""
+
+    @pytest.mark.asyncio
+    async def test_pending_row_is_open(self, queue):
+        await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        )
+        assert await queue.has_open("outreach_delivery", "alert:x")
+
+    @pytest.mark.asyncio
+    async def test_processing_row_is_open(self, queue):
+        # The recovery worker marks the original 'processing' before re-attempting;
+        # a re-defer during that window must still see it as open.
+        item_id = await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        )
+        await queue.mark_processing(item_id)
+        assert await queue.has_open("outreach_delivery", "alert:x")
+
+    @pytest.mark.asyncio
+    async def test_terminal_rows_are_not_open(self, queue):
+        completed_id = await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:c"}', "r"
+        )
+        await queue.mark_completed(completed_id)
+        assert not await queue.has_open("outreach_delivery", "alert:c")
+
+        discarded_id = await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:d"}', "r"
+        )
+        await queue.mark_discarded(discarded_id, "gone")
+        assert not await queue.has_open("outreach_delivery", "alert:d")
+
+    @pytest.mark.asyncio
+    async def test_distinguishes_topics(self, queue):
+        await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        )
+        assert not await queue.has_open("outreach_delivery", "alert:y")
+
+    @pytest.mark.asyncio
+    async def test_distinguishes_work_types(self, queue):
+        await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        )
+        assert not await queue.has_open("reflection", "alert:x")
+
+    @pytest.mark.asyncio
+    async def test_counts_multiple_open(self, queue):
+        from genesis.db.crud import deferred_work as crud
+
+        await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        )
+        await queue.enqueue(
+            "outreach_delivery", None, REFLECTION, '{"topic": "alert:x"}', "r"
+        )
+        assert (
+            await crud.count_open_by_topic(
+                queue._db, work_type="outreach_delivery", topic="alert:x"
+            )
+            == 2
+        )
+
+
 class TestStalenessExpiry:
     @pytest.mark.asyncio
     async def test_drain_never_expires(self, queue):

--- a/tests/test_resilience/test_outreach_recovery.py
+++ b/tests/test_resilience/test_outreach_recovery.py
@@ -85,6 +85,110 @@ async def test_failed_retry_resets_to_pending(worker):
 
 
 @pytest.mark.asyncio
+async def test_rejected_marks_completed_no_retry(worker):
+    """Governance-dedup REJECTED is terminal — the item is completed, not retried.
+
+    Regression: during the 2026-07 outage a delivered alert's duplicates each
+    came back REJECTED, were misread as failures, reset_to_pending, and burned
+    all 5 retries + filed junk delivery_exhausted observations.
+    """
+    from genesis.outreach.types import OutreachStatus
+
+    result = MagicMock()
+    result.status = OutreachStatus.REJECTED
+    result.error = None
+    worker._pipeline.submit_raw = AsyncMock(return_value=result)
+
+    item = _make_item(attempts=1)
+    await worker._retry(item)
+
+    worker._queue.mark_completed.assert_awaited_once_with("item-1")
+    worker._queue.reset_to_pending.assert_not_awaited()
+    worker._queue.mark_discarded.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_held_marks_completed_no_retry(worker):
+    """HELD (WS-8 email autonomy gate) is terminal — the hold store owns delivery.
+
+    Retrying re-gates and records a new pending hold each cycle; the resolution
+    watcher resumes held sends independently, so the deferred-queue copy must
+    stop retrying.
+    """
+    from genesis.outreach.types import OutreachStatus
+
+    result = MagicMock()
+    result.status = OutreachStatus.HELD
+    result.error = None
+    worker._pipeline.submit_raw = AsyncMock(return_value=result)
+
+    item = _make_item(attempts=1, channel="email")
+    await worker._retry(item)
+
+    worker._queue.mark_completed.assert_awaited_once_with("item-1")
+    worker._queue.reset_to_pending.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rejected_creates_no_observation(worker):
+    """A terminal REJECTED must not file a delivery_exhausted observation."""
+    from unittest.mock import patch
+
+    from genesis.outreach.types import OutreachStatus
+
+    result = MagicMock()
+    result.status = OutreachStatus.REJECTED
+    result.error = None
+    worker._pipeline.submit_raw = AsyncMock(return_value=result)
+
+    item = _make_item(attempts=1)
+    with patch("genesis.db.crud.observations.create", new_callable=AsyncMock) as mock_obs:
+        await worker._retry(item)
+
+    mock_obs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_still_retries(worker):
+    """A genuine send FAILED still resets to pending (unchanged behavior)."""
+    from genesis.outreach.types import OutreachStatus
+
+    result = MagicMock()
+    result.status = OutreachStatus.FAILED
+    result.error = "adapter down"
+    worker._pipeline.submit_raw = AsyncMock(return_value=result)
+
+    item = _make_item(attempts=1)
+    await worker._retry(item)
+
+    worker._queue.reset_to_pending.assert_awaited_once_with("item-1")
+    worker._queue.mark_completed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignored_discarded_no_retry(worker):
+    """IGNORED (self-addressed / unresolved recipient) is a PERMANENT non-delivery
+    — discard it, do not burn retries or file a delivery_exhausted observation."""
+    from unittest.mock import patch
+
+    from genesis.outreach.types import OutreachStatus
+
+    result = MagicMock()
+    result.status = OutreachStatus.IGNORED
+    result.error = "no recipient resolved"
+    worker._pipeline.submit_raw = AsyncMock(return_value=result)
+
+    item = _make_item(attempts=1, channel="email")
+    with patch("genesis.db.crud.observations.create", new_callable=AsyncMock) as mock_obs:
+        await worker._retry(item)
+
+    worker._queue.mark_discarded.assert_awaited_once()
+    assert "ignored" in worker._queue.mark_discarded.call_args[0][1].lower()
+    worker._queue.reset_to_pending.assert_not_awaited()
+    mock_obs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_exhausted_creates_observation(worker):
     """After max retries, item is discarded and observation created."""
     from unittest.mock import patch

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -225,6 +225,32 @@ def test_load_full_yaml(monkeypatch):
     assert ml.model_id == "mistral-large-latest"
 
 
+def test_retry_profiles_under_watchdog_threshold():
+    """Every shipped retry profile must set max_total_s BELOW the watchdog's 900s
+    scheduler-heartbeat zombie threshold.
+
+    A background route_call that outlives 900s lets the surplus heartbeat go
+    stale and the watchdog restarts the whole server (2026-07 outage: background
+    was 1800s = 2x the threshold, so a single stalled dispatch kept re-killing
+    the server ~25x/day). An omitted key parses to None (uncapped) and fails the
+    ``is not None`` check too — an uncapped profile is exactly the footgun. Keep
+    in lockstep with autonomy/watchdog.py _check_scheduler_heartbeats (900s).
+    """
+    watchdog_zombie_threshold_s = 900
+    path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
+    cfg = load_config(path, check_api_keys=False)
+    assert cfg.retry_profiles, "no retry profiles parsed"
+    for name, rp in cfg.retry_profiles.items():
+        assert rp.max_total_s is not None, (
+            f"retry profile {name!r} has no max_total_s — an uncapped background "
+            f"chain-walk can outlive the 900s watchdog zombie threshold"
+        )
+        assert rp.max_total_s < watchdog_zombie_threshold_s, (
+            f"retry profile {name!r} max_total_s={rp.max_total_s} must stay under "
+            f"the {watchdog_zombie_threshold_s}s watchdog zombie threshold"
+        )
+
+
 def test_provider_enabled_default():
     """Providers without explicit enabled field default to enabled."""
     cfg = load_config_from_string(MINIMAL_YAML)

--- a/tests/test_routing/test_degradation_resilience.py
+++ b/tests/test_routing/test_degradation_resilience.py
@@ -60,6 +60,23 @@ def test_update_from_resilience_embedding_down():
     assert tracker.current_level == DegradationLevel.LOCAL_COMPUTE_DOWN
 
 
+def test_reduced_cloud_sheds_l2_call_sites():
+    """The bug fixed by wiring update_from_resilience into the awareness tick
+    (ego goal af5c59b8): cloud REDUCED must actually SHED the _L2_SKIP call sites
+    once the composite state is latched. Before the wiring the tracker's cloud
+    level stayed frozen at NORMAL and nothing was ever shed on provider
+    degradation."""
+    rsm = ResilienceStateMachine()
+    rsm.update_cloud(CloudStatus.REDUCED)
+    tracker = DegradationTracker(resilience_state=rsm)
+    tracker.update_from_resilience()
+    assert tracker.current_level == DegradationLevel.REDUCED
+    assert tracker.should_skip("12_surplus_brainstorm") is True
+    assert tracker.should_skip("13_morning_report") is True
+    # A site outside _L2_SKIP keeps running at REDUCED.
+    assert tracker.should_skip("5_deep_reflection") is False
+
+
 def test_update_from_resilience_no_state():
     """update_from_resilience with no resilience_state is a no-op."""
     tracker = DegradationTracker()


### PR DESCRIPTION
## PR-1 — Internet-outage class fixes

First of a multi-PR effort hardening Genesis against internet outages. A ~22.5h
connectivity loss (2026-07-28/29) exposed a systemic gap: **no first-class
concept of "the internet is down"**, so every subsystem discovered the outage
independently and misattributed it — producing 690 duplicate queued alerts,
146 junk "delivery_exhausted" observations, and 25+ watchdog server-restart-loops
in 12h. This PR fixes six independent, self-contained bugs the outage revealed.
PR-2 (connectivity sentinel + degraded mode + dashboard "Internet" light), PR-3
(cloud-work parking), and PR-4 (outage tagging + backup policy) follow.

### The six fixes

- **A — Terminal statuses in outreach recovery.** The recovery worker treated
  governance-dedup `REJECTED` (an identical message already reached the user),
  WS-8-gate `HELD` (the hold store owns delivery), and `IGNORED` (self-addressed
  / unresolved recipient — permanently undeliverable) as retriable *failures*,
  burning 5 retries each and filing a high-priority junk observation. Now they're
  terminal; `FAILED`/`PENDING` still retry.
- **B — Dead TTL.** Deferred outreach used `staleness_policy="drain"`, which
  `expire_by_policy` never expires — so the intended 4h TTL was dead and
  failed-forever items accumulated. Switched to `"ttl"`.
- **C — Dedup-at-defer.** Repeated delivery failures of the same topic each
  enqueued a fresh row (governance dedup only counts *delivered* rows, so
  undelivered duplicates were invisible). New `count_open_by_topic` +
  `DeferredWorkQueue.has_open`; `_defer` suppresses a second open row for the
  same topic — closing both the recovery-retry and alert-drain amplification
  loops that produced the 690 duplicates.
- **D — Chain-walk cap under the watchdog threshold.** The `background` routing
  profile's aggregate deadline was 1800s — *twice* the watchdog's 900s
  scheduler-heartbeat zombie threshold — so a stalled background dispatch
  outlived it and the watchdog restart-killed the whole server. Lowered to 600s;
  a guard test asserts every retry profile is capped `< 900`. (A single dispatch
  doing multiple serial calls isn't fully bounded by this alone — that case is
  closed by PR-2/PR-3.)
- **E — Activate degradation shedding.** `DegradationTracker.update_from_resilience()`
  had **zero production callers**, so cloud/provider degradation never shed
  background call sites (surplus brainstorm, morning report, judges). Now wired
  into the awareness tick. tmp-pressure shedding is unchanged (verified: the skip
  sets are equivalent). Closes ego goal `af5c59b8`.
- **F — Watchdog flap damping.** A slow recurring same-reason restart (spaced
  beyond the 120s stabilization window) reset `consecutive_failures` to 0 each
  time and restarted forever. Added a rolling per-reason `restart_history`
  (preserved across healthy resets — the hole) and an escalating, capped backoff
  gate: after N same-reason restarts it backs off and emits **one** warning alert
  instead of looping. It's a BACKOFF, never a permanent refusal, and self-heals
  once the window prunes.

### Testing & review

- 161 targeted tests + full `tests/test_routing` + `tests/test_resilience` (450)
  green; `ruff` clean. Runtime-path verified via the real config loaders
  (no server boot — worktree boot is prohibited).
- Two independent Claude review passes (0 blockers, each verified against actual
  call sites). An adversarial Codex pass was attempted first per policy but was
  blocked by its own sandbox (`bwrap`) and produced no findings.
- **Full live-server E2E is a post-merge step** (recovery worker no longer
  storming, awareness tick calling the tracker, watchdog oneshot damping) — it
  requires the merged code running in the real server.

### Deploy path

Runtime code + config: `git pull` + server restart (`update.sh`). No DB schema
changes. Shipped config defaults work with zero overlay. Watchdog changes land
via the normal deploy (its oneshot re-reads code each fire).

Two known items tracked as `tabled` follow-ups: the multi-call-per-dispatch
heartbeat gap (closed by PR-2/PR-3) and a pre-existing deferred-email
recipient-re-resolution question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
