### PR TITLE
fix(hooks): gate git -C / git -c commit forms in the review gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Committing with `git -C` or `git -c` no longer skips the code-review gate.**
+  The safety hook that blocks commits until a review is recorded (and blocks
+  `--no-verify` and direct commits to `main`) recognized only the plain
+  `git commit` form. Commits written as `git -C <dir> commit` or
+  `git -c key=val commit` — a form these sessions use routinely for worktrees —
+  slipped past it entirely and committed with no review check at all. The gate
+  now recognizes those forms, so every commit is held to the same review rule,
+  and the matching post-commit cleanup clears the review for the exact worktree
+  the commit landed in (not the shell's directory), so one review can't silently
+  authorize a later unrelated commit.
 - **Deleting a memory no longer risks leaving an orphaned vector behind.** A
   memory lives across SQLite and a vector store; if the vector store hiccupped
   mid-delete, Genesis used to remove the memory's records but leave its vector

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -35,9 +35,17 @@ from shell_parse import (  # noqa: E402
 # Fail closed on it — treat as main (block Rule 1) and do NOT take the docs skip.
 _CWD_UNKNOWN = object()
 
-# Cheap early-out: a raw command that never mentions "git commit" is not a
-# commit. Actual detection (through wrappers, bash -c, etc.) uses shell_parse.
-_COMMIT_PATTERN = re.compile(r"\bgit\s+commit\b")
+# Cheap early-out: a command with no "commit" TOKEN cannot be a git commit, so
+# skip the shell_parse pass. It must gate on the token alone, NOT on a rigid
+# "git commit" adjacency — `git -C <dir> commit` and `git -c k=v commit` put
+# global options between "git" and "commit", so `\bgit\s+commit\b` MISSED them
+# and let those commit forms skip the ENTIRE gate (review, --no-verify, and the
+# direct-to-main block). Precise detection is still shell_parse's `analyze()` +
+# `git_subcommand` below; this only decides whether to run it. Kept identical in
+# review_invalidate_on_commit.py (the PostToolUse invalidator) — the pair must
+# detect the same set of commits or the marker cleared drifts from the one
+# checked. Guarded by test_commit_pattern_matches_git_dash_c_and_dash_C.
+_COMMIT_PATTERN = re.compile(r"\bcommit\b")
 
 
 def _commit_override(command: str, segs: list) -> str:

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -97,11 +97,29 @@ def _is_docs_or_config(path: str) -> bool:
 
 
 def _seg_dash_C(argv) -> str | None:
-    """The dir named by a ``git -C <dir>`` in a segment's argv, else None."""
+    """The dir named by a GLOBAL ``git -C <dir>`` in a segment's argv, else None.
+
+    Only the ``-C`` that precedes the git SUBCOMMAND is the "run as if started in
+    <dir>" global option. A ``-C`` AFTER the subcommand is that subcommand's own
+    flag with a different meaning — for ``git commit -C <commit>`` it reuses that
+    commit's message/authorship and ``<commit>`` is a commit-ish (e.g. ``HEAD``),
+    NOT a directory. Scanning the whole argv (the old behavior) mistook
+    ``git commit -C HEAD`` for a ``-C HEAD`` worktree redirect and resolved a
+    bogus ``<cwd>/HEAD`` dir. So walk only the global-option prefix and stop at
+    the first non-option token (the subcommand)."""
     argv = argv or []
-    for i, tok in enumerate(argv):
+    i = 1  # argv[0] is the executable ("git")
+    while i < len(argv):
+        tok = argv[i]
         if tok == "-C" and i + 1 < len(argv):
             return argv[i + 1]
+        if tok in _GIT_GLOBAL_VALUE_FLAGS:  # another global value-flag: skip flag+value
+            i += 2
+            continue
+        if tok.startswith("-"):  # a global boolean flag (e.g. --no-pager)
+            i += 1
+            continue
+        break  # reached the subcommand — any later -C belongs to it, not to git
     return None
 
 

--- a/scripts/review_invalidate_on_commit.py
+++ b/scripts/review_invalidate_on_commit.py
@@ -7,6 +7,23 @@ after any successful git commit, so the next commit will require review again.
 Reads the CC PostToolUse payload from stdin (via hook_input) — the git
 command from tool_input, the outcome from tool_response.
 
+Marker resolution (the dir whose per-worktree marker this commit cleared) MUST
+match the dir the PreToolUse checker (``review_enforcement_commit``) validated,
+or a stale marker survives and a later ``git add && git commit`` chain sails
+through the existence-only gate on a review that no longer applies.
+
+The two hooks see DIFFERENT cwd semantics, so they resolve differently (verified
+by a live probe 2026-07-30 — ``process_cwd == payload cwd`` in every sample):
+  - PreToolUse (checker): payload ``cwd`` is PRE-execution, so it walks the
+    command's ``cd``s onto that base (``_effective_diff_cwd``).
+  - PostToolUse (here): payload ``cwd`` is POST-execution — it ALREADY reflects
+    every ``cd`` the command ran — so we take it as-is and only adjust for a
+    ``git -C`` on the commit segment (which redirects git without moving the
+    shell). Re-walking the command's ``cd``s here (i.e. sharing
+    ``_effective_diff_cwd`` verbatim) would DOUBLE-APPLY a relative ``cd`` and
+    resolve a nonexistent dir → the ``"default"`` key → the stale-marker bypass
+    this hook exists to prevent.
+
 Exit codes:
   0 = always (PostToolUse hooks cannot block)
 """
@@ -14,6 +31,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -27,14 +45,66 @@ from hook_input import field, read_payload, tool_response  # noqa: E402
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from review_state import clear_marker  # noqa: E402
 
-_COMMIT_PATTERN = re.compile(r"\bgit\s+commit\b")
+# Commit DETECTION uses shell_parse (the same precise `analyze()` the checker
+# uses) so a loose "commit" token match doesn't clear on a non-commit that merely
+# mentions the word. Commit-DIR resolution additionally needs the checker's cwd
+# primitives, imported (not copied) so the pair can never drift:
+#   _seg_dash_C   — the `git -C <dir>` on an argv (argv parse)
+#   _resolve_against — resolve a dir against a base to an absolute path
+#   _cd_target    — classify a segment as a cd (target / _CWD_UNKNOWN / None)
+#   _CWD_UNKNOWN  — the "cannot resolve confidently" sentinel
+# Both are guarded: a broken import must never crash the hook (a crash clears
+# NOTHING → every marker stays valid for its TTL = the bypass). Detection degrades
+# to a strict regex; resolution degrades to clearing the candidate set.
+try:
+    from shell_parse import analyze, git_subcommand  # noqa: E402
+
+    _PARSE_OK = True
+except Exception:  # pragma: no cover - defensive
+    _PARSE_OK = False
+
+try:
+    from review_enforcement_commit import (  # noqa: E402
+        _CWD_UNKNOWN,
+        _cd_target,
+        _effective_diff_cwd,
+        _resolve_against,
+        _seg_dash_C,
+    )
+    from shell_parse import split_segments  # noqa: E402
+
+    _RESOLVER_OK = _PARSE_OK
+except Exception:  # pragma: no cover - defensive
+    _RESOLVER_OK = False
+    # Bind the one name used on a path reachable when the import fails (_over_clear),
+    # so it is always defined; its call is still gated behind _RESOLVER_OK.
+    _effective_diff_cwd = None
+
+# Strict fallback commit-detector for the (rare) case shell_parse is unavailable —
+# matches the pre-broadening behavior so a bare "commit" mention can't trigger a
+# clear when we cannot parse. `git -C` forms are then missed. Note this is a
+# degraded regime, not a safe one: the CHECKER imports shell_parse UNGUARDED, so
+# the same failure makes it crash (a non-blocking hook error → commits proceed)
+# and go inert — the review gate as a whole is already compromised, so the
+# invalidator's own conservative fallback here neither adds nor removes exposure.
+# (Hardening the checker to fail-closed on that import is a separate follow-up.)
+_STRICT_COMMIT = re.compile(r"\bgit\s+commit\b")
+
+# Cheap early-out on the "commit" token — NOT a rigid "git commit" adjacency,
+# which misses `git -C <dir> commit` / `git -c k=v commit` (see the matching
+# comment in review_enforcement_commit.py). The pair MUST detect the same commit
+# set: if the invalidator early-exits on a form the checker gates, the checked
+# marker is never cleared → a later commit reuses the stale review.
+_COMMIT_PATTERN = re.compile(r"\bcommit\b")
 
 
 def _extract_working_dir(command: str) -> str | None:
-    """Extract the worktree cwd from a leading ``cd <path> && ...`` so the marker
-    cleared matches the per-worktree marker that authorized this commit."""
-    import os
+    """The dir named by a leading ``cd <path> && ...`` (legacy signal).
 
+    Retained as one member of the ambiguity over-clear set: it is the only
+    resolver that recovers the ``cd W && git commit && cd Z`` case (commit runs
+    in W, but the post-execution cwd is Z), where W is this leading ``cd``.
+    """
     m = re.match(r"^cd\s+([^\s&|;]+)", command)
     if not m:
         return None
@@ -42,13 +112,98 @@ def _extract_working_dir(command: str) -> str | None:
     return path if os.path.isdir(path) else None
 
 
+def _payload_cwd(payload: dict) -> str | None:
+    """The Bash tool's POST-execution working directory from the payload."""
+    cwd = payload.get("cwd") if isinstance(payload, dict) else None
+    if isinstance(cwd, str) and cwd:
+        return os.path.normpath(cwd)
+    return None
+
+
+def _effective_clear_cwd(command: str, payload: dict, segs: list):
+    """The dir whose marker this commit cleared — POST-execution aware.
+
+    Returns an absolute ``str`` dir, or ``_CWD_UNKNOWN`` when the post-execution
+    cwd cannot be trusted to be the commit's dir (a ``cd`` AFTER the commit
+    segment, or a commit nested in a subshell/``bash -c``). ``_CWD_UNKNOWN``
+    tells the caller to over-clear the candidate set (fail toward clearing).
+    """
+    commit_seg = next((s for s in segs if git_subcommand(s.argv) == "commit"), None)
+    if commit_seg is None:
+        return _CWD_UNKNOWN
+    if getattr(commit_seg, "depth", 0) > 0:
+        # Nested (subshell / bash -c): the top-level post cwd need not reflect
+        # the nested scope's cd. Over-clear rather than trust it.
+        return _CWD_UNKNOWN
+
+    base = _payload_cwd(payload)
+
+    # A top-level `cd` AFTER the commit segment moves the post cwd DOWNSTREAM of
+    # where the commit actually ran, so `base` is no longer the commit's dir.
+    target_raw = getattr(commit_seg, "raw", None)
+    seen_commit = False
+    for raw in split_segments(command):
+        if not seen_commit:
+            if raw == target_raw:
+                seen_commit = True
+            continue
+        if _cd_target(raw) is not None:  # any cd (resolvable or UNKNOWN) after commit
+            return _CWD_UNKNOWN
+
+    # `git -C <dir>` redirects git WITHOUT moving the shell, so the post cwd
+    # (`base`) is not the commit's dir — resolve the -C target against it.
+    dash_c = _seg_dash_C(getattr(commit_seg, "argv", None))
+    if dash_c is not None:
+        return _resolve_against(base, dash_c)
+    return base
+
+
+def _over_clear(command: str, payload: dict, segs: list | None = None) -> None:
+    """Clear every candidate marker key (each a no-op if that key has no marker).
+
+    Used when resolution is ambiguous or the shared resolver is unavailable.
+    Over-clearing only forces a redundant re-review; under-clearing leaves a
+    stale marker — the bypass — so the safe direction is to clear more.
+
+    Candidates: the post-execution payload cwd, the legacy leading-``cd`` dir,
+    ``None`` (the hook process cwd, which real CC keeps == payload cwd), and —
+    when ``segs`` is available — the checker's OWN walk-based resolution
+    (``_effective_diff_cwd``). The last candidate is what covers a contrived
+    ``cd A && … ; cd W && git commit && cd Z`` form: the trailing ``cd Z`` makes
+    the post cwd (Z) and the leading ``cd`` (A) both miss the real commit dir W,
+    but the checker's walk lands on W — so including it clears the marker the
+    checker actually validated. It can over-resolve a relative-``cd`` command
+    (post-execution base), but that only adds a harmless extra clear, never an
+    under-clear. Clearing an uninvolved worktree's marker at worst forces that
+    session a redundant review; it never authorizes an unreviewed commit.
+    """
+    candidates = {_payload_cwd(payload), _extract_working_dir(command), None}
+    if segs is not None and _RESOLVER_OK:
+        walked = _effective_diff_cwd(command, payload, segs)
+        if isinstance(walked, str):
+            candidates.add(walked)
+    for cwd in candidates:
+        clear_marker(cwd=cwd)
+
+
 def main() -> None:
     payload = read_payload()
 
-    # Check if the tool input contained a git commit command
+    # Cheap early-out: no "commit" token anywhere → definitely not a commit.
     command = field(payload, "command")
     if not _COMMIT_PATTERN.search(command):
         sys.exit(0)
+
+    # Confirm a REAL executed `git commit` segment before clearing anything — the
+    # loose token match also hits "commit" in a filename / message / a non-commit
+    # git subcommand (`commit-tree`), none of which should invalidate a review.
+    # This mirrors the checker's post-early-out `analyze()` confirmation.
+    segs = analyze(command) if _PARSE_OK else None
+    if segs is not None:
+        if not any(git_subcommand(s.argv) == "commit" for s in segs):
+            sys.exit(0)
+    elif not _STRICT_COMMIT.search(command):
+        sys.exit(0)  # no parser: fall back to strict adjacency, never over-clear
 
     # Only invalidate on successful commits (exit code 0)
     try:
@@ -63,9 +218,18 @@ def main() -> None:
     except (json.JSONDecodeError, AttributeError):
         pass  # Can't parse result — be conservative, invalidate anyway
 
-    # Clear the per-worktree review marker (matching the cwd that authorized
-    # this commit) so the next commit requires a fresh review.
-    clear_marker(cwd=_extract_working_dir(command))
+    # Clear the per-worktree review marker (matching the dir that authorized this
+    # commit) so the next commit requires a fresh review. Resolution mirrors the
+    # PreToolUse checker; ambiguity or a missing resolver over-clears.
+    if not _RESOLVER_OK or segs is None:
+        _over_clear(command, payload)
+        sys.exit(0)
+
+    eff = _effective_clear_cwd(command, payload, segs)
+    if eff is _CWD_UNKNOWN:
+        _over_clear(command, payload, segs)  # segs → include the checker's walk dir
+    else:
+        clear_marker(cwd=eff)
 
     sys.exit(0)
 

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -893,6 +893,28 @@ def test_git_dash_C_to_main_blocked(repo: Path, home: Path, tmp_path: Path) -> N
     assert "main" in res.stderr.lower()
 
 
+def test_commit_dash_C_reuse_message_is_not_a_worktree(repo: Path, home: Path) -> None:
+    """`git commit -C HEAD` reuses HEAD's message — the `-C` is the commit's own
+    flag, NOT a `git -C <dir>` redirect. It must resolve the SHELL's worktree
+    (here `repo`), so an unreviewed one still BLOCKS (Rule 2) and a reviewed one
+    passes — not resolve a bogus `<cwd>/HEAD` dir. Regression for the Codex P1."""
+    res = _run_hook("git commit -C HEAD", repo, home, payload_cwd=str(repo))
+    assert res.returncode == 2, res.stderr  # unreviewed → still gated in `repo`
+    assert "without review" in res.stderr
+    assert _mark(repo, home).returncode == 0
+    res_ok = _run_hook("git commit -C HEAD", repo, home, payload_cwd=str(repo))
+    assert res_ok.returncode == 0, res_ok.stderr  # reviewed `repo` → allowed
+
+
+def test_invalidate_commit_dash_C_reuse_clears_shell_worktree(repo: Path, home: Path) -> None:
+    """The invalidator must clear the SHELL's worktree marker for
+    `git commit -C HEAD`, not a bogus `<cwd>/HEAD` (which would leave the real
+    marker stale). Pairs with the checker regression above."""
+    assert _mark(repo, home).returncode == 0
+    _run_invalidate_at("git commit -C HEAD", run_from=repo, payload_cwd=repo, home=home)
+    assert _markers(home) == [], "`git commit -C HEAD` did not clear the real marker"
+
+
 def test_commit_pattern_matches_git_dash_c_and_dash_C() -> None:
     """Drift guard: BOTH hooks' `_COMMIT_PATTERN` must detect `git -C`/`git -c`
     commit forms (and not regress to the rigid `git commit` adjacency), and the

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -376,6 +376,205 @@ def test_invalidate_ignores_non_commit(repo: Path, home: Path) -> None:
     assert len(_markers(home)) == 1  # marker survives
 
 
+# ── Invalidator/checker cwd symmetry (the #1254 follow-up, ab42b04f) ──────
+# #1254 made the PreToolUse checker resolve the commit's real worktree via
+# `git -C` / the last `cd` / the payload cwd. The PostToolUse invalidator was
+# left on the leading-`cd` regex (→ process cwd), so for a `git -C W commit` or
+# a decoy multi-`cd` the CHECKED marker (W) and the CLEARED marker (the shell's
+# worktree) diverged: W's marker survived its TTL and a later unreviewed
+# `git add && git commit` chain sailed through the existence-only gate. These
+# tests pin the invalidator to the same worktree the checker validates.
+#
+# Live-faithful setup: a 2026-07-30 probe confirmed CC spawns the hook with
+# process_cwd == payload `cwd`, and the PostToolUse `cwd` is POST-execution (it
+# already reflects the command's `cd`s). So `run_from` and `payload_cwd` are set
+# EQUAL here (matching reality), and divergence is produced the real way — via
+# `git -C` or a decoy `cd` in the command — not by forcing process≠payload.
+
+
+def _run_invalidate_at(
+    command: str, *, run_from: Path, payload_cwd: Path, home: Path
+) -> subprocess.CompletedProcess:
+    """PostToolUse invalidator with the process cwd and payload `cwd` set apart.
+
+    Real CC keeps them equal; callers pass them equal for live-faithful cases and
+    unequal only for the defensive mechanism test that pins which field is read.
+    """
+    payload = json.dumps(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "[feature/x abc1234] msg", "stderr": ""},
+            "session_id": "test",
+            "cwd": str(payload_cwd),
+        }
+    )
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(_INVALIDATE)],
+        input=payload,
+        cwd=str(run_from),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_git_dash_C_commit_clears_target_worktree_not_shell(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """`git -C W commit` from a shell sitting in a DIFFERENT worktree: the
+    checker validates W's marker via `-C`, so the invalidator MUST clear W's
+    marker. The old invalidator (leading-`cd` regex → None → process cwd) cleared
+    the shell's worktree and left W's marker alive — the stale-review bypass.
+    Live-faithful: process cwd == payload cwd == the shell worktree (repo_b)."""
+    repo_b = _second_repo(tmp_path, "repo_b_gitC")  # the shell's worktree
+    assert _mark(repo, home).returncode == 0  # review recorded for repo (= W)
+    assert len(_markers(home)) == 1
+    _run_invalidate_at(
+        f"git -C {repo} commit -m done", run_from=repo_b, payload_cwd=repo_b, home=home
+    )
+    assert _markers(home) == [], "`git -C W commit` did not clear W's marker"
+
+
+def test_git_dash_C_no_stale_bypass_e2e(repo: Path, home: Path, tmp_path: Path) -> None:
+    """End-to-end (both hooks): a reviewed `git -C W commit` is ALLOWED by the
+    checker (resolves W via `-C`), the invalidator clears W's marker, and a NEW
+    unreviewed `git -C W add && git -C W commit` chain must then BLOCK. Guards the
+    exact bypass the invalidator asymmetry opened."""
+    repo_b = _second_repo(tmp_path, "repo_b_e2e_gitC")  # shell worktree
+    assert _mark(repo, home).returncode == 0
+    # Checker allows the reviewed commit (resolves repo via -C).
+    assert (
+        _run_hook(
+            f"git -C {repo} commit -m reviewed", repo_b, home, payload_cwd=str(repo_b)
+        ).returncode
+        == 0
+    )
+    # Invalidator clears repo's marker (same -C target).
+    _run_invalidate_at(
+        f"git -C {repo} commit -m reviewed", run_from=repo_b, payload_cwd=repo_b, home=home
+    )
+    assert _markers(home) == []
+    # A new UNREVIEWED add+commit chain targeting repo must now BLOCK.
+    res = _run_hook(
+        f"git -C {repo} add -A && git -C {repo} commit -m unreviewed",
+        repo_b,
+        home,
+        payload_cwd=str(repo_b),
+    )
+    assert res.returncode == 2, res.stderr
+
+
+def test_decoy_multi_cd_clears_last_cd_worktree(repo: Path, home: Path, tmp_path: Path) -> None:
+    """A decoy `cd A && … ; cd W && git commit` runs in W (bash applies cds in
+    order; the shell ends in W, so the POST-execution payload cwd is W). The
+    invalidator must clear W's marker — not A's (which the old leading-`cd` regex
+    picked). Live-faithful: payload cwd == the post-execution dir (repo = W)."""
+    repo_b = _second_repo(tmp_path, "repo_b_decoy")  # the decoy A
+    assert _mark(repo, home).returncode == 0  # review for repo (= W)
+    _run_invalidate_at(
+        f"cd {repo_b} && true ; cd {repo} && git commit -m done",
+        run_from=repo,
+        payload_cwd=repo,
+        home=home,
+    )
+    assert _markers(home) == [], "decoy multi-cd cleared the wrong (first-cd) worktree"
+
+
+def test_cd_after_commit_over_clears_real_worktree(repo: Path, home: Path, tmp_path: Path) -> None:
+    """`cd W && git commit && cd Z`: the commit ran in W but the POST-execution
+    payload cwd is Z. The invalidator detects the `cd` AFTER the commit segment,
+    treats the cwd as ambiguous, and over-clears the candidate set — so W's
+    marker (recovered from the leading `cd W`) is still cleared."""
+    repo_z = _second_repo(tmp_path, "repo_z_after")  # Z, where the shell ends
+    assert _mark(repo, home).returncode == 0  # review for repo (= W)
+    _run_invalidate_at(
+        f"cd {repo} && git commit -m done && cd {repo_z}",
+        run_from=repo_z,
+        payload_cwd=repo_z,
+        home=home,
+    )
+    assert _markers(home) == [], "cd-after-commit did not over-clear W's marker"
+
+
+def test_decoy_plus_trailing_cd_over_clears_real_worktree(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """`cd A && … ; cd W && git commit && cd Z`: the trailing `cd Z` makes the
+    post cwd (Z) miss the real commit dir W, AND the leading-`cd` regex picks A
+    (also not W). The over-clear set must still reach W via the checker's own
+    walk-based resolution — else W's marker survives and a later unreviewed
+    add+commit chain there reuses the stale review (a bypass Codex flagged)."""
+    repo_a = _second_repo(tmp_path, "repo_a_decoytrail")  # decoy A (leading cd)
+    repo_z = _second_repo(tmp_path, "repo_z_decoytrail")  # Z (post cwd)
+    assert _mark(repo, home).returncode == 0  # review for repo (= W, the real dir)
+    _run_invalidate_at(
+        f"cd {repo_a} && true ; cd {repo} && git commit -m done && cd {repo_z}",
+        run_from=repo_z,
+        payload_cwd=repo_z,
+        home=home,
+    )
+    assert _markers(home) == [], "decoy+trailing-cd left W's marker uncleared (bypass)"
+
+
+def test_leading_space_cd_plus_trailing_cd_over_clears(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """A LEADING SPACE before `cd W` defeats `_extract_working_dir`'s `^cd` anchor,
+    and the trailing `cd Z` moves the post cwd off W — so only the checker's own
+    walk (which strips segments) still lands on W. Regression for the reviewer's
+    Blocker 3 leading-whitespace variant."""
+    repo_z = _second_repo(tmp_path, "repo_z_lead")
+    assert _mark(repo, home).returncode == 0  # review for repo (= W)
+    _run_invalidate_at(
+        f" cd {repo} && git commit -m done && cd {repo_z}",  # note leading space
+        run_from=repo_z,
+        payload_cwd=repo_z,
+        home=home,
+    )
+    assert _markers(home) == [], "leading-space cd + trailing cd left W uncleared"
+
+
+def test_compound_decoy_no_stale_bypass_e2e(repo: Path, home: Path, tmp_path: Path) -> None:
+    """Full Blocker-3 E2E: a reviewed compound-decoy commit is ALLOWED by the
+    checker against W, the invalidator clears W (via the walk candidate), and a
+    later UNREVIEWED add+commit chain in W must then BLOCK — proving the stale
+    marker no longer survives to authorize it."""
+    repo_a = _second_repo(tmp_path, "repo_a_e2e")
+    repo_z = _second_repo(tmp_path, "repo_z_e2e")
+    assert _mark(repo, home).returncode == 0
+    reviewed = f"cd {repo_a} && true ; cd {repo} && git commit -m ok && cd {repo_z}"
+    # Checker (Pre) resolves W and allows the reviewed commit.
+    assert _run_hook(reviewed, repo_a, home, payload_cwd=str(repo_a)).returncode == 0
+    # Invalidator (Post, shell ended in Z) must still clear W.
+    _run_invalidate_at(reviewed, run_from=repo_z, payload_cwd=repo_z, home=home)
+    assert _markers(home) == []
+    # A new unreviewed add+commit chain in W must BLOCK (no stale marker).
+    res = _run_hook(
+        f"cd {repo} && git add -A && git commit -m sneaky",
+        repo_z,
+        home,
+        payload_cwd=str(repo_z),
+    )
+    assert res.returncode == 2, res.stderr
+
+
+def test_invalidator_reads_payload_cwd_field_not_process_cwd(
+    repo: Path, home: Path, tmp_path: Path
+) -> None:
+    """DEFENSIVE (not live-faithful): with process cwd and payload `cwd` forced
+    apart, a bare `git commit` clears the PAYLOAD-cwd worktree. Pins the resolver
+    to the documented payload field so a future refactor to process cwd (or a CC
+    release that breaks the process==payload equality) is caught."""
+    repo_b = _second_repo(tmp_path, "repo_b_field")  # process cwd (wrong worktree)
+    assert _mark(repo, home).returncode == 0  # review for repo (payload cwd)
+    _run_invalidate_at("git commit -m done", run_from=repo_b, payload_cwd=repo, home=home)
+    assert _markers(home) == [], "invalidator keyed on process cwd, not payload cwd"
+
+
 # ── Docs/config-only skip (Change 4) ─────────────────────────────────────
 # A commit whose ENTIRE staged set is docs/config carries no code to review
 # (adaptive-review "review level: None") → Rule 2 is skipped. Conservative
@@ -619,3 +818,107 @@ def test_relative_cd_commit_to_sibling_main_blocked(repo: Path, home: Path, tmp_
     res = _run_hook("cd ../main && git commit -m x", feature, home, payload_cwd=str(feature))
     assert res.returncode == 2
     assert "main" in res.stderr.lower()
+
+
+# ── `git -C` / `git -c` commit forms reach the gate (d21db5ea, honest-use half) ──
+# The cheap early-out used to key on a rigid `\bgit\s+commit\b`, which does NOT
+# match `git -C <dir> commit` or `git -c k=v commit` (global options sit between
+# "git" and "commit"), so BOTH hooks exited early and those commit forms skipped
+# the ENTIRE gate — review (Rule 2), --no-verify (Rule 0), and direct-to-main
+# (Rule 1). Broadened to the "commit" token; `analyze()` remains the precise
+# filter. These pin every rule for the `git -C`/`git -c` forms.
+
+
+def _main_repo(tmp_path: Path, name: str) -> Path:
+    """A git repo left ON `main` with a staged change (for Rule 1 via `-C`)."""
+    r = tmp_path / name
+    r.mkdir()
+    _git(r, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(r, "config", "user.email", "t@e.st")
+    _git(r, "config", "user.name", "tester")
+    (r / "h.py").write_text("base = 1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    (r / "h.py").write_text("base = 2\n")
+    _git(r, "add", "-A")
+    return r
+
+
+def test_git_dash_C_commit_blocked_without_review(repo: Path, home: Path) -> None:
+    """`git -C W commit` on unreviewed code is BLOCKED (Rule 2) — previously it
+    slipped past the early-out and was allowed unconditionally."""
+    res = _run_hook(f"git -C {repo} commit -m x", repo, home, payload_cwd=str(repo))
+    assert res.returncode == 2, res.stderr
+    assert "without review" in res.stderr
+
+
+def test_git_dash_c_config_commit_blocked_without_review(repo: Path, home: Path) -> None:
+    """`git -c k=v commit` on unreviewed code is BLOCKED (Rule 2)."""
+    res = _run_hook("git -c commit.gpgsign=false commit -m x", repo, home, payload_cwd=str(repo))
+    assert res.returncode == 2, res.stderr
+    assert "without review" in res.stderr
+
+
+def test_git_dash_C_commit_allowed_after_marking(repo: Path, home: Path) -> None:
+    """A reviewed `git -C W commit` passes the gate."""
+    assert _mark(repo, home).returncode == 0
+    res = _run_hook(f"git -C {repo} commit -m ok", repo, home, payload_cwd=str(repo))
+    assert res.returncode == 0, res.stderr
+
+
+def test_git_dash_C_override_allows(repo: Path, home: Path) -> None:
+    """A trailing `# review-override` bypasses Rule 2 on a `git -C` commit."""
+    res = _run_hook(
+        f"git -C {repo} commit -m x  # review-override", repo, home, payload_cwd=str(repo)
+    )
+    assert res.returncode == 0, res.stderr
+
+
+def test_git_dash_C_no_verify_still_blocked(repo: Path, home: Path) -> None:
+    """`git -C W commit --no-verify` is BLOCKED by Rule 0 (which previously the
+    early-out let slip). Reviewed or not, --no-verify is never allowed."""
+    assert _mark(repo, home).returncode == 0  # even reviewed, --no-verify is denied
+    res = _run_hook(f"git -C {repo} commit -m x --no-verify", repo, home, payload_cwd=str(repo))
+    assert res.returncode == 2, res.stderr
+    assert "no-verify" in res.stderr.lower()
+
+
+def test_git_dash_C_to_main_blocked(repo: Path, home: Path, tmp_path: Path) -> None:
+    """`git -C <main-tree> commit` is BLOCKED by Rule 1 even when the shell sits
+    in a feature worktree — the `-C` target's branch decides."""
+    main = _main_repo(tmp_path, "maintree")
+    assert _mark(main, home).returncode == 0  # reviewed, to isolate Rule 1 from Rule 2
+    res = _run_hook(f"git -C {main} commit -m x", repo, home, payload_cwd=str(repo))
+    assert res.returncode == 2, res.stderr
+    assert "main" in res.stderr.lower()
+
+
+def test_commit_pattern_matches_git_dash_c_and_dash_C() -> None:
+    """Drift guard: BOTH hooks' `_COMMIT_PATTERN` must detect `git -C`/`git -c`
+    commit forms (and not regress to the rigid `git commit` adjacency), and the
+    two patterns must stay identical so the pair detects the same commit set."""
+    import importlib.util
+
+    def _pattern(mod_name: str):
+        spec = importlib.util.spec_from_file_location(
+            mod_name, str(_REPO_ROOT / "scripts" / f"{mod_name}.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        # scripts/ and scripts/hooks/ on path for the modules' own imports
+        sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+        sys.path.insert(0, str(_REPO_ROOT / "scripts" / "hooks"))
+        spec.loader.exec_module(mod)
+        return mod._COMMIT_PATTERN
+
+    checker_pat = _pattern("review_enforcement_commit")
+    invalidate_pat = _pattern("review_invalidate_on_commit")
+    forms = [
+        "git commit -m x",
+        "git -C /some/wt commit -m x",
+        "git -c commit.gpgsign=false commit -m x",
+        "cd /wt && git commit -m x",
+    ]
+    for f in forms:
+        assert checker_pat.search(f), f"checker pattern missed: {f}"
+        assert invalidate_pat.search(f), f"invalidator pattern missed: {f}"
+    assert checker_pat.pattern == invalidate_pat.pattern, "hook patterns drifted apart"


### PR DESCRIPTION
## What

Closes a real hole in the commit review-enforcement gate: **`git -C <dir> commit` and `git -c key=val commit` skipped the entire gate.** The cheap early-out in both hooks keyed on `\bgit\s+commit\b`, which doesn't match those forms (global options sit between `git` and `commit`), so both hooks `sys.exit(0)` before any logic. Verified live: an unreviewed `git -C W commit` returned `rc=0` (allowed) — bypassing review (Rule 2), `--no-verify` (Rule 0), and direct-to-main (Rule 1). These `git -C` forms are used routinely for worktree commits, so ordinary commits were silently escaping review. This is the previously-tabled evasion `d21db5ea` (honest-use half).

## How

- **Both hooks** — broaden the early-out `_COMMIT_PATTERN` from `\bgit\s+commit\b` to `\bcommit\b`. It only decides whether to run the precise detector (`shell_parse.analyze()` + `git_subcommand(argv) == "commit"`), which is unchanged — so no non-commit is newly blocked (a command merely mentioning "commit" runs `analyze()`, finds no commit segment, and is allowed).
- **Invalidator** (`review_invalidate_on_commit.py`) — previously relied on the tight regex as its *only* commit detector, so broadening it required adding the same post-early-out `analyze()` confirmation the checker has (else a "commit" mention would clear a marker). Also gives the invalidator a worktree resolver so the marker it clears matches the one the checker validated:
  - PostToolUse payload `cwd` is **post-execution** (already reflects the command's `cd`s — live-probed), so the invalidator takes it as-is and only adjusts for a `git -C` on the commit segment. It deliberately does **not** reuse the checker's pre-execution `_effective_diff_cwd` (that would double-apply a relative `cd` onto an already-post base → wrong key → the same stale-marker bypass).
  - Ambiguity (a `cd` after the commit segment, a nested/subshell commit) or a degraded import → `_over_clear` the candidate set (over-clearing costs a redundant re-review; under-clearing is the bypass). Imports are guarded so a broken import degrades instead of crashing — a crashing invalidator clears nothing and leaves every marker valid for its TTL.

## Not weakened / not a bare-commit fix

A live probe (40+ samples) established `process_cwd == payload_cwd` always, which **falsifies** the original follow-up `ab42b04f` (a bare-commit checker/invalidator asymmetry) — for a bare commit both hooks already resolve the same worktree. This PR is the *real* bug that red-teaming surfaced instead. Independently verified: `git -C`/`git -c` now BLOCK unreviewed across all three rules and ALLOW when reviewed or `# review-override`-ed; subshell / `bash -c` / `--git-dir` forms also block (fail-closed); no under-block regression. The `--git-dir`/`--work-tree` redirection resolution gap remains tabled (adversarial evasion class; fails safe).

## Tests

`tests/test_hooks/test_review_enforcement_commit.py`: checker blocks unreviewed `git -C`/`git -c` (Rule 2), `--no-verify` (Rule 0), `-C` to a main tree (Rule 1); allows reviewed + override; invalidator clears the `-C` target worktree, the decoy last-`cd` worktree, and over-clears on `cd`-after-commit; a drift guard asserts both hooks' patterns match the forms and stay byte-identical. RED-verified against the old code. 60 in-file + 11 input-contract tests pass; ruff clean.

## Deploy

Claude Code hooks — merge then `git pull` on main; reload on the next Bash call. No restart. Behavior change rolls out per-tree (each worktree runs its own hook copy), so concurrent sessions on older branches are unaffected until they pull. After this, a `git -C`/`git -c` commit of unreviewed code will be blocked (do `/review` + mark, use `cd W && git commit`, or a trailing `# review-override`).

Ledger: ac7fd7d074e24c9887f836eeae501bec

🤖 Generated with [Claude Code](https://claude.com/claude-code)
