### PR TITLE
feat(resilience): CC network preflight + surplus outage-awareness (PR-3)

### DIFF
--- a/config/resilience.yaml
+++ b/config/resilience.yaml
@@ -34,6 +34,11 @@ network:
   enabled: true
   # Degraded-mode parking lever (PR-3): off | shadow | live. Default shadow —
   # observe one real outage before granting parking authority. Invalid → shadow.
+  # PREREQUISITE before flipping to `live`: harden the periodic CC-invoker
+  # consumers (inbox retry budget, autonomy/ego outcome signals, direct_session)
+  # to treat CCNetworkOfflineError as "not attempted" rather than a failure —
+  # otherwise an outage pollutes calibration/retry state. In `shadow` the preflight
+  # never raises, so that class is dormant. See the PR-3b follow-up.
   parking_mode: shadow
   # Restore push-retry lever (PR-4): off | live. Invalid → off.
   backup_push_retry: live

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1010,9 +1010,18 @@ verified: b662f3e3 2026-07-17
   and opts out of the state machine's symmetric flap protection. The axis drives
   watchdog zombie-restart suppression (a restart can't fix an ISP outage), the
   `is_any_degraded` recovery gate (at OFFLINE only — don't re-dispatch into a
-  dead network), and the dashboard "Internet" light; it is DELIBERATELY excluded
-  from `to_legacy_degradation_level` (call-site shedding is deferred to PR-3
-  under `network.parking_mode`). Lever/kill-switch in `network_config.py`
+  dead network), and the dashboard "Internet" light. Two OFFLINE-parking
+  consumers (PR-3) gate on `network.parking_mode` (off/shadow/live, default
+  shadow) through the shared `network_config.parking_decision()` gate: the
+  **CC-invoker network preflight** (`cc/invoker.py::_network_preflight` — raises
+  `CCNetworkOfflineError` BEFORE the subprocess spawns for a WAN endpoint,
+  turning a `timeout_s`-bounded hang (7200s default) into a sub-second fail; a
+  LAN CC peer, classified via `util/netclass.py`, still runs), and the
+  **surplus tier filter** (`surplus/dispatch.py::_filter_tiers_for_network` —
+  strips cloud compute tiers so internet-dependent tasks stay `pending` instead
+  of churning `failed`). The axis stays DELIBERATELY excluded from
+  `to_legacy_degradation_level` (broader legacy-level call-site shedding remains
+  deferred/tabled). Lever/kill-switch in `network_config.py`
   (`GENESIS_NETWORK_SENTINEL_DISABLED`); window store `~/.genesis/network_state.json`
   (`network_state.py`, stdlib-only, self-bounding). Consumers staleness-check the
   sentinel's own `last_probe_at` and fail toward their safe default.

--- a/scripts/check_portability.sh
+++ b/scripts/check_portability.sh
@@ -51,6 +51,10 @@ excludes=(
   --glob '!**/scripts/hooks/commit-msg'
   --glob '!**/scripts/cc_cli_output/**'
   --glob '!**/scripts/spike_*'
+  # netclass.py is a LAN/WAN classifier — it defines the RFC-grounded private
+  # address ranges (10/8, 172.16/12, 192.168/16, 100.64/10, fc00::/7) as data,
+  # not install-specific addresses. Same rationale as excluding sanitize.py.
+  --glob '!**/src/genesis/util/netclass.py'
 )
 
 # Scan only targets that exist: a missing path makes rg exit 2 even when

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -15,6 +15,7 @@ from genesis.cc.context_injector import ContextInjector
 from genesis.cc.exceptions import (
     CCError,
     CCMCPError,
+    CCNetworkOfflineError,
     CCQuotaExhaustedError,
     CCRateLimitError,
     CCTimeoutError,
@@ -750,10 +751,18 @@ class ConversationLoop:
         try:
             output = await self._invoker.run(invocation)
             return output, session
-        except (CCRateLimitError, CCQuotaExhaustedError, CCTimeoutError):
+        except (
+            CCRateLimitError,
+            CCQuotaExhaustedError,
+            CCTimeoutError,
+            CCNetworkOfflineError,
+        ):
             # Rate limits are account-wide, and a timeout is NOT a stale-resume
             # failure — retrying fresh won't help. A timeout retry just burns a
-            # second full window (the 2026-06-30 DM double-timeout). Let the
+            # second full window (the 2026-06-30 DM double-timeout). Likewise a
+            # network-offline preflight (PR-3): the resume session is fine, the
+            # internet is down — DON'T fail the live session as stale-resume and
+            # retry fresh (which would also just re-raise offline). Let the
             # caller's terminal handler deal with it.
             raise
         except CCError:
@@ -791,9 +800,16 @@ class ConversationLoop:
         try:
             output = await self._invoker.run_streaming(invocation, on_event=on_event)
             return output, session
-        except (CCRateLimitError, CCQuotaExhaustedError, CCTimeoutError):
+        except (
+            CCRateLimitError,
+            CCQuotaExhaustedError,
+            CCTimeoutError,
+            CCNetworkOfflineError,
+        ):
             # Account-wide (rate/quota) or a timeout — retrying fresh won't help;
-            # a timeout retry just burns a second full window (2026-06-30 DM).
+            # a timeout retry just burns a second full window (2026-06-30 DM). A
+            # network-offline preflight (PR-3) likewise must NOT fail the live
+            # session as a stale resume — the internet is down, not the session.
             raise
         except CCError:
             if not was_resume:
@@ -947,7 +963,10 @@ class ConversationLoop:
             inv = replace(peer_inv, resume_session_id=sticky["cc_session_id"])
         try:
             return await self._invoke_peer(inv, on_event)
-        except (CCRateLimitError, CCQuotaExhaustedError):
+        except (CCRateLimitError, CCQuotaExhaustedError, CCNetworkOfflineError):
+            # Offline joins the fast-re-raise (same class as CAVEAT A): a dead
+            # network is not a stale peer resume — retrying fresh won't help and
+            # must not mark the sticky peer session stale.
             raise
         except CCError:
             # Don't re-stream: nothing to recover if already fresh, and never retry

--- a/src/genesis/cc/exceptions.py
+++ b/src/genesis/cc/exceptions.py
@@ -35,6 +35,24 @@ class CCMCPError(CCError):
         self.server_name = server_name
 
 
+class CCNetworkOfflineError(CCError):
+    """The network is hard-OFFLINE and the CC endpoint needs the internet.
+
+    Raised by the CCInvoker's pre-spawn network preflight (PR-3 outage
+    resilience) when the connectivity sentinel reports a fresh OFFLINE state,
+    the parking lever is ``live``, and the target endpoint classifies as WAN
+    (Anthropic's API, or any non-LAN provider). It fires *before* the subprocess
+    is spawned, so a dead-network dispatch fails in well under a second instead
+    of hanging up to ``CCInvocation.timeout_s`` (7200s default) — the 45-55min
+    hangs observed in the 2026-07-28 outage.
+
+    A ``CCError`` subclass so every existing terminal handler already catches it;
+    it is added to conversation.py's fast-re-raise tuples so a resume turn does
+    NOT mis-treat it as a stale-resume failure (which would needlessly fail a
+    live CC session).
+    """
+
+
 class _CCLimitError(CCError):
     """Shared base for rate-limit / quota errors — carries the reset signal.
 

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -18,6 +18,7 @@ from genesis.cc import roster
 from genesis.cc.exceptions import (
     CCError,
     CCMCPError,
+    CCNetworkOfflineError,
     CCProcessError,
     CCQuotaExhaustedError,
     CCRateLimitError,
@@ -609,6 +610,55 @@ class CCInvoker:
             except Exception:
                 logger.warning("CC status callback failed for %s", status, exc_info=True)
 
+    async def _network_preflight(self, invocation: CCInvocation) -> None:
+        """Fail fast pre-spawn when the network is hard-OFFLINE and WAN-bound.
+
+        PR-3 outage resilience. When the connectivity sentinel reports a fresh
+        OFFLINE state and the parking lever is ``live``, a CC dispatch whose
+        endpoint needs the internet raises :class:`CCNetworkOfflineError` here —
+        *before* the subprocess is spawned — so it fails in well under a second
+        instead of hanging up to ``timeout_s`` (7200s default; 45-55min hangs
+        were observed in the 2026-07-28 outage).
+
+        Fail-safe by construction: the lever off, an absent/stale/NORMAL/DEGRADED
+        snapshot, a LAN endpoint, or any error in the check itself all fall
+        through to a normal dispatch — identical to pre-sentinel behavior. Only
+        the precise (fresh-OFFLINE + live + WAN endpoint) case parks.
+        """
+        # Function-scope imports: cc.invoker is imported very early in runtime
+        # bootstrap; keep the resilience/util deps out of its module-load graph
+        # (cycle-proof, same rationale as surplus/dispatch.py's scoped imports).
+        try:
+            from genesis.resilience import network_config
+            from genesis.util import netclass
+
+            decision = network_config.parking_decision()
+            if decision in ("off", "normal"):
+                return
+            # Fresh OFFLINE (shadow or park). Only WAN endpoints are affected — a
+            # LAN CC peer (native mesh) stays reachable through a WAN outage. The
+            # native ``claude`` endpoint carries no base URL → WAN by rule, so a
+            # true outage correctly parks all CC here (api.anthropic.com is down).
+            endpoint_class = await netclass.default_classifier().classify_url_async(
+                invocation.anthropic_base_url
+            )
+            if endpoint_class != netclass.WAN:
+                return
+            if decision == "shadow":
+                logger.info(
+                    "network preflight: WOULD park WAN CC dispatch "
+                    "(network OFFLINE, shadow mode) — proceeding",
+                )
+                return
+            # decision == "park" (live mode)
+            raise CCNetworkOfflineError(
+                "network is OFFLINE — skipping WAN CC dispatch before subprocess spawn",
+            )
+        except CCNetworkOfflineError:
+            raise
+        except Exception:
+            logger.debug("network preflight check errored — proceeding", exc_info=True)
+
     async def run(self, invocation: CCInvocation) -> CCOutput:
         """Run a dispatched CC session (traced).
 
@@ -619,6 +669,7 @@ class CCInvoker:
         when capture is disabled.
         """
         invocation, roster_model = roster.apply_active(invocation)
+        await self._network_preflight(invocation)
         with start_span(
             "cc.session",
             SpanKind.CC_SESSION,
@@ -793,6 +844,7 @@ class CCInvoker:
     ) -> CCOutput:
         """Run CC with stream-json output (traced — see run() for span rationale)."""
         invocation, roster_model = roster.apply_active(invocation)
+        await self._network_preflight(invocation)
         with start_span(
             "cc.session",
             SpanKind.CC_SESSION,

--- a/src/genesis/resilience/network_config.py
+++ b/src/genesis/resilience/network_config.py
@@ -145,10 +145,17 @@ def sentinel_enabled() -> bool:
 
 
 def effective_parking_mode() -> str:
-    """PR-3 degraded-mode parking lever. Invalid → ``shadow`` (observe only)."""
-    cfg = load_config()
-    if not cfg.get("enabled", True):
+    """PR-3 degraded-mode parking lever. Invalid → ``shadow`` (observe only).
+
+    Honors the sentinel kill switch: if the sentinel is disabled (env
+    ``GENESIS_NETWORK_SENTINEL_DISABLED=1`` OR ``enabled: false``), parking is
+    OFF regardless of a lingering on-disk OFFLINE snapshot — the hard-off switch
+    must immediately stop parking WAN dispatches / cloud surplus, not wait for
+    the stale snapshot to age out.
+    """
+    if not sentinel_enabled():
         return "off"
+    cfg = load_config()
     mode = cfg.get("parking_mode")
     if mode is False:  # YAML-1.1 `parking_mode: off` → boolean False; honor it
         return "off"

--- a/src/genesis/resilience/network_config.py
+++ b/src/genesis/resilience/network_config.py
@@ -31,6 +31,7 @@ import copy
 import logging
 import os
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -167,6 +168,43 @@ def backup_push_retry_mode() -> str:
         logger.warning("network backup_push_retry invalid %r — degrading to off", mode)
         return "off"
     return mode
+
+
+def parking_decision(now: datetime | None = None) -> str:
+    """PR-3 consumer gate: should degraded-mode parking apply *right now*?
+
+    The single source of truth for "the network is actionably OFFLINE", shared
+    by every consumer (the CC-invoker preflight and the surplus tier filter) so
+    they cannot drift. Combines the :func:`effective_parking_mode` lever with the
+    live connectivity snapshot (``network_state.json``) and the same freshness
+    guard the watchdog/dashboard use.
+
+    Returns one of:
+      ``"off"``    — lever off; caller must no-op (behave as pre-sentinel).
+      ``"normal"`` — not actionably OFFLINE (snapshot absent, stale, or
+                     NORMAL/DEGRADED); caller proceeds exactly as today.
+      ``"shadow"`` — fresh OFFLINE + shadow mode; caller logs "would park" and
+                     proceeds (observe-only soak).
+      ``"park"``   — fresh OFFLINE + live mode; caller applies its parking action.
+
+    Fail-safe: shadow/off are the only non-``normal`` returns unless the snapshot
+    is a *fresh* OFFLINE — any missing/garbled/stale signal degrades to
+    ``"normal"`` (never invents a park). ``now`` is injectable for tests.
+    """
+    from genesis.resilience import network_state
+
+    mode = effective_parking_mode()
+    if mode == "off":
+        return "off"
+    snapshot = network_state.read_state()
+    if snapshot is None or snapshot.get("state") != "OFFLINE":
+        return "normal"
+    age = network_state.probe_age_s(snapshot, now or datetime.now(UTC))
+    if age is None or age > structural().staleness_threshold_s:
+        # Stalled/absent sentinel — don't act on a connectivity signal we can't
+        # trust (mirrors the watchdog's fail-toward-safe staleness rule).
+        return "normal"
+    return "park" if mode == "live" else "shadow"
 
 
 def _knob_int(cfg: dict[str, Any], key: str) -> int:

--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -29,6 +29,7 @@ from genesis.observability.types import Severity, Subsystem
 from genesis.surplus.types import (
     INSIGHT_PRODUCING_TASK_TYPES,
     KB_ROUTING_TASK_TYPES,
+    ComputeTier,
     TaskType,
 )
 
@@ -342,6 +343,50 @@ async def _signal_autonomy_success() -> None:
         logger.debug("Autonomy success signal failed (non-fatal)", exc_info=True)
 
 
+def _filter_tiers_for_network(tiers: list[ComputeTier]) -> list[ComputeTier]:
+    """Strip cloud compute tiers when the network is hard-OFFLINE (PR-3).
+
+    Keeps surplus outage-aware: during a detected outage, tasks that need the
+    internet stay ``pending`` (``next_task`` simply selects nothing for the
+    stripped tiers, and re-selects them the instant connectivity returns)
+    instead of dispatching into a dead network and churning ``failed`` /
+    dead-letter rows every cycle. LAN-local compute (``LOCAL_30B``) still runs.
+
+    This is dispatch-side *compute-availability* gating — the same mechanism as
+    the existing LM-Studio reachability check in ``get_available_tiers`` — NOT
+    generator alert-awareness (surplus generators stay deliberately blind to
+    infrastructure alerts). Fail-safe: the parking lever off, a non-fresh/absent
+    OFFLINE signal, or any error leaves the tier list untouched.
+    """
+    try:
+        from genesis.resilience import network_config
+
+        decision = network_config.parking_decision()
+        if decision in ("off", "normal"):
+            return tiers
+        local_only = [t for t in tiers if t == ComputeTier.LOCAL_30B]
+        if local_only == tiers:
+            return tiers  # already LAN-only (or empty) — nothing cloud to strip
+        if decision == "shadow":
+            logger.info(
+                "network OFFLINE: WOULD restrict surplus to LAN compute "
+                "(shadow mode) — proceeding",
+            )
+            return tiers
+        logger.info(
+            "network OFFLINE: surplus restricted to LAN compute (%d→%d tiers)",
+            len(tiers),
+            len(local_only),
+        )
+        return local_only
+    except Exception:
+        logger.debug(
+            "surplus network tier filter errored — leaving tiers intact",
+            exc_info=True,
+        )
+        return tiers
+
+
 async def dispatch_once(sched: DispatchContext) -> bool:
     """Single dispatch cycle. Returns True if a task was processed."""
     # 0. Recover tasks stuck in 'running' state (crashed mid-execution)
@@ -360,6 +405,11 @@ async def dispatch_once(sched: DispatchContext) -> bool:
 
     # 3. Check compute availability
     available_tiers = await sched._compute.get_available_tiers()
+
+    # 3b. Outage awareness (PR-3): when the network is hard-OFFLINE, strip cloud
+    # tiers so internet-dependent tasks stay `pending` instead of churning into a
+    # dead network. LAN-local compute still runs; fail-safe leaves tiers intact.
+    available_tiers = _filter_tiers_for_network(available_tiers)
 
     # 4. Get next task
     task = await sched._queue.next_task(available_tiers)

--- a/src/genesis/util/netclass.py
+++ b/src/genesis/util/netclass.py
@@ -62,6 +62,12 @@ _LOCAL_NETS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
 )
 
 _DEFAULT_CACHE_TTL_S = 300
+# Bound resolution so a hostname endpoint with a cold cache during a DNS outage
+# (the very condition that declares the network OFFLINE) can't stall the CC
+# preflight: a dead resolver's getaddrinfo can otherwise hang for the system
+# resolver's timeout (seconds), defeating the sub-second fail-fast. On timeout we
+# fall through to last-known-good, else the conservative WAN verdict.
+_DEFAULT_RESOLVE_TIMEOUT_S = 1.0
 
 
 def _classify_ip_obj(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
@@ -116,11 +122,13 @@ class NetClassifier:
         clock: Callable[[], float] | None = None,
         resolver: Callable[[str], list[str]] | None = None,
         async_resolver: Callable[[str], object] | None = None,
+        resolve_timeout_s: float = _DEFAULT_RESOLVE_TIMEOUT_S,
     ):
         self._ttl = cache_ttl_s
         self._clock = clock or time.monotonic
         self._resolver = resolver
         self._async_resolver = async_resolver
+        self._resolve_timeout_s = resolve_timeout_s
         # host -> (classification, resolved_at_monotonic)
         self._cache: dict[str, tuple[str, float]] = {}
 
@@ -190,8 +198,14 @@ class NetClassifier:
         if fresh is not None:
             return fresh
         try:
-            addrs = await self._resolve_async(host)
-        except OSError:
+            # Bounded: a dead resolver during an outage must not stall the
+            # preflight. TimeoutError subclasses OSError, so wait_for's timeout
+            # is caught by the same handler as a resolver error.
+            addrs = await asyncio.wait_for(
+                self._resolve_async(host),
+                self._resolve_timeout_s,
+            )
+        except (TimeoutError, OSError):
             lkg = self._last_known_good(host)
             if lkg is not None:
                 return lkg

--- a/src/genesis/util/netclass.py
+++ b/src/genesis/util/netclass.py
@@ -1,0 +1,244 @@
+"""LAN vs WAN endpoint classification — stdlib-only, sync + async.
+
+Answers one question: *does reaching this host require the public internet?*
+An endpoint is ``"local"`` (reachable on the LAN / mesh, survives a WAN outage)
+or ``"wan"`` (needs the internet). Used by the CC network preflight (PR-3): a
+hard-OFFLINE state parks only ``wan`` dispatches — a LAN CC peer keeps working.
+
+Design (encode the *principle*, not a hardcoded host list):
+- **IP-literal fast-path.** A literal address classifies directly from its range
+  with no DNS — the common case (roster peers carry literal or public URLs, the
+  native ``claude`` endpoint carries none → WAN by rule).
+- **Hostname resolution + last-known-good cache.** A hostname is resolved
+  (``getaddrinfo``) and classified from its addresses. The classification is
+  cached so it *survives DNS loss*: during an outage a previously-seen LAN host
+  keeps its ``local`` verdict instead of flipping to WAN just because the
+  resolver is unreachable.
+- **Conservative fallback.** An unresolvable host with no cached verdict →
+  ``"wan"``. Rationale: mis-parking a working LAN peer (false ``wan``) breaks
+  legitimate local work, but failing to park a WAN host (false ``local``) only
+  degrades to the pre-preflight behavior (the dispatch hangs, as it does today).
+  We resolve ambiguity toward ``wan`` *only* when we have no signal at all.
+
+LAN set (RFC-grounded, so it generalizes to any install):
+loopback (127/8, ::1), RFC1918 (10/8, 172.16/12, 192.168/16),
+CGNAT / Tailscale (100.64/10), link-local (169.254/16, fe80::/10),
+IPv6 ULA (fc00::/7 — covers Tailscale-style mesh addresses).
+
+Async note: in-loop callers MUST use the ``*_async`` variants — they resolve via
+``loop.getaddrinfo`` so a slow/dead resolver never blocks the event loop (a bare
+``socket.getaddrinfo`` would). The sync variants exist for stdlib-sync callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+import time
+from collections.abc import Callable
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+LOCAL = "local"
+WAN = "wan"
+
+# RFC-grounded LAN ranges. Defined explicitly rather than via ipaddress'
+# ``.is_private`` because that property's membership (notably CGNAT 100.64/10)
+# has shifted across CPython versions — an explicit table is version-stable and
+# self-documenting, and the plan calls for encoding the principle directly.
+_LOCAL_NETS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("127.0.0.0/8"),  # loopback
+    ipaddress.ip_network("10.0.0.0/8"),  # RFC1918
+    ipaddress.ip_network("172.16.0.0/12"),  # RFC1918
+    ipaddress.ip_network("192.168.0.0/16"),  # RFC1918
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT / Tailscale v4
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local v4
+    ipaddress.ip_network("::1/128"),  # loopback v6
+    ipaddress.ip_network("fc00::/7"),  # ULA v6 (incl. Tailscale mesh)
+    ipaddress.ip_network("fe80::/10"),  # link-local v6
+)
+
+_DEFAULT_CACHE_TTL_S = 300
+
+
+def _classify_ip_obj(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    """Classify a parsed IP address object as ``local`` or ``wan``."""
+    for net in _LOCAL_NETS:
+        # Version guard: ``in`` across families raises TypeError otherwise.
+        if ip.version == net.version and ip in net:
+            return LOCAL
+    return WAN
+
+
+def ip_literal_class(host: str) -> str | None:
+    """Classify ``host`` if it is an IP literal, else ``None``.
+
+    Accepts bracketed IPv6 (``[::1]``) as it appears in URLs.
+    """
+    candidate = host.strip()
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    # IPv6 zone id (``fe80::1%eth0``) — strip before parsing.
+    candidate = candidate.split("%", 1)[0]
+    try:
+        return _classify_ip_obj(ipaddress.ip_address(candidate))
+    except ValueError:
+        return None
+
+
+def _classify_addrs(addrs: list[str]) -> str:
+    """LOCAL iff every resolved address is LOCAL (empty → WAN).
+
+    All-local (not any-local) so an ambiguous/mixed result defaults toward WAN.
+    Real LAN hosts resolve to purely-local addresses, so this never mis-parks
+    them; there is no realistic mixed LAN+WAN endpoint in this use.
+    """
+    if not addrs:
+        return WAN
+    return LOCAL if all(ip_literal_class(a) == LOCAL for a in addrs) else WAN
+
+
+class NetClassifier:
+    """Endpoint classifier with a last-known-good resolution cache.
+
+    Injectable clock/resolvers make it fully deterministic under test. The cache
+    is per-instance; :func:`default_classifier` returns a shared process-wide
+    instance so its cache warms across CC dispatches.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_ttl_s: int = _DEFAULT_CACHE_TTL_S,
+        clock: Callable[[], float] | None = None,
+        resolver: Callable[[str], list[str]] | None = None,
+        async_resolver: Callable[[str], object] | None = None,
+    ):
+        self._ttl = cache_ttl_s
+        self._clock = clock or time.monotonic
+        self._resolver = resolver
+        self._async_resolver = async_resolver
+        # host -> (classification, resolved_at_monotonic)
+        self._cache: dict[str, tuple[str, float]] = {}
+
+    # -- resolution seams (overridable for tests) ---------------------------
+
+    def _resolve_sync(self, host: str) -> list[str]:
+        if self._resolver is not None:
+            return self._resolver(host)
+        infos = socket.getaddrinfo(host, None)
+        return [info[4][0] for info in infos]
+
+    async def _resolve_async(self, host: str) -> list[str]:
+        if self._async_resolver is not None:
+            return await self._async_resolver(host)  # type: ignore[misc]
+        loop = asyncio.get_running_loop()
+        infos = await loop.getaddrinfo(host, None)
+        return [info[4][0] for info in infos]
+
+    # -- cache helpers ------------------------------------------------------
+
+    def _cached_fresh(self, host: str) -> str | None:
+        entry = self._cache.get(host)
+        if entry is not None and (self._clock() - entry[1]) < self._ttl:
+            return entry[0]
+        return None
+
+    def _last_known_good(self, host: str) -> str | None:
+        entry = self._cache.get(host)
+        return entry[0] if entry is not None else None
+
+    def _store(self, host: str, cls: str) -> None:
+        self._cache[host] = (cls, self._clock())
+
+    # -- public API ---------------------------------------------------------
+
+    def classify_host(self, host: str) -> str:
+        """Classify a host (IP literal or name) — synchronous."""
+        if not host:
+            return WAN
+        literal = ip_literal_class(host)
+        if literal is not None:
+            return literal
+        fresh = self._cached_fresh(host)
+        if fresh is not None:
+            return fresh
+        try:
+            addrs = self._resolve_sync(host)
+        except OSError:
+            # Resolver unreachable (e.g. DNS dead in an outage) — keep the last
+            # known verdict so a LAN host stays LAN; else conservative WAN.
+            lkg = self._last_known_good(host)
+            if lkg is not None:
+                return lkg
+            return WAN
+        cls = _classify_addrs(addrs)
+        self._store(host, cls)
+        return cls
+
+    async def classify_host_async(self, host: str) -> str:
+        """Classify a host (IP literal or name) — async, loop-safe resolution."""
+        if not host:
+            return WAN
+        literal = ip_literal_class(host)
+        if literal is not None:
+            return literal
+        fresh = self._cached_fresh(host)
+        if fresh is not None:
+            return fresh
+        try:
+            addrs = await self._resolve_async(host)
+        except OSError:
+            lkg = self._last_known_good(host)
+            if lkg is not None:
+                return lkg
+            return WAN
+        cls = _classify_addrs(addrs)
+        self._store(host, cls)
+        return cls
+
+    def classify_url(self, url: str | None) -> str:
+        """Classify a URL by its host. ``None``/empty/host-less → WAN.
+
+        ``None`` is the native-``claude`` endpoint (no base URL → Anthropic's
+        public API), which is always WAN by rule.
+        """
+        host = _host_of(url)
+        return WAN if host is None else self.classify_host(host)
+
+    async def classify_url_async(self, url: str | None) -> str:
+        """Async variant of :meth:`classify_url`."""
+        host = _host_of(url)
+        return WAN if host is None else await self.classify_host_async(host)
+
+
+def _host_of(url: str | None) -> str | None:
+    """Extract a hostname from a URL. ``None`` when absent/unparseable.
+
+    Tolerates bare ``host:port`` (no scheme) by retrying with a dummy scheme,
+    since ``urlsplit`` only populates ``hostname`` when a scheme is present.
+    """
+    if not url:
+        return None
+    try:
+        parts = urlsplit(url)
+        host = parts.hostname
+        if host is None and "//" not in url:
+            host = urlsplit(f"//{url}").hostname
+    except ValueError:
+        return None
+    return host or None
+
+
+_default: NetClassifier | None = None
+
+
+def default_classifier() -> NetClassifier:
+    """Shared process-wide classifier (cache warms across CC dispatches)."""
+    global _default
+    if _default is None:
+        _default = NetClassifier()
+    return _default

--- a/tests/test_cc/test_conversation_failover.py
+++ b/tests/test_cc/test_conversation_failover.py
@@ -14,10 +14,17 @@ import pytest
 
 from genesis.cc import fallback_state, roster
 from genesis.cc.conversation import ConversationLoop
-from genesis.cc.exceptions import CCError, CCRateLimitError
+from genesis.cc.exceptions import CCError, CCNetworkOfflineError, CCRateLimitError
 from genesis.cc.invoker import CCInvoker
 from genesis.cc.system_prompt import SystemPromptAssembler
-from genesis.cc.types import CCInvocation, CCOutput, ChannelType, StreamEvent
+from genesis.cc.types import (
+    CCInvocation,
+    CCModel,
+    CCOutput,
+    ChannelType,
+    EffortLevel,
+    StreamEvent,
+)
 from genesis.db.crud import cc_sessions
 
 
@@ -229,3 +236,52 @@ async def test_run_failover_peer_rate_limit_propagates(loop, invoker):
     with pytest.raises(CCRateLimitError):
         await loop._run_failover_peer("glm-5.2", _PEER_INV, sticky=None, on_event=None)
     assert invoker.run.call_count == 1  # no fresh retry on rate-limit
+
+
+# ── CAVEAT A: network-offline on a RESUME turn must NOT fail the live session ──
+
+@pytest.mark.asyncio
+async def test_network_offline_on_resume_fast_reraises(loop, invoker):
+    # A CCNetworkOfflineError on a resume turn is the internet being down, NOT a
+    # stale resume. It must fast-re-raise WITHOUT _recover_stale_resume (which
+    # would mark the live CC session failed and retry fresh).
+    invoker.run = AsyncMock(side_effect=CCNetworkOfflineError("offline"))
+    loop._recover_stale_resume = AsyncMock()
+    inv = CCInvocation(prompt="x", resume_session_id="cc-live")
+    with pytest.raises(CCNetworkOfflineError):
+        await loop._try_invoke(
+            inv, session={"id": "cc-live"}, was_resume=True, prompt_text="x",
+            model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+            user_id="u1", channel=ChannelType.TERMINAL, thread_id=None,
+        )
+    loop._recover_stale_resume.assert_not_awaited()
+    assert invoker.run.await_count == 1  # no fresh retry
+
+
+@pytest.mark.asyncio
+async def test_network_offline_on_resume_streaming_fast_reraises(loop, invoker):
+    invoker.run_streaming = AsyncMock(side_effect=CCNetworkOfflineError("offline"))
+    loop._recover_stale_resume = AsyncMock()
+    inv = CCInvocation(prompt="x", resume_session_id="cc-live")
+    with pytest.raises(CCNetworkOfflineError):
+        await loop._try_invoke_streaming(
+            inv, session={"id": "cc-live"}, was_resume=True, prompt_text="x",
+            model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+            user_id="u1", channel=ChannelType.TERMINAL, thread_id=None, on_event=None,
+        )
+    loop._recover_stale_resume.assert_not_awaited()
+    assert invoker.run_streaming.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_failover_peer_offline_propagates_without_fresh_retry(loop, invoker):
+    # Same class on the peer path: an offline error on a sticky peer resume must
+    # propagate, NOT trigger the "retry fresh" recovery (which is for stale resumes).
+    invoker.run = AsyncMock(side_effect=CCNetworkOfflineError("offline"))
+    with pytest.raises(CCNetworkOfflineError):
+        await loop._run_failover_peer(
+            "glm-5.2", _PEER_INV,
+            sticky={"roster_model": "glm-5.2", "cc_session_id": "glm-prev"},
+            on_event=None,
+        )
+    assert invoker.run.call_count == 1  # no fresh retry

--- a/tests/test_cc/test_invoker_network_preflight.py
+++ b/tests/test_cc/test_invoker_network_preflight.py
@@ -1,0 +1,118 @@
+"""CCInvoker network preflight (PR-3) — fail fast pre-spawn on a WAN outage.
+
+The preflight raises :class:`CCNetworkOfflineError` *before* the subprocess is
+spawned when the sentinel reports a fresh OFFLINE state, the parking lever is
+``live``, and the endpoint is WAN — turning a 45-55min hang into a <1s raise.
+Everything else falls through to a normal dispatch (fail-safe). netclass runs
+for real against IP literals / ``None`` so no test touches DNS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.cc.exceptions import CCNetworkOfflineError
+from genesis.cc.invoker import CCInvoker
+from genesis.cc.types import CCInvocation
+
+# A LAN CC peer (RFC1918 literal — no DNS) vs the native/WAN endpoints.
+_LAN_URL = "http://192.168.1.10:1234"
+_WAN_URL = "https://8.8.8.8:443"
+
+
+@pytest.fixture
+def invoker():
+    return CCInvoker(claude_path="/usr/bin/claude")
+
+
+def _patch_decision(monkeypatch, value):
+    monkeypatch.setattr(
+        "genesis.resilience.network_config.parking_decision",
+        lambda now=None: value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_parks_wan_native_endpoint(invoker, monkeypatch):
+    # base_url None == native `claude` == WAN → parked in live mode.
+    _patch_decision(monkeypatch, "park")
+    with pytest.raises(CCNetworkOfflineError):
+        await invoker._network_preflight(CCInvocation(prompt="x"))
+
+
+@pytest.mark.asyncio
+async def test_preflight_parks_wan_literal_endpoint(invoker, monkeypatch):
+    _patch_decision(monkeypatch, "park")
+    inv = CCInvocation(prompt="x", anthropic_base_url=_WAN_URL)
+    with pytest.raises(CCNetworkOfflineError):
+        await invoker._network_preflight(inv)
+
+
+@pytest.mark.asyncio
+async def test_preflight_allows_lan_peer_during_outage(invoker, monkeypatch):
+    # A LAN CC peer stays reachable through a WAN outage — must NOT park.
+    _patch_decision(monkeypatch, "park")
+    inv = CCInvocation(prompt="x", anthropic_base_url=_LAN_URL)
+    await invoker._network_preflight(inv)  # no raise
+
+
+@pytest.mark.asyncio
+async def test_preflight_shadow_does_not_park(invoker, monkeypatch):
+    _patch_decision(monkeypatch, "shadow")
+    await invoker._network_preflight(CCInvocation(prompt="x"))  # WAN, but shadow
+
+
+@pytest.mark.asyncio
+async def test_preflight_normal_does_not_park(invoker, monkeypatch):
+    _patch_decision(monkeypatch, "normal")
+    await invoker._network_preflight(CCInvocation(prompt="x"))
+
+
+@pytest.mark.asyncio
+async def test_preflight_off_does_not_park(invoker, monkeypatch):
+    _patch_decision(monkeypatch, "off")
+    await invoker._network_preflight(CCInvocation(prompt="x"))
+
+
+@pytest.mark.asyncio
+async def test_preflight_failsafe_on_gate_error(invoker, monkeypatch):
+    # Any error inside the gate must fall through to a normal dispatch.
+    def _boom(now=None):
+        raise RuntimeError("gate broke")
+
+    monkeypatch.setattr("genesis.resilience.network_config.parking_decision", _boom)
+    await invoker._network_preflight(CCInvocation(prompt="x"))  # swallowed
+
+
+@pytest.mark.asyncio
+async def test_run_raises_before_spawning_subprocess(invoker, monkeypatch):
+    # The load-bearing property: run() short-circuits BEFORE _run_inner (which
+    # spawns the subprocess). A dead-network dispatch fails in <1s, not 7200s.
+    _patch_decision(monkeypatch, "park")
+    monkeypatch.setattr(
+        "genesis.cc.invoker.roster.apply_active",
+        lambda inv: (inv, "claude"),
+    )
+    spawn_spy = AsyncMock()
+    monkeypatch.setattr(invoker, "_run_inner", spawn_spy)
+
+    with pytest.raises(CCNetworkOfflineError):
+        await invoker.run(CCInvocation(prompt="x"))
+    spawn_spy.assert_not_awaited()  # never reached the subprocess path
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_raises_before_spawning_subprocess(invoker, monkeypatch):
+    _patch_decision(monkeypatch, "park")
+    monkeypatch.setattr(
+        "genesis.cc.invoker.roster.apply_active",
+        lambda inv: (inv, "claude"),
+    )
+    spawn_spy = AsyncMock()
+    monkeypatch.setattr(invoker, "_run_streaming_inner", spawn_spy)
+
+    with pytest.raises(CCNetworkOfflineError):
+        await invoker.run_streaming(CCInvocation(prompt="x"))
+    spawn_spy.assert_not_awaited()

--- a/tests/test_resilience/test_network_config.py
+++ b/tests/test_resilience/test_network_config.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import textwrap
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from genesis.resilience import network_config
+from genesis.resilience import network_config, network_state
 
 
 @pytest.fixture()
@@ -83,3 +84,79 @@ def test_structural_overlay_updates(cfg_env):
     t = network_config.structural()
     assert t.steady_cadence_s == 60
     assert t.staleness_threshold_s == 180
+
+
+# ── parking_decision — the shared PR-3 consumer gate ───────────────────
+
+_NOW = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+
+
+def _snap(state: str, *, age_s: float = 10.0, cause: str = "all_fail") -> dict:
+    """A network_state snapshot whose last_probe_at is ``age_s`` before _NOW."""
+    return {
+        "state": state,
+        "since": (_NOW - timedelta(minutes=5)).isoformat(),
+        "cause": cause,
+        "last_probe_at": (_NOW - timedelta(seconds=age_s)).isoformat(),
+        "window_open": state == "OFFLINE",
+        "closed_windows": [],
+    }
+
+
+@pytest.fixture()
+def patch_state(monkeypatch):
+    """Install a controllable network_state.read_state for parking_decision."""
+
+    def _install(snapshot):
+        monkeypatch.setattr(network_state, "read_state", lambda path=None: snapshot)
+
+    return _install
+
+
+def test_parking_off_when_lever_off(cfg_env, patch_state):
+    _write(cfg_env, "network:\n  enabled: false\n")
+    patch_state(_snap("OFFLINE"))
+    assert network_config.parking_decision(now=_NOW) == "off"
+
+
+def test_parking_normal_when_no_snapshot(cfg_env, patch_state):
+    patch_state(None)  # absent / empty-state install
+    assert network_config.parking_decision(now=_NOW) == "normal"
+
+
+def test_parking_normal_when_state_normal(cfg_env, patch_state):
+    patch_state(_snap("NORMAL"))
+    assert network_config.parking_decision(now=_NOW) == "normal"
+
+
+def test_parking_normal_when_state_degraded(cfg_env, patch_state):
+    # DEGRADED (slow-but-working / dns_only) must NOT trigger parking.
+    patch_state(_snap("DEGRADED", cause="dns_only"))
+    assert network_config.parking_decision(now=_NOW) == "normal"
+
+
+def test_parking_shadow_on_fresh_offline_default_mode(cfg_env, patch_state):
+    # Default parking_mode is shadow → observe, don't act.
+    patch_state(_snap("OFFLINE", age_s=30))
+    assert network_config.parking_decision(now=_NOW) == "shadow"
+
+
+def test_parking_park_on_fresh_offline_live_mode(cfg_env, patch_state):
+    _write(cfg_env, "network:\n  parking_mode: live\n")
+    patch_state(_snap("OFFLINE", age_s=30))
+    assert network_config.parking_decision(now=_NOW) == "park"
+
+
+def test_parking_normal_when_offline_but_stale(cfg_env, patch_state):
+    # OFFLINE but snapshot older than 3× steady cadence (360s) → don't trust it.
+    _write(cfg_env, "network:\n  parking_mode: live\n")
+    patch_state(_snap("OFFLINE", age_s=400))
+    assert network_config.parking_decision(now=_NOW) == "normal"
+
+
+def test_parking_normal_when_timestamp_unparseable(cfg_env, patch_state):
+    _write(cfg_env, "network:\n  parking_mode: live\n")
+    snap = _snap("OFFLINE")
+    snap["last_probe_at"] = "not-a-timestamp"
+    patch_state(snap)
+    assert network_config.parking_decision(now=_NOW) == "normal"

--- a/tests/test_resilience/test_network_config.py
+++ b/tests/test_resilience/test_network_config.py
@@ -160,3 +160,13 @@ def test_parking_normal_when_timestamp_unparseable(cfg_env, patch_state):
     snap["last_probe_at"] = "not-a-timestamp"
     patch_state(snap)
     assert network_config.parking_decision(now=_NOW) == "normal"
+
+
+def test_kill_switch_forces_parking_off_despite_fresh_offline(cfg_env, patch_state, monkeypatch):
+    # The env kill switch must immediately disable parking even with a fresh
+    # OFFLINE snapshot + parking_mode=live on disk (don't wait for it to age out).
+    _write(cfg_env, "network:\n  enabled: true\n  parking_mode: live\n")
+    patch_state(_snap("OFFLINE", age_s=30))
+    monkeypatch.setenv(network_config._ENV_KILL_SWITCH, "1")
+    assert network_config.effective_parking_mode() == "off"
+    assert network_config.parking_decision(now=_NOW) == "off"

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -14,8 +14,9 @@ from unittest.mock import AsyncMock
 
 import genesis.db.crud.observations as observations_mod
 import genesis.db.crud.surplus_tasks as surplus_tasks_mod
+from genesis.resilience import network_config
 from genesis.surplus import dispatch
-from genesis.surplus.types import TaskType
+from genesis.surplus.types import ComputeTier, TaskType
 
 
 class _Task:
@@ -238,16 +239,13 @@ async def test_route_insights_ingests_bookmark_enrichment(monkeypatch):
 
 # ── _filter_tiers_for_network — PR-3 outage awareness ──────────────────
 
-from genesis.resilience import network_config as _network_config  # noqa: E402
-from genesis.surplus.types import ComputeTier as _ComputeTier  # noqa: E402
-
-_CLOUD_AND_LOCAL = [_ComputeTier.FREE_API, _ComputeTier.LOCAL_30B]
-_CLOUD_ONLY = [_ComputeTier.FREE_API]
-_LOCAL_ONLY = [_ComputeTier.LOCAL_30B]
+_CLOUD_AND_LOCAL = [ComputeTier.FREE_API, ComputeTier.LOCAL_30B]
+_CLOUD_ONLY = [ComputeTier.FREE_API]
+_LOCAL_ONLY = [ComputeTier.LOCAL_30B]
 
 
 def _patch_decision(monkeypatch, value):
-    monkeypatch.setattr(_network_config, "parking_decision", lambda now=None: value)
+    monkeypatch.setattr(network_config, "parking_decision", lambda now=None: value)
 
 
 def test_filter_off_unchanged(monkeypatch):
@@ -287,7 +285,7 @@ def test_filter_failsafe_on_error(monkeypatch):
     def _boom(now=None):
         raise RuntimeError("gate broke")
 
-    monkeypatch.setattr(_network_config, "parking_decision", _boom)
+    monkeypatch.setattr(network_config, "parking_decision", _boom)
     assert dispatch._filter_tiers_for_network(list(_CLOUD_AND_LOCAL)) == _CLOUD_AND_LOCAL
 
 

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -234,3 +234,76 @@ async def test_route_insights_ingests_bookmark_enrichment(monkeypatch):
     # In KB_ROUTING (enriched bookmarks are durable) though NOT judge-eligible.
     spy, _ = await _run_route(TaskType.BOOKMARK_ENRICHMENT, monkeypatch)
     spy.assert_awaited_once()
+
+
+# ── _filter_tiers_for_network — PR-3 outage awareness ──────────────────
+
+from genesis.resilience import network_config as _network_config  # noqa: E402
+from genesis.surplus.types import ComputeTier as _ComputeTier  # noqa: E402
+
+_CLOUD_AND_LOCAL = [_ComputeTier.FREE_API, _ComputeTier.LOCAL_30B]
+_CLOUD_ONLY = [_ComputeTier.FREE_API]
+_LOCAL_ONLY = [_ComputeTier.LOCAL_30B]
+
+
+def _patch_decision(monkeypatch, value):
+    monkeypatch.setattr(_network_config, "parking_decision", lambda now=None: value)
+
+
+def test_filter_off_unchanged(monkeypatch):
+    _patch_decision(monkeypatch, "off")
+    assert dispatch._filter_tiers_for_network(list(_CLOUD_AND_LOCAL)) == _CLOUD_AND_LOCAL
+
+
+def test_filter_normal_unchanged(monkeypatch):
+    _patch_decision(monkeypatch, "normal")
+    assert dispatch._filter_tiers_for_network(list(_CLOUD_AND_LOCAL)) == _CLOUD_AND_LOCAL
+
+
+def test_filter_shadow_unchanged(monkeypatch):
+    # Shadow observes only — tiers untouched (a "would filter" log fires).
+    _patch_decision(monkeypatch, "shadow")
+    assert dispatch._filter_tiers_for_network(list(_CLOUD_AND_LOCAL)) == _CLOUD_AND_LOCAL
+
+
+def test_filter_park_strips_cloud_keeps_local(monkeypatch):
+    _patch_decision(monkeypatch, "park")
+    assert dispatch._filter_tiers_for_network(list(_CLOUD_AND_LOCAL)) == _LOCAL_ONLY
+
+
+def test_filter_park_strips_all_when_no_local(monkeypatch):
+    # Cloud-only during an outage → empty list (surplus goes quiet-pending).
+    _patch_decision(monkeypatch, "park")
+    assert dispatch._filter_tiers_for_network(list(_CLOUD_ONLY)) == []
+
+
+def test_filter_park_noop_when_already_local(monkeypatch):
+    _patch_decision(monkeypatch, "park")
+    assert dispatch._filter_tiers_for_network(list(_LOCAL_ONLY)) == _LOCAL_ONLY
+
+
+def test_filter_failsafe_on_error(monkeypatch):
+    # Any error in the gate leaves tiers intact (never strips on uncertainty).
+    def _boom(now=None):
+        raise RuntimeError("gate broke")
+
+    monkeypatch.setattr(_network_config, "parking_decision", _boom)
+    assert dispatch._filter_tiers_for_network(list(_CLOUD_AND_LOCAL)) == _CLOUD_AND_LOCAL
+
+
+async def test_dispatch_once_offline_feeds_filtered_tiers_and_never_fails(monkeypatch):
+    # OFFLINE+live+cloud-only → next_task receives [], no task runs, nothing is
+    # marked failed (the task stays `pending` for the next cycle).
+    _patch_decision(monkeypatch, "park")
+    ctx = _make_ctx(idle=True)
+    ctx._compute = _types.SimpleNamespace(
+        get_available_tiers=AsyncMock(return_value=list(_CLOUD_ONLY)),
+    )
+    ctx._queue.next_task = AsyncMock(return_value=None)
+
+    processed = await dispatch.dispatch_once(ctx)
+
+    assert processed is False
+    ctx._queue.next_task.assert_awaited_once_with([])  # cloud stripped → empty
+    ctx._queue.mark_failed.assert_not_called()
+    ctx._queue.mark_running.assert_not_called()

--- a/tests/test_util/test_netclass.py
+++ b/tests/test_util/test_netclass.py
@@ -1,0 +1,182 @@
+"""netclass — LAN/WAN classification: literals, resolution, cache, fallbacks."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.util import netclass
+from genesis.util.netclass import LOCAL, WAN, NetClassifier
+
+# ── IP-literal fast-path (no DNS) ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",  # loopback
+        "10.0.0.5",  # RFC1918 /8 (e.g. a LAN Ollama host)
+        "172.16.5.4",  # RFC1918 /12
+        "192.168.1.10",  # RFC1918 /16 (e.g. a LAN LM Studio host)
+        "100.64.0.1",  # CGNAT / Tailscale mesh v4
+        "169.254.1.1",  # link-local
+        "::1",  # v6 loopback
+        "fc00::1",  # v6 ULA
+        "fd00::1",  # v6 ULA (Tailscale-style fd.. mesh, under fc00::/7)
+        "fe80::1",  # v6 link-local
+        "[::1]",  # bracketed v6 (URL form)
+    ],
+)
+def test_local_ip_literals(ip):
+    assert NetClassifier().classify_host(ip) == LOCAL
+
+
+@pytest.mark.parametrize(
+    "ip",
+    ["8.8.8.8", "1.1.1.1", "9.9.9.9", "2606:4700:4700::1111", "203.0.113.7"],
+)
+def test_wan_ip_literals(ip):
+    assert NetClassifier().classify_host(ip) == WAN
+
+
+def test_ip_literal_class_returns_none_for_hostname():
+    assert netclass.ip_literal_class("example.com") is None
+    assert netclass.ip_literal_class("cc-peer.local") is None
+
+
+# ── URL parsing ────────────────────────────────────────────────────────
+
+
+def test_classify_url_none_is_wan():
+    # None base URL == native `claude` endpoint == Anthropic public API == WAN.
+    assert NetClassifier().classify_url(None) == WAN
+
+
+def test_classify_url_empty_is_wan():
+    assert NetClassifier().classify_url("") == WAN
+
+
+def test_classify_url_lan_literal():
+    assert NetClassifier().classify_url("http://192.168.1.10:1234/v1") == LOCAL
+
+
+def test_classify_url_wan_literal():
+    assert NetClassifier().classify_url("https://8.8.8.8:443") == WAN
+
+
+def test_classify_url_bare_hostport_no_scheme():
+    # `host:port` with no scheme still yields the host (LAN literal here).
+    assert NetClassifier().classify_url("10.0.0.5:8080") == LOCAL
+
+
+# ── Hostname resolution (injected resolver — no real DNS) ───────────────
+
+
+def test_hostname_resolves_local():
+    nc = NetClassifier(resolver=lambda h: ["192.168.1.10"])
+    assert nc.classify_host("nas.local") == LOCAL
+
+
+def test_hostname_resolves_wan():
+    nc = NetClassifier(resolver=lambda h: ["203.0.113.9"])
+    assert nc.classify_host("api.example.com") == WAN
+
+
+def test_mixed_addrs_default_to_wan():
+    # ALL-local rule: any WAN address in the set → WAN (ambiguity → conservative).
+    nc = NetClassifier(resolver=lambda h: ["192.168.1.10", "203.0.113.9"])
+    assert nc.classify_host("mixed.example") == WAN
+
+
+def test_empty_resolution_is_wan():
+    nc = NetClassifier(resolver=lambda h: [])
+    assert nc.classify_host("void.example") == WAN
+
+
+# ── Cache: freshness + last-known-good survival ────────────────────────
+
+
+def test_cache_avoids_second_resolution_while_fresh():
+    calls = {"n": 0}
+
+    def _res(h):
+        calls["n"] += 1
+        return ["192.168.1.10"]
+
+    clock = {"t": 1000.0}
+    nc = NetClassifier(resolver=_res, clock=lambda: clock["t"], cache_ttl_s=300)
+    assert nc.classify_host("nas.local") == LOCAL
+    assert nc.classify_host("nas.local") == LOCAL  # within TTL → cached
+    assert calls["n"] == 1
+
+
+def test_cache_re_resolves_after_ttl():
+    calls = {"n": 0}
+
+    def _res(h):
+        calls["n"] += 1
+        return ["192.168.1.10"]
+
+    clock = {"t": 1000.0}
+    nc = NetClassifier(resolver=_res, clock=lambda: clock["t"], cache_ttl_s=300)
+    assert nc.classify_host("nas.local") == LOCAL
+    clock["t"] = 1000.0 + 301  # past TTL
+    assert nc.classify_host("nas.local") == LOCAL
+    assert calls["n"] == 2
+
+
+def test_last_known_good_survives_resolver_failure():
+    # A LAN host classified once must STAY local when DNS later dies (outage).
+    state = {"fail": False}
+
+    def _res(h):
+        if state["fail"]:
+            raise OSError("name resolution failed")
+        return ["192.168.1.10"]
+
+    clock = {"t": 1000.0}
+    nc = NetClassifier(resolver=_res, clock=lambda: clock["t"], cache_ttl_s=1)
+    assert nc.classify_host("nas.local") == LOCAL  # warm the cache
+    state["fail"] = True
+    clock["t"] = 1000.0 + 100  # past TTL so it re-resolves → fails → falls back to LKG
+    assert nc.classify_host("nas.local") == LOCAL
+
+
+def test_unresolvable_no_cache_is_wan():
+    def _res(h):
+        raise OSError("dead")
+
+    nc = NetClassifier(resolver=_res)
+    assert nc.classify_host("never-seen.example") == WAN
+
+
+# ── Async path ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_literal_and_none():
+    nc = NetClassifier()
+    assert await nc.classify_url_async(None) == WAN
+    assert await nc.classify_url_async("http://192.168.1.10:1234") == LOCAL
+    assert await nc.classify_host_async("8.8.8.8") == WAN
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_injected():
+    async def _ares(h):
+        return ["10.0.0.9"]
+
+    nc = NetClassifier(async_resolver=_ares)
+    assert await nc.classify_host_async("box.local") == LOCAL
+
+
+@pytest.mark.asyncio
+async def test_async_resolver_failure_falls_back_to_wan():
+    async def _ares(h):
+        raise OSError("dead")
+
+    nc = NetClassifier(async_resolver=_ares)
+    assert await nc.classify_host_async("never.example") == WAN
+
+
+def test_default_classifier_is_singleton():
+    assert netclass.default_classifier() is netclass.default_classifier()

--- a/tests/test_util/test_netclass.py
+++ b/tests/test_util/test_netclass.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from genesis.util import netclass
@@ -180,3 +182,35 @@ async def test_async_resolver_failure_falls_back_to_wan():
 
 def test_default_classifier_is_singleton():
     assert netclass.default_classifier() is netclass.default_classifier()
+
+
+# ── Bounded resolution (dead resolver must not stall the preflight) ─────
+
+
+@pytest.mark.asyncio
+async def test_async_resolution_bounded_by_timeout_no_cache_is_wan():
+    # A resolver that hangs (dead DNS during an outage) must NOT hang the
+    # preflight — it times out and falls to the conservative WAN verdict.
+    async def _hang(h):
+        await asyncio.sleep(30)
+        return ["192.168.1.10"]
+
+    nc = NetClassifier(async_resolver=_hang, resolve_timeout_s=0.05)
+    assert await nc.classify_host_async("cold.example") == WAN
+
+
+@pytest.mark.asyncio
+async def test_async_resolution_timeout_falls_back_to_last_known_good():
+    state = {"hang": False}
+
+    async def _res(h):
+        if state["hang"]:
+            await asyncio.sleep(30)
+            return []
+        return ["192.168.1.10"]
+
+    # cache_ttl_s=0 forces a re-resolve on the second call.
+    nc = NetClassifier(async_resolver=_res, resolve_timeout_s=0.05, cache_ttl_s=0)
+    assert await nc.classify_host_async("nas.local") == LOCAL  # warm the cache
+    state["hang"] = True
+    assert await nc.classify_host_async("nas.local") == LOCAL  # timeout → LKG


### PR DESCRIPTION
> Replaces #1263 (superseded; this branch is a single clean commit).

## What & why

Third PR in the internet-outage resilience series (after PR-1 class fixes #1256 and PR-2 connectivity sentinel #1259). Adds a **network-OFFLINE gate** so Genesis fails fast instead of hanging when the internet is down.

During the 2026-07-28 blackout, CC dispatches on the dead network burned **45/55/23 minutes** each against a 7200s (`timeout_s`) ceiling. This turns that worst case into a **sub-second raise** (measured **0.002s** end-to-end).

## Design — two consumers, one shared gate

`network_config.parking_decision()` combines the `parking_mode` lever + the live `network_state.json` snapshot (from PR-2's sentinel) + a staleness guard, returning `off | normal | shadow | park`. Both consumers gate on it so they can't drift:

1. **CC-invoker preflight** (`invoker.run` / `run_streaming`, *before* subprocess spawn): fresh-OFFLINE + `live` + WAN endpoint → raises the new `CCNetworkOfflineError`. LAN CC peers (classified by the new stdlib-only `util/netclass.py`) stay reachable and are exempt.
2. **Surplus tier filter** (`dispatch._filter_tiers_for_network`): OFFLINE + `live` strips cloud compute tiers, so internet-dependent tasks stay `pending` (never `mark_failed`) instead of churning into a dead network.

## CAVEAT A — resume-continuity class-fix

`CCNetworkOfflineError` is added to the fast-re-raise tuples in `conversation.py` `_try_invoke`, `_try_invoke_streaming`, **and** `_run_failover_peer`, so a network blip on a **resume** turn is not misread as a stale resume (which would needlessly fail the live CC session and retry fresh).

## Fail-safe

Lever off, an absent/stale/NORMAL/DEGRADED snapshot, a LAN endpoint, or **any error** in the gate/classifier all fall through to a normal dispatch — identical to pre-sentinel behavior.

## Ships in shadow (default) — important

`parking_mode: shadow` is the shipped default. In shadow the preflight **never raises** — behavior is unchanged on deploy (pure observation). Flipping to `live` has a **hard prerequisite**: periodic CC consumers (inbox retry budget, autonomy/ego outcome signals, direct_session) must first be made outage-aware so a `CCNetworkOfflineError` is treated as "not attempted", not a failure — otherwise an outage would pollute calibration/retry state. Found in code review; tracked as a high-priority PR-3b follow-up and guarded inline in `config/resilience.yaml`.

## Scope / compatibility
- Reuses PR-2's sentinel modules; **no schema changes**; new `CCNetworkOfflineError(CCError)` is contract-compatible with every existing terminal handler.
- `util/netclass.py` is excluded from the address-portability scan (its RFC-range definitions are data, same as `sanitize.py`).

## Tests / verification
- **96 targeted** (netclass ranges/cache/last-known-good fallback, `parking_decision` gate, preflight incl. pre-spawn proof, surplus never-`failed`, CAVEAT A ×3) + **1227 regression** green; ruff clean.
- **Live E2E** against a real OFFLINE state file: `run()` raised in **0.002s** (vs 45-55min); stale→normal, shadow→observe, NORMAL→no-op, LAN-exempt all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
