### PR TITLE
feat(hooks): prompt only on the first push of a branch/PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **The push-approval prompt now appears only on a branch's first push, not on
+  every push.** Publishing a branch to the public repo still asks for your
+  approval the first time — that's the moment code actually goes public — but
+  re-pushing fixes to a branch that's already on the remote (the normal
+  PR-iteration loop) no longer re-prompts. A genuinely new branch prompts again,
+  pushing to `main` still prompts, force-pushes are still hard-blocked, and
+  autonomous/dispatched sessions still can't push at all. The check reads the live
+  remote and fails safe: any uncertainty (unreachable remote, ambiguous target)
+  falls back to asking.
+
 ### Fixed
 
 - **Committing with `git -C` or `git -c` no longer skips the code-review gate.**

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -208,47 +208,35 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
     return False
 
 
-def _get_push_remote_and_branch(cmd: str, cwd: str | None = None) -> tuple[str | None, str | None]:
-    """Parse git push command to determine target remote and branch.
+def _get_push_remote_and_branch(seg, cwd: str | None = None) -> tuple[str | None, str | None]:
+    """The (remote, destination-branch) a ``git push`` segment targets.
 
-    Returns (remote, branch) or (None, None) if can't determine. ``cwd`` is the
-    effective worktree dir, used to resolve the current branch label correctly.
+    Parsed from the quote-stripped ``seg.argv`` via ``_push_positionals`` — NOT a
+    naive ``cmd.split()``, which mis-skips value flags (``-o <val>``) and wrongly
+    treats no-value flags like ``-u`` / ``--set-upstream`` as consuming the next
+    token (collapsing the branch to the wrong value — a security bug once the
+    branch feeds an approval decision). Positional handling mirrors
+    ``_push_named_remote``:
+      • no positional   → bare ``git push``               → (``"upstream"``, current branch);
+      • one positional  → ``git push <remote>``           → (remote, current branch);
+      • two positionals → ``git push <remote> <refspec>`` → (remote, refspec DST).
+    Used for the approval-dialog LABEL; the safety decision uses the stricter
+    ``_push_targets_current_branch``. Returns (None, None) if not a push.
     """
-    parts = cmd.split()
-    # Find 'push' position
-    try:
-        push_idx = parts.index("push")
-    except ValueError:
+    argv = getattr(seg, "argv", None) or []
+    if git_subcommand(argv) != "push":
         return None, None
-
-    # Skip flags after 'push'
-    args = []
-    i = push_idx + 1
-    while i < len(parts):
-        if parts[i].startswith("-"):
-            # Skip flags and their arguments
-            if parts[i] in ("-u", "--set-upstream", "--force-with-lease"):
-                i += 1  # These don't take a separate argument in this context
-            i += 1
-            continue
-        args.append(parts[i])
-        i += 1
-
-    if len(args) == 0:
+    pos = _push_positionals(argv)
+    if not pos:
         # Bare 'git push' — pushes current branch to its upstream
         return "upstream", _current_branch(cwd=cwd)
-    if len(args) == 1:
+    if len(pos) == 1:
         # 'git push origin' — pushes current branch to remote
-        return args[0], _current_branch(cwd=cwd)
-    if len(args) >= 2:
-        # 'git push origin main' or 'git push origin feature:main'
-        remote = args[0]
-        refspec = args[1]
-        # Handle refspec like 'feature:main'
-        branch = refspec.split(":")[-1] if ":" in refspec else refspec
-        return remote, branch
-
-    return None, None
+        return pos[0], _current_branch(cwd=cwd)
+    # 'git push origin main' or 'git push origin feature:main'
+    remote, refspec = pos[0], pos[1]
+    branch = refspec.split(":")[-1] if ":" in refspec else refspec
+    return remote, branch
 
 
 def _extract_pr_number(cmd: str) -> str | None:
@@ -657,6 +645,38 @@ def _is_dispatched() -> bool:
 # happens to start with '+' or contain 'f' is not misread as a force.
 _PUSH_VALUE_FLAGS = frozenset({"-o", "--push-option", "--repo", "--receive-pack", "--exec"})
 
+# The first-push-only skip uses an ALLOWLIST posture (git's push surface is too
+# flexible to blocklist safely): a push qualifies as a "plain current-branch
+# update" ONLY if every flag it carries is ref-set-neutral — verbosity, dry-run,
+# upstream tracking, transport — never one that changes WHICH refs are pushed.
+# Anything outside these sets (``--all`` / ``--tags`` / ``--mirror`` / ``--delete``
+# / ``--prune`` / ``--repo`` / ``--stdin`` / ``--follow-tags`` / a bundled ``-d`` /
+# any unknown flag) forces the approval prompt.
+_PUSH_SAFE_LONG_FLAGS = frozenset(
+    {
+        "--set-upstream",
+        "--verbose",
+        "--quiet",
+        "--dry-run",
+        "--progress",
+        "--no-progress",
+        "--porcelain",
+        "--atomic",
+        "--no-atomic",
+        "--ipv4",
+        "--ipv6",
+        "--thin",
+        "--no-thin",
+    }
+)
+# Ref-neutral value flags (skip the flag AND its value token). ``--repo`` is a
+# value flag but broadens/redirects the push, so it is deliberately EXCLUDED.
+_PUSH_SAFE_VALUE_FLAGS = frozenset({"-o", "--push-option", "--receive-pack", "--exec"})
+# Ref-neutral short-flag letters (for bundles like ``-uq``). ``o`` is handled
+# separately (glued push-option value). ``f`` (force) and ``d`` (delete) are absent
+# by design — a bundle containing either is not a plain current-branch update.
+_PUSH_SAFE_SHORT_LETTERS = frozenset("uvqn46")
+
 
 def _push_is_force(argv: list[str]) -> bool:
     """Whether a parsed ``git push`` argv performs a force push.
@@ -749,6 +769,225 @@ def _push_repo_flag(argv: list[str]) -> str | None:
     return None
 
 
+def _push_positionals(argv) -> list[str]:
+    """The bare positional args of a ``git push`` (``[remote, refspec, ...]``).
+
+    Parsed from a quote-stripped argv, mirroring ``_push_named_remote``: git global
+    options/values, the ``push`` token, and push flags/values are all skipped —
+    including no-value flags (``-u`` / ``--set-upstream`` / ``--force-with-lease``)
+    which take NO separate token, and value flags (``_PUSH_VALUE_FLAGS``:
+    ``-o`` / ``--push-option`` / ``--repo`` / ``--receive-pack`` / ``--exec``) which
+    take one. A ``+<refspec>`` (force) positional is excluded. Empty if not a push.
+    """
+    argv = argv or []
+    i = 1  # skip argv[0] == "git"
+    # advance past git global options (and their values) to the `push` token
+    while i < len(argv):
+        t = argv[i]
+        if t in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        break
+    if i >= len(argv) or argv[i] != "push":
+        return []
+    i += 1
+    out: list[str] = []
+    while i < len(argv):
+        t = argv[i]
+        if t in _PUSH_VALUE_FLAGS:
+            i += 2
+            continue
+        if t.startswith("-") or t.startswith("+"):
+            i += 1
+            continue
+        out.append(t)
+        i += 1
+    return out
+
+
+# push.default modes that push the CURRENT branch to a SAME-NAMED remote ref (or
+# refuse). `upstream`/`tracking` push to a possibly-differently-named upstream, and
+# `matching` pushes every same-named branch — both broaden beyond a plain
+# current-branch update. Unset defaults to `simple` (safe), so it need not appear.
+_SAFE_PUSH_DEFAULTS = frozenset({"simple", "current"})
+
+
+def _git_config_get(base: list[str], key: str, *, all_values: bool = False, as_bool: bool = False):
+    """Read a git config value. Returns ``(rc, stripped_stdout)``, or ``None`` on a
+    read error / timeout / UNEXPECTED return code.
+
+    git config exits 0 when the key is set and 1 when it is absent; any other code
+    (bad config file, etc.) is an error the caller must treat as fail-closed — so
+    an empty stdout under rc 2/128 is NOT mistaken for "unset". ``as_bool`` reads via
+    ``--type=bool`` so every boolean spelling (``TRUE`` / ``on`` / the valueless
+    ``[section]\\n\\tkey`` shorthand) normalizes to a canonical ``"true"``/``"false"``.
+
+    NOTE: this reads the effective REPO config; it does NOT see a command-line
+    ``git -c key=val`` override on the push itself (tabled residue — the config
+    check is best-effort for the common repo-config case, not a hard boundary).
+    """
+    args = ["config"]
+    if as_bool:
+        args.append("--type=bool")
+    args.append("--get-all" if all_values else "--get")
+    args.append(key)
+    try:
+        r = subprocess.run(base + args, capture_output=True, text=True, timeout=5)
+    except Exception:
+        return None
+    if r.returncode not in (0, 1):
+        return None
+    return r.returncode, r.stdout.strip()
+
+
+# push.recurseSubmodules values that do NOT push submodule commits (safe). Anything
+# else (on-demand / only / a boolean-true spelling) side-channels a submodule push.
+_SAFE_RECURSE_SUBMODULES = frozenset({"no", "false", "off", "0", "check"})
+
+
+def _push_config_is_simple(remote: str | None, cwd: str | None = None) -> bool:
+    """Whether a bare / remote-only push updates ONLY the current branch under the
+    effective REPO config — ALLOWLIST posture (mirrors ``_push_targets_current_branch``).
+
+    Broadening/redirecting knobs checked (each case-insensitive):
+      • ``remote.<remote>.push`` refspec (``push = HEAD:main`` → sends HEAD to main);
+      • ``push.default`` other than ``simple``/``current`` (``upstream``/``tracking``
+        push cur to a differently-named upstream; ``matching`` pushes every
+        same-named branch);
+      • ``push.recurseSubmodules``/``submodule.recurse`` (side-channel-publishes
+        submodule commits).
+    Simple ONLY when NONE is set to a broadening value. Fail-closed: an unresolved
+    remote, any of the above, or any config-read error → False (prompt).
+
+    BEST-EFFORT, not a hard boundary (`remote` is already resolved with git's
+    pushRemote/pushDefault precedence by the caller). It reads REPO config only, so a
+    command-line ``git -c key=val push`` override, ``remote.<remote>.mirror``,
+    ``push.followTags``, or a ``url.*.pushInsteadOf`` rewrite are NOT caught — tabled
+    adversarial residue (each needs a deliberately unusual command / hostile config,
+    and `git config` writes are already soft-warned). Bounded by 5s timeouts.
+    """
+    if not remote:
+        return False
+    base = ["git"] + (["-C", cwd] if cwd else [])
+    # 1. A configured push refspec can redirect/broaden the destination.
+    got = _git_config_get(base, f"remote.{remote}.push", all_values=True)
+    if got is None:
+        return False
+    rc, out = got
+    if rc == 0 and out:
+        return False
+    # 2. push.default must be a same-name mode (unset → simple → safe).
+    got = _git_config_get(base, "push.default")
+    if got is None:
+        return False
+    rc, out = got
+    if rc == 0 and out and out.lower() not in _SAFE_PUSH_DEFAULTS:
+        return False
+    # 3. Submodule recursion would also publish submodule commits (a side channel).
+    got = _git_config_get(base, "push.recurseSubmodules")
+    if got is None:
+        return False
+    rc, out = got
+    if rc == 0 and out and out.lower() not in _SAFE_RECURSE_SUBMODULES:
+        return False  # on-demand / only / true → pushes submodule commits
+    # submodule.recurse is a boolean — read via --type=bool so TRUE / on / the
+    # valueless shorthand all normalize to a canonical "true".
+    got = _git_config_get(base, "submodule.recurse", as_bool=True)
+    if got is None:
+        return False
+    rc, out = got
+    return not (rc == 0 and out == "true")
+
+
+def _push_targets_current_branch(
+    seg, cur: str | None, remote: str | None, cwd: str | None = None
+) -> bool:
+    """Whether a non-force ``git push`` seg plainly UPDATES the current branch ``cur``.
+
+    ``remote`` is the destination the push will ACTUALLY go to, resolved by the
+    caller with git's pushRemote/pushDefault precedence (``_effective_push_remote``).
+
+    ALLOWLIST posture — the branch checked against the remote is always ``cur``
+    itself, never a parsed destination. True ONLY when BOTH hold:
+      1. Every flag after ``push`` is ref-set-neutral — a member of
+         ``_PUSH_SAFE_LONG_FLAGS`` / ``_PUSH_SAFE_VALUE_FLAGS``, or a short bundle
+         whose every letter is in ``_PUSH_SAFE_SHORT_LETTERS`` (``o`` = glued
+         push-option value). ANY other flag (``--all`` / ``--tags`` / ``--delete``
+         / a bundled ``-d`` / ``--stdin`` / ``--repo`` / unknown) → False.
+      2. The positionals name a plain current-branch update:
+         • ``git push <remote> <cur>`` (no ``src:dst`` colon) → an explicit refspec
+           overrides ``remote.push`` / ``push.default`` / ``pushRemote`` → True;
+         • bare ``git push`` / ``git push <remote>`` → True only if
+           ``_push_config_is_simple(remote)`` (no redirecting/broadening repo config);
+         • a colon refspec, a differently-named branch, or ≥2 refspecs → False.
+    Conservative by construction: any unrecognized form re-prompts. argv-based
+    (quote-stripped).
+    """
+    if not cur:
+        return False
+    argv = getattr(seg, "argv", None) or []
+    # Advance past git global options to the `push` token.
+    i = 1
+    while i < len(argv):
+        t = argv[i]
+        if t in _GIT_GLOBAL_VALUE_FLAGS:
+            i += 2
+            continue
+        if t.startswith("-"):
+            i += 1
+            continue
+        break
+    if i >= len(argv) or argv[i] != "push":
+        return False
+    i += 1
+    positionals: list[str] = []
+    while i < len(argv):
+        t = argv[i]
+        if t in _PUSH_SAFE_VALUE_FLAGS:
+            i += 2  # ref-neutral value flag: skip the flag and its value token
+            continue
+        if t.startswith("--"):
+            base = t.split("=", 1)[0]
+            if "=" in t and base in _PUSH_SAFE_VALUE_FLAGS:
+                i += 1  # --push-option=value etc.
+                continue
+            if "=" not in t and base in _PUSH_SAFE_LONG_FLAGS:
+                i += 1
+                continue
+            return False  # unknown/broadening long flag (or a =form of a no-value flag)
+        if t.startswith("+"):
+            return False  # +<refspec> force shorthand
+        if t.startswith("-") and len(t) > 1:
+            # Short single/bundle — every letter must be ref-neutral. An `o` starts a
+            # glued push-option value, so the rest of the token is that value.
+            safe = True
+            for ch in t[1:]:
+                if ch == "o":
+                    break
+                if ch not in _PUSH_SAFE_SHORT_LETTERS:
+                    safe = False
+                    break
+            if not safe:
+                return False
+            i += 1
+            continue
+        positionals.append(t)
+        i += 1
+    if len(positionals) >= 3:
+        return False  # multiple refspecs → not a single plain current-branch update
+    if len(positionals) == 2:
+        refspec = positionals[1]
+        # Explicit `<remote> <cur>` — an explicit refspec overrides remote.push /
+        # push.default / pushRemote, so it is a plain current-branch update.
+        return ":" not in refspec and refspec == cur
+    # Bare `git push` or `git push <remote>` → the ref set depends on repo config,
+    # keyed on the remote git will ACTUALLY push to (resolved by the caller).
+    return _push_config_is_simple(remote, cwd=cwd)
+
+
 def _resolve_push_remote(seg, cwd: str | None = None) -> str | None:
     """The push DESTINATION (remote name or URL) for a segment, or None if UNKNOWN.
 
@@ -777,6 +1016,30 @@ def _resolve_push_remote(seg, cwd: str | None = None) -> str | None:
     except Exception:
         pass
     return None
+
+
+def _effective_push_remote(seg, cur: str | None, cwd: str | None = None) -> str | None:
+    """The remote a ``git push`` will ACTUALLY push to, honoring git's precedence.
+
+    An explicit ``--repo`` or positional remote wins. For a bare ``git push`` git
+    picks, in order: ``branch.<cur>.pushRemote`` → ``remote.pushDefault`` →
+    ``branch.<cur>.remote`` (the ``@{upstream}`` remote) → ``origin``. The
+    republish + config checks MUST target this remote, not the fetch/upstream
+    remote — otherwise a triangular fork workflow (pull from origin, push to fork)
+    checks the wrong remote and can silently allow a first push to the fork.
+    """
+    argv = getattr(seg, "argv", None) or []
+    if _push_repo_flag(argv) or _push_named_remote(argv):
+        return _resolve_push_remote(seg, cwd=cwd)  # explicit --repo / positional wins
+    base = ["git"] + (["-C", cwd] if cwd else [])
+    if cur:
+        got = _git_config_get(base, f"branch.{cur}.pushRemote")
+        if got and got[0] == 0 and got[1]:
+            return got[1]
+    got = _git_config_get(base, "remote.pushDefault")
+    if got and got[0] == 0 and got[1]:
+        return got[1]
+    return _resolve_push_remote(seg, cwd=cwd) or "origin"
 
 
 def _looks_like_url(dest: str) -> bool:
@@ -824,6 +1087,47 @@ def _push_dest_urls(dest: str, cwd: str | None = None) -> set[str]:
     if _looks_like_url(dest):
         return {dest}
     return set()
+
+
+def _remote_branch_sha(remote: str, branch: str, cwd: str | None = None) -> str | None:
+    """The remote's tip sha for EXACTLY ``refs/heads/<branch>``, or None.
+
+    Queries the LIVE remote via ``git ls-remote`` (not a local remote-tracking
+    ref, which goes stale the moment a remote branch is deleted). Accepts only the
+    line whose ref path is EXACTLY ``refs/heads/<branch>`` — a bare pattern
+    tail-matches namespaced refs. Fail-safe: None on rc!=0 / timeout / any error /
+    absent branch — callers treat None as "not confirmed present". Bounded by a 10s
+    timeout inside the hook's 60s budget.
+    """
+    try:
+        args = ["git"] + (["-C", cwd] if cwd else []) + ["ls-remote", "--heads", remote, branch]
+        result = subprocess.run(args, capture_output=True, text=True, timeout=10)
+        if result.returncode != 0:
+            return None
+        target_ref = f"refs/heads/{branch}"
+        for ln in result.stdout.splitlines():
+            parts = ln.split()
+            if len(parts) >= 2 and parts[1] == target_ref:
+                return parts[0]
+    except Exception:
+        pass
+    return None
+
+
+def _push_is_republish(remote: str | None, branch: str | None, cwd: str | None = None) -> bool:
+    """Whether this push targets a branch ALREADY on ``remote`` (a re-push).
+
+    A branch's FIRST push creates it on the remote (and prompted the user for
+    approval); a re-push updates that already-published branch. So a branch present
+    on the remote was approved on its first push and must not re-prompt. Fail-safe:
+    an unresolved remote/branch, or any ls-remote error/timeout/absence, → False
+    (fall through to the approval prompt). Deliberately does NOT check for unpushed
+    commits — re-pushing new fixes to an already-published branch is exactly the
+    case we allow.
+    """
+    if not remote or not branch:
+        return False
+    return _remote_branch_sha(remote, branch, cwd=cwd) is not None
 
 
 def _ask(reason: str) -> int:
@@ -944,23 +1248,11 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
         ).stdout.strip()
         if not head_sha:
             return True  # can't resolve HEAD → gate
-        remote = subprocess.run(
-            ["git", "ls-remote", "--heads", "origin", branch],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if remote.returncode != 0:
-            return True  # cannot reach/read the remote → gate (fail-safe)
-        target_ref = f"refs/heads/{branch}"
-        remote_sha = ""
-        for ln in remote.stdout.splitlines():
-            parts = ln.split()
-            if len(parts) >= 2 and parts[1] == target_ref:
-                remote_sha = parts[0]
-                break
+        # Live-remote check via ls-remote (exact refs/heads/<branch>), shared with
+        # the push republish gate. None ⇒ unreachable OR branch absent → gate.
+        remote_sha = _remote_branch_sha("origin", branch)
         if not remote_sha:
-            return True  # current branch not on the remote → gh would push it → gate
+            return True  # cannot reach the remote, or branch not on it → gh would push → gate
         if head_sha == remote_sha:
             return False  # current branch tip is on the remote → nothing to push
         # HEAD differs from the remote tip: un-gate only if HEAD is already
@@ -1082,7 +1374,7 @@ def main() -> int:
                 # Fall through: any hard-block below still takes precedence.
             else:
                 # Non-force push: interactive asks, dispatched hard-denies.
-                _remote, branch = _get_push_remote_and_branch(cmd, cwd=pcwd)
+                _remote, branch = _get_push_remote_and_branch(push_segs[0], cwd=pcwd)
                 if _is_dispatched():
                     print(
                         f"BLOCKED: git push requires user approval before "
@@ -1095,6 +1387,40 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     return 2
+                # Prompt only on the FIRST push of a branch/PR. A branch already on
+                # the remote was published — and approved — on its first push, so a
+                # re-push of fixes to the SAME branch must not re-prompt (user
+                # directive 2026-07-30). The check is deliberately narrow — it fires
+                # ONLY for a plain update of the CURRENT branch, and the ref checked
+                # against the remote is always ``cur`` itself (never a parsed
+                # destination). Each guard fails safe toward the prompt:
+                #   • not pcwd_unknown → an ambiguous cwd can't resolve the branch;
+                #   • cur truthy → a real (non-detached) current branch;
+                #   • cur not in (main, master) → a push to the default branch never
+                #     goes silent (it is always on the remote);
+                #   • _push_targets_current_branch → a bare / `<remote>` / `<remote>
+                #     <cur>` push with only ref-neutral flags and (for bare/remote-only)
+                #     a simple repo config — everything else prompts;
+                #   • _push_is_republish → live ls-remote confirms `cur` is present on
+                #     the remote git will ACTUALLY push to (pushRemote/pushDefault
+                #     resolved by _effective_push_remote, so a triangular fork workflow
+                #     checks the fork, not the upstream).
+                # Dispatched sessions were hard-denied above, so this _allow is
+                # unreachable for them (the human-not-agent boundary is preserved;
+                # this only relaxes RE-approval of an already-approved branch).
+                cur = _current_branch(cwd=pcwd)
+                push_remote = _effective_push_remote(push_segs[0], cur, cwd=pcwd)
+                if (
+                    not pcwd_unknown
+                    and cur
+                    and cur not in ("main", "master")
+                    and _push_targets_current_branch(push_segs[0], cur, push_remote, cwd=pcwd)
+                    and _push_is_republish(push_remote, cur, pcwd)
+                ):
+                    return _allow(
+                        f"re-push to '{cur}' (already on the remote — approved on "
+                        f"its first push); only the first push of a branch/PR prompts."
+                    )
                 ask_reason = (
                     f"git push needs your approval before publishing externally "
                     f"(target: {branch or 'default'})."

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -669,9 +669,11 @@ _PUSH_SAFE_LONG_FLAGS = frozenset(
         "--no-thin",
     }
 )
-# Ref-neutral value flags (skip the flag AND its value token). ``--repo`` is a
-# value flag but broadens/redirects the push, so it is deliberately EXCLUDED.
-_PUSH_SAFE_VALUE_FLAGS = frozenset({"-o", "--push-option", "--receive-pack", "--exec"})
+# Ref-neutral value flags (skip the flag AND its value token). ``--repo`` (redirects
+# the push) and ``--receive-pack``/``--exec`` (select a receive-pack PROGRAM that git
+# EXECUTES on local/SSH transports — an arbitrary-code vector) are deliberately
+# EXCLUDED, so a push carrying any of them falls through to the approval prompt.
+_PUSH_SAFE_VALUE_FLAGS = frozenset({"-o", "--push-option"})
 # Ref-neutral short-flag letters (for bundles like ``-uq``). ``o`` is handled
 # separately (glued push-option value). ``f`` (force) and ``d`` (delete) are absent
 # by design — a bundle containing either is not a plain current-branch update.
@@ -854,6 +856,8 @@ def _push_config_is_simple(remote: str | None, cwd: str | None = None) -> bool:
 
     Broadening/redirecting knobs checked (each case-insensitive):
       • ``remote.<remote>.push`` refspec (``push = HEAD:main`` → sends HEAD to main);
+      • ``remote.<remote>.mirror`` (a bare push mirrors ALL refs — force-updates /
+        deletes unrelated remote refs);
       • ``push.default`` other than ``simple``/``current`` (``upstream``/``tracking``
         push cur to a differently-named upstream; ``matching`` pushes every
         same-named branch);
@@ -878,6 +882,13 @@ def _push_config_is_simple(remote: str | None, cwd: str | None = None) -> bool:
         return False
     rc, out = got
     if rc == 0 and out:
+        return False
+    # 1b. remote.<remote>.mirror makes a bare push mirror EVERY ref (force/delete).
+    got = _git_config_get(base, f"remote.{remote}.mirror", as_bool=True)
+    if got is None:
+        return False
+    rc, out = got
+    if rc == 0 and out == "true":
         return False
     # 2. push.default must be a same-name mode (unset → simple → safe).
     got = _git_config_get(base, "push.default")
@@ -1313,6 +1324,11 @@ def main() -> int:
         # gates, sqlite, --no-verify) still takes precedence — a compound
         # `git push && git commit --no-verify` blocks, never asks.
         ask_reason: str | None = None
+        # A first-push-only re-push AUTO-ALLOW is ALSO deferred to the END (same
+        # reason): emitting `_allow` inline would short-circuit the whole Bash
+        # invocation before the hard-blocks run, so `git push <republish> && git
+        # commit --no-verify` would sail through. Set the reason here; emit at the tail.
+        push_allow_reason: str | None = None
 
         # ── git push (any branch) ──────────────────────────────────
         # Interactive → the user approves in a dialog only they can satisfy.
@@ -1417,14 +1433,17 @@ def main() -> int:
                     and _push_targets_current_branch(push_segs[0], cur, push_remote, cwd=pcwd)
                     and _push_is_republish(push_remote, cur, pcwd)
                 ):
-                    return _allow(
+                    # Deferred (NOT an inline return) so any hard-block in a compound
+                    # command still takes precedence — see push_allow_reason above.
+                    push_allow_reason = (
                         f"re-push to '{cur}' (already on the remote — approved on "
                         f"its first push); only the first push of a branch/PR prompts."
                     )
-                ask_reason = (
-                    f"git push needs your approval before publishing externally "
-                    f"(target: {branch or 'default'})."
-                )
+                else:
+                    ask_reason = (
+                        f"git push needs your approval before publishing externally "
+                        f"(target: {branch or 'default'})."
+                    )
 
         # ── git merge into main ─────────────────────────────────────
         # Worktree-aware AND compound-aware: EVERY git-merge in the command is
@@ -1625,6 +1644,12 @@ def main() -> int:
         # native approve/deny dialog for its push / PR-create.
         if ask_reason is not None:
             return _ask(ask_reason)
+
+        # A first-push-only re-push auto-allow — emitted ONLY here, after every
+        # hard-block has had its chance to return 2, so a compound
+        # `git push <republish> && git commit --no-verify` still hard-blocks.
+        if push_allow_reason is not None:
+            return _allow(push_allow_reason)
 
         # A standalone, un-gated `gh pr create` (branch already on the remote, or
         # an explicit --head that gh won't push): reaching here means nothing

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -24,8 +24,16 @@ sys.path.insert(0, str(_SCRIPTS))
 from shell_parse import (  # noqa: E402
     analyze,
     gh_pr_subcommand,
+    git_subcommand,
     has_trailing_override,
 )
+
+
+def _push_seg(command: str):
+    """The git-push Segment parsed from a command string (for argv-based helpers)."""
+    return next(
+        s for s in analyze(command) if s.exe == "git" and git_subcommand(s.argv) == "push"
+    )
 
 
 def _run_guard(
@@ -79,6 +87,20 @@ def _rc(code: int) -> subprocess.CompletedProcess:
 def _proc(code: int, out: str = "") -> subprocess.CompletedProcess:
     """A fake CompletedProcess carrying a returncode and stdout."""
     return subprocess.CompletedProcess(args=[], returncode=code, stdout=out)
+
+
+def _config_run(values: dict, default: tuple = (1, "")):
+    """A ``subprocess.run`` side_effect mapping a git-config KEY (the last argv
+    token) to ``(rc, stdout)``. Unlisted keys resolve to ``default`` = ``(1, "")``
+    (git's "unset" signal). Order/count-independent — robust to how many config
+    reads _push_config_is_simple performs."""
+
+    def run(argv, **kwargs):
+        key = argv[-1]
+        rc, out = values.get(key, default)
+        return _proc(rc, out)
+
+    return run
 
 
 class TestPrCreateHeadRaw:
@@ -285,6 +307,432 @@ class TestPrCreateWouldPublish:
             ),
         ):
             assert guard_module._pr_create_would_publish(["gh", "pr", "create"]) is True
+
+
+# ── _remote_branch_sha / _push_is_republish (first-push gate) ────────
+
+
+class TestRemoteBranchSha:
+    """_remote_branch_sha queries the LIVE remote (git ls-remote) and returns the
+    tip sha for EXACTLY refs/heads/<branch>, else None (fail-safe). Shared by the
+    pr-create gate and the first-push republish gate."""
+
+    def test_exact_ref_returns_sha(self, guard_module):
+        with patch.object(
+            guard_module.subprocess, "run", return_value=_proc(0, "abc123\trefs/heads/feat")
+        ):
+            assert guard_module._remote_branch_sha("origin", "feat") == "abc123"
+
+    def test_namespaced_ref_not_matched(self, guard_module):
+        # querying "feat" can tail-match refs/heads/ws8/feat — must NOT accept it.
+        with patch.object(
+            guard_module.subprocess, "run", return_value=_proc(0, "aaa111\trefs/heads/ws8/feat")
+        ):
+            assert guard_module._remote_branch_sha("origin", "feat") is None
+
+    def test_exact_line_among_many_used(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=_proc(0, "aaa\trefs/heads/ws8/feat\nbbb\trefs/heads/feat"),
+        ):
+            assert guard_module._remote_branch_sha("origin", "feat") == "bbb"
+
+    def test_absent_returns_none(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", return_value=_proc(0, "")):
+            assert guard_module._remote_branch_sha("origin", "feat") is None
+
+    def test_rc_nonzero_returns_none(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", return_value=_proc(2, "")):
+            assert guard_module._remote_branch_sha("origin", "feat") is None
+
+    def test_timeout_returns_none(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=10),
+        ):
+            assert guard_module._remote_branch_sha("origin", "feat") is None
+
+    def test_oserror_returns_none(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=OSError("boom")):
+            assert guard_module._remote_branch_sha("origin", "feat") is None
+
+    def test_cwd_passed_as_dash_C(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", return_value=_proc(0, "")) as run:
+            guard_module._remote_branch_sha("origin", "feat", cwd="/wt")
+        argv = run.call_args_list[0].args[0]
+        assert argv[:3] == ["git", "-C", "/wt"]
+        assert "ls-remote" in argv
+
+    def test_no_cwd_omits_dash_C(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", return_value=_proc(0, "")) as run:
+            guard_module._remote_branch_sha("origin", "feat")
+        argv = run.call_args_list[0].args[0]
+        assert argv[0] == "git" and argv[1] == "ls-remote"
+
+
+class TestPushIsRepublish:
+    """_push_is_republish: True iff the branch is already on the remote (published
+    and approved on its first push). Fail-safe to False (→ prompt) on any
+    uncertainty — an unresolved remote/branch never triggers a network call."""
+
+    def test_present_is_republish(self, guard_module):
+        with patch.object(guard_module, "_remote_branch_sha", return_value="abc123"):
+            assert guard_module._push_is_republish("origin", "feat") is True
+
+    def test_absent_is_not_republish(self, guard_module):
+        with patch.object(guard_module, "_remote_branch_sha", return_value=None):
+            assert guard_module._push_is_republish("origin", "feat") is False
+
+    def test_none_remote_short_circuits(self, guard_module):
+        # unresolved remote → never republish; must NOT touch the remote.
+        with patch.object(guard_module, "_remote_branch_sha", side_effect=AssertionError):
+            assert guard_module._push_is_republish(None, "feat") is False
+
+    def test_none_branch_short_circuits(self, guard_module):
+        with patch.object(guard_module, "_remote_branch_sha", side_effect=AssertionError):
+            assert guard_module._push_is_republish("origin", None) is False
+
+    def test_cwd_forwarded(self, guard_module):
+        with patch.object(guard_module, "_remote_branch_sha", return_value="x") as srch:
+            guard_module._push_is_republish("origin", "feat", cwd="/wt")
+        assert srch.call_args_list[0].kwargs.get("cwd") == "/wt"
+
+
+class TestPushPositionals:
+    """_push_positionals extracts [remote, refspec, ...] from a quote-stripped push
+    argv, correctly skipping no-value flags (-u/--set-upstream — which do NOT eat
+    the next token) and value flags (-o <v>). Empty for a non-push / bare push."""
+
+    def test_bare_push(self, guard_module):
+        assert guard_module._push_positionals(["git", "push"]) == []
+
+    def test_remote_only(self, guard_module):
+        assert guard_module._push_positionals(["git", "push", "origin"]) == ["origin"]
+
+    def test_remote_and_branch(self, guard_module):
+        assert guard_module._push_positionals(["git", "push", "origin", "feat"]) == ["origin", "feat"]
+
+    def test_set_upstream_does_not_eat_remote(self, guard_module):
+        # Regression for the naive-split bug: -u / --set-upstream take NO separate
+        # token, so 'origin' must remain a positional (not be consumed as a value).
+        assert guard_module._push_positionals(["git", "push", "-u", "origin", "feat"]) == [
+            "origin",
+            "feat",
+        ]
+        assert guard_module._push_positionals(
+            ["git", "push", "--set-upstream", "origin", "feat"]
+        ) == ["origin", "feat"]
+
+    def test_value_flag_skips_its_value(self, guard_module):
+        assert guard_module._push_positionals(
+            ["git", "push", "-o", "ci.skip", "origin", "feat"]
+        ) == ["origin", "feat"]
+
+    def test_global_dash_c_skipped(self, guard_module):
+        assert guard_module._push_positionals(
+            ["git", "-C", "/wt", "push", "origin", "feat"]
+        ) == ["origin", "feat"]
+
+    def test_plus_refspec_excluded(self, guard_module):
+        # +feat is force shorthand → skipped (force is handled in a separate arm).
+        assert guard_module._push_positionals(["git", "push", "origin", "+feat"]) == ["origin"]
+
+    def test_not_a_push(self, guard_module):
+        assert guard_module._push_positionals(["git", "commit", "-m", "x"]) == []
+
+
+class TestPushConfigIsSimple:
+    """_push_config_is_simple: True only when NO config broadens a bare/remote-only
+    push — no `remote.<remote>.push` refspec, push.default in {unset, simple,
+    current}, and no submodule push-recursion. Fail-CLOSED on any config-read
+    error / unresolved remote."""
+
+    def test_all_unset_is_simple(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=_config_run({})):
+            assert guard_module._push_config_is_simple("origin") is True
+
+    def test_custom_push_refspec_not_simple(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"remote.origin.push": (0, "HEAD:main")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_push_default_simple_ok(self, guard_module):
+        with patch.object(
+            guard_module.subprocess, "run", side_effect=_config_run({"push.default": (0, "simple")})
+        ):
+            assert guard_module._push_config_is_simple("origin") is True
+
+    def test_push_default_current_ok(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.default": (0, "current")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is True
+
+    def test_push_default_matching_not_simple(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.default": (0, "matching")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_push_default_upstream_not_simple(self, guard_module):
+        # Regression (round-3 BLOCKER): upstream pushes cur to a possibly
+        # differently-named upstream branch (e.g. feat → origin/main).
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.default": (0, "upstream")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_push_default_tracking_not_simple(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.default": (0, "tracking")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_recurse_submodules_on_demand_not_simple(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.recurseSubmodules": (0, "on-demand")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_recurse_submodules_check_ok(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.recurseSubmodules": (0, "check")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is True
+
+    def test_recurse_submodules_false_ok(self, guard_module):
+        # `false` is git-equivalent to `no` → safe (was wrongly rejected before).
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.recurseSubmodules": (0, "false")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is True
+
+    def test_push_default_case_insensitive(self, guard_module):
+        # git enum values are case-insensitive — Matching must still be rejected.
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"push.default": (0, "Matching")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_submodule_recurse_true_not_simple(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"submodule.recurse": (0, "true")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_config_read_error_fails_closed(self, guard_module):
+        # rc 128 (bad config) with empty stdout must NOT be read as "unset".
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"remote.origin.push": (128, "")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
+    def test_none_remote_not_simple(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=AssertionError):
+            assert guard_module._push_config_is_simple(None) is False
+
+    def test_exception_fails_closed(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=OSError("boom")):
+            assert guard_module._push_config_is_simple("origin") is False
+
+
+class TestPushTargetsCurrentBranch:
+    """_push_targets_current_branch(seg, cur, remote) (ALLOWLIST posture) is True
+    ONLY for a plain current-branch update: bare / `<remote>` (with simple config)
+    or explicit `<remote> <cur>`, carrying only ref-neutral flags. `remote` is the
+    caller-resolved effective push remote. Every cross-name / delete / broadening /
+    unknown-flag / bundled-delete form is False."""
+
+    def _t(self, guard_module, cmd, cur):
+        return guard_module._push_targets_current_branch(_push_seg(cmd), cur, "origin")
+
+    # ── explicit `<remote> <cur>` → no config subprocess ──
+
+    def test_explicit_current_branch(self, guard_module):
+        assert self._t(guard_module, "git push origin feat", "feat") is True
+
+    def test_set_upstream_current_branch(self, guard_module):
+        assert self._t(guard_module, "git push -u origin feat", "feat") is True
+
+    def test_safe_short_bundle_ok(self, guard_module):
+        # -uv = --set-upstream --verbose (ref-neutral) with explicit current branch.
+        assert self._t(guard_module, "git push -uv origin feat", "feat") is True
+
+    def test_push_option_value_flag_ok(self, guard_module):
+        assert self._t(guard_module, "git push -o ci.skip origin feat", "feat") is True
+
+    def test_push_option_glued_ok(self, guard_module):
+        assert self._t(guard_module, "git push -oci.skip origin feat", "feat") is True
+
+    def test_different_named_branch_false(self, guard_module):
+        # `git push -u origin other` while on feat → NOT a current-branch update.
+        assert self._t(guard_module, "git push -u origin other", "feat") is False
+
+    def test_colon_refspec_false(self, guard_module):
+        assert self._t(guard_module, "git push origin feat:main", "feat") is False
+
+    def test_delete_refspec_false(self, guard_module):
+        assert self._t(guard_module, "git push origin :feat", "feat") is False
+
+    # ── broadening / unknown / bundled-delete flags → False (allowlist rejects) ──
+
+    def test_broadening_all_false(self, guard_module):
+        assert self._t(guard_module, "git push --all origin", "feat") is False
+
+    def test_broadening_tags_false(self, guard_module):
+        assert self._t(guard_module, "git push --tags origin", "feat") is False
+
+    def test_broadening_delete_flag_false(self, guard_module):
+        assert self._t(guard_module, "git push --delete origin feat", "feat") is False
+
+    def test_broadening_repo_flag_false(self, guard_module):
+        assert self._t(guard_module, "git push --repo origin feat", "feat") is False
+
+    def test_stdin_flag_false(self, guard_module):
+        assert self._t(guard_module, "git push --stdin origin", "feat") is False
+
+    def test_follow_tags_false(self, guard_module):
+        assert self._t(guard_module, "git push --follow-tags origin", "feat") is False
+
+    def test_bundled_delete_false(self, guard_module):
+        # -ud / -du / -qd all carry `d` (delete) → rejected by the short-letter scan.
+        for cmd in ("git push -ud origin feat", "git push -du origin feat", "git push -qd origin feat"):
+            assert self._t(guard_module, cmd, "feat") is False, cmd
+
+    # ── bare / remote-only → gated on _push_config_is_simple (mocked) ──
+
+    def test_bare_push_simple_config_true(self, guard_module):
+        with patch.object(guard_module, "_push_config_is_simple", return_value=True):
+            assert self._t(guard_module, "git push", "feat") is True
+
+    def test_bare_push_nonsimple_config_false(self, guard_module):
+        with patch.object(guard_module, "_push_config_is_simple", return_value=False):
+            assert self._t(guard_module, "git push", "feat") is False
+
+    def test_remote_only_uses_effective_remote(self, guard_module):
+        # The config check keys on the caller-resolved `remote`, not positionals[0].
+        with patch.object(guard_module, "_push_config_is_simple", return_value=True) as cfg:
+            assert self._t(guard_module, "git push origin", "feat") is True
+        assert cfg.call_args_list[0].args[0] == "origin"
+
+    def test_detached_or_empty_false(self, guard_module):
+        assert self._t(guard_module, "git push", "") is False
+        assert self._t(guard_module, "git push", None) is False
+
+
+class TestGetPushRemoteAndBranch:
+    """_get_push_remote_and_branch resolves (remote, dst-branch) from the argv —
+    fixing the naive-split bug where -u/--set-upstream ate the remote token."""
+
+    def test_set_upstream_does_not_eat_remote(self, guard_module):
+        # Regression: `git push -u origin feat` → remote=origin, branch=feat (NOT
+        # the current branch via the eaten-remote bug).
+        assert guard_module._get_push_remote_and_branch(_push_seg("git push -u origin feat")) == (
+            "origin",
+            "feat",
+        )
+
+    def test_refspec_dst(self, guard_module):
+        assert guard_module._get_push_remote_and_branch(
+            _push_seg("git push origin feat:main")
+        ) == ("origin", "main")
+
+    def test_bare_push_uses_current_branch(self, guard_module):
+        with patch.object(guard_module, "_current_branch", return_value="feat"):
+            assert guard_module._get_push_remote_and_branch(_push_seg("git push")) == (
+                "upstream",
+                "feat",
+            )
+
+    def test_remote_only_uses_current_branch(self, guard_module):
+        with patch.object(guard_module, "_current_branch", return_value="feat"):
+            assert guard_module._get_push_remote_and_branch(_push_seg("git push origin")) == (
+                "origin",
+                "feat",
+            )
+
+    def test_value_flag_not_mistaken_for_remote(self, guard_module):
+        assert guard_module._get_push_remote_and_branch(
+            _push_seg("git push -o ci.skip origin feat")
+        ) == ("origin", "feat")
+
+    def test_not_a_push_returns_none(self, guard_module):
+        seg = next(iter(analyze("git commit -m x")))
+        assert guard_module._get_push_remote_and_branch(seg) == (None, None)
+
+
+class TestEffectivePushRemote:
+    """_effective_push_remote follows git's real bare-push remote precedence:
+    explicit --repo/positional > branch.<cur>.pushRemote > remote.pushDefault >
+    @{upstream} remote > origin."""
+
+    def test_explicit_positional_remote(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=AssertionError):
+            assert (
+                guard_module._effective_push_remote(_push_seg("git push origin"), "feat") == "origin"
+            )
+
+    def test_explicit_repo_flag(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=AssertionError):
+            assert (
+                guard_module._effective_push_remote(_push_seg("git push --repo fork feat"), "feat")
+                == "fork"
+            )
+
+    def test_bare_uses_push_remote(self, guard_module):
+        # Regression (round-4 BLOCKER): triangular fork workflow — bare push goes to
+        # branch.<cur>.pushRemote, NOT the @{upstream} remote.
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"branch.feat.pushRemote": (0, "fork")}),
+        ):
+            assert guard_module._effective_push_remote(_push_seg("git push"), "feat") == "fork"
+
+    def test_bare_uses_push_default(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"remote.pushDefault": (0, "fork")}),
+        ):
+            assert guard_module._effective_push_remote(_push_seg("git push"), "feat") == "fork"
+
+    def test_bare_falls_back_to_upstream(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"@{upstream}": (0, "up/feat")}),
+        ):
+            assert guard_module._effective_push_remote(_push_seg("git push"), "feat") == "up"
+
+    def test_bare_defaults_to_origin(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", side_effect=_config_run({})):
+            assert guard_module._effective_push_remote(_push_seg("git push"), "feat") == "origin"
 
 
 # ── _check_pr_review_findings tests ─────────────────────────────────

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -535,6 +535,15 @@ class TestPushConfigIsSimple:
         ):
             assert guard_module._push_config_is_simple("origin") is False
 
+    def test_mirror_true_not_simple(self, guard_module):
+        # P1: remote.<remote>.mirror=true → a bare push mirrors ALL refs → not simple.
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            side_effect=_config_run({"remote.origin.mirror": (0, "true")}),
+        ):
+            assert guard_module._push_config_is_simple("origin") is False
+
     def test_submodule_recurse_true_not_simple(self, guard_module):
         with patch.object(
             guard_module.subprocess,
@@ -618,6 +627,14 @@ class TestPushTargetsCurrentBranch:
 
     def test_follow_tags_false(self, guard_module):
         assert self._t(guard_module, "git push --follow-tags origin", "feat") is False
+
+    def test_receive_pack_flag_false(self, guard_module):
+        # P1: --receive-pack/--exec select an EXECUTED program → not a plain re-push.
+        assert self._t(guard_module, "git push --receive-pack=/x origin feat", "feat") is False
+        assert self._t(guard_module, "git push --receive-pack /x origin feat", "feat") is False
+
+    def test_exec_flag_false(self, guard_module):
+        assert self._t(guard_module, "git push --exec=/x origin feat", "feat") is False
 
     def test_bundled_delete_false(self, guard_module):
         # -ud / -du / -qd all carry `d` (delete) → rejected by the short-letter scan.

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -28,6 +28,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest  # noqa: F401  (used by fixtures/tests appended below)
+
 _GUARD = Path(__file__).resolve().parents[2] / "scripts" / "hooks" / "git_push_guard.py"
 
 
@@ -394,3 +396,267 @@ def test_push_then_no_verify_hard_blocks_not_asks():
     assert res.returncode == 2
     assert _decision(res) is None
     assert "no-verify" in res.stderr
+
+
+# ── First-push-only gate (re-push to an already-published branch is un-gated) ──
+# The load-bearing new behavior gets a REAL local bare remote so the ALLOW path is
+# deterministic in CI (not dependent on the network / real origin). Mirrors
+# git_push_guard.py::_push_is_republish: a branch already on the remote was
+# approved on its first push, so a re-push must not re-prompt; a genuinely-first
+# push (branch absent) still asks; dispatched still hard-denies; force still blocks;
+# push-to-main / cross-name refspec still ask.
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _run_at(command: str, cwd: str, *, dispatched: bool = False) -> subprocess.CompletedProcess:
+    """Run the hook with an explicit payload cwd + matching process cwd (a real repo)."""
+    env = {
+        k: v for k, v in os.environ.items() if k not in ("CLAUDE_TOOL_INPUT", "GENESIS_CC_SESSION")
+    }
+    if dispatched:
+        env["GENESIS_CC_SESSION"] = "1"
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": cwd,
+        }
+    )
+    return subprocess.run(
+        [sys.executable, str(_GUARD)],
+        input=payload,
+        env=env,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=25,
+    )
+
+
+@pytest.fixture()
+def published_feat(tmp_path):
+    """A clone whose branch ``feat/x`` is ALREADY pushed to a local bare remote.
+
+    Returns the clone dir; the checked-out branch is ``feat/x`` (published) with
+    ``main`` also on the remote. No network — purely local git.
+    """
+    remote = tmp_path / "remote.git"
+    clone = tmp_path / "clone"
+    _git(tmp_path, "init", "--bare", str(remote))
+    _git(tmp_path, "clone", str(remote), str(clone))
+    _git(clone, "config", "user.email", "t@t.local")
+    _git(clone, "config", "user.name", "probe")
+    _git(clone, "checkout", "-b", "main")
+    (clone / "r.txt").write_text("root\n")
+    _git(clone, "add", "-A")
+    _git(clone, "commit", "-m", "root")
+    _git(clone, "push", "-u", "origin", "main")
+    _git(clone, "checkout", "-b", "feat/x")
+    (clone / "a.txt").write_text("hi\n")
+    _git(clone, "add", "-A")
+    _git(clone, "commit", "-m", "feat")
+    _git(clone, "push", "-u", "origin", "feat/x")
+    return str(clone)
+
+
+def test_republish_bare_push_allows(published_feat):
+    """On feat/x (already on the remote), a bare `git push` re-push → allow, no prompt."""
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
+
+
+def test_republish_explicit_push_allows(published_feat):
+    """`git push origin feat/x` for an already-published branch → allow."""
+    res = _run_at("git push origin feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
+
+
+def test_first_push_new_branch_asks(published_feat):
+    """A genuinely-first push of a NOT-yet-published branch still asks."""
+    _git(published_feat, "checkout", "-b", "feat/y")
+    (Path(published_feat) / "b.txt").write_text("y\n")
+    _git(published_feat, "add", "-A")
+    _git(published_feat, "commit", "-m", "y")
+    res = _run_at("git push -u origin feat/y", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_dispatched_republish_still_denied(published_feat):
+    """The human-not-agent boundary holds: a dispatched re-push is hard-denied,
+    never silently allowed."""
+    res = _run_at("git push", published_feat, dispatched=True)
+    assert res.returncode == 2
+    assert _decision(res) is None
+
+
+def test_republish_to_main_refspec_asks(published_feat):
+    """`git push origin feat/x:main` (dst=main) must still ask — a push to the
+    default branch never goes silent even though main is on the remote."""
+    res = _run_at("git push origin feat/x:main", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_cross_name_refspec_asks(published_feat):
+    """`git push origin feat/x:other` (dst != current branch) falls through to ask,
+    even if `other` exists on the remote."""
+    _git(published_feat, "branch", "other")
+    _git(published_feat, "push", "origin", "other")
+    res = _run_at("git push origin feat/x:other", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_force_republish_still_blocks(published_feat):
+    """A force re-push of an already-published branch is still HARD-blocked (the
+    force arm runs before the republish check)."""
+    res = _run_at("git push --force origin feat/x", published_feat)
+    assert res.returncode == 2
+    assert _decision(res) is None
+
+
+# ── REGRESSION (reviewer BLOCKER): the -u/--set-upstream parser must not collapse
+# the target branch to the current one and silently allow a genuine first push,
+# a push to main, a remote-branch delete, or a branch-broadening push. ──
+
+
+def test_set_upstream_new_branch_still_asks(published_feat):
+    """On the published `feat/x`, `git push -u origin feat/z` (a NOT-yet-pushed
+    branch) must ASK. The old naive parser ate the `origin` token and made
+    `branch == cur` a tautology, silently allowing this genuine first push."""
+    _git(published_feat, "branch", "feat/z")  # new local branch, unpublished; stay on feat/x
+    res = _run_at("git push -u origin feat/z", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_set_upstream_main_still_asks(published_feat):
+    """`git push -u origin main` while on a published feature branch must ASK — a
+    push to the default branch must never go silent."""
+    res = _run_at("git push -u origin main", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_delete_remote_branch_asks(published_feat):
+    """Deleting the current branch on the remote (`git push origin :feat/x`) is a
+    remote mutation, not a re-push → must ASK."""
+    res = _run_at("git push origin :feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_push_all_branches_asks(published_feat):
+    """`git push --all origin` publishes EVERY local branch — never a plain
+    current-branch re-push → must ASK."""
+    res = _run_at("git push --all origin", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_push_delete_flag_asks(published_feat):
+    """`git push --delete origin feat/x` deletes a remote branch → must ASK."""
+    res = _run_at("git push --delete origin feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+# ── REGRESSION (round-2 review): the allowlist predicate must reject bundled short
+# delete flags, --stdin, and config-broadened bare pushes — each a silent-allow
+# evasion of the first-push-only skip. ──
+
+
+def test_bundled_short_delete_asks(published_feat):
+    """`git push -ud origin feat/x` (= --set-upstream --delete) DELETES the remote
+    branch. A bundled short `d` must be caught by the allowlist's letter scan (like
+    `-uf` is caught as force) → ASK, not a silent destructive delete."""
+    res = _run_at("git push -ud origin feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_stdin_flag_asks(published_feat):
+    """`git push --stdin origin` reads refspecs from stdin (can target main / delete
+    / multiple refs) — not a plain current-branch update → ASK."""
+    res = _run_at("git push --stdin origin", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_config_push_refspec_asks(published_feat):
+    """A configured `remote.origin.push = HEAD:main` redirects a bare `git push
+    origin` to `main`. The effective-config check must catch it → ASK (a push to
+    the default branch must never go silent)."""
+    _git(published_feat, "config", "remote.origin.push", "HEAD:main")
+    res = _run_at("git push origin", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_push_default_matching_asks(published_feat):
+    """`push.default=matching` broadens a bare push to every same-named branch →
+    not a plain current-branch update → ASK."""
+    _git(published_feat, "config", "push.default", "matching")
+    res = _run_at("git push origin", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_safe_flags_still_allow(published_feat):
+    """Ref-neutral flags on an explicit current-branch re-push still ALLOW — the
+    allowlist must not over-prompt the normal `-o ci.skip` / `-uv` forms."""
+    res = _run_at("git push -uv -o ci.skip origin feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
+
+
+def test_push_default_upstream_asks(published_feat):
+    """REGRESSION (round-3 BLOCKER): with `push.default=upstream` and feat/x tracking
+    origin/main, a bare `git push` publishes feat/x's HEAD to `main`. The config
+    check must catch it → ASK (never a silent push to main)."""
+    _git(published_feat, "branch", "--set-upstream-to=origin/main", "feat/x")
+    _git(published_feat, "config", "push.default", "upstream")
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_push_default_tracking_asks(published_feat):
+    """`push.default=tracking` (deprecated alias of upstream) → same redirect risk → ASK."""
+    _git(published_feat, "branch", "--set-upstream-to=origin/main", "feat/x")
+    _git(published_feat, "config", "push.default", "tracking")
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_push_remote_triangular_asks(published_feat, tmp_path):
+    """REGRESSION (round-4 BLOCKER): a triangular fork workflow — pull from origin,
+    push to a `fork` remote via `branch.<cur>.pushRemote`. feat/x is on origin but
+    NOT on fork, so a bare `git push` is a genuine FIRST push to fork → must ASK.
+    The republish check must target the ACTUAL push remote (fork), not origin."""
+    fork = tmp_path / "fork.git"
+    _git(str(tmp_path), "init", "--bare", str(fork))
+    _git(published_feat, "remote", "add", "fork", str(fork))
+    _git(published_feat, "config", "branch.feat/x.pushRemote", "fork")
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_push_default_remote_triangular_asks(published_feat, tmp_path):
+    """Same via `remote.pushDefault=fork` — bare push goes to fork (unpublished) → ASK."""
+    fork = tmp_path / "fork2.git"
+    _git(str(tmp_path), "init", "--bare", str(fork))
+    _git(published_feat, "remote", "add", "fork2", str(fork))
+    _git(published_feat, "config", "remote.pushDefault", "fork2")
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -452,12 +452,12 @@ def published_feat(tmp_path):
     _git(clone, "config", "user.name", "probe")
     _git(clone, "checkout", "-b", "main")
     (clone / "r.txt").write_text("root\n")
-    _git(clone, "add", "-A")
+    _git(clone, "add", "r.txt")
     _git(clone, "commit", "-m", "root")
     _git(clone, "push", "-u", "origin", "main")
     _git(clone, "checkout", "-b", "feat/x")
     (clone / "a.txt").write_text("hi\n")
-    _git(clone, "add", "-A")
+    _git(clone, "add", "a.txt")
     _git(clone, "commit", "-m", "feat")
     _git(clone, "push", "-u", "origin", "feat/x")
     return str(clone)
@@ -481,7 +481,7 @@ def test_first_push_new_branch_asks(published_feat):
     """A genuinely-first push of a NOT-yet-published branch still asks."""
     _git(published_feat, "checkout", "-b", "feat/y")
     (Path(published_feat) / "b.txt").write_text("y\n")
-    _git(published_feat, "add", "-A")
+    _git(published_feat, "add", "b.txt")
     _git(published_feat, "commit", "-m", "y")
     res = _run_at("git push -u origin feat/y", published_feat)
     assert res.returncode == 0, res.stderr

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -660,3 +660,41 @@ def test_push_default_remote_triangular_asks(published_feat, tmp_path):
     res = _run_at("git push", published_feat)
     assert res.returncode == 0, res.stderr
     assert _decision(res) == "ask"
+
+
+# ── REGRESSION (cloud Codex P1s): the re-push auto-allow must be DEFERRED past all
+# hard-blocks; mirror config and receive-pack/exec must not be auto-allowed. ──
+
+
+def test_republish_then_no_verify_hard_blocks(published_feat):
+    """P1: a compound `git push <republish> && git commit --no-verify` must still
+    HARD-BLOCK (exit 2). The re-push auto-allow is deferred to the tail, so the
+    --no-verify hard-block takes precedence — the allow must NOT short-circuit it."""
+    res = _run_at("git push origin feat/x && git commit --no-verify -m x", published_feat)
+    assert res.returncode == 2
+    assert _decision(res) is None
+    assert "no-verify" in res.stderr
+
+
+def test_mirror_config_asks(published_feat):
+    """P1: `remote.origin.mirror=true` makes a bare push mirror ALL refs
+    (force-update/delete) — must ASK, never auto-allow as a re-push."""
+    _git(published_feat, "config", "remote.origin.mirror", "true")
+    res = _run_at("git push origin", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_receive_pack_flag_asks(published_feat):
+    """P1: `--receive-pack=<program>` selects an executed receive-pack program (an
+    arbitrary-code vector on local/SSH) — must ASK, not auto-allow."""
+    res = _run_at("git push --receive-pack=/tmp/helper origin feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_exec_flag_asks(published_feat):
+    """`--exec=<program>` is the alias of --receive-pack → same arbitrary-code vector → ASK."""
+    res = _run_at("git push --exec=/tmp/helper origin feat/x", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"


### PR DESCRIPTION
## What & why

The `git push` approval dialog (PreToolUse hook) fired on **every** push. It now
prompts only on a branch's **first** push — the moment code actually goes public.
Re-pushing fixes to a branch that's already on the remote (the normal PR-iteration
loop) no longer re-prompts.

Signal = **is the target branch already on the remote?** A first push publishes the
branch (and prompts); a re-push updates an already-published one. The remote *is* the
state — no tracking, self-correcting (a new branch prompts again). This mirrors the
`gh pr create` un-gate (#1252): live `git ls-remote`, exact `refs/heads/<branch>`
match, fail-safe to prompt.

## Scope — deliberately narrow (allowlist posture)

The skip fires ONLY for a plain update of the **current** branch, checked against the
remote git will *actually* push to (resolving git's real `pushRemote`/`pushDefault`
precedence). Everything else falls through to the prompt:

- cross-name / delete refspecs (`feat:other`, `:feat`), a differently-named branch;
- broadening flags (`--all` / `--tags` / `--delete` / `--stdin` / `--repo` / bundled `-d`);
- push to `main`/`master`;
- repo config that redirects/broadens a bare push (`remote.<r>.push` refspec,
  `push.default` = `upstream`/`tracking`/`matching`, submodule recursion).

Unchanged hard behavior: autonomous/dispatched sessions still **hard-deny**; force
pushes still **hard-block**; any uncertainty (ls-remote error/timeout, ambiguous cwd,
config-read error) fails safe to the prompt.

## Hardening

The `_allow` path is a new silent-allow, so the "is this a plain re-push?" predicate
was hardened over **four adversarial review rounds** (Codex + Claude in parallel each
round). Each finding was reproduced with a live repro before fixing: the `-u` parser
tautology, bundled short-delete, `--stdin`, `push.default` redirects, and the
mainstream fork/triangular `pushRemote`/`pushDefault` workflow. The predicate is an
allowlist (git's push surface is too flexible to blocklist safely).

Adversarial config residue that repo-config reads fundamentally cannot cover — a
command-line `git -c key=val push` override, `remote.<r>.mirror`, `push.followTags`,
`url.*.pushInsteadOf` — is **tabled** (documented in-code): each needs a deliberately
unusual command or hostile pre-set config, the hook already soft-warns on `git config`
writes, and this is a self-discipline guardrail, not a hard boundary (consistent with
the git -C commit-gate tabled residue).

## Tests

292 targeted tests pass (`test_merge_review_gate` + `test_push_create_override` +
`test_hook_input_contract` + `test_bash_safety_hook`); ruff clean; private-data scan
clean. Verified E2E against the live hook + throwaway repros: every evasion asks;
common re-pushes (bare / `origin <cur>` / `-u` / safe bundles / push-options) allow;
dispatched→deny, force→block, main→ask, triangular-fork→ask.

## Deploy

CC PreToolUse hook — takes effect at next CC session start after `git pull`. No
`update.sh` / restart.

Ledger: 09e1209b1e44468eb1a7fe8ea6744986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
