### PR TITLE
feat(reflection): editable model/effort per depth + xhigh bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,10 +127,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   reflection thinks harder by default.** The model and reasoning effort behind
   each reflection depth — light, deep, and strategic — used to be fixed in code.
   They're now a settings domain you can edit live from the dashboard Config tab
-  (a new **Reflection Models** panel), with no restart. The defaults also move to
-  the new `xhigh` reasoning tier: Deep reflection steps up from `high`, and
-  Strategic settles at `xhigh` (from `max`). Light stays on Haiku, which doesn't
-  use an effort setting at all, so it exposes only a model choice.
+  (a new **Reflection Models** panel), with no restart. These govern reflections
+  running on the Claude Code CLI path: Deep and Strategic run on the CLI by
+  design, so this is their primary model/effort; Light runs primarily via the API
+  free-model chain and uses its value only when it falls back to the CLI. An
+  effort control appears only for effort-capable models — switch a depth off Haiku
+  and an effort setting surfaces (Haiku ignores effort at dispatch). The defaults
+  also move to the new `xhigh` reasoning tier: Deep steps up from `high`, and
+  Strategic settles at `xhigh` (from `max`).
 
 - **`git push` in an interactive Claude Code session now asks for your approval
   instead of hard-stopping.** This safety hook used to block the command outright

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Reflection model and effort are now editable from the dashboard, and Deep
+  reflection thinks harder by default.** The model and reasoning effort behind
+  each reflection depth — light, deep, and strategic — used to be fixed in code.
+  They're now a settings domain you can edit live from the dashboard Config tab
+  (a new **Reflection Models** panel), with no restart. The defaults also move to
+  the new `xhigh` reasoning tier: Deep reflection steps up from `high`, and
+  Strategic settles at `xhigh` (from `max`). Light stays on Haiku, which doesn't
+  use an effort setting at all, so it exposes only a model choice.
+
 - **`git push` in an interactive Claude Code session now asks for your approval
   instead of hard-stopping.** This safety hook used to block the command outright
   with no in-session way through; now Claude Code shows you a native approve/deny

--- a/config/reflection_models.yaml
+++ b/config/reflection_models.yaml
@@ -1,5 +1,13 @@
 # Reflection depth → model/effort mapping.
 #
+# SCOPE — governs reflections that run on the Claude Code CLI path.
+#   * deep + strategic run on the CLI BY DESIGN (dispatch: cli in
+#     config/model_routing.yaml), so THIS file is their primary model/effort.
+#   * light runs primarily via the API free-model chain (4_light_reflection) and
+#     uses its value here (Haiku) only when it falls back to the CLI.
+# So editing deep/strategic here changes their real model/effort; editing light
+# here changes only its CLI-fallback behavior.
+#
 # Read live per reflection (no restart) by
 # genesis.cc.reflection_bridge.reflection_models_config, which the reflection
 # bridge (_bridge.py) and prompt resolver (_prompts.py) both delegate to.

--- a/config/reflection_models.yaml
+++ b/config/reflection_models.yaml
@@ -1,0 +1,27 @@
+# Reflection depth → model/effort mapping.
+#
+# Read live per reflection (no restart) by
+# genesis.cc.reflection_bridge.reflection_models_config, which the reflection
+# bridge (_bridge.py) and prompt resolver (_prompts.py) both delegate to.
+#
+# Editable from the dashboard Config tab (settings domain: reflection_models).
+# Local overrides go to ~/.genesis/config/reflection_models.local.yaml and
+# survive git updates.
+#
+# model:  one of haiku | sonnet | opus | fable
+# effort: one of low | medium | high | xhigh | max
+#
+# NOTE: Haiku does not use an effort setting — the CC invoker OMITS --effort for
+# Haiku (model_supports_effort). So `light` intentionally carries no `effort`
+# key here; setting one would be ignored at dispatch.
+
+light:
+  model: haiku
+
+deep:
+  model: sonnet
+  effort: xhigh
+
+strategic:
+  model: opus
+  effort: xhigh

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -31,6 +31,7 @@ from genesis.cc.reflection_bridge._prompts import (
     load_prompt_file,
     system_prompt_for_depth,
 )
+from genesis.cc.reflection_bridge.reflection_models_config import effort_for_depth, model_for_depth
 from genesis.cc.types import CCInvocation, CCModel, EffortLevel, SessionType, background_session_dir
 from genesis.db.crud import cc_sessions as cc_sessions_crud
 from genesis.observability.call_site_recorder import record_last_run
@@ -47,12 +48,6 @@ if TYPE_CHECKING:
     from genesis.resilience.deferred_work import DeferredWorkQueue
 
 logger = logging.getLogger(__name__)
-
-_DEPTH_MODEL = {
-    Depth.LIGHT: CCModel.HAIKU,
-    Depth.DEEP: CCModel.SONNET,
-    Depth.STRATEGIC: CCModel.OPUS,
-}
 
 _DEPTH_TIMEOUT_S = {
     Depth.LIGHT: 600,
@@ -135,19 +130,14 @@ class CCReflectionBridge:
     # ── Main reflection entry point ───────────────────────────────────
 
     def _model_for_depth(self, depth: Depth) -> CCModel:
-        return _DEPTH_MODEL.get(depth, CCModel.SONNET)
+        return model_for_depth(depth)
 
     def _effort_for_context(self, depth: Depth, tick=None, escalation_source: str | None = None) -> EffortLevel:
-        """Effort level per depth."""
-        if depth == Depth.STRATEGIC:
-            return EffortLevel.MAX
-        if depth == Depth.LIGHT:
-            return EffortLevel.LOW
-        # Deep: fixed HIGH. Adaptive effort is a V4 executor concern.
+        """Effort level per depth — config-driven via the reflection_models domain."""
         # GROUNDWORK(v4-executor): escalation_source will drive executor effort.
-        if escalation_source:
-            logger.debug("Deep reflection triggered by %s (effort fixed at HIGH)", escalation_source)
-        return EffortLevel.HIGH
+        if depth == Depth.DEEP and escalation_source:
+            logger.debug("Deep reflection triggered by %s", escalation_source)
+        return effort_for_depth(depth) or EffortLevel.MEDIUM
 
     async def _check_throttle(self, priority: int, work_type: str) -> ReflectionResult | None:
         """Check CC budget throttling. Returns a deferred result if throttled, None otherwise."""

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 from genesis.awareness.signal_format import format_signal_line, format_signals
 from genesis.awareness.types import Depth, SignalReading, TickResult
-from genesis.cc.types import CCModel
+from genesis.cc.reflection_bridge.reflection_models_config import model_for_depth
 
 if TYPE_CHECKING:
     from genesis.perception.context import ContextAssembler
@@ -540,12 +540,6 @@ async def build_light_prompt_enriched(
 # ── Prompt file loading ──────────────────────────────────────────────
 
 
-_DEPTH_MODEL = {
-    Depth.LIGHT: CCModel.HAIKU,
-    Depth.DEEP: CCModel.SONNET,
-    Depth.STRATEGIC: CCModel.OPUS,
-}
-
 _PROMPT_FILES = {
     Depth.LIGHT: "REFLECTION_LIGHT.md",
     Depth.DEEP: "REFLECTION_DEEP.md",
@@ -579,7 +573,7 @@ def _resolve_prompt_in_dir(depth: Depth, prompt_dir: Path) -> str | None:
     if not filename:
         return None
     try:
-        model = _DEPTH_MODEL.get(depth)
+        model = model_for_depth(depth)
         if model:
             stem = filename.rsplit(".", 1)[0]
             model_path = prompt_dir / f"{stem}_{model.value.upper()}.md"

--- a/src/genesis/cc/reflection_bridge/reflection_models_config.py
+++ b/src/genesis/cc/reflection_bridge/reflection_models_config.py
@@ -128,3 +128,40 @@ def effort_for_depth(depth: Depth) -> EffortLevel | None:
         )
         fallback = _HARDCODED_DEFAULTS.get(key, {}).get("effort")
         return EffortLevel(fallback) if fallback else None
+
+
+def editor_view(config: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a served reflection_models config for the dashboard editor.
+
+    The generic settings editor only renders keys present in the served config, so
+    an ``effort`` control appears for a depth only when the config carries an
+    ``effort`` key. Expose ``effort`` for exactly the depths whose selected model
+    supports it:
+
+      * effort-capable model (Sonnet/Opus/Fable) with no ``effort`` key → inject
+        the default effort so the control renders. Without this, switching a depth
+        off Haiku silently applies the hidden hardcoded value with no way to edit
+        it (Codex P2 on #1261).
+      * effort-less model (Haiku) → drop any ``effort`` key so no misleading
+        control shows; the invoker omits ``--effort`` for Haiku at dispatch.
+
+    Pure view transform over a COPY — never mutates the stored config, so it is
+    safe to call on the merged yaml the dashboard route serves.
+    """
+    from genesis.cc.types import CCModel, model_supports_effort
+
+    view = copy.deepcopy(config)
+    for key, fields in view.items():
+        if not isinstance(fields, dict):
+            continue
+        model_raw = fields.get("model")
+        try:
+            supports = bool(model_raw) and model_supports_effort(CCModel(model_raw))
+        except ValueError:
+            supports = False
+        if supports:
+            if not fields.get("effort"):
+                fields["effort"] = _HARDCODED_DEFAULTS.get(key, {}).get("effort") or "medium"
+        else:
+            fields.pop("effort", None)
+    return view

--- a/src/genesis/cc/reflection_bridge/reflection_models_config.py
+++ b/src/genesis/cc/reflection_bridge/reflection_models_config.py
@@ -1,0 +1,130 @@
+"""Config lever for the reflection depth → model/effort mapping.
+
+Cloned from ``ego.reconcile_config``: fresh-read-per-call, deep-merge over
+hardcoded defaults, degrade field-by-field toward the defaults on config damage
+so a reflection can never crash on a bad config.
+
+The reflection bridge (``_bridge.py::_model_for_depth`` / ``_effort_for_context``)
+and the prompt resolver (``_prompts.py``) both delegate here, so the depth→model
+mapping has a single source of truth. Editable from the dashboard via the
+``reflection_models`` settings domain.
+
+Effort semantics: Haiku does not use an effort setting — the CC invoker OMITS
+``--effort`` for Haiku (``model_supports_effort``). ``light`` therefore has no
+``effort`` in the base yaml (the dashboard shows only its model). The internal
+``_HARDCODED_DEFAULTS`` still resolves ``light`` to ``low`` so callers always get
+a concrete ``EffortLevel`` — the value is a harmless no-op at dispatch for Haiku.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay +
+genesis.cc.types + genesis.awareness.types only. ``genesis.mcp.health.settings``
+imports the public helpers from here (never the reverse) — mirror reconcile_config.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.awareness.types import Depth
+from genesis.cc.types import CCModel, EffortLevel
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "reflection_models.yaml"
+
+# Authoritative fallbacks — match the historical hardcoded _DEPTH_MODEL /
+# _effort_for_context, with the 2026-07-30 effort bump (deep/strategic → xhigh).
+# ``light`` keeps ``effort: low`` here (not in the yaml) so the runtime value is
+# concrete even though Haiku ignores it at dispatch.
+_HARDCODED_DEFAULTS: dict[str, dict[str, str]] = {
+    "light": {"model": "haiku", "effort": "low"},
+    "deep": {"model": "sonnet", "effort": "xhigh"},
+    "strategic": {"model": "opus", "effort": "xhigh"},
+}
+
+# Public: the settings-domain validator imports these to check keys/defaults.
+VALID_DEPTH_KEYS: frozenset[str] = frozenset(_HARDCODED_DEFAULTS)
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local overlay), per depth, so a partial
+    override (e.g. only ``deep.effort``) keeps the other fields from defaults.
+    Missing or corrupt files degrade toward ``_HARDCODED_DEFAULTS``.
+    """
+    merged = copy.deepcopy(_HARDCODED_DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("reflection_models base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("reflection_models overlay merge failed", exc_info=True)
+    for depth_key, fields in base.items():
+        if not isinstance(fields, dict):
+            continue
+        if depth_key in merged:
+            merged[depth_key] = {**merged[depth_key], **fields}
+        else:
+            merged[depth_key] = dict(fields)
+    return merged
+
+
+def _depth_key(depth: Depth) -> str:
+    # Depth values are capitalized ("Light"/"Deep"/"Strategic"); the config uses
+    # lowercase keys, so normalize.
+    raw = depth.value if isinstance(depth, Depth) else str(depth)
+    return raw.lower()
+
+
+def model_for_depth(depth: Depth) -> CCModel:
+    """Model for a reflection depth. Invalid/missing → hardcoded default → SONNET."""
+    key = _depth_key(depth)
+    raw = load_config().get(key, {}).get("model") or _HARDCODED_DEFAULTS.get(key, {}).get("model")
+    try:
+        return CCModel(raw) if raw else CCModel.SONNET
+    except ValueError:
+        logger.warning("reflection_models: invalid model %r for depth %s — using default", raw, key)
+        fallback = _HARDCODED_DEFAULTS.get(key, {}).get("model", "sonnet")
+        return CCModel(fallback)
+
+
+def effort_for_depth(depth: Depth) -> EffortLevel | None:
+    """Effort for a reflection depth, or ``None`` when none is configured.
+
+    Invalid values degrade to the hardcoded default (or ``None``). Callers that
+    need a concrete level should coalesce ``None`` themselves; the invoker omits
+    ``--effort`` for effort-less models (Haiku) regardless of this value.
+    """
+    key = _depth_key(depth)
+    raw = load_config().get(key, {}).get("effort")
+    if raw is None:
+        raw = _HARDCODED_DEFAULTS.get(key, {}).get("effort")
+    if raw is None:
+        return None
+    try:
+        return EffortLevel(raw)
+    except ValueError:
+        logger.warning(
+            "reflection_models: invalid effort %r for depth %s — using default", raw, key
+        )
+        fallback = _HARDCODED_DEFAULTS.get(key, {}).get("effort")
+        return EffortLevel(fallback) if fallback else None

--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -108,5 +108,5 @@ async def settings_update(domain_name: str):
 _FORM_DOMAINS = frozenset({
     "tts", "ego", "inbox_monitor", "outreach", "autonomous_cli_policy",
     "surplus", "resilience", "confidence_gates", "updates", "channels",
-    "contribution",
+    "reflection_models", "contribution",
 })

--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -58,6 +58,13 @@ async def settings_get(domain_name: str):
     if not domain:
         return jsonify({"error": f"Unknown domain: {domain_name}"}), 404
     data = _load_yaml_merged(domain.config_filename)
+    if domain_name == "reflection_models":
+        # Expose an effort control only for depths whose model supports effort
+        # (Haiku shows model only; switching a depth to Sonnet/Opus/Fable surfaces
+        # effort). Pure view transform — the stored config is untouched.
+        from genesis.cc.reflection_bridge.reflection_models_config import editor_view
+
+        data = editor_view(data)
     _strip_hidden(domain, data)
     return jsonify({"domain": domain_name, "config": data, "readonly": domain.readonly})
 

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -2314,7 +2314,7 @@
           // Inbox Monitor
           watch_path: 'Watch Path', response_dir: 'Response Dir Pattern',
           check_interval_seconds: 'Check Interval (sec)', batch_size: 'Batch Size',
-          effort: 'Effort Level', timeout_s: 'Timeout (sec)',
+          effort: 'Effort Level', model: 'Model', timeout_s: 'Timeout (sec)',
           // Outreach
           start: 'Start Time', end: 'End Time',
           default: 'Default Channel', blocker: 'Blocker Channel',
@@ -2450,7 +2450,7 @@
         },
         // Display order for settings domains — most important first
         _DOMAIN_ORDER: [
-          'channels', 'autonomous_cli_policy', 'ego', 'outreach', 'tts',
+          'channels', 'autonomous_cli_policy', 'ego', 'reflection_models', 'outreach', 'tts',
           'inbox_monitor', 'surplus', 'resilience', 'confidence_gates',
           'updates', 'contribution', 'recon_schedules', 'recon_watchlist', 'recon_sources',
           'autonomy', 'autonomy_rules', 'guardian',
@@ -2469,6 +2469,7 @@
           model_routing: 'Model Routing',
           content_sanitization: 'Content Sanitization',
           channels: 'Channels',
+          reflection_models: 'Reflection Models',
           contribution: 'Contribution Offers',
         },
         _sortedDomains(domains) {

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -388,6 +388,18 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=True,
     ),
+    "reflection_models": SettingsDomain(
+        name="reflection_models",
+        description=(
+            "Reflection depth → model/effort (light/deep/strategic). Read live "
+            "per reflection by cc.reflection_bridge.reflection_models_config (no "
+            "restart). Haiku (light) ignores effort — the invoker omits --effort "
+            "for it, so light carries no effort key."
+        ),
+        config_filename="reflection_models.yaml",
+        readonly=False,
+        needs_restart=False,  # read live per reflection by reflection_models_config
+    ),
     "contribution": SettingsDomain(
         name="contribution",
         description="Contribution offer pipeline (proactive upstream fix offers)",
@@ -807,6 +819,52 @@ def _validate_channels(changes: dict) -> list[str]:
             f"got '{tg['default_effort']}'"
         )
 
+    return errors
+
+
+def _validate_reflection_models(changes: dict) -> list[str]:
+    """Validate reflection depth → model/effort config changes.
+
+    Keys must be depths (light/deep/strategic); each a mapping with model and/or
+    effort. Effort is additionally rejected when it exceeds the model's ceiling
+    (via clamp_effort), so a nonsensical pairing can't be saved.
+    """
+    from genesis.cc.reflection_bridge.reflection_models_config import VALID_DEPTH_KEYS
+    from genesis.cc.types import CCModel, EffortLevel, clamp_effort, model_supports_effort
+
+    errors: list[str] = []
+    valid_models = VALID_MODEL_NAMES
+    valid_efforts = VALID_EFFORT_NAMES
+
+    for depth_key, spec in changes.items():
+        if depth_key not in VALID_DEPTH_KEYS:
+            errors.append(
+                f"Unknown depth '{depth_key}'. Valid: {', '.join(sorted(VALID_DEPTH_KEYS))}"
+            )
+            continue
+        if not isinstance(spec, dict):
+            errors.append(f"{depth_key} must be a mapping")
+            continue
+        for key in spec:
+            if key not in ("model", "effort"):
+                errors.append(f"Unknown key '{depth_key}.{key}'. Valid: model, effort")
+        model = spec.get("model")
+        if model is not None and model not in valid_models:
+            errors.append(f"{depth_key}.model must be one of {sorted(valid_models)}, got '{model}'")
+        effort = spec.get("effort")
+        if effort is not None and effort not in valid_efforts:
+            errors.append(
+                f"{depth_key}.effort must be one of {sorted(valid_efforts)}, got '{effort}'"
+            )
+        # Ceiling check: reject an effort above the chosen model's supported max.
+        if model in valid_models and effort in valid_efforts:
+            m = CCModel(model)
+            if model_supports_effort(m):
+                clamped = clamp_effort(m, EffortLevel(effort))
+                if clamped != EffortLevel(effort):
+                    errors.append(
+                        f"{depth_key}.effort '{effort}' exceeds {model}'s max '{clamped.value}'"
+                    )
     return errors
 
 
@@ -1283,6 +1341,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "surplus": _validate_surplus,
     "ego": _validate_ego,
     "channels": _validate_channels,
+    "reflection_models": _validate_reflection_models,
     "contribution": _validate_contribution,
     "observability": _validate_observability,
 }

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -391,10 +391,13 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
     "reflection_models": SettingsDomain(
         name="reflection_models",
         description=(
-            "Reflection depth → model/effort (light/deep/strategic). Read live "
-            "per reflection by cc.reflection_bridge.reflection_models_config (no "
-            "restart). Haiku (light) ignores effort — the invoker omits --effort "
-            "for it, so light carries no effort key."
+            "Reflection depth → model/effort (light/deep/strategic) for "
+            "reflections that run on the Claude Code CLI path. Deep and strategic "
+            "run on the CLI by design (dispatch: cli in model_routing.yaml), so "
+            "these are their PRIMARY model/effort; light runs primarily via the "
+            "API free-model chain and uses its value (Haiku) only on CLI fallback. "
+            "Read live per reflection (no restart). An effort control shows only "
+            "for effort-capable models — Haiku ignores --effort."
         ),
         config_filename="reflection_models.yaml",
         readonly=False,

--- a/tests/test_cc/test_reflection_bridge.py
+++ b/tests/test_cc/test_reflection_bridge.py
@@ -65,14 +65,15 @@ def test_model_for_depth(bridge):
 
 
 def test_effort_for_context(bridge):
-    # LIGHT→LOW, DEEP→HIGH (fixed), STRATEGIC→MAX
+    # Config-driven defaults (reflection_models domain): LIGHT→LOW, DEEP→XHIGH,
+    # STRATEGIC→XHIGH (Haiku ignores effort at dispatch; LOW is a harmless no-op).
     assert bridge._effort_for_context(Depth.LIGHT) == EffortLevel.LOW
-    assert bridge._effort_for_context(Depth.DEEP) == EffortLevel.HIGH
-    assert bridge._effort_for_context(Depth.STRATEGIC) == EffortLevel.MAX
-    # Deep is fixed HIGH regardless of escalation source or signal load
-    # (escalation_source is logged but doesn't change effort — that's V4 executor)
-    assert bridge._effort_for_context(Depth.DEEP, escalation_source="critical_bypass") == EffortLevel.HIGH
-    assert bridge._effort_for_context(Depth.DEEP, escalation_source="light_escalation") == EffortLevel.HIGH
+    assert bridge._effort_for_context(Depth.DEEP) == EffortLevel.XHIGH
+    assert bridge._effort_for_context(Depth.STRATEGIC) == EffortLevel.XHIGH
+    # Deep effort is unchanged by escalation source — it's logged, not acted on
+    # (escalation-driven effort is a V4 executor concern).
+    assert bridge._effort_for_context(Depth.DEEP, escalation_source="critical_bypass") == EffortLevel.XHIGH
+    assert bridge._effort_for_context(Depth.DEEP, escalation_source="light_escalation") == EffortLevel.XHIGH
 
 
 async def test_reflect_deep(db, bridge, tick, mock_invoker):

--- a/tests/test_cc/test_reflection_models_config.py
+++ b/tests/test_cc/test_reflection_models_config.py
@@ -1,0 +1,121 @@
+"""reflection_models config lever: live-read depth→model/effort accessor.
+
+Mirrors the ego reconcile_config test harness (repo_root + overlay redirected to
+tmp dirs). Verifies defaults, per-depth partial overrides, overlay precedence,
+degrade-on-damage, and no-cache live reads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genesis.awareness.types import Depth
+from genesis.cc import reflection_bridge  # noqa: F401  (ensure package import path)
+from genesis.cc.reflection_bridge import reflection_models_config as rmc
+from genesis.cc.types import CCModel, EffortLevel
+
+
+@pytest.fixture
+def config_dirs(tmp_path, monkeypatch) -> tuple[Path, Path]:
+    """Redirect base + overlay config resolution into tmp dirs.
+
+    Returns ``(base_path, overlay_path)`` — neither file exists initially.
+    """
+    repo_dir = tmp_path / "repo"
+    user_dir = tmp_path / "user_config"
+    (repo_dir / "config").mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+    monkeypatch.setattr(rmc, "repo_root", lambda: repo_dir)
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: user_dir)
+    return (
+        repo_dir / "config" / "reflection_models.yaml",
+        user_dir / "reflection_models.local.yaml",
+    )
+
+
+# ── defaults (no config on disk) ─────────────────────────────────────────
+
+
+def test_defaults_when_no_config(config_dirs):
+    assert rmc.model_for_depth(Depth.LIGHT) == CCModel.HAIKU
+    assert rmc.model_for_depth(Depth.DEEP) == CCModel.SONNET
+    assert rmc.model_for_depth(Depth.STRATEGIC) == CCModel.OPUS
+    assert rmc.effort_for_depth(Depth.LIGHT) == EffortLevel.LOW
+    assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.XHIGH
+    assert rmc.effort_for_depth(Depth.STRATEGIC) == EffortLevel.XHIGH
+
+
+# ── overrides ────────────────────────────────────────────────────────────
+
+
+def test_base_override_model(config_dirs):
+    base, _ = config_dirs
+    base.write_text("deep:\n  model: opus\n")
+    assert rmc.model_for_depth(Depth.DEEP) == CCModel.OPUS
+
+
+def test_partial_override_keeps_other_field(config_dirs):
+    """Overriding only deep.effort must keep deep.model from the defaults."""
+    base, _ = config_dirs
+    base.write_text("deep:\n  effort: max\n")
+    assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.MAX
+    assert rmc.model_for_depth(Depth.DEEP) == CCModel.SONNET  # not lost
+
+
+def test_overlay_wins_over_base(config_dirs):
+    base, overlay = config_dirs
+    base.write_text("deep:\n  effort: high\n")
+    overlay.write_text("deep:\n  effort: max\n")
+    assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.MAX
+
+
+# ── degrade on damage ────────────────────────────────────────────────────
+
+
+def test_invalid_model_degrades_to_default(config_dirs, caplog):
+    base, _ = config_dirs
+    base.write_text("deep:\n  model: gpt-9\n")
+    with caplog.at_level("WARNING"):
+        assert rmc.model_for_depth(Depth.DEEP) == CCModel.SONNET
+
+
+def test_invalid_effort_degrades_to_default(config_dirs, caplog):
+    base, _ = config_dirs
+    base.write_text("deep:\n  effort: turbo\n")
+    with caplog.at_level("WARNING"):
+        assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.XHIGH
+
+
+def test_corrupt_base_degrades_to_defaults(config_dirs):
+    base, _ = config_dirs
+    base.write_text("{{{{not yaml")
+    assert rmc.model_for_depth(Depth.DEEP) == CCModel.SONNET
+    assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.XHIGH
+
+
+def test_read_live_no_cache(config_dirs):
+    base, _ = config_dirs
+    base.write_text("deep:\n  effort: max\n")
+    assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.MAX
+    base.write_text("deep:\n  effort: high\n")
+    assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.HIGH  # next call, no cache
+
+
+# ── shipped base file sanity ─────────────────────────────────────────────
+
+
+def test_shipped_base_config_values():
+    """The shipped config/reflection_models.yaml parses with the intended values.
+
+    Light intentionally omits `effort` (Haiku ignores it); deep/strategic ship
+    at xhigh.
+    """
+    import yaml
+
+    base = Path(__file__).parents[2] / "config" / "reflection_models.yaml"
+    cfg = yaml.safe_load(base.read_text())
+    assert cfg["light"] == {"model": "haiku"}
+    assert cfg["deep"] == {"model": "sonnet", "effort": "xhigh"}
+    assert cfg["strategic"] == {"model": "opus", "effort": "xhigh"}

--- a/tests/test_cc/test_reflection_models_config.py
+++ b/tests/test_cc/test_reflection_models_config.py
@@ -103,6 +103,43 @@ def test_read_live_no_cache(config_dirs):
     assert rmc.effort_for_depth(Depth.DEEP) == EffortLevel.HIGH  # next call, no cache
 
 
+# ── editor_view: conditional effort exposure (P2 — Codex #1261) ──────────
+
+
+def test_editor_view_exposes_effort_for_effort_capable_model():
+    """Switching a depth to an effort-capable model must surface an effort key so
+    the dashboard renders a control (else the hidden hardcoded value is silently
+    used). Light shipped as Haiku with no effort; as Sonnet it must gain one."""
+    view = rmc.editor_view({"light": {"model": "sonnet"}})
+    assert view["light"]["model"] == "sonnet"
+    assert view["light"].get("effort")  # a concrete default is exposed
+    assert view["light"]["effort"] in {"low", "medium", "high", "xhigh", "max"}
+
+
+def test_editor_view_hides_effort_for_effortless_model():
+    """Haiku ignores --effort at dispatch, so the editor must NOT show an effort
+    control for it — even if a stale effort key is present in the served config."""
+    view = rmc.editor_view({"light": {"model": "haiku", "effort": "low"}})
+    assert view["light"] == {"model": "haiku"}
+
+
+def test_editor_view_keeps_existing_effort_for_capable_model():
+    view = rmc.editor_view({"deep": {"model": "sonnet", "effort": "xhigh"}})
+    assert view["deep"] == {"model": "sonnet", "effort": "xhigh"}
+
+
+def test_editor_view_does_not_mutate_input():
+    src = {"light": {"model": "haiku", "effort": "low"}}
+    rmc.editor_view(src)
+    assert src == {"light": {"model": "haiku", "effort": "low"}}  # unchanged
+
+
+def test_editor_view_ignores_non_dict_and_unknown():
+    view = rmc.editor_view({"light": "oops", "deep": {"model": "opus"}})
+    assert view["light"] == "oops"  # left as-is, never crashes
+    assert view["deep"].get("effort")  # opus is effort-capable → exposed
+
+
 # ── shipped base file sanity ─────────────────────────────────────────────
 
 

--- a/tests/test_mcp/test_settings_reflection_models.py
+++ b/tests/test_mcp/test_settings_reflection_models.py
@@ -1,0 +1,52 @@
+"""reflection_models settings validator + domain registration."""
+
+from __future__ import annotations
+
+from genesis.dashboard.routes.settings import _FORM_DOMAINS
+from genesis.mcp.health.settings import _DOMAIN_REGISTRY, _DOMAIN_VALIDATORS
+
+_validate = _DOMAIN_VALIDATORS["reflection_models"]
+
+
+def test_domain_registered_with_config_file():
+    dom = _DOMAIN_REGISTRY["reflection_models"]
+    assert dom.config_filename == "reflection_models.yaml"
+    assert dom.readonly is False
+    assert dom.needs_restart is False  # read live per reflection
+
+
+def test_has_form_on_dashboard():
+    """The domain is in the dashboard form allowlist so it renders editable."""
+    assert "reflection_models" in _FORM_DOMAINS
+
+
+def test_valid_changes_pass():
+    assert _validate({"deep": {"effort": "xhigh"}}) == []
+    assert _validate({"deep": {"model": "opus"}}) == []
+    assert _validate({"strategic": {"model": "opus", "effort": "max"}}) == []
+    assert _validate({"light": {"model": "haiku"}}) == []
+
+
+def test_unknown_depth_rejected():
+    (err,) = _validate({"bogus": {"model": "opus"}})
+    assert "Unknown depth" in err
+
+
+def test_unknown_subkey_rejected():
+    errs = _validate({"deep": {"temperature": 0.5}})
+    assert any("Unknown key" in e for e in errs)
+
+
+def test_non_mapping_spec_rejected():
+    errs = _validate({"deep": "sonnet"})
+    assert any("must be a mapping" in e for e in errs)
+
+
+def test_bad_model_rejected():
+    errs = _validate({"deep": {"model": "gpt-9"}})
+    assert any("model must be one of" in e for e in errs)
+
+
+def test_bad_effort_rejected():
+    errs = _validate({"deep": {"effort": "turbo"}})
+    assert any("effort must be one of" in e for e in errs)

--- a/tests/test_mcp/test_settings_reflection_models.py
+++ b/tests/test_mcp/test_settings_reflection_models.py
@@ -20,6 +20,17 @@ def test_has_form_on_dashboard():
     assert "reflection_models" in _FORM_DOMAINS
 
 
+def test_domain_description_scopes_cli_path_per_depth():
+    """P2 (#1261): the description must accurately scope these to the CLI path —
+    deep/strategic are CLI-PRIMARY (dispatch: cli), light uses this value only on
+    CLI fallback. Guards against the inverted 'CLI-fallback-only for all depths'
+    wording (deep/strategic route cli by design, so this file is their real lever)."""
+    desc = _DOMAIN_REGISTRY["reflection_models"].description.lower()
+    assert "cli" in desc
+    assert "primary" in desc  # deep/strategic named as CLI-primary, not a fallback
+    assert "fallback" in desc  # light's CLI-fallback case still named
+
+
 def test_valid_changes_pass():
     assert _validate({"deep": {"effort": "xhigh"}}) == []
     assert _validate({"deep": {"model": "opus"}}) == []


### PR DESCRIPTION
## What

Makes the reflection **depth → model/effort** mapping an editable settings domain instead of hardcoded constants, and raises the default reasoning effort:

- **Deep** reflection: `high` → **`xhigh`**
- **Strategic** reflection: `max` → **`xhigh`**
- Models unchanged: light=`haiku`, deep=`sonnet`, strategic=`opus`.

Light stays effort-less — the CC invoker already omits `--effort` for Haiku (`model_supports_effort`), so the `light` config exposes only a model choice.

## How

- New accessor `cc/reflection_bridge/reflection_models_config.py` (cloned from `ego/reconcile_config.py`): fresh-read-per-call, deep-merge `defaults ← base yaml ← .local overlay`, degrade field-by-field to hardcoded defaults on config damage. Single source of truth — both `_bridge.py` (`_model_for_depth` / `_effort_for_context`) and `_prompts.py` (prompt-variant resolution) delegate to it, and the two old `_DEPTH_MODEL` constants are removed.
- New `reflection_models` settings domain + `_validate_reflection_models` validator (mirrors `_validate_channels`, adds an effort-ceiling check via `clamp_effort`), registered in `_FORM_DOMAINS` so the dashboard Config tab renders an editable panel. `model`/`effort` dropdowns already existed in the generic renderer.
- Read live per reflection — **no restart**.

## Verification

- Targeted tests green: new accessor + validator suites, `test_reflection_bridge` (55), `test_settings` (50), all prompt/reflection tests (82). Ruff clean.
- E2E against the shipped config: dashboard settings route serves the nested config, validator round-trips (accepts valid, rejects bad model/effort/depth), and live reads give Deep=`sonnet`/`xhigh`, Strategic=`opus`/`xhigh`, Light=`haiku`/`low`.
- Post-merge E2E marker: after deploy, a real Deep reflection dispatches with `--effort xhigh` (grep the invoker log line `CC session starting: model=sonnet effort=xhigh`).

## Notes

- A capitalization bug (`Depth.value` is `"Deep"`, config keys are lowercase) was caught mid-build by a live smoke test and is now regression-tested.
- `MICRO` never reaches these methods (it routes to `reflection_engine`, not the CC bridge) — verified at all call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
