### PR TITLE
feat(resilience): connectivity sentinel + network axis (PR-2)

### DIFF
--- a/config/resilience.yaml
+++ b/config/resilience.yaml
@@ -26,3 +26,30 @@ notifications:
     - state_changed
     - recovery_complete
     - queue_overflow
+
+# Connectivity sentinel (genesis.resilience.network_sentinel). Read live per
+# round via genesis.resilience.network_config (no restart needed to retune).
+# Env kill switch: GENESIS_NETWORK_SENTINEL_DISABLED=1 stops it starting.
+network:
+  enabled: true
+  # Degraded-mode parking lever (PR-3): off | shadow | live. Default shadow —
+  # observe one real outage before granting parking authority. Invalid → shadow.
+  parking_mode: shadow
+  # Restore push-retry lever (PR-4): off | live. Invalid → off.
+  backup_push_retry: live
+  # Probe anchors — public DNS (Cloudflare + Google). DNS+TCP anchors exercise
+  # resolution + connectivity; IP-literal anchors isolate a DNS-only failure.
+  dns_tcp_anchors:
+    - one.one.one.one
+    - dns.google
+  ip_anchors:
+    - 1.1.1.1
+    - 8.8.8.8
+  probe_port: 443
+  probe_timeout_s: 3
+  fast_cadence_s: 20      # while not solidly green — catch recovery quickly
+  steady_cadence_s: 120   # while green
+  offline_all_fail_rounds: 2   # consecutive all-fail rounds → OFFLINE
+  online_clean_rounds: 3       # consecutive clean rounds → back ONLINE
+  stable_online_s: 300         # hold ONLINE before the recovery hook fires
+  merge_gap_s: 600             # a new outage within this merges into the last

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1004,6 +1004,18 @@ verified: b662f3e3 2026-07-17
   probes before draining); `DeferredWorkQueue` priorities + staleness policies;
   dead-letter replay. The `dream_synthesis_slice` worklist is deliberately
   excluded from the backlog alarm (drift-guard test pins it).
+  `NetworkSentinel` (`network_sentinel.py`) probes the open internet (DNS+TCP to
+  public anchors) on a cadence and publishes a 3-state `network` axis
+  (NORMAL/DEGRADED/OFFLINE) with asymmetric hysteresis — it OWNS its hysteresis
+  and opts out of the state machine's symmetric flap protection. The axis drives
+  watchdog zombie-restart suppression (a restart can't fix an ISP outage), the
+  `is_any_degraded` recovery gate (at OFFLINE only — don't re-dispatch into a
+  dead network), and the dashboard "Internet" light; it is DELIBERATELY excluded
+  from `to_legacy_degradation_level` (call-site shedding is deferred to PR-3
+  under `network.parking_mode`). Lever/kill-switch in `network_config.py`
+  (`GENESIS_NETWORK_SENTINEL_DISABLED`); window store `~/.genesis/network_state.json`
+  (`network_state.py`, stdlib-only, self-bounding). Consumers staleness-check the
+  sentinel's own `last_probe_at` and fail toward their safe default.
 - **observability/**: event bus dispatches inline AND logs every event;
   persist-queue overflow drops events but emits a rate-limited "dropped"
   meta-event (WS-17). Two health layers (async probes vs systemd shell-out);

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -190,6 +190,19 @@ class WatchdogChecker:
                     )
                     return WatchdogAction.SKIP
 
+                # Connectivity forgiveness (PR-2): a zombie scheduler during a
+                # network outage is surplus dispatch stalled on dead-network
+                # provider calls — a restart cannot fix an ISP outage (it just
+                # wipes in-memory circuit-breaker state and re-walks the dead
+                # chain slowly). Skip while the network is degraded/offline.
+                if self._network_suppresses_restart(status):
+                    logger.info(
+                        "Zombie detected (%s) but network degraded/offline "
+                        "(fresh probe) — restart can't fix connectivity, skipping",
+                        ", ".join(zombie),
+                    )
+                    return WatchdogAction.SKIP
+
                 logger.warning(
                     "Zombie scheduler detected: %s — triggering restart",
                     ", ".join(zombie),
@@ -207,6 +220,46 @@ class WatchdogChecker:
         # 3. Stale — attempt restart via shared logic
         state = self._load_state()
         return self._restart_if_allowed(state, reason="stale_status_restart")
+
+    def _network_suppresses_restart(self, status: dict) -> bool:
+        """True ONLY when a FRESH sentinel probe reports degraded/offline.
+
+        Fails safe (returns False → allow restart) on: absent network field,
+        missing/garbled timestamp, or a STALE probe (dead/stalled sentinel).
+        status.json's own top-level freshness is not sufficient — the 60s
+        status-writer loop refreshes the file timestamp independently of the
+        sentinel, so a dead sentinel + live writer would look fresh forever with
+        a frozen network field. We therefore staleness-check the sentinel's OWN
+        last_probe_at, so a genuinely wedged server with a healthy network is
+        never left unrestarted.
+        """
+        try:
+            from datetime import UTC, datetime
+
+            from genesis.resilience import network_config, network_state
+
+            net = status.get("network")
+            if not isinstance(net, dict):
+                return False
+            if net.get("state") not in ("DEGRADED", "OFFLINE"):
+                return False
+            age = network_state.probe_age_s(net, datetime.now(UTC))
+            # None (absent/garbled) OR negative (a future timestamp from clock
+            # skew / bad data) → not a trustworthy fresh probe; fail toward restart.
+            if age is None or age < 0:
+                return False
+            threshold = network_config.structural().staleness_threshold_s
+            if age > threshold:
+                logger.info(
+                    "Network field stale (%.0fs > %ds) — NOT suppressing restart",
+                    age, threshold,
+                )
+                return False
+            return True
+        except Exception:
+            # Any failure in the connectivity check must fail toward restart.
+            logger.debug("Network suppression check failed — allowing restart", exc_info=True)
+            return False
 
     def _restart_if_allowed(self, state: dict, *, reason: str) -> WatchdogAction:
         """Shared restart logic: backoff → validation → restart or skip."""

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -44,6 +44,8 @@
                                ? $store.genesisDashboard.infraLabel(name) + ': ' + probe.total_points + ' total points across ' + (probe.collections?.length || 0) + ' collections'
                              : probe.cc_tier != null
                                ? $store.genesisDashboard.infraLabel(name) + ': CC ' + probe.cc_tier + ' (' + probe.cc_used_mb + '/' + probe.cc_budget_mb + 'MB)' + (probe.sys_tier ? ', /tmp ' + probe.sys_tier + ' (' + probe.sys_used_pct + '%)' : '')
+                             : probe.message
+                               ? $store.genesisDashboard.infraLabel(name) + ': ' + (probe.status || 'unknown') + ' — ' + probe.message
                              : $store.genesisDashboard.infraLabel(name) + ': ' + (probe.status || 'unknown')">
                     <span class="status-dot"
                           :style="`background: ${$store.genesisDashboard.probeStatusColor(probe)}`"></span>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3756,7 +3756,7 @@
           // cc_slots renders in its own dedicated "Claude Code Sessions" section
           // (it's an array, not a probe) and is excluded from the probe grid; the
           // label here is defensive in case infraLabel is ever called for it.
-          const labels = { ambient: "Voice Bridge", cc_slots: "Claude Code Sessions" };
+          const labels = { ambient: "Voice Bridge", cc_slots: "Claude Code Sessions", internet: "Internet" };
           return labels[name] || name;
         },
 

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -622,6 +622,24 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         )
         current_ids.add(alert_id)
 
+    # Internet connectivity. WARNING (not CRITICAL): the container Sentinel can't
+    # fix an ISP outage, so this stays out of the Sentinel-waking CRITICAL tier.
+    # Fires only on a confirmed OFFLINE (down) — DEGRADED/unknown/absent do not
+    # alert (a slow or unmonitored network is not an incident). The infra probe
+    # already staleness-guards, so a stale sentinel reads 'unknown', not 'down'.
+    internet = snap.get("infrastructure", {}).get("internet", {})
+    if isinstance(internet, dict) and internet.get("status") == "down":
+        alert_id = "infra:internet_down"
+        detail = internet.get("message") or "offline"
+        alerts.append(
+            {
+                "id": alert_id,
+                "severity": "WARNING",
+                "message": f"Internet connectivity down ({detail})",
+            }
+        )
+        current_ids.add(alert_id)
+
     if _activity_tracker is not None:
         emb_summary = _activity_tracker.summary("episodic_memory_embedding")
         if (

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -537,7 +537,7 @@ def _validate_tts(changes: dict) -> list[str]:
 def _validate_resilience(changes: dict) -> list[str]:
     """Validate resilience config changes."""
     errors: list[str] = []
-    valid_top_keys = {"flapping", "recovery", "cc", "status", "notifications"}
+    valid_top_keys = {"flapping", "recovery", "cc", "status", "notifications", "network"}
 
     for key in changes:
         if key not in valid_top_keys:
@@ -563,6 +563,28 @@ def _validate_resilience(changes: dict) -> list[str]:
     if isinstance(cc, dict):
         _validate_positive_int(cc, "max_sessions_per_hour", errors)
         _validate_float_range(cc, "throttle_threshold_pct", 0.0, 1.0, errors)
+
+    network = changes.get("network", {})
+    if isinstance(network, dict):
+        from genesis.resilience.network_config import BACKUP_RETRY_MODES, PARKING_MODES
+
+        pm = network.get("parking_mode")
+        if pm is not None and pm not in PARKING_MODES:
+            errors.append(f"network.parking_mode must be one of {PARKING_MODES}")
+        bpr = network.get("backup_push_retry")
+        if bpr is not None and bpr not in BACKUP_RETRY_MODES:
+            errors.append(f"network.backup_push_retry must be one of {BACKUP_RETRY_MODES}")
+        for field in (
+            "probe_port",
+            "probe_timeout_s",
+            "fast_cadence_s",
+            "steady_cadence_s",
+            "offline_all_fail_rounds",
+            "online_clean_rounds",
+            "stable_online_s",
+            "merge_gap_s",
+        ):
+            _validate_positive_int(network, field, errors)
 
     return errors
 

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -200,6 +200,62 @@ def _collect_cpu_usage() -> dict:
         return {"status": "unavailable", "used_pct": None, "count": count, "pressure": pressure}
 
 
+def _internet_since_duration(since_iso: str | None) -> str | None:
+    """Human 'for Nm' / 'for Nh Nm' since the given ISO timestamp, tz-safe."""
+    if not isinstance(since_iso, str):
+        return None
+    from datetime import UTC, datetime
+
+    try:
+        dt = datetime.fromisoformat(since_iso)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    secs = int((datetime.now(UTC) - dt).total_seconds())
+    if secs < 0:
+        return None
+    if secs < 3600:
+        return f"for {secs // 60}m"
+    return f"for {secs // 3600}h {(secs % 3600) // 60}m"
+
+
+def _internet_probe_entry() -> dict | None:
+    """Build the dashboard 'internet' probe from the sentinel window store.
+
+    Returns None when the sentinel is disabled / never ran (store absent) — the
+    key is then omitted entirely (an absent connectivity signal is not a fault,
+    mirroring the ambient absent-edge pattern). A stale probe (dead/stalled
+    sentinel) surfaces as 'unknown' so the light never asserts a false green.
+    """
+    from datetime import UTC, datetime
+
+    from genesis.resilience import network_config, network_state
+
+    net = network_state.read_state()
+    if net is None:
+        return None
+    # Misconfigured sentinel (enabled, zero anchors) — surface explicitly, never
+    # a false green: it publishes a fresh `no_anchors` marker for exactly this.
+    if net.get("cause") == "no_anchors":
+        return {"status": "unknown", "message": "not configured — no probe anchors"}
+    age = network_state.probe_age_s(net, datetime.now(UTC))
+    threshold = network_config.structural().staleness_threshold_s
+    # None (absent/garbled) / negative (future timestamp) / stale → don't assert
+    # a state we can't trust; show 'unknown' rather than a possibly-false green.
+    if age is None or age < 0 or age > threshold:
+        return {"status": "unknown", "message": "connectivity sentinel stale"}
+    state = net.get("state")
+    if state == "NORMAL":
+        return {"status": "healthy"}
+    if state in ("DEGRADED", "OFFLINE"):
+        label = "offline" if state == "OFFLINE" else "degraded"
+        dur = _internet_since_duration(net.get("since"))
+        msg = f"{label} {dur}" if dur else label
+        return {"status": "down" if state == "OFFLINE" else "degraded", "message": msg}
+    return {"status": "unknown", "message": f"state {state}"}
+
+
 async def infrastructure(
     db: aiosqlite.Connection | None,
     routing_config: RoutingConfig | None,
@@ -373,6 +429,15 @@ async def infrastructure(
                 infra["ambient"].update(result.details)
     except Exception as exc:
         infra["ambient"] = {"status": "error", "error": str(exc)}
+
+    # Internet connectivity — from the network sentinel's window store. Key is
+    # omitted when the sentinel is disabled / never ran (empty-state install).
+    try:
+        internet = _internet_probe_entry()
+        if internet is not None:
+            infra["internet"] = internet
+    except Exception as exc:
+        infra["internet"] = {"status": "error", "error": str(exc)}
 
     if ollama_enabled():
         try:

--- a/src/genesis/resilience/network_config.py
+++ b/src/genesis/resilience/network_config.py
@@ -1,0 +1,203 @@
+"""NetworkSentinel control surface — live-read levers + probe tuning.
+
+The ONE place the connectivity sentinel and its downstream consumers consult
+for policy (repo_pulse_config lineage — same fresh-per-call, degrade-toward-
+less-authority discipline). All keys live under the ``network:`` section of
+``config/resilience.yaml`` (+ the ``~/.genesis/config/resilience.local.yaml``
+overlay), so they register under the existing ``resilience`` settings domain —
+no new settings domain.
+
+Levers (re-read live, no boot cache):
+- :func:`sentinel_enabled` — env kill switch ``GENESIS_NETWORK_SENTINEL_DISABLED=1``
+  (stdlib-cheap hard off) OR ``enabled: false``. When off, the sentinel never
+  starts and every consumer degrades to the empty-state (== fresh install).
+- :func:`effective_parking_mode` — ``off | shadow | live`` (default **shadow**;
+  PR-3 consumes it to gate degraded-mode parking). Invalid → ``shadow`` (observe
+  only, less write authority — never silently ``live``).
+- :func:`backup_push_retry_mode` — ``off | live`` (default **live**; PR-4
+  consumes it). Invalid → ``off`` (less action).
+
+Probe tuning (:func:`structural`) is read once at sentinel construction but
+lives here too so an operator can retune anchors/cadences via config.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
+``genesis.mcp.health.settings`` imports the mode tuples FROM here, never the
+reverse (one-way, the immunity rule).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+PARKING_MODES = ("off", "shadow", "live")
+BACKUP_RETRY_MODES = ("off", "live")
+
+_ENV_KILL_SWITCH = "GENESIS_NETWORK_SENTINEL_DISABLED"
+_CONFIG_NAME = "resilience.yaml"
+_SECTION = "network"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "parking_mode": "shadow",  # PR-3 lever — soak one outage before live
+    "backup_push_retry": "live",  # PR-4 lever — immediate push retry on restore
+    # Probe anchors — privacy-bland public DNS (Cloudflare + Google), reachable
+    # from any install, config-overridable. DNS+TCP anchors exercise name
+    # resolution AND connectivity; IP-literal anchors isolate a DNS-only failure
+    # (resolution dead, routing alive) from a full outage.
+    "dns_tcp_anchors": ["one.one.one.one", "dns.google"],
+    "ip_anchors": ["1.1.1.1", "8.8.8.8"],
+    "probe_port": 443,
+    "probe_timeout_s": 3,
+    # Cadence: fast while not-clean (catch recovery quickly), steady when green.
+    "fast_cadence_s": 20,
+    "steady_cadence_s": 120,
+    # Asymmetric hysteresis: fast to declare OFFLINE, slow to clear.
+    "offline_all_fail_rounds": 2,  # consecutive all_fail rounds → OFFLINE
+    "online_clean_rounds": 3,  # consecutive clean rounds → ONLINE
+    "stable_online_s": 300,  # hold ONLINE this long before recovery hook
+    "merge_gap_s": 600,  # new OFFLINE within this of last close merges
+}
+
+_INT_KNOBS = (
+    "probe_port",
+    "probe_timeout_s",
+    "fast_cadence_s",
+    "steady_cadence_s",
+    "offline_all_fail_rounds",
+    "online_clean_rounds",
+    "stable_online_s",
+    "merge_gap_s",
+)
+
+
+@dataclass(frozen=True)
+class NetworkTuning:
+    """Validated, immutable probe/hysteresis tuning for the sentinel."""
+
+    dns_tcp_anchors: tuple[str, ...]
+    ip_anchors: tuple[str, ...]
+    probe_port: int
+    probe_timeout_s: int
+    fast_cadence_s: int
+    steady_cadence_s: int
+    offline_all_fail_rounds: int
+    online_clean_rounds: int
+    stable_online_s: int
+    merge_gap_s: int
+
+    @property
+    def staleness_threshold_s(self) -> int:
+        """A snapshot older than 3× the steady cadence is stale (consumers
+        fail-safe). Derived, not configured, so it always tracks the cadence."""
+        return self.steady_cadence_s * 3
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged ``network:`` section fresh — per call, NO cache.
+
+    Deep-merges DEFAULTS ← ``resilience.yaml`` network section ← overlay.
+    Missing/corrupt files degrade toward DEFAULTS. A flat schema (no nested
+    dicts) so a shallow ``update`` overlay never drops sibling defaults.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    raw: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            raw = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("resilience config unreadable at %s", base_path)
+    try:
+        raw = merge_local_overlay(raw, base_path)
+    except Exception:
+        logger.warning("resilience overlay merge failed", exc_info=True)
+    section = raw.get(_SECTION, {})
+    if isinstance(section, dict):
+        merged.update(section)
+    return merged
+
+
+def sentinel_enabled() -> bool:
+    """Whether the sentinel should run. Env kill switch wins over config."""
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return False
+    return bool(load_config().get("enabled", True))
+
+
+def effective_parking_mode() -> str:
+    """PR-3 degraded-mode parking lever. Invalid → ``shadow`` (observe only)."""
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("parking_mode")
+    if mode is False:  # YAML-1.1 `parking_mode: off` → boolean False; honor it
+        return "off"
+    if mode not in PARKING_MODES:
+        logger.warning("network parking_mode invalid %r — degrading to shadow", mode)
+        return "shadow"
+    return mode
+
+
+def backup_push_retry_mode() -> str:
+    """PR-4 restore-push-retry lever. Invalid → ``off`` (less action)."""
+    cfg = load_config()
+    mode = cfg.get("backup_push_retry")
+    if mode is False:
+        return "off"
+    if mode not in BACKUP_RETRY_MODES:
+        logger.warning("network backup_push_retry invalid %r — degrading to off", mode)
+        return "off"
+    return mode
+
+
+def _knob_int(cfg: dict[str, Any], key: str) -> int:
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def _str_list(cfg: dict[str, Any], key: str) -> tuple[str, ...]:
+    value = cfg.get(key)
+    if not isinstance(value, list) or not all(isinstance(x, str) and x for x in value):
+        value = DEFAULTS[key]
+    # Empty list disables that anchor class — a plausible operator intent (e.g.
+    # DNS-only). The sentinel guards the zero-TOTAL-anchors case in _probe_round,
+    # surfacing it as an explicit 'not configured' state rather than a false green.
+    return tuple(value)
+
+
+def structural(cfg: dict[str, Any] | None = None) -> NetworkTuning:
+    """Coerce config into validated :class:`NetworkTuning`. Damage → defaults."""
+    cfg = cfg if cfg is not None else load_config()
+    return NetworkTuning(
+        dns_tcp_anchors=_str_list(cfg, "dns_tcp_anchors"),
+        ip_anchors=_str_list(cfg, "ip_anchors"),
+        probe_port=_knob_int(cfg, "probe_port"),
+        probe_timeout_s=_knob_int(cfg, "probe_timeout_s"),
+        fast_cadence_s=_knob_int(cfg, "fast_cadence_s"),
+        steady_cadence_s=_knob_int(cfg, "steady_cadence_s"),
+        offline_all_fail_rounds=_knob_int(cfg, "offline_all_fail_rounds"),
+        online_clean_rounds=_knob_int(cfg, "online_clean_rounds"),
+        stable_online_s=_knob_int(cfg, "stable_online_s"),
+        merge_gap_s=_knob_int(cfg, "merge_gap_s"),
+    )

--- a/src/genesis/resilience/network_sentinel.py
+++ b/src/genesis/resilience/network_sentinel.py
@@ -165,6 +165,10 @@ class NetworkSentinel:
         self._closed_windows: list[dict] = []
         self._task: asyncio.Task | None = None
 
+        # Restore persisted outage-window state so a restart doesn't erase history
+        # or reset an in-progress outage's start (Codex P2).
+        self._hydrate()
+
     # ── lifecycle ────────────────────────────────────────────────────────────
 
     def start(self) -> None:
@@ -405,4 +409,59 @@ class NetworkSentinel:
     def _publish(self, tuning: NetworkTuning) -> None:
         data = self.snapshot()
         data["closed_windows"] = [dict(w) for w in self._closed_windows]
+        # Persist the OPEN window too (start + cause), so a restart mid-outage
+        # can restore the original outage start rather than losing it.
+        data["open_window"] = dict(self._open_window) if self._open_window else None
         network_state.write_state(data, self._state_path)
+
+    def _hydrate(self) -> None:
+        """Restore persisted outage-window state on construction.
+
+        The store is a PERSISTENT outage-window store: without this, the first
+        probe after ANY restart would publish empty collections over
+        network_state.json, erasing closed-window history and — mid-outage —
+        losing the original outage start (the motivating 22.5h outage spanned 25
+        restarts). Fully fail-safe: a missing/corrupt/partial file leaves the
+        fresh empty state. The OPEN window and the OFFLINE axis are restored
+        together (coupled — a window is only ever open while OFFLINE) so a
+        restored window can never be orphaned; DEGRADED/NORMAL simply re-detect
+        on the first probe."""
+        data = network_state.read_state(self._state_path)
+        if not isinstance(data, dict):
+            return
+        cw = data.get("closed_windows")
+        if isinstance(cw, list):
+            valid = [
+                dict(w)
+                for w in cw
+                if isinstance(w, dict)
+                and isinstance(w.get("start"), str)
+                and isinstance(w.get("end"), str)
+            ]
+            self._closed_windows = valid[-network_state.MAX_CLOSED_WINDOWS :]
+
+        state_name = data.get("state")
+        ow = data.get("open_window")
+        # Only restore an open outage (and its OFFLINE axis) when the persisted
+        # state agrees it was OFFLINE — keeps window/axis coherent.
+        if (
+            state_name == NetworkStatus.OFFLINE.name
+            and isinstance(ow, dict)
+            and isinstance(ow.get("start"), str)
+        ):
+            self._open_window = dict(ow)
+            self._state = NetworkStatus.OFFLINE
+            since = data.get("since")
+            if isinstance(since, str):
+                try:
+                    parsed = datetime.fromisoformat(since)
+                    self._state_since = parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+                except ValueError:
+                    pass
+            cause = data.get("cause")
+            if isinstance(cause, str):
+                self._last_cause = cause
+            self._recovery_hook_fired = False  # mid-outage → recovery must fire on return
+            # Reflect the restored axis on the shared state machine immediately so
+            # is_any_degraded / status.json are correct before the first probe.
+            self._state_machine.update_network(NetworkStatus.OFFLINE)

--- a/src/genesis/resilience/network_sentinel.py
+++ b/src/genesis/resilience/network_sentinel.py
@@ -1,0 +1,408 @@
+"""NetworkSentinel — deterministic internet-connectivity detection.
+
+The ~22.5h outage of 2026-07-28 exposed that Genesis had no first-class concept
+of "the internet is down": every subsystem discovered the outage independently
+(as provider failures, backup push errors, CC timeouts) and misattributed it.
+This worker is the single ground-truth source. It directly probes the open
+internet on a cadence and publishes a 3-state axis (NORMAL / DEGRADED / OFFLINE)
+that drives watchdog forgiveness (skip zombie restarts a restart can't fix),
+recovery gating (don't re-dispatch into a dead network), the dashboard "Internet"
+light, and (PR-3/PR-4) degraded-mode parking + backup push retry.
+
+Design (see plan ok-lets-plan-everything-sunny-diffie.md, PR-2):
+- **Cause, not symptom.** CloudStatus is circuit-breaker-derived (a symptom of
+  provider call outcomes); this is a direct DNS+TCP probe (the cause).
+- **Restart-proof.** State is re-detected within ~1 probe of boot, so a watchdog
+  restart (which wipes in-memory circuit-breaker state) can't lose the signal.
+- **Asymmetric hysteresis** (owns its own — opts out of the state machine's
+  symmetric flap protection, see ResilienceStateMachine.update_network): fast to
+  declare OFFLINE (a couple all-fail rounds), slow to clear (a consecutive clean
+  streak). A DNS-only failure (resolution dead, routing alive) caps at DEGRADED —
+  forgiveness without parking.
+- **Injectable prober + clock** for hermetic, network-free tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import socket
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.resilience import network_config, network_state
+from genesis.resilience.network_config import NetworkTuning
+from genesis.resilience.state import NetworkStatus
+
+logger = logging.getLogger(__name__)
+
+# Round classifications, worst → best readability (not an ordering).
+CLEAN = "clean"  # every anchor reachable
+PARTIAL = "partial"  # some anchors reachable, mixed failures
+DNS_ONLY = "dns_only"  # routing alive (IP anchors OK), name resolution dead
+ALL_FAIL = "all_fail"  # nothing reachable
+NO_ANCHORS = "no_anchors"  # sentinel enabled but zero probe anchors configured
+
+# Per-anchor probe outcomes.
+_OK = "ok"
+_DNS_FAIL = "dns_fail"
+_TCP_FAIL = "tcp_fail"
+
+# Prober signature: given tuning, return the round classification string.
+Prober = Callable[[NetworkTuning], Awaitable[str]]
+
+
+def classify_round(dns_tcp_results: list[str], ip_results: list[str]) -> str:
+    """Pure round classifier from per-anchor outcomes.
+
+    - ``clean``    — every probed anchor OK.
+    - ``all_fail`` — no anchor OK (routing itself is dead).
+    - ``dns_only`` — every IP-literal anchor OK but every DNS+TCP anchor failed
+      at the *resolution* step: the network routes, DNS does not. Capped at
+      DEGRADED by the hysteresis (never OFFLINE) — a nameserver blip is not an
+      outage worth parking cognition for.
+    - ``partial``  — anything else (a genuine mix of reachable/unreachable).
+    """
+    all_results = dns_tcp_results + ip_results
+    if not all_results:
+        # Defensive only: _probe_round guards the zero-anchor case BEFORE calling
+        # the prober (surfacing it as 'not configured'), so this branch is not
+        # reached in normal flow. Return CLEAN as an inert default for any direct
+        # caller that passes empty lists.
+        return CLEAN
+    ok = sum(1 for r in all_results if r == _OK)
+    if ok == len(all_results):
+        return CLEAN
+    if ok == 0:
+        return ALL_FAIL
+    # Mixed. DNS-only iff routing demonstrably works (≥1 IP anchor, all IP OK)
+    # while every DNS+TCP anchor died specifically at resolution.
+    ip_all_ok = bool(ip_results) and all(r == _OK for r in ip_results)
+    dns_all_resolution_fail = bool(dns_tcp_results) and all(r == _DNS_FAIL for r in dns_tcp_results)
+    if ip_all_ok and dns_all_resolution_fail:
+        return DNS_ONLY
+    return PARTIAL
+
+
+async def _probe_anchor_dns_tcp(host: str, port: int, timeout_s: int) -> str:
+    """DNS-resolve then TCP-connect. Distinguishes a resolution failure from a
+    routing failure so ``classify_round`` can isolate a DNS-only outage."""
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await asyncio.wait_for(
+            loop.getaddrinfo(host, port, type=socket.SOCK_STREAM), timeout=timeout_s
+        )
+    except (TimeoutError, socket.gaierror, OSError):
+        return _DNS_FAIL
+    if not infos:
+        return _DNS_FAIL
+    ip = infos[0][4][0]
+    return await _probe_anchor_ip(ip, port, timeout_s)
+
+
+async def _probe_anchor_ip(ip: str, port: int, timeout_s: int) -> str:
+    """TCP-connect to an IP literal (no DNS)."""
+    try:
+        _, writer = await asyncio.wait_for(asyncio.open_connection(ip, port), timeout=timeout_s)
+    except (TimeoutError, OSError):
+        return _TCP_FAIL
+    writer.close()
+    with contextlib.suppress(Exception):
+        await writer.wait_closed()
+    return _OK
+
+
+async def default_prober(tuning: NetworkTuning) -> str:
+    """Real prober: probe all anchors concurrently, classify the round."""
+    dns_tcp_tasks = [
+        _probe_anchor_dns_tcp(h, tuning.probe_port, tuning.probe_timeout_s)
+        for h in tuning.dns_tcp_anchors
+    ]
+    ip_tasks = [
+        _probe_anchor_ip(ip, tuning.probe_port, tuning.probe_timeout_s) for ip in tuning.ip_anchors
+    ]
+    results = await asyncio.gather(*dns_tcp_tasks, *ip_tasks)
+    n_dns = len(dns_tcp_tasks)
+    return classify_round(list(results[:n_dns]), list(results[n_dns:]))
+
+
+class NetworkSentinel:
+    """Probes connectivity on a cadence; publishes a 3-state network axis."""
+
+    def __init__(
+        self,
+        *,
+        state_machine,
+        prober: Prober | None = None,
+        clock: Callable[[], datetime] | None = None,
+        tuning_provider: Callable[[], NetworkTuning] | None = None,
+        state_path: Path | None = None,
+        on_stable_online: Callable[[], None] | None = None,
+    ) -> None:
+        self._state_machine = state_machine
+        self._prober = prober or default_prober
+        self._clock = clock or (lambda: datetime.now(UTC))
+        # Re-read tuning each round so an operator can retune anchors/cadence
+        # without a restart (repo_pulse live-read discipline).
+        self._tuning_provider = tuning_provider or network_config.structural
+        self._state_path = state_path
+        self._on_stable_online = on_stable_online or self._default_recovery_hook
+
+        now = self._clock()
+        self._state: NetworkStatus = NetworkStatus.NORMAL
+        self._state_since: datetime = now
+        self._last_cause: str = CLEAN
+        self._last_probe_at: datetime | None = None
+        self._consecutive_all_fail = 0
+        self._consecutive_clean = 0
+        # Recovery hook is a ONE-SHOT that re-arms on each OFFLINE entry. Start
+        # fired (True) so a fresh server that boots ONLINE never fires it — only
+        # a genuine outage (OFFLINE) arms the next recovery.
+        self._recovery_hook_fired = True
+        self._open_window: dict | None = None
+        self._closed_windows: list[dict] = []
+        self._task: asyncio.Task | None = None
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start the probe loop (idempotent)."""
+        if self._task is None or self._task.done():
+            from genesis.util.tasks import tracked_task
+
+            self._task = tracked_task(self._loop(), name="network-sentinel")
+            logger.info("Network sentinel started")
+
+    async def stop(self) -> None:
+        """Cancel the probe loop and unwind (idempotent)."""
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+            logger.info("Network sentinel stopped")
+
+    # Safe cadence used when a round itself raises (so a transient failure to
+    # read tuning can never leave the loop with an undefined sleep interval).
+    _FALLBACK_CADENCE_S = 120
+
+    async def _loop(self) -> None:
+        while True:
+            # _probe_round both runs the round AND returns the next cadence, so a
+            # raising tuning_provider is caught HERE (not left to kill the loop on
+            # a separate unguarded cadence read). On failure we fall back to a
+            # safe steady cadence and try again next tick — the loop self-heals.
+            cadence = self._FALLBACK_CADENCE_S
+            try:
+                cadence = await self._probe_round()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("Network sentinel probe round failed", exc_info=True)
+            # Cadence AFTER the round so the first probe fires promptly at start.
+            try:
+                await asyncio.sleep(cadence)
+            except asyncio.CancelledError:
+                raise
+
+    def _cadence_for(self, tuning: NetworkTuning) -> int:
+        # Fast cadence whenever we're not solidly green — catch recovery quickly.
+        if self._state == NetworkStatus.NORMAL and self._last_cause == CLEAN:
+            return tuning.steady_cadence_s
+        return tuning.fast_cadence_s
+
+    # ── one probe round ──────────────────────────────────────────────────────
+
+    async def _probe_round(self) -> int:
+        """Run one probe round; return the cadence (seconds) until the next one."""
+        tuning = self._tuning_provider()
+
+        # Zero-anchor guard: an enabled sentinel with BOTH anchor lists empty
+        # cannot assert connectivity. Do NOT probe (classify_round([], []) would
+        # return CLEAN and pin the axis NORMAL forever). Surface the
+        # misconfiguration via a fresh `no_anchors` marker (dashboard "not
+        # configured" light + WARNING log + the cause field in status.json).
+        # The AXIS is deliberately left untouched (NORMAL). This is NOT a false
+        # green: it is the correct fail-OPEN default — with zero connectivity
+        # data we must not take degraded-mode actions. Routing to DEGRADED/OFFLINE
+        # would make the WATCHDOG suppress zombie restarts (and, at OFFLINE, pause
+        # DLQ replay) on a mere config typo — strictly worse than doing nothing.
+        if not tuning.dns_tcp_anchors and not tuning.ip_anchors:
+            logger.warning(
+                "Network sentinel has zero probe anchors configured — cannot "
+                "assert connectivity (check network.dns_tcp_anchors / "
+                "network.ip_anchors); surfacing as 'not configured'"
+            )
+            self._last_probe_at = self._clock()
+            self._last_cause = NO_ANCHORS
+            # A no-anchors round is neither clean nor all-fail progress — reset
+            # both streaks so a live config gap (anchors emptied then refilled)
+            # cannot carry a stale streak across it and reach NORMAL/OFFLINE early.
+            self._consecutive_clean = 0
+            self._consecutive_all_fail = 0
+            self._publish(tuning)
+            return self._cadence_for(tuning)
+
+        round_class = await self._prober(tuning)
+        now = self._clock()
+        self._last_probe_at = now
+        self._last_cause = round_class
+
+        new_state = self._next_state(round_class, tuning)
+        if new_state != self._state:
+            self._transition(new_state, now, tuning)
+
+        # Publish EVERY round (not just on change): last_probe_at must stay fresh
+        # or consumers (watchdog, dashboard) will read a stable-green network as
+        # "stale" and fail-safe unnecessarily.
+        self._publish(tuning)
+
+        # Fire the one-shot recovery hook once ONLINE has held long enough.
+        self._maybe_fire_recovery(now, tuning)
+        return self._cadence_for(tuning)
+
+    def _next_state(self, round_class: str, tuning: NetworkTuning) -> NetworkStatus:
+        """Pure asymmetric hysteresis. Updates the streak counters as a side
+        effect (they are per-round state, not cross-cutting)."""
+        if round_class == CLEAN:
+            self._consecutive_clean += 1
+            self._consecutive_all_fail = 0
+            if self._state == NetworkStatus.OFFLINE:
+                # Fast recovery OFF offline → DEGRADED; the clean STREAK (counted
+                # from here) still has to reach the threshold to hit NORMAL.
+                return NetworkStatus.DEGRADED
+            if self._state == NetworkStatus.DEGRADED:
+                if self._consecutive_clean >= tuning.online_clean_rounds:
+                    return NetworkStatus.NORMAL
+                return NetworkStatus.DEGRADED
+            return NetworkStatus.NORMAL  # already NORMAL, stay
+
+        # Any non-clean round breaks the clean streak.
+        self._consecutive_clean = 0
+        if round_class == ALL_FAIL:
+            # Counts EVERY consecutive all_fail, including the NORMAL→DEGRADED
+            # entry round: OFFLINE fires after `offline_all_fail_rounds` consecutive
+            # all_fail rounds total (a NORMAL round never jumps straight to OFFLINE
+            # — the NORMAL branch below always routes through DEGRADED first).
+            self._consecutive_all_fail += 1
+        else:
+            # partial / dns_only cannot drive OFFLINE — reset the all-fail streak.
+            self._consecutive_all_fail = 0
+
+        if self._state == NetworkStatus.NORMAL:
+            return NetworkStatus.DEGRADED  # 1 non-clean round → DEGRADED (fast)
+        if self._state == NetworkStatus.DEGRADED:
+            if (
+                round_class == ALL_FAIL
+                and self._consecutive_all_fail >= tuning.offline_all_fail_rounds
+            ):
+                return NetworkStatus.OFFLINE
+            return NetworkStatus.DEGRADED
+        # current OFFLINE: any anchor OK (partial/dns_only — not all_fail) recovers
+        # to DEGRADED; all_fail holds OFFLINE.
+        if round_class == ALL_FAIL:
+            return NetworkStatus.OFFLINE
+        return NetworkStatus.DEGRADED
+
+    def _transition(self, new_state: NetworkStatus, now: datetime, tuning: NetworkTuning) -> None:
+        old = self._state
+        self._state = new_state
+        self._state_since = now
+        # Publish to the composite state machine (drives is_any_degraded +
+        # resilience_state display; NOT the legacy level in PR-2).
+        self._state_machine.update_network(new_state)
+
+        if new_state == NetworkStatus.OFFLINE:
+            # Re-arm recovery FIRST: if opening the window ever raised, this
+            # outage's recovery hook must still be armed (else PR-4's push-retry
+            # would silently never fire on recovery). Window-open takes the SAME
+            # tuning snapshot as this round (no re-read → mid-round config change
+            # can't split a mergeable window).
+            self._recovery_hook_fired = False
+            self._open_or_extend_window(now, tuning)
+        elif old == NetworkStatus.OFFLINE:
+            # Left OFFLINE (→ DEGRADED) — close the outage window.
+            self._close_window(now)
+
+        logger.info("Network sentinel: %s → %s (%s)", old.name, new_state.name, self._last_cause)
+
+    # ── outage windows ───────────────────────────────────────────────────────
+
+    def _open_or_extend_window(self, now: datetime, tuning: NetworkTuning) -> None:
+        if self._open_window is not None:
+            return  # already open (shouldn't happen — OFFLINE→OFFLINE isn't a txn)
+        # Merge with the most-recent closed window if the gap is short — an
+        # intermittent outage is ONE window, not a storm of tiny ones.
+        if self._closed_windows:
+            last = self._closed_windows[-1]
+            with contextlib.suppress(ValueError, KeyError, TypeError):
+                end = datetime.fromisoformat(last["end"])
+                if end.tzinfo is None and now.tzinfo is not None:
+                    end = end.replace(tzinfo=now.tzinfo)
+                if (now - end).total_seconds() <= tuning.merge_gap_s:
+                    self._open_window = self._closed_windows.pop()
+                    self._open_window.pop("end", None)
+                    # Reflect the latest onset cause on the merged span (a
+                    # dns_only blip that escalates to all_fail should read
+                    # all_fail, not the first blip's cause).
+                    self._open_window["cause"] = self._last_cause
+                    return
+        self._open_window = {"start": now.isoformat(), "cause": self._last_cause}
+
+    def _close_window(self, now: datetime) -> None:
+        if self._open_window is None:
+            return
+        self._open_window["end"] = now.isoformat()
+        self._closed_windows.append(self._open_window)
+        self._open_window = None
+        # Bound in memory too (the file is capped independently on write).
+        if len(self._closed_windows) > network_state.MAX_CLOSED_WINDOWS:
+            self._closed_windows = self._closed_windows[-network_state.MAX_CLOSED_WINDOWS :]
+
+    # ── recovery hook ────────────────────────────────────────────────────────
+
+    def _maybe_fire_recovery(self, now: datetime, tuning: NetworkTuning) -> None:
+        if self._recovery_hook_fired or self._state != NetworkStatus.NORMAL:
+            return
+        if (now - self._state_since).total_seconds() < tuning.stable_online_s:
+            return
+        self._recovery_hook_fired = True
+        try:
+            # Sync callback by contract (Callable[[], None]). PR-4 must inject a
+            # SYNC hook (or one that schedules its own task) — an async def here
+            # would create an un-awaited coroutine that silently no-ops.
+            self._on_stable_online()
+        except Exception:
+            logger.warning("Network sentinel recovery hook raised", exc_info=True)
+
+    def _default_recovery_hook(self) -> None:
+        # PR-2 no-op (log only). PR-4 injects the backup-push-retry callback.
+        # NOTE (architect F1c): this can fire inside a still-mergeable window
+        # (merge_gap 600s > stable_online 300s), so PR-4's action MUST be
+        # idempotent / window-independent.
+        logger.info("Network sentinel: connectivity stable-online — recovery hook (no-op)")
+
+    # ── publish / snapshot ───────────────────────────────────────────────────
+
+    def snapshot(self) -> dict:
+        """Immutable snapshot for the status writer's top-level ``network`` key.
+
+        Returns a FRESH dict of primitives (no live reference to internal
+        window state) so a status-write mid-mutation can never serialize a torn
+        view. Carries ``last_probe_at`` so the watchdog can staleness-check the
+        sentinel's own probe freshness rather than trusting status.json's file
+        timestamp (which the 60s status loop refreshes independently)."""
+        return {
+            "state": self._state.name,
+            "since": self._state_since.isoformat(),
+            "cause": self._last_cause,
+            "last_probe_at": (self._last_probe_at.isoformat() if self._last_probe_at else None),
+            "window_open": self._open_window is not None,
+        }
+
+    def _publish(self, tuning: NetworkTuning) -> None:
+        data = self.snapshot()
+        data["closed_windows"] = [dict(w) for w in self._closed_windows]
+        network_state.write_state(data, self._state_path)

--- a/src/genesis/resilience/network_state.py
+++ b/src/genesis/resilience/network_state.py
@@ -1,0 +1,138 @@
+"""Connectivity window store — ``~/.genesis/network_state.json``.
+
+The NetworkSentinel (``genesis.resilience.network_sentinel``) owns the live
+in-memory connectivity state and publishes a snapshot here every probe round.
+This module is the *lightweight, stdlib-only* read/write side of that store so
+consumers that must NOT import the async probe machinery can still read it:
+
+- ``genesis.observability.snapshots.infrastructure`` — the dashboard "Internet"
+  light (runs in-process, but importing the sentinel would drag asyncio +
+  probe deps into the health snapshot path).
+- (PR-4) ``scripts/backup.sh`` — bash reads the JSON directly to decide whether
+  a failed git push is network-caused.
+
+New-store justification (New-Store Gate): consumers span the genesis-server
+process, the standalone health MCP, and bash — a cross-process JSON status file
+is the established pattern here (``status.json``, ``backup_status.json``,
+``cred_integrity_status.json``). A DB table cannot serve the bash consumer and
+the watchdog oneshot without opening the DB. Retention is built in: only the
+last ``MAX_CLOSED_WINDOWS`` closed outage windows are kept, so the file is
+self-bounding (no disk-hygiene wiring needed).
+
+Snapshot schema (all keys always present after the first write)::
+
+    {
+      "state": "NORMAL" | "DEGRADED" | "OFFLINE",
+      "since": "<ISO8601>",          # when the CURRENT state began
+      "cause": "clean|partial|dns_only|all_fail",
+      "last_probe_at": "<ISO8601>",  # freshness anchor — consumers staleness-check this
+      "window_open": bool,           # True while an outage window is open
+      "closed_windows": [            # most-recent-last, capped at MAX_CLOSED_WINDOWS
+        {"start": "<ISO8601>", "end": "<ISO8601>", "cause": "..."}
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Retention: an outage every hour for two days still fits. Bounds the file.
+MAX_CLOSED_WINDOWS = 50
+
+
+def default_path() -> Path:
+    """Install-agnostic store path (adapts to any user via ``Path.home()``)."""
+    return Path.home() / ".genesis" / "network_state.json"
+
+
+def read_state(path: Path | None = None) -> dict | None:
+    """Read the connectivity snapshot, tolerantly.
+
+    Returns ``None`` when the file is absent (sentinel disabled / never ran —
+    an empty-state install) or unreadable/corrupt. Callers treat ``None`` as
+    "no connectivity signal" and behave exactly as they did before the sentinel
+    existed. Never raises.
+    """
+    p = path or default_path()
+    try:
+        raw = p.read_text()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("network_state.json is corrupt at %s — treating as absent", p)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_state(data: dict, path: Path | None = None) -> None:
+    """Atomically write the connectivity snapshot (mkstemp + os.replace).
+
+    Caps ``closed_windows`` to ``MAX_CLOSED_WINDOWS`` (most recent kept) so the
+    file self-bounds. Mirrors ``StatusFileWriter``'s atomic-write shape so a
+    concurrent reader (dashboard, bash) never observes a partial file. Logs and
+    swallows on failure — a failed connectivity write must never crash the
+    sentinel loop (the in-memory axis remains authoritative).
+    """
+    p = path or default_path()
+    windows = data.get("closed_windows")
+    if isinstance(windows, list) and len(windows) > MAX_CLOSED_WINDOWS:
+        data = {**data, "closed_windows": windows[-MAX_CLOSED_WINDOWS:]}
+
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(data, indent=2)
+        fd, tmp_path = tempfile.mkstemp(dir=str(p.parent), suffix=".tmp")
+        fd_closed = False
+        try:
+            os.write(fd, content.encode())
+            os.close(fd)
+            fd_closed = True
+            os.replace(tmp_path, str(p))
+        except Exception:
+            if not fd_closed:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
+    except Exception:
+        logger.error(
+            "network_state write FAILED at %s — connectivity signal will be stale",
+            p,
+            exc_info=True,
+        )
+
+
+def probe_age_s(snapshot: dict | None, now: datetime) -> float | None:
+    """Seconds since the snapshot's ``last_probe_at``, or ``None`` if unknowable.
+
+    The shared freshness primitive for every consumer that must fail-safe on a
+    dead/stalled sentinel (watchdog restart-suppression, dashboard light). A
+    ``None`` return (absent snapshot, missing/garbled timestamp) means "no
+    trustworthy connectivity signal" — callers must treat it as unknown and
+    fail toward their SAFE default (the watchdog: do NOT suppress a restart).
+    """
+    if not isinstance(snapshot, dict):
+        return None
+    ts = snapshot.get("last_probe_at")
+    if not isinstance(ts, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    # Tolerate a naive stored timestamp by matching the caller's tzinfo.
+    if parsed.tzinfo is None and now.tzinfo is not None:
+        parsed = parsed.replace(tzinfo=now.tzinfo)
+    return (now - parsed).total_seconds()

--- a/src/genesis/resilience/state.py
+++ b/src/genesis/resilience/state.py
@@ -1,4 +1,4 @@
-"""Composite resilience state machine — 4 independent axes with flapping protection."""
+"""Composite resilience state machine — 6 independent axes with flapping protection."""
 
 from __future__ import annotations
 
@@ -61,6 +61,19 @@ class TmpPressureStatus(IntEnum):
     NORMAL = 3     # Green:  <50%
 
 
+class NetworkStatus(IntEnum):
+    """Internet connectivity as observed by the NetworkSentinel. Lower = worse.
+
+    Distinct from CloudStatus: cloud is a *symptom* (circuit-breaker-derived
+    from provider call outcomes), network is the *cause* (direct DNS+TCP probe
+    of the open internet). DEGRADED = reachable but impaired (slow/partial —
+    still working); OFFLINE = no connectivity confirmed across probe anchors.
+    """
+    OFFLINE = 0
+    DEGRADED = 1
+    NORMAL = 2
+
+
 # ── Transition record ────────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
@@ -83,6 +96,7 @@ class ResilienceState:
     embedding: EmbeddingStatus = EmbeddingStatus.NORMAL
     cc: CCStatus = CCStatus.NORMAL
     tmp_pressure: TmpPressureStatus = TmpPressureStatus.NORMAL
+    network: NetworkStatus = NetworkStatus.NORMAL
     timestamp: str = ""
     # Bounded append-only observability log (never read by routing). Capped so a
     # long-lived server can't grow it without limit; flap detection uses a
@@ -117,6 +131,12 @@ class ResilienceState:
         elif self.tmp_pressure == TmpPressureStatus.MODERATE and level < DegradationLevel.FALLBACK:
             level = DegradationLevel.FALLBACK
 
+        # Network axis is DELIBERATELY excluded from the legacy level in PR-2.
+        # Feeding OFFLINE→ESSENTIAL here would activate ungated call-site
+        # shedding (via DegradationTracker, wired in PR-1) from a brand-new,
+        # unsoaked connectivity detector. Shedding is deferred to PR-3, gated
+        # by the parking_mode lever with LAN-aware classification. The network
+        # axis still drives watchdog forgiveness + is_any_degraded in PR-2.
         return level
 
 
@@ -149,6 +169,10 @@ class ResilienceStateMachine:
             "embedding": _AxisFlap(),
             "cc": _AxisFlap(),
             "tmp_pressure": _AxisFlap(),
+            # Registered even though update_network opts out of flap protection:
+            # _update() does `self._flap[axis]` unconditionally before the
+            # protection check, so a missing entry would KeyError.
+            "network": _AxisFlap(),
         }
 
     @property
@@ -167,6 +191,12 @@ class ResilienceStateMachine:
             or self._state.memory != MemoryStatus.NORMAL
             or self._state.embedding != EmbeddingStatus.NORMAL
             or self._state.cc != CCStatus.NORMAL
+            # Network counts ONLY at OFFLINE, never DEGRADED: a slow-but-working
+            # network must not pause queue draining (recovery.py re-dispatch),
+            # but a confirmed-dead network should — re-dispatching into it just
+            # burns retries. In the BASE expression (not the tmp_pressure
+            # branch) because the sole consumer passes include_tmp_pressure=False.
+            or self._state.network == NetworkStatus.OFFLINE
         )
         if include_tmp_pressure:
             degraded = degraded or self._state.tmp_pressure != TmpPressureStatus.NORMAL
@@ -194,6 +224,17 @@ class ResilienceStateMachine:
 
     def update_tmp_pressure(self, status: TmpPressureStatus) -> list[StateTransition]:
         return self._update("tmp_pressure", status)
+
+    def update_network(self, status: NetworkStatus) -> list[StateTransition]:
+        # The NetworkSentinel owns its OWN asymmetric hysteresis (fast to
+        # declare OFFLINE, slow to clear). The generic per-axis flap protection
+        # is symmetric and HOLDS THE WORSE STATE for 10min on 3 flips — applied
+        # here it would latch OFFLINE for 10min past a real recovery, fighting
+        # the sentinel's fast OFFLINE→DEGRADED path AND holding is_any_degraded
+        # true (pausing DLQ replay) + suppressing watchdog restarts long after
+        # the network is back. Opt out — the sentinel's hysteresis IS the flap
+        # damping. (Same rationale as update_cc above.)
+        return self._update("network", status, apply_flapping_protection=False)
 
     def _update(
         self,

--- a/src/genesis/resilience/status_writer.py
+++ b/src/genesis/resilience/status_writer.py
@@ -72,6 +72,10 @@ class StatusFileWriter:
                 "memory": state.memory.name,
                 "embedding": state.embedding.name,
                 "cc": state.cc.name,
+                # tmp_pressure was historically omitted here despite being a real
+                # axis feeding to_legacy_degradation_level — added alongside network.
+                "tmp_pressure": state.tmp_pressure.name,
+                "network": state.network.name,
             },
             "queue_depths": {
                 "deferred_work": deferred_count,
@@ -132,6 +136,20 @@ class StatusFileWriter:
             stats = getattr(ingestor, "stats", None)
             if isinstance(stats, dict):
                 data["reflex"] = stats
+        except Exception:
+            pass
+
+        # Connectivity snapshot from the network sentinel. Carries the sentinel's
+        # OWN last_probe_at so the watchdog can staleness-check the PROBE (not the
+        # file): status.json's top-level timestamp refreshes from THIS 60s loop
+        # independently, so a dead sentinel + live status-writer would otherwise
+        # look fresh forever with a frozen network field. isinstance guard is
+        # load-bearing (absent sentinel / mock runtime → skip, never crash write).
+        try:
+            sentinel = getattr(self._runtime, "_network_sentinel", None)
+            snap = sentinel.snapshot() if sentinel is not None else None
+            if isinstance(snap, dict):
+                data["network"] = snap
         except Exception:
             pass
 
@@ -197,8 +215,11 @@ class StatusFileWriter:
             CloudStatus,
             EmbeddingStatus,
             MemoryStatus,
+            NetworkStatus,
         )
 
+        if state.network != NetworkStatus.NORMAL:
+            parts.append(f"Internet {state.network.name.lower()}")
         if state.cloud != CloudStatus.NORMAL:
             parts.append(f"Cloud {state.cloud.name.lower()}")
         if state.memory != MemoryStatus.NORMAL:

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -219,6 +219,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._task_verifier: object | None = None
         self._protected_paths: object | None = None
         self._resilience_state_machine: object | None = None
+        self._network_sentinel: object | None = None
         self._status_writer: object | None = None
         self._recovery_orchestrator: object | None = None
         self._result_writer: object | None = None
@@ -656,6 +657,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             ("campaign_runner", self._campaign_runner),
             ("awareness_loop", self._awareness_loop),
             ("cc_fallback_probe", self._cc_fallback_probe_worker),
+            ("network_sentinel", self._network_sentinel),
             ("reflex_ingestor", self._reflex_ingestor),
         ]:
             if component is None:

--- a/src/genesis/runtime/init/router.py
+++ b/src/genesis/runtime/init/router.py
@@ -52,6 +52,26 @@ def init(rt: GenesisRuntime) -> None:
         rt._resilience_state_machine = ResilienceStateMachine()
         logger.info("Resilience state machine created")
 
+        # Connectivity sentinel — probes the open internet and publishes the
+        # `network` axis (drives watchdog forgiveness, recovery gating, and the
+        # dashboard Internet light). Own try/except so a sentinel failure never
+        # aborts router setup; gated by GENESIS_NETWORK_SENTINEL_DISABLED /
+        # network.enabled (disabled → empty-state, everything behaves as before).
+        from genesis.resilience import network_config
+
+        try:
+            if network_config.sentinel_enabled():
+                from genesis.resilience.network_sentinel import NetworkSentinel
+
+                rt._network_sentinel = NetworkSentinel(
+                    state_machine=rt._resilience_state_machine,
+                )
+                rt._network_sentinel.start()
+            else:
+                logger.info("Network sentinel disabled (kill switch / config) — skipping")
+        except Exception:
+            logger.exception("Failed to start network sentinel (non-fatal)")
+
         degradation = DegradationTracker(resilience_state=rt._resilience_state_machine)
 
         from genesis.routing.dead_letter import DeadLetterQueue

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -202,6 +202,14 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "Ollama is optional and typically runs on a separate machine — "
         "model pulls there are not the container's to make."
     ),
+    "infra:internet_down": (
+        "A confirmed internet outage (network sentinel, WARNING-level) is not "
+        "something the container firefighter can remediate — it's an ISP/link "
+        "failure outside the container's control. The network axis already "
+        "drives the actionable in-container responses (watchdog restart "
+        "suppression, recovery-replay pause); this alert is a dashboard/reflex "
+        "awareness signal for the user, not a Sentinel job."
+    ),
     "backup:tier2_unconfigured": (
         "Backup configuration guidance, not an emergency (WARNING-level; "
         "also covered by the backup: prefix rule above)."

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -726,3 +726,78 @@ class TestRestartBridge:
         with patch.object(wd.subprocess, "run", side_effect=[inactive, active]), \
                 patch.object(wd.time, "sleep"):
             assert wd._wait_until_active("genesis-server.service", timeout_s=30) is True
+
+
+class TestNetworkSuppression:
+    """PR-2: zombie-restart suppression during a network outage (F4/F7).
+
+    Unit-tests the guard directly: it must suppress ONLY on a FRESH degraded/
+    offline probe, and fail toward restart on absent / stale / normal / garbled
+    connectivity — the safety-critical over-suppression path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fixed_tuning(self, monkeypatch):
+        # Pin the staleness threshold (3× steady = 360s) so the fresh/stale
+        # boundary is independent of any local resilience.yaml overlay.
+        from genesis.resilience import network_config
+
+        monkeypatch.setattr(
+            network_config, "structural",
+            lambda cfg=None: network_config.NetworkTuning(
+                dns_tcp_anchors=("a",), ip_anchors=("b",), probe_port=443,
+                probe_timeout_s=3, fast_cadence_s=20, steady_cadence_s=120,
+                offline_all_fail_rounds=2, online_clean_rounds=3,
+                stable_online_s=300, merge_gap_s=600,
+            ),
+        )
+
+    def _checker(self, tmp_path: Path, fresh_status: Path) -> WatchdogChecker:
+        return _make_checker(tmp_path, fresh_status)
+
+    def _net(self, state: str, *, age_s: float) -> dict:
+        ts = (datetime.now(UTC) - timedelta(seconds=age_s)).isoformat()
+        return {"state": state, "last_probe_at": ts}
+
+    def test_fresh_offline_suppresses(self, tmp_path: Path, fresh_status: Path):
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart({"network": self._net("OFFLINE", age_s=10)}) is True
+
+    def test_fresh_degraded_suppresses(self, tmp_path: Path, fresh_status: Path):
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart({"network": self._net("DEGRADED", age_s=10)}) is True
+
+    def test_fresh_normal_does_not_suppress(self, tmp_path: Path, fresh_status: Path):
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart({"network": self._net("NORMAL", age_s=10)}) is False
+
+    def test_absent_network_does_not_suppress(self, tmp_path: Path, fresh_status: Path):
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart({}) is False
+
+    def test_stale_offline_does_not_suppress(self, tmp_path: Path, fresh_status: Path):
+        # F4: a dead sentinel freezes the field OFFLINE while the status-writer
+        # keeps the file fresh — must NOT strand a wedged server unrestarted.
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart(
+            {"network": self._net("OFFLINE", age_s=10_000)}
+        ) is False
+
+    def test_garbled_timestamp_does_not_suppress(self, tmp_path: Path, fresh_status: Path):
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart(
+            {"network": {"state": "OFFLINE", "last_probe_at": "nonsense"}}
+        ) is False
+
+    def test_missing_timestamp_does_not_suppress(self, tmp_path: Path, fresh_status: Path):
+        c = self._checker(tmp_path, fresh_status)
+        assert c._network_suppresses_restart({"network": {"state": "OFFLINE"}}) is False
+
+    def test_future_timestamp_does_not_suppress(self, tmp_path: Path, fresh_status: Path):
+        # Codex F6: a future last_probe_at (clock skew / bad data) yields negative
+        # age — must fail toward restart, not suppress.
+        c = self._checker(tmp_path, fresh_status)
+        future = (datetime.now(UTC) + timedelta(seconds=300)).isoformat()
+        assert c._network_suppresses_restart(
+            {"network": {"state": "OFFLINE", "last_probe_at": future}}
+        ) is False

--- a/tests/test_resilience/test_network_axis.py
+++ b/tests/test_resilience/test_network_axis.py
@@ -1,0 +1,64 @@
+"""ResilienceState network axis — the PR-2 additions to the state machine."""
+
+from __future__ import annotations
+
+from genesis.resilience.state import (
+    NetworkStatus,
+    ResilienceStateMachine,
+    TmpPressureStatus,
+)
+from genesis.routing.types import DegradationLevel
+
+
+def test_network_defaults_normal():
+    sm = ResilienceStateMachine()
+    assert sm.current.network == NetworkStatus.NORMAL
+
+
+def test_update_network_applies():
+    sm = ResilienceStateMachine()
+    txns = sm.update_network(NetworkStatus.OFFLINE)
+    assert len(txns) == 1
+    assert txns[0].axis == "network"
+    assert sm.current.network == NetworkStatus.OFFLINE
+
+
+def test_is_any_degraded_counts_offline_via_base_expression():
+    # F5: the sole consumer passes include_tmp_pressure=False — network-OFFLINE
+    # must count there, so it lives in the BASE expression, not the tmp branch.
+    sm = ResilienceStateMachine()
+    sm.update_network(NetworkStatus.OFFLINE)
+    assert sm.is_any_degraded(include_tmp_pressure=False) is True
+    assert sm.is_any_degraded(include_tmp_pressure=True) is True
+
+
+def test_is_any_degraded_ignores_degraded():
+    # DEGRADED (slow but working) must NOT pause queue draining.
+    sm = ResilienceStateMachine()
+    sm.update_network(NetworkStatus.DEGRADED)
+    assert sm.is_any_degraded(include_tmp_pressure=False) is False
+
+
+def test_network_excluded_from_legacy_level():
+    # PR-2: network must NOT feed the legacy degradation level (shedding is PR-3).
+    sm = ResilienceStateMachine()
+    sm.update_network(NetworkStatus.OFFLINE)
+    assert sm.current.to_legacy_degradation_level() == DegradationLevel.NORMAL
+
+
+def test_legacy_level_still_reflects_other_axes():
+    # sanity: excluding network didn't break the existing mapping
+    sm = ResilienceStateMachine()
+    sm.update_tmp_pressure(TmpPressureStatus.CRITICAL)
+    assert sm.current.to_legacy_degradation_level() == DegradationLevel.ESSENTIAL
+
+
+def test_network_axis_opts_out_of_flap_protection():
+    # Rapid flapping must NOT latch a held state (the sentinel owns hysteresis).
+    sm = ResilienceStateMachine()
+    for _ in range(6):
+        sm.update_network(NetworkStatus.OFFLINE)
+        sm.update_network(NetworkStatus.NORMAL)
+    # ends NORMAL — never stuck holding OFFLINE despite >3 flips in the window
+    assert sm.current.network == NetworkStatus.NORMAL
+    assert sm.is_any_degraded(include_tmp_pressure=False) is False

--- a/tests/test_resilience/test_network_config.py
+++ b/tests/test_resilience/test_network_config.py
@@ -1,0 +1,85 @@
+"""network_config — levers, kill switch, invalid-degrades, structural coercion."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from genesis.resilience import network_config
+
+
+@pytest.fixture()
+def cfg_env(tmp_path, monkeypatch):
+    """Point network_config at a temp resilience.yaml and clear the kill switch."""
+    cfgdir = tmp_path / "config"
+    cfgdir.mkdir()
+    monkeypatch.setattr(network_config, "_base_path", lambda: cfgdir / "resilience.yaml")
+    monkeypatch.delenv(network_config._ENV_KILL_SWITCH, raising=False)
+    # Neutralize any real ~/.genesis overlay so tests are hermetic.
+    monkeypatch.setattr(network_config, "merge_local_overlay", lambda raw, path: raw)
+    return cfgdir / "resilience.yaml"
+
+
+def _write(path, body: str):
+    path.write_text(textwrap.dedent(body))
+
+
+def test_defaults_when_no_file(cfg_env):
+    assert network_config.effective_parking_mode() == "shadow"
+    assert network_config.backup_push_retry_mode() == "live"
+    assert network_config.sentinel_enabled() is True
+
+
+def test_kill_switch_overrides_config(cfg_env, monkeypatch):
+    _write(cfg_env, "network:\n  enabled: true\n")
+    monkeypatch.setenv(network_config._ENV_KILL_SWITCH, "1")
+    assert network_config.sentinel_enabled() is False
+
+
+def test_enabled_false_disables(cfg_env):
+    _write(cfg_env, "network:\n  enabled: false\n")
+    assert network_config.sentinel_enabled() is False
+    assert network_config.effective_parking_mode() == "off"
+
+
+def test_invalid_parking_mode_degrades_to_shadow(cfg_env):
+    _write(cfg_env, "network:\n  parking_mode: bogus\n")
+    assert network_config.effective_parking_mode() == "shadow"
+
+
+def test_invalid_backup_retry_degrades_to_off(cfg_env):
+    _write(cfg_env, "network:\n  backup_push_retry: bogus\n")
+    assert network_config.backup_push_retry_mode() == "off"
+
+
+def test_live_parking_mode_honored(cfg_env):
+    _write(cfg_env, "network:\n  parking_mode: live\n")
+    assert network_config.effective_parking_mode() == "live"
+
+
+def test_yaml_off_boolean_honored(cfg_env):
+    # unquoted `off` parses as YAML-1.1 boolean False
+    _write(cfg_env, "network:\n  parking_mode: off\n")
+    assert network_config.effective_parking_mode() == "off"
+
+
+def test_structural_defaults_and_derived_threshold(cfg_env):
+    t = network_config.structural()
+    assert t.steady_cadence_s == 120
+    assert t.staleness_threshold_s == 360  # 3× steady
+    assert t.dns_tcp_anchors and t.ip_anchors
+
+
+def test_structural_coerces_bad_ints_to_default(cfg_env):
+    _write(cfg_env, "network:\n  steady_cadence_s: -5\n  probe_timeout_s: 0\n")
+    t = network_config.structural()
+    assert t.steady_cadence_s == 120  # bad negative → default
+    assert t.probe_timeout_s == 3  # zero → default
+
+
+def test_structural_overlay_updates(cfg_env):
+    _write(cfg_env, "network:\n  steady_cadence_s: 60\n")
+    t = network_config.structural()
+    assert t.steady_cadence_s == 60
+    assert t.staleness_threshold_s == 180

--- a/tests/test_resilience/test_network_infra.py
+++ b/tests/test_resilience/test_network_infra.py
@@ -1,0 +1,155 @@
+"""Dashboard internet probe (_internet_probe_entry) + infra:internet_down alert."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.resilience import network_config, network_state
+
+# NOTE: the `snapshots` package __init__ re-exports the `infrastructure`
+# FUNCTION, shadowing the submodule attribute — so `import ...infrastructure as
+# x` would bind the function. import_module returns the real module from
+# sys.modules, giving access to the module-level probe helpers.
+infra_mod = importlib.import_module("genesis.observability.snapshots.infrastructure")
+
+
+def _fresh(state: str, *, since_s: float = 120.0) -> dict:
+    now = datetime.now(UTC)
+    return {
+        "state": state,
+        "since": (now - timedelta(seconds=since_s)).isoformat(),
+        "cause": "all_fail",
+        "last_probe_at": (now - timedelta(seconds=5)).isoformat(),
+        "window_open": state == "OFFLINE",
+    }
+
+
+@pytest.fixture()
+def patched_store(monkeypatch):
+    """Drive _internet_probe_entry from an in-memory snapshot, hermetically."""
+    holder = {"snap": None}
+    monkeypatch.setattr(network_state, "read_state", lambda path=None: holder["snap"])
+    monkeypatch.setattr(
+        network_config,
+        "structural",
+        lambda cfg=None: network_config.NetworkTuning(
+            dns_tcp_anchors=("a",),
+            ip_anchors=("b",),
+            probe_port=443,
+            probe_timeout_s=3,
+            fast_cadence_s=20,
+            steady_cadence_s=120,
+            offline_all_fail_rounds=2,
+            online_clean_rounds=3,
+            stable_online_s=300,
+            merge_gap_s=600,
+        ),
+    )
+    return holder
+
+
+def test_absent_store_omits_key(patched_store):
+    patched_store["snap"] = None
+    assert infra_mod._internet_probe_entry() is None
+
+
+def test_normal_is_healthy(patched_store):
+    patched_store["snap"] = _fresh("NORMAL")
+    assert infra_mod._internet_probe_entry()["status"] == "healthy"
+
+
+def test_offline_is_down_with_message(patched_store):
+    patched_store["snap"] = _fresh("OFFLINE", since_s=1500)
+    entry = infra_mod._internet_probe_entry()
+    assert entry["status"] == "down"
+    assert "offline" in entry["message"]
+    assert "for" in entry["message"]  # duration rendered
+
+
+def test_degraded_is_degraded(patched_store):
+    patched_store["snap"] = _fresh("DEGRADED")
+    assert infra_mod._internet_probe_entry()["status"] == "degraded"
+
+
+def test_no_anchors_renders_not_configured(patched_store):
+    # Misconfigured sentinel (zero anchors) surfaces explicitly, never a green.
+    snap = _fresh("NORMAL")
+    snap["cause"] = "no_anchors"
+    patched_store["snap"] = snap
+    entry = infra_mod._internet_probe_entry()
+    assert entry["status"] == "unknown"
+    assert "not configured" in entry["message"]
+
+
+def test_stale_probe_is_unknown(patched_store):
+    snap = _fresh("OFFLINE")
+    snap["last_probe_at"] = (datetime.now(UTC) - timedelta(seconds=10_000)).isoformat()
+    patched_store["snap"] = snap
+    entry = infra_mod._internet_probe_entry()
+    assert entry["status"] == "unknown"  # never asserts a false down/green when stale
+
+
+def test_since_duration_formatting():
+    now = datetime.now(UTC)
+    assert infra_mod._internet_since_duration(None) is None
+    assert infra_mod._internet_since_duration("garbage") is None
+    m = infra_mod._internet_since_duration((now - timedelta(minutes=5)).isoformat())
+    assert m == "for 5m"
+    h = infra_mod._internet_since_duration((now - timedelta(hours=1, minutes=20)).isoformat())
+    assert h == "for 1h 20m"
+
+
+@pytest.mark.asyncio
+async def test_internet_down_alert_fires_only_on_down():
+    """infra:internet_down is WARNING and fires only for status 'down'."""
+    import genesis.mcp.health_mcp as health_mcp_mod
+    from genesis.mcp.health_mcp import _impl_health_alerts
+
+    mock_svc = AsyncMock()
+    mock_svc.snapshot.return_value = {
+        "call_sites": {},
+        "cc_sessions": {"background": {}},
+        "infrastructure": {"internet": {"status": "down", "message": "offline for 20m"}},
+        "queues": {},
+        "awareness": {},
+    }
+    old, old_hist = health_mcp_mod._service, health_mcp_mod._alert_history.copy()
+    try:
+        health_mcp_mod._service = mock_svc
+        health_mcp_mod._alert_history = {}
+        alerts = await _impl_health_alerts()
+        hits = [a for a in alerts if a["id"] == "infra:internet_down"]
+        assert len(hits) == 1
+        assert hits[0]["severity"] == "WARNING"
+        assert "offline for 20m" in hits[0]["message"]
+    finally:
+        health_mcp_mod._service = old
+        health_mcp_mod._alert_history = old_hist
+
+
+@pytest.mark.asyncio
+async def test_internet_degraded_does_not_alert():
+    import genesis.mcp.health_mcp as health_mcp_mod
+    from genesis.mcp.health_mcp import _impl_health_alerts
+
+    mock_svc = AsyncMock()
+    mock_svc.snapshot.return_value = {
+        "call_sites": {},
+        "cc_sessions": {"background": {}},
+        "infrastructure": {"internet": {"status": "degraded", "message": "degraded for 2m"}},
+        "queues": {},
+        "awareness": {},
+    }
+    old, old_hist = health_mcp_mod._service, health_mcp_mod._alert_history.copy()
+    try:
+        health_mcp_mod._service = mock_svc
+        health_mcp_mod._alert_history = {}
+        alerts = await _impl_health_alerts()
+        assert not [a for a in alerts if a["id"] == "infra:internet_down"]
+    finally:
+        health_mcp_mod._service = old
+        health_mcp_mod._alert_history = old_hist

--- a/tests/test_resilience/test_network_sentinel.py
+++ b/tests/test_resilience/test_network_sentinel.py
@@ -437,3 +437,109 @@ async def test_no_anchors_round_resets_clean_streak(tmp_path):
     assert sen._state == NetworkStatus.DEGRADED  # would be NORMAL without the reset
     await sen._probe_round()  # r5 clean → streak 2 → NORMAL
     assert sen._state == NetworkStatus.NORMAL
+
+
+# ── restart persistence / hydration (cloud Codex P2) ─────────────────────────
+
+
+def _write_state_file(path, **fields):
+    import json
+
+    path.write_text(json.dumps(fields))
+
+
+def _new_sentinel(tmp_path, *, clock=None):
+    clock = clock or FakeClock(datetime(2026, 7, 30, 13, 0, 0, tzinfo=UTC))
+    sm = ResilienceStateMachine(clock=clock)
+
+    async def prober(_t):  # unused for pure-hydration assertions
+        return CLEAN
+
+    sen = NetworkSentinel(
+        state_machine=sm,
+        prober=prober,
+        clock=clock,
+        tuning_provider=lambda: make_tuning(),
+        state_path=tmp_path / "network_state.json",
+    )
+    return sen, sm, clock
+
+
+def test_hydrate_restores_closed_windows(tmp_path):
+    _write_state_file(
+        tmp_path / "network_state.json",
+        state="NORMAL",
+        closed_windows=[
+            {
+                "start": "2026-07-30T12:00:00+00:00",
+                "end": "2026-07-30T12:05:00+00:00",
+                "cause": "all_fail",
+            },
+        ],
+    )
+    sen, sm, _ = _new_sentinel(tmp_path)
+    assert len(sen._closed_windows) == 1
+    assert sen._state == NetworkStatus.NORMAL  # post-outage → axis re-detects
+    assert sen._open_window is None
+
+
+def test_hydrate_restores_open_outage_and_axis(tmp_path):
+    _write_state_file(
+        tmp_path / "network_state.json",
+        state="OFFLINE",
+        since="2026-07-30T12:00:00+00:00",
+        cause="all_fail",
+        window_open=True,
+        open_window={"start": "2026-07-30T12:00:00+00:00", "cause": "all_fail"},
+        closed_windows=[],
+    )
+    sen, sm, _ = _new_sentinel(tmp_path)
+    assert sen._state == NetworkStatus.OFFLINE
+    assert sm.current.network == NetworkStatus.OFFLINE  # axis reflected immediately
+    assert sen._open_window is not None
+    assert sen._open_window["start"] == "2026-07-30T12:00:00+00:00"  # original start preserved
+    assert sen._recovery_hook_fired is False  # armed to fire on recovery
+
+
+def test_hydrate_ignores_corrupt_file(tmp_path):
+    (tmp_path / "network_state.json").write_text("{not json")
+    sen, sm, _ = _new_sentinel(tmp_path)
+    assert sen._closed_windows == []
+    assert sen._open_window is None
+    assert sen._state == NetworkStatus.NORMAL
+
+
+@pytest.mark.asyncio
+async def test_hydrated_outage_continues_then_closes_with_original_start(tmp_path):
+    # Restore an open outage; still-down keeps it open (same start); recovery
+    # closes it with the ORIGINAL start (span not reset by the restart).
+    clock = FakeClock(datetime(2026, 7, 30, 13, 0, 0, tzinfo=UTC))
+    _write_state_file(
+        tmp_path / "network_state.json",
+        state="OFFLINE",
+        since="2026-07-30T12:00:00+00:00",
+        cause="all_fail",
+        window_open=True,
+        open_window={"start": "2026-07-30T12:00:00+00:00", "cause": "all_fail"},
+        closed_windows=[],
+    )
+    sm = ResilienceStateMachine(clock=clock)
+    probes = iter([ALL_FAIL, CLEAN])
+
+    async def prober(_t):
+        return next(probes)
+
+    sen = NetworkSentinel(
+        state_machine=sm,
+        prober=prober,
+        clock=clock,
+        tuning_provider=lambda: make_tuning(),
+        state_path=tmp_path / "network_state.json",
+    )
+    await sen._probe_round()  # still all_fail → stays OFFLINE, window preserved
+    assert sen._state == NetworkStatus.OFFLINE
+    assert sen._open_window["start"] == "2026-07-30T12:00:00+00:00"
+    await sen._probe_round()  # clean → OFFLINE→DEGRADED, closes the window
+    assert sen._state == NetworkStatus.DEGRADED
+    assert len(sen._closed_windows) == 1
+    assert sen._closed_windows[0]["start"] == "2026-07-30T12:00:00+00:00"  # span preserved

--- a/tests/test_resilience/test_network_sentinel.py
+++ b/tests/test_resilience/test_network_sentinel.py
@@ -1,0 +1,439 @@
+"""NetworkSentinel — hysteresis, recovery hook, windows, publishing.
+
+All tests are network-free and clock-free: a scripted prober feeds round
+classes and a fake clock advances manually, so the asymmetric hysteresis is
+exercised deterministically (no real sockets, no wall-clock dependence).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from genesis.resilience.network_config import NetworkTuning
+from genesis.resilience.network_sentinel import (
+    ALL_FAIL,
+    CLEAN,
+    DNS_ONLY,
+    PARTIAL,
+    NetworkSentinel,
+    classify_round,
+)
+from genesis.resilience.state import NetworkStatus, ResilienceStateMachine
+
+
+class FakeClock:
+    def __init__(self, start: datetime) -> None:
+        self.t = start
+
+    def __call__(self) -> datetime:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += timedelta(seconds=seconds)
+
+
+def make_tuning(**overrides) -> NetworkTuning:
+    base = dict(
+        dns_tcp_anchors=("one.one.one.one",),
+        ip_anchors=("1.1.1.1",),
+        probe_port=443,
+        probe_timeout_s=3,
+        fast_cadence_s=20,
+        steady_cadence_s=120,
+        offline_all_fail_rounds=2,
+        online_clean_rounds=3,
+        stable_online_s=300,
+        merge_gap_s=600,
+    )
+    base.update(overrides)
+    return NetworkTuning(**base)
+
+
+def make_sentinel(tmp_path, rounds, *, clock=None, on_stable_online=None, tuning=None):
+    """Build a sentinel driven by a scripted list of round classes."""
+    clock = clock or FakeClock(datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC))
+    tuning = tuning or make_tuning()
+    it = iter(rounds)
+
+    async def prober(_tuning):
+        return next(it)
+
+    sm = ResilienceStateMachine(clock=clock)
+    sentinel = NetworkSentinel(
+        state_machine=sm,
+        prober=prober,
+        clock=clock,
+        tuning_provider=lambda: tuning,
+        state_path=tmp_path / "network_state.json",
+        on_stable_online=on_stable_online,
+    )
+    return sentinel, sm, clock
+
+
+async def _drive(sentinel, clock, n, *, step_s=20):
+    for _ in range(n):
+        await sentinel._probe_round()
+        clock.advance(step_s)
+
+
+# ── pure classifier ──────────────────────────────────────────────────────────
+
+
+def test_classify_clean():
+    assert classify_round([_ok := "ok"], [_ok]) == CLEAN
+
+
+def test_classify_all_fail():
+    assert classify_round(["dns_fail"], ["tcp_fail"]) == ALL_FAIL
+
+
+def test_classify_dns_only_requires_ip_ok_and_dns_resolution_fail():
+    # routing alive (IP ok), resolution dead (dns_fail) → dns_only
+    assert classify_round(["dns_fail"], ["ok"]) == DNS_ONLY
+
+
+def test_classify_partial_when_dns_tcp_fail_is_not_resolution():
+    # DNS resolved but TCP failed while IP ok → not a pure DNS outage → partial
+    assert classify_round(["tcp_fail"], ["ok"]) == PARTIAL
+
+
+def test_classify_partial_mixed():
+    assert classify_round(["ok"], ["tcp_fail"]) == PARTIAL
+
+
+def test_classify_no_anchors_is_clean():
+    # empty anchor sets cannot assert an outage
+    assert classify_round([], []) == CLEAN
+
+
+# ── core hysteresis ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_normal_to_degraded_on_first_nonclean(tmp_path):
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL])
+    await sentinel._probe_round()
+    assert sentinel._state == NetworkStatus.DEGRADED
+    assert sm.current.network == NetworkStatus.DEGRADED  # propagated to state machine
+
+
+@pytest.mark.asyncio
+async def test_degraded_to_offline_needs_two_consecutive_all_fail(tmp_path):
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL, ALL_FAIL, ALL_FAIL])
+    await sentinel._probe_round()  # NORMAL → DEGRADED
+    await sentinel._probe_round()  # all_fail #1 → still DEGRADED
+    assert sentinel._state == NetworkStatus.DEGRADED
+    await sentinel._probe_round()  # all_fail #2 → OFFLINE
+    assert sentinel._state == NetworkStatus.OFFLINE
+    assert sm.current.network == NetworkStatus.OFFLINE
+
+
+@pytest.mark.asyncio
+async def test_dns_only_never_reaches_offline(tmp_path):
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL, DNS_ONLY, DNS_ONLY, DNS_ONLY, DNS_ONLY])
+    await _drive(sentinel, clock, 5)
+    assert sentinel._state == NetworkStatus.DEGRADED  # capped, never OFFLINE
+
+
+@pytest.mark.asyncio
+async def test_all_fail_streak_reset_by_dns_only(tmp_path):
+    # all_fail, dns_only (resets streak), all_fail → still only 1 consecutive → DEGRADED
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL, ALL_FAIL, DNS_ONLY, ALL_FAIL])
+    await _drive(sentinel, clock, 4)
+    assert sentinel._state == NetworkStatus.DEGRADED
+
+
+@pytest.mark.asyncio
+async def test_slow_clear_requires_consecutive_clean(tmp_path):
+    # F1b: a non-clean round in the middle of the clean streak resets it.
+    # DEGRADED: clean(1), partial(reset), clean(1), clean(2), clean(3)→NORMAL
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL, CLEAN, PARTIAL, CLEAN, CLEAN, CLEAN])
+    await sentinel._probe_round()  # → DEGRADED
+    await sentinel._probe_round()  # clean #1
+    assert sentinel._state == NetworkStatus.DEGRADED
+    await sentinel._probe_round()  # partial → streak reset, still DEGRADED
+    assert sentinel._state == NetworkStatus.DEGRADED
+    await sentinel._probe_round()  # clean #1
+    await sentinel._probe_round()  # clean #2
+    assert sentinel._state == NetworkStatus.DEGRADED
+    await sentinel._probe_round()  # clean #3 → NORMAL
+    assert sentinel._state == NetworkStatus.NORMAL
+
+
+@pytest.mark.asyncio
+async def test_offline_recovers_to_degraded_on_any_ok(tmp_path):
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL, ALL_FAIL, ALL_FAIL, PARTIAL])
+    await _drive(sentinel, clock, 3)  # → OFFLINE
+    assert sentinel._state == NetworkStatus.OFFLINE
+    await sentinel._probe_round()  # partial (any ok) → DEGRADED
+    assert sentinel._state == NetworkStatus.DEGRADED
+
+
+# ── recovery hook (F1a) ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recovery_hook_fires_once_after_stable_hold(tmp_path):
+    hook = Mock()
+    clock = FakeClock(datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC))
+    # drive to NORMAL, then hold clean while advancing past stable_online_s
+    rounds = [PARTIAL, ALL_FAIL, ALL_FAIL]  # → OFFLINE (arms recovery)
+    rounds += [CLEAN, CLEAN, CLEAN]  # OFFLINE→DEGRADED→…→NORMAL
+    rounds += [CLEAN, CLEAN, CLEAN]  # hold NORMAL
+    sentinel, sm, _ = make_sentinel(tmp_path, rounds, clock=clock, on_stable_online=hook)
+
+    for _ in range(6):  # reach NORMAL (3 cleans from OFFLINE)
+        await sentinel._probe_round()
+        clock.advance(20)
+    assert sentinel._state == NetworkStatus.NORMAL
+    assert hook.call_count == 0  # not yet held long enough
+
+    clock.advance(400)  # now well past stable_online_s=300 since NORMAL entry
+    await sentinel._probe_round()
+    assert hook.call_count == 1
+    await sentinel._probe_round()  # still NORMAL — must NOT re-fire
+    assert hook.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_recovery_hook_rearms_two_full_cycles(tmp_path):
+    hook = Mock()
+    clock = FakeClock(datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC))
+    # Each cycle: outage → recover to NORMAL (3 clean) → 1 hold-clean to fire hook.
+    rounds = [PARTIAL, ALL_FAIL, ALL_FAIL, CLEAN, CLEAN, CLEAN, CLEAN] + [
+        PARTIAL,
+        ALL_FAIL,
+        ALL_FAIL,
+        CLEAN,
+        CLEAN,
+        CLEAN,
+        CLEAN,
+    ]
+    sentinel, sm, _ = make_sentinel(tmp_path, rounds, clock=clock, on_stable_online=hook)
+
+    async def run_cycle():
+        for _ in range(6):  # → NORMAL
+            await sentinel._probe_round()
+            clock.advance(20)
+        assert sentinel._state == NetworkStatus.NORMAL
+        clock.advance(400)  # exceed stable_online_s
+        await sentinel._probe_round()  # the 7th (hold) round fires the hook
+
+    await run_cycle()
+    assert hook.call_count == 1
+    await run_cycle()
+    assert hook.call_count == 2  # re-armed by the 2nd OFFLINE
+
+
+# ── outage windows ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_windows_merge_within_gap(tmp_path):
+    clock = FakeClock(datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC))
+    # outage1 → recover → SHORT gap → outage2 : should be ONE merged window
+    rounds = [PARTIAL, ALL_FAIL, ALL_FAIL, PARTIAL, ALL_FAIL, ALL_FAIL]
+    sentinel, sm, _ = make_sentinel(
+        tmp_path, rounds, clock=clock, tuning=make_tuning(merge_gap_s=600)
+    )
+    await sentinel._probe_round()  # DEGRADED
+    await sentinel._probe_round()  # all_fail1
+    await sentinel._probe_round()  # OFFLINE (window opens)
+    start = sentinel._open_window["start"]
+    clock.advance(30)
+    await sentinel._probe_round()  # partial → DEGRADED (window closes)
+    assert len(sentinel._closed_windows) == 1
+    clock.advance(30)  # short gap (< 600)
+    await sentinel._probe_round()  # all_fail1
+    await sentinel._probe_round()  # OFFLINE again → merge
+    assert len(sentinel._closed_windows) == 0  # merged back into open
+    assert sentinel._open_window["start"] == start  # original start preserved
+
+
+@pytest.mark.asyncio
+async def test_windows_separate_beyond_gap(tmp_path):
+    clock = FakeClock(datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC))
+    rounds = [PARTIAL, ALL_FAIL, ALL_FAIL, PARTIAL, ALL_FAIL, ALL_FAIL]
+    sentinel, sm, _ = make_sentinel(
+        tmp_path, rounds, clock=clock, tuning=make_tuning(merge_gap_s=60)
+    )
+    await sentinel._probe_round()
+    await sentinel._probe_round()
+    await sentinel._probe_round()  # OFFLINE
+    clock.advance(30)
+    await sentinel._probe_round()  # DEGRADED (close window 1)
+    clock.advance(300)  # long gap (> 60)
+    await sentinel._probe_round()  # all_fail1
+    await sentinel._probe_round()  # OFFLINE → new window
+    assert len(sentinel._closed_windows) == 1  # window 1 stays closed
+    assert sentinel._open_window is not None
+
+
+# ── snapshot immutability (F3) ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_snapshot_is_immutable_copy(tmp_path):
+    sentinel, sm, clock = make_sentinel(tmp_path, [ALL_FAIL, PARTIAL])
+    await sentinel._probe_round()
+    snap = sentinel.snapshot()
+    snap["state"] = "TAMPERED"
+    snap["window_open"] = "TAMPERED"
+    snap2 = sentinel.snapshot()
+    assert snap2["state"] != "TAMPERED"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_carries_last_probe_at(tmp_path):
+    sentinel, sm, clock = make_sentinel(tmp_path, [CLEAN])
+    assert sentinel.snapshot()["last_probe_at"] is None  # before first probe
+    await sentinel._probe_round()
+    assert sentinel.snapshot()["last_probe_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_publish_writes_state_file_every_round(tmp_path):
+    import json
+
+    sentinel, sm, clock = make_sentinel(tmp_path, [CLEAN, CLEAN])
+    await sentinel._probe_round()
+    path = tmp_path / "network_state.json"
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["state"] == "NORMAL"
+    assert "last_probe_at" in data and data["last_probe_at"] is not None
+
+
+# ── SHOULD-FIX regressions (code review) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_zero_anchors_surfaces_not_configured_without_probing(tmp_path):
+    # An enabled sentinel with zero anchors must NOT probe (a CLEAN round would
+    # pin NORMAL — a false green) and must surface 'no_anchors' explicitly.
+    import json
+
+    empty = make_tuning(dns_tcp_anchors=(), ip_anchors=())
+    probed = {"n": 0}
+
+    async def prober(_t):
+        probed["n"] += 1
+        return CLEAN
+
+    sm = ResilienceStateMachine()
+    sen = NetworkSentinel(
+        state_machine=sm,
+        prober=prober,
+        tuning_provider=lambda: empty,
+        state_path=tmp_path / "network_state.json",
+    )
+    cadence = await sen._probe_round()
+    assert probed["n"] == 0  # prober NEVER called — no anchors to probe
+    assert sm.current.network == NetworkStatus.NORMAL  # axis untouched (inert)
+    snap = sen.snapshot()
+    assert snap["cause"] == "no_anchors"
+    assert snap["last_probe_at"] is not None  # fresh marker, not omitted
+    data = json.loads((tmp_path / "network_state.json").read_text())
+    assert data["cause"] == "no_anchors"  # dashboard renders "not configured"
+    assert cadence == empty.fast_cadence_s
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_raising_tuning_provider(tmp_path):
+    # A tuning_provider that raises must NOT permanently kill the probe loop —
+    # the round is caught, a fallback cadence is used, and probing resumes.
+    calls = {"tuning": 0, "probe": 0}
+
+    def tuning_provider():
+        calls["tuning"] += 1
+        if calls["tuning"] == 1:
+            raise RuntimeError("transient tuning failure")
+        return make_tuning(fast_cadence_s=0, steady_cadence_s=0)
+
+    async def prober(_t):
+        calls["probe"] += 1
+        if calls["probe"] >= 2:
+            raise asyncio.CancelledError  # stop the loop after it recovered
+        return CLEAN
+
+    sm = ResilienceStateMachine()
+    sen = NetworkSentinel(
+        state_machine=sm,
+        prober=prober,
+        tuning_provider=tuning_provider,
+        state_path=tmp_path / "network_state.json",
+    )
+    sen._FALLBACK_CADENCE_S = 0  # instant fallback sleep for the test
+    with pytest.raises(asyncio.CancelledError):
+        await sen._loop()
+    # The first round raised (in tuning) and the loop CAUGHT it and kept probing.
+    assert calls["probe"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_all_fail_first_reaches_offline_in_two_rounds(tmp_path):
+    # Codex F1: locks the intended semantics — `offline_all_fail_rounds` (2)
+    # CONSECUTIVE all_fail rounds → OFFLINE, counting the NORMAL→DEGRADED round.
+    sentinel, sm, clock = make_sentinel(tmp_path, [ALL_FAIL, ALL_FAIL])
+    await sentinel._probe_round()  # all_fail #1: NORMAL → DEGRADED
+    assert sentinel._state == NetworkStatus.DEGRADED
+    await sentinel._probe_round()  # all_fail #2 → OFFLINE
+    assert sentinel._state == NetworkStatus.OFFLINE
+
+
+@pytest.mark.asyncio
+async def test_offline_entry_arms_recovery_and_opens_window(tmp_path):
+    # Codex F4: OFFLINE entry must re-arm recovery AND open the window (recovery
+    # re-armed BEFORE the window op so a window failure can't strand it).
+    sentinel, sm, clock = make_sentinel(tmp_path, [PARTIAL, ALL_FAIL, ALL_FAIL])
+    await _drive(sentinel, clock, 3)
+    assert sentinel._state == NetworkStatus.OFFLINE
+    assert sentinel._recovery_hook_fired is False  # armed for this outage
+    assert sentinel._open_window is not None  # window opened
+
+
+@pytest.mark.asyncio
+async def test_no_anchors_round_resets_clean_streak(tmp_path):
+    # Codex F3: a no_anchors round (live config gap) must reset the clean streak
+    # so a later clean can't reach NORMAL on a stale streak.
+    clock = FakeClock(datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC))
+    tunings = iter(
+        [
+            make_tuning(online_clean_rounds=2),  # r1
+            make_tuning(online_clean_rounds=2),  # r2
+            make_tuning(dns_tcp_anchors=(), ip_anchors=(), online_clean_rounds=2),  # r3
+            make_tuning(online_clean_rounds=2),  # r4
+            make_tuning(online_clean_rounds=2),  # r5
+        ]
+    )
+
+    def tuning_provider():
+        return next(tunings)
+
+    probe_vals = iter([PARTIAL, CLEAN, CLEAN, CLEAN])  # r3 (no_anchors) skips prober
+
+    async def prober(_t):
+        return next(probe_vals)
+
+    sm = ResilienceStateMachine(clock=clock)
+    sen = NetworkSentinel(
+        state_machine=sm,
+        prober=prober,
+        clock=clock,
+        tuning_provider=tuning_provider,
+        state_path=tmp_path / "n.json",
+    )
+    await sen._probe_round()  # r1 partial → DEGRADED
+    await sen._probe_round()  # r2 clean → streak 1
+    assert sen._consecutive_clean == 1
+    await sen._probe_round()  # r3 no_anchors → reset streak
+    assert sen._consecutive_clean == 0
+    assert sen.snapshot()["cause"] == "no_anchors"
+    await sen._probe_round()  # r4 clean → streak 1 (NOT 2)
+    assert sen._state == NetworkStatus.DEGRADED  # would be NORMAL without the reset
+    await sen._probe_round()  # r5 clean → streak 2 → NORMAL
+    assert sen._state == NetworkStatus.NORMAL

--- a/tests/test_resilience/test_network_state.py
+++ b/tests/test_resilience/test_network_state.py
@@ -1,0 +1,63 @@
+"""network_state store — tolerant read, atomic write, retention, staleness."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.resilience import network_state
+
+
+def test_read_absent_returns_none(tmp_path):
+    assert network_state.read_state(tmp_path / "nope.json") is None
+
+
+def test_read_corrupt_returns_none(tmp_path):
+    p = tmp_path / "network_state.json"
+    p.write_text("{not json")
+    assert network_state.read_state(p) is None
+
+
+def test_read_non_dict_returns_none(tmp_path):
+    p = tmp_path / "network_state.json"
+    p.write_text("[1, 2, 3]")
+    assert network_state.read_state(p) is None
+
+
+def test_write_then_read_roundtrip(tmp_path):
+    p = tmp_path / "network_state.json"
+    data = {"state": "OFFLINE", "last_probe_at": "2026-07-30T12:00:00+00:00"}
+    network_state.write_state(data, p)
+    got = network_state.read_state(p)
+    assert got["state"] == "OFFLINE"
+
+
+def test_write_caps_closed_windows(tmp_path):
+    p = tmp_path / "network_state.json"
+    windows = [{"start": str(i), "end": str(i), "cause": "all_fail"} for i in range(120)]
+    network_state.write_state({"state": "NORMAL", "closed_windows": windows}, p)
+    got = network_state.read_state(p)
+    assert len(got["closed_windows"]) == network_state.MAX_CLOSED_WINDOWS
+    # most-recent kept
+    assert got["closed_windows"][-1]["start"] == "119"
+
+
+def test_probe_age_fresh(tmp_path):
+    now = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+    snap = {"last_probe_at": (now - timedelta(seconds=30)).isoformat()}
+    age = network_state.probe_age_s(snap, now)
+    assert 29 <= age <= 31
+
+
+def test_probe_age_none_on_absent_or_garbled():
+    now = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+    assert network_state.probe_age_s(None, now) is None
+    assert network_state.probe_age_s({}, now) is None
+    assert network_state.probe_age_s({"last_probe_at": "not-a-date"}, now) is None
+    assert network_state.probe_age_s({"last_probe_at": 12345}, now) is None
+
+
+def test_probe_age_tolerates_naive_timestamp():
+    now = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+    snap = {"last_probe_at": "2026-07-30T11:59:00"}  # naive
+    age = network_state.probe_age_s(snap, now)
+    assert age is not None and 59 <= age <= 61


### PR DESCRIPTION
## What & why

The 2026-07-28 ~22.5h internet outage exposed that Genesis had no first-class concept of "the internet is down" — every subsystem discovered the outage independently and misattributed it (provider failures, backup push errors, CC timeouts). PR-1 (#1256) fixed six mechanism bugs; this PR adds the deterministic detector.

**NetworkSentinel** probes the open internet (DNS+TCP to public anchors) on a cadence and publishes a 3-state `network` axis (NORMAL/DEGRADED/OFFLINE) with **asymmetric hysteresis**: fast to declare OFFLINE (2 consecutive all-fail rounds), slow to clear (3 consecutive clean rounds); a DNS-only failure caps at DEGRADED. It owns its hysteresis and opts out of the state machine's symmetric flap protection.

## Behavior deltas (both fail-safe, both instantly reverting)

- **Watchdog forgiveness**: skips zombie-scheduler restarts when a *fresh* sentinel probe reports the network degraded/offline — a restart can't fix an ISP outage. It staleness-checks the sentinel's **own** `last_probe_at` (not `status.json`'s file timestamp, which the 60s status-writer refreshes independently), so a dead sentinel never strands a genuinely-wedged server unrestarted.
- **Recovery gate**: `is_any_degraded()` counts network at OFFLINE only (not DEGRADED) — pauses dead-letter replay / embedding drain into a confirmed-dead network without pausing on a merely-slow one.

Everything else is **observational**: dashboard "Internet" health light, `status.json` network fields, `~/.genesis/network_state.json` outage-window store (stdlib-only, self-bounding), an `infra:internet_down` WARNING. The axis is **deliberately excluded** from `to_legacy_degradation_level` — call-site shedding is deferred to PR-3 under a `network.parking_mode` lever.

## Operator controls / generalizability

- Kill switch `GENESIS_NETWORK_SENTINEL_DISABLED=1`; `network.parking_mode` (default `shadow`) and `network.backup_push_retry` (default `live`) in `config/resilience.yaml`, under the existing `resilience` settings domain.
- Empty-state safe: disabled / never-run → status, dashboard, and watchdog all behave exactly as before. Zero-anchor misconfig surfaces as a "not configured" light, never a false green.

## Review & verification

Three independent review passes — **genesis-architect** (design), **Claude code-reviewer** (implementation), and **Codex** (independent model, inline). All findings fixed, including four real robustness bugs Codex caught (transition atomicity, window-merge tuning snapshot, no-anchors streak reset, future-timestamp suppression).

Verified end-to-end live (Level-4 data-flow): real prober classifies live connectivity; a simulated outage (unreachable TEST-NET anchors) drives OFFLINE → replay pause + watchdog suppression (fresh) / restart (stale) + dashboard "down"; empty-state/kill-switch degrade correctly. 307 tests green across touched files, ruff clean.

Ledger: 95508b0ac13f4185967ef748d6c0dab8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
