### PR TITLE
fix(surplus): stop immortalizing ideation as knowledge_units — stage instead (WS-M PR-1)

### DIFF
--- a/src/genesis/db/crud/surplus.py
+++ b/src/genesis/db/crud/surplus.py
@@ -168,3 +168,22 @@ async def purge_expired(db: aiosqlite.Connection) -> int:
     )
     await db.commit()
     return cursor.rowcount
+
+
+async def purge_discarded(db: aiosqlite.Connection, *, older_than_days: int = 30) -> int:
+    """Hard-delete discarded insights older than a cutoff. Returns count deleted.
+
+    Bounds accumulation of inert discarded rows (purge_expired only flips
+    pending→discarded; nothing removed them). Gated on created_at (no discarded_at
+    column) — conservative: a row discarded at its 7d TTL survives ~older_than_days
+    past creation, i.e. slightly longer than the nominal window. Promoted/pending
+    rows are never touched.
+    """
+    cursor = await db.execute(
+        "DELETE FROM surplus_insights WHERE promotion_status = 'discarded' "
+        "AND created_at != '' "
+        "AND datetime(REPLACE(created_at, 'T', ' ')) < datetime('now', ?)",
+        (f"-{older_than_days} days",),
+    )
+    await db.commit()
+    return cursor.rowcount

--- a/src/genesis/surplus/brainstorm.py
+++ b/src/genesis/surplus/brainstorm.py
@@ -129,6 +129,7 @@ class BrainstormRunner:
                 source=source,
                 source_task_type=str(task_type),
                 generating_model=insight.get("generating_model", "stub"),
+                drive_alignment=drive_alignment,
                 db=self._db,
             )
         except Exception:

--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -171,6 +171,7 @@ async def _route_insights(
             else:
                 try:
                     from genesis.surplus.intake import (
+                        _valid_drive,
                         run_intake,
                         source_for_task_type,
                     )
@@ -180,19 +181,27 @@ async def _route_insights(
                         source=source,
                         source_task_type=str(task.task_type),
                         generating_model=insight.get("generating_model", "unknown"),
+                        drive_alignment=task.drive_alignment,
                         db=sched._db,
                     )
                     logger.info(
-                        "Intake routed %d findings (k=%d, o=%d, d=%d) for task %s",
+                        "Intake routed %d findings (k=%d, o=%d, d=%d, staged=%d) "
+                        "for task %s",
                         intake_stats.findings_count,
                         intake_stats.routed_knowledge,
                         intake_stats.routed_observation,
                         intake_stats.routed_discard,
+                        intake_stats.routed_staging,
                         task.id[:8],
                     )
-                    # Use a synthetic staging_id for tracking
-                    content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
-                    staging_id = f"{task.task_type.value}-{content_hash}"
+                    # Prefer the real staged row id (ideation → surplus_insights)
+                    # so a linked follow-up's result_staging_id resolves; else a
+                    # synthetic tracking id (KB-routed tasks stage no surplus row).
+                    if intake_stats.staged_ids:
+                        staging_id = intake_stats.staged_ids[0]
+                    else:
+                        content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+                        staging_id = f"{task.task_type.value}-{content_hash}"
                 except Exception:
                     # Fallback: write to surplus_insights staging (old behavior)
                     logger.warning(
@@ -210,7 +219,7 @@ async def _route_insights(
                         content=content,
                         source_task_type=str(task.task_type),
                         generating_model=insight.get("generating_model", "unknown"),
-                        drive_alignment=task.drive_alignment,
+                        drive_alignment=_valid_drive(task.drive_alignment),
                         confidence=insight.get("confidence", 0.0),
                         created_at=now_iso,
                         ttl=ttl,

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -12,12 +12,13 @@ Three-step pipeline:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -131,6 +132,8 @@ class IntakeStats:
     routed_knowledge: int = 0
     routed_observation: int = 0
     routed_discard: int = 0
+    routed_staging: int = 0
+    staged_ids: list[str] = field(default_factory=list)
     scoring_skipped: bool = False
     scoring_model: str = ""
     errors: list[str] = field(default_factory=list)
@@ -512,6 +515,7 @@ async def run_intake(
     source: IntakeSource,
     source_task_type: str = "",
     generating_model: str = "",
+    drive_alignment: str = "",
     *,
     db: aiosqlite.Connection,
     store: MemoryStore | None = None,
@@ -569,6 +573,40 @@ async def run_intake(
             for f in findings
         ]
         stats.scoring_skipped = True
+
+    # Step 3a: Ephemeral first-party ideation (self-directed brainstorm /
+    # unblock / audit output) is NOT durable knowledge — stage it in
+    # surplus_insights for the ideas-review lifecycle (TTL decay) instead of
+    # immortalizing it as a knowledge_unit. Keyed on the TRUE task type
+    # (source_task_type), preserved distinct from the collapsed IntakeSource.
+    from genesis.surplus.types import is_ephemeral_ideation
+
+    if is_ephemeral_ideation(source_task_type):
+        drive = _valid_drive(drive_alignment)
+        for scored in scored_findings:
+            try:
+                sid = await _route_to_staging(scored, db=db, drive_alignment=drive)
+                stats.staged_ids.append(sid)
+                stats.routed_staging += 1
+            except Exception as exc:
+                logger.error(
+                    "Intake staging failed for finding '%s': %s",
+                    scored.finding.title[:50], exc, exc_info=True,
+                )
+                stats.errors.append(f"{scored.finding.title[:50]}: {exc}")
+        logger.info(
+            "Intake(staging): source=%s task=%s findings=%d staged=%d errors=%d",
+            stats.source, source_task_type, stats.findings_count,
+            stats.routed_staging, len(stats.errors),
+        )
+        # If EVERY staging write failed, raise so the caller falls back
+        # (dispatch re-stages into surplus_insights via its own path).
+        if stats.findings_count > 0 and stats.routed_staging == 0 and stats.errors:
+            raise RuntimeError(
+                f"Intake staging failed for all {stats.findings_count} findings: "
+                f"{stats.errors[0]}"
+            )
+        return stats
 
     # Step 3: Route each finding.
     for scored in scored_findings:
@@ -704,6 +742,55 @@ async def _route_to_observation(
         priority="medium",
         created_at=now,
     )
+
+
+_VALID_DRIVES = frozenset({"curiosity", "competence", "cooperation", "preservation"})
+
+
+def _valid_drive(drive_alignment: str) -> str:
+    """Coerce to a valid surplus_insights.drive_alignment (CHECK-constrained).
+
+    Empty/unknown → 'competence' (the default first-party drive) so the staging
+    INSERT never violates the drive_alignment CHECK constraint.
+    """
+    return drive_alignment if drive_alignment in _VALID_DRIVES else "competence"
+
+
+async def _route_to_staging(
+    scored: ScoredFinding,
+    *,
+    db: aiosqlite.Connection,
+    drive_alignment: str,
+) -> str:
+    """Stage an ephemeral-ideation finding in surplus_insights (pending, 7d TTL).
+
+    The ideas-review lifecycle: the row decays via purge_expired if never
+    promoted, instead of being immortalized as a knowledge_unit. The id is
+    content-hashed so a re-generated identical finding upserts in place (no dup
+    rows). NOTE: the upsert refreshes content/ttl/confidence but does NOT reset
+    promotion_status — an identical finding that already decayed to 'discarded'
+    stays discarded (not re-surfaced to pending). Whether recurring ideas should
+    re-surface is a PR-2 (ideas-review lane) policy decision, tracked separately.
+    """
+    from genesis.db.crud import surplus as surplus_crud
+
+    content = kb_content_for_finding(scored.finding)
+    task_type = scored.source_task_type or "ideation"
+    digest = hashlib.sha256(content.encode()).hexdigest()[:16]
+    sid = f"{task_type}-{digest}"
+    now = datetime.now(UTC)
+    await surplus_crud.upsert(
+        db,
+        id=sid,
+        content=content,
+        source_task_type=task_type,
+        generating_model=scored.generating_model or "unknown",
+        drive_alignment=drive_alignment,
+        confidence=scored.confidence,
+        created_at=now.isoformat(),
+        ttl=(now + timedelta(days=7)).isoformat(),
+    )
+    return sid
 
 
 def _domain_for_source(source: IntakeSource, task_type: str) -> str:

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -155,6 +155,14 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     except Exception:
         logger.warning("GC: surplus insights purge failed", exc_info=True)
 
+    # Hard-delete long-discarded surplus insights (bound inert-row accumulation)
+    try:
+        deleted = await surplus_crud.purge_discarded(db, older_than_days=30)
+        if deleted:
+            logger.info("Deleted %d long-discarded surplus insights", deleted)
+    except Exception:
+        logger.warning("GC: surplus discarded purge failed", exc_info=True)
+
     # GC: remove completed/failed pending_embeddings older than 30 days
     try:
         from genesis.db.crud import pending_embeddings as pe_crud

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -63,8 +63,9 @@ class TaskType(StrEnum):
 #     success = the action ran; they don't target the KB, so all-discard is normal.
 #   - Pipeline intermediates (RESEARCH_QUERY_GEN, PROMPT_REVIEW_CATALOG,
 #     PROMPT_REVIEW_SAMPLE): their output feeds the *next* pipeline step, not the
-#     KB, so intake legitimately discards it. Only the pipeline *terminals*
-#     (ANTICIPATORY_RESEARCH, PROMPT_EFFECTIVENESS_REVIEW) produce KB-bound insight.
+#     KB, so intake legitimately discards it. Of the pipeline *terminals*, only
+#     ANTICIPATORY_RESEARCH is KB-bound; PROMPT_EFFECTIVENESS_REVIEW is first-party
+#     ideation, STAGED not KB-routed (see EPHEMERAL_IDEATION_TASK_TYPES below).
 #   - Monitoring/probe types (INFRASTRUCTURE_MONITOR, CC_MEMORY_STALENESS): a
 #     "nothing noteworthy / all healthy" pass is the EXPECTED good outcome, and
 #     their status content isn't durable knowledge — all-discard isn't a failure.
@@ -107,6 +108,41 @@ INSIGHT_PRODUCING_TASK_TYPES: frozenset[TaskType] = frozenset({
 KB_ROUTING_TASK_TYPES: frozenset[TaskType] = INSIGHT_PRODUCING_TASK_TYPES | {
     TaskType.BOOKMARK_ENRICHMENT,
 }
+
+
+# Task types that produce EPHEMERAL first-party ideation — self-directed
+# brainstorm / unblock / audit output. These are Genesis-authored work-items and
+# system flags, NOT durable external knowledge, so the intake pipeline STAGES
+# them in surplus_insights (ideas-review lifecycle with TTL decay) instead of
+# immortalizing them as knowledge_units. They stay in KB_ROUTING_TASK_TYPES (so
+# dispatch still calls run_intake); run_intake reroutes them to staging by
+# checking is_ephemeral_ideation() on the TRUE task type. EXCLUDES
+# ANTICIPATORY_RESEARCH (genuine web-cited knowledge) and CODE_AUDIT (its own
+# curated FindingsBridge ingestion path — see dispatch.py::_route_insights).
+EPHEMERAL_IDEATION_TASK_TYPES: frozenset[TaskType] = frozenset({
+    TaskType.SELF_UNBLOCK,
+    TaskType.BRAINSTORM_SELF,
+    TaskType.BRAINSTORM_USER,
+    TaskType.META_BRAINSTORM,
+    TaskType.MEMORY_AUDIT,
+    TaskType.PROCEDURE_AUDIT,
+    TaskType.GAP_CLUSTERING,
+    TaskType.WING_AUDIT,
+    TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+})
+
+
+def is_ephemeral_ideation(task_type: str) -> bool:
+    """True if a surplus task-type string is ephemeral first-party ideation.
+
+    Accepts the raw task-type string (e.g. ``"self_unblock"``) as carried on
+    ``ScoredFinding.source_task_type``; unknown/empty strings → False (default
+    to durable routing — never over-shelve on an unrecognised type).
+    """
+    try:
+        return TaskType(task_type) in EPHEMERAL_IDEATION_TASK_TYPES
+    except ValueError:
+        return False
 
 
 class ComputeTier(StrEnum):

--- a/tests/test_surplus/test_brainstorm.py
+++ b/tests/test_surplus/test_brainstorm.py
@@ -96,12 +96,17 @@ async def test_execute_brainstorm_real_executor_writes_staging(db, queue):
     runner = BrainstormRunner(db, queue, clock=_fixed_clock(), executor=FakeExecutor())
     staging_id = await runner.execute_brainstorm(TaskType.BRAINSTORM_USER, "cooperation")
 
+    # brainstorm_user is ephemeral ideation → run_intake STAGES it in
+    # surplus_insights (content-hashed id), rather than immortalizing it as a
+    # knowledge_unit. The staged row is keyed by content hash, not the returned
+    # tracking id, so verify by content/type rather than get_by_id(staging_id).
     assert staging_id is not None
-    row = await surplus_crud.get_by_id(db, staging_id)
-    assert row is not None
-    assert row["promotion_status"] == "pending"
-    assert row["source_task_type"] == "brainstorm_user"
-    assert row["drive_alignment"] == "cooperation"
+    rows = await surplus_crud.list_pending(db, limit=50)
+    staged = [r for r in rows if "Real insight" in r["content"]]
+    assert staged, "brainstorm output should be staged in surplus_insights"
+    assert staged[0]["promotion_status"] == "pending"
+    assert staged[0]["source_task_type"] == "brainstorm_user"
+    assert staged[0]["drive_alignment"] == "cooperation"
 
 
 async def test_execute_brainstorm_stub_writes_no_log(db, queue):

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -199,7 +199,8 @@ def _intake_ctx():
 async def _run_route(task_type, monkeypatch):
     run_intake_spy = AsyncMock(
         return_value=_types.SimpleNamespace(
-            findings_count=1, routed_knowledge=1, routed_observation=0, routed_discard=0
+            findings_count=1, routed_knowledge=1, routed_observation=0,
+            routed_discard=0, routed_staging=0, staged_ids=[],
         )
     )
     monkeypatch.setattr(_intake_mod, "run_intake", run_intake_spy)

--- a/tests/test_surplus/test_intake_staging.py
+++ b/tests/test_surplus/test_intake_staging.py
@@ -1,0 +1,161 @@
+"""WS-M PR-1: ephemeral-ideation staging gate + purge_discarded GC.
+
+Ideation task output (self_unblock / brainstorm / audits) must be STAGED in
+surplus_insights (ideas-review lifecycle, TTL decay) instead of immortalized as
+knowledge_units. anticipatory_research / code_audit stay KB-bound.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import genesis.db.crud.surplus as surplus_crud
+from genesis.surplus.intake import IntakeSource, run_intake
+from genesis.surplus.types import (
+    EPHEMERAL_IDEATION_TASK_TYPES,
+    TaskType,
+    is_ephemeral_ideation,
+)
+
+
+class TestIdeationSet:
+    def test_core_ideation_in_set(self):
+        for tt in (
+            TaskType.SELF_UNBLOCK,
+            TaskType.BRAINSTORM_SELF,
+            TaskType.BRAINSTORM_USER,
+            TaskType.META_BRAINSTORM,
+            TaskType.MEMORY_AUDIT,
+            TaskType.PROCEDURE_AUDIT,
+            TaskType.GAP_CLUSTERING,
+            TaskType.WING_AUDIT,
+            TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+        ):
+            assert tt in EPHEMERAL_IDEATION_TASK_TYPES
+            assert is_ephemeral_ideation(str(tt))
+
+    def test_kb_bound_types_excluded(self):
+        assert TaskType.ANTICIPATORY_RESEARCH not in EPHEMERAL_IDEATION_TASK_TYPES
+        assert TaskType.CODE_AUDIT not in EPHEMERAL_IDEATION_TASK_TYPES
+        assert not is_ephemeral_ideation("anticipatory_research")
+        assert not is_ephemeral_ideation("code_audit")
+
+    def test_unknown_string_is_not_ideation(self):
+        assert not is_ephemeral_ideation("")
+        assert not is_ephemeral_ideation("not_a_real_task_type")
+
+
+@pytest.mark.asyncio
+async def test_self_unblock_routes_to_staging_not_kb(db):
+    """A self_unblock finding is staged; the knowledge-base ingest is not called."""
+    with patch(
+        "genesis.memory.knowledge_ingest.ingest_knowledge_unit",
+        new=AsyncMock(),
+    ) as ingest:
+        stats = await run_intake(
+            content="Self Unblock\n\nThe system is stuck in a priority collision.",
+            source=IntakeSource.ANTICIPATORY_RESEARCH,  # collapsed source (real flow)
+            source_task_type="self_unblock",  # TRUE task type — drives the gate
+            generating_model="test-model",
+            drive_alignment="competence",
+            db=db,
+        )
+    assert stats.routed_staging >= 1
+    assert stats.routed_knowledge == 0
+    ingest.assert_not_awaited()
+    rows = await surplus_crud.list_pending(db, limit=50)
+    staged = [r for r in rows if "priority collision" in r["content"]]
+    assert staged, "self_unblock finding should be staged in surplus_insights"
+    assert all(r["promotion_status"] == "pending" for r in staged)
+
+
+@pytest.mark.asyncio
+async def test_anticipatory_research_still_routes_to_kb(db):
+    """Genuine research is NOT staged — it goes to the knowledge base."""
+    with patch(
+        "genesis.memory.knowledge_ingest.ingest_knowledge_unit",
+        new=AsyncMock(),
+    ) as ingest:
+        stats = await run_intake(
+            content="Top AI Agent Runtime Security Tools 2026\n\nDetailed comparison.",
+            source=IntakeSource.ANTICIPATORY_RESEARCH,
+            source_task_type="anticipatory_research",
+            generating_model="test-model",
+            db=db,
+            store=AsyncMock(),
+        )
+    assert stats.routed_staging == 0
+    assert stats.routed_knowledge >= 1
+    ingest.assert_awaited()
+    rows = await surplus_crud.list_pending(db, limit=50)
+    assert not any("Top AI Agent" in r["content"] for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_invalid_drive_alignment_defaults_to_competence(db):
+    """An empty/invalid drive_alignment coerces to 'competence' (CHECK-safe)."""
+    stats = await run_intake(
+        content="Brainstorm\n\nSome idea about goal triage.",
+        source=IntakeSource.ANTICIPATORY_RESEARCH,
+        source_task_type="brainstorm_self",
+        generating_model="test-model",
+        drive_alignment="",  # invalid → must coerce, not raise on the CHECK
+        db=db,
+    )
+    assert stats.routed_staging >= 1
+    rows = await surplus_crud.list_pending(db, limit=50)
+    staged = [r for r in rows if "goal triage" in r["content"]]
+    assert staged and all(r["drive_alignment"] == "competence" for r in staged)
+
+
+@pytest.mark.asyncio
+async def test_purge_discarded_deletes_only_old_discarded(db):
+    now = datetime.now(UTC)
+    old = (now - timedelta(days=40)).isoformat()
+    recent = (now - timedelta(days=5)).isoformat()
+    future_ttl = (now + timedelta(days=7)).isoformat()
+    await surplus_crud.create(
+        db,
+        id="old-disc",
+        content="x",
+        source_task_type="self_unblock",
+        generating_model="m",
+        drive_alignment="competence",
+        created_at=old,
+        ttl=old,
+        confidence=0.6,
+    )
+    await surplus_crud.create(
+        db,
+        id="new-disc",
+        content="y",
+        source_task_type="self_unblock",
+        generating_model="m",
+        drive_alignment="competence",
+        created_at=recent,
+        ttl=recent,
+        confidence=0.6,
+    )
+    await surplus_crud.create(
+        db,
+        id="old-pending",
+        content="z",
+        source_task_type="self_unblock",
+        generating_model="m",
+        drive_alignment="competence",
+        created_at=old,
+        ttl=future_ttl,
+        confidence=0.6,
+    )
+    await surplus_crud.discard(db, "old-disc")
+    await surplus_crud.discard(db, "new-disc")
+
+    deleted = await surplus_crud.purge_discarded(db, older_than_days=30)
+
+    assert deleted == 1
+    assert await surplus_crud.get_by_id(db, "old-disc") is None  # old + discarded
+    assert await surplus_crud.get_by_id(db, "new-disc") is not None  # recent
+    assert await surplus_crud.get_by_id(db, "old-pending") is not None  # not discarded


### PR DESCRIPTION
## What

Autonomous surplus **ideation** (self-directed `self_unblock` / `brainstorm_*` / audit task output) was being written to the knowledge base as durable `knowledge_units` via the intake pipeline. This gates it: ideation task types now route to `surplus_insights` **staging** (`pending`, 7-day TTL) — the ideas-review lifecycle that decays if never promoted — instead of the KB.

Genuine `anticipatory_research` (web-cited external knowledge) and `code_audit` (its own curated `FindingsBridge` ingestion path) **stay KB-bound**.

## Why

Diagnosed on the live database: the surplus-intake bucket holds thousands of immortal `knowledge_units`, ~12 introspective-ideation rows/day and actively growing (`Self Unblock / priority collision…`, `Automate and harden backup replication…`, `Prompt Effectiveness Review`, …). These are Genesis-authored work-items and system flags, not durable facts. The task type is collapsed into a coarse `IntakeSource` for provenance, but `ScoredFinding.source_task_type` preserves the TRUE type — so the gate keys on that and cleanly shelves ideation while never over-shelving real research.

## How

- `EPHEMERAL_IDEATION_TASK_TYPES` + `is_ephemeral_ideation()` in `surplus/types.py` (9 types; excludes `anticipatory_research` + `code_audit`).
- `run_intake` reroutes matching findings via new `_route_to_staging` (content-hashed id, idempotent upsert, `drive_alignment` CHECK-coerced) and returns early before KB routing; staged ids thread back so a linked follow-up's `result_staging_id` resolves.
- `purge_discarded` GC (hard-deletes long-discarded rows) wired into the maintenance gate to bound inert-row accumulation.

## Scope

**Stop-the-bleed only.** The ideas **review lane** (reading/promoting staged rows into a review surface, coordinated with the inbox) is **PR-2**. Staged ideas TTL-decay in the interim — strictly better than immortal KB. Deferred lifecycle refinements (promotion_status-reset policy for recurring ideas, staging visibility) are tracked for PR-2.

## Verification

- 320 targeted tests pass (`tests/test_surplus/`), including a new `test_intake_staging.py`.
- E2E vs the real schema: a `self_unblock` finding produces **zero** `knowledge_units` and one `pending` staged row; `anticipatory_research` still routes to the KB; the GC hard-deletes long-discarded rows.
- Two review passes (feature-dev + a high-effort 4-finder pass): 3 findings fixed inline, 1 deferred to PR-2 with a follow-up, 2 benign notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
